### PR TITLE
test(web): cover operator pages with unit tests

### DIFF
--- a/web/src/pages/_shared/draft/BulkDeleteModal.test.tsx
+++ b/web/src/pages/_shared/draft/BulkDeleteModal.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import BulkDeleteModal from './BulkDeleteModal';
+
+describe('BulkDeleteModal', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders nothing when open is false', () => {
+        const { container } = render(
+            <BulkDeleteModal
+                open={false}
+                count={3}
+                itemNoun="route"
+                configName="main"
+                onClose={() => {}}
+                onConfirm={() => {}}
+            />,
+        );
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('shows "This action cannot be undone" when immediate is true', () => {
+        render(
+            <BulkDeleteModal
+                open
+                count={2}
+                itemNoun="route"
+                configName="main"
+                onClose={() => {}}
+                onConfirm={() => {}}
+                immediate
+            />,
+        );
+        expect(screen.getByText(/This action cannot be undone/i)).toBeInTheDocument();
+    });
+
+    it('shows draft staging text when immediate is omitted', () => {
+        render(
+            <BulkDeleteModal
+                open
+                count={2}
+                itemNoun="route"
+                configName="main"
+                onClose={() => {}}
+                onConfirm={() => {}}
+            />,
+        );
+        expect(screen.getByText(/Changes are staged in the draft/i)).toBeInTheDocument();
+    });
+
+    it('shows draft staging text when immediate is explicitly false', () => {
+        render(
+            <BulkDeleteModal
+                open
+                count={2}
+                itemNoun="route"
+                configName="main"
+                onClose={() => {}}
+                onConfirm={() => {}}
+                immediate={false}
+            />,
+        );
+        expect(screen.getByText(/Changes are staged in the draft/i)).toBeInTheDocument();
+    });
+});

--- a/web/src/pages/_shared/draft/RowHoverEditOverlay.test.tsx
+++ b/web/src/pages/_shared/draft/RowHoverEditOverlay.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import RowHoverEditOverlay from './RowHoverEditOverlay';
+
+describe('RowHoverEditOverlay', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('renders a single edit button when onDelete is not provided', () => {
+        render(
+            <RowHoverEditOverlay
+                top={40}
+                rowHeight={32}
+                onEdit={() => {}}
+                editAriaLabel="Edit row 1"
+                editTitle="Edit"
+                onMouseEnter={() => {}}
+                onMouseLeave={() => {}}
+            />,
+        );
+        const buttons = screen.getAllByRole('button');
+        expect(buttons).toHaveLength(1);
+        expect(buttons[0].getAttribute('aria-label')).toBe('Edit row 1');
+    });
+
+    it('does not apply the wide class when onDelete is absent', () => {
+        const { container } = render(
+            <RowHoverEditOverlay
+                top={40}
+                rowHeight={32}
+                onEdit={() => {}}
+                editAriaLabel="Edit row 1"
+                editTitle="Edit"
+                onMouseEnter={() => {}}
+                onMouseLeave={() => {}}
+            />,
+        );
+        expect(container.querySelector('.fw-row-action-slot--wide')).toBeNull();
+        expect(container.querySelector('.fw-row-action-slot')).not.toBeNull();
+    });
+
+    it('renders two buttons when onDelete is provided', () => {
+        render(
+            <RowHoverEditOverlay
+                top={40}
+                rowHeight={32}
+                onEdit={() => {}}
+                editAriaLabel="Edit row 1"
+                editTitle="Edit"
+                onDelete={() => {}}
+                deleteAriaLabel="Delete row 1"
+                deleteTitle="Delete"
+                onMouseEnter={() => {}}
+                onMouseLeave={() => {}}
+            />,
+        );
+        const buttons = screen.getAllByRole('button');
+        expect(buttons).toHaveLength(2);
+    });
+
+    it('delete button has danger class and correct aria-label', () => {
+        render(
+            <RowHoverEditOverlay
+                top={40}
+                rowHeight={32}
+                onEdit={() => {}}
+                editAriaLabel="Edit row 1"
+                editTitle="Edit"
+                onDelete={() => {}}
+                deleteAriaLabel="Delete row 1"
+                deleteTitle="Delete"
+                onMouseEnter={() => {}}
+                onMouseLeave={() => {}}
+            />,
+        );
+        const dangerBtn = document.querySelector('.fw-row-edit-btn--danger') as HTMLElement;
+        expect(dangerBtn).not.toBeNull();
+        expect(dangerBtn.getAttribute('aria-label')).toBe('Delete row 1');
+    });
+
+    it('applies the wide class to the slot when onDelete is provided', () => {
+        const { container } = render(
+            <RowHoverEditOverlay
+                top={40}
+                rowHeight={32}
+                onEdit={() => {}}
+                editAriaLabel="Edit row 1"
+                editTitle="Edit"
+                onDelete={() => {}}
+                deleteAriaLabel="Delete row 1"
+                deleteTitle="Delete"
+                onMouseEnter={() => {}}
+                onMouseLeave={() => {}}
+            />,
+        );
+        expect(container.querySelector('.fw-row-action-slot--wide')).not.toBeNull();
+    });
+
+    it('fires onEdit when the edit button is clicked', () => {
+        const onEdit = vi.fn();
+        render(
+            <RowHoverEditOverlay
+                top={40}
+                rowHeight={32}
+                onEdit={onEdit}
+                editAriaLabel="Edit row 1"
+                editTitle="Edit"
+                onMouseEnter={() => {}}
+                onMouseLeave={() => {}}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: 'Edit row 1' }));
+        expect(onEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onDelete when the delete button is clicked', () => {
+        const onDelete = vi.fn();
+        render(
+            <RowHoverEditOverlay
+                top={40}
+                rowHeight={32}
+                onEdit={() => {}}
+                editAriaLabel="Edit row 1"
+                editTitle="Edit"
+                onDelete={onDelete}
+                deleteAriaLabel="Delete row 1"
+                deleteTitle="Delete"
+                onMouseEnter={() => {}}
+                onMouseLeave={() => {}}
+            />,
+        );
+        fireEvent.click(screen.getByRole('button', { name: 'Delete row 1' }));
+        expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes top and rowHeight into inline styles', () => {
+        const { container } = render(
+            <RowHoverEditOverlay
+                top={128}
+                rowHeight={48}
+                onEdit={() => {}}
+                editAriaLabel="Edit"
+                editTitle="Edit"
+                onMouseEnter={() => {}}
+                onMouseLeave={() => {}}
+            />,
+        );
+        const slot = container.querySelector('.fw-row-action-slot') as HTMLElement;
+        expect(slot.style.top).toBe('128px');
+        expect(slot.style.height).toBe('48px');
+    });
+});

