### PR TITLE
refactor(nat64): use FQN versioned proto package

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -52,7 +52,6 @@ jobs:
                                                 --exclude modules/decap \
                                                 --exclude modules/dscp \
                                                 --exclude modules/fwstate \
-                                                --exclude modules/nat64 \
                                                 --exclude modules/pdump \
                                                 --exclude modules/route \
                                                 --exclude modules/route-mpls

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,6 @@ proto-lint:
 		--exclude modules/decap \
 		--exclude modules/dscp \
 		--exclude modules/fwstate \
-		--exclude modules/nat64 \
 		--exclude modules/pdump \
 		--exclude modules/route \
 		--exclude modules/route-mpls

--- a/buf.yaml
+++ b/buf.yaml
@@ -13,7 +13,6 @@ modules:
       - modules/decap
       - modules/dscp
       - modules/fwstate
-      - modules/nat64
       - modules/pdump
       - modules/route
       - modules/route-mpls

--- a/modules/nat64/cli/build.rs
+++ b/modules/nat64/cli/build.rs
@@ -1,14 +1,14 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/nat64pb/nat64.proto");
+    println!("cargo:rerun-if-changed=../controlplane/nat64pb/v1/nat64.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".commonpb", "::commonpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["nat64pb/nat64.proto"], &["../controlplane", "../../.."])?;
+        .compile_protos(&["nat64pb/v1/nat64.proto"], &["../controlplane", "../../.."])?;
 
     Ok(())
 }

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -22,7 +22,7 @@ use ync::{
 #[allow(non_snake_case)]
 pub mod nat64pb {
     use serde::Serialize;
-    tonic::include_proto!("nat64pb");
+    tonic::include_proto!("modules.nat64.controlplane.nat64pb.v1");
 }
 
 /// NAT64 module CLI.

--- a/modules/nat64/controlplane/mod.go
+++ b/modules/nat64/controlplane/mod.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb"
+	nat64pb "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1"
 )
 
 // NAT64Module is a control-plane component responsible for NAT64 translation
@@ -21,7 +21,7 @@ type NAT64Module struct {
 
 // NewNAT64Module creates a new NAT64 module instance
 func NewNAT64Module(cfg *Config, log *zap.Logger) (*NAT64Module, error) {
-	log = log.With(zap.String("module", "nat64pb.NAT64Service"))
+	log = log.With(zap.String("module", "modules.nat64.controlplane.nat64pb.v1.NAT64Service"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
@@ -58,7 +58,7 @@ func (m *NAT64Module) Endpoint() string {
 }
 
 func (m *NAT64Module) ServicesNames() []string {
-	return []string{"nat64pb.NAT64Service"}
+	return []string{"modules.nat64.controlplane.nat64pb.v1.NAT64Service"}
 }
 
 func (m *NAT64Module) RegisterService(server *grpc.Server) {

--- a/modules/nat64/controlplane/nat64pb/meson.build
+++ b/modules/nat64/controlplane/nat64pb/meson.build
@@ -1,6 +1,5 @@
-proto_dir = meson.current_source_dir()
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
 root_dir = meson.project_source_root()
-
 proto_files = [join_paths(proto_dir, 'nat64.proto')]
 
 protoc_gen = custom_target(

--- a/modules/nat64/controlplane/nat64pb/v1/nat64.proto
+++ b/modules/nat64/controlplane/nat64pb/v1/nat64.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package nat64pb;
+package modules.nat64.controlplane.nat64pb.v1;
 
 import "common/commonpb/ipaddr.proto";
 
-option go_package = "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb;nat64pb";
+option go_package = "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1;nat64pb";
 
 // NAT64Service is a control-plane service for managing NAT64 module
 service NAT64Service {

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/commonpb"
-	"github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb"
+	nat64pb "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1"
 )
 
 // NAT64ServiceOption configures the NAT64Service constructor.

--- a/modules/nat64/controlplane/service_test.go
+++ b/modules/nat64/controlplane/service_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/commonpb"
-	"github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb"
+	nat64pb "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1"
 )
 
 var errInjectedBackend = errors.New("injected backend failure")

--- a/modules/nat64/tests/functional/nat64_test.go
+++ b/modules/nat64/tests/functional/nat64_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	nat64 "github.com/yanet-platform/yanet2/modules/nat64/controlplane"
-	"github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb"
+	nat64pb "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1"
 )
 
 const (


### PR DESCRIPTION
Migrate the nat64 module gRPC contract to a fully-qualified, versioned package (modules.nat64.controlplane.nat64pb.v1) so shared services such as MetricsService and a future readiness service no longer collide on the gateway.

- Moves proto to nat64pb/v1/ and updates package + go_package declarations.
- Updates Go control plane import paths and service name strings (both ServicesNames and the logger field).
- Updates Rust CLI build.rs proto path and include_proto! macro to the new FQN.
- Removes nat64 from the buf.yaml, Makefile, and proto-lint workflow exclusion lists, enabling buf enforcement.

Part of the same FQN migration series as the recently merged forward module change (#949).