### PR TITLE
fix: allow cross-card drag and drop

### DIFF
--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -3,7 +3,7 @@ import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, EmptyState, SearchInput } from '../../../components';
 import { useFunctionsData } from './hooks/useFunctionsData';
-import { useUnsavedChangesBlocker } from '../_shared/lane-editor';
+import { useDragState, useUnsavedChangesBlocker } from '../_shared/lane-editor';
 import { FunctionCard } from './components/FunctionCard';
 import { CreateFunctionDialog } from './dialogs';
 import type { NetworkFunction } from './types';
@@ -41,6 +41,7 @@ const FunctionsPage = (): React.JSX.Element => {
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
     const searchRef = useRef<HTMLInputElement>(null);
+    const { dragState, startDrag, endDrag } = useDragState();
 
     useEffect(() => {
         const fetchTypes = async (): Promise<void> => {
@@ -133,6 +134,9 @@ const FunctionsPage = (): React.JSX.Element => {
                             isDirty={isDirty(fn.id)}
                             availableModuleTypes={availableModuleTypes}
                             dispatch={dispatch}
+                            dragState={dragState}
+                            onDragStart={startDrag}
+                            onDragEnd={endDrag}
                             onSave={handleSave(fn.id)}
                             onDiscard={handleDiscard(fn.id)}
                             onDelete={handleDelete(fn.id)}

--- a/web/src/pages/builtin/functions/components/FunctionCard.tsx
+++ b/web/src/pages/builtin/functions/components/FunctionCard.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import type { NetworkFunction, FunctionsAction, DragPayload, Module, Chain } from '../types';
 import { useModuleCounters, type ModuleInfo } from '../hooks/useModuleCounters';
-import { useDragState, getDragPayload, useSparklineHistory } from '../../_shared/lane-editor';
+import { getDragPayload, useSparklineHistory } from '../../_shared/lane-editor';
+import type { DragState } from '../../_shared/lane-editor';
 import { FunctionCardHeader } from './FunctionCardHeader';
 import { Lane } from './Lane';
 import { AddChainButton } from './AddChainButton';
@@ -15,6 +16,9 @@ interface FunctionCardProps {
     isDirty: boolean;
     availableModuleTypes: string[];
     dispatch: (action: FunctionsAction) => void;
+    dragState: DragState;
+    onDragStart: (payload: DragPayload) => void;
+    onDragEnd: () => void;
     onSave: () => Promise<void>;
     onDiscard: () => void;
     onDelete: () => Promise<boolean>;
@@ -54,19 +58,20 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
     isDirty,
     availableModuleTypes,
     dispatch,
+    dragState,
+    onDragStart,
+    onDragEnd,
     onSave,
     onDiscard,
     onDelete,
 }) => {
     const [collapsed, setCollapsed] = useState(false);
     const [diffOpen, setDiffOpen] = useState(false);
-    // Selection: either a module or a chain in this function's drawer.
     const [drawerSelection, setDrawerSelection] = useState<
         { kind: 'module'; moduleId: string; chainId: string } |
         { kind: 'chain'; chainId: string } |
         null
     >(null);
-    const { dragState, startDrag, endDrag } = useDragState();
 
     const totalWeight = fn.chains.reduce((s, c) => s + c.weight, 0);
 
@@ -114,29 +119,22 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
 
     const siblingChainNames = fn.chains.map(c => c.name);
 
-    const handleDragStart = useCallback((payload: DragPayload): void => {
-        startDrag(payload);
-    }, [startDrag]);
-
-    const handleDragEnd = useCallback((): void => {
-        endDrag();
-    }, [endDrag]);
-
     const handleDrop = useCallback((toChainId: string, toIdx: number): void => {
         const payload = getDragPayload();
-        if (!payload || payload.fromFnId !== fn.id) {
+        if (!payload) {
             return;
         }
         dispatch({
             type: 'MOVE_MODULE',
-            fnId: fn.id,
+            fromFnId: payload.fromFnId,
+            toFnId: fn.id,
             fromChainId: payload.fromChainId,
             toChainId,
             moduleId: payload.moduleId,
             toIdx,
         });
-        endDrag();
-    }, [fn.id, dispatch, endDrag]);
+        onDragEnd();
+    }, [fn.id, dispatch, onDragEnd]);
 
     const handleOpenModuleDrawer = useCallback((moduleId: string, chainId: string): void => {
         setDrawerSelection({ kind: 'module', moduleId, chainId });
@@ -283,8 +281,8 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
                                 dragState={dragState}
                                 counterMap={counterMap}
                                 siblingChainNames={siblingChainNames}
-                                onDragStart={handleDragStart}
-                                onDragEnd={handleDragEnd}
+                                onDragStart={onDragStart}
+                                onDragEnd={onDragEnd}
                                 onDrop={handleDrop}
                                 dispatch={dispatch}
                                 onAddModule={handleAddModule}
@@ -344,7 +342,8 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
                         if (m) {
                             dispatch({
                                 type: 'MOVE_MODULE',
-                                fnId: fn.id,
+                                fromFnId: fn.id,
+                                toFnId: fn.id,
                                 fromChainId: drawerChain.id,
                                 toChainId: drawerChain.id,
                                 moduleId: m.id,

--- a/web/src/pages/builtin/functions/components/LaneTrack.tsx
+++ b/web/src/pages/builtin/functions/components/LaneTrack.tsx
@@ -21,7 +21,7 @@ interface LaneTrackProps {
 
 /**
  * The flex-wrap dropzone container for a chain's modules.
- * Handles dragover slot detection via DOM geometry, validates cross-function drops.
+ * Handles dragover slot detection via DOM geometry.
  */
 export const LaneTrack: React.FC<LaneTrackProps> = ({
     fnId,
@@ -38,15 +38,15 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
 }) => {
     const [activeSlotIdx, setActiveSlotIdx] = useState<number | null>(null);
     const containerRef = useRef<HTMLDivElement>(null);
-    // When true, Esc was pressed during a drag — ignore the next drop event.
     const cancelledByEscRef = useRef(false);
 
     const { isDragging, dragPayload } = dragState;
     const isActiveDrag = isDragging && !!dragPayload;
-    const isSameFn = isActiveDrag && dragPayload.fromFnId === fnId;
-    const isCrossFunction = isActiveDrag && dragPayload.fromFnId !== fnId;
+    const isFunctionDrag = isActiveDrag && dragPayload.fromChainId !== dragPayload.fromFnId;
+    const isSameOwner = isFunctionDrag && dragPayload.fromFnId === fnId;
+    const isSameContainer = isSameOwner && dragPayload.fromChainId === chainId;
 
-    const fromModIdx = isActiveDrag && dragPayload.fromChainId === chainId
+    const fromModIdx = isSameContainer
         ? dragPayload.fromModIdx
         : -1;
 
@@ -56,7 +56,6 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
         hiddenSlots.add(fromModIdx + 1);
     }
 
-    // Esc key cancels the active drag.
     useEffect(() => {
         if (!isActiveDrag) {
             cancelledByEscRef.current = false;
@@ -74,7 +73,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
     }, [isActiveDrag, onDragEnd]);
 
     const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>): void => {
-        if (!isSameFn) {
+        if (!isFunctionDrag) {
             return;
         }
         e.preventDefault();
@@ -108,7 +107,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
         });
 
         setActiveSlotIdx(nearestIdx);
-    }, [isSameFn]);
+    }, [isFunctionDrag]);
 
     const handleDragLeave = useCallback((): void => {
         setActiveSlotIdx(null);
@@ -118,26 +117,22 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
         e.preventDefault();
         setActiveSlotIdx(null);
 
-        // Cancelled by Esc — reset flag and do nothing.
         if (cancelledByEscRef.current) {
             cancelledByEscRef.current = false;
             return;
         }
 
         const payload = getDragPayload();
-        if (!payload || payload.fromFnId !== fnId) {
+        if (!payload || payload.fromChainId === payload.fromFnId) {
             return;
         }
 
-        // No slot was hovered — user dropped outside any slot, treat as cancel.
         if (activeSlotIdx === null) {
             return;
         }
 
         const toIdx = activeSlotIdx;
-
-        // Drop resolves to the source position — no-op.
-        if (payload.fromChainId === chainId) {
+        if (payload.fromFnId === fnId && payload.fromChainId === chainId) {
             const src = payload.fromModIdx;
             if (toIdx === src || toIdx === src + 1) {
                 return;
@@ -156,10 +151,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
 
     return (
         <div
-            className={[
-                'fn-lane-track',
-                isActiveDrag && isCrossFunction ? 'fn-lane-track--reject' : '',
-            ].filter(Boolean).join(' ')}
+            className="fn-lane-track"
             ref={containerRef}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
@@ -169,7 +161,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
 
             {modules.map((m, idx) => (
                 <React.Fragment key={m.id}>
-                    {isActiveDrag && isSameFn ? (
+                    {isFunctionDrag ? (
                         <InsertSlot
                             idx={idx}
                             active={activeSlotIdx === idx}
@@ -183,9 +175,9 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
                         fnId={fnId}
                         chainId={chainId}
                         modIdx={idx}
-                        isDragging={isActiveDrag && dragPayload?.moduleId === m.id}
-                        isSourceDuringDrag={isActiveDrag && isSameFn && dragPayload?.moduleId === m.id}
-                        isInvalidDragTarget={isCrossFunction && isActiveDrag}
+                        isDragging={isFunctionDrag && dragPayload?.moduleId === m.id}
+                        isSourceDuringDrag={isFunctionDrag && isSameOwner && dragPayload?.moduleId === m.id}
+                        isInvalidDragTarget={false}
                         counter={counterMap.get(m.id)}
                         onDragStart={onDragStart}
                         onDragEnd={handleDragEnd}
@@ -204,7 +196,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
                 </>
             )}
 
-            {isActiveDrag && isSameFn && (
+            {isFunctionDrag && (
                 <InsertSlot
                     idx={modules.length}
                     active={activeSlotIdx === modules.length}

--- a/web/src/pages/builtin/functions/reducer.test.ts
+++ b/web/src/pages/builtin/functions/reducer.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { functionsReducer, initialState } from './reducer';
+import type { NetworkFunction } from './types';
+
+const loadFunction = (state: typeof initialState, fn: NetworkFunction) =>
+    functionsReducer(state, { type: 'LOAD_ENTITY', id: fn.id, entity: fn });
+
+describe('functionsReducer MOVE_MODULE', () => {
+    it('moves a module between different functions', () => {
+        let state = initialState;
+        state = loadFunction(state, {
+            id: 'f1',
+            type: 'route',
+            chains: [
+                {
+                    id: 'c1',
+                    name: 'chain1',
+                    weight: 1,
+                    modules: [
+                        { id: 'm1', name: 'm1', type: 'route' },
+                        { id: 'm2', name: 'm2', type: 'acl' },
+                    ],
+                },
+            ],
+        });
+        state = loadFunction(state, {
+            id: 'f2',
+            type: 'route',
+            chains: [
+                {
+                    id: 'c2',
+                    name: 'chain2',
+                    weight: 1,
+                    modules: [{ id: 'm3', name: 'm3', type: 'forward' }],
+                },
+            ],
+        });
+
+        const next = functionsReducer(state, {
+            type: 'MOVE_MODULE',
+            fromFnId: 'f1',
+            toFnId: 'f2',
+            fromChainId: 'c1',
+            toChainId: 'c2',
+            moduleId: 'm2',
+            toIdx: 0,
+        });
+
+        expect(next.local.f1.chains[0].modules.map(mod => mod.id)).toEqual(['m1']);
+        expect(next.local.f2.chains[0].modules.map(mod => mod.id)).toEqual(['m2', 'm3']);
+    });
+
+    it('keeps same-chain adjacent slot as no-op', () => {
+        let state = initialState;
+        state = loadFunction(state, {
+            id: 'f1',
+            type: 'route',
+            chains: [
+                {
+                    id: 'c1',
+                    name: 'chain1',
+                    weight: 1,
+                    modules: [
+                        { id: 'm1', name: 'm1', type: 'route' },
+                        { id: 'm2', name: 'm2', type: 'acl' },
+                    ],
+                },
+            ],
+        });
+
+        const next = functionsReducer(state, {
+            type: 'MOVE_MODULE',
+            fromFnId: 'f1',
+            toFnId: 'f1',
+            fromChainId: 'c1',
+            toChainId: 'c1',
+            moduleId: 'm1',
+            toIdx: 1,
+        });
+
+        expect(next.local.f1.chains[0].modules.map(mod => mod.id)).toEqual(['m1', 'm2']);
+        expect(next.dirty.has('f1')).toBe(false);
+    });
+
+    it('returns original state when target chain is missing', () => {
+        let state = initialState;
+        state = loadFunction(state, {
+            id: 'f1',
+            type: 'route',
+            chains: [
+                {
+                    id: 'c1',
+                    name: 'chain1',
+                    weight: 1,
+                    modules: [{ id: 'm1', name: 'm1', type: 'route' }],
+                },
+            ],
+        });
+
+        const next = functionsReducer(state, {
+            type: 'MOVE_MODULE',
+            fromFnId: 'f1',
+            toFnId: 'f1',
+            fromChainId: 'c1',
+            toChainId: 'missing',
+            moduleId: 'm1',
+            toIdx: 0,
+        });
+
+        expect(next).toBe(state);
+    });
+});

--- a/web/src/pages/builtin/functions/reducer.ts
+++ b/web/src/pages/builtin/functions/reducer.ts
@@ -33,15 +33,16 @@ export const functionsReducer = (
             return handleBaseEntityAction(state, action as BaseEntityAction<NetworkFunction>);
 
         case 'MOVE_MODULE': {
-            const fn = findFn(state, action.fnId);
-            if (!fn) {
+            const fromFn = findFn(state, action.fromFnId);
+            const toFn = findFn(state, action.toFnId);
+            if (!fromFn || !toFn) {
                 return state;
             }
 
             const { fromChainId, toChainId, moduleId, toIdx } = action;
 
-            if (fromChainId === toChainId) {
-                const updated = mapChains(fn, fromChainId, c => {
+            if (action.fromFnId === action.toFnId && fromChainId === toChainId) {
+                const updated = mapChains(fromFn, fromChainId, c => {
                     const fromIdx = c.modules.findIndex(m => m.id === moduleId);
                     if (fromIdx === -1) {
                         return c;
@@ -55,32 +56,39 @@ export const functionsReducer = (
                     mods.splice(insertAt, 0, moved);
                     return { ...c, modules: mods };
                 });
-                return updateFn(state, action.fnId, updated);
+                return updateFn(state, action.fromFnId, updated);
             }
 
-            let movedModule = null as typeof fn.chains[0]['modules'][0] | null;
-            const afterRemove = mapChains(fn, fromChainId, c => {
-                const fromIdx = c.modules.findIndex(m => m.id === moduleId);
-                if (fromIdx === -1) {
-                    return c;
-                }
-                const mods = [...c.modules];
-                [movedModule] = mods.splice(fromIdx, 1);
-                return { ...c, modules: mods };
-            });
-
-            if (!movedModule) {
+            const sourceChain = fromFn.chains.find(c => c.id === fromChainId);
+            const targetChain = toFn.chains.find(c => c.id === toChainId);
+            if (!sourceChain || !targetChain) {
+                return state;
+            }
+            const fromIdx = sourceChain.modules.findIndex(m => m.id === moduleId);
+            if (fromIdx === -1) {
                 return state;
             }
 
-            const capturedModule = movedModule;
-            const afterInsert = mapChains(afterRemove, toChainId, c => {
+            const movedModule = sourceChain.modules[fromIdx];
+            const sourceFnNext = mapChains(fromFn, fromChainId, c => {
                 const mods = [...c.modules];
-                mods.splice(toIdx, 0, capturedModule);
+                mods.splice(fromIdx, 1);
                 return { ...c, modules: mods };
             });
 
-            return updateFn(state, action.fnId, afterInsert);
+            const targetFnBase = action.fromFnId === action.toFnId ? sourceFnNext : toFn;
+            const targetFnNext = mapChains(targetFnBase, toChainId, c => {
+                const mods = [...c.modules];
+                mods.splice(toIdx, 0, movedModule);
+                return { ...c, modules: mods };
+            });
+
+            if (action.fromFnId === action.toFnId) {
+                return updateFn(state, action.fromFnId, targetFnNext);
+            }
+
+            const sourceState = updateFn(state, action.fromFnId, sourceFnNext);
+            return updateFn(sourceState, action.toFnId, targetFnNext);
         }
 
         case 'ADD_MODULE': {

--- a/web/src/pages/builtin/functions/types.ts
+++ b/web/src/pages/builtin/functions/types.ts
@@ -42,7 +42,15 @@ export interface Counters {
 export type CountersByModuleId = Record<string, Counters>;
 
 export type FunctionsAction =
-    | { type: 'MOVE_MODULE';          fnId: string; fromChainId: string; toChainId: string; moduleId: string; toIdx: number }
+    | {
+        type: 'MOVE_MODULE';
+        fromFnId: string;
+        toFnId: string;
+        fromChainId: string;
+        toChainId: string;
+        moduleId: string;
+        toIdx: number;
+    }
     | { type: 'ADD_MODULE';           fnId: string; chainId: string; toIdx: number; module: Module }
     | { type: 'REMOVE_MODULE';        fnId: string; chainId: string; moduleId: string }
     | { type: 'RENAME_MODULE';        fnId: string; moduleId: string; name: string }

--- a/web/src/pages/builtin/pipelines/PipelinesPage.tsx
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.tsx
@@ -3,7 +3,7 @@ import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, EmptyState, SearchInput } from '../../../components';
 import { usePipelinesData } from './hooks/usePipelinesData';
-import { useUnsavedChangesBlocker } from '../_shared/lane-editor';
+import { useDragState, useUnsavedChangesBlocker } from '../_shared/lane-editor';
 import { PipelineCard } from './components/PipelineCard';
 import { CreatePipelineDialog } from './dialogs';
 import type { Pipeline } from './types';
@@ -31,6 +31,7 @@ const PipelinesPage = (): React.JSX.Element => {
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
     const searchRef = useRef<HTMLInputElement>(null);
+    const { dragState, startDrag, endDrag } = useDragState();
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent): void => {
@@ -108,6 +109,9 @@ const PipelinesPage = (): React.JSX.Element => {
                             serverPipeline={getServerPipeline(pl.id)}
                             isDirty={isDirty(pl.id)}
                             dispatch={dispatch}
+                            dragState={dragState}
+                            onDragStart={startDrag}
+                            onDragEnd={endDrag}
                             onSave={handleSave(pl.id)}
                             onDiscard={handleDiscard(pl.id)}
                             onDelete={handleDelete(pl.id)}

--- a/web/src/pages/builtin/pipelines/components/LaneTrack.tsx
+++ b/web/src/pages/builtin/pipelines/components/LaneTrack.tsx
@@ -40,9 +40,10 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
 
     const { isDragging, dragPayload } = dragState;
     const isActiveDrag = isDragging && !!dragPayload;
-    const isSamePipeline = isActiveDrag && dragPayload.fromFnId === pipelineId;
+    const isPipelineDrag = isActiveDrag && dragPayload.fromChainId === dragPayload.fromFnId;
+    const isSamePipeline = isPipelineDrag && dragPayload.fromFnId === pipelineId;
 
-    const fromRefIdx = isActiveDrag && dragPayload.fromChainId === pipelineId
+    const fromRefIdx = isPipelineDrag && isSamePipeline
         ? dragPayload.fromModIdx
         : -1;
 
@@ -69,7 +70,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
     }, [isActiveDrag, onDragEnd]);
 
     const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>): void => {
-        if (!isSamePipeline) {
+        if (!isPipelineDrag) {
             return;
         }
         e.preventDefault();
@@ -103,7 +104,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
         });
 
         setActiveSlotIdx(nearestIdx);
-    }, [isSamePipeline]);
+    }, [isPipelineDrag]);
 
     const handleDragLeave = useCallback((): void => {
         setActiveSlotIdx(null);
@@ -119,7 +120,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
         }
 
         const payload = getDragPayload();
-        if (!payload || payload.fromFnId !== pipelineId) {
+        if (!payload || payload.fromChainId !== payload.fromFnId) {
             return;
         }
 
@@ -128,9 +129,11 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
         }
 
         const toIdx = activeSlotIdx;
-        const src = payload.fromModIdx;
-        if (toIdx === src || toIdx === src + 1) {
-            return;
+        if (payload.fromFnId === pipelineId) {
+            const src = payload.fromModIdx;
+            if (toIdx === src || toIdx === src + 1) {
+                return;
+            }
         }
 
         onDrop(toIdx);
@@ -155,7 +158,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
 
             {refs.map((ref, idx) => (
                 <React.Fragment key={ref.id}>
-                    {isActiveDrag && isSamePipeline ? (
+                    {isPipelineDrag ? (
                         <InsertSlot
                             idx={idx}
                             active={activeSlotIdx === idx}
@@ -168,8 +171,8 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
                         ref_={ref}
                         pipelineId={pipelineId}
                         refIdx={idx}
-                        isDragging={isActiveDrag && dragPayload?.moduleId === ref.id}
-                        isSourceDuringDrag={isActiveDrag && isSamePipeline && dragPayload?.moduleId === ref.id}
+                        isDragging={isPipelineDrag && dragPayload?.moduleId === ref.id}
+                        isSourceDuringDrag={isPipelineDrag && isSamePipeline && dragPayload?.moduleId === ref.id}
                         isInvalidDragTarget={false}
                         counter={counterMap.get(ref.id)}
                         onDragStart={onDragStart}
@@ -189,7 +192,7 @@ export const LaneTrack: React.FC<LaneTrackProps> = ({
                 </>
             )}
 
-            {isActiveDrag && isSamePipeline && (
+            {isPipelineDrag && (
                 <InsertSlot
                     idx={refs.length}
                     active={activeSlotIdx === refs.length}

--- a/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
+++ b/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
@@ -1,19 +1,23 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import type { Pipeline, PipelinesAction, DragPayload, FunctionRef } from '../types';
 import { useFunctionRefCounters, type FunctionRefInfo, PIPELINE_COUNTER_KEY } from '../hooks/useFunctionRefCounters';
-import { useDragState, getDragPayload, useSparklineHistory } from '../../_shared/lane-editor';
+import { getDragPayload, useSparklineHistory } from '../../_shared/lane-editor';
 import { PipelineCardHeader } from './PipelineCardHeader';
 import { LaneTrack } from './LaneTrack';
 import { Drawer } from './Drawer';
 import { DiffModal } from './DiffModal';
 import type { InterpolatedCounterData } from '../../../../hooks';
 import type { FunctionId } from '../../../../api/pipelines';
+import type { DragState } from '../../_shared/lane-editor';
 
 interface PipelineCardProps {
     pipeline: Pipeline;
     serverPipeline: Pipeline | null;
     isDirty: boolean;
     dispatch: (action: PipelinesAction) => void;
+    dragState: DragState;
+    onDragStart: (payload: DragPayload) => void;
+    onDragEnd: () => void;
     onSave: () => Promise<void>;
     onDiscard: () => void;
     onDelete: () => Promise<boolean>;
@@ -28,6 +32,9 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
     serverPipeline,
     isDirty,
     dispatch,
+    dragState,
+    onDragStart,
+    onDragEnd,
     onSave,
     onDiscard,
     onDelete,
@@ -36,7 +43,6 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
     const [collapsed, setCollapsed] = useState(false);
     const [diffOpen, setDiffOpen] = useState(false);
     const [drawerRefId, setDrawerRefId] = useState<string | null>(null);
-    const { dragState, startDrag, endDrag } = useDragState();
 
     const refInfoList: FunctionRefInfo[] = useMemo(() =>
         pipeline.functions.map(r => ({ nodeId: r.id, functionName: r.name })),
@@ -63,27 +69,20 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
 
     const sparklineData = useSparklineHistory(`pl:${pipeline.id}:total`, totalPps);
 
-    const handleDragStart = useCallback((payload: DragPayload): void => {
-        startDrag(payload);
-    }, [startDrag]);
-
-    const handleDragEnd = useCallback((): void => {
-        endDrag();
-    }, [endDrag]);
-
     const handleDrop = useCallback((toIdx: number): void => {
         const payload = getDragPayload();
-        if (!payload || payload.fromFnId !== pipeline.id) {
+        if (!payload) {
             return;
         }
         dispatch({
             type: 'MOVE_FUNCTION_REF',
-            pipelineId: pipeline.id,
+            fromPipelineId: payload.fromFnId,
+            toPipelineId: pipeline.id,
             refId: payload.moduleId,
             toIdx,
         });
-        endDrag();
-    }, [pipeline.id, dispatch, endDrag]);
+        onDragEnd();
+    }, [pipeline.id, dispatch, onDragEnd]);
 
     const handleOpenDrawer = useCallback((refId: string): void => {
         setDrawerRefId(refId);
@@ -139,8 +138,8 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
                         refs={pipeline.functions}
                         dragState={dragState}
                         counterMap={counterMap}
-                        onDragStart={handleDragStart}
-                        onDragEnd={handleDragEnd}
+                        onDragStart={onDragStart}
+                        onDragEnd={onDragEnd}
                         onDrop={handleDrop}
                         onOpenDrawer={handleOpenDrawer}
                         onRemoveRef={refId => dispatch({ type: 'REMOVE_FUNCTION_REF', pipelineId: pipeline.id, refId })}

--- a/web/src/pages/builtin/pipelines/reducer.test.ts
+++ b/web/src/pages/builtin/pipelines/reducer.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { pipelinesReducer, initialState } from './reducer';
+import type { Pipeline } from './types';
+
+const loadPipeline = (state: typeof initialState, pipeline: Pipeline) =>
+    pipelinesReducer(state, { type: 'LOAD_ENTITY', id: pipeline.id, entity: pipeline });
+
+describe('pipelinesReducer MOVE_FUNCTION_REF', () => {
+    it('moves a ref between different pipelines', () => {
+        let state = initialState;
+        state = loadPipeline(state, {
+            id: 'p1',
+            functions: [
+                { id: 'r1', name: 'a' },
+                { id: 'r2', name: 'b' },
+            ],
+        });
+        state = loadPipeline(state, {
+            id: 'p2',
+            functions: [{ id: 'r3', name: 'c' }],
+        });
+
+        const next = pipelinesReducer(state, {
+            type: 'MOVE_FUNCTION_REF',
+            fromPipelineId: 'p1',
+            toPipelineId: 'p2',
+            refId: 'r2',
+            toIdx: 1,
+        });
+
+        expect(next.local.p1.functions.map(ref => ref.id)).toEqual(['r1']);
+        expect(next.local.p2.functions.map(ref => ref.id)).toEqual(['r3', 'r2']);
+    });
+
+    it('keeps same-pipeline no-op semantics for adjacent slot', () => {
+        let state = initialState;
+        state = loadPipeline(state, {
+            id: 'p1',
+            functions: [
+                { id: 'r1', name: 'a' },
+                { id: 'r2', name: 'b' },
+            ],
+        });
+
+        const next = pipelinesReducer(state, {
+            type: 'MOVE_FUNCTION_REF',
+            fromPipelineId: 'p1',
+            toPipelineId: 'p1',
+            refId: 'r1',
+            toIdx: 1,
+        });
+
+        expect(next).toBe(state);
+    });
+
+    it('returns original state when target pipeline is missing', () => {
+        let state = initialState;
+        state = loadPipeline(state, {
+            id: 'p1',
+            functions: [{ id: 'r1', name: 'a' }],
+        });
+
+        const next = pipelinesReducer(state, {
+            type: 'MOVE_FUNCTION_REF',
+            fromPipelineId: 'p1',
+            toPipelineId: 'missing',
+            refId: 'r1',
+            toIdx: 0,
+        });
+
+        expect(next).toBe(state);
+    });
+});

--- a/web/src/pages/builtin/pipelines/reducer.ts
+++ b/web/src/pages/builtin/pipelines/reducer.ts
@@ -28,23 +28,38 @@ export const pipelinesReducer = (
             return handleBaseEntityAction(state, action as BaseEntityAction<Pipeline>);
 
         case 'MOVE_FUNCTION_REF': {
-            const pl = findPipeline(state, action.pipelineId);
-            if (!pl) {
+            const fromPipeline = findPipeline(state, action.fromPipelineId);
+            const toPipeline = findPipeline(state, action.toPipelineId);
+            if (!fromPipeline || !toPipeline) {
                 return state;
             }
-            const fromIdx = pl.functions.findIndex(r => r.id === action.refId);
+            const fromIdx = fromPipeline.functions.findIndex(r => r.id === action.refId);
             if (fromIdx === -1) {
                 return state;
             }
-            const toIdx = action.toIdx;
-            if (fromIdx === toIdx || fromIdx === toIdx - 1) {
-                return state;
+
+            if (action.fromPipelineId === action.toPipelineId) {
+                const toIdx = action.toIdx;
+                if (fromIdx === toIdx || fromIdx === toIdx - 1) {
+                    return state;
+                }
+                const refs = [...fromPipeline.functions];
+                const [moved] = refs.splice(fromIdx, 1);
+                const insertAt = fromIdx < toIdx ? toIdx - 1 : toIdx;
+                refs.splice(insertAt, 0, moved);
+                return updatePipeline(state, action.fromPipelineId, { ...fromPipeline, functions: refs });
             }
-            const refs = [...pl.functions];
-            const [moved] = refs.splice(fromIdx, 1);
-            const insertAt = fromIdx < toIdx ? toIdx - 1 : toIdx;
-            refs.splice(insertAt, 0, moved);
-            return updatePipeline(state, action.pipelineId, { ...pl, functions: refs });
+
+            const moved = fromPipeline.functions[fromIdx];
+            const sourceRefs = [...fromPipeline.functions];
+            sourceRefs.splice(fromIdx, 1);
+            const targetRefs = [...toPipeline.functions];
+            targetRefs.splice(action.toIdx, 0, moved);
+
+            const sourceNext = { ...fromPipeline, functions: sourceRefs };
+            const targetNext = { ...toPipeline, functions: targetRefs };
+            const sourceState = applyEntityUpdate(state, action.fromPipelineId, sourceNext, localToApi);
+            return applyEntityUpdate(sourceState, action.toPipelineId, targetNext, localToApi);
         }
 
         case 'ADD_FUNCTION_REF': {

--- a/web/src/pages/builtin/pipelines/types.ts
+++ b/web/src/pages/builtin/pipelines/types.ts
@@ -14,7 +14,13 @@ export interface Pipeline {
 }
 
 export type PipelinesAction =
-    | { type: 'MOVE_FUNCTION_REF';   pipelineId: string; refId: string; toIdx: number }
+    | {
+        type: 'MOVE_FUNCTION_REF';
+        fromPipelineId: string;
+        toPipelineId: string;
+        refId: string;
+        toIdx: number;
+    }
     | { type: 'ADD_FUNCTION_REF';    pipelineId: string; toIdx: number; ref: FunctionRef }
     | { type: 'REMOVE_FUNCTION_REF'; pipelineId: string; refId: string }
     | { type: 'UPDATE_FUNCTION_REF'; pipelineId: string; refId: string; name: string };


### PR DESCRIPTION
- Allows moving function references between pipeline cards.
- Allows moving modules between functions and chains.
- Adds reducer coverage for cross-owner moves and missing-target no-ops.
- Verified with npm test -- reducer.test.ts, npm test, and npm run build.