### PR TITLE
Renumber actions for filter test

### DIFF
--- a/filter/tests/basic_net4.c
+++ b/filter/tests/basic_net4.c
@@ -125,7 +125,7 @@ test_stress_seed12_regression(void *memory, size_t memory_size) {
 			&builders[i], rule_specs[i].dst_addr, dst_mask
 		);
 
-		rules[i] = build_rule(&builders[i], i + 1);
+		rules[i] = build_rule(&builders[i], i);
 	}
 
 	// Initialize filter with all 20 rules
@@ -188,7 +188,7 @@ main() {
 	builder_add_net4_dst(
 		&builder1, ip(192, 255, 168, 0), ip(255, 255, 255, 0)
 	);
-	struct filter_rule action1 = build_rule(&builder1, 1);
+	struct filter_rule action1 = build_rule(&builder1, 0);
 
 	// init filter
 	struct filter filter;
@@ -198,7 +198,7 @@ main() {
 	assert(res == 0);
 
 	query_and_expect_action(
-		&filter, ip(192, 255, 168, 1), ip(192, 255, 168, 10), 1
+		&filter, ip(192, 255, 168, 1), ip(192, 255, 168, 10), 0
 	);
 
 	// no action because src ip mismatch
@@ -226,7 +226,7 @@ main() {
 	builder_add_net4_dst(
 		&builder2, ip(7, 4, 132, 134), ip(255, 255, 128, 0)
 	);
-	struct filter_rule action2 = build_rule(&builder2, 2);
+	struct filter_rule action2 = build_rule(&builder2, 0);
 
 	struct filter filter2;
 	res = filter_init(
@@ -243,7 +243,7 @@ main() {
 	// Packet: src=5.10.138.134 (matches src), dst=7.4.200.100 (matches dst)
 	// Expected: MATCH because both src and dst match
 	query_and_expect_action(
-		&filter2, ip(5, 10, 138, 134), ip(7, 4, 200, 100), 2
+		&filter2, ip(5, 10, 138, 134), ip(7, 4, 200, 100), 0
 	);
 
 	// Packet: src=1.1.1.1 (does NOT match src), dst=7.4.200.100 (matches

--- a/filter/tests/basic_net4_fast.c
+++ b/filter/tests/basic_net4_fast.c
@@ -182,7 +182,7 @@ test_basic(void *arena, enum filter_sign sign) {
 		memcpy(builder->net4_src[0].addr, nets[net_idx].addr, 4);
 		memcpy(builder->net4_src[0].mask, &mask, 4);
 
-		rules[net_idx] = build_rule(builder, (net_idx + 1));
+		rules[net_idx] = build_rule(builder, net_idx);
 
 		uint8_t mask_byte = ((uint8_t *)&mask
 		)[3]; // Get the 4th byte of the BE mask
@@ -194,9 +194,9 @@ test_basic(void *arena, enum filter_sign sign) {
 			if (from <= checks[check_idx] &&
 			    checks[check_idx] <= to &&
 			    !expected_ranges[check_idx]->count) {
-				expected_ranges[check_idx]->values
-					[expected_ranges[check_idx]->count++] =
-					(net_idx + 1);
+				expected_ranges[check_idx]
+					->values[expected_ranges[check_idx]
+							 ->count++] = net_idx;
 			}
 		}
 	}
@@ -305,13 +305,13 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	// Packets 0-2 match rule 1, packets 3-4 match rule 2, packets 5-6 match
 	// rule 3, packet 7 matches nothing
 	uint32_t expected_actions[][3] = {
-		{1, 0, 0}, // Packet 0: Rule 1
-		{1, 0, 0}, // Packet 1: Rule 1
-		{1, 0, 0}, // Packet 2: Rule 1
-		{2, 0, 0}, // Packet 3: Rule 2
-		{2, 0, 0}, // Packet 4: Rule 2
-		{3, 0, 0}, // Packet 5: Rule 3
-		{3, 0, 0}, // Packet 6: Rule 3
+		{0, 0, 0}, // Packet 0: Rule 1
+		{0, 0, 0}, // Packet 1: Rule 1
+		{0, 0, 0}, // Packet 2: Rule 1
+		{1, 0, 0}, // Packet 3: Rule 2
+		{1, 0, 0}, // Packet 4: Rule 2
+		{2, 0, 0}, // Packet 5: Rule 3
+		{2, 0, 0}, // Packet 6: Rule 3
 		{0, 0, 0}, // Packet 7: No match
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1, 1, 0};
@@ -349,7 +349,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			);
 		}
 	}
-	rules[0] = build_rule(&builders[0], 1);
+	rules[0] = build_rule(&builders[0], 0);
 
 	// Rule 2: Add 2 networks
 	builder_init(&builders[1]);
@@ -369,7 +369,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			);
 		}
 	}
-	rules[1] = build_rule(&builders[1], 2);
+	rules[1] = build_rule(&builders[1], 1);
 
 	// Rule 3: Add 2 networks
 	builder_init(&builders[2]);
@@ -389,7 +389,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			);
 		}
 	}
-	rules[2] = build_rule(&builders[2], 3);
+	rules[2] = build_rule(&builders[2], 2);
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -498,8 +498,7 @@ stress(void *arena,
 			}
 		}
 
-		rules[rule_idx] =
-			build_rule(&builders[rule_idx], (rule_idx + 1));
+		rules[rule_idx] = build_rule(&builders[rule_idx], rule_idx);
 	}
 
 	struct value_range **expected_ranges =
@@ -594,7 +593,7 @@ stress(void *arena,
 					expected_ranges[packet_idx];
 				if (!range->count)
 					range->values[range->count++] =
-						(rule_idx + 1);
+						rule_idx;
 			}
 		}
 	}
@@ -684,7 +683,7 @@ test_no_match(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected: no matches for any packet
@@ -794,15 +793,15 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected matches
 	uint32_t expected_actions[][4] = {
-		{1, 0, 0, 0}, // Packet 0: rules 1,2,3
-		{1, 0, 0, 0}, // Packet 1: rules 1,2
-		{1, 0, 0, 0}, // Packet 2: rule 1
-		{4, 0, 0, 0}, // Packet 3: rule 4
+		{0, 0, 0, 0}, // Packet 0: rules 1,2,3
+		{0, 0, 0, 0}, // Packet 1: rules 1,2
+		{0, 0, 0, 0}, // Packet 2: rule 1
+		{3, 0, 0, 0}, // Packet 3: rule 4
 		{0, 0, 0, 0}, // Packet 4: no match
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 0};
@@ -913,7 +912,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected: first 4 match, last 2 don't
@@ -924,7 +923,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 		expected_ranges[i]->count = expected_counts[i];
 		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
 		if (expected_counts[i] > 0) {
-			expected_ranges[i]->values[0] = 1;
+			expected_ranges[i]->values[0] = 0;
 		}
 	}
 
