### PR TITLE
fix(rcu): make per-worker array dynamic

### DIFF
--- a/common/rcu.h
+++ b/common/rcu.h
@@ -72,8 +72,10 @@
  * @subsection rcu_init_example Initialization
  * @code{.c}
  * rcu_t rcu;
- * rcu_init(&rcu);
+ * rcu_init(&rcu, mctx, worker_count);
  * atomic_ulong shared_value = 0;
+ * // ...later, on teardown:
+ * rcu_free(&rcu, mctx);
  * @endcode
  *
  * @subsection rcu_reader_example Reader (Worker Thread)
@@ -96,7 +98,7 @@
  * @li Multiple readers can execute concurrently without blocking
  * @li Writers are serialized (external synchronization required for multiple
  * writers)
- * @li Each worker must use a unique worker ID (0 to RCU_WORKERS-1)
+ * @li Each worker must use a unique worker ID (0 to worker_count-1)
  * @li Workers must not nest read-side critical sections
  * @li Read-side critical sections should be short and non-blocking
  *
@@ -110,14 +112,14 @@
  * @li Throughput: 50-100M ops/sec per worker (measured on modern x86_64)
  *
  * @subsection rcu_perf_updates Update Operations
- * @li Complexity: O(RCU_WORKERS)
+ * @li Complexity: O(worker_count)
  * @li Blocks until all active readers finish
  * @li Typical latency: 100-500 nanoseconds (depends on reader activity)
  * @li Throughput: 2-10K ops/sec (limited by grace period overhead)
  *
  * @subsection rcu_perf_memory Memory Overhead
  * @li 64 bytes per worker (cache-line aligned to prevent false sharing)
- * @li Total: 64 * (RCU_WORKERS + 1) bytes
+ * @li Total: sizeof(rcu_t) + 64 * worker_count bytes
  * @li Minimal metadata overhead
  *
  * @subsection rcu_perf_scalability Scalability
@@ -148,21 +150,15 @@
  * writers. The RCU mechanism does not serialize writers.
  */
 
+#include "memory.h"
+#include "memory_address.h"
+
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 
 ////////////////////////////////////////////////////////////////////////////////
