### PR TITLE
fix(controlplane): free cp_config_gen and counter_storage on teardown

### DIFF
--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -157,7 +157,6 @@ cp_config_gen_free(
 ) {
 	// Free ectx first, as its internals reference
 	// module configs, chains, functions and pipelines
-	(void)cp_config;
 	struct config_gen_ectx *config_gen_ectx =
 		ADDR_OF(&config_gen->config_gen_ectx);
 	if (config_gen_ectx != NULL)
@@ -173,6 +172,12 @@ cp_config_gen_free(
 	// Finally, free counter storage registry
 	cp_config_counter_storage_registry_fini(
 		&config_gen->counter_storage_registry
+	);
+
+	memory_bfree(
+		&cp_config->memory_context,
+		config_gen,
+		sizeof(struct cp_config_gen)
 	);
 }
 

--- a/lib/counters/counters.c
+++ b/lib/counters/counters.c
@@ -498,6 +498,9 @@ counter_storage_pool_fini(
 
 void
 counter_storage_free(struct counter_storage *storage) {
+	if (storage == NULL)
+		return;
+
 	struct memory_context *memory_context =
 		ADDR_OF(&storage->memory_context);
 
@@ -516,6 +519,8 @@ counter_storage_free(struct counter_storage *storage) {
 		struct counter_storage_pool *pool = storage->pools + pool_idx;
 		counter_storage_pool_fini(storage, pool);
 	}
+
+	memory_bfree(memory_context, storage, sizeof(struct counter_storage));
 }
 
 void


### PR DESCRIPTION
- cp_config_gen_free now releases the cp_config_gen allocation itself; previously only owned registries were freed.
- counter_storage_free now releases the counter_storage allocation and tolerates NULL.