### PR TITLE
feat: introduce Readiness Probe service proto description 

### DIFF
--- a/common/meson.build
+++ b/common/meson.build
@@ -5,5 +5,6 @@ lib_common_dep = declare_dependency(
 if not dataplane_only
   subdir('commonpb')
   subdir('filterpb')
+  subdir('readinesspb')
 endif
 

--- a/common/readinesspb/meson.build
+++ b/common/readinesspb/meson.build
@@ -1,0 +1,24 @@
+readiness_proto_dir = meson.current_source_dir()
+root_dir = meson.project_source_root()
+
+readiness_proto_files = [
+    join_paths(readiness_proto_dir, 'readiness.proto'),
+]
+
+readiness_protoc_gen = custom_target(
+    'readiness-protoc',
+    output: [
+        'readiness.pb.go',
+        'readiness_grpc.pb.go',
+    ],
+    input: readiness_proto_files,
+    command: [
+        protoc,
+        '-I', readiness_proto_dir,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + readiness_proto_dir,
+        '--go-grpc_out=paths=source_relative:' + readiness_proto_dir,
+        '@INPUT@',
+    ],
+    build_by_default: true,
+)

--- a/common/readinesspb/readiness.proto
+++ b/common/readinesspb/readiness.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+
+package readinesspb;
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/yanet-platform/yanet2/common/readinesspb;readinesspb";
+
+// ReadinessProbe allows external consumers to query whether a component is
+// ready to serve traffic. The concept is similar to Kubernetes readiness
+// probes: a component that reports NOT_READY should be excluded from the
+// serving path (e.g. removed from a load-balancer pool or withdrawn from BGP
+// announcements) until it becomes READY again.
+//
+// A single component implementing this service may expose multiple independent
+// scopes, each with its own readiness state.
+service ReadinessProbe {
+  // Ready returns the current readiness of all (or requested) scopes.
+  rpc Ready(ReadyRequest) returns (ReadyResponse);
+}
+
+// ReadyRequest selects which scopes to query.
+//
+// A component implementing ReadinessProbe may contain multiple scopes, each
+// representing an independent dimension of readiness. Callers may request a
+// subset of scopes by name; if the list is empty the component returns the
+// state of every known scope.
+message ReadyRequest {
+  // If empty, return state for all known scopes.
+  // Otherwise, return only the requested scopes.
+  repeated string scopes = 1;
+}
+
+message ReadyResponse {
+  repeated Scope scopes = 1;
+}
+
+// Scope describes the readiness of a single logical dimension within the
+// component.
+message Scope {
+  string name = 1;
+  State state = 2;
+  // Human-readable reasons explaining why the scope is not READY.
+  repeated Reason reasons = 3;
+  // Timestamp of the last observation, used for detecting stale answers.
+  google.protobuf.Timestamp observed_at = 4;
+}
+
+enum State {
+  STATE_UNSPECIFIED = 0;
+  STATE_READY = 1;
+  STATE_DEGRADED = 2;
+  STATE_NOT_READY = 3;
+  STATE_UNKNOWN = 4;
+}
+
+message Reason {
+  string code = 1;
+  string message = 2;
+}


### PR DESCRIPTION
**Add common ReadinessProbe gRPC service definition**

Introduces `common/readinesspb/readiness.proto` — a generic readiness probe contract inspired by Kubernetes readiness probes.

### Motivation

Components in the YANET2 ecosystem need a uniform way to report whether they are ready to serve traffic. External consumers (e.g. an announcer, a load-balancer controller, or a monitoring system) should be able to query any component and get a structured, machine-readable answer without coupling to component-specific APIs.

### Design

The `ReadinessProbe` service exposes a single `Ready` RPC. A component implementing this service may contain **multiple scopes**, each representing an independent dimension of readiness (for example, "config loaded", "dataplane converged", "peers established"). Each scope carries its own state, human-readable failure reasons, and an observation timestamp for stale-answer detection.

Callers may request a subset of scopes by name; if the list is empty the component returns the state of every known scope.

### States

| State | Meaning |
|---|---|
| `READY` | The scope is fully operational |
| `DEGRADED` | The scope is partially operational but may have reduced capacity |
| `NOT_READY` | The scope is not operational; the component should be removed from the serving path |
| `UNKNOWN` | The scope state cannot be determined |

### Files

- `common/readinesspb/readiness.proto` — protobuf service, messages, and enum definitions
- `common/readinesspb/meson.build` — build integration for Go code generation

---