### PR TITLE
refactor: aspect-oriented logging

### DIFF
--- a/common/proto/meson.build
+++ b/common/proto/meson.build
@@ -2,6 +2,7 @@ common_proto_dir = meson.current_source_dir()
 
 common_proto_files = [
     join_paths(common_proto_dir, 'target.proto'),
+    join_paths(common_proto_dir, 'options.proto'),
 ]
 
 # Generate protobuf files
@@ -10,6 +11,7 @@ common_protoc_gen = custom_target(
     output: [
         'target.pb.go',
         'target_grpc.pb.go',
+        'options.pb.go',
     ],
     input: common_proto_files,
     command: [
@@ -21,4 +23,3 @@ common_protoc_gen = custom_target(
     ],
     build_by_default: true,
 )
-

--- a/common/proto/options.proto
+++ b/common/proto/options.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package commonpb;
+
+import "google/protobuf/descriptor.proto";
+
+option go_package = "github.com/yanet-platform/yanet2/common/proto;commonpb";
+
+extend google.protobuf.FieldOptions {
+	// SkipLogging marks a field that should not be logged.
+	//
+	// When set to true, the field value will be replaced with "<skipped>"
+	// in log output.
+	bool skip_logging = 50001;
+}

--- a/controlplane/internal/gateway/function_service.go
+++ b/controlplane/internal/gateway/function_service.go
@@ -6,7 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/yanet-platform/yanet2/common/proto"
+	commonpb "github.com/yanet-platform/yanet2/common/proto"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/controlplane/ynpb"
 )
@@ -146,19 +146,9 @@ func (m *FunctionService) Update(
 		function.Chains = append(function.Chains, functionChain)
 	}
 
-	m.log.Infow("updating function",
-		zap.Uint32("instance", instance),
-		zap.Any("config", function),
-	)
-
 	if err := agent.UpdateFunction(function); err != nil {
 		return nil, fmt.Errorf("failed to update function: %w", err)
 	}
-
-	m.log.Infow("updated function",
-		zap.Uint32("instance", instance),
-		zap.Any("config", function),
-	)
 
 	return &ynpb.UpdateFunctionResponse{}, nil
 }

--- a/controlplane/internal/gateway/gateway.go
+++ b/controlplane/internal/gateway/gateway.go
@@ -111,6 +111,7 @@ func NewGateway(cfg *Config, shm *ffi.SharedMemory, options ...GatewayOption) *G
 	}
 
 	server := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(xgrpc.AccessLogInterceptor(log)),
 		grpc.ForceServerCodecV2(proxy.Codec()),
 		grpc.UnknownServiceHandler(
 			proxy.TransparentHandler(director),

--- a/controlplane/internal/gateway/pipeline_service.go
+++ b/controlplane/internal/gateway/pipeline_service.go
@@ -6,7 +6,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/yanet-platform/yanet2/common/proto"
+	commonpb "github.com/yanet-platform/yanet2/common/proto"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/controlplane/ynpb"
 )
@@ -118,19 +118,9 @@ func (m *PipelineService) Update(
 		pipeline.Functions[idx] = reqFunctionId.Name
 	}
 
-	m.log.Infow("updating pipeline",
-		zap.Uint32("instance", instance),
-		zap.Any("config", pipeline),
-	)
-
 	if err := agent.UpdatePipeline(pipeline); err != nil {
 		return nil, fmt.Errorf("failed to update function: %w", err)
 	}
-
-	m.log.Infow("updated pipeline",
-		zap.Uint32("instance", instance),
-		zap.Any("config", pipeline),
-	)
 
 	return &ynpb.UpdatePipelineResponse{}, nil
 }
