### PR TITLE
refactor(devices): use FQN versioned proto packages

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -44,7 +44,6 @@ jobs:
           go run ./lint/protobuf/cmd/protolint/ --exclude subprojects \
                                                 --exclude common \
                                                 --exclude controlplane \
-                                                --exclude devices \
                                                 --exclude operators/bird-adapter \
                                                 --exclude modules/balancer \
                                                 --exclude modules/route-mpls

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,6 @@ proto-lint:
 	go run ./lint/protobuf/cmd/protolint/ --exclude subprojects \
 		--exclude common \
 		--exclude controlplane \
-		--exclude devices \
 		--exclude operators/bird-adapter \
 		--exclude modules/route-mpls
 

--- a/buf.yaml
+++ b/buf.yaml
@@ -7,7 +7,6 @@ modules:
       - operators/bird-adapter
       # Modules not yet migrated.
       - controlplane
-      - devices
       - modules/route-mpls
 lint:
   use:

--- a/devices/plain/cli/build.rs
+++ b/devices/plain/cli/build.rs
@@ -1,14 +1,14 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/plainpb/plain.proto");
+    println!("cargo:rerun-if-changed=../controlplane/plainpb/v1/plain.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".commonpb", "::commonpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["plainpb/plain.proto"], &["../../..", "../controlplane"])?;
+        .compile_protos(&["plainpb/v1/plain.proto"], &["../../..", "../controlplane"])?;
 
     Ok(())
 }

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -14,7 +14,7 @@ use ync::{
 pub mod code {
     use serde::Serialize;
 
-    tonic::include_proto!("plainpb");
+    tonic::include_proto!("devices.plain.controlplane.plainpb.v1");
 }
 
 /// DevicePlain module.

--- a/devices/plain/controlplane/mod.go
+++ b/devices/plain/controlplane/mod.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb"
+	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
 )
 
 // DevicePlainDevice is a control-plane component responsible for plain devices
