### PR TITLE
fix: accept empty ACL configs

### DIFF
--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -483,18 +483,23 @@ acl_module_config_update(
 		}
 	}
 
-	struct acl_target *targets = (struct acl_target *)memory_balloc(
-		&cp_module->memory_context,
-		sizeof(struct acl_target) * rule_count
-	);
-	if (targets == NULL) {
-		goto error;
+	struct acl_target *targets = NULL;
+	if (rule_count > 0) {
+		targets = (struct acl_target *)memory_balloc(
+			&cp_module->memory_context,
+			sizeof(struct acl_target) * rule_count
+		);
+		if (targets == NULL) {
+			goto error;
+		}
 	}
 
 	SET_OFFSET_OF(&config->targets, targets);
 	config->target_count = rule_count;
 
 	struct filter_rule *filter_rules = NULL;
+	const struct filter_rule *dummy_filter_rule_ptr = NULL;
+	const struct filter_rule **filter_rule_ptrs = &dummy_filter_rule_ptr;
 
 	for (uint32_t idx = 0; idx < rule_count; ++idx) {
 		struct acl_rule *acl_rule = acl_rules + idx;
@@ -553,19 +558,20 @@ acl_module_config_update(
 	}
 
 	// Create per filter rule list
-	filter_rules = (struct filter_rule *)malloc(
-		sizeof(struct filter_rule) * rule_count
-	);
-	if (filter_rules == NULL) {
-		goto error_target;
-	}
+	if (rule_count > 0) {
+		filter_rules = (struct filter_rule *)malloc(
+			sizeof(struct filter_rule) * rule_count
+		);
+		if (filter_rules == NULL) {
+			goto error_target;
+		}
 
-	const struct filter_rule **filter_rule_ptrs =
-		(const struct filter_rule **)malloc(
+		filter_rule_ptrs = (const struct filter_rule **)malloc(
 			sizeof(struct filter_rule *) * rule_count
 		);
-	if (filter_rule_ptrs == NULL) {
-		goto error_rules;
+		if (filter_rule_ptrs == NULL) {
+			goto error_rules;
+		}
 	}
 
 	struct timespec ts_start, ts_end;
@@ -629,23 +635,29 @@ acl_module_config_update(
 				   1000000000LL +
 			   (ts_end.tv_nsec - ts_start.tv_nsec));
 
-	free(filter_rule_ptrs);
+	if (rule_count > 0) {
+		free(filter_rule_ptrs);
+	}
 	free(filter_rules);
 
 	return 0;
 
 error_rule_ptrs:
-	free(filter_rule_ptrs);
+	if (rule_count > 0) {
+		free(filter_rule_ptrs);
+	}
 
 error_rules:
 	free(filter_rules);
 
 error_target:
-	memory_bfree(
-		&cp_module->memory_context,
-		targets,
-		sizeof(struct acl_target) * rule_count
-	);
+	if (targets != NULL) {
+		memory_bfree(
+			&cp_module->memory_context,
+			targets,
+			sizeof(struct acl_target) * rule_count
+		);
+	}
 	SET_OFFSET_OF(&config->targets, NULL);
 	config->target_count = 0;
 

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gopacket/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
@@ -18,6 +19,7 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
+	"github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb"
 )
 
 // Memory sizes for the ACL functional harness.
@@ -255,6 +257,42 @@ func TestACL_NoMatch_Drop(t *testing.T) {
 	require.Empty(t, result.Output, "no-match packet must not reach output")
 	require.Len(t, result.Drop, 1, "no-match packet must be dropped")
 
+	requireModuleCounterPackets(t, h, aclCounterPath("port0", "test"), "acl_no_match", 1)
+}
+
+// TestACL_EmptyRules_Drop verifies that an empty ACL config is valid and
+// behaves as match-nothing with acl_no_match increments.
+func TestACL_EmptyRules_Drop(t *testing.T) {
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    net.ParseIP("192.0.2.1"),
+		DstIP:    net.ParseIP("10.0.0.1"),
+	}
+	udp := layers.UDP{SrcPort: 12345, DstPort: 80}
+	udp.SetNetworkLayerForChecksum(&ip4)
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &udp)
+
+	h, agent, backend := setupACLHarness(t, []string{"port0"})
+	svc := acl.NewACLService(backend, zap.NewNop())
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:  "test",
+		Rules: nil,
+	})
+	require.NoError(t, err)
+
+	wireACLPipeline(t, agent, "port0", "test")
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Empty(t, result.Output, "empty rules config must not match and must not reach output")
+	require.Len(t, result.Drop, 1, "empty rules config must drop packet via no-match")
 	requireModuleCounterPackets(t, h, aclCounterPath("port0", "test"), "acl_no_match", 1)
 }
 


### PR DESCRIPTION
- Accept empty ACL configs by avoiding zero-size allocation failure paths in the control-plane update flow.
- Add functional coverage through the public ACL service update path, verifying empty rules drop unmatched packets and increment acl_no_match.
- Verified with go test ./modules/acl/tests/functional -run TestACL_EmptyRules_Drop -count=1.
- Verified with go test ./modules/acl/tests/functional -run 'TestACL_NoMatch_Drop|TestACL_EmptyRules_Drop|TestACL_Allow_UDP_IPv4' -count=1.
- Verified with go test ./modules/acl/controlplane ./modules/acl/tests/functional -count=1.
- Verified targeted ASAN and UBSAN with CGO_CFLAGS and CGO_LDFLAGS set to -fsanitize=address,undefined for the ACL empty-rules and adjacent functional tests.
- Full local make test-asan could not complete because the machine ran out of disk space while linking unrelated heavy fuzz and fwstate targets.
