### PR TITLE
refactor: IPRange for protobuf

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,9 @@ Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` 
 - **Comments**: English, end with period, fit within ~80 chars
   (reflow rather than preserving narrower fill). List only production
   callers, not "tests". No section-separator comments.
+- **Doc comments**: first line is a single-sentence brief ending with
+  period. If detail follows, separate with a blank `//` line, then the
+  body paragraph. Never glue brief and detail on consecutive `//` lines.
 - **Tests**: table-driven, use `require.NoError(t, err)`. Do not
   reference tests inside production-code comments.
 
@@ -251,6 +254,10 @@ Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` 
   explicit `Result<(), fmt::Error>` (not `fmt::Result` alias).
 - **No doc comments** on `Display`/`Serialize`/`TryFrom`/`From`/`Debug`/
   `Default`/`FromStr` impls — the trait name is the doc.
+- **Doc-comment structure**: `///` / `//!` blocks lead with a
+  single-sentence brief ending with period. If detail follows, separate
+  with a blank `///` line, then the body paragraph. Never glue brief
+  and detail on consecutive `///` lines.
 - **No infallible `TryFrom`**: replace with `From`, or remove the impl
   if the call site is trivially inlinable.
 - **`assert_eq!` order**: expected first, actual second:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,9 +1232,9 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "netip"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3055e2b830c27116ba791de403649c192c4984a77e2f64d88660cfca248b4b69"
+checksum = "cff1fcab1e3a897063665edc7c11f1de7591aa92179994ca049b422db94a3001"
 
 [[package]]
 name = "no-std-net"
@@ -2468,6 +2479,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,6 +3075,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
+ "erased-serde",
  "http",
  "log",
  "serde",
@@ -3091,6 +3109,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
  "yanet-filterpb",
 ]
 
