### PR TITLE
fix(web/operators-route): replace existing route on edit instead of duplicating

### DIFF
--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -92,7 +92,26 @@ const RoutePage: React.FC = () => {
             toaster.error('route-nexthop-error', 'Invalid next-hop address');
             return;
         }
+
+        const isEdit = drawer.mode === 'edit';
+        const original = drawer.route;
+        const originalPrefix = original?.prefix;
+        const originalNexthop = original?.next_hop;
+        const newNexthopStr = ipAddressToString(nexthopIp);
+        const originalNexthopStr = ipAddressToString(originalNexthop);
+        const keyChanged = isEdit && !!original && (originalPrefix !== params.prefix || originalNexthopStr !== newNexthopStr);
+
         try {
+            if (keyChanged && originalPrefix && originalNexthop) {
+                await API.route.deleteRoute({
+                    name: currentConfig,
+                    prefix: originalPrefix,
+                    nexthop_addr: originalNexthop,
+                    do_flush: false,
+                    source_id: RouteSourceID.STATIC,
+                });
+            }
+
             await API.route.insertRoute({
                 name: currentConfig,
                 prefix: params.prefix,
@@ -100,13 +119,14 @@ const RoutePage: React.FC = () => {
                 do_flush: params.doFlush,
                 source_id: RouteSourceID.STATIC,
             });
+
             await reload();
-            toaster.success('route-add-success', drawer.mode === 'add' ? 'Route added.' : 'Route updated.');
+            toaster.success('route-add-success', isEdit ? 'Route updated.' : 'Route added.');
         } catch (err) {
-            toaster.error('route-add-error', drawer.mode === 'add' ? 'Failed to add route' : 'Failed to update route', err);
+            toaster.error('route-add-error', isEdit ? 'Failed to update route' : 'Failed to add route', err);
             throw err;
         }
-    }, [currentConfig, reload, drawer.mode]);
+    }, [currentConfig, reload, drawer.mode, drawer.route]);
 
     const handleDeleteRoute = useCallback(async (route: Route): Promise<void> => {
         if (!route.prefix || !route.next_hop) {


### PR DESCRIPTION
The route operator backend exposes only Insert and Delete RPCs, with no update path. When the drawer was used to change a prefix or next hop on an existing entry, only an Insert was issued, leaving the original route in place alongside the new one.

- The submit handler now deletes the original entry first when its key has changed, then inserts the new values, so editing behaves as a replacement.
- Edits that touch only the do-flush switch (i.e. without changing the route key) keep the previous single-insert behaviour.
- A failure during the preliminary delete short-circuits the insert, so the user sees a single error toast and the original entry stays untouched.