### PR TITLE
Registry item should be referenced on insert

### DIFF
--- a/lib/controlplane/config/registry.h
+++ b/lib/controlplane/config/registry.h
@@ -4,7 +4,6 @@
 
 struct registry_item {
 	uint64_t refcnt;
-	uint64_t index;
 };
 
 static inline void
@@ -224,6 +223,7 @@ registry_insert(struct registry *registry, struct registry_item *new_item) {
 	}
 
 	registry_set(registry, index, new_item);
+	registry_item_ref(new_item);
 
 	return 0;
 }
@@ -258,7 +258,6 @@ registry_replace(
 	struct registry_item *old_item = registry_get(registry, index);
 	if (new_item != NULL) {
 		registry_item_ref(new_item);
-		new_item->index = index;
 	}
 
 	registry_set(registry, index, new_item);


### PR DESCRIPTION
Also remove unused `index` attribute from `registry item`