### PR TITLE
feat(packet): add packet_fix_mss for IPv6 TCP SYN MSS fixup

### DIFF
--- a/lib/dataplane/packet/meson.build
+++ b/lib/dataplane/packet/meson.build
@@ -29,12 +29,3 @@ lib_packet_dp_dep = declare_dependency(
   include_directories: yanet_libdir,
 )
 
-mss_test = executable(
-  'mss_test',
-  'tests/mss_test.c',
-  c_args: yanet_c_args,
-  link_args: yanet_link_args,
-  dependencies: [lib_packet_dp_dep, lib_logging_dep, libdpdk_dep],
-  include_directories: yanet_rootdir,
-)
-test('mss', mss_test, suite: 'lib_packet')

--- a/lib/dataplane/packet/meson.build
+++ b/lib/dataplane/packet/meson.build
@@ -28,3 +28,13 @@ lib_packet_dp_dep = declare_dependency(
   dependencies: dependencies,
   include_directories: yanet_libdir,
 )
+
+mss_test = executable(
+  'mss_test',
+  'tests/mss_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [lib_packet_dp_dep, lib_logging_dep, libdpdk_dep],
+  include_directories: yanet_rootdir,
+)
+test('mss', mss_test, suite: 'lib_packet')

--- a/lib/dataplane/packet/meson.build
+++ b/lib/dataplane/packet/meson.build
@@ -9,6 +9,7 @@ sources = files(
   'dscp.c',
   'encap.c',
   'packet.c',
+  'mss.c',
 )
 
 lib_packet_dp = static_library(

--- a/lib/dataplane/packet/mss.c
+++ b/lib/dataplane/packet/mss.c
@@ -1,0 +1,287 @@
+#include <netinet/in.h>
+#include <string.h>
+
+#include <rte_ether.h>
+#include <rte_ip.h>
+#include <rte_mbuf.h>
+#include <rte_tcp.h>
+
+#include "common/checksum.h"
+
+#include "lib/dataplane/packet/packet.h"
+#include "rte_branch_prediction.h"
+
+#include "mss.h"
+
+#define TCP_OPTION_KIND_EOL 0
+#define TCP_OPTION_KIND_NOP 1
+#define TCP_OPTION_KIND_MSS 2
+#define TCP_OPTION_MSS_LEN 4
+
+/* Minimum length of any variable-length TCP option: kind + len bytes. */
+#define TCP_OPTION_MIN_LEN 2
+
+/* Max TCP header length in bytes (data_off is 4 bits of 32-bit words: 15*4). */
+#define TCP_HDR_LEN_MAX 60
+
+/* One 32-bit-word step expressed in the raw data_off byte (high nibble). */
+#define TCP_DATA_OFF_ONE_WORD (1u << 4)
+
+struct tcp_option {
+	uint8_t kind;
+	uint8_t len;
+	uint8_t data[];
+} __attribute__((__packed__));
+
+/*
+ * Return the TCP header if the packet is IPv6 and carries a TCP SYN or
+ * SYN+ACK (i.e. SYN is set and RST is clear); NULL otherwise.
+ *
+ * Precondition: parse_packet guarantees that whenever
+ * transport_header.type == IPPROTO_TCP, the mbuf holds at least
+ * `transport_header.offset + sizeof(struct rte_tcp_hdr)` bytes,
+ * so the fixed 20-byte TCP header is safe to dereference here.
+ */
+static struct rte_tcp_hdr *
+get_syn_tcp_header(struct packet *packet) {
+	if (unlikely(
+		    packet->network_header.type !=
+		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)
+	    )) {
+		return NULL;
+	}
+
+	if (unlikely(packet->transport_header.type != IPPROTO_TCP)) {
+		return NULL;
+	}
+
+	struct rte_tcp_hdr *tcp = rte_pktmbuf_mtod_offset(
+		packet->mbuf,
+		struct rte_tcp_hdr *,
+		packet->transport_header.offset
+	);
+
+	uint8_t flags = tcp->tcp_flags;
+	if ((flags & (RTE_TCP_SYN_FLAG | RTE_TCP_RST_FLAG)) !=
+	    RTE_TCP_SYN_FLAG) {
+		return NULL;
+	}
+
+	return tcp;
+}
+
+/*
+ * Validate the TCP data offset field and return the TCP header length
+ * in bytes. Returns 0 if the declared length is invalid or extends past
+ * the packet end.
+ */
+static uint16_t
+tcp_header_length(struct packet *packet, struct rte_tcp_hdr *tcp) {
+	uint16_t hdr_len = (tcp->data_off >> 4) * 4;
+
+	/* Declared header shorter than the fixed TCP header => malformed. */
+	if (unlikely(hdr_len < sizeof(struct rte_tcp_hdr))) {
+		return 0;
+	}
+
+	/* Declared header extends past the packet end => malformed/truncated.
+	 */
+	uint16_t pkt_len = rte_pktmbuf_pkt_len(packet->mbuf);
+	if (unlikely(packet->transport_header.offset + hdr_len > pkt_len)) {
+		return 0;
+	}
+
+	return hdr_len;
+}
+
+enum find_result {
+	found,
+	absent,
+	malformed,
+};
+
+/*
+ * Walk the TCP options area looking for an MSS option. On success
+ * (mss_scan_found) writes a pointer to the option into *out.
+ */
+static enum find_result
+find_mss_option(
+	struct packet *packet, uint16_t hdr_len, struct tcp_option **out
+) {
+	uint16_t offset = sizeof(struct rte_tcp_hdr);
+
+	while (offset < hdr_len) {
+		struct tcp_option *opt = rte_pktmbuf_mtod_offset(
+			packet->mbuf,
+			struct tcp_option *,
+			packet->transport_header.offset + offset
+		);
+
+		/* End Of Option List: remaining bytes are padding — stop. */
+		if (opt->kind == TCP_OPTION_KIND_EOL) {
+			return absent;
+		}
+
+		if (opt->kind == TCP_OPTION_KIND_NOP) {
+			++offset;
+			continue;
+		}
+
+		/*
+		 * Variable-length option: must have at least a kind+len pair,
+		 * and its declared length must not overrun the options area.
+		 */
+		if (unlikely(
+			    offset + TCP_OPTION_MIN_LEN > hdr_len ||
+			    opt->len < TCP_OPTION_MIN_LEN ||
+			    offset + opt->len > hdr_len
+		    )) {
+			return malformed;
+		}
+
+		if (opt->kind == TCP_OPTION_KIND_MSS) {
+			if (unlikely(opt->len != TCP_OPTION_MSS_LEN)) {
+				return malformed;
+			}
+			*out = opt;
+			return found;
+		}
+
+		offset += opt->len;
+	}
+
+	return absent;
+}
+
+/*
+ * If the MSS option value exceeds `clamp_mss`, rewrite it to `clamp_mss`
+ * and patch the TCP checksum. Does nothing if the value is already low enough.
+ *
+ * Precondition: `opt` is a well-formed MSS option (kind=MSS, len=4).
+ */
+static void
+clamp_mss_option(
+	struct rte_tcp_hdr *tcp, struct tcp_option *opt, uint16_t clamp_mss
+) {
+	uint16_t *mss_ptr = (uint16_t *)opt->data;
+	uint16_t old_mss = rte_be_to_cpu_16(*mss_ptr);
+	if (old_mss <= clamp_mss) {
+		return;
+	}
+
+	/*
+	 * Incremental TCP checksum update per RFC 1624: subtract the old
+	 * 16-bit word, write the new one, add it back. The `== 0xffff`
+	 * guard preserves an all-ones checksum instead of flipping it to zero.
+	 */
+	uint16_t cksum = ~tcp->cksum;
+	cksum = csum_minus(cksum, *mss_ptr);
+	*mss_ptr = rte_cpu_to_be_16(clamp_mss);
+	cksum = csum_plus(cksum, *mss_ptr);
+	tcp->cksum = (cksum == 0xffff) ? cksum : ~cksum;
+}
+
+/*
+ * Insert a new MSS option with value `insert_mss` right after the fixed
+ * TCP header. Moves L2 + L3 + fixed TCP header to a lower address by
+ * 4 bytes, writes the option into the freed gap, then updates the TCP
+ * data offset, TCP checksum, and IPv6 payload length.
+ *
+ * Precondition: the packet is IPv6 (IPv6 payload length is the only L3
+ * length field updated here).
+ */
+static enum packet_fix_mss_result
+insert_mss_option(
+	struct packet *packet, struct rte_tcp_hdr *tcp, uint16_t insert_mss
+) {
+	/* TCP header length in bytes (high nibble = 32-bit word count). */
+	uint16_t hdr_len = (tcp->data_off >> 4) * 4;
+
+	/* Not enough room in data_off to represent one more option word. */
+	if (unlikely(hdr_len + TCP_OPTION_MSS_LEN > TCP_HDR_LEN_MAX)) {
+		return packet_fix_mss_malformed;
+	}
+
+	struct rte_mbuf *mbuf = packet->mbuf;
+
+	if (unlikely(rte_pktmbuf_prepend(mbuf, TCP_OPTION_MSS_LEN) == NULL)) {
+		return packet_fix_mss_no_headroom;
+	}
+
+	/* Move L2 + L3 + fixed TCP header to a lower address to open a 4-byte
+	 * gap. */
+	uint16_t prefix_len =
+		packet->transport_header.offset + sizeof(struct rte_tcp_hdr);
+	memmove(rte_pktmbuf_mtod(mbuf, char *),
+		rte_pktmbuf_mtod_offset(mbuf, char *, TCP_OPTION_MSS_LEN),
+		prefix_len);
+
+	/* Write the MSS option into the gap. */
+	struct tcp_option *opt =
+		rte_pktmbuf_mtod_offset(mbuf, struct tcp_option *, prefix_len);
+	opt->kind = TCP_OPTION_KIND_MSS;
+	opt->len = TCP_OPTION_MSS_LEN;
+	*(uint16_t *)opt->data = rte_cpu_to_be_16(insert_mss);
+
+	/* Re-fetch TCP header (moved due to prepend). */
+	tcp = rte_pktmbuf_mtod_offset(
+		mbuf, struct rte_tcp_hdr *, packet->transport_header.offset
+	);
+
+	/* Grow the TCP header by one 32-bit word (our newly inserted MSS
+	 * option). */
+	tcp->data_off += TCP_DATA_OFF_ONE_WORD;
+
+	/*
+	 * Update TCP checksum incrementally (RFC 1624).
+	 *
+	 * `data_off` is the high byte of a 16-bit aligned pair inside the
+	 * TCP header, so adding TCP_DATA_OFF_ONE_WORD to a host-order 16-bit
+	 * accumulator matches the change to the byte stream. The `opt`
+	 * fields are already in network order in memory, so they are
+	 * summed as-is. The MSS length term compensates for the growth
+	 * of the TCP length in the pseudo-header.
+	 */
+	uint16_t cksum = ~tcp->cksum;
+	cksum = csum_plus(cksum, TCP_DATA_OFF_ONE_WORD);
+	cksum = csum_plus(cksum, *(uint16_t *)opt);
+	cksum = csum_plus(cksum, *(uint16_t *)opt->data);
+	cksum = csum_plus(cksum, rte_cpu_to_be_16(TCP_OPTION_MSS_LEN));
+	tcp->cksum = (cksum == 0xffff) ? cksum : ~cksum;
+
+	/* Update IPv6 payload length. */
+	struct rte_ipv6_hdr *ip6 = rte_pktmbuf_mtod_offset(
+		mbuf, struct rte_ipv6_hdr *, packet->network_header.offset
+	);
+	ip6->payload_len = rte_cpu_to_be_16(
+		rte_be_to_cpu_16(ip6->payload_len) + TCP_OPTION_MSS_LEN
+	);
+
+	return packet_fix_mss_ok;
+}
+
+enum packet_fix_mss_result
+packet_fix_mss(struct packet *packet, uint16_t clamp_mss, uint16_t insert_mss) {
+	struct rte_tcp_hdr *tcp = get_syn_tcp_header(packet);
+	if (tcp == NULL) {
+		return packet_fix_mss_ok;
+	}
+
+	uint16_t hdr_len = tcp_header_length(packet, tcp);
+	if (unlikely(hdr_len == 0)) {
+		return packet_fix_mss_malformed;
+	}
+
+	struct tcp_option *mss_opt = NULL;
+	switch (find_mss_option(packet, hdr_len, &mss_opt)) {
+	case found:
+		clamp_mss_option(tcp, mss_opt, clamp_mss);
+		return packet_fix_mss_ok;
+	case malformed:
+		return packet_fix_mss_malformed;
+	case absent:
+		return insert_mss_option(packet, tcp, insert_mss);
+	}
+
+	__builtin_unreachable();
+}

