### PR TITLE
fix(counters): prolong cp_config lock while counters are alive

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -23,9 +23,12 @@ struct counter_handle {
 	struct counter_value_handle *value_handle;
 };
 
+struct cp_config;
+
 struct counter_handle_list {
 	uint64_t instance_count;
 	uint64_t count;
+	struct cp_config *cp_config;
 	struct counter_handle counters[];
 };
 

--- a/api/counter.h
+++ b/api/counter.h
@@ -23,12 +23,19 @@ struct counter_handle {
 	struct counter_value_handle *value_handle;
 };
 
-struct cp_config;
+// Used to pin counter storage lifetime.
+struct counter_lock {
+	struct dp_config *dp_config;
+};
 
 struct counter_handle_list {
 	uint64_t instance_count;
 	uint64_t count;
-	struct cp_config *cp_config;
+
+	// Active when the list pins backing counter storage
+	// until list is freed.
+	struct counter_lock lock;
+
 	struct counter_handle counters[];
 };
 

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1530,8 +1530,10 @@ yanet_get_counters_by_tags(
 		}
 	}
 
-	// Prolong lock for a list lifetime
-	list->cp_config = cp_config;
+	// Hold cp_config_lock until the list is freed because handles borrow
+	// storage from the active config generation.
+	list->lock.dp_config = dp_config;
+
 	free(storages);
 	return list;
 
@@ -1695,8 +1697,10 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 			free(handles[i].tags);
 		}
 	}
-	if (counters->cp_config != NULL) {
-		cp_config_unlock(counters->cp_config);
+	if (counters->lock.dp_config != NULL) {
+		struct cp_config *cp_config =
+			ADDR_OF(&counters->lock.dp_config->cp_config);
+		cp_config_unlock(cp_config);
 	}
 	free(counters);
 }

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1530,7 +1530,8 @@ yanet_get_counters_by_tags(
 		}
 	}
 
-	cp_config_unlock(cp_config);
+	// Prolong lock for a list lifetime
+	list->cp_config = cp_config;
 	free(storages);
 	return list;
 
@@ -1692,6 +1693,9 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 		if (i == 0 || handles[i].tags != handles[i - 1].tags) {
 			free(handles[i].tags);
 		}
+	}
+	if (counters->cp_config != NULL) {
+		cp_config_unlock(counters->cp_config);
 	}
 	free(counters);
 }

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1634,6 +1634,7 @@ yanet_get_worker_counters(struct dp_config *dp_config) {
 
 	if (list == NULL)
 		return NULL;
+	memset(list, 0, sizeof(*list));
 	list->instance_count = ADDR_OF(&storage->allocator)->instance_count;
 	list->count = count;
 	struct counter_handle *handlers = list->counters;


### PR DESCRIPTION
There is currently a race between the counters lifecycle and the controlplane configuration updates: the `counter_handle_list` returned by the counters API references the active controlplane configuration, so any update while the counters are in use results in undefined behavior.

This PR addresses [#885](https://github.com/yanet-platform/yanet2/issues/885) by acquiring `cp_config_lock` to pin the controlplane configuration for the lifetime of the counters, and releasing it via `cp_config_unlock` when `counter_handle_list` is freed.