### PR TITLE
feat(web/acl-ng): align empty-field semantics with dataplane

### DIFF
--- a/web/src/pages/modules/acl-ng/AclNgPage.tsx
+++ b/web/src/pages/modules/acl-ng/AclNgPage.tsx
@@ -326,6 +326,7 @@ const AclNgPage: React.FC = () => {
                     open={drawer.open}
                     mode={drawer.mode}
                     ruleItem={drawer.item}
+                    nextIndex={rawRules.length}
                     onClose={closeDrawer}
                     onSave={handleDrawerApply}
                     onDelete={handleDeleteItem}

--- a/web/src/pages/modules/acl-ng/ChipInput.tsx
+++ b/web/src/pages/modules/acl-ng/ChipInput.tsx
@@ -295,7 +295,6 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
     };
 
     const isMany = value.length > MANY_THRESHOLD;
-    const isWildcard = value.length === 0;
 
     const filteredIndices = useMemo(() => {
         if (!filter.trim()) return value.map((_, idx) => idx);
@@ -365,7 +364,7 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                 className={`fw-chip-input${isMany ? ' fw-chip-input--many' : ''}`}
                 onClick={() => !filter && inputRef.current?.focus()}
             >
-                {isWildcard && wildcardLabel && (
+                {wildcardLabel && value.length === 0 && (
                     <span className="acl-chip acl-chip--any">{wildcardLabel}</span>
                 )}
                 {filteredIndices.map(idx => {

--- a/web/src/pages/modules/acl-ng/RuleDrawer.tsx
+++ b/web/src/pages/modules/acl-ng/RuleDrawer.tsx
@@ -3,14 +3,24 @@ import { ActionKind, ACTION_KIND_LABELS } from '../../../api/acl-ng';
 import { TrashIcon } from '../../_shared/draft/DraftActionButtons';
 import type { RuleDraft, RuleItem } from './types';
 import { emptyDraft } from './types';
-import { itemToDraft, isValidCidr, isValidDeviceName } from './hooks';
+import { itemToDraft, isValidCidr, isValidDeviceName, defaultCounterName, draftToRule, expandRule, deadReasonText } from './hooks';
 import ChipInput from './ChipInput';
 import type { ChipInputHandle } from './ChipInput';
+
+/** Insert any-wildcard CIDRs that aren't already in the chip list. */
+const addWildcards = (cidrs: string[]): string[] => {
+    const next = [...cidrs];
+    if (!next.includes('0.0.0.0/0')) next.push('0.0.0.0/0');
+    if (!next.includes('::/0')) next.push('::/0');
+    return next;
+};
 
 interface RuleDrawerProps {
     open: boolean;
     mode: 'add' | 'edit';
     ruleItem: RuleItem | null;
+    /** Prospective index for a new rule (current rule count). Used for the add-mode counter placeholder. */
+    nextIndex: number;
     onClose: () => void;
     onSave: (draft: RuleDraft) => void;
     onDelete: (item: RuleItem) => void;
@@ -41,6 +51,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
     open,
     mode,
     ruleItem,
+    nextIndex,
     onClose,
     onSave,
     onDelete,
@@ -65,12 +76,14 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
         setIsDirty(true);
     };
 
-    const buildFlushedDraft = (base: RuleDraft): RuleDraft => ({
-        ...base,
-        deviceNames: [...base.deviceNames, ...(deviceNamesRef.current?.flush() ?? [])],
-        sourceCidrs: [...base.sourceCidrs, ...(sourceCidrsRef.current?.flush() ?? [])],
-        dstCidrs: [...base.dstCidrs, ...(dstCidrsRef.current?.flush() ?? [])],
-    });
+    const buildFlushedDraft = (base: RuleDraft): RuleDraft => {
+        return {
+            ...base,
+            deviceNames: [...base.deviceNames, ...(deviceNamesRef.current?.flush() ?? [])],
+            sourceCidrs: [...base.sourceCidrs, ...(sourceCidrsRef.current?.flush() ?? [])],
+            dstCidrs: [...base.dstCidrs, ...(dstCidrsRef.current?.flush() ?? [])],
+        };
+    };
 
     const handleApply = useCallback((): void => {
         const finalDraft = buildFlushedDraft(draft);
@@ -112,6 +125,13 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
     const hasNoTerminal = draft.actions.length > 0 && terminalIdx === -1;
     const hasUnreachable = terminalIdx !== -1 && terminalIdx < draft.actions.length - 1;
 
+    // Compute classification from draft on every render (cheap — a few extractBytes calls).
+    const draftClassification = (() => {
+        const rule = draftToRule(draft);
+        const { isL2, isDead, isDeadIp, isDeadProto } = expandRule(rule);
+        return { isL2, isDead, isDeadIp, isDeadProto };
+    })();
+
     return (
         <>
             <div
@@ -129,6 +149,22 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                     <h2 className="fw-drawer__title">
                         {mode === 'add' ? 'New rule' : (
                             <>Edit rule <span className="fw-drawer__rule-num">#{ruleItem?.index !== undefined ? ruleItem.index + 1 : ''}</span></>
+                        )}
+                        {draftClassification.isDead && (
+                            <span
+                                className="acl-rule-badge acl-rule-badge--dead"
+                                title={deadReasonText(draftClassification)}
+                            >
+                                dead
+                            </span>
+                        )}
+                        {!draftClassification.isDead && draftClassification.isL2 && (
+                            <span
+                                className="acl-rule-badge acl-rule-badge--l2"
+                                title="No IP filter — matches L2 frames per VLAN/device"
+                            >
+                                L2
+                            </span>
                         )}
                     </h2>
                     <div className="fw-drawer__head-actions">
@@ -228,11 +264,18 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                 </label>
                                 <input
                                     className="fw-input"
-                                    placeholder="e.g. my_acl_counter"
+                                    placeholder={mode === 'edit' && ruleItem !== null
+                                        ? `${defaultCounterName(ruleItem.index)} (default)`
+                                        : `${defaultCounterName(nextIndex)} (default)`}
                                     value={draft.counter}
                                     onChange={e => updateField('counter', e.target.value)}
                                 />
-                                <span className="fw-field__hint">Counter name shown in /stats. Leave empty to skip counting.</span>
+                                <span className="fw-field__hint">
+                                    Counter name shown in /stats.
+                                    {ruleItem !== null
+                                        ? ' Leave empty to use the auto-assigned default name (shifts with rule position).'
+                                        : ' Leave empty to use the auto-assigned default name.'}
+                                </span>
                             </div>
                         </div>
                     </section>
@@ -244,7 +287,19 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                 <div className="fw-field">
                                     <label className="fw-field__label">
                                         Sources
-                                        <span className="fw-field__count">{draft.sourceCidrs.length || 'any'}</span>
+                                        <div className="acl-field-label-actions">
+                                            <button
+                                                type="button"
+                                                className="fw-btn fw-btn--ghost fw-btn--sm acl-any-btn"
+                                                onClick={() => {
+                                                    updateField('sourceCidrs', addWildcards(draft.sourceCidrs));
+                                                }}
+                                                title="Add 0.0.0.0/0 and ::/0"
+                                            >
+                                                + any
+                                            </button>
+                                            <span className="fw-field__count">{draft.sourceCidrs.length}</span>
+                                        </div>
                                     </label>
                                     <ChipInput
                                         ref={sourceCidrsRef}
@@ -252,14 +307,26 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                         onChange={v => updateField('sourceCidrs', v)}
                                         placeholder="10.0.0.0/8…"
                                         kind="cidr"
-                                        wildcardLabel="Any source"
                                         validator={isValidCidr}
                                     />
+                                    <span className="fw-field__hint">Empty = no IP match.</span>
                                 </div>
                                 <div className="fw-field">
                                     <label className="fw-field__label">
                                         Destinations
-                                        <span className="fw-field__count">{draft.dstCidrs.length || 'any'}</span>
+                                        <div className="acl-field-label-actions">
+                                            <button
+                                                type="button"
+                                                className="fw-btn fw-btn--ghost fw-btn--sm acl-any-btn"
+                                                onClick={() => {
+                                                    updateField('dstCidrs', addWildcards(draft.dstCidrs));
+                                                }}
+                                                title="Add 0.0.0.0/0 and ::/0"
+                                            >
+                                                + any
+                                            </button>
+                                            <span className="fw-field__count">{draft.dstCidrs.length}</span>
+                                        </div>
                                     </label>
                                     <ChipInput
                                         ref={dstCidrsRef}
@@ -267,9 +334,9 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                         onChange={v => updateField('dstCidrs', v)}
                                         placeholder="192.168.0.0/16…"
                                         kind="cidr"
-                                        wildcardLabel="Any destination"
                                         validator={isValidCidr}
                                     />
+                                    <span className="fw-field__hint">Empty = no IP match.</span>
                                 </div>
                             </div>
                         </div>
@@ -301,7 +368,19 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                 </div>
                             </div>
                             <div className="fw-field">
-                                <label className="fw-field__label">Protocol ranges</label>
+                                <label className="fw-field__label">
+                                    Protocol ranges
+                                    <div className="acl-field-label-actions">
+                                        <button
+                                            type="button"
+                                            className="fw-btn fw-btn--ghost fw-btn--sm acl-any-btn"
+                                            onClick={() => updateField('protoRaw', '0-65535')}
+                                            title="Set to full range (any protocol)"
+                                        >
+                                            + any
+                                        </button>
+                                    </div>
+                                </label>
                                 <input
                                     className="fw-input fw-input--mono"
                                     placeholder="1536-1791"
@@ -311,7 +390,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                 <span className="fw-field__hint">
                                     Encoded as <code>(ip_proto &lt;&lt; 8) | subtype</code>.
                                     TCP=<code>1536-1791</code>, UDP=<code>4352-4607</code>, ICMP=<code>256-511</code>.
-                                    Empty = any.
+                                    Empty = no match.
                                 </span>
                                 <div className="acl-proto-presets">
                                     {[

--- a/web/src/pages/modules/acl-ng/RuleTable.tsx
+++ b/web/src/pages/modules/acl-ng/RuleTable.tsx
@@ -4,7 +4,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { Checkbox, Icon } from '@gravity-ui/uikit';
 import { Pause, Play } from '@gravity-ui/icons';
 import type { RuleItem } from './types';
-import { expandRuleItem } from './hooks';
+import { expandRuleItem, effectiveCounterName, deadReasonText } from './hooks';
 import {
     AnyChip,
     IpNetChip,
@@ -124,34 +124,54 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 />
             </div>
 
-            <div style={{ ...cellStyle('index'), color: 'var(--fw-text-3)', fontVariantNumeric: 'tabular-nums' }}>
+            <div style={{ ...cellStyle('index'), color: 'var(--fw-text-3)', fontVariantNumeric: 'tabular-nums', flexDirection: 'column', gap: 2 }}>
                 <span style={{ fontSize: 12 }}>{item.index + 1}</span>
+                {expanded.isDead && (
+                    <span
+                        className="acl-rule-badge acl-rule-badge--dead"
+                        title={deadReasonText(expanded)}
+                    >
+                        dead
+                    </span>
+                )}
+                {!expanded.isDead && expanded.isL2 && (
+                    <span
+                        className="acl-rule-badge acl-rule-badge--l2"
+                        title="No IP filter — matches L2 frames per VLAN/device"
+                    >
+                        L2
+                    </span>
+                )}
             </div>
 
             <div style={cellStyle('srcs')}>
-                <ChipList
-                    items={expanded.sourceCidrs}
-                    isAny={expanded.isAnySrc}
-                    renderChip={(cidr, idx) => <IpNetChip key={idx} cidr={cidr} />}
-                    label="sources"
-                    inline={2}
-                    summarizeAt={4}
-                    summaryKind="cidr"
-                    getItemText={(cidr) => cidr}
-                />
+                {expanded.isEmptySrc
+                    ? <span className="fw-cell-mono fw-cell-muted">—</span>
+                    : <ChipList
+                        items={expanded.sourceCidrs}
+                        renderChip={(cidr, idx) => <IpNetChip key={idx} cidr={cidr} />}
+                        label="sources"
+                        inline={2}
+                        summarizeAt={4}
+                        summaryKind="cidr"
+                        getItemText={(cidr) => cidr}
+                    />
+                }
             </div>
 
             <div style={cellStyle('dsts')}>
-                <ChipList
-                    items={expanded.dstCidrs}
-                    isAny={expanded.isAnyDst}
-                    renderChip={(cidr, idx) => <IpNetChip key={idx} cidr={cidr} />}
-                    label="destinations"
-                    inline={2}
-                    summarizeAt={4}
-                    summaryKind="cidr"
-                    getItemText={(cidr) => cidr}
-                />
+                {expanded.dstCidrs.length === 0
+                    ? <span className="fw-cell-mono fw-cell-muted">—</span>
+                    : <ChipList
+                        items={expanded.dstCidrs}
+                        renderChip={(cidr, idx) => <IpNetChip key={idx} cidr={cidr} />}
+                        label="destinations"
+                        inline={2}
+                        summarizeAt={4}
+                        summaryKind="cidr"
+                        getItemText={(cidr) => cidr}
+                    />
+                }
             </div>
 
             <div style={cellStyle('src_ports')}>
@@ -181,15 +201,18 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
             </div>
 
             <div style={cellStyle('protos')}>
-                <ChipList
-                    items={expanded.protoRanges}
-                    isAny={expanded.isAnyProto}
-                    anyLabel="any"
-                    renderChip={(r, idx) => <ProtoChip key={idx} rangeStr={r} />}
-                    label="protocols"
-                    inline={2}
-                    summarizeAt={4}
-                />
+                {expanded.protoRanges.length === 0
+                    ? <span className="fw-cell-mono fw-cell-muted">—</span>
+                    : <ChipList
+                        items={expanded.protoRanges}
+                        isAny={expanded.isAnyProto}
+                        anyLabel="any"
+                        renderChip={(r, idx) => <ProtoChip key={idx} rangeStr={r} />}
+                        label="protocols"
+                        inline={2}
+                        summarizeAt={4}
+                    />
+                }
             </div>
 
             <div style={cellStyle('vlans')}>
@@ -220,52 +243,51 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 }
             </div>
 
-            <div style={cellStyle('counter')} title={item.counter}>
-                <span className="fw-cell-mono fw-cell-muted">{item.counter || '—'}</span>
+            <div style={cellStyle('counter')} title={item.counter || `rule ${item.index} (default)`}>
+                {item.counter
+                    ? <span className="fw-cell-mono">{item.counter}</span>
+                    : <span className="fw-cell-mono fw-cell-muted">rule {item.index}</span>
+                }
             </div>
 
             <div style={{ ...cellStyle('sparkline'), gap: 4 }}>
-                {item.counter ? (
-                    counterEnabled ? (
-                        <>
-                            {rate ? (
-                                <>
-                                    <Sparkline values={rate.history} width={52} height={16} />
-                                    <span className="fw-cell-pps" title={`${rate.pps.toFixed(0)} pps`}>
-                                        {rate.pps >= 1000
-                                            ? `${(rate.pps / 1000).toFixed(1)}k`
-                                            : rate.pps.toFixed(0)}
-                                    </span>
-                                </>
-                            ) : (
-                                <span className="fw-cell-pps acl-pps-loading" title="Waiting for counter data">…</span>
-                            )}
-                            <button
-                                type="button"
-                                className="acl-counter-toggle acl-counter-toggle--on"
-                                onClick={() => onToggleCounter(item.counter)}
-                                title="Stop tracking this counter"
-                                aria-label="Disable counter"
-                            >
-                                <Icon data={Pause} size={16} />
-                            </button>
-                        </>
-                    ) : (
-                        <>
-                            <span className="fw-cell-pps" style={{ color: 'var(--fw-text-3)' }}>—</span>
-                            <button
-                                type="button"
-                                className="acl-counter-toggle acl-counter-toggle--off"
-                                onClick={() => onToggleCounter(item.counter)}
-                                title={`Track counter "${item.counter}"`}
-                                aria-label="Enable counter"
-                            >
-                                <Icon data={Play} size={16} />
-                            </button>
-                        </>
-                    )
+                {counterEnabled ? (
+                    <>
+                        {rate ? (
+                            <>
+                                <Sparkline values={rate.history} width={52} height={16} />
+                                <span className="fw-cell-pps" title={`${rate.pps.toFixed(0)} pps`}>
+                                    {rate.pps >= 1000
+                                        ? `${(rate.pps / 1000).toFixed(1)}k`
+                                        : rate.pps.toFixed(0)}
+                                </span>
+                            </>
+                        ) : (
+                            <span className="fw-cell-pps acl-pps-loading" title="Waiting for counter data">…</span>
+                        )}
+                        <button
+                            type="button"
+                            className="acl-counter-toggle acl-counter-toggle--on"
+                            onClick={() => onToggleCounter(effectiveCounterName(item.rule, item.index))}
+                            title="Stop tracking this counter"
+                            aria-label="Disable counter"
+                        >
+                            <Icon data={Pause} size={16} />
+                        </button>
+                    </>
                 ) : (
-                    <span className="fw-cell-pps" style={{ color: 'var(--fw-text-3)' }}>—</span>
+                    <>
+                        <span className="fw-cell-pps" style={{ color: 'var(--fw-text-3)' }}>—</span>
+                        <button
+                            type="button"
+                            className={`acl-counter-toggle acl-counter-toggle--off${!item.counter ? ' acl-counter-toggle--default' : ''}`}
+                            onClick={() => onToggleCounter(effectiveCounterName(item.rule, item.index))}
+                            title={`Track counter "${effectiveCounterName(item.rule, item.index)}"`}
+                            aria-label="Enable counter"
+                        >
+                            <Icon data={Play} size={16} />
+                        </button>
+                    </>
                 )}
             </div>
 
@@ -492,7 +514,7 @@ const RuleTable: React.FC<RuleTableProps> = ({
                                     selected={selectedIds.has(item.id)}
                                     active={activeRowId === item.id}
                                     rate={rates.get(item.id)}
-                                    counterEnabled={!!item.counter && enabledCounterNames.has(item.counter)}
+                                    counterEnabled={enabledCounterNames.has(effectiveCounterName(item.rule, item.index))}
                                     onToggleSelect={handleToggleSelect}
                                     onHoverChange={handleHoverChange}
                                     onToggleCounter={onToggleCounter}

--- a/web/src/pages/modules/acl-ng/acl-ng.scss
+++ b/web/src/pages/modules/acl-ng/acl-ng.scss
@@ -87,6 +87,12 @@
         border-style: dashed;
         border-color: var(--g-color-text-hint);
         font-style: italic;
+
+        // Removable variant — shown in the drawer chip input with an × button.
+        &.acl-chip--any-removable {
+            gap: 2px;
+            padding-right: 3px;
+        }
     }
 
     // Port chips — neutral.
@@ -287,6 +293,12 @@
             border-color: var(--fw-accent);
             color: var(--fw-accent);
         }
+    }
+
+    // Applied to --off toggles whose counter name is auto-assigned (no explicit counter field).
+    // Slightly more muted than a named counter to hint that the name is synthetic.
+    &--default {
+        opacity: 0.6;
     }
 
     &--on {
@@ -550,4 +562,52 @@
     &::-webkit-scrollbar {
         display: none;
     }
+}
+
+// Row classification badges — shown in the index cell and in the drawer header.
+.acl-rule-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 5px;
+    border-radius: 3px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    line-height: 16px;
+    white-space: nowrap;
+    vertical-align: middle;
+    margin-left: 5px;
+
+    &--dead {
+        color: color-mix(in srgb, var(--g-color-text-warning) 80%, transparent);
+        background: color-mix(in srgb, var(--g-color-base-warning-light) 40%, transparent);
+        border: 1px solid color-mix(in srgb, var(--g-color-base-warning-medium) 35%, transparent);
+    }
+
+    &--l2 {
+        color: var(--fw-text-3);
+        background: var(--fw-bg-3);
+        border: 1px solid var(--fw-line-2);
+    }
+}
+
+// Label row with inline action buttons (e.g. "+ any" button next to field count).
+.acl-field-label-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+// Subordinate "+" button inside a field label — kept small and muted.
+.acl-any-btn {
+    font-size: 10px;
+    font-weight: 600;
+    height: 18px;
+    padding: 0 6px;
+    letter-spacing: 0.02em;
+    text-transform: none;
+    opacity: 0.75;
+
+    &:hover { opacity: 1; }
 }

--- a/web/src/pages/modules/acl-ng/hooks.ts
+++ b/web/src/pages/modules/acl-ng/hooks.ts
@@ -41,7 +41,7 @@ const coversAllPorts = (ranges: PortRange[]): boolean => {
 
 /** Returns true when proto ranges cover the full 0-65535 encoded domain. */
 const coversAllProtos = (ranges: ProtoRange[]): boolean => {
-    if (ranges.length === 0) return true;
+    if (ranges.length === 0) return false;
     return ranges.some(r => (r.from ?? 0) === 0 && (r.to ?? 0) >= 65535);
 };
 
@@ -57,12 +57,20 @@ const coversAllVlans = (ranges: VlanRange[]): boolean => {
  * This is the expensive part: it decodes base64 CIDRs and formats all the
  * range arrays into human-readable strings. Call this inside a per-row
  * useMemo or on drawer open so only visible rows pay the cost.
+ *
+ * CIDRs are rendered verbatim — no sentinel collapsing. The classification
+ * booleans (isL2, isDead, isDeadIp, isDeadProto) reflect the dataplane
+ * semantics from modules/acl/api/controlplane.c:235-289:
+ * - isL2: no IP entries on either side — rule fires on L2 frames only.
+ * - isDeadIp: asymmetric src/dst IP families — no family matched on both sides.
+ * - isDeadProto: IP rule with an empty proto_ranges array — matches no traffic.
+ * - isDead: isDeadIp || isDeadProto.
+ * - isEmptySrc: sourceCidrs.length === 0 (no IP match on sources side).
  */
 export const expandRule = (rule: Rule): {
     sourceCidrs: string[];
-    isAnySrc: boolean;
+    isEmptySrc: boolean;
     dstCidrs: string[];
-    isAnyDst: boolean;
     srcPortRanges: string[];
     isAnySrcPort: boolean;
     dstPortRanges: string[];
@@ -72,20 +80,54 @@ export const expandRule = (rule: Rule): {
     vlanRanges: string[];
     isAnyVlan: boolean;
     deviceNames: string[];
+    isL2: boolean;
+    isDeadIp: boolean;
+    isDeadProto: boolean;
+    isDead: boolean;
 } => {
-    const sourceCidrs = (rule.srcs ?? []).map(formatIPNetItem).filter(Boolean);
-    const dstCidrs = (rule.dsts ?? []).map(formatIPNetItem).filter(Boolean);
+    const srcs = rule.srcs ?? [];
+    const dsts = rule.dsts ?? [];
+
+    const sourceCidrs = srcs.map(formatIPNetItem).filter(Boolean);
+    const dstCidrs = dsts.map(formatIPNetItem).filter(Boolean);
+
     const srcPortRanges = (rule.src_port_ranges ?? []).map(formatRange);
     const dstPortRanges = (rule.dst_port_ranges ?? []).map(formatRange);
     const protoRanges = (rule.proto_ranges ?? []).map(formatRange);
     const vlanRanges = (rule.vlan_ranges ?? []).map(formatRange);
     const deviceNames = (rule.devices ?? []).map(d => d.name ?? '').filter(Boolean);
 
+    // Per-family counts for classification (addr byte length: 4 = IPv4, 16 = IPv6).
+    let v4SrcCount = 0;
+    let v6SrcCount = 0;
+    for (const net of srcs) {
+        const len = extractBytes(net.addr)?.length ?? 0;
+        if (len === 4) v4SrcCount++;
+        else if (len === 16) v6SrcCount++;
+    }
+
+    let v4DstCount = 0;
+    let v6DstCount = 0;
+    for (const net of dsts) {
+        const len = extractBytes(net.addr)?.length ?? 0;
+        if (len === 4) v4DstCount++;
+        else if (len === 16) v6DstCount++;
+    }
+
+    const hasIP4 = v4SrcCount > 0 && v4DstCount > 0;
+    const hasIP6 = v6SrcCount > 0 && v6DstCount > 0;
+    const isL2 = v4SrcCount === 0 && v4DstCount === 0 && v6SrcCount === 0 && v6DstCount === 0;
+    // isDeadIp: asymmetric src/dst IP families — no single family is matched on both sides.
+    const isDeadIp = !hasIP4 && !hasIP6 && !isL2;
+    // isDeadProto: an IP rule with an empty proto_ranges array matches no traffic. The proto
+    // compiler lacks the "count === 0 → full range" fallback that ports/vlans/devices have.
+    const isDeadProto = !isL2 && (rule.proto_ranges?.length ?? 0) === 0;
+    const isDead = isDeadIp || isDeadProto;
+
     return {
         sourceCidrs,
-        isAnySrc: sourceCidrs.length === 0,
+        isEmptySrc: sourceCidrs.length === 0,
         dstCidrs,
-        isAnyDst: dstCidrs.length === 0,
         srcPortRanges,
         isAnySrcPort: coversAllPorts(rule.src_port_ranges ?? []),
         dstPortRanges,
@@ -95,7 +137,31 @@ export const expandRule = (rule: Rule): {
         vlanRanges,
         isAnyVlan: coversAllVlans(rule.vlan_ranges ?? []),
         deviceNames,
+        isL2,
+        isDeadIp,
+        isDeadProto,
+        isDead,
     };
+};
+
+/**
+ * Return a human-readable tooltip string explaining why a rule is dead.
+ *
+ * Both isDeadIp and isDeadProto may be true simultaneously; when they are,
+ * a combined message is returned. Returns an empty string if neither is true.
+ */
+export const deadReasonText = (expanded: { isDeadIp: boolean; isDeadProto: boolean }): string => {
+    const { isDeadIp, isDeadProto } = expanded;
+    if (isDeadIp && isDeadProto) {
+        return "IP sources/destinations don't match and protocol filter is empty — rule matches no packets";
+    }
+    if (isDeadIp) {
+        return "IP sources/destinations don't match — rule matches no packets";
+    }
+    if (isDeadProto) {
+        return 'Protocol filter is empty — rule matches no packets';
+    }
+    return '';
 };
 
 /**
@@ -105,12 +171,33 @@ export const expandRule = (rule: Rule): {
  */
 export const expandRuleItem = expandRule;
 
+/**
+ * Return the default counter name the dataplane assigns to a rule at position idx.
+ *
+ * The synthetic name is derived from the rule's CURRENT draft index. The dataplane
+ * registers counters using the LAST COMMITTED index, so if the draft has reordered
+ * rules, sparkline values may temporarily disconnect until the draft is committed.
+ * This is accepted behaviour; no UI warning is shown.
+ */
+export const defaultCounterName = (idx: number): string => `rule ${idx}`;
+
+/**
+ * Return the counter name that the dataplane will actually use for this rule.
+ *
+ * If the rule has an explicit counter set, that name is returned verbatim.
+ * Otherwise the synthetic default name derived from the rule's index is returned.
+ */
+export const effectiveCounterName = (rule: Rule, index: number): string =>
+    rule.counter || defaultCounterName(index);
+
 /** Convert a Rule array and stable ID array to RuleItem array for UI display. */
 export const rulesToNgItems = (rules: Rule[], ids: string[]): RuleItem[] =>
     rules.map((rule, index) => {
         const expanded = expandRule(rule);
+        const counter = rule.counter ?? '';
         const searchText = [
-            rule.counter ?? '',
+            counter,
+            defaultCounterName(index),
             ...expanded.sourceCidrs,
             ...expanded.dstCidrs,
             ...expanded.deviceNames,
@@ -119,7 +206,7 @@ export const rulesToNgItems = (rules: Rule[], ids: string[]): RuleItem[] =>
             id: ids[index] ?? `rule-${index}`,
             index,
             rule,
-            counter: rule.counter ?? '',
+            counter,
             searchText,
         };
     });

--- a/web/src/pages/modules/acl-ng/types.ts
+++ b/web/src/pages/modules/acl-ng/types.ts
@@ -30,11 +30,11 @@ export interface RuleDraft {
 }
 
 export const emptyDraft = (): RuleDraft => ({
-    sourceCidrs: [],
-    dstCidrs: [],
+    sourceCidrs: ['0.0.0.0/0', '::/0'],
+    dstCidrs: ['0.0.0.0/0', '::/0'],
     srcPortRaw: '',
     dstPortRaw: '',
-    protoRaw: '',
+    protoRaw: '0-65535',
     vlanRaw: '',
     deviceNames: [],
     counter: '',

--- a/web/src/pages/modules/acl-ng/useAclNgRuleCounters.ts
+++ b/web/src/pages/modules/acl-ng/useAclNgRuleCounters.ts
@@ -3,6 +3,7 @@ import { API } from '../../../api';
 import type { CounterInfo } from '../../../api';
 import { useInterpolatedCounters } from '../../../hooks';
 import type { RuleItem } from './types';
+import { effectiveCounterName } from './hooks';
 
 const HISTORY_SIZE = 60;
 
@@ -127,9 +128,10 @@ export const useAclNgRuleCounters = (
         const history = historyRef.current;
         const next = new Map<string, RuleRate>();
         for (const rule of rules) {
-            if (!rule.counter || !enabledCounters.has(rule.counter)) continue;
-            const h = history.get(rule.counter);
-            if (h) next.set(rule.id, { history: h, pps: countersRef.current.get(rule.counter)?.pps ?? 0 });
+            const cname = effectiveCounterName(rule.rule, rule.index);
+            if (!enabledCounters.has(cname)) continue;
+            const h = history.get(cname);
+            if (h) next.set(rule.id, { history: h, pps: countersRef.current.get(cname)?.pps ?? 0 });
         }
         if (next.size === 0 && ratesRef.current.size === 0) return;
         setRates(next);
@@ -220,10 +222,11 @@ export const useAclNgRuleCounters = (
 
             const next = new Map<string, RuleRate>();
             for (const rule of currentRules) {
-                if (!rule.counter || !currentEnabled.has(rule.counter)) continue;
-                const h = history.get(rule.counter);
+                const cname = effectiveCounterName(rule.rule, rule.index);
+                if (!currentEnabled.has(cname)) continue;
+                const h = history.get(cname);
                 if (h) {
-                    const pps = currentCounters.get(rule.counter)?.pps ?? 0;
+                    const pps = currentCounters.get(cname)?.pps ?? 0;
                     next.set(rule.id, { history: h, pps });
                 }
             }


### PR DESCRIPTION
The dataplane treats empty CIDR and protocol lists as no-match rather than as a wildcard, and synthesises a per-rule counter name when none is provided. The web UI previously claimed the opposite for several fields, allowing users to silently create rules that match nothing.

Adopt a faithful UI model:

- New rules start with explicit visible wildcards in source, destination and protocol fields, so what is on the wire is what is in the form.
- Quick-add controls insert the wildcards on demand.
- Rules that route nowhere or carry an empty protocol filter are classified at the row level with a muted dead badge and a context-aware tooltip naming the reason.
- Pure L2 rules carry a muted informational badge.
- Empty counter fields render the synthetic default name in a muted style, and the sparkline toggle works for those auto-named counters too.

Empty port, VLAN and device fields keep their wildcard interpretation, matching the dataplane behaviour for those dimensions.