### PR TITLE
meson.build: use add_project_arguments for subproject compatibility

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,7 @@ project(
   ],
 )
 
-add_global_arguments(
+add_project_arguments(
   ['-march=' + get_option('cpu_arch'), '-g', '-D_GNU_SOURCE'],
   language: 'c',
 )


### PR DESCRIPTION
Replace add_global_arguments with add_project_arguments to allow
using yanet2 as a Meson subproject for independent module development.