### PR TITLE
fix(filter,acl,forward,route-mpls): propagate err out of filter_init

### DIFF
--- a/filter/compiler.h
+++ b/filter/compiler.h
@@ -8,26 +8,14 @@
 #include "common/memory.h"
 #include "common/registry.h"
 #include "common/value.h"
+#include "lib/errors/errors.h"
 #include <assert.h>
 
-/**
- * @file compiler.h
- * @brief Build/teardown macros for filter classification trees.
- *
- * Defines:
- *  - filter_init: build a filter for a declared attribute signature
- *  - filter_free: free resources allocated by filter_init
- */
-/**
- * @def filter_init(filter, tag, rules, rule_count, ctx)
- * @brief Build filter for signature tag into filter using rules.
- * @param filter struct filter*
- * @param tag name used in FILTER_COMPILER_DECLARE(...)
- * @param rules const struct filter_rule* array
- * @param rule_count size_t number of rules
- * @param ctx const struct memory_context* source context
- * @return int 0 on success, negative on error
- */
+// Build and teardown functions for filter classification trees.
+//
+// filter_init: build a filter for a declared attribute signature; reports the
+// failing step via err. filter_free: release all resources allocated by
+// filter_init.
 typedef int (*filter_lookup_init_func)(
 	struct value_registry *registry,
 	void **data,
@@ -84,16 +72,23 @@ filter_init(
 	const struct filter_compiler *filter_compiler,
 	const struct filter_rule **rules,
 	uint32_t rule_count,
-	struct memory_context *memory_context
+	struct memory_context *memory_context,
+	yanet_error **err
 ) {
-	if (filter_compiler->lookup_count == 0)
+	if (filter_compiler->lookup_count == 0) {
+		yanet_error_add(err, "filter has no lookups configured");
 		return -1;
+	}
 
 	memset(filter, 0, sizeof(struct filter));
 
 	if (memory_context_init_from(
 		    &filter->memory_context, memory_context, "filter"
 	    )) {
+		yanet_error_add(
+			err,
+			"out of memory: failed to init filter memory context"
+		);
 		return -1;
 	}
 
@@ -105,6 +100,12 @@ filter_init(
 		if (value_registry_init(
 			    &v->registry, &filter->memory_context
 		    )) {
+			yanet_error_add(
+				err,
+				"out of memory: failed to init registry for "
+				"lookup %zu",
+				(size_t)lookup_idx
+			);
 			goto init_failed;
 		}
 		v->data = NULL;
@@ -115,6 +116,12 @@ filter_init(
 			    rule_count,
 			    &filter->memory_context
 		    )) {
+			yanet_error_add(
+				err,
+				"out of memory: failed to compile attribute "
+				"lookup %zu",
+				(size_t)lookup_idx
+			);
 			goto init_failed;
 		}
 	}
@@ -124,6 +131,10 @@ filter_init(
 		if (init_dummy_registry(
 			    &filter->memory_context, rule_count, &dummy
 		    )) {
+			yanet_error_add(
+				err,
+				"out of memory: failed to init dummy registry"
+			);
 			value_registry_free(&dummy);
 			goto init_failed;
 		}
@@ -134,6 +145,10 @@ filter_init(
 			    &filter->v[1].registry,
 			    &filter->v[0].table
 		    )) {
+			yanet_error_add(
+				err,
+				"out of memory: failed to merge registry values"
+			);
 			value_registry_free(&dummy);
 			goto init_failed;
 		}
@@ -150,6 +165,12 @@ filter_init(
 			    &filter->v[idx].table,
 			    &filter->v[idx].registry
 		    )) {
+			yanet_error_add(
+				err,
+				"out of memory: failed to collect registry at "
+				"index %zu",
+				idx
+			);
 			goto init_failed;
 		}
 	}
@@ -160,6 +181,10 @@ filter_init(
 		    &filter->v[2 * 1 + 1].registry,
 		    &filter->v[1].table
 	    )) {
+		yanet_error_add(
+			err,
+			"out of memory: failed to merge final registry values"
+		);
 		goto init_failed;
 	}
 

