### PR TITLE
feat: add YANET dashboard as application home page

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,11 +12,13 @@
                 "@gravity-ui/navigation": "^3",
                 "@gravity-ui/uikit": "^7",
                 "@tanstack/react-virtual": "^3.13.12",
+                "@types/three": "^0.146.0",
                 "diff": "^9.0.0",
                 "js-yaml": "^4.1.0",
                 "react": "^19",
                 "react-dom": "^19",
-                "react-router-dom": "^7.9.6"
+                "react-router-dom": "^7.9.6",
+                "three": "^0.146.0"
             },
             "devDependencies": {
                 "@testing-library/jest-dom": "^6.9.1",
@@ -2044,10 +2046,25 @@
                 "@types/react": "^19.2.0"
             }
         },
+        "node_modules/@types/three": {
+            "version": "0.146.0",
+            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.146.0.tgz",
+            "integrity": "sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/webxr": "*"
+            }
+        },
         "node_modules/@types/use-sync-external-store": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
             "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/webxr": {
+            "version": "0.5.24",
+            "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+            "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
             "license": "MIT"
         },
         "node_modules/@vitejs/plugin-react": {
@@ -2769,7 +2786,6 @@
             "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@asamuzakjp/css-color": "^5.1.11",
                 "@asamuzakjp/dom-selector": "^7.1.1",
@@ -3501,6 +3517,12 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.3.0.tgz",
             "integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
+            "license": "MIT"
+        },
+        "node_modules/three": {
+            "version": "0.146.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.146.0.tgz",
+            "integrity": "sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A==",
             "license": "MIT"
         },
         "node_modules/tiny-invariant": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,11 +14,13 @@
         "@gravity-ui/navigation": "^3",
         "@gravity-ui/uikit": "^7",
         "@tanstack/react-virtual": "^3.13.12",
+        "@types/three": "^0.146.0",
         "diff": "^9.0.0",
         "js-yaml": "^4.1.0",
         "react": "^19",
         "react-dom": "^19",
-        "react-router-dom": "^7.9.6"
+        "react-router-dom": "^7.9.6",
+        "three": "^0.146.0"
     },
     "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import type { PageId, SidebarContextValue } from './types';
 import { PAGE_IDS, SidebarContext } from './types';
 
 const importInspect = () => import('./pages/builtin/inspect/InspectPage');
+const importInspect3d = () => import('./pages/builtin/inspect-3d/Inspect3dPage');
 const importFunctions = () => import('./pages/builtin/functions/FunctionsPage');
 const importPipelines = () => import('./pages/builtin/pipelines/PipelinesPage');
 const importDevices = () => import('./pages/builtin/devices/DevicesPage');
