### PR TITLE
feat: display agent memory consumption on inspect and dashboard

### DIFF
--- a/web/src/pages/builtin/dashboard/DataplaneModules.tsx
+++ b/web/src/pages/builtin/dashboard/DataplaneModules.tsx
@@ -1,14 +1,17 @@
 import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { InstanceInfo } from '../../../api/inspect';
-import { MODULE_DESCRIPTIONS, MODULE_ROUTES, computeModulePipelineUsage } from '../inspect/utils';
+import { MODULE_DESCRIPTIONS, MODULE_ROUTES, computeModulePipelineUsage, type AgentUsage } from '../inspect/utils';
+import { MemoryBar } from '../inspect/MemoryBar';
+import { fmtIEC } from '../inspect/formatters';
 
 export interface DataplaneModulesProps {
     instance: InstanceInfo;
+    usage: Map<string, AgentUsage>;
 }
 
 /** Full-width dataplane modules grid with routing and active-state indicators. */
-export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance }) => {
+export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance, usage }) => {
     const navigate = useNavigate();
     const modules = instance.dp_modules ?? [];
     const configs = instance.cp_configs ?? [];
@@ -86,6 +89,36 @@ export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance }) 
                             </div>
                             <div className="dash-module-card__desc">{m.desc}</div>
                             <div className="dash-module-card__stats">{m.cfg}cfg · {m.pipe}pipe</div>
+                            {(() => {
+                                const ag = usage.get(m.name);
+                                if (!ag) return null;
+                                return (
+                                    <div className="dash-module-card__mem">
+                                        <div className="dash-module-card__mem-row">
+                                            <span
+                                                style={{
+                                                    color: ag.used > 0
+                                                        ? 'var(--iv-text)'
+                                                        : 'var(--iv-mute)',
+                                                    fontVariantNumeric: 'tabular-nums',
+                                                }}
+                                            >
+                                                {fmtIEC(ag.used)}
+                                            </span>
+                                            <span
+                                                style={{
+                                                    color: 'var(--iv-mute)',
+                                                    fontSize: 9,
+                                                    fontVariantNumeric: 'tabular-nums',
+                                                }}
+                                            >
+                                                {fmtIEC(ag.limit)}
+                                            </span>
+                                        </div>
+                                        <MemoryBar used={ag.used} limit={ag.limit} height={4} cells={20} />
+                                    </div>
+                                );
+                            })()}
                         </div>
                     );
                 })}

--- a/web/src/pages/builtin/dashboard/Inspector.tsx
+++ b/web/src/pages/builtin/dashboard/Inspector.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { Sparkline } from '../inspect/Sparkline';
 import { IconPort, IconTag, IconFn } from '../inspect/icons';
