### PR TITLE
refactor(nat64): iterate through instances on the CLI side

### DIFF
--- a/modules/nat64/cli/build.rs
+++ b/modules/nat64/cli/build.rs
@@ -1,13 +1,17 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=../../../common/proto/target.proto");
     println!("cargo:rerun-if-changed=../controlplane/nat64pb/nat64.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["nat64pb/nat64.proto"], &["../controlplane"])?;
+        .compile_protos(
+            &["common/proto/target.proto", "nat64pb/nat64.proto"],
+            &["../../..", "../controlplane"],
+        )?;
 
     Ok(())
 }

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -4,9 +4,10 @@ use std::net::{Ipv4Addr, Ipv6Addr};
 use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::CompleteEnv;
 use code::{
-    nat64_service_client::Nat64ServiceClient, AddMappingRequest, AddPrefixRequest, SetDropUnknownRequest,
-    SetMtuRequest, ShowConfigRequest, ShowConfigResponse, TargetModule,
+    nat64_service_client::Nat64ServiceClient, AddMappingRequest, AddPrefixRequest, ListConfigsRequest,
+    SetDropUnknownRequest, SetMtuRequest, ShowConfigRequest, ShowConfigResponse,
 };
+use commonpb::TargetModule;
 use ipnet::Ipv6Net;
 use ptree::TreeBuilder;
 use tonic::transport::Channel;
@@ -16,6 +17,12 @@ use yanet_cli::logging;
 pub mod code {
     use serde::Serialize;
     tonic::include_proto!("nat64pb");
+}
+
+#[allow(non_snake_case)]
+pub mod commonpb {
+    use serde::Serialize;
+    tonic::include_proto!("commonpb");
 }
 
 /// NAT64 module CLI.
