### PR TITLE
fix: proper type for route indices

### DIFF
--- a/dataplane/unittest/main.c
+++ b/dataplane/unittest/main.c
@@ -139,7 +139,7 @@ main(int argc, char **argv) {
 		}
 	);
 
-	route_module_config_add_route_list(rmc, 1, (uint64_t[]){0});
+	route_module_config_add_route_list(rmc, 1, (uint32_t[]){0});
 
 	route_module_config_add_prefix_v4(
 		rmc,

--- a/modules/route/controlplane.c
+++ b/modules/route/controlplane.c
@@ -83,7 +83,7 @@ route_module_config_add_route(
 
 int
 route_module_config_add_route_list(
-	struct module_data *module_data, uint64_t count, const uint64_t *indexes
+	struct module_data *module_data, size_t count, const uint32_t *indexes
 ) {
 	struct route_module_config *config = container_of(
 		module_data, struct route_module_config, module_data
@@ -93,7 +93,7 @@ route_module_config_add_route_list(
 
 	uint64_t *route_indexes = DECODE_ADDR(config, config->route_indexes);
 
-	for (uint64_t idx = 0; idx < count; ++idx) {
+	for (size_t idx = 0; idx < count; ++idx) {
 		/*
 		 * FIXME: if there are huge loads of route indexes then
 		 * the loop may be inefficient. However, I do not expect

--- a/modules/route/controlplane.h
+++ b/modules/route/controlplane.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "common/network.h"
@@ -19,7 +20,7 @@ route_module_config_add_route(
 
 int
 route_module_config_add_route_list(
-	struct module_data *module_data, uint64_t count, const uint64_t *indexes
+	struct module_data *module_data, size_t count, const uint32_t *indexes
 );
 
 int


### PR DESCRIPTION
The value type should be `uint32_t` to be consistent with the LPM value type and other functions in the "route" module.