### PR TITLE
Another way to fix the bug found by fuzz.

### DIFF
--- a/modules/nat64/api/nat64cp.c
+++ b/modules/nat64/api/nat64cp.c
@@ -77,9 +77,6 @@ nat64_module_config_init_config(
 	config->prefixes.count = 0;
 	config->mtu.ipv6 = 1280; // Minimum IPv6 MTU
 	config->mtu.ipv4 = 1450; // Default IPv4 MTU
-	// As per Section 5.3: Protecting a Node from Excessive Extension
-	// Headers Options: https://www.rfc-editor.org/rfc/rfc8504.html
-	config->options_limit = 64;
 
 	LOG(DEBUG, "Initialized NAT64 module '%s'", name);
 	return &config->module_data;

--- a/modules/nat64/controlplane/nat64pb/nat64.proto
+++ b/modules/nat64/controlplane/nat64pb/nat64.proto
@@ -31,10 +31,6 @@ service NAT64Service {
 	rpc SetMTU(SetMTURequest) returns (SetMTUResponse) {
 	}
 
-	// SetOptionsLimit sets options limit value for IPv6
-	rpc SetOptionsLimit(SetOptionsLimitRequest)
-		returns (SetOptionsLimitResponse) {
-	}
 }
 
 // TargetModule specifies the target module for configuration operations
@@ -75,7 +71,6 @@ message InstanceConfig {
 	repeated Prefix prefixes = 2;
 	repeated Mapping mappings = 3;
 	MTUConfig mtu = 4;
-	uint32 options_limit = 5;
 }
 
 // ShowConfigResponse contains the current configuration
@@ -130,10 +125,3 @@ message SetMTURequest {
 message SetMTUResponse {
 }
 
-// SetOptionsLimitRequest specifies OptionsLimit values to set
-message SetOptionsLimitRequest {
-	TargetModule target = 1;
-	uint32 options_limit = 2;
-}
-message SetOptionsLimitResponse {
-}

--- a/modules/nat64/controlplane/nat64pb/nat64.proto
+++ b/modules/nat64/controlplane/nat64pb/nat64.proto
@@ -30,7 +30,6 @@ service NAT64Service {
 	// SetMTU sets MTU values for IPv4/IPv6
 	rpc SetMTU(SetMTURequest) returns (SetMTUResponse) {
 	}
-
 }
 
 // TargetModule specifies the target module for configuration operations
@@ -124,4 +123,3 @@ message SetMTURequest {
 
 message SetMTUResponse {
 }
-

--- a/modules/nat64/dataplane/config.h
+++ b/modules/nat64/dataplane/config.h
@@ -73,12 +73,4 @@ struct nat64_module_config {
 		uint16_t ipv4; /**< IPv4 MTU limit */
 		uint16_t ipv6; /**< IPv6 MTU limit */
 	} mtu;
-	/**
-	 * @brief Limit on the number of IPv6 header options to process.
-	 *
-	 * This defines the maximum number of IPv6 options that can be
-	 * processed, following the guidance provided in the draft:
-	 * https://datatracker.ietf.org/doc/draft-ietf-6man-eh-limits/
-	 */
-	uint32_t options_limit;
 };


### PR DESCRIPTION
# NAT64: Improve IPv6 extension headers processing

This PR implements a more robust approach to handling IPv6 extension headers in NAT64 module, fixing issues found by fuzzing.

## Changes

- Remove `options_limit` configuration option in favor of strict RFC 8200 compliance
- Add proper validation of IPv6 extension headers:
  - Enforce Hop-by-Hop Options header to be first if present (RFC 8200 Section 4.1)
  - Limit maximum number of extension headers to 8
  - Prevent duplicate headers (except Destination Options which can appear twice)
  - Add bounds checking for extension header processing
  - Track seen headers using bitmap for efficient validation
- Clean up related code in control plane and CLI

## Testing

The changes have been verified by fuzzing tests that previously detected the issue.

## References

- RFC 8200 Section 4: IPv6 Extension Headers
- RFC 7915: Translation between IPv4 and IPv6