### PR TITLE
fix(route): free cp_module resources on config data init failure

### DIFF
--- a/common/test_assert.h
+++ b/common/test_assert.h
@@ -2,6 +2,8 @@
 
 #include "lib/logging/log.h"
 
+#include <string.h>
+
 /* Test framework macros */
 #define TEST_SUCCESS 0
 #define TEST_FAILED -1
@@ -31,6 +33,22 @@
 			    ##__VA_ARGS__,                                     \
 			    (long)(b),                                         \
 			    (long)(a));                                        \
+			return TEST_FAILED;                                    \
+		}                                                              \
+	} while (0)
+
+#define TEST_ASSERT_STR_CONTAINS(haystack, needle, msg, ...)                   \
+	do {                                                                   \
+		const char *_hay = (haystack);                                 \
+		const char *_ndl = (needle);                                   \
+		if (_hay == NULL || _ndl == NULL ||                            \
+		    strstr(_hay, _ndl) == NULL) {                              \
+			LOG(ERROR,                                             \
+			    "ASSERT FAILED: " msg                              \
+			    " (expected substring '%s' in '%s')",              \
+			    ##__VA_ARGS__,                                     \
+			    _ndl ? _ndl : "(null)",                            \
+			    _hay ? _hay : "(null)");                           \
 			return TEST_FAILED;                                    \
 		}                                                              \
 	} while (0)

--- a/meson.build
+++ b/meson.build
@@ -142,6 +142,7 @@ libdpdk_inc_dep = libdpdk_dep.partial_dependency(includes: true)
 subdir('common')
 subdir('lib')
 subdir('filter')
+module_test_dirs = []
 subdir('modules')
 subdir('devices')
 subdir('dataplane')
@@ -150,6 +151,9 @@ if not dataplane_only
   subdir('controlplane')
   subdir('operators')
   subdir('mock')
+  foreach dir : module_test_dirs
+    subdir(dir)
+  endforeach
   subdir('tests')
 endif
 

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -49,6 +49,7 @@ route_module_config_create(
 		    config, &config->cp_module.memory_context
 	    )) {
 		yanet_error_add(err, "failed to init config data");
+		cp_module_fini(&config->cp_module);
 		memory_bfree(
 			&agent->memory_context,
 			config,

--- a/modules/route/meson.build
+++ b/modules/route/meson.build
@@ -4,4 +4,5 @@ if not dataplane_only
   subdir('api')
   subdir('controlplane')
   subdir('fuzzing')
+  module_test_dirs += 'modules/route/tests'
 endif

--- a/modules/route/tests/meson.build
+++ b/modules/route/tests/meson.build
@@ -1,0 +1,45 @@
+includes = include_directories('../../../', '../../../lib')
+
+lib_dependencies = [
+    lib_common_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_config_cp_dep,
+    lib_agent_cp_dep,
+    lib_counters_dep,
+    lib_pipeline_dp_dep,
+    libdpdk_inc_dep,
+    lib_route_cp_dep,
+    lib_lib_utils_dep,
+    lib_yanet_mock_dep,
+]
+
+modules_dep = [
+    lib_balancer_dp_dep,
+    lib_decap_dp_dep,
+    lib_dscp_dp_dep,
+    lib_acl_dp_dep,
+    lib_fwstate_dp_dep,
+    lib_forward_dp_dep,
+    lib_route_dp_dep,
+    lib_nat64_dp_dep,
+    lib_pdump_dp_dep,
+]
+
+devices_dep = [
+    lib_dev_plain_dp_dep,
+    lib_dev_vlan_dp_dep,
+]
+
+deps = modules_dep + devices_dep + lib_dependencies
+
+route_api_test = executable(
+  'route_api_test',
+  ['route_api_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: deps,
+  include_directories: includes,
+)
+
+test('route_api_test', route_api_test, suite: 'route')

--- a/modules/route/tests/route_api_test.c
+++ b/modules/route/tests/route_api_test.c
@@ -1,0 +1,103 @@
+/*
+ * Tests that route_module_config_create does not leak memory when
+ * route_module_config_data_init fails due to OOM after cp_module_init
+ * succeeds.
+ *
+ * Mechanism: agent_attach carves a private arena of exactly memory_limit
+ * bytes from the cp_config allocator. All module allocations draw from
+ * this arena.
+ *
+ * Leak detection: block_allocator_free_size must return to its value
+ * recorded immediately after agent_attach. Any byte not freed by a
+ * cleanup path stays missing from the free list.
+ */
+
+#include "api/agent.h"
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/strutils.h"
+#include "common/test_assert.h"
+#include "controlplane/agent/agent.h"
+#include "lib/errors/errors.h"
+#include "logging/log.h"
+#include "mock/config.h"
+#include "mock/mock.h"
+#include "modules/route/api/controlplane.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * 16 KB: enough for cp_module_init's small allocations (empirically < 8 KB),
+ * but well below the 32 KB lpm_init page-chunk request.
+ */
+#define ROUTE_TEST_MEMORY_LIMIT (16u * 1024u)
+
+static int
+run_test(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm, 0, "route-test", ROUTE_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	size_t baseline = block_allocator_free_size(&agent->block_allocator);
+
+	struct cp_module *cp = route_module_config_create(agent, "probe", &err);
+	TEST_ASSERT_NULL(cp, "create unexpectedly succeeded");
+
+	const char *errmsg = (err != NULL) ? yanet_error_message(err) : "";
+	TEST_ASSERT_STR_CONTAINS(
+		errmsg, "failed to init config data", "wrong failure path"
+	);
+	yanet_error_reset(&err);
+
+	size_t after = block_allocator_free_size(&agent->block_allocator);
+	TEST_ASSERT_EQUAL(
+		(long)after,
+		(long)baseline,
+		"memory leaked after failed create: baseline=%zu after=%zu",
+		baseline,
+		after
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	struct yanet_mock_config config;
+	memset(&config, 0, sizeof(config));
+	config.cp_memory = 1 << 25;
+	config.dp_memory = 1 << 20;
+	config.device_count = 1;
+	config.devices[0].id = 0;
+	strtcpy(config.devices[0].name,
+		"01:00.0",
+		sizeof(config.devices[0].name));
+	config.worker_count = 1;
+
+	struct yanet_mock mock;
+	int res = yanet_mock_init(&mock, &config, NULL);
+	if (res != 0) {
+		fprintf(stderr, "yanet_mock_init failed: %d\n", res);
+		return 1;
+	}
+
+	struct yanet_shm *shm = yanet_mock_shm(&mock);
+	if (shm == NULL) {
+		fprintf(stderr, "yanet_mock_shm returned NULL\n");
+		yanet_mock_free(&mock);
+		return 1;
+	}
+
+	res = run_test(shm);
+	yanet_mock_free(&mock);
+
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}


### PR DESCRIPTION
When `route_module_config_data_init` failed after a successful `cp_module_init`, the counter registry, registered counters, perf-counter table, and devices array allocated by `cp_module_init` were never released.