### PR TITLE
feat(counters): increate max length of name

### DIFF
--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -14,7 +14,7 @@
 #define CP_PIPELINE_NAME_LEN 80
 #endif
 
-#define COUNTER_NAME_LEN 64
+#define COUNTER_NAME_LEN 128
 #define COUNTER_INVALID (uint64_t)-1
 
 struct counter {


### PR DESCRIPTION
## Summary
This PR increases maximum length of counter name.  This is required by balancer, which can create counters with name length around 90 symbols. In future, it can be optimized by introducing unique IDs for each VS/real.