### PR TITLE
fix(forward): thread-safe service with backend abstraction

### DIFF
--- a/modules/forward/controlplane/backend.go
+++ b/modules/forward/controlplane/backend.go
@@ -1,0 +1,43 @@
+package forward
+
+import (
+	"fmt"
+
+	cpffi "github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/forward/internal/ffi"
+)
+
+// backend is the real Backend implementation backed by shared memory.
+type backend struct {
+	agent *cpffi.Agent
+}
+
+// NewBackend creates a Backend that operates on real shared memory.
+func NewBackend(agent *cpffi.Agent) Backend {
+	return &backend{
+		agent: agent,
+	}
+}
+
+func (m *backend) UpdateModule(name string, rules []ffi.ForwardRule) (ModuleHandle, error) {
+	module, err := ffi.NewModuleConfig(m.agent, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create module config: %w", err)
+	}
+
+	if err := module.Update(rules); err != nil {
+		module.Free()
+		return nil, fmt.Errorf("failed to update module config: %w", err)
+	}
+
+	if err := m.agent.UpdateModules([]cpffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+		module.Free()
+		return nil, fmt.Errorf("failed to update module: %w", err)
+	}
+
+	return module, nil
+}
+
+func (m *backend) DeleteModule(name string) error {
+	return m.agent.DeleteModuleConfig(name)
+}

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -40,7 +40,7 @@ func NewForwardModule(cfg *Config, log *zap.SugaredLogger) (*ForwardModule, erro
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
 
-	forwardService := NewForwardService(agent)
+	forwardService := NewForwardService(NewBackend(agent))
 
 	return &ForwardModule{
 		cfg:            cfg,

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -12,27 +12,40 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/filter/ipnet4"
 	"github.com/yanet-platform/yanet2/common/go/filter/ipnet6"
 	"github.com/yanet-platform/yanet2/common/go/filter/vlanrange"
-	cpffi "github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
 	"github.com/yanet-platform/yanet2/modules/forward/internal/ffi"
 )
 
+// ModuleHandle is a handle to a module configuration.
+type ModuleHandle interface {
+	Free()
+}
+
+// Backend abstracts shared memory operations.
+type Backend interface {
+	// UpdateModule creates a module config, writes rules, and publishes
+	// it to the dataplane.
+	UpdateModule(name string, rules []ffi.ForwardRule) (ModuleHandle, error)
+	// DeleteModule removes a module config.
+	DeleteModule(name string) error
+}
+
 type forwardConfig struct {
 	rules  []*forwardpb.Rule
-	module *ffi.ModuleConfig
+	module ModuleHandle
 }
 
 type ForwardService struct {
 	forwardpb.UnimplementedForwardServiceServer
 
 	mu      sync.Mutex
-	agent   *cpffi.Agent
+	backend Backend
 	configs map[string]forwardConfig
 }
 
-func NewForwardService(agent *cpffi.Agent) *ForwardService {
+func NewForwardService(backend Backend) *ForwardService {
 	return &ForwardService{
-		agent:   agent,
+		backend: backend,
 		configs: map[string]forwardConfig{},
 	}
 }
@@ -40,17 +53,16 @@ func NewForwardService(agent *cpffi.Agent) *ForwardService {
 func (m *ForwardService) ListConfigs(
 	ctx context.Context, request *forwardpb.ListConfigsRequest,
 ) (*forwardpb.ListConfigsResponse, error) {
-
-	response := &forwardpb.ListConfigsResponse{
-		Configs: make([]string, 0),
-	}
-
-	// Lock instances store and module updates.
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	configs := make([]string, 0, len(m.configs))
 	for name := range m.configs {
-		response.Configs = append(response.Configs, name)
+		configs = append(configs, name)
+	}
+
+	response := &forwardpb.ListConfigsResponse{
+		Configs: configs,
 	}
 
 	return response, nil
@@ -136,17 +148,12 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 		rules = append(rules, rule)
 	}
 
-	module, err := ffi.NewModuleConfig(m.agent, name)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	module, err := m.backend.UpdateModule(name, rules)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create module config: %w", err)
-	}
-
-	if err := module.Update(rules); err != nil {
 		return nil, fmt.Errorf("failed to update module config: %w", err)
-	}
-
-	if err := m.agent.UpdateModules([]cpffi.ModuleConfig{module.AsFFIModule()}); err != nil {
-		return nil, fmt.Errorf("failed to update module: %w", err)
 	}
 
 	if oldModule, ok := m.configs[name]; ok {
@@ -166,13 +173,24 @@ func (m *ForwardService) DeleteConfig(ctx context.Context, req *forwardpb.Delete
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
-	// Remove module configuration from the control plane.
-	// TODO
 
-	deleted := m.agent.DeleteModuleConfig(name) == nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-	response := &forwardpb.DeleteConfigResponse{
-		Deleted: deleted,
+	config, ok := m.configs[name]
+	if !ok {
+		return nil, status.Error(codes.InvalidArgument, "not found")
 	}
-	return response, nil
+
+	if err := m.backend.DeleteModule(name); err != nil {
+		return nil, fmt.Errorf("failed to delete module config %q: %w", name, err)
+	}
+
+	if config.module != nil {
+		config.module.Free()
+	}
+
+	delete(m.configs, name)
+
+	return &forwardpb.DeleteConfigResponse{Deleted: true}, nil
 }

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -1,0 +1,95 @@
+package forward_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
+	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
+	"github.com/yanet-platform/yanet2/modules/forward/internal/ffi"
+)
+
+type mockModuleHandle struct{}
+
+func (m *mockModuleHandle) Free() {}
+
+type mockBackend struct{}
+
+func (m *mockBackend) UpdateModule(name string, rules []ffi.ForwardRule) (forward.ModuleHandle, error) {
+	return &mockModuleHandle{}, nil
+}
+
+func (m *mockBackend) DeleteModule(name string) error {
+	return nil
+}
+
+// Run with: go test -race
+func TestForwardServiceConcurrentAccess(t *testing.T) {
+	svc := forward.NewForwardService(&mockBackend{})
+	ctx := context.Background()
+
+	const goroutines = 10
+	const iterations = 100
+
+	g, ctx := errgroup.WithContext(ctx)
+
+	for i := range goroutines {
+		g.Go(func() error {
+			for j := range iterations {
+				name := fmt.Sprintf("config-%d-%d", i, j)
+				_, err := svc.UpdateConfig(ctx, &forwardpb.UpdateConfigRequest{
+					Name: name,
+					Rules: []*forwardpb.Rule{
+						{
+							Action: &forwardpb.Action{
+								Target: "device0",
+							},
+						},
+					},
+				})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	for range goroutines {
+		g.Go(func() error {
+			for range iterations {
+				_, err := svc.ListConfigs(ctx, &forwardpb.ListConfigsRequest{})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	for i := range goroutines {
+		g.Go(func() error {
+			for j := range iterations {
+				name := fmt.Sprintf("config-%d-%d", i, j)
+				svc.ShowConfig(ctx, &forwardpb.ShowConfigRequest{Name: name})
+			}
+			return nil
+		})
+	}
+
+	for i := range goroutines {
+		g.Go(func() error {
+			for j := range iterations {
+				name := fmt.Sprintf("config-%d-%d", i, j)
+				svc.DeleteConfig(ctx, &forwardpb.DeleteConfigRequest{Name: name})
+			}
+			return nil
+		})
+	}
+
+	require.NoError(t, g.Wait())
+}


### PR DESCRIPTION
ForwardService had no mutex protection in UpdateConfig and DeleteConfig, causing data races on the configs map under concurrent gRPC access. DeleteConfig also never removed entries from the map or freed module handles.

Introduce a Backend interface to abstract shared memory operations, enabling race testing without CGO. Add proper locking to all service methods, fix resource cleanup in DeleteConfig, and add a concurrent access test that passes under go test -race.