### PR TITLE
fix(acl): propagate per-rule counter name from proto to dataplane

### DIFF
--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -130,6 +130,7 @@ func convertRules(reqRules []*aclpb.Rule) ([]AclRule, error) {
 
 		rule := AclRule{
 			Actions:       convertActions(reqRule.Actions),
+			Counter:       reqRule.GetCounter(),
 			Devices:       devices,
 			VlanRanges:    vlanRanges,
 			Src4s:         src4s,

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -1,0 +1,64 @@
+package acl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb"
+)
+
+// TestConvertRulesCounter verifies that the counter field from a proto Rule
+// is correctly propagated to the corresponding AclRule.
+func TestConvertRulesCounter(t *testing.T) {
+	tests := []struct {
+		name     string
+		rules    []*aclpb.Rule
+		wantCnts []string
+	}{
+		{
+			name: "single rule with counter",
+			rules: []*aclpb.Rule{
+				{Counter: "counterA"},
+			},
+			wantCnts: []string{"counterA"},
+		},
+		{
+			name: "multiple rules preserve order and values",
+			rules: []*aclpb.Rule{
+				{Counter: "first"},
+				{Counter: "second"},
+				{Counter: "third"},
+			},
+			wantCnts: []string{"first", "second", "third"},
+		},
+		{
+			name: "empty counter is preserved as empty",
+			rules: []*aclpb.Rule{
+				{Counter: ""},
+			},
+			wantCnts: []string{""},
+		},
+		{
+			name: "mixed empty and non-empty counters",
+			rules: []*aclpb.Rule{
+				{Counter: "named"},
+				{Counter: ""},
+				{Counter: "also-named"},
+			},
+			wantCnts: []string{"named", "", "also-named"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := convertRules(tc.rules)
+			require.NoError(t, err)
+			require.Len(t, got, len(tc.wantCnts))
+			for idx, want := range tc.wantCnts {
+				assert.Equal(t, want, got[idx].Counter)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `convertRules` step in the ACL controlplane built the internal `AclRule` without copying the `counter` field from the proto request. Every rule then reached the C side with an empty counter name and fell through to the `controlplane.c` fallback that synthesises `"rule %d"`, so user-defined counter names from YAML configs never appeared in `yanet-cli-counters module` output.