### PR TITLE
refactor: no DPDK includes in header files

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -4,6 +4,8 @@
 
 #include <pthread.h>
 
+#include <rte_ether.h>
+
 #include "dpdk.h"
 
 #include "drivers/sock_dev.h"

--- a/dataplane/device.h
+++ b/dataplane/device.h
@@ -5,6 +5,7 @@
 
 #include "worker.h"
 
+struct rte_ether_addr;
 struct dataplane;
 
 struct dataplane_device {

--- a/dataplane/dpdk.c
+++ b/dataplane/dpdk.c
@@ -4,6 +4,7 @@
 
 #include <rte_dev.h>
 #include <rte_eal.h>
+#include <rte_ether.h>
 
 int
 dpdk_init(

--- a/dataplane/dpdk.h
+++ b/dataplane/dpdk.h
@@ -4,7 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <rte_ether.h>
+struct rte_ether_addr;
 
 int
 dpdk_init(const char *binary, size_t port_count, const char *const *port_names);

--- a/dataplane/modules/balancer.c
+++ b/dataplane/modules/balancer.c
@@ -4,6 +4,8 @@
 
 #include "dataplane/packet/encap.h"
 
+#include <rte_ether.h>
+
 int
 acl_handle_v4(
 	struct filter_compiler *compiler,

--- a/dataplane/modules/kernel.c
+++ b/dataplane/modules/kernel.c
@@ -6,6 +6,9 @@
 #include "packet/packet.h"
 #include "pipeline.h"
 
+#include <rte_ether.h>
+#include <rte_ip.h>
+
 struct kernel_module_config {
 	struct module_config config;
 

--- a/dataplane/modules/route.c
+++ b/dataplane/modules/route.c
@@ -5,7 +5,8 @@
 
 #include "common/lpm.h"
 
-#include "rte_ether.h"
+#include <rte_ether.h>
+#include <rte_ip.h>
 
 #define ROUTE_TYPE_IP4 4
 #define ROUTE_TYPE_IP6 6

--- a/dataplane/packet/encap.c
+++ b/dataplane/packet/encap.c
@@ -1,5 +1,8 @@
 #include "encap.h"
 
+#include <rte_ether.h>
+#include <rte_ip.h>
+
 static void
 packet_network_prepend(
 	struct packet *packet,

--- a/dataplane/packet/packet.c
+++ b/dataplane/packet/packet.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include <rte_ether.h>
+#include <rte_ip.h>
 
 /*
  * TODO: analyze if the valid packet parsing may
@@ -216,4 +217,9 @@ parse_packet(struct packet *packet) {
 	packet->transport_header.offset = offset;
 
 	return 0;
+}
+
+struct packet *
+mbuf_to_packet(struct rte_mbuf *mbuf) {
+	return (struct packet *)((void *)mbuf->buf_addr);
 }

--- a/dataplane/packet/packet.h
+++ b/dataplane/packet/packet.h
@@ -4,11 +4,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "rte_ether.h"
-#include "rte_ip.h"
-#include "rte_mbuf.h"
-
 #define PACKET_HEADER_TYPE_UNKNOWN 0
+
+struct rte_mbuf;
 
 struct network_header {
 	uint16_t type;
@@ -102,21 +100,19 @@ packet_to_mbuf(const struct packet *packet) {
 	return packet->mbuf;
 }
 
-static inline struct packet *
-mbuf_to_packet(struct rte_mbuf *mbuf) {
-	return (struct packet *)((void *)mbuf->buf_addr);
-}
+struct packet *
+mbuf_to_packet(struct rte_mbuf *mbuf);
 
 struct ipv6_ext_2byte {
 	uint8_t next_type;
 	uint8_t size;
-} __rte_packed;
+} __attribute__((__packed__));
 
 struct ipv6_ext_fragment {
 	uint8_t next_type;
 	uint8_t reserved;
 	uint16_t offset_flag;
 	uint32_t identification;
-} __rte_packed;
+} __attribute__((__packed__));
 
 #endif


### PR DESCRIPTION
This commit makes our codebase's API (which are header files) isolated from DPDK by removing DPDK includes in header files. Ideally we also must hide rte_* symbols in translation units. This potentially gives us independence from DPDK version, but this change is not going to be implemented right now.

Segregating header files from DPDK includes is also a prerequesite for DPDK-less build for lightweighted checks in github.