### PR TITLE
fix(web/dashboard): drop status gate on traffic particles

### DIFF
--- a/web/src/pages/builtin/dashboard/IsoScene3D.tsx
+++ b/web/src/pages/builtin/dashboard/IsoScene3D.tsx
@@ -822,7 +822,7 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
 
                 const pathPps = fwdPaths.map((path) => {
                     const liveDev = live.devicesById.get(path.deviceId);
-                    return liveDev?.status === 'ok' ? liveDev.rxPps : 0;
+                    return liveDev?.rxPps ?? 0;
                 });
                 const currentMax = pathPps.reduce((m, v) => (v > m ? v : m), 0);
                 const decayed = peakPpsRef.current * PARTICLE_REF_DECAY;


### PR DESCRIPTION
Particles were gated on a device's overall `status === 'ok'`, which is derived from absolute packet counters. In setups where the absolute counter stream is delayed, uninitialised, or partially broken while the rate counter is reporting hundreds of thousands of pps, the status stayed `'idle'` and the particles disappeared even under heavy real load — the previously added minimum-visible-fraction floor could not save them because `pathPps` was already clamped to zero before the floor was evaluated.

Use the rate counter directly for the particle activity signal. Other meshes (devices, pipelines, wires, labels) still use the absolute-derived status for their own liveness semantics, which is the right thing for "ever lived" coloring.