### PR TITLE
feat: add fwstate web module page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ const importDevices = () => import('./pages/builtin/devices/DevicesPage');
 const importForward = () => import('./pages/modules/forward/ForwardPage');
 const importDecap = () => import('./pages/modules/decap/DecapPage');
 const importAcl = () => import('./pages/modules/acl/AclPage');
+const importFwState = () => import('./pages/modules/fwstate/FWStatePage');
 const importPdump = () => import('./pages/modules/pdump/PdumpPage');
 const importModulesRoute = () => import('./pages/modules/route/RoutePage');
 const importOperatorsRoute = () => import('./pages/operators/route/RoutePage');
@@ -27,6 +28,7 @@ const pageImporters = [
     importForward,
     importDecap,
     importAcl,
+    importFwState,
     importPdump,
     importModulesRoute,
     importOperatorsRoute,
@@ -41,6 +43,7 @@ const DevicesPage = lazy(importDevices);
 const ForwardPage = lazy(importForward);
 const DecapPage = lazy(importDecap);
 const AclPage = lazy(importAcl);
+const FWStatePage = lazy(importFwState);
 const PdumpPage = lazy(importPdump);
 const ModulesRoutePage = lazy(importModulesRoute);
 const OperatorsRoutePage = lazy(importOperatorsRoute);
@@ -150,6 +153,7 @@ const AppContent = (): React.JSX.Element => {
                             <Route path="/modules/forward" element={<ForwardPage />} />
                             <Route path="/modules/decap" element={<DecapPage />} />
                             <Route path="/modules/acl" element={<AclPage />} />
+                            <Route path="/modules/fwstate" element={<FWStatePage />} />
                             <Route path="/modules/pdump" element={<PdumpPage />} />
                             <Route path="/modules/route" element={<ModulesRoutePage />} />
                             <Route path="/operators/route" element={<OperatorsRoutePage />} />
@@ -162,6 +166,7 @@ const AppContent = (): React.JSX.Element => {
                             <Route path="/forward" element={<Navigate to="/modules/forward" replace />} />
                             <Route path="/decap" element={<Navigate to="/modules/decap" replace />} />
                             <Route path="/acl" element={<Navigate to="/modules/acl" replace />} />
+                            <Route path="/fwstate" element={<Navigate to="/modules/fwstate" replace />} />
                             <Route path="/pdump" element={<Navigate to="/modules/pdump" replace />} />
                             <Route path="/route" element={<Navigate to="/operators/route" replace />} />
                             <Route path="/neighbours" element={<Navigate to="/operators/neighbours" replace />} />

--- a/web/src/MainMenu.tsx
+++ b/web/src/MainMenu.tsx
@@ -70,6 +70,7 @@ const MainMenu = ({ currentPage, onPageChange, renderContent, disabled = false }
         createMenuItem('modules/route', 'Route', Route),
         createMenuItem('modules/decap', 'Decap', LayoutCellsLarge),
         createMenuItem('modules/acl', 'ACL', Shield),
+        createMenuItem('modules/fwstate', 'FWState', Shield),
         createMenuItem('modules/pdump', 'Pdump', CirclePlay),
         createDivider('__div_2'),
         createSectionHeader('__section_operators', 'Operators'),

--- a/web/src/api/fwstate.ts
+++ b/web/src/api/fwstate.ts
@@ -1,0 +1,150 @@
+import { createService, createStreamingService, type CallOptions, type StreamCallbacks } from './client';
+import type { IPAddressWire } from '../utils/netip';
+
+export interface MapConfig {
+    index_size?: number;
+    extra_bucket_count?: number;
+}
+
+export interface SyncConfig {
+    src_addr?: IPAddressWire;
+    dst_ether?: string | Uint8Array | number[];
+    dst_addr_multicast?: IPAddressWire;
+    port_multicast?: number;
+    dst_addr_unicast?: IPAddressWire;
+    port_unicast?: number;
+    tcp_syn_ack?: number;
+    tcp_syn?: number;
+    tcp_fin?: number;
+    tcp?: number;
+    udp?: number;
+    default?: number;
+}
+
+export interface ShowConfigResponse {
+    name?: string;
+    linked_acls?: string[];
+    map_config?: MapConfig;
+    sync_config?: SyncConfig;
+}
+
+export interface ListConfigsResponse {
+    configs?: string[];
+}
+
+export interface LinkFWStateRequest {
+    fwstate_name?: string;
+    acl_config_names?: string[];
+}
+
+export interface MapStats {
+    index_size?: number;
+    extra_bucket_count?: number;
+    max_chain_length?: number;
+    layer_count?: number;
+    total_elements?: number;
+    max_deadline?: number;
+    memory_used?: number;
+    note?: string;
+}
+
+export interface GetStatsResponse {
+    ipv4_stats?: MapStats;
+    ipv6_stats?: MapStats;
+}
+
+export enum Direction {
+    FORWARD = 0,
+    BACKWARD = 1,
+}
+
+export interface FwStateKey {
+    proto?: number;
+    src_port?: number;
+    dst_port?: number;
+    src_addr?: IPAddressWire;
+    dst_addr?: IPAddressWire;
+}
+
+export interface FwStateValue {
+    external?: boolean;
+    flags?: number;
+    created_at?: number | string;
+    updated_at?: number | string;
+    packets_backward?: number | string;
+    packets_forward?: number | string;
+}
+
+export interface FwStateEntry {
+    key?: FwStateKey;
+    value?: FwStateValue;
+    idx?: number | string;
+    expired?: boolean;
+}
+
+export interface ListEntriesRequest {
+    config_name?: string;
+    is_ipv6?: boolean;
+    layer_index?: number;
+    include_expired?: boolean;
+    direction?: Direction;
+    batch_size?: number;
+    index?: number;
+}
+
+export interface ListEntriesResponse {
+    entries?: FwStateEntry[];
+    has_more?: boolean;
+    index?: number | string;
+    generation?: number | string;
+}
+
+export interface ShowConfigRequest {
+    name?: string;
+    ok_if_not_found?: boolean;
+}
+
+export interface UpdateConfigRequest {
+    name?: string;
+    map_config?: MapConfig;
+    sync_config?: SyncConfig;
+}
+
+export interface DeleteConfigRequest {
+    name?: string;
+}
+
+export interface GetStatsRequest {
+    name?: string;
+}
+
+const fwStateService = createService('fwstatepb.FWStateService');
+const fwStateStreamingService = createStreamingService('fwstatepb.FWStateService');
+
+export const fwstate = {
+    listConfigs: (options?: CallOptions): Promise<ListConfigsResponse> =>
+        fwStateService.call<ListConfigsResponse>('ListConfigs', options),
+
+    showConfig: (request: ShowConfigRequest, options?: CallOptions): Promise<ShowConfigResponse> =>
+        fwStateService.callWithBody<ShowConfigResponse>('ShowConfig', request, options),
+
+    updateConfig: (request: UpdateConfigRequest, options?: CallOptions): Promise<void> =>
+        fwStateService.callWithBody<void>('UpdateConfig', request, options),
+
+    deleteConfig: (request: DeleteConfigRequest, options?: CallOptions): Promise<void> =>
+        fwStateService.callWithBody<void>('DeleteConfig', request, options),
+
+    linkFWState: (request: LinkFWStateRequest, options?: CallOptions): Promise<void> =>
+        fwStateService.callWithBody<void>('LinkFWState', request, options),
+
+    getStats: (request: GetStatsRequest, options?: CallOptions): Promise<GetStatsResponse> =>
+        fwStateService.callWithBody<GetStatsResponse>('GetStats', request, options),
+
+    listEntriesPage: (
+        request: ListEntriesRequest,
+        callbacks: StreamCallbacks<ListEntriesResponse>,
+        signal?: AbortSignal,
+    ): void => {
+        fwStateStreamingService.stream<ListEntriesResponse>('ListEntries', request, callbacks, signal);
+    },
+};

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -9,6 +9,7 @@ export * from './devices';
 export * from './decap';
 export { acl, ACTION_KIND_LABELS } from './acl';
 export * from './forward';
+export { fwstate } from './fwstate';
 export * from './counters';
 
 import { neighbours } from './neighbours';
@@ -20,6 +21,7 @@ import { devices } from './devices';
 import { decap } from './decap';
 import { acl } from './acl';
 import { forward } from './forward';
+import { fwstate } from './fwstate';
 import { counters } from './counters';
 
 export const API = {
@@ -33,5 +35,6 @@ export const API = {
     decap,
     acl,
     forward,
+    fwstate,
     counters,
 };

--- a/web/src/pages/modules/_shared/chips.scss
+++ b/web/src/pages/modules/_shared/chips.scss
@@ -1,0 +1,59 @@
+.shared-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 7px;
+    border-radius: 4px;
+    font-family: var(--fw-font-mono);
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    background: var(--fw-bg-2);
+    border: 1px solid var(--fw-line-2);
+    flex-shrink: 0;
+}
+
+.shared-chip--ip {
+    background: transparent;
+}
+
+.shared-chip--ip-ipv4 {
+    color: #d6c79a;
+}
+
+.shared-chip--ip-ipv6 {
+    color: #c0d3e8;
+}
+
+.shared-chip--proto {
+    font-size: 12px;
+}
+
+.shared-chip--proto-tcp {
+    background: color-mix(in srgb, var(--g-color-base-positive-light) 55%, transparent);
+    color: var(--g-color-text-positive);
+    border-color: color-mix(in srgb, var(--g-color-base-positive-medium) 40%, transparent);
+}
+
+.shared-chip--proto-udp {
+    background: color-mix(in srgb, var(--g-color-base-info-light) 55%, transparent);
+    color: var(--g-color-text-info);
+    border-color: color-mix(in srgb, var(--g-color-base-info-medium) 40%, transparent);
+}
+
+.shared-chip--proto-icmp {
+    background: color-mix(in srgb, var(--g-color-base-warning-light) 55%, transparent);
+    color: var(--g-color-text-warning);
+    border-color: color-mix(in srgb, var(--g-color-base-warning-medium) 40%, transparent);
+}
+
+.shared-chip--proto-misc {
+    background: color-mix(in srgb, var(--g-color-base-misc-light) 55%, transparent);
+    color: var(--g-color-text-misc);
+    border-color: color-mix(in srgb, var(--g-color-base-misc-medium) 40%, transparent);
+}
+
+.shared-chip--proto-dim {
+    background: var(--fw-bg-2);
+    color: var(--fw-text-3);
+    border-color: var(--fw-line-2);
+}

--- a/web/src/pages/modules/_shared/chips.tsx
+++ b/web/src/pages/modules/_shared/chips.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import './chips.scss';
+
+export type ProtoTone = 'tcp' | 'udp' | 'icmp' | 'misc' | 'dim';
+
+export interface ProtoDisplay {
+    label: string;
+    tone: ProtoTone;
+    title: string;
+}
+
+const IP_PROTOCOL_NAMES: Record<number, string> = {
+    1: 'ICMP',
+    6: 'TCP',
+    17: 'UDP',
+    41: 'IPv6',
+    47: 'GRE',
+    50: 'ESP',
+    51: 'AH',
+    58: 'ICMPv6',
+    89: 'OSPF',
+    103: 'PIM',
+    112: 'VRRP',
+    132: 'SCTP',
+};
+
+export const getProtocolDisplay = (proto: number | undefined): ProtoDisplay => {
+    if (proto === undefined || !Number.isInteger(proto) || proto < 0) {
+        return {
+            label: '-',
+            tone: 'dim',
+            title: '-',
+        };
+    }
+
+    const protocol = proto;
+
+    return {
+        label: IP_PROTOCOL_NAMES[protocol] ?? `proto ${protocol}`,
+        tone: getProtocolTone(protocol),
+        title: IP_PROTOCOL_NAMES[protocol] ?? `proto ${protocol}`,
+    };
+};
+
+export const getProtocolTone = (proto: number): ProtoTone => {
+    if (proto === 6) return 'tcp';
+    if (proto === 17) return 'udp';
+    if (proto === 1 || proto === 58) return 'icmp';
+    if (proto === 47 || proto === 50 || proto === 51 || proto === 132) return 'misc';
+    return 'dim';
+};
+
+interface IpAddressChipProps {
+    value: string;
+    family?: 'ipv4' | 'ipv6';
+    className?: string;
+    title?: string;
+}
+
+export const IpAddressChip: React.FC<IpAddressChipProps> = ({
+    value,
+    family,
+    className = '',
+    title,
+}) => {
+    const chipFamily = family ?? (value.includes(':') ? 'ipv6' : 'ipv4');
+    return (
+        <span
+            className={`shared-chip shared-chip--ip shared-chip--ip-${chipFamily} ${className}`.trim()}
+            title={title ?? value}
+        >
+            {value}
+        </span>
+    );
+};
+
+interface ProtoChipProps {
+    label: string;
+    tone: ProtoTone;
+    className?: string;
+    title?: string;
+}
+
+export const ProtoChip: React.FC<ProtoChipProps> = ({
+    label,
+    tone,
+    className = '',
+    title,
+}) => {
+    return (
+        <span
+            className={`shared-chip shared-chip--proto shared-chip--proto-${tone} ${className}`.trim()}
+            title={title ?? label}
+        >
+            {label}
+        </span>
+    );
+};
+
+interface ProtocolNumberChipProps {
+    proto?: number;
+    className?: string;
+}
+
+export const ProtocolNumberChip: React.FC<ProtocolNumberChipProps> = ({ proto, className }) => {
+    const { label, tone, title } = getProtocolDisplay(proto);
+    return <ProtoChip label={label} tone={tone} title={title} className={className} />;
+};

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -1,10 +1,12 @@
 import React, { useCallback, useDeferredValue, useMemo, useRef, useState } from 'react';
-import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Flex, Icon, Label, Text } from '@gravity-ui/uikit';
 import { Pause, Play, Plus } from '@gravity-ui/icons';
+import { useNavigate } from 'react-router-dom';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { useAclDraft } from './useAclDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { Rule } from '../../../api/acl';
+import { ActionKind } from '../../../api/acl';
 import type { RuleItem, RuleDraft } from './types';
 import { rulesToNgItems, draftToRule, useKeyboardShortcuts } from './hooks';
 import { DRAWER_TRANSITION_MS } from './RuleTable';
@@ -25,6 +27,7 @@ const AclPage: React.FC = () => {
         draftRules,
         draftRuleIds,
         serverRules,
+        fwstateName,
         isDirty,
         anyDirty,
         dispatchDraft,
@@ -49,10 +52,12 @@ const AclPage: React.FC = () => {
     const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
     const [diffModalOpen, setDiffModalOpen] = useState(false);
     const drawerRef = useRef<RuleDrawerHandle>(null);
+    const navigate = useNavigate();
 
     useUnsavedChangesBlocker(anyDirty);
 
     const currentConfig = activeConfig || draftConfigs[0] || '';
+    const currentFwStateName = fwstateName(currentConfig);
     const rawRules: Rule[] = draftRules(currentConfig);
     const rawIds: string[] = draftRuleIds(currentConfig);
     const allItems = useMemo(() => rulesToNgItems(rawRules, rawIds), [rawRules, rawIds]);
@@ -184,10 +189,22 @@ const AclPage: React.FC = () => {
     });
 
     const currentIsDirty = isDirty(currentConfig);
+    const hasStatefulRules = useMemo(() =>
+        rawRules.some((rule) => (rule.actions ?? []).some((action) =>
+            action.kind === ActionKind.ACTION_KIND_CHECK_STATE || action.kind === ActionKind.ACTION_KIND_CREATE_STATE,
+        )), [rawRules]);
 
     const pageHeader = (
         <Flex alignItems="center" gap={4} style={{ width: '100%' }}>
             <Text variant="header-1">ACL</Text>
+            {currentFwStateName && (
+                <Button size="s" view="outlined" onClick={() => navigate('/modules/fwstate')}>
+                    FWState: {currentFwStateName}
+                </Button>
+            )}
+            {!currentFwStateName && hasStatefulRules && (
+                <Label theme="warning">Stateful rules without FWState</Label>
+            )}
             <Flex grow />
             <div style={{ flexBasis: 380, flexShrink: 1 }}>
                 <SearchInput

--- a/web/src/pages/modules/acl/chips.tsx
+++ b/web/src/pages/modules/acl/chips.tsx
@@ -4,28 +4,34 @@ import type { Action } from '../../../api/acl';
 import { ActionKind, ACTION_KIND_LABELS } from '../../../api/acl';
 import { formatIPNet, toaster, copyToClipboard } from '../../../utils';
 import { extractBytes } from './utils';
+import { getProtocolTone, IpAddressChip, ProtoChip as SharedProtoChip } from '../_shared/chips';
 
 // Protocol names per IANA IP protocol number.
 const IP_PROTOS: Record<number, string> = {
-    0: 'HOPOPT', 1: 'ICMP', 2: 'IGMP', 4: 'IPv4', 6: 'TCP',
-    17: 'UDP', 41: 'IPv6', 43: 'IPv6-Route', 44: 'IPv6-Frag',
-    47: 'GRE', 50: 'ESP', 51: 'AH', 58: 'ICMPv6', 59: 'IPv6-NoNxt',
-    60: 'IPv6-Opts', 89: 'OSPF', 103: 'PIM', 112: 'VRRP', 132: 'SCTP',
-};
-
-type ProtoTone = 'tcp' | 'udp' | 'icmp' | 'misc' | 'dim';
-
-const protoTone = (proto: number): ProtoTone => {
-    if (proto === 6) return 'tcp';
-    if (proto === 17) return 'udp';
-    if (proto === 1 || proto === 58) return 'icmp';
-    if (proto === 47 || proto === 50 || proto === 51 || proto === 132) return 'misc';
-    return 'dim';
+    0: 'HOPOPT',
+    1: 'ICMP',
+    2: 'IGMP',
+    4: 'IPv4',
+    6: 'TCP',
+    17: 'UDP',
+    41: 'IPv6',
+    43: 'IPv6-Route',
+    44: 'IPv6-Frag',
+    47: 'GRE',
+    50: 'ESP',
+    51: 'AH',
+    58: 'ICMPv6',
+    59: 'IPv6-NoNxt',
+    60: 'IPv6-Opts',
+    89: 'OSPF',
+    103: 'PIM',
+    112: 'VRRP',
+    132: 'SCTP',
 };
 
 interface DecodedProto {
     label: string;
-    tone: ProtoTone | 'dim';
+    tone: ReturnType<typeof getProtocolTone>;
     title: string;
 }
 
@@ -42,7 +48,7 @@ const decodeProtoRange = (rangeStr: string): DecodedProto => {
 
     if (pFrom === pTo) {
         const name = IP_PROTOS[pFrom] ?? `proto ${pFrom}`;
-        const tone = protoTone(pFrom);
+        const tone = getProtocolTone(pFrom);
         if (sFrom === 0 && sTo === 255) {
             return { label: name, tone, title: rangeStr };
         }
@@ -76,14 +82,7 @@ interface ProtoChipProps {
 /** Renders a single proto range chip with color based on protocol. */
 export const ProtoChip: React.FC<ProtoChipProps> = ({ rangeStr }) => {
     const { label, tone, title } = decodeProtoRange(rangeStr);
-    return (
-        <span
-            className={`acl-chip acl-chip--proto acl-chip--proto-${tone}`}
-            title={title}
-        >
-            {label}
-        </span>
-    );
+    return <SharedProtoChip label={label} tone={tone} title={title} />;
 };
 
 interface PortRangeChipProps {
@@ -120,15 +119,7 @@ interface IpNetChipProps {
 
 /** Renders a CIDR chip, colored differently for IPv4 vs IPv6. */
 export const IpNetChip: React.FC<IpNetChipProps> = ({ cidr }) => {
-    const isV6 = cidr.includes(':');
-    return (
-        <span
-            className={`acl-chip ${isV6 ? 'acl-chip--ipv6' : 'acl-chip--ipv4'}`}
-            title={cidr}
-        >
-            {cidr}
-        </span>
-    );
+    return <IpAddressChip value={cidr} />;
 };
 
 /** Format an IPNet wire object to a CIDR string. */

--- a/web/src/pages/modules/acl/draftReducer.ts
+++ b/web/src/pages/modules/acl/draftReducer.ts
@@ -9,6 +9,7 @@ const serverIds = (rules: Rule[]): string[] => rules.map((_, idx) => `srv-${idx}
 
 export interface AclDraftState {
     server: Record<string, Rule[]>;
+    serverFwStateName: Record<string, string>;
     draft: Record<string, Rule[]>;
     /**
      * Stable row ids parallel to draft[configName].
@@ -25,6 +26,7 @@ export interface AclDraftState {
 
 export const initialAclDraftState: AclDraftState = {
     server: {},
+    serverFwStateName: {},
     draft: {},
     draftIds: {},
     serverConfigs: [],
@@ -34,7 +36,7 @@ export const initialAclDraftState: AclDraftState = {
 };
 
 export type AclDraftAction =
-    | { type: 'LOAD_ALL_CONFIGS'; configs: Array<{ name: string; rules: Rule[] }> }
+    | { type: 'LOAD_ALL_CONFIGS'; configs: Array<{ name: string; rules: Rule[]; fwstateName: string }> }
     | { type: 'ADD_RULE'; configName: string; rule: Rule }
     | { type: 'UPDATE_RULE_AT_INDEX'; configName: string; index: number; rule: Rule }
     | { type: 'REMOVE_RULES'; configName: string; indices: number[] }
@@ -51,14 +53,16 @@ export const aclDraftReducer = (
     switch (action.type) {
         case 'LOAD_ALL_CONFIGS': {
             const newServer: Record<string, Rule[]> = { ...state.server };
+            const newServerFwStateName: Record<string, string> = { ...state.serverFwStateName };
             const newDraft: Record<string, Rule[]> = { ...state.draft };
             const newDraftIds: Record<string, string[]> = { ...state.draftIds };
             const serverConfigs: string[] = [];
             // Use reference equality to detect whether the user has local edits:
             // if draft[name] === server[name] the config was never mutated locally,
             // so it is safe to fast-forward to the new server snapshot.
-            for (const { name, rules } of action.configs) {
+            for (const { name, rules, fwstateName } of action.configs) {
                 newServer[name] = rules;
+                newServerFwStateName[name] = fwstateName;
                 if (state.draft[name] === state.server[name]) {
                     newDraft[name] = rules;
                     newDraftIds[name] = serverIds(rules);
@@ -76,6 +80,7 @@ export const aclDraftReducer = (
             return {
                 ...state,
                 server: newServer,
+                serverFwStateName: newServerFwStateName,
                 draft: newDraft,
                 draftIds: newDraftIds,
                 serverConfigs,
@@ -222,11 +227,13 @@ export const aclDraftReducer = (
                 // Config was pending deletion (or never had a draft entry) and is now
                 // gone from the server.
                 const { [action.configName]: _s, ...serverRest } = state.server;
+                const { [action.configName]: _f, ...fwStateNameRest } = state.serverFwStateName;
                 const { [action.configName]: _d, ...draftRest } = state.draft;
                 const { [action.configName]: _di, ...draftIdsRest } = state.draftIds;
                 return {
                     ...state,
                     server: serverRest,
+                    serverFwStateName: fwStateNameRest,
                     draft: draftRest,
                     draftIds: draftIdsRest,
                     serverConfigs: state.serverConfigs.filter(n => n !== action.configName),
@@ -241,6 +248,7 @@ export const aclDraftReducer = (
             return {
                 ...state,
                 server: { ...state.server, [action.configName]: savedRules },
+                serverFwStateName: state.serverFwStateName,
                 serverConfigs: state.serverConfigs.includes(action.configName)
                     ? state.serverConfigs
                     : [...state.serverConfigs, action.configName],

--- a/web/src/pages/modules/acl/useAclDraft.ts
+++ b/web/src/pages/modules/acl/useAclDraft.ts
@@ -10,6 +10,7 @@ import type { AclDraftAction } from './draftReducer';
 
 const EMPTY_RULES: Rule[] = [];
 const EMPTY_IDS: string[] = [];
+const EMPTY_FWSTATE_NAME = '';
 
 export interface UseAclDraftResult {
     draftConfigs: string[];
@@ -17,6 +18,7 @@ export interface UseAclDraftResult {
     draftRules: (configName: string) => Rule[];
     draftRuleIds: (configName: string) => string[];
     serverRules: (configName: string) => Rule[];
+    fwstateName: (configName: string) => string;
     isDirty: (configName: string) => boolean;
     anyDirty: boolean;
     dispatchDraft: (action: AclDraftAction) => void;
@@ -47,12 +49,12 @@ export const useAclDraft = (): UseAclDraftResult => {
             const names = listResp.configs ?? [];
 
             const configs = await Promise.all(
-                names.map(async (name): Promise<{ name: string; rules: Rule[] }> => {
+                names.map(async (name): Promise<{ name: string; rules: Rule[]; fwstateName: string }> => {
                     try {
                         const resp = await API.acl.showConfig({ name });
-                        return { name, rules: resp.rules ?? [] };
+                        return { name, rules: resp.rules ?? [], fwstateName: resp.fwstate_name ?? '' };
                     } catch {
-                        return { name, rules: [] };
+                        return { name, rules: [], fwstateName: '' };
                     }
                 }),
             );
@@ -124,6 +126,8 @@ export const useAclDraft = (): UseAclDraftResult => {
 
     const serverRulesFor = useCallback((configName: string): Rule[] =>
         state.server[configName] ?? EMPTY_RULES, [state.server]);
+    const fwstateNameFor = useCallback((configName: string): string =>
+        state.serverFwStateName[configName] ?? EMPTY_FWSTATE_NAME, [state.serverFwStateName]);
 
     const isDirty = useCallback((configName: string): boolean =>
         state.dirty.has(configName), [state.dirty]);
@@ -141,6 +145,7 @@ export const useAclDraft = (): UseAclDraftResult => {
         draftRules: draftRulesFor,
         draftRuleIds: draftRuleIdsFor,
         serverRules: serverRulesFor,
+        fwstateName: fwstateNameFor,
         isDirty,
         anyDirty,
         dispatchDraft,

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -1,0 +1,1292 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Button, Flex, Icon, Label, Select, Switch, Table, Text, TextInput } from '@gravity-ui/uikit';
+import { Plus } from '@gravity-ui/icons';
+import { useNavigate } from 'react-router-dom';
+import { API } from '../../../api';
+import { Direction, type FwStateEntry, type ListEntriesRequest, type MapStats } from '../../../api/fwstate';
+import { ConfirmDialog, ConfigTabStrip, PageLayout, PageLoader } from '../../../components';
+import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
+import { ipAddressToString, isValidIPAddress, parseIPToBytes, stringToIPAddress, type IPAddressWire } from '../../../utils/netip';
+import { formatMACFromBytes, parseMACToBytes } from '../../../utils/mac';
+import { toaster } from '../../../utils';
+import { AddConfigModal, DeleteConfigModal } from '../../_shared/draft';
+import { SaveIcon, TrashIcon } from '../../_shared/draft/DraftActionButtons';
+import { IpAddressChip, ProtocolNumberChip } from '../_shared/chips';
+import '../../../styles/draft-page.scss';
+import './fwstate.scss';
+
+interface DraftConfig {
+    mapIndexSize: number;
+    mapExtraBucketCount: number;
+    srcAddr: string;
+    dstEther: string;
+    dstAddrMulticast: string;
+    portMulticast: number;
+    dstAddrUnicast: string;
+    portUnicast: number;
+    syncMode: 'multicast' | 'unicast' | 'both';
+    tcpSynAck: string;
+    tcpSyn: string;
+    tcpFin: string;
+    tcp: string;
+    udp: string;
+    defaultTimeout: string;
+    linkedAcls: string[];
+    isLocalOnly: boolean;
+}
+
+interface AclMeta {
+    name: string;
+    fwstateName: string;
+    ruleCount: number | null;
+    isLoaded: boolean;
+    loadFailed: boolean;
+}
+
+const DEFAULT_NS = {
+    tcpSynAck: 120_000_000_000,
+    tcpSyn: 120_000_000_000,
+    tcpFin: 120_000_000_000,
+    tcp: 120_000_000_000,
+    udp: 30_000_000_000,
+    defaultTimeout: 16_000_000_000,
+};
+
+const BACKWARD_RESET_CURSOR = Number.MAX_SAFE_INTEGER;
+
+const zeroIPv6AddressWire = (): IPAddressWire => ({ addr: '::' });
+
+const formatDurationNsAsSeconds = (value: number): string => {
+    if (!Number.isFinite(value) || value <= 0) return '';
+    const seconds = value / 1_000_000_000;
+    if (Number.isInteger(seconds)) return String(seconds);
+    return seconds.toFixed(9).replace(/\.?0+$/, '');
+};
+
+const parseDurationToNs = (value: string): number | null => {
+    const trimmed = value.trim().toLowerCase();
+    if (!trimmed) return null;
+    const numberOnly = trimmed.match(/^\d+(?:\.\d+)?$/);
+    if (numberOnly) {
+        const seconds = Number(trimmed);
+        if (!Number.isFinite(seconds) || seconds <= 0) return null;
+        return Math.round(seconds * 1_000_000_000);
+    }
+    const unitMatch = trimmed.match(/^(\d+(?:\.\d+)?)(ns|ms|s|m|h)$/);
+    if (!unitMatch) return null;
+    const amount = Number(unitMatch[1]);
+    if (!Number.isFinite(amount) || amount <= 0) return null;
+    const unit = unitMatch[2];
+    if (unit === 'ns') return Math.round(amount);
+    if (unit === 'ms') return Math.round(amount * 1_000_000);
+    if (unit === 's') return Math.round(amount * 1_000_000_000);
+    if (unit === 'm') return Math.round(amount * 60 * 1_000_000_000);
+    return Math.round(amount * 3600 * 1_000_000_000);
+};
+
+const isValidIPv6Address = (value: string): boolean => {
+    return isValidIPAddress(value) && value.includes(':');
+};
+
+const isZeroIPv6Address = (value: string): boolean => {
+    const bytes = parseIPToBytes(value);
+    return Boolean(bytes && bytes.length === 16 && bytes.every((byte) => byte === 0));
+};
+
+const isValidNonzeroIPv6Address = (value: string): boolean => {
+    return isValidIPv6Address(value) && !isZeroIPv6Address(value);
+};
+
+const isValidNonzeroMAC = (value: string): boolean => {
+    const parsed = parseMACToBytes(value);
+    return Boolean(parsed && parsed.some((byte) => byte !== 0));
+};
+
+const decodeWireBytes = (wire: string | Uint8Array | number[] | undefined): number[] => {
+    if (!wire) return [];
+    if (Array.isArray(wire)) return wire;
+    if (wire instanceof Uint8Array) return Array.from(wire);
+    try {
+        return Array.from(atob(wire), (char) => char.charCodeAt(0));
+    } catch {
+        return [];
+    }
+};
+
+const toDraftConfig = (config: Awaited<ReturnType<typeof API.fwstate.showConfig>> | null, isLocalOnly: boolean): DraftConfig => {
+    const sync = config?.sync_config;
+    const multicastAddress = ipAddressToString(sync?.dst_addr_multicast as IPAddressWire | undefined).trim();
+    const unicastAddress = ipAddressToString(sync?.dst_addr_unicast as IPAddressWire | undefined).trim();
+    const multicastPresent = isValidNonzeroIPv6Address(multicastAddress) && (sync?.port_multicast ?? 0) !== 0;
+    const unicastPresent = isValidNonzeroIPv6Address(unicastAddress) && (sync?.port_unicast ?? 0) !== 0;
+    const syncMode: DraftConfig['syncMode'] = multicastPresent && unicastPresent
+        ? 'both'
+        : unicastPresent
+            ? 'unicast'
+            : 'multicast';
+    return {
+        mapIndexSize: config?.map_config?.index_size ?? 1_048_576,
+        mapExtraBucketCount: config?.map_config?.extra_bucket_count ?? 1_024,
+        srcAddr: ipAddressToString(sync?.src_addr as IPAddressWire | undefined),
+        dstEther: formatMACFromBytes(decodeWireBytes(sync?.dst_ether)),
+        dstAddrMulticast: ipAddressToString(sync?.dst_addr_multicast as IPAddressWire | undefined),
+        portMulticast: sync?.port_multicast ?? 0,
+        dstAddrUnicast: ipAddressToString(sync?.dst_addr_unicast as IPAddressWire | undefined),
+        portUnicast: sync?.port_unicast ?? 0,
+        syncMode,
+        tcpSynAck: formatDurationNsAsSeconds(sync?.tcp_syn_ack ?? DEFAULT_NS.tcpSynAck),
+        tcpSyn: formatDurationNsAsSeconds(sync?.tcp_syn ?? DEFAULT_NS.tcpSyn),
+        tcpFin: formatDurationNsAsSeconds(sync?.tcp_fin ?? DEFAULT_NS.tcpFin),
+        tcp: formatDurationNsAsSeconds(sync?.tcp ?? DEFAULT_NS.tcp),
+        udp: formatDurationNsAsSeconds(sync?.udp ?? DEFAULT_NS.udp),
+        defaultTimeout: formatDurationNsAsSeconds(sync?.default ?? DEFAULT_NS.defaultTimeout),
+        linkedAcls: config?.linked_acls ?? [],
+        isLocalOnly,
+    };
+};
+
+const normalizeUnsignedInt = (value: number | string | null | undefined): string | null => {
+    if (value === undefined || value === null) return null;
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+            return null;
+        }
+        return String(value);
+    }
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (!/^\d+$/.test(trimmed)) return null;
+    return trimmed.replace(/^0+(?=\d)/, '');
+};
+
+const normalizeUnsignedIntToNumber = (value: number | string | null | undefined): number => {
+    const normalized = normalizeUnsignedInt(value);
+    if (!normalized) return 0;
+    const parsed = Number(normalized);
+    if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed < 0) return 0;
+    if (parsed > Number.MAX_SAFE_INTEGER) return Number.MAX_SAFE_INTEGER;
+    return parsed;
+};
+
+const formatUnsignedCount = (value: number | string | null | undefined, fallbackOnMissing = '0'): string => {
+    if (value === undefined || value === null) {
+        return fallbackOnMissing;
+    }
+    return normalizeUnsignedInt(value) ?? '-';
+};
+
+const formatNsUtc = (value: number | string | null | undefined): string => {
+    const ns = normalizeUnsignedInt(value);
+    if (!ns || ns === '0') return '-';
+    try {
+        const millis = Number(BigInt(ns) / 1_000_000n);
+        const date = new Date(millis);
+        if (!Number.isFinite(date.getTime())) {
+            return '-';
+        }
+        return date.toISOString();
+    } catch {
+        return '-';
+    }
+};
+
+const formatStateIdx = (idx: number | string | null | undefined): string => {
+    if (idx === undefined || idx === null) return '0';
+    return normalizeUnsignedInt(idx) ?? '-';
+};
+
+const FLAG_TONES: Array<{ bit: number; label: string }> = [
+    { bit: 0x01, label: 'FIN' },
+    { bit: 0x02, label: 'SYN' },
+    { bit: 0x04, label: 'RST' },
+    { bit: 0x08, label: 'ACK' },
+];
+
+const renderIpChip = (ip: IPAddressWire | undefined): React.ReactElement => {
+    const value = ipAddressToString(ip).trim();
+    if (!value) {
+        return <span className="fwstate-table-cell fwstate-table-cell--empty">-</span>;
+    }
+    return <IpAddressChip value={value} />;
+};
+
+const decodeFlags = (rawFlags: number | string | null | undefined): { source: string[]; destination: string[] } => {
+    const value = typeof rawFlags === 'number' ? rawFlags : Number(rawFlags);
+    if (!Number.isInteger(value) || value < 0) {
+        return { source: [], destination: [] };
+    }
+    const sourceFlagsValue = value & 0x0f;
+    const destinationFlagsValue = (value >> 4) & 0x0f;
+    const sourceFlags = FLAG_TONES
+        .filter((flag) => sourceFlagsValue & flag.bit)
+        .map((flag) => flag.label);
+    const destinationFlags = FLAG_TONES
+        .filter((flag) => destinationFlagsValue & flag.bit)
+        .map((flag) => flag.label);
+    return { source: sourceFlags, destination: destinationFlags };
+};
+
+const renderFlagChips = (flags: string[]): React.ReactElement => {
+    if (flags.length === 0) {
+        return <span className="fwstate-flag-chip fwstate-flag-chip--none">-</span>;
+    }
+    return (
+        <span className="fwstate-flag-chip-list">
+            {flags.map((flag) => <span key={flag} className="fwstate-flag-chip">{flag}</span>)}
+        </span>
+    );
+};
+
+const FWStatePage: React.FC = () => {
+    const navigate = useNavigate();
+    const [loading, setLoading] = useState(true);
+    const [activeConfig, setActiveConfig] = useState('');
+    const [configs, setConfigs] = useState<Record<string, DraftConfig>>({});
+    const [dirtyConfigs, setDirtyConfigs] = useState<Set<string>>(new Set());
+    const [aclMeta, setAclMeta] = useState<AclMeta[]>([]);
+    const [stats, setStats] = useState<{ ipv4?: MapStats; ipv6?: MapStats } | null>(null);
+    const [addConfigOpen, setAddConfigOpen] = useState(false);
+    const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
+    const [stateRows, setStateRows] = useState<FwStateEntry[]>([]);
+    const [stateGeneration, setStateGeneration] = useState<number | string | null>(null);
+    const [stateCursor, setStateCursor] = useState<number>(0);
+    const [stateHasMore, setStateHasMore] = useState(true);
+    const [stateLoading, setStateLoading] = useState(false);
+    const [statesQuery, setStatesQuery] = useState({
+        isIpv6: true,
+        layerIndex: 0,
+        direction: Direction.FORWARD,
+        includeExpired: false,
+    });
+    const [pendingAclLink, setPendingAclLink] = useState<{
+        aclName: string;
+        linkedFwstateName: string | null;
+    } | null>(null);
+    const statesScrollRef = useRef<HTMLDivElement | null>(null);
+
+    const configNames = useMemo(() => Object.keys(configs).sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })), [configs]);
+    const currentName = activeConfig || configNames[0] || '';
+    const current = configs[currentName];
+    const canLoadStates = Boolean(currentName && current && !current.isLocalOnly);
+    const currentIsDirty = dirtyConfigs.has(currentName);
+    const currentHasLinkedAcls = (current?.linkedAcls.length ?? 0) > 0;
+    const anyDirty = dirtyConfigs.size > 0;
+    const configsRef = useRef(configs);
+    const dirtyConfigsRef = useRef(dirtyConfigs);
+    const statsRequestIdRef = useRef(0);
+    const statesRequestIdRef = useRef(0);
+    const statesAbortRef = useRef<AbortController | null>(null);
+    const lastLoadedQueryKeyRef = useRef<string | null>(null);
+    const inFlightStatesQueryKeyRef = useRef<string | null>(null);
+    const stateGenerationRef = useRef<number | string | null>(null);
+    useUnsavedChangesBlocker(anyDirty);
+
+    useEffect(() => {
+        configsRef.current = configs;
+    }, [configs]);
+
+    useEffect(() => {
+        dirtyConfigsRef.current = dirtyConfigs;
+    }, [dirtyConfigs]);
+
+    useEffect(() => {
+        stateGenerationRef.current = stateGeneration;
+    }, [stateGeneration]);
+
+    const loadAll = useCallback(async (options?: { preserveDirty?: boolean; skipDirtyNames?: Set<string> }): Promise<void> => {
+        setLoading(true);
+        try {
+            const fwConfigsResp = await API.fwstate.listConfigs();
+            const fwNames = fwConfigsResp.configs ?? [];
+            const fwFull = await Promise.all(fwNames.map(async (name) => ({ name, config: await API.fwstate.showConfig({ name }) })));
+            const nextConfigs: Record<string, DraftConfig> = {};
+            fwFull.forEach(({ name, config }) => {
+                nextConfigs[name] = toDraftConfig(config, false);
+            });
+
+            if (options?.preserveDirty) {
+                const dirtySnapshot = dirtyConfigsRef.current;
+                const configSnapshot = configsRef.current;
+                const skipDirtyNames = options.skipDirtyNames ?? new Set<string>();
+                const preservedDirtyNames = new Set(
+                    Array.from(dirtySnapshot).filter((name) => !skipDirtyNames.has(name))
+                );
+                const mergedConfigs: Record<string, DraftConfig> = { ...nextConfigs };
+
+                Object.entries(configSnapshot).forEach(([name, draft]) => {
+                    if (preservedDirtyNames.has(name) || (draft.isLocalOnly && !nextConfigs[name] && !skipDirtyNames.has(name))) {
+                        mergedConfigs[name] = draft;
+                    }
+                });
+
+                setConfigs(mergedConfigs);
+                setDirtyConfigs(
+                    new Set(Array.from(preservedDirtyNames).filter((name) => Boolean(mergedConfigs[name])))
+                );
+                setActiveConfig((prev) => {
+                    if (prev && !skipDirtyNames.has(prev) && mergedConfigs[prev]) {
+                        return prev;
+                    }
+                    return Object.keys(mergedConfigs)[0] ?? '';
+                });
+            } else {
+                setConfigs(nextConfigs);
+                setDirtyConfigs(new Set());
+                setActiveConfig((prev) => {
+                    return prev && nextConfigs[prev] ? prev : Object.keys(nextConfigs)[0] ?? '';
+                });
+            }
+        } catch (err) {
+            toaster.error('fwstate-load', 'Failed to load FWState data', err);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    const loadAclMeta = useCallback(async (): Promise<void> => {
+        try {
+            const aclListResp = await API.acl.listConfigs();
+            const aclNames = aclListResp.configs ?? [];
+            const baseRows = aclNames.map((name) => ({
+                name,
+                fwstateName: '',
+                ruleCount: null,
+                isLoaded: false,
+                loadFailed: false,
+            }));
+            setAclMeta(baseRows);
+
+            const nextAclMeta = await Promise.all(
+                aclNames.map(async (name) => {
+                    try {
+                        const config = await API.acl.showConfig({ name });
+                        const rules = config.rules ?? [];
+                        return {
+                            name,
+                            fwstateName: config.fwstate_name ?? '',
+                            ruleCount: rules.length,
+                            isLoaded: true,
+                            loadFailed: false,
+                        };
+                    } catch {
+                        return {
+                            name,
+                            fwstateName: '',
+                            ruleCount: null,
+                            isLoaded: true,
+                            loadFailed: true,
+                        };
+                    }
+                })
+            );
+            setAclMeta(nextAclMeta);
+        } catch (err) {
+            toaster.error('fwstate-acl-load', 'Failed to load ACL metadata', err);
+            setAclMeta([]);
+        }
+    }, []);
+
+    useEffect(() => {
+        let mounted = true;
+        (async () => {
+            await loadAll();
+            if (!mounted) return;
+            await loadAclMeta();
+        })();
+        return () => {
+            mounted = false;
+        };
+    }, [loadAll, loadAclMeta]);
+
+    const resetStatesView = useCallback((options?: { clearLoading?: boolean }): void => {
+        statesAbortRef.current?.abort();
+        statesAbortRef.current = null;
+        statesRequestIdRef.current += 1;
+        inFlightStatesQueryKeyRef.current = null;
+        stateGenerationRef.current = null;
+        setStateRows([]);
+        setStateCursor(0);
+        setStateHasMore(true);
+        setStateGeneration(null);
+        if (options?.clearLoading) {
+            setStateLoading(false);
+        }
+    }, []);
+
+    const statesQueryKey = useMemo(() => {
+        return JSON.stringify({
+            currentName,
+            isIpv6: statesQuery.isIpv6,
+            layerIndex: statesQuery.layerIndex,
+            direction: statesQuery.direction,
+            includeExpired: statesQuery.includeExpired,
+        });
+    }, [currentName, statesQuery.direction, statesQuery.includeExpired, statesQuery.isIpv6, statesQuery.layerIndex]);
+
+    useEffect(() => {
+        resetStatesView({ clearLoading: true });
+    }, [resetStatesView, statesQueryKey]);
+
+    useEffect(() => {
+        return () => {
+            statesAbortRef.current?.abort();
+        };
+    }, []);
+
+    useEffect(() => {
+        const requestId = ++statsRequestIdRef.current;
+        setStats(null);
+        if (!currentName) return;
+        API.fwstate.getStats({ name: currentName })
+            .then((res) => {
+                if (statsRequestIdRef.current !== requestId) {
+                    return;
+                }
+                setStats({ ipv4: res.ipv4_stats, ipv6: res.ipv6_stats });
+            })
+            .catch((err) => {
+                if (statsRequestIdRef.current !== requestId) {
+                    return;
+                }
+                toaster.error('fwstate-stats', 'Failed to load FWState stats', err);
+            });
+    }, [currentName]);
+
+    const hasOtherDirtyConfigs = useCallback((name: string): boolean => {
+        return Array.from(dirtyConfigs).some((dirtyName) => dirtyName !== name);
+    }, [dirtyConfigs]);
+
+    const openLinkAclDialog = useCallback((aclName: string): void => {
+        const aclMetaItem = aclMeta.find((item) => item.name === aclName);
+        setPendingAclLink({
+            aclName,
+            linkedFwstateName: aclMetaItem?.fwstateName ? aclMetaItem.fwstateName : null,
+        });
+    }, [aclMeta]);
+
+    const handleLinkAcl = useCallback(async (aclName: string): Promise<void> => {
+        if (!currentName) return;
+        if (dirtyConfigs.has(currentName)) {
+            toaster.error('fwstate-dirty-link-current', 'Save or discard this config before linking ACLs.');
+            return;
+        }
+        if (hasOtherDirtyConfigs(currentName)) {
+            toaster.error('fwstate-dirty-link', 'Link blocked: there are unsaved changes in other configs.');
+            return;
+        }
+        const aclNames = new Set(current?.linkedAcls ?? []);
+        aclNames.add(aclName);
+        try {
+            await API.fwstate.linkFWState({ fwstate_name: currentName, acl_config_names: Array.from(aclNames) });
+            await Promise.all([
+                loadAll({ preserveDirty: true }),
+                loadAclMeta(),
+            ]);
+        } catch (err) {
+            toaster.error('fwstate-link-error', 'Failed to link ACL config', err);
+        }
+    }, [current?.linkedAcls, currentName, dirtyConfigs, hasOtherDirtyConfigs, loadAclMeta, loadAll]);
+
+    const confirmLinkAcl = useCallback(async (): Promise<void> => {
+        if (!pendingAclLink) return;
+        const aclName = pendingAclLink.aclName;
+        setPendingAclLink(null);
+        await handleLinkAcl(aclName);
+    }, [handleLinkAcl, pendingAclLink]);
+
+    useEffect(() => {
+        const isEditableTarget = (target: EventTarget | null): boolean => {
+            if (!(target instanceof HTMLElement)) return false;
+            const tagName = target.tagName.toLowerCase();
+            if (tagName === 'input' || tagName === 'textarea' || tagName === 'select') return true;
+            return target.isContentEditable;
+        };
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.defaultPrevented) return;
+            if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return;
+            if (isEditableTarget(event.target)) return;
+
+            const key = event.key.toLowerCase();
+            if (key === '4') {
+                event.preventDefault();
+                setStatesQuery((prev) => (prev.isIpv6 ? { ...prev, isIpv6: false } : prev));
+                return;
+            }
+            if (key === '6') {
+                event.preventDefault();
+                setStatesQuery((prev) => (prev.isIpv6 ? prev : { ...prev, isIpv6: true }));
+                return;
+            }
+            if (key === 'f') {
+                event.preventDefault();
+                setStatesQuery((prev) => (prev.direction === Direction.FORWARD ? prev : { ...prev, direction: Direction.FORWARD }));
+                return;
+            }
+            if (key === 'b') {
+                event.preventDefault();
+                setStatesQuery((prev) => (prev.direction === Direction.BACKWARD ? prev : { ...prev, direction: Direction.BACKWARD }));
+                return;
+            }
+            if (key === 'e') {
+                event.preventDefault();
+                setStatesQuery((prev) => ({ ...prev, includeExpired: !prev.includeExpired }));
+            }
+        };
+
+        document.addEventListener('keydown', onKeyDown);
+        return () => {
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [setStatesQuery]);
+
+    const counts = useMemo(() => {
+        const m = new Map<string, number>();
+        configNames.forEach((name) => {
+            m.set(name, configs[name]?.linkedAcls.length ?? 0);
+        });
+        return m;
+    }, [configNames, configs]);
+
+    const updateCurrent = (patch: Partial<DraftConfig>): void => {
+        if (!currentName) return;
+        setConfigs((prev) => ({ ...prev, [currentName]: { ...prev[currentName], ...patch } }));
+        setDirtyConfigs((prev) => new Set(prev).add(currentName));
+    };
+
+    const validateCurrent = (): boolean => {
+        if (!current) return false;
+        const durationFields = [current.tcpSynAck, current.tcpSyn, current.tcpFin, current.tcp, current.udp, current.defaultTimeout];
+        const useMulticast = current.syncMode === 'multicast' || current.syncMode === 'both';
+        const useUnicast = current.syncMode === 'unicast' || current.syncMode === 'both';
+        const multicastAddrValid = isValidNonzeroIPv6Address(current.dstAddrMulticast);
+        const unicastAddrValid = isValidNonzeroIPv6Address(current.dstAddrUnicast);
+        if (current.mapIndexSize < 0 || current.mapExtraBucketCount < 0) return false;
+        if (useMulticast && (current.portMulticast < 0 || current.portMulticast > 65535)) return false;
+        if (useUnicast && (current.portUnicast < 0 || current.portUnicast > 65535)) return false;
+        if (!isValidNonzeroIPv6Address(current.srcAddr)) return false;
+        if (useMulticast && (!multicastAddrValid || current.portMulticast === 0)) return false;
+        if (useUnicast && (!unicastAddrValid || current.portUnicast === 0)) return false;
+        if (!isValidNonzeroMAC(current.dstEther)) return false;
+        if (durationFields.some((value) => parseDurationToNs(value) === null)) return false;
+        return true;
+    };
+
+    const handleSave = async (): Promise<void> => {
+        if (!current) return;
+        if (hasOtherDirtyConfigs(currentName)) {
+            toaster.error('fwstate-dirty-save', 'Save blocked: there are unsaved changes in other configs.');
+            return;
+        }
+        if (!validateCurrent()) {
+            toaster.error('fwstate-validate', 'Invalid FWState form fields');
+            return;
+        }
+        const requestName = currentName;
+        const useMulticast = current.syncMode === 'multicast' || current.syncMode === 'both';
+        const useUnicast = current.syncMode === 'unicast' || current.syncMode === 'both';
+        const syncConfig = {
+            src_addr: stringToIPAddress(current.srcAddr),
+            dst_ether: parseMACToBytes(current.dstEther),
+            dst_addr_multicast: useMulticast ? stringToIPAddress(current.dstAddrMulticast) : zeroIPv6AddressWire(),
+            port_multicast: useMulticast ? current.portMulticast : 0,
+            dst_addr_unicast: useUnicast ? stringToIPAddress(current.dstAddrUnicast) : zeroIPv6AddressWire(),
+            port_unicast: useUnicast ? current.portUnicast : 0,
+            tcp_syn_ack: parseDurationToNs(current.tcpSynAck) ?? undefined,
+            tcp_syn: parseDurationToNs(current.tcpSyn) ?? undefined,
+            tcp_fin: parseDurationToNs(current.tcpFin) ?? undefined,
+            tcp: parseDurationToNs(current.tcp) ?? undefined,
+            udp: parseDurationToNs(current.udp) ?? undefined,
+            default: parseDurationToNs(current.defaultTimeout) ?? undefined,
+        };
+        try {
+            await API.fwstate.updateConfig({
+                name: requestName,
+                map_config: {
+                    index_size: current.mapIndexSize,
+                    extra_bucket_count: current.mapExtraBucketCount,
+                },
+                sync_config: syncConfig,
+            });
+            toaster.success('fwstate-save', `Config "${requestName}" saved.`);
+            setDirtyConfigs((prev) => {
+                const next = new Set(prev);
+                next.delete(currentName);
+                return next;
+            });
+            await loadAll({ preserveDirty: true, skipDirtyNames: new Set([currentName]) });
+            setActiveConfig(currentName);
+        } catch (err) {
+            toaster.error('fwstate-save-error', 'Failed to save FWState config', err);
+        }
+    };
+
+    const handleDeleteConfig = async (): Promise<void> => {
+        if (!currentName || (current?.linkedAcls.length ?? 0) > 0) return;
+        if (hasOtherDirtyConfigs(currentName)) {
+            toaster.error('fwstate-dirty-delete', 'Delete blocked: there are unsaved changes in other configs.');
+            return;
+        }
+        if (current?.isLocalOnly) {
+            setConfigs((prev) => {
+                const next = { ...prev };
+                delete next[currentName];
+                return next;
+            });
+            setDirtyConfigs((prev) => {
+                const next = new Set(prev);
+                next.delete(currentName);
+                return next;
+            });
+            const remainingNames = configNames.filter((name) => name !== currentName);
+            setActiveConfig(remainingNames[0] ?? '');
+            setDeleteConfigOpen(false);
+            return;
+        }
+        try {
+            await API.fwstate.deleteConfig({ name: currentName });
+            setDeleteConfigOpen(false);
+            await loadAll({ preserveDirty: true, skipDirtyNames: new Set([currentName]) });
+        } catch (err) {
+            toaster.error('fwstate-delete-error', 'Failed to delete FWState config', err);
+        }
+    };
+
+    const getStatesBatchSize = (): number => {
+        const containerHeight = statesScrollRef.current?.clientHeight ?? 0;
+        const estimatedRowHeight = 42;
+        const visibleRows = Math.max(10, Math.floor(containerHeight / estimatedRowHeight));
+        return Math.max(30, Math.min(500, visibleRows * 3));
+    };
+
+    const loadStatesPage = useCallback(async (reset: boolean): Promise<void> => {
+        if (!canLoadStates || !currentName) return;
+        if (stateLoading) return;
+        if (!reset && !stateHasMore) return;
+        statesAbortRef.current?.abort();
+        const abortController = new AbortController();
+        statesAbortRef.current = abortController;
+        const requestId = ++statesRequestIdRef.current;
+        setStateLoading(true);
+        const request: ListEntriesRequest = {
+            config_name: currentName,
+            is_ipv6: statesQuery.isIpv6,
+            layer_index: statesQuery.layerIndex,
+            include_expired: statesQuery.includeExpired,
+            direction: statesQuery.direction,
+            batch_size: getStatesBatchSize(),
+            index: reset
+                ? (statesQuery.direction === Direction.BACKWARD ? BACKWARD_RESET_CURSOR : 0)
+                : stateCursor,
+        };
+        let shouldMarkLoaded = true;
+        await new Promise<void>((resolve) => {
+            API.fwstate.listEntriesPage(request, {
+                onMessage: (res) => {
+                    if (statesRequestIdRef.current !== requestId) {
+                        resolve();
+                        return;
+                    }
+                    const generation = normalizeUnsignedInt(res.generation) ?? '0';
+                    if (stateGenerationRef.current !== null && generation !== stateGenerationRef.current) {
+                        shouldMarkLoaded = false;
+                        resetStatesView({ clearLoading: true });
+                        lastLoadedQueryKeyRef.current = null;
+                        inFlightStatesQueryKeyRef.current = null;
+                        toaster.warning('fwstate-generation', 'State generation changed. Reload from start.');
+                        resolve();
+                        return;
+                    }
+                    setStateGeneration(generation);
+                    const rows = res.entries ?? [];
+                    setStateRows((prev) => reset ? rows : [...prev, ...rows]);
+                    setStateCursor(normalizeUnsignedIntToNumber(res.index));
+                    setStateHasMore(Boolean(res.has_more));
+                    resolve();
+                },
+                onError: (err) => {
+                    if (abortController.signal.aborted || statesRequestIdRef.current !== requestId) {
+                        resolve();
+                        return;
+                    }
+                    lastLoadedQueryKeyRef.current = statesQueryKey;
+                    toaster.error('fwstate-entries', 'Failed to load FWState entries', err);
+                    resolve();
+                },
+                onEnd: () => resolve(),
+            }, abortController.signal);
+        });
+        if (statesRequestIdRef.current === requestId) {
+            statesAbortRef.current = null;
+            if (shouldMarkLoaded) {
+                lastLoadedQueryKeyRef.current = statesQueryKey;
+            }
+            inFlightStatesQueryKeyRef.current = null;
+            setStateLoading(false);
+        }
+    }, [
+        canLoadStates,
+        currentName,
+        resetStatesView,
+        stateCursor,
+        stateHasMore,
+        stateLoading,
+        statesQuery.direction,
+        statesQuery.includeExpired,
+        statesQuery.isIpv6,
+        statesQuery.layerIndex,
+        statesQueryKey,
+    ]);
+
+    const aclRows = useMemo(() => aclMeta.map((row) => ({ ...row, isLinkedHere: row.fwstateName === currentName })), [aclMeta, currentName]);
+
+    const statsRows = useMemo(() => {
+        const row = (label: string, getter: (s: MapStats | undefined) => string | number) => ({
+            label,
+            ipv4: getter(stats?.ipv4),
+            ipv6: getter(stats?.ipv6),
+        });
+        return [
+            row('Index slots', (s) => s?.index_size ?? '-'),
+            row('Overflow buckets', (s) => s?.extra_bucket_count ?? '-'),
+            row('Max chain', (s) => s?.max_chain_length ?? '-'),
+            row('Layers', (s) => s?.layer_count ?? '-'),
+            row('State entries', (s) => s?.total_elements ?? '-'),
+            row('Max deadline', (s) => s?.max_deadline ?? '-'),
+            row('Memory used', (s) => s?.memory_used ?? '-'),
+        ];
+    }, [stats]);
+
+    const statsNote = stats?.ipv4?.note || stats?.ipv6?.note || '';
+
+    const aclLinkDialogTitle = pendingAclLink
+        ? pendingAclLink.linkedFwstateName && pendingAclLink.linkedFwstateName !== currentName
+            ? 'Move ACL config'
+            : 'Link ACL config'
+        : '';
+    const aclLinkDialogMessage = pendingAclLink
+        ? pendingAclLink.linkedFwstateName && pendingAclLink.linkedFwstateName !== currentName
+            ? `Move ACL "${pendingAclLink.aclName}" from "${pendingAclLink.linkedFwstateName}" to "${currentName}".`
+            : `Link ACL "${pendingAclLink.aclName}" to FWState "${currentName}".`
+        : '';
+
+    useEffect(() => {
+        if (!canLoadStates || !currentName || stateLoading) {
+            return;
+        }
+        if (lastLoadedQueryKeyRef.current === statesQueryKey) {
+            return;
+        }
+        if (inFlightStatesQueryKeyRef.current === statesQueryKey) {
+            return;
+        }
+        inFlightStatesQueryKeyRef.current = statesQueryKey;
+        void loadStatesPage(true);
+    }, [canLoadStates, currentName, loadStatesPage, stateLoading, statesQueryKey]);
+
+    useEffect(() => {
+        if (canLoadStates) {
+            return;
+        }
+        resetStatesView({ clearLoading: true });
+    }, [canLoadStates, resetStatesView]);
+
+    const handleStatesScroll = useCallback(() => {
+        const container = statesScrollRef.current;
+        if (!container || stateLoading || !stateHasMore || !canLoadStates || !currentName || stateRows.length === 0) {
+            return;
+        }
+        const threshold = 120;
+        if (container.scrollTop + container.clientHeight >= container.scrollHeight - threshold) {
+            void loadStatesPage(false);
+        }
+    }, [canLoadStates, currentName, stateHasMore, stateLoading, stateRows.length, stateCursor, stateGeneration, statesQuery.direction, statesQuery.includeExpired, statesQuery.isIpv6, statesQuery.layerIndex]);
+
+    const stateColumns = [
+        { id: 'idx', name: 'IDX', template: (item: FwStateEntry) => <span className="fwstate-mono">{formatStateIdx(item.idx)}</span> },
+        { id: 'source', name: 'SOURCE', template: (item: FwStateEntry) => renderIpChip(item.key?.src_addr as IPAddressWire | undefined) },
+        { id: 'destination', name: 'DESTINATION', template: (item: FwStateEntry) => renderIpChip(item.key?.dst_addr as IPAddressWire | undefined) },
+        {
+            id: 'proto',
+            name: 'PROTO',
+            template: (item: FwStateEntry) => <ProtocolNumberChip proto={item.key?.proto} />,
+        },
+        {
+            id: 'src_flags',
+            name: 'SRC FLAGS',
+            template: (item: FwStateEntry) => renderFlagChips(decodeFlags(item.value?.flags).source),
+        },
+        {
+            id: 'dst_flags',
+            name: 'DST FLAGS',
+            template: (item: FwStateEntry) => renderFlagChips(decodeFlags(item.value?.flags).destination),
+        },
+        { id: 'origin', name: 'ORIGIN', template: (item: FwStateEntry) => <span className="fwstate-table-cell">{item.value?.external ? 'external' : 'local'}</span> },
+        { id: 'packets_forward', name: 'PACKETS FWD', template: (item: FwStateEntry) => <span className="fwstate-mono">{formatUnsignedCount(item.value?.packets_forward)}</span> },
+        { id: 'packets_backward', name: 'PACKETS BACKWARD', template: (item: FwStateEntry) => <span className="fwstate-mono">{formatUnsignedCount(item.value?.packets_backward)}</span> },
+        { id: 'updated', name: 'UPDATED', template: (item: FwStateEntry) => <span className="fwstate-mono fwstate-updated">{formatNsUtc(item.value?.updated_at)}</span> },
+        {
+            id: 'expired',
+            name: 'EXPIRED',
+            template: (item: FwStateEntry) => (
+                <span className={`fwstate-expired-pill ${item.expired ? 'fwstate-expired-pill--expired' : 'fwstate-expired-pill--active'}`}>
+                    {item.expired ? 'Expired' : 'Active'}
+                </span>
+            ),
+        },
+    ];
+
+    const pageHeader = (
+        <Flex alignItems="center" gap={3} style={{ width: '100%' }}>
+            <Text variant="header-1">FWState</Text>
+            <Flex grow />
+            <Button view="action" onClick={() => setAddConfigOpen(true)}>
+                <Icon data={Plus} size={16} />
+                Add Config
+            </Button>
+        </Flex>
+    );
+
+    if (loading) {
+        return <PageLayout header={pageHeader}><PageLoader loading size="l" /></PageLayout>;
+    }
+
+    return (
+        <PageLayout header={pageHeader}>
+            <div className="fw-page">
+                {configNames.length === 0 ? (
+                    <div className="fw-empty-page">
+                        <div className="fw-empty-page__message">No FWState configurations found.</div>
+                        <Button view="action" onClick={() => setAddConfigOpen(true)}>Add Config</Button>
+                    </div>
+                ) : (
+                    <>
+                        <div className="fwstate-config-bar">
+                            <div className="fwstate-config-bar__tabs">
+                                <ConfigTabStrip
+                                    configs={configNames}
+                                    activeConfig={currentName}
+                                    counts={counts}
+                                    dirtyConfigs={dirtyConfigs}
+                                    onSelect={setActiveConfig}
+                                    onAddConfig={() => setAddConfigOpen(true)}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="fw-content fwstate-content">
+                            {current && (
+                                (() => {
+                                    const useMulticast = current.syncMode === 'multicast' || current.syncMode === 'both';
+                                    const useUnicast = current.syncMode === 'unicast' || current.syncMode === 'both';
+                                    const multicastAddrError = !useMulticast
+                                        ? undefined
+                                        : !isValidNonzeroIPv6Address(current.dstAddrMulticast)
+                                            ? 'Non-zero IPv6 required'
+                                            : undefined;
+                                    const multicastPortError = !useMulticast
+                                        ? undefined
+                                        : current.portMulticast < 0 || current.portMulticast > 65535
+                                            ? '0..65535'
+                                            : current.portMulticast === 0
+                                                ? 'Port required'
+                                                : undefined;
+                                    const unicastAddrError = !useUnicast
+                                        ? undefined
+                                        : !isValidNonzeroIPv6Address(current.dstAddrUnicast)
+                                            ? 'Non-zero IPv6 required'
+                                            : undefined;
+                                    const unicastPortError = !useUnicast
+                                        ? undefined
+                                        : current.portUnicast < 0 || current.portUnicast > 65535
+                                            ? '0..65535'
+                                            : current.portUnicast === 0
+                                                ? 'Port required'
+                                                : undefined;
+
+                                    return (
+                                        <div className="fwstate-settings-layout">
+                                            <div className="fwstate-panel fwstate-states-table-panel">
+                                                <div className="fwstate-panel-head">
+                                                    <Text variant="subheader-2">States</Text>
+                                                </div>
+                                                <div className="fwstate-states-toolbar">
+                                                    <div className="fwstate-states-toolbar__control fwstate-states-toolbar__control--field fwstate-states-toolbar__control--field-family">
+                                                        <Text className="fwstate-states-toolbar__label">Address family</Text>
+                                                            <div className="fwstate-states-toolbar__family">
+                                                                <Button
+                                                                    view="outlined"
+                                                                    size="s"
+                                                                    className={`fwstate-states-toolbar__family-btn${statesQuery.isIpv6 ? ' fwstate-states-toolbar__family-btn--active' : ''}`}
+                                                                    onClick={() => setStatesQuery((prev) => ({ ...prev, isIpv6: true }))}
+                                                                    title="IPv6 (6)"
+                                                                >
+                                                                    IPv6
+                                                                </Button>
+                                                                <Button
+                                                                    view="outlined"
+                                                                    size="s"
+                                                                    className={`fwstate-states-toolbar__family-btn${statesQuery.isIpv6 ? '' : ' fwstate-states-toolbar__family-btn--active'}`}
+                                                                    onClick={() => setStatesQuery((prev) => ({ ...prev, isIpv6: false }))}
+                                                                    title="IPv4 (4)"
+                                                                >
+                                                                    IPv4
+                                                                </Button>
+                                                            </div>
+                                                        </div>
+                                                    <div className="fwstate-states-toolbar__control fwstate-states-toolbar__control--field fwstate-states-toolbar__control--field-direction">
+                                                        <Text className="fwstate-states-toolbar__label">Direction</Text>
+                                                        <div title="Direction (f/b)">
+                                                            <Select
+                                                                value={[String(statesQuery.direction)]}
+                                                                onUpdate={(v) => setStatesQuery((prev) => ({ ...prev, direction: Number(v[0] ?? 0) as Direction }))}
+                                                                options={[{ value: String(Direction.FORWARD), content: 'forward' }, { value: String(Direction.BACKWARD), content: 'backward' }]}
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                    <div className="fwstate-states-toolbar__control fwstate-states-toolbar__control--switch">
+                                                        <Text className="fwstate-states-toolbar__label">Include expired</Text>
+                                                        <div title="Include expired (e)">
+                                                            <Switch checked={statesQuery.includeExpired} onUpdate={(includeExpired) => setStatesQuery((prev) => ({ ...prev, includeExpired }))} />
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <details className="fwstate-states-advanced-details">
+                                                    <summary className="fwstate-states-advanced-details__summary">
+                                                        <Text variant="caption-2" color="secondary">Advanced filters</Text>
+                                                    </summary>
+                                                    <div className="fwstate-states-advanced-details__content">
+                                                        <div className="fwstate-states-toolbar__control fwstate-states-toolbar__control--field fwstate-states-toolbar__control--field-layer">
+                                                            <Text className="fwstate-states-toolbar__label">State layer</Text>
+                                                            <div title="State layer (0 = active layer)">
+                                                                <TextInput
+                                                                    type="number"
+                                                                    value={String(statesQuery.layerIndex)}
+                                                                    onUpdate={(v) => setStatesQuery((prev) => ({ ...prev, layerIndex: Math.max(0, Number(v) || 0) }))}
+                                                                />
+                                                            </div>
+                                                            <Text className="fwstate-states-toolbar__hint">0 = active layer</Text>
+                                                        </div>
+                                                    </div>
+                                                </details>
+                                                <div className="fwstate-table-shell fwstate-table-shell--scroll" ref={statesScrollRef} onScroll={handleStatesScroll}>
+                                                    <div className="fwstate-states-table-content">
+                                                        <Table data={stateRows} columns={stateColumns} emptyMessage="" />
+                                                    </div>
+                                                    {!stateLoading && stateRows.length === 0 && <div className="fwstate-states-empty-overlay">No data</div>}
+                                                </div>
+                                                <div className="fwstate-states-footer">
+                                                    <Text className="fwstate-states-footer__text">{stateLoading ? 'Loading…' : `Shown ${stateRows.length} rows`}</Text>
+                                                    <Text className="fwstate-states-footer__text fwstate-states-footer__text--secondary">
+                                                        {stateLoading || stateRows.length === 0 || stateHasMore ? '\u00a0' : 'End of entries.'}
+                                                    </Text>
+                                                </div>
+                                            </div>
+
+                                            <div className="fwstate-operational-secondary">
+                                                <div className="fwstate-panel fwstate-acl-panel">
+                                                    <div className="fwstate-panel-head fwstate-panel-head--split">
+                                                        <Text variant="subheader-2">ACL links</Text>
+                                                        <Button view="flat" size="s" onClick={() => navigate('/modules/acl')}>Open ACL module</Button>
+                                                    </div>
+                                                    <div className="fwstate-table-shell fwstate-acl-table-shell">
+                                                        <Table
+                                                            data={aclRows}
+                                                            columns={[
+                                                                { id: 'name', name: 'ACL config', template: (row) => <span className="fwstate-table-cell">{row.name}</span> },
+                                                                { id: 'fwstate', name: 'Current FWState', template: (row) => row.fwstateName ? <Label theme={row.isLinkedHere ? 'success' : 'warning'} size="s">{row.fwstateName}</Label> : <Label theme="unknown" size="s">{row.isLoaded ? 'unlinked' : 'Loading…'}</Label> },
+                                                                { id: 'rules', name: 'Rules', template: (row) => <span className="fwstate-mono">{row.ruleCount === null ? (row.isLoaded ? (row.loadFailed ? '—' : 'Loading…') : 'Loading…') : row.ruleCount}</span> },
+                                                                {
+                                                                    id: 'action',
+                                                                    name: 'Action',
+                                                                    template: (row) => {
+                                                                        if (row.isLinkedHere) {
+                                                                            return <Label theme="success" size="s">Linked</Label>;
+                                                                        }
+                                                                        if (!row.isLoaded) {
+                                                                            return (
+                                                                                <Button size="s" view="outlined" disabled>
+                                                                                    Loading…
+                                                                                </Button>
+                                                                            );
+                                                                        }
+                                                                        if (row.loadFailed) {
+                                                                            return (
+                                                                                <Text color="secondary" className="fwstate-table-cell">
+                                                                                    Unavailable
+                                                                                </Text>
+                                                                            );
+                                                                        }
+                                                                        return (
+                                                                            <Button
+                                                                                size="s"
+                                                                                view="outlined"
+                                                                                className="fwstate-acl-link-btn"
+                                                                                onClick={() => openLinkAclDialog(row.name)}
+                                                                            >
+                                                                                {row.fwstateName ? 'Move here' : 'Link'}
+                                                                            </Button>
+                                                                        );
+                                                                    },
+                                                                },
+                                                            ]}
+                                                        />
+                                                    </div>
+                                                </div>
+
+                                                <div className="fwstate-panel">
+                                                    <div className="fwstate-panel-head">
+                                                        <Text variant="subheader-2">State map stats</Text>
+                                                    </div>
+                                                    <div className="fwstate-stats-compare">
+                                                        <div className="fwstate-stats-compare__head">Metric</div>
+                                                        <div className="fwstate-stats-compare__head">IPv4</div>
+                                                        <div className="fwstate-stats-compare__head">IPv6</div>
+                                                        {statsRows.map((row) => (
+                                                            <React.Fragment key={row.label}>
+                                                                <div className="fwstate-stats-compare__metric">{row.label}</div>
+                                                                <div className="fwstate-stats-compare__value fwstate-mono">{row.ipv4}</div>
+                                                                <div className="fwstate-stats-compare__value fwstate-mono">{row.ipv6}</div>
+                                                            </React.Fragment>
+                                                        ))}
+                                                    </div>
+                                                    {statsNote && (
+                                                        <Text className="fwstate-stats-note" color="secondary">
+                                                            {statsNote}
+                                                        </Text>
+                                                    )}
+                                                </div>
+                                            </div>
+                                            <details className="fwstate-config-details">
+                                                <summary className="fwstate-config-details__summary">
+                                                    <div className="fwstate-config-details__summary-inner">
+                                                        <Text variant="subheader-2">Configuration</Text>
+                                                        <div className="fwstate-config-details__summary-actions">
+                                                            <button
+                                                                type="button"
+                                                                className="fw-tbl-action-btn fw-tbl-action-btn--save"
+                                                                title="Save config"
+                                                                aria-label="Save config"
+                                                                disabled={!currentIsDirty}
+                                                                onClick={(event) => {
+                                                                    event.preventDefault();
+                                                                    event.stopPropagation();
+                                                                    handleSave();
+                                                                }}
+                                                            >
+                                                                <SaveIcon />
+                                                            </button>
+                                                            <button
+                                                                type="button"
+                                                                className="fw-tbl-action-btn fw-tbl-action-btn--delete"
+                                                                title="Delete config"
+                                                                aria-label="Delete config"
+                                                                disabled={!current || currentHasLinkedAcls}
+                                                                onClick={(event) => {
+                                                                    event.preventDefault();
+                                                                    event.stopPropagation();
+                                                                    setDeleteConfigOpen(true);
+                                                                }}
+                                                            >
+                                                                <TrashIcon />
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </summary>
+                                                <div className="fwstate-config-details__content">
+                                                    <div className="fwstate-settings-top-row">
+                                                        <div className="fwstate-config-section">
+                                                            <div className="fwstate-config-section__head">
+                                                                <Text variant="subheader-2">Map sizing</Text>
+                                                            </div>
+                                                            <div className="fwstate-field-grid fwstate-field-grid--map">
+                                                                <label className="fwstate-field">
+                                                                    <Text variant="caption-2" color="secondary">Hash index slots</Text>
+                                                                    <TextInput type="number" value={String(current.mapIndexSize)} onUpdate={(v) => updateCurrent({ mapIndexSize: Number(v) })} />
+                                                                </label>
+                                                                <label className="fwstate-field">
+                                                                    <Text variant="caption-2" color="secondary">Overflow buckets</Text>
+                                                                    <TextInput type="number" value={String(current.mapExtraBucketCount)} onUpdate={(v) => updateCurrent({ mapExtraBucketCount: Number(v) })} />
+                                                                </label>
+                                                            </div>
+                                                        </div>
+
+                                                        <div className="fwstate-config-section">
+                                                            <div className="fwstate-config-section__head">
+                                                                <Text variant="subheader-2">Sync endpoints</Text>
+                                                            </div>
+                                                            <div className="fwstate-sync-grid">
+                                                                <label className="fwstate-field fwstate-sync-grid__src">
+                                                                    <Text variant="caption-2" color="secondary">Sync source address</Text>
+                                                                    <TextInput value={current.srcAddr} onUpdate={(srcAddr) => updateCurrent({ srcAddr })} error={!isValidNonzeroIPv6Address(current.srcAddr) ? 'Non-zero IPv6 required' : undefined} placeholder="2001:db8::1" />
+                                                                </label>
+                                                                <label className="fwstate-field fwstate-sync-grid__mac">
+                                                                    <Text variant="caption-2" color="secondary">Destination MAC</Text>
+                                                                    <TextInput value={current.dstEther} onUpdate={(dstEther) => updateCurrent({ dstEther })} error={!isValidNonzeroMAC(current.dstEther) ? 'Non-zero MAC required' : undefined} placeholder="aa:bb:cc:dd:ee:ff" />
+                                                                </label>
+                                                                <label className="fwstate-field fwstate-sync-grid__mode">
+                                                                    <Text variant="caption-2" color="secondary">Endpoint mode</Text>
+                                                                    <Select
+                                                                        value={[current.syncMode]}
+                                                                        options={[
+                                                                            { value: 'multicast', content: 'Multicast' },
+                                                                            { value: 'unicast', content: 'Unicast' },
+                                                                            { value: 'both', content: 'Both' },
+                                                                        ]}
+                                                                        onUpdate={(value) => updateCurrent({ syncMode: (value[0] as DraftConfig['syncMode']) || 'multicast' })}
+                                                                    />
+                                                                </label>
+                                                                {useMulticast && (
+                                                                    <div className="fwstate-sync-grid__endpoint">
+                                                                        <div className="fwstate-field">
+                                                                            <Text variant="caption-2" color="secondary">Multicast endpoint</Text>
+                                                                            <div className="fwstate-endpoint-row">
+                                                                                <label className="fwstate-field">
+                                                                                    <Text variant="caption-2" color="secondary">Address</Text>
+                                                                                    <TextInput value={current.dstAddrMulticast} onUpdate={(dstAddrMulticast) => updateCurrent({ dstAddrMulticast })} error={multicastAddrError} placeholder="ff02::1" />
+                                                                                </label>
+                                                                                <label className="fwstate-field">
+                                                                                    <Text variant="caption-2" color="secondary">Port</Text>
+                                                                                    <TextInput type="number" value={String(current.portMulticast)} onUpdate={(v) => updateCurrent({ portMulticast: Number(v) })} error={multicastPortError} placeholder="2000" />
+                                                                                </label>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                )}
+                                                                {useUnicast && (
+                                                                    <div className="fwstate-sync-grid__endpoint">
+                                                                        <div className="fwstate-field">
+                                                                            <Text variant="caption-2" color="secondary">Unicast endpoint</Text>
+                                                                            <div className="fwstate-endpoint-row">
+                                                                                <label className="fwstate-field">
+                                                                                    <Text variant="caption-2" color="secondary">Address</Text>
+                                                                                    <TextInput value={current.dstAddrUnicast} onUpdate={(dstAddrUnicast) => updateCurrent({ dstAddrUnicast })} error={unicastAddrError} placeholder="2001:db8::2" />
+                                                                                </label>
+                                                                                <label className="fwstate-field">
+                                                                                    <Text variant="caption-2" color="secondary">Port</Text>
+                                                                                    <TextInput type="number" value={String(current.portUnicast)} onUpdate={(v) => updateCurrent({ portUnicast: Number(v) })} error={unicastPortError} placeholder="2000" />
+                                                                                </label>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        </div>
+                                                    </div>
+
+                                                        <div className="fwstate-config-section">
+                                                            <div className="fwstate-config-section__head">
+                                                                <Text variant="subheader-2">Timeouts</Text>
+                                                            </div>
+                                                            <div className="fwstate-field-grid fwstate-field-grid--timeouts">
+                                                            <label className="fwstate-field">
+                                                                <Text variant="caption-2" color="secondary">TCP SYN+ACK</Text>
+                                                                <TextInput
+                                                                    type="number"
+                                                                    value={current.tcpSynAck}
+                                                                    onUpdate={(tcpSynAck) => updateCurrent({ tcpSynAck })}
+                                                                    error={parseDurationToNs(current.tcpSynAck) ? undefined : 'Enter seconds'}
+                                                                    endContent={<Text className="fwstate-timeout-unit" variant="caption-2" color="secondary">s</Text>}
+                                                                />
+                                                            </label>
+                                                            <label className="fwstate-field">
+                                                                <Text variant="caption-2" color="secondary">TCP SYN</Text>
+                                                                <TextInput
+                                                                    type="number"
+                                                                    value={current.tcpSyn}
+                                                                    onUpdate={(tcpSyn) => updateCurrent({ tcpSyn })}
+                                                                    error={parseDurationToNs(current.tcpSyn) ? undefined : 'Enter seconds'}
+                                                                    endContent={<Text className="fwstate-timeout-unit" variant="caption-2" color="secondary">s</Text>}
+                                                                />
+                                                            </label>
+                                                            <label className="fwstate-field">
+                                                                <Text variant="caption-2" color="secondary">TCP FIN</Text>
+                                                                <TextInput
+                                                                    type="number"
+                                                                    value={current.tcpFin}
+                                                                    onUpdate={(tcpFin) => updateCurrent({ tcpFin })}
+                                                                    error={parseDurationToNs(current.tcpFin) ? undefined : 'Enter seconds'}
+                                                                    endContent={<Text className="fwstate-timeout-unit" variant="caption-2" color="secondary">s</Text>}
+                                                                />
+                                                            </label>
+                                                            <label className="fwstate-field">
+                                                                <Text variant="caption-2" color="secondary">TCP established</Text>
+                                                                <TextInput
+                                                                    type="number"
+                                                                    value={current.tcp}
+                                                                    onUpdate={(tcp) => updateCurrent({ tcp })}
+                                                                    error={parseDurationToNs(current.tcp) ? undefined : 'Enter seconds'}
+                                                                    endContent={<Text className="fwstate-timeout-unit" variant="caption-2" color="secondary">s</Text>}
+                                                                />
+                                                            </label>
+                                                            <label className="fwstate-field">
+                                                                <Text variant="caption-2" color="secondary">UDP</Text>
+                                                                <TextInput
+                                                                    type="number"
+                                                                    value={current.udp}
+                                                                    onUpdate={(udp) => updateCurrent({ udp })}
+                                                                    error={parseDurationToNs(current.udp) ? undefined : 'Enter seconds'}
+                                                                    endContent={<Text className="fwstate-timeout-unit" variant="caption-2" color="secondary">s</Text>}
+                                                                />
+                                                            </label>
+                                                            <label className="fwstate-field">
+                                                                <Text variant="caption-2" color="secondary">Default</Text>
+                                                                <TextInput
+                                                                    type="number"
+                                                                    value={current.defaultTimeout}
+                                                                    onUpdate={(defaultTimeout) => updateCurrent({ defaultTimeout })}
+                                                                    error={parseDurationToNs(current.defaultTimeout) ? undefined : 'Enter seconds'}
+                                                                    endContent={<Text className="fwstate-timeout-unit" variant="caption-2" color="secondary">s</Text>}
+                                                                />
+                                                            </label>
+                                                        </div>
+                                                    </div>
+                                                    </div>
+                                            </details>
+                                        </div>
+                                    );
+                                })()
+                            )}
+                        </div>
+                    </>
+                )}
+            </div>
+
+            <AddConfigModal
+                open={addConfigOpen}
+                onClose={() => setAddConfigOpen(false)}
+                placeholder="e.g. fwstate0"
+                existingNames={configNames}
+                onCreate={(name) => {
+                    setConfigs((prev) => ({ ...prev, [name]: toDraftConfig(null, true) }));
+                    setDirtyConfigs((prev) => new Set(prev).add(name));
+                    setActiveConfig(name);
+                    setAddConfigOpen(false);
+                }}
+            />
+
+            <DeleteConfigModal
+                open={deleteConfigOpen}
+                configName={currentName}
+                onClose={() => setDeleteConfigOpen(false)}
+                onConfirm={handleDeleteConfig}
+            />
+
+            <ConfirmDialog
+                open={pendingAclLink !== null}
+                onClose={() => setPendingAclLink(null)}
+                onConfirm={confirmLinkAcl}
+                title={aclLinkDialogTitle}
+                message={aclLinkDialogMessage}
+                secondaryMessage={pendingAclLink?.linkedFwstateName && pendingAclLink.linkedFwstateName !== currentName
+                    ? `This will detach ACL "${pendingAclLink.aclName}" from FWState "${pendingAclLink.linkedFwstateName}".`
+                    : undefined}
+                confirmText={pendingAclLink?.linkedFwstateName && pendingAclLink.linkedFwstateName !== currentName ? 'Move here' : 'Link'}
+                cancelText="Cancel"
+            />
+
+        </PageLayout>
+    );
+};
+
+export default FWStatePage;

--- a/web/src/pages/modules/fwstate/fwstate.scss
+++ b/web/src/pages/modules/fwstate/fwstate.scss
@@ -1,0 +1,732 @@
+.fwstate-content {
+    gap: 12px;
+    overflow: auto;
+    min-height: 0;
+}
+
+.fwstate-settings-layout,
+.fwstate-states-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    min-height: 0;
+}
+
+.fwstate-operational-secondary {
+    display: grid;
+    grid-template-columns: minmax(0, 1.7fr) minmax(300px, 1fr);
+    gap: 14px;
+    min-height: 0;
+}
+
+.fwstate-settings-top-row {
+    display: grid;
+    grid-template-columns: minmax(360px, 440px) minmax(0, 1fr);
+    gap: 14px;
+    align-items: start;
+}
+
+.fwstate-config-details {
+    border: 1px solid var(--fw-line-2);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--fw-panel) 82%, var(--fw-bg-2) 18%);
+}
+
+.fwstate-config-details__summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 12px 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    border-bottom: 1px solid transparent;
+    min-height: 44px;
+    transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.fwstate-config-details__summary-inner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.fwstate-config-details__summary:hover {
+    background: color-mix(in srgb, var(--fw-panel) 88%, var(--fw-bg-2) 12%);
+}
+
+.fwstate-config-details__summary:focus-visible {
+    outline: none;
+    box-shadow: inset 0 0 0 1px var(--fw-accent);
+    background: color-mix(in srgb, var(--fw-panel) 88%, var(--fw-bg-2) 12%);
+}
+
+.fwstate-config-details__summary::before {
+    content: '';
+    width: 8px;
+    height: 8px;
+    border-right: 2px solid var(--fw-text-3);
+    border-bottom: 2px solid var(--fw-text-3);
+    transform: rotate(-45deg);
+    transition: transform 0.18s ease;
+    flex-shrink: 0;
+    margin-right: 2px;
+}
+
+.fwstate-config-details[open] .fwstate-config-details__summary::before {
+    transform: rotate(45deg);
+}
+
+.fwstate-config-details__summary-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+    flex-shrink: 0;
+}
+
+.fwstate-config-details__summary:hover::before {
+    border-color: var(--fw-text-2);
+}
+
+.fwstate-config-details__summary::-webkit-details-marker {
+    display: none;
+}
+
+.fwstate-config-details__content {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 0 12px 12px;
+}
+
+.fwstate-config-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 2px 0 0;
+}
+
+.fwstate-config-section__head {
+    padding-bottom: 7px;
+    border-bottom: 1px solid color-mix(in srgb, var(--fw-line-2) 72%, transparent);
+}
+
+.fwstate-timeout-unit {
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    color: var(--fw-text-3);
+    font-size: 12px;
+    letter-spacing: 0.02em;
+    margin-inline-end: 1px;
+    margin-inline-start: 2px;
+}
+
+.fwstate-panel {
+    border: 1px solid var(--fw-line-2);
+    border-radius: 8px;
+    background: var(--fw-panel);
+    padding: 14px;
+}
+
+.fwstate-panel-head {
+    display: flex;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.fwstate-panel-head--split {
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.fwstate-config-bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.fwstate-config-bar__tabs {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.fwstate-field-grid {
+    display: grid;
+    gap: 12px;
+}
+
+.fwstate-field-grid--map {
+    grid-template-columns: 1fr;
+}
+
+.fwstate-field-grid--timeouts {
+    grid-template-columns: repeat(6, minmax(160px, 1fr));
+}
+
+.fwstate-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+}
+
+.fwstate-sync-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(180px, 1fr));
+    gap: 10px;
+}
+
+.fwstate-sync-grid__src,
+.fwstate-sync-grid__mac,
+.fwstate-sync-grid__mode {
+    grid-column: span 1;
+}
+
+.fwstate-sync-grid__endpoint {
+    grid-column: span 3;
+}
+
+.fwstate-endpoint-row {
+    display: grid;
+    grid-template-columns: minmax(320px, 1fr) minmax(130px, 180px);
+    gap: 10px;
+    align-items: start;
+}
+
+.fwstate-acl-panel {
+    min-height: 0;
+}
+
+.fwstate-table-shell {
+    border: 1px solid var(--fw-line-2);
+    border-radius: 8px;
+    overflow: hidden;
+    background: color-mix(in srgb, var(--fw-panel) 70%, var(--fw-bg-2) 30%);
+}
+
+.fwstate-table-shell .g-table,
+.fwstate-table-shell table {
+    width: 100%;
+    min-width: 100%;
+}
+
+.fwstate-table-shell .g-table thead th,
+.fwstate-table-shell .g-table th,
+.fwstate-table-shell table thead th,
+.fwstate-table-shell table th,
+.fwstate-table-shell .g-table__th {
+    font-size: 10.5px;
+    font-weight: 500;
+    color: var(--fw-text-3);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    line-height: 1.35;
+    border-bottom: 1px solid var(--fw-line-2);
+}
+
+.fwstate-table-shell .g-table td,
+.fwstate-table-shell .g-table__td,
+.fwstate-table-shell table td {
+    font-size: 12.5px;
+    color: var(--fw-text-2);
+    line-height: 1.35;
+    border-bottom: 1px solid var(--fw-line);
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
+.fwstate-acl-table-shell .g-table,
+.fwstate-acl-table-shell table {
+    width: 100%;
+}
+
+.fwstate-acl-table-shell {
+    overflow-x: auto;
+    overflow-y: auto;
+    max-height: 320px;
+}
+
+.fwstate-acl-link-btn {
+    --g-button-border-width: 0px;
+    --g-button-border-color: transparent;
+    --g-button-text-color: color-mix(in srgb, var(--fw-text-2) 88%, var(--fw-accent) 12%);
+    --g-button-background-color: color-mix(in srgb, var(--fw-bg-2) 86%, var(--fw-panel) 14%);
+    --g-button-background-color-hover: color-mix(in srgb, var(--fw-bg-2) 76%, var(--fw-panel) 24%);
+    border: 1px solid color-mix(in srgb, var(--fw-accent) 55%, transparent);
+    border-radius: var(--g-button-border-radius, var(--g-border-radius-s));
+    position: relative;
+    transition: color 0.15s ease;
+    box-sizing: border-box;
+}
+
+.fwstate-acl-link-btn::before {
+    border-width: 0;
+}
+
+.fwstate-acl-link-btn:hover {
+    --g-button-text-color: color-mix(in srgb, var(--fw-text) 92%, var(--fw-accent) 8%);
+    border-color: color-mix(in srgb, var(--fw-accent) 75%, transparent);
+}
+
+.fwstate-acl-link-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--fw-accent) 55%, transparent);
+}
+
+.fwstate-acl-link-btn.g-button:focus-visible::before {
+    border-color: var(--fw-accent);
+}
+
+.fwstate-table-shell--scroll {
+    position: relative;
+    overflow-x: auto;
+    overflow-y: auto;
+    height: clamp(380px, 58vh, 640px);
+}
+
+.fwstate-states-table-content {
+    position: relative;
+    min-width: 1400px;
+}
+
+.fwstate-states-table-content .g-table,
+.fwstate-states-table-content table {
+    overflow: visible;
+    width: 100%;
+    min-width: 100%;
+}
+
+.fwstate-states-table-content .g-table__thead,
+.fwstate-states-table-content .g-table__thead .g-table__row,
+.fwstate-states-table-content .g-table thead,
+.fwstate-states-table-content .g-table thead tr,
+.fwstate-states-table-content table thead,
+.fwstate-states-table-content table thead tr {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background: color-mix(in srgb, var(--fw-panel) 82%, var(--fw-bg-2) 18%);
+}
+
+.fwstate-states-table-content .g-table__th,
+.fwstate-states-table-content .g-table thead th,
+.fwstate-states-table-content table thead th {
+    position: sticky;
+    top: 0;
+    z-index: 4;
+    background: color-mix(in srgb, var(--fw-panel) 82%, var(--fw-bg-2) 18%);
+}
+
+.fwstate-stats-compare {
+    display: grid;
+    grid-template-columns: minmax(160px, 1.4fr) minmax(88px, 0.8fr) minmax(88px, 0.8fr);
+    border: 1px solid var(--fw-line-2);
+    border-radius: 8px;
+    overflow: hidden;
+    background: color-mix(in srgb, var(--fw-bg-2) 82%, var(--fw-panel) 18%);
+}
+
+.fwstate-stats-compare__head,
+.fwstate-stats-compare__metric,
+.fwstate-stats-compare__value {
+    padding: 6px 8px;
+    min-width: 0;
+    border-bottom: 1px solid var(--fw-line-2);
+    font-size: 10.5px;
+    line-height: 1.2;
+}
+
+.fwstate-stats-compare__head {
+    background: color-mix(in srgb, var(--fw-bg-2) 70%, var(--fw-panel) 30%);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 500;
+    color: var(--fw-text-3);
+}
+
+.fwstate-stats-compare__metric,
+.fwstate-stats-compare__value {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    color: var(--fw-text-2);
+}
+
+.fwstate-stats-compare__metric {
+    font-size: 12.2px;
+    color: var(--fw-text-2);
+}
+
+.fwstate-stats-compare__value {
+    font-size: 12.5px;
+    font-family: var(--fw-font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--fw-text);
+}
+
+.fwstate-stats-compare > :nth-last-child(-n + 3) {
+    border-bottom: 0;
+}
+
+.fwstate-filter-item {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.fwstate-states-table-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-height: 0;
+}
+
+.fwstate-states-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 8px 12px;
+    padding: 10px 12px;
+    border-top: 1px solid var(--fw-line-2);
+    border-bottom: 1px solid var(--fw-line-2);
+    background: color-mix(in srgb, var(--fw-bg-2) 82%, var(--fw-bg) 18%);
+}
+
+.fwstate-states-toolbar__control {
+    display: flex;
+    min-height: 48px;
+    flex-wrap: nowrap;
+}
+
+.fwstate-states-toolbar__label {
+    font-size: 10.5px;
+    color: var(--fw-text-3);
+    line-height: 1.25;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    margin-bottom: 3px;
+}
+
+.fwstate-states-toolbar__control--field {
+    flex-direction: column;
+    min-width: 0;
+    gap: 6px;
+}
+
+.fwstate-states-toolbar__control--field-layer {
+    width: 180px;
+    flex: 0 0 auto;
+}
+
+.fwstate-states-toolbar__control--field-direction {
+    width: 230px;
+    flex: 0 0 auto;
+}
+
+.fwstate-states-toolbar__control--field-family {
+    width: 220px;
+    flex: 0 0 auto;
+}
+
+.fwstate-states-toolbar__family {
+    display: flex;
+    gap: 0;
+    border: 1px solid var(--fw-line-2);
+    border-radius: 8px;
+    overflow: hidden;
+}
+
+.fwstate-states-toolbar__family-btn {
+    flex: 1 1 0;
+    min-width: 0;
+    border: 0;
+    border-radius: 0;
+    box-shadow: none;
+    --g-button-border-width: 0px;
+    --g-button-border-color: transparent;
+    color: var(--fw-text-3);
+}
+
+.fwstate-states-toolbar__family-btn + .fwstate-states-toolbar__family-btn {
+    margin-inline-start: 0;
+}
+
+.fwstate-states-toolbar__family-btn--active {
+    z-index: 2;
+    --g-button-background-color: color-mix(in srgb, var(--fw-accent) 16%, var(--fw-bg-2));
+    --g-button-text-color: color-mix(in srgb, var(--fw-text) 88%, var(--fw-accent) 12%);
+    --g-button-border-color: transparent;
+}
+
+.fwstate-states-toolbar__control--switch {
+    flex-direction: column;
+    align-items: flex-start;
+    min-width: 124px;
+    padding-bottom: 1px;
+    padding-top: 1px;
+    gap: 5px;
+}
+
+.fwstate-states-toolbar__hint {
+    font-size: 11px;
+    color: var(--fw-text-3);
+}
+
+.fwstate-states-advanced-details {
+    border-top: 1px solid var(--fw-line-2);
+    border-bottom: 1px solid var(--fw-line-2);
+    background: color-mix(in srgb, var(--fw-bg-2) 78%, var(--fw-panel) 22%);
+}
+
+.fwstate-states-advanced-details__summary {
+    list-style: none;
+    cursor: pointer;
+    padding: 7px 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--fw-text-3);
+}
+
+.fwstate-states-advanced-details__summary::before {
+    content: '';
+    width: 7px;
+    height: 7px;
+    border-right: 1.5px solid currentColor;
+    border-bottom: 1.5px solid currentColor;
+    transform: rotate(-45deg);
+    transition: transform 0.15s ease;
+    margin-top: 1px;
+}
+
+.fwstate-states-advanced-details[open] .fwstate-states-advanced-details__summary::before {
+    transform: rotate(45deg);
+}
+
+.fwstate-states-advanced-details__summary:hover {
+    color: var(--fw-text-2);
+}
+
+.fwstate-states-advanced-details__summary::-webkit-details-marker {
+    display: none;
+}
+
+.fwstate-states-advanced-details__content {
+    padding: 0 12px 10px;
+}
+
+.fwstate-states-toolbar__status {
+    font-size: 12px;
+    color: var(--fw-text-2);
+    line-height: 1.25;
+    margin-bottom: 5px;
+}
+
+.fwstate-table-shell--scroll .g-table__row_empty .g-table__cell,
+.fwstate-table-shell--scroll .g-table__row_empty .g-table__cell[data-qa] {
+    text-align: center;
+    color: transparent;
+}
+
+.fwstate-table-shell--scroll .g-table__row_empty {
+    display: none;
+}
+
+.fwstate-states-empty-overlay {
+    position: absolute;
+    inset-block-start: 44px;
+    inset-inline: 0;
+    inset-block-end: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    color: var(--fw-text-3);
+    font-size: 12.5px;
+    text-align: center;
+    z-index: 1;
+}
+
+.fwstate-states-footer {
+    min-height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.fwstate-states-footer__text {
+    font-size: 11.5px;
+    color: var(--fw-text-3);
+    line-height: 1.3;
+}
+
+.fwstate-states-footer__text--secondary {
+    min-height: 16px;
+}
+
+.fwstate-stats-note {
+    margin-top: 6px;
+    display: block;
+    line-height: 1.35;
+}
+
+.fwstate-mono {
+    font-family: var(--fw-font-mono);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    color: var(--fw-text-2);
+}
+
+.fwstate-table-cell {
+    color: var(--fw-text-2);
+    font-size: 12px;
+    line-height: 1.35;
+}
+
+.fwstate-table-cell--empty {
+    color: var(--fw-text-3);
+}
+
+.fwstate-updated {
+    white-space: nowrap;
+    color: var(--fw-text-3);
+}
+
+
+.fwstate-flag-chip-list {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    min-width: 0;
+    flex-wrap: nowrap;
+}
+
+.fwstate-flag-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    border-radius: 3px;
+    border: 1px solid transparent;
+    font-size: 12px;
+    line-height: 1.3;
+    font-weight: 500;
+    background: color-mix(in srgb, var(--fw-bg-2) 88%, transparent);
+    color: var(--fw-text-2);
+}
+
+.fwstate-flag-chip--none {
+    color: var(--fw-text-3);
+    border-color: var(--fw-line-2);
+}
+
+.fwstate-expired-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 21px;
+    padding: 0 8px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.25;
+    border: 1px solid transparent;
+    white-space: nowrap;
+}
+
+.fwstate-expired-pill--active {
+    color: var(--fw-text-3);
+    border-color: var(--fw-line-2);
+    background: var(--fw-bg-2);
+}
+
+.fwstate-expired-pill--expired {
+    color: var(--g-color-text-danger);
+    border-color: color-mix(in srgb, var(--g-color-base-danger-medium) 40%, transparent);
+    background: color-mix(in srgb, var(--g-color-base-danger-light) 55%, transparent);
+}
+
+.fwstate-settings-top-row + .fwstate-config-section {
+    padding-top: 14px;
+    margin-top: 2px;
+    border-top: 1px solid color-mix(in srgb, var(--fw-line-2) 68%, transparent);
+}
+
+@media (max-width: 1280px) {
+    .fwstate-operational-secondary {
+        grid-template-columns: minmax(0, 1.2fr) minmax(280px, 1fr);
+    }
+
+    .fwstate-field-grid--timeouts {
+        grid-template-columns: repeat(3, minmax(180px, 1fr));
+    }
+
+    .fwstate-sync-grid {
+        grid-template-columns: repeat(2, minmax(220px, 1fr));
+    }
+
+    .fwstate-sync-grid__endpoint {
+        grid-column: span 2;
+    }
+
+    .fwstate-stats-compare {
+        grid-template-columns: minmax(120px, 1.15fr) minmax(84px, .9fr) minmax(84px, .9fr);
+    }
+}
+
+@media (max-width: 980px) {
+    .fwstate-operational-secondary {
+        grid-template-columns: 1fr;
+    }
+
+    .fwstate-settings-top-row {
+        grid-template-columns: 1fr;
+    }
+
+    .fwstate-settings-top-row > .fwstate-config-section + .fwstate-config-section {
+        padding-top: 14px;
+        margin-top: 2px;
+        border-top: 1px solid color-mix(in srgb, var(--fw-line-2) 68%, transparent);
+    }
+
+    .fwstate-field-grid--timeouts {
+        grid-template-columns: repeat(2, minmax(180px, 1fr));
+    }
+
+    .fwstate-config-bar {
+        gap: 6px;
+    }
+
+    .fwstate-sync-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .fwstate-sync-grid__endpoint {
+        grid-column: span 1;
+    }
+
+    .fwstate-endpoint-row {
+        grid-template-columns: 1fr;
+    }
+
+    .fwstate-states-toolbar {
+        gap: 10px;
+    }
+
+    .fwstate-states-toolbar__control--field-layer,
+    .fwstate-states-toolbar__control--field-family,
+    .fwstate-states-toolbar__control--field-direction,
+    .fwstate-states-toolbar__control--switch {
+        width: 100%;
+        min-width: 0;
+    }
+}
+
+@media (max-width: 680px) {
+    .fwstate-field-grid--timeouts {
+        grid-template-columns: 1fr;
+    }
+}

--- a/web/src/pages/modules/fwstate/index.ts
+++ b/web/src/pages/modules/fwstate/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FWStatePage';

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -9,6 +9,7 @@ export const PAGE_IDS = [
     'modules/forward',
     'modules/decap',
     'modules/acl',
+    'modules/fwstate',
     'modules/pdump',
     'modules/route',
     'operators/route',


### PR DESCRIPTION
- Add the FWState module page with operational state-table viewing, compact configuration editing, ACL links, and state-map stats.
- Register FWState in the web router, menu, page ids, and API client.
- Share ACL-style IP and protocol chip primitives between ACL and FWState for consistent table styling.
- Surface FWState linkage in the ACL header for stateful rule configs.
- Validate the page with a production web build and live Playwright screenshots against real FWState data.