### PR TITLE
Packet pipeline refactoring

### DIFF
--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -72,7 +72,11 @@ worker_read(struct dataplane_worker *worker, struct packet_list *packets) {
 		// Preserve device by default
 		packet->tx_device_id = worker->device_id;
 
-		parse_packet(packet);
+		if (parse_packet(packet)) {
+			struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+			rte_pktmbuf_free(mbuf);
+			continue;
+		}
 		packet_list_add(packets, packet);
 	}
 }
@@ -274,7 +278,6 @@ worker_loop_round(struct dataplane_worker *worker) {
 			tsc_clock_get_time_ns(&dp_worker->clock);
 	}
 
-	struct dp_config *dp_config = worker->instance->dp_config;
 	struct cp_config *cp_config = worker->instance->cp_config;
 	struct cp_config_gen *cp_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
@@ -284,89 +287,107 @@ worker_loop_round(struct dataplane_worker *worker) {
 	worker->dp_worker->gen = cp_config_gen->gen;
 	*worker->dp_worker->iterations += 1;
 
-	struct packet_list input_packets;
-	packet_list_init(&input_packets);
-	struct packet_list output_packets;
-	packet_list_init(&output_packets);
-	struct packet_list drop_packets;
-	packet_list_init(&drop_packets);
-
-	worker_read(worker, &input_packets);
-
-	if (config_gen_ectx == NULL) {
-		packet_list_concat(&drop_packets, &input_packets);
-		packet_list_init(&input_packets);
-	}
-
 	struct packet_front packet_front;
 	packet_front_init(&packet_front);
 
-	while (packet_list_first(&input_packets)) {
-		struct packet *packet = packet_list_pop(&input_packets);
-		packet->pipeline_ectx = NULL;
+	worker_read(worker, &packet_front.pending_input);
 
-		struct device_ectx *device_ectx =
-			ADDR_OF(config_gen_ectx->devices + packet->rx_device_id
+	if (config_gen_ectx == NULL) {
+		worker_write(worker, &packet_front.drop);
+
+		packet_list_concat(
+			&packet_front.drop, &packet_front.pending_input
+		);
+
+		dataplane_drop_packets(worker->dataplane, &packet_front.drop);
+
+		return;
+	}
+
+	uint64_t device_count =
+		cp_config_gen->device_registry.registry.capacity;
+
+	while (1) {
+
+		struct packet_front schedule_input[device_count];
+		for (uint64_t idx = 0; idx < device_count; ++idx)
+			packet_front_init(schedule_input + idx);
+
+		struct packet_front schedule_output[device_count];
+		for (uint64_t idx = 0; idx < device_count; ++idx)
+			packet_front_init(schedule_output + idx);
+
+		struct packet *packet;
+
+		int empty = 1;
+
+		while ((packet = packet_list_pop(&packet_front.pending_input)
+		       ) != NULL) {
+			empty = 0;
+			packet_front_output(
+				schedule_input + packet->tx_device_id, packet
 			);
-		if (device_ectx == NULL) {
-			packet_list_add(&drop_packets, packet);
-			continue;
 		}
 
-		device_ectx_process_input(
-			worker->dp_worker, device_ectx, &packet_front, packet
-		);
-	}
-
-	packet_list_concat(&drop_packets, &packet_front.drop);
-
-	// Now group packets by pipeline and build packet_front
-	while (packet_list_first(&packet_front.pending)) {
-		struct packet *packet =
-			packet_list_first(&packet_front.pending);
-		struct pipeline_ectx *pipeline_ectx = packet->pipeline_ectx;
-
-		struct packet_list pending_packets;
-		packet_list_init(&pending_packets);
-
-		while ((packet = packet_list_pop(&packet_front.pending))) {
-			if (packet->pipeline_ectx == pipeline_ectx) {
-				packet_front_output(&packet_front, packet);
-			} else {
-				packet_list_add(&pending_packets, packet);
-			}
+		while ((packet = packet_list_pop(&packet_front.pending_output)
+		       ) != NULL) {
+			empty = 0;
+			packet_front_output(
+				schedule_output + packet->tx_device_id, packet
+			);
 		}
 
-		/*
-		 * All the packets with the same pipeline_ectx are ready to
-		 * process, so return postponed packet into pending
-		 * queue.
-		 */
-		packet_list_concat(&packet_front.pending, &pending_packets);
+		if (empty)
+			break;
 
-		pipeline_ectx_process(
-			dp_config,
-			worker->dp_worker,
-			cp_config_gen,
-			pipeline_ectx,
-			&packet_front
-		);
+		struct device_ectx **devices = config_gen_ectx->devices;
 
-		packet_list_concat(&drop_packets, &packet_front.drop);
-		packet_list_init(&packet_front.drop);
-		packet_list_concat(&output_packets, &packet_front.output);
-		packet_list_init(&packet_front.output);
+		for (uint64_t idx = 0; idx < device_count; ++idx) {
+			if (packet_list_first(&schedule_input[idx].output) ==
+			    NULL)
+				continue;
+
+			struct device_ectx *device_ectx =
+				ADDR_OF(devices + idx);
+
+			device_ectx_process_input(
+				worker->dp_worker,
+				device_ectx,
+				schedule_input + idx
+			);
+
+			packet_front_merge(&packet_front, schedule_input + idx);
+		}
+
+		for (uint64_t idx = 0; idx < device_count; ++idx) {
+			if (packet_list_first(&schedule_output[idx].output) ==
+			    NULL)
+				continue;
+
+			struct device_ectx *device_ectx =
+				ADDR_OF(devices + idx);
+
+			device_ectx_process_output(
+				worker->dp_worker,
+				device_ectx,
+				schedule_output + idx
+			);
+
+			packet_front_merge(
+				&packet_front, schedule_output + idx
+			);
+		}
 	}
 
-	worker_write(worker, &output_packets);
+	worker_write(worker, &packet_front.output);
 
 	/*
 	 * `output_packets` now contains failed-to-transmit packets which
 	 * should be freed.
 	 */
-	packet_list_concat(&drop_packets, &output_packets);
+	packet_list_concat(&packet_front.drop, &packet_front.output);
 
-	dataplane_drop_packets(worker->dataplane, &drop_packets);
+	dataplane_drop_packets(worker->dataplane, &packet_front.drop);
 }
 
 static void *

--- a/devices/plain/dataplane/dataplane.c
+++ b/devices/plain/dataplane/dataplane.c
@@ -2,30 +2,34 @@
 
 #include "common/container_of.h"
 
-#include "dataplane/module/module.h"
+#include "lib/dataplane/device/device.h"
+
 #include "dataplane/packet/packet.h"
+
 #include "dataplane/pipeline/pipeline.h"
 
 static void
 plain_input_handle(
 	struct dp_worker *dp_worker,
 	struct device_ectx *device_ectx,
-	struct packet *packet
+	struct packet_front *packet_front
 ) {
 	(void)dp_worker;
 	(void)device_ectx;
-	(void)packet;
+
+	packet_list_concat(&packet_front->output, &packet_front->input);
 }
 
 static void
 plain_output_handle(
 	struct dp_worker *dp_worker,
 	struct device_ectx *device_ectx,
-	struct packet *packet
+	struct packet_front *packet_front
 ) {
 	(void)dp_worker;
 	(void)device_ectx;
-	(void)packet;
+
+	packet_list_concat(&packet_front->output, &packet_front->input);
 }
 
 struct device_plain {

--- a/devices/vlan/dataplane/dataplane.c
+++ b/devices/vlan/dataplane/dataplane.c
@@ -4,26 +4,40 @@
 
 #include "common/container_of.h"
 
+#include "common/container_of.h"
+
 #include "dataplane/module/module.h"
+#include "dataplane/module/packet_front.h"
+
+#include "lib/dataplane/device/device.h"
+
 #include "dataplane/packet/packet.h"
+
 #include "dataplane/pipeline/pipeline.h"
 
 static void
 vlan_input_handle(
 	struct dp_worker *dp_worker,
 	struct device_ectx *device_ectx,
-	struct packet *packet
+	struct packet_front *packet_front
 ) {
 	(void)dp_worker;
 	(void)device_ectx;
-	(void)packet;
+
+	struct packet *packet = packet_list_pop(&packet_front->input);
+
+	while (packet != NULL) {
+		packet_front_output(packet_front, packet);
+
+		packet = packet_list_pop(&packet_front->input);
+	}
 }
 
 static void
 vlan_output_handle(
 	struct dp_worker *dp_worker,
 	struct device_ectx *device_ectx,
-	struct packet *packet
+	struct packet_front *packet_front
 ) {
 	(void)dp_worker;
 
@@ -31,93 +45,110 @@ vlan_output_handle(
 	struct cp_device_vlan *cp_device_vlan =
 		container_of(cp_device, struct cp_device_vlan, cp_device);
 
-	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
-	uint16_t offset = 0;
-	if (rte_pktmbuf_pkt_len(mbuf) < sizeof(struct rte_ether_hdr)) {
-		goto error_invalid;
-	}
+	struct packet *packet = packet_list_pop(&packet_front->input);
 
-	struct rte_ether_hdr *ether_hdr =
-		rte_pktmbuf_mtod_offset(mbuf, struct rte_ether_hdr *, 0);
-	offset += sizeof(struct rte_ether_hdr);
-
-	if (cp_device_vlan->vlan == 0) {
-		if (ether_hdr->ether_type !=
-		    rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN)) {
-			/*
-			 * No output tag is set for device and the packet does
-			 * not have one - nothing to do.
-			 */
-			return;
+	while (packet != NULL) {
+		struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+		uint16_t offset = 0;
+		if (rte_pktmbuf_pkt_len(mbuf) < sizeof(struct rte_ether_hdr)) {
+			packet_front_drop(packet_front, packet);
+			goto next;
 		}
 
-		/*
-		 * We do not care about the header after the vlan one so just
-		 * drop the vlan.
-		 */
-		if (rte_pktmbuf_pkt_len(mbuf) <
-		    sizeof(struct rte_ether_hdr) + offset) {
-			goto error_invalid;
-		}
-
-		struct rte_vlan_hdr *vlan_hdr = rte_pktmbuf_mtod_offset(
-			mbuf, struct rte_vlan_hdr *, offset
+		struct rte_ether_hdr *ether_hdr = rte_pktmbuf_mtod_offset(
+			mbuf, struct rte_ether_hdr *, 0
 		);
-		ether_hdr->ether_type = vlan_hdr->eth_proto;
+		offset += sizeof(struct rte_ether_hdr);
 
-		memmove(rte_pktmbuf_mtod_offset(
+		if (cp_device_vlan->vlan == 0) {
+			if (ether_hdr->ether_type !=
+			    rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN)) {
+				/*
+				 * No output tag is set for device and the
+				 * packet does not have one - nothing to do.
+				 */
+				packet_front_output(packet_front, packet);
+				goto next;
+			}
+
+			/*
+			 * We do not care about the header after the vlan one so
+			 * just drop the vlan.
+			 */
+			if (rte_pktmbuf_pkt_len(mbuf) <
+			    sizeof(struct rte_ether_hdr) + offset) {
+				packet_front_drop(packet_front, packet);
+				goto next;
+			}
+
+			struct rte_vlan_hdr *vlan_hdr = rte_pktmbuf_mtod_offset(
+				mbuf, struct rte_vlan_hdr *, offset
+			);
+			ether_hdr->ether_type = vlan_hdr->eth_proto;
+
+			memmove(rte_pktmbuf_mtod_offset(
+					mbuf,
+					char *,
+					sizeof(struct rte_vlan_hdr)
+				),
+				rte_pktmbuf_mtod(mbuf, char *),
+				sizeof(struct rte_ether_hdr));
+			rte_pktmbuf_adj(mbuf, sizeof(struct rte_vlan_hdr));
+
+			packet_front_output(packet_front, packet);
+			goto next;
+		}
+
+		// We have to set vlan tag
+		if (ether_hdr->ether_type ==
+		    rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN)) {
+			if (rte_pktmbuf_pkt_len(mbuf) <
+			    sizeof(struct rte_ether_hdr) + offset) {
+				packet_front_drop(packet_front, packet);
+				goto next;
+			}
+
+			struct rte_vlan_hdr *vlan_hdr = rte_pktmbuf_mtod_offset(
+				mbuf, struct rte_vlan_hdr *, offset
+			);
+
+			// Just update the tag
+			vlan_hdr->vlan_tci =
+				rte_cpu_to_be_16(cp_device_vlan->vlan);
+
+			packet_front_output(packet_front, packet);
+			goto next;
+		}
+
+		// Inject new vlan header
+		// FIXME: check error
+		rte_pktmbuf_prepend(mbuf, sizeof(struct rte_vlan_hdr));
+		memmove(rte_pktmbuf_mtod(mbuf, char *),
+			rte_pktmbuf_mtod_offset(
 				mbuf, char *, sizeof(struct rte_vlan_hdr)
 			),
-			rte_pktmbuf_mtod(mbuf, char *),
 			sizeof(struct rte_ether_hdr));
-		rte_pktmbuf_adj(mbuf, sizeof(struct rte_vlan_hdr));
 
-		return;
-	}
-
-	// We have to set vlan tag
-	if (ether_hdr->ether_type == rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN)) {
-		if (rte_pktmbuf_pkt_len(mbuf) <
-		    sizeof(struct rte_ether_hdr) + offset) {
-			goto error_invalid;
-		}
+		ether_hdr = rte_pktmbuf_mtod_offset(
+			mbuf, struct rte_ether_hdr *, 0
+		);
+		offset = sizeof(struct rte_ether_hdr);
 
 		struct rte_vlan_hdr *vlan_hdr = rte_pktmbuf_mtod_offset(
 			mbuf, struct rte_vlan_hdr *, offset
 		);
 
-		// Just update the tag
 		vlan_hdr->vlan_tci = rte_cpu_to_be_16(cp_device_vlan->vlan);
+		vlan_hdr->eth_proto = ether_hdr->ether_type;
+		ether_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN);
 
-		return;
+		packet_front_output(packet_front, packet);
+		goto next;
+
+	next:
+		packet = packet_list_pop(&packet_front->input);
 	}
 
-	// Inject new vlan header
-	// FIXME: check error
-	rte_pktmbuf_prepend(mbuf, sizeof(struct rte_vlan_hdr));
-	memmove(rte_pktmbuf_mtod(mbuf, char *),
-		rte_pktmbuf_mtod_offset(
-			mbuf, char *, sizeof(struct rte_vlan_hdr)
-		),
-		sizeof(struct rte_ether_hdr));
-
-	ether_hdr = rte_pktmbuf_mtod_offset(mbuf, struct rte_ether_hdr *, 0);
-	offset = sizeof(struct rte_ether_hdr);
-
-	struct rte_vlan_hdr *vlan_hdr =
-		rte_pktmbuf_mtod_offset(mbuf, struct rte_vlan_hdr *, offset);
-
-	vlan_hdr->vlan_tci = rte_cpu_to_be_16(cp_device_vlan->vlan);
-	vlan_hdr->eth_proto = ether_hdr->ether_type;
-	ether_hdr->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_VLAN);
-
-	return;
-
-error_invalid:
-	/*
-	 * FIXME: device handler does not process packet front so
-	 * it could not drop the packet so just ignore it
-	 */
 	return;
 }
 

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -713,10 +713,7 @@ device_entry_ectx_create(
 		for (uint64_t weight_idx = 0;
 		     weight_idx < cp_device_entry->pipelines[idx].weight;
 		     ++weight_idx) {
-			SET_OFFSET_OF(
-				device_entry_ectx->pipeline_map + pos,
-				pipeline_ectx
-			);
+			device_entry_ectx->pipeline_map[pos] = idx;
 			++pos;
 		}
 	}

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "common/memory_address.h"
+#include "dataplane/device/device.h"
 #include "dataplane/module/module.h"
 
 struct counter_storage;
@@ -79,7 +80,7 @@ struct device_entry_ectx {
 	uint64_t pipeline_count;
 	struct pipeline_ectx **pipelines;
 	uint64_t pipeline_map_size;
-	struct pipeline_ectx *pipeline_map[];
+	uint64_t pipeline_map[];
 };
 
 struct device_ectx {

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -6,6 +6,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "dataplane/device/device.h"
 #include "dataplane/module/module.h"
 
 #include "dataplane/time/clock.h"
@@ -25,7 +26,7 @@ struct dp_module {
 };
 
 struct dp_device {
-	char name[DEVICE_NAME_LEN];
+	char name[DEVICE_TYPE_LEN];
 	device_handler input_handler;
 	device_handler output_handler;
 };

--- a/lib/dataplane/device/device.c
+++ b/lib/dataplane/device/device.c
@@ -1,0 +1,1 @@
+#include "device.h"

--- a/lib/dataplane/device/device.h
+++ b/lib/dataplane/device/device.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#define DEVICE_TYPE_LEN 80
+
+struct packet_front;
+struct device_ectx;
+struct dp_worker;
+
+typedef void (*device_handler)(
+	struct dp_worker *dp_worker,
+	struct device_ectx *device_ectx,
+	struct packet_front *packet_front
+);
+
+struct device {
+	char name[DEVICE_TYPE_LEN];
+	device_handler input_handler;
+	device_handler output_handler;
+};
+
+typedef struct device *(*device_load_handler)();

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -1,64 +1,12 @@
 #pragma once
 
-#include <stdint.h>
+#define MODULE_TYPE_LEN 80
 
-#include "dataplane/packet/packet.h"
+#include "lib/dataplane/module/packet_front.h"
 
-#define MODULE_NAME_LEN 80
-#define MODULE_CONFIG_NAME_LEN 80
-
-/*
- * The structure enumerated packets processed by pipeline modules.
- * Each module reads a packet from an input list and then writes result to
- * an output list or drop list.
- *
- * Before module invocation input and output exchange packets so ouptut of
- * one module connects with input of the following.
- *
- * RX and TX are considered as separated stages of packet processing working
- * before and after pipeline processing.
- */
-struct packet_front {
-	struct packet_list pending;
-	struct packet_list input;
-	struct packet_list output;
-	struct packet_list drop;
-};
-
-static inline void
-packet_front_init(struct packet_front *packet_front) {
-	packet_list_init(&packet_front->pending);
-	packet_list_init(&packet_front->input);
-	packet_list_init(&packet_front->output);
-	packet_list_init(&packet_front->drop);
-}
-
-static inline void
-packet_front_output(struct packet_front *packet_front, struct packet *packet) {
-	packet_list_add(&packet_front->output, packet);
-}
-
-static inline void
-packet_front_drop(struct packet_front *packet_front, struct packet *packet) {
-	packet_list_add(&packet_front->drop, packet);
-}
-
-static inline void
-packet_front_switch(struct packet_front *packet_front) {
-	packet_list_concat(&packet_front->input, &packet_front->output);
-	packet_list_init(&packet_front->output);
-}
-
-static inline void
-packet_front_pass(struct packet_front *packet_front) {
-	packet_list_concat(&packet_front->output, &packet_front->input);
-	packet_list_init(&packet_front->input);
-}
-
-struct dp_config;
+struct packet_front;
 struct module_ectx;
 struct dp_worker;
-struct counter_storage;
 
 /*
  * Module handler called for a pipeline front.
@@ -74,26 +22,8 @@ typedef void (*module_handler)(
 );
 
 struct module {
-	char name[MODULE_NAME_LEN];
+	char name[MODULE_TYPE_LEN];
 	module_handler handler;
 };
 
 typedef struct module *(*module_load_handler)();
-
-// FIXME move the code bellow to a separate file
-#define DEVICE_NAME_LEN 80
-struct device_ectx;
-
-typedef void (*device_handler)(
-	struct dp_worker *dp_worker,
-	struct device_ectx *device_ectx,
-	struct packet *packet
-);
-
-struct device {
-	char name[DEVICE_NAME_LEN];
-	device_handler input_handler;
-	device_handler output_handler;
-};
-
-typedef struct device *(*device_load_handler)();

--- a/lib/dataplane/module/packet_front.h
+++ b/lib/dataplane/module/packet_front.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "lib/dataplane/packet/packet.h"
+
+/*
+ * The structure enumerated packets processed by pipeline modules.
+ * Each module reads a packet from an input list and then writes result to
+ * an output list or drop list.
+ *
+ * Before module invocation input and output exchange packets so ouptut of
+ * one module connects with input of the following.
+ *
+ * RX and TX are considered as separated stages of packet processing working
+ * before and after pipeline processing.
+ */
+struct packet_front {
+	struct packet_list pending_input;
+	struct packet_list pending_output;
+
+	struct packet_list input;
+	struct packet_list output;
+	struct packet_list drop;
+};
+
+static inline void
+packet_front_init(struct packet_front *packet_front) {
+	packet_list_init(&packet_front->pending_input);
+	packet_list_init(&packet_front->pending_output);
+	packet_list_init(&packet_front->input);
+	packet_list_init(&packet_front->output);
+	packet_list_init(&packet_front->drop);
+}
+
+static inline void
+packet_front_merge(struct packet_front *dst, struct packet_front *src) {
+	packet_list_concat(&dst->output, &src->output);
+	packet_list_concat(&dst->drop, &src->drop);
+	packet_list_concat(&dst->pending_input, &src->pending_input);
+	packet_list_concat(&dst->pending_output, &src->pending_output);
+}
+
+static inline void
+packet_front_output(struct packet_front *packet_front, struct packet *packet) {
+	packet_list_add(&packet_front->output, packet);
+}
+
+static inline void
+packet_front_drop(struct packet_front *packet_front, struct packet *packet) {
+	packet_list_add(&packet_front->drop, packet);
+}
+
+static inline void
+packet_front_switch(struct packet_front *packet_front) {
+	packet_list_concat(&packet_front->input, &packet_front->output);
+	packet_list_init(&packet_front->output);
+}
+
+static inline void
+packet_front_pass(struct packet_front *packet_front) {
+	packet_list_concat(&packet_front->output, &packet_front->input);
+	packet_list_init(&packet_front->input);
+}

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -34,16 +34,11 @@ counter_add_packets_bytes(
 
 void
 module_ectx_process(
-	struct dp_config *dp_config,
 	struct dp_worker *dp_worker,
-	struct cp_config_gen *cp_config_gen,
 	struct module_ectx *module_ectx,
 	struct packet_front *packet_front
 
 ) {
-	(void)dp_config;
-	(void)cp_config_gen;
-
 	for (struct packet *packet = packet_front->input.first; packet != NULL;
 	     packet = packet->next) {
 		packet->module_device_id = module_ectx_decode_device(
@@ -92,9 +87,7 @@ module_ectx_process(
 
 void
 chain_ectx_process(
-	struct dp_config *dp_config,
 	struct dp_worker *dp_worker,
-	struct cp_config_gen *cp_config_gen,
 	struct chain_ectx *chain_ectx,
 	struct packet_front *packet_front
 ) {
@@ -108,13 +101,7 @@ chain_ectx_process(
 		struct module_ectx *module_ectx =
 			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
 
-		module_ectx_process(
-			dp_config,
-			dp_worker,
-			cp_config_gen,
-			module_ectx,
-			packet_front
-		);
+		module_ectx_process(dp_worker, module_ectx, packet_front);
 
 		uint64_t tsc_stop = rte_rdtsc();
 		counter_hist_exp2_inc(
@@ -132,9 +119,7 @@ chain_ectx_process(
 
 void
 function_ectx_process(
-	struct dp_config *dp_config,
 	struct dp_worker *dp_worker,
-	struct cp_config_gen *cp_config_gen,
 	struct function_ectx *function_ectx,
 	struct packet_front *packet_front
 ) {
@@ -155,9 +140,7 @@ function_ectx_process(
 	uint64_t chain_idx = 0;
 	struct chain_ectx *chain_ectx =
 		ADDR_OF(function_ectx->chain_map + chain_idx);
-	chain_ectx_process(
-		dp_config, dp_worker, cp_config_gen, chain_ectx, packet_front
-	);
+	chain_ectx_process(dp_worker, chain_ectx, packet_front);
 
 	counter_add_packets_bytes(
 		cp_function->counter_packet_out_count,
@@ -179,9 +162,7 @@ function_ectx_process(
 
 void
 pipeline_ectx_process(
-	struct dp_config *dp_config,
 	struct dp_worker *dp_worker,
-	struct cp_config_gen *cp_config_gen,
 	struct pipeline_ectx *pipeline_ectx,
 	struct packet_front *packet_front
 ) {
@@ -203,13 +184,7 @@ pipeline_ectx_process(
 		struct function_ectx *function_ectx =
 			ADDR_OF(pipeline_ectx->functions + idx);
 
-		function_ectx_process(
-			dp_config,
-			dp_worker,
-			cp_config_gen,
-			function_ectx,
-			packet_front
-		);
+		function_ectx_process(dp_worker, function_ectx, packet_front);
 	}
 
 	counter_add_packets_bytes(
@@ -230,41 +205,54 @@ pipeline_ectx_process(
 	);
 }
 
-static void
+static inline void
 device_entry_ectx_process(
 	struct dp_worker *dp_worker,
 	struct device_ectx *device_ectx,
 	struct device_entry_ectx *entry_ectx,
-	struct packet_front *packet_front,
-	struct packet *packet
+	struct packet_front *packet_front
 ) {
-	entry_ectx->handler(dp_worker, device_ectx, packet);
-	packet->tx_device_id =
-		ADDR_OF(&device_ectx->cp_device)->config_item.index;
+	packet_front_switch(packet_front);
+	entry_ectx->handler(dp_worker, device_ectx, packet_front);
 
 	if (!entry_ectx->pipeline_map_size) {
-		packet->pipeline_ectx = NULL;
-		packet_list_add(&packet_front->drop, packet);
+		packet_list_concat(&packet_front->drop, &packet_front->output);
+		packet_list_init(&packet_front->drop);
 		return;
 	}
-	struct pipeline_ectx *pipeline_ectx =
-		ADDR_OF(entry_ectx->pipeline_map +
-			packet->hash % entry_ectx->pipeline_map_size);
-	if (!pipeline_ectx) {
-		packet->pipeline_ectx = NULL;
-		packet_list_add(&packet_front->drop, packet);
-		return;
+
+	// FIXME do not create front for each invocation
+	struct packet_front schedule[entry_ectx->pipeline_count];
+	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
+		packet_front_init(schedule + idx);
 	}
-	packet->pipeline_ectx = pipeline_ectx;
-	packet_list_add(&packet_front->pending, packet);
+
+	struct packet *packet = packet_list_pop(&packet_front->output);
+	while (packet != NULL) {
+		uint64_t pipeline_idx =
+			entry_ectx->pipeline_map
+				[packet->hash % entry_ectx->pipeline_map_size];
+
+		packet_front_output(schedule + pipeline_idx, packet);
+
+		packet = packet_list_pop(&packet_front->output);
+	}
+
+	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
+	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
+		struct pipeline_ectx *pipeline_ectx = ADDR_OF(pipelines + idx);
+
+		pipeline_ectx_process(dp_worker, pipeline_ectx, schedule + idx);
+
+		packet_front_merge(packet_front, schedule + idx);
+	}
 }
 
 void
 device_ectx_process_input(
 	struct dp_worker *dp_worker,
 	struct device_ectx *device_ectx,
-	struct packet_front *packet_front,
-	struct packet *packet
+	struct packet_front *packet_front
 ) {
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
 	counter_add_packets_bytes(
@@ -272,14 +260,14 @@ device_ectx_process_input(
 		cp_device->counter_packet_rx_bytes,
 		dp_worker->idx,
 		ADDR_OF(&device_ectx->counter_storage),
-		1,
-		packet_data_len(packet)
+		packet_list_count(&packet_front->output),
+		packet_list_bytes_sum(&packet_front->output)
 	);
 
 	struct device_entry_ectx *entry_ectx =
 		ADDR_OF(&device_ectx->input_pipelines);
 	device_entry_ectx_process(
-		dp_worker, device_ectx, entry_ectx, packet_front, packet
+		dp_worker, device_ectx, entry_ectx, packet_front
 	);
 }
 
@@ -287,8 +275,7 @@ void
 device_ectx_process_output(
 	struct dp_worker *dp_worker,
 	struct device_ectx *device_ectx,
-	struct packet_front *packet_front,
-	struct packet *packet
+	struct packet_front *packet_front
 ) {
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
 	counter_add_packets_bytes(
@@ -296,13 +283,13 @@ device_ectx_process_output(
 		cp_device->counter_packet_tx_bytes,
 		dp_worker->idx,
 		ADDR_OF(&device_ectx->counter_storage),
-		1,
-		packet_data_len(packet)
+		packet_list_count(&packet_front->output),
+		packet_list_bytes_sum(&packet_front->output)
 	);
 
 	struct device_entry_ectx *entry_ectx =
 		ADDR_OF(&device_ectx->output_pipelines);
 	device_entry_ectx_process(
-		dp_worker, device_ectx, entry_ectx, packet_front, packet
+		dp_worker, device_ectx, entry_ectx, packet_front
 	);
 }

--- a/lib/dataplane/pipeline/pipeline.h
+++ b/lib/dataplane/pipeline/pipeline.h
@@ -14,9 +14,7 @@ struct device_ectx;
 
 void
 pipeline_ectx_process(
-	struct dp_config *dp_config,
 	struct dp_worker *dp_worker,
-	struct cp_config_gen *cp_config_gen,
 	struct pipeline_ectx *pipeline_ectx,
 	struct packet_front *packet_front
 );
@@ -25,14 +23,12 @@ void
 device_ectx_process_input(
 	struct dp_worker *dp_worker,
 	struct device_ectx *device_ectx,
-	struct packet_front *packet_front,
-	struct packet *packet
+	struct packet_front *packet_front
 );
 
 void
 device_ectx_process_output(
 	struct dp_worker *dp_worker,
 	struct device_ectx *device_ectx,
-	struct packet_front *packet_front,
-	struct packet *packet
+	struct packet_front *packet_front
 );

--- a/lib/fuzzing/fuzzing.h
+++ b/lib/fuzzing/fuzzing.h
@@ -197,7 +197,12 @@ fuzzing_process_packet(
 	}
 
 	// Clean up pending packets
-	while ((cleanup_packet = packet_list_pop(&pf.pending)) != NULL) {
+	while ((cleanup_packet = packet_list_pop(&pf.pending_input)) != NULL) {
+		struct rte_mbuf *cleanup_mbuf = packet_to_mbuf(cleanup_packet);
+		rte_pktmbuf_free(cleanup_mbuf);
+	}
+
+	while ((cleanup_packet = packet_list_pop(&pf.pending_output)) != NULL) {
 		struct rte_mbuf *cleanup_mbuf = packet_to_mbuf(cleanup_packet);
 		rte_pktmbuf_free(cleanup_mbuf);
 	}

--- a/mock/worker.c
+++ b/mock/worker.c
@@ -69,7 +69,6 @@ yanet_worker_mock_handle_packets(
 			tsc_clock_get_time_ns(&dp_worker->clock);
 	}
 
-	struct dp_config *dp_config = worker->dp_config;
 	struct cp_config *cp_config = worker->cp_config;
 	struct cp_config_gen *cp_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
@@ -89,62 +88,85 @@ yanet_worker_mock_handle_packets(
 	struct packet_front packet_front;
 	packet_front_init(&packet_front);
 
-	while (packet_list_first(input_packets)) {
-		struct packet *packet = packet_list_pop(input_packets);
-		packet->pipeline_ectx = NULL;
+	packet_list_concat(&packet_front.pending_input, input_packets);
 
-		struct device_ectx *device_ectx =
-			ADDR_OF(config_gen_ectx->devices + packet->rx_device_id
+	uint64_t device_count =
+		cp_config_gen->device_registry.registry.capacity;
+
+	while (1) {
+
+		struct packet_front schedule_input[device_count];
+		for (uint64_t idx = 0; idx < device_count; ++idx)
+			packet_front_init(schedule_input + idx);
+
+		struct packet_front schedule_output[device_count];
+		for (uint64_t idx = 0; idx < device_count; ++idx)
+			packet_front_init(schedule_output + idx);
+
+		struct packet *packet;
+
+		int empty = 1;
+
+		while ((packet = packet_list_pop(&packet_front.pending_input)
+		       ) != NULL) {
+			empty = 0;
+			packet_front_output(
+				schedule_input + packet->tx_device_id, packet
 			);
-		if (device_ectx == NULL) {
-			packet_front_drop(&packet_front, packet);
-			continue;
 		}
 
-		device_ectx_process_input(
-			&worker->dp_worker, device_ectx, &packet_front, packet
-		);
-	}
-
-	// Now group packets by pipeline and build packet_front
-	while (packet_list_first(&packet_front.pending)) {
-		struct packet *packet =
-			packet_list_first(&packet_front.pending);
-		struct pipeline_ectx *pipeline_ectx = packet->pipeline_ectx;
-
-		struct packet_list pending_packets;
-		packet_list_init(&pending_packets);
-
-		while ((packet = packet_list_pop(&packet_front.pending))) {
-			if (packet->pipeline_ectx == pipeline_ectx) {
-				packet_front_output(&packet_front, packet);
-			} else {
-				packet_list_add(&pending_packets, packet);
-			}
+		while ((packet = packet_list_pop(&packet_front.pending_output)
+		       ) != NULL) {
+			empty = 0;
+			packet_front_output(
+				schedule_output + packet->tx_device_id, packet
+			);
 		}
 
-		/*
-		 * All the packets with the same pipeline_ectx are ready to
-		 * process, so return postponned packet into pending
-		 * queue.
-		 */
-		packet_list_concat(&packet_front.pending, &pending_packets);
+		if (empty)
+			break;
 
-		pipeline_ectx_process(
-			dp_config,
-			&worker->dp_worker,
-			cp_config_gen,
-			pipeline_ectx,
-			&packet_front
-		);
+		struct device_ectx **devices = config_gen_ectx->devices;
 
-		packet_list_concat(
-			&out_result->drop_packets, &packet_front.drop
-		);
-		packet_list_init(&packet_front.drop);
-		packet_list_concat(
-			&out_result->output_packets, &packet_front.output
-		);
-		packet_list_init(&packet_front.output);
+		for (uint64_t idx = 0; idx < device_count; ++idx) {
+			if (packet_list_first(&schedule_input[idx].output) ==
+			    NULL)
+				continue;
+
+			struct device_ectx *device_ectx =
+				ADDR_OF(devices + idx);
+
+			device_ectx_process_input(
+				&worker->dp_worker,
+				device_ectx,
+				schedule_input + idx
+			);
+
+			packet_front_merge(&packet_front, schedule_input + idx);
+		}
+
+		for (uint64_t idx = 0; idx < device_count; ++idx) {
+			if (packet_list_first(&schedule_output[idx].output) ==
+			    NULL)
+				continue;
+
+			struct device_ectx *device_ectx =
+				ADDR_OF(devices + idx);
+
+			device_ectx_process_output(
+				&worker->dp_worker,
+				device_ectx,
+				schedule_output + idx
+			);
+
+			packet_front_merge(
+				&packet_front, schedule_output + idx
+			);
+		}
 	}
+
+	packet_list_concat(&out_result->drop_packets, &packet_front.drop);
+	packet_list_init(&packet_front.drop);
+	packet_list_concat(&out_result->output_packets, &packet_front.output);
+	packet_list_init(&packet_front.output);
 }

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -140,35 +140,24 @@ forward_handle_packets(
 			counters[0] += 1;
 			counters[1] += packet_data_len(packet);
 
-			struct config_gen_ectx *config_gen_ectx =
-				ADDR_OF(&module_ectx->config_gen_ectx);
-
-			uint64_t device_id = module_ectx_encode_device(
+			uint16_t device_id = module_ectx_encode_device(
 				module_ectx, target->device_id
 			);
 
-			struct device_ectx *device_ectx =
-				config_gen_ectx_get_device(
-					config_gen_ectx, device_id
-				);
-			if (device_ectx == NULL) {
+			if (device_id == (uint16_t)-1) {
 				packet_front_drop(packet_front, packet);
 				continue;
 			}
 
 			if (target->mode == FORWARD_MODE_IN) {
-				device_ectx_process_input(
-					dp_worker,
-					device_ectx,
-					packet_front,
-					packet
+				packet->tx_device_id = device_id;
+				packet_list_add(
+					&packet_front->pending_input, packet
 				);
 			} else if (target->mode == FORWARD_MODE_OUT) {
-				device_ectx_process_output(
-					dp_worker,
-					device_ectx,
-					packet_front,
-					packet
+				packet->tx_device_id = device_id;
+				packet_list_add(
+					&packet_front->pending_output, packet
 				);
 			} else {
 				packet_front_output(packet_front, packet);

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -152,24 +152,18 @@ route_handle_packets(
 		struct route *route =
 			ADDR_OF(&route_config->routes) + route_index;
 
-		struct config_gen_ectx *config_gen_ectx =
-			ADDR_OF(&module_ectx->config_gen_ectx);
-
-		uint64_t device_id = module_ectx_encode_device(
+		uint16_t device_id = module_ectx_encode_device(
 			module_ectx, route->device_id
 		);
 
-		struct device_ectx *device_ectx =
-			config_gen_ectx_get_device(config_gen_ectx, device_id);
-		if (device_ectx == NULL) {
+		if (device_id == (uint16_t)-1) {
 			packet_front_drop(packet_front, packet);
 			continue;
 		}
 
 		route_set_packet_destination(packet, route);
-		device_ectx_process_output(
-			dp_worker, device_ectx, packet_front, packet
-		);
+		packet->tx_device_id = device_id;
+		packet_list_add(&packet_front->pending_output, packet);
 	}
 }
 


### PR DESCRIPTION
Change device handlers to process a pipeline front instead of packets. Also create a pipeline front for a chain and module invocation.