### PR TITLE
fix (web): pass original onConfirm to keyboard shortcut hook

### DIFF
--- a/web/src/components/FormDialog.tsx
+++ b/web/src/components/FormDialog.tsx
@@ -52,7 +52,7 @@ export const FormDialog: React.FC<FormDialogProps> = ({
     }, [canSubmit, onConfirm]);
 
     // Add Ctrl+Enter keyboard shortcut
-    useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
+    useDialogKeyboardShortcut({ open, canSubmit, onConfirm });
     
     return (
         <Dialog open={open} onClose={onClose}>


### PR DESCRIPTION
Pass onConfirm directly to useDialogKeyboardShortcut instead of handleConfirm. The hook already checks canSubmit internally.