### PR TITLE
feat: add YANET dashboard as application home page

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,11 +12,13 @@
                 "@gravity-ui/navigation": "^3",
                 "@gravity-ui/uikit": "^7",
                 "@tanstack/react-virtual": "^3.13.12",
+                "@types/three": "^0.146.0",
                 "diff": "^9.0.0",
                 "js-yaml": "^4.1.0",
                 "react": "^19",
                 "react-dom": "^19",
-                "react-router-dom": "^7.9.6"
+                "react-router-dom": "^7.9.6",
+                "three": "^0.146.0"
             },
             "devDependencies": {
                 "@testing-library/jest-dom": "^6.9.1",
@@ -2044,10 +2046,25 @@
                 "@types/react": "^19.2.0"
             }
         },
+        "node_modules/@types/three": {
+            "version": "0.146.0",
+            "resolved": "https://registry.npmjs.org/@types/three/-/three-0.146.0.tgz",
+            "integrity": "sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/webxr": "*"
+            }
+        },
         "node_modules/@types/use-sync-external-store": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
             "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+            "license": "MIT"
+        },
+        "node_modules/@types/webxr": {
+            "version": "0.5.24",
+            "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+            "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
             "license": "MIT"
         },
         "node_modules/@vitejs/plugin-react": {
@@ -2769,7 +2786,6 @@
             "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@asamuzakjp/css-color": "^5.1.11",
                 "@asamuzakjp/dom-selector": "^7.1.1",
@@ -3501,6 +3517,12 @@
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.3.0.tgz",
             "integrity": "sha512-EIHvdY5bPLuWForiR/AN2Bxngzpuwn1is4asboytXtpTgsArc+WmSJKVLlhdh71u7jFcryDqB2A8lQvj78MkyQ==",
+            "license": "MIT"
+        },
+        "node_modules/three": {
+            "version": "0.146.0",
+            "resolved": "https://registry.npmjs.org/three/-/three-0.146.0.tgz",
+            "integrity": "sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A==",
             "license": "MIT"
         },
         "node_modules/tiny-invariant": {

--- a/web/package.json
+++ b/web/package.json
@@ -14,11 +14,13 @@
         "@gravity-ui/navigation": "^3",
         "@gravity-ui/uikit": "^7",
         "@tanstack/react-virtual": "^3.13.12",
+        "@types/three": "^0.146.0",
         "diff": "^9.0.0",
         "js-yaml": "^4.1.0",
         "react": "^19",
         "react-dom": "^19",
-        "react-router-dom": "^7.9.6"
+        "react-router-dom": "^7.9.6",
+        "three": "^0.146.0"
     },
     "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import type { PageId, SidebarContextValue } from './types';
 import { PAGE_IDS, SidebarContext } from './types';
 
 const importInspect = () => import('./pages/builtin/inspect/InspectPage');
+const importDashboard = () => import('./pages/builtin/dashboard/DashboardPage');
 const importFunctions = () => import('./pages/builtin/functions/FunctionsPage');
 const importPipelines = () => import('./pages/builtin/pipelines/PipelinesPage');
 const importDevices = () => import('./pages/builtin/devices/DevicesPage');
