### PR TITLE
feat(dataplane_ut): in-process harness with route and forward functional tests

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -1,0 +1,344 @@
+package dataplaneut
+
+/*
+#cgo CFLAGS: -I../../../
+#cgo CFLAGS: -I../../../lib
+#cgo CFLAGS: -I../../../build/subprojects/dpdk/lib
+#cgo CFLAGS: -I../../../build/lib/dataplane_ut
+
+// Library search paths — modules, devices, and support libs.
+#cgo LDFLAGS: -L../../../build/modules/decap/dataplane
+#cgo LDFLAGS: -L../../../build/modules/dscp/dataplane
+#cgo LDFLAGS: -L../../../build/modules/acl/dataplane
+#cgo LDFLAGS: -L../../../build/modules/fwstate/dataplane
+#cgo LDFLAGS: -L../../../build/modules/forward/dataplane
+#cgo LDFLAGS: -L../../../build/modules/route/dataplane
+#cgo LDFLAGS: -L../../../build/modules/nat64/dataplane
+#cgo LDFLAGS: -L../../../build/modules/pdump/dataplane
+#cgo LDFLAGS: -L../../../build/devices/plain/dataplane
+#cgo LDFLAGS: -L../../../build/devices/vlan/dataplane
+#cgo LDFLAGS: -L../../../build/lib/dataplane_ut
+#cgo LDFLAGS: -L../../../build/lib/dataplane/pipeline
+#cgo LDFLAGS: -L../../../build/lib/dataplane/module
+#cgo LDFLAGS: -L../../../build/lib/dataplane/worker
+#cgo LDFLAGS: -L../../../build/lib/dataplane/config
+#cgo LDFLAGS: -L../../../build/lib/dataplane/packet
+#cgo LDFLAGS: -L../../../build/lib/logging
+#cgo LDFLAGS: -L../../../build/lib/controlplane/agent
+#cgo LDFLAGS: -L../../../build/lib/controlplane/config
+#cgo LDFLAGS: -L../../../build/lib/counters
+#cgo LDFLAGS: -L../../../build/lib/errors
+#cgo LDFLAGS: -L../../../build/filter
+#cgo LDFLAGS: -L../../../build/lib/fwstate
+#cgo LDFLAGS: -L../../../build/lib/utils
+
+// Link all static libs inside a group so the linker resolves circular
+// references between them (fwstate->acl, worker->pipeline, etc.).
+// fwstate depends on acl — acl must come first inside the group.
+#cgo LDFLAGS: -Wl,--start-group
+#cgo LDFLAGS: -ldecap_dp -ldscp_dp -lacl_dp -lfwstate_dp -lforward_dp -lroute_dp -lnat64_dp -lpdump_dp
+#cgo LDFLAGS: -lplain_dp -lvlan_dp
+#cgo LDFLAGS: -ldataplane_ut -lpipeline -lmodule -lworker_dp -lconfig_dp -lpacket
+#cgo LDFLAGS: -llogging -lagent -lconfig_cp -lcounters -lerrors -lfilter_compiler -lfwstate -llib_utils
+#cgo LDFLAGS: -Wl,--end-group
+
+#cgo LDFLAGS: -lnuma
+#cgo LDFLAGS: -ldl
+
+#cgo LDFLAGS: -Wl,-E
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/dataplane/packet/packet.h"
+
+// dataplane_ut_set_hashes writes hashes[i] into the hash field of the
+// i-th packet in list, stopping at count or the end of the list,
+// whichever comes first.
+static void
+dataplane_ut_set_hashes(
+	struct packet_list *list, const uint32_t *hashes, size_t count
+) {
+	struct packet *p = list->first;
+	for (size_t i = 0; i < count && p != NULL; i++) {
+		p->hash = hashes[i];
+		p = p->next;
+	}
+}
+
+// alloc_cptr_array copies n pointers from src (Go-backed) into a fresh
+// C-heap array and returns it.  The caller frees with free_cptr_array.
+static const char **
+alloc_cptr_array(char **src, size_t n) {
+	const char **dst = (const char **)malloc(n * sizeof(char *));
+	if (dst == NULL) {
+		return NULL;
+	}
+	for (size_t i = 0; i < n; i++) {
+		dst[i] = src[i];
+	}
+	return dst;
+}
+
+static void
+free_cptr_array(const char **arr) {
+	free(arr);
+}
+
+void
+keep_refs(void **ptrs) {
+	extern struct module *new_module_decap(void);
+	extern struct module *new_module_dscp(void);
+	extern struct module *new_module_acl(void);
+	extern struct module *new_module_fwstate(void);
+	extern struct module *new_module_forward(void);
+	extern struct module *new_module_route(void);
+	extern struct module *new_module_nat64(void);
+	extern struct module *new_module_pdump(void);
+
+	extern struct device *new_device_plain(void);
+	extern struct device *new_device_vlan(void);
+
+	static void *funcs[] = {
+		new_module_decap,
+		new_module_dscp,
+		new_module_acl,
+		new_module_fwstate,
+		new_module_forward,
+		new_module_route,
+		new_module_nat64,
+		new_module_pdump,
+
+		new_device_plain,
+		new_device_vlan,
+	};
+
+	*ptrs = funcs;
+}
+*/
+import "C"
+import (
+	"fmt"
+	"runtime"
+	"time"
+	"unsafe"
+
+	"github.com/gopacket/gopacket"
+
+	"github.com/yanet-platform/yanet2/common/go/dataplane"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/tests/functional/framework"
+)
+
+// Config holds parameters for constructing a Harness.
+//
+// WorkerCount must be >= 1.
+// Devices, Modules, and DevicesToLoad may be empty.
+type Config struct {
+	CPMemory      uint64
+	DPMemory      uint64
+	WorkerCount   uint64
+	Devices       []string
+	Modules       []string
+	DevicesToLoad []string
+}
+
+// Result of one pipeline round.
+type Result struct {
+	Output []*framework.PacketInfo
+	Drop   []*framework.PacketInfo
+}
+
+// Harness is a handle to an in-process dataplane harness.
+//
+// Never move this object in memory after construction — the underlying C
+// struct holds self-referential pointers.
+type Harness struct {
+	ptr *C.struct_dataplane_ut
+}
+
+// NewHarness constructs a Harness from cfg.
+// Free must be called when the test is done.
+func NewHarness(cfg Config) (*Harness, error) {
+	// Convert Go string slices to C string arrays. The *C.char values are
+	// C-heap strings; toCStringArray returns Go-backed pointer slices, so
+	// we copy the pointers into C-heap arrays to satisfy the CGO rule that
+	// no Go pointer may appear inside a value passed to C.
+	cDevices, freeDevices := toCStringArray(cfg.Devices)
+	defer freeDevices()
+
+	cModules, freeModules := toCStringArray(cfg.Modules)
+	defer freeModules()
+
+	cDevicesToLoad, freeDevicesToLoad := toCStringArray(cfg.DevicesToLoad)
+	defer freeDevicesToLoad()
+
+	cCfg := C.struct_dataplane_ut_config{
+		cp_memory:             C.size_t(cfg.CPMemory),
+		dp_memory:             C.size_t(cfg.DPMemory),
+		worker_count:          C.size_t(cfg.WorkerCount),
+		device_count:          C.size_t(len(cfg.Devices)),
+		module_count:          C.size_t(len(cfg.Modules)),
+		devices_to_load_count: C.size_t(len(cfg.DevicesToLoad)),
+	}
+
+	// Assign C-heap copies of the pointer arrays so the C struct contains
+	// no Go pointers, satisfying the CGO pointer-passing rules.
+	if len(cfg.Devices) > 0 {
+		cArr := C.alloc_cptr_array(&cDevices[0], C.size_t(len(cDevices)))
+		defer C.free_cptr_array(cArr)
+		cCfg.devices = cArr
+	}
+	if len(cfg.Modules) > 0 {
+		cArr := C.alloc_cptr_array(&cModules[0], C.size_t(len(cModules)))
+		defer C.free_cptr_array(cArr)
+		cCfg.modules = cArr
+	}
+	if len(cfg.DevicesToLoad) > 0 {
+		cArr := C.alloc_cptr_array(&cDevicesToLoad[0], C.size_t(len(cDevicesToLoad)))
+		defer C.free_cptr_array(cArr)
+		cCfg.devices_to_load = cArr
+	}
+
+	ptr := C.dataplane_ut_new(&cCfg)
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to create dataplane harness: dataplane_ut_new returned NULL")
+	}
+
+	return &Harness{ptr: ptr}, nil
+}
+
+// Free tears down the harness. Nil-safe.
+func (m *Harness) Free() {
+	C.dataplane_ut_free(m.ptr)
+	m.ptr = nil
+}
+
+// SharedMemory returns the shared-memory handle backing this harness.
+func (m *Harness) SharedMemory() *ffi.SharedMemory {
+	shm := C.dataplane_ut_shm(m.ptr)
+	return ffi.NewSharedMemoryFromRaw(unsafe.Pointer(shm))
+}
+
+// SetCurrentTime installs a deterministic wall-clock value used by the next
+// HandlePackets call.
+func (m *Harness) SetCurrentTime(t time.Time) {
+	C.dataplane_ut_set_time_ns(m.ptr, C.uint64_t(t.UnixNano()))
+}
+
+// CurrentTime returns the mock wall-clock value currently installed.
+func (m *Harness) CurrentTime() time.Time {
+	ns := uint64(C.dataplane_ut_get_time_ns(m.ptr))
+	return time.Unix(0, int64(ns))
+}
+
+// AdvanceTime adds d to the current mock wall-clock, stores the result, and
+// returns the new time.
+func (m *Harness) AdvanceTime(d time.Duration) time.Time {
+	now := m.CurrentTime().Add(d)
+	m.SetCurrentTime(now)
+	return now
+}
+
+// HandlePackets runs packets through worker 0 for one pipeline round.
+func (m *Harness) HandlePackets(packets ...gopacket.Packet) (*Result, error) {
+	return m.handlePackets(0, nil, packets...)
+}
+
+// HandlePacketsOnWorker runs packets through the given worker index for one
+// pipeline round.
+func (m *Harness) HandlePacketsOnWorker(worker int, packets ...gopacket.Packet) (*Result, error) {
+	return m.handlePackets(worker, nil, packets...)
+}
+
+// HandlePacketsWithHashes runs one pipeline round with caller-supplied per-packet hash values.
+//
+// hashes[i] is written into packets[i].hash before the round, giving
+// modules that select outputs via hash (e.g. route ECMP) deterministic
+// test-controlled values. hashes may be shorter than packets; entries
+// past len(hashes) keep their original hash. Returns an error if
+// len(hashes) > len(packets).
+func (m *Harness) HandlePacketsWithHashes(
+	hashes []uint32,
+	packets ...gopacket.Packet,
+) (*Result, error) {
+	if len(hashes) > len(packets) {
+		return nil, fmt.Errorf("hashes length %d exceeds packets length %d", len(hashes), len(packets))
+	}
+	return m.handlePackets(0, hashes, packets...)
+}
+
+// handlePackets is the shared implementation for all HandlePackets variants.
+//
+// It builds the packet list, optionally overwrites per-packet hash values,
+// then runs one pipeline round on the given worker index.
+func (m *Harness) handlePackets(
+	worker int,
+	hashes []uint32,
+	packets ...gopacket.Packet,
+) (*Result, error) {
+	pinner := runtime.Pinner{}
+	defer pinner.Unpin()
+
+	payloads := xpacket.PacketsGoPayload(packets...)
+	data := make([]dataplane.PacketData, 0, len(payloads))
+	for idx := range payloads {
+		data = append(data, dataplane.PacketData{
+			Payload:    payloads[idx],
+			TxDeviceId: 0,
+			RxDeviceId: 0,
+		})
+	}
+
+	packetList, err := dataplane.NewPacketListFromData(&pinner, data...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build packet list: %w", err)
+	}
+
+	if len(hashes) > 0 {
+		pinner.Pin(&hashes[0])
+		C.dataplane_ut_set_hashes(
+			(*C.struct_packet_list)(unsafe.Pointer(packetList)),
+			(*C.uint32_t)(unsafe.Pointer(&hashes[0])),
+			C.size_t(len(hashes)),
+		)
+	}
+
+	pinner.Pin(m)
+
+	var result C.struct_dataplane_ut_round_result
+	C.dataplane_ut_run(
+		m.ptr,
+		C.size_t(worker),
+		(*C.struct_packet_list)(unsafe.Pointer(packetList)),
+		&result,
+	)
+
+	pinner.Pin(&result)
+
+	output := (*dataplane.PacketList)(unsafe.Pointer(&result.output))
+	drop := (*dataplane.PacketList)(unsafe.Pointer(&result.drop))
+
+	return &Result{
+		Output: output.Info(),
+		Drop:   drop.Info(),
+	}, nil
+}
+
+// toCStringArray converts a Go string slice to a slice of *C.char values and
+// returns a cleanup function that frees each element.
+func toCStringArray(ss []string) ([]*C.char, func()) {
+	out := make([]*C.char, len(ss))
+	for idx, s := range ss {
+		out[idx] = C.CString(s)
+	}
+	free := func() {
+		for idx := range out {
+			C.free(unsafe.Pointer(out[idx]))
+		}
+	}
+	return out, free
+}

--- a/bindings/go/dataplane_ut/dataplane_ut_test.go
+++ b/bindings/go/dataplane_ut/dataplane_ut_test.go
@@ -1,0 +1,70 @@
+package dataplaneut
+
+import (
+	"testing"
+	"time"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHarnessLifecycle exercises construction, shared-memory access, and
+// teardown of the Harness without running any packets.
+func TestHarnessLifecycle(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: 1,
+	}
+
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+	defer h.Free()
+
+	shm := h.SharedMemory()
+	require.NotNil(t, shm)
+}
+
+// TestTimeRoundTrip verifies that SetCurrentTime and CurrentTime agree and
+// that AdvanceTime correctly accumulates the delta.
+func TestTimeRoundTrip(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB),
+		WorkerCount: 1,
+	}
+
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	defer h.Free()
+
+	epoch := time.Unix(0, 1_000_000_000)
+	h.SetCurrentTime(epoch)
+	got := h.CurrentTime()
+	assert.Equal(t, epoch.UnixNano(), got.UnixNano())
+
+	advanced := h.AdvanceTime(500 * time.Millisecond)
+	assert.Equal(t, epoch.Add(500*time.Millisecond).UnixNano(), advanced.UnixNano())
+	assert.Equal(t, advanced.UnixNano(), h.CurrentTime().UnixNano())
+}
+
+// TestAgentAttach checks that a control-plane agent can be attached to the
+// shared-memory arena exposed by the harness.
+func TestAgentAttach(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB),
+		WorkerCount: 1,
+	}
+
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	defer h.Free()
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("smoke-agent", 0, datasize.MB*2)
+	require.NoError(t, err)
+	require.NotNil(t, agent)
+}

