### PR TITLE
feat: HTTP <-> gRPC transparent proxy

### DIFF
--- a/controlplane/etc/yanet/controlplane-director.yaml
+++ b/controlplane/etc/yanet/controlplane-director.yaml
@@ -9,6 +9,7 @@ logging:
 gateway:
   server:
     endpoint: &gateway_endpoint "[::1]:8080"
+    http_endpoint: "[::1]:8081"
 modules:
   route:
     # MemoryPathPrefix is the path to the shared-memory file that is used to

--- a/controlplane/internal/gateway/cfg.go
+++ b/controlplane/internal/gateway/cfg.go
@@ -10,6 +10,9 @@ type Config struct {
 type ServerConfig struct {
 	// Endpoint is the endpoint for the gateway server to be exposed on.
 	Endpoint string `yaml:"endpoint"`
+	// HTTPEndpoint is the endpoint for the HTTP server that provides
+	// access to gRPC services for web clients.
+	HTTPEndpoint string `yaml:"http_endpoint"`
 }
 
 func DefaultConfig() *Config {

--- a/controlplane/internal/gateway/gateway.go
+++ b/controlplane/internal/gateway/gateway.go
@@ -166,9 +166,7 @@ func (m *Gateway) Run(ctx context.Context) error {
 		})
 	}
 
