### PR TITLE
Use rule index instead of action identifier

### DIFF
--- a/filter/compiler.h
+++ b/filter/compiler.h
@@ -31,7 +31,7 @@
 typedef int (*filter_lookup_init_func)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rule_count,
 	struct memory_context *mctx
 );
@@ -81,7 +81,7 @@ static inline int
 filter_init(
 	struct filter *filter,
 	const struct filter_compiler *filter_compiler,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	uint32_t rule_count,
 	struct memory_context *memory_context
 ) {
@@ -129,7 +129,6 @@ filter_init(
 
 		if (merge_and_set_registry_values(
 			    &filter->memory_context,
-			    (rules),
 			    &dummy,
 			    &filter->v[1].registry,
 			    &filter->v[0].table,
@@ -157,7 +156,6 @@ filter_init(
 
 	if (merge_and_set_registry_values(
 		    &filter->memory_context,
-		    rules,
 		    &filter->v[2 * 1].registry,
 		    &filter->v[2 * 1 + 1].registry,
 		    &filter->v[1].table,

--- a/filter/compiler/attribute.h
+++ b/filter/compiler/attribute.h
@@ -11,7 +11,7 @@
 	int FILTER_ATTR_COMPILER_INIT_FUNC(name)(                              \
 		struct value_registry * registry,                              \
 		void **data,                                                   \
-		const struct filter_rule *rules,                               \
+		const struct filter_rule **rules,                              \
 		size_t rule_count,                                             \
 		struct memory_context *mctx                                    \
 	);                                                                     \

--- a/filter/compiler/device.c
+++ b/filter/compiler/device.c
@@ -11,12 +11,18 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rule_count,
 	struct memory_context *memory_context
 ) {
 	uint64_t max_device_id = 0;
-	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
+	for (const struct filter_rule **r_ptr = rules;
+	     r_ptr < rules + rule_count;
+	     ++r_ptr) {
+		if (*r_ptr == NULL)
+			continue;
+		const struct filter_rule *r = *r_ptr;
+
 		for (uint16_t idx = 0; idx < r->device_count; ++idx) {
 			if (r->devices[idx].id > max_device_id) {
 				max_device_id = r->devices[idx].id;
@@ -40,7 +46,13 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 		goto error_remap_table;
 	}
 
-	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
+	for (const struct filter_rule **r_ptr = rules;
+	     r_ptr < rules + rule_count;
+	     ++r_ptr) {
+		if (*r_ptr == NULL)
+			continue;
+		const struct filter_rule *r = *r_ptr;
+
 		if (r->device_count == 0) {
 			continue;
 		}
@@ -59,8 +71,15 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 	value_table_compact(t, &remap_table);
 	remap_table_free(&remap_table);
 
-	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
+	for (const struct filter_rule **r_ptr = rules;
+	     r_ptr < rules + rule_count;
+	     ++r_ptr) {
 		value_registry_start(registry);
+
+		if (*r_ptr == NULL)
+			continue;
+		const struct filter_rule *r = *r_ptr;
+
 		if (r->device_count == 0) {
 			for (uint64_t id = 0; id < max_device_id + 1; ++id) {
 				if (value_registry_collect(

--- a/filter/compiler/helper.c
+++ b/filter/compiler/helper.c
@@ -30,55 +30,18 @@ init_dummy_registry(
 ////////////////////////////////////////////////////////////////////////////////
 
 struct value_set_ctx {
-	const struct filter_rule *rules;
 	struct value_table *table;
 	struct value_registry *registry;
 	struct remap_table remap_table;
 };
 
 static int
-action_list_is_term(struct value_registry *registry, uint32_t range_idx) {
-	struct value_range *range = ADDR_OF(&registry->ranges) + range_idx;
-	if (range->count == 0)
-		return 0;
-
-	return 1;
-}
-
-static int
 value_table_set_action(uint32_t v1, uint32_t v2, uint32_t idx, void *data) {
 	struct value_set_ctx *set_ctx = (struct value_set_ctx *)data;
-	uint32_t prev_value = value_table_get(set_ctx->table, v1, v2);
-
-	if (!action_list_is_term(set_ctx->registry, prev_value)) {
-		uint32_t *value = value_table_get_ptr(set_ctx->table, v1, v2);
-		/*
-		 * FIXME: we assume value table produces increasing sequence
-		 * of values - this is important for value registry handling.
-		 */
-		int res =
-			remap_table_touch(&set_ctx->remap_table, *value, value);
-
-		if (res <= 0)
-			return res;
-
-		if (value_registry_start(set_ctx->registry))
-			return -1;
-
-		struct value_range *copy_range =
-			ADDR_OF(&set_ctx->registry->ranges) + prev_value;
-
-		for (uint32_t ridx = 0; ridx < copy_range->count; ++ridx) {
-			value_registry_collect(
-				set_ctx->registry,
-				ADDR_OF(&copy_range->values)[ridx]
-			);
-		}
-
-		value_registry_collect(
-			set_ctx->registry, set_ctx->rules[idx].action
-		);
-	}
+	uint32_t *value = value_table_get_ptr(set_ctx->table, v1, v2);
+	if (*value)
+		return 0;
+	*value = idx + 1;
 
 	return 0;
 }
@@ -86,7 +49,6 @@ value_table_set_action(uint32_t v1, uint32_t v2, uint32_t idx, void *data) {
 int
 merge_and_set_registry_values(
 	struct memory_context *memory_context,
-	const struct filter_rule *rules,
 	struct value_registry *registry1,
 	struct value_registry *registry2,
 	struct value_table *table,
@@ -109,21 +71,14 @@ merge_and_set_registry_values(
 		goto error_merge;
 
 	struct value_set_ctx set_ctx;
-	set_ctx.rules = rules;
 	set_ctx.table = table;
 	set_ctx.registry = registry;
-	if (remap_table_init(
-		    &set_ctx.remap_table,
-		    memory_context,
-		    value_registry_capacity(registry1) *
-			    value_registry_capacity(registry2)
-	    )) {
-		goto error_merge;
-	}
 
 	for (uint32_t range_idx = 0; range_idx < registry1->range_count;
 	     ++range_idx) {
-		remap_table_new_gen(&set_ctx.remap_table);
+		if (value_registry_start(registry) ||
+		    value_registry_collect(registry, range_idx))
+			goto error_join;
 		if (value_registry_join_range(
 			    registry1,
 			    registry2,
@@ -134,12 +89,9 @@ merge_and_set_registry_values(
 			goto error_join;
 	}
 
-	remap_table_free(&set_ctx.remap_table);
-
 	return 0;
 
 error_join:
-	remap_table_free(&set_ctx.remap_table);
 
 error_merge:
 	value_registry_free(registry);

--- a/filter/compiler/helper.h
+++ b/filter/compiler/helper.h
@@ -18,7 +18,6 @@ merge_and_collect_registry(
 int
 merge_and_set_registry_values(
 	struct memory_context *memory_context,
-	const struct filter_rule *actions,
 	struct value_registry *registry1,
 	struct value_registry *registry2,
 	struct value_table *table,

--- a/filter/compiler/net4.c
+++ b/filter/compiler/net4.c
@@ -90,7 +90,7 @@ net4_collect_registry(
 static inline int
 collect_net4_values(
 	struct memory_context *memory_context,
-	const struct filter_rule *actions,
+	const struct filter_rule **actions,
 	uint32_t count,
 	rule_get_net4_func get_net4,
 	struct lpm *lpm,
@@ -100,9 +100,13 @@ collect_net4_values(
 	if (range_collector_init(&collector, memory_context))
 		goto error;
 
-	for (const struct filter_rule *action = actions;
-	     action < actions + count;
-	     ++action) {
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + count;
+	     ++action_ptr) {
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
+
 		if (action->net4.src_count == 0 &&
 		    action->net4.dst_count == 0) {
 			continue;
@@ -143,11 +147,16 @@ collect_net4_values(
 	if (remap_table_init(&remap_table, memory_context, collector.count))
 		goto error_remap;
 
-	for (const struct filter_rule *action = actions;
-	     action < actions + count;
-	     ++action) {
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + count;
+	     ++action_ptr) {
 
 		remap_table_new_gen(&remap_table);
+
+		if (*action_ptr == NULL)
+			continue;
+
+		const struct filter_rule *action = *action_ptr;
 
 		struct net4 *nets;
 		uint32_t net_count;
@@ -164,10 +173,15 @@ collect_net4_values(
 	value_table_compact(&table, &remap_table);
 	lpm4_remap(lpm, &table);
 	lpm4_compact(lpm);
-	for (const struct filter_rule *action = actions;
-	     action < actions + count;
-	     ++action) {
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + count;
+	     ++action_ptr) {
+		// A value range should be created even for empty rules
 		value_registry_start(registry);
+
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
 
 		struct net4 *nets;
 		uint32_t net_count;
@@ -210,7 +224,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(net4_src)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *actions,
+	const struct filter_rule **actions,
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
@@ -231,7 +245,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(net4_dst)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *actions,
+	const struct filter_rule **actions,
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {

--- a/filter/compiler/net4_fast.c
+++ b/filter/compiler/net4_fast.c
@@ -48,11 +48,13 @@ net4_from_to(struct net4 *n, uint32_t *from, uint32_t *to) {
 
 static int
 validate_and_count(
-	const struct filter_rule *rules, size_t rules_count, net_getter getter
+	const struct filter_rule **rules, size_t rules_count, net_getter getter
 ) {
 	int cnt = 0;
 	for (size_t i = 0; i < rules_count; ++i) {
-		struct net4_count n4_count = getter(rules + i);
+		if (rules[i] == NULL)
+			continue;
+		struct net4_count n4_count = getter(rules[i]);
 		for (size_t j = 0; j < n4_count.count; ++j) {
 			if (!validate_net4(n4_count.net4 + j)) {
 				return -1;
@@ -67,7 +69,7 @@ static int
 classifier_init(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rules_count,
 	struct memory_context *mctx,
 	net_getter getter
@@ -92,7 +94,9 @@ classifier_init(
 
 	size_t segment_idx = 0;
 	for (size_t rule_idx = 0; rule_idx < rules_count; ++rule_idx) {
-		struct net4_count cur = getter(&rules[rule_idx]);
+		if (rules[rule_idx] == NULL)
+			continue;
+		struct net4_count cur = getter(rules[rule_idx]);
 		for (size_t j = 0; j < cur.count; ++j) {
 			uint32_t from, to;
 			net4_from_to(cur.net4 + j, &from, &to);
@@ -120,7 +124,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(net4_fast_dst)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
@@ -146,7 +150,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(net4_fast_src)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {

--- a/filter/compiler/net6.c
+++ b/filter/compiler/net6.c
@@ -62,7 +62,7 @@ net6_normalize(struct net6 *src, struct net6 *dst) {
 static inline int
 collect_net6_range(
 	struct memory_context *memory_context,
-	const struct filter_rule *actions,
+	const struct filter_rule **actions,
 	uint32_t count,
 	action_get_net6_func get_net6,
 	net6_get_part_func get_part,
@@ -73,9 +73,13 @@ collect_net6_range(
 	if (range_collector_init(&collector, memory_context))
 		goto error;
 
-	for (const struct filter_rule *action = actions;
-	     action < actions + count;
-	     ++action) {
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + count;
+	     ++action_ptr) {
+
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
 
 		struct net6 *nets;
 		uint32_t net_count;
@@ -126,7 +130,7 @@ error:
 static inline int
 merge_net6_range(
 	struct memory_context *memory_context,
-	const struct filter_rule *actions,
+	const struct filter_rule **actions,
 	uint32_t count,
 	action_get_net6_func get_net6,
 	const struct range_index *ri_hi,
@@ -157,9 +161,13 @@ merge_net6_range(
 	struct radix rdx;
 	radix_init(&rdx, memory_context);
 
-	for (const struct filter_rule *action = actions;
-	     action < actions + count;
-	     ++action) {
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + count;
+	     ++action_ptr) {
+
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
 
 		remap_table_new_gen(&remap_table);
 
@@ -246,9 +254,13 @@ merge_net6_range(
 	struct value_registry net_registry;
 	value_registry_init(&net_registry, memory_context);
 
-	for (const struct filter_rule *action = actions;
-	     action < actions + count;
-	     ++action) {
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + count;
+	     ++action_ptr) {
+
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
 
 		struct net6 *nets;
 		uint32_t net_count;
@@ -313,12 +325,16 @@ merge_net6_range(
 
 	value_registry_init(registry, memory_context);
 
-	for (const struct filter_rule *action = actions;
-	     action < actions + count;
-	     ++action) {
-
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + count;
+	     ++action_ptr) {
+		// A value range should be created even for empty rules
 		if (value_registry_start(registry))
 			return -1;
+
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
 
 		struct net6 *nets;
 		uint32_t net_count;
@@ -368,7 +384,7 @@ init_net6(
 	struct value_registry *registry,
 	action_get_net6_func get_net6,
 	void **data,
-	const struct filter_rule *actions,
+	const struct filter_rule **actions,
 	size_t count,
 	struct memory_context *memory_context
 ) {
@@ -441,7 +457,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(net6_src)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
@@ -460,7 +476,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(net6_dst)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {

--- a/filter/compiler/net6_fast.c
+++ b/filter/compiler/net6_fast.c
@@ -55,11 +55,13 @@ net6_part_from_to(struct net6 *n, int part, uint64_t *from, uint64_t *to) {
 
 static int
 validate_and_count(
-	const struct filter_rule *rules, size_t rules_count, get_net getter
+	const struct filter_rule **rules, size_t rules_count, get_net getter
 ) {
 	int cnt = 0;
 	for (size_t i = 0; i < rules_count; ++i) {
-		struct net6_count n6_count = getter(rules + i);
+		if (rules[i] == NULL)
+			continue;
+		struct net6_count n6_count = getter(rules[i]);
 		for (size_t j = 0; j < n6_count.count; ++j) {
 			if (!validate_net6(n6_count.nets + j)) {
 				return -1;
@@ -78,7 +80,7 @@ init_classifier_part(
 	size_t segments_count,
 	struct segments_u64_classifier *classifier,
 	int part /* 0/1 */,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rules_count
 ) {
 	struct segment_u64 *segments =
@@ -89,7 +91,9 @@ init_classifier_part(
 
 	size_t segment_idx = 0;
 	for (size_t rule_idx = 0; rule_idx < rules_count; ++rule_idx) {
-		struct net6_count cur = getter(&rules[rule_idx]);
+		if (rules[rule_idx] == NULL)
+			continue;
+		struct net6_count cur = getter(rules[rule_idx]);
 		for (size_t j = 0; j < cur.count; ++j) {
 			uint64_t from, to;
 			net6_part_from_to(cur.nets + j, part, &from, &to);
@@ -117,7 +121,7 @@ init_classifier(
 	get_net getter,
 	struct memory_context *mctx,
 	struct net6_fast_classifier *classifier,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rules_count,
 	struct value_registry *registry
 ) {
@@ -216,7 +220,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(net6_fast_dst)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rules_count,
 	struct memory_context *memory_context
 ) {
@@ -241,7 +245,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(net6_fast_src)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rules_count,
 	struct memory_context *memory_context
 ) {

--- a/filter/compiler/port.c
+++ b/filter/compiler/port.c
@@ -15,7 +15,7 @@ typedef void (*action_get_port_range_func)(
 static int
 collect_port_values(
 	struct memory_context *memory_context,
-	const struct filter_rule *actions,
+	const struct filter_rule **actions,
 	uint32_t count,
 	action_get_port_range_func get_port_range,
 	struct value_table *table,
@@ -29,11 +29,15 @@ collect_port_values(
 		goto error_remap_table;
 	}
 
-	for (const struct filter_rule *action = actions;
-	     action < actions + count;
-	     ++action) {
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + count;
+	     ++action_ptr) {
 
 		remap_table_new_gen(&remap_table);
+
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
 
 		struct filter_port_range *port_ranges;
 		uint32_t port_range_count;
@@ -60,10 +64,14 @@ collect_port_values(
 	value_table_compact(table, &remap_table);
 	remap_table_free(&remap_table);
 
-	for (const struct filter_rule *action = actions;
-	     action < actions + count;
-	     ++action) {
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + count;
+	     ++action_ptr) {
+		// A value range should be created even for empty rules
 		value_registry_start(registry);
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
 
 		struct filter_port_range *port_ranges;
 		uint32_t port_range_count;
@@ -132,7 +140,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(port_dst)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *actions,
+	const struct filter_rule **actions,
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
@@ -156,7 +164,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(port_src)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *actions,
+	const struct filter_rule **actions,
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {

--- a/filter/compiler/port_fast.c
+++ b/filter/compiler/port_fast.c
@@ -26,13 +26,15 @@ validate_port_ranges(struct filter_port_ranges ranges) {
 
 static int
 validate_and_count(
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rules_count,
 	port_ranges_getter getter
 ) {
 	int cnt = 0;
 	for (size_t i = 0; i < rules_count; ++i) {
-		struct filter_port_ranges ranges = getter(rules + i);
+		if (rules[i] == NULL)
+			continue;
+		struct filter_port_ranges ranges = getter(rules[i]);
 		if (!validate_port_ranges(ranges)) {
 			return -1;
 		}
@@ -45,7 +47,7 @@ static int
 classifier_init(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rules_count,
 	struct memory_context *mctx,
 	port_ranges_getter getter
@@ -64,7 +66,9 @@ classifier_init(
 		malloc(sizeof(struct segment_u16) * count);
 	size_t segment_idx = 0;
 	for (size_t rule_idx = 0; rule_idx < rules_count; ++rule_idx) {
-		struct filter_port_ranges ranges = getter(&rules[rule_idx]);
+		if (rules[rule_idx] == NULL)
+			continue;
+		struct filter_port_ranges ranges = getter(rules[rule_idx]);
 		for (size_t range_idx = 0; range_idx < ranges.count;
 		     ++range_idx) {
 			struct filter_port_range range =
@@ -93,7 +97,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(port_fast_dst)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rules_count,
 	struct memory_context *memory_context
 ) {
@@ -114,7 +118,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(port_fast_src)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rules_count,
 	struct memory_context *memory_context
 ) {

--- a/filter/compiler/proto.c
+++ b/filter/compiler/proto.c
@@ -19,7 +19,7 @@ static int
 proto_classifier_init_internal(
 	struct value_registry *registry,
 	struct proto_classifier *c,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	uint32_t rule_count,
 	struct memory_context *mem
 ) {
@@ -31,7 +31,13 @@ proto_classifier_init_internal(
 	if (remap_table_init(&remap_table, mem, 1 << TCP_FLAGS)) {
 		goto error_remap_table;
 	}
-	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
+	for (const struct filter_rule **r_ptr = rules;
+	     r_ptr < rules + rule_count;
+	     ++r_ptr) {
+		if (*r_ptr == NULL)
+			continue;
+		const struct filter_rule *r = *r_ptr;
+
 		const struct filter_proto *proto = &r->transport.proto;
 		if (proto->proto != IPPROTO_TCP) { // not TCP
 			continue;
@@ -71,9 +77,15 @@ proto_classifier_init_internal(
 		}
 	}
 
-	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
-		const struct filter_proto *proto = &r->transport.proto;
+	for (const struct filter_rule **r_ptr = rules;
+	     r_ptr < rules + rule_count;
+	     ++r_ptr) {
+		// A value range should be created even for empty rules
 		value_registry_start(registry);
+		if (*r_ptr == NULL)
+			continue;
+		const struct filter_rule *r = *r_ptr;
+		const struct filter_proto *proto = &r->transport.proto;
 		switch (proto->proto) {
 		case IPPROTO_UDP:
 			value_registry_collect(registry, c->max_tcp_class + 1);
@@ -129,7 +141,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(proto)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rule_count,
 	struct memory_context *memory_context
 ) {

--- a/filter/compiler/proto_range.c
+++ b/filter/compiler/proto_range.c
@@ -14,7 +14,7 @@
 static int
 collect_proto_values(
 	struct memory_context *memory_context,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	uint32_t count,
 	struct value_table *table,
 	struct value_registry *registry
@@ -33,8 +33,12 @@ collect_proto_values(
 		goto error_remap_table;
 	}
 
-	for (const struct filter_rule *rule = rules; rule < rules + count;
-	     ++rule) {
+	for (const struct filter_rule **rule_ptr = rules;
+	     rule_ptr < rules + count;
+	     ++rule_ptr) {
+		if (*rule_ptr == NULL)
+			continue;
+		const struct filter_rule *rule = *rule_ptr;
 
 		remap_table_new_gen(&remap_table);
 
@@ -63,9 +67,15 @@ collect_proto_values(
 	value_table_compact(table, &remap_table);
 	remap_table_free(&remap_table);
 
-	for (const struct filter_rule *rule = rules; rule < rules + count;
-	     ++rule) {
+	for (const struct filter_rule **rule_ptr = rules;
+	     rule_ptr < rules + count;
+	     ++rule_ptr) {
+		// A value range should be created even for empty rules
 		value_registry_start(registry);
+		if (*rule_ptr == NULL)
+			continue;
+
+		const struct filter_rule *rule = *rule_ptr;
 
 		struct filter_proto_range *proto_ranges =
 			rule->transport.protos;
@@ -105,7 +115,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(proto_range)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rule_count,
 	struct memory_context *mctx
 ) {

--- a/filter/compiler/proto_range_fast.c
+++ b/filter/compiler/proto_range_fast.c
@@ -23,12 +23,14 @@ validate_proto_ranges(struct filter_proto_ranges ranges) {
 }
 
 static int
-validate_and_count(const struct filter_rule *rules, size_t rules_count) {
+validate_and_count(const struct filter_rule **rules, size_t rules_count) {
 	int cnt = 0;
 	for (size_t i = 0; i < rules_count; ++i) {
+		if (rules[i] == NULL)
+			continue;
 		struct filter_proto_ranges ranges;
-		ranges.count = rules[i].transport.proto_count;
-		ranges.items = rules[i].transport.protos;
+		ranges.count = rules[i]->transport.proto_count;
+		ranges.items = rules[i]->transport.protos;
 		if (!validate_proto_ranges(ranges)) {
 			return -1;
 		}
@@ -43,7 +45,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(proto_range_fast)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rule_count,
 	struct memory_context *mctx
 ) {
@@ -67,7 +69,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(proto_range_fast)(
 
 	size_t segment_idx = 0;
 	for (size_t rule_idx = 0; rule_idx < rule_count; ++rule_idx) {
-		const struct filter_rule *rule = &rules[rule_idx];
+		const struct filter_rule *rule = rules[rule_idx];
+		if (rule == NULL)
+			continue;
 		struct filter_proto_range *proto_ranges =
 			rule->transport.protos;
 		size_t proto_count = rule->transport.proto_count;

--- a/filter/compiler/segments.c
+++ b/filter/compiler/segments.c
@@ -152,12 +152,9 @@ fill_registry_from_segments_u16(
 ) {
 	for (size_t segment_idx = 0; segment_idx < segment_count;
 	     ++segment_idx) {
-		if (segment_idx == 0 ||
-		    segments[segment_idx].label !=
-			    segments[segment_idx - 1].label) {
-			if (value_registry_start(registry) != 0) {
+		while (segments[segment_idx].label >= registry->range_count) {
+			if (value_registry_start(registry))
 				return -1;
-			}
 		}
 
 		struct segment_u16 *segment = &segments[segment_idx];
@@ -350,12 +347,9 @@ fill_registry_from_segments_u32(
 ) {
 	for (size_t segment_idx = 0; segment_idx < segment_count;
 	     ++segment_idx) {
-		if (segment_idx == 0 ||
-		    segments[segment_idx].label !=
-			    segments[segment_idx - 1].label) {
-			if (value_registry_start(registry) != 0) {
+		while (segments[segment_idx].label >= registry->range_count) {
+			if (value_registry_start(registry))
 				return -1;
-			}
 		}
 
 		struct segment_u32 *segment = &segments[segment_idx];
@@ -549,12 +543,9 @@ fill_registry_from_segments_u64(
 ) {
 	for (size_t segment_idx = 0; segment_idx < segment_count;
 	     ++segment_idx) {
-		if (segment_idx == 0 ||
-		    segments[segment_idx].label !=
-			    segments[segment_idx - 1].label) {
-			if (value_registry_start(registry) != 0) {
+		while (segments[segment_idx].label >= registry->range_count) {
+			if (value_registry_start(registry))
 				return -1;
-			}
 		}
 
 		struct segment_u64 *segment = &segments[segment_idx];

--- a/filter/compiler/vlan.c
+++ b/filter/compiler/vlan.c
@@ -10,7 +10,7 @@ int
 FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 	struct value_registry *registry,
 	void **data,
-	const struct filter_rule *rules,
+	const struct filter_rule **rules,
 	size_t rule_count,
 	struct memory_context *memory_context
 ) {
@@ -30,7 +30,13 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 		goto error_remap_table;
 	}
 
-	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
+	for (const struct filter_rule **r_ptr = rules;
+	     r_ptr < rules + rule_count;
+	     ++r_ptr) {
+		if (*r_ptr == NULL)
+			continue;
+		const struct filter_rule *r = *r_ptr;
+
 		if (r->vlan_range_count == 0) {
 			continue;
 		}
@@ -54,8 +60,15 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 	value_table_compact(t, &remap_table);
 	remap_table_free(&remap_table);
 
-	for (const struct filter_rule *r = rules; r < rules + rule_count; ++r) {
+	for (const struct filter_rule **r_ptr = rules;
+	     r_ptr < rules + rule_count;
+	     ++r_ptr) {
+		// A value range should be created even for empty rules
 		value_registry_start(registry);
+		if (*r_ptr == NULL)
+			continue;
+		const struct filter_rule *r = *r_ptr;
+
 		if (r->vlan_range_count == 0) {
 			for (uint16_t vlan = 0; vlan <= 4095; ++vlan) {
 				value_registry_collect(

--- a/filter/rule.h
+++ b/filter/rule.h
@@ -140,9 +140,5 @@ struct filter_rule {
 
 	uint16_t vlan;
 
-	// first 15 bits are for user action
-	// 16th bit is for terminate flag
-	// the oldest 16 bits are for category mask,
-	// which is 0 if rule is for all categories.
 	uint32_t action;
 };

--- a/filter/tests/basic_net4.c
+++ b/filter/tests/basic_net4.c
@@ -110,6 +110,7 @@ test_stress_seed12_regression(void *memory, size_t memory_size) {
 	// Build all 20 rules
 	struct filter_rule_builder builders[20];
 	struct filter_rule rules[20];
+	const struct filter_rule *rule_ptrs[20];
 
 	for (size_t i = 0; i < 20; i++) {
 		builder_init(&builders[i]);
@@ -125,13 +126,14 @@ test_stress_seed12_regression(void *memory, size_t memory_size) {
 			&builders[i], rule_specs[i].dst_addr, dst_mask
 		);
 
-		rules[i] = build_rule(&builders[i], i);
+		rules[i] = build_rule(&builders[i]);
+		rule_ptrs[i] = rules + i;
 	}
 
 	// Initialize filter with all 20 rules
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net4_compile, rules, 20, &memory_context
+		&filter, sign_net4_compile, rule_ptrs, 20, &memory_context
 	);
 	assert(res == 0);
 
@@ -188,12 +190,13 @@ main() {
 	builder_add_net4_dst(
 		&builder1, ip(192, 255, 168, 0), ip(255, 255, 255, 0)
 	);
-	struct filter_rule action1 = build_rule(&builder1, 0);
+	struct filter_rule action1 = build_rule(&builder1);
+	const struct filter_rule *action_ptr = &action1;
 
 	// init filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net4_compile, &action1, 1, &memory_context
+		&filter, sign_net4_compile, &action_ptr, 1, &memory_context
 	);
 	assert(res == 0);
 
@@ -226,11 +229,13 @@ main() {
 	builder_add_net4_dst(
 		&builder2, ip(7, 4, 132, 134), ip(255, 255, 128, 0)
 	);
-	struct filter_rule action2 = build_rule(&builder2, 0);
+	struct filter_rule action2 = build_rule(&builder2);
+
+	const struct filter_rule *action2_ptr = &action2;
 
 	struct filter filter2;
 	res = filter_init(
-		&filter2, sign_net4_compile, &action2, 1, &memory_context
+		&filter2, sign_net4_compile, &action2_ptr, 1, &memory_context
 	);
 	assert(res == 0);
 

--- a/filter/tests/basic_net4_fast.c
+++ b/filter/tests/basic_net4_fast.c
@@ -182,7 +182,7 @@ test_basic(void *arena, enum filter_sign sign) {
 		memcpy(builder->net4_src[0].addr, nets[net_idx].addr, 4);
 		memcpy(builder->net4_src[0].mask, &mask, 4);
 
-		rules[net_idx] = build_rule(builder, net_idx);
+		rules[net_idx] = build_rule(builder);
 
 		uint8_t mask_byte = ((uint8_t *)&mask
 		)[3]; // Get the 4th byte of the BE mask
@@ -210,14 +210,26 @@ test_basic(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t i = 0; i < nets_count; i++)
+		rule_ptrs[i] = &rules[i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -349,7 +361,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			);
 		}
 	}
-	rules[0] = build_rule(&builders[0], 0);
+	rules[0] = build_rule(&builders[0]);
 
 	// Rule 2: Add 2 networks
 	builder_init(&builders[1]);
@@ -369,7 +381,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			);
 		}
 	}
-	rules[1] = build_rule(&builders[1], 1);
+	rules[1] = build_rule(&builders[1]);
 
 	// Rule 3: Add 2 networks
 	builder_init(&builders[2]);
@@ -389,7 +401,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			);
 		}
 	}
-	rules[2] = build_rule(&builders[2], 2);
+	rules[2] = build_rule(&builders[2]);
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -400,14 +412,26 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[num_rules];
+	for (size_t i = 0; i < num_rules; i++)
+		rule_ptrs[i] = &rules[i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, num_rules, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			num_rules,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, num_rules, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			num_rules,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -498,7 +522,7 @@ stress(void *arena,
 			}
 		}
 
-		rules[rule_idx] = build_rule(&builders[rule_idx], rule_idx);
+		rules[rule_idx] = build_rule(&builders[rule_idx]);
 	}
 
 	struct value_range **expected_ranges =
@@ -511,13 +535,18 @@ stress(void *arena,
 	}
 
 	// Initialize both filters
+	const struct filter_rule **rule_ptrs =
+		malloc(sizeof(const struct filter_rule *) * num_rules);
+	for (size_t i = 0; i < num_rules; i++)
+		rule_ptrs[i] = &rules[i];
+
 	struct filter filter;
 	switch (sign) {
 	case src:
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			num_rules,
 			&memory_context
 		);
@@ -526,7 +555,7 @@ stress(void *arena,
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			num_rules,
 			&memory_context
 		);
@@ -535,7 +564,7 @@ stress(void *arena,
 		res = filter_init(
 			&filter,
 			sign_fast_src_dst_compile,
-			rules,
+			rule_ptrs,
 			num_rules,
 			&memory_context
 		);
@@ -605,6 +634,7 @@ stress(void *arena,
 		result, "failed to query packets and compare with old filter"
 	);
 
+	free(rule_ptrs);
 	free(rules);
 	free(builders);
 	for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx) {
@@ -683,7 +713,7 @@ test_no_match(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected: no matches for any packet
@@ -703,14 +733,26 @@ test_no_match(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t i = 0; i < nets_count; i++)
+		rule_ptrs[i] = &rules[i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -793,7 +835,7 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected matches
@@ -825,14 +867,26 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t i = 0; i < nets_count; i++)
+		rule_ptrs[i] = &rules[i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -912,7 +966,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected: first 4 match, last 2 don't
@@ -936,14 +990,26 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t i = 0; i < nets_count; i++)
+		rule_ptrs[i] = &rules[i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1025,7 +1091,7 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected: first 3 match their respective rules, last 3 don't match
@@ -1058,14 +1124,26 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t i = 0; i < nets_count; i++)
+		rule_ptrs[i] = &rules[i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1148,7 +1226,7 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 				(const uint8_t *)&mask
 			);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected: packets 0,1,4 match rule 1; packets 2,3,5 match rule 2
@@ -1179,14 +1257,26 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t i = 0; i < nets_count; i++)
+		rule_ptrs[i] = &rules[i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");

--- a/filter/tests/basic_net6.c
+++ b/filter/tests/basic_net6.c
@@ -143,12 +143,12 @@ test1(void *memory) {
 	};
 	make_addr(net.addr, 0xB, 16, 0xA, 16);
 	builder_add_net6_dst(&builder, net);
-	struct filter_rule rule = build_rule(&builder, 0);
-	const struct filter_rule rules[1] = {rule};
+	struct filter_rule rule = build_rule(&builder);
+	const struct filter_rule *rule_ptrs[1] = {&rule};
 
 	// init filter
 	struct filter filter;
-	res = filter_init(&filter, sign_net6_dst_compile, rules, 1, &mctx);
+	res = filter_init(&filter, sign_net6_dst_compile, rule_ptrs, 1, &mctx);
 	assert(res == 0);
 
 	// query packet 1
@@ -293,12 +293,12 @@ test2(void *memory) {
 	memset(net.addr, 0xBb, 8);
 	memset(net.addr + 8, 0xAa, 8);
 	builder_add_net6_dst(&builder, net);
-	struct filter_rule rule = build_rule(&builder, 0);
-	const struct filter_rule rules[1] = {rule};
+	struct filter_rule rule = build_rule(&builder);
+	const struct filter_rule *rule_ptrs[1] = {&rule};
 
 	// init filter
 	struct filter filter;
-	res = filter_init(&filter, sign_net6_dst_compile, rules, 1, &mctx);
+	res = filter_init(&filter, sign_net6_dst_compile, rule_ptrs, 1, &mctx);
 	assert(res == 0);
 
 	// query packet 1
@@ -449,7 +449,7 @@ test3(void *memory) {
 		make_addr(dst_net.addr, 0xB, 16, 0xA, 16);
 		builder_add_net6_dst(&builder1, dst_net);
 
-		rule1 = build_rule(&builder1, 0);
+		rule1 = build_rule(&builder1);
 	}
 
 	struct filter_rule rule2;
@@ -509,14 +509,14 @@ test3(void *memory) {
 		make_addr(dst_net.addr, 0xB, 16, 0xA, 16);
 		builder_add_net6_dst(&builder2, dst_net);
 
-		rule2 = build_rule(&builder2, 1);
+		rule2 = build_rule(&builder2);
 	}
 
-	const struct filter_rule rules[2] = {rule1, rule2};
+	const struct filter_rule *rule_ptrs[2] = {&rule1, &rule2};
 
 	// init filter
 	struct filter filter;
-	res = filter_init(&filter, sign_net6_compile, rules, 2, &mctx);
+	res = filter_init(&filter, sign_net6_compile, rule_ptrs, 2, &mctx);
 	assert(res == 0);
 
 	// query packet 1

--- a/filter/tests/basic_net6_fast.c
+++ b/filter/tests/basic_net6_fast.c
@@ -201,7 +201,7 @@ test_basic(void *arena, enum filter_sign sign) {
 		builder->net6_dst[0] = net;
 		builder->net6_src[0] = net;
 
-		rules[net_idx] = build_rule(builder, net_idx);
+		rules[net_idx] = build_rule(builder);
 		// Calculate range for this network
 		uint8_t from = nets[net_idx].addr[15] & mask[15];
 		uint8_t to = nets[net_idx].addr[15] | ~mask[15];
@@ -227,14 +227,26 @@ test_basic(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -490,7 +502,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			builder_add_net6_dst(&builders[0], net);
 		}
 	}
-	rules[0] = build_rule(&builders[0], 0);
+	rules[0] = build_rule(&builders[0]);
 
 	// Rule 2: Add 2 networks
 	builder_init(&builders[1]);
@@ -506,7 +518,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			builder_add_net6_dst(&builders[1], net);
 		}
 	}
-	rules[1] = build_rule(&builders[1], 1);
+	rules[1] = build_rule(&builders[1]);
 
 	// Rule 3: Add 2 networks
 	builder_init(&builders[2]);
@@ -522,7 +534,7 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			builder_add_net6_dst(&builders[2], net);
 		}
 	}
-	rules[2] = build_rule(&builders[2], 2);
+	rules[2] = build_rule(&builders[2]);
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -533,14 +545,26 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[num_rules];
+	for (size_t rp_i = 0; rp_i < num_rules; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, num_rules, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			num_rules,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, num_rules, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			num_rules,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -641,7 +665,7 @@ stress(void *arena,
 			}
 		}
 
-		rules[rule_idx] = build_rule(&builders[rule_idx], rule_idx);
+		rules[rule_idx] = build_rule(&builders[rule_idx]);
 	}
 
 	struct value_range **expected_ranges =
@@ -654,13 +678,18 @@ stress(void *arena,
 	}
 
 	// Initialize filter
+	const struct filter_rule **rule_ptrs =
+		malloc(sizeof(const struct filter_rule *) * num_rules);
+	for (size_t rp_i = 0; rp_i < num_rules; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	switch (sign) {
 	case src:
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			num_rules,
 			&memory_context
 		);
@@ -669,7 +698,7 @@ stress(void *arena,
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			num_rules,
 			&memory_context
 		);
@@ -678,7 +707,7 @@ stress(void *arena,
 		res = filter_init(
 			&filter,
 			sign_fast_src_dst_compile,
-			rules,
+			rule_ptrs,
 			num_rules,
 			&memory_context
 		);
@@ -745,6 +774,7 @@ stress(void *arena,
 		result, "failed to query packets and compare with old filter"
 	);
 
+	free(rule_ptrs);
 	free(rules);
 	free(builders);
 	for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx) {
@@ -842,7 +872,7 @@ test_no_match(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected: no matches for any packet
@@ -862,14 +892,26 @@ test_no_match(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1054,7 +1096,7 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected matches
@@ -1086,14 +1128,26 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1234,7 +1288,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected: first 4 match, last 2 don't
@@ -1258,14 +1312,26 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1370,7 +1436,7 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected: first 3 match their respective rules, last 3 don't match
@@ -1403,14 +1469,26 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1556,7 +1634,7 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 		} else {
 			builder_add_net6_dst(&builders[net_idx], net);
 		}
-		rules[net_idx] = build_rule(&builders[net_idx], net_idx);
+		rules[net_idx] = build_rule(&builders[net_idx]);
 	}
 
 	// Expected: packets 0,1,4 match rule 1; packets 2,3,5 match rule 2
@@ -1587,14 +1665,26 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[nets_count];
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, nets_count, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			nets_count,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");

--- a/filter/tests/basic_port_fast.c
+++ b/filter/tests/basic_port_fast.c
@@ -186,7 +186,7 @@ test_basic(void *arena, enum filter_sign sign) {
 			);
 		}
 
-		rules[range_idx] = build_rule(builder, range_idx);
+		rules[range_idx] = build_rule(builder);
 
 		for (size_t check_idx = 0; check_idx < checks_count;
 		     ++check_idx) {
@@ -209,12 +209,16 @@ test_basic(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[ranges_count];
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -222,7 +226,7 @@ test_basic(void *arena, enum filter_sign sign) {
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -326,7 +330,7 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 		builder_add_port_dst_range(&builders[0], 443, 443);
 		builder_add_port_dst_range(&builders[0], 8080, 8080);
 	}
-	rules[0] = build_rule(&builders[0], 0);
+	rules[0] = build_rule(&builders[0]);
 
 	// Rule 2: Add 2 port ranges (22, 3389)
 	builder_init(&builders[1]);
@@ -337,7 +341,7 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 		builder_add_port_dst_range(&builders[1], 22, 22);
 		builder_add_port_dst_range(&builders[1], 3389, 3389);
 	}
-	rules[1] = build_rule(&builders[1], 1);
+	rules[1] = build_rule(&builders[1]);
 
 	// Rule 3: Add 2 port ranges (3306, 5432)
 	builder_init(&builders[2]);
@@ -348,7 +352,7 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 		builder_add_port_dst_range(&builders[2], 3306, 3306);
 		builder_add_port_dst_range(&builders[2], 5432, 5432);
 	}
-	rules[2] = build_rule(&builders[2], 2);
+	rules[2] = build_rule(&builders[2]);
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -359,14 +363,26 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[num_rules];
+	for (size_t rp_i = 0; rp_i < num_rules; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
-			&filter, sign_fast_src_compile, rules, num_rules, &mctx
+			&filter,
+			sign_fast_src_compile,
+			rule_ptrs,
+			num_rules,
+			&mctx
 		);
 	} else {
 		res = filter_init(
-			&filter, sign_fast_dst_compile, rules, num_rules, &mctx
+			&filter,
+			sign_fast_dst_compile,
+			rule_ptrs,
+			num_rules,
+			&mctx
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -447,7 +463,7 @@ stress(void *arena,
 			}
 		}
 
-		rules[rule_idx] = build_rule(&builders[rule_idx], rule_idx);
+		rules[rule_idx] = build_rule(&builders[rule_idx]);
 	}
 
 	struct value_range **expected_ranges =
@@ -460,13 +476,18 @@ stress(void *arena,
 	}
 
 	// Initialize filter
+	const struct filter_rule **rule_ptrs =
+		malloc(sizeof(const struct filter_rule *) * num_rules);
+	for (size_t rp_i = 0; rp_i < num_rules; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	switch (sign) {
 	case src:
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			num_rules,
 			&memory_context
 		);
@@ -475,7 +496,7 @@ stress(void *arena,
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			num_rules,
 			&memory_context
 		);
@@ -484,7 +505,7 @@ stress(void *arena,
 		res = filter_init(
 			&filter,
 			sign_fast_src_dst_compile,
-			rules,
+			rule_ptrs,
 			num_rules,
 			&memory_context
 		);
@@ -599,6 +620,7 @@ stress(void *arena,
 		result, "failed to query packets and compare with expected"
 	);
 
+	free(rule_ptrs);
 	free(rules);
 	free(builders);
 	for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx) {
@@ -688,7 +710,7 @@ test_no_match(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
+		rules[range_idx] = build_rule(&builders[range_idx]);
 	}
 
 	// Expected: no matches for any packet
@@ -708,12 +730,16 @@ test_no_match(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[ranges_count];
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -721,7 +747,7 @@ test_no_match(void *arena, enum filter_sign sign) {
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -814,7 +840,7 @@ test_overlapping_ranges(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
+		rules[range_idx] = build_rule(&builders[range_idx]);
 	}
 
 	// Expected matches
@@ -846,12 +872,16 @@ test_overlapping_ranges(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[ranges_count];
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -859,7 +889,7 @@ test_overlapping_ranges(void *arena, enum filter_sign sign) {
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -949,7 +979,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
+		rules[range_idx] = build_rule(&builders[range_idx]);
 	}
 
 	// Expected: first 4 match, last 2 don't
@@ -973,12 +1003,16 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[ranges_count];
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -986,7 +1020,7 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -1081,7 +1115,7 @@ test_single_port_ranges(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
+		rules[range_idx] = build_rule(&builders[range_idx]);
 	}
 
 	// Expected: first 4 match their respective rules, last 4 don't match
@@ -1116,12 +1150,16 @@ test_single_port_ranges(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[ranges_count];
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -1129,7 +1167,7 @@ test_single_port_ranges(void *arena, enum filter_sign sign) {
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -1221,7 +1259,7 @@ test_adjacent_ranges(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
+		rules[range_idx] = build_rule(&builders[range_idx]);
 	}
 
 	// Expected: ports 0,1,4 match rule 1; ports 2,3,5 match rule 2
@@ -1252,12 +1290,16 @@ test_adjacent_ranges(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[ranges_count];
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -1265,7 +1307,7 @@ test_adjacent_ranges(void *arena, enum filter_sign sign) {
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -1359,7 +1401,7 @@ test_extreme_ports(void *arena, enum filter_sign sign) {
 				ranges[range_idx].to
 			);
 		}
-		rules[range_idx] = build_rule(&builders[range_idx], range_idx);
+		rules[range_idx] = build_rule(&builders[range_idx]);
 	}
 
 	// Expected matches
@@ -1394,12 +1436,16 @@ test_extreme_ports(void *arena, enum filter_sign sign) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[ranges_count];
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	if (sign == src) {
 		res = filter_init(
 			&filter,
 			sign_fast_src_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);
@@ -1407,7 +1453,7 @@ test_extreme_ports(void *arena, enum filter_sign sign) {
 		res = filter_init(
 			&filter,
 			sign_fast_dst_compile,
-			rules,
+			rule_ptrs,
 			ranges_count,
 			&mctx
 		);

--- a/filter/tests/basic_ports.c
+++ b/filter/tests/basic_ports.c
@@ -71,7 +71,7 @@ test_src_dst_ports(void *memory) {
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 5, 7);
 	builder_add_port_dst_range(&builder1, 1, 5);
-	struct filter_rule action1 = build_rule(&builder1, 0);
+	struct filter_rule action1 = build_rule(&builder1);
 
 	// action 2:
 	//   src_port: [6..8]
@@ -80,13 +80,15 @@ test_src_dst_ports(void *memory) {
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 6, 8);
 	builder_add_port_dst_range(&builder2, 3, 4);
-	struct filter_rule action2 = build_rule(&builder2, 1);
+	struct filter_rule action2 = build_rule(&builder2);
 
-	struct filter_rule actions[2] = {action1, action2};
+	const struct filter_rule *action_ptrs[2] = {&action1, &action2};
 
 	// init filter
 	struct filter f;
-	res = filter_init(&f, sign_ports_compile, actions, 2, &memory_context);
+	res = filter_init(
+		&f, sign_ports_compile, action_ptrs, 2, &memory_context
+	);
 	assert(res == 0);
 
 	query_and_expect_action(&f, 6, 3, 0);
@@ -111,24 +113,28 @@ src_dst_ports(void *memory) {
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 1024, 5016);
 	builder_add_port_dst_range(&builder1, 500, 50000);
-	struct filter_rule action1 = build_rule(&builder1, 0);
+	struct filter_rule action1 = build_rule(&builder1);
 
 	struct filter_rule_builder builder2;
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 30, 500);
 	builder_add_port_dst_range(&builder2, 400, 12040);
-	struct filter_rule action2 = build_rule(&builder2, 1);
+	struct filter_rule action2 = build_rule(&builder2);
 
 	struct filter_rule_builder builder3;
 	builder_init(&builder3);
 	builder_add_port_src_range(&builder3, 100, 2014);
 	builder_add_port_dst_range(&builder3, 5000, 15000);
-	struct filter_rule action3 = build_rule(&builder3, 2);
+	struct filter_rule action3 = build_rule(&builder3);
 
-	struct filter_rule actions[3] = {action1, action2, action3};
+	const struct filter_rule *action_ptrs[3] = {
+		&action1, &action2, &action3
+	};
 
 	struct filter f;
-	res = filter_init(&f, sign_ports_compile, actions, 3, &memory_context);
+	res = filter_init(
+		&f, sign_ports_compile, action_ptrs, 3, &memory_context
+	);
 	assert(res == 0);
 
 	query_and_expect_action(&f, 30, 400, 1);
@@ -169,26 +175,30 @@ test_any_port(void *memory) {
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 1024, 5016);
 	builder_add_port_dst_range(&builder1, 0, 65535);
-	struct filter_rule action1 = build_rule(&builder1, 0);
+	struct filter_rule action1 = build_rule(&builder1);
 
 	// rule 2: src any, dst [400..12040]
 	struct filter_rule_builder builder2;
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 0, 65535);
 	builder_add_port_dst_range(&builder2, 400, 12040);
-	struct filter_rule action2 = build_rule(&builder2, 1);
+	struct filter_rule action2 = build_rule(&builder2);
 
 	// rule 3: src [100..2014], dst [5000..15000]
 	struct filter_rule_builder builder3;
 	builder_init(&builder3);
 	builder_add_port_src_range(&builder3, 100, 2014);
 	builder_add_port_dst_range(&builder3, 5000, 15000);
-	struct filter_rule action3 = build_rule(&builder3, 2);
+	struct filter_rule action3 = build_rule(&builder3);
 
-	struct filter_rule actions[3] = {action1, action2, action3};
+	const struct filter_rule *action_ptrs[3] = {
+		&action1, &action2, &action3
+	};
 
 	struct filter f;
-	res = filter_init(&f, sign_ports_compile, actions, 3, &memory_context);
+	res = filter_init(
+		&f, sign_ports_compile, action_ptrs, 3, &memory_context
+	);
 	assert(res == 0);
 
 	query_and_expect_action(&f, 1025, 11111, 0);

--- a/filter/tests/basic_proto.c
+++ b/filter/tests/basic_proto.c
@@ -60,23 +60,23 @@ test_proto_1(void *memory) {
 	struct filter_rule_builder b1;
 	builder_init(&b1);
 	builder_set_proto(&b1, IPPROTO_TCP, 0b101, 0b010);
-	struct filter_rule r1 = build_rule(&b1, 0);
+	struct filter_rule r1 = build_rule(&b1);
 
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_set_proto(&b2, IPPROTO_UDP, 0, 0);
-	struct filter_rule r2 = build_rule(&b2, 1);
+	struct filter_rule r2 = build_rule(&b2);
 
 	struct filter_rule_builder b3;
 	builder_init(&b3);
 	builder_set_proto(&b3, PROTO_UNSPEC, 0, 0);
-	struct filter_rule r3 = build_rule(&b3, 2);
+	struct filter_rule r3 = build_rule(&b3);
 
-	struct filter_rule rules[3] = {r1, r2, r3};
+	const struct filter_rule *rule_ptrs[3] = {&r1, &r2, &r3};
 
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_proto_compile, rules, 3, &memory_context
+		&filter, sign_proto_compile, rule_ptrs, 3, &memory_context
 	);
 	assert(res == 0);
 

--- a/filter/tests/basic_proto_range.c
+++ b/filter/tests/basic_proto_range.c
@@ -60,22 +60,22 @@ test_proto_1(void *memory) {
 	builder_add_proto_range(
 		&b1, 256 * IPPROTO_TCP, 256 * IPPROTO_TCP + 255
 	);
-	struct filter_rule r1 = build_rule(&b1, 0);
+	struct filter_rule r1 = build_rule(&b1);
 
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_add_proto_range(
 		&b2, 256 * IPPROTO_UDP, 256 * IPPROTO_UDP + 255
 	);
-	struct filter_rule r2 = build_rule(&b2, 1);
+	struct filter_rule r2 = build_rule(&b2);
 
-	struct filter_rule rules[2] = {r1, r2};
+	const struct filter_rule *rule_ptrs[2] = {&r1, &r2};
 
 	struct filter filter;
 
 	LOG(INFO, "filter init...");
 	res = filter_init(
-		&filter, sign_proto_range_compile, rules, 2, &memory_context
+		&filter, sign_proto_range_compile, rule_ptrs, 2, &memory_context
 	);
 	assert(res == 0);
 

--- a/filter/tests/basic_proto_range_fast.c
+++ b/filter/tests/basic_proto_range_fast.c
@@ -66,16 +66,20 @@ test_basic_tcp_udp(void *memory) {
 	builder_add_proto_range(
 		&b1, 256 * IPPROTO_TCP, 256 * IPPROTO_TCP + 255
 	);
-	struct filter_rule r1 = build_rule(&b1, 0);
+	struct filter_rule r1 = build_rule(&b1);
 
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_add_proto_range(
 		&b2, 256 * IPPROTO_UDP, 256 * IPPROTO_UDP + 255
 	);
-	struct filter_rule r2 = build_rule(&b2, 1);
+	struct filter_rule r2 = build_rule(&b2);
 
 	struct filter_rule rules[2] = {r1, r2};
+
+	const struct filter_rule *rule_ptrs[2];
+	for (size_t rp_i = 0; rp_i < 2; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
 
 	struct filter filter;
 
@@ -83,7 +87,7 @@ test_basic_tcp_udp(void *memory) {
 	res = filter_init(
 		&filter,
 		sign_proto_range_fast_compile,
-		rules,
+		rule_ptrs,
 		2,
 		&memory_context
 	);
@@ -118,7 +122,7 @@ test_tcp_flags(void *memory) {
 	builder_add_proto_range(
 		&b1, 256 * IPPROTO_TCP + 0x02, 256 * IPPROTO_TCP + 0x02
 	);
-	struct filter_rule r1 = build_rule(&b1, 0);
+	struct filter_rule r1 = build_rule(&b1);
 
 	// Rule 2: TCP ACK (flag 0x10)
 	struct filter_rule_builder b2;
@@ -126,7 +130,7 @@ test_tcp_flags(void *memory) {
 	builder_add_proto_range(
 		&b2, 256 * IPPROTO_TCP + 0x10, 256 * IPPROTO_TCP + 0x10
 	);
-	struct filter_rule r2 = build_rule(&b2, 1);
+	struct filter_rule r2 = build_rule(&b2);
 
 	// Rule 3: TCP FIN (flag 0x01)
 	struct filter_rule_builder b3;
@@ -134,15 +138,19 @@ test_tcp_flags(void *memory) {
 	builder_add_proto_range(
 		&b3, 256 * IPPROTO_TCP + 0x01, 256 * IPPROTO_TCP + 0x01
 	);
-	struct filter_rule r3 = build_rule(&b3, 2);
+	struct filter_rule r3 = build_rule(&b3);
 
 	struct filter_rule rules[3] = {r1, r2, r3};
+
+	const struct filter_rule *rule_ptrs[3];
+	for (size_t rp_i = 0; rp_i < 3; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
 
 	struct filter filter;
 	res = filter_init(
 		&filter,
 		sign_proto_range_fast_compile,
-		rules,
+		rule_ptrs,
 		3,
 		&memory_context
 	);
@@ -183,15 +191,19 @@ test_multiple_ranges_per_rule(void *memory) {
 	builder_add_proto_range(
 		&b1, 256 * IPPROTO_UDP, 256 * IPPROTO_UDP + 255
 	);
-	struct filter_rule r1 = build_rule(&b1, 0);
+	struct filter_rule r1 = build_rule(&b1);
 
 	struct filter_rule rules[1] = {r1};
+
+	const struct filter_rule *rule_ptrs[1];
+	for (size_t rp_i = 0; rp_i < 1; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
 
 	struct filter filter;
 	res = filter_init(
 		&filter,
 		sign_proto_range_fast_compile,
-		rules,
+		rule_ptrs,
 		1,
 		&memory_context
 	);
@@ -224,21 +236,25 @@ test_boundary_values(void *memory) {
 	struct filter_rule_builder b1;
 	builder_init(&b1);
 	builder_add_proto_range(&b1, 0, 100);
-	struct filter_rule r1 = build_rule(&b1, 0);
+	struct filter_rule r1 = build_rule(&b1);
 
 	// Rule 2: Proto range 65435-65535 (near max uint16_t)
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_add_proto_range(&b2, 65435, 65535);
-	struct filter_rule r2 = build_rule(&b2, 1);
+	struct filter_rule r2 = build_rule(&b2);
 
 	struct filter_rule rules[2] = {r1, r2};
+
+	const struct filter_rule *rule_ptrs[2];
+	for (size_t rp_i = 0; rp_i < 2; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
 
 	struct filter filter;
 	res = filter_init(
 		&filter,
 		sign_proto_range_fast_compile,
-		rules,
+		rule_ptrs,
 		2,
 		&memory_context
 	);

--- a/filter/tests/basic_vlan.c
+++ b/filter/tests/basic_vlan.c
@@ -47,23 +47,23 @@ test_proto_1(void *memory) {
 	struct filter_rule_builder b1;
 	builder_init(&b1);
 	builder_set_vlan(&b1, 10);
-	struct filter_rule r1 = build_rule(&b1, 0);
+	struct filter_rule r1 = build_rule(&b1);
 
 	struct filter_rule_builder b2;
 	builder_init(&b2);
 	builder_set_vlan(&b2, 20);
-	struct filter_rule r2 = build_rule(&b2, 1);
+	struct filter_rule r2 = build_rule(&b2);
 
 	struct filter_rule_builder b3;
 	builder_init(&b3);
 	builder_set_vlan(&b3, 30);
-	struct filter_rule r3 = build_rule(&b3, 2);
+	struct filter_rule r3 = build_rule(&b3);
 
-	struct filter_rule rules[3] = {r1, r2, r3};
+	const struct filter_rule *rule_ptrs[3] = {&r1, &r2, &r3};
 
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_vlan_compile, rules, 3, &memory_context
+		&filter, sign_vlan_compile, rule_ptrs, 3, &memory_context
 	);
 	assert(res == 0);
 

--- a/filter/tests/bench_net4.c
+++ b/filter/tests/bench_net4.c
@@ -226,7 +226,7 @@ generate_rules(
 			builder_set_proto(&builders[i], proto, 0, 0);
 		}
 
-		rules[i] = build_rule(&builders[i], i);
+		rules[i] = build_rule(&builders[i]);
 	}
 }
 
@@ -549,13 +549,18 @@ main(int argc, char **argv) {
 
 	// Initialize filter
 	printf("Initializing filter...\n");
+	const struct filter_rule **rule_ptrs =
+		malloc(sizeof(const struct filter_rule *) * config.num_rules);
+	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	switch (config.sig_type) {
 	case sig_net4_dst:
 		res = filter_init(
 			&filter,
 			bench_dst_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -564,7 +569,7 @@ main(int argc, char **argv) {
 		res = filter_init(
 			&filter,
 			bench_dst_port_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -573,7 +578,7 @@ main(int argc, char **argv) {
 		res = filter_init(
 			&filter,
 			bench_dst_port_proto_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -699,6 +704,7 @@ main(int argc, char **argv) {
 	munmap(packet_alloc_arena, packet_alloc_size);
 	munmap(packet_buffers, packet_buffers_size);
 	munmap(packet_info_array, packet_info_size);
+	free(rule_ptrs);
 	munmap(builders, builders_size);
 	munmap(rules, rules_size);
 	munmap(arena, arena_size);

--- a/filter/tests/bench_net4_fast.c
+++ b/filter/tests/bench_net4_fast.c
@@ -227,7 +227,7 @@ generate_rules(
 			builder_set_proto(&builders[i], proto, 0, 0);
 		}
 
-		rules[i] = build_rule(&builders[i], i);
+		rules[i] = build_rule(&builders[i]);
 	}
 }
 
@@ -562,13 +562,18 @@ main(int argc, char **argv) {
 
 	// Initialize filter
 	printf("Initializing filter...\n");
+	const struct filter_rule **rule_ptrs =
+		malloc(sizeof(const struct filter_rule *) * config.num_rules);
+	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	switch (config.sig_type) {
 	case sig_net4_dst:
 		res = filter_init(
 			&filter,
 			bench_dst_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -577,7 +582,7 @@ main(int argc, char **argv) {
 		res = filter_init(
 			&filter,
 			bench_dst_port_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -586,7 +591,7 @@ main(int argc, char **argv) {
 		res = filter_init(
 			&filter,
 			bench_dst_port_proto_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -712,6 +717,7 @@ main(int argc, char **argv) {
 	munmap(packet_alloc_arena, packet_alloc_size);
 	munmap(packet_buffers, packet_buffers_size);
 	munmap(packet_info_array, packet_info_size);
+	free(rule_ptrs);
 	munmap(builders, builders_size);
 	munmap(rules, rules_size);
 	munmap(arena, arena_size);

--- a/filter/tests/bench_net6.c
+++ b/filter/tests/bench_net6.c
@@ -247,7 +247,7 @@ generate_rules(
 			builder_set_proto(&builders[i], proto, 0, 0);
 		}
 
-		rules[i] = build_rule(&builders[i], i);
+		rules[i] = build_rule(&builders[i]);
 	}
 }
 
@@ -595,13 +595,18 @@ main(int argc, char **argv) {
 
 	// Initialize filter
 	printf("Initializing filter...\n");
+	const struct filter_rule **rule_ptrs =
+		malloc(sizeof(const struct filter_rule *) * config.num_rules);
+	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	switch (config.sig_type) {
 	case sig_net6_dst:
 		res = filter_init(
 			&filter,
 			bench_dst_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -610,7 +615,7 @@ main(int argc, char **argv) {
 		res = filter_init(
 			&filter,
 			bench_dst_port_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -619,7 +624,7 @@ main(int argc, char **argv) {
 		res = filter_init(
 			&filter,
 			bench_dst_port_proto_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -745,6 +750,7 @@ main(int argc, char **argv) {
 	munmap(packet_alloc_arena, packet_alloc_size);
 	munmap(packet_buffers, packet_buffers_size);
 	munmap(packet_info_array, packet_info_size);
+	free(rule_ptrs);
 	munmap(builders, builders_size);
 	munmap(rules, rules_size);
 	munmap(arena, arena_size);

--- a/filter/tests/bench_net6_fast.c
+++ b/filter/tests/bench_net6_fast.c
@@ -248,7 +248,7 @@ generate_rules(
 			builder_set_proto(&builders[i], proto, 0, 0);
 		}
 
-		rules[i] = build_rule(&builders[i], i);
+		rules[i] = build_rule(&builders[i]);
 	}
 }
 
@@ -596,13 +596,18 @@ main(int argc, char **argv) {
 
 	// Initialize filter
 	printf("Initializing filter...\n");
+	const struct filter_rule **rule_ptrs =
+		malloc(sizeof(const struct filter_rule *) * config.num_rules);
+	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++)
+		rule_ptrs[rp_i] = &rules[rp_i];
+
 	struct filter filter;
 	switch (config.sig_type) {
 	case sig_net6_dst:
 		res = filter_init(
 			&filter,
 			bench_dst_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -611,7 +616,7 @@ main(int argc, char **argv) {
 		res = filter_init(
 			&filter,
 			bench_dst_port_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -620,7 +625,7 @@ main(int argc, char **argv) {
 		res = filter_init(
 			&filter,
 			bench_dst_port_proto_compile,
-			rules,
+			rule_ptrs,
 			config.num_rules,
 			&memory_context
 		);
@@ -746,6 +751,7 @@ main(int argc, char **argv) {
 	munmap(packet_alloc_arena, packet_alloc_size);
 	munmap(packet_buffers, packet_buffers_size);
 	munmap(packet_info_array, packet_info_size);
+	free(rule_ptrs);
 	munmap(builders, builders_size);
 	munmap(rules, rules_size);
 	munmap(arena, arena_size);

--- a/filter/tests/combo_net4_port_proto_dst.c
+++ b/filter/tests/combo_net4_port_proto_dst.c
@@ -45,7 +45,7 @@ test_no_match_proto_only(void *arena) {
 	builder_add_net4_dst(&builder, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder, 80, 90);
 	builder_set_proto(&builder, IPPROTO_TCP, 0, 0);
-	struct filter_rule rule = build_rule(&builder, 0);
+	struct filter_rule rule = build_rule(&builder);
 
 	// Test packets: IP and port match but protocol doesn't
 	const struct {
@@ -94,9 +94,11 @@ test_no_match_proto_only(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptr = &rule;
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_proto_dst_compile, &rule, 1, &mctx
+		&filter, combo_net4_port_proto_dst_compile, &rule_ptr, 1, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -131,7 +133,7 @@ test_all_match(void *arena) {
 	builder_add_net4_dst(&builder, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder, 80, 90);
 	builder_set_proto(&builder, IPPROTO_TCP, 0, 0);
-	struct filter_rule rule = build_rule(&builder, 0);
+	struct filter_rule rule = build_rule(&builder);
 
 	// Test packets: All match
 	const struct {
@@ -181,9 +183,11 @@ test_all_match(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptr = &rule;
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_proto_dst_compile, &rule, 1, &mctx
+		&filter, combo_net4_port_proto_dst_compile, &rule_ptr, 1, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -218,7 +222,7 @@ test_multiple_rules_overlap(void *arena) {
 	builder_add_net4_dst(&builder1, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder1, 80, 90);
 	builder_set_proto(&builder1, IPPROTO_TCP, 0, 0);
-	struct filter_rule rule1 = build_rule(&builder1, 0);
+	struct filter_rule rule1 = build_rule(&builder1);
 
 	// Rule 2: dst IP 10.0.0.0/16, dst port 85-95, TCP
 	struct filter_rule_builder builder2;
@@ -226,7 +230,7 @@ test_multiple_rules_overlap(void *arena) {
 	builder_add_net4_dst(&builder2, ip(10, 0, 0, 0), ip(255, 255, 0, 0));
 	builder_add_port_dst_range(&builder2, 85, 95);
 	builder_set_proto(&builder2, IPPROTO_TCP, 0, 0);
-	struct filter_rule rule2 = build_rule(&builder2, 1);
+	struct filter_rule rule2 = build_rule(&builder2);
 
 	// Rule 3: dst IP 10.0.0.0/24, dst port 80-90, UDP
 	struct filter_rule_builder builder3;
@@ -234,7 +238,7 @@ test_multiple_rules_overlap(void *arena) {
 	builder_add_net4_dst(&builder3, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder3, 80, 90);
 	builder_set_proto(&builder3, IPPROTO_UDP, 0, 0);
-	struct filter_rule rule3 = build_rule(&builder3, 2);
+	struct filter_rule rule3 = build_rule(&builder3);
 
 	struct filter_rule rules[] = {rule1, rule2, rule3};
 
@@ -301,9 +305,13 @@ test_multiple_rules_overlap(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[3] = {
+		&rules[0], &rules[1], &rules[2]
+	};
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_proto_dst_compile, rules, 3, &mctx
+		&filter, combo_net4_port_proto_dst_compile, rule_ptrs, 3, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -338,7 +346,7 @@ test_tcp_flags(void *arena) {
 	builder_add_net4_dst(&builder1, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder1, 80, 80);
 	builder_set_proto(&builder1, IPPROTO_TCP, 0x02, 0); // SYN flag
-	struct filter_rule rule1 = build_rule(&builder1, 0);
+	struct filter_rule rule1 = build_rule(&builder1);
 
 	// Rule 2: dst IP 10.0.0.0/24, dst port 80, TCP with ACK flag
 	struct filter_rule_builder builder2;
@@ -346,7 +354,7 @@ test_tcp_flags(void *arena) {
 	builder_add_net4_dst(&builder2, ip(10, 0, 0, 0), ip(255, 255, 255, 0));
 	builder_add_port_dst_range(&builder2, 80, 80);
 	builder_set_proto(&builder2, IPPROTO_TCP, 0x10, 0); // ACK flag
-	struct filter_rule rule2 = build_rule(&builder2, 1);
+	struct filter_rule rule2 = build_rule(&builder2);
 
 	struct filter_rule rules[] = {rule1, rule2};
 
@@ -410,9 +418,11 @@ test_tcp_flags(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[2] = {&rules[0], &rules[1]};
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_proto_dst_compile, rules, 2, &mctx
+		&filter, combo_net4_port_proto_dst_compile, rule_ptrs, 2, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 

--- a/filter/tests/combo_net4_port_src.c
+++ b/filter/tests/combo_net4_port_src.c
@@ -74,7 +74,7 @@ test_no_match_port_only(void *arena) {
 	uint32_t mask = prefix_mask(24);
 	builder_add_net4_src(&builder, ip(10, 0, 0, 0), (const uint8_t *)&mask);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 0);
+	struct filter_rule rule = build_rule(&builder);
 
 	// Test packets: IP matches but port doesn't
 	const struct {
@@ -122,9 +122,11 @@ test_no_match_port_only(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptr = &rule;
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_src_compile, &rule, 1, &mctx
+		&filter, combo_net4_port_src_compile, &rule_ptr, 1, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -154,7 +156,7 @@ test_no_match_ip_only(void *arena) {
 	uint32_t mask = prefix_mask(24);
 	builder_add_net4_src(&builder, ip(10, 0, 0, 0), (const uint8_t *)&mask);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 0);
+	struct filter_rule rule = build_rule(&builder);
 
 	// Test packets: Port matches but IP doesn't
 	const struct {
@@ -202,9 +204,11 @@ test_no_match_ip_only(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptr = &rule;
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_src_compile, &rule, 1, &mctx
+		&filter, combo_net4_port_src_compile, &rule_ptr, 1, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -234,7 +238,7 @@ test_both_match(void *arena) {
 	uint32_t mask = prefix_mask(24);
 	builder_add_net4_src(&builder, ip(10, 0, 0, 0), (const uint8_t *)&mask);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 0);
+	struct filter_rule rule = build_rule(&builder);
 
 	// Test packets: Both IP and port match
 	const struct {
@@ -283,9 +287,11 @@ test_both_match(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptr = &rule;
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_src_compile, &rule, 1, &mctx
+		&filter, combo_net4_port_src_compile, &rule_ptr, 1, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -321,7 +327,7 @@ test_overlapping(void *arena) {
 		&builders[0], ip(10, 0, 0, 0), (const uint8_t *)&mask1
 	);
 	builder_add_port_src_range(&builders[0], 80, 100);
-	rules[0] = build_rule(&builders[0], 0);
+	rules[0] = build_rule(&builders[0]);
 
 	builder_init(&builders[1]);
 	uint32_t mask2 = prefix_mask(16);
@@ -329,7 +335,7 @@ test_overlapping(void *arena) {
 		&builders[1], ip(10, 1, 0, 0), (const uint8_t *)&mask2
 	);
 	builder_add_port_src_range(&builders[1], 90, 110);
-	rules[1] = build_rule(&builders[1], 1);
+	rules[1] = build_rule(&builders[1]);
 
 	builder_init(&builders[2]);
 	uint32_t mask3 = prefix_mask(24);
@@ -337,7 +343,7 @@ test_overlapping(void *arena) {
 		&builders[2], ip(10, 1, 1, 0), (const uint8_t *)&mask3
 	);
 	builder_add_port_src_range(&builders[2], 95, 105);
-	rules[2] = build_rule(&builders[2], 2);
+	rules[2] = build_rule(&builders[2]);
 
 	// Test packets
 	const struct {
@@ -392,9 +398,13 @@ test_overlapping(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptrs[3] = {
+		&rules[0], &rules[1], &rules[2]
+	};
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_src_compile, rules, 3, &mctx
+		&filter, combo_net4_port_src_compile, rule_ptrs, 3, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 

--- a/filter/tests/combo_net6_port_src.c
+++ b/filter/tests/combo_net6_port_src.c
@@ -87,7 +87,7 @@ test_no_match_port_only(void *arena) {
 	memcpy(net.mask, mask, NET6_LEN);
 	builder_add_net6_src(&builder, net);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 0);
+	struct filter_rule rule = build_rule(&builder);
 
 	// Test packets: IP matches but port doesn't
 	const struct {
@@ -142,9 +142,11 @@ test_no_match_port_only(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptr = &rule;
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net6_port_src_compile, &rule, 1, &mctx
+		&filter, combo_net6_port_src_compile, &rule_ptr, 1, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -181,7 +183,7 @@ test_no_match_ip_only(void *arena) {
 	memcpy(net.mask, mask, NET6_LEN);
 	builder_add_net6_src(&builder, net);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 0);
+	struct filter_rule rule = build_rule(&builder);
 
 	// Test packets: Port matches but IP doesn't
 	const struct {
@@ -251,9 +253,11 @@ test_no_match_ip_only(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptr = &rule;
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net6_port_src_compile, &rule, 1, &mctx
+		&filter, combo_net6_port_src_compile, &rule_ptr, 1, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -290,7 +294,7 @@ test_both_match(void *arena) {
 	memcpy(net.mask, mask, NET6_LEN);
 	builder_add_net6_src(&builder, net);
 	builder_add_port_src_range(&builder, 80, 90);
-	struct filter_rule rule = build_rule(&builder, 0);
+	struct filter_rule rule = build_rule(&builder);
 
 	// Test packets: Both IP and port match
 	const struct {
@@ -362,9 +366,11 @@ test_both_match(void *arena) {
 	res = memory_context_init(&mctx, "test", &alloc);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
+	const struct filter_rule *rule_ptr = &rule;
+
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net6_port_src_compile, &rule, 1, &mctx
+		&filter, combo_net6_port_src_compile, &rule_ptr, 1, &mctx
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 

--- a/filter/tests/corner.c
+++ b/filter/tests/corner.c
@@ -67,24 +67,24 @@ check_single_attribute(void *memory) {
 	builder_add_port_src_range(&builder1, 5, 7);
 	builder_add_port_src_range(&builder1, 6, 10);
 	builder_add_port_src_range(&builder1, 15, 20);
-	struct filter_rule rule1 = build_rule(&builder1, 0);
+	struct filter_rule rule1 = build_rule(&builder1);
 
 	// second action
 	// src port: [11-21]
 	struct filter_rule_builder builder2;
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 11, 21);
-	struct filter_rule rule2 = build_rule(&builder2, 1);
+	struct filter_rule rule2 = build_rule(&builder2);
 
 	// third action
 	// src port: [30-40]
 	struct filter_rule_builder builder3;
 	builder_init(&builder3);
 	builder_add_port_src_range(&builder3, 30, 40);
-	struct filter_rule rule3 = build_rule(&builder3, 2);
+	struct filter_rule rule3 = build_rule(&builder3);
 
 	// setup rules
-	struct filter_rule rules[3] = {rule1, rule2, rule3};
+	const struct filter_rule *rules[3] = {&rule1, &rule2, &rule3};
 
 	// setup filter
 	struct filter filter;

--- a/filter/tests/helpers.h
+++ b/filter/tests/helpers.h
@@ -144,10 +144,8 @@ builder_set_vlan(struct filter_rule_builder *b, uint16_t vlan) {
 }
 
 static inline struct filter_rule
-build_rule(struct filter_rule_builder *b, uint32_t action) {
+build_rule(struct filter_rule_builder *b) {
 	struct filter_rule r = {0};
-	r.action = action;
-
 	r.net4.src_count = (uint32_t)b->net4_src_count;
 	r.net4.srcs = b->net4_src;
 	r.net4.dst_count = (uint32_t)b->net4_dst_count;

--- a/filter/tests/macros.c
+++ b/filter/tests/macros.c
@@ -28,11 +28,12 @@ run_case(void) {
 	struct filter_rule_builder b;
 	builder_init(&b);
 	builder_add_port_src_range(&b, 1024, 5016);
-	struct filter_rule r = build_rule(&b, 0);
+	struct filter_rule r = build_rule(&b);
 
 	// init filter
+	const struct filter_rule *r_ptr = &r;
 	struct filter f;
-	res = filter_init(&f, sign, &r, 1, &memory_context);
+	res = filter_init(&f, sign, &r_ptr, 1, &memory_context);
 	assert(res == 0);
 
 	// craft packet: UDP 4000

--- a/filter/tests/memory.c
+++ b/filter/tests/memory.c
@@ -100,7 +100,7 @@ test_src_dst_ports(void *memory) {
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 5, 7);
 	builder_add_port_dst_range(&builder1, 1, 5);
-	struct filter_rule action1 = build_rule(&builder1, 0);
+	struct filter_rule action1 = build_rule(&builder1);
 
 	// action 2:
 	//	src_port: [6..8]
@@ -109,14 +109,14 @@ test_src_dst_ports(void *memory) {
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 6, 8);
 	builder_add_port_dst_range(&builder2, 3, 4);
-	struct filter_rule action2 = build_rule(&builder2, 1);
+	struct filter_rule action2 = build_rule(&builder2);
 
-	struct filter_rule actions[2] = {action1, action2};
+	const struct filter_rule *action_ptrs[2] = {&action1, &action2};
 
 	// init filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_ports_compile, actions, 2, &memory_context
+		&filter, sign_ports_compile, action_ptrs, 2, &memory_context
 	);
 	assert(res == 0);
 
@@ -145,21 +145,21 @@ test_src_port_only(void *memory) {
 	struct filter_rule_builder builder1;
 	builder_init(&builder1);
 	builder_add_port_src_range(&builder1, 500, 700);
-	struct filter_rule action1 = build_rule(&builder1, 0);
+	struct filter_rule action1 = build_rule(&builder1);
 
 	// action 2:
 	//	src_port: [600..800]
 	struct filter_rule_builder builder2;
 	builder_init(&builder2);
 	builder_add_port_src_range(&builder2, 600, 800);
-	struct filter_rule action2 = build_rule(&builder2, 1);
+	struct filter_rule action2 = build_rule(&builder2);
 
-	struct filter_rule actions[2] = {action1, action2};
+	const struct filter_rule *action_ptrs[2] = {&action1, &action2};
 
 	// init filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_port_src_compile, actions, 2, &memory_context
+		&filter, sign_port_src_compile, action_ptrs, 2, &memory_context
 	);
 	assert(res == 0);
 

--- a/filter/tests/net4_ports.c
+++ b/filter/tests/net4_ports.c
@@ -62,7 +62,7 @@ test(void *memory) {
 	builder_add_port_dst_range(&b1, 200, 250);
 	builder_add_net4_src(&b1, ip(198, 233, 0, 0), ip(255, 255, 0, 0));
 	builder_add_net4_dst(&b1, ip(192, 0, 0, 0), ip(255, 0, 0, 0));
-	struct filter_rule a1 = build_rule(&b1, 0);
+	struct filter_rule a1 = build_rule(&b1);
 
 	// a2:
 	//  src_port: 200-300
@@ -75,14 +75,18 @@ test(void *memory) {
 	builder_add_port_dst_range(&b2, 100, 300);
 	builder_add_net4_src(&b2, ip(198, 233, 10, 0), ip(255, 255, 255, 0));
 	builder_add_net4_dst(&b2, ip(192, 0, 0, 0), ip(255, 0, 0, 0));
-	struct filter_rule a2 = build_rule(&b2, 1);
+	struct filter_rule a2 = build_rule(&b2);
 
-	struct filter_rule actions[2] = {a1, a2};
+	const struct filter_rule *action_ptrs[2] = {&a1, &a2};
 
 	// build filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net4_ports_compile, actions, 2, &memory_context
+		&filter,
+		sign_net4_ports_compile,
+		action_ptrs,
+		2,
+		&memory_context
 	);
 	assert(res == 0);
 

--- a/filter/tests/shm/compiler.c
+++ b/filter/tests/shm/compiler.c
@@ -23,6 +23,7 @@ build_filter(struct common *common, struct memory_context *mctx) {
 	const size_t rule_count = 100;
 	struct filter_rule_builder builders[rule_count];
 	struct filter_rule rules[rule_count];
+	const struct filter_rule *rule_ptrs[rule_count];
 	uint64_t rng = 1231231;
 	for (size_t i = 0; i < rule_count; ++i) {
 		struct filter_rule_builder *builder = &builders[i];
@@ -39,11 +40,12 @@ build_filter(struct common *common, struct memory_context *mctx) {
 		builder_set_proto(
 			builder, i % 2 == 0 ? IPPROTO_TCP : IPPROTO_UDP, 0, 0
 		);
-		rules[i] = build_rule(builder, i);
+		rules[i] = build_rule(builder);
+		rule_ptrs[i] = rules + i;
 	}
 	LOG(INFO, "compiling %zu rules...", rule_count);
 	int res = filter_init(
-		&common->filter, filter_sign, rules, rule_count, mctx
+		&common->filter, filter_sign, rule_ptrs, rule_count, mctx
 	);
 	if (res < 0) {
 		LOG(ERROR, "compilation failed: %d", res);

--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -148,23 +148,17 @@ acl_module_config_free(struct cp_module *cp_module) {
 
 typedef int (*acl_rule_check_func)(const struct acl_rule *acl_rule);
 
-static uint32_t
-filter_acl_rules(
+static void
+make_filter_rules(
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
-	struct filter_rule *filter_rules,
-	acl_rule_check_func check
-	// TODO: should be there an instantiation callback??
+	struct filter_rule *filter_rules
 ) {
-	uint32_t filter_rule_idx = 0;
 	for (uint32_t acl_rule_idx = 0; acl_rule_idx < acl_rule_count;
 	     ++acl_rule_idx) {
 		struct acl_rule *acl_rule = acl_rules + acl_rule_idx;
-		if (!check(acl_rule))
-			continue;
 
-		struct filter_rule *filter_rule =
-			filter_rules + filter_rule_idx++;
+		struct filter_rule *filter_rule = filter_rules + acl_rule_idx;
 		filter_rule->device_count = acl_rule->devices.count;
 		filter_rule->devices = acl_rule->devices.items;
 
@@ -192,8 +186,31 @@ filter_acl_rules(
 		filter_rule->transport.dst_count =
 			acl_rule->dst_port_ranges.count;
 		filter_rule->transport.dsts = acl_rule->dst_port_ranges.items;
+	}
+}
 
-		filter_rule->action = acl_rule_idx;
+static uint32_t
+filter_acl_rules(
+	struct acl_rule *acl_rules,
+	uint32_t acl_rule_count,
+	const struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs,
+	acl_rule_check_func check
+) {
+	uint32_t filter_rule_idx = 0;
+	for (uint32_t acl_rule_idx = 0; acl_rule_idx < acl_rule_count;
+	     ++acl_rule_idx) {
+		struct acl_rule *acl_rule = acl_rules + acl_rule_idx;
+
+		const struct filter_rule *filter_rule =
+			filter_rules + acl_rule_idx;
+
+		if (!check(acl_rule)) {
+			filter_rule_ptrs[acl_rule_idx] = NULL;
+		} else {
+			filter_rule_ptrs[acl_rule_idx] = filter_rule;
+			++filter_rule_idx;
+		}
 	}
 
 	return filter_rule_idx;
@@ -260,22 +277,25 @@ acl_module_init_l2(
 	struct cp_module *cp_module,
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
-	struct filter_rule *filter_rules
+	struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
 
-	uint32_t filter_rule_count = filter_acl_rules(
-		acl_rules, acl_rule_count, filter_rules, check_acl_rule_l2
+	config->filter_rule_count_vlan = filter_acl_rules(
+		acl_rules,
+		acl_rule_count,
+		filter_rules,
+		filter_rule_ptrs,
+		check_acl_rule_l2
 	);
-
-	config->filter_rule_count_vlan = filter_rule_count;
 
 	return filter_init(
 		&config->filter_vlan,
 		ACL_FILTER_VLAN_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		acl_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -285,22 +305,25 @@ acl_module_init_ip4(
 	struct cp_module *cp_module,
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
-	struct filter_rule *filter_rules
+	struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
 
-	uint32_t filter_rule_count = filter_acl_rules(
-		acl_rules, acl_rule_count, filter_rules, check_acl_rule_ip4
+	config->filter_rule_count_ip4 = filter_acl_rules(
+		acl_rules,
+		acl_rule_count,
+		filter_rules,
+		filter_rule_ptrs,
+		check_acl_rule_ip4
 	);
-
-	config->filter_rule_count_ip4 = filter_rule_count;
 
 	return filter_init(
 		&config->filter_ip4,
 		ACL_FILTER_IP4_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		acl_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -310,22 +333,25 @@ acl_module_init_ip4_port(
 	struct cp_module *cp_module,
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
-	struct filter_rule *filter_rules
+	struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
 
-	uint32_t filter_rule_count = filter_acl_rules(
-		acl_rules, acl_rule_count, filter_rules, check_acl_rule_ip4_port
+	config->filter_rule_count_ip4_port = filter_acl_rules(
+		acl_rules,
+		acl_rule_count,
+		filter_rules,
+		filter_rule_ptrs,
+		check_acl_rule_ip4_port
 	);
-
-	config->filter_rule_count_ip4_port = filter_rule_count;
 
 	return filter_init(
 		&config->filter_ip4_port,
 		ACL_FILTER_IP4_PROTO_PORT_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		acl_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -335,22 +361,25 @@ acl_module_init_ip6(
 	struct cp_module *cp_module,
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
-	struct filter_rule *filter_rules
+	struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
 
-	uint32_t filter_rule_count = filter_acl_rules(
-		acl_rules, acl_rule_count, filter_rules, check_acl_rule_ip6
+	config->filter_rule_count_ip6 = filter_acl_rules(
+		acl_rules,
+		acl_rule_count,
+		filter_rules,
+		filter_rule_ptrs,
+		check_acl_rule_ip6
 	);
-
-	config->filter_rule_count_ip6 = filter_rule_count;
 
 	return filter_init(
 		&config->filter_ip6,
 		ACL_FILTER_IP6_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		acl_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -360,22 +389,25 @@ acl_module_init_ip6_port(
 	struct cp_module *cp_module,
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
-	struct filter_rule *filter_rules
+	struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
 
-	uint32_t filter_rule_count = filter_acl_rules(
-		acl_rules, acl_rule_count, filter_rules, check_acl_rule_ip6_port
+	config->filter_rule_count_ip6_port = filter_acl_rules(
+		acl_rules,
+		acl_rule_count,
+		filter_rules,
+		filter_rule_ptrs,
+		check_acl_rule_ip6_port
 	);
-
-	config->filter_rule_count_ip6_port = filter_rule_count;
 
 	return filter_init(
 		&config->filter_ip6_port,
 		ACL_FILTER_IP6_PROTO_PORT_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		acl_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -441,27 +473,63 @@ acl_module_config_update(
 		goto error_target;
 	}
 
+	const struct filter_rule **filter_rule_ptrs =
+		(const struct filter_rule **)malloc(
+			sizeof(struct filter_rule *) * rule_count
+		);
+	if (filter_rule_ptrs == NULL) {
+		goto error_rules;
+	}
+
 	struct timespec ts_start, ts_end;
 	clock_gettime(CLOCK_MONOTONIC, &ts_start);
 
-	if (acl_module_init_l2(cp_module, acl_rules, rule_count, filter_rules))
-		goto error_target;
+	make_filter_rules(acl_rules, rule_count, filter_rules);
 
-	if (acl_module_init_ip4(cp_module, acl_rules, rule_count, filter_rules))
-		goto error_target;
+	if (acl_module_init_l2(
+		    cp_module,
+		    acl_rules,
+		    rule_count,
+		    filter_rules,
+		    filter_rule_ptrs
+	    ))
+		goto error_rule_ptrs;
+
+	if (acl_module_init_ip4(
+		    cp_module,
+		    acl_rules,
+		    rule_count,
+		    filter_rules,
+		    filter_rule_ptrs
+	    ))
+		goto error_rule_ptrs;
 
 	if (acl_module_init_ip4_port(
-		    cp_module, acl_rules, rule_count, filter_rules
+		    cp_module,
+		    acl_rules,
+		    rule_count,
+		    filter_rules,
+		    filter_rule_ptrs
 	    ))
-		goto error_target;
+		goto error_rule_ptrs;
 
-	if (acl_module_init_ip6(cp_module, acl_rules, rule_count, filter_rules))
-		goto error_target;
+	if (acl_module_init_ip6(
+		    cp_module,
+		    acl_rules,
+		    rule_count,
+		    filter_rules,
+		    filter_rule_ptrs
+	    ))
+		goto error_rule_ptrs;
 
 	if (acl_module_init_ip6_port(
-		    cp_module, acl_rules, rule_count, filter_rules
+		    cp_module,
+		    acl_rules,
+		    rule_count,
+		    filter_rules,
+		    filter_rule_ptrs
 	    ))
-		goto error_target;
+		goto error_rule_ptrs;
 
 	clock_gettime(CLOCK_MONOTONIC, &ts_end);
 	config->compilation_time_ns =
@@ -469,9 +537,16 @@ acl_module_config_update(
 				   1000000000LL +
 			   (ts_end.tv_nsec - ts_start.tv_nsec));
 
+	free(filter_rule_ptrs);
 	free(filter_rules);
 
 	return 0;
+
+error_rule_ptrs:
+	free(filter_rule_ptrs);
+
+error_rules:
+	free(filter_rules);
 
 error_target:
 	free(filter_rules);

--- a/modules/acl/controlplane/ffi.go
+++ b/modules/acl/controlplane/ffi.go
@@ -154,4 +154,3 @@ func (m *ModuleConfig) GetInfo() *AclConfigInfo {
 		FilterRuleCountVlan:    uint64(cInfo.filter_rule_count_vlan),
 	}
 }
-

--- a/modules/balancer/controlplane/handler/rules.c
+++ b/modules/balancer/controlplane/handler/rules.c
@@ -97,7 +97,6 @@ make_filter_rules(
 			);
 			return -1;
 		}
-		rules[rule_idx].action = rule_idx;
 	}
 	*result_rules = rules;
 	return 0;
@@ -139,25 +138,39 @@ build_filter(
 	}
 
 	const size_t rules_count = vs_count;
+	const struct filter_rule **rule_ptrs = (const struct filter_rule **)
+		malloc(sizeof(struct filter_rule *) * rules_count);
+	if (rule_ptrs == NULL) {
+		memory_bfree(mctx, filter, sizeof(struct filter));
+		free_rules(rules_count, rules);
+		NEW_ERROR("no memory");
+		return -1;
+	}
+	for (size_t idx = 0; idx < rules_count; ++idx)
+		rule_ptrs[idx] = rules + idx;
+
 	if (proto == IPPROTO_IPV6) {
 		if (filter_init(
-			    filter, vs_lookup_ipv6, rules, rules_count, mctx
+			    filter, vs_lookup_ipv6, rule_ptrs, rules_count, mctx
 		    ) != 0) {
 			memory_bfree(mctx, filter, sizeof(struct filter));
 			free_rules(rules_count, rules);
+			free(rule_ptrs);
 			NEW_ERROR("no memory");
 			return -1;
 		}
 	} else {
 		if (filter_init(
-			    filter, vs_lookup_ipv4, rules, rules_count, mctx
+			    filter, vs_lookup_ipv4, rule_ptrs, rules_count, mctx
 		    ) != 0) {
 			memory_bfree(mctx, filter, sizeof(struct filter));
 			free_rules(rules_count, rules);
+			free(rule_ptrs);
 			NEW_ERROR("no memory");
 			return -1;
 		}
 	}
+	free(rule_ptrs);
 
 	SET_OFFSET_OF(&packet_handler_vs->filter, filter);
 

--- a/modules/balancer/controlplane/handler/vs.c
+++ b/modules/balancer/controlplane/handler/vs.c
@@ -700,17 +700,28 @@ setup_acl(
 		rule->transport.srcs = ADDR_OF(&rule->transport.srcs);
 	}
 
+	const struct filter_rule **rule_ptrs = (const struct filter_rule **)
+		malloc(sizeof(struct filter_rule *) * rule_count);
+	if (rule_ptrs == NULL) {
+		PUSH_ERROR("no memory");
+		return -1;
+	}
+	for (size_t idx = 0; idx < rule_count; ++idx) {
+		rule_ptrs[idx] = rules + idx;
+	}
+
 	// Initialize filter with absolute pointers
 	int res;
 	if (vs->identifier.ip_proto == IPPROTO_IP) {
 		res = filter_init(
-			vs->acl, vs_acl_ipv4, rules, rule_count, mctx
+			vs->acl, vs_acl_ipv4, rule_ptrs, rule_count, mctx
 		);
 	} else { // IPPROTO_IPV6
 		res = filter_init(
-			vs->acl, vs_acl_ipv6, rules, rule_count, mctx
+			vs->acl, vs_acl_ipv6, rule_ptrs, rule_count, mctx
 		);
 	}
+	free(rule_ptrs);
 
 	// Restore relative pointers
 	for (size_t i = 0; i < rule_count; ++i) {
@@ -878,9 +889,6 @@ setup_acl_rules(
 			// counter is undefined, because tag not specified
 			rule_counters[i] = (uint64_t)-1;
 		}
-
-		// store actions equal rule stable index
-		rules[i].action = i;
 	}
 
 	// Store using relative pointers

--- a/modules/forward/api/controlplane.c
+++ b/modules/forward/api/controlplane.c
@@ -83,25 +83,20 @@ forward_module_config_free(struct cp_module *cp_module) {
 
 typedef int (*forward_rule_check_func)(const struct forward_rule *forward_rule);
 
-static uint32_t
-filter_forward_rules(
+static void
+make_filter_rules(
 	struct forward_rule *forward_rules,
 	uint32_t forward_rule_count,
-	struct filter_rule *filter_rules,
-	forward_rule_check_func check
-	// TODO: should be there an instantiation callback??
+	struct filter_rule *filter_rules
 ) {
-	uint32_t filter_rule_idx = 0;
 	for (uint32_t forward_rule_idx = 0;
 	     forward_rule_idx < forward_rule_count;
 	     ++forward_rule_idx) {
 		struct forward_rule *forward_rule =
 			forward_rules + forward_rule_idx;
-		if (!check(forward_rule))
-			continue;
 
 		struct filter_rule *filter_rule =
-			filter_rules + filter_rule_idx++;
+			filter_rules + forward_rule_idx;
 		filter_rule->device_count = forward_rule->devices.count;
 		filter_rule->devices = forward_rule->devices.items;
 
@@ -117,8 +112,31 @@ filter_forward_rules(
 		filter_rule->net6.srcs = forward_rule->src_net6s.items;
 		filter_rule->net6.dst_count = forward_rule->dst_net6s.count;
 		filter_rule->net6.dsts = forward_rule->dst_net6s.items;
+	}
+}
 
-		filter_rule->action = forward_rule_idx;
+static uint32_t
+filter_forward_rules(
+	struct forward_rule *forward_rules,
+	uint32_t forward_rule_count,
+	const struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs,
+	forward_rule_check_func check
+) {
+	uint32_t filter_rule_idx = 0;
+	for (uint32_t forward_rule_idx = 0;
+	     forward_rule_idx < forward_rule_count;
+	     ++forward_rule_idx) {
+		struct forward_rule *forward_rule =
+			forward_rules + forward_rule_idx;
+
+		if (!check(forward_rule)) {
+			filter_rule_ptrs[forward_rule_idx] = NULL;
+		} else {
+			filter_rule_ptrs[forward_rule_idx] =
+				filter_rules + forward_rule_idx;
+			++filter_rule_idx;
+		}
 	}
 
 	return filter_rule_idx;
@@ -156,24 +174,26 @@ forward_module_init_l2(
 	struct cp_module *cp_module,
 	struct forward_rule *forward_rules,
 	uint32_t forward_rule_count,
-	struct filter_rule *filter_rules
+	struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct forward_module_config *config = container_of(
 		cp_module, struct forward_module_config, cp_module
 	);
 
-	uint32_t filter_rule_count = filter_forward_rules(
+	filter_forward_rules(
 		forward_rules,
 		forward_rule_count,
 		filter_rules,
+		filter_rule_ptrs,
 		check_forward_rule_l2
 	);
 
 	return filter_init(
 		&config->filter_vlan,
 		FWD_FILTER_VLAN_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		forward_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -183,24 +203,26 @@ forward_module_init_ip4(
 	struct cp_module *cp_module,
 	struct forward_rule *forward_rules,
 	uint32_t forward_rule_count,
-	struct filter_rule *filter_rules
+	struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct forward_module_config *config = container_of(
 		cp_module, struct forward_module_config, cp_module
 	);
 
-	uint32_t filter_rule_count = filter_forward_rules(
+	filter_forward_rules(
 		forward_rules,
 		forward_rule_count,
 		filter_rules,
+		filter_rule_ptrs,
 		check_forward_rule_ip4
 	);
 
 	return filter_init(
 		&config->filter_ip4,
 		FWD_FILTER_IP4_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		forward_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -210,24 +232,26 @@ forward_module_init_ip6(
 	struct cp_module *cp_module,
 	struct forward_rule *forward_rules,
 	uint32_t forward_rule_count,
-	struct filter_rule *filter_rules
+	struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct forward_module_config *config = container_of(
 		cp_module, struct forward_module_config, cp_module
 	);
 
-	uint32_t filter_rule_count = filter_forward_rules(
+	filter_forward_rules(
 		forward_rules,
 		forward_rule_count,
 		filter_rules,
+		filter_rule_ptrs,
 		check_forward_rule_ip6
 	);
 
 	return filter_init(
 		&config->filter_ip6,
 		FWD_FILTER_IP6_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		forward_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -290,24 +314,53 @@ forward_module_config_update(
 		goto error_target;
 	}
 
+	make_filter_rules(forward_rules, rule_count, filter_rules);
+
+	const struct filter_rule **filter_rule_ptrs =
+		(const struct filter_rule **)malloc(
+			sizeof(struct filter_rule *) * rule_count
+		);
+	if (filter_rule_ptrs == NULL) {
+		goto error_rules;
+	}
+
 	if (forward_module_init_l2(
-		    cp_module, forward_rules, rule_count, filter_rules
+		    cp_module,
+		    forward_rules,
+		    rule_count,
+		    filter_rules,
+		    filter_rule_ptrs
 	    ))
-		goto error_target;
+		goto error_rule_ptrs;
 
 	if (forward_module_init_ip4(
-		    cp_module, forward_rules, rule_count, filter_rules
+		    cp_module,
+		    forward_rules,
+		    rule_count,
+		    filter_rules,
+		    filter_rule_ptrs
 	    ))
-		goto error_target;
+		goto error_rule_ptrs;
 
 	if (forward_module_init_ip6(
-		    cp_module, forward_rules, rule_count, filter_rules
+		    cp_module,
+		    forward_rules,
+		    rule_count,
+		    filter_rules,
+		    filter_rule_ptrs
 	    ))
-		goto error_target;
+		goto error_rule_ptrs;
 
+	free(filter_rule_ptrs);
 	free(filter_rules);
 
 	return 0;
+
+error_rule_ptrs:
+	free(filter_rule_ptrs);
+
+error_rules:
+	free(filter_rules);
 
 error_target:
 	memory_bfree(

--- a/modules/route-mpls/api/controlplane.c
+++ b/modules/route-mpls/api/controlplane.c
@@ -100,25 +100,20 @@ typedef int (*route_mpls_rule_check_func)(
 	const struct route_mpls_rule *route_mpls_rule
 );
 
-static uint32_t
-filter_route_mpls_rules(
+static void
+make_filter_rules(
 	struct route_mpls_rule *route_mpls_rules,
 	uint32_t route_mpls_rule_count,
-	struct filter_rule *filter_rules,
-	route_mpls_rule_check_func check
-	// TODO: should be there an instantiation callback??
+	struct filter_rule *filter_rules
 ) {
-	uint32_t filter_rule_idx = 0;
 	for (uint32_t route_mpls_rule_idx = 0;
 	     route_mpls_rule_idx < route_mpls_rule_count;
 	     ++route_mpls_rule_idx) {
 		struct route_mpls_rule *route_mpls_rule =
 			route_mpls_rules + route_mpls_rule_idx;
-		if (!check(route_mpls_rule))
-			continue;
 
 		struct filter_rule *filter_rule =
-			filter_rules + filter_rule_idx++;
+			filter_rules + route_mpls_rule_idx;
 
 		memset(filter_rule, 0, sizeof(struct filter_rule));
 
@@ -127,8 +122,31 @@ filter_route_mpls_rules(
 
 		filter_rule->net6.dst_count = route_mpls_rule->net6s.count;
 		filter_rule->net6.dsts = route_mpls_rule->net6s.items;
+	}
+}
 
-		filter_rule->action = route_mpls_rule_idx;
+static uint32_t
+filter_route_mpls_rules(
+	struct route_mpls_rule *route_mpls_rules,
+	uint32_t route_mpls_rule_count,
+	const struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs,
+	route_mpls_rule_check_func check
+) {
+	uint32_t filter_rule_idx = 0;
+	for (uint32_t route_mpls_rule_idx = 0;
+	     route_mpls_rule_idx < route_mpls_rule_count;
+	     ++route_mpls_rule_idx) {
+		struct route_mpls_rule *route_mpls_rule =
+			route_mpls_rules + route_mpls_rule_idx;
+
+		if (!check(route_mpls_rule)) {
+			filter_rule_ptrs[route_mpls_rule_idx] = NULL;
+		} else {
+			filter_rule_ptrs[route_mpls_rule_idx] =
+				filter_rules + route_mpls_rule_idx;
+			++filter_rule_idx;
+		}
 	}
 
 	return filter_rule_idx;
@@ -149,23 +167,25 @@ route_mpls_module_init_ip4(
 	struct cp_module *cp_module,
 	struct route_mpls_rule *route_mpls_rules,
 	uint64_t route_mpls_rule_count,
-	struct filter_rule *filter_rules
+	const struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct module_config *config =
 		container_of(cp_module, struct module_config, cp_module);
 
-	uint32_t filter_rule_count = filter_route_mpls_rules(
+	filter_route_mpls_rules(
 		route_mpls_rules,
 		route_mpls_rule_count,
 		filter_rules,
+		filter_rule_ptrs,
 		check_route_mpls_rule_ip4
 	);
 
 	return filter_init(
 		&config->filter_ip4,
 		FILTER_IP4_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		route_mpls_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -175,23 +195,25 @@ route_mpls_module_init_ip6(
 	struct cp_module *cp_module,
 	struct route_mpls_rule *route_mpls_rules,
 	uint64_t route_mpls_rule_count,
-	struct filter_rule *filter_rules
+	const struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs
 ) {
 	struct module_config *config =
 		container_of(cp_module, struct module_config, cp_module);
 
-	uint32_t filter_rule_count = filter_route_mpls_rules(
+	filter_route_mpls_rules(
 		route_mpls_rules,
 		route_mpls_rule_count,
 		filter_rules,
+		filter_rule_ptrs,
 		check_route_mpls_rule_ip6
 	);
 
 	return filter_init(
 		&config->filter_ip6,
 		FILTER_IP6_TAG,
-		filter_rules,
-		filter_rule_count,
+		filter_rule_ptrs,
+		route_mpls_rule_count,
 		&cp_module->memory_context
 	);
 }
@@ -332,25 +354,46 @@ route_mpls_module_config_update(
 		goto error;
 	}
 
+	make_filter_rules(
+		route_mpls_rules, route_mpls_rule_count, filter_rules
+	);
+
+	const struct filter_rule **filter_rule_ptrs =
+		(const struct filter_rule **)malloc(
+			sizeof(struct filter_rule *) * route_mpls_rule_count
+		);
+	if (filter_rule_ptrs == NULL) {
+		goto error_rules;
+	}
+
 	if (route_mpls_module_init_ip4(
 		    cp_module,
 		    route_mpls_rules,
 		    route_mpls_rule_count,
-		    filter_rules
+		    filter_rules,
+		    filter_rule_ptrs
 	    ))
-		goto error;
+		goto error_rule_ptrs;
 
 	if (route_mpls_module_init_ip6(
 		    cp_module,
 		    route_mpls_rules,
 		    route_mpls_rule_count,
-		    filter_rules
+		    filter_rules,
+		    filter_rule_ptrs
 	    ))
-		goto error;
+		goto error_rule_ptrs;
 
+	free(filter_rule_ptrs);
 	free(filter_rules);
 
 	return 0;
+
+error_rule_ptrs:
+	free(filter_rule_ptrs);
+
+error_rules:
+	free(filter_rules);
 
 error:
 


### PR DESCRIPTION
Complex rulesets contains rules with different combination of filter conditions. Such rules are sorted out into separate lists and compiled and queried separately. After lookup one have to compare lookup findings and decide which one is the first one.

Previous approach uses action_id attached to each rule and there was an implicit dependency on action id value to make different filter lookup correctly comparable.

Existing modules created monotonically increasing action identifiers which effectively mean the rule index.

The commit make such logic explicit - now filter compiler accepts an array of rule pointers with NULL placeholders and returns first matching rule index in this array.