--- a/bindings/go/dataplane_ut/testing.go
+++ b/bindings/go/dataplane_ut/testing.go
@@ -1,0 +1,73 @@
+package dataplaneut
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// CounterPath identifies a per-module counter inside the dataplane
+// configuration tree.
+type CounterPath struct {
+	Device     string
+	Pipeline   string
+	Function   string
+	Chain      string
+	ModuleType string
+	ModuleName string
+}
+
+// RequireModuleCounter asserts that the named per-module counter at the
+// given path holds wantPackets and wantBytes.
+//
+// The counter is expected to be size 2: [packets, bytes]. Reads worker 0.
+func RequireModuleCounter(
+	t *testing.T,
+	h *Harness,
+	path CounterPath,
+	counterName string,
+	wantPackets, wantBytes uint64,
+) {
+	t.Helper()
+
+	counters := h.SharedMemory().DPConfig(0).ModuleCounters(
+		path.Device,
+		path.Pipeline,
+		path.Function,
+		path.Chain,
+		path.ModuleType,
+		path.ModuleName,
+		[]string{counterName},
+	)
+
+	byName := map[string][]uint64{}
+	for _, c := range counters {
+		if len(c.Values) > 0 {
+			byName[c.Name] = c.Values[0]
+		}
+	}
+
+	vals, ok := byName[counterName]
+	require.True(t, ok, "counter %q not found in module counters", counterName)
+	require.GreaterOrEqual(t, len(vals), 2, "counter %q must have at least two values (packets, bytes)", counterName)
+	require.Equal(t, wantPackets, vals[0], "counter %q packet count mismatch", counterName)
+	require.Equal(t, wantBytes, vals[1], "counter %q byte count mismatch", counterName)
+}
+
+// SingleValueCounters flattens a CounterInfo slice into a map of
+// counter name -> first worker's first value.
+//
+// Suitable for size-1 counters (pipeline, function, chain, device counters).
+// For multi-value counters (e.g. module counters with [packets, bytes]),
+// use RequireModuleCounter or read counters[idx].Values directly.
+func SingleValueCounters(counters []ffi.CounterInfo) map[string]uint64 {
+	byName := map[string]uint64{}
+	for _, c := range counters {
+		if len(c.Values) > 0 && len(c.Values[0]) > 0 {
+			byName[c.Name] = c.Values[0][0]
+		}
+	}
+	return byName
+}

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -26,6 +26,11 @@
 #include "dataplane/device.h"
 #include "dataplane/worker.h"
 
+#include "lib/dataplane/config/agent.h"
+#include "lib/dataplane/config/bootstrap.h"
+#include "lib/dataplane/config/counter_storage.h"
+#include "lib/dataplane/config/module_loader.h"
+#include "lib/dataplane/config/topology.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/packet.h"
 #include "lib/errors/errors.h"
@@ -207,149 +212,6 @@ dataplane_create_devices(
 }
 
 int
