### PR TITLE
fix: use shared rate formatters in devices

### DIFF
--- a/web/src/pages/builtin/devices/DeviceDetails.tsx
+++ b/web/src/pages/builtin/devices/DeviceDetails.tsx
@@ -9,7 +9,7 @@ import {
 } from './components/Icons';
 import { DeviceDiffModal } from './components/DeviceDiffModal';
 import { BigSpark } from './components/BigSpark';
-import { fmtPps, fmtBps } from './components/MiniSpark';
+import { formatBps, formatPps } from '../../../utils';
 import { PipelineTable } from './PipelineTable';
 import type { LocalDevice } from './types';
 import type { PipelineId } from '../../../api/pipelines';
@@ -56,10 +56,7 @@ const MetricBlock = ({
             </span>
             <span className="dv-metric-lbl">{subLabel}</span>
         </div>
-        <div className="dv-metric-val mono">
-            {isPps ? fmtPps(value) : fmtBps(value)}
-            {isPps && <span className="dv-metric-unit">pps</span>}
-        </div>
+        <div className="dv-metric-val mono">{isPps ? formatPps(value) : formatBps(value)}</div>
         <BigSpark
             deviceId={deviceId}
             series={series}

--- a/web/src/pages/builtin/devices/DeviceListItem.tsx
+++ b/web/src/pages/builtin/devices/DeviceListItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IconPlain, IconVlan } from './components/Icons';
 import { MiniSpark } from './components/MiniSpark';
-import { fmtPps } from './components/MiniSpark';
+import { formatPps } from '../../../utils';
 import type { LocalDevice } from './types';
 import type { CounterHistoryEntry } from '../../../hooks/useCounterHistory';
 import type { DeviceCounterData } from '../../../hooks/useDeviceCounters';
@@ -64,8 +64,7 @@ export const DeviceListItem: React.FC<DeviceListItemProps> = ({
             </span>
 
             <span className="dv-row-metric">
-                <span className="dv-row-pps mono">{fmtPps(rxPps)}</span>
-                <span className="dv-row-pps-lbl">pps</span>
+                <span className="dv-row-pps mono">{formatPps(rxPps)}</span>
             </span>
 
             <span className="dv-row-status">

--- a/web/src/pages/builtin/devices/components/MiniSpark.tsx
+++ b/web/src/pages/builtin/devices/components/MiniSpark.tsx
@@ -1,23 +1,5 @@
 import React from 'react';
 
-/** Format packets per second without the unit suffix (used inside sparkline labels). */
-export const fmtPps = (n: number): string => {
-    if (n === 0) return '0';
-    if (n >= 1e9) return (n / 1e9).toFixed(2) + 'G';
-    if (n >= 1e6) return (n / 1e6).toFixed(1) + 'M';
-    if (n >= 1e3) return (n / 1e3).toFixed(1) + 'K';
-    return String(Math.round(n));
-};
-
-/** Format bytes per second with a unit suffix. */
-export const fmtBps = (n: number): string => {
-    if (n === 0) return '0';
-    if (n >= 1e9) return (n / 1e9).toFixed(2) + ' GB/s';
-    if (n >= 1e6) return (n / 1e6).toFixed(1) + ' MB/s';
-    if (n >= 1e3) return (n / 1e3).toFixed(1) + ' KB/s';
-    return n + ' B/s';
-};
-
 const pathFor = (values: number[], w: number, h: number, pad = 1): string => {
     if (!values.length) return '';
     const max = Math.max(1, ...values);

--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { formatBps, formatPps } from './format';
+
+describe('formatPps', () => {
+    it('rounds values below 1k and adds suffix', () => {
+        expect(formatPps(0)).toBe('0 pps');
+        expect(formatPps(285.13421819144713)).toBe('285 pps');
+    });
+
+    it('formats values in the K and M ranges with units', () => {
+        expect(formatPps(1_234)).toBe('1.2K pps');
+        expect(formatPps(1_234_567)).toBe('1.2M pps');
+    });
+});
+
+describe('formatBps', () => {
+    it('rounds bytes per second below 1 KB', () => {
+        expect(formatBps(285.13421819144713)).toBe('285 B/s');
+    });
+
+    it('formats rates with binary suffixes above 1 KB', () => {
+        expect(formatBps(1536)).toBe('1.5 KB/s');
+        expect(formatBps(1024 * 1024)).toBe('1.0 MB/s');
+    });
+});


### PR DESCRIPTION
- Reused shared web rate formatters on the Devices page instead of local formatter copies.
- Removed Devices-owned pps and bps formatter exports from the sparkline component.
- Added focused shared formatter coverage for fractional byte and packet rates.
- Validated with `npm run test -- src/utils/format.test.ts` and `npm run build`.