### PR TITLE
feat: expose worker rx burst counters

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -73,6 +73,20 @@ yanet_get_module_counters(
 struct counter_handle_list *
 yanet_get_worker_counters(struct dp_config *dp_config);
 
+struct worker_counter_metadata {
+	uint32_t core_id;
+	uint32_t device_id;
+	uint32_t queue_id;
+	uint32_t rx_burst_size;
+};
+
+int
+yanet_get_worker_counter_metadata(
+	struct dp_config *dp_config,
+	uint64_t worker_idx,
+	struct worker_counter_metadata *metadata
+);
+
 struct counter_handle *
 yanet_get_counter(struct counter_handle_list *counters, uint64_t idx);
 

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -12,7 +12,7 @@ use ync::{
 };
 use ynpb::pb::{
     counters_service_client::CountersServiceClient, CounterTag, CountersByTagsRequest, LatencyRangeCounter,
-    PerfCounter, PerfCountersRequest, PerfCountersResponse,
+    PerfCounter, PerfCountersRequest, PerfCountersResponse, WorkerCountersRequest,
 };
 
 /// Counters module - displays counters information.
@@ -96,6 +96,8 @@ pub enum ModeCmd {
     Module(ModuleCmd),
     /// Show performance counters for a module.
     Perf(PerfCmd),
+    /// Show worker counters.
+    Workers,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -238,6 +240,7 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
 
             service.show_perf(request, cmd.json).await?
         }
+        Some(ModeCmd::Workers) => service.show_workers().await?,
     }
 
     Ok(())
@@ -346,6 +349,12 @@ impl CountersService {
         } else {
             format_perf_counters(response.get_ref());
         }
+        Ok(())
+    }
+
+    pub async fn show_workers(&mut self) -> Result<(), Box<dyn Error>> {
+        let response = self.client.workers(WorkerCountersRequest {}).await?;
+        println!("{}", serde_json::to_string(response.get_ref())?);
         Ok(())
     }
 }

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -151,3 +151,38 @@ func (m *Counters) ByTags(
 
 	return response, nil
 }
+
+// Workers returns raw cumulative worker counters.
+func (m *Counters) Workers(
+	ctx context.Context,
+	request *ynpb.WorkerCountersRequest,
+) (*ynpb.WorkerCountersResponse, error) {
+	dpConfig := m.shm.DPConfig(m.instanceID)
+	workers, err := dpConfig.WorkerCounters()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ynpb.WorkerCountersResponse{
+		Workers: make([]*ynpb.WorkerCounter, 0, len(workers)),
+	}
+	for _, worker := range workers {
+		response.Workers = append(response.Workers, &ynpb.WorkerCounter{
+			WorkerIdx:       worker.WorkerIdx,
+			CoreId:          worker.CoreID,
+			DeviceId:        worker.DeviceID,
+			QueueId:         worker.QueueID,
+			MaxBurstSize:    worker.MaxBurstSize,
+			RxBursts:        worker.RxBursts,
+			Iterations:      worker.Iterations,
+			RxPackets:       worker.RxPackets,
+			RxBytes:         worker.RxBytes,
+			TxPackets:       worker.TxPackets,
+			TxBytes:         worker.TxBytes,
+			RemoteRxPackets: worker.RemoteRxPackets,
+			RemoteTxPackets: worker.RemoteTxPackets,
+		})
+	}
+
+	return response, nil
+}