-import { fmtPps, fmtBps } from '../inspect/formatters';
+import { fmtPps, fmtBps, fmtIEC } from '../inspect/formatters';
+import type { AgentUsage } from '../inspect/utils';
+import { MemoryBar } from '../inspect/MemoryBar';
 
 export interface SelectedItem {
     kind: 'device' | 'pipeline' | 'fn';
@@ -65,6 +67,7 @@ export interface InspectorProps {
     structuralPipelines: StructuralPipeline[];
     structuralFunctions: StructuralFunction[];
     live: LiveSnapshot;
+    usage: Map<string, AgentUsage>;
 }
 
 /** A small coloured status dot. */
@@ -111,7 +114,8 @@ const InspectDevice: React.FC<{
     liveD: LiveSnapshot['devicesById'] extends Map<string, infer V> ? V : never;
     pipelines: StructuralPipeline[];
     livePipes: LiveSnapshot['pipelinesById'];
-}> = ({ d, liveD, pipelines, livePipes }) => {
+    usage: Map<string, AgentUsage>;
+}> = ({ d, liveD, pipelines, livePipes, usage }) => {
     const pIn = pipelines.find((p) => p.id === d.pipeIn);
     const pOut = pipelines.find((p) => p.id === d.pipeOut);
     const isVlan = d.kind === 'vlan';
@@ -162,6 +166,30 @@ const InspectDevice: React.FC<{
             <SectionHeader>STATE</SectionHeader>
             <StatRow label="status" value={status} />
             <StatRow label="kind" value={d.kind} />
+            {(() => {
+                const agent = usage.get(d.kind);
+                if (!agent) return null;
+                return (
+                    <>
+                        <SectionHeader>
+                            {'AGENT MEMORY · '}
+                            <span style={{ color: 'var(--iv-text-dim)', textTransform: 'lowercase' }}>
+                                {d.kind}
+                            </span>
+                        </SectionHeader>
+                        <StatRow
+                            label="used"
+                            value={fmtIEC(agent.used)}
+                            hint={`(${(agent.pct * 100).toFixed(1)}%)`}
+                        />
+                        <StatRow label="limit" value={fmtIEC(agent.limit)} />
+                        <StatRow label="free" value={fmtIEC(agent.free)} />
+                        <div style={{ marginTop: 6 }}>
+                            <MemoryBar used={agent.used} limit={agent.limit} height={4} cells={28} />
+                        </div>
+                    </>
+                );
+            })()}
         </div>
     );
 };
@@ -286,6 +314,7 @@ export const Inspector: React.FC<InspectorProps> = ({
     structuralPipelines,
     structuralFunctions,
     live,
+    usage,
 }) => {
     let content: React.ReactNode = null;
     let title = '';
@@ -304,6 +333,7 @@ export const Inspector: React.FC<InspectorProps> = ({
                 liveD={liveD}
                 pipelines={structuralPipelines}
                 livePipes={live.pipelinesById}
+                usage={usage}
             />
         );
         title = 'DEVICE';

--- a/web/src/pages/builtin/dashboard/InstanceCard.tsx
+++ b/web/src/pages/builtin/dashboard/InstanceCard.tsx
@@ -8,6 +8,8 @@ import { IsoScene3D } from './IsoScene3D';
 import { SceneErrorBoundary } from './SceneErrorBoundary';
 import { Throughput } from './Throughput';
 import { DataplaneModules } from './DataplaneModules';
+import { SystemAgents } from '../inspect/SystemAgents';
+import { computeAgentUsage, computeMemoryTotals } from '../inspect/utils';
 
 export interface InstanceCardProps {
     instance: InstanceInfo;
@@ -29,6 +31,9 @@ export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
 
     const workerCount = useWorkerCount(deviceNames);
 
+    const usage = useMemo(() => computeAgentUsage(instance), [instance]);
+    const memTotals = useMemo(() => computeMemoryTotals(usage), [usage]);
+
     const physicalDeviceNames = useMemo(() => {
         const result = new Set<string>();
         devices.forEach((d, idx) => {
@@ -43,7 +48,7 @@ export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
         <>
             <div className="dash-top-row">
                 <div className="dash-top-row__left">
-                    <SystemState workerCount={workerCount} />
+                    <SystemState workerCount={workerCount} memTotals={memTotals} />
                     <KpiStrip instance={instance} />
                 </div>
                 <div className="dash-top-row__right">
@@ -55,9 +60,11 @@ export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
                     instance={instance}
                     rateCounters={rateCounters}
                     absoluteCounters={absoluteCounters}
+                    usage={usage}
                 />
             </SceneErrorBoundary>
-            <DataplaneModules instance={instance} />
+            <DataplaneModules instance={instance} usage={usage} />
+            <SystemAgents instance={instance} usage={usage} />
         </>
     );
 };

--- a/web/src/pages/builtin/dashboard/IsoScene3D.tsx
+++ b/web/src/pages/builtin/dashboard/IsoScene3D.tsx
@@ -6,11 +6,13 @@ import { usePipelineCounters, useFunctionCounters, useDeviceTrendSeries } from '
 import { fmtPps } from '../inspect/formatters';
 import { Inspector } from './Inspector';
 import type { SelectedItem } from './Inspector';
+import type { AgentUsage } from '../inspect/utils';
 
 export interface IsoScene3DProps {
     instance: InstanceInfo;
     rateCounters: Map<string, DeviceCounterData>;
     absoluteCounters: Map<string, DeviceAbsoluteData>;
+    usage: Map<string, AgentUsage>;
 }
 
 interface LabelInfo {
@@ -201,6 +203,7 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
     instance,
     rateCounters,
     absoluteCounters,
+    usage,
 }) => {
     const devices = instance.devices ?? [];
     const pipelines = instance.pipelines ?? [];
@@ -1004,6 +1007,7 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
                     structuralPipelines={structuralPipelines}
                     structuralFunctions={structuralFunctions}
                     live={liveRef.current}
+                    usage={usage}
                 />
             )}
         </div>

--- a/web/src/pages/builtin/dashboard/SystemState.tsx
+++ b/web/src/pages/builtin/dashboard/SystemState.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import type { MemoryTotals } from '../inspect/utils';
+import { fmtIEC } from '../inspect/formatters';
+import { MemoryBar } from '../inspect/MemoryBar';
 
 interface Pair {
     key: string;
@@ -8,14 +11,43 @@ interface Pair {
 
 export interface SystemStateProps {
     workerCount?: number | null;
+    memTotals?: MemoryTotals;
 }
 
 /** System-level status card. Fields without real API values render "—". */
-export const SystemState: React.FC<SystemStateProps> = ({ workerCount }) => {
+export const SystemState: React.FC<SystemStateProps> = ({ workerCount, memTotals }) => {
+    const memValue: React.ReactNode = memTotals && memTotals.memLimit > 0
+        ? (
+            <div className="dash-system__mem">
+                <MemoryBar used={memTotals.memUsed} limit={memTotals.memLimit} height={4} cells={20} />
+                <div className="dash-system__mem-pop">
+                    <div>
+                        <span style={{ color: 'var(--iv-text)' }}>{fmtIEC(memTotals.memUsed)}</span>
+                        <span style={{ color: 'var(--iv-mute)' }}>{' / '}{fmtIEC(memTotals.memLimit)}</span>
+                    </div>
+                    <div style={{ color: 'var(--iv-text-dim)' }}>
+                        {(memTotals.memUsed / memTotals.memLimit * 100).toFixed(2)}% used
+                    </div>
+                    {memTotals.hot != null && (
+                        <div>
+                            <span style={{ color: 'var(--iv-mute)' }}>{'hottest: '}</span>
+                            <span style={{ color: 'var(--iv-text-dim)' }}>{memTotals.hot.name}</span>
+                        </div>
+                    )}
+                    {memTotals.agents > 0 && (
+                        <div style={{ color: 'var(--iv-mute)' }}>
+                            {memTotals.agentsActive}/{memTotals.agents} active
+                        </div>
+                    )}
+                </div>
+            </div>
+        )
+        : '—';
+
     const pairs: Pair[] = [
-        { key: 'uptime',       value: '—' },
-        { key: 'workers',      value: workerCount != null ? String(workerCount) : '—' },
         { key: 'controlplane', value: 'reachable', valueClassName: 'dash-system__ok' },
+        { key: 'workers',      value: workerCount != null ? String(workerCount) : '—' },
+        { key: 'memory',       value: memValue, valueClassName: 'dash-system__mem-cell' },
     ];
 
     return (

--- a/web/src/pages/builtin/dashboard/dashboard.scss
+++ b/web/src/pages/builtin/dashboard/dashboard.scss
@@ -41,6 +41,8 @@
     --iv-ok:             var(--g-color-text-positive);
     --iv-idle:           var(--g-color-text-hint);
     --iv-danger:         var(--g-color-text-danger);
+    --iv-warn:           var(--g-color-text-warning);
+    --iv-faint:          var(--iv-border-strong);
     --iv-mono:           'JetBrains Mono', ui-monospace, monospace;
     --iv-font-ui:        'Inter', system-ui, sans-serif;
 
@@ -595,12 +597,29 @@
         font-size: 9px;
         color: var(--iv-text-dim);
     }
+
+    &__mem {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        margin-top: 2px;
+    }
+
+    &__mem-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        font-size: 10px;
+        font-variant-numeric: tabular-nums;
+    }
 }
 
 // ── System state strip ────────────────────────────────────────────────────────
 
 .dash-system {
     @include dash-ambient-scan;
+    overflow: visible;
+    z-index: 10; // lift above sibling KpiStrip cells (which have z-index: 1)
 
     border: 1px solid var(--iv-border-strong);
     background: var(--iv-surface);
@@ -655,6 +674,49 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.dash-system__mem-cell {
+    flex: 1;
+    min-width: 60px;
+    align-self: center;
+    display: block;
+    overflow: visible;
+    line-height: 0;
+}
+
+.dash-system__mem {
+    position: relative;
+    width: 100%;
+    cursor: default;
+
+    &:hover .dash-system__mem-pop {
+        opacity: 1;
+        pointer-events: auto;
+        transform: translate(-50%, 0);
+    }
+}
+
+.dash-system__mem-pop {
+    position: absolute;
+    left: 50%;
+    top: calc(100% + 8px);
+    bottom: auto;
+    transform: translate(-50%, -4px);
+    min-width: 180px;
+    padding: 8px 10px;
+    background: var(--iv-surface);
+    border: 1px solid var(--iv-border-strong);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+    color: var(--iv-text);
+    font-size: 11px;
+    line-height: 1.4;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 120ms ease-out, transform 120ms ease-out;
+    z-index: 100;
+    font-variant-numeric: tabular-nums;
 }
 
 .dash-dot {

--- a/web/src/pages/builtin/inspect/HudHero.tsx
+++ b/web/src/pages/builtin/inspect/HudHero.tsx
@@ -6,19 +6,60 @@ import { HeroSparkline } from './HeroSparkline';
 import { Crosshair } from './Crosshair';
 import { RadialPulse } from './RadialPulse';
 import { SideKpi } from './SideKpi';
-import { fmtBps, fmtPps } from './formatters';
+import { fmtBps, fmtIEC, fmtPps } from './formatters';
+import { MemoryBar } from './MemoryBar';
+import type { MemoryTotals } from './utils';
 
 export interface HudHeroProps {
     instance: InstanceInfo;
     rateCounters: Map<string, DeviceCounterData>;
     physicalDeviceNames: Set<string>;
+    memTotals: MemoryTotals;
 }
+
+interface SideKpiMemoryProps {
+    totals: MemoryTotals;
+}
+
+/** Memory KPI cell — aggregate used/limit bar with hottest agent callout. */
+const SideKpiMemory: React.FC<SideKpiMemoryProps> = ({ totals }) => (
+    <div className="iv-side-kpi">
+        <div className="iv-side-kpi__label">MEMORY</div>
+        <div
+            style={{
+                fontSize: 22,
+                fontWeight: 500,
+                letterSpacing: -0.5,
+                lineHeight: 1.05,
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: 6,
+            }}
+        >
+            <span>{fmtIEC(totals.memUsed)}</span>
+            <span style={{ fontSize: 11, color: 'var(--iv-text-dim)' }}>
+                / {fmtIEC(totals.memLimit)}
+            </span>
+        </div>
+        <MemoryBar used={totals.memUsed} limit={totals.memLimit} height={4} cells={28} />
+        <div style={{ color: 'var(--iv-text-dim)', fontSize: 10 }}>
+            {totals.agentsActive}/{totals.agents} agents
+            {totals.hot !== null && (
+                <span style={{ color: 'var(--iv-mute)' }}>
+                    {' · hot: '}
+                    <span style={{ color: 'var(--iv-text-dim)' }}>{totals.hot.name}</span>
+                </span>
+            )}
+        </div>
+    </div>
+);
 
 /** Top hero panel showing aggregate throughput and key KPI side columns. */
 export const HudHero: React.FC<HudHeroProps> = ({
     instance,
     rateCounters,
     physicalDeviceNames,
+    memTotals,
 }) => {
     const devices = instance.devices ?? [];
     const pipelines = instance.pipelines ?? [];
@@ -75,7 +116,7 @@ export const HudHero: React.FC<HudHeroProps> = ({
             <div className="iv-hero__side iv-hero__side--right">
                 <SideKpi label="MODULES" primary={modules.length} />
                 <SideKpi label="CONFIGS" primary={configs.length} />
-                <SideKpi label="UPTIME" primary="—" />
+                <SideKpiMemory totals={memTotals} />
             </div>
         </div>
     );

--- a/web/src/pages/builtin/inspect/InstanceCard.tsx
+++ b/web/src/pages/builtin/inspect/InstanceCard.tsx
@@ -4,8 +4,10 @@ import { useDeviceCounters } from '../../../hooks';
 import { HudHero } from './HudHero';
 import { DeviceWall } from './DeviceWall';
 import { ModuleStrip } from './ModuleStrip';
+import { SystemAgents } from './SystemAgents';
 import { PipeWall } from './PipeWall';
 import { FnWall } from './FnWall';
+import { computeAgentUsage, computeMemoryTotals } from './utils';
 
 export interface InstanceCardProps {
     instance: InstanceInfo;
@@ -35,19 +37,24 @@ export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
         return result;
     }, [devices]);
 
+    const agentUsage = useMemo(() => computeAgentUsage(instance), [instance]);
+    const memTotals = useMemo(() => computeMemoryTotals(agentUsage), [agentUsage]);
+
     return (
         <div className="iv-instance">
             <HudHero
                 instance={instance}
                 rateCounters={rateCounters}
                 physicalDeviceNames={physicalDeviceNames}
+                memTotals={memTotals}
             />
             <DeviceWall
                 instance={instance}
                 rateCounters={rateCounters}
                 absoluteCounters={absoluteCounters}
             />
-            <ModuleStrip instance={instance} />
+            <ModuleStrip instance={instance} usage={agentUsage} />
+            <SystemAgents instance={instance} usage={agentUsage} />
             <div className="iv-row">
                 <PipeWall instance={instance} />
                 <FnWall instance={instance} />

--- a/web/src/pages/builtin/inspect/MemoryBar.tsx
+++ b/web/src/pages/builtin/inspect/MemoryBar.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+export interface MemoryBarProps {
+    used: number;
+    limit: number;
+    height?: number;
+    cells?: number;
+    color?: string;
+    muted?: string;
+}
+
+/** HUD-style segmented memory bar. Lit cells are proportional to used/limit. */
+export const MemoryBar: React.FC<MemoryBarProps> = ({
+    used,
+    limit,
+    height = 4,
+    cells = 24,
+    color = 'var(--iv-accent)',
+    muted = 'var(--iv-faint)',
+}) => {
+    const pct = limit > 0 ? Math.min(1, used / limit) : 0;
+    const lit = Math.round(pct * cells);
+    const fill =
+        pct > 0.9
+            ? 'var(--iv-danger)'
+            : pct > 0.7
+              ? 'var(--iv-warn)'
+              : color;
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                gap: 1,
+                height,
+                width: '100%',
+                alignItems: 'stretch',
+            }}
+        >
+            {Array.from({ length: cells }, (_, idx) => (
+                <div
+                    key={idx}
+                    style={{
+                        flex: 1,
+                        background: idx < lit ? fill : muted,
+                        opacity: idx < lit ? 0.55 + (idx / cells) * 0.45 : 1,
+                    }}
+                />
+            ))}
+        </div>
+    );
+};

--- a/web/src/pages/builtin/inspect/ModuleStrip.tsx
+++ b/web/src/pages/builtin/inspect/ModuleStrip.tsx
@@ -1,14 +1,18 @@
 import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { InstanceInfo } from '../../../api/inspect';
+import { fmtIEC } from './formatters';
+import { MemoryBar } from './MemoryBar';
 import { MODULE_DESCRIPTIONS, MODULE_ROUTES, computeModulePipelineUsage } from './utils';
+import type { AgentUsage } from './utils';
 
 export interface ModuleStripProps {
     instance: InstanceInfo;
+    usage: Map<string, AgentUsage>;
 }
 
 /** Horizontal strip showing all dataplane modules with usage indicators. */
-export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance }) => {
+export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance, usage }) => {
     const navigate = useNavigate();
     const modules = instance.dp_modules ?? [];
     const configs = instance.cp_configs ?? [];
@@ -80,6 +84,35 @@ export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance }) => {
                             </div>
                             <div className="iv-module-card__desc">{m.desc}</div>
                             <div className="iv-module-card__stats">{m.cfg}cfg · {m.pipe}pipe</div>
+                            {(() => {
+                                const mem = usage.get(m.name);
+                                if (!mem) return null;
+                                return (
+                                    <div className="iv-module-card__mem">
+                                        <div className="iv-module-card__mem-row">
+                                            <span
+                                                style={{
+                                                    color:
+                                                        mem.used > 0
+                                                            ? 'var(--iv-text)'
+                                                            : 'var(--iv-mute)',
+                                                }}
+                                            >
+                                                {fmtIEC(mem.used)}
+                                            </span>
+                                            <span className="iv-module-card__mem-limit">
+                                                {fmtIEC(mem.limit)}
+                                            </span>
+                                        </div>
+                                        <MemoryBar
+                                            used={mem.used}
+                                            limit={mem.limit}
+                                            height={4}
+                                            cells={20}
+                                        />
+                                    </div>
+                                );
+                            })()}
                         </div>
                     );
                 })}

