### PR TITLE
NCM IPv6 support in filter

### DIFF
--- a/common/network.h
+++ b/common/network.h
@@ -7,13 +7,21 @@ struct ether_addr {
 };
 
 struct net6 {
-	uint64_t addr_hi;
-	uint64_t addr_lo;
-	uint64_t mask_hi;
-	uint64_t mask_lo;
+	// IPv6 address in the host byte order.
+	uint8_t ip[16];
+
+	// Network prefix length for 8 higher bytes.
+	uint8_t pref_hi;
+
+	// Network prefix length for 8 lower bytes.
+	uint8_t pref_lo;
 };
 
 struct net4 {
+	// IPv4 address in the host byte order.
 	uint32_t addr;
+
+	// IPv4 network mask in the host byte order.
+	// Only prefix-consecutive masks are supported.
 	uint32_t mask;
 };

--- a/common/network.h
+++ b/common/network.h
@@ -6,6 +6,8 @@ struct ether_addr {
 	uint8_t addr[6];
 };
 
+#define NET6_LEN 16
+
 struct net6 {
 	// IPv6 address in the host byte order.
 	uint8_t ip[16];

--- a/filter/attribute.h
+++ b/filter/attribute.h
@@ -4,6 +4,7 @@
 #include "lib/dataplane/packet/packet.h"
 
 #include "attribute/net4.h"
+#include "attribute/net6.h"
 #include "attribute/port.h"
 #include "attribute/proto.h"
 #include "attribute/vlan.h"
@@ -88,7 +89,15 @@ static const struct filter_attribute attribute_net4_dst = {
 // IPv6
 ////////////////////////////////////////////////////////////////////////////////
 
-// TODO
+// IPv6 source address
+static const struct filter_attribute attribute_net6_src = {
+	init_net6_src, lookup_net6_src, free_net6
+};
+
+// IPv6 destination address
+static const struct filter_attribute attribute_net6_dst = {
+	init_net6_dst, lookup_net6_dst, free_net6
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 // VLAN

--- a/filter/attribute/net6.h
+++ b/filter/attribute/net6.h
@@ -1,0 +1,382 @@
+#pragma once
+
+#include "../helper.h"
+#include "../rule.h"
+#include "common/lpm.h"
+#include "common/range_collector.h"
+
+#include "util.h"
+
+#include "common/registry.h"
+#include "dataplane/packet/packet.h"
+
+#include <endian.h>
+#include <rte_ip.h>
+#include <rte_mbuf.h>
+
+////////////////////////////////////////////////////////////////////////////////
+
+typedef void (*action_get_net6_func)(
+	const struct filter_rule *rule, struct net6 **net, uint32_t *count
+);
+
+static inline void
+action_get_net6_src(
+	const struct filter_rule *rule, struct net6 **net, uint32_t *count
+) {
+	*net = rule->net6.srcs;
+	*count = rule->net6.src_count;
+}
+
+static inline void
+action_get_net6_dst(
+	const struct filter_rule *action, struct net6 **net, uint32_t *count
+) {
+	*net = action->net6.dsts;
+	*count = action->net6.dst_count;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct net6_part {
+	// Bytes in host byte order
+	uint64_t bytes;
+
+	// Bytes in host byte order
+	uint64_t mask;
+};
+
+typedef struct net6_part (*net6_get_part_func)(struct net6 *net);
+
+static struct net6_part
+net6_get_hi_part(struct net6 *net) {
+	struct net6_part part;
+	part.bytes = 0;
+	for (size_t i = 0, shift = 0; i < 8; ++i, shift += 8) {
+		part.bytes |= ((uint64_t)net->ip[8 + i]) << shift;
+	}
+	part.mask = -1ull << (64 - net->pref_hi);
+	part.mask = be64toh(part.mask);
+	part.bytes &= part.mask;
+	return part;
+}
+
+static struct net6_part
+net6_get_lo_part(struct net6 *net) {
+	struct net6_part part;
+	part.bytes = 0;
+	for (size_t i = 0, shift = 0; i < 8; ++i, shift += 8) {
+		part.bytes |= ((uint64_t)net->ip[i]) << shift;
+	}
+	part.mask = -1ull << (64 - net->pref_lo);
+	part.mask = be64toh(part.mask);
+	part.bytes &= part.mask;
+	return part;
+}
+////////////////////////////////////////////////////////////////////////////////
+
+static inline void
+net6_collect_values(
+	struct net6 *start,
+	uint32_t count,
+	net6_get_part_func get_part,
+	struct lpm *lpm,
+	struct value_table *table
+) {
+	for (struct net6 *net6 = start; net6 < start + count; ++net6) {
+		struct net6_part part = get_part(net6);
+		uint64_t to = part.bytes | ~part.mask;
+		lpm8_collect_values(
+			lpm,
+			(uint8_t *)&part.bytes,
+			(uint8_t *)&to,
+			lpm_collect_value_iterator,
+			table
+		);
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+static inline void
+net6_collect_registry(
+	struct net6 *start,
+	uint32_t count,
+	net6_get_part_func get_part,
+	struct lpm *lpm,
+	struct value_registry *registry
+) {
+	for (struct net6 *net6 = start; net6 < start + count; ++net6) {
+		struct net6_part part = get_part(net6);
+		uint64_t to = part.bytes | ~part.mask;
+		lpm8_collect_values(
+			lpm,
+			(uint8_t *)&part.bytes,
+			(uint8_t *)&to,
+			lpm_collect_registry_iterator,
+			registry
+		);
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+static int
+collect_net6_values(
+	struct memory_context *memory_context,
+	const struct filter_rule *rules,
+	uint32_t count,
+	action_get_net6_func get_net6,
+	net6_get_part_func get_part,
+	struct lpm *lpm,
+	struct value_registry *registry
+) {
+	struct range_collector collector;
+	if (range_collector_init(&collector, memory_context))
+		goto error;
+
+	for (const struct filter_rule *rule = rules; rule < rules + count;
+	     ++rule) {
+
+		if (rule->net6.src_count == 0 && rule->net6.dst_count == 0) {
+			continue;
+		}
+
+		struct net6 *nets;
+		uint32_t net_count;
+		get_net6(rule, &nets, &net_count);
+
+		for (struct net6 *net6 = nets; net6 < nets + net_count;
+		     ++net6) {
+			struct net6_part part = get_part(net6);
+			if (range8_collector_add(
+				    &collector,
+				    (uint8_t *)&part.bytes,
+				    __builtin_popcountll(part.mask)
+			    ))
+				goto error_collector;
+		}
+	}
+	if (lpm_init(lpm, memory_context)) {
+		goto error_lpm;
+	}
+	if (range_collector_collect(&collector, 8, lpm)) {
+		goto error_collector;
+	}
+
+	struct value_table table;
+	if (value_table_init(&table, memory_context, 1, collector.count))
+		goto error_vtab;
+
+	for (const struct filter_rule *action = rules; action < rules + count;
+	     ++action) {
+		if (action->net6.dst_count == 0 &&
+		    action->net6.src_count == 0) {
+			continue;
+		}
+
+		value_table_new_gen(&table);
+
+		struct net6 *nets;
+		uint32_t net_count;
+		get_net6(action, &nets, &net_count);
+
+		net6_collect_values(nets, net_count, get_part, lpm, &table);
+	}
+
+	value_table_compact(&table);
+	lpm8_remap(lpm, &table);
+	lpm8_compact(lpm);
+
+	if (value_registry_init(registry, memory_context))
+		goto error_reg;
+
+	for (const struct filter_rule *action = rules; action < rules + count;
+	     ++action) {
+		if (action->net6.dst_count == 0 &&
+		    action->net6.src_count == 0) {
+			continue;
+		}
+
+		value_registry_start(registry);
+
+		struct net6 *nets;
+		uint32_t net_count;
+		get_net6(action, &nets, &net_count);
+
+		net6_collect_registry(nets, net_count, get_part, lpm, registry);
+	}
+
+	value_table_free(&table);
+	return 0;
+
+error_reg:
+	value_table_free(&table);
+error_collector:
+	range_collector_free(&collector, 8);
+error_lpm:
+	lpm_free(lpm);
+
+error_vtab:
+
+error:
+	return -1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+struct net6_classifier {
+	struct lpm hi;
+	struct lpm lo;
+	struct value_table comb;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Initialization
+////////////////////////////////////////////////////////////////////////////////
+
+static inline int
+init_net6(
+	struct value_registry *registry,
+	action_get_net6_func get_net6,
+	void **data,
+	const struct filter_rule *rules,
+	size_t actions_count,
+	struct memory_context *memory_context
+) {
+	struct net6_classifier *net6 =
+		memory_balloc(memory_context, sizeof(struct net6_classifier));
+	*data = net6;
+
+	struct value_registry hi_registry;
+	int res = collect_net6_values(
+		memory_context,
+		rules,
+		actions_count,
+		get_net6,
+		net6_get_hi_part,
+		&net6->hi,
+		&hi_registry
+	);
+	if (res < 0) {
+		goto free;
+	}
+
+	struct value_registry lo_registry;
+	res = collect_net6_values(
+		memory_context,
+		rules,
+		actions_count,
+		get_net6,
+		net6_get_lo_part,
+		&net6->lo,
+		&lo_registry
+	);
+	if (res < 0) {
+		goto free;
+	}
+
+	res = merge_and_collect_registry(
+		memory_context,
+		&hi_registry,
+		&lo_registry,
+		&net6->comb,
+		registry
+	);
+
+free:
+	value_registry_free(&hi_registry);
+	value_registry_free(&lo_registry);
+
+	return res;
+}
+
+// Allows to initialize attribute for IPv6 destination address.
+static inline int
+init_net6_src(
+	struct value_registry *registry,
+	void **data,
+	const struct filter_rule *rules,
+	size_t actions_count,
+	struct memory_context *memory_context
+) {
+	return init_net6(
+		registry,
+		action_get_net6_src,
+		data,
+		rules,
+		actions_count,
+		memory_context
+	);
+}
+
+// Allows to initialize attribute for IPv6 source address.
+static inline int
+init_net6_dst(
+	struct value_registry *registry,
+	void **data,
+	const struct filter_rule *rules,
+	size_t actions_count,
+	struct memory_context *memory_context
+) {
+	return init_net6(
+		registry,
+		action_get_net6_dst,
+		data,
+		rules,
+		actions_count,
+		memory_context
+	);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Lookup
+////////////////////////////////////////////////////////////////////////////////
+
+// Allows to lookup classifier for packet IPv6 destination address.
+static inline uint32_t
+lookup_net6_dst(struct packet *packet, void *data) {
+	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+
+	struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
+		mbuf, struct rte_ipv6_hdr *, packet->network_header.offset
+	);
+
+	struct net6_classifier *c = (struct net6_classifier *)data;
+	uint32_t hi = lpm8_lookup(&c->hi, (const uint8_t *)ipv6_hdr->dst_addr);
+	uint32_t lo =
+		lpm8_lookup(&c->lo, (const uint8_t *)ipv6_hdr->dst_addr + 8);
+
+	return value_table_get(&c->comb, hi, lo);
+}
+
+// Allows to lookup classifier for packet IPv6 destination address.
+static inline uint32_t
+lookup_net6_src(struct packet *packet, void *data) {
+	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+
+	struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
+		mbuf, struct rte_ipv6_hdr *, packet->network_header.offset
+	);
+
+	struct net6_classifier *c = (struct net6_classifier *)data;
+	uint32_t hi = lpm8_lookup(&c->hi, (const uint8_t *)ipv6_hdr->src_addr);
+	uint32_t lo =
+		lpm8_lookup(&c->lo, (const uint8_t *)ipv6_hdr->src_addr + 8);
+
+	return value_table_get(&c->comb, hi, lo);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Free
+////////////////////////////////////////////////////////////////////////////////
+
+// Allows to free data for IPv6 classification.
+static inline void
+free_net6(void *data, struct memory_context *memory_context) {
+	(void)memory_context;
+	struct net6_classifier *c = (struct net6_classifier *)data;
+	lpm_free(&c->lo);
+	lpm_free(&c->hi);
+	value_table_free(&c->comb);
+}

--- a/filter/attribute/net6.h
+++ b/filter/attribute/net6.h
@@ -52,8 +52,8 @@ static struct net6_part
 net6_get_hi_part(struct net6 *net) {
 	struct net6_part part;
 	part.bytes = 0;
-	for (size_t i = 0, shift = 0; i < 8; ++i, shift += 8) {
-		part.bytes |= ((uint64_t)net->ip[8 + i]) << shift;
+	for (size_t i = 0, shift = 0; i < NET6_LEN / 2; ++i, shift += 8) {
+		part.bytes |= ((uint64_t)net->ip[NET6_LEN / 2 + i]) << shift;
 	}
 	part.mask = -1ull << (64 - net->pref_hi);
 	part.mask = be64toh(part.mask);
@@ -65,7 +65,7 @@ static struct net6_part
 net6_get_lo_part(struct net6 *net) {
 	struct net6_part part;
 	part.bytes = 0;
-	for (size_t i = 0, shift = 0; i < 8; ++i, shift += 8) {
+	for (size_t i = 0, shift = 0; i < NET6_LEN / 2; ++i, shift += 8) {
 		part.bytes |= ((uint64_t)net->ip[i]) << shift;
 	}
 	part.mask = -1ull << (64 - net->pref_lo);

--- a/filter/attribute/util.h
+++ b/filter/attribute/util.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "common/registry.h"
+#include "common/value.h"
+
+////////////////////////////////////////////////////////////////////////////////
+
+static inline int
+lpm_collect_value_iterator(uint32_t value, void *data) {
+	struct value_table *table = (struct value_table *)data;
+	return value_table_touch(table, 0, value);
+}
+
+static inline int
+lpm_collect_registry_iterator(uint32_t value, void *data) {
+	struct value_registry *registry = (struct value_registry *)data;
+	return value_registry_collect(registry, value);
+}

--- a/filter/filter.h
+++ b/filter/filter.h
@@ -79,6 +79,8 @@
 // Also, user specifies function to free data allocated by user in the
 // initialization function.
 
+////////////////////////////////////////////////////////////////////////////////
+
 #pragma once
 
 #include "attribute.h"

--- a/filter/ipfw.c
+++ b/filter/ipfw.c
@@ -65,14 +65,24 @@ typedef void (*net6_get_part_func)(
 
 static void
 net6_get_hi_part(struct net6 *net, uint64_t *addr, uint64_t *mask) {
-	*addr = net->addr_hi;
-	*mask = net->mask_hi;
+	*addr = 0;
+	for (size_t i = 0, shift = 0; i < 8; ++i, shift += 8) {
+		*addr |= ((uint64_t)net->ip[8 + i]) << shift;
+	}
+	*mask = -1ull << (64 - net->pref_hi);
+	*mask = be64toh(*mask);
+	*addr &= *mask;
 }
 
 static void
 net6_get_lo_part(struct net6 *net, uint64_t *addr, uint64_t *mask) {
-	*addr = net->addr_lo;
-	*mask = net->mask_lo;
+	*addr = 0;
+	for (size_t i = 0, shift = 0; i < 8; ++i, shift += 8) {
+		*addr |= ((uint64_t)net->ip[8 + i]) << shift;
+	}
+	*mask = -1ull << (64 - net->pref_lo);
+	*mask = be64toh(*mask);
+	*addr &= *mask;
 }
 
 static inline int

--- a/filter/ipfw.c
+++ b/filter/ipfw.c
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 
 #include "common/memory.h"
+#include "common/network.h"
 #include "common/range_collector.h"
 #include "common/registry.h"
 #include "common/value.h"
@@ -66,8 +67,8 @@ typedef void (*net6_get_part_func)(
 static void
 net6_get_hi_part(struct net6 *net, uint64_t *addr, uint64_t *mask) {
 	*addr = 0;
-	for (size_t i = 0, shift = 0; i < 8; ++i, shift += 8) {
-		*addr |= ((uint64_t)net->ip[8 + i]) << shift;
+	for (size_t i = 0, shift = 0; i < NET6_LEN / 2; ++i, shift += 8) {
+		*addr |= ((uint64_t)net->ip[NET6_LEN / 2 + i]) << shift;
 	}
 	*mask = -1ull << (64 - net->pref_hi);
 	*mask = be64toh(*mask);
@@ -77,8 +78,8 @@ net6_get_hi_part(struct net6 *net, uint64_t *addr, uint64_t *mask) {
 static void
 net6_get_lo_part(struct net6 *net, uint64_t *addr, uint64_t *mask) {
 	*addr = 0;
-	for (size_t i = 0, shift = 0; i < 8; ++i, shift += 8) {
-		*addr |= ((uint64_t)net->ip[8 + i]) << shift;
+	for (size_t i = 0, shift = 0; i < NET6_LEN / 2; ++i, shift += 8) {
+		*addr |= ((uint64_t)net->ip[NET6_LEN / 2 + i]) << shift;
 	}
 	*mask = -1ull << (64 - net->pref_lo);
 	*mask = be64toh(*mask);

--- a/filter/rule.h
+++ b/filter/rule.h
@@ -11,6 +11,8 @@ struct filter_net6 {
 	uint32_t dst_count;
 
 	// IPv6 + mask in little-endian
+	// both masks must be prefix-consecutive
+	// (like 11..100..0)
 	struct net6 *srcs;
 	struct net6 *dsts;
 };
@@ -20,6 +22,8 @@ struct filter_net4 {
 	uint32_t dst_count;
 
 	// IPv4 + mask in little-endian
+	// mask must be prefix-consecutive
+	// (like 11..100..0)
 	struct net4 *srcs;
 	struct net4 *dsts;
 };

--- a/filter/tests/basic_net6.c
+++ b/filter/tests/basic_net6.c
@@ -1,0 +1,400 @@
+#include "attribute.h"
+#include "filter.h"
+#include "utils.h"
+#include <assert.h>
+
+////////////////////////////////////////////////////////////////////////////////
+
+void
+query_packet_and_expect_action(
+	struct filter *filter,
+	uint8_t src_ip[16],
+	uint8_t dst_ip[16],
+	uint32_t action
+) {
+	struct packet packet = make_packet_net6(src_ip, dst_ip, 100, 200);
+	query_filter_and_expect_action(filter, &packet, action);
+	free_packet(&packet);
+}
+
+void
+query_packet_and_expect_no_actions(
+	struct filter *filter, uint8_t src_ip[16], uint8_t dst_ip[16]
+) {
+	struct packet packet = make_packet_net6(src_ip, dst_ip, 100, 200);
+	query_filter_and_expect_no_actions(filter, &packet);
+	free_packet(&packet);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void
+make_addr(uint8_t *ip, uint8_t big, uint8_t c1, uint8_t low, uint8_t c2) {
+	memset(ip, 0, 16);
+	for (uint8_t i = 0; i < c2; ++i) {
+		if (i % 2 == 0) {
+			ip[8 - i / 2 - 1] = low << 4;
+		} else {
+			ip[8 - i / 2 - 1] |= low;
+		}
+	}
+	for (uint8_t i = 0; i < c1; ++i) {
+		if (i % 2 == 0) {
+			ip[16 - i / 2 - 1] = big << 4;
+		} else {
+			ip[16 - i / 2 - 1] |= big;
+		}
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void
+test1(void *memory) {
+	// init memory
+	struct block_allocator allocator;
+	block_allocator_init(&allocator);
+	block_allocator_put_arena(&allocator, memory, 1 << 24);
+
+	struct memory_context mctx;
+	int res = memory_context_init(&mctx, "test", &allocator);
+	assert(res == 0);
+
+	// build rules
+	struct filter_rule_builder builder;
+	builder_init(&builder);
+	struct net6 net = {
+		.ip = {},
+		.pref_hi = 40,
+		.pref_lo = 24,
+	};
+	memset(net.ip, 0xaa, 8);
+	memset(net.ip + 8, 0xbb, 8);
+	builder_add_net6_dst(&builder, net);
+	struct filter_rule rule = build_rule(&builder, 1);
+	const struct filter_rule rules[1] = {rule};
+
+	// init filter
+	const struct filter_attribute *attrs[1] = {&attribute_net6_dst};
+	struct filter filter;
+	res = filter_init(&filter, attrs, 1, rules, 1, &mctx);
+	assert(res == 0);
+
+	// query packet 1
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0xaa, 8);
+		memset(dst + 8, 0xbb, 8);
+		query_packet_and_expect_action(&filter, src, dst, 1);
+	}
+
+	// query packet 2
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0xbb, 16);
+		query_packet_and_expect_no_actions(&filter, src, dst);
+
+		memset(dst, 0xaa, 16);
+		query_packet_and_expect_no_actions(&filter, src, dst);
+	}
+
+	// query packet 3
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0, 16);
+		dst[15] = dst[14] = dst[13] = dst[12] = dst[11] = 0xbb;
+		dst[5] = 0xaa;
+		dst[6] = dst[7] = 0xaa;
+		query_packet_and_expect_action(&filter, src, dst, 1);
+	}
+
+	// query packet 4
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0xaa, 8);
+		memset(dst + 8, 0xbb, 8);
+		dst[11] = 0xb0;
+		query_packet_and_expect_no_actions(&filter, src, dst);
+	}
+
+	// query packet 5
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0xaa, 8);
+		memset(dst + 8, 0xbb, 8);
+		dst[10] = 0xb0;
+		query_packet_and_expect_action(&filter, src, dst, 1);
+	}
+
+	// query packet 6
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0xaa, 8);
+		memset(dst + 8, 0xbb, 8);
+		dst[5] = 0xa0;
+		query_packet_and_expect_no_actions(&filter, src, dst);
+	}
+
+	// query packet 7
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0xaa, 8);
+		memset(dst + 8, 0xbb, 8);
+		dst[6] = 0xa0;
+		query_packet_and_expect_no_actions(&filter, src, dst);
+	}
+
+	// query packet 8
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0xaa, 8);
+		memset(dst + 8, 0xbb, 8);
+		dst[4] = 0xa0;
+		query_packet_and_expect_action(&filter, src, dst, 1);
+	}
+
+	// query packet 9
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0xaa, 8);
+		memset(dst + 8, 0xbb, 8);
+		memset(dst, 0, 5);
+		memset(dst + 8, 0, 3);
+		query_packet_and_expect_action(&filter, src, dst, 1);
+	}
+
+	filter_free(&filter);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void
+test2(void *memory) {
+	// init memory
+	struct block_allocator allocator;
+	block_allocator_init(&allocator);
+	block_allocator_put_arena(&allocator, memory, 1 << 24);
+
+	struct memory_context mctx;
+	int res = memory_context_init(&mctx, "test", &allocator);
+	assert(res == 0);
+
+	// build rules
+	struct filter_rule_builder builder;
+	builder_init(&builder);
+	struct net6 net = {
+		.ip = {},
+		.pref_hi = 36,
+		.pref_lo = 20,
+	};
+	memset(net.ip, 0xaa, 8);
+	memset(net.ip + 8, 0xbb, 8);
+	builder_add_net6_dst(&builder, net);
+	struct filter_rule rule = build_rule(&builder, 1);
+	const struct filter_rule rules[1] = {rule};
+
+	// init filter
+	const struct filter_attribute *attrs[1] = {&attribute_net6_dst};
+	struct filter filter;
+	res = filter_init(&filter, attrs, 1, rules, 1, &mctx);
+	assert(res == 0);
+
+	// query packet 1
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0, 5);
+		dst[5] = 0xa0;
+		memset(dst + 6, 0xaa, 2);
+		memset(dst + 8, 0, 3);
+		dst[11] = 0xb0;
+		memset(dst + 12, 0xbb, 4);
+		query_packet_and_expect_action(&filter, src, dst, 1);
+	}
+
+	// query packet 2
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0, 5);
+		dst[5] = 0x90;
+		memset(dst + 6, 0xaa, 2);
+		memset(dst + 8, 0, 3);
+		dst[11] = 0xb0;
+		memset(dst + 12, 0xbb, 4);
+		query_packet_and_expect_no_actions(&filter, src, dst);
+	}
+
+	// query packet 3
+	{
+		uint8_t src[16] = {};
+		uint8_t dst[16];
+		memset(dst, 0, 5);
+		dst[5] = 0xa0;
+		memset(dst + 6, 0xaa, 2);
+		memset(dst + 8, 0, 3);
+		dst[11] = 0xf0;
+		memset(dst + 12, 0xbb, 4);
+		query_packet_and_expect_no_actions(&filter, src, dst);
+	}
+
+	filter_free(&filter);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void
+test3(void *memory) {
+	// init memory
+	struct block_allocator allocator;
+	block_allocator_init(&allocator);
+	block_allocator_put_arena(&allocator, memory, 1 << 24);
+
+	struct memory_context mctx;
+	int res = memory_context_init(&mctx, "test", &allocator);
+	assert(res == 0);
+
+	// build rules
+
+	// rule1
+	struct filter_rule rule1;
+	struct filter_rule_builder builder1;
+	{
+		builder_init(&builder1);
+
+		// add IPv6 source address rule
+		struct net6 src_net = {
+			.ip = {},
+			.pref_hi = 36,
+			.pref_lo = 20,
+		};
+		memset(src_net.ip, 0xaa, 8);
+		memset(src_net.ip + 8, 0xbb, 8);
+		builder_add_net6_src(&builder1, src_net);
+
+		// add IPv6 destination address rule
+		struct net6 dst_net = {
+			.ip = {},
+			.pref_hi = 40,
+			.pref_lo = 24,
+		};
+		memset(dst_net.ip, 0xaa, 8);
+		memset(dst_net.ip + 8, 0xbb, 8);
+		builder_add_net6_dst(&builder1, dst_net);
+
+		rule1 = build_rule(&builder1, 1);
+	}
+
+	struct filter_rule rule2;
+	struct filter_rule_builder builder2;
+	{
+		builder_init(&builder2);
+
+		// add IPv6 source address rule
+		struct net6 src_net = {
+			.ip = {},
+			.pref_hi = 40,
+			.pref_lo = 24,
+		};
+		memset(src_net.ip, 0xaa, 8);
+		memset(src_net.ip + 8, 0xbb, 8);
+		builder_add_net6_src(&builder2, src_net);
+
+		// add IPv6 destination address rule
+		struct net6 dst_net = {
+			.ip = {},
+			.pref_hi = 36,
+			.pref_lo = 20,
+		};
+		memset(dst_net.ip, 0xaa, 8);
+		memset(dst_net.ip + 8, 0xbb, 8);
+		builder_add_net6_dst(&builder2, dst_net);
+
+		rule2 = build_rule(&builder2, 2);
+	}
+
+	const struct filter_rule rules[2] = {rule1, rule2};
+
+	// init filter
+	const struct filter_attribute *attrs[2] = {
+		&attribute_net6_src, &attribute_net6_dst
+	};
+	struct filter filter;
+	res = filter_init(&filter, attrs, 2, rules, 2, &mctx);
+	assert(res == 0);
+
+	// query packet 1
+	{
+		uint8_t src[16];
+		make_addr(src, 0xb, 10, 0xa, 6);
+
+		uint8_t dst[16];
+		make_addr(dst, 0xb, 10, 0xa, 6);
+
+		query_packet_and_expect_action(&filter, src, dst, 1);
+	}
+
+	// query packet 2
+	{
+		uint8_t src[16];
+		make_addr(src, 0xb, 10, 0xa, 6);
+
+		uint8_t dst[16];
+		make_addr(dst, 0xb, 9, 0xa, 5);
+
+		query_packet_and_expect_action(&filter, src, dst, 2);
+	}
+
+	// query packet 3
+	{
+		uint8_t src[16];
+		make_addr(src, 0xb, 9, 0xa, 6);
+
+		uint8_t dst[16];
+		make_addr(dst, 0xb, 10, 0xa, 6);
+
+		query_packet_and_expect_action(&filter, src, dst, 1);
+	}
+
+	// query packet 4
+	{
+		uint8_t src[16];
+		make_addr(src, 0xb, 9, 0xa, 5);
+
+		uint8_t dst[16];
+		make_addr(dst, 0xb, 9, 0xa, 5);
+
+		query_packet_and_expect_no_actions(&filter, src, dst);
+	}
+
+	filter_free(&filter);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+int
+main() {
+	void *memory = malloc(1 << 24); // 16MB
+
+	puts("test1...");
+	test1(memory);
+
+	puts("test2...");
+	test2(memory);
+
+	puts("test3...");
+	test3(memory);
+
+	puts("OK");
+
+	return 0;
+}

--- a/filter/tests/basic_net6.c
+++ b/filter/tests/basic_net6.c
@@ -395,5 +395,7 @@ main() {
 
 	puts("OK");
 
+	free(memory);
+
 	return 0;
 }

--- a/filter/tests/meson.build
+++ b/filter/tests/meson.build
@@ -13,7 +13,6 @@ test('basic_ports', test_filter_basic_ports, suite: ['filter'])
 
 # test basic net4
 test_filter_basic_net4 = executable('basic_net4',
-  
 ['basic_net4.c'],
   c_args: yanet_test_c_args,
   link_args: yanet_link_args,
@@ -21,6 +20,16 @@ test_filter_basic_net4 = executable('basic_net4',
   link_language: 'c'
 )
 test('basic_net4', test_filter_basic_net4, suite: ['filter'])
+
+# test basic net6
+test_filter_basic_net6 = executable('basic_net6',
+['basic_net6.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: test_deps,
+  link_language: 'c'
+)
+test('basic_net6', test_filter_basic_net6, suite: ['filter'])
 
 # test corner cases
 test_filter_corner = executable(

--- a/filter/utils/utils.c
+++ b/filter/utils/utils.c
@@ -85,8 +85,8 @@ make_mbuf(
 // IPv6 in host byte order
 static struct rte_mbuf *
 make_mbuf_net6(
-	const uint8_t src_ip[16],
-	const uint8_t dst_ip[16],
+	const uint8_t src_ip[NET6_LEN],
+	const uint8_t dst_ip[NET6_LEN],
 	uint16_t src_port,
 	uint16_t dst_port
 ) {
@@ -123,9 +123,9 @@ make_mbuf_net6(
 	struct rte_ipv6_hdr *ip = (struct rte_ipv6_hdr *)(eth + 1);
 	ip->proto = IPPROTO_UDP;
 	ip->payload_len = rte_cpu_to_be_16(sizeof(struct rte_udp_hdr));
-	for (size_t i = 0; i < 16; ++i) {
-		ip->src_addr[i] = src_ip[16 - i - 1];
-		ip->dst_addr[i] = dst_ip[16 - i - 1];
+	for (size_t i = 0; i < NET6_LEN; ++i) {
+		ip->src_addr[i] = src_ip[NET6_LEN - i - 1];
+		ip->dst_addr[i] = dst_ip[NET6_LEN - i - 1];
 	}
 
 	struct rte_udp_hdr *udp = (struct rte_udp_hdr *)(ip + 1);
@@ -165,8 +165,8 @@ make_packet(
 // IPv6 in host byte order
 struct packet
 make_packet_net6(
-	const uint8_t src_ip[16],
-	const uint8_t dst_ip[16],
+	const uint8_t src_ip[NET6_LEN],
+	const uint8_t dst_ip[NET6_LEN],
 	uint16_t src_port,
 	uint16_t dst_port
 ) {

--- a/filter/utils/utils.c
+++ b/filter/utils/utils.c
@@ -84,7 +84,7 @@ make_mbuf(
 
 // IPv6 in host byte order
 static struct rte_mbuf *
-make_mbuf_v6(
+make_mbuf_net6(
 	const uint8_t src_ip[16],
 	const uint8_t dst_ip[16],
 	uint16_t src_port,
@@ -171,7 +171,7 @@ make_packet_net6(
 	uint16_t dst_port
 ) {
 	struct packet packet;
-	packet.mbuf = make_mbuf_v6(src_ip, dst_ip, src_port, dst_port);
+	packet.mbuf = make_mbuf_net6(src_ip, dst_ip, src_port, dst_port);
 	assert(packet.mbuf != NULL);
 	int parse_result = parse_packet(&packet);
 	assert(parse_result == 0);

--- a/filter/utils/utils.h
+++ b/filter/utils/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/network.h"
 #include "dataplane/packet/packet.h"
 #include "rule.h"
 
@@ -25,8 +26,8 @@ make_packet(
 
 struct packet
 make_packet_net6(
-	const uint8_t src_ip[16],
-	const uint8_t dst_ip[16],
+	const uint8_t src_ip[NET6_LEN],
+	const uint8_t dst_ip[NET6_LEN],
 	uint16_t src_port,
 	uint16_t dst_port
 );

--- a/filter/utils/utils.h
+++ b/filter/utils/utils.h
@@ -23,6 +23,14 @@ make_packet(
 	uint16_t vlan
 );
 
+struct packet
+make_packet_net6(
+	const uint8_t src_ip[16],
+	const uint8_t dst_ip[16],
+	uint16_t src_port,
+	uint16_t dst_port
+);
+
 void
 query_filter_and_expect_action(
 	struct filter *filter, struct packet *packet, uint32_t expected_action


### PR DESCRIPTION
This PR brings support for non-consecutive IPv6 masks in filter.
For now, only masks of the following type are supported: _AB_, where _A_ and _B_ are prefix-consecutive masks of length 64.

This PR refers to issues [232](https://github.com/yanet-platform/yanet2/issues/232) and [233](https://github.com/yanet-platform/yanet2/issues/233).