### PR TITLE
refactor(cli): --cfg to --name, add short aliases, YANET_ENDPOINT env

### DIFF
--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 rust-version = "1.84"
 
 [dependencies]
-clap = { version = "4.5", features = ["cargo", "derive", "string"] }
+clap = { version = "4.5", features = ["cargo", "derive", "env", "string"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 simple_logger = { version = "5", features = ["timestamps", "stderr"] }

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -38,7 +38,7 @@ pub type LayeredChannel = AuthService<Channel>;
 #[derive(Debug, Clone, clap::Args)]
 pub struct ConnectionArgs {
     /// Gateway endpoint.
-    #[arg(long, default_value = "grpc://[::1]:8080", global = true)]
+    #[arg(long, default_value = "grpc://[::1]:8080", global = true, env = "YANET_ENDPOINT")]
     pub endpoint: String,
     /// Authentication options.
     #[command(flatten)]

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -48,53 +48,53 @@ pub enum ModeCmd {
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeviceCmd {
-    #[arg(long)]
+    #[arg(short = 'd', long)]
     pub device_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct PipelineCmd {
-    #[arg(long)]
+    #[arg(short = 'd', long)]
     pub device_name: String,
-    #[arg(long)]
+    #[arg(short = 'p', long)]
     pub pipeline_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct FunctionCmd {
-    #[arg(long)]
+    #[arg(short = 'd', long)]
     pub device_name: String,
-    #[arg(long)]
+    #[arg(short = 'p', long)]
     pub pipeline_name: String,
-    #[arg(long)]
+    #[arg(short = 'f', long)]
     pub function_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ChainCmd {
-    #[arg(long)]
+    #[arg(short = 'd', long)]
     pub device_name: String,
-    #[arg(long)]
+    #[arg(short = 'p', long)]
     pub pipeline_name: String,
-    #[arg(long)]
+    #[arg(short = 'f', long)]
     pub function_name: String,
-    #[arg(long)]
+    #[arg(short = 'c', long)]
     pub chain_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ModuleCmd {
-    #[arg(long)]
+    #[arg(short = 'd', long)]
     pub device_name: String,
-    #[arg(long)]
+    #[arg(short = 'p', long)]
     pub pipeline_name: String,
-    #[arg(long)]
+    #[arg(short = 'f', long)]
     pub function_name: String,
-    #[arg(long)]
+    #[arg(short = 'c', long)]
     pub chain_name: String,
-    #[arg(long)]
+    #[arg(short = 't', long)]
     pub module_type: String,
-    #[arg(long)]
+    #[arg(short = 'm', long)]
     pub module_name: String,
 }
 

--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -20,14 +20,14 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// ACL config name
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// ACL config name
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Path to the ruleset YAML file
     #[arg(required = true, long = "rules", value_name = "PATH")]
@@ -37,7 +37,7 @@ pub struct UpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// ACL config name
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -46,7 +46,7 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// Decap module name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Output format.
     #[clap(long, value_enum, default_value_t = OutputFormat::Tree)]
@@ -56,7 +56,7 @@ pub struct ShowConfigCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct AddPrefixesCmd {
     /// Decap module name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Prefix to be added to the input filter of the decapsulation module.
     #[arg(long, short)]
@@ -66,7 +66,7 @@ pub struct AddPrefixesCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RemovePrefixesCmd {
     /// Decap module name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Prefix to be removed from the input filter of the decapsulation module.
     #[arg(long, short)]

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -49,7 +49,7 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// DSCP module name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Output format.
     #[clap(long, value_enum, default_value_t = OutputFormat::Tree)]
@@ -59,7 +59,7 @@ pub struct ShowConfigCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct AddPrefixesCmd {
     /// DSCP module name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Prefix to be added to the input filter of the DSCP module.
     #[arg(long, short, required = true)]
@@ -69,7 +69,7 @@ pub struct AddPrefixesCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RemovePrefixesCmd {
     /// DSCP module name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Prefix to be removed from the input filter of the DSCP module.
     #[arg(long, short, required = true)]
@@ -79,7 +79,7 @@ pub struct RemovePrefixesCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct SetDscpMarkingCmd {
     /// DSCP module name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// DSCP marking flag: 0 - Never, 1 - Default (only if original DSCP is 0),
     /// 2 - Always

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -50,21 +50,21 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// The name of the module config to show.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// The name of the module config to delete.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// The name of the module config to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config: String,
     /// Ruleset file path.
     #[arg(required = true, long = "rules", value_name = "PATH")]

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -29,21 +29,21 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// The name of the fwstate config to delete
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// FWState config name to show
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct LinkCmd {
     /// FWState config name to link
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 
     /// ACL config names to link (can be specified multiple times)
@@ -54,14 +54,14 @@ pub struct LinkCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct StatsCmd {
     /// FWState config name to get statistics for
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// FWState config name to operate on
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 
     /// Size of the hash table index for firewall state maps
@@ -130,7 +130,7 @@ pub enum DirectionArg {
 #[derive(Debug, Clone, Parser)]
 pub struct EntriesCmd {
     /// FWState config name
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 
     /// Use IPv6 map instead of IPv4

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -72,7 +72,7 @@ pub enum MappingCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// The name of the config to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Output format.
     #[clap(long, value_enum, default_value_t = OutputFormat::Tree)]
@@ -82,7 +82,7 @@ pub struct ShowConfigCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct AddPrefixCmd {
     /// The name of the config to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// IPv6 prefix (12 bytes) to be added.
     #[arg(long)]
@@ -92,7 +92,7 @@ pub struct AddPrefixCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct AddMappingCmd {
     /// The name of the config to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// IPv4 address (4 bytes).
     #[arg(long)]
@@ -108,7 +108,7 @@ pub struct AddMappingCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct MtuCmd {
     /// The name of the config to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// MTU value for IPv4.
     #[arg(long)]
@@ -122,7 +122,7 @@ pub struct MtuCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DropCmd {
     /// The name of the config to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Drop packets with unknown prefix
     #[arg(long)]

--- a/modules/pdump/cli/src/args.rs
+++ b/modules/pdump/cli/src/args.rs
@@ -15,14 +15,14 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// Pdump config name to delete.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// Pdump config name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Output format.
     #[clap(long, value_enum, default_value_t = ConfigOutputFormat::Tree)]
@@ -32,11 +32,11 @@ pub struct ShowConfigCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct SetConfigCmd {
     /// Pdump config name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 
     /// Filter represents a pcap-style filter expression
-    #[arg(long, short)]
+    #[arg(long)]
     pub filter: Option<String>,
 
     /// Determine the packet list to capture packets from.
@@ -55,7 +55,7 @@ pub struct SetConfigCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ReadCmd {
     /// Pdump config name to operate on.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 
     /// Dump output format.

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -33,7 +33,7 @@ use ync::logging;
 pub struct Cmd {
     #[clap(subcommand)]
     pub mode: ModeCmd,
-    /// Gateway endpoint.
+    /// gRPC endpoint URL.
     #[clap(long, default_value = "grpc://[::1]:8080", global = true)]
     pub endpoint: String,
     /// Be verbose in terms of logging.
@@ -60,28 +60,28 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RouteShowCmd {
     /// Route config name.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct RouteCreateCmd {
     /// Route config name.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct RouteDeleteCmd {
     /// Route config name.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct RouteUpdateCmd {
     /// Route config name.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Route prefix
     #[arg(long = "prefix", short)]
@@ -106,7 +106,7 @@ pub struct RouteUpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RouteWithdrawCmd {
     /// Route config name.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Route prefix
     #[arg(long = "prefix", short)]

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -127,7 +127,7 @@ pub enum FibAction {
 #[derive(Debug, Clone, Parser)]
 pub struct FibUpdateCmd {
     /// Route module config name.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
     /// Path to the FIB YAML file.
     #[arg(required = true, long = "rules", value_name = "PATH")]
@@ -143,7 +143,7 @@ pub struct FibShowCmd {
     #[arg(long)]
     pub ipv6: bool,
     /// Route config name.
-    #[arg(long = "cfg", short)]
+    #[arg(long = "name", short = 'n')]
     pub config_name: String,
 }
 


### PR DESCRIPTION
Replace --cfg/-c with --name/-n in acl, decap, dscp, forward, fwstate, nat64, pdump, route, and route-mpls CLI modules to match the convention already established in balancer/pipeline/function. Also add short aliases to counters subcommands , and add YANET_ENDPOINT env var support to ConnectionArgs