### PR TITLE
feat: used reattach for agents

### DIFF
--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -77,11 +77,25 @@ func (m *SharedMemory) AgentAttach(name string, instanceIdx uint32, size datasiz
 	return &Agent{name: name, ptr: ptr}, nil
 }
 
+// AgentReattach attaches a module agent to shared memory on the dataplane instance.
+// If Agent with such name already attached, it will be reattached to the same memory.
+func (m *SharedMemory) AgentReattach(name string, instanceIdx uint32, size datasize.ByteSize) (*Agent, error) {
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	ptr := C.agent_reattach(m.ptr, C.uint32_t(instanceIdx), cName, C.size_t(size))
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to attach agent: %s", name)
+	}
+
+	return &Agent{name: name, ptr: ptr}, nil
+}
+
 // AgentsAttach attaches agents to shared memory on the specified list of instances.
 func (m *SharedMemory) AgentsAttach(name string, instanceIndices []uint32, size datasize.ByteSize) ([]*Agent, error) {
 	agents := make([]*Agent, 0, len(instanceIndices))
 	for _, instanceIdx := range instanceIndices {
-		agent, err := m.AgentAttach(name, instanceIdx, size)
+		agent, err := m.AgentReattach(name, instanceIdx, size)
 		if err != nil {
 			return nil, fmt.Errorf("failed to connect to shared memory on instance %d: %w", instanceIdx, err)
 		}

--- a/controlplane/internal/gateway/function_service.go
+++ b/controlplane/internal/gateway/function_service.go
@@ -116,7 +116,7 @@ func (m *FunctionService) Update(
 ) (*ynpb.UpdateFunctionResponse, error) {
 	reqFunction := request.Function
 
-	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
+	agent, err := m.shm.AgentReattach(functionAgentName, m.instanceID, functionAgentMemory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to agent %q: %w", functionAgentName, err)
 	}
@@ -159,7 +159,7 @@ func (m *FunctionService) Delete(
 ) (*ynpb.DeleteFunctionResponse, error) {
 	functionName := request.Id.Name
 
-	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
+	agent, err := m.shm.AgentReattach(functionAgentName, m.instanceID, functionAgentMemory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to agent %q: %w", functionAgentName, err)
 	}

--- a/controlplane/internal/gateway/pipeline_service.go
+++ b/controlplane/internal/gateway/pipeline_service.go
@@ -100,7 +100,7 @@ func (m *PipelineService) Update(
 	ctx context.Context,
 	request *ynpb.UpdatePipelineRequest,
 ) (*ynpb.UpdatePipelineResponse, error) {
-	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
+	agent, err := m.shm.AgentReattach(agentName, m.instanceID, defaultAgentMemory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to agent %q: %w", agentName, err)
 	}
@@ -130,7 +130,7 @@ func (m *PipelineService) Delete(
 ) (*ynpb.DeletePipelineResponse, error) {
 	pipelineName := request.GetId().GetName()
 
-	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
+	agent, err := m.shm.AgentReattach(agentName, m.instanceID, defaultAgentMemory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to agent %q: %w", agentName, err)
 	}

--- a/devices/plain/controlplane/mod.go
+++ b/devices/plain/controlplane/mod.go
@@ -33,7 +33,7 @@ func NewDevicePlainDevice(cfg *Config, log *zap.SugaredLogger) (*DevicePlainDevi
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("plain", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("plain", cfg.InstanceID, cfg.MemoryRequirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/devices/vlan/controlplane/mod.go
+++ b/devices/vlan/controlplane/mod.go
@@ -33,7 +33,7 @@ func NewDeviceVlanDevice(cfg *Config, log *zap.SugaredLogger) (*DeviceVlanDevice
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("vlan", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("vlan", cfg.InstanceID, cfg.MemoryRequirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/mock/go/mock_test.go
+++ b/mock/go/mock_test.go
@@ -29,7 +29,7 @@ func TestBasic(t *testing.T) {
 	defer mock.Free()
 
 	shm := mock.SharedMemory()
-	agent, err := shm.AgentAttach("config", 0, config.GetAgentsMemory())
+	agent, err := shm.AgentReattach("config", 0, config.GetAgentsMemory())
 	require.NoError(t, err)
 	require.NotNil(t, agent)
 

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -41,7 +41,7 @@ func NewACLModule(cfg *Config, log *zap.SugaredLogger) (*ACLModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach(agentName, cfg.InstanceID, cfg.MemoryRequirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/acl/tests/acl/setup.go
+++ b/modules/acl/tests/acl/setup.go
@@ -50,7 +50,7 @@ func SetupTest(config *TestConfig) (*TestSetup, error) {
 	}
 
 	agent, err := mock.SharedMemory().
-		AgentAttach("acl", 0, config.mock.GetAgentsMemory())
+		AgentReattach("acl", 0, config.mock.GetAgentsMemory())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent: %w", err)
 	}

--- a/modules/balancer/agent/go/ffi/manager_test.go
+++ b/modules/balancer/agent/go/ffi/manager_test.go
@@ -274,7 +274,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("SetupControlplane", func(t *testing.T) {
-		agent, err := m.SharedMemory().AgentAttach("bootstrap", 0, 1<<20)
+		agent, err := m.SharedMemory().AgentReattach("bootstrap", 0, 1<<20)
 		require.NoError(t, err, "failed to attach bootstrap agent")
 		{
 			functionConfig := ffi.FunctionConfig{

--- a/modules/balancer/agent/go/manager_test.go
+++ b/modules/balancer/agent/go/manager_test.go
@@ -405,7 +405,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("SetupControlplane", func(t *testing.T) {
-		cpAgent, err := m.SharedMemory().AgentAttach("bootstrap", 0, 1<<20)
+		cpAgent, err := m.SharedMemory().AgentReattach("bootstrap", 0, 1<<20)
 		require.NoError(t, err, "failed to attach bootstrap agent")
 		{
 			functionConfig := yanet2.FunctionConfig{

--- a/modules/balancer/bench/go/bench.go
+++ b/modules/balancer/bench/go/bench.go
@@ -383,7 +383,7 @@ const (
 
 func setupYanet(shm *yanet.SharedMemory) error {
 	// Attach bootstrap agent to configure the controlplane
-	bootstrap, err := shm.AgentAttach("bootstrap", 0, 1<<20)
+	bootstrap, err := shm.AgentReattach("bootstrap", 0, 1<<20)
 	if err != nil {
 		return fmt.Errorf("failed to attach to bootstrap agent: %w", err)
 	}

--- a/modules/balancer/tests/go/utils/setup.go
+++ b/modules/balancer/tests/go/utils/setup.go
@@ -88,7 +88,7 @@ func Make(config *TestConfig) (*TestSetup, error) {
 		panic("failed to get balancer after successful creation")
 	}
 
-	bootstrap, err := mock.SharedMemory().AgentAttach("bootstrap", 0, 1<<20)
+	bootstrap, err := mock.SharedMemory().AgentReattach("bootstrap", 0, 1<<20)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to bootstrap agent: %v", err)
 	}

--- a/modules/decap/controlplane/mod.go
+++ b/modules/decap/controlplane/mod.go
@@ -33,7 +33,7 @@ func NewDecapModule(cfg *Config, log *zap.SugaredLogger) (*DecapModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("decap", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("decap", cfg.InstanceID, cfg.MemoryRequirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/dscp/controlplane/mod.go
+++ b/modules/dscp/controlplane/mod.go
@@ -33,7 +33,7 @@ func NewDSCPModule(cfg *Config, log *zap.SugaredLogger) (*DscpModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("dscp", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("dscp", cfg.InstanceID, cfg.MemoryRequirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -35,7 +35,7 @@ func NewForwardModule(cfg *Config, log *zap.SugaredLogger) (*ForwardModule, erro
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach(agentName, cfg.InstanceID, cfg.MemoryRequirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/nat64/controlplane/mod.go
+++ b/modules/nat64/controlplane/mod.go
@@ -33,7 +33,7 @@ func NewNAT64Module(cfg *Config, log *zap.SugaredLogger) (*NAT64Module, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("nat64", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("nat64", cfg.InstanceID, cfg.MemoryRequirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -41,7 +41,7 @@ func NewPdumpModule(cfg *Config, log *zap.SugaredLogger) (*PdumpModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("pdump", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("pdump", cfg.InstanceID, cfg.MemoryRequirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -55,7 +55,7 @@ func NewRouteModule(cfg *Config, log *zap.SugaredLogger) (*RouteModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("route", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("route", cfg.InstanceID, cfg.MemoryRequirements)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}


### PR DESCRIPTION
Updated agent attachment logic. Agents now reuse their previous shared memory upon reconnection, enabling safe controlplane restarts. A public interface for shared memory connection with new memory allocation remains available.