-
-/**
- * @brief Maximum number of worker threads supported by RCU
- *
- * This constant defines the maximum number of concurrent readers that can
- * use the RCU mechanism. Each worker must have a unique ID from 0 to
- * RCU_WORKERS-1.
- */
-#define RCU_WORKERS 8
 
 /**
  * @brief Per-worker RCU state
@@ -192,14 +188,14 @@ typedef struct {
  * @brief Main RCU control structure
  *
  * This structure maintains the global epoch and per-worker state for the
- * RCU mechanism. It should be initialized with rcu_init() before use.
- *
- * @note The total size is approximately 64 * (RCU_WORKERS + 1) bytes due to
- *       cache-line alignment of worker states.
+ * RCU mechanism.
  */
 typedef struct {
-	/** Per-worker state array, one entry per worker thread */
-	rcu_worker_t workers[RCU_WORKERS];
+	/** Per-worker state array, stored as a relative offset */
+	rcu_worker_t *workers;
+
+	/** Number of worker slots in the workers array */
+	size_t worker_count;
 
 	/** Global epoch counter (0 or 1), flipped during updates */
 	atomic_uint global_epoch;
@@ -213,7 +209,7 @@ typedef struct {
  * This allows the RCU mechanism to track which workers are reading old data.
  *
  * @param rcu Pointer to the RCU control structure
- * @param w Worker ID (must be in range [0, RCU_WORKERS))
+ * @param w Worker ID (must be in range [0, worker_count))
  *
  * @note This function uses relaxed memory ordering for the epoch read and
  *       release ordering for the active flag to ensure proper synchronization.
@@ -225,7 +221,7 @@ typedef struct {
  */
 static inline void
 rcu_read_begin(rcu_t *rcu, size_t w) {
-	rcu_worker_t *me = &rcu->workers[w];
+	rcu_worker_t *me = &ADDR_OF(&rcu->workers)[w];
 	// Sample epoch, then pack both active=1 and epoch into single atomic
 	// store
 	unsigned e =
@@ -243,7 +239,7 @@ rcu_read_begin(rcu_t *rcu, size_t w) {
  * workers have finished their critical sections.
  *
  * @param rcu Pointer to the RCU control structure
- * @param w Worker ID (must be in range [0, RCU_WORKERS))
+ * @param w Worker ID (must be in range [0, worker_count))
  *
  * @note This function uses release memory ordering to ensure all reads in
  *       the critical section complete before marking inactive.
@@ -254,7 +250,7 @@ rcu_read_begin(rcu_t *rcu, size_t w) {
  */
 static inline void
 rcu_read_end(rcu_t *rcu, size_t w) {
-	rcu_worker_t *me = &rcu->workers[w];
+	rcu_worker_t *me = &ADDR_OF(&rcu->workers)[w];
 	// Clear active bit (set state to 0)
 	atomic_store_explicit(&me->state, 0, memory_order_release);
 }
@@ -268,7 +264,7 @@ rcu_read_end(rcu_t *rcu, size_t w) {
  * epoch change are visible.
  *
  * @param rcu Pointer to the RCU control structure
- * @param w Worker ID (must be in range [0, RCU_WORKERS))
+ * @param w Worker ID (must be in range [0, worker_count))
  * @param addr Pointer to atomic variable to load (e.g., atomic_ulong*)
  * @return The loaded value
  *
@@ -296,7 +292,7 @@ rcu_read_end(rcu_t *rcu, size_t w) {
  * It's provided for symmetry with RCU_READ_BEGIN().
  *
  * @param rcu Pointer to the RCU control structure
- * @param w Worker ID (must be in range [0, RCU_WORKERS))
+ * @param w Worker ID (must be in range [0, worker_count))
  */
 #define RCU_READ_END(rcu, w) rcu_read_end(rcu, w)
 
@@ -339,10 +335,11 @@ cpu_relax(void) {
  */
 static void
 wait_epoch_flush(rcu_t *rcu, unsigned e) {
+	rcu_worker_t *workers = ADDR_OF(&rcu->workers);
 	for (;;) {
 		bool any = false;
-		for (size_t i = 0; i < RCU_WORKERS; i++) {
-			rcu_worker_t *w = &rcu->workers[i];
+		for (size_t i = 0; i < rcu->worker_count; i++) {
+			rcu_worker_t *w = &workers[i];
 			// Load packed state once - gets both active and epoch
 			unsigned state = atomic_load_explicit(
 				&w->state, memory_order_acquire
@@ -482,29 +479,42 @@ rcu_update(rcu_t *rcu, atomic_ulong *value, uint64_t upd) {
 /**
  * @brief Initialize an RCU control structure
  *
- * This function initializes all fields of the RCU structure to their default
- * values. It must be called before any other RCU operations.
+ * Allocates the per-worker state array from the given memory context and
+ * sets the global epoch and every worker slot to zero (idle, epoch 0).
+ * Must be called before any other RCU operation and paired with rcu_free.
  *
- * Initial state:
- * - Global epoch: 0
- * - All workers: inactive (active = 0)
- * - All worker epochs: 0
+ * Returns 0 on success, -1 if the per-worker array could not be allocated.
  *
- * @param rcu Pointer to the RCU control structure to initialize
+ * Not thread-safe; must complete before any concurrent reader or writer
+ * touches the structure.
+ */
+static inline int
+rcu_init(rcu_t *rcu, struct memory_context *mctx, size_t worker_count) {
+	size_t bytes = sizeof(rcu_worker_t) * worker_count;
+	rcu_worker_t *workers = memory_balloc(mctx, bytes);
+	if (workers == NULL && worker_count > 0) {
+		return -1;
+	}
+	memset(workers, 0, bytes);
+	SET_OFFSET_OF(&rcu->workers, workers);
+	rcu->worker_count = worker_count;
+	atomic_store_explicit(&rcu->global_epoch, 0, memory_order_relaxed);
+	return 0;
+}
+
+/**
+ * @brief Release the per-worker state array previously allocated by rcu_init
  *
- * @note This function is NOT thread-safe. It must be called before any
- *       concurrent access to the RCU structure.
- * @note After initialization, the RCU structure is ready for use by readers
- *       and writers.
- *
- * Example:
- * ```c
- * rcu_t rcu;
- * rcu_init(&rcu);
- * // Now ready for use
- * ```
+ * Must be called with the same memory context that was passed to rcu_init.
+ * After this call the RCU structure must not be used.
  */
 static inline void
-rcu_init(rcu_t *rcu) {
-	memset(rcu, 0, sizeof(rcu_t));
+rcu_free(rcu_t *rcu, struct memory_context *mctx) {
+	memory_bfree(
+		mctx,
+		ADDR_OF(&rcu->workers),
+		sizeof(rcu_worker_t) * rcu->worker_count
+	);
+	rcu->workers = NULL;
+	rcu->worker_count = 0;
 }

--- a/modules/balancer/controlplane/handler/selector.c
+++ b/modules/balancer/controlplane/handler/selector.c
@@ -96,11 +96,15 @@ selector_init(
 	enum vs_scheduler scheduler
 ) {
 	memory_context_init_from(&selector->mctx, mctx, "real_selector");
-	rcu_init(&selector->rcu);
+	if (rcu_init(&selector->rcu, &selector->mctx, MAX_WORKERS_NUM) != 0) {
+		PUSH_ERROR("failed to init rcu");
+		return -1;
+	}
 	selector->use_rr = scheduler == round_robin ? 1 : 0;
 	selector->ring_id = 0;
 	if (ring_init(&selector->rings[0], &selector->mctx, 0, NULL) != 0) {
 		PUSH_ERROR("failed to init ring");
+		rcu_free(&selector->rcu, &selector->mctx);
 		return -1;
 	}
 	uint64_t rng = 0xdeadbeef;
@@ -114,4 +118,5 @@ void
 selector_free(struct real_selector *selector) {
 	size_t cur_ring_id = selector->ring_id;
 	ring_free(&selector->rings[cur_ring_id], &selector->mctx);
+	rcu_free(&selector->rcu, &selector->mctx);
 }

--- a/modules/balancer/controlplane/state/session_table.c
+++ b/modules/balancer/controlplane/state/session_table.c
@@ -3,6 +3,7 @@
 #include "common/rcu.h"
 #include "common/ttlmap/detail/ttlmap.h"
 #include "common/ttlmap/ttlmap.h"
+#include "state/worker.h"
 
 #include "lib/controlplane/diag/diag.h"
 
@@ -46,9 +47,10 @@ session_table_init(
 
 	ttlmap_init_empty(&table->maps[1]);
 
-	// Init generation count
-	// (guarded with rcu)
-	rcu_init(&table->rcu);
+	if (rcu_init(&table->rcu, &table->mctx, MAX_WORKERS_NUM) != 0) {
+		TTLMAP_FREE(&table->maps[0]);
+		return -1;
+	}
 	table->current_gen = 0;
 
 	return 0;
@@ -59,6 +61,7 @@ session_table_free(struct session_table *table) {
 	for (size_t i = 0; i < 2; ++i) {
 		TTLMAP_FREE(&table->maps[i]);
 	}
+	rcu_free(&table->rcu, &table->mctx);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/modules/balancer/controlplane/state/worker.h
+++ b/modules/balancer/controlplane/state/worker.h
@@ -1,9 +1,3 @@
 #pragma once
 
-#include "common/rcu.h"
-
-#include <assert.h>
-
 #define MAX_WORKERS_NUM 8
-
-static_assert(MAX_WORKERS_NUM <= RCU_WORKERS, "too many workers");

--- a/tests/common/rcu_bench.c
+++ b/tests/common/rcu_bench.c
@@ -12,14 +12,24 @@
  * Run with: ./rcu_bench
  */
 
+#include "common/memory.h"
+#include "common/memory_block.h"
 #include "common/rcu.h"
 #include "lib/logging/log.h"
 
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/time.h>
 #include <unistd.h>
+
+#define BENCH_WORKERS 8
+
+// Shared benchmark memory context, initialised once in main() and used as
+// the rcu_init allocator for every benchmark.
+static struct block_allocator g_balloc;
+static struct memory_context g_mctx;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Benchmark Helper Functions
@@ -62,24 +72,24 @@ benchmark_reader_func(void *arg) {
 
 static void
 benchmark_multiworker_throughput(size_t num_workers) {
-	if (num_workers > RCU_WORKERS) {
+	if (num_workers > BENCH_WORKERS) {
 		LOG(ERROR,
 		    "Cannot benchmark with %zu workers (max: %d)",
 		    num_workers,
-		    RCU_WORKERS);
+		    BENCH_WORKERS);
 		return;
 	}
 
 	LOG(INFO, "Benchmarking RCU with %zu workers...", num_workers);
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, BENCH_WORKERS);
 	atomic_ulong value = 0;
 	atomic_bool stop = false;
 	atomic_ullong total_reads = 0;
 
-	pthread_t threads[RCU_WORKERS];
-	struct benchmark_args args[RCU_WORKERS];
+	pthread_t threads[BENCH_WORKERS];
+	struct benchmark_args args[BENCH_WORKERS];
 
 	// Create reader threads
 	for (size_t i = 0; i < num_workers; i++) {
@@ -185,20 +195,20 @@ benchmark_contention(void) {
 	LOG(INFO, "Running contention benchmark...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, BENCH_WORKERS);
 	atomic_ulong value = 0;
 	atomic_ullong total_ops = 0;
-	uint64_t worker_times[RCU_WORKERS] = {0};
+	uint64_t worker_times[BENCH_WORKERS] = {0};
 
 	const size_t iterations_per_worker = 500000;
 
-	pthread_t threads[RCU_WORKERS];
-	struct contention_args args[RCU_WORKERS];
+	pthread_t threads[BENCH_WORKERS];
+	struct contention_args args[BENCH_WORKERS];
 
 	uint64_t start_time = get_time_us();
 
 	// Create all workers simultaneously for maximum contention
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < BENCH_WORKERS; i++) {
 		args[i].rcu = &rcu;
 		args[i].value = &value;
 		args[i].worker_id = i;
@@ -216,7 +226,7 @@ benchmark_contention(void) {
 	}
 
 	// Wait for all workers
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < BENCH_WORKERS; i++) {
 		pthread_join(threads[i], NULL);
 	}
 
@@ -232,7 +242,7 @@ benchmark_contention(void) {
 	uint64_t max_time = worker_times[0];
 	uint64_t sum_time = 0;
 
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < BENCH_WORKERS; i++) {
 		if (worker_times[i] < min_time)
 			min_time = worker_times[i];
 		if (worker_times[i] > max_time)
@@ -240,11 +250,11 @@ benchmark_contention(void) {
 		sum_time += worker_times[i];
 	}
 
-	double avg_time = (double)sum_time / RCU_WORKERS;
+	double avg_time = (double)sum_time / BENCH_WORKERS;
 	double fairness = (double)min_time / (double)max_time;
 
 	LOG(INFO, "=== Contention Benchmark Results ===");
-	LOG(INFO, "  Workers: %d", RCU_WORKERS);
+	LOG(INFO, "  Workers: %d", BENCH_WORKERS);
 	LOG(INFO, "  Iterations per worker: %zu", iterations_per_worker);
 	LOG(INFO, "  Total operations: %lu", ops);
 	LOG(INFO, "  Total time: %.3f seconds", (double)total_time / 1000000.0);
@@ -253,7 +263,7 @@ benchmark_contention(void) {
 	    total_throughput / 1000000.0);
 	LOG(INFO,
 	    "  Per-worker throughput: %.2f Mops/sec",
-	    total_throughput / RCU_WORKERS / 1000000.0);
+	    total_throughput / BENCH_WORKERS / 1000000.0);
 	LOG(INFO,
 	    "  Worker time - min: %.3f ms, max: %.3f ms, avg: %.3f ms",
 	    (double)min_time / 1000.0,
@@ -272,7 +282,7 @@ benchmark_latency_distribution(void) {
 	LOG(INFO, "Running latency distribution benchmark...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, BENCH_WORKERS);
 	atomic_ulong value = 0;
 
 	const size_t num_samples = 10000;
@@ -395,11 +405,11 @@ writer_bench_func(void *arg) {
 
 static void
 benchmark_reader_writer_interaction(size_t num_readers) {
-	if (num_readers >= RCU_WORKERS) {
+	if (num_readers >= BENCH_WORKERS) {
 		LOG(ERROR,
 		    "Need at least 1 worker for writer (readers: %zu, max: %d)",
 		    num_readers,
-		    RCU_WORKERS - 1);
+		    BENCH_WORKERS - 1);
 		return;
 	}
 
@@ -408,7 +418,7 @@ benchmark_reader_writer_interaction(size_t num_readers) {
 	    num_readers);
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, BENCH_WORKERS);
 	atomic_ulong value = 0;
 	atomic_bool stop = false;
 	atomic_ullong total_reads = 0;
@@ -417,9 +427,9 @@ benchmark_reader_writer_interaction(size_t num_readers) {
 	const size_t max_latencies = 10000;
 	uint64_t update_latencies[max_latencies];
 
-	pthread_t reader_threads[RCU_WORKERS];
+	pthread_t reader_threads[BENCH_WORKERS];
 	pthread_t writer_thread;
-	struct reader_writer_bench_args reader_args[RCU_WORKERS];
+	struct reader_writer_bench_args reader_args[BENCH_WORKERS];
 	struct writer_bench_args writer_args;
 
 	// Create reader threads
@@ -529,15 +539,31 @@ main(void) {
 	log_enable_name("info");
 
 	LOG(INFO, "=== RCU Performance Benchmark Suite ===");
-	LOG(INFO, "RCU_WORKERS: %d", RCU_WORKERS);
+	LOG(INFO, "BENCH_WORKERS: %d", BENCH_WORKERS);
 	LOG(INFO, "");
+
+	const size_t arena_size = 1 << 20;
+	void *arena = malloc(arena_size);
+	if (arena == NULL) {
+		LOG(ERROR, "failed to allocate benchmark arena");
+		return 1;
+	}
+	if (block_allocator_init(&g_balloc) != 0) {
+		LOG(ERROR, "block_allocator_init failed");
+		return 1;
+	}
+	block_allocator_put_arena(&g_balloc, arena, arena_size);
+	if (memory_context_init(&g_mctx, "rcu_bench", &g_balloc) < 0) {
+		LOG(ERROR, "memory_context_init failed");
+		return 1;
+	}
 
 	// Benchmark 1: Throughput with varying worker counts
 	LOG(INFO, "--- Benchmark 1: Throughput Scalability ---");
 	size_t worker_counts[] = {1, 2, 4, 8};
 	for (size_t i = 0; i < sizeof(worker_counts) / sizeof(worker_counts[0]);
 	     i++) {
-		if (worker_counts[i] <= RCU_WORKERS) {
+		if (worker_counts[i] <= BENCH_WORKERS) {
 			benchmark_multiworker_throughput(worker_counts[i]);
 		}
 	}
@@ -555,12 +581,14 @@ main(void) {
 	size_t reader_counts[] = {1, 2, 4, 7};
 	for (size_t i = 0; i < sizeof(reader_counts) / sizeof(reader_counts[0]);
 	     i++) {
-		if (reader_counts[i] < RCU_WORKERS) {
+		if (reader_counts[i] < BENCH_WORKERS) {
 			benchmark_reader_writer_interaction(reader_counts[i]);
 		}
 	}
 
 	LOG(INFO, "=== Benchmark Suite Completed ===");
+
+	free(arena);
 
 	return 0;
 }

--- a/tests/common/rcu_test.c
+++ b/tests/common/rcu_test.c
@@ -13,6 +13,9 @@
  * - Aggressive race detection tests
  */
 
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/memory_block.h"
 #include "common/rcu.h"
 #include "lib/logging/log.h"
 #include "tests/common/helpers.h"
@@ -21,12 +24,21 @@
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/time.h>
 #include <unistd.h>
 
 // Helper macros to extract active and epoch from packed state
 #define GET_ACTIVE(state) ((state) & 1u)
 #define GET_EPOCH(state) (((state) >> 1) & 1u)
+
+#define TEST_WORKERS 8
+
+// Shared test memory context, initialised once in main() and used as the
+// rcu_init allocator for every test. rcu_fini is intentionally omitted in
+// individual tests: the process exits after main() returns.
+static struct block_allocator g_balloc;
+static struct memory_context g_mctx;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Test 1: Basic Initialization
@@ -40,7 +52,7 @@ test_basic_init(void) {
 	LOG(INFO, "Running test_basic_init...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 
 	// Check global epoch is 0
 	unsigned global_epoch =
@@ -49,10 +61,12 @@ test_basic_init(void) {
 		global_epoch, 0, "global_epoch should be 0 after init"
 	);
 
+	rcu_worker_t *workers = ADDR_OF(&rcu.workers);
+
 	// Check all workers are inactive with epoch 0
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		unsigned state = atomic_load_explicit(
-			&rcu.workers[i].state, memory_order_relaxed
+			&workers[i].state, memory_order_relaxed
 		);
 		unsigned epoch = GET_EPOCH(state);
 		unsigned active = GET_ACTIVE(state);
@@ -80,17 +94,18 @@ test_single_reader(void) {
 	LOG(INFO, "Running test_single_reader...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 42;
+
+	rcu_worker_t *workers = ADDR_OF(&rcu.workers);
 
 	// Begin read-side critical section
 	uint64_t read_value = RCU_READ_BEGIN(&rcu, 0, &value);
 	TEST_ASSERT_EQUAL(read_value, 42, "should read correct value");
 
 	// Check worker 0 is now active
-	unsigned state = atomic_load_explicit(
-		&rcu.workers[0].state, memory_order_relaxed
-	);
+	unsigned state =
+		atomic_load_explicit(&workers[0].state, memory_order_relaxed);
 	unsigned active = GET_ACTIVE(state);
 	TEST_ASSERT_EQUAL(active, 1, "worker should be active during read");
 
@@ -98,9 +113,7 @@ test_single_reader(void) {
 	RCU_READ_END(&rcu, 0);
 
 	// Check worker 0 is now inactive
-	state = atomic_load_explicit(
-		&rcu.workers[0].state, memory_order_relaxed
-	);
+	state = atomic_load_explicit(&workers[0].state, memory_order_relaxed);
 	active = GET_ACTIVE(state);
 	TEST_ASSERT_EQUAL(
 		active, 0, "worker should be inactive after read end"
@@ -122,7 +135,7 @@ test_single_writer(void) {
 	LOG(INFO, "Running test_single_writer...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 10;
 
 	// Update value
@@ -155,7 +168,7 @@ test_multiple_updates(void) {
 	LOG(INFO, "Running test_multiple_updates...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 0;
 
 	// Perform multiple updates
@@ -182,7 +195,7 @@ test_reader_writer_interaction(void) {
 	LOG(INFO, "Running test_reader_writer_interaction...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 100;
 
 	// Start read-side critical section
@@ -218,12 +231,14 @@ test_multiple_workers(void) {
 	LOG(INFO, "Running test_multiple_workers...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 777;
 
+	rcu_worker_t *workers = ADDR_OF(&rcu.workers);
+
 	// Start read-side critical sections for all workers
-	uint64_t values[RCU_WORKERS];
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	uint64_t values[TEST_WORKERS];
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		values[i] = RCU_READ_BEGIN(&rcu, i, &value);
 		TEST_ASSERT_EQUAL(
 			values[i], 777, "all workers should read same value"
@@ -231,19 +246,19 @@ test_multiple_workers(void) {
 
 		// Verify worker is active
 		unsigned state = atomic_load_explicit(
-			&rcu.workers[i].state, memory_order_relaxed
+			&workers[i].state, memory_order_relaxed
 		);
 		unsigned active = GET_ACTIVE(state);
 		TEST_ASSERT_EQUAL(active, 1, "worker should be active");
 	}
 
 	// End all read-side critical sections
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		RCU_READ_END(&rcu, i);
 
 		// Verify worker is inactive
 		unsigned state = atomic_load_explicit(
-			&rcu.workers[i].state, memory_order_relaxed
+			&workers[i].state, memory_order_relaxed
 		);
 		unsigned active = GET_ACTIVE(state);
 		TEST_ASSERT_EQUAL(active, 0, "worker should be inactive");
@@ -265,16 +280,17 @@ test_epoch_synchronization(void) {
 	LOG(INFO, "Running test_epoch_synchronization...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 1;
+
+	rcu_worker_t *workers = ADDR_OF(&rcu.workers);
 
 	// Start read with worker 0
 	uint64_t read1 = RCU_READ_BEGIN(&rcu, 0, &value);
 	TEST_ASSERT_EQUAL(read1, 1, "initial read should be 1");
 
-	unsigned state0 = atomic_load_explicit(
-		&rcu.workers[0].state, memory_order_relaxed
-	);
+	unsigned state0 =
+		atomic_load_explicit(&workers[0].state, memory_order_relaxed);
 	unsigned epoch0 = GET_EPOCH(state0);
 	TEST_ASSERT_EQUAL(epoch0, 0, "worker should be in epoch 0");
 
@@ -287,9 +303,8 @@ test_epoch_synchronization(void) {
 	uint64_t read2 = RCU_READ_BEGIN(&rcu, 0, &value);
 	TEST_ASSERT_EQUAL(read2, 2, "read after update should be 2");
 
-	unsigned state1 = atomic_load_explicit(
-		&rcu.workers[0].state, memory_order_relaxed
-	);
+	unsigned state1 =
+		atomic_load_explicit(&workers[0].state, memory_order_relaxed);
 	unsigned epoch1 = GET_EPOCH(state1);
 	TEST_ASSERT_EQUAL(
 		epoch1, 0, "worker should be in epoch 0 after full cycle"
@@ -342,15 +357,15 @@ test_concurrent_readers(void) {
 	LOG(INFO, "Running test_concurrent_readers...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 42;
 	atomic_uint error_count = 0;
 
-	pthread_t threads[RCU_WORKERS];
-	struct reader_thread_args args[RCU_WORKERS];
+	pthread_t threads[TEST_WORKERS];
+	struct reader_thread_args args[TEST_WORKERS];
 
 	// Create reader threads
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		args[i].rcu = &rcu;
 		args[i].value = &value;
 		args[i].worker_id = i;
@@ -364,7 +379,7 @@ test_concurrent_readers(void) {
 	}
 
 	// Wait for all threads
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		int res = pthread_join(threads[i], NULL);
 		TEST_ASSERT_EQUAL(res, 0, "pthread_join should succeed");
 	}
@@ -419,16 +434,16 @@ test_concurrent_readers_with_writer(void) {
 	LOG(INFO, "Running test_concurrent_readers_with_writer...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 0;
 	atomic_bool stop = false;
 	atomic_uint read_count = 0;
 
-	pthread_t threads[RCU_WORKERS];
-	struct reader_writer_args args[RCU_WORKERS];
+	pthread_t threads[TEST_WORKERS];
+	struct reader_writer_args args[TEST_WORKERS];
 
 	// Create reader threads
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		args[i].rcu = &rcu;
 		args[i].value = &value;
 		args[i].stop = &stop;
@@ -452,7 +467,7 @@ test_concurrent_readers_with_writer(void) {
 	atomic_store(&stop, true);
 
 	// Wait for all threads
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		int res = pthread_join(threads[i], NULL);
 		TEST_ASSERT_EQUAL(res, 0, "pthread_join should succeed");
 	}
@@ -481,7 +496,7 @@ test_rapid_updates(void) {
 	LOG(INFO, "Running test_rapid_updates...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 0;
 
 	// Perform many rapid updates
@@ -499,10 +514,12 @@ test_rapid_updates(void) {
 		"final value should match iteration count"
 	);
 
+	rcu_worker_t *workers = ADDR_OF(&rcu.workers);
+
 	// Verify all workers are inactive
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		unsigned state = atomic_load_explicit(
-			&rcu.workers[i].state, memory_order_relaxed
+			&workers[i].state, memory_order_relaxed
 		);
 		unsigned active = GET_ACTIVE(state);
 		TEST_ASSERT_EQUAL(active, 0, "all workers should be inactive");
@@ -521,25 +538,27 @@ test_all_workers_active(void) {
 	LOG(INFO, "Running test_all_workers_active...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 999;
 
+	rcu_worker_t *workers = ADDR_OF(&rcu.workers);
+
 	// Activate all workers
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		RCU_READ_BEGIN(&rcu, i, &value);
 	}
 
 	// Verify all are active
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		unsigned state = atomic_load_explicit(
-			&rcu.workers[i].state, memory_order_relaxed
+			&workers[i].state, memory_order_relaxed
 		);
 		unsigned active = GET_ACTIVE(state);
 		TEST_ASSERT_EQUAL(active, 1, "worker should be active");
 	}
 
 	// Deactivate all workers
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		RCU_READ_END(&rcu, i);
 	}
 
@@ -563,7 +582,7 @@ test_memory_ordering(void) {
 	LOG(INFO, "Running test_memory_ordering...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 0;
 	atomic_ulong auxiliary = 0;
 
@@ -595,7 +614,7 @@ test_rcu_load(void) {
 	LOG(INFO, "Running test_rcu_load...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 555;
 
 	// Test rcu_load
@@ -668,17 +687,17 @@ test_aggressive_race_detection(void) {
 	LOG(INFO, "Running test_aggressive_race_detection...");
 
 	rcu_t rcu;
-	rcu_init(&rcu);
+	rcu_init(&rcu, &g_mctx, TEST_WORKERS);
 	atomic_ulong value = 0;
 	atomic_bool stop = false;
 	atomic_uint stale_reads = 0;
 	atomic_uint read_count = 0;
 
-	pthread_t threads[RCU_WORKERS];
-	struct hammer_reader_args args[RCU_WORKERS];
+	pthread_t threads[TEST_WORKERS];
+	struct hammer_reader_args args[TEST_WORKERS];
 
 	// Create aggressive reader threads
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		args[i].rcu = &rcu;
 		args[i].value = &value;
 		args[i].worker_id = i;
@@ -703,7 +722,7 @@ test_aggressive_race_detection(void) {
 	atomic_store_explicit(&stop, true, memory_order_release);
 
 	// Wait for all threads
-	for (size_t i = 0; i < RCU_WORKERS; i++) {
+	for (size_t i = 0; i < TEST_WORKERS; i++) {
 		int res = pthread_join(threads[i], NULL);
 		TEST_ASSERT_EQUAL(res, 0, "pthread_join should succeed");
 	}
@@ -715,7 +734,7 @@ test_aggressive_race_detection(void) {
 	LOG(INFO,
 	    "Completed %u reads across %d workers, stale reads: %u",
 	    reads,
-	    RCU_WORKERS,
+	    TEST_WORKERS,
 	    stales);
 
 	TEST_ASSERT_EQUAL(
@@ -738,43 +757,86 @@ main(void) {
 
 	LOG(INFO, "=== Starting RCU Test Suite ===");
 
-	int result = TEST_SUCCESS;
-
-	// Run all tests
-	if (test_basic_init() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_single_reader() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_single_writer() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_multiple_updates() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_reader_writer_interaction() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_multiple_workers() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_epoch_synchronization() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_concurrent_readers() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_concurrent_readers_with_writer() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_rapid_updates() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_all_workers_active() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_memory_ordering() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_rcu_load() != TEST_SUCCESS)
-		result = TEST_FAILED;
-	if (test_aggressive_race_detection() != TEST_SUCCESS)
-		result = TEST_FAILED;
-
-	if (result == TEST_SUCCESS) {
-		LOG(INFO, "=== All RCU tests passed! ===");
-	} else {
-		LOG(ERROR, "=== Some RCU tests failed ===");
+	const size_t arena_size = 1 << 20;
+	void *arena = malloc(arena_size);
+	if (arena == NULL) {
+		LOG(ERROR, "failed to allocate test arena");
+		return TEST_FAILED;
+	}
+	if (block_allocator_init(&g_balloc) != 0) {
+		LOG(ERROR, "block_allocator_init failed");
+		return TEST_FAILED;
+	}
+	block_allocator_put_arena(&g_balloc, arena, arena_size);
+	if (memory_context_init(&g_mctx, "rcu_test", &g_balloc) < 0) {
+		LOG(ERROR, "memory_context_init failed");
+		return TEST_FAILED;
 	}
 
-	return result;
+	int failed = 0;
+	if (test_basic_init() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_basic_init");
+		failed++;
+	}
+	if (test_single_reader() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_single_reader");
+		failed++;
+	}
+	if (test_single_writer() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_single_writer");
+		failed++;
+	}
+	if (test_multiple_updates() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_multiple_updates");
+		failed++;
+	}
+	if (test_reader_writer_interaction() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_reader_writer_interaction");
+		failed++;
+	}
+	if (test_multiple_workers() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_multiple_workers");
+		failed++;
+	}
+	if (test_epoch_synchronization() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_epoch_synchronization");
+		failed++;
+	}
+	if (test_concurrent_readers() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_concurrent_readers");
+		failed++;
+	}
+	if (test_concurrent_readers_with_writer() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_concurrent_readers_with_writer");
+		failed++;
+	}
+	if (test_rapid_updates() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_rapid_updates");
+		failed++;
+	}
+	if (test_all_workers_active() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_all_workers_active");
+		failed++;
+	}
+	if (test_memory_ordering() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_memory_ordering");
+		failed++;
+	}
+	if (test_rcu_load() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_rcu_load");
+		failed++;
+	}
+	if (test_aggressive_race_detection() != TEST_SUCCESS) {
+		LOG(ERROR, "FAILED: test_aggressive_race_detection");
+		failed++;
+	}
+
+	free(arena);
+
+	if (failed == 0) {
+		LOG(INFO, "=== All RCU tests passed! ===");
+		return TEST_SUCCESS;
+	}
+	LOG(ERROR, "=== %d RCU test(s) failed ===", failed);
+	return TEST_FAILED;
 }


### PR DESCRIPTION
## Motivation

A yanet dataplane can run arbitrarily many workers, so `RCU_WORKERS = 8` and its `MAX_WORKERS_NUM` mirror in the balancer are the wrong shape: RCU must track exactly as many workers as its owner has, decided at runtime.

## What changed

- `rcu_t` now holds a memory-context-allocated `workers` array, sized at `rcu_init` time; `rcu_free` releases it. The pointer is stored as a relative offset so `rcu_t` stays shared-memory-safe.
- `RCU_WORKERS` and the `static_assert` tying it to `MAX_WORKERS_NUM` are gone.
- Tests and benches build a local `block_allocator` + `memory_context`, dereference `rcu.workers` via `ADDR_OF`, and free the arena on exit.

## Follow-up

The balancer still hardcodes `MAX_WORKERS_NUM = 8` as the value it passes to `rcu_init` (from `session_table_init` / `selector_init`) and as the size of the inline `selector_worker` array. Same class of mistake, deliberately out of scope — fixing it means threading a runtime worker count through the balancer init path, which lands in a separate PR.