### PR TITLE
chore: add manual deb build for ubuntu 22.04

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -10,13 +10,32 @@ on:
     paths-ignore:
       - "web/**"
   workflow_dispatch:
+    inputs:
+      include_2204:
+        description: "Include Ubuntu 22.04 build"
+        type: boolean
+        default: false
 
 jobs:
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ github.event.inputs.include_2204 }}" == "true" ]]; then
+            echo 'matrix={"unbtver":["24.04","22.04"]}' >> $GITHUB_OUTPUT
+          else
+            echo 'matrix={"unbtver":["24.04"]}' >> $GITHUB_OUTPUT
+          fi
+
   build-deb:
+    needs: set-matrix
     strategy:
-      matrix:
-        unbtver:
-          - 24.04
+      fail-fast: false
+      matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
+
     runs-on: ubuntu-${{ matrix.unbtver }}
     env:
       cache_name: deb-build-${{ matrix.unbtver }}
@@ -32,8 +51,7 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+
       - name: Cache rust
         uses: actions/cache@v4
         with:
@@ -79,11 +97,26 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: yanet2-debs-${{ matrix.unbtver }}
+          name: debs-${{ matrix.unbtver }}
           path: outdeb/*
 
-      - name: Create Release for ${{ matrix.unbtver }}
-        if: startsWith(github.ref, 'refs/tags/')
+  release:
+    needs: build-deb
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts
+        run: |
+          mkdir -p outdeb
+          find artifacts -type f -name "*.deb" -exec cp {} outdeb/ \;
+
+      - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
           files: outdeb/*


### PR DESCRIPTION
## Add Ubuntu 22.04 DEB build support and improve release workflow

This PR extends the CI workflow to support building DEB packages for **Ubuntu 22.04**, in addition to the existing **Ubuntu 24.04** builds.

### Key changes

* **Added Ubuntu 22.04 build support**

  * Introduced matrix-based builds to support multiple Ubuntu versions
  * Ubuntu 24.04 remains the default build target
  * Ubuntu 22.04 can be enabled manually via `workflow_dispatch` (`include_2204` flag)

* **Manual control for 22.04 builds**

  * Prevents unnecessary CI load by running 22.04 builds only when explicitly requested
  * Keeps default pipeline fast and efficient

* **Improved release workflow**

  * Added a dedicated `release` job
  * Ensures release artifacts are published **once after all builds complete**
  * Eliminates potential race conditions when uploading assets

* **Artifact aggregation**

  * Collects artifacts from all matrix builds
  * Merges them into a single release bundle

### Behavior

* **Push tag (`v*`)**

  * Builds Ubuntu 24.04 packages
  * Publishes a GitHub Release

* **Manual run (`workflow_dispatch`)**

  * Optionally builds both:

    * Ubuntu 24.04
    * Ubuntu 22.04 (if enabled)
  * Release is created only when triggered from a tag

* **Pull requests**

  * Run build checks for Ubuntu 24.04 only

### Motivation

* Provide compatibility with environments still using Ubuntu 22.04
* Keep CI efficient by avoiding unnecessary builds
* Ensure reliable and deterministic release publishing

### Notes

* Ubuntu 22.04 builds are opt-in by design
* The workflow structure allows easy extension to additional OS versions or architectures in the future
