### PR TITLE
refactor(cli/auth): async rewrite with safety hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3145,6 +3145,7 @@ dependencies = [
  "simple_logger",
  "ssh-key",
  "thiserror",
+ "tokio",
  "tonic",
  "tower",
  "uuid",

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -12,6 +12,7 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 simple_logger = { version = "5", features = ["timestamps", "stderr"] }
 colored = "3"
+tokio = { version = "1", features = ["net", "io-util", "time", "sync"] }
 tonic = "0.13"
 tower = "0.5"
 http = "1"

--- a/cli/core/src/auth/agent.rs
+++ b/cli/core/src/auth/agent.rs
@@ -1,23 +1,28 @@
-//! Synchronous SSH Agent client over Unix domain socket.
+//! Asynchronous SSH Agent client over Unix domain socket.
 //!
 //! Implements only the subset of the SSH agent protocol needed for
 //! authentication: listing identities and signing data.
 
-use std::{
-    env,
-    io::{self, Read, Write},
-    os::unix::net::UnixStream,
-    path::Path,
-};
+use std::{env, io, path::Path};
 
 use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
 use ssh_key::{Algorithm, Certificate, PublicKey};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::UnixStream,
+};
 
 const SSH_AGENT_FAILURE: u8 = 5;
 const SSH_AGENTC_REQUEST_IDENTITIES: u8 = 11;
 const SSH_AGENT_IDENTITIES_ANSWER: u8 = 12;
 const SSH_AGENTC_SIGN_REQUEST: u8 = 13;
 const SSH_AGENT_SIGN_RESPONSE: u8 = 14;
