### PR TITLE
fix: nat64 CLI compilation

### DIFF
--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -3,12 +3,11 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 
 use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::CompleteEnv;
-use ipnet::Ipv6Net;
-
 use code::{
     nat64_service_client::Nat64ServiceClient, AddMappingRequest, AddPrefixRequest, SetDropUnknownRequest,
     SetMtuRequest, ShowConfigRequest, ShowConfigResponse, TargetModule,
 };
+use ipnet::Ipv6Net;
 use ptree::TreeBuilder;
 use tonic::transport::Channel;
 use yanet_cli::logging;
@@ -231,37 +230,39 @@ impl NAT64Service {
         let response = self.client.set_mtu(request).await?.into_inner();
         log::debug!("SetMtuResponse: {:?}", response);
         Ok(())
-        pub async fn set_drop_unknown(&mut self, cmd: DropCmd) -> Result<(), Box<dyn Error>> {
-            let request = SetDropUnknownRequest {
-                target: Some(TargetModule {
-                    module_name: cmd.module_name,
-                    numa: cmd.numa.unwrap_or_default(),
-                }),
-                drop_unknown_prefix: cmd.drop_unknown_prefix,
-                drop_unknown_mapping: cmd.drop_unknown_mapping,
-            };
-            log::debug!("SetDropUnknownRequest: {:?}", request);
-            let response = self.client.set_drop_unknown(request).await?.into_inner();
-            log::debug!("SetDropUnknownResponse: {:?}", response);
-            Ok(())
-        }
     }
-    
-    /// Command for setting drop_unknown flags
-    #[derive(Debug, Clone, Parser)]
-    pub struct DropCmd {
-        /// NAT64 module name to operate on.
-        #[arg(long = "mod")]
-        pub module_name: String,
-        /// NUMA node index where the changes should be applied.
-        #[arg(long)]
-        pub numa: Option<Vec<u32>>,
-        /// Drop packets with unknown prefix
-        #[arg(long)]
-        pub drop_unknown_prefix: bool,
-        /// Drop packets with unknown mapping
-        #[arg(long)]
-        pub drop_unknown_mapping: bool,
+
+    pub async fn set_drop_unknown(&mut self, cmd: DropCmd) -> Result<(), Box<dyn Error>> {
+        let request = SetDropUnknownRequest {
+            target: Some(TargetModule {
+                module_name: cmd.module_name,
+                numa: cmd.numa.unwrap_or_default(),
+            }),
+            drop_unknown_prefix: cmd.drop_unknown_prefix,
+            drop_unknown_mapping: cmd.drop_unknown_mapping,
+        };
+        log::debug!("SetDropUnknownRequest: {:?}", request);
+        let response = self.client.set_drop_unknown(request).await?.into_inner();
+        log::debug!("SetDropUnknownResponse: {:?}", response);
+        Ok(())
+    }
+}
+
+/// Command for setting drop_unknown flags
+#[derive(Debug, Clone, Parser)]
+pub struct DropCmd {
+    /// NAT64 module name to operate on.
+    #[arg(long = "mod")]
+    pub module_name: String,
+    /// NUMA node index where the changes should be applied.
+    #[arg(long)]
+    pub numa: Option<Vec<u32>>,
+    /// Drop packets with unknown prefix
+    #[arg(long)]
+    pub drop_unknown_prefix: bool,
+    /// Drop packets with unknown mapping
+    #[arg(long)]
+    pub drop_unknown_mapping: bool,
 }
 
 pub fn print_json(resp: &ShowConfigResponse) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
This PR fixes a compilation issue in the NAT64 CLI by adjusting imports and function closures.

- Moves the import of ipnet::Ipv6Net to a new position
- Adds a closing brace in the set_mtu function to properly terminate its block