--- a/lib/dataplane/packet/mss.c
+++ b/lib/dataplane/packet/mss.c
@@ -8,6 +8,7 @@
 
 #include "common/checksum.h"
 
+#include "data.h"
 #include "lib/dataplane/packet/packet.h"
 #include "rte_branch_prediction.h"
 
@@ -43,7 +44,7 @@ struct tcp_option {
  * so the fixed 20-byte TCP header is safe to dereference here.
  */
 static struct rte_tcp_hdr *
-get_syn_tcp_header(struct packet *packet) {
+tcp_hdr(struct packet *packet) {
 	if (unlikely(
 		    packet->network_header.type !=
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)
@@ -76,7 +77,7 @@ get_syn_tcp_header(struct packet *packet) {
  * the packet end.
  */
 static uint16_t
-tcp_header_length(struct packet *packet, struct rte_tcp_hdr *tcp) {
+tcp_hdr_len(struct packet *packet, struct rte_tcp_hdr *tcp) {
 	uint16_t hdr_len = (tcp->data_off >> 4) * 4;
 
 	/* Declared header shorter than the fixed TCP header => malformed. */
@@ -101,8 +102,8 @@ enum find_result {
 };
 
 /*
- * Walk the TCP options area looking for an MSS option. On success
- * (mss_scan_found) writes a pointer to the option into *out.
+ * Walk the TCP options area looking for an MSS option. On `found`,
+ * writes a pointer to the option into *out.
  */
 static enum find_result
 find_mss_option(
@@ -117,7 +118,6 @@ find_mss_option(
 			packet->transport_header.offset + offset
 		);
 
-		/* End Of Option List: remaining bytes are padding — stop. */
 		if (opt->kind == TCP_OPTION_KIND_EOL) {
 			return absent;
 		}
@@ -127,10 +127,6 @@ find_mss_option(
 			continue;
 		}
 
-		/*
-		 * Variable-length option: must have at least a kind+len pair,
-		 * and its declared length must not overrun the options area.
-		 */
 		if (unlikely(
 			    offset + TCP_OPTION_MIN_LEN > hdr_len ||
 			    opt->len < TCP_OPTION_MIN_LEN ||
@@ -169,87 +165,93 @@ clamp_mss_option(
 		return;
 	}
 
-	/*
-	 * Incremental TCP checksum update per RFC 1624: subtract the old
-	 * 16-bit word, write the new one, add it back. The `== 0xffff`
-	 * guard preserves an all-ones checksum instead of flipping it to zero.
-	 */
+	/* Incremental TCP checksum update per RFC 1624. */
 	uint16_t cksum = ~tcp->cksum;
 	cksum = csum_minus(cksum, *mss_ptr);
 	*mss_ptr = rte_cpu_to_be_16(clamp_mss);
 	cksum = csum_plus(cksum, *mss_ptr);
+	/* preserve all-ones checksum (RFC 1624). */
 	tcp->cksum = (cksum == 0xffff) ? cksum : ~cksum;
 }
 
 /*
- * Insert a new MSS option with value `insert_mss` right after the fixed
- * TCP header. Moves L2 + L3 + fixed TCP header to a lower address by
- * 4 bytes, writes the option into the freed gap, then updates the TCP
- * data offset, TCP checksum, and IPv6 payload length.
- *
- * Precondition: the packet is IPv6 (IPv6 payload length is the only L3
- * length field updated here).
+ * Prepend 4 bytes of headroom to the mbuf and shift the first `prefix_len`
+ * bytes (L2 + L3 + fixed TCP header) down by 4, opening a 4-byte gap right
+ * after the fixed TCP header.
  */
-static enum packet_fix_mss_result
-insert_mss_option(
-	struct packet *packet, struct rte_tcp_hdr *tcp, uint16_t insert_mss
-) {
-	/* TCP header length in bytes (high nibble = 32-bit word count). */
-	uint16_t hdr_len = (tcp->data_off >> 4) * 4;
-
-	/* Not enough room in data_off to represent one more option word. */
-	if (unlikely(hdr_len + TCP_OPTION_MSS_LEN > TCP_HDR_LEN_MAX)) {
-		return packet_fix_mss_malformed;
-	}
-
-	struct rte_mbuf *mbuf = packet->mbuf;
-
+static enum packet_set_mss_result
+insert_mss_gap(struct rte_mbuf *mbuf, uint16_t prefix_len) {
 	if (unlikely(rte_pktmbuf_prepend(mbuf, TCP_OPTION_MSS_LEN) == NULL)) {
-		return packet_fix_mss_no_headroom;
+		return packet_set_mss_no_headroom;
 	}
-
-	/* Move L2 + L3 + fixed TCP header to a lower address to open a 4-byte
-	 * gap. */
-	uint16_t prefix_len =
-		packet->transport_header.offset + sizeof(struct rte_tcp_hdr);
 	memmove(rte_pktmbuf_mtod(mbuf, char *),
 		rte_pktmbuf_mtod_offset(mbuf, char *, TCP_OPTION_MSS_LEN),
 		prefix_len);
+	return packet_set_mss_ok;
+}
 
-	/* Write the MSS option into the gap. */
+static struct tcp_option *
+write_into_mss_gap(struct rte_mbuf *mbuf, uint16_t offset, uint16_t mss) {
 	struct tcp_option *opt =
-		rte_pktmbuf_mtod_offset(mbuf, struct tcp_option *, prefix_len);
+		rte_pktmbuf_mtod_offset(mbuf, struct tcp_option *, offset);
 	opt->kind = TCP_OPTION_KIND_MSS;
 	opt->len = TCP_OPTION_MSS_LEN;
-	*(uint16_t *)opt->data = rte_cpu_to_be_16(insert_mss);
+	*(uint16_t *)opt->data = rte_cpu_to_be_16(mss);
+	return opt;
+}
 
-	/* Re-fetch TCP header (moved due to prepend). */
-	tcp = rte_pktmbuf_mtod_offset(
-		mbuf, struct rte_tcp_hdr *, packet->transport_header.offset
-	);
-
-	/* Grow the TCP header by one 32-bit word (our newly inserted MSS
-	 * option). */
-	tcp->data_off += TCP_DATA_OFF_ONE_WORD;
-
-	/*
-	 * Update TCP checksum incrementally (RFC 1624).
-	 *
-	 * `data_off` is the high byte of a 16-bit aligned pair inside the
-	 * TCP header, so adding TCP_DATA_OFF_ONE_WORD to a host-order 16-bit
-	 * accumulator matches the change to the byte stream. The `opt`
-	 * fields are already in network order in memory, so they are
-	 * summed as-is. The MSS length term compensates for the growth
-	 * of the TCP length in the pseudo-header.
-	 */
+/*
+ * Update TCP checksum incrementally for a freshly-inserted MSS option:
+ * data_off grew by one word, the option (kind+len, value) is new, and the
+ * pseudo-header TCP length grew by TCP_OPTION_MSS_LEN.
+ */
+static void
+tcp_cksum_add_mss(struct rte_tcp_hdr *tcp, struct tcp_option *opt) {
 	uint16_t cksum = ~tcp->cksum;
 	cksum = csum_plus(cksum, TCP_DATA_OFF_ONE_WORD);
 	cksum = csum_plus(cksum, *(uint16_t *)opt);
 	cksum = csum_plus(cksum, *(uint16_t *)opt->data);
 	cksum = csum_plus(cksum, rte_cpu_to_be_16(TCP_OPTION_MSS_LEN));
+	/* preserve all-ones checksum (RFC 1624). */
 	tcp->cksum = (cksum == 0xffff) ? cksum : ~cksum;
+}
 
-	/* Update IPv6 payload length. */
+/*
+ * Insert a new MSS option with value `insert_mss` right after the fixed
+ * TCP header, then update the TCP data offset, TCP checksum, and IPv6
+ * payload length.
+ *
+ * Precondition: the packet is IPv6 (IPv6 payload length is the only L3
+ * length field updated here).
+ */
+static enum packet_set_mss_result
+insert_mss_option(
+	struct packet *packet, struct rte_tcp_hdr *tcp, uint16_t insert_mss
+) {
+	uint16_t hdr_len = (tcp->data_off >> 4) * 4;
+	if (unlikely(hdr_len + TCP_OPTION_MSS_LEN > TCP_HDR_LEN_MAX)) {
+		return packet_set_mss_malformed;
+	}
+
+	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+	uint16_t prefix_len =
+		packet->transport_header.offset + sizeof(struct rte_tcp_hdr);
+
+	enum packet_set_mss_result rc = insert_mss_gap(mbuf, prefix_len);
+	if (unlikely(rc != packet_set_mss_ok)) {
+		return rc;
+	}
+
+	struct tcp_option *opt =
+		write_into_mss_gap(mbuf, prefix_len, insert_mss);
+
+	/* Need refetch tcp header as it moved in memory on inserting. */
+	tcp = rte_pktmbuf_mtod_offset(
+		mbuf, struct rte_tcp_hdr *, packet->transport_header.offset
+	);
+	tcp->data_off += TCP_DATA_OFF_ONE_WORD;
+	tcp_cksum_add_mss(tcp, opt);
+
 	struct rte_ipv6_hdr *ip6 = rte_pktmbuf_mtod_offset(
 		mbuf, struct rte_ipv6_hdr *, packet->network_header.offset
 	);
@@ -257,30 +259,30 @@ insert_mss_option(
 		rte_be_to_cpu_16(ip6->payload_len) + TCP_OPTION_MSS_LEN
 	);
 
-	return packet_fix_mss_ok;
+	return packet_set_mss_ok;
 }
 
-enum packet_fix_mss_result
-packet_fix_mss(struct packet *packet, uint16_t clamp_mss, uint16_t insert_mss) {
-	struct rte_tcp_hdr *tcp = get_syn_tcp_header(packet);
+enum packet_set_mss_result
+packet_set_mss(struct packet *packet, uint16_t clamp_mss, uint16_t insert_mss) {
+	struct rte_tcp_hdr *tcp = tcp_hdr(packet);
 	if (tcp == NULL) {
-		return packet_fix_mss_ok;
+		return packet_set_mss_ok;
 	}
 
-	uint16_t hdr_len = tcp_header_length(packet, tcp);
+	uint16_t hdr_len = tcp_hdr_len(packet, tcp);
 	if (unlikely(hdr_len == 0)) {
-		return packet_fix_mss_malformed;
+		return packet_set_mss_malformed;
 	}
 
 	struct tcp_option *mss_opt = NULL;
 	switch (find_mss_option(packet, hdr_len, &mss_opt)) {
 	case found:
 		clamp_mss_option(tcp, mss_opt, clamp_mss);
-		return packet_fix_mss_ok;
-	case malformed:
-		return packet_fix_mss_malformed;
+		return packet_set_mss_ok;
 	case absent:
 		return insert_mss_option(packet, tcp, insert_mss);
+	case malformed:
+		return packet_set_mss_malformed;
 	}
 
 	__builtin_unreachable();

--- a/lib/dataplane/packet/mss.h
+++ b/lib/dataplane/packet/mss.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stdint.h>
+
+struct packet;
+
+enum packet_fix_mss_result {
+	/* MSS was clamped, inserted, or the packet did not need fixing. */
+	packet_fix_mss_ok = 0,
+	/*
+	 * TCP header or options are malformed, or the header already
+	 * occupies the full 60 bytes so a new option cannot fit in the
+	 * data_off field. The packet is left untouched.
+	 */
+	packet_fix_mss_malformed,
+	/* mbuf has no headroom at the front to prepend the new option. */
+	packet_fix_mss_no_headroom,
+};
+
+/*
+ * Normalize the TCP MSS option on an IPv6 TCP SYN packet in a single pass.
+ *
+ *   - If the packet is not an IPv6 TCP SYN (or its RST flag is set), it is
+ *     left untouched.
+ *   - If an MSS option is present and its value exceeds `clamp_mss`, the
+ *     option is rewritten to `clamp_mss`. Lower values are kept as-is.
+ *   - If no MSS option is present, a new option with value `insert_mss`
+ *     is inserted immediately after the fixed TCP header.
+ *
+ * TCP checksum and IPv6 payload length are updated as needed.
+ */
+enum packet_fix_mss_result
+packet_fix_mss(struct packet *packet, uint16_t clamp_mss, uint16_t insert_mss);

--- a/lib/dataplane/packet/mss.h
+++ b/lib/dataplane/packet/mss.h
@@ -4,17 +4,17 @@
 
 struct packet;
 
-enum packet_fix_mss_result {
+enum packet_set_mss_result {
 	/* MSS was clamped, inserted, or the packet did not need fixing. */
-	packet_fix_mss_ok = 0,
+	packet_set_mss_ok = 0,
 	/*
 	 * TCP header or options are malformed, or the header already
 	 * occupies the full 60 bytes so a new option cannot fit in the
 	 * data_off field. The packet is left untouched.
 	 */
-	packet_fix_mss_malformed,
+	packet_set_mss_malformed,
 	/* mbuf has no headroom at the front to prepend the new option. */
-	packet_fix_mss_no_headroom,
+	packet_set_mss_no_headroom,
 };
 
 /*
@@ -29,5 +29,5 @@ enum packet_fix_mss_result {
  *
  * TCP checksum and IPv6 payload length are updated as needed.
  */
-enum packet_fix_mss_result
-packet_fix_mss(struct packet *packet, uint16_t clamp_mss, uint16_t insert_mss);
+enum packet_set_mss_result
+packet_set_mss(struct packet *packet, uint16_t clamp_mss, uint16_t insert_mss);

--- a/lib/dataplane/packet/tests/mss_test.c
+++ b/lib/dataplane/packet/tests/mss_test.c
@@ -1,0 +1,732 @@
+#include <netinet/in.h>
+#include <stdalign.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rte_byteorder.h>
+#include <rte_ether.h>
+#include <rte_ip.h>
+#include <rte_mbuf.h>
+#include <rte_tcp.h>
+#include <rte_udp.h>
+
+#include "common/test_assert.h"
+#include "lib/dataplane/packet/mss.h"
+#include "lib/dataplane/packet/packet.h"
+#include "logging/log.h"
+
+#define TCP_OPT_KIND_EOL 0
+#define TCP_OPT_KIND_NOP 1
+#define TCP_OPT_KIND_MSS 2
+
+#define DEFAULT_HEADROOM 128
+#define DEFAULT_TAILROOM 256
+
+#define SNAPSHOT_CAP 512
+
+////////////////////////////////////////////////////////////////////////////////
+// Packet construction helpers
+
+struct test_pkt {
+	struct packet packet;
+	struct rte_mbuf *mbuf;
+};
+
+static void
+free_test_pkt(struct test_pkt *tp) {
+	free(tp->mbuf);
+	tp->mbuf = NULL;
+}
+
+static int
+alloc_mbuf(struct test_pkt *tp, uint16_t headroom, uint16_t pkt_len, uint16_t tailroom) {
+	size_t buf_len = (size_t)headroom + pkt_len;
+	size_t mbuf_size = sizeof(struct rte_mbuf) + buf_len + tailroom;
+	size_t align = alignof(struct rte_mbuf);
+	if (mbuf_size % align != 0) {
+		mbuf_size += align - mbuf_size % align;
+	}
+	struct rte_mbuf *mbuf = aligned_alloc(align, mbuf_size);
+	if (!mbuf) {
+		return -1;
+	}
+	memset(mbuf, 0, sizeof(*mbuf));
+	mbuf->buf_addr = (char *)mbuf + sizeof(struct rte_mbuf);
+	mbuf->buf_len = buf_len;
+	mbuf->data_off = headroom;
+	mbuf->data_len = pkt_len;
+	mbuf->pkt_len = pkt_len;
+	mbuf->nb_segs = 1;
+	rte_mbuf_refcnt_set(mbuf, 1);
+
+	memset(rte_pktmbuf_mtod(mbuf, void *), 0, pkt_len);
+	tp->mbuf = mbuf;
+	memset(&tp->packet, 0, sizeof(tp->packet));
+	tp->packet.mbuf = mbuf;
+	return 0;
+}
+
+/* Build IPv6 + TCP packet. `data_off_override` = 0 means compute from opt_len,
+ * otherwise write the given value verbatim (allowing malformed headers).
+ * If `compute_cksum` is non-zero the TCP checksum is written; otherwise left
+ * at whatever memset produced. */
+static int
+build_ip6_tcp(
+	struct test_pkt *tp,
+	uint8_t tcp_flags,
+	const uint8_t *opts,
+	uint16_t opt_len,
+	uint8_t data_off_override,
+	uint16_t headroom,
+	int compute_cksum
+) {
+	uint16_t l4_len = sizeof(struct rte_tcp_hdr) + opt_len;
+	uint16_t pkt_len = sizeof(struct rte_ether_hdr) +
+			   sizeof(struct rte_ipv6_hdr) + l4_len;
+
+	if (alloc_mbuf(tp, headroom, pkt_len, DEFAULT_TAILROOM) != 0) {
+		return -1;
+	}
+
+	uint8_t *data = rte_pktmbuf_mtod(tp->mbuf, uint8_t *);
+	struct rte_ether_hdr *eth = (struct rte_ether_hdr *)data;
+	eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6);
+
+	struct rte_ipv6_hdr *ip6 = (struct rte_ipv6_hdr *)(eth + 1);
+	ip6->vtc_flow = rte_cpu_to_be_32(0x60000000);
+	ip6->payload_len = rte_cpu_to_be_16(l4_len);
+	ip6->proto = IPPROTO_TCP;
+	ip6->hop_limits = 64;
+	ip6->src_addr[0] = 0x20;
+	ip6->src_addr[1] = 0x01;
+	ip6->dst_addr[0] = 0x20;
+	ip6->dst_addr[1] = 0x01;
+	ip6->dst_addr[15] = 1;
+
+	struct rte_tcp_hdr *tcp = (struct rte_tcp_hdr *)(ip6 + 1);
+	tcp->src_port = rte_cpu_to_be_16(12345);
+	tcp->dst_port = rte_cpu_to_be_16(80);
+	tcp->sent_seq = rte_cpu_to_be_32(1);
+	tcp->recv_ack = 0;
+	uint8_t data_off = data_off_override
+				   ? data_off_override
+				   : (uint8_t)((sizeof(*tcp) + opt_len) / 4);
+	tcp->data_off = (uint8_t)(data_off << 4);
+	tcp->tcp_flags = tcp_flags;
+	tcp->rx_win = rte_cpu_to_be_16(65535);
+	tcp->cksum = 0;
+	tcp->tcp_urp = 0;
+
+	if (opt_len > 0 && opts != NULL) {
+		memcpy((uint8_t *)(tcp + 1), opts, opt_len);
+	}
+
+	if (compute_cksum) {
+		tcp->cksum = rte_ipv6_udptcp_cksum(ip6, tcp);
+	}
+
+	if (parse_packet(&tp->packet) != 0) {
+		free_test_pkt(tp);
+		return -1;
+	}
+	return 0;
+}
+
+static int
+build_ip6_udp(struct test_pkt *tp) {
+	uint16_t l4_len = sizeof(struct rte_udp_hdr);
+	uint16_t pkt_len = sizeof(struct rte_ether_hdr) +
+			   sizeof(struct rte_ipv6_hdr) + l4_len;
+
+	if (alloc_mbuf(tp, DEFAULT_HEADROOM, pkt_len, DEFAULT_TAILROOM) != 0) {
+		return -1;
+	}
+
+	uint8_t *data = rte_pktmbuf_mtod(tp->mbuf, uint8_t *);
+	struct rte_ether_hdr *eth = (struct rte_ether_hdr *)data;
+	eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6);
+
+	struct rte_ipv6_hdr *ip6 = (struct rte_ipv6_hdr *)(eth + 1);
+	ip6->vtc_flow = rte_cpu_to_be_32(0x60000000);
+	ip6->payload_len = rte_cpu_to_be_16(l4_len);
+	ip6->proto = IPPROTO_UDP;
+	ip6->hop_limits = 64;
+	ip6->src_addr[0] = 0x20;
+	ip6->dst_addr[0] = 0x20;
+	ip6->dst_addr[15] = 1;
+
+	struct rte_udp_hdr *udp = (struct rte_udp_hdr *)(ip6 + 1);
+	udp->src_port = rte_cpu_to_be_16(12345);
+	udp->dst_port = rte_cpu_to_be_16(80);
+	udp->dgram_len = rte_cpu_to_be_16(sizeof(*udp));
+	udp->dgram_cksum = 0;
+
+	return parse_packet(&tp->packet);
+}
+
+static int
+build_ip4_tcp_syn(struct test_pkt *tp) {
+	uint16_t pkt_len = sizeof(struct rte_ether_hdr) +
+			   sizeof(struct rte_ipv4_hdr) +
+			   sizeof(struct rte_tcp_hdr);
+
+	if (alloc_mbuf(tp, DEFAULT_HEADROOM, pkt_len, DEFAULT_TAILROOM) != 0) {
+		return -1;
+	}
+
+	uint8_t *data = rte_pktmbuf_mtod(tp->mbuf, uint8_t *);
+	struct rte_ether_hdr *eth = (struct rte_ether_hdr *)data;
+	eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+
+	struct rte_ipv4_hdr *ip4 = (struct rte_ipv4_hdr *)(eth + 1);
+	ip4->version_ihl = 0x45;
+	ip4->total_length = rte_cpu_to_be_16(
+		sizeof(struct rte_ipv4_hdr) + sizeof(struct rte_tcp_hdr)
+	);
+	ip4->time_to_live = 64;
+	ip4->next_proto_id = IPPROTO_TCP;
+	ip4->src_addr = rte_cpu_to_be_32(0x01010101);
+	ip4->dst_addr = rte_cpu_to_be_32(0x02020202);
+
+	struct rte_tcp_hdr *tcp = (struct rte_tcp_hdr *)(ip4 + 1);
+	tcp->src_port = rte_cpu_to_be_16(12345);
+	tcp->dst_port = rte_cpu_to_be_16(80);
+	tcp->data_off = 5 << 4;
+	tcp->tcp_flags = RTE_TCP_SYN_FLAG;
+	tcp->rx_win = rte_cpu_to_be_16(65535);
+	tcp->cksum = 0;
+
+	return parse_packet(&tp->packet);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Accessors and verifiers
+
+static struct rte_ipv6_hdr *
+pkt_ip6(struct packet *p) {
+	return rte_pktmbuf_mtod_offset(
+		p->mbuf, struct rte_ipv6_hdr *, p->network_header.offset
+	);
+}
+
+static struct rte_tcp_hdr *
+pkt_tcp(struct packet *p) {
+	return rte_pktmbuf_mtod_offset(
+		p->mbuf, struct rte_tcp_hdr *, p->transport_header.offset
+	);
+}
+
+/* Recompute the IPv6 TCP checksum from scratch and compare to the on-packet
+ * value. Returns TEST_SUCCESS if they match. */
+static int
+verify_ip6_tcp_cksum(struct packet *p) {
+	struct rte_ipv6_hdr *ip6 = pkt_ip6(p);
+	struct rte_tcp_hdr *tcp = pkt_tcp(p);
+	uint16_t saved = tcp->cksum;
+	tcp->cksum = 0;
+	uint16_t expected = rte_ipv6_udptcp_cksum(ip6, tcp);
+	tcp->cksum = saved;
+	TEST_ASSERT_EQUAL(
+		saved,
+		expected,
+		"TCP checksum mismatch: on-pkt=0x%04x expected=0x%04x",
+		saved,
+		expected
+	);
+	return TEST_SUCCESS;
+}
+
+struct pkt_snapshot {
+	uint16_t pkt_len;
+	uint16_t data_off;
+	uint8_t data[SNAPSHOT_CAP];
+};
+
+static void
+snapshot(struct packet *p, struct pkt_snapshot *s) {
+	uint16_t len = rte_pktmbuf_pkt_len(p->mbuf);
+	s->pkt_len = len;
+	s->data_off = p->mbuf->data_off;
+	memcpy(s->data, rte_pktmbuf_mtod(p->mbuf, void *), len);
+}
+
+static int
+assert_unchanged(struct packet *p, const struct pkt_snapshot *s) {
+	TEST_ASSERT_EQUAL(
+		rte_pktmbuf_pkt_len(p->mbuf), s->pkt_len, "pkt_len changed"
+	);
+	TEST_ASSERT_EQUAL(p->mbuf->data_off, s->data_off, "data_off changed");
+	TEST_ASSERT(
+		memcmp(rte_pktmbuf_mtod(p->mbuf, void *), s->data, s->pkt_len
+		) == 0,
+		"packet bytes changed"
+	);
+	return TEST_SUCCESS;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// MSS option builders
+
+static void
+write_mss_opt(uint8_t *dst, uint16_t mss) {
+	dst[0] = TCP_OPT_KIND_MSS;
+	dst[1] = 4;
+	uint16_t be = rte_cpu_to_be_16(mss);
+	memcpy(dst + 2, &be, 2);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Test cases
+
+static int
+test_clamp_gt(void) {
+	uint8_t opts[4];
+	write_mss_opt(opts, 1460);
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+		),
+		"build"
+	);
+
+	uint16_t ip6_len_before =
+		rte_be_to_cpu_16(pkt_ip6(&tp.packet)->payload_len);
+	uint8_t data_off_before = pkt_tcp(&tp.packet)->data_off;
+
+	enum packet_fix_mss_result rc = packet_fix_mss(&tp.packet, 1200, 1300);
+	TEST_ASSERT_EQUAL(rc, packet_fix_mss_ok, "rc");
+
+	struct rte_tcp_hdr *tcp = pkt_tcp(&tp.packet);
+	uint16_t *mss_field =
+		(uint16_t *)((uint8_t *)(tcp + 1) + 2); /* after kind+len */
+	TEST_ASSERT_EQUAL(
+		rte_be_to_cpu_16(*mss_field), 1200, "MSS not clamped"
+	);
+	TEST_ASSERT_EQUAL(
+		rte_be_to_cpu_16(pkt_ip6(&tp.packet)->payload_len),
+		ip6_len_before,
+		"payload_len changed"
+	);
+	TEST_ASSERT_EQUAL(tcp->data_off, data_off_before, "data_off changed");
+	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&tp.packet), "cksum");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_clamp_lt(void) {
+	uint8_t opts[4];
+	write_mss_opt(opts, 1000);
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+		),
+		"build"
+	);
+	struct pkt_snapshot s;
+	snapshot(&tp.packet, &s);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+	);
+	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_clamp_eq(void) {
+	uint8_t opts[4];
+	write_mss_opt(opts, 1200);
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+		),
+		"build"
+	);
+	struct pkt_snapshot s;
+	snapshot(&tp.packet, &s);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+	);
+	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_insert_no_mss(void) {
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp, RTE_TCP_SYN_FLAG, NULL, 0, 0, DEFAULT_HEADROOM, 1
+		),
+		"build"
+	);
+	uint32_t pkt_len_before = rte_pktmbuf_pkt_len(tp.mbuf);
+	uint16_t ip6_len_before =
+		rte_be_to_cpu_16(pkt_ip6(&tp.packet)->payload_len);
+	uint8_t data_off_before = pkt_tcp(&tp.packet)->data_off;
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+	);
+
+	TEST_ASSERT_EQUAL(
+		rte_pktmbuf_pkt_len(tp.mbuf),
+		pkt_len_before + 4u,
+		"pkt_len did not grow by 4"
+	);
+	struct rte_tcp_hdr *tcp = pkt_tcp(&tp.packet);
+	TEST_ASSERT_EQUAL(
+		tcp->data_off,
+		data_off_before + (1 << 4),
+		"data_off not +1 word"
+	);
+	TEST_ASSERT_EQUAL(
+		rte_be_to_cpu_16(pkt_ip6(&tp.packet)->payload_len),
+		ip6_len_before + 4,
+		"IPv6 payload_len not +4"
+	);
+	uint8_t *opt = (uint8_t *)(tcp + 1);
+	TEST_ASSERT_EQUAL(opt[0], TCP_OPT_KIND_MSS, "opt kind");
+	TEST_ASSERT_EQUAL(opt[1], 4, "opt len");
+	uint16_t mss_be;
+	memcpy(&mss_be, opt + 2, 2);
+	TEST_ASSERT_EQUAL(rte_be_to_cpu_16(mss_be), 1300, "inserted MSS");
+	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&tp.packet), "cksum");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_skip_ipv4(void) {
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(build_ip4_tcp_syn(&tp), "build");
+	struct pkt_snapshot s;
+	snapshot(&tp.packet, &s);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+	);
+	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_skip_non_tcp(void) {
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(build_ip6_udp(&tp), "build");
+	struct pkt_snapshot s;
+	snapshot(&tp.packet, &s);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+	);
+	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_skip_non_syn(void) {
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp, RTE_TCP_ACK_FLAG, NULL, 0, 0, DEFAULT_HEADROOM, 1
+		),
+		"build"
+	);
+	struct pkt_snapshot s;
+	snapshot(&tp.packet, &s);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+	);
+	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_skip_syn_rst(void) {
+	uint8_t opts[4];
+	write_mss_opt(opts, 1460);
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp,
+			RTE_TCP_SYN_FLAG | RTE_TCP_RST_FLAG,
+			opts,
+			4,
+			0,
+			DEFAULT_HEADROOM,
+			1
+		),
+		"build"
+	);
+	struct pkt_snapshot s;
+	snapshot(&tp.packet, &s);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+	);
+	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_malformed_len_zero(void) {
+	/* kind=8 (TS) but len=0 — variable-length option must have len >= 2. */
+	uint8_t opts[4] = {8, 0, 0, 0};
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+		),
+		"build"
+	);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300),
+		packet_fix_mss_malformed,
+		"rc"
+	);
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_malformed_overrun(void) {
+	/* MSS kind=2 with len=6 would overrun an 8-byte options area that
+	 * actually declares 4 bytes; we use an 8-byte options area with an
+	 * initial non-MSS variable-length option whose len overruns. */
+	uint8_t opts[8] = {30, 10, 0, 0, 0, 0, 0, 0};
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp, RTE_TCP_SYN_FLAG, opts, 8, 0, DEFAULT_HEADROOM, 1
+		),
+		"build"
+	);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300),
+		packet_fix_mss_malformed,
+		"rc"
+	);
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_eol_respected(void) {
+	uint8_t opts[4] = {TCP_OPT_KIND_NOP, TCP_OPT_KIND_EOL, 0xFF, 0xFF};
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+		),
+		"build"
+	);
+	uint32_t pkt_len_before = rte_pktmbuf_pkt_len(tp.mbuf);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+	);
+	TEST_ASSERT_EQUAL(
+		rte_pktmbuf_pkt_len(tp.mbuf),
+		pkt_len_before + 4u,
+		"insert did not grow packet"
+	);
+	struct rte_tcp_hdr *tcp = pkt_tcp(&tp.packet);
+	uint8_t *new_opt = (uint8_t *)(tcp + 1);
+	TEST_ASSERT_EQUAL(new_opt[0], TCP_OPT_KIND_MSS, "new opt kind");
+	TEST_ASSERT_EQUAL(new_opt[1], 4, "new opt len");
+	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&tp.packet), "cksum");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_no_headroom(void) {
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(&tp, RTE_TCP_SYN_FLAG, NULL, 0, 0, 0, 1), "build"
+	);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300),
+		packet_fix_mss_no_headroom,
+		"rc"
+	);
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_malformed_mss_wrong_len(void) {
+	/* MSS with len=6 instead of 4. */
+	uint8_t opts[8] = {TCP_OPT_KIND_MSS, 6, 0x05, 0xB4, 0, 0, 0, 0};
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp, RTE_TCP_SYN_FLAG, opts, 8, 0, DEFAULT_HEADROOM, 1
+		),
+		"build"
+	);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300),
+		packet_fix_mss_malformed,
+		"rc"
+	);
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_malformed_data_off_short(void) {
+	/* data_off = 4 (16 bytes) < fixed 20-byte TCP header. */
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp,
+			RTE_TCP_SYN_FLAG,
+			NULL,
+			0,
+			/*data_off_override=*/4,
+			DEFAULT_HEADROOM,
+			0
+		),
+		"build"
+	);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300),
+		packet_fix_mss_malformed,
+		"rc"
+	);
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_malformed_hdr_full_60(void) {
+	/* data_off = 15 (60 bytes) with 40 bytes of NOP options, no MSS:
+	 * find_mss_option returns absent; insert_mss_option refuses because
+	 * hdr_len + 4 > 60. */
+	uint8_t opts[40];
+	memset(opts, TCP_OPT_KIND_NOP, sizeof(opts));
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp,
+			RTE_TCP_SYN_FLAG,
+			opts,
+			sizeof(opts),
+			0,
+			DEFAULT_HEADROOM,
+			1
+		),
+		"build"
+	);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300),
+		packet_fix_mss_malformed,
+		"rc"
+	);
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+static int
+test_clamp_syn_ack(void) {
+	uint8_t opts[4];
+	write_mss_opt(opts, 1460);
+	struct test_pkt tp;
+	TEST_ASSERT_SUCCESS(
+		build_ip6_tcp(
+			&tp,
+			RTE_TCP_SYN_FLAG | RTE_TCP_ACK_FLAG,
+			opts,
+			4,
+			0,
+			DEFAULT_HEADROOM,
+			1
+		),
+		"build"
+	);
+
+	TEST_ASSERT_EQUAL(
+		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+	);
+	struct rte_tcp_hdr *tcp = pkt_tcp(&tp.packet);
+	uint16_t *mss_field = (uint16_t *)((uint8_t *)(tcp + 1) + 2);
+	TEST_ASSERT_EQUAL(
+		rte_be_to_cpu_16(*mss_field), 1200, "MSS not clamped on SYN+ACK"
+	);
+	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&tp.packet), "cksum");
+
+	free_test_pkt(&tp);
+	return TEST_SUCCESS;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	LOG(INFO, "running mss tests...");
+
+	TEST_ASSERT_SUCCESS(test_clamp_gt(), "clamp_gt");
+	TEST_ASSERT_SUCCESS(test_clamp_lt(), "clamp_lt");
+	TEST_ASSERT_SUCCESS(test_clamp_eq(), "clamp_eq");
+	TEST_ASSERT_SUCCESS(test_insert_no_mss(), "insert_no_mss");
+	TEST_ASSERT_SUCCESS(test_skip_ipv4(), "skip_ipv4");
+	TEST_ASSERT_SUCCESS(test_skip_non_tcp(), "skip_non_tcp");
+	TEST_ASSERT_SUCCESS(test_skip_non_syn(), "skip_non_syn");
+	TEST_ASSERT_SUCCESS(test_skip_syn_rst(), "skip_syn_rst");
+	TEST_ASSERT_SUCCESS(test_malformed_len_zero(), "malformed_len_zero");
+	TEST_ASSERT_SUCCESS(test_malformed_overrun(), "malformed_overrun");
+	TEST_ASSERT_SUCCESS(test_eol_respected(), "eol_respected");
+	TEST_ASSERT_SUCCESS(test_no_headroom(), "no_headroom");
+	TEST_ASSERT_SUCCESS(
+		test_malformed_mss_wrong_len(), "malformed_mss_wrong_len"
+	);
+	TEST_ASSERT_SUCCESS(
+		test_malformed_data_off_short(), "malformed_data_off_short"
+	);
+	TEST_ASSERT_SUCCESS(
+		test_malformed_hdr_full_60(), "malformed_hdr_full_60"
+	);
+	TEST_ASSERT_SUCCESS(test_clamp_syn_ack(), "clamp_syn_ack");
+
+	LOG(INFO, "all mss tests passed");
+
+	return 0;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -7,3 +7,4 @@ subdir('controlplane')
 subdir('utils')
 subdir('fwstate') # depends on dataplane lib
 subdir('fuzzing')
