### PR TITLE
fix(ci): run build and functional tests on Rust changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
       - "go.mod"
       - "go.sum"
       - "Makefile"
+      - "**.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
   pull_request:
     branches: ["main"]
     paths:
@@ -21,6 +24,9 @@ on:
       - "go.mod"
       - "go.sum"
       - "Makefile"
+      - "**.rs"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
 
 jobs:
   build:


### PR DESCRIPTION
The `Build YANET` workflow gates the functional tests but its `paths:` filter has no Rust patterns, so CLI-only PRs never exercise the release binaries against the functional suite.

- Add `**.rs`, `**/Cargo.toml`, `**/Cargo.lock` to the `push` and `pull_request` `paths:` in `.github/workflows/build.yml`.
- Trigger surface now matches `rust-check.yml`.
