### PR TITLE
feat(web/dashboard): drive particle speed and count by absolute PPS

### DIFF
--- a/web/src/pages/builtin/dashboard/IsoScene3D.tsx
+++ b/web/src/pages/builtin/dashboard/IsoScene3D.tsx
@@ -9,10 +9,14 @@ import type { SelectedItem } from './Inspector';
 import type { AgentUsage } from '../inspect/utils';
 import { metaFor } from '../functions/moduleMeta';
 
-const PARTICLE_MIN_REF_PPS = 10;
-const PARTICLE_REF_DECAY = 0.995;
-const PARTICLE_MAX_DT = 0.05;
-const PARTICLE_MIN_VISIBLE_FRACTION = 0.15;
+const PARTICLE_PPS_LOW = 1000;
+const PARTICLE_PPS_HIGH = 100_000_000;
+const PARTICLE_TIME_AT_LOW_SEC = 5.0;
+const PARTICLE_TIME_AT_HIGH_SEC = 0.5;
+const PARTICLE_COUNT_AT_LOW = 5;
+const PARTICLE_COUNT_AT_HIGH = 100;
+const PARTICLE_COUNT_PER_PATH = PARTICLE_COUNT_AT_HIGH;
+const PARTICLE_MAX_FRAME_DT_SEC = 0.1;
 
 export interface IsoScene3DProps {
     instance: InstanceInfo;
@@ -37,16 +41,17 @@ interface FwdPath {
     pts: THREE.Vector3[];
     lens: number[];
     total: number;
-    density: number;
     deviceId: string;
 }
 
 interface Particle {
     pi: number;
+    idxInPath: number;
     t: number;
-    speed: number;
     posIdx: number;
-    lastFraction: number;
+    lastDtRate: number;
+    speedMul: number;
+    rank: number;
 }
 
 interface ParticleSystem {
@@ -177,24 +182,25 @@ const buildParticles = (
     color: number,
     sizeBase: number,
 ): ParticleSystem => {
-    const N = paths.reduce((sum, p) => sum + Math.max(1, Math.round(p.density * 18)), 0);
+    const N = paths.length * PARTICLE_COUNT_PER_PATH;
     if (!N) return { points: null, ps: [], geo: null };
 
     const positions = new Float32Array(N * 3);
     const ps: Particle[] = [];
     let idx = 0;
-    paths.forEach((path, pi) => {
-        const count = Math.max(1, Math.round(path.density * 18));
-        for (let i = 0; i < count; i++) {
+    paths.forEach((_path, pi) => {
+        for (let i = 0; i < PARTICLE_COUNT_PER_PATH; i++) {
             ps.push({
                 pi,
-                t: Math.random(),
-                speed: 0.0008 + path.density * 0.0014,
+                idxInPath: i,
+                t: i / PARTICLE_COUNT_PER_PATH,
                 posIdx: idx,
-                lastFraction: 0,
+                lastDtRate: 0,
+                speedMul: 0.8 + Math.random() * 0.4,
+                rank: Math.random(),
             });
             positions[idx * 3 + 0] = 0;
-            positions[idx * 3 + 1] = 0;
+            positions[idx * 3 + 1] = -1000;
             positions[idx * 3 + 2] = 0;
             idx++;
         }
@@ -211,6 +217,7 @@ const buildParticles = (
         depthWrite: false,
     });
     const points = new THREE.Points(geo, mat);
+    points.frustumCulled = false;
     return { points, ps, geo };
 };
 
@@ -376,7 +383,8 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
     });
     const canvasSizeRef = useRef(canvasSize);
     canvasSizeRef.current = canvasSize;
-    const peakPpsRef = useRef<number>(PARTICLE_MIN_REF_PPS);
+    const lastFrameTimeRef = useRef<number | null>(null);
+    const pathActiveRef = useRef<boolean[]>([]);
 
     useEffect(() => {
         const check = (): boolean => {
@@ -617,7 +625,7 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
             const mat = new THREE.LineBasicMaterial({
                 color: 0x3a3731,
                 transparent: true,
-                opacity: 0.3,
+                opacity: 0.25,
             });
             const line = new THREE.Line(geo, mat);
             scene.add(line);
@@ -644,7 +652,7 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
                 lens.push(l);
                 total += l;
             }
-            fwdPaths.push({ pts, lens, total, density: 0.5, deviceId: d.id });
+            fwdPaths.push({ pts, lens, total, deviceId: d.id });
         });
 
         const fwdPS = buildParticles(fwdPaths, 0xFFC061, 2.4);
@@ -811,60 +819,94 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
 
             wires.forEach((w) => {
                 const liveDev = live.devicesById.get(w.deviceId);
-                const active = liveDev?.status === 'ok' && (liveDev?.rxPps ?? 0) > 0;
+                const pps = liveDev?.rxPps ?? 0;
+                const active = pps > 0;
                 const wireMat = w.line.material as THREE.LineBasicMaterial;
                 wireMat.color.setHex(active ? 0xFFC061 : 0x3a3731);
-                wireMat.opacity = active ? 0.55 : 0.3;
+                wireMat.opacity = active ? 0.4 : 0.25;
             });
 
             if (fwdPS.points && fwdPS.geo) {
                 const positions = fwdPS.geo.attributes['position'].array as Float32Array;
 
+                const rawDt = lastFrameTimeRef.current === null
+                    ? 0
+                    : (now - lastFrameTimeRef.current) / 1000;
+                lastFrameTimeRef.current = now;
+                const dtSec = Math.min(PARTICLE_MAX_FRAME_DT_SEC, Math.max(0, rawDt));
+
                 const pathPps = fwdPaths.map((path) => {
                     const liveDev = live.devicesById.get(path.deviceId);
                     return liveDev?.rxPps ?? 0;
                 });
-                const currentMax = pathPps.reduce((m, v) => (v > m ? v : m), 0);
-                const decayed = peakPpsRef.current * PARTICLE_REF_DECAY;
-                const peak = Math.max(currentMax, decayed, PARTICLE_MIN_REF_PPS);
-                peakPpsRef.current = peak;
-                const logFloor = Math.log10(PARTICLE_MIN_REF_PPS);
-                const logPeak = Math.log10(peak);
-                const logSpan = Math.max(logPeak - logFloor, 1e-6);
+
+                const logLow = Math.log10(PARTICLE_PPS_LOW);
+                const logHigh = Math.log10(PARTICLE_PPS_HIGH);
+                const logSpan = logHigh - logLow;
+
+                interface PathState {
+                    active: boolean;
+                    dtRate: number;
+                    visibleFraction: number;
+                }
+                const pathStates: PathState[] = pathPps.map((pps) => {
+                    if (pps <= 0) return { active: false, dtRate: 0, visibleFraction: 0 };
+                    const clamped = Math.max(PARTICLE_PPS_LOW, Math.min(PARTICLE_PPS_HIGH, pps));
+                    const u = (Math.log10(clamped) - logLow) / logSpan;
+                    const T_sec = PARTICLE_TIME_AT_LOW_SEC
+                        + (PARTICLE_TIME_AT_HIGH_SEC - PARTICLE_TIME_AT_LOW_SEC) * u;
+                    const N_desired = Math.max(
+                        1,
+                        Math.round(
+                            PARTICLE_COUNT_AT_LOW
+                            * Math.pow(PARTICLE_COUNT_AT_HIGH / PARTICLE_COUNT_AT_LOW, u),
+                        ),
+                    );
+                    return {
+                        active: true,
+                        dtRate: 1 / T_sec,
+                        visibleFraction: N_desired / PARTICLE_COUNT_PER_PATH,
+                    };
+                });
+
+                const wasActive = pathActiveRef.current;
+                const newActive = pathStates.map((s) => s.active);
+                pathActiveRef.current = newActive;
 
                 fwdPS.ps.forEach((p) => {
                     const path = fwdPaths[p.pi];
-                    if (!path) return;
-                    const pps = pathPps[p.pi];
-                    const baseFraction = pps <= 0
-                        ? 0
-                        : Math.min(1, (Math.log10(Math.max(pps, PARTICLE_MIN_REF_PPS)) - logFloor) / logSpan);
-                    const fraction = baseFraction > 0
-                        ? Math.max(baseFraction, PARTICLE_MIN_VISIBLE_FRACTION)
-                        : 0;
+                    const ps = pathStates[p.pi];
+                    if (!path || !ps) return;
 
-                    if (fraction > 0) {
-                        if (p.lastFraction === 0) {
-                            p.t = Math.random();
+                    let render = false;
+                    if (ps.active) {
+                        if (!wasActive[p.pi]) {
+                            p.t = p.idxInPath / PARTICLE_COUNT_PER_PATH;
+                            p.lastDtRate = 0;
                         }
-                        p.t += Math.min(PARTICLE_MAX_DT, p.speed * 4 * fraction);
+                        p.t += dtSec * ps.dtRate * p.speedMul;
                         if (p.t > 1) p.t -= 1;
-                        p.lastFraction = fraction;
-                    } else {
-                        if (p.lastFraction === 0) {
-                            positions[p.posIdx * 3 + 0] = 0;
-                            positions[p.posIdx * 3 + 1] = -1000;
-                            positions[p.posIdx * 3 + 2] = 0;
-                            return;
+                        const visible = p.rank < ps.visibleFraction;
+                        if (visible) {
+                            p.lastDtRate = ps.dtRate * p.speedMul;
+                            render = true;
+                        } else {
+                            p.lastDtRate = 0;
                         }
-                        p.t += Math.min(PARTICLE_MAX_DT, p.speed * 4 * p.lastFraction);
+                    } else if (p.lastDtRate > 0) {
+                        p.t += dtSec * p.lastDtRate;
                         if (p.t > 1) {
-                            p.lastFraction = 0;
-                            positions[p.posIdx * 3 + 0] = 0;
-                            positions[p.posIdx * 3 + 1] = -1000;
-                            positions[p.posIdx * 3 + 2] = 0;
-                            return;
+                            p.lastDtRate = 0;
+                        } else {
+                            render = true;
                         }
+                    }
+
+                    if (!render) {
+                        positions[p.posIdx * 3 + 0] = 0;
+                        positions[p.posIdx * 3 + 1] = -1000;
+                        positions[p.posIdx * 3 + 2] = 0;
+                        return;
                     }
 
                     const target = p.t * path.total;


### PR DESCRIPTION
The dashboard's floating traffic particles now react to absolute PPS instead of being normalized against a running peak across paths. Traversal time is interpolated linearly in log10(pps) between five seconds at 1 Kpps and a fraction of a second at 100 Mpps; particle count grows geometrically across the same range.

Each particle is seeded once at creation with a small random speed multiplier and a visibility rank, so the stream looks organic rather than marching in lockstep, and the visible subset changes naturally with load.

A few smaller fixes ride along: the per-frame advancement uses the real \`requestAnimationFrame\` delta capped at 100 ms so backgrounded tabs don't fast-forward, particles drain to the end of their path when traffic stops, and the Points object opts out of frustum culling — that was the silent culprit behind particles intermittently disappearing whenever the bounding sphere was captured from the initial parked positions.