### PR TITLE
fix(web/operators-neighbours): suppress name error flash on create

### DIFF
--- a/web/src/pages/operators/neighbours/CreateTableModal.tsx
+++ b/web/src/pages/operators/neighbours/CreateTableModal.tsx
@@ -30,11 +30,13 @@ const CreateTableModal: React.FC<CreateTableModalProps> = ({
 
     const trimmedName = name.trim();
     const priorityNum = Number(defaultPriority);
-    const nameError = !trimmedName
-        ? 'Name is required'
-        : existingNames.includes(trimmedName)
-            ? 'A table with this name already exists'
-            : undefined;
+    const nameError = submitting
+        ? undefined
+        : !trimmedName
+            ? 'Name is required'
+            : existingNames.includes(trimmedName)
+                ? 'A table with this name already exists'
+                : undefined;
     const priorityError =
         !defaultPriority.trim() || isNaN(priorityNum) || priorityNum < 0 || !Number.isInteger(priorityNum)
             ? 'Priority must be a non-negative integer'


### PR DESCRIPTION
The create-table modal validated the proposed name against the live list of existing tables. While the submit awaited the backend and the parent page reloaded the table list, the freshly created table appeared in that list and the validator briefly painted the field with a "name already exists" error before the modal could close. The validator now skips while the submit is in flight, hiding the transient red label.