+subdir('tests') # depends on utils lib

--- a/lib/tests/dataplane/meson.build
+++ b/lib/tests/dataplane/meson.build
@@ -1,0 +1,14 @@
+mss_test = executable(
+  'mss_test',
+  'mss_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_packet_dp_dep,
+    lib_lib_utils_dep,
+    lib_logging_dep,
+    libdpdk_dep,
+  ],
+  include_directories: yanet_rootdir,
+)
+test('mss', mss_test, suite: 'lib_packet')

--- a/lib/tests/dataplane/mss_test.c
+++ b/lib/tests/dataplane/mss_test.c
@@ -1,7 +1,5 @@
 #include <netinet/in.h>
-#include <stdalign.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include <rte_byteorder.h>
@@ -12,9 +10,12 @@
 #include <rte_udp.h>
 
 #include "common/test_assert.h"
+
+#include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/mss.h"
 #include "lib/dataplane/packet/packet.h"
-#include "logging/log.h"
+#include "lib/logging/log.h"
+#include "lib/utils/packet.h"
 
 #define TCP_OPT_KIND_EOL 0
 #define TCP_OPT_KIND_NOP 1
@@ -25,47 +26,7 @@
 
 #define SNAPSHOT_CAP 512
 
-////////////////////////////////////////////////////////////////////////////////
 // Packet construction helpers
