### PR TITLE
fix(fwstate): accumulate flags and packet counters on in-layer updates

### DIFF
--- a/lib/fwstate/fwmap.h
+++ b/lib/fwstate/fwmap.h
@@ -35,12 +35,12 @@ typedef enum {
 	FWMAP_RAND_DEFAULT,
 	FWMAP_RAND_SECURE,
 	FWMAP_COPY_KEY_DEFAULT,
-	FWMAP_COPY_VALUE_DEFAULT,
-	FWMAP_MERGE_VALUE_DEFAULT,
+	FWMAP_UPDATE_VALUE_DEFAULT,
+	FWMAP_PROMOTE_VALUE_DEFAULT,
 	FWMAP_COPY_KEY_FW4,
 	FWMAP_COPY_KEY_FW6,
-	FWMAP_COPY_VALUE_FWSTATE,
-	FWMAP_MERGE_VALUE_FWSTATE,
+	FWMAP_UPDATE_VALUE_FWSTATE,
+	FWMAP_PROMOTE_VALUE_FWSTATE,
 	FWMAP_KEY_EQUAL_FW4,
 	FWMAP_KEY_EQUAL_FW6,
 	FWMAP_FUNC_COUNT
@@ -66,12 +66,23 @@ typedef bool (*fwmap_key_equal_fn_t)(
 // Prevents hash collision attacks and ensures different distributions.
 typedef uint64_t (*fwmap_rand_fn_t)(void);
 
-// Copy function types for custom key/value copying.
+// Copy/merge function types for custom key/value handling.
+//
+// - copy_key: copies the key into a freshly allocated slot.
+// - update_value: applied when the key already lives in (or is being inserted
+//   into) the active layer. The "old" value, if any, is already located at
+//   *dst; dst_empty tells whether this is the first write to the slot.
+//   Implementations are expected to merge with the existing dst contents when
+//   !dst_empty (e.g. OR-accumulate flags, sum packet counters).
+// - promote_value: applied exactly once when a key found only in a stale
+//   (lower) layer is being promoted into a fresh slot of the active layer.
+//   The previous value lives in *old_value (in the stale layer); the incoming
+//   value is *new_value; *dst is empty.
 typedef void (*fwmap_copy_key_fn_t)(void *dst, const void *src, size_t size);
-typedef void (*fwmap_copy_value_fn_t)(
+typedef void (*fwmap_update_value_fn_t)(
 	void *dst, const void *src, bool dst_empty, size_t size
 );
-typedef void (*fwmap_merge_value_fn_t)(
+typedef void (*fwmap_promote_value_fn_t)(
 	void *dst, const void *new_value, const void *old_value, size_t size
 );
 
@@ -86,8 +97,8 @@ typedef struct fwmap_config {
 	fwmap_func_id_t key_equal_fn_id;
 	fwmap_func_id_t rand_fn_id;
 	fwmap_func_id_t copy_key_fn_id;
-	fwmap_func_id_t copy_value_fn_id;
-	fwmap_func_id_t merge_value_fn_id;
+	fwmap_func_id_t update_value_fn_id;
+	fwmap_func_id_t promote_value_fn_id;
 } fwmap_config_t;
 
 typedef struct fwmap_bucket {
@@ -129,8 +140,8 @@ typedef struct fwmap {
 	uint8_t hash_fn_id;
 	uint8_t key_equal_fn_id;
 	uint8_t copy_key_fn_id;
-	uint8_t copy_value_fn_id;
-	uint8_t merge_value_fn_id;
+	uint8_t update_value_fn_id;
+	uint8_t promote_value_fn_id;
 
 	// Alignment offsets for cache-aligned allocations
 	uint8_t map_alloc_offset;
@@ -255,7 +266,7 @@ fwmap_default_copy_key(void *dst, const void *src, size_t size) {
 }
 
 static inline void
-fwmap_default_copy_value(
+fwmap_default_update_value(
 	void *dst, const void *src, bool dst_empty, size_t size
 ) {
 	(void)dst_empty;
@@ -263,7 +274,7 @@ fwmap_default_copy_value(
 }
 
 static inline void
-fwmap_default_merge_value(
+fwmap_default_promote_value(
 	void *dst, const void *old_value, const void *new_value, size_t size
 ) {
 	(void)dst, (void)old_value, (void)new_value, (void)size;
@@ -286,11 +297,11 @@ fwmap_config_set_defaults(fwmap_config_t *config) {
 	if (config->copy_key_fn_id == FWMAP_UNINITIALIZED) {
 		config->copy_key_fn_id = FWMAP_COPY_KEY_DEFAULT;
 	}
-	if (config->copy_value_fn_id == FWMAP_UNINITIALIZED) {
-		config->copy_value_fn_id = FWMAP_COPY_VALUE_DEFAULT;
+	if (config->update_value_fn_id == FWMAP_UNINITIALIZED) {
+		config->update_value_fn_id = FWMAP_UPDATE_VALUE_DEFAULT;
 	}
-	if (config->merge_value_fn_id == FWMAP_UNINITIALIZED) {
-		config->merge_value_fn_id = FWMAP_MERGE_VALUE_DEFAULT;
+	if (config->promote_value_fn_id == FWMAP_UNINITIALIZED) {
+		config->promote_value_fn_id = FWMAP_PROMOTE_VALUE_DEFAULT;
 	}
 }
 
@@ -817,8 +828,8 @@ fwmap_new(const fwmap_config_t *user_config, struct memory_context *ctx) {
 	map->hash_fn_id = config.hash_fn_id;
 	map->key_equal_fn_id = config.key_equal_fn_id;
 	map->copy_key_fn_id = config.copy_key_fn_id;
-	map->copy_value_fn_id = config.copy_value_fn_id;
-	map->merge_value_fn_id = config.merge_value_fn_id;
+	map->update_value_fn_id = config.update_value_fn_id;
+	map->promote_value_fn_id = config.promote_value_fn_id;
 
 	map->index_mask = index_size - 1;
 	// Shift amount equals the number of bits set in the chunk_index_mask
@@ -1218,8 +1229,8 @@ fwmap_put(
 ) {
 	fwmap_copy_key_fn_t copy_key_fn =
 		(fwmap_copy_key_fn_t)fwmap_func_registry[map->copy_key_fn_id];
-	fwmap_copy_value_fn_t copy_value_fn = (fwmap_copy_value_fn_t
-	)fwmap_func_registry[map->copy_value_fn_id];
+	fwmap_update_value_fn_t update_value_fn = (fwmap_update_value_fn_t
+	)fwmap_func_registry[map->update_value_fn_id];
 
 	fwmap_entry_t entry = fwmap_entry(map, worker_idx, now, ttl, key, lock);
 	if (!entry.key) {
@@ -1228,7 +1239,7 @@ fwmap_put(
 	if (entry.empty) {
 		copy_key_fn(entry.key, key, map->key_size);
 	}
-	copy_value_fn(entry.value, value, entry.empty, map->value_size);
+	update_value_fn(entry.value, value, entry.empty, map->value_size);
 
 	return (int64_t)entry.idx;
 }
@@ -1304,12 +1315,12 @@ static void *fwmap_func_registry[FWMAP_FUNC_COUNT] = {
 	[FWMAP_RAND_DEFAULT] = (void *)fwmap_rand_default,
 	[FWMAP_RAND_SECURE] = (void *)fwmap_rand_secure,
 	[FWMAP_COPY_KEY_DEFAULT] = (void *)fwmap_default_copy_key,
-	[FWMAP_COPY_VALUE_DEFAULT] = (void *)fwmap_default_copy_value,
-	[FWMAP_MERGE_VALUE_DEFAULT] = (void *)fwmap_default_merge_value,
+	[FWMAP_UPDATE_VALUE_DEFAULT] = (void *)fwmap_default_update_value,
+	[FWMAP_PROMOTE_VALUE_DEFAULT] = (void *)fwmap_default_promote_value,
 	[FWMAP_COPY_KEY_FW4] = (void *)fwmap_copy_key_fw4,
 	[FWMAP_COPY_KEY_FW6] = (void *)fwmap_copy_key_fw6,
-	[FWMAP_COPY_VALUE_FWSTATE] = (void *)fwmap_copy_value_fwstate,
-	[FWMAP_MERGE_VALUE_FWSTATE] = (void *)fwmap_merge_value_fwstate,
+	[FWMAP_UPDATE_VALUE_FWSTATE] = (void *)fwmap_update_value_fwstate,
+	[FWMAP_PROMOTE_VALUE_FWSTATE] = (void *)fwmap_promote_value_fwstate,
 	[FWMAP_KEY_EQUAL_FW4] = (void *)fwmap_fw4_key_equal,
 	[FWMAP_KEY_EQUAL_FW6] = (void *)fwmap_fw6_key_equal
 };

--- a/lib/fwstate/layermap.h
+++ b/lib/fwstate/layermap.h
@@ -199,10 +199,10 @@ layermap_put(
 ) {
 	fwmap_copy_key_fn_t copy_key_fn = (fwmap_copy_key_fn_t
 	)fwmap_func_registry[active_layer->copy_key_fn_id];
-	fwmap_copy_value_fn_t copy_value_fn = (fwmap_copy_value_fn_t
-	)fwmap_func_registry[active_layer->copy_value_fn_id];
-	fwmap_merge_value_fn_t merge_value_fn = (fwmap_merge_value_fn_t
-	)fwmap_func_registry[active_layer->merge_value_fn_id];
+	fwmap_update_value_fn_t update_value_fn = (fwmap_update_value_fn_t
+	)fwmap_func_registry[active_layer->update_value_fn_id];
+	fwmap_promote_value_fn_t promote_value_fn = (fwmap_promote_value_fn_t
+	)fwmap_func_registry[active_layer->promote_value_fn_id];
 
 	fwmap_entry_t entry =
 		fwmap_entry(active_layer, worker_idx, now, ttl, key, lock);
@@ -228,7 +228,7 @@ layermap_put(
 				&value_from_stale
 			);
 			if (result >= 0) {
-				merge_value_fn(
+				promote_value_fn(
 					entry.value,
 					value,
 					old_value,
@@ -245,7 +245,7 @@ layermap_put(
 		}
 	}
 
-	copy_value_fn(
+	update_value_fn(
 		entry.value, value, entry.empty, active_layer->value_size
 	);
 	return (int64_t)entry.idx;

--- a/lib/fwstate/ops.h
+++ b/lib/fwstate/ops.h
@@ -26,24 +26,53 @@ fwmap_copy_key_fw6(void *dst, const void *src, size_t size) {
 	*d = *s;
 }
 
+// In-layer update for an fwstate entry.
+//
+// When `dst_empty` is true this is a fresh insert and we simply copy *src.
+// Otherwise *dst already holds the previous value of the same key in the same
+// active layer, and we must accumulate state across the update so that no
+// information is lost between consecutive sync frames.
 static inline void
-fwmap_copy_value_fwstate(
+fwmap_update_value_fwstate(
 	void *dst, const void *src, bool dst_empty, size_t size
 ) {
 	(void)size;
 	const struct fw_state_value *s = (const struct fw_state_value *)src;
 	struct fw_state_value *d = (struct fw_state_value *)dst;
 
-	uint64_t created_at = d->created_at;
-	*d = *s;
-	if (!dst_empty) {
-		// On update, preserve the original creation timestamp.
-		d->created_at = created_at;
+	if (dst_empty) {
+		*d = *s;
+		return;
 	}
+
+	// Snapshot the previous value before we overwrite *dst with *src.
+	struct fw_state_value old = *d;
+	*d = *s;
+
+	// Update: take ownership/timestamp from the incoming frame, but keep
+	// the original creation timestamp so the connection age is preserved.
+	d->created_at = old.created_at;
+	// (external and updated_at are inherited from *s by the *d = *s above.)
+
+	// Merge: TCP flags accumulate across frames (FIN/SYN/RST/ACK once seen,
+	// stays seen), and per-direction packet counters are summed.
+	d->flags.raw |= old.flags.raw;
+	d->packets_forward += old.packets_forward;
+	d->packets_backward += old.packets_backward;
 }
 
+// Cross-layer promotion of an fwstate entry from a stale (lower) layer into
+// a freshly allocated slot in the active layer.
+//
+// *dst points to the new empty slot. *new_value is the incoming value being
+// inserted into the active layer. *old_value is the existing value located in
+// a stale layer below. We combine both:
+//   - created_at is taken from the oldest copy (the stale one);
+//   - external and updated_at are taken from the incoming value;
+//   - TCP flags are OR-merged;
+//   - per-direction packet counters are summed.
 static inline void
-fwmap_merge_value_fwstate(
+fwmap_promote_value_fwstate(
 	void *dst, const void *new_value, const void *old_value, size_t size
 ) {
 	(void)size;
@@ -54,17 +83,18 @@ fwmap_merge_value_fwstate(
 	const struct fw_state_value *old_v =
 		(const struct fw_state_value *)old_value;
 
-	// Update
+	// Update: ownership and last-seen timestamp come from the incoming
+	// frame; the creation timestamp comes from the older copy in the stale
+	// layer so the connection age is preserved across promotion.
 	d->external = new_v->external;
 	d->updated_at = new_v->updated_at;
-	// preserve oldest created_at
 	d->created_at = old_v->created_at;
 
-	// Merge
+	// Merge: TCP flags are OR-combined and per-direction packet counters
+	// are summed across the two layers.
 	d->flags.raw = new_v->flags.raw | old_v->flags.raw;
 	d->packets_backward = new_v->packets_backward + old_v->packets_backward;
 	d->packets_forward = new_v->packets_forward + old_v->packets_forward;
-	return;
 }
 
 // == Custom key comparison functions for fwstate keys.

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -136,8 +136,8 @@ fwstate_init_config(
 	config->copy_key_fn_id = copy_key_fn_id;
 
 	config->value_size = sizeof(struct fw_state_value);
-	config->copy_value_fn_id = FWMAP_COPY_VALUE_FWSTATE;
-	config->merge_value_fn_id = FWMAP_MERGE_VALUE_FWSTATE;
+	config->update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE;
+	config->promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE;
 
 	config->hash_seed = 0;
 	config->hash_fn_id = FWMAP_HASH_FNV1A;

--- a/modules/fwstate/fuzzing/fwstate.c
+++ b/modules/fwstate/fuzzing/fwstate.c
@@ -60,8 +60,8 @@ fwstate_test_config(struct cp_module **cp_module) {
 		.key_equal_fn_id = FWMAP_KEY_EQUAL_FW4,
 		.rand_fn_id = FWMAP_RAND_DEFAULT,
 		.copy_key_fn_id = FWMAP_COPY_KEY_FW4,
-		.copy_value_fn_id = FWMAP_COPY_VALUE_FWSTATE,
-		.merge_value_fn_id = FWMAP_MERGE_VALUE_FWSTATE,
+		.update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE,
+		.promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE,
 		.index_size = 1024,
 		.extra_bucket_count = 64,
 	};
@@ -81,8 +81,8 @@ fwstate_test_config(struct cp_module **cp_module) {
 		.key_equal_fn_id = FWMAP_KEY_EQUAL_FW6,
 		.rand_fn_id = FWMAP_RAND_DEFAULT,
 		.copy_key_fn_id = FWMAP_COPY_KEY_FW6,
-		.copy_value_fn_id = FWMAP_COPY_VALUE_FWSTATE,
-		.merge_value_fn_id = FWMAP_MERGE_VALUE_FWSTATE,
+		.update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE,
+		.promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE,
 		.index_size = 1024,
 		.extra_bucket_count = 64,
 	};

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -191,8 +191,26 @@ func fwstateHandlePackets(cpModule *C.struct_cp_module, packets ...gopacket.Pack
 	return &result, nil
 }
 
+// SyncFrameOption is a functional option for createSyncFrame
+type SyncFrameOption func(*C.struct_fw_state_sync_frame)
+
+// WithFrameFlags sets raw flags byte in the sync frame.
+// `flags` is a union exposed to cgo as [1]byte, so we write through it directly.
+func WithFrameFlags(flags uint8) SyncFrameOption {
+	return func(f *C.struct_fw_state_sync_frame) {
+		*(*uint8)(unsafe.Pointer(&f.flags[0])) = flags
+	}
+}
+
+// WithFrameFib sets fib (direction marker: 0 = forward, 1 = backward)
+func WithFrameFib(fib uint8) SyncFrameOption {
+	return func(f *C.struct_fw_state_sync_frame) {
+		f.fib = C.uint8_t(fib)
+	}
+}
+
 // createSyncFrame creates a properly formatted fw_state_sync_frame
-func createSyncFrame(proto layers.IPProtocol, addrType uint8, srcPort uint16, dstPort uint16, dstIP6, srcIP6 []byte) []byte {
+func createSyncFrame(proto layers.IPProtocol, addrType uint8, srcPort uint16, dstPort uint16, dstIP6, srcIP6 []byte, opts ...SyncFrameOption) []byte {
 	syncFrame := make([]byte, C.sizeof_struct_fw_state_sync_frame)
 
 	// Use unsafe pointer to treat the byte slice as a C struct
@@ -215,7 +233,96 @@ func createSyncFrame(proto layers.IPProtocol, addrType uint8, srcPort uint16, ds
 		}
 	}
 
+	for _, opt := range opts {
+		opt(framePtr)
+	}
+
 	return syncFrame
+}
+
+// StateValueSnapshot is a Go-side snapshot of a fw_state_value entry.
+type StateValueSnapshot struct {
+	Found           bool
+	External        bool
+	FlagsRaw        uint8
+	CreatedAt       uint64
+	UpdatedAt       uint64
+	PacketsForward  uint64
+	PacketsBackward uint64
+	Deadline        uint64
+}
+
+// GetStateValue reads the raw fw_state_value for a given 5-tuple via layermap_get_value_and_deadline.
+// Returns Found=false if the state does not exist.
+func GetStateValue(
+	cpModule *C.struct_cp_module,
+	proto layers.IPProtocol,
+	srcPort uint16,
+	dstPort uint16,
+	srcAddr string,
+	dstAddr string,
+) StateValueSnapshot {
+	m := (*C.struct_fwstate_module_config)(unsafe.Pointer(cpModule))
+	cfg := &m.cfg
+
+	srcIP, err1 := netip.ParseAddr(srcAddr)
+	dstIP, err2 := netip.ParseAddr(dstAddr)
+	if err1 != nil || err2 != nil {
+		return StateValueSnapshot{}
+	}
+
+	var fwmap *C.fwmap_t
+	var keyPtr unsafe.Pointer
+
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+
+	if srcIP.Is6() && dstIP.Is6() {
+		fwmap = (*C.fwmap_t)(C.addr_of((*unsafe.Pointer)(unsafe.Pointer(&cfg.fw6state))))
+		key6 := C.struct_fw6_state_key{}
+		key6.hdr.proto = C.uint16_t(proto)
+		key6.hdr.src_port = C.uint16_t(srcPort)
+		key6.hdr.dst_port = C.uint16_t(dstPort)
+		srcBytes := srcIP.As16()
+		dstBytes := dstIP.As16()
+		copy(unsafe.Slice((*byte)(&key6.src_addr[0]), 16), srcBytes[:])
+		copy(unsafe.Slice((*byte)(&key6.dst_addr[0]), 16), dstBytes[:])
+		pinner.Pin(&key6)
+		keyPtr = unsafe.Pointer(&key6)
+	} else {
+		fwmap = (*C.fwmap_t)(C.addr_of((*unsafe.Pointer)(unsafe.Pointer(&cfg.fw4state))))
+		key4 := C.struct_fw4_state_key{}
+		key4.hdr.proto = C.uint16_t(proto)
+		key4.hdr.src_port = C.uint16_t(srcPort)
+		key4.hdr.dst_port = C.uint16_t(dstPort)
+		srcBytes := srcIP.As4()
+		dstBytes := dstIP.As4()
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(&key4.src_addr)), 4), srcBytes[:])
+		copy(unsafe.Slice((*byte)(unsafe.Pointer(&key4.dst_addr)), 4), dstBytes[:])
+		pinner.Pin(&key4)
+		keyPtr = unsafe.Pointer(&key4)
+	}
+
+	var value unsafe.Pointer
+	var deadline C.uint64_t
+	var valueFromStale C.bool
+	// now=0 so deadline check inside fwmap_get_value_and_deadline always passes
+	ret := C.layermap_get_value_and_deadline(fwmap, 0, keyPtr, &value, nil, &deadline, &valueFromStale)
+	if ret < 0 || value == nil {
+		return StateValueSnapshot{Found: false}
+	}
+
+	v := (*C.struct_fw_state_value)(value)
+	return StateValueSnapshot{
+		Found:           true,
+		External:        bool(v.external),
+		FlagsRaw:        *(*uint8)(unsafe.Pointer(&v.flags[0])),
+		CreatedAt:       uint64(v.created_at),
+		UpdatedAt:       uint64(v.updated_at),
+		PacketsForward:  uint64(v.packets_forward),
+		PacketsBackward: uint64(v.packets_backward),
+		Deadline:        uint64(deadline),
+	}
 }
 
 // CheckStateExists checks if a state exists in the fwmap

--- a/modules/fwstate/tests/dataplane/fwstate_test.go
+++ b/modules/fwstate/tests/dataplane/fwstate_test.go
@@ -23,6 +23,8 @@ type syncPacketConfig struct {
 	srcAddr    string
 	dstAddr    string
 	isExternal bool
+	flags      uint8
+	fib        uint8
 }
 
 // WithPorts sets custom source and destination ports
@@ -45,6 +47,20 @@ func WithAddrs(srcAddr, dstAddr string) SyncPacketOption {
 func WithExternal() SyncPacketOption {
 	return func(c *syncPacketConfig) {
 		c.isExternal = true
+	}
+}
+
+// WithFlags sets raw TCP flags byte on the embedded sync frame
+func WithFlags(flags uint8) SyncPacketOption {
+	return func(c *syncPacketConfig) {
+		c.flags = flags
+	}
+}
+
+// WithFib sets fib (direction) on the embedded sync frame: 0=forward, 1=backward
+func WithFib(fib uint8) SyncPacketOption {
+	return func(c *syncPacketConfig) {
+		c.fib = fib
 	}
 }
 
@@ -100,7 +116,11 @@ func createSyncPacket(t *testing.T, proto layers.IPProtocol, opts ...SyncPacketO
 	// Create sync frame using the helper function
 	dstIP6 := net.ParseIP(cfg.dstAddr)
 	srcIP6 := net.ParseIP(cfg.srcAddr)
-	syncFrame := createSyncFrame(proto, 6, cfg.srcPort, cfg.dstPort, dstIP6, srcIP6)
+	syncFrame := createSyncFrame(
+		proto, 6, cfg.srcPort, cfg.dstPort, dstIP6, srcIP6,
+		WithFrameFlags(cfg.flags),
+		WithFrameFib(cfg.fib),
+	)
 
 	payload := gopacket.Payload(syncFrame)
 
@@ -284,4 +304,154 @@ func TestFWStateTrimStaleLayers(t *testing.T) {
 	// Old state should not exist (layer was trimmed)
 	oldStateExists := CheckStateExists(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
 	require.False(t, oldStateExists, "Old state should not exist after trim")
+}
+
+// TestFWStateUpdateAccumulatesFlags verifies that on subsequent sync frames for
+// the same 5-tuple in the SAME active layer, TCP flags accumulate (logical OR)
+// rather than being overwritten.
+//
+// This is a regression test for a bug previously present in
+// fwmap_update_value_fwstate() (formerly fwmap_copy_value_fwstate): when the
+// entry already existed in the active layer (dst_empty=false), the function
+// did *d = *s and only preserved created_at, fully clobbering flags /
+// packets_* / external with the incoming frame and dropping previously
+// accumulated state.
+//
+// Expected behavior:
+//   - First sync frame sets SYN.
+//   - Second sync frame (for the same key) sets ACK.
+//   - After processing both, stored flags must contain SYN|ACK.
+func TestFWStateUpdateAccumulatesFlags(t *testing.T) {
+	memCtx := testutils.NewMemoryContext("fwstate_acc_flags_test", datasize.MB*64)
+	defer memCtx.Free()
+	cpModule := fwstateModuleConfig(memCtx)
+
+	const synBit = 0x02 // FWSTATE_SYN, src nibble
+	const ackBit = 0x08 // FWSTATE_ACK, src nibble
+
+	pktSyn := createSyncPacket(t, layers.IPProtocolTCP, WithFlags(synBit))
+	_, err := fwstateHandlePackets(cpModule, pktSyn)
+	require.NoError(t, err)
+
+	snap1 := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
+	require.True(t, snap1.Found, "state must exist after first sync")
+	require.Equal(t, uint8(synBit), snap1.FlagsRaw, "after first sync only SYN must be set")
+
+	pktAck := createSyncPacket(t, layers.IPProtocolTCP, WithFlags(ackBit))
+	_, err = fwstateHandlePackets(cpModule, pktAck)
+	require.NoError(t, err)
+
+	snap2 := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
+	require.True(t, snap2.Found, "state must still exist after second sync")
+	require.Equalf(t, uint8(synBit|ackBit), snap2.FlagsRaw,
+		"flags must accumulate via OR across updates in the same layer (got 0x%02x, want 0x%02x)",
+		snap2.FlagsRaw, synBit|ackBit)
+}
+
+// TestFWStateUpdateAccumulatesPacketCounters verifies that packets_forward /
+// packets_backward counters accumulate across updates in the same active layer
+// rather than being reset to the last sync frame's contribution.
+//
+// Each incoming sync frame contributes +1 to either packets_forward (fib=0) or
+// packets_backward (fib=1) — see fwstate_build_value() in
+// modules/fwstate/dataplane/dataplane.c. Sending N sync frames for the same
+// key MUST result in totals equal to the sum of all per-frame contributions.
+func TestFWStateUpdateAccumulatesPacketCounters(t *testing.T) {
+	memCtx := testutils.NewMemoryContext("fwstate_acc_counters_test", datasize.MB*64)
+	defer memCtx.Free()
+	cpModule := fwstateModuleConfig(memCtx)
+
+	const forwardCount = 3
+	const backwardCount = 2
+
+	for range forwardCount {
+		pkt := createSyncPacket(t, layers.IPProtocolTCP, WithFib(0))
+		_, err := fwstateHandlePackets(cpModule, pkt)
+		require.NoError(t, err)
+	}
+	for range backwardCount {
+		pkt := createSyncPacket(t, layers.IPProtocolTCP, WithFib(1))
+		_, err := fwstateHandlePackets(cpModule, pkt)
+		require.NoError(t, err)
+	}
+
+	snap := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
+	require.True(t, snap.Found, "state must exist after sync frames")
+
+	require.Equalf(t, uint64(forwardCount), snap.PacketsForward,
+		"packets_forward must accumulate (got %d, want %d)",
+		snap.PacketsForward, forwardCount)
+	require.Equalf(t, uint64(backwardCount), snap.PacketsBackward,
+		"packets_backward must accumulate (got %d, want %d)",
+		snap.PacketsBackward, backwardCount)
+}
+
+// TestFWStateUpdatePreservesCreatedAt verifies that the original created_at
+// timestamp is preserved across updates within the same active layer by
+// fwmap_update_value_fwstate(). Pairs with the accumulation tests above to
+// pin down all preservation/merge semantics on the in-layer update path.
+func TestFWStateUpdatePreservesCreatedAt(t *testing.T) {
+	memCtx := testutils.NewMemoryContext("fwstate_created_at_test", datasize.MB*64)
+	defer memCtx.Free()
+	cpModule := fwstateModuleConfig(memCtx)
+
+	pkt1 := createSyncPacket(t, layers.IPProtocolTCP)
+	_, err := fwstateHandlePackets(cpModule, pkt1)
+	require.NoError(t, err)
+
+	snap1 := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
+	require.True(t, snap1.Found)
+	createdAt := snap1.CreatedAt
+	require.Greater(t, createdAt, uint64(0))
+
+	// Sleep a tiny bit so that current_time advances between calls.
+	// Even without an explicit sleep, the next call uses clock_get_time_ns()
+	// which is monotonic — but we rely on observable difference only for
+	// updated_at, not for the test assertion itself.
+	pkt2 := createSyncPacket(t, layers.IPProtocolTCP)
+	_, err = fwstateHandlePackets(cpModule, pkt2)
+	require.NoError(t, err)
+
+	snap2 := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
+	require.True(t, snap2.Found)
+
+	require.Equal(t, createdAt, snap2.CreatedAt,
+		"created_at must be preserved across updates")
+}
+
+// TestFWStateMergeFromStaleLayer verifies that when an entry exists only in a
+// stale (next) layer and a new sync arrives in a fresh active layer, the
+// cross-layer promotion path (fwmap_promote_value_fwstate) is used: flags are
+// OR-ed and packet counters are summed. This pins the cross-layer merge
+// behaviour so that a regression turning it back into "overwrite" is caught.
+func TestFWStateMergeFromStaleLayer(t *testing.T) {
+	memCtx := testutils.NewMemoryContext("fwstate_merge_stale_test", datasize.MB*64)
+	defer memCtx.Free()
+	cpModule := fwstateModuleConfig(memCtx)
+
+	const synBit = 0x02
+	const ackBit = 0x08
+
+	// Populate stale layer with SYN + 1 forward packet.
+	pkt1 := createSyncPacket(t, layers.IPProtocolTCP, WithFlags(synBit), WithFib(0))
+	_, err := fwstateHandlePackets(cpModule, pkt1)
+	require.NoError(t, err)
+
+	// Push that layer down, allocate a new active layer.
+	InsertNewLayer(cpModule)
+
+	// Insert into the fresh active layer with ACK + 1 backward packet.
+	pkt2 := createSyncPacket(t, layers.IPProtocolTCP, WithFlags(ackBit), WithFib(1))
+	_, err = fwstateHandlePackets(cpModule, pkt2)
+	require.NoError(t, err)
+
+	snap := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
+	require.True(t, snap.Found, "merged state must be visible from active layer")
+	require.Equalf(t, uint8(synBit|ackBit), snap.FlagsRaw,
+		"flags must be merged across layers (got 0x%02x, want 0x%02x)",
+		snap.FlagsRaw, synBit|ackBit)
+	require.Equalf(t, uint64(1), snap.PacketsForward,
+		"packets_forward from stale layer must be carried over (got %d)", snap.PacketsForward)
+	require.Equalf(t, uint64(1), snap.PacketsBackward,
+		"packets_backward from active layer must be summed in (got %d)", snap.PacketsBackward)
 }

--- a/tests/fwstate/fwmap_heavy_bench_test.c
+++ b/tests/fwstate/fwmap_heavy_bench_test.c
@@ -194,7 +194,7 @@ test_multithreaded_benchmark(void *mt_arena) {
 			(void *)bench_key_equal;
 		fwmap_func_registry[FWMAP_COPY_KEY_DEFAULT] =
 			(void *)bench_copy_key;
-		fwmap_func_registry[FWMAP_COPY_VALUE_DEFAULT] =
+		fwmap_func_registry[FWMAP_UPDATE_VALUE_DEFAULT] =
 			(void *)bench_copy_value;
 		registered = true;
 	}
@@ -208,7 +208,7 @@ test_multithreaded_benchmark(void *mt_arena) {
 		.key_equal_fn_id = FWMAP_KEY_EQUAL_DEFAULT,
 		.rand_fn_id = FWMAP_RAND_DEFAULT,
 		.copy_key_fn_id = FWMAP_COPY_KEY_DEFAULT,
-		.copy_value_fn_id = FWMAP_COPY_VALUE_DEFAULT,
+		.update_value_fn_id = FWMAP_UPDATE_VALUE_DEFAULT,
 		.index_size = index_size,
 		.extra_bucket_count = index_size >> 8,
 	};

--- a/tests/fwstate/fwstate_cursor_test.c
+++ b/tests/fwstate/fwstate_cursor_test.c
@@ -66,8 +66,8 @@ test_env_create(void *arena, const char *name) {
 	cfg.key_equal_fn_id = FWMAP_KEY_EQUAL_FW4;
 	cfg.rand_fn_id = FWMAP_RAND_DEFAULT;
 	cfg.copy_key_fn_id = FWMAP_COPY_KEY_FW4;
-	cfg.copy_value_fn_id = FWMAP_COPY_VALUE_FWSTATE;
-	cfg.merge_value_fn_id = FWMAP_MERGE_VALUE_FWSTATE;
+	cfg.update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE;
+	cfg.promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE;
 	cfg.index_size = 128;
 	cfg.extra_bucket_count = 8;
 


### PR DESCRIPTION
fwmap_copy_value_fwstate() used to overwrite the stored fw_state_value
when the key already existed in the active layer, preserving only
created_at. Successive sync frames for the same flow therefore lost
accumulated TCP flags and reset packets_forward/packets_backward.

Make the in-layer update path merge with the previous value: OR flags,
sum per-direction counters, take updated_at/external from the new frame,
keep created_at.

Also rename the two value callbacks for clarity:
  copy_value  -> update_value  (in-layer; old lives in *dst)
  merge_value -> promote_value (cross-layer; old lives in stale layer)

Add Go regression tests covering both the in-layer accumulation and the
cross-layer promotion behavior.
