### PR TITLE
fix(value_registry): null all fields on free

### DIFF
--- a/common/registry.h
+++ b/common/registry.h
@@ -293,6 +293,8 @@ value_registry_free(struct value_registry *registry) {
 		);
 	}
 	SET_OFFSET_OF(&registry->ranges, NULL);
+	registry->range_count = 0;
+	registry->max_value = 0;
 }
 
 static inline uint32_t


### PR DESCRIPTION
This PR ensures value_registry is fully reset by clearing the range_count and max_value fields, which were previously left untouched. This makes the free operation idempotent.