### PR TITLE
feat (route/neigh): add multi-source neighbour table with priority-based merging

### DIFF
--- a/common/rust/netip/src/lib.rs
+++ b/common/rust/netip/src/lib.rs
@@ -1,4 +1,7 @@
-use core::fmt::{self, Display, Formatter};
+use core::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
 
 /// A MAC address.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Default, Hash)]
@@ -37,3 +40,40 @@ impl Display for MacAddr {
         write!(fmt, "{a:02x}:{b:02x}:{c:02x}:{d:02x}:{e:02x}:{f:02x}")
     }
 }
+
+impl FromStr for MacAddr {
+    type Err = MacAddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut octets = [0u8; 6];
+        let mut idx = 0;
+
+        for part in s.split(':') {
+            if idx >= 6 {
+                return Err(MacAddrParseError);
+            }
+            octets[idx] = u8::from_str_radix(part, 16).map_err(|_| MacAddrParseError)?;
+            idx += 1;
+        }
+
+        if idx != 6 {
+            return Err(MacAddrParseError);
+        }
+
+        Ok(MacAddr::new(
+            octets[0], octets[1], octets[2], octets[3], octets[4], octets[5],
+        ))
+    }
+}
+
+/// Error returned when parsing a MAC address string fails.
+#[derive(Debug, Clone, Copy)]
+pub struct MacAddrParseError;
+
+impl Display for MacAddrParseError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        write!(f, "invalid MAC address format, expected EUI-48: xx:xx:xx:xx:xx:xx")
+    }
+}
+
+impl core::error::Error for MacAddrParseError {}

--- a/modules/route/cli/neighbour/src/lib.rs
+++ b/modules/route/cli/neighbour/src/lib.rs
@@ -60,11 +60,37 @@ pub struct NeighbourEntry {
     /// MAC address of the local interface that connects to this neighbor.
     #[tabled(rename = "INTERFACE MAC")]
     pub hardware_addr: MacAddr,
-    /// Current state of the neighbor relationship (e.g., REACHABLE, STALE,
-    /// PROBE).
+    /// Network interface name.
+    #[tabled(rename = "DEVICE")]
+    pub device: String,
+    /// Current state of the neighbor relationship (e.g., REACHABLE,
+    /// STALE, PROBE).
     #[tabled(rename = "STATE")]
     pub state: State,
     /// Time elapsed since this neighbor entry was last updated.
     #[tabled(rename = "AGE")]
     pub age: Age,
+    /// Name of the source table this entry belongs to.
+    #[tabled(rename = "SOURCE")]
+    pub source: String,
+    /// Priority of this entry (lower wins).
+    #[tabled(rename = "PRIORITY")]
+    pub priority: u32,
+}
+
+/// Represents metadata about a neighbour table.
+#[derive(Debug, Tabled)]
+pub struct TableEntry {
+    /// Name of the table.
+    #[tabled(rename = "NAME")]
+    pub name: String,
+    /// Default priority for entries in this table.
+    #[tabled(rename = "DEFAULT PRIORITY")]
+    pub default_priority: u32,
+    /// Number of entries in this table.
+    #[tabled(rename = "ENTRIES")]
+    pub entry_count: i64,
+    /// Whether this table is built-in.
+    #[tabled(rename = "BUILT-IN")]
+    pub built_in: bool,
 }

