### PR TITLE
refactor(cli): migrate inspect CLI to structured output

### DIFF
--- a/cli/modules/inspect/Cargo.toml
+++ b/cli/modules/inspect/Cargo.toml
@@ -9,12 +9,10 @@ rust-version = "1.84"
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
-log = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
 colored = "3"
-serde_json = "1"
 ptree = "0.5"
 bytesize = "2.0.1"

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -1,17 +1,18 @@
 //! CLI for YANET "inspect" module.
 
-use core::error::Error;
-
 use bytesize::ByteSize;
-use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
+use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
-    logging,
+    errors::Error,
+    output::{self, CommonFormat},
 };
 use ynpb::pb::{inspect_service_client::InspectServiceClient, InspectRequest, InspectResponse};
+
+const INSPECT_SERVICE: &str = "ynpb.InspectService";
 
 /// Inspect module - displays system introspection information.
 #[derive(Debug, Clone, Parser)]
@@ -21,20 +22,11 @@ pub struct Cmd {
     #[command(flatten)]
     pub connection: ConnectionArgs,
     /// Output format.
-    #[clap(long, value_enum, default_value_t = OutputFormat::Tree)]
-    pub format: OutputFormat,
+    #[arg(long, value_enum, default_value = "human", global = true)]
+    pub format: CommonFormat,
     /// Be verbose in terms of logging.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
-}
-
-/// Output format options.
-#[derive(Debug, Clone, ValueEnum)]
-pub enum OutputFormat {
-    /// Tree structure with colored output (default).
-    Tree,
-    /// JSON format.
-    Json,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -42,143 +34,143 @@ pub async fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
 
     let cmd = Cmd::parse();
-    let _ = logging::init(cmd.verbose as usize);
+    ync::init(cmd.verbose, cmd.format);
 
     if let Err(err) = run(cmd).await {
-        log::error!("ERROR: {err}");
-        std::process::exit(1);
+        output::failure(&err);
+        std::process::exit(err.exit_code());
     }
 }
 
-async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
+async fn run(cmd: Cmd) -> Result<(), Error> {
     let mut service = InspectService::new(&cmd.connection).await?;
+    let response = service.inspect().await?;
 
-    match cmd.format {
-        OutputFormat::Json => service.show_json().await?,
-        OutputFormat::Tree => service.show_tree().await?,
-    }
+    output::data(&response, false, format_args!(""), || render_tree(&response));
 
     Ok(())
 }
 
 pub struct InspectService {
     client: InspectServiceClient<LayeredChannel>,
+    endpoint: String,
 }
 
 impl InspectService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Box<dyn Error>> {
-        let channel = ync::client::connect(connection).await?;
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
+        let channel = ync::client::connect(connection)
+            .await
+            .map_err(|err| Error::from_connection(err, "inspect", connection.endpoint.clone()))?;
         let client = InspectServiceClient::new(channel)
             .send_compressed(CompressionEncoding::Gzip)
             .accept_compressed(CompressionEncoding::Gzip);
-        Ok(Self { client })
+
+        Ok(Self {
+            client,
+            endpoint: connection.endpoint.clone(),
+        })
     }
 
-    pub async fn show_json(&mut self) -> Result<(), Box<dyn Error>> {
-        let request = InspectRequest {};
-        let response = self.client.inspect(request).await?;
-        println!("{}", serde_json::to_string(response.get_ref())?);
-        Ok(())
+    pub async fn inspect(&mut self) -> Result<InspectResponse, Error> {
+        let response = self
+            .client
+            .inspect(InspectRequest {})
+            .await
+            .map_err(|status| Error::from_status(status, "inspect", self.endpoint.clone(), INSPECT_SERVICE))?
+            .into_inner();
+
+        Ok(response)
     }
+}
 
