### PR TITLE
fix(web/api-client): propagate backend error body in HTTP failures

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9,6 +9,26 @@ const compressGzip = async (data: string): Promise<Blob> => {
     return new Response(compressedStream).blob();
 };
 
+/** Extract a human-readable detail from an error response body. */
+const readErrorDetail = async (response: Response): Promise<string> => {
+    try {
+        const text = await response.text();
+        if (!text) return '';
+        try {
+            const parsed = JSON.parse(text);
+            if (typeof parsed === 'object' && parsed !== null) {
+                if (typeof parsed.message === 'string') return parsed.message;
+                if (typeof parsed.error === 'string') return parsed.error;
+            }
+            return text;
+        } catch {
+            return text;
+        }
+    } catch {
+        return '';
+    }
+};
+
 const callGRPCServiceWithBody = async <T>(
     servicePath: string,
     body: any,
@@ -35,7 +55,9 @@ const callGRPCServiceWithBody = async <T>(
     });
 
     if (!response.ok) {
-        throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
+        const detail = await readErrorDetail(response);
+        const base = `HTTP ${response.status} ${response.statusText}`;
+        throw new Error(detail ? `${base}: ${detail}` : base);
     }
 
     return await response.json() as T;
@@ -118,7 +140,9 @@ const streamGRPCService = async <T>(
         });
 
         if (!response.ok) {
-            throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
+            const detail = await readErrorDetail(response);
+            const base = `HTTP ${response.status} ${response.statusText}`;
+            throw new Error(detail ? `${base}: ${detail}` : base);
         }
 
         if (!response.body) {


### PR DESCRIPTION
The shared API client surfaced only the HTTP status line when a request failed, hiding the descriptive error message the gateway returned in the response body. The client now reads the body on failure, extracts a human-readable detail (a JSON message or error field, falling back to raw text) and appends it to the thrown error, so toasts on every page show what the backend actually rejected.

For example, submitting an under-configured neighbour now surfaces:
> HTTP 400 Bad Request: neighbour entry "fe80::1" is missing hardware_addr

instead of the generic `HTTP error: 400 Bad Request`.