### PR TITLE
fix: initialize config_gen_ectx on allocation to prevent use-after-poison

### DIFF
--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -77,6 +77,7 @@ cp_config_gen_create_from(
 	}
 
 	new_config_gen->gen = old_config_gen->gen + 1;
+	new_config_gen->config_gen_ectx = NULL;
 
 	SET_OFFSET_OF(
 		&new_config_gen->dp_config, ADDR_OF(&old_config_gen->dp_config)
@@ -615,6 +616,7 @@ cp_config_gen_create(struct agent *agent) {
 		return NULL;
 	}
 	cp_config_gen->gen = 0;
+	cp_config_gen->config_gen_ectx = NULL;
 	SET_OFFSET_OF(
 		&cp_config_gen->dp_config, ADDR_OF(&cp_config->dp_config)
 	);

--- a/mock/mock.c
+++ b/mock/mock.c
@@ -209,8 +209,8 @@ dataplane_initialize(
 	);
 	SET_OFFSET_OF(&agent.dp_config, dp_config);
 	SET_OFFSET_OF(&agent.cp_config, cp_config);
+
 	struct cp_config_gen *cp_config_gen = cp_config_gen_create(&agent);
-	cp_config_gen->config_gen_ectx = NULL;
 	SET_OFFSET_OF(&cp_config->cp_config_gen, cp_config_gen);
 
 	struct dp_worker **workers_array = memory_balloc(

--- a/tests/controlplane/config_gen_test.c
+++ b/tests/controlplane/config_gen_test.c
@@ -1,0 +1,93 @@
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/econtext.h"
+#include "controlplane/config/zone.h"
+#include "dataplane/config/zone.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DP_MEMORY (1 << 20)
+#define CP_MEMORY (1 << 20)
+
+// Allocate a block of the given size, fill it with non-zero garbage,
+// and free it back.
+//
+// The next allocation of the same size will return this recycled block with
+// stale content.
+static void
+pollute_allocator(struct memory_context *ctx, size_t size) {
+	void *block = memory_balloc(ctx, size);
+	assert(block != NULL);
+	memset(block, 0xAB, size);
+	memory_bfree(ctx, block, size);
+}
+
+int
+main(void) {
+	void *storage = aligned_alloc(64, DP_MEMORY + CP_MEMORY);
+	TEST_ASSERT_NOT_NULL(storage, "failed to allocate storage");
+	memset(storage, 0, DP_MEMORY + CP_MEMORY);
+
+	// Set up minimal dp_config + cp_config in shared memory.
+	struct dp_config *dp = (struct dp_config *)storage;
+	block_allocator_init(&dp->block_allocator);
+	block_allocator_put_arena(
+		&dp->block_allocator,
+		storage + sizeof(struct dp_config),
+		DP_MEMORY - sizeof(struct dp_config)
+	);
+	memory_context_init(&dp->memory_context, "dp", &dp->block_allocator);
+
+	struct cp_config *cp =
+		(struct cp_config *)((uintptr_t)storage + DP_MEMORY);
+	block_allocator_init(&cp->block_allocator);
+	block_allocator_put_arena(
+		&cp->block_allocator,
+		storage + DP_MEMORY + sizeof(struct cp_config),
+		CP_MEMORY - sizeof(struct cp_config)
+	);
+	memory_context_init(&cp->memory_context, "cp", &cp->block_allocator);
+	SET_OFFSET_OF(&dp->cp_config, cp);
+	SET_OFFSET_OF(&cp->dp_config, dp);
+
+	// Pollute the allocator pool so the next config_gen allocation
+	// returns a recycled block with stale (non-zero) content.
+	pollute_allocator(&cp->memory_context, sizeof(struct cp_config_gen));
+
+	// Create config_gen on the recycled block.
+	struct agent agent;
+	memset(&agent, 0, sizeof(agent));
+	memory_context_init_from(
+		&agent.memory_context, &cp->memory_context, "test"
+	);
+	SET_OFFSET_OF(&agent.dp_config, dp);
+	SET_OFFSET_OF(&agent.cp_config, cp);
+
+	struct cp_config_gen *gen = cp_config_gen_create(&agent);
+	TEST_ASSERT_NOT_NULL(gen, "cp_config_gen_create failed");
+
+	// Reproduce the worker's code path:
+	//   config_gen_ectx = ADDR_OF(&cp_config_gen->config_gen_ectx);
+	//
+	// Without the fix, this resolves the stale offset into a wild
+	// pointer. Accessing it triggers ASAN use-after-poison / SIGSEGV.
+	// With the fix, ADDR_OF returns NULL and the access is skipped.
+	struct config_gen_ectx *ectx = ADDR_OF(&gen->config_gen_ectx);
+	if (ectx != NULL) {
+		volatile uint64_t x = ectx->device_count;
+		(void)x;
+	}
+
+	TEST_ASSERT_NULL(
+		ectx, "config_gen_ectx must resolve to NULL on fresh gen"
+	);
+
+	free(storage);
+	return 0;
+}

--- a/tests/controlplane/meson.build
+++ b/tests/controlplane/meson.build
@@ -1,0 +1,14 @@
+config_gen_test = executable(
+  'config_gen_test',
+  ['config_gen_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_common_dep,
+    lib_logging_dep,
+    lib_config_cp_dep,
+    lib_config_dp_dep,
+  ],
+  include_directories: yanet_libdir,
+)
+test('config_gen', config_gen_test, suite: ['controlplane'])

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,4 @@
 subdir('common')
+subdir('controlplane')
 subdir('fwstate')
 subdir('fuzzing')


### PR DESCRIPTION
**Long-story-short**: there was random dataplane crash with ASAN build. Now it's gone.

Explanation requires detailing about cp/dp config exchanges.

The `cp_config_gen_create` and `cp_config_gen_create_from` allocate `cp_config_gen` via `memory_balloc`, which does not(!) zero memory. When the block allocator returns a recycled block, the `config_gen_ectx` field contains stale data from its previous owner.

The dataplane worker reads this field via `ADDR_OF(&cp_config_gen->config_gen_ectx)`, which computes a relative pointer: `stored_offset + &field`. With stale (non-zero) content, this resolves to a wild pointer into freed (ASAN-poisoned) memory, causing a `use-after-poison` crash in `worker_loop_round`.

The fix explicitly sets `config_gen_ectx = NULL` right after allocation in both creation paths, so `ADDR_OF` correctly returns NULL before `config_gen_ectx_create` has a chance to set the real value.

The fun part: the mock previously contained a workaround. This is no longer needed since the fix is now inside `cp_config_gen_create` itself.

A regression test (`config_gen_test`) reproduces the bug by polluting the allocator pool with garbage before calling `cp_config_gen_create`. Without the fix, the stale offset resolves to a wild pointer and the volatile read triggers UBSAN/ASAN. With the fix, `ADDR_OF` returns NULL and the access is skipped.