### PR TITLE
fix(ci): repair (I hope) Go and C fuzzer workflows

### DIFF
--- a/.github/workflows/c-fuzz-test.yml
+++ b/.github/workflows/c-fuzz-test.yml
@@ -31,6 +31,16 @@ jobs:
         with:
           submodules: true
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
+          cache: false
+
+      - name: Install Go Protobuf Plugins
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
       - uses: hendrikmuhs/ccache-action@v1.2.18
         name: ccache
         with:

--- a/.github/workflows/go-fuzz-test.yml
+++ b/.github/workflows/go-fuzz-test.yml
@@ -13,8 +13,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: jidicula/go-fuzz-action@v1.2.0
+      - uses: actions/setup-go@v5
         with:
-          packages: "./..."
-          fuzz-time: 10m
           go-version: "1.24.x"
+
+      - name: Run Go fuzz tests
+        run: |
+          # Find all fuzz test functions and run each one
+          packages=$(go list ./...)
+          for pkg in $packages; do
+            fuzz_funcs=$(go test "$pkg" -list '^Fuzz' 2>/dev/null | grep '^Fuzz' || true)
+            for func in $fuzz_funcs; do
+              echo "Fuzzing $func in $pkg"
+              go test "$pkg" -run '^$' -fuzz "^${func}\$" -fuzztime 10m
+            done
+          done
+
+      - name: Upload fuzz failure testdata
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: fuzz-testdata
+          path: "**/testdata/fuzz/**"
+          retention-days: 7


### PR DESCRIPTION
Replace deprecated jidicula/go-fuzz-action (which depends on actions/upload-artifact v3) with inline steps using setup-go and actions/upload-artifact v4.

Add Go toolchain and protobuf Go plugins installation to the C fuzzer workflow, since the disk-space cleanup step removes the pre-installed Go from the runner.