### PR TITLE
refactor: unify non-empty and non-zero config validation checks

### DIFF
--- a/common/go/xcfg/error.go
+++ b/common/go/xcfg/error.go
@@ -1,0 +1,31 @@
+package xcfg
+
+import "fmt"
+
+// LineError is returned from UnmarshalYAML when a value fails validation.
+type LineError struct {
+	Line int
+	Err  error
+}
+
+func (m *LineError) Error() string {
+	return fmt.Sprintf("line %d: %s", m.Line, m.Err)
+}
+
+func (m *LineError) Unwrap() error {
+	return m.Err
+}
+
+// PathError is returned from Decode's validate when a field fails validation.
+type PathError struct {
+	Path string
+	Err  error
+}
+
+func (m *PathError) Error() string {
+	return fmt.Sprintf("%s: %s", m.Path, m.Err)
+}
+
+func (m *PathError) Unwrap() error {
+	return m.Err
+}

--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -1,0 +1,82 @@
+package xcfg
+
+import (
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type validatable interface {
+	Validate() error
+}
+
+// Decode deserializes YAML data into dst and then recursively validates all
+// fields that implement "validatable".
+func Decode(buf []byte, dst any) error {
+	if err := yaml.Unmarshal(buf, dst); err != nil {
+		return err
+	}
+
+	return validate(reflect.ValueOf(dst), "")
+}
+
+func validate(v reflect.Value, path string) error {
+	// Dereference pointers.
+	for v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
+	}
+
+	// Check if the value itself implements validatable.
+	if v.CanAddr() {
+		if val, ok := v.Addr().Interface().(validatable); ok {
+			if err := val.Validate(); err != nil {
+				if path == "" {
+					return err
+				}
+				return &PathError{Path: path, Err: err}
+			}
+		}
+	}
+
+	// Recurse into struct fields.
+	if v.Kind() == reflect.Struct {
+		t := v.Type()
+		for i := range t.NumField() {
+			f := t.Field(i)
+			if !f.IsExported() {
+				continue
+			}
+
+			name := yamlFieldName(f)
+			fieldPath := name
+			if path != "" {
+				fieldPath = path + "." + name
+			}
+
+			if err := validate(v.Field(i), fieldPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// yamlFieldName returns the YAML key name for a struct field.
+func yamlFieldName(f reflect.StructField) string {
+	tag := f.Tag.Get("yaml")
+	if tag == "" {
+		return f.Name
+	}
+
+	name, _, _ := strings.Cut(tag, ",")
+	if name == "" {
+		return f.Name
+	}
+
+	return name
+}

--- a/common/go/xcfg/load_test.go
+++ b/common/go/xcfg/load_test.go
@@ -1,0 +1,140 @@
+package xcfg
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Load_Valid(t *testing.T) {
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+		Path NonEmptyString `yaml:"path"`
+	}
+
+	var cfg Config
+	require.NoError(t, Decode([]byte("name: foo\npath: /tmp"), &cfg))
+	require.Equal(t, "foo", cfg.Name.Unwrap())
+	require.Equal(t, "/tmp", cfg.Path.Unwrap())
+}
+
+func Test_Load_RejectsEmptyString(t *testing.T) {
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+	}
+
+	var cfg Config
+	require.Error(t, Decode([]byte(`name: ""`), &cfg))
+}
+
+func Test_Load_RejectsNullField(t *testing.T) {
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+		Path NonEmptyString `yaml:"path"`
+	}
+
+	var cfg Config
+	err := Decode([]byte("name:\npath: /tmp"), &cfg)
+
+	var pathErr *PathError
+	require.ErrorAs(t, err, &pathErr)
+	require.Equal(t, "name", pathErr.Path)
+}
+
+func Test_Load_RejectsMissingField(t *testing.T) {
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+		Path NonEmptyString `yaml:"path"`
+	}
+
+	var cfg Config
+	err := Decode([]byte("path: /tmp"), &cfg)
+
+	var pathErr *PathError
+	require.ErrorAs(t, err, &pathErr)
+	require.Equal(t, "name", pathErr.Path)
+}
+
+func Test_Load_ValidatesNestedStruct(t *testing.T) {
+	type Inner struct {
+		Addr NonEmptyString `yaml:"addr"`
+	}
+	type Outer struct {
+		Name  NonEmptyString `yaml:"name"`
+		Inner Inner          `yaml:"inner"`
+	}
+
+	var cfg Outer
+	require.NoError(t, Decode([]byte("name: x\ninner:\n  addr: y"), &cfg))
+}
+
+func Test_Load_RejectsNestedNull(t *testing.T) {
+	type Inner struct {
+		Addr NonEmptyString `yaml:"addr"`
+	}
+	type Outer struct {
+		Name  NonEmptyString `yaml:"name"`
+		Inner Inner          `yaml:"inner"`
+	}
+
+	var cfg Outer
+	err := Decode([]byte("name: x\ninner:\n  addr:"), &cfg)
+
+	var pathErr *PathError
+	require.ErrorAs(t, err, &pathErr)
+	require.Equal(t, "inner.addr", pathErr.Path)
+}
+
+func Test_Load_SkipsNilPointer(t *testing.T) {
+	type Inner struct {
+		Path NonEmptyString `yaml:"path"`
+	}
+	type Outer struct {
+		Inner *Inner `yaml:"inner"`
+	}
+
+	var cfg Outer
+	require.NoError(t, Decode([]byte("{}"), &cfg))
+}
+
+func Test_Load_ValidatesNonNilPointer(t *testing.T) {
+	type Inner struct {
+		Path NonEmptyString `yaml:"path"`
+	}
+	type Outer struct {
+		Inner *Inner `yaml:"inner"`
+	}
+
+	var cfg Outer
+	require.Error(t, Decode([]byte("inner:\n  path:"), &cfg))
+}
+
+func Test_Load_PreservesDefaults(t *testing.T) {
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+		Path NonEmptyString `yaml:"path"`
+	}
+
+	cfg := Config{
+		Name: MustNonEmptyString("default-name"),
+		Path: MustNonEmptyString("/default/path"),
+	}
+	require.NoError(t, Decode([]byte("name: custom"), &cfg))
+	require.Equal(t, "custom", cfg.Name.Unwrap())
+	require.Equal(t, "/default/path", cfg.Path.Unwrap())
+}
+
+func Test_Load_LineErrorUnwrapsFromPathError(t *testing.T) {
+	// Verify that LineError from UnmarshalYAML is accessible via
+	// errors.As through the error chain, even when Decode doesn't
+	// directly produce it (yaml.v3 wraps it in TypeError).
+	var lineErr *LineError
+	err := errors.New("not a line error")
+	require.False(t, errors.As(err, &lineErr))
+
+	le := &LineError{Line: 5, Err: errors.New("test")}
+	pe := &PathError{Path: "a.b", Err: le}
+	require.True(t, errors.As(pe, &lineErr))
+	require.Equal(t, 5, lineErr.Line)
+}