+
+/// Maximum allowed agent response size (1 MiB).
+const MAX_RESPONSE_SIZE: usize = 1 << 20;
+
+/// Maximum number of identities accepted from agent.
+const MAX_IDENTITIES: usize = 1024;
 
 #[derive(Debug, thiserror::Error)]
 pub enum AgentError {
@@ -41,6 +46,9 @@ pub enum AgentError {
 
     #[error("no suitable certificate found in SSH agent")]
     NoCertificateFound,
+
+    #[error("payload too large for SSH agent protocol")]
+    PayloadTooLarge,
 }
 
 #[derive(Debug)]
@@ -53,9 +61,9 @@ impl SshIdentity {
     /// Parse from raw wire bytes (RFC 4253 section 6.6 format).
     fn from_wire_bytes(buf: &[u8]) -> Result<Self, AgentError> {
         // Read the algorithm string to determine if it's a certificate.
-        let algo_str = read_wire_string(buf).ok_or_else(|| AgentError::InvalidResponse("truncated key blob".into()))?;
+        let id = read_wire_string(buf).ok_or_else(|| AgentError::InvalidResponse("truncated key blob".into()))?;
 
-        if Algorithm::new_certificate(algo_str).is_ok() {
+        if Algorithm::new_certificate(id).is_ok() {
             let cert = Certificate::from_bytes(buf)?;
             Ok(Self::Certificate(Box::new(cert)))
         } else {
@@ -67,8 +75,8 @@ impl SshIdentity {
     /// Returns the certificate if this identity is one.
     pub fn certificate(&self) -> Option<&Certificate> {
         match self {
+            Self::PublicKey(..) => None,
             Self::Certificate(c) => Some(c.as_ref()),
-            Self::PublicKey(_) => None,
         }
     }
 
@@ -81,43 +89,40 @@ impl SshIdentity {
     }
 }
 
+#[derive(Debug)]
 pub struct SshAgent {
     sock: UnixStream,
 }
 
 impl SshAgent {
     /// Connect to the SSH agent using `SSH_AUTH_SOCK` environment variable.
-    pub fn from_env() -> Result<Self, AgentError> {
+    pub async fn from_env() -> Result<Self, AgentError> {
         let path = env::var("SSH_AUTH_SOCK").map_err(|_| AgentError::NoAuthSock)?;
-        Self::connect(&path)
+        Self::connect(&path).await
     }
 
     /// Connect to the SSH agent at the given socket path.
-    pub fn connect<P: AsRef<Path>>(path: P) -> Result<Self, AgentError> {
-        let sock = UnixStream::connect(path)?;
+    pub async fn connect<P: AsRef<Path>>(path: P) -> Result<Self, AgentError> {
+        let sock = UnixStream::connect(path).await?;
         Ok(Self { sock })
     }
 
     /// List all identities from the SSH agent.
-    pub fn identities(&mut self) -> Result<Vec<SshIdentity>, AgentError> {
-        // Send SSH_AGENTC_REQUEST_IDENTITIES (no payload).
-        self.send_message(SSH_AGENTC_REQUEST_IDENTITIES, &[])?;
-
-        // Receive SSH_AGENT_IDENTITIES_ANSWER.
-        let response = self.recv_message(SSH_AGENT_IDENTITIES_ANSWER)?;
+    pub async fn identities(&mut self) -> Result<Vec<SshIdentity>, AgentError> {
+        self.send_message(SSH_AGENTC_REQUEST_IDENTITIES, &[]).await?;
+        let response = self.recv_message(SSH_AGENT_IDENTITIES_ANSWER).await?;
         parse_identities_answer(&response)
     }
 
-    /// Find the first certificate matching the given key_id tag
-    /// (e.g. ":secure:").
-    pub fn find_certificate(&mut self, tag: &str) -> Result<(Certificate, Vec<u8>), AgentError> {
-        let identities = self.identities()?;
+    /// Find the first certificate matching the given tag.
+    pub async fn find_certificate(&mut self, tag: &str) -> Result<(Certificate, Vec<u8>), AgentError> {
+        let identities = self.identities().await?;
 
         for identity in identities {
             if let Some(cert) = identity.certificate() {
                 if cert.key_id().contains(tag) {
                     let blob = identity.to_bytes()?;
-                    // We need to move the cert out.
+
                     if let SshIdentity::Certificate(cert) = identity {
                         return Ok((*cert, blob));
                     }
@@ -130,69 +135,72 @@ impl SshAgent {
 
     /// Sign data using the key identified by `key_blob`.
     ///
-    /// Returns the full SSH wire-format signature (algorithm string +
-    /// signature blob), suitable for base64-encoding into the token.
-    pub fn sign(&mut self, key_blob: &[u8], data: &[u8], flags: u32) -> Result<Vec<u8>, AgentError> {
+    /// Returns the full SSH wire-format signature, suitable for base64-encoding
+    /// into the token.
+    pub async fn sign(&mut self, key_blob: &[u8], data: &[u8], flags: u32) -> Result<Vec<u8>, AgentError> {
         let mut payload = Vec::new();
         write_wire_bytes(&mut payload, key_blob)?;
         write_wire_bytes(&mut payload, data)?;
-        payload.write_u32::<BigEndian>(flags)?;
+        WriteBytesExt::write_u32::<BigEndian>(&mut payload, flags)?;
 
-        self.send_message(SSH_AGENTC_SIGN_REQUEST, &payload)?;
+        self.send_message(SSH_AGENTC_SIGN_REQUEST, &payload).await?;
 
-        let response = self.recv_message(SSH_AGENT_SIGN_RESPONSE)?;
-        parse_sign_response(&response)
+        let response = self.recv_message(SSH_AGENT_SIGN_RESPONSE).await?;
+        parse_sign_response(&response).map(|s| s.to_vec())
     }
 
     /// Send a framed message to the agent.
-    fn send_message(&mut self, msg_type: u8, payload: &[u8]) -> Result<(), AgentError> {
-        let len = 1 + payload.len() as u32;
-        let mut buf = Vec::with_capacity(4 + len as usize);
-        buf.write_u32::<BigEndian>(len)?;
-        buf.push(msg_type);
-        buf.extend_from_slice(payload);
-        self.sock.write_all(&buf)?;
+    async fn send_message(&mut self, ty: u8, payload: &[u8]) -> Result<(), AgentError> {
+        let len = u32::try_from(1 + payload.len()).map_err(|_| AgentError::PayloadTooLarge)?;
+        self.sock.write_u32(len).await?;
+        self.sock.write_u8(ty).await?;
+        self.sock.write_all(payload).await?;
         Ok(())
     }
 
     /// Receive a framed message from the agent.
-    fn recv_message(&mut self, expected_type: u8) -> Result<Vec<u8>, AgentError> {
+    async fn recv_message(&mut self, expected_type: u8) -> Result<Vec<u8>, AgentError> {
         let mut len_buf = [0u8; 4];
-        self.sock.read_exact(&mut len_buf)?;
+        self.sock.read_exact(&mut len_buf).await?;
         let len = BigEndian::read_u32(&len_buf) as usize;
 
         if len == 0 {
             return Err(AgentError::InvalidResponse("zero-length response".into()));
         }
+        if len > MAX_RESPONSE_SIZE {
+            return Err(AgentError::InvalidResponse(format!(
+                "response too large: {len} > {MAX_RESPONSE_SIZE}"
+            )));
+        }
 
         let mut buf = vec![0u8; len];
-        self.sock.read_exact(&mut buf)?;
+        self.sock.read_exact(&mut buf).await?;
 
-        let msg_type = buf[0];
-        if msg_type == SSH_AGENT_FAILURE {
+        let ty = buf[0];
+        if ty == SSH_AGENT_FAILURE {
             return Err(AgentError::AgentFailure);
         }
-        if msg_type != expected_type {
-            return Err(AgentError::UnexpectedResponse {
-                expected: expected_type,
-                got: msg_type,
-            });
+        if ty != expected_type {
+            return Err(AgentError::UnexpectedResponse { expected: expected_type, got: ty });
         }
 
         Ok(buf[1..].to_vec())
     }
 }
 
-/// Read a length-prefixed string from wire bytes, returning the string content.
+/// Read a length-prefixed string from wire bytes, returning the string
+/// content.
 fn read_wire_string(buf: &[u8]) -> Option<&str> {
     if buf.len() < 4 {
         return None;
     }
+
     let len = BigEndian::read_u32(buf) as usize;
     if buf.len() < 4 + len {
         return None;
     }
-    std::str::from_utf8(&buf[4..4 + len]).ok()
+
+    core::str::from_utf8(&buf[4..4 + len]).ok()
 }
 
 /// Read a length-prefixed byte string, returning (bytes, remaining).
@@ -200,17 +208,21 @@ fn read_wire_bytes(buf: &[u8]) -> Option<(&[u8], &[u8])> {
     if buf.len() < 4 {
         return None;
     }
+
     let len = BigEndian::read_u32(buf) as usize;
     if buf.len() < 4 + len {
         return None;
     }
+
     Some((&buf[4..4 + len], &buf[4 + len..]))
 }
 
 /// Write a length-prefixed byte string.
-fn write_wire_bytes<W: Write>(w: &mut W, data: &[u8]) -> Result<(), io::Error> {
-    w.write_u32::<BigEndian>(data.len() as u32)?;
+fn write_wire_bytes<W: io::Write>(w: &mut W, data: &[u8]) -> Result<(), AgentError> {
+    let len = u32::try_from(data.len()).map_err(|_| AgentError::PayloadTooLarge)?;
+    w.write_u32::<BigEndian>(len)?;
     w.write_all(data)?;
+
     Ok(())
 }
 
@@ -221,18 +233,23 @@ fn parse_identities_answer(buf: &[u8]) -> Result<Vec<SshIdentity>, AgentError> {
     }
 
     let num_keys = BigEndian::read_u32(buf) as usize;
+    if num_keys > MAX_IDENTITIES {
+        return Err(AgentError::InvalidResponse(format!(
+            "too many identities: {num_keys} > {MAX_IDENTITIES}"
+        )));
+    }
+
     let mut rest = &buf[4..];
     let mut identities = Vec::with_capacity(num_keys);
 
     for _ in 0..num_keys {
-        // Read key blob.
         let (key_blob, remaining) =
             read_wire_bytes(rest).ok_or_else(|| AgentError::InvalidResponse("truncated key blob".into()))?;
 
         let identity = SshIdentity::from_wire_bytes(key_blob)?;
 
-        // Read comment (skip it).
-        let (_, remaining) =
+        // Skip comment.
+        let (.., remaining) =
             read_wire_bytes(remaining).ok_or_else(|| AgentError::InvalidResponse("truncated comment".into()))?;
 
         identities.push(identity);
@@ -247,10 +264,10 @@ fn parse_identities_answer(buf: &[u8]) -> Result<Vec<SshIdentity>, AgentError> {
 /// Returns the full SSH wire-format signature (the inner string containing
 /// algorithm + blob), which is what the Go server expects for
 /// `ssh.Unmarshal(sigBytes, &sig)`.
-fn parse_sign_response(buf: &[u8]) -> Result<Vec<u8>, AgentError> {
+fn parse_sign_response(buf: &[u8]) -> Result<&[u8], AgentError> {
     // The response is a single string containing the signature.
-    let (sig_blob, _) =
+    let (signature, ..) =
         read_wire_bytes(buf).ok_or_else(|| AgentError::InvalidResponse("truncated sign response".into()))?;
 
-    Ok(sig_blob.to_vec())
+    Ok(signature)
 }

--- a/cli/core/src/auth/interceptor.rs
+++ b/cli/core/src/auth/interceptor.rs
@@ -1,15 +1,13 @@
 //! Tonic gRPC interceptor for SSH certificate authentication.
-//!
-//! Uses a tower [`Layer`]/[`Service`] to intercept HTTP/2 requests and
-//! attach a signed SSH certificate token to the `x-yanet-authentication`
-//! metadata header. This approach (vs tonic's `Interceptor` trait) gives
-//! access to the request URI, which is needed for method binding.
 
 use std::{
-    sync::{Arc, Mutex},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 
+use tokio::sync::Mutex;
 use tower::{Layer, Service};
 
 use super::{
@@ -20,7 +18,7 @@ use super::{
 /// Tower layer that wraps a service with SSH certificate authentication.
 #[derive(Clone)]
 pub struct AuthLayer {
-    inner: Arc<Mutex<AuthLayerState>>,
+    state: Arc<Mutex<AuthLayerState>>,
 }
 
 enum AuthLayerState {
@@ -32,23 +30,22 @@ impl AuthLayer {
     /// Create an auth layer that signs requests using the SSH agent.
     pub fn sshcert(agent: SshAgent, cert_blob: Vec<u8>) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(AuthLayerState::SshCert { agent, cert_blob })),
+            state: Arc::new(Mutex::new(AuthLayerState::SshCert { agent, cert_blob })),
         }
     }
 
-    /// Create an auth layer from the SSH agent, finding a `:insecure:`
-    /// certificate.
-    pub fn from_agent() -> Result<Self, AgentError> {
-        let mut agent = SshAgent::from_env()?;
-        // TODO: configurable certificate tag.
-        let (_cert, blob) = agent.find_certificate(":insecure:")?;
+    /// Create an auth layer from the SSH agent, finding a certificate
+    /// matching the given tag.
+    pub async fn from_agent(cert_tag: &str) -> Result<Self, AgentError> {
+        let mut agent = SshAgent::from_env().await?;
+        let (_cert, blob) = agent.find_certificate(cert_tag).await?;
         Ok(Self::sshcert(agent, blob))
     }
 
     /// Create a no-op auth layer that passes requests through unchanged.
     pub fn nop() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(AuthLayerState::Nop)),
+            state: Arc::new(Mutex::new(AuthLayerState::Nop)),
         }
     }
 }
@@ -57,9 +54,11 @@ impl<S> Layer<S> for AuthLayer {
     type Service = AuthService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        AuthService { inner, state: self.inner.clone() }
+        AuthService { inner, state: self.state.clone() }
     }
 }
+
+type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Tower service that attaches SSH certificate auth tokens to requests.
 #[derive(Clone)]
@@ -70,40 +69,45 @@ pub struct AuthService<S> {
 
 impl<S, B> Service<http::Request<B>> for AuthService<S>
 where
-    S: Service<http::Request<B>>,
+    S: Service<http::Request<B>> + Clone + Send + 'static,
+    S::Future: Send,
+    S::Response: Send,
+    S::Error: Into<BoxError> + Send,
+    B: Send + 'static,
 {
     type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
+    type Error = BoxError;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
+        self.inner.poll_ready(cx).map_err(Into::into)
     }
 
     fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
-        let mut state = self.state.lock().expect("auth state lock poisoned");
+        // Standard Tower pattern: clone and swap to get an owned service
+        // for the async block.
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        let state = self.state.clone();
 
-        if let AuthLayerState::SshCert { agent, cert_blob } = &mut *state {
-            let method = request.uri().path().to_string();
+        Box::pin(async move {
+            {
+                let mut guard = state.lock().await;
 
-            match Token::build(cert_blob, &method, agent) {
-                Ok(token) => match token.to_header_value() {
-                    Ok(header_value) => {
-                        if let Ok(value) = header_value.parse() {
-                            request.headers_mut().insert("x-yanet-authentication", value);
-                        }
-                    }
-                    Err(e) => {
-                        log::error!("failed to serialize sshcert token: {e}");
-                    }
-                },
-                Err(e) => {
-                    log::error!("failed to build sshcert token: {e}");
+                if let AuthLayerState::SshCert { agent, cert_blob } = &mut *guard {
+                    let method = request.uri().path().to_string();
+                    let header = Token::build_header_value(cert_blob, &method, agent)
+                        .await
+                        .map_err(|e| -> BoxError { Box::new(e) })?;
+
+                    let value = header
+                        .parse()
+                        .map_err(|e: http::header::InvalidHeaderValue| -> BoxError { Box::new(e) })?;
+                    request.headers_mut().insert("x-yanet-authentication", value);
                 }
             }
-        }
 
-        drop(state);
-        self.inner.call(request)
+            inner.call(request).await.map_err(Into::into)
+        })
     }
 }

--- a/cli/core/src/auth/mod.rs
+++ b/cli/core/src/auth/mod.rs
@@ -17,6 +17,11 @@ use clap::ValueEnum;
 
 pub use self::interceptor::AuthLayer;
 
+/// Default certificate tag to match in the SSH agent.
+///
+/// TODO: from config.
+const DEFAULT_CERT_TAG: &str = ":insecure:";
+
 /// Supported authentication methods.
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum AuthMethod {
@@ -43,11 +48,11 @@ pub enum AuthError {
 }
 
 /// Create a tower layer based on the CLI auth arguments.
-pub fn create_layer(args: &AuthArgs) -> Result<AuthLayer, AuthError> {
+pub async fn create_layer(args: &AuthArgs) -> Result<AuthLayer, AuthError> {
     match args.auth {
         AuthMethod::None => Ok(AuthLayer::nop()),
         AuthMethod::Sshcert => {
-            let layer = AuthLayer::from_agent()?;
+            let layer = AuthLayer::from_agent(DEFAULT_CERT_TAG).await?;
             Ok(layer)
         }
     }

--- a/cli/core/src/auth/token.rs
+++ b/cli/core/src/auth/token.rs
@@ -14,6 +14,15 @@ const TOKEN_VERSION: i32 = 1;
 /// Header prefix for the `x-yanet-authentication` metadata value.
 const TOKEN_PREFIX: &str = "sshcert ";
 
+#[derive(Debug, thiserror::Error)]
+pub enum TokenError {
+    #[error("signing failed: {0}")]
+    Sign(#[from] AgentError),
+
+    #[error("token serialization failed: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
 /// SSH certificate authentication token.
 ///
 /// JSON-serialized and base64-encoded into the `x-yanet-authentication`
@@ -36,7 +45,7 @@ impl Token {
     /// 2. Build canonical signed data.
     /// 3. Ask SSH agent to sign it.
     /// 4. Base64-encode the SSH wire-format signature.
-    pub fn build(cert_blob: &[u8], method: &str, agent: &mut SshAgent) -> Result<Self, AgentError> {
+    pub async fn build(cert_blob: &[u8], method: &str, agent: &mut SshAgent) -> Result<Self, TokenError> {
         let certificate = BASE64.encode(cert_blob);
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -49,7 +58,7 @@ impl Token {
             TOKEN_VERSION, certificate, timestamp, nonce, method,
         );
 
-        let sig_bytes = agent.sign(cert_blob, canonical.as_bytes(), 0)?;
+        let sig_bytes = agent.sign(cert_blob, canonical.as_bytes(), 0).await?;
         let signature = BASE64.encode(&sig_bytes);
 
         Ok(Self {
@@ -65,9 +74,19 @@ impl Token {
     /// Encode the token into the `x-yanet-authentication` header value.
     ///
     /// Format: `sshcert <base64(json)>`.
-    pub fn to_header_value(&self) -> Result<String, serde_json::Error> {
+    pub fn to_header_value(&self) -> Result<String, TokenError> {
         let json = serde_json::to_string(self)?;
         let encoded = BASE64.encode(json.as_bytes());
-        Ok(format!("{}{}", TOKEN_PREFIX, encoded))
+        Ok(format!("{TOKEN_PREFIX}{encoded}"))
+    }
+
+    /// Build a signed token and encode it into a header value in one step.
+    pub async fn build_header_value(
+        cert_blob: &[u8],
+        method: &str,
+        agent: &mut SshAgent,
+    ) -> Result<String, TokenError> {
+        let token = Self::build(cert_blob, method, agent).await?;
+        token.to_header_value()
     }
 }

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -59,6 +59,7 @@ pub enum ConnectionError {
 /// Connect to the endpoint with all interceptors pre-applied.
 pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, ConnectionError> {
     let channel = Channel::from_shared(args.endpoint.clone())?.connect().await?;
-    let layer = auth::create_layer(&args.auth)?;
-    Ok(layer.layer(channel))
+    let auth = auth::create_layer(&args.auth).await?;
+
+    Ok(auth.layer(channel))
 }


### PR DESCRIPTION
- Convert SSH agent client to async tokio I/O
- Add response size and identity count bounds