### PR TITLE
refactor (web): extract useDialogKeyboardShortcut hook

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -1,6 +1,9 @@
 export { useAsyncData, usePollingData } from './useAsyncData';
 export type { UseAsyncDataOptions, UseAsyncDataResult, UsePollingDataOptions } from './useAsyncData';
 
+export { useDialogKeyboardShortcut } from './useDialogKeyboardShortcut';
+export type { UseDialogKeyboardShortcutOptions } from './useDialogKeyboardShortcut';
+
 export { useGraphEditor } from './useGraphEditor';
 export type { GraphState, UseGraphEditorOptions, UseGraphEditorResult } from './useGraphEditor';
 

--- a/web/src/hooks/useDialogKeyboardShortcut.ts
+++ b/web/src/hooks/useDialogKeyboardShortcut.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+
+export interface UseDialogKeyboardShortcutOptions {
+    /** Whether the dialog is open */
+    open: boolean;
+    /** Whether the form can be submitted */
+    canSubmit: boolean;
+    /** Callback to execute on Ctrl+Enter / Cmd+Enter */
+    onConfirm: () => void;
+}
+
+/**
+ * Hook that adds Ctrl+Enter / Cmd+Enter keyboard shortcut for dialog submission.
+ *
+ * @example
+ * ```tsx
+ * const MyDialog = ({ open, onConfirm }) => {
+ *   const [canSubmit, setCanSubmit] = useState(false);
+ *   const handleConfirm = useCallback(() => { ... }, []);
+ *
+ *   useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
+ *
+ *   return <Dialog>...</Dialog>;
+ * };
+ * ```
+ */
+export const useDialogKeyboardShortcut = ({
+    open,
+    canSubmit,
+    onConfirm,
+}: UseDialogKeyboardShortcutOptions) => {
+    useEffect(() => {
+        if (!open || !canSubmit) return;
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                e.preventDefault();
+                onConfirm();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [open, canSubmit, onConfirm]);
+};

--- a/web/src/pages/decap/AddPrefixDialog.tsx
+++ b/web/src/pages/decap/AddPrefixDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { Box, Dialog, TextInput } from '@gravity-ui/uikit';
 import { FormField } from '../../components';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { AddPrefixDialogProps } from './types';
 import { parseCIDRPrefix, CIDRParseError } from '../../utils';
 import './decap.css';
@@ -86,19 +87,7 @@ export const AddPrefixDialog: React.FC<AddPrefixDialogProps> = ({
     }, [existingConfigs, configName]);
 
     // Handle Ctrl+Enter / Cmd+Enter
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={handleClose}>

--- a/web/src/pages/decap/DeletePrefixDialog.tsx
+++ b/web/src/pages/decap/DeletePrefixDialog.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Box, Dialog, Text } from '@gravity-ui/uikit';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { DeletePrefixDialogProps } from './types';
 import './decap.css';
 
