### PR TITLE
fix(filter): return error on net6_fast classifier init failure

### DIFF
--- a/filter/compiler/net6_fast.c
+++ b/filter/compiler/net6_fast.c
@@ -8,8 +8,6 @@
 #include "compiler/segments.h"
 #include "declare.h"
 #include "rule.h"
-#include <assert.h>
-#include <stdlib.h>
 
 static int
 validate_net6_half(uint8_t *bytes) {
@@ -183,6 +181,7 @@ init_classifier(
 		value_registry_free(&low_registry);
 		free_classifier_part(&classifier->high, mctx);
 		free_classifier_part(&classifier->low, mctx);
+		return -1;
 	}
 
 	value_registry_free(&high_registry);


### PR DESCRIPTION
## Summary
- In `init_classifier` (filter/compiler/net6_fast.c), the error branch freed both classifier parts and the low registry but did not `return -1`, so the function continued into the success path and reported success despite the failure. 
- Added the missing `return -1;` so the caller observes the error. 
- Removed unused `<assert.h>` and `<stdlib.h>` includes from the file.