### PR TITLE
refactor: align function module add flow

### DIFF
--- a/web/src/pages/builtin/functions/components/FunctionCard.tsx
+++ b/web/src/pages/builtin/functions/components/FunctionCard.tsx
@@ -146,6 +146,36 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
         setDrawerSelection({ kind: 'chain', chainId });
     }, []);
 
+    const handleAddModule = useCallback((chainId: string): void => {
+        const chain = fn.chains.find(c => c.id === chainId);
+        if (!chain) {
+            return;
+        }
+
+        const existingNames = new Set(chain.modules.map(module => module.name));
+        let idx = chain.modules.length;
+        let candidateName = `module${idx}`;
+        while (existingNames.has(candidateName)) {
+            idx++;
+            candidateName = `module${idx}`;
+        }
+
+        const module: Module = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+            type: 'route',
+            name: candidateName,
+        };
+
+        dispatch({
+            type: 'ADD_MODULE',
+            fnId: fn.id,
+            chainId,
+            toIdx: chain.modules.length,
+            module,
+        });
+        setDrawerSelection({ kind: 'module', moduleId: module.id, chainId });
+    }, [fn.id, fn.chains, dispatch]);
+
     const handleCloseDrawer = useCallback((): void => {
         setDrawerSelection(null);
     }, []);
@@ -257,6 +287,7 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
                                 onDragEnd={handleDragEnd}
                                 onDrop={handleDrop}
                                 dispatch={dispatch}
+                                onAddModule={handleAddModule}
                                 onOpenModuleDrawer={handleOpenModuleDrawer}
                                 onOpenChainDrawer={handleOpenChainDrawer}
                             />

--- a/web/src/pages/builtin/functions/components/Lane.tsx
+++ b/web/src/pages/builtin/functions/components/Lane.tsx
@@ -18,6 +18,7 @@ interface LaneProps {
     onDragEnd: () => void;
     onDrop: (toChainId: string, toIdx: number) => void;
     dispatch: (action: FunctionsAction) => void;
+    onAddModule: (chainId: string) => void;
     onOpenModuleDrawer: (moduleId: string, chainId: string) => void;
     onOpenChainDrawer: (chainId: string) => void;
 }
@@ -37,6 +38,7 @@ export const Lane: React.FC<LaneProps> = ({
     onDragEnd,
     onDrop,
     dispatch,
+    onAddModule,
     onOpenModuleDrawer,
     onOpenChainDrawer,
 }) => {
@@ -65,23 +67,6 @@ export const Lane: React.FC<LaneProps> = ({
         dispatch({ type: 'RENAME_MODULE', fnId, moduleId, name });
     };
 
-    const handleAddModule = (): void => {
-        const existingNames = new Set(chain.modules.map(m => m.name));
-        let idx = chain.modules.length;
-        let candidateName = `module${idx}`;
-        while (existingNames.has(candidateName)) {
-            idx++;
-            candidateName = `module${idx}`;
-        }
-        const newModule = {
-            id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
-            type: 'route',
-            name: candidateName,
-        };
-        dispatch({ type: 'ADD_MODULE', fnId, chainId: chain.id, toIdx: chain.modules.length, module: newModule });
-        onOpenModuleDrawer(newModule.id, chain.id);
-    };
-
     return (
         <div
             className="fn-lane"
@@ -107,7 +92,7 @@ export const Lane: React.FC<LaneProps> = ({
                 onDrop={onDrop}
                 onRenameModule={handleRenameModule}
                 onOpenDrawer={moduleId => onOpenModuleDrawer(moduleId, chain.id)}
-                onAddModule={handleAddModule}
+                onAddModule={() => onAddModule(chain.id)}
             />
         </div>
     );


### PR DESCRIPTION
- Moves function module creation and drawer selection into the owning function card.
- Keeps lane components focused on lane behavior, matching the neighboring pipelines add-reference flow.
- Preserves the existing default module type, naming, and insert-at-end behavior.
- Validated with `npm run build` in `web/`.