### PR TITLE
refactor(route): improve logging and add parameter validation

### DIFF
--- a/modules/route/bird-adapter/service.go
+++ b/modules/route/bird-adapter/service.go
@@ -203,11 +203,15 @@ func (m *AdapterService) processBirdImport(conn *grpc.ClientConn, cfg *bird.Conf
 
 	// onUpdate sends route batches over the gRPC stream. Called by bird.Export.
 	onUpdate := func(ctx context.Context, routes []rib.Route) error {
-		log.Debugf("processing %d BIRD routes", len(routes))
+		log.Debugw("processing BIRD routes",
+			zap.Int("count", len(routes)),
+		)
 		for idx := range routes {
 			select {
 			case <-ctx.Done():
-				log.Warnf("update stream send cancelled: %v", ctx.Err())
+				log.Warnw("update stream send cancelled",
+					zap.Error(ctx.Err()),
+				)
 				_, closeErr := (*holder.currentStream).CloseAndRecv()
 				return errors.Join(ctx.Err(), closeErr, errStreamClosed) // Signal runBirdImportLoop
 			default:

--- a/modules/route/controlplane/ffi.go
+++ b/modules/route/controlplane/ffi.go
@@ -63,6 +63,9 @@ func (m *ModuleConfig) RouteAdd(srcAddr net.HardwareAddr, dstAddr net.HardwareAd
 	if len(dstAddr) != 6 {
 		return -1, fmt.Errorf("unsupported destination MAC address: must be EUI-48")
 	}
+	if device == "" {
+		return -1, fmt.Errorf("device name is required")
+	}
 
 	cName := C.CString(device)
 	defer C.free(unsafe.Pointer(cName))

--- a/modules/route/controlplane/routepb/convert.go
+++ b/modules/route/controlplane/routepb/convert.go
@@ -96,8 +96,8 @@ func ToRIBRoute(route *Route, toRemove bool) (*rib.Route, error) {
 
 // RouteSourceID returns the internal rib.RouteSourceID from InsertRouteRequest
 // Defaults to RouteSourceStatic if unknown or unspecified
-func (r *InsertRouteRequest) RouteSourceID() rib.RouteSourceID {
-	switch r.GetSourceId() {
+func (m *InsertRouteRequest) RouteSourceID() rib.RouteSourceID {
+	switch m.GetSourceId() {
 	case RouteSourceID_ROUTE_SOURCE_ID_BIRD:
 		return rib.RouteSourceBird
 	default:
@@ -107,8 +107,8 @@ func (r *InsertRouteRequest) RouteSourceID() rib.RouteSourceID {
 
 // RouteSourceID returns the internal rib.RouteSourceID from DeleteRouteRequest
 // Defaults to RouteSourceStatic if unknown or unspecified
-func (r *DeleteRouteRequest) RouteSourceID() rib.RouteSourceID {
-	switch r.GetSourceId() {
+func (m *DeleteRouteRequest) RouteSourceID() rib.RouteSourceID {
+	switch m.GetSourceId() {
 	case RouteSourceID_ROUTE_SOURCE_ID_BIRD:
 		return rib.RouteSourceBird
 	default:

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -308,7 +308,7 @@ func (m *RouteService) InsertRoute(
 	name := request.GetName()
 	if name == "" {
 		m.log.Errorw("InsertRoute: name validation failed",
-			"config_name", name,
+			zap.String("config_name", name),
 		)
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
@@ -316,22 +316,22 @@ func (m *RouteService) InsertRoute(
 	prefix, err := netip.ParsePrefix(request.GetPrefix())
 	if err != nil {
 		m.log.Errorw("InsertRoute: failed to parse prefix",
-			"error", err,
-			"prefix_str", request.GetPrefix(),
-			"name", name,
+			zap.Error(err),
+			zap.String("prefix_str", request.GetPrefix()),
+			zap.String("name", name),
 		)
-		return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix %q: %v", request.GetPrefix(), err)
 	}
 
 	nexthopAddr, err := netip.ParseAddr(request.GetNexthopAddr())
 	if err != nil {
 		m.log.Errorw("InsertRoute: failed to parse nexthop address",
-			"error", err,
-			"nexthop_str", request.GetNexthopAddr(),
-			"prefix", prefix,
-			"name", name,
+			zap.Error(err),
+			zap.String("nexthop_str", request.GetNexthopAddr()),
+			zap.Stringer("prefix", prefix),
+			zap.String("name", name),
 		)
-		return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop address: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop address %q: %v", request.GetNexthopAddr(), err)
 	}
 
 	sourceID := request.RouteSourceID()
@@ -340,11 +340,11 @@ func (m *RouteService) InsertRoute(
 
 	if err := holder.AddUnicastRoute(prefix, nexthopAddr, sourceID); err != nil {
 		m.log.Errorw("InsertRoute: failed to add unicast route to RIB",
-			"error", err,
-			"prefix", prefix,
-			"nexthop", nexthopAddr,
-			"source", sourceID,
-			"name", name,
+			zap.Error(err),
+			zap.Stringer("prefix", prefix),
+			zap.Stringer("nexthop", nexthopAddr),
+			zap.Uint8("source", uint8(sourceID)),
+			zap.String("name", name),
 		)
 		return nil, fmt.Errorf("failed to add unicast route: %w", err)
 	}
@@ -352,20 +352,20 @@ func (m *RouteService) InsertRoute(
 	if request.GetDoFlush() {
 		if err := m.syncRouteUpdates(holder, name); err != nil {
 			m.log.Errorw("InsertRoute: failed to sync route updates",
-				"error", err,
-				"prefix", prefix,
-				"nexthop", nexthopAddr,
-				"name", name,
+				zap.Error(err),
+				zap.Stringer("prefix", prefix),
+				zap.Stringer("nexthop", nexthopAddr),
+				zap.String("name", name),
 			)
 			return &routepb.InsertRouteResponse{}, err
 		}
 	}
 
 	m.log.Infow("InsertRoute completed successfully",
-		"prefix", prefix,
-		"nexthop", nexthopAddr,
-		"name", name,
-		"duration", time.Since(startTime),
+		zap.Stringer("prefix", prefix),
+		zap.Stringer("nexthop", nexthopAddr),
+		zap.String("name", name),
+		zap.Duration("duration", time.Since(startTime)),
 	)
 	return &routepb.InsertRouteResponse{}, nil
 }
@@ -395,17 +395,19 @@ func (m *RouteService) DeleteRoute(
 
 	holder, ok := m.getRib(name)
 	if !ok {
-		m.log.Warnw("DeleteRoute: no RIB found for module", "name", name)
+		m.log.Warnw("DeleteRoute: no RIB found for module",
+			zap.String("name", name),
+		)
 		return &routepb.DeleteRouteResponse{}, nil
 	}
 
 	if err := holder.RemoveUnicastRoute(prefix, nexthopAddr, sourceID); err != nil {
 		m.log.Errorw("DeleteRoute: failed to remove unicast route from RIB",
-			"error", err,
-			"prefix", prefix,
-			"nexthop", nexthopAddr,
-			"source", sourceID,
-			"name", name,
+			zap.Error(err),
+			zap.Stringer("prefix", prefix),
+			zap.Stringer("nexthop", nexthopAddr),
+			zap.Uint8("source", uint8(sourceID)),
+			zap.String("name", name),
 		)
 		return nil, fmt.Errorf("failed to remove unicast route: %w", err)
 	}
@@ -413,20 +415,20 @@ func (m *RouteService) DeleteRoute(
 	if request.GetDoFlush() {
 		if err := m.syncRouteUpdates(holder, name); err != nil {
 			m.log.Errorw("DeleteRoute: failed to sync route deletions",
-				"error", err,
-				"prefix", prefix,
-				"nexthop", nexthopAddr,
-				"name", name,
+				zap.Error(err),
+				zap.Stringer("prefix", prefix),
+				zap.Stringer("nexthop", nexthopAddr),
+				zap.String("name", name),
 			)
 			return nil, status.Errorf(codes.Internal, "failed to sync route deletions: %v", err)
 		}
 	}
 
 	m.log.Infow("DeleteRoute completed successfully",
-		"prefix", prefix,
-		"nexthop", nexthopAddr,
-		"name", name,
-		"duration", time.Since(startTime),
+		zap.Stringer("prefix", prefix),
+		zap.Stringer("nexthop", nexthopAddr),
+		zap.String("name", name),
+		zap.Duration("duration", time.Since(startTime)),
 	)
 	return &routepb.DeleteRouteResponse{}, nil
 }
@@ -461,15 +463,17 @@ func (m *RouteService) DeleteConfig(
 	_, exists := m.ribs[name]
 	if !exists {
 		m.ribsLock.Unlock()
-		m.log.Warnw("DeleteConfig: RIB not found", "name", name)
+		m.log.Warnw("DeleteConfig: RIB not found",
+			zap.String("name", name),
+		)
 		return &routepb.DeleteConfigResponse{}, nil
 	}
 	delete(m.ribs, name)
 	m.ribsLock.Unlock()
 
 	m.log.Infow("DeleteConfig completed successfully",
-		"name", name,
-		"duration", time.Since(startTime),
+		zap.String("name", name),
+		zap.Duration("duration", time.Since(startTime)),
 	)
 
 	return &routepb.DeleteConfigResponse{}, nil
@@ -566,7 +570,9 @@ func (m *RouteService) getOrCreateRib(name string) *rib.RIB {
 
 	ribRef, ok := m.ribs[name]
 	if !ok {
-		m.log.Infow("creating new RIB", "name", name)
+		m.log.Infow("creating new RIB",
+			zap.String("name", name),
+		)
 		ribRef = rib.NewRIB(m.log)
 		m.ribs[name] = ribRef
 	}
@@ -583,8 +589,8 @@ func (m *RouteService) syncRouteUpdates(ribRef *rib.RIB, name string) error {
 	err := m.updateModuleConfig(name, ribDump)
 	if err != nil {
 		m.log.Errorw("syncRouteUpdates: failed to update module config",
-			"error", err,
-			"name", name,
+			zap.Error(err),
+			zap.String("name", name),
 		)
 		return err
 	}
@@ -598,8 +604,8 @@ func (m *RouteService) updateModuleConfig(
 	config, err := NewModuleConfig(m.agent, name)
 	if err != nil {
 		m.log.Errorw("updateModuleConfig: failed to create module config",
-			"error", err,
-			"name", name,
+			zap.Error(err),
+			zap.String("name", name),
 		)
 		return fmt.Errorf("failed to create %q module config: %w", name, err)
 	}
@@ -639,9 +645,9 @@ func (m *RouteService) updateModuleConfig(
 				entry, ok := neighbours.Lookup(route.NextHop.Unmap())
 				if !ok {
 					m.log.Warnw("updateModuleConfig: neighbour not found for nexthop",
-						"nexthop", route.NextHop,
-						"prefix", prefix,
-						"name", name,
+						zap.Stringer("nexthop", route.NextHop),
+						zap.Stringer("prefix", prefix),
+						zap.String("name", name),
 					)
 					stats.neighbourNotFound++
 					continue
@@ -659,12 +665,12 @@ func (m *RouteService) updateModuleConfig(
 				)
 				if err != nil {
 					m.log.Errorw("updateModuleConfig: failed to add hardware route",
-						"error", err,
-						"hardware_route", entry.HardwareRoute,
-						"prefix", prefix,
-						"name", name,
+						zap.Error(err),
+						zap.Stringer("hardware_route", entry.HardwareRoute),
+						zap.Stringer("prefix", prefix),
+						zap.String("name", name),
 					)
-					return fmt.Errorf("failed to add hardware route %q: %w", entry.HardwareRoute, err)
+					return fmt.Errorf("failed to add hardware route %v for prefix %s: %w", entry.HardwareRoute, prefix, err)
 				}
 				stats.hardwareRoutesAdded++
 				hardwareRoutes[entry.HardwareRoute] = uint32(idx)
@@ -680,10 +686,10 @@ func (m *RouteService) updateModuleConfig(
 				routeListIdx, err := config.RouteListAdd(routesListSetKey.AsSlice())
 				if err != nil {
 					m.log.Errorw("updateModuleConfig: failed to add route list",
-						"error", err,
-						"route_indices", routesListSetKey.AsSlice(),
-						"prefix", prefix,
-						"name", name,
+						zap.Error(err),
+						zap.Uint32s("route_indices", routesListSetKey.AsSlice()),
+						zap.Stringer("prefix", prefix),
+						zap.String("name", name),
 					)
 					return fmt.Errorf("failed to add routes list: %w", err)
 				}
@@ -693,10 +699,10 @@ func (m *RouteService) updateModuleConfig(
 
 			if err := config.PrefixAdd(prefix, uint32(idx)); err != nil {
 				m.log.Errorw("updateModuleConfig: failed to add prefix",
-					"error", err,
-					"prefix", prefix,
-					"route_list_index", idx,
-					"name", name,
+					zap.Error(err),
+					zap.Stringer("prefix", prefix),
+					zap.Int("route_list_index", idx),
+					zap.String("name", name),
 				)
 				return fmt.Errorf("failed to add prefix %q: %w", prefix, err)
 			}
@@ -705,20 +711,20 @@ func (m *RouteService) updateModuleConfig(
 	}
 
 	m.log.Infow("updateModuleConfig: finished processing routes",
-		"module", name,
-		"total_prefixes", stats.totalPrefixes,
-		"total_routes", stats.totalRoutes,
-		"skipped_prefixes", stats.skippedPrefixes,
-		"neighbour_not_found", stats.neighbourNotFound,
-		"hardware_routes_added", stats.hardwareRoutesAdded,
-		"prefixes_added", stats.prefixesAdded,
-		"processing_duration", time.Since(routeInsertionStart),
+		zap.String("module", name),
+		zap.Int("total_prefixes", stats.totalPrefixes),
+		zap.Int("total_routes", stats.totalRoutes),
+		zap.Int("skipped_prefixes", stats.skippedPrefixes),
+		zap.Int("neighbour_not_found", stats.neighbourNotFound),
+		zap.Int("hardware_routes_added", stats.hardwareRoutesAdded),
+		zap.Int("prefixes_added", stats.prefixesAdded),
+		zap.Duration("processing_duration", time.Since(routeInsertionStart)),
 	)
 
 	if err := m.agent.UpdateModules([]ffi.ModuleConfig{config.AsFFIModule()}); err != nil {
 		m.log.Errorw("updateModuleConfig: failed to update modules via FFI",
-			"error", err,
-			"name", name,
+			zap.Error(err),
+			zap.String("name", name),
 		)
 		return fmt.Errorf("failed to update module: %w", err)
 	}

--- a/modules/route/internal/discovery/neigh/neigh.go
+++ b/modules/route/internal/discovery/neigh/neigh.go
@@ -163,7 +163,9 @@ func (m *NeighMonitor) processNeighUpdate(update netlink.NeighUpdate) error {
 		//
 		// Instead, the entire neighbors table is overwritten on a timer event.
 	default:
-		m.log.Warnf("received unexpected neighbour update type: %d", update.Type)
+		m.log.Warnw("received unexpected neighbour update type",
+			zap.Uint16("type", update.Type),
+		)
 	}
 
 	return nil
@@ -205,24 +207,32 @@ func (m *NeighMonitor) updateNeighbours() error {
 	for _, neigh := range neighs {
 		nexthopAddr, ok := netip.AddrFromSlice(neigh.IP)
 		if !ok {
-			m.log.Warnf("failed to parse neighbour IP address: %q", neigh.IP)
+			m.log.Warnw("failed to parse neighbour IP address",
+				zap.String("ip", neigh.IP.String()),
+			)
 			continue
 		}
 
 		// Skip entries with invalid MAC.
 		if len(neigh.HardwareAddr) != 6 {
-			m.log.Warnf("skipping entry with unsupported MAC address %q: must be EUI-48", neigh.HardwareAddr)
+			m.log.Warnw("skipping entry with unsupported MAC address: must be EUI-48",
+				zap.Stringer("mac", neigh.HardwareAddr),
+			)
 			continue
 		}
 
 		// Get the hardware address of the interface.
 		hardwareAddr, ok := linkIndexToHardwareAddr[neigh.LinkIndex]
 		if !ok {
-			m.log.Warnf("no hardware address for link index: %d - %#+v", neigh.LinkIndex, neigh)
+			m.log.Warnw("no hardware address for link index",
+				zap.Int("link_index", neigh.LinkIndex),
+			)
 			continue
 		}
 		if len(hardwareAddr) != 6 {
-			m.log.Warnf("skipping entry with unsupported interface MAC address %q: must be EUI-48", hardwareAddr)
+			m.log.Warnw("skipping entry with unsupported interface MAC address: must be EUI-48",
+				zap.Stringer("mac", hardwareAddr),
+			)
 			continue
 		}
 

--- a/modules/route/internal/rib/rib.go
+++ b/modules/route/internal/rib/rib.go
@@ -61,8 +61,8 @@ func (m *RIB) AddUnicastRoute(prefix netip.Prefix, nexthopAddr netip.Addr, sourc
 	m.changedAt.Store(time.Now().UnixNano())
 
 	m.log.Infow("RIB: added unicast route",
-		"prefix", prefix,
-		"nexthop", nexthopAddr,
+		zap.Stringer("prefix", prefix),
+		zap.Stringer("nexthop", nexthopAddr),
 	)
 
 	return nil
@@ -94,16 +94,16 @@ func (m *RIB) RemoveUnicastRoute(prefix netip.Prefix, nexthopAddr netip.Addr, so
 	if found > 0 {
 		m.changedAt.Store(time.Now().UnixNano())
 		m.log.Infow("RIB: removed unicast route",
-			"prefix", prefix,
-			"nexthop", nexthopAddr,
-			"source", sourceID,
-			"count", found,
+			zap.Stringer("prefix", prefix),
+			zap.Stringer("nexthop", nexthopAddr),
+			zap.Uint8("source", uint8(sourceID)),
+			zap.Int("count", found),
 		)
 	} else {
 		m.log.Warnw("RIB: route not found for removal",
-			"prefix", prefix,
-			"nexthop", nexthopAddr,
-			"source", sourceID,
+			zap.Stringer("prefix", prefix),
+			zap.Stringer("nexthop", nexthopAddr),
+			zap.Uint8("source", uint8(sourceID)),
 		)
 	}
 
@@ -195,10 +195,14 @@ func (m *RIB) CleanupTask(sessionID uint64, quit chan bool, ttl time.Duration) {
 	timeout := time.After(ttl)
 	select {
 	case <-quit:
-		m.log.Infow("RIB: cleanup task cancelled before timeout", "sessionID", sessionID)
+		m.log.Infow("RIB: cleanup task cancelled before timeout",
+			zap.Uint64("sessionID", sessionID),
+		)
 		return
 	case <-timeout:
-		m.log.Infow("RIB: cleanup task timeout reached, starting cleanup", "sessionID", sessionID)
+		m.log.Infow("RIB: cleanup task timeout reached, starting cleanup",
+			zap.Uint64("sessionID", sessionID),
+		)
 	}
 
 	removedCount := 0
@@ -214,8 +218,8 @@ func (m *RIB) CleanupTask(sessionID uint64, quit chan bool, ttl time.Duration) {
 		select {
 		case <-quit:
 			m.log.Infow("RIB: cleanup task interrupted during cleanup",
-				"sessionID", sessionID,
-				"removedCount", removedCount,
+				zap.Uint64("sessionID", sessionID),
+				zap.Int("removedCount", removedCount),
 			)
 			return
 		default:
@@ -231,5 +235,8 @@ func (m *RIB) CleanupTask(sessionID uint64, quit chan bool, ttl time.Duration) {
 		m.update(routeList.Routes...)
 	}
 
-	m.log.Infow("RIB: cleanup task completed", "sessionID", sessionID, "removedCount", removedCount)
+	m.log.Infow("RIB: cleanup task completed",
+		zap.Uint64("sessionID", sessionID),
+		zap.Int("removedCount", removedCount),
+	)
 }


### PR DESCRIPTION
Migrate logging to use typed zap fields instead of key-value pairs according to project standards. Add validation for device parameter in RouteAdd to prevent empty values. Fix receiver names to follow project convention (use 'm' consistently).