### PR TITLE
feat(balancer): optionally pass real weights and states in config

### DIFF
--- a/modules/balancer2/controlplane/balancerpb/config.proto
+++ b/modules/balancer2/controlplane/balancerpb/config.proto
@@ -82,8 +82,14 @@ message RealIdentifier {
 
 message RealConfig {
   RelativeRealIdentifier id = 1;
-  uint32 weight = 2;
-  filterpb.IPNet src = 3;
+
+  // If not set, inherit from previous config.
+  optional uint32 weight = 2;
+
+  // If not set, inherit from previous config.
+  optional bool enabled = 3;
+
+  filterpb.IPNet src = 4;
 }
 
 message VsFlags {


### PR DESCRIPTION
This PR adds support for optional `weight` and `enabled` fields in the real configuration. During a config update, these values can now either be inherited from the existing state or overwritten with new values