@@ -28,19 +29,7 @@ export const DeletePrefixDialog: React.FC<DeletePrefixDialogProps> = ({
     const canSubmit = !isSubmitting && prefixCount > 0;
 
     // Handle Ctrl+Enter / Cmd+Enter
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>

--- a/web/src/pages/forward/AddRuleDialog.tsx
+++ b/web/src/pages/forward/AddRuleDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Dialog, TextInput, Select } from '@gravity-ui/uikit';
 import { FormField } from '../../components';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { AddRuleDialogProps } from './types';
 import type { Rule } from '../../api/forward';
 import { ForwardMode } from '../../api/forward';
@@ -98,19 +99,7 @@ export const AddRuleDialog: React.FC<AddRuleDialogProps> = ({
     const canSubmit = !formError && !isSubmitting;
 
     // Handle Ctrl+Enter / Cmd+Enter
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={handleClose}>

--- a/web/src/pages/forward/DeleteRuleDialog.tsx
+++ b/web/src/pages/forward/DeleteRuleDialog.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Box, Dialog, Text } from '@gravity-ui/uikit';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { DeleteRuleDialogProps } from './types';
 import './forward.scss';
 
@@ -24,19 +25,7 @@ export const DeleteRuleDialog: React.FC<DeleteRuleDialogProps> = ({
     const canSubmit = !isSubmitting && selectedCount > 0;
 
     // Handle Ctrl+Enter / Cmd+Enter
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>

--- a/web/src/pages/forward/EditRuleDialog.tsx
+++ b/web/src/pages/forward/EditRuleDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Dialog, TextInput, Select } from '@gravity-ui/uikit';
 import { FormField } from '../../components';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { EditRuleDialogProps } from './types';
 import type { Rule } from '../../api/forward';
 import { ForwardMode, FORWARD_MODE_LABELS } from '../../api/forward';
@@ -120,19 +121,7 @@ export const EditRuleDialog: React.FC<EditRuleDialogProps> = ({
     const canSubmit = !formError && !isSubmitting;
 
     // Handle Ctrl+Enter / Cmd+Enter
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={handleClose}>

--- a/web/src/pages/functions/dialogs/WeightEditorDialog.tsx
+++ b/web/src/pages/functions/dialogs/WeightEditorDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Dialog, TextInput, Box, Text } from '@gravity-ui/uikit';
+import { useDialogKeyboardShortcut } from '../../../hooks';
 import type { FunctionEdge } from '../types';
 import '../../FunctionsPage.css';
 
@@ -41,18 +42,7 @@ export const WeightEditorDialog: React.FC<WeightEditorDialogProps> = ({
         onConfirm(weights);
     }, [weights, onConfirm]);
     
-    useEffect(() => {
-        if (!open) return;
-        
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-                handleConfirm();
-            }
-        };
-        
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit: true, onConfirm: handleConfirm });
     
     return (
         <Dialog open={open} onClose={onClose}>

--- a/web/src/pages/neighbours/AddNeighbourDialog.tsx
+++ b/web/src/pages/neighbours/AddNeighbourDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Dialog, TextInput, Select } from '@gravity-ui/uikit';
 import { FormField } from '../../components';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import { macToUint64 } from '../../utils/mac';
 import type { Neighbour } from '../../api/neighbours';
 import type { AddNeighbourDialogProps } from './types';
@@ -80,19 +81,7 @@ export const AddNeighbourDialog: React.FC<AddNeighbourDialogProps> = ({
         }
     }, [canSubmit, nextHop, linkAddr, hardwareAddr, device, priority, table, onConfirm, onClose]);
 
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>

--- a/web/src/pages/neighbours/CreateTableDialog.tsx
+++ b/web/src/pages/neighbours/CreateTableDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Dialog, TextInput } from '@gravity-ui/uikit';
 import { FormField } from '../../components';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { CreateTableDialogProps } from './types';
 
 export const CreateTableDialog: React.FC<CreateTableDialogProps> = ({
@@ -40,19 +41,7 @@ export const CreateTableDialog: React.FC<CreateTableDialogProps> = ({
         }
     }, [canSubmit, name, priorityNum, onConfirm, onClose]);
 
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>

--- a/web/src/pages/neighbours/EditNeighbourDialog.tsx
+++ b/web/src/pages/neighbours/EditNeighbourDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Dialog, TextInput } from '@gravity-ui/uikit';
 import { FormField } from '../../components';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import { formatMACAddress, macToUint64 } from '../../utils/mac';
 import type { Neighbour } from '../../api/neighbours';
 import type { EditNeighbourDialogProps } from './types';
@@ -73,19 +74,7 @@ export const EditNeighbourDialog: React.FC<EditNeighbourDialogProps> = ({
         }
     }, [canSubmit, nextHop, linkAddr, hardwareAddr, device, priority, table, onConfirm, onClose]);
 
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>

