### PR TITLE
feat(testutils): add cp test harness and route functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ cli-clean/%:
 	$(CARGO) clean || true
 
 test: go-cache-clean dataplane
-	go test -count=1 $$(go list ./... | grep -v 'tests/functional')
+	go test -count=1 $$(go list ./... | grep -vE '^github.com/yanet-platform/yanet2/tests/functional($$|/)')
 	meson test -C build
 
 test-asan: go-cache-clean
@@ -175,7 +175,7 @@ test-asan: go-cache-clean
 		meson configure -Dbuildtype=debug -Doptimization=0 -Dfuzzing=disabled -Db_sanitize=address,undefined build; \
 	fi
 	meson compile -C build
-	CGO_CFLAGS="-fsanitize=address,undefined" CGO_LDFLAGS="-fsanitize=address,undefined" go test -count=1 $$(go list ./... | grep -v 'tests/functional')
+	CGO_CFLAGS="-fsanitize=address,undefined" CGO_LDFLAGS="-fsanitize=address,undefined" go test -count=1 $$(go list ./... | grep -vE '^github.com/yanet-platform/yanet2/tests/functional($$|/)')
 	meson test -C build
 
 test-tsan:

--- a/common/go/testutils/cp/cp.go
+++ b/common/go/testutils/cp/cp.go
@@ -1,0 +1,112 @@
+// Package cp provides a thin Go wrapper around the lib/testutils/cp C harness.
+//
+// The harness creates an in-process shared memory arena that mirrors a real
+// YANET shared memory segment. Tests use it to build cp-API module configs
+// without standing up a full dataplane process.
+package cp
+
+//#cgo CFLAGS: -I../../../../ -I../../../../lib
+//#cgo LDFLAGS: -L../../../../build/lib/testutils/cp -ltestutils_cp
+//#cgo LDFLAGS: -L../../../../build/lib/controlplane/agent -lagent
+//#cgo LDFLAGS: -L../../../../build/lib/controlplane/config -lconfig_cp
+//#cgo LDFLAGS: -L../../../../build/lib/counters -lcounters
+//#cgo LDFLAGS: -L../../../../build/lib/dataplane/pipeline -lpipeline
+//#cgo LDFLAGS: -L../../../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../../../build/lib/dataplane/module -lmodule
+//#cgo LDFLAGS: -L../../../../build/lib/logging -llogging
+//#cgo LDFLAGS: -L../../../../build/lib/errors -lerrors
+//#cgo LDFLAGS: -ldl
+/*
+#include <stdlib.h>
+#include "lib/testutils/cp/cp.h"
+#include "lib/errors/errors.h"
+*/
+import "C"
+import (
+	"fmt"
+	"runtime"
+	"unsafe"
+)
+
+// SHM is an in-process test shared memory arena.
+//
+// Create one with NewSHM, then close it when the test is done.
+type SHM struct {
+	ptr *C.struct_test_shm
+}
+
+// NewSHM creates an in-process test arena and registers the named modules.
+//
+// Each name in modules must correspond to a new_module_<name> symbol
+// exported by a statically linked module library. Sizes cpSize and dpSize
+// are the byte capacities of the cp and dp memory regions respectively.
+func NewSHM(cpSize, dpSize uint64, modules []string) (*SHM, error) {
+	var cerr *C.yanet_error
+	defer C.yanet_error_reset(&cerr)
+
+	if len(modules) == 0 {
+		shm := C.test_shm_create(
+			C.size_t(cpSize),
+			C.size_t(dpSize),
+			nil,
+			0,
+			&cerr,
+		)
+		if shm == nil {
+			msg := C.GoString(C.yanet_error_message(cerr))
+			return nil, fmt.Errorf("failed to create test shm: %s", msg)
+		}
+		return &SHM{ptr: shm}, nil
+	}
+
+	// Build a null-terminated C string array for the module names.
+	cnames := make([]*C.char, len(modules))
+	for idx, name := range modules {
+		cnames[idx] = C.CString(name)
+	}
+	defer func() {
+		for _, cname := range cnames {
+			C.free(unsafe.Pointer(cname))
+		}
+	}()
+
+	pinner := runtime.Pinner{}
+	defer pinner.Unpin()
+	pinner.Pin(&cnames[0])
+
+	shm := C.test_shm_create(
+		C.size_t(cpSize),
+		C.size_t(dpSize),
+		(**C.char)(unsafe.Pointer(&cnames[0])),
+		C.size_t(len(modules)),
+		&cerr,
+	)
+	if shm == nil {
+		msg := C.GoString(C.yanet_error_message(cerr))
+		return nil, fmt.Errorf("failed to create test shm: %s", msg)
+	}
+
+	return &SHM{ptr: shm}, nil
+}
+
+// Close releases all resources owned by the SHM arena.
+func (m *SHM) Close() error {
+	if m.ptr == nil {
+		return nil
+	}
+	C.test_shm_destroy(m.ptr)
+	m.ptr = nil
+	return nil
+}
+
+// RawPtr returns the in-process arena pointer as the shm handle understood
+// by ffi.NewSharedMemoryFromRaw.
+//
+// The returned pointer is the arena base address, which the ffi layer treats
+// as a *C.struct_yanet_shm. Valid only for the lifetime of the SHM.
+func (m *SHM) RawPtr() unsafe.Pointer {
+	if m.ptr == nil {
+		return nil
+	}
+	return C.test_shm_dp_config(m.ptr)
+}

--- a/common/go/testutils/cp/cp_test.go
+++ b/common/go/testutils/cp/cp_test.go
@@ -1,0 +1,26 @@
+package cp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/yanet-platform/yanet2/common/go/testutils/cp"
+)
+
+const (
+	smokeCP = 8 * 1024 * 1024
+	smokeDP = 4 * 1024 * 1024
+)
+
+// TestSHM_Lifecycle verifies that the Go wrapper correctly creates a SHM
+// arena and closes it without error. No modules are registered because the
+// cp package is generic and does not link any module dataplane library.
+func TestSHM_Lifecycle(t *testing.T) {
+	shm, err := cp.NewSHM(smokeCP, smokeDP, nil)
+	require.NoError(t, err)
+	require.NotNil(t, shm)
+	require.NotNil(t, shm.RawPtr())
+
+	err = shm.Close()
+	require.NoError(t, err)
+}

