### PR TITLE
fix: make FWState refresh table button reload states

### DIFF
--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -879,7 +879,8 @@ const StatesTabBody: React.FC<StatesTabBodyProps> = ({
         lastLoadedKeyRef.current = null;
         inFlightKeyRef.current = null;
         resetView(true);
-    }, [resetView]);
+        void loadPage(true);
+    }, [loadPage, resetView]);
 
     return (
         <div className="fws-states">


### PR DESCRIPTION
The Refresh table button on the FWState states tab cleared internal state but never issued a new fetch, so it appeared to do nothing. It now clears the table and reloads the first batch of states.

Closes #935.