@@ -1026,14 +1025,14 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected: first 3 match their respective rules, last 3 don't match
 	uint32_t expected_actions[][1] = {
+		{0},
 		{1},
 		{2},
-		{3},
 		{0},
 		{0},
 		{0},
@@ -1149,17 +1148,17 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected: packets 0,1,4 match rule 1; packets 2,3,5 match rule 2
 	uint32_t expected_actions[][1] = {
-		{1}, // Packet 0
-		{1}, // Packet 1
-		{2}, // Packet 2
-		{2}, // Packet 3
-		{1}, // Packet 4
-		{2}, // Packet 5
+		{0}, // Packet 0
+		{0}, // Packet 1
+		{1}, // Packet 2
+		{1}, // Packet 3
+		{0}, // Packet 4
+		{1}, // Packet 5
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1};
 

--- a/filter/tests/basic_net6.c
+++ b/filter/tests/basic_net6.c
@@ -143,7 +143,7 @@ test1(void *memory) {
 	};
 	make_addr(net.addr, 0xB, 16, 0xA, 16);
 	builder_add_net6_dst(&builder, net);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 	const struct filter_rule rules[1] = {rule};
 
 	// init filter
@@ -156,7 +156,7 @@ test1(void *memory) {
 		uint8_t src[NET6_LEN] = {};
 		uint8_t dst[NET6_LEN];
 		make_addr(dst, 0xB, 16, 0xA, 16);
-		query_packet_and_expect_action(&filter, src, dst, 1, "dst");
+		query_packet_and_expect_action(&filter, src, dst, 0, "dst");
 	}
 
 	// query packet 2
@@ -177,7 +177,7 @@ test1(void *memory) {
 		memset(dst, 0, NET6_LEN);
 		dst[0] = dst[1] = dst[2] = dst[3] = dst[4] = 0xBB;
 		dst[8] = dst[9] = dst[10] = 0xAA;
-		query_packet_and_expect_action(&filter, src, dst, 1, "dst");
+		query_packet_and_expect_action(&filter, src, dst, 0, "dst");
 	}
 
 	// query packet 4
@@ -195,7 +195,7 @@ test1(void *memory) {
 		uint8_t dst[NET6_LEN];
 		make_addr(dst, 0xB, 16, 0xA, 16);
 		dst[5] = 0xB0;
-		query_packet_and_expect_action(&filter, src, dst, 1, "dst");
+		query_packet_and_expect_action(&filter, src, dst, 0, "dst");
 	}
 
 	// query packet 6
@@ -222,7 +222,7 @@ test1(void *memory) {
 		uint8_t dst[NET6_LEN];
 		make_addr(dst, 0xB, 16, 0xA, 16);
 		dst[11] = 0xA0;
-		query_packet_and_expect_action(&filter, src, dst, 1, "dst");
+		query_packet_and_expect_action(&filter, src, dst, 0, "dst");
 	}
 
 	// query packet 9
@@ -246,7 +246,7 @@ test1(void *memory) {
 			0x00,
 			0x00,
 		};
-		query_packet_and_expect_action(&filter, src, dst, 1, "dst");
+		query_packet_and_expect_action(&filter, src, dst, 0, "dst");
 	}
 
 	filter_free(&filter, sign_net6_dst_compile);
@@ -293,7 +293,7 @@ test2(void *memory) {
 	memset(net.addr, 0xBb, 8);
 	memset(net.addr + 8, 0xAa, 8);
 	builder_add_net6_dst(&builder, net);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 	const struct filter_rule rules[1] = {rule};
 
 	// init filter
@@ -322,7 +322,7 @@ test2(void *memory) {
 			0x00,
 			0x00,
 		};
-		query_packet_and_expect_action(&filter, src, dst, 1, "dst");
+		query_packet_and_expect_action(&filter, src, dst, 0, "dst");
 	}
 
 	// query packet 2
@@ -449,7 +449,7 @@ test3(void *memory) {
 		make_addr(dst_net.addr, 0xB, 16, 0xA, 16);
 		builder_add_net6_dst(&builder1, dst_net);
 
-		rule1 = build_rule(&builder1, 1);
+		rule1 = build_rule(&builder1, 0);
 	}
 
 	struct filter_rule rule2;
@@ -509,7 +509,7 @@ test3(void *memory) {
 		make_addr(dst_net.addr, 0xB, 16, 0xA, 16);
 		builder_add_net6_dst(&builder2, dst_net);
 
-		rule2 = build_rule(&builder2, 2);
+		rule2 = build_rule(&builder2, 1);
 	}
 
 	const struct filter_rule rules[2] = {rule1, rule2};
@@ -527,7 +527,7 @@ test3(void *memory) {
 		uint8_t dst[16];
 		make_addr(dst, 0xB, 10, 0xA, 6);
 
-		query_packet_and_expect_action(&filter, src, dst, 1, "both");
+		query_packet_and_expect_action(&filter, src, dst, 0, "both");
 	}
 
 	// query packet 2
@@ -538,7 +538,7 @@ test3(void *memory) {
 		uint8_t dst[16];
 		make_addr(dst, 0xB, 9, 0xA, 5);
 
-		query_packet_and_expect_action(&filter, src, dst, 2, "both");
+		query_packet_and_expect_action(&filter, src, dst, 1, "both");
 	}
 
 	// query packet 3
@@ -549,7 +549,7 @@ test3(void *memory) {
 		uint8_t dst[16];
 		make_addr(dst, 0xB, 10, 0xA, 6);
 
-		query_packet_and_expect_action(&filter, src, dst, 1, "both");
+		query_packet_and_expect_action(&filter, src, dst, 0, "both");
 	}
 
 	// query packet 4

--- a/filter/tests/basic_net6_fast.c
+++ b/filter/tests/basic_net6_fast.c
@@ -201,7 +201,7 @@ test_basic(void *arena, enum filter_sign sign) {
 		builder->net6_dst[0] = net;
 		builder->net6_src[0] = net;
 
-		rules[net_idx] = build_rule(builder, (net_idx + 1));
+		rules[net_idx] = build_rule(builder, net_idx);
 		// Calculate range for this network
 		uint8_t from = nets[net_idx].addr[15] & mask[15];
 		uint8_t to = nets[net_idx].addr[15] | ~mask[15];
@@ -211,9 +211,9 @@ test_basic(void *arena, enum filter_sign sign) {
 			if (from <= checks[check_idx] &&
 			    checks[check_idx] <= to &&
 			    !expected_ranges[check_idx]->count) {
-				expected_ranges[check_idx]->values
-					[expected_ranges[check_idx]->count++] =
-					(net_idx + 1);
+				expected_ranges[check_idx]
+					->values[expected_ranges[check_idx]
+							 ->count++] = net_idx;
 			}
 		}
 	}
@@ -450,13 +450,13 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	// Packets 0-2 match rule 1, packets 3-4 match rule 2, packets 5-6 match
 	// rule 3, packet 7 matches nothing
 	uint32_t expected_actions[][3] = {
-		{1, 0, 0}, // Packet 0: Rule 1
-		{1, 0, 0}, // Packet 1: Rule 1
-		{1, 0, 0}, // Packet 2: Rule 1
-		{2, 0, 0}, // Packet 3: Rule 2
-		{2, 0, 0}, // Packet 4: Rule 2
-		{3, 0, 0}, // Packet 5: Rule 3
-		{3, 0, 0}, // Packet 6: Rule 3
+		{0, 0, 0}, // Packet 0: Rule 1
+		{0, 0, 0}, // Packet 1: Rule 1
+		{0, 0, 0}, // Packet 2: Rule 1
+		{1, 0, 0}, // Packet 3: Rule 2
+		{1, 0, 0}, // Packet 4: Rule 2
+		{2, 0, 0}, // Packet 5: Rule 3
+		{2, 0, 0}, // Packet 6: Rule 3
 		{0, 0, 0}, // Packet 7: No match
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1, 1, 0};
@@ -490,7 +490,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			builder_add_net6_dst(&builders[0], net);
 		}
 	}
-	rules[0] = build_rule(&builders[0], 1);
+	rules[0] = build_rule(&builders[0], 0);
 
 	// Rule 2: Add 2 networks
 	builder_init(&builders[1]);
@@ -506,7 +506,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			builder_add_net6_dst(&builders[1], net);
 		}
 	}
-	rules[1] = build_rule(&builders[1], 2);
+	rules[1] = build_rule(&builders[1], 1);
 
 	// Rule 3: Add 2 networks
 	builder_init(&builders[2]);
@@ -522,7 +522,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			builder_add_net6_dst(&builders[2], net);
 		}
 	}
