### PR TITLE
Extract `remap_table` from `value_table`

### DIFF
--- a/common/value.h
+++ b/common/value.h
@@ -14,7 +14,6 @@
 
 struct value_table {
 	struct memory_context *memory_context;
-	struct remap_table remap_table;
 	uint32_t h_dim;
 	uint32_t v_dim;
 	uint32_t **values;
@@ -22,7 +21,6 @@ struct value_table {
 
 static inline void
 value_table_free(struct value_table *value_table) {
-	remap_table_free(&value_table->remap_table);
 	struct memory_context *memory_context =
 		ADDR_OF(&value_table->memory_context);
 
@@ -55,12 +53,6 @@ value_table_init(
 ) {
 	SET_OFFSET_OF(&value_table->memory_context, memory_context);
 
-	if (remap_table_init(
-		    &value_table->remap_table, memory_context, h_dim * v_dim
-	    )) {
-		return -1;
-	}
-
 	value_table->h_dim = h_dim;
 	value_table->v_dim = v_dim;
 
@@ -73,11 +65,9 @@ value_table_init(
 	uint32_t **values = (uint32_t **)memory_balloc(
 		memory_context, chunk_count * sizeof(uint32_t *)
 	);
-
-	if (values == NULL) {
-		remap_table_free(&value_table->remap_table);
+	if (values == NULL)
 		return -1;
-	}
+
 	memset(values, 0, chunk_count * sizeof(uint32_t *));
 	SET_OFFSET_OF(&value_table->values, values);
 
@@ -97,11 +87,6 @@ value_table_init(
 	return 0;
 }
 
-static inline void
-value_table_new_gen(struct value_table *value_table) {
-	remap_table_new_gen(&value_table->remap_table);
-}
-
 static inline uint32_t *
 value_table_get_ptr(
 	struct value_table *value_table, uint32_t h_idx, uint32_t v_idx
@@ -117,29 +102,13 @@ static inline uint32_t
 value_table_get(
 	struct value_table *value_table, uint32_t h_idx, uint32_t v_idx
 ) {
-	uint32_t **values = ADDR_OF(&value_table->values);
-	uint64_t idx = (v_idx * value_table->h_dim) + h_idx;
-
-	return ADDR_OF(
-		values + idx / VALUE_TABLE_CHUNK_SIZE
-	)[idx % VALUE_TABLE_CHUNK_SIZE];
-}
-
-static inline int
-value_table_touch(
-	struct value_table *value_table, uint32_t h_idx, uint32_t v_idx
-) {
-	uint32_t **values = ADDR_OF(&value_table->values);
-	uint64_t idx = (v_idx * value_table->h_dim) + h_idx;
-
-	uint32_t *value = ADDR_OF(values + idx / VALUE_TABLE_CHUNK_SIZE) +
-			  (idx % VALUE_TABLE_CHUNK_SIZE);
-	return remap_table_touch(&value_table->remap_table, *value, value);
+	return *value_table_get_ptr(value_table, h_idx, v_idx);
 }
 
 static inline void
-value_table_compact(struct value_table *value_table) {
-	remap_table_compact(&value_table->remap_table);
+value_table_compact(
+	struct value_table *value_table, struct remap_table *remap_table
+) {
 
 	uint32_t **values = ADDR_OF(&value_table->values);
 
@@ -149,8 +118,6 @@ value_table_compact(struct value_table *value_table) {
 			ADDR_OF(values + idx / VALUE_TABLE_CHUNK_SIZE) +
 			(idx % VALUE_TABLE_CHUNK_SIZE);
 
-		*value = remap_table_compacted(
-			&value_table->remap_table, *value
-		);
+		*value = remap_table_compacted(remap_table, *value);
 	}
 }

--- a/filter/compiler/device.c
+++ b/filter/compiler/device.c
@@ -33,39 +33,64 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 	if (res < 0) {
 		goto error_init;
 	}
-	// FIXME: handle errors
 	SET_OFFSET_OF(data, t);
+
+	struct remap_table remap_table;
+	if (remap_table_init(&remap_table, memory_context, max_device_id + 1)) {
+		goto error_remap_table;
+	}
+
 	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
 		if (r->device_count == 0) {
 			continue;
 		}
-		value_table_new_gen(t);
+		remap_table_new_gen(&remap_table);
 		for (uint16_t idx = 0; idx < r->device_count; ++idx) {
-			value_table_touch(t, 0, r->devices[idx].id);
+			uint32_t *value =
+				value_table_get_ptr(t, 0, r->devices[idx].id);
+			if (remap_table_touch(&remap_table, *value, value) <
+			    0) {
+				goto error_touch;
+			}
 		}
 	}
-	value_table_compact(t);
+
+	remap_table_compact(&remap_table);
+	value_table_compact(t, &remap_table);
+	remap_table_free(&remap_table);
 
 	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
 		value_registry_start(registry);
 		if (r->device_count == 0) {
 			for (uint64_t id = 0; id < max_device_id + 1; ++id) {
-				value_registry_collect(
-					registry, value_table_get(t, 0, id)
-				);
+				if (value_registry_collect(
+					    registry, value_table_get(t, 0, id)
+				    )) {
+					goto error_collect;
+				}
 			}
 		} else {
 			for (uint16_t idx = 0; idx < r->device_count; ++idx) {
-				value_registry_collect(
-					registry,
-					value_table_get(
-						t, 0, r->devices[idx].id
-					)
-				);
+				if (value_registry_collect(
+					    registry,
+					    value_table_get(
+						    t, 0, r->devices[idx].id
+					    )
+				    )) {
+					goto error_collect;
+				}
 			}
 		}
 	}
 	return 0;
+
+error_touch:
+	remap_table_free(&remap_table);
+
+error_collect:
+error_remap_table:
+	value_table_free(t);
+	SET_OFFSET_OF(data, NULL);
 
 error_init:
 	memory_bfree(memory_context, t, sizeof(struct value_table));

--- a/filter/compiler/helper.c
+++ b/filter/compiler/helper.c
@@ -33,6 +33,7 @@ struct value_set_ctx {
 	const struct filter_rule *rules;
 	struct value_table *table;
 	struct value_registry *registry;
+	struct remap_table remap_table;
 };
 
 static int
@@ -50,11 +51,13 @@ value_table_set_action(uint32_t v1, uint32_t v2, uint32_t idx, void *data) {
 	uint32_t prev_value = value_table_get(set_ctx->table, v1, v2);
 
 	if (!action_list_is_term(set_ctx->registry, prev_value)) {
+		uint32_t *value = value_table_get_ptr(set_ctx->table, v1, v2);
 		/*
 		 * FIXME: we assume value table produces increasing sequence
 		 * of values - this is important for value registry handling.
 		 */
-		int res = value_table_touch(set_ctx->table, v1, v2);
+		int res =
+			remap_table_touch(&set_ctx->remap_table, *value, value);
 
 		if (res <= 0)
 			return res;
@@ -109,10 +112,18 @@ merge_and_set_registry_values(
 	set_ctx.rules = rules;
 	set_ctx.table = table;
 	set_ctx.registry = registry;
+	if (remap_table_init(
+		    &set_ctx.remap_table,
+		    memory_context,
+		    value_registry_capacity(registry1) *
+			    value_registry_capacity(registry2)
+	    )) {
+		goto error_merge;
+	}
 
 	for (uint32_t range_idx = 0; range_idx < registry1->range_count;
 	     ++range_idx) {
-		value_table_new_gen(table);
+		remap_table_new_gen(&set_ctx.remap_table);
 		if (value_registry_join_range(
 			    registry1,
 			    registry2,
@@ -120,10 +131,15 @@ merge_and_set_registry_values(
 			    value_table_set_action,
 			    &set_ctx
 		    ))
-			goto error_merge;
+			goto error_join;
 	}
 
+	remap_table_free(&set_ctx.remap_table);
+
 	return 0;
+
+error_join:
+	remap_table_free(&set_ctx.remap_table);
 
 error_merge:
 	value_registry_free(registry);
@@ -134,11 +150,18 @@ error_registry:
 	return -1;
 }
 
+struct collect_ctx {
+	struct value_table *value_table;
+	struct remap_table remap_table;
+};
+
 static int
 value_table_touch_action(uint32_t v1, uint32_t v2, uint32_t idx, void *data) {
 	(void)idx;
-	struct value_table *table = (struct value_table *)data;
-	if (value_table_touch(table, v1, v2) < 0)
+	struct collect_ctx *collect_ctx = (struct collect_ctx *)data;
+
+	uint32_t *value = value_table_get_ptr(collect_ctx->value_table, v1, v2);
+	if (remap_table_touch(&collect_ctx->remap_table, *value, value))
 		return -1;
 	return 0;
 }
@@ -159,21 +182,39 @@ merge_registry_values(
 		return -1;
 	}
 
+	struct collect_ctx collect_ctx;
+	collect_ctx.value_table = table;
+	if (remap_table_init(
+		    &collect_ctx.remap_table,
+		    memory_context,
+		    value_registry_capacity(registry1) *
+			    value_registry_capacity(registry2)
+	    )) {
+		goto error_remap_table;
+	}
+
 	for (uint32_t range_idx = 0; range_idx < registry1->range_count;
 	     ++range_idx) {
-		value_table_new_gen(table);
+		remap_table_new_gen(&collect_ctx.remap_table);
 		value_registry_join_range(
 			registry1,
 			registry2,
 			range_idx,
 			value_table_touch_action,
-			table
+			&collect_ctx
 		);
 	}
 
-	value_table_compact(table);
+	remap_table_compact(&collect_ctx.remap_table);
+	value_table_compact(table, &collect_ctx.remap_table);
+	remap_table_free(&collect_ctx.remap_table);
 
 	return 0;
+
+error_remap_table:
+	value_table_free(table);
+
+	return -1;
 }
 
 struct value_collect_ctx {

--- a/filter/compiler/helper.h
+++ b/filter/compiler/helper.h
@@ -33,12 +33,6 @@ init_dummy_registry(
 );
 
 static inline int
-lpm_collect_value_iterator(uint32_t value, void *data) {
-	struct value_table *table = (struct value_table *)data;
-	return value_table_touch(table, 0, value);
-}
-
-static inline int
 lpm_collect_registry_iterator(uint32_t value, void *data) {
 	struct value_registry *registry = (struct value_registry *)data;
 	return value_registry_collect(registry, value);

--- a/filter/compiler/net4.c
+++ b/filter/compiler/net4.c
@@ -34,7 +34,8 @@ net4_collect_values(
 	struct net4 *start,
 	uint32_t count,
 	struct range_index *range_index,
-	struct value_table *table
+	struct value_table *table,
+	struct remap_table *remap_table
 ) {
 	uint32_t *values = ADDR_OF(&range_index->values);
 
@@ -54,7 +55,9 @@ net4_collect_values(
 			);
 
 		for (uint32_t idx = start; idx < stop; ++idx) {
-			if (value_table_touch(table, 0, values[idx]) < 0) {
+			uint32_t *value =
+				value_table_get_ptr(table, 0, values[idx]);
+			if (remap_table_touch(remap_table, *value, value) < 0) {
 				return -1;
 			}
 		}
@@ -121,42 +124,44 @@ collect_net4_values(
 		}
 	}
 	if (lpm_init(lpm, memory_context)) {
-		goto error_lpm;
+		goto error_collector;
 	}
 	struct range_index range_index;
 	if (range_index_init(&range_index, memory_context)) {
-		lpm_free(lpm);
-		goto error_collector;
+		goto error_lpm;
 	}
 
 	if (range_collector_collect(&collector, 4, lpm, &range_index)) {
-		goto error_collector;
+		goto error_range_collect;
 	}
 
 	struct value_table table;
 	if (value_table_init(&table, memory_context, 1, collector.count))
-		goto error_vtab;
+		goto error_table;
+
+	struct remap_table remap_table;
+	if (remap_table_init(&remap_table, memory_context, collector.count))
+		goto error_remap;
 
 	for (const struct filter_rule *action = actions;
 	     action < actions + count;
 	     ++action) {
 
-		value_table_new_gen(&table);
+		remap_table_new_gen(&remap_table);
 
 		struct net4 *nets;
 		uint32_t net_count;
 		get_net4(action, &nets, &net_count);
 
 		if (net4_collect_values(
-			    nets, net_count, &range_index, &table
+			    nets, net_count, &range_index, &table, &remap_table
 		    )) {
-			// FIXME: error
+			goto error_net_collect;
 		}
 	}
 
-	range_index_free(&range_index);
-
-	value_table_compact(&table);
+	remap_table_compact(&remap_table);
+	value_table_compact(&table, &remap_table);
 	lpm4_remap(lpm, &table);
 	lpm4_compact(lpm);
 	for (const struct filter_rule *action = actions;
@@ -171,16 +176,28 @@ collect_net4_values(
 		net4_collect_registry(nets, net_count, lpm, registry);
 	}
 
+	remap_table_free(&remap_table);
 	value_table_free(&table);
+	range_index_free(&range_index);
 	range_collector_free(&collector, 4);
 	return 0;
 
-error_collector:
-	range_collector_free(&collector, 4);
+error_net_collect:
+	remap_table_free(&remap_table);
+
+error_remap:
+	value_table_free(&table);
+
+error_table:
+
+error_range_collect:
+	range_index_free(&range_index);
+
 error_lpm:
 	lpm_free(lpm);
 
-error_vtab:
+error_collector:
+	range_collector_free(&collector, 4);
 
 error:
 	return -1;

--- a/filter/compiler/net6.c
+++ b/filter/compiler/net6.c
@@ -143,6 +143,15 @@ merge_net6_range(
 		return -1;
 	}
 
+	struct remap_table remap_table;
+	if (remap_table_init(
+		    &remap_table,
+		    memory_context,
+		    (ri_hi->max_value + 1) * (ri_lo->max_value + 1)
+	    )) {
+		goto error_remap_table;
+	}
+
 	uint32_t net_cnt = 0;
 
 	struct radix rdx;
@@ -152,7 +161,7 @@ merge_net6_range(
 	     action < actions + count;
 	     ++action) {
 
-		value_table_new_gen(table);
+		remap_table_new_gen(&remap_table);
 
 		uint32_t *values_hi = ADDR_OF(&ri_hi->values);
 		uint32_t *values_lo = ADDR_OF(&ri_lo->values);
@@ -209,18 +218,27 @@ merge_net6_range(
 					for (uint32_t idx_lo = start_lo;
 					     idx_lo < stop_lo;
 					     ++idx_lo) {
-						if (value_table_touch(
-							    table,
-							    values_hi[idx_hi],
-							    values_lo[idx_lo]
+						uint32_t *value =
+							value_table_get_ptr(
+								table,
+								values_hi
+									[idx_hi],
+								values_lo
+									[idx_lo]
+							);
+						if (remap_table_touch(
+							    &remap_table,
+							    *value,
+							    value
 						    ) < 0) {
-							return -1;
+							goto error_touch;
 						}
 					}
 				}
 			}
 		}
 	}
+	remap_table_free(&remap_table);
 
 	uint32_t *values_hi = ADDR_OF(&ri_hi->values);
 	uint32_t *values_lo = ADDR_OF(&ri_lo->values);
@@ -331,6 +349,14 @@ merge_net6_range(
 	// FIXME: free temporary resources
 
 	return 0;
+
+error_touch:
+	remap_table_free(&remap_table);
+
+error_remap_table:
+	value_table_free(table);
+
+	return -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/filter/compiler/port.c
+++ b/filter/compiler/port.c
@@ -24,11 +24,16 @@ collect_port_values(
 	if (value_table_init(table, memory_context, 1, 65536))
 		return -1;
 
+	struct remap_table remap_table;
+	if (remap_table_init(&remap_table, memory_context, 65536)) {
+		goto error_remap_table;
+	}
+
 	for (const struct filter_rule *action = actions;
 	     action < actions + count;
 	     ++action) {
 
-		value_table_new_gen(table);
+		remap_table_new_gen(&remap_table);
 
 		struct filter_port_range *port_ranges;
 		uint32_t port_range_count;
@@ -40,12 +45,20 @@ collect_port_values(
 				continue;
 			for (uint32_t port = ports->from; port <= ports->to;
 			     ++port) {
-				value_table_touch(table, 0, port);
+				uint32_t *value =
+					value_table_get_ptr(table, 0, port);
+				if (remap_table_touch(
+					    &remap_table, *value, value
+				    ) < 0) {
+					goto error_touch;
+				}
 			}
 		}
 	}
 
-	value_table_compact(table);
+	remap_table_compact(&remap_table);
+	value_table_compact(table, &remap_table);
+	remap_table_free(&remap_table);
 
 	for (const struct filter_rule *action = actions;
 	     action < actions + count;
@@ -60,25 +73,37 @@ collect_port_values(
 		     ++ports) {
 			for (uint32_t port = ports->from; port <= ports->to;
 			     ++port) {
-				value_registry_collect(
-					registry,
-					value_table_get(table, 0, port)
-				);
+				if (value_registry_collect(
+					    registry,
+					    value_table_get(table, 0, port)
+				    )) {
+					goto error_collect;
+				}
 			}
 		}
 
 		// Handle default - the full range
 		if (!port_range_count) {
 			for (uint32_t port = 0; port <= 65535; ++port) {
-				value_registry_collect(
-					registry,
-					value_table_get(table, 0, port)
-				);
+				if (value_registry_collect(
+					    registry,
+					    value_table_get(table, 0, port)
+				    )) {
+					goto error_collect;
+				}
 			}
 		}
 	}
 
 	return 0;
+
+error_touch:
+	remap_table_free(&remap_table);
+
+error_collect:
+error_remap_table:
+	value_table_free(table);
+	return -1;
 }
 
 static void
@@ -141,14 +166,19 @@ FILTER_ATTR_COMPILER_INIT_FUNC(port_src)(
 		return -1;
 	}
 	SET_OFFSET_OF(data, table);
-	return collect_port_values(
-		memory_context,
-		actions,
-		actions_count,
-		get_port_range_src,
-		table,
-		registry
-	);
+	if (collect_port_values(
+		    memory_context,
+		    actions,
+		    actions_count,
+		    get_port_range_src,
+		    table,
+		    registry
+	    )) {
+		SET_OFFSET_OF(data, NULL);
+		return -1;
+	}
+
+	return 0;
 }
 
 void

--- a/filter/compiler/proto.c
+++ b/filter/compiler/proto.c
@@ -27,6 +27,10 @@ proto_classifier_init_internal(
 	if (res < 0) {
 		return res;
 	}
+	struct remap_table remap_table;
+	if (remap_table_init(&remap_table, mem, 1 << TCP_FLAGS)) {
+		goto error_remap_table;
+	}
 	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
 		const struct filter_proto *proto = &r->transport.proto;
 		if (proto->proto != IPPROTO_TCP) { // not TCP
@@ -36,18 +40,29 @@ proto_classifier_init_internal(
 			// impossible
 			continue;
 		}
-		value_table_new_gen(&c->tcp_flags);
+		remap_table_new_gen(&remap_table);
 		int16_t mask = proto->disable_bits ^ ((1 << TCP_FLAGS) - 1) ^
 			       proto->enable_bits;
 		for (int16_t m = mask; m > 0; m = (m - 1) & mask) {
-			value_table_touch(
+			uint32_t *value = value_table_get_ptr(
 				&c->tcp_flags, 0, m | proto->enable_bits
 			);
+			if (remap_table_touch(&remap_table, *value, value) <
+			    0) {
+				goto error_touch;
+			}
 		}
-		value_table_touch(&c->tcp_flags, 0, proto->enable_bits);
+		uint32_t *value = value_table_get_ptr(
+			&c->tcp_flags, 0, proto->enable_bits
+		);
+		if (remap_table_touch(&remap_table, *value, value)) {
+			goto error_touch;
+		}
 	}
 
-	value_table_compact(&c->tcp_flags);
+	remap_table_compact(&remap_table);
+	value_table_compact(&c->tcp_flags, &remap_table);
+	remap_table_free(&remap_table);
 	c->max_tcp_class = 0;
 	for (uint16_t i = 0; i < (1 << TCP_FLAGS); ++i) {
 		uint32_t value = value_table_get(&c->tcp_flags, 0, i);
@@ -98,6 +113,14 @@ proto_classifier_init_internal(
 	}
 
 	return 0;
+
+error_touch:
+	remap_table_free(&remap_table);
+
+error_remap_table:
+	value_table_free(&c->tcp_flags);
+
+	return -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/filter/compiler/proto_range.c
+++ b/filter/compiler/proto_range.c
@@ -24,10 +24,19 @@ collect_proto_values(
 	    ))
 		return -1;
 
+	struct remap_table remap_table;
+	if (remap_table_init(
+		    &remap_table,
+		    memory_context,
+		    PROTO_RANGE_CLASSIFIER_MAX_VALUE
+	    )) {
+		goto error_remap_table;
+	}
+
 	for (const struct filter_rule *rule = rules; rule < rules + count;
 	     ++rule) {
 
-		value_table_new_gen(table);
+		remap_table_new_gen(&remap_table);
 
 		struct filter_proto_range *proto_ranges =
 			rule->transport.protos;
@@ -39,12 +48,20 @@ collect_proto_values(
 			for (uint32_t proto = proto_range->from;
 			     proto <= proto_range->to;
 			     ++proto) {
-				value_table_touch(table, 0, proto);
+				uint32_t *value =
+					value_table_get_ptr(table, 0, proto);
+				if (remap_table_touch(
+					    &remap_table, *value, value
+				    ) < 0) {
+					goto error_touch;
+				}
 			}
 		}
 	}
 
-	value_table_compact(table);
+	remap_table_compact(&remap_table);
+	value_table_compact(table, &remap_table);
+	remap_table_free(&remap_table);
 
 	for (const struct filter_rule *rule = rules; rule < rules + count;
 	     ++rule) {
@@ -60,15 +77,26 @@ collect_proto_values(
 			for (uint32_t proto = proto_range->from;
 			     proto <= proto_range->to;
 			     ++proto) {
-				value_registry_collect(
-					registry,
-					value_table_get(table, 0, proto)
-				);
+				if (value_registry_collect(
+					    registry,
+					    value_table_get(table, 0, proto)
+				    )) {
+					goto error_collect;
+				}
 			}
 		}
 	}
 
 	return 0;
+
+error_touch:
+	remap_table_free(&remap_table);
+
+error_collect:
+error_remap_table:
+
+	value_table_free(table);
+	return -1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -87,9 +115,14 @@ FILTER_ATTR_COMPILER_INIT_FUNC(proto_range)(
 		return -1;
 	}
 	SET_OFFSET_OF(data, classifier);
-	return collect_proto_values(
-		mctx, rules, rule_count, &classifier->table, registry
-	);
+	if (collect_proto_values(
+		    mctx, rules, rule_count, &classifier->table, registry
+	    )) {
+		SET_OFFSET_OF(data, NULL);
+		return -1;
+	}
+
+	return 0;
 }
 
 void

--- a/filter/compiler/vlan.c
+++ b/filter/compiler/vlan.c
@@ -19,25 +19,41 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 	if (t == NULL) {
 		return -1;
 	}
-	int res = value_table_init(t, memory_context, 1, 4096);
-	if (res < 0) {
-		return res;
+
+	if (value_table_init(t, memory_context, 1, 4096)) {
+		goto error_init;
 	}
 	SET_OFFSET_OF(data, t);
+
+	struct remap_table remap_table;
+	if (remap_table_init(&remap_table, memory_context, 4096)) {
+		goto error_remap_table;
+	}
+
 	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
 		if (r->vlan_range_count == 0) {
 			continue;
 		}
-		value_table_new_gen(t);
+		remap_table_new_gen(&remap_table);
 		for (uint32_t idx = 0; idx < r->vlan_range_count; ++idx) {
 			for (uint16_t vlan = r->vlan_ranges[idx].from;
 			     vlan <= r->vlan_ranges[idx].to;
 			     ++vlan) {
-				value_table_touch(t, 0, vlan);
+				uint32_t *value =
+					value_table_get_ptr(t, 0, vlan);
+				if (remap_table_touch(
+					    &remap_table, *value, value
+				    ) < 0) {
+					goto error_touch;
+				}
 			}
 		}
 	}
-	value_table_compact(t);
+
+	remap_table_compact(&remap_table);
+	value_table_compact(t, &remap_table);
+	remap_table_free(&remap_table);
+
 	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
 		value_registry_start(registry);
 		if (r->vlan_range_count == 0) {
@@ -51,13 +67,29 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 			for (uint16_t vlan = r->vlan_ranges[idx].from;
 			     vlan <= r->vlan_ranges[idx].to;
 			     ++vlan) {
-				value_registry_collect(
-					registry, value_table_get(t, 0, vlan)
-				);
+				if (value_registry_collect(
+					    registry,
+					    value_table_get(t, 0, vlan)
+				    )) {
+					goto error_collect;
+				}
 			}
 		}
 	}
 	return 0;
+
+error_touch:
+	remap_table_free(&remap_table);
+
+error_collect:
+error_remap_table:
+	value_table_free(t);
+	SET_OFFSET_OF(data, NULL);
+
+error_init:
+	memory_bfree(memory_context, t, sizeof(struct value_table));
+
+	return -1;
 }
 
 void

--- a/tests/common/value_table.c
+++ b/tests/common/value_table.c
@@ -23,6 +23,10 @@ main() {
 	int res = value_table_init(&table, &mem_ctx, 1, 10);
 	assert(res == 0);
 
+	struct remap_table remap_table;
+	res = remap_table_init(&remap_table, &mem_ctx, 10);
+	assert(res == 0);
+
 	uint32_t l[5] = {2, 3, 0, 8, 6};
 	uint32_t r[5] = {5, 7, 4, 9, 10};
 
@@ -30,14 +34,16 @@ main() {
 	memset(mask, 0, sizeof(mask));
 
 	for (size_t i = 0; i < 5; ++i) {
-		value_table_new_gen(&table);
+		remap_table_new_gen(&remap_table);
 		for (size_t x = l[i]; x < r[i]; ++x) {
 			mask[x] |= 1 << i;
-			value_table_touch(&table, 0, x);
+			uint32_t *value = value_table_get_ptr(&table, 0, x);
+			remap_table_touch(&remap_table, *value, value);
 		}
 	}
 
-	value_table_compact(&table);
+	remap_table_compact(&remap_table);
+	value_table_compact(&table, &remap_table);
 
 	for (size_t i = 0; i < 10; ++i) {
 		for (size_t j = i + 1; j < 10; ++j) {
@@ -48,6 +54,7 @@ main() {
 		}
 	}
 
+	remap_table_free(&remap_table);
 	value_table_free(&table);
 	free(arena0);
 


### PR DESCRIPTION
`remap_table` structure is a helper entity used for ruleset enumeration while compilation whereas `value_table` is being shipped through shared memory to a module configuration so they should be separated from each other