### PR TITLE
feat(web): add ACL NG page

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -23,7 +23,7 @@
 
         #root {
             height: 100vh;
-            width: 100vw;
+            margin: 0;
         }
     </style>
 </head>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ const importDevices = () => import('./pages/builtin/devices/DevicesPage');
 const importForward = () => import('./pages/modules/forward/ForwardPage');
 const importDecap = () => import('./pages/modules/decap/DecapPage');
 const importAcl = () => import('./pages/modules/acl/AclPage');
+const importAclNg = () => import('./pages/modules/acl-ng/AclNgPage');
 const importPdump = () => import('./pages/modules/pdump/PdumpPage');
 const importModulesRoute = () => import('./pages/modules/route/RoutePage');
 const importOperatorsRoute = () => import('./pages/operators/route/RoutePage');
@@ -25,6 +26,7 @@ const pageImporters = [
     importForward,
     importDecap,
     importAcl,
+    importAclNg,
     importPdump,
     importModulesRoute,
     importOperatorsRoute,
@@ -38,6 +40,7 @@ const DevicesPage = lazy(importDevices);
 const ForwardPage = lazy(importForward);
 const DecapPage = lazy(importDecap);
 const AclPage = lazy(importAcl);
+const AclNgPage = lazy(importAclNg);
 const PdumpPage = lazy(importPdump);
 const ModulesRoutePage = lazy(importModulesRoute);
 const OperatorsRoutePage = lazy(importOperatorsRoute);
@@ -146,6 +149,7 @@ const AppContent = (): React.JSX.Element => {
                             <Route path="/modules/forward" element={<ForwardPage />} />
                             <Route path="/modules/decap" element={<DecapPage />} />
                             <Route path="/modules/acl" element={<AclPage />} />
+                            <Route path="/modules/acl-ng" element={<AclNgPage />} />
                             <Route path="/modules/pdump" element={<PdumpPage />} />
                             <Route path="/modules/route" element={<ModulesRoutePage />} />
                             <Route path="/operators/route" element={<OperatorsRoutePage />} />

--- a/web/src/MainMenu.tsx
+++ b/web/src/MainMenu.tsx
@@ -68,6 +68,7 @@ const MainMenu = ({ currentPage, onPageChange, renderContent, disabled = false }
         createMenuItem('modules/route', 'Route', Route),
         createMenuItem('modules/decap', 'Decap', LayoutCellsLarge),
         createMenuItem('modules/acl', 'ACL', Shield),
+        createMenuItem('modules/acl-ng', 'ACL NG', Shield),
         createMenuItem('modules/pdump', 'Pdump', CirclePlay),
         createDivider('__div_2'),
         createSectionHeader('__section_operators', 'Operators'),

--- a/web/src/api/acl-ng.ts
+++ b/web/src/api/acl-ng.ts
@@ -1,0 +1,111 @@
+import { createService, type CallOptions } from './client';
+
+// Types matching aclpb/acl.proto and filterpb/filter.proto exactly.
+// No Action.counter, no keep_state, no MapConfig, no SyncConfig, no DUMP kind.
+
+export interface IPNet {
+    addr?: string | Uint8Array | number[];
+    mask?: string | Uint8Array | number[];
+}
+
+export interface PortRange {
+    from?: number;
+    to?: number;
+}
+
+export interface ProtoRange {
+    from?: number;
+    to?: number;
+}
+
+export interface VlanRange {
+    from?: number;
+    to?: number;
+}
+
+export interface Device {
+    name?: string;
+}
+
+export enum ActionKind {
+    ACTION_KIND_PASS = 0,
+    ACTION_KIND_DENY = 1,
+    ACTION_KIND_COUNT = 2,
+    ACTION_KIND_CHECK_STATE = 4,
+    ACTION_KIND_CREATE_STATE = 5,
+    ACTION_KIND_LOG = 6,
+}
+
+/** Human-readable label for each ActionKind. */
+export const ACTION_KIND_LABELS: Record<ActionKind, string> = {
+    [ActionKind.ACTION_KIND_PASS]: 'pass',
+    [ActionKind.ACTION_KIND_DENY]: 'deny',
+    [ActionKind.ACTION_KIND_COUNT]: 'count',
+    [ActionKind.ACTION_KIND_CHECK_STATE]: '?state',
+    [ActionKind.ACTION_KIND_CREATE_STATE]: '+state',
+    [ActionKind.ACTION_KIND_LOG]: 'log',
+};
+
+export interface Action {
+    kind?: ActionKind;
+}
+
+export interface Rule {
+    actions?: Action[];
+    counter?: string;
+    devices?: Device[];
+    vlan_ranges?: VlanRange[];
+    srcs?: IPNet[];
+    dsts?: IPNet[];
+    proto_ranges?: ProtoRange[];
+    src_port_ranges?: PortRange[];
+    dst_port_ranges?: PortRange[];
+}
+
+export interface ListConfigsResponse {
+    configs?: string[];
+}
+
+export interface ShowConfigRequest {
+    name?: string;
+}
+
+export interface ShowConfigResponse {
+    name?: string;
+    rules?: Rule[];
+    fwstate_name?: string;
+}
+
+export interface UpdateConfigRequest {
+    name?: string;
+    rules?: Rule[];
+}
+
+export interface UpdateConfigResponse {}
+
+export interface DeleteConfigRequest {
+    name?: string;
+}
+
+export interface DeleteConfigResponse {
+    deleted?: boolean;
+}
+
+const aclNgService = createService('aclpb.ACLService');
+
+export const aclng = {
+    listConfigs: (options?: CallOptions): Promise<ListConfigsResponse> =>
+        aclNgService.call<ListConfigsResponse>('ListConfigs', options),
+
+    showConfig: (request: ShowConfigRequest, options?: CallOptions): Promise<ShowConfigResponse> =>
+        aclNgService.callWithBody<ShowConfigResponse>('ShowConfig', request, options),
+
+    updateConfig: (request: UpdateConfigRequest, options?: CallOptions): Promise<UpdateConfigResponse> =>
+        aclNgService.callWithBody<UpdateConfigResponse>('UpdateConfig', request, {
+            compress: true,
+            ...options,
+        }),
+
+    deleteConfig: (request: DeleteConfigRequest, options?: CallOptions): Promise<DeleteConfigResponse> =>
+        aclNgService.callWithBody<DeleteConfigResponse>('DeleteConfig', request, options),
+};

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -8,6 +8,7 @@ export * from './pipelines';
 export * from './devices';
 export * from './decap';
 export * from './acl';
+export { aclng, ACTION_KIND_LABELS } from './acl-ng';
 export * from './forward';
 export * from './counters';
 
@@ -19,6 +20,7 @@ import { pipelines } from './pipelines';
 import { devices } from './devices';
 import { decap } from './decap';
 import { acl } from './acl';
+import { aclng } from './acl-ng';
 import { forward } from './forward';
 import { counters } from './counters';
 
@@ -32,6 +34,7 @@ export const API = {
     devices,
     decap,
     acl,
+    aclng,
     forward,
     counters,
 };

--- a/web/src/components/YamlIOModal.tsx
+++ b/web/src/components/YamlIOModal.tsx
@@ -5,6 +5,16 @@ import { toaster, copyToClipboard } from '../utils';
 
 export type YamlIOMode = 'import' | 'export' | null;
 
+/** Files larger than this threshold suppress the textarea preview. */
+const LARGE_FILE_THRESHOLD = 1_000_000;
+
+/** Progress information reported by an async import worker. */
+export interface ParseProgress {
+    stage: 'yaml' | 'rules' | string;
+    done: number;
+    total: number;
+}
+
 export interface YamlIOModalProps {
     /** Config name used in export metadata and download filename. */
     configName: string;
@@ -16,8 +26,17 @@ export interface YamlIOModalProps {
     downloadPrefix?: string;
     /** YAML text for export mode. Computed once when the modal opens. */
     exportYaml: () => string;
-    /** Parse the textarea text and apply the import. Should throw on failure. */
-    onImport: (text: string) => void;
+    /**
+     * Parse the textarea text and apply the import synchronously. Should throw on failure.
+     * Either onImport or onImportAsync must be supplied.
+     */
+    onImport?: (text: string) => void;
+    /**
+     * Parse the textarea text asynchronously. Receives an onProgress callback that the
+     * caller should invoke for each progress event. Should reject with an Error on failure.
+     * Either onImport or onImportAsync must be supplied.
+     */
+    onImportAsync?: (text: string, onProgress: (p: ParseProgress) => void) => Promise<void>;
     /** Toast key prefix, e.g. "fw-yaml" or "fib-yaml". */
     toastPrefix: string;
     /** Placeholder YAML shown in import textarea. */
@@ -45,6 +64,7 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
     downloadPrefix,
     exportYaml,
     onImport,
+    onImportAsync,
     toastPrefix,
     importPlaceholder,
     exportFooterHint,
@@ -53,16 +73,40 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
     importExtraControls,
 }) => {
     const [showModal, setShowModal] = useState<YamlIOMode>(null);
-    const [text, setText] = useState('');
+    // textContent holds the actual YAML string; textarea only shows it when small.
+    const textContent = useRef('');
+    // Preview-safe string bound to the textarea (empty for large files).
+    const [previewText, setPreviewText] = useState('');
+    const [isLargeFile, setIsLargeFile] = useState(false);
+    const [loadProgress, setLoadProgress] = useState<number | null>(null);
+    const [isParsing, setIsParsing] = useState(false);
+    const [parseProgress, setParseProgress] = useState<ParseProgress | null>(null);
     const [parseError, setParseError] = useState<string | null>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+    const applyText = (content: string): void => {
+        textContent.current = content;
+        if (content.length > LARGE_FILE_THRESHOLD) {
+            setIsLargeFile(true);
+            setPreviewText('');
+        } else {
+            setIsLargeFile(false);
+            setPreviewText(content);
+        }
+    };
+
     useEffect(() => {
         if (showModal === 'export') {
-            setText(exportYaml());
+            const yamlText = exportYaml();
+            applyText(yamlText);
         } else if (showModal === 'import') {
-            setText('');
+            textContent.current = '';
+            setPreviewText('');
+            setIsLargeFile(false);
+            setLoadProgress(null);
             setParseError(null);
+            setIsParsing(false);
+            setParseProgress(null);
         }
     // Intentionally re-run only when modal opens, not on every data update.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -79,7 +123,7 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
 
     const handleDownload = (): void => {
         const filename = downloadPrefix ?? configName;
-        const blob = new Blob([text], { type: 'text/yaml' });
+        const blob = new Blob([textContent.current], { type: 'text/yaml' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
@@ -91,7 +135,7 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
 
     const handleCopy = async (): Promise<void> => {
         try {
-            await copyToClipboard(text);
+            await copyToClipboard(textContent.current);
             toaster.success(`${toastPrefix}-copy`, 'Copied to clipboard.');
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
@@ -101,23 +145,121 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
 
     const handleImport = (): void => {
         setParseError(null);
-        try {
-            onImport(text);
-            setShowModal(null);
-        } catch (e) {
-            setParseError((e as Error).message);
+        setParseProgress(null);
+        setIsParsing(true);
+
+        if (onImportAsync) {
+            onImportAsync(textContent.current, (p) => setParseProgress(p))
+                .then(() => {
+                    setIsParsing(false);
+                    setParseProgress(null);
+                    setShowModal(null);
+                })
+                .catch((e: unknown) => {
+                    setIsParsing(false);
+                    setParseProgress(null);
+                    setParseError((e as Error).message);
+                });
+            return;
         }
+
+        // Defer the parse via setTimeout so the browser can paint the spinner
+        // before the synchronous YAML parse blocks the main thread.
+        setTimeout(() => {
+            try {
+                onImport?.(textContent.current);
+                setIsParsing(false);
+                setShowModal(null);
+            } catch (e) {
+                setIsParsing(false);
+                setParseError((e as Error).message);
+            }
+        }, 0);
     };
 
     const handleFileLoad = (file: File): void => {
+        setLoadProgress(0);
+        setParseError(null);
         const reader = new FileReader();
-        reader.onload = (e) => setText(e.target?.result as string ?? '');
+
+        reader.onloadstart = (): void => {
+            setLoadProgress(0);
+        };
+
+        reader.onprogress = (e: ProgressEvent): void => {
+            if (e.lengthComputable && e.total > 0) {
+                setLoadProgress(Math.round((e.loaded / e.total) * 100));
+            }
+        };
+
+        reader.onload = (e): void => {
+            const content = e.target?.result as string ?? '';
+            setLoadProgress(null);
+            applyText(content);
+        };
+
+        reader.onerror = (): void => {
+            setLoadProgress(null);
+            setParseError('Failed to read file.');
+        };
+
         reader.readAsText(file);
     };
 
     const closeModal = (): void => {
         setShowModal(null);
         setParseError(null);
+        setIsParsing(false);
+        setLoadProgress(null);
+        setParseProgress(null);
+    };
+
+    const hasContent = textContent.current.trim().length > 0;
+
+    const renderParseStatus = (): React.ReactNode => {
+        if (!isParsing) return null;
+
+        if (parseProgress) {
+            const { stage, done, total } = parseProgress;
+            if (stage === 'yaml') {
+                const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+                return (
+                    <div style={{ marginTop: 6 }}>
+                        <div style={{ color: 'var(--fw-text-3)', fontSize: 12, marginBottom: 4 }}>
+                            Parsing YAML… {done < total ? '' : '100%'}
+                        </div>
+                        <div className="fw-parse-progress">
+                            <div
+                                className="fw-parse-progress__bar"
+                                style={{ width: `${pct}%` }}
+                            />
+                        </div>
+                    </div>
+                );
+            }
+            if (stage === 'rules') {
+                const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+                return (
+                    <div style={{ marginTop: 6 }}>
+                        <div style={{ color: 'var(--fw-text-3)', fontSize: 12, marginBottom: 4 }}>
+                            Converting rules: {done.toLocaleString()} / {total.toLocaleString()} ({pct}%)
+                        </div>
+                        <div className="fw-parse-progress">
+                            <div
+                                className="fw-parse-progress__bar"
+                                style={{ width: `${pct}%` }}
+                            />
+                        </div>
+                    </div>
+                );
+            }
+        }
+
+        return (
+            <div style={{ marginTop: 6, color: 'var(--fw-text-3)', fontSize: 12 }}>
+                Parsing YAML…
+            </div>
+        );
     };
 
     return (
@@ -173,21 +315,37 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                                             }}
                                         />
                                     </label>
-                                    <span className="fw-modal__or">or paste below</span>
+                                    {loadProgress !== null && (
+                                        <span className="fw-modal__load-progress">
+                                            Reading… {loadProgress}%
+                                        </span>
+                                    )}
+                                    {loadProgress === null && (
+                                        <span className="fw-modal__or">or paste below</span>
+                                    )}
                                     {importExtraControls}
                                 </div>
                             )}
-                            <textarea
-                                ref={textareaRef}
-                                className="fw-code-area"
-                                value={text}
-                                onChange={(e) => {
-                                    setText(e.target.value);
-                                    setParseError(null);
-                                }}
-                                placeholder={showModal === 'import' ? importPlaceholder : ''}
-                                spellCheck={false}
-                            />
+                            {isLargeFile ? (
+                                <div className="fw-modal__large-file-notice">
+                                    Large file loaded ({(textContent.current.length / 1_048_576).toFixed(1)} MB) — preview suppressed to avoid browser slowdown.
+                                </div>
+                            ) : (
+                                <textarea
+                                    ref={textareaRef}
+                                    className="fw-code-area"
+                                    value={previewText}
+                                    onChange={(e) => {
+                                        const v = e.target.value;
+                                        textContent.current = v;
+                                        setPreviewText(v);
+                                        setParseError(null);
+                                    }}
+                                    placeholder={showModal === 'import' ? importPlaceholder : ''}
+                                    spellCheck={false}
+                                />
+                            )}
+                            {renderParseStatus()}
                             {parseError && (
                                 <div style={{ marginTop: 6, color: 'var(--g-color-text-danger)', fontSize: 12 }}>
                                     {parseError}
@@ -229,9 +387,9 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                                         type="button"
                                         className="fw-btn fw-btn--primary"
                                         onClick={handleImport}
-                                        disabled={!text.trim()}
+                                        disabled={!hasContent || isParsing || loadProgress !== null}
                                     >
-                                        {importButtonLabel}
+                                        {isParsing ? 'Parsing…' : importButtonLabel}
                                     </button>
                                 )}
                             </div>

--- a/web/src/hooks/useContainerHeight.ts
+++ b/web/src/hooks/useContainerHeight.ts
@@ -3,6 +3,7 @@ import { useLayoutEffect, useState } from 'react';
 export const useContainerHeight = (
     containerRef: React.RefObject<HTMLElement | null>,
     minHeight = 300,
+    bottomOffset = 20,
 ): number => {
     const [height, setHeight] = useState(0);
 
@@ -12,7 +13,7 @@ export const useContainerHeight = (
 
         const updateHeight = () => {
             const rect = el.getBoundingClientRect();
-            const available = window.innerHeight - rect.top - 20;
+            const available = window.innerHeight - rect.top - bottomOffset;
             setHeight(Math.max(minHeight, available));
         };
 
@@ -24,7 +25,7 @@ export const useContainerHeight = (
             resizeObserver.disconnect();
             window.removeEventListener('resize', updateHeight);
         };
-    }, [containerRef, minHeight]);
+    }, [containerRef, minHeight, bottomOffset]);
 
     return height;
 };

--- a/web/src/pages/_shared/draft/VirtualDraftTable.tsx
+++ b/web/src/pages/_shared/draft/VirtualDraftTable.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo, useRef, memo } from 'react';
+import { useContainerHeight } from '../../../hooks';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Checkbox } from '@gravity-ui/uikit';
 import DraftActionButtons from './DraftActionButtons';
@@ -227,6 +228,8 @@ export const VirtualDraftTable = <T extends { id: string }>({
     emptyMessage,
 }: VirtualDraftTableProps<T>): React.JSX.Element => {
     const scrollRef = useRef<HTMLDivElement>(null);
+    const wrapRef = useRef<HTMLDivElement>(null);
+    const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT + 20);
 
     const {
         hoveredRow,
@@ -279,7 +282,7 @@ export const VirtualDraftTable = <T extends { id: string }>({
     }, [virtualRows, visibleRows.length]);
 
     return (
-        <div className="fw-tbl-wrap">
+        <div ref={wrapRef} className="fw-tbl-wrap">
             <div className="fw-tbl-header-row">
                 <div className="fw-vtbl-header" style={{ height: HEADER_HEIGHT, minWidth: totalWidth }}>
                     <div
@@ -307,7 +310,11 @@ export const VirtualDraftTable = <T extends { id: string }>({
                 />
             </div>
 
-            <div ref={setScrollRef} className="fw-vtbl-body">
+            <div
+                ref={setScrollRef}
+                className="fw-vtbl-body"
+                style={bodyHeight > 0 ? { flex: '0 0 auto', height: bodyHeight } : undefined}
+            >
                 {visibleRows.length === 0 ? (
                     <div className="fw-table-empty">{emptyMessage}</div>
                 ) : (

--- a/web/src/pages/modules/acl-ng/AclNgPage.tsx
+++ b/web/src/pages/modules/acl-ng/AclNgPage.tsx
@@ -1,0 +1,352 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { Button, Flex, Icon, Text, TextInput } from '@gravity-ui/uikit';
+import { Magnifier, Pause, Play, Plus } from '@gravity-ui/icons';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
+import { useAclNgDraft } from './useAclNgDraft';
+import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
+import type { Rule } from '../../../api/acl-ng';
+import type { RuleItem, RuleDraft } from './types';
+import { rulesToNgItems, expandRuleItem, draftToRule, useKeyboardShortcuts } from './hooks';
+import { DRAWER_TRANSITION_MS } from './RuleTable';
+import RuleTable from './RuleTable';
+import RuleDrawer from './RuleDrawer';
+import type { RuleDrawerHandle } from './RuleDrawer';
+import YamlIO, { type ImportMode } from './YamlIO';
+import { SaveDiffModal } from './SaveDiffModal';
+import { useAclNgRuleCounters } from './useAclNgRuleCounters';
+import { AddConfigModal, DeleteConfigModal, BulkDeleteModal } from '../../_shared/draft';
+import '../../../styles/draft-page.scss';
+import './acl-ng.scss';
+
+const AclNgPage: React.FC = () => {
+    const {
+        draftConfigs,
+        loading,
+        draftRules,
+        draftRuleIds,
+        serverRules,
+        isDirty,
+        anyDirty,
+        dispatchDraft,
+        saveConfig,
+        discardConfig,
+    } = useAclNgDraft();
+
+    const [activeConfig, setActiveConfig] = useState<string>('');
+    const [paused, setPaused] = useState(false);
+    const [enabledCounterNames, setEnabledCounterNames] = useState<Set<string>>(new Set());
+    const [search, setSearch] = useState('');
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [activeRowId, setActiveRowId] = useState<string | null>(null);
+    const [drawer, setDrawer] = useState<{ open: boolean; mode: 'add' | 'edit'; item: RuleItem | null }>({
+        open: false,
+        mode: 'add',
+        item: null,
+    });
+    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+    const [addConfigOpen, setAddConfigOpen] = useState(false);
+    const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
+    const [diffModalOpen, setDiffModalOpen] = useState(false);
+    const searchRef = useRef<HTMLInputElement>(null);
+    const drawerRef = useRef<RuleDrawerHandle>(null);
+
+    useUnsavedChangesBlocker(anyDirty);
+
+    const currentConfig = activeConfig || draftConfigs[0] || '';
+    const rawRules: Rule[] = draftRules(currentConfig);
+    const rawIds: string[] = draftRuleIds(currentConfig);
+    const allItems = useMemo(() => rulesToNgItems(rawRules, rawIds), [rawRules, rawIds]);
+
+    const { rates } = useAclNgRuleCounters(currentConfig, allItems, enabledCounterNames, !paused);
+
+    const ruleCounts = useMemo((): Map<string, number> => {
+        const m = new Map<string, number>();
+        draftConfigs.forEach(c => m.set(c, draftRules(c).length));
+        return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [draftConfigs, draftRules]);
+
+    const dirtySet = useMemo((): Set<string> => {
+        const s = new Set<string>();
+        draftConfigs.forEach(c => { if (isDirty(c)) s.add(c); });
+        return s;
+    }, [draftConfigs, isDirty]);
+
+    const visibleItems = useMemo((): RuleItem[] => {
+        const q = search.trim().toLowerCase();
+        if (!q) return allItems;
+        return allItems.filter(item => {
+            // Cheap checks first (no CIDR decode).
+            if (item.counter.toLowerCase().includes(q)) return true;
+            // Decode CIDRs and device names only when needed.
+            const expanded = expandRuleItem(item.rule);
+            return (
+                expanded.sourceCidrs.some(s => s.toLowerCase().includes(q)) ||
+                expanded.dstCidrs.some(s => s.toLowerCase().includes(q)) ||
+                expanded.deviceNames.some(d => d.toLowerCase().includes(q))
+            );
+        });
+    }, [allItems, search]);
+
+    const openAdd = useCallback((): void => {
+        setActiveRowId(null);
+        setDrawer({ open: true, mode: 'add', item: null });
+    }, []);
+
+    const openEdit = useCallback((item: RuleItem): void => {
+        setActiveRowId(item.id);
+        setDrawer({ open: true, mode: 'edit', item });
+    }, []);
+
+    const closeDrawer = useCallback((): void => {
+        setDrawer(d => ({ ...d, open: false }));
+        setTimeout(() => {
+            setActiveRowId(null);
+            setDrawer(d => ({ ...d, item: null }));
+        }, DRAWER_TRANSITION_MS);
+    }, []);
+
+    const handleDrawerApply = useCallback((draft: RuleDraft): void => {
+        const rule = draftToRule(draft);
+        if (drawer.mode === 'add') {
+            dispatchDraft({ type: 'ADD_RULE', configName: currentConfig, rule });
+        } else if (drawer.item) {
+            dispatchDraft({ type: 'UPDATE_RULE_AT_INDEX', configName: currentConfig, index: drawer.item.index, rule });
+        }
+        closeDrawer();
+    }, [drawer, currentConfig, dispatchDraft, closeDrawer]);
+
+    const handleDeleteItem = useCallback((item: RuleItem): void => {
+        dispatchDraft({ type: 'REMOVE_RULES', configName: currentConfig, indices: [item.index] });
+        closeDrawer();
+    }, [currentConfig, dispatchDraft, closeDrawer]);
+
+    const handleDuplicate = useCallback((item: RuleItem): void => {
+        setActiveRowId(null);
+        setDrawer({ open: true, mode: 'add', item: { ...item, rule: { ...item.rule } } });
+    }, []);
+
+    const handleBulkDelete = useCallback((): void => {
+        const indices = visibleItems
+            .filter(item => selectedIds.has(item.id))
+            .map(item => item.index);
+        dispatchDraft({ type: 'REMOVE_RULES', configName: currentConfig, indices });
+        setSelectedIds(new Set());
+        setDeleteConfirmOpen(false);
+    }, [selectedIds, visibleItems, currentConfig, dispatchDraft]);
+
+    const handleDeleteConfig = useCallback((): void => {
+        dispatchDraft({ type: 'DELETE_CONFIG', configName: currentConfig });
+        setActiveConfig('');
+        setDeleteConfigOpen(false);
+    }, [currentConfig, dispatchDraft]);
+
+    const handleSave = useCallback(async (): Promise<void> => {
+        await saveConfig(currentConfig);
+        setDiffModalOpen(false);
+    }, [currentConfig, saveConfig]);
+
+    const handleSavePress = useCallback((): void => {
+        if (drawer.open) {
+            drawerRef.current?.flushAndApply();
+        }
+        setDiffModalOpen(true);
+    }, [drawer.open]);
+
+    const handleToggleCounter = useCallback((counterName: string): void => {
+        setEnabledCounterNames(prev => {
+            const next = new Set(prev);
+            if (next.has(counterName)) {
+                next.delete(counterName);
+            } else {
+                next.add(counterName);
+            }
+            return next;
+        });
+    }, []);
+
+    const handleDiscard = useCallback((): void => {
+        discardConfig(currentConfig);
+    }, [currentConfig, discardConfig]);
+
+    const handleImportYaml = useCallback((importedConfigName: string, rules: Rule[], mode: ImportMode): void => {
+        const target = importedConfigName || currentConfig;
+        if (mode === 'append') {
+            const current = draftRules(target);
+            dispatchDraft({ type: 'REPLACE_ALL_RULES', configName: target, rules: [...current, ...rules] });
+        } else {
+            dispatchDraft({ type: 'REPLACE_ALL_RULES', configName: target, rules });
+        }
+        setActiveConfig(target);
+    }, [currentConfig, draftRules, dispatchDraft]);
+
+    useKeyboardShortcuts({
+        onNewRule: openAdd,
+        onFocusSearch: () => searchRef.current?.focus(),
+        onEscape: closeDrawer,
+        drawerOpen: drawer.open,
+    });
+
+    const currentIsDirty = isDirty(currentConfig);
+
+    const pageHeader = (
+        <Flex alignItems="center" gap={4} style={{ width: '100%' }}>
+            <Text variant="header-1">ACL NG</Text>
+            <Flex grow />
+            <div style={{ flexBasis: 380, flexShrink: 1 }}>
+                <TextInput
+                    controlRef={searchRef}
+                    value={search}
+                    onUpdate={setSearch}
+                    placeholder="Search rules… (/)"
+                    startContent={
+                        <Flex alignItems="center" justifyContent="center" style={{ paddingInline: 8, color: 'var(--g-color-text-hint)' }}>
+                            <Icon data={Magnifier} size={16} />
+                        </Flex>
+                    }
+                    hasClear
+                    type="search"
+                />
+            </div>
+            {enabledCounterNames.size > 0 && (
+                <Button
+                    view="outlined"
+                    onClick={() => setPaused(p => !p)}
+                    title={paused ? 'Resume counter polling' : 'Pause counter polling'}
+                >
+                    <Icon data={paused ? Play : Pause} size={16} />
+                    {paused ? 'Resume' : 'Pause'}
+                </Button>
+            )}
+            {currentConfig && (
+                <YamlIO
+                    configName={currentConfig}
+                    rules={rawRules}
+                    onImport={handleImportYaml}
+                />
+            )}
+            <Button view="action" onClick={openAdd}>
+                <Icon data={Plus} size={16} />
+                Add Rule
+            </Button>
+        </Flex>
+    );
+
+    if (loading) {
+        return (
+            <PageLayout header={pageHeader}>
+                <PageLoader loading size="l" />
+            </PageLayout>
+        );
+    }
+
+    return (
+        <PageLayout header={pageHeader}>
+            <div className="fw-page">
+                {draftConfigs.length === 0 ? (
+                    <div className="fw-empty-page">
+                        <div className="fw-empty-page__message">
+                            No ACL NG configurations found.
+                        </div>
+                        <Button view="action" onClick={() => setAddConfigOpen(true)}>
+                            Add Config
+                        </Button>
+                    </div>
+                ) : (
+                    <>
+                        <ConfigTabStrip
+                            configs={draftConfigs}
+                            activeConfig={currentConfig}
+                            counts={ruleCounts}
+                            dirtyConfigs={dirtySet}
+                            onSelect={c => {
+                                setActiveConfig(c);
+                                setSelectedIds(new Set());
+                                setActiveRowId(null);
+                            }}
+                            onAddConfig={() => setAddConfigOpen(true)}
+                        />
+
+                        <div className="fw-content">
+                            <RuleTable
+                                items={visibleItems}
+                                selectedIds={selectedIds}
+                                activeRowId={activeRowId}
+                                onSelectionChange={setSelectedIds}
+                                onEditRule={openEdit}
+                                currentIsDirty={currentIsDirty}
+                                onSave={handleSavePress}
+                                onDiscard={handleDiscard}
+                                onDeleteConfig={() => setDeleteConfigOpen(true)}
+                                rates={rates}
+                                enabledCounterNames={enabledCounterNames}
+                                onToggleCounter={handleToggleCounter}
+                            />
+                        </div>
+                    </>
+                )}
+
+                {selectedIds.size > 0 && (
+                    <BulkBar
+                        count={selectedIds.size}
+                        itemNoun="rule"
+                        onDelete={() => setDeleteConfirmOpen(true)}
+                        onClear={() => setSelectedIds(new Set())}
+                    />
+                )}
+
+                <BulkDeleteModal
+                    open={deleteConfirmOpen}
+                    count={selectedIds.size}
+                    itemNoun="rule"
+                    configName={currentConfig}
+                    onClose={() => setDeleteConfirmOpen(false)}
+                    onConfirm={handleBulkDelete}
+                />
+
+                <AddConfigModal
+                    open={addConfigOpen}
+                    onClose={() => setAddConfigOpen(false)}
+                    onCreate={name => {
+                        dispatchDraft({ type: 'ADD_CONFIG', configName: name });
+                        setActiveConfig(name);
+                        setAddConfigOpen(false);
+                    }}
+                    placeholder="e.g. acl0"
+                    existingNames={draftConfigs}
+                />
+
+                <DeleteConfigModal
+                    open={deleteConfigOpen}
+                    configName={currentConfig}
+                    onClose={() => setDeleteConfigOpen(false)}
+                    onConfirm={handleDeleteConfig}
+                />
+
+                <RuleDrawer
+                    ref={drawerRef}
+                    open={drawer.open}
+                    mode={drawer.mode}
+                    ruleItem={drawer.item}
+                    onClose={closeDrawer}
+                    onSave={handleDrawerApply}
+                    onDelete={handleDeleteItem}
+                    onDuplicate={handleDuplicate}
+                />
+
+                {diffModalOpen && (
+                    <SaveDiffModal
+                        configName={currentConfig}
+                        draftRules={rawRules}
+                        draftIds={rawIds}
+                        serverRules={serverRules(currentConfig)}
+                        onClose={() => setDiffModalOpen(false)}
+                        onApply={handleSave}
+                    />
+                )}
+            </div>
+        </PageLayout>
+    );
+};
+
+export default AclNgPage;

--- a/web/src/pages/modules/acl-ng/ChipInput.tsx
+++ b/web/src/pages/modules/acl-ng/ChipInput.tsx
@@ -1,0 +1,475 @@
+import React, { useEffect, useImperativeHandle, useRef, useState, useMemo, useCallback } from 'react';
+import { Dialog, TextInput } from '@gravity-ui/uikit';
+
+type ChipKind = 'cidr' | 'device' | 'vlan';
+
+interface ChipInputProps {
+    value: string[];
+    onChange: (values: string[]) => void;
+    placeholder?: string;
+    kind: ChipKind;
+    wildcardLabel?: string;
+    validator: (s: string) => boolean;
+}
+
+/** Imperative handle for synchronously flushing pending text before a parent save. */
+export interface ChipInputHandle {
+    /**
+     * Synchronously return any tokens in the current draft text and clear it.
+     * Does NOT call onChange — the caller merges the returned tokens itself so
+     * that draft text and committed chips land in one synchronous transaction.
+     */
+    flush(): string[];
+}
+
+const MANY_THRESHOLD = 20;
+
+interface BulkPasteModalProps {
+    existing: string[];
+    validate: (s: string) => boolean;
+    onClose: () => void;
+    onApply: (items: string[], mode: 'append' | 'replace') => void;
+}
+
+const BulkPasteModal: React.FC<BulkPasteModalProps> = ({ existing, validate, onClose, onApply }) => {
+    const [text, setText] = useState('');
+    const [mode, setMode] = useState<'append' | 'replace'>('append');
+
+    const parsed = useMemo(
+        () => text.split(/[\s,;]+/).map(s => s.trim()).filter(Boolean),
+        [text],
+    );
+
+    const invalid = useMemo(
+        () => parsed.filter(v => !validate(v)),
+        [parsed, validate],
+    );
+
+    const deduped = useMemo(() => {
+        const seen = new Set(existing);
+        const result: string[] = [];
+        for (const item of parsed) {
+            if (!seen.has(item)) {
+                seen.add(item);
+                result.push(item);
+            }
+        }
+        return result;
+    }, [parsed, existing]);
+
+    const dupCount = parsed.length - deduped.length;
+    const validCount = mode === 'replace'
+        ? parsed.filter(v => validate(v)).length
+        : deduped.filter(v => validate(v)).length;
+
+    const handleApply = useCallback((): void => {
+        const validItems = mode === 'replace'
+            ? parsed.filter(v => validate(v))
+            : deduped.filter(v => validate(v));
+        onApply(validItems, mode);
+    }, [parsed, deduped, mode, validate, onApply]);
+
+    return (
+        <Dialog open onClose={onClose} size="m">
+            <Dialog.Header caption="Bulk paste" />
+            <Dialog.Body>
+                <p style={{ margin: '0 0 10px', fontSize: 12.5, color: 'var(--fw-text-3)' }}>
+                    Whitespace, comma, or newline separated values.
+                </p>
+                <textarea
+                    autoFocus
+                    className="fw-input fw-input--mono"
+                    style={{ width: '100%', height: 220, resize: 'vertical', fontFamily: 'var(--fw-font-mono)', fontSize: 12 }}
+                    value={text}
+                    placeholder={'10.0.0.0/24\n10.0.1.0/24, 10.0.2.0/24\n2001:db8::/32'}
+                    onChange={e => setText(e.target.value)}
+                    spellCheck={false}
+                />
+                <div style={{ display: 'flex', gap: 14, marginTop: 10, fontSize: 12.5, flexWrap: 'wrap', alignItems: 'center' }}>
+                    <span style={{ color: 'var(--fw-text-3)' }}>parsed:</span>
+                    <span style={{ fontFamily: 'var(--fw-font-mono)' }}>{parsed.length} total</span>
+                    {invalid.length > 0 && (
+                        <span style={{ color: 'var(--g-color-text-danger)', fontFamily: 'var(--fw-font-mono)' }}>
+                            {invalid.length} invalid
+                        </span>
+                    )}
+                    {dupCount > 0 && (
+                        <span style={{ color: 'var(--fw-text-3)', fontFamily: 'var(--fw-font-mono)' }}>
+                            {dupCount} duplicate
+                        </span>
+                    )}
+                    <span style={{ fontFamily: 'var(--fw-font-mono)', color: 'var(--g-color-text-warning)' }}>
+                        {validCount} will be {mode === 'replace' ? 'set' : 'added'}
+                    </span>
+                </div>
+                <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
+                    <button
+                        type="button"
+                        className={`fw-btn ${mode === 'append' ? 'fw-btn--primary' : 'fw-btn--ghost'}`}
+                        onClick={() => setMode('append')}
+                    >
+                        Append
+                    </button>
+                    <button
+                        type="button"
+                        className={`fw-btn ${mode === 'replace' ? 'fw-btn--primary' : 'fw-btn--ghost'}`}
+                        onClick={() => setMode('replace')}
+                    >
+                        Replace all
+                    </button>
+                </div>
+            </Dialog.Body>
+            <Dialog.Footer
+                onClickButtonCancel={onClose}
+                onClickButtonApply={handleApply}
+                textButtonCancel="Cancel"
+                textButtonApply={mode === 'replace' ? `Replace with ${validCount}` : `Append ${validCount}`}
+            />
+        </Dialog>
+    );
+};
+
+interface ListPopoverProps {
+    items: string[];
+    label: string;
+    onClose: () => void;
+}
+
+const ListPopover: React.FC<ListPopoverProps> = ({ items, label, onClose }) => {
+    const [q, setQ] = useState('');
+    const filtered = q.trim()
+        ? items.filter(s => s.toLowerCase().includes(q.trim().toLowerCase()))
+        : items;
+
+    let stats = `${items.length} ${label}`;
+    const hasCidrs = items.some(s => s.includes('/'));
+    if (hasCidrs) {
+        let v4 = 0, v6 = 0;
+        for (const s of items) (s.includes(':') ? v6++ : v4++);
+        stats = `${items.length} total · ${v4} v4 · ${v6} v6`;
+    }
+
+    const copyAll = (): void => {
+        navigator.clipboard.writeText(items.join('\n')).catch(() => undefined);
+    };
+
+    return (
+        <Dialog open onClose={onClose} size="m">
+            <Dialog.Header caption={label} />
+            <Dialog.Body>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10, minHeight: 0, maxHeight: '50vh' }}>
+                    <div style={{ fontSize: 12, color: 'var(--fw-text-3)', marginBottom: 4 }}>{stats}</div>
+                    <TextInput
+                        autoFocus
+                        value={q}
+                        onUpdate={setQ}
+                        placeholder={`Filter ${items.length} ${label}…`}
+                        hasClear
+                        size="s"
+                    />
+                    <div style={{
+                        flex: 1,
+                        overflow: 'auto',
+                        background: 'var(--fw-bg-2)',
+                        border: '1px solid var(--fw-line)',
+                        borderRadius: 6,
+                        padding: 8,
+                        display: 'flex',
+                        flexWrap: 'wrap',
+                        gap: 5,
+                        alignContent: 'flex-start',
+                        minHeight: 80,
+                        maxHeight: 320,
+                    }}>
+                        {filtered.length === 0 ? (
+                            <span style={{ color: 'var(--fw-text-3)', fontSize: 12, padding: 12 }}>No matches.</span>
+                        ) : (
+                            filtered.map((s, idx) => {
+                                const isV6 = s.includes(':');
+                                const cls = s.includes('/')
+                                    ? (isV6 ? 'acl-chip acl-chip--ipv6' : 'acl-chip acl-chip--ipv4')
+                                    : 'acl-chip acl-chip--device';
+                                return (
+                                    <span key={idx} className={cls} title={s}>{s}</span>
+                                );
+                            })
+                        )}
+                    </div>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 12 }}>
+                        <span style={{ color: 'var(--fw-text-3)' }}>
+                            Showing {filtered.length} of {items.length}
+                        </span>
+                        <button type="button" className="fw-btn fw-btn--ghost" style={{ fontSize: 12, padding: '2px 10px' }} onClick={copyAll}>
+                            Copy all
+                        </button>
+                    </div>
+                </div>
+            </Dialog.Body>
+            <Dialog.Footer
+                onClickButtonCancel={onClose}
+                textButtonCancel="Close"
+            />
+        </Dialog>
+    );
+};
+
+/**
+ * Token chip input with bulk-paste dialog and scrollable chip list for large sets.
+ * Accepts comma-separated paste, Enter/Tab to commit, Backspace to remove last.
+ * Exposes a flush() handle so parent forms can collect pending text before saving
+ * without relying on the asynchronous onBlur → setState path.
+ *
+ * When the chip count exceeds 20, the container becomes scrollable and shows a
+ * filter input to search within visible chips.
+ */
+const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
+    value,
+    onChange,
+    placeholder,
+    wildcardLabel,
+    validator,
+}, ref) => {
+    const [draft, setDraft] = useState('');
+    const draftRef = useRef('');
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [filter, setFilter] = useState('');
+    const [bulkOpen, setBulkOpen] = useState(false);
+    const [popoverOpen, setPopoverOpen] = useState(false);
+
+    useEffect(() => {
+        draftRef.current = draft;
+    }, [draft]);
+
+    useImperativeHandle(ref, () => ({
+        flush() {
+            const tokens = draftRef.current
+                .split(/[,\s]+/)
+                .map((t) => t.trim())
+                .filter(Boolean);
+            if (tokens.length > 0) {
+                setDraft('');
+                draftRef.current = '';
+            }
+            return tokens;
+        },
+    }), []);
+
+    const commitDraft = (raw?: string): void => {
+        const source = raw ?? draft;
+        const tokens = source.split(/[,\s]+/).map((t) => t.trim()).filter(Boolean);
+        if (!tokens.length) return;
+        onChange([...value, ...tokens]);
+        setDraft('');
+        draftRef.current = '';
+    };
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+        const v = e.target.value;
+        if (v.includes(',')) {
+            commitDraft(v);
+        } else {
+            setDraft(v);
+            draftRef.current = v;
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+        if ((e.key === 'Enter' || e.key === 'Tab') && draft.trim()) {
+            e.preventDefault();
+            commitDraft();
+        } else if (e.key === 'Backspace' && !draft && value.length > 0) {
+            onChange(value.slice(0, -1));
+        }
+    };
+
+    const handleBlur = (): void => {
+        if (draft.trim()) commitDraft();
+    };
+
+    const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>): void => {
+        const text = e.clipboardData.getData('text');
+        if (/[,\s]/.test(text)) {
+            e.preventDefault();
+            commitDraft(text);
+        }
+    };
+
+    const isMany = value.length > MANY_THRESHOLD;
+    const isWildcard = value.length === 0;
+
+    const filteredIndices = useMemo(() => {
+        if (!filter.trim()) return value.map((_, idx) => idx);
+        const q = filter.trim().toLowerCase();
+        return value.map((v, idx) => ({ v, idx })).filter(({ v }) => v.toLowerCase().includes(q)).map(({ idx }) => idx);
+    }, [value, filter]);
+
+    const kindLabel = (): string => {
+        switch (true) {
+            case value.some(v => v.includes('/')): return 'CIDRs';
+            case value.some(v => v.includes(':')): return 'addresses';
+            default: return 'items';
+        }
+    };
+
+    // Summary for table-cell collapse (>6 items).
+    const isBig = value.length > 6;
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {isMany && (
+                <div className="acl-chip-toolbar">
+                    <div style={{ flex: 1 }}>
+                        <TextInput
+                            size="s"
+                            value={filter}
+                            onUpdate={setFilter}
+                            placeholder={`Filter ${value.length} items…`}
+                            hasClear
+                        />
+                    </div>
+                    <button
+                        type="button"
+                        className="fw-btn fw-btn--ghost"
+                        style={{ fontSize: 11, padding: '2px 8px' }}
+                        onClick={() => setBulkOpen(true)}
+                    >
+                        Paste bulk
+                    </button>
+                    {isBig && (
+                        <button
+                            type="button"
+                            className="fw-btn fw-btn--ghost"
+                            style={{ fontSize: 11, padding: '2px 8px' }}
+                            onClick={() => setPopoverOpen(true)}
+                            title="View full list"
+                        >
+                            View all
+                        </button>
+                    )}
+                    <button
+                        type="button"
+                        className="fw-btn fw-btn--ghost"
+                        style={{ fontSize: 11, padding: '2px 8px', color: 'var(--g-color-text-danger)' }}
+                        onClick={() => onChange([])}
+                        title="Remove all"
+                    >
+                        Clear
+                    </button>
+                    <span style={{ fontSize: 11, color: 'var(--fw-text-3)', fontFamily: 'var(--fw-font-mono)' }}>
+                        {value.length}
+                    </span>
+                </div>
+            )}
+
+            <div
+                className={`fw-chip-input${isMany ? ' fw-chip-input--many' : ''}`}
+                onClick={() => !filter && inputRef.current?.focus()}
+            >
+                {isWildcard && wildcardLabel && (
+                    <span className="acl-chip acl-chip--any">{wildcardLabel}</span>
+                )}
+                {filteredIndices.map(idx => {
+                    const v = value[idx];
+                    const valid = validator(v);
+                    return (
+                        <span key={idx} className={`fw-chip${valid ? '' : ' fw-chip--invalid'}`}>
+                            <span
+                                className="fw-chip__label"
+                                role="button"
+                                tabIndex={0}
+                                title="Click to edit"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onChange(value.filter((_, j) => j !== idx));
+                                    setDraft(v);
+                                    draftRef.current = v;
+                                    setTimeout(() => inputRef.current?.focus(), 0);
+                                }}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Enter' || e.key === ' ') {
+                                        e.preventDefault();
+                                        onChange(value.filter((_, j) => j !== idx));
+                                        setDraft(v);
+                                        draftRef.current = v;
+                                        setTimeout(() => inputRef.current?.focus(), 0);
+                                    }
+                                }}
+                            >
+                                {v}
+                            </span>
+                            <button
+                                type="button"
+                                className="fw-chip__x"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    onChange(value.filter((_, j) => j !== idx));
+                                }}
+                                aria-label={`Remove ${v}`}
+                            >
+                                ×
+                            </button>
+                        </span>
+                    );
+                })}
+                {filter && filteredIndices.length === 0 && (
+                    <span style={{ fontSize: 12, color: 'var(--fw-text-3)', fontFamily: 'var(--fw-font-mono)' }}>
+                        no matches
+                    </span>
+                )}
+                {!filter && (
+                    <input
+                        ref={inputRef}
+                        type="text"
+                        value={draft}
+                        placeholder={value.length ? '' : placeholder}
+                        onChange={handleChange}
+                        onKeyDown={handleKeyDown}
+                        onBlur={handleBlur}
+                        onPaste={handlePaste}
+                        className="fw-chip-input__raw"
+                    />
+                )}
+            </div>
+
+            {!isMany && (
+                <button
+                    type="button"
+                    className="fw-btn fw-btn--ghost"
+                    style={{ fontSize: 11, alignSelf: 'flex-start', padding: '2px 8px' }}
+                    onClick={() => setBulkOpen(true)}
+                >
+                    + Paste many
+                </button>
+            )}
+
+            {bulkOpen && (
+                <BulkPasteModal
+                    existing={value}
+                    validate={validator}
+                    onClose={() => setBulkOpen(false)}
+                    onApply={(items, pasteMode) => {
+                        if (pasteMode === 'replace') {
+                            onChange(items);
+                        } else {
+                            const seen = new Set(value);
+                            onChange([...value, ...items.filter(i => !seen.has(i))]);
+                        }
+                        setBulkOpen(false);
+                    }}
+                />
+            )}
+
+            {popoverOpen && (
+                <ListPopover
+                    items={value}
+                    label={kindLabel()}
+                    onClose={() => setPopoverOpen(false)}
+                />
+            )}
+        </div>
+    );
+});
+
+ChipInput.displayName = 'ChipInput';
+
+export default ChipInput;

