### PR TITLE
refactor: canonicalize nat64 control plane

### DIFF
--- a/modules/nat64/api/nat64cp.c
+++ b/modules/nat64/api/nat64cp.c
@@ -85,7 +85,7 @@ nat64_module_config_free(struct cp_module *cp_module) {
 		sizeof(struct nat64_module_config)
 	);
 
-	LOG(DEBUG, "Completed cleanup of NAT64 module '%s'", cp_module->name);
+	LOG(DEBUG, "Completed cleanup of NAT64 module config");
 }
 
 int
@@ -346,6 +346,29 @@ nat64_module_config_set_drop_unknown(
 	    "Set drop unknown flags: prefix=%d, mapping=%d",
 	    drop_unknown_prefix,
 	    drop_unknown_mapping);
+
+	return 0;
+}
+
+int
+nat64_module_config_set_mtu(
+	struct cp_module *cp_module, uint16_t ipv4_mtu, uint16_t ipv6_mtu
+) {
+	if (!cp_module) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	struct nat64_module_config *config =
+		container_of(cp_module, struct nat64_module_config, cp_module);
+
+	config->mtu.ipv4 = ipv4_mtu;
+	config->mtu.ipv6 = ipv6_mtu;
+
+	LOG(DEBUG,
+	    "Set MTU limits: ipv4=%" PRIu16 ", ipv6=%" PRIu16,
+	    ipv4_mtu,
+	    ipv6_mtu);
 
 	return 0;
 }

--- a/modules/nat64/api/nat64cp.h
+++ b/modules/nat64/api/nat64cp.h
@@ -105,3 +105,17 @@ nat64_module_config_set_drop_unknown(
 	bool drop_unknown_prefix,
 	bool drop_unknown_mapping
 );
+
+/**
+ * @brief Sets IPv4/IPv6 MTU limits.
+ *
+ * @param cp_module Pointer to the module data structure
+ * @param ipv4_mtu IPv4 MTU limit
+ * @param ipv6_mtu IPv6 MTU limit
+ * @return 0 on success, -1 on failure with errno set:
+ *         - EINVAL: Invalid module data pointer
+ */
+int
+nat64_module_config_set_mtu(
+	struct cp_module *cp_module, uint16_t ipv4_mtu, uint16_t ipv6_mtu
+);

--- a/modules/nat64/bindings/go/cnat64/cgo.go
+++ b/modules/nat64/bindings/go/cnat64/cgo.go
@@ -1,8 +1,8 @@
-package nat64
+package cnat64
 
-//#cgo CFLAGS: -I../../../ -I../../../lib
-//#cgo LDFLAGS: -L../../../build/modules/nat64/api -lnat64_cp -llogging
-//#cgo LDFLAGS: -L../../../build/lib/logging/ -llogging
+//#cgo CFLAGS: -I../../../../../ -I../../../../../lib
+//#cgo LDFLAGS: -L../../../../../build/modules/nat64/api -lnat64_cp
+//#cgo LDFLAGS: -L../../../../../build/lib/logging/ -llogging
 //
 //#include "api/agent.h"
 //#include "modules/nat64/api/nat64cp.h"
