### PR TITLE
feat(api): add tag-based counter query API

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -9,24 +9,9 @@ struct dp_config;
 
 struct counter_value_handle;
 
-// Predicate kind for a counter_tag. The counter must not carry the tag
-// (counter_tag_absent), must carry the tag with any value
-// (counter_tag_present), or must carry the tag with the exact string
-// stored in tag.value (counter_tag_match).
-enum counter_tag_predicate {
-	counter_tag_absent,
-	counter_tag_present,
-	counter_tag_match
-};
-
-// A single predicate over a counter's tags. key names the tag, and
-// predicate selects which check to apply (see counter_tag_predicate).
-// The implementation reads tag.value only when predicate is
-// counter_tag_match.
 struct counter_tag {
 	const char *key;
 	const char *value;
-	enum counter_tag_predicate predicate;
 };
 
 struct counter_handle {
@@ -104,28 +89,21 @@ yanet_get_counter_value(
 // zero returns every counter known to the dataplane. tags and query
 // may be NULL when their respective counts are zero.
 //
-// Each counter_tag is a predicate against the counter's tags; see
-// counter_tag_predicate for the meaning of each predicate kind. The
-// counter_tag_absent predicate is how callers pin a counter to a
-// specific hierarchy level; for example,
-//     { .key = "device",   .value = "d1", .predicate = counter_tag_match  }
-//     { .key = "pipeline",                .predicate = counter_tag_absent }
-// selects counters of device "d1" only.
+// Each counter_tag is a predicate against the counter's tags, with
+// the check encoded in value: an empty string requires the tag to be
+// absent, "*" requires the tag to be present with any value, and any
+// other string requires the tag to be present with exactly that
+// value.
 //
 // Recognized keys are "device", "pipeline", "function", "chain",
-// "module_type", "module_name", "shard". The first six correspond
-// one-to-one with the path components of the typed yanet_get_*_counters
-// family. "shard" identifies the dataplane shard that holds the
-// counter; the value is an opaque coordinate and may change in future
-// versions. A counter is stored independently per shard, so to obtain
-// a single aggregate the caller must sum across all matching shards.
+// "module_type", "module_name", "shard". A counter is stored independently
+// per shard, so to obtain a single aggregate the caller must sum across
+// all matching shards.
 //
 // A tag is rejected with err filled and NULL returned if any of the
-// following holds: key is NULL; predicate is outside the
-// counter_tag_* set; predicate is counter_tag_match and value is
-// NULL; key is unrecognized; or tags contains another predicate with
-// the same key. Tag strings are borrowed only for the duration of the
-// call.
+// following holds: key is NULL; value is NULL; key is unrecognized;
+// or tags contains another predicate with the same key. Tag strings
+// are borrowed only for the duration of the call.
 //
 // The returned list must be released with yanet_counter_handle_list_free.
 // On failure NULL is returned and err is filled; an empty match is a

--- a/api/counter.h
+++ b/api/counter.h
@@ -9,9 +9,24 @@ struct dp_config;
 
 struct counter_value_handle;
 
+// Predicate kind for a counter_tag. The counter must not carry the tag
+// (counter_tag_absent), must carry the tag with any value
+// (counter_tag_present), or must carry the tag with the exact string
+// stored in tag.value (counter_tag_match).
+enum counter_tag_predicate {
+	counter_tag_absent,
+	counter_tag_present,
+	counter_tag_match
+};
+
+// A single predicate over a counter's tags. key names the tag, and
+// predicate selects which check to apply (see counter_tag_predicate).
+// The implementation reads tag.value only when predicate is
+// counter_tag_match.
 struct counter_tag {
 	const char *key;
 	const char *value;
+	enum counter_tag_predicate predicate;
 };
 
 struct counter_handle {
@@ -83,22 +98,34 @@ yanet_get_counter_value(
 	uint64_t worker_idx
 );
 
-// Return counters that match every tag and one of the names in query.
-// Pass tag_count == 0 to impose no per-attribute constraint and
-// query_count == 0 to match any name; passing both as zero returns
-// every counter known to the dataplane.
+// Return counters that satisfy every predicate in tags and match at
+// least one name in query. Pass tag_count == 0 to impose no per-tag
+// constraint and query_count == 0 to match any name; passing both as
+// zero returns every counter known to the dataplane. tags and query
+// may be NULL when their respective counts are zero.
 //
-// Each tag's key selects an attribute and value is the required match. A
-// NULL value inverts the check: the counter must not carry the attribute
-// at all. The NULL form is how callers pin a counter to a specific
-// hierarchy level; for example, {"device", "d1"} together with
-// {"pipeline", NULL} selects counters of device "d1" only.
+// Each counter_tag is a predicate against the counter's tags; see
+// counter_tag_predicate for the meaning of each predicate kind. The
+// counter_tag_absent predicate is how callers pin a counter to a
+// specific hierarchy level; for example,
+//     { .key = "device",   .value = "d1", .predicate = counter_tag_match  }
+//     { .key = "pipeline",                .predicate = counter_tag_absent }
+// selects counters of device "d1" only.
 //
 // Recognized keys are "device", "pipeline", "function", "chain",
-// "module_type", "module_name" and correspond one-to-one with the path
-// components of the typed yanet_get_*_counters family. An unrecognized
-// key is reported through err and NULL is returned. Tag strings are
-// borrowed only for the duration of the call.
+// "module_type", "module_name", "shard". The first six correspond
+// one-to-one with the path components of the typed yanet_get_*_counters
+// family. "shard" identifies the dataplane shard that holds the
+// counter; the value is an opaque coordinate and may change in future
+// versions. A counter is stored independently per shard, so to obtain
+// a single aggregate the caller must sum across all matching shards.
+//
+// A tag is rejected with err filled and NULL returned if any of the
+// following holds: key is NULL; predicate is outside the
+// counter_tag_* set; predicate is counter_tag_match and value is
+// NULL; key is unrecognized; or tags contains another predicate with
+// the same key. Tag strings are borrowed only for the duration of the
+// call.
 //
 // The returned list must be released with yanet_counter_handle_list_free.
 // On failure NULL is returned and err is filled; an empty match is a

--- a/api/counter.h
+++ b/api/counter.h
@@ -9,10 +9,17 @@ struct dp_config;
 
 struct counter_value_handle;
 
+struct counter_tag {
+	const char *key;
+	const char *value;
+};
+
 struct counter_handle {
 	char name[60];
 	uint64_t size;
 	uint64_t gen;
+	const struct counter_tag *tags;
+	size_t tag_count;
 	struct counter_value_handle *value_handle;
 };
 
@@ -74,6 +81,36 @@ yanet_get_counter_value(
 	struct counter_value_handle *value_handle,
 	uint64_t value_idx,
 	uint64_t worker_idx
+);
+
+// Return counters that match every tag and one of the names in query.
+// Pass tag_count == 0 to impose no per-attribute constraint and
+// query_count == 0 to match any name; passing both as zero returns
+// every counter known to the dataplane.
+//
+// Each tag's key selects an attribute and value is the required match. A
+// NULL value inverts the check: the counter must not carry the attribute
+// at all. The NULL form is how callers pin a counter to a specific
+// hierarchy level; for example, {"device", "d1"} together with
+// {"pipeline", NULL} selects counters of device "d1" only.
+//
+// Recognized keys are "device", "pipeline", "function", "chain",
+// "module_type", "module_name" and correspond one-to-one with the path
+// components of the typed yanet_get_*_counters family. An unrecognized
+// key is reported through err and NULL is returned. Tag strings are
+// borrowed only for the duration of the call.
+//
+// The returned list must be released with yanet_counter_handle_list_free.
+// On failure NULL is returned and err is filled; an empty match is a
+// non-NULL empty list.
+struct counter_handle_list *
+yanet_get_counters_by_tags(
+	struct dp_config *dp_config,
+	const struct counter_tag *tags,
+	size_t tag_count,
+	const char *const *query,
+	size_t query_count,
+	yanet_error **err
 );
 
 void


### PR DESCRIPTION
- Introduce an attribute tag type that pairs a hierarchy key with its expected value.
- Extend the counter handle with an optional list of attribute tags so consumers can read a counter's hierarchy without parsing its name.
- Add a query function that returns counters matching a set of attribute tags, optionally narrowed by a list of names, with explicit semantics for empty tag and name sets

This change introduces the API surface only. The agent-side implementation and consumer updates will land in follow-up PRs.