### PR TITLE
route-mpls minor refactoring

### DIFF
--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -95,15 +95,6 @@ pub struct RouteUpdateCmd {
     /// The IP address of the tunnel source.
     #[arg(long = "src")]
     pub src_addr: IpAddr,
-    /// Local preference
-    #[arg(long = "local_pref")]
-    pub local_pref: u32,
-    /// AS Path
-    #[arg(long = "as_path")]
-    pub as_path: Vec<u32>,
-    /// MED
-    #[arg(long = "med")]
-    pub med: u32,
     /// The ECMP weight.
     #[arg(long = "weight")]
     pub weight: u64,
@@ -232,9 +223,6 @@ impl RouteMplsService {
                             IpAddr::V4(v4) => v4.octets().to_vec(),
                             IpAddr::V6(v6) => v6.octets().to_vec(),
                         },
-                        local_pref: cmd.local_pref,
-                        as_path: cmd.as_path,
-                        med: cmd.med,
                         weight: cmd.weight,
                         counter: cmd.counter,
                     }),
@@ -259,9 +247,6 @@ impl RouteMplsService {
                             IpAddr::V4(v4) => v4.octets().to_vec(),
                             IpAddr::V6(v6) => v6.octets().to_vec(),
                         },
-                        local_pref: 0,
-                        as_path: vec![],
-                        med: 0,
                         weight: 0,
                         counter: "".to_string(),
                     }),

--- a/modules/route-mpls/controlplane/ffi.go
+++ b/modules/route-mpls/controlplane/ffi.go
@@ -3,6 +3,12 @@ package route_mpls
 //#cgo CFLAGS: -I../../../ -I../../../lib
 //#cgo LDFLAGS: -L../../../build/modules/route-mpls/api -lroute_mpls_cp
 //
+//#include <errno.h>
+//
+//static void reset_errno() {
+//    errno = 0;
+//}
+//
 //#include "api/agent.h"
 //#include "modules/route-mpls/api/controlplane.h"
 //