-
-struct test_pkt {
-	struct packet packet;
-	struct rte_mbuf *mbuf;
-};
-
-static void
-free_test_pkt(struct test_pkt *tp) {
-	free(tp->mbuf);
-	tp->mbuf = NULL;
-}
-
-static int
-alloc_mbuf(struct test_pkt *tp, uint16_t headroom, uint16_t pkt_len, uint16_t tailroom) {
-	size_t buf_len = (size_t)headroom + pkt_len;
-	size_t mbuf_size = sizeof(struct rte_mbuf) + buf_len + tailroom;
-	size_t align = alignof(struct rte_mbuf);
-	if (mbuf_size % align != 0) {
-		mbuf_size += align - mbuf_size % align;
-	}
-	struct rte_mbuf *mbuf = aligned_alloc(align, mbuf_size);
-	if (!mbuf) {
-		return -1;
-	}
-	memset(mbuf, 0, sizeof(*mbuf));
-	mbuf->buf_addr = (char *)mbuf + sizeof(struct rte_mbuf);
-	mbuf->buf_len = buf_len;
-	mbuf->data_off = headroom;
-	mbuf->data_len = pkt_len;
-	mbuf->pkt_len = pkt_len;
-	mbuf->nb_segs = 1;
-	rte_mbuf_refcnt_set(mbuf, 1);
-
-	memset(rte_pktmbuf_mtod(mbuf, void *), 0, pkt_len);
-	tp->mbuf = mbuf;
-	memset(&tp->packet, 0, sizeof(tp->packet));
-	tp->packet.mbuf = mbuf;
-	return 0;
-}
 
 /* Build IPv6 + TCP packet. `data_off_override` = 0 means compute from opt_len,
  * otherwise write the given value verbatim (allowing malformed headers).
@@ -73,7 +34,7 @@ alloc_mbuf(struct test_pkt *tp, uint16_t headroom, uint16_t pkt_len, uint16_t ta
  * at whatever memset produced. */
 static int
 build_ip6_tcp(
-	struct test_pkt *tp,
+	struct packet *p,
 	uint8_t tcp_flags,
 	const uint8_t *opts,
 	uint16_t opt_len,
@@ -85,11 +46,13 @@ build_ip6_tcp(
 	uint16_t pkt_len = sizeof(struct rte_ether_hdr) +
 			   sizeof(struct rte_ipv6_hdr) + l4_len;
 
-	if (alloc_mbuf(tp, headroom, pkt_len, DEFAULT_TAILROOM) != 0) {
+	memset(p, 0, sizeof(*p));
+	p->mbuf = alloc_mbuf(headroom, pkt_len, DEFAULT_TAILROOM);
+	if (!p->mbuf) {
 		return -1;
 	}
 
-	uint8_t *data = rte_pktmbuf_mtod(tp->mbuf, uint8_t *);
+	uint8_t *data = rte_pktmbuf_mtod(p->mbuf, uint8_t *);
 	struct rte_ether_hdr *eth = (struct rte_ether_hdr *)data;
 	eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6);
 
@@ -126,24 +89,26 @@ build_ip6_tcp(
 		tcp->cksum = rte_ipv6_udptcp_cksum(ip6, tcp);
 	}
 
-	if (parse_packet(&tp->packet) != 0) {
-		free_test_pkt(tp);
+	if (parse_packet(p) != 0) {
+		free_packet(p);
 		return -1;
 	}
 	return 0;
 }
 
 static int
-build_ip6_udp(struct test_pkt *tp) {
+build_ip6_udp(struct packet *p) {
 	uint16_t l4_len = sizeof(struct rte_udp_hdr);
 	uint16_t pkt_len = sizeof(struct rte_ether_hdr) +
 			   sizeof(struct rte_ipv6_hdr) + l4_len;
 
-	if (alloc_mbuf(tp, DEFAULT_HEADROOM, pkt_len, DEFAULT_TAILROOM) != 0) {
+	memset(p, 0, sizeof(*p));
+	p->mbuf = alloc_mbuf(DEFAULT_HEADROOM, pkt_len, DEFAULT_TAILROOM);
+	if (!p->mbuf) {
 		return -1;
 	}
 
-	uint8_t *data = rte_pktmbuf_mtod(tp->mbuf, uint8_t *);
+	uint8_t *data = rte_pktmbuf_mtod(p->mbuf, uint8_t *);
 	struct rte_ether_hdr *eth = (struct rte_ether_hdr *)data;
 	eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6);
 
@@ -162,20 +127,22 @@ build_ip6_udp(struct test_pkt *tp) {
 	udp->dgram_len = rte_cpu_to_be_16(sizeof(*udp));
 	udp->dgram_cksum = 0;
 
-	return parse_packet(&tp->packet);
+	return parse_packet(p);
 }
 
 static int
-build_ip4_tcp_syn(struct test_pkt *tp) {
+build_ip4_tcp_syn(struct packet *p) {
 	uint16_t pkt_len = sizeof(struct rte_ether_hdr) +
 			   sizeof(struct rte_ipv4_hdr) +
 			   sizeof(struct rte_tcp_hdr);
 
-	if (alloc_mbuf(tp, DEFAULT_HEADROOM, pkt_len, DEFAULT_TAILROOM) != 0) {
+	memset(p, 0, sizeof(*p));
+	p->mbuf = alloc_mbuf(DEFAULT_HEADROOM, pkt_len, DEFAULT_TAILROOM);
+	if (!p->mbuf) {
 		return -1;
 	}
 
-	uint8_t *data = rte_pktmbuf_mtod(tp->mbuf, uint8_t *);
+	uint8_t *data = rte_pktmbuf_mtod(p->mbuf, uint8_t *);
 	struct rte_ether_hdr *eth = (struct rte_ether_hdr *)data;
 	eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
 
@@ -197,10 +164,9 @@ build_ip4_tcp_syn(struct test_pkt *tp) {
 	tcp->rx_win = rte_cpu_to_be_16(65535);
 	tcp->cksum = 0;
 
-	return parse_packet(&tp->packet);
+	return parse_packet(p);
 }
 
-////////////////////////////////////////////////////////////////////////////////
 // Accessors and verifiers
 
 static struct rte_ipv6_hdr *
@@ -253,9 +219,7 @@ snapshot(struct packet *p, struct pkt_snapshot *s) {
 
 static int
 assert_unchanged(struct packet *p, const struct pkt_snapshot *s) {
-	TEST_ASSERT_EQUAL(
-		rte_pktmbuf_pkt_len(p->mbuf), s->pkt_len, "pkt_len changed"
-	);
+	TEST_ASSERT_EQUAL(packet_data_len(p), s->pkt_len, "pkt_len changed");
 	TEST_ASSERT_EQUAL(p->mbuf->data_off, s->data_off, "data_off changed");
 	TEST_ASSERT(
 		memcmp(rte_pktmbuf_mtod(p->mbuf, void *), s->data, s->pkt_len
@@ -265,7 +229,6 @@ assert_unchanged(struct packet *p, const struct pkt_snapshot *s) {
 	return TEST_SUCCESS;
 }
 
-////////////////////////////////////////////////////////////////////////////////
 // MSS option builders
 
 static void
@@ -276,43 +239,41 @@ write_mss_opt(uint8_t *dst, uint16_t mss) {
 	memcpy(dst + 2, &be, 2);
 }
 
-////////////////////////////////////////////////////////////////////////////////
 // Test cases
 
 static int
 test_clamp_gt(void) {
 	uint8_t opts[4];
 	write_mss_opt(opts, 1460);
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+			&p, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
 		),
 		"build"
 	);
 
-	uint16_t ip6_len_before =
-		rte_be_to_cpu_16(pkt_ip6(&tp.packet)->payload_len);
-	uint8_t data_off_before = pkt_tcp(&tp.packet)->data_off;
+	uint16_t ip6_len_before = rte_be_to_cpu_16(pkt_ip6(&p)->payload_len);
+	uint8_t data_off_before = pkt_tcp(&p)->data_off;
 
-	enum packet_fix_mss_result rc = packet_fix_mss(&tp.packet, 1200, 1300);
-	TEST_ASSERT_EQUAL(rc, packet_fix_mss_ok, "rc");
+	enum packet_set_mss_result rc = packet_set_mss(&p, 1200, 1300);
+	TEST_ASSERT_EQUAL(rc, packet_set_mss_ok, "rc");
 
-	struct rte_tcp_hdr *tcp = pkt_tcp(&tp.packet);
+	struct rte_tcp_hdr *tcp = pkt_tcp(&p);
 	uint16_t *mss_field =
 		(uint16_t *)((uint8_t *)(tcp + 1) + 2); /* after kind+len */
 	TEST_ASSERT_EQUAL(
 		rte_be_to_cpu_16(*mss_field), 1200, "MSS not clamped"
 	);
 	TEST_ASSERT_EQUAL(
-		rte_be_to_cpu_16(pkt_ip6(&tp.packet)->payload_len),
+		rte_be_to_cpu_16(pkt_ip6(&p)->payload_len),
 		ip6_len_before,
 		"payload_len changed"
 	);
 	TEST_ASSERT_EQUAL(tcp->data_off, data_off_before, "data_off changed");
-	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&tp.packet), "cksum");
+	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&p), "cksum");
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
@@ -320,22 +281,22 @@ static int
 test_clamp_lt(void) {
 	uint8_t opts[4];
 	write_mss_opt(opts, 1000);
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+			&p, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
 		),
 		"build"
 	);
 	struct pkt_snapshot s;
-	snapshot(&tp.packet, &s);
+	snapshot(&p, &s);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_ok, "rc"
 	);
-	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+	TEST_ASSERT_SUCCESS(assert_unchanged(&p, &s), "unchanged");
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
@@ -343,121 +304,123 @@ static int
 test_clamp_eq(void) {
 	uint8_t opts[4];
 	write_mss_opt(opts, 1200);
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+			&p, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
 		),
 		"build"
 	);
 	struct pkt_snapshot s;
-	snapshot(&tp.packet, &s);
+	snapshot(&p, &s);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_ok, "rc"
 	);
-	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+	TEST_ASSERT_SUCCESS(assert_unchanged(&p, &s), "unchanged");
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
 static int
 test_insert_no_mss(void) {
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp, RTE_TCP_SYN_FLAG, NULL, 0, 0, DEFAULT_HEADROOM, 1
+			&p, RTE_TCP_SYN_FLAG, NULL, 0, 0, DEFAULT_HEADROOM, 1
 		),
 		"build"
 	);
-	uint32_t pkt_len_before = rte_pktmbuf_pkt_len(tp.mbuf);
-	uint16_t ip6_len_before =
-		rte_be_to_cpu_16(pkt_ip6(&tp.packet)->payload_len);
-	uint8_t data_off_before = pkt_tcp(&tp.packet)->data_off;
+	uint32_t pkt_len_before = rte_pktmbuf_pkt_len(p.mbuf);
+	uint16_t ip6_len_before = rte_be_to_cpu_16(pkt_ip6(&p)->payload_len);
+	uint8_t data_off_before = pkt_tcp(&p)->data_off;
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_ok, "rc"
 	);
 
 	TEST_ASSERT_EQUAL(
-		rte_pktmbuf_pkt_len(tp.mbuf),
+		rte_pktmbuf_pkt_len(p.mbuf),
 		pkt_len_before + 4u,
 		"pkt_len did not grow by 4"
 	);
