### PR TITLE
feat: suggest function module config names

### DIFF
--- a/web/src/pages/builtin/functions/FunctionsPage.scss
+++ b/web/src/pages/builtin/functions/FunctionsPage.scss
@@ -743,6 +743,13 @@
     }
 }
 
+.inline-edit {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    max-width: 100%;
+}
+
 .inline-edit-pencil-icon {
     display: inline-flex;
     align-items: center;
@@ -770,6 +777,41 @@
 
     &--error {
         border-bottom-color: var(--fn-danger);
+    }
+}
+
+.inline-edit-suggestions {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    z-index: 560;
+    background: var(--fn-bg-2);
+    border: 1px solid var(--fn-line-2);
+    border-radius: var(--fn-r-sm);
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
+    max-height: 180px;
+    overflow-y: auto;
+}
+
+.inline-edit-suggestion {
+    all: unset;
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 4px 8px;
+    color: var(--fn-text-2);
+    font-size: 12px;
+    cursor: pointer;
+
+    &:hover {
+        background: var(--fn-bg-3);
+        color: var(--fn-text);
+    }
+
+    &--active {
+        background: var(--fn-line);
+        color: var(--fn-text);
     }
 }
 

--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -38,6 +38,8 @@ const matchesFn = (fn: NetworkFunction, query: string): boolean => {
 const FunctionsPage = (): React.JSX.Element => {
     const { functions, loading, isDirty, getServerFn, dispatch, saveFn, discardFn, createFn, deleteFn } = useFunctionsData();
     const [availableModuleTypes, setAvailableModuleTypes] = useState<string[]>([]);
+    const [availableModuleConfigNamesByType, setAvailableModuleConfigNamesByType] = useState<Record<string, string[]>>({});
+    const [availableModuleConfigNames, setAvailableModuleConfigNames] = useState<string[]>([]);
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState('');
     const { dragState, startDrag, endDrag } = useDragState();
@@ -47,8 +49,39 @@ const FunctionsPage = (): React.JSX.Element => {
             try {
                 const resp = await API.inspect.inspect();
                 const cpConfigs = resp.instance_info?.cp_configs ?? [];
-                const types = [...new Set(cpConfigs.map(c => c.type ?? '').filter(Boolean))];
-                setAvailableModuleTypes(types);
+                const namesByType = new Map<string, Set<string>>();
+                const types = new Set<string>();
+                const allNames = new Set<string>();
+
+                cpConfigs.forEach(cfg => {
+                    const type = cfg.type?.trim() ?? '';
+                    const name = cfg.name?.trim() ?? '';
+                    if (type) {
+                        types.add(type);
+                    }
+                    if (!name) {
+                        return;
+                    }
+
+                    allNames.add(name);
+                    if (!type) {
+                        return;
+                    }
+
+                    const names = namesByType.get(type) ?? new Set<string>();
+                    names.add(name);
+                    namesByType.set(type, names);
+                });
+
+                const typeList = [...types].sort((a, b) => a.localeCompare(b));
+                const byType: Record<string, string[]> = {};
+                namesByType.forEach((names, type) => {
+                    byType[type] = [...names].sort((a, b) => a.localeCompare(b));
+                });
+
+                setAvailableModuleTypes(typeList);
+                setAvailableModuleConfigNamesByType(byType);
+                setAvailableModuleConfigNames([...allNames].sort((a, b) => a.localeCompare(b)));
             } catch {
                 // Non-critical; drawer will show current module type only.
             }
@@ -120,6 +153,8 @@ const FunctionsPage = (): React.JSX.Element => {
                             serverFn={getServerFn(fn.id)}
                             isDirty={isDirty(fn.id)}
                             availableModuleTypes={availableModuleTypes}
+                            availableModuleConfigNamesByType={availableModuleConfigNamesByType}
+                            availableModuleConfigNames={availableModuleConfigNames}
                             dispatch={dispatch}
                             dragState={dragState}
                             onDragStart={startDrag}

--- a/web/src/pages/builtin/functions/components/Drawer.tsx
+++ b/web/src/pages/builtin/functions/components/Drawer.tsx
@@ -15,6 +15,7 @@ interface DrawerModuleProps {
     chain: Chain | null;
     counter?: InterpolatedCounterData;
     availableTypes: string[];
+    availableModuleConfigNames: string[];
     onClose: () => void;
     onRename: (newName: string) => void;
     onChangeType: (newType: string) => void;
@@ -97,7 +98,17 @@ const ModuleDrawerContent = ({
     setConfirmRemove: (v: boolean) => void;
     validateName: (name: string) => string | null;
 }): React.JSX.Element => {
-    const { module, chain, counter, availableTypes, onClose, onRename, onChangeType, onRemove } = props;
+    const {
+        module,
+        chain,
+        counter,
+        availableTypes,
+        availableModuleConfigNames,
+        onClose,
+        onRename,
+        onChangeType,
+        onRemove,
+    } = props;
     const meta = metaFor(module.type);
     const accent = meta.color;
     const sparklineData = useSparklineHistory(module.id, counter?.pps ?? 0);
@@ -116,6 +127,7 @@ const ModuleDrawerContent = ({
                         value={module.name}
                         onChange={onRename}
                         validate={validateName}
+                        suggestions={availableModuleConfigNames}
                         className="fn-drawer__name-edit"
                     />
                 </div>
@@ -173,6 +185,7 @@ const ModuleDrawerContent = ({
                         value={module.name}
                         onChange={onRename}
                         validate={validateName}
+                        suggestions={availableModuleConfigNames}
                     />
                 </div>
                 {chain && (

--- a/web/src/pages/builtin/functions/components/FunctionCard.tsx
+++ b/web/src/pages/builtin/functions/components/FunctionCard.tsx
@@ -15,6 +15,8 @@ interface FunctionCardProps {
     serverFn: NetworkFunction | null;
     isDirty: boolean;
     availableModuleTypes: string[];
+    availableModuleConfigNamesByType: Record<string, string[]>;
+    availableModuleConfigNames: string[];
     dispatch: (action: FunctionsAction) => void;
     dragState: DragState;
     onDragStart: (payload: DragPayload) => void;
@@ -57,6 +59,8 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
     serverFn,
     isDirty,
     availableModuleTypes,
+    availableModuleConfigNamesByType,
+    availableModuleConfigNames,
     dispatch,
     dragState,
     onDragStart,
@@ -118,6 +122,12 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
     const sparklineData = useSparklineHistory(`fn:${fn.id}:total`, totalPps);
 
     const siblingChainNames = fn.chains.map(c => c.name);
+
+    const getConfigNameSuggestions = useCallback((moduleType: string): string[] => {
+        return (availableModuleConfigNamesByType[moduleType]?.length ?? 0) > 0
+            ? availableModuleConfigNamesByType[moduleType]
+            : availableModuleConfigNames;
+    }, [availableModuleConfigNames, availableModuleConfigNamesByType]);
 
     const handleDrop = useCallback((toChainId: string, toIdx: number): void => {
         const payload = getDragPayload();
@@ -301,6 +311,7 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
                     chain={drawerChain}
                     counter={counterMap.get(drawerSelection.moduleId)}
                     availableTypes={availableModuleTypes}
+                    availableModuleConfigNames={getConfigNameSuggestions(drawerModule.type)}
                     onClose={handleCloseDrawer}
                     onRename={name => {
                         dispatch({ type: 'RENAME_MODULE', fnId: fn.id, moduleId: drawerModule.id, name });

--- a/web/src/pages/builtin/functions/components/InlineEdit.tsx
+++ b/web/src/pages/builtin/functions/components/InlineEdit.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useMemo } from 'react';
 
 /** Pencil icon shown on hover for editable text. */
 const PencilIcon = (): React.JSX.Element => (
@@ -25,6 +25,7 @@ export interface InlineEditProps {
     validate?: (value: string) => string | null;
     placeholder?: string;
     className?: string;
+    suggestions?: string[];
     /** 'chain' adds dashed underline + pencil icon on hover; 'module' adds dashed underline only. */
     hintVariant?: 'chain' | 'module';
 }
@@ -39,44 +40,94 @@ export const InlineEdit: React.FC<InlineEditProps> = ({
     validate,
     placeholder,
     className,
+    suggestions,
     hintVariant,
 }) => {
     const [editing, setEditing] = useState(false);
     const [draft, setDraft] = useState(value);
     const [error, setError] = useState<string | null>(null);
+    const [activeSuggestion, setActiveSuggestion] = useState(-1);
     const inputRef = useRef<HTMLInputElement>(null);
+    const suggestionLimit = 8;
 
     const startEdit = useCallback((e?: React.SyntheticEvent): void => {
         e?.stopPropagation();
         setDraft(value);
         setError(null);
+        setActiveSuggestion(-1);
         setEditing(true);
         setTimeout(() => {
             inputRef.current?.select();
         }, 0);
     }, [value]);
 
-    const tryCommit = useCallback((): void => {
-        const trimmed = draft.trim();
+    const suggestionItems = useMemo(() => {
+        if (!suggestions || suggestions.length === 0 || !editing) {
+            return [];
+        }
+        const pool = new Set<string>();
+        const search = draft.trim().toLowerCase();
+        for (const name of suggestions) {
+            if (!name) {
+                continue;
+            }
+            if (search && !name.toLowerCase().includes(search)) {
+                continue;
+            }
+            pool.add(name);
+        }
+        return [...pool].slice(0, suggestionLimit);
+    }, [draft, editing, suggestions]);
+
+    const commitDraft = useCallback((nextDraft?: string): void => {
+        const trimmed = (nextDraft ?? draft).trim();
         const err = validate ? validate(trimmed) : null;
         if (err) {
             setError(err);
             return;
         }
         setEditing(false);
+        setActiveSuggestion(-1);
         setError(null);
         if (trimmed !== value) {
             onChange(trimmed);
         }
     }, [draft, validate, value, onChange]);
 
+    const tryCommit = useCallback((): void => {
+        commitDraft();
+    }, [commitDraft]);
+
     const revert = useCallback((): void => {
         setEditing(false);
+        setActiveSuggestion(-1);
         setError(null);
         setDraft(value);
     }, [value]);
 
+    const applySuggestion = useCallback((name: string): void => {
+        setDraft(name);
+        commitDraft(name);
+    }, [commitDraft]);
+
     const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>): void => {
+        if (suggestionItems.length > 0) {
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setActiveSuggestion(prev => (prev + 1) % suggestionItems.length);
+                return;
+            }
+            if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setActiveSuggestion(prev => (prev <= 0 ? suggestionItems.length - 1 : prev - 1));
+                return;
+            }
+            if (e.key === 'Enter' && activeSuggestion >= 0) {
+                e.preventDefault();
+                applySuggestion(suggestionItems[activeSuggestion]);
+                return;
+            }
+        }
         if (e.key === 'Enter') {
             e.preventDefault();
             tryCommit();
@@ -85,7 +136,7 @@ export const InlineEdit: React.FC<InlineEditProps> = ({
             e.stopPropagation();
             revert();
         }
-    }, [tryCommit, revert]);
+    }, [activeSuggestion, applySuggestion, suggestionItems, tryCommit, revert]);
 
     const handleBlur = useCallback((): void => {
         if (editing) {
@@ -95,17 +146,35 @@ export const InlineEdit: React.FC<InlineEditProps> = ({
 
     if (editing) {
         return (
-            <span style={{ position: 'relative', display: 'inline-block' }}>
+            <span className="inline-edit">
                 <input
                     ref={inputRef}
                     className={`inline-edit-input${error ? ' inline-edit-input--error' : ''}${className ? ` ${className}` : ''}`}
                     value={draft}
-                    onChange={e => { setDraft(e.target.value); setError(null); }}
+                    onChange={e => { setDraft(e.target.value); setActiveSuggestion(-1); setError(null); }}
+                    onFocus={() => setActiveSuggestion(-1)}
                     onKeyDown={handleKeyDown}
                     onBlur={handleBlur}
                     placeholder={placeholder}
                     autoFocus
                 />
+                {suggestionItems.length > 0 && (
+                    <div className="inline-edit-suggestions" role="listbox">
+                        {suggestionItems.map((name, idx) => (
+                            <button
+                                key={name}
+                                type="button"
+                                className={`inline-edit-suggestion${activeSuggestion === idx ? ' inline-edit-suggestion--active' : ''}`}
+                                onMouseEnter={() => setActiveSuggestion(idx)}
+                                onMouseDown={e => { e.preventDefault(); e.stopPropagation(); applySuggestion(name); }}
+                                role="option"
+                                aria-selected={activeSuggestion === idx}
+                            >
+                                {name}
+                            </button>
+                        ))}
+                    </div>
+                )}
                 {error && (
                     <span className="inline-edit-error-tooltip">{error}</span>
                 )}


### PR DESCRIPTION
- Added module config-name suggestions in the Functions module drawer.
- Kept the field editable so new config names can still be typed freely.
- Reused Inspect `cp_configs` names with type-aware suggestions and fallback names.
- Verified with `npm run build`, scoped `git diff --check`, and reviewer approval.
- Full `npx tsc --noEmit --pretty false` still reports existing errors outside this change in `src/api/index.ts` and `src/pages/modules/_shared/chips.tsx`.