-	rules[2] = build_rule(&builders[2], 3);
+	rules[2] = build_rule(&builders[2], 2);
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -641,8 +641,7 @@ stress(void *arena,
 			}
 		}
 
-		rules[rule_idx] =
-			build_rule(&builders[rule_idx], (rule_idx + 1));
+		rules[rule_idx] = build_rule(&builders[rule_idx], rule_idx);
 	}
 
 	struct value_range **expected_ranges =
@@ -734,7 +733,7 @@ stress(void *arena,
 			if (ok) {
 				struct value_range *range =
 					expected_ranges[packet_idx];
-				range->values[range->count++] = (rule_idx + 1);
+				range->values[range->count++] = rule_idx;
 			}
 		}
 	}
@@ -843,7 +842,7 @@ test_no_match(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected: no matches for any packet
@@ -1055,15 +1054,15 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected matches
 	uint32_t expected_actions[][4] = {
-		{1, 0, 0, 0}, // Packet 0: rules 1,2,3
-		{1, 0, 0, 0}, // Packet 1: rules 1,2
-		{1, 0, 0, 0}, // Packet 2: rule 1
-		{4, 0, 0, 0}, // Packet 3: rule 4
+		{0, 0, 0, 0}, // Packet 0: rules 1,2,3
+		{0, 0, 0, 0}, // Packet 1: rules 1,2
+		{0, 0, 0, 0}, // Packet 2: rule 1
+		{3, 0, 0, 0}, // Packet 3: rule 4
 		{0, 0, 0, 0}, // Packet 4: no match
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 0};
@@ -1235,7 +1234,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected: first 4 match, last 2 don't
@@ -1246,7 +1245,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 		expected_ranges[i]->count = expected_counts[i];
 		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
 		if (expected_counts[i] > 0) {
-			expected_ranges[i]->values[0] = 1;
+			expected_ranges[i]->values[0] = 0;
 		}
 	}
 
@@ -1371,14 +1370,14 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected: first 3 match their respective rules, last 3 don't match
 	uint32_t expected_actions[][1] = {
+		{0},
 		{1},
 		{2},
-		{3},
 		{0},
 		{0},
 		{0},
@@ -1557,17 +1556,17 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], (net_idx + 1));
+		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
 	}
 
 	// Expected: packets 0,1,4 match rule 1; packets 2,3,5 match rule 2
 	uint32_t expected_actions[][1] = {
-		{1}, // Packet 0
-		{1}, // Packet 1
-		{2}, // Packet 2
-		{2}, // Packet 3
-		{1}, // Packet 4
-		{2}, // Packet 5
+		{0}, // Packet 0
+		{0}, // Packet 1
+		{1}, // Packet 2
+		{1}, // Packet 3
+		{0}, // Packet 4
+		{1}, // Packet 5
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1};
 

--- a/filter/tests/basic_port_fast.c
+++ b/filter/tests/basic_port_fast.c
@@ -186,16 +186,16 @@ test_basic(void *arena, enum filter_sign sign) {
 			);
 		}
 
-		rules[range_idx] = build_rule(builder, (range_idx + 1));
+		rules[range_idx] = build_rule(builder, range_idx);
 
 		for (size_t check_idx = 0; check_idx < checks_count;
 		     ++check_idx) {
 			if (ranges[range_idx].from <= check_ports[check_idx] &&
 			    check_ports[check_idx] <= ranges[range_idx].to &&
 			    !expected_ranges[check_idx]->count) {
-				expected_ranges[check_idx]->values
-					[expected_ranges[check_idx]->count++] =
-					(range_idx + 1);
+				expected_ranges[check_idx]
+					->values[expected_ranges[check_idx]
+							 ->count++] = range_idx;
 			}
 		}
 	}
@@ -289,13 +289,13 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 
 	// Expected actions for each test packet
 	uint32_t expected_actions[][3] = {
-		{1, 0, 0}, // Packet 0: Rule 1
-		{1, 0, 0}, // Packet 1: Rule 1
-		{1, 0, 0}, // Packet 2: Rule 1
-		{2, 0, 0}, // Packet 3: Rule 2
-		{2, 0, 0}, // Packet 4: Rule 2
-		{3, 0, 0}, // Packet 5: Rule 3
-		{3, 0, 0}, // Packet 6: Rule 3
+		{0, 0, 0}, // Packet 0: Rule 1
+		{0, 0, 0}, // Packet 1: Rule 1
+		{0, 0, 0}, // Packet 2: Rule 1
+		{1, 0, 0}, // Packet 3: Rule 2
+		{1, 0, 0}, // Packet 4: Rule 2
+		{2, 0, 0}, // Packet 5: Rule 3
+		{2, 0, 0}, // Packet 6: Rule 3
 		{0, 0, 0}, // Packet 7: No match
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1, 1, 0};
@@ -326,7 +326,7 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 		builder_add_port_dst_range(&builders[0], 443, 443);
 		builder_add_port_dst_range(&builders[0], 8080, 8080);
 	}
-	rules[0] = build_rule(&builders[0], 1);
+	rules[0] = build_rule(&builders[0], 0);
 
 	// Rule 2: Add 2 port ranges (22, 3389)
 	builder_init(&builders[1]);
@@ -337,7 +337,7 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 		builder_add_port_dst_range(&builders[1], 22, 22);
 		builder_add_port_dst_range(&builders[1], 3389, 3389);
 	}
-	rules[1] = build_rule(&builders[1], 2);
+	rules[1] = build_rule(&builders[1], 1);
 
 	// Rule 3: Add 2 port ranges (3306, 5432)
 	builder_init(&builders[2]);
@@ -348,7 +348,7 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 		builder_add_port_dst_range(&builders[2], 3306, 3306);
 		builder_add_port_dst_range(&builders[2], 5432, 5432);
 	}
-	rules[2] = build_rule(&builders[2], 3);
+	rules[2] = build_rule(&builders[2], 2);
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -447,8 +447,7 @@ stress(void *arena,
 			}
 		}
 
-		rules[rule_idx] =
-			build_rule(&builders[rule_idx], (rule_idx + 1));
+		rules[rule_idx] = build_rule(&builders[rule_idx], rule_idx);
 	}
 
 	struct value_range **expected_ranges =
@@ -560,7 +559,7 @@ stress(void *arena,
 					expected_ranges[packet_idx];
 				if (!range->count)
 					range->values[range->count++] =
-						(rule_idx + 1);
+						rule_idx;
 			}
 		}
 
@@ -689,8 +688,7 @@ test_no_match(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] =
-			build_rule(&builders[range_idx], (range_idx + 1));
+		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
 	}
 
 	// Expected: no matches for any packet
@@ -816,16 +814,15 @@ test_overlapping_ranges(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] =
-			build_rule(&builders[range_idx], (range_idx + 1));
+		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
 	}
 
 	// Expected matches
 	uint32_t expected_actions[][4] = {
-		{1, 0, 0, 0}, // Port 1350: rules 1,2,3
-		{1, 0, 0, 0}, // Port 1250: rules 1,2
-		{1, 0, 0, 0}, // Port 1100: rule 1
-		{4, 0, 0, 0}, // Port 3500: rule 4
+		{0, 0, 0, 0}, // Port 1350: rules 1,2,3
+		{0, 0, 0, 0}, // Port 1250: rules 1,2
+		{0, 0, 0, 0}, // Port 1100: rule 1
+		{3, 0, 0, 0}, // Port 3500: rule 4
 		{0, 0, 0, 0}, // Port 5000: no match
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 0};
@@ -952,8 +949,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] =
-			build_rule(&builders[range_idx], (range_idx + 1));
+		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
 	}
 
 	// Expected: first 4 match, last 2 don't
@@ -964,7 +960,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 		expected_ranges[i]->count = expected_counts[i];
 		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
 		if (expected_counts[i] > 0) {
-			expected_ranges[i]->values[0] = 1;
+			expected_ranges[i]->values[0] = 0;
 		}
 	}
 
