### PR TITLE
refactor(forward): use FQN versioned proto package

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -51,7 +51,6 @@ jobs:
                                                 --exclude modules/balancer2 \
                                                 --exclude modules/decap \
                                                 --exclude modules/dscp \
-                                                --exclude modules/forward \
                                                 --exclude modules/fwstate \
                                                 --exclude modules/nat64 \
                                                 --exclude modules/pdump \

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ proto-lint:
 		--exclude modules/balancer2 \
 		--exclude modules/decap \
 		--exclude modules/dscp \
-		--exclude modules/forward \
 		--exclude modules/fwstate \
 		--exclude modules/nat64 \
 		--exclude modules/pdump \

--- a/buf.yaml
+++ b/buf.yaml
@@ -12,7 +12,6 @@ modules:
       - modules/balancer2
       - modules/decap
       - modules/dscp
-      - modules/forward
       - modules/fwstate
       - modules/nat64
       - modules/pdump

--- a/modules/forward/cli/build.rs
+++ b/modules/forward/cli/build.rs
@@ -1,14 +1,14 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/forwardpb/forward.proto");
+    println!("cargo:rerun-if-changed=../controlplane/forwardpb/v1/forward.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".filterpb", "::filterpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["forwardpb/forward.proto"], &["../../..", "../controlplane"])?;
+        .compile_protos(&["forwardpb/v1/forward.proto"], &["../../..", "../controlplane"])?;
 
     Ok(())
 }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -22,7 +22,7 @@ use ync::{
 pub mod forwardpb {
     use serde::Serialize;
 
-    tonic::include_proto!("forwardpb");
+    tonic::include_proto!("modules.forward.controlplane.forwardpb.v1");
 }
 
 /// Forward module.

--- a/modules/forward/controlplane/forwardpb/meson.build
+++ b/modules/forward/controlplane/forwardpb/meson.build
@@ -1,4 +1,4 @@
-proto_dir = meson.current_source_dir()
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
 root_dir = meson.project_source_root()
 proto_files = [join_paths(proto_dir, 'forward.proto')]
 

--- a/modules/forward/controlplane/forwardpb/v1/forward.proto
+++ b/modules/forward/controlplane/forwardpb/v1/forward.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package forwardpb;
+package modules.forward.controlplane.forwardpb.v1;
 
 import "common/filterpb/filter.proto";
 
-option go_package = "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb;forwardpb";
+option go_package = "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1;forwardpb";
 
 // ForwardService is a controlplane service for forwarding module.
 service ForwardService {

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	cpffi "github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
+	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
 const agentName = "forward"
@@ -23,7 +23,7 @@ type ForwardModule struct {
 }
 
 func NewForwardModule(cfg *Config, log *zap.Logger) (*ForwardModule, error) {
-	log = log.With(zap.String("module", "forwardpb.ForwardService"))
+	log = log.With(zap.String("module", "modules.forward.controlplane.forwardpb.v1.ForwardService"))
 
 	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
@@ -60,7 +60,7 @@ func (m *ForwardModule) Endpoint() string {
 }
 
 func (m *ForwardModule) ServicesNames() []string {
-	return []string{"forwardpb.ForwardService"}
+	return []string{"modules.forward.controlplane.forwardpb.v1.ForwardService"}
 }
 
 func (m *ForwardModule) RegisterService(server *grpc.Server) {

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/yanet-platform/yanet2/common/filterpb"
 	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
-	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
+	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
 // ModuleHandle is a handle to a module configuration.

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
 	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
-	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
+	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
 type mockModuleHandle struct{}

--- a/operators/forward/internal/operator/actuator_gateway.go
+++ b/operators/forward/internal/operator/actuator_gateway.go
@@ -12,7 +12,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/commonpb"
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	"github.com/yanet-platform/yanet2/controlplane/ynpb"
-	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
+	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
 // GatewayActuator publishes the desired forward state to a single gateway.

--- a/operators/forward/internal/operator/rules.go
+++ b/operators/forward/internal/operator/rules.go
@@ -9,7 +9,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/yanet-platform/yanet2/common/filterpb"
-	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
+	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
 // yamlVlanRange mirrors the YAML schema for a VLAN range entry.

--- a/operators/forward/internal/operator/source.go
+++ b/operators/forward/internal/operator/source.go
@@ -4,7 +4,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb"
+	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
 // State is the desired payload pushed by each reconcile pass.

--- a/web/src/api/forward.ts
+++ b/web/src/api/forward.ts
@@ -76,7 +76,7 @@ export interface DeleteConfigResponse {
     deleted?: boolean;
 }
 
-const forwardService = createService('forwardpb.ForwardService');
+const forwardService = createService('modules.forward.controlplane.forwardpb.v1.ForwardService');
 
 export const forward = {
     listConfigs: (options?: CallOptions): Promise<ListConfigsResponse> => {


### PR DESCRIPTION
Migrate the forward module gRPC contract to a fully-qualified, versioned proto package (`modules.forward.controlplane.forwardpb.v1`).

This is the first of a series migrating modules, devices and the bird-adapter operator to FQN + versioning, so shared services such as `MetricsService` and a future readiness `ReadyService` no longer collide on the gateway by fully-qualified name.

- Move the proto into a `v1/` directory and rename the package and `go_package`.
- Update the Go control plane, the forward operator, the Rust CLI and the web API client to the new service name.
- Enable buf enforcement for the module by removing it from the buf and Makefile exclude lists.