@@ -140,7 +130,7 @@ func (m *PipelineService) Delete(
 	request *ynpb.DeletePipelineRequest,
 ) (*ynpb.DeletePipelineResponse, error) {
 	instance := request.GetInstance()
-	pipeline_name := request.Id.Name
+	pipelineName := request.GetId().GetName()
 
 	agent, err := m.shm.AgentAttach(agentName, instance, defaultAgentMemory)
 	if err != nil {
@@ -148,7 +138,7 @@ func (m *PipelineService) Delete(
 	}
 	defer agent.Close()
 
-	if err := agent.DeletePipeline(pipeline_name); err != nil {
+	if err := agent.DeletePipeline(pipelineName); err != nil {
 		return nil, fmt.Errorf("failed to delete pipeline: %w", err)
 	}
 

--- a/controlplane/internal/gateway/runner.go
+++ b/controlplane/internal/gateway/runner.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/yanet-platform/yanet2/controlplane/internal/xgrpc"
 	"github.com/yanet-platform/yanet2/controlplane/ynpb"
 )
 
@@ -41,11 +42,15 @@ func NewBuiltInModuleRunner(
 	gatewayEndpoint string,
 	log *zap.SugaredLogger,
 ) *BuiltInModuleRunner {
+	log = log.Named(module.Name()).With(zap.String("module", module.Name()))
+
 	return &BuiltInModuleRunner{
 		module:          module,
 		gatewayEndpoint: gatewayEndpoint,
-		server:          grpc.NewServer(),
-		log:             log.Named(module.Name()).With(zap.String("module", module.Name())),
+		server: grpc.NewServer(
+			grpc.ChainUnaryInterceptor(xgrpc.AccessLogInterceptor(log)),
+		),
+		log: log,
 	}
 }
 

--- a/controlplane/internal/xgrpc/interceptor.go
+++ b/controlplane/internal/xgrpc/interceptor.go
@@ -1,0 +1,137 @@
+package xgrpc
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	commonpb "github.com/yanet-platform/yanet2/common/proto"
+)
+
+// AccessLogInterceptor returns a gRPC unary server interceptor that logs
+// requests and responses.
+//
+// The interceptor logs:
+// - Debug: method entry with sanitized request
+// - Info: successful completion with duration and status
+// - Error: failed calls with duration, status and error message
+func AccessLogInterceptor(log *zap.SugaredLogger) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		now := time.Now()
+
+		if message, ok := req.(proto.Message); ok {
+			if log.Level().Enabled(zap.DebugLevel) {
+				log.Debugw("started gRPC execution",
+					zap.String("method", info.FullMethod),
+					zap.Any("request", sanitizeMessage(message)),
+				)
+			}
+		} else {
+			log.Debugw("started gRPC execution",
+				zap.String("method", info.FullMethod),
+			)
+		}
+
+		resp, err := handler(ctx, req)
+		duration := time.Since(now)
+		status, _ := status.FromError(err)
+
+		if err != nil {
+			log.Errorw("failed to execute gRPC",
+				zap.String("method", info.FullMethod),
+				zap.String("status", status.Code().String()),
+				zap.Duration("duration", duration),
+				zap.Error(err),
+			)
+		} else {
+			log.Infow("completed gRPC execution",
+				zap.String("method", info.FullMethod),
+				zap.String("status", status.Code().String()),
+				zap.Duration("duration", duration),
+			)
+		}
+
+		return resp, err
+	}
+}
+
+// sanitizeMessage creates a sanitized copy of the proto message for logging.
+// Fields marked with skip_logging=true will have their values replaced with
+// "<skipped>".
+func sanitizeMessage(msg proto.Message) map[string]any {
+	result := map[string]any{}
+
+	msgReflect := msg.ProtoReflect()
+	msgReflect.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		fieldName := string(fd.Name())
+
+		// Check if field has skip_logging option.
+		if shouldSkipLogging(fd) {
+			result[fieldName] = "<skipped>"
+			return true
+		}
+
+		// Handle nested messages recursively.
+		if fd.Kind() == protoreflect.MessageKind && !fd.IsList() && !fd.IsMap() {
+			if nestedMsg := v.Message(); nestedMsg.IsValid() {
+				result[fieldName] = sanitizeMessage(nestedMsg.Interface())
+			}
+			return true
+		}
+
+		// Handle repeated message fields.
+		if fd.IsList() && fd.Kind() == protoreflect.MessageKind {
+			list := v.List()
+			items := make([]any, list.Len())
+			for i := 0; i < list.Len(); i++ {
+				items[i] = sanitizeMessage(list.Get(i).Message().Interface())
+			}
+			result[fieldName] = items
+			return true
+		}
+
+		// Handle map fields with message values.
+		if fd.IsMap() && fd.MapValue().Kind() == protoreflect.MessageKind {
+			mapVal := v.Map()
+			mapResult := map[string]any{}
+			mapVal.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+				mapResult[k.String()] = sanitizeMessage(v.Message().Interface())
+				return true
+			})
+			result[fieldName] = mapResult
+			return true
+		}
+
+		// For other fields, use the interface value.
+		result[fieldName] = v.Interface()
+		return true
+	})
+
+	return result
+}
+
+// shouldSkipLogging checks if a field has the skip_logging option set to true.
+func shouldSkipLogging(fd protoreflect.FieldDescriptor) bool {
+	opts := fd.Options()
+	if opts == nil {
+		return false
+	}
+
+	// Get the skip_logging extension value.
+	ext := proto.GetExtension(opts, commonpb.E_SkipLogging)
+	if skip, ok := ext.(bool); ok {
+		return skip
+	}
+
+	return false
+}

