### PR TITLE
feat(commonpb): IPAddress message

### DIFF
--- a/common/commonpb/ipaddr.go
+++ b/common/commonpb/ipaddr.go
@@ -1,0 +1,87 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+)
+
+// NewIPAddressFromAddr creates an IPAddress from a netip.Addr value.
+//
+// If addr is the zero value, the returned message has empty addr bytes.
+func NewIPAddressFromAddr(addr netip.Addr) *IPAddress {
+	if !addr.IsValid() {
+		return &IPAddress{}
+	}
+	if addr.Is4() {
+		raw := addr.As4()
+		return &IPAddress{Addr: raw[:]}
+	}
+	raw := addr.As16()
+	return &IPAddress{Addr: raw[:]}
+}
+
+// NewIPAddressV4 creates an IPAddress from a 4-byte IPv4 address in
+// network byte order.
+func NewIPAddressV4(addr [4]byte) *IPAddress {
+	return &IPAddress{Addr: addr[:]}
+}
+
+// NewIPAddressV6 creates an IPAddress from a 16-byte IPv6 address in
+// network byte order.
+func NewIPAddressV6(addr [16]byte) *IPAddress {
+	return &IPAddress{Addr: addr[:]}
+}
+
+// ToAddr converts the IPAddress back to a netip.Addr value.
+// Returns an error if the byte length is not exactly 4 or 16.
+func (m *IPAddress) ToAddr() (netip.Addr, error) {
+	switch len(m.GetAddr()) {
+	case 4:
+		return netip.AddrFrom4([4]byte(m.GetAddr())), nil
+	case 16:
+		return netip.AddrFrom16([16]byte(m.GetAddr())), nil
+	default:
+		return netip.Addr{}, fmt.Errorf("invalid IP address length: %d", len(m.GetAddr()))
+	}
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *IPAddress) AsLogValue() any {
+	addr, err := m.ToAddr()
+	if err != nil {
+		return "invalid"
+	}
+
+	return addr.String()
+}
+
+// MarshalJSON serializes addr as a human-readable IP address string.
+func (m *IPAddress) MarshalJSON() ([]byte, error) {
+	addr, err := m.ToAddr()
+	if err != nil {
+		return nil, err
+	}
+	return fmt.Appendf(nil, `{"addr":"%s"}`, addr.String()), nil
+}
+
+// UnmarshalJSON accepts addr as an IPv4 or IPv6 address string.
+func (m *IPAddress) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Addr string `json:"addr"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.Addr == "" {
+		return fmt.Errorf("empty IP address is not allowed")
+	}
+
+	parsed, err := netip.ParseAddr(raw.Addr)
+	if err != nil {
+		return fmt.Errorf("failed to parse IP address: %w", err)
+	}
+
+	*m = *NewIPAddressFromAddr(parsed)
+	return nil
+}

--- a/common/commonpb/ipaddr.proto
+++ b/common/commonpb/ipaddr.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package commonpb;
+
+option go_package = "github.com/yanet-platform/yanet2/common/commonpb;commonpb";
+
+// IPAddress represents an IPv4 or IPv6 host address.
+//
+// Family is determined by the length of addr:
+//   - 4 bytes  - IPv4 in network byte order;
+//   - 16 bytes - IPv6 in network byte order.
+// Any other length is invalid.
+message IPAddress {
+  // Network-byte-order address bytes.
+  //
+  // MUST be exactly 4 (IPv4) or 16 (IPv6) bytes. Any other length is a
+  // malformed message.
+  bytes addr = 1;
+  // Reserved for zone.
+  reserved 2;
+}

--- a/common/commonpb/ipaddr_test.go
+++ b/common/commonpb/ipaddr_test.go
@@ -1,0 +1,271 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIPAddressFromAddr_V4(t *testing.T) {
+	addr := netip.MustParseAddr("10.0.0.1")
+	ip := NewIPAddressFromAddr(addr)
+	require.Equal(t, []byte{10, 0, 0, 1}, ip.Addr)
+}
+
+func TestNewIPAddressFromAddr_V6(t *testing.T) {
+	addr := netip.MustParseAddr("2001:db8::1")
+	ip := NewIPAddressFromAddr(addr)
+	require.Len(t, ip.Addr, 16)
+}
+
+func TestNewIPAddressFromAddr_Zero(t *testing.T) {
+	ip := NewIPAddressFromAddr(netip.Addr{})
+	require.Empty(t, ip.Addr)
+}
+
+func TestNewIPAddressV4(t *testing.T) {
+	raw := [4]byte{192, 168, 1, 1}
+	ip := NewIPAddressV4(raw)
+	require.Equal(t, []byte{192, 168, 1, 1}, ip.Addr)
+}
+
+func TestNewIPAddressV6(t *testing.T) {
+	raw := [16]byte{
+		0x20, 0x01, 0x0d, 0xb8,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+	ip := NewIPAddressV6(raw)
+	require.Len(t, ip.Addr, 16)
+	require.Equal(t, raw[:], ip.Addr)
+}
+
+func TestIPAddress_ToAddr_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		addr netip.Addr
+	}{
+		{
+			name: "IPv4",
+			addr: netip.MustParseAddr("10.0.0.1"),
+		},
+		{
+			name: "IPv4 broadcast",
+			addr: netip.MustParseAddr("255.255.255.255"),
+		},
+		{
+			name: "IPv6",
+			addr: netip.MustParseAddr("2001:db8::1"),
+		},
+		{
+			name: "IPv6 loopback",
+			addr: netip.MustParseAddr("::1"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := NewIPAddressFromAddr(tt.addr)
+			got, err := ip.ToAddr()
+			require.NoError(t, err)
+			require.Equal(t, tt.addr, got)
+		})
+	}
+}
+
+func TestIPAddress_ToAddr_V4Constructor(t *testing.T) {
+	raw := [4]byte{172, 16, 0, 1}
+	ip := NewIPAddressV4(raw)
+	got, err := ip.ToAddr()
+	require.NoError(t, err)
+	require.Equal(t, netip.AddrFrom4(raw), got)
+}
+
+func TestIPAddress_ToAddr_V6Constructor(t *testing.T) {
+	raw := [16]byte{
+		0xfe, 0x80, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x01,
+	}
+	ip := NewIPAddressV6(raw)
+	got, err := ip.ToAddr()
+	require.NoError(t, err)
+	require.Equal(t, netip.AddrFrom16(raw), got)
+}
+
+func TestIPAddress_ToAddr_InvalidLength(t *testing.T) {
+	tests := []struct {
+		name   string
+		length int
+	}{
+		{name: "zero", length: 0},
+		{name: "one byte", length: 1},
+		{name: "three bytes", length: 3},
+		{name: "five bytes", length: 5},
+		{name: "fifteen bytes", length: 15},
+		{name: "seventeen bytes", length: 17},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := &IPAddress{Addr: make([]byte, tt.length)}
+			_, err := ip.ToAddr()
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestIPAddress_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      *IPAddress
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "IPv4",
+			ip:   NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1")),
+			want: `{"addr":"10.0.0.1"}`,
+		},
+		{
+			name: "IPv6",
+			ip:   NewIPAddressFromAddr(netip.MustParseAddr("2001:db8::1")),
+			want: `{"addr":"2001:db8::1"}`,
+		},
+		{
+			name:    "invalid length",
+			ip:      &IPAddress{Addr: []byte{1, 2, 3}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.ip)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestIPAddress_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    netip.Addr
+		wantErr bool
+	}{
+		{
+			name:  "IPv4",
+			input: `{"addr":"10.0.0.1"}`,
+			want:  netip.MustParseAddr("10.0.0.1"),
+		},
+		{
+			name:  "IPv6",
+			input: `{"addr":"2001:db8::1"}`,
+			want:  netip.MustParseAddr("2001:db8::1"),
+		},
+		{
+			name:    "empty string",
+			input:   `{"addr":""}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed address",
+			input:   `{"addr":"not-an-ip"}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{"addr":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ip IPAddress
+			err := json.Unmarshal([]byte(tt.input), &ip)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			got, err := ip.ToAddr()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIPAddress_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		addr netip.Addr
+	}{
+		{name: "IPv4", addr: netip.MustParseAddr("10.0.0.1")},
+		{name: "IPv6", addr: netip.MustParseAddr("2001:db8::1")},
+		{name: "IPv6 loopback", addr: netip.MustParseAddr("::1")},
+		{name: "IPv4 zeros", addr: netip.MustParseAddr("0.0.0.0")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := NewIPAddressFromAddr(tt.addr)
+
+			data, err := json.Marshal(original)
+			require.NoError(t, err)
+
+			var got IPAddress
+			require.NoError(t, json.Unmarshal(data, &got))
+
+			gotAddr, err := got.ToAddr()
+			require.NoError(t, err)
+			require.Equal(t, tt.addr, gotAddr)
+		})
+	}
+}
+
+func TestIPAddress_AsLogValue(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   *IPAddress
+		want string
+	}{
+		{
+			name: "IPv4",
+			ip:   NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1")),
+			want: "10.0.0.1",
+		},
+		{
+			name: "IPv6",
+			ip:   NewIPAddressFromAddr(netip.MustParseAddr("2001:db8::1")),
+			want: "2001:db8::1",
+		},
+		{
+			name: "invalid bytes",
+			ip:   &IPAddress{Addr: []byte{1, 2, 3}},
+			want: "invalid",
+		},
+		{
+			name: "empty bytes",
+			ip:   &IPAddress{},
+			want: "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.ip.AsLogValue())
+		})
+	}
+}

--- a/common/commonpb/meson.build
+++ b/common/commonpb/meson.build
@@ -4,6 +4,7 @@ common_proto_files = [
     join_paths(common_proto_dir, 'target.proto'),
     join_paths(common_proto_dir, 'metric.proto'),
     join_paths(common_proto_dir, 'macaddr.proto'),
+    join_paths(common_proto_dir, 'ipaddr.proto'),
 ]
 
 # Generate protobuf files
@@ -13,6 +14,7 @@ common_protoc_gen = custom_target(
         'target.pb.go',
         'metric.pb.go',
         'macaddr.pb.go',
+        'ipaddr.pb.go',
     ],
     input: common_proto_files,
     command: [

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -4,6 +4,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=common/commonpb/target.proto");
     println!("cargo:rerun-if-changed=common/commonpb/metric.proto");
     println!("cargo:rerun-if-changed=common/commonpb/macaddr.proto");
+    println!("cargo:rerun-if-changed=common/commonpb/ipaddr.proto");
 
     tonic_build::configure()
         .build_server(false)
@@ -14,6 +15,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
                 "common/commonpb/target.proto",
                 "common/commonpb/metric.proto",
                 "common/commonpb/macaddr.proto",
+                "common/commonpb/ipaddr.proto",
             ],
             &["../../.."],
         )?;

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -1,4 +1,9 @@
-use core::{error::Error, str::FromStr};
+use core::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    str::FromStr,
+};
 
 #[allow(clippy::all, non_snake_case)]
 pub mod pb {
@@ -16,5 +21,116 @@ impl FromStr for pb::DevicePipeline {
             .parse::<u64>()
             .map_err(|e| format!("invalid weight in '{s}': {e}"))?;
         Ok(pb::DevicePipeline { name: name.to_string(), weight })
+    }
+}
+
+impl From<IpAddr> for pb::IpAddress {
+    fn from(addr: IpAddr) -> Self {
+        let bytes = match addr {
+            IpAddr::V4(v4) => v4.octets().to_vec(),
+            IpAddr::V6(v6) => v6.octets().to_vec(),
+        };
+        pb::IpAddress { addr: bytes }
+    }
+}
+
+impl TryFrom<&pb::IpAddress> for IpAddr {
+    type Error = Box<dyn Error>;
+
+    fn try_from(ip: &pb::IpAddress) -> Result<Self, Self::Error> {
+        match ip.addr.len() {
+            4 => {
+                let octets: [u8; 4] = ip.addr[..].try_into().unwrap();
+                Ok(IpAddr::V4(Ipv4Addr::from(octets)))
+            }
+            16 => {
+                let octets: [u8; 16] = ip.addr[..].try_into().unwrap();
+                Ok(IpAddr::V6(Ipv6Addr::from(octets)))
+            }
+            n => Err(format!("invalid IP address length {n}: expected 4 (IPv4) or 16 (IPv6)").into()),
+        }
+    }
+}
+
+impl Display for pb::IpAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match IpAddr::try_from(self) {
+            Ok(addr) => addr.fmt(f),
+            Err(_) => f.write_str("invalid"),
+        }
+    }
+}
+
+impl FromStr for pb::IpAddress {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let addr = IpAddr::from_str(s)?;
+        Ok(Self::from(addr))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn v4_round_trip() {
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        let ip = pb::IpAddress::from(addr);
+        assert_eq!(4, ip.addr.len());
+        let got = IpAddr::try_from(&ip).unwrap();
+        assert_eq!(addr, got);
+    }
+
+    #[test]
+    fn v6_round_trip() {
+        let addr = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        let ip = pb::IpAddress::from(addr);
+        assert_eq!(16, ip.addr.len());
+        let got = IpAddr::try_from(&ip).unwrap();
+        assert_eq!(addr, got);
+    }
+
+    #[test]
+    fn try_from_rejects_invalid_lengths() {
+        for len in [0usize, 1, 3, 5, 15, 17] {
+            let ip = pb::IpAddress { addr: vec![0u8; len] };
+            assert!(IpAddr::try_from(&ip).is_err(), "expected error for length {len}");
+        }
+    }
+
+    #[test]
+    fn from_str_parses_valid() {
+        let v4: pb::IpAddress = "10.0.0.1".parse().unwrap();
+        assert_eq!(vec![10, 0, 0, 1], v4.addr);
+
+        let v6: pb::IpAddress = "2001:db8::1".parse().unwrap();
+        let got = IpAddr::try_from(&v6).unwrap();
+        assert_eq!(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)), got);
+    }
+
+    #[test]
+    fn from_str_rejects_invalid() {
+        assert!("".parse::<pb::IpAddress>().is_err());
+        assert!("not-an-ip".parse::<pb::IpAddress>().is_err());
+    }
+
+    #[test]
+    fn display_v4() {
+        let ip = pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)));
+        assert_eq!("10.0.0.1", ip.to_string());
+    }
+
+    #[test]
+    fn display_v6() {
+        let ip = pb::IpAddress::from(IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
+        assert_eq!("2001:db8::1", ip.to_string());
+    }
+
+    #[test]
+    fn display_invalid_length() {
+        let ip = pb::IpAddress { addr: vec![0u8; 5] };
+        assert_eq!("invalid", ip.to_string());
     }
 }

--- a/web/src/utils/netip.ts
+++ b/web/src/utils/netip.ts
@@ -674,3 +674,38 @@ export const formatIPNet = (
         return `${ipStr}/${maskStr}`;
     }
 };
+
+// Wire-format shape of commonpb.IPAddress as it arrives from the
+// gRPC-JSON gateway. The addr field may be base64 (string), a numeric
+// byte array, or a Uint8Array.
+export type IPAddressWire = {
+    addr?: string | number[] | Uint8Array;
+};
+
+// Decode a wire IPAddress into a human-readable IP string. Returns an
+// empty string when the message is missing, has an empty addr, or the
+// byte length is neither 4 nor 16.
+export const ipAddressToString = (ip: IPAddressWire | undefined): string => {
+    if (!ip || ip.addr === undefined || ip.addr === null) return '';
+    let bytes: number[];
+    if (typeof ip.addr === 'string') {
+        if (ip.addr.length === 0) return '';
+        const binary = atob(ip.addr);
+        bytes = Array.from({ length: binary.length }, (_, idx) => binary.charCodeAt(idx));
+    } else if (ip.addr instanceof Uint8Array) {
+        bytes = Array.from(ip.addr);
+    } else {
+        bytes = ip.addr;
+    }
+    if (bytes.length === 0) return '';
+    return formatIPFromBytes(bytes);
+};
+
+// Encode an IPv4 or IPv6 string into a wire IPAddress message. Returns
+// undefined for empty input or unparseable addresses.
+export const stringToIPAddress = (s: string): IPAddressWire | undefined => {
+    if (!s) return undefined;
+    const bytes = parseIPToBytes(s);
+    if (!bytes) return undefined;
+    return { addr: bytes };
+};


### PR DESCRIPTION
Trying to switch from string representation to a typed one. Expected less errors on wire format, better decomposition (can be reused into some kind of IPNetwork message or IPRange message).