### PR TITLE
Specify exact Go release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yanet-platform/yanet2
 
-go 1.24
+go 1.24.13
 
 require (
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500


### PR DESCRIPTION
Otherwise you'll get this trying to build:

```
FAILED: controlplane/yanet-bird-adapter 
/usr/bin/go build '-ldflags=-X github.com/yanet-platform/yanet2/controlplane/internal/version.version=0.0.1' -buildvcs=false -o controlplane/yanet-bird-adapter /home/kriomant/yanet2/controlplane/cmd/bird-adapter
go: downloading go1.24 (linux/amd64)
go: download go1.24 for linux/amd64: toolchain not available
```