--- a/lib/testutils/cp/cp.c
+++ b/lib/testutils/cp/cp.c
@@ -1,0 +1,284 @@
+#include "cp.h"
+
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/exp_array.h"
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/strutils.h"
+
+#include "api/agent.h"
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/zone.h"
+#include "dataplane/config/zone.h"
+
+#include "counters/counters.h"
+#include "dataplane/module/module.h"
+
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+
+struct test_shm {
+	// Raw arena: [dp_config | dp arena ...][cp_config | cp arena ...]
+	void *arena;
+	struct cp_config *cp_config;
+	// Free size of cp_config->block_allocator captured after create
+	// finishes its own bookkeeping allocations. Used by test_shm_destroy
+	// to detect leaks.
+	size_t cp_baseline_free;
+};
+
+// Round size up to a multiple of align. align must be a power of two.
+static inline size_t
+round_up(size_t size, size_t align) {
+	return (size + align - 1) & ~(align - 1);
+}
+
+struct test_shm *
+test_shm_create(
+	size_t cp_size,
+	size_t dp_size,
+	const char *const *module_names,
+	size_t module_name_count,
+	yanet_error **err
+) {
+	cp_size = round_up(cp_size, 64);
+	dp_size = round_up(dp_size, 64);
+
+	struct test_shm *shm =
+		(struct test_shm *)calloc(1, sizeof(struct test_shm));
+	if (shm == NULL) {
+		yanet_error_add(err, "failed to allocate test_shm handle");
+		return NULL;
+	}
+
+	// Single contiguous allocation for both dp and cp zones.
+	void *arena = aligned_alloc(64, dp_size + cp_size);
+	if (arena == NULL) {
+		yanet_error_add(err, "failed to allocate arena");
+		free(shm);
+		return NULL;
+	}
+	memset(arena, 0, dp_size + cp_size);
+
+	shm->arena = arena;
+
+	// Lay out dp_config at the front of the arena.
+	struct dp_config *dp_config = (struct dp_config *)arena;
+	dp_config->instance_count = 1;
+	dp_config->instance_idx = 0;
+	dp_config->numa_idx = 0;
+	dp_config->worker_count = 1;
+	dp_config->storage_size = dp_size + cp_size;
+
+	// Give the dp block allocator the region after the dp_config header.
+	block_allocator_init(&dp_config->block_allocator);
+	block_allocator_put_arena(
+		&dp_config->block_allocator,
+		(uint8_t *)arena + sizeof(struct dp_config),
+		dp_size - sizeof(struct dp_config)
+	);
+	memory_context_init(
+		&dp_config->memory_context, "dp", &dp_config->block_allocator
+	);
+
+	// Lay out cp_config immediately after the dp zone.
+	struct cp_config *cp_config =
+		(struct cp_config *)((uint8_t *)arena + dp_size);
+
+	// Give the cp block allocator the region after the cp_config header.
+	block_allocator_init(&cp_config->block_allocator);
+	block_allocator_put_arena(
+		&cp_config->block_allocator,
+		(uint8_t *)arena + dp_size + sizeof(struct cp_config),
+		cp_size - sizeof(struct cp_config)
+	);
+	memory_context_init(
+		&cp_config->memory_context, "cp", &cp_config->block_allocator
+	);
+
+	// Cross-link dp_config <-> cp_config via offset pointers.
+	SET_OFFSET_OF(&dp_config->cp_config, cp_config);
+	SET_OFFSET_OF(&cp_config->dp_config, dp_config);
+
+	shm->cp_config = cp_config;
+
+	// Allocate a zero-element cp_agent_registry from cp memory.
+	struct cp_agent_registry *reg =
+		(struct cp_agent_registry *)memory_balloc(
+			&cp_config->memory_context,
+			sizeof(struct cp_agent_registry)
+		);
+	if (reg == NULL) {
+		yanet_error_add(err, "failed to allocate cp_agent_registry");
+		goto fail_arena;
+	}
+	reg->count = 0;
+	SET_OFFSET_OF(&cp_config->agent_registry, reg);
+
+	// Initialize the counter storage allocator for the cp zone.
+	// instance_count=1 matches worker_count=1.
+	counter_storage_allocator_init(
+		&cp_config->counter_storage_allocator,
+		&cp_config->memory_context,
+		1
+	);
+
+	// Initialize cp_config_gen using the canonical stub-agent pattern.
+	// A transient stack-allocated agent is constructed here solely to
+	// satisfy the cp_config_gen_create signature, which requires an agent
+	// to resolve dp_config and cp_config pointers.
+	//
+	// Note: the SET_OFFSET_OF calls below store stack-relative offsets
+	// inside the stub agent's own fields. This is safe because the stub
+	// agent never escapes this scope — it is used only within
+	// cp_config_gen_create and is destroyed before the function returns.
+	// The returned cp_config_gen lives in shm and holds no back-references
+	// to the stub agent (confirmed by inspection: dp_topology.device_count
+	// is zero so cp_device_init, which stores agent in cp_device, is never
+	// called).
+	{
+		struct agent stub_agent;
+		memset(&stub_agent, 0, sizeof(struct agent));
+		memory_context_init_from(
+			&stub_agent.memory_context,
+			&cp_config->memory_context,
+			"test_shm cp_config_gen init"
+		);
+		SET_OFFSET_OF(&stub_agent.dp_config, dp_config);
+		SET_OFFSET_OF(&stub_agent.cp_config, cp_config);
+
+		yanet_error *cgen_err = NULL;
+		struct cp_config_gen *config_gen =
+			cp_config_gen_create(&stub_agent, &cgen_err);
+		if (config_gen == NULL) {
+			yanet_error_add(
+				err,
+				"failed to init cp_config_gen: %s",
+				yanet_error_message(cgen_err)
+			);
+			yanet_error_free(cgen_err);
+			memory_context_fini(&stub_agent.memory_context);
+			goto fail_arena;
+		}
+		memory_context_fini(&stub_agent.memory_context);
+		SET_OFFSET_OF(&cp_config->cp_config_gen, config_gen);
+	}
+
+	// Allocate a single dp_worker. gen=UINT64_MAX ensures
+	// dp_config_wait_for_gen never spins on any generation value.
+	struct dp_worker **workers_array = (struct dp_worker **)memory_balloc(
+		&dp_config->memory_context, sizeof(struct dp_worker *)
+	);
+	struct dp_worker *worker = (struct dp_worker *)memory_balloc(
+		&dp_config->memory_context, sizeof(struct dp_worker)
+	);
+	if (workers_array == NULL || worker == NULL) {
+		yanet_error_add(err, "failed to allocate dp_worker");
+		goto fail_arena;
+	}
+	worker->gen = UINT64_MAX;
+	SET_OFFSET_OF(workers_array, worker);
+	SET_OFFSET_OF(&dp_config->workers, workers_array);
+
+	// Resolve each module from the process image and register it. The
+	// loader returns a heap-allocated module; we copy name and handler
+	// into dp_modules, then free it.
+	for (size_t idx = 0; idx < module_name_count; ++idx) {
+		const char *name = module_names[idx];
+		char sym[128];
+		snprintf(sym, sizeof(sym), "new_module_%s", name);
+		module_load_handler loader =
+			(module_load_handler)dlsym(RTLD_DEFAULT, sym);
+		if (loader == NULL) {
+			yanet_error_add(
+				err,
+				"symbol '%s' not found in process image",
+				sym
+			);
+			goto fail_arena;
+		}
+		struct module *m = loader();
+		if (m == NULL) {
+			yanet_error_add(
+				err,
+				"loader for module '%s' returned NULL",
+				name
+			);
+			goto fail_arena;
+		}
+		struct dp_module *dp_modules = ADDR_OF(&dp_config->dp_modules);
+		if (mem_array_expand_exp(
+			    &dp_config->memory_context,
+			    (void **)&dp_modules,
+			    sizeof(struct dp_module),
+			    &dp_config->module_count
+		    )) {
+			free(m);
+			yanet_error_add(
+				err,
+				"failed to expand dp_modules for '%s'",
+				name
+			);
+			goto fail_arena;
+		}
+		struct dp_module *slot =
+			dp_modules + dp_config->module_count - 1;
+		strtcpy(slot->name, m->name, sizeof(slot->name));
+		slot->handler = m->handler;
+		SET_OFFSET_OF(&dp_config->dp_modules, dp_modules);
+		// Convention: new_module_<name> returns a pointer to the start
+		// of a single malloc'd block. Free it here, after copying the
+		// handler into dp_modules. A module that violates this turns
+		// the free into a bug.
+		free(m);
+	}
+
+	// Capture the cp baseline free size after all harness bookkeeping is
+	// done. test_shm_destroy compares against this to detect leaks.
+	shm->cp_baseline_free =
+		block_allocator_free_size(&cp_config->block_allocator);
+
+	return shm;
+
+fail_arena:
+	free(arena);
+	free(shm);
+	return NULL;
+}
+
+void
+test_shm_destroy(struct test_shm *shm) {
+	if (shm == NULL) {
+		return;
+	}
+
+	struct cp_config *cp_config = shm->cp_config;
+
+	size_t cp_free_now =
+		block_allocator_free_size(&cp_config->block_allocator);
+	if (cp_free_now != shm->cp_baseline_free) {
+		LOG(WARN,
+		    "cp allocator leak detected: baseline=%zu current=%zu "
+		    "delta=%zd bytes",
+		    shm->cp_baseline_free,
+		    cp_free_now,
+		    (ssize_t)shm->cp_baseline_free - (ssize_t)cp_free_now);
+	}
+
+	counter_storage_allocator_fini(&cp_config->counter_storage_allocator);
+	memory_context_fini(&((struct dp_config *)shm->arena)->memory_context);
+	memory_context_fini(&cp_config->memory_context);
+
+	free(shm->arena);
+	free(shm);
+}
+
+void *
+test_shm_dp_config(struct test_shm *shm) {
+	return shm->arena;
+}

