### PR TITLE
refactor(fwstate): rename fwmap_destroy to fwmap_free

### DIFF
--- a/lib/fwstate/fwmap.h
+++ b/lib/fwstate/fwmap.h
@@ -607,7 +607,7 @@ fwmap_update_counters(
 
 // Free a FWMap and all its resources.
 static inline void
-fwmap_destroy(fwmap_t *map, struct memory_context *ctx) {
+fwmap_free(fwmap_t *map, struct memory_context *ctx) {
 	if (!map) {
 		return;
 	}
@@ -948,7 +948,7 @@ fwmap_new(const fwmap_config_t *user_config, struct memory_context *ctx) {
 	return map;
 
 fail:
-	fwmap_destroy(map, ctx);
+	fwmap_free(map, ctx);
 	return NULL;
 }
 

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -14,12 +14,12 @@ static void
 fwstate_config_destroy(struct fwstate_config *config, struct agent *agent) {
 	if (config->fw4state != NULL) {
 		fwmap_t *fw4 = ADDR_OF(&config->fw4state);
-		fwmap_destroy(fw4, &agent->memory_context);
+		fwmap_free(fw4, &agent->memory_context);
 		config->fw4state = NULL;
 	}
 	if (config->fw6state != NULL) {
 		fwmap_t *fw6 = ADDR_OF(&config->fw6state);
-		fwmap_destroy(fw6, &agent->memory_context);
+		fwmap_free(fw6, &agent->memory_context);
 		config->fw6state = NULL;
 	}
 }
@@ -199,7 +199,7 @@ fwstate_config_create_maps(
 	fwmap_t *fw6state = fwmap_new(&fw6_config, &agent->memory_context);
 	if (fw6state == NULL) {
 		fwmap_t *fw4 = ADDR_OF(&config->cfg.fw4state);
-		fwmap_destroy(fw4, &agent->memory_context);
+		fwmap_free(fw4, &agent->memory_context);
 		config->cfg.fw4state = NULL;
 		return -1;
 	}
@@ -267,7 +267,7 @@ fwstate_config_insert_new_layer(
 		fwmap_t *fw4_active = ADDR_OF(&config->cfg.fw4state);
 		fwmap_t *fw4_old = ADDR_OF(&fw4_active->next);
 		SET_OFFSET_OF(&config->cfg.fw4state, fw4_old);
-		fwmap_destroy(fw4_active, &agent->memory_context);
+		fwmap_free(fw4_active, &agent->memory_context);
 		return -1;
 	}
 
@@ -383,7 +383,7 @@ fwstate_outdated_layers_free(
 			(layermap_list_t *)ADDR_OF(&v4_node->next);
 
 		// Free the layer
-		fwmap_destroy(layer, &agent->memory_context);
+		fwmap_free(layer, &agent->memory_context);
 
 		// Free the list node
 		memory_bfree(&agent->memory_context, v4_node, sizeof(*v4_node));
@@ -399,7 +399,7 @@ fwstate_outdated_layers_free(
 			(layermap_list_t *)ADDR_OF(&v6_node->next);
 
 		// Free the layer
-		fwmap_destroy(layer, &agent->memory_context);
+		fwmap_free(layer, &agent->memory_context);
 
 		// Free the list node
 		memory_bfree(&agent->memory_context, v6_node, sizeof(*v6_node));

--- a/tests/fwstate/fwmap_basic_test.c
+++ b/tests/fwstate/fwmap_basic_test.c
@@ -109,7 +109,7 @@ test_lifecycle(void *arena) {
 	assert(ret >= 0);
 	assert(*retrieved == 200);
 
-	fwmap_destroy(map, ctx);
+	fwmap_free(map, ctx);
 	verify_memory_leaks(ctx, "lifecycle");
 	printf("  Lifecycle test passed\n");
 }
@@ -173,7 +173,7 @@ test_bulk_operations(void *arena) {
 		assert(*value == expected);
 	}
 
-	fwmap_destroy(map, ctx);
+	fwmap_free(map, ctx);
 	verify_memory_leaks(ctx, "bulk_ops");
 	printf("  Bulk operations test passed\n");
 }
@@ -240,7 +240,7 @@ test_collision_chains(void *arena) {
 	fwmap_stats_t stats = fwmap_get_stats(map);
 	printf("    Memory usage: %zu bytes\n", stats.memory_used);
 
-	fwmap_destroy(map, ctx);
+	fwmap_free(map, ctx);
 
 	/* Restore original hash function */
 	fwmap_func_registry[FWMAP_HASH_FNV1A] = original_hash;
@@ -285,7 +285,7 @@ test_ttl_expiration(void *arena) {
 	ret = fwmap_get(map, now, &key, (void **)&retrieved, NULL);
 	assert(ret < 0); /* Must fail to find expired entry */
 
-	fwmap_destroy(map, ctx);
+	fwmap_free(map, ctx);
 	verify_memory_leaks(ctx, "ttl_expiry");
 	printf("  TTL expiration test passed\n");
 }
@@ -335,7 +335,7 @@ test_entry_access(void *arena) {
 	assert(ret >= 0);
 	assert(*retrieved == 2000);
 
-	fwmap_destroy(map, ctx);
+	fwmap_free(map, ctx);
 	verify_memory_leaks(ctx, "entry_access");
 	printf("  Entry access test passed\n");
 }
@@ -456,7 +456,7 @@ test_capacity_limits(void *arena) {
 
 	free(key_buf);
 	free(val_buf);
-	fwmap_destroy(map, ctx);
+	fwmap_free(map, ctx);
 	verify_memory_leaks(ctx, "capacity");
 	printf("  Capacity limits test passed\n");
 }

--- a/tests/fwstate/fwmap_bench_test.c
+++ b/tests/fwstate/fwmap_bench_test.c
@@ -123,7 +123,7 @@ benchmark_performance(void *arena) {
 	printf("    Max chain length: %u\n", stats.max_chain_length);
 	printf("    Memory used: %zu KB\n", stats.memory_used / 1024);
 
-	fwmap_destroy(map, ctx);
+	fwmap_free(map, ctx);
 
 	// Verify memory leaks.
 	verify_memory_leaks(ctx, "benchmark_performance");

--- a/tests/fwstate/fwmap_heavy_bench_test.c
+++ b/tests/fwstate/fwmap_heavy_bench_test.c
@@ -357,7 +357,7 @@ test_multithreaded_benchmark(void *mt_arena) {
 		}
 	}
 
-	fwmap_destroy(map, ctx);
+	fwmap_free(map, ctx);
 	verify_memory_leaks(ctx, "benchmark");
 
 	printf("\n%s%sMulti-threaded benchmark test PASSED%s\n",

--- a/tests/fwstate/fwstate_cursor_test.c
+++ b/tests/fwstate/fwstate_cursor_test.c
@@ -84,7 +84,7 @@ test_env_create(void *arena, const char *name) {
  */
 static void
 test_env_destroy(test_env_t *env) {
-	fwmap_destroy(env->map, env->ctx);
+	fwmap_free(env->map, env->ctx);
 	verify_memory_leaks(env->ctx, env->name);
 }
 

--- a/tests/fwstate/layermap_test.c
+++ b/tests/fwstate/layermap_test.c
@@ -167,7 +167,7 @@ test_layermap_basic_operations(void *arena) {
 	fwmap_t *layer = active_layer;
 	while (layer) {
 		fwmap_t *next = (fwmap_t *)ADDR_OF(&layer->next);
-		fwmap_destroy(layer, ctx);
+		fwmap_free(layer, ctx);
 		layer = next;
 	}
 
@@ -338,7 +338,7 @@ test_layermap_multithreaded(void *arena) {
 	fwmap_t *layer = active_layer;
 	while (layer) {
 		fwmap_t *next = (fwmap_t *)ADDR_OF(&layer->next);
-		fwmap_destroy(layer, ctx);
+		fwmap_free(layer, ctx);
 		layer = next;
 	}
 


### PR DESCRIPTION
Align with project-wide lifecycle naming convention (class B: _new/_free); fwmap_free(NULL) is already a valid no-op via the existing NULL guard.