-	struct rte_tcp_hdr *tcp = pkt_tcp(&tp.packet);
+
+	struct rte_tcp_hdr *tcp = pkt_tcp(&p);
 	TEST_ASSERT_EQUAL(
 		tcp->data_off,
 		data_off_before + (1 << 4),
 		"data_off not +1 word"
 	);
+
 	TEST_ASSERT_EQUAL(
-		rte_be_to_cpu_16(pkt_ip6(&tp.packet)->payload_len),
+		rte_be_to_cpu_16(pkt_ip6(&p)->payload_len),
 		ip6_len_before + 4,
 		"IPv6 payload_len not +4"
 	);
+
 	uint8_t *opt = (uint8_t *)(tcp + 1);
 	TEST_ASSERT_EQUAL(opt[0], TCP_OPT_KIND_MSS, "opt kind");
 	TEST_ASSERT_EQUAL(opt[1], 4, "opt len");
 	uint16_t mss_be;
 	memcpy(&mss_be, opt + 2, 2);
 	TEST_ASSERT_EQUAL(rte_be_to_cpu_16(mss_be), 1300, "inserted MSS");
-	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&tp.packet), "cksum");
+	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&p), "cksum");
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
 static int
 test_skip_ipv4(void) {
-	struct test_pkt tp;
-	TEST_ASSERT_SUCCESS(build_ip4_tcp_syn(&tp), "build");
+	struct packet p;
+	TEST_ASSERT_SUCCESS(build_ip4_tcp_syn(&p), "build");
 	struct pkt_snapshot s;
-	snapshot(&tp.packet, &s);
+	snapshot(&p, &s);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_ok, "rc"
 	);
