### PR TITLE
feat: show vlan frame details in pdump

### DIFF
--- a/web/src/pages/modules/pdump/PacketDrawer.tsx
+++ b/web/src/pages/modules/pdump/PacketDrawer.tsx
@@ -16,7 +16,7 @@ interface PacketDrawerProps {
     onNext: () => void;
 }
 
-type SectionKind = 'meta' | 'eth' | 'ipv4' | 'ipv6' | 'tcp' | 'udp' | 'icmp' | 'http';
+type SectionKind = 'meta' | 'eth' | 'vlan' | 'ipv4' | 'ipv6' | 'tcp' | 'udp' | 'icmp' | 'http';
 
 interface SectionProps {
     kind: SectionKind;
@@ -65,7 +65,7 @@ interface HexDumpProps {
 }
 
 const HexDump: React.FC<HexDumpProps> = ({ bytes, parsed }) => {
-    const ethEnd = parsed.ethernet?.etherType === 0x8100 ? 18 : 14;
+    const ethEnd = 14 + (parsed.vlans?.length ?? 0) * 4;
     const ipEnd = parsed.ipv4
         ? ethEnd + parsed.ipv4.ihl * 4
         : parsed.ipv6
@@ -245,6 +245,22 @@ const PacketDrawer: React.FC<PacketDrawerProps> = ({
                                 <KV k="Source MAC" v={packet.parsed.ethernet.srcMac} />
                                 <KV k="Dest MAC" v={packet.parsed.ethernet.dstMac} />
                                 <KV k="EtherType" v={`${packet.parsed.ethernet.etherTypeName} (0x${packet.parsed.ethernet.etherType.toString(16)})`} />
+                            </Section>
+                        )}
+
+                        {packet.parsed.vlans && packet.parsed.vlans.length > 0 && (
+                            <Section kind="vlan" title="VLAN / 802.1Q" sub={`${packet.parsed.vlans.length} tag${packet.parsed.vlans.length > 1 ? 's' : ''}`}>
+                                {packet.parsed.vlans.map((tag, idx) => (
+                                    <React.Fragment key={idx}>
+                                        <KV k="Tag" v={`#${idx + 1}`} />
+                                        <KV k="TPID" v={`${tag.tpidName} (0x${tag.tpid.toString(16)})`} />
+                                        <KV k="TCI" v={`0x${tag.tci.toString(16).padStart(4, '0')}`} />
+                                        <KV k="PCP" v={tag.pcp} />
+                                        <KV k="DEI" v={tag.dei ? '1' : '0'} />
+                                        <KV k="VLAN ID" v={tag.vlanId} />
+                                        <KV k="Inner EtherType" v={`${tag.innerEtherTypeName} (0x${tag.innerEtherType.toString(16)})`} />
+                                    </React.Fragment>
+                                ))}
                             </Section>
                         )}
 

--- a/web/src/pages/modules/pdump/pdump.scss
+++ b/web/src/pages/modules/pdump/pdump.scss
@@ -416,6 +416,7 @@
     }
 
     &--eth   .pdump-section__marker { background: var(--fw-text-3); }
+    &--vlan  .pdump-section__marker { background: #d9a154; }
     &--ipv4  .pdump-section__marker { background: var(--g-color-text-positive); }
     &--ipv6  .pdump-section__marker { background: var(--g-color-text-positive); }
     &--tcp   .pdump-section__marker { background: var(--g-color-text-info); }

--- a/web/src/utils/packetParser.test.ts
+++ b/web/src/utils/packetParser.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { parsePacket } from './packetParser';
+
+const fromHex = (hex: string): Uint8Array => {
+    const normalized = hex.replace(/\s+/g, '');
+    const bytes: number[] = [];
+    for (let idx = 0; idx < normalized.length; idx += 2) {
+        bytes.push(parseInt(normalized.slice(idx, idx + 2), 16));
+    }
+    return Uint8Array.from(bytes);
+};
+
+describe('parsePacket VLAN parsing', () => {
+    it('parses a single VLAN-tagged IPv4 packet and keeps IPv4 offsets correct', () => {
+        const packet = fromHex(`
+            00 11 22 33 44 55 66 77 88 99 aa bb 81 00
+            b0 64 08 00
+            45 00 00 14 12 34 40 00 40 11 00 00 c0 a8 01 01 c0 a8 01 02
+        `);
+
+        const parsed = parsePacket(packet);
+
+        expect(parsed.vlans).toHaveLength(1);
+        expect(parsed.vlans?.[0]).toMatchObject({
+            tpid: 0x8100,
+            tpidName: '802.1Q',
+            tci: 0xb064,
+            pcp: 5,
+            dei: true,
+            vlanId: 100,
+            innerEtherType: 0x0800,
+            innerEtherTypeName: 'IPv4',
+        });
+        expect(parsed.ipv4?.srcAddr).toBe('192.168.1.1');
+        expect(parsed.ipv4?.dstAddr).toBe('192.168.1.2');
+        expect(parsed.payloadOffset).toBe(38);
+    });
+
+    it('parses stacked VLAN tags and uses final inner EtherType for IPv4', () => {
+        const packet = fromHex(`
+            00 11 22 33 44 55 66 77 88 99 aa bb 88 a8
+            60 c8 81 00
+            31 2c 08 00
+            45 00 00 14 12 34 40 00 40 ff 00 00 0a 00 00 01 0a 00 00 02
+        `);
+
+        const parsed = parsePacket(packet);
+
+        expect(parsed.vlans).toHaveLength(2);
+        expect(parsed.vlans?.[0]).toMatchObject({
+            tpid: 0x88a8,
+            pcp: 3,
+            dei: false,
+            vlanId: 200,
+            innerEtherType: 0x8100,
+            innerEtherTypeName: '802.1Q',
+        });
+        expect(parsed.vlans?.[1]).toMatchObject({
+            tpid: 0x8100,
+            pcp: 1,
+            dei: true,
+            vlanId: 300,
+            innerEtherType: 0x0800,
+            innerEtherTypeName: 'IPv4',
+        });
+        expect(parsed.ipv4?.srcAddr).toBe('10.0.0.1');
+        expect(parsed.ipv4?.dstAddr).toBe('10.0.0.2');
+        expect(parsed.payloadOffset).toBe(42);
+    });
+});

--- a/web/src/utils/packetParser.ts
+++ b/web/src/utils/packetParser.ts
@@ -7,6 +7,17 @@ export interface EthernetHeader {
     etherTypeName: string;
 }
 
+export interface VlanTag {
+    tpid: number;
+    tpidName: string;
+    tci: number;
+    pcp: number;
+    dei: boolean;
+    vlanId: number;
+    innerEtherType: number;
+    innerEtherTypeName: string;
+}
+
 export interface IPv4Header {
     version: number;
     ihl: number;
@@ -101,6 +112,7 @@ export interface HTTPMessage {
 
 export interface ParsedPacket {
     ethernet?: EthernetHeader;
+    vlans?: VlanTag[];
     ipv4?: IPv4Header;
     ipv6?: IPv6Header;
     tcp?: TCPHeader;
@@ -117,6 +129,8 @@ const ETHERTYPE_IPV4 = 0x0800;
 const ETHERTYPE_IPV6 = 0x86dd;
 const ETHERTYPE_ARP = 0x0806;
 const ETHERTYPE_VLAN = 0x8100;
+const ETHERTYPE_VLAN_QINQ = 0x88a8;
+const ETHERTYPE_VLAN_9100 = 0x9100;
 
 // IP Protocol constants
 const IPPROTO_ICMP = 1;
@@ -154,9 +168,53 @@ const getEtherTypeName = (etherType: number): string => {
         case ETHERTYPE_IPV4: return 'IPv4';
         case ETHERTYPE_IPV6: return 'IPv6';
         case ETHERTYPE_ARP: return 'ARP';
-        case ETHERTYPE_VLAN: return 'VLAN';
+        case ETHERTYPE_VLAN: return '802.1Q';
+        case ETHERTYPE_VLAN_QINQ: return '802.1ad';
+        case ETHERTYPE_VLAN_9100: return '802.1Q-in-Q';
         default: return `0x${etherType.toString(16)}`;
     }
+};
+
+const isVlanEtherType = (etherType: number): boolean => {
+    return etherType === ETHERTYPE_VLAN || etherType === ETHERTYPE_VLAN_QINQ || etherType === ETHERTYPE_VLAN_9100;
+};
+
+const parseVlans = (data: Uint8Array, offset: number, outerEtherType: number): { vlans: VlanTag[]; etherType: number; offset: number } | null => {
+    if (!isVlanEtherType(outerEtherType)) {
+        return { vlans: [], etherType: outerEtherType, offset };
+    }
+
+    const vlans: VlanTag[] = [];
+    let currentOffset = offset;
+    let currentEtherType = outerEtherType;
+
+    while (isVlanEtherType(currentEtherType)) {
+        if (data.length < currentOffset + 4) {
+            return null;
+        }
+
+        const tci = (data[currentOffset] << 8) | data[currentOffset + 1];
+        const innerEtherType = (data[currentOffset + 2] << 8) | data[currentOffset + 3];
+        vlans.push({
+            tpid: currentEtherType,
+            tpidName: getEtherTypeName(currentEtherType),
+            tci,
+            pcp: (tci >> 13) & 0x07,
+            dei: (tci & 0x1000) !== 0,
+            vlanId: tci & 0x0fff,
+            innerEtherType,
+            innerEtherTypeName: getEtherTypeName(innerEtherType),
+        });
+
+        currentEtherType = innerEtherType;
+        currentOffset += 4;
+    }
+
+    return {
+        vlans,
+        etherType: currentEtherType,
+        offset: currentOffset,
+    };
 };
 
 const getIPProtocolName = (protocol: number): string => {
@@ -453,13 +511,16 @@ export const parsePacket = (data: Uint8Array): ParsedPacket => {
     result.ethernet = ethernet;
     offset = 14;
 
-    // Handle VLAN tag
     let etherType = ethernet.etherType;
-    if (etherType === ETHERTYPE_VLAN) {
-        if (data.length < offset + 4) return result;
-        etherType = (data[offset + 2] << 8) | data[offset + 3];
-        offset += 4;
+    const parsedVlans = parseVlans(data, offset, etherType);
+    if (!parsedVlans) {
+        return result;
     }
+    if (parsedVlans.vlans.length > 0) {
+        result.vlans = parsedVlans.vlans;
+    }
+    etherType = parsedVlans.etherType;
+    offset = parsedVlans.offset;
 
     // Parse IP layer
     let ipProtocol: number | null = null;
@@ -631,4 +692,3 @@ export const base64ToUint8Array = (base64: string): Uint8Array => {
     }
     return bytes;
 };
-


### PR DESCRIPTION
- Shows VLAN tag details in the pdump packet drawer, including TPID, TCI, PCP, DEI, VLAN ID, and inner EtherType.
- Parses stacked VLAN tags before selecting the inner IPv4 or IPv6 payload.
- Adds focused parser coverage for single and stacked VLAN-tagged IPv4 frames.

Validation:
- `cd web && npm run test -- packetParser`.
- `cd web && npm run build`.
- Reviewer agent approved the change.