### PR TITLE
feat(commonpb): validate inputs in NewIPRange constructor

### DIFF
--- a/common/commonpb/iprange.go
+++ b/common/commonpb/iprange.go
@@ -6,12 +6,43 @@ import (
 	"net/netip"
 )
 
-// NewIPRange creates an IPRange from two netip.Addr values.
-func NewIPRange(start, end netip.Addr) *IPRange {
+// NewIPRange creates an IPRange from two netip.Addr values, returning an error
+// if either address is invalid.
+//
+// Returns an error if start is not a valid address, if end is not a valid
+// address, if start and end belong to different address families, or if start
+// is greater than end.
+func NewIPRange(start, end netip.Addr) (*IPRange, error) {
+	if !start.IsValid() {
+		return nil, fmt.Errorf("invalid start address")
+	}
+	if !end.IsValid() {
+		return nil, fmt.Errorf("invalid end address")
+	}
+	if start.Is4() != end.Is4() {
+		return nil, fmt.Errorf("address family mismatch: start is IPv%d, end is IPv%d",
+			familyNum(start), familyNum(end))
+	}
+	if start.Compare(end) > 0 {
+		return nil, fmt.Errorf("start address %q is greater than end address %q",
+			start.String(), end.String())
+	}
 	return &IPRange{
 		Start: NewIPAddressFromAddr(start),
 		End:   NewIPAddressFromAddr(end),
+	}, nil
+}
+
+// MustIPRange is like NewIPRange but panics if validation fails.
+//
+// Intended for tests and package-level variable initialisation where the
+// inputs are static and any failure indicates a programming bug.
+func MustIPRange(start, end netip.Addr) *IPRange {
+	r, err := NewIPRange(start, end)
+	if err != nil {
+		panic(err)
 	}
+	return r
 }
 
 // ToRange converts the IPRange back to a pair of netip.Addr values.
@@ -98,6 +129,11 @@ func (m *IPRange) UnmarshalJSON(data []byte) error {
 		)
 	}
 
-	*m = *NewIPRange(start, end)
+	r, err := NewIPRange(start, end)
+	if err != nil {
+		return err
+	}
+	m.Start = r.Start
+	m.End = r.End
 	return nil
 }

--- a/common/commonpb/iprange_test.go
+++ b/common/commonpb/iprange_test.go
@@ -13,7 +13,8 @@ func TestNewIPRange_V4(t *testing.T) {
 	start := netip.MustParseAddr("10.0.0.0")
 	end := netip.MustParseAddr("10.0.0.255")
 
-	r := NewIPRange(start, end)
+	r, err := NewIPRange(start, end)
+	require.NoError(t, err)
 
 	require.NotNil(t, r.Start)
 	require.NotNil(t, r.End)
@@ -25,12 +26,62 @@ func TestNewIPRange_V6(t *testing.T) {
 	start := netip.MustParseAddr("2001:db8::")
 	end := netip.MustParseAddr("2001:db8::ffff")
 
-	r := NewIPRange(start, end)
+	r, err := NewIPRange(start, end)
+	require.NoError(t, err)
 
 	require.NotNil(t, r.Start)
 	require.NotNil(t, r.End)
 	require.Len(t, r.Start.Addr, 16)
 	require.Len(t, r.End.Addr, 16)
+}
+
+func TestNewIPRange_Errors(t *testing.T) {
+	tests := []struct {
+		name    string
+		start   netip.Addr
+		end     netip.Addr
+		wantSub string // substring expected in err.Error()
+	}{
+		{
+			name:    "invalid start",
+			start:   netip.Addr{},
+			end:     netip.MustParseAddr("10.0.0.1"),
+			wantSub: "invalid start address",
+		},
+		{
+			name:    "invalid end",
+			start:   netip.MustParseAddr("10.0.0.1"),
+			end:     netip.Addr{},
+			wantSub: "invalid end address",
+		},
+		{
+			name:    "family mismatch",
+			start:   netip.MustParseAddr("10.0.0.0"),
+			end:     netip.MustParseAddr("2001:db8::1"),
+			wantSub: "address family mismatch",
+		},
+		{
+			name:    "start greater than end IPv4",
+			start:   netip.MustParseAddr("10.0.0.10"),
+			end:     netip.MustParseAddr("10.0.0.1"),
+			wantSub: "greater than end address",
+		},
+		{
+			name:    "start greater than end IPv6",
+			start:   netip.MustParseAddr("2001:db8::10"),
+			end:     netip.MustParseAddr("2001:db8::1"),
+			wantSub: "greater than end address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := NewIPRange(tt.start, tt.end)
+			require.Error(t, err)
+			require.Nil(t, r)
+			require.Contains(t, err.Error(), tt.wantSub)
+		})
+	}
 }
 
 func TestIPRange_ToRange_RoundTrip(t *testing.T) {
@@ -63,7 +114,7 @@ func TestIPRange_ToRange_RoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := NewIPRange(tt.start, tt.end)
+			r := MustIPRange(tt.start, tt.end)
 			gotStart, gotEnd, err := r.ToRange()
 			require.NoError(t, err)
 			require.Equal(t, tt.start, gotStart)
@@ -108,12 +159,12 @@ func TestIPRange_MarshalJSON(t *testing.T) {
 	}{
 		{
 			name: "IPv4",
-			r:    NewIPRange(netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
+			r:    MustIPRange(netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
 			want: `{"start":"10.0.0.0","end":"10.0.0.255"}`,
 		},
 		{
 			name: "IPv6",
-			r:    NewIPRange(netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
+			r:    MustIPRange(netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
 			want: `{"start":"2001:db8::","end":"2001:db8::ffff"}`,
 		},
 		{
@@ -228,7 +279,7 @@ func TestIPRange_JSONRoundTrip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			original := NewIPRange(tt.start, tt.end)
+			original := MustIPRange(tt.start, tt.end)
 
 			data, err := json.Marshal(original)
 			require.NoError(t, err)
@@ -252,12 +303,12 @@ func TestIPRange_AsLogValue(t *testing.T) {
 	}{
 		{
 			name: "IPv4",
-			r:    NewIPRange(netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
+			r:    MustIPRange(netip.MustParseAddr("10.0.0.0"), netip.MustParseAddr("10.0.0.255")),
 			want: "[10.0.0.0, 10.0.0.255]",
 		},
 		{
 			name: "IPv6",
-			r:    NewIPRange(netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
+			r:    MustIPRange(netip.MustParseAddr("2001:db8::"), netip.MustParseAddr("2001:db8::ffff")),
 			want: "[2001:db8::, 2001:db8::ffff]",
 		},
 		{

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -128,8 +128,13 @@ func (m *RouteService) ShowFIB(
 			}
 		}
 
+		ipRange, err := commonpb.NewIPRange(e.PrefixFrom, e.PrefixTo)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to build IP range from FIB entry: %v", err)
+		}
+
 		response.Entries = append(response.Entries, &routepb.FIBRangeEntry{
-			Range:    commonpb.NewIPRange(e.PrefixFrom, e.PrefixTo),
+			Range:    ipRange,
 			Nexthops: nexthops,
 		})
 	}


### PR DESCRIPTION
The constructor now returns an error when start or end is an invalid address, when the two endpoints belong to different families, or when start is greater than end. Single-address ranges remain valid because the order check uses strict inequality.

The internal call inside `UnmarshalJSON` and the sole production caller in the route module's FIB-list handler are updated to handle the new error. FIB entries that fail the new invariants now surface as a server-side internal error rather than silently producing a malformed range on the wire.