### PR TITLE
fwstate: refactor key/value structs, improve CLI output

### DIFF
--- a/lib/fwstate/fwstate_cursor.h
+++ b/lib/fwstate/fwstate_cursor.h
@@ -32,21 +32,22 @@ typedef struct fwstate_cursor_entry {
 /// protocol type and TCP flags.
 static inline uint64_t
 fwstate_entry_ttl(
-	const struct fw_state_value *v, const struct fwstate_timeouts *t
+	uint16_t proto, uint8_t raw_flags, const struct fwstate_timeouts *t
 ) {
-	if (v->type == IPPROTO_UDP) {
+	union fw_state_flags_u flags = {.raw = raw_flags};
+	if (proto == IPPROTO_UDP) {
 		return t->udp;
 	}
-	if (v->type == IPPROTO_TCP) {
-		if (v->flags.tcp.src & FWSTATE_FIN ||
-		    v->flags.tcp.dst & FWSTATE_FIN) {
+	if (proto == IPPROTO_TCP) {
+		if (flags.tcp.src & FWSTATE_FIN ||
+		    flags.tcp.dst & FWSTATE_FIN) {
 			return t->tcp_fin;
 		}
-		if ((v->flags.tcp.src & FWSTATE_SYN) &&
-		    (v->flags.tcp.dst & FWSTATE_ACK)) {
+		if ((flags.tcp.src & FWSTATE_SYN) &&
+		    (flags.tcp.dst & FWSTATE_ACK)) {
 			return t->tcp_syn_ack;
 		}
-		if (v->flags.tcp.src & FWSTATE_SYN) {
+		if (flags.tcp.src & FWSTATE_SYN) {
 			return t->tcp_syn;
 		}
 		return t->tcp;
@@ -88,17 +89,20 @@ fwstate_cursor_read_forward(
 			continue;
 		}
 
-		// Check expiration
-		uint64_t ttl = fwstate_entry_ttl(value, &cursor->timeouts);
-		bool expired = (value->updated_at + ttl <= now);
-
-		if (!cursor->include_expired && expired) {
+		void *key = fwmap_get_key(map, cursor->key_pos);
+		if (key == NULL) {
 			cursor->key_pos++;
 			continue;
 		}
 
-		void *key = fwmap_get_key(map, cursor->key_pos);
-		if (key == NULL) {
+		const struct fw_state_key_hdr *hdr =
+			(const struct fw_state_key_hdr *)key;
+		uint64_t ttl = fwstate_entry_ttl(
+			hdr->proto, value->flags.raw, &cursor->timeouts
+		);
+		bool expired = (value->updated_at + ttl <= now);
+
+		if (!cursor->include_expired && expired) {
 			cursor->key_pos++;
 			continue;
 		}
@@ -155,17 +159,20 @@ fwstate_cursor_read_backward(
 			continue;
 		}
 
-		// Check expiration
-		uint64_t ttl = fwstate_entry_ttl(value, &cursor->timeouts);
-		bool expired = (value->updated_at + ttl <= now);
-
-		if (!cursor->include_expired && expired) {
+		void *key = fwmap_get_key(map, (uint32_t)pos);
+		if (key == NULL) {
 			pos--;
 			continue;
 		}
 
-		void *key = fwmap_get_key(map, (uint32_t)pos);
-		if (key == NULL) {
+		const struct fw_state_key_hdr *hdr =
+			(const struct fw_state_key_hdr *)key;
+		uint64_t ttl = fwstate_entry_ttl(
+			hdr->proto, value->flags.raw, &cursor->timeouts
+		);
+		bool expired = (value->updated_at + ttl <= now);
+
+		if (!cursor->include_expired && expired) {
 			pos--;
 			continue;
 		}

--- a/lib/fwstate/lookup.c
+++ b/lib/fwstate/lookup.c
@@ -55,17 +55,18 @@ fwstate_build_state_key_v4(
 		mbuf, struct rte_ipv4_hdr *, packet->network_header.offset
 	);
 
-	key->proto = ipv4_hdr->next_proto_id;
-	key->_ = 0;
+	key->hdr.proto = ipv4_hdr->next_proto_id;
 	// Swap src/dst addresses to match initial 5-tuple stored in state
 	key->src_addr = ipv4_hdr->dst_addr;
 	key->dst_addr = ipv4_hdr->src_addr;
 
 	// Extract and swap src/dst ports
 	uint16_t src_port, dst_port;
-	fwstate_extract_ports(mbuf, packet, key->proto, &src_port, &dst_port);
-	key->src_port = dst_port; // little-endian
-	key->dst_port = src_port; // little-endian
+	fwstate_extract_ports(
+		mbuf, packet, key->hdr.proto, &src_port, &dst_port
+	);
+	key->hdr.src_port = dst_port; // little-endian
+	key->hdr.dst_port = src_port; // little-endian
 }
 
 /**
@@ -80,16 +81,18 @@ fwstate_build_state_key_v6(
 		mbuf, struct rte_ipv6_hdr *, packet->network_header.offset
 	);
 
-	key->proto = ipv6_hdr->proto;
+	key->hdr.proto = ipv6_hdr->proto;
 	// Swap src/dst addresses to match initial 5-tuple stored in state
 	rte_memcpy(key->src_addr, ipv6_hdr->dst_addr, 16);
 	rte_memcpy(key->dst_addr, ipv6_hdr->src_addr, 16);
 
 	// Extract and swap src/dst ports
 	uint16_t src_port, dst_port;
-	fwstate_extract_ports(mbuf, packet, key->proto, &src_port, &dst_port);
-	key->src_port = dst_port; // little-endian
-	key->dst_port = src_port; // little-endian
+	fwstate_extract_ports(
+		mbuf, packet, key->hdr.proto, &src_port, &dst_port
+	);
+	key->hdr.src_port = dst_port; // little-endian
+	key->hdr.dst_port = src_port; // little-endian
 }
 
 /**

--- a/lib/fwstate/ops.h
+++ b/lib/fwstate/ops.h
@@ -56,8 +56,6 @@ fwmap_merge_value_fwstate(
 
 	// Update
 	d->external = new_v->external;
-	d->type = new_v->type;
-	d->packets_since_last_sync = new_v->packets_since_last_sync;
 	d->updated_at = new_v->updated_at;
 	// preserve oldest created_at
 	d->created_at = old_v->created_at;
@@ -77,9 +75,10 @@ fwmap_fw4_key_equal(const void *a, const void *b, size_t size) {
 	const struct fw4_state_key *k1 = (const struct fw4_state_key *)a;
 	const struct fw4_state_key *k2 = (const struct fw4_state_key *)b;
 
-	return k1->proto == k2->proto && k1->src_port == k2->src_port &&
-	       k1->dst_port == k2->dst_port && k1->src_addr == k2->src_addr &&
-	       k1->dst_addr == k2->dst_addr;
+	return k1->hdr.proto == k2->hdr.proto &&
+	       k1->hdr.src_port == k2->hdr.src_port &&
+	       k1->hdr.dst_port == k2->hdr.dst_port &&
+	       k1->src_addr == k2->src_addr && k1->dst_addr == k2->dst_addr;
 }
 
 static inline bool
@@ -94,7 +93,8 @@ fwmap_fw6_key_equal(const void *a, const void *b, size_t size) {
 	const uint64_t *dst1 = (const uint64_t *)k1->dst_addr;
 	const uint64_t *dst2 = (const uint64_t *)k2->dst_addr;
 
-	return k1->proto == k2->proto && k1->src_port == k2->src_port &&
-	       k1->dst_port == k2->dst_port && src1[0] == src2[0] &&
+	return k1->hdr.proto == k2->hdr.proto &&
+	       k1->hdr.src_port == k2->hdr.src_port &&
+	       k1->hdr.dst_port == k2->hdr.dst_port && src1[0] == src2[0] &&
 	       src1[1] == src2[1] && dst1[0] == dst2[0] && dst1[1] == dst2[1];
 }

--- a/lib/fwstate/types.h
+++ b/lib/fwstate/types.h
@@ -10,21 +10,27 @@
 #define FW_STATE_SYNC_THRESHOLD (uint64_t)8e9 // nanoseconds
 #define FW_STATE_DEFAULT_TIMEOUT (uint64_t)120e9
 
-struct fw4_state_key {
+/**
+ * Common header shared by all fw_state key types.
+ * Must be the first member so that any key pointer can be safely cast
+ * to fw_state_key_hdr to access the 5-tuple transport fields.
+ */
+struct fw_state_key_hdr {
 	uint16_t proto;
 	uint16_t src_port;
 	uint16_t dst_port;
-	uint16_t _;
+	uint16_t _; // padding to align addresses on u64 boundary
+};
+
+struct fw4_state_key {
+	struct fw_state_key_hdr hdr;
 	uint32_t src_addr;
 	uint32_t dst_addr;
 };
 
 // FIXME: ensure that during map allocations keys are aligned on u64 boundary
 struct fw6_state_key {
-	uint16_t proto;
-	uint16_t src_port;
-	uint16_t dst_port;
-	uint16_t _; // Align stride addr and src/dst addrs on u64 boundary
+	struct fw_state_key_hdr hdr;
 	uint8_t src_addr[16];
 	uint8_t dst_addr[16];
 };
@@ -63,6 +69,16 @@ fwstate_flags_from_tcp(uint8_t tcp_flags) {
 	return (tcp_flags & 7) | ((tcp_flags >> 1) & FWSTATE_ACK);
 }
 
+/**
+ * Per-connection TCP flag pair stored as a single byte.
+ *
+ * Layout (LSB first):
+ *   bits [3:0] — src flags  (raw & 0x0F)
+ *   bits [7:4] — dst flags  ((raw >> 4) & 0x0F)
+ *
+ * Each 4-bit nibble uses the fw_state_tcp_flags encoding:
+ *   FIN = 0x01, SYN = 0x02, RST = 0x04, ACK = 0x08
+ */
 struct fw_state_flags {
 	uint8_t src : 4;
 	uint8_t dst : 4;
@@ -79,10 +95,8 @@ union fw_state_flags_u {
  */
 struct fw_state_value {
 	bool external; // State ownership (internal/external)
-	uint8_t type;  // Transport protocol type (TCP/UDP)
 	union fw_state_flags_u flags;
-	// Number of packets since last sync
-	uint32_t packets_since_last_sync;
+	uint8_t _pad[6];
 	// Timestamp when the state was created
 	uint64_t created_at;
 	// Timestamp when the last sync packet was emitted

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -1,5 +1,9 @@
 use core::error::Error;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::{
+    fmt,
+    net::{Ipv4Addr, Ipv6Addr},
+    time::{Duration, UNIX_EPOCH},
+};
 
 use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
@@ -8,6 +12,7 @@ use fwstatepb::{
     DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
     ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
 };
+use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::codec::CompressionEncoding;
@@ -216,7 +221,7 @@ impl FWStateService {
             layer_index: cmd.layer,
             include_expired: cmd.include_expired,
             direction: direction as i32,
-            count: cmd.batch,
+            batch_size: cmd.batch,
             index: cmd.index,
         };
         tx.send(initial_req).await.map_err(|e| format!("send error: {e}"))?;
@@ -229,8 +234,8 @@ impl FWStateService {
 
         if !json_output {
             println!(
-                "{:<6} {:<45} {:<45} {:<8} {:<8} {:<7}",
-                "IDX", "SRC", "DST", "PROTO", "STATE", "EXPRD"
+                "{:<6} {:<45} {:<45} {:<8} {:<9} {:<7}",
+                "IDX", "SRC", "DST", "PROTO", "FLAGS S|D", "EXPRD"
             );
         }
 
@@ -245,7 +250,8 @@ impl FWStateService {
                     break;
                 }
                 if json_output {
-                    println!("{}", serde_json::to_string(&entry)?);
+                    let je = JsonEntry::from_entry(entry, cmd.ipv6);
+                    println!("{}", serde_json::to_string(&je)?);
                 } else {
                     print_entry(entry, cmd.ipv6);
                 }
@@ -266,7 +272,7 @@ impl FWStateService {
                 layer_index: cmd.layer,
                 include_expired: cmd.include_expired,
                 direction: direction as i32,
-                count: cmd.batch,
+                batch_size: cmd.batch,
                 index: resp.index,
             };
             tx.send(next_req).await.map_err(|e| format!("send error: {e}"))?;
@@ -276,7 +282,7 @@ impl FWStateService {
     }
 }
 
-fn format_addr(addr: &Option<fwstatepb::Addr>, is_ipv6: bool) -> String {
+fn format_addr(addr: Option<&fwstatepb::Addr>, is_ipv6: bool) -> String {
     match addr {
         Some(a) if is_ipv6 && a.bytes.len() == 16 => {
             let octets: [u8; 16] = a.bytes[..16].try_into().unwrap();
@@ -290,21 +296,155 @@ fn format_addr(addr: &Option<fwstatepb::Addr>, is_ipv6: bool) -> String {
     }
 }
 
-fn proto_name(proto: u32) -> &'static str {
+/// Format IANA protocol number as a human-readable name.
+/// See: https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml
+fn format_proto(proto: u32) -> String {
     match proto {
-        6 => "TCP",
-        17 => "UDP",
-        1 => "ICMP",
-        58 => "ICMPv6",
-        _ => "OTHER",
+        1 => "ICMP".into(),
+        4 => "IPv4".into(),
+        6 => "TCP".into(),
+        17 => "UDP".into(),
+        41 => "IPv6".into(),
+        47 => "GRE".into(),
+        58 => "ICMPv6".into(),
+        132 => "SCTP".into(),
+        _ => proto.to_string(),
+    }
+}
+
+/// Decoded TCP flags for a single direction (4-bit nibble).
+///
+/// Bit layout (from [`lib/fwstate/types.h`]):
+///   - 0x01 = FIN
+///   - 0x02 = SYN
+///   - 0x04 = RST
+///   - 0x08 = ACK
+struct TcpNibble(u8);
+
+const TCP_FLAG_TABLE: [(u8, char, &str); 4] = [
+    (0x08, 'A', "ACK"),
+    (0x02, 'S', "SYN"),
+    (0x04, 'R', "RST"),
+    (0x01, 'F', "FIN"),
+];
+
+impl TcpNibble {
+    fn names(&self) -> Vec<&'static str> {
+        TCP_FLAG_TABLE
+            .iter()
+            .filter(|(mask, _, _)| self.0 & mask != 0)
+            .map(|(_, _, name)| *name)
+            .collect()
+    }
+}
+
+impl fmt::Display for TcpNibble {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (mask, ch, _) in TCP_FLAG_TABLE {
+            if self.0 & mask != 0 {
+                write!(f, "{ch}")?;
+            } else {
+                f.write_str("-")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Firewall state flags byte containing src (lower nibble) and dst
+/// (upper nibble) TCP flag sets.
+///
+/// The raw byte is stored in `fw_state_value.flags` and transmitted
+/// via protobuf as `FwStateValue.flags`.
+/// See `struct fw_state_flags` (from `lib/fwstate/types.h`)
+struct FwStateFlags(u32);
+
+impl FwStateFlags {
+    fn src(&self) -> TcpNibble {
+        TcpNibble((self.0 & 0x0f) as u8)
+    }
+
+    fn dst(&self) -> TcpNibble {
+        TcpNibble(((self.0 >> 4) & 0x0f) as u8)
+    }
+}
+
+impl fmt::Display for FwStateFlags {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}|{}", self.src(), self.dst())
+    }
+}
+
+/// Flat JSON representation of a firewall state entry.
+#[derive(Serialize)]
+struct JsonEntry {
+    idx: u32,
+    expired: bool,
+    src_port: u32,
+    dst_port: u32,
+    src_addr: String,
+    dst_addr: String,
+    proto: String,
+    origin: &'static str,
+    flags: SrcDstFlags,
+    packets: SrcDstPackets,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Serialize)]
+struct SrcDstFlags {
+    src: Vec<&'static str>,
+    dst: Vec<&'static str>,
+}
+
+#[derive(Serialize)]
+struct SrcDstPackets {
+    src: u64,
+    dst: u64,
+}
+
+impl JsonEntry {
+    fn from_entry(entry: &fwstatepb::FwStateEntry, is_ipv6: bool) -> Self {
+        let key = entry.key.as_ref();
+        let val = entry.value.as_ref();
+        let flags = FwStateFlags(val.map(|v| v.flags).unwrap_or(0));
+        let external = val.map(|v| v.external).unwrap_or(false);
+
+        Self {
+            idx: entry.idx,
+            expired: entry.expired,
+            src_port: key.map(|k| k.src_port).unwrap_or(0),
+            dst_port: key.map(|k| k.dst_port).unwrap_or(0),
+            src_addr: format_addr(key.and_then(|k| k.src_addr.as_ref()), is_ipv6),
+            dst_addr: format_addr(key.and_then(|k| k.dst_addr.as_ref()), is_ipv6),
+            proto: format_proto(key.map(|k| k.proto).unwrap_or(0)),
+            origin: if external { "external" } else { "local" },
+            flags: SrcDstFlags {
+                src: flags.src().names(),
+                dst: flags.dst().names(),
+            },
+            packets: SrcDstPackets {
+                src: val.map(|v| v.packets_forward).unwrap_or(0),
+                dst: val.map(|v| v.packets_backward).unwrap_or(0),
+            },
+            created_at: humantime::format_rfc3339(
+                UNIX_EPOCH + Duration::from_nanos(val.map(|v| v.created_at).unwrap_or(0)),
+            )
+            .to_string(),
+            updated_at: humantime::format_rfc3339(
+                UNIX_EPOCH + Duration::from_nanos(val.map(|v| v.updated_at).unwrap_or(0)),
+            )
+            .to_string(),
+        }
     }
 }
 
 fn print_entry(entry: &fwstatepb::FwStateEntry, is_ipv6: bool) {
     let (src_addr, dst_addr, src_port, dst_port, proto) = match &entry.key {
         Some(k) => (
-            format_addr(&k.src_addr, is_ipv6),
-            format_addr(&k.dst_addr, is_ipv6),
+            format_addr(k.src_addr.as_ref(), is_ipv6),
+            format_addr(k.dst_addr.as_ref(), is_ipv6),
             k.src_port,
             k.dst_port,
             k.proto,
@@ -312,19 +452,18 @@ fn print_entry(entry: &fwstatepb::FwStateEntry, is_ipv6: bool) {
         None => ("?".into(), "?".into(), 0, 0, 0),
     };
 
-    let proto_type = entry.value.as_ref().map(|v| v.protocol_type).unwrap_or(proto);
     let flags = entry.value.as_ref().map(|v| v.flags).unwrap_or(0);
 
     let src = format!("{}:{}", src_addr, src_port);
     let dst = format!("{}:{}", dst_addr, dst_port);
 
     println!(
-        "{:<6} {:<45} {:<45} {:<8} {:<8} {:<7}",
+        "{:<6} {:<45} {:<45} {:<8} {:<9} {:<7}",
         entry.idx,
         src,
         dst,
-        proto_name(proto_type),
-        format!("0x{:02x}", flags),
+        format_proto(proto),
+        FwStateFlags(flags),
         if entry.expired { "yes" } else { "no" },
     );
 }

--- a/modules/fwstate/controlplane/ffi.go
+++ b/modules/fwstate/controlplane/ffi.go
@@ -324,20 +324,19 @@ func (m *FwStateConfig) readEntries(
 	for i := range n {
 		entry := buf[i]
 		val := (*C.struct_fw_state_value)(entry.value)
+		hdr := (*C.struct_fw_state_key_hdr)(entry.key)
 
-		ttl := C.fwstate_entry_ttl(val, &cursor.timeouts)
+		ttl := C.fwstate_entry_ttl(hdr.proto, C.uint8_t(val.flags[0]), &cursor.timeouts)
 		expired := val.updated_at+ttl <= C.uint64_t(now)
 
 		pbKey := convertCKey(entry.key, isIPv6)
 		pbVal := &fwstatepb.FwStateValue{
-			External:             bool(val.external),
-			ProtocolType:         uint32(val._type),
-			Flags:                uint32(val.flags[0]),
-			PacketsSinceLastSync: uint32(val.packets_since_last_sync),
-			CreatedAt:            uint64(val.created_at),
-			UpdatedAt:            uint64(val.updated_at),
-			PacketsBackward:      uint64(val.packets_backward),
-			PacketsForward:       uint64(val.packets_forward),
+			External:        bool(val.external),
+			Flags:           uint32(val.flags[0]),
+			CreatedAt:       uint64(val.created_at),
+			UpdatedAt:       uint64(val.updated_at),
+			PacketsBackward: uint64(val.packets_backward),
+			PacketsForward:  uint64(val.packets_forward),
 		}
 
 		entries = append(entries, CursorEntry{
@@ -371,9 +370,9 @@ func convertCKey(ptr unsafe.Pointer, isIPv6 bool) *fwstatepb.FwStateKey {
 		srcAddr := C.GoBytes(unsafe.Pointer(&k.src_addr[0]), 16)
 		dstAddr := C.GoBytes(unsafe.Pointer(&k.dst_addr[0]), 16)
 		return &fwstatepb.FwStateKey{
-			Proto:   uint32(k.proto),
-			SrcPort: uint32(k.src_port),
-			DstPort: uint32(k.dst_port),
+			Proto:   uint32(k.hdr.proto),
+			SrcPort: uint32(k.hdr.src_port),
+			DstPort: uint32(k.hdr.dst_port),
 			SrcAddr: &fwstatepb.Addr{Bytes: srcAddr},
 			DstAddr: &fwstatepb.Addr{Bytes: dstAddr},
 		}
@@ -385,9 +384,9 @@ func convertCKey(ptr unsafe.Pointer, isIPv6 bool) *fwstatepb.FwStateKey {
 	*(*uint32)(unsafe.Pointer(&srcAddr[0])) = uint32(k.src_addr)
 	*(*uint32)(unsafe.Pointer(&dstAddr[0])) = uint32(k.dst_addr)
 	return &fwstatepb.FwStateKey{
-		Proto:   uint32(k.proto),
-		SrcPort: uint32(k.src_port),
-		DstPort: uint32(k.dst_port),
+		Proto:   uint32(k.hdr.proto),
+		SrcPort: uint32(k.hdr.src_port),
+		DstPort: uint32(k.hdr.dst_port),
 		SrcAddr: &fwstatepb.Addr{Bytes: srcAddr},
 		DstAddr: &fwstatepb.Addr{Bytes: dstAddr},
 	}

--- a/modules/fwstate/controlplane/fwstatepb/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/fwstate.proto
@@ -108,13 +108,11 @@ message FwStateKey {
 
 message FwStateValue {
 	bool external = 1;
-	uint32 protocol_type = 2; // IPPROTO_TCP, IPPROTO_UDP, etc.
-	uint32 flags = 3;	  // raw fw_state_flags_u byte
-	uint32 packets_since_last_sync = 4;
-	uint64 created_at = 5; // nanoseconds
-	uint64 updated_at = 6; // nanoseconds
-	uint64 packets_backward = 7;
-	uint64 packets_forward = 8;
+	uint32 flags = 2;      // raw fw_state_flags_u byte
+	uint64 created_at = 3; // nanoseconds
+	uint64 updated_at = 4; // nanoseconds
+	uint64 packets_backward = 5;
+	uint64 packets_forward = 6;
 }
 
 message FwStateEntry {
@@ -130,7 +128,7 @@ message ListEntriesRequest {
 	uint32 layer_index = 3;	  // Which layer to iterate (0 = active)
 	bool include_expired = 4; // Whether to include expired entries
 	Direction direction = 5;  // Direction for this read
-	uint32 count = 6;	  // Number of entries to return in this batch
+	uint32 batch_size = 6;	  // Number of entries to return in this batch
 	uint32 index = 7; // Cursor position from previous response (0 on first)
 }
 

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -390,7 +390,7 @@ func (m *FWStateService) ListEntries(
 			return status.Error(codes.InvalidArgument, "config_name is required")
 		}
 
-		count := req.GetCount()
+		count := req.GetBatchSize()
 		if count == 0 {
 			count = 100
 		}

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -101,9 +101,7 @@ fwstate_build_value(
 ) {
 	struct fwstate state = {
 		.value.external = is_external,
-		.value.type = sync_frame->proto,
 		.value.flags = sync_frame->flags,
-		.value.packets_since_last_sync = 0,
 		.value.created_at =
 			now, // tentative; may be overwritten during map insert
 		.value.updated_at = now,
@@ -153,10 +151,9 @@ fwstate_process_sync_v4(
 	struct fwstate_timeouts *timeouts
 ) {
 	struct fw4_state_key key = {
-		.proto = sync_frame->proto,
-		.src_port = sync_frame->src_port,
-		.dst_port = sync_frame->dst_port,
-		._ = 0,
+		.hdr.proto = sync_frame->proto,
+		.hdr.src_port = sync_frame->src_port,
+		.hdr.dst_port = sync_frame->dst_port,
 		.src_addr = sync_frame->src_ip,
 		.dst_addr = sync_frame->dst_ip,
 	};
@@ -193,9 +190,9 @@ fwstate_process_sync_v6(
 	struct fwstate_timeouts *timeouts
 ) {
 	struct fw6_state_key key = {
-		.proto = sync_frame->proto,
-		.src_port = sync_frame->src_port,
-		.dst_port = sync_frame->dst_port,
+		.hdr.proto = sync_frame->proto,
+		.hdr.src_port = sync_frame->src_port,
+		.hdr.dst_port = sync_frame->dst_port,
 	};
 	rte_memcpy(key.src_addr, sync_frame->src_ip6, 16);
 	rte_memcpy(key.dst_addr, sync_frame->dst_ip6, 16);

--- a/modules/fwstate/tests/dataplane/cursor_test.go
+++ b/modules/fwstate/tests/dataplane/cursor_test.go
@@ -45,7 +45,7 @@ func TestCursorForwardRead(t *testing.T) {
 		err := insertFw4Entry(cpModule,
 			protoTCP, uint16(1000+i), 80,
 			ipToUint32("10.0.0.1"), ipToUint32("192.168.0.1"),
-			uint8(protoTCP), flagACK, flagACK,
+			flagACK, flagACK,
 			now, now,
 		)
 		require.NoError(t, err, "insert entry %d", i)
@@ -78,7 +78,7 @@ func TestCursorBackwardRead(t *testing.T) {
 		err := insertFw4Entry(cpModule,
 			protoTCP, uint16(2000+i), 443,
 			ipToUint32("10.0.0.1"), ipToUint32("192.168.0.2"),
-			uint8(protoTCP), flagACK, flagACK,
+			flagACK, flagACK,
 			now, now,
 		)
 		require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestCursorExpiredFiltering(t *testing.T) {
 	err := insertFw4Entry(cpModule,
 		protoTCP, 3000, 80,
 		ipToUint32("10.0.0.1"), ipToUint32("192.168.0.1"),
-		uint8(protoTCP), flagACK, flagACK,
+		flagACK, flagACK,
 		now, now,
 	)
 	require.NoError(t, err)
@@ -117,7 +117,7 @@ func TestCursorExpiredFiltering(t *testing.T) {
 	err = insertFw4Entry(cpModule,
 		protoUDP, 3001, 53,
 		ipToUint32("10.0.0.2"), ipToUint32("192.168.0.1"),
-		uint8(protoUDP), 0, 0,
+		0, 0,
 		now, now,
 	)
 	require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestCursorExpiredFiltering(t *testing.T) {
 	err = insertFw4Entry(cpModule,
 		protoTCP, 3002, 443,
 		ipToUint32("10.0.0.3"), ipToUint32("192.168.0.1"),
-		uint8(protoTCP), flagACK, flagACK,
+		flagACK, flagACK,
 		now, now,
 	)
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestCursorExpiredFiltering(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, results, 2)
 	for _, r := range results {
-		require.Equal(t, uint8(protoTCP), r.Type)
+		require.Equal(t, uint16(protoTCP), r.Proto)
 	}
 
 	// With include_expired=true, should return all 3.
@@ -165,7 +165,7 @@ func TestCursorKeyDataCorrectness(t *testing.T) {
 	err := insertFw4Entry(cpModule,
 		protoTCP, 12345, 8080,
 		srcAddr, dstAddr,
-		uint8(protoTCP), flagSYN, 0,
+		flagSYN, 0,
 		now, now,
 	)
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestCursorValueDataCorrectness(t *testing.T) {
 	err := insertFw4Entry(cpModule,
 		protoTCP, 9000, 80,
 		ipToUint32("10.0.0.1"), ipToUint32("192.168.0.1"),
-		uint8(protoTCP), flagACK, flagACK,
+		flagACK, flagACK,
 		now-1000, now,
 	)
 	require.NoError(t, err)
@@ -206,7 +206,6 @@ func TestCursorValueDataCorrectness(t *testing.T) {
 	require.Len(t, results, 1)
 
 	r := results[0]
-	require.Equal(t, uint8(protoTCP), r.Type)
 	require.Equal(t, uint64(now), r.UpdatedAt)
 	require.Equal(t, uint64(1), r.PktForward)
 	require.Equal(t, uint64(0), r.PktBackward)
@@ -238,7 +237,7 @@ func TestCursorPaging(t *testing.T) {
 		err := insertFw4Entry(cpModule,
 			protoTCP, uint16(6000+i), 80,
 			ipToUint32("10.0.0.1")+uint32(i), ipToUint32("192.168.0.1"),
-			uint8(protoTCP), flagACK, flagACK,
+			flagACK, flagACK,
 			now, now,
 		)
 		require.NoError(t, err)

--- a/modules/fwstate/tests/dataplane/cursor_test_helper.go
+++ b/modules/fwstate/tests/dataplane/cursor_test_helper.go
@@ -24,7 +24,6 @@ type CursorResult struct {
 	DstPort  uint16
 	SrcAddr  uint32
 	DstAddr  uint32
-	Type     uint8
 	Flags    uint8
 	External bool
 
@@ -40,7 +39,7 @@ func insertFw4Entry(
 	cpModule *C.struct_cp_module,
 	proto uint16, srcPort uint16, dstPort uint16,
 	srcAddr uint32, dstAddr uint32,
-	valueType uint8, srcFlags uint8, dstFlags uint8,
+	srcFlags uint8, dstFlags uint8,
 	createdAt uint64, updatedAt uint64,
 ) error {
 	// Resolve the active IPv4 map (layer 0)
@@ -50,14 +49,13 @@ func insertFw4Entry(
 	}
 
 	var key C.struct_fw4_state_key
-	key.proto = C.uint16_t(proto)
-	key.src_port = C.uint16_t(srcPort)
-	key.dst_port = C.uint16_t(dstPort)
+	key.hdr.proto = C.uint16_t(proto)
+	key.hdr.src_port = C.uint16_t(srcPort)
+	key.hdr.dst_port = C.uint16_t(dstPort)
 	key.src_addr = C.uint32_t(srcAddr)
 	key.dst_addr = C.uint32_t(dstAddr)
 
 	var val C.struct_fw_state_value
-	val._type = C.uint8_t(valueType)
 	val.flags[0] = byte(srcFlags | (dstFlags << 4))
 	val.external = C.bool(false)
 	val.created_at = C.uint64_t(createdAt)
@@ -109,12 +107,11 @@ func readCursorForward(
 
 		results = append(results, CursorResult{
 			Idx:         uint32(entry.idx),
-			Proto:       uint16(k.proto),
-			SrcPort:     uint16(k.src_port),
-			DstPort:     uint16(k.dst_port),
+			Proto:       uint16(k.hdr.proto),
+			SrcPort:     uint16(k.hdr.src_port),
+			DstPort:     uint16(k.hdr.dst_port),
 			SrcAddr:     uint32(k.src_addr),
 			DstAddr:     uint32(k.dst_addr),
-			Type:        uint8(v._type),
 			Flags:       uint8(v.flags[0]),
 			External:    bool(v.external),
 			CreatedAt:   uint64(v.created_at),
@@ -162,12 +159,11 @@ func readCursorBackward(
 
 		results = append(results, CursorResult{
 			Idx:         uint32(entry.idx),
-			Proto:       uint16(k.proto),
-			SrcPort:     uint16(k.src_port),
-			DstPort:     uint16(k.dst_port),
+			Proto:       uint16(k.hdr.proto),
+			SrcPort:     uint16(k.hdr.src_port),
+			DstPort:     uint16(k.hdr.dst_port),
 			SrcAddr:     uint32(k.src_addr),
 			DstAddr:     uint32(k.dst_addr),
-			Type:        uint8(v._type),
 			Flags:       uint8(v.flags[0]),
 			External:    bool(v.external),
 			CreatedAt:   uint64(v.created_at),

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -240,9 +240,9 @@ func CheckStateExists(
 		fwmap = (*C.fwmap_t)(C.addr_of((*unsafe.Pointer)(unsafe.Pointer(&cfg.fw6state))))
 		key6 := C.struct_fw6_state_key{}
 
-		key6.proto = C.uint16_t(proto)
-		key6.src_port = C.uint16_t(srcPort)
-		key6.dst_port = C.uint16_t(dstPort)
+		key6.hdr.proto = C.uint16_t(proto)
+		key6.hdr.src_port = C.uint16_t(srcPort)
+		key6.hdr.dst_port = C.uint16_t(dstPort)
 
 		// Copy addresses using unsafe.Slice (addresses stay in network order)
 		srcBytes := srcIP.As16()
@@ -259,9 +259,9 @@ func CheckStateExists(
 		fwmap = (*C.fwmap_t)(C.addr_of((*unsafe.Pointer)(unsafe.Pointer(&cfg.fw4state))))
 		key4 := C.struct_fw4_state_key{}
 
-		key4.proto = C.uint16_t(proto)
-		key4.src_port = C.uint16_t(srcPort)
-		key4.dst_port = C.uint16_t(dstPort)
+		key4.hdr.proto = C.uint16_t(proto)
+		key4.hdr.src_port = C.uint16_t(srcPort)
+		key4.hdr.dst_port = C.uint16_t(dstPort)
 
 		// Copy addresses using unsafe.Slice (addresses stay in network order)
 		srcBytes := srcIP.As4()
@@ -324,9 +324,9 @@ func GetStateDeadline(
 	if srcIP.Is6() && dstIP.Is6() {
 		fwmap = (*C.fwmap_t)(C.addr_of((*unsafe.Pointer)(unsafe.Pointer(&cfg.fw6state))))
 		key6 := C.struct_fw6_state_key{}
-		key6.proto = C.uint16_t(proto)
-		key6.src_port = C.uint16_t(srcPort)
-		key6.dst_port = C.uint16_t(dstPort)
+		key6.hdr.proto = C.uint16_t(proto)
+		key6.hdr.src_port = C.uint16_t(srcPort)
+		key6.hdr.dst_port = C.uint16_t(dstPort)
 
 		srcBytes := srcIP.As16()
 		dstBytes := dstIP.As16()
@@ -341,9 +341,9 @@ func GetStateDeadline(
 		cfgReal := (*C.struct_fwstate_config)(C.addr_of((*unsafe.Pointer)(unsafe.Pointer(cfg))))
 		fwmap = (*C.fwmap_t)(C.addr_of((*unsafe.Pointer)(unsafe.Pointer(&cfgReal.fw4state))))
 		key4 := C.struct_fw4_state_key{}
-		key4.proto = C.uint16_t(proto)
-		key4.src_port = C.uint16_t(srcPort)
-		key4.dst_port = C.uint16_t(dstPort)
+		key4.hdr.proto = C.uint16_t(proto)
+		key4.hdr.src_port = C.uint16_t(srcPort)
+		key4.hdr.dst_port = C.uint16_t(dstPort)
 
 		srcBytes := srcIP.As4()
 		dstBytes := dstIP.As4()

--- a/tests/functional/main/fwstate_test.go
+++ b/tests/functional/main/fwstate_test.go
@@ -2,6 +2,7 @@ package functional
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -19,9 +20,9 @@ var expectedEntries = []struct {
 	proto string
 	flags string
 }{
-	{"192.0.2.10:10000", "192.0.3.1:80", "TCP", "0x02"},
-	{"192.0.2.11:10001", "192.0.3.1:80", "TCP", "0x02"},
-	{"192.0.2.12:10002", "192.0.3.1:80", "TCP", "0x02"},
+	{"192.0.2.10:10000", "192.0.3.1:80", "TCP", "-S--|----"},
+	{"192.0.2.11:10001", "192.0.3.1:80", "TCP", "-S--|----"},
+	{"192.0.2.12:10002", "192.0.3.1:80", "TCP", "-S--|----"},
 }
 
 func TestFWStateListEntries(t *testing.T) {
@@ -90,7 +91,7 @@ func TestFWStateListEntries(t *testing.T) {
 			require.Contains(t, output, e.dst, "should contain destination %s", e.dst)
 		}
 		require.Contains(t, output, "TCP")
-		require.Contains(t, output, "0x02")
+		require.Contains(t, output, "-S--|----")
 	})
 
 	// 5. Forward listing with JSON: parse and verify key fields.
@@ -101,26 +102,22 @@ func TestFWStateListEntries(t *testing.T) {
 		require.NoError(t, err, "list-entries forward json failed")
 		t.Log("JSON output:\n", output)
 
-		type jsonKey struct {
-			Proto   int `json:"proto"`
-			SrcPort int `json:"src_port"`
-			DstPort int `json:"dst_port"`
-			SrcAddr struct {
-				Bytes []int `json:"bytes"`
-			} `json:"src_addr"`
-			DstAddr struct {
-				Bytes []int `json:"bytes"`
-			} `json:"dst_addr"`
-		}
 		type jsonEntry struct {
-			Key   jsonKey `json:"key"`
-			Idx   int     `json:"idx"`
-			Value struct {
-				ProtocolType   int  `json:"protocol_type"`
-				Flags          int  `json:"flags"`
-				PacketsForward int  `json:"packets_forward"`
-				External       bool `json:"external"`
-			} `json:"value"`
+			Idx     int    `json:"idx"`
+			SrcPort int    `json:"src_port"`
+			DstPort int    `json:"dst_port"`
+			SrcAddr string `json:"src_addr"`
+			DstAddr string `json:"dst_addr"`
+			Proto   string `json:"proto"`
+			Origin  string `json:"origin"`
+			Flags   struct {
+				Src []string `json:"src"`
+				Dst []string `json:"dst"`
+			} `json:"flags"`
+			Packets struct {
+				Src int `json:"src"`
+				Dst int `json:"dst"`
+			} `json:"packets"`
 		}
 
 		var entries []jsonEntry
@@ -138,15 +135,16 @@ func TestFWStateListEntries(t *testing.T) {
 
 		for i, e := range entries {
 			require.Equal(t, i, e.Idx, "entry %d idx", i)
-			require.Equal(t, 6, e.Key.Proto, "entry %d proto should be TCP(6)", i)
-			require.Equal(t, 10000+i, e.Key.SrcPort, "entry %d src_port", i)
-			require.Equal(t, 80, e.Key.DstPort, "entry %d dst_port", i)
-			require.Equal(t, []int{192, 0, 2, 10 + i}, e.Key.SrcAddr.Bytes, "entry %d src_addr", i)
-			require.Equal(t, []int{192, 0, 3, 1}, e.Key.DstAddr.Bytes, "entry %d dst_addr", i)
-			require.Equal(t, 6, e.Value.ProtocolType, "entry %d protocol_type", i)
-			require.Equal(t, 2, e.Value.Flags, "entry %d flags should be SYN(0x02)", i)
-			require.Equal(t, 1, e.Value.PacketsForward, "entry %d packets_forward", i)
-			require.False(t, e.Value.External, "entry %d should not be external", i)
+			require.Equal(t, "TCP", e.Proto, "entry %d proto should be TCP", i)
+			require.Equal(t, 10000+i, e.SrcPort, "entry %d src_port", i)
+			require.Equal(t, 80, e.DstPort, "entry %d dst_port", i)
+			require.Equal(t, fmt.Sprintf("192.0.2.%d", 10+i), e.SrcAddr, "entry %d src_addr", i)
+			require.Equal(t, "192.0.3.1", e.DstAddr, "entry %d dst_addr", i)
+			require.Equal(t, "local", e.Origin, "entry %d origin should be local", i)
+			require.Equal(t, []string{"SYN"}, e.Flags.Src, "entry %d flags.src should be [SYN]", i)
+			require.Empty(t, e.Flags.Dst, "entry %d flags.dst should be empty", i)
+			require.Equal(t, 1, e.Packets.Src, "entry %d packets.src", i)
+			require.Equal(t, 0, e.Packets.Dst, "entry %d packets.dst", i)
 		}
 	})
 

--- a/tests/fwstate/fwstate_cursor_test.c
+++ b/tests/fwstate/fwstate_cursor_test.c
@@ -19,7 +19,7 @@
 #include <string.h>
 #include <sys/mman.h>
 
-#define ARENA_SIZE_MB 1024
+#define ARENA_SIZE_MB 64
 #define ARENA_SIZE ((1 << 20) * ARENA_SIZE_MB)
 #define DEFAULT_TTL 50000
 #define WORKER_ID 0
@@ -72,9 +72,9 @@ make_fw4_key(
 ) {
 	struct fw4_state_key key;
 	memset(&key, 0, sizeof(key));
-	key.proto = proto;
-	key.src_port = src_port;
-	key.dst_port = dst_port;
+	key.hdr.proto = proto;
+	key.hdr.src_port = src_port;
+	key.hdr.dst_port = dst_port;
 	key.src_addr = src_addr;
 	key.dst_addr = dst_addr;
 	return key;
@@ -85,7 +85,6 @@ make_fw4_key(
  */
 static struct fw_state_value
 make_fw_value(
-	uint8_t type,
 	uint8_t src_flags,
 	uint8_t dst_flags,
 	uint64_t created_at,
@@ -93,7 +92,6 @@ make_fw_value(
 ) {
 	struct fw_state_value val;
 	memset(&val, 0, sizeof(val));
-	val.type = type;
 	val.flags.tcp.src = src_flags;
 	val.flags.tcp.dst = dst_flags;
 	val.created_at = created_at;
@@ -122,44 +120,47 @@ static void
 test_ttl_selection(void) {
 	printf("\n--- TTL Selection Test ---\n");
 
-	struct fw_state_value v;
-	memset(&v, 0, sizeof(v));
+	union fw_state_flags_u flags;
+	memset(&flags, 0, sizeof(flags));
 
 	/* TCP SYN only */
-	v.type = IPPROTO_TCP;
-	v.flags.tcp.src = FWSTATE_SYN;
-	v.flags.tcp.dst = 0;
-	assert(fwstate_entry_ttl(&v, &test_timeouts) == test_timeouts.tcp_syn);
+	flags.tcp.src = FWSTATE_SYN;
+	flags.tcp.dst = 0;
+	assert(fwstate_entry_ttl(IPPROTO_TCP, flags.raw, &test_timeouts) ==
+	       test_timeouts.tcp_syn);
 
 	/* TCP SYN-ACK */
-	v.flags.tcp.src = FWSTATE_SYN;
-	v.flags.tcp.dst = FWSTATE_ACK;
-	assert(fwstate_entry_ttl(&v, &test_timeouts) ==
+	flags.tcp.src = FWSTATE_SYN;
+	flags.tcp.dst = FWSTATE_ACK;
+	assert(fwstate_entry_ttl(IPPROTO_TCP, flags.raw, &test_timeouts) ==
 	       test_timeouts.tcp_syn_ack);
 
 	/* TCP FIN (src side) */
-	v.flags.tcp.src = FWSTATE_FIN;
-	v.flags.tcp.dst = 0;
-	assert(fwstate_entry_ttl(&v, &test_timeouts) == test_timeouts.tcp_fin);
+	flags.tcp.src = FWSTATE_FIN;
+	flags.tcp.dst = 0;
+	assert(fwstate_entry_ttl(IPPROTO_TCP, flags.raw, &test_timeouts) ==
+	       test_timeouts.tcp_fin);
 
 	/* TCP FIN (dst side) */
-	v.flags.tcp.src = 0;
-	v.flags.tcp.dst = FWSTATE_FIN;
-	assert(fwstate_entry_ttl(&v, &test_timeouts) == test_timeouts.tcp_fin);
+	flags.tcp.src = 0;
+	flags.tcp.dst = FWSTATE_FIN;
+	assert(fwstate_entry_ttl(IPPROTO_TCP, flags.raw, &test_timeouts) ==
+	       test_timeouts.tcp_fin);
 
 	/* TCP established (no special flags) */
-	v.flags.tcp.src = FWSTATE_ACK;
-	v.flags.tcp.dst = FWSTATE_ACK;
-	assert(fwstate_entry_ttl(&v, &test_timeouts) == test_timeouts.tcp);
+	flags.tcp.src = FWSTATE_ACK;
+	flags.tcp.dst = FWSTATE_ACK;
+	assert(fwstate_entry_ttl(IPPROTO_TCP, flags.raw, &test_timeouts) ==
+	       test_timeouts.tcp);
 
 	/* UDP */
-	v.type = IPPROTO_UDP;
-	v.flags.raw = 0;
-	assert(fwstate_entry_ttl(&v, &test_timeouts) == test_timeouts.udp);
+	flags.raw = 0;
+	assert(fwstate_entry_ttl(IPPROTO_UDP, flags.raw, &test_timeouts) ==
+	       test_timeouts.udp);
 
 	/* Default (ICMP) */
-	v.type = IPPROTO_ICMP;
-	assert(fwstate_entry_ttl(&v, &test_timeouts) == test_timeouts.default_);
+	assert(fwstate_entry_ttl(IPPROTO_ICMP, flags.raw, &test_timeouts) ==
+	       test_timeouts.default_);
 
 	printf("  TTL selection test passed\n");
 }
@@ -230,9 +231,7 @@ test_forward_iteration(void *arena) {
 			0x0A000001 + (uint32_t)i,
 			0xC0A80001
 		);
-		vals[i] = make_fw_value(
-			IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now
-		);
+		vals[i] = make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 		int64_t ret = insert_fw4_entry(map, &keys[i], &vals[i]);
 		assert(ret >= 0);
 	}
@@ -252,9 +251,9 @@ test_forward_iteration(void *arena) {
 	for (int i = 0; i < 5; i++) {
 		assert(out[i].idx == (uint32_t)i);
 		struct fw4_state_key *k = (struct fw4_state_key *)out[i].key;
-		assert(k->src_port == (uint16_t)(1000 + i));
-		assert(k->dst_port == 80);
-		assert(k->proto == IPPROTO_TCP);
+		assert(k->hdr.src_port == (uint16_t)(1000 + i));
+		assert(k->hdr.dst_port == 80);
+		assert(k->hdr.proto == IPPROTO_TCP);
 	}
 
 	/* Cursor should advance to 5 */
@@ -294,9 +293,7 @@ test_backward_iteration(void *arena) {
 			0x0A000001 + (uint32_t)i,
 			0xC0A80002
 		);
-		vals[i] = make_fw_value(
-			IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now
-		);
+		vals[i] = make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 		int64_t ret = insert_fw4_entry(map, &keys[i], &vals[i]);
 		assert(ret >= 0);
 	}
@@ -316,7 +313,7 @@ test_backward_iteration(void *arena) {
 	for (int i = 0; i < 5; i++) {
 		assert(out[i].idx == (uint32_t)(4 - i));
 		struct fw4_state_key *k = (struct fw4_state_key *)out[i].key;
-		assert(k->src_port == (uint16_t)(2000 + 4 - i));
+		assert(k->hdr.src_port == (uint16_t)(2000 + 4 - i));
 	}
 
 	fwmap_destroy(map, ctx);
@@ -346,18 +343,18 @@ test_expired_skipped(void *arena) {
 	struct fw4_state_key k0 =
 		make_fw4_key(IPPROTO_TCP, 3000, 80, 0x0A000001, 0xC0A80001);
 	struct fw_state_value v0 =
-		make_fw_value(IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now);
+		make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 	assert(insert_fw4_entry(map, &k0, &v0) >= 0);
 
 	struct fw4_state_key k1 =
 		make_fw4_key(IPPROTO_UDP, 3001, 53, 0x0A000002, 0xC0A80001);
-	struct fw_state_value v1 = make_fw_value(IPPROTO_UDP, 0, 0, now, now);
+	struct fw_state_value v1 = make_fw_value(0, 0, now, now);
 	assert(insert_fw4_entry(map, &k1, &v1) >= 0);
 
 	struct fw4_state_key k2 =
 		make_fw4_key(IPPROTO_TCP, 3002, 443, 0x0A000003, 0xC0A80001);
 	struct fw_state_value v2 =
-		make_fw_value(IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now);
+		make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 	assert(insert_fw4_entry(map, &k2, &v2) >= 0);
 
 	/*
@@ -378,11 +375,10 @@ test_expired_skipped(void *arena) {
 		fwstate_cursor_read_forward(map, &cursor, read_now, out, 10);
 	assert(n == 2);
 
-	/* Both returned entries should be TCP */
+	/* Both returned entries should have keys with TCP proto */
 	for (int i = 0; i < 2; i++) {
-		struct fw_state_value *val =
-			(struct fw_state_value *)out[i].value;
-		assert(val->type == IPPROTO_TCP);
+		struct fw4_state_key *key = (struct fw4_state_key *)out[i].key;
+		assert(key->hdr.proto == IPPROTO_TCP);
 	}
 
 	fwmap_destroy(map, ctx);
@@ -412,18 +408,18 @@ test_include_expired(void *arena) {
 	struct fw4_state_key k0 =
 		make_fw4_key(IPPROTO_TCP, 4000, 80, 0x0A000001, 0xC0A80001);
 	struct fw_state_value v0 =
-		make_fw_value(IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now);
+		make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 	assert(insert_fw4_entry(map, &k0, &v0) >= 0);
 
 	struct fw4_state_key k1 =
 		make_fw4_key(IPPROTO_UDP, 4001, 53, 0x0A000002, 0xC0A80001);
-	struct fw_state_value v1 = make_fw_value(IPPROTO_UDP, 0, 0, now, now);
+	struct fw_state_value v1 = make_fw_value(0, 0, now, now);
 	assert(insert_fw4_entry(map, &k1, &v1) >= 0);
 
 	struct fw4_state_key k2 =
 		make_fw4_key(IPPROTO_TCP, 4002, 443, 0x0A000003, 0xC0A80001);
 	struct fw_state_value v2 =
-		make_fw_value(IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now);
+		make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 	assert(insert_fw4_entry(map, &k2, &v2) >= 0);
 
 	/* Advance time so UDP is expired */
@@ -468,19 +464,19 @@ test_uninitialized_skipped(void *arena) {
 	struct fw4_state_key k0 =
 		make_fw4_key(IPPROTO_TCP, 5000, 80, 0x0A000001, 0xC0A80001);
 	struct fw_state_value v0 =
-		make_fw_value(IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now);
+		make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 	assert(insert_fw4_entry(map, &k0, &v0) >= 0);
 
 	struct fw4_state_key k1 =
 		make_fw4_key(IPPROTO_TCP, 5001, 80, 0x0A000002, 0xC0A80001);
 	struct fw_state_value v1 =
-		make_fw_value(IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now);
+		make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 	assert(insert_fw4_entry(map, &k1, &v1) >= 0);
 
 	struct fw4_state_key k2 =
 		make_fw4_key(IPPROTO_TCP, 5002, 80, 0x0A000003, 0xC0A80001);
 	struct fw_state_value v2 =
-		make_fw_value(IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now);
+		make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 	assert(insert_fw4_entry(map, &k2, &v2) >= 0);
 
 	/* Zero out updated_at of middle entry to simulate uninitialized */
@@ -536,9 +532,8 @@ test_paging(void *arena) {
 			0x0A000001 + (uint32_t)i,
 			0xC0A80001
 		);
-		struct fw_state_value val = make_fw_value(
-			IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now
-		);
+		struct fw_state_value val =
+			make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 		assert(insert_fw4_entry(map, &key, &val) >= 0);
 	}
 
@@ -621,9 +616,8 @@ test_forward_bounds(void *arena) {
 			0x0A000001 + (uint32_t)i,
 			0xC0A80001
 		);
-		struct fw_state_value val = make_fw_value(
-			IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now
-		);
+		struct fw_state_value val =
+			make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 		assert(insert_fw4_entry(map, &key, &val) >= 0);
 	}
 
@@ -675,9 +669,8 @@ test_backward_clamping(void *arena) {
 			0x0A000001 + (uint32_t)i,
 			0xC0A80001
 		);
-		struct fw_state_value val = make_fw_value(
-			IPPROTO_TCP, FWSTATE_ACK, FWSTATE_ACK, now, now
-		);
+		struct fw_state_value val =
+			make_fw_value(FWSTATE_ACK, FWSTATE_ACK, now, now);
 		assert(insert_fw4_entry(map, &key, &val) >= 0);
 	}
 
@@ -702,8 +695,8 @@ test_backward_clamping(void *arena) {
 	/* Verify port values match expected reverse order */
 	struct fw4_state_key *k0 = (struct fw4_state_key *)out[0].key;
 	struct fw4_state_key *k2 = (struct fw4_state_key *)out[2].key;
-	assert(k0->src_port == 8002);
-	assert(k2->src_port == 8000);
+	assert(k0->hdr.src_port == 8002);
+	assert(k2->hdr.src_port == 8000);
 
 	fwmap_destroy(map, ctx);
 	verify_memory_leaks(ctx, "bwd_clamp");

--- a/tests/fwstate/layermap_test.c
+++ b/tests/fwstate/layermap_test.c
@@ -10,7 +10,7 @@
 #include <time.h>
 #include <unistd.h>
 
-#define ARENA_SIZE (1 << 20) * 500 // 500MB arena
+#define ARENA_SIZE (1 << 20) * 64 // MB arena
 volatile uint64_t now_time = 0;
 
 void


### PR DESCRIPTION
Structural changes:
- Extract fw_state_key_hdr (proto, src_port, dst_port) and embed it
  as the first member of fw4_state_key and fw6_state_key, enabling
  type-safe access to transport fields from a generic key pointer.
- Remove redundant fields from fw_state_value: type (duplicated
  key.proto), packets_since_last_sync (unused).
- Update fwstate_entry_ttl() to accept (proto, raw_flags) instead of
  the full value struct, decoupling TTL calculation from value layout.
- Rename ListEntriesRequest.count to batch_size in protobuf.
- Remove protocol_type and packets_since_last_sync from FwStateValue
  protobuf message, renumber fields.

CLI improvements:
- Display TCP flags as fixed-width ASRF|ASRF instead of hex, with
  FLAGS S|D column header.
- JSON output: flat structure with human-readable IP addresses,
  RFC 3339 timestamps, IANA protocol names, origin (local/external),
  decomposed flags {src, dst} and packets {src, dst}.
- Unknown protocol numbers rendered as their numeric value instead
  of "OTHER".

Update all C, Go, Rust code and tests accordingly.
