### PR TITLE
feat(shm): make AllModulePositions return an iterator

### DIFF
--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -13,6 +13,7 @@ import "C"
 
 import (
 	"fmt"
+	"iter"
 	"unsafe"
 
 	"github.com/c2h5oh/datasize"
@@ -764,7 +765,7 @@ type ModuleReference struct {
 	ModuleName string
 }
 
-func (m *DPConfig) AllModulePositions(moduleType string) []ModuleReference {
+func (m *DPConfig) AllModulePositions(moduleType string) iter.Seq[ModuleReference] {
 	deviceList := m.Devices()
 
 	pipelineList := m.Pipelines()
@@ -779,19 +780,29 @@ func (m *DPConfig) AllModulePositions(moduleType string) []ModuleReference {
 		functions[function.Name] = function.Chains
 	}
 
-	count := 0
-	for _, device := range deviceList {
-		pipelineVariants := [][]DevicePipelineInfo{
-			device.InputPipelines,
-			device.OutputPipelines,
-		}
-		for _, pipelines := range pipelineVariants {
-			for _, pipeline := range pipelines {
-				for _, function := range pipelineFunctions[pipeline.Name] {
-					for _, chain := range functions[function] {
-						for _, module := range chain.Modules {
-							if module.Type == moduleType {
-								count += 1
+	return func(yield func(ModuleReference) bool) {
+		for _, device := range deviceList {
+			pipelineVariants := [][]DevicePipelineInfo{
+				device.InputPipelines,
+				device.OutputPipelines,
+			}
+			for _, pipelines := range pipelineVariants {
+				for _, pipeline := range pipelines {
+					for _, function := range pipelineFunctions[pipeline.Name] {
+						for _, chain := range functions[function] {
+							for _, module := range chain.Modules {
+								if module.Type == moduleType {
+									if !yield(ModuleReference{
+										Device:     device.Name,
+										Pipeline:   pipeline.Name,
+										Function:   function,
+										Chain:      chain.Name,
+										ModuleType: module.Type,
+										ModuleName: module.Name,
+									}) {
+										return
+									}
+								}
 							}
 						}
 					}
@@ -799,34 +810,4 @@ func (m *DPConfig) AllModulePositions(moduleType string) []ModuleReference {
 			}
 		}
 	}
-
-	result := make([]ModuleReference, 0, count)
-	for _, device := range deviceList {
-		pipelineVariants := [][]DevicePipelineInfo{
-			device.InputPipelines,
-			device.OutputPipelines,
-		}
-		for _, pipelines := range pipelineVariants {
-			for _, pipeline := range pipelines {
-				for _, function := range pipelineFunctions[pipeline.Name] {
-					for _, chain := range functions[function] {
-						for _, module := range chain.Modules {
-							if module.Type == moduleType {
-								result = append(result, ModuleReference{
-									Device:     device.Name,
-									Pipeline:   pipeline.Name,
-									Function:   function,
-									Chain:      chain.Name,
-									ModuleType: module.Type,
-									ModuleName: module.Name,
-								})
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	return result
 }

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -127,7 +127,7 @@ func (m *ACLService) collectMetrics() ([]*commonpb.Metric, error) {
 
 	result := make([]*commonpb.Metric, 0)
 	gaugesEmitted := make(map[string]struct{})
-	for _, pos := range positions {
+	for pos := range positions {
 		configName := pos.ModuleName
 
 		baseLabels := []*commonpb.Label{
@@ -213,7 +213,10 @@ func (m *ACLService) collectMetrics() ([]*commonpb.Metric, error) {
 				)
 
 			default:
-				ruleLabels := append(baseLabels, &commonpb.Label{Name: "counter", Value: counter.Name})
+				ruleLabels := append(
+					baseLabels,
+					&commonpb.Label{Name: "counter", Value: counter.Name},
+				)
 				result = append(result,
 					makeCounter("acl_rule_packets", packets, ruleLabels...),
 					makeCounter("acl_rule_bytes", bytes, ruleLabels...),
@@ -230,13 +233,32 @@ func (m *ACLService) collectMetrics() ([]*commonpb.Metric, error) {
 
 			if cfg, ok := m.configs[configName]; ok && cfg.acl != nil {
 				info := cfg.acl.GetInfo()
-				result = append(result,
-					makeGauge("acl_compilation_time_ns", float64(info.CompilationTimeNs), configLabels...),
-					makeGauge("acl_filter_rule_count_vlan", float64(info.FilterRuleCountVlan), configLabels...),
-					makeGauge("acl_filter_rule_count_ip4", float64(info.FilterRuleCountIp4), configLabels...),
-					makeGauge("acl_filter_rule_count_ip4_port", float64(info.FilterRuleCountIp4Port), configLabels...),
-					makeGauge("acl_filter_rule_count_ip6", float64(info.FilterRuleCountIp6), configLabels...),
-					makeGauge("acl_filter_rule_count_ip6_port", float64(info.FilterRuleCountIp6Port), configLabels...),
+				result = append(
+					result,
+					makeGauge(
+						"acl_compilation_time_ns",
+						float64(info.CompilationTimeNs),
+						configLabels...),
+					makeGauge(
+						"acl_filter_rule_count_vlan",
+						float64(info.FilterRuleCountVlan),
+						configLabels...),
+					makeGauge(
+						"acl_filter_rule_count_ip4",
+						float64(info.FilterRuleCountIp4),
+						configLabels...),
+					makeGauge(
+						"acl_filter_rule_count_ip4_port",
+						float64(info.FilterRuleCountIp4Port),
+						configLabels...),
+					makeGauge(
+						"acl_filter_rule_count_ip6",
+						float64(info.FilterRuleCountIp6),
+						configLabels...),
+					makeGauge(
+						"acl_filter_rule_count_ip6_port",
+						float64(info.FilterRuleCountIp6Port),
+						configLabels...),
 					makeGauge("acl_memory_bytes", float64(m.memoryBytes), configLabels...),
 				)
 			}

--- a/modules/balancer/agent/go/agent.go
+++ b/modules/balancer/agent/go/agent.go
@@ -144,7 +144,11 @@ func (a *BalancerAgent) Inspect() *balancerpb.AgentInspect {
 
 func (a *BalancerAgent) Metrics() ([]*commonpb.Metric, error) {
 	dpConfig := a.handle.DPConfig()
-	positions := dpConfig.AllModulePositions("balancer")
+	positionsIter := dpConfig.AllModulePositions("balancer")
+	positions := make([]yanet.ModuleReference, 0)
+	for position := range positionsIter {
+		positions = append(positions, position)
+	}
 
 	managers := make([]*BalancerManager, 0, len(positions))
 	{
@@ -208,7 +212,11 @@ func (a *BalancerAgent) StatsEntries(
 	refFilter *balancerpb.PacketHandlerRef,
 ) ([]*balancerpb.StatsEntry, error) {
 	dpConfig := a.handle.DPConfig()
-	positions := dpConfig.AllModulePositions("balancer")
+	positionsIter := dpConfig.AllModulePositions("balancer")
+	positions := make([]yanet.ModuleReference, 0)
+	for position := range positionsIter {
+		positions = append(positions, position)
+	}
 
 	// Snapshot managers under lock to avoid holding agent mutex during per-position stats reads.
 	managersByName := make(map[string]*BalancerManager, len(a.managers))


### PR DESCRIPTION
 ## Summary
- Change `DPConfig.AllModulePositions` to return `iter.Seq[ModuleReference]`, removing the two-pass count-then-allocate logic.
- Update `acl` metrics collector to range over the iterator directly.
- Update `balancer` agent call sites to collect the iterator into a slice where a length is still needed.