### PR TITLE
feat: yanet-pipeline-operator

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -92,6 +92,9 @@ jobs:
           - component: bird-adapter
             image: ghcr.io/yanet-platform/yanet2/bird-adapter
             dockerfile: deploy/bird-adapter.Dockerfile
+          - component: pipeline-operator
+            image: ghcr.io/yanet-platform/yanet2/pipeline-operator
+            dockerfile: deploy/yanet-pipeline-operator.Dockerfile
     steps:
       - uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ install: dataplane cli-install
 	install -m 644 controlplane/etc/yanet/controlplane-director.yaml $(DESTDIR)/etc/yanet2/controlplane.yaml
 	install -m 644 dataplane.yaml $(DESTDIR)/etc/yanet2/dataplane.yaml
 	install -m 644 controlplane/etc/yanet/bird-adapter.yaml $(DESTDIR)/etc/yanet2/bird-adapter.yaml
+	install -m 644 agents/yanet-pipeline-operator/etc/yanet/yanet-pipeline-operator.yaml $(DESTDIR)/etc/yanet2/yanet-pipeline-operator.yaml
 
 clean: go-cache-clean $(foreach module,$(MODULES),cli-clean/$(module))
 	@echo "Cleaning build directories..."

--- a/agents/meson.build
+++ b/agents/meson.build
@@ -1,2 +1,3 @@
 subdir('bird-adapter')
+subdir('yanet-pipeline-operator')
 

