### PR TITLE
fix: zero-copy interaction with CGO in tests

### DIFF
--- a/lib/dataplane/module/testing.c
+++ b/lib/dataplane/module/testing.c
@@ -31,15 +31,21 @@ testing_init_mbuf(struct rte_mbuf *m, struct test_data data, uint16_t buf_len) {
 
 struct packet_front *
 testing_packet_front(
-	struct test_data payload[], uint64_t count, uint16_t buf_len
+	struct test_data payload[],
+	uint8_t *arena,
+	uint64_t arena_size,
+	uint64_t mbuf_count,
+	uint16_t mbuf_size
 ) {
-	uint8_t *data = calloc(count, buf_len);
-	struct packet_front *pf = malloc(sizeof(struct packet_front));
+	assert(arena_size >=
+	       (sizeof(struct packet_front) + mbuf_size * mbuf_count));
+	struct packet_front *pf = (struct packet_front *)(arena);
 	packet_front_init(pf);
+	arena += sizeof(struct packet_front);
 
-	for (uint64_t i = 0; i < count; i++) {
-		struct rte_mbuf *m = (struct rte_mbuf *)(data + buf_len * i);
-		testing_init_mbuf(m, payload[i], buf_len);
+	for (uint64_t i = 0; i < mbuf_count; i++) {
+		struct rte_mbuf *m = (struct rte_mbuf *)(arena + mbuf_size * i);
+		testing_init_mbuf(m, payload[i], mbuf_size);
 
 		struct packet *p = mbuf_to_packet(m);
 		// Initialize packet

--- a/lib/dataplane/module/testing.h
+++ b/lib/dataplane/module/testing.h
@@ -7,7 +7,12 @@ struct test_data {
 
 struct packet_front *
 testing_packet_front(
-	struct test_data payload[], uint64_t count, uint16_t buf_len
+	struct test_data payload[],
+	uint8_t *arena,
+	uint64_t arena_size,
+	uint64_t mbuf_count,
+	uint16_t mbuf_size
 );
+
 uint8_t *
 testing_packet_data(const struct packet *p, uint16_t *len);

--- a/tests/go/modules/decap/decap.go
+++ b/tests/go/modules/decap/decap.go
@@ -36,8 +36,10 @@ func decapModuleConfig(prefixes []netip.Prefix) C.struct_decap_module_config {
 
 func decapHandlePackets(mc *C.struct_decap_module_config, packets ...gopacket.Packet) common.PacketFrontResult {
 	payload := common.PacketsToPaylod(packets)
-	pf := common.PacketFrontFromPayload(payload)
+	pinner, pf := common.PacketFrontFromPayload(payload)
 	common.ParsePackets(pf)
 	C.decap_handle_packets(nil, &mc.config, (*C.struct_packet_front)(unsafe.Pointer(pf)))
-	return common.PacketFrontToPayload(pf)
+	result := common.PacketFrontToPayload(pf)
+	pinner.Unpin()
+	return result
 }


### PR DESCRIPTION
This PR addresses memory management within our tests by eliminating unhandled allocations on the C heap. All memory management is now consolidated within the Go heap, reducing potential memory management issues.