### PR TITLE
Agent introspection

### DIFF
--- a/agent/info/main.go
+++ b/agent/info/main.go
@@ -33,6 +33,25 @@ func main() {
 	dp_modules := C.yanet_get_dp_module_list_info(dpConfig)
 	defer C.dp_module_list_info_free(dp_modules)
 
+	agents := C.yanet_get_cp_agent_list_info(dpConfig)
+	defer C.cp_agent_list_info_free(agents)
+
+	for agentIdx := C.uint64_t(0); agentIdx < agents.count; agentIdx++ {
+		agent := (*C.struct_cp_agent_info)(nil)
+		C.yanet_get_cp_agent_info(agents, agentIdx, &agent)
+		fmt.Printf("Agent %s\n", C.GoString(&agent.name[0]))
+		for instanceIdx := C.uint64_t(0); instanceIdx < agent.instance_count; instanceIdx++ {
+			instance := (*C.struct_cp_agent_instance_info)(nil)
+			C.yanet_get_cp_agent_instance_info(agent, instanceIdx, &instance)
+			fmt.Printf("  Pid %v Limit %d Allocated %d Freed %d\n",
+				instance.pid,
+				instance.memory_limit,
+				instance.allocated,
+				instance.freed,
+			)
+		}
+	}
+
 	cp_modules := C.yanet_get_cp_module_list_info(dpConfig)
 	defer C.cp_module_list_info_free(cp_modules)
 

--- a/api/agent.h
+++ b/api/agent.h
@@ -204,3 +204,41 @@ yanet_get_cp_pipeline_module_info(
 	uint64_t index,
 	uint64_t *config_index
 );
+
+struct cp_agent_instance_info {
+	pid_t pid;
+	uint64_t memory_limit;
+	uint64_t allocated;
+	uint64_t freed;
+};
+
+struct cp_agent_info {
+	char name[80];
+	uint64_t instance_count;
+	struct cp_agent_instance_info instances[];
+};
+
+struct cp_agent_list_info {
+	uint64_t count;
+	struct cp_agent_info *agents[];
+};
+
+int
+yanet_get_cp_agent_instance_info(
+	struct cp_agent_info *agent_info,
+	uint64_t index,
+	struct cp_agent_instance_info **instance_info
+);
+
+int
+yanet_get_cp_agent_info(
+	struct cp_agent_list_info *agent_list_info,
+	uint64_t index,
+	struct cp_agent_info **agent_info
+);
+
+void
+cp_agent_list_info_free(struct cp_agent_list_info *agent_list_info);
+
+struct cp_agent_list_info *
+yanet_get_cp_agent_list_info(struct dp_config *dp_config);

--- a/common/strutils.h
+++ b/common/strutils.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include <errno.h>
+
+ssize_t
+strtcpy(char *restrict dst, const char *restrict src, size_t dsize) {
+	bool trunc;
+	size_t dlen, slen;
+
+	if (dsize == 0) {
+		errno = ENOBUFS;
+		return -1;
+	}
+
+	slen = strnlen(src, dsize);
+	trunc = (slen == dsize);
+	dlen = slen - trunc;
+
+	stpcpy(mempcpy(dst, src, dlen), "");
+	if (trunc)
+		errno = E2BIG;
+	return trunc ? -1 : (ssize_t)slen;
+}

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -17,6 +17,7 @@ struct agent {
 	struct dp_config *dp_config;
 	struct cp_config *cp_config;
 	pid_t pid;
+	uint64_t memory_limit;
 	struct agent *prev;
 	char name[80];
 };


### PR DESCRIPTION
The commit adds routines to fetch and decode information about agents connected to `YANET` shared memory. At the point one may list all connected agents with history and fetch information about `pid` and memory consumption of each connection instance in form like
```
Agent bootstrap
  Pid 12579 Limit 4194304 Allocated 336 Freed 0
  Pid 12572 Limit 4194304 Allocated 336 Freed 0
  Pid 12565 Limit 4194304 Allocated 336 Freed 0
  Pid 12559 Limit 4194304 Allocated 336 Freed 0
  Pid 5479 Limit 4194304 Allocated 336 Freed 0
```