### PR TITLE
refactor: poll web counters by tags

### DIFF
--- a/web/src/api/counters.ts
+++ b/web/src/api/counters.ts
@@ -14,6 +14,25 @@ export interface CountersResponse {
     counters?: CounterInfo[];
 }
 
+export interface CounterTag {
+    key?: string;
+    value?: string;
+}
+
+export interface CountersByTagsRequest {
+    tags?: CounterTag[];
+    query?: string[];
+}
+
+export interface CounterGroup {
+    tags?: CounterTag[];
+    counters?: CounterInfo[];
+}
+
+export interface CountersByTagsResponse {
+    groups?: CounterGroup[];
+}
+
 export interface DeviceCountersRequest {
     device: string;
 }
@@ -66,5 +85,8 @@ export const counters = {
     },
     module: (request: ModuleCountersRequest, options?: CallOptions): Promise<CountersResponse> => {
         return countersService.callWithBody<CountersResponse>('Module', request, options);
+    },
+    byTags: (request: CountersByTagsRequest, options?: CallOptions): Promise<CountersByTagsResponse> => {
+        return countersService.callWithBody<CountersByTagsResponse>('ByTags', request, options);
     },
 };

--- a/web/src/hooks/useDeviceCounters.ts
+++ b/web/src/hooks/useDeviceCounters.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { API } from '../api';
-import type { CounterInfo } from '../api';
+import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../utils';
 import {
     useInterpolatedCounters,
     type InterpolatedCounterData,
@@ -43,24 +43,6 @@ export interface UseDeviceCountersResult {
 }
 
 /**
- * Helper to sum counter values across all instances.
- */
-const sumCounterValues = (counter: CounterInfo | undefined): bigint => {
-    if (!counter?.instances) return BigInt(0);
-    return counter.instances.reduce((sum, inst) => {
-        const val = inst.values?.[0];
-        return sum + BigInt(val ?? 0);
-    }, BigInt(0));
-};
-
-/**
- * Helper to find counter by name.
- */
-const findCounter = (counters: CounterInfo[] | undefined, name: string): CounterInfo | undefined => {
-    return counters?.find(c => c.name === name);
-};
-
-/**
  * Hook for fetching and interpolating device counters (RX/TX rates).
  *
  * Uses the generic useInterpolatedCounters hook with device-specific fetch logic.
@@ -95,24 +77,29 @@ export const useDeviceCounters = (
             newValues.set(`${name}:tx`, { packets: BigInt(0), bytes: BigInt(0) });
         }
 
-        // Fetch counters for each device
-        await Promise.all(
-            deviceNames.map(async (deviceName) => {
-                try {
-                    const response = await API.counters.device({ device: deviceName });
+        try {
+            const response = await API.counters.byTags({
+                tags: [
+                    { key: 'device', value: '*' },
+                    { key: 'pipeline', value: '' },
+                ],
+                query: ['rx', 'rx_bytes', 'tx', 'tx_bytes'],
+            });
 
-                    const rxPackets = sumCounterValues(findCounter(response.counters, 'rx'));
-                    const rxBytes = sumCounterValues(findCounter(response.counters, 'rx_bytes'));
-                    const txPackets = sumCounterValues(findCounter(response.counters, 'tx'));
-                    const txBytes = sumCounterValues(findCounter(response.counters, 'tx_bytes'));
+            const grouped = groupCounterGroupsByTagsAndName(response.groups, ['device'], 0);
 
-                    newValues.set(`${deviceName}:rx`, { packets: rxPackets, bytes: rxBytes });
-                    newValues.set(`${deviceName}:tx`, { packets: txPackets, bytes: txBytes });
-                } catch {
-                    // Ignore errors for individual device counters
-                }
-            })
-        );
+            for (const deviceName of deviceNames) {
+                const rxPackets = grouped.get(makeGroupedCounterKey([deviceName], 'rx'))?.value ?? BigInt(0);
+                const rxBytes = grouped.get(makeGroupedCounterKey([deviceName], 'rx_bytes'))?.value ?? BigInt(0);
+                const txPackets = grouped.get(makeGroupedCounterKey([deviceName], 'tx'))?.value ?? BigInt(0);
+                const txBytes = grouped.get(makeGroupedCounterKey([deviceName], 'tx_bytes'))?.value ?? BigInt(0);
+
+                newValues.set(`${deviceName}:rx`, { packets: rxPackets, bytes: rxBytes });
+                newValues.set(`${deviceName}:tx`, { packets: txPackets, bytes: txBytes });
+            }
+        } catch {
+            // Ignore global counters fetch errors.
+        }
 
         return newValues;
     }, [deviceNames]);

--- a/web/src/pages/builtin/dashboard/hooks.ts
+++ b/web/src/pages/builtin/dashboard/hooks.ts
@@ -22,8 +22,14 @@ export const useWorkerCount = (deviceNames: string[]): number | null => {
         let cancelled = false;
         (async () => {
             try {
-                const resp = await API.counters.device({ device: firstDevice });
-                const counter = resp.counters?.[0];
+                const resp = await API.counters.byTags({
+                    tags: [
+                        { key: 'device', value: firstDevice },
+                        { key: 'pipeline', value: '' },
+                    ],
+                    query: ['rx'],
+                });
+                const counter = resp.groups?.[0]?.counters?.[0];
                 if (!counter?.instances) {
                     if (!cancelled) setCount(null);
                     return;

--- a/web/src/pages/builtin/functions/hooks/useModuleCounters.ts
+++ b/web/src/pages/builtin/functions/hooks/useModuleCounters.ts
@@ -1,22 +1,8 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { API } from '../../../../api';
-import type { CounterInfo, DeviceInfo } from '../../../../api';
 import { useInterpolatedCounters } from '../../../../hooks';
 import type { InterpolatedCounterData } from '../../../../hooks';
-
-const DEFAULT_INTERVAL_MS = 1500;
-
-const sumCounterValues = (counter: CounterInfo | undefined): bigint => {
-    if (!counter?.instances) return BigInt(0);
-    return counter.instances.reduce((sum, inst) => {
-        const instSum = (inst.values ?? []).reduce((s, val) => s + BigInt(val ?? 0), BigInt(0));
-        return sum + instSum;
-    }, BigInt(0));
-};
-
-const findCounter = (counters: CounterInfo[] | undefined, name: string): CounterInfo | undefined => {
-    return counters?.find(c => c.name === name);
-};
+import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../../utils';
 
 export interface ModuleInfo {
     nodeId: string;
@@ -32,72 +18,13 @@ export interface UseModuleCountersResult {
 /**
  * Hook for fetching and interpolating module counters.
  *
- * Uses the generic useInterpolatedCounters hook with module-specific fetch logic.
- * Polls module counters every 1 second from backend using the Module API.
- * Aggregates counters across all devices and pipelines using the function.
- * Updates visual every 30ms using linear interpolation.
- *
- * The topology (device and pipeline list) is re-fetched at DEFAULT_INTERVAL_MS
- * so that adding or removing a device is reflected without a page reload.
+ * Polls module counters every 1 second from backend using the ByTags API
+ * and updates visual every 30ms using linear interpolation.
  */
 export const useModuleCounters = (
     functionName: string,
     moduleInfoList: ModuleInfo[]
 ): UseModuleCountersResult => {
-    const [devices, setDevices] = useState<DeviceInfo[]>([]);
-    const [pipelineNames, setPipelineNames] = useState<string[]>([]);
-
-    useEffect(() => {
-        let cancelled = false;
-
-        const fetchDevicesAndPipelines = async (): Promise<void> => {
-            try {
-                const response = await API.inspect.inspect();
-                if (cancelled) return;
-                const instanceInfo = response.instance_info;
-                const allDevices = instanceInfo?.devices ?? [];
-                const allPipelines = instanceInfo?.pipelines ?? [];
-
-                const matchingPipelines = allPipelines.filter(p => {
-                    const funcs = p.functions ?? [];
-                    return funcs.includes(functionName);
-                });
-
-                const pipelineNamesSet = new Set(matchingPipelines.map(p => p.name).filter((n): n is string => !!n));
-
-                const matchingDeviceNames = new Set<string>();
-                const matchingDevices: DeviceInfo[] = [];
-                for (const device of allDevices) {
-                    const inputPipelines = device.input_pipelines ?? [];
-                    const outputPipelines = device.output_pipelines ?? [];
-                    const allDevicePipelines = [...inputPipelines, ...outputPipelines];
-
-                    for (const pipeline of allDevicePipelines) {
-                        if (pipeline.name && pipelineNamesSet.has(pipeline.name)) {
-                            const devName = device.name ?? '';
-                            if (!matchingDeviceNames.has(devName)) {
-                                matchingDeviceNames.add(devName);
-                                matchingDevices.push(device);
-                            }
-                        }
-                    }
-                }
-
-                setDevices(matchingDevices);
-                setPipelineNames(Array.from(pipelineNamesSet));
-            } catch {
-                // Topology fetch failures are non-fatal; counters just stay empty.
-            }
-        };
-
-        fetchDevicesAndPipelines();
-        const id = setInterval(fetchDevicesAndPipelines, DEFAULT_INTERVAL_MS);
-        return () => {
-            cancelled = true;
-            clearInterval(id);
-        };
-    }, [functionName]);
-
     const nodeIds = moduleInfoList.map(m => m.nodeId);
 
     const fetchCounters = useCallback(async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
@@ -107,50 +34,47 @@ export const useModuleCounters = (
             newValues.set(moduleInfo.nodeId, { packets: BigInt(0), bytes: BigInt(0) });
         }
 
-        // Build flat list of all (device, pipeline, moduleInfo) triples and fetch in parallel.
-        const triples: Array<{ deviceName: string; pipelineName: string; moduleInfo: ModuleInfo }> = [];
-        for (const device of devices) {
-            const deviceName = device.name || '';
-            for (const pipelineName of pipelineNames) {
-                for (const moduleInfo of moduleInfoList) {
-                    triples.push({ deviceName, pipelineName, moduleInfo });
-                }
-            }
+        if (!functionName || moduleInfoList.length === 0) {
+            return newValues;
         }
 
-        const results = await Promise.allSettled(
-            triples.map(({ deviceName, pipelineName, moduleInfo }) =>
-                API.counters.module({
-                    device: deviceName,
-                    pipeline: pipelineName,
-                    function: functionName,
-                    chain: moduleInfo.chainName,
-                    module_type: moduleInfo.moduleType,
-                    module_name: moduleInfo.moduleName,
-                    counter_query: ['rx', 'rx_bytes'],
-                }).then(response => ({ moduleInfo, response }))
-            )
-        );
-
-        for (const result of results) {
-            if (result.status !== 'fulfilled') continue;
-            const { moduleInfo, response } = result.value;
-            const rxPackets = sumCounterValues(findCounter(response.counters, 'rx'));
-            const rxBytes = sumCounterValues(findCounter(response.counters, 'rx_bytes'));
-            const current = newValues.get(moduleInfo.nodeId) ?? { packets: BigInt(0), bytes: BigInt(0) };
-            newValues.set(moduleInfo.nodeId, {
-                packets: current.packets + rxPackets,
-                bytes: current.bytes + rxBytes,
+        try {
+            const response = await API.counters.byTags({
+                tags: [{ key: 'module_type', value: '*' }],
+                query: ['rx', 'rx_bytes'],
             });
+            const grouped = groupCounterGroupsByTagsAndName(
+                response.groups,
+                ['function', 'chain', 'module_type', 'module_name'],
+                0
+            );
+
+            for (const moduleInfo of moduleInfoList) {
+                const keyPrefix = [
+                    functionName,
+                    moduleInfo.chainName,
+                    moduleInfo.moduleType,
+                    moduleInfo.moduleName,
+                ];
+                const rxPackets = grouped.get(makeGroupedCounterKey(keyPrefix, 'rx'))?.value ?? BigInt(0);
+                const rxBytes = grouped.get(makeGroupedCounterKey(keyPrefix, 'rx_bytes'))?.value ?? BigInt(0);
+
+                newValues.set(moduleInfo.nodeId, {
+                    packets: rxPackets,
+                    bytes: rxBytes,
+                });
+            }
+        } catch {
+            // tolerate fetch failures.
         }
 
         return newValues;
-    }, [devices, pipelineNames, functionName, moduleInfoList]);
+    }, [functionName, moduleInfoList]);
 
     const { counters } = useInterpolatedCounters({
         keys: nodeIds,
         fetchCounters,
-        enabled: devices.length > 0 && pipelineNames.length > 0 && moduleInfoList.length > 0,
+        enabled: functionName.length > 0 && moduleInfoList.length > 0,
         pollingInterval: 1000,
         interpolationInterval: 30,
     });

--- a/web/src/pages/builtin/inspect/hooks.ts
+++ b/web/src/pages/builtin/inspect/hooks.ts
@@ -1,31 +1,10 @@
 import { useEffect, useRef, useState, useMemo } from 'react';
 import { API } from '../../../api';
-import type { CounterInfo, CountersResponse } from '../../../api';
 import type { DeviceCounterData } from '../../../hooks';
+import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../utils';
 
 const DEFAULT_INTERVAL_MS = 1500;
 const DEFAULT_MAX_LEN = 30;
-
-const sumCounter = (counters: CounterInfo[] | undefined, name: string): bigint => {
-    const c = counters?.find((x) => x.name === name);
-    if (!c?.instances) return BigInt(0);
-    return c.instances.reduce((sum, inst) => {
-        const val = inst.values?.[0];
-        return sum + BigInt(val ?? 0);
-    }, BigInt(0));
-};
-
-/**
- * Aggregate pipeline/function throughput from input/input_bytes counters.
- * These endpoints register input/output/drop counters (not rx/tx); using
- * input represents traffic that entered the pipeline/function regardless
- * of whether it was forwarded or dropped.
- */
-const sumPipelineThroughput = (response: CountersResponse): { packets: bigint; bytes: bigint } => {
-    const packets = sumCounter(response.counters, 'input');
-    const bytes = sumCounter(response.counters, 'input_bytes');
-    return { packets, bytes };
-};
 
 /**
  * Push the current value onto a rolling history at the polling interval.
@@ -127,8 +106,8 @@ interface RatesAndSeries {
 }
 
 /**
- * Poll pipeline counters across (device, pipeline) pairs and produce
- * per-pipeline rate and rolling series.
+ * Poll pipeline counters via tag selection and produce per-pipeline
+ * rate and rolling series.
  */
 export const usePipelineCounters = (
     devices: string[],
@@ -159,35 +138,30 @@ export const usePipelineCounters = (
 
         const tick = async (): Promise<void> => {
             const now = Date.now();
-            const currentDevices = devicesRef.current;
             const currentPipelines = pipelinesRef.current;
-
-            const deltas = await Promise.all(
-                currentDevices.flatMap((device) =>
-                    currentPipelines.map(async (pipeline) => {
-                        try {
-                            const resp = await API.counters.pipeline({ device, pipeline });
-                            const sums = sumPipelineThroughput(resp);
-                            return { name: pipeline, packets: sums.packets, bytes: sums.bytes };
-                        } catch {
-                            // tolerate per-pair failures.
-                            return null;
-                        }
-                    }),
-                ),
-            );
 
             const totals = new Map<string, { packets: bigint; bytes: bigint }>();
             for (const p of currentPipelines) {
                 totals.set(p, { packets: BigInt(0), bytes: BigInt(0) });
             }
-            for (const delta of deltas) {
-                if (delta === null) continue;
-                const cur = totals.get(delta.name) ?? { packets: BigInt(0), bytes: BigInt(0) };
-                totals.set(delta.name, {
-                    packets: cur.packets + delta.packets,
-                    bytes: cur.bytes + delta.bytes,
+
+            try {
+                const response = await API.counters.byTags({
+                    tags: [
+                        { key: 'pipeline', value: '*' },
+                        { key: 'function', value: '' },
+                    ],
+                    query: ['input', 'input_bytes'],
                 });
+                const grouped = groupCounterGroupsByTagsAndName(response.groups, ['pipeline'], 0);
+                for (const pipeline of currentPipelines) {
+                    totals.set(pipeline, {
+                        packets: grouped.get(makeGroupedCounterKey([pipeline], 'input'))?.value ?? BigInt(0),
+                        bytes: grouped.get(makeGroupedCounterKey([pipeline], 'input_bytes'))?.value ?? BigInt(0),
+                    });
+                }
+            } catch {
+                // tolerate fetch failures.
             }
 
             if (cancelled) return;
@@ -240,8 +214,8 @@ export const usePipelineCounters = (
 };
 
 /**
- * Poll function counters across (device, pipeline, function) triples and
- * produce per-function rate and rolling series.
+ * Poll function counters via tag selection and produce per-function
+ * rate and rolling series.
  */
 export const useFunctionCounters = (
     devices: string[],
@@ -281,44 +255,28 @@ export const useFunctionCounters = (
 
         const tick = async (): Promise<void> => {
             const now = Date.now();
-            const currentDevices = devicesRef.current;
-            const currentPipelines = pipelinesRef.current;
             const currentFunctions = functionsRef.current;
-
-            const tasks: Promise<{ name: string; packets: bigint; bytes: bigint } | null>[] = [];
-            for (const device of currentDevices) {
-                for (const pipeline of currentPipelines) {
-                    for (const fn of currentFunctions) {
-                        tasks.push(
-                            (async () => {
-                                try {
-                                    const resp = await API.counters.function({
-                                        device,
-                                        pipeline,
-                                        function: fn,
-                                    });
-                                    const sums = sumPipelineThroughput(resp);
-                                    return { name: fn, packets: sums.packets, bytes: sums.bytes };
-                                } catch {
-                                    // tolerate per-triple failures.
-                                    return null;
-                                }
-                            })(),
-                        );
-                    }
-                }
-            }
-            const deltas = await Promise.all(tasks);
 
             const totals = new Map<string, { packets: bigint; bytes: bigint }>();
             currentFunctions.forEach((f) => totals.set(f, { packets: BigInt(0), bytes: BigInt(0) }));
-            for (const delta of deltas) {
-                if (delta === null) continue;
-                const cur = totals.get(delta.name) ?? { packets: BigInt(0), bytes: BigInt(0) };
-                totals.set(delta.name, {
-                    packets: cur.packets + delta.packets,
-                    bytes: cur.bytes + delta.bytes,
+
+            try {
+                const response = await API.counters.byTags({
+                    tags: [
+                        { key: 'function', value: '*' },
+                        { key: 'chain', value: '' },
+                    ],
+                    query: ['input', 'input_bytes'],
                 });
+                const grouped = groupCounterGroupsByTagsAndName(response.groups, ['function'], 0);
+                for (const functionName of currentFunctions) {
+                    totals.set(functionName, {
+                        packets: grouped.get(makeGroupedCounterKey([functionName], 'input'))?.value ?? BigInt(0),
+                        bytes: grouped.get(makeGroupedCounterKey([functionName], 'input_bytes'))?.value ?? BigInt(0),
+                    });
+                }
+            } catch {
+                // tolerate fetch failures.
             }
 
             if (cancelled) return;

--- a/web/src/pages/builtin/pipelines/hooks/useFunctionRefCounters.ts
+++ b/web/src/pages/builtin/pipelines/hooks/useFunctionRefCounters.ts
@@ -1,26 +1,11 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback } from 'react';
 import { API } from '../../../../api';
-import type { CounterInfo, DeviceInfo } from '../../../../api';
 import { useInterpolatedCounters } from '../../../../hooks';
 import type { InterpolatedCounterData } from '../../../../hooks';
+import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../../utils';
 
 /** Well-known key for pipeline-level fallthrough counters. */
 export const PIPELINE_COUNTER_KEY = '__pipeline__';
-
-const DEFAULT_INTERVAL_MS = 1500;
-
-const sumCounterValues = (counter: CounterInfo | undefined): bigint => {
-    if (!counter?.instances) {
-        return BigInt(0);
-    }
-    return counter.instances.reduce((sum, inst) => {
-        const instSum = (inst.values ?? []).reduce((s, val) => s + BigInt(val ?? 0), BigInt(0));
-        return sum + instSum;
-    }, BigInt(0));
-};
-
-const findCounter = (counters: CounterInfo[] | undefined, name: string): CounterInfo | undefined =>
-    counters?.find(c => c.name === name);
 
 export interface FunctionRefInfo {
     nodeId: string;
@@ -34,51 +19,14 @@ export interface UseFunctionRefCountersResult {
 /**
  * Fetches and interpolates per-function-ref counters for a pipeline.
  *
- * Resolves all devices that have pipelineName in input_pipelines or output_pipelines,
- * then polls API.counters.function for each (device, functionName) pair each second.
- * Results are keyed by nodeId (FunctionRef.id), not by function name, so duplicate
- * function names in a pipeline each get their own bucket pointing to shared counters.
- * When refs is empty, fetches pipeline-level counters under PIPELINE_COUNTER_KEY.
- *
- * The topology (device list) is re-fetched at DEFAULT_INTERVAL_MS so that
- * adding or removing a device is reflected without a page reload.
+ * Polls CountersService.ByTags each second and returns values keyed by
+ * FunctionRef.id. When refs is empty, fetches pipeline-level counters
+ * under PIPELINE_COUNTER_KEY.
  */
 export const useFunctionRefCounters = (
     pipelineName: string,
     refs: FunctionRefInfo[],
 ): UseFunctionRefCountersResult => {
-    const [devices, setDevices] = useState<DeviceInfo[]>([]);
-
-    useEffect(() => {
-        let cancelled = false;
-
-        const fetchDevices = async (): Promise<void> => {
-            try {
-                const response = await API.inspect.inspect();
-                if (cancelled) return;
-                const allDevices = response.instance_info?.devices ?? [];
-
-                const matchingDevices = allDevices.filter(device => {
-                    const inputPipelines = device.input_pipelines ?? [];
-                    const outputPipelines = device.output_pipelines ?? [];
-                    return inputPipelines.some(p => p.name === pipelineName) ||
-                        outputPipelines.some(p => p.name === pipelineName);
-                });
-
-                setDevices(matchingDevices);
-            } catch {
-                // Topology fetch failures are non-fatal; counters just stay empty.
-            }
-        };
-
-        fetchDevices();
-        const id = setInterval(fetchDevices, DEFAULT_INTERVAL_MS);
-        return () => {
-            cancelled = true;
-            clearInterval(id);
-        };
-    }, [pipelineName]);
-
     const hasFunctionRefs = refs.length > 0;
 
     const keys: string[] = hasFunctionRefs
@@ -88,74 +36,64 @@ export const useFunctionRefCounters = (
     const fetchCounters = useCallback(async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
         const newValues = new Map<string, { packets: bigint; bytes: bigint }>();
 
+        if (!pipelineName) {
+            return newValues;
+        }
+
         if (hasFunctionRefs) {
             for (const ref of refs) {
                 newValues.set(ref.nodeId, { packets: BigInt(0), bytes: BigInt(0) });
             }
 
-            // Build flat list of all (device, ref) pairs and fetch in parallel.
-            const pairs: Array<{ deviceName: string; ref: FunctionRefInfo }> = [];
-            for (const device of devices) {
-                const deviceName = device.name ?? '';
-                for (const ref of refs) {
-                    pairs.push({ deviceName, ref });
-                }
-            }
-
-            const results = await Promise.allSettled(
-                pairs.map(({ deviceName, ref }) =>
-                    API.counters.function({
-                        device: deviceName,
-                        pipeline: pipelineName,
-                        function: ref.functionName,
-                    }).then(response => ({ ref, response }))
-                )
-            );
-
-            for (const result of results) {
-                if (result.status !== 'fulfilled') continue;
-                const { ref, response } = result.value;
-                const rxPackets = sumCounterValues(findCounter(response.counters, 'input'));
-                const rxBytes = sumCounterValues(findCounter(response.counters, 'input_bytes'));
-                const current = newValues.get(ref.nodeId) ?? { packets: BigInt(0), bytes: BigInt(0) };
-                newValues.set(ref.nodeId, {
-                    packets: current.packets + rxPackets,
-                    bytes: current.bytes + rxBytes,
+            try {
+                const response = await API.counters.byTags({
+                    tags: [
+                        { key: 'pipeline', value: pipelineName },
+                        { key: 'function', value: '*' },
+                        { key: 'chain', value: '' },
+                    ],
+                    query: ['input', 'input_bytes'],
                 });
+                const grouped = groupCounterGroupsByTagsAndName(response.groups, ['pipeline', 'function'], 0);
+
+                for (const ref of refs) {
+                    const tagValues = [pipelineName, ref.functionName];
+                    const packets = grouped.get(makeGroupedCounterKey(tagValues, 'input'))?.value ?? BigInt(0);
+                    const bytes = grouped.get(makeGroupedCounterKey(tagValues, 'input_bytes'))?.value ?? BigInt(0);
+
+                    newValues.set(ref.nodeId, { packets, bytes });
+                }
+            } catch {
+                // tolerate fetch failures.
             }
         } else {
             newValues.set(PIPELINE_COUNTER_KEY, { packets: BigInt(0), bytes: BigInt(0) });
 
-            // Fetch all device pipeline counters in parallel.
-            const results = await Promise.allSettled(
-                devices.map(device =>
-                    API.counters.pipeline({
-                        device: device.name ?? '',
-                        pipeline: pipelineName,
-                    })
-                )
-            );
-
-            for (const result of results) {
-                if (result.status !== 'fulfilled') continue;
-                const response = result.value;
-                const rxPackets = sumCounterValues(findCounter(response.counters, 'input'));
-                const rxBytes = sumCounterValues(findCounter(response.counters, 'input_bytes'));
-                const current = newValues.get(PIPELINE_COUNTER_KEY) ?? { packets: BigInt(0), bytes: BigInt(0) };
-                newValues.set(PIPELINE_COUNTER_KEY, {
-                    packets: current.packets + rxPackets,
-                    bytes: current.bytes + rxBytes,
+            try {
+                const response = await API.counters.byTags({
+                    tags: [
+                        { key: 'pipeline', value: pipelineName },
+                        { key: 'function', value: '' },
+                    ],
+                    query: ['input', 'input_bytes'],
                 });
+                const grouped = groupCounterGroupsByTagsAndName(response.groups, ['pipeline'], 0);
+                newValues.set(PIPELINE_COUNTER_KEY, {
+                    packets: grouped.get(makeGroupedCounterKey([pipelineName], 'input'))?.value ?? BigInt(0),
+                    bytes: grouped.get(makeGroupedCounterKey([pipelineName], 'input_bytes'))?.value ?? BigInt(0),
+                });
+            } catch {
+                // tolerate fetch failures.
             }
         }
 
         return newValues;
-    }, [devices, pipelineName, refs, hasFunctionRefs]);
+    }, [pipelineName, refs, hasFunctionRefs]);
 
     const { counters } = useInterpolatedCounters({
         keys,
         fetchCounters,
-        enabled: devices.length > 0,
+        enabled: pipelineName.length > 0,
         pollingInterval: 1000,
         interpolationInterval: 30,
     });

--- a/web/src/pages/modules/acl/useAclRuleCounters.ts
+++ b/web/src/pages/modules/acl/useAclRuleCounters.ts
@@ -1,74 +1,14 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { API } from '../../../api';
-import type { CounterInfo } from '../../../api';
 import { useInterpolatedCounters } from '../../../hooks';
 import type { RuleItem } from './types';
 import { effectiveCounterName } from './hooks';
+import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../utils';
 
 const HISTORY_SIZE = 60;
 
 const appendCapped = (arr: number[], v: number, cap: number): number[] =>
     arr.length < cap ? [...arr, v] : [...arr.slice(1), v];
-
-const sumCounterValues = (counter: CounterInfo | undefined): bigint => {
-    if (!counter?.instances) return BigInt(0);
-    return counter.instances.reduce((sum, inst) => {
-        if (!inst.values) return sum;
-        const val = inst.values[0];
-        return sum + BigInt(val ?? 0);
-    }, BigInt(0));
-};
-
-const findCounter = (counters: CounterInfo[] | undefined, name: string): CounterInfo | undefined =>
-    counters?.find(c => c.name === name);
-
-interface MountPoint {
-    device: string;
-    pipeline: string;
-    functionName: string;
-    chainName: string;
-}
-
-const discoverMountPoints = async (configName: string): Promise<MountPoint[]> => {
-    const response = await API.inspect.inspect();
-    const info = response.instance_info;
-    if (!info) return [];
-
-    const pipelines = info.pipelines ?? [];
-    const functions = info.functions ?? [];
-    const devices = info.devices ?? [];
-
-    const points: MountPoint[] = [];
-
-    for (const fn of functions) {
-        const fnName = fn.name ?? '';
-        for (const chain of fn.chains ?? []) {
-            const chainName = chain.name ?? '';
-            const hasAcl = (chain.modules ?? []).some(
-                m => m.type === 'acl' && m.name === configName
-            );
-            if (!hasAcl) continue;
-
-            for (const pipeline of pipelines) {
-                const pipelineName = pipeline.name ?? '';
-                if (!(pipeline.functions ?? []).includes(fnName)) continue;
-
-                for (const device of devices) {
-                    const deviceName = device.name ?? '';
-                    const allDevicePipelines = [
-                        ...(device.input_pipelines ?? []),
-                        ...(device.output_pipelines ?? []),
-                    ];
-                    if (!allDevicePipelines.some(dp => dp.name === pipelineName)) continue;
-
-                    points.push({ device: deviceName, pipeline: pipelineName, functionName: fnName, chainName });
-                }
-            }
-        }
-    }
-
-    return points;
-};
 
 /** Per-rule rate data: rolling history for the sparkline and the latest interpolated pps. */
 export interface RuleRate {
@@ -82,7 +22,7 @@ export interface UseAclRuleCountersResult {
 }
 
 /**
- * Polls CountersService.Module once per second for the enabled subset of ACL rules.
+ * Polls CountersService.ByTags once per second for the enabled subset of ACL rules.
  * Only rules whose counter name appears in enabledCounters are polled; if the set is
  * empty, no requests are made at all.
  *
@@ -95,9 +35,6 @@ export const useAclRuleCounters = (
     enabledCounters: Set<string>,
     enabled: boolean,
 ): UseAclRuleCountersResult => {
-    const [mountPointsEntry, setMountPointsEntry] = useState<{ config: string; points: MountPoint[] }>({ config: '', points: [] });
-    const mountPoints = mountPointsEntry.config === configName ? mountPointsEntry.points : [];
-
     const historyRef = useRef<Map<string, number[]>>(new Map());
     const [rates, setRates] = useState<Map<string, RuleRate>>(new Map());
     const ratesRef = useRef(rates);
@@ -106,23 +43,10 @@ export const useAclRuleCounters = (
     // Declared here so the effect below (which reads countersRef.current) can reference it safely.
     const countersRef = useRef<Map<string, { pps: number }>>(new Map());
 
-    const discoveryGen = useRef(0);
-
     useEffect(() => {
-        if (!configName) return;
         historyRef.current = new Map();
-        setMountPointsEntry({ config: '', points: [] });
         setRates(new Map());
-        discoveryGen.current += 1;
-        const myGen = discoveryGen.current;
-        discoverMountPoints(configName).then(points => {
-            if (myGen !== discoveryGen.current) return;
-            setMountPointsEntry({ config: configName, points });
-        }).catch((err: unknown) => {
-            if (myGen !== discoveryGen.current) return;
-            console.error('Failed to discover ACL mount points:', err);
-        });
-    }, [configName]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [configName]);
 
     useEffect(() => {
         const history = historyRef.current;
@@ -139,8 +63,6 @@ export const useAclRuleCounters = (
 
     const rulesRef = useRef(rules);
     rulesRef.current = rules;
-    const mountPointsRef = useRef(mountPoints);
-    mountPointsRef.current = mountPoints;
     const enabledCountersRef = useRef(enabledCounters);
     enabledCountersRef.current = enabledCounters;
 
@@ -152,42 +74,36 @@ export const useAclRuleCounters = (
             result.set(name, { packets: BigInt(0), bytes: BigInt(0) });
         }
 
-        const points = mountPointsRef.current;
-        if (points.length === 0 || counterNames.length === 0) return result;
+        if (!configName || counterNames.length === 0) {
+            return result;
+        }
 
-        const fetches = points.map(mp =>
-            API.counters.module({
-                device: mp.device,
-                pipeline: mp.pipeline,
-                function: mp.functionName,
-                chain: mp.chainName,
-                module_type: 'acl',
-                module_name: configName,
-                counter_query: counterNames,
-            }).then(response => response.counters ?? [])
-        );
-
-        const settled = await Promise.allSettled(fetches);
-
-        for (const outcome of settled) {
-            if (outcome.status !== 'fulfilled') continue;
-            const countersArr = outcome.value;
+        try {
+            const response = await API.counters.byTags({
+                tags: [
+                    { key: 'module_type', value: 'acl' },
+                    { key: 'module_name', value: configName },
+                ],
+                query: counterNames,
+            });
+            const grouped = groupCounterGroupsByTagsAndName(response.groups, [], 0);
             for (const counterName of counterNames) {
-                const ci = findCounter(countersArr, counterName);
-                const packets = sumCounterValues(ci);
-                const current = result.get(counterName)!;
-                result.set(counterName, { packets: current.packets + packets, bytes: BigInt(0) });
+                result.set(counterName, {
+                    packets: grouped.get(makeGroupedCounterKey([], counterName))?.value ?? BigInt(0),
+                    bytes: BigInt(0),
+                });
             }
+        } catch {
+            // tolerate fetch failures.
         }
 
         return result;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [configName, mountPoints, counterNames.join(',')]);
+    }, [configName, counterNames]);
 
     const { counters } = useInterpolatedCounters({
         keys: counterNames,
         fetchCounters,
-        enabled: enabled && mountPoints.length > 0 && counterNames.length > 0,
+        enabled: enabled && configName.length > 0 && counterNames.length > 0,
         pollingInterval: 1000,
         interpolationInterval: 30,
     });

--- a/web/src/pages/modules/forward/useForwardRuleCounters.ts
+++ b/web/src/pages/modules/forward/useForwardRuleCounters.ts
@@ -1,80 +1,14 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { API } from '../../../api';
-import type { CounterInfo } from '../../../api';
 import { useInterpolatedCounters } from '../../../hooks';
 import type { RuleItem } from './types';
+import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../utils';
 
 const HISTORY_SIZE = 60;
 
 /** Returns a new array with v appended, capped at cap elements. */
 const appendCapped = (arr: number[], v: number, cap: number): number[] =>
     arr.length < cap ? [...arr, v] : [...arr.slice(1), v];
-
-const sumCounterValues = (counter: CounterInfo | undefined): bigint => {
-    if (!counter?.instances) return BigInt(0);
-    return counter.instances.reduce((sum, inst) => {
-        if (!inst.values) return sum;
-        const val = inst.values[0];
-        return sum + BigInt(val ?? 0);
-    }, BigInt(0));
-};
-
-const findCounter = (counters: CounterInfo[] | undefined, name: string): CounterInfo | undefined =>
-    counters?.find(c => c.name === name);
-
-/** A (device, pipeline, function, chain) quad where the forward module is mounted. */
-interface MountPoint {
-    device: string;
-    pipeline: string;
-    functionName: string;
-    chainName: string;
-}
-
-/**
- * Discovers all mount points for a named forward config by calling InspectService.
- * Returns only the quads where at least one chain module matches
- * { type: 'forward', name: configName }.
- */
-const discoverMountPoints = async (configName: string): Promise<MountPoint[]> => {
-    const response = await API.inspect.inspect();
-    const info = response.instance_info;
-    if (!info) return [];
-
-    const pipelines = info.pipelines ?? [];
-    const functions = info.functions ?? [];
-    const devices = info.devices ?? [];
-
-    const points: MountPoint[] = [];
-
-    for (const fn of functions) {
-        const fnName = fn.name ?? '';
-        for (const chain of fn.chains ?? []) {
-            const chainName = chain.name ?? '';
-            const hasForward = (chain.modules ?? []).some(
-                m => m.type === 'forward' && m.name === configName
-            );
-            if (!hasForward) continue;
-
-            for (const pipeline of pipelines) {
-                const pipelineName = pipeline.name ?? '';
-                if (!(pipeline.functions ?? []).includes(fnName)) continue;
-
-                for (const device of devices) {
-                    const deviceName = device.name ?? '';
-                    const allDevicePipelines = [
-                        ...(device.input_pipelines ?? []),
-                        ...(device.output_pipelines ?? []),
-                    ];
-                    if (!allDevicePipelines.some(dp => dp.name === pipelineName)) continue;
-
-                    points.push({ device: deviceName, pipeline: pipelineName, functionName: fnName, chainName });
-                }
-            }
-        }
-    }
-
-    return points;
-};
 
 /** Per-rule rate data: rolling history for the sparkline and the latest interpolated pps. */
 export interface RuleRate {
@@ -88,9 +22,9 @@ export interface UseForwardRuleCountersResult {
 }
 
 /**
- * Polls CountersService.Module once per second for all rules of the given forward
- * config, maintains a 60-sample pps rolling window per rule, and interpolates at
- * ~30ms for smooth sparkline animation.
+ * Polls CountersService.ByTags once per second for all rules of the given
+ * forward config, maintains a 60-sample pps rolling window per rule, and
+ * interpolates at ~30ms for smooth sparkline animation.
  *
  * When enabled=false, polling and history sampling pause; the last known values are
  * preserved so sparklines freeze rather than disappear.
@@ -103,15 +37,6 @@ export const useForwardRuleCounters = (
     rules: RuleItem[],
     enabled: boolean,
 ): UseForwardRuleCountersResult => {
-    // Mount points are stored together with the config name they were discovered
-    // for. Deriving the effective mount points by comparing tags during render
-    // ensures that stale points from config A are never visible in a render that
-    // already shows config B, even before the discovery effect has had a chance
-    // to call setMountPointsEntry([]) after the tab switch.
-    const [mountPointsEntry, setMountPointsEntry] = useState<{ config: string; points: MountPoint[] }>({ config: '', points: [] });
-    const mountPoints = mountPointsEntry.config === configName ? mountPointsEntry.points : [];
-
-    // Rolling history: Map<counterName, number[]>
     const historyRef = useRef<Map<string, number[]>>(new Map());
 
     // Map<ruleId, RuleRate> — returned snapshot; reference changes on each sample.
@@ -119,38 +44,19 @@ export const useForwardRuleCounters = (
     const ratesRef = useRef(rates);
     ratesRef.current = rates;
 
-    // Monotonically incremented on each configName change. Promise resolutions
-    // that carry a stale generation are silently dropped so that a slow request
-    // for config A cannot overwrite the state that belongs to config B.
-    const discoveryGen = useRef(0);
-
     useEffect(() => {
-        if (!configName) return;
-        // Synchronously clear stale state from the previous config so the UI
-        // never displays data belonging to a different config instance.
         historyRef.current = new Map();
-        setMountPointsEntry({ config: '', points: [] });
         setRates(new Map());
-        discoveryGen.current += 1;
-        const myGen = discoveryGen.current;
-        discoverMountPoints(configName).then(points => {
-            if (myGen !== discoveryGen.current) return;
-            setMountPointsEntry({ config: configName, points });
-        }).catch((err: unknown) => {
-            if (myGen !== discoveryGen.current) return;
-            console.error('Failed to discover forward mount points:', err);
-        });
-    }, [configName]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [configName]);
 
-    // When rules change (e.g. immediately after a config switch when history has
-    // been cleared), rebuild the snapshot so the UI reflects the current history
-    // state without waiting for the next 1-second tick.
     useEffect(() => {
         const history = historyRef.current;
         const next = new Map<string, RuleRate>();
         for (const rule of rules) {
             const h = rule.counter ? history.get(rule.counter) : undefined;
-            if (h) next.set(rule.id, { history: h, pps: countersRef.current.get(rule.counter)?.pps ?? 0 });
+            if (h) {
+                next.set(rule.id, { history: h, pps: countersRef.current.get(rule.counter)?.pps ?? 0 });
+            }
         }
         if (next.size === 0 && ratesRef.current.size === 0) return;
         setRates(next);
@@ -159,8 +65,6 @@ export const useForwardRuleCounters = (
     // Stable refs so callbacks don't need to re-create on every render.
     const rulesRef = useRef(rules);
     rulesRef.current = rules;
-    const mountPointsRef = useRef(mountPoints);
-    mountPointsRef.current = mountPoints;
 
     // Unique counter names across all rules — these are the keys for useInterpolatedCounters.
     const counterNames = Array.from(new Set(rules.map(r => r.counter).filter(Boolean)));
@@ -171,42 +75,36 @@ export const useForwardRuleCounters = (
             result.set(name, { packets: BigInt(0), bytes: BigInt(0) });
         }
 
-        const points = mountPointsRef.current;
-        if (points.length === 0 || counterNames.length === 0) return result;
+        if (!configName || counterNames.length === 0) {
+            return result;
+        }
 
-        const fetches = points.map(mp =>
-            API.counters.module({
-                device: mp.device,
-                pipeline: mp.pipeline,
-                function: mp.functionName,
-                chain: mp.chainName,
-                module_type: 'forward',
-                module_name: configName,
-                counter_query: [],
-            }).then(response => response.counters ?? [])
-        );
-
-        const settled = await Promise.allSettled(fetches);
-
-        for (const outcome of settled) {
-            if (outcome.status !== 'fulfilled') continue;
-            const countersArr = outcome.value;
+        try {
+            const response = await API.counters.byTags({
+                tags: [
+                    { key: 'module_type', value: 'forward' },
+                    { key: 'module_name', value: configName },
+                ],
+                query: counterNames,
+            });
+            const grouped = groupCounterGroupsByTagsAndName(response.groups, [], 0);
             for (const counterName of counterNames) {
-                const ci = findCounter(countersArr, counterName);
-                const packets = sumCounterValues(ci);
-                const current = result.get(counterName)!;
-                result.set(counterName, { packets: current.packets + packets, bytes: current.bytes });
+                result.set(counterName, {
+                    packets: grouped.get(makeGroupedCounterKey([], counterName))?.value ?? BigInt(0),
+                    bytes: BigInt(0),
+                });
             }
+        } catch {
+            // tolerate fetch failures.
         }
 
         return result;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [configName, mountPoints, counterNames.join(',')]);
+    }, [configName, counterNames]);
 
     const { counters } = useInterpolatedCounters({
         keys: counterNames,
         fetchCounters,
-        enabled: enabled && mountPoints.length > 0 && counterNames.length > 0,
+        enabled: enabled && configName.length > 0 && counterNames.length > 0,
         pollingInterval: 1000,
         interpolationInterval: 30,
     });

--- a/web/src/utils/counterGroups.test.ts
+++ b/web/src/utils/counterGroups.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getCounterGroupTagValue,
+    groupCounterGroupsByTagsAndName,
+    makeGroupedCounterKey,
+    sumCounterInfoValuesAtIndex,
+} from './counterGroups';
+import type { CounterGroup, CounterInfo } from '../api';
+
+describe('getCounterGroupTagValue', () => {
+    it('reads an existing tag value', () => {
+        const group: CounterGroup = {
+            tags: [{ key: 'device', value: 'eth0' }],
+        };
+
+        expect(getCounterGroupTagValue(group, 'device')).toBe('eth0');
+        expect(getCounterGroupTagValue(group, 'pipeline')).toBeUndefined();
+    });
+});
+
+describe('sumCounterInfoValuesAtIndex', () => {
+    it('sums values across all instances by index', () => {
+        const counter: CounterInfo = {
+            name: 'rx',
+            instances: [
+                { values: [1, 2] },
+                { values: [3, 4] },
+            ],
+        };
+
+        expect(sumCounterInfoValuesAtIndex(counter, 0)).toBe(BigInt(4));
+        expect(sumCounterInfoValuesAtIndex(counter, 1)).toBe(BigInt(6));
+    });
+});
+
+describe('groupCounterGroupsByTagsAndName', () => {
+    it('merges duplicate groups and duplicate counter names by selected tags', () => {
+        const groups: CounterGroup[] = [
+            {
+                tags: [{ key: 'pipeline', value: 'p1' }],
+                counters: [
+                    { name: 'input', instances: [{ values: [10] }] },
+                    { name: 'input', instances: [{ values: [5] }] },
+                ],
+            },
+            {
+                tags: [{ key: 'pipeline', value: 'p1' }],
+                counters: [
+                    { name: 'input', instances: [{ values: [7] }] },
+                ],
+            },
+            {
+                tags: [{ key: 'pipeline', value: 'p2' }],
+                counters: [
+                    { name: 'input', instances: [{ values: [100] }] },
+                ],
+            },
+        ];
+
+        const grouped = groupCounterGroupsByTagsAndName(groups, ['pipeline'], 0);
+        expect(grouped.get(makeGroupedCounterKey(['p1'], 'input'))?.value).toBe(BigInt(22));
+        expect(grouped.get(makeGroupedCounterKey(['p2'], 'input'))?.value).toBe(BigInt(100));
+    });
+});

--- a/web/src/utils/counterGroups.ts
+++ b/web/src/utils/counterGroups.ts
@@ -1,0 +1,55 @@
+import type { CounterGroup, CounterInfo } from '../api';
+
+export interface GroupedCounterValue {
+    counterName: string;
+    tagValues: string[];
+    value: bigint;
+}
+
+export const getCounterGroupTagValue = (group: CounterGroup, key: string): string | undefined => {
+    return group.tags?.find((tag) => tag.key === key)?.value;
+};
+
+export const sumCounterInfoValuesAtIndex = (counter: CounterInfo | undefined, index: number): bigint => {
+    if (!counter?.instances) {
+        return BigInt(0);
+    }
+
+    return counter.instances.reduce((sum, instance) => {
+        return sum + BigInt(instance.values?.[index] ?? 0);
+    }, BigInt(0));
+};
+
+export const makeGroupedCounterKey = (tagValues: string[], counterName: string): string => {
+    return JSON.stringify([...tagValues, counterName]);
+};
+
+export const groupCounterGroupsByTagsAndName = (
+    groups: CounterGroup[] | undefined,
+    tagKeys: string[],
+    valueIndex: number
+): Map<string, GroupedCounterValue> => {
+    const result = new Map<string, GroupedCounterValue>();
+
+    for (const group of groups ?? []) {
+        const tagValues = tagKeys.map((tagKey) => getCounterGroupTagValue(group, tagKey) ?? '');
+        for (const counter of group.counters ?? []) {
+            const counterName = counter.name ?? '';
+            if (!counterName) {
+                continue;
+            }
+
+            const key = makeGroupedCounterKey(tagValues, counterName);
+            const current = result.get(key);
+            const increment = sumCounterInfoValuesAtIndex(counter, valueIndex);
+            if (!current) {
+                result.set(key, { counterName, tagValues, value: increment });
+                continue;
+            }
+
+            result.set(key, { ...current, value: current.value + increment });
+        }
+    }
+
+    return result;
+};

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './format';
 export * from './sorting';
 export * from './packetParser';
 export * from './clipboard';
+export * from './counterGroups';


### PR DESCRIPTION
- Switch Web live counter polling to CountersService.ByTags after PR 887.
- Add shared counter group helpers for shard aggregation and tag grouping.
- Cover helper aggregation behavior with Vitest tests.
- Verified with `cd web && npm run test` and `cd web && npm run build`.
- `cd web && npx --no-install tsc --noEmit` still reports existing duplicate exports in `web/src/api/index.ts` outside this change.