### PR TITLE
feat(inspect): expose per-subsystem memory tree

### DIFF
--- a/api/info.h
+++ b/api/info.h
@@ -187,6 +187,23 @@ yanet_get_cp_device_output_pipeline_info(
 
 // Instance
 
+// Length of a memory_context name, matching sizeof(memory_context::name).
+#define CP_MCTX_NAME_LEN 64
+
+// One node from the agent's memory_context tree, copied to the heap by the
+// info API so the caller does not need to touch shared memory.
+struct cp_memory_node_info {
+	char name[CP_MCTX_NAME_LEN];
+	// Index of this node's parent within the enclosing memory_nodes array.
+	// UINT32_MAX marks the root node (the agent's own context).
+	uint32_t parent_idx;
+	uint32_t _pad;
+	uint64_t balloc_count;
+	uint64_t bfree_count;
+	uint64_t balloc_size;
+	uint64_t bfree_size;
+};
+
 struct cp_agent_instance_info {
 	pid_t pid;
 	uint64_t memory_limit;
@@ -196,12 +213,23 @@ struct cp_agent_instance_info {
 	// Subtract from memory_limit to see how much memory the agent is
 	// currently using.
 	uint64_t free_bytes;
+	// Flat, DFS-ordered snapshot of the agent's memory_context tree.
+	//
+	// Node 0 is the root (the agent's own context).
+	// Every subsequent node's parent_idx points back into this array.
+	//
+	// The snapshot is best-effort: a concurrent update may cause a node to
+	// appear or disappear between the two traversal passes.
+	uint64_t memory_node_count;
+	struct cp_memory_node_info memory_nodes[];
 };
 
 struct cp_agent_info {
 	char name[80];
 	uint64_t instance_count;
-	struct cp_agent_instance_info instances[];
+	// Each element is a separately allocated block that includes the
+	// cp_agent_instance_info header and its trailing memory_nodes array.
+	struct cp_agent_instance_info *instances[];
 };
 
 struct cp_agent_list_info {

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -11,7 +11,7 @@ use ync::{
     client::{ConnectionArgs, LayeredChannel},
     logging,
 };
-use ynpb::pb::{inspect_service_client::InspectServiceClient, InspectRequest, InspectResponse};
+use ynpb::pb::{inspect_service_client::InspectServiceClient, InspectRequest, InspectResponse, MemoryNode};
 
 /// Inspect module - displays system introspection information.
 #[derive(Debug, Clone, Parser)]
@@ -120,6 +120,9 @@ impl InspectService {
                     tree.add_empty_child(format!("Used:         {}", ByteSize::b(used)));
                     tree.add_empty_child(format!("Free:         {}", ByteSize::b(instance.free_bytes)));
                     tree.add_empty_child(format!("Generation: {}", instance.generation));
+                    if !instance.memory_tree.is_empty() {
+                        add_memory_tree(&mut tree, &instance.memory_tree);
+                    }
                     tree.end_child();
                 }
 
@@ -181,4 +184,67 @@ impl InspectService {
 
         Ok(())
     }
+}
+
+/// Live bytes held by a memory node: allocated minus freed, floored at zero.
+fn node_live(node: &MemoryNode) -> u64 {
+    node.balloc_size.saturating_sub(node.bfree_size)
+}
+
+/// Subtree total: self live bytes plus the live bytes of all descendants.
+fn subtree_live(nodes: &[MemoryNode], children_of: &[Vec<usize>], idx: usize) -> u64 {
+    let self_live = node_live(&nodes[idx]);
+    let children_total: u64 = children_of[idx]
+        .iter()
+        .map(|&c| subtree_live(nodes, children_of, c))
+        .sum();
+    self_live.saturating_add(children_total)
+}
+
+/// Recursively render one node and its children into the ptree builder.
+///
+/// Children are sorted by subtree total descending so the heaviest subtrees
+/// appear first, and nodes with zero subtree total are skipped.
+fn render_memory_node(tree: &mut TreeBuilder, nodes: &[MemoryNode], idx: usize, children_of: &[Vec<usize>]) {
+    let node = &nodes[idx];
+    let total = subtree_live(nodes, children_of, idx);
+    tree.begin_child(format!("{} (Used: {})", node.name, ByteSize::b(total)));
+
+    let mut kids: Vec<usize> = children_of[idx].clone();
+    kids.sort_by_key(|&c| std::cmp::Reverse(subtree_live(nodes, children_of, c)));
+    for kid in kids {
+        if subtree_live(nodes, children_of, kid) > 0 {
+            render_memory_node(tree, nodes, kid, children_of);
+        }
+    }
+
+    tree.end_child();
+}
+
+/// Build a children index and render the memory context tree under a
+/// "Memory tree:" branch in the ptree builder.
+fn add_memory_tree(tree: &mut TreeBuilder, nodes: &[MemoryNode]) {
+    // Build a flat children list: children_of[i] holds the indices of all
+    // nodes whose parent is i.
+    let mut children_of: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
+    let mut root_idx: Option<usize> = None;
+
+    for (idx, node) in nodes.iter().enumerate() {
+        if node.parent_idx == u32::MAX {
+            root_idx = Some(idx);
+        } else {
+            let parent = node.parent_idx as usize;
+            if parent < nodes.len() {
+                children_of[parent].push(idx);
+            }
+        }
+    }
+
+    let Some(root) = root_idx else {
+        return;
+    };
+
+    tree.begin_child("Memory tree:".to_string());
+    render_memory_node(tree, nodes, root, &children_of);
+    tree.end_child();
 }

--- a/common/big_array.h
+++ b/common/big_array.h
@@ -312,6 +312,7 @@ big_array_free(struct big_array *array) {
 	memory_bfree(
 		&array->mctx, subarrays, sizeof(void *) * array->subarrays_count
 	);
+	memory_context_fini(&array->mctx);
 	memset(array, 0, sizeof(struct big_array));
 }
 

--- a/common/big_array.h
+++ b/common/big_array.h
@@ -286,6 +286,11 @@ big_array_get(struct big_array *array, size_t index) {
 static inline void
 big_array_free(struct big_array *array) {
 	if (array->subarrays == NULL) {
+		// Zero-size arrays have no subarray data but still have a
+		// linked memory context that must be unlinked before the
+		// embedding block can be safely reused.
+		memory_context_fini(&array->mctx);
+		memset(array, 0, sizeof(struct big_array));
 		return;
 	}
 	void **subarrays = ADDR_OF(&array->subarrays);

--- a/common/lpm.h
+++ b/common/lpm.h
@@ -149,6 +149,8 @@ lpm_free(struct lpm *lpm) {
 	memory_bfree(
 		memory_context, pages, sizeof(struct lpm_page *) * chunk_count
 	);
+
+	memory_context_fini(&lpm->memory_context);
 }
 
 static inline int

--- a/common/memory.h
+++ b/common/memory.h
@@ -8,7 +8,6 @@
 #include "memory_block.h"
 #include "strutils.h"
 
-// TODO: link parent and child context
 struct memory_context {
 	struct block_allocator *block_allocator;
 	size_t balloc_count;
@@ -17,6 +16,17 @@ struct memory_context {
 	size_t bfree_size;
 
 	char name[64];
+
+	// Tree links for per-subsystem memory diagnostics.
+	//
+	// All three are shared-memory offset pointers. Use ADDR_OF and
+	// SET_OFFSET_OF to dereference or assign them.
+	//
+	// A NULL parent marks a root context (agent, dataplane bootstrap,
+	// cp_config bootstrap).
+	struct memory_context *parent;
+	struct memory_context *first_child;
+	struct memory_context *next_sibling;
 };
 
 static inline int
@@ -32,6 +42,11 @@ memory_context_init(
 
 	SET_OFFSET_OF(&context->block_allocator, block_allocator);
 	(void)strtcpy(context->name, name, sizeof(context->name));
+
+	// Root context has no parent and no children yet.
+	SET_OFFSET_OF(&context->parent, NULL);
+	SET_OFFSET_OF(&context->first_child, NULL);
+	SET_OFFSET_OF(&context->next_sibling, NULL);
 
 	return 0;
 }
@@ -52,7 +67,54 @@ memory_context_init_from(
 	);
 	(void)strtcpy(context->name, name, sizeof(context->name));
 
+	// Remember which context contains us.
+	//
+	// Required for unlink on teardown.
+	SET_OFFSET_OF(&context->parent, parent);
+	SET_OFFSET_OF(&context->first_child, NULL);
+
+	// Insert at the head of the parent's child list.
+	//
+	// Write next_sibling before updating parent->first_child so a
+	// concurrent reader always sees a consistent chain.
+	EQUATE_OFFSET(&context->next_sibling, &parent->first_child);
+	SET_OFFSET_OF(&parent->first_child, context);
+
 	return 0;
+}
+
+// Remove this context from its parent's child list.
+//
+// Safe to call multiple times on the same context (idempotent).
+//
+// No-op when parent is NULL.
+static inline void
+memory_context_fini(struct memory_context *context) {
+	struct memory_context *parent = ADDR_OF(&context->parent);
+	if (parent == NULL) {
+		return;
+	}
+
+	// Walk the sibling chain to find and unlink ourselves.
+	struct memory_context **cursor = &parent->first_child;
+	for (;;) {
+		struct memory_context *child = ADDR_OF(cursor);
+		if (child == NULL) {
+			// Not found — already unlinked or never linked.
+			break;
+		}
+		if (child == context) {
+			// Bridge over ourselves: predecessor now points at our
+			// next sibling.
+			EQUATE_OFFSET(cursor, &context->next_sibling);
+			break;
+		}
+		cursor = &child->next_sibling;
+	}
+
+	// Clear parent so repeat calls become no-ops.
+	SET_OFFSET_OF(&context->parent, NULL);
+	SET_OFFSET_OF(&context->next_sibling, NULL);
 }
 
 static inline void *

--- a/common/ttlmap/ttlmap.h
+++ b/common/ttlmap/ttlmap.h
@@ -19,7 +19,11 @@ typedef struct ttlmap ttlmap_t;
 		map_ptr, mctx_ptr, key_type, value_type, kv_entries            \
 	)
 
-#define TTLMAP_FREE(map_ptr) __TTLMAP_FREE_INTERNAL(map_ptr)
+#define TTLMAP_FREE(map_ptr)                                                   \
+	do {                                                                   \
+		__TTLMAP_FREE_INTERNAL(map_ptr);                               \
+		memory_context_fini(&(map_ptr)->mctx);                         \
+	} while (0)
 
 #define TTLMAP_GET(                                                            \
 	map_ptr, key_ptr, value_ptr_ptr, lock_ptr_ptr, now, timeout            \

--- a/controlplane/builtin/inspect.go
+++ b/controlplane/builtin/inspect.go
@@ -157,11 +157,24 @@ func (m *Inspect) agents(dpConfig *ffi.DPConfig) []*ynpb.AgentInfo {
 		}
 
 		for instanceIdx, instance := range agent.Instances {
+			memoryTree := make([]*ynpb.MemoryNode, len(instance.MemoryTree))
+			for nodeIdx, node := range instance.MemoryTree {
+				memoryTree[nodeIdx] = &ynpb.MemoryNode{
+					Name:        node.Name,
+					ParentIdx:   node.ParentIdx,
+					BallocCount: node.BAllocCount,
+					BfreeCount:  node.BFreeCount,
+					BallocSize:  node.BAllocSize,
+					BfreeSize:   node.BFreeSize,
+				}
+			}
+
 			agentInfo.Instances[instanceIdx] = &ynpb.AgentInstanceInfo{
 				Pid:         instance.PID,
 				MemoryLimit: instance.MemoryLimit,
 				FreeBytes:   instance.FreeBytes,
 				Generation:  instance.Gen,
+				MemoryTree:  memoryTree,
 			}
 		}
 

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -277,11 +277,38 @@ func (m *DPConfig) Agents() []AgentInfo {
 				panic("FFI corruption: agent instance index became invalid")
 			}
 
+			nodeCount := uint64(instanceInfo.memory_node_count)
+			memoryTree := make([]AgentMemoryNode, nodeCount)
+			if nodeCount > 0 {
+				// CGO does not expose C99 flexible array members. The nodes
+				// are stored immediately after the struct header. The pointer
+				// arithmetic is a single expression so the GC cannot observe
+				// the intermediate uintptr value (unsafe rule 1).
+				cNodes := unsafe.Slice(
+					(*C.struct_cp_memory_node_info)(unsafe.Pointer(
+						uintptr(unsafe.Pointer(instanceInfo))+unsafe.Sizeof(*instanceInfo),
+					)),
+					nodeCount,
+				)
+				for nodeIdx := range memoryTree {
+					n := &cNodes[nodeIdx]
+					memoryTree[nodeIdx] = AgentMemoryNode{
+						Name:        C.GoString(&n.name[0]),
+						ParentIdx:   uint32(n.parent_idx),
+						BAllocCount: uint64(n.balloc_count),
+						BFreeCount:  uint64(n.bfree_count),
+						BAllocSize:  uint64(n.balloc_size),
+						BFreeSize:   uint64(n.bfree_size),
+					}
+				}
+			}
+
 			instances[instIdx] = AgentInstanceInfo{
 				PID:         uint32(instanceInfo.pid),
 				MemoryLimit: uint64(instanceInfo.memory_limit),
 				FreeBytes:   uint64(instanceInfo.free_bytes),
 				Gen:         uint64(instanceInfo.gen),
+				MemoryTree:  memoryTree,
 			}
 		}
 
@@ -320,12 +347,27 @@ type AgentInfo struct {
 	Instances []AgentInstanceInfo
 }
 
+// AgentMemoryNode is one entry in a flat, depth-first snapshot of an agent's
+// memory-context tree, copied from shared memory by the C info API.
+type AgentMemoryNode struct {
+	Name        string
+	ParentIdx   uint32
+	BAllocCount uint64
+	BFreeCount  uint64
+	BAllocSize  uint64
+	BFreeSize   uint64
+}
+
 // AgentInstanceInfo contains details about a specific agent instance.
 type AgentInstanceInfo struct {
 	PID         uint32
 	MemoryLimit uint64
 	FreeBytes   uint64
 	Gen         uint64
+	// MemoryTree is a flat depth-first snapshot of the agent's memory-context
+	// tree. Index 0 is the root; each subsequent node references its parent
+	// via ParentIdx.
+	MemoryTree []AgentMemoryNode
 }
 
 // Name returns the name of the dataplane module.

--- a/controlplane/ynpb/inspect.proto
+++ b/controlplane/ynpb/inspect.proto
@@ -185,6 +185,25 @@ message AgentInfo {
   repeated AgentInstanceInfo instances = 2;
 }
 
+// MemoryNode is one entry in a flat, depth-first snapshot of an agent's
+// memory-context tree, used for per-subsystem memory diagnostics.
+message MemoryNode {
+  // Human-readable name of this memory context.
+  string name = 1;
+  // Index of the parent node within the same memory_tree array.
+  //
+  // UINT32_MAX (0xFFFFFFFF) marks the root node (the agent's own context).
+  uint32 parent_idx = 2;
+  // Number of allocation calls made through this context.
+  uint64 balloc_count = 3;
+  // Number of free calls made through this context.
+  uint64 bfree_count = 4;
+  // Total bytes allocated through this context.
+  uint64 balloc_size = 5;
+  // Total bytes freed through this context.
+  uint64 bfree_size = 6;
+}
+
 // AgentInstanceInfo contains runtime information about a specific agent process
 // instance.
 message AgentInstanceInfo {
@@ -206,6 +225,17 @@ message AgentInstanceInfo {
   // Bytes still available for allocation in this agent instance.
   // Subtract from memory_limit to find how much memory is currently in use.
   uint64 free_bytes = 6;
+  // Flat depth-first snapshot of the agent's memory-context tree, used for
+  // per-subsystem memory diagnostics.
+  //
+  // Index 0 is the root.
+  //
+  // Each subsequent node references its parent via parent_idx.node
+  // references its parent via parent_idx.
+  //
+  // The snapshot is best-effort and may be slightly inconsistent under
+  // concurrent updates.
+  repeated MemoryNode memory_tree = 7;
 }
 
 // DeviceInfo contains information about a network device.

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -532,6 +532,10 @@ dataplane_init(
 			&instance->cp_config->cp_config_gen, cp_config_gen
 		);
 
+		// The stub agent is stack-allocated; unlink it from the tree
+		// before it goes out of scope.
+		memory_context_fini(&agent.memory_context);
+
 		instance_offset +=
 			instance_config->dp_memory + instance_config->cp_memory;
 	}

--- a/devices/plain/api/controlplane.c
+++ b/devices/plain/api/controlplane.c
@@ -28,6 +28,7 @@ cp_device_plain_create(
 	if (cp_device_init(
 		    &cp_device_plain->cp_device,
 		    agent,
+		    &agent->memory_context,
 		    &config->cp_device_config,
 		    err
 	    )) {
@@ -50,7 +51,7 @@ cp_device_plain_free(struct cp_device *cp_device) {
 	struct agent *agent = ADDR_OF(&cp_device->agent);
 	// FIXME: remove the check as agent should be assigned
 	if (agent != NULL) {
-		cp_device_destroy(&agent->memory_context, cp_device);
+		cp_device_fini(&agent->memory_context, cp_device);
 		memory_bfree(
 			&agent->memory_context,
 			cp_device_plain,

--- a/devices/vlan/api/controlplane.c
+++ b/devices/vlan/api/controlplane.c
@@ -28,6 +28,7 @@ cp_device_vlan_create(
 	if (cp_device_init(
 		    &cp_device_vlan->cp_device,
 		    agent,
+		    &agent->memory_context,
 		    &config->cp_device_config,
 		    err
 	    )) {
@@ -52,7 +53,7 @@ cp_device_vlan_free(struct cp_device *cp_device) {
 	struct agent *agent = ADDR_OF(&cp_device->agent);
 	// FIXME: remove the check as agent should be assigned
 	if (agent != NULL) {
-		cp_device_destroy(&agent->memory_context, cp_device);
+		cp_device_fini(&agent->memory_context, cp_device);
 		memory_bfree(
 			&agent->memory_context,
 			cp_device_vlan,

--- a/filter/compiler.h
+++ b/filter/compiler.h
@@ -75,6 +75,7 @@ filter_free(
 		value_registry_free(&v0->registry);
 		value_table_free(&v0->table);
 	}
+	memory_context_fini(&filter->memory_context);
 }
 
 static inline int

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1172,7 +1172,7 @@ yanet_get_cp_agent_instance_info(
 		return -1;
 	}
 
-	*instance_info = agent_info->instances + index;
+	*instance_info = agent_info->instances[index];
 
 	return 0;
 }
@@ -1193,12 +1193,110 @@ yanet_get_cp_agent_info(
 
 void
 cp_agent_list_info_free(struct cp_agent_list_info *agent_list_info) {
+	if (agent_list_info == NULL) {
+		return;
+	}
+
 	for (uint64_t agent_idx = 0; agent_idx < agent_list_info->count;
 	     ++agent_idx) {
-		free(agent_list_info->agents[agent_idx]);
+		struct cp_agent_info *agent_info =
+			agent_list_info->agents[agent_idx];
+		if (agent_info == NULL) {
+			continue;
+		}
+
+		// Free each instance block, which includes its trailing
+		// memory_nodes array.
+		for (uint64_t inst_idx = 0;
+		     inst_idx < agent_info->instance_count;
+		     ++inst_idx) {
+			free(agent_info->instances[inst_idx]);
+		}
+
+		free(agent_info);
 	}
 
 	free(agent_list_info);
+}
+
+// Walk the memory_context tree rooted at ctx in depth-first order and count
+// the total number of nodes (including ctx itself).
+static uint64_t
+memory_context_count_nodes(struct memory_context *ctx) {
+	uint64_t count = 1;
+	struct memory_context *child = ADDR_OF(&ctx->first_child);
+	while (child != NULL) {
+		count += memory_context_count_nodes(child);
+		child = ADDR_OF(&child->next_sibling);
+	}
+	return count;
+}
+
+// Walk the memory_context tree in depth-first order and fill consecutive
+// entries in the nodes array, starting at *next_idx. parent_idx is the array
+// index of the node that owns ctx (UINT32_MAX for the root).
+//
+// Returns the updated *next_idx after all descendants are recorded.
+static void
+memory_context_fill_nodes(
+	struct memory_context *ctx,
+	struct cp_memory_node_info *nodes,
+	uint32_t parent_idx,
+	uint32_t *next_idx
+) {
+	uint32_t my_idx = (*next_idx)++;
+	struct cp_memory_node_info *node = &nodes[my_idx];
+
+	strtcpy(node->name, ctx->name, sizeof(node->name));
+	node->parent_idx = parent_idx;
+	node->_pad = 0;
+	node->balloc_count = ctx->balloc_count;
+	node->bfree_count = ctx->bfree_count;
+	node->balloc_size = ctx->balloc_size;
+	node->bfree_size = ctx->bfree_size;
+
+	// Recurse into children so that each child knows its parent's index.
+	struct memory_context *child = ADDR_OF(&ctx->first_child);
+	while (child != NULL) {
+		// Snapshot next_sibling before descending in case a concurrent
+		// writer modifies the chain; we skip any node that looks
+		// obviously broken rather than crashing.
+		struct memory_context *sibling = ADDR_OF(&child->next_sibling);
+		memory_context_fill_nodes(child, nodes, my_idx, next_idx);
+		child = sibling;
+	}
+}
+
+// Build a cp_agent_instance_info block (including trailing memory_nodes) for
+// a single agent instance. Returns NULL on allocation failure.
+static struct cp_agent_instance_info *
+build_instance_info(struct agent *agent) {
+	// Two-pass approach: count nodes first, then allocate and fill.
+	uint64_t node_count =
+		memory_context_count_nodes(&agent->memory_context);
+
+	struct cp_agent_instance_info *info = (struct cp_agent_instance_info *)
+		malloc(sizeof(struct cp_agent_instance_info) +
+		       sizeof(struct cp_memory_node_info) * node_count);
+	if (info == NULL) {
+		return NULL;
+	}
+
+	info->pid = agent->pid;
+	info->memory_limit = agent->memory_limit;
+	info->gen = agent->gen;
+	info->free_bytes = block_allocator_free_size(&agent->block_allocator);
+	info->memory_node_count = node_count;
+
+	uint32_t next_idx = 0;
+	memory_context_fill_nodes(
+		&agent->memory_context,
+		info->memory_nodes,
+		UINT32_MAX,
+		&next_idx
+	);
+
+	return info;
 }
 
 struct cp_agent_list_info *
@@ -1223,6 +1321,8 @@ yanet_get_cp_agent_list_info(struct dp_config *dp_config) {
 	     ++agent_idx) {
 		struct agent *agent =
 			ADDR_OF(&agent_registry->agents[agent_idx]);
+
+		// Count how many historical instances exist in the prev chain.
 		uint64_t instance_count = 1;
 		struct agent *prev_agent = ADDR_OF(&agent->prev);
 		while (prev_agent != NULL) {
@@ -1230,9 +1330,11 @@ yanet_get_cp_agent_list_info(struct dp_config *dp_config) {
 			++instance_count;
 		}
 
+		// Allocate the agent info header plus the pointer array for
+		// its instances. Each instance block is allocated separately.
 		struct cp_agent_info *agent_info = (struct cp_agent_info *)
 			malloc(sizeof(struct cp_agent_info) +
-			       sizeof(struct cp_agent_instance_info) *
+			       sizeof(struct cp_agent_instance_info *) *
 				       instance_count);
 		if (agent_info == NULL) {
 			cp_agent_list_info_free(agent_list_info);
@@ -1243,18 +1345,27 @@ yanet_get_cp_agent_list_info(struct dp_config *dp_config) {
 		strtcpy(agent_info->name, agent->name, sizeof(agent_info->name)
 		);
 		agent_info->instance_count = 0;
-		while (agent_info->instance_count < instance_count) {
-			struct cp_agent_instance_info *instance =
-				agent_info->instances +
-				agent_info->instance_count++;
-			instance->pid = agent->pid;
-			instance->memory_limit = agent->memory_limit;
-			instance->gen = agent->gen;
-			instance->free_bytes = block_allocator_free_size(
-				&agent->block_allocator
-			);
 
-			agent = ADDR_OF(&agent->prev);
+		// Walk the prev chain and build one instance block per entry.
+		struct agent *cur = agent;
+		while (agent_info->instance_count < instance_count) {
+			struct cp_agent_instance_info *inst =
+				build_instance_info(cur);
+			if (inst == NULL) {
+				// Free the instance blocks already allocated.
+				for (uint64_t k = 0;
+				     k < agent_info->instance_count;
+				     ++k) {
+					free(agent_info->instances[k]);
+				}
+				free(agent_info);
+				cp_agent_list_info_free(agent_list_info);
+				agent_list_info = NULL;
+				goto unlock;
+			}
+			agent_info->instances[agent_info->instance_count++] =
+				inst;
+			cur = ADDR_OF(&cur->prev);
 		}
 
 		agent_list_info->agents[agent_list_info->count++] = agent_info;

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -118,6 +118,7 @@ int
 cp_device_init(
 	struct cp_device *cp_device,
 	struct agent *agent,
+	struct memory_context *mctx_parent,
 	const struct cp_device_config *cp_device_config,
 	yanet_error **err
 ) {
@@ -140,9 +141,7 @@ cp_device_init(
 	strtcpy(cp_device->name, cp_device_config->name, sizeof(cp_device->name)
 	);
 	memory_context_init_from(
-		&cp_device->memory_context,
-		&agent->memory_context,
-		cp_device_config->name
+		&cp_device->memory_context, mctx_parent, cp_device_config->name
 	);
 
 	SET_OFFSET_OF(&cp_device->agent, agent);
@@ -238,6 +237,7 @@ cp_device_init(
 struct cp_device *
 cp_device_create(
 	struct agent *agent,
+	struct memory_context *mctx_parent,
 	struct cp_device_config *device_config,
 	yanet_error **err
 ) {
@@ -253,7 +253,9 @@ cp_device_create(
 		return NULL;
 	}
 
-	if (cp_device_init(new_device, agent, device_config, err)) {
+	if (cp_device_init(
+		    new_device, agent, mctx_parent, device_config, err
+	    )) {
 		yanet_error_add(
 			err,
 			"failed to initialize device '%s'",
@@ -281,7 +283,7 @@ cp_device_entry_free(
 }
 
 void
-cp_device_destroy(
+cp_device_fini(
 	struct memory_context *memory_context, struct cp_device *cp_device
 ) {
 	cp_device_entry_free(
@@ -291,13 +293,15 @@ cp_device_destroy(
 	cp_device_entry_free(
 		memory_context, ADDR_OF(&cp_device->input_pipelines)
 	);
+
+	memory_context_fini(&cp_device->memory_context);
 }
 
 void
 cp_device_free(
 	struct memory_context *memory_context, struct cp_device *cp_device
 ) {
-	cp_device_destroy(memory_context, cp_device);
+	cp_device_fini(memory_context, cp_device);
 	memory_bfree(memory_context, cp_device, sizeof(struct cp_device));
 }
 

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -88,6 +88,7 @@ cp_device_config_deinit(struct cp_device_config *config);
 struct cp_device *
 cp_device_create(
 	struct agent *agent,
+	struct memory_context *mctx_parent,
 	struct cp_device_config *device_config,
 	yanet_error **err
 );
@@ -97,16 +98,21 @@ cp_device_free(
 	struct memory_context *memory_context, struct cp_device *cp_device
 );
 
+// Initialize *cp_device in shared memory.
+//
+// mctx_parent is the memory_context that will appear as the parent of the
+// device's own context in the per-subsystem memory tree.
 int
 cp_device_init(
 	struct cp_device *cp_device,
 	struct agent *agent,
+	struct memory_context *mctx_parent,
 	const struct cp_device_config *cp_device_config,
 	yanet_error **err
 );
 
 void
-cp_device_destroy(
+cp_device_fini(
 	struct memory_context *memory_context, struct cp_device *cp_device
 );
 

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -175,6 +175,8 @@ cp_module_fini(struct cp_module *cp_module) {
 	cp_module->device_count = 0;
 
 	SET_OFFSET_OF(&cp_module->agent, NULL);
+
+	memory_context_fini(&cp_module->memory_context);
 }
 
 int

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -693,8 +693,12 @@ cp_config_gen_create(struct agent *agent, yanet_error **err) {
 		pipe_cfg.count = 0;
 		device_config.input_pipelines = &pipe_cfg;
 		device_config.output_pipelines = &pipe_cfg;
-		struct cp_device *cp_device =
-			cp_device_create(agent, &device_config, err);
+		// Use cp_config->memory_context as the tree parent so that
+		// the device's memory_context outlives any transient stub
+		// agent that may have been used to call cp_config_gen_create.
+		struct cp_device *cp_device = cp_device_create(
+			agent, &cp_config->memory_context, &device_config, err
+		);
 		if (cp_device == NULL) {
 			yanet_error_add(
 				err,

--- a/mock/mock.c
+++ b/mock/mock.c
@@ -218,6 +218,9 @@ dataplane_initialize(
 		cp_config_gen_create(&agent, &err);
 	if (cp_config_gen == NULL) {
 		yanet_error_free(err);
+		// The stub agent is stack-allocated; unlink it from the tree
+		// before it goes out of scope.
+		memory_context_fini(&agent.memory_context);
 		return -1;
 	}
 	SET_OFFSET_OF(&cp_config->cp_config_gen, cp_config_gen);
@@ -227,6 +230,7 @@ dataplane_initialize(
 		workers_count * sizeof(struct dp_worker *)
 	);
 	if (workers_array == NULL) {
+		memory_context_fini(&agent.memory_context);
 		return -1;
 	}
 
@@ -260,11 +264,16 @@ dataplane_initialize(
 		    "failed to link counter registry: %s",
 		    yanet_error_message(err));
 		yanet_error_free(err);
+		memory_context_fini(&agent.memory_context);
 		return -1;
 	}
 
 	*res_dp_config = dp_config;
 	*res_cp_config = cp_config;
+
+	// The stub agent is stack-allocated; unlink it from the tree
+	// before it goes out of scope.
+	memory_context_fini(&agent.memory_context);
 
 	return 0;
 }

--- a/modules/balancer/controlplane/handler/handler.c
+++ b/modules/balancer/controlplane/handler/handler.c
@@ -613,6 +613,9 @@ packet_handler_free(struct packet_handler *handler) {
 	lpm_free(&handler->decap_ipv4);
 	lpm_free(&handler->decap_ipv6);
 
+	// Unlink and release the controlplane module.
+	cp_module_fini(&handler->cp_module);
+
 	// Free the handler itself
 	memory_bfree(mctx, handler, sizeof(struct packet_handler));
 }

--- a/modules/balancer/controlplane/handler/handler.c
+++ b/modules/balancer/controlplane/handler/handler.c
@@ -455,16 +455,16 @@ packet_handler_setup(
 		&handler->cp_module.counter_registry;
 
 	if (init_counters(handler, counter_registry, err) != 0) {
-		goto free_handler;
+		goto free_cp_module;
 	}
 
 	if (init_sources(handler, mctx, config) != 0) {
 		yanet_error_add(err, "failed to setup source addresses");
-		goto free_handler;
+		goto free_cp_module;
 	}
 
 	if (init_decaps(handler, mctx, config, err) != 0) {
-		goto free_handler;
+		goto free_cp_module;
 	}
 
 	size_t workers = ADDR_OF(&agent->dp_config)->worker_count;
@@ -500,6 +500,9 @@ free_vs:
 free_decap:
 	lpm_free(&handler->decap_ipv4);
 	lpm_free(&handler->decap_ipv6);
+
+free_cp_module:
+	cp_module_fini(&handler->cp_module);
 
 free_handler:
 	memory_bfree(mctx, handler, sizeof(struct packet_handler));

--- a/modules/balancer/controlplane/handler/selector.c
+++ b/modules/balancer/controlplane/handler/selector.c
@@ -123,4 +123,5 @@ selector_free(struct real_selector *selector) {
 	size_t cur_ring_id = selector->ring_id;
 	ring_free(&selector->rings[cur_ring_id], &selector->mctx);
 	rcu_free(&selector->rcu, &selector->mctx);
+	memory_context_fini(&selector->mctx);
 }

--- a/modules/balancer/controlplane/state/session_table.c
+++ b/modules/balancer/controlplane/state/session_table.c
@@ -66,6 +66,7 @@ session_table_free(struct session_table *table) {
 		TTLMAP_FREE(&table->maps[i]);
 	}
 	rcu_free(&table->rcu, &table->mctx);
+	memory_context_fini(&table->mctx);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/common/memory_context_tree_test.c
+++ b/tests/common/memory_context_tree_test.c
@@ -1,0 +1,361 @@
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+#include "lib/logging/log.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static size_t
+helper_count_children(struct memory_context *ctx) {
+	size_t n = 0;
+	struct memory_context *child = ADDR_OF(&ctx->first_child);
+	while (child != NULL) {
+		++n;
+		child = ADDR_OF(&child->next_sibling);
+	}
+	return n;
+}
+
+// Returns 1 when needle is reachable in the child chain of parent.
+static int
+helper_child_is_linked(
+	struct memory_context *parent, struct memory_context *needle
+) {
+	struct memory_context *child = ADDR_OF(&parent->first_child);
+	while (child != NULL) {
+		if (child == needle) {
+			return 1;
+		}
+		child = ADDR_OF(&child->next_sibling);
+	}
+	return 0;
+}
+
+static int
+helper_make_arena(void **raw_out, struct block_allocator *ba) {
+	// 2 MiB, large enough for all test structures.
+	const size_t raw_size = (1u << 21) + (1u << 21);
+	void *raw = malloc(raw_size);
+	if (raw == NULL) {
+		return -1;
+	}
+
+	// Align to 2 MiB boundary inside the allocation.
+	uintptr_t p = (uintptr_t)raw;
+	uintptr_t aligned = (p + (1u << 21) - 1) & ~((uintptr_t)(1u << 21) - 1);
+	block_allocator_init(ba);
+	block_allocator_put_arena(ba, (void *)aligned, 1u << 21);
+	*raw_out = raw;
+	return 0;
+}
+
+// NOTE: root context has all tree links NULL.
+static int
+test_root_links_null(void) {
+	void *raw = NULL;
+	struct block_allocator ba;
+	TEST_ASSERT(helper_make_arena(&raw, &ba) == 0, "arena setup failed");
+
+	struct memory_context root;
+	memory_context_init(&root, "root", &ba);
+
+	TEST_ASSERT(
+		ADDR_OF(&root.parent) == NULL,
+		"root parent must be NULL after init"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&root.first_child) == NULL,
+		"root first_child must be NULL after init"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&root.next_sibling) == NULL,
+		"root next_sibling must be NULL after init"
+	);
+
+	free(raw);
+	return 0;
+}
+
+// NOTE: head-insertion order — first_child is the last added child, and
+// next_sibling walks back in insertion order.
+static int
+test_head_insertion_order(void) {
+	void *raw = NULL;
+	struct block_allocator ba;
+	TEST_ASSERT(helper_make_arena(&raw, &ba) == 0, "arena setup failed");
+
+	struct memory_context root;
+	memory_context_init(&root, "root", &ba);
+
+	struct memory_context a, b, c;
+	memory_context_init_from(&a, &root, "a");
+	memory_context_init_from(&b, &root, "b");
+	memory_context_init_from(&c, &root, "c");
+
+	// After inserting a, b, c in order, first_child should be c (last
+	// added) and the chain should be c -> b -> a -> NULL.
+	struct memory_context *head = ADDR_OF(&root.first_child);
+	TEST_ASSERT(
+		head == &c, "first_child should be the last inserted child"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&c.next_sibling) == &b, "c.next_sibling should be b"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&b.next_sibling) == &a, "b.next_sibling should be a"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&a.next_sibling) == NULL,
+		"a.next_sibling should be NULL"
+	);
+	TEST_ASSERT(
+		helper_count_children(&root) == 3, "root should have 3 children"
+	);
+
+	free(raw);
+	return 0;
+}
+
+// NOTE: nested init_from at multiple depths.
+static int
+test_nested_depth(void) {
+	void *raw = NULL;
+	struct block_allocator ba;
+	TEST_ASSERT(helper_make_arena(&raw, &ba) == 0, "arena setup failed");
+
+	// Simulate: agent -> cp_module -> filter -> lpm -> big_array
+	struct memory_context agent, cp_mod, filter, lpm, big_array;
+
+	memory_context_init(&agent, "agent", &ba);
+	memory_context_init_from(&cp_mod, &agent, "cp_module");
+	memory_context_init_from(&filter, &cp_mod, "filter");
+	memory_context_init_from(&lpm, &filter, "lpm");
+	memory_context_init_from(&big_array, &lpm, "big_array");
+
+	// Verify parent pointers at each level.
+	TEST_ASSERT(ADDR_OF(&agent.parent) == NULL, "agent has no parent");
+	TEST_ASSERT(
+		ADDR_OF(&cp_mod.parent) == &agent,
+		"cp_mod parent should be agent"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&filter.parent) == &cp_mod,
+		"filter parent should be cp_mod"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&lpm.parent) == &filter, "lpm parent should be filter"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&big_array.parent) == &lpm,
+		"big_array parent should be lpm"
+	);
+
+	// Verify linkage at each depth.
+	TEST_ASSERT(
+		ADDR_OF(&agent.first_child) == &cp_mod,
+		"agent.first_child should be cp_mod"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&cp_mod.first_child) == &filter,
+		"cp_mod.first_child should be filter"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&filter.first_child) == &lpm,
+		"filter.first_child should be lpm"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&lpm.first_child) == &big_array,
+		"lpm.first_child should be big_array"
+	);
+
+	free(raw);
+	return 0;
+}
+
+// NOTE: fini of a middle sibling leaves the chain intact for the others.
+static int
+test_fini_middle_sibling(void) {
+	void *raw = NULL;
+	struct block_allocator ba;
+	TEST_ASSERT(helper_make_arena(&raw, &ba) == 0, "arena setup failed");
+
+	struct memory_context root;
+	memory_context_init(&root, "root", &ba);
+
+	struct memory_context a, b, c;
+	memory_context_init_from(&a, &root, "a");
+	memory_context_init_from(&b, &root, "b");
+	memory_context_init_from(&c, &root, "c");
+
+	// Chain is c -> b -> a. Remove b (the middle one).
+	memory_context_fini(&b);
+
+	// b must no longer be reachable.
+	TEST_ASSERT(
+		!helper_child_is_linked(&root, &b),
+		"b must not be reachable after fini"
+	);
+	// a and c must still be reachable.
+	TEST_ASSERT(
+		helper_child_is_linked(&root, &a),
+		"a must remain reachable after fini"
+	);
+	TEST_ASSERT(
+		helper_child_is_linked(&root, &c),
+		"c must remain reachable after fini"
+	);
+	TEST_ASSERT(
+		helper_count_children(&root) == 2, "root should have 2 children"
+	);
+
+	// Chain should now be c -> a -> NULL.
+	TEST_ASSERT(
+		ADDR_OF(&root.first_child) == &c,
+		"first_child should still be c"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&c.next_sibling) == &a,
+		"c.next_sibling should now be a (b was removed)"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&a.next_sibling) == NULL,
+		"a.next_sibling should be NULL"
+	);
+
+	// b's parent should be NULL after fini.
+	TEST_ASSERT(
+		ADDR_OF(&b.parent) == NULL, "b.parent must be NULL after fini"
+	);
+
+	free(raw);
+	return 0;
+}
+
+// NOTE: fini is idempotent — calling it twice must not crash or corrupt.
+static int
+test_fini_idempotent(void) {
+	void *raw = NULL;
+	struct block_allocator ba;
+	TEST_ASSERT(helper_make_arena(&raw, &ba) == 0, "arena setup failed");
+
+	struct memory_context root;
+	memory_context_init(&root, "root", &ba);
+
+	struct memory_context child;
+	memory_context_init_from(&child, &root, "child");
+
+	memory_context_fini(&child);
+	// Second call must not corrupt root.first_child or crash.
+	memory_context_fini(&child);
+
+	TEST_ASSERT(
+		ADDR_OF(&root.first_child) == NULL,
+		"root should have no children after double fini"
+	);
+	TEST_ASSERT(helper_count_children(&root) == 0, "child count must be 0");
+
+	free(raw);
+	return 0;
+}
+
+// NOTE: fini of a root context (parent == NULL) is a no-op.
+static int
+test_fini_root_noop(void) {
+	void *raw = NULL;
+	struct block_allocator ba;
+	TEST_ASSERT(helper_make_arena(&raw, &ba) == 0, "arena setup failed");
+
+	struct memory_context root;
+	memory_context_init(&root, "root", &ba);
+
+	// Must not crash or modify anything.
+	memory_context_fini(&root);
+
+	TEST_ASSERT(
+		ADDR_OF(&root.parent) == NULL,
+		"root parent still NULL after fini"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&root.first_child) == NULL,
+		"root first_child still NULL after fini"
+	);
+
+	free(raw);
+	return 0;
+}
+
+// NOTE: stress — 100 cycles of init_from/fini on a single parent leave
+// an empty child list.
+static int
+test_stress_init_fini_cycle(void) {
+	void *raw = NULL;
+	struct block_allocator ba;
+	TEST_ASSERT(helper_make_arena(&raw, &ba) == 0, "arena setup failed");
+
+	struct memory_context root;
+	memory_context_init(&root, "root", &ba);
+
+	struct memory_context child;
+
+	for (int cycle = 0; cycle < 100; ++cycle) {
+		memory_context_init_from(&child, &root, "child");
+		TEST_ASSERT(
+			helper_child_is_linked(&root, &child),
+			"child must be linked after init_from (cycle %d)",
+			cycle
+		);
+		memory_context_fini(&child);
+		TEST_ASSERT(
+			!helper_child_is_linked(&root, &child),
+			"child must be unlinked after fini (cycle %d)",
+			cycle
+		);
+		TEST_ASSERT(
+			helper_count_children(&root) == 0,
+			"root must have 0 children after fini (cycle %d)",
+			cycle
+		);
+	}
+
+	free(raw);
+	return 0;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	if (test_root_links_null() != 0) {
+		LOG(ERROR, "test_root_links_null failed");
+		return -1;
+	}
+	if (test_head_insertion_order() != 0) {
+		LOG(ERROR, "test_head_insertion_order failed");
+		return -1;
+	}
+	if (test_nested_depth() != 0) {
+		LOG(ERROR, "test_nested_depth failed");
+		return -1;
+	}
+	if (test_fini_middle_sibling() != 0) {
+		LOG(ERROR, "test_fini_middle_sibling failed");
+		return -1;
+	}
+	if (test_fini_idempotent() != 0) {
+		LOG(ERROR, "test_fini_idempotent failed");
+		return -1;
+	}
+	if (test_fini_root_noop() != 0) {
+		LOG(ERROR, "test_fini_root_noop failed");
+		return -1;
+	}
+	if (test_stress_init_fini_cycle() != 0) {
+		LOG(ERROR, "test_stress_init_fini_cycle failed");
+		return -1;
+	}
+
+	LOG(INFO, "memory_context tree tests: OK");
+	return 0;
+}

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -63,6 +63,15 @@ balloc_test = executable(
 )
 test('balloc', balloc_test, suite: ['common'])
 
+memory_context_tree_test = executable(
+  'memory_context_tree_test',
+  ['memory_context_tree_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies
+)
+test('memory_context_tree', memory_context_tree_test, suite: ['common'])
+
 executable(
   'balloc_bench',
   ['balloc_bench.c'],

--- a/tests/controlplane/agent_memory_tree_test.c
+++ b/tests/controlplane/agent_memory_tree_test.c
@@ -1,0 +1,303 @@
+#include "api/agent.h"
+#include "api/info.h"
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/zone.h"
+#include "dataplane/config/zone.h"
+
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DP_MEMORY (1u << 22)
+#define CP_MEMORY (1u << 22)
+
+// Build a minimal dp_config + cp_config pair in a pre-allocated block so we
+// can call agent_attach and yanet_get_cp_agent_list_info without a real
+// shared-memory file.
+static int
+setup_dp_cp(
+	void *storage, struct dp_config **dp_out, struct cp_config **cp_out
+) {
+	struct dp_config *dp = (struct dp_config *)storage;
+	block_allocator_init(&dp->block_allocator);
+	block_allocator_put_arena(
+		&dp->block_allocator,
+		(char *)storage + sizeof(struct dp_config),
+		DP_MEMORY - sizeof(struct dp_config)
+	);
+	memory_context_init(&dp->memory_context, "dp", &dp->block_allocator);
+
+	struct cp_config *cp =
+		(struct cp_config *)((char *)storage + DP_MEMORY);
+	block_allocator_init(&cp->block_allocator);
+	block_allocator_put_arena(
+		&cp->block_allocator,
+		(char *)storage + DP_MEMORY + sizeof(struct cp_config),
+		CP_MEMORY - sizeof(struct cp_config)
+	);
+	memory_context_init(&cp->memory_context, "cp", &cp->block_allocator);
+
+	SET_OFFSET_OF(&dp->cp_config, cp);
+	SET_OFFSET_OF(&cp->dp_config, dp);
+
+	// Initialise the agent registry to an empty one.
+	struct cp_agent_registry *reg =
+		(struct cp_agent_registry *)memory_balloc(
+			&cp->memory_context, sizeof(struct cp_agent_registry)
+		);
+	TEST_ASSERT_NOT_NULL(reg, "failed to alloc agent_registry");
+	memset(reg, 0, sizeof(struct cp_agent_registry));
+	SET_OFFSET_OF(&cp->agent_registry, reg);
+
+	struct agent bootstrap;
+	memset(&bootstrap, 0, sizeof(bootstrap));
+	memory_context_init_from(
+		&bootstrap.memory_context, &cp->memory_context, "bootstrap"
+	);
+	SET_OFFSET_OF(&bootstrap.dp_config, dp);
+	SET_OFFSET_OF(&bootstrap.cp_config, cp);
+
+	yanet_error *err = NULL;
+	struct cp_config_gen *config_gen =
+		cp_config_gen_create(&bootstrap, &err);
+	TEST_ASSERT_NOT_NULL(config_gen, "cp_config_gen_create failed");
+	SET_OFFSET_OF(&cp->cp_config_gen, config_gen);
+
+	*dp_out = dp;
+	*cp_out = cp;
+	return 0;
+}
+
+// NOTE: after attaching one agent and adding two child memory_contexts to
+// simulate two cp_modules (one of which has a deeper filter->lpm chain),
+// yanet_get_cp_agent_list_info should return a flat DFS-ordered node list
+// with the correct parent_idx values and the right total count.
+static int
+test_memory_tree_exported(void) {
+	void *storage = aligned_alloc(64, DP_MEMORY + CP_MEMORY);
+	TEST_ASSERT_NOT_NULL(storage, "failed to allocate storage");
+	memset(storage, 0, DP_MEMORY + CP_MEMORY);
+
+	struct dp_config *dp;
+	struct cp_config *cp;
+	int rc = setup_dp_cp(storage, &dp, &cp);
+	if (rc != 0) {
+		free(storage);
+		return rc;
+	}
+
+	// Attach an agent so it appears in the registry.
+	yanet_error *err = NULL;
+	struct agent *ag = agent_attach(
+		(struct yanet_shm *)dp, 0, "test_agent", 1u << 20, &err
+	);
+	TEST_ASSERT_NOT_NULL(ag, "agent_attach failed");
+
+	// Simulate two cp_modules hanging off the agent's memory_context.
+	// mod_fwd gets a deeper chain: filter -> lpm.
+	struct memory_context mod_fwd, mod_dec, filter, lpm;
+	memory_context_init_from(&mod_fwd, &ag->memory_context, "mod_fwd");
+	memory_context_init_from(&mod_dec, &ag->memory_context, "mod_dec");
+	memory_context_init_from(&filter, &mod_fwd, "filter");
+	memory_context_init_from(&lpm, &filter, "lpm");
+
+	// Expected DFS order.
+	//
+	// Note that head-insertion reverses siblings, so mod_dec is first_child
+	// of agent, then mod_fwd:
+	//   0: test_agent  (root, parent_idx = UINT32_MAX)
+	//   1: mod_dec     (parent 0)
+	//   2: mod_fwd     (parent 0)
+	//   3: filter      (parent 2)
+	//   4: lpm         (parent 3)
+	const uint64_t expected_nodes = 5;
+
+	struct cp_agent_list_info *list = yanet_get_cp_agent_list_info(dp);
+	TEST_ASSERT_NOT_NULL(
+		list, "yanet_get_cp_agent_list_info returned NULL"
+	);
+	TEST_ASSERT(list->count == 1, "expected exactly 1 agent");
+
+	struct cp_agent_info *ai;
+	rc = yanet_get_cp_agent_info(list, 0, &ai);
+	TEST_ASSERT(rc == 0, "yanet_get_cp_agent_info failed");
+	TEST_ASSERT(
+		strncmp(ai->name, "test_agent", sizeof(ai->name)) == 0,
+		"agent name mismatch"
+	);
+	TEST_ASSERT(ai->instance_count == 1, "expected 1 instance");
+
+	struct cp_agent_instance_info *inst;
+	rc = yanet_get_cp_agent_instance_info(ai, 0, &inst);
+	TEST_ASSERT(rc == 0, "yanet_get_cp_agent_instance_info failed");
+	TEST_ASSERT(
+		inst->memory_node_count == expected_nodes,
+		"expected %lu memory nodes, got %lu",
+		(unsigned long)expected_nodes,
+		(unsigned long)inst->memory_node_count
+	);
+
+	// Node 0 is the root.
+	TEST_ASSERT(
+		strncmp(inst->memory_nodes[0].name,
+			"test_agent",
+			CP_MCTX_NAME_LEN) == 0,
+		"node[0] name should be test_agent"
+	);
+	TEST_ASSERT(
+		inst->memory_nodes[0].parent_idx == UINT32_MAX,
+		"root node parent_idx must be UINT32_MAX"
+	);
+
+	// Every non-root node must have parent_idx strictly less than its
+	// own index.
+	//
+	// Because of the DFS invariant: parent always comes before child.
+	for (uint64_t idx = 1; idx < inst->memory_node_count; ++idx) {
+		TEST_ASSERT(
+			inst->memory_nodes[idx].parent_idx < (uint32_t)idx,
+			"node[%lu] parent_idx %u >= idx - not DFS order",
+			(unsigned long)idx,
+			inst->memory_nodes[idx].parent_idx
+		);
+	}
+
+	// Verify that named nodes are present and parents are correct.
+	//
+	// Because children are inserted at the head of the chain, mod_dec
+	// (added after mod_fwd) appears first in DFS order.
+	TEST_ASSERT(
+		strncmp(inst->memory_nodes[1].name, "mod_dec", CP_MCTX_NAME_LEN
+		) == 0,
+		"node[1] should be mod_dec"
+	);
+	TEST_ASSERT(
+		inst->memory_nodes[1].parent_idx == 0,
+		"mod_dec parent should be 0 (test_agent)"
+	);
+
+	TEST_ASSERT(
+		strncmp(inst->memory_nodes[2].name, "mod_fwd", CP_MCTX_NAME_LEN
+		) == 0,
+		"node[2] should be mod_fwd"
+	);
+	TEST_ASSERT(
+		inst->memory_nodes[2].parent_idx == 0,
+		"mod_fwd parent should be 0 (test_agent)"
+	);
+
+	TEST_ASSERT(
+		strncmp(inst->memory_nodes[3].name, "filter", CP_MCTX_NAME_LEN
+		) == 0,
+		"node[3] should be filter"
+	);
+	TEST_ASSERT(
+		inst->memory_nodes[3].parent_idx == 2,
+		"filter parent should be 2 (mod_fwd)"
+	);
+
+	TEST_ASSERT(
+		strncmp(inst->memory_nodes[4].name, "lpm", CP_MCTX_NAME_LEN) ==
+			0,
+		"node[4] should be lpm"
+	);
+	TEST_ASSERT(
+		inst->memory_nodes[4].parent_idx == 3,
+		"lpm parent should be 3 (filter)"
+	);
+
+	cp_agent_list_info_free(list);
+	free(storage);
+	return 0;
+}
+
+static int
+test_free_null_safe(void) {
+	cp_agent_list_info_free(NULL);
+	return 0;
+}
+
+// NOTE: after tearing down child contexts, a fresh info call reflects the
+// reduced node count - only the root remains.
+static int
+test_memory_tree_after_fini(void) {
+	void *storage = aligned_alloc(64, DP_MEMORY + CP_MEMORY);
+	TEST_ASSERT_NOT_NULL(storage, "failed to allocate storage");
+	memset(storage, 0, DP_MEMORY + CP_MEMORY);
+
+	struct dp_config *dp;
+	struct cp_config *cp;
+	int rc = setup_dp_cp(storage, &dp, &cp);
+	if (rc != 0) {
+		free(storage);
+		return rc;
+	}
+
+	yanet_error *err = NULL;
+	struct agent *ag = agent_attach(
+		(struct yanet_shm *)dp, 0, "solo_agent", 1u << 20, &err
+	);
+	TEST_ASSERT_NOT_NULL(ag, "agent_attach failed");
+
+	// Attach a child, then immediately detach it.
+	struct memory_context child;
+	memory_context_init_from(&child, &ag->memory_context, "transient");
+	memory_context_fini(&child);
+
+	struct cp_agent_list_info *list = yanet_get_cp_agent_list_info(dp);
+	TEST_ASSERT_NOT_NULL(
+		list, "yanet_get_cp_agent_list_info returned NULL"
+	);
+
+	struct cp_agent_info *ai;
+	yanet_get_cp_agent_info(list, 0, &ai);
+
+	struct cp_agent_instance_info *inst;
+	yanet_get_cp_agent_instance_info(ai, 0, &inst);
+
+	// After fini the child is gone; only the root context remains.
+	TEST_ASSERT(
+		inst->memory_node_count == 1,
+		"expected only root node after child fini, got %lu",
+		(unsigned long)inst->memory_node_count
+	);
+	TEST_ASSERT(
+		strncmp(inst->memory_nodes[0].name,
+			"solo_agent",
+			CP_MCTX_NAME_LEN) == 0,
+		"root node name mismatch after child fini"
+	);
+
+	cp_agent_list_info_free(list);
+	free(storage);
+	return 0;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	if (test_memory_tree_exported() != 0) {
+		LOG(ERROR, "test_memory_tree_exported failed");
+		return -1;
+	}
+	if (test_free_null_safe() != 0) {
+		LOG(ERROR, "test_free_null_safe failed");
+		return -1;
+	}
+	if (test_memory_tree_after_fini() != 0) {
+		LOG(ERROR, "test_memory_tree_after_fini failed");
+		return -1;
+	}
+
+	LOG(INFO, "agent_memory_tree tests: OK");
+	return 0;
+}

--- a/tests/controlplane/meson.build
+++ b/tests/controlplane/meson.build
@@ -12,3 +12,20 @@ config_gen_test = executable(
   include_directories: yanet_libdir,
 )
 test('config_gen', config_gen_test, suite: ['controlplane'])
+
+agent_memory_tree_test = executable(
+  'agent_memory_tree_test',
+  ['agent_memory_tree_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_common_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_config_cp_dep,
+    lib_config_dp_dep,
+    lib_agent_cp_dep,
+  ],
+  include_directories: [yanet_rootdir, yanet_libdir],
+)
+test('agent_memory_tree', agent_memory_tree_test, suite: ['controlplane'])

--- a/web/src/api/inspect.ts
+++ b/web/src/api/inspect.ts
@@ -32,11 +32,21 @@ export interface PipelineInfo {
     functions?: string[];
 }
 
+export interface MemoryNode {
+    name?: string;
+    parent_idx?: number;
+    balloc_count?: string | number;
+    bfree_count?: string | number;
+    balloc_size?: string | number;
+    bfree_size?: string | number;
+}
+
 export interface AgentInstanceInfo {
     pid?: number;
     memory_limit?: string | number; // uint64 — serialized as string in JSON
     free_bytes?: string | number; // uint64 — serialized as string in JSON
     generation?: string | number; // uint64 — serialized as string in JSON
+    memory_tree?: MemoryNode[];
 }
 
 export interface AgentInfo {


### PR DESCRIPTION
Link memory contexts into a parent-children tree and surface it through the inspect snapshot. Operators can now see agent memory broken down by the subsystem that allocated it, which makes leak hunting feasible in production without ASAN.