@@ -1085,16 +1081,15 @@ test_single_port_ranges(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] =
-			build_rule(&builders[range_idx], (range_idx + 1));
+		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
 	}
 
 	// Expected: first 4 match their respective rules, last 4 don't match
 	uint32_t expected_actions[][1] = {
+		{0},
 		{1},
 		{2},
 		{3},
-		{4},
 		{0},
 		{0},
 		{0},
@@ -1226,18 +1221,17 @@ test_adjacent_ranges(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] =
-			build_rule(&builders[range_idx], (range_idx + 1));
+		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
 	}
 
 	// Expected: ports 0,1,4 match rule 1; ports 2,3,5 match rule 2
 	uint32_t expected_actions[][1] = {
-		{1}, // Port 1000
-		{1}, // Port 1999
-		{2}, // Port 2000
-		{2}, // Port 2999
-		{1}, // Port 1500
-		{2}, // Port 2500
+		{0}, // Port 1000
+		{0}, // Port 1999
+		{1}, // Port 2000
+		{1}, // Port 2999
+		{0}, // Port 1500
+		{1}, // Port 2500
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1};
 
@@ -1365,20 +1359,19 @@ test_extreme_ports(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] =
-			build_rule(&builders[range_idx], (range_idx + 1));
+		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
 	}
 
 	// Expected matches
 	uint32_t expected_actions[][3] = {
-		{1, 0, 0}, // Port 0: rules 1
-		{1, 0, 0}, // Port 1: rules 1
-		{1, 0, 0}, // Port 100: rules 1
-		{3, 0, 0}, // Port 101: rule 3
-		{2, 0, 0}, // Port 65400: rules 2
-		{2, 0, 0}, // Port 65534: rules 2
-		{2, 0, 0}, // Port 65535: rules 2
-		{3, 0, 0}, // Port 500: rule 3
+		{0, 0, 0}, // Port 0: rules 1
+		{0, 0, 0}, // Port 1: rules 1
+		{0, 0, 0}, // Port 100: rules 1
+		{2, 0, 0}, // Port 101: rule 3
+		{1, 0, 0}, // Port 65400: rules 2
+		{1, 0, 0}, // Port 65534: rules 2
+		{1, 0, 0}, // Port 65535: rules 2
+		{2, 0, 0}, // Port 500: rule 3
 	};
 	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1, 1, 1};
 

--- a/filter/tests/basic_ports.c
+++ b/filter/tests/basic_ports.c
@@ -71,7 +71,7 @@ test_src_dst_ports(void *memory) {
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 5, 7);
 	builder_add_port_dst_range(&builder1, 1, 5);
-	struct filter_rule action1 = build_rule(&builder1, 1);
+	struct filter_rule action1 = build_rule(&builder1, 0);
 
 	// action 2:
 	//   src_port: [6..8]
@@ -80,7 +80,7 @@ test_src_dst_ports(void *memory) {
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 6, 8);
 	builder_add_port_dst_range(&builder2, 3, 4);
-	struct filter_rule action2 = build_rule(&builder2, 2);
+	struct filter_rule action2 = build_rule(&builder2, 1);
 
 	struct filter_rule actions[2] = {action1, action2};
 
@@ -89,8 +89,8 @@ test_src_dst_ports(void *memory) {
 	res = filter_init(&f, sign_ports_compile, actions, 2, &memory_context);
 	assert(res == 0);
 
-	query_and_expect_action(&f, 6, 3, 1);
-	query_and_expect_action(&f, 8, 3, 2);
+	query_and_expect_action(&f, 6, 3, 0);
+	query_and_expect_action(&f, 8, 3, 1);
 
 	filter_free(&f, sign_ports_compile);
 }
@@ -111,19 +111,19 @@ src_dst_ports(void *memory) {
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 1024, 5016);
 	builder_add_port_dst_range(&builder1, 500, 50000);
-	struct filter_rule action1 = build_rule(&builder1, 1);
+	struct filter_rule action1 = build_rule(&builder1, 0);
 
 	struct filter_rule_builder builder2;
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 30, 500);
 	builder_add_port_dst_range(&builder2, 400, 12040);
-	struct filter_rule action2 = build_rule(&builder2, 2);
+	struct filter_rule action2 = build_rule(&builder2, 1);
 
 	struct filter_rule_builder builder3;
 	builder_init(&builder3);
 	builder_add_port_src_range(&builder3, 100, 2014);
 	builder_add_port_dst_range(&builder3, 5000, 15000);
-	struct filter_rule action3 = build_rule(&builder3, 3);
+	struct filter_rule action3 = build_rule(&builder3, 2);
 
 	struct filter_rule actions[3] = {action1, action2, action3};
 
@@ -131,21 +131,21 @@ src_dst_ports(void *memory) {
 	res = filter_init(&f, sign_ports_compile, actions, 3, &memory_context);
 	assert(res == 0);
 
-	query_and_expect_action(&f, 30, 400, 2);
-	query_and_expect_action(&f, 35, 445, 2);
-	query_and_expect_action(&f, 120, 6000, 2);
-	query_and_expect_action(&f, 300, 12040, 2);
+	query_and_expect_action(&f, 30, 400, 1);
+	query_and_expect_action(&f, 35, 445, 1);
+	query_and_expect_action(&f, 120, 6000, 1);
+	query_and_expect_action(&f, 300, 12040, 1);
 
-	query_and_expect_action(&f, 300, 12041, 3);
-	query_and_expect_action(&f, 300, 14900, 3);
-	query_and_expect_action(&f, 300, 15000, 3);
+	query_and_expect_action(&f, 300, 12041, 2);
+	query_and_expect_action(&f, 300, 14900, 2);
+	query_and_expect_action(&f, 300, 15000, 2);
 
-	query_and_expect_action(&f, 600, 14000, 3);
-	query_and_expect_action(&f, 1024, 14000, 1);
-	query_and_expect_action(&f, 2000, 13000, 1);
-	query_and_expect_action(&f, 5000, 500, 1);
-	query_and_expect_action(&f, 5000, 50000, 1);
-	query_and_expect_action(&f, 5016, 500, 1);
+	query_and_expect_action(&f, 600, 14000, 2);
+	query_and_expect_action(&f, 1024, 14000, 0);
+	query_and_expect_action(&f, 2000, 13000, 0);
+	query_and_expect_action(&f, 5000, 500, 0);
+	query_and_expect_action(&f, 5000, 50000, 0);
+	query_and_expect_action(&f, 5016, 500, 0);
 
 	query_and_expect_no_action(&f, 5017, 3000);
 	query_and_expect_no_action(&f, 20, 3000);
@@ -169,21 +169,21 @@ test_any_port(void *memory) {
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 1024, 5016);
 	builder_add_port_dst_range(&builder1, 0, 65535);
-	struct filter_rule action1 = build_rule(&builder1, 1);
+	struct filter_rule action1 = build_rule(&builder1, 0);
 
 	// rule 2: src any, dst [400..12040]
 	struct filter_rule_builder builder2;
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 0, 65535);
 	builder_add_port_dst_range(&builder2, 400, 12040);
-	struct filter_rule action2 = build_rule(&builder2, 2);
+	struct filter_rule action2 = build_rule(&builder2, 1);
 
 	// rule 3: src [100..2014], dst [5000..15000]
 	struct filter_rule_builder builder3;
 	builder_init(&builder3);
 	builder_add_port_src_range(&builder3, 100, 2014);
 	builder_add_port_dst_range(&builder3, 5000, 15000);
-	struct filter_rule action3 = build_rule(&builder3, 3);
+	struct filter_rule action3 = build_rule(&builder3, 2);
 
 	struct filter_rule actions[3] = {action1, action2, action3};
 
