### PR TITLE
refactor(fwstate): use common MAC address proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,6 +3288,7 @@ dependencies = [
  "clap_complete",
  "humantime",
  "log",
+ "netip",
  "prost",
  "prost-types",
  "serde",

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -5,7 +5,7 @@ use core::{
     str::FromStr,
 };
 
-use netip::{Contiguous, IpNetwork, ipv4_range_to_networks, ipv6_range_to_networks};
+use netip::{Contiguous, IpNetwork, MacAddr, ipv4_range_to_networks, ipv6_range_to_networks};
 
 #[allow(clippy::all, non_snake_case)]
 pub mod pb {
@@ -33,6 +33,24 @@ impl From<IpAddr> for pb::IpAddress {
             IpAddr::V6(v6) => v6.octets().to_vec(),
         };
         pb::IpAddress { addr: bytes }
+    }
+}
+
+impl From<MacAddr> for pb::MacAddress {
+    fn from(mac: MacAddr) -> Self {
+        pb::MacAddress { addr: mac.as_u64() }
+    }
+}
+
+impl TryFrom<&pb::MacAddress> for MacAddr {
+    type Error = Box<dyn Error>;
+
+    fn try_from(mac: &pb::MacAddress) -> Result<Self, Self::Error> {
+        if mac.addr >> 48 != 0 {
+            return Err("upper 16 bits are set for MAC address".into());
+        }
+
+        Ok(MacAddr::from(mac.addr))
     }
 }
 