@@ -3282,6 +3301,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]
@@ -3319,6 +3339,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]
@@ -3365,11 +3386,13 @@ dependencies = [
  "log",
  "netip",
  "prost",
+ "serde",
  "tabled",
  "tokio",
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]
@@ -3451,12 +3474,14 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
 ]
 
 [[package]]
 name = "yanet-commonpb"
 version = "0.1.0"
 dependencies = [
+ "netip",
  "prost",
  "serde",
  "tonic",

--- a/common/commonpb/iprange.go
+++ b/common/commonpb/iprange.go
@@ -1,0 +1,103 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+)
+
+// NewIPRange creates an IPRange from two netip.Addr values.
+func NewIPRange(start, end netip.Addr) *IPRange {
+	return &IPRange{
+		Start: NewIPAddressFromAddr(start),
+		End:   NewIPAddressFromAddr(end),
+	}
+}
+
+// ToRange converts the IPRange back to a pair of netip.Addr values.
+//
+// Returns an error if either endpoint fails to parse or if the endpoints
+// belong to different address families.
+func (m *IPRange) ToRange() (netip.Addr, netip.Addr, error) {
+	start, err := m.GetStart().ToAddr()
+	if err != nil {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("failed to parse start address: %w", err)
+	}
+
+	end, err := m.GetEnd().ToAddr()
+	if err != nil {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("failed to parse end address: %w", err)
+	}
+
+	if start.Is4() != end.Is4() {
+		return netip.Addr{}, netip.Addr{}, fmt.Errorf("address family mismatch: start is IPv%d, end is IPv%d",
+			familyNum(start), familyNum(end))
+	}
+
+	return start, end, nil
+}
+
+// familyNum returns 4 for IPv4 and 6 for IPv6.
+func familyNum(addr netip.Addr) int {
+	if addr.Is4() {
+		return 4
+	}
+	return 6
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *IPRange) AsLogValue() any {
+	start, end, err := m.ToRange()
+	if err != nil {
+		return "invalid"
+	}
+
+	return fmt.Sprintf("[%s, %s]", start.String(), end.String())
+}
+
+// MarshalJSON serializes the range as human-readable IP address strings.
+func (m *IPRange) MarshalJSON() ([]byte, error) {
+	start, end, err := m.ToRange()
+	if err != nil {
+		return nil, err
+	}
+	return fmt.Appendf(nil, `{"start":"%s","end":"%s"}`, start.String(), end.String()), nil
+}
+
+// UnmarshalJSON accepts start and end as IPv4 or IPv6 address strings.
+func (m *IPRange) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Start string `json:"start"`
+		End   string `json:"end"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.Start == "" {
+		return fmt.Errorf("empty start address is not allowed")
+	}
+	if raw.End == "" {
+		return fmt.Errorf("empty end address is not allowed")
+	}
+
+	start, err := netip.ParseAddr(raw.Start)
+	if err != nil {
+		return fmt.Errorf("failed to parse start address: %w", err)
+	}
+
+	end, err := netip.ParseAddr(raw.End)
+	if err != nil {
+		return fmt.Errorf("failed to parse end address: %w", err)
+	}
+
+	if start.Is4() != end.Is4() {
+		return fmt.Errorf(
+			"address family mismatch: start is IPv%d, end is IPv%d",
+			familyNum(start),
+			familyNum(end),
+		)
+	}
+
+	*m = *NewIPRange(start, end)
+	return nil
+}

--- a/common/commonpb/iprange.proto
+++ b/common/commonpb/iprange.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package commonpb;
+
+option go_package = "github.com/yanet-platform/yanet2/common/commonpb;commonpb";
+
+import "common/commonpb/ipaddr.proto";
+
+// IPRange represents an inclusive address range [start, end].
+//
+// Both endpoints must belong to the same address family (both IPv4 or
+// both IPv6) and must compare start <= end as bytes in network byte
+// order. A single-address range has start == end.
+message IPRange {
+  // Lower bound, inclusive.
+  IPAddress start = 1;
+  // Upper bound, inclusive.
+  IPAddress end = 2;
+}

--- a/common/commonpb/iprange_test.go
+++ b/common/commonpb/iprange_test.go
@@ -1,0 +1,286 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewIPRange_V4(t *testing.T) {
+	start := netip.MustParseAddr("10.0.0.0")
+	end := netip.MustParseAddr("10.0.0.255")
+
+	r := NewIPRange(start, end)
+
+	require.NotNil(t, r.Start)
+	require.NotNil(t, r.End)
+	require.Equal(t, []byte{10, 0, 0, 0}, r.Start.Addr)
+	require.Equal(t, []byte{10, 0, 0, 255}, r.End.Addr)
+}
+
+func TestNewIPRange_V6(t *testing.T) {
+	start := netip.MustParseAddr("2001:db8::")
+	end := netip.MustParseAddr("2001:db8::ffff")
+
+	r := NewIPRange(start, end)
+
+	require.NotNil(t, r.Start)
+	require.NotNil(t, r.End)
+	require.Len(t, r.Start.Addr, 16)
+	require.Len(t, r.End.Addr, 16)
+}
+
+func TestIPRange_ToRange_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		start netip.Addr
+		end   netip.Addr
+	}{
+		{
+			name:  "IPv4 range",
+			start: netip.MustParseAddr("10.0.0.0"),
+			end:   netip.MustParseAddr("10.0.0.255"),
+		},
+		{
+			name:  "IPv4 single address",
+			start: netip.MustParseAddr("192.168.1.1"),
+			end:   netip.MustParseAddr("192.168.1.1"),
+		},
+		{
+			name:  "IPv6 range",
+			start: netip.MustParseAddr("2001:db8::"),
+			end:   netip.MustParseAddr("2001:db8::ffff"),
+		},
+		{
+			name:  "IPv6 single address",
+			start: netip.MustParseAddr("::1"),
+			end:   netip.MustParseAddr("::1"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := NewIPRange(tt.start, tt.end)
+			gotStart, gotEnd, err := r.ToRange()
+			require.NoError(t, err)
+			require.Equal(t, tt.start, gotStart)
+			require.Equal(t, tt.end, gotEnd)
+		})
+	}
+}
+
+func TestIPRange_ToRange_InvalidStart(t *testing.T) {
+	r := &IPRange{
+		Start: &IPAddress{Addr: []byte{1, 2, 3}},
+		End:   NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.255")),
+	}
+	_, _, err := r.ToRange()
+	require.Error(t, err)
+}
+
+func TestIPRange_ToRange_InvalidEnd(t *testing.T) {
+	r := &IPRange{
+		Start: NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.0")),
+		End:   &IPAddress{Addr: []byte{1, 2, 3}},
+	}
+	_, _, err := r.ToRange()
+	require.Error(t, err)
+}
+
+func TestIPRange_ToRange_FamilyMismatch(t *testing.T) {
+	r := &IPRange{
+		Start: NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.0")),
+		End:   NewIPAddressFromAddr(netip.MustParseAddr("2001:db8::ffff")),
+	}
+	_, _, err := r.ToRange()
+	require.Error(t, err)
+}
+
+func TestIPRange_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		r       *IPRange
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "IPv4",
+			r:    NewIPRange(netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
+			want: `{"start":"10.0.0.0","end":"10.0.0.255"}`,
+		},
+		{
+			name: "IPv6",
+			r:    NewIPRange(netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
+			want: `{"start":"2001:db8::","end":"2001:db8::ffff"}`,
+		},
+		{
+			name: "invalid start length",
+			r: &IPRange{
+				Start: &IPAddress{Addr: []byte{1, 2, 3}},
+				End:   NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.255")),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := json.Marshal(tt.r)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestIPRange_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantStart netip.Addr
+		wantEnd   netip.Addr
+		wantErr   bool
+	}{
+		{
+			name:      "IPv4",
+			input:     `{"start":"10.0.0.0","end":"10.0.0.255"}`,
+			wantStart: netip.MustParseAddr("10.0.0.0"),
+			wantEnd:   netip.MustParseAddr("10.0.0.255"),
+		},
+		{
+			name:      "IPv6",
+			input:     `{"start":"2001:db8::","end":"2001:db8::ffff"}`,
+			wantStart: netip.MustParseAddr("2001:db8::"),
+			wantEnd:   netip.MustParseAddr("2001:db8::ffff"),
+		},
+		{
+			name:    "empty start",
+			input:   `{"start":"","end":"10.0.0.255"}`,
+			wantErr: true,
+		},
+		{
+			name:    "empty end",
+			input:   `{"start":"10.0.0.0","end":""}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed start",
+			input:   `{"start":"not-an-ip","end":"10.0.0.255"}`,
+			wantErr: true,
+		},
+		{
+			name:    "malformed end",
+			input:   `{"start":"10.0.0.0","end":"not-an-ip"}`,
+			wantErr: true,
+		},
+		{
+			name:    "family mismatch v4 start v6 end",
+			input:   `{"start":"10.0.0.0","end":"2001:db8::ffff"}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{"start":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r IPRange
+			err := json.Unmarshal([]byte(tt.input), &r)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			gotStart, gotEnd, err := r.ToRange()
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStart, gotStart)
+			require.Equal(t, tt.wantEnd, gotEnd)
+		})
+	}
+}
+
+func TestIPRange_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		start netip.Addr
+		end   netip.Addr
+	}{
+		{
+			name:  "IPv4",
+			start: netip.MustParseAddr("10.0.0.0"),
+			end:   netip.MustParseAddr("10.0.0.255"),
+		},
+		{
+			name:  "IPv6",
+			start: netip.MustParseAddr("2001:db8::"),
+			end:   netip.MustParseAddr("2001:db8::ffff"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := NewIPRange(tt.start, tt.end)
+
+			data, err := json.Marshal(original)
+			require.NoError(t, err)
+
+			var got IPRange
+			require.NoError(t, json.Unmarshal(data, &got))
+
+			gotStart, gotEnd, err := got.ToRange()
+			require.NoError(t, err)
+			require.Equal(t, tt.start, gotStart)
+			require.Equal(t, tt.end, gotEnd)
+		})
+	}
+}
+
+func TestIPRange_AsLogValue(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *IPRange
+		want string
+	}{
+		{
+			name: "IPv4",
+			r:    NewIPRange(netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
+			want: "[10.0.0.0, 10.0.0.255]",
+		},
+		{
+			name: "IPv6",
+			r:    NewIPRange(netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
+			want: "[2001:db8::, 2001:db8::ffff]",
+		},
+		{
+			name: "invalid start bytes",
+			r: &IPRange{
+				Start: &IPAddress{Addr: []byte{1, 2, 3}},
+				End:   NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.255")),
+			},
+			want: "invalid",
+		},
+		{
+			name: "family mismatch",
+			r: &IPRange{
+				Start: NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.0")),
+				End:   NewIPAddressFromAddr(netip.MustParseAddr("2001:db8::ffff")),
+			},
+			want: "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.r.AsLogValue())
+		})
+	}
+}

--- a/common/commonpb/meson.build
+++ b/common/commonpb/meson.build
@@ -1,13 +1,18 @@
 common_proto_dir = meson.current_source_dir()
+root_dir = meson.project_source_root()
 
 common_proto_files = [
     join_paths(common_proto_dir, 'target.proto'),
     join_paths(common_proto_dir, 'metric.proto'),
     join_paths(common_proto_dir, 'macaddr.proto'),
     join_paths(common_proto_dir, 'ipaddr.proto'),
+    join_paths(common_proto_dir, 'iprange.proto'),
 ]
 
-# Generate protobuf files
+# Generate protobuf files. The root include dir is required so that
+# iprange.proto can import ipaddr.proto via the canonical path
+# "common/commonpb/ipaddr.proto", which matches the import path used by
+# consumers outside this directory.
 common_protoc_gen = custom_target(
     'common-protoc',
     output: [
@@ -15,12 +20,13 @@ common_protoc_gen = custom_target(
         'metric.pb.go',
         'macaddr.pb.go',
         'ipaddr.pb.go',
+        'iprange.pb.go',
     ],
     input: common_proto_files,
     command: [
         protoc,
-        '-I', common_proto_dir,
-        '--go_out=paths=source_relative:' + common_proto_dir,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + root_dir,
         '@INPUT@',
     ],
     build_by_default: true,

--- a/common/rust/commonpb/Cargo.toml
+++ b/common/rust/commonpb/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 rust-version = "1.85"
 
 [dependencies]
+netip = "0.3"
 prost = "0.13"
 serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -5,6 +5,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=common/commonpb/metric.proto");
     println!("cargo:rerun-if-changed=common/commonpb/macaddr.proto");
     println!("cargo:rerun-if-changed=common/commonpb/ipaddr.proto");
+    println!("cargo:rerun-if-changed=common/commonpb/iprange.proto");
 
     tonic_build::configure()
         .build_server(false)
@@ -16,6 +17,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
                 "common/commonpb/metric.proto",
                 "common/commonpb/macaddr.proto",
                 "common/commonpb/ipaddr.proto",
+                "common/commonpb/iprange.proto",
             ],
             &["../../.."],
         )?;

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -5,6 +5,8 @@ use core::{
     str::FromStr,
 };
 
+use netip::{Contiguous, IpNetwork, ipv4_range_to_networks, ipv6_range_to_networks};
+
 #[allow(clippy::all, non_snake_case)]
 pub mod pb {
     tonic::include_proto!("commonpb");
@@ -56,7 +58,7 @@ impl Display for pb::IpAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match IpAddr::try_from(self) {
             Ok(addr) => addr.fmt(f),
-            Err(_) => f.write_str("invalid"),
+            Err(..) => f.write_str("invalid"),
         }
     }
 }
@@ -67,6 +69,66 @@ impl FromStr for pb::IpAddress {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let addr = IpAddr::from_str(s)?;
         Ok(Self::from(addr))
+    }
+}
+
+impl From<(IpAddr, IpAddr)> for pb::IpRange {
+    fn from((start, end): (IpAddr, IpAddr)) -> Self {
+        pb::IpRange {
+            start: Some(pb::IpAddress::from(start)),
+            end: Some(pb::IpAddress::from(end)),
+        }
+    }
+}
+
+impl TryFrom<&pb::IpRange> for (IpAddr, IpAddr) {
+    type Error = Box<dyn Error>;
+
+    fn try_from(range: &pb::IpRange) -> Result<Self, Self::Error> {
+        let start = range.start.as_ref().ok_or("invalid IP range: missing start address")?;
+        let end = range.end.as_ref().ok_or("invalid IP range: missing end address")?;
+        let start = IpAddr::try_from(start)?;
+        let end = IpAddr::try_from(end)?;
+        if start.is_ipv4() != end.is_ipv4() {
+            return Err("invalid IP range: address family mismatch between start and end".into());
+        }
+
+        Ok((start, end))
+    }
+}
+
+impl Display for pb::IpRange {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match <(IpAddr, IpAddr)>::try_from(self) {
+            Ok((start, end)) => write!(f, "[{start}, {end}]"),
+            Err(..) => f.write_str("invalid"),
+        }
+    }
+}
+
+impl pb::IpRange {
+    /// Returns an iterator over the minimum set of CIDR blocks covering the
+    /// range.
+    ///
+    /// Each item is a `Contiguous<IpNetwork>` carrying the guarantee that the
+    /// prefix fits a contiguous slice of `[start, end]` — no non-contiguous
+    /// mask bits. On any conversion error (missing endpoint, family mismatch),
+    /// returns an empty iterator without panicking.
+    pub fn cidrs(&self) -> Box<dyn Iterator<Item = Contiguous<IpNetwork>> + '_> {
+        let (start, end) = match <(IpAddr, IpAddr)>::try_from(self) {
+            Ok(pair) => pair,
+            Err(..) => return Box::new(core::iter::empty()),
+        };
+
+        match (start, end) {
+            (IpAddr::V4(start), IpAddr::V4(end)) => {
+                Box::new(ipv4_range_to_networks(start, end).map(Contiguous::<IpNetwork>::from))
+            }
+            (IpAddr::V6(start), IpAddr::V6(end)) => {
+                Box::new(ipv6_range_to_networks(start, end).map(Contiguous::<IpNetwork>::from))
+            }
+            _ => Box::new(core::iter::empty()),
+        }
     }
 }
 
@@ -132,5 +194,88 @@ mod test {
     fn display_invalid_length() {
         let ip = pb::IpAddress { addr: vec![0u8; 5] };
         assert_eq!("invalid", ip.to_string());
+    }
+
+    #[test]
+    fn iprange_v4_round_trip() {
+        let start = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0));
+        let end = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 255));
+        let range = pb::IpRange::from((start, end));
+        let (got_start, got_end) = <(IpAddr, IpAddr)>::try_from(&range).unwrap();
+        assert_eq!(start, got_start);
+        assert_eq!(end, got_end);
+    }
+
+    #[test]
+    fn iprange_v6_round_trip() {
+        let start = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0));
+        let end = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        let range = pb::IpRange::from((start, end));
+        let (got_start, got_end) = <(IpAddr, IpAddr)>::try_from(&range).unwrap();
+        assert_eq!(start, got_start);
+        assert_eq!(end, got_end);
+    }
+
+    #[test]
+    fn iprange_try_from_rejects_family_mismatch() {
+        let start = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let end = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        let range = pb::IpRange {
+            start: Some(pb::IpAddress::from(start)),
+            end: Some(pb::IpAddress::from(end)),
+        };
+        assert!(<(IpAddr, IpAddr)>::try_from(&range).is_err());
+    }
+
+    #[test]
+    fn iprange_display_v4() {
+        let start = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0));
+        let end = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 255));
+        let range = pb::IpRange::from((start, end));
+        assert_eq!("[10.0.0.0, 10.0.0.255]", range.to_string());
+    }
+
+    #[test]
+    fn iprange_display_v6() {
+        let start = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0));
+        let end = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        let range = pb::IpRange::from((start, end));
+        assert_eq!("[2001:db8::, 2001:db8::1]", range.to_string());
+    }
+
+    #[test]
+    fn iprange_display_invalid() {
+        let range = pb::IpRange { start: None, end: None };
+        assert_eq!("invalid", range.to_string());
+    }
+
+    #[test]
+    fn iprange_cidrs_v4() {
+        let start = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0));
+        let end = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5));
+        let range = pb::IpRange::from((start, end));
+        let cidrs: Vec<String> = range.cidrs().map(|net| net.to_string()).collect();
+        assert_eq!(vec!["10.0.0.0/30", "10.0.0.4/31"], cidrs);
+    }
+
+    #[test]
+    fn iprange_cidrs_single() {
+        let addr = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1));
+        let range = pb::IpRange::from((addr, addr));
+        let cidrs: Vec<String> = range.cidrs().map(|net| net.to_string()).collect();
+        assert_eq!(1, cidrs.len());
+        assert_eq!("192.168.1.1/32", cidrs[0]);
+    }
+
+    #[test]
+    fn iprange_cidrs_invalid_family() {
+        let start = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        let end = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        let range = pb::IpRange {
+            start: Some(pb::IpAddress::from(start)),
+            end: Some(pb::IpAddress::from(end)),
+        };
+        let cidrs: Vec<Contiguous<IpNetwork>> = range.cidrs().collect();
+        assert_eq!(0, cidrs.len());
     }
 }

--- a/common/rust/filterpb/Cargo.toml
+++ b/common/rust/filterpb/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 rust-version = "1.85"
 
 [dependencies]
-netip = "0.2"
+netip = "0.3"
 prost = "0.13"
 serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.85"
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
-netip = "0.2"
+netip = "0.3"
 log = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }

--- a/modules/balancer2/cli/Cargo.toml
+++ b/modules/balancer2/cli/Cargo.toml
@@ -23,7 +23,7 @@ ptree = "0.5"
 tabled = { version = "0.18", features = ["ansi"] }
 log = "0.4"
 chrono = "0.4"
-netip = "0.2"
+netip = "0.3"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/modules/decap/cli/Cargo.toml
+++ b/modules/decap/cli/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.85"
 
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
-netip = "0.2"
+netip = "0.3"
 bitmap = { path = "../../../common/rust/bitmap", version = "0.1" }
 log = "0.4"
 clap = { version = "4.5", features = ["derive"] }

--- a/modules/dscp/cli/Cargo.toml
+++ b/modules/dscp/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
-netip = "0.2"
+netip = "0.3"
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 log = "0.4"

--- a/modules/forward/cli/Cargo.toml
+++ b/modules/forward/cli/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
-netip = "0.2"
+netip = "0.3"
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 colored = "3"

--- a/modules/nat64/cli/Cargo.toml
+++ b/modules/nat64/cli/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.84"
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
-netip = "0.2"
+netip = "0.3"
 log = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }

--- a/modules/route-mpls/cli/Cargo.toml
+++ b/modules/route-mpls/cli/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.84"
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
-netip = "0.2"
+netip = "0.3"
 log = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }

--- a/modules/route/cli/route/Cargo.toml
+++ b/modules/route/cli/route/Cargo.toml
@@ -17,7 +17,7 @@ prost = "0.13"
 tonic = { version = "0.13", features = ["gzip"] }
 tabled = { version = "0.18", features = ["ansi"] }
 serde = { version = "1", features = ["derive"] }
-netip = "0.2"
+netip = "0.3"
 serde_yaml = "0.9.34"
 
 [build-dependencies]

--- a/modules/route/cli/route/src/lib.rs
+++ b/modules/route/cli/route/src/lib.rs
@@ -28,18 +28,25 @@ pub struct FibDisplayEntry {
 }
 
 impl FibDisplayEntry {
-    /// Convert a FIBEntry proto message into one or more display
-    /// entries (one per nexthop for ECMP).
-    pub fn from_fib_entry(entry: routepb::FibEntry) -> Vec<Self> {
-        let prefix = entry.prefix;
-        entry
-            .nexthops
+    /// Convert a `FibRangeEntry` proto message into display rows.
+    ///
+    /// Emits one row per (CIDR, nexthop) pair. The CIDR list is produced by
+    /// decomposing the `range` field into the minimum set of covering
+    /// networks. Returns an empty `Vec` when `range` is absent or invalid.
+    pub fn from_range_entry(entry: routepb::FibRangeEntry) -> Vec<Self> {
+        let Some(range) = entry.range else {
+            return Vec::new();
+        };
+        let prefixes: Vec<String> = range.cidrs().map(|net| net.to_string()).collect();
+        prefixes
             .into_iter()
-            .map(|nh| FibDisplayEntry {
-                prefix: prefix.clone(),
-                dst_mac: format_mac(nh.dst_mac),
-                src_mac: format_mac(nh.src_mac),
-                device: nh.device,
+            .flat_map(|prefix| {
+                entry.nexthops.iter().map(move |nh| FibDisplayEntry {
+                    prefix: prefix.clone(),
+                    dst_mac: format_mac(nh.dst_mac),
+                    src_mac: format_mac(nh.src_mac),
+                    device: nh.device.clone(),
+                })
             })
             .collect()
     }

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -213,7 +213,7 @@ impl RouteService {
         let entries: Vec<FibDisplayEntry> = response
             .entries
             .into_iter()
-            .flat_map(FibDisplayEntry::from_fib_entry)
+            .flat_map(FibDisplayEntry::from_range_entry)
             .collect();
 
         if entries.is_empty() {

--- a/modules/route/controlplane/routepb/route.proto
+++ b/modules/route/controlplane/routepb/route.proto
@@ -4,6 +4,7 @@ package routepb;
 
 option go_package = "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb;routepb";
 
+import "common/commonpb/iprange.proto";
 import "common/commonpb/macaddr.proto";
 
 service RouteService {
@@ -47,8 +48,8 @@ message ShowFIBRequest {
 
 // ShowFIBResponse contains the list of FIB entries.
 message ShowFIBResponse {
-  // List of entries in the forwarding information base.
-  repeated FIBEntry entries = 1;
+  // List of FIB rows; each carries one range with its nexthops.
+  repeated FIBRangeEntry entries = 1;
 }
 
 // FIBEntry represents a single prefix in the FIB with its nexthops.
@@ -67,6 +68,16 @@ message FIBNexthop {
   commonpb.MACAddress src_mac = 2;
   // Egress device name.
   string device = 3;
+}
+
+// FIBRangeEntry represents a single dataplane FIB row.
+//
+// Carries the contiguous address range covered by one set of nexthops.
+// Used in ShowFIBResponse. UpdateFIBRequest still uses FIBEntry with a
+// CIDR string until a typed commonpb.IPPrefix lands.
+message FIBRangeEntry {
+  commonpb.IPRange range = 1;
+  repeated FIBNexthop nexthops = 2;
 }
 
 // UpdateFIBRequest carries the full FIB to be applied atomically.

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -9,7 +9,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/commonpb"
-	"github.com/yanet-platform/yanet2/common/go/xnetip"
 	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
 	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb"
 )
@@ -108,7 +107,7 @@ func (m *RouteService) ShowFIB(
 	}
 
 	response := &routepb.ShowFIBResponse{
-		Entries: make([]*routepb.FIBEntry, 0, len(entries)),
+		Entries: make([]*routepb.FIBRangeEntry, 0, len(entries)),
 	}
 	for _, e := range entries {
 		if req.GetIpv4Only() && e.AddressFamily != croute.AddressFamilyIPv4 {
@@ -127,20 +126,10 @@ func (m *RouteService) ShowFIB(
 			}
 		}
 
-		prefixes, ok := xnetip.RangeToCIDRs(e.PrefixFrom, e.PrefixTo)
-		if !ok {
-			m.log.Warn("skipping FIB entry with invalid address range",
-				zap.String("from", e.PrefixFrom.String()),
-				zap.String("to", e.PrefixTo.String()),
-			)
-			continue
-		}
-		for _, p := range prefixes {
-			response.Entries = append(response.Entries, &routepb.FIBEntry{
-				Prefix:   p.String(),
-				Nexthops: nexthops,
-			})
-		}
+		response.Entries = append(response.Entries, &routepb.FIBRangeEntry{
+			Range:    commonpb.NewIPRange(e.PrefixFrom, e.PrefixTo),
+			Nexthops: nexthops,
+		})
 	}
 	return response, nil
 }

--- a/operators/route/cli/neighbour/Cargo.toml
+++ b/operators/route/cli/neighbour/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 log = "0.4"
-netip = "0.2"
+netip = "0.3"
 tabled = { version = "0.18", features = ["ansi"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/operators/route/cli/route/Cargo.toml
+++ b/operators/route/cli/route/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 log = "0.4"
-netip = "0.2"
+netip = "0.3"
 colored = "3"
 serde = "1"
 tabled = { version = "0.18", features = ["ansi"] }

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -1,6 +1,6 @@
 import { createService, type CallOptions } from './client';
 import type { MACAddress } from './neighbours';
-import type { IPAddressWire } from '../utils/netip';
+import type { IPAddressWire, IPRangeWire } from '../utils/netip';
 
 // Route types
 
@@ -82,8 +82,13 @@ export interface ShowFIBRequest {
     ipv6_only?: boolean;
 }
 
+export interface FIBRangeEntry {
+    range?: IPRangeWire;
+    nexthops?: FIBNexthop[];
+}
+
 export interface ShowFIBResponse {
-    entries?: FIBEntry[];
+    entries?: FIBRangeEntry[];
 }
 
 export interface FIBEntry {

--- a/web/src/pages/modules/route/useFIBDraft.ts
+++ b/web/src/pages/modules/route/useFIBDraft.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useReducer, useState } from 'react';
 import { API } from '../../../api';
 import { toaster } from '../../../utils';
-import type { FIBEntry, FIBNexthop } from '../../../api/routes';
+import type { FIBEntry, FIBNexthop, FIBRangeEntry } from '../../../api/routes';
+import { ipRangeToCIDRs } from '../../../utils/netip';
 import type { FIBRowItem } from './types';
 import { fibDraftReducer, initialFIBDraftState } from './fibDraftReducer';
 import type { FIBDraftAction } from './fibDraftReducer';
@@ -9,23 +10,25 @@ import type { FIBDraftAction } from './fibDraftReducer';
 let rowIdCounter = 0;
 const newRowId = (): string => `row-${++rowIdCounter}-${Date.now()}`;
 
-/** Flatten FIBEntry array into flat (prefix, nexthop) row items. */
-export const flattenFIBEntries = (entries: FIBEntry[]): FIBRowItem[] => {
+/** Flatten FIBRangeEntry array into flat (prefix, nexthop) row items. */
+export const flattenFIBEntries = (entries: FIBRangeEntry[]): FIBRowItem[] => {
     const rows: FIBRowItem[] = [];
     for (const entry of entries) {
-        const prefix = entry.prefix || '';
+        const cidrs = ipRangeToCIDRs(entry.range);
         const nexthops = entry.nexthops || [];
-        if (nexthops.length === 0) {
-            rows.push({ id: newRowId(), prefix, dst_mac: '', src_mac: '', device: '' });
-        } else {
-            for (const nh of nexthops) {
-                rows.push({
-                    id: newRowId(),
-                    prefix,
-                    dst_mac: nh.dst_mac?.addr || '',
-                    src_mac: nh.src_mac?.addr || '',
-                    device: nh.device || '',
-                });
+        for (const prefix of cidrs) {
+            if (nexthops.length === 0) {
+                rows.push({ id: newRowId(), prefix, dst_mac: '', src_mac: '', device: '' });
+            } else {
+                for (const nh of nexthops) {
+                    rows.push({
+                        id: newRowId(),
+                        prefix,
+                        dst_mac: nh.dst_mac?.addr || '',
+                        src_mac: nh.src_mac?.addr || '',
+                        device: nh.device || '',
+                    });
+                }
             }
         }
     }

--- a/web/src/utils/netip.ts
+++ b/web/src/utils/netip.ts
@@ -682,6 +682,15 @@ export type IPAddressWire = {
     addr?: string | number[] | Uint8Array;
 };
 
+// Wire-format shape of an IP range as returned by the gRPC-JSON gateway.
+// Both endpoints are plain IP strings — Go's IPRange.MarshalJSON flattens
+// the nested IPAddress shape into top-level strings rather than nesting
+// {addr:"..."} objects.
+export interface IPRangeWire {
+    start?: string;
+    end?: string;
+}
+
 // Decode a wire IPAddress into a human-readable IP string. Returns an
 // empty string when the message is missing or has an empty addr.
 // The canonical wire form from Go's MarshalJSON is a plain IP string.
@@ -702,4 +711,90 @@ export const stringToIPAddress = (s: string): IPAddressWire | undefined => {
     const parsed = parseIPAddress(s);
     if (!parsed.ok) return undefined;
     return { addr: s };
+};
+
+// Convert an IP bytes array to a BigInt.
+const bytesToBigInt = (bytes: number[]): bigint => {
+    let result = 0n;
+    for (const b of bytes) {
+        result = (result << 8n) | BigInt(b);
+    }
+    return result;
+};
+
+// Convert a BigInt back to a bytes array of the given length.
+const bigIntToBytes = (value: bigint, length: number): number[] => {
+    const bytes: number[] = new Array(length).fill(0);
+    for (let i = length - 1; i >= 0; i--) {
+        bytes[i] = Number(value & 0xffn);
+        value >>= 8n;
+    }
+    return bytes;
+};
+
+// Compute the last address of a prefix (addr | ~mask).
+const lastAddrOfPrefix = (addrBits: bigint, prefixLen: number, totalBits: number): bigint => {
+    const hostBits = totalBits - prefixLen;
+    const mask = hostBits >= totalBits ? 0n : (1n << BigInt(hostBits)) - 1n;
+    return addrBits | mask;
+};
+
+// Decompose an IP range into the minimal set of CIDR prefix strings.
+// Mirrors xnetip.RangeToCIDRs from the Go common library.
+// Returns [] for missing/invalid ranges or family-mismatched endpoints.
+export const ipRangeToCIDRs = (range: IPRangeWire | undefined): string[] => {
+    if (!range) return [];
+
+    const startStr = range.start ?? '';
+    const endStr = range.end ?? '';
+    if (!startStr || !endStr) return [];
+
+    const startBytes = parseIPToBytes(startStr);
+    const endBytes = parseIPToBytes(endStr);
+    if (!startBytes || !endBytes) return [];
+    if (startBytes.length !== endBytes.length) return [];
+
+    const totalBytes = startBytes.length;
+    const totalBits = totalBytes * 8;
+
+    let curr = bytesToBigInt(startBytes);
+    const to = bytesToBigInt(endBytes);
+    if (curr > to) return [];
+
+    const results: string[] = [];
+
+    while (curr <= to) {
+        let prefixLen = totalBits;
+
+        while (prefixLen > 0) {
+            // Try a larger block (one fewer prefix bit).
+            const candidate = prefixLen - 1;
+            const hostBits = totalBits - candidate;
+            // Check alignment: curr must be the network address for this prefix.
+            const alignMask = hostBits >= totalBits ? 0n : (1n << BigInt(hostBits)) - 1n;
+            if ((curr & alignMask) !== 0n) break;
+            // Check the block does not overshoot the end address.
+            if (lastAddrOfPrefix(curr, candidate, totalBits) > to) break;
+            prefixLen = candidate;
+        }
+
+        const addrStr = formatIPFromBytes(bigIntToBytes(curr, totalBytes));
+        results.push(`${addrStr}/${prefixLen}`);
+
+        const last = lastAddrOfPrefix(curr, prefixLen, totalBits);
+        if (last === to) break;
+        curr = last + 1n;
+    }
+
+    return results;
+};
+
+// Return the "[start, end]" string representation of an IP range.
+// Returns '' for missing or invalid ranges.
+export const ipRangeToString = (range: IPRangeWire | undefined): string => {
+    if (!range) return '';
+    const start = range.start ?? '';
+    const end = range.end ?? '';
+    if (!start || !end) return '';
+    return `[${start}, ${end}]`;
 };


### PR DESCRIPTION
- Move IPRange to [CIDR] format from CP to CLI/WEB.
- No longer pass strings.