@@ -191,9 +191,9 @@ test_any_port(void *memory) {
 	res = filter_init(&f, sign_ports_compile, actions, 3, &memory_context);
 	assert(res == 0);
 
-	query_and_expect_action(&f, 1025, 11111, 1);
-	query_and_expect_action(&f, 11111, 404, 2);
-	query_and_expect_action(&f, 500, 15000, 3);
+	query_and_expect_action(&f, 1025, 11111, 0);
+	query_and_expect_action(&f, 11111, 404, 1);
+	query_and_expect_action(&f, 500, 15000, 2);
 
 	query_and_expect_no_action(&f, 1000, 200);
 

--- a/filter/tests/basic_proto.c
+++ b/filter/tests/basic_proto.c
@@ -60,17 +60,17 @@ test_proto_1(void *memory) {
 	struct filter_rule_builder b1;
 	builder_init(&b1);
 	builder_set_proto(&b1, IPPROTO_TCP, 0b101, 0b010);
-	struct filter_rule r1 = build_rule(&b1, 1);
+	struct filter_rule r1 = build_rule(&b1, 0);
 
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_set_proto(&b2, IPPROTO_UDP, 0, 0);
-	struct filter_rule r2 = build_rule(&b2, 2);
+	struct filter_rule r2 = build_rule(&b2, 1);
 
 	struct filter_rule_builder b3;
 	builder_init(&b3);
 	builder_set_proto(&b3, PROTO_UNSPEC, 0, 0);
-	struct filter_rule r3 = build_rule(&b3, 3);
+	struct filter_rule r3 = build_rule(&b3, 2);
 
 	struct filter_rule rules[3] = {r1, r2, r3};
 
@@ -80,15 +80,15 @@ test_proto_1(void *memory) {
 	);
 	assert(res == 0);
 
-	query_tcp_packet(&filter, 0b101, 1);
-	query_tcp_packet(&filter, 0b10101, 1);
-	query_tcp_packet(&filter, 0b1101, 1);
-	query_tcp_packet(&filter, (1 << 9) - 1 - 2, 1);
-	query_tcp_packet(&filter, 0b010, 3);
-	query_tcp_packet(&filter, 0b011, 3);
-	query_tcp_packet(&filter, 0b1110, 3);
+	query_tcp_packet(&filter, 0b101, 0);
+	query_tcp_packet(&filter, 0b10101, 0);
+	query_tcp_packet(&filter, 0b1101, 0);
+	query_tcp_packet(&filter, (1 << 9) - 1 - 2, 0);
+	query_tcp_packet(&filter, 0b010, 2);
+	query_tcp_packet(&filter, 0b011, 2);
+	query_tcp_packet(&filter, 0b1110, 2);
 
-	query_udp_packet(&filter, 2);
+	query_udp_packet(&filter, 1);
 
 	filter_free(&filter, sign_proto_compile);
 }

--- a/filter/tests/basic_proto_range.c
+++ b/filter/tests/basic_proto_range.c
@@ -60,14 +60,14 @@ test_proto_1(void *memory) {
 	builder_add_proto_range(
 		&b1, 256 * IPPROTO_TCP, 256 * IPPROTO_TCP + 255
 	);
-	struct filter_rule r1 = build_rule(&b1, 1);
+	struct filter_rule r1 = build_rule(&b1, 0);
 
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_add_proto_range(
 		&b2, 256 * IPPROTO_UDP, 256 * IPPROTO_UDP + 255
 	);
-	struct filter_rule r2 = build_rule(&b2, 2);
+	struct filter_rule r2 = build_rule(&b2, 1);
 
 	struct filter_rule rules[2] = {r1, r2};
 
@@ -80,10 +80,10 @@ test_proto_1(void *memory) {
 	assert(res == 0);
 
 	LOG(INFO, "query tcp packet...");
-	query_tcp_packet(&filter, 0, 1);
+	query_tcp_packet(&filter, 0, 0);
 
 	LOG(INFO, "query udp packet...");
-	query_udp_packet(&filter, 2);
+	query_udp_packet(&filter, 1);
 
 	filter_free(&filter, sign_proto_range_compile);
 }

--- a/filter/tests/basic_proto_range_fast.c
+++ b/filter/tests/basic_proto_range_fast.c
@@ -66,14 +66,14 @@ test_basic_tcp_udp(void *memory) {
 	builder_add_proto_range(
 		&b1, 256 * IPPROTO_TCP, 256 * IPPROTO_TCP + 255
 	);
-	struct filter_rule r1 = build_rule(&b1, 1);
+	struct filter_rule r1 = build_rule(&b1, 0);
 
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_add_proto_range(
 		&b2, 256 * IPPROTO_UDP, 256 * IPPROTO_UDP + 255
 	);
-	struct filter_rule r2 = build_rule(&b2, 2);
+	struct filter_rule r2 = build_rule(&b2, 1);
 
 	struct filter_rule rules[2] = {r1, r2};
 
@@ -90,10 +90,10 @@ test_basic_tcp_udp(void *memory) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	LOG(INFO, "query tcp packet...");
-	query_tcp_packet(&filter, 0, 1);
+	query_tcp_packet(&filter, 0, 0);
 
 	LOG(INFO, "query udp packet...");
-	query_udp_packet(&filter, 2);
+	query_udp_packet(&filter, 1);
 
 	filter_free(&filter, sign_proto_range_fast_compile);
 
@@ -118,7 +118,7 @@ test_tcp_flags(void *memory) {
 	builder_add_proto_range(
 		&b1, 256 * IPPROTO_TCP + 0x02, 256 * IPPROTO_TCP + 0x02
 	);
-	struct filter_rule r1 = build_rule(&b1, 1);
+	struct filter_rule r1 = build_rule(&b1, 0);
 
 	// Rule 2: TCP ACK (flag 0x10)
 	struct filter_rule_builder b2;
@@ -126,7 +126,7 @@ test_tcp_flags(void *memory) {
 	builder_add_proto_range(
 		&b2, 256 * IPPROTO_TCP + 0x10, 256 * IPPROTO_TCP + 0x10
 	);
-	struct filter_rule r2 = build_rule(&b2, 2);
+	struct filter_rule r2 = build_rule(&b2, 1);
 
 	// Rule 3: TCP FIN (flag 0x01)
 	struct filter_rule_builder b3;
@@ -134,7 +134,7 @@ test_tcp_flags(void *memory) {
 	builder_add_proto_range(
 		&b3, 256 * IPPROTO_TCP + 0x01, 256 * IPPROTO_TCP + 0x01
 	);
-	struct filter_rule r3 = build_rule(&b3, 3);
+	struct filter_rule r3 = build_rule(&b3, 2);
 
 	struct filter_rule rules[3] = {r1, r2, r3};
 
@@ -149,13 +149,13 @@ test_tcp_flags(void *memory) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	LOG(INFO, "query tcp SYN packet...");
-	query_tcp_packet(&filter, 0x02, 1);
+	query_tcp_packet(&filter, 0x02, 0);
 
 	LOG(INFO, "query tcp ACK packet...");
-	query_tcp_packet(&filter, 0x10, 2);
+	query_tcp_packet(&filter, 0x10, 1);
 
 	LOG(INFO, "query tcp FIN packet...");
-	query_tcp_packet(&filter, 0x01, 3);
+	query_tcp_packet(&filter, 0x01, 2);
 
 	filter_free(&filter, sign_proto_range_fast_compile);
 
@@ -183,7 +183,7 @@ test_multiple_ranges_per_rule(void *memory) {
 	builder_add_proto_range(
 		&b1, 256 * IPPROTO_UDP, 256 * IPPROTO_UDP + 255
 	);
-	struct filter_rule r1 = build_rule(&b1, 1);
+	struct filter_rule r1 = build_rule(&b1, 0);
 
 	struct filter_rule rules[1] = {r1};
 
@@ -198,10 +198,10 @@ test_multiple_ranges_per_rule(void *memory) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	LOG(INFO, "query tcp packet...");
-	query_tcp_packet(&filter, 0, 1);
+	query_tcp_packet(&filter, 0, 0);
 
 	LOG(INFO, "query udp packet...");
-	query_udp_packet(&filter, 1);
+	query_udp_packet(&filter, 0);
 
 	filter_free(&filter, sign_proto_range_fast_compile);
 
@@ -224,13 +224,13 @@ test_boundary_values(void *memory) {
 	struct filter_rule_builder b1;
 	builder_init(&b1);
 	builder_add_proto_range(&b1, 0, 100);
-	struct filter_rule r1 = build_rule(&b1, 1);
+	struct filter_rule r1 = build_rule(&b1, 0);
 
 	// Rule 2: Proto range 65435-65535 (near max uint16_t)
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_add_proto_range(&b2, 65435, 65535);
-	struct filter_rule r2 = build_rule(&b2, 2);
+	struct filter_rule r2 = build_rule(&b2, 1);
 
 	struct filter_rule rules[2] = {r1, r2};
 
@@ -258,7 +258,7 @@ test_boundary_values(void *memory) {
 	);
 	TEST_ASSERT_EQUAL(actions1->count, 1, "proto 0 should match rule 1");
 	TEST_ASSERT_EQUAL(
-		ADDR_OF(&actions1->values)[0], 1, "proto 0 should match rule 1"
+		ADDR_OF(&actions1->values)[0], 0, "proto 0 should match rule 1"
 	);
 	free_packet(&packet1);
 

--- a/filter/tests/basic_vlan.c
+++ b/filter/tests/basic_vlan.c
@@ -47,17 +47,17 @@ test_proto_1(void *memory) {
 	struct filter_rule_builder b1;
 	builder_init(&b1);
 	builder_set_vlan(&b1, 10);
-	struct filter_rule r1 = build_rule(&b1, 1);
+	struct filter_rule r1 = build_rule(&b1, 0);
 
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_set_vlan(&b2, 20);
-	struct filter_rule r2 = build_rule(&b2, 2);
+	struct filter_rule r2 = build_rule(&b2, 1);
 
 	struct filter_rule_builder b3;
 	builder_init(&b3);
 	builder_set_vlan(&b3, 30);
-	struct filter_rule r3 = build_rule(&b3, 3);
+	struct filter_rule r3 = build_rule(&b3, 2);
 
 	struct filter_rule rules[3] = {r1, r2, r3};
 
@@ -67,9 +67,9 @@ test_proto_1(void *memory) {
 	);
 	assert(res == 0);
 
-	query_packet(&filter, 10, 1);
-	query_packet(&filter, 20, 2);
-	query_packet(&filter, 30, 3);
+	query_packet(&filter, 10, 0);
+	query_packet(&filter, 20, 1);
+	query_packet(&filter, 30, 2);
 
 	filter_free(&filter, sign_vlan_compile);
 }

--- a/filter/tests/bench_net4.c
+++ b/filter/tests/bench_net4.c
@@ -226,7 +226,7 @@ generate_rules(
 			builder_set_proto(&builders[i], proto, 0, 0);
 		}
 
-		rules[i] = build_rule(&builders[i], (i + 1));
+		rules[i] = build_rule(&builders[i], i);
 	}
 }
 

--- a/filter/tests/bench_net4_fast.c
+++ b/filter/tests/bench_net4_fast.c
@@ -227,7 +227,7 @@ generate_rules(
 			builder_set_proto(&builders[i], proto, 0, 0);
 		}
 
-		rules[i] = build_rule(&builders[i], (i + 1));
+		rules[i] = build_rule(&builders[i], i);
 	}
 }
 

--- a/filter/tests/bench_net6.c
+++ b/filter/tests/bench_net6.c
@@ -247,7 +247,7 @@ generate_rules(
 			builder_set_proto(&builders[i], proto, 0, 0);
 		}
 
-		rules[i] = build_rule(&builders[i], (i + 1));
+		rules[i] = build_rule(&builders[i], i);
 	}
 }
 

--- a/filter/tests/bench_net6_fast.c
+++ b/filter/tests/bench_net6_fast.c
@@ -248,7 +248,7 @@ generate_rules(
 			builder_set_proto(&builders[i], proto, 0, 0);
 		}
 
-		rules[i] = build_rule(&builders[i], (i + 1));
+		rules[i] = build_rule(&builders[i], i);
 	}
 }
 

