### PR TITLE
refactor(decap): use FQN versioned proto package

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -49,7 +49,6 @@ jobs:
                                                 --exclude modules/acl \
                                                 --exclude modules/balancer \
                                                 --exclude modules/balancer2 \
-                                                --exclude modules/decap \
                                                 --exclude modules/dscp \
                                                 --exclude modules/fwstate \
                                                 --exclude modules/nat64 \

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ proto-lint:
 		--exclude operators/bird-adapter \
 		--exclude modules/acl \
 		--exclude modules/balancer2 \
-		--exclude modules/decap \
 		--exclude modules/dscp \
 		--exclude modules/fwstate \
 		--exclude modules/nat64 \

--- a/buf.yaml
+++ b/buf.yaml
@@ -10,7 +10,6 @@ modules:
       - devices
       - modules/acl
       - modules/balancer2
-      - modules/decap
       - modules/dscp
       - modules/fwstate
       - modules/nat64

--- a/modules/decap/cli/build.rs
+++ b/modules/decap/cli/build.rs
@@ -1,13 +1,13 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/decappb/decap.proto");
+    println!("cargo:rerun-if-changed=../controlplane/decappb/v1/decap.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["decappb/decap.proto"], &["../controlplane"])?;
+        .compile_protos(&["decappb/v1/decap.proto"], &["../controlplane"])?;
 
     Ok(())
 }

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -18,7 +18,7 @@ use ync::{
 pub mod decappb {
     use serde::Serialize;
 
-    tonic::include_proto!("decappb");
+    tonic::include_proto!("modules.decap.controlplane.decappb.v1");
 }
 
 /// Decap module.

--- a/modules/decap/controlplane/decappb/meson.build
+++ b/modules/decap/controlplane/decappb/meson.build
@@ -1,4 +1,5 @@
-proto_dir = meson.current_source_dir()
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
+root_dir = meson.project_source_root()
 proto_files = [join_paths(proto_dir, 'decap.proto')]
 
 protoc_gen = custom_target(
@@ -8,6 +9,7 @@ protoc_gen = custom_target(
     command: [
         protoc,
         '-I', proto_dir,
+        '-I', root_dir,
         '--go_out=paths=source_relative:' + proto_dir,
         '--go-grpc_out=paths=source_relative:' + proto_dir,
         '@INPUT@',

--- a/modules/decap/controlplane/decappb/v1/decap.proto
+++ b/modules/decap/controlplane/decappb/v1/decap.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package decappb;
+package modules.decap.controlplane.decappb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb;decappb";
+option go_package = "github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1;decappb";
 
 // DecapService is a service for decapsulation module.
 service DecapService {

--- a/modules/decap/controlplane/mod.go
+++ b/modules/decap/controlplane/mod.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb"
+	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
 
 // DecapModule is a control-plane component of a module that is responsible for
@@ -21,7 +21,7 @@ type DecapModule struct {
 }
 
 func NewDecapModule(cfg *Config, log *zap.Logger) (*DecapModule, error) {
-	log = log.With(zap.String("module", "decappb.DecapService"))
+	log = log.With(zap.String("module", "modules.decap.controlplane.decappb.v1.DecapService"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
@@ -58,7 +58,7 @@ func (m *DecapModule) Endpoint() string {
 }
 
 func (m *DecapModule) ServicesNames() []string {
-	return []string{"decappb.DecapService"}
+	return []string{"modules.decap.controlplane.decappb.v1.DecapService"}
 }
 
 func (m *DecapModule) RegisterService(server *grpc.Server) {

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/go/xnetip"
-	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb"
+	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
 
 var (

--- a/modules/decap/controlplane/service_test.go
+++ b/modules/decap/controlplane/service_test.go
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb"
+	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
 
 var errInjectedBackend = errors.New("injected backend failure")

--- a/web/src/api/decap.ts
+++ b/web/src/api/decap.ts
@@ -24,7 +24,7 @@ export interface RemovePrefixesRequest {
 
 export interface RemovePrefixesResponse { }
 
-const decapService = createService('decappb.DecapService');
+const decapService = createService('modules.decap.controlplane.decappb.v1.DecapService');
 
 export const decap = {
     showConfig: (request: ShowConfigRequest, options?: CallOptions): Promise<ShowConfigResponse> => {


### PR DESCRIPTION
Migrate the decap module gRPC contract to a fully-qualified, versioned package (modules.decap.controlplane.decappb.v1) so shared services such as MetricsService and a future readiness service no longer collide on the gateway.

- Part of the ongoing FQN migration series (forward module already merged in #949).
- Updates Go control plane import paths and both hardcoded service name strings in mod.go.
- Updates Rust CLI build.rs proto path and include_proto! macro argument.
- Updates web client createService call to the new FQN service name.
- Removes decap from the exclude lists in buf.yaml, Makefile, and proto-lint.yml so buf now enforces the versioned package layout.