### PR TITLE
fix: replace strcpy with bounded strtcpy

### DIFF
--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1760,7 +1760,7 @@ agent_storage_put(
 	}
 
 	memcpy(new_storage->data, data, size);
-	strcpy(new_storage->name, name);
+	strtcpy(new_storage->name, name, sizeof(new_storage->name));
 	new_storage->size = size;
 	new_storage->next = NULL;
 

--- a/mock/mock.c
+++ b/mock/mock.c
@@ -319,7 +319,9 @@ yanet_mock_init(
 	for (size_t i = 0; i < config->device_count; ++i) {
 		struct dp_port *device = &devices[i];
 		memset(device, 0, sizeof(struct dp_port));
-		strcpy(device->port_name, config->devices[i].name);
+		strtcpy(device->port_name,
+			config->devices[i].name,
+			sizeof(device->port_name));
 		device->port_id = config->devices[i].id;
 	}
 	SET_OFFSET_OF(&dp_config->dp_topology.devices, devices);

--- a/mock/tests/basic_test.c
+++ b/mock/tests/basic_test.c
@@ -2,6 +2,7 @@
 #include "api/agent.h"
 #include "api/config.h"
 
+#include "common/strutils.h"
 #include "common/test_assert.h"
 #include "controlplane/config/cp_device.h"
 #include "controlplane/config/cp_function.h"
@@ -186,7 +187,9 @@ main() {
 	config.devices[0].id = 0;
 	config.worker_count = 1;
 	memset(config.devices[0].name, 0, sizeof(config.devices[0].name));
-	strcpy(config.devices[0].name, "01:00.0");
+	strtcpy(config.devices[0].name,
+		"01:00.0",
+		sizeof(config.devices[0].name));
 
 	LOG(INFO, "initialize mock...");
 


### PR DESCRIPTION
Replace unbounded strcpy calls with strtcpy to prevent potential buffer overflows.