### PR TITLE
refactor(commonpb): introduce shared yanet-commonpb crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,6 +3278,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]
@@ -3298,6 +3299,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]
@@ -3353,6 +3355,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]
@@ -3466,6 +3469,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]
@@ -3486,6 +3490,16 @@ dependencies = [
  "tonic-build",
  "tower",
  "yanet-cli",
+]
+
+[[package]]
+name = "yanet-commonpb"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "serde",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 resolver = "2"
 
 members = [
+    "common/rust/commonpb",
     "cli/core",
     "cli/modules/common",
     "cli/modules/inspect",

--- a/cli/modules/function/Cargo.toml
+++ b/cli/modules/function/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["YANET Team"]
 description = "CLI for YANET function module"
 
 [dependencies]
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
 log = "0.4"
 clap = { version = "4.5", features = ["derive"] }

--- a/cli/modules/function/build.rs
+++ b/cli/modules/function/build.rs
@@ -1,16 +1,13 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../../../common/commonpb/target.proto");
     println!("cargo:rerun-if-changed=../../../controlplane/ynpb/function.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
-        .compile_protos(
-            &["common/commonpb/target.proto", "controlplane/ynpb/function.proto"],
-            &["../../.."],
-        )?;
+        .extern_path(".commonpb", "::commonpb::pb")
+        .compile_protos(&["controlplane/ynpb/function.proto"], &["../../.."])?;
 
     Ok(())
 }

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -8,17 +8,12 @@ use code::{
     function_service_client::FunctionServiceClient, Chain, DeleteFunctionRequest, Function, FunctionChain,
     UpdateFunctionRequest,
 };
-use commonpb::{FunctionId, ModuleId};
+use commonpb::pb::{FunctionId, ModuleId};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
     logging,
 };
-
-#[allow(non_snake_case)]
-pub mod commonpb {
-    tonic::include_proto!("commonpb");
-}
 
 #[allow(non_snake_case)]
 pub mod code {

--- a/cli/modules/pipeline/Cargo.toml
+++ b/cli/modules/pipeline/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["YANET Team"]
 description = "CLI for YANET pipeline module"
 
 [dependencies]
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
 log = "0.4"
 clap = { version = "4.5", features = ["derive"] }

--- a/cli/modules/pipeline/build.rs
+++ b/cli/modules/pipeline/build.rs
@@ -1,16 +1,13 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../../../common/commonpb/target.proto");
     println!("cargo:rerun-if-changed=../../../controlplane/ynpb/pipeline.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
-        .compile_protos(
-            &["common/commonpb/target.proto", "controlplane/ynpb/pipeline.proto"],
-            &["../../.."],
-        )?;
+        .extern_path(".commonpb", "::commonpb::pb")
+        .compile_protos(&["controlplane/ynpb/pipeline.proto"], &["../../.."])?;
 
     Ok(())
 }

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -5,17 +5,12 @@ use core::error::Error;
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use code::{pipeline_service_client::PipelineServiceClient, DeletePipelineRequest, Pipeline, UpdatePipelineRequest};
-use commonpb::{FunctionId, PipelineId};
+use commonpb::pb::{FunctionId, PipelineId};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
     logging,
 };
-
-#[allow(non_snake_case)]
-pub mod commonpb {
-    tonic::include_proto!("commonpb");
-}
 
 #[allow(non_snake_case)]
 pub mod code {

--- a/common/rust/commonpb/Cargo.toml
+++ b/common/rust/commonpb/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "yanet-commonpb"
+version = "0.1.0"
+edition = "2024"
+publish = false
+rust-version = "1.85"
+
+[dependencies]
+prost = "0.13"
+serde = { version = "1", features = ["derive"] }
+tonic = { version = "0.13", features = ["gzip"] }
+
+[build-dependencies]
+tonic-build = "0.13"

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -1,0 +1,9 @@
+use core::error::Error;
+
+pub fn main() -> Result<(), Box<dyn Error>> {
+    tonic_build::configure()
+        .build_server(false)
+        .message_attribute(".", "#[derive(serde::Serialize)]")
+        .compile_protos(&["common/commonpb/target.proto"], &["../../.."])?;
+    Ok(())
+}

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -1,0 +1,20 @@
+use core::{error::Error, str::FromStr};
+
+#[allow(clippy::all, non_snake_case)]
+pub mod pb {
+    tonic::include_proto!("commonpb");
+}
+
+impl FromStr for pb::DevicePipeline {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (name, weight) = s
+            .split_once(':')
+            .ok_or_else(|| format!("invalid pipeline format '{s}': expected 'name:weight'"))?;
+        let weight = weight
+            .parse::<u64>()
+            .map_err(|e| format!("invalid weight in '{s}': {e}"))?;
+        Ok(pb::DevicePipeline { name: name.to_string(), weight })
+    }
+}

--- a/devices/plain/cli/Cargo.toml
+++ b/devices/plain/cli/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 rust-version = "1.85"
 
 [dependencies]
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }

--- a/devices/plain/cli/build.rs
+++ b/devices/plain/cli/build.rs
@@ -1,17 +1,14 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../../../common/commonpb/target.proto");
     println!("cargo:rerun-if-changed=../controlplane/plainpb/plain.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
+        .extern_path(".commonpb", "::commonpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(
-            &["common/commonpb/target.proto", "plainpb/plain.proto"],
-            &["../../..", "../controlplane"],
-        )?;
+        .compile_protos(&["plainpb/plain.proto"], &["../../..", "../controlplane"])?;
 
     Ok(())
 }

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -1,9 +1,9 @@
-use core::{error::Error, str::FromStr};
+use core::error::Error;
 
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::CompleteEnv;
 use code::{UpdateDevicePlainRequest, device_plain_service_client::DevicePlainServiceClient};
-use commonpb::{Device, DevicePipeline};
+use commonpb::pb::Device;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
@@ -15,13 +15,6 @@ pub mod code {
     use serde::Serialize;
 
     tonic::include_proto!("plainpb");
-}
-
-#[allow(non_snake_case)]
-pub mod commonpb {
-    use serde::Serialize;
-
-    tonic::include_proto!("commonpb");
 }
 
 /// DevicePlain module.
@@ -63,20 +56,6 @@ pub struct UpdateCmd {
     /// Pipeline assignments in format "pipeline_name:weight"
     #[arg(short, long)]
     pub output: Vec<String>,
-}
-
-impl FromStr for DevicePipeline {
-    type Err = Box<dyn Error>;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (name, weight) = s
-            .split_once(':')
-            .ok_or_else(|| format!("invalid pipeline format '{s}': expected 'name:weight'"))?;
-        let weight = weight
-            .parse::<u64>()
-            .map_err(|e| format!("invalid weight in '{s}': {e}"))?;
-        Ok(DevicePipeline { name: name.to_string(), weight })
-    }
 }
 
 pub struct DevicePlainService {

--- a/devices/vlan/cli/Cargo.toml
+++ b/devices/vlan/cli/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 rust-version = "1.85"
 
 [dependencies]
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }

--- a/devices/vlan/cli/build.rs
+++ b/devices/vlan/cli/build.rs
@@ -1,17 +1,14 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../../../common/commonpb/target.proto");
     println!("cargo:rerun-if-changed=../controlplane/vlanpb/vlan.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
+        .extern_path(".commonpb", "::commonpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(
-            &["common/commonpb/target.proto", "vlanpb/vlan.proto"],
-            &["../../..", "../controlplane"],
-        )?;
+        .compile_protos(&["vlanpb/vlan.proto"], &["../../..", "../controlplane"])?;
 
     Ok(())
 }

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -1,9 +1,9 @@
-use core::{error::Error, str::FromStr};
+use core::error::Error;
 
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::CompleteEnv;
 use code::{UpdateDeviceVlanRequest, device_vlan_service_client::DeviceVlanServiceClient};
-use commonpb::{Device, DevicePipeline};
+use commonpb::pb::Device;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
@@ -15,13 +15,6 @@ pub mod code {
     use serde::Serialize;
 
     tonic::include_proto!("vlanpb");
-}
-
-#[allow(non_snake_case)]
-pub mod commonpb {
-    use serde::Serialize;
-
-    tonic::include_proto!("commonpb");
 }
 
 /// DeviceVlan module.
@@ -66,20 +59,6 @@ pub struct UpdateCmd {
     /// Vlan tag
     #[arg(short, long)]
     pub vlan: u16,
-}
-
-impl FromStr for DevicePipeline {
-    type Err = Box<dyn Error>;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (name, weight) = s
-            .split_once(':')
-            .ok_or_else(|| format!("invalid pipeline format '{s}': expected 'name:weight'"))?;
-        let weight = weight
-            .parse::<u64>()
-            .map_err(|e| format!("invalid weight in '{s}': {e}"))?;
-        Ok(DevicePipeline { name: name.to_string(), weight })
-    }
 }
 
 pub struct DeviceVlanService {


### PR DESCRIPTION
## Problem

`common/commonpb/target.proto` was compiled independently by 4 CLI crates (`devices/plain/cli`, `devices/vlan/cli`, `cli/modules/function`, `cli/modules/pipeline`). Each crate generated its own local copy of `DevicePipeline`, `Device`, `FunctionId`, etc., making the types incompatible and forcing trait impls (e.g. `impl FromStr for DevicePipeline`) to be duplicated across crates.

## Solution

tonic recommends compiling shared proto files once in a dedicated crate and wiring consumers via `extern_path`, so generated types are canonical and trait impls live in one place.

This PR introduces `common/rust/commonpb` (`yanet-commonpb`), following the existing `common/rust/` pattern (alongside `bitmap`, `netip`). All four consumer crates are migrated to depend on it and use `.extern_path(".commonpb", "::commonpb::pb")` in their `build.rs` to avoid re-generating local copies.

The duplicated `impl FromStr for DevicePipeline` is removed from `devices/plain/cli` and `devices/vlan/cli` and now lives in a single place in `yanet-commonpb`.

## Test plan

- `cargo build -p yanet-commonpb`
- `cargo build -p yanet-cli-device-plain -p yanet-cli-device-vlan -p yanet-cli-function -p yanet-cli-pipeline`
- `cargo clippy -p yanet-commonpb -p yanet-cli-device-plain -p yanet-cli-device-vlan` — no warnings