### PR TITLE
refactor: clean function CLI output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3273,9 +3273,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "log",
- "serde",
- "serde_json",
  "serde_yaml",
  "tokio",
  "tonic",

--- a/cli/modules/function/Cargo.toml
+++ b/cli/modules/function/Cargo.toml
@@ -9,11 +9,8 @@ description = "CLI for YANET function module"
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_yaml = "0.9"
-log = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
+serde_yaml = "0.9"

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -1,20 +1,20 @@
 //! CLI for YANET "function" module.
 
-use core::error::Error;
-
-use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
+use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use commonpb::pb::FunctionId;
-use serde::Serialize;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
-    logging,
+    errors::Error,
+    output::{self, CommonFormat},
 };
 use ynpb::pb::{
     function_service_client::FunctionServiceClient, DeleteFunctionRequest, Function, FunctionChain, GetFunctionRequest,
-    ListFunctionsRequest, ListFunctionsResponse, UpdateFunctionRequest,
+    ListFunctionsRequest, UpdateFunctionRequest,
 };
+
+const FUNCTION_SERVICE: &str = "ynpb.FunctionService";
 
 /// Function module.
 #[derive(Debug, Clone, Parser)]
@@ -25,6 +25,9 @@ pub struct Cmd {
     pub mode: ModeCmd,
     #[command(flatten)]
     pub connection: ConnectionArgs,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "human", global = true)]
+    pub format: CommonFormat,
     /// Be verbose in terms of logging.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
@@ -33,7 +36,7 @@ pub struct Cmd {
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
     /// List all functions.
-    List(ListCmd),
+    List,
     /// Show function definition.
     Show(ShowCmd),
     /// Update function configurations.
@@ -42,28 +45,11 @@ pub enum ModeCmd {
     Delete(DeleteCmd),
 }
 
-#[derive(Debug, Clone, Copy, Default, ValueEnum)]
-pub enum OutputFormat {
-    #[default]
-    Yaml,
-    Json,
-}
-
-#[derive(Debug, Clone, Parser)]
-pub struct ListCmd {
-    /// Output format.
-    #[clap(long, value_enum, default_value_t)]
-    pub format: OutputFormat,
-}
-
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Function name.
     #[arg(short, long)]
     pub name: String,
-    /// Output format.
-    #[clap(long, value_enum, default_value_t)]
-    pub format: OutputFormat,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -88,82 +74,116 @@ pub async fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
 
     let cmd = Cmd::parse();
-    let _ = logging::init(cmd.verbose as usize);
+    ync::init(cmd.verbose, cmd.format);
 
     if let Err(err) = run(cmd).await {
-        log::error!("ERROR: {err}");
-        std::process::exit(1);
+        output::failure(&err);
+        std::process::exit(err.exit_code());
     }
 }
 
-async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
-    let mut service = FunctionService::new(&cmd.connection).await?;
+async fn run(cmd: Cmd) -> Result<(), Error> {
+    let action = action_name(&cmd.mode);
+    let mut service = FunctionService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
-        ModeCmd::List(cmd) => {
-            let response = service.list_functions().await?;
-            println_fmt(&response.ids, cmd.format)?;
+        ModeCmd::List => {
+            let ids = service.list_functions().await?;
+            output::data(&ids, false, format_args!("No functions found."), || {
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&ids).expect("function list YAML serialization must not fail")
+                );
+            });
         }
-        ModeCmd::Show(cmd) => {
-            let function = service.get_function(&cmd.name).await?;
-            println_fmt(&function, cmd.format)?;
+        ModeCmd::Show(show) => {
+            let function = service.get_function(&show.name).await?;
+            output::data(&function, false, format_args!(""), || {
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&function).expect("function YAML serialization must not fail")
+                );
+            });
         }
-        ModeCmd::Update(cmd) => {
-            service.update_functions(cmd).await?;
-            println!("OK");
+        ModeCmd::Update(update) => {
+            let name = update.name.clone();
+            service.update_function(update).await?;
+            output::success("update", format_args!("updated function {}", name));
         }
-        ModeCmd::Delete(cmd) => {
-            service.delete_function(cmd).await?;
-            println!("OK");
+        ModeCmd::Delete(delete) => {
+            let name = delete.name.clone();
+            service.delete_function(delete).await?;
+            output::success("delete", format_args!("deleted function {}", name));
         }
     }
 
     Ok(())
 }
 
