### PR TITLE
fix(web): convert weight to number before sending to API

### DIFF
--- a/web/src/pages/functions/utils.ts
+++ b/web/src/pages/functions/utils.ts
@@ -391,7 +391,7 @@ export const graphToApi = (
                 name: path.chainName,
                 modules,
             },
-            weight: path.weight,
+            weight: parseInt(String(path.weight), 10),
         };
     });
 


### PR DESCRIPTION
The weight field was being sent as a string from the text input, but the backend expects uint64. This caused JSON unmarshal error: 'cannot unmarshal string into Go struct field FunctionChain.function.chains.weight of type uint64'