@@ -19,6 +20,7 @@ const importNeighbours = () => import('./pages/operators/neighbours/NeighboursPa
 
 const pageImporters = [
     importInspect,
+    importDashboard,
     importFunctions,
     importPipelines,
     importDevices,
@@ -32,6 +34,7 @@ const pageImporters = [
 ];
 
 const InspectPage = lazy(importInspect);
+const DashboardPage = lazy(importDashboard);
 const FunctionsPage = lazy(importFunctions);
 const PipelinesPage = lazy(importPipelines);
 const DevicesPage = lazy(importDevices);
@@ -90,7 +93,7 @@ const AppContent = (): React.JSX.Element => {
     const getCurrentPage = (): PageId => {
         const path = location.pathname;
         if (path === '/' || path === '') {
-            return 'builtin/inspect';
+            return 'builtin/dashboard';
         }
         const segments = path.split('/').filter(Boolean);
         if (segments.length >= 2) {
@@ -99,7 +102,7 @@ const AppContent = (): React.JSX.Element => {
                 return candidate;
             }
         }
-        return 'builtin/inspect';
+        return 'builtin/dashboard';
     };
 
     const currentPage = getCurrentPage();
@@ -137,8 +140,9 @@ const AppContent = (): React.JSX.Element => {
                 renderContent={() => (
                     <Suspense fallback={<PageLoader loading size="l" />}>
                         <Routes>
-                            <Route path="/" element={<Navigate to="/builtin/inspect" replace />} />
+                            <Route path="/" element={<Navigate to="/builtin/dashboard" replace />} />
                             <Route path="/builtin/inspect" element={<InspectPage />} />
+                            <Route path="/builtin/dashboard" element={<DashboardPage />} />
                             <Route path="/builtin/functions" element={<FunctionsPage />} />
                             <Route path="/builtin/functions-ng" element={<Navigate to="/builtin/functions" replace />} />
                             <Route path="/builtin/pipelines" element={<PipelinesPage />} />
@@ -151,6 +155,7 @@ const AppContent = (): React.JSX.Element => {
                             <Route path="/operators/route" element={<OperatorsRoutePage />} />
                             <Route path="/operators/neighbours" element={<NeighboursPage />} />
                             <Route path="/inspect" element={<Navigate to="/builtin/inspect" replace />} />
+                            <Route path="/dashboard" element={<Navigate to="/builtin/dashboard" replace />} />
                             <Route path="/functions" element={<Navigate to="/builtin/functions" replace />} />
                             <Route path="/pipelines" element={<Navigate to="/builtin/pipelines" replace />} />
                             <Route path="/devices" element={<Navigate to="/builtin/devices" replace />} />

--- a/web/src/MainMenu.tsx
+++ b/web/src/MainMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AsideHeader } from '@gravity-ui/navigation';
 import type { MenuItem as AsideHeaderMenuItem } from '@gravity-ui/navigation';
 import { Link, Eye, Route, CurlyBracketsFunction, ListUl, HardDrive, LayoutCellsLarge, CirclePlay, Shield, ArrowRight } from '@gravity-ui/icons';
@@ -20,6 +21,7 @@ type NavMenuItem = AsideHeaderMenuItem & {
 
 const MainMenu = ({ currentPage, onPageChange, renderContent, disabled = false }: MainMenuProps): React.JSX.Element => {
     const [compact, setCompact] = useState<boolean>(false);
+    const navigate = useNavigate();
 
     const createMenuItem = (id: PageId, title: string, icon: NavMenuItem['icon']): NavMenuItem => ({
         id,
@@ -84,6 +86,13 @@ const MainMenu = ({ currentPage, onPageChange, renderContent, disabled = false }
             logo={{
                 icon: () => <Logo size={24} />,
                 text: 'YANET',
+                href: '/builtin/dashboard',
+                onClick: (event) => {
+                    event.preventDefault();
+                    if (!disabled) {
+                        navigate('/builtin/dashboard');
+                    }
+                },
             }}
             renderContent={renderContent}
         />

--- a/web/src/pages/builtin/dashboard/DashboardPage.tsx
+++ b/web/src/pages/builtin/dashboard/DashboardPage.tsx
@@ -1,0 +1,42 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { toaster } from '../../../utils';
+import { API } from '../../../api';
+import type { InstanceInfo } from '../../../api/inspect';
+import { PageLoader, EmptyState } from '../../../components';
+import { InstanceCard } from './InstanceCard';
+import './dashboard.scss';
+
+/** Dashboard page rendering YANET topology as an isometric three.js scene. */
+const DashboardPage = (): React.JSX.Element => {
+    const [instanceInfo, setInstanceInfo] = useState<InstanceInfo | null>(null);
+    const [initialLoading, setInitialLoading] = useState<boolean>(true);
+
+    const loadInspect = useCallback(async (): Promise<void> => {
+        try {
+            const data = await API.inspect.inspect();
+            setInstanceInfo(data.instance_info ?? null);
+        } catch (err) {
+            toaster.error('dashboard-error', 'Failed to fetch inspect data', err);
+        } finally {
+            setInitialLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadInspect();
+    }, [loadInspect]);
+
+    return (
+        <div className="dashboard-page">
+            {initialLoading ? (
+                <PageLoader loading size="l" />
+            ) : !instanceInfo ? (
+                <EmptyState message="No instance data found" />
+            ) : (
+                <InstanceCard instance={instanceInfo} />
+            )}
+        </div>
+    );
+};
+
+export default DashboardPage;

--- a/web/src/pages/builtin/dashboard/DataplaneModules.tsx
+++ b/web/src/pages/builtin/dashboard/DataplaneModules.tsx
@@ -1,0 +1,95 @@
+import React, { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { InstanceInfo } from '../../../api/inspect';
+import { MODULE_DESCRIPTIONS, MODULE_ROUTES, computeModulePipelineUsage } from '../inspect/utils';
+
+export interface DataplaneModulesProps {
+    instance: InstanceInfo;
+}
+
+/** Full-width dataplane modules grid with routing and active-state indicators. */
+export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance }) => {
+    const navigate = useNavigate();
+    const modules = instance.dp_modules ?? [];
+    const configs = instance.cp_configs ?? [];
+
+    const pipeUsage = useMemo(() => computeModulePipelineUsage(instance), [instance]);
+
+    const moduleData = useMemo(
+        () =>
+            modules.map((m) => {
+                const name = m.name ?? '';
+                const cfg = configs.filter(
+                    (c) => (c.type?.toLowerCase() ?? '') === name.toLowerCase(),
+                ).length;
+                const pipe = pipeUsage.get(name.toLowerCase()) ?? 0;
+                const inUse = cfg > 0 || pipe > 0;
+                return { name, cfg, pipe, inUse, desc: MODULE_DESCRIPTIONS[name] ?? '' };
+            }),
+        [modules, configs, pipeUsage],
+    );
+
+    const colCount = Math.min(9, Math.max(1, modules.length));
+
+    return (
+        <div className="dash-modules">
+            <div className="dash-modules__head">
+                <span>
+                    DATAPLANE MODULES{' '}
+                    <span style={{ color: 'var(--iv-text-dim)' }}>{modules.length}</span>
+                </span>
+                <span>
+                    <span style={{ color: 'var(--iv-ok)' }}>●</span>
+                    {' in use   '}
+                    <span style={{ color: 'var(--iv-idle)' }}>○</span>
+                    {' available'}
+                </span>
+            </div>
+            <div
+                className="dash-modules__grid"
+                style={{ gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))` }}
+            >
+                {moduleData.map((m) => {
+                    const href = MODULE_ROUTES[m.name];
+                    const isClickable = Boolean(href);
+                    const className = [
+                        'dash-module-card',
+                        m.inUse && 'dash-module-card--active',
+                        isClickable && 'dash-module-card--clickable',
+                    ].filter(Boolean).join(' ');
+                    const handleClick = href ? () => navigate(href) : undefined;
+                    const handleKeyDown = href
+                        ? (e: React.KeyboardEvent<HTMLDivElement>) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  navigate(href);
+                              }
+                          }
+                        : undefined;
+                    return (
+                        <div
+                            key={m.name}
+                            className={className}
+                            onClick={handleClick}
+                            onKeyDown={handleKeyDown}
+                            tabIndex={isClickable ? 0 : undefined}
+                            role={isClickable ? 'link' : undefined}
+                        >
+                            <div className="dash-module-card__top">
+                                <span className="dash-module-card__name">{m.name}</span>
+                                <span
+                                    className="dash-dot"
+                                    style={{
+                                        background: m.inUse ? 'var(--iv-ok)' : 'var(--iv-idle)',
+                                    }}
+                                />
+                            </div>
+                            <div className="dash-module-card__desc">{m.desc}</div>
+                            <div className="dash-module-card__stats">{m.cfg}cfg · {m.pipe}pipe</div>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/web/src/pages/builtin/dashboard/Inspector.tsx
+++ b/web/src/pages/builtin/dashboard/Inspector.tsx
@@ -1,0 +1,362 @@
+import React from 'react';
+import { Sparkline } from '../inspect/Sparkline';
+import { IconPort, IconTag, IconFn } from '../inspect/icons';
+import { fmtPps, fmtBps } from '../inspect/formatters';
+
+export interface SelectedItem {
+    kind: 'device' | 'pipeline' | 'fn';
+    id: string;
+}
+
+/** Structural device data derived from instance topology only. */
+export interface StructuralDevice {
+    id: string;
+    name: string;
+    kind: 'plain' | 'vlan';
+    vlan?: number;
+    parent?: string;
+    mtu?: number;
+    speed?: string;
+    pipeIn?: string;
+    pipeOut?: string;
+}
+
+/** Structural pipeline data derived from instance topology only. */
+export interface StructuralPipeline {
+    id: string;
+    name: string;
+    fns: string[];
+}
+
+/** Structural function data derived from instance topology only. */
+export interface StructuralFunction {
+    id: string;
+    mod: string;
+    chains: number;
+}
+
+/** Live per-frame snapshot of rates, trends, and statuses. */
+export interface LiveSnapshot {
+    devicesById: Map<string, {
+        rxPps: number;
+        rxBps: number;
+        txPps: number;
+        txBps: number;
+        status: 'ok' | 'idle';
+        trendRx: number[];
+        trendTx: number[];
+    }>;
+    pipelinesById: Map<string, {
+        pps: number;
+        trend: number[];
+        status: 'ok' | 'idle';
+    }>;
+    functionsById: Map<string, {
+        pps: number;
+        trend: number[];
+        status: 'ok' | 'idle';
+    }>;
+}
+
+export interface InspectorProps {
+    selected: SelectedItem;
+    onClose: () => void;
+    structuralDevices: StructuralDevice[];
+    structuralPipelines: StructuralPipeline[];
+    structuralFunctions: StructuralFunction[];
+    live: LiveSnapshot;
+}
+
+/** A small coloured status dot. */
+const Dot: React.FC<{ status: 'ok' | 'idle'; size?: number }> = ({ status, size = 6 }) => (
+    <span
+        className="dash-dot"
+        style={{
+            width: size,
+            height: size,
+            background: status === 'ok' ? 'var(--iv-ok)' : 'var(--iv-idle)',
+        }}
+    />
+);
+
+/** A labelled stat row with optional hint text. */
+const StatRow: React.FC<{ label: string; value: React.ReactNode; hint?: string }> = ({
+    label,
+    value,
+    hint,
+}) => (
+    <div className="dash-stat-row">
+        <span className="dash-stat-row__label">{label}</span>
+        <span className="dash-stat-row__value">
+            {value}
+            {hint && <span className="dash-stat-row__hint">{hint}</span>}
+        </span>
+    </div>
+);
+
+/** A section sub-header with an optional item count. */
+const SectionHeader: React.FC<{ children: React.ReactNode; count?: number }> = ({
+    children,
+    count,
+}) => (
+    <div className="dash-section-header">
+        {children}
+        {count !== undefined && <span className="dash-section-header__count">{count}</span>}
+    </div>
+);
+
+/** Inspector content for a device. */
+const InspectDevice: React.FC<{
+    d: StructuralDevice;
+    liveD: LiveSnapshot['devicesById'] extends Map<string, infer V> ? V : never;
+    pipelines: StructuralPipeline[];
+    livePipes: LiveSnapshot['pipelinesById'];
+}> = ({ d, liveD, pipelines, livePipes }) => {
+    const pIn = pipelines.find((p) => p.id === d.pipeIn);
+    const pOut = pipelines.find((p) => p.id === d.pipeOut);
+    const isVlan = d.kind === 'vlan';
+    const status = liveD.status;
+    const pInLive = pIn ? livePipes.get(pIn.id) : undefined;
+    const pOutLive = pOut ? livePipes.get(pOut.id) : undefined;
+    return (
+        <div>
+            <div className="dash-insp-name">
+                <span style={{ color: isVlan ? 'var(--iv-link)' : 'var(--iv-accent)' }}>
+                    {isVlan ? <IconTag size={14} /> : <IconPort size={14} />}
+                </span>
+                <span className="dash-insp-name__text">{d.name}</span>
+                <Dot status={status} size={6} />
+            </div>
+            <div className="dash-insp-sub">
+                {isVlan
+                    ? `vlan ${d.vlan ?? '?'} on ${d.parent ?? '?'}`
+                    : `physical · mtu ${d.mtu ?? '?'} · ${d.speed ?? '?'}`}
+            </div>
+            <SectionHeader>RX</SectionHeader>
+            <StatRow label="pps" value={fmtPps(liveD.rxPps)} />
+            <StatRow label="bps" value={fmtBps(liveD.rxBps)} />
+            <div className="dash-sparkline-wrap">
+                <Sparkline
+                    data={liveD.trendRx}
+                    w={266}
+                    h={32}
+                    color={isVlan ? 'var(--iv-link)' : 'var(--iv-accent)'}
+                    fill
+                />
+            </div>
+            <SectionHeader>TX</SectionHeader>
+            <StatRow label="pps" value={fmtPps(liveD.txPps)} />
+            <StatRow label="bps" value={fmtBps(liveD.txBps)} />
+            <div className="dash-sparkline-wrap">
+                <Sparkline
+                    data={liveD.trendTx}
+                    w={266}
+                    h={32}
+                    color={isVlan ? 'var(--iv-link)' : 'var(--iv-accent)'}
+                    fill
+                />
+            </div>
+            <SectionHeader>PIPELINES</SectionHeader>
+            <StatRow label="in" value={pIn ? pIn.name : '—'} hint={pInLive ? `${fmtPps(pInLive.pps)} pps` : undefined} />
+            <StatRow label="out" value={pOut ? pOut.name : '—'} hint={pOutLive ? `${fmtPps(pOutLive.pps)} pps` : undefined} />
+            <SectionHeader>STATE</SectionHeader>
+            <StatRow label="status" value={status} />
+            <StatRow label="kind" value={d.kind} />
+        </div>
+    );
+};
+
+/** Inspector content for a pipeline. */
+const InspectPipeline: React.FC<{
+    p: StructuralPipeline;
+    liveP: LiveSnapshot['pipelinesById'] extends Map<string, infer V> ? V : never;
+    devices: StructuralDevice[];
+    liveDevices: LiveSnapshot['devicesById'];
+    functions: StructuralFunction[];
+    liveFns: LiveSnapshot['functionsById'];
+}> = ({ p, liveP, devices, liveDevices, functions, liveFns }) => {
+    const feedDevs = devices.filter((d) => d.pipeIn === p.id);
+    return (
+        <div>
+            <div className="dash-insp-name">
+                <Dot status={liveP.status} size={6} />
+                <span className="dash-insp-name__text">{p.name}</span>
+            </div>
+            <div className="dash-insp-sub">{p.fns.length} functions in chain</div>
+            <StatRow label="pps" value={fmtPps(liveP.pps)} />
+            <StatRow label="status" value={liveP.status} />
+            <div className="dash-sparkline-wrap">
+                <Sparkline data={liveP.trend} w={266} h={32} color="var(--iv-accent)" fill />
+            </div>
+            <SectionHeader count={p.fns.length}>FUNCTION CHAIN</SectionHeader>
+            <div>
+                {p.fns.map((fname, idx) => {
+                    const fnStruct = functions.find((f) => f.id === fname);
+                    const liveFn = liveFns.get(fname);
+                    return (
+                        <div key={fname} className="dash-chain-item">
+                            <span className="dash-chain-item__idx">{idx + 1}.</span>
+                            <span style={{ color: 'var(--iv-accent)' }}>
+                                <IconFn size={10} />
+                            </span>
+                            <span className="dash-chain-item__name">
+                                {(fnStruct?.id ?? fname).replace(/^fn:/, '')}
+                            </span>
+                            <span className="dash-chain-item__pps">{fmtPps(liveFn?.pps ?? 0)}</span>
+                        </div>
+                    );
+                })}
+            </div>
+            <SectionHeader count={feedDevs.length}>FEEDING DEVICES</SectionHeader>
+            <div>
+                {feedDevs.slice(0, 8).map((d) => {
+                    const liveDev = liveDevices.get(d.id);
+                    return (
+                        <div key={d.id} className="dash-feed-item">
+                            <Dot status={liveDev?.status ?? 'idle'} size={4} />
+                            <span style={{ color: d.kind === 'vlan' ? 'var(--iv-link)' : 'var(--iv-accent)' }}>
+                                {d.kind === 'vlan' ? <IconTag size={10} /> : <IconPort size={10} />}
+                            </span>
+                            <span className="dash-feed-item__name">{d.name}</span>
+                            <span className="dash-feed-item__pps">{fmtPps(liveDev?.rxPps ?? 0)}</span>
+                        </div>
+                    );
+                })}
+                {feedDevs.length > 8 && (
+                    <span style={{ color: 'var(--iv-mute)', fontSize: 10 }}>
+                        +{feedDevs.length - 8} more
+                    </span>
+                )}
+                {feedDevs.length === 0 && (
+                    <span style={{ color: 'var(--iv-mute)', fontSize: 10 }}>none</span>
+                )}
+            </div>
+        </div>
+    );
+};
+
+/** Inspector content for a function. */
+const InspectFn: React.FC<{
+    f: StructuralFunction;
+    liveF: LiveSnapshot['functionsById'] extends Map<string, infer V> ? V : never;
+    pipelines: StructuralPipeline[];
+    livePipes: LiveSnapshot['pipelinesById'];
+}> = ({ f, liveF, pipelines, livePipes }) => {
+    const usedBy = pipelines.filter((p) => p.fns.includes(f.id));
+    return (
+        <div>
+            <div className="dash-insp-name">
+                <span style={{ color: liveF.pps > 0 ? 'var(--iv-accent)' : 'var(--iv-mute)' }}>
+                    <IconFn size={14} />
+                </span>
+                <span className="dash-insp-name__text">{f.id}</span>
+                <Dot status={liveF.status} size={6} />
+            </div>
+            <div className="dash-insp-sub">
+                module: <span style={{ color: 'var(--iv-text-dim)' }}>{f.mod || '—'}</span>
+            </div>
+            <StatRow label="pps" value={fmtPps(liveF.pps)} />
+            <StatRow label="status" value={liveF.status} />
+            {f.mod && <StatRow label="module" value={f.mod} />}
+            <div className="dash-sparkline-wrap">
+                <Sparkline data={liveF.trend} w={266} h={32} color="var(--iv-accent)" fill />
+            </div>
+            <SectionHeader count={usedBy.length}>USED BY PIPELINES</SectionHeader>
+            <div>
+                {usedBy.map((p) => {
+                    const liveP = livePipes.get(p.id);
+                    return (
+                        <div key={p.id} className="dash-feed-item">
+                            <Dot status={liveP?.status ?? 'idle'} size={4} />
+                            <span className="dash-feed-item__name">{p.name}</span>
+                            <span className="dash-feed-item__pps">{fmtPps(liveP?.pps ?? 0)}</span>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};
+
+/** Right-side overlay inspector panel shown when a scene object is selected. */
+export const Inspector: React.FC<InspectorProps> = ({
+    selected,
+    onClose,
+    structuralDevices,
+    structuralPipelines,
+    structuralFunctions,
+    live,
+}) => {
+    let content: React.ReactNode = null;
+    let title = '';
+
+    if (selected.kind === 'device') {
+        const d = structuralDevices.find((x) => x.id === selected.id);
+        if (!d) return null;
+        const liveD = live.devicesById.get(d.id) ?? {
+            rxPps: 0, rxBps: 0, txPps: 0, txBps: 0,
+            status: 'idle' as const,
+            trendRx: [], trendTx: [],
+        };
+        content = (
+            <InspectDevice
+                d={d}
+                liveD={liveD}
+                pipelines={structuralPipelines}
+                livePipes={live.pipelinesById}
+            />
+        );
+        title = 'DEVICE';
+    } else if (selected.kind === 'pipeline') {
+        const p = structuralPipelines.find((x) => x.id === selected.id);
+        if (!p) return null;
+        const liveP = live.pipelinesById.get(p.id) ?? {
+            pps: 0, trend: [], status: 'idle' as const,
+        };
+        content = (
+            <InspectPipeline
+                p={p}
+                liveP={liveP}
+                devices={structuralDevices}
+                liveDevices={live.devicesById}
+                functions={structuralFunctions}
+                liveFns={live.functionsById}
+            />
+        );
+        title = 'PIPELINE';
+    } else if (selected.kind === 'fn') {
+        const f = structuralFunctions.find((x) => x.id === selected.id);
+        if (!f) return null;
+        const liveF = live.functionsById.get(f.id) ?? {
+            pps: 0, trend: [], status: 'idle' as const,
+        };
+        content = (
+            <InspectFn
+                f={f}
+                liveF={liveF}
+                pipelines={structuralPipelines}
+                livePipes={live.pipelinesById}
+            />
+        );
+        title = 'FUNCTION';
+    }
+
+    if (!content) return null;
+
+    return (
+        <div
+            className="dash-inspector"
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onPointerDown={(e) => e.stopPropagation()}
+        >
+            <div className="dash-inspector__head">
+                <span>{title}</span>
+                <button className="dash-inspector__close" onClick={onClose}>
+                    ×
+                </button>
+            </div>
+            <div className="dash-inspector__body dash-scroll">{content}</div>
+        </div>
+    );
+};

--- a/web/src/pages/builtin/dashboard/InstanceCard.tsx
+++ b/web/src/pages/builtin/dashboard/InstanceCard.tsx
@@ -1,0 +1,63 @@
+import React, { useMemo } from 'react';
+import type { InstanceInfo } from '../../../api/inspect';
+import { useDeviceCounters } from '../../../hooks';
+import { SystemState } from './SystemState';
+import { useWorkerCount } from './hooks';
+import { KpiStrip } from './KpiStrip';
+import { IsoScene3D } from './IsoScene3D';
+import { SceneErrorBoundary } from './SceneErrorBoundary';
+import { Throughput } from './Throughput';
+import { DataplaneModules } from './DataplaneModules';
+
+export interface InstanceCardProps {
+    instance: InstanceInfo;
+}
+
+/** Root layout for a single YANET instance: system state, KPI strip, 3D scene, modules. */
+export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
+    const devices = instance.devices ?? [];
+
+    const deviceNames = useMemo(
+        () => devices.map((d, idx) => d.name ?? `device-${idx}`),
+        [devices],
+    );
+
+    const { counters: rateCounters, absoluteCounters } = useDeviceCounters(
+        deviceNames,
+        devices.length > 0,
+    );
+
+    const workerCount = useWorkerCount(deviceNames);
+
+    const physicalDeviceNames = useMemo(() => {
+        const result = new Set<string>();
+        devices.forEach((d, idx) => {
+            if (d.type === 'plain') {
+                result.add(d.name ?? `device-${idx}`);
+            }
+        });
+        return result;
+    }, [devices]);
+
+    return (
+        <>
+            <div className="dash-top-row">
+                <div className="dash-top-row__left">
+                    <SystemState workerCount={workerCount} />
+                    <KpiStrip instance={instance} />
+                </div>
+                <div className="dash-top-row__right">
+                    <Throughput rateCounters={rateCounters} physicalDeviceNames={physicalDeviceNames} />
+                </div>
+            </div>
+            <SceneErrorBoundary>
+                <IsoScene3D
+                    instance={instance}
+                    rateCounters={rateCounters}
+                    absoluteCounters={absoluteCounters}
+                />
+            </SceneErrorBoundary>
+            <DataplaneModules instance={instance} />
+        </>
+    );
+};

--- a/web/src/pages/builtin/dashboard/IsoScene3D.tsx
+++ b/web/src/pages/builtin/dashboard/IsoScene3D.tsx
@@ -1,0 +1,1064 @@
+import React, { useEffect, useRef, useState, useMemo } from 'react';
+import * as THREE from 'three';
+import type { InstanceInfo } from '../../../api/inspect';
+import type { DeviceCounterData, DeviceAbsoluteData } from '../../../hooks';
+import { usePipelineCounters, useFunctionCounters, useDeviceTrendSeries } from '../inspect/hooks';
+import { fmtPps } from '../inspect/formatters';
+import { Inspector } from './Inspector';
+import type { SelectedItem } from './Inspector';
+
+export interface IsoScene3DProps {
+    instance: InstanceInfo;
+    rateCounters: Map<string, DeviceCounterData>;
+    absoluteCounters: Map<string, DeviceAbsoluteData>;
+}
+
+interface LabelInfo {
+    kind: 'device' | 'pipeline' | 'fn';
+    id: string;
+    anchor: 'right' | 'pipeline' | 'top';
+    worldPos: () => THREE.Vector3;
+    text: string;
+    subtext: string;
+    active?: boolean;
+    sx: number;
+    sy: number;
+}
+
+interface FwdPath {
+    pts: THREE.Vector3[];
+    lens: number[];
+    total: number;
+    density: number;
+}
+
+interface Particle {
+    pi: number;
+    t: number;
+    speed: number;
+    posIdx: number;
+}
+
+interface ParticleSystem {
+    points: THREE.Points | null;
+    ps: Particle[];
+    geo: THREE.BufferGeometry | null;
+}
+
+interface FnMeshEntry {
+    mesh: THREE.Mesh;
+    fnId: string;
+    baseH: number;
+    x: number;
+    z: number;
+    w: number;
+    d: number;
+}
+
+interface WireEntry {
+    line: THREE.Line;
+    deviceId: string;
+    pipeId: string;
+}
+
+interface ThreeRefs {
+    scene: THREE.Scene | null;
+    camera: THREE.OrthographicCamera | null;
+    renderer: THREE.WebGLRenderer | null;
+    pickGroup: THREE.Group | null;
+    deviceMeshes: Record<string, THREE.Mesh>;
+    pipeMeshes: Record<string, THREE.Mesh>;
+    fnMeshes: FnMeshEntry[];
+    fwdPS: ParticleSystem;
+    fwdPaths: FwdPath[];
+    labelSources: Omit<LabelInfo, 'sx' | 'sy'>[];
+    wires: WireEntry[];
+    sceneCenter: THREE.Vector3 | null;
+}
+
+/** Structural device data derived only from instance topology (no live counters). */
+interface StructuralDevice {
+    id: string;
+    name: string;
+    kind: 'plain' | 'vlan';
+    vlan?: number;
+    parent?: string;
+    mtu?: number;
+    speed?: string;
+    pipeIn?: string;
+    pipeOut?: string;
+}
+
+/** Structural pipeline data derived only from instance topology. */
+interface StructuralPipeline {
+    id: string;
+    name: string;
+    fns: string[];
+}
+
+/** Structural function data derived only from instance topology. */
+interface StructuralFunction {
+    id: string;
+    mod: string;
+    chains: number;
+}
+
+/** Per-frame live snapshot: rates, trends, statuses. Updated every counter tick. */
+interface LiveSnapshot {
+    devicesById: Map<string, {
+        rxPps: number;
+        rxBps: number;
+        txPps: number;
+        txBps: number;
+        status: 'ok' | 'idle';
+        trendRx: number[];
+        trendTx: number[];
+    }>;
+    pipelinesById: Map<string, {
+        pps: number;
+        trend: number[];
+        status: 'ok' | 'idle';
+    }>;
+    functionsById: Map<string, {
+        pps: number;
+        trend: number[];
+        status: 'ok' | 'idle';
+    }>;
+}
+
+/** Build a box mesh anchored at its bottom face. */
+const makeBox = (
+    w: number,
+    h: number,
+    d: number,
+    fillHex: number,
+    opacity: number = 1,
+    emissive: number = 0x000000,
+): THREE.Mesh => {
+    const geo = new THREE.BoxGeometry(w, h, d);
+    geo.translate(0, h / 2, 0);
+    const mat = new THREE.MeshLambertMaterial({
+        color: fillHex,
+        transparent: opacity < 1,
+        opacity,
+        emissive,
+        emissiveIntensity: emissive ? 0.4 : 0,
+    });
+    const mesh = new THREE.Mesh(geo, mat);
+    const edges = new THREE.LineSegments(
+        new THREE.EdgesGeometry(geo),
+        new THREE.LineBasicMaterial({ color: 0x3a3731, transparent: true, opacity: 0.85 }),
+    );
+    mesh.add(edges);
+    mesh.userData.edges = edges;
+    return mesh;
+};
+
+/** Build a particle system from an array of paths. */
+const buildParticles = (
+    paths: FwdPath[],
+    color: number,
+    sizeBase: number,
+): ParticleSystem => {
+    const N = paths.reduce((sum, p) => sum + Math.max(1, Math.round(p.density * 18)), 0);
+    if (!N) return { points: null, ps: [], geo: null };
+
+    const positions = new Float32Array(N * 3);
+    const ps: Particle[] = [];
+    let idx = 0;
+    paths.forEach((path, pi) => {
+        const count = Math.max(1, Math.round(path.density * 18));
+        for (let i = 0; i < count; i++) {
+            ps.push({
+                pi,
+                t: Math.random(),
+                speed: (0.0008 + path.density * 0.0014) * (0.7 + Math.random() * 0.6),
+                posIdx: idx,
+            });
+            positions[idx * 3 + 0] = 0;
+            positions[idx * 3 + 1] = 0;
+            positions[idx * 3 + 2] = 0;
+            idx++;
+        }
+    });
+
+    const geo = new THREE.BufferGeometry();
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    const mat = new THREE.PointsMaterial({
+        color,
+        size: sizeBase,
+        transparent: true,
+        opacity: 0.7,
+        sizeAttenuation: false,
+        depthWrite: false,
+    });
+    const points = new THREE.Points(geo, mat);
+    return { points, ps, geo };
+};
+
+/** Isometric 3D topology scene: devices, pipelines, functions, and forward particles. */
+export const IsoScene3D: React.FC<IsoScene3DProps> = ({
+    instance,
+    rateCounters,
+    absoluteCounters,
+}) => {
+    const devices = instance.devices ?? [];
+    const pipelines = instance.pipelines ?? [];
+    const functions = instance.functions ?? [];
+
+    const structuralDevices = useMemo((): StructuralDevice[] =>
+        devices.map((d, idx) => ({
+            id: d.name ?? `device-${idx}`,
+            name: d.name ?? `device-${idx}`,
+            kind: d.type === 'vlan' ? 'vlan' : 'plain',
+            pipeIn: d.input_pipelines?.[0]?.name,
+            pipeOut: d.output_pipelines?.[0]?.name,
+        })),
+    [devices]);
+
+    const structuralPipelines = useMemo((): StructuralPipeline[] =>
+        pipelines.map((p, idx) => ({
+            id: p.name ?? `pipeline-${idx}`,
+            name: p.name ?? `pipeline-${idx}`,
+            fns: p.functions ?? [],
+        })),
+    [pipelines]);
+
+    const structuralFunctions = useMemo((): StructuralFunction[] =>
+        functions.map((f, idx) => ({
+            id: f.name ?? `function-${idx}`,
+            mod: f.chains?.[0]?.modules?.[0]?.type ?? '',
+            chains: f.chains?.length ?? 0,
+        })),
+    [functions]);
+
+    const deviceNames = useMemo(
+        () => structuralDevices.map((d) => d.name),
+        [structuralDevices],
+    );
+
+    const pipelineNames = useMemo(
+        () => structuralPipelines.map((p) => p.name),
+        [structuralPipelines],
+    );
+
+    const functionNames = useMemo(
+        () => structuralFunctions.map((f) => f.id),
+        [structuralFunctions],
+    );
+
+    const { rates: pipeRates, series: pipeSeries } = usePipelineCounters(
+        deviceNames,
+        pipelineNames,
+        deviceNames.length > 0 && pipelineNames.length > 0,
+    );
+
+    const { rates: fnRates, series: fnSeries } = useFunctionCounters(
+        deviceNames,
+        pipelineNames,
+        functionNames,
+        deviceNames.length > 0 && pipelineNames.length > 0 && functionNames.length > 0,
+    );
+
+    const trendRxMap = useDeviceTrendSeries(rateCounters, 'rx');
+    const trendTxMap = useDeviceTrendSeries(rateCounters, 'tx');
+
+    const liveRef = useRef<LiveSnapshot>({
+        devicesById: new Map(),
+        pipelinesById: new Map(),
+        functionsById: new Map(),
+    });
+    liveRef.current = useMemo<LiveSnapshot>(() => {
+        const devicesById = new Map<string, {
+            rxPps: number;
+            rxBps: number;
+            txPps: number;
+            txBps: number;
+            status: 'ok' | 'idle';
+            trendRx: number[];
+            trendTx: number[];
+        }>();
+        structuralDevices.forEach((d) => {
+            const counters = rateCounters.get(d.id);
+            const abs = absoluteCounters.get(d.id);
+            const rxPps = counters?.rx?.pps ?? 0;
+            const rxBps = counters?.rx?.bps ?? 0;
+            const txPps = counters?.tx?.pps ?? 0;
+            const txBps = counters?.tx?.bps ?? 0;
+            const status: 'ok' | 'idle' =
+                abs && (abs.rx.packets > 0 || abs.tx.packets > 0) ? 'ok' : 'idle';
+            devicesById.set(d.id, {
+                rxPps,
+                rxBps,
+                txPps,
+                txBps,
+                status,
+                trendRx: trendRxMap.get(d.id) ?? [],
+                trendTx: trendTxMap.get(d.id) ?? [],
+            });
+        });
+        const pipelinesById = new Map<string, {
+            pps: number;
+            trend: number[];
+            status: 'ok' | 'idle';
+        }>();
+        structuralPipelines.forEach((p) => {
+            const rate = pipeRates.get(p.id);
+            const pps = rate?.pps ?? 0;
+            pipelinesById.set(p.id, {
+                pps,
+                trend: pipeSeries.get(p.id) ?? [],
+                status: pps > 0 ? 'ok' : 'idle',
+            });
+        });
+        const functionsById = new Map<string, {
+            pps: number;
+            trend: number[];
+            status: 'ok' | 'idle';
+        }>();
+        structuralFunctions.forEach((f) => {
+            const rate = fnRates.get(f.id);
+            const pps = rate?.pps ?? 0;
+            functionsById.set(f.id, {
+                pps,
+                trend: fnSeries.get(f.id) ?? [],
+                status: pps > 0 ? 'ok' : 'idle',
+            });
+        });
+        return { devicesById, pipelinesById, functionsById };
+    }, [
+        structuralDevices, structuralPipelines, structuralFunctions,
+        rateCounters, absoluteCounters,
+        pipeRates, pipeSeries,
+        fnRates, fnSeries,
+        trendRxMap, trendTxMap,
+    ]);
+
+    const containerRef = useRef<HTMLDivElement>(null);
+    const canvasMountRef = useRef<HTMLDivElement>(null);
+    const [selected, setSelected] = useState<SelectedItem | null>(null);
+    const [labels, setLabels] = useState<LabelInfo[]>([]);
+    const [canvasSize, setCanvasSize] = useState({ w: 900, h: 620 });
+    const [webglAvailable, setWebglAvailable] = useState<boolean | null>(null);
+    const [rendererError, setRendererError] = useState(false);
+    const threeRef = useRef<ThreeRefs>({
+        scene: null,
+        camera: null,
+        renderer: null,
+        pickGroup: null,
+        deviceMeshes: {},
+        pipeMeshes: {},
+        fnMeshes: [],
+        fwdPS: { points: null, ps: [], geo: null },
+        fwdPaths: [],
+        labelSources: [],
+        wires: [],
+        sceneCenter: null,
+    });
+    const canvasSizeRef = useRef(canvasSize);
+    canvasSizeRef.current = canvasSize;
+
+    useEffect(() => {
+        let cancelled = false;
+        const check = (): boolean => {
+            try {
+                const canvas = document.createElement('canvas');
+                const gl =
+                    canvas.getContext('webgl2') ||
+                    canvas.getContext('webgl') ||
+                    canvas.getContext('experimental-webgl');
+                return !!gl;
+            } catch {
+                return false;
+            }
+        };
+        if (!cancelled) {
+            setWebglAvailable(check());
+        }
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!containerRef.current) return;
+        const obs = new ResizeObserver((entries) => {
+            const entry = entries[0];
+            if (!entry) return;
+            const { width } = entry.contentRect;
+            setCanvasSize({ w: Math.max(300, Math.floor(width)), h: 620 });
+        });
+        obs.observe(containerRef.current);
+        const { width } = containerRef.current.getBoundingClientRect();
+        if (width > 0) {
+            setCanvasSize({ w: Math.floor(width), h: 620 });
+        }
+        return () => obs.disconnect();
+    }, []);
+
+    useEffect(() => {
+        const r = threeRef.current;
+        if (!r.renderer || !r.camera) return;
+        const { w, h } = canvasSize;
+        r.renderer.setSize(w, h);
+        const aspect = w / h;
+        const camSize = 360;
+        const cam = r.camera;
+        cam.left = -camSize * aspect / 2;
+        cam.right = camSize * aspect / 2;
+        cam.top = camSize / 2;
+        cam.bottom = -camSize / 2;
+        cam.updateProjectionMatrix();
+    }, [canvasSize]);
+
+    useEffect(() => {
+        if (webglAvailable !== true) {
+            return;
+        }
+        if (!canvasMountRef.current) return;
+        let cancelled = false;
+        const mount = canvasMountRef.current;
+        while (mount.firstChild) mount.removeChild(mount.firstChild);
+
+        const { w: VW, h: VH } = canvasSize;
+        const scene = new THREE.Scene();
+        scene.background = null;
+
+        const aspect = VW / VH;
+        const camSize = 360;
+        const camera = new THREE.OrthographicCamera(
+            -camSize * aspect / 2,
+            camSize * aspect / 2,
+            camSize / 2,
+            -camSize / 2,
+            -4000,
+            4000,
+        );
+
+        let renderer: THREE.WebGLRenderer;
+        // Three.js calls console.error multiple times during failed WebGL
+        // initialisation before throwing; silence them so a graceful fallback
+        // does not look like a stream of crashes in the console. Restored on
+        // both branches immediately after construction returns or throws.
+        const origError = console.error;
+        const origWarn = console.warn;
+        console.error = (): void => {};
+        console.warn = (): void => {};
+        try {
+            renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+            console.error = origError;
+            console.warn = origWarn;
+        } catch (err) {
+            console.error = origError;
+            console.warn = origWarn;
+            if (!cancelled) {
+                setRendererError(true);
+            }
+            return;
+        }
+        renderer.setPixelRatio(window.devicePixelRatio || 1);
+        renderer.setSize(VW, VH);
+        renderer.setClearColor(0x000000, 0);
+        mount.appendChild(renderer.domElement);
+        renderer.domElement.style.display = 'block';
+
+        scene.add(new THREE.AmbientLight(0xfff3e0, 0.55));
+        const dir = new THREE.DirectionalLight(0xffe6cc, 0.5);
+        dir.position.set(200, 600, 300);
+        scene.add(dir);
+        scene.add(new THREE.HemisphereLight(0xc9a070, 0x0d0d0c, 0.35));
+
+        const numPipes = structuralPipelines.length;
+        const LANE_LEN = 480;
+        const LANE_SPACING = Math.max(28, Math.min(46, 230 / Math.max(1, numPipes - 1)));
+        const LANE_HALF_W = Math.min(17, LANE_SPACING * 0.45);
+        const LANE_THICK = 4;
+        const X0 = 0;
+        const Z0 = 0;
+
+        const plainDevs = structuralDevices.filter((d) => d.kind === 'plain');
+        const vlanDevs = structuralDevices.filter((d) => d.kind === 'vlan');
+        const devW = 26;
+        const devD = 14;
+        const devH = 7;
+        const colSpan = (numPipes - 1) * LANE_SPACING + LANE_HALF_W * 2;
+        const devGap = Math.max(1, Math.min(4, (colSpan - plainDevs.length * devD) / Math.max(1, plainDevs.length - 1)));
+        const vlanGap = Math.max(1, Math.min(4, (colSpan - vlanDevs.length * devD) / Math.max(1, vlanDevs.length - 1)));
+
+        const devicePositions: Record<string, { x: number; z: number; kind: 'plain' | 'vlan' }> = {};
+        plainDevs.forEach((d, i) => {
+            devicePositions[d.id] = { x: -140, z: Z0 + i * (devD + devGap), kind: 'plain' };
+        });
+        vlanDevs.forEach((d, i) => {
+            devicePositions[d.id] = { x: -90, z: Z0 + i * (devD + vlanGap), kind: 'vlan' };
+        });
+
+        const pipeZ = structuralPipelines.map((_, i) => Z0 + i * LANE_SPACING);
+
+        const pickGroup = new THREE.Group();
+        scene.add(pickGroup);
+
+        const deviceMeshes: Record<string, THREE.Mesh> = {};
+        structuralDevices.forEach((d) => {
+            const pos = devicePositions[d.id];
+            if (!pos) return;
+            const isVlan = d.kind === 'vlan';
+            const color = 0x1d1b18;
+            const edgeColor = 0x3a3731;
+            const mesh = makeBox(devW, devH, devD, color, 0.95);
+            ((mesh.userData.edges as THREE.LineSegments).material as THREE.LineBasicMaterial).color.setHex(edgeColor);
+            mesh.position.set(pos.x + devW / 2, 0, pos.z + devD / 2);
+            mesh.userData = {
+                ...mesh.userData,
+                kind: 'device',
+                id: d.id,
+                baseColor: color,
+                edgeColor,
+                isVlan,
+            };
+            pickGroup.add(mesh);
+            deviceMeshes[d.id] = mesh;
+        });
+
+        const pipeMeshes: Record<string, THREE.Mesh> = {};
+        structuralPipelines.forEach((p, pi) => {
+            const z = pipeZ[pi];
+            const color = 0x1a1816;
+            const edgeColor = 0x3a3731;
+            const mesh = makeBox(LANE_LEN, LANE_THICK, LANE_HALF_W * 2, color, 0.9);
+            const edgesMat = (mesh.userData.edges as THREE.LineSegments).material as THREE.LineBasicMaterial;
+            edgesMat.color.setHex(edgeColor);
+            edgesMat.opacity = 0.5;
+            mesh.position.set(X0 + LANE_LEN / 2, 0, z);
+            mesh.userData = { ...mesh.userData, kind: 'pipeline', id: p.id, baseColor: color, edgeColor };
+            pickGroup.add(mesh);
+            pipeMeshes[p.id] = mesh;
+        });
+
+        const FN_DEPTH = Math.max(10, LANE_HALF_W * 1.6);
+        const fnMeshes: FnMeshEntry[] = [];
+        structuralPipelines.forEach((p, pi) => {
+            if (!p.fns.length) return;
+            const slotLen = (LANE_LEN - 40) / p.fns.length;
+            p.fns.forEach((fname, fi) => {
+                const xStart = X0 + 22 + slotLen * fi + 3;
+                const w = Math.max(18, slotLen - 9);
+                const baseH = 5;
+                const color = 0x1a1816;
+                const edgeColor = 0x3a3731;
+                const mesh = makeBox(w, baseH, FN_DEPTH, color, 0.92, 0x000000);
+                ((mesh.userData.edges as THREE.LineSegments).material as THREE.LineBasicMaterial).color.setHex(edgeColor);
+                mesh.position.set(xStart + w / 2, LANE_THICK, pipeZ[pi]);
+                mesh.userData = {
+                    ...mesh.userData,
+                    kind: 'fn',
+                    id: fname,
+                    baseColor: color,
+                    edgeColor,
+                };
+                pickGroup.add(mesh);
+                fnMeshes.push({
+                    mesh,
+                    fnId: fname,
+                    baseH,
+                    x: xStart,
+                    z: pipeZ[pi] - FN_DEPTH / 2,
+                    w,
+                    d: FN_DEPTH,
+                });
+            });
+        });
+
+        {
+            const gridSize = 700;
+            const gridDiv = 18;
+            const grid = new THREE.GridHelper(gridSize, gridDiv, 0x2a2823, 0x1f1d1a);
+            (grid.material as THREE.Material).opacity = 0.45;
+            (grid.material as THREE.Material).transparent = true;
+            grid.position.set(120, -0.5, colSpan / 2);
+            scene.add(grid);
+        }
+
+        const wires: WireEntry[] = [];
+        structuralDevices.forEach((d) => {
+            if (!d.pipeIn) return;
+            const pi = structuralPipelines.findIndex((p) => p.id === d.pipeIn);
+            if (pi < 0) return;
+            const pos = devicePositions[d.id];
+            if (!pos) return;
+            const pts = [
+                new THREE.Vector3(pos.x + devW, devH / 2, pos.z + devD / 2),
+                new THREE.Vector3(X0 - 6, devH / 2, pos.z + devD / 2),
+                new THREE.Vector3(X0, LANE_THICK + 1, pipeZ[pi]),
+            ];
+            const geo = new THREE.BufferGeometry().setFromPoints(pts);
+            const mat = new THREE.LineBasicMaterial({
+                color: 0x3a3731,
+                transparent: true,
+                opacity: 0.3,
+            });
+            const line = new THREE.Line(geo, mat);
+            scene.add(line);
+            wires.push({ line, deviceId: d.id, pipeId: d.pipeIn });
+        });
+
+        const fwdPaths: FwdPath[] = [];
+        structuralDevices.forEach((d) => {
+            if (!d.pipeIn) return;
+            const pi = structuralPipelines.findIndex((p) => p.id === d.pipeIn);
+            if (pi < 0) return;
+            const pos = devicePositions[d.id];
+            if (!pos) return;
+            const pts = [
+                new THREE.Vector3(pos.x + devW, devH / 2, pos.z + devD / 2),
+                new THREE.Vector3(X0 - 6, devH / 2, pos.z + devD / 2),
+                new THREE.Vector3(X0, LANE_THICK + 1, pipeZ[pi]),
+                new THREE.Vector3(X0 + LANE_LEN, LANE_THICK + 1, pipeZ[pi]),
+            ];
+            const lens: number[] = [];
+            let total = 0;
+            for (let i = 1; i < pts.length; i++) {
+                const l = pts[i].distanceTo(pts[i - 1]);
+                lens.push(l);
+                total += l;
+            }
+            fwdPaths.push({ pts, lens, total, density: 0.5 });
+        });
+
+        const fwdPS = buildParticles(fwdPaths, 0xFFC061, 2.4);
+        if (fwdPS.points) scene.add(fwdPS.points);
+
+        const sceneCenter = new THREE.Vector3(LANE_LEN / 2 - 40, 20, colSpan / 2);
+        const sph = new THREE.Spherical(500, Math.PI / 3.2, -Math.PI / 4);
+        camera.position.setFromSpherical(sph).add(sceneCenter);
+        camera.lookAt(sceneCenter);
+
+        const labelSources: Omit<LabelInfo, 'sx' | 'sy'>[] = [];
+        Object.entries(deviceMeshes).forEach(([id, m]) => {
+            const d = structuralDevices.find((x) => x.id === id);
+            if (!d) return;
+            labelSources.push({
+                kind: 'device',
+                id,
+                anchor: 'right',
+                worldPos: () => new THREE.Vector3(m.position.x - devW / 2 - 2, devH / 2, m.position.z),
+                text: d.name,
+                subtext: '',
+                active: false,
+            });
+        });
+        Object.entries(pipeMeshes).forEach(([id, m]) => {
+            const p = structuralPipelines.find((x) => x.id === id);
+            if (!p) return;
+            labelSources.push({
+                kind: 'pipeline',
+                id,
+                anchor: 'pipeline',
+                worldPos: () =>
+                    new THREE.Vector3(m.position.x - LANE_LEN / 2 - 4, 0, m.position.z),
+                text: p.name,
+                subtext: '',
+                active: false,
+            });
+        });
+        fnMeshes.forEach((fb) => {
+            labelSources.push({
+                kind: 'fn',
+                id: fb.fnId,
+                anchor: 'top',
+                worldPos: () =>
+                    new THREE.Vector3(
+                        fb.mesh.position.x,
+                        LANE_THICK + fb.mesh.scale.y * fb.baseH + 4,
+                        fb.mesh.position.z,
+                    ),
+                text: fb.fnId.replace(/^fn:/, ''),
+                subtext: '',
+                active: false,
+            });
+        });
+
+        threeRef.current = {
+            scene,
+            camera,
+            renderer,
+            pickGroup,
+            deviceMeshes,
+            pipeMeshes,
+            fnMeshes,
+            fwdPS,
+            fwdPaths,
+            labelSources,
+            wires,
+            sceneCenter,
+        };
+
+        const raycaster = new THREE.Raycaster();
+        const mouse = new THREE.Vector2();
+
+        const onPointerUp = (e: PointerEvent): void => {
+            const rect = renderer.domElement.getBoundingClientRect();
+            mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+            mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+            raycaster.setFromCamera(mouse, camera);
+            const hits = raycaster.intersectObjects(pickGroup.children, false);
+            if (hits.length) {
+                const h = hits[0].object;
+                const ud = h.userData as { kind?: string; id?: string };
+                if (ud.kind && ud.id) {
+                    setSelected({ kind: ud.kind as SelectedItem['kind'], id: ud.id });
+                }
+            }
+        };
+        renderer.domElement.addEventListener('pointerup', onPointerUp);
+
+        let lastHoverCheck = 0;
+        const onPointerMove = (e: PointerEvent): void => {
+            const now = performance.now();
+            if (now - lastHoverCheck < 50) return;
+            lastHoverCheck = now;
+            const rect = renderer.domElement.getBoundingClientRect();
+            mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+            mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+            raycaster.setFromCamera(mouse, camera);
+            const hits = raycaster.intersectObjects(pickGroup.children, false);
+            renderer.domElement.style.cursor = hits.length > 0 ? 'pointer' : 'default';
+        };
+        renderer.domElement.addEventListener('pointermove', onPointerMove);
+
+        let raf: number;
+        let lastLabelTick = 0;
+        const tmpV = new THREE.Vector3();
+
+        const animate = (now: number): void => {
+            const live = liveRef.current;
+
+            fnMeshes.forEach((fb) => {
+                const liveFn = live.functionsById.get(fb.fnId);
+                const active = (liveFn?.pps ?? 0) > 0;
+                const mat = fb.mesh.material as THREE.MeshLambertMaterial;
+                mat.color.setHex(active ? 0x5a4632 : 0x1a1816);
+                (mat.emissive as THREE.Color).setHex(active ? 0x4a3a22 : 0x000000);
+                mat.emissiveIntensity = active ? 0.4 : 0;
+                ((fb.mesh.userData.edges as THREE.LineSegments).material as THREE.LineBasicMaterial)
+                    .color.setHex(active ? 0xFFC061 : 0x3a3731);
+                if (active) {
+                    const phase = now * 0.0009 + fb.x * 0.05;
+                    const target = 1 + Math.sin(phase) * 0.1 + Math.sin(phase * 2.3 + fb.z) * 0.06;
+                    fb.mesh.scale.y += (target - fb.mesh.scale.y) * 0.06;
+                }
+            });
+
+            Object.entries(pipeMeshes).forEach(([id, mesh]) => {
+                const livePipe = live.pipelinesById.get(id);
+                const pps = livePipe?.pps ?? 0;
+                const active = pps > 0;
+                const intensity = Math.min(1, pps / 30e6);
+                const color = active
+                    ? new THREE.Color().setHSL(0.07, 0.45, 0.16 + intensity * 0.06).getHex()
+                    : 0x1a1816;
+                const edgeColor = active ? 0xFFC061 : 0x3a3731;
+                const mat = mesh.material as THREE.MeshLambertMaterial;
+                mat.color.setHex(color);
+                const edgesMat = (mesh.userData.edges as THREE.LineSegments).material as THREE.LineBasicMaterial;
+                edgesMat.color.setHex(edgeColor);
+                edgesMat.opacity = active ? 0.7 : 0.5;
+                mesh.userData.baseColor = color;
+                mesh.userData.edgeColor = edgeColor;
+            });
+
+            Object.entries(deviceMeshes).forEach(([id, mesh]) => {
+                const liveDev = live.devicesById.get(id);
+                const active = liveDev?.status === 'ok' && (liveDev?.rxPps ?? 0) > 0;
+                const isVlan = (mesh.userData as { isVlan?: boolean }).isVlan ?? false;
+                const color = active ? (isVlan ? 0x4a607a : 0x70533a) : 0x1d1b18;
+                const edgeColor = active ? (isVlan ? 0x88a8c4 : 0xFFC061) : 0x3a3731;
+                const mat = mesh.material as THREE.MeshLambertMaterial;
+                mat.color.setHex(color);
+                ((mesh.userData.edges as THREE.LineSegments).material as THREE.LineBasicMaterial)
+                    .color.setHex(edgeColor);
+                mesh.userData.baseColor = color;
+                mesh.userData.edgeColor = edgeColor;
+            });
+
+            wires.forEach((w) => {
+                const liveDev = live.devicesById.get(w.deviceId);
+                const active = liveDev?.status === 'ok' && (liveDev?.rxPps ?? 0) > 0;
+                const wireMat = w.line.material as THREE.LineBasicMaterial;
+                wireMat.color.setHex(active ? 0xFFC061 : 0x3a3731);
+                wireMat.opacity = active ? 0.55 : 0.3;
+            });
+
+            if (fwdPS.points && fwdPS.geo) {
+                const positions = fwdPS.geo.attributes['position'].array as Float32Array;
+                fwdPS.ps.forEach((p) => {
+                    p.t += p.speed * 4;
+                    if (p.t > 1) p.t -= 1;
+                    const path = fwdPaths[p.pi];
+                    if (!path) return;
+                    const target = p.t * path.total;
+                    let acc = 0;
+                    let pt = path.pts[0];
+                    for (let i = 1; i < path.pts.length; i++) {
+                        const l = path.lens[i - 1];
+                        if (acc + l >= target) {
+                            const u = (target - acc) / l;
+                            tmpV.copy(path.pts[i - 1]).lerp(path.pts[i], u);
+                            pt = tmpV;
+                            break;
+                        }
+                        acc += l;
+                    }
+                    positions[p.posIdx * 3 + 0] = pt.x;
+                    positions[p.posIdx * 3 + 1] = pt.y;
+                    positions[p.posIdx * 3 + 2] = pt.z;
+                });
+                fwdPS.geo.attributes['position'].needsUpdate = true;
+            }
+
+            renderer.render(scene, camera);
+
+            if (now - lastLabelTick > 33) {
+                lastLabelTick = now;
+                const out: LabelInfo[] = [];
+                const { w: vw, h: vh } = canvasSizeRef.current;
+                labelSources.forEach((l) => {
+                    const wp = l.worldPos();
+                    wp.project(camera);
+                    if (wp.z < -1 || wp.z > 1) return;
+                    const sx = (wp.x * 0.5 + 0.5) * vw;
+                    const sy = (-wp.y * 0.5 + 0.5) * vh;
+                    if (sx < -50 || sx > vw + 50 || sy < -20 || sy > vh + 20) return;
+                    let subtext = '';
+                    let active = false;
+                    if (l.kind === 'device') {
+                        const liveDev = liveRef.current.devicesById.get(l.id);
+                        subtext = `${fmtPps(liveDev?.rxPps ?? 0)} pps`;
+                        active = liveDev?.status === 'ok';
+                    } else if (l.kind === 'pipeline') {
+                        const livePipe = liveRef.current.pipelinesById.get(l.id);
+                        subtext = fmtPps(livePipe?.pps ?? 0);
+                        active = livePipe?.status === 'ok';
+                    } else if (l.kind === 'fn') {
+                        const liveFn = liveRef.current.functionsById.get(l.id);
+                        subtext = fmtPps(liveFn?.pps ?? 0);
+                        active = liveFn?.status === 'ok';
+                    }
+                    out.push({ ...l, sx, sy, subtext, active });
+                });
+                setLabels(out);
+            }
+
+            raf = requestAnimationFrame(animate);
+        };
+        raf = requestAnimationFrame(animate);
+
+        return () => {
+            cancelled = true;
+            cancelAnimationFrame(raf);
+            renderer.domElement.removeEventListener('pointerup', onPointerUp);
+            renderer.domElement.removeEventListener('pointermove', onPointerMove);
+            scene.traverse((obj) => {
+                if ('geometry' in obj && (obj as unknown as { geometry?: { dispose?: () => void } }).geometry?.dispose) {
+                    (obj as unknown as { geometry: { dispose: () => void } }).geometry.dispose();
+                }
+                const material = (obj as unknown as { material?: unknown }).material;
+                if (Array.isArray(material)) {
+                    material.forEach((m: { dispose?: () => void }) => m.dispose?.());
+                } else if (material && typeof (material as { dispose?: () => void }).dispose === 'function') {
+                    (material as { dispose: () => void }).dispose();
+                }
+            });
+            if (fwdPS.geo) fwdPS.geo.dispose();
+            renderer.dispose();
+            renderer.forceContextLoss?.();
+            if (mount && mount.contains(renderer.domElement)) {
+                mount.removeChild(renderer.domElement);
+            }
+            threeRef.current = {
+                scene: null,
+                camera: null,
+                renderer: null,
+                pickGroup: null,
+                deviceMeshes: {},
+                pipeMeshes: {},
+                fnMeshes: [],
+                fwdPS: { points: null, ps: [], geo: null },
+                fwdPaths: [],
+                labelSources: [],
+                wires: [],
+                sceneCenter: null,
+            };
+        };
+    }, [webglAvailable, structuralDevices, structuralPipelines, structuralFunctions]);
+
+    useEffect(() => {
+        const r = threeRef.current;
+        if (!r.pickGroup) return;
+
+        const isRelated = (kind: string, id: string): boolean => {
+            if (!selected) return true;
+            if (selected.kind === kind && selected.id === id) return true;
+            if (selected.kind === 'device') {
+                const d = structuralDevices.find((x) => x.id === selected.id);
+                if (!d) return false;
+                if (kind === 'pipeline') return d.pipeIn === id || d.pipeOut === id;
+                if (kind === 'fn') {
+                    const pIn = structuralPipelines.find((p) => p.id === d.pipeIn);
+                    const pOut = structuralPipelines.find((p) => p.id === d.pipeOut);
+                    return (
+                        (pIn !== undefined && pIn.fns.includes(id)) ||
+                        (pOut !== undefined && pOut.fns.includes(id))
+                    );
+                }
+                return false;
+            }
+            if (selected.kind === 'pipeline') {
+                const p = structuralPipelines.find((x) => x.id === selected.id);
+                if (!p) return false;
+                if (kind === 'fn') return p.fns.includes(id);
+                if (kind === 'device') {
+                    return structuralDevices.some(
+                        (d) => (d.pipeIn === selected.id || d.pipeOut === selected.id) && d.id === id,
+                    );
+                }
+                return false;
+            }
+            if (selected.kind === 'fn') {
+                if (kind === 'pipeline') {
+                    return structuralPipelines.find((x) => x.id === id)?.fns.includes(selected.id) ?? false;
+                }
+                return false;
+            }
+            return false;
+        };
+
+        r.pickGroup.children.forEach((m) => {
+            const mesh = m as THREE.Mesh;
+            const ud = mesh.userData as {
+                kind: string;
+                id: string;
+                baseColor: number;
+                edgeColor: number;
+                edges: THREE.LineSegments;
+            };
+            const rel = isRelated(ud.kind, ud.id);
+            const isSel = selected ? ud.kind === selected.kind && ud.id === selected.id : false;
+            const mat = mesh.material as THREE.MeshLambertMaterial;
+            mat.opacity = selected ? (rel ? 0.95 : 0.18) : 0.95;
+            if (ud.edges) {
+                const edgeMat = ud.edges.material as THREE.LineBasicMaterial;
+                edgeMat.opacity = selected
+                    ? rel ? 0.95 : 0.10
+                    : ud.edgeColor === 0x3a3731 ? 0.5 : 0.75;
+                edgeMat.color.setHex(isSel ? 0xe8e4d8 : ud.edgeColor);
+            }
+            if (mat.emissive) {
+                mat.emissive.setHex(
+                    isSel ? 0xFFC061 : ud.kind === 'fn' && ud.baseColor === 0x5a4632 ? 0x4a3a22 : 0x000000,
+                );
+                mat.emissiveIntensity = isSel
+                    ? 0.6
+                    : ud.kind === 'fn' && ud.baseColor === 0x5a4632 ? 0.4 : 0;
+            }
+        });
+
+        r.wires.forEach((w) => {
+            const rel = isRelated('device', w.deviceId) && isRelated('pipeline', w.pipeId);
+            (w.line.material as THREE.LineBasicMaterial).opacity = selected ? (rel ? 0.7 : 0.06) : 0.4;
+        });
+    }, [selected, structuralDevices, structuralPipelines, structuralFunctions]);
+
+    const unsupported = webglAvailable === false || rendererError;
+    const loading = webglAvailable === null;
+
+    return (
+        <div ref={containerRef} className="dash-scene-container">
+            <div className="dash-scene-horizon" />
+            {!unsupported && <div ref={canvasMountRef} className="dash-scene-canvas" />}
+            {unsupported && (
+                <div className="dash-scene-fallback">
+                    <div className="dash-scene-fallback__title">3D view unavailable</div>
+                    <div className="dash-scene-fallback__hint">
+                        WebGL is required to render the isometric topology but could not be
+                        initialised in this environment.
+                    </div>
+                    <div className="dash-scene-fallback__hint">
+                        Use the standard{' '}
+                        <a className="dash-scene-fallback__link" href="/builtin/inspect">
+                            Inspect
+                        </a>{' '}
+                        view instead.
+                    </div>
+                </div>
+            )}
+            {loading && (
+                <div className="dash-scene-fallback">
+                    <div className="dash-scene-fallback__hint">loading 3d engine…</div>
+                </div>
+            )}
+            <div className="dash-label-overlay">
+                {!unsupported && labels.map((l, i) => (
+                    <SceneLabel key={`${l.kind}-${l.id}-${i}`} l={l} />
+                ))}
+            </div>
+            {selected && !unsupported && (
+                <Inspector
+                    selected={selected}
+                    onClose={() => setSelected(null)}
+                    structuralDevices={structuralDevices}
+                    structuralPipelines={structuralPipelines}
+                    structuralFunctions={structuralFunctions}
+                    live={liveRef.current}
+                />
+            )}
+        </div>
+    );
+};
+
+/** A projected HTML label for a scene object. */
+const SceneLabel: React.FC<{ l: LabelInfo }> = ({ l }) => {
+    if (l.kind === 'pipeline') {
+        return (
+            <div
+                className={`dash-label--pipeline${l.active ? ' dash-label--pipeline-active' : ''}`}
+                style={{ left: l.sx - 60, top: l.sy - 9 }}
+            >
+                <span
+                    className="dash-dot"
+                    style={{
+                        width: 5,
+                        height: 5,
+                        background: l.active ? 'var(--iv-ok)' : 'var(--iv-idle)',
+                    }}
+                />
+                <span>{l.text}</span>
+            </div>
+        );
+    }
+    if (l.kind === 'device') {
+        return (
+            <div
+                className="dash-label--device"
+                style={{ left: l.sx - 90, top: l.sy - 10 }}
+            >
+                <div>{l.text}</div>
+                <div className="dash-label--device-sub">{l.subtext}</div>
+            </div>
+        );
+    }
+    if (l.kind === 'fn') {
+        return (
+            <div
+                className="dash-label--fn"
+                style={{ left: l.sx - 60, top: l.sy - 22 }}
+            >
+                <div className={l.active ? 'dash-label--fn-active' : 'dash-label--fn-idle'}>
+                    {l.text}
+                </div>
+                <div className="dash-label--fn-sub">{l.subtext}</div>
+            </div>
+        );
+    }
+    return null;
+};

--- a/web/src/pages/builtin/dashboard/KpiStrip.tsx
+++ b/web/src/pages/builtin/dashboard/KpiStrip.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type { InstanceInfo } from '../../../api/inspect';
+
+export interface KpiStripProps {
+    instance: InstanceInfo;
+}
+
+/** Compact horizontal strip of device/pipeline/function/module/config counts. */
+export const KpiStrip: React.FC<KpiStripProps> = ({ instance }) => {
+    const devices = instance.devices ?? [];
+    const pipelines = instance.pipelines ?? [];
+    const functions = instance.functions ?? [];
+    const modules = instance.dp_modules ?? [];
+    const configs = instance.cp_configs ?? [];
+
+    return (
+        <div className="dash-kpi-counts">
+            <div className="dash-kpi-counts__cell">
+                <span className="dash-kpi-counts__label">DEVICES</span>
+                <span className="dash-kpi-counts__value">{devices.length}</span>
+            </div>
+            <div className="dash-kpi-counts__cell">
+                <span className="dash-kpi-counts__label">PIPELINES</span>
+                <span className="dash-kpi-counts__value">{pipelines.length}</span>
+            </div>
+            <div className="dash-kpi-counts__cell">
+                <span className="dash-kpi-counts__label">FUNCTIONS</span>
+                <span className="dash-kpi-counts__value">{functions.length}</span>
+            </div>
+            <div className="dash-kpi-counts__cell">
+                <span className="dash-kpi-counts__label">MODULES</span>
+                <span className="dash-kpi-counts__value">{modules.length}</span>
+            </div>
+            <div className="dash-kpi-counts__cell">
+                <span className="dash-kpi-counts__label">CONFIGS</span>
+                <span className="dash-kpi-counts__value">{configs.length}</span>
+            </div>
+        </div>
+    );
+};

--- a/web/src/pages/builtin/dashboard/SceneErrorBoundary.tsx
+++ b/web/src/pages/builtin/dashboard/SceneErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+interface SceneErrorBoundaryProps {
+    children: React.ReactNode;
+}
+
+interface SceneErrorBoundaryState {
+    hasError: boolean;
+}
+
+/**
+ * Catches unhandled exceptions thrown by the three.js scene so a WebGL
+ * failure or runtime crash does not bring down the rest of the page.
+ */
+export class SceneErrorBoundary extends React.Component<
+    SceneErrorBoundaryProps,
+    SceneErrorBoundaryState
+> {
+    state: SceneErrorBoundaryState = { hasError: false };
+
+    static getDerivedStateFromError(): SceneErrorBoundaryState {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error): void {
+        console.error('IsoScene3D crashed:', error);
+    }
+
+    render(): React.ReactNode {
+        if (this.state.hasError) {
+            return (
+                <div className="dash-scene-container">
+                    <div className="dash-scene-fallback">
+                        <div className="dash-scene-fallback__title">3D view unavailable</div>
+                        <div className="dash-scene-fallback__hint">
+                            The 3D scene failed to initialise. WebGL may not be
+                            supported in this environment.
+                        </div>
+                        <div className="dash-scene-fallback__hint">
+                            Use the standard{' '}
+                            <a className="dash-scene-fallback__link" href="/builtin/inspect">
+                                Inspect
+                            </a>{' '}
+                            view instead.
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+        return this.props.children;
+    }
+}

--- a/web/src/pages/builtin/dashboard/SystemState.tsx
+++ b/web/src/pages/builtin/dashboard/SystemState.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface Pair {
+    key: string;
+    value: React.ReactNode;
+    valueClassName?: string;
+}
+
+export interface SystemStateProps {
+    workerCount?: number | null;
+}
+
+/** System-level status card. Fields without real API values render "—". */
+export const SystemState: React.FC<SystemStateProps> = ({ workerCount }) => {
+    const pairs: Pair[] = [
+        { key: 'uptime',       value: '—' },
+        { key: 'workers',      value: workerCount != null ? String(workerCount) : '—' },
+        { key: 'controlplane', value: 'reachable', valueClassName: 'dash-system__ok' },
+    ];
+
+    return (
+        <div className="dash-system">
+            <div className="dash-system__label">SYSTEM STATE</div>
+            <div className="dash-system__pairs">
+                {pairs.map((p) => (
+                    <div key={p.key} className="dash-system__pair">
+                        <span className="dash-system__key">{p.key}</span>
+                        <span className={p.valueClassName ?? 'dash-system__val'}>{p.value}</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};

--- a/web/src/pages/builtin/dashboard/Throughput.tsx
+++ b/web/src/pages/builtin/dashboard/Throughput.tsx
@@ -1,0 +1,50 @@
+import React, { useMemo } from 'react';
+import type { DeviceCounterData } from '../../../hooks';
+import { useRollingSeries } from '../inspect/hooks';
+import { Sparkline } from '../inspect/Sparkline';
+import { fmtBps, fmtPps } from '../inspect/formatters';
+
+export interface ThroughputProps {
+    rateCounters: Map<string, DeviceCounterData>;
+    physicalDeviceNames: Set<string>;
+}
+
+/** Aggregate throughput hero with a full-width sparkline beneath. */
+export const Throughput: React.FC<ThroughputProps> = ({ rateCounters, physicalDeviceNames }) => {
+    const { aggregatePps, aggregateBps } = useMemo(() => {
+        let pps = 0;
+        let bps = 0;
+        rateCounters.forEach((d, name) => {
+            if (!physicalDeviceNames.has(name)) return;
+            pps += d.rx?.pps ?? 0;
+            bps += d.rx?.bps ?? 0;
+        });
+        return { aggregatePps: pps, aggregateBps: bps };
+    }, [rateCounters, physicalDeviceNames]);
+
+    const throughputSeries = useRollingSeries(aggregatePps, 60);
+
+    return (
+        <div className="dash-throughput">
+            <div className="dash-throughput__top">
+                <span className="dash-throughput__label">THROUGHPUT</span>
+                <span className="dash-throughput__row">
+                    <span className="dash-throughput__big">{fmtBps(aggregateBps)}</span>
+                    <span className="dash-throughput__unit">bps</span>
+                    <span className="dash-throughput__sep">·</span>
+                    <span className="dash-throughput__pps">
+                        {fmtPps(aggregatePps)}{' '}
+                        <span className="dash-throughput__pps-unit">pps</span>
+                    </span>
+                </span>
+            </div>
+            <Sparkline
+                data={throughputSeries}
+                color="var(--iv-accent)"
+                fill
+                w={720}
+                h={36}
+            />
+        </div>
+    );
+};

--- a/web/src/pages/builtin/dashboard/dashboard.scss
+++ b/web/src/pages/builtin/dashboard/dashboard.scss
@@ -1,0 +1,669 @@
+@mixin dash-ambient-scan {
+    position: relative;
+    overflow: hidden;
+
+    &::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background-image: repeating-linear-gradient(
+            0deg,
+            color-mix(in srgb, var(--iv-text) 2.5%, transparent) 0 1px,
+            transparent 1px 4px
+        );
+        z-index: 0;
+    }
+
+    > * {
+        position: relative;
+        z-index: 1;
+    }
+}
+
+.dashboard-page {
+    // Warm dark-brown palette, mirrored from .inspect-page.
+    --iv-bg:             #15110D;
+    --iv-bg-2:           #181410;
+    --iv-surface:        #1C1814;
+    --iv-surface-strong: #1C1814;
+    --iv-bg-3:           #221C16;
+    --iv-border:         rgba(255, 199, 140, 0.02);
+    --iv-border-strong:  rgba(255, 200, 140, 0.12);
+    --iv-text:           #F2EEE8;
+    --iv-text-dim:       #B8B0A4;
+    --iv-mute:           #7E7468;
+    --iv-dim:            #7E7468;
+    --iv-accent:         #FFC061;
+    --iv-accent-soft:    rgba(255, 192, 97, 0.14);
+    --iv-accent-line:    rgba(255, 192, 97, 0.4);
+    --iv-link:           var(--g-color-text-info);
+    --iv-ok:             var(--g-color-text-positive);
+    --iv-idle:           var(--g-color-text-hint);
+    --iv-danger:         var(--g-color-text-danger);
+    --iv-mono:           'JetBrains Mono', ui-monospace, monospace;
+    --iv-font-ui:        'Inter', system-ui, sans-serif;
+
+    font-family: var(--iv-mono);
+    color: var(--iv-text);
+    background: var(--iv-bg);
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    min-height: 100%;
+    overflow-y: auto;
+
+    .dash-scroll {
+        scrollbar-width: thin;
+        scrollbar-color: var(--iv-border-strong) transparent;
+
+        &::-webkit-scrollbar {
+            width: 6px;
+            height: 6px;
+        }
+
+        &::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background: var(--iv-border-strong);
+        }
+
+        &::-webkit-scrollbar-thumb:hover {
+            background: var(--iv-accent-line);
+        }
+    }
+
+    // ── Scene Container ───────────────────────────────────────────────
+
+    .dash-scene-container {
+        position: relative;
+        height: 620px;
+        background: linear-gradient(180deg, rgba(20,18,16,0.7) 0%, rgba(13,13,12,0.9) 100%);
+        border: 1px solid var(--iv-border-strong);
+        overflow: hidden;
+        flex-shrink: 0;
+    }
+
+    .dash-scene-canvas {
+        position: absolute;
+        inset: 0;
+    }
+
+    .dash-scene-horizon {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        background: linear-gradient(180deg, rgba(255,192,97,0.06) 0%, rgba(255,192,97,0) 55%);
+    }
+
+    .dash-label-overlay {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        overflow: hidden;
+    }
+
+    .dash-scene-fallback {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        text-align: center;
+        padding: 40px;
+        color: var(--iv-text-dim);
+        pointer-events: auto;
+
+        &__title {
+            color: var(--iv-text);
+            font-size: 16px;
+            font-weight: 500;
+            letter-spacing: 0.4px;
+        }
+
+        &__hint {
+            color: var(--iv-mute);
+            font-size: 12px;
+            max-width: 520px;
+            line-height: 1.5;
+        }
+
+        &__link {
+            color: var(--iv-accent);
+            text-decoration: none;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+    }
+
+    .dash-label--pipeline {
+        position: absolute;
+        padding: 0 6px;
+        height: 18px;
+        background: rgba(13,13,12,0.85);
+        border: 1px solid var(--iv-border-strong);
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 10px;
+        color: var(--iv-text);
+        font-weight: 500;
+        pointer-events: none;
+    }
+
+    .dash-label--pipeline-active {
+        border-color: var(--iv-accent-soft);
+    }
+
+    .dash-label--device {
+        position: absolute;
+        width: 88px;
+        text-align: right;
+        color: var(--iv-text);
+        font-size: 9px;
+        line-height: 1.25;
+        pointer-events: none;
+        text-shadow: 0 1px 0 rgba(0,0,0,0.6);
+    }
+
+    .dash-label--device-sub {
+        color: var(--iv-mute);
+        font-size: 8px;
+    }
+
+    .dash-label--fn {
+        position: absolute;
+        width: 120px;
+        text-align: center;
+        color: var(--iv-text);
+        font-size: 9px;
+        line-height: 1.25;
+        pointer-events: none;
+        text-shadow: 0 1px 0 rgba(0,0,0,0.6);
+    }
+
+    .dash-label--fn-active {
+        color: var(--iv-text);
+        font-weight: 500;
+    }
+
+    .dash-label--fn-idle {
+        color: var(--iv-mute);
+        font-weight: 500;
+    }
+
+    .dash-label--fn-sub {
+        color: var(--iv-text-dim);
+        font-size: 8px;
+    }
+
+    // ── Inspector Panel ───────────────────────────────────────────────
+
+    .dash-inspector {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        bottom: 12px;
+        width: 296px;
+        background: rgba(13,13,12,0.94);
+        border: 1px solid var(--iv-border-strong);
+        border-left: 2px solid var(--iv-accent);
+        box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+        display: flex;
+        flex-direction: column;
+        font-size: 12px;
+        color: var(--iv-text);
+        overflow: hidden;
+        z-index: 10;
+    }
+
+    .dash-inspector__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 10px 14px;
+        border-bottom: 1px solid var(--iv-border-strong);
+        color: var(--iv-mute);
+        font-size: 10px;
+        letter-spacing: 1.8px;
+        flex-shrink: 0;
+    }
+
+    .dash-inspector__close {
+        background: transparent;
+        border: none;
+        color: var(--iv-mute);
+        cursor: pointer;
+        font: inherit;
+        font-size: 14px;
+        line-height: 1;
+        padding: 0;
+
+        &:hover {
+            color: var(--iv-text);
+        }
+    }
+
+    .dash-inspector__body {
+        overflow: auto;
+        padding: 12px 14px;
+        flex: 1;
+        scrollbar-width: thin;
+        scrollbar-color: var(--iv-border-strong) transparent;
+    }
+
+    .dash-insp-name {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 6px;
+    }
+
+    .dash-insp-name__text {
+        font-size: 15px;
+        font-weight: 500;
+    }
+
+    .dash-insp-sub {
+        color: var(--iv-mute);
+        font-size: 11px;
+        margin-bottom: 10px;
+    }
+
+    .dash-stat-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        padding: 4px 0;
+        border-bottom: 1px dotted var(--iv-border-strong);
+    }
+
+    .dash-stat-row__label {
+        color: var(--iv-mute);
+        font-size: 10px;
+        letter-spacing: 1px;
+    }
+
+    .dash-stat-row__value {
+        color: var(--iv-text);
+        font-size: 12px;
+    }
+
+    .dash-stat-row__hint {
+        color: var(--iv-mute);
+        font-size: 10px;
+        margin-left: 4px;
+    }
+
+    .dash-section-header {
+        margin-top: 12px;
+        margin-bottom: 6px;
+        color: var(--iv-mute);
+        font-size: 10px;
+        letter-spacing: 1.6px;
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+    }
+
+    .dash-section-header__count {
+        color: var(--iv-text-dim);
+    }
+
+    .dash-chain-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 4px 6px;
+        border: 1px solid var(--iv-border-strong);
+        background: rgba(20,18,16,0.4);
+        margin-bottom: 4px;
+    }
+
+    .dash-chain-item__idx {
+        color: var(--iv-mute);
+        font-size: 10px;
+        font-family: monospace;
+    }
+
+    .dash-chain-item__name {
+        flex: 1;
+        font-size: 11px;
+    }
+
+    .dash-chain-item__pps {
+        font-size: 10px;
+        color: var(--iv-text-dim);
+    }
+
+    .dash-feed-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 11px;
+        margin-bottom: 4px;
+    }
+
+    .dash-feed-item__name {
+        flex: 1;
+    }
+
+    .dash-feed-item__pps {
+        color: var(--iv-text-dim);
+        font-size: 10px;
+    }
+
+    .dash-dot {
+        display: inline-block;
+        flex-shrink: 0;
+        border-radius: 50%;
+    }
+
+    .dash-sparkline-wrap {
+        margin-top: 6px;
+    }
+
+    .dash-top-row {
+        display: flex;
+        flex-direction: row;
+        gap: 10px;
+        align-items: stretch;
+        flex-wrap: wrap;
+        flex-shrink: 0;
+    }
+
+    .dash-top-row__left {
+        flex: 1 1 0;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        min-width: 0;
+    }
+
+    .dash-top-row__right {
+        flex: 1.3 1 0;
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+    }
+}
+
+// ── Light-mode palette overrides ──────────────────────────────────────────────
+
+[data-theme="light"] {
+    .dashboard-page {
+        --iv-bg:             #FAF7F2;
+        --iv-bg-2:           #F3EFE9;
+        --iv-surface:        #FFFFFF;
+        --iv-surface-strong: #FFFFFF;
+        --iv-bg-3:           #EBE6DE;
+        --iv-border:         rgba(80, 60, 30, 0.08);
+        --iv-border-strong:  rgba(80, 60, 30, 0.16);
+        --iv-text:           #1A1410;
+        --iv-text-dim:       #5C4E3A;
+        --iv-mute:           #9C8B74;
+        --iv-dim:            #9C8B74;
+    }
+}
+
+// ── Throughput card ───────────────────────────────────────────────────────────
+
+.dash-throughput {
+    @include dash-ambient-scan;
+
+    border: 1px solid var(--iv-border-strong);
+    background: var(--iv-surface);
+    padding: 12px 18px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1;
+    min-width: 0;
+
+    &__top {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 18px;
+    }
+
+    &__label {
+        color: var(--iv-mute);
+        font-size: 10px;
+        letter-spacing: 1.6px;
+        flex-shrink: 0;
+    }
+
+    &__row {
+        display: inline-flex;
+        align-items: baseline;
+        gap: 10px;
+    }
+
+    &__big {
+        font-size: 14px;
+        font-weight: 500;
+        letter-spacing: -0.2px;
+        color: var(--iv-text);
+        font-variant-numeric: tabular-nums;
+    }
+
+    &__unit {
+        color: var(--iv-mute);
+        font-size: 11px;
+    }
+
+    &__sep {
+        color: var(--iv-mute);
+        font-size: 13px;
+    }
+
+    &__pps {
+        color: var(--iv-accent);
+        font-size: 14px;
+        font-weight: 500;
+        font-variant-numeric: tabular-nums;
+    }
+
+    &__pps-unit {
+        color: var(--iv-mute);
+        font-size: 11px;
+    }
+
+    svg {
+        display: block;
+        width: 100%;
+        height: auto;
+        max-width: 100%;
+        max-height: 56px;
+        opacity: 0.55;
+        margin-top: auto;
+    }
+}
+
+// ── Compact count strip ───────────────────────────────────────────────────────
+
+.dash-kpi-counts {
+    @include dash-ambient-scan;
+
+    border: 1px solid var(--iv-border-strong);
+    background: var(--iv-surface);
+    padding: 8px 18px;
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 28px;
+    row-gap: 4px;
+    flex-shrink: 0;
+}
+
+.dash-kpi-counts__cell {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 6px;
+    font-size: 12px;
+}
+
+.dash-kpi-counts__label {
+    color: var(--iv-mute);
+    letter-spacing: 1.6px;
+    font-size: 10px;
+}
+
+.dash-kpi-counts__value {
+    color: var(--iv-text);
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+}
+
+// ── Dataplane modules ─────────────────────────────────────────────────────────
+
+.dash-modules {
+    border: 1px solid var(--iv-border-strong);
+    background: var(--iv-surface);
+    padding: 12px 18px;
+
+    &__head {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        margin-bottom: 10px;
+        color: var(--iv-mute);
+        font-size: 10px;
+        letter-spacing: 1.6px;
+    }
+
+    &__grid {
+        display: grid;
+        gap: 8px;
+    }
+}
+
+.dash-module-card {
+    cursor: not-allowed;
+    border: 1px solid var(--iv-border-strong);
+    border-left: 2px solid var(--iv-dim);
+    background: var(--iv-bg-3);
+    padding: 8px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    transition: border-color 0.12s;
+
+    &--active {
+        border-left-color: var(--iv-accent);
+    }
+
+    &--clickable {
+        cursor: pointer;
+
+        &:hover {
+            border-top-color: var(--iv-text-dim);
+            border-right-color: var(--iv-text-dim);
+            border-bottom-color: var(--iv-text-dim);
+        }
+
+        &:focus-visible {
+            outline: 1px solid var(--iv-accent);
+            outline-offset: 1px;
+        }
+    }
+
+    &__top {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    &__name {
+        font-size: 11px;
+        font-weight: 500;
+    }
+
+    &__desc {
+        font-size: 9px;
+        color: var(--iv-mute);
+    }
+
+    &__stats {
+        font-size: 9px;
+        color: var(--iv-text-dim);
+    }
+}
+
+// ── System state strip ────────────────────────────────────────────────────────
+
+.dash-system {
+    @include dash-ambient-scan;
+
+    border: 1px solid var(--iv-border-strong);
+    background: var(--iv-surface);
+    padding: 12px 18px 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex-shrink: 0;
+    min-width: 0;
+}
+
+.dash-system__label {
+    color: var(--iv-mute);
+    font-size: 10px;
+    letter-spacing: 1.6px;
+    flex-shrink: 0;
+}
+
+.dash-system__pairs {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    column-gap: 18px;
+    row-gap: 4px;
+    font-size: 12px;
+}
+
+.dash-system__pair {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    min-width: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+}
+
+.dash-system__key {
+    color: var(--iv-mute);
+    flex-shrink: 0;
+}
+
+.dash-system__val {
+    color: var(--iv-text);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dash-system__ok {
+    color: var(--iv-ok);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.dash-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--iv-idle);
+    display: inline-block;
+    flex-shrink: 0;
+
+    &--ok { background: var(--iv-ok); }
+}

--- a/web/src/pages/builtin/dashboard/hooks.ts
+++ b/web/src/pages/builtin/dashboard/hooks.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { API } from '../../../api';
+
+/**
+ * Infer total worker count from a device counter response. Each counter
+ * instance corresponds to one dataplane (NUMA) instance, and each value
+ * slot in `values[]` corresponds to one worker on that instance. Polling
+ * a single device is enough — every counter is sized the same way.
+ *
+ * Returns null while the first fetch is in flight, or if no device names
+ * are available, or on error.
+ */
+export const useWorkerCount = (deviceNames: string[]): number | null => {
+    const [count, setCount] = useState<number | null>(null);
+    const firstDevice = deviceNames[0] ?? '';
+
+    useEffect(() => {
+        if (!firstDevice) {
+            setCount(null);
+            return;
+        }
+        let cancelled = false;
+        (async () => {
+            try {
+                const resp = await API.counters.device({ device: firstDevice });
+                const counter = resp.counters?.[0];
+                if (!counter?.instances) {
+                    if (!cancelled) setCount(null);
+                    return;
+                }
+                let total = 0;
+                for (const inst of counter.instances) {
+                    total += inst.values?.length ?? 0;
+                }
+                if (!cancelled) setCount(total > 0 ? total : null);
+            } catch {
+                if (!cancelled) setCount(null);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [firstDevice]);
+
+    return count;
+};

--- a/web/src/pages/builtin/dashboard/index.ts
+++ b/web/src/pages/builtin/dashboard/index.ts
@@ -1,0 +1,10 @@
+export { InstanceCard } from './InstanceCard';
+export { IsoScene3D } from './IsoScene3D';
+export { Inspector } from './Inspector';
+export { KpiStrip } from './KpiStrip';
+export { Throughput } from './Throughput';
+export { SystemState } from './SystemState';
+export { DataplaneModules } from './DataplaneModules';
+export { SceneErrorBoundary } from './SceneErrorBoundary';
+export type { StructuralDevice, StructuralPipeline, StructuralFunction, SelectedItem, LiveSnapshot } from './Inspector';
+export { default } from './DashboardPage';

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 
 export const PAGE_IDS = [
     'builtin/inspect',
+    'builtin/dashboard',
     'builtin/functions',
     'builtin/pipelines',
     'builtin/devices',


### PR DESCRIPTION
Adds a new /builtin/dashboard page and makes it the application's landing page (root / redirects there). The page renders the real instance data as an isometric three.js topology where device boxes feed parallel pipeline lanes and function blocks sit on top of those lanes. Hovering a clickable element shows a pointer cursor; clicking opens a side inspector with rates, status and a trend sparkline.

- Camera is locked to the isometric view (no rotation, zoom or pan); pointer-move raycasts only to update cursor state.
- Scene rebuilds only when the structural data (device/pipeline/function identities) changes, never on counter ticks, so the WebGL context is created once per page lifetime. Live rates and trends feed the animation loop through a ref.
- Falls back to a friendly "WebGL unavailable" panel and an error boundary if the browser cannot create a WebGL context.
- Top region: system state strip (uptime / workers / controlplane status, with worker count inferred from the first device's counter response), compact KPI counts strip, and a throughput hero with aggregate bps/pps and a sparkline pinned to the card's bottom.
- Bottom region: dataplane modules grid with deep-link navigation to the corresponding module pages; modules without a page show the non-clickable cursor.
- All three top cards share a subtle ambient horizontal-scan overlay; sharp rectangular corners; warm dark-brown palette consistent with the /builtin/inspect HUD page; light-theme override scoped under .dashboard-page.
- The dashboard is not listed in the sidebar; the AsideHeader logo button navigates to it via React Router (with href fallback for middle-click open in new tab).
- three and @types/three added as dependencies; the page chunk is lazy-loaded.
- The existing /builtin/inspect HUD page remains unchanged.