### PR TITLE
refactor(pdump): use FQN versioned proto package

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -51,6 +51,5 @@ jobs:
                                                 --exclude modules/balancer2 \
                                                 --exclude modules/dscp \
                                                 --exclude modules/fwstate \
-                                                --exclude modules/pdump \
                                                 --exclude modules/route \
                                                 --exclude modules/route-mpls

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,6 @@ proto-lint:
 		--exclude modules/balancer2 \
 		--exclude modules/dscp \
 		--exclude modules/fwstate \
-		--exclude modules/pdump \
 		--exclude modules/route \
 		--exclude modules/route-mpls
 

--- a/buf.yaml
+++ b/buf.yaml
@@ -12,7 +12,6 @@ modules:
       - modules/balancer2
       - modules/dscp
       - modules/fwstate
-      - modules/pdump
       - modules/route
       - modules/route-mpls
 lint:

--- a/modules/pdump/cli/build.rs
+++ b/modules/pdump/cli/build.rs
@@ -2,13 +2,13 @@ use core::error::Error;
 use std::{env, path::PathBuf};
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/pdumppb/pdump.proto");
+    println!("cargo:rerun-if-changed=../controlplane/pdumppb/v1/pdump.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["pdumppb/pdump.proto"], &["../controlplane"])?;
+        .compile_protos(&["pdumppb/v1/pdump.proto"], &["../controlplane"])?;
 
     let bindings = bindgen::Builder::default()
         .header("../dataplane/mode.h")

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -31,7 +31,7 @@ mod writer;
 pub mod pdumppb {
     use serde::Serialize;
 
-    tonic::include_proto!("pdumppb");
+    tonic::include_proto!("modules.pdump.controlplane.pdumppb.v1");
 }
 
 /// Pdump - packet dump module

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb"
+	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb/v1"
 )
 
 // PdumpModule is a control-plane component of a packet dump module.
@@ -22,7 +22,7 @@ type PdumpModule struct {
 }
 
 func NewPdumpModule(cfg *Config, log *zap.Logger) (*PdumpModule, error) {
-	log = log.With(zap.String("module", "pdumppb.PdumpService"))
+	log = log.With(zap.String("module", "modules.pdump.controlplane.pdumppb.v1.PdumpService"))
 
 	// setup CGO export logger
 	logger = log.WithOptions(
@@ -66,7 +66,7 @@ func (m *PdumpModule) Endpoint() string {
 }
 
 func (m *PdumpModule) ServicesNames() []string {
-	return []string{"pdumppb.PdumpService"}
+	return []string{"modules.pdump.controlplane.pdumppb.v1.PdumpService"}
 }
 
 func (m *PdumpModule) RegisterService(server *grpc.Server) {

--- a/modules/pdump/controlplane/pdumppb/meson.build
+++ b/modules/pdump/controlplane/pdumppb/meson.build
@@ -1,4 +1,5 @@
-proto_dir = meson.current_source_dir()
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
+root_dir = meson.project_source_root()
 proto_files = [join_paths(proto_dir, 'pdump.proto')]
 
 protoc_gen = custom_target(
@@ -8,6 +9,7 @@ protoc_gen = custom_target(
   command: [
     protoc,
     '-I', proto_dir,
+    '-I', root_dir,
     '--go_out=paths=source_relative:' + proto_dir,
     '--go-grpc_out=paths=source_relative:' + proto_dir,
     '@INPUT@',

--- a/modules/pdump/controlplane/pdumppb/v1/pdump.proto
+++ b/modules/pdump/controlplane/pdumppb/v1/pdump.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package pdumppb;
+package modules.pdump.controlplane.pdumppb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb;pdumppb";
+option go_package = "github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb/v1;pdumppb";
 
 // PdumpService is a service for Differentiated Services Code Point module.
 service PdumpService {

--- a/modules/pdump/controlplane/ring.go
+++ b/modules/pdump/controlplane/ring.go
@@ -14,7 +14,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb"
+	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb/v1"
 )
 
 type ringMsgHdr C.struct_ring_msg_hdr

--- a/modules/pdump/controlplane/ring_test.go
+++ b/modules/pdump/controlplane/ring_test.go
@@ -15,7 +15,7 @@ import (
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb"
+	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb/v1"
 )
 
 // Test constants and helpers

--- a/modules/pdump/controlplane/service.go
+++ b/modules/pdump/controlplane/service.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/c2h5oh/datasize"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb"
+	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb/v1"
 )
 
 const errMsgConfigNameRequired = "module config name is required"

--- a/web/src/api/pdump.ts
+++ b/web/src/api/pdump.ts
@@ -41,8 +41,8 @@ export interface FieldMask {
     paths?: string[];
 }
 
-const pdumpService = createService('pdumppb.PdumpService');
-const pdumpStreamService = createStreamingService('pdumppb.PdumpService');
+const pdumpService = createService('modules.pdump.controlplane.pdumppb.v1.PdumpService');
+const pdumpStreamService = createStreamingService('modules.pdump.controlplane.pdumppb.v1.PdumpService');
 
 export const pdumpApi = {
     listConfigs: (options?: CallOptions): Promise<ListConfigsResponse> => {


### PR DESCRIPTION
Migrate the pdump module gRPC contract to a fully-qualified, versioned package (modules.pdump.controlplane.pdumppb.v1) so shared services such as MetricsService and a future readiness service no longer collide on the gateway. Updates the Go control plane, Rust CLI, and web client to the new service name, and enables buf enforcement for the module.

- Moves proto definition to versioned subdirectory pdumppb/v1/.
- Updates proto package and go_package option to use fully-qualified name.
- Updates ServicesNames() and module logger to the new service FQN.
- Updates Rust CLI build.rs proto path and include_proto! macro argument.
- Updates web client service name string in pdump.ts.
- Removes pdump from the exclusion lists in buf.yaml, Makefile, and proto-lint workflow.

This is the same migration pattern already applied to the forward module in #949.