### PR TITLE
fix: properly assign pipelines in coordinator

### DIFF
--- a/coordinator/etc/yanet/yanet-coordinator.yaml
+++ b/coordinator/etc/yanet/yanet-coordinator.yaml
@@ -20,8 +20,21 @@ stages:
           forward:
             config_name: "forward-bootstrap0"
             config_path: "modules/forward/etc/yanet/forward-bootstrap.yaml"
-        pipeline:
-          name: bootstrap
-          chain:
-            - module_name: "forward"
-              config_name: "forward-bootstrap0"
+        pipelines:
+          - name: bootstrap
+            chain:
+              - module_name: "forward"
+                config_name: "forward-bootstrap0"
+          - name: decap
+            chain:
+              - module_name: "forward"
+                config_name: "forward-bootstrap0"
+        devices:
+          - id: 0
+            pipelines:
+              - name: decap
+                weight: 1
+          - id: 1
+            pipelines:
+              - name: bootstrap
+                weight: 1

--- a/coordinator/internal/stage/cfg.go
+++ b/coordinator/internal/stage/cfg.go
@@ -19,8 +19,10 @@ type Config struct {
 type NUMAConfig struct {
 	// Modules configuration for this NUMA node.
 	Modules map[string]ModuleConfig `yaml:"modules,omitempty"`
-	// Pipeline configuration for this NUMA node.
-	Pipeline *PipelineConfig `yaml:"pipeline,omitempty"`
+	// Pipelines configuration for this NUMA node.
+	Pipelines []PipelineConfig `yaml:"pipelines,omitempty"`
+	// Devices configuration for this NUMA node.
+	Devices []DeviceConfig `yaml:"devices,omitempty"`
 }
 
 // ModuleConfig contains configuration for a specific module.
@@ -45,4 +47,20 @@ type NodeConfig struct {
 	ModuleName string `yaml:"module_name"`
 	// ConfigName is the configuration name for this module.
 	ConfigName string `yaml:"config_name"`
+}
+
+// DeviceConfig represents a device configuration.
+type DeviceConfig struct {
+	// ID is the ID of the device.
+	ID uint32 `yaml:"id"`
+	// Pipelines is the list of pipelines to assign to the device.
+	Pipelines []DevicePipelineConfig `yaml:"pipelines"`
+}
+
+// DevicePipelineConfig represents a pipeline configuration for a device.
+type DevicePipelineConfig struct {
+	// Name is the name of the pipeline.
+	Name string `yaml:"name"`
+	// Weight is the weight of the pipeline.
+	Weight uint64 `yaml:"weight"`
 }


### PR DESCRIPTION
This PR fixes the pipeline assignment logic in the coordinator by updating the configuration to handle multiple pipelines per NUMA node and assigning them to devices.

- Updated the stage setup to iterate over multiple pipelines instead of a single pipeline.
- Introduced a new function to assign pipelines to devices.
- Modified configuration files and YAML examples to reflect multiple pipelines and device assignments.
