### PR TITLE
refactor(forward): iterate through instances on the CLI side

### DIFF
--- a/docs/virtual-run.org
+++ b/docs/virtual-run.org
@@ -123,18 +123,18 @@ export DECAP_PREFIX=<prefix>
 *** configure. Save to file like =decap_cfg.sh=
 #+begin_src shell
 #!/bin/sh
-yanet-cli forward l2-enable --mod=forward0 --src 0 --dst 1
-yanet-cli forward l2-enable --mod=forward0 --src 1 --dst 0
-yanet-cli forward l3-add --mod=forward0 --src 0 --dst 1 --net $IP4/32
-yanet-cli forward l3-add --mod=forward0 --src 0 --dst 1 --net $IP6/128
-yanet-cli forward l3-add --mod=forward0 --src 0 --dst 1 --net ff02::/16
+yanet-cli forward l2-enable --cfg=forward0 --instance 0 --src 0 --dst 1
+yanet-cli forward l2-enable --cfg=forward0 --instance 0 --src 1 --dst 0
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 0 --dst 1 --net $IP4/32
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 0 --dst 1 --net $IP6/128
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 0 --dst 1 --net ff02::/16
 
-yanet-cli forward l3-add --mod=forward0 --src 1 --dst 0 --net 0.0.0.0/0
-yanet-cli forward l3-add --mod=forward0 --src 1 --dst 0 --net ::/0
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 1 --dst 0 --net 0.0.0.0/0
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 1 --dst 0 --net ::/0
 
-yanet-cli decap prefix-add -p $DECAP_PREFIX --mod decap0
+yanet-cli decap prefix-add --cfg decap0 --instance 0 -p $DECAP_PREFIX
 
-yanet-cli route insert --mod route0 --via $DEFGW6 ::/0
+yanet-cli route insert --cfg route0 --instance 0 --via $DEFGW6 ::/0
 
 yanet-cli pipeline update --name=bootstrap --modules forward:forward0 --instance=0
 yanet-cli pipeline update --name=decap --modules forward:forward0 --modules decap:decap0 --modules route:route0 --instance=0
@@ -143,8 +143,8 @@ yanet-cli pipeline assign --instance=0 --device=1 --pipelines bootstrap:1
 yanet-cli pipeline assign --instance=0 --device=0 --pipelines decap:1
 # tmp hack for resolve neighbors
 sleep 3
-yanet-cli route insert --mod route0 --via $DEFGW6 ::/0
-yanet-cli route insert --mod route0 --via $DEFGW4 0.0.0.0/0
+yanet-cli route insert --cfg route0 --instance 0 --via $DEFGW6 ::/0
+yanet-cli route insert --cfg route0 --instance 0 --via $DEFGW4 0.0.0.0/0
 #+end_src
 ** NAT64
 *** env
@@ -154,19 +154,19 @@ export NAT64_PREFIX=<prefix>
 *** configure. Save to file like =nat64_cfg.sh=. Don't forget to run =chmod +x= on it.
 #+begin_src shell
 #!/bin/sh
-yanet-cli forward l2-enable --mod=forward0 --src 0 --dst 1
-yanet-cli forward l2-enable --mod=forward0 --src 1 --dst 0
+yanet-cli forward l2-enable --cfg=forward0 --instance 0 --src 0 --dst 1
+yanet-cli forward l2-enable --cfg=forward0 --instance 0 --src 1 --dst 0
 
-yanet-cli forward l3-add --mod=forward0 --src 0 --dst 1 --net $IP4/32
-yanet-cli forward l3-add --mod=forward0 --src 0 --dst 1 --net $IP6/128
-yanet-cli forward l3-add --mod=forward0 --src 0 --dst 1 --net ff02::/16
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 0 --dst 1 --net $IP4/32
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 0 --dst 1 --net $IP6/128
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 0 --dst 1 --net ff02::/16
 
-yanet-cli forward l3-add --mod=forward0 --src 1 --dst 0 --net 0.0.0.0/0
-yanet-cli forward l3-add --mod=forward0 --src 1 --dst 0 --net ::/0
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 1 --dst 0 --net 0.0.0.0/0
+yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 1 --dst 0 --net ::/0
 
-yanet-cli route insert --mod route0 --via $DEFGW6 ::/0
+yanet-cli route insert --cfg route0 --via $DEFGW6 ::/0
 
-yanet-cli nat64 prefix add --prefix $NAT64_PREFIX --mod nat0
+yanet-cli nat64 prefix add --mod nat0 --prefix $NAT64_PREFIX
 yanet-cli nat64 mapping add --mod nat0 --ipv4 <ipv4> --ipv6 <ipv6> --prefix-index 0
 yanet-cli nat64 mtu --mod nat0 --ipv4-mtu 1450 --ipv6-mtu 6950
 
@@ -178,7 +178,7 @@ yanet-cli pipeline assign --instance=0 --device=0 --pipelines nat64:1
 
 # tmp hack for resolve neighbors
 sleep 3
-yanet-cli route insert --mod route0 --via $DEFGW6 ::/0
-yanet-cli route insert --mod route0 --via $DEFGW4 0.0.0.0/0
+yanet-cli route insert --cfg route0 --instance 0 --via $DEFGW6 ::/0
+yanet-cli route insert --cfg route0 --instance 0 --via $DEFGW4 0.0.0.0/0
 
 #+end_src

--- a/modules/forward/api/controlplane.c
+++ b/modules/forward/api/controlplane.c
@@ -260,7 +260,7 @@ forward_module_topology_device_count(struct agent *agent) {
 }
 
 int