--- a/filter/tests/combo_net4_port_proto_dst.c
+++ b/filter/tests/combo_net4_port_proto_dst.c
@@ -45,7 +45,7 @@ test_no_match_proto_only(void *arena) {
 	builder_add_net4_dst(&builder, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder, 80, 90);
 	builder_set_proto(&builder, IPPROTO_TCP, 0, 0);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 
 	// Test packets: IP and port match but protocol doesn't
 	const struct {
@@ -131,7 +131,7 @@ test_all_match(void *arena) {
 	builder_add_net4_dst(&builder, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder, 80, 90);
 	builder_set_proto(&builder, IPPROTO_TCP, 0, 0);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 
 	// Test packets: All match
 	const struct {
@@ -169,7 +169,7 @@ test_all_match(void *arena) {
 		expected_ranges[i] = malloc(sizeof(struct value_range));
 		expected_ranges[i]->count = 1;
 		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		expected_ranges[i]->values[0] = 1;
+		expected_ranges[i]->values[0] = 0;
 	}
 
 	struct block_allocator alloc;
@@ -218,7 +218,7 @@ test_multiple_rules_overlap(void *arena) {
 	builder_add_net4_dst(&builder1, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder1, 80, 90);
 	builder_set_proto(&builder1, IPPROTO_TCP, 0, 0);
-	struct filter_rule rule1 = build_rule(&builder1, 1);
+	struct filter_rule rule1 = build_rule(&builder1, 0);
 
 	// Rule 2: dst IP 10.0.0.0/16, dst port 85-95, TCP
 	struct filter_rule_builder builder2;
@@ -226,7 +226,7 @@ test_multiple_rules_overlap(void *arena) {
 	builder_add_net4_dst(&builder2, ip(10, 0, 0, 0), ip(255, 255, 0, 0));
 	builder_add_port_dst_range(&builder2, 85, 95);
 	builder_set_proto(&builder2, IPPROTO_TCP, 0, 0);
-	struct filter_rule rule2 = build_rule(&builder2, 2);
+	struct filter_rule rule2 = build_rule(&builder2, 1);
 
 	// Rule 3: dst IP 10.0.0.0/24, dst port 80-90, UDP
 	struct filter_rule_builder builder3;
@@ -234,7 +234,7 @@ test_multiple_rules_overlap(void *arena) {
 	builder_add_net4_dst(&builder3, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder3, 80, 90);
 	builder_set_proto(&builder3, IPPROTO_UDP, 0, 0);
-	struct filter_rule rule3 = build_rule(&builder3, 3);
+	struct filter_rule rule3 = build_rule(&builder3, 2);
 
 	struct filter_rule rules[] = {rule1, rule2, rule3};
 
@@ -247,15 +247,15 @@ test_multiple_rules_overlap(void *arena) {
 		uint32_t expected_actions[3];
 	} test_cases[] = {
 		// IP: 10.0.0.50, Port: 85, TCP -> matches rule1 and rule2
-		{{10, 0, 0, 50}, 85, IPPROTO_TCP, 1, {1, 0, 0}},
+		{{10, 0, 0, 50}, 85, IPPROTO_TCP, 1, {0, 0, 0}},
 		// IP: 10.0.0.50, Port: 80, TCP -> matches rule1 only
-		{{10, 0, 0, 50}, 80, IPPROTO_TCP, 1, {1, 0, 0}},
+		{{10, 0, 0, 50}, 80, IPPROTO_TCP, 1, {0, 0, 0}},
 		// IP: 10.0.1.50, Port: 85, TCP -> matches rule2 only
-		{{10, 0, 1, 50}, 85, IPPROTO_TCP, 1, {2, 0, 0}},
+		{{10, 0, 1, 50}, 85, IPPROTO_TCP, 1, {1, 0, 0}},
 		// IP: 10.0.0.50, Port: 85, UDP -> matches rule3 only
-		{{10, 0, 0, 50}, 85, IPPROTO_UDP, 1, {3, 0, 0}},
+		{{10, 0, 0, 50}, 85, IPPROTO_UDP, 1, {2, 0, 0}},
 		// IP: 10.0.0.50, Port: 95, TCP -> matches rule2 only
-		{{10, 0, 0, 50}, 95, IPPROTO_TCP, 1, {2, 0, 0}},
+		{{10, 0, 0, 50}, 95, IPPROTO_TCP, 1, {1, 0, 0}},
 		// IP: 10.0.0.50, Port: 100, TCP -> no match
 		{{10, 0, 0, 50}, 100, IPPROTO_TCP, 0, {0, 0, 0}},
 		// IP: 10.1.0.50, Port: 85, TCP -> no match (outside /16)
@@ -338,7 +338,7 @@ test_tcp_flags(void *arena) {
 	builder_add_net4_dst(&builder1, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder1, 80, 80);
 	builder_set_proto(&builder1, IPPROTO_TCP, 0x02, 0); // SYN flag
-	struct filter_rule rule1 = build_rule(&builder1, 1);
+	struct filter_rule rule1 = build_rule(&builder1, 0);
 
 	// Rule 2: dst IP 10.0.0.0/24, dst port 80, TCP with ACK flag
 	struct filter_rule_builder builder2;
@@ -346,7 +346,7 @@ test_tcp_flags(void *arena) {
 	builder_add_net4_dst(&builder2, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder2, 80, 80);
 	builder_set_proto(&builder2, IPPROTO_TCP, 0x10, 0); // ACK flag
-	struct filter_rule rule2 = build_rule(&builder2, 2);
+	struct filter_rule rule2 = build_rule(&builder2, 1);
 
 	struct filter_rule rules[] = {rule1, rule2};
 
@@ -360,11 +360,11 @@ test_tcp_flags(void *arena) {
 		uint32_t expected_actions[2];
 	} test_cases[] = {
 		// SYN flag -> matches rule1
-		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x02, 1, {1, 0}},
+		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x02, 1, {0, 0}},
 		// ACK flag -> matches rule2
-		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x10, 1, {2, 0}},
+		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x10, 1, {1, 0}},
 		// SYN+ACK flags -> matches both rules
-		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x12, 1, {1, 0}},
+		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x12, 1, {0, 0}},
 		// FIN flag -> no match
 		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x01, 0, {0, 0}},
 		// No flags -> no match

--- a/filter/tests/combo_net4_port_src.c
+++ b/filter/tests/combo_net4_port_src.c
@@ -74,7 +74,7 @@ test_no_match_port_only(void *arena) {
 	uint32_t mask = prefix_mask(24);
 	builder_add_net4_src(&builder, ip(10, 0, 0, 0), (const uint8_t *)&mask);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 
 	// Test packets: IP matches but port doesn't
 	const struct {
@@ -154,7 +154,7 @@ test_no_match_ip_only(void *arena) {
 	uint32_t mask = prefix_mask(24);
 	builder_add_net4_src(&builder, ip(10, 0, 0, 0), (const uint8_t *)&mask);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 
 	// Test packets: Port matches but IP doesn't
 	const struct {
@@ -234,7 +234,7 @@ test_both_match(void *arena) {
 	uint32_t mask = prefix_mask(24);
 	builder_add_net4_src(&builder, ip(10, 0, 0, 0), (const uint8_t *)&mask);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 
 	// Test packets: Both IP and port match
 	const struct {
@@ -271,7 +271,7 @@ test_both_match(void *arena) {
 		expected_ranges[i] = malloc(sizeof(struct value_range));
 		expected_ranges[i]->count = 1;
 		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		expected_ranges[i]->values[0] = 1;
+		expected_ranges[i]->values[0] = 0;
 	}
 
 	struct block_allocator alloc;
@@ -321,7 +321,7 @@ test_overlapping(void *arena) {
 		&builders[0], ip(10, 0, 0, 0), (const uint8_t *)&mask1
 	);
 	builder_add_port_src_range(&builders[0], 80, 100);
-	rules[0] = build_rule(&builders[0], 1);
+	rules[0] = build_rule(&builders[0], 0);
 
 	builder_init(&builders[1]);
 	uint32_t mask2 = prefix_mask(16);
@@ -329,7 +329,7 @@ test_overlapping(void *arena) {
 		&builders[1], ip(10, 1, 0, 0), (const uint8_t *)&mask2
 	);
 	builder_add_port_src_range(&builders[1], 90, 110);
-	rules[1] = build_rule(&builders[1], 2);
+	rules[1] = build_rule(&builders[1], 1);
 
 	builder_init(&builders[2]);
 	uint32_t mask3 = prefix_mask(24);
@@ -337,7 +337,7 @@ test_overlapping(void *arena) {
 		&builders[2], ip(10, 1, 1, 0), (const uint8_t *)&mask3
 	);
 	builder_add_port_src_range(&builders[2], 95, 105);
-	rules[2] = build_rule(&builders[2], 3);
+	rules[2] = build_rule(&builders[2], 2);
 
 	// Test packets
 	const struct {
@@ -346,10 +346,10 @@ test_overlapping(void *arena) {
 		uint32_t expected_actions[3];
 		size_t expected_count;
 	} test_cases[] = {
-		{{10, 2, 0, 1}, 85, {1, 0, 0}, 1}, // Only rule 1 matches
+		{{10, 2, 0, 1}, 85, {0, 0, 0}, 1}, // Only rule 1 matches
 		{{10, 1, 1, 100}, 79, {0, 0, 0}, 0
 		}, // IP matches all but port matches none
-		{{10, 1, 1, 100}, 106, {2, 0, 0}, 1
+		{{10, 1, 1, 100}, 106, {1, 0, 0}, 1
 		}, // Only rule 2 matches (port 106 in 90-110, not in 80-100 or
 		   // 95-105)
 	};

--- a/filter/tests/combo_net6_port_src.c
+++ b/filter/tests/combo_net6_port_src.c
@@ -87,7 +87,7 @@ test_no_match_port_only(void *arena) {
 	memcpy(net.mask, mask, NET6_LEN);
 	builder_add_net6_src(&builder, net);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 
 	// Test packets: IP matches but port doesn't
 	const struct {
@@ -181,7 +181,7 @@ test_no_match_ip_only(void *arena) {
 	memcpy(net.mask, mask, NET6_LEN);
 	builder_add_net6_src(&builder, net);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 
 	// Test packets: Port matches but IP doesn't
 	const struct {
@@ -290,7 +290,7 @@ test_both_match(void *arena) {
 	memcpy(net.mask, mask, NET6_LEN);
 	builder_add_net6_src(&builder, net);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 1);
+	struct filter_rule rule = build_rule(&builder, 0);
 
 	// Test packets: Both IP and port match
 	const struct {
@@ -350,7 +350,7 @@ test_both_match(void *arena) {
 		expected_ranges[i] = malloc(sizeof(struct value_range));
 		expected_ranges[i]->count = 1;
 		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		expected_ranges[i]->values[0] = 1;
+		expected_ranges[i]->values[0] = 0;
 	}
 
 	struct block_allocator alloc;

--- a/filter/tests/corner.c
+++ b/filter/tests/corner.c
@@ -67,21 +67,21 @@ check_single_attribute(void *memory) {
 	builder_add_port_src_range(&builder1, 5, 7);
 	builder_add_port_src_range(&builder1, 6, 10);
 	builder_add_port_src_range(&builder1, 15, 20);
-	struct filter_rule rule1 = build_rule(&builder1, 1);
+	struct filter_rule rule1 = build_rule(&builder1, 0);
 
 	// second action
 	// src port: [11-21]
 	struct filter_rule_builder builder2;
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 11, 21);
-	struct filter_rule rule2 = build_rule(&builder2, 2);
+	struct filter_rule rule2 = build_rule(&builder2, 1);
 
 	// third action
 	// src port: [30-40]
 	struct filter_rule_builder builder3;
 	builder_init(&builder3);
 	builder_add_port_src_range(&builder3, 30, 40);
-	struct filter_rule rule3 = build_rule(&builder3, 3);
+	struct filter_rule rule3 = build_rule(&builder3, 2);
 
 	// setup rules
 	struct filter_rule rules[3] = {rule1, rule2, rule3};
@@ -119,7 +119,7 @@ check_single_attribute(void *memory) {
 		};
 
 		uint32_t expected_actions[queries] = {
-			1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 1, 1, 1, 2, 3, 3, 3, 3
+			0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 0, 0, 1, 2, 2, 2, 2
 		};
 
 		for (size_t i = 0; i < queries; ++i) {

--- a/filter/tests/macros.c
+++ b/filter/tests/macros.c
@@ -28,7 +28,7 @@ run_case(void) {
 	struct filter_rule_builder b;
 	builder_init(&b);
 	builder_add_port_src_range(&b, 1024, 5016);
-	struct filter_rule r = build_rule(&b, 1);
+	struct filter_rule r = build_rule(&b, 0);
 
 	// init filter
 	struct filter f;
@@ -47,7 +47,7 @@ run_case(void) {
 	struct value_range *actions;
 	filter_query(&f, sign_compile, &packet_ptr, &actions, 1);
 	assert(actions->count == 1);
-	assert(ADDR_OF(&actions->values)[0] == 1);
+	assert(ADDR_OF(&actions->values)[0] == 0);
 
 	free_packet(&p);
 	filter_free(&f, sign);

--- a/filter/tests/memory.c
+++ b/filter/tests/memory.c
@@ -100,7 +100,7 @@ test_src_dst_ports(void *memory) {
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 5, 7);
 	builder_add_port_dst_range(&builder1, 1, 5);
-	struct filter_rule action1 = build_rule(&builder1, 1);
+	struct filter_rule action1 = build_rule(&builder1, 0);
 
 	// action 2:
 	//	src_port: [6..8]
@@ -109,7 +109,7 @@ test_src_dst_ports(void *memory) {
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 6, 8);
 	builder_add_port_dst_range(&builder2, 3, 4);
-	struct filter_rule action2 = build_rule(&builder2, 2);
+	struct filter_rule action2 = build_rule(&builder2, 1);
 
 	struct filter_rule actions[2] = {action1, action2};
 
@@ -120,8 +120,8 @@ test_src_dst_ports(void *memory) {
 	);
 	assert(res == 0);
 
-	query_and_expect_action(&filter, 6, 3, 1, "ports");
-	query_and_expect_action(&filter, 8, 3, 2, "ports");
+	query_and_expect_action(&filter, 6, 3, 0, "ports");
+	query_and_expect_action(&filter, 8, 3, 1, "ports");
 
 	filter_free(&filter, sign_ports_compile);
 
@@ -145,14 +145,14 @@ test_src_port_only(void *memory) {
 	struct filter_rule_builder builder1;
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 500, 700);
-	struct filter_rule action1 = build_rule(&builder1, 1);
+	struct filter_rule action1 = build_rule(&builder1, 0);
 
 	// action 2:
 	//	src_port: [600..800]
 	struct filter_rule_builder builder2;
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 600, 800);
-	struct filter_rule action2 = build_rule(&builder2, 2);
+	struct filter_rule action2 = build_rule(&builder2, 1);
 
 	struct filter_rule actions[2] = {action1, action2};
 
@@ -163,11 +163,11 @@ test_src_port_only(void *memory) {
 	);
 	assert(res == 0);
 
-	query_and_expect_action(&filter, 500, 0, 1, "port_src");
-	query_and_expect_action(&filter, 600, 0, 1, "port_src");
-	query_and_expect_action(&filter, 700, 0, 1, "port_src");
-	query_and_expect_action(&filter, 701, 0, 2, "port_src");
-	query_and_expect_action(&filter, 800, 0, 2, "port_src");
+	query_and_expect_action(&filter, 500, 0, 0, "port_src");
+	query_and_expect_action(&filter, 600, 0, 0, "port_src");
+	query_and_expect_action(&filter, 700, 0, 0, "port_src");
+	query_and_expect_action(&filter, 701, 0, 1, "port_src");
+	query_and_expect_action(&filter, 800, 0, 1, "port_src");
 
 	query_and_expect_no_action(&filter, 499, 0, "port_src");
 	query_and_expect_no_action(&filter, 801, 0, "port_src");

--- a/filter/tests/net4_ports.c
+++ b/filter/tests/net4_ports.c
@@ -62,7 +62,7 @@ test(void *memory) {
 	builder_add_port_dst_range(&b1, 200, 250);
 	builder_add_net4_src(&b1, ip(198, 233, 0, 0), ip(255, 255, 0, 0));
 	builder_add_net4_dst(&b1, ip(192, 0, 0, 0), ip(255, 0, 0, 0));
-	struct filter_rule a1 = build_rule(&b1, 1);
+	struct filter_rule a1 = build_rule(&b1, 0);
 
 	// a2:
 	//  src_port: 200-300
@@ -75,7 +75,7 @@ test(void *memory) {
 	builder_add_port_dst_range(&b2, 100, 300);
 	builder_add_net4_src(&b2, ip(198, 233, 10, 0), ip(255, 255, 255, 0));
 	builder_add_net4_dst(&b2, ip(192, 0, 0, 0), ip(255, 0, 0, 0));
-	struct filter_rule a2 = build_rule(&b2, 2);
+	struct filter_rule a2 = build_rule(&b2, 1);
 
 	struct filter_rule actions[2] = {a1, a2};
 
@@ -89,11 +89,11 @@ test(void *memory) {
 	// make queries
 
 	query_and_expect_action(
-		&filter, ip(198, 233, 10, 15), ip(192, 1, 1, 1), 200, 230, 1
+		&filter, ip(198, 233, 10, 15), ip(192, 1, 1, 1), 200, 230, 0
 	);
 
 	query_and_expect_action(
-		&filter, ip(198, 233, 10, 15), ip(192, 1, 1, 1), 200, 150, 2
+		&filter, ip(198, 233, 10, 15), ip(192, 1, 1, 1), 200, 150, 1
 	);
 
 	filter_free(&filter, sign_net4_ports_compile);

--- a/filter/tests/shm/compiler.c
+++ b/filter/tests/shm/compiler.c
@@ -39,7 +39,7 @@ build_filter(struct common *common, struct memory_context *mctx) {
 		builder_set_proto(
 			builder, i % 2 == 0 ? IPPROTO_TCP : IPPROTO_UDP, 0, 0
 		);
-		rules[i] = build_rule(builder, i + 1);
+		rules[i] = build_rule(builder, i);
 	}
 	LOG(INFO, "compiling %zu rules...", rule_count);
 	int res = filter_init(


### PR DESCRIPTION
`Multifilter` result merging requires all rules have monotonic increasing action number is to make different filter lookup result comparable.

The commit is just renumber action action id inside filter test just to make further commits clean.