### PR TITLE
refactor(cli): migrate common CLI to structured output

### DIFF
--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -1,12 +1,16 @@
 //! CLI for YANET "logging" core module.
 
-use core::error::Error;
-
 use clap::{ArgAction, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::CompleteEnv;
 use tonic::codec::CompressionEncoding;
-use ync::{client::ConnectionArgs, logging};
+use ync::{
+    client::ConnectionArgs,
+    errors::Error,
+    output::{self, CommonFormat},
+};
 use ynpb::pb::{logging_client::LoggingClient, UpdateLevelRequest};
+
+const LOGGING_SERVICE: &str = "ynpb.Logging";
 
 /// Common functionality.
 #[derive(Debug, Clone, Parser)]
@@ -17,6 +21,9 @@ struct Cmd {
     pub mode: ModeCmd,
     #[command(flatten)]
     pub connection: ConnectionArgs,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "human", global = true)]
+    pub format: CommonFormat,
     /// Be verbose in terms of logging.
     #[arg(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
@@ -66,16 +73,30 @@ pub async fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
 
     let cmd = Cmd::parse();
-    let _ = logging::init(cmd.verbose as usize);
+    ync::init(cmd.verbose, cmd.format);
 
     if let Err(err) = run(cmd).await {
-        log::error!("ERROR: {err}");
-        std::process::exit(1);
+        output::failure(&err);
+        std::process::exit(err.exit_code());
     }
 }
 
-async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
-    let channel = ync::client::connect(&cmd.connection).await?;
+impl ModeCmd {
+    pub fn action(&self) -> &'static str {
+        match self {
+            ModeCmd::Logging(LoggingCmd::SetLevel(..)) => "set-level",
+        }
+    }
+}
+
+async fn run(cmd: Cmd) -> Result<(), Error> {
+    let action = cmd.mode.action();
+    let endpoint = cmd.connection.endpoint.clone();
+
+    let channel = ync::client::connect(&cmd.connection)
+        .await
+        .map_err(|err| Error::from_connection(err, action, endpoint.clone()))?;
+
     let mut client = LoggingClient::new(channel)
         .send_compressed(CompressionEncoding::Gzip)
         .accept_compressed(CompressionEncoding::Gzip);
@@ -83,10 +104,14 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
     match cmd.mode {
         ModeCmd::Logging(LoggingCmd::SetLevel(cmd)) => {
             let request = UpdateLevelRequest {
-                level: ynpb::pb::LogLevel::from(cmd.level).into(),
+                level: ynpb::pb::LogLevel::from(cmd.level.clone()).into(),
             };
-            let _ = client.update_level(request).await?;
-            println!("OK");
+            client
+                .update_level(request)
+                .await
+                .map_err(|status| Error::from_status(status, action, endpoint.clone(), LOGGING_SERVICE))?;
+
+            output::success(action, format_args!("set log level to {:?}", cmd.level));
         }
     }
 


### PR DESCRIPTION
Migrates the `common` CLI (binary `yanet-cli-common`, the logging-service command) off the legacy log-based output onto the shared structured output framework, matching the already-migrated `function` and route-operator CLIs.

- Adds a global `--format` flag selecting the human or JSON backend through `ync::init`.
- Reports errors through the output facade with kind-specific process exit codes instead of `log::error!` + a fixed exit code.
- Returns the structured `ync::errors::Error` from `run` rather than a boxed dynamic error.
- Derives the action label from the selected subcommand, so connection, RPC, and success messages all report the correct action and new subcommands extend cleanly.

This is the first of four core-CLI migrations (common, inspect, pipeline, counters), one per PR.

Note: the crate is named `common` / `yanet-cli-common` but is actually a standalone logging-service binary, not a shared library. Renaming it touches the Cargo workspace and binary naming, so it is intentionally left out of this migration.