### PR TITLE
perf: replace protojson with encoding/json for API responses

### DIFF
--- a/web/src/api/acl.ts
+++ b/web/src/api/acl.ts
@@ -37,35 +37,35 @@ export enum ActionKind {
 export interface Action {
     kind?: ActionKind;
     counter?: string;
-    keepState?: boolean;
+    keep_state?: boolean;
 }
 
 export interface Rule {
     action?: Action;
     srcs?: IPNet[];
     dsts?: IPNet[];
-    srcPortRanges?: PortRange[];
-    dstPortRanges?: PortRange[];
+    src_port_ranges?: PortRange[];
+    dst_port_ranges?: PortRange[];
     devices?: Device[];
-    vlanRanges?: VlanRange[];
-    protoRanges?: ProtoRange[];
+    vlan_ranges?: VlanRange[];
+    proto_ranges?: ProtoRange[];
 }
 
 export interface MapConfig {
-    indexSize?: number;
-    extraBucketCount?: number;
+    index_size?: number;
+    extra_bucket_count?: number;
 }
 
 export interface SyncConfig {
-    srcAddr?: string | Uint8Array | number[];
-    dstEther?: string | Uint8Array | number[];
-    dstAddrMulticast?: string | Uint8Array | number[];
-    portMulticast?: number;
-    dstAddrUnicast?: string | Uint8Array | number[];
-    portUnicast?: number;
-    tcpSynAck?: number | string; // nanoseconds
-    tcpSyn?: number | string;
-    tcpFin?: number | string;
+    src_addr?: string | Uint8Array | number[];
+    dst_ether?: string | Uint8Array | number[];
+    dst_addr_multicast?: string | Uint8Array | number[];
+    port_multicast?: number;
+    dst_addr_unicast?: string | Uint8Array | number[];
+    port_unicast?: number;
+    tcp_syn_ack?: number | string; // nanoseconds
+    tcp_syn?: number | string;
+    tcp_fin?: number | string;
     tcp?: number | string;
     udp?: number | string;
     default?: number | string;
@@ -87,8 +87,8 @@ export interface AclShowConfigRequest {
 export interface AclShowConfigResponse {
     name?: string;
     rules?: Rule[];
-    fwstateMap?: MapConfig;
-    fwstateSync?: SyncConfig;
+    fwstate_map?: MapConfig;
+    fwstate_sync?: SyncConfig;
 }
 
 export interface AclDeleteConfigRequest {
@@ -107,8 +107,8 @@ export interface AclListConfigsResponse {
 
 export interface AclUpdateFWStateConfigRequest {
     name?: string;
-    mapConfig?: MapConfig;
-    syncConfig?: SyncConfig;
+    map_config?: MapConfig;
+    sync_config?: SyncConfig;
 }
 
 export interface AclUpdateFWStateConfigResponse { }

--- a/web/src/api/counters.ts
+++ b/web/src/api/counters.ts
@@ -41,8 +41,8 @@ export interface ModuleCountersRequest {
     pipeline: string;
     function: string;
     chain: string;
-    moduleType: string; // module_type
-    moduleName: string; // module_name
+    module_type: string;
+    module_name: string;
 }
 
 const countersService = createService('ynpb.CountersService');
@@ -61,13 +61,6 @@ export const counters = {
         return countersService.callWithBody<CountersResponse>('Chain', request, options);
     },
     module: (request: ModuleCountersRequest, options?: CallOptions): Promise<CountersResponse> => {
-        return countersService.callWithBody<CountersResponse>('Module', {
-            device: request.device,
-            pipeline: request.pipeline,
-            function: request.function,
-            chain: request.chain,
-            module_type: request.moduleType,
-            module_name: request.moduleName,
-        }, options);
+        return countersService.callWithBody<CountersResponse>('Module', request, options);
     },
 };

--- a/web/src/api/forward.ts
+++ b/web/src/api/forward.ts
@@ -37,7 +37,7 @@ export interface Action {
 export interface Rule {
     action?: Action;
     devices?: Device[];
-    vlanRanges?: VlanRange[];
+    vlan_ranges?: VlanRange[];
     srcs?: IPNet[];
     dsts?: IPNet[];
 }

--- a/web/src/api/inspect.ts
+++ b/web/src/api/inspect.ts
@@ -34,7 +34,7 @@ export interface PipelineInfo {
 
 export interface AgentInstanceInfo {
     pid?: number;
-    memoryLimit?: string | number; // uint64 - serialized as string in JSON
+    memory_limit?: string | number; // uint64 - serialized as string in JSON
     allocated?: string | number; // uint64 - serialized as string in JSON
     freed?: string | number; // uint64 - serialized as string in JSON
     generation?: string | number; // uint64 - serialized as string in JSON
@@ -53,15 +53,15 @@ export interface DevicePipelineInfo {
 export interface DeviceInfo {
     type?: string;
     name?: string;
-    inputPipelines?: DevicePipelineInfo[]; // input_pipelines
-    outputPipelines?: DevicePipelineInfo[]; // output_pipelines
+    input_pipelines?: DevicePipelineInfo[];
+    output_pipelines?: DevicePipelineInfo[];
 }
 
 export interface InstanceInfo {
-    instanceIdx?: number; // instance_idx
-    numaIdx?: number; // numa_idx
-    dpModules?: DPModuleInfo[]; // dp_modules
-    cpConfigs?: CPConfigInfo[]; // cp_configs
+    instance_idx?: number;
+    numa_idx?: number;
+    dp_modules?: DPModuleInfo[];
+    cp_configs?: CPConfigInfo[];
     functions?: FunctionInfo[];
     pipelines?: PipelineInfo[];
     agents?: AgentInfo[];
@@ -69,7 +69,7 @@ export interface InstanceInfo {
 }
 
 export interface InspectResponse {
-    instanceInfo?: InstanceInfo;
+    instance_info?: InstanceInfo;
 }
 
 const inspectService = createService('ynpb.InspectService');

--- a/web/src/api/neighbours.ts
+++ b/web/src/api/neighbours.ts
@@ -6,11 +6,11 @@ export interface MACAddress {
 }
 
 export interface Neighbour {
-    nextHop?: string; // next_hop
-    linkAddr?: MACAddress; // link_addr
-    hardwareAddr?: MACAddress; // hardware_addr
+    next_hop?: string;
+    link_addr?: MACAddress;
+    hardware_addr?: MACAddress;
     state?: number; // NeighbourState enum
-    updatedAt?: string | number; // updated_at (int64, UNIX timestamp in seconds) - serialized as string in JSON
+    updated_at?: string | number; // int64, UNIX timestamp in seconds - serialized as string in JSON
 }
 
 export interface ListNeighboursResponse {

--- a/web/src/api/pdump.ts
+++ b/web/src/api/pdump.ts
@@ -10,7 +10,7 @@ export interface PdumpConfig {
     filter?: string;
     mode?: number;
     snaplen?: number;
-    ringSize?: number;
+    ring_size?: number;
 }
 
 export interface ListConfigsResponse {
@@ -23,18 +23,22 @@ export interface ShowConfigResponse {
 
 export interface RecordMeta {
     timestamp?: string;
-    dataSize?: number;
-    packetLen?: number;
-    workerIdx?: number;
-    pipelineIdx?: number;
-    rxDeviceId?: number;
-    txDeviceId?: number;
+    data_size?: number;
+    packet_len?: number;
+    worker_idx?: number;
+    pipeline_idx?: number;
+    rx_device_id?: number;
+    tx_device_id?: number;
     queue?: number;
 }
 
 export interface PdumpRecord {
     meta?: RecordMeta;
     data?: string; // base64 encoded
+}
+
+export interface FieldMask {
+    paths?: string[];
 }
 
 const pdumpService = createService('pdumppb.PdumpService');
@@ -52,12 +56,12 @@ export const pdumpApi = {
     setConfig: (
         name: string,
         config: PdumpConfig,
-        updateMask?: { paths?: string[] },
+        update_mask?: FieldMask,
         options?: CallOptions
     ): Promise<void> => {
         return pdumpService.callWithBody<void>(
             'SetConfig',
-            { name, config, updateMask },
+            { name, config, update_mask },
             options
         );
     },

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -3,24 +3,24 @@ import { createService, type CallOptions } from './client';
 // Route types
 
 export interface LargeCommunity {
-    globalAdministrator?: number; // global_administrator
-    localDataPart1?: number; // local_data_part1
-    localDataPart2?: number; // local_data_part2
+    global_administrator?: number;
+    local_data_part1?: number;
+    local_data_part2?: number;
 }
 
 export interface Route {
     prefix?: string;
-    nextHop?: string; // next_hop
+    next_hop?: string;
     peer?: string;
-    routeDistinguisher?: string | number; // route_distinguisher (uint64)
-    peerAs?: number; // peer_as
-    originAs?: number; // origin_as
+    route_distinguisher?: string | number; // uint64
+    peer_as?: number;
+    origin_as?: number;
     med?: number;
     pref?: number;
-    asPathLen?: number; // as_path_len
+    as_path_len?: number;
     source?: number; // RouteSourceID enum
-    largeCommunities?: LargeCommunity[]; // large_communities
-    isBest?: boolean; // is_best
+    large_communities?: LargeCommunity[];
+    is_best?: boolean;
 }
 
 export interface ListConfigsResponse {
@@ -29,8 +29,8 @@ export interface ListConfigsResponse {
 
 export interface ShowRoutesRequest {
     name?: string;
-    ipv4Only?: boolean; // ipv4_only
-    ipv6Only?: boolean; // ipv6_only
+    ipv4_only?: boolean;
+    ipv6_only?: boolean;
 }
 
 export interface ShowRoutesResponse {
@@ -40,8 +40,8 @@ export interface ShowRoutesResponse {
 export interface InsertRouteRequest {
     name?: string;
     prefix?: string;
-    nexthopAddr?: string; // nexthop_addr
-    doFlush?: boolean; // do_flush
+    nexthop_addr?: string;
+    do_flush?: boolean;
 }
 
 export interface InsertRouteResponse {
@@ -50,8 +50,8 @@ export interface InsertRouteResponse {
 export interface DeleteRouteRequest {
     name?: string;
     prefix?: string;
-    nexthopAddr?: string; // nexthop_addr
-    doFlush?: boolean; // do_flush
+    nexthop_addr?: string;
+    do_flush?: boolean;
 }
 
 export interface DeleteRouteResponse {

--- a/web/src/pages/InspectPage.tsx
+++ b/web/src/pages/InspectPage.tsx
@@ -20,7 +20,7 @@ const InspectPage = (): React.JSX.Element => {
             try {
                 const data = await API.inspect.inspect();
                 if (!isMounted) return;
-                setInstanceInfo(data.instanceInfo || null);
+                setInstanceInfo(data.instance_info || null);
             } catch (err) {
                 if (!isMounted) return;
                 toaster.error('inspect-error', 'Failed to fetch inspect data', err);

--- a/web/src/pages/NeighboursPage.tsx
+++ b/web/src/pages/NeighboursPage.tsx
@@ -49,7 +49,7 @@ const serializeSortToURL = (sortState: TableSortState, searchParams: URLSearchPa
 };
 
 
-const renderMacAddress = (addr?: Neighbour['linkAddr']): string => {
+const renderMacAddress = (addr?: Neighbour['link_addr']): string => {
     if (addr?.addr === undefined) {
         return '-';
     }
@@ -116,36 +116,36 @@ const NeighboursPage = (): React.JSX.Element => {
 
     const columns: TableColumnConfig<Neighbour>[] = useMemo(() => [
         {
-            id: 'nextHop',
+            id: 'next_hop',
             name: 'Next Hop',
             meta: {
-                sort: (a: Neighbour, b: Neighbour) => compareNullableStrings(a.nextHop, b.nextHop),
+                sort: (a: Neighbour, b: Neighbour) => compareNullableStrings(a.next_hop, b.next_hop),
             },
-            template: (item: Neighbour) => item.nextHop || '-',
+            template: (item: Neighbour) => item.next_hop || '-',
         },
         {
-            id: 'linkAddr',
+            id: 'link_addr',
             name: 'Neighbour MAC',
             meta: {
                 sort: (a: Neighbour, b: Neighbour) => {
-                    const valA = getMACAddressValue(a.linkAddr?.addr);
-                    const valB = getMACAddressValue(b.linkAddr?.addr);
+                    const valA = getMACAddressValue(a.link_addr?.addr);
+                    const valB = getMACAddressValue(b.link_addr?.addr);
                     return compareMACAddressValues(valA, valB);
                 },
             },
-            template: (item: Neighbour) => renderMacAddress(item.linkAddr),
+            template: (item: Neighbour) => renderMacAddress(item.link_addr),
         },
         {
-            id: 'hardwareAddr',
+            id: 'hardware_addr',
             name: 'Interface MAC',
             meta: {
                 sort: (a: Neighbour, b: Neighbour) => {
-                    const valA = getMACAddressValue(a.hardwareAddr?.addr);
-                    const valB = getMACAddressValue(b.hardwareAddr?.addr);
+                    const valA = getMACAddressValue(a.hardware_addr?.addr);
+                    const valB = getMACAddressValue(b.hardware_addr?.addr);
                     return compareMACAddressValues(valA, valB);
                 },
             },
-            template: (item: Neighbour) => renderMacAddress(item.hardwareAddr),
+            template: (item: Neighbour) => renderMacAddress(item.hardware_addr),
         },
         {
             id: 'state',
@@ -158,21 +158,21 @@ const NeighboursPage = (): React.JSX.Element => {
                         return stateA - stateB;
                     }
 
-                    return compareNullableStrings(a.nextHop, b.nextHop);
+                    return compareNullableStrings(a.next_hop, b.next_hop);
                 },
             },
             template: (item: Neighbour) => getNUDStateString(item.state),
         },
         {
-            id: 'updatedAt',
+            id: 'updated_at',
             name: `Updated At (UTC${utcOffsetString})`,
             meta: {
                 sort: (a: Neighbour, b: Neighbour) => compareNullableNumbers(
-                    getUnixSecondsValue(a.updatedAt),
-                    getUnixSecondsValue(b.updatedAt)
+                    getUnixSecondsValue(a.updated_at),
+                    getUnixSecondsValue(b.updated_at)
                 ),
             },
-            template: (item: Neighbour) => formatUnixSeconds(item.updatedAt),
+            template: (item: Neighbour) => formatUnixSeconds(item.updated_at),
         },
     ], [utcOffsetString]);
 

--- a/web/src/pages/RoutePage.tsx
+++ b/web/src/pages/RoutePage.tsx
@@ -52,8 +52,8 @@ const RoutePage: React.FC = () => {
     const [addRouteForm, setAddRouteForm] = useState<AddRouteFormData>({
         configName: '',
         prefix: '',
-        nexthopAddr: '',
-        doFlush: false,
+        nexthop_addr: '',
+        do_flush: false,
     });
 
     // Derived state
@@ -65,8 +65,8 @@ const RoutePage: React.FC = () => {
         setAddRouteForm({
             configName: activeConfigTab,
             prefix: '',
-            nexthopAddr: '',
-            doFlush: false,
+            nexthop_addr: '',
+            do_flush: false,
         });
         setAddDialogOpen(true);
     }, [activeConfigTab]);
@@ -103,7 +103,7 @@ const RoutePage: React.FC = () => {
             return;
         }
 
-        if (!addRouteForm.prefix || !addRouteForm.nexthopAddr) {
+        if (!addRouteForm.prefix || !addRouteForm.nexthop_addr) {
             toaster.error('add-route-validation-error', 'Please fill in all required fields');
             return;
         }
@@ -132,7 +132,7 @@ const RoutePage: React.FC = () => {
             return;
         }
 
-        const nexthopResult = parseIPAddress(addRouteForm.nexthopAddr);
+        const nexthopResult = parseIPAddress(addRouteForm.nexthop_addr);
         if (!nexthopResult.ok) {
             let errorMessage = 'Invalid nexthop address format';
             if (nexthopResult.error === IPParseError.InvalidFormat) {
@@ -146,8 +146,8 @@ const RoutePage: React.FC = () => {
             await API.route.insertRoute({
                 name: configName,
                 prefix: addRouteForm.prefix,
-                nexthopAddr: addRouteForm.nexthopAddr,
-                doFlush: addRouteForm.doFlush,
+                nexthop_addr: addRouteForm.nexthop_addr,
+                do_flush: addRouteForm.do_flush,
             });
 
             setAddDialogOpen(false);
@@ -191,7 +191,7 @@ const RoutePage: React.FC = () => {
             let skippedInvalidRoute = false;
 
             for (const route of selectedRoutesList) {
-                if (!route.prefix || !route.nextHop) {
+                if (!route.prefix || !route.next_hop) {
                     skippedInvalidRoute = true;
                     continue;
                 }
@@ -199,8 +199,8 @@ const RoutePage: React.FC = () => {
                 await API.route.deleteRoute({
                     name: activeConfigTab,
                     prefix: route.prefix,
-                    nexthopAddr: route.nextHop,
-                    doFlush: true,
+                    nexthop_addr: route.next_hop,
+                    do_flush: true,
                 });
             }
 

--- a/web/src/pages/acl/FWStateForm.tsx
+++ b/web/src/pages/acl/FWStateForm.tsx
@@ -76,7 +76,7 @@ export const FWStateForm: React.FC<FWStateFormProps> = ({
         const num = parseInt(value, 10);
         onMapConfigChange({
             ...mapConfig,
-            indexSize: isNaN(num) ? undefined : num,
+            index_size: isNaN(num) ? undefined : num,
         });
     }, [mapConfig, onMapConfigChange]);
 
@@ -84,7 +84,7 @@ export const FWStateForm: React.FC<FWStateFormProps> = ({
         const num = parseInt(value, 10);
         onMapConfigChange({
             ...mapConfig,
-            extraBucketCount: isNaN(num) ? undefined : num,
+            extra_bucket_count: isNaN(num) ? undefined : num,
         });
     }, [mapConfig, onMapConfigChange]);
 
@@ -112,14 +112,14 @@ export const FWStateForm: React.FC<FWStateFormProps> = ({
                 <Box className="fwstate-form__grid--2cols">
                     <InputFormField
                         label="Index Size"
-                        value={mapConfig?.indexSize?.toString() || ''}
+                        value={mapConfig?.index_size?.toString() || ''}
                         onChange={handleIndexSizeChange}
                         placeholder="e.g., 65536"
                         hint="Size of the hash table index"
                     />
                     <InputFormField
                         label="Extra Bucket Count"
-                        value={mapConfig?.extraBucketCount?.toString() || ''}
+                        value={mapConfig?.extra_bucket_count?.toString() || ''}
                         onChange={handleExtraBucketCountChange}
                         placeholder="e.g., 1024"
                         hint="Number of extra buckets for collisions"
@@ -136,48 +136,48 @@ export const FWStateForm: React.FC<FWStateFormProps> = ({
                 <Box className="fwstate-form__grid--2cols">
                     <InputFormField
                         label="Source IPv6 Address"
-                        value={formatIPv6(syncConfig?.srcAddr)}
-                        onChange={createSyncConfigHandler('srcAddr', parseIPv6ToBytes)}
+                        value={formatIPv6(syncConfig?.src_addr)}
+                        onChange={createSyncConfigHandler('src_addr', parseIPv6ToBytes)}
                         placeholder="e.g., 2001:db8::1"
                     />
                     <InputFormField
                         label="Destination MAC Address"
-                        value={formatMAC(syncConfig?.dstEther)}
-                        onChange={createSyncConfigHandler('dstEther', parseMACToBytes)}
+                        value={formatMAC(syncConfig?.dst_ether)}
+                        onChange={createSyncConfigHandler('dst_ether', parseMACToBytes)}
                         placeholder="e.g., 00:11:22:33:44:55"
                     />
                     <InputFormField
                         label="Multicast IPv6 Address"
-                        value={formatIPv6(syncConfig?.dstAddrMulticast)}
-                        onChange={createSyncConfigHandler('dstAddrMulticast', parseIPv6ToBytes)}
+                        value={formatIPv6(syncConfig?.dst_addr_multicast)}
+                        onChange={createSyncConfigHandler('dst_addr_multicast', parseIPv6ToBytes)}
                         placeholder="e.g., ff02::1"
                     />
                     <InputFormField
                         label="Multicast Port"
-                        value={syncConfig?.portMulticast?.toString() || ''}
+                        value={syncConfig?.port_multicast?.toString() || ''}
                         onChange={(v) => {
                             const num = parseInt(v, 10);
                             onSyncConfigChange({
                                 ...syncConfig,
-                                portMulticast: isNaN(num) ? undefined : num,
+                                port_multicast: isNaN(num) ? undefined : num,
                             });
                         }}
                         placeholder="e.g., 5000"
                     />
                     <InputFormField
                         label="Unicast IPv6 Address"
-                        value={formatIPv6(syncConfig?.dstAddrUnicast)}
-                        onChange={createSyncConfigHandler('dstAddrUnicast', parseIPv6ToBytes)}
+                        value={formatIPv6(syncConfig?.dst_addr_unicast)}
+                        onChange={createSyncConfigHandler('dst_addr_unicast', parseIPv6ToBytes)}
                         placeholder="e.g., 2001:db8::2"
                     />
                     <InputFormField
                         label="Unicast Port"
-                        value={syncConfig?.portUnicast?.toString() || ''}
+                        value={syncConfig?.port_unicast?.toString() || ''}
                         onChange={(v) => {
                             const num = parseInt(v, 10);
                             onSyncConfigChange({
                                 ...syncConfig,
-                                portUnicast: isNaN(num) ? undefined : num,
+                                port_unicast: isNaN(num) ? undefined : num,
                             });
                         }}
                         placeholder="e.g., 5001"
@@ -194,11 +194,11 @@ export const FWStateForm: React.FC<FWStateFormProps> = ({
                 <Box className="fwstate-form__grid--3cols">
                     <InputFormField
                         label="TCP SYN-ACK"
-                        value={formatDuration(syncConfig?.tcpSynAck)}
+                        value={formatDuration(syncConfig?.tcp_syn_ack)}
                         onChange={(v) => {
                             onSyncConfigChange({
                                 ...syncConfig,
-                                tcpSynAck: parseDuration(v),
+                                tcp_syn_ack: parseDuration(v),
                             });
                         }}
                         placeholder="e.g., 60s"
@@ -206,11 +206,11 @@ export const FWStateForm: React.FC<FWStateFormProps> = ({
                     />
                     <InputFormField
                         label="TCP SYN"
-                        value={formatDuration(syncConfig?.tcpSyn)}
+                        value={formatDuration(syncConfig?.tcp_syn)}
                         onChange={(v) => {
                             onSyncConfigChange({
                                 ...syncConfig,
-                                tcpSyn: parseDuration(v),
+                                tcp_syn: parseDuration(v),
                             });
                         }}
                         placeholder="e.g., 30s"
@@ -218,11 +218,11 @@ export const FWStateForm: React.FC<FWStateFormProps> = ({
                     />
                     <InputFormField
                         label="TCP FIN"
-                        value={formatDuration(syncConfig?.tcpFin)}
+                        value={formatDuration(syncConfig?.tcp_fin)}
                         onChange={(v) => {
                             onSyncConfigChange({
                                 ...syncConfig,
-                                tcpFin: parseDuration(v),
+                                tcp_fin: parseDuration(v),
                             });
                         }}
                         placeholder="e.g., 30s"

--- a/web/src/pages/acl/VirtualizedAclTable.tsx
+++ b/web/src/pages/acl/VirtualizedAclTable.tsx
@@ -25,19 +25,19 @@ const formatIPNets = (nets: Rule['srcs']): string => {
 };
 
 // Format port ranges for display
-const formatPortRanges = (ranges: Rule['srcPortRanges']): string => {
+const formatPortRanges = (ranges: Rule['src_port_ranges']): string => {
     if (!ranges || ranges.length === 0) return '*';
     return ranges.map((r) => formatPortRange({ from: r.from || 0, to: r.to || 0 })).join(', ');
 };
 
 // Format proto ranges for display
-const formatProtoRanges = (ranges: Rule['protoRanges']): string => {
+const formatProtoRanges = (ranges: Rule['proto_ranges']): string => {
     if (!ranges || ranges.length === 0) return '*';
     return ranges.map((r) => formatProtoRange({ from: r.from || 0, to: r.to || 0 })).join(', ');
 };
 
 // Format vlan ranges for display
-const formatVlanRanges = (ranges: Rule['vlanRanges']): string => {
+const formatVlanRanges = (ranges: Rule['vlan_ranges']): string => {
     if (!ranges || ranges.length === 0) return '*';
     return ranges.map((r) => formatVlanRange({ from: r.from || 0, to: r.to || 0 })).join(', ');
 };
@@ -104,17 +104,17 @@ const TableRow: React.FC<TableRowProps> = React.memo(({ rule, index, start }) =>
             <div style={cellStyles.dsts} title={formatIPNets(rule.dsts)}>
                 {formatIPNets(rule.dsts)}
             </div>
-            <div style={cellStyles.srcPorts} title={formatPortRanges(rule.srcPortRanges)}>
-                {formatPortRanges(rule.srcPortRanges)}
+            <div style={cellStyles.srcPorts} title={formatPortRanges(rule.src_port_ranges)}>
+                {formatPortRanges(rule.src_port_ranges)}
             </div>
-            <div style={cellStyles.dstPorts} title={formatPortRanges(rule.dstPortRanges)}>
-                {formatPortRanges(rule.dstPortRanges)}
+            <div style={cellStyles.dstPorts} title={formatPortRanges(rule.dst_port_ranges)}>
+                {formatPortRanges(rule.dst_port_ranges)}
             </div>
-            <div style={cellStyles.protocols} title={formatProtoRanges(rule.protoRanges)}>
-                {formatProtoRanges(rule.protoRanges)}
+            <div style={cellStyles.protocols} title={formatProtoRanges(rule.proto_ranges)}>
+                {formatProtoRanges(rule.proto_ranges)}
             </div>
-            <div style={cellStyles.vlans} title={formatVlanRanges(rule.vlanRanges)}>
-                {formatVlanRanges(rule.vlanRanges)}
+            <div style={cellStyles.vlans} title={formatVlanRanges(rule.vlan_ranges)}>
+                {formatVlanRanges(rule.vlan_ranges)}
             </div>
             <div style={cellStyles.devices} title={formatDevices(rule.devices)}>
                 {formatDevices(rule.devices)}

--- a/web/src/pages/acl/hooks.ts
+++ b/web/src/pages/acl/hooks.ts
@@ -79,12 +79,12 @@ export const useAclData = (): UseAclDataResult => {
                             const rules = response.rules || [];
                             dataMap.set(configName, {
                                 rules,
-                                fwstateMap: response.fwstateMap,
-                                fwstateSync: response.fwstateSync,
+                                fwstateMap: response.fwstate_map,
+                                fwstateSync: response.fwstate_sync,
                                 state: 'saved',
                                 originalRules: rules,
-                                originalFwstateMap: response.fwstateMap,
-                                originalFwstateSync: response.fwstateSync,
+                                originalFwstateMap: response.fwstate_map,
+                                originalFwstateSync: response.fwstate_sync,
                             });
                         } catch (err) {
                             toaster.error(`acl-fetch-error-${configName}`, `Failed to load ACL config ${configName}`, err);
@@ -131,12 +131,12 @@ export const useAclData = (): UseAclDataResult => {
                         const rules = response.rules || [];
                         dataMap.set(configName, {
                             rules,
-                            fwstateMap: response.fwstateMap,
-                            fwstateSync: response.fwstateSync,
+                            fwstateMap: response.fwstate_map,
+                            fwstateSync: response.fwstate_sync,
                             state: 'saved',
                             originalRules: rules,
-                            originalFwstateMap: response.fwstateMap,
-                            originalFwstateSync: response.fwstateSync,
+                            originalFwstateMap: response.fwstate_map,
+                            originalFwstateSync: response.fwstate_sync,
                         });
                     } catch (err) {
                         toaster.error(`acl-reload-error-${configName}`, `Failed to reload ACL config ${configName}`, err);
@@ -292,8 +292,8 @@ export const useAclData = (): UseAclDataResult => {
         try {
             await API.acl.updateFWStateConfig({
                 name: configName,
-                mapConfig: data.fwstateMap,
-                syncConfig: data.fwstateSync,
+                map_config: data.fwstateMap,
+                sync_config: data.fwstateSync,
             });
             markConfigSaved(configName);
             toaster.success('acl-fwstate-save-success', `FW State config for ${configName} saved successfully`);

--- a/web/src/pages/acl/yamlParser.ts
+++ b/web/src/pages/acl/yamlParser.ts
@@ -97,17 +97,17 @@ const convertYamlRule = (yamlRule: YamlAclRule): Rule => {
     const action: Action = {
         kind: actionKind,
         counter: yamlRule.counter || '',
-        keepState: false,
+        keep_state: false,
     };
 
     return {
         action,
         srcs,
         dsts,
-        srcPortRanges,
-        dstPortRanges,
-        protoRanges,
-        vlanRanges,
+        src_port_ranges: srcPortRanges,
+        dst_port_ranges: dstPortRanges,
+        proto_ranges: protoRanges,
+        vlan_ranges: vlanRanges,
         devices: (yamlRule.devices || []).map((name) => ({ name })),
     };
 };

--- a/web/src/pages/decap/useDecapData.ts
+++ b/web/src/pages/decap/useDecapData.ts
@@ -37,10 +37,10 @@ export const useDecapData = (): UseDecapDataResult => {
 
                 if (!isMounted) return;
 
-                const info = inspectResponse.instanceInfo;
+                const info = inspectResponse.instance_info;
 
                 // Find decap configs
-                const decapConfigs = (info?.cpConfigs || [])
+                const decapConfigs = (info?.cp_configs || [])
                     .filter((cfg) => cfg.type === 'decap')
                     .map((cfg) => cfg.name || '');
 

--- a/web/src/pages/devices/hooks.ts
+++ b/web/src/pages/devices/hooks.ts
@@ -28,11 +28,11 @@ const deviceInfoToLocal = (info: DeviceInfo): LocalDevice => {
     return {
         id: { type: info.type, name: info.name },
         type,
-        inputPipelines: (info.inputPipelines || []).map(p => ({
+        inputPipelines: (info.input_pipelines || []).map(p => ({
             name: p.name,
             weight: parseWeight(p.weight),
         })),
-        outputPipelines: (info.outputPipelines || []).map(p => ({
+        outputPipelines: (info.output_pipelines || []).map(p => ({
             name: p.name,
             weight: parseWeight(p.weight),
         })),
@@ -56,7 +56,7 @@ export const useDeviceData = (): UseDeviceDataResult => {
         try {
             // Get devices from inspect
             const inspectResponse: InspectResponse = await API.inspect.inspect();
-            const instanceInfo = inspectResponse.instanceInfo;
+            const instanceInfo = inspectResponse.instance_info;
 
             const loadedDevices = instanceInfo?.devices?.map(deviceInfoToLocal) || [];
             setDevices(loadedDevices);

--- a/web/src/pages/forward/AddRuleDialog.tsx
+++ b/web/src/pages/forward/AddRuleDialog.tsx
@@ -80,7 +80,7 @@ export const AddRuleDialog: React.FC<AddRuleDialogProps> = ({
                     counter: counter.trim() || undefined,
                 },
                 devices: parseDevices(devices),
-                vlanRanges: parseVlanRanges(vlans),
+                vlan_ranges: parseVlanRanges(vlans),
                 srcs: parsePrefixesToIPNets(srcs),
                 dsts: parsePrefixesToIPNets(dsts),
             };

--- a/web/src/pages/forward/EditRuleDialog.tsx
+++ b/web/src/pages/forward/EditRuleDialog.tsx
@@ -36,7 +36,7 @@ const devicesToString = (devices: Rule['devices']): string => {
 /**
  * Convert vlan ranges to comma-separated string for editing
  */
-const vlanRangesToString = (ranges: Rule['vlanRanges']): string => {
+const vlanRangesToString = (ranges: Rule['vlan_ranges']): string => {
     const formatted = formatVlanRanges(ranges);
     return formatted === '*' ? '' : formatted;
 };
@@ -72,7 +72,7 @@ export const EditRuleDialog: React.FC<EditRuleDialogProps> = ({
             setMode([modeEnumToString(rule.action?.mode)]);
             setCounter(rule.action?.counter || '');
             setDevices(devicesToString(rule.devices));
-            setVlans(vlanRangesToString(rule.vlanRanges));
+            setVlans(vlanRangesToString(rule.vlan_ranges));
             setSrcs(ipNetsToString(rule.srcs));
             setDsts(ipNetsToString(rule.dsts));
             setIsSubmitting(false);
@@ -103,7 +103,7 @@ export const EditRuleDialog: React.FC<EditRuleDialogProps> = ({
                     counter: counter.trim() || undefined,
                 },
                 devices: parseDevices(devices),
-                vlanRanges: parseVlanRanges(vlans),
+                vlan_ranges: parseVlanRanges(vlans),
                 srcs: parsePrefixesToIPNets(srcs),
                 dsts: parsePrefixesToIPNets(dsts),
             };

--- a/web/src/pages/forward/RuleRow.tsx
+++ b/web/src/pages/forward/RuleRow.tsx
@@ -85,8 +85,8 @@ export const RuleRow: React.FC<RuleRowProps> = memo(({
             </Box>
 
             {/* VLANs */}
-            <Box style={cellStyles.vlans} title={formatVlanRanges(rule.vlanRanges)}>
-                <Text variant="body-1">{formatVlanRanges(rule.vlanRanges)}</Text>
+            <Box style={cellStyles.vlans} title={formatVlanRanges(rule.vlan_ranges)}>
+                <Text variant="body-1">{formatVlanRanges(rule.vlan_ranges)}</Text>
             </Box>
 
             {/* Sources */}

--- a/web/src/pages/forward/useForwardData.ts
+++ b/web/src/pages/forward/useForwardData.ts
@@ -40,10 +40,10 @@ export const useForwardData = (): UseForwardDataResult => {
 
                 if (!isMounted) return;
 
-                const info = inspectResponse.instanceInfo;
+                const info = inspectResponse.instance_info;
 
                 // Find forward configs
-                const forwardConfigs = (info?.cpConfigs || [])
+                const forwardConfigs = (info?.cp_configs || [])
                     .filter((cfg) => cfg.type === 'forward')
                     .map((cfg) => cfg.name || '');
 

--- a/web/src/pages/functions/hooks.ts
+++ b/web/src/pages/functions/hooks.ts
@@ -320,7 +320,7 @@ export const useModuleCounters = (
         const fetchDevicesAndPipelines = async () => {
             try {
                 const response = await API.inspect.inspect();
-                const instanceInfo = response.instanceInfo;
+                const instanceInfo = response.instance_info;
                 const allDevices = instanceInfo?.devices ?? [];
                 const allPipelines = instanceInfo?.pipelines ?? [];
                 
@@ -335,8 +335,8 @@ export const useModuleCounters = (
                 // Find devices that use these pipelines
                 const matchingDevices: DeviceInfo[] = [];
                 for (const device of allDevices) {
-                    const inputPipelines = device.inputPipelines ?? [];
-                    const outputPipelines = device.outputPipelines ?? [];
+                    const inputPipelines = device.input_pipelines ?? [];
+                    const outputPipelines = device.output_pipelines ?? [];
                     const allDevicePipelines = [...inputPipelines, ...outputPipelines];
                     
                     for (const pipeline of allDevicePipelines) {
@@ -382,8 +382,8 @@ export const useModuleCounters = (
                             pipeline: pipelineName,
                             function: functionName,
                             chain: moduleInfo.chainName,
-                            moduleType: moduleInfo.moduleType,
-                            moduleName: moduleInfo.moduleName,
+                            module_type: moduleInfo.moduleType,
+                            module_name: moduleInfo.moduleName,
                         });
                         
                         // Module counters are named 'rx' and 'rx_bytes'

--- a/web/src/pages/inspect/SummaryRow.tsx
+++ b/web/src/pages/inspect/SummaryRow.tsx
@@ -16,8 +16,8 @@ export interface SummaryRowProps {
 }
 
 export const SummaryRow: React.FC<SummaryRowProps> = ({ instance }) => {
-    const modulesCount = instance.dpModules?.length ?? 0;
-    const configsCount = instance.cpConfigs?.length ?? 0;
+    const modulesCount = instance.dp_modules?.length ?? 0;
+    const configsCount = instance.cp_configs?.length ?? 0;
     const pipelinesCount = instance.pipelines?.length ?? 0;
     const devicesCount = instance.devices?.length ?? 0;
     const functionsCount = instance.functions?.length ?? 0;

--- a/web/src/pages/inspect/sections/AgentsSection.tsx
+++ b/web/src/pages/inspect/sections/AgentsSection.tsx
@@ -31,12 +31,12 @@ export const AgentsSection: React.FC<AgentsSectionProps> = ({ instance }) => {
             template: (item: AgentInstanceInfo) => item.pid?.toString() || '-',
         },
         {
-            id: 'memoryLimit',
+            id: 'memory_limit',
             name: 'Memory Limit',
             meta: {
-                sort: (a: AgentInstanceInfo, b: AgentInstanceInfo) => compareBigIntValues(a.memoryLimit, b.memoryLimit),
+                sort: (a: AgentInstanceInfo, b: AgentInstanceInfo) => compareBigIntValues(a.memory_limit, b.memory_limit),
             },
-            template: (item: AgentInstanceInfo) => formatUint64(item.memoryLimit),
+            template: (item: AgentInstanceInfo) => formatUint64(item.memory_limit),
         },
         {
             id: 'allocated',

--- a/web/src/pages/inspect/sections/ConfigurationsSection.tsx
+++ b/web/src/pages/inspect/sections/ConfigurationsSection.tsx
@@ -14,7 +14,7 @@ export interface ConfigurationsSectionProps {
 }
 
 export const ConfigurationsSection: React.FC<ConfigurationsSectionProps> = ({ instance }) => {
-    const configs = instance.cpConfigs ?? [];
+    const configs = instance.cp_configs ?? [];
 
     const cpConfigColumns: TableColumnConfig<CPConfigInfo>[] = useMemo(() => [
         {

--- a/web/src/pages/inspect/sections/DevicesSection.tsx
+++ b/web/src/pages/inspect/sections/DevicesSection.tsx
@@ -25,8 +25,8 @@ interface DeviceRowData {
     [key: string]: unknown;
     name: string;
     type: string;
-    inputPipelines: DevicePipelineInfo[];
-    outputPipelines: DevicePipelineInfo[];
+    input_pipelines: DevicePipelineInfo[];
+    output_pipelines: DevicePipelineInfo[];
     counters: DeviceCounters | null;
 }
 
@@ -104,8 +104,8 @@ export const DevicesSection: React.FC<DevicesSectionProps> = ({ instance }) => {
             return {
                 name: deviceName,
                 type: device.type || '-',
-                inputPipelines: device.inputPipelines ?? [],
-                outputPipelines: device.outputPipelines ?? [],
+                input_pipelines: device.input_pipelines ?? [],
+                output_pipelines: device.output_pipelines ?? [],
                 counters: countersMap.get(deviceName) ?? null,
             };
         });
@@ -161,20 +161,20 @@ export const DevicesSection: React.FC<DevicesSectionProps> = ({ instance }) => {
             },
         },
         {
-            id: 'inputPipelines',
+            id: 'input_pipelines',
             name: 'Input Pipelines',
             template: (item: DeviceRowData) => (
-                <Text variant="body-2" color={item.inputPipelines.length === 0 ? 'secondary' : undefined}>
-                    {formatPipelines(item.inputPipelines)}
+                <Text variant="body-2" color={item.input_pipelines.length === 0 ? 'secondary' : undefined}>
+                    {formatPipelines(item.input_pipelines)}
                 </Text>
             ),
         },
         {
-            id: 'outputPipelines',
+            id: 'output_pipelines',
             name: 'Output Pipelines',
             template: (item: DeviceRowData) => (
-                <Text variant="body-2" color={item.outputPipelines.length === 0 ? 'secondary' : undefined}>
-                    {formatPipelines(item.outputPipelines)}
+                <Text variant="body-2" color={item.output_pipelines.length === 0 ? 'secondary' : undefined}>
+                    {formatPipelines(item.output_pipelines)}
                 </Text>
             ),
         },

--- a/web/src/pages/inspect/sections/ModulesSection.tsx
+++ b/web/src/pages/inspect/sections/ModulesSection.tsx
@@ -11,7 +11,7 @@ export interface ModulesSectionProps {
 }
 
 export const ModulesSection: React.FC<ModulesSectionProps> = ({ instance }) => {
-    const modules = instance.dpModules ?? [];
+    const modules = instance.dp_modules ?? [];
 
     return (
         <InspectSection
@@ -25,7 +25,7 @@ export const ModulesSection: React.FC<ModulesSectionProps> = ({ instance }) => {
             {modules.length > 0 ? (
                 <Box className="modules-grid">
                     {modules.map((module) => {
-                        const configCount = instance.cpConfigs?.filter(
+                        const configCount = instance.cp_configs?.filter(
                             (cfg) => cfg.type?.toLowerCase() === module.name?.toLowerCase()
                         ).length || 0;
 

--- a/web/src/pages/pdump/ConfigDialog.tsx
+++ b/web/src/pages/pdump/ConfigDialog.tsx
@@ -43,7 +43,7 @@ export const ConfigDialog: React.FC<ConfigDialogProps> = ({
                 setFilter(initialConfig.filter ?? '');
                 setModes(initialConfig.mode ? parseModeFlags(initialConfig.mode) : []);
                 setSnaplen(initialConfig.snaplen?.toString() ?? '');
-                setRingSize(initialConfig.ringSize?.toString() ?? '');
+                setRingSize(initialConfig.ring_size?.toString() ?? '');
             } else {
                 setConfigName(initialConfigName ?? '');
                 setFilter('');
@@ -75,7 +75,7 @@ export const ConfigDialog: React.FC<ConfigDialogProps> = ({
                 filter: filter || '',
                 mode: modeFlagsToNumber(modes),
                 snaplen: snaplen ? parseInt(snaplen, 10) : undefined,
-                ringSize: ringSize ? parseInt(ringSize, 10) : undefined,
+                ring_size: ringSize ? parseInt(ringSize, 10) : undefined,
             };
 
             // Build update mask with all fields that should be updated
@@ -83,7 +83,7 @@ export const ConfigDialog: React.FC<ConfigDialogProps> = ({
             if (config.snaplen !== undefined) {
                 paths.push('snaplen');
             }
-            if (config.ringSize !== undefined) {
+            if (config.ring_size !== undefined) {
                 paths.push('ring_size');
             }
 

--- a/web/src/pages/pdump/PacketDetails.tsx
+++ b/web/src/pages/pdump/PacketDetails.tsx
@@ -39,13 +39,13 @@ export const PacketDetails: React.FC<PacketDetailsProps> = ({ packet }) => {
 
             {/* Metadata */}
             <Section title="Capture Info">
-                <Field label="Worker" value={record.meta?.workerIdx ?? 'N/A'} />
-                <Field label="Pipeline" value={record.meta?.pipelineIdx ?? 'N/A'} />
-                <Field label="RX Device" value={record.meta?.rxDeviceId ?? 'N/A'} />
-                <Field label="TX Device" value={record.meta?.txDeviceId ?? 'N/A'} />
+                <Field label="Worker" value={record.meta?.worker_idx ?? 'N/A'} />
+                <Field label="Pipeline" value={record.meta?.pipeline_idx ?? 'N/A'} />
+                <Field label="RX Device" value={record.meta?.rx_device_id ?? 'N/A'} />
+                <Field label="TX Device" value={record.meta?.tx_device_id ?? 'N/A'} />
                 <Field label="Queue" value={record.meta?.queue ?? 'N/A'} />
-                <Field label="Packet Length" value={record.meta?.packetLen ?? parsed.raw.length} />
-                <Field label="Captured" value={record.meta?.dataSize ?? parsed.raw.length} />
+                <Field label="Packet Length" value={record.meta?.packet_len ?? parsed.raw.length} />
+                <Field label="Captured" value={record.meta?.data_size ?? parsed.raw.length} />
             </Section>
 
             {/* Ethernet */}

--- a/web/src/pages/pdump/PacketDetailsDialog.tsx
+++ b/web/src/pages/pdump/PacketDetailsDialog.tsx
@@ -61,13 +61,13 @@ export const PacketDetailsDialog: React.FC<PacketDetailsDialogProps> = ({
                     {/* Capture Info */}
                     <Section title="Capture Info">
                         <Flex gap={4} className="packet-dialog__flex-wrap">
-                            <Field label="Worker" value={record.meta?.workerIdx ?? 'N/A'} />
-                            <Field label="Pipeline" value={record.meta?.pipelineIdx ?? 'N/A'} />
-                            <Field label="RX Device" value={record.meta?.rxDeviceId ?? 'N/A'} />
-                            <Field label="TX Device" value={record.meta?.txDeviceId ?? 'N/A'} />
+                            <Field label="Worker" value={record.meta?.worker_idx ?? 'N/A'} />
+                            <Field label="Pipeline" value={record.meta?.pipeline_idx ?? 'N/A'} />
+                            <Field label="RX Device" value={record.meta?.rx_device_id ?? 'N/A'} />
+                            <Field label="TX Device" value={record.meta?.tx_device_id ?? 'N/A'} />
                             <Field label="Queue" value={record.meta?.queue ?? 'N/A'} />
-                            <Field label="Length" value={record.meta?.packetLen ?? parsed.raw.length} />
-                            <Field label="Captured" value={record.meta?.dataSize ?? parsed.raw.length} />
+                            <Field label="Length" value={record.meta?.packet_len ?? parsed.raw.length} />
+                            <Field label="Captured" value={record.meta?.data_size ?? parsed.raw.length} />
                         </Flex>
                     </Section>
 

--- a/web/src/pages/pipelines/hooks.ts
+++ b/web/src/pages/pipelines/hooks.ts
@@ -295,12 +295,12 @@ export const useFunctionCounters = (
         const fetchDevices = async () => {
             try {
                 const response = await API.inspect.inspect();
-                const allDevices = response.instanceInfo?.devices ?? [];
+                const allDevices = response.instance_info?.devices ?? [];
                 
                 // Find devices that use this pipeline
                 const matchingDevices = allDevices.filter(device => {
-                    const inputPipelines = device.inputPipelines ?? [];
-                    const outputPipelines = device.outputPipelines ?? [];
+                    const inputPipelines = device.input_pipelines ?? [];
+                    const outputPipelines = device.output_pipelines ?? [];
                     return inputPipelines.some(p => p.name === pipelineName) ||
                            outputPipelines.some(p => p.name === pipelineName);
                 });

--- a/web/src/pages/route/AddRouteDialog.tsx
+++ b/web/src/pages/route/AddRouteDialog.tsx
@@ -14,7 +14,7 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
     validateNexthop: validateNexthopFn,
 }) => {
     const prefixError = validatePrefixFn(form.prefix);
-    const nexthopError = validateNexthopFn(form.nexthopAddr);
+    const nexthopError = validateNexthopFn(form.nexthop_addr);
     const configNameError = !form.configName.trim() ? 'Config name is required' : undefined;
 
     const handleConfigNameChange = (value: string): void => {
@@ -26,11 +26,11 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
     };
 
     const handleNexthopChange = (value: string): void => {
-        onFormChange({ ...form, nexthopAddr: value });
+        onFormChange({ ...form, nexthop_addr: value });
     };
 
     const handleDoFlushChange = (checked: boolean): void => {
-        onFormChange({ ...form, doFlush: checked });
+        onFormChange({ ...form, do_flush: checked });
     };
 
     return (
@@ -72,7 +72,7 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
                         hint="IP address of the next hop (IPv4 or IPv6)"
                     >
                         <TextInput
-                            value={form.nexthopAddr}
+                            value={form.nexthop_addr}
                             onUpdate={handleNexthopChange}
                             placeholder="192.168.1.1 or 2001:db8::1"
                             validationState={nexthopError ? 'invalid' : undefined}
@@ -83,7 +83,7 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
                     <Box>
                         <Box className="add-route-dialog__switch-row">
                             <Switch
-                                checked={form.doFlush}
+                                checked={form.do_flush}
                                 onUpdate={handleDoFlushChange}
                             />
                             <Text variant="body-1">Flush RIB to FIB</Text>

--- a/web/src/pages/route/RouteListItem.tsx
+++ b/web/src/pages/route/RouteListItem.tsx
@@ -6,7 +6,7 @@ import './route.css';
 export const RouteListItem: React.FC<RouteListItemProps> = ({ route }) => (
     <Box className="route-list-item">
         <Text variant="body-1">
-            {route.prefix || '-'} → {route.nextHop || '-'}
+            {route.prefix || '-'} → {route.next_hop || '-'}
             {route.peer && ` (peer: ${route.peer})`}
         </Text>
     </Box>

--- a/web/src/pages/route/TableHeader.tsx
+++ b/web/src/pages/route/TableHeader.tsx
@@ -28,11 +28,11 @@ export const TableHeader: React.FC<TableHeaderProps> = ({
                 <Text variant="subheader-1">#</Text>
             </Box>
             <SortableHeader column="prefix" label="Prefix" style={cellStyles.prefix} sortState={sortState} onSort={onSort} disabled={!canSort} />
-            <SortableHeader column="nextHop" label="Next Hop" style={cellStyles.nextHop} sortState={sortState} onSort={onSort} disabled={!canSort} />
+            <SortableHeader column="next_hop" label="Next Hop" style={cellStyles.next_hop} sortState={sortState} onSort={onSort} disabled={!canSort} />
             <SortableHeader column="peer" label="Peer" style={cellStyles.peer} sortState={sortState} onSort={onSort} disabled={!canSort} />
-            <SortableHeader column="isBest" label="Best" style={cellStyles.isBest} sortState={sortState} onSort={onSort} disabled={!canSort} />
+            <SortableHeader column="is_best" label="Best" style={cellStyles.is_best} sortState={sortState} onSort={onSort} disabled={!canSort} />
             <SortableHeader column="pref" label="Pref" style={cellStyles.pref} sortState={sortState} onSort={onSort} disabled={!canSort} />
-            <SortableHeader column="asPathLen" label="AS Path" style={cellStyles.asPathLen} sortState={sortState} onSort={onSort} disabled={!canSort} />
+            <SortableHeader column="as_path_len" label="AS Path" style={cellStyles.as_path_len} sortState={sortState} onSort={onSort} disabled={!canSort} />
             <SortableHeader column="source" label="Source" style={cellStyles.source} sortState={sortState} onSort={onSort} disabled={!canSort} />
         </Box>
     );

--- a/web/src/pages/route/VirtualRow.tsx
+++ b/web/src/pages/route/VirtualRow.tsx
@@ -42,11 +42,11 @@ export const VirtualRow = ({ route, index, start, isSelected, onSelect }: Virtua
             </div>
             <div style={cellStyles.index}>{index + 1}</div>
             <div style={cellStyles.prefix}>{route.prefix || '-'}</div>
-            <div style={cellStyles.nextHop}>{route.nextHop || '-'}</div>
+            <div style={cellStyles.next_hop}>{route.next_hop || '-'}</div>
             <div style={cellStyles.peer}>{route.peer || '-'}</div>
-            <div style={cellStyles.isBest}>{route.isBest ? 'Yes' : 'No'}</div>
+            <div style={cellStyles.is_best}>{route.is_best ? 'Yes' : 'No'}</div>
             <div style={cellStyles.pref}>{route.pref ?? '-'}</div>
-            <div style={cellStyles.asPathLen}>{route.asPathLen ?? '-'}</div>
+            <div style={cellStyles.as_path_len}>{route.as_path_len ?? '-'}</div>
             <div style={cellStyles.source}>{ROUTE_SOURCES[route.source ?? 0] || 'Unknown'}</div>
         </div>
     );

--- a/web/src/pages/route/VirtualizedRouteTable.tsx
+++ b/web/src/pages/route/VirtualizedRouteTable.tsx
@@ -63,7 +63,7 @@ export const VirtualizedRouteTable: React.FC<VirtualizedRouteTableProps> = ({
             const lowerQuery = searchQuery.toLowerCase();
             result = result.filter(route =>
                 route.prefix?.toLowerCase().includes(lowerQuery) ||
-                route.nextHop?.toLowerCase().includes(lowerQuery) ||
+                route.next_hop?.toLowerCase().includes(lowerQuery) ||
                 route.peer?.toLowerCase().includes(lowerQuery)
             );
         }

--- a/web/src/pages/route/constants.ts
+++ b/web/src/pages/route/constants.ts
@@ -12,11 +12,11 @@ export const COLUMN_WIDTHS = {
     checkbox: 40,
     index: 90,
     prefix: 320,
-    nextHop: 320,
+    next_hop: 320,
     peer: 320,
-    isBest: 60,
+    is_best: 60,
     pref: 60,
-    asPathLen: 80,
+    as_path_len: 80,
     source: 80,
 } as const;
 
@@ -53,10 +53,10 @@ export const cellStyles: Record<keyof typeof COLUMN_WIDTHS, React.CSSProperties>
         whiteSpace: 'nowrap',
         userSelect: 'text',
     },
-    nextHop: {
-        width: COLUMN_WIDTHS.nextHop,
-        minWidth: COLUMN_WIDTHS.nextHop,
-        maxWidth: COLUMN_WIDTHS.nextHop,
+    next_hop: {
+        width: COLUMN_WIDTHS.next_hop,
+        minWidth: COLUMN_WIDTHS.next_hop,
+        maxWidth: COLUMN_WIDTHS.next_hop,
         paddingRight: 8,
         overflow: 'hidden',
         textOverflow: 'ellipsis',
@@ -73,10 +73,10 @@ export const cellStyles: Record<keyof typeof COLUMN_WIDTHS, React.CSSProperties>
         whiteSpace: 'nowrap',
         userSelect: 'text',
     },
-    isBest: {
-        width: COLUMN_WIDTHS.isBest,
-        minWidth: COLUMN_WIDTHS.isBest,
-        maxWidth: COLUMN_WIDTHS.isBest,
+    is_best: {
+        width: COLUMN_WIDTHS.is_best,
+        minWidth: COLUMN_WIDTHS.is_best,
+        maxWidth: COLUMN_WIDTHS.is_best,
         paddingRight: 8,
         userSelect: 'text',
     },
@@ -87,10 +87,10 @@ export const cellStyles: Record<keyof typeof COLUMN_WIDTHS, React.CSSProperties>
         paddingRight: 8,
         userSelect: 'text',
     },
-    asPathLen: {
-        width: COLUMN_WIDTHS.asPathLen,
-        minWidth: COLUMN_WIDTHS.asPathLen,
-        maxWidth: COLUMN_WIDTHS.asPathLen,
+    as_path_len: {
+        width: COLUMN_WIDTHS.as_path_len,
+        minWidth: COLUMN_WIDTHS.as_path_len,
+        maxWidth: COLUMN_WIDTHS.as_path_len,
         paddingRight: 8,
         userSelect: 'text',
     },

--- a/web/src/pages/route/hooks.ts
+++ b/web/src/pages/route/hooks.ts
@@ -23,12 +23,12 @@ export const useRouteColumns = (): TableColumnConfig<Route>[] => {
             template: (item: Route) => item.prefix || '-',
         },
         {
-            id: 'nextHop',
+            id: 'next_hop',
             name: 'Next Hop',
             meta: {
-                sort: (a: Route, b: Route) => compareNullableStrings(a.nextHop, b.nextHop),
+                sort: (a: Route, b: Route) => compareNullableStrings(a.next_hop, b.next_hop),
             },
-            template: (item: Route) => item.nextHop || '-',
+            template: (item: Route) => item.next_hop || '-',
         },
         {
             id: 'peer',
@@ -39,12 +39,12 @@ export const useRouteColumns = (): TableColumnConfig<Route>[] => {
             template: (item: Route) => item.peer || '-',
         },
         {
-            id: 'isBest',
+            id: 'is_best',
             name: 'Best',
             meta: {
-                sort: (a: Route, b: Route) => compareBooleans(a.isBest, b.isBest),
+                sort: (a: Route, b: Route) => compareBooleans(a.is_best, b.is_best),
             },
-            template: (item: Route) => item.isBest ? 'Yes' : 'No',
+            template: (item: Route) => item.is_best ? 'Yes' : 'No',
         },
         {
             id: 'pref',
@@ -55,12 +55,12 @@ export const useRouteColumns = (): TableColumnConfig<Route>[] => {
             template: (item: Route) => item.pref?.toString() || '-',
         },
         {
-            id: 'asPathLen',
+            id: 'as_path_len',
             name: 'AS Path Len',
             meta: {
-                sort: (a: Route, b: Route) => compareNullableNumbers(a.asPathLen, b.asPathLen),
+                sort: (a: Route, b: Route) => compareNullableNumbers(a.as_path_len, b.as_path_len),
             },
-            template: (item: Route) => item.asPathLen?.toString() || '-',
+            template: (item: Route) => item.as_path_len?.toString() || '-',
         },
         {
             id: 'source',
@@ -98,11 +98,11 @@ export const useConfigRoutesData = (
  */
 export const sortComparators: Record<SortableColumn, (a: Route, b: Route) => number> = {
     prefix: (a, b) => (a.prefix || '').localeCompare(b.prefix || ''),
-    nextHop: (a, b) => (a.nextHop || '').localeCompare(b.nextHop || ''),
+    next_hop: (a, b) => (a.next_hop || '').localeCompare(b.next_hop || ''),
     peer: (a, b) => (a.peer || '').localeCompare(b.peer || ''),
-    isBest: (a, b) => (a.isBest ? 1 : 0) - (b.isBest ? 1 : 0),
+    is_best: (a, b) => (a.is_best ? 1 : 0) - (b.is_best ? 1 : 0),
     pref: (a, b) => (a.pref ?? 0) - (b.pref ?? 0),
-    asPathLen: (a, b) => (a.asPathLen ?? 0) - (b.asPathLen ?? 0),
+    as_path_len: (a, b) => (a.as_path_len ?? 0) - (b.as_path_len ?? 0),
     source: (a, b) => (a.source ?? 0) - (b.source ?? 0),
 };
 

--- a/web/src/pages/route/mockData.ts
+++ b/web/src/pages/route/mockData.ts
@@ -79,16 +79,16 @@ export const createMockRouteGenerator = (totalCount: number, seed: number = 42):
 
         return {
             prefix,
-            nextHop,
+            next_hop: nextHop,
             peer,
-            routeDistinguisher: rng.nextInt(1, 65535),
-            peerAs: rng.nextInt(1, 65535),
-            originAs: rng.nextInt(1, 65535),
+            route_distinguisher: rng.nextInt(1, 65535),
+            peer_as: rng.nextInt(1, 65535),
+            origin_as: rng.nextInt(1, 65535),
             med: rng.nextInt(0, 1000),
             pref: rng.nextInt(0, 200),
-            asPathLen: rng.nextInt(1, 10),
+            as_path_len: rng.nextInt(1, 10),
             source: rng.nextInt(0, 2),
-            isBest: rng.next() > 0.5,
+            is_best: rng.next() > 0.5,
         };
     };
 
@@ -146,7 +146,7 @@ export const createMockRouteGenerator = (totalCount: number, seed: number = 42):
             const route = getRoute(i);
             const matches =
                 route.prefix?.toLowerCase().includes(lowerQuery) ||
-                route.nextHop?.toLowerCase().includes(lowerQuery) ||
+                route.next_hop?.toLowerCase().includes(lowerQuery) ||
                 route.peer?.toLowerCase().includes(lowerQuery);
 
             if (matches) {

--- a/web/src/pages/route/types.ts
+++ b/web/src/pages/route/types.ts
@@ -5,8 +5,8 @@ import type { Route } from '../../api/routes';
 export interface AddRouteFormData {
     configName: string;
     prefix: string;
-    nexthopAddr: string;
-    doFlush: boolean;
+    nexthop_addr: string;
+    do_flush: boolean;
 }
 
 // Route table common props
@@ -78,7 +78,7 @@ export interface ConfigTabsProps extends RoutesByConfigProps { }
 export interface RouteConfigContentProps extends RoutesByConfigProps { }
 
 // Sorting types
-export type SortableColumn = 'prefix' | 'nextHop' | 'peer' | 'isBest' | 'pref' | 'asPathLen' | 'source';
+export type SortableColumn = 'prefix' | 'next_hop' | 'peer' | 'is_best' | 'pref' | 'as_path_len' | 'source';
 export type SortDirection = 'asc' | 'desc';
 
 export interface SortState {

--- a/web/src/pages/route/utils.ts
+++ b/web/src/pages/route/utils.ts
@@ -7,7 +7,7 @@ import {
 } from '../../utils';
 
 export const getRouteId = (route: Route): string => {
-    return `${route.prefix || ''}_${route.nextHop || ''}_${route.peer || ''}_${route.routeDistinguisher || ''}`;
+    return `${route.prefix || ''}_${route.next_hop || ''}_${route.peer || ''}_${route.route_distinguisher || ''}`;
 };
 
 export const validatePrefix = (prefix: string): string | undefined => {


### PR DESCRIPTION
Replace protojson.Marshal() with encoding/json streaming serialization in the gRPC-to-HTTP gateway for significantly improved performance on large API responses.

Performance improvement on 137MB ACL ruleset:
- Before: 5.07s
- After: 3.04s (~40% faster)

Key changes:
- Use json.NewEncoder().Encode() for streaming serialization directly to http.ResponseWriter, avoiding large in-memory buffer allocation
- Update frontend to use snake_case field names matching encoding/json output (e.g. next_hop instead of nextHop)