### PR TITLE
fix(ci): apply nightly rustfmt to all Rust sources

### DIFF
--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -371,8 +371,9 @@ fn format_perf_counters(response: &code::PerfCountersResponse) {
     // Total content width without padding (used for reference)
     let _content_width = rx_width + separator_width + tx_width;
 
-    // Distribute padding: some before RX, some between RX and separator, some after TX
-    // We want the separator centered, so left_half and right_half should be equal
+    // Distribute padding: some before RX, some between RX and separator, some after
+    // TX We want the separator centered, so left_half and right_half should be
+    // equal
     let left_half: usize = 37; // (74 - 0) / 2, but we want separator at position 37
     let right_half: usize = 37;
 
@@ -786,7 +787,8 @@ fn format_latency(ns: u64) -> String {
     }
 }
 
-/// Format large numbers with thousand separators or K/M/G/T suffixes for very large numbers
+/// Format large numbers with thousand separators or K/M/G/T suffixes for very
+/// large numbers
 fn format_number(n: u64) -> String {
     const THOUSAND: f64 = 1_000.0;
     const MILLION: f64 = 1_000_000.0;
@@ -820,7 +822,8 @@ fn format_number(n: u64) -> String {
     }
 }
 
-/// Calculate display width of a string (accounting for multi-byte UTF-8 characters)
+/// Calculate display width of a string (accounting for multi-byte UTF-8
+/// characters)
 fn display_width(s: &str) -> usize {
     s.chars().count()
 }

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -89,10 +89,7 @@ impl DevicePlainService {
                             panic!("Invalid pipeline format. Expected 'pipeline_name:weight'");
                         }
                         let weight = parts[1].parse::<u64>().expect("Invalid weight value");
-                        DevicePipeline {
-                            name: parts[0].to_string(),
-                            weight,
-                        }
+                        DevicePipeline { name: parts[0].to_string(), weight }
                     })
                     .collect(),
                 output: cmd
@@ -104,10 +101,7 @@ impl DevicePlainService {
                             panic!("Invalid pipeline format. Expected 'pipeline_name:weight'");
                         }
                         let weight = parts[1].parse::<u64>().expect("Invalid weight value");
-                        DevicePipeline {
-                            name: parts[0].to_string(),
-                            weight,
-                        }
+                        DevicePipeline { name: parts[0].to_string(), weight }
                     })
                     .collect(),
             }),

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -92,10 +92,7 @@ impl DeviceVlanService {
                             panic!("Invalid pipeline format. Expected 'pipeline_name:weight'");
                         }
                         let weight = parts[1].parse::<u64>().expect("Invalid weight value");
-                        DevicePipeline {
-                            name: parts[0].to_string(),
-                            weight,
-                        }
+                        DevicePipeline { name: parts[0].to_string(), weight }
                     })
                     .collect(),
                 output: cmd
@@ -107,10 +104,7 @@ impl DeviceVlanService {
                             panic!("Invalid pipeline format. Expected 'pipeline_name:weight'");
                         }
                         let weight = parts[1].parse::<u64>().expect("Invalid weight value");
-                        DevicePipeline {
-                            name: parts[0].to_string(),
-                            weight,
-                        }
+                        DevicePipeline { name: parts[0].to_string(), weight }
                     })
                     .collect(),
             }),

