### PR TITLE
fix(sock-send): The comparison statement was incorrectly written as a…

### DIFF
--- a/sock-send/main.c
+++ b/sock-send/main.c
@@ -108,7 +108,7 @@ read_data(int fd, u_char *buf, ssize_t len) {
 		case 0:
 			return -1;
 		case -1:
-			if ((errno == EAGAIN) || (errno = EWOULDBLOCK)) {
+			if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
 				usleep(1000);
 			} else {
 				return -1;


### PR DESCRIPTION
source code below
```C
int
read_data(int fd, u_char *buf, ssize_t len) {
	ssize_t ret = 0;
	while (len > 0 && !done) {
		ret = read(fd, buf, len);
		switch (ret) {
		case 0:
			return -1;
		case -1:
			if ((errno == EAGAIN) || (errno = EWOULDBLOCK)) {
				usleep(1000);
			} else {
				return -1;
			}
			break;
		default:
			len -= ret;
			buf += ret;
			break;
		}
	}

	return 0;
}
```
should be written as *errno == EWOULDBLOCK*