--- a/filter/meson.build
+++ b/filter/meson.build
@@ -23,13 +23,14 @@ lib_filter_compiler = static_library(
   compiler_sources,
   c_args: yanet_c_args,
   link_args: yanet_link_args,
-  dependencies: [lib_common_dep],
+  dependencies: [lib_common_dep, lib_errors_dep],
   install: false,
 )
 
 lib_filter_compiler_dep = declare_dependency(
   link_with: lib_filter_compiler,
-  include_directories: include_directories('.'), 
+  include_directories: include_directories('.'),
+  dependencies: [lib_errors_dep],
 )
 
 subdir('tests')

--- a/filter/tests/basic_net4.c
+++ b/filter/tests/basic_net4.c
@@ -132,7 +132,7 @@ test_stress_seed12_regression(void *memory, size_t memory_size) {
 	// Initialize filter with all 20 rules
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net4_compile, rule_ptrs, 20, &memory_context
+		&filter, sign_net4_compile, rule_ptrs, 20, &memory_context, NULL
 	);
 	assert(res == 0);
 
@@ -196,7 +196,12 @@ main() {
 	// init filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net4_compile, &action_ptr, 1, &memory_context
+		&filter,
+		sign_net4_compile,
+		&action_ptr,
+		1,
+		&memory_context,
+		NULL
 	);
 	assert(res == 0);
 
