### PR TITLE
fix: add missing fields for static routes

### DIFF
--- a/modules/route/controlplane/internal/rib/rib.go
+++ b/modules/route/controlplane/internal/rib/rib.go
@@ -41,8 +41,10 @@ func (m *RIB) AddUnicastRoute(prefix netip.Prefix, nexthopAddr netip.Addr) error
 	m.log.Debugf("adding unicast route %q via %q", prefix, nexthopAddr)
 
 	route := Route{
-		Prefix:  prefix,
-		NextHop: nexthopAddr,
+		Prefix:    prefix,
+		NextHop:   nexthopAddr,
+		SourceID:  RouteSourceStatic,
+		UpdatedAt: time.Now(),
 	}
 
 	m.mu.Lock()


### PR DESCRIPTION
This PR fixes a missing functionality by adding the required fields to static routes in the RIB. The key changes include:

- Setting the SourceID to RouteSourceStatic on insert unicast static
  route.
- Initializing the UpdatedAt field with the current time.