### PR TITLE
fix(web/dashboard): revert tx signal in particle path activity

### DIFF
--- a/web/src/pages/builtin/dashboard/IsoScene3D.tsx
+++ b/web/src/pages/builtin/dashboard/IsoScene3D.tsx
@@ -810,8 +810,7 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
 
                 const pathPps = fwdPaths.map((path) => {
                     const liveDev = live.devicesById.get(path.deviceId);
-                    if (!liveDev || liveDev.status !== 'ok') return 0;
-                    return Math.max(liveDev.rxPps, liveDev.txPps);
+                    return liveDev?.status === 'ok' ? liveDev.rxPps : 0;
                 });
                 const currentMax = pathPps.reduce((m, v) => (v > m ? v : m), 0);
                 const decayed = peakPpsRef.current * PARTICLE_REF_DECAY;


### PR DESCRIPTION
Using `max(rxPps, txPps)` as the per-path activity signal caused particles to disappear at both low (1-2 Kpps) and high (1-2 Mpps) load regimes. Revert that part of #864; the minimum visible fraction floor is kept since it's a one-way safety net that only adds visibility for active paths.