@@ -19,6 +20,7 @@ const importNeighbours = () => import('./pages/operators/neighbours/NeighboursPa
 
 const pageImporters = [
     importInspect,
+    importInspect3d,
     importFunctions,
     importPipelines,
     importDevices,
@@ -32,6 +34,7 @@ const pageImporters = [
 ];
 
 const InspectPage = lazy(importInspect);
+const Inspect3dPage = lazy(importInspect3d);
 const FunctionsPage = lazy(importFunctions);
 const PipelinesPage = lazy(importPipelines);
 const DevicesPage = lazy(importDevices);
@@ -139,6 +142,7 @@ const AppContent = (): React.JSX.Element => {
                         <Routes>
                             <Route path="/" element={<Navigate to="/builtin/inspect" replace />} />
                             <Route path="/builtin/inspect" element={<InspectPage />} />
+                            <Route path="/builtin/inspect-3d" element={<Inspect3dPage />} />
                             <Route path="/builtin/functions" element={<FunctionsPage />} />
                             <Route path="/builtin/functions-ng" element={<Navigate to="/builtin/functions" replace />} />
                             <Route path="/builtin/pipelines" element={<PipelinesPage />} />
@@ -151,6 +155,7 @@ const AppContent = (): React.JSX.Element => {
                             <Route path="/operators/route" element={<OperatorsRoutePage />} />
                             <Route path="/operators/neighbours" element={<NeighboursPage />} />
                             <Route path="/inspect" element={<Navigate to="/builtin/inspect" replace />} />
+                            <Route path="/inspect-3d" element={<Navigate to="/builtin/inspect-3d" replace />} />
                             <Route path="/functions" element={<Navigate to="/builtin/functions" replace />} />
                             <Route path="/pipelines" element={<Navigate to="/builtin/pipelines" replace />} />
                             <Route path="/devices" element={<Navigate to="/builtin/devices" replace />} />

--- a/web/src/MainMenu.tsx
+++ b/web/src/MainMenu.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { AsideHeader } from '@gravity-ui/navigation';
 import type { MenuItem as AsideHeaderMenuItem } from '@gravity-ui/navigation';
-import { Link, Eye, Route, CurlyBracketsFunction, ListUl, HardDrive, LayoutCellsLarge, CirclePlay, Shield, ArrowRight } from '@gravity-ui/icons';
+import { Link, Eye, Route, CurlyBracketsFunction, ListUl, HardDrive, LayoutCellsLarge, CirclePlay, Shield, ArrowRight, Cube } from '@gravity-ui/icons';
 import Logo from './icons/Logo';
 import type { PageId } from './types';
 import './MainMenu.scss';
@@ -59,6 +59,7 @@ const MainMenu = ({ currentPage, onPageChange, renderContent, disabled = false }
     const menuItems: NavMenuItem[] = [
         createSectionHeader('__section_builtin', 'Builtin'),
         createMenuItem('builtin/inspect', 'Inspect', Eye),
+        createMenuItem('builtin/inspect-3d', 'Inspect (3D)', Cube),
         createMenuItem('builtin/functions', 'Functions', CurlyBracketsFunction),
         createMenuItem('builtin/pipelines', 'Pipelines', ListUl),
         createMenuItem('builtin/devices', 'Devices', HardDrive),

--- a/web/src/pages/builtin/inspect-3d/Inspect3dPage.tsx
+++ b/web/src/pages/builtin/inspect-3d/Inspect3dPage.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { toaster } from '../../../utils';
+import { API } from '../../../api';
+import type { InstanceInfo } from '../../../api/inspect';
+import { PageLayout, PageLoader, EmptyState } from '../../../components';
+import { Inspect3dPageHeader } from './Inspect3dPageHeader';
+import { Inspect3dPageFooter } from './Inspect3dPageFooter';
+import { InstanceCard } from './InstanceCard';
+import './inspect-3d.scss';
+
+/** Inspect (3D) page rendering YANET topology as an isometric three.js scene. */
+const Inspect3dPage = (): React.JSX.Element => {
+    const [instanceInfo, setInstanceInfo] = useState<InstanceInfo | null>(null);
+    const [initialLoading, setInitialLoading] = useState<boolean>(true);
+    const [refreshing, setRefreshing] = useState<boolean>(false);
+    const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
+
+    const loadInspect = useCallback(async (): Promise<void> => {
+        try {
+            setRefreshing(true);
+            const data = await API.inspect.inspect();
+            setInstanceInfo(data.instance_info ?? null);
+            setLastUpdate(new Date());
+        } catch (err) {
+            toaster.error('inspect-3d-error', 'Failed to fetch inspect data', err);
+        } finally {
+            setRefreshing(false);
+            setInitialLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadInspect();
+    }, [loadInspect]);
+
+    const header = (
+        <Inspect3dPageHeader onRefresh={loadInspect} refreshing={refreshing} />
+    );
+
+    return (
+        <PageLayout header={header}>
+            <div className="inspect-3d-page">
+                {initialLoading ? (
+                    <PageLoader loading size="l" />
+                ) : !instanceInfo ? (
+                    <EmptyState message="No instance data found" />
+                ) : (
+                    <InstanceCard instance={instanceInfo} />
+                )}
+                <Inspect3dPageFooter lastUpdate={lastUpdate} />
+            </div>
+        </PageLayout>
+    );
+};
+
+export default Inspect3dPage;

--- a/web/src/pages/builtin/inspect-3d/Inspect3dPageFooter.tsx
+++ b/web/src/pages/builtin/inspect-3d/Inspect3dPageFooter.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export interface Inspect3dPageFooterProps {
+    lastUpdate: Date | null;
+}
+
+const formatTime = (d: Date): string => {
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    const ss = String(d.getSeconds()).padStart(2, '0');
+    return `${hh}:${mm}:${ss}`;
+};
+
+/** Footer showing last update time and connectivity status. */
+export const Inspect3dPageFooter: React.FC<Inspect3dPageFooterProps> = ({ lastUpdate }) => {
+    const ts = lastUpdate ? formatTime(lastUpdate) : '—';
+    return (
+        <div className="inspect-3d-page-footer">
+            last update {ts} · controlplane reachable
+        </div>
+    );
+};

--- a/web/src/pages/builtin/inspect-3d/Inspect3dPageHeader.tsx
+++ b/web/src/pages/builtin/inspect-3d/Inspect3dPageHeader.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Button } from '@gravity-ui/uikit';
+import { ArrowsRotateRight } from '@gravity-ui/icons';
+import { PageHeader } from '../../../components';
+
+export interface Inspect3dPageHeaderProps {
+    onRefresh: () => void;
+    refreshing?: boolean;
+}
+
+/** Page header for the Inspect (3D) page with a refresh button. */
+export const Inspect3dPageHeader: React.FC<Inspect3dPageHeaderProps> = ({
+    onRefresh,
+    refreshing = false,
+}) => (
+    <PageHeader
+        title="Inspect (3D)"
+        actions={
+            <Button view="outlined" size="m" onClick={onRefresh} loading={refreshing}>
+                <Button.Icon>
+                    <ArrowsRotateRight />
+                </Button.Icon>
+                Refresh
+            </Button>
+        }
+    />
+);

--- a/web/src/pages/builtin/inspect-3d/Inspector.tsx
+++ b/web/src/pages/builtin/inspect-3d/Inspector.tsx
@@ -1,0 +1,295 @@
+import React from 'react';
+import { Sparkline } from '../inspect/Sparkline';
+import { IconPort, IconTag, IconFn } from '../inspect/icons';
+import { fmtPps, fmtBps } from '../inspect/formatters';
+
+export interface DeviceData {
+    id: string;
+    name: string;
+    kind: 'plain' | 'vlan';
+    rxPps: number;
+    rxBps: number;
+    txPps: number;
+    txBps: number;
+    status: 'ok' | 'idle';
+    pipeIn?: string;
+    pipeOut?: string;
+    trendRx: number[];
+    trendTx: number[];
+    vlan?: number;
+    parent?: string;
+    mtu?: number;
+    speed?: string;
+}
+
+export interface PipelineData {
+    id: string;
+    name: string;
+    fns: string[];
+    pps: number;
+    trend: number[];
+    status: 'ok' | 'idle';
+}
+
+export interface FunctionData {
+    id: string;
+    mod: string;
+    pps: number;
+    trend: number[];
+    status: 'ok' | 'idle';
+}
+
+export interface SelectedItem {
+    kind: 'device' | 'pipeline' | 'fn';
+    id: string;
+}
+
+export interface InspectorProps {
+    selected: SelectedItem;
+    onClose: () => void;
+    devices: DeviceData[];
+    pipelines: PipelineData[];
+    functions: FunctionData[];
+}
+
+/** A small coloured status dot. */
+const Dot: React.FC<{ status: 'ok' | 'idle'; size?: number }> = ({ status, size = 6 }) => (
+    <span
+        className="iv3-dot"
+        style={{
+            width: size,
+            height: size,
+            background: status === 'ok' ? 'var(--iv3-ok)' : 'var(--iv3-idle)',
+        }}
+    />
+);
+
+/** A labelled stat row with optional hint text. */
+const StatRow: React.FC<{ label: string; value: React.ReactNode; hint?: string }> = ({
+    label,
+    value,
+    hint,
+}) => (
+    <div className="iv3-stat-row">
+        <span className="iv3-stat-row__label">{label}</span>
+        <span className="iv3-stat-row__value">
+            {value}
+            {hint && <span className="iv3-stat-row__hint">{hint}</span>}
+        </span>
+    </div>
+);
+
+/** A section sub-header with an optional item count. */
+const SectionHeader: React.FC<{ children: React.ReactNode; count?: number }> = ({
+    children,
+    count,
+}) => (
+    <div className="iv3-section-header">
+        {children}
+        {count !== undefined && <span className="iv3-section-header__count">{count}</span>}
+    </div>
+);
+
+/** Inspector content for a device. */
+const InspectDevice: React.FC<{
+    d: DeviceData;
+    pipelines: PipelineData[];
+}> = ({ d, pipelines }) => {
+    const pIn = pipelines.find((p) => p.id === d.pipeIn);
+    const pOut = pipelines.find((p) => p.id === d.pipeOut);
+    const isVlan = d.kind === 'vlan';
+    return (
+        <div>
+            <div className="iv3-insp-name">
+                <span style={{ color: isVlan ? 'var(--iv3-link)' : 'var(--iv3-accent)' }}>
+                    {isVlan ? <IconTag size={14} /> : <IconPort size={14} />}
+                </span>
+                <span className="iv3-insp-name__text">{d.name}</span>
+                <Dot status={d.status} size={6} />
+            </div>
+            <div className="iv3-insp-sub">
+                {isVlan
+                    ? `vlan ${d.vlan ?? '?'} on ${d.parent ?? '?'}`
+                    : `physical · mtu ${d.mtu ?? '?'} · ${d.speed ?? '?'}`}
+            </div>
+            <SectionHeader>RX</SectionHeader>
+            <StatRow label="pps" value={fmtPps(d.rxPps)} />
+            <StatRow label="bps" value={fmtBps(d.rxBps)} />
+            <div className="iv3-sparkline-wrap">
+                <Sparkline
+                    data={d.trendRx}
+                    w={266}
+                    h={32}
+                    color={isVlan ? 'var(--iv3-link)' : 'var(--iv3-accent)'}
+                    fill
+                />
+            </div>
+            <SectionHeader>TX</SectionHeader>
+            <StatRow label="pps" value={fmtPps(d.txPps)} />
+            <StatRow label="bps" value={fmtBps(d.txBps)} />
+            <div className="iv3-sparkline-wrap">
+                <Sparkline
+                    data={d.trendTx}
+                    w={266}
+                    h={32}
+                    color={isVlan ? 'var(--iv3-link)' : 'var(--iv3-accent)'}
+                    fill
+                />
+            </div>
+            <SectionHeader>PIPELINES</SectionHeader>
+            <StatRow label="in" value={pIn ? pIn.name : '—'} />
+            <StatRow label="out" value={pOut ? pOut.name : '—'} />
+            <SectionHeader>STATE</SectionHeader>
+            <StatRow label="status" value={d.status} />
+            <StatRow label="kind" value={d.kind} />
+        </div>
+    );
+};
+
+/** Inspector content for a pipeline. */
+const InspectPipeline: React.FC<{
+    p: PipelineData;
+    devices: DeviceData[];
+    functions: FunctionData[];
+}> = ({ p, devices, functions }) => {
+    const feedDevs = devices.filter((d) => d.pipeIn === p.id);
+    const fnObjs = p.fns
+        .map((fname) => functions.find((f) => f.id === fname))
+        .filter((f): f is FunctionData => f !== undefined);
+    return (
+        <div>
+            <div className="iv3-insp-name">
+                <Dot status={p.status} size={6} />
+                <span className="iv3-insp-name__text">{p.name}</span>
+            </div>
+            <div className="iv3-insp-sub">{p.fns.length} functions in chain</div>
+            <StatRow label="pps" value={fmtPps(p.pps)} />
+            <StatRow label="status" value={p.status} />
+            <div className="iv3-sparkline-wrap">
+                <Sparkline data={p.trend} w={266} h={32} color="var(--iv3-accent)" fill />
+            </div>
+            <SectionHeader count={p.fns.length}>FUNCTION CHAIN</SectionHeader>
+            <div>
+                {fnObjs.map((f, idx) => (
+                    <div key={f.id} className="iv3-chain-item">
+                        <span className="iv3-chain-item__idx">{idx + 1}.</span>
+                        <span style={{ color: 'var(--iv3-accent)' }}>
+                            <IconFn size={10} />
+                        </span>
+                        <span className="iv3-chain-item__name">
+                            {f.id.replace(/^fn:/, '')}
+                        </span>
+                        <span className="iv3-chain-item__pps">{fmtPps(f.pps)}</span>
+                    </div>
+                ))}
+            </div>
+            <SectionHeader count={feedDevs.length}>FEEDING DEVICES</SectionHeader>
+            <div>
+                {feedDevs.slice(0, 8).map((d) => (
+                    <div key={d.id} className="iv3-feed-item">
+                        <Dot status={d.status} size={4} />
+                        <span style={{ color: d.kind === 'vlan' ? 'var(--iv3-link)' : 'var(--iv3-accent)' }}>
+                            {d.kind === 'vlan' ? <IconTag size={10} /> : <IconPort size={10} />}
+                        </span>
+                        <span className="iv3-feed-item__name">{d.name}</span>
+                        <span className="iv3-feed-item__pps">{fmtPps(d.rxPps)}</span>
+                    </div>
+                ))}
+                {feedDevs.length > 8 && (
+                    <span style={{ color: 'var(--iv3-mute)', fontSize: 10 }}>
+                        +{feedDevs.length - 8} more
+                    </span>
+                )}
+                {feedDevs.length === 0 && (
+                    <span style={{ color: 'var(--iv3-mute)', fontSize: 10 }}>none</span>
+                )}
+            </div>
+        </div>
+    );
+};
+
+/** Inspector content for a function. */
+const InspectFn: React.FC<{
+    f: FunctionData;
+    pipelines: PipelineData[];
+}> = ({ f, pipelines }) => {
+    const usedBy = pipelines.filter((p) => p.fns.includes(f.id));
+    return (
+        <div>
+            <div className="iv3-insp-name">
+                <span style={{ color: f.pps > 0 ? 'var(--iv3-accent)' : 'var(--iv3-mute)' }}>
+                    <IconFn size={14} />
+                </span>
+                <span className="iv3-insp-name__text">{f.id}</span>
+                <Dot status={f.status} size={6} />
+            </div>
+            <div className="iv3-insp-sub">
+                module: <span style={{ color: 'var(--iv3-text-dim)' }}>{f.mod || '—'}</span>
+            </div>
+            <StatRow label="pps" value={fmtPps(f.pps)} />
+            <StatRow label="status" value={f.status} />
+            {f.mod && <StatRow label="module" value={f.mod} />}
+            <div className="iv3-sparkline-wrap">
+                <Sparkline data={f.trend} w={266} h={32} color="var(--iv3-accent)" fill />
+            </div>
+            <SectionHeader count={usedBy.length}>USED BY PIPELINES</SectionHeader>
+            <div>
+                {usedBy.map((p) => (
+                    <div key={p.id} className="iv3-feed-item">
+                        <Dot status={p.status} size={4} />
+                        <span className="iv3-feed-item__name">{p.name}</span>
+                        <span className="iv3-feed-item__pps">{fmtPps(p.pps)}</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+/** Right-side overlay inspector panel shown when a scene object is selected. */
+export const Inspector: React.FC<InspectorProps> = ({
+    selected,
+    onClose,
+    devices,
+    pipelines,
+    functions,
+}) => {
+    let content: React.ReactNode = null;
+    let title = '';
+
+    if (selected.kind === 'device') {
+        const d = devices.find((x) => x.id === selected.id);
+        if (!d) return null;
+        content = <InspectDevice d={d} pipelines={pipelines} />;
+        title = 'DEVICE';
+    } else if (selected.kind === 'pipeline') {
+        const p = pipelines.find((x) => x.id === selected.id);
+        if (!p) return null;
+        content = <InspectPipeline p={p} devices={devices} functions={functions} />;
+        title = 'PIPELINE';
+    } else if (selected.kind === 'fn') {
+        const f = functions.find((x) => x.id === selected.id);
+        if (!f) return null;
+        content = <InspectFn f={f} pipelines={pipelines} />;
+        title = 'FUNCTION';
+    }
+
+    if (!content) return null;
+
+    return (
+        <div
+            className="iv3-inspector"
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+        >
+            <div className="iv3-inspector__head">
+                <span>{title}</span>
+                <button className="iv3-inspector__close" onClick={onClose}>
+                    ×
+                </button>
+            </div>
+            <div className="iv3-inspector__body iv3-scroll">{content}</div>
+        </div>
+    );
+};

--- a/web/src/pages/builtin/inspect-3d/InstanceCard.tsx
+++ b/web/src/pages/builtin/inspect-3d/InstanceCard.tsx
@@ -1,0 +1,51 @@
+import React, { useMemo } from 'react';
+import type { InstanceInfo } from '../../../api/inspect';
+import { useDeviceCounters } from '../../../hooks';
+import { HudHero } from '../inspect/HudHero';
+import { ModuleStrip } from '../inspect/ModuleStrip';
+import { IsoScene3D } from './IsoScene3D';
+
+export interface InstanceCardProps {
+    instance: InstanceInfo;
+}
+
+/** Root layout for a single YANET instance: hero strip, 3D scene, and module strip. */
+export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
+    const devices = instance.devices ?? [];
+
+    const deviceNames = useMemo(
+        () => devices.map((d, idx) => d.name ?? `device-${idx}`),
+        [devices],
+    );
+
+    const { counters: rateCounters, absoluteCounters } = useDeviceCounters(
+        deviceNames,
+        devices.length > 0,
+    );
+
+    const physicalDeviceNames = useMemo(() => {
+        const result = new Set<string>();
+        devices.forEach((d, idx) => {
+            if (d.type === 'plain') {
+                result.add(d.name ?? `device-${idx}`);
+            }
+        });
+        return result;
+    }, [devices]);
+
+    return (
+        <div className="iv3-instance">
+            <HudHero
+                instance={instance}
+                rateCounters={rateCounters}
+                physicalDeviceNames={physicalDeviceNames}
+            />
+            <IsoScene3D
+                instance={instance}
+                rateCounters={rateCounters}
+                absoluteCounters={absoluteCounters}
+            />
+            <ModuleStrip instance={instance} />
+        </div>
+    );
+};

--- a/web/src/pages/builtin/inspect-3d/IsoScene3D.tsx
+++ b/web/src/pages/builtin/inspect-3d/IsoScene3D.tsx
@@ -1,0 +1,820 @@
+import React, { useEffect, useRef, useState, useMemo } from 'react';
+import * as THREE from 'three';
+import type { InstanceInfo } from '../../../api/inspect';
+import type { DeviceCounterData, DeviceAbsoluteData } from '../../../hooks';
+import { usePipelineCounters, useFunctionCounters, useDeviceTrendSeries } from '../inspect/hooks';
+import { fmtPps } from '../inspect/formatters';
+import { Inspector } from './Inspector';
+import type { DeviceData, PipelineData, FunctionData, SelectedItem } from './Inspector';
+
+export interface IsoScene3DProps {
+    instance: InstanceInfo;
+    rateCounters: Map<string, DeviceCounterData>;
+    absoluteCounters: Map<string, DeviceAbsoluteData>;
+}
+
+interface LabelInfo {
+    kind: 'device' | 'pipeline' | 'fn';
+    id: string;
+    anchor: 'right' | 'pipeline' | 'top';
+    worldPos: () => THREE.Vector3;
+    text: string;
+    subtext: string;
+    active?: boolean;
+    sx: number;
+    sy: number;
+}
+
+interface FwdPath {
+    pts: THREE.Vector3[];
+    lens: number[];
+    total: number;
+    density: number;
+}
+
+interface Particle {
+    pi: number;
+    t: number;
+    speed: number;
+    posIdx: number;
+}
+
+interface ParticleSystem {
+    points: THREE.Points | null;
+    ps: Particle[];
+    geo: THREE.BufferGeometry | null;
+}
+
+interface FnMeshEntry {
+    mesh: THREE.Mesh;
+    fnId: string;
+    baseH: number;
+    x: number;
+    z: number;
+    w: number;
+    d: number;
+}
+
+interface WireEntry {
+    line: THREE.Line;
+    deviceId: string;
+    pipeId: string;
+}
+
+interface ThreeRefs {
+    scene: THREE.Scene | null;
+    camera: THREE.OrthographicCamera | null;
+    renderer: THREE.WebGLRenderer | null;
+    pickGroup: THREE.Group | null;
+    deviceMeshes: Record<string, THREE.Mesh>;
+    pipeMeshes: Record<string, THREE.Mesh>;
+    fnMeshes: FnMeshEntry[];
+    fwdPS: ParticleSystem;
+    fwdPaths: FwdPath[];
+    labelSources: Omit<LabelInfo, 'sx' | 'sy'>[];
+    wires: WireEntry[];
+    sceneCenter: THREE.Vector3 | null;
+}
+
+/** Build a box mesh anchored at its bottom face. */
+const makeBox = (
+    w: number,
+    h: number,
+    d: number,
+    fillHex: number,
+    opacity: number = 1,
+    emissive: number = 0x000000,
+): THREE.Mesh => {
+    const geo = new THREE.BoxGeometry(w, h, d);
+    geo.translate(0, h / 2, 0);
+    const mat = new THREE.MeshLambertMaterial({
+        color: fillHex,
+        transparent: opacity < 1,
+        opacity,
+        emissive,
+        emissiveIntensity: emissive ? 0.4 : 0,
+    });
+    const mesh = new THREE.Mesh(geo, mat);
+    const edges = new THREE.LineSegments(
+        new THREE.EdgesGeometry(geo),
+        new THREE.LineBasicMaterial({ color: 0x3a3731, transparent: true, opacity: 0.85 }),
+    );
+    mesh.add(edges);
+    mesh.userData.edges = edges;
+    return mesh;
+};
+
+/** Build a particle system from an array of paths. */
+const buildParticles = (
+    paths: FwdPath[],
+    color: number,
+    sizeBase: number,
+): ParticleSystem => {
+    const N = paths.reduce((sum, p) => sum + Math.max(1, Math.round(p.density * 18)), 0);
+    if (!N) return { points: null, ps: [], geo: null };
+
+    const positions = new Float32Array(N * 3);
+    const ps: Particle[] = [];
+    let idx = 0;
+    paths.forEach((path, pi) => {
+        const count = Math.max(1, Math.round(path.density * 18));
+        for (let i = 0; i < count; i++) {
+            ps.push({
+                pi,
+                t: Math.random(),
+                speed: (0.0008 + path.density * 0.0014) * (0.7 + Math.random() * 0.6),
+                posIdx: idx,
+            });
+            positions[idx * 3 + 0] = 0;
+            positions[idx * 3 + 1] = 0;
+            positions[idx * 3 + 2] = 0;
+            idx++;
+        }
+    });
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    const mat = new THREE.PointsMaterial({
+        color,
+        size: sizeBase,
+        transparent: true,
+        opacity: 0.7,
+        sizeAttenuation: false,
+        depthWrite: false,
+    });
+    const points = new THREE.Points(geo, mat);
+    return { points, ps, geo };
+};
+
+/** Isometric 3D topology scene: devices, pipelines, functions, and forward particles. */
+export const IsoScene3D: React.FC<IsoScene3DProps> = ({
+    instance,
+    rateCounters,
+    absoluteCounters: _absoluteCounters,
+}) => {
+    const devices = instance.devices ?? [];
+    const pipelines = instance.pipelines ?? [];
+    const functions = instance.functions ?? [];
+
+    const deviceNames = useMemo(
+        () => devices.map((d, idx) => d.name ?? `device-${idx}`),
+        [devices],
+    );
+
+    const pipelineNames = useMemo(
+        () => pipelines.map((p) => p.name ?? ''),
+        [pipelines],
+    );
+
+    const functionNames = useMemo(
+        () => functions.map((f) => f.name ?? ''),
+        [functions],
+    );
+
+    const { rates: pipeRates, series: pipeSeries } = usePipelineCounters(
+        deviceNames,
+        pipelineNames,
+        deviceNames.length > 0 && pipelineNames.length > 0,
+    );
+
+    const { rates: fnRates, series: fnSeries } = useFunctionCounters(
+        deviceNames,
+        pipelineNames,
+        functionNames,
+        deviceNames.length > 0 && pipelineNames.length > 0 && functionNames.length > 0,
+    );
+
+    const trendRxMap = useDeviceTrendSeries(rateCounters, 'rx');
+    const trendTxMap = useDeviceTrendSeries(rateCounters, 'tx');
+
+    const DEVICES = useMemo((): DeviceData[] =>
+        devices.map((dev, devIdx) => {
+            const name = dev.name ?? `device-${devIdx}`;
+            const counters = rateCounters.get(name);
+            const rxPps = counters?.rx?.pps ?? 0;
+            const rxBps = counters?.rx?.bps ?? 0;
+            const txPps = counters?.tx?.pps ?? 0;
+            const txBps = counters?.tx?.bps ?? 0;
+            return {
+                id: name,
+                name,
+                kind: dev.type === 'vlan' ? 'vlan' : 'plain',
+                rxPps,
+                rxBps,
+                txPps,
+                txBps,
+                status: rxPps > 0 || txPps > 0 ? 'ok' : 'idle',
+                pipeIn: dev.input_pipelines?.[0]?.name,
+                pipeOut: dev.output_pipelines?.[0]?.name,
+                trendRx: trendRxMap.get(name) ?? [],
+                trendTx: trendTxMap.get(name) ?? [],
+            };
+        }),
+    [devices, rateCounters, trendRxMap, trendTxMap]);
+
+    const PIPELINES = useMemo((): PipelineData[] =>
+        pipelines.map((p) => {
+            const name = p.name ?? '';
+            const rate = pipeRates.get(name);
+            const pps = rate?.pps ?? 0;
+            return {
+                id: name,
+                name,
+                fns: p.functions ?? [],
+                pps,
+                trend: pipeSeries.get(name) ?? [],
+                status: pps > 0 ? 'ok' : 'idle',
+            };
+        }),
+    [pipelines, pipeRates, pipeSeries]);
+
+    const FUNCTIONS = useMemo((): FunctionData[] =>
+        functions.map((f) => {
+            const name = f.name ?? '';
+            const rate = fnRates.get(name);
+            const pps = rate?.pps ?? 0;
+            const mod = f.chains?.[0]?.modules?.[0]?.type ?? '';
+            return {
+                id: name,
+                mod,
+                pps,
+                trend: fnSeries.get(name) ?? [],
+                status: pps > 0 ? 'ok' : 'idle',
+            };
+        }),
+    [functions, fnRates, fnSeries]);
+
+    const containerRef = useRef<HTMLDivElement>(null);
+    const canvasMountRef = useRef<HTMLDivElement>(null);
+    const [selected, setSelected] = useState<SelectedItem | null>(null);
+    const [labels, setLabels] = useState<LabelInfo[]>([]);
+    const [canvasSize, setCanvasSize] = useState({ w: 900, h: 620 });
+    const threeRef = useRef<ThreeRefs>({
+        scene: null,
+        camera: null,
+        renderer: null,
+        pickGroup: null,
+        deviceMeshes: {},
+        pipeMeshes: {},
+        fnMeshes: [],
+        fwdPS: { points: null, ps: [], geo: null },
+        fwdPaths: [],
+        labelSources: [],
+        wires: [],
+        sceneCenter: null,
+    });
+
+    useEffect(() => {
+        if (!containerRef.current) return;
+        const obs = new ResizeObserver((entries) => {
+            const entry = entries[0];
+            if (!entry) return;
+            const { width } = entry.contentRect;
+            setCanvasSize({ w: Math.max(300, Math.floor(width)), h: 620 });
+        });
+        obs.observe(containerRef.current);
+        const { width } = containerRef.current.getBoundingClientRect();
+        if (width > 0) {
+            setCanvasSize({ w: Math.floor(width), h: 620 });
+        }
+        return () => obs.disconnect();
+    }, []);
+
+    useEffect(() => {
+        const r = threeRef.current;
+        if (!r.renderer || !r.camera) return;
+        const { w, h } = canvasSize;
+        r.renderer.setSize(w, h);
+        const aspect = w / h;
+        const camSize = 360;
+        const cam = r.camera;
+        cam.left = -camSize * aspect / 2;
+        cam.right = camSize * aspect / 2;
+        cam.top = camSize / 2;
+        cam.bottom = -camSize / 2;
+        cam.updateProjectionMatrix();
+    }, [canvasSize]);
+
+    useEffect(() => {
+        if (!canvasMountRef.current) return;
+        const mount = canvasMountRef.current;
+        while (mount.firstChild) mount.removeChild(mount.firstChild);
+
+        const { w: VW, h: VH } = canvasSize;
+        const scene = new THREE.Scene();
+        scene.background = null;
+
+        const aspect = VW / VH;
+        const camSize = 360;
+        const camera = new THREE.OrthographicCamera(
+            -camSize * aspect / 2,
+            camSize * aspect / 2,
+            camSize / 2,
+            -camSize / 2,
+            -4000,
+            4000,
+        );
+
+        const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+        renderer.setPixelRatio(window.devicePixelRatio || 1);
+        renderer.setSize(VW, VH);
+        renderer.setClearColor(0x000000, 0);
+        mount.appendChild(renderer.domElement);
+        renderer.domElement.style.display = 'block';
+
+        scene.add(new THREE.AmbientLight(0xfff3e0, 0.55));
+        const dir = new THREE.DirectionalLight(0xffe6cc, 0.5);
+        dir.position.set(200, 600, 300);
+        scene.add(dir);
+        scene.add(new THREE.HemisphereLight(0xc9a070, 0x0d0d0c, 0.35));
+
+        const numPipes = PIPELINES.length;
+        const LANE_LEN = 480;
+        const LANE_SPACING = Math.max(28, Math.min(46, 230 / Math.max(1, numPipes - 1)));
+        const LANE_HALF_W = Math.min(11, LANE_SPACING * 0.32);
+        const LANE_THICK = 4;
+        const X0 = 0;
+        const Z0 = 0;
+
+        const plainDevs = DEVICES.filter((d) => d.kind === 'plain');
+        const vlanDevs = DEVICES.filter((d) => d.kind === 'vlan');
+        const devW = 26;
+        const devD = 14;
+        const devH = 7;
+        const colSpan = (numPipes - 1) * LANE_SPACING + LANE_HALF_W * 2;
+        const devGap = Math.max(1, Math.min(4, (colSpan - plainDevs.length * devD) / Math.max(1, plainDevs.length - 1)));
+        const vlanGap = Math.max(1, Math.min(4, (colSpan - vlanDevs.length * devD) / Math.max(1, vlanDevs.length - 1)));
+
+        const devicePositions: Record<string, { x: number; z: number; kind: 'plain' | 'vlan' }> = {};
+        plainDevs.forEach((d, i) => {
+            devicePositions[d.id] = { x: -140, z: Z0 + i * (devD + devGap), kind: 'plain' };
+        });
+        vlanDevs.forEach((d, i) => {
+            devicePositions[d.id] = { x: -90, z: Z0 + i * (devD + vlanGap), kind: 'vlan' };
+        });
+
+        const pipeZ = PIPELINES.map((_, i) => Z0 + i * LANE_SPACING);
+
+        const pickGroup = new THREE.Group();
+        scene.add(pickGroup);
+
+        const deviceMeshes: Record<string, THREE.Mesh> = {};
+        DEVICES.forEach((d) => {
+            const pos = devicePositions[d.id];
+            if (!pos) return;
+            const active = d.status === 'ok' && d.rxPps > 0;
+            const isVlan = d.kind === 'vlan';
+            const color = active ? (isVlan ? 0x4a607a : 0x70533a) : 0x1d1b18;
+            const edgeColor = active ? (isVlan ? 0x88a8c4 : 0xFFC061) : 0x3a3731;
+            const mesh = makeBox(devW, devH, devD, color, 0.95);
+            ((mesh.userData.edges as THREE.LineSegments).material as THREE.LineBasicMaterial).color.setHex(edgeColor);
+            mesh.position.set(pos.x + devW / 2, 0, pos.z + devD / 2);
+            mesh.userData = { ...mesh.userData, kind: 'device', id: d.id, baseColor: color, edgeColor };
+            pickGroup.add(mesh);
+            deviceMeshes[d.id] = mesh;
+        });
+
+        const pipeMeshes: Record<string, THREE.Mesh> = {};
+        PIPELINES.forEach((p, pi) => {
+            const z = pipeZ[pi];
+            const active = p.status === 'ok' && p.pps > 0;
+            const intensity = Math.min(1, p.pps / 30e6);
+            const color = active
+                ? new THREE.Color().setHSL(0.07, 0.45, 0.16 + intensity * 0.06).getHex()
+                : 0x1a1816;
+            const edgeColor = active ? 0xFFC061 : 0x3a3731;
+            const mesh = makeBox(LANE_LEN, LANE_THICK, LANE_HALF_W * 2, color, 0.9);
+            const edgesMat = (mesh.userData.edges as THREE.LineSegments).material as THREE.LineBasicMaterial;
+            edgesMat.color.setHex(edgeColor);
+            edgesMat.opacity = active ? 0.7 : 0.5;
+            mesh.position.set(X0 + LANE_LEN / 2, 0, z);
+            mesh.userData = { ...mesh.userData, kind: 'pipeline', id: p.id, baseColor: color, edgeColor };
+            pickGroup.add(mesh);
+            pipeMeshes[p.id] = mesh;
+        });
+
+        const fnMeshes: FnMeshEntry[] = [];
+        PIPELINES.forEach((p, pi) => {
+            if (!p.fns.length) return;
+            const slotLen = (LANE_LEN - 40) / p.fns.length;
+            p.fns.forEach((fname, fi) => {
+                const fn = FUNCTIONS.find((f) => f.id === fname);
+                const xStart = X0 + 22 + slotLen * fi + 3;
+                const w = Math.max(18, slotLen - 9);
+                const baseH = 5;
+                const extra = fn && fn.pps > 0
+                    ? Math.min(28, Math.log10(1 + fn.pps / 1e5) * 8)
+                    : 0;
+                const h = baseH + extra;
+                const active = fn && fn.pps > 0;
+                const color = active ? 0x5a4632 : 0x1a1816;
+                const edgeColor = active ? 0xFFC061 : 0x3a3731;
+                const emissive = active ? 0x4a3a22 : 0x000000;
+                const mesh = makeBox(w, h, 14, color, 0.92, emissive);
+                ((mesh.userData.edges as THREE.LineSegments).material as THREE.LineBasicMaterial).color.setHex(edgeColor);
+                mesh.position.set(xStart + w / 2, LANE_THICK, pipeZ[pi] - 7 + 7);
+                mesh.userData = {
+                    ...mesh.userData,
+                    kind: 'fn',
+                    id: fn ? fn.id : fname,
+                    baseColor: color,
+                    edgeColor,
+                };
+                pickGroup.add(mesh);
+                fnMeshes.push({
+                    mesh,
+                    fnId: fn ? fn.id : fname,
+                    baseH: h,
+                    x: xStart,
+                    z: pipeZ[pi] - 7,
+                    w,
+                    d: 14,
+                });
+            });
+        });
+
+        {
+            const gridSize = 700;
+            const gridDiv = 18;
+            const grid = new THREE.GridHelper(gridSize, gridDiv, 0x2a2823, 0x1f1d1a);
+            (grid.material as THREE.Material).opacity = 0.45;
+            (grid.material as THREE.Material).transparent = true;
+            grid.position.set(120, -0.5, colSpan / 2);
+            scene.add(grid);
+        }
+
+        const wires: WireEntry[] = [];
+        DEVICES.forEach((d) => {
+            if (!d.pipeIn) return;
+            const pi = PIPELINES.findIndex((p) => p.id === d.pipeIn);
+            if (pi < 0) return;
+            const pos = devicePositions[d.id];
+            if (!pos) return;
+            const active = d.status === 'ok' && d.rxPps > 0;
+            const pts = [
+                new THREE.Vector3(pos.x + devW, devH / 2, pos.z + devD / 2),
+                new THREE.Vector3(X0 - 6, devH / 2, pos.z + devD / 2),
+                new THREE.Vector3(X0, LANE_THICK + 1, pipeZ[pi]),
+            ];
+            const geo = new THREE.BufferGeometry().setFromPoints(pts);
+            const mat = new THREE.LineBasicMaterial({
+                color: active ? 0xFFC061 : 0x3a3731,
+                transparent: true,
+                opacity: active ? 0.55 : 0.3,
+            });
+            const line = new THREE.Line(geo, mat);
+            scene.add(line);
+            wires.push({ line, deviceId: d.id, pipeId: d.pipeIn });
+        });
+
+        const fwdPaths: FwdPath[] = [];
+        DEVICES.forEach((d) => {
+            if (!d.pipeIn) return;
+            const pi = PIPELINES.findIndex((p) => p.id === d.pipeIn);
+            if (pi < 0) return;
+            const pos = devicePositions[d.id];
+            if (!pos) return;
+            const pts = [
+                new THREE.Vector3(pos.x + devW, devH / 2, pos.z + devD / 2),
+                new THREE.Vector3(X0 - 6, devH / 2, pos.z + devD / 2),
+                new THREE.Vector3(X0, LANE_THICK + 1, pipeZ[pi]),
+                new THREE.Vector3(X0 + LANE_LEN, LANE_THICK + 1, pipeZ[pi]),
+            ];
+            const lens: number[] = [];
+            let total = 0;
+            for (let i = 1; i < pts.length; i++) {
+                const l = pts[i].distanceTo(pts[i - 1]);
+                lens.push(l);
+                total += l;
+            }
+            fwdPaths.push({ pts, lens, total, density: Math.min(1, d.rxPps / 14e6) });
+        });
+
+        const fwdPS = buildParticles(fwdPaths, 0xFFC061, 2.4);
+        if (fwdPS.points) scene.add(fwdPS.points);
+
+        const sceneCenter = new THREE.Vector3(LANE_LEN / 2 - 40, 20, colSpan / 2);
+        const sph = new THREE.Spherical(500, Math.PI / 3.2, -Math.PI / 4);
+        camera.position.setFromSpherical(sph).add(sceneCenter);
+        camera.lookAt(sceneCenter);
+
+        const labelSources: Omit<LabelInfo, 'sx' | 'sy'>[] = [];
+        Object.entries(deviceMeshes).forEach(([id, m]) => {
+            const d = DEVICES.find((x) => x.id === id);
+            if (!d) return;
+            labelSources.push({
+                kind: 'device',
+                id,
+                anchor: 'right',
+                worldPos: () => new THREE.Vector3(m.position.x - devW / 2 - 2, devH / 2, m.position.z),
+                text: d.name,
+                subtext: fmtPps(d.rxPps) + ' pps',
+                active: d.status === 'ok' && d.rxPps > 0,
+            });
+        });
+        Object.entries(pipeMeshes).forEach(([id, m]) => {
+            const p = PIPELINES.find((x) => x.id === id);
+            if (!p) return;
+            labelSources.push({
+                kind: 'pipeline',
+                id,
+                anchor: 'pipeline',
+                worldPos: () =>
+                    new THREE.Vector3(m.position.x - LANE_LEN / 2 - 4, 0, m.position.z),
+                text: p.name,
+                subtext: fmtPps(p.pps),
+                active: p.status === 'ok' && p.pps > 0,
+            });
+        });
+        fnMeshes.forEach((fb) => {
+            const fn = FUNCTIONS.find((f) => f.id === fb.fnId);
+            labelSources.push({
+                kind: 'fn',
+                id: fb.fnId,
+                anchor: 'top',
+                worldPos: () =>
+                    new THREE.Vector3(
+                        fb.mesh.position.x,
+                        LANE_THICK + fb.mesh.scale.y * fb.baseH + 4,
+                        fb.mesh.position.z,
+                    ),
+                text: fb.fnId.replace(/^fn:/, ''),
+                subtext: fn ? fmtPps(fn.pps) : '—',
+                active: fn ? fn.pps > 0 : false,
+            });
+        });
+
+        threeRef.current = {
+            scene,
+            camera,
+            renderer,
+            pickGroup,
+            deviceMeshes,
+            pipeMeshes,
+            fnMeshes,
+            fwdPS,
+            fwdPaths,
+            labelSources,
+            wires,
+            sceneCenter,
+        };
+
+        const raycaster = new THREE.Raycaster();
+        const mouse = new THREE.Vector2();
+
+        const onPointerUp = (e: PointerEvent): void => {
+            const rect = renderer.domElement.getBoundingClientRect();
+            mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+            mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+            raycaster.setFromCamera(mouse, camera);
+            const hits = raycaster.intersectObjects(pickGroup.children, false);
+            if (hits.length) {
+                const h = hits[0].object;
+                const ud = h.userData as { kind?: string; id?: string };
+                if (ud.kind && ud.id) {
+                    setSelected({ kind: ud.kind as SelectedItem['kind'], id: ud.id });
+                }
+            }
+        };
+        renderer.domElement.addEventListener('pointerup', onPointerUp);
+
+        let raf: number;
+        let lastLabelTick = 0;
+        const tmpV = new THREE.Vector3();
+
+        const animate = (now: number): void => {
+            fnMeshes.forEach((fb) => {
+                const fn = FUNCTIONS.find((f) => f.id === fb.fnId);
+                if (!fn || fn.pps === 0) return;
+                const phase = now * 0.0009 + fb.x * 0.05;
+                const targetScale =
+                    1 + Math.sin(phase) * 0.1 + Math.sin(phase * 2.3 + fb.z) * 0.06;
+                fb.mesh.scale.y += (targetScale - fb.mesh.scale.y) * 0.06;
+            });
+
+            if (fwdPS.points && fwdPS.geo) {
+                const positions = fwdPS.geo.attributes['position'].array as Float32Array;
+                fwdPS.ps.forEach((p) => {
+                    p.t += p.speed * 16;
+                    if (p.t > 1) p.t -= 1;
+                    const path = fwdPaths[p.pi];
+                    if (!path) return;
+                    const target = p.t * path.total;
+                    let acc = 0;
+                    let pt = path.pts[0];
+                    for (let i = 1; i < path.pts.length; i++) {
+                        const l = path.lens[i - 1];
+                        if (acc + l >= target) {
+                            const u = (target - acc) / l;
+                            tmpV.copy(path.pts[i - 1]).lerp(path.pts[i], u);
+                            pt = tmpV;
+                            break;
+                        }
+                        acc += l;
+                    }
+                    positions[p.posIdx * 3 + 0] = pt.x;
+                    positions[p.posIdx * 3 + 1] = pt.y;
+                    positions[p.posIdx * 3 + 2] = pt.z;
+                });
+                fwdPS.geo.attributes['position'].needsUpdate = true;
+            }
+
+            renderer.render(scene, camera);
+
+            if (now - lastLabelTick > 33) {
+                lastLabelTick = now;
+                const out: LabelInfo[] = [];
+                labelSources.forEach((l) => {
+                    const wp = l.worldPos();
+                    wp.project(camera);
+                    if (wp.z < -1 || wp.z > 1) return;
+                    const sx = (wp.x * 0.5 + 0.5) * VW;
+                    const sy = (-wp.y * 0.5 + 0.5) * VH;
+                    if (sx < -50 || sx > VW + 50 || sy < -20 || sy > VH + 20) return;
+                    out.push({ ...l, sx, sy });
+                });
+                setLabels(out);
+            }
+
+            raf = requestAnimationFrame(animate);
+        };
+        raf = requestAnimationFrame(animate);
+
+        return () => {
+            cancelAnimationFrame(raf);
+            renderer.domElement.removeEventListener('pointerup', onPointerUp);
+            renderer.dispose();
+            scene.traverse((obj) => {
+                if (obj instanceof THREE.Mesh) {
+                    obj.geometry.dispose();
+                    if (Array.isArray(obj.material)) {
+                        obj.material.forEach((m) => m.dispose());
+                    } else {
+                        obj.material.dispose();
+                    }
+                }
+            });
+            if (fwdPS.geo) fwdPS.geo.dispose();
+            if (mount.contains(renderer.domElement)) mount.removeChild(renderer.domElement);
+            threeRef.current = {
+                scene: null,
+                camera: null,
+                renderer: null,
+                pickGroup: null,
+                deviceMeshes: {},
+                pipeMeshes: {},
+                fnMeshes: [],
+                fwdPS: { points: null, ps: [], geo: null },
+                fwdPaths: [],
+                labelSources: [],
+                wires: [],
+                sceneCenter: null,
+            };
+        };
+    }, [DEVICES, PIPELINES, FUNCTIONS, canvasSize]);
+
+    useEffect(() => {
+        const r = threeRef.current;
+        if (!r.pickGroup) return;
+
+        const isRelated = (kind: string, id: string): boolean => {
+            if (!selected) return true;
+            if (selected.kind === kind && selected.id === id) return true;
+            if (selected.kind === 'device') {
+                const d = DEVICES.find((x) => x.id === selected.id);
+                if (!d) return false;
+                if (kind === 'pipeline') return d.pipeIn === id || d.pipeOut === id;
+                if (kind === 'fn') {
+                    const pIn = PIPELINES.find((p) => p.id === d.pipeIn);
+                    const pOut = PIPELINES.find((p) => p.id === d.pipeOut);
+                    return (
+                        (pIn !== undefined && pIn.fns.includes(id)) ||
+                        (pOut !== undefined && pOut.fns.includes(id))
+                    );
+                }
+                return false;
+            }
+            if (selected.kind === 'pipeline') {
+                const p = PIPELINES.find((x) => x.id === selected.id);
+                if (!p) return false;
+                if (kind === 'fn') return p.fns.includes(id);
+                if (kind === 'device') {
+                    return DEVICES.some(
+                        (d) => (d.pipeIn === selected.id || d.pipeOut === selected.id) && d.id === id,
+                    );
+                }
+                return false;
+            }
+            if (selected.kind === 'fn') {
+                if (kind === 'pipeline') {
+                    return PIPELINES.find((x) => x.id === id)?.fns.includes(selected.id) ?? false;
+                }
+                return false;
+            }
+            return false;
+        };
+
+        r.pickGroup.children.forEach((m) => {
+            const mesh = m as THREE.Mesh;
+            const ud = mesh.userData as {
+                kind: string;
+                id: string;
+                baseColor: number;
+                edgeColor: number;
+                edges: THREE.LineSegments;
+            };
+            const rel = isRelated(ud.kind, ud.id);
+            const isSel = selected ? ud.kind === selected.kind && ud.id === selected.id : false;
+            const mat = mesh.material as THREE.MeshLambertMaterial;
+            mat.opacity = selected ? (rel ? 0.95 : 0.18) : 0.95;
+            if (ud.edges) {
+                const edgeMat = ud.edges.material as THREE.LineBasicMaterial;
+                edgeMat.opacity = selected
+                    ? rel ? 0.95 : 0.10
+                    : ud.edgeColor === 0x3a3731 ? 0.5 : 0.75;
+                edgeMat.color.setHex(isSel ? 0xe8e4d8 : ud.edgeColor);
+            }
+            if (mat.emissive) {
+                mat.emissive.setHex(
+                    isSel ? 0xFFC061 : ud.kind === 'fn' && ud.baseColor === 0x5a4632 ? 0x4a3a22 : 0x000000,
+                );
+                mat.emissiveIntensity = isSel
+                    ? 0.6
+                    : ud.kind === 'fn' && ud.baseColor === 0x5a4632 ? 0.4 : 0;
+            }
+        });
+
+        r.wires.forEach((w) => {
+            const rel = isRelated('device', w.deviceId) && isRelated('pipeline', w.pipeId);
+            (w.line.material as THREE.LineBasicMaterial).opacity = selected ? (rel ? 0.7 : 0.06) : 0.4;
+        });
+    }, [selected, DEVICES, PIPELINES]);
+
+    return (
+        <div ref={containerRef} className="iv3-scene-container">
+            <div className="iv3-scene-horizon" />
+            <div ref={canvasMountRef} className="iv3-scene-canvas" />
+            <div className="iv3-label-overlay">
+                {labels.map((l, i) => (
+                    <SceneLabel key={`${l.kind}-${l.id}-${i}`} l={l} />
+                ))}
+            </div>
+            {selected && (
+                <Inspector
+                    selected={selected}
+                    onClose={() => setSelected(null)}
+                    devices={DEVICES}
+                    pipelines={PIPELINES}
+                    functions={FUNCTIONS}
+                />
+            )}
+        </div>
+    );
+};
+
+/** A projected HTML label for a scene object. */
+const SceneLabel: React.FC<{ l: LabelInfo }> = ({ l }) => {
+    if (l.kind === 'pipeline') {
+        return (
+            <div
+                className={`iv3-label--pipeline${l.active ? ' iv3-label--pipeline-active' : ''}`}
+                style={{ left: l.sx - 60, top: l.sy - 9 }}
+            >
+                <span
+                    className="iv3-dot"
+                    style={{
+                        width: 5,
+                        height: 5,
+                        background: l.active ? 'var(--iv3-ok)' : 'var(--iv3-idle)',
+                    }}
+                />
+                <span>{l.text}</span>
+            </div>
+        );
+    }
+    if (l.kind === 'device') {
+        return (
+            <div
+                className="iv3-label--device"
+                style={{ left: l.sx - 90, top: l.sy - 10 }}
+            >
+                <div>{l.text}</div>
+                <div className="iv3-label--device-sub">{l.subtext}</div>
+            </div>
+        );
+    }
+    if (l.kind === 'fn') {
+        return (
+            <div
+                className="iv3-label--fn"
+                style={{ left: l.sx - 60, top: l.sy - 22 }}
+            >
+                <div className={l.active ? 'iv3-label--fn-active' : 'iv3-label--fn-idle'}>
+                    {l.text}
+                </div>
+                <div className="iv3-label--fn-sub">{l.subtext}</div>
+            </div>
+        );
+    }
+    return null;
+};

--- a/web/src/pages/builtin/inspect-3d/index.ts
+++ b/web/src/pages/builtin/inspect-3d/index.ts
@@ -1,0 +1,7 @@
+export { Inspect3dPageHeader } from './Inspect3dPageHeader';
+export { Inspect3dPageFooter } from './Inspect3dPageFooter';
+export { InstanceCard } from './InstanceCard';
+export { IsoScene3D } from './IsoScene3D';
+export { Inspector } from './Inspector';
+export type { DeviceData, PipelineData, FunctionData, SelectedItem } from './Inspector';
+export { default } from './Inspect3dPage';

--- a/web/src/pages/builtin/inspect-3d/inspect-3d.scss
+++ b/web/src/pages/builtin/inspect-3d/inspect-3d.scss
@@ -1,0 +1,351 @@
+// ── inspect-3d.scss ── isometric 3D topology page styles ─────────────────────
+
+.inspect-3d-page {
+    // Warm dark-brown palette, mirrored from .inspect-page.
+    --iv3-bg:             #15110D;
+    --iv3-bg-2:           #181410;
+    --iv3-surface:        #1C1814;
+    --iv3-surface-strong: #1C1814;
+    --iv3-bg-3:           #221C16;
+    --iv3-border:         rgba(255, 199, 140, 0.02);
+    --iv3-border-strong:  rgba(255, 200, 140, 0.12);
+    --iv3-text:           #F2EEE8;
+    --iv3-text-dim:       #B8B0A4;
+    --iv3-mute:           #7E7468;
+    --iv3-dim:            #7E7468;
+    --iv3-accent:         #FFC061;
+    --iv3-accent-soft:    rgba(255, 192, 97, 0.14);
+    --iv3-accent-line:    rgba(255, 192, 97, 0.4);
+    --iv3-link:           var(--g-color-text-info);
+    --iv3-ok:             var(--g-color-text-positive);
+    --iv3-idle:           var(--g-color-text-hint);
+    --iv3-danger:         var(--g-color-text-danger);
+    --iv3-mono:           'JetBrains Mono', ui-monospace, monospace;
+    --iv3-font-ui:        'Inter', system-ui, sans-serif;
+
+    font-family: var(--iv3-mono);
+    color: var(--iv3-text);
+    background: var(--iv3-bg);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    overflow-y: auto;
+    flex: 1;
+    min-height: 0;
+
+    .iv3-scroll {
+        scrollbar-width: thin;
+        scrollbar-color: var(--iv3-border-strong) transparent;
+
+        &::-webkit-scrollbar {
+            width: 6px;
+            height: 6px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background: var(--iv3-border-strong);
+        }
+
+        &::-webkit-scrollbar-thumb:hover {
+            background: var(--iv3-accent-line);
+        }
+    }
+
+    .iv3-instance {
+        display: flex;
+        flex-direction: column;
+        gap: 14px;
+        flex: 1;
+        min-height: 0;
+    }
+
+    // ── Scene Container ───────────────────────────────────────────────
+
+    .iv3-scene-container {
+        position: relative;
+        height: 620px;
+        background: linear-gradient(180deg, rgba(20,18,16,0.7) 0%, rgba(13,13,12,0.9) 100%);
+        border: 1px solid var(--iv3-border-strong);
+        overflow: hidden;
+        flex-shrink: 0;
+    }
+
+    .iv3-scene-canvas {
+        position: absolute;
+        inset: 0;
+    }
+
+    .iv3-scene-horizon {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background: linear-gradient(180deg, rgba(255,192,97,0.06) 0%, rgba(255,192,97,0) 55%);
+    }
+
+    .iv3-label-overlay {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        overflow: hidden;
+    }
+
+    .iv3-label--pipeline {
+        position: absolute;
+        padding: 0 6px;
+        height: 18px;
+        background: rgba(13,13,12,0.85);
+        border: 1px solid var(--iv3-border-strong);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 10px;
+        color: var(--iv3-text);
+        font-weight: 500;
+        pointer-events: none;
+    }
+
+    .iv3-label--pipeline-active {
+        border-color: var(--iv3-accent-soft);
+    }
+
+    .iv3-label--device {
+        position: absolute;
+        width: 88px;
+        text-align: right;
+        color: var(--iv3-text);
+        font-size: 9px;
+        line-height: 1.25;
+        pointer-events: none;
+        text-shadow: 0 1px 0 rgba(0,0,0,0.6);
+    }
+
+    .iv3-label--device-sub {
+        color: var(--iv3-mute);
+        font-size: 8px;
+    }
+
+    .iv3-label--fn {
+        position: absolute;
+        width: 120px;
+        text-align: center;
+        color: var(--iv3-text);
+        font-size: 9px;
+        line-height: 1.25;
+        pointer-events: none;
+        text-shadow: 0 1px 0 rgba(0,0,0,0.6);
+    }
+
+    .iv3-label--fn-active {
+        color: var(--iv3-text);
+        font-weight: 500;
+    }
+
+    .iv3-label--fn-idle {
+        color: var(--iv3-mute);
+        font-weight: 500;
+    }
+
+    .iv3-label--fn-sub {
+        color: var(--iv3-text-dim);
+        font-size: 8px;
+    }
+
+    // ── Inspector Panel ───────────────────────────────────────────────
+
+    .iv3-inspector {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        bottom: 12px;
+        width: 296px;
+        background: rgba(13,13,12,0.94);
+        border: 1px solid var(--iv3-border-strong);
+        border-left: 2px solid var(--iv3-accent);
+        box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+        display: flex;
+        flex-direction: column;
+        font-size: 12px;
+        color: var(--iv3-text);
+        overflow: hidden;
+        z-index: 10;
+    }
+
+    .iv3-inspector__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 14px;
+        border-bottom: 1px solid var(--iv3-border-strong);
+        color: var(--iv3-mute);
+        font-size: 10px;
+        letter-spacing: 1.8px;
+        flex-shrink: 0;
+    }
+
+    .iv3-inspector__close {
+        background: transparent;
+        border: none;
+        color: var(--iv3-mute);
+        cursor: pointer;
+        font: inherit;
+        font-size: 14px;
+        line-height: 1;
+        padding: 0;
+
+        &:hover {
+            color: var(--iv3-text);
+        }
+    }
+
+    .iv3-inspector__body {
+        overflow: auto;
+        padding: 12px 14px;
+        flex: 1;
+        scrollbar-width: thin;
+        scrollbar-color: var(--iv3-border-strong) transparent;
+    }
+
+    .iv3-insp-name {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 6px;
+    }
+
+    .iv3-insp-name__text {
+        font-size: 15px;
+        font-weight: 500;
+    }
+
+    .iv3-insp-sub {
+        color: var(--iv3-mute);
+        font-size: 11px;
+        margin-bottom: 10px;
+    }
+
+    .iv3-stat-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        padding: 4px 0;
+        border-bottom: 1px dotted var(--iv3-border-strong);
+    }
+
+    .iv3-stat-row__label {
+        color: var(--iv3-mute);
+        font-size: 10px;
+        letter-spacing: 1px;
+    }
+
+    .iv3-stat-row__value {
+        color: var(--iv3-text);
+        font-size: 12px;
+    }
+
+    .iv3-stat-row__hint {
+        color: var(--iv3-mute);
+        font-size: 10px;
+        margin-left: 4px;
+    }
+
+    .iv3-section-header {
+        margin-top: 12px;
+        margin-bottom: 6px;
+        color: var(--iv3-mute);
+        font-size: 10px;
+        letter-spacing: 1.6px;
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+    }
+
+    .iv3-section-header__count {
+        color: var(--iv3-text-dim);
+    }
+
+    .iv3-chain-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 6px;
+        border: 1px solid var(--iv3-border-strong);
+        background: rgba(20,18,16,0.4);
+        margin-bottom: 4px;
+    }
+
+    .iv3-chain-item__idx {
+        color: var(--iv3-mute);
+        font-size: 10px;
+        font-family: monospace;
+    }
+
+    .iv3-chain-item__name {
+        flex: 1;
+        font-size: 11px;
+    }
+
+    .iv3-chain-item__pps {
+        font-size: 10px;
+        color: var(--iv3-text-dim);
+    }
+
+    .iv3-feed-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        margin-bottom: 4px;
+    }
+
+    .iv3-feed-item__name {
+        flex: 1;
+    }
+
+    .iv3-feed-item__pps {
+        color: var(--iv3-text-dim);
+        font-size: 10px;
+    }
+
+    .iv3-dot {
+        display: inline-block;
+        flex-shrink: 0;
+        border-radius: 50%;
+    }
+
+    .iv3-sparkline-wrap {
+        margin-top: 6px;
+    }
+}
+
+// ── Light-mode palette overrides ──────────────────────────────────────────────
+
+[data-theme="light"] {
+    .inspect-3d-page {
+        --iv3-bg:             #FAF7F2;
+        --iv3-bg-2:           #F3EFE9;
+        --iv3-surface:        #FFFFFF;
+        --iv3-surface-strong: #FFFFFF;
+        --iv3-bg-3:           #EBE6DE;
+        --iv3-border:         rgba(80, 60, 30, 0.08);
+        --iv3-border-strong:  rgba(80, 60, 30, 0.16);
+        --iv3-text:           #1A1410;
+        --iv3-text-dim:       #5C4E3A;
+        --iv3-mute:           #9C8B74;
+        --iv3-dim:            #9C8B74;
+    }
+}
+
+// ── Footer ────────────────────────────────────────────────────────────────────
+
+.inspect-3d-page-footer {
+    padding: 0 32px 16px;
+    text-align: right;
+    color: var(--g-color-text-hint);
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 
 export const PAGE_IDS = [
     'builtin/inspect',
+    'builtin/inspect-3d',
     'builtin/functions',
     'builtin/pipelines',
     'builtin/devices',


### PR DESCRIPTION
Adds a new /builtin/dashboard page and makes it the application's landing page (root / redirects there). The page renders the real instance data as an isometric three.js topology where device boxes feed parallel pipeline lanes and function blocks sit on top of those lanes. Hovering a clickable element shows a pointer cursor; clicking opens a side inspector with rates, status and a trend sparkline.

- Camera is locked to the isometric view (no rotation, zoom or pan); pointer-move raycasts only to update cursor state.
- Scene rebuilds only when the structural data (device/pipeline/function identities) changes, never on counter ticks, so the WebGL context is created once per page lifetime. Live rates and trends feed the animation loop through a ref.
- Falls back to a friendly "WebGL unavailable" panel and an error boundary if the browser cannot create a WebGL context.
- Top region: system state strip (uptime / workers / controlplane status, with worker count inferred from the first device's counter response), compact KPI counts strip, and a throughput hero with aggregate bps/pps and a sparkline pinned to the card's bottom.
- Bottom region: dataplane modules grid with deep-link navigation to the corresponding module pages; modules without a page show the non-clickable cursor.
- All three top cards share a subtle ambient horizontal-scan overlay; sharp rectangular corners; warm dark-brown palette consistent with the /builtin/inspect HUD page; light-theme override scoped under .dashboard-page.
- The dashboard is not listed in the sidebar; the AsideHeader logo button navigates to it via React Router (with href fallback for middle-click open in new tab).
- three and @types/three added as dependencies; the page chunk is lazy-loaded.
- The existing /builtin/inspect HUD page remains unchanged.