### PR TITLE
feat(cli): expose -n short flag for name on function/pipeline subcommands

### DIFF
--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -59,7 +59,7 @@ pub struct ListCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Function name.
-    #[arg(long)]
+    #[arg(short, long)]
     pub name: String,
     /// Output format.
     #[clap(long, value_enum, default_value_t)]
@@ -69,7 +69,7 @@ pub struct ShowCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// Function name.
-    #[arg(long)]
+    #[arg(short, long)]
     pub name: String,
     /// Chains in format name:weight=type:name,type:name
     #[arg(long)]

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -59,7 +59,7 @@ pub struct ListCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Pipeline name.
-    #[arg(long)]
+    #[arg(short, long)]
     pub name: String,
     /// Output format.
     #[clap(long, value_enum, default_value_t)]
@@ -69,7 +69,7 @@ pub struct ShowCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// Pipeline name.
-    #[arg(long)]
+    #[arg(short, long)]
     pub name: String,
     /// Pipeline functions.
     #[arg(long, value_delimiter = ',')]


### PR DESCRIPTION
Align the function and pipeline CLIs with the rest of YANET's module and device CLIs by accepting both `--name` and `-n` for the config/instance name on the `show` and `update` subcommands. Until now those two subcommands only accepted `--name`, while every other module CLI (acl, decap, dscp, forward, nat64, route, route-mpls, pdump, fwstate, balancer2) and device CLI (plain, vlan) already exposed both forms.

The fix changes `#[arg(long)]` to `#[arg(short, long)]` on four name fields, letting clap derive the short letter from the field. `DeleteCmd` in both files already followed this pattern, so this brings `ShowCmd` and `UpdateCmd` into line.