### PR TITLE
fix(web): align device list sparklines

### DIFF
--- a/web/src/pages/builtin/devices/devices.scss
+++ b/web/src/pages/builtin/devices/devices.scss
@@ -290,7 +290,7 @@
 
     .dv-row {
         display: grid;
-        grid-template-columns: 22px 1fr auto auto auto;
+        grid-template-columns: 22px 1fr 72px 88px auto;
         align-items: center;
         gap: 10px;
         width: 100%;


### PR DESCRIPTION
Fix the sparklines in the Devices page device list rendering at different horizontal positions from row to row.

The device row grid previously sized the sparkline and rate columns to their content, so a wider rate value shifted the sparkline column. Pinning the sparkline and rate columns to fixed widths leaves only the device-name column flexible, so every sparkline now lines up in a single vertical column.