--- a/controlplane/ffi/worker.go
+++ b/controlplane/ffi/worker.go
@@ -1,0 +1,127 @@
+package ffi
+
+//#cgo CFLAGS: -I../../
+//#include "api/counter.h"
+import "C"
+
+import "fmt"
+
+const (
+	workerCounterSingleValueIdx  = C.uint64_t(0)
+	workerCounterPacketsValueIdx = C.uint64_t(0)
+	workerCounterBytesValueIdx   = C.uint64_t(1)
+)
+
+type WorkerCounter struct {
+	WorkerIdx       uint32
+	CoreID          uint32
+	DeviceID        uint32
+	QueueID         uint32
+	MaxBurstSize    uint32
+	RxBursts        []uint64
+	Iterations      uint64
+	RxPackets       uint64
+	RxBytes         uint64
+	TxPackets       uint64
+	TxBytes         uint64
+	RemoteRxPackets uint64
+	RemoteTxPackets uint64
+}
+
+func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
+	counters := C.yanet_get_worker_counters(m.ptr)
+	if counters == nil {
+		return nil, fmt.Errorf("failed to get worker counters")
+	}
+	defer C.yanet_counter_handle_list_free(counters)
+
+	counterByName := map[string]*C.struct_counter_handle{}
+	for idx := range counters.count {
+		handle := C.yanet_get_counter(counters, idx)
+		if handle == nil {
+			continue
+		}
+		counterByName[C.GoString(&handle.name[0])] = handle
+	}
+
+	rxBurstsHandle := counterByName["rx_bursts"]
+	iterationsHandle := counterByName["iterations"]
+	rxHandle := counterByName["rx"]
+	txHandle := counterByName["tx"]
+	remoteRxHandle := counterByName["remote_rx"]
+	remoteTxHandle := counterByName["remote_tx"]
+
+	workerCount := counters.instance_count
+	result := make([]WorkerCounter, workerCount)
+	for idx := range workerCount {
+		var metadata C.struct_worker_counter_metadata
+		if C.yanet_get_worker_counter_metadata(m.ptr, idx, &metadata) != 0 {
+			return nil, fmt.Errorf(
+				"failed to get worker counter metadata for worker %d",
+				uint64(idx),
+			)
+		}
+
+		worker := WorkerCounter{
+			WorkerIdx: uint32(idx),
+			Iterations: uint64(C.yanet_get_counter_value(
+				iterationsHandle.value_handle,
+				workerCounterSingleValueIdx,
+				idx,
+			)),
+			RxPackets: uint64(C.yanet_get_counter_value(
+				rxHandle.value_handle,
+				workerCounterPacketsValueIdx,
+				idx,
+			)),
+			RxBytes: uint64(C.yanet_get_counter_value(
+				rxHandle.value_handle,
+				workerCounterBytesValueIdx,
+				idx,
+			)),
+			TxPackets: uint64(C.yanet_get_counter_value(
+				txHandle.value_handle,
+				workerCounterPacketsValueIdx,
+				idx,
+			)),
+			TxBytes: uint64(C.yanet_get_counter_value(
+				txHandle.value_handle,
+				workerCounterBytesValueIdx,
+				idx,
+			)),
+			RemoteRxPackets: uint64(C.yanet_get_counter_value(
+				remoteRxHandle.value_handle,
+				workerCounterPacketsValueIdx,
+				idx,
+			)),
+			RemoteTxPackets: uint64(C.yanet_get_counter_value(
+				remoteTxHandle.value_handle,
+				workerCounterPacketsValueIdx,
+				idx,
+			)),
+		}
+
+		rxBurstSize := uint32(metadata.rx_burst_size) + 1
+		worker.RxBursts = make([]uint64, rxBurstSize)
+		for burstIdx := C.uint64_t(0); burstIdx < rxBurstsHandle.size; burstIdx++ {
+			worker.RxBursts[burstIdx] = uint64(C.yanet_get_counter_value(
+				rxBurstsHandle.value_handle,
+				burstIdx,
+				idx,
+			))
+		}
+
+		if rxBurstSize > 0 {
+			worker.MaxBurstSize = rxBurstSize - 1
+		}
+
+		worker.CoreID = uint32(metadata.core_id)
+		worker.DeviceID = uint32(metadata.device_id)
+		worker.QueueID = uint32(metadata.queue_id)
+		worker.MaxBurstSize = uint32(metadata.rx_burst_size)
+
+		result[idx] = worker
+	}
+
+	return result, nil
+}

