### PR TITLE
fix: replace volatile with proper C11 atomics in data_pipe and shared state

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,12 @@ jobs:
       - name: Show meson test log
         run: grep -v 'Inherited environment' build/meson-logs/testlog.txt
 
+      - name: Run TSAN tests
+        run: make test-tsan
+      - name: Show TSAN test log
+        if: always()
+        run: grep -v 'Inherited environment' build-tsan/meson-logs/testlog.txt || true
+
       - name: Clean debug build artifacts to free space
         run: |
           echo "=== Disk space before cleanup ==="

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all dataplane test test-functional proto-lint cli cli-install fuzz clean $(foreach module,$(MODULES),cli/$(module) cli-install/$(module))
+.PHONY: all dataplane test test-tsan test-functional proto-lint cli cli-install fuzz clean $(foreach module,$(MODULES),cli/$(module) cli-install/$(module))
 
 # Define the list of modules to avoid repetition
 MODULES := decap dscp route forward nat64 pdump acl fwstate
@@ -64,6 +64,14 @@ test-asan: go-cache-clean
 	meson compile -C build
 	CGO_CFLAGS="-fsanitize=address,undefined" CGO_LDFLAGS="-fsanitize=address,undefined" go test -count=1 $$(go list ./... | grep -v 'tests/functional')
 	meson test -C build
+
+test-tsan:
+	@if [ ! -d "build-tsan" ]; then \
+		meson setup build-tsan -Dbuildtype=debug -Doptimization=0 -Db_sanitize=thread; \
+	else \
+		meson configure -Dbuildtype=debug -Doptimization=0 -Db_sanitize=thread build-tsan; \
+	fi
+	meson test -C build-tsan --suite common
 
 test-functional:
 	@echo "Running functional tests..."

--- a/common/data_pipe.h
+++ b/common/data_pipe.h
@@ -1,82 +1,174 @@
 #pragma once
+
+#include <stdatomic.h>
 #include <stdlib.h>
 