--- a/devices/plain/controlplane/mod.go
+++ b/devices/plain/controlplane/mod.go
@@ -37,7 +37,7 @@ func NewDevicePlainDevice(cfg *Config, log *zap.SugaredLogger) (*DevicePlainDevi
 		return nil, err
 	}
 
-	plainService := NewDevicePlainService(agents, log)
+	plainService := NewDevicePlainService(agents)
 
 	return &DevicePlainDevice{
 		cfg:     cfg,

--- a/devices/vlan/controlplane/mod.go
+++ b/devices/vlan/controlplane/mod.go
@@ -37,7 +37,7 @@ func NewDeviceVlanDevice(cfg *Config, log *zap.SugaredLogger) (*DeviceVlanDevice
 		return nil, err
 	}
 
-	vlanService := NewDeviceVlanService(agents, log)
+	vlanService := NewDeviceVlanService(agents)
 
 	return &DeviceVlanDevice{
 		cfg:     cfg,

--- a/devices/vlan/controlplane/service.go
+++ b/devices/vlan/controlplane/service.go
@@ -4,27 +4,20 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
-
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb"
 )
 
-// DeviceVlanService implements the DeviceVlan gRPC service
+// DeviceVlanService implements the DeviceVlan gRPC service.
 type DeviceVlanService struct {
 	vlanpb.UnimplementedDeviceVlanServiceServer
 
 	agents []*ffi.Agent
-	log    *zap.SugaredLogger
 }
 
-func NewDeviceVlanService(
-	agents []*ffi.Agent,
-	log *zap.SugaredLogger,
-) *DeviceVlanService {
+func NewDeviceVlanService(agents []*ffi.Agent) *DeviceVlanService {
 	return &DeviceVlanService{
 		agents: agents,
-		log:    log,
 	}
 }
 
@@ -32,31 +25,21 @@ func (m *DeviceVlanService) UpdateDevice(
 	ctx context.Context,
 	request *vlanpb.UpdateDeviceVlanRequest,
 ) (*vlanpb.UpdateDeviceVlanResponse, error) {
-	name, inst, err := request.GetTarget().Validate(uint32(len(m.agents)))
+	name, instance, err := request.GetTarget().Validate(uint32(len(m.agents)))
 	if err != nil {
 		return nil, err
 	}
 
-	m.log.Debugw("updating configuration",
-		zap.String("device", name),
-		zap.Uint32("instance", inst),
-	)
-
-	agent := m.agents[inst]
+	agent := m.agents[instance]
 
 	deviceConfig, err := NewDeviceConfig(agent, name, request.GetDevice(), uint16(request.GetVlan()))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create device config for instance %d: %w", inst, err)
+		return nil, fmt.Errorf("failed to create device config for instance %d: %w", instance, err)
 	}
 
 	if err := agent.UpdateDevices([]ffi.ShmDeviceConfig{deviceConfig.AsFFIDevice()}); err != nil {
-		return nil, fmt.Errorf("failed to update module on instance %d: %w", inst, err)
+		return nil, fmt.Errorf("failed to update module on instance %d: %w", instance, err)
 	}
-
-	m.log.Debugw("successfully updated device config",
-		zap.String("name", name),
-		zap.Uint32("instance", inst),
-	)
 
 	return nil, nil
 }

--- a/modules/acl/controlplane/ffi.go
+++ b/modules/acl/controlplane/ffi.go
@@ -391,7 +391,7 @@ func (m *ModuleConfig) Update(rules []aclRule) error {
 	return nil
 }
 
-func DeleteConfig(m *AclService, configName string, instance uint32) bool {
+func DeleteConfig(m *ACLService, configName string, instance uint32) bool {
 	cTypeName := C.CString(agentName)
 	defer C.free(unsafe.Pointer(cTypeName))
 

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -17,7 +17,7 @@ type AclModule struct {
 	cfg     *Config
 	shm     *ffi.SharedMemory
 	agents  []*ffi.Agent
-	service *AclService
+	service *ACLService
 	log     *zap.SugaredLogger
 }
 
@@ -41,7 +41,7 @@ func NewAclModule(cfg *Config, log *zap.SugaredLogger) (*AclModule, error) {
 		return nil, fmt.Errorf("failed to attach agents: %w", err)
 	}
 
-	service := NewAclService(agents, log)
+	service := NewACLService(agents)
 
 	return &AclModule{
 		cfg:     cfg,

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -159,10 +159,5 @@ func (m *DecapService) updateModuleConfig(
 		return fmt.Errorf("failed to update module: %w", err)
 	}
 
-	m.log.Infow("successfully updated module",
-		zap.String("name", name),
-		zap.Uint32("instance", inst),
-	)
-
 	return nil
 }

--- a/modules/dscp/controlplane/service.go
+++ b/modules/dscp/controlplane/service.go
@@ -256,9 +256,5 @@ func (m *DscpService) updateModuleConfig(
 		return fmt.Errorf("failed to update module: %w", err)
 	}
 
-	m.log.Infow("successfully updated module",
-		zap.String("name", name),
-		zap.Uint32("instance", instance),
-	)
 	return nil
 }

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -39,7 +39,7 @@ func NewForwardModule(cfg *Config, log *zap.SugaredLogger) (*ForwardModule, erro
 		return nil, err
 	}
 
-	forwardService := NewForwardService(agents, log)
+	forwardService := NewForwardService(agents)
 
 	return &ForwardModule{
 		cfg:            cfg,

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -277,11 +277,6 @@ func (s *NAT64Service) SetDropUnknown(ctx context.Context, req *nat64pb.SetDropU
 }
 
 func (s *NAT64Service) updateModuleConfig(name string, instance uint32) error {
-	s.log.Debugw("updating configuration",
-		zap.String("module", name),
-		zap.Uint32("instance", instance),
-	)
-
 	if int(instance) >= len(s.agents) {
 		return fmt.Errorf("instance index %d is out of range (agents length: %d)", instance, len(s.agents))
 	}
@@ -302,21 +297,21 @@ func (s *NAT64Service) updateModuleConfig(name string, instance uint32) error {
 		s.configs[key] = config
 	}
 
-	// Configure all prefixes
+	// Configure all prefixes.
 	for _, prefix := range config.Prefixes {
 		if err := moduleConfig.AddPrefix(prefix); err != nil {
 			return fmt.Errorf("failed to add prefix on instance %d: %w", instance, err)
 		}
 	}
 
-	// Configure all mappings
+	// Configure all mappings.
 	for _, mapping := range config.Mappings {
 		if err := moduleConfig.AddMapping(mapping.IPv4, mapping.IPv6, mapping.PrefixIndex); err != nil {
 			return fmt.Errorf("failed to add mapping on instance %d: %w", instance, err)
 		}
 	}
 
-	// Set drop unknown flags
+	// Set drop unknown flags.
 	if err := moduleConfig.SetDropUnknown(config.DropUnknownPrefix, config.DropUnknownMapping); err != nil {
 		return fmt.Errorf("failed to set drop unknown flags on instance %d: %w", instance, err)
 	}
@@ -324,11 +319,6 @@ func (s *NAT64Service) updateModuleConfig(name string, instance uint32) error {
 	if err := agent.UpdateModules([]ffi.ModuleConfig{moduleConfig.AsFFIModule()}); err != nil {
 		return fmt.Errorf("failed to update module on instance %d: %w", instance, err)
 	}
-
-	s.log.Debugw("successfully updated module config",
-		zap.String("name", name),
-		zap.Uint32("instance", instance),
-	)
 
 	return nil
 }

--- a/modules/pdump/controlplane/service.go
+++ b/modules/pdump/controlplane/service.go
@@ -281,10 +281,6 @@ func (m *PdumpService) updateModuleConfig(
 		return fmt.Errorf("failed to update module %s: %w", name, err)
 	}
 
-	m.log.Infow("successfully updated module",
-		zap.String("name", name),
-		zap.Uint32("instance", instance),
-	)
 	return nil
 }
 

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -395,9 +395,5 @@ func (m *RouteService) updateModuleConfig(
 		return fmt.Errorf("failed to update module: %w", err)
 	}
 
-	m.log.Infow("successfully updated module",
-		zap.String("name", name),
-		zap.Uint32("inst", inst),
-	)
 	return nil
 }


### PR DESCRIPTION
This PR adds a centralized gRPC access logging interceptor (with a skip_logging proto field option) and wires it into the gateway and built-in module servers, replacing per-service boilerplate logs. This yields consistent structured request logging, honors annotated sensitive/large fields via <skipped>, captures status/duration/error uniformly, and reduces duplicated logging code across services.