--- a/modules/route/cli/neighbour/src/main.rs
+++ b/modules/route/cli/neighbour/src/main.rs
@@ -5,7 +5,11 @@ use std::time::UNIX_EPOCH;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use code::{neighbour_client::NeighbourClient, ListNeighboursRequest};
+use code::{
+    neighbour_client::NeighbourClient, CreateNeighbourTableRequest, ListNeighbourTablesRequest, ListNeighboursRequest,
+    MacAddress, NeighbourEntry as ProtoNeighbourEntry, RemoveNeighbourTableRequest, RemoveNeighboursRequest,
+    UpdateNeighbourTableRequest, UpdateNeighboursRequest,
+};
 use netip::MacAddr;
 use tabled::{
     settings::{
@@ -16,7 +20,7 @@ use tabled::{
     Table,
 };
 use tonic::{codec::CompressionEncoding, transport::Channel};
-use yanet_cli_neighbour::{Age, NeighbourEntry, State};
+use yanet_cli_neighbour::{Age, NeighbourEntry, State, TableEntry};
 use ync::logging;
 
 #[allow(non_snake_case)]
@@ -43,11 +47,99 @@ pub struct Cmd {
 pub enum ModeCmd {
     /// Show current neighbors.
     Show(ShowCmd),
+    /// Add one or more static neighbour entries.
+    Add(AddCmd),
+    /// Remove one or more neighbour entries.
+    Remove(RemoveCmd),
+    /// Neighbour table operations.
+    Table(TableCmd),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct TableCmd {
+    #[clap(subcommand)]
+    pub action: TableAction,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub enum TableAction {
+    /// List neighbour tables.
+    Show,
+    /// Create a new neighbour table.
+    Create(CreateTableCmd),
+    /// Update an existing neighbour table.
+    Update(UpdateTableCmd),
+    /// Remove a neighbour table.
+    Remove(RemoveTableCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
-    // NOTE: optional parameters can be added here if needed.
+    /// Show entries from a specific table only. If omitted, shows the
+    /// merged view.
+    #[arg(long)]
+    pub table: Option<String>,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct AddCmd {
+    /// Next-hop IP address.
+    pub next_hop: String,
+    /// MAC address of the next-hop device (neighbour MAC).
+    #[arg(long)]
+    pub link_addr: String,
+    /// MAC address of the local interface.
+    #[arg(long)]
+    pub hardware_addr: String,
+    /// Network interface name.
+    #[arg(long)]
+    pub device: Option<String>,
+    /// Neighbour table name.
+    ///
+    /// Defaults to "static".
+    #[arg(long)]
+    pub table: Option<String>,
+    /// Priority for this entry.
+    ///
+    /// Lower value means higher priority.
+    /// Defaults to the table's default priority.
+    #[arg(long)]
+    pub priority: Option<u32>,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct RemoveCmd {
+    /// Next-hop IP address(es) to remove.
+    pub next_hops: Vec<String>,
+    /// Neighbour table name.
+    ///
+    /// Defaults to "static".
+    #[arg(long)]
+    pub table: Option<String>,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct CreateTableCmd {
+    /// Neighbour table name.
+    pub name: String,
+    /// Default priority for entries in this table.
+    #[arg(long)]
+    pub default_priority: u32,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct UpdateTableCmd {
+    /// Neighbour table name.
+    pub name: String,
+    /// New default priority for entries in this table.
+    #[arg(long)]
+    pub default_priority: u32,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct RemoveTableCmd {
+    /// Table name.
+    pub name: String,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -67,7 +159,15 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
     let mut service = NeighbourService::new(cmd.endpoint).await?;
 
     match cmd.mode {
-        ModeCmd::Show(_) => service.show_neighbours().await,
+        ModeCmd::Show(args) => service.show_neighbours(args.table).await,
+        ModeCmd::Add(args) => service.update_neighbour(args).await,
+        ModeCmd::Remove(args) => service.remove_neighbours(args).await,
+        ModeCmd::Table(cmd) => match cmd.action {
+            TableAction::Show => service.list_tables().await,
+            TableAction::Create(args) => service.create_table(args).await,
+            TableAction::Update(args) => service.update_table(args).await,
+            TableAction::Remove(args) => service.remove_table(args).await,
+        },
     }
 }
 
@@ -89,9 +189,10 @@ impl NeighbourService {
         Ok(Self { client })
     }
 
-    /// Retrieves and displays the current neighbor table in a formatted table.
-    pub async fn show_neighbours(&mut self) -> Result<(), Box<dyn Error>> {
-        let request = ListNeighboursRequest {};
+    /// Retrieves and displays the current neighbor table in a formatted
+    /// table.
+    pub async fn show_neighbours(&mut self, table: Option<String>) -> Result<(), Box<dyn Error>> {
+        let request = ListNeighboursRequest { table: table.unwrap_or_default() };
         let response = self.client.list(request).await?.into_inner();
 
         let mut entries = response
@@ -114,15 +215,17 @@ impl NeighbourService {
                     next_hop,
                     link_addr,
                     hardware_addr,
+                    device: entry.device,
                     state: State(entry.state),
                     age: Age(updated_at),
+                    source: entry.source,
+                    priority: entry.priority,
                 }
             })
             .collect::<Vec<_>>();
 
         entries.sort_by(|a, b| (a.state, &a.next_hop).cmp(&(b.state, &b.next_hop)));
 
-        // TODO: in the future we may want to --format=json.
         let mut table = Table::new(entries);
         table.with(
             Style::modern()
@@ -136,4 +239,108 @@ impl NeighbourService {
 
         Ok(())
     }
+
+    /// Adds or updates a neighbour entry.
+    pub async fn update_neighbour(&mut self, args: AddCmd) -> Result<(), Box<dyn Error>> {
+        let link_addr = parse_mac(&args.link_addr)?;
+        let hardware_addr = parse_mac(&args.hardware_addr)?;
+
+        let request = UpdateNeighboursRequest {
+            table: args.table.unwrap_or_default(),
+            entries: vec![ProtoNeighbourEntry {
+                next_hop: args.next_hop,
+                link_addr: Some(link_addr),
+                hardware_addr: Some(hardware_addr),
+                device: args.device.unwrap_or_default(),
+                priority: args.priority.unwrap_or_default(),
+                ..Default::default()
+            }],
+        };
+
+        self.client.update_neighbours(request).await?;
+        println!("OK");
+        Ok(())
+    }
+
+    /// Removes one or more neighbour entries.
+    pub async fn remove_neighbours(&mut self, args: RemoveCmd) -> Result<(), Box<dyn Error>> {
+        let request = RemoveNeighboursRequest {
+            table: args.table.unwrap_or_default(),
+            next_hops: args.next_hops,
+        };
+
+        self.client.remove_neighbours(request).await?;
+        println!("OK");
+        Ok(())
+    }
+
+    /// Lists all neighbour tables.
+    pub async fn list_tables(&mut self) -> Result<(), Box<dyn Error>> {
+        let response = self
+            .client
+            .list_tables(ListNeighbourTablesRequest {})
+            .await?
+            .into_inner();
+
+        let entries: Vec<TableEntry> = response
+            .tables
+            .into_iter()
+            .map(|t| TableEntry {
+                name: t.name,
+                default_priority: t.default_priority,
+                entry_count: t.entry_count,
+                built_in: t.built_in,
+            })
+            .collect();
+
+        let mut table = Table::new(entries);
+        table.with(
+            Style::modern()
+                .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
+                .remove_frame()
+                .remove_horizontal(),
+        );
+        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
+
+        println!("{table}");
+        Ok(())
+    }
+
+    /// Creates a new neighbour table.
+    pub async fn create_table(&mut self, args: CreateTableCmd) -> Result<(), Box<dyn Error>> {
+        let request = CreateNeighbourTableRequest {
+            name: args.name,
+            default_priority: args.default_priority,
+        };
+
+        self.client.create_table(request).await?;
+        println!("OK");
+        Ok(())
+    }
+
+    /// Updates an existing neighbour table.
+    pub async fn update_table(&mut self, args: UpdateTableCmd) -> Result<(), Box<dyn Error>> {
+        let request = UpdateNeighbourTableRequest {
+            name: args.name,
+            default_priority: args.default_priority,
+        };
+
+        self.client.update_table(request).await?;
+        println!("OK");
+        Ok(())
+    }
+
+    /// Removes a neighbour table.
+    pub async fn remove_table(&mut self, args: RemoveTableCmd) -> Result<(), Box<dyn Error>> {
+        let request = RemoveNeighbourTableRequest { name: args.name };
+
+        self.client.remove_table(request).await?;
+        println!("OK");
+        Ok(())
+    }
+}
+
+fn parse_mac(s: &str) -> Result<MacAddress, Box<dyn Error>> {
+    let mac: MacAddr = s.parse()?;
+    Ok(MacAddress { addr: mac.as_u64() })
 }

--- a/modules/route/controlplane/cfg.go
+++ b/modules/route/controlplane/cfg.go
@@ -19,6 +19,22 @@ type Config struct {
 	GatewayEndpoint    string            `yaml:"gateway_endpoint"`
 	RibTTL             time.Duration     `yaml:"rib_ttl"`
 	LinkMap            map[string]string `yaml:"link_map"`
+	// NetlinkMonitor configures the kernel neighbour discovery via netlink.
+	NetlinkMonitor NetlinkMonitorConfig `yaml:"netlink_monitor"`
+}
+
+// NetlinkMonitorConfig configures the kernel neighbour discovery via netlink.
+type NetlinkMonitorConfig struct {
+	// Disabled disables the netlink neighbour monitor entirely.
+	//
+	// When disabled, no kernel neighbour table is created and no netlink
+	// subscription is started.
+	Disabled bool `yaml:"disabled"`
+	// TableName is the name of the kernel neighbour table.
+	TableName string `yaml:"table_name"`
+	// DefaultPriority is the default priority for kernel-learned
+	// neighbour entries.
+	DefaultPriority uint32 `yaml:"default_priority"`
 }
 
 func DefaultConfig() *Config {
@@ -29,5 +45,9 @@ func DefaultConfig() *Config {
 		GatewayEndpoint:    "[::1]:8080",
 		RibTTL:             time.Minute,
 		LinkMap:            make(map[string]string),
+		NetlinkMonitor: NetlinkMonitorConfig{
+			TableName:       "kernel",
+			DefaultPriority: 100,
+		},
 	}
 }

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -3,7 +3,6 @@ package route
 import (
 	"context"
 	"fmt"
-	"net/netip"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -11,28 +10,40 @@ import (
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	routepb "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb"
-	"github.com/yanet-platform/yanet2/modules/route/internal/discovery"
 	"github.com/yanet-platform/yanet2/modules/route/internal/discovery/neigh"
+)
+
+const (
+	// defaultStaticPriority is the default priority for statically
+	// configured neighbours.
+	defaultStaticPriority = 10
 )
 
 // RouteModule is a controlplane part of a module that is responsible for
 // routing configuration.
 type RouteModule struct {
-	cfg                *Config
-	shm                *ffi.SharedMemory
-	agent              *ffi.Agent
-	neighbourDiscovery *neigh.NeighMonitor
-	routeService       *RouteService
-	neighbourService   *NeighbourService
-	log                *zap.SugaredLogger
+	cfg              *Config
+	shm              *ffi.SharedMemory
+	agent            *ffi.Agent
+	neighbourMonitor *neigh.NeighMonitor
+	routeService     *RouteService
+	neighbourService *NeighbourService
+	log              *zap.SugaredLogger
 }
 
 // NewRouteModule creates a new RouteModule.
 func NewRouteModule(cfg *Config, log *zap.SugaredLogger) (*RouteModule, error) {
 	log = log.With(zap.String("module", "routepb.RouteService"))
 
-	neighbourCache := discovery.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
-	neighbourDiscovery := neigh.NewNeighMonitor(neighbourCache, neigh.WithLog(log), neigh.WithLinkMap(cfg.LinkMap))
+	neighbourTable := neigh.NewNeighTable()
+	if _, err := neighbourTable.CreateSource("static", defaultStaticPriority, true); err != nil {
+		return nil, fmt.Errorf("failed to create static neighbour source: %w", err)
+	}
+
+	neighbourMonitor, err := newNeighbourMonitor(cfg, neighbourTable, log)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create neighbour monitor: %w", err)
+	}
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
 	if err != nil {
@@ -49,18 +60,48 @@ func NewRouteModule(cfg *Config, log *zap.SugaredLogger) (*RouteModule, error) {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
 
-	routeService := NewRouteService(agent, neighbourCache, cfg.RibTTL, log)
-	neighbourService := NewNeighbourService(neighbourCache, log)
+	routeService := NewRouteService(agent, neighbourTable, cfg.RibTTL, log)
+	neighbourService := NewNeighbourService(neighbourTable, log)
 
 	return &RouteModule{
-		cfg:                cfg,
-		shm:                shm,
-		agent:              agent,
-		neighbourDiscovery: neighbourDiscovery,
-		routeService:       routeService,
-		neighbourService:   neighbourService,
-		log:                log,
+		cfg:              cfg,
+		shm:              shm,
+		agent:            agent,
+		neighbourMonitor: neighbourMonitor,
+		routeService:     routeService,
+		neighbourService: neighbourService,
+		log:              log,
 	}, nil
+}
+
+// newNeighbourMonitor creates a new neighbour monitor if netlink discovery is
+// enabled.
+func newNeighbourMonitor(
+	cfg *Config,
+	neighTable *neigh.NeighTable,
+	log *zap.SugaredLogger,
+) (*neigh.NeighMonitor, error) {
+	if cfg.NetlinkMonitor.Disabled {
+		return nil, nil
+	}
+
+	source, err := neighTable.CreateSource(
+		cfg.NetlinkMonitor.TableName,
+		cfg.NetlinkMonitor.DefaultPriority,
+		true,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kernel neighbour source: %w", err)
+	}
+
+	neighbourMonitor := neigh.NewNeighMonitor(
+		neighTable,
+		source,
+		neigh.WithLog(log),
+		neigh.WithLinkMap(cfg.LinkMap),
+	)
+
+	return neighbourMonitor, nil
 }
 
 func (m *RouteModule) Name() string {
@@ -101,8 +142,9 @@ func (m *RouteModule) Close() error {
 // controlplane/internal/gateway/runner.go
 func (m *RouteModule) Run(ctx context.Context) error {
 	wg, ctx := errgroup.WithContext(ctx)
+
 	wg.Go(func() error {
-		return m.neighbourDiscovery.Run(ctx)
+		return m.runNeighbourMonitor(ctx)
 	})
 	wg.Go(func() error {
 		<-ctx.Done()
@@ -111,4 +153,12 @@ func (m *RouteModule) Run(ctx context.Context) error {
 	})
 
 	return wg.Wait()
+}
+
+func (m *RouteModule) runNeighbourMonitor(ctx context.Context) error {
+	if m.neighbourMonitor == nil {
+		return nil
+	}
+
+	return m.neighbourMonitor.Run(ctx)
 }

--- a/modules/route/controlplane/neighbour_service.go
+++ b/modules/route/controlplane/neighbour_service.go
@@ -2,6 +2,9 @@ package route
 
 import (
 	"context"
+	"fmt"
+	"net/netip"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -9,43 +12,193 @@ import (
 	"github.com/yanet-platform/yanet2/modules/route/internal/discovery/neigh"
 )
 
-// NeighbourService implements the Neighbour service for retrieving neighbor information.
+const defaultStaticTable = "static"
+
+// NeighbourService implements the Neighbour service for retrieving and
+// managing neighbor information.
 type NeighbourService struct {
 	routepb.UnimplementedNeighbourServer
 
-	neighCache *neigh.NexthopCache
+	neighTable *neigh.NeighTable
 	log        *zap.SugaredLogger
 }
 
 // NewNeighbourService creates a new NeighbourService.
-func NewNeighbourService(neighCache *neigh.NexthopCache, log *zap.SugaredLogger) *NeighbourService {
+func NewNeighbourService(neighTable *neigh.NeighTable, log *zap.SugaredLogger) *NeighbourService {
 	return &NeighbourService{
-		neighCache: neighCache,
+		neighTable: neighTable,
 		log:        log,
 	}
 }
 
-// List returns all current neighbors.
-func (m *NeighbourService) List(ctx context.Context, req *routepb.ListNeighboursRequest) (*routepb.ListNeighboursResponse, error) {
-	// Get a view of the current neighbor cache
-	view := m.neighCache.View()
+// List returns neighbors.
+//
+// If table is empty, returns the merged view.
+// If table is set, returns entries from the specified table only.
+func (m *NeighbourService) List(
+	ctx context.Context,
+	req *routepb.ListNeighboursRequest,
+) (*routepb.ListNeighboursResponse, error) {
+	table := req.GetTable()
+
+	var view neigh.NexthopCacheView
+	if table == "" {
+		view = m.neighTable.View()
+	} else {
+		v, ok := m.neighTable.SourceView(table)
+		if !ok {
+			return nil, fmt.Errorf("table %q not found", table)
+		}
+		view = v
+	}
+
 	entries, size := view.Entries()
 
-	// Convert all entries to proto format
-	protoEntries := make([]*routepb.NeighbourEntry, 0, size)
-
+	neighbours := make([]*routepb.NeighbourEntry, 0, size)
 	for entry := range entries {
-		protoEntry := &routepb.NeighbourEntry{
-			NextHop:      entry.NextHop.String(),
-			LinkAddr:     routepb.NewMACAddressEUI48(entry.HardwareRoute.DestinationMAC),
-			HardwareAddr: routepb.NewMACAddressEUI48(entry.HardwareRoute.SourceMAC),
-			State:        routepb.NeighbourState(entry.State),
-			UpdatedAt:    entry.UpdatedAt.Unix(),
+		source := entry.Source
+		if source == "" {
+			source = table
 		}
-		protoEntries = append(protoEntries, protoEntry)
+
+		neighbours = append(
+			neighbours,
+			&routepb.NeighbourEntry{
+				NextHop:      entry.NextHop.String(),
+				LinkAddr:     routepb.NewMACAddressEUI48(entry.HardwareRoute.DestinationMAC),
+				HardwareAddr: routepb.NewMACAddressEUI48(entry.HardwareRoute.SourceMAC),
+				State:        routepb.NeighbourState(entry.State),
+				UpdatedAt:    entry.UpdatedAt.Unix(),
+				Source:       source,
+				Priority:     entry.Priority,
+				Device:       entry.HardwareRoute.Device,
+			},
+		)
 	}
 
 	return &routepb.ListNeighboursResponse{
-		Neighbours: protoEntries,
+		Neighbours: neighbours,
 	}, nil
+}
+
+// CreateTable creates a new neighbour table.
+func (m *NeighbourService) CreateTable(_ context.Context, req *routepb.CreateNeighbourTableRequest) (*routepb.CreateNeighbourTableResponse, error) {
+	if _, err := m.neighTable.CreateSource(req.GetName(), req.GetDefaultPriority(), false); err != nil {
+		return nil, err
+	}
+	m.log.Infow("created neighbour table",
+		zap.String("name", req.GetName()),
+		zap.Uint32("default_priority", req.GetDefaultPriority()),
+	)
+	return &routepb.CreateNeighbourTableResponse{}, nil
+}
+
+// UpdateTable updates the default priority of an existing neighbour
+// table.
+func (m *NeighbourService) UpdateTable(_ context.Context, req *routepb.UpdateNeighbourTableRequest) (*routepb.UpdateNeighbourTableResponse, error) {
+	if err := m.neighTable.UpdateSource(req.GetName(), req.GetDefaultPriority()); err != nil {
+		return nil, err
+	}
+	m.log.Infow("updated neighbour table",
+		zap.String("name", req.GetName()),
+		zap.Uint32("default_priority", req.GetDefaultPriority()),
+	)
+	return &routepb.UpdateNeighbourTableResponse{}, nil
+}
+
+// RemoveTable removes a user-defined neighbour table.
+func (m *NeighbourService) RemoveTable(_ context.Context, req *routepb.RemoveNeighbourTableRequest) (*routepb.RemoveNeighbourTableResponse, error) {
+	if err := m.neighTable.DeleteSource(req.GetName()); err != nil {
+		return nil, err
+	}
+	m.log.Infow("removed neighbour table",
+		zap.String("name", req.GetName()),
+	)
+	return &routepb.RemoveNeighbourTableResponse{}, nil
+}
+
+// ListTables returns metadata about all registered neighbour tables.
+func (m *NeighbourService) ListTables(_ context.Context, _ *routepb.ListNeighbourTablesRequest) (*routepb.ListNeighbourTablesResponse, error) {
+	sources := m.neighTable.ListSources()
+
+	tables := make([]*routepb.NeighbourTableInfo, 0, len(sources))
+	for _, src := range sources {
+		tables = append(tables, &routepb.NeighbourTableInfo{
+			Name:            src.Name,
+			DefaultPriority: src.DefaultPriority,
+			EntryCount:      int64(src.EntryCount),
+			BuiltIn:         src.BuiltIn,
+		})
+	}
+
+	return &routepb.ListNeighbourTablesResponse{
+		Tables: tables,
+	}, nil
+}
+
+// UpdateNeighbours inserts or updates one or more neighbour entries in
+// the specified table.
+func (m *NeighbourService) UpdateNeighbours(_ context.Context, req *routepb.UpdateNeighboursRequest) (*routepb.UpdateNeighboursResponse, error) {
+	table := req.GetTable()
+	if table == "" {
+		table = defaultStaticTable
+	}
+
+	entries := make([]neigh.NeighbourEntry, 0, len(req.GetEntries()))
+	for _, e := range req.GetEntries() {
+		addr, err := netip.ParseAddr(e.GetNextHop())
+		if err != nil {
+			return nil, fmt.Errorf("invalid nexthop %q: %w", e.GetNextHop(), err)
+		}
+
+		entries = append(entries, neigh.NeighbourEntry{
+			NextHop: addr,
+			HardwareRoute: neigh.HardwareRoute{
+				SourceMAC:      e.GetHardwareAddr().EUI48(),
+				DestinationMAC: e.GetLinkAddr().EUI48(),
+				Device:         e.GetDevice(),
+			},
+			UpdatedAt: time.Now(),
+			State:     neigh.NeighbourStatePermanent,
+			Priority:  e.GetPriority(),
+		})
+	}
+
+	if err := m.neighTable.Add(table, entries); err != nil {
+		return nil, err
+	}
+
+	m.log.Infow("updated neighbour entries",
+		zap.String("table", table),
+		zap.Int("count", len(entries)),
+	)
+	return &routepb.UpdateNeighboursResponse{}, nil
+}
+
+// RemoveNeighbours deletes one or more neighbour entries from the
+// specified table.
+func (m *NeighbourService) RemoveNeighbours(_ context.Context, req *routepb.RemoveNeighboursRequest) (*routepb.RemoveNeighboursResponse, error) {
+	table := req.GetTable()
+	if table == "" {
+		table = defaultStaticTable
+	}
+
+	addrs := make([]netip.Addr, 0, len(req.GetNextHops()))
+	for _, hop := range req.GetNextHops() {
+		addr, err := netip.ParseAddr(hop)
+		if err != nil {
+			return nil, fmt.Errorf("invalid next_hop %q: %w", hop, err)
+		}
+		addrs = append(addrs, addr)
+	}
+
+	if err := m.neighTable.Remove(table, addrs); err != nil {
+		return nil, err
+	}
+
+	m.log.Infow("removed neighbour entries",
+		zap.String("table", table),
+		zap.Int("count", len(addrs)),
+	)
+	return &routepb.RemoveNeighboursResponse{}, nil
 }

--- a/modules/route/controlplane/routepb/macaddr.go
+++ b/modules/route/controlplane/routepb/macaddr.go
@@ -2,9 +2,13 @@ package routepb
 
 import (
 	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"strconv"
 )
 
-// TODO: docs.
+// NewMACAddressEUI48 creates a MACAddress from a 6-byte EUI-48
+// address.
 func NewMACAddressEUI48(addr [6]byte) *MACAddress {
 	buf := [8]byte{}
 	copy(buf[:], addr[:])
@@ -12,4 +16,54 @@ func NewMACAddressEUI48(addr [6]byte) *MACAddress {
 	return &MACAddress{
 		Addr: binary.BigEndian.Uint64(buf[:]),
 	}
+}
+
+// EUI48 extracts a 6-byte EUI-48 address from the MACAddress.
+func (m *MACAddress) EUI48() [6]byte {
+	buf := [8]byte{}
+	binary.BigEndian.PutUint64(buf[:], m.GetAddr())
+
+	return [6]byte(buf[:6])
+}
+
+// MarshalJSON serializes addr as a JSON string to avoid precision
+// loss in JavaScript (uint64 exceeds Number.MAX_SAFE_INTEGER).
+func (m *MACAddress) MarshalJSON() ([]byte, error) {
+	return fmt.Appendf(nil, `{"addr":"%d"}`, m.Addr), nil
+}
+
+// UnmarshalJSON accepts addr as either a JSON number or a JSON
+// string so that JavaScript clients that cannot represent uint64
+// without precision loss can send the value as a string.
+func (m *MACAddress) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Addr json.RawMessage `json:"addr"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if len(raw.Addr) == 0 {
+		return nil
+	}
+
+	s := string(raw.Addr)
+	// JSON string: "3a:ac:26:9b:5b:f9"
+	if len(s) >= 2 && s[0] == '"' {
+		unquoted := s[1 : len(s)-1]
+		v, err := strconv.ParseUint(unquoted, 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid addr string: %w", err)
+		}
+		m.Addr = v
+		return nil
+	}
+
+	// JSON number: 0x3aac269b5bf90000
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid addr number: %w", err)
+	}
+
+	m.Addr = v
+	return nil
 }

--- a/modules/route/controlplane/routepb/neighbour.proto
+++ b/modules/route/controlplane/routepb/neighbour.proto
@@ -8,16 +8,57 @@ import "macaddr.proto";
 
 // Neighbour is a service for viewing and managing neighbors.
 service Neighbour {
-	// List returns all current neighbors.
-	rpc List(ListNeighboursRequest) returns (ListNeighboursResponse) {
-	}
+	// List returns neighbors either merged view or from a specific table.
+	//
+	// If table name is empty, returns the merged view across all tables.
+	// If table name is specified, returns entries from that specific table
+	// only.
+	rpc List(ListNeighboursRequest) returns (ListNeighboursResponse);
+
+	// CreateTable creates a new user-defined neighbour table with the
+	// given default priority.
+	rpc CreateTable(CreateNeighbourTableRequest)
+		returns (CreateNeighbourTableResponse);
+	// UpdateTable changes the default priority of an existing neighbour
+	// table.
+	rpc UpdateTable(UpdateNeighbourTableRequest)
+		returns (UpdateNeighbourTableResponse);
+	// RemoveTable removes a user-defined neighbour table and all its
+	// entries.
+	//
+	// Built-in tables (e.g. "kernel", "static") cannot be removed.
+	rpc RemoveTable(RemoveNeighbourTableRequest)
+		returns (RemoveNeighbourTableResponse);
+	// ListTables returns metadata about all registered neighbour tables.
+	rpc ListTables(ListNeighbourTablesRequest)
+		returns (ListNeighbourTablesResponse);
+
+	// UpdateNeighbours inserts or updates one or more neighbour entries
+	// in the specified table.
+	//
+	// If the table name is empty, defaults to "static". Server-managed
+	// fields (state, updated_at, source) in NeighbourEntry are ignored
+	// on input.
+	rpc UpdateNeighbours(UpdateNeighboursRequest)
+		returns (UpdateNeighboursResponse);
+	// RemoveNeighbours deletes one or more neighbour entries from the
+	// specified table by their next-hop IP addresses.
+	//
+	// If the table name is empty, defaults to "static".
+	rpc RemoveNeighbours(RemoveNeighboursRequest)
+		returns (RemoveNeighboursResponse);
 }
 
-// ListNeighboursRequest is the request to list all neighbors.
+// ListNeighboursRequest is the request to list neighbors.
 message ListNeighboursRequest {
+	// Table is the name of the table to list entries from.
+	//
+	// If empty, returns the merged view.
+	// If specified, returns entries from that specific table only.
+	string table = 1;
 }
 
-// ListNeighboursResponse contains the list of all current neighbors.
+// ListNeighboursResponse contains the list of neighbors.
 message ListNeighboursResponse {
 	repeated NeighbourEntry neighbours = 1;
 }
@@ -40,17 +81,111 @@ enum NeighbourState {
 message NeighbourEntry {
 	// NextHop is the IP address of the next hop.
 	string next_hop = 1;
-
 	// LinkAddr is the MAC address of the next hop.
 	MACAddress link_addr = 2;
-
 	// HardwareAddr is the MAC address of the local interface.
 	MACAddress hardware_addr = 3;
-
 	// State is the state of the neighbor entry.
 	NeighbourState state = 4;
-
 	// UpdatedAt is the timestamp when this entry was last updated.
 	// This is a UNIX timestamp in seconds.
 	int64 updated_at = 5;
+	// Source is the name of the table this entry belongs to.
+	string source = 6;
+	// Priority determines which entry wins when the same IP exists in
+	// multiple tables. Lower value means higher priority.
+	uint32 priority = 7;
+	// Device is the network interface name.
+	string device = 8;
+}
+
+// CreateNeighbourTableRequest is the request to create a new neighbour table.
+message CreateNeighbourTableRequest {
+	// Name is the name of the table to create.
+	string name = 1;
+	// DefaultPriority is the default priority for entries in this table.
+	uint32 default_priority = 2;
+}
+
+// CreateNeighbourTableResponse is the response to creating a neighbour table.
+message CreateNeighbourTableResponse {
+}
+
+// UpdateNeighbourTableRequest is the request to update a neighbour table.
+message UpdateNeighbourTableRequest {
+	// Name is the name of the table to update.
+	string name = 1;
+	// DefaultPriority is the default priority for entries in this table.
+	uint32 default_priority = 2;
+}
+
+// UpdateNeighbourTableResponse is the response to updating a neighbour table.
+message UpdateNeighbourTableResponse {
+}
+
+// RemoveNeighbourTableRequest is the request to remove a neighbour table.
+message RemoveNeighbourTableRequest {
+	// Name is the name of the table to remove.
+	string name = 1;
+}
+
+// RemoveNeighbourTableResponse is the response to removing a neighbour
+// table.
+message RemoveNeighbourTableResponse {
+}
+
+// ListNeighbourTablesRequest is the request to list all neighbour tables.
+message ListNeighbourTablesRequest {
+}
+
+// ListNeighbourTablesResponse contains the list of all neighbour tables.
+message ListNeighbourTablesResponse {
+	repeated NeighbourTableInfo tables = 1;
+}
+
+// NeighbourTableInfo contains metadata about a neighbour table.
+message NeighbourTableInfo {
+	// Name is the unique name of the table.
+	string name = 1;
+	// DefaultPriority is the default priority assigned to new entries.
+	uint32 default_priority = 2;
+	// EntryCount is the number of entries currently in the table.
+	int64 entry_count = 3;
+	// BuiltIn indicates whether the table is built-in and cannot be
+	// removed.
+	bool built_in = 4;
+}
+
+// UpdateNeighboursRequest is the request to insert or update one or more
+// neighbour entries.
+message UpdateNeighboursRequest {
+	// Table is the target table name.
+	//
+	// Defaults to "static" if empty.
+	string table = 1;
+	// Entries is the list of neighbour entries to insert or update.
+	//
+	// Server-managed fields (state, updated_at, source) are ignored
+	// on input.
+	repeated NeighbourEntry entries = 2;
+}
+
+// UpdateNeighboursResponse is the response to updating neighbour
+// entries.
+message UpdateNeighboursResponse {
+}
+
+// RemoveNeighboursRequest is the request to remove one or more
+// neighbour entries.
+message RemoveNeighboursRequest {
+	// Table is the target table name.
+	//
+	// Defaults to "static" if empty.
+	string table = 1;
+	// NextHops is the list of next-hop IP addresses to remove.
+	repeated string next_hops = 2;
+}
+
+// RemoveNeighboursResponse is the response to removing neighbour entries.
+message RemoveNeighboursResponse {
 }

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -33,7 +33,7 @@ type RouteService struct {
 	ribsLock   sync.RWMutex
 	ribs       map[string]*rib.RIB
 	ffiModules map[string]*ModuleConfig
-	neighCache *neigh.NexthopCache
+	neighTable *neigh.NeighTable
 
 	ribTTL time.Duration
 	quitCh chan bool
@@ -43,7 +43,7 @@ type RouteService struct {
 
 func NewRouteService(
 	agent *ffi.Agent,
-	neighCache *neigh.NexthopCache,
+	neighTable *neigh.NeighTable,
 	ribTTL time.Duration,
 	log *zap.SugaredLogger,
 ) *RouteService {
@@ -51,7 +51,7 @@ func NewRouteService(
 		agent:      agent,
 		ribs:       map[string]*rib.RIB{},
 		ffiModules: map[string]*ModuleConfig{},
-		neighCache: neighCache,
+		neighTable: neighTable,
 		ribTTL:     ribTTL,
 		quitCh:     make(chan bool),
 		log:        log,
@@ -611,7 +611,7 @@ func (m *RouteService) updateModuleConfig(
 	}
 
 	// Obtain neighbour entry with resolved hardware addresses
-	neighbours := m.neighCache.View()
+	neighbours := m.neighTable.View()
 
 	// Statistics for summary logging
 	var stats struct {

--- a/modules/route/internal/discovery/cache.go
+++ b/modules/route/internal/discovery/cache.go
@@ -45,6 +45,22 @@ func (m *Cache[K, V]) Swap(cache map[K]V) {
 	m.cache = cache
 }
 
+// Set inserts or updates a single entry in the cache.
+func (m *Cache[K, V]) Set(key K, value V) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.cache[key] = value
+}
+
+// Delete removes a single entry from the cache.
+func (m *Cache[K, V]) Delete(key K) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.cache, key)
+}
+
 // CacheView is a read-only view of the cache.
 type CacheView[K comparable, V any] struct {
 	cache map[K]V

--- a/modules/route/internal/discovery/neigh/entry.go
+++ b/modules/route/internal/discovery/neigh/entry.go
@@ -18,6 +18,15 @@ type NeighbourEntry struct {
 	UpdatedAt time.Time
 	// State is the state of the neighbor entry.
 	State NeighbourState
+	// Source is the name of the table this entry belongs to.
+	//
+	// It is set during merge and is empty inside individual source caches.
+	Source string
+	// Priority determines which entry wins when the same IP exists in multiple
+	// tables.
+	//
+	// Lower value means higher priority.
+	Priority uint32
 }
 
 // HardwareRoute is a hashable pair of MAC addresses.

--- a/modules/route/internal/discovery/neigh/neigh.go
+++ b/modules/route/internal/discovery/neigh/neigh.go
@@ -33,6 +33,7 @@ func WithUpdateInterval(interval time.Duration) Option {
 	}
 }
 
+// WithLinkMap configures the neighbour monitor with a link name mapping.
 func WithLinkMap(linkMap map[string]string) Option {
 	return func(o *options) {
 		o.LinkMap = linkMap
@@ -62,24 +63,28 @@ func newOptions() *options {
 
 // NeighMonitor is a monitor of neighbour events.
 //
-// It populates the nexthop cache with discovered neighbours both reactively
-// and periodically.
+// It populates the nexthop cache with discovered neighbours both
+// reactively and periodically. The results are written into the
+// kernel source of the NeighTable via SwapSource, which triggers
+// a re-merge of the merged cache.
 type NeighMonitor struct {
-	nexthopCache   *NexthopCache
+	neighTable     *NeighTable
+	source         *NeighSource
 	updateInterval time.Duration
 	linkMap        map[string]string
 	log            *zap.SugaredLogger
 }
 
 // NewNeighMonitor creates a new neighbour monitor.
-func NewNeighMonitor(neighbours *NexthopCache, options ...Option) *NeighMonitor {
+func NewNeighMonitor(neighTable *NeighTable, source *NeighSource, options ...Option) *NeighMonitor {
 	opts := newOptions()
 	for _, o := range options {
 		o(opts)
 	}
 
 	m := &NeighMonitor{
-		nexthopCache:   neighbours,
+		neighTable:     neighTable,
+		source:         source,
 		linkMap:        opts.LinkMap,
 		updateInterval: opts.UpdateInterval,
 		log:            opts.Log,
@@ -88,11 +93,6 @@ func NewNeighMonitor(neighbours *NexthopCache, options ...Option) *NeighMonitor 
 	// Bootstrap neighbours synchronously here.
 	m.updateNeighbours()
 	return m
-}
-
-// Cache returns the nexthop cache.
-func (m *NeighMonitor) Cache() *NexthopCache {
-	return m.nexthopCache
 }
 
 // Run runs the neighbour monitor until the specified context is canceled.
@@ -184,12 +184,12 @@ func (m *NeighMonitor) updateNeighbours() error {
 
 	linkIndexToName := map[int]string{}
 
-	// Create a map of link indexes to hardware addresses for quick lookup
+	// Create a map of link indexes to hardware addresses for quick lookup.
 	linkIndexToHardwareAddr := map[int]net.HardwareAddr{}
 	for _, link := range links {
 		attrs := link.Attrs()
 
-		// TODO: should be filter out loopback links?
+		// TODO: should we filter out loopback links?
 
 		hardwareAddr := attrs.HardwareAddr
 		if hardwareAddr == nil {
@@ -200,9 +200,9 @@ func (m *NeighMonitor) updateNeighbours() error {
 		linkIndexToName[attrs.Index] = attrs.Name
 	}
 
-	view := m.nexthopCache.View()
+	view := m.source.Cache.View()
 
-	// Create the new cache map with resolved hardware addresses
+	// Create the new cache map with resolved hardware addresses.
 	nexthopCache := map[netip.Addr]NeighbourEntry{}
 	for _, neigh := range neighs {
 		nexthopAddr, ok := netip.AddrFromSlice(neigh.IP)
@@ -241,7 +241,7 @@ func (m *NeighMonitor) updateNeighbours() error {
 			device = linkIndexToName[neigh.LinkIndex]
 		}
 
-		// Create the entry with resolved hardware addresses
+		// Create the entry with resolved hardware addresses.
 		entry := NeighbourEntry{
 			NextHop: nexthopAddr,
 			HardwareRoute: HardwareRoute{
@@ -270,8 +270,10 @@ func (m *NeighMonitor) updateNeighbours() error {
 		nexthopCache[nexthopAddr] = entry
 	}
 
-	// Swap the entire table atomically.
-	m.nexthopCache.Swap(nexthopCache)
+	// Swap the source table and trigger a re-merge of the merged cache.
+	if err := m.neighTable.SwapSource(m.source.Name, nexthopCache); err != nil {
+		return fmt.Errorf("failed to swap source: %w", err)
+	}
 
 	m.log.Infow("updated nexthop cache", zap.Int("size", len(nexthopCache)))
 	return nil

--- a/modules/route/internal/discovery/neigh/state.go
+++ b/modules/route/internal/discovery/neigh/state.go
@@ -9,6 +9,9 @@ import (
 // Used to provide state's string representation.
 type NeighbourState int
 
+// NeighbourStatePermanent represents a permanent (static) neighbour.
+const NeighbourStatePermanent = NeighbourState(netlink.NUD_PERMANENT)
+
 // String returns string representation of this state.
 func (m NeighbourState) String() string {
 	switch m {

--- a/modules/route/internal/discovery/neigh/table.go
+++ b/modules/route/internal/discovery/neigh/table.go
@@ -1,0 +1,244 @@
+package neigh
+
+import (
+	"fmt"
+	"net/netip"
+	"sync"
+
+	"github.com/yanet-platform/yanet2/modules/route/internal/discovery"
+)
+
+// NeighSource represents a single source of neighbour entries.
+type NeighSource struct {
+	// Name is the unique identifier of this source (e.g. "kernel", "static").
+	Name string
+	// DefaultPriority is assigned to entries that do not specify an explicit
+	// priority.
+	//
+	// Lower value means higher preference.
+	DefaultPriority uint32
+	// Cache holds the entries for this source.
+	Cache *NexthopCache
+	// BuiltIn marks sources that cannot be deleted.
+	BuiltIn bool
+}
+
+// SourceInfo contains metadata about a neighbour source.
+type SourceInfo struct {
+	Name            string
+	DefaultPriority uint32
+	EntryCount      int
+	BuiltIn         bool
+}
+
+// NeighTable merges multiple neighbour sources by per-entry priority.
+//
+// All mutations are serialized under mu. After every mutation the merged
+// cache is rebuilt and atomically swapped so that readers (via View)
+// never block.
+type NeighTable struct {
+	mu sync.Mutex
+	// sources maps source name to its NeighSource.
+	sources map[string]*NeighSource
+	// merged is the final merged cache that consumers read via View().
+	merged *NexthopCache
+}
+
+// NewNeighTable creates a new empty NeighTable.
+func NewNeighTable() *NeighTable {
+	return &NeighTable{
+		sources: map[string]*NeighSource{},
+		merged:  discovery.NewEmptyCache[netip.Addr, NeighbourEntry](),
+	}
+}
+
+// View returns a lock-free snapshot of the merged table.
+func (m *NeighTable) View() NexthopCacheView {
+	return m.merged.View()
+}
+
+// SourceView returns a lock-free snapshot of a specific source table.
+func (m *NeighTable) SourceView(name string) (NexthopCacheView, bool) {
+	m.mu.Lock()
+	src := m.sources[name]
+	m.mu.Unlock()
+
+	if src == nil {
+		return NexthopCacheView{}, false
+	}
+
+	return src.Cache.View(), true
+}
+
+// CreateSource creates a new source with the given default priority.
+//
+// If the source already exists, an error is returned. Set builtIn to
+// true for sources that must not be deleted (e.g. "kernel", "static").
+func (m *NeighTable) CreateSource(name string, defaultPriority uint32, builtIn bool) (*NeighSource, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.sources[name]; ok {
+		return nil, fmt.Errorf("source %q already exists", name)
+	}
+
+	src := &NeighSource{
+		Name:            name,
+		DefaultPriority: defaultPriority,
+		Cache:           discovery.NewEmptyCache[netip.Addr, NeighbourEntry](),
+		BuiltIn:         builtIn,
+	}
+
+	m.sources[name] = src
+	// No need to rebuild: new source is empty.
+	return src, nil
+}
+
+// UpdateSource changes the default priority of an existing source.
+func (m *NeighTable) UpdateSource(name string, defaultPriority uint32) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	src, ok := m.sources[name]
+	if !ok {
+		return fmt.Errorf("source %q not found", name)
+	}
+
+	src.DefaultPriority = defaultPriority
+	return nil
+}
+
+// DeleteSource removes a user-defined source and triggers a re-merge.
+func (m *NeighTable) DeleteSource(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	src, ok := m.sources[name]
+	if !ok {
+		return fmt.Errorf("source %q not found", name)
+	}
+
+	if src.BuiltIn {
+		return fmt.Errorf("cannot delete built-in source %q", name)
+	}
+
+	delete(m.sources, name)
+	m.rebuildMergedCacheLocked()
+	return nil
+}
+
+// ListSources returns metadata about all registered sources.
+func (m *NeighTable) ListSources() []SourceInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]SourceInfo, 0, len(m.sources))
+	for _, src := range m.sources {
+		view := src.Cache.View()
+		_, count := view.Entries()
+		result = append(result, SourceInfo{
+			Name:            src.Name,
+			DefaultPriority: src.DefaultPriority,
+			EntryCount:      count,
+			BuiltIn:         src.BuiltIn,
+		})
+	}
+	return result
+}
+
+// Source returns a source by name.
+func (m *NeighTable) Source(name string) (*NeighSource, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	src, ok := m.sources[name]
+	return src, ok
+}
+
+// Add inserts or updates entries in the specified source table and
+// triggers a single re-merge.
+func (m *NeighTable) Add(table string, entries []NeighbourEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	src, ok := m.sources[table]
+	if !ok {
+		return fmt.Errorf("source %q not found", table)
+	}
+
+	for _, entry := range entries {
+		if entry.Priority == 0 {
+			entry.Priority = src.DefaultPriority
+		}
+		src.Cache.Set(entry.NextHop, entry)
+	}
+
+	m.rebuildMergedCacheLocked()
+	return nil
+}
+
+// Remove deletes entries from the specified source table and triggers
+// a single re-merge.
+func (m *NeighTable) Remove(table string, addrs []netip.Addr) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	src, ok := m.sources[table]
+	if !ok {
+		return fmt.Errorf("source %q not found", table)
+	}
+
+	for _, addr := range addrs {
+		src.Cache.Delete(addr)
+	}
+
+	m.rebuildMergedCacheLocked()
+	return nil
+}
+
+// SwapSource atomically replaces all entries in the named source and triggers
+// a re-merge.
+//
+// Entries with zero priority inherit the source's default priority.
+func (m *NeighTable) SwapSource(name string, entries map[netip.Addr]NeighbourEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	src, ok := m.sources[name]
+	if !ok {
+		return fmt.Errorf("source %q not found", name)
+	}
+
+	for addr, entry := range entries {
+		if entry.Priority == 0 {
+			entry.Priority = src.DefaultPriority
+			entries[addr] = entry
+		}
+	}
+
+	src.Cache.Swap(entries)
+	m.rebuildMergedCacheLocked()
+	return nil
+}
+
+// rebuildMergedCacheLocked rebuilds the merged cache from all sources.
+//
+// Must be called with m.mu held.
+func (m *NeighTable) rebuildMergedCacheLocked() {
+	merged := map[netip.Addr]NeighbourEntry{}
+
+	for _, src := range m.sources {
+		view := src.Cache.View()
+		entries, _ := view.Entries()
+
+		for entry := range entries {
+			entry.Source = src.Name
+			existing, ok := merged[entry.NextHop]
+			if !ok || entry.Priority < existing.Priority {
+				merged[entry.NextHop] = entry
+			}
+		}
+	}
+
+	m.merged.Swap(merged)
+}

--- a/modules/route/internal/discovery/neigh/table_test.go
+++ b/modules/route/internal/discovery/neigh/table_test.go
@@ -1,0 +1,296 @@
+package neigh
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func makeEntry(ip string, mac [6]byte, priority uint32) NeighbourEntry {
+	return NeighbourEntry{
+		NextHop: netip.MustParseAddr(ip),
+		HardwareRoute: HardwareRoute{
+			DestinationMAC: mac,
+		},
+		UpdatedAt: time.Now(),
+		State:     NeighbourStatePermanent,
+		Priority:  priority,
+	}
+}
+
+// mustCreateSource is a test helper that creates a source and fails the
+// test on error.
+func mustCreateSource(t *testing.T, nt *NeighTable, name string, defaultPriority uint32, builtIn bool) *NeighSource {
+	t.Helper()
+	src, err := nt.CreateSource(name, defaultPriority, builtIn)
+	require.NoError(t, err)
+	return src
+}
+
+func TestNeighTableMergeLowestPriorityWins(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "kernel", 100, true)
+	mustCreateSource(t, nt, "static", 10, true)
+
+	// Add an entry with priority 100 to kernel.
+	require.NoError(t, nt.SwapSource("kernel", map[netip.Addr]NeighbourEntry{
+		netip.MustParseAddr("10.0.0.1"): makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 100),
+	}))
+
+	// Add the same IP with priority 10 to static.
+	require.NoError(t, nt.Add("static", []NeighbourEntry{makeEntry("10.0.0.1", [6]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}, 10)}))
+
+	// Merged view should pick static (priority 10 < 100).
+	view := nt.View()
+	entry, ok := view.Lookup(netip.MustParseAddr("10.0.0.1"))
+	require.True(t, ok)
+	require.Equal(t, uint32(10), entry.Priority)
+	require.Equal(t, "static", entry.Source)
+	require.Equal(t, [6]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}, entry.HardwareRoute.DestinationMAC)
+}
+
+func TestNeighTableMergeHigherPriorityLoses(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "static", 200, true)
+	mustCreateSource(t, nt, "kernel", 50, true)
+
+	require.NoError(t, nt.Add("static", []NeighbourEntry{makeEntry("10.0.0.1", [6]byte{0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC}, 200)}))
+	require.NoError(t, nt.SwapSource("kernel", map[netip.Addr]NeighbourEntry{
+		netip.MustParseAddr("10.0.0.1"): makeEntry("10.0.0.1", [6]byte{0xDD, 0xDD, 0xDD, 0xDD, 0xDD, 0xDD}, 50),
+	}))
+
+	view := nt.View()
+	entry, ok := view.Lookup(netip.MustParseAddr("10.0.0.1"))
+	require.True(t, ok)
+	require.Equal(t, uint32(50), entry.Priority)
+	require.Equal(t, "kernel", entry.Source)
+}
+
+func TestNeighTableDefaultPriority(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "static", 42, true)
+
+	// Add entry with priority 0 -> should inherit default.
+	entry := makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 0)
+	require.NoError(t, nt.Add("static", []NeighbourEntry{entry}))
+
+	view := nt.View()
+	e, ok := view.Lookup(netip.MustParseAddr("10.0.0.1"))
+	require.True(t, ok)
+	require.Equal(t, uint32(42), e.Priority)
+}
+
+func TestNeighTableRemoveEntry(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "static", 10, true)
+
+	require.NoError(t, nt.Add("static", []NeighbourEntry{makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10)}))
+
+	view := nt.View()
+	_, ok := view.Lookup(netip.MustParseAddr("10.0.0.1"))
+	require.True(t, ok)
+
+	require.NoError(t, nt.Remove("static", []netip.Addr{netip.MustParseAddr("10.0.0.1")}))
+
+	view = nt.View()
+	_, ok = view.Lookup(netip.MustParseAddr("10.0.0.1"))
+	require.False(t, ok)
+}
+
+func TestNeighTableRemoveEntryFallsBack(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "static", 10, true)
+	mustCreateSource(t, nt, "kernel", 100, true)
+
+	// Both sources have the same IP.
+	require.NoError(t, nt.Add("static", []NeighbourEntry{makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10)}))
+	require.NoError(t, nt.SwapSource("kernel", map[netip.Addr]NeighbourEntry{
+		netip.MustParseAddr("10.0.0.1"): makeEntry("10.0.0.1", [6]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}, 100),
+	}))
+
+	// Remove from static -> kernel should take over.
+	require.NoError(t, nt.Remove("static", []netip.Addr{netip.MustParseAddr("10.0.0.1")}))
+
+	view := nt.View()
+	entry, ok := view.Lookup(netip.MustParseAddr("10.0.0.1"))
+	require.True(t, ok)
+	require.Equal(t, "kernel", entry.Source)
+	require.Equal(t, uint32(100), entry.Priority)
+}
+
+func TestNeighTableSourceView(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "kernel", 100, true)
+	mustCreateSource(t, nt, "static", 10, true)
+
+	require.NoError(t, nt.Add("static", []NeighbourEntry{makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10)}))
+	require.NoError(t, nt.SwapSource("kernel", map[netip.Addr]NeighbourEntry{
+		netip.MustParseAddr("10.0.0.2"): makeEntry("10.0.0.2", [6]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}, 100),
+	}))
+
+	// Source view for static should only contain 10.0.0.1.
+	sv, ok := nt.SourceView("static")
+	require.True(t, ok)
+	_, count := sv.Entries()
+	require.Equal(t, 1, count)
+	_, ok = sv.Lookup(netip.MustParseAddr("10.0.0.1"))
+	require.True(t, ok)
+
+	// Source view for kernel should only contain 10.0.0.2.
+	sv, ok = nt.SourceView("kernel")
+	require.True(t, ok)
+	_, count = sv.Entries()
+	require.Equal(t, 1, count)
+	_, ok = sv.Lookup(netip.MustParseAddr("10.0.0.2"))
+	require.True(t, ok)
+
+	// Non-existent source returns false.
+	_, ok = nt.SourceView("nonexistent")
+	require.False(t, ok)
+}
+
+func TestNeighTableCreateSource(t *testing.T) {
+	nt := NewNeighTable()
+
+	_, err := nt.CreateSource("custom", 50, false)
+	require.NoError(t, err)
+
+	sources := nt.ListSources()
+	require.Len(t, sources, 1)
+	require.Equal(t, "custom", sources[0].Name)
+	require.Equal(t, uint32(50), sources[0].DefaultPriority)
+	require.False(t, sources[0].BuiltIn)
+
+	// Duplicate creation fails.
+	_, err = nt.CreateSource("custom", 60, false)
+	require.Error(t, err)
+}
+
+func TestNeighTableUpdateSource(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "kernel", 100, true)
+
+	require.NoError(t, nt.UpdateSource("kernel", 200))
+
+	sources := nt.ListSources()
+	require.Len(t, sources, 1)
+	require.Equal(t, uint32(200), sources[0].DefaultPriority)
+
+	// Non-existent source fails.
+	require.Error(t, nt.UpdateSource("nonexistent", 50))
+}
+
+func TestNeighTableDeleteSource(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "kernel", 100, true)
+	mustCreateSource(t, nt, "custom", 50, false)
+
+	// Cannot delete built-in.
+	require.Error(t, nt.DeleteSource("kernel"))
+
+	// Can delete user-defined.
+	require.NoError(t, nt.DeleteSource("custom"))
+
+	sources := nt.ListSources()
+	require.Len(t, sources, 1)
+	require.Equal(t, "kernel", sources[0].Name)
+
+	// Non-existent source fails.
+	require.Error(t, nt.DeleteSource("nonexistent"))
+}
+
+func TestNeighTableDeleteSourceRemovesEntries(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "custom", 10, false)
+
+	require.NoError(t, nt.Add("custom", []NeighbourEntry{makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10)}))
+
+	view := nt.View()
+	_, ok := view.Lookup(netip.MustParseAddr("10.0.0.1"))
+	require.True(t, ok)
+
+	require.NoError(t, nt.DeleteSource("custom"))
+
+	view = nt.View()
+	_, ok = view.Lookup(netip.MustParseAddr("10.0.0.1"))
+	require.False(t, ok)
+}
+
+func TestNeighTableAddToNonExistentSource(t *testing.T) {
+	nt := NewNeighTable()
+
+	require.Error(t, nt.Add("nonexistent", []NeighbourEntry{makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10)}))
+}
+
+func TestNeighTableSwapSourceNonExistent(t *testing.T) {
+	nt := NewNeighTable()
+
+	require.Error(t, nt.SwapSource("nonexistent", map[netip.Addr]NeighbourEntry{}))
+}
+
+func TestNeighTableBatchAdd(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "static", 10, true)
+
+	entries := []NeighbourEntry{
+		makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10),
+		makeEntry("10.0.0.2", [6]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}, 20),
+		makeEntry("10.0.0.3", [6]byte{0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC}, 30),
+	}
+	require.NoError(t, nt.Add("static", entries))
+
+	view := nt.View()
+	_, count := view.Entries()
+	require.Equal(t, 3, count)
+}
+
+func TestNeighTableBatchRemove(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "static", 10, true)
+
+	entries := []NeighbourEntry{
+		makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10),
+		makeEntry("10.0.0.2", [6]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}, 20),
+		makeEntry("10.0.0.3", [6]byte{0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC}, 30),
+	}
+	require.NoError(t, nt.Add("static", entries))
+
+	require.NoError(t, nt.Remove("static", []netip.Addr{
+		netip.MustParseAddr("10.0.0.1"),
+		netip.MustParseAddr("10.0.0.3"),
+	}))
+
+	view := nt.View()
+	_, count := view.Entries()
+	require.Equal(t, 1, count)
+
+	_, ok := view.Lookup(netip.MustParseAddr("10.0.0.2"))
+	require.True(t, ok)
+}
+
+func TestNeighTableListSources(t *testing.T) {
+	nt := NewNeighTable()
+	mustCreateSource(t, nt, "kernel", 100, true)
+	mustCreateSource(t, nt, "static", 10, true)
+
+	require.NoError(t, nt.Add("static", []NeighbourEntry{makeEntry("10.0.0.1", [6]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA}, 10)}))
+	require.NoError(t, nt.SwapSource("kernel", map[netip.Addr]NeighbourEntry{
+		netip.MustParseAddr("10.0.0.2"): makeEntry("10.0.0.2", [6]byte{0xBB, 0xBB, 0xBB, 0xBB, 0xBB, 0xBB}, 100),
+		netip.MustParseAddr("10.0.0.3"): makeEntry("10.0.0.3", [6]byte{0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC}, 100),
+	}))
+
+	sources := nt.ListSources()
+	require.Len(t, sources, 2)
+
+	sourceMap := map[string]SourceInfo{}
+	for _, s := range sources {
+		sourceMap[s.Name] = s
+	}
+
+	require.Equal(t, 1, sourceMap["static"].EntryCount)
+	require.True(t, sourceMap["static"].BuiltIn)
+	require.Equal(t, 2, sourceMap["kernel"].EntryCount)
+	require.True(t, sourceMap["kernel"].BuiltIn)
+}

--- a/web/src/api/neighbours.ts
+++ b/web/src/api/neighbours.ts
@@ -10,17 +10,58 @@ export interface Neighbour {
     link_addr?: MACAddress;
     hardware_addr?: MACAddress;
     state?: number; // NeighbourState enum
-    updated_at?: string | number; // int64, UNIX timestamp in seconds - serialized as string in JSON
+    updated_at?: string | number; // int64, UNIX timestamp in seconds
+    source?: string;
+    priority?: number;
+    device?: string;
 }
 
 export interface ListNeighboursResponse {
     neighbours?: Neighbour[];
 }
 
+export interface NeighbourTableInfo {
+    name?: string;
+    default_priority?: number;
+    entry_count?: string | number; // int64
+    built_in?: boolean;
+}
+
+export interface ListNeighbourTablesResponse {
+    tables?: NeighbourTableInfo[];
+}
+
 const neighbourService = createService('routepb.Neighbour');
 
 export const neighbours = {
-    list: (options?: CallOptions): Promise<ListNeighboursResponse> => {
+    list: (table?: string, options?: CallOptions): Promise<ListNeighboursResponse> => {
+        if (table) {
+            return neighbourService.callWithBody<ListNeighboursResponse>('List', { table }, options);
+        }
         return neighbourService.call<ListNeighboursResponse>('List', options);
+    },
+
+    listTables: (options?: CallOptions): Promise<ListNeighbourTablesResponse> => {
+        return neighbourService.call<ListNeighbourTablesResponse>('ListTables', options);
+    },
+
+    updateNeighbours: (table: string, entries: Neighbour[], options?: CallOptions): Promise<void> => {
+        return neighbourService.callWithBody<void>('UpdateNeighbours', { table, entries }, options);
+    },
+
+    removeNeighbours: (table: string, nextHops: string[], options?: CallOptions): Promise<void> => {
+        return neighbourService.callWithBody<void>('RemoveNeighbours', { table, next_hops: nextHops }, options);
+    },
+
+    createTable: (name: string, defaultPriority: number, options?: CallOptions): Promise<void> => {
+        return neighbourService.callWithBody<void>('CreateTable', { name, default_priority: defaultPriority }, options);
+    },
+
+    updateTable: (name: string, defaultPriority: number, options?: CallOptions): Promise<void> => {
+        return neighbourService.callWithBody<void>('UpdateTable', { name, default_priority: defaultPriority }, options);
+    },
+
+    removeTable: (name: string, options?: CallOptions): Promise<void> => {
+        return neighbourService.callWithBody<void>('RemoveTable', { name }, options);
     },
 };

--- a/web/src/pages/NeighboursPage.css
+++ b/web/src/pages/NeighboursPage.css
@@ -1,3 +1,0 @@
-.neighbours-row:hover {
-    background-color: var(--g-color-base-simple-hover);
-}

--- a/web/src/pages/NeighboursPage.tsx
+++ b/web/src/pages/NeighboursPage.tsx
@@ -1,203 +1,437 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Table, withTableSorting, Box } from '@gravity-ui/uikit';
-import type { TableColumnConfig, TableSortState } from '@gravity-ui/uikit';
+import { Box, TabProvider, TabList, Tab, Button, Flex, Text } from '@gravity-ui/uikit';
 import { toaster } from '../utils';
 import { API } from '../api';
-import type { Neighbour } from '../api/neighbours';
-import { formatMACAddress, getMACAddressValue, compareMACAddressValues } from '../utils/mac';
-import { getUTCOffsetString } from '../utils/date';
-import { getNUDStateString } from '../utils/nud';
+import type { Neighbour, NeighbourTableInfo } from '../api/neighbours';
 import { PageLayout, PageLoader } from '../components';
 import {
-    compareNullableNumbers,
-    compareNullableStrings,
-    formatUnixSeconds,
-    getUnixSecondsValue,
-} from '../utils/sorting';
-import './NeighboursPage.css';
+    AddNeighbourDialog,
+    EditNeighbourDialog,
+    RemoveNeighboursDialog,
+    CreateTableDialog,
+    EditTableDialog,
+    RemoveTableDialog,
+    VirtualizedNeighbourTable,
+} from './neighbours';
+import {
+    DEFAULT_SORT,
+    isSortableColumn,
+    isSortDirection,
+} from './neighbours/hooks';
+import type { SortState, SortableColumn, SortDirection } from './neighbours/hooks';
+import './neighbours/neighbours.scss';
 
 const REFRESH_INTERVAL_MS = 5000;
+const MERGED_TAB = '__merged__';
 
-const SortableTable = withTableSorting(Table);
+// URL query param keys
+const QP_TAB = 'tab';
+const QP_SORT = 'sort';
+const QP_ORDER = 'order';
+const QP_SEARCH = 'search';
 
-// Helper functions for URL sort state management
-const parseSortFromURL = (searchParams: URLSearchParams): TableSortState => {
-    const sortColumn = searchParams.get('sortColumn');
-    const sortOrder = searchParams.get('sortOrder');
-
-    if (!sortColumn || !sortOrder || (sortOrder !== 'asc' && sortOrder !== 'desc')) {
-        return [{ column: 'state', order: 'asc' }];
+const parseSortState = (params: URLSearchParams): SortState => {
+    const col = params.get(QP_SORT);
+    const dir = params.get(QP_ORDER);
+    if (col && isSortableColumn(col)) {
+        return {
+            column: col,
+            direction: dir && isSortDirection(dir) ? dir : 'asc',
+        };
     }
-
-    return [{ column: sortColumn, order: sortOrder as 'asc' | 'desc' }];
+    return DEFAULT_SORT;
 };
 
-const serializeSortToURL = (sortState: TableSortState, searchParams: URLSearchParams): URLSearchParams => {
-    const newParams = new URLSearchParams(searchParams);
-
-    if (!sortState || sortState.length === 0) {
-        newParams.set('sortColumn', 'state');
-        newParams.set('sortOrder', 'asc');
-    } else {
-        const { column, order } = sortState[0];
-        newParams.set('sortColumn', column);
-        newParams.set('sortOrder', order);
-    }
-
-    return newParams;
+const parseTab = (params: URLSearchParams): string => {
+    return params.get(QP_TAB) || MERGED_TAB;
 };
 
-
-const renderMacAddress = (addr?: Neighbour['link_addr']): string => {
-    if (addr?.addr === undefined) {
-        return '-';
-    }
-
-    return formatMACAddress(addr.addr);
+const parseSearch = (params: URLSearchParams): string => {
+    return params.get(QP_SEARCH) || '';
 };
 
 const NeighboursPage = (): React.JSX.Element => {
     const [searchParams, setSearchParams] = useSearchParams();
-    const [neighbours, setNeighbours] = useState<Neighbour[]>([]);
-    const [loading, setLoading] = useState<boolean>(true);
 
-    const utcOffsetString = useMemo(() => getUTCOffsetString(), []);
+    // Derive state from URL
+    const activeTab = parseTab(searchParams);
+    const sortState = parseSortState(searchParams);
+    const searchQuery = parseSearch(searchParams);
 
-    // Get sort state from URL
-    const sortState = useMemo(() => {
-        return parseSortFromURL(searchParams);
-    }, [searchParams]);
+    const [tables, setTables] = useState<NeighbourTableInfo[]>([]);
+    const [initialLoading, setInitialLoading] = useState<boolean>(true);
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-    // Handle sort state changes
-    const handleSortStateChange = useCallback((newSortState: TableSortState) => {
-        const newParams = serializeSortToURL(newSortState, searchParams);
-        setSearchParams(newParams, { replace: true });
-    }, [searchParams]);
+    // Cache: tab key -> neighbours list. Merged tab uses MERGED_TAB key.
+    const [cache, setCache] = useState<Map<string, Neighbour[]>>(new Map());
 
+    // Dialog states
+    const [addDialogOpen, setAddDialogOpen] = useState(false);
+    const [editDialogOpen, setEditDialogOpen] = useState(false);
+    const [removeDialogOpen, setRemoveDialogOpen] = useState(false);
+    const [createTableDialogOpen, setCreateTableDialogOpen] = useState(false);
+    const [editTableDialogOpen, setEditTableDialogOpen] = useState(false);
+    const [removeTableDialogOpen, setRemoveTableDialogOpen] = useState(false);
+    const [editingNeighbour, setEditingNeighbour] = useState<Neighbour | null>(null);
 
+    // Ref to track the active tab for async operations
+    const activeTabRef = useRef(activeTab);
+    activeTabRef.current = activeTab;
+
+    // Helper to update URL params without replacing other params
+    const updateParams = useCallback((updates: Record<string, string | null>) => {
+        setSearchParams(prev => {
+            const next = new URLSearchParams(prev);
+            for (const [key, value] of Object.entries(updates)) {
+                if (value === null || value === '') {
+                    next.delete(key);
+                } else {
+                    next.set(key, value);
+                }
+            }
+            return next;
+        }, { replace: true });
+    }, [setSearchParams]);
+
+    const handleSort = useCallback((column: SortableColumn) => {
+        const newDirection: SortDirection =
+            sortState.column === column && sortState.direction === 'asc' ? 'desc' : 'asc';
+        updateParams({
+            [QP_SORT]: column,
+            [QP_ORDER]: newDirection,
+        });
+    }, [sortState, updateParams]);
+
+    const handleSearchChange = useCallback((query: string) => {
+        updateParams({ [QP_SEARCH]: query || null });
+    }, [updateParams]);
+
+    const loadTables = useCallback(async (): Promise<NeighbourTableInfo[]> => {
+        try {
+            const data = await API.neighbours.listTables();
+            const sorted = (data.tables || []).slice().sort((a, b) =>
+                (a.name || '').localeCompare(b.name || ''),
+            );
+            setTables(sorted);
+            return sorted;
+        } catch (err) {
+            toaster.error('tables-error', 'Failed to fetch neighbour tables', err);
+            return [];
+        }
+    }, []);
+
+    // Fetch neighbours for a specific tab and update cache
+    const fetchNeighbours = useCallback(async (tabKey: string): Promise<Neighbour[]> => {
+        const tableFilter = tabKey === MERGED_TAB ? undefined : tabKey;
+        const data = await API.neighbours.list(tableFilter);
+        const neighbours = data.neighbours || [];
+        setCache(prev => {
+            const next = new Map(prev);
+            next.set(tabKey, neighbours);
+            return next;
+        });
+        return neighbours;
+    }, []);
+
+    // Prefetch all tables in background
+    const prefetchAll = useCallback(async (tableList: NeighbourTableInfo[]) => {
+        const keys = [MERGED_TAB, ...tableList.map(t => t.name || '').filter(Boolean)];
+        const results = await Promise.allSettled(
+            keys.map(async (key) => {
+                const tableFilter = key === MERGED_TAB ? undefined : key;
+                const data = await API.neighbours.list(tableFilter);
+                return { key, neighbours: data.neighbours || [] };
+            }),
+        );
+
+        setCache(prev => {
+            const next = new Map(prev);
+            for (const result of results) {
+                if (result.status === 'fulfilled') {
+                    next.set(result.value.key, result.value.neighbours);
+                }
+            }
+            return next;
+        });
+    }, []);
+
+    // Initial load: tables + prefetch all
     useEffect(() => {
         let isMounted = true;
 
-        const loadNeighbours = async (withLoader: boolean): Promise<void> => {
-            if (withLoader) {
-                setLoading(true);
-            }
-
-            try {
-                const data = await API.neighbours.list();
-                if (!isMounted) {
-                    return;
-                }
-                setNeighbours(data.neighbours || []);
-            } catch (err) {
-                if (!isMounted) {
-                    return;
-                }
-                toaster.error('neighbours-error', 'Failed to fetch neighbours', err);
-            } finally {
-                if (withLoader && isMounted) {
-                    setLoading(false);
-                }
+        const init = async () => {
+            const tableList = await loadTables();
+            if (!isMounted) return;
+            await prefetchAll(tableList);
+            if (isMounted) {
+                setInitialLoading(false);
             }
         };
 
-        loadNeighbours(true);
+        init();
+        return () => { isMounted = false; };
+    }, [loadTables, prefetchAll]);
 
-        const intervalId = window.setInterval(() => {
-            loadNeighbours(false);
+    // Periodic refresh: update active tab + tables
+    useEffect(() => {
+        if (initialLoading) return;
+
+        const intervalId = window.setInterval(async () => {
+            const tab = activeTabRef.current;
+            try {
+                await fetchNeighbours(tab);
+            } catch {
+                // Silently ignore periodic refresh errors
+            }
+            loadTables();
         }, REFRESH_INTERVAL_MS);
 
-        return () => {
-            isMounted = false;
-            window.clearInterval(intervalId);
-        };
+        return () => window.clearInterval(intervalId);
+    }, [initialLoading, fetchNeighbours, loadTables]);
+
+    // On tab switch: immediately show cached data, then refresh in background
+    const handleTabChange = useCallback((tab: string) => {
+        updateParams({
+            [QP_TAB]: tab === MERGED_TAB ? null : tab,
+        });
+        setSelectedIds(new Set());
+        // Refresh data for the new tab in background
+        fetchNeighbours(tab).catch(() => { });
+        loadTables();
+    }, [fetchNeighbours, loadTables, updateParams]);
+
+    const neighbours = cache.get(activeTab) || [];
+
+    const isMergedView = activeTab === MERGED_TAB;
+
+    const activeTableInfo = useMemo(
+        () => tables.find((t) => t.name === activeTab) ?? null,
+        [tables, activeTab],
+    );
+
+    const isBuiltIn = activeTableInfo?.built_in ?? false;
+
+    // Reload all data (after mutations)
+    const reloadAll = useCallback(async () => {
+        const tableList = await loadTables();
+        await prefetchAll(tableList);
+    }, [loadTables, prefetchAll]);
+
+    // Entry actions
+    const handleAddConfirm = useCallback(async (table: string, entry: Neighbour) => {
+        try {
+            await API.neighbours.updateNeighbours(table, [entry]);
+            toaster.success('neighbour-added', 'Neighbour added successfully');
+            await reloadAll();
+        } catch (err) {
+            toaster.error('neighbour-add-error', 'Failed to add neighbour', err);
+            throw err;
+        }
+    }, [reloadAll]);
+
+    const handleEditConfirm = useCallback(async (table: string, entry: Neighbour) => {
+        try {
+            await API.neighbours.updateNeighbours(table, [entry]);
+            toaster.success('neighbour-updated', 'Neighbour updated successfully');
+            await reloadAll();
+        } catch (err) {
+            toaster.error('neighbour-edit-error', 'Failed to update neighbour', err);
+            throw err;
+        }
+    }, [reloadAll]);
+
+    const handleRemoveConfirm = useCallback(async () => {
+        if (isMergedView || !activeTab) return;
+        try {
+            const nextHops = Array.from(selectedIds);
+            await API.neighbours.removeNeighbours(activeTab, nextHops);
+            toaster.success('neighbours-removed', `${nextHops.length} neighbour(s) removed`);
+            setSelectedIds(new Set());
+            await reloadAll();
+        } catch (err) {
+            toaster.error('neighbours-remove-error', 'Failed to remove neighbours', err);
+            throw err;
+        }
+    }, [isMergedView, activeTab, selectedIds, reloadAll]);
+
+    // Table actions
+    const handleCreateTableConfirm = useCallback(async (name: string, defaultPriority: number) => {
+        try {
+            await API.neighbours.createTable(name, defaultPriority);
+            toaster.success('table-created', `Table "${name}" created`);
+            await reloadAll();
+            updateParams({ [QP_TAB]: name });
+        } catch (err) {
+            toaster.error('table-create-error', 'Failed to create table', err);
+            throw err;
+        }
+    }, [reloadAll, updateParams]);
+
+    const handleEditTableConfirm = useCallback(async (name: string, defaultPriority: number) => {
+        try {
+            await API.neighbours.updateTable(name, defaultPriority);
+            toaster.success('table-updated', `Table "${name}" updated`);
+            await loadTables();
+        } catch (err) {
+            toaster.error('table-edit-error', 'Failed to update table', err);
+            throw err;
+        }
+    }, [loadTables]);
+
+    const handleRemoveTableConfirm = useCallback(async () => {
+        if (!activeTableInfo?.name) return;
+        try {
+            await API.neighbours.removeTable(activeTableInfo.name);
+            toaster.success('table-removed', `Table "${activeTableInfo.name}" removed`);
+            updateParams({ [QP_TAB]: null });
+            setSelectedIds(new Set());
+            await reloadAll();
+        } catch (err) {
+            toaster.error('table-remove-error', 'Failed to remove table', err);
+            throw err;
+        }
+    }, [activeTableInfo, reloadAll, updateParams]);
+
+    const handleEditClick = useCallback((item: Neighbour) => {
+        setEditingNeighbour(item);
+        setEditDialogOpen(true);
     }, []);
 
-    const columns: TableColumnConfig<Neighbour>[] = useMemo(() => [
-        {
-            id: 'next_hop',
-            name: 'Next Hop',
-            meta: {
-                sort: (a: Neighbour, b: Neighbour) => compareNullableStrings(a.next_hop, b.next_hop),
-            },
-            template: (item: Neighbour) => item.next_hop || '-',
-        },
-        {
-            id: 'link_addr',
-            name: 'Neighbour MAC',
-            meta: {
-                sort: (a: Neighbour, b: Neighbour) => {
-                    const valA = getMACAddressValue(a.link_addr?.addr);
-                    const valB = getMACAddressValue(b.link_addr?.addr);
-                    return compareMACAddressValues(valA, valB);
-                },
-            },
-            template: (item: Neighbour) => renderMacAddress(item.link_addr),
-        },
-        {
-            id: 'hardware_addr',
-            name: 'Interface MAC',
-            meta: {
-                sort: (a: Neighbour, b: Neighbour) => {
-                    const valA = getMACAddressValue(a.hardware_addr?.addr);
-                    const valB = getMACAddressValue(b.hardware_addr?.addr);
-                    return compareMACAddressValues(valA, valB);
-                },
-            },
-            template: (item: Neighbour) => renderMacAddress(item.hardware_addr),
-        },
-        {
-            id: 'state',
-            name: 'State',
-            meta: {
-                sort: (a: Neighbour, b: Neighbour) => {
-                    const stateA = a.state ?? 0;
-                    const stateB = b.state ?? 0;
-                    if (stateA !== stateB) {
-                        return stateA - stateB;
-                    }
+    const editTable = useCallback(() => {
+        return isMergedView ? (editingNeighbour?.source || 'static') : activeTab;
+    }, [isMergedView, editingNeighbour, activeTab]);
 
-                    return compareNullableStrings(a.next_hop, b.next_hop);
-                },
-            },
-            template: (item: Neighbour) => getNUDStateString(item.state),
-        },
-        {
-            id: 'updated_at',
-            name: `Updated At (UTC${utcOffsetString})`,
-            meta: {
-                sort: (a: Neighbour, b: Neighbour) => compareNullableNumbers(
-                    getUnixSecondsValue(a.updated_at),
-                    getUnixSecondsValue(b.updated_at)
-                ),
-            },
-            template: (item: Neighbour) => formatUnixSeconds(item.updated_at),
-        },
-    ], [utcOffsetString]);
+    const handleSelectionChange = useCallback((ids: string[]) => {
+        setSelectedIds(new Set(ids));
+    }, []);
 
-    const getRowDescriptor = useCallback(() => ({ classNames: ['neighbours-row'] }), []);
+    // Determine default table for Add dialog
+    const defaultAddTable = isMergedView ? 'static' : activeTab;
 
-    if (loading) {
+    const headerContent = (
+        <Flex gap={2} alignItems="center" style={{ width: '100%' }}>
+            <Text variant="header-1">Neighbours</Text>
+            <Box style={{ flex: 1 }} />
+            <Button view="action" onClick={() => setAddDialogOpen(true)}>
+                Add Neighbour
+            </Button>
+            <Button
+                view="outlined-danger"
+                onClick={() => setRemoveDialogOpen(true)}
+                disabled={isMergedView || selectedIds.size === 0}
+            >
+                Remove Selected
+            </Button>
+            <Box style={{ width: 1, height: 24, backgroundColor: 'var(--g-color-line-generic)' }} />
+            <Button view="normal" onClick={() => setCreateTableDialogOpen(true)}>
+                Create Table
+            </Button>
+            {!isMergedView && (
+                <>
+                    <Button
+                        view="normal"
+                        onClick={() => setEditTableDialogOpen(true)}
+                    >
+                        Edit Table
+                    </Button>
+                    <Button
+                        view="outlined-danger"
+                        onClick={() => setRemoveTableDialogOpen(true)}
+                        disabled={isBuiltIn}
+                    >
+                        Remove Table
+                    </Button>
+                </>
+            )}
+        </Flex>
+    );
+
+    if (initialLoading) {
         return (
             <PageLayout title="Neighbours">
-                <PageLoader loading={loading} size="l" />
+                <PageLoader loading={initialLoading} size="l" />
             </PageLayout>
         );
     }
 
     return (
-        <PageLayout title="Neighbours">
-            <Box spacing={{ p: 5 }} style={{ width: '100%', minWidth: 0 }}>
-                <SortableTable
-                    data={neighbours}
-                    columns={columns}
-                    width="max"
-                    defaultSortState={sortState}
-                    onSortStateChange={handleSortStateChange}
-                    getRowDescriptor={getRowDescriptor}
-                />
-            </Box>
+        <PageLayout header={headerContent}>
+            <Flex direction="column" className="neigh-page__content">
+                <TabProvider value={activeTab} onUpdate={handleTabChange}>
+                    <TabList>
+                        <Tab value={MERGED_TAB}>
+                            Merged
+                        </Tab>
+                        {tables.map((t) => (
+                            <Tab key={t.name} value={t.name || ''}>
+                                {t.name} ({Number(t.entry_count ?? 0)})
+                            </Tab>
+                        ))}
+                    </TabList>
+                </TabProvider>
+
+                <Box spacing={{ mt: 2 }} style={{ flex: 1, minHeight: 0 }}>
+                    <VirtualizedNeighbourTable
+                        neighbours={neighbours}
+                        selectedIds={selectedIds}
+                        onSelectionChange={handleSelectionChange}
+                        onEditNeighbour={handleEditClick}
+                        sortState={sortState}
+                        onSort={handleSort}
+                        searchQuery={searchQuery}
+                        onSearchChange={handleSearchChange}
+                    />
+                </Box>
+            </Flex>
+
+            {/* Entry dialogs */}
+            <AddNeighbourDialog
+                open={addDialogOpen}
+                onClose={() => setAddDialogOpen(false)}
+                onConfirm={handleAddConfirm}
+                tables={tables}
+                defaultTable={defaultAddTable}
+            />
+
+            <EditNeighbourDialog
+                open={editDialogOpen}
+                onClose={() => {
+                    setEditDialogOpen(false);
+                    setEditingNeighbour(null);
+                }}
+                onConfirm={handleEditConfirm}
+                neighbour={editingNeighbour}
+                table={editTable()}
+            />
+
+            <RemoveNeighboursDialog
+                open={removeDialogOpen}
+                onClose={() => setRemoveDialogOpen(false)}
+                onConfirm={handleRemoveConfirm}
+                selectedCount={selectedIds.size}
+            />
+
+            {/* Table dialogs */}
+            <CreateTableDialog
+                open={createTableDialogOpen}
+                onClose={() => setCreateTableDialogOpen(false)}
+                onConfirm={handleCreateTableConfirm}
+            />
+
+            <EditTableDialog
+                open={editTableDialogOpen}
+                onClose={() => setEditTableDialogOpen(false)}
+                onConfirm={handleEditTableConfirm}
+                tableInfo={activeTableInfo}
+            />
+
+            <RemoveTableDialog
+                open={removeTableDialogOpen}
+                onClose={() => setRemoveTableDialogOpen(false)}
+                onConfirm={handleRemoveTableConfirm}
+                tableName={activeTableInfo?.name || ''}
+            />
         </PageLayout>
     );
 };

--- a/web/src/pages/neighbours/AddNeighbourDialog.tsx
+++ b/web/src/pages/neighbours/AddNeighbourDialog.tsx
@@ -1,0 +1,172 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Box, Dialog, TextInput, Select } from '@gravity-ui/uikit';
+import { FormField } from '../../components';
+import { macToUint64 } from '../../utils/mac';
+import type { Neighbour } from '../../api/neighbours';
+import type { AddNeighbourDialogProps } from './types';
+
+const validateNextHop = (value: string): string | undefined => {
+    if (!value.trim()) return 'Next Hop is required';
+    return undefined;
+};
+
+const validateMAC = (value: string): string | undefined => {
+    if (!value.trim()) return undefined; // optional
+    if (!macToUint64(value)) return 'Invalid MAC address (expected xx:xx:xx:xx:xx:xx)';
+    return undefined;
+};
+
+export const AddNeighbourDialog: React.FC<AddNeighbourDialogProps> = ({
+    open,
+    onClose,
+    onConfirm,
+    tables,
+    defaultTable,
+}) => {
+    const [table, setTable] = useState<string[]>([defaultTable]);
+    const [nextHop, setNextHop] = useState('');
+    const [linkAddr, setLinkAddr] = useState('');
+    const [hardwareAddr, setHardwareAddr] = useState('');
+    const [device, setDevice] = useState('');
+    const [priority, setPriority] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (open) {
+            setTable([defaultTable]);
+            setNextHop('');
+            setLinkAddr('');
+            setHardwareAddr('');
+            setDevice('');
+            setPriority('');
+            setIsSubmitting(false);
+        }
+    }, [open, defaultTable]);
+
+    const tableOptions = tables
+        .filter((t) => t.name)
+        .map((t) => ({ value: t.name!, content: t.name! }));
+
+    const nextHopError = nextHop ? validateNextHop(nextHop) : undefined;
+    const linkAddrError = validateMAC(linkAddr);
+    const hardwareAddrError = validateMAC(hardwareAddr);
+    const canSubmit = !isSubmitting && !!nextHop.trim() && !linkAddrError && !hardwareAddrError;
+
+    const handleConfirm = useCallback(async () => {
+        if (!canSubmit) return;
+
+        setIsSubmitting(true);
+        try {
+            const entry: Neighbour = {
+                next_hop: nextHop.trim(),
+                device: device.trim() || undefined,
+                priority: priority.trim() ? Number(priority.trim()) : undefined,
+            };
+
+            const linkMac = macToUint64(linkAddr);
+            if (linkMac) {
+                entry.link_addr = { addr: linkMac };
+            }
+
+            const hwMac = macToUint64(hardwareAddr);
+            if (hwMac) {
+                entry.hardware_addr = { addr: hwMac };
+            }
+
+            await onConfirm(table[0], entry);
+            onClose();
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [canSubmit, nextHop, linkAddr, hardwareAddr, device, priority, table, onConfirm, onClose]);
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
+                e.preventDefault();
+                handleConfirm();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [open, canSubmit, handleConfirm]);
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <Dialog.Header caption="Add Neighbour" />
+            <Dialog.Body>
+                <Box style={{ display: 'flex', flexDirection: 'column', gap: 16, width: 500 }}>
+                    <FormField label="Table" required hint="Target table for the new entry">
+                        <Select
+                            value={table}
+                            onUpdate={setTable}
+                            options={tableOptions}
+                        />
+                    </FormField>
+
+                    <FormField label="Next Hop" required hint="IP address (IPv4 or IPv6)">
+                        <TextInput
+                            value={nextHop}
+                            onUpdate={setNextHop}
+                            placeholder="e.g., 192.168.1.1 or fe80::1"
+                            validationState={nextHopError ? 'invalid' : undefined}
+                            errorMessage={nextHopError}
+                            autoFocus
+                        />
+                    </FormField>
+
+                    <FormField label="Neighbour MAC" hint="Link-layer address (xx:xx:xx:xx:xx:xx)">
+                        <TextInput
+                            value={linkAddr}
+                            onUpdate={setLinkAddr}
+                            placeholder="e.g., 52:54:00:12:34:56"
+                            validationState={linkAddrError ? 'invalid' : undefined}
+                            errorMessage={linkAddrError}
+                        />
+                    </FormField>
+
+                    <FormField label="Interface MAC" hint="Local interface MAC address">
+                        <TextInput
+                            value={hardwareAddr}
+                            onUpdate={setHardwareAddr}
+                            placeholder="e.g., 52:54:00:12:34:56"
+                            validationState={hardwareAddrError ? 'invalid' : undefined}
+                            errorMessage={hardwareAddrError}
+                        />
+                    </FormField>
+
+                    <FormField label="Device" hint="Network interface name">
+                        <TextInput
+                            value={device}
+                            onUpdate={setDevice}
+                            placeholder="e.g., eth0"
+                        />
+                    </FormField>
+
+                    <FormField label="Priority" hint="Lower value = higher priority (0 uses table default)">
+                        <TextInput
+                            value={priority}
+                            onUpdate={setPriority}
+                            placeholder="e.g., 100"
+                            type="number"
+                        />
+                    </FormField>
+                </Box>
+            </Dialog.Body>
+            <Dialog.Footer
+                onClickButtonApply={handleConfirm}
+                onClickButtonCancel={onClose}
+                textButtonApply="Add"
+                textButtonCancel="Cancel"
+                propsButtonApply={{
+                    view: 'action' as const,
+                    disabled: !canSubmit,
+                    loading: isSubmitting,
+                }}
+            />
+        </Dialog>
+    );
+};

--- a/web/src/pages/neighbours/CreateTableDialog.tsx
+++ b/web/src/pages/neighbours/CreateTableDialog.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Box, Dialog, TextInput } from '@gravity-ui/uikit';
+import { FormField } from '../../components';
+import type { CreateTableDialogProps } from './types';
+
+export const CreateTableDialog: React.FC<CreateTableDialogProps> = ({
+    open,
+    onClose,
+    onConfirm,
+}) => {
+    const [name, setName] = useState('');
+    const [defaultPriority, setDefaultPriority] = useState('100');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (open) {
+            setName('');
+            setDefaultPriority('100');
+            setIsSubmitting(false);
+        }
+    }, [open]);
+
+    const nameError = name.trim() ? undefined : 'Name is required';
+    const priorityNum = Number(defaultPriority);
+    const priorityError = !defaultPriority.trim() || isNaN(priorityNum) || priorityNum < 0
+        ? 'Priority must be a non-negative number'
+        : undefined;
+
+    const canSubmit = !isSubmitting && !nameError && !priorityError;
+
+    const handleConfirm = useCallback(async () => {
+        if (!canSubmit) return;
+
+        setIsSubmitting(true);
+        try {
+            await onConfirm(name.trim(), priorityNum);
+            onClose();
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [canSubmit, name, priorityNum, onConfirm, onClose]);
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
+                e.preventDefault();
+                handleConfirm();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [open, canSubmit, handleConfirm]);
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <Dialog.Header caption="Create Neighbour Table" />
+            <Dialog.Body>
+                <Box style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                    <FormField label="Name" required hint="Unique table name">
+                        <TextInput
+                            value={name}
+                            onUpdate={setName}
+                            placeholder="e.g., my-table"
+                            validationState={name && nameError ? 'invalid' : undefined}
+                            errorMessage={nameError}
+                            autoFocus
+                        />
+                    </FormField>
+
+                    <FormField label="Default Priority" required hint="Default priority for new entries (lower = higher priority)">
+                        <TextInput
+                            value={defaultPriority}
+                            onUpdate={setDefaultPriority}
+                            placeholder="e.g., 100"
+                            type="number"
+                            validationState={defaultPriority && priorityError ? 'invalid' : undefined}
+                            errorMessage={priorityError}
+                        />
+                    </FormField>
+                </Box>
+            </Dialog.Body>
+            <Dialog.Footer
+                onClickButtonApply={handleConfirm}
+                onClickButtonCancel={onClose}
+                textButtonApply="Create"
+                textButtonCancel="Cancel"
+                propsButtonApply={{
+                    view: 'action' as const,
+                    disabled: !canSubmit,
+                    loading: isSubmitting,
+                }}
+            />
+        </Dialog>
+    );
+};
+

--- a/web/src/pages/neighbours/EditNeighbourDialog.tsx
+++ b/web/src/pages/neighbours/EditNeighbourDialog.tsx
@@ -1,0 +1,155 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Box, Dialog, TextInput } from '@gravity-ui/uikit';
+import { FormField } from '../../components';
+import { formatMACAddress, macToUint64 } from '../../utils/mac';
+import type { Neighbour } from '../../api/neighbours';
+import type { EditNeighbourDialogProps } from './types';
+
+const validateMAC = (value: string): string | undefined => {
+    if (!value.trim()) return undefined; // optional
+    if (!macToUint64(value)) return 'Invalid MAC address (expected xx:xx:xx:xx:xx:xx)';
+    return undefined;
+};
+
+const renderMAC = (addr?: Neighbour['link_addr']): string => {
+    if (addr?.addr === undefined) return '';
+    return formatMACAddress(addr.addr);
+};
+
+export const EditNeighbourDialog: React.FC<EditNeighbourDialogProps> = ({
+    open,
+    onClose,
+    onConfirm,
+    neighbour,
+    table,
+}) => {
+    const [nextHop, setNextHop] = useState('');
+    const [linkAddr, setLinkAddr] = useState('');
+    const [hardwareAddr, setHardwareAddr] = useState('');
+    const [device, setDevice] = useState('');
+    const [priority, setPriority] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (open && neighbour) {
+            setNextHop(neighbour.next_hop || '');
+            setLinkAddr(renderMAC(neighbour.link_addr));
+            setHardwareAddr(renderMAC(neighbour.hardware_addr));
+            setDevice(neighbour.device || '');
+            setPriority(neighbour.priority?.toString() || '');
+            setIsSubmitting(false);
+        }
+    }, [open, neighbour]);
+
+    const linkAddrError = validateMAC(linkAddr);
+    const hardwareAddrError = validateMAC(hardwareAddr);
+    const canSubmit = !isSubmitting && !!nextHop.trim() && !linkAddrError && !hardwareAddrError;
+
+    const handleConfirm = useCallback(async () => {
+        if (!canSubmit) return;
+
+        setIsSubmitting(true);
+        try {
+            const entry: Neighbour = {
+                next_hop: nextHop.trim(),
+                device: device.trim() || undefined,
+                priority: priority.trim() ? Number(priority.trim()) : undefined,
+            };
+
+            const linkMac = macToUint64(linkAddr);
+            if (linkMac) {
+                entry.link_addr = { addr: linkMac };
+            }
+
+            const hwMac = macToUint64(hardwareAddr);
+            if (hwMac) {
+                entry.hardware_addr = { addr: hwMac };
+            }
+
+            await onConfirm(table, entry);
+            onClose();
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [canSubmit, nextHop, linkAddr, hardwareAddr, device, priority, table, onConfirm, onClose]);
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
+                e.preventDefault();
+                handleConfirm();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [open, canSubmit, handleConfirm]);
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <Dialog.Header caption={`Edit Neighbour — ${table}`} />
+            <Dialog.Body>
+                <Box style={{ display: 'flex', flexDirection: 'column', gap: 16, width: 500 }}>
+                    <FormField label="Next Hop" required hint="IP address (read-only for existing entry)">
+                        <TextInput
+                            value={nextHop}
+                            onUpdate={setNextHop}
+                            disabled
+                        />
+                    </FormField>
+
+                    <FormField label="Neighbour MAC" hint="Link-layer address (xx:xx:xx:xx:xx:xx)">
+                        <TextInput
+                            value={linkAddr}
+                            onUpdate={setLinkAddr}
+                            placeholder="e.g., 52:54:00:12:34:56"
+                            validationState={linkAddrError ? 'invalid' : undefined}
+                            errorMessage={linkAddrError}
+                            autoFocus
+                        />
+                    </FormField>
+
+                    <FormField label="Interface MAC" hint="Local interface MAC address">
+                        <TextInput
+                            value={hardwareAddr}
+                            onUpdate={setHardwareAddr}
+                            placeholder="e.g., 52:54:00:12:34:56"
+                            validationState={hardwareAddrError ? 'invalid' : undefined}
+                            errorMessage={hardwareAddrError}
+                        />
+                    </FormField>
+
+                    <FormField label="Device" hint="Network interface name">
+                        <TextInput
+                            value={device}
+                            onUpdate={setDevice}
+                            placeholder="e.g., eth0"
+                        />
+                    </FormField>
+
+                    <FormField label="Priority" hint="Lower value = higher priority (0 uses table default)">
+                        <TextInput
+                            value={priority}
+                            onUpdate={setPriority}
+                            placeholder="e.g., 100"
+                            type="number"
+                        />
+                    </FormField>
+                </Box>
+            </Dialog.Body>
+            <Dialog.Footer
+                onClickButtonApply={handleConfirm}
+                onClickButtonCancel={onClose}
+                textButtonApply="Save"
+                textButtonCancel="Cancel"
+                propsButtonApply={{
+                    view: 'action' as const,
+                    disabled: !canSubmit,
+                    loading: isSubmitting,
+                }}
+            />
+        </Dialog>
+    );
+};

--- a/web/src/pages/neighbours/EditTableDialog.tsx
+++ b/web/src/pages/neighbours/EditTableDialog.tsx
@@ -1,0 +1,94 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Box, Dialog, TextInput } from '@gravity-ui/uikit';
+import { FormField } from '../../components';
+import type { EditTableDialogProps } from './types';
+
+export const EditTableDialog: React.FC<EditTableDialogProps> = ({
+    open,
+    onClose,
+    onConfirm,
+    tableInfo,
+}) => {
+    const [defaultPriority, setDefaultPriority] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (open && tableInfo) {
+            setDefaultPriority(tableInfo.default_priority?.toString() || '0');
+            setIsSubmitting(false);
+        }
+    }, [open, tableInfo]);
+
+    const priorityNum = Number(defaultPriority);
+    const priorityError = !defaultPriority.trim() || isNaN(priorityNum) || priorityNum < 0
+        ? 'Priority must be a non-negative number'
+        : undefined;
+
+    const canSubmit = !isSubmitting && !priorityError;
+
+    const handleConfirm = useCallback(async () => {
+        if (!canSubmit || !tableInfo?.name) return;
+
+        setIsSubmitting(true);
+        try {
+            await onConfirm(tableInfo.name, priorityNum);
+            onClose();
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [canSubmit, tableInfo, priorityNum, onConfirm, onClose]);
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
+                e.preventDefault();
+                handleConfirm();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [open, canSubmit, handleConfirm]);
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <Dialog.Header caption={`Edit Table — ${tableInfo?.name || ''}`} />
+            <Dialog.Body>
+                <Box style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                    <FormField label="Name" hint="Table name (read-only)">
+                        <TextInput
+                            value={tableInfo?.name || ''}
+                            disabled
+                        />
+                    </FormField>
+
+                    <FormField label="Default Priority" required hint="Default priority for new entries (lower = higher priority)">
+                        <TextInput
+                            value={defaultPriority}
+                            onUpdate={setDefaultPriority}
+                            placeholder="e.g., 100"
+                            type="number"
+                            validationState={defaultPriority && priorityError ? 'invalid' : undefined}
+                            errorMessage={priorityError}
+                            autoFocus
+                        />
+                    </FormField>
+                </Box>
+            </Dialog.Body>
+            <Dialog.Footer
+                onClickButtonApply={handleConfirm}
+                onClickButtonCancel={onClose}
+                textButtonApply="Save"
+                textButtonCancel="Cancel"
+                propsButtonApply={{
+                    view: 'action' as const,
+                    disabled: !canSubmit,
+                    loading: isSubmitting,
+                }}
+            />
+        </Dialog>
+    );
+};
+

--- a/web/src/pages/neighbours/NeighbourTableHeader.tsx
+++ b/web/src/pages/neighbours/NeighbourTableHeader.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Box, Text, Checkbox } from '@gravity-ui/uikit';
+import { SortableHeader } from './SortableHeader';
+import type { SortState, SortableColumn } from './hooks';
+import { cellStyles, TOTAL_WIDTH, HEADER_HEIGHT } from './constants';
+
+export interface NeighbourTableHeaderProps {
+    sortState: SortState;
+    onSort: (column: SortableColumn) => void;
+}
+
+export const NeighbourTableHeader: React.FC<NeighbourTableHeaderProps> = ({
+    sortState,
+    onSort,
+}) => {
+    return (
+        <Box
+            className="neigh-table-header"
+            style={{ height: HEADER_HEIGHT, minWidth: TOTAL_WIDTH }}
+        >
+            <Box style={cellStyles.checkbox}>
+                <Checkbox checked={false} disabled />
+            </Box>
+            <Box style={{ ...cellStyles.index, color: undefined }}>
+                <Text variant="subheader-1">#</Text>
+            </Box>
+            <SortableHeader column="next_hop" label="Next Hop" style={cellStyles.next_hop} sortState={sortState} onSort={onSort} />
+            <SortableHeader column="link_addr" label="Neighbour MAC" style={cellStyles.link_addr} sortState={sortState} onSort={onSort} />
+            <SortableHeader column="hardware_addr" label="Interface MAC" style={cellStyles.hardware_addr} sortState={sortState} onSort={onSort} />
+            <SortableHeader column="device" label="Device" style={cellStyles.device} sortState={sortState} onSort={onSort} />
+            <SortableHeader column="state" label="State" style={cellStyles.state} sortState={sortState} onSort={onSort} />
+            <SortableHeader column="source" label="Source" style={cellStyles.source} sortState={sortState} onSort={onSort} />
+            <SortableHeader column="priority" label="Priority" style={cellStyles.priority} sortState={sortState} onSort={onSort} />
+            <SortableHeader column="updated_at" label="Updated At" style={cellStyles.updated_at} sortState={sortState} onSort={onSort} />
+            <Box style={cellStyles.actions}>
+                <Text variant="subheader-1">Edit</Text>
+            </Box>
+        </Box>
+    );
+};

--- a/web/src/pages/neighbours/NeighbourVirtualRow.tsx
+++ b/web/src/pages/neighbours/NeighbourVirtualRow.tsx
@@ -1,0 +1,84 @@
+import { Checkbox, Button, Icon } from '@gravity-ui/uikit';
+import { Pencil } from '@gravity-ui/icons';
+import type { Neighbour } from '../../api/neighbours';
+import { formatMACAddress } from '../../utils/mac';
+import { getNUDStateString } from '../../utils/nud';
+import { formatUnixSeconds } from '../../utils/sorting';
+import { cellStyles, TOTAL_WIDTH, ROW_HEIGHT } from './constants';
+
+export interface NeighbourVirtualRowProps {
+    neighbour: Neighbour;
+    index: number;
+    start: number;
+    isSelected: boolean;
+    onSelect: (neighbour: Neighbour, checked: boolean) => void;
+    onEdit?: (neighbour: Neighbour) => void;
+}
+
+const renderMac = (addr?: { addr?: string | number }): string => {
+    if (addr?.addr === undefined) return '-';
+    return formatMACAddress(addr.addr);
+};
+
+export const NeighbourVirtualRow = ({
+    neighbour,
+    index,
+    start,
+    isSelected,
+    onSelect,
+    onEdit,
+}: NeighbourVirtualRowProps) => {
+    const handleCheckboxChange = (checked: boolean) => {
+        onSelect(neighbour, checked);
+    };
+
+    const handleEditClick = () => {
+        onEdit?.(neighbour);
+    };
+
+    return (
+        <div
+            style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                minWidth: TOTAL_WIDTH,
+                height: ROW_HEIGHT,
+                transform: `translateY(${start}px)`,
+                display: 'flex',
+                alignItems: 'center',
+                padding: '0 8px',
+                borderBottom: '1px solid var(--g-color-line-generic)',
+                backgroundColor: isSelected
+                    ? 'var(--g-color-base-selection)'
+                    : index % 2 === 0
+                        ? 'transparent'
+                        : 'var(--g-color-base-generic-ultralight)',
+                boxSizing: 'border-box',
+            }}
+        >
+            <div style={cellStyles.checkbox}>
+                <Checkbox checked={isSelected} onUpdate={handleCheckboxChange} />
+            </div>
+            <div style={cellStyles.index}>{index + 1}</div>
+            <div style={cellStyles.next_hop}>{neighbour.next_hop || '-'}</div>
+            <div style={cellStyles.link_addr}>{renderMac(neighbour.link_addr)}</div>
+            <div style={cellStyles.hardware_addr}>{renderMac(neighbour.hardware_addr)}</div>
+            <div style={cellStyles.device}>{neighbour.device || '-'}</div>
+            <div style={cellStyles.state}>{getNUDStateString(neighbour.state)}</div>
+            <div style={cellStyles.source}>{neighbour.source || '-'}</div>
+            <div style={cellStyles.priority}>{neighbour.priority?.toString() ?? '-'}</div>
+            <div style={cellStyles.updated_at}>{formatUnixSeconds(neighbour.updated_at)}</div>
+            <div style={cellStyles.actions}>
+                <Button
+                    view="flat"
+                    size="s"
+                    onClick={handleEditClick}
+                >
+                    <Icon data={Pencil} size={16} />
+                </Button>
+            </div>
+        </div>
+    );
+};

--- a/web/src/pages/neighbours/RemoveNeighboursDialog.tsx
+++ b/web/src/pages/neighbours/RemoveNeighboursDialog.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Box, Dialog, Text } from '@gravity-ui/uikit';
+import type { RemoveNeighboursDialogProps } from './types';
+
+export const RemoveNeighboursDialog: React.FC<RemoveNeighboursDialogProps> = ({
+    open,
+    onClose,
+    onConfirm,
+    selectedCount,
+}) => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleConfirm = useCallback(async () => {
+        setIsSubmitting(true);
+        try {
+            await onConfirm();
+            onClose();
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [onConfirm, onClose]);
+
+    const canSubmit = !isSubmitting && selectedCount > 0;
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
+                e.preventDefault();
+                handleConfirm();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [open, canSubmit, handleConfirm]);
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <Dialog.Header caption="Remove Neighbours" />
+            <Dialog.Body>
+                <Box style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <Text variant="body-1">
+                        Are you sure you want to remove {selectedCount} neighbour(s)?
+                    </Text>
+                    <Text variant="body-1" color="secondary">
+                        Press Ctrl+Enter to confirm.
+                    </Text>
+                </Box>
+            </Dialog.Body>
+            <Dialog.Footer
+                onClickButtonApply={handleConfirm}
+                onClickButtonCancel={onClose}
+                textButtonApply="Remove"
+                textButtonCancel="Cancel"
+                propsButtonApply={{
+                    view: 'outlined-danger' as const,
+                    disabled: !canSubmit,
+                    loading: isSubmitting,
+                }}
+            />
+        </Dialog>
+    );
+};

--- a/web/src/pages/neighbours/RemoveTableDialog.tsx
+++ b/web/src/pages/neighbours/RemoveTableDialog.tsx
@@ -1,0 +1,65 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { Box, Dialog, Text } from '@gravity-ui/uikit';
+import type { RemoveTableDialogProps } from './types';
+
+export const RemoveTableDialog: React.FC<RemoveTableDialogProps> = ({
+    open,
+    onClose,
+    onConfirm,
+    tableName,
+}) => {
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const handleConfirm = useCallback(async () => {
+        setIsSubmitting(true);
+        try {
+            await onConfirm();
+            onClose();
+        } finally {
+            setIsSubmitting(false);
+        }
+    }, [onConfirm, onClose]);
+
+    const canSubmit = !isSubmitting;
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
+                e.preventDefault();
+                handleConfirm();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [open, canSubmit, handleConfirm]);
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <Dialog.Header caption="Remove Table" />
+            <Dialog.Body>
+                <Box style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <Text variant="body-1">
+                        Are you sure you want to remove table <strong>{tableName}</strong> and all its entries?
+                    </Text>
+                    <Text variant="body-1" color="secondary">
+                        Press Ctrl+Enter to confirm.
+                    </Text>
+                </Box>
+            </Dialog.Body>
+            <Dialog.Footer
+                onClickButtonApply={handleConfirm}
+                onClickButtonCancel={onClose}
+                textButtonApply="Remove"
+                textButtonCancel="Cancel"
+                propsButtonApply={{
+                    view: 'outlined-danger' as const,
+                    disabled: !canSubmit,
+                    loading: isSubmitting,
+                }}
+            />
+        </Dialog>
+    );
+};

--- a/web/src/pages/neighbours/SortableHeader.tsx
+++ b/web/src/pages/neighbours/SortableHeader.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Box, Text, Icon } from '@gravity-ui/uikit';
+import { ChevronUp, ChevronDown } from '@gravity-ui/icons';
+import type { SortState, SortableColumn } from './hooks';
+
+export interface SortableHeaderProps {
+    column: SortableColumn;
+    label: string;
+    style: React.CSSProperties;
+    sortState: SortState;
+    onSort: (column: SortableColumn) => void;
+}
+
+export const SortableHeader: React.FC<SortableHeaderProps> = ({ column, label, style, sortState, onSort }) => {
+    const handleClick = () => onSort(column);
+    const isActive = sortState.column === column;
+
+    return (
+        <Box
+            style={{
+                ...style,
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+            }}
+            onClick={handleClick}
+        >
+            <Text variant="subheader-1">{label}</Text>
+            {isActive && (
+                <Icon data={sortState.direction === 'asc' ? ChevronUp : ChevronDown} size={14} />
+            )}
+        </Box>
+    );
+};

--- a/web/src/pages/neighbours/VirtualizedNeighbourTable.tsx
+++ b/web/src/pages/neighbours/VirtualizedNeighbourTable.tsx
@@ -1,0 +1,179 @@
+import React, { useRef, useCallback, useMemo } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { Box, Text, TextInput, Label } from '@gravity-ui/uikit';
+import { EmptyState } from '../../components';
+import type { Neighbour } from '../../api/neighbours';
+import type { SortState, SortableColumn } from './hooks';
+import { useContainerHeight, useProcessedNeighbours } from './hooks';
+import { ROW_HEIGHT, OVERSCAN, TOTAL_WIDTH, SEARCH_BAR_HEIGHT, HEADER_HEIGHT, FOOTER_HEIGHT } from './constants';
+import { NeighbourVirtualRow } from './NeighbourVirtualRow';
+import { NeighbourTableHeader } from './NeighbourTableHeader';
+
+export interface VirtualizedNeighbourTableProps {
+    neighbours: Neighbour[];
+    selectedIds: Set<string>;
+    onSelectionChange: (ids: string[]) => void;
+    onEditNeighbour?: (neighbour: Neighbour) => void;
+    sortState: SortState;
+    onSort: (column: SortableColumn) => void;
+    searchQuery: string;
+    onSearchChange: (query: string) => void;
+}
+
+const getNeighbourId = (n: Neighbour): string => n.next_hop || '';
+
+export const VirtualizedNeighbourTable: React.FC<VirtualizedNeighbourTableProps> = ({
+    neighbours,
+    selectedIds,
+    onSelectionChange,
+    onEditNeighbour,
+    sortState,
+    onSort,
+    searchQuery,
+    onSearchChange,
+}) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const parentRef = useRef<HTMLDivElement>(null);
+
+    const containerHeight = useContainerHeight(containerRef);
+
+    const processedData = useProcessedNeighbours(neighbours, searchQuery, sortState);
+
+    // Virtualizer
+    const rowVirtualizer = useVirtualizer({
+        count: processedData.length,
+        getScrollElement: () => parentRef.current,
+        estimateSize: () => ROW_HEIGHT,
+        overscan: OVERSCAN,
+    });
+
+    // Row select handler
+    const handleRowSelect = useCallback((neighbour: Neighbour, checked: boolean) => {
+        const id = getNeighbourId(neighbour);
+        const newSelection = new Set(selectedIds);
+        if (checked) {
+            newSelection.add(id);
+        } else {
+            newSelection.delete(id);
+        }
+        onSelectionChange(Array.from(newSelection));
+    }, [selectedIds, onSelectionChange]);
+
+    const handleClearSelection = useCallback(() => {
+        onSelectionChange([]);
+    }, [onSelectionChange]);
+
+    // Stats text
+    const isFiltered = !!searchQuery.trim();
+    const statsText = useMemo(() => {
+        if (isFiltered) {
+            return `Found: ${processedData.length.toLocaleString()} of ${neighbours.length.toLocaleString()}`;
+        }
+        return `Total: ${processedData.length.toLocaleString()}`;
+    }, [isFiltered, processedData.length, neighbours.length]);
+
+    const selectedText = useMemo(() => {
+        return selectedIds.size > 0 ? `Selected: ${selectedIds.size.toLocaleString()}` : null;
+    }, [selectedIds.size]);
+
+    // Don't render until height is measured
+    if (containerHeight === 0) {
+        return <div ref={containerRef} className="neigh-table__container" />;
+    }
+
+    const tableBodyHeight = containerHeight - SEARCH_BAR_HEIGHT - HEADER_HEIGHT - FOOTER_HEIGHT - 2;
+    const virtualRows = rowVirtualizer.getVirtualItems();
+
+    // Footer text
+    const footerText = virtualRows.length > 0
+        ? `Rows ${(virtualRows[0].index + 1).toLocaleString()} - ${(virtualRows[virtualRows.length - 1].index + 1).toLocaleString()} of ${processedData.length.toLocaleString()}`
+        : '';
+
+    return (
+        <div ref={containerRef} className="neigh-table" style={{ height: containerHeight }}>
+            {/* Search bar */}
+            <Box className="neigh-search-bar" style={{ height: SEARCH_BAR_HEIGHT }}>
+                <Box className="neigh-search-bar__input">
+                    <TextInput
+                        placeholder="Search by next hop, device, or source..."
+                        value={searchQuery}
+                        onUpdate={onSearchChange}
+                        size="m"
+                        hasClear
+                    />
+                </Box>
+                <Box className="neigh-search-bar__stats">
+                    <Label theme="info" size="m">{statsText}</Label>
+                    {selectedText && (
+                        <>
+                            <Label theme="warning" size="m">{selectedText}</Label>
+                            <Text
+                                variant="body-1"
+                                color="link"
+                                className="neigh-search-bar__clear"
+                                onClick={handleClearSelection}
+                            >
+                                Clear
+                            </Text>
+                        </>
+                    )}
+                </Box>
+            </Box>
+
+            {/* Table container */}
+            <Box className="neigh-table__wrapper">
+                <NeighbourTableHeader
+                    sortState={sortState}
+                    onSort={onSort}
+                />
+
+                {/* Virtualized body */}
+                <div
+                    ref={parentRef}
+                    className="neigh-table__body"
+                    style={{ height: tableBodyHeight }}
+                >
+                    {processedData.length === 0 ? (
+                        <Box className="neigh-table__empty">
+                            <EmptyState message="No neighbours found" />
+                        </Box>
+                    ) : (
+                        <div
+                            className="neigh-table__virtual-container"
+                            style={{
+                                height: rowVirtualizer.getTotalSize(),
+                                minWidth: TOTAL_WIDTH,
+                            }}
+                        >
+                            {virtualRows.map(virtualRow => {
+                                const neighbour = processedData[virtualRow.index];
+                                if (!neighbour) return null;
+
+                                const id = getNeighbourId(neighbour);
+                                const isSelected = selectedIds.has(id);
+
+                                return (
+                                    <NeighbourVirtualRow
+                                        key={virtualRow.index}
+                                        neighbour={neighbour}
+                                        index={virtualRow.index}
+                                        start={virtualRow.start}
+                                        isSelected={isSelected}
+                                        onSelect={handleRowSelect}
+                                        onEdit={onEditNeighbour}
+                                    />
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            </Box>
+
+            {/* Footer */}
+            <Box className="neigh-table__footer" style={{ height: FOOTER_HEIGHT }}>
+                <Text variant="body-2" color="secondary">{footerText}</Text>
+                <Text variant="body-2" color="secondary">Scroll to navigate</Text>
+            </Box>
+        </div>
+    );
+};

--- a/web/src/pages/neighbours/constants.ts
+++ b/web/src/pages/neighbours/constants.ts
@@ -1,0 +1,74 @@
+import type React from 'react';
+
+// Table dimensions
+export const ROW_HEIGHT = 36;
+export const HEADER_HEIGHT = 44;
+export const SEARCH_BAR_HEIGHT = 52;
+export const FOOTER_HEIGHT = 32;
+export const OVERSCAN = 15;
+
+// Column widths for virtualized neighbour table
+export const COLUMN_WIDTHS = {
+    checkbox: 40,
+    index: 70,
+    next_hop: 280,
+    link_addr: 170,
+    hardware_addr: 170,
+    device: 100,
+    state: 100,
+    source: 100,
+    priority: 80,
+    updated_at: 200,
+    actions: 60,
+} as const;
+
+export const TOTAL_WIDTH = Object.values(COLUMN_WIDTHS).reduce((a, b) => a + b, 0);
+
+const makeCellStyle = (width: number, extra?: React.CSSProperties): React.CSSProperties => ({
+    width,
+    minWidth: width,
+    maxWidth: width,
+    paddingRight: 8,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    userSelect: 'text',
+    ...extra,
+});
+
+// Pre-computed cell styles for virtualized table
+export const cellStyles: Record<keyof typeof COLUMN_WIDTHS, React.CSSProperties> = {
+    checkbox: {
+        width: COLUMN_WIDTHS.checkbox,
+        minWidth: COLUMN_WIDTHS.checkbox,
+        maxWidth: COLUMN_WIDTHS.checkbox,
+        paddingRight: 8,
+        display: 'flex',
+        justifyContent: 'center',
+    },
+    index: {
+        width: COLUMN_WIDTHS.index,
+        minWidth: COLUMN_WIDTHS.index,
+        maxWidth: COLUMN_WIDTHS.index,
+        paddingRight: 8,
+        textAlign: 'right',
+        color: 'var(--g-color-text-secondary)',
+    },
+    next_hop: makeCellStyle(COLUMN_WIDTHS.next_hop),
+    link_addr: makeCellStyle(COLUMN_WIDTHS.link_addr),
+    hardware_addr: makeCellStyle(COLUMN_WIDTHS.hardware_addr),
+    device: makeCellStyle(COLUMN_WIDTHS.device),
+    state: makeCellStyle(COLUMN_WIDTHS.state),
+    source: makeCellStyle(COLUMN_WIDTHS.source),
+    priority: makeCellStyle(COLUMN_WIDTHS.priority),
+    updated_at: makeCellStyle(COLUMN_WIDTHS.updated_at),
+    actions: {
+        width: COLUMN_WIDTHS.actions,
+        minWidth: COLUMN_WIDTHS.actions,
+        maxWidth: COLUMN_WIDTHS.actions,
+        paddingRight: 8,
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+};

--- a/web/src/pages/neighbours/hooks.ts
+++ b/web/src/pages/neighbours/hooks.ts
@@ -1,0 +1,132 @@
+import { useState, useEffect, useLayoutEffect, useMemo } from 'react';
+import type { Neighbour } from '../../api/neighbours';
+import { getMACAddressValue, compareMACAddressValues } from '../../utils/mac';
+import { compareNullableStrings, getUnixSecondsValue, compareNullableNumbers } from '../../utils/sorting';
+
+// Sorting types
+export type SortableColumn =
+    | 'next_hop'
+    | 'link_addr'
+    | 'hardware_addr'
+    | 'device'
+    | 'state'
+    | 'source'
+    | 'priority'
+    | 'updated_at';
+
+export type SortDirection = 'asc' | 'desc';
+
+export interface SortState {
+    column: SortableColumn | null;
+    direction: SortDirection;
+}
+
+export const SORTABLE_COLUMNS: ReadonlySet<string> = new Set<SortableColumn>([
+    'next_hop', 'link_addr', 'hardware_addr', 'device',
+    'state', 'source', 'priority', 'updated_at',
+]);
+
+export const DEFAULT_SORT: SortState = { column: 'state', direction: 'asc' };
+
+export const isSortableColumn = (value: string): value is SortableColumn =>
+    SORTABLE_COLUMNS.has(value);
+
+export const isSortDirection = (value: string): value is SortDirection =>
+    value === 'asc' || value === 'desc';
+
+// Sort comparators for neighbour columns
+export const sortComparators: Record<SortableColumn, (a: Neighbour, b: Neighbour) => number> = {
+    next_hop: (a, b) => compareNullableStrings(a.next_hop, b.next_hop),
+    link_addr: (a, b) => compareMACAddressValues(
+        getMACAddressValue(a.link_addr?.addr),
+        getMACAddressValue(b.link_addr?.addr),
+    ),
+    hardware_addr: (a, b) => compareMACAddressValues(
+        getMACAddressValue(a.hardware_addr?.addr),
+        getMACAddressValue(b.hardware_addr?.addr),
+    ),
+    device: (a, b) => compareNullableStrings(a.device, b.device),
+    state: (a, b) => {
+        const stateA = a.state ?? 0;
+        const stateB = b.state ?? 0;
+        if (stateA !== stateB) return stateA - stateB;
+        return compareNullableStrings(a.next_hop, b.next_hop);
+    },
+    source: (a, b) => compareNullableStrings(a.source, b.source),
+    priority: (a, b) => (a.priority ?? 0) - (b.priority ?? 0),
+    updated_at: (a, b) => compareNullableNumbers(
+        getUnixSecondsValue(a.updated_at),
+        getUnixSecondsValue(b.updated_at),
+    ),
+};
+
+// Hook for measuring container height
+export const useContainerHeight = (containerRef: React.RefObject<HTMLDivElement | null>) => {
+    const [containerHeight, setContainerHeight] = useState(0);
+
+    useLayoutEffect(() => {
+        const updateHeight = () => {
+            if (containerRef.current) {
+                const rect = containerRef.current.getBoundingClientRect();
+                const availableHeight = window.innerHeight - rect.top - 20;
+                setContainerHeight(Math.max(300, availableHeight));
+            }
+        };
+
+        updateHeight();
+        window.addEventListener('resize', updateHeight);
+
+        return () => {
+            window.removeEventListener('resize', updateHeight);
+        };
+    }, [containerRef]);
+
+    return containerHeight;
+};
+
+// Hook for filtering and sorting neighbours
+export const useProcessedNeighbours = (
+    neighbours: Neighbour[],
+    searchQuery: string,
+    sortState: SortState,
+) => {
+    return useMemo(() => {
+        let result = neighbours;
+
+        // Apply search filter
+        if (searchQuery.trim()) {
+            const lowerQuery = searchQuery.toLowerCase();
+            result = result.filter(n =>
+                n.next_hop?.toLowerCase().includes(lowerQuery) ||
+                n.device?.toLowerCase().includes(lowerQuery) ||
+                n.source?.toLowerCase().includes(lowerQuery),
+            );
+        }
+
+        // Apply sorting
+        if (sortState.column) {
+            const comparator = sortComparators[sortState.column];
+            result = [...result].sort(comparator);
+            if (sortState.direction === 'desc') {
+                result.reverse();
+            }
+        }
+
+        return result;
+    }, [neighbours, searchQuery, sortState]);
+};
+
+// Hook for debounced value
+export const useDebouncedValue = (value: string, delay: number = 200): string => {
+    const [debouncedValue, setDebouncedValue] = useState(value);
+
+    useEffect(() => {
+        const timeoutId = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        return () => clearTimeout(timeoutId);
+    }, [value, delay]);
+
+    return debouncedValue;
+};

--- a/web/src/pages/neighbours/index.ts
+++ b/web/src/pages/neighbours/index.ts
@@ -1,0 +1,8 @@
+export { AddNeighbourDialog } from './AddNeighbourDialog';
+export { EditNeighbourDialog } from './EditNeighbourDialog';
+export { RemoveNeighboursDialog } from './RemoveNeighboursDialog';
+export { CreateTableDialog } from './CreateTableDialog';
+export { EditTableDialog } from './EditTableDialog';
+export { RemoveTableDialog } from './RemoveTableDialog';
+export { VirtualizedNeighbourTable } from './VirtualizedNeighbourTable';
+export type * from './types';

--- a/web/src/pages/neighbours/neighbours.scss
+++ b/web/src/pages/neighbours/neighbours.scss
@@ -1,0 +1,78 @@
+@use '../../styles/variables' as *;
+@use '../../styles/mixins' as *;
+
+// Neighbour Table
+.neigh-table {
+    @include flex-column;
+
+    &__container {
+        height: 100%;
+    }
+
+    &__wrapper {
+        flex: 1;
+        border: 1px solid var(--g-color-line-generic);
+        border-radius: $radius-lg;
+        overflow: hidden;
+        @include flex-column;
+    }
+
+    &__body {
+        overflow: auto;
+        contain: strict;
+    }
+
+    &__virtual-container {
+        position: relative;
+    }
+
+    &__empty {
+        padding: 40px $spacing-xl;
+        text-align: center;
+    }
+
+    &__footer {
+        @include flex-row;
+        justify-content: space-between;
+        flex-shrink: 0;
+    }
+}
+
+// Search Bar
+.neigh-search-bar {
+    @include flex-row($spacing-lg);
+    flex-shrink: 0;
+
+    &__input {
+        width: 350px;
+    }
+
+    &__stats {
+        @include flex-row($spacing-sm);
+    }
+
+    &__clear {
+        cursor: pointer;
+    }
+}
+
+// Table Header
+.neigh-table-header {
+    @include flex-row;
+    border-bottom: 1px solid var(--g-color-line-generic);
+    background-color: var(--g-color-base-generic);
+    padding: 0 $spacing-sm;
+    flex-shrink: 0;
+}
+
+// Neighbours Page
+.neigh-page {
+    &__content {
+        width: 100%;
+        flex: 1;
+        min-width: 0;
+        padding: $spacing-xl;
+        @include flex-column;
+        min-height: 0;
+    }
+}

--- a/web/src/pages/neighbours/types.ts
+++ b/web/src/pages/neighbours/types.ts
@@ -1,0 +1,44 @@
+import type { Neighbour, NeighbourTableInfo } from '../../api/neighbours';
+
+export interface AddNeighbourDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: (table: string, entry: Neighbour) => Promise<void>;
+    tables: NeighbourTableInfo[];
+    defaultTable: string;
+}
+
+export interface EditNeighbourDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: (table: string, entry: Neighbour) => Promise<void>;
+    neighbour: Neighbour | null;
+    table: string;
+}
+
+export interface RemoveNeighboursDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void>;
+    selectedCount: number;
+}
+
+export interface CreateTableDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: (name: string, defaultPriority: number) => Promise<void>;
+}
+
+export interface EditTableDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: (name: string, defaultPriority: number) => Promise<void>;
+    tableInfo: NeighbourTableInfo | null;
+}
+
+export interface RemoveTableDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onConfirm: () => Promise<void>;
+    tableName: string;
+}

--- a/web/src/utils/mac.ts
+++ b/web/src/utils/mac.ts
@@ -107,3 +107,24 @@ export const parseMACToBytes = (mac: string): number[] | undefined => {
     }
     return bytes;
 };
+
+/**
+ * Convert MAC address string to uint64 string for proto MACAddress.addr.
+ *
+ * The proto stores MAC as a big-endian uint64 where the 6 MAC bytes occupy
+ * the most significant positions and the lowest 2 bytes are zero.
+ * Example: "3a:ac:26:9b:5b:f9" -> "0x3aac269b5bf90000" as decimal string.
+ *
+ * @param mac - MAC address string in format "xx:xx:xx:xx:xx:xx"
+ * @returns uint64 value as a decimal string, or undefined if invalid
+ */
+export const macToUint64 = (mac: string): string | undefined => {
+    const bytes = parseMACToBytes(mac);
+    if (!bytes) return undefined;
+
+    let value = BigInt(0);
+    for (let i = 0; i < 6; i++) {
+        value |= BigInt(bytes[i]) << BigInt((7 - i) * 8);
+    }
+    return value.toString();
+};


### PR DESCRIPTION
Introduce a multi-source neighbour management system inspired by Linux iproute2 and FRRouting, where multiple tables (kernel, static, and user-defined) coexist and are merged by per-entry priority.

Key changes:
- NeighTable manages multiple NeighSource instances and maintains a merged cache rebuilt eagerly on every mutation, enabling lock-free reads via atomic swap.
- gRPC API for table CRUD (CreateTable, UpdateTable, RemoveTable, ListTables) and batch entry operations (UpdateNeighbours, RemoveNeighbours).
- Netlink monitor is now an external data source, configurable via YAML (disable_netlink_monitor, table_name, default_priority).
- Built-in "kernel" and "static" tables are created at startup; custom tables can be added at runtime.
- CLI extended with table management subcommands, batch add/remove, and per-table filtering.
- Web UI displays both individual source tables and the aggregated merged view via tabs.