-struct data_pipe {
-	volatile size_t *w_pos;
-	volatile size_t *r_pos;
-	volatile size_t *f_pos;
+// TODO: move to project constants, since cache line size is not always 64.
+#ifndef DATA_PIPE_CACHE_LINE_SIZE
+#define DATA_PIPE_CACHE_LINE_SIZE 64
+#endif
 
-	void **data;
-	size_t size;
+// Lock-free SPSC ring buffer.
+//
+// Used to pass data (typically packet pointers) between dataplane workers
+// running on different cores.
+//
+// The ring has (1 << size) slots.
+//
+//
+// Three-phase protocol
+// ====================
+//
+// Each slot goes through three stages in a cycle:
+//
+//   1. push  (w_pos advances) - producer places items into the ring.
+//   2. pop   (r_pos advances) - consumer takes items and may modify them
+//                               in-place (e.g. write tx_result).
+//   3. free  (f_pos advances) - producer reclaims slots and observes any
+//                               modifications made by the consumer.
+//
+// This gives a request-response pattern over a ring buffer:
+//   push item -> remote side processes it -> collect result.
+//
+//          f_pos          r_pos          w_pos
+//            |              |              |
+//            v              v              v
+//   +--------+--------------+--------------+--------+
+//   |  free  |   consumed   |    pushed    |  free  |
+//   +--------+--------------+--------------+--------+
+//            |              |              |
+//            |   pop done,  | ready to pop |
+//            | ready to free|              |
+//            |              |              |
+//        free moves     pop moves      push moves
+//         right -->      right -->      right -->
+//
+// Position invariant (modulo wrap):  f_pos <= r_pos <= w_pos
+//
+// Available slots per operation:
+//   push:  ring_size - (w_pos - f_pos)   (free slots to write into)
+//   pop:   w_pos - r_pos                 (items ready to consume)
+//   free:  r_pos - f_pos                 (items consumed, ready to reclaim)
+//
+//
+// Memory layout
+// =============
+//
+// w_pos and f_pos are placed in the same cache line (both accessed by the
+// producer).
+// r_pos is DATA_PIPE_CACHE_LINE_SIZE bytes away on a separate cache line to
+// avoid false sharing with the consumer.
+//
+//
+// Callback pattern
+// ================
+//
+// All operations take a data_pipe_handle_func callback. The callback receives
+// a pointer directly into the ring buffer and the number of contiguous
+// available slots; it returns how many slots it actually processed.
+//
+//
+// Memory ordering
+// ===============
+//
+// from_pos (owned side) is loaded with relaxed ordering.
+// to_pos (remote side) is loaded with acquire to see the remote writes.
+//
+// After the callback, from_pos is stored with release so the remote side sees
+// the data written by the callback.
+struct data_pipe {
+	_Atomic size_t *w_pos; // write position (producer)
+	_Atomic size_t *r_pos; // read position (consumer), separate cache line
+	_Atomic size_t *f_pos; // free position (producer), same line as w_pos
+
+	void **data; // slot array, (1 << size) entries
+	size_t size; // log2 of the ring capacity
 };
 
+// Initialize a data pipe.
+//
+// Returns 0 on success, -1 on error.
+//
 // FIXME: provide w_pos, r_pos, f_pos
 static inline int
 data_pipe_init(struct data_pipe *pipe, size_t size) {
 	pipe->size = size;
 
 	pipe->data = (void **)malloc(sizeof(void *) * (1 << size));
-	if (pipe->data == NULL)
+	if (pipe->data == NULL) {
 		return -1;
-	pipe->w_pos = (size_t *)malloc(128);
+	}
+	pipe->w_pos = (_Atomic size_t *)malloc(2 * DATA_PIPE_CACHE_LINE_SIZE);
 	if (pipe->w_pos == NULL) {
 		free(pipe->data);
 		return -1;
 	}
 	pipe->f_pos = pipe->w_pos + 1;
-	pipe->r_pos = pipe->w_pos + 64 / sizeof(size_t);
+	pipe->r_pos = (_Atomic size_t *)((char *)pipe->w_pos +
+					 DATA_PIPE_CACHE_LINE_SIZE);
 
-	*(pipe->w_pos) = 0;
-	*(pipe->f_pos) = 0;
-	*(pipe->r_pos) = 0;
+	atomic_store_explicit(pipe->w_pos, 0, memory_order_relaxed);
+	atomic_store_explicit(pipe->f_pos, 0, memory_order_relaxed);
+	atomic_store_explicit(pipe->r_pos, 0, memory_order_relaxed);
 
 	return 0;
 }
 
+// Free resources allocated by data_pipe_init().
 static inline void
 data_pipe_free(struct data_pipe *pipe) {
 	free(pipe->data);
-	free((void *)pipe->w_pos);
+	free(pipe->w_pos);
 }
 
+// Callback type for ring buffer operations.
+//
+// Receives a pointer into the ring buffer, the number of available slots, and
+// an opaque user context.
+//
+// Returns how many slots were actually processed (must be <= count).
 typedef size_t (*data_pipe_handle_func)(void **item, size_t count, void *data);
 
-// FIXME: check if we have to use memory barriers here
+// Core ring buffer handler.
+//
+// Computes available = to - from + space, then clips to contiguous slots
+// before the ring boundary.
+//
+// Invokes handle_func on the available range and advances from_pos.
+//
+// space is ring_size for push (counts free slots) and 0 for pop/free.
 static inline size_t
 data_pipe_ring_handle(
-	volatile size_t *from_pos,
-	volatile size_t *to_pos,
+	_Atomic size_t *from_pos,
+	_Atomic size_t *to_pos,
 	void **data,
 	size_t size,
 	size_t space,
 	data_pipe_handle_func handle_func,
 	void *handle_func_data
 ) {
-	size_t from = *from_pos;
-	size_t to = *to_pos;
+	size_t from = atomic_load_explicit(from_pos, memory_order_relaxed);
+	size_t to = atomic_load_explicit(to_pos, memory_order_acquire);
 
 	size_t available = to - from + space;
 	from &= (1 << size) - 1;
-	/*
-	 * Branch-less code: the first part is 1 if and only if we wrap
-	 * around the ring size whereas the second part is size of the ring
-	 * overflow.
-	 */
+	// Branchless code: the first part is 1 if and only if we wrap around
+	// the ring size whereas the second part is size of the ring overflow.
 	available -=
 		((from + available) >> size) * (from + available - (1 << size));
 
-	if (!available)
+	if (!available) {
 		return 0;
+	}
 
 	size_t handled = handle_func(data + from, available, handle_func_data);
 
-	// FIXME write fence
-
-	*from_pos += handled;
+	atomic_fetch_add_explicit(from_pos, handled, memory_order_release);
 
 	return handled;
 }
 
+// Push items into the ring.
 static inline size_t
 data_pipe_item_push(
 	struct data_pipe *data_pipe,
@@ -94,6 +186,10 @@ data_pipe_item_push(
 	);
 }
 
+// Pop items from the ring.
+//
+// The callback may modify items in-place; those modifications become visible
+// to the producer during the subsequent free phase.
 static inline size_t
 data_pipe_item_pop(
 	struct data_pipe *data_pipe,
@@ -111,6 +207,9 @@ data_pipe_item_pop(
 	);
 }
 
+// Reclaim consumed slots.
+//
+// The callback can observe modifications made by the consumer during pop.
 static inline size_t
 data_pipe_item_free(
 	struct data_pipe *data_pipe,

--- a/common/memory_address.h
+++ b/common/memory_address.h
@@ -51,7 +51,8 @@
 		SET_OFFSET_OF(DST, ADDR_OF(SRC));                              \
 	} while (0)
 
-/*
+#include <stdatomic.h>
+
 #define ATOMIC_ADDR_OF(OFFSET)                                                 \
 	__extension__({                                                        \
 		typeof(*OFFSET) _offset = atomic_load_explicit(                \
@@ -69,4 +70,3 @@
 			       (uintptr_t)((ADDR) ? (PTR) : NULL)),            \
 		memory_order_release                                           \
 	)
-*/

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -287,7 +287,9 @@ worker_loop_round(struct dataplane_worker *worker) {
 	struct config_gen_ectx *config_gen_ectx =
 		ADDR_OF(&cp_config_gen->config_gen_ectx);
 
-	worker->dp_worker->gen = cp_config_gen->gen;
+	__atomic_store_n(
+		&worker->dp_worker->gen, cp_config_gen->gen, __ATOMIC_RELEASE
+	);
 	*worker->dp_worker->iterations += 1;
 
 	struct packet_front packet_front;

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -20,7 +20,7 @@ cp_config_try_lock(struct cp_config *cp_config) {
 		&zero,
 		pid,
 		false,
-		__ATOMIC_RELAXED,
+		__ATOMIC_ACQUIRE,
 		__ATOMIC_RELAXED
 	);
 }
@@ -34,7 +34,7 @@ cp_config_lock(struct cp_config *cp_config) {
 		&zero,
 		pid,
 		false,
-		__ATOMIC_RELAXED,
+		__ATOMIC_ACQUIRE,
 		__ATOMIC_RELAXED
 	)) {
 		zero = 0;
@@ -50,7 +50,7 @@ cp_config_unlock(struct cp_config *cp_config) {
 		&pid,
 		zero,
 		false,
-		__ATOMIC_RELAXED,
+		__ATOMIC_RELEASE,
 		__ATOMIC_RELAXED
 	);
 }

