### PR TITLE
fix: open function module editor after add

### DIFF
--- a/web/src/pages/builtin/functions/components/Lane.tsx
+++ b/web/src/pages/builtin/functions/components/Lane.tsx
@@ -79,6 +79,7 @@ export const Lane: React.FC<LaneProps> = ({
             name: candidateName,
         };
         dispatch({ type: 'ADD_MODULE', fnId, chainId: chain.id, toIdx: chain.modules.length, module: newModule });
+        onOpenModuleDrawer(newModule.id, chain.id);
     };
 
     return (


### PR DESCRIPTION
- Opens the function module editor drawer immediately after adding a module from a chain lane.
- Matches the existing pipelines add-reference flow.
- Validated with `npm run build` in `web/`.