### PR TITLE
refactor(counters): support for tag-based lookups in FFI and CLI

### DIFF
--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -11,9 +11,9 @@ use ync::{
     logging,
 };
 use ynpb::pb::{
-    counters_service_client::CountersServiceClient, ChainCountersRequest, DeviceCountersRequest,
-    FunctionCountersRequest, LatencyRangeCounter, ModuleCountersRequest, PerfCounter, PerfCountersRequest,
-    PerfCountersResponse, PipelineCountersRequest,
+    counters_service_client::CountersServiceClient, ChainCountersRequest, CounterTag, CountersByTagsRequest,
+    DeviceCountersRequest, FunctionCountersRequest, LatencyRangeCounter, ModuleCountersRequest, PerfCounter,
+    PerfCountersRequest, PerfCountersResponse, PipelineCountersRequest,
 };
 
 /// Counters module - displays counters information.
@@ -22,12 +22,65 @@ use ynpb::pb::{
 #[command(flatten_help = true)]
 pub struct Cmd {
     #[clap(subcommand)]
-    pub mode: ModeCmd,
+    pub mode: Option<ModeCmd>,
+    #[command(flatten)]
+    pub by_tags: ByTagsCmd,
     #[command(flatten)]
     pub connection: ConnectionArgs,
     /// Be verbose in terms of logging.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
+}
+
+#[derive(Debug, Clone, Parser, Default)]
+pub struct ByTagsCmd {
+    #[arg(short, long = "name")]
+    pub names: Vec<String>,
+    #[arg(short, long)]
+    pub device: Option<String>,
+    #[arg(short, long)]
+    pub pipeline: Option<String>,
+    #[arg(short, long)]
+    pub function: Option<String>,
+    #[arg(short, long)]
+    pub chain: Option<String>,
+    #[arg(short = 't', long)]
+    pub module_type: Option<String>,
+    #[arg(short = 'm', long)]
+    pub module_name: Option<String>,
+}
+
+impl From<ByTagsCmd> for CountersByTagsRequest {
+    fn from(cmd: ByTagsCmd) -> Self {
+        let mut tags = Vec::new();
+
+        if let Some(value) = cmd.device {
+            tags.push(CounterTag { key: "device".to_string(), value });
+        }
+        if let Some(value) = cmd.pipeline {
+            tags.push(CounterTag { key: "pipeline".to_string(), value });
+        }
+        if let Some(value) = cmd.function {
+            tags.push(CounterTag { key: "function".to_string(), value });
+        }
+        if let Some(value) = cmd.chain {
+            tags.push(CounterTag { key: "chain".to_string(), value });
+        }
+        if let Some(value) = cmd.module_type {
+            tags.push(CounterTag {
+                key: "module_type".to_string(),
+                value,
+            });
+        }
+        if let Some(value) = cmd.module_name {
+            tags.push(CounterTag {
+                key: "module_name".to_string(),
+                value,
+            });
+        }
+
+        Self { tags, query: cmd.names }
+    }
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -137,19 +190,20 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
     let mut service = CountersService::new(&cmd.connection).await?;
 
     match cmd.mode {
-        ModeCmd::Device(cmd) => service.show_device(cmd.device_name).await?,
-        ModeCmd::Pipeline(cmd) => service.show_pipeline(cmd.device_name, cmd.pipeline_name).await?,
-        ModeCmd::Function(cmd) => {
+        None => service.show_by_tags(cmd.by_tags.into()).await?,
+        Some(ModeCmd::Device(cmd)) => service.show_device(cmd.device_name).await?,
+        Some(ModeCmd::Pipeline(cmd)) => service.show_pipeline(cmd.device_name, cmd.pipeline_name).await?,
+        Some(ModeCmd::Function(cmd)) => {
             service
                 .show_function(cmd.device_name, cmd.pipeline_name, cmd.function_name)
                 .await?
         }
-        ModeCmd::Chain(cmd) => {
+        Some(ModeCmd::Chain(cmd)) => {
             service
                 .show_chain(cmd.device_name, cmd.pipeline_name, cmd.function_name, cmd.chain_name)
                 .await?
         }
-        ModeCmd::Module(cmd) => {
+        Some(ModeCmd::Module(cmd)) => {
             service
                 .show_module(
                     cmd.device_name,
@@ -161,7 +215,7 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
                 )
                 .await?
         }
-        ModeCmd::Perf(cmd) => {
+        Some(ModeCmd::Perf(cmd)) => {
             // Parse module format: module_type:module_name
             let parts: Vec<&str> = cmd.module.split(':').collect();
             if parts.len() != 2 {
@@ -201,6 +255,12 @@ impl CountersService {
             .send_compressed(CompressionEncoding::Gzip)
             .accept_compressed(CompressionEncoding::Gzip);
         Ok(Self { client })
+    }
+
+    pub async fn show_by_tags(&mut self, request: CountersByTagsRequest) -> Result<(), Box<dyn Error>> {
+        let response = self.client.by_tags(request).await?;
+        println!("{}", serde_json::to_string(response.get_ref())?);
+        Ok(())
     }
 
     pub async fn show_device(&mut self, device_name: String) -> Result<(), Box<dyn Error>> {

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -196,3 +196,44 @@ func (m *Counters) Perf(
 
 	return response, nil
 }
+
+// ByTags returns counters grouped by tag set, filtered by the request's
+// tag and query predicates.
+func (m *Counters) ByTags(
+	ctx context.Context,
+	request *ynpb.CountersByTagsRequest,
+) (*ynpb.CountersByTagsResponse, error) {
+	reqTags := request.GetTags()
+	tags := make([]ffi.CounterTag, len(reqTags))
+	for idx, tag := range reqTags {
+		tags[idx] = ffi.CounterTag{
+			Key:   tag.GetKey(),
+			Value: tag.GetValue(),
+		}
+	}
+
+	dpConfig := m.shm.DPConfig(m.instanceID)
+	groups, err := dpConfig.CountersByTags(tags, request.GetQuery())
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ynpb.CountersByTagsResponse{
+		Groups: make([]*ynpb.CounterGroup, 0, len(groups)),
+	}
+	for _, group := range groups {
+		pbTags := make([]*ynpb.CounterTag, 0, len(group.Tags))
+		for _, tag := range group.Tags {
+			pbTags = append(pbTags, &ynpb.CounterTag{
+				Key:   tag.Key,
+				Value: tag.Value,
+			})
+		}
+		response.Groups = append(response.Groups, &ynpb.CounterGroup{
+			Tags:     pbTags,
+			Counters: m.encodeCounters(group.Counters),
+		})
+	}
+
+	return response, nil
+}

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -415,40 +415,43 @@ func (m *DPConfig) Devices() []DeviceInfo {
 }
 
 type CounterInfo struct {
-	Name   string
+	Name string
+	// [instance][value_index]
 	Values [][]uint64
+}
+
+func decodeCounterHandle(
+	handle *C.struct_counter_handle,
+	instanceCount C.uint64_t,
+) CounterInfo {
+	counterInfo := CounterInfo{
+		Name:   C.GoString(&handle.name[0]),
+		Values: make([][]uint64, 0, instanceCount),
+	}
+
+	for iidx := C.uint64_t(0); iidx < instanceCount; iidx++ {
+		values := make([]uint64, 0, int(handle.size))
+		for vidx := C.uint64_t(0); vidx < handle.size; vidx++ {
+			values = append(values, uint64(C.yanet_get_counter_value(
+				handle.value_handle,
+				vidx,
+				iidx,
+			)))
+		}
+		counterInfo.Values = append(counterInfo.Values, values)
+	}
+
+	return counterInfo
 }
 
 func (m *DPConfig) encodeCounters(
 	counters *C.struct_counter_handle_list,
 ) []CounterInfo {
-	res := make([]CounterInfo, 0)
+	res := make([]CounterInfo, 0, counters.count)
 
 	for cidx := C.uint64_t(0); cidx < counters.count; cidx++ {
 		handle := C.yanet_get_counter(counters, cidx)
-		counterInfo := CounterInfo{
-			Name:   C.GoString(&handle.name[0]),
-			Values: make([][]uint64, 0, counters.instance_count),
-		}
-
-		for iidx := C.uint64_t(0); iidx < counters.instance_count; iidx++ {
-			counterInfo.Values = append(
-				counterInfo.Values,
-				make([]uint64, 0, int(handle.size)),
-			)
-			for vidx := C.uint64_t(0); vidx < handle.size; vidx++ {
-				counterInfo.Values[iidx] = append(
-					counterInfo.Values[iidx],
-					uint64(C.yanet_get_counter_value(
-						handle.value_handle,
-						vidx,
-						iidx,
-					)),
-				)
-			}
-		}
-
-		res = append(res, counterInfo)
+		res = append(res, decodeCounterHandle(handle, counters.instance_count))
 	}
 
 	return res
@@ -603,6 +606,112 @@ func (m *DPConfig) ModuleCounters(
 	}
 
 	return m.encodeCounters(counters)
+}
+
+// CounterTag is a (key, value) predicate against a counter's tag set.
+// Value semantics follow the C API: an empty string requires the tag to
+// be absent, "*" requires the tag to be present with any value, and any
+// other string requires an exact match.
+type CounterTag struct {
+	Key   string
+	Value string
+}
+
+// CounterGroup is a set of counters that share the same tag set.
+type CounterGroup struct {
+	Tags     []CounterTag
+	Counters []CounterInfo
+}
+
+// CountersByTags returns counters matching every predicate in tags and at
+// least one name in query. A nil or empty tags slice imposes no per-tag
+// constraint; a nil or empty query matches any counter name.
+func (m *DPConfig) CountersByTags(
+	tags []CounterTag,
+	query []string,
+) ([]CounterGroup, error) {
+	cTags := make([]C.struct_counter_tag, len(tags))
+	for idx, tag := range tags {
+		cKey := C.CString(tag.Key)
+		cValue := C.CString(tag.Value)
+		defer C.free(unsafe.Pointer(cKey))
+		defer C.free(unsafe.Pointer(cValue))
+		cTags[idx] = C.struct_counter_tag{key: cKey, value: cValue}
+	}
+
+	cQuery := make([]*C.char, len(query))
+	for idx, name := range query {
+		cQuery[idx] = C.CString(name)
+		defer C.free(unsafe.Pointer(cQuery[idx]))
+	}
+
+	var cTagsPtr *C.struct_counter_tag
+	if len(cTags) > 0 {
+		cTagsPtr = &cTags[0]
+	}
+	var cQueryPtr **C.char
+	var queryCount C.size_t
+	if len(cQuery) > 0 {
+		cQueryPtr = &cQuery[0]
+		queryCount = C.size_t(len(cQuery))
+	} else {
+		queryCount = C.size_t(^uint64(0))
+	}
+
+	var cErr *C.yanet_error
+	counters := C.yanet_get_counters_by_tags(
+		m.ptr,
+		cTagsPtr,
+		C.size_t(len(cTags)),
+		cQueryPtr,
+		queryCount,
+		&cErr,
+	)
+	if counters == nil {
+		if err := cerrors.FromC(unsafe.Pointer(cErr)); err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("unknown error")
+	}
+	defer C.yanet_counter_handle_list_free(counters)
+
+	groups := make([]CounterGroup, 0)
+
+	for idx := C.uint64_t(0); idx < counters.count; idx++ {
+		handle := C.yanet_get_counter(counters, idx)
+
+		if idx == 0 || C.yanet_get_counter(counters, idx-1).tags != handle.tags {
+			tags := decodeCounterTags(handle.tags, handle.tag_count)
+			groups = append(groups, CounterGroup{Tags: tags})
+		}
+
+		group := &groups[len(groups)-1]
+		group.Counters = append(
+			group.Counters,
+			decodeCounterHandle(handle, counters.instance_count),
+		)
+	}
+
+	return groups, nil
+}
+
+func decodeCounterTags(
+	tags *C.struct_counter_tag,
+	count C.size_t,
+) []CounterTag {
+	if tags == nil || count == 0 {
+		return nil
+	}
+
+	cTags := unsafe.Slice(tags, count)
+	out := make([]CounterTag, count)
+	for idx := range cTags {
+		out[idx] = CounterTag{
+			Key:   C.GoString(cTags[idx].key),
+			Value: C.GoString(cTags[idx].value),
+		}
+	}
+	return out
 }
 
 // PerformanceCounterLatencyRange represents a latency range in performance counters.

--- a/controlplane/ynpb/counters.proto
+++ b/controlplane/ynpb/counters.proto
@@ -12,7 +12,25 @@ service CountersService {
   rpc Chain(ChainCountersRequest) returns (CountersResponse) {}
   rpc Module(ModuleCountersRequest) returns (CountersResponse) {}
   rpc Perf(PerfCountersRequest) returns (PerfCountersResponse) {}
+  rpc ByTags(CountersByTagsRequest) returns (CountersByTagsResponse) {}
 }
+
+message CounterTag {
+  string key = 1;
+  string value = 2;
+}
+
+message CountersByTagsRequest {
+  repeated CounterTag tags = 1;
+  repeated string query = 2;
+}
+
+message CounterGroup {
+  repeated CounterTag tags = 1;
+  repeated CounterInfo counters = 2;
+}
+
+message CountersByTagsResponse { repeated CounterGroup groups = 1; }
 
 message DeviceCountersRequest { string device = 1; }
 

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 
 #include "common/memory.h"
+#include "common/memory_address.h"
 #include "common/memory_block.h"
 #include "common/strutils.h"
 

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1,7 +1,6 @@
 #include "agent.h"
 
 #include <linux/mman.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -11,13 +10,10 @@
 
 #include <errno.h>
 
-#include "api/counter.h"
 #include "common/memory.h"
-#include "common/memory_address.h"
 #include "common/memory_block.h"
 #include "common/strutils.h"
 
-#include "controlplane/config/cp_counter.h"
 #include "controlplane/config/cp_module.h"
 #include "controlplane/config/zone.h"
 #include "counters/counters.h"
@@ -1361,12 +1357,12 @@ cp_device_config_set_output_pipeline(
 
 // Check if counter name matches any query pattern.
 //
-// Returns true if query_count == 0 (return all) or name matches.
+// Returns true if query_count == -1 (return all) or name matches.
 static bool
 counter_name_matches_query(
 	const char *name, const char *const *query, size_t query_count
 ) {
-	if (query_count == (uint64_t)-1) {
+	if (query_count == (size_t)-1) {
 		return true;
 	}
 

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1372,7 +1372,6 @@ counter_name_matches_query(
 			return true;
 		}
 	}
-
 	return false;
 }
 

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1,6 +1,7 @@
 #include "agent.h"
 
 #include <linux/mman.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -10,11 +11,13 @@
 
 #include <errno.h>
 
+#include "api/counter.h"
 #include "common/memory.h"
 #include "common/memory_address.h"
 #include "common/memory_block.h"
 #include "common/strutils.h"
 
+#include "controlplane/config/cp_counter.h"
 #include "controlplane/config/cp_module.h"
 #include "controlplane/config/zone.h"
 #include "counters/counters.h"
@@ -1358,12 +1361,12 @@ cp_device_config_set_output_pipeline(
 
 // Check if counter name matches any query pattern.
 //
-// Returns true if query_count == -1 (return all) or name matches.
+// Returns true if query_count == 0 (return all) or name matches.
 static bool
 counter_name_matches_query(
 	const char *name, const char *const *query, size_t query_count
 ) {
-	if (query_count == (size_t)-1) {
+	if (query_count == (uint64_t)-1) {
 		return true;
 	}
 
@@ -1373,6 +1376,7 @@ counter_name_matches_query(
 			return true;
 		}
 	}
+
 	return false;
 }
 


### PR DESCRIPTION
Adds tag-based counter lookups to the Go control plane protobuf and Rust CLI.