### PR TITLE
fix(web/dashboard): drop dead cancelled flag in WebGL pre-flight effect

### DIFF
--- a/web/src/pages/builtin/dashboard/IsoScene3D.tsx
+++ b/web/src/pages/builtin/dashboard/IsoScene3D.tsx
@@ -359,7 +359,6 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
     canvasSizeRef.current = canvasSize;
 
     useEffect(() => {
-        let cancelled = false;
         const check = (): boolean => {
             try {
                 const canvas = document.createElement('canvas');
@@ -372,12 +371,7 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
                 return false;
             }
         };
-        if (!cancelled) {
-            setWebglAvailable(check());
-        }
-        return () => {
-            cancelled = true;
-        };
+        setWebglAvailable(check());
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
The WebGL pre-flight effect in the dashboard scene was fully synchronous, so the cancelled guard and its cleanup were dead code — the guard always evaluated to true and the cleanup never fired before the state update. Addresses the github-code-quality bot review on #856.