--- a/lib/testutils/cp/cp.h
+++ b/lib/testutils/cp/cp.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lib/errors/errors.h"
+
+// Opaque handle to the in-process test shared memory arena.
+struct test_shm;
+
+// Create an in-process arena that mimics a YANET shared memory segment.
+//
+// Allocates a single contiguous block, lays out dp_config at the front and
+// cp_config at offset dp_size, initializes both allocators, cross-links them
+// via offset pointers, allocates the cp_agent_registry and cp_config_gen
+// stubs, and registers each module named in module_names by resolving
+// new_module_<name> from the current process image.
+//
+// cp_size and dp_size are rounded up to 64-byte alignment internally.
+// module_name_count may be 0; in that case module_names is ignored.
+//
+// Returns NULL and sets *err on failure.
+struct test_shm *
+test_shm_create(
+	size_t cp_size,
+	size_t dp_size,
+	const char *const *module_names,
+	size_t module_name_count,
+	yanet_error **err
+);
+
+// Release all resources owned by shm, including the arena allocation.
+//
+// Logs a warning if the cp_config block allocator free size differs from the
+// baseline captured after create finished its own bookkeeping allocations.
+void
+test_shm_destroy(struct test_shm *shm);
+
+// Return the dp_config pointer for the arena owned by shm.
+//
+// Owned by shm; do not free the returned pointer.
+void *
+test_shm_dp_config(struct test_shm *shm);

