### PR TITLE
fix: refresh repeated fwstate states

### DIFF
--- a/lib/fwstate/fwstate_cursor.h
+++ b/lib/fwstate/fwstate_cursor.h
@@ -72,12 +72,14 @@ fwstate_cursor_read_entry(
 		return 0;
 	}
 
-	const struct fw_state_key_hdr *hdr =
-		(const struct fw_state_key_hdr *)key;
-	uint64_t ttl = fwstate_entry_ttl(
-		hdr->proto, value->flags.raw, &cursor->timeouts
+	uint64_t deadline;
+	int64_t entry_idx = fwmap_get_value_and_deadline(
+		map, 0, key, NULL, NULL, &deadline
 	);
-	bool expired = (value->updated_at + ttl <= now);
+	if (entry_idx < 0 || entry_idx != cursor->key_pos) {
+		return 0;
+	}
+	bool expired = (deadline <= now);
 
 	if (!cursor->include_expired && expired) {
 		return 0;

--- a/lib/fwstate/ops.h
+++ b/lib/fwstate/ops.h
@@ -34,12 +34,18 @@ fwmap_copy_value_fwstate(
 	const struct fw_state_value *s = (const struct fw_state_value *)src;
 	struct fw_state_value *d = (struct fw_state_value *)dst;
 
-	uint64_t created_at = d->created_at;
-	*d = *s;
-	if (!dst_empty) {
-		// On update, preserve the original creation timestamp.
-		d->created_at = created_at;
+	if (dst_empty) {
+		*d = *s;
+		return;
 	}
+
+	struct fw_state_value old = *d;
+	*d = *s;
+	// On update, preserve the original creation timestamp.
+	d->created_at = old.created_at;
+	d->flags.raw |= old.flags.raw;
+	d->packets_forward += old.packets_forward;
+	d->packets_backward += old.packets_backward;
 }
 
 static inline void

--- a/tests/fwstate/fwstate_cursor_test.c
+++ b/tests/fwstate/fwstate_cursor_test.c
@@ -9,6 +9,7 @@
 #include "common/memory.h"
 #include "lib/fwstate/fwmap.h"
 #include "lib/fwstate/fwstate_cursor.h"
+#include "lib/fwstate/ops.h"
 #include "lib/fwstate/types.h"
 #include "test_utils.h"
 
@@ -21,7 +22,7 @@
 
 #define ARENA_SIZE_MB 64
 #define ARENA_SIZE ((1 << 20) * ARENA_SIZE_MB)
-#define DEFAULT_TTL 50000
+#define DEFAULT_TTL 120e9
 #define WORKER_ID 0
 
 /* Global time counter for TTL expiration testing */
@@ -89,6 +90,25 @@ test_env_destroy(test_env_t *env) {
 	memory_context_fini(env->ctx);
 }
 
+static void
+test_env_insert_tcp_with_ttl(
+	test_env_t *env,
+	uint32_t count,
+	uint16_t base_port,
+	uint16_t dst_port,
+	uint64_t ttl
+);
+
+static void
+test_env_insert_udp_with_ttl(
+	test_env_t *env,
+	uint32_t count,
+	uint16_t base_port,
+	uint16_t dst_port,
+	uint32_t addr_offset,
+	uint64_t ttl
+);
+
 /*
  * Insert `count` TCP entries with sequential source ports starting at
  * `base_port`, all targeting `dst_port`. Source addresses increment from
@@ -97,6 +117,19 @@ test_env_destroy(test_env_t *env) {
 static void
 test_env_insert_tcp(
 	test_env_t *env, uint32_t count, uint16_t base_port, uint16_t dst_port
+) {
+	test_env_insert_tcp_with_ttl(
+		env, count, base_port, dst_port, DEFAULT_TTL
+	);
+}
+
+static void
+test_env_insert_tcp_with_ttl(
+	test_env_t *env,
+	uint32_t count,
+	uint16_t base_port,
+	uint16_t dst_port,
+	uint64_t ttl
 ) {
 	for (uint32_t i = 0; i < count; i++) {
 		struct fw4_state_key key;
@@ -116,7 +149,7 @@ test_env_insert_tcp(
 		val.packets_forward = 1;
 
 		int64_t ret = fwmap_put(
-			env->map, WORKER_ID, now, DEFAULT_TTL, &key, &val, NULL
+			env->map, WORKER_ID, now, ttl, &key, &val, NULL
 		);
 		assert(ret >= 0);
 	}
@@ -128,12 +161,13 @@ test_env_insert_tcp(
  * 10.0.0.1 + addr_offset.
  */
 static void
-test_env_insert_udp(
+test_env_insert_udp_with_ttl(
 	test_env_t *env,
 	uint32_t count,
 	uint16_t base_port,
 	uint16_t dst_port,
-	uint32_t addr_offset
+	uint32_t addr_offset,
+	uint64_t ttl
 ) {
 	for (uint32_t i = 0; i < count; i++) {
 		struct fw4_state_key key;
@@ -151,7 +185,7 @@ test_env_insert_udp(
 		val.packets_forward = 1;
 
 		int64_t ret = fwmap_put(
-			env->map, WORKER_ID, now, DEFAULT_TTL, &key, &val, NULL
+			env->map, WORKER_ID, now, ttl, &key, &val, NULL
 		);
 		assert(ret >= 0);
 	}
@@ -333,7 +367,7 @@ test_expired_skipped(void *arena) {
 
 	/* Insert: TCP(3000->80), UDP(3001->53), TCP(3002->443) */
 	test_env_insert_tcp(&env, 1, 3000, 80);
-	test_env_insert_udp(&env, 1, 3001, 53, 1);
+	test_env_insert_udp_with_ttl(&env, 1, 3001, 53, 1, 30e9);
 	test_env_insert_tcp(&env, 1, 3002, 443);
 
 	/*
@@ -377,7 +411,7 @@ test_include_expired(void *arena) {
 	/* Same setup as expired test: TCP(4000->80), UDP(4001->53),
 	 * TCP(4002->443) */
 	test_env_insert_tcp(&env, 1, 4000, 80);
-	test_env_insert_udp(&env, 1, 4001, 53, 1);
+	test_env_insert_udp_with_ttl(&env, 1, 4001, 53, 1, 30e9);
 	test_env_insert_tcp(&env, 1, 4002, 443);
 
 	/* Advance time so UDP is expired */
@@ -401,7 +435,93 @@ test_include_expired(void *arena) {
 }
 
 /* ====================================================================== */
-/* Test 7: Uninitialized entries skipped                                   */
+/* Test 7: Cursor uses refreshed deadline instead of recomputed TTL */
+/* ====================================================================== */
+
+static void
+test_cursor_deadline_over_flags_ttl(void *arena) {
+	printf("\n--- Cursor deadline over flags test ---\n");
+	struct memory_context *ctx =
+		init_context_from_arena(arena, ARENA_SIZE, "cursor_deadline");
+
+	fwmap_config_t cfg;
+	memset(&cfg, 0, sizeof(cfg));
+	cfg.key_size = sizeof(struct fw4_state_key);
+	cfg.value_size = sizeof(struct fw_state_value);
+	cfg.hash_seed = 0;
+	cfg.worker_count = 1;
+	cfg.hash_fn_id = FWMAP_HASH_FNV1A;
+	cfg.key_equal_fn_id = FWMAP_KEY_EQUAL_FW4;
+	cfg.rand_fn_id = FWMAP_RAND_DEFAULT;
+	cfg.copy_key_fn_id = FWMAP_COPY_KEY_FW4;
+	cfg.copy_value_fn_id = FWMAP_COPY_VALUE_FWSTATE;
+	cfg.merge_value_fn_id = FWMAP_MERGE_VALUE_FWSTATE;
+	cfg.index_size = 128;
+	cfg.extra_bucket_count = 8;
+
+	fwmap_t *map = fwmap_new(&cfg, ctx);
+	assert(map != NULL);
+
+	struct fw4_state_key key = {
+		.hdr.proto = IPPROTO_TCP,
+		.hdr.src_port = 7000,
+		.hdr.dst_port = 80,
+		.src_addr = 0x0A000001,
+		.dst_addr = 0x0A000002,
+	};
+
+	struct fw_state_value syn = {
+		.created_at = now,
+		.updated_at = now,
+		.packets_forward = 1,
+		.flags.tcp.src = FWSTATE_SYN,
+	};
+	int64_t ret = fwmap_put(map, WORKER_ID, now, 3e9, &key, &syn, NULL);
+	assert(ret >= 0);
+
+	struct fw_state_value ack = {
+		.created_at = now + 10,
+		.updated_at = now + 10,
+		.packets_forward = 1,
+		.flags.tcp.dst = FWSTATE_ACK,
+	};
+	ret = fwmap_put(map, WORKER_ID, now + 10, 20e9, &key, &ack, NULL);
+	assert(ret >= 0);
+
+	struct fwstate_timeouts short_timeouts = {
+		.tcp_syn_ack = 1e9,
+		.tcp_syn = 3e9,
+		.tcp_fin = 20e9,
+		.tcp = 20e9,
+		.udp = 30e9,
+		.default_ = 16e9,
+	};
+	fwstate_cursor_entry_t out[4];
+	fwstate_cursor_t cursor = {
+		.key_pos = 0,
+		.include_expired = false,
+		.timeouts = short_timeouts,
+	};
+	uint64_t read_now = now + 15e9;
+	uint32_t n =
+		fwstate_cursor_read_forward(map, &cursor, read_now, out, 10);
+	assert(n == 1);
+	assert(out[0].expired == false);
+	assert(out[0].idx == 0);
+	assert(out[0].value != NULL);
+
+	struct fw_state_value *value = (struct fw_state_value *)out[0].value;
+	assert(value->flags.tcp.src == FWSTATE_SYN);
+	assert(value->flags.tcp.dst == FWSTATE_ACK);
+
+	fwmap_free(map, ctx);
+	verify_memory_leaks(ctx, "cursor_deadline");
+	memory_context_fini(ctx);
+	printf("  Cursor deadline over flags test passed\n");
+}
+
+/* ====================================================================== */
+/* Test 8: Uninitialized entries skipped                                   */
 /* ====================================================================== */
 
 static void
@@ -439,7 +559,7 @@ test_uninitialized_skipped(void *arena) {
 }
 
 /* ====================================================================== */
-/* Test 8: Paging                                                          */
+/* Test 9: Paging                                                          */
 /* ====================================================================== */
 
 static void
@@ -502,7 +622,7 @@ test_paging(void *arena) {
 }
 
 /* ====================================================================== */
-/* Test 9: Forward bounds safety                                           */
+/* Test 10: Forward bounds safety                                          */
 /* ====================================================================== */
 
 static void
@@ -535,7 +655,7 @@ test_forward_bounds(void *arena) {
 }
 
 /* ====================================================================== */
-/* Test 10: Backward clamping                                              */
+/* Test 11: Backward clamping                                              */
 /* ====================================================================== */
 
 static void
@@ -576,7 +696,7 @@ test_backward_clamping(void *arena) {
 }
 
 /* ====================================================================== */
-/* Test 11: Single entry backward                                          */
+/* Test 12: Single entry backward                                          */
 /* ====================================================================== */
 
 static void
@@ -611,7 +731,7 @@ test_single_entry_backward(void *arena) {
 }
 
 /* ====================================================================== */
-/* Test 12: Backward paging                                                */
+/* Test 13: Backward paging                                                */
 /* ====================================================================== */
 
 static void
@@ -674,7 +794,7 @@ test_backward_paging(void *arena) {
 }
 
 /* ====================================================================== */
-/* Test 13: Expired entry at index 0 in backward with include_expired      */
+/* Test 14: Expired entry at index 0 in backward with include_expired      */
 /* ====================================================================== */
 
 static void
@@ -683,7 +803,7 @@ test_backward_expired_at_zero(void *arena) {
 	test_env_t env = test_env_create(arena, "bwd_exp0");
 
 	/* Entry 0: UDP (30s TTL) -- will expire */
-	test_env_insert_udp(&env, 1, 14000, 53, 0);
+	test_env_insert_udp_with_ttl(&env, 1, 14000, 53, 0, 30e9);
 
 	/* Entry 1: TCP (120s TTL) -- will not expire */
 	test_env_insert_tcp(&env, 1, 14001, 80);
@@ -745,6 +865,7 @@ main(void) {
 	test_backward_iteration(arena);
 	test_expired_skipped(arena);
 	test_include_expired(arena);
+	test_cursor_deadline_over_flags_ttl(arena);
 	test_uninitialized_skipped(arena);
 	test_paging(arena);
 	test_forward_bounds(arena);

--- a/tests/fwstate/layermap_test.c
+++ b/tests/fwstate/layermap_test.c
@@ -1,7 +1,9 @@
 #include "lib/fwstate/layermap.h"
+#include "lib/fwstate/types.h"
 #include "test_utils.h"
 #include <assert.h>
 #include <fcntl.h>
+#include <netinet/in.h>
 #include <pthread.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -174,6 +176,165 @@ test_layermap_basic_operations(void *arena) {
 	verify_memory_leaks(ctx, "layermap_basic_operations");
 	memory_context_fini(ctx);
 	fprintf(stderr, "Layermap basic operations test PASSED\n");
+}
+
+static void
+test_layermap_fwstate_refresh_semantics(void *arena) {
+	fprintf(stderr, "Testing fwstate refresh semantics...\n");
+
+	uint16_t worker_idx = 0;
+
+	struct memory_context *ctx =
+		init_context_from_arena(arena, ARENA_SIZE, "fwstate_refresh");
+
+	fwmap_config_t config = {
+		.key_size = sizeof(struct fw4_state_key),
+		.value_size = sizeof(struct fw_state_value),
+		.hash_seed = 0xdeadbeef,
+		.worker_count = 1,
+		.index_size = 128,
+		.extra_bucket_count = 16,
+		.hash_fn_id = FWMAP_HASH_FNV1A,
+		.key_equal_fn_id = FWMAP_KEY_EQUAL_FW4,
+		.rand_fn_id = FWMAP_RAND_DEFAULT,
+		.copy_key_fn_id = FWMAP_COPY_KEY_FW4,
+		.copy_value_fn_id = FWMAP_COPY_VALUE_FWSTATE,
+		.merge_value_fn_id = FWMAP_MERGE_VALUE_FWSTATE,
+	};
+
+	fwmap_t *active_layer = fwmap_new(&config, ctx);
+	assert(active_layer != NULL);
+
+	struct fw4_state_key key = {
+		.hdr.proto = IPPROTO_TCP,
+		.hdr.src_port = 1234,
+		.hdr.dst_port = 443,
+		.src_addr = 0x0a000001,
+		.dst_addr = 0x0a000002,
+	};
+
+	struct fw_state_value syn = {
+		.external = true,
+		.flags.tcp.src = FWSTATE_SYN,
+		.created_at = 100,
+		.updated_at = 100,
+		.packets_forward = 1,
+	};
+	int64_t ret = layermap_put(
+		active_layer, worker_idx, 100, 1000, &key, &syn, NULL
+	);
+	assert(ret >= 0);
+	assert(fwmap_size(active_layer) == 1);
+
+	struct fw_state_value ack = {
+		.external = false,
+		.flags.tcp.src = FWSTATE_ACK,
+		.created_at = 200,
+		.updated_at = 200,
+		.packets_forward = 1,
+	};
+	ret = layermap_put(
+		active_layer, worker_idx, 200, 1000, &key, &ack, NULL
+	);
+	assert(ret >= 0);
+	assert(fwmap_size(active_layer) == 1);
+
+	struct fw_state_value *value = NULL;
+	bool value_from_stale = false;
+	ret = layermap_get(
+		active_layer,
+		250,
+		&key,
+		(void **)&value,
+		NULL,
+		&value_from_stale
+	);
+	assert(ret >= 0);
+	assert(!value_from_stale);
+	assert(value->created_at == 100);
+	assert(value->updated_at == 200);
+	assert(value->external == ack.external);
+	assert(value->packets_forward == 2);
+	assert(value->packets_backward == 0);
+	assert(value->flags.tcp.src == (FWSTATE_SYN | FWSTATE_ACK));
+	assert(value->flags.tcp.dst == 0);
+
+	// Rotate to test stale-layer merge keeps existing created_at and uses
+	// cumulative flags.
+	SET_OFFSET_OF(&active_layer, active_layer);
+	ret = layermap_insert_new_layer_cp(&active_layer, &config, ctx);
+	assert(ret == 0);
+	active_layer = ADDR_OF(&active_layer);
+
+	struct fw_state_value syn_refresh = {
+		.external = true,
+		.flags.tcp.src = FWSTATE_SYN,
+		.created_at = 300,
+		.updated_at = 300,
+		.packets_forward = 1,
+	};
+	ret = layermap_put(
+		active_layer, worker_idx, 300, 1000, &key, &syn_refresh, NULL
+	);
+	assert(ret >= 0);
+	ret = layermap_get(
+		active_layer,
+		350,
+		&key,
+		(void **)&value,
+		NULL,
+		&value_from_stale
+	);
+	assert(ret >= 0);
+	assert(!value_from_stale);
+	assert(value->created_at == 100);
+	assert(value->updated_at == 300);
+	assert(value->external == syn_refresh.external);
+	assert(value->flags.tcp.src == (FWSTATE_SYN | FWSTATE_ACK));
+	assert(value->flags.tcp.dst == 0);
+	assert(value->packets_forward == 3);
+
+	struct fw_state_value ack_refresh = {
+		.external = false,
+		.flags.tcp.src = 0,
+		.flags.tcp.dst = FWSTATE_ACK,
+		.created_at = 400,
+		.updated_at = 400,
+		.packets_forward = 1,
+	};
+	ret = layermap_put(
+		active_layer, worker_idx, 400, 1000, &key, &ack_refresh, NULL
+	);
+	assert(ret >= 0);
+
+	ret = layermap_get(
+		active_layer,
+		450,
+		&key,
+		(void **)&value,
+		NULL,
+		&value_from_stale
+	);
+	assert(ret >= 0);
+	assert(!value_from_stale);
+	assert(value->created_at == 100);
+	assert(value->updated_at == 400);
+	assert(value->external == ack_refresh.external);
+	assert(value->flags.tcp.src == (FWSTATE_SYN | FWSTATE_ACK));
+	assert(value->flags.tcp.dst == FWSTATE_ACK);
+	assert(value->packets_forward == 4);
+
+	// Cleanup: destroy all layers in the chain
+	fwmap_t *layer = active_layer;
+	while (layer) {
+		fwmap_t *next = (fwmap_t *)ADDR_OF(&layer->next);
+		fwmap_free(layer, ctx);
+		layer = next;
+	}
+
+	verify_memory_leaks(ctx, "fwstate_refresh");
+	memory_context_fini(ctx);
+	fprintf(stderr, "FWState refresh semantics test PASSED\n");
 }
 
 struct rotator_args {
@@ -360,6 +521,7 @@ main() {
 	}
 
 	test_layermap_basic_operations(arena);
+	test_layermap_fwstate_refresh_semantics(arena);
 	test_layermap_multithreaded(arena);
 
 	free_arena(arena, ARENA_SIZE);


### PR DESCRIPTION
- Fixed repeated FWState refreshes so packet counters accumulate while creation time is preserved.
- Preserved cumulative TCP flag semantics for displayed state values.
- Changed cursor expiration to use the refreshed FWMap bucket deadline instead of recomputing TTL from cumulative flags.
- Added C coverage for active-layer refresh, stale-layer promotion, and deadline-based cursor expiration.
- Validated with targeted FWState Meson tests and a full Meson compile.