### PR TITLE
fix: correct age for neighbour entries

### DIFF
--- a/modules/route/controlplane/internal/discovery/cache.go
+++ b/modules/route/controlplane/internal/discovery/cache.go
@@ -1,6 +1,8 @@
 package discovery
 
 import (
+	"iter"
+	"maps"
 	"sync"
 )
 
@@ -50,17 +52,11 @@ type CacheView[K comparable, V any] struct {
 
 // Lookup returns the value for the specified key.
 func (m *CacheView[K, V]) Lookup(key K) (V, bool) {
-	link, ok := m.cache[key]
-	return link, ok
+	v, ok := m.cache[key]
+	return v, ok
 }
 
-// Entries returns all entries in the cache as a map.
-func (m *CacheView[K, V]) Entries() map[K]V {
-	// Return a copy of the cache map to avoid modifying the original
-	entries := make(map[K]V, len(m.cache))
-	for k, v := range m.cache {
-		entries[k] = v
-	}
-
-	return entries
+// Entries returns entries in the cache as an iterator.
+func (m *CacheView[K, V]) Entries() (iter.Seq[V], int) {
+	return maps.Values(m.cache), len(m.cache)
 }

--- a/modules/route/controlplane/neighbour_service.go
+++ b/modules/route/controlplane/neighbour_service.go
@@ -29,12 +29,12 @@ func NewNeighbourService(neighCache *neigh.NexthopCache, log *zap.SugaredLogger)
 func (m *NeighbourService) List(ctx context.Context, req *routepb.ListNeighboursRequest) (*routepb.ListNeighboursResponse, error) {
 	// Get a view of the current neighbor cache
 	view := m.neighCache.View()
-	entries := view.Entries()
+	entries, size := view.Entries()
 
 	// Convert all entries to proto format
-	protoEntries := make([]*routepb.NeighbourEntry, 0, len(entries))
+	protoEntries := make([]*routepb.NeighbourEntry, 0, size)
 
-	for _, entry := range entries {
+	for entry := range entries {
 		protoEntry := &routepb.NeighbourEntry{
 			NextHop:      entry.NextHop.String(),
 			LinkAddr:     routepb.NewMACAddressEUI48(entry.HardwareRoute.DestinationMAC),


### PR DESCRIPTION
This PR aims to fix the age correction for neighbour entries by adjusting how neighbour entries are retrieved and updated within the controlplane modules.

- Updated retrieval of neighbour entries from the cache using an iterator and a size for capacity allocation.
- Updated neighbour monitor to compare and assign the UpdatedAt field from the cache view.
- Refactored the cache view to return an iterator along with the size to avoid making a full copy.