### PR TITLE
feat(acl): add config hash 

### DIFF
--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -32,6 +32,9 @@ pub struct UpdateCmd {
     /// Path to the ruleset YAML file
     #[arg(required = true, long = "rules", value_name = "PATH")]
     pub rules: PathBuf,
+    /// Skip compilation if the server-side hash already equals this value
+    #[arg(long = "hash", value_name = "HEX")]
+    pub rules_hash: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -423,10 +423,12 @@ impl ACLService {
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),
             rules: config.rules,
+            rules_hash: cmd.rules_hash,
         };
         log::trace!("UpdateConfigRequest: {request:?}");
         let response = self.client.update_config(request).await?.into_inner();
         log::debug!("UpdateConfigResponse: {response:?}");
+        println!("modified={} rules_hash={}", response.modified, response.rules_hash);
         Ok(())
     }
 

--- a/modules/acl/controlplane/acl_adapter.go
+++ b/modules/acl/controlplane/acl_adapter.go
@@ -75,6 +75,7 @@ func (m *ACLAdapter) RelinkConfigs(
 
 		m.service.configs[name] = aclConfig{
 			rules:       oldConfig.rules,
+			rulesHash:   oldConfig.rulesHash,
 			acl:         newHandle,
 			fwstateName: fwstateConfig.Name(),
 		}
@@ -120,6 +121,7 @@ func (m *ACLAdapter) LinkConfigs(
 
 		m.service.configs[name] = aclConfig{
 			rules:       oldConfig.rules,
+			rulesHash:   oldConfig.rulesHash,
 			acl:         newHandle,
 			fwstateName: fwstateConfig.Name(),
 		}

--- a/modules/acl/controlplane/aclpb/v1/acl.go
+++ b/modules/acl/controlplane/aclpb/v1/acl.go
@@ -10,6 +10,9 @@ func (m *UpdateConfigRequest) AsLogValue() any {
 		enc.AddString("name", m.Name)
 		enc.AddString("rules", "<redacted>")
 		enc.AddInt("rules_count", len(m.Rules))
+		if m.RulesHash != nil {
+			enc.AddString("rules_hash", *m.RulesHash)
+		}
 		return nil
 	})
 }

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -25,9 +25,13 @@ service ACLService {
 message UpdateConfigRequest {
   string name = 1;
   repeated Rule rules = 2;
+  optional string rules_hash = 3;
 }
 
-message UpdateConfigResponse {}
+message UpdateConfigResponse {
+  bool modified = 1;
+  string rules_hash = 2;
+}
 
 message ShowConfigRequest { string name = 1; }
 
@@ -35,6 +39,7 @@ message ShowConfigResponse {
   string name = 1;
   repeated Rule rules = 2;
   string fwstate_name = 3;
+  string rules_hash = 4;
 }
 
 message Rule {

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -2,6 +2,8 @@ package acl
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"sync"
 
 	"go.uber.org/zap"
@@ -59,6 +61,7 @@ type ACLService struct {
 
 type aclConfig struct {
 	rules       []*aclpb.Rule
+	rulesHash   string
 	acl         ModuleHandle
 	fwstateName string
 }
@@ -172,6 +175,22 @@ func rulesEqual(a, b []*aclpb.Rule) bool {
 	return true
 }
 
+func computeRulesHash(rules []*aclpb.Rule) string {
+	h := sha256.New()
+	opts := proto.MarshalOptions{Deterministic: true}
+	for _, rule := range rules {
+		data, err := opts.Marshal(rule)
+		if err != nil {
+			continue
+		}
+		// Write 4-byte big-endian length prefix to avoid ambiguity between messages
+		length := uint32(len(data))
+		h.Write([]byte{byte(length >> 24), byte(length >> 16), byte(length >> 8), byte(length)})
+		h.Write(data)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 func (m *ACLService) UpdateConfig(
 	ctx context.Context,
 	req *aclpb.UpdateConfigRequest,
@@ -186,9 +205,26 @@ func (m *ACLService) UpdateConfig(
 	defer m.mu.Unlock()
 	defer tracker.Fix()
 
-	if existing, ok := m.configs[name]; ok && rulesEqual(existing.rules, req.Rules) {
-		return &aclpb.UpdateConfigResponse{}, nil
+	// If the server hash matches rules_hash the update is skipped and modified=false is returned 
+	// If the server hash differs rules are compiled and published
+	// If rules_hash without rules is rejected when the hashes differ
+	// (omit rules_hash to force-publish an empty ACL)
+
+	if clientHash := req.GetRulesHash(); clientHash != "" {
+		if existing, ok := m.configs[name]; ok && existing.rulesHash == clientHash {
+			return &aclpb.UpdateConfigResponse{
+				Modified:  false,
+				RulesHash: existing.rulesHash,
+			}, nil
+		}
+		if len(req.Rules) == 0 {
+			return nil, status.Error(codes.InvalidArgument,
+				"rules_hash provided without rules on hash mismatch: "+
+					"omit rules_hash to force-publish an empty ruleset")
+		}
 	}
+
+	newHash := computeRulesHash(req.Rules)
 
 	rules, err := convertRules(req.Rules)
 	if err != nil {
@@ -222,11 +258,15 @@ func (m *ACLService) UpdateConfig(
 
 	m.configs[name] = aclConfig{
 		rules:       req.Rules,
+		rulesHash:   newHash,
 		acl:         handle,
 		fwstateName: oldConfigs.fwstateName,
 	}
 
-	return &aclpb.UpdateConfigResponse{}, nil
+	return &aclpb.UpdateConfigResponse{
+		Modified:  true,
+		RulesHash: newHash,
+	}, nil
 }
 
 func (m *ACLService) ShowConfig(
@@ -252,6 +292,7 @@ func (m *ACLService) ShowConfig(
 		Name:        name,
 		Rules:       config.rules,
 		FwstateName: config.fwstateName,
+		RulesHash:   config.rulesHash,
 	}
 
 	return response, nil

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -192,28 +192,40 @@ func TestConvertRulesCounter(t *testing.T) {
 	}
 }
 
-// TestUpdateConfig_Idempotency verifies that calling UpdateConfig twice with
-// identical rules does not publish a second time.
+// TestUpdateConfig_Idempotency: a second UpdateConfig call carrying 
+// the hash returned by the first is skipped, while a call
+// without rules_hash always compiles and publishes
 func TestUpdateConfig_Idempotency(t *testing.T) {
 	b := newFakeBackend(0)
 	svc := newTestService(b)
 
-	req := &aclpb.UpdateConfigRequest{
+	// First call: no hash, must always publish
+	resp, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
 		Name:  "acl0",
 		Rules: []*aclpb.Rule{},
-	}
-
-	_, err := svc.UpdateConfig(t.Context(), req)
+	})
 	require.NoError(t, err)
+	assert.True(t, resp.Modified)
+	assert.NotEmpty(t, resp.RulesHash)
+	assert.Equal(t, 1, b.PublishCalls())
 
-	publishBefore := b.PublishCalls()
-
-	_, err = svc.UpdateConfig(t.Context(), req)
+	// Second call: no hash, must publish again regardless of content
+	_, err = svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:  "acl0",
+		Rules: []*aclpb.Rule{},
+	})
 	require.NoError(t, err)
+	assert.Equal(t, 2, b.PublishCalls(), "call without rules_hash must always publish")
 
-	publishAfter := b.PublishCalls()
-
-	assert.Equal(t, publishBefore, publishAfter, "second call with identical rules must not publish")
+	// Third call: correct hash, must be skipped
+	resp2, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:      "acl0",
+		Rules:     []*aclpb.Rule{},
+		RulesHash: &resp.RulesHash,
+	})
+	require.NoError(t, err)
+	assert.False(t, resp2.Modified)
+	assert.Equal(t, 2, b.PublishCalls(), "call with matching rules_hash must not publish")
 }
 
 // TestUpdateConfig_ErrorPropagation verifies that a backend failure from


### PR DESCRIPTION
Config hash allows operator to check whether rules differ from the controlplane state without transferring the full ruleset