### PR TITLE
fix(ci): use nightly rustfmt for fmt check

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
       - run: cargo fmt --all -- --check
 


### PR DESCRIPTION
.rustfmt.toml uses nightly-only options (wrap_comments, format_code_in_doc_comments, imports_granularity, group_imports), so the fmt job must use the nightly toolchain.