### PR TITLE
refactor(route): use FQN versioned proto package

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -50,5 +50,4 @@ jobs:
                                                 --exclude modules/balancer \
                                                 --exclude modules/balancer2 \
                                                 --exclude modules/fwstate \
-                                                --exclude modules/route \
                                                 --exclude modules/route-mpls

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,6 @@ proto-lint:
 		--exclude modules/acl \
 		--exclude modules/balancer2 \
 		--exclude modules/fwstate \
-		--exclude modules/route \
 		--exclude modules/route-mpls
 
 go-cache-clean:

--- a/buf.yaml
+++ b/buf.yaml
@@ -11,7 +11,6 @@ modules:
       - modules/acl
       - modules/balancer2
       - modules/fwstate
-      - modules/route
       - modules/route-mpls
 lint:
   use:

--- a/modules/route/cli/route/build.rs
+++ b/modules/route/cli/route/build.rs
@@ -1,13 +1,16 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../../controlplane/routepb/route.proto");
+    println!("cargo:rerun-if-changed=../../controlplane/routepb/v1/route.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".commonpb", "::commonpb::pb")
-        .compile_protos(&["modules/route/controlplane/routepb/route.proto"], &["../../../../"])?;
+        .compile_protos(
+            &["modules/route/controlplane/routepb/v1/route.proto"],
+            &["../../../../"],
+        )?;
 
     Ok(())
 }

--- a/modules/route/cli/route/src/lib.rs
+++ b/modules/route/cli/route/src/lib.rs
@@ -4,7 +4,7 @@ use tabled::Tabled;
 
 #[allow(clippy::all, non_snake_case)]
 pub mod routepb {
-    tonic::include_proto!("routepb");
+    tonic::include_proto!("modules.route.controlplane.routepb.v1");
 }
 
 fn format_mac(mac: Option<MacAddress>) -> String {

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -10,7 +10,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/bitset"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
-	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
 
 // ModuleHandle is a handle to a route module configuration in shared

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	cpffi "github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
 
 const (
@@ -55,7 +55,7 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 		o(opts)
 	}
 
-	log := opts.Log.With(zap.String("module", "routepb.RouteService"))
+	log := opts.Log.With(zap.String("module", "modules.route.controlplane.routepb.v1.RouteService"))
 
 	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
@@ -96,7 +96,7 @@ func (m *RouteModule) Endpoint() string {
 // ServicesNames returns the gRPC service names exposed by the module.
 func (m *RouteModule) ServicesNames() []string {
 	return []string{
-		"routepb.RouteService",
+		"modules.route.controlplane.routepb.v1.RouteService",
 	}
 }
 

--- a/modules/route/controlplane/routepb/meson.build
+++ b/modules/route/controlplane/routepb/meson.build
@@ -1,5 +1,5 @@
 root_dir = meson.project_source_root()
-proto_dir = meson.current_source_dir()
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
 proto_files = [
     join_paths(proto_dir, 'route.proto'),
 ]

--- a/modules/route/controlplane/routepb/v1/route.proto
+++ b/modules/route/controlplane/routepb/v1/route.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package routepb;
+package modules.route.controlplane.routepb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb;routepb";
+option go_package = "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1;routepb";
 
 import "common/commonpb/iprange.proto";
 import "common/commonpb/macaddr.proto";

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/yanet-platform/yanet2/common/commonpb"
 	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
-	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
 
 // RouteServiceOption configures the RouteService constructor.

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
-	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
 
 const (

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -12,7 +12,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/commonpb"
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	"github.com/yanet-platform/yanet2/controlplane/ynpb"
-	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb"
+	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
 
 // GatewayActuator applies route-operator state to a single Gateway via

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -102,7 +102,7 @@ export interface FIBNexthop {
     device?: string;
 }
 
-const routeService = createService('routepb.RouteService');
+const routeService = createService('modules.route.controlplane.routepb.v1.RouteService');
 const operatorRouteService = createService('operators.route.operatorpb.v1.RouteService');
 
 export const route = {


### PR DESCRIPTION
Migrate the `route` module gRPC contract to a fully-qualified, versioned proto package (`modules.route.controlplane.routepb.v1`).

Part of the series migrating modules, devices and the bird-adapter operator to FQN + versioning so shared services such as `MetricsService` and a future readiness `ReadyService` no longer collide on the gateway by fully-qualified name.

- Move the proto into a `v1/` directory and rename the package and `go_package`.
- Update the Go control plane, the route operator, the Rust CLI and the web API client (the module RouteService line only; the route-operator service is left as is).
- Enable buf and protolint enforcement by removing the module from the buf, Makefile and workflow exclude lists.