### PR TITLE
feat(web): per-row delete and live-write polish for operator pages

### DIFF
--- a/web/src/pages/_shared/draft/BulkDeleteModal.tsx
+++ b/web/src/pages/_shared/draft/BulkDeleteModal.tsx
@@ -7,6 +7,8 @@ interface BulkDeleteModalProps {
     configName: string;
     onClose: () => void;
     onConfirm: () => void;
+    /** Live-write pages (operators/*) set this to switch the hint sentence to a non-draft wording. */
+    immediate?: boolean;
 }
 
 /** Modal confirming bulk deletion of selected rows. */
@@ -17,6 +19,7 @@ const BulkDeleteModal: React.FC<BulkDeleteModalProps> = ({
     configName,
     onClose,
     onConfirm,
+    immediate = false,
 }) => {
     if (!open) return null;
     return (
@@ -27,7 +30,13 @@ const BulkDeleteModal: React.FC<BulkDeleteModalProps> = ({
                     <button type="button" className="fw-icon-btn" onClick={onClose} aria-label="Close">✕</button>
                 </header>
                 <div className="fw-modal__body fw-modal__body--confirm">
-                    <p>Delete <strong>{count}</strong> selected {itemNoun}(s) from <code>{configName}</code>? Changes are staged in the draft; discard the draft to revert.</p>
+                    <p>
+                        Delete <strong>{count}</strong> selected {itemNoun}(s) from <code>{configName}</code>?
+                        {' '}
+                        {immediate
+                            ? 'This action cannot be undone.'
+                            : 'Changes are staged in the draft; discard the draft to revert.'}
+                    </p>
                 </div>
                 <footer className="fw-modal__foot">
                     <span />

--- a/web/src/pages/_shared/draft/RowHoverEditOverlay.tsx
+++ b/web/src/pages/_shared/draft/RowHoverEditOverlay.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TrashIcon } from './DraftActionButtons';
 
 interface RowHoverEditOverlayProps {
     /** Top offset in px from useRowHoverOverlay's overlayTopOffset. */
@@ -11,6 +12,12 @@ interface RowHoverEditOverlayProps {
     editAriaLabel: string;
     /** Hover title attribute, e.g. "Edit rule". */
     editTitle: string;
+    /** Optional delete action. When provided, renders a second danger button to the right of edit. */
+    onDelete?: () => void;
+    /** Accessible label for the delete button. */
+    deleteAriaLabel?: string;
+    /** Hover title for the delete button. */
+    deleteTitle?: string;
     /** Forwarded to the slot root so hover state can be tracked. */
     onMouseEnter: () => void;
     onMouseLeave: () => void;
@@ -23,11 +30,14 @@ const RowHoverEditOverlay: React.FC<RowHoverEditOverlayProps> = ({
     onEdit,
     editAriaLabel,
     editTitle,
+    onDelete,
+    deleteAriaLabel,
+    deleteTitle,
     onMouseEnter,
     onMouseLeave,
 }) => (
     <div
-        className="fw-row-action-slot"
+        className={`fw-row-action-slot${onDelete ? ' fw-row-action-slot--wide' : ''}`}
         style={{ top, height: rowHeight }}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
@@ -41,6 +51,17 @@ const RowHoverEditOverlay: React.FC<RowHoverEditOverlayProps> = ({
         >
             ✎
         </button>
+        {onDelete && (
+            <button
+                type="button"
+                className="fw-row-edit-btn fw-row-edit-btn--visible fw-row-edit-btn--danger"
+                onClick={onDelete}
+                aria-label={deleteAriaLabel ?? 'Delete'}
+                title={deleteTitle ?? 'Delete'}
+            >
+                <TrashIcon />
+            </button>
+        )}
     </div>
 );
 

--- a/web/src/pages/operators/neighbours/NeighbourTable.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourTable.tsx
@@ -45,6 +45,8 @@ export interface NeighbourTableProps {
     canDeleteTable: boolean;
     onEditTable: () => void;
     onDeleteTable: () => void;
+    onDeleteRow?: (id: string) => void;
+    canEditRow?: boolean;
 }
 
 interface SortButtonProps {
@@ -98,6 +100,8 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
     canDeleteTable,
     onEditTable,
     onDeleteTable,
+    onDeleteRow,
+    canEditRow,
 }) => {
     const scrollRef = useRef<HTMLDivElement>(null);
     const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT + 20);
@@ -290,13 +294,16 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
                 <span className="fw-toolbar__count">{footerText}</span>
             </div>
 
-            {hoveredRow !== null && (
+            {canEditRow !== false && hoveredRow !== null && (
                 <RowHoverEditOverlay
                     top={overlayTopOffset}
                     rowHeight={ROW_HEIGHT}
                     onEdit={handleOverlayEdit}
                     editAriaLabel={`Edit neighbour ${ipAddressToString(hoveredRow.next_hop) || (rows.indexOf(hoveredRow) + 1)}`}
                     editTitle="Edit neighbour"
+                    onDelete={onDeleteRow ? () => onDeleteRow(getNeighbourId(hoveredRow)) : undefined}
+                    deleteAriaLabel={`Delete neighbour ${ipAddressToString(hoveredRow.next_hop) || ''}`.trim()}
+                    deleteTitle="Delete neighbour"
                     onMouseEnter={handleOverlayMouseEnter}
                     onMouseLeave={handleOverlayMouseLeave}
                 />

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -68,6 +68,10 @@ const NeighboursPage: React.FC = () => {
         neighbour: null,
     });
     const [bulkRemoveOpen, setBulkRemoveOpen] = useState(false);
+    const [rowDeleteConfirm, setRowDeleteConfirm] = useState<{ open: boolean; neighbour: Neighbour | null }>({
+        open: false,
+        neighbour: null,
+    });
     const [createTableOpen, setCreateTableOpen] = useState(false);
     const [editTableOpen, setEditTableOpen] = useState(false);
     const [deleteTableOpen, setDeleteTableOpen] = useState(false);
@@ -174,6 +178,18 @@ const NeighboursPage: React.FC = () => {
         await removeNeighbours(table, [wire]);
         setSelectedIds(new Set());
     }, [isMergedView, activeTab, removeNeighbours]);
+
+    const handleDeleteRowRequest = useCallback((id: string): void => {
+        const neighbour = allRows.find((n) => getNeighbourId(n) === id) || null;
+        if (neighbour) setRowDeleteConfirm({ open: true, neighbour });
+    }, [allRows]);
+
+    const handleDeleteRowConfirm = useCallback(async (): Promise<void> => {
+        const neighbour = rowDeleteConfirm.neighbour;
+        setRowDeleteConfirm({ open: false, neighbour: null });
+        if (!neighbour) return;
+        await handleDeleteNeighbour(neighbour);
+    }, [rowDeleteConfirm.neighbour, handleDeleteNeighbour]);
 
     const handleBulkRemove = useCallback(async (): Promise<void> => {
         if (isMergedView || !activeTab) return;
@@ -300,6 +316,8 @@ const NeighboursPage: React.FC = () => {
                                 canDeleteTable={canDeleteTable}
                                 onEditTable={() => setEditTableOpen(true)}
                                 onDeleteTable={() => setDeleteTableOpen(true)}
+                                onDeleteRow={isMergedView ? undefined : handleDeleteRowRequest}
+                                canEditRow={!isMergedView}
                             />
                         </div>
                     </>
@@ -321,6 +339,17 @@ const NeighboursPage: React.FC = () => {
                     configName={activeTab}
                     onClose={() => setBulkRemoveOpen(false)}
                     onConfirm={handleBulkRemove}
+                    immediate
+                />
+
+                <BulkDeleteModal
+                    open={rowDeleteConfirm.open}
+                    count={1}
+                    itemNoun="neighbour"
+                    configName={activeTableInfo?.name || activeTab}
+                    onClose={() => setRowDeleteConfirm({ open: false, neighbour: null })}
+                    onConfirm={handleDeleteRowConfirm}
+                    immediate
                 />
 
                 <DeleteConfigModal

--- a/web/src/pages/operators/route/RIBTable.tsx
+++ b/web/src/pages/operators/route/RIBTable.tsx
@@ -38,6 +38,7 @@ export interface RIBTableProps {
     onEditRow: (id: string) => void;
     onSelectionChange: (ids: Set<string>) => void;
     emptyMessage: string;
+    onDeleteRow: (id: string) => void;
 }
 
 interface SortButtonProps {
@@ -87,6 +88,7 @@ export const RIBTable: React.FC<RIBTableProps> = ({
     onEditRow,
     onSelectionChange,
     emptyMessage,
+    onDeleteRow,
 }) => {
     const scrollRef = useRef<HTMLDivElement>(null);
     const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT + 20);
@@ -259,6 +261,9 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                     onEdit={handleOverlayEdit}
                     editAriaLabel={`Edit route ${rows.indexOf(hoveredRow) + 1}`}
                     editTitle="Edit route"
+                    onDelete={() => onDeleteRow(getRouteId(hoveredRow))}
+                    deleteAriaLabel={`Delete route ${hoveredRow.prefix || ''}`.trim()}
+                    deleteTitle="Delete route"
                     onMouseEnter={handleOverlayMouseEnter}
                     onMouseLeave={handleOverlayMouseLeave}
                 />

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -29,6 +29,10 @@ const RoutePage: React.FC = () => {
     const [addConfigOpen, setAddConfigOpen] = useState(false);
     const [activeRowId, setActiveRowId] = useState<string | null>(null);
     const [editingRowId, setEditingRowId] = useState<string | null>(null);
+    const [rowDeleteConfirm, setRowDeleteConfirm] = useState<{ open: boolean; route: Route | null }>({
+        open: false,
+        route: null,
+    });
 
     const searchRef = useRef<HTMLInputElement>(null);
 
@@ -150,16 +154,27 @@ const RoutePage: React.FC = () => {
         }
     }, [currentConfig, reload, setSelected]);
 
+    const handleDeleteRowRequest = useCallback((id: string): void => {
+        const route = allRows.find((r) => getRouteId(r) === id) || null;
+        if (route) setRowDeleteConfirm({ open: true, route });
+    }, [allRows]);
+
+    const handleDeleteRowConfirm = useCallback(async (): Promise<void> => {
+        const route = rowDeleteConfirm.route;
+        setRowDeleteConfirm({ open: false, route: null });
+        if (!route) return;
+        await handleDeleteRoute(route);
+    }, [rowDeleteConfirm.route, handleDeleteRoute]);
+
     const handleFlush = useCallback(async (): Promise<void> => {
         if (!currentConfig) return;
         try {
             await API.route.flushRoutes({ name: currentConfig });
-            await reload();
             toaster.success('flush-success', `Flushed routes for ${currentConfig}.`);
         } catch (err) {
             toaster.error('flush-error', 'Failed to flush routes', err);
         }
-    }, [currentConfig, reload]);
+    }, [currentConfig]);
 
     const handleBulkDelete = useCallback(async (): Promise<void> => {
         const routes = allRows.filter((r) => currentSelected.has(getRouteId(r)));
@@ -265,6 +280,7 @@ const RoutePage: React.FC = () => {
                                 onEditRow={handleEditRow}
                                 onSelectionChange={(ids) => setSelected(currentConfig, ids)}
                                 emptyMessage={search ? 'No routes match your search.' : 'No routes.'}
+                                onDeleteRow={handleDeleteRowRequest}
                             />
                         </div>
                     </>
@@ -286,6 +302,17 @@ const RoutePage: React.FC = () => {
                     configName={currentConfig}
                     onClose={() => setBulkDeleteOpen(false)}
                     onConfirm={handleBulkDelete}
+                    immediate
+                />
+
+                <BulkDeleteModal
+                    open={rowDeleteConfirm.open}
+                    count={1}
+                    itemNoun="route"
+                    configName={currentConfig}
+                    onClose={() => setRowDeleteConfirm({ open: false, route: null })}
+                    onConfirm={handleDeleteRowConfirm}
+                    immediate
                 />
 
                 <RouteDrawer

--- a/web/src/styles/draft-page.scss
+++ b/web/src/styles/draft-page.scss
@@ -484,6 +484,11 @@
     z-index: 3;
     pointer-events: auto;
     background: transparent;
+
+    &--wide {
+        width: 76px;
+        gap: 4px;
+    }
 }
 
 .fw-row-edit-btn {
@@ -506,6 +511,17 @@
         background: var(--fw-bg-2);
         color: var(--fw-text);
         border-color: var(--fw-text-3);
+    }
+
+    &--danger {
+        color: var(--fw-danger);
+        border-color: color-mix(in srgb, var(--g-color-text-danger) 25%, transparent);
+
+        &:hover {
+            background: color-mix(in srgb, var(--g-color-text-danger) 8%, transparent);
+            border-color: var(--fw-danger);
+            color: var(--fw-danger);
+        }
     }
 
 }


### PR DESCRIPTION
Brings the hover edit overlay to feature-parity with the bulk action bar and tightens the live-write semantics on the operator pages.

- Shared hover overlay now optionally renders a danger button next to edit; the slot widens to keep both buttons square.
- RIBTable always exposes the per-row delete button; NeighbourTable shows it only outside the merged view.
- Both pages drive a single-row confirmation through the existing bulk delete modal.
- BulkDeleteModal gained an `immediate` flag that swaps the hint sentence so live-write pages no longer claim deletions are staged in a draft.
- Merged neighbour view stops rendering the edit overlay since the tab is a read-only aggregate.
- Flushing the RIB no longer triggers a redundant reload, so the table no longer flickers after a successful flush.
- Restored the previously-pruned `fw-row-action-slot--wide` and `fw-row-edit-btn--danger` style variants used by the new two-button overlay layout.