-	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+	TEST_ASSERT_SUCCESS(assert_unchanged(&p, &s), "unchanged");
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
 static int
 test_skip_non_tcp(void) {
-	struct test_pkt tp;
-	TEST_ASSERT_SUCCESS(build_ip6_udp(&tp), "build");
+	struct packet p;
+	TEST_ASSERT_SUCCESS(build_ip6_udp(&p), "build");
 	struct pkt_snapshot s;
-	snapshot(&tp.packet, &s);
+	snapshot(&p, &s);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_ok, "rc"
 	);
-	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+	TEST_ASSERT_SUCCESS(assert_unchanged(&p, &s), "unchanged");
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
 static int
 test_skip_non_syn(void) {
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp, RTE_TCP_ACK_FLAG, NULL, 0, 0, DEFAULT_HEADROOM, 1
+			&p, RTE_TCP_ACK_FLAG, NULL, 0, 0, DEFAULT_HEADROOM, 1
 		),
 		"build"
 	);
 	struct pkt_snapshot s;
-	snapshot(&tp.packet, &s);
+	snapshot(&p, &s);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_ok, "rc"
 	);
-	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+	TEST_ASSERT_SUCCESS(assert_unchanged(&p, &s), "unchanged");
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
@@ -465,10 +428,10 @@ static int
 test_skip_syn_rst(void) {
 	uint8_t opts[4];
 	write_mss_opt(opts, 1460);
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp,
+			&p,
 			RTE_TCP_SYN_FLAG | RTE_TCP_RST_FLAG,
 			opts,
 			4,
@@ -479,36 +442,34 @@ test_skip_syn_rst(void) {
 		"build"
 	);
 	struct pkt_snapshot s;
-	snapshot(&tp.packet, &s);
+	snapshot(&p, &s);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_ok, "rc"
 	);
