### PR TITLE
Free module data and agent allocated memory

### DIFF
--- a/agent/info/main.go
+++ b/agent/info/main.go
@@ -43,11 +43,12 @@ func main() {
 		for instanceIdx := C.uint64_t(0); instanceIdx < agent.instance_count; instanceIdx++ {
 			instance := (*C.struct_cp_agent_instance_info)(nil)
 			C.yanet_get_cp_agent_instance_info(agent, instanceIdx, &instance)
-			fmt.Printf("  Pid %v Limit %d Allocated %d Freed %d\n",
+			fmt.Printf("  Pid %v Limit %d Allocated %d Freed %d Gen %d\n",
 				instance.pid,
 				instance.memory_limit,
 				instance.allocated,
 				instance.freed,
+				instance.gen,
 			)
 		}
 	}

--- a/api/agent.h
+++ b/api/agent.h
@@ -154,6 +154,7 @@ yanet_get_dp_module_info(
 struct cp_module_info {
 	uint64_t index;
 	char config_name[80];
+	uint64_t gen;
 };
 
 struct cp_module_list_info {
@@ -210,6 +211,7 @@ struct cp_agent_instance_info {
 	uint64_t memory_limit;
 	uint64_t allocated;
 	uint64_t freed;
+	uint64_t gen;
 };
 
 struct cp_agent_info {

--- a/common/memory_address.h
+++ b/common/memory_address.h
@@ -5,6 +5,6 @@
 			   (uintptr_t)((*OFFSET) ? (OFFSET) : NULL)))
 #define SET_OFFSET_OF(PTR, ADDR)                                               \
 	do {                                                                   \
-		*PTR = ((typeof(ADDR))((uintptr_t)(ADDR) -                     \
-				       (uintptr_t)(ADDR ? PTR : NULL)));       \
+		*(PTR) = ((typeof(ADDR))((uintptr_t)(ADDR) -                   \
+					 (uintptr_t)(ADDR ? (PTR) : NULL)));   \
 	} while (0)

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -300,12 +300,16 @@ dataplane_init_storage(
 		(struct cp_config_gen *)memory_balloc(
 			&cp_config->memory_context, sizeof(struct cp_config_gen)
 		);
+
+	cp_config_gen->gen = 0;
+
 	SET_OFFSET_OF(&cp_config_gen->module_registry, cp_module_registry);
 	SET_OFFSET_OF(&cp_config_gen->pipeline_registry, cp_pipeline_registry);
 	SET_OFFSET_OF(&cp_config_gen->device_registry, device_registry);
 	SET_OFFSET_OF(&cp_config->cp_config_gen, cp_config_gen);
 
 	SET_OFFSET_OF(&dp_config->cp_config, cp_config);
+	SET_OFFSET_OF(&cp_config->dp_config, dp_config);
 
 	*res_dp_config = dp_config;
 	*res_cp_config = cp_config;

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -11,6 +11,8 @@
 struct dataplane;
 struct dataplane_numa_node;
 
+struct dp_worker;
+
 struct worker_read_ctx {
 
 	uint16_t read_size;
@@ -37,6 +39,7 @@ struct dataplane_worker {
 	struct dataplane *dataplane;
 	struct dataplane_numa_node *node;
 	struct dataplane_device *device;
+	struct dp_worker *dp_worker;
 
 	pthread_t thread_id;
 

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -9,6 +9,8 @@
 struct dp_config;
 struct cp_config;
 
+struct module_data;
+
 struct agent;
 
 struct agent {
@@ -18,9 +20,20 @@ struct agent {
 	struct cp_config *cp_config;
 	pid_t pid;
 	uint64_t memory_limit;
+	uint64_t gen;
+	uint64_t loaded_module_count;
+	uint64_t active_module_count;
 	struct agent *prev;
 	char name[80];
+
+	uint64_t arena_count;
+	void **arenas;
+
+	struct module_data *unused_module;
 };
+
+void
+agent_cleanup(struct agent *agent);
 
 struct module_data;
 

--- a/modules/forward/controlplane.h
+++ b/modules/forward/controlplane.h
@@ -10,6 +10,9 @@ forward_module_config_init(
 	struct agent *agent, const char *name, uint16_t device_count
 );
 
+void
+forward_module_config_free(struct module_data *module_data);
+
 int
 forward_module_config_enable_v4(
 	struct module_data *module_data,

--- a/modules/route/controlplane.h
+++ b/modules/route/controlplane.h
@@ -11,6 +11,9 @@ struct module_data;
 struct module_data *
 route_module_config_init(struct agent *agent, const char *name);
 
+void
+route_module_config_free(struct module_data *module_data);
+
 int
 route_module_config_add_route(
 	struct module_data *module_data,


### PR DESCRIPTION
After the commit agent waits for all `dataplane` workers catch the new configuration generation and then links all replaced module data into corresponding agent unused module list.

An alive agent checks unused module chain and then free containing module data after configuration change committed.

Also an agent checks if there are previous agent instances considered as `dead` and free all the memory allocated for them.