### PR TITLE
fix(web/acl-ng): delete-config flow plus miscellaneous UX

### DIFF
--- a/web/src/pages/_shared/draft/BulkDeleteModal.tsx
+++ b/web/src/pages/_shared/draft/BulkDeleteModal.tsx
@@ -27,7 +27,7 @@ const BulkDeleteModal: React.FC<BulkDeleteModalProps> = ({
                     <button type="button" className="fw-icon-btn" onClick={onClose} aria-label="Close">✕</button>
                 </header>
                 <div className="fw-modal__body fw-modal__body--confirm">
-                    <p>Delete <strong>{count}</strong> selected {itemNoun}(s) from <code>{configName}</code>? This cannot be undone.</p>
+                    <p>Delete <strong>{count}</strong> selected {itemNoun}(s) from <code>{configName}</code>? Changes are staged in the draft; discard the draft to revert.</p>
                 </div>
                 <footer className="fw-modal__foot">
                     <span />

--- a/web/src/pages/modules/acl-ng/AclNgPage.tsx
+++ b/web/src/pages/modules/acl-ng/AclNgPage.tsx
@@ -29,6 +29,7 @@ const AclNgPage: React.FC = () => {
         anyDirty,
         dispatchDraft,
         saveConfig,
+        commitDeleteConfig,
         discardConfig,
     } = useAclNgDraft();
 
@@ -135,11 +136,16 @@ const AclNgPage: React.FC = () => {
         setDeleteConfirmOpen(false);
     }, [selectedIds, visibleItems, currentConfig, dispatchDraft]);
 
-    const handleDeleteConfig = useCallback((): void => {
-        dispatchDraft({ type: 'DELETE_CONFIG', configName: currentConfig });
-        setActiveConfig('');
+    const handleDeleteConfig = useCallback(async (): Promise<void> => {
+        const name = currentConfig;
         setDeleteConfigOpen(false);
-    }, [currentConfig, dispatchDraft]);
+        try {
+            await commitDeleteConfig(name);
+            setActiveConfig('');
+        } catch {
+            // Toast already surfaced by the hook.
+        }
+    }, [currentConfig, commitDeleteConfig]);
 
     const handleSave = useCallback(async (): Promise<void> => {
         await saveConfig(currentConfig);

--- a/web/src/pages/modules/acl-ng/RuleDrawer.tsx
+++ b/web/src/pages/modules/acl-ng/RuleDrawer.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import { ActionKind, ACTION_KIND_LABELS } from '../../../api/acl-ng';
+import { TrashIcon } from '../../_shared/draft/DraftActionButtons';
 import type { RuleDraft, RuleItem } from './types';
 import { emptyDraft } from './types';
 import { itemToDraft, isValidCidr, isValidDeviceName } from './hooks';
@@ -147,7 +148,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                     onClick={() => onDelete(ruleItem)}
                                     title="Delete rule"
                                 >
-                                    🗑
+                                    <TrashIcon />
                                 </button>
                             </>
                         )}

--- a/web/src/pages/modules/acl-ng/SaveDiffModal.tsx
+++ b/web/src/pages/modules/acl-ng/SaveDiffModal.tsx
@@ -91,7 +91,7 @@ export const SaveDiffModal: React.FC<SaveDiffModalProps> = ({
     };
 
     return (
-        <Dialog open onClose={onClose} size="s">
+        <Dialog open onClose={onClose} size="s" disableOutsideClick={applying} disableEscapeKeyDown={applying}>
             <Dialog.Header caption="Save changes" />
             <Dialog.Body>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>

--- a/web/src/pages/modules/acl-ng/draftReducer.ts
+++ b/web/src/pages/modules/acl-ng/draftReducer.ts
@@ -212,13 +212,15 @@ export const aclNgDraftReducer = (
 
         case 'MARK_SAVED': {
             const savedRules = state.draft[action.configName];
+            const wasPendingDelete = state.pendingDeleteConfigs.has(action.configName);
             const pendingDeleteConfigs = new Set(state.pendingDeleteConfigs);
             pendingDeleteConfigs.delete(action.configName);
             const nextDirty = new Set(state.dirty);
             nextDirty.delete(action.configName);
 
-            if (savedRules === undefined) {
-                // Config was pending deletion and is now gone from the server.
+            if (wasPendingDelete || savedRules === undefined) {
+                // Config was pending deletion (or never had a draft entry) and is now
+                // gone from the server.
                 const { [action.configName]: _s, ...serverRest } = state.server;
                 const { [action.configName]: _d, ...draftRest } = state.draft;
                 const { [action.configName]: _di, ...draftIdsRest } = state.draftIds;

--- a/web/src/pages/modules/acl-ng/useAclNgDraft.ts
+++ b/web/src/pages/modules/acl-ng/useAclNgDraft.ts
@@ -21,6 +21,7 @@ export interface UseAclNgDraftResult {
     anyDirty: boolean;
     dispatchDraft: (action: AclNgDraftAction) => void;
     saveConfig: (configName: string) => Promise<void>;
+    commitDeleteConfig: (configName: string) => Promise<void>;
     discardConfig: (configName: string) => void;
 }
 
@@ -94,6 +95,23 @@ export const useAclNgDraft = (): UseAclNgDraftResult => {
         }
     }, [state.draft, state.pendingDeleteConfigs]);
 
+    const commitDeleteConfig = useCallback(async (configName: string): Promise<void> => {
+        const isLocalOnly = state.localOnlyConfigs.includes(configName);
+        rawDispatch({ type: 'DELETE_CONFIG', configName });
+        if (isLocalOnly) {
+            return;
+        }
+        try {
+            await API.aclng.deleteConfig({ name: configName });
+            rawDispatch({ type: 'MARK_SAVED', configName });
+            toaster.success(`acl-ng-save-${configName}`, `Config "${configName}" deleted.`);
+        } catch (err) {
+            rawDispatch({ type: 'DISCARD_CONFIG', configName });
+            toaster.error(`acl-ng-save-err-${configName}`, `Failed to delete "${configName}"`, err);
+            throw err;
+        }
+    }, [state.localOnlyConfigs]);
+
     const discardConfig = useCallback((configName: string): void => {
         rawDispatch({ type: 'DISCARD_CONFIG', configName });
     }, []);
@@ -113,7 +131,7 @@ export const useAclNgDraft = (): UseAclNgDraftResult => {
     const draftConfigs = [
         ...state.serverConfigs.filter(n => !state.pendingDeleteConfigs.has(n)),
         ...state.localOnlyConfigs,
-    ];
+    ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }));
 
     const anyDirty = state.dirty.size > 0;
 
@@ -127,6 +145,7 @@ export const useAclNgDraft = (): UseAclNgDraftResult => {
         anyDirty,
         dispatchDraft,
         saveConfig,
+        commitDeleteConfig,
         discardConfig,
     };
 };


### PR DESCRIPTION
Several small ACL NG fixes bundled together.

- Deleting a server-side config now actually deletes it. Previously the tab was hidden from the UI but no API call was made, so the configuration came back on the next page reload. A dedicated hook helper now atomically marks the config for deletion, calls the delete RPC, and rolls back on API failure.
- The save confirmation modal blocks backdrop dismissal and Escape while a save is in flight, so a slow save can't be interrupted by an accidental click outside.
- The bulk-delete confirmation copy is corrected to reflect draft-staging semantics (changes are reversible by discarding the draft).
- Tabs are now sorted alphabetically with numeric collation, so e.g. config2 precedes config10.
- The delete-rule button in the edit drawer uses the shared trash icon instead of an emoji.
- A latent reducer branching bug exposed by the new immediate-delete flow is fixed so the deleted tab no longer reappears in the UI after the API call succeeds.