### PR TITLE
feat: make fwstate inspect card clickable

### DIFF
--- a/web/src/pages/builtin/dashboard/DataplaneModules.tsx
+++ b/web/src/pages/builtin/dashboard/DataplaneModules.tsx
@@ -1,7 +1,14 @@
 import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { InstanceInfo } from '../../../api/inspect';
-import { MODULE_DESCRIPTIONS, MODULE_ROUTES, computeModulePipelineUsage, type AgentUsage } from '../inspect/utils';
+import {
+    computeModulePipelineUsage,
+    getModuleCardAgentUsage,
+    getModuleDescription,
+    getModuleRoute,
+    normalizeModuleName,
+    type AgentUsage,
+} from '../inspect/utils';
 import { MemoryBar } from '../inspect/MemoryBar';
 import { fmtIEC } from '../inspect/formatters';
 
@@ -20,14 +27,16 @@ export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance, us
 
     const moduleData = useMemo(
         () =>
-            modules.map((m) => {
+            modules.map((m, idx) => {
                 const name = m.name ?? '';
+                const key = name || `module-${idx}`;
+                const moduleKey = normalizeModuleName(name);
                 const cfg = configs.filter(
-                    (c) => (c.type?.toLowerCase() ?? '') === name.toLowerCase(),
+                    (c) => normalizeModuleName(c.type ?? '') === moduleKey,
                 ).length;
-                const pipe = pipeUsage.get(name.toLowerCase()) ?? 0;
+                const pipe = pipeUsage.get(moduleKey) ?? 0;
                 const inUse = cfg > 0 || pipe > 0;
-                return { name, cfg, pipe, inUse, desc: MODULE_DESCRIPTIONS[name] ?? '' };
+                return { key, name, cfg, pipe, inUse, desc: getModuleDescription(name) };
             }),
         [modules, configs, pipeUsage],
     );
@@ -53,7 +62,7 @@ export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance, us
                 style={{ gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))` }}
             >
                 {moduleData.map((m) => {
-                    const href = MODULE_ROUTES[m.name];
+                    const href = getModuleRoute(m.name);
                     const isClickable = Boolean(href);
                     const className = [
                         'dash-module-card',
@@ -71,7 +80,7 @@ export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance, us
                         : undefined;
                     return (
                         <div
-                            key={m.name}
+                            key={m.key}
                             className={className}
                             onClick={handleClick}
                             onKeyDown={handleKeyDown}
@@ -90,7 +99,7 @@ export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance, us
                             <div className="dash-module-card__desc">{m.desc}</div>
                             <div className="dash-module-card__stats">{m.cfg}cfg · {m.pipe}pipe</div>
                             {(() => {
-                                const ag = usage.get(m.name);
+                                const ag = getModuleCardAgentUsage(usage, m.name);
                                 if (!ag) return null;
                                 return (
                                     <div className="dash-module-card__mem">

--- a/web/src/pages/builtin/inspect/ModuleStrip.tsx
+++ b/web/src/pages/builtin/inspect/ModuleStrip.tsx
@@ -3,7 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import type { InstanceInfo } from '../../../api/inspect';
 import { fmtIEC } from './formatters';
 import { MemoryBar } from './MemoryBar';
-import { MODULE_DESCRIPTIONS, MODULE_ROUTES, computeModulePipelineUsage } from './utils';
+import {
+    computeModulePipelineUsage,
+    getModuleCardAgentUsage,
+    getModuleDescription,
+    getModuleRoute,
+    normalizeModuleName,
+} from './utils';
 import type { AgentUsage } from './utils';
 
 export interface ModuleStripProps {
@@ -21,12 +27,14 @@ export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance, usage }) => 
 
     const moduleData = useMemo(
         () =>
-            modules.map((m) => {
+            modules.map((m, idx) => {
                 const name = m.name ?? '';
-                const cfg = configs.filter((c) => (c.type?.toLowerCase() ?? '') === name.toLowerCase()).length;
-                const pipe = pipeUsage.get(name.toLowerCase()) ?? 0;
+                const key = name || `module-${idx}`;
+                const moduleKey = normalizeModuleName(name);
+                const cfg = configs.filter((c) => normalizeModuleName(c.type ?? '') === moduleKey).length;
+                const pipe = pipeUsage.get(moduleKey) ?? 0;
                 const inUse = cfg > 0 || pipe > 0;
-                return { name, cfg, pipe, inUse, desc: MODULE_DESCRIPTIONS[name] ?? '' };
+                return { key, name, cfg, pipe, inUse, desc: getModuleDescription(name) };
             }),
         [modules, configs, pipeUsage],
     );
@@ -50,7 +58,7 @@ export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance, usage }) => 
                 style={{ gridTemplateColumns: `repeat(${modules.length || 1}, minmax(0, 1fr))` }}
             >
                 {moduleData.map((m) => {
-                    const href = MODULE_ROUTES[m.name];
+                    const href = getModuleRoute(m.name);
                     const isClickable = Boolean(href);
                     const className = [
                         'iv-module-card',
@@ -68,7 +76,7 @@ export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance, usage }) => 
                         : undefined;
                     return (
                         <div
-                            key={m.name}
+                            key={m.key}
                             className={className}
                             onClick={handleClick}
                             onKeyDown={handleKeyDown}
@@ -85,7 +93,7 @@ export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance, usage }) => 
                             <div className="iv-module-card__desc">{m.desc}</div>
                             <div className="iv-module-card__stats">{m.cfg}cfg · {m.pipe}pipe</div>
                             {(() => {
-                                const mem = usage.get(m.name);
+                                const mem = getModuleCardAgentUsage(usage, m.name);
                                 if (!mem) return null;
                                 return (
                                     <div className="iv-module-card__mem">

--- a/web/src/pages/builtin/inspect/utils.ts
+++ b/web/src/pages/builtin/inspect/utils.ts
@@ -7,6 +7,7 @@ export const MODULE_ROUTES: Record<string, string> = {
     decap:   '/modules/decap',
     acl:     '/modules/acl',
     pdump:   '/modules/pdump',
+    fwstate: '/modules/fwstate',
 };
 
 /** Human-readable description for each known dataplane module. */
@@ -22,6 +23,16 @@ export const MODULE_DESCRIPTIONS: Record<string, string> = {
     'route-mpls': 'MPLS routing',
     balancer2: 'Load balancer',
 };
+
+export const normalizeModuleName = (name: string): string => name.toLowerCase();
+
+export const getModuleRoute = (name: string): string | undefined => (
+    MODULE_ROUTES[normalizeModuleName(name)]
+);
+
+export const getModuleDescription = (name: string): string => (
+    MODULE_DESCRIPTIONS[normalizeModuleName(name)] ?? ''
+);
 
 /**
  * Count how many dataplane modules are actively used by at least one
@@ -82,6 +93,47 @@ export interface MemoryTotals {
 }
 
 const META_AGENTS = new Set(['function', 'pipeline']);
+const MODULE_CARD_MEMORY_ALIASES: Record<string, string[]> = {
+    fwstate: ['acl'],
+};
+
+const findAgentUsage = (
+    usage: Map<string, AgentUsage>,
+    name: string,
+): AgentUsage | undefined => {
+    const direct = usage.get(name);
+    if (direct) {
+        return direct;
+    }
+
+    const key = normalizeModuleName(name);
+    for (const [usageName, agentUsage] of usage) {
+        if (normalizeModuleName(usageName) === key) {
+            return agentUsage;
+        }
+    }
+    return undefined;
+};
+
+/** Return memory usage for a dataplane module card. */
+export const getModuleCardAgentUsage = (
+    usage: Map<string, AgentUsage>,
+    moduleName: string,
+): AgentUsage | undefined => {
+    const direct = findAgentUsage(usage, moduleName);
+    if (direct) {
+        return direct;
+    }
+
+    const aliases = MODULE_CARD_MEMORY_ALIASES[normalizeModuleName(moduleName)] ?? [];
+    for (const alias of aliases) {
+        const aliased = findAgentUsage(usage, alias);
+        if (aliased) {
+            return aliased;
+        }
+    }
+    return undefined;
+};
 
 /**
  * Classify and aggregate per-agent memory metrics from instance.agents.
@@ -91,15 +143,22 @@ const META_AGENTS = new Set(['function', 'pipeline']);
  * agents regardless of whether devices of that type are present).
  */
 export const computeAgentUsage = (instance: InstanceInfo): Map<string, AgentUsage> => {
-    const moduleNames = new Set((instance.dp_modules ?? []).map((m) => m.name ?? ''));
+    const moduleNameByKey = new Map(
+        (instance.dp_modules ?? [])
+            .map((m) => m.name ?? '')
+            .filter(Boolean)
+            .map((name) => [normalizeModuleName(name), name]),
+    );
 
     const result = new Map<string, AgentUsage>();
     for (const agent of (instance.agents ?? []) as AgentInfo[]) {
         const name = agent.name ?? '';
+        const moduleName = moduleNameByKey.get(normalizeModuleName(name));
+        const resultName = moduleName ?? name;
         let kind: AgentKind;
         if (META_AGENTS.has(name)) {
             kind = 'meta';
-        } else if (moduleNames.has(name)) {
+        } else if (moduleName) {
             kind = 'module';
         } else {
             kind = 'system';
@@ -118,16 +177,21 @@ export const computeAgentUsage = (instance: InstanceInfo): Map<string, AgentUsag
         const used = Math.max(0, limit - free);
         const pct = limit > 0 ? used / limit : 0;
 
-        result.set(name, {
-            name,
+        const prev = result.get(resultName);
+        result.set(resultName, {
+            name: resultName,
             kind,
-            used,
-            limit,
-            free,
-            pct,
-            gen: maxGen,
-            instances: instanceList.length,
+            used: (prev?.used ?? 0) + used,
+            limit: (prev?.limit ?? 0) + limit,
+            free: (prev?.free ?? 0) + free,
+            pct: 0,
+            gen: Math.max(prev?.gen ?? 0, maxGen),
+            instances: (prev?.instances ?? 0) + instanceList.length,
         });
+        const current = result.get(resultName);
+        if (current) {
+            current.pct = current.limit > 0 ? current.used / current.limit : 0;
+        }
     }
     return result;
 };


### PR DESCRIPTION
- Added the FWState Inspect module-card route so mouse and keyboard activation opens the FWState page.
- Reused normalized module helpers for Inspect and Dashboard module cards.
- Displayed FWState module-card memory from the ACL shared-memory agent when no dedicated FWState agent is present.
- Validated with `npm test`, `npm run build`, `git diff --check`, reviewer approval, and a Playwright smoke check for FWState memory text plus click and Enter navigation.