### PR TITLE
Fix mpls target nexthops leak

### DIFF
--- a/modules/route-mpls/api/controlplane.c
+++ b/modules/route-mpls/api/controlplane.c
@@ -232,6 +232,7 @@ route_mpls_rule_target_create(
 	       0,
 	       sizeof(struct nexthop) * route_mpls_rule->nexthop_count);
 	SET_OFFSET_OF(&target->nexthops, nexthops);
+	target->nexthop_count = route_mpls_rule->nexthop_count;
 
 	uint64_t map_pos = 0;
 


### PR DESCRIPTION
If nexthop count is uninitialized then corresponding memory leaks while mpls module configuration destroy.