### PR TITLE
feat: new error handling pattern

### DIFF
--- a/bindings/go/cerrors/cgo.go
+++ b/bindings/go/cerrors/cgo.go
@@ -1,0 +1,49 @@
+// Package cerrors provides Go bindings for the C yanet_error type defined in
+// lib/errors.
+//
+// It is meant to be used by FFI wrappers to convert C error chains into
+// idiomatic Go errors.
+package cerrors
+
+//#cgo CFLAGS: -I../../../
+//#cgo LDFLAGS: -L../../../build/lib/errors -lerrors
+//
+//#include <stdlib.h>
+//#include "lib/errors/errors.h"
+import "C"
+
+import (
+	"errors"
+	"unsafe"
+)
+
+// Error is a Go wrapper around a formatted *C.yanet_error chain.
+//
+// The underlying C error chain is formatted and freed inside FromC().
+type Error struct {
+	msg string
+}
+
+func (m Error) Error() string {
+	return m.msg
+}
+
+// FromC converts a *C.yanet_error returned from C code into a Go error and
+// releases the underlying C chain.
+//
+// Returns nil when cErr is NULL.
+func FromC(cErr unsafe.Pointer) error {
+	if cErr == nil {
+		return nil
+	}
+	err := (*C.yanet_error)(cErr)
+	defer C.yanet_error_free(err)
+
+	cMsg := C.yanet_error_format(err)
+	if cMsg == nil {
+		return errors.New("yanet: out of memory formatting error")
+	}
+	defer C.free(unsafe.Pointer(cMsg))
+
+	return &Error{msg: C.GoString(cMsg)}
+}

--- a/lib/errors/errors.c
+++ b/lib/errors/errors.c
@@ -1,0 +1,169 @@
+#include "errors.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct yanet_error {
+	char *message;
+	struct yanet_error *cause;
+};
+
+// Static singleton returned when a constructor cannot allocate memory. It is
+// distinguished from heap-allocated errors by its address, so
+// yanet_error_free() can skip it safely.
+//
+// It is legal to pass as a cause to yanet_error_wrap().
+static yanet_error err_oom = {
+	.message = (char *)"out of memory",
+	.cause = NULL,
+};
+
+static yanet_error *
+yanet_error_vwrap(yanet_error *cause, const char *fmt, va_list ap) {
+	char *message = NULL;
+	if (vasprintf(&message, fmt, ap) < 0) {
+		// Preserve the chain; drop the new frame. If there was no
+		// chain to begin with, at least surface the OOM.
+		return cause != NULL ? cause : &err_oom;
+	}
+
+	yanet_error *err = malloc(sizeof(*err));
+	if (err == NULL) {
+		free(message);
+		return cause != NULL ? cause : &err_oom;
+	}
+
+	err->message = message;
+	err->cause = cause;
+	return err;
+}
+
+// Wraps an existing error with a new frame that prepends context.
+//
+// Ownership of `cause` is transferred to the returned error.
+//
+// If allocation fails, `cause` is returned unchanged: the chain is preserved,
+// only the new frame is lost. The `cause` MAY be NULL, in which case this
+// behaves like yanet_error_new().
+yanet_error *
+yanet_error_wrap(yanet_error *cause, const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	yanet_error *err = yanet_error_vwrap(cause, fmt, ap);
+	va_end(ap);
+	return err;
+}
+
+static yanet_error *
+yanet_error_vnew(const char *fmt, va_list ap) {
+	return yanet_error_vwrap(NULL, fmt, ap);
+}
+
+// Creates a leaf error with a printf-formatted message.
+//
+// On allocation failure a static out-of-memory singleton is returned, so the
+// caller never needs to check the result for NULL.
+//
+// The returned pointer must eventually be passed to yanet_error_free()
+// (directly or by being wrapped into another error).
+yanet_error *
+yanet_error_new(const char *fmt, ...) {
+	va_list ap;
+	va_start(ap, fmt);
+	yanet_error *err = yanet_error_vwrap(NULL, fmt, ap);
+	va_end(ap);
+	return err;
+}
+
+void
+yanet_error_free(yanet_error *err) {
+	while (err != NULL && err != &err_oom) {
+		yanet_error *cause = err->cause;
+		free(err->message);
+		free(err);
+		err = cause;
+	}
+}
+
+const char *
+yanet_error_message(const yanet_error *err) {
+	return err != NULL ? err->message : NULL;
+}
+
+const yanet_error *
+yanet_error_cause(const yanet_error *err) {
+	return err != NULL ? err->cause : NULL;
+}
+
+char *
+yanet_error_format(const yanet_error *err) {
+	if (err == NULL) {
+		return NULL;
+	}
+
+	// First pass: compute the required buffer size.
+	size_t total = 1; // \0 terminator.
+	for (const yanet_error *cur = err; cur != NULL; cur = cur->cause) {
+		total += strlen(cur->message);
+		if (cur->cause != NULL) {
+			total += 2; // ": "
+		}
+	}
+
+	char *out = malloc(total);
+	if (out == NULL) {
+		return NULL;
+	}
+
+	char *p = out;
+	char *end = out + total;
+	for (const yanet_error *cur = err; cur != NULL; cur = cur->cause) {
+		int n = snprintf(p, end - p, "%s", cur->message);
+		if (n < 0 || p + n >= end) {
+			// Should not happen given the pre-computed size, but
+			// bail out gracefully just in case.
+			free(out);
+			return NULL;
+		}
+		p += n;
+		if (cur->cause != NULL) {
+			n = snprintf(p, end - p, ": ");
+			if (n < 0 || p + n >= end) {
+				free(out);
+				return NULL;
+			}
+			p += n;
+		}
+	}
+
+	return out;
+}
+
+void
+yanet_error_add(yanet_error **err, const char *fmt, ...) {
+	if (err == NULL) {
+		return;
+	}
+
+	va_list ap;
+	va_start(ap, fmt);
+
+	if (*err == NULL) {
+		*err = yanet_error_vnew(fmt, ap);
+	} else {
+		*err = yanet_error_vwrap(*err, fmt, ap);
+	}
+
+	va_end(ap);
+}
+
+void
+yanet_error_reset(yanet_error **err) {
+	if (err == NULL || *err == NULL) {
+		return;
+	}
+	yanet_error_free(*err);
+	*err = NULL;
+}

