### PR TITLE
fix(forward): fix sizeof bug in module config free

### DIFF
--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -58,6 +58,12 @@ type Agent struct {
 	ptr  *C.struct_agent
 }
 
+// BlockAllocatorFreeSize returns the total free memory in the agent's block
+// allocator.
+func (m *Agent) BlockAllocatorFreeSize() uint64 {
+	return uint64(C.block_allocator_free_size(&m.ptr.block_allocator))
+}
+
 func (m *Agent) Close() error {
 	_, err := C.agent_detach(m.ptr)
 	return err

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -148,6 +148,21 @@ cp_module_init(
 	return 0;
 }
 
+void
+cp_module_fini(struct cp_module *cp_module) {
+	counter_registry_free(&cp_module->counter_registry);
+
+	struct cp_module_device *devices = ADDR_OF(&cp_module->devices);
+	if (devices != NULL) {
+		memory_bfree(
+			&cp_module->memory_context,
+			devices,
+			sizeof(struct cp_module_device) *
+				cp_module->device_count
+		);
+	}
+}
+
 int
 cp_module_link_device(
 	struct cp_module *cp_module, const char *name, uint64_t *index

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -113,6 +113,16 @@ cp_module_init(
 	const char *module_name
 );
 
+/**
+ * Release resources allocated by cp_module_init.
+ *
+ * Must be called before freeing the module configuration struct itself.
+ *
+ * @param cp_module Pointer to the module configuration to finalize
+ */
+void
+cp_module_fini(struct cp_module *cp_module);
+
 struct cp_module_registry {
 	struct memory_context *memory_context;
 	struct registry registry;

--- a/lib/counters/counters.c
+++ b/lib/counters/counters.c
@@ -28,6 +28,20 @@ counter_registry_init(
 	return 0;
 }
 
+void
+counter_registry_free(struct counter_registry *registry) {
+	struct memory_context *memory_context =
+		ADDR_OF(&registry->memory_context);
+	struct counter *names = ADDR_OF(&registry->names);
+	if (names != NULL) {
+		memory_bfree(
+			memory_context,
+			names,
+			sizeof(struct counter) * registry->capacity
+		);
+	}
+}
+
 uint64_t
 counter_registry_lookup_index(
 	struct counter_registry *registry, const char *name, uint64_t size

--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -46,6 +46,9 @@ counter_registry_register(
 	struct counter_registry *registry, const char *name, uint64_t size
 );
 
+void
+counter_registry_free(struct counter_registry *registry);
+
 int
 counter_registry_link(
 	struct counter_registry *dst, struct counter_registry *src

--- a/modules/forward/api/controlplane.c
+++ b/modules/forward/api/controlplane.c
@@ -9,6 +9,7 @@
 #include "common/container_of.h"
 
 #include "controlplane/agent/agent.h"
+#include "controlplane/config/cp_module.h"
 
 FILTER_COMPILER_DECLARE(FWD_FILTER_VLAN_TAG, device, vlan);
 
@@ -60,12 +61,14 @@ forward_module_config_free(struct cp_module *cp_module) {
 	memory_bfree(
 		&cp_module->memory_context,
 		ADDR_OF(&config->targets),
-		sizeof(struct forward_target *) * config->target_count
+		sizeof(struct forward_target) * config->target_count
 	);
 
 	FILTER_FREE(&config->filter_vlan, FWD_FILTER_VLAN_TAG);
 	FILTER_FREE(&config->filter_ip4, FWD_FILTER_IP4_TAG);
 	FILTER_FREE(&config->filter_ip6, FWD_FILTER_IP6_TAG);
+
+	cp_module_fini(cp_module);
 
 	struct agent *agent = ADDR_OF(&cp_module->agent);
 	// FIXME: remove the check as agent should be assigned

--- a/modules/forward/tests/forward/forward_test.go
+++ b/modules/forward/tests/forward/forward_test.go
@@ -1,0 +1,57 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	cpffi "github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/forward/internal/ffi"
+)
+
+func TestForwardConfigMemoryLeak(t *testing.T) {
+	// Here is the MAGIC:
+	//
+	// We use 8 rules so that the targets array size difference between
+	// sizeof(forward_target) * 8 = 192 and sizeof(forward_target*) * 8 = 64
+	// lands in different block allocator's pools even with ASAN red zones,
+	// which are +128 bytes.
+	//
+	// With fewer rules both sizes round up to the same power-of-2 pool and
+	// the leak is invisible to "block_allocator_free_size".
+	rules := make([]ffi.ForwardRule, 8)
+	for idx := range rules {
+		rules[idx] = ffi.ForwardRule{
+			Target:  defaultDeviceName,
+			Mode:    ffi.ModeIn,
+			Counter: fmt.Sprintf("rule%d", idx),
+		}
+	}
+
+	setup, err := SetupTest(&TestConfig{
+		rules: rules,
+	})
+	require.NoError(t, err)
+	defer setup.Free()
+
+	freeSizeB := setup.agent.BlockAllocatorFreeSize()
+
+	// Create a second config generation to replace the first.
+	moduleB, err := ffi.NewModuleConfig(setup.agent, defaultConfigName)
+	require.NoError(t, err)
+
+	err = moduleB.Update(rules)
+	require.NoError(t, err)
+
+	err = setup.agent.UpdateModules([]cpffi.ModuleConfig{moduleB.AsFFIModule()})
+	require.NoError(t, err)
+
+	// Free the old config.
+	//
+	// The memory allocated by the module must be returned to the block
+	// allocator.
+	setup.module.Free()
+
+	freeSizeA := setup.agent.BlockAllocatorFreeSize()
+	require.Equal(t, freeSizeB, freeSizeA)
+}

--- a/modules/forward/tests/forward/setup.go
+++ b/modules/forward/tests/forward/setup.go
@@ -1,0 +1,146 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/c2h5oh/datasize"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	mock "github.com/yanet-platform/yanet2/mock/go"
+	forwardffi "github.com/yanet-platform/yanet2/modules/forward/internal/ffi"
+)
+
+var defaultDeviceName string = "01:00.0"
+var defaultPipelineName string = "pipeline0"
+var defaultFunctionName string = "function0"
+var defaultChainName string = "chain0"
+var defaultConfigName string = "forward0"
+
+type TestConfig struct {
+	mock  *mock.YanetMockConfig
+	rules []forwardffi.ForwardRule
+}
+
+type TestSetup struct {
+	mock   *mock.YanetMock
+	agent  *ffi.Agent
+	module *forwardffi.ModuleConfig
+}
+
+func SetupTest(config *TestConfig) (*TestSetup, error) {
+	if config.mock == nil {
+		config.mock = &mock.YanetMockConfig{
+			AgentsMemory: datasize.MB * 64,
+			Workers:      1,
+			Devices: []mock.YanetMockDeviceConfig{
+				{
+					ID:   0,
+					Name: defaultDeviceName,
+				},
+			},
+		}
+	}
+	m, err := mock.NewYanetMock(config.mock)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new yanet mock: %w", err)
+	}
+
+	agent, err := m.SharedMemory().
+		AgentReattach("forward", 0, config.mock.GetAgentsMemory())
+	if err != nil {
+		return nil, fmt.Errorf("failed to attach agent: %w", err)
+	}
+
+	module, err := forwardffi.NewModuleConfig(agent, defaultConfigName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create new forward module: %w", err)
+	}
+
+	err = module.Update(config.rules)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update forward module: %w", err)
+	}
+
+	if err := agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+		return nil, fmt.Errorf("failed to update dp modules: %w", err)
+	}
+
+	if err := setupCp(agent); err != nil {
+		return nil, fmt.Errorf("failed to setup yanet mock: %w", err)
+	}
+
+	return &TestSetup{
+		mock:   m,
+		agent:  agent,
+		module: module,
+	}, nil
+}
+
+func setupCp(agent *ffi.Agent) error {
+	functionConfig := ffi.FunctionConfig{
+		Name: defaultFunctionName,
+		Chains: []ffi.FunctionChainConfig{
+			{
+				Weight: 1,
+				Chain: ffi.ChainConfig{
+					Name: defaultChainName,
+					Modules: []ffi.ChainModuleConfig{
+						{
+							Type: "forward",
+							Name: defaultConfigName,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := agent.UpdateFunction(functionConfig); err != nil {
+		return fmt.Errorf("failed to update functions: %w", err)
+	}
+
+	inputPipelineConfig := ffi.PipelineConfig{
+		Name:      defaultPipelineName,
+		Functions: []string{defaultFunctionName},
+	}
+
+	dummyPipelineConfig := ffi.PipelineConfig{
+		Name:      "dummy",
+		Functions: []string{},
+	}
+
+	if err := agent.UpdatePipeline(inputPipelineConfig); err != nil {
+		return fmt.Errorf("failed to update pipeline: %w", err)
+	}
+
+	if err := agent.UpdatePipeline(dummyPipelineConfig); err != nil {
+		return fmt.Errorf("failed to update pipeline: %w", err)
+	}
+
+	deviceConfig := ffi.DeviceConfig{
+		Name: defaultDeviceName,
+		Input: []ffi.DevicePipelineConfig{
+			{
+				Name:   defaultPipelineName,
+				Weight: 1,
+			},
+		},
+		Output: []ffi.DevicePipelineConfig{
+			{
+				Name:   "dummy",
+				Weight: 1,
+			},
+		},
+	}
+
+	if err := agent.UpdatePlainDevices([]ffi.DeviceConfig{deviceConfig}); err != nil {
+		return fmt.Errorf("failed to update devices: %w", err)
+	}
+
+	return nil
+}
+
+func (m *TestSetup) Free() {
+	m.agent.Close()
+	m.mock.Free()
+}


### PR DESCRIPTION
The `forward_module_config_free` used `sizeof(struct forward_target *)`, which is 8 bytes instead of `sizeof(struct forward_target)` - 24 bytes when freeing the targets array.
This returned memory to the wrong block allocator pool, causing a silent memory leak on every config update.

Add `cp_module_fini` as a symmetric destructor for `cp_module_init` to properly release `counter_registry` and devices.

Add a forward module memory leak test that verifies block allocator free size is unchanged after a module create/free cycle.