### PR TITLE
refactor(ffi): drop Go AgentReattach wrapper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ the dataplane through the gateway, distinct from per-module gRPC services.
 ### Shared Memory Pattern
 
 1. Module control plane attaches via `ffi.SharedMemory` (Go CGO)
-2. Creates agent via `shm.AgentReattach(name, instanceIdx, size)`
+2. Creates agent via `shm.AgentAttach(name, instanceIdx, size)`
 3. Writes C-level config through FFI functions (e.g., `acl_module_config_update()`)
 4. Uses `runtime.Pinner` to pin Go memory during C calls
 5. Dataplane reads updated config atomically

--- a/controlplane/builtin/function.go
+++ b/controlplane/builtin/function.go
@@ -132,7 +132,7 @@ func (m *Function) Update(
 ) (*ynpb.UpdateFunctionResponse, error) {
 	reqFunction := request.Function
 
-	agent, err := m.shm.AgentReattach(functionAgentName, m.instanceID, functionAgentMemory)
+	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to agent %q: %w", functionAgentName, err)
 	}
@@ -176,7 +176,7 @@ func (m *Function) Delete(
 ) (*ynpb.DeleteFunctionResponse, error) {
 	functionName := request.Id.Name
 
-	agent, err := m.shm.AgentReattach(functionAgentName, m.instanceID, functionAgentMemory)
+	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to agent %q: %w", functionAgentName, err)
 	}

--- a/controlplane/builtin/pipeline.go
+++ b/controlplane/builtin/pipeline.go
@@ -116,7 +116,7 @@ func (m *Pipeline) Update(
 	ctx context.Context,
 	request *ynpb.UpdatePipelineRequest,
 ) (*ynpb.UpdatePipelineResponse, error) {
-	agent, err := m.shm.AgentReattach(agentName, m.instanceID, defaultAgentMemory)
+	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to agent %q: %w", agentName, err)
 	}
@@ -147,7 +147,7 @@ func (m *Pipeline) Delete(
 ) (*ynpb.DeletePipelineResponse, error) {
 	pipelineName := request.GetId().GetName()
 
-	agent, err := m.shm.AgentReattach(agentName, m.instanceID, defaultAgentMemory)
+	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to agent %q: %w", agentName, err)
 	}

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -88,31 +88,6 @@ func (m *SharedMemory) AgentAttach(
 	return &Agent{name: name, ptr: ptr}, nil
 }
 
