### PR TITLE
refactor(encap): simplify packet_ip[46]_encap and document encap.h

### DIFF
--- a/lib/dataplane/packet/encap.c
+++ b/lib/dataplane/packet/encap.c
@@ -206,7 +206,7 @@ packet_mpls_encap(
 }
 
 int
-packet_encap_ip4_udp(
+packet_ipv4_encap_udp(
 	struct packet *packet,
 	const uint8_t *src_ip,
 	const uint8_t *dst_ip,
@@ -272,7 +272,7 @@ packet_encap_ip4_udp(
 }
 
 int
-packet_encap_ip6_udp(
+packet_ip6_encap_udp(
 	struct packet *packet,
 	const uint8_t *src_ip,
 	const uint8_t *dst_ip,

--- a/lib/dataplane/packet/encap.c
+++ b/lib/dataplane/packet/encap.c
@@ -186,7 +186,7 @@ packet_mpls_encap(
 }
 
 int
-packet_ipv4_encap_udp(
+packet_ip4_encap_udp(
 	struct packet *packet,
 	const uint8_t *src_ip,
 	const uint8_t *dst_ip,

--- a/lib/dataplane/packet/encap.c
+++ b/lib/dataplane/packet/encap.c
@@ -6,6 +6,7 @@
 #include <rte_udp.h>
 
 #include "common/checksum.h"
+#include "common/network.h"
 #include "lib/dataplane/packet/data.h"
 
 int
@@ -46,7 +47,7 @@ packet_network_prepend(
 
 	packet->transport_header.offset += size;
 
-	// FIXME previos heade type (ex: vlan)
+	// FIXME previous header type (ex: vlan)
 	uint16_t *next_hdr_type = rte_pktmbuf_mtod_offset(
 		mbuf, uint16_t *, packet->network_header.offset - 2
 	);
@@ -61,70 +62,60 @@ packet_ip4_encap(
 ) {
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
-	struct rte_ipv4_hdr *ipv4_hdr_inner = NULL;
-	struct rte_ipv6_hdr *ipv6_hdr_inner = NULL;
+	struct rte_ipv4_hdr outer_hdr;
+	rte_memcpy(&outer_hdr.src_addr, src, NET4_LEN);
+	rte_memcpy(&outer_hdr.dst_addr, dst, NET4_LEN);
+	outer_hdr.version_ihl = 0x45;
 
 	if (packet->network_header.type ==
 	    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
-		ipv4_hdr_inner = rte_pktmbuf_mtod_offset(
+		struct rte_ipv4_hdr *inner_hdr = rte_pktmbuf_mtod_offset(
 			mbuf,
 			struct rte_ipv4_hdr *,
 			packet->network_header.offset
 		);
+		outer_hdr.type_of_service = inner_hdr->type_of_service;
+		outer_hdr.total_length = rte_cpu_to_be_16(
+			sizeof(struct rte_ipv4_hdr) +
+			rte_be_to_cpu_16(inner_hdr->total_length)
+		);
+
+		outer_hdr.packet_id = inner_hdr->packet_id;
+		outer_hdr.fragment_offset = inner_hdr->fragment_offset;
+		outer_hdr.time_to_live = inner_hdr->time_to_live;
+		outer_hdr.next_proto_id = IPPROTO_IPIP;
 	} else if (packet->network_header.type ==
 		   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
-		ipv6_hdr_inner = rte_pktmbuf_mtod_offset(
+		struct rte_ipv6_hdr *inner_hdr = rte_pktmbuf_mtod_offset(
 			mbuf,
 			struct rte_ipv6_hdr *,
 			packet->network_header.offset
 		);
+		outer_hdr.type_of_service =
+			(rte_be_to_cpu_32(inner_hdr->vtc_flow) >> 20) & 0xFF;
+		outer_hdr.total_length = rte_cpu_to_be_16(
+			sizeof(struct rte_ipv4_hdr) +
+			sizeof(struct rte_ipv6_hdr) +
+			rte_be_to_cpu_16(inner_hdr->payload_len)
+		);
+
+		outer_hdr.packet_id = rte_cpu_to_be_16(0x01);
+		outer_hdr.fragment_offset = 0;
+		outer_hdr.time_to_live = inner_hdr->hop_limits;
+		outer_hdr.next_proto_id = IPPROTO_IPV6;
 	} else {
 		return -1;
 	}
 
-	struct rte_ipv4_hdr header;
-	rte_memcpy(&header.src_addr, src, 4);
-	rte_memcpy(&header.dst_addr, dst, 4);
-	header.version_ihl = 0x45;
+	outer_hdr.hdr_checksum = 0;
+	outer_hdr.hdr_checksum = rte_ipv4_cksum(&outer_hdr);
 
-	if (ipv4_hdr_inner) {
-		header.type_of_service = ipv4_hdr_inner->type_of_service;
-		header.total_length = rte_cpu_to_be_16(
-			sizeof(struct rte_ipv4_hdr) +
-			rte_be_to_cpu_16(ipv4_hdr_inner->total_length)
-		);
-
-		header.packet_id = ipv4_hdr_inner->packet_id;
-		header.fragment_offset = ipv4_hdr_inner->fragment_offset;
-		header.time_to_live = ipv4_hdr_inner->time_to_live;
-		header.next_proto_id = IPPROTO_IPIP;
-	} else {
-		header.type_of_service =
-			(rte_be_to_cpu_32(ipv6_hdr_inner->vtc_flow) >> 20) &
-			0xFF;
-		header.total_length = rte_cpu_to_be_16(
-			sizeof(struct rte_ipv4_hdr) +
-			sizeof(struct rte_ipv6_hdr) +
-			rte_be_to_cpu_16(ipv6_hdr_inner->payload_len)
-		);
-
-		header.packet_id = rte_cpu_to_be_16(0x01);
-		header.fragment_offset = 0;
-		header.time_to_live = ipv6_hdr_inner->hop_limits;
-		header.next_proto_id = IPPROTO_IPV6;
-	}
-
-	header.hdr_checksum = 0;
-	header.hdr_checksum = rte_ipv4_cksum(&header);
-
-	packet_network_prepend(
+	return packet_network_prepend(
 		packet,
 		rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4),
-		&header,
-		sizeof(header)
+		&outer_hdr,
+		sizeof(outer_hdr)
 	);
-
-	return 0;
 }
 
 int
@@ -133,58 +124,47 @@ packet_ip6_encap(
 ) {
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
-	struct rte_ipv4_hdr *ipv4_hdr_inner = NULL;
-	struct rte_ipv6_hdr *ipv6_hdr_inner = NULL;
+	struct rte_ipv6_hdr outer_hdr;
+	rte_memcpy(&outer_hdr.src_addr, src, NET6_LEN);
+	rte_memcpy(&outer_hdr.dst_addr, dst, NET6_LEN);
 
 	if (packet->network_header.type ==
 	    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
-		ipv4_hdr_inner = rte_pktmbuf_mtod_offset(
+		struct rte_ipv4_hdr *inner_hdr = rte_pktmbuf_mtod_offset(
 			mbuf,
 			struct rte_ipv4_hdr *,
 			packet->network_header.offset
 		);
+		outer_hdr.vtc_flow = rte_cpu_to_be_32(
+			(0x6 << 28) | (inner_hdr->type_of_service << 20)
+		); // TODO: flow label?
+		outer_hdr.payload_len = inner_hdr->total_length;
+		outer_hdr.proto = IPPROTO_IPIP;
+		outer_hdr.hop_limits = inner_hdr->time_to_live;
 	} else if (packet->network_header.type ==
 		   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
-		ipv6_hdr_inner = rte_pktmbuf_mtod_offset(
+		struct rte_ipv6_hdr *inner_hdr = rte_pktmbuf_mtod_offset(
 			mbuf,
 			struct rte_ipv6_hdr *,
 			packet->network_header.offset
 		);
+		outer_hdr.vtc_flow = inner_hdr->vtc_flow;
+		outer_hdr.payload_len = rte_cpu_to_be_16(
+			sizeof(struct rte_ipv6_hdr) +
+			rte_be_to_cpu_16(inner_hdr->payload_len)
+		);
+		outer_hdr.proto = IPPROTO_IPV6;
+		outer_hdr.hop_limits = inner_hdr->hop_limits;
 	} else {
 		return -1;
 	}
 
-	struct rte_ipv6_hdr header;
-	rte_memcpy(&header.src_addr, src, 16);
-	rte_memcpy(&header.dst_addr, dst, 16);
-
-	if (ipv4_hdr_inner != NULL) {
-		header.vtc_flow = rte_cpu_to_be_32(
-			(0x6 << 28) | (ipv4_hdr_inner->type_of_service << 20)
-		); ///< @todo: flow label
-		header.payload_len = ipv4_hdr_inner->total_length;
-		header.proto = IPPROTO_IPIP;
-		header.hop_limits = ipv4_hdr_inner->time_to_live;
-	} else if (ipv6_hdr_inner != NULL) {
-		header.vtc_flow = ipv6_hdr_inner->vtc_flow;
-		header.payload_len = rte_cpu_to_be_16(
-			sizeof(struct rte_ipv6_hdr) +
-			rte_be_to_cpu_16(ipv6_hdr_inner->payload_len)
-		);
-		header.proto = IPPROTO_IPV6;
-		header.hop_limits = ipv6_hdr_inner->hop_limits;
-	}
-
-	// FIXME: update udp cksum if embedded
-
-	packet_network_prepend(
+	return packet_network_prepend(
 		packet,
 		rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6),
-		&header,
-		sizeof(header)
+		&outer_hdr,
+		sizeof(outer_hdr)
 	);
-
-	return 0;
 }
 
 int

--- a/lib/dataplane/packet/encap.h
+++ b/lib/dataplane/packet/encap.h
@@ -18,7 +18,7 @@ packet_mpls_encap(
 );
 
 int
-packet_encap_ip4_udp(
+packet_ipv4_encap_udp(
 	struct packet *packet,
 	const uint8_t *src_ip,
 	const uint8_t *dst_ip,
@@ -27,7 +27,7 @@ packet_encap_ip4_udp(
 );
 
 int
-packet_encap_ip6_udp(
+packet_ip6_encap_udp(
 	struct packet *packet,
 	const uint8_t *src_addr,
 	const uint8_t *dst_addr,

--- a/lib/dataplane/packet/encap.h
+++ b/lib/dataplane/packet/encap.h
@@ -46,7 +46,7 @@ packet_mpls_encap(
 );
 
 int
-packet_ipv4_encap_udp(
+packet_ip4_encap_udp(
 	struct packet *packet,
 	const uint8_t *src_ip,
 	const uint8_t *dst_ip,

--- a/lib/dataplane/packet/encap.h
+++ b/lib/dataplane/packet/encap.h
@@ -2,9 +2,37 @@
 
 #include "packet.h"
 
+/**
+ * @brief Encapsulate a packet in an outer IPv4 header (IP-in-IP tunneling).
+ *
+ * Prepends an IPv4 header to the packet, deriving TOS, TTL and total length
+ * from the existing inner IPv4 or IPv6 header. The outer protocol is set to
+ * IPIP for an IPv4 inner and IPV6 for an IPv6 inner; the header checksum is
+ * computed before prepending.
+ *
+ * @param packet Packet whose current network header is IPv4 or IPv6.
+ * @param dst Outer destination address (NET4_LEN bytes, network order).
+ * @param src Outer source address (NET4_LEN bytes, network order).
+ * @return 0 on success, -1 if the inner network type is unsupported or the
+ *         mbuf cannot be extended.
+ */
 int
 packet_ip4_encap(struct packet *packet, const uint8_t *dst, const uint8_t *src);
 
+/**
+ * @brief Encapsulate a packet in an outer IPv6 header (IP-in-IP tunneling).
+ *
+ * Prepends an IPv6 header to the packet, deriving traffic class, hop limit
+ * and payload length from the existing inner IPv4 or IPv6 header. The outer
+ * next-header is set to IPIP for an IPv4 inner and IPV6 for an IPv6 inner.
+ * The flow label is currently left unset.
+ *
+ * @param packet Packet whose current network header is IPv4 or IPv6.
+ * @param dst Outer destination address (NET6_LEN bytes, network order).
+ * @param src Outer source address (NET6_LEN bytes, network order).
+ * @return 0 on success, -1 if the inner network type is unsupported or the
+ *         mbuf cannot be extended.
+ */
 int
 packet_ip6_encap(struct packet *packet, const uint8_t *dst, const uint8_t *src);
 

--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -153,7 +153,7 @@ route_mpls_handle_packets(
 		uint16_t dst_port = htobe16(6635);
 
 		if (nexthop->type == ROUTE_TYPE_V4) {
-			if (packet_encap_ip4_udp(
+			if (packet_ipv4_encap_udp(
 				    packet,
 				    nexthop->ip4_tunnel.src,
 				    nexthop->ip4_tunnel.dst,
@@ -165,7 +165,7 @@ route_mpls_handle_packets(
 				continue;
 			}
 		} else {
-			if (packet_encap_ip6_udp(
+			if (packet_ip6_encap_udp(
 				    packet,
 				    nexthop->ip6_tunnel.src,
 				    nexthop->ip6_tunnel.dst,

--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -153,7 +153,7 @@ route_mpls_handle_packets(
 		uint16_t dst_port = htobe16(6635);
 
 		if (nexthop->type == ROUTE_TYPE_V4) {
-			if (packet_ipv4_encap_udp(
+			if (packet_ip4_encap_udp(
 				    packet,
 				    nexthop->ip4_tunnel.src,
 				    nexthop->ip4_tunnel.dst,


### PR DESCRIPTION
## Summary

- Merge the two-pass "set pointer, then check which is non-NULL" dispatch in
  `packet_ip4_encap` and `packet_ip6_encap` into a single branch per inner
  type. Inner-header pointers now live inside the branch that uses them.
- Rename the outer-header local to `outer_hdr` and the inner pointer to
  `inner_hdr` consistently across both functions so they read as mirror
  images.
- Replace magic `4` / `16` address sizes with `NET4_LEN` / `NET6_LEN` from
  `common/network.h`.
- Return the result of `packet_network_prepend` directly instead of
  discarding it and returning `0`, so prepend failures propagate.
- Add Doxygen `@brief` / `@param` / `@return` docs for `packet_ip4_encap`
  and `packet_ip6_encap` in `encap.h`, matching the existing style in
  `packet.h`.
- Fix a typo in a `FIXME` comment ("previos heade" => "previous header").
- Rename `packet_encap_ip4_udp`/`packet_encap_ip6_udp` to `packet_ip4_encap_udp`/`packet_ip6_encap_udp` for consistency with another encap methods.