### PR TITLE
pdump: vendored libpcap, static pcap for controlplane

### DIFF
--- a/.github/workflows/Dockerfile.base
+++ b/.github/workflows/Dockerfile.base
@@ -3,5 +3,5 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt update -y
-RUN apt install -y meson clang
+RUN apt install -y meson clang cmake
 RUN apt install -y python3-pyelftools libnuma-dev libpcap-dev git

--- a/.github/workflows/Dockerfile.base
+++ b/.github/workflows/Dockerfile.base
@@ -4,4 +4,4 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt update -y
 RUN apt install -y meson clang cmake
-RUN apt install -y python3-pyelftools libnuma-dev libpcap-dev git
+RUN apt install -y python3-pyelftools libnuma-dev libpcap-dev git flex bison

--- a/.github/workflows/Dockerfile.base.dev
+++ b/.github/workflows/Dockerfile.base.dev
@@ -15,6 +15,7 @@ ARG PROTOC_GEN_GO_GRPC_VERSION=latest
 
 RUN apt-get update -y && apt-get install -y \
     meson \
+    cmake \
     clang \
     clang-format-19 \
     clang-tidy-19 \

--- a/.github/workflows/Dockerfile.base.dev
+++ b/.github/workflows/Dockerfile.base.dev
@@ -20,6 +20,8 @@ RUN apt-get update -y && apt-get install -y \
     clang-format-19 \
     clang-tidy-19 \
     curl \
+    flex \
+    bison \
     git \
     just \
     make \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: meson clang python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq clang-tidy-19
+          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq clang-tidy-19
           version: 1.1
 
       - name: Install LLVM 19 toolchain

--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: meson clang python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
+          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
           version: 1.1
 
       - uses: actions/checkout@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "subprojects/dpdk"]
 	path = subprojects/dpdk
 	url = https://github.com/yanet-platform/dpdk
+[submodule "subprojects/libpcap"]
+	path = subprojects/libpcap
+	url = https://github.com/the-tcpdump-group/libpcap.git

--- a/modules/pdump/api/meson.build
+++ b/modules/pdump/api/meson.build
@@ -1,39 +1,75 @@
-cp_dependencies = [
-  lib_common_dep,
-  lib_errors_dep,
-  lib_config_cp_dep,
-]
-
-ext_deps = ['rte_bpf']
-
-foreach e:ext_deps
-  cp_dependencies += libdpdk.get_variable('static_' + e)
-endforeach
-
-pdump_cp_link_deps = []
-foreach l:libdpdk.get_variable('dpdk_static_libraries')
-  if l.name() in ext_deps 
-    pdump_cp_link_deps += l
-  endif
-endforeach
-
 pdump_dataplane_inc = include_directories('../dataplane')
 