@@ -67,9 +74,12 @@ pub enum MappingCmd {
 
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
-    /// NAT64 module name to operate on.
-    #[arg(long = "mod")]
-    pub module_name: Option<String>,
+    /// The name of the module to operate on.
+    #[arg(long = "cfg", short)]
+    pub config_name: Option<String>,
+    /// Indices of dataplane instances from which configurations should be retrieved.
+    #[arg(long, short, required = false)]
+    pub instances: Vec<u32>,
     /// Output format.
     #[clap(long, value_enum, default_value_t = OutputFormat::Tree)]
     pub format: OutputFormat,
@@ -77,12 +87,12 @@ pub struct ShowConfigCmd {
 
 #[derive(Debug, Clone, Parser)]
 pub struct AddPrefixCmd {
-    /// NAT64 module name to operate on.
-    #[arg(long = "mod")]
-    pub module_name: String,
+    /// The name of the module to operate on.
+    #[arg(long = "cfg", short)]
+    pub config_name: String,
     /// Dataplane instances where changes should be applied.
-    #[arg(long)]
-    pub instances: Option<Vec<u32>>,
+    #[arg(long, short, required = true)]
+    pub instances: Vec<u32>,
     /// IPv6 prefix (12 bytes) to be added.
     #[arg(long)]
     pub prefix: Ipv6Net,
@@ -90,12 +100,12 @@ pub struct AddPrefixCmd {
 
 #[derive(Debug, Clone, Parser)]
 pub struct AddMappingCmd {
-    /// NAT64 module name to operate on.
-    #[arg(long = "mod")]
-    pub module_name: String,
+    /// The name of the module to operate on.
+    #[arg(long = "cfg", short)]
+    pub config_name: String,
     /// Dataplane instances where changes should be applied.
-    #[arg(long)]
-    pub instances: Option<Vec<u32>>,
+    #[arg(long, short, required = true)]
+    pub instances: Vec<u32>,
     /// IPv4 address (4 bytes).
     #[arg(long)]
     pub ipv4: Ipv4Addr,
@@ -109,12 +119,12 @@ pub struct AddMappingCmd {
 
 #[derive(Debug, Clone, Parser)]
 pub struct MtuCmd {
-    /// NAT64 module name to operate on.
-    #[arg(long = "mod")]
-    pub module_name: String,
+    /// The name of the module to operate on.
+    #[arg(long = "cfg", short)]
+    pub config_name: String,
     /// Dataplane instances where changes should be applied.
-    #[arg(long)]
-    pub instances: Option<Vec<u32>>,
+    #[arg(long, short, required = true)]
+    pub instances: Vec<u32>,
     /// MTU value for IPv4.
     #[arg(long)]
     pub ipv4_mtu: u32,
@@ -171,79 +181,125 @@ impl NAT64Service {
     }
 
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Box<dyn Error>> {
-        let request = ShowConfigRequest {
-            target: Some(TargetModule {
-                module_name: cmd.module_name.unwrap_or_default(),
-                instances: Vec::new(),
-            }),
+        let Some(name) = cmd.config_name else {
+            self.print_config_list().await?;
+            return Ok(());
         };
-        let response = self.client.show_config(request).await?.into_inner();
+
+        let mut instances = cmd.instances;
+        if instances.is_empty() {
+            instances = self.get_dataplane_instances().await?;
+        }
+        let mut configs = Vec::new();
+        for instance in instances {
+            let request = ShowConfigRequest {
+                target: Some(TargetModule {
+                    config_name: name.to_owned(),
+                    dataplane_instance: instance,
+                }),
+            };
+            log::trace!("show config request on dataplane instance {instance}: {request:?}");
+            let response = self.client.show_config(request).await?.into_inner();
+            log::debug!("show config response on dataplane instance {instance}: {response:?}");
+            configs.push(response);
+        }
+
         match cmd.format {
-            OutputFormat::Json => print_json(&response)?,
-            OutputFormat::Tree => print_tree(&response)?,
+            OutputFormat::Json => print_json(configs)?,
+            OutputFormat::Tree => print_tree(configs)?,
         }
         Ok(())
     }
 
     pub async fn add_prefix(&mut self, cmd: AddPrefixCmd) -> Result<(), Box<dyn Error>> {
-        let request = AddPrefixRequest {
-            target: Some(TargetModule {
-                module_name: cmd.module_name,
-                instances: cmd.instances.unwrap_or_default(),
-            }),
-            prefix: cmd.prefix.addr().octets()[..12].to_vec(),
-        };
-        log::debug!("AddPrefixRequest: {request:?}");
-        let response = self.client.add_prefix(request).await?.into_inner();
-        log::debug!("AddPrefixResponse: {response:?}");
+        for instance in cmd.instances {
+            let request = AddPrefixRequest {
+                target: Some(TargetModule {
+                    config_name: cmd.config_name.clone(),
+                    dataplane_instance: instance,
+                }),
+                prefix: cmd.prefix.addr().octets()[..12].to_vec(),
+            };
+            log::debug!("AddPrefixRequest: {request:?}");
+            let response = self.client.add_prefix(request).await?.into_inner();
+            log::debug!("AddPrefixResponse: {response:?}");
+        }
         Ok(())
     }
 
     pub async fn add_mapping(&mut self, cmd: AddMappingCmd) -> Result<(), Box<dyn Error>> {
-        let request = AddMappingRequest {
-            target: Some(TargetModule {
-                module_name: cmd.module_name,
-                instances: cmd.instances.unwrap_or_default(),
-            }),
-            ipv4: cmd.ipv4.octets().to_vec(),
-            ipv6: cmd.ipv6.octets().to_vec(),
-            prefix_index: cmd.prefix_index,
-        };
-        log::debug!("AddMappingRequest: {request:?}");
-        let response = self.client.add_mapping(request).await?.into_inner();
-        log::debug!("AddMappingResponse: {response:?}");
+        for instance in cmd.instances {
+            let request = AddMappingRequest {
+                target: Some(TargetModule {
+                    config_name: cmd.config_name.clone(),
+                    dataplane_instance: instance,
+                }),
+                ipv4: cmd.ipv4.octets().to_vec(),
+                ipv6: cmd.ipv6.octets().to_vec(),
+                prefix_index: cmd.prefix_index,
+            };
+            log::debug!("AddMappingRequest: {request:?}");
+            let response = self.client.add_mapping(request).await?.into_inner();
+            log::debug!("AddMappingResponse: {response:?}");
+        }
         Ok(())
     }
 
     pub async fn set_mtu(&mut self, cmd: MtuCmd) -> Result<(), Box<dyn Error>> {
-        let request = SetMtuRequest {
-            target: Some(TargetModule {
-                module_name: cmd.module_name,
-                instances: cmd.instances.unwrap_or_default(),
-            }),
-            mtu: Some(code::MtuConfig {
-                ipv4_mtu: cmd.ipv4_mtu,
-                ipv6_mtu: cmd.ipv6_mtu,
-            }),
-        };
-        log::debug!("SetMtuRequest: {request:?}");
-        let response = self.client.set_mtu(request).await?.into_inner();
-        log::debug!("SetMtuResponse: {response:?}");
+        for instance in cmd.instances {
+            let request = SetMtuRequest {
+                target: Some(TargetModule {
+                    config_name: cmd.config_name.clone(),
+                    dataplane_instance: instance,
+                }),
+                mtu: Some(code::MtuConfig {
+                    ipv4_mtu: cmd.ipv4_mtu,
+                    ipv6_mtu: cmd.ipv6_mtu,
+                }),
+            };
+            log::debug!("SetMtuRequest: {request:?}");
+            let response = self.client.set_mtu(request).await?.into_inner();
+            log::debug!("SetMtuResponse: {response:?}");
+        }
         Ok(())
     }
 
     pub async fn set_drop_unknown(&mut self, cmd: DropCmd) -> Result<(), Box<dyn Error>> {
-        let request = SetDropUnknownRequest {
-            target: Some(TargetModule {
-                module_name: cmd.module_name,
-                instances: cmd.instances.unwrap_or_default(),
-            }),
-            drop_unknown_prefix: cmd.drop_unknown_prefix,
-            drop_unknown_mapping: cmd.drop_unknown_mapping,
-        };
-        log::debug!("SetDropUnknownRequest: {request:?}");
-        let response = self.client.set_drop_unknown(request).await?.into_inner();
-        log::debug!("SetDropUnknownResponse: {response:?}");
+        for instance in cmd.instances {
+            let request = SetDropUnknownRequest {
+                target: Some(TargetModule {
+                    config_name: cmd.config_name.clone(),
+                    dataplane_instance: instance,
+                }),
+                drop_unknown_prefix: cmd.drop_unknown_prefix,
+                drop_unknown_mapping: cmd.drop_unknown_mapping,
+            };
+            log::debug!("SetDropUnknownRequest: {request:?}");
+            let response = self.client.set_drop_unknown(request).await?.into_inner();
+            log::debug!("SetDropUnknownResponse: {response:?}");
+        }
+        Ok(())
+    }
+
+    async fn get_dataplane_instances(&mut self) -> Result<Vec<u32>, Box<dyn Error>> {
+        let request = ListConfigsRequest {};
+        let response = self.client.list_configs(request).await?.into_inner();
+        Ok(response.instance_configs.iter().map(|c| c.instance).collect())
+    }
+
+    async fn print_config_list(&mut self) -> Result<(), Box<dyn Error>> {
+        let request = ListConfigsRequest {};
+        let response = self.client.list_configs(request).await?.into_inner();
+        let mut tree = TreeBuilder::new("List NAT64 Configs".to_string());
+        for instance_config in response.instance_configs {
+            tree.begin_child(format!("Instance {}", instance_config.instance));
+            for config in instance_config.configs {
+                tree.add_empty_child(config);
+            }
+            tree.end_child();
+        }
+        let tree = tree.build();
+        ptree::print_tree(&tree)?;
         Ok(())
     }
 }
@@ -251,12 +307,12 @@ impl NAT64Service {
 /// Command for setting drop_unknown flags
 #[derive(Debug, Clone, Parser)]
 pub struct DropCmd {
-    /// NAT64 module name to operate on.
-    #[arg(long = "mod")]
-    pub module_name: String,
+    /// The name of the module to operate on.
+    #[arg(long = "cfg", short)]
+    pub config_name: String,
     /// Dataplane instances where changes should be applied.
-    #[arg(long)]
-    pub instances: Option<Vec<u32>>,
+    #[arg(long, short, required = true)]
+    pub instances: Vec<u32>,
     /// Drop packets with unknown prefix
     #[arg(long)]
     pub drop_unknown_prefix: bool,
@@ -265,37 +321,39 @@ pub struct DropCmd {
     pub drop_unknown_mapping: bool,
 }
 
-pub fn print_json(resp: &ShowConfigResponse) -> Result<(), Box<dyn Error>> {
-    println!("{}", serde_json::to_string(resp)?);
+pub fn print_json(configs: Vec<ShowConfigResponse>) -> Result<(), Box<dyn Error>> {
+    println!("{}", serde_json::to_string(&configs)?);
     Ok(())
 }
 
-pub fn print_tree(resp: &ShowConfigResponse) -> Result<(), Box<dyn Error>> {
+pub fn print_tree(configs: Vec<ShowConfigResponse>) -> Result<(), Box<dyn Error>> {
     let mut tree = TreeBuilder::new("NAT64 Configs".to_string());
 
-    for config in &resp.configs {
-        tree.begin_child(format!("Instance {}", config.instance));
+    for resp in &configs {
+        tree.begin_child(format!("Instance {}", resp.instance));
 
-        tree.begin_child("Prefixes".to_string());
-        for (idx, prefix) in config.prefixes.iter().enumerate() {
-            tree.add_empty_child(format!("{}: {:?}", idx, prefix.prefix));
-        }
-        tree.end_child();
-
-        tree.begin_child("Mappings".to_string());
-        for mapping in &config.mappings {
-            tree.add_empty_child(format!(
-                "IPv4: {:?} -> IPv6: {:?} (prefix: {})",
-                mapping.ipv4, mapping.ipv6, mapping.prefix_index
-            ));
-        }
-        tree.end_child();
-
-        if let Some(mtu) = &config.mtu {
-            tree.begin_child("MTU".to_string());
-            tree.add_empty_child(format!("IPv4: {}", mtu.ipv4_mtu));
-            tree.add_empty_child(format!("IPv6: {}", mtu.ipv6_mtu));
+        if let Some(config) = &resp.config {
+            tree.begin_child("Prefixes".to_string());
+            for (idx, prefix) in config.prefixes.iter().enumerate() {
+                tree.add_empty_child(format!("{}: {:?}", idx, prefix.prefix));
+            }
             tree.end_child();
+
+            tree.begin_child("Mappings".to_string());
+            for mapping in &config.mappings {
+                tree.add_empty_child(format!(
+                    "IPv4: {:?} -> IPv6: {:?} (prefix: {})",
+                    mapping.ipv4, mapping.ipv6, mapping.prefix_index
+                ));
+            }
+            tree.end_child();
+
+            if let Some(mtu) = &config.mtu {
+                tree.begin_child("MTU".to_string());
+                tree.add_empty_child(format!("IPv4: {}", mtu.ipv4_mtu));
+                tree.add_empty_child(format!("IPv6: {}", mtu.ipv6_mtu));
+                tree.end_child();
+            }
         }
 
         tree.end_child();

--- a/modules/nat64/controlplane/nat64pb/meson.build
+++ b/modules/nat64/controlplane/nat64pb/meson.build
@@ -1,4 +1,5 @@
 proto_dir = meson.current_source_dir()
+root_dir = meson.project_source_root()
 proto_files = [join_paths(proto_dir, 'nat64.proto')]
 
 protoc_gen = custom_target(
@@ -7,11 +8,13 @@ protoc_gen = custom_target(
     input: proto_files,
     command: [
         protoc,
-        '-I', meson.current_source_dir(),
-        '--go_out=paths=source_relative:' + meson.current_source_dir(),
-        '--go-grpc_out=paths=source_relative:' + meson.current_source_dir(),
+        '-I', proto_dir,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + proto_dir,
+        '--go-grpc_out=paths=source_relative:' + proto_dir,
         '@INPUT@',
     ],
+    depends: [common_protoc_gen],
     build_by_default: true,
 )
 nat64_protoc_gen = protoc_gen

--- a/modules/nat64/controlplane/nat64pb/nat64.proto
+++ b/modules/nat64/controlplane/nat64pb/nat64.proto
@@ -2,10 +2,15 @@ syntax = "proto3";
 
 package nat64pb;
 
+import "common/proto/target.proto";
+
 option go_package = "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb;nat64pb";
 
 // NAT64Service is a control-plane service for managing NAT64 module
 service NAT64Service {
+	rpc ListConfigs(ListConfigsRequest) returns (ListConfigsResponse) {
+	}
+
 	// ShowConfig returns the current configuration of the NAT64 module
 	rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse) {
 	}
@@ -38,18 +43,24 @@ service NAT64Service {
 	}
 }
 
-// TargetModule specifies the target module for configuration operations
-message TargetModule {
-	// ModuleName is the name of the module to configure
-	string module_name = 1;
-	// Instances specifies dataplane instances that should be affected
-	// Empty means all instances
-	repeated uint32 instances = 2;
+// Represents config names of dataplane instances
+message InstanceConfigs {
+	// Dataplane instance
+	uint32 instance = 1;
+	repeated string configs = 2;
+}
+
+message ListConfigsRequest {
+}
+
+// ListConfigsResponse contains existing configurations per dataplane instance.
+message ListConfigsResponse {
+	repeated InstanceConfigs instance_configs = 1;
 }
 
 // ShowConfigRequest requests the current configuration
 message ShowConfigRequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 }
 
 // MTUConfig contains MTU configuration values
@@ -70,23 +81,22 @@ message Mapping {
 	uint32 prefix_index = 3; // Index of the used prefix
 }
 
-// InstanceConfig represents configuration for a single dataplane instance
-message InstanceConfig {
-	// Dataplane instance
-	uint32 instance = 1;
-	repeated Prefix prefixes = 2;
-	repeated Mapping mappings = 3;
-	MTUConfig mtu = 4;
+// Config represents configuration for a single dataplane instance
+message Config {
+	repeated Prefix prefixes = 1;
+	repeated Mapping mappings = 2;
+	MTUConfig mtu = 3;
 }
 
 // ShowConfigResponse contains the current configuration
 message ShowConfigResponse {
-	repeated InstanceConfig configs = 1;
+	uint32 instance = 1;
+	Config config = 2;
 }
 
 // AddPrefixRequest specifies a prefix to add
 message AddPrefixRequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 	bytes prefix = 2; // 12-byte IPv6 prefix
 }
 
@@ -95,7 +105,7 @@ message AddPrefixResponse {
 
 // RemovePrefixRequest specifies a prefix to remove
 message RemovePrefixRequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 	bytes prefix = 2; // 12-byte IPv6 prefix
 }
 
@@ -104,7 +114,7 @@ message RemovePrefixResponse {
 
 // AddMappingRequest specifies an IPv4-IPv6 mapping to add
 message AddMappingRequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 	bytes ipv4 = 2;		 // IPv4 address in network byte order
 	bytes ipv6 = 3;		 // IPv6 address (16 bytes)
 	uint32 prefix_index = 4; // Index of the used prefix
@@ -115,7 +125,7 @@ message AddMappingResponse {
 
 // RemoveMappingRequest specifies an IPv4-IPv6 mapping to remove
 message RemoveMappingRequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 	bytes ipv4 = 2; // IPv4 address to remove mapping for
 }
 
@@ -124,7 +134,7 @@ message RemoveMappingResponse {
 
 // SetMTURequest specifies MTU values to set
 message SetMTURequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 	MTUConfig mtu = 2;
 }
 
@@ -133,7 +143,7 @@ message SetMTUResponse {
 
 // SetDropUnknownRequest specifies drop_unknown flags to set
 message SetDropUnknownRequest {
-	TargetModule target = 1;
+	commonpb.TargetModule target = 1;
 	bool drop_unknown_prefix = 2;  // Drop packets with unknown prefix
 	bool drop_unknown_mapping = 3; // Drop packets with unknown mapping
 }


### PR DESCRIPTION
## Refactor NAT64 CLI to handle single instance operations

This change simplifies the NAT64 module by moving instance iteration from the service layer to the CLI, enabling more granular control and better error handling.

### Key Changes

**CLI Updates:**
- Changed `--mod` flag to `--cfg` for consistency
- Made `--instances` required for configuration commands
- Updated CLI to iterate through instances and make individual service calls
- Added support for common target proto with proper validation

**Service Simplification:**
- Removed bulk instance processing from service methods
- Each service call now handles exactly one instance
- Simplified `ShowConfig` to return single config instead of array
- Removed `getInstances()` helper method
- Updated `updateModuleConfigs()` to `updateModuleConfig()` for single instance

**Protocol Changes:**
- Added `ListConfigsRequest` for multi-instance queries
- Updated build configuration to include common target proto
- Integrated `commonpb.TargetModule` for consistent target validation

This refactoring improves error isolation, makes the API more predictable, and provides better control over individual instance operations.