### PR TITLE
perf(ci): tune workflow caches to reduce build time

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -44,6 +44,14 @@ jobs:
         with:
           submodules: true
 
+      - uses: hendrikmuhs/ccache-action@v1.2.18
+        name: ccache
+        with:
+          key: ${{ runner.os }}-deb-ccache-${{ matrix.unbtver }}
+          max-size: 2G
+          verbose: 2
+          create-symlink: true
+
       - name: update apt (act hack)
         if: ${{ env.ACT }}
         run: |
@@ -59,7 +67,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.unbtver }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.unbtver }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.unbtver }}
+            ${{ runner.os }}-cargo-${{ matrix.unbtver }}
 
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,10 +67,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/*.rs') }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/*.rs') }}-
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq clang-tidy-19
@@ -91,6 +91,8 @@ jobs:
         name: ccache
         with:
           key: ${{ runner.os }}-build-cache
+          max-size: 2G
+          verbose: 2
 
       - uses: actions/setup-go@v5
         with:
@@ -108,9 +110,9 @@ jobs:
           path: |
             ${{ env.cache }}
             ${{ env.modcache }}
-          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}-${{ hashFiles('**/*.go') }}
+          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
-            ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}-
+            ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
             ${{ env.cache_name }}-${{ runner.os }}-go-
 
       - name: Install Go Protobuf Plugins

--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -45,6 +45,8 @@ jobs:
         name: ccache
         with:
           key: ${{ runner.os }}-fuzz-build-cache
+          max-size: 1G
+          verbose: 2
 
       - name: Build fuzz targets
         run: make fuzz


### PR DESCRIPTION
Three independent CI cache issues, addressed in one pass:

- ccache in `build.yml` ran with `max-size: 500M`, but the job runs three sequential variants (ASAN, TSAN, release) that produce distinct cache entries due to differing flags. The third variant could evict mid-run.
- `build-deb.yml` had no ccache; every run rebuilt DPDK from scratch inside `debuild`.
- Go and Cargo cache keys in `build.yml` hashed every `*.go` / `*.rs` file, generating a fresh ~200 MB entry per PR that was rarely re-hit. Roughly 3 GB of dead per-PR entries had accumulated.

Changes:

- Bump ccache `max-size` to 2 GB in `build.yml` and 1 GB in `fuzz-test.yml`. Enable `verbose: 2` for hit-rate visibility.
- Add ccache to `build-deb.yml` with `create-symlink: true` and a key scoped per `matrix.unbtver` (gcc/glibc differ between 22.04 and 24.04).
- Drop wildcard source-file hashes from Go and Cargo keys in `build.yml`. Cargo and Go content-address their own outputs inside `target/` and `$GOCACHE`, so the key change does not affect incremental correctness.
- Unify the `build-deb.yml` Cargo key with `Cargo.toml` and a tiered `restore-keys` chain.

Expected impact: ~2-4 min saved on `build.yml`, ~3-5 min on `build-deb.yml`. ~3 GB of cache budget free.