### PR TITLE
fix(web): lazy load FIB data on tab switch

### DIFF
--- a/web/src/pages/RoutePage.tsx
+++ b/web/src/pages/RoutePage.tsx
@@ -40,6 +40,7 @@ const RoutePage: React.FC = () => {
         handleConfigTabChange,
         reloadRoutes,
         reloadFIB,
+        loadFIBForConfig,
     } = useRouteData();
 
     const {
@@ -352,6 +353,7 @@ const RoutePage: React.FC = () => {
                     getRouteId={getRouteId}
                     onEditRoute={handleEditRouteClick}
                     getFIBEntries={getFIBEntries}
+                    loadFIBEntries={loadFIBForConfig}
                 />
             </Box>
 

--- a/web/src/pages/route/ConfigTabs.tsx
+++ b/web/src/pages/route/ConfigTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Box, TabProvider, TabList, Tab, TabPanel } from '@gravity-ui/uikit';
 import { VirtualizedRouteTable } from './VirtualizedRouteTable';
 import { FIBTable } from './FIBTable';
@@ -15,9 +15,33 @@ export const ConfigTabs: React.FC<ConfigTabsProps> = ({
     getRouteId,
     onEditRoute,
     getFIBEntries,
+    loadFIBEntries,
 }) => {
     const validActiveConfig = configs.includes(activeConfig) ? activeConfig : configs[0] || '';
     const [activeSubTab, setActiveSubTab] = useState<string>('rib');
+    const [fibLoading, setFibLoading] = useState(false);
+
+    useEffect(() => {
+        if (activeSubTab !== 'fib' || !validActiveConfig || !loadFIBEntries) {
+            return;
+        }
+
+        let cancelled = false;
+        setFibLoading(true);
+        loadFIBEntries(validActiveConfig).finally(() => {
+            if (!cancelled) {
+                setFibLoading(false);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [activeSubTab, validActiveConfig, loadFIBEntries]);
+
+    const handleSubTabChange = useCallback((tab: string) => {
+        setActiveSubTab(tab);
+    }, []);
 
     return (
         <TabProvider value={validActiveConfig} onUpdate={onConfigChange}>
@@ -35,7 +59,7 @@ export const ConfigTabs: React.FC<ConfigTabsProps> = ({
 
                     return (
                         <TabPanel key={configName} value={configName}>
-                            <TabProvider value={activeSubTab} onUpdate={setActiveSubTab}>
+                            <TabProvider value={activeSubTab} onUpdate={handleSubTabChange}>
                                 <TabList size="m">
                                     <Tab value="rib">RIB</Tab>
                                     <Tab value="fib">FIB</Tab>
@@ -51,7 +75,11 @@ export const ConfigTabs: React.FC<ConfigTabsProps> = ({
                                         />
                                     </TabPanel>
                                     <TabPanel value="fib">
-                                        <FIBTable entries={fibEntries} />
+                                        {fibLoading ? (
+                                            <Box style={{ padding: '16px', textAlign: 'center' }}>Loading FIB...</Box>
+                                        ) : (
+                                            <FIBTable entries={fibEntries} />
+                                        )}
                                     </TabPanel>
                                 </Box>
                             </TabProvider>

--- a/web/src/pages/route/RouteConfigContent.tsx
+++ b/web/src/pages/route/RouteConfigContent.tsx
@@ -12,6 +12,7 @@ export const RouteConfigContent: React.FC<RouteConfigContentProps> = ({
     getRouteId,
     onEditRoute,
     getFIBEntries,
+    loadFIBEntries,
 }) => {
 
     if (configs.length === 0) {
@@ -31,6 +32,7 @@ export const RouteConfigContent: React.FC<RouteConfigContentProps> = ({
             getRouteId={getRouteId}
             onEditRoute={onEditRoute}
             getFIBEntries={getFIBEntries}
+            loadFIBEntries={loadFIBEntries}
         />
     );
 };

--- a/web/src/pages/route/types.ts
+++ b/web/src/pages/route/types.ts
@@ -83,6 +83,7 @@ export interface RoutesByConfigProps {
     getRouteId: (route: Route) => string;
     onEditRoute?: (route: Route) => void;
     getFIBEntries?: (configName: string) => FIBEntry[];
+    loadFIBEntries?: (configName: string) => Promise<FIBEntry[]>;
 }
 
 // Props for ConfigTabs and RouteConfigContent (without routeColumns since VirtualizedRouteTable doesn't need it)

--- a/web/src/pages/route/useRouteData.ts
+++ b/web/src/pages/route/useRouteData.ts
@@ -19,6 +19,7 @@ export interface UseRouteDataResult {
     handleConfigTabChange: (config: string) => void;
     reloadRoutes: (configsList: string[]) => Promise<Map<string, Route[]>>;
     reloadFIB: (configsList: string[]) => Promise<Map<string, FIBEntry[]>>;
+    loadFIBForConfig: (configName: string) => Promise<FIBEntry[]>;
 }
 
 export const useRouteData = (): UseRouteDataResult => {
@@ -41,17 +42,12 @@ export const useRouteData = (): UseRouteDataResult => {
                 const configsList = configsResponse.configs || [];
 
                 const routesMap = new Map<string, Route[]>();
-                const fibMap = new Map<string, FIBEntry[]>();
 
                 await Promise.all(
                     configsList.map(async (configName) => {
                         try {
-                            const [routesResponse, fibResponse] = await Promise.all([
-                                API.route.showRoutes({ name: configName }),
-                                API.route.showFIB({ name: configName }),
-                            ]);
+                            const routesResponse = await API.route.showRoutes({ name: configName });
                             routesMap.set(configName, routesResponse.routes || []);
-                            fibMap.set(configName, fibResponse.entries || []);
                         } catch (err) {
                             if (!isMounted) return;
                             toaster.error(`route-fetch-error-${configName}`, `Failed to load data for ${configName}`, err);
@@ -63,7 +59,6 @@ export const useRouteData = (): UseRouteDataResult => {
 
                 setConfigs(configsList);
                 setConfigRoutes(routesMap);
-                setConfigFIB(fibMap);
                 if (configsList.length > 0) {
                     setActiveConfigTab(configsList[0]);
                 }
@@ -130,6 +125,27 @@ export const useRouteData = (): UseRouteDataResult => {
         return fibMap;
     }, []);
 
+    const loadFIBForConfig = useCallback(async (configName: string): Promise<FIBEntry[]> => {
+        const cached = configFIB.get(configName);
+        if (cached) {
+            return cached;
+        }
+
+        try {
+            const fibResponse = await API.route.showFIB({ name: configName });
+            const entries = fibResponse.entries || [];
+            setConfigFIB((prev) => {
+                const next = new Map(prev);
+                next.set(configName, entries);
+                return next;
+            });
+            return entries;
+        } catch (err) {
+            toaster.error(`load-fib-error-${configName}`, `Failed to load FIB for ${configName}`, err);
+            return [];
+        }
+    }, [configFIB]);
+
     return {
         configs,
         configRoutes,
@@ -146,5 +162,6 @@ export const useRouteData = (): UseRouteDataResult => {
         handleConfigTabChange,
         reloadRoutes,
         reloadFIB,
+        loadFIBForConfig,
     };
 };


### PR DESCRIPTION
FIB data is no longer fetched during initial page load for all configs. Instead, showFIB is called only when the user switches to the FIB sub-tab, with results cached to avoid redundant requests.