### PR TITLE
perf(web/acl-ng): non-blocking rule search

### DIFF
--- a/web/src/pages/modules/acl-ng/AclNgPage.tsx
+++ b/web/src/pages/modules/acl-ng/AclNgPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useDeferredValue, useMemo, useRef, useState } from 'react';
 import { Button, Flex, Icon, Text, TextInput } from '@gravity-ui/uikit';
 import { Magnifier, Pause, Play, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
@@ -6,7 +6,7 @@ import { useAclNgDraft } from './useAclNgDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { Rule } from '../../../api/acl-ng';
 import type { RuleItem, RuleDraft } from './types';
-import { rulesToNgItems, expandRuleItem, draftToRule, useKeyboardShortcuts } from './hooks';
+import { rulesToNgItems, draftToRule, useKeyboardShortcuts } from './hooks';
 import { DRAWER_TRANSITION_MS } from './RuleTable';
 import RuleTable from './RuleTable';
 import RuleDrawer from './RuleDrawer';
@@ -73,21 +73,13 @@ const AclNgPage: React.FC = () => {
         return s;
     }, [draftConfigs, isDirty]);
 
+    const deferredSearch = useDeferredValue(search);
+
     const visibleItems = useMemo((): RuleItem[] => {
-        const q = search.trim().toLowerCase();
+        const q = deferredSearch.trim().toLowerCase();
         if (!q) return allItems;
-        return allItems.filter(item => {
-            // Cheap checks first (no CIDR decode).
-            if (item.counter.toLowerCase().includes(q)) return true;
-            // Decode CIDRs and device names only when needed.
-            const expanded = expandRuleItem(item.rule);
-            return (
-                expanded.sourceCidrs.some(s => s.toLowerCase().includes(q)) ||
-                expanded.dstCidrs.some(s => s.toLowerCase().includes(q)) ||
-                expanded.deviceNames.some(d => d.toLowerCase().includes(q))
-            );
-        });
-    }, [allItems, search]);
+        return allItems.filter(item => item.searchText.includes(q));
+    }, [allItems, deferredSearch]);
 
     const openAdd = useCallback((): void => {
         setActiveRowId(null);

--- a/web/src/pages/modules/acl-ng/hooks.ts
+++ b/web/src/pages/modules/acl-ng/hooks.ts
@@ -107,12 +107,22 @@ export const expandRuleItem = expandRule;
 
 /** Convert a Rule array and stable ID array to RuleItem array for UI display. */
 export const rulesToNgItems = (rules: Rule[], ids: string[]): RuleItem[] =>
-    rules.map((rule, index) => ({
-        id: ids[index] ?? `rule-${index}`,
-        index,
-        rule,
-        counter: rule.counter ?? '',
-    }));
+    rules.map((rule, index) => {
+        const expanded = expandRule(rule);
+        const searchText = [
+            rule.counter ?? '',
+            ...expanded.sourceCidrs,
+            ...expanded.dstCidrs,
+            ...expanded.deviceNames,
+        ].join('\n').toLowerCase();
+        return {
+            id: ids[index] ?? `rule-${index}`,
+            index,
+            rule,
+            counter: rule.counter ?? '',
+            searchText,
+        };
+    });
 
 /** Convert a RuleItem back to a RuleDraft for drawer editing. */
 export const itemToDraft = (item: RuleItem): RuleDraft => ruleToDraft(item.rule);

--- a/web/src/pages/modules/acl-ng/types.ts
+++ b/web/src/pages/modules/acl-ng/types.ts
@@ -12,6 +12,8 @@ export interface RuleItem {
     rule: Rule;
     /** Counter name (empty string when unset). */
     counter: string;
+    /** Lowercased substring-search index: counter + decoded CIDRs + device names. */
+    searchText: string;
 }
 
 /** Mutable draft state for the rule drawer form. */


### PR DESCRIPTION
The search filter on the ACL NG page previously decoded every rule's source and destination CIDRs on every keystroke, freezing the main thread for large rule sets.

- Each rule now carries a pre-computed lowercased index string assembled once at load time, covering counter, source and destination networks, and device names.
- The filter is now a simple substring match against that index. No per-keystroke CIDR byte decoding.
- The search input value is wrapped in useDeferredValue so React schedules the filter recompute at low priority. Typing stays responsive even on the largest configs while the visible list catches up a frame or two behind.