--- a/lib/testutils/cp/cp_smoke_test.c
+++ b/lib/testutils/cp/cp_smoke_test.c
@@ -1,0 +1,198 @@
+#include "cp.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include "api/agent.h"
+#include "common/memory_block.h"
+#include "common/strutils.h"
+#include "common/test_assert.h"
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/zone.h"
+#include "dataplane/config/zone.h"
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+
+// 8 MB cp, 4 MB dp: enough for the harness itself plus a spare agent arena.
+#define SMOKE_CP_SIZE (8u * 1024u * 1024u)
+#define SMOKE_DP_SIZE (4u * 1024u * 1024u)
+
+// 1 MB agent arena: sufficient for cp_module_init bookkeeping.
+#define SMOKE_AGENT_MEM (1u * 1024u * 1024u)
+
+static int
+test_lifecycle(void) {
+	yanet_error *err = NULL;
+
+	struct test_shm *shm =
+		test_shm_create(SMOKE_CP_SIZE, SMOKE_DP_SIZE, NULL, 0, &err);
+	TEST_ASSERT_NOT_NULL(shm, "test_shm_create failed");
+
+	struct agent *agent = agent_attach(
+		(struct yanet_shm *)test_shm_dp_config(shm),
+		0,
+		"smoke-lifecycle",
+		SMOKE_AGENT_MEM,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	agent_cleanup(agent);
+	test_shm_destroy(shm);
+
+	return TEST_SUCCESS;
+}
+
+static int
+test_free_size_baseline(void) {
+	yanet_error *err = NULL;
+
+	struct test_shm *shm =
+		test_shm_create(SMOKE_CP_SIZE, SMOKE_DP_SIZE, NULL, 0, &err);
+	TEST_ASSERT_NOT_NULL(shm, "test_shm_create failed");
+
+	struct dp_config *dp_config =
+		(struct dp_config *)test_shm_dp_config(shm);
+	struct cp_config *cp_config = ADDR_OF(&dp_config->cp_config);
+
+	// Capture how much cp memory is free before the agent is attached.
+	size_t before = block_allocator_free_size(&cp_config->block_allocator);
+
+	struct agent *agent = agent_attach(
+		(struct yanet_shm *)test_shm_dp_config(shm),
+		0,
+		"smoke-free-size",
+		SMOKE_AGENT_MEM,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	// The agent's own arena is drawn from cp memory, so cp free_size
+	// must decrease while the agent is alive.
+	size_t during = block_allocator_free_size(&cp_config->block_allocator);
+	TEST_ASSERT(
+		during < before,
+		"cp free_size did not decrease after agent_attach: "
+		"before=%zu during=%zu",
+		before,
+		during
+	);
+
+	// After cleanup, the agent's arenas are returned to cp. The only
+	// permanent consumption is the cp_agent_registry slot for the new
+	// agent name, which is a fixed small overhead.
+	agent_cleanup(agent);
+
+	size_t after = block_allocator_free_size(&cp_config->block_allocator);
+	TEST_ASSERT(
+		after > during,
+		"cp free_size did not increase after agent_cleanup: "
+		"during=%zu after=%zu",
+		during,
+		after
+	);
+
+	test_shm_destroy(shm);
+	return TEST_SUCCESS;
+}
+
+static int
+test_module_registration(void) {
+	yanet_error *err = NULL;
+
+	static const char *names[] = {"route", "decap"};
+	struct test_shm *shm =
+		test_shm_create(SMOKE_CP_SIZE, SMOKE_DP_SIZE, names, 2, &err);
+	TEST_ASSERT_NOT_NULL(shm, "test_shm_create with modules failed");
+
+	struct dp_config *dp_config =
+		(struct dp_config *)test_shm_dp_config(shm);
+
+	TEST_ASSERT_EQUAL(
+		(long)dp_config->module_count,
+		(long)2,
+		"expected 2 registered modules, got %lu",
+		dp_config->module_count
+	);
+
+	struct dp_module *modules = ADDR_OF(&dp_config->dp_modules);
+
+	bool found_route = false;
+	bool found_decap = false;
+	for (uint64_t idx = 0; idx < dp_config->module_count; ++idx) {
+		TEST_ASSERT_NOT_NULL(
+			(void *)(uintptr_t)modules[idx].handler,
+			"module[%lu] has NULL handler",
+			idx
+		);
+		if (strncmp(modules[idx].name, "route", 80) == 0) {
+			found_route = true;
+		}
+		if (strncmp(modules[idx].name, "decap", 80) == 0) {
+			found_decap = true;
+		}
+	}
+
+	TEST_ASSERT(found_route, "module 'route' not registered");
+	TEST_ASSERT(found_decap, "module 'decap' not registered");
+
+	test_shm_destroy(shm);
+	return TEST_SUCCESS;
+}
+
+static int
+test_attach_no_modules(void) {
+	yanet_error *err = NULL;
+
+	struct test_shm *shm =
+		test_shm_create(SMOKE_CP_SIZE, SMOKE_DP_SIZE, NULL, 0, &err);
+	TEST_ASSERT_NOT_NULL(shm, "test_shm_create failed");
+
+	struct agent *agent = agent_attach(
+		(struct yanet_shm *)test_shm_dp_config(shm),
+		0,
+		"smoke-no-modules",
+		SMOKE_AGENT_MEM,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(
+		agent, "agent_attach should succeed even with no modules"
+	);
+
+	agent_cleanup(agent);
+	test_shm_destroy(shm);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	int rc = 0;
+
+	if (test_lifecycle() != TEST_SUCCESS) {
+		LOG(ERROR, "test_lifecycle FAILED");
+		rc = 1;
+	}
+
+	if (test_free_size_baseline() != TEST_SUCCESS) {
+		LOG(ERROR, "test_free_size_baseline FAILED");
+		rc = 1;
+	}
+
+	if (test_module_registration() != TEST_SUCCESS) {
+		LOG(ERROR, "test_module_registration FAILED");
+		rc = 1;
+	}
+
+	if (test_attach_no_modules() != TEST_SUCCESS) {
+		LOG(ERROR, "test_attach_no_modules FAILED");
+		rc = 1;
+	}
+
+	if (rc == 0) {
+		LOG(INFO, "all smoke tests passed");
+	}
+
+	return rc;
+}

--- a/lib/testutils/cp/meson.build
+++ b/lib/testutils/cp/meson.build
@@ -1,0 +1,57 @@
+lib_testutils_cp_deps = [
+  lib_common_dep,
+  lib_logging_dep,
+  lib_errors_dep,
+  lib_config_cp_dep,
+  lib_agent_cp_dep,
+  lib_counters_dep,
+  lib_pipeline_dp_dep,
+]
+
+lib_testutils_cp = static_library(
+  'testutils_cp',
+  'cp.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + ['-ldl'],
+  dependencies: lib_testutils_cp_deps,
+  include_directories: [yanet_rootdir, yanet_libdir],
+  install: false,
+)
+
+lib_testutils_cp_dep = declare_dependency(
+  link_with: lib_testutils_cp,
+  dependencies: lib_testutils_cp_deps,
+  include_directories: [yanet_rootdir, yanet_libdir],
+)
+
+# Modules linked into the smoke test so dlsym(RTLD_DEFAULT) can resolve
+# new_module_route and new_module_decap.
+smoke_modules_dep = [
+  lib_decap_dp_dep,
+  lib_dscp_dp_dep,
+  lib_acl_dp_dep,
+  lib_fwstate_dp_dep,
+  lib_forward_dp_dep,
+  lib_route_dp_dep,
+  lib_nat64_dp_dep,
+  lib_pdump_dp_dep,
+]
+
+smoke_devices_dep = [
+  lib_dev_plain_dp_dep,
+  lib_dev_vlan_dp_dep,
+]
+
+cp_smoke_test = executable(
+  'cp_smoke_test',
+  'cp_smoke_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + ['-ldl'],
+  dependencies: [
+    lib_testutils_cp_dep,
+    libdpdk_inc_dep,
+  ] + smoke_modules_dep + smoke_devices_dep,
+  include_directories: [yanet_rootdir, yanet_libdir],
+)
+
+test('cp_smoke_test', cp_smoke_test, suite: 'testutils')

--- a/lib/testutils/meson.build
+++ b/lib/testutils/meson.build
@@ -1,0 +1,1 @@
+subdir('cp')

--- a/meson.build
+++ b/meson.build
@@ -155,6 +155,7 @@ if not dataplane_only
     subdir(dir)
   endforeach
   subdir('tests')
+  subdir('lib/testutils')
 endif
 
 # Define a default test setup that excludes large tests

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -46,6 +46,14 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
+// CPModulePtr returns the raw *C.struct_cp_module as an unsafe.Pointer.
+//
+// Intended for tests that need to call the dataplane handler directly
+// via a C shim that expects a cp_module pointer.
+func (m *ModuleConfig) CPModulePtr() unsafe.Pointer {
+	return unsafe.Pointer(m.asRawPtr())
+}
+
 // Free releases the underlying C memory.
 //
 // Safe to call multiple times: subsequent calls are no-ops.

--- a/modules/route/tests/functional/route.go
+++ b/modules/route/tests/functional/route.go
@@ -1,0 +1,218 @@
+package route_test
+
+//#cgo CFLAGS: -I../../../../ -I../../../../lib
+//#cgo LDFLAGS: -L../../../../build/lib/testutils/cp -ltestutils_cp
+//#cgo LDFLAGS: -L../../../../build/modules/route/api -lroute_cp
+//#cgo LDFLAGS: -L../../../../build/modules/route/dataplane -lroute_dp
+//#cgo LDFLAGS: -L../../../../build/lib/controlplane/agent -lagent
+//#cgo LDFLAGS: -L../../../../build/lib/controlplane/config -lconfig_cp
+//#cgo LDFLAGS: -L../../../../build/lib/counters -lcounters
+//#cgo LDFLAGS: -L../../../../build/lib/dataplane/pipeline -lpipeline
+//#cgo LDFLAGS: -L../../../../build/lib/dataplane/config -lconfig_dp
+//#cgo LDFLAGS: -L../../../../build/lib/dataplane/module -lmodule
+//#cgo LDFLAGS: -L../../../../build/lib/dataplane/packet -lpacket
+//#cgo LDFLAGS: -L../../../../build/lib/logging -llogging
+//#cgo LDFLAGS: -L../../../../build/lib/errors -lerrors
+//#cgo LDFLAGS: -Wl,--export-dynamic -ldl
+/*
+#include <stdlib.h>
+#include "dataplane/module/module.h"
+#include "dataplane/pipeline/econtext.h"
+#include "lib/dataplane/module/packet_front.h"
+
+struct module *new_module_route(void);
+
+static void
+run_route(
+	struct cp_module *cp_module, uint64_t *mc_index, uint64_t mc_index_size,
+	struct packet_front *pf, const uint32_t *hashes, uint64_t packet_count
+) {
+	if (hashes != NULL) {
+		struct packet *p = pf->input.first;
+		for (uint64_t idx = 0; idx < packet_count && p != NULL; idx++) {
+			p->hash = hashes[idx];
+			p = p->next;
+		}
+	}
+	struct module *mod = new_module_route();
+	struct module_ectx ectx = {};
+	SET_OFFSET_OF(&ectx.cp_module, cp_module);
+	SET_OFFSET_OF(&ectx.mc_index, mc_index);
+	ectx.mc_index_size = mc_index_size;
+	mod->handler(NULL, &ectx, pf);
+	free(mod);
+	packet_list_concat(&pf->output, &pf->pending_output);
+	packet_list_init(&pf->pending_output);
+}
+*/
+import "C"
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"runtime"
+	"testing"
+	"unsafe"
+
+	"github.com/gopacket/gopacket"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/commonpb"
+	"github.com/yanet-platform/yanet2/common/go/dataplane"
+	testcp "github.com/yanet-platform/yanet2/common/go/testutils/cp"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
+	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb"
+)
+
+const (
+	routeCPSize  = 16 * 1024 * 1024
+	routeDPSize  = 4 * 1024 * 1024
+	routeMemSize = 2 * 1024 * 1024
+)
+
+// FIBNexthop is a test-domain nexthop descriptor.
+//
+// Device is the interface name passed on the wire. Registration order
+// determines the mc_index slot: the first unique device gets slot 1, the
+// second gets slot 2, and so on (slot 0 is the empty-name sentinel).
+type FIBNexthop struct {
+	DstMAC net.HardwareAddr
+	SrcMAC net.HardwareAddr
+	Device string
+}
+
+// FIBEntry is a test-domain FIB prefix with associated nexthops.
+type FIBEntry struct {
+	Prefix   netip.Prefix
+	Nexthops []FIBNexthop
+}
+
+// setupRouteBackend stands up the Go controlplane backend against an
+// in-process test shm.
+//
+// Returns the backend. All shm and agent resources are cleaned up via
+// t.Cleanup in LIFO order (shm.Close runs last).
+func setupRouteBackend(t *testing.T) route.Backend {
+	t.Helper()
+
+	shm, err := testcp.NewSHM(routeCPSize, routeDPSize, []string{"route"})
+	require.NoError(t, err)
+	// Register Close first so it executes last (LIFO teardown).
+	t.Cleanup(func() { _ = shm.Close() })
+
+	ffiShm := ffi.NewSharedMemoryFromRaw(shm.RawPtr())
+	// No Detach in cleanup: ffi.SharedMemory.Detach calls yanet_shm_detach
+	// which expects a process-level shm fd. The in-process arena is owned
+	// by shm.Close above.
+
+	agent, err := ffiShm.AgentAttach("route", 0, routeMemSize)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	return route.NewBackend(agent)
+}
+
+// applyFIB pushes the given entries via the backend and returns the cp_module
+// pointer for the named config, ready for routeHandlePackets.
+func applyFIB(t *testing.T, backend route.Backend, name string, entries []FIBEntry) unsafe.Pointer {
+	t.Helper()
+
+	pbEntries := make([]*routepb.FIBEntry, 0, len(entries))
+	for _, e := range entries {
+		nexthops := make([]*routepb.FIBNexthop, 0, len(e.Nexthops))
+		for _, nh := range e.Nexthops {
+			nexthops = append(nexthops, &routepb.FIBNexthop{
+				DstMac: commonpb.NewMACAddressEUI48([6]byte(nh.DstMAC)),
+				SrcMac: commonpb.NewMACAddressEUI48([6]byte(nh.SrcMAC)),
+				Device: nh.Device,
+			})
+		}
+		pbEntries = append(pbEntries, &routepb.FIBEntry{
+			Prefix:   e.Prefix.String(),
+			Nexthops: nexthops,
+		})
+	}
+
+	handle, err := backend.UpdateModule(name, pbEntries)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	mc, ok := handle.(*croute.ModuleConfig)
+	require.True(t, ok, "handle is not *croute.ModuleConfig")
+
+	return mc.CPModulePtr()
+}
+
+// routeHandlePackets invokes the route handler for the given packets.
+//
+// mcIndex[0] maps the empty-name sentinel device (unused by routing);
+// mcIndex[1..N] map the devices registered in the order nexthops were first
+// seen by the backend.
+func routeHandlePackets(
+	mc unsafe.Pointer,
+	mcIndex []uint64,
+	packets ...gopacket.Packet,
+) (*dataplane.PacketFrontPayload, error) {
+	return routeHandlePacketsWithHashes(mc, mcIndex, nil, packets...)
+}
+
+// routeHandlePacketsWithHashes is like routeHandlePackets but also accepts a
+// per-packet hash slice that controls ECMP bucket selection. If hashes is nil
+// the handler uses whatever hash value is already set on each packet (zero in
+// the test environment).
+func routeHandlePacketsWithHashes(
+	mc unsafe.Pointer,
+	mcIndex []uint64,
+	hashes []uint32,
+	packets ...gopacket.Packet,
+) (*dataplane.PacketFrontPayload, error) {
+	pinner := runtime.Pinner{}
+	defer pinner.Unpin()
+
+	pf, err := dataplane.NewPacketFrontFromPackets(&pinner, packets...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create packet front: %w", err)
+	}
+
+	var mcPtr *C.uint64_t
+	if len(mcIndex) > 0 {
+		pinner.Pin(&mcIndex[0])
+		mcPtr = (*C.uint64_t)(unsafe.Pointer(&mcIndex[0]))
+	}
+
+	var hashPtr *C.uint32_t
+	if len(hashes) > 0 {
+		chashes := make([]C.uint32_t, len(hashes))
+		for idx, h := range hashes {
+			chashes[idx] = C.uint32_t(h)
+		}
+		pinner.Pin(&chashes[0])
+		hashPtr = &chashes[0]
+	}
+
+	C.run_route(
+		(*C.struct_cp_module)(mc),
+		mcPtr,
+		C.uint64_t(len(mcIndex)),
+		(*C.struct_packet_front)(unsafe.Pointer(pf)),
+		hashPtr,
+		C.uint64_t(len(packets)),
+	)
+
+	payload := pf.Payload()
+	return &payload, nil
+}
+
+// mcIndexFor builds the mc_index lookup table from a list of encoded
+// output device IDs in registration order.
+//
+// Slot 0 is reserved for the empty-name sentinel that cp_module_init
+// installs in every cp_module; callers pass only real-device IDs and
+// the helper prepends the sentinel automatically. Slot 1 corresponds
+// to the first device registered via UpdateFIB, slot 2 to the second,
+// in the order nexthops were first seen by the backend.
+func mcIndexFor(devices ...uint64) []uint64 {
+	return append([]uint64{0}, devices...)
+}

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -1,0 +1,375 @@
+package route_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+)
+
+// encodedDeviceID is the encoded output device value placed in mc_index. Any
+// non-0xFFFF value signals a valid output device to the route handler.
+const encodedDeviceID = uint64(7)
+
+// invalidDeviceID is the sentinel that causes the route handler to drop the
+// packet (mirrors (uint16_t)-1 cast to uint64_t).
+const invalidDeviceID = uint64(0xFFFF)
+
+// testingEtherLayers returns a reusable set of Ethernet and IP layers for
+// building route test packets.
+func testingEtherLayers() (layers.Ethernet, layers.IPv4, layers.IPv6, layers.ICMPv4) {
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    net.ParseIP("10.0.0.1"),
+		DstIP:    net.ParseIP("192.168.1.1"),
+	}
+	ip6 := layers.IPv6{
+		Version:    6,
+		HopLimit:   64,
+		NextHeader: layers.IPProtocolICMPv6,
+		SrcIP:      net.ParseIP("::1"),
+		DstIP:      net.ParseIP("2001:db8::1"),
+	}
+	icmp := layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+	}
+	return eth, ip4, ip6, icmp
+}
+
+// routeNextHop is the nexthop definition used across single-hop tests.
+// Packets forwarded via this hop will have their Ethernet header rewritten
+// with these MACs.
+var routeNextHop = FIBNexthop{
+	DstMAC: xerror.Unwrap(net.ParseMAC("de:ad:be:ef:00:01")),
+	SrcMAC: xerror.Unwrap(net.ParseMAC("ca:fe:ba:be:00:01")),
+	Device: "veth1",
+}
+
+func TestRoute_IPv4_Forward(t *testing.T) {
+	eth, ip4, _, icmp := testingEtherLayers()
+
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	t.Log("Origin packet", pkt)
+
+	prefix := xerror.Unwrap(netip.ParsePrefix("192.168.1.0/24"))
+
+	backend := setupRouteBackend(t)
+	mc := applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+	})
+
+	result, err := routeHandlePackets(mc, mcIndexFor(encodedDeviceID), pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "expected one forwarded packet")
+	require.Empty(t, result.Drop, "expected no dropped packets")
+
+	resultPkt := xpacket.ParseEtherPacket(result.Output[0])
+	t.Log("Result packet", resultPkt)
+
+	// The Ethernet header must be rewritten with the next-hop MACs.
+	ethOut := layers.Ethernet{
+		SrcMAC:       routeNextHop.SrcMAC,
+		DstMAC:       routeNextHop.DstMAC,
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	// TTL must be decremented by one.
+	ip4Out := ip4
+	ip4Out.TTL = 63
+	expectedPkt := xpacket.LayersToPacket(t, &ethOut, &ip4Out, &icmp)
+	t.Log("Expected packet", expectedPkt)
+
+	diff := cmp.Diff(expectedPkt.Layers(), resultPkt.Layers(), cmpopts.IgnoreUnexported(layers.ICMPv4{}))
+	require.Empty(t, diff)
+
+	// Verify that the IPv4 layer parsed cleanly (gopacket validates checksum on decode).
+	ip4Layer := resultPkt.Layer(layers.LayerTypeIPv4)
+	require.NotNil(t, ip4Layer, "IPv4 layer must be present in result")
+}
+
+func TestRoute_IPv6_Forward(t *testing.T) {
+	_, _, ip6, _ := testingEtherLayers()
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv6,
+	}
+	icmp6 := layers.ICMPv6{
+		TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeEchoRequest, 0),
+	}
+	icmp6.SetNetworkLayerForChecksum(&ip6)
+
+	pkt := xpacket.LayersToPacket(t, &eth, &ip6, &icmp6)
+	t.Log("Origin packet", pkt)
+
+	prefix := xerror.Unwrap(netip.ParsePrefix("2001:db8::/32"))
+
+	backend := setupRouteBackend(t)
+	mc := applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+	})
+
+	result, err := routeHandlePackets(mc, mcIndexFor(encodedDeviceID), pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "expected one forwarded packet")
+	require.Empty(t, result.Drop, "expected no dropped packets")
+
+	resultPkt := xpacket.ParseEtherPacket(result.Output[0])
+	t.Log("Result packet", resultPkt)
+
+	ethOut := layers.Ethernet{
+		SrcMAC:       routeNextHop.SrcMAC,
+		DstMAC:       routeNextHop.DstMAC,
+		EthernetType: layers.EthernetTypeIPv6,
+	}
+	// HopLimit must be decremented by one.
+	ip6Out := ip6
+	ip6Out.HopLimit = 63
+	expectedPkt := xpacket.LayersToPacket(t, &ethOut, &ip6Out, &icmp6)
+	t.Log("Expected packet", expectedPkt)
+
+	diff := cmp.Diff(expectedPkt.Layers(), resultPkt.Layers(),
+		cmpopts.IgnoreUnexported(layers.IPv6{}, layers.ICMPv6{}),
+	)
+	require.Empty(t, diff)
+}
+
+func TestRoute_TTL_Drop(t *testing.T) {
+	prefix := xerror.Unwrap(netip.ParsePrefix("192.168.1.0/24"))
+
+	cases := []struct {
+		name            string
+		ttl             uint8
+		expectForwarded bool
+	}{
+		{name: "ttl_zero_drop", ttl: 0, expectForwarded: false},
+		{name: "ttl_one_drop", ttl: 1, expectForwarded: false},
+		{name: "ttl_two_forward", ttl: 2, expectForwarded: true},
+		{name: "ttl_64_forward", ttl: 64, expectForwarded: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eth, ip4, _, icmp := testingEtherLayers()
+			ip4.TTL = tc.ttl
+
+			pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+			t.Logf("Origin packet idx=0\n%s", pkt)
+
+			backend := setupRouteBackend(t)
+			mc := applyFIB(t, backend, "test", []FIBEntry{
+				{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+			})
+
+			result, err := routeHandlePackets(mc, mcIndexFor(encodedDeviceID), pkt)
+			require.NoError(t, err)
+
+			if tc.expectForwarded {
+				require.Len(t, result.Output, 1, "expected forwarded packet")
+				require.Empty(t, result.Drop, "expected no dropped packets")
+				resultPkt := xpacket.ParseEtherPacket(result.Output[0])
+				ip4Layer := resultPkt.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
+				require.Equal(t, uint8(tc.ttl-1), ip4Layer.TTL)
+			} else {
+				require.Empty(t, result.Output, "expected no forwarded packets")
+				require.Len(t, result.Drop, 1, "expected dropped packet")
+			}
+		})
+	}
+}
+
+func TestRoute_HopLimit_Drop(t *testing.T) {
+	prefix := xerror.Unwrap(netip.ParsePrefix("2001:db8::/32"))
+
+	cases := []struct {
+		name            string
+		hopLimit        uint8
+		expectForwarded bool
+	}{
+		{name: "hop_limit_zero_drop", hopLimit: 0, expectForwarded: false},
+		{name: "hop_limit_one_drop", hopLimit: 1, expectForwarded: false},
+		{name: "hop_limit_two_forward", hopLimit: 2, expectForwarded: true},
+		{name: "hop_limit_64_forward", hopLimit: 64, expectForwarded: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eth := layers.Ethernet{
+				SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+				DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+				EthernetType: layers.EthernetTypeIPv6,
+			}
+			_, _, ip6, _ := testingEtherLayers()
+			ip6.HopLimit = tc.hopLimit
+			icmp6 := layers.ICMPv6{
+				TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeEchoRequest, 0),
+			}
+			icmp6.SetNetworkLayerForChecksum(&ip6)
+
+			pkt := xpacket.LayersToPacket(t, &eth, &ip6, &icmp6)
+			t.Logf("Origin packet idx=0\n%s", pkt)
+
+			backend := setupRouteBackend(t)
+			mc := applyFIB(t, backend, "test", []FIBEntry{
+				{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+			})
+
+			result, err := routeHandlePackets(mc, mcIndexFor(encodedDeviceID), pkt)
+			require.NoError(t, err)
+
+			if tc.expectForwarded {
+				require.Len(t, result.Output, 1, "expected forwarded packet")
+				require.Empty(t, result.Drop, "expected no dropped packets")
+				resultPkt := xpacket.ParseEtherPacket(result.Output[0])
+				ip6Layer := resultPkt.Layer(layers.LayerTypeIPv6).(*layers.IPv6)
+				require.Equal(t, uint8(tc.hopLimit-1), ip6Layer.HopLimit)
+			} else {
+				require.Empty(t, result.Output, "expected no forwarded packets")
+				require.Len(t, result.Drop, 1, "expected dropped packet")
+			}
+		})
+	}
+}
+
+func TestRoute_NoMatch_Drop(t *testing.T) {
+	eth, ip4, _, icmp := testingEtherLayers()
+	// Destination is not covered by any prefix in the LPM.
+	ip4.DstIP = net.ParseIP("10.99.99.99")
+
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	t.Log("Origin packet", pkt)
+
+	prefix := xerror.Unwrap(netip.ParsePrefix("192.168.1.0/24"))
+
+	backend := setupRouteBackend(t)
+	mc := applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+	})
+
+	result, err := routeHandlePackets(mc, mcIndexFor(encodedDeviceID), pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "unrouted packet must be dropped")
+	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
+}
+
+func TestRoute_NonIP_Drop(t *testing.T) {
+	prefix := xerror.Unwrap(netip.ParsePrefix("192.168.1.0/24"))
+
+	backend := setupRouteBackend(t)
+	mc := applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+	})
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("ff:ff:ff:ff:ff:ff")),
+		EthernetType: layers.EthernetTypeARP,
+	}
+	arp := layers.ARP{
+		AddrType:          layers.LinkTypeEthernet,
+		Protocol:          layers.EthernetTypeIPv4,
+		HwAddressSize:     6,
+		ProtAddressSize:   4,
+		Operation:         layers.ARPRequest,
+		SourceHwAddress:   eth.SrcMAC,
+		SourceProtAddress: net.ParseIP("10.0.0.1").To4(),
+		DstHwAddress:      net.HardwareAddr{0, 0, 0, 0, 0, 0},
+		DstProtAddress:    net.ParseIP("10.0.0.2").To4(),
+	}
+
+	pkt := xpacket.LayersToPacket(t, &eth, &arp)
+	t.Log("Origin packet", pkt)
+
+	result, err := routeHandlePackets(mc, mcIndexFor(encodedDeviceID), pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "non-IP packet must be dropped")
+	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
+}
+
+func TestRoute_ECMP_HashSelection(t *testing.T) {
+	// Two nexthops share one prefix via a two-entry route_list.
+	hop0 := FIBNexthop{
+		DstMAC: xerror.Unwrap(net.ParseMAC("de:ad:00:00:00:01")),
+		SrcMAC: xerror.Unwrap(net.ParseMAC("ca:fe:00:00:00:01")),
+		Device: "veth1",
+	}
+	hop1 := FIBNexthop{
+		DstMAC: xerror.Unwrap(net.ParseMAC("de:ad:00:00:00:02")),
+		SrcMAC: xerror.Unwrap(net.ParseMAC("ca:fe:00:00:00:02")),
+		Device: "veth2",
+	}
+
+	prefix := xerror.Unwrap(netip.ParsePrefix("192.168.1.0/24"))
+
+	backend := setupRouteBackend(t)
+	mc := applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{hop0, hop1}},
+	})
+
+	// Slots correspond to hop0 ("veth1") and hop1 ("veth2") in nexthop
+	// slice order — that order determines device registration order.
+	mcIndex := mcIndexFor(encodedDeviceID, encodedDeviceID+1)
+
+	// Build 4 identical packets. Inject explicit hash values: two with hash=0
+	// (route_list[0 % 2] → hop0) and two with hash=1 (route_list[1 % 2] → hop1),
+	// confirming both arms are reachable.
+	eth, ip4, _, icmp := testingEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pkts := []gopacket.Packet{pkt, pkt, pkt, pkt}
+	hashes := []uint32{0, 1, 0, 1}
+
+	result, err := routeHandlePacketsWithHashes(mc, mcIndex, hashes, pkts...)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 4, "all packets must be forwarded")
+	require.Empty(t, result.Drop)
+
+	// Verify both nexthops were selected exactly twice each.
+	hop0Count, hop1Count := 0, 0
+	for _, raw := range result.Output {
+		resultPkt := xpacket.ParseEtherPacket(raw)
+		ethLayer := resultPkt.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
+		switch ethLayer.DstMAC.String() {
+		case hop0.DstMAC.String():
+			hop0Count++
+		case hop1.DstMAC.String():
+			hop1Count++
+		}
+	}
+	t.Logf("ECMP distribution: hop0=%d hop1=%d", hop0Count, hop1Count)
+	require.Equal(t, 2, hop0Count, "hop0 must be selected for hash=0 packets")
+	require.Equal(t, 2, hop1Count, "hop1 must be selected for hash=1 packets")
+}
+
+func TestRoute_DeviceTranslation_Drop(t *testing.T) {
+	eth, ip4, _, icmp := testingEtherLayers()
+
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	t.Log("Origin packet", pkt)
+
+	prefix := xerror.Unwrap(netip.ParsePrefix("192.168.1.0/24"))
+
+	backend := setupRouteBackend(t)
+	mc := applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+	})
+
+	result, err := routeHandlePackets(mc, mcIndexFor(invalidDeviceID), pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "packet with invalid device translation must be dropped")
+	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
+}


