### PR TITLE
fix: stabilize ACL sparkline cell width

### DIFF
--- a/web/src/pages/modules/acl/RuleTable.tsx
+++ b/web/src/pages/modules/acl/RuleTable.tsx
@@ -37,7 +37,7 @@ const COLUMN_WIDTHS = {
     devices: 130,
     counter: 140,
     actions: 190,
-    sparkline: 110,
+    sparkline: 210,
 } as const;
 
 const TOTAL_WIDTH = Object.values(COLUMN_WIDTHS).reduce((a, b) => a + b, 0);
@@ -255,15 +255,18 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                     <>
                         {rate ? (
                             <>
-                                <Sparkline values={rate.history} width={52} height={16} />
-                                <span className="fw-cell-pps" title={`${rate.pps.toFixed(0)} pps`}>
+                                <Sparkline values={rate.history} width={120} height={22} />
+                                <span className="fw-cell-pps acl-cell-pps" title={`${rate.pps.toFixed(0)} pps`}>
                                     {rate.pps >= 1000
                                         ? `${(rate.pps / 1000).toFixed(1)}k`
                                         : rate.pps.toFixed(0)}
                                 </span>
                             </>
                         ) : (
-                            <span className="fw-cell-pps acl-pps-loading" title="Waiting for counter data">…</span>
+                            <>
+                                <Sparkline values={null} width={120} height={22} />
+                                <span className="fw-cell-pps acl-cell-pps acl-pps-loading" title="Waiting for counter data">…</span>
+                            </>
                         )}
                         <button
                             type="button"
@@ -277,7 +280,8 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                     </>
                 ) : (
                     <>
-                        <span className="fw-cell-pps" style={{ color: 'var(--fw-text-3)' }}>—</span>
+                        <Sparkline values={null} width={120} height={22} />
+                        <span className="fw-cell-pps acl-cell-pps" style={{ color: 'var(--fw-text-3)' }}>—</span>
                         <button
                             type="button"
                             className={`acl-counter-toggle acl-counter-toggle--off${!item.counter ? ' acl-counter-toggle--default' : ''}`}

--- a/web/src/pages/modules/acl/Sparkline.tsx
+++ b/web/src/pages/modules/acl/Sparkline.tsx
@@ -25,6 +25,13 @@ const Sparkline: React.FC<SparklineProps> = ({
             <span
                 className="fw-spark-empty"
                 title="No counter history available"
+                style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    width,
+                    height,
+                }}
             >
                 --
             </span>

--- a/web/src/pages/modules/acl/acl.scss
+++ b/web/src/pages/modules/acl/acl.scss
@@ -312,6 +312,12 @@
     }
 }
 
+.acl-cell-pps {
+    display: inline-block;
+    width: 36px;
+    text-align: right;
+}
+
 .acl-pps-loading {
     color: var(--fw-text-3);
     font-family: var(--fw-font-mono);


### PR DESCRIPTION
The sparkline cell in the ACL rule table shifted horizontally between rows depending on the pps digit count ("0" vs "1.5k") and whether counter history had loaded yet (svg vs `--` fallback vs `…` loading text without a sparkline slot). The toggle button stayed right-anchored, but the sparkline and pps text positions visibly jumped row-to-row.

Reserve fixed-width slots so every state renders as `[sparkline 120×22] [pps 36px, right-aligned] [toggle button]`:

- Empty/loading/disabled branches now render a placeholder of the same SVG dimensions instead of unsized text.
- The pps span gets an ACL-local `acl-cell-pps` class with a fixed width (the shared `.fw-cell-pps` used by forward is untouched).
- Enlarge the sparkline from 52×16 to 120×22 and widen the column from 110 to 210 so the trend is actually readable. The button stays right-anchored via existing `margin-left: auto`.

Changes localised to `web/src/pages/modules/acl/` — forward is not affected.