### PR TITLE
Fix `forward` batch packet iteration

### DIFF
--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -99,10 +99,12 @@ forward_handle_packets(
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
 			if (ip4_result[ip4_idx] < action)
 				action = ip4_result[ip4_idx];
+			++ip4_idx;
 		} else if (packet->network_header.type ==
 			   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
 			if (ip6_result[ip6_idx] < action)
 				action = ip6_result[ip6_idx];
+			++ip6_idx;
 		}
 
 		if (action != FILTER_RULE_INVALID)


### PR DESCRIPTION
The `ip4` and `ip6` packet indices must be incremented each time the corresponding packet is processed.