### PR TITLE
fix(fwstate): unify TTL selection and align cursor expiry with last sync

### DIFF
--- a/lib/fwstate/fwstate_cursor.h
+++ b/lib/fwstate/fwstate_cursor.h
@@ -1,17 +1,15 @@
 #pragma once
 
-#include <netinet/in.h>
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "config.h"
 #include "fwmap.h"
+#include "types.h"
 
 typedef struct fwstate_cursor {
 	int64_t key_pos;
 	bool include_expired;
-	struct fwstate_timeouts timeouts;
 } fwstate_cursor_t;
 
 typedef struct fwstate_cursor_entry {
@@ -20,33 +18,6 @@ typedef struct fwstate_cursor_entry {
 	uint32_t idx;
 	bool expired;
 } fwstate_cursor_entry_t;
-
-/// Select the appropriate TTL for a firewall state entry based on its
-/// protocol type and TCP flags.
-static inline uint64_t
-fwstate_entry_ttl(
-	uint16_t proto, uint8_t raw_flags, const struct fwstate_timeouts *t
-) {
-	union fw_state_flags_u flags = {.raw = raw_flags};
-	if (proto == IPPROTO_UDP) {
-		return t->udp;
-	}
-	if (proto == IPPROTO_TCP) {
-		if (flags.tcp.src & FWSTATE_FIN ||
-		    flags.tcp.dst & FWSTATE_FIN) {
-			return t->tcp_fin;
-		}
-		if ((flags.tcp.src & FWSTATE_SYN) &&
-		    (flags.tcp.dst & FWSTATE_ACK)) {
-			return t->tcp_syn_ack;
-		}
-		if (flags.tcp.src & FWSTATE_SYN) {
-			return t->tcp_syn;
-		}
-		return t->tcp;
-	}
-	return t->default_;
-}
 
 static inline int
 fwstate_cursor_read_entry(
@@ -72,12 +43,7 @@ fwstate_cursor_read_entry(
 		return 0;
 	}
 
-	const struct fw_state_key_hdr *hdr =
-		(const struct fw_state_key_hdr *)key;
-	uint64_t ttl = fwstate_entry_ttl(
-		hdr->proto, value->flags.raw, &cursor->timeouts
-	);
-	bool expired = (value->updated_at + ttl <= now);
+	bool expired = fwstate_value_is_expired(value, now);
 
 	if (!cursor->include_expired && expired) {
 		return 0;

--- a/lib/fwstate/ops.h
+++ b/lib/fwstate/ops.h
@@ -49,10 +49,12 @@ fwmap_update_value_fwstate(
 	struct fw_state_value old = *d;
 	*d = *s;
 
-	// Update: take ownership/timestamp from the incoming frame, but keep
-	// the original creation timestamp so the connection age is preserved.
+	// Update: take ownership/timestamp/last_ttl from the incoming frame,
+	// but keep the original creation timestamp so the connection age is
+	// preserved.
 	d->created_at = old.created_at;
-	// (external and updated_at are inherited from *s by the *d = *s above.)
+	// (external, updated_at, and last_ttl are inherited from *s by *d =
+	// *s.)
 
 	// Merge: TCP flags accumulate across frames (FIN/SYN/RST/ACK once seen,
 	// stays seen), and per-direction packet counters are summed.
@@ -83,12 +85,13 @@ fwmap_promote_value_fwstate(
 	const struct fw_state_value *old_v =
 		(const struct fw_state_value *)old_value;
 
-	// Update: ownership and last-seen timestamp come from the incoming
-	// frame; the creation timestamp comes from the older copy in the stale
-	// layer so the connection age is preserved across promotion.
+	// Update: ownership, last-seen timestamp, and last_ttl come from the
+	// incoming frame; the creation timestamp comes from the older copy in
+	// the stale layer so the connection age is preserved across promotion.
 	d->external = new_v->external;
 	d->updated_at = new_v->updated_at;
 	d->created_at = old_v->created_at;
+	fwstate_value_set_last_ttl(d, fwstate_ttl48_load(new_v->last_ttl));
 
 	// Merge: TCP flags are OR-combined and per-direction packet counters
 	// are summed across the two layers.

--- a/lib/fwstate/types.h
+++ b/lib/fwstate/types.h
@@ -1,14 +1,20 @@
 #pragma once
 
+#include <netinet/in.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+
+#include "config.h"
 
 #define FW_STATE_ADDR_TYPE_IP4 4
 #define FW_STATE_ADDR_TYPE_IP6 6
 
 #define FW_STATE_SYNC_THRESHOLD (uint64_t)8e9 // nanoseconds
 #define FW_STATE_DEFAULT_TIMEOUT (uint64_t)120e9
+
+// Nanosecond TTL stored in fw_state_value::last_ttl (48-bit, little-endian).
+#define FWSTATE_TTL48_MAX ((uint64_t)((1ULL << 48) - 1))
 
 /**
  * Common header shared by all fw_state key types.
@@ -97,7 +103,9 @@ union fw_state_flags_u {
 struct fw_state_value {
 	bool external; // State ownership (internal/external)
 	union fw_state_flags_u flags;
-	uint8_t _pad[6];
+	// TTL (ns) from the last put/sync frame; expiry is updated_at +
+	// last_ttl.
+	uint8_t last_ttl[6];
 	// Timestamp when the state was created
 	uint64_t created_at;
 	// Timestamp when the last sync packet was emitted
@@ -129,3 +137,67 @@ struct fw_state_sync_frame {
 	uint32_t flow_id6;   // IPv6 flow label
 	uint32_t extra;	     // Reserved for future use
 } __attribute__((__packed__));
+
+static inline void
+fwstate_ttl48_store(uint8_t out[6], uint64_t ttl_ns) {
+	out[0] = (uint8_t)(ttl_ns);
+	out[1] = (uint8_t)(ttl_ns >> 8);
+	out[2] = (uint8_t)(ttl_ns >> 16);
+	out[3] = (uint8_t)(ttl_ns >> 24);
+	out[4] = (uint8_t)(ttl_ns >> 32);
+	out[5] = (uint8_t)(ttl_ns >> 40);
+}
+
+static inline uint64_t
+fwstate_ttl48_load(const uint8_t in[6]) {
+	return (uint64_t)in[0] | ((uint64_t)in[1] << 8) |
+	       ((uint64_t)in[2] << 16) | ((uint64_t)in[3] << 24) |
+	       ((uint64_t)in[4] << 32) | ((uint64_t)in[5] << 40);
+}
+
+static inline void
+fwstate_value_set_last_ttl(struct fw_state_value *value, uint64_t ttl_ns) {
+	// Configured timeouts must fit in last_ttl (see FWSTATE_TTL48_MAX).
+	fwstate_ttl48_store(value->last_ttl, ttl_ns);
+}
+
+static inline uint64_t
+fwstate_value_expires_at(const struct fw_state_value *value) {
+	return value->updated_at + fwstate_ttl48_load(value->last_ttl);
+}
+
+static inline bool
+fwstate_value_is_expired(const struct fw_state_value *value, uint64_t now) {
+	if (value->updated_at == 0) {
+		return true;
+	}
+	return fwstate_value_expires_at(value) <= now;
+}
+
+/// Select TTL for a frame from protocol and TCP flags.
+/// Ported from yanet/dataplane/slow_worker.cpp:496.
+static inline uint64_t
+fwstate_entry_ttl(
+	uint16_t proto, uint8_t raw_flags, const struct fwstate_timeouts *t
+) {
+	union fw_state_flags_u flags = {.raw = raw_flags};
+
+	uint64_t ttl = t->default_;
+	if (proto == IPPROTO_UDP) {
+		ttl = t->udp;
+	} else if (proto == IPPROTO_TCP) {
+		ttl = t->tcp;
+
+		uint8_t tcp_flags = flags.tcp.src | flags.tcp.dst;
+		if (tcp_flags & FWSTATE_ACK) {
+			ttl = t->tcp_syn_ack;
+		} else if (tcp_flags & FWSTATE_SYN) {
+			ttl = t->tcp_syn;
+		}
+		if (tcp_flags & FWSTATE_FIN) {
+			ttl = t->tcp_fin;
+		}
+	}
+
+	return ttl;
+}

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -455,10 +455,6 @@ fwstate_config_cursor_create(
 	int64_t index,
 	bool include_expired
 ) {
-	struct fwstate_module_config *config = container_of(
-		cp_module, struct fwstate_module_config, cp_module
-	);
-
 	// Verify the map/layer exists
 	fwmap_t *map =
 		fwstate_config_resolve_map(cp_module, is_ipv6, layer_index);
@@ -469,7 +465,6 @@ fwstate_config_cursor_create(
 
 	cursor->key_pos = index;
 	cursor->include_expired = include_expired;
-	cursor->timeouts = config->cfg.sync_config.timeouts;
 
 	return 0;
 }

--- a/modules/fwstate/controlplane/fwstatepb/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/fwstate.proto
@@ -132,7 +132,7 @@ message MapConfig {
 // Firewall state synchronization configuration
 message SyncConfig {
   commonpb.IPAddress src_addr = 1;           // IPv6 source address;
-  bytes dst_ether = 2;                        // Destination MAC address (6 bytes);
+  bytes dst_ether = 2;                       // Destination MAC address (6 bytes);
   commonpb.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address;
   uint32 port_multicast = 4;                 // Multicast port;
   commonpb.IPAddress dst_addr_unicast = 5;   // Unicast IPv6 address;

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -122,24 +122,10 @@ fwstate_build_value(
 		state.value.packets_backward = 1;
 	}
 
-	// Determine TTL based on protocol and flags
-	// Logic from yanet/dataplane/slow_worker.cpp:496
-	state.ttl = timeouts_config->default_;
-	if (sync_frame->proto == IPPROTO_UDP) {
-		state.ttl = timeouts_config->udp;
-	} else if (sync_frame->proto == IPPROTO_TCP) {
-		state.ttl = timeouts_config->tcp;
-		uint8_t flags =
-			state.value.flags.tcp.src | state.value.flags.tcp.dst;
-		if (flags & FWSTATE_ACK) {
-			state.ttl = timeouts_config->tcp_syn_ack;
-		} else if (flags & FWSTATE_SYN) {
-			state.ttl = timeouts_config->tcp_syn;
-		}
-		if (flags & FWSTATE_FIN) {
-			state.ttl = timeouts_config->tcp_fin;
-		}
-	}
+	state.ttl = fwstate_entry_ttl(
+		sync_frame->proto, state.value.flags.raw, timeouts_config
+	);
+	fwstate_value_set_last_ttl(&state.value, state.ttl);
 
 	return state;
 }

--- a/modules/fwstate/tests/dataplane/cursor_test.go
+++ b/modules/fwstate/tests/dataplane/cursor_test.go
@@ -24,6 +24,12 @@ const (
 	flagSYN uint8 = 0x02
 )
 
+// Match fwstateModuleConfig sync timeouts (nanoseconds).
+const (
+	ttlTCPNs = uint64(120e9)
+	ttlUDPNs = uint64(30e9)
+)
+
 // ipToUint32 converts an IPv4 string to a uint32 in network byte order.
 func ipToUint32(s string) uint32 {
 	ip := net.ParseIP(s).To4()
@@ -46,7 +52,7 @@ func TestCursorForwardRead(t *testing.T) {
 			protoTCP, uint16(1000+i), 80,
 			ipToUint32("10.0.0.1"), ipToUint32("192.168.0.1"),
 			flagACK, flagACK,
-			now, now,
+			now, now, ttlTCPNs,
 		)
 		require.NoError(t, err, "insert entry %d", i)
 	}
@@ -79,7 +85,7 @@ func TestCursorBackwardRead(t *testing.T) {
 			protoTCP, uint16(2000+i), 443,
 			ipToUint32("10.0.0.1"), ipToUint32("192.168.0.2"),
 			flagACK, flagACK,
-			now, now,
+			now, now, ttlTCPNs,
 		)
 		require.NoError(t, err)
 	}
@@ -112,7 +118,7 @@ func TestCursorExpiredFiltering(t *testing.T) {
 		protoTCP, 3000, 80,
 		ipToUint32("10.0.0.1"), ipToUint32("192.168.0.1"),
 		flagACK, flagACK,
-		now, now,
+		now, now, ttlTCPNs,
 	)
 	require.NoError(t, err)
 
@@ -121,7 +127,7 @@ func TestCursorExpiredFiltering(t *testing.T) {
 		protoUDP, 3001, 53,
 		ipToUint32("10.0.0.2"), ipToUint32("192.168.0.1"),
 		0, 0,
-		now, now,
+		now, now, ttlUDPNs,
 	)
 	require.NoError(t, err)
 
@@ -130,7 +136,7 @@ func TestCursorExpiredFiltering(t *testing.T) {
 		protoTCP, 3002, 443,
 		ipToUint32("10.0.0.3"), ipToUint32("192.168.0.1"),
 		flagACK, flagACK,
-		now, now,
+		now, now, ttlTCPNs,
 	)
 	require.NoError(t, err)
 
@@ -169,7 +175,7 @@ func TestCursorKeyDataCorrectness(t *testing.T) {
 		protoTCP, 12345, 8080,
 		srcAddr, dstAddr,
 		flagSYN, 0,
-		now, now,
+		now, now, ttlTCPNs,
 	)
 	require.NoError(t, err)
 
@@ -198,7 +204,7 @@ func TestCursorValueDataCorrectness(t *testing.T) {
 		protoTCP, 9000, 80,
 		ipToUint32("10.0.0.1"), ipToUint32("192.168.0.1"),
 		flagACK, flagACK,
-		now-1000, now,
+		now-1000, now, ttlTCPNs,
 	)
 	require.NoError(t, err)
 
@@ -241,7 +247,7 @@ func TestCursorPaging(t *testing.T) {
 			protoTCP, uint16(6000+i), 80,
 			ipToUint32("10.0.0.1")+uint32(i), ipToUint32("192.168.0.1"),
 			flagACK, flagACK,
-			now, now,
+			now, now, ttlTCPNs,
 		)
 		require.NoError(t, err)
 	}

--- a/modules/fwstate/tests/dataplane/cursor_test_helper.go
+++ b/modules/fwstate/tests/dataplane/cursor_test_helper.go
@@ -33,14 +33,14 @@ type CursorResult struct {
 	PktBackward uint64
 }
 
-// insertFw4Entry inserts a single IPv4 fwstate entry directly into the
-// active layer's fwmap using fwmap_put.
+// insertFw4Entry inserts a single IPv4 fwstate entry into the active layer.
 func insertFw4Entry(
 	cpModule *C.struct_cp_module,
 	proto uint16, srcPort uint16, dstPort uint16,
 	srcAddr uint32, dstAddr uint32,
 	srcFlags uint8, dstFlags uint8,
 	createdAt uint64, updatedAt uint64,
+	ttlNs uint64,
 ) error {
 	// Resolve the active IPv4 map (layer 0)
 	fwmap := C.fwstate_config_resolve_map(cpModule, C.bool(false), C.uint32_t(0))
@@ -62,9 +62,9 @@ func insertFw4Entry(
 	val.updated_at = C.uint64_t(updatedAt)
 	val.packets_forward = C.uint64_t(1)
 	val.packets_backward = C.uint64_t(0)
+	C.fwstate_value_set_last_ttl(&val, C.uint64_t(ttlNs))
 
-	ttl := C.uint64_t(50000) // large TTL for the bucket deadline
-	ret := C.fwmap_put(fwmap, C.uint16_t(0), C.uint64_t(updatedAt), ttl,
+	ret := C.fwmap_put(fwmap, C.uint16_t(0), C.uint64_t(updatedAt), C.uint64_t(ttlNs),
 		unsafe.Pointer(&key), unsafe.Pointer(&val), nil)
 	if ret < 0 {
 		return fmt.Errorf("fwmap_put failed: %d", ret)

--- a/tests/fwstate/fwstate_cursor_test.c
+++ b/tests/fwstate/fwstate_cursor_test.c
@@ -21,7 +21,6 @@
 
 #define ARENA_SIZE_MB 64
 #define ARENA_SIZE ((1 << 20) * ARENA_SIZE_MB)
-#define DEFAULT_TTL 50000
 #define WORKER_ID 0
 
 /* Global time counter for TTL expiration testing */
@@ -114,9 +113,16 @@ test_env_insert_tcp(
 		val.created_at = now;
 		val.updated_at = now;
 		val.packets_forward = 1;
+		fwstate_value_set_last_ttl(&val, test_timeouts.tcp);
 
 		int64_t ret = fwmap_put(
-			env->map, WORKER_ID, now, DEFAULT_TTL, &key, &val, NULL
+			env->map,
+			WORKER_ID,
+			now,
+			test_timeouts.tcp,
+			&key,
+			&val,
+			NULL
 		);
 		assert(ret >= 0);
 	}
@@ -149,9 +155,16 @@ test_env_insert_udp(
 		val.created_at = now;
 		val.updated_at = now;
 		val.packets_forward = 1;
+		fwstate_value_set_last_ttl(&val, test_timeouts.udp);
 
 		int64_t ret = fwmap_put(
-			env->map, WORKER_ID, now, DEFAULT_TTL, &key, &val, NULL
+			env->map,
+			WORKER_ID,
+			now,
+			test_timeouts.udp,
+			&key,
+			&val,
+			NULL
 		);
 		assert(ret >= 0);
 	}
@@ -192,11 +205,11 @@ test_ttl_selection(void) {
 	assert(fwstate_entry_ttl(IPPROTO_TCP, flags.raw, &test_timeouts) ==
 	       test_timeouts.tcp_fin);
 
-	/* TCP established (no special flags) */
+	/* TCP with ACK on both sides */
 	flags.tcp.src = FWSTATE_ACK;
 	flags.tcp.dst = FWSTATE_ACK;
 	assert(fwstate_entry_ttl(IPPROTO_TCP, flags.raw, &test_timeouts) ==
-	       test_timeouts.tcp);
+	       test_timeouts.tcp_syn_ack);
 
 	/* UDP */
 	flags.raw = 0;
@@ -225,7 +238,6 @@ test_empty_map(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = 0,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 	uint32_t n =
 		fwstate_cursor_read_forward(env.map, &cursor, now, out, 10);
@@ -257,7 +269,6 @@ test_forward_iteration(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = 0,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 
 	uint32_t n =
@@ -297,7 +308,6 @@ test_backward_iteration(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = INT64_MAX,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 
 	uint32_t n =
@@ -347,7 +357,6 @@ test_expired_skipped(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = 0,
 		.include_expired = false,
-		.timeouts = test_timeouts,
 	};
 
 	uint32_t n = fwstate_cursor_read_forward(
@@ -388,7 +397,6 @@ test_include_expired(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = 0,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 
 	uint32_t n = fwstate_cursor_read_forward(
@@ -423,7 +431,6 @@ test_uninitialized_skipped(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = 0,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 
 	uint32_t n =
@@ -455,7 +462,6 @@ test_paging(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = 0,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 
 	int total = 0;
@@ -519,7 +525,6 @@ test_forward_bounds(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = 3,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 	uint32_t n =
 		fwstate_cursor_read_forward(env.map, &cursor, now, out, 10);
@@ -555,7 +560,6 @@ test_backward_clamping(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = 999,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 
 	uint32_t n =
@@ -591,7 +595,6 @@ test_single_entry_backward(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = INT64_MAX,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 
 	uint32_t n =
@@ -627,7 +630,6 @@ test_backward_paging(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = INT64_MAX,
 		.include_expired = true,
-		.timeouts = test_timeouts,
 	};
 
 	int total = 0;
@@ -696,7 +698,6 @@ test_backward_expired_at_zero(void *arena) {
 	fwstate_cursor_t cursor = {
 		.key_pos = INT64_MAX,
 		.include_expired = false,
-		.timeouts = test_timeouts,
 	};
 
 	uint32_t n = fwstate_cursor_read_backward(


### PR DESCRIPTION
Move fwstate_entry_ttl to types.h with dataplane semantics. Store the
incoming frame TTL as u48 last_ttl in fw_state_value; cursor expiry uses
updated_at + last_ttl so ListEntries matches bucket deadline policy.