### PR TITLE
refactor(cli): no expect

### DIFF
--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -66,7 +66,7 @@ pub async fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
 
     let cmd = Cmd::parse();
-    logging::init(cmd.verbose as usize).expect("no error expected");
+    let _ = logging::init(cmd.verbose as usize);
 
     if let Err(err) = run(cmd).await {
         log::error!("ERROR: {err}");

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -125,7 +125,7 @@ pub async fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
 
     let cmd = Cmd::parse();
-    logging::init(cmd.verbose as usize).expect("no error expected");
+    let _ = logging::init(cmd.verbose as usize);
 
     if let Err(err) = run(cmd).await {
         log::error!("ERROR: {err}");

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -88,7 +88,7 @@ pub async fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
 
     let cmd = Cmd::parse();
-    logging::init(cmd.verbose as usize).expect("no error expected");
+    let _ = logging::init(cmd.verbose as usize);
 
     if let Err(err) = run(cmd).await {
         log::error!("ERROR: {err}");

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -41,7 +41,7 @@ pub async fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
 
     let cmd = Cmd::parse();
-    logging::init(cmd.verbose as usize).expect("no error expected");
+    let _ = logging::init(cmd.verbose as usize);
 
     if let Err(err) = run(cmd).await {
         log::error!("ERROR: {err}");

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -88,7 +88,7 @@ pub async fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
 
     let cmd = Cmd::parse();
-    logging::init(cmd.verbose as usize).expect("no error expected");
+    let _ = logging::init(cmd.verbose as usize);
 
     if let Err(err) = run(cmd).await {
         log::error!("ERROR: {err}");


### PR DESCRIPTION
Uninitialized logger is not a fatal error (however, unlikely).