--- a/modules/balancer/cli/examples/common/mod.rs
+++ b/modules/balancer/cli/examples/common/mod.rs
@@ -499,8 +499,14 @@ pub fn create_config_stats_example() -> balancerpb::ShowStatsResponse {
                         outgoing_bytes: 799_500_000,
                     }),
                     allowed_sources: vec![
-                        balancerpb::AllowedSourcesStats { tag: "100".to_string(), passes: 500_000 },
-                        balancerpb::AllowedSourcesStats { tag: "200".to_string(), passes: 299_500 },
+                        balancerpb::AllowedSourcesStats {
+                            tag: "100".to_string(),
+                            passes: 500_000,
+                        },
+                        balancerpb::AllowedSourcesStats {
+                            tag: "200".to_string(),
+                            passes: 299_500,
+                        },
                         // Tag 0 (no tag) doesn't appear in stats
                     ],
                     reals: vec![
@@ -573,7 +579,10 @@ pub fn create_config_stats_example() -> balancerpb::ShowStatsResponse {
                     }),
                     allowed_sources: vec![
                         // Tag 0 (no tag) doesn't appear in stats
-                        balancerpb::AllowedSourcesStats { tag: "300".to_string(), passes: 400_000 },
+                        balancerpb::AllowedSourcesStats {
+                            tag: "300".to_string(),
+                            passes: 400_000,
+                        },
                     ],
                     reals: vec![balancerpb::NamedRealStats {
                         real: Some(balancerpb::RealIdentifier {
@@ -622,7 +631,10 @@ pub fn create_config_stats_example() -> balancerpb::ShowStatsResponse {
                         outgoing_packets: 300_000,
                         outgoing_bytes: 300_000_000,
                     }),
-                    allowed_sources: vec![balancerpb::AllowedSourcesStats { tag: "400".to_string(), passes: 300_000 }],
+                    allowed_sources: vec![balancerpb::AllowedSourcesStats {
+                        tag: "400".to_string(),
+                        passes: 300_000,
+                    }],
                     reals: vec![
                         balancerpb::NamedRealStats {
                             real: Some(balancerpb::RealIdentifier {

--- a/modules/balancer/cli/examples/graph.rs
+++ b/modules/balancer/cli/examples/graph.rs
@@ -6,8 +6,10 @@ mod common;
 
 use std::{env, error::Error};
 
-use yanet_cli_balancer::output::{self, OutputFormat};
-use yanet_cli_balancer::rpc::balancerpb;
+use yanet_cli_balancer::{
+    output::{self, OutputFormat},
+    rpc::balancerpb,
+};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let response = balancerpb::ShowGraphResponse {

--- a/modules/balancer/cli/examples/vs.rs
+++ b/modules/balancer/cli/examples/vs.rs
@@ -1,7 +1,7 @@
 //! Example: vs command output
 //! Run with: cargo run --example vs [operation] [format]
-//! Where operation is one of: update, delete (default: both operations, all formats)
-//! Where format is one of: table, tree, json (default: all formats)
+//! Where operation is one of: update, delete (default: both operations, all
+//! formats) Where format is one of: table, tree, json (default: all formats)
 
 mod common;
 

--- a/modules/balancer/cli/src/cmd.rs
+++ b/modules/balancer/cli/src/cmd.rs
@@ -80,7 +80,8 @@ pub struct InspectFormatFlags {
 }
 
 impl InspectFormatFlags {
-    /// Convert flags to InspectOutputFormat, defaulting to Normal if none specified
+    /// Convert flags to InspectOutputFormat, defaulting to Normal if none
+    /// specified
     pub fn to_format(&self) -> crate::output::InspectOutputFormat {
         if self.json {
             output::InspectOutputFormat::Json
@@ -165,8 +166,9 @@ pub struct EnableRealCmd {
     #[arg(long, short = 'n')]
     pub name: Option<String>,
 
-    /// Virtual service in format "ip:port/proto", "[ipv6]:port/proto", or "ipv6:port/proto"
-    /// (e.g., "192.168.1.1:80/tcp", "[2001:db8::1]:443/tcp", or "2001:db8::1:443/tcp")
+    /// Virtual service in format "ip:port/proto", "[ipv6]:port/proto", or
+    /// "ipv6:port/proto" (e.g., "192.168.1.1:80/tcp",
+    /// "[2001:db8::1]:443/tcp", or "2001:db8::1:443/tcp")
     #[arg(long)]
     pub vs: String,
 
@@ -213,7 +215,8 @@ fn parse_vs_identifier(vs_str: &str) -> Result<(std::net::IpAddr, u16, balancerp
         }
     };
 
-    // Parse IP and port, handling IPv4, IPv6 with brackets, and IPv6 without brackets
+    // Parse IP and port, handling IPv4, IPv6 with brackets, and IPv6 without
+    // brackets
     let (ip_str, port_str) = if addr_port.starts_with('[') {
         // IPv6 bracket notation: [ipv6]:port
         let bracket_end = addr_port.find(']').ok_or_else(|| {
@@ -327,8 +330,9 @@ pub struct DisableRealCmd {
     #[arg(long, short = 'n')]
     pub name: Option<String>,
 
-    /// Virtual service in format "ip:port/proto", "[ipv6]:port/proto", or "ipv6:port/proto"
-    /// (e.g., "192.168.1.1:80/tcp", "[2001:db8::1]:443/tcp", or "2001:db8::1:443/tcp")
+    /// Virtual service in format "ip:port/proto", "[ipv6]:port/proto", or
+    /// "ipv6:port/proto" (e.g., "192.168.1.1:80/tcp",
+    /// "[2001:db8::1]:443/tcp", or "2001:db8::1:443/tcp")
     #[arg(long)]
     pub vs: String,
 
@@ -573,8 +577,9 @@ pub struct DeleteVsCmd {
     #[arg(long, short = 'n')]
     pub name: Option<String>,
 
-    /// Virtual services to delete in format "ip:port/proto", "[ipv6]:port/proto", or "ipv6:port/proto"
-    /// (e.g., "192.168.1.1:80/tcp", "[2001:db8::1]:443/tcp", or "2001:db8::1:443/tcp")
+    /// Virtual services to delete in format "ip:port/proto",
+    /// "[ipv6]:port/proto", or "ipv6:port/proto" (e.g., "192.168.1.1:80/
+    /// tcp", "[2001:db8::1]:443/tcp", or "2001:db8::1:443/tcp")
     #[arg(long, required = true, num_args = 1..)]
     pub vs: Vec<String>,
 

--- a/modules/balancer/cli/src/entities.rs
+++ b/modules/balancer/cli/src/entities.rs
@@ -46,8 +46,9 @@ pub fn opt_addr_to_ip(addr: &Option<balancerpb::Addr>) -> Result<IpAddr, String>
 }
 
 /// Format AllowedSources protobuf message as a string
-/// Returns networks in CIDR notation (if possible) or netmask notation with optional port ranges and tag
-/// Format: "10.0.0.0/8, 192.168.0.0/16 [80,443,1024-65535] [tag: 100]"
+/// Returns networks in CIDR notation (if possible) or netmask notation with
+/// optional port ranges and tag Format: "10.0.0.0/8, 192.168.0.0/16
+/// [80,443,1024-65535] [tag: 100]"
 pub fn format_allowed_src(allowed_src: &balancerpb::AllowedSources) -> Result<String, String> {
     if allowed_src.nets.is_empty() {
         return Err("no networks specified".to_string());
@@ -61,7 +62,8 @@ pub fn format_allowed_src(allowed_src: &balancerpb::AllowedSources) -> Result<St
             let addr = opt_addr_to_ip(&net.addr)?;
             let mask_bytes = net.mask.as_ref().ok_or("missing mask")?.bytes.as_slice();
 
-            // Try to convert to CIDR prefix, fall back to netmask notation if not contiguous
+            // Try to convert to CIDR prefix, fall back to netmask notation if not
+            // contiguous
             match mask_to_prefix(mask_bytes) {
                 Ok(prefix_len) => Ok(format!("{}/{}", addr, prefix_len)),
                 Err(_) => {
@@ -105,7 +107,8 @@ pub fn format_allowed_src(allowed_src: &balancerpb::AllowedSources) -> Result<St
 }
 
 /// Parse CIDR notation (e.g., "192.168.0.0/24")
-/// This function is kept for backward compatibility but internally uses parse_network
+/// This function is kept for backward compatibility but internally uses
+/// parse_network
 #[allow(dead_code)]
 pub fn parse_cidr(cidr: &str) -> Result<(IpAddr, u32), String> {
     let (addr, mask_bytes) = parse_network(cidr)?;
@@ -248,7 +251,8 @@ pub fn mask_to_prefix(mask_bytes: &[u8]) -> Result<u32, String> {
 /// Examples:
 /// - Single port: "80" -> [PortRange { from: 80, to: 80 }]
 /// - Range: "1024-65535" -> [PortRange { from: 1024, to: 65535 }]
-/// - Multiple: "80,443,8000-9000" -> [PortRange { from: 80, to: 80 }, PortRange { from: 443, to: 443 }, PortRange { from: 8000, to: 9000 }]
+/// - Multiple: "80,443,8000-9000" -> [PortRange { from: 80, to: 80 }, PortRange
+///   { from: 443, to: 443 }, PortRange { from: 8000, to: 9000 }]
 pub fn parse_ports(ports_str: &str) -> Result<Vec<PortRange>, String> {
     let mut ranges = Vec::new();
 
@@ -353,7 +357,8 @@ pub struct PortRange {
 #[serde(untagged)]
 pub enum AllowedSrcEntry {
     /// Simple network string (backward compatible)
-    /// Supports both CIDR ("10.0.0.0/8") and netmask ("10.0.0.0/255.0.0.0") notation
+    /// Supports both CIDR ("10.0.0.0/8") and netmask ("10.0.0.0/255.0.0.0")
+    /// notation
     Simple(String),
 
     /// Structured format with optional port restrictions and tag
@@ -645,7 +650,7 @@ impl TryFrom<VirtualService> for balancerpb::VirtualService {
                                 mask: Some(balancerpb::Addr { bytes: mask_bytes }),
                             }],
                             ports: vec![], // Empty = all ports allowed
-                            tag: None,        // No tag
+                            tag: None,     // No tag
                         })
                     }
                     AllowedSrcEntry::Structured { network, ports, tag } => {

--- a/modules/balancer/cli/src/output.rs
+++ b/modules/balancer/cli/src/output.rs
@@ -1914,7 +1914,8 @@ fn print_show_graph_table(response: &balancerpb::ShowGraphResponse) -> Result<()
     println!();
 
     if let Some(graph) = &response.graph {
-        // Display each VS with its reals in a hierarchical format (similar to info output)
+        // Display each VS with its reals in a hierarchical format (similar to info
+        // output)
         if !graph.virtual_services.is_empty() {
             for vs in &graph.virtual_services {
                 if let Some(vs_id) = &vs.identifier {


### PR DESCRIPTION
## Summary

- Run `cargo +nightly fmt` across the entire workspace to fix CI formatting failures
- Affected files: `cli/modules/counters`, `devices/plain/cli`, `devices/vlan/cli`, `modules/balancer/cli`

## Test plan

- [x] CI `cargo fmt` check passes