@@ -21,7 +21,7 @@ type DevicePlainDevice struct {
 
 // NewDevicePlainDevice creates a new DevicePlain device instance
 func NewDevicePlainDevice(cfg *Config, log *zap.Logger) (*DevicePlainDevice, error) {
-	log = log.With(zap.String("module", "plainpb.DevicePlainService"))
+	log = log.With(zap.String("module", "devices.plain.controlplane.plainpb.v1.DevicePlainService"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
@@ -58,7 +58,7 @@ func (m *DevicePlainDevice) Endpoint() string {
 }
 
 func (m *DevicePlainDevice) ServicesNames() []string {
-	return []string{"plainpb.DevicePlainService"}
+	return []string{"devices.plain.controlplane.plainpb.v1.DevicePlainService"}
 }
 
 func (m *DevicePlainDevice) RegisterService(server *grpc.Server) {

--- a/devices/plain/controlplane/plainpb/meson.build
+++ b/devices/plain/controlplane/plainpb/meson.build
@@ -1,4 +1,4 @@
-proto_dir = meson.current_source_dir()
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
 root_dir = meson.project_source_root()
 proto_files = [join_paths(proto_dir, 'plain.proto')]
 

--- a/devices/plain/controlplane/plainpb/v1/plain.proto
+++ b/devices/plain/controlplane/plainpb/v1/plain.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package plainpb;
+package devices.plain.controlplane.plainpb.v1;
 
 import "common/commonpb/target.proto";
 
-option go_package = "github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb;plainpb";
+option go_package = "github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1;plainpb";
 
 service DevicePlainService { rpc UpdateDevice(UpdateDevicePlainRequest) returns (UpdateDevicePlainResponse); }
 

--- a/devices/plain/controlplane/service.go
+++ b/devices/plain/controlplane/service.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb"
+	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
 )
 
 // DevicePlainService implements the DevicePlain gRPC service.

--- a/devices/vlan/cli/build.rs
+++ b/devices/vlan/cli/build.rs
@@ -1,14 +1,14 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=../controlplane/vlanpb/vlan.proto");
+    println!("cargo:rerun-if-changed=../controlplane/vlanpb/v1/vlan.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".commonpb", "::commonpb::pb")
         .message_attribute(".", "#[derive(Serialize)]")
-        .compile_protos(&["vlanpb/vlan.proto"], &["../../..", "../controlplane"])?;
+        .compile_protos(&["vlanpb/v1/vlan.proto"], &["../../..", "../controlplane"])?;
 
     Ok(())
 }

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -14,7 +14,7 @@ use ync::{
 pub mod code {
     use serde::Serialize;
 
-    tonic::include_proto!("vlanpb");
+    tonic::include_proto!("devices.vlan.controlplane.vlanpb.v1");
 }
 
 /// DeviceVlan module.

--- a/devices/vlan/controlplane/mod.go
+++ b/devices/vlan/controlplane/mod.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb"
+	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
 
 // DeviceVlanDevice is a control-plane component responsible for vlan devices
@@ -21,7 +21,7 @@ type DeviceVlanDevice struct {
 
 // NewDeviceVlanDevice creates a new DeviceVlan device instance
 func NewDeviceVlanDevice(cfg *Config, log *zap.Logger) (*DeviceVlanDevice, error) {
-	log = log.With(zap.String("module", "vlanpb.DeviceVlanService"))
+	log = log.With(zap.String("module", "devices.vlan.controlplane.vlanpb.v1.DeviceVlanService"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
@@ -58,7 +58,7 @@ func (m *DeviceVlanDevice) Endpoint() string {
 }
 
 func (m *DeviceVlanDevice) ServicesNames() []string {
-	return []string{"vlanpb.DeviceVlanService"}
+	return []string{"devices.vlan.controlplane.vlanpb.v1.DeviceVlanService"}
 }
 
 func (m *DeviceVlanDevice) RegisterService(server *grpc.Server) {

--- a/devices/vlan/controlplane/service.go
+++ b/devices/vlan/controlplane/service.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb"
+	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
 
 // DeviceVlanService implements the DeviceVlan gRPC service.

--- a/devices/vlan/controlplane/vlanpb/meson.build
+++ b/devices/vlan/controlplane/vlanpb/meson.build
@@ -1,4 +1,4 @@
-proto_dir = meson.current_source_dir()
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
 root_dir = meson.project_source_root()
 proto_files = [join_paths(proto_dir, 'vlan.proto')]
 

--- a/devices/vlan/controlplane/vlanpb/v1/vlan.proto
+++ b/devices/vlan/controlplane/vlanpb/v1/vlan.proto
@@ -1,12 +1,11 @@
 syntax = "proto3";
 
-package vlanpb;
+package devices.vlan.controlplane.vlanpb.v1;
 
 import "common/commonpb/target.proto";
 
-option go_package = "github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb;vlanpb";
+option go_package = "github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1;vlanpb";
 
-// BalancerService is a control-plane service for managing balancer module.
 service DeviceVlanService { rpc UpdateDevice(UpdateDeviceVlanRequest) returns (UpdateDeviceVlanResponse); }
 
 message UpdateDeviceVlanRequest {

--- a/operators/pipeline/internal/operator/actuator_gateway.go
+++ b/operators/pipeline/internal/operator/actuator_gateway.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	"github.com/yanet-platform/yanet2/controlplane/ynpb"
-	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb"
-	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb"
+	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
+	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
 
 // GatewayActuatorMetricsObserver receives semantic events from a

--- a/operators/pipeline/internal/operator/convert.go
+++ b/operators/pipeline/internal/operator/convert.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/yanet-platform/yanet2/common/commonpb"
 	"github.com/yanet-platform/yanet2/controlplane/ynpb"
-	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb"
-	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb"
+	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
+	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
 
 func pipelineToProto(p PipelineConfig) *ynpb.Pipeline {

--- a/web/src/api/devices.ts
+++ b/web/src/api/devices.ts
@@ -50,8 +50,8 @@ export const DEVICE_TYPES = ['plain', 'vlan'] as const;
 export type DeviceType = typeof DEVICE_TYPES[number];
 
 const deviceService = createService('ynpb.DeviceService');
-const plainService = createService('plainpb.DevicePlainService');
-const vlanService = createService('vlanpb.DeviceVlanService');
+const plainService = createService('devices.plain.controlplane.plainpb.v1.DevicePlainService');
+const vlanService = createService('devices.vlan.controlplane.vlanpb.v1.DeviceVlanService');
 
 export const devices = {
     list: (request: ListDevicesRequest, options?: CallOptions): Promise<ListDevicesResponse> => {


### PR DESCRIPTION
Migrate the `plain` and `vlan` device adapters to fully-qualified, versioned proto packages (`devices.plain.controlplane.plainpb.v1`, `devices.vlan.controlplane.vlanpb.v1`).

Part of the FQN + versioning series so shared services such as `MetricsService` and a future readiness `ReadyService` no longer collide on the gateway by fully-qualified name.

- Move both protos into `v1/` directories and rename the packages and `go_package`.
- Update the Go control plane, both Rust CLIs and the web API client.
- Enable buf and protolint enforcement by removing `devices` from the buf, Makefile and workflow exclude lists.