@@ -235,7 +240,12 @@ main() {
 
 	struct filter filter2;
 	res = filter_init(
-		&filter2, sign_net4_compile, &action2_ptr, 1, &memory_context
+		&filter2,
+		sign_net4_compile,
+		&action2_ptr,
+		1,
+		&memory_context,
+		NULL
 	);
 	assert(res == 0);
 

--- a/filter/tests/basic_net4_fast.c
+++ b/filter/tests/basic_net4_fast.c
@@ -215,7 +215,8 @@ test_basic(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -223,7 +224,8 @@ test_basic(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -411,7 +413,8 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			num_rules,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -419,7 +422,8 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			num_rules,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -537,7 +541,8 @@ stress(void *arena,
 			sign_fast_src_compile,
 			rule_ptrs,
 			num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case dst:
@@ -546,7 +551,8 @@ stress(void *arena,
 			sign_fast_dst_compile,
 			rule_ptrs,
 			num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case src_dst:
@@ -555,7 +561,8 @@ stress(void *arena,
 			sign_fast_src_dst_compile,
 			rule_ptrs,
 			num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	}
@@ -739,7 +746,8 @@ test_no_match(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -747,7 +755,8 @@ test_no_match(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -867,7 +876,8 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -875,7 +885,8 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -988,7 +999,8 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -996,7 +1008,8 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1116,7 +1129,8 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -1124,7 +1138,8 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1245,7 +1260,8 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -1253,7 +1269,8 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");

--- a/filter/tests/basic_net6.c
+++ b/filter/tests/basic_net6.c
@@ -147,7 +147,9 @@ test1(void *memory) {
 
 	// init filter
 	struct filter filter;
-	res = filter_init(&filter, sign_net6_dst_compile, rule_ptrs, 1, &mctx);
+	res = filter_init(
+		&filter, sign_net6_dst_compile, rule_ptrs, 1, &mctx, NULL
+	);
 	assert(res == 0);
 
 	// query packet 1
@@ -298,7 +300,9 @@ test2(void *memory) {
 
 	// init filter
 	struct filter filter;
-	res = filter_init(&filter, sign_net6_dst_compile, rule_ptrs, 1, &mctx);
+	res = filter_init(
+		&filter, sign_net6_dst_compile, rule_ptrs, 1, &mctx, NULL
+	);
 	assert(res == 0);
 
 	// query packet 1
@@ -517,7 +521,9 @@ test3(void *memory) {
 
 	// init filter
 	struct filter filter;
-	res = filter_init(&filter, sign_net6_compile, rule_ptrs, 2, &mctx);
+	res = filter_init(
+		&filter, sign_net6_compile, rule_ptrs, 2, &mctx, NULL
+	);
 	assert(res == 0);
 
 	// query packet 1

--- a/filter/tests/basic_net6_fast.c
+++ b/filter/tests/basic_net6_fast.c
@@ -232,7 +232,8 @@ test_basic(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -240,7 +241,8 @@ test_basic(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -544,7 +546,8 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			num_rules,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -552,7 +555,8 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			num_rules,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -680,7 +684,8 @@ stress(void *arena,
 			sign_fast_src_compile,
 			rule_ptrs,
 			num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case dst:
@@ -689,7 +694,8 @@ stress(void *arena,
 			sign_fast_dst_compile,
 			rule_ptrs,
 			num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case src_dst:
@@ -698,7 +704,8 @@ stress(void *arena,
 			sign_fast_src_dst_compile,
 			rule_ptrs,
 			num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	}
@@ -900,7 +907,8 @@ test_no_match(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -908,7 +916,8 @@ test_no_match(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1130,7 +1139,8 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -1138,7 +1148,8 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1312,7 +1323,8 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -1320,7 +1332,8 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1463,7 +1476,8 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -1471,7 +1485,8 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1655,7 +1670,8 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -1663,7 +1679,8 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			nets_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");

--- a/filter/tests/basic_port_fast.c
+++ b/filter/tests/basic_port_fast.c
@@ -214,7 +214,8 @@ test_basic(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -222,7 +223,8 @@ test_basic(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -362,7 +364,8 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			num_rules,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -370,7 +373,8 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			num_rules,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -478,7 +482,8 @@ stress(void *arena,
 			sign_fast_src_compile,
 			rule_ptrs,
 			num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case dst:
@@ -487,7 +492,8 @@ stress(void *arena,
 			sign_fast_dst_compile,
 			rule_ptrs,
 			num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case src_dst:
@@ -496,7 +502,8 @@ stress(void *arena,
 			sign_fast_src_dst_compile,
 			rule_ptrs,
 			num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	}
@@ -720,7 +727,8 @@ test_no_match(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -728,7 +736,8 @@ test_no_match(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -856,7 +865,8 @@ test_overlapping_ranges(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -864,7 +874,8 @@ test_overlapping_ranges(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -985,7 +996,8 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -993,7 +1005,8 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1126,7 +1139,8 @@ test_single_port_ranges(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -1134,7 +1148,8 @@ test_single_port_ranges(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1262,7 +1277,8 @@ test_adjacent_ranges(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -1270,7 +1286,8 @@ test_adjacent_ranges(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
@@ -1402,7 +1419,8 @@ test_extreme_ports(void *arena, enum filter_sign sign) {
 			sign_fast_src_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	} else {
 		res = filter_init(
@@ -1410,7 +1428,8 @@ test_extreme_ports(void *arena, enum filter_sign sign) {
 			sign_fast_dst_compile,
 			rule_ptrs,
 			ranges_count,
-			&mctx
+			&mctx,
+			NULL
 		);
 	}
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");

--- a/filter/tests/basic_ports.c
+++ b/filter/tests/basic_ports.c
@@ -86,7 +86,7 @@ test_src_dst_ports(void *memory) {
 	// init filter
 	struct filter f;
 	res = filter_init(
-		&f, sign_ports_compile, action_ptrs, 2, &memory_context
+		&f, sign_ports_compile, action_ptrs, 2, &memory_context, NULL
 	);
 	assert(res == 0);
 
@@ -133,7 +133,7 @@ src_dst_ports(void *memory) {
 
 	struct filter f;
 	res = filter_init(
-		&f, sign_ports_compile, action_ptrs, 3, &memory_context
+		&f, sign_ports_compile, action_ptrs, 3, &memory_context, NULL
 	);
 	assert(res == 0);
 
@@ -198,7 +198,7 @@ test_any_port(void *memory) {
 
 	struct filter f;
 	res = filter_init(
-		&f, sign_ports_compile, action_ptrs, 3, &memory_context
+		&f, sign_ports_compile, action_ptrs, 3, &memory_context, NULL
 	);
 	assert(res == 0);
 

--- a/filter/tests/basic_proto.c
+++ b/filter/tests/basic_proto.c
@@ -74,7 +74,7 @@ test_proto_1(void *memory) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_proto_compile, rule_ptrs, 3, &memory_context
+		&filter, sign_proto_compile, rule_ptrs, 3, &memory_context, NULL
 	);
 	assert(res == 0);
 

--- a/filter/tests/basic_proto_range.c
+++ b/filter/tests/basic_proto_range.c
@@ -73,7 +73,12 @@ test_proto_1(void *memory) {
 
 	LOG(INFO, "filter init...");
 	res = filter_init(
-		&filter, sign_proto_range_compile, rule_ptrs, 2, &memory_context
+		&filter,
+		sign_proto_range_compile,
+		rule_ptrs,
+		2,
+		&memory_context,
+		NULL
 	);
 	assert(res == 0);
 

--- a/filter/tests/basic_proto_range_fast.c
+++ b/filter/tests/basic_proto_range_fast.c
@@ -87,7 +87,8 @@ test_basic_tcp_udp(void *memory) {
 		sign_proto_range_fast_compile,
 		rule_ptrs,
 		2,
-		&memory_context
+		&memory_context,
+		NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -151,7 +152,8 @@ test_tcp_flags(void *memory) {
 		sign_proto_range_fast_compile,
 		rule_ptrs,
 		3,
-		&memory_context
+		&memory_context,
+		NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -205,7 +207,8 @@ test_multiple_ranges_per_rule(void *memory) {
 		sign_proto_range_fast_compile,
 		rule_ptrs,
 		1,
-		&memory_context
+		&memory_context,
+		NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -257,7 +260,8 @@ test_boundary_values(void *memory) {
 		sign_proto_range_fast_compile,
 		rule_ptrs,
 		2,
-		&memory_context
+		&memory_context,
+		NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 

--- a/filter/tests/basic_vlan.c
+++ b/filter/tests/basic_vlan.c
@@ -62,7 +62,7 @@ test_proto_1(void *memory) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_vlan_compile, rule_ptrs, 3, &memory_context
+		&filter, sign_vlan_compile, rule_ptrs, 3, &memory_context, NULL
 	);
 	assert(res == 0);
 

--- a/filter/tests/bench_net4.c
+++ b/filter/tests/bench_net4.c
@@ -561,7 +561,8 @@ main(int argc, char **argv) {
 			bench_dst_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case sig_net4_dst_port:
@@ -570,7 +571,8 @@ main(int argc, char **argv) {
 			bench_dst_port_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case sig_net4_dst_port_proto:
@@ -579,7 +581,8 @@ main(int argc, char **argv) {
 			bench_dst_port_proto_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	}

--- a/filter/tests/bench_net4_fast.c
+++ b/filter/tests/bench_net4_fast.c
@@ -574,7 +574,8 @@ main(int argc, char **argv) {
 			bench_dst_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case sig_net4_dst_port:
@@ -583,7 +584,8 @@ main(int argc, char **argv) {
 			bench_dst_port_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case sig_net4_dst_port_proto:
@@ -592,7 +594,8 @@ main(int argc, char **argv) {
 			bench_dst_port_proto_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	}

--- a/filter/tests/bench_net6.c
+++ b/filter/tests/bench_net6.c
@@ -607,7 +607,8 @@ main(int argc, char **argv) {
 			bench_dst_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case sig_net6_dst_port:
@@ -616,7 +617,8 @@ main(int argc, char **argv) {
 			bench_dst_port_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case sig_net6_dst_port_proto:
@@ -625,7 +627,8 @@ main(int argc, char **argv) {
 			bench_dst_port_proto_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	}

--- a/filter/tests/bench_net6_fast.c
+++ b/filter/tests/bench_net6_fast.c
@@ -608,7 +608,8 @@ main(int argc, char **argv) {
 			bench_dst_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case sig_net6_dst_port:
@@ -617,7 +618,8 @@ main(int argc, char **argv) {
 			bench_dst_port_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	case sig_net6_dst_port_proto:
@@ -626,7 +628,8 @@ main(int argc, char **argv) {
 			bench_dst_port_proto_compile,
 			rule_ptrs,
 			config.num_rules,
-			&memory_context
+			&memory_context,
+			NULL
 		);
 		break;
 	}

--- a/filter/tests/combo_net4_port_proto_dst.c
+++ b/filter/tests/combo_net4_port_proto_dst.c
@@ -96,7 +96,12 @@ test_no_match_proto_only(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_proto_dst_compile, &rule_ptr, 1, &mctx
+		&filter,
+		combo_net4_port_proto_dst_compile,
+		&rule_ptr,
+		1,
+		&mctx,
+		NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -182,7 +187,12 @@ test_all_match(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_proto_dst_compile, &rule_ptr, 1, &mctx
+		&filter,
+		combo_net4_port_proto_dst_compile,
+		&rule_ptr,
+		1,
+		&mctx,
+		NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -305,7 +315,12 @@ test_multiple_rules_overlap(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_proto_dst_compile, rule_ptrs, 3, &mctx
+		&filter,
+		combo_net4_port_proto_dst_compile,
+		rule_ptrs,
+		3,
+		&mctx,
+		NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -420,7 +435,12 @@ test_tcp_flags(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_proto_dst_compile, rule_ptrs, 2, &mctx
+		&filter,
+		combo_net4_port_proto_dst_compile,
+		rule_ptrs,
+		2,
+		&mctx,
+		NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 

--- a/filter/tests/combo_net4_port_src.c
+++ b/filter/tests/combo_net4_port_src.c
@@ -123,7 +123,7 @@ test_no_match_port_only(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_src_compile, &rule_ptr, 1, &mctx
+		&filter, combo_net4_port_src_compile, &rule_ptr, 1, &mctx, NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -204,7 +204,7 @@ test_no_match_ip_only(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_src_compile, &rule_ptr, 1, &mctx
+		&filter, combo_net4_port_src_compile, &rule_ptr, 1, &mctx, NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -285,7 +285,7 @@ test_both_match(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_src_compile, &rule_ptr, 1, &mctx
+		&filter, combo_net4_port_src_compile, &rule_ptr, 1, &mctx, NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -393,7 +393,7 @@ test_overlapping(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net4_port_src_compile, rule_ptrs, 3, &mctx
+		&filter, combo_net4_port_src_compile, rule_ptrs, 3, &mctx, NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 

--- a/filter/tests/combo_net6_port_src.c
+++ b/filter/tests/combo_net6_port_src.c
@@ -143,7 +143,7 @@ test_no_match_port_only(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net6_port_src_compile, &rule_ptr, 1, &mctx
+		&filter, combo_net6_port_src_compile, &rule_ptr, 1, &mctx, NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -253,7 +253,7 @@ test_no_match_ip_only(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net6_port_src_compile, &rule_ptr, 1, &mctx
+		&filter, combo_net6_port_src_compile, &rule_ptr, 1, &mctx, NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 
@@ -364,7 +364,7 @@ test_both_match(void *arena) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, combo_net6_port_src_compile, &rule_ptr, 1, &mctx
+		&filter, combo_net6_port_src_compile, &rule_ptr, 1, &mctx, NULL
 	);
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize filter");
 

--- a/filter/tests/corner.c
+++ b/filter/tests/corner.c
@@ -88,7 +88,7 @@ check_single_attribute(void *memory) {
 	// setup filter
 	struct filter filter;
 	int init_result = filter_init(
-		&filter, sign_port_src_compile, rules, 3, &memory_context
+		&filter, sign_port_src_compile, rules, 3, &memory_context, NULL
 	);
 	assert(init_result == 0);
 

--- a/filter/tests/macros.c
+++ b/filter/tests/macros.c
@@ -33,7 +33,7 @@ run_case(void) {
 	// init filter
 	const struct filter_rule *r_ptr = &r;
 	struct filter f;
-	res = filter_init(&f, sign, &r_ptr, 1, &memory_context);
+	res = filter_init(&f, sign, &r_ptr, 1, &memory_context, NULL);
 	assert(res == 0);
 
 	// craft packet: UDP 4000

--- a/filter/tests/memory.c
+++ b/filter/tests/memory.c
@@ -115,7 +115,12 @@ test_src_dst_ports(void *memory) {
 	// init filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_ports_compile, action_ptrs, 2, &memory_context
+		&filter,
+		sign_ports_compile,
+		action_ptrs,
+		2,
+		&memory_context,
+		NULL
 	);
 	assert(res == 0);
 
@@ -159,7 +164,12 @@ test_src_port_only(void *memory) {
 	// init filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_port_src_compile, action_ptrs, 2, &memory_context
+		&filter,
+		sign_port_src_compile,
+		action_ptrs,
+		2,
+		&memory_context,
+		NULL
 	);
 	assert(res == 0);
 

--- a/filter/tests/net4_ports.c
+++ b/filter/tests/net4_ports.c
@@ -85,7 +85,8 @@ test(void *memory) {
 		sign_net4_ports_compile,
 		action_ptrs,
 		2,
-		&memory_context
+		&memory_context,
+		NULL
 	);
 	assert(res == 0);
 

--- a/filter/tests/shm/compiler.c
+++ b/filter/tests/shm/compiler.c
@@ -45,7 +45,7 @@ build_filter(struct common *common, struct memory_context *mctx) {
 	}
 	LOG(INFO, "compiling %zu rules...", rule_count);
 	int res = filter_init(
-		&common->filter, filter_sign, rule_ptrs, rule_count, mctx
+		&common->filter, filter_sign, rule_ptrs, rule_count, mctx, NULL
 	);
 	if (res < 0) {
 		LOG(ERROR, "compilation failed: %d", res);

--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -294,7 +294,8 @@ acl_module_init_l2(
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
 	struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
@@ -307,13 +308,18 @@ acl_module_init_l2(
 		check_acl_rule_l2
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_vlan,
 		ACL_FILTER_VLAN_TAG,
 		filter_rule_ptrs,
 		acl_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_vlan");
+	}
+	return rc;
 }
 
 static int
@@ -322,7 +328,8 @@ acl_module_init_ip4(
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
 	struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
@@ -335,13 +342,18 @@ acl_module_init_ip4(
 		check_acl_rule_ip4
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_ip4,
 		ACL_FILTER_IP4_TAG,
 		filter_rule_ptrs,
 		acl_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_ip4");
+	}
+	return rc;
 }
 
 static int
@@ -350,7 +362,8 @@ acl_module_init_ip4_port(
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
 	struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
@@ -363,13 +376,18 @@ acl_module_init_ip4_port(
 		check_acl_rule_ip4_port
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_ip4_port,
 		ACL_FILTER_IP4_PROTO_PORT_TAG,
 		filter_rule_ptrs,
 		acl_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_ip4_port");
+	}
+	return rc;
 }
 
 static int
@@ -378,7 +396,8 @@ acl_module_init_ip6(
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
 	struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
@@ -391,13 +410,18 @@ acl_module_init_ip6(
 		check_acl_rule_ip6
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_ip6,
 		ACL_FILTER_IP6_TAG,
 		filter_rule_ptrs,
 		acl_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_ip6");
+	}
+	return rc;
 }
 
 static int
@@ -406,7 +430,8 @@ acl_module_init_ip6_port(
 	struct acl_rule *acl_rules,
 	uint32_t acl_rule_count,
 	struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct acl_module_config *config =
 		container_of(cp_module, struct acl_module_config, cp_module);
@@ -419,13 +444,18 @@ acl_module_init_ip6_port(
 		check_acl_rule_ip6_port
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_ip6_port,
 		ACL_FILTER_IP6_PROTO_PORT_TAG,
 		filter_rule_ptrs,
 		acl_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_ip6_port");
+	}
+	return rc;
 }
 
 int
@@ -548,7 +578,8 @@ acl_module_config_update(
 		    acl_rules,
 		    rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 
@@ -557,7 +588,8 @@ acl_module_config_update(
 		    acl_rules,
 		    rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 
@@ -566,7 +598,8 @@ acl_module_config_update(
 		    acl_rules,
 		    rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 
@@ -575,7 +608,8 @@ acl_module_config_update(
 		    acl_rules,
 		    rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 
@@ -584,7 +618,8 @@ acl_module_config_update(
 		    acl_rules,
 		    rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 

--- a/modules/forward/api/controlplane.c
+++ b/modules/forward/api/controlplane.c
@@ -176,7 +176,8 @@ forward_module_init_l2(
 	struct forward_rule *forward_rules,
 	uint32_t forward_rule_count,
 	struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct forward_module_config *config = container_of(
 		cp_module, struct forward_module_config, cp_module
@@ -190,13 +191,18 @@ forward_module_init_l2(
 		check_forward_rule_l2
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_vlan,
 		FWD_FILTER_VLAN_TAG,
 		filter_rule_ptrs,
 		forward_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_vlan");
+	}
+	return rc;
 }
 
 static int
@@ -205,7 +211,8 @@ forward_module_init_ip4(
 	struct forward_rule *forward_rules,
 	uint32_t forward_rule_count,
 	struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct forward_module_config *config = container_of(
 		cp_module, struct forward_module_config, cp_module
@@ -219,13 +226,18 @@ forward_module_init_ip4(
 		check_forward_rule_ip4
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_ip4,
 		FWD_FILTER_IP4_TAG,
 		filter_rule_ptrs,
 		forward_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_ip4");
+	}
+	return rc;
 }
 
 static int
@@ -234,7 +246,8 @@ forward_module_init_ip6(
 	struct forward_rule *forward_rules,
 	uint32_t forward_rule_count,
 	struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct forward_module_config *config = container_of(
 		cp_module, struct forward_module_config, cp_module
@@ -248,13 +261,18 @@ forward_module_init_ip6(
 		check_forward_rule_ip6
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_ip6,
 		FWD_FILTER_IP6_TAG,
 		filter_rule_ptrs,
 		forward_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_ip6");
+	}
+	return rc;
 }
 
 int
@@ -335,7 +353,8 @@ forward_module_config_update(
 		    forward_rules,
 		    rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 
@@ -344,7 +363,8 @@ forward_module_config_update(
 		    forward_rules,
 		    rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 
@@ -353,7 +373,8 @@ forward_module_config_update(
 		    forward_rules,
 		    rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 

--- a/modules/route-mpls/api/controlplane.c
+++ b/modules/route-mpls/api/controlplane.c
@@ -177,7 +177,8 @@ route_mpls_module_init_ip4(
 	struct route_mpls_rule *route_mpls_rules,
 	uint64_t route_mpls_rule_count,
 	const struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct module_config *config =
 		container_of(cp_module, struct module_config, cp_module);
@@ -190,13 +191,18 @@ route_mpls_module_init_ip4(
 		check_route_mpls_rule_ip4
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_ip4,
 		FILTER_IP4_TAG,
 		filter_rule_ptrs,
 		route_mpls_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_ip4");
+	}
+	return rc;
 }
 
 static int
@@ -205,7 +211,8 @@ route_mpls_module_init_ip6(
 	struct route_mpls_rule *route_mpls_rules,
 	uint64_t route_mpls_rule_count,
 	const struct filter_rule *filter_rules,
-	const struct filter_rule **filter_rule_ptrs
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
 ) {
 	struct module_config *config =
 		container_of(cp_module, struct module_config, cp_module);
@@ -218,13 +225,18 @@ route_mpls_module_init_ip6(
 		check_route_mpls_rule_ip6
 	);
 
-	return filter_init(
+	int rc = filter_init(
 		&config->filter_ip6,
 		FILTER_IP6_TAG,
 		filter_rule_ptrs,
 		route_mpls_rule_count,
-		&cp_module->memory_context
+		&cp_module->memory_context,
+		err
 	);
+	if (rc) {
+		yanet_error_add(err, "failed to init filter_ip6");
+	}
+	return rc;
 }
 
 static struct target *
@@ -384,7 +396,8 @@ route_mpls_module_config_update(
 		    route_mpls_rules,
 		    route_mpls_rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 
@@ -393,7 +406,8 @@ route_mpls_module_config_update(
 		    route_mpls_rules,
 		    route_mpls_rule_count,
 		    filter_rules,
-		    filter_rule_ptrs
+		    filter_rule_ptrs,
+		    err
 	    ))
 		goto error_rule_ptrs;
 


### PR DESCRIPTION
`filter_init` previously returned `-1` without setting `*err` on the memory-exhaustion path, so module callers (`acl_module_config_update`, `forward_module_config_update`, `route_mpls_module_config_update`) returned `-1` with a NULL error. At the Go binding boundary this produced the artifact `failed to update ACL config: %!w(<nil>)` (the result of `fmt.Errorf("...: %w", nil)`), and operators had no signal about what actually failed. This was the underlying cause of the ACL functional test failures under ASAN that PR #875 worked around by bumping `aclMemSize` from 8 MB to 16 MB.

This change threads `yanet_error **err` through `filter_init` and the module-level filter init wrappers in acl, forward, and route-mpls. Every -1 return path inside `filter_init` now calls `yanet_error_add` with a message that identifies the failing step and states "out of memory" as the cause. The wrappers add the filter name on top. The Go binding now surfaces a meaningful chain such as:

```
failed to update ACL config: failed to init filter_ip6_port: out of memory: failed to compile attribute lookup 4
```

Test and bench call sites in `filter/tests/` pass `NULL` for `err`; they assert via the int return value and do not need the message.

`yanet_error_add(NULL, ...)` is already NULL-safe, so passing `NULL` is well-defined.

Closes the silent-error path identified during PR #875 investigation.