--- a/web/src/pages/operators/neighbours/NeighbourDrawer.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourDrawer.tsx
@@ -3,7 +3,7 @@ import { Select } from '@gravity-ui/uikit';
 import { DraftItemDrawer } from '../../_shared/draft';
 import { ipAddressToString, stringToIPAddress } from '../../../utils/netip';
 import type { Neighbour, NeighbourTableInfo } from '../../../api/neighbours';
-import { validateMAC, validateNextHop } from './utils';
+import { validateMAC, validateNextHop, resolveSubmitTable } from './utils';
 import { MERGED_TAB } from './types';
 
 export interface NeighbourDrawerProps {
@@ -79,15 +79,7 @@ const NeighbourDrawer: React.FC<NeighbourDrawerProps> = ({
         if (!canSubmit) return;
         setSubmitting(true);
         try {
-            const resolvedTable = (() => {
-                if (mode === 'add' && activeTable === MERGED_TAB) {
-                    return selectedTable[0] || defaultTable;
-                }
-                if (mode === 'edit' && activeTable === MERGED_TAB) {
-                    return neighbour?.source || 'static';
-                }
-                return activeTable;
-            })();
+            const resolvedTable = resolveSubmitTable(mode, activeTable, selectedTable[0], defaultTable, neighbour);
 
             let nextHopWire: Neighbour['next_hop'];
             if (mode === 'add') {
@@ -123,15 +115,7 @@ const NeighbourDrawer: React.FC<NeighbourDrawerProps> = ({
         }
     };
 
-    const resolvedTableForTitle = (() => {
-        if (mode === 'add' && activeTable === MERGED_TAB) {
-            return selectedTable[0] || defaultTable;
-        }
-        if (mode === 'edit' && activeTable === MERGED_TAB) {
-            return neighbour?.source || 'static';
-        }
-        return activeTable;
-    })();
+    const resolvedTableForTitle = resolveSubmitTable(mode, activeTable, selectedTable[0], defaultTable, neighbour);
     const tableLabel = mode === 'add' && activeTable === MERGED_TAB
         ? undefined
         : resolvedTableForTitle || undefined;

--- a/web/src/pages/operators/neighbours/utils.test.ts
+++ b/web/src/pages/operators/neighbours/utils.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { resolveSubmitTable, validateMAC, validateNextHop, sortComparators } from './utils';
+import { MERGED_TAB } from './types';
+import type { Neighbour } from '../../../api/neighbours';
+
+// ---------------------------------------------------------------------------
+// resolveSubmitTable
+// ---------------------------------------------------------------------------
+
+describe('resolveSubmitTable', () => {
+    const makeNeighbour = (source?: string): Neighbour => ({ source });
+
+    it('add + merged tab: returns selectedTable when provided', () => {
+        const result = resolveSubmitTable('add', MERGED_TAB, 'arp', 'static', null);
+        expect(result).toBe('arp');
+    });
+
+    it('add + merged tab: falls back to defaultTable when selectedTable is undefined', () => {
+        const result = resolveSubmitTable('add', MERGED_TAB, undefined, 'static', null);
+        expect(result).toBe('static');
+    });
+
+    it('add + non-merged tab: returns activeTable', () => {
+        const result = resolveSubmitTable('add', 'arp', 'static', 'static', null);
+        expect(result).toBe('arp');
+    });
+
+    it('edit + merged tab: returns neighbour.source', () => {
+        const result = resolveSubmitTable('edit', MERGED_TAB, undefined, 'static', makeNeighbour('arp'));
+        expect(result).toBe('arp');
+    });
+
+    it('edit + merged tab + no neighbour.source: falls back to static', () => {
+        const result = resolveSubmitTable('edit', MERGED_TAB, undefined, 'static', makeNeighbour(undefined));
+        expect(result).toBe('static');
+    });
+
+    it('edit + non-merged tab: returns activeTable', () => {
+        const result = resolveSubmitTable('edit', 'ndp', undefined, 'static', makeNeighbour('arp'));
+        expect(result).toBe('ndp');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// validateMAC
+// ---------------------------------------------------------------------------
+
+describe('validateMAC', () => {
+    it('returns undefined for a valid lowercase MAC', () => {
+        expect(validateMAC('52:54:00:12:34:56')).toBeUndefined();
+    });
+
+    it('returns undefined for an empty string', () => {
+        expect(validateMAC('')).toBeUndefined();
+    });
+
+    it('returns undefined for a whitespace-only string', () => {
+        expect(validateMAC('   ')).toBeUndefined();
+    });
+
+    it('returns an error message for garbage input', () => {
+        expect(validateMAC('not-a-mac')).toBeTruthy();
+    });
+
+    it('returns an error message for an incomplete MAC', () => {
+        expect(validateMAC('52:54:00:12')).toBeTruthy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// validateNextHop
+// ---------------------------------------------------------------------------
+
+describe('validateNextHop', () => {
+    it('returns undefined for a valid IPv4 address', () => {
+        expect(validateNextHop('192.168.1.1')).toBeUndefined();
+    });
+
+    it('returns undefined for a valid IPv6 address', () => {
+        expect(validateNextHop('fe80::1')).toBeUndefined();
+    });
+
+    it('returns an error for an empty string', () => {
+        expect(validateNextHop('')).toBeTruthy();
+    });
+
+    it('returns an error for garbage input', () => {
+        expect(validateNextHop('not-an-ip')).toBeTruthy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// sortComparators
+// ---------------------------------------------------------------------------
+
+describe('sortComparators', () => {
+    const makeNeighbour = (overrides: Partial<Neighbour>): Neighbour => ({ ...overrides });
+
+    it('next_hop: sorts by IP string representation', () => {
+        const a = makeNeighbour({ next_hop: { addr: '10.0.0.1' } });
+        const b = makeNeighbour({ next_hop: { addr: '192.168.1.1' } });
+        expect(sortComparators.next_hop(a, b)).toBeLessThan(0);
+        expect(sortComparators.next_hop(b, a)).toBeGreaterThan(0);
+    });
+
+    it('priority: sorts numerically', () => {
+        const a = makeNeighbour({ priority: 10 });
+        const b = makeNeighbour({ priority: 200 });
+        expect(sortComparators.priority(a, b)).toBeLessThan(0);
+        expect(sortComparators.priority(b, a)).toBeGreaterThan(0);
+    });
+
+    it('priority: treats missing priority as 0', () => {
+        const a = makeNeighbour({});
+        const b = makeNeighbour({ priority: 5 });
+        expect(sortComparators.priority(a, b)).toBeLessThan(0);
+    });
+
+    it('source: sorts lexicographically', () => {
+        const a = makeNeighbour({ source: 'arp' });
+        const b = makeNeighbour({ source: 'static' });
+        expect(sortComparators.source(a, b)).toBeLessThan(0);
+    });
+
+    it('device: sorts lexicographically', () => {
+        const a = makeNeighbour({ device: 'eth0' });
+        const b = makeNeighbour({ device: 'eth1' });
+        expect(sortComparators.device(a, b)).toBeLessThan(0);
+    });
+});

--- a/web/src/pages/operators/neighbours/utils.ts
+++ b/web/src/pages/operators/neighbours/utils.ts
@@ -9,6 +9,24 @@ import {
 } from '../../../utils';
 import { ipAddressToString, stringToIPAddress } from '../../../utils/netip';
 import type { SortableColumn } from './types';
+import { MERGED_TAB } from './types';
+
+/** Resolve the target table for a neighbour drawer submit. */
+export const resolveSubmitTable = (
+    mode: 'add' | 'edit',
+    activeTable: string,
+    selectedTable: string | undefined,
+    defaultTable: string,
+    neighbour: Neighbour | null,
+): string => {
+    if (mode === 'add' && activeTable === MERGED_TAB) {
+        return selectedTable || defaultTable;
+    }
+    if (mode === 'edit' && activeTable === MERGED_TAB) {
+        return neighbour?.source || 'static';
+    }
+    return activeTable;
+};
 
 export { isValidMAC };
 

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -10,7 +10,7 @@ import { RouteSourceID, type Route } from '../../../api/routes';
 import { useRIB } from './useRIB';
 import { RIBTable } from './RIBTable';
 import RouteDrawer from './RouteDrawer';
-import { getRouteId, sortComparators } from './utils';
+import { getRouteId, sortComparators, planRouteSubmit } from './utils';
 import type { RouteSortState, RouteSortableColumn } from './types';
 import '../../../styles/draft-page.scss';
 
@@ -99,30 +99,36 @@ const RoutePage: React.FC = () => {
 
         const isEdit = drawer.mode === 'edit';
         const original = drawer.route;
-        const originalPrefix = original?.prefix;
-        const originalNexthop = original?.next_hop;
         const newNexthopStr = ipAddressToString(nexthopIp);
-        const originalNexthopStr = ipAddressToString(originalNexthop);
-        const keyChanged = isEdit && !!original && (originalPrefix !== params.prefix || originalNexthopStr !== newNexthopStr);
+        const originalNexthopStr = ipAddressToString(original?.next_hop);
+        const ops = planRouteSubmit(
+            drawer.mode,
+            { prefix: params.prefix, nexthopIp, doFlush: params.doFlush },
+            newNexthopStr,
+            original,
+            originalNexthopStr,
+        );
 
         try {
-            if (keyChanged && originalPrefix && originalNexthop) {
-                await API.route.deleteRoute({
-                    name: currentConfig,
-                    prefix: originalPrefix,
-                    nexthop_addr: originalNexthop,
-                    do_flush: false,
-                    source_id: RouteSourceID.STATIC,
-                });
+            for (const op of ops) {
+                if (op.type === 'delete') {
+                    await API.route.deleteRoute({
+                        name: currentConfig,
+                        prefix: op.prefix,
+                        nexthop_addr: op.nexthop,
+                        do_flush: false,
+                        source_id: RouteSourceID.STATIC,
+                    });
+                } else {
+                    await API.route.insertRoute({
+                        name: currentConfig,
+                        prefix: op.prefix,
+                        nexthop_addr: op.nexthop,
+                        do_flush: op.doFlush,
+                        source_id: RouteSourceID.STATIC,
+                    });
+                }
             }
-
-            await API.route.insertRoute({
-                name: currentConfig,
-                prefix: params.prefix,
-                nexthop_addr: nexthopIp,
-                do_flush: params.doFlush,
-                source_id: RouteSourceID.STATIC,
-            });
 
             await reload();
             toaster.success('route-add-success', isEdit ? 'Route updated.' : 'Route added.');

--- a/web/src/pages/operators/route/utils.test.ts
+++ b/web/src/pages/operators/route/utils.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { planRouteSubmit, validatePrefix, validateNexthop, sortComparators } from './utils';
+import { stringToIPAddress } from '../../../utils/netip';
+import type { Route } from '../../../api/routes';
+
+// ---------------------------------------------------------------------------
+// planRouteSubmit
+// ---------------------------------------------------------------------------
+
+describe('planRouteSubmit', () => {
+    const ip = (s: string) => stringToIPAddress(s)!;
+
+    it('add mode: produces a single insert op', () => {
+        const ops = planRouteSubmit(
+            'add',
+            { prefix: '10.0.0.0/8', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            '192.168.1.1',
+            null,
+            '',
+        );
+        expect(ops).toHaveLength(1);
+        expect(ops[0].type).toBe('insert');
+        if (ops[0].type === 'insert') {
+            expect(ops[0].prefix).toBe('10.0.0.0/8');
+            expect(ops[0].doFlush).toBe(false);
+        }
+    });
+
+    it('edit mode, no key change: produces a single insert op without delete', () => {
+        const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
+        const ops = planRouteSubmit(
+            'edit',
+            { prefix: '10.0.0.0/8', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            '192.168.1.1',
+            original,
+            '192.168.1.1',
+        );
+        expect(ops).toHaveLength(1);
+        expect(ops[0].type).toBe('insert');
+    });
+
+    it('edit mode, prefix changed: produces delete then insert', () => {
+        const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
+        const ops = planRouteSubmit(
+            'edit',
+            { prefix: '172.16.0.0/12', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            '192.168.1.1',
+            original,
+            '192.168.1.1',
+        );
+        expect(ops).toHaveLength(2);
+        expect(ops[0].type).toBe('delete');
+        if (ops[0].type === 'delete') {
+            expect(ops[0].prefix).toBe('10.0.0.0/8');
+        }
+        expect(ops[1].type).toBe('insert');
+        if (ops[1].type === 'insert') {
+            expect(ops[1].prefix).toBe('172.16.0.0/12');
+        }
+    });
+
+    it('edit mode, nexthop changed: produces delete then insert', () => {
+        const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
+        const ops = planRouteSubmit(
+            'edit',
+            { prefix: '10.0.0.0/8', nexthopIp: ip('10.0.0.1'), doFlush: true },
+            '10.0.0.1',
+            original,
+            '192.168.1.1',
+        );
+        expect(ops).toHaveLength(2);
+        expect(ops[0].type).toBe('delete');
+        expect(ops[1].type).toBe('insert');
+        if (ops[1].type === 'insert') {
+            expect(ops[1].doFlush).toBe(true);
+        }
+    });
+
+    it('edit mode, both prefix and nexthop changed: produces delete then insert', () => {
+        const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
+        const ops = planRouteSubmit(
+            'edit',
+            { prefix: '172.16.0.0/12', nexthopIp: ip('10.0.0.1'), doFlush: false },
+            '10.0.0.1',
+            original,
+            '192.168.1.1',
+        );
+        expect(ops).toHaveLength(2);
+        expect(ops[0].type).toBe('delete');
+        expect(ops[1].type).toBe('insert');
+    });
+
+    it('edit mode, original has no prefix: skips delete, produces only insert', () => {
+        const original: Route = { next_hop: ip('192.168.1.1') };
+        const ops = planRouteSubmit(
+            'edit',
+            { prefix: '10.0.0.0/8', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            '192.168.1.1',
+            original,
+            '192.168.1.1',
+        );
+        expect(ops).toHaveLength(1);
+        expect(ops[0].type).toBe('insert');
+    });
+
+    it('edit mode, original has no next_hop: skips delete, produces only insert', () => {
+        const original: Route = { prefix: '10.0.0.0/8' };
+        const ops = planRouteSubmit(
+            'edit',
+            { prefix: '172.16.0.0/12', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            '192.168.1.1',
+            original,
+            '',
+        );
+        expect(ops).toHaveLength(1);
+        expect(ops[0].type).toBe('insert');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// validatePrefix
+// ---------------------------------------------------------------------------
+
+describe('validatePrefix', () => {
+    it('returns undefined for a valid IPv4 CIDR', () => {
+        expect(validatePrefix('192.168.1.0/24')).toBeUndefined();
+    });
+
+    it('returns undefined for a valid IPv6 CIDR', () => {
+        expect(validatePrefix('2001:db8::/32')).toBeUndefined();
+    });
+
+    it('returns undefined for an empty string (field not yet filled)', () => {
+        expect(validatePrefix('')).toBeUndefined();
+    });
+
+    it('returns an error message for garbage input', () => {
+        expect(validatePrefix('not-a-cidr')).toBeTruthy();
+    });
+
+    it('returns an error message for an IP without prefix length', () => {
+        expect(validatePrefix('192.168.1.1')).toBeTruthy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// validateNexthop
+// ---------------------------------------------------------------------------
+
+describe('validateNexthop', () => {
+    it('returns undefined for a valid IPv4 address', () => {
+        expect(validateNexthop('192.168.1.1')).toBeUndefined();
+    });
+
+    it('returns undefined for a valid IPv6 address', () => {
+        expect(validateNexthop('2001:db8::1')).toBeUndefined();
+    });
+
+    it('returns undefined for an empty string', () => {
+        expect(validateNexthop('')).toBeUndefined();
+    });
+
+    it('returns an error message for garbage input', () => {
+        expect(validateNexthop('not-an-ip')).toBeTruthy();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// sortComparators
+// ---------------------------------------------------------------------------
+
+describe('sortComparators', () => {
+    const makeRoute = (overrides: Partial<Route>): Route => ({ ...overrides });
+
+    it('prefix: sorts lexicographically by prefix string', () => {
+        const a = makeRoute({ prefix: '10.0.0.0/8' });
+        const b = makeRoute({ prefix: '192.168.0.0/16' });
+        expect(sortComparators.prefix(a, b)).toBeLessThan(0);
+        expect(sortComparators.prefix(b, a)).toBeGreaterThan(0);
+        expect(sortComparators.prefix(a, a)).toBe(0);
+    });
+
+    it('pref: sorts numerically by pref field', () => {
+        const a = makeRoute({ pref: 10 });
+        const b = makeRoute({ pref: 200 });
+        expect(sortComparators.pref(a, b)).toBeLessThan(0);
+        expect(sortComparators.pref(b, a)).toBeGreaterThan(0);
+    });
+
+    it('pref: treats missing pref as 0', () => {
+        const a = makeRoute({});
+        const b = makeRoute({ pref: 5 });
+        expect(sortComparators.pref(a, b)).toBeLessThan(0);
+    });
+
+    it('is_best: false sorts before true', () => {
+        const a = makeRoute({ is_best: false });
+        const b = makeRoute({ is_best: true });
+        expect(sortComparators.is_best(a, b)).toBeLessThan(0);
+    });
+});

--- a/web/src/pages/operators/route/utils.ts
+++ b/web/src/pages/operators/route/utils.ts
@@ -1,7 +1,38 @@
 import type { Route } from '../../../api/routes';
 import { parseCIDRPrefix, parseIPAddress, CIDRParseError, IPParseError } from '../../../utils';
-import { ipAddressToString } from '../../../utils/netip';
+import { ipAddressToString, type IPAddressWire } from '../../../utils/netip';
 import type { RouteSortableColumn } from './types';
+
+export interface RouteSubmitParams {
+    prefix: string;
+    nexthopIp: IPAddressWire;
+    doFlush: boolean;
+}
+
+export type RouteSubmitOp =
+    | { type: 'delete'; prefix: string; nexthop: IPAddressWire }
+    | { type: 'insert'; prefix: string; nexthop: IPAddressWire; doFlush: boolean };
+
+/** Plan API operations for submitting a route. In add mode, just insert.
+ *
+ * In edit mode, delete the original first when its key changed. */
+export const planRouteSubmit = (
+    mode: 'add' | 'edit',
+    params: RouteSubmitParams,
+    newNexthopStr: string,
+    original: Route | null,
+    originalNexthopStr: string,
+): RouteSubmitOp[] => {
+    const ops: RouteSubmitOp[] = [];
+    const keyChanged = mode === 'edit'
+        && !!original
+        && (original.prefix !== params.prefix || originalNexthopStr !== newNexthopStr);
+    if (keyChanged && original?.prefix && original.next_hop) {
+        ops.push({ type: 'delete', prefix: original.prefix, nexthop: original.next_hop });
+    }
+    ops.push({ type: 'insert', prefix: params.prefix, nexthop: params.nexthopIp, doFlush: params.doFlush });
+    return ops;
+};
 
 export const ROUTE_SOURCES = ['Unknown', 'Static', 'BIRD'] as const;
 


### PR DESCRIPTION
Extracts two pure helpers from the operator pages so that the most exercised behaviour becomes testable in isolation: the RIB submit planner that decides whether to delete the original entry before inserting, and the neighbour drawer table resolver that picks the right target table when editing from the merged view. The page-level call sites become thin wrappers over these helpers.

- Vitest coverage for the planners on the route and neighbour pages.
- Validators and sort comparators covered on both pages.
- Shared row hover overlay covered in both single-button and two-button shapes.
- Bulk delete modal covered on the live-write hint variant and the draft variant.