### PR TITLE
fix(tests): update CLI arguments in functional tests

### DIFF
--- a/tests/functional/balancer_test.sh
+++ b/tests/functional/balancer_test.sh
@@ -18,8 +18,8 @@ ip nei add fe80::1 lladdr 52:54:00:6b:ff:a1 dev kni0
 ip nei add 203.0.113.1 lladdr 52:54:00:6b:ff:a1 dev kni0
 sleep 3
 
-/mnt/target/release/yanet-cli-route insert --cfg route0 --via fe80::1 ::/0
-/mnt/target/release/yanet-cli-route insert --cfg route0 --via 203.0.113.1 0.0.0.0/0
+/mnt/target/release/yanet-cli-route insert --name route0 --via fe80::1 ::/0
+/mnt/target/release/yanet-cli-route insert --name route0 --via 203.0.113.1 0.0.0.0/0
 
 /mnt/target/release/yanet-cli-balancer update --name balancer0 --config /mnt/yanet2/balancer.yaml
 

--- a/tests/functional/decap_test.sh
+++ b/tests/functional/decap_test.sh
@@ -39,25 +39,25 @@ ip nei add 203.0.113.1 lladdr 52:54:00:6b:ff:a1 dev kni0
 sleep 3
 
 # Enable L2 forwarding between devices
-/mnt/target/release/yanet-cli-forward l2-enable --cfg=forward0 --src 0 --dst 1
-/mnt/target/release/yanet-cli-forward l2-enable --cfg=forward0 --src 1 --dst 0
+/mnt/target/release/yanet-cli-forward l2-enable --name=forward0 --src 0 --dst 1
+/mnt/target/release/yanet-cli-forward l2-enable --name=forward0 --src 1 --dst 0
 
 # Add L3 forwarding rules
-/mnt/target/release/yanet-cli-forward l3-add --cfg=forward0 --src 1 --dst 0 --net 0.0.0.0/0
-/mnt/target/release/yanet-cli-forward l3-add --cfg=forward0 --src 1 --dst 0 --net ::/0
-/mnt/target/release/yanet-cli-forward l3-add --cfg=forward0 --src 0 --dst 1 --net 203.0.113.14/32
-/mnt/target/release/yanet-cli-forward l3-add --cfg=forward0 --src 0 --dst 1 --net fe80::5054:ff:fe6b:ffa5/64
-/mnt/target/release/yanet-cli-forward l3-add --cfg=forward0 --src 0 --dst 1 --net ff02::/16
+/mnt/target/release/yanet-cli-forward l3-add --name=forward0 --src 1 --dst 0 --net 0.0.0.0/0
+/mnt/target/release/yanet-cli-forward l3-add --name=forward0 --src 1 --dst 0 --net ::/0
+/mnt/target/release/yanet-cli-forward l3-add --name=forward0 --src 0 --dst 1 --net 203.0.113.14/32
+/mnt/target/release/yanet-cli-forward l3-add --name=forward0 --src 0 --dst 1 --net fe80::5054:ff:fe6b:ffa5/64
+/mnt/target/release/yanet-cli-forward l3-add --name=forward0 --src 0 --dst 1 --net ff02::/16
 
 # Route
-/mnt/target/release/yanet-cli-route insert --cfg route0 --via fe80::1 ::/0
-/mnt/target/release/yanet-cli-route insert --cfg route0 --via 203.0.113.1 0.0.0.0/0
+/mnt/target/release/yanet-cli-route insert --name route0 --via fe80::1 ::/0
+/mnt/target/release/yanet-cli-route insert --name route0 --via 203.0.113.1 0.0.0.0/0
 
 # Add decap prefixes (outer tunnel destination addresses)
 # IPv4 prefix for IPIP6 (IPv6-in-IPv4) tunnels
-/mnt/target/release/yanet-cli-decap prefix-add --cfg decap0 -p 4.5.6.7/32
+/mnt/target/release/yanet-cli-decap prefix-add --name decap0 -p 4.5.6.7/32
 # IPv6 prefix for IP6IP (IPv4-in-IPv6) tunnels