--- a/web/src/pages/neighbours/EditTableDialog.tsx
+++ b/web/src/pages/neighbours/EditTableDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Dialog, TextInput } from '@gravity-ui/uikit';
 import { FormField } from '../../components';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { EditTableDialogProps } from './types';
 
 export const EditTableDialog: React.FC<EditTableDialogProps> = ({
@@ -38,19 +39,7 @@ export const EditTableDialog: React.FC<EditTableDialogProps> = ({
         }
     }, [canSubmit, tableInfo, priorityNum, onConfirm, onClose]);
 
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>

--- a/web/src/pages/neighbours/RemoveNeighboursDialog.tsx
+++ b/web/src/pages/neighbours/RemoveNeighboursDialog.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Box, Dialog, Text } from '@gravity-ui/uikit';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { RemoveNeighboursDialogProps } from './types';
 
 export const RemoveNeighboursDialog: React.FC<RemoveNeighboursDialogProps> = ({
@@ -22,19 +23,7 @@ export const RemoveNeighboursDialog: React.FC<RemoveNeighboursDialogProps> = ({
 
     const canSubmit = !isSubmitting && selectedCount > 0;
 
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>

--- a/web/src/pages/neighbours/RemoveTableDialog.tsx
+++ b/web/src/pages/neighbours/RemoveTableDialog.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Box, Dialog, Text } from '@gravity-ui/uikit';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { RemoveTableDialogProps } from './types';
 
 export const RemoveTableDialog: React.FC<RemoveTableDialogProps> = ({
@@ -22,19 +23,7 @@ export const RemoveTableDialog: React.FC<RemoveTableDialogProps> = ({
 
     const canSubmit = !isSubmitting;
 
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>

--- a/web/src/pages/route/AddRouteDialog.tsx
+++ b/web/src/pages/route/AddRouteDialog.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Text, Dialog, TextInput, Switch } from '@gravity-ui/uikit';
 import { FormField } from '../../components';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { AddRouteDialogProps } from './types';
 import './route.scss';
 
@@ -32,6 +33,10 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
     const handleDoFlushChange = (checked: boolean): void => {
         onFormChange({ ...form, do_flush: checked });
     };
+
+    const canSubmit = !configNameError && !prefixError && !nexthopError;
+
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>
@@ -69,7 +74,7 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
                     <FormField
                         label="Next Hop"
                         required
-                        hint="IP address of the next hop (IPv4 or IPv6)"
+                        hint="IP address of the next hop (IPv4 or IPv6). Press Ctrl+Enter to save."
                     >
                         <TextInput
                             value={form.nexthop_addr}
@@ -96,7 +101,10 @@ export const AddRouteDialog: React.FC<AddRouteDialogProps> = ({
                 onClickButtonCancel={onClose}
                 textButtonApply="Add"
                 textButtonCancel="Cancel"
-                propsButtonApply={{ view: 'action' as const }}
+                propsButtonApply={{
+                    view: 'action' as const,
+                    disabled: !canSubmit,
+                }}
             />
         </Dialog>
     );

--- a/web/src/pages/route/DeleteRouteDialog.tsx
+++ b/web/src/pages/route/DeleteRouteDialog.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Text, Dialog } from '@gravity-ui/uikit';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import { RouteListItem } from './RouteListItem';
 import { formatRouteCount } from './utils';
 import type { DeleteRouteDialogProps } from './types';
@@ -12,6 +13,9 @@ export const DeleteRouteDialog: React.FC<DeleteRouteDialogProps> = ({
     selectedRoutes,
 }) => {
     const count = selectedRoutes.length;
+    const canSubmit = count > 0;
+
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>
@@ -19,7 +23,7 @@ export const DeleteRouteDialog: React.FC<DeleteRouteDialogProps> = ({
             <Dialog.Body>
                 <Box className="delete-route-dialog__message">
                     <Text variant="body-1">
-                        Are you sure you want to delete {count} {formatRouteCount(count)}?
+                        Are you sure you want to delete {count} {formatRouteCount(count)}? Press Ctrl+Enter to confirm.
                     </Text>
                 </Box>
                 {selectedRoutes.length > 0 && (
@@ -40,7 +44,10 @@ export const DeleteRouteDialog: React.FC<DeleteRouteDialogProps> = ({
                 onClickButtonCancel={onClose}
                 textButtonApply="Delete"
                 textButtonCancel="Cancel"
-                propsButtonApply={{ view: 'outlined-danger' as const }}
+                propsButtonApply={{
+                    view: 'outlined-danger' as const,
+                    disabled: !canSubmit,
+                }}
             />
         </Dialog>
     );

--- a/web/src/pages/route/EditRouteDialog.tsx
+++ b/web/src/pages/route/EditRouteDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Text, Dialog, TextInput, Switch } from '@gravity-ui/uikit';
 import { FormField } from '../../components';
+import { useDialogKeyboardShortcut } from '../../hooks';
 import type { EditRouteDialogProps } from './types';
 import './route.scss';
 
@@ -43,19 +44,7 @@ export const EditRouteDialog: React.FC<EditRouteDialogProps> = ({
         }
     }, [canSubmit, prefix, nexthopAddr, doFlush, onConfirm, onClose]);
 
-    useEffect(() => {
-        if (!open) return;
-
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && canSubmit) {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, handleConfirm]);
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
 
     return (
         <Dialog open={open} onClose={onClose}>


### PR DESCRIPTION
Consolidate duplicate Ctrl+Enter/Cmd+Enter keyboard shortcut logic from 13 dialog components into a reusable hook.

Removes ~150 lines of duplicated code.