### PR TITLE
feat(common): introduce flatmap

### DIFF
--- a/common/flatmap.h
+++ b/common/flatmap.h
@@ -1,0 +1,165 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "common/crc32.h"
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "lib/errors/errors.h"
+
+struct flatmap {
+	void *keys;
+	void *values;
+	uint8_t *present;
+	size_t capacity;
+};
+
+// Releases the storage held by a flat map and resets it to empty.
+//
+// Safe to call on a map that was never built. The key and value sizes must
+// match those used to build the map.
+static inline void
+flatmap_free(
+	struct flatmap *map,
+	struct memory_context *mctx,
+	size_t key_size,
+	size_t value_size
+) {
+	if (map->keys != NULL) {
+		memory_bfree(
+			mctx, ADDR_OF(&map->keys), key_size * map->capacity
+		);
+	}
+	if (map->values != NULL) {
+		memory_bfree(
+			mctx, ADDR_OF(&map->values), value_size * map->capacity
+		);
+	}
+	if (map->present != NULL) {
+		memory_bfree(mctx, ADDR_OF(&map->present), map->capacity);
+	}
+	memset(map, 0, sizeof(*map));
+}
+
+// Builds a flat map from arrays of keys and values, using memory from the
+// given context.
+//
+// The capacity must be strictly greater than the number of entries. Passing
+// zero entries builds a valid, empty map. Duplicate keys are rejected.
+// Returns 0 on success, or -1 with an error added to the given error chain on
+// failure.
+static inline int
+flatmap_build(
+	struct flatmap *map,
+	struct memory_context *mctx,
+	size_t capacity,
+	size_t count,
+	const void *keys,
+	size_t key_size,
+	const void *values,
+	size_t value_size,
+	yanet_error **error
+) {
+	if (capacity <= count) {
+		yanet_error_add(error, "capacity must be greater than count");
+		return -1;
+	}
+
+	size_t keys_memory = key_size * capacity;
+	size_t values_memory = value_size * capacity;
+	memset(map, 0, sizeof(*map));
+
+	map->capacity = capacity;
+
+	map->keys = memory_balloc(mctx, keys_memory);
+	SET_OFFSET_OF(&map->keys, map->keys);
+	if (map->keys == NULL) {
+		yanet_error_add(error, "allocation failed");
+		return -1;
+	}
+
+	map->values = memory_balloc(mctx, values_memory);
+	SET_OFFSET_OF(&map->values, map->values);
+	if (map->values == NULL) {
+		flatmap_free(map, mctx, key_size, value_size);
+		yanet_error_add(error, "allocation failed");
+		return -1;
+	}
+
+	uint8_t *present = memory_balloc(mctx, capacity);
+	if (present == NULL) {
+		flatmap_free(map, mctx, key_size, value_size);
+		yanet_error_add(error, "allocation failed");
+		return -1;
+	}
+	memset(present, 0, capacity);
+	SET_OFFSET_OF(&map->present, present);
+
+	for (size_t i = 0; i < count; ++i) {
+		const void *key = keys + i * key_size;
+		size_t j = crc32(key, key_size, 0) % capacity;
+		while (present[j]) {
+			const void *map_key =
+				ADDR_OF(&map->keys) + j * key_size;
+			if (memcmp(key, map_key, key_size) == 0) {
+				size_t other = 0;
+				while (memcmp(keys + other * key_size,
+					      key,
+					      key_size) != 0) {
+					++other;
+				}
+				flatmap_free(map, mctx, key_size, value_size);
+				yanet_error_add(
+					error,
+					"key at index %zu matches key at "
+					"index %zu",
+					i,
+					other
+				);
+				return -1;
+			}
+			++j;
+			if (j == capacity) {
+				j = 0;
+			}
+		}
+		present[j] = 1;
+		memcpy(ADDR_OF(&map->keys) + j * key_size,
+		       keys + i * key_size,
+		       key_size);
+		memcpy(ADDR_OF(&map->values) + j * value_size,
+		       values + i * value_size,
+		       value_size);
+	}
+
+	return 0;
+}
+
+// Looks up the value stored for a key.
+//
+// Returns a pointer to the value, or NULL if the key is not present. The
+// key and value sizes must match those used to build the map.
+static inline void *
+flatmap_lookup(
+	const struct flatmap *map,
+	const void *key,
+	size_t key_size,
+	size_t value_size
+) {
+	const void *keys = ADDR_OF(&map->keys);
+	void *values = ADDR_OF(&map->values);
+	uint8_t *present = ADDR_OF(&map->present);
+	size_t j = crc32(key, key_size, 0) % map->capacity;
+	while (present[j]) {
+		if (memcmp(keys + j * key_size, key, key_size) == 0) {
+			return values + j * value_size;
+		}
+		++j;
+		if (j == map->capacity) {
+			j = 0;
+		}
+	}
+	return NULL;
+}

