### PR TITLE
refactor (web): enhance FormDialog with disabled prop and keyboard shortcut

### DIFF
--- a/web/src/components/CreateEntityDialog.tsx
+++ b/web/src/components/CreateEntityDialog.tsx
@@ -64,6 +64,7 @@ export const CreateEntityDialog: React.FC<CreateEntityDialogProps> = ({
 
     const defaultPlaceholder = placeholder ?? `Enter ${entityType.toLowerCase()} name`;
     const defaultHint = hint ?? `Unique identifier for the ${entityType.toLowerCase()}`;
+    const canSubmit = !error && name.trim().length > 0;
 
     return (
         <FormDialog
@@ -72,6 +73,7 @@ export const CreateEntityDialog: React.FC<CreateEntityDialogProps> = ({
             onConfirm={handleConfirm}
             title={`Create ${entityType}`}
             confirmText="Create"
+            disabled={!canSubmit}
         >
             <FormField
                 label={`${entityType} Name`}

--- a/web/src/components/FormDialog.tsx
+++ b/web/src/components/FormDialog.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import { Dialog, Box } from '@gravity-ui/uikit';
+import { useDialogKeyboardShortcut } from '../hooks';
 
 export interface FormDialogProps {
     /** Whether the dialog is open */
@@ -16,6 +17,8 @@ export interface FormDialogProps {
     cancelText?: string;
     /** Whether the confirm action is loading */
     loading?: boolean;
+    /** Whether to disable the confirm button */
+    disabled?: boolean;
     /** Whether to show cancel button */
     showCancel?: boolean;
     /** Dialog body content (form fields) */
@@ -35,30 +38,21 @@ export const FormDialog: React.FC<FormDialogProps> = ({
     confirmText = 'Confirm',
     cancelText = 'Cancel',
     loading = false,
+    disabled = false,
     showCancel = true,
     children,
     width = '400px',
 }) => {
+    const canSubmit = !loading && !disabled;
+
     const handleConfirm = useCallback(() => {
-        if (!loading) {
+        if (canSubmit) {
             onConfirm();
         }
-    }, [loading, onConfirm]);
+    }, [canSubmit, onConfirm]);
 
-    // Handle Ctrl+Enter / Cmd+Enter keyboard shortcut
-    useEffect(() => {
-        if (!open) return;
-        
-        const handleKeyDown = (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-                e.preventDefault();
-                handleConfirm();
-            }
-        };
-        
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, handleConfirm]);
+    // Add Ctrl+Enter keyboard shortcut
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
     
     return (
         <Dialog open={open} onClose={onClose}>
@@ -74,7 +68,10 @@ export const FormDialog: React.FC<FormDialogProps> = ({
                 textButtonApply={confirmText}
                 textButtonCancel={showCancel ? cancelText : undefined}
                 loading={loading}
-                propsButtonApply={{ view: 'action' as const }}
+                propsButtonApply={{
+                    view: 'action' as const,
+                    disabled: !canSubmit,
+                }}
             />
         </Dialog>
     );

--- a/web/src/hooks/useDialogKeyboardShortcut.ts
+++ b/web/src/hooks/useDialogKeyboardShortcut.ts
@@ -30,10 +30,11 @@ export const useDialogKeyboardShortcut = ({
     onConfirm,
 }: UseDialogKeyboardShortcutOptions) => {
     useEffect(() => {
-        if (!open || !canSubmit) return;
+        if (!open) return;
 
         const handleKeyDown = (e: KeyboardEvent) => {
             if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                if (!canSubmit) return;
                 e.preventDefault();
                 onConfirm();
             }

--- a/web/src/pages/acl/dialogs/CreateConfigDialog.tsx
+++ b/web/src/pages/acl/dialogs/CreateConfigDialog.tsx
@@ -46,6 +46,8 @@ export const CreateConfigDialog: React.FC<CreateConfigDialogProps> = ({
         onConfirm(name.trim());
     }, [name, validate, onConfirm]);
 
+    const canSubmit = !error && name.trim().length > 0;
+
     return (
         <FormDialog
             open={open}
@@ -53,6 +55,7 @@ export const CreateConfigDialog: React.FC<CreateConfigDialogProps> = ({
             onConfirm={handleConfirm}
             title="Create ACL Config"
             confirmText="Create"
+            disabled={!canSubmit}
         >
             <FormField
                 label="Config Name"

--- a/web/src/pages/pdump/ConfigDialog.tsx
+++ b/web/src/pages/pdump/ConfigDialog.tsx
@@ -103,6 +103,7 @@ export const ConfigDialog: React.FC<ConfigDialogProps> = ({
     };
 
     const title = isCreate ? 'Create Pdump Configuration' : `Edit ${initialConfigName}`;
+    const canSubmit = isCreate ? configName.trim().length > 0 : true;
 
     return (
         <FormDialog
@@ -112,6 +113,7 @@ export const ConfigDialog: React.FC<ConfigDialogProps> = ({
             title={title}
             confirmText={isCreate ? 'Create' : 'Save'}
             loading={loading}
+            disabled={!canSubmit}
             width="500px"
         >
             <Flex direction="column" gap={4}>


### PR DESCRIPTION
Add disabled prop to FormDialog for better form validation control. Replace manual keyboard handler with useDialogKeyboardShortcut hook.