### PR TITLE
feat(neighbour): use IPAddress on wire for host fields

### DIFF
--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -14,7 +14,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use commonpb::pb::MacAddress;
+use commonpb::pb::{IpAddress, MacAddress};
 use netip::MacAddr;
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
@@ -191,9 +191,10 @@ impl NeighbourService {
         let mut entries = response
             .neighbours
             .into_iter()
-            .map(|entry| {
+            .map(|entry| -> Result<NeighbourEntry, Box<dyn Error>> {
                 let updated_at = UNIX_EPOCH + Duration::from_secs(entry.updated_at as u64);
-                let next_hop = entry.next_hop.parse().unwrap();
+                let next_hop: IpAddr =
+                    IpAddr::try_from(entry.next_hop.as_ref().ok_or("neighbour entry missing next_hop")?)?;
 
                 let link_addr = {
                     let addr = entry.link_addr.map(|v| v.addr).unwrap_or_default();
@@ -204,7 +205,7 @@ impl NeighbourService {
                     MacAddr::from(addr)
                 };
 
-                NeighbourEntry {
+                Ok(NeighbourEntry {
                     next_hop,
                     link_addr,
                     hardware_addr,
@@ -213,9 +214,9 @@ impl NeighbourService {
                     age: Age(updated_at),
                     source: entry.source,
                     priority: entry.priority,
-                }
+                })
             })
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, _>>()?;
 
         entries.sort_by(|a, b| (a.state, &a.next_hop).cmp(&(b.state, &b.next_hop)));
 
@@ -230,7 +231,7 @@ impl NeighbourService {
         let request = UpdateNeighboursRequest {
             table: args.table.unwrap_or_default(),
             entries: vec![ProtoNeighbourEntry {
-                next_hop: args.next_hop,
+                next_hop: Some(args.next_hop.parse::<IpAddress>()?),
                 link_addr: Some(link_addr),
                 hardware_addr: Some(hardware_addr),
                 device: args.device.unwrap_or_default(),
@@ -245,9 +246,14 @@ impl NeighbourService {
     }
 
     pub async fn remove_neighbours(&mut self, args: RemoveCmd) -> Result<(), Box<dyn Error>> {
+        let next_hops = args
+            .next_hops
+            .into_iter()
+            .map(|s| s.parse::<IpAddress>())
+            .collect::<Result<Vec<_>, _>>()?;
         let request = RemoveNeighboursRequest {
             table: args.table.unwrap_or_default(),
-            next_hops: args.next_hops,
+            next_hops,
         };
 
         self.client.remove_neighbours(request).await?;

--- a/operators/route/internal/operator/service_neighbour.go
+++ b/operators/route/internal/operator/service_neighbour.go
@@ -70,7 +70,7 @@ func (m *NeighbourService) List(
 		neighbours = append(
 			neighbours,
 			&operatorpb.NeighbourEntry{
-				NextHop:      entry.NextHop.String(),
+				NextHop:      commonpb.NewIPAddressFromAddr(entry.NextHop),
 				LinkAddr:     commonpb.NewMACAddressEUI48(entry.HardwareRoute.DestinationMAC),
 				HardwareAddr: commonpb.NewMACAddressEUI48(entry.HardwareRoute.SourceMAC),
 				State:        operatorpb.NeighbourState(entry.State),
@@ -152,15 +152,15 @@ func (m *NeighbourService) UpdateNeighbours(
 
 	entries := make([]neigh.NeighbourEntry, 0, len(req.GetEntries()))
 	for _, e := range req.GetEntries() {
-		addr, err := netip.ParseAddr(e.GetNextHop())
+		addr, err := e.GetNextHop().ToAddr()
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid nexthop %q: %v", e.GetNextHop(), err)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid nexthop %q: %v", addr, err)
 		}
 		if e.GetHardwareAddr() == nil {
-			return nil, status.Errorf(codes.InvalidArgument, "neighbour entry %q is missing hardware_addr", e.GetNextHop())
+			return nil, status.Errorf(codes.InvalidArgument, "neighbour entry %q is missing hardware_addr", addr)
 		}
 		if e.GetLinkAddr() == nil {
-			return nil, status.Errorf(codes.InvalidArgument, "neighbour entry %q is missing link_addr", e.GetNextHop())
+			return nil, status.Errorf(codes.InvalidArgument, "neighbour entry %q is missing link_addr", addr)
 		}
 
 		entries = append(entries, neigh.NeighbourEntry{
@@ -195,9 +195,9 @@ func (m *NeighbourService) RemoveNeighbours(
 
 	addrs := make([]netip.Addr, 0, len(req.GetNextHops()))
 	for _, hop := range req.GetNextHops() {
-		addr, err := netip.ParseAddr(hop)
+		addr, err := hop.ToAddr()
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "invalid next_hop %q: %v", hop, err)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid next_hop %q: %v", addr, err)
 		}
 		addrs = append(addrs, addr)
 	}

--- a/operators/route/operatorpb/v1/neighbour.proto
+++ b/operators/route/operatorpb/v1/neighbour.proto
@@ -4,6 +4,7 @@ package operators.route.operatorpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1;operatorpb";
 
+import "common/commonpb/ipaddr.proto";
 import "common/commonpb/macaddr.proto";
 
 // NeighbourService is the operator-owned neighbour table surface.
@@ -54,7 +55,7 @@ enum NeighbourState {
 
 // NeighbourEntry represents a single neighbor entry.
 message NeighbourEntry {
-  string next_hop = 1;
+  commonpb.IPAddress next_hop = 1;
   commonpb.MACAddress link_addr = 2;
   commonpb.MACAddress hardware_addr = 3;
   NeighbourState state = 4;
@@ -104,7 +105,7 @@ message UpdateNeighboursResponse {}
 
 message RemoveNeighboursRequest {
   string table = 1;
-  repeated string next_hops = 2;
+  repeated commonpb.IPAddress next_hops = 2;
 }
 
 message RemoveNeighboursResponse {}

--- a/web/src/api/neighbours.ts
+++ b/web/src/api/neighbours.ts
@@ -1,4 +1,5 @@
 import { createService, type CallOptions } from './client';
+import type { IPAddressWire } from '../utils/netip';
 
 // Neighbour types
 export interface MACAddress {
@@ -6,7 +7,7 @@ export interface MACAddress {
 }
 
 export interface Neighbour {
-    next_hop?: string;
+    next_hop?: IPAddressWire;
     link_addr?: MACAddress;
     hardware_addr?: MACAddress;
     state?: number; // NeighbourState enum
@@ -49,7 +50,7 @@ export const neighbours = {
         return neighbourService.callWithBody<void>('UpdateNeighbours', { table, entries }, options);
     },
 
-    removeNeighbours: (table: string, nextHops: string[], options?: CallOptions): Promise<void> => {
+    removeNeighbours: (table: string, nextHops: IPAddressWire[], options?: CallOptions): Promise<void> => {
         return neighbourService.callWithBody<void>('RemoveNeighbours', { table, next_hops: nextHops }, options);
     },
 

--- a/web/src/pages/operators/neighbours/AddNeighbourDialog.tsx
+++ b/web/src/pages/operators/neighbours/AddNeighbourDialog.tsx
@@ -3,11 +3,13 @@ import { Box, Dialog, TextInput, Select } from '@gravity-ui/uikit';
 import { FormField } from '../../../components';
 import { useDialogKeyboardShortcut } from '../../../hooks';
 import { isValidMAC } from '../../../utils';
+import { stringToIPAddress } from '../../../utils/netip';
 import type { Neighbour } from '../../../api/neighbours';
 import type { AddNeighbourDialogProps } from './types';
 
 const validateNextHop = (value: string): string | undefined => {
     if (!value.trim()) return 'Next Hop is required';
+    if (!stringToIPAddress(value.trim())) return 'Invalid IP address';
     return undefined;
 };
 
@@ -58,8 +60,11 @@ export const AddNeighbourDialog: React.FC<AddNeighbourDialogProps> = ({
 
         setIsSubmitting(true);
         try {
+            const nextHopWire = stringToIPAddress(nextHop.trim());
+            if (!nextHopWire) return;
+
             const entry: Neighbour = {
-                next_hop: nextHop.trim(),
+                next_hop: nextHopWire,
                 device: device.trim() || undefined,
                 priority: priority.trim() ? Number(priority.trim()) : undefined,
             };

--- a/web/src/pages/operators/neighbours/EditNeighbourDialog.tsx
+++ b/web/src/pages/operators/neighbours/EditNeighbourDialog.tsx
@@ -3,6 +3,7 @@ import { Box, Dialog, TextInput } from '@gravity-ui/uikit';
 import { FormField } from '../../../components';
 import { useDialogKeyboardShortcut } from '../../../hooks';
 import { isValidMAC } from '../../../utils';
+import { ipAddressToString, stringToIPAddress } from '../../../utils/netip';
 import type { Neighbour } from '../../../api/neighbours';
 import type { EditNeighbourDialogProps } from './types';
 
@@ -32,7 +33,7 @@ export const EditNeighbourDialog: React.FC<EditNeighbourDialogProps> = ({
 
     useEffect(() => {
         if (open && neighbour) {
-            setNextHop(neighbour.next_hop || '');
+            setNextHop(ipAddressToString(neighbour.next_hop));
             setLinkAddr(renderMAC(neighbour.link_addr));
             setHardwareAddr(renderMAC(neighbour.hardware_addr));
             setDevice(neighbour.device || '');
@@ -50,8 +51,11 @@ export const EditNeighbourDialog: React.FC<EditNeighbourDialogProps> = ({
 
         setIsSubmitting(true);
         try {
+            const nextHopWire = stringToIPAddress(nextHop.trim());
+            if (!nextHopWire) return;
+
             const entry: Neighbour = {
-                next_hop: nextHop.trim(),
+                next_hop: nextHopWire,
                 device: device.trim() || undefined,
                 priority: priority.trim() ? Number(priority.trim()) : undefined,
             };

--- a/web/src/pages/operators/neighbours/NeighbourVirtualRow.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourVirtualRow.tsx
@@ -2,6 +2,7 @@ import { Checkbox, Button, Icon } from '@gravity-ui/uikit';
 import { Pencil } from '@gravity-ui/icons';
 import type { Neighbour } from '../../../api/neighbours';
 import { formatUnixSeconds, getNUDStateString } from '../../../utils';
+import { ipAddressToString } from '../../../utils/netip';
 import { cellStyles, TOTAL_WIDTH, ROW_HEIGHT } from './constants';
 
 export interface NeighbourVirtualRowProps {
@@ -59,7 +60,7 @@ export const NeighbourVirtualRow = ({
                 <Checkbox checked={isSelected} onUpdate={handleCheckboxChange} />
             </div>
             <div style={cellStyles.index}>{index + 1}</div>
-            <div style={cellStyles.next_hop}>{neighbour.next_hop || '-'}</div>
+            <div style={cellStyles.next_hop}>{ipAddressToString(neighbour.next_hop) || '-'}</div>
             <div style={cellStyles.link_addr}>{renderMac(neighbour.link_addr)}</div>
             <div style={cellStyles.hardware_addr}>{renderMac(neighbour.hardware_addr)}</div>
             <div style={cellStyles.device}>{neighbour.device || '-'}</div>

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom';
 import { Box, TabProvider, TabList, Tab, Button, Flex, Divider } from '@gravity-ui/uikit';
 import { toaster } from '../../../utils';
+import { stringToIPAddress } from '../../../utils/netip';
 import { API } from '../../../api';
 import type { Neighbour, NeighbourTableInfo } from '../../../api/neighbours';
 import { PageLayout, PageLoader, PageHeader, ConfirmDialog } from '../../../components';
@@ -243,7 +244,9 @@ const NeighboursPage = (): React.JSX.Element => {
     const handleRemoveConfirm = useCallback(async () => {
         if (isMergedView || !activeTab) return;
         try {
-            const nextHops = Array.from(selectedIds);
+            const nextHops = Array.from(selectedIds)
+                .map(s => stringToIPAddress(s))
+                .filter((w): w is NonNullable<typeof w> => w !== undefined);
             await API.neighbours.removeNeighbours(activeTab, nextHops);
             toaster.success('neighbours-removed', `${nextHops.length} neighbour(s) removed`);
             setSelectedIds(new Set());

--- a/web/src/pages/operators/neighbours/VirtualizedNeighbourTable.tsx
+++ b/web/src/pages/operators/neighbours/VirtualizedNeighbourTable.tsx
@@ -6,6 +6,7 @@ import type { Neighbour } from '../../../api/neighbours';
 import type { SortState, SortableColumn } from './hooks';
 import { useContainerHeight } from '../../../hooks';
 import { useProcessedNeighbours } from './hooks';
+import { ipAddressToString } from '../../../utils/netip';
 import { ROW_HEIGHT, OVERSCAN, TOTAL_WIDTH, SEARCH_BAR_HEIGHT, HEADER_HEIGHT, FOOTER_HEIGHT } from './constants';
 import { NeighbourVirtualRow } from './NeighbourVirtualRow';
 import { NeighbourTableHeader } from './NeighbourTableHeader';
@@ -21,7 +22,7 @@ export interface VirtualizedNeighbourTableProps {
     onSearchChange: (query: string) => void;
 }
 
-const getNeighbourId = (n: Neighbour): string => n.next_hop || '';
+const getNeighbourId = (n: Neighbour): string => ipAddressToString(n.next_hop);
 
 export const VirtualizedNeighbourTable: React.FC<VirtualizedNeighbourTableProps> = ({
     neighbours,

--- a/web/src/pages/operators/neighbours/hooks.ts
+++ b/web/src/pages/operators/neighbours/hooks.ts
@@ -7,6 +7,7 @@ import {
     getMACAddressValue,
     getUnixSecondsValue,
 } from '../../../utils';
+import { ipAddressToString } from '../../../utils/netip';
 
 // Sorting types
 export type SortableColumn =
@@ -41,7 +42,7 @@ export const isSortDirection = (value: string): value is SortDirection =>
 
 // Sort comparators for neighbour columns
 export const sortComparators: Record<SortableColumn, (a: Neighbour, b: Neighbour) => number> = {
-    next_hop: (a, b) => compareNullableStrings(a.next_hop, b.next_hop),
+    next_hop: (a, b) => compareNullableStrings(ipAddressToString(a.next_hop) || undefined, ipAddressToString(b.next_hop) || undefined),
     link_addr: (a, b) => compareMACAddressValues(
         getMACAddressValue(a.link_addr?.addr),
         getMACAddressValue(b.link_addr?.addr),
@@ -55,7 +56,7 @@ export const sortComparators: Record<SortableColumn, (a: Neighbour, b: Neighbour
         const stateA = a.state ?? 0;
         const stateB = b.state ?? 0;
         if (stateA !== stateB) return stateA - stateB;
-        return compareNullableStrings(a.next_hop, b.next_hop);
+        return compareNullableStrings(ipAddressToString(a.next_hop) || undefined, ipAddressToString(b.next_hop) || undefined);
     },
     source: (a, b) => compareNullableStrings(a.source, b.source),
     priority: (a, b) => (a.priority ?? 0) - (b.priority ?? 0),
@@ -78,7 +79,7 @@ export const useProcessedNeighbours = (
         if (searchQuery.trim()) {
             const lowerQuery = searchQuery.toLowerCase();
             result = result.filter(n =>
-                n.next_hop?.toLowerCase().includes(lowerQuery) ||
+                ipAddressToString(n.next_hop).toLowerCase().includes(lowerQuery) ||
                 n.device?.toLowerCase().includes(lowerQuery) ||
                 n.source?.toLowerCase().includes(lowerQuery),
             );

--- a/web/src/utils/netip.test.ts
+++ b/web/src/utils/netip.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { ipAddressToString, stringToIPAddress } from './netip';
+
+describe('ipAddressToString', () => {
+    it('returns the string directly for IPv4 wire form', () => {
+        expect(ipAddressToString({ addr: '10.0.0.1' })).toBe('10.0.0.1');
+    });
+
+    it('returns the string directly for IPv6 wire form', () => {
+        expect(ipAddressToString({ addr: '2001:db8::1' })).toBe('2001:db8::1');
+    });
+
+    it('returns the string directly for link-local IPv6', () => {
+        expect(ipAddressToString({ addr: 'fe80::1' })).toBe('fe80::1');
+    });
+
+    it('handles number[] bytes as defensive fallback (IPv4)', () => {
+        expect(ipAddressToString({ addr: [10, 0, 0, 1] })).toBe('10.0.0.1');
+    });
+
+    it('handles Uint8Array bytes as defensive fallback (IPv4)', () => {
+        expect(ipAddressToString({ addr: new Uint8Array([10, 0, 0, 1]) })).toBe('10.0.0.1');
+    });
+
+    it('returns empty string for undefined', () => {
+        expect(ipAddressToString(undefined)).toBe('');
+    });
+
+    it('returns empty string for missing addr', () => {
+        expect(ipAddressToString({})).toBe('');
+    });
+});
+
+describe('stringToIPAddress', () => {
+    it('encodes a valid IPv4 address', () => {
+        expect(stringToIPAddress('10.0.0.1')).toEqual({ addr: '10.0.0.1' });
+    });
+
+    it('encodes a valid IPv6 address', () => {
+        expect(stringToIPAddress('2001:db8::1')).toEqual({ addr: '2001:db8::1' });
+    });
+
+    it('returns undefined for an invalid address', () => {
+        expect(stringToIPAddress('not-an-ip')).toBeUndefined();
+    });
+
+    it('returns undefined for an empty string', () => {
+        expect(stringToIPAddress('')).toBeUndefined();
+    });
+});

--- a/web/src/utils/netip.ts
+++ b/web/src/utils/netip.ts
@@ -683,20 +683,14 @@ export type IPAddressWire = {
 };
 
 // Decode a wire IPAddress into a human-readable IP string. Returns an
-// empty string when the message is missing, has an empty addr, or the
-// byte length is neither 4 nor 16.
+// empty string when the message is missing or has an empty addr.
+// The canonical wire form from Go's MarshalJSON is a plain IP string.
 export const ipAddressToString = (ip: IPAddressWire | undefined): string => {
     if (!ip || ip.addr === undefined || ip.addr === null) return '';
-    let bytes: number[];
     if (typeof ip.addr === 'string') {
-        if (ip.addr.length === 0) return '';
-        const binary = atob(ip.addr);
-        bytes = Array.from({ length: binary.length }, (_, idx) => binary.charCodeAt(idx));
-    } else if (ip.addr instanceof Uint8Array) {
-        bytes = Array.from(ip.addr);
-    } else {
-        bytes = ip.addr;
+        return ip.addr;
     }
+    const bytes = ip.addr instanceof Uint8Array ? Array.from(ip.addr) : ip.addr;
     if (bytes.length === 0) return '';
     return formatIPFromBytes(bytes);
 };
@@ -705,7 +699,7 @@ export const ipAddressToString = (ip: IPAddressWire | undefined): string => {
 // undefined for empty input or unparseable addresses.
 export const stringToIPAddress = (s: string): IPAddressWire | undefined => {
     if (!s) return undefined;
-    const bytes = parseIPToBytes(s);
-    if (!bytes) return undefined;
-    return { addr: bytes };
+    const parsed = parseIPAddress(s);
+    if (!parsed.ok) return undefined;
+    return { addr: s };
 };


### PR DESCRIPTION
Switch NeighbourEntry.next_hop and RemoveNeighboursRequest.next_hops from plain strings to the typed commonpb.IPAddress message introduced earlier. Producers and consumers across the Go service, Rust CLI, and web UI route IP addresses through the shared helpers instead of ad-hoc string parsing.

Pilot for a broader migration of host-address fields off strings, ahead of upcoming IPPrefix and IPRange types.