--- a/agents/yanet-pipeline-operator/cmd/yanet-pipeline-operator/main.go
+++ b/agents/yanet-pipeline-operator/cmd/yanet-pipeline-operator/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/yanet-platform/yanet2/agents/yanet-pipeline-operator/internal/operator"
+	"github.com/yanet-platform/yanet2/common/go/logging"
+	"github.com/yanet-platform/yanet2/common/go/xcmd"
+)
+
+var rootArgs struct {
+	ConfigPath string
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "yanet-pipeline-operator",
+	Short: "YANET pipeline operator — manages pipelines and device bindings",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := run()
+		if errors.Is(err, xcmd.Interrupted{}) {
+			return nil
+		}
+
+		return err
+	},
+}
+
+func init() {
+	rootCmd.Flags().StringVarP(
+		&rootArgs.ConfigPath,
+		"config", "c", "",
+		"Path to the configuration file (required)",
+	)
+	rootCmd.MarkFlagRequired("config")
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		if errors.Is(err, xcmd.Interrupted{}) {
+			return
+		}
+		fmt.Printf("ERROR: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	cfg, err := operator.LoadConfig(rootArgs.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	log, _, err := logging.Init(&cfg.Logging)
+	if err != nil {
+		return fmt.Errorf("failed to initialize logging: %w", err)
+	}
+	defer log.Sync()
+
+	log.Debugw("parsed config", zap.Any("config", cfg))
+
+	operator, err := operator.NewOperator(cfg, operator.WithLog(log.Desugar()))
+	if err != nil {
+		return fmt.Errorf("failed to construct operator: %w", err)
+	}
+	defer func() {
+		if err := operator.Close(); err != nil {
+			log.Warnw("failed to close operator", zap.Error(err))
+		}
+	}()
+
+	wg, ctx := errgroup.WithContext(context.Background())
+	wg.Go(func() error {
+		return operator.Run(ctx)
+	})
+	wg.Go(func() error {
+		return xcmd.WaitInterrupted(ctx)
+	})
+
+	return wg.Wait()
+}

--- a/agents/yanet-pipeline-operator/etc/yanet/yanet-pipeline-operator.yaml
+++ b/agents/yanet-pipeline-operator/etc/yanet/yanet-pipeline-operator.yaml
@@ -1,0 +1,55 @@
+logging:
+  level: debug
+
+server:
+  endpoint: "[::1]:50001"
+
+gateways:
+  - name: numa0
+    endpoint: "[::1]:8080"
+
+reconcile:
+  interval: 30s
+  initial_backoff: 500ms
+  max_backoff: 30s
+
+stages:
+  - name: bootstrap
+    pipelines:
+      - name: main
+        functions:
+          - "fn:decap"
+          - "fn:acl"
+          - "fn:route"
+      - name: bypass
+        functions: []
+    devices:
+      plain:
+        - name: virtio_user_kni0
+          input:
+            - name: main
+              weight: 1
+          output:
+            - name: bypass
+              weight: 1
+      vlan: []
+  - name: production
+    pipelines:
+      - name: main
+        functions:
+          - "fn:decap"
+          - "fn:acl"
+          - "fn:route"
+          - "fn:balancer"
+      - name: bypass
+        functions: []
+    devices:
+      plain:
+        - name: virtio_user_kni0
+          input:
+            - name: main
+              weight: 1
+          output:
+            - name: bypass
+              weight: 1
+      vlan: []

--- a/agents/yanet-pipeline-operator/internal/operator/actuator_fanout.go
+++ b/agents/yanet-pipeline-operator/internal/operator/actuator_fanout.go
@@ -1,0 +1,75 @@
+package operator
+
+import (
+	"context"
+	"errors"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+// FanOutActuator applies a StageConfig to several Actuators concurrently.
+//
+// Apply waits for every underlying Actuator to complete and returns the
+// first non-nil error observed. If any underlying Actuator fails the stage
+// is considered "not applied" by the reconciler.
+type FanOutActuator struct {
+	actuators []Actuator
+
+	log *zap.Logger
+}
+
+func NewFanOutActuator(
+	actuators []Actuator,
+	options ...FanOutActuatorOption,
+) *FanOutActuator {
+	opts := newFanOutActuatorOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	return &FanOutActuator{
+		actuators: actuators,
+		log:       opts.Log,
+	}
+}
+
+// Apply runs Apply on every underlying Actuator concurrently.
+//
+// We deliberately use errgroup.Group without a derived context: every
+// underlying Apply runs to completion regardless of whether a sibling
+// failed, so each gateway lands in a deterministic state instead of a
+// half-applied one.
+func (m *FanOutActuator) Apply(ctx context.Context, stage *StageConfig) error {
+	wg := errgroup.Group{}
+	for _, a := range m.actuators {
+		wg.Go(func() error {
+			return a.Apply(ctx, stage)
+		})
+	}
+
+	if err := wg.Wait(); err != nil {
+		return err
+	}
+
+	m.log.Info("applied stage to gateways",
+		zap.String("stage", stage.Name),
+	)
+
+	return nil
+}
+
+// Close closes every underlying Actuator serially and joins their errors.
+//
+// Each Actuator is closed regardless of whether a sibling failed, so one
+// bad close does not mask others.
+func (m *FanOutActuator) Close() error {
+	var errs []error
+	for _, a := range m.actuators {
+		if err := a.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/agents/yanet-pipeline-operator/internal/operator/actuator_gateway.go
+++ b/agents/yanet-pipeline-operator/internal/operator/actuator_gateway.go
@@ -1,0 +1,170 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb"
+	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb"
+)
+
+// GatewayActuator applies a StageConfig to a single Gateway and prunes
+// pipelines that are no longer part of the desired stage.
+type GatewayActuator struct {
+	name      string
+	conn      *grpc.ClientConn
+	pipelines ynpb.PipelineServiceClient
+	plain     plainpb.DevicePlainServiceClient
+	vlan      vlanpb.DeviceVlanServiceClient
+
+	log *zap.Logger
+}
+
+// NewGatewayActuator dials the Gateway endpoint and returns a ready-to-use
+// actuator.
+func NewGatewayActuator(
+	cfg GatewayConfig,
+	options ...GatewayActuatorOption,
+) (*GatewayActuator, error) {
+	opts := newGatewayActuatorOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	endpoint := cfg.Endpoint.Unwrap()
+	conn, err := grpc.NewClient(
+		endpoint,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial gateway %q at %q: %w", cfg.Name, endpoint, err)
+	}
+
+	return &GatewayActuator{
+		name:      cfg.Name,
+		conn:      conn,
+		pipelines: ynpb.NewPipelineServiceClient(conn),
+		plain:     plainpb.NewDevicePlainServiceClient(conn),
+		vlan:      vlanpb.NewDeviceVlanServiceClient(conn),
+		log:       opts.Log.With(zap.String("gateway", cfg.Name)),
+	}, nil
+}
+
+func (m *GatewayActuator) Close() error {
+	return m.conn.Close()
+}
+
+// Apply pushes the stage to the Gateway and best-effort prunes stale
+// pipelines.
+//
+// Garbage collection failures are logged as warnings and never propagate.
+func (m *GatewayActuator) Apply(ctx context.Context, stage *StageConfig) error {
+	if err := m.applyStage(ctx, stage); err != nil {
+		return fmt.Errorf("failed to apply stage to gateway %q: %w", m.name, err)
+	}
+
+	m.log.Info("applied stage",
+		zap.String("stage", stage.Name),
+	)
+
+	if err := m.collectGarbage(ctx, stage); err != nil {
+		m.log.Warn("garbage collection failed", zap.Error(err))
+	}
+
+	return nil
+}
+
+// applyStage pushes pipelines and device bindings to the Gateway.
+//
+// Pipelines are updated first so subsequent device bindings can reference
+// them.
+func (m *GatewayActuator) applyStage(ctx context.Context, stage *StageConfig) error {
+	for _, p := range stage.Pipelines {
+		req := &ynpb.UpdatePipelineRequest{Pipeline: pipelineToProto(p)}
+		if _, err := m.pipelines.Update(ctx, req); err != nil {
+			return fmt.Errorf("update pipeline %q: %w", p.Name, err)
+		}
+
+		m.log.Debug("applied pipeline",
+			zap.String("pipeline", p.Name),
+			zap.Strings("functions", p.Functions),
+		)
+	}
+
+	for _, d := range stage.Devices.Plain {
+		req := plainDeviceToProto(d)
+		if _, err := m.plain.UpdateDevice(ctx, req); err != nil {
+			return fmt.Errorf("update plain device %q: %w", d.Name, err)
+		}
+
+		m.log.Debug("applied plain device",
+			zap.String("device", d.Name),
+			zap.Strings("input", devicePipelineRefStrings(d.Input)),
+			zap.Strings("output", devicePipelineRefStrings(d.Output)),
+		)
+	}
+
+	for _, d := range stage.Devices.VLAN {
+		req := vlanDeviceToProto(d)
+		if _, err := m.vlan.UpdateDevice(ctx, req); err != nil {
+			return fmt.Errorf("update vlan device %q: %w", d.Name, err)
+		}
+
+		m.log.Debug("applied vlan device",
+			zap.String("device", d.Name),
+			zap.Uint32("vlan", d.VLAN),
+			zap.Strings("input", devicePipelineRefStrings(d.Input)),
+			zap.Strings("output", devicePipelineRefStrings(d.Output)),
+		)
+	}
+
+	return nil
+}
+
+// collectGarbage deletes pipelines that exist on the Gateway but are not
+// part of the desired stage.
+//
+// Per-pipeline Delete failures are logged and skipped: pipelines still
+// referenced by a device will fail (PipelineService.Delete refuses while
+// any device references the pipeline), and that is expected behavior the
+// caller should not treat as fatal.
+//
+// Functions are intentionally not GC'd here: they are owned by their own
+// per-function operators (route-operator, acl-operator, ...).
+func (m *GatewayActuator) collectGarbage(ctx context.Context, stage *StageConfig) error {
+	desired := make(map[string]struct{}, len(stage.Pipelines))
+	for _, p := range stage.Pipelines {
+		desired[p.Name] = struct{}{}
+	}
+
+	list, err := m.pipelines.List(ctx, &ynpb.ListPipelinesRequest{})
+	if err != nil {
+		return fmt.Errorf("list pipelines: %w", err)
+	}
+
+	for _, id := range list.GetIds() {
+		if _, ok := desired[id.GetName()]; ok {
+			continue
+		}
+
+		req := &ynpb.DeletePipelineRequest{Id: id}
+		if _, err := m.pipelines.Delete(ctx, req); err != nil {
+			m.log.Warn("failed to delete stale pipeline",
+				zap.String("pipeline", id.GetName()),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		m.log.Info("deleted stale pipeline",
+			zap.String("pipeline", id.GetName()),
+		)
+	}
+
+	return nil
+}

--- a/agents/yanet-pipeline-operator/internal/operator/actuator_gateway.go
+++ b/agents/yanet-pipeline-operator/internal/operator/actuator_gateway.go
@@ -22,7 +22,8 @@ type GatewayActuator struct {
 	plain     plainpb.DevicePlainServiceClient
 	vlan      vlanpb.DeviceVlanServiceClient
 
-	log *zap.Logger
+	metrics GatewayActuatorMetricsObserver
+	log     *zap.Logger
 }
 
 // NewGatewayActuator dials the Gateway endpoint and returns a ready-to-use
@@ -51,6 +52,7 @@ func NewGatewayActuator(
 		pipelines: ynpb.NewPipelineServiceClient(conn),
 		plain:     plainpb.NewDevicePlainServiceClient(conn),
 		vlan:      vlanpb.NewDeviceVlanServiceClient(conn),
+		metrics:   opts.Metrics,
 		log:       opts.Log.With(zap.String("gateway", cfg.Name)),
 	}, nil
 }
@@ -64,7 +66,9 @@ func (m *GatewayActuator) Close() error {
 //
 // Garbage collection failures are logged as warnings and never propagate.
 func (m *GatewayActuator) Apply(ctx context.Context, stage *StageConfig) error {
-	if err := m.applyStage(ctx, stage); err != nil {
+	err := m.applyStage(ctx, stage)
+	m.metrics.OnApplyCompleted(err)
+	if err != nil {
 		return fmt.Errorf("failed to apply stage to gateway %q: %w", m.name, err)
 	}
 
@@ -72,7 +76,7 @@ func (m *GatewayActuator) Apply(ctx context.Context, stage *StageConfig) error {
 		zap.String("stage", stage.Name),
 	)
 
-	if err := m.collectGarbage(ctx, stage); err != nil {
+	if err := m.gc(ctx, stage); err != nil {
 		m.log.Warn("garbage collection failed", zap.Error(err))
 	}
 
@@ -85,8 +89,14 @@ func (m *GatewayActuator) Apply(ctx context.Context, stage *StageConfig) error {
 // them.
 func (m *GatewayActuator) applyStage(ctx context.Context, stage *StageConfig) error {
 	for _, p := range stage.Pipelines {
-		req := &ynpb.UpdatePipelineRequest{Pipeline: pipelineToProto(p)}
-		if _, err := m.pipelines.Update(ctx, req); err != nil {
+		_, err := m.pipelines.Update(
+			ctx,
+			&ynpb.UpdatePipelineRequest{
+				Pipeline: pipelineToProto(p),
+			},
+		)
+		m.metrics.OnResourceUpdated(kindPipeline, err)
+		if err != nil {
 			return fmt.Errorf("update pipeline %q: %w", p.Name, err)
 		}
 
@@ -97,8 +107,9 @@ func (m *GatewayActuator) applyStage(ctx context.Context, stage *StageConfig) er
 	}
 
 	for _, d := range stage.Devices.Plain {
-		req := plainDeviceToProto(d)
-		if _, err := m.plain.UpdateDevice(ctx, req); err != nil {
+		_, err := m.plain.UpdateDevice(ctx, plainDeviceToProto(d))
+		m.metrics.OnResourceUpdated(kindDevicePlain, err)
+		if err != nil {
 			return fmt.Errorf("update plain device %q: %w", d.Name, err)
 		}
 
@@ -110,8 +121,9 @@ func (m *GatewayActuator) applyStage(ctx context.Context, stage *StageConfig) er
 	}
 
 	for _, d := range stage.Devices.VLAN {
-		req := vlanDeviceToProto(d)
-		if _, err := m.vlan.UpdateDevice(ctx, req); err != nil {
+		_, err := m.vlan.UpdateDevice(ctx, vlanDeviceToProto(d))
+		m.metrics.OnResourceUpdated(kindDeviceVlan, err)
+		if err != nil {
 			return fmt.Errorf("update vlan device %q: %w", d.Name, err)
 		}
 
@@ -126,7 +138,7 @@ func (m *GatewayActuator) applyStage(ctx context.Context, stage *StageConfig) er
 	return nil
 }
 
-// collectGarbage deletes pipelines that exist on the Gateway but are not
+// gc deletes pipelines that exist on the Gateway but are not
 // part of the desired stage.
 //
 // Per-pipeline Delete failures are logged and skipped: pipelines still
@@ -136,7 +148,7 @@ func (m *GatewayActuator) applyStage(ctx context.Context, stage *StageConfig) er
 //
 // Functions are intentionally not GC'd here: they are owned by their own
 // per-function operators (route-operator, acl-operator, ...).
-func (m *GatewayActuator) collectGarbage(ctx context.Context, stage *StageConfig) error {
+func (m *GatewayActuator) gc(ctx context.Context, stage *StageConfig) error {
 	desired := make(map[string]struct{}, len(stage.Pipelines))
 	for _, p := range stage.Pipelines {
 		desired[p.Name] = struct{}{}
@@ -144,9 +156,11 @@ func (m *GatewayActuator) collectGarbage(ctx context.Context, stage *StageConfig
 
 	list, err := m.pipelines.List(ctx, &ynpb.ListPipelinesRequest{})
 	if err != nil {
+		m.metrics.OnGC(0, 0, err)
 		return fmt.Errorf("list pipelines: %w", err)
 	}
 
+	deleted, failed := 0, 0
 	for _, id := range list.GetIds() {
 		if _, ok := desired[id.GetName()]; ok {
 			continue
@@ -154,6 +168,7 @@ func (m *GatewayActuator) collectGarbage(ctx context.Context, stage *StageConfig
 
 		req := &ynpb.DeletePipelineRequest{Id: id}
 		if _, err := m.pipelines.Delete(ctx, req); err != nil {
+			failed++
 			m.log.Warn("failed to delete stale pipeline",
 				zap.String("pipeline", id.GetName()),
 				zap.Error(err),
@@ -161,10 +176,12 @@ func (m *GatewayActuator) collectGarbage(ctx context.Context, stage *StageConfig
 			continue
 		}
 
+		deleted++
 		m.log.Info("deleted stale pipeline",
 			zap.String("pipeline", id.GetName()),
 		)
 	}
 
+	m.metrics.OnGC(deleted, failed, nil)
 	return nil
 }

--- a/agents/yanet-pipeline-operator/internal/operator/cfg.go
+++ b/agents/yanet-pipeline-operator/internal/operator/cfg.go
@@ -1,0 +1,104 @@
+package operator
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/yanet-platform/yanet2/common/go/logging"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+const (
+	DefaultReconcileInterval       = 30 * time.Second
+	DefaultReconcileInitialBackoff = 500 * time.Millisecond
+	DefaultReconcileMaxBackoff     = 30 * time.Second
+)
+
+// Config is the top-level YAML configuration for yanet-pipeline-operator.
+type Config struct {
+	Logging   logging.Config    `yaml:"logging"`
+	Server    *GRPCServerConfig `yaml:"server"`
+	Gateways  []GatewayConfig   `yaml:"gateways"`
+	Reconcile ReconcileConfig   `yaml:"reconcile"`
+	Stages    []StageConfig     `yaml:"stages"`
+}
+
+// GatewayConfig holds the name and gRPC endpoint of a single Gateway.
+type GatewayConfig struct {
+	// Name is a human-readable label used in logs and status reports.
+	Name string `yaml:"name"`
+	// Endpoint is the gRPC address of the Gateway.
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+}
+
+// ReconcileConfig holds timing parameters for the reconcile loop.
+type ReconcileConfig struct {
+	// Interval is the steady-state period between successful reconcile
+	// passes.
+	Interval xcfg.NonZero[time.Duration] `yaml:"interval"`
+	// InitialBackoff is the first sleep after a failed pass; grows
+	// exponentially.
+	InitialBackoff xcfg.NonZero[time.Duration] `yaml:"initial_backoff"`
+	// MaxBackoff caps the exponential backoff sleep.
+	MaxBackoff xcfg.NonZero[time.Duration] `yaml:"max_backoff"`
+}
+
+func (m *ReconcileConfig) Validate() error {
+	if m.MaxBackoff.Unwrap() < m.InitialBackoff.Unwrap() {
+		return fmt.Errorf(
+			"max_backoff (%s) must be >= initial_backoff (%s)",
+			m.MaxBackoff.Unwrap(),
+			m.InitialBackoff.Unwrap(),
+		)
+	}
+
+	return nil
+}
+
+func (m *Config) Validate() error {
+	if len(m.Gateways) == 0 {
+		return errors.New("at least one gateway must be configured")
+	}
+
+	return nil
+}
+
+// DefaultConfig returns a Config populated with sensible defaults.
+func DefaultConfig() *Config {
+	return &Config{
+		Logging: logging.Config{
+			Level: zapcore.InfoLevel,
+		},
+		Server: &GRPCServerConfig{
+			Endpoint: xcfg.MustNonEmptyString("localhost:50001"),
+		},
+		Reconcile: ReconcileConfig{
+			Interval:       xcfg.MustNonZero(DefaultReconcileInterval),
+			InitialBackoff: xcfg.MustNonZero(DefaultReconcileInitialBackoff),
+			MaxBackoff:     xcfg.MustNonZero(DefaultReconcileMaxBackoff),
+		},
+	}
+}
+
+// LoadConfig reads a YAML file from path and returns the parsed Config.
+//
+// Default values are applied before unmarshalling so any absent field
+// retains its default. Validation is driven by xcfg.Decode, which calls
+// Validate() on every field whose type implements it.
+func LoadConfig(path string) (*Config, error) {
+	buf, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	cfg := DefaultConfig()
+	if err := xcfg.Decode(buf, cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	return cfg, nil
+}

--- a/agents/yanet-pipeline-operator/internal/operator/convert.go
+++ b/agents/yanet-pipeline-operator/internal/operator/convert.go
@@ -1,0 +1,66 @@
+package operator
+
+import (
+	"fmt"
+
+	"github.com/yanet-platform/yanet2/common/commonpb"
+	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb"
+	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb"
+)
+
+func pipelineToProto(p PipelineConfig) *ynpb.Pipeline {
+	functions := make([]*commonpb.FunctionId, len(p.Functions))
+	for idx, name := range p.Functions {
+		functions[idx] = &commonpb.FunctionId{Name: name}
+	}
+
+	return &ynpb.Pipeline{
+		Id:        &commonpb.PipelineId{Name: p.Name},
+		Functions: functions,
+	}
+}
+
+func plainDeviceToProto(d DeviceConfig) *plainpb.UpdateDevicePlainRequest {
+	return &plainpb.UpdateDevicePlainRequest{
+		Name: d.Name,
+		Device: &commonpb.Device{
+			Input:  devicePipelineToProto(d.Input),
+			Output: devicePipelineToProto(d.Output),
+		},
+	}
+}
+
+func vlanDeviceToProto(d VLANDeviceConfig) *vlanpb.UpdateDeviceVlanRequest {
+	return &vlanpb.UpdateDeviceVlanRequest{
+		Name: d.Name,
+		Vlan: d.VLAN,
+		Device: &commonpb.Device{
+			Input:  devicePipelineToProto(d.Input),
+			Output: devicePipelineToProto(d.Output),
+		},
+	}
+}
+
+func devicePipelineToProto(refs []PipelineRefConfig) []*commonpb.DevicePipeline {
+	out := make([]*commonpb.DevicePipeline, len(refs))
+	for idx, r := range refs {
+		out[idx] = &commonpb.DevicePipeline{
+			Name:   r.Name,
+			Weight: r.Weight,
+		}
+	}
+
+	return out
+}
+
+// devicePipelineRefStrings renders pipeline refs as "name(weight=N)"
+// strings for human-readable log output.
+func devicePipelineRefStrings(refs []PipelineRefConfig) []string {
+	out := make([]string, len(refs))
+	for idx, r := range refs {
+		out[idx] = fmt.Sprintf("%s(weight=%d)", r.Name, r.Weight)
+	}
+
+	return out
+}

--- a/agents/yanet-pipeline-operator/internal/operator/metrics.go
+++ b/agents/yanet-pipeline-operator/internal/operator/metrics.go
@@ -1,0 +1,253 @@
+package operator
+
+import (
+	"time"
+
+	"github.com/yanet-platform/yanet2/common/commonpb"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+)
+
+// Resource kinds reported via OnResourceUpdated.
+const (
+	kindPipeline    = "pipeline"
+	kindDevicePlain = "device-plain"
+	kindDeviceVlan  = "device-vlan"
+)
+
+var reconcilerStateNames = map[ReconcilerState]string{
+	ReconcilerStateIdle:     "idle",
+	ReconcilerStateApplying: "applying",
+	ReconcilerStateSleeping: "sleeping",
+}
+
+// Metrics is the single observability sink for the operator.
+type Metrics struct {
+	reconcileTotal  metrics.Counter
+	reconcileErrors metrics.Counter
+	stageAdvance    metrics.Counter
+
+	states         map[ReconcilerState]*metrics.Gauge
+	queueDepth     metrics.Gauge
+	backoffSeconds metrics.Gauge
+
+	gateways []*GatewayMetrics
+}
+
+func NewMetrics(gateways []*GatewayMetrics) *Metrics {
+	states := make(map[ReconcilerState]*metrics.Gauge, len(reconcilerStateNames))
+	for state := range reconcilerStateNames {
+		states[state] = &metrics.Gauge{}
+	}
+
+	return &Metrics{
+		states:   states,
+		gateways: gateways,
+	}
+}
+
+func (m *Metrics) OnReconcileCompleted(err error) {
+	m.reconcileTotal.Inc()
+	if err != nil {
+		m.reconcileErrors.Inc()
+	}
+}
+
+func (m *Metrics) OnStageAdvanced() {
+	m.stageAdvance.Inc()
+}
+
+func (m *Metrics) OnBackoffScheduled(delay time.Duration) {
+	m.backoffSeconds.Store(delay.Seconds())
+}
+
+func (m *Metrics) OnBackoffReset() {
+	m.backoffSeconds.Store(0)
+}
+
+func (m *Metrics) OnQueueChanged(depth int) {
+	m.queueDepth.Store(float64(depth))
+}
+
+func (m *Metrics) OnStateChanged(state ReconcilerState) {
+	for k, g := range m.states {
+		if k == state {
+			g.Store(1)
+		} else {
+			g.Store(0)
+		}
+	}
+}
+
+// Collect renders the current state of every metric as a []*commonpb.Metric.
+func (m *Metrics) Collect() []*commonpb.Metric {
+	out := make([]*commonpb.Metric, 0)
+
+	out = append(out, makeCounter(
+		"pipeline_operator_reconcile_total",
+		m.reconcileTotal.Load(),
+	))
+	out = append(out, makeCounter(
+		"pipeline_operator_reconcile_errors_total",
+		m.reconcileErrors.Load(),
+	))
+	out = append(out, makeCounter(
+		"pipeline_operator_stage_advance_total",
+		m.stageAdvance.Load(),
+	))
+
+	for state, g := range m.states {
+		out = append(out, makeGauge(
+			"pipeline_operator_state",
+			g.Load(),
+			makeLabel("state", reconcilerStateNames[state]),
+		))
+	}
+	out = append(out, makeGauge(
+		"pipeline_operator_queue_depth",
+		m.queueDepth.Load(),
+	))
+	out = append(out, makeGauge(
+		"pipeline_operator_backoff_seconds",
+		m.backoffSeconds.Load(),
+	))
+
+	for _, g := range m.gateways {
+		out = append(out, g.collect()...)
+	}
+
+	return out
+}
+
+// GatewayMetrics is the per-gateway implementation of
+// GatewayActuatorMetricsObserver.
+type GatewayMetrics struct {
+	name string
+
+	resourceUpdate       map[string]*metrics.Counter
+	resourceUpdateErrors map[string]*metrics.Counter
+
+	apply       metrics.Counter
+	applyErrors metrics.Counter
+
+	gcRuns         metrics.Counter
+	gcErrors       metrics.Counter
+	gcDeleted      metrics.Counter
+	gcDeleteErrors metrics.Counter
+}
+
+func NewGatewayMetrics(name string) *GatewayMetrics {
+	kinds := []string{kindPipeline, kindDevicePlain, kindDeviceVlan}
+
+	resourceUpdate := make(map[string]*metrics.Counter, len(kinds))
+	resourceUpdateErrors := make(map[string]*metrics.Counter, len(kinds))
+	for _, k := range kinds {
+		resourceUpdate[k] = &metrics.Counter{}
+		resourceUpdateErrors[k] = &metrics.Counter{}
+	}
+
+	return &GatewayMetrics{
+		name:                 name,
+		resourceUpdate:       resourceUpdate,
+		resourceUpdateErrors: resourceUpdateErrors,
+	}
+}
+
+func (m *GatewayMetrics) OnApplyCompleted(err error) {
+	m.apply.Inc()
+	if err != nil {
+		m.applyErrors.Inc()
+	}
+}
+
+func (m *GatewayMetrics) OnResourceUpdated(kind string, err error) {
+	if c, ok := m.resourceUpdate[kind]; ok {
+		c.Inc()
+	}
+
+	if err != nil {
+		if c, ok := m.resourceUpdateErrors[kind]; ok {
+			c.Inc()
+		}
+	}
+}
+
+// OnGC records the outcome of one garbage-collection pass.
+func (m *GatewayMetrics) OnGC(deleted, failed int, err error) {
+	m.gcRuns.Inc()
+	if err != nil || failed > 0 {
+		m.gcErrors.Inc()
+	}
+	if deleted > 0 {
+		m.gcDeleted.Add(uint64(deleted))
+	}
+	if failed > 0 {
+		m.gcDeleteErrors.Add(uint64(failed))
+	}
+}
+
+func (m *GatewayMetrics) collect() []*commonpb.Metric {
+	gw := makeLabel("gateway", m.name)
+	out := make([]*commonpb.Metric, 0)
+
+	out = append(out, makeCounter(
+		"pipeline_operator_gateway_apply_total",
+		m.apply.Load(),
+		gw,
+	))
+	out = append(out, makeCounter(
+		"pipeline_operator_gateway_apply_errors_total",
+		m.applyErrors.Load(),
+		gw,
+	))
+
+	for kind, c := range m.resourceUpdate {
+		out = append(out, makeCounter(
+			"pipeline_operator_resource_update_total",
+			c.Load(),
+			gw, makeLabel("kind", kind),
+		))
+	}
+	for kind, c := range m.resourceUpdateErrors {
+		out = append(out, makeCounter(
+			"pipeline_operator_resource_update_errors_total",
+			c.Load(),
+			gw, makeLabel("kind", kind),
+		))
+	}
+
+	out = append(out,
+		makeCounter("pipeline_operator_gc_runs_total", m.gcRuns.Load(), gw),
+		makeCounter("pipeline_operator_gc_errors_total", m.gcErrors.Load(), gw),
+		makeCounter(
+			"pipeline_operator_gc_pipelines_deleted_total",
+			m.gcDeleted.Load(),
+			gw,
+		),
+		makeCounter(
+			"pipeline_operator_gc_pipelines_delete_errors_total",
+			m.gcDeleteErrors.Load(),
+			gw,
+		),
+	)
+	return out
+}
+
+func makeLabel(name, value string) *commonpb.Label {
+	return &commonpb.Label{Name: name, Value: value}
+}
+
+func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &commonpb.Metric_Counter{Counter: value},
+	}
+}
+
+func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &commonpb.Metric_Gauge{Gauge: value},
+	}
+}

--- a/agents/yanet-pipeline-operator/internal/operator/metrics_observer.go
+++ b/agents/yanet-pipeline-operator/internal/operator/metrics_observer.go
@@ -1,0 +1,70 @@
+package operator
+
+import (
+	"time"
+
+	"github.com/yanet-platform/yanet2/common/commonpb"
+)
+
+// MetricsCollector renders the current state of the operator metrics
+// as a flat slice of commonpb.Metric values.
+type MetricsCollector interface {
+	Collect() []*commonpb.Metric
+}
+
+// noopMetricsCollector is the default MetricsCollector wired into
+// service options when the caller does not pass a real one.
+type noopMetricsCollector struct{}
+
+func (noopMetricsCollector) Collect() []*commonpb.Metric {
+	return nil
+}
+
+// ReconcilerState is the current state of the reconcile loop.
+type ReconcilerState int
+
+const (
+	ReconcilerStateIdle ReconcilerState = iota
+	ReconcilerStateApplying
+	ReconcilerStateSleeping
+)
+
+// ReconcilerMetricsObserver receives semantic events from the reconcile
+// loop and translates them into metrics.
+type ReconcilerMetricsObserver interface {
+	OnReconcileCompleted(err error)
+	OnStageAdvanced()
+	OnBackoffScheduled(delay time.Duration)
+	OnBackoffReset()
+	OnQueueChanged(depth int)
+	OnStateChanged(state ReconcilerState)
+}
+
+// GatewayActuatorMetricsObserver receives semantic events from a single
+// gateway actuator and translates them into metrics.
+type GatewayActuatorMetricsObserver interface {
+	OnApplyCompleted(err error)
+	OnResourceUpdated(kind string, err error)
+	OnGC(deleted, failed int, err error)
+}
+
+// noopReconcilerMetricsObserver is the default
+// ReconcilerMetricsObserver wired into reconciler options when no
+// metrics sink is attached.
+type noopReconcilerMetricsObserver struct{}
+
+func (noopReconcilerMetricsObserver) OnReconcileCompleted(error)       {}
+func (noopReconcilerMetricsObserver) OnStageAdvanced()                 {}
+func (noopReconcilerMetricsObserver) OnBackoffScheduled(time.Duration) {}
+func (noopReconcilerMetricsObserver) OnBackoffReset()                  {}
+func (noopReconcilerMetricsObserver) OnQueueChanged(int)               {}
+func (noopReconcilerMetricsObserver) OnStateChanged(ReconcilerState)   {}
+
+// noopGatewayActuatorMetricsObserver is the default
+// GatewayActuatorMetricsObserver wired into gateway-actuator options
+// when no metrics sink is attached.
+type noopGatewayActuatorMetricsObserver struct{}
+
+func (noopGatewayActuatorMetricsObserver) OnApplyCompleted(error)          {}
+func (noopGatewayActuatorMetricsObserver) OnResourceUpdated(string, error) {}
+func (noopGatewayActuatorMetricsObserver) OnGC(int, int, error)            {}

--- a/agents/yanet-pipeline-operator/internal/operator/operator.go
+++ b/agents/yanet-pipeline-operator/internal/operator/operator.go
@@ -24,16 +24,23 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 
 	log := opts.Log
 
+	gatewayMetrics := make([]*GatewayMetrics, len(cfg.Gateways))
+	for idx := range cfg.Gateways {
+		gatewayMetrics[idx] = NewGatewayMetrics(cfg.Gateways[idx].Name)
+	}
+	metrics := NewMetrics(gatewayMetrics)
+
 	server := NewGRPCServer(
 		cfg.Server,
-		NewService(WithServiceLog(log)),
+		NewService(WithServiceLog(log), WithServiceMetrics(metrics)),
 		WithGRPCLog(log),
 	)
 
 	actuators := make([]Actuator, 0, len(cfg.Gateways))
-	for _, gw := range cfg.Gateways {
+	for idx, gw := range cfg.Gateways {
 		actuator, err := NewGatewayActuator(
 			gw,
+			WithGatewayActuatorMetrics(gatewayMetrics[idx]),
 			WithGatewayActuatorLog(log),
 		)
 		if err != nil {
@@ -53,7 +60,6 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 
 	reconciler := NewReconciler(
 		actuator,
-		WithReconcilerLog(log),
 		WithReconcileInterval(
 			cfg.Reconcile.Interval.Unwrap(),
 		),
@@ -61,6 +67,8 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			cfg.Reconcile.InitialBackoff.Unwrap(),
 			cfg.Reconcile.MaxBackoff.Unwrap(),
 		),
+		WithReconcilerMetrics(metrics),
+		WithReconcilerLog(log),
 	)
 
 	m := &Operator{

--- a/agents/yanet-pipeline-operator/internal/operator/operator.go
+++ b/agents/yanet-pipeline-operator/internal/operator/operator.go
@@ -1,0 +1,99 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+)
+
+type Operator struct {
+	cfg        *Config
+	server     *GRPCServer
+	reconciler *Reconciler
+	actuator   Actuator
+	log        *zap.Logger
+}
+
+func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log
+
+	server := NewGRPCServer(
+		cfg.Server,
+		NewService(WithServiceLog(log)),
+		WithGRPCLog(log),
+	)
+
+	actuators := make([]Actuator, 0, len(cfg.Gateways))
+	for _, gw := range cfg.Gateways {
+		actuator, err := NewGatewayActuator(
+			gw,
+			WithGatewayActuatorLog(log),
+		)
+		if err != nil {
+			for _, a := range actuators {
+				_ = a.Close()
+			}
+			return nil, fmt.Errorf("failed to construct gateway actuator %q: %w", gw.Name, err)
+		}
+
+		actuators = append(actuators, actuator)
+	}
+
+	actuator := NewFanOutActuator(
+		actuators,
+		WithFanOutActuatorLog(log),
+	)
+
+	reconciler := NewReconciler(
+		actuator,
+		WithReconcilerLog(log),
+		WithReconcileInterval(
+			cfg.Reconcile.Interval.Unwrap(),
+		),
+		WithReconcileBackoff(
+			cfg.Reconcile.InitialBackoff.Unwrap(),
+			cfg.Reconcile.MaxBackoff.Unwrap(),
+		),
+	)
+
+	m := &Operator{
+		cfg:        cfg,
+		server:     server,
+		reconciler: reconciler,
+		actuator:   actuator,
+		log:        log,
+	}
+
+	return m, nil
+}
+
+func (m *Operator) Close() error {
+	return m.actuator.Close()
+}
+
+func (m *Operator) Run(ctx context.Context) error {
+	if len(m.cfg.Stages) > 0 {
+		queue := make([]*StageConfig, len(m.cfg.Stages))
+		for idx := range m.cfg.Stages {
+			queue[idx] = &m.cfg.Stages[idx]
+		}
+		m.reconciler.SetStages(queue)
+	}
+
+	wg, ctx := errgroup.WithContext(ctx)
+	wg.Go(func() error {
+		return m.server.Run(ctx)
+	})
+	wg.Go(func() error {
+		return m.reconciler.Run(ctx)
+	})
+
+	return wg.Wait()
+}

--- a/agents/yanet-pipeline-operator/internal/operator/options.go
+++ b/agents/yanet-pipeline-operator/internal/operator/options.go
@@ -26,18 +26,20 @@ func WithLog(log *zap.Logger) Option {
 }
 
 type reconcilerOptions struct {
-	Log            *zap.Logger
 	Interval       time.Duration
 	InitialBackoff time.Duration
 	MaxBackoff     time.Duration
+	Metrics        ReconcilerMetricsObserver
+	Log            *zap.Logger
 }
 
 func newReconcilerOptions() *reconcilerOptions {
 	return &reconcilerOptions{
-		Log:            zap.NewNop(),
 		Interval:       DefaultReconcileInterval,
 		InitialBackoff: DefaultReconcileInitialBackoff,
 		MaxBackoff:     DefaultReconcileMaxBackoff,
+		Metrics:        noopReconcilerMetricsObserver{},
+		Log:            zap.NewNop(),
 	}
 }
 
@@ -67,13 +69,21 @@ func WithReconcileBackoff(initial, max time.Duration) ReconcilerOption {
 	}
 }
 
+func WithReconcilerMetrics(metrics ReconcilerMetricsObserver) ReconcilerOption {
+	return func(o *reconcilerOptions) {
+		o.Metrics = metrics
+	}
+}
+
 type serviceOptions struct {
-	Log *zap.Logger
+	Metrics MetricsCollector
+	Log     *zap.Logger
 }
 
 func newServiceOptions() *serviceOptions {
 	return &serviceOptions{
-		Log: zap.NewNop(),
+		Metrics: noopMetricsCollector{},
+		Log:     zap.NewNop(),
 	}
 }
 
@@ -85,13 +95,25 @@ func WithServiceLog(log *zap.Logger) ServiceOption {
 	}
 }
 
+// WithServiceMetrics attaches the metrics sink that GetMetrics serves
+// from.
+//
+// When unset, GetMetrics returns an empty response.
+func WithServiceMetrics(m MetricsCollector) ServiceOption {
+	return func(o *serviceOptions) {
+		o.Metrics = m
+	}
+}
+
 type gatewayActuatorOptions struct {
-	Log *zap.Logger
+	Metrics GatewayActuatorMetricsObserver
+	Log     *zap.Logger
 }
 
 func newGatewayActuatorOptions() *gatewayActuatorOptions {
 	return &gatewayActuatorOptions{
-		Log: zap.NewNop(),
+		Metrics: noopGatewayActuatorMetricsObserver{},
+		Log:     zap.NewNop(),
 	}
 }
 
@@ -100,6 +122,12 @@ type GatewayActuatorOption func(*gatewayActuatorOptions)
 func WithGatewayActuatorLog(log *zap.Logger) GatewayActuatorOption {
 	return func(o *gatewayActuatorOptions) {
 		o.Log = log
+	}
+}
+
+func WithGatewayActuatorMetrics(metrics GatewayActuatorMetricsObserver) GatewayActuatorOption {
+	return func(o *gatewayActuatorOptions) {
+		o.Metrics = metrics
 	}
 }
 

--- a/agents/yanet-pipeline-operator/internal/operator/options.go
+++ b/agents/yanet-pipeline-operator/internal/operator/options.go
@@ -1,0 +1,122 @@
+package operator
+
+import (
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type options struct {
+	Log *zap.Logger
+}
+
+func newOptions() *options {
+	return &options{
+		Log: zap.NewNop(),
+	}
+}
+
+type Option func(*options)
+
+// WithLog sets the logger for the Operator and all sub-components.
+func WithLog(log *zap.Logger) Option {
+	return func(o *options) {
+		o.Log = log
+	}
+}
+
+type reconcilerOptions struct {
+	Log            *zap.Logger
+	Interval       time.Duration
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+}
+
+func newReconcilerOptions() *reconcilerOptions {
+	return &reconcilerOptions{
+		Log:            zap.NewNop(),
+		Interval:       DefaultReconcileInterval,
+		InitialBackoff: DefaultReconcileInitialBackoff,
+		MaxBackoff:     DefaultReconcileMaxBackoff,
+	}
+}
+
+type ReconcilerOption func(*reconcilerOptions)
+
+// WithReconcilerLog sets the logger used by the reconcile loop.
+func WithReconcilerLog(log *zap.Logger) ReconcilerOption {
+	return func(o *reconcilerOptions) {
+		o.Log = log
+	}
+}
+
+// WithReconcileInterval sets the steady-state period between successful
+// reconcile passes.
+func WithReconcileInterval(d time.Duration) ReconcilerOption {
+	return func(o *reconcilerOptions) {
+		o.Interval = d
+	}
+}
+
+// WithReconcileBackoff sets the initial and maximum sleep durations for
+// the exponential backoff applied after failed reconcile passes.
+func WithReconcileBackoff(initial, max time.Duration) ReconcilerOption {
+	return func(o *reconcilerOptions) {
+		o.InitialBackoff = initial
+		o.MaxBackoff = max
+	}
+}
+
+type serviceOptions struct {
+	Log *zap.Logger
+}
+
+func newServiceOptions() *serviceOptions {
+	return &serviceOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+type ServiceOption func(*serviceOptions)
+
+func WithServiceLog(log *zap.Logger) ServiceOption {
+	return func(o *serviceOptions) {
+		o.Log = log
+	}
+}
+
+type gatewayActuatorOptions struct {
+	Log *zap.Logger
+}
+
+func newGatewayActuatorOptions() *gatewayActuatorOptions {
+	return &gatewayActuatorOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+type GatewayActuatorOption func(*gatewayActuatorOptions)
+
+func WithGatewayActuatorLog(log *zap.Logger) GatewayActuatorOption {
+	return func(o *gatewayActuatorOptions) {
+		o.Log = log
+	}
+}
+
+type fanOutActuatorOptions struct {
+	Log *zap.Logger
+}
+
+func newFanOutActuatorOptions() *fanOutActuatorOptions {
+	return &fanOutActuatorOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+type FanOutActuatorOption func(*fanOutActuatorOptions)
+
+func WithFanOutActuatorLog(log *zap.Logger) FanOutActuatorOption {
+	return func(o *fanOutActuatorOptions) {
+		o.Log = log
+	}
+}

--- a/agents/yanet-pipeline-operator/internal/operator/reconciler.go
+++ b/agents/yanet-pipeline-operator/internal/operator/reconciler.go
@@ -33,7 +33,8 @@ type Reconciler struct {
 
 	wakeCh chan struct{}
 
-	log *zap.Logger
+	metrics ReconcilerMetricsObserver
+	log     *zap.Logger
 }
 
 // NewReconciler constructs a Reconciler bound to the given Actuator.
@@ -54,8 +55,9 @@ func NewReconciler(actuator Actuator, options ...ReconcilerOption) *Reconciler {
 		actuator: actuator,
 		backoff:  backoff,
 		interval: opts.Interval,
-		log:      opts.Log,
 		wakeCh:   make(chan struct{}, 1),
+		metrics:  opts.Metrics,
+		log:      opts.Log,
 	}
 }
 
@@ -64,6 +66,15 @@ func NewReconciler(actuator Actuator, options ...ReconcilerOption) *Reconciler {
 //
 // An empty or nil slice returns the reconciler to the idle state.
 func (m *Reconciler) SetStages(stages []*StageConfig) {
+	depth := m.replaceStages(stages)
+
+	m.metrics.OnQueueChanged(depth)
+}
+
+// replaceStages swaps the queue under the lock and signals Run. It
+// returns the resulting queue depth so the caller can publish metrics
+// outside the lock.
+func (m *Reconciler) replaceStages(stages []*StageConfig) int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -73,6 +84,8 @@ func (m *Reconciler) SetStages(stages []*StageConfig) {
 	case m.wakeCh <- struct{}{}:
 	default:
 	}
+
+	return len(m.stages)
 }
 
 // Switch replaces the queue with a single target stage and wakes Run
@@ -104,6 +117,7 @@ func (m *Reconciler) Run(ctx context.Context) error {
 	for {
 		target := m.snapshot()
 		if target == nil {
+			m.metrics.OnStateChanged(ReconcilerStateIdle)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -114,6 +128,7 @@ func (m *Reconciler) Run(ctx context.Context) error {
 		}
 
 		var d time.Duration
+		m.metrics.OnStateChanged(ReconcilerStateApplying)
 		err := m.actuator.Apply(ctx, target)
 		if err != nil {
 			if ctx.Err() != nil {
@@ -125,12 +140,17 @@ func (m *Reconciler) Run(ctx context.Context) error {
 				zap.Error(err),
 			)
 			d = m.backoff.NextBackOff()
+			m.metrics.OnReconcileCompleted(err)
+			m.metrics.OnBackoffScheduled(d)
 		} else {
 			m.advance(target)
 			d = m.interval
 			m.backoff.Reset()
+			m.metrics.OnReconcileCompleted(nil)
+			m.metrics.OnBackoffReset()
 		}
 
+		m.metrics.OnStateChanged(ReconcilerStateSleeping)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -168,20 +188,38 @@ func (m *Reconciler) snapshot() *StageConfig {
 // advance drops the just-applied head from the queue, exposing the
 // next stage. The tail stage is preserved as the steady-state target.
 //
+// The mutation runs under the lock in popHead; metric observers are
+// invoked here, after the lock has been released, so they never
+// contend with concurrent reconciler state changes.
+func (m *Reconciler) advance(applied *StageConfig) {
+	advanced, depth := m.popHead(applied)
+	if !advanced {
+		return
+	}
+
+	m.metrics.OnStageAdvanced()
+	m.metrics.OnQueueChanged(depth)
+}
+
+// popHead drops the just-applied head if it is still at the front of
+// the queue. It runs entirely under the lock and returns whether a
+// transition happened along with the resulting queue depth so the
+// caller can publish metrics outside the lock.
+//
 // If the queue was concurrently replaced by SetStages while Apply was
 // in flight, the stage we just applied may no longer be at the head;
-// in that case we leave the queue alone so the new head wins on the
-// next iteration.
-func (m *Reconciler) advance(applied *StageConfig) {
+// in that case the queue is left alone so the new head wins on the
+// next iteration. The single-element queue is also preserved as the
+// steady-state target.
+func (m *Reconciler) popHead(applied *StageConfig) (bool, int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if len(m.stages) == 0 || m.stages[0] != applied {
-		return
+		return false, 0
 	}
-
 	if len(m.stages) == 1 {
-		return
+		return false, 0
 	}
 
 	next := m.stages[1]
@@ -195,4 +233,6 @@ func (m *Reconciler) advance(applied *StageConfig) {
 	case m.wakeCh <- struct{}{}:
 	default:
 	}
+
+	return true, len(m.stages)
 }

--- a/agents/yanet-pipeline-operator/internal/operator/reconciler.go
+++ b/agents/yanet-pipeline-operator/internal/operator/reconciler.go
@@ -1,0 +1,198 @@
+package operator
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"go.uber.org/zap"
+)
+
+// Actuator applies a desired stage configuration.
+type Actuator interface {
+	Apply(ctx context.Context, stage *StageConfig) error
+	Close() error
+}
+
+// Reconciler drives the system through an ordered queue of target
+// StageConfigs.
+//
+// The head of the queue is the active reconcile target. After a
+// successful Apply the head is dropped, exposing the next stage —
+// unless the queue has length one, in which case the tail stage is
+// retained as the steady-state target and applied on the configured
+// interval.
+type Reconciler struct {
+	actuator Actuator
+	backoff  backoff.ExponentialBackOff
+	interval time.Duration
+
+	mu     sync.Mutex
+	stages []*StageConfig
+
+	wakeCh chan struct{}
+
+	log *zap.Logger
+}
+
+// NewReconciler constructs a Reconciler bound to the given Actuator.
+func NewReconciler(actuator Actuator, options ...ReconcilerOption) *Reconciler {
+	opts := newReconcilerOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	backoff := backoff.ExponentialBackOff{
+		InitialInterval:     opts.InitialBackoff,
+		RandomizationFactor: backoff.DefaultRandomizationFactor,
+		Multiplier:          backoff.DefaultMultiplier,
+		MaxInterval:         opts.MaxBackoff,
+	}
+
+	return &Reconciler{
+		actuator: actuator,
+		backoff:  backoff,
+		interval: opts.Interval,
+		log:      opts.Log,
+		wakeCh:   make(chan struct{}, 1),
+	}
+}
+
+// SetStages atomically replaces the queue of target stages and wakes Run if
+// it is sleeping.
+//
+// An empty or nil slice returns the reconciler to the idle state.
+func (m *Reconciler) SetStages(stages []*StageConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.stages = stages
+
+	select {
+	case m.wakeCh <- struct{}{}:
+	default:
+	}
+}
+
+// Switch replaces the queue with a single target stage and wakes Run
+// if it is sleeping.
+//
+// It is a thin wrapper over SetStages — calling it from any source
+// (config bootstrap, gRPC API) atomically discards whatever queue was being
+// walked.
+func (m *Reconciler) Switch(stage *StageConfig) {
+	m.SetStages([]*StageConfig{stage})
+}
+
+// Run executes the reconcile loop until specified context is cancelled.
+//
+// The loop has three states:
+//   - Idle (queue empty — block on ctx and wake).
+//   - Applying (Apply runs to completion).
+//   - Sleeping (interval after success, backoff after failure;
+//     preemptable by SetStages/Switch or ctx).
+//
+// Apply is never cancelled mid-flight by a concurrent SetStages —
+// preemption happens between applies, not within them.
+func (m *Reconciler) Run(ctx context.Context) error {
+	m.log.Info("running reconciler loop")
+	defer m.log.Info("stopped reconciler loop")
+
+	m.backoff.Reset()
+
+	for {
+		target := m.snapshot()
+		if target == nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-m.wakeCh:
+			}
+
+			continue
+		}
+
+		var d time.Duration
+		err := m.actuator.Apply(ctx, target)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+
+			m.log.Warn("reconcile failed",
+				zap.String("stage", target.Name),
+				zap.Error(err),
+			)
+			d = m.backoff.NextBackOff()
+		} else {
+			m.advance(target)
+			d = m.interval
+			m.backoff.Reset()
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-m.wakeCh:
+		case <-time.After(d):
+		}
+	}
+}
+
+// snapshot returns the current queue head and drains any pending wake
+// signal.
+//
+// Draining under the same lock SetStages holds means a wake signal
+// that pre-dates the snapshot is consumed alongside the target it
+// announced, so the next sleep won't trip on it.
+//
+// A wake signal arriving after this call is preserved by SetStages
+// re-filling the buffered slot.
+func (m *Reconciler) snapshot() *StageConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	select {
+	case <-m.wakeCh:
+	default:
+	}
+
+	if len(m.stages) == 0 {
+		return nil
+	}
+
+	return m.stages[0]
+}
+
+// advance drops the just-applied head from the queue, exposing the
+// next stage. The tail stage is preserved as the steady-state target.
+//
+// If the queue was concurrently replaced by SetStages while Apply was
+// in flight, the stage we just applied may no longer be at the head;
+// in that case we leave the queue alone so the new head wins on the
+// next iteration.
+func (m *Reconciler) advance(applied *StageConfig) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(m.stages) == 0 || m.stages[0] != applied {
+		return
+	}
+
+	if len(m.stages) == 1 {
+		return
+	}
+
+	next := m.stages[1]
+	m.stages = m.stages[1:]
+	m.log.Info("advanced to next stage",
+		zap.String("from", applied.Name),
+		zap.String("to", next.Name),
+	)
+
+	select {
+	case m.wakeCh <- struct{}{}:
+	default:
+	}
+}

--- a/agents/yanet-pipeline-operator/internal/operator/reconciler_test.go
+++ b/agents/yanet-pipeline-operator/internal/operator/reconciler_test.go
@@ -1,0 +1,298 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockActuator struct {
+	mu       sync.Mutex
+	calls    []*StageConfig
+	errs     []error
+	notifyCh chan struct{}
+}
+
+func newMockActuator() *mockActuator {
+	return &mockActuator{
+		notifyCh: make(chan struct{}, 64),
+	}
+}
+
+func (m *mockActuator) Apply(ctx context.Context, stage *StageConfig) error {
+	m.mu.Lock()
+	m.calls = append(m.calls, stage)
+	var err error
+	if len(m.errs) > 0 {
+		err = m.errs[0]
+		m.errs = m.errs[1:]
+	}
+	m.mu.Unlock()
+
+	select {
+	case m.notifyCh <- struct{}{}:
+	default:
+	}
+
+	return err
+}
+
+func (m *mockActuator) Close() error { return nil }
+
+func (m *mockActuator) CallsCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return len(m.calls)
+}
+
+func (m *mockActuator) LastCall() *StageConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.calls) == 0 {
+		return nil
+	}
+
+	return m.calls[len(m.calls)-1]
+}
+
+func (m *mockActuator) Calls() []*StageConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	out := make([]*StageConfig, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+func (m *mockActuator) QueueErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.errs = append(m.errs, err)
+}
+
+func waitApply(t *testing.T, a *mockActuator, timeout time.Duration) {
+	t.Helper()
+
+	select {
+	case <-a.notifyCh:
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for Apply")
+	}
+}
+
+func runReconciler(t *testing.T, r *Reconciler) (context.CancelFunc, <-chan error) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- r.Run(ctx)
+	}()
+
+	return cancel, errCh
+}
+
+// Idle Run unwinds on ctx cancel.
+func TestReconciler_IdleCancellation(t *testing.T) {
+	a := newMockActuator()
+	r := NewReconciler(a)
+
+	cancel, errCh := runReconciler(t, r)
+
+	// Give the loop a moment to settle into the idle select.
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, 0, a.CallsCount())
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Reconciler.Run did not return after cancel")
+	}
+}
+
+// Pre-Run Switch is observed on iter 1.
+func TestReconciler_SwitchBeforeRun(t *testing.T) {
+	a := newMockActuator()
+	r := NewReconciler(
+		a,
+		WithReconcileInterval(time.Hour), // would block forever without preemption
+	)
+
+	stage := &StageConfig{Name: "boot"}
+	r.Switch(stage)
+
+	cancel, errCh := runReconciler(t, r)
+	defer func() {
+		cancel()
+		<-errCh
+	}()
+
+	waitApply(t, a, time.Second)
+
+	require.Equal(t, 1, a.CallsCount())
+	require.Same(t, stage, a.LastCall())
+}
+
+// Switch wakes a post-success sleep.
+func TestReconciler_SwitchPreemptsSleep(t *testing.T) {
+	a := newMockActuator()
+	r := NewReconciler(
+		a,
+		WithReconcileInterval(time.Hour), // would block forever without preemption
+	)
+
+	first := &StageConfig{Name: "first"}
+	r.Switch(first)
+
+	cancel, errCh := runReconciler(t, r)
+	defer func() {
+		cancel()
+		<-errCh
+	}()
+
+	waitApply(t, a, time.Second)
+
+	second := &StageConfig{Name: "second"}
+	start := time.Now()
+	r.Switch(second)
+
+	waitApply(t, a, time.Second)
+
+	require.Less(t, time.Since(start), 800*time.Millisecond,
+		"Reconciler.Switch should preempt the long sleep, not wait for the interval")
+	require.Equal(t, "second", a.LastCall().Name)
+}
+
+// Error backs off, success resets.
+//
+// The first call returns an error and the loop retries after a short
+// backoff sleep (not the long success interval); the subsequent
+// successful Apply resets the backoff and the loop falls into the
+// configured interval.
+func TestReconciler_BackoffOnErrorThenReset(t *testing.T) {
+	a := newMockActuator()
+	a.QueueErr(errors.New("boom")) // first call fails, second succeeds
+
+	r := NewReconciler(
+		a,
+		WithReconcileInterval(time.Hour),
+		WithReconcileBackoff(5*time.Millisecond, 50*time.Millisecond),
+	)
+
+	stage := &StageConfig{Name: "stage"}
+	r.Switch(stage)
+
+	cancel, errCh := runReconciler(t, r)
+	defer func() {
+		cancel()
+		<-errCh
+	}()
+
+	// First Apply: errors out.
+	waitApply(t, a, time.Second)
+	require.Equal(t, 1, a.CallsCount())
+
+	// Second Apply happens after a short backoff sleep, well under the
+	// hour-long success interval.
+	start := time.Now()
+	waitApply(t, a, time.Second)
+
+	require.Less(t, time.Since(start), 800*time.Millisecond,
+		"retry should occur after backoff, not after interval")
+	require.Equal(t, 2, a.CallsCount())
+
+	// After success the next sleep is `interval` (one hour), so no
+	// further Apply call should fire within a short window.
+	select {
+	case <-a.notifyCh:
+		t.Fatalf("unexpected Apply: backoff should have reset to interval")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// SetStages walks the queue: each stage is applied successfully
+// before the next one is exposed, and the tail stage is retained as
+// the steady-state target.
+func TestReconciler_WalksQueue(t *testing.T) {
+	a := newMockActuator()
+	a.QueueErr(errors.New("boom")) // first apply of s1 fails
+
+	r := NewReconciler(
+		a,
+		WithReconcileInterval(time.Hour),
+		WithReconcileBackoff(5*time.Millisecond, 50*time.Millisecond),
+	)
+
+	s1 := &StageConfig{Name: "s1"}
+	s2 := &StageConfig{Name: "s2"}
+	s3 := &StageConfig{Name: "s3"}
+	r.SetStages([]*StageConfig{s1, s2, s3})
+
+	cancel, errCh := runReconciler(t, r)
+	defer func() {
+		cancel()
+		<-errCh
+	}()
+
+	require.Eventually(t, func() bool { return a.CallsCount() >= 4 },
+		time.Second, 5*time.Millisecond)
+
+	calls := a.Calls()
+	require.Equal(t, "s1", calls[0].Name, "first apply: s1 (fails)")
+	require.Equal(t, "s1", calls[1].Name, "s1 must succeed before advancing")
+	require.Equal(t, "s2", calls[2].Name, "advance to s2")
+	require.Equal(t, "s3", calls[3].Name, "advance to s3")
+
+	// Once the queue collapses to s3 the next sleep is the interval
+	// (one hour), so no further Apply call should fire within a
+	// short window.
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, 4, a.CallsCount(),
+		"queue should hold s3 until interval elapses")
+}
+
+// Switch atomically replaces a queue mid-walk.
+func TestReconciler_SwitchReplacesQueue(t *testing.T) {
+	a := newMockActuator()
+
+	r := NewReconciler(
+		a,
+		WithReconcileInterval(time.Hour),
+	)
+
+	s1 := &StageConfig{Name: "s1"}
+	s2 := &StageConfig{Name: "s2"}
+	other := &StageConfig{Name: "other"}
+	r.SetStages([]*StageConfig{s1, s2})
+
+	cancel, errCh := runReconciler(t, r)
+	defer func() {
+		cancel()
+		<-errCh
+	}()
+
+	require.Eventually(t, func() bool { return a.CallsCount() >= 2 },
+		time.Second, 5*time.Millisecond)
+
+	r.Switch(other)
+
+	require.Eventually(t, func() bool {
+		c := a.LastCall()
+		return c != nil && c.Name == "other"
+	}, time.Second, 5*time.Millisecond,
+		"Switch must replace the queue, not let it advance further")
+
+	countBefore := a.CallsCount()
+	time.Sleep(100 * time.Millisecond)
+	require.Equal(t, countBefore, a.CallsCount(),
+		"queue should hold other until interval elapses")
+}

--- a/agents/yanet-pipeline-operator/internal/operator/server.go
+++ b/agents/yanet-pipeline-operator/internal/operator/server.go
@@ -1,0 +1,98 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	"github.com/yanet-platform/yanet2/agents/yanet-pipeline-operator/operatorpb"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+type grpcServerOptions struct {
+	Log *zap.Logger
+}
+
+func newGRPCServerOptions() *grpcServerOptions {
+	return &grpcServerOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+type GRPCServerOption func(*grpcServerOptions)
+
+func WithGRPCLog(log *zap.Logger) GRPCServerOption {
+	return func(o *grpcServerOptions) {
+		o.Log = log
+	}
+}
+
+type GRPCServerConfig struct {
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+}
+
+type GRPCServer struct {
+	cfg    *GRPCServerConfig
+	server *grpc.Server
+	log    *zap.Logger
+}
+
+func NewGRPCServer(
+	cfg *GRPCServerConfig,
+	service *Service,
+	options ...GRPCServerOption,
+) *GRPCServer {
+	opts := newGRPCServerOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	server := grpc.NewServer()
+	operatorpb.RegisterPipelineOperatorServiceServer(server, service)
+
+	return &GRPCServer{
+		cfg:    cfg,
+		server: server,
+		log:    opts.Log,
+	}
+}
+
+func (m *GRPCServer) Run(ctx context.Context) error {
+	endpoint := m.cfg.Endpoint.Unwrap()
+	listener, err := net.Listen("tcp", endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to listen gRPC on %q: %w", endpoint, err)
+	}
+
+	m.log.Info("exposing gRPC server",
+		zap.String("addr", listener.Addr().String()),
+	)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- m.server.Serve(listener)
+	}()
+
+	select {
+	case <-ctx.Done():
+		m.log.Info("stopping gRPC server", zap.Stringer("addr", listener.Addr()))
+		defer m.log.Info("stopped gRPC server", zap.Stringer("addr", listener.Addr()))
+
+		m.server.GracefulStop()
+		// Drain Serve's return value; after GracefulStop it returns nil
+		// on clean shutdown.
+		if err := <-serveErr; err != nil {
+			return fmt.Errorf("failed to serve gRPC: %w", err)
+		}
+		return nil
+	case err := <-serveErr:
+		// Serve returned before ctx was cancelled — treat as fatal.
+		if err != nil {
+			return fmt.Errorf("failed to serve gRPC: %w", err)
+		}
+		return nil
+	}
+}

--- a/agents/yanet-pipeline-operator/internal/operator/service.go
+++ b/agents/yanet-pipeline-operator/internal/operator/service.go
@@ -1,6 +1,8 @@
 package operator
 
 import (
+	"context"
+
 	"go.uber.org/zap"
 
 	"github.com/yanet-platform/yanet2/agents/yanet-pipeline-operator/operatorpb"
@@ -10,7 +12,8 @@ import (
 type Service struct {
 	operatorpb.UnimplementedPipelineOperatorServiceServer
 
-	log *zap.Logger
+	metrics MetricsCollector
+	log     *zap.Logger
 }
 
 func NewService(options ...ServiceOption) *Service {
@@ -20,6 +23,22 @@ func NewService(options ...ServiceOption) *Service {
 	}
 
 	return &Service{
-		log: opts.Log,
+		metrics: opts.Metrics,
+		log:     opts.Log,
 	}
+}
+
+// GetMetrics returns the current snapshot of all operator metrics.
+//
+// When no metrics sink is wired in, the response is empty rather than an
+// error.
+func (m *Service) GetMetrics(
+	ctx context.Context,
+	req *operatorpb.GetMetricsRequest,
+) (*operatorpb.GetMetricsResponse, error) {
+	metrics := m.metrics.Collect()
+
+	return &operatorpb.GetMetricsResponse{
+		Metrics: metrics,
+	}, nil
 }

--- a/agents/yanet-pipeline-operator/internal/operator/service.go
+++ b/agents/yanet-pipeline-operator/internal/operator/service.go
@@ -1,0 +1,25 @@
+package operator
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/yanet-platform/yanet2/agents/yanet-pipeline-operator/operatorpb"
+)
+
+// Service implements the PipelineOperatorService gRPC API.
+type Service struct {
+	operatorpb.UnimplementedPipelineOperatorServiceServer
+
+	log *zap.Logger
+}
+
+func NewService(options ...ServiceOption) *Service {
+	opts := newServiceOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	return &Service{
+		log: opts.Log,
+	}
+}

--- a/agents/yanet-pipeline-operator/internal/operator/stage.go
+++ b/agents/yanet-pipeline-operator/internal/operator/stage.go
@@ -1,0 +1,35 @@
+package operator
+
+type StageConfig struct {
+	Name      string           `yaml:"name"`
+	Pipelines []PipelineConfig `yaml:"pipelines"`
+	Devices   DevicesConfig    `yaml:"devices"`
+}
+
+type DevicesConfig struct {
+	Plain []DeviceConfig     `yaml:"plain"`
+	VLAN  []VLANDeviceConfig `yaml:"vlan"`
+}
+
+type PipelineConfig struct {
+	Name      string   `yaml:"name"`
+	Functions []string `yaml:"functions"`
+}
+
+type DeviceConfig struct {
+	Name   string              `yaml:"name"`
+	Input  []PipelineRefConfig `yaml:"input"`
+	Output []PipelineRefConfig `yaml:"output"`
+}
+
+type VLANDeviceConfig struct {
+	Name   string              `yaml:"name"`
+	VLAN   uint32              `yaml:"vlan"`
+	Input  []PipelineRefConfig `yaml:"input"`
+	Output []PipelineRefConfig `yaml:"output"`
+}
+
+type PipelineRefConfig struct {
+	Name   string `yaml:"name"`
+	Weight uint64 `yaml:"weight"`
+}

--- a/agents/yanet-pipeline-operator/meson.build
+++ b/agents/yanet-pipeline-operator/meson.build
@@ -1,27 +1,28 @@
-subdir('adapterpb')
+subdir('operatorpb')
 
-# Skip bird-adapter when fuzzing — it does not use CGO but still gets sanitizer
-# flags that interfere with the fuzzing build.
+# Skip pipeline-operator when fuzzing — no CGO but still gets sanitizer flags
+# that interfere with the fuzzing build.
 if not get_option('fuzzing').enabled()
   custom_target(
-      'yanet-bird-adapter',
-      output: 'yanet-bird-adapter',
+      'yanet-pipeline-operator',
+      output: 'yanet-pipeline-operator',
       command: [
           go,
           'build',
           '-ldflags=' + ld_flags,
           '-buildvcs=false',
           '-o', '@OUTPUT@',
-          join_paths(meson.project_source_root(), 'controlplane', 'cmd', 'bird-adapter'),
+          join_paths(meson.current_source_dir(), 'cmd', 'yanet-pipeline-operator'),
       ],
       env: yanet_go_env,
       build_by_default: true,
       build_always_stale: true,
       depends: [
+          pipeline_operator_protoc_gen,
           ynpb_gen,
-          bird_adapter_protoc_gen,
-          route_protoc_gen,
           common_protoc_gen,
+          plain_protoc_gen,
+          vlan_protoc_gen,
       ],
       install: true,
       install_dir: get_option('bindir'),

--- a/agents/yanet-pipeline-operator/operatorpb/meson.build
+++ b/agents/yanet-pipeline-operator/operatorpb/meson.build
@@ -1,0 +1,19 @@
+proto_dir = meson.current_source_dir()
+root_dir = meson.project_source_root()
+proto_files = [join_paths(proto_dir, 'operator.proto')]
+
+protoc_gen = custom_target(
+    'pipeline-operator-protoc',
+    output: ['operator.pb.go', 'operator_grpc.pb.go'],
+    input: proto_files,
+    command: [
+        protoc,
+        '-I', proto_dir,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + proto_dir,
+        '--go-grpc_out=paths=source_relative:' + proto_dir,
+        '@INPUT@',
+    ],
+    build_by_default: true,
+)
+pipeline_operator_protoc_gen = protoc_gen

--- a/agents/yanet-pipeline-operator/operatorpb/operator.proto
+++ b/agents/yanet-pipeline-operator/operatorpb/operator.proto
@@ -4,11 +4,18 @@ package operatorpb;
 
 option go_package = "github.com/yanet-platform/yanet2/agents/yanet-pipeline-operator/operatorpb;operatorpb";
 
+import "common/commonpb/metric.proto";
+
 // PipelineOperatorService is the intent surface for pipeline lifecycle
 // management.
 //
 // Intentionally deferred: RPCs (SetTargetStage / Activate / Deactivate) will
 // be added once the YAML-bootstrap workflow proves out.
-// Until then this service exists to reserve the gRPC name and ensure Gateway
-// routing is wired.
-service PipelineOperatorService {}
+service PipelineOperatorService {
+  // GetMetrics returns a snapshot of operator runtime metrics.
+  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+}
+
+message GetMetricsRequest {}
+
+message GetMetricsResponse { repeated commonpb.Metric metrics = 1; }

--- a/agents/yanet-pipeline-operator/operatorpb/operator.proto
+++ b/agents/yanet-pipeline-operator/operatorpb/operator.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package operatorpb;
+
+option go_package = "github.com/yanet-platform/yanet2/agents/yanet-pipeline-operator/operatorpb;operatorpb";
+
+// PipelineOperatorService is the intent surface for pipeline lifecycle
+// management.
+//
+// Intentionally deferred: RPCs (SetTargetStage / Activate / Deactivate) will
+// be added once the YAML-bootstrap workflow proves out.
+// Until then this service exists to reserve the gRPC name and ensure Gateway
+// routing is wired.
+service PipelineOperatorService {}

--- a/common/go/xcmd/signal.go
+++ b/common/go/xcmd/signal.go
@@ -15,6 +15,11 @@ func (m Interrupted) Error() string {
 	return m.String()
 }
 
+func (m Interrupted) Is(target error) bool {
+	_, ok := target.(Interrupted)
+	return ok
+}
+
 // WaitInterrupted blocks until either SIGINT or SIGTERM signal is received or
 // the provided context is canceled.
 func WaitInterrupted(ctx context.Context) error {

--- a/controlplane/meson.build
+++ b/controlplane/meson.build
@@ -54,30 +54,3 @@ custom_target(
     install: true,
     install_dir: get_option('bindir'),
 )
-
-# Skip bird-adapter when fuzzing - it doesn't use CGO but still gets sanitizer flags
-if not get_option('fuzzing').enabled()
-  custom_target(
-      'yanet-bird-adapter',
-      output: 'yanet-bird-adapter',
-      command: [
-          go,
-          'build',
-          '-ldflags=' + ld_flags,
-          '-buildvcs=false',
-          '-o', '@OUTPUT@',
-          join_paths(meson.current_source_dir(), 'cmd', 'bird-adapter'),
-      ],
-      env: yanet_go_env,
-      build_by_default: true,
-      build_always_stale: true,
-      depends: [
-          ynpb_gen,
-          bird_adapter_protoc_gen,
-          route_protoc_gen,
-          common_protoc_gen,
-      ],
-      install: true,
-      install_dir: get_option('bindir'),
-  )
-endif

--- a/debian/control
+++ b/debian/control
@@ -77,3 +77,13 @@ Description: Yanet2 BIRD adapter component
  Control plane for Yanet2 BIRD import adapter.
  .
  This package contains the control-plane services that manage the BIRD import configurations that enable the BIRD import feed to push routes into route-instance configurations.
+
+Package: yanet2-pipeline-operator
+Architecture: any
+Depends: ${shlibs:Depends}
+ , ${misc:Depends}
+Description: YANET2 pipeline operator
+ Autonomous YANET2 pipeline lifecycle management operator.
+ .
+ This package contains the pipeline operator that owns pipelines
+ and device-to-pipeline bindings.

--- a/debian/yanet2-pipeline-operator.install
+++ b/debian/yanet2-pipeline-operator.install
@@ -1,0 +1,2 @@
+usr/bin/yanet-pipeline-operator
+etc/yanet2/yanet-pipeline-operator.yaml

--- a/debian/yanet2-pipeline-operator.service
+++ b/debian/yanet2-pipeline-operator.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=yanet2 pipeline operator
+After=yanet2-controlplane.service
+Wants=yanet2-controlplane.service
+StartLimitBurst=3600000
+StartLimitIntervalSec=0
+
+[Service]
+User=root
+Group=yanet
+
+ExecStart=/usr/bin/yanet-pipeline-operator -c /etc/yanet2/yanet-pipeline-operator.yaml
+TimeoutSec=1200
+Restart=always
+RestartSec=1
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/yanet-pipeline-operator.Dockerfile
+++ b/deploy/yanet-pipeline-operator.Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN echo 'APT::Sandbox::User "root";' > /etc/apt/apt.conf.d/99sandbox
+
+COPY deploy/packages/yanet2-pipeline-operator_*.deb /tmp/
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends /tmp/*.deb \
+    && rm -rf /tmp/*.deb /var/lib/apt/lists/*
+
+ENTRYPOINT ["yanet-pipeline-operator", "-c", "/etc/yanet2/yanet-pipeline-operator.yaml"]

--- a/meson.build
+++ b/meson.build
@@ -147,8 +147,8 @@ subdir('devices')
 subdir('dataplane')
 
 if not dataplane_only
-  subdir('agents')
   subdir('controlplane')
+  subdir('agents')
   subdir('mock')
   subdir('tests')
 endif


### PR DESCRIPTION
## Problem

Pipeline lifecycle in YANET — declaring pipelines, wiring them to devices, advancing the system from a bootstrap state to a steady-state — is currently driven by ad-hoc imperative scripts.

Each operator (BIRD adapter, future route/ACL/balancer operators) only owns its own slice of state; nothing in the system owns the answer to "what should the dataplane pipeline graph look like, and how do we converge to that target if a Gateway is restarted, drops state, or comes online late".

This makes staged rollouts (bootstrap → bypass → main) impossible to express declaratively, leaves the burden of retrying transient gRPC failures on the caller, and gives the operator no single place to look at when a device ends up bound to the wrong pipeline.

## Solution

This PR introduces `yanet-pipeline-operator` — a standalone agent that owns the pipeline graph and the device→pipeline bindings across one or more Gateways.

Core building blocks:

- **Stage** — a desired-state snapshot: a set of pipelines plus the plain/VLAN device bindings that reference them. Configured in YAML.
- **Reconciler** — drives the system through an ordered queue of target stages. The head of the queue is the active reconcile target; on success it is dropped, exposing the next stage. The tail stage is retained as the steady-state target and re-applied on the configured interval.
  Failures trigger exponential backoff, successes reset it. The loop is preemptable: a new target wakes the loop without cancelling an in-flight `Apply`, so each Gateway always lands in a deterministic state.
- **Gateway actuator** — pushes a stage to a single Gateway via `PipelineService` / `DevicePlainService` / `DeviceVlanService`, then best-effort prunes pipelines that are no longer referenced by the desired stage.
  Functions are intentionally **not** garbage-collected here — they belong to their per-function operators.
- **Fan-out actuator** — applies a stage to every configured Gateway concurrently, waits for all of them to complete (no early-cancel), and reports the first error. A half-failed fan-out is treated as "stage not applied" by the reconciler, which then retries with backoff.
- **gRPC server skeleton** — `PipelineOperatorService` is registered so the Gateway routing layer is wired and the service name is reserved.

Supporting changes:

- Move the `bird-adapter` Meson `custom_target` out of `controlplane/meson.build` into `agents/bird-adapter/meson.build`, matching the new convention that every agent owns its own build target.
- Reorder the top-level `subdir('controlplane')` / `subdir('agents')` calls so agents can depend on protobuf generators emitted under `controlplane/`.
- `xcmd.Interrupted` now implements `Is(error) bool` so `errors.Is(err, xcmd.Interrupted{})` works at the cobra `RunE` boundary instead of typed equality.

## Future work

The operator is intentionally minimal in this PR — only the YAML-driven bootstrap path is wired end-to-end. The following are queued up:

### gRPC API
- `SetTargetStage(name, stage)` — push a new desired stage from outside the YAML bootstrap.
- `Activate(name)` / `Deactivate()` — explicit activation of a known stage; turns the reconciler off without stopping the process.
- `ListStages` / `GetCurrentStage` — read-side surface for tooling and dashboards.
- Authentication / authorization story for the operator's gRPC surface.

### CLI
- `yanet-cli pipeline-operator` subcommand for the RPCs above.
- Human-friendly stage-diff output (what would change vs. the active stage).

### Observability
- Prometheus metrics: reconcile attempts, successes, failures, current backoff, applied-stage gauge, last-apply latency per Gateway.
- Structured event log for stage transitions (advance, switch, GC).

### Reconciler
- Health probes that expose "are we converged" to readiness checks.
- Bounded queue / queue-replacement policy from the API surface.
- Support for partial-stage reconciliation (apply only the diff).
- Surface per-Gateway last-error and last-success timestamps.