-// AgentReattach attaches a module agent to shared memory on the dataplane instance.
-// If Agent with such name already attached, it will be reattached to the same memory.
-func (m *SharedMemory) AgentReattach(
-	name string,
-	instanceIdx uint32,
-	size datasize.ByteSize,
-) (*Agent, error) {
-	cName := C.CString(name)
-	defer C.free(unsafe.Pointer(cName))
-
-	var cErr *C.yanet_error
-	ptr := C.agent_reattach(
-		m.ptr,
-		C.uint32_t(instanceIdx),
-		cName,
-		C.size_t(size),
-		&cErr,
-	)
-	if ptr == nil {
-		return nil, fmt.Errorf("failed to reattach agent %q: %w", name, cerrors.FromC(unsafe.Pointer(cErr)))
-	}
-
-	return &Agent{name: name, ptr: ptr}, nil
-}
-
 // AgentsAttach attaches agents to shared memory on the specified list of instances.
 func (m *SharedMemory) AgentsAttach(
 	name string,
@@ -121,7 +96,7 @@ func (m *SharedMemory) AgentsAttach(
 ) ([]*Agent, error) {
 	agents := make([]*Agent, 0, len(instanceIndices))
 	for _, instanceIdx := range instanceIndices {
-		agent, err := m.AgentReattach(name, instanceIdx, size)
+		agent, err := m.AgentAttach(name, instanceIdx, size)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"failed to connect to shared memory on instance %d: %w",

--- a/devices/plain/controlplane/mod.go
+++ b/devices/plain/controlplane/mod.go
@@ -33,7 +33,7 @@ func NewDevicePlainDevice(cfg *Config, log *zap.Logger) (*DevicePlainDevice, err
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("plain", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("plain", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/devices/vlan/controlplane/mod.go
+++ b/devices/vlan/controlplane/mod.go
@@ -33,7 +33,7 @@ func NewDeviceVlanDevice(cfg *Config, log *zap.Logger) (*DeviceVlanDevice, error
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("vlan", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("vlan", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/mock/go/mock_test.go
+++ b/mock/go/mock_test.go
@@ -29,7 +29,7 @@ func TestBasic(t *testing.T) {
 	defer mock.Free()
 
 	shm := mock.SharedMemory()
-	agent, err := shm.AgentReattach("config", 0, config.GetAgentsMemory())
+	agent, err := shm.AgentAttach("config", 0, config.GetAgentsMemory())
 	require.NoError(t, err)
 	require.NotNil(t, agent)
 

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -12,9 +12,11 @@ import (
 	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb"
 )
 
-const agentName = "acl"
-const serviceName = "aclpb.ACLService"
-const fwstateServiceName = "fwstatepb.FWStateService"
+const (
+	agentName          = "acl"
+	serviceName        = "aclpb.ACLService"
+	fwstateServiceName = "fwstatepb.FWStateService"
+)
 
 // ACLModule is a control-plane component for ACL (Access Control List) module
 // with integrated firewall state management
@@ -41,7 +43,7 @@ func NewACLModule(cfg *Config, log *zap.Logger) (*ACLModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/acl/tests/acl/setup.go
+++ b/modules/acl/tests/acl/setup.go
@@ -50,7 +50,7 @@ func SetupTest(config *TestConfig) (*TestSetup, error) {
 	}
 
 	agent, err := mock.SharedMemory().
-		AgentReattach("acl", 0, config.mock.GetAgentsMemory())
+		AgentAttach("acl", 0, config.mock.GetAgentsMemory())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent: %w", err)
 	}

--- a/modules/balancer/agent/go/ffi/manager_test.go
+++ b/modules/balancer/agent/go/ffi/manager_test.go
@@ -274,7 +274,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("SetupControlplane", func(t *testing.T) {
-		agent, err := m.SharedMemory().AgentReattach("bootstrap", 0, 1<<20)
+		agent, err := m.SharedMemory().AgentAttach("bootstrap", 0, 1<<20)
 		require.NoError(t, err, "failed to attach bootstrap agent")
 		{
 			functionConfig := ffi.FunctionConfig{

--- a/modules/balancer/agent/go/manager_test.go
+++ b/modules/balancer/agent/go/manager_test.go
@@ -408,7 +408,7 @@ func TestManager(t *testing.T) {
 	})
 
 	t.Run("SetupControlplane", func(t *testing.T) {
-		cpAgent, err := m.SharedMemory().AgentReattach("bootstrap", 0, 1<<20)
+		cpAgent, err := m.SharedMemory().AgentAttach("bootstrap", 0, 1<<20)
 		require.NoError(t, err, "failed to attach bootstrap agent")
 		{
 			functionConfig := yanet2.FunctionConfig{

--- a/modules/balancer/bench/go/bench.go
+++ b/modules/balancer/bench/go/bench.go
@@ -380,7 +380,7 @@ const (
 
 func setupYanet(shm *yanet.SharedMemory) error {
 	// Attach bootstrap agent to configure the controlplane
-	bootstrap, err := shm.AgentReattach("bootstrap", 0, 1<<20)
+	bootstrap, err := shm.AgentAttach("bootstrap", 0, 1<<20)
 	if err != nil {
 		return fmt.Errorf("failed to attach to bootstrap agent: %w", err)
 	}

--- a/modules/balancer/tests/go/utils/setup.go
+++ b/modules/balancer/tests/go/utils/setup.go
@@ -88,7 +88,7 @@ func Make(config *TestConfig) (*TestSetup, error) {
 		panic("failed to get balancer after successful creation")
 	}
 
-	bootstrap, err := mock.SharedMemory().AgentReattach("bootstrap", 0, 1<<20)
+	bootstrap, err := mock.SharedMemory().AgentAttach("bootstrap", 0, 1<<20)
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to bootstrap agent: %v", err)
 	}

--- a/modules/decap/controlplane/mod.go
+++ b/modules/decap/controlplane/mod.go
@@ -33,7 +33,7 @@ func NewDecapModule(cfg *Config, log *zap.Logger) (*DecapModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("decap", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("decap", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/dscp/controlplane/mod.go
+++ b/modules/dscp/controlplane/mod.go
@@ -34,7 +34,7 @@ func NewDSCPModule(cfg *Config, log *zap.Logger) (*DscpModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("dscp", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("dscp", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -35,7 +35,7 @@ func NewForwardModule(cfg *Config, log *zap.Logger) (*ForwardModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/forward/tests/forward/setup.go
+++ b/modules/forward/tests/forward/setup.go
@@ -46,7 +46,7 @@ func SetupTest(config *TestConfig) (*TestSetup, error) {
 	}
 
 	agent, err := m.SharedMemory().
-		AgentReattach("forward", 0, config.mock.GetAgentsMemory())
+		AgentAttach("forward", 0, config.mock.GetAgentsMemory())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent: %w", err)
 	}

--- a/modules/nat64/controlplane/mod.go
+++ b/modules/nat64/controlplane/mod.go
@@ -33,7 +33,7 @@ func NewNAT64Module(cfg *Config, log *zap.Logger) (*NAT64Module, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("nat64", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("nat64", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -41,7 +41,7 @@ func NewPdumpModule(cfg *Config, log *zap.Logger) (*PdumpModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach("pdump", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach("pdump", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -67,7 +67,7 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentReattach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}


### PR DESCRIPTION
All Go callers — module control planes, devices, mocks, and balancer agent tests — now go through AgentAttach. The C-side reattach helper is retained because the legacy balancer agent still depends on it; it will be removed once balancer2 supersedes the legacy balancer.