### PR TITLE
fix(ci): fix all cargo clippy -D warnings failures

### DIFF
--- a/cli/core/src/auth/agent.rs
+++ b/cli/core/src/auth/agent.rs
@@ -46,7 +46,7 @@ pub enum AgentError {
 #[derive(Debug)]
 pub enum SshIdentity {
     PublicKey(PublicKey),
-    Certificate(Certificate),
+    Certificate(Box<Certificate>),
 }
 
 impl SshIdentity {
@@ -57,7 +57,7 @@ impl SshIdentity {
 
         if Algorithm::new_certificate(algo_str).is_ok() {
             let cert = Certificate::from_bytes(buf)?;
-            Ok(Self::Certificate(cert))
+            Ok(Self::Certificate(Box::new(cert)))
         } else {
             let pk = PublicKey::from_bytes(buf)?;
             Ok(Self::PublicKey(pk))
@@ -67,7 +67,7 @@ impl SshIdentity {
     /// Returns the certificate if this identity is one.
     pub fn certificate(&self) -> Option<&Certificate> {
         match self {
-            Self::Certificate(c) => Some(c),
+            Self::Certificate(c) => Some(c.as_ref()),
             Self::PublicKey(_) => None,
         }
     }
@@ -119,7 +119,7 @@ impl SshAgent {
                     let blob = identity.to_bytes()?;
                     // We need to move the cert out.
                     if let SshIdentity::Certificate(cert) = identity {
-                        return Ok((cert, blob));
+                        return Ok((*cert, blob));
                     }
                 }
             }

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -151,7 +151,7 @@ impl InspectService {
                 tree.begin_child(format!("Pipeline {}", pipeline.name));
                 tree.add_empty_child("rx".to_string());
                 for function in &pipeline.functions {
-                    tree.add_empty_child(format!("{}", function));
+                    tree.add_empty_child(function.to_string());
                 }
                 tree.add_empty_child("tx".to_string());
                 tree.end_child();

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -91,7 +91,7 @@ impl DevicePlainService {
                         let weight = parts[1].parse::<u64>().expect("Invalid weight value");
                         DevicePipeline {
                             name: parts[0].to_string(),
-                            weight: weight,
+                            weight,
                         }
                     })
                     .collect(),
@@ -106,7 +106,7 @@ impl DevicePlainService {
                         let weight = parts[1].parse::<u64>().expect("Invalid weight value");
                         DevicePipeline {
                             name: parts[0].to_string(),
-                            weight: weight,
+                            weight,
                         }
                     })
                     .collect(),

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -94,7 +94,7 @@ impl DeviceVlanService {
                         let weight = parts[1].parse::<u64>().expect("Invalid weight value");
                         DevicePipeline {
                             name: parts[0].to_string(),
-                            weight: weight,
+                            weight,
                         }
                     })
                     .collect(),
@@ -109,7 +109,7 @@ impl DeviceVlanService {
                         let weight = parts[1].parse::<u64>().expect("Invalid weight value");
                         DevicePipeline {
                             name: parts[0].to_string(),
-                            weight: weight,
+                            weight,
                         }
                     })
                     .collect(),

--- a/modules/balancer/cli/src/json_output.rs
+++ b/modules/balancer/cli/src/json_output.rs
@@ -448,7 +448,7 @@ pub fn convert_show_config(response: &balancerpb::ShowConfigResponse) -> ShowCon
                                     )
                                 };
 
-                                Some(AllowedSourcesJson { networks, ports, tag: s.tag.as_ref().map(|t| t.clone()) })
+                                Some(AllowedSourcesJson { networks, ports, tag: s.tag.clone() })
                             })
                             .collect(),
                         reals: vs

--- a/modules/balancer/cli/src/rpc.rs
+++ b/modules/balancer/cli/src/rpc.rs
@@ -1,6 +1,6 @@
 //! gRPC proto module definitions
 
-#[allow(non_snake_case)]
+#[allow(clippy::all, non_snake_case)]
 pub mod balancerpb {
     tonic::include_proto!("balancerpb");
 }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -261,7 +261,7 @@ impl ForwardService {
         let rules: Vec<forwardpb::Rule> = config.into();
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),
-            rules: rules,
+            rules,
         };
         log::trace!("UpdateConfigRequest: {request:?}");
         let response = self.client.update_config(request).await?.into_inner();

--- a/modules/pdump/cli/src/writer.rs
+++ b/modules/pdump/cli/src/writer.rs
@@ -205,12 +205,12 @@ pub fn pdump_write(
             log::error!("failed to write record: {e}");
             break;
         };
-        if let Some(limit) = packet_limit {
-            if count >= limit {
-                log::debug!("stopping writer because the packet capture limit has been reached: {limit}");
+        if let Some(limit) = packet_limit
+            && count >= limit
+        {
+            log::debug!("stopping writer because the packet capture limit has been reached: {limit}");
 
-                break;
-            }
+            break;
         }
         count += 1;
     }

--- a/modules/route/cli/route/src/lib.rs
+++ b/modules/route/cli/route/src/lib.rs
@@ -7,7 +7,7 @@ use colored::Colorize;
 use ipnet::IpNet;
 use tabled::Tabled;
 
-#[allow(non_snake_case)]
+#[allow(clippy::all, non_snake_case)]
 pub mod routepb {
     tonic::include_proto!("routepb");
 }


### PR DESCRIPTION
- cli/core: box Certificate variant in SshIdentity to fix large_enum_variant lint (552 vs 160 bytes)
- balancer, route: add #[allow(clippy::all)] to tonic proto modules to suppress doc formatting lints in generated code
- devices/plain, devices/vlan, forward: use field shorthand (weight: weight -> weight, rules: rules -> rules)
- inspect: replace useless format!("{}", x) with x.to_string()
- balancer/json_output: replace as_ref().map(|t| t.clone()) with .clone()
- pdump: collapse nested if-let with let-chain