### PR TITLE
fix: replace web search shortcut

### DIFF
--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { Magnifier } from '@gravity-ui/icons';
 import { Flex, Icon, TextInput } from '@gravity-ui/uikit';
 
@@ -7,20 +7,91 @@ interface SearchInputProps {
     onUpdate: (value: string) => void;
     placeholder?: string;
     controlRef?: React.RefObject<HTMLInputElement | null>;
+    enableFocusShortcut?: boolean;
+    showShortcutHint?: boolean;
 }
+
+const isMacPlatform = (): boolean => {
+    if (typeof navigator === 'undefined') {
+        return false;
+    }
+    const platform = navigator.platform || '';
+    const userAgent = navigator.userAgent || '';
+    return /Mac|iPhone|iPad|iPod/.test(platform) || /Macintosh|Mac OS X/.test(userAgent);
+};
+
+const isSearchShortcut = (e: KeyboardEvent): boolean => {
+    const key = e.key.toLowerCase();
+    if (key !== 'k') {
+        return false;
+    }
+
+    const isMac = isMacPlatform();
+    if (isMac) {
+        return e.metaKey && !e.ctrlKey;
+    }
+
+    return e.ctrlKey && !e.metaKey;
+};
+
+const appendSearchShortcutHint = (placeholder = 'Search', showShortcutHint = true): string => {
+    if (!showShortcutHint) {
+        return placeholder;
+    }
+
+    const isMac = isMacPlatform();
+    const shortcut = isMac ? '⌘K' : 'Ctrl+K';
+    const hasHint = placeholder.includes('(⌘K)')
+        || placeholder.includes('(Ctrl+K)')
+        || placeholder.includes('(/)');
+    if (hasHint) {
+        return placeholder;
+    }
+
+    return `${placeholder} (${shortcut})`;
+};
 
 export const SearchInput: React.FC<SearchInputProps> = ({
     value,
     onUpdate,
     placeholder,
     controlRef,
+    enableFocusShortcut = true,
+    showShortcutHint = true,
 }) => {
+    const fallbackRef = useRef<HTMLInputElement | null>(null);
+    const inputRef = controlRef ?? fallbackRef;
+
+    useEffect(() => {
+        if (!enableFocusShortcut) {
+            return;
+        }
+
+        const onKeyDown = (e: KeyboardEvent): void => {
+            if (isSearchShortcut(e)) {
+                e.preventDefault();
+                inputRef.current?.focus();
+            }
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [enableFocusShortcut, inputRef]);
+
+    const placeholderWithHint = useMemo(() => {
+        if (placeholder === undefined) {
+            return placeholder;
+        }
+
+        return appendSearchShortcutHint(placeholder, showShortcutHint);
+    }, [placeholder, showShortcutHint]);
+
     return (
         <TextInput
-            controlRef={controlRef}
+            controlRef={inputRef}
             value={value}
             onUpdate={onUpdate}
-            placeholder={placeholder}
+            placeholder={placeholderWithHint}
             startContent={
                 <Flex alignItems="center" justifyContent="center" style={{ paddingInline: 8, color: 'var(--g-color-text-hint)' }}>
                     <Icon data={Magnifier} size={16} />

--- a/web/src/components/TableSearchBar/TableSearchBar.tsx
+++ b/web/src/components/TableSearchBar/TableSearchBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, TextInput, Loader, Label, Text } from '@gravity-ui/uikit';
+import { Box, Loader, Label, Text } from '@gravity-ui/uikit';
+import { SearchInput } from '../SearchInput';
 import './TableSearchBar.scss';
 
 export interface TableSearchBarProps {
@@ -32,12 +33,10 @@ export const TableSearchBar: React.FC<TableSearchBarProps> = ({
     return (
         <Box className={`table-search-bar ${className}`} style={{ height }}>
             <Box className="table-search-bar__input" style={{ width: inputWidth }}>
-                <TextInput
+                <SearchInput
                     placeholder={placeholder}
                     value={searchQuery}
                     onUpdate={onSearchChange}
-                    size="m"
-                    hasClear
                 />
             </Box>
             <Box className="table-search-bar__stats">

--- a/web/src/pages/_shared/draft/DraftPageToolbar.tsx
+++ b/web/src/pages/_shared/draft/DraftPageToolbar.tsx
@@ -8,7 +8,6 @@ interface DraftPageToolbarProps {
     searchValue: string;
     onSearchChange: (v: string) => void;
     searchPlaceholder: string;
-    searchRef?: React.RefObject<HTMLInputElement | null>;
     /** Optional slot for YAML import/export control. */
     yamlSlot?: React.ReactNode;
     addLabel: string;
@@ -21,7 +20,6 @@ const DraftPageToolbar: React.FC<DraftPageToolbarProps> = ({
     searchValue,
     onSearchChange,
     searchPlaceholder,
-    searchRef,
     yamlSlot,
     addLabel,
     onAdd,
@@ -31,7 +29,6 @@ const DraftPageToolbar: React.FC<DraftPageToolbarProps> = ({
         <Flex grow />
             <div style={{ flexBasis: 380, flexShrink: 1 }}>
                 <SearchInput
-                    controlRef={searchRef}
                     value={searchValue}
                     onUpdate={onSearchChange}
                     placeholder={searchPlaceholder}

--- a/web/src/pages/_shared/draft/useDraftShortcuts.ts
+++ b/web/src/pages/_shared/draft/useDraftShortcuts.ts
@@ -6,15 +6,14 @@ interface UseDraftShortcutsOpts<T extends { id: string }> {
     setActiveRowId: (id: string | null) => void;
     editingRowId: string | null;
     setEditingRowId: (id: string | null) => void;
-    searchRef: React.RefObject<HTMLInputElement | null>;
     onDeleteRow: (row: T) => void;
 }
 
 /**
  * Registers keyboard shortcuts shared across draft-table pages.
  *
- * Escape closes the drawer; / focuses search; Arrow keys navigate rows;
- * Enter opens the drawer; d / Backspace deletes the active row.
+ * Escape closes the drawer; Arrow keys navigate rows; Enter opens the drawer;
+ * and d / Backspace deletes the active row.
  */
 export function useDraftShortcuts<T extends { id: string }>({
     rows,
@@ -22,7 +21,6 @@ export function useDraftShortcuts<T extends { id: string }>({
     setActiveRowId,
     editingRowId,
     setEditingRowId,
-    searchRef,
     onDeleteRow,
 }: UseDraftShortcutsOpts<T>): void {
     useEffect(() => {
@@ -32,11 +30,6 @@ export function useDraftShortcuts<T extends { id: string }>({
             }
             const tag = (e.target as HTMLElement).tagName;
             if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-            if (e.key === '/' && !e.metaKey && !e.ctrlKey) {
-                e.preventDefault();
-                searchRef.current?.focus();
-                return;
-            }
             if (!rows.length) return;
             if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
                 e.preventDefault();
@@ -59,5 +52,5 @@ export function useDraftShortcuts<T extends { id: string }>({
         };
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
-    }, [editingRowId, activeRowId, rows, onDeleteRow, setActiveRowId, setEditingRowId, searchRef]);
+    }, [editingRowId, activeRowId, rows, onDeleteRow, setActiveRowId, setEditingRowId]);
 }

--- a/web/src/pages/builtin/devices/DevicePageHeader.tsx
+++ b/web/src/pages/builtin/devices/DevicePageHeader.tsx
@@ -7,7 +7,6 @@ export interface DevicePageHeaderProps {
     onCreateDevice: () => void;
     searchQuery: string;
     onSearchChange: (value: string) => void;
-    searchRef: React.RefObject<HTMLInputElement | null>;
 }
 
 /** Page header rendered inside the PageLayout header slot. */
@@ -15,7 +14,6 @@ export const DevicePageHeader: React.FC<DevicePageHeaderProps> = ({
     onCreateDevice,
     searchQuery,
     onSearchChange,
-    searchRef,
 }) => {
     return (
         <Flex alignItems="center" gap={4} style={{ width: '100%' }}>
@@ -23,10 +21,9 @@ export const DevicePageHeader: React.FC<DevicePageHeaderProps> = ({
             <Flex grow />
             <div style={{ flexBasis: 380, flexShrink: 1 }}>
                 <SearchInput
-                    controlRef={searchRef}
                     value={searchQuery}
                     onUpdate={onSearchChange}
-                    placeholder="Search devices… (⌘K)"
+                    placeholder="Search devices…"
                 />
             </div>
             <Button view="action" onClick={onCreateDevice}>

--- a/web/src/pages/builtin/devices/DevicesPage.tsx
+++ b/web/src/pages/builtin/devices/DevicesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { PageLayout, PageLoader, EmptyState } from '../../../components';
 import type { DeviceType } from '../../../api/devices';
 import type { LocalDevice } from './types';
@@ -32,18 +32,6 @@ const DevicesPage: React.FC = () => {
     const [selectedDeviceName, setSelectedDeviceName] = useState<string | null>(null);
     const [grouping, setGrouping] = useState<GroupingMode>('type');
     const [searchQuery, setSearchQuery] = useState('');
-    const searchRef = useRef<HTMLInputElement>(null);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                searchRef.current?.focus();
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, []);
 
     const selectedDevice = useMemo(() => {
         if (!selectedDeviceName) return null;
@@ -100,7 +88,6 @@ const DevicesPage: React.FC = () => {
             onCreateDevice={handleCreateDevice}
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
-            searchRef={searchRef}
         />
     );
 

--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, EmptyState, SearchInput } from '../../../components';
@@ -40,7 +40,6 @@ const FunctionsPage = (): React.JSX.Element => {
     const [availableModuleTypes, setAvailableModuleTypes] = useState<string[]>([]);
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
-    const searchRef = useRef<HTMLInputElement>(null);
     const { dragState, startDrag, endDrag } = useDragState();
 
     useEffect(() => {
@@ -55,17 +54,6 @@ const FunctionsPage = (): React.JSX.Element => {
             }
         };
         fetchTypes();
-    }, []);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                searchRef.current?.focus();
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
     }, []);
 
     const filteredFunctions = useMemo(() => {
@@ -92,10 +80,9 @@ const FunctionsPage = (): React.JSX.Element => {
             <Flex grow />
             <div style={{ flexBasis: 380, flexShrink: 1 }}>
                 <SearchInput
-                    controlRef={searchRef}
                     value={searchQuery}
                     onUpdate={setSearchQuery}
-                    placeholder="Search functions, chains, modules… (⌘K)"
+                    placeholder="Search functions, chains, modules…"
                 />
             </div>
             <Button

--- a/web/src/pages/builtin/pipelines/PipelinesPage.tsx
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, EmptyState, SearchInput } from '../../../components';
@@ -30,19 +30,7 @@ const PipelinesPage = (): React.JSX.Element => {
     const { pipelines, loading, isDirty, getServerPipeline, dispatch, savePipeline, discardPipeline, createPipeline, deletePipeline, loadFunctionList } = usePipelinesData();
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
-    const searchRef = useRef<HTMLInputElement>(null);
     const { dragState, startDrag, endDrag } = useDragState();
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                searchRef.current?.focus();
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, []);
 
     const filteredPipelines = useMemo(() => {
         if (!searchQuery.trim()) {
@@ -68,10 +56,9 @@ const PipelinesPage = (): React.JSX.Element => {
             <Flex grow />
             <div style={{ flexBasis: 380, flexShrink: 1 }}>
                 <SearchInput
-                    controlRef={searchRef}
                     value={searchQuery}
                     onUpdate={setSearchQuery}
-                    placeholder="Search pipelines, functions… (⌘K)"
+                    placeholder="Search pipelines, functions…"
                 />
             </div>
             <Button

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -48,7 +48,6 @@ const AclPage: React.FC = () => {
     const [addConfigOpen, setAddConfigOpen] = useState(false);
     const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
     const [diffModalOpen, setDiffModalOpen] = useState(false);
-    const searchRef = useRef<HTMLInputElement>(null);
     const drawerRef = useRef<RuleDrawerHandle>(null);
 
     useUnsavedChangesBlocker(anyDirty);
@@ -180,7 +179,6 @@ const AclPage: React.FC = () => {
 
     useKeyboardShortcuts({
         onNewRule: openAdd,
-        onFocusSearch: () => searchRef.current?.focus(),
         onEscape: closeDrawer,
         drawerOpen: drawer.open,
     });
@@ -193,10 +191,9 @@ const AclPage: React.FC = () => {
             <Flex grow />
             <div style={{ flexBasis: 380, flexShrink: 1 }}>
                 <SearchInput
-                    controlRef={searchRef}
                     value={search}
                     onUpdate={setSearch}
-                    placeholder="Search rules… (/)"
+                    placeholder="Search rules…"
                 />
             </div>
             {enabledCounterNames.size > 0 && (

--- a/web/src/pages/modules/acl/hooks.ts
+++ b/web/src/pages/modules/acl/hooks.ts
@@ -279,11 +279,10 @@ export const isValidDeviceName = (s: string): boolean => /^[a-zA-Z0-9_:.\-]+$/.t
 /** Keyboard shortcuts for the ACL page. */
 export const useKeyboardShortcuts = (opts: {
     onNewRule: () => void;
-    onFocusSearch: () => void;
     onEscape: () => void;
     drawerOpen: boolean;
 }): void => {
-    const { onNewRule, onFocusSearch, onEscape, drawerOpen } = opts;
+    const { onNewRule, onEscape, drawerOpen } = opts;
 
     useEffect(() => {
         const onKey = (e: KeyboardEvent): void => {
@@ -293,14 +292,11 @@ export const useKeyboardShortcuts = (opts: {
             }
             const tag = (e.target as HTMLElement).tagName;
             if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-            if (e.key === '/' && !e.metaKey && !e.ctrlKey) {
-                e.preventDefault();
-                onFocusSearch();
-            } else if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+            if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
                 onNewRule();
             }
         };
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
-    }, [onNewRule, onFocusSearch, onEscape, drawerOpen]);
+    }, [onNewRule, onEscape, drawerOpen]);
 };

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -34,7 +34,6 @@ const DecapPage: React.FC = () => {
     const [addConfigOpen, setAddConfigOpen] = useState(false);
     const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
 
-    const searchRef = useRef<HTMLInputElement>(null);
     const drawerRef = useRef<PrefixDrawerHandle>(null);
     const dragDrop = useDraftDragDrop();
 
@@ -101,17 +100,16 @@ const DecapPage: React.FC = () => {
 
     useDraftShortcuts({
         rows: rawRows, activeRowId, setActiveRowId, editingRowId, setEditingRowId,
-        searchRef, onDeleteRow: handlers.handleDeleteRow,
+        onDeleteRow: handlers.handleDeleteRow,
     });
 
     const pageHeader = (
-        <DraftPageToolbar
-            title="Decap"
-            searchValue={search}
-            onSearchChange={setSearch}
-            searchPlaceholder="Search prefix… (/)"
-            searchRef={searchRef}
-            yamlSlot={currentConfig ? (
+            <DraftPageToolbar
+                title="Decap"
+                searchValue={search}
+                onSearchChange={setSearch}
+                searchPlaceholder="Search prefix…"
+                yamlSlot={currentConfig ? (
                 <PrefixYamlIO configName={currentConfig} rows={rawRows} onImport={handlers.handleImportYaml} />
             ) : undefined}
             addLabel="Add Prefix"

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -45,7 +45,6 @@ const ForwardPage: React.FC = () => {
     const [addConfigOpen, setAddConfigOpen] = useState(false);
     const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
     const [diffModalOpen, setDiffModalOpen] = useState(false);
-    const searchRef = useRef<HTMLInputElement>(null);
     const drawerRef = useRef<RuleDrawerHandle>(null);
 
     useUnsavedChangesBlocker(anyDirty);
@@ -159,7 +158,6 @@ const ForwardPage: React.FC = () => {
 
     useKeyboardShortcuts({
         onNewRule: openAdd,
-        onFocusSearch: () => searchRef.current?.focus(),
         onEscape: closeDrawer,
         drawerOpen: drawer.open,
     });
@@ -172,10 +170,9 @@ const ForwardPage: React.FC = () => {
             <Flex grow />
             <div style={{ flexBasis: 380, flexShrink: 1 }}>
                 <SearchInput
-                    controlRef={searchRef}
                     value={search}
                     onUpdate={setSearch}
-                    placeholder="Search rules… (/)"
+                    placeholder="Search rules…"
                 />
             </div>
             {currentConfig && (

--- a/web/src/pages/modules/forward/hooks.ts
+++ b/web/src/pages/modules/forward/hooks.ts
@@ -125,11 +125,10 @@ export const itemToDraft = (item: RuleItem): RuleDraft => ({
 /** Register keyboard shortcuts for the forward page. */
 export const useKeyboardShortcuts = (opts: {
     onNewRule: () => void;
-    onFocusSearch: () => void;
     onEscape: () => void;
     drawerOpen: boolean;
 }): void => {
-    const { onNewRule, onFocusSearch, onEscape, drawerOpen } = opts;
+    const { onNewRule, onEscape, drawerOpen } = opts;
 
     useEffect(() => {
         const onKey = (e: KeyboardEvent): void => {
@@ -138,19 +137,16 @@ export const useKeyboardShortcuts = (opts: {
                 onEscape();
                 return;
             }
-            // n and / are gated: do not fire when focus is inside a text field.
+            // n is gated: do not fire when focus is inside a text field.
             const tag = (e.target as HTMLElement).tagName;
             if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-            if (e.key === '/' && !e.metaKey && !e.ctrlKey) {
-                e.preventDefault();
-                onFocusSearch();
-            } else if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+            if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
                 onNewRule();
             }
         };
         window.addEventListener('keydown', onKey);
         return () => window.removeEventListener('keydown', onKey);
-    }, [onNewRule, onFocusSearch, onEscape, drawerOpen]);
+    }, [onNewRule, onEscape, drawerOpen]);
 };
 
 /** Validate CIDR string (IPv4 or IPv6). Returns true if valid. */

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -34,7 +34,6 @@ const RoutePage: React.FC = () => {
     const [addConfigOpen, setAddConfigOpen] = useState(false);
     const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
 
-    const searchRef = useRef<HTMLInputElement>(null);
     const drawerRef = useRef<FIBDrawerHandle>(null);
     const dragDrop = useDraftDragDrop();
 
@@ -106,19 +105,18 @@ const RoutePage: React.FC = () => {
 
     useDraftShortcuts({
         rows: rawRows, activeRowId, setActiveRowId, editingRowId, setEditingRowId,
-        searchRef, onDeleteRow: handlers.handleDeleteRow,
+        onDeleteRow: handlers.handleDeleteRow,
     });
 
     const pageHeader = (
-        <DraftPageToolbar
-            title="Route FIB"
-            searchValue={search}
-            onSearchChange={setSearch}
-            searchPlaceholder="Search prefix, MAC or device… (/)"
-            searchRef={searchRef}
-            yamlSlot={currentConfig ? (
-                <FIBYamlIO configName={currentConfig} rows={rawRows} onImport={handlers.handleImportYaml} />
-            ) : undefined}
+            <DraftPageToolbar
+                title="Route FIB"
+                searchValue={search}
+                onSearchChange={setSearch}
+                searchPlaceholder="Search prefix, MAC or device…"
+                yamlSlot={currentConfig ? (
+                    <FIBYamlIO configName={currentConfig} rows={rawRows} onImport={handlers.handleImportYaml} />
+                ) : undefined}
             addLabel="Add Route"
             onAdd={openAdd}
         />

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
@@ -78,7 +78,6 @@ const NeighboursPage: React.FC = () => {
     const [activeRowId, setActiveRowId] = useState<string | null>(null);
     const [editingRowId, setEditingRowId] = useState<string | null>(null);
 
-    const searchRef = useRef<HTMLInputElement>(null);
 
     const isMergedView = activeTab === MERGED_TAB;
     const activeTableInfo: NeighbourTableInfo | null = tables.find((t) => t.name === activeTab) ?? null;
@@ -240,10 +239,9 @@ const NeighboursPage: React.FC = () => {
             <Flex grow />
             <div style={{ flexBasis: 360, flexShrink: 1 }}>
                 <SearchInput
-                    controlRef={searchRef}
                     value={search}
                     onUpdate={(v) => updateParams({ [QP_SEARCH]: v || null })}
-                    placeholder="Search next hop, device, source… (/)"
+                    placeholder="Search next hop, device, source…"
                 />
             </div>
             <Button view="outlined" onClick={() => setCreateTableOpen(true)}>

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
@@ -34,7 +34,6 @@ const RoutePage: React.FC = () => {
         route: null,
     });
 
-    const searchRef = useRef<HTMLInputElement>(null);
 
     const currentConfig = activeConfig || configs[0] || '';
     const allRows = configRoutes.get(currentConfig) || [];
@@ -221,10 +220,9 @@ const RoutePage: React.FC = () => {
             <Flex grow />
             <div style={{ flexBasis: 380, flexShrink: 1 }}>
                 <SearchInput
-                    controlRef={searchRef}
                     value={search}
                     onUpdate={setSearch}
-                    placeholder="Search prefix, nexthop or peer… (/)"
+                    placeholder="Search prefix, nexthop or peer…"
                 />
             </div>
             <Button view="outlined" onClick={handleFlush} disabled={!currentConfig}>


### PR DESCRIPTION
- Centralizes search focus shortcuts and shortcut hints in the shared Web `SearchInput` component.
- Replaces the old `/` search focus shortcut with platform-specific `Command+K` on macOS and `Ctrl+K` on Linux and Windows.
- Removes page-level search shortcut handlers while preserving existing non-search keyboard shortcuts.
- Validated with `npm run build`, grep checks for old shortcuts, Playwright focus checks for Linux and macOS shortcut behavior, and reviewer approval.
- `npx tsc --noEmit` still fails on pre-existing ambiguous exports in `web/src/api/index.ts`.