### PR TITLE
Forward batch test

### DIFF
--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -663,6 +663,59 @@ func (f *F) SendPacketAndParseAll(inputIfaceIndex int, outputIfaceIndex int, pac
 	return outputPacketInfos, nil
 }
 
+func (f *F) SendPacketsAndParseAll(inputIfaceIndex int, outputIfaceIndex int, packets [][]byte, timeout time.Duration) ([]*PacketInfo, error) {
+	f.log.Infof("Sending packets on interface %d and capturing response on interface %d", inputIfaceIndex, outputIfaceIndex)
+
+	// Get socket clients
+	inputClient, err := f.GetSocketClient(inputIfaceIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get input socket client: %w", err)
+	}
+
+	outputClient, err := f.GetSocketClient(outputIfaceIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get output socket client: %w", err)
+	}
+
+	// Get dump file paths for this test
+	inputDumpPath, outputDumpPath := f.getDumpFilePaths()
+
+	// Connect to sockets
+	if err := inputClient.Connect(); err != nil {
+		return nil, fmt.Errorf("failed to connect to input socket: %w", err)
+	}
+
+	if err := outputClient.Connect(); err != nil {
+		return nil, fmt.Errorf("failed to connect to output socket: %w", err)
+	}
+
+	_, _ = outputClient.ReceiveAllPackets(timeout, outputDumpPath)
+
+	// Send packets on input interface
+	if err := inputClient.SendPackets(packets, inputDumpPath); err != nil {
+		return nil, fmt.Errorf("failed to send packet: %w", err)
+	}
+
+	responses, err := outputClient.ReceiveAllPackets(timeout, outputDumpPath)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to receive output packets: %w", err)
+	}
+
+	// Parse all response packets
+	var outputPacketInfos []*PacketInfo
+	for i, responseData := range responses {
+		outputPacketInfo, err := f.PacketParser.ParsePacket(responseData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse response packet %d: %w", i, err)
+		}
+		f.log.Debugf("Received packet %d: %s", i, outputPacketInfo.String())
+		outputPacketInfos = append(outputPacketInfos, outputPacketInfo)
+	}
+
+	return outputPacketInfos, nil
+}
+
 // GetSocketClient retrieves or creates a socket client for the specified network
 // interface. The method implements caching to reuse existing connections and
 // ensures thread-safe access to the socket client pool.

--- a/tests/functional/framework/socket_client.go
+++ b/tests/functional/framework/socket_client.go
@@ -277,6 +277,44 @@ func (sc *SocketClient) SendPacket(packet []byte, dumpPath string) error {
 	return nil
 }
 
+func (sc *SocketClient) SendPackets(packets [][]byte, dumpPath string) error {
+	if sc.inner.conn == nil {
+		return fmt.Errorf("not connected to socket")
+	}
+
+	if err := sc.inner.conn.SetWriteDeadline(time.Now().Add(sc.inner.timeout)); err != nil {
+		return fmt.Errorf("failed to set write deadline: %w", err)
+	}
+
+	headerSize := binary.Size(uint32(0))
+	// Evaluate buffer size
+	size := 0
+	for idx := range packets {
+		size = size + headerSize + len(packets[idx])
+	}
+	// Create a buffer with the packet length in network byte order followed by the packet data
+	packetWithLength := make([]byte, size)
+	current := packetWithLength[0:]
+	for idx := range packets {
+		binary.BigEndian.PutUint32(current, uint32(len(packets[idx])))
+		copy(current[headerSize:], packets[idx])
+		current = current[len(packets[idx])+headerSize:]
+	}
+
+	sc.log.Debugf("Sending packets with length prefixes: % x", packetWithLength)
+
+	// Write raw socket data to dump file if path is provided
+	if err := writeToDumpFile(dumpPath, packetWithLength); err != nil {
+		sc.log.Warnf("Failed to write to dump file: %v", err)
+	}
+
+	if _, err := sc.inner.conn.Write(packetWithLength); err != nil {
+		return fmt.Errorf("failed to send packet: %w", err)
+	}
+
+	return nil
+}
+
 // ReceivePacket captures a network packet from the QEMU socket connection with
 // MAC address filtering and timeout handling. The method implements the QEMU
 // socket protocol by reading length-prefixed packets and filtering based on

--- a/tests/functional/main/forward_test.go
+++ b/tests/functional/main/forward_test.go
@@ -202,4 +202,67 @@ func TestForward(t *testing.T) {
 		assert.Equal(t, framework.VMIPv6Host, outputPacket.SrcIP.String(), "Source IP should be the destination of the request")
 		assert.Equal(t, framework.VMIPv6Gateway, outputPacket.DstIP.String(), "Destination IP should be the source of the request")
 	})
+
+	fw.Run("Test_Batch", func(fw *framework.F, t *testing.T) {
+		// Send two packets, the first one is passed through forward
+		// module whereas the second should be routed to a kernel and
+		// responded with an ICMP
+		packets := [][]byte{
+			createICMPPacket(
+				net.ParseIP(framework.VMIPv4Gateway),
+				net.ParseIP(framework.VMIPv4Host),
+				[]byte("icmp test"),
+			),
+			createForwardPacket(
+				net.ParseIP("192.0.2.1"), // src IP (within 192.0.2.0/24)
+				net.ParseIP("192.0.2.2"), // dst IP (within 192.0.2.0/24)
+				[]byte("forward test"),
+			),
+			createICMPPacket(
+				net.ParseIP(framework.VMIPv4Gateway),
+				net.ParseIP(framework.VMIPv4Host),
+				[]byte("icmp test"),
+			),
+			createForwardPacket(
+				net.ParseIP("192.0.2.1"), // src IP (within 192.0.2.0/24)
+				net.ParseIP("192.0.2.2"), // dst IP (within 192.0.2.0/24)
+				[]byte("forward test"),
+			),
+			createICMPPacket(
+				net.ParseIP(framework.VMIPv4Gateway),
+				net.ParseIP(framework.VMIPv4Host),
+				[]byte("icmp test"),
+			),
+			createForwardPacket(
+				net.ParseIP("192.0.2.1"), // src IP (within 192.0.2.0/24)
+				net.ParseIP("192.0.2.2"), // dst IP (within 192.0.2.0/24)
+				[]byte("forward test"),
+			),
+			createICMPPacket(
+				net.ParseIP(framework.VMIPv4Gateway),
+				net.ParseIP(framework.VMIPv4Host),
+				[]byte("icmp test"),
+			),
+			createForwardPacket(
+				net.ParseIP("192.0.2.1"), // src IP (within 192.0.2.0/24)
+				net.ParseIP("192.0.2.2"), // dst IP (within 192.0.2.0/24)
+				[]byte("forward test"),
+			),
+		}
+
+		outputPackets, err := fw.SendPacketsAndParseAll(0, 0, packets, 100*time.Millisecond)
+		require.NoError(t, err, "Failed to send batch")
+
+		assert.Equal(t, 8, len(outputPackets), "eight packets expected")
+		cntICMP := 0
+		for _, pack := range outputPackets {
+			if framework.VMIPv4Host == pack.SrcIP.String() &&
+				framework.VMIPv4Gateway == pack.DstIP.String() {
+				cntICMP++
+			}
+		}
+
+		assert.Equal(t, cntICMP, 4, "four ICMP replies are expected")
+	})
+
 }


### PR DESCRIPTION
The test checks forward routing for packet batches - before the fix all `ip4` and `ip6` packets were routed to a target defined by the first one `ip4` or `ip6` packet.