### PR TITLE
feat: expose route flush via API, CLI, and web UI

### DIFF
--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -66,6 +66,13 @@ export interface DeleteRouteRequest {
 export interface DeleteRouteResponse {
 }
 
+export interface FlushRoutesRequest {
+    target?: TargetModule;
+}
+
+export interface FlushRoutesResponse {
+}
+
 const routeService = createService('routepb.RouteService');
 
 export const route = {
@@ -80,5 +87,8 @@ export const route = {
     },
     deleteRoute: (request: DeleteRouteRequest, signal?: AbortSignal): Promise<DeleteRouteResponse> => {
         return routeService.callWithBody<DeleteRouteResponse>('DeleteRoute', request, signal);
+    },
+    flushRoutes: (request: FlushRoutesRequest, signal?: AbortSignal): Promise<FlushRoutesResponse> => {
+        return routeService.callWithBody<FlushRoutesResponse>('FlushRoutes', request, signal);
     },
 };

--- a/web/src/pages/RoutePage.tsx
+++ b/web/src/pages/RoutePage.tsx
@@ -66,6 +66,7 @@ const RoutePage: React.FC = () => {
     const currentSelectedMap = selectedRoutes.get(currentInstance);
     const currentSelected = currentSelectedMap?.get(currentActiveConfig);
     const isDeleteDisabled = !currentSelected || currentSelected.size === 0;
+    const isFlushDisabled = !currentActiveConfig;
 
     const handleAddRouteClick = useCallback((): void => {
         setAddRouteForm({
@@ -84,6 +85,25 @@ const RoutePage: React.FC = () => {
         }
         setDeleteDialogOpen(true);
     }, [isDeleteDisabled]);
+
+    const handleFlushClick = useCallback(async (): Promise<void> => {
+        if (!currentActiveConfig) {
+            toaster.warning('flush-route-config-warning', 'Please select a config to flush');
+            return;
+        }
+
+        try {
+            await API.route.flushRoutes({
+                target: {
+                    configName: currentActiveConfig,
+                    dataplaneInstance: currentInstance,
+                },
+            });
+            toaster.success('flush-route-success', `Flushed routes for ${currentActiveConfig} on instance ${currentInstance}`);
+        } catch (err) {
+            toaster.error('flush-route-error', 'Failed to flush routes', err);
+        }
+    }, [currentActiveConfig, currentInstance]);
 
     const handleAddRouteConfirm = useCallback(async (): Promise<void> => {
         const configName = addRouteForm.configName.trim();
@@ -256,7 +276,9 @@ const RoutePage: React.FC = () => {
         <RoutePageHeader
             onAddRoute={handleAddRouteClick}
             onDeleteRoute={handleDeleteRouteClick}
+            onFlush={handleFlushClick}
             isDeleteDisabled={mockEnabled ? mockSelectedIds.size === 0 : isDeleteDisabled}
+            isFlushDisabled={isFlushDisabled}
             mockEnabled={mockEnabled}
             onMockToggle={handleMockToggle}
             mockSize={mockSize}

--- a/web/src/pages/route/RoutePageHeader.tsx
+++ b/web/src/pages/route/RoutePageHeader.tsx
@@ -11,7 +11,9 @@ const mockOptions = Object.entries(MOCK_CONFIGS).map(([key, value]) => ({
 export const RoutePageHeader: React.FC<RoutePageHeaderProps> = ({
     onAddRoute,
     onDeleteRoute,
+    onFlush,
     isDeleteDisabled,
+    isFlushDisabled,
     mockEnabled,
     onMockToggle,
     mockSize,
@@ -48,6 +50,13 @@ export const RoutePageHeader: React.FC<RoutePageHeaderProps> = ({
                 disabled={isDeleteDisabled || mockEnabled}
             >
                 Delete Route
+            </Button>
+            <Button
+                view="outlined"
+                onClick={onFlush}
+                disabled={isFlushDisabled || mockEnabled}
+            >
+                Flush RIB → FIB
             </Button>
         </Box>
     </Flex>

--- a/web/src/pages/route/types.ts
+++ b/web/src/pages/route/types.ts
@@ -25,7 +25,9 @@ export type RouteTableProps = RouteTableBaseProps;
 export interface RoutePageHeaderProps {
     onAddRoute: () => void;
     onDeleteRoute: () => void;
+    onFlush: () => void;
     isDeleteDisabled: boolean;
+    isFlushDisabled: boolean;
     mockEnabled?: boolean;
     onMockToggle?: (enabled: boolean) => void;
     mockSize?: string;


### PR DESCRIPTION
## Summary
- Add FlushRoutes request/response client wiring for the web API gateway.
- Expose flush action in Route page header (Flush RIB → FIB) using current config/instance.
- Add route CLI `flush` subcommand to trigger RIB→FIB flush per config/instance.

Closes #308.