-/mnt/target/release/yanet-cli-decap prefix-add --cfg decap0 -p 1:2:3:4::abcd/128
+/mnt/target/release/yanet-cli-decap prefix-add --name decap0 -p 1:2:3:4::abcd/128
 
 # Configure pipelines (following docs/virtual-run.org)
 /mnt/target/release/yanet-cli-pipeline update --name=bootstrap --modules forward:forward0
@@ -70,4 +70,4 @@ sleep 3
 
 # Inspect configuration
 /mnt/target/release/yanet-cli-inspect
-/mnt/target/release/yanet-cli-route show --cfg route0
+/mnt/target/release/yanet-cli-route show --name route0

--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -54,12 +54,12 @@ var (
 		"ip addr add " + VMIPv4Host + "/24 dev kni0",
 
 		// Configure L2 and L3 forwarding
-		CLIForward + " update --cfg=forward0 --rules /mnt/yanet2/forward.yaml",
+		CLIForward + " update --name=forward0 --rules /mnt/yanet2/forward.yaml",
 
 		// Bootstrap the default IPv4/IPv6 FIB for the "route0" config.
 		// The YAML payload is created on the host before this command
 		// runs; see framework_test.go.
-		CLIRoute + " fib update --cfg=route0 --rules /mnt/config/route0.yaml",
+		CLIRoute + " fib update --name=route0 --rules /mnt/config/route0.yaml",
 
 		CLIFunction + " update --name=virt --chains chain0:10=forward:forward0",
 		CLIFunction + " update --name=test --chains chain2:1=forward:forward0,route:route0",

--- a/tests/functional/main/acl_test.go
+++ b/tests/functional/main/acl_test.go
@@ -20,7 +20,7 @@ func TestACL(t *testing.T) {
 	// 1. ACL Configuration Tests
 	fw.Run("Configure_ACL_module", func(fw *framework.F, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --cfg acl0 --rules /mnt/yanet2/tests/functional/testdata/acl.yaml",
+			framework.CLIACL + " update --name acl0 --rules /mnt/yanet2/tests/functional/testdata/acl.yaml",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl0,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
 		}
@@ -507,7 +507,7 @@ func TestACLMbufLeak(t *testing.T) {
 
 	fw.Run("Configure", func(fw *framework.F, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --cfg acl_mbufleak --rules /mnt/yanet2/tests/functional/testdata/acl-mbuf-leak.yaml",
+			framework.CLIACL + " update --name acl_mbufleak --rules /mnt/yanet2/tests/functional/testdata/acl-mbuf-leak.yaml",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_mbufleak,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
 		}

--- a/tests/functional/main/decap_test.go
+++ b/tests/functional/main/decap_test.go
@@ -20,8 +20,8 @@ func TestDecap(t *testing.T) {
 	fw.Run("Configure_Decap_Module", func(fw *framework.F, t *testing.T) {
 		// Decap-specific configuration
 		commands := []string{
-			"/mnt/target/release/yanet-cli-decap prefix-add --cfg decap0 -p 4.5.6.7/32",
-			"/mnt/target/release/yanet-cli-decap prefix-add --cfg decap0 -p 1:2:3:4::abcd/128",
+			"/mnt/target/release/yanet-cli-decap prefix-add --name decap0 -p 4.5.6.7/32",
+			"/mnt/target/release/yanet-cli-decap prefix-add --name decap0 -p 1:2:3:4::abcd/128",
 
 			"/mnt/target/release/yanet-cli-function update --name=test --chains c0:3=forward:forward0,decap:decap0,route:route0",
 			"/mnt/target/release/yanet-cli-pipeline update --name=test --functions test",

--- a/tests/functional/main/fwstate_test.go
+++ b/tests/functional/main/fwstate_test.go
@@ -35,7 +35,7 @@ func TestFWStateListEntries(t *testing.T) {
 	// 1. Configure fwstate module with maps and sync settings.
 	fw.Run("Configure_fwstate", func(fw *framework.F, t *testing.T) {
 		commands := []string{
-			framework.CLIFWState + " update --cfg fwstate0" +
+			framework.CLIFWState + " update --name fwstate0" +
 				" --index-size 1024" +
 				" --extra-bucket-count 64" +
 				" --src-addr 2001:db8::100" +
@@ -52,8 +52,8 @@ func TestFWStateListEntries(t *testing.T) {
 	// 2. Link fwstate to an ACL config so the dataplane module is active.
 	fw.Run("Link_fwstate_to_acl", func(fw *framework.F, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --cfg acl_fw --rules /mnt/yanet2/acl+fwstate.yaml",
-			framework.CLIFWState + " link --cfg fwstate0 --acl acl_fw",
+			framework.CLIACL + " update --name acl_fw --rules /mnt/yanet2/acl+fwstate.yaml",
+			framework.CLIFWState + " link --name fwstate0 --acl acl_fw",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_fw,fwstate:fwstate0,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
 		}
@@ -85,7 +85,7 @@ func TestFWStateListEntries(t *testing.T) {
 	// 4. Forward listing: verify exact entries.
 	fw.Run("Forward_listing", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --cfg fwstate0 --batch 100 --direction forward --include-expired",
+			framework.CLIFWState + " entries --name fwstate0 --batch 100 --direction forward --include-expired",
 		)
 		require.NoError(t, err, "list-entries forward failed")
 		t.Log("Forward listing output:\n", output)
@@ -101,7 +101,7 @@ func TestFWStateListEntries(t *testing.T) {
 	// 5. Forward listing with JSON: parse and verify key fields.
 	fw.Run("Forward_listing_json", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --cfg fwstate0 --batch 100 --direction forward --include-expired --json",
+			framework.CLIFWState + " entries --name fwstate0 --batch 100 --direction forward --include-expired --json",
 		)
 		require.NoError(t, err, "list-entries forward json failed")
 		t.Log("JSON output:\n", output)
@@ -155,7 +155,7 @@ func TestFWStateListEntries(t *testing.T) {
 	// 6. Backward listing from last entry: verify all entries present.
 	fw.Run("Backward_listing", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --cfg fwstate0 --batch 100 --direction backward --index 4294967295 --include-expired",
+			framework.CLIFWState + " entries --name fwstate0 --batch 100 --direction backward --index 4294967295 --include-expired",
 		)
 		require.NoError(t, err, "list-entries backward failed")
 		t.Log("Backward listing output:\n", output)
@@ -168,7 +168,7 @@ func TestFWStateListEntries(t *testing.T) {
 	// 7. Pagination: read with batch=1, verify all entries are still returned.
 	fw.Run("Pagination", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --cfg fwstate0 --batch 1 --direction forward --include-expired",
+			framework.CLIFWState + " entries --name fwstate0 --batch 1 --direction forward --include-expired",
 		)
 		require.NoError(t, err, "list-entries with batch=1 failed")
 		t.Log("Pagination output:\n", output)
@@ -182,7 +182,7 @@ func TestFWStateListEntries(t *testing.T) {
 	// 8. Config not found: request entries from a non-existent config.
 	fw.Run("Config_not_found", func(fw *framework.F, t *testing.T) {
 		_, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --cfg nonexistent --batch 10",
+			framework.CLIFWState + " entries --name nonexistent --batch 10",
 		)
 		require.Error(t, err, "should fail for non-existent config")
 	})
@@ -227,7 +227,7 @@ func TestFWStateListEntries(t *testing.T) {
 	// 11. Stats: verify total_elements matches the number of injected entries.
 	fw.Run("Stats_after_entries", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " stats --cfg fwstate0",
+			framework.CLIFWState + " stats --name fwstate0",
 		)
 		require.NoError(t, err, "stats command failed")
 		t.Log("Stats output:\n", output)
@@ -271,7 +271,7 @@ func TestFWStateListEntries(t *testing.T) {
 	// 13. IPv6 forward listing: verify entries were created.
 	fw.Run("IPv6_forward_listing", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --cfg fwstate0 --ipv6 --batch 100 --direction forward --include-expired",
+			framework.CLIFWState + " entries --name fwstate0 --ipv6 --batch 100 --direction forward --include-expired",
 		)
 		require.NoError(t, err, "IPv6 list-entries forward failed")
 		t.Log("IPv6 forward listing output:\n", output)
@@ -320,7 +320,7 @@ func TestFWStateListEntries(t *testing.T) {
 	// 16. IPv6 stats: verify total_elements.
 	fw.Run("IPv6_stats", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " stats --cfg fwstate0",
+			framework.CLIFWState + " stats --name fwstate0",
 		)
 		require.NoError(t, err, "stats command failed")
 		t.Log("Stats output:\n", output)
@@ -356,7 +356,7 @@ func TestFWStateUDPEndianness(t *testing.T) {
 	// 1. Configure fwstate + ACL (reuse existing config from TestFWStateListEntries)
 	fw.Run("Configure_fwstate", func(fw *framework.F, t *testing.T) {
 		commands := []string{
-			framework.CLIFWState + " update --cfg fwstate_udp" +
+			framework.CLIFWState + " update --name fwstate_udp" +
 				" --index-size 1024" +
 				" --extra-bucket-count 64" +
 				" --src-addr 2001:db8::100" +
@@ -372,8 +372,8 @@ func TestFWStateUDPEndianness(t *testing.T) {
 
 	fw.Run("Link_fwstate_to_acl", func(fw *framework.F, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --cfg acl_udp --rules /mnt/yanet2/acl+fwstate.yaml",
-			framework.CLIFWState + " link --cfg fwstate_udp --acl acl_udp",
+			framework.CLIACL + " update --name acl_udp --rules /mnt/yanet2/acl+fwstate.yaml",
+			framework.CLIFWState + " link --name fwstate_udp --acl acl_udp",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_udp,fwstate:fwstate_udp,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
 		}
@@ -403,7 +403,7 @@ func TestFWStateUDPEndianness(t *testing.T) {
 	// 3. Verify state was created with correct ports via entries listing.
 	fw.Run("Verify_UDP_state_entries", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --cfg fwstate_udp --batch 100 --direction forward --include-expired",
+			framework.CLIFWState + " entries --name fwstate_udp --batch 100 --direction forward --include-expired",
 		)
 		require.NoError(t, err, "list-entries forward failed")
 		t.Log("UDP entries output:\n", output)
@@ -597,7 +597,7 @@ func TestFWStateExternalSyncFrame(t *testing.T) {
 	// 1. Configure fwstate module.
 	fw.Run("Configure_fwstate", func(fw *framework.F, t *testing.T) {
 		commands := []string{
-			framework.CLIFWState + " update --cfg fwstate_ext" +
+			framework.CLIFWState + " update --name fwstate_ext" +
 				" --index-size 1024" +
 				" --extra-bucket-count 64" +
 				" --src-addr 2001:db8::100" +
@@ -614,8 +614,8 @@ func TestFWStateExternalSyncFrame(t *testing.T) {
 	// 2. Link fwstate to ACL with the sync frame allow rule.
 	fw.Run("Link_fwstate_to_acl", func(fw *framework.F, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --cfg acl_ext --rules /mnt/yanet2/acl+fwstate.yaml",
-			framework.CLIFWState + " link --cfg fwstate_ext --acl acl_ext",
+			framework.CLIACL + " update --name acl_ext --rules /mnt/yanet2/acl+fwstate.yaml",
+			framework.CLIFWState + " link --name fwstate_ext --acl acl_ext",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_ext,fwstate:fwstate_ext,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
 		}
@@ -626,7 +626,7 @@ func TestFWStateExternalSyncFrame(t *testing.T) {
 	// 3. Verify no state entries exist initially.
 	fw.Run("Verify_empty_state", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " stats --cfg fwstate_ext",
+			framework.CLIFWState + " stats --name fwstate_ext",
 		)
 		require.NoError(t, err, "stats command failed")
 		t.Log("Initial stats:\n", output)
@@ -664,7 +664,7 @@ func TestFWStateExternalSyncFrame(t *testing.T) {
 	// 5. Verify that the external sync frame created a state entry.
 	fw.Run("Verify_state_created", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --cfg fwstate_ext --batch 100 --direction forward --include-expired",
+			framework.CLIFWState + " entries --name fwstate_ext --batch 100 --direction forward --include-expired",
 		)
 		require.NoError(t, err, "list-entries forward failed")
 		t.Log("Entries after external sync:\n", output)
@@ -677,7 +677,7 @@ func TestFWStateExternalSyncFrame(t *testing.T) {
 	// 6. Verify the state entry is marked as external via JSON listing.
 	fw.Run("Verify_state_is_external", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " entries --cfg fwstate_ext --batch 100 --direction forward --include-expired --json",
+			framework.CLIFWState + " entries --name fwstate_ext --batch 100 --direction forward --include-expired --json",
 		)
 		require.NoError(t, err, "list-entries forward json failed")
 		t.Log("JSON entries:\n", output)
@@ -715,7 +715,7 @@ func TestFWStateExternalSyncFrame(t *testing.T) {
 	// 7. Verify stats show exactly 1 entry.
 	fw.Run("Verify_stats", func(fw *framework.F, t *testing.T) {
 		output, err := fw.ExecuteCommand(
-			framework.CLIFWState + " stats --cfg fwstate_ext",
+			framework.CLIFWState + " stats --name fwstate_ext",
 		)
 		require.NoError(t, err, "stats command failed")
 		t.Log("Stats after external sync:\n", output)

--- a/tests/functional/main/nat64_test.go
+++ b/tests/functional/main/nat64_test.go
@@ -18,7 +18,7 @@ import (
 // setAndWaitForNAT64DropFlags sets NAT64 drop flags and waits for them to be applied
 func setAndWaitForNAT64DropFlags(fw *framework.F, dropUnknownPrefix, dropUnknownMapping bool, timeout time.Duration) error {
 	// Build the drop command
-	cmd := "/mnt/target/release/yanet-cli-nat64 drop --cfg nat64_0"
+	cmd := "/mnt/target/release/yanet-cli-nat64 drop --name nat64_0"
 	if dropUnknownPrefix {
 		cmd += " --drop-unknown-prefix"
 	}
@@ -36,7 +36,7 @@ func setAndWaitForNAT64DropFlags(fw *framework.F, dropUnknownPrefix, dropUnknown
 	deadline := time.Now().Add(timeout)
 
 	for time.Now().Before(deadline) {
-		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-nat64 show --cfg nat64_0 --format json")
+		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-nat64 show --name nat64_0 --format json")
 		if err != nil {
 			return fmt.Errorf("failed to check NAT64 status: %w", err)
 		}
@@ -96,9 +96,9 @@ func TestNAT64(t *testing.T) {
 		// NAT64-specific configuration
 		commands := []string{
 			// Configure NAT64 mappings (using addresses from unit tests)
-			"/mnt/target/release/yanet-cli-nat64 prefix add --cfg nat64_0 --prefix 2001:db8::/96",
-			"/mnt/target/release/yanet-cli-nat64 mapping add --cfg nat64_0 --ipv4 198.51.100.1 --ipv6 2001:db8::4 --prefix-index 0",
-			"/mnt/target/release/yanet-cli-nat64 mapping add --cfg nat64_0 --ipv4 198.51.100.2 --ipv6 2001:db8::3 --prefix-index 0",
+			"/mnt/target/release/yanet-cli-nat64 prefix add --name nat64_0 --prefix 2001:db8::/96",
+			"/mnt/target/release/yanet-cli-nat64 mapping add --name nat64_0 --ipv4 198.51.100.1 --ipv6 2001:db8::4 --prefix-index 0",
+			"/mnt/target/release/yanet-cli-nat64 mapping add --name nat64_0 --ipv4 198.51.100.2 --ipv6 2001:db8::3 --prefix-index 0",
 
 			"/mnt/target/release/yanet-cli-function update --name=test --chains chain0:1=forward:forward0,nat64:nat64_0,route:route0",
 			// Configure pipeline

--- a/tests/functional/main/route_mpls_test.go
+++ b/tests/functional/main/route_mpls_test.go
@@ -116,28 +116,28 @@ func TestRouteMPLS(t *testing.T) {
 
 	fw.Run("Insert_Static_RouteMPLS-4-4", func(fw *framework.F, t *testing.T) {
 		// Insert route with the nexthop (do_flush is automatic in insert command)
-		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 5.0.0.0/9 --dst 10.12.1.1 --src 4.2.4.2 --label 45 --weight 5 --counter 4-4")
+		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --name route-mpls -p 5.0.0.0/9 --dst 10.12.1.1 --src 4.2.4.2 --label 45 --weight 5 --counter 4-4")
 		require.NoError(t, err, "Failed to insert route")
 		t.Logf("Insert route output: %s", output)
 	})
 
 	fw.Run("Insert_Static_RouteMPLS-4-6", func(fw *framework.F, t *testing.T) {
 		// Insert route with the nexthop (do_flush is automatic in insert command)
-		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 6.0.0.0/10 --dst ccee::11 --src 2424::1212 --label 45 --weight 5 --counter 4-6")
+		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --name route-mpls -p 6.0.0.0/10 --dst ccee::11 --src 2424::1212 --label 45 --weight 5 --counter 4-6")
 		require.NoError(t, err, "Failed to insert route")
 		t.Logf("Insert route output: %s", output)
 	})
 
 	fw.Run("Insert_Static_RouteMPLS-6-4", func(fw *framework.F, t *testing.T) {
 		// Insert route with the nexthop (do_flush is automatic in insert command)
-		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 0066::0/17 --dst 10.12.1.1 --src 4.2.4.2 --label 45 --weight 5 --counter 6-4")
+		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --name route-mpls -p 0066::0/17 --dst 10.12.1.1 --src 4.2.4.2 --label 45 --weight 5 --counter 6-4")
 		require.NoError(t, err, "Failed to insert route")
 		t.Logf("Insert route output: %s", output)
 	})
 
 	fw.Run("Insert_Static_RouteMPLS-6-6", func(fw *framework.F, t *testing.T) {
 		// Insert route with the nexthop (do_flush is automatic in insert command)
-		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --cfg route-mpls -p 0088::0/19 --dst ccee::11 --src 2424::1212 --label 45 --weight 5 --counter 6-6")
+		output, err := fw.ExecuteCommand("/mnt/target/release/yanet-cli-route-mpls update --name route-mpls -p 0088::0/19 --dst ccee::11 --src 2424::1212 --label 45 --weight 5 --counter 6-6")
 		require.NoError(t, err, "Failed to insert route")
 		t.Logf("Insert route output: %s", output)
 	})

--- a/tests/functional/main/route_test.go
+++ b/tests/functional/main/route_test.go
@@ -109,7 +109,7 @@ func applyFIB(t *testing.T, fw *framework.F, cfgName, suffix string, prefixes ..
 	require.NoError(t, fw.CreateConfigFile(name, string(body)),
 		"failed to create FIB config file")
 
-	cmd := framework.CLIRoute + " fib update --cfg=" + cfgName +
+	cmd := framework.CLIRoute + " fib update --name=" + cfgName +
 		" --rules /mnt/config/" + name
 	_, err = fw.ExecuteCommand(cmd)
 	require.NoError(t, err, "failed to update FIB")


### PR DESCRIPTION
Updates functional tests to use the renamed CLI flags from #748 (`--cfg` → `--name`).