-api_sources = files(
-  'controlplane.c',
+# libpcap: git submodule at subprojects/libpcap, built with CMake into this
+# module's build dir (Meson's cmake.subproject hits a dependency cycle in upstream libpcap).
+fs = import('fs')
+cmake = find_program('cmake', required: true, version: '>=3.5')
+pcap_src_root = meson.project_source_root() / 'subprojects' / 'libpcap'
+if not fs.exists(pcap_src_root / 'CMakeLists.txt')
+  error(
+    'pdump: missing libpcap sources at subprojects/libpcap. Initialize git submodules: git submodule update --init --recursive',
+  )
+endif
+
+pcap_cmake_build = meson.current_build_dir() / 'external' / 'libpcap-cmake'
+pcap_prefix = meson.current_build_dir() / 'external' / 'libpcap-install'
+libpcap_a = pcap_prefix / 'lib' / 'libpcap.a'
+
+pcap_cmake_args = [
+  '-S', pcap_src_root,
+  '-B', pcap_cmake_build,
+  '-G', 'Ninja',
+  '-DCMAKE_INSTALL_PREFIX=' + pcap_prefix,
+  '-DCMAKE_BUILD_TYPE=' + (get_option('buildtype') == 'debug' ? 'Debug' : 'RelWithDebInfo'),
+  '-DBUILD_SHARED_LIBS=OFF',
+  '-DDISABLE_BLUETOOTH=ON',
+  '-DDISABLE_NETMAP=ON',
+  '-DDISABLE_DPDK=ON',
+  '-DDISABLE_DBUS=ON',
+  '-DDISABLE_RDMA=ON',
+  '-DDISABLE_DAG=ON',
+  '-DDISABLE_SEPTEL=ON',
+  '-DDISABLE_SNF=ON',
+  '-DDISABLE_TC=ON',
+  '-DCMAKE_C_FLAGS=' + ' '.join(yanet_c_args),
+  '-DCMAKE_EXE_LINKER_FLAGS=' + ' '.join(yanet_link_args),
+  '-DCMAKE_SHARED_LINKER_FLAGS=' + ' '.join(yanet_link_args),
+  '-DCMAKE_MODULE_LINKER_FLAGS=' + ' '.join(yanet_link_args),
+]
+if host_machine.system() == 'linux'
+  pcap_cmake_args += ['-DBUILD_WITH_LIBNL=OFF', '-DDISABLE_LINUX_USBMON=ON']
+endif
+
+if not fs.exists(libpcap_a)
+  message('[pdump] Configuring libpcap with CMake in ' + pcap_cmake_build)
+  run_command(cmake, pcap_cmake_args, check: true)
+  message('[pdump] Building and installing libpcap to ' + pcap_prefix)
+  run_command(cmake, '--build', pcap_cmake_build, '--target', 'install', check: true)
+else
+  message('[pdump] Reusing built libpcap: ' + libpcap_a)
+endif
+
+pcap_libdir = pcap_prefix / 'lib'
+pcap_incdir = pcap_prefix / 'include'
+message('[pdump] Linking pdump_cp with static libpcap from ' + pcap_libdir)
+libpcap_dep = declare_dependency(
+  compile_args: ['-I' + pcap_incdir],
+  dependencies: cc.find_library('pcap', dirs: pcap_libdir, static: true),
 )
+
+cp_dependencies = [lib_common_dep, lib_errors_dep, lib_config_cp_dep, libdpdk_dep, libpcap_dep]
+api_sources = files('controlplane.c')
 
 lib_pdump_cp = static_library(
   'pdump_cp',
   api_sources,
   c_args: yanet_c_args,
   link_args: yanet_link_args,
-  link_whole: pdump_cp_link_deps,
   dependencies: cp_dependencies,
   include_directories: [yanet_rootdir, pdump_dataplane_inc],
   install: false,
 )
-
 lib_pdump_cp_dep = declare_dependency(
   link_with: lib_pdump_cp,
+  dependencies: cp_dependencies,
 )

--- a/modules/pdump/api/meson.build
+++ b/modules/pdump/api/meson.build
@@ -1,61 +1,31 @@
 pdump_dataplane_inc = include_directories('../dataplane')
 
-# libpcap: git submodule at subprojects/libpcap, built with CMake into this
-# module's build dir (Meson's cmake.subproject hits a dependency cycle in upstream libpcap).
-fs = import('fs')
-cmake = find_program('cmake', required: true, version: '>=3.5')
-pcap_src_root = meson.project_source_root() / 'subprojects' / 'libpcap'
-if not fs.exists(pcap_src_root / 'CMakeLists.txt')
-  error(
-    'pdump: missing libpcap sources at subprojects/libpcap. Initialize git submodules: git submodule update --init --recursive',
-  )
-endif
-
-pcap_cmake_build = meson.current_build_dir() / 'external' / 'libpcap-cmake'
-pcap_prefix = meson.current_build_dir() / 'external' / 'libpcap-install'
-libpcap_a = pcap_prefix / 'lib' / 'libpcap.a'
-
-pcap_cmake_args = [
-  '-S', pcap_src_root,
-  '-B', pcap_cmake_build,
-  '-G', 'Ninja',
-  '-DCMAKE_INSTALL_PREFIX=' + pcap_prefix,
-  '-DCMAKE_BUILD_TYPE=' + (get_option('buildtype') == 'debug' ? 'Debug' : 'RelWithDebInfo'),
-  '-DBUILD_SHARED_LIBS=OFF',
-  '-DDISABLE_BLUETOOTH=ON',
-  '-DDISABLE_NETMAP=ON',
-  '-DDISABLE_DPDK=ON',
-  '-DDISABLE_DBUS=ON',
-  '-DDISABLE_RDMA=ON',
-  '-DDISABLE_DAG=ON',
-  '-DDISABLE_SEPTEL=ON',
-  '-DDISABLE_SNF=ON',
-  '-DDISABLE_TC=ON',
-  '-DCMAKE_C_FLAGS=' + ' '.join(yanet_c_args),
-  '-DCMAKE_EXE_LINKER_FLAGS=' + ' '.join(yanet_link_args),
-  '-DCMAKE_SHARED_LINKER_FLAGS=' + ' '.join(yanet_link_args),
-  '-DCMAKE_MODULE_LINKER_FLAGS=' + ' '.join(yanet_link_args),
-]
-if host_machine.system() == 'linux'
-  pcap_cmake_args += ['-DBUILD_WITH_LIBNL=OFF', '-DDISABLE_LINUX_USBMON=ON']
-endif
-
-if not fs.exists(libpcap_a)
-  message('[pdump] Configuring libpcap with CMake in ' + pcap_cmake_build)
-  run_command(cmake, pcap_cmake_args, check: true)
-  message('[pdump] Building and installing libpcap to ' + pcap_prefix)
-  run_command(cmake, '--build', pcap_cmake_build, '--target', 'install', check: true)
-else
-  message('[pdump] Reusing built libpcap: ' + libpcap_a)
-endif
-
-pcap_libdir = pcap_prefix / 'lib'
-pcap_incdir = pcap_prefix / 'include'
-message('[pdump] Linking pdump_cp with static libpcap from ' + pcap_libdir)
-libpcap_dep = declare_dependency(
-  compile_args: ['-I' + pcap_incdir],
-  dependencies: cc.find_library('pcap', dirs: pcap_libdir, static: true),
-)
+# Static libpcap from subprojects/libpcap submodule (built via Meson's CMake module).
+cmake = import('cmake')
+pcap_opts = cmake.subproject_options()
+pcap_opts.add_cmake_defines({
+  'BUILD_SHARED_LIBS': 'OFF',
+  'DISABLE_BLUETOOTH': 'ON',
+  'DISABLE_NETMAP': 'ON',
+  'DISABLE_DPDK': 'ON',
+  'DISABLE_DBUS': 'ON',
+  'DISABLE_RDMA': 'ON',
+  'DISABLE_DAG': 'ON',
+  'DISABLE_SEPTEL': 'ON',
+  'DISABLE_SNF': 'ON',
+  'DISABLE_TC': 'ON',
+  'BUILD_WITH_LIBNL': 'OFF',
+  'DISABLE_LINUX_USBMON': 'ON',
+  'CMAKE_MESSAGE_LOG_LEVEL': 'WARNING',
+  'CMAKE_SUPPRESS_DEVELOPER_WARNINGS': 'ON',
+})
+# Don't propagate -Werror/-Wall/-Wextra into the third-party subproject;
+# also drop the project-wide -D_GNU_SOURCE because libpcap defines it itself
+# in ftmacros.h, which would otherwise trigger -Wmacro-redefined.
+pcap_opts.set_override_option('werror', 'false')
+pcap_opts.set_override_option('warning_level', '0')
+pcap_opts.append_compile_args('c', '-U_GNU_SOURCE')
+libpcap_dep = cmake.subproject('libpcap', options: pcap_opts).dependency('pcap_static')
 
 cp_dependencies = [lib_common_dep, lib_errors_dep, lib_config_cp_dep, libdpdk_dep, libpcap_dep]
 api_sources = files('controlplane.c')

--- a/modules/pdump/controlplane/ffi.go
+++ b/modules/pdump/controlplane/ffi.go
@@ -1,8 +1,9 @@
 package pdump
 
 //#cgo CFLAGS: -I../../../ -I../dataplane
+//#cgo CFLAGS: -I../../../build/modules/pdump/api/external/libpcap-install/include
 //#cgo LDFLAGS: -L../../../build/modules/pdump/api -lpdump_cp
-//#cgo LDFLAGS: -lpcap
+//#cgo LDFLAGS: -L../../../build/modules/pdump/api/external/libpcap-install/lib -Wl,-Bstatic -lpcap -Wl,-Bdynamic
 //
 //#include <stdlib.h>
 //#include "modules/pdump/api/controlplane.h"

--- a/modules/pdump/controlplane/ffi.go
+++ b/modules/pdump/controlplane/ffi.go
@@ -1,9 +1,8 @@
 package pdump
 
-//#cgo CFLAGS: -I../../../ -I../dataplane
-//#cgo CFLAGS: -I../../../build/modules/pdump/api/external/libpcap-install/include
+//#cgo CFLAGS: -I../../../ -I../dataplane -I../../../subprojects/libpcap
 //#cgo LDFLAGS: -L../../../build/modules/pdump/api -lpdump_cp
-//#cgo LDFLAGS: -L../../../build/modules/pdump/api/external/libpcap-install/lib -Wl,-Bstatic -lpcap -Wl,-Bdynamic
+//#cgo LDFLAGS: -L../../../build/subprojects/libpcap -l:libpcap_static.a
 //
 //#include <stdlib.h>
 //#include "modules/pdump/api/controlplane.h"


### PR DESCRIPTION
pdump_cp no longer pulls in DPDK’s rte_bpf via link_whole and the bespoke loop over dpdk_static_libraries. Instead, it links against the regular libdpdk_dep and adds a vendored static libpcap built as a Meson CMake subproject from the subprojects/libpcap git submodule, with a stripped feature set and suppressed warnings/-Werror for the third‑party build.

In modules/pdump/api/meson.build, libpcap is consumed as the pcap_static dependency and cp_dependencies now includes lib_errors_dep alongside the existing controlplane deps. In modules/pdump/controlplane/ffi.go, CGO flags are updated to include subprojects/libpcap headers and to link libpcap_static.a from the build tree instead of relying on system -lpcap.