### PR TITLE
refactor(devices): migrate plain/vlan CLIs to yanet-cli core

### DIFF
--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -1,11 +1,14 @@
-use core::error::Error;
+use core::{error::Error, str::FromStr};
 
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::CompleteEnv;
 use code::{UpdateDevicePlainRequest, device_plain_service_client::DevicePlainServiceClient};
 use commonpb::{Device, DevicePipeline};
-use tonic::{codec::CompressionEncoding, transport::Channel};
-use ync::logging;
+use tonic::codec::CompressionEncoding;
+use ync::{
+    client::{ConnectionArgs, LayeredChannel},
+    logging,
+};
 
 #[allow(non_snake_case)]
 pub mod code {
@@ -28,9 +31,8 @@ pub mod commonpb {
 pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
-    /// Gateway endpoint.
-    #[clap(long, default_value = "grpc://[::1]:8080", global = true)]
-    pub endpoint: String,
+    #[command(flatten)]
+    pub connection: ConnectionArgs,
     /// Log verbosity level.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
@@ -63,14 +65,28 @@ pub struct UpdateCmd {
     pub output: Vec<String>,
 }
 
+impl FromStr for DevicePipeline {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (name, weight) = s
+            .split_once(':')
+            .ok_or_else(|| format!("invalid pipeline format '{s}': expected 'name:weight'"))?;
+        let weight = weight
+            .parse::<u64>()
+            .map_err(|e| format!("invalid weight in '{s}': {e}"))?;
+        Ok(DevicePipeline { name: name.to_string(), weight })
+    }
+}
+
 pub struct DevicePlainService {
-    client: DevicePlainServiceClient<Channel>,
+    client: DevicePlainServiceClient<LayeredChannel>,
 }
 
 impl DevicePlainService {
-    pub async fn new(endpoint: String) -> Result<Self, Box<dyn Error>> {
-        let client = DevicePlainServiceClient::connect(endpoint).await?;
-        let client = client
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Box<dyn Error>> {
+        let channel = ync::client::connect(connection).await?;
+        let client = DevicePlainServiceClient::new(channel)
             .send_compressed(CompressionEncoding::Gzip)
             .accept_compressed(CompressionEncoding::Gzip);
         Ok(Self { client })
@@ -83,27 +99,13 @@ impl DevicePlainService {
                 input: cmd
                     .input
                     .into_iter()
-                    .map(|p| {
-                        let parts: Vec<&str> = p.split(':').collect();
-                        if parts.len() != 2 {
-                            panic!("Invalid pipeline format. Expected 'pipeline_name:weight'");
-                        }
-                        let weight = parts[1].parse::<u64>().expect("Invalid weight value");
-                        DevicePipeline { name: parts[0].to_string(), weight }
-                    })
-                    .collect(),
+                    .map(|s| s.parse())
+                    .collect::<Result<Vec<_>, _>>()?,
                 output: cmd
                     .output
                     .into_iter()
-                    .map(|p| {
-                        let parts: Vec<&str> = p.split(':').collect();
-                        if parts.len() != 2 {
-                            panic!("Invalid pipeline format. Expected 'pipeline_name:weight'");
-                        }
-                        let weight = parts[1].parse::<u64>().expect("Invalid weight value");
-                        DevicePipeline { name: parts[0].to_string(), weight }
-                    })
-                    .collect(),
+                    .map(|s| s.parse())
+                    .collect::<Result<Vec<_>, _>>()?,
             }),
         };
 
@@ -115,7 +117,7 @@ impl DevicePlainService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
-    let mut service = DevicePlainService::new(cmd.endpoint).await?;
+    let mut service = DevicePlainService::new(&cmd.connection).await?;
 
     match cmd.mode {
         ModeCmd::Update(cmd) => service.update_config(cmd).await,

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -1,11 +1,14 @@
-use core::error::Error;
+use core::{error::Error, str::FromStr};
 
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::CompleteEnv;
 use code::{UpdateDeviceVlanRequest, device_vlan_service_client::DeviceVlanServiceClient};
 use commonpb::{Device, DevicePipeline};
-use tonic::{codec::CompressionEncoding, transport::Channel};
-use ync::logging;
+use tonic::codec::CompressionEncoding;
+use ync::{
+    client::{ConnectionArgs, LayeredChannel},
+    logging,
+};
 
 #[allow(non_snake_case)]
 pub mod code {
@@ -28,9 +31,8 @@ pub mod commonpb {
 pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
-    /// Gateway endpoint.
-    #[clap(long, default_value = "grpc://[::1]:8080", global = true)]
-    pub endpoint: String,
+    #[command(flatten)]
+    pub connection: ConnectionArgs,
     /// Log verbosity level.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
@@ -66,14 +68,28 @@ pub struct UpdateCmd {
     pub vlan: u16,
 }
 
+impl FromStr for DevicePipeline {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (name, weight) = s
+            .split_once(':')
+            .ok_or_else(|| format!("invalid pipeline format '{s}': expected 'name:weight'"))?;
+        let weight = weight
+            .parse::<u64>()
+            .map_err(|e| format!("invalid weight in '{s}': {e}"))?;
+        Ok(DevicePipeline { name: name.to_string(), weight })
+    }
+}
+
 pub struct DeviceVlanService {
-    client: DeviceVlanServiceClient<Channel>,
+    client: DeviceVlanServiceClient<LayeredChannel>,
 }
 
 impl DeviceVlanService {
-    pub async fn new(endpoint: String) -> Result<Self, Box<dyn Error>> {
-        let client = DeviceVlanServiceClient::connect(endpoint).await?;
-        let client = client
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Box<dyn Error>> {
+        let channel = ync::client::connect(connection).await?;
+        let client = DeviceVlanServiceClient::new(channel)
             .send_compressed(CompressionEncoding::Gzip)
             .accept_compressed(CompressionEncoding::Gzip);
         Ok(Self { client })
@@ -86,27 +102,13 @@ impl DeviceVlanService {
                 input: cmd
                     .input
                     .into_iter()
-                    .map(|p| {
-                        let parts: Vec<&str> = p.split(':').collect();
-                        if parts.len() != 2 {
-                            panic!("Invalid pipeline format. Expected 'pipeline_name:weight'");
-                        }
-                        let weight = parts[1].parse::<u64>().expect("Invalid weight value");
-                        DevicePipeline { name: parts[0].to_string(), weight }
-                    })
-                    .collect(),
+                    .map(|s| s.parse())
+                    .collect::<Result<Vec<_>, _>>()?,
                 output: cmd
                     .output
                     .into_iter()
-                    .map(|p| {
-                        let parts: Vec<&str> = p.split(':').collect();
-                        if parts.len() != 2 {
-                            panic!("Invalid pipeline format. Expected 'pipeline_name:weight'");
-                        }
-                        let weight = parts[1].parse::<u64>().expect("Invalid weight value");
-                        DevicePipeline { name: parts[0].to_string(), weight }
-                    })
-                    .collect(),
+                    .map(|s| s.parse())
+                    .collect::<Result<Vec<_>, _>>()?,
             }),
             vlan: cmd.vlan as u32,
         };
@@ -119,7 +121,7 @@ impl DeviceVlanService {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
-    let mut service = DeviceVlanService::new(cmd.endpoint).await?;
+    let mut service = DeviceVlanService::new(&cmd.connection).await?;
 
     match cmd.mode {
         ModeCmd::Update(cmd) => service.update_config(cmd).await,


### PR DESCRIPTION
## Summary

- Replace raw `Channel` + `endpoint: String` with `LayeredChannel` and `ConnectionArgs` from `yanet-cli`, so auth interceptors are applied consistently with all other module CLIs.
- Implement `FromStr for DevicePipeline` with proper error propagation via `?` instead of `panic!`/`expect` on invalid user input.
- Pipeline parsing in `update_config` is now `.map(|s| s.parse()).collect::<Result<Vec<_>, _>>()?`.

## Test plan

- [x] `cargo build -p yanet-cli-device-plain -p yanet-cli-device-vlan` passes
- [x] `cargo clippy -p yanet-cli-device-plain -p yanet-cli-device-vlan` clean