### PR TITLE
refactor: use pragma once instead of header guards

### DIFF
--- a/common/container_of.h
+++ b/common/container_of.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #ifndef container_of
 
 #include <stddef.h>

--- a/common/data_pipe.h
+++ b/common/data_pipe.h
@@ -1,6 +1,4 @@
-#ifndef DATA_PIPE_H
-#define DATA_PIPE_H
-
+#pragma once
 #include <stdlib.h>
 
 struct data_pipe {
@@ -128,5 +126,3 @@ data_pipe_item_free(
 		free_func_data
 	);
 }
-
-#endif

--- a/common/key.h
+++ b/common/key.h
@@ -1,5 +1,4 @@
-#ifndef FILTER_KEY_H
-#define FILTER_KEY_H
+#pragma once
 
 #include <stdint.h>
 
@@ -81,5 +80,3 @@ filter_key_cmp(uint8_t key_size, const uint8_t *l, const uint8_t *r) {
 
 	return 0;
 }
-
-#endif

--- a/common/lpm.h
+++ b/common/lpm.h
@@ -1,5 +1,4 @@
-#ifndef LPM_H
-#define LPM_H
+#pragma once
 
 /*
  * Longest Prefix Match (LPM) tree used to map a range of n-byte values into
@@ -546,5 +545,3 @@ static inline void
 lpm4_compact(struct lpm *lpm4) {
 	return lpm_compact(lpm4, 4);
 }
-
-#endif

--- a/common/network.h
+++ b/common/network.h
@@ -1,5 +1,4 @@
-#ifndef NETWORK_H
-#define NETWORK_H
+#pragma once
 
 struct net6 {
 	uint64_t addr_hi;
@@ -12,5 +11,3 @@ struct net4 {
 	uint32_t addr;
 	uint32_t mask;
 };
-
-#endif

--- a/common/radix.h
+++ b/common/radix.h
@@ -1,5 +1,4 @@
-#ifndef RADIX_H
-#define RADIX_H
+#pragma once
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -211,5 +210,3 @@ radix32_walk(
 ) {
 	return radix_walk(radix32, 4, iterate_func, iterate_func_data);
 }
-
-#endif

--- a/common/range_collector.h
+++ b/common/range_collector.h
@@ -1,5 +1,4 @@
-#ifndef FILTER_NET6_PART_COLLECTOR
-#define FILTER_NET6_PART_COLLECTOR
+#pragma once
 
 #include <stdint.h>
 
@@ -300,5 +299,3 @@ static inline int
 range4_collector_collect(struct range_collector *collector, struct lpm *lpm) {
 	return range_collector_collect(collector, 4, lpm);
 }
-
-#endif

--- a/common/registry.h
+++ b/common/registry.h
@@ -1,5 +1,4 @@
-#ifndef FILTER_REGISTRY_H
-#define FILTER_REGISTRY_H
+#pragma once
 
 /*
  * Value registry required to map a key into range of unique values.
@@ -246,5 +245,3 @@ error:
 	value_registry_free(dst_registry);
 	return -1;
 }
-
-#endif

--- a/common/remap.h
+++ b/common/remap.h
@@ -1,5 +1,4 @@
-#ifndef FILTER_REMAP_H
-#define FILTER_REMAP_H
+#pragma once
 
 /*
  * Remap table allows to remap one unsinged into another and intended to spare
@@ -186,5 +185,3 @@ remap_table_compacted(struct remap_table *table, uint32_t key) {
 	struct remap_item *item = remap_table_item(table, key);
 	return item->value;
 }
-
-#endif

--- a/common/value.h
+++ b/common/value.h
@@ -1,5 +1,4 @@
-#ifndef FILTER_VALUE_H
-#define FILTER_VALUE_H
+#pragma once
 
 /*
  * Rectangular value table allowing one to touch each key pair using
@@ -79,5 +78,3 @@ value_table_compact(struct value_table *value_table) {
 		);
 	}
 }
-
-#endif

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -1,5 +1,4 @@
-#ifndef DATAPLANE_H
-#define DATAPLANE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -58,5 +57,3 @@ dataplane_register_module(struct dataplane *dataplane, struct module *module);
 
 int
 dataplane_configure_module(struct dataplane *dataplane);
-
-#endif

--- a/dataplane/device.h
+++ b/dataplane/device.h
@@ -1,5 +1,4 @@
-#ifndef DEVICA_H
-#define DEVICE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -39,5 +38,3 @@ int
 dataplane_dpdk_port_get_mac(
 	struct dataplane_device *device, struct rte_ether_addr *ether_addr
 );
-
-#endif

--- a/dataplane/dpdk.h
+++ b/dataplane/dpdk.h
@@ -1,5 +1,4 @@
-#ifndef DATAPLANE_DPDK_H
-#define DATAPLANE_DPDK_H
+#pragma once
 
 #include <stddef.h>
 #include <stdint.h>
@@ -17,5 +16,3 @@ dpdk_add_vdev_port(
 	uint16_t queue_count,
 	uint16_t numa_id
 );
-
-#endif

--- a/dataplane/drivers/sock_dev.h
+++ b/dataplane/drivers/sock_dev.h
@@ -1,9 +1,6 @@
-#ifndef SOCKDEV_H
-#define SOCKDEV_H
+#pragma once
 
 #define SOCK_DEV_PREFIX "sock_dev:"
 
 int
 sock_dev_create(const char *path, const char *name, int numa_node);
-
-#endif

--- a/dataplane/module.h
+++ b/dataplane/module.h
@@ -1,5 +1,4 @@
-#ifndef MODULE_H
-#define MODULE_H
+#pragma once
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -113,5 +112,3 @@ module_configure(
 		new_config
 	);
 }
-
-#endif

--- a/dataplane/modules/acl.h
+++ b/dataplane/modules/acl.h
@@ -1,5 +1,4 @@
-#ifndef ACL_H
-#define ACL_H
+#pragma once
 
 #include "module.h"
 
@@ -19,5 +18,3 @@ struct acl_module {
 
 struct module *
 new_module_acl();
-
-#endif

--- a/dataplane/modules/balancer.h
+++ b/dataplane/modules/balancer.h
@@ -1,5 +1,4 @@
-#ifndef BALANCER_H
-#define BALANCER_H
+#pragma once
 
 #include "module.h"
 
@@ -46,5 +45,3 @@ struct balancer_module {
 
 struct module *
 new_module_balancer();
-
-#endif

--- a/dataplane/modules/decap.h
+++ b/dataplane/modules/decap.h
@@ -1,5 +1,4 @@
-#ifndef DECAP_H
-#define DECAP_H
+#pragma once
 
 #include "module.h"
 
@@ -13,5 +12,3 @@ struct decap_module {
 
 struct decap_module *
 new_decap();
-
-#endif

--- a/dataplane/modules/kernel.h
+++ b/dataplane/modules/kernel.h
@@ -1,5 +1,4 @@
-#ifndef MODULE_KERNEL_H
-#define MODULE_KERNEL_H
+#pragma once
 
 #include <stdint.h>
 
@@ -19,5 +18,3 @@ struct module_kernel_config_data {
 
 struct module *
 new_module_kernel();
-
-#endif

--- a/dataplane/modules/route.h
+++ b/dataplane/modules/route.h
@@ -1,9 +1,6 @@
-#ifndef ROUTE_H
-#define ROUTE_H
+#pragma once
 
 #include "module.h"
 
 struct module *
 new_module_route();
-
-#endif

--- a/dataplane/packet/encap.h
+++ b/dataplane/packet/encap.h
@@ -1,5 +1,4 @@
-#ifndef ENCAP_H
-#define ENCAP_H
+#pragma once
 
 #include "packet.h"
 
@@ -18,5 +17,3 @@ int
 packet_gre6_encap(
 	struct packet *packet, const uint8_t *dst, const uint8_t *src
 );
-
-#endif

--- a/dataplane/packet/packet.h
+++ b/dataplane/packet/packet.h
@@ -1,5 +1,4 @@
-#ifndef PACKET_H
-#define PACKET_H
+#pragma once
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -114,5 +113,3 @@ struct ipv6_ext_fragment {
 	uint16_t offset_flag;
 	uint32_t identification;
 } __attribute__((__packed__));
-
-#endif

--- a/dataplane/pipeline.h
+++ b/dataplane/pipeline.h
@@ -1,5 +1,4 @@
-#ifndef PIPELINE_H
-#define PIPELINE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -130,5 +129,3 @@ void
 pipeline_process(
 	struct pipeline *pipeline, struct pipeline_front *pipeline_front
 );
-
-#endif

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -1,5 +1,4 @@
-#ifndef WORKER_H
-#define WORKER_H
+#pragma once
 
 #include "pipeline.h"
 
@@ -60,5 +59,3 @@ dataplane_worker_init(
 	struct dataplane_worker *worker,
 	int queue_id
 );
-
-#endif

--- a/filter/classify.h
+++ b/filter/classify.h
@@ -1,5 +1,4 @@
-#ifndef FILTER_CLASSIFY_H
-#define FILTER_CLASSIFY_H
+#pragma once
 
 #include <stdint.h>
 
@@ -29,5 +28,3 @@ uint32_t filter_classify_src_port(
 uint32_t filter_classify_dst_port(
 	const struct filter *filter, const struct packet *packet
 );
-
-#endif

--- a/filter/ipfw.h
+++ b/filter/ipfw.h
@@ -1,5 +1,4 @@
-#ifndef FILTER_IPFW_H
-#define FILTER_IPFW_H
+#pragma once
 
 #include <stdint.h>
 
@@ -78,5 +77,3 @@ int filter_compiler_init(
 	struct filter_action *actions,
 	uint32_t count
 );
-
-#endif


### PR DESCRIPTION
Instead of coming up with names of header guards I suggest to use #pragma once directive. It's hard to find compilers that do not support this.

Pros:
- No need to figure out how to name header guards.
- No more chance of clashing, since current guards are not generic enough.

Cons:
- Don't see anything. Maybe we lose a chance to be compiled on ancient compilers.

Closes #6.