### PR TITLE
fix(web/operators-neighbours): hide required marker on read-only Next Hop

### DIFF
--- a/web/src/pages/operators/neighbours/NeighbourDrawer.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourDrawer.tsx
@@ -159,7 +159,8 @@ const NeighbourDrawer: React.FC<NeighbourDrawerProps> = ({
                 <div className="fw-section__body">
                     <div className="fw-field">
                         <label className="fw-field__label">
-                            Next Hop <span className="fw-field__req">*</span>
+                            Next Hop
+                            {mode === 'add' && <span className="fw-field__req">*</span>}
                         </label>
                         <input
                             className={`fw-input fw-input--mono${nextHopError ? ' fw-input--invalid' : ''}`}
@@ -170,6 +171,9 @@ const NeighbourDrawer: React.FC<NeighbourDrawerProps> = ({
                         />
                         {nextHopError && (
                             <span className="fw-field__hint fw-field__error">{nextHopError}</span>
+                        )}
+                        {mode === 'edit' && (
+                            <span className="fw-field__hint">Primary key — delete and recreate to change.</span>
                         )}
                     </div>
                 </div>


### PR DESCRIPTION
The neighbour drawer disables the Next Hop input on edit because the field acts as the primary key for the entry, but the required asterisk stayed beside the label and confused users into thinking it expected input. The marker now appears only in add mode, and edit mode shows a short hint explaining that the field is the primary key.