### PR TITLE
feat(ci): replace broken clang-format action

### DIFF
--- a/.github/actions/clang-format/Dockerfile
+++ b/.github/actions/clang-format/Dockerfile
@@ -1,0 +1,27 @@
+ARG ALPINE_TAG=3.21
+
+FROM alpine:${ALPINE_TAG} AS builder
+
+ARG VERSION=19
+ARG BRANCH=release/${VERSION}.x
+
+RUN set -x \
+ && apk add --no-cache git cmake ninja g++ python3 \
+ && git clone --depth 1 --branch "${BRANCH}" https://github.com/llvm/llvm-project.git /src \
+ && ln -s ../../clang /src/llvm/tools/ \
+ && mkdir /src/llvm/_build \
+ && cd /src/llvm/_build \
+ && cmake .. \
+        -G Ninja \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_FLAGS="-static-libgcc" \
+        -DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++" \
+ && ninja clang-format \
+ && strip bin/clang-format
+
+FROM alpine:${ALPINE_TAG}
+
+COPY --from=builder /src/llvm/_build/bin/clang-format /usr/bin/clang-format
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/.github/actions/clang-format/action.yml
+++ b/.github/actions/clang-format/action.yml
@@ -1,0 +1,19 @@
+name: 'clang-format check'
+description: 'Run clang-format on files matching given patterns'
+
+inputs:
+  include:
+    description: 'Newline-separated file name patterns for find -name (e.g., *.h)'
+    required: true
+  exclude-regex:
+    description: 'Extended regex to exclude file paths (grep -Ev)'
+    required: false
+    default: ''
+  style:
+    description: 'clang-format style'
+    required: false
+    default: 'file'
+
+runs:
+  using: 'docker'
+  image: 'docker://ghcr.io/yanet-platform/clang-format:19'

--- a/.github/actions/clang-format/entrypoint.sh
+++ b/.github/actions/clang-format/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# clang-format check entrypoint.
+# Inputs (via environment variables set by GitHub Actions):
+#   INPUT_INCLUDE        - newline-separated file name patterns (for find -name)
+#   INPUT_EXCLUDE_REGEX  - extended regex to exclude file paths (grep -Ev)
+#   INPUT_STYLE          - clang-format style (default: file)
+set -e
+
+STYLE="${INPUT_STYLE:-file}"
+WORKSPACE="${GITHUB_WORKSPACE:-.}"
+
+cd "$WORKSPACE" || { echo "ERROR: cannot cd to $WORKSPACE"; exit 1; }
+
+# Collect files matching the include patterns.
+FILELIST="$(mktemp)"
+trap 'rm -f "$FILELIST"' EXIT
+
+echo "$INPUT_INCLUDE" | while IFS= read -r pattern; do
+    # Skip empty lines.
+    [ -z "$pattern" ] && continue
+    find . -type f -name "$pattern"
+done | sort -u > "$FILELIST"
+
+# Apply exclude regex if provided.
+if [ -n "$INPUT_EXCLUDE_REGEX" ]; then
+    FILTERED="$(mktemp)"
+    grep -Ev "$INPUT_EXCLUDE_REGEX" "$FILELIST" > "$FILTERED" || true
+    mv "$FILTERED" "$FILELIST"
+fi
+
+TOTAL="$(wc -l < "$FILELIST" | tr -d ' ')"
+if [ "$TOTAL" -eq 0 ]; then
+    echo "No files matched the include patterns."
+    exit 0
+fi
+
+echo "Checking $TOTAL file(s) with clang-format (style=$STYLE)..."
+
+FAILED=0
+while IFS= read -r file; do
+    if ! /usr/bin/clang-format --dry-run --Werror --style="$STYLE" "$file" 2>/dev/null; then
+        FAILED=$((FAILED + 1))
+        echo "--- Formatting diff for $file ---"
+        /usr/bin/clang-format --style="$STYLE" "$file" | diff -u "$file" - || true
+        echo ""
+    fi
+done < "$FILELIST"
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "clang-format: $FAILED file(s) need formatting."
+    exit 1
+fi
+
+echo "clang-format: all files are properly formatted."

--- a/.github/workflows/build-push-clang-format-image.yml
+++ b/.github/workflows/build-push-clang-format-image.yml
@@ -1,0 +1,34 @@
+name: Build and push clang-format image
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/actions/clang-format/**"
+
+permissions:
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .github/actions/clang-format
+          push: true
+          tags: ghcr.io/yanet-platform/clang-format:19

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -7,22 +7,35 @@ on:
       - "**.h"
       - "**.c"
       - "**.proto"
-      - "**/meson.build"
   pull_request:
     branches: ["main"]
     paths:
       - "**.h"
       - "**.c"
       - "**.proto"
-      - "**/meson.build"
 
 jobs:
-  fmt:
+  c-cpp-fmt:
+    name: C formatting
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run clang-format
-        uses: jidicula/clang-format-action@v4.14.0
+        uses: ./.github/actions/clang-format
         with:
-          clang-format-version: 19
-          exclude-regex: subprojects/.*
+          include: |
+            *.h
+            *.c
+          exclude-regex: '^./subprojects/'
+
+  proto-fmt:
+    name: Protobuf formatting
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run clang-format
+        uses: ./.github/actions/clang-format
+        with:
+          include: |
+            *.proto
+          exclude-regex: '^./subprojects/'


### PR DESCRIPTION
Replace jidicula/clang-format-action (whose Docker image is no longer available on ghcr.io) with an in-repo GitHub Action backed by a minimal Docker image (~11 MB) containing a statically built clang-format 19 on Alpine.

Add automated image build and push workflow for ghcr.io. Split formatting check into separate C and Protobuf jobs with configurable include patterns and exclude regex.