--- a/web/src/pages/builtin/inspect/SystemAgents.scss
+++ b/web/src/pages/builtin/inspect/SystemAgents.scss
@@ -1,0 +1,60 @@
+.iv-system-agents {
+    border: 1px solid var(--iv-border-strong);
+    background: var(--iv-surface);
+    padding: 10px 16px 11px;
+    flex-shrink: 0;
+
+    .iv-system-agents__header {
+        margin-bottom: 9px;
+    }
+
+    .iv-system-agents__grid {
+        display: grid;
+        gap: 18px;
+    }
+}
+
+.iv-system-agents__row {
+    display: grid;
+    grid-template-columns: 64px 1fr auto;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.iv-system-agents__name {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+}
+
+.iv-system-agents__name-text {
+    font-size: 11px;
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.iv-system-agents__value {
+    font-size: 9.5px;
+    color: var(--iv-text-dim);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.iv-system-agents__title {
+    color: var(--iv-mute);
+    font-size: 10px;
+    letter-spacing: 1.6px;
+}
+
+.iv-system-agents__dot {
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}

--- a/web/src/pages/builtin/inspect/SystemAgents.tsx
+++ b/web/src/pages/builtin/inspect/SystemAgents.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import type { InstanceInfo } from '../../../api/inspect';
+import type { AgentUsage } from './utils';
+import { fmtIEC } from './formatters';
+import { MemoryBar } from './MemoryBar';
+import './SystemAgents.scss';
+
+export interface SystemAgentsProps {
+    instance: InstanceInfo;
+    usage: Map<string, AgentUsage>;
+}
+
+const META_ORDER = ['function', 'pipeline'];
+
+/** Compact horizontal strip for system and meta agents (plain/vlan/function/pipeline). */
+export const SystemAgents: React.FC<SystemAgentsProps> = ({ instance: _instance, usage }) => {
+    const systems: AgentUsage[] = [];
+    const metas: AgentUsage[] = [];
+
+    for (const u of usage.values()) {
+        if (u.kind === 'system') systems.push(u);
+        else if (u.kind === 'meta') metas.push(u);
+    }
+
+    if (systems.length === 0 && metas.length === 0) return null;
+
+    systems.sort((a, b) => a.name.localeCompare(b.name));
+    metas.sort((a, b) => {
+        const ai = META_ORDER.indexOf(a.name);
+        const bi = META_ORDER.indexOf(b.name);
+        const an = ai === -1 ? META_ORDER.length : ai;
+        const bn = bi === -1 ? META_ORDER.length : bi;
+        return an - bn || a.name.localeCompare(b.name);
+    });
+
+    const agents = [...systems, ...metas];
+    const count = agents.length;
+
+    return (
+        <div className="iv-system-agents">
+            <div className="iv-system-agents__header iv-system-agents__title">
+                SYSTEM AGENTS
+            </div>
+            <div
+                className="iv-system-agents__grid"
+                style={{ gridTemplateColumns: `repeat(${count}, 1fr)` }}
+            >
+                {agents.map((a) => {
+                    const accent = a.kind === 'meta' ? 'var(--iv-link)' : 'var(--iv-accent)';
+                    const active = a.used > 0;
+                    return (
+                        <div key={a.name} className="iv-system-agents__row">
+                            <div className="iv-system-agents__name">
+                                <span
+                                    className="iv-system-agents__dot"
+                                    style={{
+                                        background: active ? accent : 'var(--iv-idle)',
+                                    }}
+                                />
+                                <span className="iv-system-agents__name-text">{a.name}</span>
+                            </div>
+                            <MemoryBar
+                                used={a.used}
+                                limit={a.limit}
+                                height={4}
+                                cells={20}
+                                color={accent}
+                            />
+                            <span className="iv-system-agents__value">
+                                <span
+                                    style={{
+                                        color: a.used > 0 ? 'var(--iv-text)' : 'var(--iv-mute)',
+                                    }}
+                                >
+                                    {fmtIEC(a.used)}
+                                </span>
+                                {' '}
+                                <span style={{ color: 'var(--iv-mute)' }}>
+                                    / {fmtIEC(a.limit)}
+                                </span>
+                            </span>
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/web/src/pages/builtin/inspect/formatters.ts
+++ b/web/src/pages/builtin/inspect/formatters.ts
@@ -17,3 +17,14 @@ export const fmtBps = (n: number): string => {
     if (b >= 1e3) return `${(b / 1e3).toFixed(1)}k`;
     return Math.round(b).toString();
 };
+
+/** Format byte count in IEC binary units (KiB/MiB/GiB), 1024-base. Matches CLI. */
+export const fmtIEC = (n: number): string => {
+    if (!n || !isFinite(n)) return '0 B';
+    const KiB = 1024, MiB = KiB * 1024, GiB = MiB * 1024, TiB = GiB * 1024;
+    if (n >= TiB) return `${(n / TiB).toFixed(2)} TiB`;
+    if (n >= GiB) return `${(n / GiB).toFixed(1)} GiB`;
+    if (n >= MiB) return `${(n / MiB).toFixed(1)} MiB`;
+    if (n >= KiB) return `${(n / KiB).toFixed(1)} KiB`;
+    return `${Math.round(n)} B`;
+};

--- a/web/src/pages/builtin/inspect/inspect.scss
+++ b/web/src/pages/builtin/inspect/inspect.scss
@@ -18,6 +18,8 @@
     --iv-ok:             var(--g-color-text-positive);
     --iv-idle:           var(--g-color-text-hint);
     --iv-danger:         var(--g-color-text-danger);
+    --iv-warn:           var(--g-color-text-warning);
+    --iv-faint:          var(--iv-border-strong);
     --iv-r-sm:           4px;
     --iv-r-md:           6px;
     --iv-r-lg:           10px;
@@ -420,6 +422,26 @@
         .iv-module-card__stats {
             font-size: 9px;
             color: var(--iv-text-dim);
+        }
+
+        .iv-module-card__mem {
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
+            margin-top: 2px;
+        }
+
+        .iv-module-card__mem-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            font-size: 10px;
+            font-variant-numeric: tabular-nums;
+        }
+
+        .iv-module-card__mem-limit {
+            font-size: 9px;
+            color: var(--iv-mute);
         }
     }
 

--- a/web/src/pages/builtin/inspect/utils.ts
+++ b/web/src/pages/builtin/inspect/utils.ts
@@ -1,4 +1,4 @@
-import type { InstanceInfo } from '../../../api/inspect';
+import type { AgentInfo, InstanceInfo } from '../../../api/inspect';
 
 /** Per-module deep-link route. Modules without a dedicated page are absent. */
 export const MODULE_ROUTES: Record<string, string> = {
@@ -56,6 +56,104 @@ export const computeModulesInUse = (instance: InstanceInfo): number => {
         if (used.has(t)) count += 1;
     }
     return count;
+};
+
+export type AgentKind = 'module' | 'system' | 'meta';
+
+/** Aggregated memory and generation metrics for one named agent. */
+export interface AgentUsage {
+    name: string;
+    kind: AgentKind;
+    used: number;
+    limit: number;
+    free: number;
+    pct: number;
+    gen: number;
+    instances: number;
+}
+
+/** Instance-level memory totals derived from all agent usages. */
+export interface MemoryTotals {
+    memUsed: number;
+    memLimit: number;
+    agents: number;
+    agentsActive: number;
+    hot: AgentUsage | null;
+}
+
+const META_AGENTS = new Set(['function', 'pipeline']);
+
+/**
+ * Classify and aggregate per-agent memory metrics from instance.agents.
+ *
+ * Classification priority: meta (function/pipeline) > module (dp_module name
+ * match) > system (everything else — plain, vlan, and any future device-type
+ * agents regardless of whether devices of that type are present).
+ */
+export const computeAgentUsage = (instance: InstanceInfo): Map<string, AgentUsage> => {
+    const moduleNames = new Set((instance.dp_modules ?? []).map((m) => m.name ?? ''));
+
+    const result = new Map<string, AgentUsage>();
+    for (const agent of (instance.agents ?? []) as AgentInfo[]) {
+        const name = agent.name ?? '';
+        let kind: AgentKind;
+        if (META_AGENTS.has(name)) {
+            kind = 'meta';
+        } else if (moduleNames.has(name)) {
+            kind = 'module';
+        } else {
+            kind = 'system';
+        }
+
+        let limit = 0;
+        let free = 0;
+        let maxGen = 0;
+        const instanceList = agent.instances ?? [];
+        for (const inst of instanceList) {
+            limit += Number(inst.memory_limit ?? 0);
+            free += Number(inst.free_bytes ?? 0);
+            const g = Number(inst.generation ?? 0);
+            if (g > maxGen) maxGen = g;
+        }
+        const used = Math.max(0, limit - free);
+        const pct = limit > 0 ? used / limit : 0;
+
+        result.set(name, {
+            name,
+            kind,
+            used,
+            limit,
+            free,
+            pct,
+            gen: maxGen,
+            instances: instanceList.length,
+        });
+    }
+    return result;
+};
+
+/**
+ * Compute instance-level memory totals from a pre-built agent usage map.
+ */
+export const computeMemoryTotals = (usage: Map<string, AgentUsage>): MemoryTotals => {
+    let memUsed = 0;
+    let memLimit = 0;
+    let agents = 0;
+    let agentsActive = 0;
+    let hot: AgentUsage | null = null;
+
+    for (const u of usage.values()) {
+        memUsed += u.used;
+        memLimit += u.limit;
+        agents += 1;
+        if (u.used > 0) {
+            agentsActive += 1;
+            if (!hot || u.pct > hot.pct) {
+                hot = u;
+            }
+        }
+    }
+    return { memUsed, memLimit, agents, agentsActive, hot };
 };
 
 /**


### PR DESCRIPTION
Surface per-agent memory usage data that already arrives through the inspect API across the inspect and dashboard pages, so operators can spot tight arenas at a glance.

- Add a memory KPI to the inspect HUD hero (aggregate used / limit with a HUD bar and the hottest agent).
- Render per-module memory bars on the inspect module strip and on the dashboard module grid.
- Introduce a shared system-agents strip surfacing the plain, vlan, function, and pipeline arenas with utilisation bars.
- Add a per-device AGENT MEMORY section to the dashboard inspector panel.
- Trim the dashboard system-state card to controlplane / workers / memory, where memory is a compact progress bar that reveals a detailed breakdown on hover.