-dataplane_load_module(
-	struct dp_config *dp_config, void *bin_hndl, const char *name
-) {
-	LOG(INFO, "load module %s", name);
-	char loader_name[64];
-	snprintf(loader_name, sizeof(loader_name), "%s%s", "new_module_", name);
-	module_load_handler loader =
-		(module_load_handler)dlsym(bin_hndl, loader_name);
-	if (loader == NULL) {
-		LOG(ERROR, "failed to load dyn symbol %s", loader_name);
-		return -1;
-	}
-	struct module *module = loader();
-
-	struct dp_module *dp_modules = ADDR_OF(&dp_config->dp_modules);
-	if (mem_array_expand_exp(
-		    &dp_config->memory_context,
-		    (void **)&dp_modules,
-		    sizeof(*dp_modules),
-		    &dp_config->module_count
-	    )) {
-		LOG(ERROR, "failed to allocate memory for module %s", name);
-		// FIXME: free module
-		return -1;
-	}
-
-	struct dp_module *dp_module = dp_modules + dp_config->module_count - 1;
-
-	strtcpy(dp_module->name, module->name, sizeof(dp_module->name));
-	dp_module->handler = module->handler;
-
-	SET_OFFSET_OF(&dp_config->dp_modules, dp_modules);
-
-	return 0;
-}
-
-int
-dataplane_load_device(
-	struct dp_config *dp_config, void *bin_hndl, const char *name
-) {
-	LOG(INFO, "load device %s", name);
-	char loader_name[64];
-	snprintf(loader_name, sizeof(loader_name), "%s%s", "new_device_", name);
-	device_load_handler loader =
-		(device_load_handler)dlsym(bin_hndl, loader_name);
-	if (loader == NULL) {
-		LOG(ERROR, "failed to load dyn symbol %s", loader_name);
-		return -1;
-	}
-	struct device *device = loader();
-
-	struct dp_device *dp_devices = ADDR_OF(&dp_config->dp_devices);
-	if (mem_array_expand_exp(
-		    &dp_config->memory_context,
-		    (void **)&dp_devices,
-		    sizeof(*dp_devices),
-		    &dp_config->device_count
-	    )) {
-		LOG(ERROR, "failed to allocate memory for device %s", name);
-		// FIXME: free device
-		return -1;
-	}
-
-	struct dp_device *dp_device = dp_devices + dp_config->device_count - 1;
-
-	strtcpy(dp_device->name, device->name, sizeof(dp_device->name));
-	dp_device->input_handler = device->input_handler;
-	dp_device->output_handler = device->output_handler;
-
-	SET_OFFSET_OF(&dp_config->dp_devices, dp_devices);
-
-	return 0;
-}
-
-int
-dataplane_init_storage(
-	uint32_t numa_idx,
-	uint32_t instance_idx,
-	void *storage,
-	size_t dp_memory,
-	size_t cp_memory,
-
-	struct dp_config **res_dp_config,
-	struct cp_config **res_cp_config
-) {
-	// TODO: move pages to requested numa node
-
-	struct dp_config *dp_config = (struct dp_config *)storage;
-
-	dp_config->numa_idx = numa_idx;
-	dp_config->instance_idx = instance_idx;
-	dp_config->storage_size = dp_memory + cp_memory;
-
-	block_allocator_init(&dp_config->block_allocator);
-	block_allocator_put_arena(
-		&dp_config->block_allocator,
-		storage + sizeof(struct dp_config),
-		dp_memory - sizeof(struct dp_config)
-	);
-	memory_context_init(
-		&dp_config->memory_context, "dp", &dp_config->block_allocator
-	);
-
-	dp_config->config_lock = 0;
-
-	dp_config->dp_modules = NULL;
-	dp_config->module_count = 0;
-
-	dp_config->workers = NULL;
-	dp_config->worker_count = 0;
-
-	struct cp_config *cp_config =
-		(struct cp_config *)((uintptr_t)storage + dp_memory);
-
-	block_allocator_init(&cp_config->block_allocator);
-	block_allocator_put_arena(
-		&cp_config->block_allocator,
-		storage + dp_memory + sizeof(struct cp_config),
-		cp_memory - sizeof(struct cp_config)
-	);
-	memory_context_init(
-		&cp_config->memory_context, "cp", &cp_config->block_allocator
-	);
-
-	// FIXME: cp_config bootstrap routine
-	struct cp_agent_registry *cp_agent_registry =
-		(struct cp_agent_registry *)memory_balloc(
-			&cp_config->memory_context,
-			sizeof(struct cp_agent_registry)
-		);
-	cp_agent_registry->count = 0;
-	SET_OFFSET_OF(&cp_config->agent_registry, cp_agent_registry);
-
-	SET_OFFSET_OF(&dp_config->cp_config, cp_config);
-	SET_OFFSET_OF(&cp_config->dp_config, dp_config);
-
-	*res_dp_config = dp_config;
-	*res_cp_config = cp_config;
-
-	return 0;
-}
-
-int
 dataplane_init(
 	struct dataplane *dataplane,
 	const char *binary,
@@ -443,7 +305,7 @@ dataplane_init(
 			config->instances + instance_idx;
 
 		LOG(INFO, "initialize storage for instance %u", instance_idx);
-		int rc = dataplane_init_storage(
+		int rc = dp_storage_init(
 			instance_config->numa_idx,
 			instance_idx,
 			storage + instance_offset,
@@ -467,9 +329,8 @@ dataplane_init(
 		//
 		// FIXME: not paired with a free: released only when shm is torn
 		// down.
-		struct agent *agent = (struct agent *)memory_balloc(
-			&instance->cp_config->memory_context,
-			sizeof(struct agent)
+		struct agent *agent = dp_system_agent_new(
+			instance->cp_config, instance->dp_config, "dataplane"
 		);
 		if (agent == NULL) {
 			LOG(ERROR,
@@ -477,30 +338,22 @@ dataplane_init(
 			    instance_idx);
 			return -1;
 		}
-		memset(agent, 0, sizeof(struct agent));
-		strtcpy(agent->name, "dataplane", sizeof(agent->name));
-		memory_context_init_from(
-			&agent->memory_context,
-			&instance->cp_config->memory_context,
-			"dataplane"
-		);
-		SET_OFFSET_OF(&agent->dp_config, instance->dp_config);
-		SET_OFFSET_OF(&agent->cp_config, instance->cp_config);
 
-		instance->dp_config->dp_topology.device_count =
-			config->device_count;
-		struct dp_port *ports = (struct dp_port *)memory_balloc(
-			&instance->dp_config->memory_context,
-			sizeof(struct dp_port) *
-				instance->dp_config->dp_topology.device_count
+		struct dp_port *ports = dp_topology_alloc_devices(
+			instance->dp_config, config->device_count
 		);
+		if (ports == NULL) {
+			LOG(ERROR,
+			    "failed to allocate dp_topology devices for "
+			    "instance %u",
+			    instance_idx);
+			return -1;
+		}
 		for (uint64_t idx = 0; idx < config->device_count; ++idx) {
 			strtcpy(ports[idx].port_name,
 				config->devices[idx].port_name,
 				sizeof(ports[idx].port_name));
 		}
-
-		SET_OFFSET_OF(&instance->dp_config->dp_topology.devices, ports);
 
 		instance->dp_config->instance_idx = instance_idx;
 		instance->dp_config->instance_count = dataplane->instance_count;
@@ -518,7 +371,7 @@ dataplane_init(
 		};
 		for (size_t i = 0; i < sizeof(modules) / sizeof(modules[0]);
 		     ++i) {
-			if (dataplane_load_module(
+			if (dp_load_module(
 				    instance->dp_config, bin_hndl, modules[i]
 			    ) == -1) {
 				return -1;
@@ -528,7 +381,7 @@ dataplane_init(
 		static const char *devices[] = {"plain", "vlan"};
 		for (size_t i = 0; i < sizeof(devices) / sizeof(devices[0]);
 		     ++i) {
-			if (dataplane_load_device(
+			if (dp_load_device(
 				    instance->dp_config, bin_hndl, devices[i]
 			    ) == -1) {
 				return -1;
@@ -605,39 +458,12 @@ dataplane_init(
 		dp_config->instance_idx = instance_idx;
 		dp_config->instance_count = dataplane->instance_count;
 
-		counter_storage_allocator_init(
-			&dp_config->counter_storage_allocator,
-			&dp_config->memory_context,
-			dp_config->worker_count
-		);
-
 		struct cp_config *cp_config = instance->cp_config;
-		counter_storage_allocator_init(
-			&cp_config->counter_storage_allocator,
-			&cp_config->memory_context,
-			dp_config->worker_count
-		);
-
-		yanet_error *err = NULL;
-		if (counter_registry_link(
-			    &dp_config->worker_counters, NULL, &err
-		    )) {
-			LOG(ERROR,
-			    "failed to link counter registry: %s",
-			    yanet_error_message(err));
-			yanet_error_free(err);
+		if (dp_counter_storage_init(
+			    dp_config, cp_config, dp_config->worker_count
+		    ) != 0) {
 			return -1;
 		}
-
-		SET_OFFSET_OF(
-			&dp_config->worker_counter_storage,
-			counter_storage_spawn(
-				&dp_config->memory_context,
-				&dp_config->counter_storage_allocator,
-				NULL,
-				&dp_config->worker_counters
-			)
-		);
 	}
 
 	return 0;

--- a/dataplane/meson.build
+++ b/dataplane/meson.build
@@ -9,6 +9,7 @@ lib_dependencies = [
   lib_time_dp_dep,
   lib_config_dp_dep,
   lib_config_cp_dep,
+  lib_worker_dp_dep,
   lib_filter_query_dep,
 ]
 

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -51,6 +51,8 @@
 #include "lib/dataplane/time/clock.h"
 
 #include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/worker/counters.h"
+#include "lib/dataplane/worker/pipeline_round.h"
 
 #include "common/data_pipe.h"
 #include "logging/log.h"
@@ -280,7 +282,7 @@ worker_loop_round(struct dataplane_worker *worker) {
 	{
 		struct dp_worker *dp_worker = worker->dp_worker;
 		dp_worker->current_time =
-			tsc_clock_get_time_ns(&dp_worker->clock);
+			dataplane_time_ns_fn(&dp_worker->clock);
 	}
 
 	struct cp_config *cp_config = worker->instance->cp_config;
@@ -311,80 +313,9 @@ worker_loop_round(struct dataplane_worker *worker) {
 		return;
 	}
 
-	uint64_t device_count =
-		cp_config_gen->device_registry.registry.capacity;
-
-	while (1) {
-
-		struct packet_front schedule_input[device_count];
-		for (uint64_t idx = 0; idx < device_count; ++idx)
-			packet_front_init(schedule_input + idx);
-
-		struct packet_front schedule_output[device_count];
-		for (uint64_t idx = 0; idx < device_count; ++idx)
-			packet_front_init(schedule_output + idx);
-
-		struct packet *packet;
-
-		int empty = 1;
-
-		while ((packet = packet_list_pop(&packet_front.pending_input)
-		       ) != NULL) {
-			empty = 0;
-			packet_front_output(
-				schedule_input + packet->tx_device_id, packet
-			);
-		}
-
-		while ((packet = packet_list_pop(&packet_front.pending_output)
-		       ) != NULL) {
-			empty = 0;
-			packet_front_output(
-				schedule_output + packet->tx_device_id, packet
-			);
-		}
-
-		if (empty)
-			break;
-
-		struct device_ectx **devices = config_gen_ectx->devices;
-
-		for (uint64_t idx = 0; idx < device_count; ++idx) {
-			if (packet_list_first(&schedule_input[idx].output) ==
-			    NULL)
-				continue;
-
-			struct device_ectx *device_ectx =
-				ADDR_OF(devices + idx);
-
-			device_ectx_process_input(
-				worker->dp_worker,
-				device_ectx,
-				schedule_input + idx
-			);
-
-			packet_front_merge(&packet_front, schedule_input + idx);
-		}
-
-		for (uint64_t idx = 0; idx < device_count; ++idx) {
-			if (packet_list_first(&schedule_output[idx].output) ==
-			    NULL)
-				continue;
-
-			struct device_ectx *device_ectx =
-				ADDR_OF(devices + idx);
-
-			device_ectx_process_output(
-				worker->dp_worker,
-				device_ectx,
-				schedule_output + idx
-			);
-
-			packet_front_merge(
-				&packet_front, schedule_output + idx
-			);
-		}
-	}
+	worker_pipeline_round(
+		worker->dp_worker, cp_config_gen, config_gen_ectx, &packet_front
+	);
 
 	worker_write(worker, &packet_front.output);
 
@@ -406,26 +337,6 @@ worker_thread_start(void *arg) {
 	}
 
 	return NULL;
-}
-
-static int
-worker_register_counter(
-	struct dp_config *dp_config, const char *name, uint64_t size
-) {
-	yanet_error *err = NULL;
-	uint64_t rc = counter_registry_register(
-		&dp_config->worker_counters, name, size, &err
-	);
-	if (rc == COUNTER_INVALID) {
-		LOG(ERROR,
-		    "failed to register '%s' counter: %s",
-		    name,
-		    yanet_error_message(err));
-		yanet_error_free(err);
-		return -1;
-	}
-
-	return 0;
 }
 
 int
@@ -576,19 +487,7 @@ dataplane_worker_init(
 		&dp_config->worker_counters, &dp_config->memory_context, 0
 	);
 
-	if (worker_register_counter(dp_config, "iterations", 1)) {
-		return -1;
-	}
-	if (worker_register_counter(dp_config, "rx", 2)) {
-		return -1;
-	}
-	if (worker_register_counter(dp_config, "tx", 2)) {
-		return -1;
-	}
-	if (worker_register_counter(dp_config, "remote_rx", 2)) {
-		return -1;
-	}
-	if (worker_register_counter(dp_config, "remote_tx", 2)) {
+	if (worker_counters_register(dp_config)) {
 		return -1;
 	}
 

--- a/lib/dataplane/config/agent.c
+++ b/lib/dataplane/config/agent.c
@@ -1,0 +1,33 @@
+#include "agent.h"
+
+#include <string.h>
+
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/strutils.h"
+#include "lib/controlplane/agent/agent.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/config/zone.h"
+
+struct agent *
+dp_system_agent_new(
+	struct cp_config *cp_config,
+	struct dp_config *dp_config,
+	const char *name
+) {
+	struct agent *agent = (struct agent *)memory_balloc(
+		&cp_config->memory_context, sizeof(struct agent)
+	);
+	if (agent == NULL) {
+		return NULL;
+	}
+
+	memset(agent, 0, sizeof(struct agent));
+	strtcpy(agent->name, name, sizeof(agent->name));
+	memory_context_init_from(
+		&agent->memory_context, &cp_config->memory_context, name
+	);
+	SET_OFFSET_OF(&agent->dp_config, dp_config);
+	SET_OFFSET_OF(&agent->cp_config, cp_config);
+	return agent;
+}

--- a/lib/dataplane/config/agent.h
+++ b/lib/dataplane/config/agent.h
@@ -1,0 +1,18 @@
+#pragma once
+
+struct cp_config;
+struct dp_config;
+struct agent;
+
+// Allocate and initialise a system agent inside cp_config's memory zone.
+//
+// The agent's memory_context is parented to cp_config's so that any
+// per-agent allocations land inside the controlplane zone.
+//
+// Returns the agent on success or NULL on out-of-memory.
+struct agent *
+dp_system_agent_new(
+	struct cp_config *cp_config,
+	struct dp_config *dp_config,
+	const char *name
+);

--- a/lib/dataplane/config/bootstrap.c
+++ b/lib/dataplane/config/bootstrap.c
@@ -1,0 +1,73 @@
+#include "bootstrap.h"
+
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/config/zone.h"
+
+int
+dp_storage_init(
+	uint32_t numa_idx,
+	uint32_t instance_idx,
+	void *storage,
+	size_t dp_memory,
+	size_t cp_memory,
+	struct dp_config **res_dp_config,
+	struct cp_config **res_cp_config
+) {
+	// TODO: move pages to requested numa node
+
+	struct dp_config *dp_config = (struct dp_config *)storage;
+
+	dp_config->numa_idx = numa_idx;
+	dp_config->instance_idx = instance_idx;
+	dp_config->storage_size = dp_memory + cp_memory;
+
+	block_allocator_init(&dp_config->block_allocator);
+	block_allocator_put_arena(
+		&dp_config->block_allocator,
+		storage + sizeof(struct dp_config),
+		dp_memory - sizeof(struct dp_config)
+	);
+	memory_context_init(
+		&dp_config->memory_context, "dp", &dp_config->block_allocator
+	);
+
+	dp_config->config_lock = 0;
+
+	dp_config->dp_modules = NULL;
+	dp_config->module_count = 0;
+
+	dp_config->workers = NULL;
+	dp_config->worker_count = 0;
+
+	struct cp_config *cp_config =
+		(struct cp_config *)((uintptr_t)storage + dp_memory);
+
+	block_allocator_init(&cp_config->block_allocator);
+	block_allocator_put_arena(
+		&cp_config->block_allocator,
+		storage + dp_memory + sizeof(struct cp_config),
+		cp_memory - sizeof(struct cp_config)
+	);
+	memory_context_init(
+		&cp_config->memory_context, "cp", &cp_config->block_allocator
+	);
+
+	// FIXME: cp_config bootstrap routine
+	struct cp_agent_registry *cp_agent_registry =
+		(struct cp_agent_registry *)memory_balloc(
+			&cp_config->memory_context,
+			sizeof(struct cp_agent_registry)
+		);
+	cp_agent_registry->count = 0;
+	SET_OFFSET_OF(&cp_config->agent_registry, cp_agent_registry);
+
+	SET_OFFSET_OF(&dp_config->cp_config, cp_config);
+	SET_OFFSET_OF(&cp_config->dp_config, dp_config);
+
+	*res_dp_config = dp_config;
+	*res_cp_config = cp_config;
+
+	return 0;
+}

--- a/lib/dataplane/config/bootstrap.h
+++ b/lib/dataplane/config/bootstrap.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct dp_config;
+struct cp_config;
+
+// Initialise dataplane and controlplane configuration zones inside a
+// contiguous storage blob.
+//
+// On success *res_dp_config and *res_cp_config point into storage and
+// are mutually navigable via offset pointers. Caller owns storage.
+// Returns 0 on success, -1 on failure.
+int
+dp_storage_init(
+	uint32_t numa_idx,
+	uint32_t instance_idx,
+	void *storage,
+	size_t dp_memory,
+	size_t cp_memory,
+	struct dp_config **res_dp_config,
+	struct cp_config **res_cp_config
+);

--- a/lib/dataplane/config/counter_storage.c
+++ b/lib/dataplane/config/counter_storage.c
@@ -1,0 +1,47 @@
+#include "counter_storage.h"
+
+#include "common/memory_address.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/counters/counters.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+
+int
+dp_counter_storage_init(
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	uint64_t worker_count
+) {
+	counter_storage_allocator_init(
+		&dp_config->counter_storage_allocator,
+		&dp_config->memory_context,
+		worker_count
+	);
+	counter_storage_allocator_init(
+		&cp_config->counter_storage_allocator,
+		&cp_config->memory_context,
+		worker_count
+	);
+
+	yanet_error *err = NULL;
+	if (counter_registry_link(&dp_config->worker_counters, NULL, &err)) {
+		LOG(ERROR,
+		    "failed to link worker counter registry: %s",
+		    yanet_error_message(err));
+		yanet_error_free(err);
+		return -1;
+	}
+
+	SET_OFFSET_OF(
+		&dp_config->worker_counter_storage,
+		counter_storage_spawn(
+			&dp_config->memory_context,
+			&dp_config->counter_storage_allocator,
+			NULL,
+			&dp_config->worker_counters
+		)
+	);
+
+	return 0;
+}

--- a/lib/dataplane/config/counter_storage.h
+++ b/lib/dataplane/config/counter_storage.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <stdint.h>
+
+struct cp_config;
+struct dp_config;
+
+// Initialise per-zone counter storage and link the worker counter registry.
+//
+// Allocates counter_storage_allocator instances for both zones, links the
+// worker counter registry, and spawns its backing storage. Caller must have
+// registered the worker counters into dp_config->worker_counters before
+// invoking.
+//
+// Returns 0 on success, -1 if the registry link fails or storage
+// allocation cannot complete.
+int
+dp_counter_storage_init(
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	uint64_t worker_count
+);

--- a/lib/dataplane/config/meson.build
+++ b/lib/dataplane/config/meson.build
@@ -1,9 +1,17 @@
 dependencies = [
   lib_module_dp_dep,
   lib_pipeline_dp_dep,
+  lib_errors_dep,
+  lib_logging_dep,
+  lib_counters_dep,
 ]
 
 sources = files(
+  'agent.c',
+  'bootstrap.c',
+  'counter_storage.c',
+  'module_loader.c',
+  'topology.c',
   'zone.c',
 )
 

--- a/lib/dataplane/config/module_loader.c
+++ b/lib/dataplane/config/module_loader.c
@@ -1,0 +1,88 @@
+#include "module_loader.h"
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "common/exp_array.h"
+#include "common/memory_address.h"
+#include "common/strutils.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/device/device.h"
+#include "lib/dataplane/module/module.h"
+#include "lib/logging/log.h"
+
+int
+dp_load_module(struct dp_config *dp_config, void *bin_hndl, const char *name) {
+	LOG(INFO, "load module %s", name);
+	char loader_name[64];
+	snprintf(loader_name, sizeof(loader_name), "%s%s", "new_module_", name);
+	module_load_handler loader =
+		(module_load_handler)dlsym(bin_hndl, loader_name);
+	if (loader == NULL) {
+		LOG(ERROR, "failed to load dyn symbol %s", loader_name);
+		return -1;
+	}
+	struct module *module = loader();
+
+	struct dp_module *dp_modules = ADDR_OF(&dp_config->dp_modules);
+	if (mem_array_expand_exp(
+		    &dp_config->memory_context,
+		    (void **)&dp_modules,
+		    sizeof(*dp_modules),
+		    &dp_config->module_count
+	    )) {
+		LOG(ERROR, "failed to allocate memory for module %s", name);
+		// FIXME: free module
+		return -1;
+	}
+
+	struct dp_module *dp_module = dp_modules + dp_config->module_count - 1;
+
+	strtcpy(dp_module->name, module->name, sizeof(dp_module->name));
+	dp_module->handler = module->handler;
+
+	SET_OFFSET_OF(&dp_config->dp_modules, dp_modules);
+
+	free(module);
+
+	return 0;
+}
+
+int
+dp_load_device(struct dp_config *dp_config, void *bin_hndl, const char *name) {
+	LOG(INFO, "load device %s", name);
+	char loader_name[64];
+	snprintf(loader_name, sizeof(loader_name), "%s%s", "new_device_", name);
+	device_load_handler loader =
+		(device_load_handler)dlsym(bin_hndl, loader_name);
+	if (loader == NULL) {
+		LOG(ERROR, "failed to load dyn symbol %s", loader_name);
+		return -1;
+	}
+	struct device *device = loader();
+
+	struct dp_device *dp_devices = ADDR_OF(&dp_config->dp_devices);
+	if (mem_array_expand_exp(
+		    &dp_config->memory_context,
+		    (void **)&dp_devices,
+		    sizeof(*dp_devices),
+		    &dp_config->device_count
+	    )) {
+		LOG(ERROR, "failed to allocate memory for device %s", name);
+		// FIXME: free device
+		return -1;
+	}
+
+	struct dp_device *dp_device = dp_devices + dp_config->device_count - 1;
+
+	strtcpy(dp_device->name, device->name, sizeof(dp_device->name));
+	dp_device->input_handler = device->input_handler;
+	dp_device->output_handler = device->output_handler;
+
+	SET_OFFSET_OF(&dp_config->dp_devices, dp_devices);
+
+	free(device);
+
+	return 0;
+}

--- a/lib/dataplane/config/module_loader.h
+++ b/lib/dataplane/config/module_loader.h
@@ -1,0 +1,15 @@
+#pragma once
+
+struct dp_config;
+
+// Load a packet-processing module via dlsym(bin_hndl, "new_module_<name>")
+// and append it to dp_config->dp_modules. Returns 0 on success, -1 on
+// dlsym miss or out-of-memory.
+int
+dp_load_module(struct dp_config *dp_config, void *bin_hndl, const char *name);
+
+// Load a device adapter via dlsym(bin_hndl, "new_device_<name>") and append
+// it to dp_config->dp_devices, copying both input and output handlers.
+// Returns 0 on success, -1 on dlsym miss or out-of-memory.
+int
+dp_load_device(struct dp_config *dp_config, void *bin_hndl, const char *name);

--- a/lib/dataplane/config/topology.c
+++ b/lib/dataplane/config/topology.c
@@ -1,0 +1,21 @@
+#include "topology.h"
+
+#include "common/memory.h"
+#include "common/memory_address.h"
+
+#include "lib/dataplane/config/zone.h"
+
+struct dp_port *
+dp_topology_alloc_devices(struct dp_config *dp_config, size_t count) {
+	struct dp_port *ports = (struct dp_port *)memory_balloc(
+		&dp_config->memory_context, sizeof(struct dp_port) * count
+	);
+	if (ports == NULL) {
+		return NULL;
+	}
+
+	dp_config->dp_topology.device_count = count;
+	SET_OFFSET_OF(&dp_config->dp_topology.devices, ports);
+
+	return ports;
+}

--- a/lib/dataplane/config/topology.h
+++ b/lib/dataplane/config/topology.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 struct dp_port {
@@ -11,3 +12,11 @@ struct dp_topology {
 	uint64_t device_count;
 	struct dp_port *devices;
 };
+
+struct dp_config;
+
+// Allocate the dp_topology.devices array of count slots and wire it into
+// dp_config. The slots are left uninitialised — the caller fills each
+// entry's fields. Returns NULL on out-of-memory.
+struct dp_port *
+dp_topology_alloc_devices(struct dp_config *dp_config, size_t count);

--- a/lib/dataplane/time/clock.c
+++ b/lib/dataplane/time/clock.c
@@ -5,8 +5,6 @@
 #include <rte_cycles.h>
 #include <x86intrin.h>
 
-////////////////////////////////////////////////////////////////////////////////
-
 int
 tsc_clock_init(struct tsc_clock *clock) {
 	struct timespec ts;
@@ -35,3 +33,5 @@ tsc_clock_get_time_ns(struct tsc_clock *clock) {
 
 	return clock->real_time_ns + (tsc >> 10) * clock->tsc_to_ns;
 }
+
+dataplane_time_ns_fn_t dataplane_time_ns_fn = tsc_clock_get_time_ns;

--- a/lib/dataplane/time/clock.h
+++ b/lib/dataplane/time/clock.h
@@ -39,3 +39,19 @@ tsc_clock_adjust(struct tsc_clock *clock);
 // Get current real time in nanoseconds.
 uint64_t
 tsc_clock_get_time_ns(struct tsc_clock *clock);
+
+// Signature of the per-round wall-time read.
+//
+// The default implementation calls tsc_clock_get_time_ns. Tests and
+// alternative harnesses may install a substitute by assigning to
+// dataplane_time_ns_fn before any worker activity begins. The
+// substitute may ignore the clock argument and read a process-global
+// mock time source instead.
+typedef uint64_t (*dataplane_time_ns_fn_t)(struct tsc_clock *clock);
+
+// Process-global override point for wall-time reads inside the worker
+// loop.
+//
+// Defaults to tsc_clock_get_time_ns. Not thread-safe to swap — install
+// once before any worker thread starts.
+extern dataplane_time_ns_fn_t dataplane_time_ns_fn;

--- a/lib/dataplane/worker/counters.c
+++ b/lib/dataplane/worker/counters.c
@@ -1,0 +1,43 @@
+#include "counters.h"
+
+#include "lib/counters/counters.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+
+static int
+register_one(struct dp_config *dp_config, const char *name, uint64_t size) {
+	yanet_error *err = NULL;
+	uint64_t rc = counter_registry_register(
+		&dp_config->worker_counters, name, size, &err
+	);
+	if (rc == COUNTER_INVALID) {
+		LOG(ERROR,
+		    "failed to register '%s' counter: %s",
+		    name,
+		    yanet_error_message(err));
+		yanet_error_free(err);
+		return -1;
+	}
+	return 0;
+}
+
+int
+worker_counters_register(struct dp_config *dp_config) {
+	if (register_one(dp_config, "iterations", 1)) {
+		return -1;
+	}
+	if (register_one(dp_config, "rx", 2)) {
+		return -1;
+	}
+	if (register_one(dp_config, "tx", 2)) {
+		return -1;
+	}
+	if (register_one(dp_config, "remote_rx", 2)) {
+		return -1;
+	}
+	if (register_one(dp_config, "remote_tx", 2)) {
+		return -1;
+	}
+	return 0;
+}

--- a/lib/dataplane/worker/counters.h
+++ b/lib/dataplane/worker/counters.h
@@ -1,0 +1,11 @@
+#pragma once
+
+struct dp_config;
+
+// Register the five standard worker counters (iterations, rx, tx,
+// remote_rx, remote_tx) in dp_config->worker_counters. Caller must
+// initialise the registry via counter_registry_init before calling.
+//
+// Returns 0 on success, -1 if any counter fails to register.
+int
+worker_counters_register(struct dp_config *dp_config);

--- a/lib/dataplane/worker/meson.build
+++ b/lib/dataplane/worker/meson.build
@@ -1,12 +1,19 @@
 dependencies = [
   lib_common_dep,
+  lib_counters_dep,
+  lib_logging_dep,
+  lib_errors_dep,
   lib_config_dp_dep,
+  lib_pipeline_dp_dep,
+  lib_module_dp_dep,
   libdpdk_inc_dep,
 ]
 
 
 sources = files(
+  'pipeline_round.c',
   'worker.c',
+  'counters.c',
 )
 
 lib_worker_dp = static_library(

--- a/lib/dataplane/worker/pipeline_round.c
+++ b/lib/dataplane/worker/pipeline_round.c
@@ -1,0 +1,89 @@
+#include "pipeline_round.h"
+
+#include "common/memory_address.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/module/packet_front.h"
+#include "lib/dataplane/pipeline/econtext.h"
+#include "lib/dataplane/pipeline/pipeline.h"
+
+void
+worker_pipeline_round(
+	struct dp_worker *dp_worker,
+	struct cp_config_gen *cp_config_gen,
+	struct config_gen_ectx *config_gen_ectx,
+	struct packet_front *packet_front
+) {
+	uint64_t device_count =
+		cp_config_gen->device_registry.registry.capacity;
+
+	while (1) {
+		struct packet_front schedule_input[device_count];
+		for (uint64_t idx = 0; idx < device_count; ++idx) {
+			packet_front_init(schedule_input + idx);
+		}
+
+		struct packet_front schedule_output[device_count];
+		for (uint64_t idx = 0; idx < device_count; ++idx) {
+			packet_front_init(schedule_output + idx);
+		}
+
+		struct packet *packet;
+
+		int empty = 1;
+
+		while ((packet = packet_list_pop(&packet_front->pending_input)
+		       ) != NULL) {
+			empty = 0;
+			packet_front_output(
+				schedule_input + packet->tx_device_id, packet
+			);
+		}
+
+		while ((packet = packet_list_pop(&packet_front->pending_output)
+		       ) != NULL) {
+			empty = 0;
+			packet_front_output(
+				schedule_output + packet->tx_device_id, packet
+			);
+		}
+
+		if (empty) {
+			break;
+		}
+
+		struct device_ectx **devices = config_gen_ectx->devices;
+
+		for (uint64_t idx = 0; idx < device_count; ++idx) {
+			if (packet_list_first(&schedule_input[idx].output) ==
+			    NULL) {
+				continue;
+			}
+
+			struct device_ectx *device_ectx =
+				ADDR_OF(devices + idx);
+
+			device_ectx_process_input(
+				dp_worker, device_ectx, schedule_input + idx
+			);
+
+			packet_front_merge(packet_front, schedule_input + idx);
+		}
+
+		for (uint64_t idx = 0; idx < device_count; ++idx) {
+			if (packet_list_first(&schedule_output[idx].output) ==
+			    NULL) {
+				continue;
+			}
+
+			struct device_ectx *device_ectx =
+				ADDR_OF(devices + idx);
+
+			device_ectx_process_output(
+				dp_worker, device_ectx, schedule_output + idx
+			);
+
+			packet_front_merge(packet_front, schedule_output + idx);
+		}
+	}
+}

--- a/lib/dataplane/worker/pipeline_round.h
+++ b/lib/dataplane/worker/pipeline_round.h
@@ -1,0 +1,25 @@
+#pragma once
+
+struct dp_worker;
+struct cp_config_gen;
+struct config_gen_ectx;
+struct packet_front;
+
+// Drain pending_input and pending_output through the device pipeline.
+//
+// The caller has already snapshotted cp_config_gen and ensured a non-NULL
+// config_gen_ectx, set dp_worker->current_time, incremented the worker
+// iteration counter, and populated packet_front->pending_input or
+// pending_output with packets ready for pipeline processing.
+// config_gen_ectx must be non-NULL.
+//
+// On return, packet_front->output holds packets that should be written
+// out (or onward), packet_front->drop holds packets the pipeline rejected,
+// and both pending_input and pending_output are empty.
+void
+worker_pipeline_round(
+	struct dp_worker *dp_worker,
+	struct cp_config_gen *cp_config_gen,
+	struct config_gen_ectx *config_gen_ectx,
+	struct packet_front *packet_front
+);

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -1,0 +1,396 @@
+#include "dataplane_ut.h"
+
+// dp_worker->gen is initialized to a value far above any plausible
+// production cp_config_gen->gen so that harness workers never
+// observe a "wait for newer generation" state.
+#define DATAPLANE_UT_HIGH_GEN 1000000000000000ULL
+
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/strutils.h"
+#include "lib/controlplane/agent/agent.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/counters/counters.h"
+#include "lib/dataplane/config/agent.h"
+#include "lib/dataplane/config/bootstrap.h"
+#include "lib/dataplane/config/counter_storage.h"
+#include "lib/dataplane/config/module_loader.h"
+#include "lib/dataplane/config/topology.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/module/packet_front.h"
+#include "lib/dataplane/worker/counters.h"
+#include "lib/dataplane/worker/pipeline_round.h"
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+#include "mock/worker_mempool.h"
+
+struct dataplane_ut {
+	void *arena;
+	size_t arena_size;
+	struct dp_config *dp_config;
+	struct cp_config *cp_config;
+	struct rte_mempool *mempool;
+	uint64_t mock_time_ns;
+};
+
+// Counter indices used by wire_worker_counters to address the five
+// standard worker counter slots by their registration order.
+enum {
+	WORKER_CTR_ITERATIONS = 0,
+	WORKER_CTR_RX = 1,
+	WORKER_CTR_TX = 2,
+	WORKER_CTR_REMOTE_RX = 3,
+	WORKER_CTR_REMOTE_TX = 4,
+};
+
+// Wire counter address pointers for a single dp_worker.
+//
+// The worker_counter_storage must already be spawned and wired into
+// dp_config before calling this.
+static void
+wire_worker_counters(struct dp_worker *dp_worker, struct dp_config *dp_config) {
+	struct counter_storage *storage =
+		ADDR_OF(&dp_config->worker_counter_storage);
+	uint64_t idx = dp_worker->idx;
+
+	dp_worker->iterations =
+		counter_get_address(WORKER_CTR_ITERATIONS, idx, storage);
+
+	dp_worker->rx_count =
+		counter_get_address(WORKER_CTR_RX, idx, storage) + 0;
+	dp_worker->rx_size =
+		counter_get_address(WORKER_CTR_RX, idx, storage) + 1;
+
+	dp_worker->tx_count =
+		counter_get_address(WORKER_CTR_TX, idx, storage) + 0;
+	dp_worker->tx_size =
+		counter_get_address(WORKER_CTR_TX, idx, storage) + 1;
+
+	dp_worker->remote_rx_count =
+		counter_get_address(WORKER_CTR_REMOTE_RX, idx, storage) + 0;
+
+	dp_worker->remote_tx_count =
+		counter_get_address(WORKER_CTR_REMOTE_TX, idx, storage) + 0;
+}
+
+struct dataplane_ut *
+dataplane_ut_new(const struct dataplane_ut_config *cfg) {
+	if (cfg == NULL) {
+		LOG(ERROR, "dataplane_ut_new: cfg is NULL");
+		return NULL;
+	}
+	if (cfg->cp_memory + cfg->dp_memory == 0) {
+		LOG(ERROR, "dataplane_ut_new: total memory is zero");
+		return NULL;
+	}
+	if (cfg->worker_count < 1) {
+		LOG(ERROR, "dataplane_ut_new: worker_count must be at least 1");
+		return NULL;
+	}
+
+	struct dataplane_ut *ut = calloc(1, sizeof(*ut));
+	if (ut == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_new: failed to allocate harness struct");
+		return NULL;
+	}
+
+	// Allocate the shared arena. calloc zeros the struct so every pointer
+	// field is NULL until explicitly set — partial-init free is safe.
+	ut->arena_size = cfg->cp_memory + cfg->dp_memory;
+	ut->arena = aligned_alloc(64, ut->arena_size);
+	if (ut->arena == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_new: failed to allocate %zu-byte arena",
+		    ut->arena_size);
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+	memset(ut->arena, 0, ut->arena_size);
+
+	// Lay out dp_config and cp_config inside the arena.
+	if (dp_storage_init(
+		    0,
+		    0,
+		    ut->arena,
+		    cfg->dp_memory,
+		    cfg->cp_memory,
+		    &ut->dp_config,
+		    &ut->cp_config
+	    ) == -1) {
+		LOG(ERROR, "dataplane_ut_new: dp_storage_init failed");
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+
+	// Set instance_count — dp_storage_init leaves it at zero.
+	ut->dp_config->instance_count = 1;
+
+	// Open the current binary so dlsym can resolve module/device symbols.
+	void *bin_hndl = dlopen(NULL, RTLD_NOW | RTLD_GLOBAL);
+	if (bin_hndl == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_new: dlopen(NULL) failed: %s",
+		    dlerror());
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+
+	// Load requested packet-processing modules.
+	for (size_t idx = 0; idx < cfg->module_count; ++idx) {
+		if (dp_load_module(
+			    ut->dp_config, bin_hndl, cfg->modules[idx]
+		    ) == -1) {
+			LOG(ERROR,
+			    "dataplane_ut_new: failed to load module %s",
+			    cfg->modules[idx]);
+			dataplane_ut_free(ut);
+			return NULL;
+		}
+	}
+
+	// Load requested device adapters.
+	for (size_t idx = 0; idx < cfg->devices_to_load_count; ++idx) {
+		if (dp_load_device(
+			    ut->dp_config, bin_hndl, cfg->devices_to_load[idx]
+		    ) == -1) {
+			LOG(ERROR,
+			    "dataplane_ut_new: failed to load device %s",
+			    cfg->devices_to_load[idx]);
+			dataplane_ut_free(ut);
+			return NULL;
+		}
+	}
+
+	// Allocate the system agent inside cp_config memory so that its
+	// offset pointers remain valid across all processes that map the
+	// same arena. A stack agent would mix shm-relative offsets with
+	// process-local addresses and produce SIGBUS on cross-process
+	// dereference.
+	struct agent *agent = dp_system_agent_new(
+		ut->cp_config, ut->dp_config, "dataplane_ut"
+	);
+	if (agent == NULL) {
+		LOG(ERROR, "dataplane_ut_new: failed to allocate system agent");
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+
+	// Populate dp_topology with the logical port names from cfg.
+	if (cfg->device_count > 0) {
+		struct dp_port *ports = dp_topology_alloc_devices(
+			ut->dp_config, cfg->device_count
+		);
+		if (ports == NULL) {
+			LOG(ERROR,
+			    "dataplane_ut_new: failed to allocate dp_topology");
+			dataplane_ut_free(ut);
+			return NULL;
+		}
+		for (size_t idx = 0; idx < cfg->device_count; ++idx) {
+			strtcpy(ports[idx].port_name,
+				cfg->devices[idx],
+				sizeof(ports[idx].port_name));
+		}
+	}
+
+	// Create the initial cp_config_gen so agents can register modules
+	// and pipelines.
+	yanet_error *err = NULL;
+	struct cp_config_gen *cp_config_gen = cp_config_gen_create(agent, &err);
+	if (cp_config_gen == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_new: cp_config_gen_create failed: %s",
+		    yanet_error_message(err));
+		yanet_error_free(err);
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+	SET_OFFSET_OF(&ut->cp_config->cp_config_gen, cp_config_gen);
+
+	// Register the five standard worker counters used by the pipeline.
+	// Sizes and names mirror production worker.c::worker_register_counter.
+	counter_registry_init(
+		&ut->dp_config->worker_counters,
+		&ut->dp_config->memory_context,
+		0
+	);
+	if (worker_counters_register(ut->dp_config) == -1) {
+		LOG(ERROR,
+		    "dataplane_ut_new: failed to register worker counters");
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+
+	// Initialise counter storage allocators for both zones, link the
+	// worker registry, and spawn the backing storage so address
+	// pointers resolve. worker_count drives the per-instance layout.
+	if (dp_counter_storage_init(
+		    ut->dp_config, ut->cp_config, cfg->worker_count
+	    ) != 0) {
+		LOG(ERROR, "dataplane_ut_new: dp_counter_storage_init failed");
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+
+	// Create the mock mempool now so step 2 can allocate mbufs.
+	ut->mempool = mock_mempool_create();
+	if (ut->mempool == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_new: mock_mempool_create returned NULL");
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+
+	// Allocate dp_workers array inside dp_config memory.
+	struct dp_worker **workers_array = (struct dp_worker **)memory_balloc(
+		&ut->dp_config->memory_context,
+		cfg->worker_count * sizeof(struct dp_worker *)
+	);
+	if (workers_array == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_new: failed to allocate workers pointer array"
+		);
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+
+	ut->dp_config->worker_count = cfg->worker_count;
+	SET_OFFSET_OF(&ut->dp_config->workers, workers_array);
+
+	struct dp_worker **dp_workers = ADDR_OF(&ut->dp_config->workers);
+	for (size_t idx = 0; idx < cfg->worker_count; ++idx) {
+		struct dp_worker *dp_worker = (struct dp_worker *)memory_balloc(
+			&ut->dp_config->memory_context, sizeof(struct dp_worker)
+		);
+		if (dp_worker == NULL) {
+			LOG(ERROR,
+			    "dataplane_ut_new: failed to allocate dp_worker "
+			    "%zu",
+			    idx);
+			dataplane_ut_free(ut);
+			return NULL;
+		}
+		memset(dp_worker, 0, sizeof(struct dp_worker));
+		dp_worker->idx = idx;
+		// A high generation value ensures the pipeline never waits for
+		// a newer config snapshot — same trick used by mock.
+		dp_worker->gen = DATAPLANE_UT_HIGH_GEN;
+		dp_worker->rx_mempool = ut->mempool;
+
+		wire_worker_counters(dp_worker, ut->dp_config);
+
+		SET_OFFSET_OF(dp_workers + idx, dp_worker);
+	}
+
+	return ut;
+}
+
+void
+dataplane_ut_free(struct dataplane_ut *ut) {
+	if (ut == NULL) {
+		return;
+	}
+
+	if (ut->mempool != NULL) {
+		// mock_mempool_create allocates via calloc; free matches.
+		// Do NOT call rte_mempool_free — the mock pool is not a real
+		// DPDK pool and has no backing memory to tear down that way.
+		free(ut->mempool);
+		ut->mempool = NULL;
+	}
+
+	if (ut->cp_config != NULL) {
+		counter_storage_allocator_fini(
+			&ut->cp_config->counter_storage_allocator
+		);
+		memory_context_fini(&ut->cp_config->memory_context);
+	}
+
+	if (ut->dp_config != NULL) {
+		counter_storage_allocator_fini(
+			&ut->dp_config->counter_storage_allocator
+		);
+		memory_context_fini(&ut->dp_config->memory_context);
+	}
+
+	if (ut->arena != NULL) {
+		free(ut->arena);
+		ut->arena = NULL;
+	}
+
+	free(ut);
+}
+
+struct yanet_shm *
+dataplane_ut_shm(struct dataplane_ut *ut) {
+	// yanet_shm is opaque; the arena base address serves as the handle,
+	// matching the pattern used by mock/mock.c::yanet_mock_shm.
+	return (struct yanet_shm *)ut->arena;
+}
+
+void
+dataplane_ut_set_time_ns(struct dataplane_ut *ut, uint64_t ns) {
+	ut->mock_time_ns = ns;
+}
+
+uint64_t
+dataplane_ut_get_time_ns(struct dataplane_ut *ut) {
+	return ut->mock_time_ns;
+}
+
+struct rte_mbuf *
+dataplane_ut_alloc_mbuf(struct dataplane_ut *ut) {
+	return rte_pktmbuf_alloc(ut->mempool);
+}
+
+void
+dataplane_ut_run(
+	struct dataplane_ut *ut,
+	size_t worker_idx,
+	struct packet_list *input,
+	struct dataplane_ut_round_result *result
+) {
+	// The harness only manages one instance, so dp_workers lives in
+	// dp_config->workers as a registry of size worker_count.
+	struct dp_worker **workers = ADDR_OF(&ut->dp_config->workers);
+	struct dp_worker *dp_worker = ADDR_OF(&workers[worker_idx]);
+
+	// Mirror worker_loop_round housekeeping: time, gen, iterations.
+	dp_worker->current_time = ut->mock_time_ns;
+
+	struct cp_config_gen *cp_config_gen =
+		ADDR_OF(&ut->cp_config->cp_config_gen);
+	struct config_gen_ectx *config_gen_ectx =
+		ADDR_OF(&cp_config_gen->config_gen_ectx);
+
+	__atomic_store_n(&dp_worker->gen, cp_config_gen->gen, __ATOMIC_RELEASE);
+	*dp_worker->iterations += 1;
+
+	struct packet_front packet_front;
+	packet_front_init(&packet_front);
+
+	packet_list_concat(&packet_front.pending_input, input);
+	packet_list_init(input);
+
+	packet_list_init(&result->output);
+	packet_list_init(&result->drop);
+
+	if (config_gen_ectx == NULL) {
+		// No active pipeline: drop everything.
+		packet_list_concat(&result->drop, &packet_front.pending_input);
+		return;
+	}
+
+	worker_pipeline_round(
+		dp_worker, cp_config_gen, config_gen_ectx, &packet_front
+	);
+
+	packet_list_concat(&result->output, &packet_front.output);
+	packet_list_concat(&result->drop, &packet_front.drop);
+}

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "lib/dataplane/packet/packet.h"
+
+struct rte_mbuf;
+struct yanet_shm;
+struct dataplane_ut;
+
+// Construction parameters for an in-process dataplane harness.
+// worker_count must be >= 1.
+//
+// The three list pairs may be empty.
+struct dataplane_ut_config {
+	size_t cp_memory;
+	size_t dp_memory;
+	size_t worker_count;
+
+	const char *const *devices;
+	size_t device_count;
+
+	const char *const *modules;
+	size_t module_count;
+
+	const char *const *devices_to_load;
+	size_t devices_to_load_count;
+};
+
+// Construct an in-process dataplane harness.
+//
+// Returns the harness handle on success, or NULL if any allocation or
+// loader step fails. The caller releases it with dataplane_ut_free.
+struct dataplane_ut *
+dataplane_ut_new(const struct dataplane_ut_config *cfg);
+
+// Tear down a harness previously returned by dataplane_ut_new. NULL-safe.
+void
+dataplane_ut_free(struct dataplane_ut *ut);
+
+// Return the shared-memory handle backing this harness.
+// Suitable for passing to agent_attach.
+struct yanet_shm *
+dataplane_ut_shm(struct dataplane_ut *ut);
+
+// Install a wall-time value used by the next dataplane_ut_run call.
+//
+// Useful for driving time-sensitive module logic such as TTLs and NAT timeouts.
+void
+dataplane_ut_set_time_ns(struct dataplane_ut *ut, uint64_t ns);
+
+// Read the currently installed wall-time value.
+uint64_t
+dataplane_ut_get_time_ns(struct dataplane_ut *ut);
+
+// Allocate an mbuf from the harness mempool.
+//
+// Returns NULL on exhaustion. The caller frees with rte_pktmbuf_free.
+struct rte_mbuf *
+dataplane_ut_alloc_mbuf(struct dataplane_ut *ut);
+
+// Result of one pipeline round. The caller owns the mbufs in both lists
+// and must free them when done.
+struct dataplane_ut_round_result {
+	struct packet_list output;
+	struct packet_list drop;
+};
+
+// Run one pipeline round on worker_idx with the given input.
+//
+// input is drained to empty on return; result->output and result->drop
+// hold the post-pipeline packets, whose mbuf ownership transfers to the caller.
+//
+// The harness is single-threaded: concurrent calls on the same handle
+// race on dp_worker state and the shared mempool.
+void
+dataplane_ut_run(
+	struct dataplane_ut *ut,
+	size_t worker_idx,
+	struct packet_list *input,
+	struct dataplane_ut_round_result *result
+);

--- a/lib/dataplane_ut/meson.build
+++ b/lib/dataplane_ut/meson.build
@@ -1,0 +1,31 @@
+dependencies = [
+  lib_common_dep,
+  lib_logging_dep,
+  lib_errors_dep,
+  lib_counters_dep,
+  lib_config_dp_dep,
+  lib_config_cp_dep,
+  lib_agent_cp_dep,
+  lib_worker_dp_dep,
+  libdpdk_inc_dep,
+]
+
+sources = files(
+  'dataplane_ut.c',
+)
+
+lib_dataplane_ut = static_library(
+  'dataplane_ut',
+  sources,
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + ['-Wl,-E'],
+  dependencies: dependencies,
+  include_directories: yanet_rootdir,
+  install: false,
+)
+
+lib_dataplane_ut_dep = declare_dependency(
+  link_with: [lib_dataplane_ut],
+  include_directories: yanet_rootdir,
+  dependencies: dependencies,
+)

--- a/lib/dataplane_ut/tests/meson.build
+++ b/lib/dataplane_ut/tests/meson.build
@@ -1,0 +1,18 @@
+smoke_test = executable(
+  'dataplane_ut_smoke_test',
+  ['smoke_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    libdpdk_dep,
+  ],
+  link_with: [lib_dev_plain_dp],
+  include_directories: yanet_rootdir,
+)
+test('dataplane_ut_smoke', smoke_test, suite: 'dataplane_ut')

--- a/lib/dataplane_ut/tests/smoke_test.c
+++ b/lib/dataplane_ut/tests/smoke_test.c
@@ -1,0 +1,80 @@
+#include "common/test_assert.h"
+#include "lib/dataplane_ut/dataplane_ut.h"
+
+#include <rte_mbuf.h>
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	const char *port_names[] = {"01:00.0"};
+	const char *devs_to_load[] = {"plain"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = NULL,
+		.module_count = 0,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	TEST_ASSERT_NOT_NULL(shm, "dataplane_ut_shm returned NULL");
+
+	dataplane_ut_free(ut);
+
+	{
+		struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+		TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+
+		// Time setter / getter round-trip.
+		dataplane_ut_set_time_ns(ut, 12345ULL);
+		TEST_ASSERT_EQUAL(
+			(long)dataplane_ut_get_time_ns(ut),
+			(long)12345ULL,
+			"get_time_ns must echo set_time_ns"
+		);
+
+		// Mbuf factory yields a usable mbuf.
+		struct rte_mbuf *mbuf = dataplane_ut_alloc_mbuf(ut);
+		TEST_ASSERT_NOT_NULL(
+			mbuf, "dataplane_ut_alloc_mbuf returned NULL"
+		);
+		rte_pktmbuf_free(mbuf);
+
+		// Empty-input round must complete cleanly and yield empty
+		// output and drop lists.
+		struct packet_list empty;
+		packet_list_init(&empty);
+		struct dataplane_ut_round_result result;
+		dataplane_ut_run(ut, 0, &empty, &result);
+		TEST_ASSERT_EQUAL(
+			(long)packet_list_count(&result.output),
+			0L,
+			"empty input must yield empty output"
+		);
+		TEST_ASSERT_EQUAL(
+			(long)packet_list_count(&result.drop),
+			0L,
+			"empty input must yield empty drop"
+		);
+
+		dataplane_ut_free(ut);
+	}
+
+	// NULL-safe free must not crash.
+	dataplane_ut_free(NULL);
+
+	// Input validation: NULL cfg must return NULL, not crash.
+	struct dataplane_ut *bad = dataplane_ut_new(NULL);
+	TEST_ASSERT_NULL(bad, "dataplane_ut_new(NULL) should return NULL");
+
+	return 0;
+}

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -8,4 +8,5 @@ subdir('controlplane')
 subdir('utils')
 subdir('fwstate') # depends on dataplane lib
 subdir('fuzzing')
+subdir('dataplane_ut')
 subdir('tests') # depends on utils lib

--- a/meson.build
+++ b/meson.build
@@ -145,6 +145,7 @@ subdir('filter')
 module_test_dirs = []
 subdir('modules')
 subdir('devices')
+subdir('lib/dataplane_ut/tests')
 subdir('dataplane')
 
 if not dataplane_only

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -1,0 +1,569 @@
+package forward_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
+)
+
+// Memory sizes for the forward functional harness.
+const (
+	fwdCPSize  = 64 * 1024 * 1024
+	fwdDPSize  = 4 * 1024 * 1024
+	fwdMemSize = 8 * 1024 * 1024
+)
+
+// ip4Any is a source/destination wildcard for IPv4 filter rules.
+//
+// Both Src4s and Dst4s must be non-empty for a rule to appear in the ip4
+// filter. Use this as the source wildcard when only the destination matters.
+var ip4Any = filter.IPNets{{
+	Addr: netip.MustParseAddr("0.0.0.0"),
+	Mask: netip.MustParseAddr("0.0.0.0"),
+}}
+
+// ip6Any is a source/destination wildcard for IPv6 filter rules.
+//
+// Both Src6s and Dst6s must be non-empty for a rule to appear in the ip6
+// filter.
+var ip6Any = filter.IPNets{{
+	Addr: netip.MustParseAddr("::"),
+	Mask: netip.MustParseAddr("::"),
+}}
+
+// ip4Prefix converts a prefix string into a single-element IPv4 IPNets.
+func ip4Prefix(s string) filter.IPNets {
+	p := netip.MustParsePrefix(s)
+	nets, err := filter.Net4sFromPrefixes([]netip.Prefix{p})
+	if err != nil {
+		panic(err)
+	}
+	return nets
+}
+
+// ip6Prefix converts a prefix string into a single-element IPv6 IPNets.
+func ip6Prefix(s string) filter.IPNets {
+	p := netip.MustParsePrefix(s)
+	nets, err := filter.Net6sFromPrefixes([]netip.Prefix{p})
+	if err != nil {
+		panic(err)
+	}
+	return nets
+}
+
+// setupForwardHarness builds a dataplane harness with the forward module
+// loaded and attaches a control-plane agent.
+//
+// devices is the set of logical port names to register in the harness
+// topology. The first device in the list serves as the primary ingress port.
+// Cleanup is wired via t.Cleanup in LIFO order.
+func setupForwardHarness(
+	t *testing.T,
+	devices []string,
+) (*dataplaneut.Harness, *ffi.Agent, forward.Backend) {
+	t.Helper()
+
+	cfg := dataplaneut.Config{
+		CPMemory:      fwdCPSize,
+		DPMemory:      fwdDPSize,
+		WorkerCount:   1,
+		Devices:       devices,
+		Modules:       []string{"forward"},
+		DevicesToLoad: []string{"plain"},
+	}
+	h, err := dataplaneut.NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("fwd-test", 0, fwdMemSize)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	backend := forward.NewBackend(agent)
+	return h, agent, backend
+}
+
+// applyRules pushes the given rules via backend.UpdateModule.
+//
+// The module handle is freed via t.Cleanup. The caller must wire the pipeline
+// after calling applyRules, because the forward module config must exist in
+// shared memory before UpdatePlainDevices resolves chain module references.
+func applyRules(
+	t *testing.T,
+	backend forward.Backend,
+	name string,
+	rules []cforward.ForwardRule,
+) forward.ModuleHandle {
+	t.Helper()
+
+	handle, err := backend.UpdateModule(name, rules)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+	return handle
+}
+
+// wireForwardPipeline wires a chain[forward:configName] -> function -> pipeline
+// -> plain-device topology.
+//
+// Each name in extraDevices gets its own dummy input/output pipelines so that
+// ModeIn and ModeOut packet re-routing resolves without looping. Must be
+// called after applyRules.
+func wireForwardPipeline(
+	t *testing.T,
+	agent *ffi.Agent,
+	primaryDevice, configName string,
+	extraDevices []string,
+) {
+	t.Helper()
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: configName,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: configName + "_chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "forward", Name: configName},
+				},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      configName,
+		Functions: []string{configName},
+	}))
+
+	// A dummy pipeline with no functions passes packets straight through.
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name: "dummy",
+	}))
+
+	// Additional dummy pipelines for extra devices — each output must use a
+	// distinct pipeline name to avoid counter-key collisions.
+	for _, dev := range extraDevices {
+		pipeName := "dummy_extra_out_" + dev
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name: pipeName,
+		}))
+		pipeName2 := "dummy_extra_in_" + dev
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name: pipeName2,
+		}))
+	}
+
+	// Wire the primary ingress device with the forward-module pipeline.
+	primaryCfg := ffi.DeviceConfig{
+		Name:   primaryDevice,
+		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}
+
+	allDevices := []ffi.DeviceConfig{primaryCfg}
+	for _, dev := range extraDevices {
+		allDevices = append(allDevices, ffi.DeviceConfig{
+			Name:   dev,
+			Input:  []ffi.DevicePipelineConfig{{Name: "dummy_extra_in_" + dev, Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "dummy_extra_out_" + dev, Weight: 1}},
+		})
+	}
+
+	require.NoError(t, agent.UpdatePlainDevices(allDevices))
+}
+
+// fwdEtherLayers returns shared Ethernet, IPv4, IPv6, and ICMPv4 layer
+// templates for forward functional tests.
+func fwdEtherLayers() (layers.Ethernet, layers.IPv4, layers.IPv6, layers.ICMPv4) {
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    net.ParseIP("1.2.3.4"),
+		DstIP:    net.ParseIP("10.0.0.5"),
+	}
+	ip6 := layers.IPv6{
+		Version:    6,
+		HopLimit:   64,
+		NextHeader: layers.IPProtocolICMPv6,
+		SrcIP:      net.ParseIP("::1"),
+		DstIP:      net.ParseIP("2001:db8::1"),
+	}
+	icmp := layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+	}
+	return eth, ip4, ip6, icmp
+}
+
+// TestForward_NoMatch verifies that a packet not matched by any rule passes
+// through to the next module unchanged.
+//
+// Covers branch: action == FILTER_RULE_INVALID -> packet_front_output (no target).
+func TestForward_NoMatch(t *testing.T) {
+	// A rule with only Dst4s and no Src4s is excluded from the ip4 filter
+	// by check_has_ip4 (which requires both src and dst). Such a rule also
+	// fails check_forward_rule_l2 (which rejects rules with any ip condition).
+	// The rule therefore appears in no filter, so every packet misses it.
+	noMatchRule := cforward.ForwardRule{
+		Target:  "port0",
+		Mode:    cforward.ModeNone,
+		Counter: "unmatchable",
+		Dst4s:   ip4Prefix("10.0.0.0/24"),
+		// Src4s deliberately absent — makes the rule invisible to all filters.
+	}
+
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	applyRules(t, backend, "test", []cforward.ForwardRule{noMatchRule})
+	wireForwardPipeline(t, agent, "port0", "test", nil)
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "unmatched packet must pass through")
+	require.Empty(t, result.Drop, "unmatched packet must not be dropped")
+}
+
+// TestForward_ModeNone_IPv4 verifies that an IPv4 packet matched by an ip4
+// rule with ModeNone passes through to the next module without device redirect,
+// and that the per-rule counter is incremented.
+//
+// Covers branch: target found, mode == FORWARD_MODE_NONE -> packet_front_output.
+func TestForward_ModeNone_IPv4(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	rule := cforward.ForwardRule{
+		Target:  "port0",
+		Mode:    cforward.ModeNone,
+		Counter: "rule0",
+		Src4s:   ip4Any,
+		Dst4s:   ip4Prefix("10.0.0.0/24"),
+	}
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	applyRules(t, backend, "test", []cforward.ForwardRule{rule})
+	wireForwardPipeline(t, agent, "port0", "test", nil)
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "ModeNone packet must pass through")
+	require.Empty(t, result.Drop, "ModeNone packet must not be dropped")
+
+	path := dataplaneut.CounterPath{
+		Device:     "port0",
+		Pipeline:   "test",
+		Function:   "test",
+		Chain:      "test_chain",
+		ModuleType: "forward",
+		ModuleName: "test",
+	}
+	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 1, pktSize)
+}
+
+// TestForward_ModeOut_IPv4 verifies that an IPv4 packet matched by a ModeOut
+// rule is re-queued for egress via the target device, and that the per-rule
+// counter is incremented.
+//
+// Covers branch: target found, mode == FORWARD_MODE_OUT -> set tx_device_id,
+// queue to pending_output.
+func TestForward_ModeOut_IPv4(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	rule := cforward.ForwardRule{
+		Target:  "port1",
+		Mode:    cforward.ModeOut,
+		Counter: "rule0",
+		Src4s:   ip4Any,
+		Dst4s:   ip4Prefix("10.0.0.0/24"),
+	}
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	applyRules(t, backend, "test", []cforward.ForwardRule{rule})
+	wireForwardPipeline(t, agent, "port0", "test", []string{"port1"})
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	// The packet is queued via pending_output -> device_ectx_process_output on
+	// port1 -> dummy output pipeline -> packet_front.output.
+	require.Len(t, result.Output, 1, "ModeOut packet must reach output after egress pipeline")
+	require.Empty(t, result.Drop, "ModeOut packet with valid device must not be dropped")
+
+	path := dataplaneut.CounterPath{
+		Device:     "port0",
+		Pipeline:   "test",
+		Function:   "test",
+		Chain:      "test_chain",
+		ModuleType: "forward",
+		ModuleName: "test",
+	}
+	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 1, pktSize)
+}
+
+// TestForward_ModeIn_IPv4 verifies that an IPv4 packet matched by a ModeIn
+// rule is re-queued for ingress via the target device, and that the per-rule
+// counter is incremented.
+//
+// Covers branch: target found, mode == FORWARD_MODE_IN -> set tx_device_id,
+// queue to pending_input.
+func TestForward_ModeIn_IPv4(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	rule := cforward.ForwardRule{
+		Target:  "port1",
+		Mode:    cforward.ModeIn,
+		Counter: "rule0",
+		Src4s:   ip4Any,
+		Dst4s:   ip4Prefix("10.0.0.0/24"),
+	}
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	applyRules(t, backend, "test", []cforward.ForwardRule{rule})
+	// port1 gets a dummy input pipeline — the re-routed packet passes through
+	// it unchanged and ends up in packet_front.output.
+	wireForwardPipeline(t, agent, "port0", "test", []string{"port1"})
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	// The packet traverses: pending_input -> device_ectx_process_input on
+	// port1 -> dummy_extra_in_port1 pipeline -> packet_front.output.
+	require.Len(t, result.Output, 1, "ModeIn packet must reach output after ingress re-route")
+	require.Empty(t, result.Drop, "ModeIn packet with valid device must not be dropped")
+
+	path := dataplaneut.CounterPath{
+		Device:     "port0",
+		Pipeline:   "test",
+		Function:   "test",
+		Chain:      "test_chain",
+		ModuleType: "forward",
+		ModuleName: "test",
+	}
+	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 1, pktSize)
+}
+
+// TestForward_UnmappedDevice verifies that a rule whose target device is not
+// registered in UpdatePlainDevices causes the matched packet to be dropped.
+//
+// The per-rule counter is incremented BEFORE the device translation check,
+// so the counter must show 1 even though the packet is dropped.
+//
+// Covers branch: target found, module_ectx_encode_device returns -1 -> drop.
+func TestForward_UnmappedDevice(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	// "phantom" is never registered via UpdatePlainDevices; its mc_index
+	// entry stays at the initial sentinel value of -1.
+	rule := cforward.ForwardRule{
+		Target:  "phantom",
+		Mode:    cforward.ModeOut,
+		Counter: "rule0",
+		Src4s:   ip4Any,
+		Dst4s:   ip4Prefix("10.0.0.0/24"),
+	}
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	applyRules(t, backend, "test", []cforward.ForwardRule{rule})
+	// Only port0 is wired; "phantom" has no cp_device entry.
+	wireForwardPipeline(t, agent, "port0", "test", nil)
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "packet with unmapped device must be dropped")
+	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
+
+	// Counter is bumped before the device translation check.
+	path := dataplaneut.CounterPath{
+		Device:     "port0",
+		Pipeline:   "test",
+		Function:   "test",
+		Chain:      "test_chain",
+		ModuleType: "forward",
+		ModuleName: "test",
+	}
+	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 1, pktSize)
+}
+
+// TestForward_IPv6_ModeOut verifies that an IPv6 packet matched by an ip6
+// rule with ModeOut is re-queued for egress via the target device, and that
+// the per-rule counter is incremented.
+//
+// Covers the filter_ip6 path through forward_handle_packets.
+func TestForward_IPv6_ModeOut(t *testing.T) {
+	eth, _, ip6, _ := fwdEtherLayers()
+	eth.EthernetType = layers.EthernetTypeIPv6
+	icmp6 := layers.ICMPv6{
+		TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeEchoRequest, 0),
+	}
+	icmp6.SetNetworkLayerForChecksum(&ip6)
+
+	pkt := xpacket.LayersToPacket(t, &eth, &ip6, &icmp6)
+	pktSize := uint64(len(pkt.Data()))
+
+	rule := cforward.ForwardRule{
+		Target:  "port1",
+		Mode:    cforward.ModeOut,
+		Counter: "rule0",
+		Src6s:   ip6Any,
+		Dst6s:   ip6Prefix("2001:db8::/32"),
+	}
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	applyRules(t, backend, "test", []cforward.ForwardRule{rule})
+	wireForwardPipeline(t, agent, "port0", "test", []string{"port1"})
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "IPv6 ModeOut packet must reach output after egress pipeline")
+	require.Empty(t, result.Drop, "IPv6 ModeOut packet with valid device must not be dropped")
+
+	path := dataplaneut.CounterPath{
+		Device:     "port0",
+		Pipeline:   "test",
+		Function:   "test",
+		Chain:      "test_chain",
+		ModuleType: "forward",
+		ModuleName: "test",
+	}
+	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 1, pktSize)
+}
+
+// TestForward_NonIP verifies that a non-IP packet (ARP) is matched by a
+// device-only rule that appears in the L2 (vlan) filter.
+//
+// Non-IP packets skip the ip4 and ip6 filter branches entirely. The vlan
+// filter result is used as the final action. A device-only rule (no ip
+// conditions) qualifies for the L2 filter via check_forward_rule_l2.
+//
+// Covers the path: vlan_result valid, neither IPv4 nor IPv6 branch taken,
+// action = vlan_result -> target found -> mode == FORWARD_MODE_NONE -> passthrough.
+func TestForward_NonIP(t *testing.T) {
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("ff:ff:ff:ff:ff:ff")),
+		EthernetType: layers.EthernetTypeARP,
+	}
+	arp := layers.ARP{
+		AddrType:          layers.LinkTypeEthernet,
+		Protocol:          layers.EthernetTypeIPv4,
+		HwAddressSize:     6,
+		ProtAddressSize:   4,
+		Operation:         layers.ARPRequest,
+		SourceHwAddress:   eth.SrcMAC,
+		SourceProtAddress: net.ParseIP("10.0.0.1").To4(),
+		DstHwAddress:      net.HardwareAddr{0, 0, 0, 0, 0, 0},
+		DstProtAddress:    net.ParseIP("10.0.0.2").To4(),
+	}
+	pkt := xpacket.LayersToPacket(t, &eth, &arp)
+	pktSize := uint64(len(pkt.Data()))
+
+	// A rule with no ip conditions qualifies for the L2 filter only. An ARP
+	// packet will match it because neither ip4 nor ip6 filter branches are
+	// entered — the final action stays at vlan_result.
+	rule := cforward.ForwardRule{
+		Target:  "port0",
+		Mode:    cforward.ModeNone,
+		Counter: "l2rule",
+		Devices: filter.Devices{{Name: "port0"}},
+		// No Src4s/Dst4s/Src6s/Dst6s — L2-only rule.
+	}
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	applyRules(t, backend, "test", []cforward.ForwardRule{rule})
+	wireForwardPipeline(t, agent, "port0", "test", nil)
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "ARP packet matching L2 rule with ModeNone must pass through")
+	require.Empty(t, result.Drop, "ARP packet must not be dropped")
+
+	path := dataplaneut.CounterPath{
+		Device:     "port0",
+		Pipeline:   "test",
+		Function:   "test",
+		Chain:      "test_chain",
+		ModuleType: "forward",
+		ModuleName: "test",
+	}
+	dataplaneut.RequireModuleCounter(t, h, path, "l2rule", 1, pktSize)
+}
+
+// TestForward_MinAction verifies that when a packet matches both the L2 filter
+// (rule 0) and the ip4 filter (rule 1), the handler picks the lower action
+// value via min(vlan_result, ip4_result), so only rule 0's counter is bumped.
+//
+// Rule 0: device-only (L2 filter, action 0).
+// Rule 1: ip4 prefix rule (ip4 filter, action 1).
+// An IPv4 packet satisfies both filters. action = min(0, 1) = 0 -> rule 0 wins.
+//
+// Covers branch: both vlan_result and ip4_result valid -> action = min ->
+// lower-index rule's target is used.
+func TestForward_MinAction(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	rules := []cforward.ForwardRule{
+		{
+			// Rule 0: L2-only. Qualifies for filter_vlan (no ip conditions).
+			// An IPv4 packet with device "port0" matches here -> vlan_result = 0.
+			Target:  "port0",
+			Mode:    cforward.ModeNone,
+			Counter: "l2win",
+			Devices: filter.Devices{{Name: "port0"}},
+		},
+		{
+			// Rule 1: ip4-only. Qualifies for filter_ip4 (has both src and dst).
+			// The same IPv4 packet matches here -> ip4_result = 1.
+			// min(0, 1) = 0, so rule 1 never fires.
+			Target:  "port0",
+			Mode:    cforward.ModeNone,
+			Counter: "ip4lose",
+			Src4s:   ip4Any,
+			Dst4s:   ip4Prefix("10.0.0.0/24"),
+		},
+	}
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	applyRules(t, backend, "test", rules)
+	wireForwardPipeline(t, agent, "port0", "test", nil)
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "packet must pass through via rule 0 (ModeNone)")
+	require.Empty(t, result.Drop, "packet must not be dropped")
+
+	// Rule 0 counter must be 1; rule 1 counter must be 0 (never selected).
+	path := dataplaneut.CounterPath{
+		Device:     "port0",
+		Pipeline:   "test",
+		Function:   "test",
+		Chain:      "test_chain",
+		ModuleType: "forward",
+		ModuleName: "test",
+	}
+	dataplaneut.RequireModuleCounter(t, h, path, "l2win", 1, pktSize)
+	dataplaneut.RequireModuleCounter(t, h, path, "ip4lose", 0, 0)
+}

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -1,0 +1,694 @@
+package route_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/common/commonpb"
+	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb"
+)
+
+const (
+	routeCPSize  = 16 * 1024 * 1024
+	routeDPSize  = 4 * 1024 * 1024
+	routeMemSize = 2 * 1024 * 1024
+)
+
+// FIBNexthop is a test-domain nexthop descriptor.
+type FIBNexthop struct {
+	DstMAC net.HardwareAddr
+	SrcMAC net.HardwareAddr
+	Device string
+}
+
+// FIBEntry is a test-domain FIB prefix with associated nexthops.
+type FIBEntry struct {
+	Prefix   netip.Prefix
+	Nexthops []FIBNexthop
+}
+
+// routeNextHop is the shared nexthop used across single-hop tests.
+//
+// Packets forwarded via this hop will have their Ethernet header rewritten
+// with these MACs and egress via "port0".
+var routeNextHop = FIBNexthop{
+	DstMAC: xerror.Unwrap(net.ParseMAC("de:ad:be:ef:00:01")),
+	SrcMAC: xerror.Unwrap(net.ParseMAC("ca:fe:ba:be:00:01")),
+	Device: "port0",
+}
+
+// setupRouteHarness builds the harness, attaches a control-plane agent,
+// and constructs the production route.Backend over the attached agent.
+//
+// The harness, agent, and backend are returned. Cleanup is wired via
+// t.Cleanup in LIFO order. Pipeline wiring must follow after calling
+// applyFIB, because the route module config must exist in shared memory
+// before UpdatePlainDevices resolves chain module references.
+func setupRouteHarness(
+	t *testing.T,
+	deviceName string,
+) (*dataplaneut.Harness, *ffi.Agent, route.Backend) {
+	t.Helper()
+
+	cfg := dataplaneut.Config{
+		CPMemory:      routeCPSize,
+		DPMemory:      routeDPSize,
+		WorkerCount:   1,
+		Devices:       []string{deviceName},
+		Modules:       []string{"route"},
+		DevicesToLoad: []string{"plain"},
+	}
+	h, err := dataplaneut.NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("r-test", 0, routeMemSize)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	backend := route.NewBackend(agent)
+	return h, agent, backend
+}
+
+// wirePipeline wires a chain[route:configName] -> function -> pipeline -> plain
+// device topology.
+//
+// Must be called after applyFIB so that the route module config named
+// configName is already present in shared memory when the pipeline resolves
+// its chain module references.
+func wirePipeline(
+	t *testing.T,
+	agent *ffi.Agent,
+	deviceName, configName string,
+) {
+	t.Helper()
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: configName,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: configName + "_chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "route", Name: configName},
+				},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      configName,
+		Functions: []string{configName},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name: "dummy",
+	}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   deviceName,
+		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+}
+
+// applyFIB pushes entries via backend.UpdateModule and registers cleanup.
+//
+// Returns the route.ModuleHandle; the caller may inspect it. The handle is
+// freed via t.Cleanup.
+func applyFIB(
+	t *testing.T,
+	backend route.Backend,
+	name string,
+	entries []FIBEntry,
+) route.ModuleHandle {
+	t.Helper()
+
+	pbEntries := make([]*routepb.FIBEntry, 0, len(entries))
+	for _, e := range entries {
+		nexthops := make([]*routepb.FIBNexthop, 0, len(e.Nexthops))
+		for _, nh := range e.Nexthops {
+			nexthops = append(nexthops, &routepb.FIBNexthop{
+				DstMac: commonpb.NewMACAddressEUI48([6]byte(nh.DstMAC)),
+				SrcMac: commonpb.NewMACAddressEUI48([6]byte(nh.SrcMAC)),
+				Device: nh.Device,
+			})
+		}
+		pbEntries = append(pbEntries, &routepb.FIBEntry{
+			Prefix:   e.Prefix.String(),
+			Nexthops: nexthops,
+		})
+	}
+
+	handle, err := backend.UpdateModule(name, pbEntries)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+	return handle
+}
+
+// testingEtherLayers returns a reusable set of Ethernet and IP layers for
+// building route test packets.
+func testingEtherLayers() (layers.Ethernet, layers.IPv4, layers.IPv6, layers.ICMPv4) {
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    net.ParseIP("10.0.0.1"),
+		DstIP:    net.ParseIP("192.168.1.1"),
+	}
+	ip6 := layers.IPv6{
+		Version:    6,
+		HopLimit:   64,
+		NextHeader: layers.IPProtocolICMPv6,
+		SrcIP:      net.ParseIP("::1"),
+		DstIP:      net.ParseIP("2001:db8::1"),
+	}
+	icmp := layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+	}
+	return eth, ip4, ip6, icmp
+}
+
+// TestRoute_IPv4_Forward verifies that an IPv4 packet destined for a known
+// prefix is forwarded with Ethernet header rewritten and TTL decremented by
+// one.
+func TestRoute_IPv4_Forward(t *testing.T) {
+	eth, ip4, _, icmp := testingEtherLayers()
+
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	t.Log("Origin packet", pkt)
+
+	prefix := netip.MustParsePrefix("192.168.1.0/24")
+
+	h, agent, backend := setupRouteHarness(t, "port0")
+	applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+	})
+	wirePipeline(t, agent, "port0", "test")
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "expected one forwarded packet")
+	require.Empty(t, result.Drop, "expected no dropped packets")
+
+	resultPkt := xpacket.ParseEtherPacket(result.Output[0].RawData)
+	t.Log("Result packet", resultPkt)
+
+	// Ethernet header must be rewritten with the nexthop MACs.
+	ethOut := layers.Ethernet{
+		SrcMAC:       routeNextHop.SrcMAC,
+		DstMAC:       routeNextHop.DstMAC,
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	// TTL must be decremented by one.
+	ip4Out := ip4
+	ip4Out.TTL = 63
+	expectedPkt := xpacket.LayersToPacket(t, &ethOut, &ip4Out, &icmp)
+	t.Log("Expected packet", expectedPkt)
+
+	diff := cmp.Diff(
+		expectedPkt.Layers(),
+		resultPkt.Layers(),
+		cmpopts.IgnoreUnexported(layers.ICMPv4{}),
+	)
+	require.Empty(t, diff)
+
+	// Verify that the IPv4 layer parsed cleanly.
+	ip4Layer := resultPkt.Layer(layers.LayerTypeIPv4)
+	require.NotNil(t, ip4Layer, "IPv4 layer must be present in result")
+}
+
+// TestRoute_IPv6_Forward verifies that an IPv6 packet destined for a known
+// prefix is forwarded with Ethernet header rewritten and HopLimit decremented
+// by one.
+func TestRoute_IPv6_Forward(t *testing.T) {
+	_, _, ip6, _ := testingEtherLayers()
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv6,
+	}
+	icmp6 := layers.ICMPv6{
+		TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeEchoRequest, 0),
+	}
+	icmp6.SetNetworkLayerForChecksum(&ip6)
+
+	pkt := xpacket.LayersToPacket(t, &eth, &ip6, &icmp6)
+	t.Log("Origin packet", pkt)
+
+	prefix := netip.MustParsePrefix("2001:db8::/32")
+
+	h, agent, backend := setupRouteHarness(t, "port0")
+	applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+	})
+	wirePipeline(t, agent, "port0", "test")
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "expected one forwarded packet")
+	require.Empty(t, result.Drop, "expected no dropped packets")
+
+	resultPkt := xpacket.ParseEtherPacket(result.Output[0].RawData)
+	t.Log("Result packet", resultPkt)
+
+	ethOut := layers.Ethernet{
+		SrcMAC:       routeNextHop.SrcMAC,
+		DstMAC:       routeNextHop.DstMAC,
+		EthernetType: layers.EthernetTypeIPv6,
+	}
+	// HopLimit must be decremented by one.
+	ip6Out := ip6
+	ip6Out.HopLimit = 63
+	expectedPkt := xpacket.LayersToPacket(t, &ethOut, &ip6Out, &icmp6)
+	t.Log("Expected packet", expectedPkt)
+
+	diff := cmp.Diff(
+		expectedPkt.Layers(),
+		resultPkt.Layers(),
+		cmpopts.IgnoreUnexported(layers.IPv6{}, layers.ICMPv6{}),
+	)
+	require.Empty(t, diff)
+}
+
+// TestRoute_TTL_Drop verifies that IPv4 packets with TTL ≤ 1 are dropped and
+// packets with TTL ≥ 2 are forwarded with the TTL decremented.
+func TestRoute_TTL_Drop(t *testing.T) {
+	prefix := netip.MustParsePrefix("192.168.1.0/24")
+
+	cases := []struct {
+		name            string
+		ttl             uint8
+		expectForwarded bool
+	}{
+		{name: "ttl_zero_drop", ttl: 0, expectForwarded: false},
+		{name: "ttl_one_drop", ttl: 1, expectForwarded: false},
+		{name: "ttl_two_forward", ttl: 2, expectForwarded: true},
+		{name: "ttl_64_forward", ttl: 64, expectForwarded: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eth, ip4, _, icmp := testingEtherLayers()
+			ip4.TTL = tc.ttl
+
+			pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+
+			h, agent, backend := setupRouteHarness(t, "port0")
+			applyFIB(t, backend, "test", []FIBEntry{
+				{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+			})
+			wirePipeline(t, agent, "port0", "test")
+
+			result, err := h.HandlePackets(pkt)
+			require.NoError(t, err)
+
+			if tc.expectForwarded {
+				require.Len(t, result.Output, 1, "expected forwarded packet")
+				require.Empty(t, result.Drop, "expected no dropped packets")
+				resultPkt := xpacket.ParseEtherPacket(result.Output[0].RawData)
+				ip4Layer := resultPkt.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
+				require.Equal(t, uint8(tc.ttl-1), ip4Layer.TTL)
+			} else {
+				require.Empty(t, result.Output, "expected no forwarded packets")
+				require.Len(t, result.Drop, 1, "expected dropped packet")
+			}
+		})
+	}
+}
+
+// TestRoute_HopLimit_Drop verifies that IPv6 packets with HopLimit ≤ 1 are
+// dropped and packets with HopLimit ≥ 2 are forwarded with HopLimit
+// decremented.
+func TestRoute_HopLimit_Drop(t *testing.T) {
+	prefix := netip.MustParsePrefix("2001:db8::/32")
+
+	cases := []struct {
+		name            string
+		hopLimit        uint8
+		expectForwarded bool
+	}{
+		{name: "hop_limit_zero_drop", hopLimit: 0, expectForwarded: false},
+		{name: "hop_limit_one_drop", hopLimit: 1, expectForwarded: false},
+		{name: "hop_limit_two_forward", hopLimit: 2, expectForwarded: true},
+		{name: "hop_limit_64_forward", hopLimit: 64, expectForwarded: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			eth := layers.Ethernet{
+				SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+				DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+				EthernetType: layers.EthernetTypeIPv6,
+			}
+			_, _, ip6, _ := testingEtherLayers()
+			ip6.HopLimit = tc.hopLimit
+			icmp6 := layers.ICMPv6{
+				TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeEchoRequest, 0),
+			}
+			icmp6.SetNetworkLayerForChecksum(&ip6)
+
+			pkt := xpacket.LayersToPacket(t, &eth, &ip6, &icmp6)
+
+			h, agent, backend := setupRouteHarness(t, "port0")
+			applyFIB(t, backend, "test", []FIBEntry{
+				{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+			})
+			wirePipeline(t, agent, "port0", "test")
+
+			result, err := h.HandlePackets(pkt)
+			require.NoError(t, err)
+
+			if tc.expectForwarded {
+				require.Len(t, result.Output, 1, "expected forwarded packet")
+				require.Empty(t, result.Drop, "expected no dropped packets")
+				resultPkt := xpacket.ParseEtherPacket(result.Output[0].RawData)
+				ip6Layer := resultPkt.Layer(layers.LayerTypeIPv6).(*layers.IPv6)
+				require.Equal(t, uint8(tc.hopLimit-1), ip6Layer.HopLimit)
+			} else {
+				require.Empty(t, result.Output, "expected no forwarded packets")
+				require.Len(t, result.Drop, 1, "expected dropped packet")
+			}
+		})
+	}
+}
+
+// TestRoute_NoMatch_Drop verifies that a packet whose destination address is
+// not covered by any installed prefix is dropped.
+func TestRoute_NoMatch_Drop(t *testing.T) {
+	eth, ip4, _, icmp := testingEtherLayers()
+	// Destination is not covered by any prefix in the LPM.
+	ip4.DstIP = net.ParseIP("10.99.99.99")
+
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	t.Log("Origin packet", pkt)
+
+	prefix := netip.MustParsePrefix("192.168.1.0/24")
+
+	h, agent, backend := setupRouteHarness(t, "port0")
+	applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+	})
+	wirePipeline(t, agent, "port0", "test")
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "unrouted packet must be dropped")
+	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
+}
+
+// TestRoute_NonIP_Drop verifies that non-IP Ethernet frames (e.g. ARP) are
+// dropped by the route module.
+func TestRoute_NonIP_Drop(t *testing.T) {
+	prefix := netip.MustParsePrefix("192.168.1.0/24")
+
+	h, agent, backend := setupRouteHarness(t, "port0")
+	applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+	})
+	wirePipeline(t, agent, "port0", "test")
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("ff:ff:ff:ff:ff:ff")),
+		EthernetType: layers.EthernetTypeARP,
+	}
+	arp := layers.ARP{
+		AddrType:          layers.LinkTypeEthernet,
+		Protocol:          layers.EthernetTypeIPv4,
+		HwAddressSize:     6,
+		ProtAddressSize:   4,
+		Operation:         layers.ARPRequest,
+		SourceHwAddress:   eth.SrcMAC,
+		SourceProtAddress: net.ParseIP("10.0.0.1").To4(),
+		DstHwAddress:      net.HardwareAddr{0, 0, 0, 0, 0, 0},
+		DstProtAddress:    net.ParseIP("10.0.0.2").To4(),
+	}
+
+	pkt := xpacket.LayersToPacket(t, &eth, &arp)
+	t.Log("Origin packet", pkt)
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "non-IP packet must be dropped")
+	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
+}
+
+// TestRoute_ECMP_HashSelection verifies ECMP nexthop selection based on
+// per-packet hash values.
+//
+// Two nexthops share one prefix. Packets with hash=0 select slot 0 (hop0)
+// and packets with hash=1 select slot 1 (hop1), because the route module
+// picks route_list[packet->hash % count].
+func TestRoute_ECMP_HashSelection(t *testing.T) {
+	const (
+		// hashForFirstHop selects route_list[0 % 2] = hop0.
+		hashForFirstHop uint32 = 0
+		// hashForSecondHop selects route_list[1 % 2] = hop1.
+		hashForSecondHop uint32 = 1
+	)
+
+	hop0 := FIBNexthop{
+		DstMAC: xerror.Unwrap(net.ParseMAC("de:ad:00:00:00:01")),
+		SrcMAC: xerror.Unwrap(net.ParseMAC("ca:fe:00:00:00:01")),
+		Device: "port0",
+	}
+	hop1 := FIBNexthop{
+		DstMAC: xerror.Unwrap(net.ParseMAC("de:ad:00:00:00:02")),
+		SrcMAC: xerror.Unwrap(net.ParseMAC("ca:fe:00:00:00:02")),
+		Device: "port1",
+	}
+
+	prefix := netip.MustParsePrefix("192.168.1.0/24")
+
+	// Build a two-device harness so both nexthop egress ports are registered.
+	cfg := dataplaneut.Config{
+		CPMemory:      routeCPSize,
+		DPMemory:      routeDPSize,
+		WorkerCount:   1,
+		Devices:       []string{"port0", "port1"},
+		Modules:       []string{"route"},
+		DevicesToLoad: []string{"plain"},
+	}
+	h, err := dataplaneut.NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("r-ecmp", 0, routeMemSize)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	backend := route.NewBackend(agent)
+
+	applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{hop0, hop1}},
+	})
+
+	// Wire both devices through the pipeline. Each device gets its own
+	// function and chain so the module config reference ("test") resolves.
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: "test",
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: "test_chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "route", Name: "test"},
+				},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "test",
+		Functions: []string{"test"},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name: "dummy0",
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name: "dummy1",
+	}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{
+		{
+			Name:   "port0",
+			Input:  []ffi.DevicePipelineConfig{{Name: "test", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "dummy0", Weight: 1}},
+		},
+		{
+			Name:   "port1",
+			Input:  []ffi.DevicePipelineConfig{{Name: "test", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "dummy1", Weight: 1}},
+		},
+	}))
+
+	// Build four identical packets and inject explicit hashes: two packets
+	// with hash=0 must hit hop0 and two with hash=1 must hit hop1.
+	eth, ip4, _, icmp := testingEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	hashes := []uint32{hashForFirstHop, hashForSecondHop, hashForFirstHop, hashForSecondHop}
+
+	result, err := h.HandlePacketsWithHashes(hashes, pkt, pkt, pkt, pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 4, "all packets must be forwarded")
+	require.Empty(t, result.Drop, "no packets should be dropped")
+
+	// Identify which nexthop each packet used by inspecting its destination MAC.
+	hop0Count, hop1Count := 0, 0
+	for _, info := range result.Output {
+		resultPkt := xpacket.ParseEtherPacket(info.RawData)
+		ethLayer := resultPkt.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
+		switch ethLayer.DstMAC.String() {
+		case hop0.DstMAC.String():
+			hop0Count++
+		case hop1.DstMAC.String():
+			hop1Count++
+		}
+	}
+	t.Logf("ECMP distribution: hop0=%d hop1=%d", hop0Count, hop1Count)
+	require.Equal(t, 2, hop0Count, "hop0 must be selected for hash=0 packets")
+	require.Equal(t, 2, hop1Count, "hop1 must be selected for hash=1 packets")
+}
+
+// TestRoute_Counters verifies that the pipeline increments per-direction packet
+// and byte counters correctly for both forwarded and dropped packets.
+func TestRoute_Counters(t *testing.T) {
+	prefix := netip.MustParsePrefix("10.0.0.0/24")
+
+	t.Run("pass", func(t *testing.T) {
+		eth, ip4, _, icmp := testingEtherLayers()
+		ip4.DstIP = net.ParseIP("10.0.0.5")
+
+		pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+		pktSize := uint64(len(pkt.Data()))
+
+		h, agent, backend := setupRouteHarness(t, "port0")
+		applyFIB(t, backend, "test", []FIBEntry{
+			{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+		})
+		wirePipeline(t, agent, "port0", "test")
+
+		result, err := h.HandlePackets(pkt)
+		require.NoError(t, err)
+		require.Len(t, result.Output, 1, "expected one forwarded packet")
+		require.Empty(t, result.Drop, "expected no dropped packets")
+
+		byName := dataplaneut.SingleValueCounters(h.SharedMemory().DPConfig(0).PipelineCounters("port0", "test"))
+
+		// The route module dispatches forwarded packets to the device output
+		// queue inside the pipeline, so packet_front->output is empty at the
+		// end of pipeline_ectx_process.
+		//
+		// The pipeline "output" counter therefore reflects packets that
+		// remained in the output list — zero for a routed packet.
+		//
+		// The distinguishing property of a forwarded packet is that
+		// drop == 0 while input == 1.
+		require.Equal(t, uint64(1), byName["input"], "input counter must equal 1")
+		require.Equal(t, uint64(0), byName["output"], "routed packet leaves via device queue, not pipeline output list")
+		require.Equal(t, uint64(0), byName["drop"], "drop counter must equal 0")
+		require.Equal(t, pktSize, byName["input_bytes"], "input_bytes must equal packet size")
+		require.Equal(t, uint64(0), byName["output_bytes"], "output_bytes must equal 0 for device-dispatched packet")
+		require.Equal(t, uint64(0), byName["drop_bytes"], "drop_bytes must equal 0")
+
+		// Device tx counter is the real pass signal: device_ectx_process_output
+		// increments tx when the packet is handed off to the NIC queue.
+		byDevName := dataplaneut.SingleValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
+		require.Equal(t, uint64(1), byDevName["rx"], "device rx must equal 1")
+		require.Equal(t, uint64(1), byDevName["tx"], "device tx (pass) must equal 1")
+		require.Equal(t, pktSize, byDevName["rx_bytes"], "device rx_bytes must equal packet size")
+		require.Equal(t, pktSize, byDevName["tx_bytes"], "device tx_bytes (pass) must equal packet size")
+	})
+
+	t.Run("drop", func(t *testing.T) {
+		eth, ip4, _, icmp := testingEtherLayers()
+		ip4.DstIP = net.ParseIP("192.168.99.99")
+
+		pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+		pktSize := uint64(len(pkt.Data()))
+
+		h, agent, backend := setupRouteHarness(t, "port0")
+		applyFIB(t, backend, "test", []FIBEntry{
+			{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+		})
+		wirePipeline(t, agent, "port0", "test")
+
+		result, err := h.HandlePackets(pkt)
+		require.NoError(t, err)
+		require.Empty(t, result.Output, "expected no forwarded packets")
+		require.Len(t, result.Drop, 1, "expected one dropped packet")
+
+		byName := dataplaneut.SingleValueCounters(h.SharedMemory().DPConfig(0).PipelineCounters("port0", "test"))
+		require.Equal(t, uint64(1), byName["input"], "input counter must equal 1")
+		require.Equal(t, uint64(0), byName["output"], "output counter must equal 0")
+		require.Equal(t, uint64(1), byName["drop"], "drop counter must equal 1")
+		require.Equal(t, pktSize, byName["input_bytes"], "input_bytes must equal packet size")
+		require.Equal(t, uint64(0), byName["output_bytes"], "output_bytes must equal 0")
+		require.Equal(t, pktSize, byName["drop_bytes"], "drop_bytes must equal packet size")
+
+		// Device tx stays zero for a dropped packet: device_ectx_process_output
+		// is never reached, so no tx increment occurs.
+		byDevName := dataplaneut.SingleValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
+		require.Equal(t, uint64(1), byDevName["rx"], "device rx must equal 1")
+		require.Equal(t, uint64(0), byDevName["tx"], "device tx must equal 0 — packet dropped")
+		require.Equal(t, pktSize, byDevName["rx_bytes"], "device rx_bytes must equal packet size")
+		require.Equal(t, uint64(0), byDevName["tx_bytes"], "device tx_bytes must equal 0")
+	})
+}
+
+// TestRoute_DeviceTranslation_Drop verifies that a route referencing an
+// unregistered output device causes the packet to be dropped.
+//
+// When a nexthop names a device ("phantom") that is not registered as a
+// cp_device, the mc_index slot for that module-device stays at the sentinel
+// value (-1).
+//
+// The route handler calls module_ectx_encode_device which returns the
+// sentinel, then drops the packet.
+func TestRoute_DeviceTranslation_Drop(t *testing.T) {
+	eth, ip4, _, icmp := testingEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	t.Log("Origin packet", pkt)
+
+	prefix := netip.MustParsePrefix("192.168.1.0/24")
+
+	// The nexthop references "phantom" — a device name that will never
+	// appear in UpdatePlainDevices, leaving mc_index at the sentinel.
+	phantomHop := FIBNexthop{
+		DstMAC: xerror.Unwrap(net.ParseMAC("de:ad:00:00:00:ff")),
+		SrcMAC: xerror.Unwrap(net.ParseMAC("ca:fe:00:00:00:ff")),
+		Device: "phantom",
+	}
+
+	h, agent, backend := setupRouteHarness(t, "port0")
+	applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{phantomHop}},
+	})
+
+	// Wire only "port0" through UpdatePlainDevices.
+	//
+	// The "phantom" device referenced by the nexthop has no matching
+	// cp_device, so its mc_index slot remains at the sentinel (-1) after
+	// the link step.
+	wirePipeline(t, agent, "port0", "test")
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "packet with unregistered device must be dropped")
+	require.Len(t, result.Drop, 1, "expected exactly one dropped packet")
+}


