### PR TITLE
feat(web/operators-neighbours): require both MAC fields when adding

### DIFF
--- a/web/src/pages/operators/neighbours/NeighbourDrawer.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourDrawer.tsx
@@ -72,8 +72,8 @@ const NeighbourDrawer: React.FC<NeighbourDrawerProps> = ({
     }, [open, mode, defaultTable, neighbour]);
 
     const nextHopError = mode === 'add' ? validateNextHop(nextHop) : undefined;
-    const linkAddrError = validateMAC(linkAddr);
-    const hardwareAddrError = validateMAC(hardwareAddr);
+    const linkAddrError = validateMAC(linkAddr, { required: true });
+    const hardwareAddrError = validateMAC(hardwareAddr, { required: true });
 
     const canSubmit =
         !submitting &&
@@ -191,7 +191,9 @@ const NeighbourDrawer: React.FC<NeighbourDrawerProps> = ({
                 <div className="fw-section-h">L2</div>
                 <div className="fw-section__body">
                     <div className="fw-field">
-                        <label className="fw-field__label">Neighbour MAC</label>
+                        <label className="fw-field__label">
+                            Neighbour MAC <span className="fw-field__req">*</span>
+                        </label>
                         <input
                             className={`fw-input fw-input--mono${linkAddrError ? ' fw-input--invalid' : ''}`}
                             value={linkAddr}
@@ -203,7 +205,9 @@ const NeighbourDrawer: React.FC<NeighbourDrawerProps> = ({
                         )}
                     </div>
                     <div className="fw-field">
-                        <label className="fw-field__label">Interface MAC</label>
+                        <label className="fw-field__label">
+                            Interface MAC <span className="fw-field__req">*</span>
+                        </label>
                         <input
                             className={`fw-input fw-input--mono${hardwareAddrError ? ' fw-input--invalid' : ''}`}
                             value={hardwareAddr}

--- a/web/src/pages/operators/neighbours/utils.test.ts
+++ b/web/src/pages/operators/neighbours/utils.test.ts
@@ -50,11 +50,11 @@ describe('validateMAC', () => {
         expect(validateMAC('52:54:00:12:34:56')).toBeUndefined();
     });
 
-    it('returns undefined for an empty string', () => {
+    it('returns undefined for an empty string (no options)', () => {
         expect(validateMAC('')).toBeUndefined();
     });
 
-    it('returns undefined for a whitespace-only string', () => {
+    it('returns undefined for a whitespace-only string (no options)', () => {
         expect(validateMAC('   ')).toBeUndefined();
     });
 
@@ -64,6 +64,27 @@ describe('validateMAC', () => {
 
     it('returns an error message for an incomplete MAC', () => {
         expect(validateMAC('52:54:00:12')).toBeTruthy();
+    });
+
+    it('returns undefined for empty string when required is not set', () => {
+        expect(validateMAC('', {})).toBeUndefined();
+    });
+
+    it('returns required error for empty string when required is true', () => {
+        expect(validateMAC('', { required: true })).toBe('MAC address is required');
+    });
+
+    it('returns required error for whitespace-only string when required is true', () => {
+        expect(validateMAC('   ', { required: true })).toBe('MAC address is required');
+    });
+
+    it('returns undefined for valid MAC when required is true', () => {
+        expect(validateMAC('52:54:00:12:34:56', { required: true })).toBeUndefined();
+    });
+
+    it('returns format error for invalid MAC regardless of required option', () => {
+        expect(validateMAC('not-a-mac', { required: true })).toBe('Invalid MAC address (expected xx:xx:xx:xx:xx:xx)');
+        expect(validateMAC('not-a-mac', { required: false })).toBe('Invalid MAC address (expected xx:xx:xx:xx:xx:xx)');
     });
 });
 

--- a/web/src/pages/operators/neighbours/utils.ts
+++ b/web/src/pages/operators/neighbours/utils.ts
@@ -42,9 +42,12 @@ export const isSortDirection = (value: string): value is 'asc' | 'desc' =>
     value === 'asc' || value === 'desc';
 
 /** Validates a MAC address string. Returns an error message or undefined when valid. */
-export const validateMAC = (value: string): string | undefined => {
-    if (!value.trim()) return undefined;
-    if (!isValidMAC(value.trim())) return 'Invalid MAC address (expected xx:xx:xx:xx:xx:xx)';
+export const validateMAC = (value: string, options?: { required?: boolean }): string | undefined => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+        return options?.required ? 'MAC address is required' : undefined;
+    }
+    if (!isValidMAC(trimmed)) return 'Invalid MAC address (expected xx:xx:xx:xx:xx:xx)';
     return undefined;
 };
 


### PR DESCRIPTION
The neighbour drawer marked only Next Hop as required, but a static entry needs both the neighbour MAC (link_addr) and the interface MAC (hardware_addr) to be usable. The drawer now treats empty MAC fields as validation errors and the labels show the required asterisk, matching the semantics already enforced by the dataplane on submit.

- The shared validator gains an opt-in `required` option, used only by the neighbour drawer.
- Existing tests for the validator are extended with new cases covering the required mode.