--- a/controlplane/ynpb/counters.proto
+++ b/controlplane/ynpb/counters.proto
@@ -5,8 +5,9 @@ package ynpb;
 option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
 
 service CountersService {
-  rpc Perf(PerfCountersRequest) returns (PerfCountersResponse) {}
-  rpc ByTags(CountersByTagsRequest) returns (CountersByTagsResponse) {}
+  rpc Perf(PerfCountersRequest) returns (PerfCountersResponse);
+  rpc ByTags(CountersByTagsRequest) returns (CountersByTagsResponse);
+  rpc Workers(WorkerCountersRequest) returns (WorkerCountersResponse);
 }
 
 message CounterTag {
@@ -31,6 +32,41 @@ message CounterInstanceInfo { repeated uint64 values = 1; }
 message CounterInfo {
   string name = 1;
   repeated CounterInstanceInfo instances = 2;
+}
+
+// Requests a snapshot of raw cumulative worker polling and traffic counters.
+message WorkerCountersRequest {}
+
+// Returns one cumulative counter record per dataplane worker thread.
+message WorkerCountersResponse { repeated WorkerCounter workers = 1; }
+
+message WorkerCounter {
+  // Stable worker index in the dataplane worker table.
+  uint32 worker_idx = 1;
+  // CPU core currently assigned to this worker.
+  uint32 core_id = 2;
+  // Device identifier used by this worker for RX/TX.
+  uint32 device_id = 3;
+  // RX queue identifier polled by this worker.
+  uint32 queue_id = 4;
+  // Maximum valid burst index for rx_bursts.
+  uint32 max_burst_size = 5;
+  // RX poll histogram: index 0 is empty polls, index n is polls with n packets.
+  repeated uint64 rx_bursts = 6;
+  // Total worker loop iterations since the counters were reset.
+  uint64 iterations = 7;
+  // Total packets received by this worker.
+  uint64 rx_packets = 8;
+  // Total received bytes counted by this worker.
+  uint64 rx_bytes = 9;
+  // Total packets transmitted by this worker.
+  uint64 tx_packets = 10;
+  // Total transmitted bytes counted by this worker.
+  uint64 tx_bytes = 11;
+  // Total packets received from remote workers.
+  uint64 remote_rx_packets = 12;
+  // Total packets sent to remote workers.
+  uint64 remote_tx_packets = 13;
 }
 
 // Request message for retrieving module performance counters.

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -68,6 +68,9 @@ worker_read(struct dataplane_worker *worker, struct packet_list *packets) {
 		worker->port_id, worker->queue_id, mbufs, ctx->read_size
 	);
 	*(worker->dp_worker->rx_count) += read;
+	if (worker->dp_worker->rx_bursts != NULL) {
+		worker->dp_worker->rx_bursts[read] += 1;
+	}
 
 	for (uint32_t idx = 0; idx < read; ++idx) {
 		struct packet *packet = mbuf_to_packet(mbufs[idx]);
@@ -405,9 +408,13 @@ dataplane_worker_init(
 	);
 	dp_config->worker_count += 1;
 
-	worker->read_ctx.read_size = 32;
+	worker->read_ctx.read_size = WORKER_RX_BURST_SIZE;
 	worker->write_ctx.write_size = 32;
 	worker->write_ctx.rx_pipes = NULL;
+	dp_worker->core_id = config->core_id;
+	dp_worker->device_id = worker->device_id;
+	dp_worker->queue_id = queue_id;
+	dp_worker->rx_burst_size = WORKER_RX_BURST_SIZE;
 
 	packet_list_init(&worker->pending);
 
@@ -552,6 +559,9 @@ dataplane_worker_start(struct dataplane_worker *worker) {
 			ADDR_OF(&dp_config->worker_counter_storage)
 		) +
 		0;
+	dp_worker->rx_bursts = counter_get_address(
+		5, dp_worker->idx, ADDR_OF(&dp_config->worker_counter_storage)
+	);
 
 	pthread_attr_t wrk_th_attr;
 	pthread_attr_init(&wrk_th_attr);

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1650,6 +1650,38 @@ yanet_get_worker_counters(struct dp_config *dp_config) {
 	return list;
 }
 
+int
+yanet_get_worker_counter_metadata(
+	struct dp_config *dp_config,
+	uint64_t worker_idx,
+	struct worker_counter_metadata *metadata
+) {
+	if (dp_config == NULL || metadata == NULL) {
+		return -1;
+	}
+
+	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
+	if (workers == NULL) {
+		return -1;
+	}
+
+	if (worker_idx >= dp_config->worker_count) {
+		return -1;
+	}
+
+	struct dp_worker *worker = ADDR_OF(&workers[worker_idx]);
+	if (worker == NULL) {
+		return -1;
+	}
+
+	metadata->core_id = worker->core_id;
+	metadata->device_id = worker->device_id;
+	metadata->queue_id = worker->queue_id;
+	metadata->rx_burst_size = worker->rx_burst_size;
+
+	return 0;
+}
+
 void
 yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 	if (counters == NULL) {

--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -5,7 +5,7 @@
 #include "common/memory.h"
 #include "lib/errors/errors.h"
 
-#define COUNTER_MAX_SIZE_EXP 5
+#define COUNTER_MAX_SIZE_EXP 6
 #define COUNTER_POOL_SIZE (COUNTER_MAX_SIZE_EXP + 1)
 #define COUNTER_STORAGE_PAGE_SIZE 4096
 

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -61,7 +61,11 @@ struct dp_worker {
 
 	struct rte_mempool *rx_mempool;
 
-	uint8_t pad[24];
+	uint64_t *rx_bursts;
+	uint32_t core_id;
+	uint32_t device_id;
+	uint32_t queue_id;
+	uint32_t rx_burst_size;
 };
 struct dp_config {
 	uint32_t instance_count;

--- a/lib/dataplane/worker/counters.c
+++ b/lib/dataplane/worker/counters.c
@@ -39,5 +39,8 @@ worker_counters_register(struct dp_config *dp_config) {
 	if (register_one(dp_config, "remote_tx", 2)) {
 		return -1;
 	}
+	if (register_one(dp_config, "rx_bursts", WORKER_RX_BURST_SIZE + 1)) {
+		return -1;
+	}
 	return 0;
 }

--- a/lib/dataplane/worker/counters.h
+++ b/lib/dataplane/worker/counters.h
@@ -2,8 +2,11 @@
 
 struct dp_config;
 
-// Register the five standard worker counters (iterations, rx, tx,
-// remote_rx, remote_tx) in dp_config->worker_counters. Caller must
+enum {
+	WORKER_RX_BURST_SIZE = 32,
+};
+
+// Register standard worker counters in dp_config->worker_counters. Caller must
 // initialise the registry via counter_registry_init before calling.
 //
 // Returns 0 on success, -1 if any counter fails to register.

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -38,7 +38,7 @@ struct dataplane_ut {
 	uint64_t mock_time_ns;
 };
 
-// Counter indices used by wire_worker_counters to address the five
+// Counter indices used by wire_worker_counters to address the
 // standard worker counter slots by their registration order.
 enum {
 	WORKER_CTR_ITERATIONS = 0,
@@ -46,6 +46,7 @@ enum {
 	WORKER_CTR_TX = 2,
 	WORKER_CTR_REMOTE_RX = 3,
 	WORKER_CTR_REMOTE_TX = 4,
+	WORKER_CTR_RX_BURSTS = 5,
 };
 
 // Wire counter address pointers for a single dp_worker.
@@ -76,6 +77,8 @@ wire_worker_counters(struct dp_worker *dp_worker, struct dp_config *dp_config) {
 
 	dp_worker->remote_tx_count =
 		counter_get_address(WORKER_CTR_REMOTE_TX, idx, storage) + 0;
+	dp_worker->rx_bursts =
+		counter_get_address(WORKER_CTR_RX_BURSTS, idx, storage);
 }
 
 struct dataplane_ut *
@@ -213,7 +216,7 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	}
 	SET_OFFSET_OF(&ut->cp_config->cp_config_gen, cp_config_gen);
 
-	// Register the five standard worker counters used by the pipeline.
+	// Register the standard worker counters used by the pipeline.
 	// Sizes and names mirror production worker.c::worker_register_counter.
 	counter_registry_init(
 		&ut->dp_config->worker_counters,
@@ -282,6 +285,10 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		// a newer config snapshot — same trick used by mock.
 		dp_worker->gen = DATAPLANE_UT_HIGH_GEN;
 		dp_worker->rx_mempool = ut->mempool;
+		dp_worker->core_id = (uint32_t)idx;
+		dp_worker->device_id = 0;
+		dp_worker->queue_id = (uint32_t)idx;
+		dp_worker->rx_burst_size = WORKER_RX_BURST_SIZE;
 
 		wire_worker_counters(dp_worker, ut->dp_config);
 


### PR DESCRIPTION
- Add raw per-worker RX burst counters and worker metadata to the counters API.
- Export worker counters through the built-in counters service and counters CLI as cumulative JSON.
- Keep load/rate calculation outside the dataplane and API so consumers can compare samples themselves.
- Add C API metadata access so Go FFI does not depend on dataplane internal layout headers.
- Validate with proto lint, Go tests, Rust formatting/tests, Meson compile, and targeted Meson tests.