### PR TITLE
feat(cli): improve function and pipeline UX

### DIFF
--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -3,7 +3,7 @@
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use commonpb::pb::FunctionId;
-use tonic::codec::CompressionEncoding;
+use tonic::{codec::CompressionEncoding, Status};
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
     errors::Error,
@@ -45,6 +45,17 @@ pub enum ModeCmd {
     Delete(DeleteCmd),
 }
 
+impl ModeCmd {
+    pub fn action(&self) -> &'static str {
+        match self {
+            ModeCmd::List => "list functions",
+            ModeCmd::Show(..) => "show function",
+            ModeCmd::Update(..) => "update function",
+            ModeCmd::Delete(..) => "delete function",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Function name.
@@ -53,12 +64,16 @@ pub struct ShowCmd {
 }
 
 #[derive(Debug, Clone, Parser)]
+#[command(
+    about = "Update function configuration.",
+    after_help = "Examples:\n  yanet-cli function update --name my-function \\\n      --chains edge:20=filter:acl,route:ipv4 \\\n      --chains control:10=counter:rx"
+)]
 pub struct UpdateCmd {
     /// Function name.
     #[arg(short, long)]
     pub name: String,
-    /// Chains in format name:weight=type:name,type:name
-    #[arg(long)]
+    /// Chains in format `name:weight=type:name,type:name`.
+    #[arg(long, required = true)]
     pub chains: Vec<FunctionChain>,
 }
 
