### PR TITLE
feat(dataplane): introduce per-device device_name field

### DIFF
--- a/dataplane/config.c
+++ b/dataplane/config.c
@@ -19,6 +19,7 @@ enum state {
 
 	state_devices,
 	state_device,
+	state_device_name,
 	state_device_port_name,
 	state_device_mac_addr,
 	state_device_mtu,
@@ -129,6 +130,12 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				if (*end != '\0')
 					goto error;
 				state = state_instance;
+				break;
+			case state_device_name:
+				strtcpy(device->device_name,
+					start,
+					sizeof(device->device_name));
+				state = state_device;
 				break;
 
 			case state_device_port_name:
@@ -254,7 +261,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 
 				break;
 			case state_device:
-				if (!strcmp("port_name", start)) {
+				if (!strcmp("device_name", start)) {
+					state = state_device_name;
+				} else if (!strcmp("port_name", start)) {
 					state = state_device_port_name;
 				} else if (!strcmp("mac_addr", start)) {
 					state = state_device_mac_addr;
@@ -435,6 +444,13 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				state = state_instances;
 				break;
 			case state_device:
+				// Default device_name to port_name when the
+				// YAML did not provide an explicit device_name.
+				if (device->device_name[0] == '\0') {
+					strtcpy(device->device_name,
+						device->port_name,
+						sizeof(device->device_name));
+				}
 				state = state_devices;
 				break;
 			case state_worker:

--- a/dataplane/config.h
+++ b/dataplane/config.h
@@ -18,6 +18,7 @@ struct dataplane_device_worker_config {
 };
 
 struct dataplane_device_config {
+	char device_name[80];
 	char port_name[80];
 	char mac_addr[20];
 

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -350,9 +350,9 @@ dataplane_init(
 			return -1;
 		}
 		for (uint64_t idx = 0; idx < config->device_count; ++idx) {
-			strtcpy(ports[idx].port_name,
-				config->devices[idx].port_name,
-				sizeof(ports[idx].port_name));
+			strtcpy(ports[idx].device_name,
+				config->devices[idx].device_name,
+				sizeof(ports[idx].device_name));
 		}
 
 		instance->dp_config->instance_idx = instance_idx;

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -711,7 +711,8 @@ cp_config_gen_create(struct agent *agent, yanet_error **err) {
 		struct cp_device_config device_config;
 		memset(&device_config, 0, sizeof(struct cp_device_config));
 		strtcpy(device_config.name,
-			ADDR_OF(&dp_config->dp_topology.devices)[idx].port_name,
+			ADDR_OF(&dp_config->dp_topology.devices)[idx]
+				.device_name,
 			CP_DEVICE_NAME_LEN);
 		strtcpy(device_config.type, "plain", sizeof(device_config.type)
 		);

--- a/lib/dataplane/config/topology.h
+++ b/lib/dataplane/config/topology.h
@@ -5,7 +5,7 @@
 
 struct dp_port {
 	uint16_t port_id;
-	char port_name[80];
+	char device_name[80];
 };
 
 struct dp_topology {

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -193,9 +193,9 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 			return NULL;
 		}
 		for (size_t idx = 0; idx < cfg->device_count; ++idx) {
-			strtcpy(ports[idx].port_name,
+			strtcpy(ports[idx].device_name,
 				cfg->devices[idx],
-				sizeof(ports[idx].port_name));
+				sizeof(ports[idx].device_name));
 		}
 	}
 


### PR DESCRIPTION
- Logical device name distinct from DPDK port_name, propagated into dp_topology and the controlplane device config builder.
- Falls back to port_name when device_name is absent in YAML, so existing configs keep working.