-fn println_fmt<T>(value: &T, format: OutputFormat) -> Result<(), Box<dyn Error>>
-where
-    T: Serialize,
-{
-    match format {
-        OutputFormat::Yaml => {
-            print!("{}", serde_yaml::to_string(value)?);
-        }
-        OutputFormat::Json => {
-            println!("{}", serde_json::to_string(value)?);
-        }
+fn action_name(mode: &ModeCmd) -> &'static str {
+    match mode {
+        ModeCmd::List => "list functions",
+        ModeCmd::Show(..) => "show function",
+        ModeCmd::Update(..) => "update function",
+        ModeCmd::Delete(..) => "delete function",
     }
-
-    Ok(())
 }
 
 pub struct FunctionService {
     client: FunctionServiceClient<LayeredChannel>,
+    endpoint: String,
 }
 
 impl FunctionService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Box<dyn Error>> {
-        let channel = ync::client::connect(connection).await?;
+    pub async fn new(connection: &ConnectionArgs, action: &str) -> Result<Self, Error> {
+        let channel = ync::client::connect(connection)
+            .await
+            .map_err(|err| Error::from_connection(err, action, connection.endpoint.clone()))?;
         let client = FunctionServiceClient::new(channel)
             .send_compressed(CompressionEncoding::Gzip)
             .accept_compressed(CompressionEncoding::Gzip);
-        Ok(Self { client })
+
+        Ok(Self {
+            client,
+            endpoint: connection.endpoint.clone(),
+        })
     }
 
-    pub async fn list_functions(&mut self) -> Result<ListFunctionsResponse, Box<dyn Error>> {
-        let response = self.client.list(ListFunctionsRequest {}).await?.into_inner();
-        Ok(response)
+    pub async fn list_functions(&mut self) -> Result<Vec<FunctionId>, Error> {
+        let response = self
+            .client
+            .list(ListFunctionsRequest {})
+            .await
+            .map_err(|status| Error::from_status(status, "list functions", self.endpoint.clone(), FUNCTION_SERVICE))?
+            .into_inner();
+
+        Ok(response.ids)
     }
 
-    pub async fn get_function(&mut self, name: &str) -> Result<Option<Function>, Box<dyn Error>> {
+    pub async fn get_function(&mut self, name: &str) -> Result<Function, Error> {
         let request = GetFunctionRequest {
             id: Some(FunctionId { name: name.to_string() }),
         };
-        let response = self.client.get(request).await?.into_inner();
-        Ok(response.function)
+        let response = self
+            .client
+            .get(request)
+            .await
+            .map_err(|status| Error::from_status(status, "show function", self.endpoint.clone(), FUNCTION_SERVICE))?
+            .into_inner();
+
+        let function = response.function.ok_or_else(|| {
+            Error::from_status(
+                tonic::Status::not_found(format!("function {} not found", name)),
+                "show function",
+                self.endpoint.clone(),
+                FUNCTION_SERVICE,
+            )
+        })?;
+
+        Ok(function)
     }
 
-    pub async fn update_functions(&mut self, cmd: UpdateCmd) -> Result<(), Box<dyn Error>> {
+    pub async fn update_function(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
         let request = UpdateFunctionRequest {
             function: Some(Function {
                 id: Some(FunctionId { name: cmd.name }),
@@ -171,15 +191,23 @@ impl FunctionService {
             }),
         };
 
-        self.client.update(request).await?;
+        self.client
+            .update(request)
+            .await
+            .map_err(|status| Error::from_status(status, "update function", self.endpoint.clone(), FUNCTION_SERVICE))?;
+
         Ok(())
     }
 
-    pub async fn delete_function(&mut self, cmd: DeleteCmd) -> Result<(), Box<dyn Error>> {
+    pub async fn delete_function(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let request = DeleteFunctionRequest {
             id: Some(FunctionId { name: cmd.name }),
         };
-        self.client.delete(request).await?;
+        self.client
+            .delete(request)
+            .await
+            .map_err(|status| Error::from_status(status, "delete function", self.endpoint.clone(), FUNCTION_SERVICE))?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
- Move the function CLI to the shared `ync::init` output setup.
- Use structured error and success rendering instead of user-facing log lines.
- Keep human list/show output as YAML while routing JSON through the shared output backend.
- Remove unused direct function CLI dependencies.
- Validated with `cargo check -p yanet-cli-function`, `cargo +nightly fmt -p yanet-cli-function -- --check`, and `cargo clippy -p yanet-cli-function -- -D warnings`.