--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -16,8 +16,10 @@ dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen) {
 	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
 	uint64_t idx = 0;
 	do {
-		volatile struct dp_worker *worker = ADDR_OF(workers + idx);
-		if (worker->gen < gen) {
+		struct dp_worker *worker = ADDR_OF(workers + idx);
+		uint64_t worker_gen =
+			__atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE);
+		if (worker_gen < gen) {
 			// TODO cpu yield
 			continue;
 		}
@@ -35,7 +37,7 @@ dp_config_try_lock(struct dp_config *dp_config) {
 		&zero,
 		pid,
 		false,
-		__ATOMIC_RELAXED,
+		__ATOMIC_ACQUIRE,
 		__ATOMIC_RELAXED
 	);
 }
@@ -49,7 +51,7 @@ dp_config_lock(struct dp_config *dp_config) {
 		&zero,
 		pid,
 		false,
-		__ATOMIC_RELAXED,
+		__ATOMIC_ACQUIRE,
 		__ATOMIC_RELAXED
 	)) {
 		zero = 0;
@@ -65,7 +67,7 @@ dp_config_unlock(struct dp_config *dp_config) {
 		&pid,
 		zero,
 		false,
-		__ATOMIC_RELAXED,
+		__ATOMIC_RELEASE,
 		__ATOMIC_RELAXED
 	);
 }

--- a/lib/fwstate/layermap.h
+++ b/lib/fwstate/layermap.h
@@ -1,6 +1,5 @@
 #include "common/memory.h"
 #include "fwmap.h"
