### PR TITLE
feat(web/pdump): remember recent BPF filters in localStorage

### DIFF
--- a/web/src/pages/modules/pdump/ConfigDialog.tsx
+++ b/web/src/pages/modules/pdump/ConfigDialog.tsx
@@ -3,6 +3,7 @@ import { pdumpApi, parseModeFlags, modeFlagsToNumber, type PdumpConfig } from '.
 import { toaster } from '../../../utils';
 import BpfTokens from './BpfTokens';
 import PdumpModal from './PdumpModal';
+import { loadRecentFilters, pushRecentFilter } from './recentFilters';
 import './pdump.scss';
 
 const BPF_SUGGESTIONS = [
@@ -41,9 +42,11 @@ export const ConfigDialog: React.FC<ConfigDialogProps> = ({
     const [snaplen, setSnaplen] = useState('');
     const [ringSize, setRingSize] = useState('');
     const [loading, setLoading] = useState(false);
+    const [recent, setRecent] = useState<string[]>([]);
 
     useEffect(() => {
         if (open) {
+            setRecent(loadRecentFilters());
             if (isCreate) {
                 setConfigName('');
                 setFilter('');
@@ -97,6 +100,7 @@ export const ConfigDialog: React.FC<ConfigDialogProps> = ({
             }
 
             await pdumpApi.setConfig(targetConfigName, config, { paths });
+            pushRecentFilter(filter);
             toaster.success('pdump-config-saved', isCreate ? 'Configuration created' : 'Configuration saved');
             onSaved();
             onClose();
@@ -166,6 +170,22 @@ export const ConfigDialog: React.FC<ConfigDialogProps> = ({
                         <span style={{ marginLeft: 8 }}><BpfTokens expr={filter} /></span>
                     )}
                 </span>
+                {recent.length > 0 && (
+                    <div className="pdump-bpf-recents">
+                        <div className="pdump-bpf-recents__label">Recent</div>
+                        <div className="pdump-bpf-suggestions">
+                            {recent.map(f => (
+                                <span
+                                    key={f}
+                                    className="pdump-bpf-suggestion"
+                                    onClick={() => setFilter(f)}
+                                >
+                                    {f}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+                )}
                 <div className="pdump-bpf-suggestions">
                     {BPF_SUGGESTIONS.map(ex => (
                         <span

--- a/web/src/pages/modules/pdump/pdump.scss
+++ b/web/src/pages/modules/pdump/pdump.scss
@@ -168,6 +168,18 @@
     }
 }
 
+.pdump-bpf-recents {
+    margin-bottom: 4px;
+}
+
+.pdump-bpf-recents__label {
+    font-size: 11px;
+    color: var(--fw-muted, #8a8580);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 4px;
+}
+
 // Config strip — one-row meta + live stats + actions for the active config.
 .pdump-strip {
     display: flex;

--- a/web/src/pages/modules/pdump/recentFilters.ts
+++ b/web/src/pages/modules/pdump/recentFilters.ts
@@ -1,0 +1,36 @@
+const STORAGE_KEY = 'yanet.pdump.recentFilters';
+const MAX_RECENT = 6;
+
+export const loadRecentFilters = (): string[] => {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (raw === null) {
+            return [];
+        }
+        const parsed: unknown = JSON.parse(raw);
+        if (!Array.isArray(parsed)) {
+            return [];
+        }
+        const valid = parsed.filter(
+            (entry): entry is string => typeof entry === 'string' && entry.trim().length > 0
+        );
+        return valid.slice(0, MAX_RECENT);
+    } catch {
+        return [];
+    }
+};
+
+export const pushRecentFilter = (filter: string): void => {
+    const trimmed = filter.trim();
+    if (trimmed.length === 0) {
+        return;
+    }
+    try {
+        const current = loadRecentFilters();
+        const without = current.filter(entry => entry !== trimmed);
+        const updated = [trimmed, ...without].slice(0, MAX_RECENT);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+    } catch {
+        // Silently ignore storage errors.
+    }
+};


### PR DESCRIPTION
The Create/Edit Pdump dialog now surfaces the user's six most-recently saved BPF filters as clickable chips, in addition to the existing fixed examples row. Recents persist across sessions in localStorage with LRU semantics — exact-match duplicates are bumped to the front, the list is capped at six, and a filter is recorded only after a successful `setConfig`. Storage I/O and JSON parsing are wrapped to fail silently on private-mode browsers, quota errors, and corrupted payloads.