### PR TITLE
refactor: ACL cli post-review

### DIFF
--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -1,5 +1,6 @@
+use std::{path::PathBuf, time::Duration};
+
 use clap::Parser;
-use std::time::Duration;
 
 /// Parse duration from string (e.g., "60s", "5m", "1h")
 fn parse_duration(s: &str) -> Result<Duration, String> {
@@ -22,9 +23,6 @@ pub struct DeleteCmd {
     /// The name of the module to delete
     #[arg(long = "cfg", short)]
     pub config_name: String,
-    /// Dataplane instances from which to delete config
-    #[arg(long, short, required = true)]
-    pub instance: u32,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -32,12 +30,9 @@ pub struct UpdateCmd {
     /// The name of the module to operate on.
     #[arg(long = "cfg", short)]
     pub config_name: String,
-    /// Dataplane instances where the changes should be applied.
-    #[arg(long, short, required = true)]
-    pub instance: u32,
     /// Ruleset file name.
-    #[arg(required = true, long = "rules", value_name = "rules")]
-    pub rules: String,
+    #[arg(required = true, long = "rules", value_name = "PATH")]
+    pub rules: PathBuf,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -1,23 +1,18 @@
-use core::error::Error;
-
-use std::net::IpAddr;
-
-use ipnetwork::IpNetwork;
-
-use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
-use commonpb::TargetModule;
-use tonic::transport::Channel;
-use ync::logging;
-
-use serde::{Deserialize, Serialize};
+use core::{error::Error, net::IpAddr};
+use std::{fs::File, path::Path};
 
 use aclpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest, UpdateFwStateConfigRequest,
     acl_service_client::AclServiceClient,
 };
-
 use args::{DeleteCmd, ModeCmd, SetFwstateConfigCmd, ShowCmd, UpdateCmd};
+use clap::{ArgAction, CommandFactory, Parser};
+use clap_complete::CompleteEnv;
+use commonpb::TargetModule;
+use ipnetwork::IpNetwork;
+use serde::{Deserialize, Serialize};
+use tonic::transport::Channel;
+use ync::logging;
 
 mod args;
 mod format;
@@ -325,10 +320,14 @@ impl TryFrom<ACLConfig> for Vec<aclpb::Rule> {
 ////////////////////////////////////////////////////////////////////////////////
 
 impl ACLConfig {
-    pub fn from_file(path: &str) -> Result<Self, Box<dyn Error>> {
-        let file = std::fs::File::open(path)?;
-        let config = serde_yaml::from_reader(file)?;
-        Ok(config)
+    pub fn from_file<P>(path: P) -> Result<Self, Box<dyn Error>>
+    where
+        P: AsRef<Path>,
+    {
+        let rd = File::open(path)?;
+        let cfg = serde_yaml::from_reader(rd)?;
+
+        Ok(cfg)
     }
 }
 


### PR DESCRIPTION
- Remove `instances` parameter.
- Ruleset path is now `PathBuf`.
- Format.