### PR TITLE
refactor(fwstate): unify fwstate TTL selection in lib/fwstate

### DIFF
--- a/lib/fwstate/fwstate_cursor.h
+++ b/lib/fwstate/fwstate_cursor.h
@@ -21,33 +21,6 @@ typedef struct fwstate_cursor_entry {
 	bool expired;
 } fwstate_cursor_entry_t;
 
-/// Select the appropriate TTL for a firewall state entry based on its
-/// protocol type and TCP flags.
-static inline uint64_t
-fwstate_entry_ttl(
-	uint16_t proto, uint8_t raw_flags, const struct fwstate_timeouts *t
-) {
-	union fw_state_flags_u flags = {.raw = raw_flags};
-	if (proto == IPPROTO_UDP) {
-		return t->udp;
-	}
-	if (proto == IPPROTO_TCP) {
-		if (flags.tcp.src & FWSTATE_FIN ||
-		    flags.tcp.dst & FWSTATE_FIN) {
-			return t->tcp_fin;
-		}
-		if ((flags.tcp.src & FWSTATE_SYN) &&
-		    (flags.tcp.dst & FWSTATE_ACK)) {
-			return t->tcp_syn_ack;
-		}
-		if (flags.tcp.src & FWSTATE_SYN) {
-			return t->tcp_syn;
-		}
-		return t->tcp;
-	}
-	return t->default_;
-}
-
 static inline int
 fwstate_cursor_read_entry(
 	fwmap_t *map,

--- a/lib/fwstate/types.h
+++ b/lib/fwstate/types.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <netinet/in.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#include "config.h"
 
 #define FW_STATE_ADDR_TYPE_IP4 4
 #define FW_STATE_ADDR_TYPE_IP6 6
@@ -129,3 +132,33 @@ struct fw_state_sync_frame {
 	uint32_t flow_id6;   // IPv6 flow label
 	uint32_t extra;	     // Reserved for future use
 } __attribute__((__packed__));
+
+/// Select the appropriate TTL for a firewall state entry based on its
+/// protocol type and TCP flags.
+/// Ported from the dataplane implementation
+/// (yanet/dataplane/slow_worker.cpp:496).
+static inline uint64_t
+fwstate_entry_ttl(
+	uint16_t proto, uint8_t raw_flags, const struct fwstate_timeouts *t
+) {
+	union fw_state_flags_u flags = {.raw = raw_flags};
+
+	uint64_t ttl = t->default_;
+	if (proto == IPPROTO_UDP) {
+		ttl = t->udp;
+	} else if (proto == IPPROTO_TCP) {
+		ttl = t->tcp;
+
+		uint8_t tcp_flags = flags.tcp.src | flags.tcp.dst;
+		if (tcp_flags & FWSTATE_ACK) {
+			ttl = t->tcp_syn_ack;
+		} else if (tcp_flags & FWSTATE_SYN) {
+			ttl = t->tcp_syn;
+		}
+		if (tcp_flags & FWSTATE_FIN) {
+			ttl = t->tcp_fin;
+		}
+	}
+
+	return ttl;
+}

--- a/modules/fwstate/controlplane/fwstatepb/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/fwstate.proto
@@ -132,7 +132,7 @@ message MapConfig {
 // Firewall state synchronization configuration
 message SyncConfig {
   commonpb.IPAddress src_addr = 1;           // IPv6 source address;
-  bytes dst_ether = 2;                        // Destination MAC address (6 bytes);
+  bytes dst_ether = 2;                       // Destination MAC address (6 bytes);
   commonpb.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address;
   uint32 port_multicast = 4;                 // Multicast port;
   commonpb.IPAddress dst_addr_unicast = 5;   // Unicast IPv6 address;

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -122,24 +122,9 @@ fwstate_build_value(
 		state.value.packets_backward = 1;
 	}
 
-	// Determine TTL based on protocol and flags
-	// Logic from yanet/dataplane/slow_worker.cpp:496
-	state.ttl = timeouts_config->default_;
-	if (sync_frame->proto == IPPROTO_UDP) {
-		state.ttl = timeouts_config->udp;
-	} else if (sync_frame->proto == IPPROTO_TCP) {
-		state.ttl = timeouts_config->tcp;
-		uint8_t flags =
-			state.value.flags.tcp.src | state.value.flags.tcp.dst;
-		if (flags & FWSTATE_ACK) {
-			state.ttl = timeouts_config->tcp_syn_ack;
-		} else if (flags & FWSTATE_SYN) {
-			state.ttl = timeouts_config->tcp_syn;
-		}
-		if (flags & FWSTATE_FIN) {
-			state.ttl = timeouts_config->tcp_fin;
-		}
-	}
+	state.ttl = fwstate_entry_ttl(
+		sync_frame->proto, state.value.flags.raw, timeouts_config
+	);
 
 	return state;
 }

--- a/tests/fwstate/fwstate_cursor_test.c
+++ b/tests/fwstate/fwstate_cursor_test.c
@@ -196,7 +196,7 @@ test_ttl_selection(void) {
 	flags.tcp.src = FWSTATE_ACK;
 	flags.tcp.dst = FWSTATE_ACK;
 	assert(fwstate_entry_ttl(IPPROTO_TCP, flags.raw, &test_timeouts) ==
-	       test_timeouts.tcp);
+	       test_timeouts.tcp_syn_ack);
 
 	/* UDP */
 	flags.raw = 0;


### PR DESCRIPTION
Move fwstate_entry_ttl to shared fwstate types and switch dataplane to use it,
matching dataplane semantics across users.