### PR TITLE
refactor: make MapTrie generic

### DIFF
--- a/controlplane/modules/route/internal/rib/map_trie.go
+++ b/controlplane/modules/route/internal/rib/map_trie.go
@@ -4,89 +4,142 @@ import (
 	"net/netip"
 )
 
-type MapTrieKey struct {
-	Prefix netip.Prefix
-}
+// MapTrie is a generic data structure with properties of a prefix trie but
+// implemented using maps.
+//
+// It is an array of maps, where each index corresponds to a prefix length.
+//
+// The maximum size is 129 to accommodate both IPv4 (32 bits) and IPv6 (128 bits),
+// plus an extra slot for the default route (/0).
+//
+// The type parameter V represents the value type stored for each prefix.
+type MapTrie[V any] [129]map[netip.Prefix]V
 
-// MapTrie has the properties of a prefix trie but stores prefixes in maps.
-type MapTrie [129]map[MapTrieKey]*RoutesList
+// NewMapTrie returns a new MapTrie data structure with the specified
+// initial capacity.
+func NewMapTrie[V any](cap int) MapTrie[V] {
+	trie := MapTrie[V]{}
 
-// NewMapTrie returns a new MapTrie data structure.
-func NewMapTrie(capacity int) MapTrie {
-	mt := MapTrie{}
-	for idx := range mt {
-		mt[idx] = make(map[MapTrieKey]*RoutesList, capacity)
+	for idx := range trie {
+		trie[idx] = make(map[netip.Prefix]V, cap)
 	}
-	return mt
+
+	return trie
 }
 
-// Lookup searches the MapTrie for a RoutesList that matches the longest
-// possible prefix.
-// If no match is found, the function returns nil.
-func (m *MapTrie) Lookup(addr netip.Addr) (*RoutesList, bool) {
+// Lookup searches the MapTrie for a value that matches the longest
+// possible prefix for the given IP address.
+//
+// If no match is found, the function returns the zero value and false.
+func (m *MapTrie[V]) Lookup(addr netip.Addr) (V, bool) {
 	bitLen := addr.BitLen()
+
 	for bits := bitLen; bits >= 0; bits-- {
-		p, _ := addr.Prefix(bits)
-		mtk := MapTrieKey{Prefix: p}
-		if v, ok := m[bits][mtk]; ok {
-			return v, true
+		// TODO: leave comment why we ignore error.
+		prefix, _ := addr.Prefix(bits)
+
+		if value, ok := m[bits][prefix]; ok {
+			return value, true
 		}
 	}
-	return nil, false
+
+	var zero V
+	return zero, false
+}
+
+// LookupTraverse finds all prefixes in the MapTrie that contain the given IP address,
+// calling a function for each matching prefix in ascending order of prefix length.
+//
+// The callback function receives each matching prefix and its associated value,
+// and can control traversal by returning a boolean value. Return true to continue
+// processing, or false to stop the traversal.
+func (m *MapTrie[V]) LookupTraverse(addr netip.Addr, fn func(netip.Prefix, V) bool) {
+	bitLen := addr.BitLen()
+
+	// Note, that "<=" is not a bug!
+	for bits := 0; bits <= bitLen; bits++ {
+		prefix, _ := addr.Prefix(bits)
+
+		if value, ok := m[bits][prefix]; ok {
+			if fn(prefix, value) {
+				continue
+			}
+		}
+	}
+}
+
+func (m *MapTrie[V]) LookupTraverseRev(addr netip.Addr, fn func(netip.Prefix, V) bool) {
+	bitLen := addr.BitLen()
+
+	for bits := bitLen; bits >= 0; bits-- {
+		prefix, _ := addr.Prefix(bits)
+
+		if value, ok := m[bits][prefix]; ok {
+			if fn(prefix, value) {
+				continue
+			}
+		}
+	}
 }
 
 // Matches returns a list of keys that match the given IP.
+//
 // The returned slice is sorted from the longest to the shortest prefix.
 // It returns an empty list if there are no matches.
-func (m *MapTrie) Matches(addr netip.Addr) []MapTrieKey {
-	bitLen := addr.BitLen()
-	matches := []MapTrieKey{}
-	for bits := bitLen; bits >= 0; bits-- {
-		p, _ := addr.Prefix(bits)
-		mtk := MapTrieKey{Prefix: p}
-		if _, ok := m[bits][mtk]; ok {
-			matches = append(matches, mtk)
-		}
-	}
+func (m *MapTrie[V]) Matches(addr netip.Addr) []netip.Prefix {
+	matches := []netip.Prefix{}
+
+	m.LookupTraverseRev(addr, func(prefix netip.Prefix, value V) bool {
+		matches = append(matches, prefix)
+		return true
+	})
+
 	return matches
 }
 
-// Entry returns a reference to the RoutesList for insertion.
-// The returned RoutesList should not be preserved by the user.
-// If there is no RoutesList at the given key, Entry will create it
-// and return a reference to the newly created RoutesList.
-func (m *MapTrie) Entry(route Route) *RoutesList {
-	rl, ok := m[route.Prefix.Bits()][route.MapTrieKey]
-	if !ok {
-		rl = &RoutesList{}
-		m[route.Prefix.Bits()][route.MapTrieKey] = rl
+// InsertOrUpdate adds a new entry or updates an existing one in the MapTrie.
+//
+// The function first normalizes the prefix with masking, then either inserts a new
+// value using the onEmpty callback or updates an existing value using the onUpdate
+// callback.
+func (m *MapTrie[V]) InsertOrUpdate(prefix netip.Prefix, onEmpty func() V, onUpdate func(V) V) {
+	prefix = prefix.Masked()
+	bits := prefix.Bits()
+
+	if currValue, ok := m[bits][prefix]; ok {
+		m[bits][prefix] = onUpdate(currValue)
+		return
 	}
-	return rl
+
+	m[bits][prefix] = onEmpty()
 }
 
-// InsertOrUpdate inserts the Route into the existing RoutesList or creates
-// a new RoutesList with the given Route.
-func (m *MapTrie) InsertOrUpdate(route Route) {
-	m.Entry(route).Insert(route)
-}
-
-// Len returns the total number of routes stored in the trie
-func (m *MapTrie) Len() int {
+// Len returns the total number of prefixes stored in the MapTrie.
+//
+// This counts entries across all prefix lengths.
+func (m *MapTrie[V]) Len() int {
 	l := 0
 	for idx := range m {
 		l += len(m[idx])
 	}
+
 	return l
 }
 
-// Dump creates a copy of the data stored in the trie and returns it.
-func (m MapTrie) Dump() map[MapTrieKey]RoutesList {
-	out := make(map[MapTrieKey]RoutesList, m.Len())
-	// Traverse from longest to shortest prefixes
+// Dump creates a flat map containing all prefixes and their values from the MapTrie.
+//
+// The function traverses the trie from longest to shortest prefixes, which means
+// that if there are overlapping prefixes, the shorter ones will overwrite the longer
+// ones in the returned map.
+func (m MapTrie[V]) Dump() map[netip.Prefix]V {
+	out := make(map[netip.Prefix]V, m.Len())
+
+	// Traverse from longest to shortest prefixes.
 	for idx := len(m) - 1; idx >= 0; idx-- {
 		for key, v := range m[idx] {
-			out[key] = *v
+			out[key] = v
 		}
 	}
+
 	return out
 }

--- a/controlplane/modules/route/internal/rib/map_trie.go
+++ b/controlplane/modules/route/internal/rib/map_trie.go
@@ -1,8 +1,37 @@
 package rib
 
-import (
-	"net/netip"
-)
+// MapTrieKey defines requirements for keys used in the MapTrie data structure.
+//
+// The type parameter T represents the concrete type implementing this
+// interface.
+type MapTrieKey[T any] interface {
+	// comparable ensures that keys can be used in maps.
+	comparable
+	// Masked returns a normalized version of the key with only significant
+	// bits.
+	//
+	// This ensures proper prefix matching behavior.
+	Masked() T
+	// Bits returns the number of significant bits in this key.
+	//
+	// For IP prefixes, this would be the prefix length.
+	Bits() int
+}
+
+// MapTrieQuery defines the interface for objects that can be used for querying
+// the MapTrie.
+type MapTrieQuery[K MapTrieKey[K]] interface {
+	// BitLen returns the maximum number of significant bits in this query.
+	//
+	// For IP addresses, this would be 32 for IPv4 or 128 for IPv6.
+	BitLen() int
+	// Prefix generates a key of the specified bit length from this query.
+	//
+	// For IP addresses, this would create a network prefix of the given
+	// length.
+	// Returns an error if the requested bit length is invalid.
+	Prefix(int) (K, error)
+}
 
 // MapTrie is a generic data structure with properties of a prefix trie but
 // implemented using maps.
@@ -12,31 +41,32 @@ import (
 // The maximum size is 129 to accommodate both IPv4 (32 bits) and IPv6 (128 bits),
 // plus an extra slot for the default route (/0).
 //
+// The type parameter K represents the key type that implements MapTrieKey.
+// The type parameter Q represents the query type that implements MapTrieQuery.
 // The type parameter V represents the value type stored for each prefix.
-type MapTrie[V any] [129]map[netip.Prefix]V
+type MapTrie[K MapTrieKey[K], Q MapTrieQuery[K], V any] [129]map[K]V
 
 // NewMapTrie returns a new MapTrie data structure with the specified
 // initial capacity.
-func NewMapTrie[V any](cap int) MapTrie[V] {
-	trie := MapTrie[V]{}
+func NewMapTrie[K MapTrieKey[K], Q MapTrieQuery[K], V any](cap int) MapTrie[K, Q, V] {
+	trie := MapTrie[K, Q, V]{}
 
 	for idx := range trie {
-		trie[idx] = make(map[netip.Prefix]V, cap)
+		trie[idx] = make(map[K]V, cap)
 	}
 
 	return trie
 }
 
 // Lookup searches the MapTrie for a value that matches the longest
-// possible prefix for the given IP address.
+// possible prefix for the given query.
 //
 // If no match is found, the function returns the zero value and false.
-func (m *MapTrie[V]) Lookup(addr netip.Addr) (V, bool) {
-	bitLen := addr.BitLen()
+func (m *MapTrie[K, Q, V]) Lookup(query Q) (V, bool) {
+	bitLen := query.BitLen()
 
 	for bits := bitLen; bits >= 0; bits-- {
-		// TODO: leave comment why we ignore error.
-		prefix, _ := addr.Prefix(bits)
+		prefix, _ := query.Prefix(bits)
 
 		if value, ok := m[bits][prefix]; ok {
 			return value, true
@@ -47,18 +77,18 @@ func (m *MapTrie[V]) Lookup(addr netip.Addr) (V, bool) {
 	return zero, false
 }
 
-// LookupTraverse finds all prefixes in the MapTrie that contain the given IP address,
+// LookupTraverse finds all prefixes in the MapTrie that contain the given query,
 // calling a function for each matching prefix in ascending order of prefix length.
 //
 // The callback function receives each matching prefix and its associated value,
 // and can control traversal by returning a boolean value. Return true to continue
 // processing, or false to stop the traversal.
-func (m *MapTrie[V]) LookupTraverse(addr netip.Addr, fn func(netip.Prefix, V) bool) {
-	bitLen := addr.BitLen()
+func (m *MapTrie[K, Q, V]) LookupTraverse(query Q, fn func(K, V) bool) {
+	bitLen := query.BitLen()
 
 	// Note, that "<=" is not a bug!
 	for bits := 0; bits <= bitLen; bits++ {
-		prefix, _ := addr.Prefix(bits)
+		prefix, _ := query.Prefix(bits)
 
 		if value, ok := m[bits][prefix]; ok {
 			if fn(prefix, value) {
@@ -68,11 +98,17 @@ func (m *MapTrie[V]) LookupTraverse(addr netip.Addr, fn func(netip.Prefix, V) bo
 	}
 }
 
-func (m *MapTrie[V]) LookupTraverseRev(addr netip.Addr, fn func(netip.Prefix, V) bool) {
-	bitLen := addr.BitLen()
+// LookupTraverseRev finds all prefixes in the MapTrie that contain the given query,
+// calling a function for each matching prefix in descending order of prefix length.
+//
+// The callback function receives each matching prefix and its associated value,
+// and can control traversal by returning a boolean value. Return true to continue
+// processing, or false to stop the traversal.
+func (m *MapTrie[K, Q, V]) LookupTraverseRev(query Q, fn func(K, V) bool) {
+	bitLen := query.BitLen()
 
 	for bits := bitLen; bits >= 0; bits-- {
-		prefix, _ := addr.Prefix(bits)
+		prefix, _ := query.Prefix(bits)
 
 		if value, ok := m[bits][prefix]; ok {
 			if fn(prefix, value) {
@@ -82,14 +118,14 @@ func (m *MapTrie[V]) LookupTraverseRev(addr netip.Addr, fn func(netip.Prefix, V)
 	}
 }
 
-// Matches returns a list of keys that match the given IP.
+// Matches returns a list of keys that match the given query.
 //
 // The returned slice is sorted from the longest to the shortest prefix.
 // It returns an empty list if there are no matches.
-func (m *MapTrie[V]) Matches(addr netip.Addr) []netip.Prefix {
-	matches := []netip.Prefix{}
+func (m *MapTrie[K, Q, V]) Matches(query Q) []K {
+	matches := []K{}
 
-	m.LookupTraverseRev(addr, func(prefix netip.Prefix, value V) bool {
+	m.LookupTraverseRev(query, func(prefix K, value V) bool {
 		matches = append(matches, prefix)
 		return true
 	})
@@ -102,7 +138,7 @@ func (m *MapTrie[V]) Matches(addr netip.Addr) []netip.Prefix {
 // The function first normalizes the prefix with masking, then either inserts a new
 // value using the onEmpty callback or updates an existing value using the onUpdate
 // callback.
-func (m *MapTrie[V]) InsertOrUpdate(prefix netip.Prefix, onEmpty func() V, onUpdate func(V) V) {
+func (m *MapTrie[K, Q, V]) InsertOrUpdate(prefix K, onEmpty func() V, onUpdate func(V) V) {
 	prefix = prefix.Masked()
 	bits := prefix.Bits()
 
@@ -117,7 +153,7 @@ func (m *MapTrie[V]) InsertOrUpdate(prefix netip.Prefix, onEmpty func() V, onUpd
 // Len returns the total number of prefixes stored in the MapTrie.
 //
 // This counts entries across all prefix lengths.
-func (m *MapTrie[V]) Len() int {
+func (m *MapTrie[K, Q, V]) Len() int {
 	l := 0
 	for idx := range m {
 		l += len(m[idx])
@@ -127,12 +163,8 @@ func (m *MapTrie[V]) Len() int {
 }
 
 // Dump creates a flat map containing all prefixes and their values from the MapTrie.
-//
-// The function traverses the trie from longest to shortest prefixes, which means
-// that if there are overlapping prefixes, the shorter ones will overwrite the longer
-// ones in the returned map.
-func (m MapTrie[V]) Dump() map[netip.Prefix]V {
-	out := make(map[netip.Prefix]V, m.Len())
+func (m MapTrie[K, Q, V]) Dump() map[K]V {
+	out := make(map[K]V, m.Len())
 
 	// Traverse from longest to shortest prefixes.
 	for idx := len(m) - 1; idx >= 0; idx-- {

--- a/controlplane/modules/route/internal/rib/map_trie_test.go
+++ b/controlplane/modules/route/internal/rib/map_trie_test.go
@@ -21,7 +21,7 @@ var onUpdate = func(v int) func(int) int {
 }
 
 func Test_MapTrie_LookupEmpty(t *testing.T) {
-	trie := NewMapTrie[int](0)
+	trie := NewMapTrie[netip.Prefix, netip.Addr, int](0)
 
 	// Expect failed lookup in empty trie.
 	_, ok := trie.Lookup(netip.MustParseAddr("192.168.9.1"))
@@ -38,7 +38,7 @@ func Test_MapTrie_LookupAfterInsert(t *testing.T) {
 		{"127.0.0.1", false, 0},
 	}
 
-	trie := NewMapTrie[int](0)
+	trie := NewMapTrie[netip.Prefix, netip.Addr, int](0)
 	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(0), onUpdate(0))
 
 	for _, c := range cases {
@@ -58,7 +58,7 @@ func Test_MapTrie_LookupAfterInsertUpdate(t *testing.T) {
 		{"127.0.0.1", false, 0},
 	}
 
-	trie := NewMapTrie[int](0)
+	trie := NewMapTrie[netip.Prefix, netip.Addr, int](0)
 	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(0), onUpdate(0))
 	// This should update the value to 1.
 	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(1), onUpdate(1))
@@ -83,7 +83,7 @@ func Test_MapTrie_LookupAfterInsertNestedPrefixes(t *testing.T) {
 		{"127.0.0.1", true, 0},
 	}
 
-	trie := NewMapTrie[int](0)
+	trie := NewMapTrie[netip.Prefix, netip.Addr, int](0)
 	trie.InsertOrUpdate(netip.MustParsePrefix("0.0.0.0/0"), onEmpty(0), onUpdate(0))
 	trie.InsertOrUpdate(netip.MustParsePrefix("192.0.0.0/8"), onEmpty(1), onUpdate(1))
 	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(2), onUpdate(2))
@@ -113,7 +113,7 @@ func Test_MapTrie_Lookup6(t *testing.T) {
 
 	addr := netip.MustParseAddr("fd25:cf19:6b13:cafe:babe:be57:f00d:0001")
 
-	trie := NewMapTrie[int](0)
+	trie := NewMapTrie[netip.Prefix, netip.Addr, int](0)
 
 	for idx, c := range cases {
 		prefix := netip.MustParsePrefix(c.prefix).Masked()
@@ -145,7 +145,7 @@ func Test_MapTrie_Lookup6TopDownInsert(t *testing.T) {
 
 	addr := netip.MustParseAddr("fd25:cf19:6b13:cafe:babe:be57:f00d:0001")
 
-	trie := NewMapTrie[int](0)
+	trie := NewMapTrie[netip.Prefix, netip.Addr, int](0)
 
 	for idx, c := range cases {
 		prefix := netip.MustParsePrefix(c.prefix).Masked()
@@ -161,7 +161,7 @@ func Test_MapTrie_Lookup6TopDownInsert(t *testing.T) {
 }
 
 func Test_MapTrie_LookupTraverse(t *testing.T) {
-	trie := NewMapTrie[int](0)
+	trie := NewMapTrie[netip.Prefix, netip.Addr, int](0)
 
 	traverseLPM := func(addr netip.Addr) []netip.Prefix {
 		out := make([]netip.Prefix, 0)
@@ -305,7 +305,7 @@ func Fuzz_MapTrie_InsertAndLookup(f *testing.F) {
 	f.Add(byte(128), allFF[:], allFF[:])
 
 	f.Fuzz(func(t *testing.T, m byte, pb []byte, qb []byte) {
-		mt := NewMapTrie[RoutesList](0)
+		mt := NewMapTrie[netip.Prefix, netip.Addr, RoutesList](0)
 
 		prefixBytes := [16]byte{}
 		copy(prefixBytes[:], pb)
@@ -403,7 +403,7 @@ func initTestData(v4count int, v6count int, random bool) ([]netip.Addr, []Route)
 
 func Test_MapTrie_InsertMany(t *testing.T) {
 	addrs, routes := initTestData(200000, 200000, true)
-	mt := NewMapTrie[RoutesList](1024 * 4)
+	mt := NewMapTrie[netip.Prefix, netip.Addr, RoutesList](1024 * 4)
 	for _, route := range routes {
 		mt.InsertOrUpdate(
 			route.Prefix,
@@ -427,7 +427,7 @@ func Benchmark_MapTrie_InsertUniq(b *testing.B) {
 	routes := benchDataInsertuniqRoutes
 
 	inuse0 := heapInUse()
-	trie := NewMapTrie[RoutesList](1024)
+	trie := NewMapTrie[netip.Prefix, netip.Addr, RoutesList](1024)
 	inuse1 := heapInUse()
 	b.Logf("The initial Memory usage of MapTrie: %s", datasize.ByteSize(inuse1-inuse0))
 
@@ -466,7 +466,7 @@ var _, benchDataInsertMessRoutes = initTestData(1_000_000, 400_000, true)
 func Benchmark_MapTrie_InsertMess(b *testing.B) {
 	routes := benchDataInsertMessRoutes
 	inUse0 := heapInUse()
-	trie := NewMapTrie[RoutesList](1024)
+	trie := NewMapTrie[netip.Prefix, netip.Addr, RoutesList](1024)
 
 	inUse1 := heapInUse()
 	b.Logf("Initial Memory usage by mapTrie %s", datasize.ByteSize(inUse1-inUse0))
@@ -498,7 +498,7 @@ func Benchmark_mapTrie_lookup_mess_1k(b *testing.B) {
 	addrs := benchLookup1kAddrs
 	routes := benchLookup1kRoutes
 
-	mt := NewMapTrie[RoutesList](1024)
+	mt := NewMapTrie[netip.Prefix, netip.Addr, RoutesList](1024)
 	for _, route := range routes {
 		mt.InsertOrUpdate(
 			route.Prefix,

--- a/controlplane/modules/route/internal/rib/map_trie_test.go
+++ b/controlplane/modules/route/internal/rib/map_trie_test.go
@@ -8,102 +8,292 @@ import (
 	"testing"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestMapTrieInsert(t *testing.T) {
+var onEmpty = func(v int) func() int {
+	return func() int { return v }
+}
+
+var onUpdate = func(v int) func(int) int {
+	return func(int) int { return v }
+}
+
+func Test_MapTrie_LookupEmpty(t *testing.T) {
+	trie := NewMapTrie[int](0)
+
+	// Expect failed lookup in empty trie.
+	_, ok := trie.Lookup(netip.MustParseAddr("192.168.9.1"))
+	assert.False(t, ok)
+}
+
+func Test_MapTrie_LookupAfterInsert(t *testing.T) {
 	cases := []struct {
-		prefix      string
+		addr        string
+		expectedOk  bool
 		expectedIdx int
 	}{
-		{"192.168.9.1/16", 0},
-		{"192.168.9.1/24", 1},
-		{"192.168.18.0/8", 0},
+		{"192.168.9.1", true, 0},
+		{"127.0.0.1", false, 0},
 	}
-	mt := NewMapTrie(0)
-	for _, c := range cases {
-		prefix := netip.MustParsePrefix(c.prefix)
-		expected := netip.MustParsePrefix(cases[c.expectedIdx].prefix).Masked()
 
-		route := Route{
-			MapTrieKey: MapTrieKey{Prefix: prefix.Masked()},
-		}
-		mt.InsertOrUpdate(route)
-		addr := prefix.Addr()
-		list, ok := mt.Lookup(addr)
-		require.True(t, ok, "lookup %s, expected %s", addr, expected)
-		actual := list.Routes[0].Prefix.Masked()
-		require.Equal(t, expected, actual, "%s != %s", expected, actual)
+	trie := NewMapTrie[int](0)
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(0), onUpdate(0))
+
+	for _, c := range cases {
+		v, ok := trie.Lookup(netip.MustParseAddr(c.addr))
+		require.Equal(t, c.expectedOk, ok)
+		assert.Equal(t, c.expectedIdx, v)
 	}
 }
 
-func TestMapTrieLookupv6(t *testing.T) {
-	addr := netip.MustParseAddr("fd25:cf19:6b13:cafe:babe:be57:f00d:0001")
+func Test_MapTrie_LookupAfterInsertUpdate(t *testing.T) {
 	cases := []struct {
-		prefix string
-		match  bool
+		addr        string
+		expectedOk  bool
+		expectedIdx int
 	}{
-		{"fd25:8888:6b13:cafe:babe:be57:f00d:04a5/16", true},
-		{"fd25:8888:6b13:cafe:babe:be57:f00d:04a5/64", false},
-		{"fd25:cf19:6b13:cafe:babe:be57:f00d:04a5/64", true},
-		{"fd25:cf19:6b13:cafe:babe:be57:f00d:04a5/112", true},
-		{"fd25:cf19:6b13:cafe:babe:be57:f00d:04a5/120", false},
-		{"fd25:cf19:6b13:cafe:babe:be57:f00d:04a5/128", false},
+		{"192.168.9.1", true, 1},
+		{"127.0.0.1", false, 0},
 	}
-	mt := NewMapTrie(0)
+
+	trie := NewMapTrie[int](0)
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(0), onUpdate(0))
+	// This should update the value to 1.
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(1), onUpdate(1))
+
 	for _, c := range cases {
+		v, ok := trie.Lookup(netip.MustParseAddr(c.addr))
+		require.Equal(t, c.expectedOk, ok)
+		assert.Equal(t, c.expectedIdx, v)
+	}
+}
+
+func Test_MapTrie_LookupAfterInsertNestedPrefixes(t *testing.T) {
+	cases := []struct {
+		addr        string
+		expectedOk  bool
+		expectedIdx int
+	}{
+		{"192.168.1.1", true, 4},
+		{"192.168.1.2", true, 3},
+		{"192.168.2.2", true, 2},
+		{"192.200.1.1", true, 1},
+		{"127.0.0.1", true, 0},
+	}
+
+	trie := NewMapTrie[int](0)
+	trie.InsertOrUpdate(netip.MustParsePrefix("0.0.0.0/0"), onEmpty(0), onUpdate(0))
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.0.0.0/8"), onEmpty(1), onUpdate(1))
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(2), onUpdate(2))
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.1.0/24"), onEmpty(3), onUpdate(3))
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.1.1/32"), onEmpty(4), onUpdate(4))
+
+	for _, c := range cases {
+		v, ok := trie.Lookup(netip.MustParseAddr(c.addr))
+		require.Equal(t, c.expectedOk, ok)
+		assert.Equal(t, c.expectedIdx, v)
+	}
+}
+
+func Test_MapTrie_Lookup6(t *testing.T) {
+	cases := []struct {
+		prefix      string
+		expectedOk  bool
+		expectedIdx int
+	}{
+		{"fd25:cf19:6b13:cafe:babe:be57:f00d:04a5/128", false, 0},
+		{"fd25:cf19:6b13:cafe:babe:be57:f00d:400/120", false, 0},
+		{"fd25:cf19:6b13:cafe:babe:be57:f00d::/112", true, 2},
+		{"fd25:cf19:6b13:cafe::/64", true, 2},
+		{"fd25:8888:6b13:cafe::/64", true, 2},
+		{"fd25::/16", true, 2},
+	}
+
+	addr := netip.MustParseAddr("fd25:cf19:6b13:cafe:babe:be57:f00d:0001")
+
+	trie := NewMapTrie[int](0)
+
+	for idx, c := range cases {
 		prefix := netip.MustParsePrefix(c.prefix).Masked()
 
-		route := Route{
-			MapTrieKey: MapTrieKey{Prefix: prefix},
-		}
-		mt.InsertOrUpdate(route)
-		list, ok := mt.Lookup(addr)
-		mp := list.Routes[0].Prefix
-		ok = ok && prefix == mp
-		require.Equal(t, c.match, ok, "lookup expected to match==%t but ok=%t addr=%s prefix=%s mp=%s",
-			c.match, ok, addr, prefix, mp)
+		trie.InsertOrUpdate(prefix, onEmpty(idx), onUpdate(idx))
+
+		value, ok := trie.Lookup(addr)
+		require.Equal(t, c.expectedOk, ok,
+			"lookup expected match==%t, but ok=%t, prefix=%s", c.expectedOk, ok, prefix)
+		require.Equal(t, c.expectedIdx, value,
+			"lookup expected value==%d, but value=%d, prefix=%s", c.expectedIdx, value, prefix)
 	}
 }
 
-func TestMapTrieMatches(t *testing.T) {
+func Test_MapTrie_Lookup6TopDownInsert(t *testing.T) {
 	cases := []struct {
-		prefix  string
-		inMatch bool
+		prefix      string
+		expectedOk  bool
+		expectedIdx int
 	}{
-		{"192.168.9.1/32", false},
-		{"192.168.9.1/27", false},
-		{"192.168.9.1/26", true},
-		{"192.168.10.1/24", false},
-		{"192.168.9.1/24", true},
-		{"192.168.9.1/16", true},
-		{"a8c0:109::/16", false},       // 192.168.9.1 in hex
-		{"a8c0:109::/112", false},      // 192.168.9.1 in hex
-		{"::ffff:a8c0:109/16", false},  // v6 mapped ::ffff:168.192.1.9
-		{"::ffff:a8c0:109/112", false}, // v6 mapped ::ffff:168.192.1.9
-		{"192.168.18.0/8", true},
-		{"193.168.9.1/8", false},
-		{"192.168.18.0/0", true},
-	}
-	mt := NewMapTrie(0)
-	query := netip.MustParseAddr("192.168.9.32") // in /26 mask
-
-	expected := []MapTrieKey{}
-	for _, c := range cases {
-		prefix := netip.MustParsePrefix(c.prefix)
-		route := Route{MapTrieKey: MapTrieKey{Prefix: prefix.Masked()}}
-		if c.inMatch {
-			expected = append(expected, route.MapTrieKey)
-		}
-		t.Logf("expect matches: %s", expected)
-		mt.InsertOrUpdate(route)
-		actual := mt.Matches(query)
-		require.Equal(t, expected, actual)
+		{"fd25::/16", true, 0},
+		{"fd25:8888:6b13:cafe::/64", true, 0},
+		{"fd25:cf19:6b13:cafe::/64", true, 2},
+		{"fd25:cf19:6b13:cafe:babe:be57:f00d::/112", true, 3},
+		{"fd25:cf19:6b13:cafe:babe:be57:f00d:400/120", true, 3},
+		{"fd25:cf19:6b13:cafe:babe:be57:f00d:04a5/128", true, 3},
+		{"fd25:cf19:6b13:cafe:babe:be57:f00d:0001/128", true, 6},
 	}
 
+	addr := netip.MustParseAddr("fd25:cf19:6b13:cafe:babe:be57:f00d:0001")
+
+	trie := NewMapTrie[int](0)
+
+	for idx, c := range cases {
+		prefix := netip.MustParsePrefix(c.prefix).Masked()
+
+		trie.InsertOrUpdate(prefix, onEmpty(idx), onUpdate(idx))
+
+		value, ok := trie.Lookup(addr)
+		require.Equal(t, c.expectedOk, ok,
+			"lookup expected match==%t, but ok=%t, prefix=%s", c.expectedOk, ok, prefix)
+		require.Equal(t, c.expectedIdx, value,
+			"lookup expected value==%d, but value=%d, prefix=%s", c.expectedIdx, value, prefix)
+	}
 }
 
-func FuzzMapTrieInsertAndLookup(f *testing.F) {
+func Test_MapTrie_LookupTraverse(t *testing.T) {
+	trie := NewMapTrie[int](0)
+
+	traverseLPM := func(addr netip.Addr) []netip.Prefix {
+		out := make([]netip.Prefix, 0)
+		trie.LookupTraverse(addr, func(prefix netip.Prefix, value int) bool {
+			out = append(out, prefix)
+			return true
+		})
+
+		return out
+	}
+
+	addr := netip.MustParseAddr("192.168.9.32")
+	assert.Equal(t, []netip.Prefix{}, traverseLPM(addr))
+
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.9.32/32"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.9.0/24"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	// Note, that 192.168.9.0/27 does not contain 192.168.9.32 ...
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.9.0/27"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	// ... but 192.168.9.0/26 does.
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.9.0/26"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	// Does not affect.
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.10.0/24"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.168.0.0/16"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	// 192.168.0.0 in hex.
+	trie.InsertOrUpdate(netip.MustParsePrefix("a8c0::/16"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	trie.InsertOrUpdate(netip.MustParsePrefix("a8c0::/112"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	// v6 mapped ::ffff:168.192.1.9
+	trie.InsertOrUpdate(netip.MustParsePrefix("::ffff:a8c0:109/16"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	// v6 mapped ::ffff:168.192.1.9
+	trie.InsertOrUpdate(netip.MustParsePrefix("::ffff:a8c0:109/112"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	trie.InsertOrUpdate(netip.MustParsePrefix("192.0.0.0/8"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.0.0.0/8"),
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	trie.InsertOrUpdate(netip.MustParsePrefix("193.168.9.1/8"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.0.0.0/8"),
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	// NOTE: this is very important case! No intermix between IPv4 and IPv6 ...
+	trie.InsertOrUpdate(netip.MustParsePrefix("::/0"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("192.0.0.0/8"),
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+
+	// ... but IPv4 UNSPECIFIED is okay.
+	trie.InsertOrUpdate(netip.MustParsePrefix("0.0.0.0/0"), onEmpty(0), onUpdate(0))
+	assert.Equal(t, []netip.Prefix{
+		netip.MustParsePrefix("0.0.0.0/0"),
+		netip.MustParsePrefix("192.0.0.0/8"),
+		netip.MustParsePrefix("192.168.0.0/16"),
+		netip.MustParsePrefix("192.168.9.0/24"),
+		netip.MustParsePrefix("192.168.9.0/26"),
+		netip.MustParsePrefix("192.168.9.32/32"),
+	}, traverseLPM(addr))
+}
+
+func Fuzz_MapTrie_InsertAndLookup(f *testing.F) {
 	addr := netip.MustParseAddr("fd25:c819:6888:0:b282:ffff:1841:3832").As16()
 	allZero := netip.IPv6Unspecified().As16()
 	allFF := netip.MustParseAddr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff").As16()
@@ -115,7 +305,7 @@ func FuzzMapTrieInsertAndLookup(f *testing.F) {
 	f.Add(byte(128), allFF[:], allFF[:])
 
 	f.Fuzz(func(t *testing.T, m byte, pb []byte, qb []byte) {
-		mt := NewMapTrie(0)
+		mt := NewMapTrie[RoutesList](0)
 
 		prefixBytes := [16]byte{}
 		copy(prefixBytes[:], pb)
@@ -124,8 +314,19 @@ func FuzzMapTrieInsertAndLookup(f *testing.F) {
 		m = min(m, 128)
 		p := netip.PrefixFrom(prefixAddr, int(m)).Masked()
 
-		route := Route{MapTrieKey: MapTrieKey{Prefix: p}}
-		mt.InsertOrUpdate(route)
+		route := Route{Prefix: p}
+		mt.InsertOrUpdate(
+			p,
+			func() RoutesList {
+				return RoutesList{
+					Routes: []Route{route},
+				}
+			},
+			func(m RoutesList) RoutesList {
+				m.Routes = append(m.Routes, route)
+				return m
+			},
+		)
 
 		queryBytes := [16]byte{}
 		copy(queryBytes[:], qb)
@@ -156,6 +357,7 @@ func heapInUse() uint64 {
 	runtime.GC()
 	ms := runtime.MemStats{}
 	runtime.ReadMemStats(&ms)
+
 	return ms.HeapInuse
 }
 
@@ -194,16 +396,23 @@ func initTestData(v4count int, v6count int, random bool) ([]netip.Addr, []Route)
 			mask = rand.Intn(a.BitLen() + 1)
 		}
 		p, _ := a.Prefix(mask)
-		routes[idx] = Route{MapTrieKey: MapTrieKey{Prefix: p.Masked()}}
+		routes[idx] = Route{Prefix: p.Masked()}
 	}
 	return addrs, routes
 }
 
-func TestMapTrieInsertMany(t *testing.T) {
+func Test_MapTrie_InsertMany(t *testing.T) {
 	addrs, routes := initTestData(200000, 200000, true)
-	mt := NewMapTrie(1024 * 4)
+	mt := NewMapTrie[RoutesList](1024 * 4)
 	for _, route := range routes {
-		mt.InsertOrUpdate(route)
+		mt.InsertOrUpdate(
+			route.Prefix,
+			func() RoutesList { return RoutesList{Routes: []Route{route}} },
+			func(m RoutesList) RoutesList {
+				m.Routes = append(m.Routes, route)
+				return m
+			},
+		)
 	}
 	for _, addr := range addrs {
 		_, ok := mt.Lookup(addr)
@@ -213,18 +422,28 @@ func TestMapTrieInsertMany(t *testing.T) {
 
 var benchDataInsertuniqAddrs, benchDataInsertuniqRoutes = initTestData(1_000_000, 400_000, false)
 
-func Benchmark_mapTrie_insert_uniq(b *testing.B) {
+func Benchmark_MapTrie_InsertUniq(b *testing.B) {
 	addrs := benchDataInsertuniqAddrs
 	routes := benchDataInsertuniqRoutes
 
 	inuse0 := heapInUse()
-	mt := NewMapTrie(1024)
+	trie := NewMapTrie[RoutesList](1024)
 	inuse1 := heapInUse()
 	b.Logf("The initial Memory usage of MapTrie: %s", datasize.ByteSize(inuse1-inuse0))
+
 	b.ResetTimer()
 	for range b.N {
-		for idx := range routes {
-			mt.InsertOrUpdate(routes[idx])
+		for idx, route := range routes {
+			trie.InsertOrUpdate(
+				routes[idx].Prefix,
+				func() RoutesList {
+					return RoutesList{Routes: []Route{route}}
+				},
+				func(m RoutesList) RoutesList {
+					m.Routes = append(m.Routes, route)
+					return m
+				},
+			)
 		}
 	}
 	b.StopTimer()
@@ -232,34 +451,45 @@ func Benchmark_mapTrie_insert_uniq(b *testing.B) {
 	var found int
 	idx := max(rand.Intn(len(addrs))-1000, 0)
 	for idx := range addrs[idx : idx+1000] {
-		v, ok := mt.Lookup(addrs[idx])
+		v, ok := trie.Lookup(addrs[idx])
 		if !ok {
 			panic("not found")
 		}
 		found += len(v.Routes)
 	}
-	b.Logf("Total number of routes %d: uniq %d", len(routes), mt.Len())
+	b.Logf("Total number of routes %d: uniq %d", len(routes), trie.Len())
 	b.Logf("Memory usage by mapTrie %s found=%d of 1k", datasize.ByteSize(inuse2-inuse0), found)
 }
 
-var benchDataInsertMessAddrs, benchDataInsertMessRoutes = initTestData(1_000_000, 400_000, true)
+var _, benchDataInsertMessRoutes = initTestData(1_000_000, 400_000, true)
 
-func Benchmark_mapTrie_insert_mess(b *testing.B) {
+func Benchmark_MapTrie_InsertMess(b *testing.B) {
 	routes := benchDataInsertMessRoutes
-	inuse0 := heapInUse()
-	mt := NewMapTrie(1024)
-	inuse1 := heapInUse()
-	b.Logf("Initial Memory usage by mapTrie %s", datasize.ByteSize(inuse1-inuse0))
+	inUse0 := heapInUse()
+	trie := NewMapTrie[RoutesList](1024)
+
+	inUse1 := heapInUse()
+	b.Logf("Initial Memory usage by mapTrie %s", datasize.ByteSize(inUse1-inUse0))
 	b.ResetTimer()
 	for range b.N {
-		for idx := range routes {
-			mt.InsertOrUpdate(routes[idx])
+		for idx, route := range routes {
+			trie.InsertOrUpdate(
+				routes[idx].Prefix,
+				func() RoutesList {
+					return RoutesList{Routes: []Route{route}}
+				},
+				func(m RoutesList) RoutesList {
+					m.Routes = append(m.Routes, route)
+					return m
+				},
+			)
 		}
 	}
 	b.StopTimer()
 	inuse2 := heapInUse()
-	b.Logf("Total number of prefixes %d: uniq %d", len(routes), mt.Len())
-	b.Logf("Memory usage by mapTrie %s", datasize.ByteSize(inuse2-inuse0))
+
+	b.Logf("Total number of prefixes %d: uniq %d", len(routes), trie.Len())
+	b.Logf("Memory usage by mapTrie %s", datasize.ByteSize(inuse2-inUse0))
 }
 
 var benchLookup1kAddrs, benchLookup1kRoutes = initTestData(1_000_000, 400_000, true)
@@ -268,9 +498,17 @@ func Benchmark_mapTrie_lookup_mess_1k(b *testing.B) {
 	addrs := benchLookup1kAddrs
 	routes := benchLookup1kRoutes
 
-	mt := NewMapTrie(1024)
+	mt := NewMapTrie[RoutesList](1024)
 	for _, route := range routes {
-		mt.InsertOrUpdate(route)
+		mt.InsertOrUpdate(
+			route.Prefix,
+			func() RoutesList {
+				return RoutesList{Routes: []Route{route}}
+			},
+			func(m RoutesList) RoutesList {
+				return m
+			},
+		)
 	}
 
 	var found int

--- a/controlplane/modules/route/internal/rib/rib.go
+++ b/controlplane/modules/route/internal/rib/rib.go
@@ -14,7 +14,7 @@ import (
 
 type RIB struct {
 	mu         sync.RWMutex
-	routes     MapTrie
+	routes     MapTrie[RoutesList]
 	neighbours *neigh.NexthopCache
 	links      *link.LinksCache
 	log        *zap.SugaredLogger
@@ -22,7 +22,7 @@ type RIB struct {
 
 func NewRIB(neighbours *neigh.NexthopCache, links *link.LinksCache, log *zap.SugaredLogger) *RIB {
 	return &RIB{
-		routes:     NewMapTrie(1024),
+		routes:     NewMapTrie[RoutesList](1024),
 		neighbours: neighbours,
 		links:      links,
 		log:        log,
@@ -64,7 +64,7 @@ func (m *RIB) AddUnicastRoute(prefix netip.Prefix, nexthopAddr netip.Addr) error
 	)
 
 	route := Route{
-		MapTrieKey: MapTrieKey{Prefix: prefix},
+		Prefix: prefix,
 	}
 
 	// Safe, because we've checked for MAC address format earlier.
@@ -72,7 +72,19 @@ func (m *RIB) AddUnicastRoute(prefix netip.Prefix, nexthopAddr netip.Addr) error
 	copy(route.DestinationMAC[:], neigh.HardwareAddr)
 
 	m.mu.Lock()
-	m.routes.InsertOrUpdate(route)
+	m.routes.InsertOrUpdate(
+		prefix,
+		func() RoutesList {
+			return RoutesList{
+				Routes: []Route{route},
+			}
+		},
+		func(m RoutesList) RoutesList {
+			// WIP(sakateka): FIXME: deduplicate routes
+			m.Routes = append(m.Routes, route)
+			return m
+		},
+	)
 	m.mu.Unlock()
 
 	m.log.Infow("added unicast route",
@@ -85,14 +97,14 @@ func (m *RIB) AddUnicastRoute(prefix netip.Prefix, nexthopAddr netip.Addr) error
 	return nil
 }
 
-func (m *RIB) DumpRoutes() map[MapTrieKey]RoutesList {
+func (m *RIB) DumpRoutes() map[netip.Prefix]RoutesList {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.routes.Dump()
 }
 
 type Route struct {
-	MapTrieKey
+	netip.Prefix
 	NextHop netip.Addr
 	// Temporary placeholder
 	HardwareRoute
@@ -110,9 +122,4 @@ func (m HardwareRoute) String() string {
 
 type RoutesList struct {
 	Routes []Route
-}
-
-func (m *RoutesList) Insert(route Route) {
-	// WIP(sakateka): FIXME: deduplicate routes
-	m.Routes = append(m.Routes, route)
 }

--- a/controlplane/modules/route/internal/rib/rib.go
+++ b/controlplane/modules/route/internal/rib/rib.go
@@ -14,7 +14,7 @@ import (
 
 type RIB struct {
 	mu         sync.RWMutex
-	routes     MapTrie[RoutesList]
+	routes     MapTrie[netip.Prefix, netip.Addr, RoutesList]
 	neighbours *neigh.NexthopCache
 	links      *link.LinksCache
 	log        *zap.SugaredLogger
@@ -22,7 +22,7 @@ type RIB struct {
 
 func NewRIB(neighbours *neigh.NexthopCache, links *link.LinksCache, log *zap.SugaredLogger) *RIB {
 	return &RIB{
-		routes:     NewMapTrie[RoutesList](1024),
+		routes:     NewMapTrie[netip.Prefix, netip.Addr, RoutesList](1024),
 		neighbours: neighbours,
 		links:      links,
 		log:        log,

--- a/controlplane/modules/route/service.go
+++ b/controlplane/modules/route/service.go
@@ -116,7 +116,7 @@ func (m *RouteService) InsertRoute(
 				idx = uint32(routeListIdx)
 			}
 
-			if err := config.PrefixAdd(key.Prefix, idx); err != nil {
+			if err := config.PrefixAdd(key, idx); err != nil {
 				return nil, fmt.Errorf("failed to add prefix %q: %w", prefix, err)
 			}
 		}


### PR DESCRIPTION
The most noticable change - MapTrie is now a generic structure, where the type parameter V represents the value type stored for each prefix.

Performance changes:
- InsertOrUpdate method now accepts two functions. The first one is called on empty value. The second is called when a value exists and needs to be updated. This results in less unnecessary allocations.

Minor changes:
- Add traversal functions to MapTrie.
- Add documentation for previously undocumented functions in MapTrie.
- Rewrite tests to improve readability and cause and effect relationship.