-	TEST_ASSERT_SUCCESS(assert_unchanged(&tp.packet, &s), "unchanged");
+	TEST_ASSERT_SUCCESS(assert_unchanged(&p, &s), "unchanged");
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
 static int
 test_malformed_len_zero(void) {
-	/* kind=8 (TS) but len=0 — variable-length option must have len >= 2. */
+	/* kind=8 but len=0 — variable-length option must have len >= 2. */
 	uint8_t opts[4] = {8, 0, 0, 0};
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+			&p, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
 		),
 		"build"
 	);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300),
-		packet_fix_mss_malformed,
-		"rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_malformed, "rc"
 	);
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
@@ -518,68 +479,65 @@ test_malformed_overrun(void) {
 	 * actually declares 4 bytes; we use an 8-byte options area with an
 	 * initial non-MSS variable-length option whose len overruns. */
 	uint8_t opts[8] = {30, 10, 0, 0, 0, 0, 0, 0};
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp, RTE_TCP_SYN_FLAG, opts, 8, 0, DEFAULT_HEADROOM, 1
+			&p, RTE_TCP_SYN_FLAG, opts, 8, 0, DEFAULT_HEADROOM, 1
 		),
 		"build"
 	);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300),
-		packet_fix_mss_malformed,
-		"rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_malformed, "rc"
 	);
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
 static int
 test_eol_respected(void) {
 	uint8_t opts[4] = {TCP_OPT_KIND_NOP, TCP_OPT_KIND_EOL, 0xFF, 0xFF};
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
+			&p, RTE_TCP_SYN_FLAG, opts, 4, 0, DEFAULT_HEADROOM, 1
 		),
 		"build"
 	);
-	uint32_t pkt_len_before = rte_pktmbuf_pkt_len(tp.mbuf);
+	uint32_t pkt_len_before = rte_pktmbuf_pkt_len(p.mbuf);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_ok, "rc"
 	);
 	TEST_ASSERT_EQUAL(
-		rte_pktmbuf_pkt_len(tp.mbuf),
+		rte_pktmbuf_pkt_len(p.mbuf),
 		pkt_len_before + 4u,
 		"insert did not grow packet"
 	);
-	struct rte_tcp_hdr *tcp = pkt_tcp(&tp.packet);
+	struct rte_tcp_hdr *tcp = pkt_tcp(&p);
 	uint8_t *new_opt = (uint8_t *)(tcp + 1);
 	TEST_ASSERT_EQUAL(new_opt[0], TCP_OPT_KIND_MSS, "new opt kind");
 	TEST_ASSERT_EQUAL(new_opt[1], 4, "new opt len");
-	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&tp.packet), "cksum");
 
-	free_test_pkt(&tp);
+	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&p), "cksum");
+
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
 static int
 test_no_headroom(void) {
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
-		build_ip6_tcp(&tp, RTE_TCP_SYN_FLAG, NULL, 0, 0, 0, 1), "build"
+		build_ip6_tcp(&p, RTE_TCP_SYN_FLAG, NULL, 0, 0, 0, 1), "build"
 	);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300),
-		packet_fix_mss_no_headroom,
-		"rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_no_headroom, "rc"
 	);
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
@@ -587,31 +545,29 @@ static int
 test_malformed_mss_wrong_len(void) {
 	/* MSS with len=6 instead of 4. */
 	uint8_t opts[8] = {TCP_OPT_KIND_MSS, 6, 0x05, 0xB4, 0, 0, 0, 0};
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp, RTE_TCP_SYN_FLAG, opts, 8, 0, DEFAULT_HEADROOM, 1
+			&p, RTE_TCP_SYN_FLAG, opts, 8, 0, DEFAULT_HEADROOM, 1
 		),
 		"build"
 	);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300),
-		packet_fix_mss_malformed,
-		"rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_malformed, "rc"
 	);
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
 static int
 test_malformed_data_off_short(void) {
 	/* data_off = 4 (16 bytes) < fixed 20-byte TCP header. */
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp,
+			&p,
 			RTE_TCP_SYN_FLAG,
 			NULL,
 			0,
@@ -623,12 +579,10 @@ test_malformed_data_off_short(void) {
 	);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300),
