### PR TITLE
feat(counters): add query filter for module counters API

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 struct dp_config;
@@ -46,6 +47,7 @@ yanet_get_chain_counters(
 	const char *chain_name
 );
 
+// Get module counters, optionally filtered by name.
 struct counter_handle_list *
 yanet_get_module_counters(
 	struct dp_config *dp_config,
@@ -54,7 +56,9 @@ yanet_get_module_counters(
 	const char *function_name,
 	const char *chain_name,
 	const char *module_type,
-	const char *module_name
+	const char *module_name,
+	const char *const *query,
+	size_t query_count
 );
 
 struct counter_handle_list *

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -226,6 +226,7 @@ impl CountersService {
             chain: chain_name,
             module_type,
             module_name,
+            counter_query: Vec::new(),
         };
         let response = self.client.module(request).await?;
         println!("{}", serde_json::to_string(response.get_ref())?);

--- a/controlplane/internal/gateway/counters_service.go
+++ b/controlplane/internal/gateway/counters_service.go
@@ -111,15 +111,16 @@ func (m *CountersService) Module(
 	ctx context.Context,
 	request *ynpb.ModuleCountersRequest,
 ) (*ynpb.CountersResponse, error) {
-	device := request.GetDevice()
-	pipeline := request.GetPipeline()
-	function := request.GetFunction()
-	chain := request.GetChain()
-	moduleType := request.GetModuleType()
-	moduleName := request.GetModuleName()
-
 	dpConfig := m.shm.DPConfig(m.instanceID)
-	counterValues := dpConfig.ModuleCounters(device, pipeline, function, chain, moduleType, moduleName)
+	counterValues := dpConfig.ModuleCounters(
+		request.GetDevice(),
+		request.GetPipeline(),
+		request.GetFunction(),
+		request.GetChain(),
+		request.GetModuleType(),
+		request.GetModuleName(),
+		request.GetCounterQuery(),
+	)
 
 	response := &ynpb.CountersResponse{
 		Counters: m.encodeCounters(counterValues),

--- a/controlplane/ynpb/counters.proto
+++ b/controlplane/ynpb/counters.proto
@@ -47,6 +47,11 @@ message ModuleCountersRequest {
 	string chain = 4;
 	string module_type = 5;
 	string module_name = 6;
+	// CounterQuery filters counters by name. If empty, returns all
+	// counters.
+	//
+	// TODO: support wildcards or regex?
+	repeated string counter_query = 7;
 }
 
 message CounterInstanceInfo {

--- a/modules/balancer/controlplane/handler/stats.c
+++ b/modules/balancer/controlplane/handler/stats.c
@@ -258,7 +258,9 @@ packet_handler_fill_stats(
 		ref->function,
 		ref->chain,
 		"balancer",
-		module
+		module,
+		NULL,
+		(size_t)-1
 	);
 	assert(counter_handles != NULL);
 

--- a/modules/route/bird-adapter/proto/bird_import.proto
+++ b/modules/route/bird-adapter/proto/bird_import.proto
@@ -6,7 +6,8 @@ option go_package = "github.com/yanet-platform/yanet2/modules/route/bird-adapter
 
 // AdapterService provides configuration for the BIRD import adapter.
 service AdapterService {
-	// SetupConfig configures the BIRD import settings for a specific module.
+	// SetupConfig configures the BIRD import settings for a specific
+	// module.
 	rpc SetupConfig(SetupConfigRequest) returns (SetupConfigResponse);
 }
 

--- a/web/src/api/counters.ts
+++ b/web/src/api/counters.ts
@@ -43,6 +43,10 @@ export interface ModuleCountersRequest {
     chain: string;
     module_type: string;
     module_name: string;
+    // Filter counters by name.
+    // 
+    // If empty, returns all counters.
+    counter_query?: string[];
 }
 
 const countersService = createService('ynpb.CountersService');

--- a/web/src/pages/functions/hooks.ts
+++ b/web/src/pages/functions/hooks.ts
@@ -384,6 +384,7 @@ export const useModuleCounters = (
                             chain: moduleInfo.chainName,
                             module_type: moduleInfo.moduleType,
                             module_name: moduleInfo.moduleName,
+                            counter_query: ['rx', 'rx_bytes'],
                         });
                         
                         // Module counters are named 'rx' and 'rx_bytes'


### PR DESCRIPTION
Adds the ability to filter module counters by name at the C level, significantly reducing data transfer and CGO overhead for clients that only need specific counters.

Previously, fetching module counters returned all counters (10000+ for ACL modules), resulting in 640,000 CGO calls and 100-300ms latency. With the new counter_query parameter, clients can request only the counters they need (e.g., 'rx', 'rx_bytes'), reducing response time to ~1-5ms.

In the future we can change the underlying filtering mechanism using hashmaps or regex state machines.