### PR TITLE
fix(web/draft-drawer): close drawer on Escape

### DIFF
--- a/web/src/pages/_shared/draft/DraftItemDrawer.tsx
+++ b/web/src/pages/_shared/draft/DraftItemDrawer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 interface DraftItemDrawerProps {
     open: boolean;
@@ -37,7 +37,19 @@ const DraftItemDrawer: React.FC<DraftItemDrawerProps> = ({
     onJump,
     ariaLabel,
     children,
-}) => (
+}) => {
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape') {
+                onClose();
+            }
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [open, onClose]);
+
+    return (
     <>
         <div
             className={`fw-backdrop${open ? ' fw-backdrop--open' : ''}`}
@@ -127,6 +139,7 @@ const DraftItemDrawer: React.FC<DraftItemDrawerProps> = ({
             )}
         </aside>
     </>
-);
+    );
+};
 
 export default DraftItemDrawer;


### PR DESCRIPTION
The shared draft drawer used by all module and operator pages only closed via the backdrop click and the explicit close button. Pressing Escape now also dismisses it.

- Forward and ACL already mirror this at the page level; the new drawer-level listener makes the behaviour consistent across every consumer and is idempotent when both fire.
- Listener attaches only while the drawer is open and detaches in cleanup.