### PR DESCRIPTION
- Introduces `lib/dataplane_ut`: in-process harness booting a slimmed real dataplane (no DPDK ports, no worker threads) so modules can be tested through the production write path and the real worker_pipeline_round engine. The harness is single-threaded — concurrent `_run` calls on the same handle race.
- Lifts eight primitives out of `dataplane/` into `lib/dataplane/`: pipeline round driver, storage init, dlsym module/device loaders, topology array allocator, worker counters bootstrap, system agent allocator, counter storage init, time source indirection.
- Adds Go wrapper at `bindings/go/dataplane_ut` mirroring `mock/go`, plus counter-assertion helpers (`RequireModuleCounter`, `SingleValueCounters`, `CounterPath` struct).
- Route functional suite: 9 tests covering v4/v6 forward, TTL and HopLimit drops, no-match drop, non-IP drop, ECMP hash selection, device translation drop, and per-stage counter assertions. They run through the production `route.Backend` write path.
- Forward functional suite: 8 tests covering `forward_handle_packets` cyclomatic branches (no-match passthrough, modes NONE/IN/OUT, unmapped device drop, IPv6, non-IP via vlan-only filter, min-action priority), with inline per-rule counter assertions.
- Production behaviour deltas (both align with `mock`): dlsym loaders free the returned struct on success; topology allocation checks OOM.