### PR TITLE
fix: link with libpcap dynamically for sock-send

### DIFF
--- a/sock-send/meson.build
+++ b/sock-send/meson.build
@@ -1,6 +1,6 @@
 dependencies = []
 dependencies += dependency('threads')
-dependencies += dependency('libpcap', static: true)
+dependencies += dependency('libpcap', static: false)
 
 sources = files('main.c')
 


### PR DESCRIPTION
Ubuntu 22.04, for example, does not provide libpcap static libraries for licensing reasons, I suppose. So let's link dynamically instead.