-forward_module_delete(struct cp_module *cp_module) {
+forward_module_config_delete(struct cp_module *cp_module) {
 	return agent_delete_module(
 		cp_module->agent, "forward", cp_module->name
 	);

--- a/modules/forward/api/controlplane.h
+++ b/modules/forward/api/controlplane.h
@@ -42,7 +42,7 @@ forward_module_config_enable_l2(
 uint64_t
 forward_module_topology_device_count(struct agent *agent);
 
-// Allows to delete some module of forward.
+// Enables deletion of configurations for the forwarding module.
 // @return Returns -1 on error and 0 on success.
 int
-forward_module_delete(struct cp_module *cp_module);
+forward_module_config_delete(struct cp_module *cp_module);

--- a/modules/forward/cli/build.rs
+++ b/modules/forward/cli/build.rs
@@ -1,13 +1,17 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=../../../common/proto/target.proto");
     println!("cargo:rerun-if-changed=../controlplane/forwardpb/forward.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["forwardpb/forward.proto"], &["../controlplane"])?;
+        .compile_protos(
+            &["common/proto/target.proto", "forwardpb/forward.proto"],
+            &["../../..", "../controlplane"],
+        )?;
 
     Ok(())
 }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -79,6 +79,9 @@ pub struct DeleteCmd {
     /// The name of the module to delete
     #[arg(long = "cfg", short)]
     pub config_name: String,
+    /// Dataplane instances from which to delete config
+    #[arg(long, short, required = true)]
+    pub instances: Vec<u32>,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -174,14 +177,16 @@ impl ForwardService {
         Ok(())
     }
 
-    pub async fn delete_module(&mut self, cmd: DeleteCmd) -> Result<(), Box<dyn Error>> {
-        let request = DeleteConfigRequest {
-            target: Some(TargetModule {
-                config_name: cmd.config_name,
-                dataplane_instance: 0,
-            }),
-        };
-        self.client.delete_config(request).await?;
+    pub async fn delete_config(&mut self, cmd: DeleteCmd) -> Result<(), Box<dyn Error>> {
+        for instance in cmd.instances {
+            let request = DeleteConfigRequest {
+                target: Some(TargetModule {
+                    config_name: cmd.config_name.clone(),
+                    dataplane_instance: instance,
+                }),
+            };
+            self.client.delete_config(request).await?;
+        }
         Ok(())
     }
 
@@ -266,7 +271,7 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
 
     match cmd.mode {
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::Delete(cmd) => service.delete_module(cmd).await,
+        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
         ModeCmd::L2Enable(cmd) => service.enable_l2_forward(cmd).await,
         ModeCmd::L3Add(cmd) => service.add_l3_forward(cmd).await,
         ModeCmd::L3Remove(cmd) => service.remove_l3_forward(cmd).await,

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -3,19 +3,29 @@ use core::error::Error;
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::CompleteEnv;
 use code::{
-    AddL3ForwardRequest, DeleteModuleRequest, L2ForwardEnableRequest, L3ForwardEntry, RemoveL3ForwardRequest,
-    ShowConfigRequest, ShowConfigResponse, TargetModule, forward_service_client::ForwardServiceClient,
+    AddL3ForwardRequest, DeleteConfigRequest, L2ForwardEnableRequest, L3ForwardEntry, RemoveL3ForwardRequest,
+    ShowConfigRequest, ShowConfigResponse, forward_service_client::ForwardServiceClient,
 };
+use commonpb::TargetModule;
 use ipnet::IpNet;
 use ptree::TreeBuilder;
 use tonic::transport::Channel;
-use ync::{instance::InstanceMap, logging};
+use ync::logging;
+
+use crate::code::ListConfigsRequest;
 
 #[allow(non_snake_case)]
 pub mod code {
     use serde::Serialize;
 
     tonic::include_proto!("forwardpb");
+}
+
+#[allow(non_snake_case)]
+pub mod commonpb {
+    use serde::Serialize;
+
+    tonic::include_proto!("commonpb");
 }
 
 /// Forward module.
@@ -54,8 +64,11 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// The name of the module to operate on.
-    #[arg(long = "mod", short)]
-    pub module_name: String,
+    #[arg(long = "cfg", short)]
+    pub config_name: Option<String>,
+    /// Indices of dataplane instances from which configurations should be retrieved.
+    #[arg(long, short, required = false)]
+    pub instances: Vec<u32>,
     /// Output format.
     #[clap(long, value_enum, default_value_t = OutputFormat::Tree)]
     pub format: OutputFormat,
@@ -64,20 +77,18 @@ pub struct ShowConfigCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// The name of the module to delete
-    #[arg(long = "mod", short)]
-    pub module_name: String,
+    #[arg(long = "cfg", short)]
+    pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct L2ForwardCmd {
     /// The name of the module to operate on.
-    #[arg(long = "mod", short)]
-    pub module_name: String,
-    /// Dataplane instances where the changes should be applied, optional.
-    ///
-    /// If no instances specified, the route will be applied to all instances nodes.
-    #[arg(long)]
-    pub instances: Option<Vec<u32>>,
+    #[arg(long = "cfg", short)]
+    pub config_name: String,
+    /// Dataplane instances where the changes should be applied.
+    #[arg(long, short, required = true)]
+    pub instances: Vec<u32>,
     /// Source device ID.
     #[arg(required = true, long = "src", value_name = "src-dev-id")]
     pub src: u16,
@@ -89,13 +100,11 @@ pub struct L2ForwardCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct AddL3ForwardCmd {
     /// The name of the module to operate on.
-    #[arg(long = "mod", short)]
-    pub module_name: String,
-    /// Dataplane instances where the changes should be applied, optional.
-    ///
-    /// If no instances specified, the route will be applied to all instances nodes.
-    #[arg(long)]
-    pub instances: Option<Vec<u32>>,
+    #[arg(long = "cfg", short)]
+    pub config_name: String,
+    /// Dataplane instances where the changes should be applied.
+    #[arg(long, short, required = true)]
+    pub instances: Vec<u32>,
     /// Source device ID.
     #[arg(required = true, long = "src", value_name = "src-dev-id")]
     pub src: u16,
@@ -110,13 +119,11 @@ pub struct AddL3ForwardCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RemoveL3ForwardCmd {
     /// The name of the module to operate on.
-    #[arg(long = "mod", short)]
-    pub module_name: String,
-    /// Dataplane instances where the changes should be applied, optional.
-    ///
-    /// If no instances specified, the route will be applied to all instances nodes.
-    #[arg(long)]
-    pub instances: Option<Vec<u32>>,
+    #[arg(long = "cfg", short)]
+    pub config_name: String,
+    /// Dataplane instances where the changes should be applied.
+    #[arg(long, short, required = true)]
+    pub instances: Vec<u32>,
     /// Source device ID.
     #[arg(required = true, long = "src", value_name = "src-dev-id")]
     pub src: u16,
@@ -136,89 +143,120 @@ impl ForwardService {
     }
 
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Box<dyn Error>> {
-        let request = ShowConfigRequest {
-            target: Some(TargetModule {
-                module_name: cmd.module_name.to_owned(),
-                instances: InstanceMap::MAX.as_u32(),
-            }),
+        let Some(name) = cmd.config_name else {
+            self.print_config_list().await?;
+            return Ok(());
         };
-        let response = self.client.show_config(request).await?.into_inner();
+
+        let mut instances = cmd.instances;
+        if instances.is_empty() {
+            instances = self.get_dataplane_instances().await?;
+        }
+        let mut configs = Vec::new();
+        for instance in instances {
+            let request = ShowConfigRequest {
+                target: Some(TargetModule {
+                    config_name: name.to_owned(),
+                    dataplane_instance: instance,
+                }),
+            };
+            log::trace!("show config request on dataplane instance {instance}: {request:?}");
+            let response = self.client.show_config(request).await?.into_inner();
+            log::debug!("show config response on dataplane instance {instance}: {response:?}");
+            configs.push(response);
+        }
+
         match cmd.format {
-            OutputFormat::Json => print_json(&response)?,
-            OutputFormat::Tree => print_tree(&response)?,
+            OutputFormat::Json => print_json(configs)?,
+            OutputFormat::Tree => print_tree(configs)?,
         }
 
         Ok(())
     }
 
     pub async fn delete_module(&mut self, cmd: DeleteCmd) -> Result<(), Box<dyn Error>> {
-        let request = DeleteModuleRequest {
+        let request = DeleteConfigRequest {
             target: Some(TargetModule {
-                module_name: cmd.module_name,
-                instances: InstanceMap::MAX.as_u32(),
+                config_name: cmd.config_name,
+                dataplane_instance: 0,
             }),
         };
-        self.client.delete_module(request).await?;
+        self.client.delete_config(request).await?;
         Ok(())
     }
 
     pub async fn enable_l2_forward(&mut self, cmd: L2ForwardCmd) -> Result<(), Box<dyn Error>> {
-        let request = L2ForwardEnableRequest {
-            target: Some(TargetModule {
-                module_name: cmd.module_name,
-                instances: cmd
-                    .instances
-                    .map(InstanceMap::from)
-                    .unwrap_or(InstanceMap::MAX)
-                    .as_u32(),
-            }),
-            src_dev_id: cmd.src as u32,
-            dst_dev_id: cmd.dst as u32,
-        };
-        log::trace!("L2ForwardEnableRequest: {request:?}");
-        let response = self.client.enable_l2_forward(request).await?.into_inner();
-        log::debug!("L2ForwardEnableResponse: {response:?}");
+        for instance in cmd.instances {
+            let request = L2ForwardEnableRequest {
+                target: Some(TargetModule {
+                    config_name: cmd.config_name.clone(),
+                    dataplane_instance: instance,
+                }),
+                src_dev_id: cmd.src as u32,
+                dst_dev_id: cmd.dst as u32,
+            };
+            log::trace!("L2ForwardEnableRequest: {request:?}");
+            let response = self.client.enable_l2_forward(request).await?.into_inner();
+            log::debug!("L2ForwardEnableResponse: {response:?}");
+        }
         Ok(())
     }
 
     pub async fn add_l3_forward(&mut self, cmd: AddL3ForwardCmd) -> Result<(), Box<dyn Error>> {
-        let request = AddL3ForwardRequest {
-            target: Some(TargetModule {
-                module_name: cmd.module_name,
-                instances: cmd
-                    .instances
-                    .map(InstanceMap::from)
-                    .unwrap_or(InstanceMap::MAX)
-                    .as_u32(),
-            }),
-            src_dev_id: cmd.src as u32,
-            forward: Some(L3ForwardEntry {
-                network: cmd.network.to_string(),
-                dst_dev_id: cmd.dst as u32,
-            }),
-        };
-        log::trace!("AddL3ForwardRequest: {request:?}");
-        let response = self.client.add_l3_forward(request).await?.into_inner();
-        log::debug!("AddL3ForwardResponse: {response:?}");
+        for instance in cmd.instances {
+            let request = AddL3ForwardRequest {
+                target: Some(TargetModule {
+                    config_name: cmd.config_name.clone(),
+                    dataplane_instance: instance,
+                }),
+                src_dev_id: cmd.src as u32,
+                forward: Some(L3ForwardEntry {
+                    network: cmd.network.to_string(),
+                    dst_dev_id: cmd.dst as u32,
+                }),
+            };
+            log::trace!("AddL3ForwardRequest: {request:?}");
+            let response = self.client.add_l3_forward(request).await?.into_inner();
+            log::debug!("AddL3ForwardResponse: {response:?}");
+        }
         Ok(())
     }
 
     pub async fn remove_l3_forward(&mut self, cmd: RemoveL3ForwardCmd) -> Result<(), Box<dyn Error>> {
-        let request = RemoveL3ForwardRequest {
-            target: Some(TargetModule {
-                module_name: cmd.module_name,
-                instances: cmd
-                    .instances
-                    .map(InstanceMap::from)
-                    .unwrap_or(InstanceMap::MAX)
-                    .as_u32(),
-            }),
-            src_dev_id: cmd.src as u32,
-            network: cmd.network.to_string(),
-        };
-        log::trace!("RemoveL3ForwardRequest: {request:?}");
-        let response = self.client.remove_l3_forward(request).await?.into_inner();
-        log::debug!("RemoveL3ForwardResponse: {response:?}");
+        for instance in cmd.instances {
+            let request = RemoveL3ForwardRequest {
+                target: Some(TargetModule {
+                    config_name: cmd.config_name.clone(),
+                    dataplane_instance: instance,
+                }),
+                src_dev_id: cmd.src as u32,
+                network: cmd.network.to_string(),
+            };
+            log::trace!("RemoveL3ForwardRequest: {request:?}");
+            let response = self.client.remove_l3_forward(request).await?.into_inner();
+            log::debug!("RemoveL3ForwardResponse: {response:?}");
+        }
+        Ok(())
+    }
+
+    async fn get_dataplane_instances(&mut self) -> Result<Vec<u32>, Box<dyn Error>> {
+        let request = ListConfigsRequest {};
+        let response = self.client.list_configs(request).await?.into_inner();
+        Ok(response.instance_configs.iter().map(|c| c.instance).collect())
+    }
+
+    async fn print_config_list(&mut self) -> Result<(), Box<dyn Error>> {
+        let request = ListConfigsRequest {};
+        let response = self.client.list_configs(request).await?.into_inner();
+        let mut tree = TreeBuilder::new("List Forward Configs".to_string());
+        for instance_config in response.instance_configs {
+            tree.begin_child(format!("Instance {}", instance_config.instance));
+            for config in instance_config.configs {
+                tree.add_empty_child(config);
+            }
+        }
+        let tree = tree.build();
+        ptree::print_tree(&tree)?;
         Ok(())
     }
 }
@@ -235,28 +273,30 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
     }
 }
 
-pub fn print_json(resp: &ShowConfigResponse) -> Result<(), Box<dyn Error>> {
-    println!("{}", serde_json::to_string(resp)?);
+pub fn print_json(configs: Vec<ShowConfigResponse>) -> Result<(), Box<dyn Error>> {
+    println!("{}", serde_json::to_string(&configs)?);
     Ok(())
 }
 
-pub fn print_tree(resp: &ShowConfigResponse) -> Result<(), Box<dyn Error>> {
-    let mut tree = TreeBuilder::new("Forward Configs".to_string());
+pub fn print_tree(configs: Vec<ShowConfigResponse>) -> Result<(), Box<dyn Error>> {
+    let mut tree = TreeBuilder::new("View Forward Configs".to_string());
 
-    for instance in &resp.configs {
-        tree.begin_child(format!("'{}' on instance {}", resp.name, instance.instance));
+    for config in &configs {
+        tree.begin_child(format!("Instance {}", config.instance));
 
-        for dev in instance.devices.iter() {
-            tree.begin_child(format!("dev-id {}", dev.src_dev_id));
-            tree.add_empty_child(format!("L2 via dev-id {}", dev.dst_dev_id));
-            if !dev.forwards.is_empty() {
-                tree.begin_child(format!("L3 forwards (num={})", dev.forwards.len()));
-                for fwd in &dev.forwards {
-                    tree.add_empty_child(format!("{} via dev-id {}", fwd.network, fwd.dst_dev_id));
+        if let Some(config) = &config.config {
+            for dev in &config.devices {
+                tree.begin_child(format!("dev-id {}", dev.src_dev_id));
+                tree.add_empty_child(format!("L2 via dev-id {}", dev.dst_dev_id));
+                if !dev.forwards.is_empty() {
+                    tree.begin_child(format!("L3 forwards (num={})", dev.forwards.len()));
+                    for fwd in &dev.forwards {
+                        tree.add_empty_child(format!("{} via dev-id {}", fwd.network, fwd.dst_dev_id));
+                    }
+                    tree.end_child();
                 }
                 tree.end_child();
             }
-            tree.end_child();
         }
 
         tree.end_child();

--- a/modules/forward/controlplane/ffi.go
+++ b/modules/forward/controlplane/ffi.go
@@ -12,7 +12,6 @@ import (
 	"net/netip"
 	"unsafe"
 
-	dataplane "github.com/yanet-platform/yanet2/common/go/dataplane"
 	"github.com/yanet-platform/yanet2/common/go/xnetip"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
@@ -134,24 +133,17 @@ func topologyDeviceCount(agent *ffi.Agent) uint64 {
 	return uint64(C.forward_module_topology_device_count((*C.struct_agent)(agent.AsRawPtr())))
 }
 
-func DeleteModule(m *ForwardService, instanceMap dataplane.DpInstanceMap, moduleName string) dataplane.DpInstanceMap {
+func DeleteModule(m *ForwardService, configName string, instance uint32) bool {
 	cTypeName := C.CString(agentName)
 	defer C.free(unsafe.Pointer(cTypeName))
 
-	cModuleName := C.CString(moduleName)
-	defer C.free(unsafe.Pointer(cModuleName))
+	cConfigName := C.CString(configName)
+	defer C.free(unsafe.Pointer(cConfigName))
 
-	deleted := dataplane.DpInstanceMap(0)
-	for inst := range instanceMap.Iter() {
-		if inst >= uint32(len(m.agents)) {
-			break
-		}
-		agent := m.agents[inst]
-		result := C.agent_delete_module((*C.struct_agent)(agent.AsRawPtr()), cTypeName, cModuleName)
-		if result == 0 {
-			deleted.Enable(inst)
-		}
+	if instance >= uint32(len(m.agents)) {
+		return true
 	}
-
-	return deleted
+	agent := m.agents[instance]
+	result := C.agent_delete_module((*C.struct_agent)(agent.AsRawPtr()), cTypeName, cConfigName)
+	return result == 0
 }

--- a/modules/forward/controlplane/ffi.go
+++ b/modules/forward/controlplane/ffi.go
@@ -133,7 +133,7 @@ func topologyDeviceCount(agent *ffi.Agent) uint64 {
 	return uint64(C.forward_module_topology_device_count((*C.struct_agent)(agent.AsRawPtr())))
 }
 
-func DeleteModule(m *ForwardService, configName string, instance uint32) bool {
+func DeleteConfig(m *ForwardService, configName string, instance uint32) bool {
 	cTypeName := C.CString(agentName)
 	defer C.free(unsafe.Pointer(cTypeName))
 

--- a/modules/forward/controlplane/forwardpb/forward.proto
+++ b/modules/forward/controlplane/forwardpb/forward.proto
@@ -2,10 +2,16 @@ syntax = "proto3";
 
 package forwardpb;
 
+import "common/proto/target.proto";
+
 option go_package = "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb;forwardpb";
 
 // ForwardService is a controlplane service for forwarding module.
 service ForwardService {
+	// ListConfigs returns all forward module configurations of all
+	// dataplane instances.
+	rpc ListConfigs(ListConfigsRequest) returns (ListConfigsResponse);
+
 	// ShowConfig returns the current configuration for the forward module.
 	rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse);
 
@@ -21,25 +27,9 @@ service ForwardService {
 	rpc RemoveL3Forward(RemoveL3ForwardRequest)
 		returns (RemoveL3ForwardResponse);
 
-	// Allows to delete forward module if it is not referenced
+	// Allows to delete forward config if it is not referenced
 	// by any pipeline.
-	rpc DeleteModule(DeleteModuleRequest) returns (DeleteModuleResponse);
-}
-
-// TargetModule request for operating on a specific target module.
-message TargetModule {
-	// ModuleName is the name of the module for which to reload the
-	// configuration.
-	string module_name = 1;
-	// Instances specifies a bitmap of dataplane instances that should be
-	// affected.
-	uint32 instances = 2;
-}
-
-// ShowConfigResponse retrieves the runtime configuration for the forward
-// module.
-message ShowConfigRequest {
-	TargetModule target = 1;
+	rpc DeleteConfig(DeleteConfigRequest) returns (DeleteConfigResponse);
 }
 
 message L3ForwardEntry {
@@ -53,20 +43,40 @@ message ForwardDeviceConfig {
 	repeated L3ForwardEntry forwards = 3;
 }
 
-message InstanceConfig {
+message Config {
+	repeated ForwardDeviceConfig devices = 1;
+}
+
+// Represents config names of dataplane instances
+message InstanceConfigs {
+	// Dataplane instance
 	uint32 instance = 1;
-	repeated ForwardDeviceConfig devices = 2;
+	repeated string configs = 2;
+}
+
+message ListConfigsRequest {
+}
+
+// ListConfigsResponse contains existing configurations per dataplane instance.
+message ListConfigsResponse {
+	repeated InstanceConfigs instance_configs = 1;
+}
+
+// ShowConfigResponse retrieves the runtime configuration for the forward
+// module.
+message ShowConfigRequest {
+	commonpb.TargetModule target = 1;
 }
 
 // ShowConfigResponse contains the configuration details of the forward module.
 message ShowConfigResponse {
-	string name = 1;
-	repeated InstanceConfig configs = 2;
+	uint32 instance = 1;
+	Config config = 2;
 }
 
 // L2ForwardEnableRequest enables Layer 2 forwarding between specified devices.
 message L2ForwardEnableRequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 	uint32 src_dev_id = 2;
 	uint32 dst_dev_id = 3;
 }
@@ -78,7 +88,7 @@ message L2ForwardEnableResponse {
 // should be added for the device identified by the device ID. If an existing
 // forward rule is present, it will be replaced.
 message AddL3ForwardRequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 	uint32 src_dev_id = 2;
 	L3ForwardEntry forward = 3;
 }
@@ -89,7 +99,7 @@ message AddL3ForwardResponse {
 // RemoveL3ForwardRequest specifies the device ID within the target module
 // from which to remove the forward entry for the specified network.
 message RemoveL3ForwardRequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 	uint32 src_dev_id = 2;
 	string network = 3;
 }
@@ -97,15 +107,13 @@ message RemoveL3ForwardRequest {
 message RemoveL3ForwardResponse {
 }
 
-// Delete module with specified name.
-message DeleteModuleRequest {
+// Delete config with specified name.
+message DeleteConfigRequest {
 	// Specifies module name and
-	// instances of forward agent to delete.
-	TargetModule target = 1;
+	// dataplane instance of forward agent to delete.
+	commonpb.TargetModule target = 1;
 }
 
-message DeleteModuleResponse {
-	// Specifies bitmap of dataplane instances,
-	// for which modules were successfully deleted.
-	uint32 deleted = 1;
+message DeleteConfigResponse {
+	bool deleted = 1;
 }

--- a/modules/forward/controlplane/forwardpb/meson.build
+++ b/modules/forward/controlplane/forwardpb/meson.build
@@ -1,4 +1,5 @@
 proto_dir = meson.current_source_dir()
+root_dir = meson.project_source_root()
 proto_files = [join_paths(proto_dir, 'forward.proto')]
 
 protoc_gen = custom_target(
@@ -7,11 +8,13 @@ protoc_gen = custom_target(
     input: proto_files,
     command: [
         protoc,
-        '-I', meson.current_source_dir(),
-        '--go_out=paths=source_relative:' + meson.current_source_dir(),
-        '--go-grpc_out=paths=source_relative:' + meson.current_source_dir(),
+        '-I', proto_dir,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + proto_dir,
+        '--go-grpc_out=paths=source_relative:' + proto_dir,
         '@INPUT@',
     ],
+    depends: [common_protoc_gen],
     build_by_default: true,
 )
 forward_protoc_gen = protoc_gen

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -250,12 +250,14 @@ func (m *ForwardService) DeleteConfig(ctx context.Context, req *forwardpb.Delete
 	if err != nil {
 		return nil, err
 	}
-	deleted := DeleteConfig(m, name, inst)
+	// Remove module configuration from the control plane.
+	delete(m.configs, instanceKey{name, inst})
 
+	deleted := DeleteConfig(m, name, inst)
 	m.log.Infow("deleted module config",
 		zap.String("name", name),
 		zap.Uint32("instance", inst),
-		zap.Bool("deleted", deleted),
+		zap.Bool("dataplane_hit", deleted),
 	)
 
 	response := &forwardpb.DeleteConfigResponse{

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -245,12 +245,12 @@ func (m *ForwardService) RemoveL3Forward(ctx context.Context, req *forwardpb.Rem
 	return &forwardpb.RemoveL3ForwardResponse{}, nil
 }
 
-func (m *ForwardService) DeleteModule(ctx context.Context, req *forwardpb.DeleteConfigRequest) (*forwardpb.DeleteConfigResponse, error) {
+func (m *ForwardService) DeleteConfig(ctx context.Context, req *forwardpb.DeleteConfigRequest) (*forwardpb.DeleteConfigResponse, error) {
 	name, inst, err := req.GetTarget().Validate(uint32(len(m.agents)))
 	if err != nil {
 		return nil, err
 	}
-	deleted := DeleteModule(m, name, inst)
+	deleted := DeleteConfig(m, name, inst)
 
 	m.log.Infow("deleted module config",
 		zap.String("name", name),

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -12,13 +12,11 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	dataplane "github.com/yanet-platform/yanet2/common/go/dataplane"
-	"github.com/yanet-platform/yanet2/common/go/xiter"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
 )
 
-type ffiConfigUpdater func(m *ForwardService, name string, instanceMap dataplane.DpInstanceMap) error
+type ffiConfigUpdater func(m *ForwardService, name string, instance uint32) error
 
 type ForwardService struct {
 	forwardpb.UnimplementedForwardServiceServer
@@ -37,27 +35,49 @@ func NewForwardService(agents []*ffi.Agent, log *zap.SugaredLogger, deviceCount 
 		log:         log,
 		configs:     make(map[instanceKey][]ForwardDeviceConfig),
 		deviceCount: deviceCount,
-		updater:     updateModuleConfigs,
+		updater:     updateModuleConfig,
 	}
 }
 
+func (m *ForwardService) ListConfigs(
+	ctx context.Context, request *forwardpb.ListConfigsRequest,
+) (*forwardpb.ListConfigsResponse, error) {
+
+	response := &forwardpb.ListConfigsResponse{
+		InstanceConfigs: make([]*forwardpb.InstanceConfigs, len(m.agents)),
+	}
+	for inst := range m.agents {
+		response.InstanceConfigs[inst] = &forwardpb.InstanceConfigs{
+			Instance: uint32(inst),
+		}
+	}
+
+	// Lock instances store and module updates
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for key := range m.configs {
+		instConfig := response.InstanceConfigs[key.dataplaneInstance]
+		instConfig.Configs = append(instConfig.Configs, key.name)
+	}
+
+	return response, nil
+}
+
 func (m *ForwardService) ShowConfig(ctx context.Context, req *forwardpb.ShowConfigRequest) (*forwardpb.ShowConfigResponse, error) {
-	name, instanceMap, err := validateTarget(req.Target, len(m.agents))
+	name, inst, err := req.GetTarget().Validate(uint32(len(m.agents)))
 	if err != nil {
 		return nil, err
 	}
 
+	key := instanceKey{name: name, dataplaneInstance: inst}
+	response := &forwardpb.ShowConfigResponse{Instance: inst}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	configs := make([]*forwardpb.InstanceConfig, 0, instanceMap.Len())
-	for instance := range instanceMap.Iter() {
-		key := instanceKey{name: name, dataplaneInstance: instance}
-		config := m.configs[key]
-		if config == nil {
-			continue
-		}
-
+	config := m.configs[key]
+	if config != nil {
 		devices := make([]*forwardpb.ForwardDeviceConfig, 0, m.deviceCount)
 		for srcDevIdx, device := range config {
 			deviceConfig := &forwardpb.ForwardDeviceConfig{
@@ -88,20 +108,14 @@ func (m *ForwardService) ShowConfig(ctx context.Context, req *forwardpb.ShowConf
 			return cmp.Compare(a.DstDevId, b.DstDevId)
 		})
 
-		configs = append(configs, &forwardpb.InstanceConfig{
-			Instance: instance,
-			Devices:  devices,
-		})
+		response.Config = &forwardpb.Config{Devices: devices}
 	}
 
-	return &forwardpb.ShowConfigResponse{
-		Name:    req.Target.ModuleName,
-		Configs: configs,
-	}, nil
+	return response, nil
 }
 
 func (m *ForwardService) EnableL2Forward(ctx context.Context, req *forwardpb.L2ForwardEnableRequest) (*forwardpb.L2ForwardEnableResponse, error) {
-	name, instances, err := validateTarget(req.Target, len(m.agents))
+	name, inst, err := req.GetTarget().Validate(uint32(len(m.agents)))
 	if err != nil {
 		return nil, err
 	}
@@ -115,22 +129,20 @@ func (m *ForwardService) EnableL2Forward(ctx context.Context, req *forwardpb.L2F
 	defer m.mu.Unlock()
 
 	// Enable (or override) forwarding between devices
-	for instance := range instances.Iter() {
-		key := instanceKey{name: name, dataplaneInstance: instance}
-		config, exists := m.configs[key]
-		if !exists {
-			config = defaultForwardConfig(m.deviceCount)
-			m.configs[key] = config
-		}
-
-		// Update in-memory configuration
-		config[srcDevId].DstDevId = dstDevId
+	key := instanceKey{name: name, dataplaneInstance: inst}
+	config, exists := m.configs[key]
+	if !exists {
+		config = defaultForwardConfig(m.deviceCount)
+		m.configs[key] = config
 	}
+
+	// Update in-memory configuration
+	config[srcDevId].DstDevId = dstDevId
 
 	// FIXME: Commit in-memory config only if SHM updates are successful?
 
 	// Then update shm configs
-	if err := m.updater(m, name, instances); err != nil {
+	if err := m.updater(m, name, inst); err != nil {
 		return nil, fmt.Errorf("failed to update module configs: %w", err)
 	}
 
@@ -138,14 +150,14 @@ func (m *ForwardService) EnableL2Forward(ctx context.Context, req *forwardpb.L2F
 		zap.String("name", name),
 		zap.Uint16("src_dev_id", uint16(srcDevId)),
 		zap.Uint16("dst_dev_id", uint16(dstDevId)),
-		zap.Uint32s("instances", slices.Collect(instances.Iter())),
+		zap.Uint32("instance", inst),
 	)
 
 	return &forwardpb.L2ForwardEnableResponse{}, nil
 }
 
 func (m *ForwardService) AddL3Forward(ctx context.Context, req *forwardpb.AddL3ForwardRequest) (*forwardpb.AddL3ForwardResponse, error) {
-	name, instances, err := validateTarget(req.Target, len(m.agents))
+	name, inst, err := req.GetTarget().Validate(uint32(len(m.agents)))
 	if err != nil {
 		return nil, err
 	}
@@ -161,25 +173,23 @@ func (m *ForwardService) AddL3Forward(ctx context.Context, req *forwardpb.AddL3F
 	defer m.mu.Unlock()
 
 	// First update in-memory configs
-	for instance := range instances.Iter() {
-		key := instanceKey{name: name, dataplaneInstance: instance}
-		config := m.configs[key]
-		if config == nil {
-			config = defaultForwardConfig(m.deviceCount)
-			m.configs[key] = config
-		}
-
-		sourceDev := &config[srcDevId]
-		if sourceDev.Forwards == nil {
-			sourceDev.Forwards = make(map[netip.Prefix]DeviceID)
-		}
-		sourceDev.Forwards[network] = dstDevId
+	key := instanceKey{name: name, dataplaneInstance: inst}
+	config := m.configs[key]
+	if config == nil {
+		config = defaultForwardConfig(m.deviceCount)
+		m.configs[key] = config
 	}
+
+	sourceDev := &config[srcDevId]
+	if sourceDev.Forwards == nil {
+		sourceDev.Forwards = make(map[netip.Prefix]DeviceID)
+	}
+	sourceDev.Forwards[network] = dstDevId
 
 	// FIXME: Commit in-memory config only if SHM updates are successful?
 
 	// Then update shm configs
-	if err := m.updater(m, name, instances); err != nil {
+	if err := m.updater(m, name, inst); err != nil {
 		return nil, fmt.Errorf("failed to update module configs: %w", err)
 	}
 
@@ -194,7 +204,7 @@ func (m *ForwardService) AddL3Forward(ctx context.Context, req *forwardpb.AddL3F
 }
 
 func (m *ForwardService) RemoveL3Forward(ctx context.Context, req *forwardpb.RemoveL3ForwardRequest) (*forwardpb.RemoveL3ForwardResponse, error) {
-	name, instances, err := validateTarget(req.Target, len(m.agents))
+	name, inst, err := req.GetTarget().Validate(uint32(len(m.agents)))
 	if err != nil {
 		return nil, err
 	}
@@ -207,24 +217,22 @@ func (m *ForwardService) RemoveL3Forward(ctx context.Context, req *forwardpb.Rem
 	defer m.mu.Unlock()
 
 	// First update in-memory configs
-	for inst := range instances.Iter() {
-		key := instanceKey{name: name, dataplaneInstance: inst}
-		config, exists := m.configs[key]
-		if !exists {
-			continue
-		}
-
-		sourceDev := &config[srcDevId]
-		if sourceDev.Forwards == nil {
-			continue
-		}
-		delete(sourceDev.Forwards, network)
+	key := instanceKey{name: name, dataplaneInstance: inst}
+	config, exists := m.configs[key]
+	if !exists {
+		return &forwardpb.RemoveL3ForwardResponse{}, nil
 	}
+
+	sourceDev := &config[srcDevId]
+	if sourceDev.Forwards == nil {
+		return &forwardpb.RemoveL3ForwardResponse{}, nil
+	}
+	delete(sourceDev.Forwards, network)
 
 	// FIXME: Commit in-memory config only if SHM updates are successful?
 
 	// Then update shm configs
-	if err := m.updater(m, name, instances); err != nil {
+	if err := m.updater(m, name, inst); err != nil {
 		return nil, fmt.Errorf("failed to update module configs: %w", err)
 	}
 
@@ -237,17 +245,21 @@ func (m *ForwardService) RemoveL3Forward(ctx context.Context, req *forwardpb.Rem
 	return &forwardpb.RemoveL3ForwardResponse{}, nil
 }
 
-func (m *ForwardService) DeleteModule(ctx context.Context, req *forwardpb.DeleteModuleRequest) (*forwardpb.DeleteModuleResponse, error) {
-	moduleName, instances, err := validateTarget(req.GetTarget(), len(m.agents))
+func (m *ForwardService) DeleteModule(ctx context.Context, req *forwardpb.DeleteConfigRequest) (*forwardpb.DeleteConfigResponse, error) {
+	name, inst, err := req.GetTarget().Validate(uint32(len(m.agents)))
 	if err != nil {
 		return nil, err
 	}
-	deleted := DeleteModule(m, instances, moduleName)
+	deleted := DeleteModule(m, name, inst)
 
-	m.log.Infow("deleted module for instances", zap.Uint32("deleted", uint32(deleted)))
+	m.log.Infow("deleted module config",
+		zap.String("name", name),
+		zap.Uint32("instance", inst),
+		zap.Bool("deleted", deleted),
+	)
 
-	response := &forwardpb.DeleteModuleResponse{
-		Deleted: uint32(deleted),
+	response := &forwardpb.DeleteConfigResponse{
+		Deleted: deleted,
 	}
 	return response, nil
 }
@@ -278,112 +290,57 @@ func (m *ForwardService) validateForwardParams(srcDeviceId uint32, network strin
 	return sourceDeviceId, prefix, targetDeviceId, nil
 }
 
-func validateTarget(target *forwardpb.TargetModule, numAgents int) (string, dataplane.DpInstanceMap, error) {
-	if target == nil {
-		return "", dataplane.DpInstanceMap(0), status.Errorf(codes.InvalidArgument, "target cannot be nil")
-	}
-
-	name := target.GetModuleName()
-	if name == "" {
-		return "", dataplane.DpInstanceMap(0), status.Errorf(codes.InvalidArgument, "module name is required")
-	}
-
-	instanceMap, err := transformInstanceMap(dataplane.DpInstanceMap(target.Instances), numAgents)
-	if err != nil {
-		return "", dataplane.DpInstanceMap(0), err
-	}
-
-	return name, instanceMap, nil
-}
-
-func updateModuleConfigs(
+func updateModuleConfig(
 	m *ForwardService,
 	name string,
-	instances dataplane.DpInstanceMap,
+	instance uint32,
 ) error {
-	m.log.Debugw("updating configuration",
-		zap.String("module", name),
-		zap.Uint32s("instances", slices.Collect(instances.Iter())),
-	)
+	m.log.Debugw("update config", zap.String("config", name), zap.Uint32("instance", instance))
 
-	// Create module configs for each instance
-	configs := make([]*ModuleConfig, instances.Len())
-	for i, inst := range xiter.Enumerate(instances.Iter()) {
-		agent := m.agents[inst]
-		if agent == nil {
-			return fmt.Errorf("agent for instance %d is nil", inst)
-		}
-
-		key := instanceKey{name: name, dataplaneInstance: inst}
-		config := m.configs[key]
-		if config == nil {
-			config = defaultForwardConfig(m.deviceCount)
-			m.configs[key] = config
-		}
-
-		// Count total number of devices for initialization
-		deviceCount := uint16(len(config))
-		if len(config) != int(deviceCount) {
-			return fmt.Errorf("too many devices: %d", len(config))
-		}
-
-		moduleConfig, err := NewModuleConfig(agent, name)
-		if err != nil {
-			return fmt.Errorf("failed to create module config for instance %d: %w", inst, err)
-		}
-
-		// Configure all forwards
-		for idx, device := range config {
-			srcDeviceID := DeviceID(idx)
-			dstDeviceID := device.DstDevId
-
-			if err := moduleConfig.L2ForwardEnable(srcDeviceID, dstDeviceID); err != nil {
-				return fmt.Errorf("failed to enable forward from dev(%d) to dev(%d) on instance %d: %w", srcDeviceID, dstDeviceID, inst, err)
-			}
-
-			// Then configure all forwards for this device
-			for network, targetDevice := range device.Forwards {
-				if err := moduleConfig.L3ForwardEnable(network, srcDeviceID, targetDevice); err != nil {
-					return fmt.Errorf("failed to enable forward from dev(%d) to dev(%d) for network %s on instance %d: %w",
-						srcDeviceID, targetDevice, network, inst, err)
-				}
-			}
-		}
-
-		configs[i] = moduleConfig
+	agent := m.agents[instance]
+	if agent == nil {
+		return fmt.Errorf("agent for instance %d is nil", instance)
 	}
 
-	// Apply all configurations
-	for i, inst := range xiter.Enumerate(instances.Iter()) {
-		agent := m.agents[inst]
-		config := configs[i]
-
-		if err := agent.UpdateModules([]ffi.ModuleConfig{config.AsFFIModule()}); err != nil {
-			return fmt.Errorf("failed to update module on instance %d: %w", inst, err)
-		}
-
-		m.log.Debugw("successfully updated module config",
-			zap.String("name", name),
-			zap.Uint32("instance", inst),
-		)
+	key := instanceKey{name: name, dataplaneInstance: instance}
+	config := m.configs[key]
+	if config == nil {
+		config = defaultForwardConfig(m.deviceCount)
+		m.configs[key] = config
 	}
 
-	m.log.Infow("successfully updated all module configurations",
+	moduleConfig, err := NewModuleConfig(agent, name)
+	if err != nil {
+		return fmt.Errorf("failed to create %q module config: %w", name, err)
+	}
+
+	// Configure all forwards
+	for idx, device := range config {
+		srcDeviceID := DeviceID(idx)
+		dstDeviceID := device.DstDevId
+
+		if err := moduleConfig.L2ForwardEnable(srcDeviceID, dstDeviceID); err != nil {
+			return fmt.Errorf("failed to enable forward from dev(%d) to dev(%d) on instance %d: %w", srcDeviceID, dstDeviceID, instance, err)
+		}
+
+		// Then configure all forwards for this device
+		for network, targetDevice := range device.Forwards {
+			if err := moduleConfig.L3ForwardEnable(network, srcDeviceID, targetDevice); err != nil {
+				return fmt.Errorf("failed to enable forward from dev(%d) to dev(%d) for network %s on instance %d: %w",
+					srcDeviceID, targetDevice, network, instance, err)
+			}
+		}
+	}
+
+	if err := agent.UpdateModules([]ffi.ModuleConfig{moduleConfig.AsFFIModule()}); err != nil {
+		return fmt.Errorf("failed to update module: %w", err)
+	}
+
+	m.log.Infow("successfully updated module",
 		zap.String("name", name),
-		zap.Uint32s("instances", slices.Collect(instances.Iter())),
+		zap.Uint32("instance", instance),
 	)
-
 	return nil
-}
-
-func transformInstanceMap(requestedInstanceMap dataplane.DpInstanceMap, numAgents int) (dataplane.DpInstanceMap, error) {
-	instanceMap := requestedInstanceMap.Intersect(dataplane.NewWithTrailingOnes(numAgents))
-
-	if instanceMap.IsEmpty() {
-		return dataplane.DpInstanceMap(0), status.Error(codes.InvalidArgument, "instance list are empty")
-	}
-
-	return instanceMap, nil
 }
 
 func defaultForwardConfig(deviceCount uint16) []ForwardDeviceConfig {

--- a/modules/forward/coordinator/service.go
+++ b/modules/forward/coordinator/service.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
-	dp "github.com/yanet-platform/yanet2/common/go/dataplane"
+	commonpb "github.com/yanet-platform/yanet2/common/proto"
 	"github.com/yanet-platform/yanet2/coordinator/coordinatorpb"
 	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
 )
@@ -80,9 +80,9 @@ func (m *ModuleService) setupConfig(
 	client := forwardpb.NewForwardServiceClient(conn)
 
 	// Create a target configuration for the ForwardService
-	target := &forwardpb.TargetModule{
-		ModuleName: configName,
-		Instances:  uint32(dp.NewWithOneBitSet(instance)),
+	target := &commonpb.TargetModule{
+		ConfigName:        configName,
+		DataplaneInstance: instance,
 	}
 
 	for _, forward := range config.L2Forwards {


### PR DESCRIPTION
## common TargetModule proto and iteration on the CLI side

This PR refactors the forward module to use a unified `commonpb.TargetModule` instead of module-specific targeting, improving consistency across the yanet2 codebase.

### Key Changes

**API Standardization:**
- Replace `forwardpb.TargetModule` with `commonpb.TargetModule` across all forward module components
- Change from bitmask-based instance targeting (`Instances: 0b1`) to single instance targeting (`DataplaneInstance: 0`)
- Rename `ModuleName` field to `ConfigName` for clarity

**CLI Updates:**
- Update yanet-cli commands to use `--cfg` and `--instance` flags instead of `--mod`
- Standardize command syntax across forward, decap, route, and dscp modules
- Update documentation examples in `virtual-run.org` with new CLI syntax

**Service Layer Changes:**
- Refactor controlplane service to handle single-instance targeting
- Update test suite to reflect new API structure (removed multi-instance test scenarios)

**Protocol Buffer Updates:**
- Add `common/proto/target.proto` compilation to build process
- Remove module-specific TargetModule definitions

### Impact
- **Breaking Change**: Existing CLI scripts and API clients need to be updated
- **Improved Consistency**: Most of the modules now use the same targeting mechanism
- **Simplified Logic**: Single-instance targeting reduces complexity and potential bugs
- **Better Maintainability**: Centralized target definition makes future changes easier

This refactoring lays the foundation for a more maintainable and consistent module system architecture.