### PR TITLE
fix(gateway): use correct directory permissions in runner

### DIFF
--- a/controlplane/internal/gateway/runner.go
+++ b/controlplane/internal/gateway/runner.go
@@ -100,7 +100,7 @@ func (m *BuiltInModuleRunner) listen() (net.Listener, error) {
 
 	if strings.HasPrefix(endpoint, "/") {
 		dir := path.Dir(endpoint)
-		if err := os.MkdirAll(dir, 0644); err != nil {
+		if err := os.MkdirAll(dir, 0755); err != nil {
 			return nil, err
 		}
 		if err := os.Remove(endpoint); err != nil {


### PR DESCRIPTION
`MkdirAll` for the module socket directory was called with `0644`, which lacks the execute bit needed for directories to be traversable. Changed to `0755`.