### PR TITLE
refactor: iterable bitset, change output type to uint32

### DIFF
--- a/common/go/bitset/bitset_test.go
+++ b/common/go/bitset/bitset_test.go
@@ -1,6 +1,7 @@
 package bitset
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,24 +21,67 @@ func Test_TinyBitsetTraverse(t *testing.T) {
 	b := TinyBitset{}
 	b.Insert(0)
 	b.Insert(42)
+	b.Insert(512)
 
-	bits := make([]int, 0)
-	b.Traverse(func(idx int) {
+	bits := make([]uint32, 0)
+	b.Traverse(func(idx uint32) bool {
 		bits = append(bits, idx)
+		return true
 	})
 
-	assert.Equal(t, []int{0, 42}, bits)
+	assert.Equal(t, []uint32{0, 42, 512}, bits)
+}
+
+func Test_TinyBitsetPartialTraverse(t *testing.T) {
+	b := TinyBitset{}
+	b.Insert(42)
+	b.Insert(84)
+	b.Insert(512)
+
+	bits := make([]uint32, 0)
+	b.Traverse(func(idx uint32) bool {
+		bits = append(bits, idx)
+		return false
+	})
+
+	assert.Equal(t, []uint32{42}, bits)
 }
 
 func Test_TinyBitsetTraverseEmpty(t *testing.T) {
 	b := TinyBitset{}
 
-	bits := make([]int, 0)
-	b.Traverse(func(idx int) {
+	bits := make([]uint32, 0)
+	b.Traverse(func(idx uint32) bool {
 		bits = append(bits, idx)
+		return true
 	})
 
-	assert.Equal(t, []int{}, bits)
+	assert.Equal(t, []uint32{}, bits)
+}
+
+func Test_TinyBitsetIter(t *testing.T) {
+	b := TinyBitset{}
+	b.Insert(0)
+	b.Insert(42)
+	b.Insert(512)
+
+	bits := slices.Collect(b.Iter())
+
+	assert.Equal(t, []uint32{0, 42, 512}, bits)
+}
+
+func Test_TinyBitsetPartialIter(t *testing.T) {
+	b := TinyBitset{}
+	b.Insert(42)
+	b.Insert(512)
+
+	bits := make([]uint32, 0)
+	for bit := range b.Iter() {
+		bits = append(bits, bit)
+		break
+	}
+
+	assert.Equal(t, []uint32{42}, bits)
 }
 
 func Test_TinyBitsetAsSlice(t *testing.T) {
@@ -45,7 +89,7 @@ func Test_TinyBitsetAsSlice(t *testing.T) {
 	b.Insert(0)
 	b.Insert(42)
 
-	assert.Equal(t, []int{0, 42}, b.AsSlice())
+	assert.Equal(t, []uint32{0, 42}, b.AsSlice())
 }
 
 func Test_TinyBitsetPanicsOnLargeIndex(t *testing.T) {

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -93,8 +93,9 @@ func (m *SharedMemory) NumaMap() uint32 {
 // NumaIndices returns a list of indices available NUMA nodes.
 func (m *SharedMemory) NumaIndices() []uint32 {
 	numaIndices := make([]uint32, 0)
-	bitset.NewBitsTraverser(uint64(m.NumaMap())).Traverse(func(numaIdx int) {
-		numaIndices = append(numaIndices, uint32(numaIdx))
+	bitset.NewBitsTraverser(uint64(m.NumaMap())).Traverse(func(numaIdx uint32) bool {
+		numaIndices = append(numaIndices, numaIdx)
+		return true
 	})
 	return numaIndices
 }

--- a/controlplane/internal/gateway/inspect_service.go
+++ b/controlplane/internal/gateway/inspect_service.go
@@ -30,8 +30,7 @@ func (m *InspectService) Inspect(
 		NumaBitmap: numaBitmap,
 	}
 
-	bitset.NewBitsTraverser(uint64(numaBitmap)).Traverse(func(idx int) {
-		numaIdx := uint32(idx)
+	bitset.NewBitsTraverser(uint64(numaBitmap)).Traverse(func(numaIdx uint32) bool {
 		dpConfig := m.shm.DPConfig(numaIdx)
 
 		numaInfo := &ynpb.NUMAInfo{
@@ -44,6 +43,7 @@ func (m *InspectService) Inspect(
 		}
 
 		response.NumaInfo = append(response.NumaInfo, numaInfo)
+		return true
 	})
 
 	return response, nil

--- a/modules/route/controlplane/ffi.go
+++ b/modules/route/controlplane/ffi.go
@@ -69,7 +69,7 @@ func (m *ModuleConfig) RouteAdd(srcAddr net.HardwareAddr, dstAddr net.HardwareAd
 	return int(idx), nil
 }
 
-func (m *ModuleConfig) RouteListAdd(routeIndices []int) (int, error) {
+func (m *ModuleConfig) RouteListAdd(routeIndices []uint32) (int, error) {
 	cRouteIndices := make([]C.uint32_t, len(routeIndices))
 	for idx, v := range routeIndices {
 		cRouteIndices[idx] = C.uint32_t(v)


### PR DESCRIPTION
This PR refactors the iterable bitset implementation by changing the output type from int to uint32, ensuring consistent type usage across API functions and tests.

- Update RouteListAdd to accept []uint32 in the FFI interface.
- Modify Traverse callbacks and iteration methods to use uint32 with a bool return value for early termination support.
- Update tests to reflect these type changes in bitset behavior.