@@ -33,7 +33,7 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	var cErr *C.yanet_error
 	ptr := C.nat64_module_config_create((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
 	if ptr == nil {
-		return nil, fmt.Errorf("failed to initialize NAT64 module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+		return nil, fmt.Errorf("failed to initialize module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}
 
 	return &ModuleConfig{
@@ -50,15 +50,18 @@ func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// AddMapping adds a new IPv4-IPv6 address mapping
-func (m *ModuleConfig) AddMapping(ipv4 []byte, ipv6 []byte, prefixIndex uint32) error {
-	if len(ipv4) != 4 {
-		return fmt.Errorf("invalid IPv4 address length: got %d, want 4", len(ipv4))
+// Free releases the underlying C memory.
+//
+// Safe to call multiple times: subsequent calls are no-ops.
+func (m *ModuleConfig) Free() {
+	if ptr := m.asRawPtr(); ptr != nil {
+		C.nat64_module_config_free(ptr)
+		m.ptr = ffi.ModuleConfig{}
 	}
-	if len(ipv6) != 16 {
-		return fmt.Errorf("invalid IPv6 address length: got %d, want 16", len(ipv6))
-	}
+}
 
+// addMapping maps 1:1 to nat64_module_config_add_mapping.
+func (m *ModuleConfig) addMapping(ipv4 [4]byte, ipv6 [16]byte, prefixIndex uint32) error {
 	rc, err := C.nat64_module_config_add_mapping(
 		m.asRawPtr(),
 		*(*C.uint32_t)(unsafe.Pointer(&ipv4[0])),
@@ -75,12 +78,8 @@ func (m *ModuleConfig) AddMapping(ipv4 []byte, ipv6 []byte, prefixIndex uint32) 
 	return nil
 }
 
-// AddPrefix adds a new NAT64 prefix
-func (m *ModuleConfig) AddPrefix(prefix []byte) error {
-	if len(prefix) != 12 {
-		return fmt.Errorf("invalid prefix length: got %d, want 12", len(prefix))
-	}
-
+// addPrefix maps 1:1 to nat64_module_config_add_prefix.
+func (m *ModuleConfig) addPrefix(prefix [12]byte) error {
 	rc, err := C.nat64_module_config_add_prefix(
 		m.asRawPtr(),
 		(*C.uint8_t)(unsafe.Pointer(&prefix[0])),
@@ -95,8 +94,8 @@ func (m *ModuleConfig) AddPrefix(prefix []byte) error {
 	return nil
 }
 
-// SetDropUnknown sets drop_unknown_prefix and drop_unknown_mapping flags
-func (m *ModuleConfig) SetDropUnknown(dropUnknownPrefix bool, dropUnknownMapping bool) error {
+// setDropUnknown maps 1:1 to nat64_module_config_set_drop_unknown.
+func (m *ModuleConfig) setDropUnknown(dropUnknownPrefix bool, dropUnknownMapping bool) error {
 	rc, err := C.nat64_module_config_set_drop_unknown(
 		m.asRawPtr(),
 		C.bool(dropUnknownPrefix),
@@ -107,6 +106,23 @@ func (m *ModuleConfig) SetDropUnknown(dropUnknownPrefix bool, dropUnknownMapping
 	}
 	if rc < 0 {
 		return fmt.Errorf("failed to set drop unknown flags: return code %d", rc)
+	}
+
+	return nil
+}
+
+// setMTU maps 1:1 to nat64_module_config_set_mtu.
+func (m *ModuleConfig) setMTU(ipv4MTU uint16, ipv6MTU uint16) error {
+	rc, err := C.nat64_module_config_set_mtu(
+		m.asRawPtr(),
+		C.uint16_t(ipv4MTU),
+		C.uint16_t(ipv6MTU),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to set MTU: %w", err)
+	}
+	if rc < 0 {
+		return fmt.Errorf("failed to set MTU: return code %d", rc)
 	}
 
 	return nil

--- a/modules/nat64/bindings/go/cnat64/safe.go
+++ b/modules/nat64/bindings/go/cnat64/safe.go
@@ -1,0 +1,48 @@
+package cnat64
+
+import (
+	"fmt"
+	"math"
+	"net/netip"
+)
+
+// AddMapping adds a new IPv4-IPv6 address mapping
+func (m *ModuleConfig) AddMapping(ipv4 netip.Addr, ipv6 netip.Addr, prefixIndex uint32) error {
+	if !ipv4.Is4() {
+		return fmt.Errorf("ipv4 %q is not an IPv4 address", ipv4)
+	}
+	if !ipv6.Is6() || ipv6.Is4In6() {
+		return fmt.Errorf("ipv6 %q is not a pure IPv6 address", ipv6)
+	}
+
+	return m.addMapping(ipv4.As4(), ipv6.As16(), prefixIndex)
+}
+
+// AddPrefix adds a new NAT64 prefix
+func (m *ModuleConfig) AddPrefix(prefix []byte) error {
+	if len(prefix) != 12 {
+		return fmt.Errorf("invalid prefix length: got %d, want 12", len(prefix))
+	}
+
+	var p [12]byte
+	copy(p[:], prefix)
+
+	return m.addPrefix(p)
+}
+
+// SetDropUnknown sets drop_unknown_prefix and drop_unknown_mapping flags
+func (m *ModuleConfig) SetDropUnknown(dropUnknownPrefix bool, dropUnknownMapping bool) error {
+	return m.setDropUnknown(dropUnknownPrefix, dropUnknownMapping)
+}
+
+// SetMTU sets IPv4/IPv6 MTU limits.
+func (m *ModuleConfig) SetMTU(ipv4MTU uint32, ipv6MTU uint32) error {
+	if ipv4MTU > math.MaxUint16 {
+		return fmt.Errorf("invalid IPv4 MTU: got %d, max %d", ipv4MTU, math.MaxUint16)
+	}
+	if ipv6MTU > math.MaxUint16 {
+		return fmt.Errorf("invalid IPv6 MTU: got %d, max %d", ipv6MTU, math.MaxUint16)
+	}
+
+	return m.setMTU(uint16(ipv4MTU), uint16(ipv6MTU))
+}

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -8,7 +8,8 @@ use clap_complete::CompleteEnv;
 use commonpb::pb::IpAddress;
 use nat64pb::{
     nat64_service_client::Nat64ServiceClient, AddMappingRequest, AddPrefixRequest, ListConfigsRequest,
-    SetDropUnknownRequest, SetMtuRequest, ShowConfigRequest, ShowConfigResponse,
+    RemoveMappingRequest, RemovePrefixRequest, SetDropUnknownRequest, SetMtuRequest, ShowConfigRequest,
+    ShowConfigResponse,
 };
 use netip::{Contiguous, Ipv6Network};
 use ptree::TreeBuilder;
@@ -64,12 +65,16 @@ pub enum ModeCmd {
 pub enum PrefixCmd {
     /// Add a new NAT64 prefix
     Add(AddPrefixCmd),
+    /// Remove NAT64 prefix
+    Remove(RemovePrefixCmd),
 }
 
 #[derive(Debug, Clone, Subcommand)]
 pub enum MappingCmd {
     /// Add a new IPv4-IPv6 mapping
     Add(AddMappingCmd),
+    /// Remove IPv4-IPv6 mapping
+    Remove(RemoveMappingCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -93,6 +98,16 @@ pub struct AddPrefixCmd {
 }
 
 #[derive(Debug, Clone, Parser)]
+pub struct RemovePrefixCmd {
+    /// The name of the config to operate on.
+    #[arg(long = "name", short = 'n')]
+    pub config_name: String,
+    /// IPv6 prefix (12 bytes) to be removed.
+    #[arg(long)]
+    pub prefix: Contiguous<Ipv6Network>,
+}
+
+#[derive(Debug, Clone, Parser)]
 pub struct AddMappingCmd {
     /// The name of the config to operate on.
     #[arg(long = "name", short = 'n')]
@@ -106,6 +121,16 @@ pub struct AddMappingCmd {
     /// Index of the prefix to use.
     #[arg(long)]
     pub prefix_index: u32,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct RemoveMappingCmd {
+    /// The name of the config to operate on.
+    #[arg(long = "name", short = 'n')]
+    pub config_name: String,
+    /// IPv4 address (4 bytes).
+    #[arg(long)]
+    pub ipv4: Ipv4Addr,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -164,9 +189,11 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
         ModeCmd::Prefix { cmd } => match cmd {
             PrefixCmd::Add(cmd) => service.add_prefix(cmd).await,
+            PrefixCmd::Remove(cmd) => service.remove_prefix(cmd).await,
         },
         ModeCmd::Mapping { cmd } => match cmd {
             MappingCmd::Add(cmd) => service.add_mapping(cmd).await,
+            MappingCmd::Remove(cmd) => service.remove_mapping(cmd).await,
         },
         ModeCmd::Mtu(cmd) => service.set_mtu(cmd).await,
         ModeCmd::Drop(cmd) => service.set_drop_unknown(cmd).await,
@@ -226,6 +253,18 @@ impl NAT64Service {
         Ok(())
     }
 
+    pub async fn remove_prefix(&mut self, cmd: RemovePrefixCmd) -> Result<(), Box<dyn Error>> {
+        let request = RemovePrefixRequest {
+            name: cmd.config_name.clone(),
+            prefix: cmd.prefix.addr().octets()[..12].to_vec(),
+        };
+        log::debug!("RemovePrefixRequest: {request:?}");
+        self.client.remove_prefix(request).await?;
+
+        println!("OK");
+        Ok(())
+    }
+
     pub async fn add_mapping(&mut self, cmd: AddMappingCmd) -> Result<(), Box<dyn Error>> {
         let request = AddMappingRequest {
             name: cmd.config_name.clone(),
@@ -235,6 +274,18 @@ impl NAT64Service {
         };
         log::debug!("AddMappingRequest: {request:?}");
         self.client.add_mapping(request).await?;
+
+        println!("OK");
+        Ok(())
+    }
+
+    pub async fn remove_mapping(&mut self, cmd: RemoveMappingCmd) -> Result<(), Box<dyn Error>> {
+        let request = RemoveMappingRequest {
+            name: cmd.config_name.clone(),
+            ipv4: Some(IpAddress { addr: cmd.ipv4.octets().to_vec() }),
+        };
+        log::debug!("RemoveMappingRequest: {request:?}");
+        self.client.remove_mapping(request).await?;
 
         println!("OK");
         Ok(())

--- a/modules/nat64/controlplane/backend.go
+++ b/modules/nat64/controlplane/backend.go
@@ -1,0 +1,66 @@
+package nat64
+
+import (
+	"fmt"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/nat64/bindings/go/cnat64"
+)
+
+type ModuleHandle interface {
+	Free()
+}
+
+var _ ModuleHandle = (*cnat64.ModuleConfig)(nil)
+
+type Backend interface {
+	UpdateModule(name string, config *NAT64Config) (ModuleHandle, error)
+}
+
+type backend struct {
+	agent *ffi.Agent
+}
+
+func NewBackend(agent *ffi.Agent) Backend {
+	return &backend{
+		agent: agent,
+	}
+}
+
+func (m *backend) UpdateModule(name string, config *NAT64Config) (ModuleHandle, error) {
+	module, err := cnat64.NewModuleConfig(m.agent, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create module config: %w", err)
+	}
+
+	for _, prefix := range config.Prefixes {
+		if err := module.AddPrefix(prefix); err != nil {
+			module.Free()
+			return nil, fmt.Errorf("failed to add prefix: %w", err)
+		}
+	}
+
+	for _, mapping := range config.Mappings {
+		if err := module.AddMapping(mapping.IPv4, mapping.IPv6, mapping.PrefixIndex); err != nil {
+			module.Free()
+			return nil, fmt.Errorf("failed to add mapping: %w", err)
+		}
+	}
+
+	if err := module.SetDropUnknown(config.DropUnknownPrefix, config.DropUnknownMapping); err != nil {
+		module.Free()
+		return nil, fmt.Errorf("failed to set drop unknown flags: %w", err)
+	}
+
+	if err := module.SetMTU(config.MTU.IPv4MTU, config.MTU.IPv6MTU); err != nil {
+		module.Free()
+		return nil, fmt.Errorf("failed to set MTU: %w", err)
+	}
+
+	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+		module.Free()
+		return nil, fmt.Errorf("failed to update module: %w", err)
+	}
+
+	return module, nil
+}

--- a/modules/nat64/controlplane/mod.go
+++ b/modules/nat64/controlplane/mod.go
@@ -38,7 +38,7 @@ func NewNAT64Module(cfg *Config, log *zap.Logger) (*NAT64Module, error) {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
 
-	nat64Service := NewNAT64Service(agent, log)
+	nat64Service := NewNAT64Service(NewBackend(agent), WithNAT64ServiceLog(log))
 
 	return &NAT64Module{
 		cfg:          cfg,

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -1,9 +1,12 @@
 package nat64
 
 import (
+	"bytes"
 	"context"
-	"fmt"
+	"maps"
+	"math"
 	"net/netip"
+	"slices"
 	"sync"
 
 	"go.uber.org/zap"
@@ -11,18 +14,49 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/commonpb"
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb"
 )
+
+// NAT64ServiceOption configures the NAT64Service constructor.
+type NAT64ServiceOption func(*nat64ServiceOptions)
+
+type nat64ServiceOptions struct {
+	Log *zap.Logger
+}
+
+func newNAT64ServiceOptions() *nat64ServiceOptions {
+	return &nat64ServiceOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithNAT64ServiceLog sets the logger for the NAT64Service.
+func WithNAT64ServiceLog(log *zap.Logger) NAT64ServiceOption {
+	return func(o *nat64ServiceOptions) {
+		o.Log = log
+	}
+}
 
 // NAT64Service implements the NAT64 gRPC service
 type NAT64Service struct {
 	nat64pb.UnimplementedNAT64ServiceServer
 
 	mu      sync.Mutex
-	agent   *ffi.Agent
+	backend Backend
+	configs map[string]config
 	log     *zap.Logger
-	configs map[string]*NAT64Config
+}
+
+type config struct {
+	config NAT64Config
+	module ModuleHandle
+}
+
+func (m config) Clone() config {
+	return config{
+		config: m.config.Clone(),
+		module: m.module,
+	}
 }
 
 // NAT64Config represents the configuration for a NAT64 instance
@@ -32,6 +66,20 @@ type NAT64Config struct {
 	MTU                MTUConfig
 	DropUnknownPrefix  bool
 	DropUnknownMapping bool
+}
+
+func (m NAT64Config) Clone() NAT64Config {
+	cfg := NAT64Config{
+		Prefixes:           make([][]byte, len(m.Prefixes)),
+		Mappings:           slices.Clone(m.Mappings),
+		MTU:                m.MTU,
+		DropUnknownPrefix:  m.DropUnknownPrefix,
+		DropUnknownMapping: m.DropUnknownMapping,
+	}
+	for idx := range m.Prefixes {
+		cfg.Prefixes[idx] = slices.Clone(m.Prefixes[idx])
+	}
+	return cfg
 }
 
 // Mapping represents an IPv4-IPv6 address mapping
@@ -47,28 +95,40 @@ type MTUConfig struct {
 	IPv6MTU uint32
 }
 
-func NewNAT64Service(agent *ffi.Agent, log *zap.Logger) *NAT64Service {
+const (
+	defaultIPv4MTU uint32 = 1450
+	defaultIPv6MTU uint32 = 1280
+)
+
+func defaultNAT64Config() NAT64Config {
+	return NAT64Config{
+		MTU: MTUConfig{
+			IPv4MTU: defaultIPv4MTU,
+			IPv6MTU: defaultIPv6MTU,
+		},
+	}
+}
+
+func NewNAT64Service(backend Backend, options ...NAT64ServiceOption) *NAT64Service {
+	opts := newNAT64ServiceOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &NAT64Service{
-		agent:   agent,
-		log:     log,
-		configs: make(map[string]*NAT64Config),
+		backend: backend,
+		log:     opts.Log,
+		configs: map[string]config{},
 	}
 }
 
 func (m *NAT64Service) ListConfigs(ctx context.Context, req *nat64pb.ListConfigsRequest) (*nat64pb.ListConfigsResponse, error) {
-	response := &nat64pb.ListConfigsResponse{
-		Configs: make([]string, 0),
-	}
-
-	// Lock instances store and module updates
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	for name := range m.configs {
-		response.Configs = append(response.Configs, name)
-	}
-
-	return response, nil
+	return &nat64pb.ListConfigsResponse{
+		Configs: slices.Sorted(maps.Keys(m.configs)),
+	}, nil
 }
 
 func (m *NAT64Service) ShowConfig(ctx context.Context, req *nat64pb.ShowConfigRequest) (*nat64pb.ShowConfigResponse, error) {
@@ -82,32 +142,35 @@ func (m *NAT64Service) ShowConfig(ctx context.Context, req *nat64pb.ShowConfigRe
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	config := m.configs[name]
-	if config != nil {
-		response.Config = &nat64pb.Config{
-			Prefixes: make([]*nat64pb.Prefix, 0, len(config.Prefixes)),
-			Mappings: make([]*nat64pb.Mapping, 0, len(config.Mappings)),
-			Mtu: &nat64pb.MTUConfig{
-				Ipv4Mtu: config.MTU.IPv4MTU,
-				Ipv6Mtu: config.MTU.IPv6MTU,
-			},
-			DropUnknownPrefix:  config.DropUnknownPrefix,
-			DropUnknownMapping: config.DropUnknownMapping,
-		}
+	inst, ok := m.configs[name]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "config not found")
+	}
 
-		for _, prefix := range config.Prefixes {
-			response.Config.Prefixes = append(response.Config.Prefixes, &nat64pb.Prefix{
-				Prefix: prefix,
-			})
-		}
+	cfg := inst.config
+	response.Config = &nat64pb.Config{
+		Prefixes: make([]*nat64pb.Prefix, 0, len(cfg.Prefixes)),
+		Mappings: make([]*nat64pb.Mapping, 0, len(cfg.Mappings)),
+		Mtu: &nat64pb.MTUConfig{
+			Ipv4Mtu: cfg.MTU.IPv4MTU,
+			Ipv6Mtu: cfg.MTU.IPv6MTU,
+		},
+		DropUnknownPrefix:  cfg.DropUnknownPrefix,
+		DropUnknownMapping: cfg.DropUnknownMapping,
+	}
 
-		for _, mapping := range config.Mappings {
-			response.Config.Mappings = append(response.Config.Mappings, &nat64pb.Mapping{
-				Ipv4:        commonpb.NewIPAddressFromAddr(mapping.IPv4),
-				Ipv6:        commonpb.NewIPAddressFromAddr(mapping.IPv6),
-				PrefixIndex: mapping.PrefixIndex,
-			})
-		}
+	for _, prefix := range cfg.Prefixes {
+		response.Config.Prefixes = append(response.Config.Prefixes, &nat64pb.Prefix{
+			Prefix: slices.Clone(prefix),
+		})
+	}
+
+	for _, mapping := range cfg.Mappings {
+		response.Config.Mappings = append(response.Config.Mappings, &nat64pb.Mapping{
+			Ipv4:        commonpb.NewIPAddressFromAddr(mapping.IPv4),
+			Ipv6:        commonpb.NewIPAddressFromAddr(mapping.IPv6),
+			PrefixIndex: mapping.PrefixIndex,
+		})
 	}
 
 	return response, nil
@@ -125,26 +188,54 @@ func (m *NAT64Service) AddPrefix(ctx context.Context, req *nat64pb.AddPrefixRequ
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Update in-memory config
-	config := m.configs[name]
-	if config == nil {
-		config = &NAT64Config{}
-		m.configs[name] = config
+	inst := m.instanceFor(name).Clone()
+	inst.config.Prefixes = append(inst.config.Prefixes, slices.Clone(req.Prefix))
+
+	if err := m.updateModuleConfig(name, inst); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
-
-	config.Prefixes = append(config.Prefixes, req.Prefix)
-
-	// Update module config
-	if err := m.updateModuleConfig(name); err != nil {
-		return nil, fmt.Errorf("failed to update module config: %w", err)
-	}
-
-	m.log.Info("successfully added prefix",
-		zap.String("name", name),
-		zap.Binary("prefix", req.Prefix),
-	)
 
 	return &nat64pb.AddPrefixResponse{}, nil
+}
+
+func (m *NAT64Service) RemovePrefix(ctx context.Context, req *nat64pb.RemovePrefixRequest) (*nat64pb.RemovePrefixResponse, error) {
+	if len(req.Prefix) != 12 {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid prefix length: got %d, want 12", len(req.Prefix))
+	}
+
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "module config name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst, ok := m.configs[name]
+	if !ok {
+		return &nat64pb.RemovePrefixResponse{}, nil
+	}
+	next := inst.Clone()
+
+	removeIdx := -1
+	for idx, prefix := range next.config.Prefixes {
+		if bytes.Equal(prefix, req.Prefix) {
+			removeIdx = idx
+			break
+		}
+	}
+	if removeIdx == -1 {
+		return &nat64pb.RemovePrefixResponse{}, nil
+	}
+
+	next.config.Prefixes = slices.Delete(next.config.Prefixes, removeIdx, removeIdx+1)
+	next.config.Mappings = adjustMappingsAfterPrefixRemove(next.config.Mappings, uint32(removeIdx))
+
+	if err := m.updateModuleConfig(name, next); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+	}
+
+	return &nat64pb.RemovePrefixResponse{}, nil
 }
 
 func (m *NAT64Service) AddMapping(ctx context.Context, req *nat64pb.AddMappingRequest) (*nat64pb.AddMappingResponse, error) {
@@ -171,37 +262,35 @@ func (m *NAT64Service) AddMapping(ctx context.Context, req *nat64pb.AddMappingRe
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Update in-memory config
-	config := m.configs[name]
-	if config == nil {
-		config = &NAT64Config{}
-		m.configs[name] = config
+	inst := m.instanceFor(name).Clone()
+	if req.PrefixIndex >= uint32(len(inst.config.Prefixes)) {
+		return nil, status.Errorf(
+			codes.InvalidArgument,
+			"invalid prefix index: got %d, prefixes count %d",
+			req.PrefixIndex,
+			len(inst.config.Prefixes),
+		)
 	}
-
-	config.Mappings = append(config.Mappings, Mapping{
+	inst.config.Mappings = append(inst.config.Mappings, Mapping{
 		IPv4:        ipv4,
 		IPv6:        ipv6,
 		PrefixIndex: req.PrefixIndex,
 	})
 
-	// Update module config
-	if err := m.updateModuleConfig(name); err != nil {
-		return nil, fmt.Errorf("failed to update module config: %w", err)
+	if err := m.updateModuleConfig(name, inst); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
-
-	m.log.Info("successfully added mapping",
-		zap.String("name", name),
-		zap.Stringer("ipv4", ipv4),
-		zap.Stringer("ipv6", ipv6),
-		zap.Uint32("prefix_index", req.PrefixIndex),
-	)
 
 	return &nat64pb.AddMappingResponse{}, nil
 }
 
-func (m *NAT64Service) SetMTU(ctx context.Context, req *nat64pb.SetMTURequest) (*nat64pb.SetMTUResponse, error) {
-	if req.Mtu == nil {
-		return nil, status.Error(codes.InvalidArgument, "mtu config is required")
+func (m *NAT64Service) RemoveMapping(ctx context.Context, req *nat64pb.RemoveMappingRequest) (*nat64pb.RemoveMappingResponse, error) {
+	ipv4, err := req.GetIpv4().ToAddr()
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid ipv4 (bytes=%x): %v", req.GetIpv4().GetAddr(), err)
+	}
+	if !ipv4.Is4() {
+		return nil, status.Errorf(codes.InvalidArgument, "ipv4 %q is not an IPv4 address", ipv4)
 	}
 
 	name := req.GetName()
@@ -212,28 +301,54 @@ func (m *NAT64Service) SetMTU(ctx context.Context, req *nat64pb.SetMTURequest) (
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Update in-memory config
-	config := m.configs[name]
-	if config == nil {
-		config = &NAT64Config{}
-		m.configs[name] = config
+	inst, ok := m.configs[name]
+	if !ok {
+		return &nat64pb.RemoveMappingResponse{}, nil
+	}
+	next := inst.Clone()
+
+	next.config.Mappings = slices.DeleteFunc(next.config.Mappings, func(mapping Mapping) bool {
+		return mapping.IPv4 == ipv4
+	})
+	if len(next.config.Mappings) == len(inst.config.Mappings) {
+		return &nat64pb.RemoveMappingResponse{}, nil
 	}
 
-	config.MTU = MTUConfig{
+	if err := m.updateModuleConfig(name, next); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+	}
+
+	return &nat64pb.RemoveMappingResponse{}, nil
+}
+
+func (m *NAT64Service) SetMTU(ctx context.Context, req *nat64pb.SetMTURequest) (*nat64pb.SetMTUResponse, error) {
+	if req.Mtu == nil {
+		return nil, status.Error(codes.InvalidArgument, "mtu config is required")
+	}
+	if req.Mtu.Ipv4Mtu > math.MaxUint16 {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid IPv4 MTU: got %d, max %d", req.Mtu.Ipv4Mtu, math.MaxUint16)
+	}
+	if req.Mtu.Ipv6Mtu > math.MaxUint16 {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid IPv6 MTU: got %d, max %d", req.Mtu.Ipv6Mtu, math.MaxUint16)
+	}
+
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "module config name is required")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	inst := m.instanceFor(name).Clone()
+	inst.config.MTU = MTUConfig{
 		IPv4MTU: req.Mtu.Ipv4Mtu,
 		IPv6MTU: req.Mtu.Ipv6Mtu,
 	}
 
-	// Update module config
-	if err := m.updateModuleConfig(name); err != nil {
-		return nil, fmt.Errorf("failed to update module config: %w", err)
+	if err := m.updateModuleConfig(name, inst); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
-
-	m.log.Info("successfully set MTU",
-		zap.String("name", name),
-		zap.Uint32("ipv4_mtu", req.Mtu.Ipv4Mtu),
-		zap.Uint32("ipv6_mtu", req.Mtu.Ipv6Mtu),
-	)
 
 	return &nat64pb.SetMTUResponse{}, nil
 }
@@ -247,66 +362,52 @@ func (m *NAT64Service) SetDropUnknown(ctx context.Context, req *nat64pb.SetDropU
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Update in-memory config
-	config := m.configs[name]
-	if config == nil {
-		config = &NAT64Config{}
-		m.configs[name] = config
+	inst := m.instanceFor(name).Clone()
+	inst.config.DropUnknownPrefix = req.DropUnknownPrefix
+	inst.config.DropUnknownMapping = req.DropUnknownMapping
+
+	if err := m.updateModuleConfig(name, inst); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
-
-	config.DropUnknownPrefix = req.DropUnknownPrefix
-	config.DropUnknownMapping = req.DropUnknownMapping
-
-	// Update module config
-	if err := m.updateModuleConfig(name); err != nil {
-		return nil, fmt.Errorf("failed to update module config: %w", err)
-	}
-
-	m.log.Info("successfully set drop unknown flags",
-		zap.String("name", name),
-		zap.Bool("drop_unknown_prefix", req.DropUnknownPrefix),
-		zap.Bool("drop_unknown_mapping", req.DropUnknownMapping),
-	)
 
 	return &nat64pb.SetDropUnknownResponse{}, nil
 }
 
-func (m *NAT64Service) updateModuleConfig(name string) error {
-	moduleConfig, err := NewModuleConfig(m.agent, name)
+func (m *NAT64Service) instanceFor(name string) config {
+	inst, ok := m.configs[name]
+	if !ok {
+		return config{
+			config: defaultNAT64Config(),
+		}
+	}
+	return inst
+}
+
+func (m *NAT64Service) updateModuleConfig(name string, inst config) error {
+	module, err := m.backend.UpdateModule(name, &inst.config)
 	if err != nil {
-		return fmt.Errorf("failed to create module config: %w", err)
+		return err
 	}
 
-	config := m.configs[name]
-	if config == nil {
-		config = &NAT64Config{}
-		m.configs[name] = config
+	if inst.module != nil {
+		inst.module.Free()
 	}
-
-	// Configure all prefixes.
-	for _, prefix := range config.Prefixes {
-		if err := moduleConfig.AddPrefix(prefix); err != nil {
-			return fmt.Errorf("failed to add prefix: %w", err)
-		}
-	}
-
-	// Configure all mappings.
-	for _, mapping := range config.Mappings {
-		ipv4 := mapping.IPv4.As4()
-		ipv6 := mapping.IPv6.As16()
-		if err := moduleConfig.AddMapping(ipv4[:], ipv6[:], mapping.PrefixIndex); err != nil {
-			return fmt.Errorf("failed to add mapping: %w", err)
-		}
-	}
-
-	// Set drop unknown flags.
-	if err := moduleConfig.SetDropUnknown(config.DropUnknownPrefix, config.DropUnknownMapping); err != nil {
-		return fmt.Errorf("failed to set drop unknown flags: %w", err)
-	}
-
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{moduleConfig.AsFFIModule()}); err != nil {
-		return fmt.Errorf("failed to update module: %w", err)
-	}
+	inst.module = module
+	m.configs[name] = inst
 
 	return nil
+}
+
+func adjustMappingsAfterPrefixRemove(mappings []Mapping, removed uint32) []Mapping {
+	out := make([]Mapping, 0, len(mappings))
+	for _, mapping := range mappings {
+		switch {
+		case mapping.PrefixIndex == removed:
+			continue
+		case mapping.PrefixIndex > removed:
+			mapping.PrefixIndex--
+		}
+		out = append(out, mapping)
+	}
+	return out
 }

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -1,0 +1,190 @@
+package nat64
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/common/commonpb"
+	"github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb"
+)
+
+var errInjectedBackend = errors.New("injected backend failure")
+
+type mockHandle struct {
+	freed bool
+}
+
+func (m *mockHandle) Free() {
+	m.freed = true
+}
+
+type mockBackend struct {
+	configs []NAT64Config
+	handles []*mockHandle
+	failAt  int
+}
+
+func (m *mockBackend) UpdateModule(name string, cfg *NAT64Config) (ModuleHandle, error) {
+	if m.failAt != 0 && len(m.configs)+1 == m.failAt {
+		return nil, errInjectedBackend
+	}
+
+	handle := &mockHandle{}
+	m.configs = append(m.configs, cfg.Clone())
+	m.handles = append(m.handles, handle)
+	return handle, nil
+}
+
+// Test_NAT64Service_AddShowRemove verifies basic config lifecycle operations.
+func Test_NAT64Service_AddShowRemove(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+	ctx := t.Context()
+
+	prefix0 := []byte{0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	prefix1 := []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0}
+	ipv4 := netip.MustParseAddr("192.0.2.1")
+	ipv6 := netip.MustParseAddr("2001:db8::1")
+
+	_, err := service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{Name: "nat64-0", Prefix: prefix0})
+	require.NoError(t, err)
+	_, err = service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{Name: "nat64-0", Prefix: prefix1})
+	require.NoError(t, err)
+	require.True(t, backend.handles[0].freed)
+	require.False(t, backend.handles[1].freed)
+	_, err = service.AddMapping(ctx, &nat64pb.AddMappingRequest{
+		Name:        "nat64-0",
+		Ipv4:        commonpb.NewIPAddressFromAddr(ipv4),
+		Ipv6:        commonpb.NewIPAddressFromAddr(ipv6),
+		PrefixIndex: 1,
+	})
+	require.NoError(t, err)
+	require.True(t, backend.handles[1].freed)
+	require.False(t, backend.handles[2].freed)
+
+	show, err := service.ShowConfig(ctx, &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+	require.NoError(t, err)
+	require.Len(t, show.GetConfig().GetPrefixes(), 2)
+	require.Len(t, show.GetConfig().GetMappings(), 1)
+
+	_, err = service.RemovePrefix(ctx, &nat64pb.RemovePrefixRequest{Name: "nat64-0", Prefix: prefix0})
+	require.NoError(t, err)
+
+	show, err = service.ShowConfig(ctx, &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+	require.NoError(t, err)
+	require.Len(t, show.GetConfig().GetPrefixes(), 1)
+	require.Equal(t, prefix1, show.GetConfig().GetPrefixes()[0].GetPrefix())
+	require.Len(t, show.GetConfig().GetMappings(), 1)
+	require.Equal(t, uint32(0), show.GetConfig().GetMappings()[0].GetPrefixIndex())
+
+	_, err = service.RemoveMapping(ctx, &nat64pb.RemoveMappingRequest{
+		Name: "nat64-0",
+		Ipv4: commonpb.NewIPAddressFromAddr(ipv4),
+	})
+	require.NoError(t, err)
+
+	show, err = service.ShowConfig(ctx, &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+	require.NoError(t, err)
+	require.Empty(t, show.GetConfig().GetMappings())
+}
+
+// Test_NAT64Service_SetMTUPassedToBackend verifies MTU values reach backend.
+func Test_NAT64Service_SetMTUPassedToBackend(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+
+	_, err := service.SetMTU(t.Context(), &nat64pb.SetMTURequest{
+		Name: "nat64-0",
+		Mtu: &nat64pb.MTUConfig{
+			Ipv4Mtu: 1450,
+			Ipv6Mtu: 1280,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, backend.configs, 1)
+	require.Equal(t, MTUConfig{IPv4MTU: 1450, IPv6MTU: 1280}, backend.configs[0].MTU)
+}
+
+// Test_NAT64Service_AddPrefixDefaultMTU verifies default MTU on new config.
+func Test_NAT64Service_AddPrefixDefaultMTU(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+
+	_, err := service.AddPrefix(t.Context(), &nat64pb.AddPrefixRequest{
+		Name:   "nat64-0",
+		Prefix: []byte{0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+	})
+	require.NoError(t, err)
+	require.Len(t, backend.configs, 1)
+	require.Equal(t, MTUConfig{IPv4MTU: 1450, IPv6MTU: 1280}, backend.configs[0].MTU)
+}
+
+// Test_NAT64Service_SetDropUnknownDefaultMTU verifies default MTU is preserved.
+func Test_NAT64Service_SetDropUnknownDefaultMTU(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+
+	_, err := service.SetDropUnknown(t.Context(), &nat64pb.SetDropUnknownRequest{
+		Name:               "nat64-0",
+		DropUnknownPrefix:  true,
+		DropUnknownMapping: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, backend.configs, 1)
+	require.Equal(t, MTUConfig{IPv4MTU: 1450, IPv6MTU: 1280}, backend.configs[0].MTU)
+}
+
+// Test_NAT64Service_SetMTUExplicitZero verifies zero MTU is kept.
+func Test_NAT64Service_SetMTUExplicitZero(t *testing.T) {
+	backend := &mockBackend{}
+	service := NewNAT64Service(backend)
+
+	_, err := service.SetMTU(t.Context(), &nat64pb.SetMTURequest{
+		Name: "nat64-0",
+		Mtu: &nat64pb.MTUConfig{
+			Ipv4Mtu: 0,
+			Ipv6Mtu: 0,
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, backend.configs, 1)
+	require.Equal(t, MTUConfig{IPv4MTU: 0, IPv6MTU: 0}, backend.configs[0].MTU)
+}
+
+// Test_NAT64Service_UpdateFailureAtomic verifies failed updates do not mutate cache.
+func Test_NAT64Service_UpdateFailureAtomic(t *testing.T) {
+	backend := &mockBackend{failAt: 2}
+	service := NewNAT64Service(backend)
+	ctx := t.Context()
+
+	prefix0 := []byte{0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	prefix1 := []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0}
+
+	_, err := service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{Name: "nat64-0", Prefix: prefix0})
+	require.NoError(t, err)
+	_, err = service.AddPrefix(ctx, &nat64pb.AddPrefixRequest{Name: "nat64-0", Prefix: prefix1})
+	require.Equal(t, codes.Internal, status.Code(err))
+
+	show, err := service.ShowConfig(ctx, &nat64pb.ShowConfigRequest{Name: "nat64-0"})
+	require.NoError(t, err)
+	require.Len(t, show.GetConfig().GetPrefixes(), 1)
+	require.Equal(t, prefix0, show.GetConfig().GetPrefixes()[0].GetPrefix())
+	require.False(t, backend.handles[0].freed)
+}
+
+// Test_NAT64Service_InvalidMTU verifies invalid MTU is rejected.
+func Test_NAT64Service_InvalidMTU(t *testing.T) {
+	service := NewNAT64Service(&mockBackend{})
+
+	resp, err := service.SetMTU(t.Context(), &nat64pb.SetMTURequest{
+		Name: "nat64-0",
+		Mtu:  &nat64pb.MTUConfig{Ipv4Mtu: 65536},
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}


### PR DESCRIPTION
- Moved NAT64 CGO calls into module bindings and added a backend boundary for shared-memory updates.
- Wired MTU updates through the backend while preserving default MTU behavior for new configs.
- Added service tests for lifecycle operations, MTU defaults, explicit zero MTU, and update atomicity.
- Exposed NAT64 prefix and mapping removal in the CLI.