### PR TITLE
fix(acl/cli): share commonpb crate to fix clippy dead_code

### DIFF
--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.85"
 
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
 netip = "0.2"
 log = "0.4"

--- a/modules/acl/cli/build.rs
+++ b/modules/acl/cli/build.rs
@@ -6,6 +6,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
+        .extern_path(".commonpb", "::commonpb::pb")
         .extern_path(".filterpb", "::filterpb::pb")
         .compile_protos(&["acl.proto"], &["../../..", "../controlplane/aclpb"])?;
 

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -23,9 +23,7 @@ use ync::{
 mod args;
 mod metric;
 
-mod commonpb {
-    tonic::include_proto!("commonpb");
-}
+use ::commonpb::pb as commonpb;
 
 #[allow(non_snake_case)]
 pub mod aclpb {


### PR DESCRIPTION
The acl CLI was re-compiling commonpb protos locally through tonic-build, which emitted unused GetMetrics request/response types into the binary crate. Recent clippy stable releases promote dead_code on pub items in bin crates to an error under -D warnings, breaking CI on main.

Route the commonpb proto package to the shared yanet-commonpb crate via extern_path, the same convention already used by balancer2, route, devices, and the route operator CLIs.