### PR TITLE
refactor: use MAC address type instead of strings in protobuf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ memory-bank
 
 # generated files
 *.pb.go
+
+# Ignore Cargo.lock for libraries.
+common/**/Cargo.lock

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -699,6 +699,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
+name = "netip"
+version = "0.1.0"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1586,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "log",
+ "netip",
  "prost",
  "prost-types",
  "tabled",

--- a/cli/modules/neighbour/Cargo.toml
+++ b/cli/modules/neighbour/Cargo.toml
@@ -16,6 +16,7 @@ prost = "0.13"
 prost-types = "0.13"
 tonic = { version = "0.12" }
 tabled = { version = "0.18" }
+netip = { version = "0.1", path = "../../../common/rust/netip" }
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/cli/modules/neighbour/src/lib.rs
+++ b/cli/modules/neighbour/src/lib.rs
@@ -4,6 +4,7 @@ use core::{
 };
 use std::time::SystemTime;
 
+use netip::MacAddr;
 use tabled::Tabled;
 
 // Newtype wrapper around NeighbourState for better display
@@ -55,11 +56,12 @@ pub struct NeighbourEntry {
     pub next_hop: IpAddr,
     /// MAC address of the next-hop device.
     #[tabled(rename = "NEIGHBOUR MAC")]
-    pub link_addr: String,
+    pub link_addr: MacAddr,
     /// MAC address of the local interface that connects to this neighbor.
     #[tabled(rename = "INTERFACE MAC")]
-    pub hardware_addr: String,
-    /// Current state of the neighbor relationship (e.g., REACHABLE, STALE, PROBE).
+    pub hardware_addr: MacAddr,
+    /// Current state of the neighbor relationship (e.g., REACHABLE, STALE,
+    /// PROBE).
     #[tabled(rename = "STATE")]
     pub state: State,
     /// Time elapsed since this neighbor entry was last updated.

--- a/cli/modules/neighbour/src/main.rs
+++ b/cli/modules/neighbour/src/main.rs
@@ -6,6 +6,7 @@ use std::time::UNIX_EPOCH;
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use code::{neighbour_client::NeighbourClient, ListNeighboursRequest};
+use netip::MacAddr;
 use tabled::{
     settings::{
         object::Columns,
@@ -97,10 +98,19 @@ impl NeighbourService {
                 let updated_at = UNIX_EPOCH + Duration::from_secs(entry.updated_at as u64);
                 let next_hop = entry.next_hop.parse().unwrap();
 
+                let link_addr = {
+                    let addr = entry.link_addr.map(|v| v.addr).unwrap_or_default();
+                    MacAddr::from(addr)
+                };
+                let hardware_addr = {
+                    let addr = entry.hardware_addr.map(|v| v.addr).unwrap_or_default();
+                    MacAddr::from(addr)
+                };
+
                 NeighbourEntry {
                     next_hop,
-                    link_addr: entry.link_addr,
-                    hardware_addr: entry.hardware_addr,
+                    link_addr,
+                    hardware_addr,
                     state: State(entry.state),
                     age: Age(updated_at),
                 }

--- a/common/rust/netip/.rustfmt.toml
+++ b/common/rust/netip/.rustfmt.toml
@@ -1,0 +1,7 @@
+max_width = 120
+reorder_imports = true
+imports_granularity = "Crate"
+group_imports = "StdExternalCrate"
+struct_lit_width = 36
+wrap_comments = true
+format_code_in_doc_comments = true

--- a/common/rust/netip/Cargo.toml
+++ b/common/rust/netip/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "netip"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]

--- a/common/rust/netip/src/lib.rs
+++ b/common/rust/netip/src/lib.rs
@@ -1,0 +1,39 @@
+use core::fmt::{self, Display, Formatter};
+
+/// A MAC address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Default, Hash)]
+pub struct MacAddr(u64);
+
+impl MacAddr {
+    /// Creates a new MAC address from its 6 octets in transmission order.
+    ///
+    /// Each parameter represents one byte of the MAC address in the standard
+    /// format `xx:xx:xx:xx:xx:xx`.
+    #[inline]
+    pub const fn new(a: u8, b: u8, c: u8, d: u8, e: u8, f: u8) -> MacAddr {
+        Self(u64::from_be_bytes([a, b, c, d, e, f, 0, 0]))
+    }
+
+    /// Returns the MAC address as a u64 value.    
+    #[inline]
+    pub const fn as_u64(&self) -> u64 {
+        match self {
+            Self(addr) => *addr,
+        }
+    }
+}
+
+impl From<u64> for MacAddr {
+    #[inline]
+    fn from(addr: u64) -> MacAddr {
+        MacAddr(addr)
+    }
+}
+
+impl Display for MacAddr {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
+        let [a, b, c, d, e, f, ..] = self.as_u64().to_be_bytes();
+
+        write!(fmt, "{a:02x}:{b:02x}:{c:02x}:{d:02x}:{e:02x}:{f:02x}")
+    }
+}

--- a/controlplane/Makefile
+++ b/controlplane/Makefile
@@ -15,7 +15,7 @@ MAIN_GO := cmd/yncp-director/main.go
 
 # Proto file dependencies
 YNPB_PROTO_FILES := $(YNPB_DIR)/gateway.proto $(YNPB_DIR)/logging.proto
-ROUTE_PROTO_FILES := $(ROUTE_PB_DIR)/route.proto $(ROUTE_PB_DIR)/neighbour.proto
+ROUTE_PROTO_FILES := $(ROUTE_PB_DIR)/route.proto $(ROUTE_PB_DIR)/neighbour.proto $(ROUTE_PB_DIR)/macaddr.proto
 
 # Protoc options
 PROTOC_GO_OPT := --go_opt=paths=source_relative
@@ -30,7 +30,7 @@ $(YNPB_DIR): $(YNPB_PROTO_FILES)
 $(ROUTE_PB_DIR): $(ROUTE_PROTO_FILES)
 	@echo "+ $@"
 	@if ! which $(PROTOC) > /dev/null; then echo "protoc protobuf compiler required for build"; exit 1; fi;
-	@$(PROTOC) -I ./$(ROUTE_PB_DIR) --go_out=./$@ $(PROTOC_GO_OPT) --go-grpc_out=./$@ $(PROTOC_GRPC_OPT) $^
+	@$(PROTOC) -I ./$(ROUTE_PB_DIR) --go_out=./$@ $(PROTOC_GO_OPT) --go-grpc_out=./$@ $(PROTOC_GRPC_OPT) $(ROUTE_PROTO_FILES)
 
 build: ynpb $(ROUTE_PB_DIR)
 	$(GO) build -o $(OUTPUT_BIN) $(MAIN_GO)

--- a/controlplane/modules/route/neighbour_service.go
+++ b/controlplane/modules/route/neighbour_service.go
@@ -2,7 +2,6 @@ package route
 
 import (
 	"context"
-	"net"
 
 	"go.uber.org/zap"
 
@@ -38,8 +37,8 @@ func (m *NeighbourService) List(ctx context.Context, req *routepb.ListNeighbours
 	for _, entry := range entries {
 		protoEntry := &routepb.NeighbourEntry{
 			NextHop:      entry.NextHop.String(),
-			LinkAddr:     net.HardwareAddr(entry.HardwareRoute.DestinationMAC[:]).String(),
-			HardwareAddr: net.HardwareAddr(entry.HardwareRoute.SourceMAC[:]).String(),
+			LinkAddr:     routepb.NewMACAddressEUI48(entry.HardwareRoute.DestinationMAC),
+			HardwareAddr: routepb.NewMACAddressEUI48(entry.HardwareRoute.SourceMAC),
 			State:        routepb.NeighbourState(entry.State),
 			UpdatedAt:    entry.UpdatedAt.Unix(),
 		}

--- a/controlplane/modules/route/routepb/macaddr.go
+++ b/controlplane/modules/route/routepb/macaddr.go
@@ -1,0 +1,15 @@
+package routepb
+
+import (
+	"encoding/binary"
+)
+
+// TODO: docs.
+func NewMACAddressEUI48(addr [6]byte) *MACAddress {
+	buf := [8]byte{}
+	copy(buf[:], addr[:])
+
+	return &MACAddress{
+		Addr: binary.BigEndian.Uint64(buf[:]),
+	}
+}

--- a/controlplane/modules/route/routepb/macaddr.proto
+++ b/controlplane/modules/route/routepb/macaddr.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package routepb;
+
+option go_package = "github.com/yanet-platform/yanet2/controlplane/modules/route/routepb;routepb";
+
+// MACAddress represents a hardware address.
+//
+// There are various MAC address formats, for example:
+// - EUI-48 (48-bit MAC addresses, most common).
+// - EUI-64 (64-bit extended unique identifier).
+message MACAddress {
+	reserved 1;
+	// Addr keeps MAC address bytes as a 64-bit unsigned integer in network
+	// byte order.
+	//
+	// For example, for the given MAC address "3a:ac:26:9b:5b:f9":
+	//  - As array: [0x3a, 0xac, 0x26, 0x9b, 0x5b, 0xf9, 0x00, 0x00].
+	//  - As uint64: 0x3aac269b5bf90000.
+	uint64 addr = 2;
+}

--- a/controlplane/modules/route/routepb/neighbour.proto
+++ b/controlplane/modules/route/routepb/neighbour.proto
@@ -4,6 +4,8 @@ package routepb;
 
 option go_package = "github.com/yanet-platform/yanet2/controlplane/modules/route/routepb;routepb";
 
+import "macaddr.proto";
+
 // Neighbour is a service for viewing and managing neighbors.
 service Neighbour {
 	// List returns all current neighbors.
@@ -40,10 +42,10 @@ message NeighbourEntry {
 	string next_hop = 1;
 
 	// LinkAddr is the MAC address of the next hop.
-	string link_addr = 2;
+	MACAddress link_addr = 2;
 
 	// HardwareAddr is the MAC address of the local interface.
-	string hardware_addr = 3;
+	MACAddress hardware_addr = 3;
 
 	// State is the state of the neighbor entry.
 	NeighbourState state = 4;

--- a/web/Cargo.lock
+++ b/web/Cargo.lock
@@ -1460,6 +1460,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "netip"
+version = "0.1.0"
+
+[[package]]
 name = "next_tuple"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,6 +3076,7 @@ dependencies = [
  "leptos-use",
  "leptos_router",
  "log",
+ "netip",
  "prost",
  "prost-build",
  "reqwest",

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["network", "traffic-generator"]
 publish = false
 
 [dependencies]
+netip = { version = "0.1", path = "../common/rust/netip" }
 leptos = { version = "0.7", features = ["csr"] }
 leptos_router = { version = "0.7" }
 web-sys = { version = "0.3.60", features = ["Storage"] }

--- a/web/src/components/demo.rs
+++ b/web/src/components/demo.rs
@@ -2,19 +2,16 @@ use std::{borrow::Cow, time::Duration};
 
 use leptos::prelude::*;
 
-use crate::{
-    api::neighbour::NeighbourClient,
-    components::common::{
-        button::Button,
-        dropdown::Dropdown,
-        header::Header,
-        input::Input,
-        popover::{Popover, PopoverTrigger},
-        popup::SpanPopup,
-        progress::ProgressBar,
-        snackbar::{SnackbarContext, SnackbarData},
-        viewport::{Viewport, ViewportContent},
-    },
+use crate::components::common::{
+    button::Button,
+    dropdown::Dropdown,
+    header::Header,
+    input::Input,
+    popover::{Popover, PopoverTrigger},
+    popup::SpanPopup,
+    progress::ProgressBar,
+    snackbar::{SnackbarContext, SnackbarData},
+    viewport::{Viewport, ViewportContent},
 };
 
 #[component]
@@ -32,37 +29,6 @@ pub fn DemoView() -> impl IntoView {
 
     let snackbar = expect_context::<SnackbarContext>();
 
-    // Create an action to fetch neighbours
-    let fetch_neighbours = Action::new_local(move |_| async move {
-        let client = NeighbourClient::new();
-
-        match client.list_neighbours().await {
-            Ok(neighbours) => {
-                log::info!("Retrieved {} neighbours", neighbours.len());
-
-                // Log each neighbour
-                for (i, neighbour) in neighbours.iter().enumerate() {
-                    log::info!(
-                        "Neighbour {}: IP={}, MAC={}, State={}",
-                        i + 1,
-                        neighbour.next_hop,
-                        neighbour.link_addr,
-                        neighbour.state
-                    );
-                }
-
-                snackbar.push(SnackbarData::error(format!(
-                    "Retrieved {} neighbours",
-                    neighbours.len()
-                )));
-            }
-            Err(err) => {
-                log::info!("Failed to retrieve neighbours: {}", err);
-                snackbar.push(SnackbarData::error(format!("Failed to retrieve neighbours: {}", err)));
-            }
-        }
-    });
-
     view! {
         <Viewport>
             <Header>
@@ -72,15 +38,6 @@ pub fn DemoView() -> impl IntoView {
                     on:click=move |_| snackbar.push(SnackbarData::error("Test popup"))
                 >
                     "Add popup"
-                </Button>
-
-                <Button
-                    primary=true
-                    on:click=move |_| {
-                        fetch_neighbours.dispatch(());
-                    }
-                >
-                    "Get Neighbours"
                 </Button>
             </Header>
 


### PR DESCRIPTION
This commit changes the way we pass MAC addresses in protobuf. Instead of strings we now pass them as a separate struct containing a single 64-bit field, which encodes a MAC address in big-endian.

This ensures that MAC addresses are correct, and no from-strings-parsing in CLI and web components is now required. Previously we had to check for errors while doing so.
Now we won't.