@@ -37,6 +43,7 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
+	C.reset_errno()
 	ptr, err := C.route_mpls_module_config_create((*C.struct_agent)(agent.AsRawPtr()), cName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize module config: %w", err)
@@ -134,6 +141,7 @@ func (m *ModuleConfig) Update(rules []routeMPLSRule) error {
 		cRule.nexthop_count = C.uint64_t(len(cNextHops))
 	}
 
+	C.reset_errno()
 	rc, err := C.route_mpls_module_config_update(
 		m.asRawPtr(),
 		&cRules[0],

--- a/modules/route-mpls/controlplane/routemplspb/routempls.proto
+++ b/modules/route-mpls/controlplane/routemplspb/routempls.proto
@@ -58,11 +58,8 @@ message NextHop {
   uint32 label = 2;
   bytes source_ip = 3;
   bytes destination_ip = 4;
-  uint32 local_pref = 5;
-  repeated uint32 as_path = 6;
-  uint32 med = 7;
-  uint64 weight = 8;
-  string counter = 9;
+  uint64 weight = 5;
+  string counter = 6;
 }
 
 enum ActionKind {

--- a/modules/route-mpls/controlplane/service.go
+++ b/modules/route-mpls/controlplane/service.go
@@ -33,10 +33,6 @@ type NextHop struct {
 	Destination netip.Addr
 	MPLSLabel   uint32
 
-	LocalPref uint32
-	ASPath    []uint32
-	Med       uint32
-
 	Weight uint64
 
 	Counter string
@@ -44,18 +40,6 @@ type NextHop struct {
 
 type NextHopList struct {
 	NextHops []NextHop
-}
-
-func nextHopCompareCB(l NextHop, r NextHop) int {
-	if prefDiff := int(l.LocalPref) - int(r.LocalPref); prefDiff != 0 {
-		return prefDiff
-	}
-
-	if pathDiff := len(r.ASPath) - len(l.ASPath); pathDiff != 0 {
-		return pathDiff
-	}
-
-	return int(l.Med) - int(r.Med)
 }
 
 func (m *NextHopList) lookup(destination netip.Addr, mplsLabel uint32) int {
@@ -75,8 +59,6 @@ func (m *NextHopList) Insert(nextHop NextHop) {
 	} else {
 		m.NextHops = append(m.NextHops, nextHop)
 	}
-
-	slices.SortFunc(m.NextHops, nextHopCompareCB)
 }
 
 func (m *NextHopList) Remove(nextHop NextHop) {
@@ -152,9 +134,6 @@ func (m *RouteMPLSService) ShowConfig(
 							Label:         nexthop.MPLSLabel,
 							SourceIp:      nexthop.Source.AsSlice(),
 							DestinationIp: nexthop.Destination.AsSlice(),
-							LocalPref:     nexthop.LocalPref,
-							AsPath:        nexthop.ASPath,
-							Med:           nexthop.Med,
 							Weight:        nexthop.Weight,
 							Counter:       nexthop.Counter,
 						},
@@ -294,10 +273,6 @@ func makeNextHop(nexthop *routemplspb.NextHop) (NextHop, error) {
 		Destination: dst,
 		MPLSLabel:   nexthop.Label,
 
-		LocalPref: nexthop.LocalPref,
-		ASPath:    nexthop.AsPath,
-		Med:       nexthop.Med,
-
 		Weight: nexthop.Weight,
 
 		Counter: nexthop.Counter,
@@ -314,11 +289,6 @@ func (m *RouteMPLSService) CreateConfig(
 	name := req.Name
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
-	}
-
-	_, ok := m.configs[name]
-	if ok {
-		return nil, status.Error(codes.InvalidArgument, "already exists")
 	}
 
 	prefixes := maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0)
@@ -363,6 +333,10 @@ func (m *RouteMPLSService) CreateConfig(
 	if err := config.submit(); err != nil {
 		module.Free()
 		return nil, err
+	}
+
+	if oldConfig, ok := m.configs[name]; ok {
+		oldConfig.routeMPLS.Free()
 	}
 
 	m.configs[name] = config

--- a/tests/functional/main/route_mpls_test.go
+++ b/tests/functional/main/route_mpls_test.go
@@ -198,7 +198,7 @@ func TestRouteMPLS(t *testing.T) {
 
 		require.NotNil(t, inputPacket, "Input packet should be parsed")
 		require.NotNil(t, outputPacket, "Output packet should be parsed")
-		require.Equal(t, outputPacket.DstIP, net.ParseIP("10.12.1.1").To4(), "Invalid uneel destiation")
+		require.Equal(t, outputPacket.DstIP, net.ParseIP("10.12.1.1").To4(), "Invalid tunnel destiation")
 	})
 
 	fw.Run("Test_Packet_Routing_With_RouteMPLS-4-6", func(fw *framework.F, t *testing.T) {
@@ -216,7 +216,7 @@ func TestRouteMPLS(t *testing.T) {
 
 		require.NotNil(t, inputPacket, "Input packet should be parsed")
 		require.NotNil(t, outputPacket, "Output packet should be parsed")
-		require.Equal(t, outputPacket.DstIP, net.ParseIP("ccee::11"), "Invalid uneel destiation")
+		require.Equal(t, outputPacket.DstIP, net.ParseIP("ccee::11"), "Invalid tunnel destiation")
 	})
 
 	fw.Run("Test_Packet_Routing_With_RouteMPLS-6-4", func(fw *framework.F, t *testing.T) {
@@ -234,7 +234,7 @@ func TestRouteMPLS(t *testing.T) {
 
 		require.NotNil(t, inputPacket, "Input packet should be parsed")
 		require.NotNil(t, outputPacket, "Output packet should be parsed")
-		require.Equal(t, outputPacket.DstIP, net.ParseIP("10.12.1.1").To4(), "Invalid uneel destiation")
+		require.Equal(t, outputPacket.DstIP, net.ParseIP("10.12.1.1").To4(), "Invalid tunnel destiation")
 	})
 
 	fw.Run("Test_Packet_Routing_With_RouteMPLS-6-6", func(fw *framework.F, t *testing.T) {
@@ -252,7 +252,7 @@ func TestRouteMPLS(t *testing.T) {
 
 		require.NotNil(t, inputPacket, "Input packet should be parsed")
 		require.NotNil(t, outputPacket, "Output packet should be parsed")
-		require.Equal(t, outputPacket.DstIP, net.ParseIP("ccee::11"), "Invalid uneel destiation")
+		require.Equal(t, outputPacket.DstIP, net.ParseIP("ccee::11"), "Invalid tunnel destiation")
 	})
 
 	fw.Run("Delete_Static_Route", func(fw *framework.F, t *testing.T) {

--- a/tests/functional/main/route_mpls_test.go
+++ b/tests/functional/main/route_mpls_test.go
@@ -140,28 +140,28 @@ func TestRouteMPLS(t *testing.T) {
 
 	fw.Run("Insert_Static_RouteMPLS-4-4", func(fw *framework.F, t *testing.T) {
 		// Insert route with the nexthop (do_flush is automatic in insert command)
-		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 5.0.0.0/9 --dst 10.12.1.1 --src 4.2.4.2 --label 45 --as_path 14 --local_pref 10 --med 10 --weight 5 --counter 4-4")
+		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 5.0.0.0/9 --dst 10.12.1.1 --src 4.2.4.2 --label 45 --weight 5 --counter 4-4")
 		require.NoError(t, err, "Failed to insert route")
 		t.Logf("Insert route output: %s", output)
 	})
 
 	fw.Run("Insert_Static_RouteMPLS-4-6", func(fw *framework.F, t *testing.T) {
 		// Insert route with the nexthop (do_flush is automatic in insert command)
-		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 6.0.0.0/10 --dst ccee::11 --src 2424::1212 --label 45 --as_path 14 --local_pref 10 --med 10 --weight 5 --counter 4-6")
+		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 6.0.0.0/10 --dst ccee::11 --src 2424::1212 --label 45 --weight 5 --counter 4-6")
 		require.NoError(t, err, "Failed to insert route")
 		t.Logf("Insert route output: %s", output)
 	})
 
 	fw.Run("Insert_Static_RouteMPLS-6-4", func(fw *framework.F, t *testing.T) {
 		// Insert route with the nexthop (do_flush is automatic in insert command)
-		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 0066::0/17 --dst 10.12.1.1 --src 4.2.4.2 --label 45 --as_path 14 --local_pref 10 --med 10 --weight 5 --counter 6-4")
+		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 0066::0/17 --dst 10.12.1.1 --src 4.2.4.2 --label 45 --weight 5 --counter 6-4")
 		require.NoError(t, err, "Failed to insert route")
 		t.Logf("Insert route output: %s", output)
 	})
 
 	fw.Run("Insert_Static_RouteMPLS-6-6", func(fw *framework.F, t *testing.T) {
 		// Insert route with the nexthop (do_flush is automatic in insert command)
-		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 0088::0/19 --dst ccee::11 --src 2424::1212 --label 45 --as_path 14 --local_pref 10 --med 10 --weight 5 --counter 6-6")
+		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 0088::0/19 --dst ccee::11 --src 2424::1212 --label 45 --weight 5 --counter 6-6")
 		require.NoError(t, err, "Failed to insert route")
 		t.Logf("Insert route output: %s", output)
 	})


### PR DESCRIPTION
The commit includes following minor changes
 - do not handle path attributes as the module uses all known routes without any preference distinction what is responsibility of an external application
 - reset `errno` before `cgo` calling
 - replace existing configuration on `Create` `RPC`