### PR TITLE
refactor: adapt cp_chain to memory pattern

### DIFF
--- a/lib/controlplane/config/cp_chain.c
+++ b/lib/controlplane/config/cp_chain.c
@@ -2,6 +2,7 @@
 
 #include "controlplane/config/zone.h"
 
+#include <assert.h>
 #include <stdio.h>
 
 static inline size_t
@@ -11,8 +12,36 @@ cp_chain_alloc_size(uint64_t length) {
 }
 
 struct cp_chain *
-cp_chain_create(
-	struct memory_context *memory_context,
+cp_chain_new(struct memory_context *memory_context, uint64_t length) {
+	size_t alloc_size = cp_chain_alloc_size(length);
+	struct cp_chain *self =
+		(struct cp_chain *)memory_balloc(memory_context, alloc_size);
+	if (self == NULL) {
+		return NULL;
+	}
+
+	memset(self, 0, alloc_size);
+
+	SET_OFFSET_OF(&self->memory_context, memory_context);
+	self->length = length;
+
+	return self;
+}
+
+void
+cp_chain_free(struct cp_chain *self) {
+	if (self == NULL) {
+		return;
+	}
+
+	struct memory_context *mctx = ADDR_OF(&self->memory_context);
+	size_t alloc_size = cp_chain_alloc_size(self->length);
+	memory_bfree(mctx, self, alloc_size);
+}
+
+int
+cp_chain_init(
+	struct cp_chain *self,
 	struct dp_config *dp_config,
 	struct cp_config_gen *cp_config_gen,
 	struct cp_chain_config *cp_chain_config,
@@ -21,41 +50,29 @@ cp_chain_create(
 	(void)dp_config;
 	(void)cp_config_gen;
 
-	struct cp_chain *new_chain = (struct cp_chain *)memory_balloc(
-		memory_context, cp_chain_alloc_size(cp_chain_config->length)
-	);
-	if (new_chain == NULL) {
-		yanet_error_add(
-			err,
-			"failed to allocate memory for chain '%s'",
-			cp_chain_config->name
-		);
-		return NULL;
-	}
+	struct memory_context *mctx = ADDR_OF(&self->memory_context);
 
-	if (counter_registry_init(
-		    &new_chain->counter_registry, memory_context, 0
-	    )) {
+	assert(self->length == cp_chain_config->length);
+
+	if (counter_registry_init(&self->counter_registry, mctx, 0)) {
 		yanet_error_add(
 			err,
 			"failed to initialize counter registry for chain '%s'",
 			cp_chain_config->name
 		);
-		goto error;
+		goto err_out;
 	}
 
-	strtcpy(new_chain->name, cp_chain_config->name, sizeof(new_chain->name)
-	);
-	new_chain->length = cp_chain_config->length;
+	strtcpy(self->name, cp_chain_config->name, sizeof(self->name));
 
 	for (uint64_t idx = 0; idx < cp_chain_config->length; ++idx) {
-		strtcpy(new_chain->modules[idx].type,
+		strtcpy(self->modules[idx].type,
 			cp_chain_config->modules[idx].type,
-			sizeof(new_chain->modules[idx].type));
+			sizeof(self->modules[idx].type));
 
-		strtcpy(new_chain->modules[idx].name,
+		strtcpy(self->modules[idx].name,
 			cp_chain_config->modules[idx].name,
-			sizeof(new_chain->modules[idx].name));
+			sizeof(self->modules[idx].name));
 
 		char tsc_counter_name[COUNTER_NAME_LEN];
 		snprintf(
@@ -65,14 +82,10 @@ cp_chain_create(
 			idx
 		);
 
-		new_chain->modules[idx].tsc_counter_id =
-			counter_registry_register(
-				&new_chain->counter_registry,
-				tsc_counter_name,
-				8,
-				err
-			);
-		if (new_chain->modules[idx].tsc_counter_id == COUNTER_INVALID) {
+		self->modules[idx].tsc_counter_id = counter_registry_register(
+			&self->counter_registry, tsc_counter_name, 8, err
+		);
+		if (self->modules[idx].tsc_counter_id == COUNTER_INVALID) {
 			yanet_error_add(
 				err,
 				"failed to register '%s' counter for chain "
@@ -80,27 +93,18 @@ cp_chain_create(
 				tsc_counter_name,
 				cp_chain_config->name
 			);
-			goto error;
+			goto err_out;
 		}
 	}
 
-	return new_chain;
-error:
+	return 0;
 
-	memory_bfree(
-		memory_context,
-		new_chain,
-		cp_chain_alloc_size(cp_chain_config->length)
-	);
-
-	return NULL;
+err_out:
+	cp_chain_fini(self);
+	return -1;
 }
 
 void
-cp_chain_free(
-	struct memory_context *memory_context, struct cp_chain *cp_chain
-) {
-	memory_bfree(
-		memory_context, cp_chain, cp_chain_alloc_size(cp_chain->length)
-	);
+cp_chain_fini(struct cp_chain *self) {
+	counter_registry_free(&self->counter_registry);
 }

--- a/lib/controlplane/config/cp_chain.h
+++ b/lib/controlplane/config/cp_chain.h
@@ -15,6 +15,8 @@ struct cp_chain_module {
 };
 
 struct cp_chain {
+	struct memory_context *memory_context; // shm-relative pointer
+
 	char name[CP_CHAIN_NAME_LEN];
 
 	struct counter_registry counter_registry;
@@ -40,14 +42,35 @@ struct cp_chain_config {
 struct dp_config;
 struct cp_config_gen;
 
+// Allocate a new cp_chain with capacity for length modules.
+//
+// Returns NULL on allocation failure; caller is responsible for reporting the
+// error.
 struct cp_chain *
-cp_chain_create(
-	struct memory_context *memory_context,
+cp_chain_new(struct memory_context *memory_context, uint64_t length);
+
+// Free the memory backing self.
+//
+// NULL-safe no-op.
+//
+// Does not call cp_chain_fini: caller must do that separately first.
+void
+cp_chain_free(struct cp_chain *self);
+
+// Initialize chain resources.
+//
+// On failure, internally calls cp_chain_fini and returns -1.
+int
+cp_chain_init(
+	struct cp_chain *self,
 	struct dp_config *dp_config,
 	struct cp_config_gen *cp_config_gen,
 	struct cp_chain_config *cp_chain_config,
 	yanet_error **err
 );
 
+// Tear down resources acquired by cp_chain_init.
+//
+// Idempotent on zero-init.
 void
-cp_chain_free(struct memory_context *memory_context, struct cp_chain *cp_chain);
+cp_chain_fini(struct cp_chain *self);

--- a/lib/controlplane/config/cp_function.c
+++ b/lib/controlplane/config/cp_function.c
@@ -157,20 +157,26 @@ cp_function_create(
 	     chain_idx < cp_function_config->chain_count;
 	     ++chain_idx) {
 
-		struct cp_chain *new_chain = cp_chain_create(
+		struct cp_chain *new_chain = cp_chain_new(
 			memory_context,
-			dp_config,
-			cp_config_gen,
-			cp_function_config->chains[chain_idx].chain,
-			err
+			cp_function_config->chains[chain_idx].chain->length
 		);
-
 		if (new_chain == NULL) {
 			yanet_error_add(
 				err,
-				"failed to create chain for function '%s'",
+				"failed to allocate chain for function '%s'",
 				cp_function_config->name
 			);
+			goto error;
+		}
+		if (cp_chain_init(
+			    new_chain,
+			    dp_config,
+			    cp_config_gen,
+			    cp_function_config->chains[chain_idx].chain,
+			    err
+		    )) {
+			cp_chain_free(new_chain);
 			goto error;
 		}
 
@@ -200,7 +206,8 @@ cp_function_free(
 		if (cp_chain == NULL)
 			continue;
 
-		cp_chain_free(memory_context, cp_chain);
+		cp_chain_fini(cp_chain);
+		cp_chain_free(cp_chain);
 	}
 
 	memory_bfree(


### PR DESCRIPTION
Explicit new/free/init/fini. Keep allocator pointer inside.