@@ -247,6 +265,20 @@ mod test {
     fn iprange_display_invalid() {
         let range = pb::IpRange { start: None, end: None };
         assert_eq!("invalid", range.to_string());
+    }
+
+    #[test]
+    fn mac_round_trip() {
+        let mac = "aa:bb:cc:dd:ee:ff".parse::<MacAddr>().unwrap();
+        let proto = pb::MacAddress::from(mac);
+        let got = MacAddr::try_from(&proto).unwrap();
+        assert_eq!(mac, got);
+    }
+
+    #[test]
+    fn mac_try_from_rejects_upper_bits() {
+        let proto = pb::MacAddress { addr: 0x1_0000_0000_0000 };
+        assert!(MacAddr::try_from(&proto).is_err());
     }
 
     #[test]

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -20,6 +20,7 @@ tonic = { version = "0.13", features = ["gzip"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 humantime = "2"
+netip = "0.3"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/modules/fwstate/cli/build.rs
+++ b/modules/fwstate/cli/build.rs
@@ -3,6 +3,7 @@ use core::error::Error;
 pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/fwstatepb/fwstate.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/ipaddr.proto");
+    println!("cargo:rerun-if-changed=../../../common/commonpb/macaddr.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use commonpb::pb::{IpAddress, MacAddress};
+use commonpb::pb::IpAddress;
 use fwstatepb::{
     DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
     ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
@@ -118,7 +118,7 @@ impl FWStateService {
 
         if let Some(ref dst_ether) = cmd.dst_ether {
             let mac: MacAddr = dst_ether.parse()?;
-            sync_config.dst_ether = Some(MacAddress { addr: mac.as_u64() });
+            sync_config.dst_ether = Some(mac.into());
         }
 
         if let Some(ref dst_addr_multicast) = cmd.dst_addr_multicast {

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -7,11 +7,12 @@ use std::{
 use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use commonpb::pb::IpAddress;
+use commonpb::pb::{IpAddress, MacAddress};
 use fwstatepb::{
     DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
     ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
 };
+use netip::MacAddr;
 use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -50,20 +51,10 @@ fn parse_ipv6(s: &str) -> Result<IpAddress, Box<dyn Error>> {
     Ok(IpAddress { addr: addr.octets().to_vec() })
 }
 
-/// Parse MAC address from string to bytes
-fn parse_mac(s: &str) -> Result<Vec<u8>, Box<dyn Error>> {
-    let parts: Vec<&str> = s.split(':').collect();
-    if parts.len() != 6 {
-        return Err(format!("invalid MAC address format: {}", s).into());
-    }
-
-    let mut bytes = Vec::with_capacity(6);
-    for part in parts {
-        let byte = u8::from_str_radix(part, 16).map_err(|_| format!("invalid MAC address byte: {}", part))?;
-        bytes.push(byte);
-    }
-
-    Ok(bytes)
+/// Parse MAC address string into an `MacAddress` proto message.
+fn parse_mac(s: &str) -> Result<MacAddress, Box<dyn Error>> {
+    let mac: MacAddr = s.parse()?;
+    Ok(MacAddress { addr: mac.as_u64() })
 }
 
 pub struct FWStateService {
@@ -132,7 +123,7 @@ impl FWStateService {
         }
 
         if let Some(ref dst_ether) = cmd.dst_ether {
-            sync_config.dst_ether = parse_mac(dst_ether)?;
+            sync_config.dst_ether = Some(parse_mac(dst_ether)?);
         }
 
         if let Some(ref dst_addr_multicast) = cmd.dst_addr_multicast {

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -51,12 +51,6 @@ fn parse_ipv6(s: &str) -> Result<IpAddress, Box<dyn Error>> {
     Ok(IpAddress { addr: addr.octets().to_vec() })
 }
 
-/// Parse MAC address string into an `MacAddress` proto message.
-fn parse_mac(s: &str) -> Result<MacAddress, Box<dyn Error>> {
-    let mac: MacAddr = s.parse()?;
-    Ok(MacAddress { addr: mac.as_u64() })
-}
-
 pub struct FWStateService {
     client: FwStateServiceClient<LayeredChannel>,
 }
@@ -123,7 +117,8 @@ impl FWStateService {
         }
 
         if let Some(ref dst_ether) = cmd.dst_ether {
-            sync_config.dst_ether = Some(parse_mac(dst_ether)?);
+            let mac: MacAddr = dst_ether.parse()?;
+            sync_config.dst_ether = Some(MacAddress { addr: mac.as_u64() });
         }
 
         if let Some(ref dst_addr_multicast) = cmd.dst_addr_multicast {

--- a/modules/fwstate/controlplane/fwstatepb/convert.go
+++ b/modules/fwstate/controlplane/fwstatepb/convert.go
@@ -30,7 +30,11 @@ func (m *SyncConfig) ToC() cfwstate.SyncConfig {
 	var cfg cfwstate.SyncConfig
 	src := m.GetSrcAddr().GetAddr()
 	copy(cfg.SrcAddr[:], src)
-	copy(cfg.DstEther[:], m.GetDstEther())
+	dstEther := m.GetDstEther()
+	if dstEther != nil {
+		eui := dstEther.EUI48()
+		copy(cfg.DstEther[:], eui[:])
+	}
 	copy(cfg.DstAddrMulticast[:], m.GetDstAddrMulticast().GetAddr())
 	copy(cfg.DstAddrUnicast[:], m.GetDstAddrUnicast().GetAddr())
 	cfg.PortMulticast = uint16(m.GetPortMulticast())
@@ -55,7 +59,7 @@ func (m *SyncConfig) ToCWithDefaults(current cfwstate.SyncConfig) cfwstate.SyncC
 	if len(m.GetSrcAddr().GetAddr()) == 0 {
 		cfg.SrcAddr = current.SrcAddr
 	}
-	if len(m.GetDstEther()) == 0 {
+	if m.GetDstEther() == nil {
 		cfg.DstEther = current.DstEther
 	}
 	if len(m.GetDstAddrMulticast().GetAddr()) == 0 {
@@ -95,7 +99,7 @@ func (m *SyncConfig) ToCWithDefaults(current cfwstate.SyncConfig) cfwstate.SyncC
 func FromCSyncConfig(cfg cfwstate.SyncConfig) *SyncConfig {
 	return &SyncConfig{
 		SrcAddr:          &commonpb.IPAddress{Addr: append([]byte(nil), cfg.SrcAddr[:]...)},
-		DstEther:         append([]byte(nil), cfg.DstEther[:]...),
+		DstEther:         commonpb.NewMACAddressEUI48(cfg.DstEther),
 		DstAddrMulticast: &commonpb.IPAddress{Addr: append([]byte(nil), cfg.DstAddrMulticast[:]...)},
 		PortMulticast:    uint32(cfg.PortMulticast),
 		DstAddrUnicast:   &commonpb.IPAddress{Addr: append([]byte(nil), cfg.DstAddrUnicast[:]...)},

--- a/modules/fwstate/controlplane/fwstatepb/convert_test.go
+++ b/modules/fwstate/controlplane/fwstatepb/convert_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/yanet-platform/yanet2/common/commonpb"
+	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
 // TestPortsRoundTrip verifies that port_unicast and port_multicast survive
@@ -15,7 +16,7 @@ func TestPortsRoundTrip(t *testing.T) {
 
 	pb := &SyncConfig{
 		SrcAddr:          &commonpb.IPAddress{Addr: make([]byte, 16)},
-		DstEther:         make([]byte, 6),
+		DstEther:         commonpb.NewMACAddressEUI48([6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
 		DstAddrMulticast: &commonpb.IPAddress{Addr: make([]byte, 16)},
 		DstAddrUnicast:   &commonpb.IPAddress{Addr: make([]byte, 16)},
 		PortMulticast:    portMulticast,
@@ -27,4 +28,31 @@ func TestPortsRoundTrip(t *testing.T) {
 
 	require.Equal(t, portMulticast, got.PortMulticast)
 	require.Equal(t, portUnicast, got.PortUnicast)
+	require.Equal(t, pb.DstEther.GetAddr(), got.DstEther.GetAddr())
+}
+
+func TestSyncConfig_ToCWithDefaults(t *testing.T) {
+	t.Run("omitted", func(t *testing.T) {
+		current := cfwstate.SyncConfig{
+			DstEther: [6]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+		}
+		pb := &SyncConfig{}
+
+		cfg := pb.ToCWithDefaults(current)
+
+		require.Equal(t, current.DstEther, cfg.DstEther)
+	})
+
+	t.Run("explicit_zero", func(t *testing.T) {
+		current := cfwstate.SyncConfig{
+			DstEther: [6]byte{0x10, 0x11, 0x12, 0x13, 0x14, 0x15},
+		}
+		pb := &SyncConfig{
+			DstEther: &commonpb.MACAddress{},
+		}
+
+		cfg := pb.ToCWithDefaults(current)
+
+		require.Equal(t, [6]byte{}, cfg.DstEther)
+	})
 }

--- a/modules/fwstate/controlplane/fwstatepb/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/fwstate.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package fwstatepb;
 
 import "common/commonpb/ipaddr.proto";
+import "common/commonpb/macaddr.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb;fwstatepb";
 
@@ -132,7 +133,7 @@ message MapConfig {
 // Firewall state synchronization configuration
 message SyncConfig {
   commonpb.IPAddress src_addr = 1;           // IPv6 source address;
-  bytes dst_ether = 2;                       // Destination MAC address (6 bytes);
+  commonpb.MACAddress dst_ether = 2;         // Destination MAC address (6 bytes);
   commonpb.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address;
   uint32 port_multicast = 4;                 // Multicast port;
   commonpb.IPAddress dst_addr_unicast = 5;   // Unicast IPv6 address;

--- a/modules/fwstate/controlplane/fwstatepb/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/fwstate.proto
@@ -133,7 +133,7 @@ message MapConfig {
 // Firewall state synchronization configuration
 message SyncConfig {
   commonpb.IPAddress src_addr = 1;           // IPv6 source address;
-  commonpb.MACAddress dst_ether = 2;         // Destination MAC address (6 bytes);
+  commonpb.MACAddress dst_ether = 2;         // Destination MAC address;
   commonpb.IPAddress dst_addr_multicast = 3; // Multicast IPv6 address;
   uint32 port_multicast = 4;                 // Multicast port;
   commonpb.IPAddress dst_addr_unicast = 5;   // Unicast IPv6 address;

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -430,8 +430,14 @@ func validateSyncConfig(cfg *fwstatepb.SyncConfig) error {
 	}
 
 	// Check dst_ether (6 bytes for MAC)
-	if len(cfg.DstEther) != 6 || isAllZeroBytes(cfg.DstEther) {
+	dstEther := cfg.GetDstEther()
+	if dstEther == nil {
 		missing = append(missing, "dst_ether")
+	} else {
+		eui := dstEther.EUI48()
+		if isAllZeroBytes(eui[:]) {
+			missing = append(missing, "dst_ether")
+		}
 	}
 
 	// Check that at least one destination pair is configured

--- a/modules/fwstate/controlplane/service_test.go
+++ b/modules/fwstate/controlplane/service_test.go
@@ -1,0 +1,49 @@
+package fwstate
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/commonpb"
+	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb"
+)
+
+// TestValidateSyncConfigDstEther checks that dst_ether validation
+// distinguishes between absent and explicitly-zero MAC values.
+func TestValidateSyncConfigDstEther(t *testing.T) {
+	newConfig := func() *fwstatepb.SyncConfig {
+		return &fwstatepb.SyncConfig{
+			SrcAddr:          &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
+			DstAddrMulticast: &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
+			PortMulticast:    1,
+		}
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		cfg := newConfig()
+		cfg.DstEther = nil
+
+		err := validateSyncConfig(cfg)
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "dst_ether"))
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		cfg := newConfig()
+		cfg.DstEther = &commonpb.MACAddress{}
+
+		err := validateSyncConfig(cfg)
+		require.Error(t, err)
+		require.True(t, strings.Contains(err.Error(), "dst_ether"))
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		cfg := newConfig()
+		cfg.DstEther = commonpb.NewMACAddressEUI48([6]byte{1, 2, 3, 4, 5, 6})
+
+		err := validateSyncConfig(cfg)
+		require.NoError(t, err)
+	})
+}

--- a/modules/route/cli/route/src/lib.rs
+++ b/modules/route/cli/route/src/lib.rs
@@ -1,4 +1,5 @@
 use commonpb::pb::MacAddress;
+use netip::MacAddr;
 use tabled::Tabled;
 
 #[allow(clippy::all, non_snake_case)]
@@ -7,11 +8,14 @@ pub mod routepb {
 }
 
 fn format_mac(mac: Option<MacAddress>) -> String {
-    let bytes = mac.map(|m| m.addr.to_be_bytes()).unwrap_or_default();
-    format!(
-        "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
-        bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
-    )
+    let mac = match mac {
+        Some(mac) => match MacAddr::try_from(&mac) {
+            Ok(mac) => return mac.to_string(),
+            Err(..) => "invalid",
+        },
+        None => "00:00:00:00:00:00",
+    };
+    mac.to_string()
 }
 
 /// FIB entry for display in the CLI table.

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -62,7 +62,7 @@ impl FibConfig {
 
 fn parse_mac(s: &str) -> Result<MacAddress, Box<dyn Error>> {
     let mac: MacAddr = s.parse()?;
-    Ok(MacAddress { addr: mac.as_u64() })
+    Ok(mac.into())
 }
 
 impl TryFrom<FibNexthop> for routepb::FibNexthop {

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -196,13 +196,13 @@ impl NeighbourService {
                 let next_hop: IpAddr =
                     IpAddr::try_from(entry.next_hop.as_ref().ok_or("neighbour entry missing next_hop")?)?;
 
-                let link_addr = {
-                    let addr = entry.link_addr.map(|v| v.addr).unwrap_or_default();
-                    MacAddr::from(addr)
+                let link_addr = match entry.link_addr {
+                    Some(v) => MacAddr::try_from(&v)?,
+                    None => MacAddr::from(0),
                 };
-                let hardware_addr = {
-                    let addr = entry.hardware_addr.map(|v| v.addr).unwrap_or_default();
-                    MacAddr::from(addr)
+                let hardware_addr = match entry.hardware_addr {
+                    Some(v) => MacAddr::try_from(&v)?,
+                    None => MacAddr::from(0),
                 };
 
                 Ok(NeighbourEntry {
@@ -313,7 +313,7 @@ impl NeighbourService {
 
 fn parse_mac(s: &str) -> Result<MacAddress, Box<dyn Error>> {
     let mac: MacAddr = s.parse()?;
-    Ok(MacAddress { addr: mac.as_u64() })
+    Ok(mac.into())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]

--- a/web/src/api/fwstate.ts
+++ b/web/src/api/fwstate.ts
@@ -1,4 +1,5 @@
 import { createService, createStreamingService, type CallOptions, type StreamCallbacks } from './client';
+import type { MACAddress } from './neighbours';
 import type { IPAddressWire } from '../utils/netip';
 
 export interface MapConfig {
@@ -8,7 +9,7 @@ export interface MapConfig {
 
 export interface SyncConfig {
     src_addr?: IPAddressWire;
-    dst_ether?: string | Uint8Array | number[];
+    dst_ether?: MACAddress;
     dst_addr_multicast?: IPAddressWire;
     port_multicast?: number;
     dst_addr_unicast?: IPAddressWire;

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -21,7 +21,7 @@ import { ConfirmDialog, ConfigTabStrip, PageLayout, PageLoader } from '../../../
 import { useContainerHeight } from '../../../hooks';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import { ipAddressToString, isValidIPAddress, parseIPToBytes, stringToIPAddress, type IPAddressWire } from '../../../utils/netip';
-import { formatMACFromBytes, parseMACToBytes } from '../../../utils/mac';
+import { parseMACToBytes } from '../../../utils/mac';
 import { formatBytes, toaster } from '../../../utils';
 import { AddConfigModal, DeleteConfigModal } from '../../_shared/draft';
 import { SaveIcon, TrashIcon } from '../../_shared/draft/DraftActionButtons';
@@ -121,17 +121,6 @@ const isValidNonzeroMAC = (value: string): boolean => {
     return Boolean(parsed && parsed.some((byte) => byte !== 0));
 };
 
-const decodeWireBytes = (wire: string | Uint8Array | number[] | undefined): number[] => {
-    if (!wire) return [];
-    if (Array.isArray(wire)) return wire;
-    if (wire instanceof Uint8Array) return Array.from(wire);
-    try {
-        return Array.from(atob(wire), (char) => char.charCodeAt(0));
-    } catch {
-        return [];
-    }
-};
-
 const toDraftConfig = (config: Awaited<ReturnType<typeof API.fwstate.showConfig>> | null, isLocalOnly: boolean): DraftConfig => {
     const sync = config?.sync_config;
     const multicastAddress = ipAddressToString(sync?.dst_addr_multicast as IPAddressWire | undefined).trim();
@@ -147,7 +136,7 @@ const toDraftConfig = (config: Awaited<ReturnType<typeof API.fwstate.showConfig>
         mapIndexSize: config?.map_config?.index_size ?? 1_048_576,
         mapExtraBucketCount: config?.map_config?.extra_bucket_count ?? 1_024,
         srcAddr: ipAddressToString(sync?.src_addr as IPAddressWire | undefined),
-        dstEther: formatMACFromBytes(decodeWireBytes(sync?.dst_ether)),
+        dstEther: sync?.dst_ether?.addr ?? '',
         dstAddrMulticast: ipAddressToString(sync?.dst_addr_multicast as IPAddressWire | undefined),
         portMulticast: sync?.port_multicast ?? 0,
         dstAddrUnicast: ipAddressToString(sync?.dst_addr_unicast as IPAddressWire | undefined),
@@ -1360,7 +1349,7 @@ const FWStatePage: React.FC = () => {
         const useUnicast = current.syncMode === 'unicast' || current.syncMode === 'both';
         const syncConfig = {
             src_addr: stringToIPAddress(current.srcAddr),
-            dst_ether: parseMACToBytes(current.dstEther),
+            dst_ether: { addr: current.dstEther },
             dst_addr_multicast: useMulticast ? stringToIPAddress(current.dstAddrMulticast) : zeroIPv6AddressWire(),
             port_multicast: useMulticast ? current.portMulticast : 0,
             dst_addr_unicast: useUnicast ? stringToIPAddress(current.dstAddrUnicast) : zeroIPv6AddressWire(),


### PR DESCRIPTION
Summary
- Switched FWState sync MAC proto wiring to commonpb.MACAddress.
- Updated FWState control-plane conversion, validation, Rust CLI input, and Web API handling.
- Added focused validation and conversion coverage for the new MAC shape.

Validation
- Ran make proto-lint.
- Ran cargo build -p yanet-cli-fwstate.
- Ran cargo clippy -p yanet-cli-fwstate.
- Ran cargo +nightly fmt -- --check in modules/fwstate/cli.
- Ran npm run build in web.
- Ran git diff --check.
- Reviewed with reviewer agent; approved.

Note
- Local Go FWState tests could not link without generated C static libraries in build/, matching the clean-worktree build artifact limitation.