### PR TITLE
fix(dataplane): overflow in TSC-to-ns conversion during clock init

### DIFF
--- a/lib/dataplane/time/clock.c
+++ b/lib/dataplane/time/clock.c
@@ -19,7 +19,7 @@ tsc_clock_init(struct tsc_clock *clock) {
 	clock->tsc_to_ns = 1024e9 / rte_get_tsc_hz();
 
 	clock->real_time_ns -=
-		clock->timestamp_counter * clock->tsc_to_ns >> 10;
+		(clock->timestamp_counter >> 10) * clock->tsc_to_ns;
 
 	return 0;
 }


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                
                                                                                                                                                                                                            
  In `tsc_clock_init`, the initial offset was computed as:
                                                                                                                                                                                                            
  ```c
  clock->timestamp_counter * clock->tsc_to_ns >> 10
```
                                                                                                                                                                                                            
 The multiplication is performed on the raw 64-bit TSC value before the >> 10 shift. For a machine that has been up for a non-trivial amount of time, timestamp_counter is large enough that multiplying by `tsc_to_ns` overflows `uint64_t`, producing a garbage `real_time_ns` baseline.

## Fix

Shift first, then multiply — the same ordering already used by `tsc_clock_get_time_ns` at
`lib/dataplane/time/clock.c:36`:

```c
(clock->timestamp_counter >> 10) * clock->tsc_to_ns
```

This keeps the intermediate value bounded and makes init consistent with the read path.