-#include <stdatomic.h>
 
 typedef struct layermap_list {
 	fwmap_t *layer;
@@ -31,8 +30,7 @@ layermap_trim_stale_layers_cp(
 		if (layermap_is_layer_outdated(layer, now)) {
 			// Unlink the outdated layer
 			fwmap_t *next_layer = (fwmap_t *)ADDR_OF(&layer->next);
-			SET_OFFSET_OF(prev_next, next_layer);
-			__atomic_thread_fence(__ATOMIC_RELEASE);
+			ATOMIC_SET_OFFSET_OF(prev_next, next_layer);
 
 			// Add to outdated layers list
 			layermap_list_t *node =

--- a/tests/common/data_pipe_tsan.c
+++ b/tests/common/data_pipe_tsan.c
@@ -1,0 +1,102 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "common/data_pipe.h"
+
+#define PIPE_SIZE_LOG2 8
+#define NUM_ITERATIONS 100000
+
+struct data_pipe shared_pipe;
+volatile int producer_done = 0;
+
+static size_t
+push_handler(void **items, size_t count, void *ctx) {
+	uintptr_t *val = (uintptr_t *)ctx;
+	if (count == 0) {
+		return 0;
+	}
+	items[0] = (void *)(*val);
+	return 1;
+}
+
+static size_t
+pop_handler(void **items, size_t count, void *ctx) {
+	uintptr_t *out = (uintptr_t *)ctx;
+	if (count == 0) {
+		return 0;
+	}
+	*out = (uintptr_t)items[0];
+	return 1;
+}
+
+static size_t
+free_handler(void **items, size_t count, void *ctx) {
+	(void)items;
+	(void)ctx;
+	if (count == 0) {
+		return 0;
+	}
+	return 1;
+}
+
+static void *
+producer_thread(void *arg) {
+	(void)arg;
+	for (uintptr_t i = 1; i <= NUM_ITERATIONS; i++) {
+		uintptr_t val = i;
+		while (data_pipe_item_push(&shared_pipe, push_handler, &val) ==
+		       0) {
+		}
+	}
+	producer_done = 1;
+	return NULL;
+}
+
+static void *
+consumer_thread(void *arg) {
+	(void)arg;
+	uintptr_t received = 0;
+	uintptr_t expected = 1;
+
+	while (received < NUM_ITERATIONS) {
+		uintptr_t val = 0;
+		if (data_pipe_item_pop(&shared_pipe, pop_handler, &val) == 0) {
+			continue;
+		}
+
+		if (val != expected) {
+			fprintf(stderr,
+				"DATA CORRUPTION: expected %lu, got %lu\n",
+				(unsigned long)expected,
+				(unsigned long)val);
+		}
+		expected++;
+		received++;
+
+		data_pipe_item_free(&shared_pipe, free_handler, NULL);
+	}
+
+	return NULL;
+}
+
+int
+main(void) {
+	printf("=== TSAN test: real common/data_pipe.h ===\n");
+
+	int ret = data_pipe_init(&shared_pipe, PIPE_SIZE_LOG2);
+	assert(ret == 0);
+
+	pthread_t prod, cons;
+	pthread_create(&prod, NULL, producer_thread, NULL);
+	pthread_create(&cons, NULL, consumer_thread, NULL);
+
+	pthread_join(prod, NULL);
+	pthread_join(cons, NULL);
+
+	data_pipe_free(&shared_pipe);
+
+	printf("Done.\n");
+	return 0;
+}

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -121,3 +121,15 @@ executable(
   link_args: yanet_link_args,
   dependencies: dependencies
 )
+
+thread_dep = dependency('threads')
+
+data_pipe_test = executable(
+  'data_pipe_test',
+  ['data_pipe_tsan.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: [lib_common_dep, thread_dep],
+  include_directories: yanet_rootdir,
+)
+test('data_pipe', data_pipe_test, suite: ['common'])


### PR DESCRIPTION
The old code used volatile pointers with plain reads/writes and had two FIXMEs about missing memory barriers. On x86_64 this worked by accident because TSO already guarantees store-store and load-load ordering, so volatile (which only prevents compiler reordering) was sufficient in practice. On weakly-ordered architectures (aarch64, mips, powerpc) this would be broken.

Replace volatile with _Atomic and explicit memory ordering:
- acquire loads on the remote position to see data written by the other side;
- release stores on the local position to publish data to the other side;
- relaxed loads on the owned position (no cross-core synchronization needed).

On x86_64 acquire/release compile to plain mov instructions — the same codegen as volatile — so there is zero performance overhead. The only expensive atomic ordering on x86_64 is seq_cst store (MFENCE/XCHG), which is not used here.

Also fix acquire/release ordering on config zone locks and the worker gen handoff, uncomment ATOMIC_ADDR_OF/ATOMIC_SET_OFFSET_OF macros in memory_address.h, and add a TSAN stress test for data_pipe.

Docs are vibe-coded, but reviewed, edited and IMO useful.