### PR DESCRIPTION
Introduce a control-plane test harness and route module functional tests built on top of it.

### `lib/testutils/cp`

A C library that allocates a single in-process arena, lays out `dp_config` + `cp_config` in it, wires the cross-link offset pointers, initialises `cp_config_gen` via the canonical stub-agent pattern, and registers requested module dataplane symbols (resolved via `dlsym(RTLD_DEFAULT)`).

Once attached, production control-plane APIs (`agent_attach`, `route_module_config_*`, `agent_update_modules`, …) work against the arena exactly as they do against real shared memory. No DPDK EAL, no hugepages, no root.

Public C surface is intentionally minimal: `test_shm_create`, `test_shm_destroy`, `test_shm_dp_config`. A pure-C smoke test exercises lifecycle, agent attach/cleanup, and module registration.

### `common/go/testutils/cp`

Thin Go wrapper that exposes the harness as `SHM` with `NewSHM`, `Close`, `RawPtr`. `RawPtr` returns the arena pointer cast as the `yanet_shm` handle, so it can be plugged into the existing `ffi.NewSharedMemoryFromRaw` and from there into the production `ffi.SharedMemory.AgentAttach` chain.

### `modules/route/tests/functional`

First module suite built on the harness. Each test stands up the harness, attaches an agent, constructs `route.Backend`, pushes FIB state via `Backend.UpdateModule`, retrieves the module handle's `cp_module` pointer through the new `croute.ModuleConfig.CPModulePtr` accessor, and feeds packets to the dataplane handler via a thin CGO shim.

Covers: IPv4/IPv6 forwarding with MAC rewrite and TTL/hop-limit decrement, TTL boundary drops, no-match drop, non-IP drop, ECMP hash-based selection, and device-translation failure drop. The setup exercises the real Go controlplane write-path (`Backend` + `croute` + `ffi.Agent` + `agent_update_modules`), so a regression in the controlplane stack is caught by the same test that asserts dataplane behaviour.

### Makefile

The pre-existing `grep -v 'tests/functional'` filter accidentally caught the new module-scoped functional suite. The regex is now anchored to the top-level `tests/functional` only, so module-scoped suites are picked up by `make test` and `make test-asan`.