-	// Run built-in modules.
 	for _, builtInModule := range m.builtInModules {
-		builtInModule := builtInModule // capture for closure.
 		wg.Go(func() error {
 			m.log.Infow("starting built-in module", zap.String("module", fmt.Sprintf("%T", builtInModule)))
 			return builtInModule.Run(ctx)

--- a/controlplane/internal/gateway/gateway.go
+++ b/controlplane/internal/gateway/gateway.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
+	"time"
 
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"go.uber.org/zap"
@@ -154,10 +156,19 @@ func (m *Gateway) Run(ctx context.Context) error {
 	m.log.Infow("exposing gRPC gateway", zap.Stringer("addr", listener.Addr()))
 
 	wg, ctx := errgroup.WithContext(ctx)
+
 	wg.Go(func() error {
 		return m.server.Serve(listener)
 	})
+	if m.cfg.Server.HTTPEndpoint != "" {
+		wg.Go(func() error {
+			return m.runHTTPServer(ctx)
+		})
+	}
+
+	// Run built-in modules.
 	for _, builtInModule := range m.builtInModules {
+		builtInModule := builtInModule // capture for closure.
 		wg.Go(func() error {
 			m.log.Infow("starting built-in module", zap.String("module", fmt.Sprintf("%T", builtInModule)))
 			return builtInModule.Run(ctx)
@@ -172,4 +183,32 @@ func (m *Gateway) Run(ctx context.Context) error {
 	m.server.GracefulStop()
 
 	return wg.Wait()
+}
+
+// runHTTPServer runs the HTTP server that provides access to gRPC services
+// via HTTP.
+func (m *Gateway) runHTTPServer(ctx context.Context) error {
+	server := &http.Server{
+		Addr:    m.cfg.Server.HTTPEndpoint,
+		Handler: NewHTTPHandler(m.registry, m.log),
+	}
+
+	// Set up graceful shutdown.
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		m.log.Infow("shutting down HTTP server", zap.String("addr", m.cfg.Server.HTTPEndpoint))
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			m.log.Warnw("failed to shut down HTTP server", zap.Error(err))
+		}
+	}()
+
+	m.log.Infow("exposing HTTP <-> gRPC gateway", zap.String("addr", m.cfg.Server.HTTPEndpoint))
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		return fmt.Errorf("failed to serve: %w", err)
+	}
+
+	return nil
 }

--- a/controlplane/internal/gateway/proxy.go
+++ b/controlplane/internal/gateway/proxy.go
@@ -1,0 +1,202 @@
+package gateway
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/siderolabs/grpc-proxy/proxy"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/xgrpc"
+)
+
+// TransparentWebGRPCProxy is an HTTP handler that translates HTTP requests
+// with binary protobuf payloads to gRPC calls.
+type TransparentWebGRPCProxy struct {
+	registry *BackendRegistry
+	log      *zap.SugaredLogger
+}
+
+// NewHTTPHandler creates a new HTTPHandler.
+func NewHTTPHandler(registry *BackendRegistry, log *zap.SugaredLogger) *TransparentWebGRPCProxy {
+	return &TransparentWebGRPCProxy{
+		registry: registry,
+		log:      log,
+	}
+}
+
+// ServeHTTP handles HTTP requests.
+func (m *TransparentWebGRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Only support POST method for actual gRPC calls.
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed. Only POST is supported", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Convert URL path to gRPC fullMethodName format.
+	fullMethodName := r.URL.Path
+	fullMethodName = strings.TrimPrefix(fullMethodName, "/api")
+	if !strings.HasPrefix(fullMethodName, "/") {
+		fullMethodName = "/" + fullMethodName
+	}
+
+	service, method, err := xgrpc.ParseFullMethod(fullMethodName)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid method name: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	backend, ok := m.registry.GetBackend(service)
+	if !ok {
+		http.Error(w, fmt.Sprintf("Service not found: %s", service), http.StatusNotFound)
+		return
+	}
+
+	// Read request body (binary protobuf payload).
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to read request body: %v", err), http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// Create context with metadata from HTTP headers.
+	ctx := r.Context()
+	md := metadata.New(nil)
+	for k, v := range r.Header {
+		k = strings.ToLower(k)
+		if !strings.HasPrefix(k, "sec-") && k != "host" && k != "connection" {
+			md.Set(k, v...)
+		}
+	}
+	ctx = metadata.NewOutgoingContext(ctx, md)
+
+	outCtx, conn, err := backend.GetConnection(ctx, fullMethodName)
+	if err != nil {
+		m.log.Errorw("failed to get connection to backend",
+			zap.String("service", service),
+			zap.String("method", method),
+			zap.Error(err),
+		)
+		http.Error(w, fmt.Sprintf("Failed to connect to backend: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Create byte buffer for response.
+	var respData []byte
+
+	// We use a custom codec to directly send/receive binary protobuf data.
+	responseBuffer := proxy.NewFrame(nil)
+
+	// Invoke the gRPC method with the binary protobuf payload.
+	err = conn.Invoke(
+		outCtx,
+		fullMethodName,
+		proxy.NewFrame(body),
+		responseBuffer,
+		grpc.ForceCodecV2(proxy.Codec()),
+	)
+	if err != nil {
+		m.log.Errorw("failed to proxy gRPC",
+			zap.String("service", service),
+			zap.String("method", method),
+			zap.Error(err),
+		)
+
+		// Convert gRPC error to HTTP error
+		statusErr, ok := status.FromError(err)
+		if ok {
+			code := statusErr.Code()
+			http.Error(w, statusErr.Message(), grpcCodeToHTTPStatus(code))
+		} else {
+			http.Error(w, fmt.Sprintf("failed to proxy gRPC: %v", err), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	// We need to re-marshal the response to get the binary data.
+	codec := proxy.Codec()
+	bufSlice, err := codec.Marshal(responseBuffer)
+	if err != nil {
+		m.log.Errorw("failed to marshal response",
+			zap.String("service", service),
+			zap.String("method", method),
+			zap.Error(err),
+		)
+		http.Error(w, fmt.Sprintf("Failed to marshal response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	// Materialize the buffer slice.
+	respData = bufSlice.Materialize()
+
+	// Set our special content type header.
+	w.Header().Set("Content-Type", "application/x-protobuf")
+
+	// Write the binary payload to the response.
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(respData); err != nil {
+		m.log.Errorw("failed to write HTTP response",
+			zap.String("service", service),
+			zap.String("method", method),
+			zap.Error(err),
+		)
+	}
+}
+
+// grpcCodeToHTTPStatus maps gRPC status codes to HTTP status codes.
+func grpcCodeToHTTPStatus(code codes.Code) int {
+	switch code {
+	case codes.OK:
+		return http.StatusOK
+	case codes.Canceled:
+		return http.StatusRequestTimeout
+	case codes.Unknown:
+		return http.StatusInternalServerError
+	case codes.InvalidArgument:
+		return http.StatusBadRequest
+	case codes.DeadlineExceeded:
+		return http.StatusGatewayTimeout
+	case codes.NotFound:
+		return http.StatusNotFound
+	case codes.AlreadyExists:
+		return http.StatusConflict
+	case codes.PermissionDenied:
+		return http.StatusForbidden
+	case codes.ResourceExhausted:
+		return http.StatusTooManyRequests
+	case codes.FailedPrecondition:
+		return http.StatusBadRequest
+	case codes.Aborted:
+		return http.StatusConflict
+	case codes.OutOfRange:
+		return http.StatusBadRequest
+	case codes.Unimplemented:
+		return http.StatusNotImplemented
+	case codes.Internal:
+		return http.StatusInternalServerError
+	case codes.Unavailable:
+		return http.StatusServiceUnavailable
+	case codes.DataLoss:
+		return http.StatusInternalServerError
+	case codes.Unauthenticated:
+		return http.StatusUnauthorized
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/controlplane/internal/gateway/proxy.go
+++ b/controlplane/internal/gateway/proxy.go
@@ -73,7 +73,6 @@ func (m *TransparentWebGRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		http.Error(w, fmt.Sprintf("Failed to read request body: %v", err), http.StatusBadRequest)
 		return
 	}
-	defer r.Body.Close()
 
 	// Create context with metadata from HTTP headers.
 	ctx := r.Context()
@@ -96,9 +95,6 @@ func (m *TransparentWebGRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		http.Error(w, fmt.Sprintf("Failed to connect to backend: %v", err), http.StatusInternalServerError)
 		return
 	}
-
-	// Create byte buffer for response.
-	var respData []byte
 
 	// We use a custom codec to directly send/receive binary protobuf data.
 	responseBuffer := proxy.NewFrame(nil)
@@ -143,7 +139,7 @@ func (m *TransparentWebGRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Materialize the buffer slice.
-	respData = bufSlice.Materialize()
+	respData := bufSlice.Materialize()
 
 	// Set our special content type header.
 	w.Header().Set("Content-Type", "application/x-protobuf")

--- a/web/.rustfmt.toml
+++ b/web/.rustfmt.toml
@@ -1,4 +1,3 @@
-edition = "2021"
 max_width = 120
 reorder_imports = true
 imports_granularity = "Crate"

--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +81,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "attribute-derive"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +121,21 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "base64"
@@ -266,6 +302,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,10 +444,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "event-listener"
@@ -425,10 +490,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -555,6 +647,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "gloo-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +705,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
+name = "h2"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +734,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -645,6 +768,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hydration_context"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +808,78 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "throw_error",
+]
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -853,6 +1077,12 @@ name = "interpolator"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "itertools"
@@ -1083,6 +1313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfae20f6b19ad527b550c223fddc3077a547fc70cda94b9b566575423fd303ee"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
 name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,10 +1370,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "next_tuple"
@@ -1181,6 +1466,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "oco_ref"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,6 +1489,50 @@ name = "once_cell"
 version = "1.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+
+[[package]]
+name = "openssl"
+version = "0.10.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "or_poisoned"
@@ -1250,6 +1588,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,6 +1628,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "powerfmt"
@@ -1350,6 +1704,58 @@ dependencies = [
  "syn",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1471,6 +1877,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rstml"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1486,10 +1950,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -1513,10 +2035,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -1576,6 +2130,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -1664,6 +2230,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +2250,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1699,6 +2281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +2298,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1741,6 +2353,20 @@ dependencies = [
  "throw_error",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1834,6 +2460,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1866,6 +2540,58 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-builder"
@@ -1924,6 +2650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,6 +2713,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2103,7 +2850,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2111,6 +2858,45 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]
@@ -2228,6 +3014,7 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 name = "yanetweb"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "chrono",
  "console_log",
  "instant",
@@ -2235,6 +3022,9 @@ dependencies = [
  "leptos-use",
  "leptos_router",
  "log",
+ "prost",
+ "prost-build",
+ "reqwest",
  "wasm-logger",
  "web-sys",
 ]
@@ -2289,6 +3079,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerovec"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -16,10 +16,18 @@ instant = { version = "0.1", features = ["wasm-bindgen", "inaccurate"] }
 chrono = { version = "0.4", features = ["serde", "wasmbind"] }
 console_log = "1"
 
+# gRPC/Protobuf dependencies
+prost = "0.13"
+reqwest = { version = "0.12", features = ["json"] }
+bytes = "1.5"
+
 # TDB.
 log = "0.4"
 wasm-logger = "0.2"
 leptos-use = { version = "0.15.6", features = ["use_element_bounding"] }
+
+[build-dependencies]
+prost-build = "0.13"
 
 [profile.wasm-release]
 inherits = "release"

--- a/web/build.rs
+++ b/web/build.rs
@@ -1,0 +1,28 @@
+use std::{io, path::PathBuf};
+
+fn main() -> io::Result<()> {
+    println!("cargo:rerun-if-changed=../controlplane/modules/route/routepb");
+
+    // Path to the directory containing proto files.
+    let route_proto_dir = PathBuf::from("../controlplane/modules/route/routepb");
+
+    // Collect all .proto files.
+    let mut proto_files = Vec::new();
+    for entry in std::fs::read_dir(route_proto_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() && path.extension().unwrap_or_default() == "proto" {
+            proto_files.push(path);
+        }
+    }
+
+    prost_build::Config::new().compile_protos(
+        &[
+            "../controlplane/modules/route/routepb/route.proto",
+            "../controlplane/modules/route/routepb/neighbour.proto",
+        ],
+        &["../controlplane/modules/route/routepb"],
+    )?;
+
+    Ok(())
+}

--- a/web/src/api/mod.rs
+++ b/web/src/api/mod.rs
@@ -1,0 +1,107 @@
+use core::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+};
+
+use prost::Message;
+
+pub mod neighbour;
+
+/// Custom error type for gRPC HTTP client
+#[derive(Debug)]
+pub enum GrpcHttpError {
+    /// Request error
+    Request(reqwest::Error),
+    /// Server returned an error
+    Server { status: u16, message: String },
+    /// Error encoding the request
+    Encode(String),
+    /// Error decoding the response
+    Decode(String),
+}
+
+impl Display for GrpcHttpError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Self::Request(err) => write!(f, "HTTP request failed: {}", err),
+            Self::Server { status, message } => {
+                write!(f, "Server error ({}): {}", status, message)
+            }
+            Self::Encode(err) => write!(f, "Failed to encode request: {}", err),
+            Self::Decode(err) => write!(f, "Failed to decode response: {}", err),
+        }
+    }
+}
+
+impl Error for GrpcHttpError {}
+
+impl From<reqwest::Error> for GrpcHttpError {
+    fn from(err: reqwest::Error) -> Self {
+        GrpcHttpError::Request(err)
+    }
+}
+
+/// A client for making HTTP requests to gRPC services
+pub struct GrpcHttpClient {
+    /// Base URL for the HTTP-gRPC gateway
+    base_url: String,
+    /// HTTP client for making requests
+    client: reqwest::Client,
+}
+
+impl GrpcHttpClient {
+    /// Create a new HTTP-gRPC client
+    ///
+    /// The base_url should be the URL of the HTTP-gRPC gateway, e.g. "http://localhost:8080"
+    pub fn new(base_url: String) -> Self {
+        Self {
+            base_url,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Call a gRPC method over HTTP
+    ///
+    /// This method sends a binary protobuf message to the HTTP-gRPC gateway and
+    /// expects a binary protobuf response.
+    pub async fn call<Req, Resp>(&self, service: &str, method: &str, request: &Req) -> Result<Resp, GrpcHttpError>
+    where
+        Req: Message,
+        Resp: Message + Default,
+    {
+        // Serialize the request message to bytes
+        let mut buf = Vec::new();
+        request
+            .encode(&mut buf)
+            .map_err(|e| GrpcHttpError::Encode(e.to_string()))?;
+
+        // Format the URL
+        let url = format!("{}/api/{}/{}", self.base_url, service, method);
+
+        // Send the request
+        let response = self
+            .client
+            .post(&url)
+            .header("Content-Type", "application/x-protobuf")
+            .body(buf)
+            .send()
+            .await?;
+
+        // Check for error status
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let message = response.text().await.unwrap_or_else(|_| String::from("Unknown error"));
+            return Err(GrpcHttpError::Server { status, message });
+        }
+
+        // Get the binary response body
+        let bytes = response.bytes().await?;
+
+        // Deserialize the response
+        let mut resp = Resp::default();
+        resp.merge(bytes.as_ref())
+            .map_err(|e| GrpcHttpError::Decode(e.to_string()))?;
+
+        Ok(resp)
+    }
+}

--- a/web/src/api/neighbour.rs
+++ b/web/src/api/neighbour.rs
@@ -1,0 +1,34 @@
+use core::fmt;
+
+use self::code::{ListNeighboursRequest, ListNeighboursResponse, NeighbourEntry};
+use super::{GrpcHttpClient, GrpcHttpError};
+
+#[allow(non_snake_case)]
+mod code {
+    include!(concat!(env!("OUT_DIR"), "/routepb.rs"));
+}
+
+/// Client for interacting with the Neighbour API.
+pub struct NeighbourClient {
+    client: GrpcHttpClient,
+}
+
+impl NeighbourClient {
+    /// Constructs a new [`NeighbourClient`].
+    pub fn new(base_url: String) -> Self {
+        Self {
+            client: GrpcHttpClient::new(base_url),
+        }
+    }
+
+    pub async fn list_neighbours(&self) -> Result<Vec<NeighbourEntry>, GrpcHttpError> {
+        let request = ListNeighboursRequest {};
+
+        let response = self
+            .client
+            .call::<ListNeighboursRequest, ListNeighboursResponse>("routepb.Neighbour", "List", &request)
+            .await?;
+
+        Ok(response.neighbours)
+    }
+}

--- a/web/src/components/demo.rs
+++ b/web/src/components/demo.rs
@@ -2,16 +2,19 @@ use std::{borrow::Cow, time::Duration};
 
 use leptos::prelude::*;
 
-use crate::components::common::{
-    button::Button,
-    dropdown::Dropdown,
-    header::Header,
-    input::Input,
-    popover::{Popover, PopoverTrigger},
-    popup::SpanPopup,
-    progress::ProgressBar,
-    snackbar::{SnackbarContext, SnackbarData},
-    viewport::{Viewport, ViewportContent},
+use crate::{
+    api,
+    components::common::{
+        button::Button,
+        dropdown::Dropdown,
+        header::Header,
+        input::Input,
+        popover::{Popover, PopoverTrigger},
+        popup::SpanPopup,
+        progress::ProgressBar,
+        snackbar::{SnackbarContext, SnackbarData},
+        viewport::{Viewport, ViewportContent},
+    },
 };
 
 #[component]
@@ -28,9 +31,37 @@ pub fn DemoView() -> impl IntoView {
     set_interval(move || set_progress.update(|p| *p += 0.01), Duration::from_millis(20));
 
     let snackbar = expect_context::<SnackbarContext>();
-    snackbar.push(SnackbarData::error("Test popup 1"));
-    snackbar.push(SnackbarData::error("Test popup 2"));
-    snackbar.push(SnackbarData::error("Test popup 3"));
+
+    // Create an action to fetch neighbours
+    let fetch_neighbours = Action::new_local(move |_| async move {
+        let client = api::neighbour::NeighbourClient::new(window().origin());
+
+        match client.list_neighbours().await {
+            Ok(neighbours) => {
+                log::info!("Retrieved {} neighbours", neighbours.len());
+
+                // Log each neighbour
+                for (i, neighbour) in neighbours.iter().enumerate() {
+                    log::info!(
+                        "Neighbour {}: IP={}, MAC={}, State={}",
+                        i + 1,
+                        neighbour.next_hop,
+                        neighbour.link_addr,
+                        neighbour.state
+                    );
+                }
+
+                snackbar.push(SnackbarData::error(format!(
+                    "Retrieved {} neighbours",
+                    neighbours.len()
+                )));
+            }
+            Err(err) => {
+                log::info!("Failed to retrieve neighbours: {}", err);
+                snackbar.push(SnackbarData::error(format!("Failed to retrieve neighbours: {}", err)));
+            }
+        }
+    });
 
     view! {
         <Viewport>
@@ -38,9 +69,18 @@ pub fn DemoView() -> impl IntoView {
                 <h1>"Demo"</h1>
                 <Button
                     primary=true
-                    on:click=move |_| snackbar.push(SnackbarData::error("Test popup 3"))
+                    on:click=move |_| snackbar.push(SnackbarData::error("Test popup"))
                 >
                     "Add popup"
+                </Button>
+
+                <Button
+                    primary=true
+                    on:click=move |_| {
+                        fetch_neighbours.dispatch(());
+                    }
+                >
+                    "Get Neighbours"
                 </Button>
             </Header>
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -5,7 +5,7 @@ use leptos_router::{
 };
 use settings::SideBarContext;
 
-// mod api;
+mod api;
 mod components;
 // mod i18n;
 mod settings;


### PR DESCRIPTION
The idea is to terminate HTTP requests on Gateway side, then just pass them directly to gRPC streams without modification.

This approach allows to forward requests/responses without knowing its protobuf definition, and that's the reason why we don't use go-grpc-gateway to solve the issue.