--- a/common/go/xcfg/nonempty.go
+++ b/common/go/xcfg/nonempty.go
@@ -1,0 +1,75 @@
+package xcfg
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// NonEmptyString is a wrapper around string that ensures the string is not
+// empty.
+type NonEmptyString struct {
+	v string
+}
+
+// MustNonEmptyString creates a new NonEmptyString, panicking if the string is
+// empty.
+func MustNonEmptyString(v string) NonEmptyString {
+	m, err := NewNonEmptyString(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return m
+}
+
+// NewNonEmptyString creates a new NonEmptyString, returning an error if the
+// string is empty.
+func NewNonEmptyString(v string) (NonEmptyString, error) {
+	m := NonEmptyString{v: v}
+	if err := m.Validate(); err != nil {
+		return NonEmptyString{}, err
+	}
+
+	return m, nil
+}
+
+// Unwrap returns the underlying string.
+func (m NonEmptyString) Unwrap() string {
+	return m.v
+}
+
+// Validate checks that the string is not empty.
+func (m NonEmptyString) Validate() error {
+	if len(m.v) == 0 {
+		return fmt.Errorf("non-empty string is required")
+	}
+
+	return nil
+}
+
+// String implements fmt.Stringer.
+func (m NonEmptyString) String() string {
+	return m.v
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (m NonEmptyString) MarshalYAML() (any, error) {
+	return m.v, nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler, rejecting empty strings.
+func (m *NonEmptyString) UnmarshalYAML(node *yaml.Node) error {
+	var out string
+	if err := node.Decode(&out); err != nil {
+		return fmt.Errorf("failed to decode non-empty string: %w", err)
+	}
+
+	n, err := NewNonEmptyString(out)
+	if err != nil {
+		return &LineError{Line: node.Line, Err: err}
+	}
+
+	*m = n
+	return nil
+}

--- a/common/go/xcfg/nonempty_test.go
+++ b/common/go/xcfg/nonempty_test.go
@@ -1,0 +1,87 @@
+package xcfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func Test_NonEmptyString(t *testing.T) {
+	v, err := NewNonEmptyString("some")
+	require.NoError(t, err)
+	require.Equal(t, "some", v.Unwrap())
+	require.Equal(t, "some", v.String())
+}
+
+func Test_NonEmptyString_NewRejectsEmpty(t *testing.T) {
+	_, err := NewNonEmptyString("")
+	require.Error(t, err)
+}
+
+func Test_NonEmptyString_NewAcceptsWhitespace(t *testing.T) {
+	v, err := NewNonEmptyString(" ")
+	require.NoError(t, err)
+	require.Equal(t, " ", v.Unwrap())
+}
+
+func Test_NonEmptyString_MustPanicsOnEmpty(t *testing.T) {
+	require.Panics(t, func() { MustNonEmptyString("") })
+}
+
+func Test_NonEmptyString_MustSucceeds(t *testing.T) {
+	v := MustNonEmptyString("ok")
+	require.Equal(t, "ok", v.Unwrap())
+}
+
+func Test_NonEmptyString_ValidateRejectsZeroValue(t *testing.T) {
+	var zero NonEmptyString
+	require.Error(t, zero.Validate())
+}
+
+func Test_NonEmptyString_ValidateAcceptsConstructed(t *testing.T) {
+	v := MustNonEmptyString("ok")
+	require.NoError(t, v.Validate())
+}
+
+func Test_NonEmptyString_UnmarshalRejectsEmpty(t *testing.T) {
+	var out struct {
+		V NonEmptyString `yaml:"v"`
+	}
+	require.Error(t, yaml.Unmarshal([]byte(`v: ""`), &out))
+}
+
+func Test_NonEmptyString_UnmarshalAcceptsValid(t *testing.T) {
+	var out struct {
+		V NonEmptyString `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(`v: hello`), &out))
+	require.Equal(t, "hello", out.V.Unwrap())
+}
+
+func Test_NonEmptyString_NullYAMLCaughtByValidate(t *testing.T) {
+	var out struct {
+		V NonEmptyString `yaml:"v"`
+	}
+	// "v:" (null) does not trigger UnmarshalYAML in yaml.v3,
+	// leaving zero value.
+	//
+	// Validate() catches this instead.
+	require.NoError(t, yaml.Unmarshal([]byte("v:"), &out))
+	require.Error(t, out.V.Validate())
+}
+
+func Test_NonEmptyString_YAMLRoundTrip(t *testing.T) {
+	type doc struct {
+		V NonEmptyString `yaml:"v"`
+	}
+
+	original := doc{V: MustNonEmptyString("/dev/hugepages/yanet")}
+
+	buf, err := yaml.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded doc
+	require.NoError(t, yaml.Unmarshal(buf, &decoded))
+	require.Equal(t, original.V.Unwrap(), decoded.V.Unwrap())
+}

--- a/common/go/xcfg/nonzero.go
+++ b/common/go/xcfg/nonzero.go
@@ -1,0 +1,78 @@
+package xcfg
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Numeric constrains to types with an underlying numeric representation.
+type Numeric interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~float32 | ~float64
+}
+
+// NonZero is a wrapper around a numeric type that ensures the value is not
+// zero.
+type NonZero[T Numeric] struct {
+	v T
+}
+
+// MustNonZero creates a new NonZero, panicking if the value is zero.
+func MustNonZero[T Numeric](v T) NonZero[T] {
+	m, err := NewNonZero(v)
+	if err != nil {
+		panic(err)
+	}
+
+	return m
+}
+
+// NewNonZero creates a new NonZero.
+func NewNonZero[T Numeric](v T) (NonZero[T], error) {
+	m := NonZero[T]{v: v}
+	if err := m.Validate(); err != nil {
+		return NonZero[T]{}, err
+	}
+
+	return m, nil
+}
+
+// Unwrap returns the underlying value.
+func (m NonZero[T]) Unwrap() T {
+	return m.v
+}
+
+// String implements fmt.Stringer.
+func (m NonZero[T]) String() string {
+	return fmt.Sprint(m.v)
+}
+
+// Validate checks that the value is not zero.
+func (m NonZero[T]) Validate() error {
+	if m.v == 0 {
+		return fmt.Errorf("non-zero value is required")
+	}
+
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler for round-trip serialization.
+func (m NonZero[T]) MarshalYAML() (any, error) {
+	return m.v, nil
+}
+
+// UnmarshalYAML implements yaml.Unmarshaler, rejecting zero values.
+func (m *NonZero[T]) UnmarshalYAML(node *yaml.Node) error {
+	var out T
+	if err := node.Decode(&out); err != nil {
+		return fmt.Errorf("failed to decode non-zero value: %w", err)
+	}
+
+	n, err := NewNonZero(out)
+	if err != nil {
+		return &LineError{Line: node.Line, Err: err}
+	}
+
+	*m = n
+	return nil
+}

--- a/common/go/xcfg/nonzero_test.go
+++ b/common/go/xcfg/nonzero_test.go
@@ -1,0 +1,114 @@
+package xcfg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func Test_NonZero(t *testing.T) {
+	v := MustNonZero(7)
+	require.Equal(t, 7, v.Unwrap())
+}
+
+func Test_NonZero_NewRejectsZero(t *testing.T) {
+	_, err := NewNonZero(0)
+	require.Error(t, err)
+}
+
+func Test_NonZero_NewAcceptsPositive(t *testing.T) {
+	v, err := NewNonZero(42)
+	require.NoError(t, err)
+	require.Equal(t, 42, v.Unwrap())
+	require.Equal(t, "42", v.String())
+}
+
+func Test_NonZero_NewAcceptsNegative(t *testing.T) {
+	v, err := NewNonZero(-1)
+	require.NoError(t, err)
+	require.Equal(t, -1, v.Unwrap())
+}
+
+func Test_NonZero_MustPanicsOnZero(t *testing.T) {
+	require.Panics(t, func() { MustNonZero(0) })
+}
+
+func Test_NonZero_ValidateRejectsZeroValue(t *testing.T) {
+	var zero NonZero[int]
+	require.Error(t, zero.Validate())
+}
+
+func Test_NonZero_ValidateAcceptsConstructed(t *testing.T) {
+	v := MustNonZero(5)
+	require.NoError(t, v.Validate())
+}
+
+func Test_NonZero_UnmarshalRejectsZero(t *testing.T) {
+	var out struct {
+		V NonZero[int] `yaml:"v"`
+	}
+	require.Error(t, yaml.Unmarshal([]byte("v: 0"), &out))
+}
+
+func Test_NonZero_UnmarshalAcceptsPositive(t *testing.T) {
+	var out struct {
+		V NonZero[int] `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("v: 10"), &out))
+	require.Equal(t, 10, out.V.Unwrap())
+}
+
+func Test_NonZero_NullYAMLCaughtByValidate(t *testing.T) {
+	var out struct {
+		V NonZero[int] `yaml:"v"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte("v:"), &out))
+	require.Error(t, out.V.Validate())
+}
+
+func Test_NonZero_YAMLRoundTrip(t *testing.T) {
+	type doc struct {
+		V NonZero[int] `yaml:"v"`
+	}
+
+	original := doc{V: MustNonZero(64)}
+
+	buf, err := yaml.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded doc
+	require.NoError(t, yaml.Unmarshal(buf, &decoded))
+	require.Equal(t, original.V.Unwrap(), decoded.V.Unwrap())
+}
+
+func Test_NonZero_WorksWithTypeAlias(t *testing.T) {
+	// NonZero works with custom numeric types.
+	type mySize uint64
+
+	v, err := NewNonZero(mySize(128))
+	require.NoError(t, err)
+	require.Equal(t, mySize(128), v.Unwrap())
+}
+
+func Test_NonZero_WorksWithLoad(t *testing.T) {
+	type Config struct {
+		Name  NonEmptyString `yaml:"name"`
+		Count NonZero[int]   `yaml:"count"`
+	}
+
+	var cfg Config
+	require.NoError(t, Decode([]byte("name: foo\ncount: 5"), &cfg))
+	require.Equal(t, 5, cfg.Count.Unwrap())
+}
+
+func Test_NonZero_LoadRejectsMissing(t *testing.T) {
+	type Config struct {
+		Count NonZero[int] `yaml:"count"`
+	}
+
+	var cfg Config
+	err := Decode([]byte("{}"), &cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "count")
+}

--- a/controlplane/yncp/cfg.go
+++ b/controlplane/yncp/cfg.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/yanet-platform/yanet2/common/go/logging"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	"github.com/yanet-platform/yanet2/controlplane/internal/gateway"
 
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
@@ -72,7 +73,7 @@ func LoadConfig(path string) (*Config, error) {
 	}
 
 	cfg := DefaultConfig()
-	if err := yaml.Unmarshal(buf, cfg); err != nil {
+	if err := xcfg.Decode(buf, cfg); err != nil {
 		return nil, fmt.Errorf("failed to deserialize config: %w", err)
 	}
 

--- a/devices/plain/controlplane/cfg.go
+++ b/devices/plain/controlplane/cfg.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 // Config represents plain device configuration
@@ -13,41 +14,25 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 
 	// MemoryPath is the path to the shared memory file
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 
 	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
 	// Endpoint is the gRPC endpoint address
-	Endpoint string `yaml:"endpoint"`
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 
 	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
-	if c.MemoryPath == "" {
-		return fmt.Errorf("memory path is required")
-	}
-
-	if c.MemoryRequirements == 0 {
-		return fmt.Errorf("memory requirements must be greater than 0")
-	}
-
-	if c.Endpoint == "" {
-		return fmt.Errorf("endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid endpoint address: %w", err)
 	}
 
-	if c.GatewayEndpoint == "" {
-		return fmt.Errorf("gateway endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid gateway endpoint address: %w", err)
 	}
 
@@ -57,9 +42,9 @@ func (c *Config) Validate() error {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 16 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/devices/plain/controlplane/mod.go
+++ b/devices/plain/controlplane/mod.go
@@ -23,7 +23,7 @@ type DevicePlainDevice struct {
 func NewDevicePlainDevice(cfg *Config, log *zap.SugaredLogger) (*DevicePlainDevice, error) {
 	log = log.With(zap.String("module", "plainpb.DevicePlainService"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func NewDevicePlainDevice(cfg *Config, log *zap.SugaredLogger) (*DevicePlainDevi
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("plain", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("plain", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -54,7 +54,7 @@ func (m *DevicePlainDevice) Name() string {
 }
 
 func (m *DevicePlainDevice) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *DevicePlainDevice) ServicesNames() []string {

--- a/devices/vlan/controlplane/cfg.go
+++ b/devices/vlan/controlplane/cfg.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 // Config represents VLAN device configuration
@@ -13,41 +14,25 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 
 	// MemoryPath is the path to the shared memory file
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 
 	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
 	// Endpoint is the gRPC endpoint address
-	Endpoint string `yaml:"endpoint"`
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 
 	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
-	if c.MemoryPath == "" {
-		return fmt.Errorf("memory path is required")
-	}
-
-	if c.MemoryRequirements == 0 {
-		return fmt.Errorf("memory requirements must be greater than 0")
-	}
-
-	if c.Endpoint == "" {
-		return fmt.Errorf("endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid endpoint address: %w", err)
 	}
 
-	if c.GatewayEndpoint == "" {
-		return fmt.Errorf("gateway endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid gateway endpoint address: %w", err)
 	}
 
@@ -57,9 +42,9 @@ func (c *Config) Validate() error {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 16 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/devices/vlan/controlplane/mod.go
+++ b/devices/vlan/controlplane/mod.go
@@ -23,7 +23,7 @@ type DeviceVlanDevice struct {
 func NewDeviceVlanDevice(cfg *Config, log *zap.SugaredLogger) (*DeviceVlanDevice, error) {
 	log = log.With(zap.String("module", "vlanpb.DeviceVlanService"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func NewDeviceVlanDevice(cfg *Config, log *zap.SugaredLogger) (*DeviceVlanDevice
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("vlan", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("vlan", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -54,7 +54,7 @@ func (m *DeviceVlanDevice) Name() string {
 }
 
 func (m *DeviceVlanDevice) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *DeviceVlanDevice) ServicesNames() []string {

--- a/modules/acl/controlplane/cfg.go
+++ b/modules/acl/controlplane/cfg.go
@@ -5,49 +5,30 @@ import (
 	"net"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 // Config represents ACL module configuration
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
 	InstanceID uint32 `yaml:"instance_id"`
-
 	// MemoryPath is the path to the shared memory file
-	MemoryPath string `yaml:"memory_path"`
-
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
-
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 	// Endpoint is the gRPC endpoint address
-	Endpoint string `yaml:"endpoint"`
-
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
-	if c.MemoryPath == "" {
-		return fmt.Errorf("memory path is required")
-	}
-
-	if c.MemoryRequirements == 0 {
-		return fmt.Errorf("memory requirements must be greater than 0")
-	}
-
-	if c.Endpoint == "" {
-		return fmt.Errorf("endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid endpoint address: %w", err)
 	}
 
-	if c.GatewayEndpoint == "" {
-		return fmt.Errorf("gateway endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid gateway endpoint address: %w", err)
 	}
 
@@ -57,9 +38,9 @@ func (c *Config) Validate() error {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 64 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(64 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -31,7 +31,7 @@ type ACLModule struct {
 func NewACLModule(cfg *Config, log *zap.SugaredLogger) (*ACLModule, error) {
 	log = log.With(zap.String("module", serviceName))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach shared memory: %w", err)
 	}
@@ -41,7 +41,7 @@ func NewACLModule(cfg *Config, log *zap.SugaredLogger) (*ACLModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach(agentName, cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -65,7 +65,7 @@ func (m *ACLModule) Name() string {
 }
 
 func (m *ACLModule) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *ACLModule) ServicesNames() []string {

--- a/modules/balancer/agent/go/config.go
+++ b/modules/balancer/agent/go/config.go
@@ -1,6 +1,9 @@
 package balancer
 
-import "github.com/c2h5oh/datasize"
+import (
+	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -10,21 +13,21 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 
 	// MemoryRequirements is the amount of memory that is required for a single
 	// agent
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        string `yaml:"endpoint"`
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 128 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(128 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/balancer/agent/go/mod.go
+++ b/modules/balancer/agent/go/mod.go
@@ -23,12 +23,12 @@ func NewBalancerModule(
 ) (*BalancerModule, error) {
 	log = log.With(zap.String("module", "balancerpb.BalancerService"))
 
-	shm, err := yanet.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := yanet.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach shared memory: %w", err)
 	}
 
-	svc, err := NewBalancerService(shm, cfg.MemoryRequirements, log)
+	svc, err := NewBalancerService(shm, cfg.MemoryRequirements.Unwrap(), log)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create balancer service: %w", err)
 	}
@@ -44,7 +44,7 @@ func (m *BalancerModule) Name() string {
 }
 
 func (m *BalancerModule) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *BalancerModule) ServicesNames() []string {

--- a/modules/decap/controlplane/cfg.go
+++ b/modules/decap/controlplane/cfg.go
@@ -2,6 +2,7 @@ package decap
 
 import (
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
@@ -9,20 +10,20 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 	// MemoryRequirements is the amount of memory that is required for a single
 	// transaction.
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        string `yaml:"endpoint"`
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 16 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/decap/controlplane/mod.go
+++ b/modules/decap/controlplane/mod.go
@@ -23,7 +23,7 @@ type DecapModule struct {
 func NewDecapModule(cfg *Config, log *zap.SugaredLogger) (*DecapModule, error) {
 	log = log.With(zap.String("module", "decappb.DecapService"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func NewDecapModule(cfg *Config, log *zap.SugaredLogger) (*DecapModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("decap", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("decap", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -54,7 +54,7 @@ func (m *DecapModule) Name() string {
 }
 
 func (m *DecapModule) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *DecapModule) ServicesNames() []string {

--- a/modules/dscp/controlplane/cfg.go
+++ b/modules/dscp/controlplane/cfg.go
@@ -2,6 +2,7 @@ package dscp
 
 import (
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
@@ -9,20 +10,20 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 	// MemoryRequirements is the amount of memory that is required for a single
 	// transaction.
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        string `yaml:"endpoint"`
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 16 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/dscp/controlplane/mod.go
+++ b/modules/dscp/controlplane/mod.go
@@ -23,7 +23,7 @@ type DscpModule struct {
 func NewDSCPModule(cfg *Config, log *zap.SugaredLogger) (*DscpModule, error) {
 	log = log.With(zap.String("module", "dscppb.DscpService"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func NewDSCPModule(cfg *Config, log *zap.SugaredLogger) (*DscpModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("dscp", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("dscp", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -54,7 +54,7 @@ func (m *DscpModule) Name() string {
 }
 
 func (m *DscpModule) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *DscpModule) ServicesNames() []string {

--- a/modules/forward/controlplane/cfg.go
+++ b/modules/forward/controlplane/cfg.go
@@ -2,6 +2,7 @@ package forward
 
 import (
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
@@ -9,20 +10,20 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 	// MemoryRequirements is the amount of memory that is required for a single
 	// transaction.
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        string `yaml:"endpoint"`
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 16 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -25,7 +25,7 @@ type ForwardModule struct {
 func NewForwardModule(cfg *Config, log *zap.SugaredLogger) (*ForwardModule, error) {
 	log = log.With(zap.String("module", "forwardpb.ForwardService"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func NewForwardModule(cfg *Config, log *zap.SugaredLogger) (*ForwardModule, erro
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach(agentName, cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -56,7 +56,7 @@ func (m *ForwardModule) Name() string {
 }
 
 func (m *ForwardModule) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *ForwardModule) ServicesNames() []string {

--- a/modules/fwstate/controlplane/cfg.go
+++ b/modules/fwstate/controlplane/cfg.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 // Config represents FWState module configuration
@@ -13,41 +14,25 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 
 	// MemoryPath is the path to the shared memory file
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 
 	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
 	// Endpoint is the gRPC endpoint address
-	Endpoint string `yaml:"endpoint"`
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 
 	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
-	if c.MemoryPath == "" {
-		return fmt.Errorf("memory path is required")
-	}
-
-	if c.MemoryRequirements == 0 {
-		return fmt.Errorf("memory requirements must be greater than 0")
-	}
-
-	if c.Endpoint == "" {
-		return fmt.Errorf("endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid endpoint address: %w", err)
 	}
 
-	if c.GatewayEndpoint == "" {
-		return fmt.Errorf("gateway endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid gateway endpoint address: %w", err)
 	}
 
@@ -57,9 +42,9 @@ func (c *Config) Validate() error {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 64 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(64 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/nat64/controlplane/cfg.go
+++ b/modules/nat64/controlplane/cfg.go
@@ -5,6 +5,7 @@ import (
 	"net"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 // Config represents NAT64 module configuration
@@ -13,41 +14,25 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 
 	// MemoryPath is the path to the shared memory file
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 
 	// MemoryRequirements specifies memory requirements for the module
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
 	// Endpoint is the gRPC endpoint address
-	Endpoint string `yaml:"endpoint"`
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 
 	// GatewayEndpoint is the address of the gateway service
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
-	if c.MemoryPath == "" {
-		return fmt.Errorf("memory path is required")
-	}
-
-	if c.MemoryRequirements == 0 {
-		return fmt.Errorf("memory requirements must be greater than 0")
-	}
-
-	if c.Endpoint == "" {
-		return fmt.Errorf("endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.Endpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid endpoint address: %w", err)
 	}
 
-	if c.GatewayEndpoint == "" {
-		return fmt.Errorf("gateway endpoint is required")
-	}
-
-	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint); err != nil {
+	if _, err := net.ResolveTCPAddr("tcp", c.GatewayEndpoint.Unwrap()); err != nil {
 		return fmt.Errorf("invalid gateway endpoint address: %w", err)
 	}
 
@@ -57,9 +42,9 @@ func (c *Config) Validate() error {
 // DefaultConfig returns default configuration
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 16 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/nat64/controlplane/mod.go
+++ b/modules/nat64/controlplane/mod.go
@@ -23,7 +23,7 @@ type NAT64Module struct {
 func NewNAT64Module(cfg *Config, log *zap.SugaredLogger) (*NAT64Module, error) {
 	log = log.With(zap.String("module", "nat64pb.NAT64Service"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, err
 	}
@@ -33,7 +33,7 @@ func NewNAT64Module(cfg *Config, log *zap.SugaredLogger) (*NAT64Module, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("nat64", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("nat64", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -54,7 +54,7 @@ func (m *NAT64Module) Name() string {
 }
 
 func (m *NAT64Module) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *NAT64Module) ServicesNames() []string {

--- a/modules/pdump/controlplane/cfg.go
+++ b/modules/pdump/controlplane/cfg.go
@@ -2,6 +2,7 @@ package pdump
 
 import (
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
@@ -9,22 +10,22 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 	// MemoryRequirements is the amount of memory that is required for a single
 	// transaction.
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 
-	Endpoint        string `yaml:"endpoint"`
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
-	DebugEBPF       bool   `yaml:"debug_ebpf"`
+	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
+	DebugEBPF       bool                `yaml:"debug_ebpf"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 16 * datasize.MB,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 		DebugEBPF:          false,
 	}
 }

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -31,7 +31,7 @@ func NewPdumpModule(cfg *Config, log *zap.SugaredLogger) (*PdumpModule, error) {
 	)
 	debugEBPF = cfg.DebugEBPF
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func NewPdumpModule(cfg *Config, log *zap.SugaredLogger) (*PdumpModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("pdump", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("pdump", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -62,7 +62,7 @@ func (m *PdumpModule) Name() string {
 }
 
 func (m *PdumpModule) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *PdumpModule) ServicesNames() []string {

--- a/modules/route-mpls/controlplane/cfg.go
+++ b/modules/route-mpls/controlplane/cfg.go
@@ -2,6 +2,7 @@ package route_mpls
 
 import (
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
@@ -9,19 +10,19 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 	// MemoryRequirements is the amount of memory that is required for a single
 	// transaction.
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
-	Endpoint           string            `yaml:"endpoint"`
-	GatewayEndpoint    string            `yaml:"gateway_endpoint"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	Endpoint           xcfg.NonEmptyString             `yaml:"endpoint"`
+	GatewayEndpoint    xcfg.NonEmptyString             `yaml:"gateway_endpoint"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 16777216,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/route-mpls/controlplane/mod.go
+++ b/modules/route-mpls/controlplane/mod.go
@@ -24,7 +24,7 @@ type RouteMPLSModule struct {
 func NewRouteMPLSModule(cfg *Config, log *zap.SugaredLogger) (*RouteMPLSModule, error) {
 	log = log.With(zap.String("module", "routemplspb.RouteService"))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to shared memory %q: %w", cfg.MemoryPath, err)
 	}
@@ -34,7 +34,7 @@ func NewRouteMPLSModule(cfg *Config, log *zap.SugaredLogger) (*RouteMPLSModule, 
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("route-mpls", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentAttach("route-mpls", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -55,7 +55,7 @@ func (m *RouteMPLSModule) Name() string {
 }
 
 func (m *RouteMPLSModule) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *RouteMPLSModule) ServicesNames() []string {

--- a/modules/route/controlplane/cfg.go
+++ b/modules/route/controlplane/cfg.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
 type Config struct {
@@ -11,14 +12,14 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 	// MemoryPath is the path to the shared-memory file that is used to
 	// communicate with dataplane.
-	MemoryPath string `yaml:"memory_path"`
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
 	// MemoryRequirements is the amount of memory that is required for a single
 	// transaction.
-	MemoryRequirements datasize.ByteSize `yaml:"memory_requirements"`
-	Endpoint           string            `yaml:"endpoint"`
-	GatewayEndpoint    string            `yaml:"gateway_endpoint"`
-	RibTTL             time.Duration     `yaml:"rib_ttl"`
-	LinkMap            map[string]string `yaml:"link_map"`
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+	Endpoint           xcfg.NonEmptyString             `yaml:"endpoint"`
+	GatewayEndpoint    xcfg.NonEmptyString             `yaml:"gateway_endpoint"`
+	RibTTL             time.Duration                   `yaml:"rib_ttl"`
+	LinkMap            map[string]string               `yaml:"link_map"`
 	// NetlinkMonitor configures the kernel neighbour discovery via netlink.
 	NetlinkMonitor NetlinkMonitorConfig `yaml:"netlink_monitor"`
 }
@@ -39,10 +40,10 @@ type NetlinkMonitorConfig struct {
 
 func DefaultConfig() *Config {
 	return &Config{
-		MemoryPath:         "/dev/hugepages/yanet",
-		MemoryRequirements: 16777216,
-		Endpoint:           "[::1]:0",
-		GatewayEndpoint:    "[::1]:8080",
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 		RibTTL:             time.Minute,
 		LinkMap:            make(map[string]string),
 		NetlinkMonitor: NetlinkMonitorConfig{

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -45,7 +45,7 @@ func NewRouteModule(cfg *Config, log *zap.SugaredLogger) (*RouteModule, error) {
 		return nil, fmt.Errorf("failed to create neighbour monitor: %w", err)
 	}
 
-	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath)
+	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to shared memory %q: %w", cfg.MemoryPath, err)
 	}
@@ -55,7 +55,7 @@ func NewRouteModule(cfg *Config, log *zap.SugaredLogger) (*RouteModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("route", cfg.InstanceID, cfg.MemoryRequirements)
+	agent, err := shm.AgentReattach("route", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -109,7 +109,7 @@ func (m *RouteModule) Name() string {
 }
 
 func (m *RouteModule) Endpoint() string {
-	return m.cfg.Endpoint
+	return m.cfg.Endpoint.Unwrap()
 }
 
 func (m *RouteModule) ServicesNames() []string {


### PR DESCRIPTION
After this change the following line will be printed, pointing exactly at the line location where error occurred.

ERROR: failed to load config: failed to deserialize config: line 23: non-empty string is required