@@ -83,13 +98,13 @@ pub async fn main() {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let action = action_name(&cmd.mode);
+    let action = cmd.mode.action();
     let mut service = FunctionService::new(&cmd.connection, action).await?;
 
     match cmd.mode {
         ModeCmd::List => {
             let ids = service.list_functions().await?;
-            output::data(&ids, false, format_args!("No functions found."), || {
+            output::data(&ids, ids.is_empty(), format_args!("No functions found."), || {
                 print!(
                     "{}",
                     serde_yaml::to_string(&ids).expect("function list YAML serialization must not fail")
@@ -108,25 +123,31 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::Update(update) => {
             let name = update.name.clone();
             service.update_function(update).await?;
-            output::success("update", format_args!("updated function {}", name));
+            output::success("update function", format_args!("Updated function '{name}'."));
         }
         ModeCmd::Delete(delete) => {
             let name = delete.name.clone();
             service.delete_function(delete).await?;
-            output::success("delete", format_args!("deleted function {}", name));
+            output::success("delete function", format_args!("Deleted function '{name}'."));
         }
     }
 
     Ok(())
 }
 
-fn action_name(mode: &ModeCmd) -> &'static str {
-    match mode {
-        ModeCmd::List => "list functions",
-        ModeCmd::Show(..) => "show function",
-        ModeCmd::Update(..) => "update function",
-        ModeCmd::Delete(..) => "delete function",
+fn map_not_found(status: Status, action: &'static str, endpoint: &str, resource: Option<&str>) -> Error {
+    if status.message().trim().eq_ignore_ascii_case("not found") {
+        let resource = resource.unwrap_or("requested function");
+
+        return Error::from_status(
+            Status::not_found(format!("{resource} not found")),
+            action,
+            endpoint.to_owned(),
+            FUNCTION_SERVICE,
+        );
     }
+
+    Error::from_status(status, action, endpoint.to_owned(), FUNCTION_SERVICE)
 }
 
 pub struct FunctionService {
@@ -135,7 +156,7 @@ pub struct FunctionService {
 }
 
 impl FunctionService {
-    pub async fn new(connection: &ConnectionArgs, action: &str) -> Result<Self, Error> {
+    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
         let channel = ync::client::connect(connection)
             .await
             .map_err(|err| Error::from_connection(err, action, connection.endpoint.clone()))?;
@@ -154,7 +175,7 @@ impl FunctionService {
             .client
             .list(ListFunctionsRequest {})
             .await
-            .map_err(|status| Error::from_status(status, "list functions", self.endpoint.clone(), FUNCTION_SERVICE))?
+            .map_err(|status| map_not_found(status, "list functions", &self.endpoint, None))?
             .into_inner();
 
         Ok(response.ids)
@@ -164,16 +185,24 @@ impl FunctionService {
         let request = GetFunctionRequest {
             id: Some(FunctionId { name: name.to_string() }),
         };
+
         let response = self
             .client
             .get(request)
             .await
-            .map_err(|status| Error::from_status(status, "show function", self.endpoint.clone(), FUNCTION_SERVICE))?
+            .map_err(|status| {
+                map_not_found(
+                    status,
+                    "show function",
+                    &self.endpoint,
+                    Some(&format!("function '{name}'")),
+                )
+            })?
             .into_inner();
 
         let function = response.function.ok_or_else(|| {
             Error::from_status(
-                tonic::Status::not_found(format!("function {} not found", name)),
+                Status::not_found(format!("function '{name}' not found")),
                 "show function",
                 self.endpoint.clone(),
                 FUNCTION_SERVICE,
@@ -186,27 +215,39 @@ impl FunctionService {
     pub async fn update_function(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
         let request = UpdateFunctionRequest {
             function: Some(Function {
-                id: Some(FunctionId { name: cmd.name }),
+                id: Some(FunctionId { name: cmd.name.clone() }),
                 chains: cmd.chains,
             }),
         };
 
-        self.client
-            .update(request)
-            .await
-            .map_err(|status| Error::from_status(status, "update function", self.endpoint.clone(), FUNCTION_SERVICE))?;
+        self.client.update(request).await.map_err(|status| {
+            map_not_found(
+                status,
+                "update function",
+                &self.endpoint,
+                Some(&format!("function '{name}'", name = cmd.name)),
+            )
+        })?;
 
         Ok(())
     }
 
     pub async fn delete_function(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
-        let request = DeleteFunctionRequest {
-            id: Some(FunctionId { name: cmd.name }),
-        };
+        let name = cmd.name;
+
         self.client
-            .delete(request)
+            .delete(DeleteFunctionRequest {
+                id: Some(FunctionId { name: name.clone() }),
+            })
             .await
-            .map_err(|status| Error::from_status(status, "delete function", self.endpoint.clone(), FUNCTION_SERVICE))?;
+            .map_err(|status| {
+                map_not_found(
+                    status,
+                    "delete function",
+                    &self.endpoint,
+                    Some(&format!("function '{name}'")),
+                )
+            })?;
 
         Ok(())
     }

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -3,7 +3,7 @@
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use commonpb::pb::{FunctionId, PipelineId};
-use tonic::codec::CompressionEncoding;
+use tonic::{codec::CompressionEncoding, Status};
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
     errors::Error,
@@ -64,6 +64,10 @@ pub struct ShowCmd {
 }
 
 #[derive(Debug, Clone, Parser)]
+#[command(
+    about = "Update pipeline configuration.",
+    after_help = "Examples:\n  yanet-cli pipeline update --name main --functions acl,route"
+)]
 pub struct UpdateCmd {
     /// Pipeline name.
     #[arg(short, long)]
@@ -100,7 +104,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     match cmd.mode {
         ModeCmd::List => {
             let ids = service.list_pipelines().await?;
-            output::data(&ids, ids.is_empty(), format_args!("no pipelines configured"), || {
+            output::data(&ids, ids.is_empty(), format_args!("No pipelines found."), || {
                 print!(
                     "{}",
                     serde_yaml::to_string(&ids).expect("pipeline list YAML serialization must not fail")
@@ -119,16 +123,31 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::Update(update) => {
             let name = update.name.clone();
             service.update_pipeline(update).await?;
-            output::success(action, format_args!("updated pipeline {name}"));
+            output::success(action, format_args!("Updated pipeline '{name}'."));
         }
         ModeCmd::Delete(delete) => {
             let name = delete.name.clone();
             service.delete_pipeline(delete).await?;
-            output::success(action, format_args!("deleted pipeline {name}"));
+            output::success(action, format_args!("Deleted pipeline '{name}'."));
         }
     }
 
     Ok(())
+}
+
+fn map_not_found(status: Status, action: &'static str, endpoint: &str, resource: Option<&str>) -> Error {
+    if status.message().trim().eq_ignore_ascii_case("not found") {
+        let resource = resource.unwrap_or("requested pipeline");
+
+        return Error::from_status(
+            Status::not_found(format!("{resource} not found")),
+            action,
+            endpoint.to_owned(),
+            PIPELINE_SERVICE,
+        );
+    }
+
+    Error::from_status(status, action, endpoint.to_owned(), PIPELINE_SERVICE)
 }
 
 pub struct PipelineService {
@@ -153,18 +172,12 @@ impl PipelineService {
         })
     }
 
-    fn map_err(&self) -> impl FnOnce(tonic::Status) -> Error + '_ {
-        let endpoint = self.endpoint.clone();
-        let action = self.action;
-        move |status| Error::from_status(status, action, endpoint, PIPELINE_SERVICE)
-    }
-
     pub async fn list_pipelines(&mut self) -> Result<Vec<PipelineId>, Error> {
         let response = self
             .client
             .list(ListPipelinesRequest {})
             .await
-            .map_err(self.map_err())?
+            .map_err(|status| map_not_found(status, self.action, &self.endpoint, Some("pipeline service")))?
             .into_inner();
 
         Ok(response.ids)
@@ -174,7 +187,12 @@ impl PipelineService {
         let request = GetPipelineRequest {
             id: Some(PipelineId { name: name.to_string() }),
         };
-        let response = self.client.get(request).await.map_err(self.map_err())?.into_inner();
+        let response = self
+            .client
+            .get(request)
+            .await
+            .map_err(|status| map_not_found(status, self.action, &self.endpoint, Some(&format!("pipeline '{name}'"))))?
+            .into_inner();
 
         let pipeline = response.pipeline.ok_or_else(|| {
             Error::from_status(
@@ -189,9 +207,10 @@ impl PipelineService {
     }
 
     pub async fn update_pipeline(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
+        let pipeline_name = cmd.name;
         let request = UpdatePipelineRequest {
             pipeline: Some(Pipeline {
-                id: Some(PipelineId { name: cmd.name }),
+                id: Some(PipelineId { name: pipeline_name.clone() }),
                 functions: cmd
                     .functions
                     .into_iter()
@@ -200,7 +219,14 @@ impl PipelineService {
             }),
         };
 
-        self.client.update(request).await.map_err(self.map_err())?;
+        self.client.update(request).await.map_err(|status| {
+            map_not_found(
+                status,
+                self.action,
+                &self.endpoint,
+                Some(&format!("pipeline '{pipeline_name}'")),
+            )
+        })?;
 
         Ok(())
     }
@@ -210,7 +236,10 @@ impl PipelineService {
             id: Some(PipelineId { name: cmd.name }),
         };
 
-        self.client.delete(request).await.map_err(self.map_err())?;
+        let name = request.id.as_ref().expect("pipeline id").name.clone();
+        self.client.delete(request).await.map_err(|status| {
+            map_not_found(status, self.action, &self.endpoint, Some(&format!("pipeline '{name}'")))
+        })?;
 
         Ok(())
     }


### PR DESCRIPTION
Summary
- Add examples and stricter required input for function update.
- Improve function and pipeline empty-state and success messages.
- Normalize generic gateway not-found responses into structured CLI not_found errors.

Validation
- cargo +nightly fmt --package yanet-cli-function --package yanet-cli-pipeline -- --check.
- cargo clippy -p yanet-cli-function -p yanet-cli-pipeline.
- cargo build -p yanet-cli-function -p yanet-cli-pipeline.
- Manual function and pipeline help and not-found JSON checks.