### PR TITLE
refactor: consolidate pdump configuration into unified SetConfig API

### DIFF
--- a/modules/pdump/cli/src/args.rs
+++ b/modules/pdump/cli/src/args.rs
@@ -3,10 +3,7 @@ use clap::{Parser, ValueEnum};
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
     Show(ShowConfigCmd),
-    SetFilter(SetFilterCmd),
-    SetDumpMode(SetDumpModeCmd),
-    SetSnapLen(SetSnapLenCmd),
-    SetRingSize(SetRingSizeCmd),
+    Set(SetConfigCmd),
     Read(ReadCmd),
 }
 
@@ -16,7 +13,7 @@ pub struct ShowConfigCmd {
     #[arg(long = "cfg", short)]
     pub config_name: Option<String>,
     /// Indices of dataplane instances where changes should be applied, optionally repeated.
-    #[arg(long, required = false)]
+    #[arg(long, short, required = false)]
     pub instances: Vec<u32>,
     /// Output format.
     #[clap(long, value_enum, default_value_t = ConfigOutputFormat::Tree)]
@@ -24,44 +21,29 @@ pub struct ShowConfigCmd {
 }
 
 #[derive(Debug, Clone, Parser)]
-pub struct SetFilterCmd {
+pub struct SetConfigCmd {
     /// Pdump config name to operate on.
     #[arg(long = "cfg", short)]
     pub config_name: String,
     /// Indices of dataplane instances where changes should be applied, optionally repeated.
-    #[arg(long, required = true)]
+    #[arg(long, short, required = true)]
     pub instances: Vec<u32>,
 
-    #[arg(long = "filter", short)]
-    pub filter: String,
-}
-
-#[derive(Debug, Clone, Parser)]
-pub struct SetDumpModeCmd {
-    /// Pdump config name to operate on.
-    #[arg(long = "cfg", short)]
-    pub config_name: String,
-    /// Indices of dataplane instances where changes should be applied, optionally repeated.
-    #[arg(long, required = true)]
-    pub instances: Vec<u32>,
+    /// Filter represents a pcap-style filter expression
+    #[arg(long, short)]
+    pub filter: Option<String>,
 
     /// Determine the packet list to capture packets from.
     #[command(flatten)]
-    pub mode: crate::dump_mode::Mode,
-}
+    pub mode: Option<crate::dump_mode::Mode>,
 
-#[derive(Debug, Clone, Parser)]
-pub struct SetSnapLenCmd {
-    /// Pdump config name to operate on.
-    #[arg(long = "cfg", short)]
-    pub config_name: String,
-    /// Indices of dataplane instances where changes should be applied, optionally repeated.
-    #[arg(long, required = true)]
-    pub instances: Vec<u32>,
-
-    // SnapLen is the maximum packet length to capture.
+    /// Snaplen is the maximum packet length to capture.
     #[arg(long = "snaplen", short = 's')]
-    pub snaplen: u32,
+    pub snaplen: Option<u32>,
+
+    /// Per-worker ring buffer size
+    #[arg(long = "ring-size", value_parser=ring_buffer_size_range)]
+    pub ring_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -70,7 +52,7 @@ pub struct ReadCmd {
     #[arg(long = "cfg", short)]
     pub config_name: String,
     /// Indices of dataplane instances where the data should be read.
-    #[arg(long, required = true)]
+    #[arg(long, short, required = true)]
     pub instances: Vec<u32>,
 
     /// Dump output format.
@@ -101,20 +83,6 @@ fn ring_buffer_size_range(s: &str) -> Result<u64, String> {
         }
         Ok(val)
     }
-}
-
-#[derive(Debug, Clone, Parser)]
-pub struct SetRingSizeCmd {
-    /// Pdump config name to operate on.
-    #[arg(long = "cfg", short)]
-    pub config_name: String,
-    /// Indices of dataplane instances where changes should be applied, optionally repeated.
-    #[arg(long, required = true)]
-    pub instances: Vec<u32>,
-
-    /// Per-worker ring buffer size
-    #[arg(long = "size", short = 's', value_parser=ring_buffer_size_range)]
-    pub ring_size: u32,
 }
 
 /// Dump Output format options.

--- a/modules/pdump/controlplane/pdumppb/pdump.proto
+++ b/modules/pdump/controlplane/pdumppb/pdump.proto
@@ -15,20 +15,8 @@ service PdumpService {
 	// ShowConfig returns the current configuration for the pdump module.
 	rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse);
 
-	// SetFilter sets the packet filter.
-	rpc SetFilter(SetFilterRequest) returns (SetFilterResponse);
-
-	// SetDumpMode switches the pdump module to read packets from the
-	// drop packet list instead of the input packet list or from both lists.
-	rpc SetDumpMode(SetDumpModeRequest) returns (SetDumpModeResponse);
-
-	// SetSnapLen sets the maximum packet length to capture.
-	rpc SetSnapLen(SetSnapLenRequest) returns (SetSnapLenResponse);
-
-	// SetWorkerRingSize sets the size of the per-worker ring buffer where
-	// matched packets are written.
-	rpc SetWorkerRingSize(SetWorkerRingSizeRequest)
-		returns (SetWorkerRingSizeResponse);
+	// SetConfig sets a new config for the pdump module
+	rpc SetConfig(SetConfigRequest) returns (SetConfigResponse);
 
 	// ReadDump activates reading packet dumps from shared memory. Each
 	// packet is returned as an individual Record message containing
@@ -89,13 +77,14 @@ message ShowConfigRequest {
 
 // Config contains the pdump module configuration.
 message Config {
-	// pcap style filter
+	// Pcap style filter.
 	string filter = 1;
 	// Mode specifies a bitmap of queues that should be dumped.
+	// For now available queues are INPUT, OUTPUT, DROP, BYPASS.
 	uint32 mode = 2;
-	// snaplen specifies maximum packet length to capture
+	// Snaplen specifies maximum packet length to capture.
 	uint32 snaplen = 3;
-	// ring_size specifies per worker ring buffer size
+	// Ring_size specifies per worker ring buffer size.
 	uint32 ring_size = 4;
 }
 
@@ -106,35 +95,19 @@ message ShowConfigResponse {
 	Config config = 3;
 }
 
-// SetFilterRequest contains information about the target module and
-// the filter for the pdump module's configuration.
-message SetFilterRequest {
+// SetConfigRequest contains new configuration for the pdump module instance
+message SetConfigRequest {
 	commonpb.TargetModule target = 1;
-	string filter = 2;
-}
-message SetFilterResponse {
-}
-
-message SetDumpModeRequest {
-	commonpb.TargetModule target = 1;
-	uint32 mode = 2;
+	Config config = 2;
+	FieldMask update_mask = 3;
 }
 
-message SetDumpModeResponse {
+message SetConfigResponse {
 }
 
-message SetSnapLenRequest {
-	commonpb.TargetModule target = 1;
-	uint32 snaplen = 2;
-}
-
-message SetSnapLenResponse {
-}
-
-message SetWorkerRingSizeRequest {
-	commonpb.TargetModule target = 1;
-	uint32 ring_size = 2;
-}
-
-message SetWorkerRingSizeResponse {
+// Copy pasted from import "google/protobuf/field_mask.proto";
+// for integrity purposes.
+message FieldMask {
+	// The set of field mask paths.
+	repeated string paths = 1;
 }


### PR DESCRIPTION
## Overview

This pull request refactors the pdump module configuration system by consolidating multiple separate configuration handlers into a single, more powerful API using gRPC FieldMask for selective updates.

## Changes

### CLI Improvements
- **Unified command interface**: Merged 4 separate subcommands (`set-filter`, `set-dump-mode`, `set-snaplen`, `set-ring-size`) into a single `set` command
- **Optional parameters**: All configuration fields are now optional, allowing users to update only the fields they need
- **Improved UX**: Single command with clear optional flags instead of multiple specialized commands
- **Consistent argument naming**: Standardized short flags (`-i` for instances, `-c` for config name)

### gRPC Service Refactoring
- **API consolidation**: Replaced 4 separate RPCs with a single `SetConfig` RPC
- **FieldMask implementation**: Uses `google.protobuf.FieldMask` pattern for selective field updates
- **Atomic updates**: All configuration changes are applied atomically, preventing race conditions

### Protocol Buffer Changes
- **Simplified service definition**: Removed 4 separate RPCs (`SetFilter`, `SetDumpMode`, `SetSnapLen`, `SetWorkerRingSize`) 
- **Consolidated messages**: Eliminated 8 request/response message types, replaced with single `SetConfigRequest`/`SetConfigResponse`
- **Embedded FieldMask**: Included FieldMask definition directly to avoid build system complexity

## Example Usage

### Before
```bash
pdump set-filter --cfg myconfig --instances 0,1 --filter "tcp port 80"
pdump set-dump-mode --cfg myconfig --instances 0,1 --input --drop  
pdump set-snaplen --cfg myconfig --instances 0,1 --snaplen 1500
pdump set-ring-size --cfg myconfig --instances 0,1 --ring-size 1048576
```
### After
```bash
pdump set --cfg myconfig --instances 0,1 \
  --filter "tcp port 80" \
  --input --drop \
  --snaplen 1500 \
  --ring-size 1048576
```