-		packet_fix_mss_malformed,
-		"rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_malformed, "rc"
 	);
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
@@ -639,10 +593,10 @@ test_malformed_hdr_full_60(void) {
 	 * hdr_len + 4 > 60. */
 	uint8_t opts[40];
 	memset(opts, TCP_OPT_KIND_NOP, sizeof(opts));
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp,
+			&p,
 			RTE_TCP_SYN_FLAG,
 			opts,
 			sizeof(opts),
@@ -654,12 +608,10 @@ test_malformed_hdr_full_60(void) {
 	);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300),
-		packet_fix_mss_malformed,
-		"rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_malformed, "rc"
 	);
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
@@ -667,10 +619,10 @@ static int
 test_clamp_syn_ack(void) {
 	uint8_t opts[4];
 	write_mss_opt(opts, 1460);
-	struct test_pkt tp;
+	struct packet p;
 	TEST_ASSERT_SUCCESS(
 		build_ip6_tcp(
-			&tp,
+			&p,
 			RTE_TCP_SYN_FLAG | RTE_TCP_ACK_FLAG,
 			opts,
 			4,
@@ -682,51 +634,66 @@ test_clamp_syn_ack(void) {
 	);
 
 	TEST_ASSERT_EQUAL(
-		packet_fix_mss(&tp.packet, 1200, 1300), packet_fix_mss_ok, "rc"
+		packet_set_mss(&p, 1200, 1300), packet_set_mss_ok, "rc"
 	);
-	struct rte_tcp_hdr *tcp = pkt_tcp(&tp.packet);
+	struct rte_tcp_hdr *tcp = pkt_tcp(&p);
 	uint16_t *mss_field = (uint16_t *)((uint8_t *)(tcp + 1) + 2);
 	TEST_ASSERT_EQUAL(
 		rte_be_to_cpu_16(*mss_field), 1200, "MSS not clamped on SYN+ACK"
 	);
-	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&tp.packet), "cksum");
+	TEST_ASSERT_SUCCESS(verify_ip6_tcp_cksum(&p), "cksum");
 
-	free_test_pkt(&tp);
+	free_packet(&p);
 	return TEST_SUCCESS;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
 int
 main(void) {
-	log_enable_name("debug");
+	log_enable_name("info");
 
-	LOG(INFO, "running mss tests...");
+	LOG(INFO, "=== Starting MSS Test Suite ===");
 
-	TEST_ASSERT_SUCCESS(test_clamp_gt(), "clamp_gt");
-	TEST_ASSERT_SUCCESS(test_clamp_lt(), "clamp_lt");
-	TEST_ASSERT_SUCCESS(test_clamp_eq(), "clamp_eq");
-	TEST_ASSERT_SUCCESS(test_insert_no_mss(), "insert_no_mss");
-	TEST_ASSERT_SUCCESS(test_skip_ipv4(), "skip_ipv4");
-	TEST_ASSERT_SUCCESS(test_skip_non_tcp(), "skip_non_tcp");
-	TEST_ASSERT_SUCCESS(test_skip_non_syn(), "skip_non_syn");
-	TEST_ASSERT_SUCCESS(test_skip_syn_rst(), "skip_syn_rst");
-	TEST_ASSERT_SUCCESS(test_malformed_len_zero(), "malformed_len_zero");
-	TEST_ASSERT_SUCCESS(test_malformed_overrun(), "malformed_overrun");
-	TEST_ASSERT_SUCCESS(test_eol_respected(), "eol_respected");
-	TEST_ASSERT_SUCCESS(test_no_headroom(), "no_headroom");
-	TEST_ASSERT_SUCCESS(
-		test_malformed_mss_wrong_len(), "malformed_mss_wrong_len"
-	);
-	TEST_ASSERT_SUCCESS(
-		test_malformed_data_off_short(), "malformed_data_off_short"
-	);
-	TEST_ASSERT_SUCCESS(
-		test_malformed_hdr_full_60(), "malformed_hdr_full_60"
-	);
-	TEST_ASSERT_SUCCESS(test_clamp_syn_ack(), "clamp_syn_ack");
+	struct {
+		const char *name;
+		int (*fn)(void);
+	} tests[] = {
+		{"clamp_gt", test_clamp_gt},
+		{"clamp_lt", test_clamp_lt},
+		{"clamp_eq", test_clamp_eq},
+		{"insert_no_mss", test_insert_no_mss},
+		{"skip_ipv4", test_skip_ipv4},
+		{"skip_non_tcp", test_skip_non_tcp},
+		{"skip_non_syn", test_skip_non_syn},
+		{"skip_syn_rst", test_skip_syn_rst},
+		{"malformed_len_zero", test_malformed_len_zero},
+		{"malformed_overrun", test_malformed_overrun},
+		{"eol_respected", test_eol_respected},
+		{"no_headroom", test_no_headroom},
+		{"malformed_mss_wrong_len", test_malformed_mss_wrong_len},
+		{"malformed_data_off_short", test_malformed_data_off_short},
+		{"malformed_hdr_full_60", test_malformed_hdr_full_60},
+		{"clamp_syn_ack", test_clamp_syn_ack},
+	};
 
-	LOG(INFO, "all mss tests passed");
+	size_t total = sizeof(tests) / sizeof(tests[0]);
+	size_t failed = 0;
 
-	return 0;
+	for (size_t i = 0; i < total; i++) {
+		LOG(INFO, "[%zu/%zu] running %s...", i + 1, total, tests[i].name
+		);
+		if (tests[i].fn() != TEST_SUCCESS) {
+			LOG(ERROR, "%s FAILED", tests[i].name);
+			failed++;
+		} else {
+			LOG(INFO, "%s passed", tests[i].name);
+		}
+	}
+
+	if (failed == 0) {
+		LOG(INFO, "=== All %zu MSS tests passed! ===", total);
+	} else {
+		LOG(ERROR, "=== %zu/%zu MSS tests failed ===", failed, total);
+	}
+
+	return failed == 0 ? TEST_SUCCESS : TEST_FAILED;
 }

--- a/lib/tests/meson.build
+++ b/lib/tests/meson.build
@@ -1,0 +1,1 @@
+subdir('dataplane')

--- a/lib/utils/packet.c
+++ b/lib/utils/packet.c
@@ -9,12 +9,12 @@
 #include <rte_udp.h>
 
 #include <assert.h>
+#include <stdalign.h>
 #include <stdlib.h>
 
 #include <rte_build_config.h>
 #include <string.h>
 
-#include "lib/dataplane/module/packet_front.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/packet.h"
 #include "yanet_build_config.h"
@@ -234,6 +234,28 @@ free_packet(struct packet *packet) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+struct rte_mbuf *
+alloc_mbuf(uint16_t headroom, uint16_t pkt_len, uint16_t tailroom) {
+	size_t buf_len = (size_t)headroom + pkt_len;
+	size_t mbuf_size = sizeof(struct rte_mbuf) + buf_len + tailroom;
+	size_t align = alignof(struct rte_mbuf);
+	mbuf_size += (align - mbuf_size % align) % align;
+	struct rte_mbuf *mbuf = aligned_alloc(align, mbuf_size);
+	if (!mbuf) {
+		return NULL;
+	}
+	memset(mbuf, 0, sizeof(*mbuf));
+	mbuf->buf_addr = (char *)mbuf + sizeof(struct rte_mbuf);
+	mbuf->buf_len = buf_len;
+	mbuf->data_off = headroom;
+	mbuf->data_len = pkt_len;
+	mbuf->pkt_len = pkt_len;
+	mbuf->nb_segs = 1;
+	rte_mbuf_refcnt_set(mbuf, 1);
+	memset(rte_pktmbuf_mtod(mbuf, void *), 0, pkt_len);
+	return mbuf;
+}
 
 void
 init_mbuf(struct rte_mbuf *m, struct packet_info *data, uint16_t buf_len) {

--- a/lib/utils/packet.h
+++ b/lib/utils/packet.h
@@ -104,3 +104,15 @@ fill_packet_from_data(struct packet *packet, struct packet_info *data);
 
 void
 init_mbuf(struct rte_mbuf *m, struct packet_info *data, uint16_t buf_len);
+
+////////////////////////////////////////////////////////////////////////////////
+
+/// Allocate an mbuf using the default C allocator (aligned_alloc).
+///
+/// The buffer is laid out as `headroom + pkt_len + tailroom`; the data area is
+/// zeroed and refcount is initialised to 1. The caller owns the returned mbuf
+/// and must release it with free().
+///
+/// Returns NULL on allocation failure.
+struct rte_mbuf *
+alloc_mbuf(uint16_t headroom, uint16_t pkt_len, uint16_t tailroom);


### PR DESCRIPTION
## Summary

- Introduce `lib/dataplane/packet/mss.{c,h}` with `packet_fix_mss(packet, clamp_mss, insert_mss)` — a single-pass MSS normalizer for IPv6 TCP SYN packets.
- Two independent MSS parameters (clamp ceiling vs. insert fallback).
- Structured `enum packet_fix_mss_result` so callers can distinguish `ok`, `malformed`, and `no_headroom` for metrics instead of a silent void return.

## Test plan

- [x] Clamp path: IPv6 TCP SYN with MSS > clamp → option rewritten, TCP checksum valid
- [x] No-op path: IPv6 TCP SYN with MSS ≤ clamp → packet unchanged
- [x] Insert path: IPv6 TCP SYN with no MSS → option inserted, TCP checksum + IPv6 payload length updated
- [x] Skip paths: IPv4, non-TCP, non-SYN, SYN+RST → untouched, returns `ok`
- [x] Malformed options (`len == 0`, declared length overruns data offset, mid-options EOL) → returns `malformed`
- [x] Zero-headroom mbuf with no MSS option → returns `no_headroom`