--- a/lib/errors/errors.h
+++ b/lib/errors/errors.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <stdarg.h>
+
+// Error type.
+//
+// Functions that can fail and that wishes to set an extended error message
+// should accept `yanet_error **` as a last out-parameter.
+//
+// If such function does not fail, it should leave the error pointer unchanged.
+struct yanet_error;
+
+typedef struct yanet_error yanet_error;
+
+// Frees the whole chain.
+//
+// No-op on NULL and on the out-of-memory singleton.
+void
+yanet_error_free(yanet_error *err);
+
+// Returns the message of this frame (not the whole chain).
+const char *
+yanet_error_message(const yanet_error *err);
+
+// Returns the wrapped cause, or NULL if `err` is a leaf.
+const yanet_error *
+yanet_error_cause(const yanet_error *err);
+
+// Formats the chain as a heap-allocated C string.
+char *
+yanet_error_format(const yanet_error *err);
+
+// Adds an error frame to an error chain in-place.
+//
+// This is the preferred helper for functions that report errors via a
+// `yanet_error **` out-parameter.
+//
+// Behavior:
+// - If `err == NULL`, this function does nothing.
+// - If `err != NULL` and `*err == NULL`, a new leaf error is created.
+// - If `err != NULL` and `*err != NULL`, the existing error is wrapped with
+//   a new frame that prepends additional context.
+//
+// This makes the function suitable both for:
+// - creating a root error at the point where a failure happens, and
+// - adding context while propagating an existing error upward.
+//
+// Notes:
+// - Ownership of the resulting chain remains with the caller.
+// - Callers should normally pass a pointer to a variable initialized to NULL
+//   for a single logical operation.
+// - Reusing a non-NULL error across unrelated operations will extend the
+//   existing chain instead of replacing it.
+void
+yanet_error_add(yanet_error **err, const char *fmt, ...)
+	__attribute__((format(printf, 2, 3)));
+
+// Frees the current error chain stored in `*err` and resets it to NULL.
+//
+// Behavior:
+// - If `err == NULL`, this function does nothing.
+// - If `err != NULL` and `*err == NULL`, this function does nothing.
+// - Otherwise, the whole error chain is freed and `*err` is set to NULL.
+//
+// Use this before reusing the same `yanet_error *` variable for a new,
+// unrelated operation.
+void
+yanet_error_reset(yanet_error **err);

--- a/lib/errors/meson.build
+++ b/lib/errors/meson.build
@@ -1,0 +1,17 @@
+sources = files(
+  'errors.c',
+)
+
+lib_errors = static_library(
+  'errors',
+  sources,
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  include_directories: [yanet_rootdir],
+  install: false,
+)
+
+lib_errors_dep = declare_dependency(
+  link_with: lib_errors,
+  include_directories: [include_directories('.'), yanet_rootdir],
+)

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -1,6 +1,7 @@
 yanet_libdir = include_directories('.')
 
 subdir('logging')
+subdir('errors')
 subdir('counters')
 subdir('dataplane')
 subdir('controlplane')


### PR DESCRIPTION
Introduce an error chain that replaces the thread-local `diag/tls_stack` mechanism. Each frame carries a printf-formatted message and an optional cause pointer, forming a singly-linked list.

Add `bindings/go/cerrors` for converting C error chains into Go errors.

The migration of existing callers will follow in a separate change.