### PR TITLE
feat: show RX/TX PPS in devices menu and scale overlaid sparklines

### DIFF
--- a/web/src/pages/builtin/devices/DeviceListItem.tsx
+++ b/web/src/pages/builtin/devices/DeviceListItem.tsx
@@ -25,6 +25,7 @@ export const DeviceListItem: React.FC<DeviceListItemProps> = ({
     const iconColor = isVlan ? 'var(--violet)' : 'var(--teal)';
     const name = device.id.name || '';
     const rxPps = counterData?.rx.pps ?? 0;
+    const txPps = counterData?.tx.pps ?? 0;
     const rxHistory = history?.rx ?? [];
     const txHistory = history?.tx ?? [];
 
@@ -64,7 +65,14 @@ export const DeviceListItem: React.FC<DeviceListItemProps> = ({
             </span>
 
             <span className="dv-row-metric">
-                <span className="dv-row-pps mono">{formatPps(rxPps)}</span>
+                <span className="dv-row-pps-entry">
+                    <span className="dv-row-pps-lbl dv-lbl-rx">RX</span>
+                    <span className="dv-row-pps mono">{formatPps(rxPps)}</span>
+                </span>
+                <span className="dv-row-pps-entry">
+                    <span className="dv-row-pps-lbl dv-lbl-tx">TX</span>
+                    <span className="dv-row-pps mono">{formatPps(txPps)}</span>
+                </span>
             </span>
 
             <span className="dv-row-status">

--- a/web/src/pages/builtin/devices/components/MiniSpark.tsx
+++ b/web/src/pages/builtin/devices/components/MiniSpark.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
-const pathFor = (values: number[], w: number, h: number, pad = 1): string => {
+const pathFor = (values: number[], w: number, h: number, max: number, pad = 1): string => {
     if (!values.length) return '';
-    const max = Math.max(1, ...values);
     const stepX = (w - pad * 2) / (values.length - 1 || 1);
     let d = '';
     for (let idx = 0; idx < values.length; idx++) {
@@ -13,9 +12,8 @@ const pathFor = (values: number[], w: number, h: number, pad = 1): string => {
     return d;
 };
 
-const areaFor = (values: number[], w: number, h: number, pad = 1): string => {
+const areaFor = (values: number[], w: number, h: number, max: number, pad = 1): string => {
     if (!values.length) return '';
-    const max = Math.max(1, ...values);
     const stepX = (w - pad * 2) / (values.length - 1 || 1);
     let d = `M${pad} ${h - pad} `;
     for (let idx = 0; idx < values.length; idx++) {
@@ -39,9 +37,10 @@ export interface MiniSparkProps {
 /** Compact dual-series sparkline shown in list rows. */
 export const MiniSpark = ({ deviceId, rx, tx, width = 72, height = 24 }: MiniSparkProps): React.JSX.Element => {
     const gid = `dv-g-${deviceId}`;
-    const rxPath = pathFor(rx, width, height);
-    const txPath = pathFor(tx, width, height);
-    const rxArea = areaFor(rx, width, height);
+    const max = Math.max(1, ...rx, ...tx);
+    const rxPath = pathFor(rx, width, height, max);
+    const txPath = pathFor(tx, width, height, max);
+    const rxArea = areaFor(rx, width, height, max);
     return (
         <svg
             width={width}

--- a/web/src/pages/builtin/devices/devices.scss
+++ b/web/src/pages/builtin/devices/devices.scss
@@ -388,20 +388,38 @@
         display: flex;
         flex-direction: column;
         align-items: flex-end;
-        gap: 0;
+        gap: 2px;
+    }
+
+    .dv-row-pps-entry {
+        display: flex;
+        align-items: baseline;
+        gap: 4px;
     }
 
     .dv-row-pps {
-        font-size: 12px;
+        font-size: 11.5px;
         color: var(--fg);
         font-weight: 500;
         font-family: var(--mono);
     }
 
     .dv-row-pps-lbl {
-        font-size: 9.5px;
+        font-size: 9px;
         color: var(--fg-3);
         letter-spacing: 0.05em;
+        font-weight: 600;
+        min-width: 14px;
+        text-align: right;
+    }
+
+    .dv-lbl-rx {
+        color: var(--teal-dim);
+    }
+
+    .dv-lbl-tx {
+        color: var(--blue);
+        opacity: 0.75;
     }
 
     .dv-row-status {


### PR DESCRIPTION
Devices menu list rows now display both RX and TX packets-per-second instead of RX only, with the values color-coded to match the overlaid sparkline (RX teal, TX blue).

The overlaid RX/TX sparklines in the device list are now normalized against a single shared maximum, so the two lines are visually comparable rather than each being scaled to its own peak.