--- a/tests/common/flatmap_test.c
+++ b/tests/common/flatmap_test.c
@@ -1,0 +1,227 @@
+#include "common/flatmap.h"
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int
+setup_allocator(struct block_allocator *ba, void **raw_mem, size_t size) {
+	TEST_ASSERT(
+		block_allocator_init(ba) == 0, "block_allocator_init failed"
+	);
+
+	*raw_mem = malloc(size);
+	TEST_ASSERT(*raw_mem != NULL, "failed to allocate raw memory");
+
+	block_allocator_put_arena(ba, *raw_mem, size);
+	return TEST_SUCCESS;
+}
+
+static int
+test_zero_count(void) {
+	LOG(INFO, "Test zero count...");
+
+	struct block_allocator ba;
+	void *raw_mem = NULL;
+	const size_t arena_size = 1 << 20;
+	TEST_ASSERT(
+		setup_allocator(&ba, &raw_mem, arena_size) == TEST_SUCCESS,
+		"setup allocator"
+	);
+
+	struct memory_context mctx;
+	TEST_ASSERT(
+		memory_context_init(&mctx, "flatmap", &ba) == 0,
+		"init memory context"
+	);
+
+	struct flatmap map;
+	int res = flatmap_build(
+		&map,
+		&mctx,
+		8,
+		0,
+		NULL,
+		sizeof(uint32_t),
+		NULL,
+		sizeof(uint32_t),
+		NULL
+	);
+	TEST_ASSERT(res == 0, "build flat map");
+
+	uint32_t probes[] = {0, 1, 42, 0xDEADBEEFu};
+	for (size_t idx = 0; idx < sizeof(probes) / sizeof(probes[0]); ++idx) {
+		void *found = flatmap_lookup(
+			&map, &probes[idx], sizeof(uint32_t), sizeof(uint32_t)
+		);
+		TEST_ASSERT_NULL(found, "lookup on empty map must return NULL");
+	}
+
+	flatmap_free(&map, &mctx, sizeof(uint32_t), sizeof(uint32_t));
+	TEST_ASSERT_EQUAL(
+		mctx.bfree_count,
+		mctx.balloc_count,
+		"memory context: free count != alloc count"
+	);
+	TEST_ASSERT_EQUAL(
+		mctx.bfree_size,
+		mctx.balloc_size,
+		"memory context: free size != alloc size"
+	);
+	free(raw_mem);
+	return TEST_SUCCESS;
+}
+
+static int
+test_basic_lookup(void) {
+	LOG(INFO, "Test basic lookup...");
+
+	struct block_allocator ba;
+	void *raw_mem = NULL;
+	const size_t arena_size = 1 << 20;
+	TEST_ASSERT(
+		setup_allocator(&ba, &raw_mem, arena_size) == TEST_SUCCESS,
+		"setup allocator"
+	);
+
+	struct memory_context mctx;
+	TEST_ASSERT(
+		memory_context_init(&mctx, "flatmap", &ba) == 0,
+		"init memory context"
+	);
+
+	const uint32_t keys[] = {1, 2, 3, 100, 200};
+	const uint32_t values[] = {10, 20, 30, 1000, 2000};
+	const size_t count = sizeof(keys) / sizeof(keys[0]);
+
+	struct flatmap map;
+	int res = flatmap_build(
+		&map,
+		&mctx,
+		count * 2,
+		count,
+		keys,
+		sizeof(uint32_t),
+		values,
+		sizeof(uint32_t),
+		NULL
+	);
+	TEST_ASSERT(res == 0, "build flat map");
+
+	for (size_t idx = 0; idx < count; ++idx) {
+		uint32_t key = keys[idx];
+		uint32_t *value = (uint32_t *)flatmap_lookup(
+			&map, &key, sizeof(uint32_t), sizeof(uint32_t)
+		);
+		TEST_ASSERT_NOT_NULL(
+			value, "lookup of present key %u returned NULL", key
+		);
+		TEST_ASSERT_EQUAL(
+			*value, values[idx], "value mismatch for key %u", key
+		);
+	}
+
+	const uint32_t missing[] = {0, 4, 99, 500, 0xFFFFFFFFu};
+	for (size_t idx = 0; idx < sizeof(missing) / sizeof(missing[0]);
+	     ++idx) {
+		void *value = flatmap_lookup(
+			&map, &missing[idx], sizeof(uint32_t), sizeof(uint32_t)
+		);
+		TEST_ASSERT_NULL(
+			value,
+			"lookup of missing key %u returned non-NULL",
+			missing[idx]
+		);
+	}
+
+	flatmap_free(&map, &mctx, sizeof(uint32_t), sizeof(uint32_t));
+	TEST_ASSERT_EQUAL(
+		mctx.bfree_count,
+		mctx.balloc_count,
+		"memory context: free count != alloc count"
+	);
+	TEST_ASSERT_EQUAL(
+		mctx.bfree_size,
+		mctx.balloc_size,
+		"memory context: free size != alloc size"
+	);
+	free(raw_mem);
+	return TEST_SUCCESS;
+}
+
+static int
+test_duplicate_key(void) {
+	LOG(INFO, "Test duplicate key...");
+
+	struct block_allocator ba;
+	void *raw_mem = NULL;
+	const size_t arena_size = 1 << 20;
+	TEST_ASSERT(
+		setup_allocator(&ba, &raw_mem, arena_size) == TEST_SUCCESS,
+		"setup allocator"
+	);
+
+	struct memory_context mctx;
+	TEST_ASSERT(
+		memory_context_init(&mctx, "flatmap", &ba) == 0,
+		"init memory context"
+	);
+
+	const uint32_t keys[] = {1, 2, 1, 100};
+	const uint32_t values[] = {10, 20, 30, 1000};
+	const size_t count = sizeof(keys) / sizeof(keys[0]);
+
+	struct flatmap map;
+	yanet_error *err = NULL;
+	int res = flatmap_build(
+		&map,
+		&mctx,
+		count * 2,
+		count,
+		keys,
+		sizeof(uint32_t),
+		values,
+		sizeof(uint32_t),
+		&err
+	);
+	TEST_ASSERT(res == -1, "build must reject a duplicate key");
+	TEST_ASSERT_NOT_NULL(err, "build must report an error");
+
+	yanet_error_free(err);
+
+	TEST_ASSERT_EQUAL(
+		mctx.bfree_count,
+		mctx.balloc_count,
+		"memory context: free count != alloc count"
+	);
+	TEST_ASSERT_EQUAL(
+		mctx.bfree_size,
+		mctx.balloc_size,
+		"memory context: free size != alloc size"
+	);
+	free(raw_mem);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	if (test_zero_count() != TEST_SUCCESS) {
+		return -1;
+	}
+	if (test_basic_lookup() != TEST_SUCCESS) {
+		return -1;
+	}
+	if (test_duplicate_key() != TEST_SUCCESS) {
+		return -1;
+	}
+
+	LOG(INFO, "All flatmap tests passed");
+	return 0;
+}

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -124,3 +124,14 @@ data_pipe_test = executable(
   include_directories: yanet_rootdir,
 )
 test('data_pipe', data_pipe_test, suite: ['common'])
+
+flatmap_test = executable(
+  'flatmap_test',
+  ['flatmap_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: [lib_common_dep, lib_logging_dep, lib_errors_dep],
+  include_directories: yanet_rootdir,
+)
+test('flatmap', flatmap_test, suite: ['common'])
+


### PR DESCRIPTION
## Summary
Adds a static, open-addressed hash map for hot-path lookups. The map is built once from a fixed key/value array and is read-only afterwards; this makes it cheaper than ttlmap, which carries locking for the mutable case.

The first consumer will be balancer module, which resolves the real-server index by IP address in the dataplane.

## Tests
The basic tests were implemented.