### PR TITLE
refactor(balancer): caller-supplied counter names

### DIFF
--- a/modules/balancer2/api/controlplane.h
+++ b/modules/balancer2/api/controlplane.h
@@ -20,6 +20,7 @@ struct balancer_real_config {
 	struct net_addr dst;
 	struct net src;
 	enum ip_family ip_family;
+	const char *counter_name;
 };
 
 /*
@@ -32,7 +33,7 @@ struct balancer_allowed_sources {
 	struct filter_net4s net4s;
 	struct filter_net6s net6s;
 	struct filter_port_ranges port_ranges;
-	const char *tag;
+	const char *counter_name;
 };
 
 enum balancer_vs_sched {
@@ -73,6 +74,8 @@ struct balancer_vs_config {
 	size_t real_count;
 
 	bool fix_mss;
+
+	const char *counter_name;
 };
 
 /*
@@ -109,6 +112,8 @@ balancer_create(
 	struct balancer_session_timeouts *timeouts,
 	const struct balancer_vs_config *vs,
 	uint32_t vs_count,
+	const char *common_counter_name,
+	const char *l4_counter_name,
 	yanet_error **error
 );
 
@@ -165,30 +170,6 @@ balancer_vs_update_real_states(
 	const bool *states,
 	yanet_error **error
 );
-
-/*
- * Counters are registered by API with their names. The
- * controlplane parses emitted counter names against these to route
- * values back to their VS, real, or balancer-level source.
- *
- * VS counter format:      vs_<vip>:<port>/<proto>
- *   where proto is "tcp" or "udp".
- */
-extern const char *const balancer_vs_counter_prefix;
-
-/*
- * VS ACL counter format:  vs_acl_<vip>:<port>/<proto>_<tag>
- */
-extern const char *const balancer_vs_acl_counter_prefix;
-
-/*
- * Real counter format:    real_<vip>:<port>/<proto>_<real_dst>
- */
-extern const char *const balancer_real_counter_prefix;
-
-extern const char *const balancer_common_counter_name;
-
-extern const char *const balancer_l4_counter_name;
 
 /*
  * A session table holds active session entries — one per tracked

--- a/modules/balancer2/bindings/go/cbalancer2/cgo.go
+++ b/modules/balancer2/bindings/go/cbalancer2/cgo.go
@@ -23,19 +23,6 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
-var (
-	// VSCounterPrefix is the name prefix used for per-VS counters.
-	VSCounterPrefix = C.GoString(C.balancer_vs_counter_prefix)
-	// VSACLCounterPrefix is the name prefix used for per-VS ACL counters.
-	VSACLCounterPrefix = C.GoString(C.balancer_vs_acl_counter_prefix)
-	// RealCounterPrefix is the name prefix used for per-real counters.
-	RealCounterPrefix = C.GoString(C.balancer_real_counter_prefix)
-	// CommonCounterName is the name of the balancer-level common counter.
-	CommonCounterName = C.GoString(C.balancer_common_counter_name)
-	// L4CounterName is the name of the balancer-level L4 counter.
-	L4CounterName = C.GoString(C.balancer_l4_counter_name)
-)
-
 // TunnelKind selects the encapsulation used to forward client traffic to the
 // selected real.
 type TunnelKind int
@@ -194,12 +181,9 @@ func (m *SessionTableChain) PopBack() error {
 	return nil
 }
 
-// cAllowedSources pairs a balancer_allowed_sources C struct with the C string
-// memory referenced by its tag field, so the latter can be released with the
-// former.
 type cAllowedSources struct {
-	c   C.struct_balancer_allowed_sources
-	tag *C.char
+	c           C.struct_balancer_allowed_sources
+	counterName *C.char
 }
 
 func (m *AllowedSources) cBuild(pinner *runtime.Pinner) cAllowedSources {
@@ -209,30 +193,37 @@ func (m *AllowedSources) cBuild(pinner *runtime.Pinner) cAllowedSources {
 	filter.CBuildNet6s(&out.c.net6s, m.Net6s, pinner)
 	filter.CBuildPortRanges(&out.c.port_ranges, m.PortRanges, pinner)
 
-	if m.Tag != "" {
-		out.tag = C.CString(m.Tag)
-		out.c.tag = out.tag
+	if m.CounterName != "" {
+		out.counterName = C.CString(m.CounterName)
+		out.c.counter_name = out.counterName
 	}
 	return out
 }
 
 func (m *cAllowedSources) free() {
-	if m.tag != nil {
-		C.free(unsafe.Pointer(m.tag))
-		m.tag = nil
+	if m.counterName != nil {
+		C.free(unsafe.Pointer(m.counterName))
+		m.counterName = nil
 	}
 }
 
-// cVSConfig owns the C strings referenced by a balancer_vs_config during a
-// balancer_create call, transitively through the cAllowedSources entries it
-// holds.
 type cVSConfig struct {
-	c       C.struct_balancer_vs_config
-	allowed []cAllowedSources
+	c           C.struct_balancer_vs_config
+	reals       []cRealConfig
+	allowed     []cAllowedSources
+	counterName *C.char
 }
 
 func (m *VSConfig) cBuild(pinner *runtime.Pinner) (cVSConfig, error) {
 	var out cVSConfig
+
+	success := false
+
+	defer func() {
+		if !success {
+			out.free()
+		}
+	}()
 
 	if !m.Dst.IsValid() {
 		return cVSConfig{}, errors.New("destination address is invalid")
@@ -247,14 +238,21 @@ func (m *VSConfig) cBuild(pinner *runtime.Pinner) (cVSConfig, error) {
 	out.c.tunnel = C.enum_balancer_tunnel_kind(m.Tunnel)
 	out.c.fix_mss = C.bool(m.FixMSS)
 
+	if m.CounterName != "" {
+		out.counterName = C.CString(m.CounterName)
+		out.c.counter_name = out.counterName
+	}
+
 	if len(m.Reals) > 0 {
+		out.reals = make([]cRealConfig, len(m.Reals))
 		cReals := make([]C.struct_balancer_real_config, len(m.Reals))
 		for i := range m.Reals {
 			cReal, err := m.Reals[i].cBuild()
 			if err != nil {
 				return cVSConfig{}, fmt.Errorf("real[%d]: %w", i, err)
 			}
-			cReals[i] = cReal
+			out.reals[i] = cReal
+			cReals[i] = cReal.c
 		}
 		pinner.Pin(&cReals[0])
 		out.c.reals = &cReals[0]
@@ -273,25 +271,47 @@ func (m *VSConfig) cBuild(pinner *runtime.Pinner) (cVSConfig, error) {
 		out.c.allowed_sources_count = C.size_t(len(m.AllowedSources))
 	}
 
+	success = true
+
 	return out, nil
 }
 
 func (m *cVSConfig) free() {
+	for i := range m.reals {
+		m.reals[i].free()
+	}
+	m.reals = nil
 	for i := range m.allowed {
 		m.allowed[i].free()
 	}
 	m.allowed = nil
+	if m.counterName != nil {
+		C.free(unsafe.Pointer(m.counterName))
+		m.counterName = nil
+	}
 }
 
-func (m *RealConfig) cBuild() (C.struct_balancer_real_config, error) {
+type cRealConfig struct {
+	c           C.struct_balancer_real_config
+	counterName *C.char
+}
+
+func (m *cRealConfig) free() {
+	if m.counterName != nil {
+		C.free(unsafe.Pointer(m.counterName))
+		m.counterName = nil
+	}
+}
+
+func (m *RealConfig) cBuild() (cRealConfig, error) {
 	if !m.Dst.IsValid() {
-		return C.struct_balancer_real_config{}, errors.New("destination address is invalid")
+		return cRealConfig{}, errors.New("destination address is invalid")
 	}
 	if !m.Src.IsValid() {
-		return C.struct_balancer_real_config{}, errors.New("source network is invalid")
+		return cRealConfig{}, errors.New("source network is invalid")
 	}
 	if m.Dst.Is4() != m.Src.Addr.Is4() {
-		return C.struct_balancer_real_config{}, errors.New(
+		return cRealConfig{}, errors.New(
 			"destination and source address families differ",
 		)
 	}
@@ -299,13 +319,20 @@ func (m *RealConfig) cBuild() (C.struct_balancer_real_config, error) {
 	cDst, family := netipToCNetAddr(m.Dst)
 	cSrc, err := netWithMaskToCNet(m.Src)
 	if err != nil {
-		return C.struct_balancer_real_config{}, fmt.Errorf("source net: %w", err)
+		return cRealConfig{}, fmt.Errorf("source net: %w", err)
 	}
-	return C.struct_balancer_real_config{
-		dst:       cDst,
-		src:       cSrc,
-		ip_family: family,
-	}, nil
+	out := cRealConfig{
+		c: C.struct_balancer_real_config{
+			dst:       cDst,
+			src:       cSrc,
+			ip_family: family,
+		},
+	}
+	if m.CounterName != "" {
+		out.counterName = C.CString(m.CounterName)
+		out.c.counter_name = out.counterName
+	}
+	return out, nil
 }
 
 func (m SessionTimeouts) toC() C.struct_balancer_session_timeouts {
@@ -324,9 +351,23 @@ func createBalancer(
 	chain *SessionTableChain,
 	timeouts SessionTimeouts,
 	vs []VSConfig,
+	commonCounterName string,
+	l4CounterName string,
 ) (*Balancer, error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
+
+	var cCommonCounter *C.char
+	if commonCounterName != "" {
+		cCommonCounter = C.CString(commonCounterName)
+		defer C.free(unsafe.Pointer(cCommonCounter))
+	}
+
+	var cL4Counter *C.char
+	if l4CounterName != "" {
+		cL4Counter = C.CString(l4CounterName)
+		defer C.free(unsafe.Pointer(cL4Counter))
+	}
 
 	cTimeouts := timeouts.toC()
 
@@ -363,6 +404,8 @@ func createBalancer(
 		&cTimeouts,
 		cVSPtr,
 		C.uint32_t(len(vs)),
+		cCommonCounter,
+		cL4Counter,
 		&cErr,
 	)
 	if ptr == nil {

--- a/modules/balancer2/bindings/go/cbalancer2/safe.go
+++ b/modules/balancer2/bindings/go/cbalancer2/safe.go
@@ -27,8 +27,9 @@ type SessionTimeouts struct {
 // the encapsulation source (for the IPIP/GRE tunnel); its mask may be any
 // (possibly non-contiguous) bitmask, and its address family must match Dst.
 type RealConfig struct {
-	Dst netip.Addr
-	Src xnetip.NetWithMask
+	Dst         netip.Addr
+	Src         xnetip.NetWithMask
+	CounterName string
 }
 
 // AllowedSources describes one entry in a virtual service's source allow
@@ -37,10 +38,10 @@ type RealConfig struct {
 // empty set of networks disallows all networks; an empty set of ports allows
 // all ports.
 type AllowedSources struct {
-	Net4s      filter.IPNets
-	Net6s      filter.IPNets
-	PortRanges filter.PortRanges
-	Tag        string
+	Net4s       filter.IPNets
+	Net6s       filter.IPNets
+	PortRanges  filter.PortRanges
+	CounterName string
 }
 
 // VSConfig describes a single virtual service.
@@ -57,6 +58,7 @@ type VSConfig struct {
 	Tunnel         TunnelKind
 	Reals          []RealConfig
 	FixMSS         bool
+	CounterName    string
 }
 
 // NewBalancer builds a balancer handle from its full configuration.
@@ -69,11 +71,13 @@ func NewBalancer(
 	chain *SessionTableChain,
 	timeouts SessionTimeouts,
 	vs []VSConfig,
+	commonCounterName string,
+	l4CounterName string,
 ) (*Balancer, error) {
 	if uint64(len(vs)) > math.MaxUint32 {
 		return nil, fmt.Errorf("too many virtual services: %d", len(vs))
 	}
-	return createBalancer(agent, name, chain, timeouts, vs)
+	return createBalancer(agent, name, chain, timeouts, vs, commonCounterName, l4CounterName)
 }
 
 // NewSessionTable creates a session table with the given capacity (number of


### PR DESCRIPTION
## Summary

Counter names for virtual services, reals, allowed-source rules, and the balancer-level common and L4 counters are now provided by the caller rather than composed by the controlplane API from the underlying tuple.
- Adds a counter name field to the real, allowed-sources, and VS configuration structs, and threads common and L4 counter names through the balancer creation entrypoint.
- Removes the exported counter-name prefix and constant symbols and the format documentation that paired with them.
- Updates the Go binding to mirror the new contract: renames the allowed-sources tag field, owns the new C strings through the cgo wrappers, and frees them on partial-failure paths via a deferred cleanup in the VS builder.
