### PR TITLE
Do not use `value_registry` as filter lookup result

### DIFF
--- a/filter/compiler.h
+++ b/filter/compiler.h
@@ -131,8 +131,7 @@ filter_init(
 			    &filter->memory_context,
 			    &dummy,
 			    &filter->v[1].registry,
-			    &filter->v[0].table,
-			    &filter->v[0].registry
+			    &filter->v[0].table
 		    )) {
 			value_registry_free(&dummy);
 			goto init_failed;
@@ -158,8 +157,7 @@ filter_init(
 		    &filter->memory_context,
 		    &filter->v[2 * 1].registry,
 		    &filter->v[2 * 1 + 1].registry,
-		    &filter->v[1].table,
-		    &filter->v[1].registry
+		    &filter->v[1].table
 	    )) {
 		goto init_failed;
 	}

--- a/filter/compiler/helper.c
+++ b/filter/compiler/helper.c
@@ -1,6 +1,6 @@
 #include "filter/compiler/helper.h"
 #include "common/registry.h"
-#include "filter/rule.h"
+#include "filter/filter.h"
 
 int
 init_dummy_registry(
@@ -31,17 +31,15 @@ init_dummy_registry(
 
 struct value_set_ctx {
 	struct value_table *table;
-	struct value_registry *registry;
-	struct remap_table remap_table;
 };
 
 static int
 value_table_set_action(uint32_t v1, uint32_t v2, uint32_t idx, void *data) {
 	struct value_set_ctx *set_ctx = (struct value_set_ctx *)data;
 	uint32_t *value = value_table_get_ptr(set_ctx->table, v1, v2);
-	if (*value)
+	if (*value != FILTER_RULE_INVALID)
 		return 0;
-	*value = idx + 1;
+	*value = idx;
 
 	return 0;
 }
@@ -51,8 +49,7 @@ merge_and_set_registry_values(
 	struct memory_context *memory_context,
 	struct value_registry *registry1,
 	struct value_registry *registry2,
-	struct value_table *table,
-	struct value_registry *registry
+	struct value_table *table
 ) {
 	if (value_table_init(
 		    table,
@@ -63,22 +60,21 @@ merge_and_set_registry_values(
 		return -1;
 	}
 
-	if (value_registry_init(registry, memory_context)) {
-		goto error_registry;
+	for (uint64_t v_idx = 0; v_idx < value_registry_capacity(registry2);
+	     ++v_idx) {
+		for (uint64_t h_idx = 0;
+		     h_idx < value_registry_capacity(registry1);
+		     ++h_idx) {
+			*value_table_get_ptr(table, h_idx, v_idx) =
+				FILTER_RULE_INVALID;
+		}
 	}
-
-	if (value_registry_start(registry))
-		goto error_merge;
 
 	struct value_set_ctx set_ctx;
 	set_ctx.table = table;
-	set_ctx.registry = registry;
 
 	for (uint32_t range_idx = 0; range_idx < registry1->range_count;
 	     ++range_idx) {
-		if (value_registry_start(registry) ||
-		    value_registry_collect(registry, range_idx))
-			goto error_join;
 		if (value_registry_join_range(
 			    registry1,
 			    registry2,
@@ -92,11 +88,6 @@ merge_and_set_registry_values(
 	return 0;
 
 error_join:
-
-error_merge:
-	value_registry_free(registry);
-
-error_registry:
 	value_table_free(table);
 
 	return -1;

--- a/filter/compiler/helper.h
+++ b/filter/compiler/helper.h
@@ -20,8 +20,7 @@ merge_and_set_registry_values(
 	struct memory_context *memory_context,
 	struct value_registry *registry1,
 	struct value_registry *registry2,
-	struct value_table *table,
-	struct value_registry *registry
+	struct value_table *table
 );
 
 int

--- a/filter/filter.h
+++ b/filter/filter.h
@@ -32,6 +32,8 @@
 #include <stdint.h>
 #include <threads.h>
 
+#define FILTER_RULE_INVALID (uint32_t)0xffffffff
+
 /**
  * @def MAX_ATTRIBUTES
  * @brief Upper bound on attribute count in a filter signature.

--- a/filter/query.h
+++ b/filter/query.h
@@ -39,7 +39,7 @@ filter_query(
 	struct filter *filter,
 	const struct filter_query *filter_query,
 	struct packet **packets,
-	struct value_range **results,
+	uint32_t *results,
 	uint32_t packet_count
 ) {
 	/* Local slots storage */
@@ -80,8 +80,6 @@ filter_query(
 				: __slots[(__root << 1) * packet_count + idx],
 			__slots[(__root << 1 | 1) * packet_count + idx]
 		);
-		struct value_range *__range =
-			ADDR_OF(&__r->registry.ranges) + __res;
-		(results)[idx] = __range;
+		(results)[idx] = __res;
 	}
 }

--- a/filter/tests/basic_net4.c
+++ b/filter/tests/basic_net4.c
@@ -23,10 +23,9 @@ query_and_expect_action(
 	int res = fill_packet_net4(&p, sip, dip, 0, 0, IPPROTO_UDP, 0);
 	assert(res == 0);
 	struct packet *packet_ptr = &p;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_net4, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&p);
 }
 
@@ -38,9 +37,9 @@ query_and_expect_no_action(
 	int res = fill_packet_net4(&p, sip, dip, 0, 0, IPPROTO_UDP, 0);
 	assert(res == 0);
 	struct packet *packet_ptr = &p;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_net4, &packet_ptr, &actions, 1);
-	assert(actions->count == 0);
+	assert(actions == FILTER_RULE_INVALID);
 	free_packet(&p);
 }
 

--- a/filter/tests/basic_net4_fast.c
+++ b/filter/tests/basic_net4_fast.c
@@ -61,10 +61,9 @@ query_and_expect_actions(
 	enum filter_sign type,
 	struct packet **packets,
 	size_t packets_count,
-	struct value_range **expected
+	uint32_t *expected
 ) {
-	struct value_range **ranges =
-		malloc(sizeof(struct value_range *) * packets_count);
+	uint32_t *ranges = malloc(sizeof(uint32_t) * packets_count);
 
 	switch (type) {
 	case src:
@@ -158,12 +157,9 @@ test_basic(void *arena, enum filter_sign sign) {
 	};
 	const size_t nets_count = sizeof(nets) / sizeof(nets[0]);
 
-	struct value_range *expected_ranges[checks_count];
+	uint32_t expected_ranges[checks_count];
 	for (size_t i = 0; i < checks_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values =
-			malloc(sizeof(uint32_t) * nets_count); // reserve
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct filter_rule rules[nets_count];
@@ -193,10 +189,8 @@ test_basic(void *arena, enum filter_sign sign) {
 		     ++check_idx) {
 			if (from <= checks[check_idx] &&
 			    checks[check_idx] <= to &&
-			    !expected_ranges[check_idx]->count) {
-				expected_ranges[check_idx]
-					->values[expected_ranges[check_idx]
-							 ->count++] = net_idx;
+			    expected_ranges[check_idx] == FILTER_RULE_INVALID) {
+				expected_ranges[check_idx] = net_idx;
 			}
 		}
 	}
@@ -240,8 +234,6 @@ test_basic(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < checks_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -316,27 +308,16 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	// Expected actions for each test packet
 	// Packets 0-2 match rule 1, packets 3-4 match rule 2, packets 5-6 match
 	// rule 3, packet 7 matches nothing
-	uint32_t expected_actions[][3] = {
-		{0, 0, 0}, // Packet 0: Rule 1
-		{0, 0, 0}, // Packet 1: Rule 1
-		{0, 0, 0}, // Packet 2: Rule 1
-		{1, 0, 0}, // Packet 3: Rule 2
-		{1, 0, 0}, // Packet 4: Rule 2
-		{2, 0, 0}, // Packet 5: Rule 3
-		{2, 0, 0}, // Packet 6: Rule 3
-		{0, 0, 0}, // Packet 7: No match
+	uint32_t expected_actions[] = {
+		0,		     // Packet 0: Rule 1
+		0,		     // Packet 1: Rule 1
+		0,		     // Packet 2: Rule 1
+		1,		     // Packet 3: Rule 2
+		1,		     // Packet 4: Rule 2
+		2,		     // Packet 5: Rule 3
+		2,		     // Packet 6: Rule 3
+		FILTER_RULE_INVALID, // Packet 7: No match
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1, 1, 0};
-
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 3);
-		for (size_t j = 0; j < expected_counts[i]; ++j) {
-			expected_ranges[i]->values[j] = expected_actions[i][j];
-		}
-	}
 
 	// Build the 3 rules
 	const size_t num_rules = 3;
@@ -437,13 +418,11 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -525,13 +504,9 @@ stress(void *arena,
 		rules[rule_idx] = build_rule(&builders[rule_idx]);
 	}
 
-	struct value_range **expected_ranges =
-		malloc(sizeof(struct value_range *) * num_packets);
+	uint32_t *expected_ranges = malloc(sizeof(uint32_t) * num_packets);
 	for (size_t range_idx = 0; range_idx < num_packets; ++range_idx) {
-		expected_ranges[range_idx] = malloc(sizeof(struct value_range));
-		expected_ranges[range_idx]->count = 0;
-		expected_ranges[range_idx]->values =
-			malloc(sizeof(uint32_t) * num_rules); // reserve
+		expected_ranges[range_idx] = FILTER_RULE_INVALID;
 	}
 
 	// Initialize both filters
@@ -617,12 +592,9 @@ stress(void *arena,
 			    !is_ip_from_net(&rule->net4.dsts[0], dst_ip)) {
 				ok = 0;
 			}
-			if (ok) {
-				struct value_range *range =
-					expected_ranges[packet_idx];
-				if (!range->count)
-					range->values[range->count++] =
-						rule_idx;
+			if (ok && expected_ranges[packet_idx] ==
+					  FILTER_RULE_INVALID) {
+				expected_ranges[packet_idx] = rule_idx;
 			}
 		}
 	}
@@ -638,8 +610,6 @@ stress(void *arena,
 	free(rules);
 	free(builders);
 	for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx) {
-		free(expected_ranges[packet_idx]->values);
-		free(expected_ranges[packet_idx]);
 		free_packet(packets[packet_idx]);
 		free(packets[packet_idx]);
 	}
@@ -717,11 +687,9 @@ test_no_match(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: no matches for any packet
-	struct value_range *expected_ranges[test_ips_count];
+	uint32_t expected_ranges[test_ips_count];
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t));
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct block_allocator alloc;
@@ -763,8 +731,6 @@ test_no_match(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -839,24 +805,13 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected matches
-	uint32_t expected_actions[][4] = {
-		{0, 0, 0, 0}, // Packet 0: rules 1,2,3
-		{0, 0, 0, 0}, // Packet 1: rules 1,2
-		{0, 0, 0, 0}, // Packet 2: rule 1
-		{3, 0, 0, 0}, // Packet 3: rule 4
-		{0, 0, 0, 0}, // Packet 4: no match
+	uint32_t expected_actions[] = {
+		0,		     // Packet 0: rules 1,2,3
+		0,		     // Packet 1: rules 1,2
+		0,		     // Packet 2: rule 1
+		3,		     // Packet 3: rule 4
+		FILTER_RULE_INVALID, // Packet 4: no match
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 0};
-
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 4);
-		for (size_t j = 0; j < expected_counts[i]; ++j) {
-			expected_ranges[i]->values[j] = expected_actions[i][j];
-		}
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -892,13 +847,11 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -970,16 +923,9 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: first 4 match, last 2 don't
-	uint32_t expected_counts[] = {1, 1, 1, 1, 0, 0};
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		if (expected_counts[i] > 0) {
-			expected_ranges[i]->values[0] = 0;
-		}
-	}
+	uint32_t expected_actions[] = {
+		0, 0, 0, 0, FILTER_RULE_INVALID, FILTER_RULE_INVALID
+	};
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1015,13 +961,11 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -1095,25 +1039,14 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: first 3 match their respective rules, last 3 don't match
-	uint32_t expected_actions[][1] = {
-		{0},
-		{1},
-		{2},
-		{0},
-		{0},
-		{0},
+	uint32_t expected_actions[] = {
+		0,
+		1,
+		2,
+		FILTER_RULE_INVALID,
+		FILTER_RULE_INVALID,
+		FILTER_RULE_INVALID,
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 0, 0, 0};
-
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		if (expected_counts[i] > 0) {
-			expected_ranges[i]->values[0] = expected_actions[i][0];
-		}
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1149,13 +1082,11 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -1230,23 +1161,14 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: packets 0,1,4 match rule 1; packets 2,3,5 match rule 2
-	uint32_t expected_actions[][1] = {
-		{0}, // Packet 0
-		{0}, // Packet 1
-		{1}, // Packet 2
-		{1}, // Packet 3
-		{0}, // Packet 4
-		{1}, // Packet 5
+	uint32_t expected_actions[] = {
+		0, // Packet 0
+		0, // Packet 1
+		1, // Packet 2
+		1, // Packet 3
+		0, // Packet 4
+		1, // Packet 5
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1};
-
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		expected_ranges[i]->values[0] = expected_actions[i][0];
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1282,13 +1204,11 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}

--- a/filter/tests/basic_net6.c
+++ b/filter/tests/basic_net6.c
@@ -33,7 +33,7 @@ query_packet_and_expect_action(
 	assert(res == 0);
 
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 
 	if (strcmp(sign, "dst") == 0) {
 		filter_query(filter, sign_net6_dst, &packet_ptr, &actions, 1);
@@ -43,8 +43,7 @@ query_packet_and_expect_action(
 		assert(0 && "Invalid sign");
 	}
 
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == action);
+	assert(actions == action);
 	free_packet(&packet);
 }
 
@@ -62,7 +61,7 @@ query_packet_and_expect_no_actions(
 	assert(res == 0);
 
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 
 	if (strcmp(sign, "dst") == 0) {
 		filter_query(filter, sign_net6_dst, &packet_ptr, &actions, 1);
@@ -72,7 +71,7 @@ query_packet_and_expect_no_actions(
 		assert(0 && "Invalid sign");
 	}
 
-	assert(actions->count == 0);
+	assert(actions == FILTER_RULE_INVALID);
 	free_packet(&packet);
 }
 

--- a/filter/tests/basic_net6_fast.c
+++ b/filter/tests/basic_net6_fast.c
@@ -61,10 +61,9 @@ query_and_expect_actions(
 	enum filter_sign type,
 	struct packet **packets,
 	size_t packets_count,
-	struct value_range **expected
+	uint32_t *expected
 ) {
-	struct value_range **ranges =
-		malloc(sizeof(struct value_range *) * packets_count);
+	uint32_t *ranges = malloc(sizeof(uint32_t) * packets_count);
 
 	switch (type) {
 	case src:
@@ -175,12 +174,9 @@ test_basic(void *arena, enum filter_sign sign) {
 		prefix_mask(mask, nets[i].prefix);
 	}
 
-	struct value_range *expected_ranges[checks_count];
+	uint32_t expected_ranges[checks_count];
 	for (size_t i = 0; i < checks_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values =
-			malloc(sizeof(uint32_t) * nets_count); // reserve
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct filter_rule rules[nets_count];
@@ -210,10 +206,8 @@ test_basic(void *arena, enum filter_sign sign) {
 		     ++check_idx) {
 			if (from <= checks[check_idx] &&
 			    checks[check_idx] <= to &&
-			    !expected_ranges[check_idx]->count) {
-				expected_ranges[check_idx]
-					->values[expected_ranges[check_idx]
-							 ->count++] = net_idx;
+			    expected_ranges[check_idx] == FILTER_RULE_INVALID) {
+				expected_ranges[check_idx] = net_idx;
 			}
 		}
 	}
@@ -257,8 +251,6 @@ test_basic(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < checks_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -461,27 +453,16 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	// Expected actions for each test packet
 	// Packets 0-2 match rule 1, packets 3-4 match rule 2, packets 5-6 match
 	// rule 3, packet 7 matches nothing
-	uint32_t expected_actions[][3] = {
-		{0, 0, 0}, // Packet 0: Rule 1
-		{0, 0, 0}, // Packet 1: Rule 1
-		{0, 0, 0}, // Packet 2: Rule 1
-		{1, 0, 0}, // Packet 3: Rule 2
-		{1, 0, 0}, // Packet 4: Rule 2
-		{2, 0, 0}, // Packet 5: Rule 3
-		{2, 0, 0}, // Packet 6: Rule 3
-		{0, 0, 0}, // Packet 7: No match
+	uint32_t expected_actions[] = {
+		0,		     // Packet 0: Rule 1
+		0,		     // Packet 1: Rule 1
+		0,		     // Packet 2: Rule 1
+		1,		     // Packet 3: Rule 2
+		1,		     // Packet 4: Rule 2
+		2,		     // Packet 5: Rule 3
+		2,		     // Packet 6: Rule 3
+		FILTER_RULE_INVALID, // Packet 7: No match
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1, 1, 0};
-
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 3);
-		for (size_t j = 0; j < expected_counts[i]; ++j) {
-			expected_ranges[i]->values[j] = expected_actions[i][j];
-		}
-	}
 
 	// Build the 3 rules
 	const size_t num_rules = 3;
@@ -570,13 +551,11 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -668,13 +647,9 @@ stress(void *arena,
 		rules[rule_idx] = build_rule(&builders[rule_idx]);
 	}
 
-	struct value_range **expected_ranges =
-		malloc(sizeof(struct value_range *) * num_packets);
+	uint32_t *expected_ranges = malloc(sizeof(uint32_t) * num_packets);
 	for (size_t range_idx = 0; range_idx < num_packets; ++range_idx) {
-		expected_ranges[range_idx] = malloc(sizeof(struct value_range));
-		expected_ranges[range_idx]->count = 0;
-		expected_ranges[range_idx]->values =
-			malloc(sizeof(uint32_t) * num_rules); // reserve
+		expected_ranges[range_idx] = FILTER_RULE_INVALID;
 	}
 
 	// Initialize filter
@@ -759,10 +734,9 @@ stress(void *arena,
 			    !is_ip_from_net(&rule->net6.dsts[0], dst_ip)) {
 				ok = 0;
 			}
-			if (ok) {
-				struct value_range *range =
-					expected_ranges[packet_idx];
-				range->values[range->count++] = rule_idx;
+			if (ok && expected_ranges[packet_idx] ==
+					  FILTER_RULE_INVALID) {
+				expected_ranges[packet_idx] = rule_idx;
 			}
 		}
 	}
@@ -778,8 +752,6 @@ stress(void *arena,
 	free(rules);
 	free(builders);
 	for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx) {
-		free(expected_ranges[packet_idx]->values);
-		free(expected_ranges[packet_idx]);
 		free_packet(packets[packet_idx]);
 		free(packets[packet_idx]);
 	}
@@ -876,11 +848,9 @@ test_no_match(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: no matches for any packet
-	struct value_range *expected_ranges[test_ips_count];
+	uint32_t expected_ranges[test_ips_count];
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t));
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct block_allocator alloc;
@@ -922,8 +892,6 @@ test_no_match(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -1100,24 +1068,13 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected matches
-	uint32_t expected_actions[][4] = {
-		{0, 0, 0, 0}, // Packet 0: rules 1,2,3
-		{0, 0, 0, 0}, // Packet 1: rules 1,2
-		{0, 0, 0, 0}, // Packet 2: rule 1
-		{3, 0, 0, 0}, // Packet 3: rule 4
-		{0, 0, 0, 0}, // Packet 4: no match
+	uint32_t expected_actions[] = {
+		0,		     // Packet 0: rules 1,2,3
+		0,		     // Packet 1: rules 1,2
+		0,		     // Packet 2: rule 1
+		3,		     // Packet 3: rule 4
+		FILTER_RULE_INVALID, // Packet 4: no match
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 0};
-
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 4);
-		for (size_t j = 0; j < expected_counts[i]; ++j) {
-			expected_ranges[i]->values[j] = expected_actions[i][j];
-		}
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1153,13 +1110,11 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -1292,16 +1247,9 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: first 4 match, last 2 don't
-	uint32_t expected_counts[] = {1, 1, 1, 1, 0, 0};
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		if (expected_counts[i] > 0) {
-			expected_ranges[i]->values[0] = 0;
-		}
-	}
+	uint32_t expected_actions[] = {
+		0, 0, 0, 0, FILTER_RULE_INVALID, FILTER_RULE_INVALID
+	};
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1337,13 +1285,11 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -1440,25 +1386,14 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: first 3 match their respective rules, last 3 don't match
-	uint32_t expected_actions[][1] = {
-		{0},
-		{1},
-		{2},
-		{0},
-		{0},
-		{0},
+	uint32_t expected_actions[] = {
+		0,
+		1,
+		2,
+		FILTER_RULE_INVALID,
+		FILTER_RULE_INVALID,
+		FILTER_RULE_INVALID,
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 0, 0, 0};
-
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		if (expected_counts[i] > 0) {
-			expected_ranges[i]->values[0] = expected_actions[i][0];
-		}
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1494,13 +1429,11 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -1638,23 +1571,14 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: packets 0,1,4 match rule 1; packets 2,3,5 match rule 2
-	uint32_t expected_actions[][1] = {
-		{0}, // Packet 0
-		{0}, // Packet 1
-		{1}, // Packet 2
-		{1}, // Packet 3
-		{0}, // Packet 4
-		{1}, // Packet 5
+	uint32_t expected_actions[] = {
+		0, // Packet 0
+		0, // Packet 1
+		1, // Packet 2
+		1, // Packet 3
+		0, // Packet 4
+		1, // Packet 5
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1};
-
-	struct value_range *expected_ranges[test_ips_count];
-	for (size_t i = 0; i < test_ips_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		expected_ranges[i]->values[0] = expected_actions[i][0];
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1690,13 +1614,11 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ips_count, expected_ranges
+		&filter, sign, packets, test_ips_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ips_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}

--- a/filter/tests/basic_port_fast.c
+++ b/filter/tests/basic_port_fast.c
@@ -60,10 +60,9 @@ query_and_expect_actions(
 	enum filter_sign type,
 	struct packet **packets,
 	size_t packets_count,
-	struct value_range **expected
+	uint32_t *expected
 ) {
-	struct value_range **ranges =
-		malloc(sizeof(struct value_range *) * packets_count);
+	uint32_t *ranges = malloc(sizeof(uint32_t) * packets_count);
 
 	switch (type) {
 	case src:
@@ -158,12 +157,9 @@ test_basic(void *arena, enum filter_sign sign) {
 	};
 	const size_t ranges_count = sizeof(ranges) / sizeof(ranges[0]);
 
-	struct value_range *expected_ranges[checks_count];
+	uint32_t expected_ranges[checks_count];
 	for (size_t i = 0; i < checks_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values =
-			malloc(sizeof(uint32_t) * ranges_count); // reserve
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct filter_rule rules[ranges_count];
@@ -192,10 +188,8 @@ test_basic(void *arena, enum filter_sign sign) {
 		     ++check_idx) {
 			if (ranges[range_idx].from <= check_ports[check_idx] &&
 			    check_ports[check_idx] <= ranges[range_idx].to &&
-			    !expected_ranges[check_idx]->count) {
-				expected_ranges[check_idx]
-					->values[expected_ranges[check_idx]
-							 ->count++] = range_idx;
+			    expected_ranges[check_idx] == FILTER_RULE_INVALID) {
+				expected_ranges[check_idx] = range_idx;
 			}
 		}
 	}
@@ -239,8 +233,6 @@ test_basic(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < checks_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -292,27 +284,16 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected actions for each test packet
-	uint32_t expected_actions[][3] = {
-		{0, 0, 0}, // Packet 0: Rule 1
-		{0, 0, 0}, // Packet 1: Rule 1
-		{0, 0, 0}, // Packet 2: Rule 1
-		{1, 0, 0}, // Packet 3: Rule 2
-		{1, 0, 0}, // Packet 4: Rule 2
-		{2, 0, 0}, // Packet 5: Rule 3
-		{2, 0, 0}, // Packet 6: Rule 3
-		{0, 0, 0}, // Packet 7: No match
+	uint32_t expected_actions[] = {
+		0,		     // Packet 0: Rule 1
+		0,		     // Packet 1: Rule 1
+		0,		     // Packet 2: Rule 1
+		1,		     // Packet 3: Rule 2
+		1,		     // Packet 4: Rule 2
+		2,		     // Packet 5: Rule 3
+		2,		     // Packet 6: Rule 3
+		FILTER_RULE_INVALID, // Packet 7: No match
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1, 1, 0};
-
-	struct value_range *expected_ranges[test_ports_count];
-	for (size_t i = 0; i < test_ports_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 3);
-		for (size_t j = 0; j < expected_counts[i]; ++j) {
-			expected_ranges[i]->values[j] = expected_actions[i][j];
-		}
-	}
 
 	// Build the 3 rules
 	const size_t num_rules = 3;
@@ -388,13 +369,11 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ports_count, expected_ranges
+		&filter, sign, packets, test_ports_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ports_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -466,13 +445,9 @@ stress(void *arena,
 		rules[rule_idx] = build_rule(&builders[rule_idx]);
 	}
 
-	struct value_range **expected_ranges =
-		malloc(sizeof(struct value_range *) * num_packets);
+	uint32_t *expected_ranges = malloc(sizeof(uint32_t) * num_packets);
 	for (size_t range_idx = 0; range_idx < num_packets; ++range_idx) {
-		expected_ranges[range_idx] = malloc(sizeof(struct value_range));
-		expected_ranges[range_idx]->count = 0;
-		expected_ranges[range_idx]->values =
-			malloc(sizeof(uint32_t) * num_rules); // reserve
+		expected_ranges[range_idx] = FILTER_RULE_INVALID;
 	}
 
 	// Initialize filter
@@ -575,41 +550,22 @@ stress(void *arena,
 					ok = 0;
 			}
 
-			if (ok) {
-				struct value_range *range =
-					expected_ranges[packet_idx];
-				if (!range->count)
-					range->values[range->count++] =
-						rule_idx;
+			if (ok && expected_ranges[packet_idx] ==
+					  FILTER_RULE_INVALID) {
+				expected_ranges[packet_idx] = rule_idx;
 			}
 		}
 
 		// Debug log for first failure
-		if (packet_idx < 10 && expected_ranges[packet_idx]->count > 0) {
+		if (packet_idx < 10 &&
+		    expected_ranges[packet_idx] != FILTER_RULE_INVALID) {
 			LOG(DEBUG,
 			    "Packet %zu: src_port=%u, dst_port=%u, expected "
-			    "%zu actions",
+			    "%u action",
 			    packet_idx,
 			    src_port,
 			    dst_port,
-			    expected_ranges[packet_idx]->count);
-			for (size_t i = 0;
-			     i < expected_ranges[packet_idx]->count;
-			     ++i) {
-				uint32_t action =
-					expected_ranges[packet_idx]->values[i];
-				uint32_t rule_idx = action - 1;
-				if (rule_idx < num_rules) {
-					struct filter_rule *rule =
-						&rules[rule_idx];
-					LOG(DEBUG,
-					    "  Rule %u has %u src ranges, %u "
-					    "dst ranges",
-					    (unsigned)rule_idx,
-					    rule->transport.src_count,
-					    rule->transport.dst_count);
-				}
-			}
+			    expected_ranges[packet_idx]);
 		}
 	}
 
@@ -624,8 +580,6 @@ stress(void *arena,
 	free(rules);
 	free(builders);
 	for (size_t packet_idx = 0; packet_idx < num_packets; ++packet_idx) {
-		free(expected_ranges[packet_idx]->values);
-		free(expected_ranges[packet_idx]);
 		free_packet(packets[packet_idx]);
 		free(packets[packet_idx]);
 	}
@@ -714,11 +668,9 @@ test_no_match(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: no matches for any packet
-	struct value_range *expected_ranges[test_ports_count];
+	uint32_t expected_ranges[test_ports_count];
 	for (size_t i = 0; i < test_ports_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t));
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct block_allocator alloc;
@@ -760,8 +712,6 @@ test_no_match(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ports_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -844,24 +794,13 @@ test_overlapping_ranges(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected matches
-	uint32_t expected_actions[][4] = {
-		{0, 0, 0, 0}, // Port 1350: rules 1,2,3
-		{0, 0, 0, 0}, // Port 1250: rules 1,2
-		{0, 0, 0, 0}, // Port 1100: rule 1
-		{3, 0, 0, 0}, // Port 3500: rule 4
-		{0, 0, 0, 0}, // Port 5000: no match
+	uint32_t expected_actions[] = {
+		0,		     // Port 1350: rules 1,2,3
+		0,		     // Port 1250: rules 1,2
+		0,		     // Port 1100: rule 1
+		3,		     // Port 3500: rule 4
+		FILTER_RULE_INVALID, // Port 5000: no match
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 0};
-
-	struct value_range *expected_ranges[test_ports_count];
-	for (size_t i = 0; i < test_ports_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 4);
-		for (size_t j = 0; j < expected_counts[i]; ++j) {
-			expected_ranges[i]->values[j] = expected_actions[i][j];
-		}
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -897,13 +836,11 @@ test_overlapping_ranges(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ports_count, expected_ranges
+		&filter, sign, packets, test_ports_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ports_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -983,16 +920,9 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: first 4 match, last 2 don't
-	uint32_t expected_counts[] = {1, 1, 1, 1, 0, 0};
-	struct value_range *expected_ranges[test_ports_count];
-	for (size_t i = 0; i < test_ports_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		if (expected_counts[i] > 0) {
-			expected_ranges[i]->values[0] = 0;
-		}
-	}
+	uint32_t expected_actions[] = {
+		0, 0, 0, 0, FILTER_RULE_INVALID, FILTER_RULE_INVALID
+	};
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1028,13 +958,11 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ports_count, expected_ranges
+		&filter, sign, packets, test_ports_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ports_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -1119,27 +1047,16 @@ test_single_port_ranges(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: first 4 match their respective rules, last 4 don't match
-	uint32_t expected_actions[][1] = {
-		{0},
-		{1},
-		{2},
-		{3},
-		{0},
-		{0},
-		{0},
-		{0},
+	uint32_t expected_actions[] = {
+		0,
+		1,
+		2,
+		3,
+		FILTER_RULE_INVALID,
+		FILTER_RULE_INVALID,
+		FILTER_RULE_INVALID,
+		FILTER_RULE_INVALID,
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 0, 0, 0, 0};
-
-	struct value_range *expected_ranges[test_ports_count];
-	for (size_t i = 0; i < test_ports_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		if (expected_counts[i] > 0) {
-			expected_ranges[i]->values[0] = expected_actions[i][0];
-		}
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1175,13 +1092,11 @@ test_single_port_ranges(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ports_count, expected_ranges
+		&filter, sign, packets, test_ports_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ports_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -1263,23 +1178,14 @@ test_adjacent_ranges(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected: ports 0,1,4 match rule 1; ports 2,3,5 match rule 2
-	uint32_t expected_actions[][1] = {
-		{0}, // Port 1000
-		{0}, // Port 1999
-		{1}, // Port 2000
-		{1}, // Port 2999
-		{0}, // Port 1500
-		{1}, // Port 2500
+	uint32_t expected_actions[] = {
+		0, // Port 1000
+		0, // Port 1999
+		1, // Port 2000
+		1, // Port 2999
+		0, // Port 1500
+		1, // Port 2500
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1};
-
-	struct value_range *expected_ranges[test_ports_count];
-	for (size_t i = 0; i < test_ports_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		expected_ranges[i]->values[0] = expected_actions[i][0];
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1315,13 +1221,11 @@ test_adjacent_ranges(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ports_count, expected_ranges
+		&filter, sign, packets, test_ports_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ports_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -1405,27 +1309,16 @@ test_extreme_ports(void *arena, enum filter_sign sign) {
 	}
 
 	// Expected matches
-	uint32_t expected_actions[][3] = {
-		{0, 0, 0}, // Port 0: rules 1
-		{0, 0, 0}, // Port 1: rules 1
-		{0, 0, 0}, // Port 100: rules 1
-		{2, 0, 0}, // Port 101: rule 3
-		{1, 0, 0}, // Port 65400: rules 2
-		{1, 0, 0}, // Port 65534: rules 2
-		{1, 0, 0}, // Port 65535: rules 2
-		{2, 0, 0}, // Port 500: rule 3
+	uint32_t expected_actions[] = {
+		0, // Port 0: rules 1
+		0, // Port 1: rules 1
+		0, // Port 100: rules 1
+		2, // Port 101: rule 3
+		1, // Port 65400: rules 2
+		1, // Port 65534: rules 2
+		1, // Port 65535: rules 2
+		2, // Port 500: rule 3
 	};
-	uint32_t expected_counts[] = {1, 1, 1, 1, 1, 1, 1, 1};
-
-	struct value_range *expected_ranges[test_ports_count];
-	for (size_t i = 0; i < test_ports_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = expected_counts[i];
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 3);
-		for (size_t j = 0; j < expected_counts[i]; ++j) {
-			expected_ranges[i]->values[j] = expected_actions[i][j];
-		}
-	}
 
 	struct block_allocator alloc;
 	int res = block_allocator_init(&alloc);
@@ -1461,13 +1354,11 @@ test_extreme_ports(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
 	res = query_and_expect_actions(
-		&filter, sign, packets, test_ports_count, expected_ranges
+		&filter, sign, packets, test_ports_count, expected_actions
 	);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_ports_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}

--- a/filter/tests/basic_ports.c
+++ b/filter/tests/basic_ports.c
@@ -28,10 +28,9 @@ query_and_expect_action(
 	);
 	assert(res == 0);
 	struct packet *packet_ptr = &p;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_ports, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&p);
 }
 
@@ -47,9 +46,9 @@ query_and_expect_no_action(
 	);
 	assert(res == 0);
 	struct packet *packet_ptr = &p;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_ports, &packet_ptr, &actions, 1);
-	assert(actions->count == 0);
+	assert(actions == FILTER_RULE_INVALID);
 	free_packet(&p);
 }
 

--- a/filter/tests/basic_proto.c
+++ b/filter/tests/basic_proto.c
@@ -22,10 +22,9 @@ query_tcp_packet(struct filter *filter, uint16_t flags, uint32_t expected) {
 	int res = fill_packet_net4(&packet, sip, dip, 0, 0, IPPROTO_TCP, flags);
 	assert(res == 0);
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_proto, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&packet);
 }
 
@@ -37,10 +36,9 @@ query_udp_packet(struct filter *filter, uint32_t expected) {
 	int res = fill_packet_net4(&packet, sip, dip, 0, 0, IPPROTO_UDP, 0);
 	assert(res == 0);
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_proto, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&packet);
 }
 

--- a/filter/tests/basic_proto_range.c
+++ b/filter/tests/basic_proto_range.c
@@ -20,10 +20,9 @@ query_tcp_packet(struct filter *filter, uint16_t flags, uint32_t expected) {
 	int res = fill_packet_net4(&packet, sip, dip, 0, 0, IPPROTO_TCP, flags);
 	assert(res == 0);
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_proto_range, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&packet);
 }
 
@@ -35,10 +34,9 @@ query_udp_packet(struct filter *filter, uint32_t expected) {
 	int res = fill_packet_net4(&packet, sip, dip, 0, 0, IPPROTO_UDP, 0);
 	assert(res == 0);
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_proto_range, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&packet);
 }
 

--- a/filter/tests/basic_proto_range_fast.c
+++ b/filter/tests/basic_proto_range_fast.c
@@ -24,10 +24,9 @@ query_tcp_packet(struct filter *filter, uint16_t flags, uint32_t expected) {
 	int res = fill_packet_net4(&packet, sip, dip, 0, 0, IPPROTO_TCP, flags);
 	assert(res == 0);
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_proto_range_fast, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&packet);
 }
 
@@ -39,10 +38,9 @@ query_udp_packet(struct filter *filter, uint32_t expected) {
 	int res = fill_packet_net4(&packet, sip, dip, 0, 0, IPPROTO_UDP, 0);
 	assert(res == 0);
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_proto_range_fast, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&packet);
 }
 
@@ -268,14 +266,11 @@ test_boundary_values(void *memory) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to fill packet");
 
 	struct packet *packet_ptr1 = &packet1;
-	struct value_range *actions1;
+	uint32_t actions1;
 	filter_query(
 		&filter, sign_proto_range_fast, &packet_ptr1, &actions1, 1
 	);
-	TEST_ASSERT_EQUAL(actions1->count, 1, "proto 0 should match rule 1");
-	TEST_ASSERT_EQUAL(
-		ADDR_OF(&actions1->values)[0], 0, "proto 0 should match rule 1"
-	);
+	TEST_ASSERT_EQUAL(actions1, 0, "proto 0 should match rule 1");
 	free_packet(&packet1);
 
 	filter_free(&filter, sign_proto_range_fast_compile);

--- a/filter/tests/basic_vlan.c
+++ b/filter/tests/basic_vlan.c
@@ -24,10 +24,9 @@ query_packet(struct filter *filter, uint16_t vlan, uint32_t expected) {
 	packet.vlan = vlan;
 
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_vlan, &packet_ptr, &actions, 1);
-	assert(actions->count == 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&packet);
 }
 

--- a/filter/tests/bench_net4.c
+++ b/filter/tests/bench_net4.c
@@ -335,9 +335,8 @@ run_benchmark(
 	stats->total_packets = batch_size * num_batches;
 
 	// Allocate ranges using hugepages
-	size_t ranges_size = sizeof(struct value_range *) * batch_size;
-	struct value_range **ranges =
-		(struct value_range **)allocate_hugepage_memory(ranges_size);
+	size_t ranges_size = sizeof(uint32_t) * batch_size;
+	uint32_t *ranges = (uint32_t *)allocate_hugepage_memory(ranges_size);
 	if (ranges == NULL) {
 		return -1;
 	}

--- a/filter/tests/bench_net4_fast.c
+++ b/filter/tests/bench_net4_fast.c
@@ -336,9 +336,8 @@ run_benchmark(
 	stats->total_packets = batch_size * num_batches;
 
 	// Allocate ranges using hugepages
-	size_t ranges_size = sizeof(struct value_range *) * batch_size;
-	struct value_range **ranges =
-		(struct value_range **)allocate_hugepage_memory(ranges_size);
+	size_t ranges_size = sizeof(uint32_t) * batch_size;
+	uint32_t *ranges = (uint32_t *)allocate_hugepage_memory(ranges_size);
 	if (ranges == NULL) {
 		return -1;
 	}

--- a/filter/tests/bench_net6.c
+++ b/filter/tests/bench_net6.c
@@ -381,9 +381,8 @@ run_benchmark(
 	stats->total_packets = batch_size * num_batches;
 
 	// Allocate ranges using hugepages
-	size_t ranges_size = sizeof(struct value_range *) * batch_size;
-	struct value_range **ranges =
-		(struct value_range **)allocate_hugepage_memory(ranges_size);
+	size_t ranges_size = sizeof(uint32_t) * batch_size;
+	uint32_t *ranges = (uint32_t *)allocate_hugepage_memory(ranges_size);
 	if (ranges == NULL) {
 		return -1;
 	}

--- a/filter/tests/bench_net6_fast.c
+++ b/filter/tests/bench_net6_fast.c
@@ -382,9 +382,8 @@ run_benchmark(
 	stats->total_packets = batch_size * num_batches;
 
 	// Allocate ranges using hugepages
-	size_t ranges_size = sizeof(struct value_range *) * batch_size;
-	struct value_range **ranges =
-		(struct value_range **)allocate_hugepage_memory(ranges_size);
+	size_t ranges_size = sizeof(uint32_t) * batch_size;
+	uint32_t *ranges = (uint32_t *)allocate_hugepage_memory(ranges_size);
 	if (ranges == NULL) {
 		return -1;
 	}

--- a/filter/tests/combo_net4_port_proto_dst.c
+++ b/filter/tests/combo_net4_port_proto_dst.c
@@ -78,11 +78,9 @@ test_no_match_proto_only(void *arena) {
 	}
 
 	// Expected: no matches
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t));
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct block_allocator alloc;
@@ -102,22 +100,19 @@ test_no_match_proto_only(void *arena) {
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
-	struct value_range **ranges =
-		malloc(sizeof(struct value_range *) * test_count);
+	uint32_t *actions = malloc(sizeof(uint32_t) * test_count);
 	filter_query(
-		&filter, combo_net4_port_proto_dst, packets, ranges, test_count
+		&filter, combo_net4_port_proto_dst, packets, actions, test_count
 	);
 
-	res = compare_expected_ranges(ranges, expected_ranges, test_count);
+	res = compare_expected_ranges(actions, expected_ranges, test_count);
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
-	free(ranges);
+	free(actions);
 
 	return TEST_SUCCESS;
 }
@@ -166,12 +161,9 @@ test_all_match(void *arena) {
 	}
 
 	// Expected: all match
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 1;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		expected_ranges[i]->values[0] = 0;
+		expected_ranges[i] = 0;
 	}
 
 	struct block_allocator alloc;
@@ -191,8 +183,7 @@ test_all_match(void *arena) {
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
-	struct value_range **ranges =
-		malloc(sizeof(struct value_range *) * test_count);
+	uint32_t *ranges = malloc(sizeof(uint32_t) * test_count);
 	filter_query(
 		&filter, combo_net4_port_proto_dst, packets, ranges, test_count
 	);
@@ -201,8 +192,6 @@ test_all_match(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -261,9 +250,14 @@ test_multiple_rules_overlap(void *arena) {
 		// IP: 10.0.0.50, Port: 95, TCP -> matches rule2 only
 		{{10, 0, 0, 50}, 95, IPPROTO_TCP, 1, {1, 0, 0}},
 		// IP: 10.0.0.50, Port: 100, TCP -> no match
-		{{10, 0, 0, 50}, 100, IPPROTO_TCP, 0, {0, 0, 0}},
+		{{10, 0, 0, 50},
+		 100,
+		 IPPROTO_TCP,
+		 0,
+		 {FILTER_RULE_INVALID, 0, 0}},
 		// IP: 10.1.0.50, Port: 85, TCP -> no match (outside /16)
-		{{10, 1, 0, 50}, 85, IPPROTO_TCP, 0, {0, 0, 0}},
+		{{10, 1, 0, 50}, 85, IPPROTO_TCP, 0, {FILTER_RULE_INVALID, 0, 0}
+		},
 	};
 	const size_t test_count = sizeof(test_cases) / sizeof(test_cases[0]);
 
@@ -285,15 +279,9 @@ test_multiple_rules_overlap(void *arena) {
 	}
 
 	// Expected ranges
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = test_cases[i].expected_count;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 4);
-		for (size_t j = 0; j < test_cases[i].expected_count; ++j) {
-			expected_ranges[i]->values[j] =
-				test_cases[i].expected_actions[j];
-		}
+		expected_ranges[i] = test_cases[i].expected_actions[0];
 	}
 
 	struct block_allocator alloc;
@@ -315,8 +303,7 @@ test_multiple_rules_overlap(void *arena) {
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
-	struct value_range **ranges =
-		malloc(sizeof(struct value_range *) * test_count);
+	uint32_t *ranges = malloc(sizeof(uint32_t) * test_count);
 	filter_query(
 		&filter, combo_net4_port_proto_dst, packets, ranges, test_count
 	);
@@ -325,8 +312,6 @@ test_multiple_rules_overlap(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -374,9 +359,19 @@ test_tcp_flags(void *arena) {
 		// SYN+ACK flags -> matches both rules
 		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x12, 1, {0, 0}},
 		// FIN flag -> no match
-		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x01, 0, {0, 0}},
+		{{10, 0, 0, 1},
+		 80,
+		 IPPROTO_TCP,
+		 0x01,
+		 0,
+		 {FILTER_RULE_INVALID, 0}},
 		// No flags -> no match
-		{{10, 0, 0, 1}, 80, IPPROTO_TCP, 0x00, 0, {0, 0}},
+		{{10, 0, 0, 1},
+		 80,
+		 IPPROTO_TCP,
+		 0x00,
+		 0,
+		 {FILTER_RULE_INVALID, 0}},
 	};
 	const size_t test_count = sizeof(test_cases) / sizeof(test_cases[0]);
 
@@ -398,15 +393,9 @@ test_tcp_flags(void *arena) {
 	}
 
 	// Expected ranges
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = test_cases[i].expected_count;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 3);
-		for (size_t j = 0; j < test_cases[i].expected_count; ++j) {
-			expected_ranges[i]->values[j] =
-				test_cases[i].expected_actions[j];
-		}
+		expected_ranges[i] = test_cases[i].expected_actions[0];
 	}
 
 	struct block_allocator alloc;
@@ -426,8 +415,7 @@ test_tcp_flags(void *arena) {
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
-	struct value_range **ranges =
-		malloc(sizeof(struct value_range *) * test_count);
+	uint32_t *ranges = malloc(sizeof(uint32_t) * test_count);
 	filter_query(
 		&filter, combo_net4_port_proto_dst, packets, ranges, test_count
 	);
@@ -436,8 +424,6 @@ test_tcp_flags(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}

--- a/filter/tests/combo_net4_port_src.c
+++ b/filter/tests/combo_net4_port_src.c
@@ -34,10 +34,9 @@ query_and_expect_actions(
 	struct filter *filter,
 	struct packet **packets,
 	size_t packets_count,
-	struct value_range **expected
+	uint32_t *expected
 ) {
-	struct value_range **ranges =
-		malloc(sizeof(struct value_range *) * packets_count);
+	uint32_t *ranges = malloc(sizeof(uint32_t) * packets_count);
 
 	filter_query(
 		filter, combo_net4_port_src, packets, ranges, packets_count
@@ -106,11 +105,9 @@ test_no_match_port_only(void *arena) {
 	}
 
 	// Expected: no matches
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t));
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct block_allocator alloc;
@@ -136,8 +133,6 @@ test_no_match_port_only(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -188,11 +183,9 @@ test_no_match_ip_only(void *arena) {
 	}
 
 	// Expected: no matches
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t));
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct block_allocator alloc;
@@ -218,8 +211,6 @@ test_no_match_ip_only(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -270,12 +261,9 @@ test_both_match(void *arena) {
 	}
 
 	// Expected: all match
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 1;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		expected_ranges[i]->values[0] = 0;
+		expected_ranges[i] = 0;
 	}
 
 	struct block_allocator alloc;
@@ -301,8 +289,6 @@ test_both_match(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -353,7 +339,7 @@ test_overlapping(void *arena) {
 		size_t expected_count;
 	} test_cases[] = {
 		{{10, 2, 0, 1}, 85, {0, 0, 0}, 1}, // Only rule 1 matches
-		{{10, 1, 1, 100}, 79, {0, 0, 0}, 0
+		{{10, 1, 1, 100}, 79, {FILTER_RULE_INVALID, 0, 0}, 0
 		}, // IP matches all but port matches none
 		{{10, 1, 1, 100}, 106, {1, 0, 0}, 1
 		}, // Only rule 2 matches (port 106 in 90-110, not in 80-100 or
@@ -378,15 +364,9 @@ test_overlapping(void *arena) {
 		);
 	}
 
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = test_cases[i].expected_count;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 4);
-		for (size_t j = 0; j < test_cases[i].expected_count; ++j) {
-			expected_ranges[i]->values[j] =
-				test_cases[i].expected_actions[j];
-		}
+		expected_ranges[i] = test_cases[i].expected_actions[0];
 	}
 
 	struct block_allocator alloc;
@@ -414,8 +394,6 @@ test_overlapping(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}

--- a/filter/tests/combo_net6_port_src.c
+++ b/filter/tests/combo_net6_port_src.c
@@ -35,10 +35,9 @@ query_and_expect_actions(
 	struct filter *filter,
 	struct packet **packets,
 	size_t packets_count,
-	struct value_range **expected
+	uint32_t *expected
 ) {
-	struct value_range **ranges =
-		malloc(sizeof(struct value_range *) * packets_count);
+	uint32_t *ranges = malloc(sizeof(uint32_t) * packets_count);
 
 	filter_query(
 		filter, combo_net6_port_src, packets, ranges, packets_count
@@ -126,11 +125,9 @@ test_no_match_port_only(void *arena) {
 	}
 
 	// Expected: no matches
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t));
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct block_allocator alloc;
@@ -156,8 +153,6 @@ test_no_match_port_only(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -237,11 +232,9 @@ test_no_match_ip_only(void *arena) {
 	}
 
 	// Expected: no matches
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 0;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t));
+		expected_ranges[i] = FILTER_RULE_INVALID;
 	}
 
 	struct block_allocator alloc;
@@ -267,8 +260,6 @@ test_no_match_ip_only(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}
@@ -349,12 +340,9 @@ test_both_match(void *arena) {
 	}
 
 	// Expected: all match
-	struct value_range *expected_ranges[test_count];
+	uint32_t expected_ranges[test_count];
 	for (size_t i = 0; i < test_count; ++i) {
-		expected_ranges[i] = malloc(sizeof(struct value_range));
-		expected_ranges[i]->count = 1;
-		expected_ranges[i]->values = malloc(sizeof(uint32_t) * 2);
-		expected_ranges[i]->values[0] = 0;
+		expected_ranges[i] = 0;
 	}
 
 	struct block_allocator alloc;
@@ -380,8 +368,6 @@ test_both_match(void *arena) {
 	TEST_ASSERT_SUCCESS(res, "some checks failed");
 
 	for (size_t i = 0; i < test_count; ++i) {
-		free(expected_ranges[i]->values);
-		free(expected_ranges[i]);
 		free_packet(packets[i]);
 		free(packets[i]);
 	}

--- a/filter/tests/corner.c
+++ b/filter/tests/corner.c
@@ -25,10 +25,9 @@ query_and_expect_action(
 	);
 	assert(res == 0);
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_port_src, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&packet);
 }
 
@@ -42,9 +41,9 @@ query_and_expect_no_action(struct filter *filter, uint16_t src_port) {
 	);
 	assert(res == 0);
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_port_src, &packet_ptr, &actions, 1);
-	assert(actions->count == 0);
+	assert(actions == FILTER_RULE_INVALID);
 	free_packet(&packet);
 }
 

--- a/filter/tests/helpers.h
+++ b/filter/tests/helpers.h
@@ -181,56 +181,15 @@ build_rule(struct filter_rule_builder *b) {
 
 static inline int
 compare_expected_ranges(
-	struct value_range **ranges,
-	struct value_range **expected,
-	size_t packets_count
+	uint32_t *ranges, uint32_t *expected, size_t packets_count
 ) {
 	for (size_t packet_idx = 0; packet_idx < packets_count; ++packet_idx) {
-		struct value_range *range = ranges[packet_idx];
-		uint32_t *range_values = ADDR_OF(&range->values);
-
-		struct value_range *expected_range = expected[packet_idx];
-		uint32_t *expected_range_values = expected_range->values;
-
-		for (size_t expected_value_idx = 0;
-		     expected_value_idx < expected_range->count;
-		     ++expected_value_idx) {
-			int found = 0;
-			for (size_t got_idx = 0; got_idx < range->count;
-			     ++got_idx) {
-				if (expected_range_values[expected_value_idx] ==
-				    range_values[got_idx]) {
-					found = 1;
-					break;
-				}
-			}
-
-			TEST_ASSERT(
-				found,
-				"packet at idx %zu: not got expected action %u",
-				packet_idx,
-				expected_range_values[expected_value_idx]
-			);
-		}
-
-		for (size_t got_idx = 0; got_idx < range->count; ++got_idx) {
-			int found = 0;
-			for (size_t expected_value_idx = 0;
-			     expected_value_idx < expected_range->count;
-			     ++expected_value_idx) {
-				if (expected_range_values[expected_value_idx] ==
-				    range_values[got_idx]) {
-					found = 1;
-					break;
-				}
-			}
-			TEST_ASSERT(
-				found,
-				"packet at idx %zu: got unexpected action %u",
-				packet_idx,
-				range_values[got_idx]
-			);
-		}
+		TEST_ASSERT(
+			ranges[packet_idx] == expected[packet_idx],
+			"packet at idx %zu: not got expected action %u",
+			packet_idx,
+			expected[packet_idx]
+		);
 	}
 
 	return TEST_SUCCESS;

--- a/filter/tests/macros.c
+++ b/filter/tests/macros.c
@@ -45,10 +45,9 @@ run_case(void) {
 
 	// query via header-only API
 	struct packet *packet_ptr = &p;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(&f, sign_compile, &packet_ptr, &actions, 1);
-	assert(actions->count == 1);
-	assert(ADDR_OF(&actions->values)[0] == 0);
+	assert(actions == 0);
 
 	free_packet(&p);
 	filter_free(&f, sign);

--- a/filter/tests/memory.c
+++ b/filter/tests/memory.c
@@ -36,7 +36,7 @@ query_and_expect_action(
 	assert(res == 0);
 
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 
 	if (strcmp(sign, "ports") == 0) {
 		filter_query(filter, sign_ports, &packet_ptr, &actions, 1);
@@ -46,8 +46,7 @@ query_and_expect_action(
 		assert(0 && "Invalid sign");
 	}
 
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&packet);
 }
 
@@ -67,7 +66,7 @@ query_and_expect_no_action(
 	assert(res == 0);
 
 	struct packet *packet_ptr = &packet;
-	struct value_range *actions;
+	uint32_t actions;
 
 	if (strcmp(sign, "ports") == 0) {
 		filter_query(filter, sign_ports, &packet_ptr, &actions, 1);
@@ -77,7 +76,7 @@ query_and_expect_no_action(
 		assert(0 && "Invalid sign");
 	}
 
-	assert(actions->count == 0);
+	assert(actions == FILTER_RULE_INVALID);
 	free_packet(&packet);
 }
 

--- a/filter/tests/net4_ports.c
+++ b/filter/tests/net4_ports.c
@@ -30,10 +30,9 @@ query_and_expect_action(
 	);
 	assert(res == 0);
 	struct packet *packet_ptr = &p;
-	struct value_range *actions;
+	uint32_t actions;
 	filter_query(filter, sign_net4_ports, &packet_ptr, &actions, 1);
-	assert(actions->count >= 1);
-	assert(ADDR_OF(&actions->values)[0] == expected);
+	assert(actions == expected);
 	free_packet(&p);
 }
 

--- a/filter/tests/shm/filter.c
+++ b/filter/tests/shm/filter.c
@@ -47,7 +47,7 @@ filter_packets(struct common *common) {
 		}
 
 		struct packet *packet_ptr = &packet;
-		struct value_range *actions;
+		uint32_t actions;
 		filter_query(
 			&common->filter, filter_sign, &packet_ptr, &actions, 1
 		);
@@ -57,7 +57,7 @@ filter_packets(struct common *common) {
 			    "error occurred durring classification: %d",
 			    res);
 			++errors;
-		} else if (actions->count > 0) {
+		} else if (actions != FILTER_RULE_INVALID) {
 			++found;
 		}
 	}

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -79,28 +79,25 @@ acl_handle_packets(
 	 */
 
 	struct packet *vlan_packets[packet_list_count(&packet_front->input)];
-	struct value_range
-		*vlan_result[packet_list_count(&packet_front->input)];
+	uint32_t vlan_result[packet_list_count(&packet_front->input)];
 	uint64_t vlan_idx = 0;
 
 	struct packet *ip4_packets[packet_list_count(&packet_front->input)];
-	struct value_range *ip4_result[packet_list_count(&packet_front->input)];
+	uint32_t ip4_result[packet_list_count(&packet_front->input)];
 	uint64_t ip4_idx = 0;
 
 	struct packet
 		*ip4_port_packets[packet_list_count(&packet_front->input)];
-	struct value_range
-		*ip4_port_result[packet_list_count(&packet_front->input)];
+	uint32_t ip4_port_result[packet_list_count(&packet_front->input)];
 	uint64_t ip4_port_idx = 0;
 
 	struct packet *ip6_packets[packet_list_count(&packet_front->input)];
-	struct value_range *ip6_result[packet_list_count(&packet_front->input)];
+	uint32_t ip6_result[packet_list_count(&packet_front->input)];
 	uint64_t ip6_idx = 0;
 
 	struct packet
 		*ip6_port_packets[packet_list_count(&packet_front->input)];
-	struct value_range
-		*ip6_port_result[packet_list_count(&packet_front->input)];
+	uint32_t ip6_port_result[packet_list_count(&packet_front->input)];
 	uint64_t ip6_port_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);
@@ -180,80 +177,46 @@ acl_handle_packets(
 	while ((packet = packet_list_pop(&packet_front->input)) != NULL) {
 		struct acl_target *target = NULL;
 
-		const uint32_t *actions = NULL;
-		uint32_t action_count = 0;
+		uint32_t action = vlan_result[vlan_idx];
 
-		// Set vlan as default
-		actions = ADDR_OF(&vlan_result[vlan_idx]->values);
-		action_count = vlan_result[vlan_idx]->count;
 		++vlan_idx;
 
 		if (packet->network_header.type ==
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
 			state_table = fw4state;
 
-			const uint32_t *ip4_actions =
-				ADDR_OF(&ip4_result[ip4_idx]->values);
-			uint32_t ip4_action_count = ip4_result[ip4_idx]->count;
-			++ip4_idx;
-
-			if (ip4_action_count && (action_count == 0 ||
-						 ip4_actions[0] < actions[0])) {
-				actions = ip4_actions;
-				action_count = ip4_action_count;
+			if (ip4_result[ip4_idx] < action) {
+				action = ip4_result[ip4_idx];
 			}
+
+			++ip4_idx;
 
 			if (packet->transport_header.type == IPPROTO_TCP ||
 			    packet->transport_header.type == IPPROTO_UDP) {
-				const uint32_t *ip4_port_actions = ADDR_OF(
-					&ip4_port_result[ip4_port_idx]->values
-				);
-				uint32_t ip4_port_action_count =
-					ip4_port_result[ip4_port_idx]->count;
-				++ip4_port_idx;
-
-				if (ip4_port_action_count &&
-				    (action_count == 0 ||
-				     ip4_port_actions[0] < actions[0])) {
-					actions = ip4_port_actions;
-					action_count = ip4_port_action_count;
+				if (ip4_port_result[ip4_port_idx] < action) {
+					action = ip4_port_result[ip4_port_idx];
 				}
 			}
 		} else if (packet->network_header.type ==
 			   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
 			state_table = fw6state;
 
-			const uint32_t *ip6_actions =
-				ADDR_OF(&ip6_result[ip6_idx]->values);
-			uint32_t ip6_action_count = ip6_result[ip6_idx]->count;
-			++ip6_idx;
-
-			if (ip6_action_count && (action_count == 0 ||
-						 ip6_actions[0] < actions[0])) {
-				actions = ip6_actions;
-				action_count = ip6_action_count;
+			if (ip6_result[ip6_idx] < action) {
+				action = ip6_result[ip6_idx];
 			}
+
+			++ip6_idx;
 
 			if (packet->transport_header.type == IPPROTO_TCP ||
 			    packet->transport_header.type == IPPROTO_UDP) {
-				const uint32_t *ip6_port_actions = ADDR_OF(
-					&ip6_port_result[ip6_port_idx]->values
-				);
-				uint32_t ip6_port_action_count =
-					ip6_port_result[ip6_port_idx]->count;
-				++ip6_port_idx;
-
-				if (ip6_port_action_count &&
-				    (action_count == 0 ||
-				     ip6_port_actions[0] < actions[0])) {
-					actions = ip6_port_actions;
-					action_count = ip6_port_action_count;
+				if (ip6_port_result[ip6_port_idx] < action) {
+					action = ip6_port_result[ip6_port_idx];
 				}
 			}
 		}
 
-		if (action_count)
-			target = ADDR_OF(&acl_config->targets) + actions[0];
+		if (action != FILTER_RULE_INVALID)
+			target = ADDR_OF(&acl_config->targets) + action;
 
 		const uint64_t pkt_len = packet_data_len(packet);
 

--- a/modules/balancer/dataplane/lookup.h
+++ b/modules/balancer/dataplane/lookup.h
@@ -29,7 +29,7 @@ FILTER_QUERY_DECLARE(vs_acl_ipv4, net4_fast_src, port_fast_src);
 
 static inline uint32_t
 vs_v4_table_lookup(struct packet_handler *handler, struct packet *packet) {
-	struct value_range *result;
+	uint32_t result;
 	filter_query(
 		ADDR_OF(&handler->vs_ipv4.filter),
 		vs_lookup_ipv4,
@@ -37,12 +37,7 @@ vs_v4_table_lookup(struct packet_handler *handler, struct packet *packet) {
 		&result,
 		1
 	);
-	if (result->count == 0) {
-		return -1;
-	}
-	/// @todo: actions_count > 1 ?
-	uint32_t service_id = ADDR_OF(&result->values)[0];
-	return service_id;
+	return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -54,7 +49,7 @@ FILTER_QUERY_DECLARE(vs_acl_ipv6, net6_fast_src, port_fast_src);
 
 static inline uint32_t
 vs_v6_table_lookup(struct packet_handler *handler, struct packet *packet) {
-	struct value_range *result;
+	uint32_t result;
 	filter_query(
 		ADDR_OF(&handler->vs_ipv6.filter),
 		vs_lookup_ipv6,
@@ -62,12 +57,7 @@ vs_v6_table_lookup(struct packet_handler *handler, struct packet *packet) {
 		&result,
 		1
 	);
-	if (result->count == 0) {
-		return -1;
-	}
-	/// @todo: actions_count > 1 ?
-	uint32_t service_id = ADDR_OF(&result->values)[0];
-	return service_id;
+	return result;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -89,12 +79,9 @@ vs_v4_lookup(struct packet_ctx *ctx) {
 }
 
 static inline bool
-check_fw_and_inc_stats(
-	struct packet_ctx *ctx, struct vs *vs, struct value_range *result
-) {
-	if (result->count > 0) {
-		assert(result->count == 1);
-		uint32_t rule_idx = ADDR_OF(&result->values)[0];
+check_fw_and_inc_stats(struct packet_ctx *ctx, struct vs *vs, uint32_t result) {
+	if (result != FILTER_RULE_INVALID) {
+		uint32_t rule_idx = result;
 		uint64_t counter_id = ADDR_OF(&vs->rule_counters)[rule_idx];
 		if (counter_id != (uint64_t)-1) {
 			counter_get_address(
@@ -109,7 +96,7 @@ check_fw_and_inc_stats(
 static inline bool
 vs_v4_fw(struct packet_ctx *ctx, struct vs *vs, struct packet *packet) {
 	(void)ctx;
-	struct value_range *result;
+	uint32_t result;
 	filter_query(ADDR_OF(&vs->acl), vs_acl_ipv4, &packet, &result, 1);
 	return check_fw_and_inc_stats(ctx, vs, result);
 }
@@ -164,7 +151,7 @@ vs_v6_lookup(struct packet_ctx *ctx) {
 static inline bool
 vs_v6_fw(struct packet_ctx *ctx, struct vs *vs, struct packet *packet) {
 	(void)ctx;
-	struct value_range *result;
+	uint32_t result;
 	filter_query(ADDR_OF(&vs->acl), vs_acl_ipv6, &packet, &result, 1);
 	return check_fw_and_inc_stats(ctx, vs, result);
 }

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -32,16 +32,15 @@ forward_handle_packets(
 	);
 
 	struct packet *vlan_packets[packet_list_count(&packet_front->input)];
-	struct value_range
-		*vlan_result[packet_list_count(&packet_front->input)];
+	uint32_t vlan_result[packet_list_count(&packet_front->input)];
 	uint64_t vlan_idx = 0;
 
 	struct packet *ip4_packets[packet_list_count(&packet_front->input)];
-	struct value_range *ip4_result[packet_list_count(&packet_front->input)];
+	uint32_t ip4_result[packet_list_count(&packet_front->input)];
 	uint64_t ip4_idx = 0;
 
 	struct packet *ip6_packets[packet_list_count(&packet_front->input)];
-	struct value_range *ip6_result[packet_list_count(&packet_front->input)];
+	uint32_t ip6_result[packet_list_count(&packet_front->input)];
 	uint64_t ip6_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);
@@ -93,42 +92,21 @@ forward_handle_packets(
 	while ((packet = packet_list_pop(&packet_front->input)) != NULL) {
 		struct forward_target *target = NULL;
 
-		const uint32_t *actions = NULL;
-		uint32_t action_count = 0;
-
-		// Set vlan as default
-		actions = ADDR_OF(&vlan_result[vlan_idx]->values);
-		action_count = vlan_result[vlan_idx]->count;
+		uint32_t action = vlan_result[vlan_idx];
 		++vlan_idx;
 
 		if (packet->network_header.type ==
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
-			const uint32_t *ip4_actions =
-				ADDR_OF(&ip4_result[ip4_idx]->values);
-			uint32_t ip4_action_count = ip4_result[ip4_idx]->count;
-			++ip4_idx;
-
-			if (ip4_action_count && (action_count == 0 ||
-						 ip4_actions[0] < actions[0])) {
-				actions = ip4_actions;
-				action_count = ip4_action_count;
-			}
+			if (ip4_result[ip4_idx] < action)
+				action = ip4_result[ip4_idx];
 		} else if (packet->network_header.type ==
 			   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
-			const uint32_t *ip6_actions =
-				ADDR_OF(&ip6_result[ip6_idx]->values);
-			uint32_t ip6_action_count = ip6_result[ip6_idx]->count;
-			++ip6_idx;
-
-			if (ip6_action_count && (action_count == 0 ||
-						 ip6_actions[0] < actions[0])) {
-				actions = ip6_actions;
-				action_count = ip6_action_count;
-			}
+			if (ip6_result[ip6_idx] < action)
+				action = ip6_result[ip6_idx];
 		}
 
-		if (action_count)
-			target = ADDR_OF(&forward_config->targets) + actions[0];
+		if (action != FILTER_RULE_INVALID)
+			target = ADDR_OF(&forward_config->targets) + action;
 
 		if (target != NULL) {
 			uint64_t *counters = counter_get_address(

--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -43,11 +43,11 @@ route_mpls_handle_packets(
 	);
 
 	struct packet *ip4_packets[packet_list_count(&packet_front->input)];
-	struct value_range *ip4_result[packet_list_count(&packet_front->input)];
+	uint32_t ip4_result[packet_list_count(&packet_front->input)];
 	uint64_t ip4_idx = 0;
 
 	struct packet *ip6_packets[packet_list_count(&packet_front->input)];
-	struct value_range *ip6_result[packet_list_count(&packet_front->input)];
+	uint32_t ip6_result[packet_list_count(&packet_front->input)];
 	uint64_t ip6_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);
@@ -90,28 +90,26 @@ route_mpls_handle_packets(
 
 		if (packet->network_header.type ==
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
-			if (!ip4_result[ip4_idx]->count) {
+			if (ip4_result[ip4_idx] == FILTER_RULE_INVALID) {
 				++ip4_idx;
 				continue;
 			}
 
 			target =
 				ADDR_OF(ADDR_OF(&module_config->targets) +
-					ADDR_OF(&ip4_result[ip4_idx]->values)[0]
-				);
+					ip4_result[ip4_idx]);
 
 			++ip4_idx;
 		} else if (packet->network_header.type ==
 			   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
-			if (!ip6_result[ip6_idx]->count) {
+			if (ip6_result[ip6_idx] == FILTER_RULE_INVALID) {
 				++ip6_idx;
 				continue;
 			}
 
 			target =
 				ADDR_OF(ADDR_OF(&module_config->targets) +
-					ADDR_OF(&ip6_result[ip6_idx]->values)[0]
-				);
+					ip6_result[ip6_idx]);
 
 			++ip6_idx;
 		}


### PR DESCRIPTION
Filter returns only one first-winning rule index so we may eliminate `value_registry` from the last filter stage. Empty result denoted as FILTER_RULE_INVALID (uint32_t)-1 value