--- a/web/src/pages/modules/acl-ng/RuleDrawer.tsx
+++ b/web/src/pages/modules/acl-ng/RuleDrawer.tsx
@@ -1,0 +1,405 @@
+import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { ActionKind, ACTION_KIND_LABELS } from '../../../api/acl-ng';
+import type { RuleDraft, RuleItem } from './types';
+import { emptyDraft } from './types';
+import { itemToDraft, isValidCidr, isValidDeviceName } from './hooks';
+import ChipInput from './ChipInput';
+import type { ChipInputHandle } from './ChipInput';
+
+interface RuleDrawerProps {
+    open: boolean;
+    mode: 'add' | 'edit';
+    ruleItem: RuleItem | null;
+    onClose: () => void;
+    onSave: (draft: RuleDraft) => void;
+    onDelete: (item: RuleItem) => void;
+    onDuplicate: (item: RuleItem) => void;
+}
+
+/** Imperative handle for flushing pending chip text and applying the drawer from outside. */
+export interface RuleDrawerHandle {
+    flushAndApply(): boolean;
+}
+
+const ALL_KINDS: ActionKind[] = [
+    ActionKind.ACTION_KIND_CREATE_STATE,
+    ActionKind.ACTION_KIND_CHECK_STATE,
+    ActionKind.ACTION_KIND_COUNT,
+    ActionKind.ACTION_KIND_LOG,
+    ActionKind.ACTION_KIND_PASS,
+    ActionKind.ACTION_KIND_DENY,
+];
+
+const TERMINAL_KINDS = new Set<ActionKind>([
+    ActionKind.ACTION_KIND_PASS,
+    ActionKind.ACTION_KIND_DENY,
+]);
+
+/** Side drawer for adding/editing an ACL NG rule. */
+const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
+    open,
+    mode,
+    ruleItem,
+    onClose,
+    onSave,
+    onDelete,
+    onDuplicate,
+}, ref) => {
+    const [draft, setDraft] = useState<RuleDraft>(emptyDraft());
+    const [isDirty, setIsDirty] = useState(false);
+    const deviceNamesRef = useRef<ChipInputHandle>(null);
+    const sourceCidrsRef = useRef<ChipInputHandle>(null);
+    const dstCidrsRef = useRef<ChipInputHandle>(null);
+
+    useEffect(() => {
+        if (open) {
+            const initial = ruleItem ? itemToDraft(ruleItem) : emptyDraft();
+            setDraft({ ...initial });
+            setIsDirty(false);
+        }
+    }, [open, mode, ruleItem?.id]);
+
+    const updateField = <K extends keyof RuleDraft>(key: K, val: RuleDraft[K]): void => {
+        setDraft(prev => ({ ...prev, [key]: val }));
+        setIsDirty(true);
+    };
+
+    const buildFlushedDraft = (base: RuleDraft): RuleDraft => ({
+        ...base,
+        deviceNames: [...base.deviceNames, ...(deviceNamesRef.current?.flush() ?? [])],
+        sourceCidrs: [...base.sourceCidrs, ...(sourceCidrsRef.current?.flush() ?? [])],
+        dstCidrs: [...base.dstCidrs, ...(dstCidrsRef.current?.flush() ?? [])],
+    });
+
+    const handleApply = useCallback((): void => {
+        const finalDraft = buildFlushedDraft(draft);
+        setDraft(finalDraft);
+        onSave(finalDraft);
+    }, [draft, onSave]);
+
+    useImperativeHandle(ref, () => ({
+        flushAndApply() {
+            if (!open) return false;
+            handleApply();
+            return true;
+        },
+    }), [open, handleApply]);
+
+    const handleClose = (): void => {
+        if (isDirty) {
+            const ok = window.confirm('You have unsaved changes. Close anyway?');
+            if (!ok) return;
+        }
+        onClose();
+    };
+
+    const addAction = (kind: ActionKind): void => {
+        updateField('actions', [...draft.actions, kind]);
+    };
+
+    const removeAction = (idx: number): void => {
+        updateField('actions', draft.actions.filter((_, i) => i !== idx));
+    };
+
+    const changeAction = (idx: number, kind: ActionKind): void => {
+        const next = [...draft.actions];
+        next[idx] = kind;
+        updateField('actions', next);
+    };
+
+    const terminalIdx = draft.actions.findIndex(k => TERMINAL_KINDS.has(k));
+    const hasNoTerminal = draft.actions.length > 0 && terminalIdx === -1;
+    const hasUnreachable = terminalIdx !== -1 && terminalIdx < draft.actions.length - 1;
+
+    return (
+        <>
+            <div
+                className={`fw-backdrop${open ? ' fw-backdrop--open' : ''}`}
+                onClick={handleClose}
+                aria-hidden="true"
+            />
+            <aside
+                className={`fw-drawer${open ? ' fw-drawer--open' : ''}`}
+                role="dialog"
+                aria-modal="true"
+                aria-label={mode === 'add' ? 'Add ACL rule' : 'Edit ACL rule'}
+            >
+                <header className="fw-drawer__head">
+                    <h2 className="fw-drawer__title">
+                        {mode === 'add' ? 'New rule' : (
+                            <>Edit rule <span className="fw-drawer__rule-num">#{ruleItem?.index !== undefined ? ruleItem.index + 1 : ''}</span></>
+                        )}
+                    </h2>
+                    <div className="fw-drawer__head-actions">
+                        {mode === 'edit' && ruleItem && (
+                            <>
+                                <button
+                                    type="button"
+                                    className="fw-icon-btn"
+                                    onClick={() => onDuplicate(ruleItem)}
+                                    title="Duplicate rule"
+                                >
+                                    ⎘
+                                </button>
+                                <button
+                                    type="button"
+                                    className="fw-icon-btn fw-icon-btn--danger"
+                                    onClick={() => onDelete(ruleItem)}
+                                    title="Delete rule"
+                                >
+                                    🗑
+                                </button>
+                            </>
+                        )}
+                        <button
+                            type="button"
+                            className="fw-icon-btn"
+                            onClick={handleClose}
+                            aria-label="Close drawer"
+                        >
+                            ✕
+                        </button>
+                    </div>
+                </header>
+
+                <div className="fw-drawer__body">
+                    <section className="fw-section">
+                        <div className="fw-section-h">Actions</div>
+                        <div className="fw-section__body">
+                            <div className="fw-field">
+                                <label className="fw-field__label">
+                                    Action chain
+                                    <span className="fw-field__count">{draft.actions.length} step{draft.actions.length !== 1 ? 's' : ''}</span>
+                                </label>
+                                <div className="acl-action-editor">
+                                    {draft.actions.map((kind, idx) => (
+                                        <div key={idx} className="acl-action-row">
+                                            <span className="acl-action-row__idx">{idx + 1}.</span>
+                                            <select
+                                                className="fw-input acl-action-select"
+                                                value={kind}
+                                                onChange={e => changeAction(idx, parseInt(e.target.value, 10) as ActionKind)}
+                                            >
+                                                {ALL_KINDS.map(k => (
+                                                    <option key={k} value={k}>
+                                                        {ACTION_KIND_LABELS[k]}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                            <button
+                                                type="button"
+                                                className="fw-icon-btn fw-icon-btn--danger"
+                                                onClick={() => removeAction(idx)}
+                                                aria-label={`Remove step ${idx + 1}`}
+                                                title="Remove step"
+                                            >
+                                                ×
+                                            </button>
+                                        </div>
+                                    ))}
+                                    <div className="acl-action-add-row">
+                                        {ALL_KINDS.map(kind => (
+                                            <button
+                                                key={kind}
+                                                type="button"
+                                                className="fw-btn fw-btn--ghost acl-action-preset"
+                                                onClick={() => addAction(kind)}
+                                            >
+                                                + {ACTION_KIND_LABELS[kind]}
+                                            </button>
+                                        ))}
+                                    </div>
+                                </div>
+                                {hasNoTerminal && (
+                                    <span className="fw-field__hint acl-hint--warn">
+                                        No terminal action (pass/deny) — traffic will fall through.
+                                    </span>
+                                )}
+                                {hasUnreachable && (
+                                    <span className="fw-field__hint acl-hint--warn">
+                                        Steps after step {terminalIdx + 1} are unreachable.
+                                    </span>
+                                )}
+                            </div>
+                            <div className="fw-field">
+                                <label className="fw-field__label">
+                                    Counter <span className="fw-field__optional">optional</span>
+                                </label>
+                                <input
+                                    className="fw-input"
+                                    placeholder="e.g. my_acl_counter"
+                                    value={draft.counter}
+                                    onChange={e => updateField('counter', e.target.value)}
+                                />
+                                <span className="fw-field__hint">Counter name shown in /stats. Leave empty to skip counting.</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="fw-section">
+                        <div className="fw-section-h">Match — addresses</div>
+                        <div className="fw-section__body">
+                            <div className="fw-fgrid">
+                                <div className="fw-field">
+                                    <label className="fw-field__label">
+                                        Sources
+                                        <span className="fw-field__count">{draft.sourceCidrs.length || 'any'}</span>
+                                    </label>
+                                    <ChipInput
+                                        ref={sourceCidrsRef}
+                                        value={draft.sourceCidrs}
+                                        onChange={v => updateField('sourceCidrs', v)}
+                                        placeholder="10.0.0.0/8…"
+                                        kind="cidr"
+                                        wildcardLabel="Any source"
+                                        validator={isValidCidr}
+                                    />
+                                </div>
+                                <div className="fw-field">
+                                    <label className="fw-field__label">
+                                        Destinations
+                                        <span className="fw-field__count">{draft.dstCidrs.length || 'any'}</span>
+                                    </label>
+                                    <ChipInput
+                                        ref={dstCidrsRef}
+                                        value={draft.dstCidrs}
+                                        onChange={v => updateField('dstCidrs', v)}
+                                        placeholder="192.168.0.0/16…"
+                                        kind="cidr"
+                                        wildcardLabel="Any destination"
+                                        validator={isValidCidr}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="fw-section">
+                        <div className="fw-section-h">Match — ports and protocols</div>
+                        <div className="fw-section__body">
+                            <div className="fw-fgrid">
+                                <div className="fw-field">
+                                    <label className="fw-field__label">Src port ranges</label>
+                                    <input
+                                        className="fw-input fw-input--mono"
+                                        placeholder="0-65535"
+                                        value={draft.srcPortRaw}
+                                        onChange={e => updateField('srcPortRaw', e.target.value)}
+                                    />
+                                    <span className="fw-field__hint">e.g. <code>80</code>, <code>80-90</code>, <code>80, 443</code>. Empty = any.</span>
+                                </div>
+                                <div className="fw-field">
+                                    <label className="fw-field__label">Dst port ranges</label>
+                                    <input
+                                        className="fw-input fw-input--mono"
+                                        placeholder="0-65535"
+                                        value={draft.dstPortRaw}
+                                        onChange={e => updateField('dstPortRaw', e.target.value)}
+                                    />
+                                    <span className="fw-field__hint">e.g. <code>80</code>, <code>443</code>, <code>8080-8443</code>. Empty = any.</span>
+                                </div>
+                            </div>
+                            <div className="fw-field">
+                                <label className="fw-field__label">Protocol ranges</label>
+                                <input
+                                    className="fw-input fw-input--mono"
+                                    placeholder="1536-1791"
+                                    value={draft.protoRaw}
+                                    onChange={e => updateField('protoRaw', e.target.value)}
+                                />
+                                <span className="fw-field__hint">
+                                    Encoded as <code>(ip_proto &lt;&lt; 8) | subtype</code>.
+                                    TCP=<code>1536-1791</code>, UDP=<code>4352-4607</code>, ICMP=<code>256-511</code>.
+                                    Empty = any.
+                                </span>
+                                <div className="acl-proto-presets">
+                                    {[
+                                        { label: '+ TCP', range: '1536-1791' },
+                                        { label: '+ UDP', range: '4352-4607' },
+                                        { label: '+ ICMP', range: '256-511' },
+                                        { label: '+ ICMPv6', range: '14848-15103' },
+                                        { label: '+ GRE', range: '12032-12287' },
+                                        { label: '+ ESP', range: '12800-13055' },
+                                    ].map(({ label, range }) => (
+                                        <button
+                                            key={range}
+                                            type="button"
+                                            className="fw-btn fw-btn--ghost acl-proto-preset"
+                                            onClick={() => {
+                                                const current = draft.protoRaw.trim();
+                                                if (!current) {
+                                                    updateField('protoRaw', range);
+                                                } else if (!current.includes(range)) {
+                                                    updateField('protoRaw', `${current}, ${range}`);
+                                                }
+                                            }}
+                                        >
+                                            {label}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="fw-section">
+                        <div className="fw-section-h">Match — L2 / device</div>
+                        <div className="fw-section__body">
+                            <div className="fw-field">
+                                <label className="fw-field__label">VLAN ranges</label>
+                                <input
+                                    className="fw-input fw-input--mono"
+                                    placeholder="0-4095"
+                                    value={draft.vlanRaw}
+                                    onChange={e => updateField('vlanRaw', e.target.value)}
+                                />
+                                <span className="fw-field__hint">
+                                    Single <code>100</code>, range <code>100-200</code>, list <code>100, 200, 300-400</code>. Empty = all VLANs.
+                                </span>
+                            </div>
+                            <div className="fw-field">
+                                <label className="fw-field__label">
+                                    Devices
+                                    <span className="fw-field__count">{draft.deviceNames.length || 'any'}</span>
+                                </label>
+                                <ChipInput
+                                    ref={deviceNamesRef}
+                                    value={draft.deviceNames}
+                                    onChange={v => updateField('deviceNames', v)}
+                                    placeholder="eth0, 0000:81:00.0…"
+                                    kind="device"
+                                    wildcardLabel="Any device"
+                                    validator={isValidDeviceName}
+                                />
+                            </div>
+                        </div>
+                    </section>
+                </div>
+
+                <footer className="fw-drawer__foot">
+                    <span className="fw-drawer__foot-meta">
+                        {mode === 'add'
+                            ? 'Will be appended to config.'
+                            : `Rule #${(ruleItem?.index ?? -1) + 1}`}
+                    </span>
+                    <div className="fw-drawer__foot-actions">
+                        <button type="button" className="fw-btn fw-btn--ghost" onClick={handleClose}>
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            className="fw-btn fw-btn--primary"
+                            onClick={handleApply}
+                        >
+                            Apply
+                        </button>
+                    </div>
+                </footer>
+            </aside>
+        </>
+    );
+});
+
+RuleDrawer.displayName = 'RuleDrawer';
+
+export default RuleDrawer;

--- a/web/src/pages/modules/acl-ng/RuleTable.tsx
+++ b/web/src/pages/modules/acl-ng/RuleTable.tsx
@@ -1,18 +1,24 @@
-import React, { useCallback, useMemo, useRef, useState, useEffect, memo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, memo } from 'react';
 import { useContainerHeight } from '../../../hooks';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Checkbox } from '@gravity-ui/uikit';
+import { Checkbox, Icon } from '@gravity-ui/uikit';
+import { Pause, Play } from '@gravity-ui/icons';
 import type { RuleItem } from './types';
-import type { RuleRate } from './useForwardRuleCounters';
-import DirectionBadge from './DirectionBadge';
-import AnyBadge from './AnyBadge';
-import Sparkline from './Sparkline';
-import { formatPps } from '../../../utils';
+import { expandRuleItem } from './hooks';
+import {
+    AnyChip,
+    IpNetChip,
+    PortRangeChip,
+    VlanRangeChip,
+    ProtoChip,
+    ActionChain,
+    ChipList,
+} from './chips';
 import { DraftActionButtons } from '../../_shared/draft';
+import type { RuleRate } from './useAclNgRuleCounters';
+import Sparkline from './Sparkline';
 
-/** Duration in ms of the CSS transition on .fw-drawer — keep in sync with SCSS. */
-const DRAWER_TRANSITION_MS = 220;
-export { DRAWER_TRANSITION_MS };
+export const DRAWER_TRANSITION_MS = 220;
 
 const ROW_HEIGHT = 44;
 const HEADER_HEIGHT = 40;
@@ -22,16 +28,17 @@ const OVERSCAN = 15;
 const COLUMN_WIDTHS = {
     checkbox: 38,
     index: 48,
-    target: 160,
-    mode: 90,
+    srcs: 180,
+    dsts: 180,
+    src_ports: 130,
+    dst_ports: 130,
+    protos: 150,
+    vlans: 110,
+    devices: 130,
     counter: 140,
-    devices: 140,
-    vlans: 120,
-    srcs: 200,
-    dsts: 200,
-    sparkline: 150,
+    actions: 190,
+    sparkline: 110,
 } as const;
-
 
 const TOTAL_WIDTH = Object.values(COLUMN_WIDTHS).reduce((a, b) => a + b, 0);
 
@@ -43,49 +50,38 @@ const cellStyle = (col: ColKey): React.CSSProperties => ({
     maxWidth: COLUMN_WIDTHS[col],
     flexShrink: 0,
     overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
     paddingRight: col === 'checkbox' ? 0 : 8,
     display: 'flex',
     alignItems: 'center',
     justifyContent: col === 'checkbox' || col === 'index' ? 'center' : 'flex-start',
 });
 
-/** Compact mono list of values with overflow truncation. */
-const ValueCell: React.FC<{ values: string[] }> = ({ values }) => {
-    if (values.length === 0) return null;
-    const visible = values.slice(0, 3);
-    const rest = values.length - visible.length;
-    return (
-        <span className="fw-cell-values" title={values.join(', ')}>
-            {visible.map((v, idx) => (
-                <span key={idx} className="fw-cell-mono">{v}</span>
-            ))}
-            {rest > 0 && <span className="fw-cell-more">+{rest}</span>}
-        </span>
-    );
-};
-
 interface VirtualRowProps {
     item: RuleItem;
     start: number;
     selected: boolean;
     active: boolean;
-    rateData: RuleRate | null;
+    rate: RuleRate | undefined;
+    counterEnabled: boolean;
     onToggleSelect: (id: string) => void;
     onHoverChange: (item: RuleItem | null, start: number) => void;
+    onToggleCounter: (counterName: string) => void;
 }
 
-/** Single virtualized rule row — no per-row action slot; hover is reported to the parent overlay. */
 const VirtualRow: React.FC<VirtualRowProps> = memo(({
     item,
     start,
     selected,
     active,
-    rateData,
+    rate,
+    counterEnabled,
     onToggleSelect,
     onHoverChange,
+    onToggleCounter,
 }) => {
+    // Expand the rule lazily — only called for the ~25 visible rows at a time.
+    const expanded = useMemo(() => expandRuleItem(item.rule), [item.rule]);
+
     const handleCheckboxChange = useCallback((_checked: boolean): void => {
         onToggleSelect(item.id);
     }, [onToggleSelect, item.id]);
@@ -99,8 +95,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
     }, [onHoverChange]);
 
     let rowBg = 'transparent';
-    if (active) rowBg = 'var(--fw-accent-soft)';
-    else if (selected) rowBg = 'var(--fw-accent-soft)';
+    if (active || selected) rowBg = 'var(--fw-accent-soft)';
 
     return (
         <div
@@ -121,10 +116,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 paddingLeft: 4,
             }}
         >
-            <div
-                style={cellStyle('checkbox')}
-                onClick={(e) => e.stopPropagation()}
-            >
+            <div style={cellStyle('checkbox')} onClick={e => e.stopPropagation()}>
                 <Checkbox
                     checked={selected}
                     onUpdate={handleCheckboxChange}
@@ -136,51 +128,124 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 <span style={{ fontSize: 12 }}>{item.index + 1}</span>
             </div>
 
-            <div style={cellStyle('target')} title={item.target}>
-                <span className="fw-cell-mono fw-cell-strong">{item.target || '—'}</span>
+            <div style={cellStyle('srcs')}>
+                <ChipList
+                    items={expanded.sourceCidrs}
+                    isAny={expanded.isAnySrc}
+                    renderChip={(cidr, idx) => <IpNetChip key={idx} cidr={cidr} />}
+                />
             </div>
 
-            <div style={cellStyle('mode')}>
-                <DirectionBadge mode={item.mode} />
+            <div style={cellStyle('dsts')}>
+                <ChipList
+                    items={expanded.dstCidrs}
+                    isAny={expanded.isAnyDst}
+                    renderChip={(cidr, idx) => <IpNetChip key={idx} cidr={cidr} />}
+                />
+            </div>
+
+            <div style={cellStyle('src_ports')}>
+                {expanded.isAnySrcPort
+                    ? <AnyChip>any</AnyChip>
+                    : <ChipList
+                        items={expanded.srcPortRanges}
+                        renderChip={(r, idx) => <PortRangeChip key={idx} rangeStr={r} />}
+                    />
+                }
+            </div>
+
+            <div style={cellStyle('dst_ports')}>
+                {expanded.isAnyDstPort
+                    ? <AnyChip>any</AnyChip>
+                    : <ChipList
+                        items={expanded.dstPortRanges}
+                        renderChip={(r, idx) => <PortRangeChip key={idx} rangeStr={r} />}
+                    />
+                }
+            </div>
+
+            <div style={cellStyle('protos')}>
+                <ChipList
+                    items={expanded.protoRanges}
+                    isAny={expanded.protoRanges.length === 0}
+                    anyLabel="any"
+                    renderChip={(r, idx) => <ProtoChip key={idx} rangeStr={r} />}
+                />
+            </div>
+
+            <div style={cellStyle('vlans')}>
+                {expanded.isAnyVlan
+                    ? <AnyChip>any</AnyChip>
+                    : <ChipList
+                        items={expanded.vlanRanges}
+                        renderChip={(r, idx) => <VlanRangeChip key={idx} rangeStr={r} />}
+                    />
+                }
+            </div>
+
+            <div style={cellStyle('devices')}>
+                {expanded.deviceNames.length === 0
+                    ? <AnyChip>any</AnyChip>
+                    : <ChipList
+                        items={expanded.deviceNames}
+                        renderChip={(d, idx) => (
+                            <span key={idx} className="acl-chip acl-chip--device" title={d}>{d}</span>
+                        )}
+                    />
+                }
             </div>
 
             <div style={cellStyle('counter')} title={item.counter}>
                 <span className="fw-cell-mono fw-cell-muted">{item.counter || '—'}</span>
             </div>
 
-            <div style={cellStyle('devices')}>
-                {item.deviceNames.length > 0
-                    ? <ValueCell values={item.deviceNames} />
-                    : <AnyBadge label="any" />
-                }
+            <div style={{ ...cellStyle('sparkline'), gap: 4 }}>
+                {item.counter ? (
+                    counterEnabled ? (
+                        <>
+                            {rate ? (
+                                <>
+                                    <Sparkline values={rate.history} width={52} height={16} />
+                                    <span className="fw-cell-pps" title={`${rate.pps.toFixed(0)} pps`}>
+                                        {rate.pps >= 1000
+                                            ? `${(rate.pps / 1000).toFixed(1)}k`
+                                            : rate.pps.toFixed(0)}
+                                    </span>
+                                </>
+                            ) : (
+                                <span className="fw-cell-pps acl-pps-loading" title="Waiting for counter data">…</span>
+                            )}
+                            <button
+                                type="button"
+                                className="acl-counter-toggle acl-counter-toggle--on"
+                                onClick={() => onToggleCounter(item.counter)}
+                                title="Stop tracking this counter"
+                                aria-label="Disable counter"
+                            >
+                                <Icon data={Pause} size={16} />
+                            </button>
+                        </>
+                    ) : (
+                        <>
+                            <span className="fw-cell-pps" style={{ color: 'var(--fw-text-3)' }}>—</span>
+                            <button
+                                type="button"
+                                className="acl-counter-toggle acl-counter-toggle--off"
+                                onClick={() => onToggleCounter(item.counter)}
+                                title={`Track counter "${item.counter}"`}
+                                aria-label="Enable counter"
+                            >
+                                <Icon data={Play} size={16} />
+                            </button>
+                        </>
+                    )
+                ) : (
+                    <span className="fw-cell-pps" style={{ color: 'var(--fw-text-3)' }}>—</span>
+                )}
             </div>
 
-            <div style={cellStyle('vlans')}>
-                {item.isAllVlans
-                    ? <AnyBadge label="any" />
-                    : <span className="fw-cell-mono fw-cell-muted">{item.vlansDisplay || '—'}</span>
-                }
-            </div>
-
-            <div style={cellStyle('srcs')}>
-                {item.isAnySrc
-                    ? <AnyBadge label="any" />
-                    : <ValueCell values={item.sourceCidrs} />
-                }
-            </div>
-
-            <div style={cellStyle('dsts')}>
-                {item.isAnyDst
-                    ? <AnyBadge label="any" />
-                    : <ValueCell values={item.dstCidrs} />
-                }
-            </div>
-
-            <div style={{ ...cellStyle('sparkline'), gap: 8 }}>
-                <Sparkline values={rateData?.history ?? null} width={56} height={16} />
-                <span className="fw-cell-pps">
-                    {rateData ? formatPps(rateData.pps) : '— pps'}
-                </span>
+            <div style={cellStyle('actions')}>
+                <ActionChain actions={item.rule.actions ?? []} />
             </div>
         </div>
     );
@@ -192,53 +257,39 @@ interface RuleTableProps {
     items: RuleItem[];
     selectedIds: Set<string>;
     activeRowId: string | null;
-    /** Map from RuleItem.id to rate data (sparkline history + live pps). */
-    rateValues: Map<string, RuleRate>;
     onSelectionChange: (ids: Set<string>) => void;
     onEditRule: (item: RuleItem) => void;
     currentIsDirty: boolean;
     onSave: () => void;
     onDiscard: () => void;
     onDeleteConfig: () => void;
+    rates: Map<string, RuleRate>;
+    enabledCounterNames: Set<string>;
+    onToggleCounter: (counterName: string) => void;
 }
 
-/** Virtualized rule table using @tanstack/react-virtual. */
+/** Virtualized ACL NG rule table using @tanstack/react-virtual. */
 const RuleTable: React.FC<RuleTableProps> = ({
     items,
     selectedIds,
     activeRowId,
-    rateValues,
     onSelectionChange,
     onEditRule,
     currentIsDirty,
     onSave,
     onDiscard,
     onDeleteConfig,
+    rates,
+    enabledCounterNames,
+    onToggleCounter,
 }) => {
     const scrollRef = useRef<HTMLDivElement>(null);
     const wrapRef = useRef<HTMLDivElement>(null);
     const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT + 20);
-
-    /**
-     * Pending hide timeout id. When the cursor leaves a row we schedule a
-     * short delay before clearing hoveredItem, giving the overlay time to
-     * receive its own mouseenter and cancel the hide.
-     */
+    const headerInnerRef = useRef<HTMLDivElement>(null);
     const hideTimeoutRef = useRef<number | null>(null);
-
-    /**
-     * Hover state for the floating edit button overlay.
-     * hoveredItem is null when no row is hovered.
-     * hoveredStart is the virtualizer `start` offset (px from scroll content top).
-     */
     const [hoveredItem, setHoveredItem] = useState<RuleItem | null>(null);
     const [hoveredStart, setHoveredStart] = useState(0);
-
-    /**
-     * Tracks the vertical scroll offset of the body so the overlay (which is
-     * a child of .fw-tbl-wrap, not the scroll body) can compute its correct
-     * top position: HEADER_HEIGHT + virtualizer_start - scrollTop.
-     */
     const [bodyScrollTop, setBodyScrollTop] = useState(0);
 
     const rowVirtualizer = useVirtualizer({
@@ -251,12 +302,17 @@ const RuleTable: React.FC<RuleTableProps> = ({
     useEffect(() => {
         const el = scrollRef.current;
         if (!el) return;
-        const onScroll = (): void => setBodyScrollTop(el.scrollTop);
-        el.addEventListener('scroll', onScroll, { passive: true });
-        return () => el.removeEventListener('scroll', onScroll);
+        const onBodyScroll = (): void => {
+            setBodyScrollTop(el.scrollTop);
+            const inner = headerInnerRef.current;
+            if (inner) {
+                inner.style.transform = `translateX(-${el.scrollLeft}px)`;
+            }
+        };
+        el.addEventListener('scroll', onBodyScroll, { passive: true });
+        return () => el.removeEventListener('scroll', onBodyScroll);
     }, []);
 
-    // Cancel any pending hide timeout when the table unmounts.
     useEffect(() => () => {
         if (hideTimeoutRef.current !== null) {
             window.clearTimeout(hideTimeoutRef.current);
@@ -274,7 +330,7 @@ const RuleTable: React.FC<RuleTableProps> = ({
         if (selectedIds.size === items.length && items.length > 0) {
             onSelectionChange(new Set());
         } else {
-            onSelectionChange(new Set(items.map((item) => item.id)));
+            onSelectionChange(new Set(items.map(item => item.id)));
         }
     }, [selectedIds.size, items, onSelectionChange]);
 
@@ -284,8 +340,6 @@ const RuleTable: React.FC<RuleTableProps> = ({
             hideTimeoutRef.current = null;
         }
         if (item === null) {
-            // Schedule the hide so the overlay can intercept if the cursor
-            // moved onto it rather than away from the table entirely.
             hideTimeoutRef.current = window.setTimeout(() => {
                 hideTimeoutRef.current = null;
                 setHoveredItem(null);
@@ -300,10 +354,6 @@ const RuleTable: React.FC<RuleTableProps> = ({
         if (hoveredItem) onEditRule(hoveredItem);
     }, [hoveredItem, onEditRule]);
 
-    /**
-     * When the cursor moves from the row into the overlay, cancel the pending
-     * hide so the button stays mounted and clickable.
-     */
     const handleOverlayMouseEnter = useCallback((): void => {
         if (hideTimeoutRef.current !== null) {
             window.clearTimeout(hideTimeoutRef.current);
@@ -317,44 +367,28 @@ const RuleTable: React.FC<RuleTableProps> = ({
 
     const isAllSelected = items.length > 0 && selectedIds.size === items.length;
     const isIndeterminate = selectedIds.size > 0 && selectedIds.size < items.length;
-
     const virtualRows = rowVirtualizer.getVirtualItems();
 
     const footerText = useMemo(() => {
-        if (items.length === 0) return '';
-        if (virtualRows.length === 0) return '';
+        if (items.length === 0 || virtualRows.length === 0) return '';
         const first = virtualRows[0].index + 1;
         const last = virtualRows[virtualRows.length - 1].index + 1;
         return `Shown ${first.toLocaleString()}–${last.toLocaleString()} of ${items.length.toLocaleString()}`;
     }, [virtualRows, items.length]);
 
-    /**
-     * Edit-button overlay y-offset relative to .fw-tbl-wrap (position:relative).
-     *
-     * The overlay is a child of .fw-tbl-wrap, NOT the scroll body.  This means:
-     *   • right: 0 resolves against .fw-tbl-wrap's right edge = wrap_right (fixed).
-     *   • top must account for the header height and the current scroll position:
-     *       top = HEADER_HEIGHT + virtualizer_start - scrollTop
-     *
-     * Geometry (button center vs header delete button center):
-     *   header delete center  = wrap_right − 8px(padding-right) − 16px(half of 32px) = wrap_right − 24px
-     *   slot width 40px, padding-right 8px, button 26px:
-     *     button center from slot_right = (40 − 8 − 26) / 2 + 13 = 3 + 13 = 16px from content edge
-     *     = 16 + 8 = 24px from slot_right = wrap_right − 24px  ✓
-     *
-     * Horizontal scrolling: the overlay is outside the scroll body so h-scroll
-     * never moves it — it stays permanently at right: 0 of .fw-tbl-wrap.
-     */
     const overlayTopOffset = HEADER_HEIGHT + hoveredStart - bodyScrollTop;
 
     return (
-        <div ref={wrapRef} className="fw-tbl-wrap">
-            {/* Sticky header row */}
+        <div
+            ref={wrapRef}
+            className="fw-tbl-wrap acl-table"
+        >
             <div className="fw-tbl-header-row">
                 <div
                     className="fw-vtbl-header"
-                    style={{ height: HEADER_HEIGHT, minWidth: TOTAL_WIDTH }}
+                    style={{ height: HEADER_HEIGHT }}
                 >
+                    <div ref={headerInnerRef} style={{ display: 'flex', minWidth: TOTAL_WIDTH, height: '100%', alignItems: 'center', willChange: 'transform' }}>
                     <div style={cellStyle('checkbox')}>
                         <Checkbox
                             indeterminate={isIndeterminate}
@@ -367,29 +401,36 @@ const RuleTable: React.FC<RuleTableProps> = ({
                     <div style={{ ...cellStyle('index'), justifyContent: 'center' }}>
                         <span className="fw-th-text">#</span>
                     </div>
-                    <div style={cellStyle('target')}>
-                        <span className="fw-th-text">Target</span>
-                    </div>
-                    <div style={cellStyle('mode')}>
-                        <span className="fw-th-text">Mode</span>
-                    </div>
-                    <div style={cellStyle('counter')}>
-                        <span className="fw-th-text">Counter</span>
-                    </div>
-                    <div style={cellStyle('devices')}>
-                        <span className="fw-th-text">Devices</span>
-                    </div>
-                    <div style={cellStyle('vlans')}>
-                        <span className="fw-th-text">VLANs</span>
-                    </div>
                     <div style={cellStyle('srcs')}>
                         <span className="fw-th-text">Sources</span>
                     </div>
                     <div style={cellStyle('dsts')}>
                         <span className="fw-th-text">Destinations</span>
                     </div>
+                    <div style={cellStyle('src_ports')}>
+                        <span className="fw-th-text">Src ports</span>
+                    </div>
+                    <div style={cellStyle('dst_ports')}>
+                        <span className="fw-th-text">Dst ports</span>
+                    </div>
+                    <div style={cellStyle('protos')}>
+                        <span className="fw-th-text">Protocols</span>
+                    </div>
+                    <div style={cellStyle('vlans')}>
+                        <span className="fw-th-text">VLANs</span>
+                    </div>
+                    <div style={cellStyle('devices')}>
+                        <span className="fw-th-text">Devices</span>
+                    </div>
+                    <div style={cellStyle('counter')}>
+                        <span className="fw-th-text">Counter</span>
+                    </div>
                     <div style={cellStyle('sparkline')}>
                         <span className="fw-th-text">pps</span>
+                    </div>
+                    <div style={cellStyle('actions')}>
+                        <span className="fw-th-text">Actions</span>
+                    </div>
                     </div>
                 </div>
                 <DraftActionButtons
@@ -400,7 +441,6 @@ const RuleTable: React.FC<RuleTableProps> = ({
                 />
             </div>
 
-            {/* Virtualized scroll body */}
             <div
                 ref={scrollRef}
                 className="fw-vtbl-body"
@@ -416,7 +456,7 @@ const RuleTable: React.FC<RuleTableProps> = ({
                             position: 'relative',
                         }}
                     >
-                        {virtualRows.map((virtualRow) => {
+                        {virtualRows.map(virtualRow => {
                             const item = items[virtualRow.index];
                             if (!item) return null;
                             return (
@@ -426,18 +466,18 @@ const RuleTable: React.FC<RuleTableProps> = ({
                                     start={virtualRow.start}
                                     selected={selectedIds.has(item.id)}
                                     active={activeRowId === item.id}
-                                    rateData={rateValues.get(item.id) ?? null}
+                                    rate={rates.get(item.id)}
+                                    counterEnabled={!!item.counter && enabledCounterNames.has(item.counter)}
                                     onToggleSelect={handleToggleSelect}
                                     onHoverChange={handleHoverChange}
+                                    onToggleCounter={onToggleCounter}
                                 />
                             );
                         })}
                     </div>
                 )}
-
             </div>
 
-            {/* Footer */}
             <div className="fw-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
                 <span className="fw-toolbar__count">{footerText}</span>
                 {selectedIds.size > 0 && (
@@ -447,24 +487,6 @@ const RuleTable: React.FC<RuleTableProps> = ({
                 )}
             </div>
 
-            {/*
-              * Floating edit button overlay — direct child of .fw-tbl-wrap
-              * (position:relative), NOT inside the scroll body.
-              *
-              *  right: 0  → always at wrap_right, regardless of horizontal scroll.
-              *  top       → HEADER_HEIGHT + virtualizer_start − scrollTop
-              *              keeps the button vertically aligned with the hovered row
-              *              while the body scrolls.
-              *
-              * Button center geometry (aligns with header delete button):
-              *   slot: 40px wide, padding-right 8px, justify-content:center (32px effective)
-              *   button: 26px centered in 32px → center offset from slot right = 8 + 3 + 13 = 24px
-              *   wrap right − 24px  =  header delete button center  ✓
-              *
-              * The overlay is clipped by .fw-tbl-wrap (overflow:hidden) so it never
-              * bleeds into the header or footer — rows at the very top/bottom that scroll
-              * into the boundary just have the button disappear naturally.
-              */}
             {hoveredItem !== null && (
                 <div
                     className="fw-row-action-slot"
@@ -476,7 +498,7 @@ const RuleTable: React.FC<RuleTableProps> = ({
                         type="button"
                         className="fw-row-edit-btn fw-row-edit-btn--visible"
                         onClick={handleOverlayEdit}
-                        aria-label={`Edit rule ${hoveredItem !== null ? hoveredItem.index + 1 : ''}`}
+                        aria-label={`Edit rule ${hoveredItem.index + 1}`}
                         title="Edit rule"
                     >
                         ✎

--- a/web/src/pages/modules/acl-ng/SaveDiffModal.tsx
+++ b/web/src/pages/modules/acl-ng/SaveDiffModal.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { Dialog, Text } from '@gravity-ui/uikit';
+import * as yaml from 'js-yaml';
+import type { Rule } from '../../../api/acl-ng';
+import { ActionKind } from '../../../api/acl-ng';
+import { formatIPNet } from '../../../utils';
+import { extractBytes } from './utils';
+
+// TODO(acl-ng): structured diff disabled until the per-card layout is reworked.
+
+const ACTION_KIND_YAML_NAMES: Record<ActionKind, string> = {
+    [ActionKind.ACTION_KIND_PASS]: 'ACTION_KIND_PASS',
+    [ActionKind.ACTION_KIND_DENY]: 'ACTION_KIND_DENY',
+    [ActionKind.ACTION_KIND_COUNT]: 'ACTION_KIND_COUNT',
+    [ActionKind.ACTION_KIND_CHECK_STATE]: 'ACTION_KIND_CHECK_STATE',
+    [ActionKind.ACTION_KIND_CREATE_STATE]: 'ACTION_KIND_CREATE_STATE',
+    [ActionKind.ACTION_KIND_LOG]: 'ACTION_KIND_LOG',
+};
+
+/** Serialize ACL rules to the canonical YAML schema matching yanet-cli acl show output. */
+export const rulesToDiffYaml = (rules: Rule[]): string => {
+    const yamlRules = rules.map(r => {
+        const fmtIPNet = (net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] }): string => {
+            const addrBytes = extractBytes(net.addr);
+            const maskBytes = extractBytes(net.mask);
+            if (!addrBytes) return '';
+            return formatIPNet(addrBytes, maskBytes);
+        };
+        const srcs = (r.srcs ?? []).map(fmtIPNet).filter(Boolean);
+        const dsts = (r.dsts ?? []).map(fmtIPNet).filter(Boolean);
+        const fmtRange = (rng: { from?: number; to?: number }): string => {
+            const from = rng.from ?? 0;
+            const to = rng.to ?? 0;
+            if (from === to) return String(from);
+            return `${from}-${to}`;
+        };
+        const src_port_ranges = (r.src_port_ranges ?? []).map(fmtRange);
+        const dst_port_ranges = (r.dst_port_ranges ?? []).map(fmtRange);
+        const proto_ranges = (r.proto_ranges ?? []).map(fmtRange);
+        const vlan_ranges = (r.vlan_ranges ?? []).map(fmtRange);
+        const devices = (r.devices ?? []).map(d => d.name ?? '').filter(Boolean);
+        const actions = (r.actions ?? []).map(a => ({
+            kind: ACTION_KIND_YAML_NAMES[a.kind ?? ActionKind.ACTION_KIND_PASS] ?? 'ACTION_KIND_PASS',
+        }));
+
+        const entry: Record<string, unknown> = {};
+        if (srcs.length > 0) entry['srcs'] = srcs;
+        if (dsts.length > 0) entry['dsts'] = dsts;
+        if (src_port_ranges.length > 0) entry['src_port_ranges'] = src_port_ranges;
+        if (dst_port_ranges.length > 0) entry['dst_port_ranges'] = dst_port_ranges;
+        if (proto_ranges.length > 0) entry['proto_ranges'] = proto_ranges;
+        if (vlan_ranges.length > 0) entry['vlan_ranges'] = vlan_ranges;
+        if (devices.length > 0) entry['devices'] = devices;
+        if (r.counter) entry['counter'] = r.counter;
+        entry['actions'] = actions;
+        return entry;
+    });
+
+    return yaml.dump(
+        { rules: yamlRules },
+        { sortKeys: false, lineWidth: 120, noRefs: true },
+    );
+};
+
+interface SaveDiffModalProps {
+    configName: string;
+    draftRules: Rule[];
+    draftIds: string[];
+    serverRules: Rule[];
+    onClose: () => void;
+    onApply: () => Promise<void>;
+}
+
+/** Confirmation modal for saving the current ACL NG draft. */
+export const SaveDiffModal: React.FC<SaveDiffModalProps> = ({
+    configName,
+    onClose,
+    onApply,
+}) => {
+    const [applying, setApplying] = useState(false);
+
+    const handleApply = async (): Promise<void> => {
+        setApplying(true);
+        try {
+            await onApply();
+        } finally {
+            setApplying(false);
+        }
+    };
+
+    return (
+        <Dialog open onClose={onClose} size="s">
+            <Dialog.Header caption="Save changes" />
+            <Dialog.Body>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <Text variant="subheader-2">Diff preview is under construction.</Text>
+                    <Text variant="body-2" color="secondary">
+                        Click &ldquo;Save&rdquo; to push the current draft of{' '}
+                        <Text variant="code-inline-2">{configName}</Text>{' '}
+                        to the server.
+                    </Text>
+                </div>
+            </Dialog.Body>
+            <Dialog.Footer
+                onClickButtonCancel={onClose}
+                onClickButtonApply={handleApply}
+                textButtonApply="Save"
+                textButtonCancel="Cancel"
+                loading={applying}
+            />
+        </Dialog>
+    );
+};

--- a/web/src/pages/modules/acl-ng/Sparkline.tsx
+++ b/web/src/pages/modules/acl-ng/Sparkline.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+interface SparklineProps {
+    /** Data points to render. Null means no data is available. */
+    values: number[] | null;
+    width?: number;
+    height?: number;
+    color?: string;
+    fill?: boolean;
+}
+
+/**
+ * Pure SVG sparkline component for ACL NG counter cells.
+ * When values is null or empty, renders an empty placeholder slot.
+ */
+const Sparkline: React.FC<SparklineProps> = ({
+    values,
+    width = 64,
+    height = 18,
+    color = 'var(--fw-accent)',
+    fill = true,
+}) => {
+    if (!values || values.length < 2) {
+        return (
+            <span
+                className="fw-spark-empty"
+                title="No counter history available"
+            >
+                --
+            </span>
+        );
+    }
+
+    const max = Math.max(1, ...values);
+    const min = Math.min(0, ...values);
+    const range = Math.max(1, max - min);
+    const step = width / (values.length - 1 || 1);
+
+    const points = values.map((v, idx) => {
+        const x = idx * step;
+        const y = height - ((v - min) / range) * (height - 2) - 1;
+        return [x, y] as [number, number];
+    });
+
+    const path = points
+        .map((p, idx) => `${idx === 0 ? 'M' : 'L'}${p[0].toFixed(1)},${p[1].toFixed(1)}`)
+        .join(' ');
+    const fillPath = `${path} L${width},${height} L0,${height} Z`;
+    const last = points[points.length - 1];
+
+    return (
+        <svg
+            width={width}
+            height={height}
+            viewBox={`0 0 ${width} ${height}`}
+            className="fw-spark-svg"
+            aria-hidden="true"
+        >
+            {fill && <path d={fillPath} fill={color} opacity="0.16" />}
+            <path
+                d={path}
+                fill="none"
+                stroke={color}
+                strokeWidth="1.25"
+                strokeLinejoin="round"
+                strokeLinecap="round"
+            />
+            {last && <circle cx={last[0]} cy={last[1]} r="1.6" fill={color} />}
+        </svg>
+    );
+};
+
+export default Sparkline;

--- a/web/src/pages/modules/acl-ng/YamlIO.tsx
+++ b/web/src/pages/modules/acl-ng/YamlIO.tsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react';
+import type { Rule } from '../../../api/acl-ng';
+import { toaster } from '../../../utils';
+import { rulesToDiffYaml } from './SaveDiffModal';
+import YamlIOModal from '../../../components/YamlIOModal';
+import type { ParseProgress } from '../../../components/YamlIOModal';
+import YamlImportWorker from './yamlImport.worker.ts?worker';
+
+/** Worker message types sent from worker to main thread. */
+type WorkerMessage =
+    | { type: 'progress'; stage: 'yaml' | 'rules'; done: number; total: number }
+    | { type: 'done'; rules: Rule[] }
+    | { type: 'error'; message: string };
+
+/**
+ * Parse YAML text in a dedicated Web Worker, calling onProgress for each
+ * progress event. Resolves with the parsed Rule array, rejects on error.
+ * The worker is terminated after the promise settles.
+ */
+const parseYamlToRulesAsync = (
+    text: string,
+    onProgress: (p: ParseProgress) => void,
+): Promise<Rule[]> => {
+    return new Promise((resolve, reject) => {
+        const worker = new YamlImportWorker();
+
+        worker.onmessage = (e: MessageEvent<WorkerMessage>): void => {
+            const msg = e.data;
+            if (msg.type === 'progress') {
+                onProgress({ stage: msg.stage, done: msg.done, total: msg.total });
+            } else if (msg.type === 'done') {
+                worker.terminate();
+                resolve(msg.rules);
+            } else if (msg.type === 'error') {
+                worker.terminate();
+                reject(new Error(msg.message));
+            }
+        };
+
+        worker.onerror = (err: ErrorEvent): void => {
+            worker.terminate();
+            reject(new Error(err.message));
+        };
+
+        worker.postMessage({ type: 'parse', text });
+    });
+};
+
+/** Import mode: replace all existing rules or append to them. */
+export type ImportMode = 'replace' | 'append';
+
+interface YamlIOProps {
+    configName: string;
+    rules: Rule[];
+    onImport: (configName: string, rules: Rule[], mode: ImportMode) => void;
+}
+
+/** YAML import/export controls for the ACL NG page header. */
+const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport }) => {
+    const [mode, setMode] = useState<ImportMode>('replace');
+
+    useEffect(() => {
+        setMode('replace');
+    }, [configName]);
+
+    const handleImportAsync = async (
+        text: string,
+        onProgress: (p: ParseProgress) => void,
+    ): Promise<void> => {
+        const parsed = await parseYamlToRulesAsync(text, onProgress);
+        onImport(configName, parsed, mode);
+        const modeLabel = mode === 'replace' ? 'replace' : 'append';
+        toaster.success('acl-ng-yaml-import', `Imported ${parsed.length} rules (${modeLabel}).`);
+    };
+
+    const importExtraControls = (
+        <div style={{ display: 'flex', gap: 4 }}>
+            <button
+                type="button"
+                className={mode === 'replace' ? 'fw-btn fw-btn--sm' : 'fw-btn fw-btn--ghost fw-btn--sm'}
+                onClick={() => setMode('replace')}
+            >
+                Replace all
+            </button>
+            <button
+                type="button"
+                className={mode === 'append' ? 'fw-btn fw-btn--sm' : 'fw-btn fw-btn--ghost fw-btn--sm'}
+                onClick={() => setMode('append')}
+            >
+                Append
+            </button>
+        </div>
+    );
+
+    return (
+        <YamlIOModal
+            configName={configName}
+            itemCount={rules.length}
+            itemLabel="rules"
+            exportYaml={() => rulesToDiffYaml(rules)}
+            onImportAsync={handleImportAsync}
+            toastPrefix="acl-ng-yaml"
+            importPlaceholder={
+                'rules:\n' +
+                '  - srcs:\n' +
+                '      - 192.0.2.0/24\n' +
+                '    dsts:\n' +
+                '      - 192.0.3.0/24\n' +
+                '    dst_port_ranges:\n' +
+                '      - "80-80"\n' +
+                '    proto_ranges:\n' +
+                '      - "1536-1791"\n' +
+                '    actions:\n' +
+                '      - kind: ACTION_KIND_PASS'
+            }
+            exportFooterHint="Exports current draft rules (unsaved changes included)."
+            importFooterHint={`Loads into "${configName}" as draft — review before save.`}
+            importButtonLabel="Load as draft"
+            importExtraControls={importExtraControls}
+        />
+    );
+};
+
+export default YamlIO;

--- a/web/src/pages/modules/acl-ng/acl-ng.scss
+++ b/web/src/pages/modules/acl-ng/acl-ng.scss
@@ -1,0 +1,495 @@
+@use '../../../styles/variables' as *;
+@use '../../../styles/mixins' as *;
+
+// ACL NG page styles. Shared chrome (fw-page, fw-tabs, fw-tbl-*, etc.) lives in
+// web/src/styles/draft-page.scss which this page imports. This file covers only
+// ACL-specific chip colors, action chain, editor elements, and override tweaks.
+
+// Chip list container.
+.acl-chip-list {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: nowrap;
+    gap: 3px;
+    overflow: hidden;
+    max-width: 100%;
+}
+
+// Base chip — inherits mono font from fw-cell-mono via composition.
+.acl-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 4px;
+    font-family: var(--fw-font-mono);
+    font-size: 11.5px;
+    font-weight: 500;
+    white-space: nowrap;
+    background: var(--g-color-base-generic-accent);
+    border: 1px solid var(--g-color-line-generic);
+    flex-shrink: 0;
+
+    &--overflow {
+        color: var(--fw-text-3);
+        background: var(--fw-bg-2);
+        border-color: var(--fw-line-2);
+        font-size: 11px;
+    }
+
+    // IPv4 chips — warm beige/tan text; transparent background, border only.
+    &--ipv4 {
+        background: transparent;
+        color: #d6c79a;
+    }
+
+    // IPv6 chips — cool blue-grey text; transparent background, border only.
+    &--ipv6 {
+        background: transparent;
+        color: #c0d3e8;
+    }
+
+    // "any" wildcard chip — dashed border, muted italic text.
+    &--any {
+        background: transparent;
+        color: var(--g-color-text-secondary);
+        border-style: dashed;
+        border-color: var(--g-color-text-hint);
+        font-style: italic;
+    }
+
+    // Port chips — neutral.
+    &--port {
+        background: var(--fw-bg-3);
+        color: var(--fw-text-2);
+        border-color: var(--fw-line-2);
+    }
+
+    // VLAN chips — subtle amber.
+    &--vlan {
+        background: color-mix(in srgb, var(--g-color-base-warning-light) 50%, transparent);
+        color: var(--g-color-text-warning);
+        border-color: color-mix(in srgb, var(--g-color-base-warning-medium) 40%, transparent);
+    }
+
+    // Device chips — muted mono style.
+    &--device {
+        background: var(--fw-bg-2);
+        color: var(--fw-text-2);
+        border-color: var(--fw-line-2);
+    }
+
+    // Proto chips by tone.
+    &--proto {
+        &-tcp {
+            background: color-mix(in srgb, var(--g-color-base-positive-light) 55%, transparent);
+            color: var(--g-color-text-positive);
+            border-color: color-mix(in srgb, var(--g-color-base-positive-medium) 40%, transparent);
+        }
+
+        &-udp {
+            background: color-mix(in srgb, var(--g-color-base-info-light) 55%, transparent);
+            color: var(--g-color-text-info);
+            border-color: color-mix(in srgb, var(--g-color-base-info-medium) 40%, transparent);
+        }
+
+        &-icmp {
+            background: color-mix(in srgb, var(--g-color-base-warning-light) 55%, transparent);
+            color: var(--g-color-text-warning);
+            border-color: color-mix(in srgb, var(--g-color-base-warning-medium) 40%, transparent);
+        }
+
+        &-misc {
+            background: color-mix(in srgb, var(--g-color-base-misc-light) 55%, transparent);
+            color: var(--g-color-text-misc);
+            border-color: color-mix(in srgb, var(--g-color-base-misc-medium) 40%, transparent);
+        }
+
+        &-dim {
+            background: var(--fw-bg-2);
+            color: var(--fw-text-3);
+            border-color: var(--fw-line-2);
+        }
+    }
+}
+
+// Action chain in table cells.
+.acl-action-chain {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    overflow: hidden;
+    max-width: 100%;
+}
+
+.acl-action-empty {
+    color: var(--fw-text-3);
+    font-family: var(--fw-font-mono);
+    font-size: 12px;
+}
+
+.acl-action-arrow {
+    color: var(--fw-text-3);
+    font-size: 11px;
+    flex-shrink: 0;
+}
+
+.acl-action-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 4px;
+    font-family: var(--fw-font-mono);
+    font-size: 11.5px;
+    font-weight: 500;
+    white-space: nowrap;
+    border: 1px solid transparent;
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--fw-text-2);
+    border-color: var(--fw-line-2);
+
+    &--pass {
+        font-weight: 600;
+        background: color-mix(in srgb, var(--g-color-base-positive-light) 60%, transparent);
+        color: var(--g-color-text-positive);
+        border-color: color-mix(in srgb, var(--g-color-base-positive-medium) 50%, transparent);
+    }
+
+    &--deny {
+        font-weight: 600;
+        background: color-mix(in srgb, var(--g-color-base-danger-light) 60%, transparent);
+        color: var(--g-color-text-danger);
+        border-color: color-mix(in srgb, var(--g-color-base-danger-medium) 50%, transparent);
+    }
+
+    &--log {
+        background: color-mix(in srgb, var(--g-color-base-warning-light) 55%, transparent);
+        color: var(--g-color-text-warning);
+        border-color: color-mix(in srgb, var(--g-color-base-warning-medium) 40%, transparent);
+    }
+
+    &--state {
+        background: rgba(111, 221, 224, 0.12);
+        color: #6FDDE0;
+        border-color: rgba(111, 221, 224, 0.25);
+    }
+}
+
+// Action editor (drawer form).
+.acl-action-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.acl-action-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.acl-action-row__idx {
+    color: var(--fw-text-3);
+    font-family: var(--fw-font-mono);
+    font-size: 12px;
+    min-width: 20px;
+}
+
+.acl-action-select {
+    flex: 1;
+}
+
+.acl-action-add-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding-top: 4px;
+}
+
+.acl-action-preset {
+    font-size: 11.5px;
+    padding: 2px 8px;
+    height: auto;
+}
+
+// Proto preset buttons.
+.acl-proto-presets {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: 6px;
+}
+
+.acl-proto-preset {
+    font-size: 11.5px;
+    padding: 2px 8px;
+    height: auto;
+}
+
+// Warning hints in drawer.
+.acl-hint--warn {
+    color: var(--g-color-text-warning);
+}
+
+// Counter toggle button in sparkline cell.
+.acl-counter-toggle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: auto;
+    width: 32px;
+    height: 32px;
+    border: 1px solid var(--fw-line-2);
+    border-radius: 6px;
+    background: transparent;
+    cursor: pointer;
+    line-height: 1;
+    flex-shrink: 0;
+    padding: 0;
+    transition: background 0.1s, border-color 0.1s;
+
+    &--off {
+        color: var(--fw-text-3);
+
+        &:hover {
+            background: var(--fw-bg-2);
+            border-color: var(--fw-accent);
+            color: var(--fw-accent);
+        }
+    }
+
+    &--on {
+        color: var(--fw-accent);
+        border-color: var(--fw-accent);
+        background: color-mix(in srgb, var(--fw-accent) 10%, transparent);
+
+        &:hover {
+            background: color-mix(in srgb, var(--fw-accent) 20%, transparent);
+        }
+    }
+}
+
+.acl-pps-loading {
+    color: var(--fw-text-3);
+    font-family: var(--fw-font-mono);
+    font-size: 11px;
+}
+
+// Structured diff modal styles.
+.acl-diff-summary-bar {
+    display: flex;
+    gap: 14px;
+    align-items: center;
+    padding: 8px 12px;
+    margin-bottom: 16px;
+    background: var(--fw-bg-2);
+    border-radius: 6px;
+    border: 1px solid var(--fw-line);
+    flex-wrap: wrap;
+}
+
+.acl-diff-stat {
+    font-size: 13px;
+    font-weight: 600;
+    font-family: var(--fw-font-mono);
+
+    &--same { color: var(--fw-text-3); }
+    &--add  { color: var(--g-color-text-positive); }
+    &--mod  { color: var(--g-color-text-warning); }
+    &--rem  { color: var(--g-color-text-danger); }
+    &--reord { color: var(--g-color-text-misc); }
+}
+
+.acl-diff-empty-state {
+    text-align: center;
+    color: var(--fw-text-3);
+    font-size: 13px;
+    padding: 32px 0;
+}
+
+.acl-diff-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.acl-diff-section {
+    border-radius: 6px;
+    overflow: hidden;
+    border: 1px solid var(--fw-line);
+
+    &--add  { border-left: 3px solid var(--g-color-base-positive-medium); }
+    &--mod  { border-left: 3px solid var(--g-color-base-warning-medium); }
+    &--rem  { border-left: 3px solid var(--g-color-base-danger-medium); }
+    &--reord { border-left: 3px solid var(--g-color-base-misc-medium); }
+}
+
+.acl-diff-section-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--fw-bg-2);
+    cursor: pointer;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--fw-text-2);
+    border: none;
+    width: 100%;
+    text-align: left;
+
+    &:hover { background: var(--fw-bg-3); }
+}
+
+.acl-diff-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+    background: var(--fw-bg-3);
+    color: var(--fw-text-2);
+    border: 1px solid var(--fw-line-2);
+}
+
+.acl-diff-chevron {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--fw-text-3);
+}
+
+.acl-diff-section-body {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 8px;
+    background: var(--fw-bg);
+}
+
+.acl-diff-card {
+    background: var(--fw-bg-2);
+    border: 1px solid var(--fw-line);
+    border-radius: 5px;
+    overflow: hidden;
+
+    &--add  { border-left: 3px solid var(--g-color-base-positive-medium); }
+    &--mod  { border-left: 3px solid var(--g-color-base-warning-medium); }
+    &--rem  { border-left: 3px solid var(--g-color-base-danger-medium); }
+    &--reord { border-left: 3px solid var(--g-color-base-misc-medium); }
+}
+
+.acl-diff-card-ref {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 10px;
+    border-bottom: 1px solid var(--fw-line);
+    background: var(--fw-bg-3);
+}
+
+.acl-diff-num {
+    font-size: 12px;
+    font-weight: 700;
+    font-family: var(--fw-font-mono);
+    color: var(--fw-text-2);
+}
+
+.acl-diff-badge {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    padding: 1px 5px;
+    border-radius: 3px;
+
+    &--add  { color: var(--g-color-text-positive); background: color-mix(in srgb, var(--g-color-base-positive-light) 60%, transparent); }
+    &--mod  { color: var(--g-color-text-warning); background: color-mix(in srgb, var(--g-color-base-warning-light) 60%, transparent); }
+    &--rem  { color: var(--g-color-text-danger); background: color-mix(in srgb, var(--g-color-base-danger-light) 60%, transparent); }
+    &--reord { color: var(--g-color-text-misc); background: color-mix(in srgb, var(--g-color-base-misc-light) 60%, transparent); }
+}
+
+.acl-diff-arrow {
+    color: var(--fw-text-3);
+    font-size: 11px;
+}
+
+.acl-diff-card-body {
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}
+
+.acl-diff-line {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    flex-wrap: wrap;
+    font-size: 12px;
+}
+
+.acl-diff-label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--fw-text-3);
+    min-width: 52px;
+    padding-top: 2px;
+    flex-shrink: 0;
+}
+
+.acl-diff-mod-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 4px 0;
+    border-bottom: 1px solid var(--fw-line);
+
+    &:last-child { border-bottom: none; }
+}
+
+.acl-diff-before-after {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+    flex-wrap: wrap;
+}
+
+.acl-diff-before,
+.acl-diff-after {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 3px;
+}
+
+// ChipInput toolbar for large lists.
+.acl-chip-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 4px;
+    flex-wrap: wrap;
+}
+
+// Scrollable chip container for many chips.
+.fw-chip-input--many {
+    max-height: 180px;
+    overflow-y: auto;
+    align-content: flex-start;
+}
+
+// The header outer div is a clipping container only — the inner div is
+// translated horizontally in sync with the body scroll via transform.
+// overflow-x: hidden overrides the auto set by draft-page.scss.
+.acl-table .fw-vtbl-header {
+    overflow-x: hidden !important;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
+}

--- a/web/src/pages/modules/acl-ng/chips.tsx
+++ b/web/src/pages/modules/acl-ng/chips.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import type { Action } from '../../../api/acl-ng';
+import { ActionKind, ACTION_KIND_LABELS } from '../../../api/acl-ng';
+import { formatIPNet } from '../../../utils';
+import { extractBytes } from './utils';
+
+// Protocol names per IANA IP protocol number.
+const IP_PROTOS: Record<number, string> = {
+    0: 'HOPOPT', 1: 'ICMP', 2: 'IGMP', 4: 'IPv4', 6: 'TCP',
+    17: 'UDP', 41: 'IPv6', 43: 'IPv6-Route', 44: 'IPv6-Frag',
+    47: 'GRE', 50: 'ESP', 51: 'AH', 58: 'ICMPv6', 59: 'IPv6-NoNxt',
+    60: 'IPv6-Opts', 89: 'OSPF', 103: 'PIM', 112: 'VRRP', 132: 'SCTP',
+};
+
+type ProtoTone = 'tcp' | 'udp' | 'icmp' | 'misc' | 'dim';
+
+const protoTone = (proto: number): ProtoTone => {
+    if (proto === 6) return 'tcp';
+    if (proto === 17) return 'udp';
+    if (proto === 1 || proto === 58) return 'icmp';
+    if (proto === 47 || proto === 50 || proto === 51 || proto === 132) return 'misc';
+    return 'dim';
+};
+
+interface DecodedProto {
+    label: string;
+    tone: ProtoTone | 'dim';
+    title: string;
+}
+
+/** Decode an encoded proto range string "A-B" to a display label + tone. */
+const decodeProtoRange = (rangeStr: string): DecodedProto => {
+    const m = /^(\d+)\s*-\s*(\d+)$/.exec(rangeStr.trim());
+    if (!m) return { label: rangeStr, tone: 'dim', title: rangeStr };
+    const from = parseInt(m[1], 10);
+    const to = parseInt(m[2], 10);
+    const pFrom = from >> 8;
+    const pTo = to >> 8;
+    const sFrom = from & 0xff;
+    const sTo = to & 0xff;
+
+    if (pFrom === pTo) {
+        const name = IP_PROTOS[pFrom] ?? `proto ${pFrom}`;
+        const tone = protoTone(pFrom);
+        if (sFrom === 0 && sTo === 255) {
+            return { label: name, tone, title: rangeStr };
+        }
+        const sub = sFrom === sTo ? String(sFrom) : `${sFrom}-${sTo}`;
+        return { label: `${name}/${sub}`, tone, title: rangeStr };
+    }
+    return { label: `${from}-${to}`, tone: 'dim', title: rangeStr };
+};
+
+/** Collapse "N-N" to "N". Returns empty string for empty input. */
+const collapseRange = (rangeStr: string): string => {
+    const m = /^(\d+)\s*-\s*(\d+)$/.exec(rangeStr.trim());
+    if (!m) return rangeStr;
+    if (m[1] === m[2]) return m[1];
+    return `${m[1]}-${m[2]}`;
+};
+
+interface AnyChipProps {
+    children?: React.ReactNode;
+}
+
+/** Dashed-border muted chip for wildcard values. */
+export const AnyChip: React.FC<AnyChipProps> = ({ children = 'any' }) => (
+    <span className="acl-chip acl-chip--any">{children}</span>
+);
+
+interface ProtoChipProps {
+    rangeStr: string;
+}
+
+/** Renders a single proto range chip with color based on protocol. */
+export const ProtoChip: React.FC<ProtoChipProps> = ({ rangeStr }) => {
+    const { label, tone, title } = decodeProtoRange(rangeStr);
+    return (
+        <span
+            className={`acl-chip acl-chip--proto acl-chip--proto-${tone}`}
+            title={title}
+        >
+            {label}
+        </span>
+    );
+};
+
+interface PortRangeChipProps {
+    rangeStr: string;
+}
+
+/** Renders a single port range chip. Collapses "N-N" to "N". */
+export const PortRangeChip: React.FC<PortRangeChipProps> = ({ rangeStr }) => {
+    const label = collapseRange(rangeStr);
+    return (
+        <span className="acl-chip acl-chip--port" title={rangeStr}>
+            {label}
+        </span>
+    );
+};
+
+interface VlanRangeChipProps {
+    rangeStr: string;
+}
+
+/** Renders a single VLAN range chip. */
+export const VlanRangeChip: React.FC<VlanRangeChipProps> = ({ rangeStr }) => {
+    const label = collapseRange(rangeStr);
+    return (
+        <span className="acl-chip acl-chip--vlan" title={rangeStr}>
+            {label}
+        </span>
+    );
+};
+
+interface IpNetChipProps {
+    cidr: string;
+}
+
+/** Renders a CIDR chip, colored differently for IPv4 vs IPv6. */
+export const IpNetChip: React.FC<IpNetChipProps> = ({ cidr }) => {
+    const isV6 = cidr.includes(':');
+    return (
+        <span
+            className={`acl-chip ${isV6 ? 'acl-chip--ipv6' : 'acl-chip--ipv4'}`}
+            title={cidr}
+        >
+            {cidr}
+        </span>
+    );
+};
+
+/** Format an IPNet wire object to a CIDR string. */
+export const formatIPNetChip = (net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] }): string => {
+    const addrBytes = extractBytes(net.addr);
+    const maskBytes = extractBytes(net.mask);
+    if (!addrBytes || addrBytes.length === 0) return '';
+    return formatIPNet(addrBytes, maskBytes);
+};
+
+interface ChipListProps<T> {
+    items: T[];
+    renderChip: (item: T, idx: number) => React.ReactNode;
+    anyLabel?: string;
+    isAny?: boolean;
+    maxVisible?: number;
+}
+
+/** Renders up to maxVisible chips inline, then "+N" overflow indicator. */
+export const ChipList = <T,>({
+    items,
+    renderChip,
+    anyLabel = 'any',
+    isAny = false,
+    maxVisible = 3,
+}: ChipListProps<T>): React.ReactElement => {
+    if (isAny || items.length === 0) {
+        return <AnyChip>{anyLabel}</AnyChip>;
+    }
+    const visible = items.slice(0, maxVisible);
+    const rest = items.length - visible.length;
+    return (
+        <span className="acl-chip-list" title={String(items)}>
+            {visible.map((item, idx) => renderChip(item, idx))}
+            {rest > 0 && <span className="acl-chip acl-chip--overflow">+{rest}</span>}
+        </span>
+    );
+};
+
+/** Terminal action kinds (chain ends here). */
+const TERMINAL_KINDS = new Set<ActionKind>([
+    ActionKind.ACTION_KIND_PASS,
+    ActionKind.ACTION_KIND_DENY,
+]);
+
+interface ActionChainProps {
+    actions: Action[];
+}
+
+/** Renders an action chain as chips joined by arrows. */
+export const ActionChain: React.FC<ActionChainProps> = ({ actions }) => {
+    if (actions.length === 0) {
+        return <span className="acl-action-empty">—</span>;
+    }
+
+    return (
+        <span className="acl-action-chain">
+            {actions.map((action, idx) => {
+                const kind = action.kind ?? ActionKind.ACTION_KIND_PASS;
+                const label = ACTION_KIND_LABELS[kind] ?? String(kind);
+                const isTerminal = TERMINAL_KINDS.has(kind);
+                const isPass = kind === ActionKind.ACTION_KIND_PASS;
+                const isDeny = kind === ActionKind.ACTION_KIND_DENY;
+
+                const isLog = kind === ActionKind.ACTION_KIND_LOG;
+                const isState =
+                    kind === ActionKind.ACTION_KIND_CREATE_STATE ||
+                    kind === ActionKind.ACTION_KIND_CHECK_STATE;
+
+                let cls = 'acl-action-chip';
+                if (isPass) cls += ' acl-action-chip--pass';
+                else if (isDeny) cls += ' acl-action-chip--deny';
+                else if (isLog) cls += ' acl-action-chip--log';
+                else if (isState) cls += ' acl-action-chip--state';
+                else if (isTerminal) cls += ' acl-action-chip--terminal';
+
+                return (
+                    <React.Fragment key={idx}>
+                        {idx > 0 && <span className="acl-action-arrow" aria-hidden="true">→</span>}
+                        <span className={cls}>{label}</span>
+                    </React.Fragment>
+                );
+            })}
+        </span>
+    );
+};

--- a/web/src/pages/modules/acl-ng/draftReducer.ts
+++ b/web/src/pages/modules/acl-ng/draftReducer.ts
@@ -1,0 +1,254 @@
+import type { Rule } from '../../../api/acl-ng';
+
+/** Monotonically increasing counter for generating stable tmp- ids. */
+let tmpIdCounter = 0;
+const nextTmpId = (): string => `tmp-${++tmpIdCounter}`;
+
+/** Assign stable server ids to a rules array. */
+const serverIds = (rules: Rule[]): string[] => rules.map((_, idx) => `srv-${idx}`);
+
+export interface AclNgDraftState {
+    server: Record<string, Rule[]>;
+    draft: Record<string, Rule[]>;
+    /**
+     * Stable row ids parallel to draft[configName].
+     * server-loaded rules: "srv-N"; locally-added rules: "tmp-N".
+     * Preserved across UPDATE_RULE_AT_INDEX and REMOVE_RULES so that
+     * the structured diff can match rows across mutations.
+     */
+    draftIds: Record<string, string[]>;
+    serverConfigs: string[];
+    localOnlyConfigs: string[];
+    pendingDeleteConfigs: Set<string>;
+    dirty: Set<string>;
+}
+
+export const initialAclNgDraftState: AclNgDraftState = {
+    server: {},
+    draft: {},
+    draftIds: {},
+    serverConfigs: [],
+    localOnlyConfigs: [],
+    pendingDeleteConfigs: new Set(),
+    dirty: new Set(),
+};
+
+export type AclNgDraftAction =
+    | { type: 'LOAD_ALL_CONFIGS'; configs: Array<{ name: string; rules: Rule[] }> }
+    | { type: 'ADD_RULE'; configName: string; rule: Rule }
+    | { type: 'UPDATE_RULE_AT_INDEX'; configName: string; index: number; rule: Rule }
+    | { type: 'REMOVE_RULES'; configName: string; indices: number[] }
+    | { type: 'REPLACE_ALL_RULES'; configName: string; rules: Rule[] }
+    | { type: 'ADD_CONFIG'; configName: string }
+    | { type: 'DELETE_CONFIG'; configName: string }
+    | { type: 'DISCARD_CONFIG'; configName: string }
+    | { type: 'MARK_SAVED'; configName: string };
+
+export const aclNgDraftReducer = (
+    state: AclNgDraftState,
+    action: AclNgDraftAction,
+): AclNgDraftState => {
+    switch (action.type) {
+        case 'LOAD_ALL_CONFIGS': {
+            const newServer: Record<string, Rule[]> = { ...state.server };
+            const newDraft: Record<string, Rule[]> = { ...state.draft };
+            const newDraftIds: Record<string, string[]> = { ...state.draftIds };
+            const serverConfigs: string[] = [];
+            // Use reference equality to detect whether the user has local edits:
+            // if draft[name] === server[name] the config was never mutated locally,
+            // so it is safe to fast-forward to the new server snapshot.
+            for (const { name, rules } of action.configs) {
+                newServer[name] = rules;
+                if (state.draft[name] === state.server[name]) {
+                    newDraft[name] = rules;
+                    newDraftIds[name] = serverIds(rules);
+                }
+                serverConfigs.push(name);
+            }
+            // Configs fresh from the server are never dirty; local-only and
+            // pending-delete configs retain whatever dirty state they had before.
+            const nextDirty = new Set(state.dirty);
+            for (const { name } of action.configs) {
+                if (!state.localOnlyConfigs.includes(name) && !state.pendingDeleteConfigs.has(name)) {
+                    nextDirty.delete(name);
+                }
+            }
+            return {
+                ...state,
+                server: newServer,
+                draft: newDraft,
+                draftIds: newDraftIds,
+                serverConfigs,
+                dirty: nextDirty,
+            };
+        }
+
+        case 'ADD_RULE': {
+            const current = state.draft[action.configName] ?? [];
+            const currentIds = state.draftIds[action.configName] ?? [];
+            const nextDirty = new Set(state.dirty);
+            nextDirty.add(action.configName);
+            return {
+                ...state,
+                draft: { ...state.draft, [action.configName]: [...current, action.rule] },
+                draftIds: { ...state.draftIds, [action.configName]: [...currentIds, nextTmpId()] },
+                dirty: nextDirty,
+            };
+        }
+
+        case 'UPDATE_RULE_AT_INDEX': {
+            const current = state.draft[action.configName] ?? [];
+            const updated = [...current];
+            updated[action.index] = action.rule;
+            // Id is preserved — row identity doesn't change on edit.
+            const nextDirty = new Set(state.dirty);
+            nextDirty.add(action.configName);
+            return {
+                ...state,
+                draft: { ...state.draft, [action.configName]: updated },
+                dirty: nextDirty,
+            };
+        }
+
+        case 'REMOVE_RULES': {
+            const current = state.draft[action.configName] ?? [];
+            const currentIds = state.draftIds[action.configName] ?? [];
+            const toRemove = new Set(action.indices);
+            const updated = current.filter((_, idx) => !toRemove.has(idx));
+            const updatedIds = currentIds.filter((_, idx) => !toRemove.has(idx));
+            const nextDirty = new Set(state.dirty);
+            nextDirty.add(action.configName);
+            return {
+                ...state,
+                draft: { ...state.draft, [action.configName]: updated },
+                draftIds: { ...state.draftIds, [action.configName]: updatedIds },
+                dirty: nextDirty,
+            };
+        }
+
+        case 'REPLACE_ALL_RULES': {
+            const isNew = !state.serverConfigs.includes(action.configName)
+                && !state.localOnlyConfigs.includes(action.configName);
+            const nextDirty = new Set(state.dirty);
+            nextDirty.add(action.configName);
+            return {
+                ...state,
+                draft: { ...state.draft, [action.configName]: action.rules },
+                draftIds: { ...state.draftIds, [action.configName]: action.rules.map(() => nextTmpId()) },
+                localOnlyConfigs: isNew
+                    ? [...state.localOnlyConfigs, action.configName]
+                    : state.localOnlyConfigs,
+                dirty: nextDirty,
+            };
+        }
+
+        case 'ADD_CONFIG': {
+            if (
+                state.serverConfigs.includes(action.configName)
+                || state.localOnlyConfigs.includes(action.configName)
+            ) {
+                return state;
+            }
+            const nextDirty = new Set(state.dirty);
+            nextDirty.add(action.configName);
+            return {
+                ...state,
+                draft: { ...state.draft, [action.configName]: [] },
+                draftIds: { ...state.draftIds, [action.configName]: [] },
+                localOnlyConfigs: [...state.localOnlyConfigs, action.configName],
+                dirty: nextDirty,
+            };
+        }
+
+        case 'DELETE_CONFIG': {
+            const isLocalOnly = state.localOnlyConfigs.includes(action.configName);
+            if (isLocalOnly) {
+                const { [action.configName]: _d, ...draftRest } = state.draft;
+                const { [action.configName]: _di, ...draftIdsRest } = state.draftIds;
+                const nextDirty = new Set(state.dirty);
+                nextDirty.delete(action.configName);
+                return {
+                    ...state,
+                    draft: draftRest,
+                    draftIds: draftIdsRest,
+                    localOnlyConfigs: state.localOnlyConfigs.filter(n => n !== action.configName),
+                    dirty: nextDirty,
+                };
+            }
+            const pendingDeleteConfigs = new Set(state.pendingDeleteConfigs);
+            pendingDeleteConfigs.add(action.configName);
+            const nextDirty = new Set(state.dirty);
+            nextDirty.add(action.configName);
+            return { ...state, pendingDeleteConfigs, dirty: nextDirty };
+        }
+
+        case 'DISCARD_CONFIG': {
+            const serverRules = state.server[action.configName];
+            const pendingDeleteConfigs = new Set(state.pendingDeleteConfigs);
+            pendingDeleteConfigs.delete(action.configName);
+            const nextDirty = new Set(state.dirty);
+            nextDirty.delete(action.configName);
+            if (serverRules === undefined) {
+                // Local-only config: discard means remove it entirely.
+                const { [action.configName]: _d, ...draftRest } = state.draft;
+                const { [action.configName]: _di, ...draftIdsRest } = state.draftIds;
+                return {
+                    ...state,
+                    draft: draftRest,
+                    draftIds: draftIdsRest,
+                    localOnlyConfigs: state.localOnlyConfigs.filter(n => n !== action.configName),
+                    pendingDeleteConfigs,
+                    dirty: nextDirty,
+                };
+            }
+            return {
+                ...state,
+                draft: { ...state.draft, [action.configName]: serverRules },
+                draftIds: { ...state.draftIds, [action.configName]: serverIds(serverRules) },
+                pendingDeleteConfigs,
+                dirty: nextDirty,
+            };
+        }
+
+        case 'MARK_SAVED': {
+            const savedRules = state.draft[action.configName];
+            const pendingDeleteConfigs = new Set(state.pendingDeleteConfigs);
+            pendingDeleteConfigs.delete(action.configName);
+            const nextDirty = new Set(state.dirty);
+            nextDirty.delete(action.configName);
+
+            if (savedRules === undefined) {
+                // Config was pending deletion and is now gone from the server.
+                const { [action.configName]: _s, ...serverRest } = state.server;
+                const { [action.configName]: _d, ...draftRest } = state.draft;
+                const { [action.configName]: _di, ...draftIdsRest } = state.draftIds;
+                return {
+                    ...state,
+                    server: serverRest,
+                    draft: draftRest,
+                    draftIds: draftIdsRest,
+                    serverConfigs: state.serverConfigs.filter(n => n !== action.configName),
+                    localOnlyConfigs: state.localOnlyConfigs.filter(n => n !== action.configName),
+                    pendingDeleteConfigs,
+                    dirty: nextDirty,
+                };
+            }
+
+            // Advance server snapshot to match what was just persisted so that
+            // subsequent LOAD_ALL_CONFIGS can use reference equality correctly.
+            return {
+                ...state,
+                server: { ...state.server, [action.configName]: savedRules },
+                serverConfigs: state.serverConfigs.includes(action.configName)
+                    ? state.serverConfigs
+                    : [...state.serverConfigs, action.configName],
+                localOnlyConfigs: state.localOnlyConfigs.filter(n => n !== action.configName),
+                pendingDeleteConfigs,
+                dirty: nextDirty,
+            };
+        }
+
+        default:
+            return state;
+    }
+};

--- a/web/src/pages/modules/acl-ng/hooks.ts
+++ b/web/src/pages/modules/acl-ng/hooks.ts
@@ -1,0 +1,201 @@
+import { useEffect } from 'react';
+import type { Rule, PortRange, VlanRange, ProtoRange, Action } from '../../../api/acl-ng';
+import { ActionKind } from '../../../api/acl-ng';
+import { formatIPNet } from '../../../utils';
+import { extractBytes } from './utils';
+import type { RuleDraft, RuleItem } from './types';
+import { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
+export { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
+
+/**
+ * Normalize a wire-shape Action.kind into a concrete ActionKind.
+ *
+ * proto3 omits default-value (0) fields from JSON, so a PASS action
+ * arrives as `{}` with kind=undefined. Treat undefined as PASS, not
+ * a missing action.
+ */
+export const normalizeActionKind = (kind: ActionKind | undefined): ActionKind =>
+    kind ?? ActionKind.ACTION_KIND_PASS;
+
+/** Format a single IPNet (base64 bytes) to a CIDR string. */
+const formatIPNetItem = (net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] }): string => {
+    const addrBytes = extractBytes(net.addr);
+    const maskBytes = extractBytes(net.mask);
+    if (!addrBytes || addrBytes.length === 0) return '';
+    return formatIPNet(addrBytes, maskBytes);
+};
+
+/** Format a PortRange or ProtoRange {from, to} to a string like "80" or "80-90". */
+const formatRange = (r: { from?: number; to?: number }): string => {
+    const from = r.from ?? 0;
+    const to = r.to ?? 0;
+    if (from === to) return String(from);
+    return `${from}-${to}`;
+};
+
+/** Returns true when port ranges cover the full 0-65535 domain. */
+const coversAllPorts = (ranges: PortRange[]): boolean => {
+    if (ranges.length === 0) return true;
+    return ranges.some(r => (r.from ?? 0) === 0 && (r.to ?? 0) >= 65535);
+};
+
+/** Returns true when VLAN ranges cover the full 0-4095 domain. */
+const coversAllVlans = (ranges: VlanRange[]): boolean => {
+    if (ranges.length === 0) return true;
+    return ranges.some(r => (r.from ?? 0) === 0 && (r.to ?? 0) >= 4095);
+};
+
+/**
+ * Expand a Rule into its fully-formatted display shape.
+ *
+ * This is the expensive part: it decodes base64 CIDRs and formats all the
+ * range arrays into human-readable strings. Call this inside a per-row
+ * useMemo or on drawer open so only visible rows pay the cost.
+ */
+export const expandRule = (rule: Rule): {
+    sourceCidrs: string[];
+    isAnySrc: boolean;
+    dstCidrs: string[];
+    isAnyDst: boolean;
+    srcPortRanges: string[];
+    isAnySrcPort: boolean;
+    dstPortRanges: string[];
+    isAnyDstPort: boolean;
+    protoRanges: string[];
+    vlanRanges: string[];
+    isAnyVlan: boolean;
+    deviceNames: string[];
+} => {
+    const sourceCidrs = (rule.srcs ?? []).map(formatIPNetItem).filter(Boolean);
+    const dstCidrs = (rule.dsts ?? []).map(formatIPNetItem).filter(Boolean);
+    const srcPortRanges = (rule.src_port_ranges ?? []).map(formatRange);
+    const dstPortRanges = (rule.dst_port_ranges ?? []).map(formatRange);
+    const protoRanges = (rule.proto_ranges ?? []).map(formatRange);
+    const vlanRanges = (rule.vlan_ranges ?? []).map(formatRange);
+    const deviceNames = (rule.devices ?? []).map(d => d.name ?? '').filter(Boolean);
+
+    return {
+        sourceCidrs,
+        isAnySrc: sourceCidrs.length === 0,
+        dstCidrs,
+        isAnyDst: dstCidrs.length === 0,
+        srcPortRanges,
+        isAnySrcPort: coversAllPorts(rule.src_port_ranges ?? []),
+        dstPortRanges,
+        isAnyDstPort: coversAllPorts(rule.dst_port_ranges ?? []),
+        protoRanges,
+        vlanRanges,
+        isAnyVlan: coversAllVlans(rule.vlan_ranges ?? []),
+        deviceNames,
+    };
+};
+
+/**
+ * Alias for expandRule — retained for call sites that use the longer name.
+ *
+ * Expands a wire-format Rule into its fully-decoded display shape.
+ */
+export const expandRuleItem = expandRule;
+
+/** Convert a Rule array and stable ID array to RuleItem array for UI display. */
+export const rulesToNgItems = (rules: Rule[], ids: string[]): RuleItem[] =>
+    rules.map((rule, index) => ({
+        id: ids[index] ?? `rule-${index}`,
+        index,
+        rule,
+        counter: rule.counter ?? '',
+    }));
+
+/** Convert a RuleItem back to a RuleDraft for drawer editing. */
+export const itemToDraft = (item: RuleItem): RuleDraft => ruleToDraft(item.rule);
+
+/** Convert a ProtoRange wire object to the encoded-range string "A-B". */
+export const protoRangeToStr = (r: ProtoRange): string => {
+    const from = r.from ?? 0;
+    const to = r.to ?? 0;
+    if (from === to) return String(from);
+    return `${from}-${to}`;
+};
+
+/** Convert a RuleDraft to a wire Rule. */
+export const draftToRule = (draft: RuleDraft): Rule => {
+    const actions: Action[] = draft.actions.map(kind => ({ kind }));
+    return {
+        actions,
+        counter: draft.counter || undefined,
+        devices: draft.deviceNames.map(name => ({ name })),
+        vlan_ranges: parseRangesRaw(draft.vlanRaw),
+        srcs: parseCidrsToIPNets(draft.sourceCidrs),
+        dsts: parseCidrsToIPNets(draft.dstCidrs),
+        proto_ranges: parseProtoRangesRaw(draft.protoRaw),
+        src_port_ranges: parseRangesRaw(draft.srcPortRaw),
+        dst_port_ranges: parseRangesRaw(draft.dstPortRaw),
+    };
+};
+
+/** Convert a Rule to a RuleDraft for drawer editing. */
+export const ruleToDraft = (rule: Rule): RuleDraft => {
+    const expanded = expandRule(rule);
+    return {
+        sourceCidrs: [...expanded.sourceCidrs],
+        dstCidrs: [...expanded.dstCidrs],
+        srcPortRaw: expanded.srcPortRanges.join(', '),
+        dstPortRaw: expanded.dstPortRanges.join(', '),
+        protoRaw: (rule.proto_ranges ?? []).map(protoRangeToStr).join(', '),
+        vlanRaw: expanded.vlanRanges.join(', '),
+        deviceNames: [...expanded.deviceNames],
+        counter: rule.counter ?? '',
+        actions: (rule.actions ?? []).map(a => normalizeActionKind(a.kind)),
+    };
+};
+
+/** Validate CIDR string (IPv4 or IPv6). Returns true if valid. */
+export const isValidCidr = (s: string): boolean => {
+    const trimmed = s.trim();
+    if (!trimmed) return false;
+    const ipv4 = trimmed.match(/^(\d{1,3}(?:\.\d{1,3}){3})(?:\/(\d{1,2}))?$/);
+    if (ipv4) {
+        const parts = ipv4[1].split('.').map(Number);
+        if (parts.some(n => n > 255)) return false;
+        if (ipv4[2] !== undefined && (Number(ipv4[2]) < 0 || Number(ipv4[2]) > 32)) return false;
+        return true;
+    }
+    const ipv6 = trimmed.match(/^([0-9a-fA-F:]+)(?:\/(\d{1,3}))?$/);
+    if (ipv6 && trimmed.includes(':')) {
+        if (ipv6[2] !== undefined && (Number(ipv6[2]) < 0 || Number(ipv6[2]) > 128)) return false;
+        return true;
+    }
+    return false;
+};
+
+/** Validate device name string. */
+export const isValidDeviceName = (s: string): boolean => /^[a-zA-Z0-9_:.\-]+$/.test(s.trim());
+
+/** Keyboard shortcuts for the ACL NG page. */
+export const useKeyboardShortcuts = (opts: {
+    onNewRule: () => void;
+    onFocusSearch: () => void;
+    onEscape: () => void;
+    drawerOpen: boolean;
+}): void => {
+    const { onNewRule, onFocusSearch, onEscape, drawerOpen } = opts;
+
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape' && drawerOpen) {
+                onEscape();
+                return;
+            }
+            const tag = (e.target as HTMLElement).tagName;
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+            if (e.key === '/' && !e.metaKey && !e.ctrlKey) {
+                e.preventDefault();
+                onFocusSearch();
+            } else if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+                onNewRule();
+            }
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [onNewRule, onFocusSearch, onEscape, drawerOpen]);
+};

--- a/web/src/pages/modules/acl-ng/index.ts
+++ b/web/src/pages/modules/acl-ng/index.ts
@@ -1,0 +1,1 @@
+export { default as AclNgPage } from './AclNgPage';

--- a/web/src/pages/modules/acl-ng/parseHelpers.ts
+++ b/web/src/pages/modules/acl-ng/parseHelpers.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure parse helpers shared between the main thread and the YAML import worker.
+ *
+ * No DOM, no React, no module side-effects beyond js-yaml.
+ * Both hooks.ts and yamlImport.worker.ts import from here.
+ */
+
+import { parseIPToBytes, prefixLengthToMaskBytes, bytesToBase64 } from '../../../utils';
+import type { ProtoRange } from '../../../api/acl-ng';
+
+/** Parse CIDR strings to IPNet array with base64-encoded bytes. */
+export const parseCidrsToIPNets = (cidrs: string[]): Array<{ addr: string; mask: string }> => {
+    const results: Array<{ addr: string; mask: string }> = [];
+    for (const cidr of cidrs) {
+        const parts = cidr.trim().split('/');
+        if (parts.length !== 2) continue;
+        const [ipPart, maskStr] = parts;
+        const prefixLength = parseInt(maskStr, 10);
+        if (isNaN(prefixLength)) continue;
+        const addrBytes = parseIPToBytes(ipPart);
+        if (!addrBytes) continue;
+        const isIPv4 = addrBytes.length === 4;
+        const maxPrefix = isIPv4 ? 32 : 128;
+        if (prefixLength < 0 || prefixLength > maxPrefix) continue;
+        const maskBytes = prefixLengthToMaskBytes(prefixLength, isIPv4 ? 4 : 16);
+        results.push({
+            addr: bytesToBase64(addrBytes),
+            mask: bytesToBase64(maskBytes),
+        });
+    }
+    return results;
+};
+
+/** Parse a port/vlan range string (e.g. "80-90", "80") to a {from, to} object. */
+const parseRangeStr = (s: string): { from: number; to: number } | null => {
+    const trimmed = s.trim();
+    if (!trimmed) return null;
+    if (trimmed.includes('-')) {
+        const [fromStr, toStr] = trimmed.split('-');
+        const from = parseInt(fromStr, 10);
+        const to = parseInt(toStr, 10);
+        if (isNaN(from) || isNaN(to)) return null;
+        return { from, to };
+    }
+    const val = parseInt(trimmed, 10);
+    if (isNaN(val)) return null;
+    return { from: val, to: val };
+};
+
+/** Parse a raw range input string (comma or newline separated) to a range array. */
+export const parseRangesRaw = (raw: string): Array<{ from: number; to: number }> => {
+    if (!raw.trim()) return [];
+    return raw.split(/[,\n]+/)
+        .map(s => parseRangeStr(s))
+        .filter((r): r is { from: number; to: number } => r !== null);
+};
+
+/** Parse encoded proto ranges (e.g. "1536-1791") to ProtoRange wire objects. */
+export const parseProtoRangesRaw = (raw: string): ProtoRange[] => {
+    if (!raw.trim()) return [];
+    return raw.split(/[,\n]+/)
+        .map(s => parseRangeStr(s))
+        .filter((r): r is { from: number; to: number } => r !== null);
+};

--- a/web/src/pages/modules/acl-ng/structuredDiff.ts
+++ b/web/src/pages/modules/acl-ng/structuredDiff.ts
@@ -1,0 +1,163 @@
+import type { Rule, Action } from '../../../api/acl-ng';
+import { formatIPNet } from '../../../utils';
+import { extractBytes } from './utils';
+
+/** Format an IPNet wire object to a CIDR string for comparison purposes. */
+const fmtIPNet = (net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] }): string => {
+    const addrBytes = extractBytes(net.addr);
+    const maskBytes = extractBytes(net.mask);
+    if (!addrBytes || addrBytes.length === 0) return '';
+    return formatIPNet(addrBytes, maskBytes);
+};
+
+/** Serialize a range {from, to} to a canonical string for equality comparison. */
+const fmtRange = (r: { from?: number; to?: number }): string =>
+    `${r.from ?? 0}-${r.to ?? 0}`;
+
+/** Serialize an action to a canonical string. */
+const fmtAction = (a: Action): string => String(a.kind ?? 0);
+
+/** Field names that participate in equality comparison. */
+type RuleField =
+    | 'actions'
+    | 'counter'
+    | 'srcs'
+    | 'dsts'
+    | 'src_port_ranges'
+    | 'dst_port_ranges'
+    | 'proto_ranges'
+    | 'vlan_ranges'
+    | 'devices';
+
+/** Human-readable labels for display in the diff UI. */
+export const RULE_FIELD_LABELS: Record<RuleField, string> = {
+    actions: 'Actions',
+    counter: 'Counter',
+    srcs: 'Sources',
+    dsts: 'Destinations',
+    src_port_ranges: 'Src ports',
+    dst_port_ranges: 'Dst ports',
+    proto_ranges: 'Protocols',
+    vlan_ranges: 'VLANs',
+    devices: 'Devices',
+};
+
+const RULE_FIELDS: RuleField[] = [
+    'actions',
+    'counter',
+    'srcs',
+    'dsts',
+    'src_port_ranges',
+    'dst_port_ranges',
+    'proto_ranges',
+    'vlan_ranges',
+    'devices',
+];
+
+/** Serialize a field from a Rule to a canonical string array for comparison. */
+const fieldValues = (rule: Rule, field: RuleField): string[] => {
+    switch (field) {
+        case 'actions':
+            return (rule.actions ?? []).map(fmtAction);
+        case 'counter':
+            return [rule.counter ?? ''];
+        case 'srcs':
+            return (rule.srcs ?? []).map(fmtIPNet).filter(Boolean);
+        case 'dsts':
+            return (rule.dsts ?? []).map(fmtIPNet).filter(Boolean);
+        case 'src_port_ranges':
+            return (rule.src_port_ranges ?? []).map(fmtRange);
+        case 'dst_port_ranges':
+            return (rule.dst_port_ranges ?? []).map(fmtRange);
+        case 'proto_ranges':
+            return (rule.proto_ranges ?? []).map(fmtRange);
+        case 'vlan_ranges':
+            return (rule.vlan_ranges ?? []).map(fmtRange);
+        case 'devices':
+            return (rule.devices ?? []).map(d => d.name ?? '').filter(Boolean);
+    }
+};
+
+const fieldEqual = (a: Rule, b: Rule, field: RuleField): boolean =>
+    JSON.stringify(fieldValues(a, field)) === JSON.stringify(fieldValues(b, field));
+
+export interface AddedEntry {
+    rule: Rule;
+    newIdx: number;
+    id: string;
+}
+
+export interface RemovedEntry {
+    rule: Rule;
+    oldIdx: number;
+    id: string;
+}
+
+export interface ModifiedEntry {
+    before: Rule;
+    after: Rule;
+    oldIdx: number;
+    newIdx: number;
+    id: string;
+    diffFields: RuleField[];
+}
+
+export interface ReorderedEntry {
+    rule: Rule;
+    oldIdx: number;
+    newIdx: number;
+    id: string;
+}
+
+export interface StructuredDiff {
+    added: AddedEntry[];
+    removed: RemovedEntry[];
+    modified: ModifiedEntry[];
+    reordered: ReorderedEntry[];
+}
+
+/**
+ * Compute a structured diff between two rule arrays.
+ *
+ * Rules are matched by stable id. draftIds[i] is the id for draft[i];
+ * server rules are always assigned ids "srv-N" for index N.
+ *
+ * Action comparison is order-sensitive (action chain order matters for ACL).
+ * CIDR comparison is string-level after formatting (addr+mask bytes → CIDR string).
+ */
+export const computeStructuredDiff = (
+    draft: Rule[],
+    draftIds: string[],
+    server: Rule[],
+): StructuredDiff => {
+    // Server side: always use srv-N ids (matches what draftReducer assigns on load).
+    const sById = new Map(server.map((rule, idx) => [`srv-${idx}`, { rule, idx }]));
+    const lById = new Map(draft.map((rule, idx) => [draftIds[idx] ?? `tmp-${idx}`, { rule, idx }]));
+
+    const added: AddedEntry[] = [];
+    const removed: RemovedEntry[] = [];
+    const modified: ModifiedEntry[] = [];
+    const reordered: ReorderedEntry[] = [];
+
+    for (const [id, { rule: lr, idx: li }] of lById) {
+        const s = sById.get(id);
+        if (!s) {
+            added.push({ rule: lr, newIdx: li, id });
+            continue;
+        }
+        const diffFields = RULE_FIELDS.filter(f => !fieldEqual(lr, s.rule, f));
+        if (diffFields.length > 0) {
+            modified.push({ before: s.rule, after: lr, oldIdx: s.idx, newIdx: li, id, diffFields });
+        } else if (s.idx !== li) {
+            reordered.push({ id, oldIdx: s.idx, newIdx: li, rule: lr });
+        }
+    }
+
+    for (const [id, { rule, idx }] of sById) {
+        if (!lById.has(id)) {
+            removed.push({ rule, oldIdx: idx, id });
+        }
+    }
+
+    return { added, removed, modified, reordered };
+};

--- a/web/src/pages/modules/acl-ng/types.ts
+++ b/web/src/pages/modules/acl-ng/types.ts
@@ -1,0 +1,40 @@
+import type { Rule, ActionKind } from '../../../api/acl-ng';
+
+export type { Rule, ActionKind };
+
+/** Display item produced by rulesToNgItems — one per rule in the draft. */
+export interface RuleItem {
+    /** Stable unique ID (from the server-assigned rule ID). */
+    id: string;
+    /** Zero-based position in the rule array. */
+    index: number;
+    /** Raw wire-format rule. */
+    rule: Rule;
+    /** Counter name (empty string when unset). */
+    counter: string;
+}
+
+/** Mutable draft state for the rule drawer form. */
+export interface RuleDraft {
+    sourceCidrs: string[];
+    dstCidrs: string[];
+    srcPortRaw: string;
+    dstPortRaw: string;
+    protoRaw: string;
+    vlanRaw: string;
+    deviceNames: string[];
+    counter: string;
+    actions: ActionKind[];
+}
+
+export const emptyDraft = (): RuleDraft => ({
+    sourceCidrs: [],
+    dstCidrs: [],
+    srcPortRaw: '',
+    dstPortRaw: '',
+    protoRaw: '',
+    vlanRaw: '',
+    deviceNames: [],
+    counter: '',
+    actions: [],
+});

--- a/web/src/pages/modules/acl-ng/useAclNgDraft.ts
+++ b/web/src/pages/modules/acl-ng/useAclNgDraft.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useReducer, useState } from 'react';
+import { API } from '../../../api';
+import { toaster } from '../../../utils';
+import type { Rule } from '../../../api/acl-ng';
+import {
+    aclNgDraftReducer,
+    initialAclNgDraftState,
+} from './draftReducer';
+import type { AclNgDraftAction } from './draftReducer';
+
+const EMPTY_RULES: Rule[] = [];
+const EMPTY_IDS: string[] = [];
+
+export interface UseAclNgDraftResult {
+    draftConfigs: string[];
+    loading: boolean;
+    draftRules: (configName: string) => Rule[];
+    draftRuleIds: (configName: string) => string[];
+    serverRules: (configName: string) => Rule[];
+    isDirty: (configName: string) => boolean;
+    anyDirty: boolean;
+    dispatchDraft: (action: AclNgDraftAction) => void;
+    saveConfig: (configName: string) => Promise<void>;
+    discardConfig: (configName: string) => void;
+}
+
+/**
+ * Wraps ACL NG config data with a local-draft layer.
+ *
+ * Server state is fetched once on mount via listConfigs + showConfig per name.
+ * All UI mutations go through dispatchDraft and update only local state until
+ * the user explicitly calls saveConfig.
+ */
+export const useAclNgDraft = (): UseAclNgDraftResult => {
+    const [state, rawDispatch] = useReducer(aclNgDraftReducer, initialAclNgDraftState);
+    const [loading, setLoading] = useState(true);
+
+    const dispatchDraft = useCallback((action: AclNgDraftAction): void => {
+        rawDispatch(action);
+    }, []);
+
+    const load = useCallback(async (): Promise<void> => {
+        setLoading(true);
+        try {
+            const listResp = await API.aclng.listConfigs();
+            const names = listResp.configs ?? [];
+
+            const configs = await Promise.all(
+                names.map(async (name): Promise<{ name: string; rules: Rule[] }> => {
+                    try {
+                        const resp = await API.aclng.showConfig({ name });
+                        return { name, rules: resp.rules ?? [] };
+                    } catch {
+                        return { name, rules: [] };
+                    }
+                }),
+            );
+
+            rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });
+        } catch (err) {
+            toaster.error('acl-ng-load', 'Failed to load ACL NG configurations', err);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    const saveConfig = useCallback(async (configName: string): Promise<void> => {
+        const isPendingDelete = state.pendingDeleteConfigs.has(configName);
+
+        if (isPendingDelete) {
+            try {
+                await API.aclng.deleteConfig({ name: configName });
+                rawDispatch({ type: 'MARK_SAVED', configName });
+                toaster.success(`acl-ng-save-${configName}`, `Config "${configName}" deleted.`);
+            } catch (err) {
+                toaster.error(`acl-ng-save-err-${configName}`, `Failed to delete "${configName}"`, err);
+                throw err;
+            }
+            return;
+        }
+
+        const rules = state.draft[configName] ?? [];
+        try {
+            await API.aclng.updateConfig({ name: configName, rules });
+            rawDispatch({ type: 'MARK_SAVED', configName });
+            toaster.success(`acl-ng-save-${configName}`, `Config "${configName}" saved.`);
+        } catch (err) {
+            toaster.error(`acl-ng-save-err-${configName}`, `Failed to save "${configName}"`, err);
+            throw err;
+        }
+    }, [state.draft, state.pendingDeleteConfigs]);
+
+    const discardConfig = useCallback((configName: string): void => {
+        rawDispatch({ type: 'DISCARD_CONFIG', configName });
+    }, []);
+
+    const draftRulesFor = useCallback((configName: string): Rule[] =>
+        state.draft[configName] ?? EMPTY_RULES, [state.draft]);
+
+    const draftRuleIdsFor = useCallback((configName: string): string[] =>
+        state.draftIds[configName] ?? EMPTY_IDS, [state.draftIds]);
+
+    const serverRulesFor = useCallback((configName: string): Rule[] =>
+        state.server[configName] ?? EMPTY_RULES, [state.server]);
+
+    const isDirty = useCallback((configName: string): boolean =>
+        state.dirty.has(configName), [state.dirty]);
+
+    const draftConfigs = [
+        ...state.serverConfigs.filter(n => !state.pendingDeleteConfigs.has(n)),
+        ...state.localOnlyConfigs,
+    ];
+
+    const anyDirty = state.dirty.size > 0;
+
+    return {
+        draftConfigs,
+        loading,
+        draftRules: draftRulesFor,
+        draftRuleIds: draftRuleIdsFor,
+        serverRules: serverRulesFor,
+        isDirty,
+        anyDirty,
+        dispatchDraft,
+        saveConfig,
+        discardConfig,
+    };
+};

--- a/web/src/pages/modules/acl-ng/useAclNgRuleCounters.ts
+++ b/web/src/pages/modules/acl-ng/useAclNgRuleCounters.ts
@@ -1,0 +1,240 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { API } from '../../../api';
+import type { CounterInfo } from '../../../api';
+import { useInterpolatedCounters } from '../../../hooks';
+import type { RuleItem } from './types';
+
+const HISTORY_SIZE = 60;
+
+const appendCapped = (arr: number[], v: number, cap: number): number[] =>
+    arr.length < cap ? [...arr, v] : [...arr.slice(1), v];
+
+const sumCounterValues = (counter: CounterInfo | undefined): bigint => {
+    if (!counter?.instances) return BigInt(0);
+    return counter.instances.reduce((sum, inst) => {
+        if (!inst.values) return sum;
+        const val = inst.values[0];
+        return sum + BigInt(val ?? 0);
+    }, BigInt(0));
+};
+
+const findCounter = (counters: CounterInfo[] | undefined, name: string): CounterInfo | undefined =>
+    counters?.find(c => c.name === name);
+
+interface MountPoint {
+    device: string;
+    pipeline: string;
+    functionName: string;
+    chainName: string;
+}
+
+const discoverMountPoints = async (configName: string): Promise<MountPoint[]> => {
+    const response = await API.inspect.inspect();
+    const info = response.instance_info;
+    if (!info) return [];
+
+    const pipelines = info.pipelines ?? [];
+    const functions = info.functions ?? [];
+    const devices = info.devices ?? [];
+
+    const points: MountPoint[] = [];
+
+    for (const fn of functions) {
+        const fnName = fn.name ?? '';
+        for (const chain of fn.chains ?? []) {
+            const chainName = chain.name ?? '';
+            const hasAcl = (chain.modules ?? []).some(
+                m => m.type === 'acl' && m.name === configName
+            );
+            if (!hasAcl) continue;
+
+            for (const pipeline of pipelines) {
+                const pipelineName = pipeline.name ?? '';
+                if (!(pipeline.functions ?? []).includes(fnName)) continue;
+
+                for (const device of devices) {
+                    const deviceName = device.name ?? '';
+                    const allDevicePipelines = [
+                        ...(device.input_pipelines ?? []),
+                        ...(device.output_pipelines ?? []),
+                    ];
+                    if (!allDevicePipelines.some(dp => dp.name === pipelineName)) continue;
+
+                    points.push({ device: deviceName, pipeline: pipelineName, functionName: fnName, chainName });
+                }
+            }
+        }
+    }
+
+    return points;
+};
+
+/** Per-rule rate data: rolling history for the sparkline and the latest interpolated pps. */
+export interface RuleRate {
+    history: number[];
+    pps: number;
+}
+
+export interface UseAclNgRuleCountersResult {
+    /** Map from RuleItem.id to rate data (history + live pps). */
+    rates: Map<string, RuleRate>;
+}
+
+/**
+ * Polls CountersService.Module once per second for the enabled subset of ACL rules.
+ * Only rules whose counter name appears in enabledCounters are polled; if the set is
+ * empty, no requests are made at all.
+ *
+ * When paused (enabled=false), polling stops but last-known values are preserved so
+ * sparklines freeze rather than disappear.
+ */
+export const useAclNgRuleCounters = (
+    configName: string,
+    rules: RuleItem[],
+    enabledCounters: Set<string>,
+    enabled: boolean,
+): UseAclNgRuleCountersResult => {
+    const [mountPointsEntry, setMountPointsEntry] = useState<{ config: string; points: MountPoint[] }>({ config: '', points: [] });
+    const mountPoints = mountPointsEntry.config === configName ? mountPointsEntry.points : [];
+
+    const historyRef = useRef<Map<string, number[]>>(new Map());
+    const [rates, setRates] = useState<Map<string, RuleRate>>(new Map());
+    const ratesRef = useRef(rates);
+    ratesRef.current = rates;
+
+    // Declared here so the effect below (which reads countersRef.current) can reference it safely.
+    const countersRef = useRef<Map<string, { pps: number }>>(new Map());
+
+    const discoveryGen = useRef(0);
+
+    useEffect(() => {
+        if (!configName) return;
+        historyRef.current = new Map();
+        setMountPointsEntry({ config: '', points: [] });
+        setRates(new Map());
+        discoveryGen.current += 1;
+        const myGen = discoveryGen.current;
+        discoverMountPoints(configName).then(points => {
+            if (myGen !== discoveryGen.current) return;
+            setMountPointsEntry({ config: configName, points });
+        }).catch((err: unknown) => {
+            if (myGen !== discoveryGen.current) return;
+            console.error('Failed to discover ACL NG mount points:', err);
+        });
+    }, [configName]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    useEffect(() => {
+        const history = historyRef.current;
+        const next = new Map<string, RuleRate>();
+        for (const rule of rules) {
+            if (!rule.counter || !enabledCounters.has(rule.counter)) continue;
+            const h = history.get(rule.counter);
+            if (h) next.set(rule.id, { history: h, pps: countersRef.current.get(rule.counter)?.pps ?? 0 });
+        }
+        if (next.size === 0 && ratesRef.current.size === 0) return;
+        setRates(next);
+    }, [rules, enabledCounters]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const rulesRef = useRef(rules);
+    rulesRef.current = rules;
+    const mountPointsRef = useRef(mountPoints);
+    mountPointsRef.current = mountPoints;
+    const enabledCountersRef = useRef(enabledCounters);
+    enabledCountersRef.current = enabledCounters;
+
+    const counterNames = Array.from(enabledCounters).filter(Boolean);
+
+    const fetchCounters = useCallback(async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
+        const result = new Map<string, { packets: bigint; bytes: bigint }>();
+        for (const name of counterNames) {
+            result.set(name, { packets: BigInt(0), bytes: BigInt(0) });
+        }
+
+        const points = mountPointsRef.current;
+        if (points.length === 0 || counterNames.length === 0) return result;
+
+        const fetches = points.map(mp =>
+            API.counters.module({
+                device: mp.device,
+                pipeline: mp.pipeline,
+                function: mp.functionName,
+                chain: mp.chainName,
+                module_type: 'acl',
+                module_name: configName,
+                counter_query: counterNames,
+            }).then(response => response.counters ?? [])
+        );
+
+        const settled = await Promise.allSettled(fetches);
+
+        for (const outcome of settled) {
+            if (outcome.status !== 'fulfilled') continue;
+            const countersArr = outcome.value;
+            for (const counterName of counterNames) {
+                const ci = findCounter(countersArr, counterName);
+                const packets = sumCounterValues(ci);
+                const current = result.get(counterName)!;
+                result.set(counterName, { packets: current.packets + packets, bytes: BigInt(0) });
+            }
+        }
+
+        return result;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [configName, mountPoints, counterNames.join(',')]);
+
+    const { counters } = useInterpolatedCounters({
+        keys: counterNames,
+        fetchCounters,
+        enabled: enabled && mountPoints.length > 0 && counterNames.length > 0,
+        pollingInterval: 1000,
+        interpolationInterval: 30,
+    });
+
+    countersRef.current = counters;
+
+    useEffect(() => {
+        if (!enabled || counterNames.length === 0) return;
+
+        const tick = (): void => {
+            const currentCounters = countersRef.current;
+            const currentRules = rulesRef.current;
+            const currentEnabled = enabledCountersRef.current;
+            if (!currentCounters.size || !currentRules.length) return;
+
+            const history = historyRef.current;
+            let mutated = false;
+
+            for (const [counterName, data] of currentCounters.entries()) {
+                if (!currentEnabled.has(counterName)) continue;
+                const pps = data.pps;
+                const existing = history.get(counterName);
+                if (!existing) {
+                    history.set(counterName, Array(HISTORY_SIZE).fill(pps) as number[]);
+                } else {
+                    history.set(counterName, appendCapped(existing, pps, HISTORY_SIZE));
+                }
+                mutated = true;
+            }
+
+            if (!mutated) return;
+
+            const next = new Map<string, RuleRate>();
+            for (const rule of currentRules) {
+                if (!rule.counter || !currentEnabled.has(rule.counter)) continue;
+                const h = history.get(rule.counter);
+                if (h) {
+                    const pps = currentCounters.get(rule.counter)?.pps ?? 0;
+                    next.set(rule.id, { history: h, pps });
+                }
+            }
+            setRates(next);
+        };
+
+        tick();
+        const id = setInterval(tick, 1000);
+        return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enabled, counterNames.join(',')]);
+
+    return { rates };
+};

--- a/web/src/pages/modules/acl-ng/utils.ts
+++ b/web/src/pages/modules/acl-ng/utils.ts
@@ -1,0 +1,15 @@
+/** Convert raw bytes in various formats to a number array. */
+export const extractBytes = (data: string | Uint8Array | number[] | undefined): number[] | undefined => {
+    if (!data) return undefined;
+    if (Array.isArray(data)) return data;
+    if (data instanceof Uint8Array) return Array.from(data);
+    if (typeof data === 'string') {
+        try {
+            const binary = atob(data);
+            return Array.from(binary, (c) => c.charCodeAt(0));
+        } catch {
+            return undefined;
+        }
+    }
+    return undefined;
+};

--- a/web/src/pages/modules/acl-ng/yamlImport.worker.ts
+++ b/web/src/pages/modules/acl-ng/yamlImport.worker.ts
@@ -1,0 +1,149 @@
+/**
+ * Web Worker for off-main-thread YAML import.
+ *
+ * Message protocol:
+ *   In  (main → worker): { type: 'parse', text: string }
+ *   Out (worker → main): { type: 'progress', stage: 'yaml' | 'rules', done: number, total: number }
+ *                      | { type: 'done', rules: Rule[] }
+ *                      | { type: 'error', message: string }
+ */
+
+import yaml from 'js-yaml';
+import { ActionKind } from '../../../api/acl-ng';
+import type { Rule } from '../../../api/acl-ng';
+import { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
+
+/** Raw shape of an action entry in the YAML schema. */
+interface YamlAction {
+    kind?: string;
+}
+
+/** Raw shape of a rule entry in the YAML schema. */
+interface YamlRule {
+    srcs?: unknown;
+    dsts?: unknown;
+    src_port_ranges?: unknown;
+    dst_port_ranges?: unknown;
+    proto_ranges?: unknown;
+    vlan_ranges?: unknown;
+    devices?: unknown;
+    counter?: unknown;
+    actions?: unknown;
+}
+
+const ACTION_KIND_FROM_STRING: Record<string, ActionKind> = {
+    ACTION_KIND_PASS: ActionKind.ACTION_KIND_PASS,
+    ACTION_KIND_DENY: ActionKind.ACTION_KIND_DENY,
+    ACTION_KIND_COUNT: ActionKind.ACTION_KIND_COUNT,
+    ACTION_KIND_CHECK_STATE: ActionKind.ACTION_KIND_CHECK_STATE,
+    ACTION_KIND_CREATE_STATE: ActionKind.ACTION_KIND_CREATE_STATE,
+    ACTION_KIND_LOG: ActionKind.ACTION_KIND_LOG,
+};
+
+const parseStringArray = (val: unknown): string[] => {
+    if (!Array.isArray(val)) return [];
+    return (val as unknown[]).filter((s): s is string => typeof s === 'string');
+};
+
+const convertRow = (r: unknown): Rule => {
+    if (!r || typeof r !== 'object') return {};
+    const row = r as YamlRule;
+
+    const srcs = parseCidrsToIPNets(parseStringArray(row.srcs));
+    const dsts = parseCidrsToIPNets(parseStringArray(row.dsts));
+
+    const srcPortStrings = parseStringArray(row.src_port_ranges);
+    const src_port_ranges = srcPortStrings.length > 0 ? parseRangesRaw(srcPortStrings.join(', ')) : [];
+
+    const dstPortStrings = parseStringArray(row.dst_port_ranges);
+    const dst_port_ranges = dstPortStrings.length > 0 ? parseRangesRaw(dstPortStrings.join(', ')) : [];
+
+    const protoStrings = parseStringArray(row.proto_ranges);
+    const proto_ranges = protoStrings.length > 0 ? parseProtoRangesRaw(protoStrings.join(', ')) : [];
+
+    const vlanStrings = parseStringArray(row.vlan_ranges);
+    const vlan_ranges = vlanStrings.length > 0 ? parseRangesRaw(vlanStrings.join(', ')) : [];
+
+    const devices = parseStringArray(row.devices).map(name => ({ name }));
+    const counter = typeof row.counter === 'string' ? row.counter : undefined;
+
+    const actionsRaw = Array.isArray(row.actions) ? row.actions as unknown[] : [];
+    const actions = actionsRaw
+        .filter((a): a is YamlAction => !!a && typeof a === 'object')
+        .map((a): { kind: ActionKind } | null => {
+            if (typeof a.kind !== 'string') return null;
+            const kind = ACTION_KIND_FROM_STRING[a.kind];
+            if (kind === undefined) return null;
+            return { kind };
+        })
+        .filter((a): a is { kind: ActionKind } => a !== null);
+
+    return { srcs, dsts, src_port_ranges, dst_port_ranges, proto_ranges, vlan_ranges, devices, counter, actions };
+};
+
+/** Convert raw rule rows in chunks, posting progress after each chunk. */
+const convertRulesChunked = (rawRules: unknown[]): Promise<Rule[]> => {
+    const CHUNK_SIZE = 2000;
+    const total = rawRules.length;
+    const results: Rule[] = new Array(total);
+
+    return new Promise((resolve) => {
+        let offset = 0;
+
+        const processChunk = (): void => {
+            const end = Math.min(offset + CHUNK_SIZE, total);
+            for (let idx = offset; idx < end; idx++) {
+                results[idx] = convertRow(rawRules[idx]);
+            }
+            offset = end;
+
+            self.postMessage({ type: 'progress', stage: 'rules', done: offset, total });
+
+            if (offset < total) {
+                setTimeout(processChunk, 0);
+            } else {
+                resolve(results);
+            }
+        };
+
+        processChunk();
+    });
+};
+
+self.onmessage = async (e: MessageEvent<{ type: string; text: string }>): Promise<void> => {
+    if (e.data.type !== 'parse') return;
+
+    const { text } = e.data;
+
+    self.postMessage({ type: 'progress', stage: 'yaml', done: 0, total: 1 });
+
+    let parsed: unknown;
+    try {
+        parsed = yaml.load(text);
+    } catch (err) {
+        self.postMessage({ type: 'error', message: `YAML parse error: ${(err as Error).message}` });
+        return;
+    }
+
+    self.postMessage({ type: 'progress', stage: 'yaml', done: 1, total: 1 });
+
+    if (!parsed || typeof parsed !== 'object') {
+        self.postMessage({ type: 'error', message: 'Expected a YAML object with a "rules" list.' });
+        return;
+    }
+
+    const doc = parsed as Record<string, unknown>;
+    if (!Array.isArray(doc['rules'])) {
+        self.postMessage({ type: 'error', message: 'Expected a top-level "rules" list.' });
+        return;
+    }
+
+    const rawRules = doc['rules'] as unknown[];
+
+    try {
+        const rules = await convertRulesChunked(rawRules);
+        self.postMessage({ type: 'done', rules });
+    } catch (err) {
+        self.postMessage({ type: 'error', message: `Conversion error: ${(err as Error).message}` });
+    }
+};

--- a/web/src/styles/draft-page.scss
+++ b/web/src/styles/draft-page.scss
@@ -65,8 +65,8 @@
 .fw-page {
     display: flex;
     flex-direction: column;
-    min-height: 0;
     flex: 1;
+    min-height: 0;
     background: var(--fw-page-bg);
     color: var(--fw-text);
     font-size: 13px;
@@ -882,6 +882,42 @@
 }
 
 .fw-modal__or { color: var(--fw-text-3); }
+
+.fw-modal__load-progress {
+    font-size: 12px;
+    color: var(--fw-accent);
+    font-variant-numeric: tabular-nums;
+}
+
+.fw-parse-progress {
+    height: 4px;
+    background: var(--fw-line-2);
+    border-radius: 2px;
+    overflow: hidden;
+
+    &__bar {
+        height: 100%;
+        background: var(--fw-accent);
+        border-radius: 2px;
+        transition: width 0.15s ease;
+        min-width: 2px;
+    }
+}
+
+.fw-modal__large-file-notice {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 120px;
+    border: 1px dashed var(--fw-line-2);
+    border-radius: 6px;
+    color: var(--fw-text-3);
+    font-size: 13px;
+    padding: 16px 24px;
+    text-align: center;
+    background: var(--fw-bg-2);
+}
 
 .fw-code-area {
     flex: 1;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -8,6 +8,7 @@ export const PAGE_IDS = [
     'modules/forward',
     'modules/decap',
     'modules/acl',
+    'modules/acl-ng',
     'modules/pdump',
     'modules/route',
     'operators/route',

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Introduces a new `/modules/acl-ng` page modelled on the forward page with ACL-specific display: chip-rendered cells for sources, destinations, ports, protocols, VLANs, devices, and action chains; per-row sparkline toggle wired to the counters API; YAML import via a Web Worker with progress reporting; support for very large configurations (hundreds of thousands of rules).

Also reworks virtualized table sizing across forward, route, decap and acl-ng so the body is sized imperatively via `useContainerHeight` against viewport coordinates, instead of relying on a flex chain through gravity-ui's `AsideHeader` (which does not propagate a definite height).

The diff modal on save is temporarily reduced to a placeholder confirmation; the structured-diff implementation lives behind it for a future revision. The existing `/modules/acl` page is untouched.