-    pub async fn show_tree(&mut self) -> Result<(), Box<dyn Error>> {
-        let request = InspectRequest {};
-        let response = self.client.inspect(request).await?;
-        self.format_tree_output(response.get_ref())?;
-        Ok(())
-    }
+fn render_tree(response: &InspectResponse) {
+    let mut tree = TreeBuilder::new("YANET System".to_string());
 
-    fn format_tree_output(&self, response: &InspectResponse) -> Result<(), Box<dyn Error>> {
-        let mut tree = TreeBuilder::new("YANET System".to_string());
+    if let Some(info) = &response.instance_info {
+        tree.begin_child(format!("Instance {}", info.instance_idx));
 
-        if let Some(info) = &response.instance_info {
-            tree.begin_child(format!("Instance {}", info.instance_idx));
+        tree.begin_child(format!("Attached to NUMA {}", info.numa_idx));
+        tree.end_child();
 
-            tree.begin_child(format!("Attached to NUMA {}", info.numa_idx));
-            tree.end_child();
+        tree.begin_child("Dataplane Modules".to_string());
+        for (idx, module) in info.dp_modules.iter().enumerate() {
+            tree.add_empty_child(format!("{}: {}", idx, module.name));
+        }
+        tree.end_child();
 
-            tree.begin_child("Dataplane Modules".to_string());
-            for (idx, module) in info.dp_modules.iter().enumerate() {
-                tree.add_empty_child(format!("{}: {}", idx, module.name));
-            }
-            tree.end_child();
+        tree.begin_child("Controlplane Configurations".to_string());
+        for cfg in &info.cp_configs {
+            tree.add_empty_child(format!("{}:{} (gen: {})", cfg.r#type, cfg.name, cfg.generation));
+        }
+        tree.end_child();
 
-            tree.begin_child("Controlplane Configurations".to_string());
-            for cfg in &info.cp_configs {
-                tree.add_empty_child(format!("{}:{} (gen: {})", cfg.r#type, cfg.name, cfg.generation));
-            }
-            tree.end_child();
+        tree.begin_child("Agents".to_string());
+        for agent in &info.agents {
+            tree.begin_child(agent.name.to_string());
 
-            tree.begin_child("Agents".to_string());
-            for agent in &info.agents {
-                tree.begin_child(agent.name.to_string());
-
-                for instance in &agent.instances {
-                    let used = instance.memory_limit.saturating_sub(instance.free_bytes);
-                    tree.begin_child(format!("Instance (PID: {})", instance.pid));
-                    tree.add_empty_child(format!("Memory limit: {}", ByteSize::b(instance.memory_limit)));
-                    tree.add_empty_child(format!("Used:         {}", ByteSize::b(used)));
-                    tree.add_empty_child(format!("Free:         {}", ByteSize::b(instance.free_bytes)));
-                    tree.add_empty_child(format!("Generation: {}", instance.generation));
-                    tree.end_child();
-                }
-
+            for instance in &agent.instances {
+                let used = instance.memory_limit.saturating_sub(instance.free_bytes);
+                tree.begin_child(format!("Instance (PID: {})", instance.pid));
+                tree.add_empty_child(format!("Memory limit: {}", ByteSize::b(instance.memory_limit)));
+                tree.add_empty_child(format!("Used:         {}", ByteSize::b(used)));
+                tree.add_empty_child(format!("Free:         {}", ByteSize::b(instance.free_bytes)));
+                tree.add_empty_child(format!("Generation: {}", instance.generation));
                 tree.end_child();
             }
-            tree.end_child();
 
-            tree.begin_child("Functions".to_string());
-            for function in &info.functions {
-                tree.begin_child(format!("Function {}", function.name));
-                for chain in &function.chains {
-                    tree.begin_child(format!("Chain {} (weight {})", chain.name, chain.weight));
-                    for module in &chain.modules {
-                        tree.add_empty_child(format!("Module {}:{}", module.r#type, module.name));
-                    }
-                    tree.end_child();
+            tree.end_child();
+        }
+        tree.end_child();
+
+        tree.begin_child("Functions".to_string());
+        for function in &info.functions {
+            tree.begin_child(format!("Function {}", function.name));
+            for chain in &function.chains {
+                tree.begin_child(format!("Chain {} (weight {})", chain.name, chain.weight));
+                for module in &chain.modules {
+                    tree.add_empty_child(format!("Module {}:{}", module.r#type, module.name));
                 }
                 tree.end_child();
             }
             tree.end_child();
+        }
+        tree.end_child();
 
-            tree.begin_child("Pipelines".to_string());
-            for pipeline in &info.pipelines {
-                tree.begin_child(format!("Pipeline {}", pipeline.name));
-                tree.add_empty_child("rx".to_string());
-                for function in &pipeline.functions {
-                    tree.add_empty_child(function.to_string());
-                }
-                tree.add_empty_child("tx".to_string());
-                tree.end_child();
+        tree.begin_child("Pipelines".to_string());
+        for pipeline in &info.pipelines {
+            tree.begin_child(format!("Pipeline {}", pipeline.name));
+            tree.add_empty_child("rx".to_string());
+            for function in &pipeline.functions {
+                tree.add_empty_child(function.to_string());
+            }
+            tree.add_empty_child("tx".to_string());
+            tree.end_child();
+        }
+        tree.end_child();
+
+        tree.begin_child("Devices".to_string());
+        for device in &info.devices {
+            tree.begin_child(format!("Device {}:{}", device.r#type, device.name));
+
+            tree.begin_child("input".to_string());
+            for pipeline in &device.input_pipelines {
+                tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
             }
             tree.end_child();
 
-            tree.begin_child("Devices".to_string());
-            for device in &info.devices {
-                tree.begin_child(format!("Device {}:{}", device.r#type, device.name));
-
-                tree.begin_child("input".to_string());
-                for pipeline in &device.input_pipelines {
-                    tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
-                }
-                tree.end_child();
-
-                tree.begin_child("output".to_string());
-                for pipeline in &device.output_pipelines {
-                    tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
-                }
-                tree.end_child();
-
-                tree.end_child();
+            tree.begin_child("output".to_string());
+            for pipeline in &device.output_pipelines {
+                tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
             }
             tree.end_child();
 
             tree.end_child();
         }
+        tree.end_child();
 
-        let tree = tree.build();
-        ptree::print_tree(&tree)?;
-
-        Ok(())
+        tree.end_child();
     }
+
+    let tree = tree.build();
+    let _ = ptree::print_tree(&tree);
 }


### PR DESCRIPTION
Migrates the `inspect` CLI (binary `yanet-cli-inspect`) onto the shared structured output framework, matching the already-migrated `function` and route-operator CLIs and the preceding `common` migration (#938).

- Replaces the local `OutputFormat { Tree, Json }` enum with the shared `CommonFormat`, selected through `ync::init`. The `--format` flag now accepts `human` (default) or `json`; the previous `tree` value is replaced by `human`, which renders the same tree.
- Reports errors through the output facade with kind-specific process exit codes instead of `log::error!` + a fixed exit code, and returns the structured `ync::errors::Error` from `run` rather than a boxed dynamic error.
- Issues the introspection RPC exactly once and serves both backends from the single response, eliminating the previous duplicate round-trip where the JSON and tree paths each called the service.
- Moves tree rendering into a standalone function (the former method had an unused receiver) and drops the now-dead `log` and `serde_json` dependencies.

This is the second of four core-CLI migrations (common, inspect, pipeline, counters), one per PR.

Note: `colored` remains in the crate's dependencies but is unused; it was already unused before this change, so its removal is left out of scope.