### PR TITLE
refactor(route-mpls): use FQN versioned proto package

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -45,5 +45,4 @@ jobs:
                                                 --exclude common \
                                                 --exclude controlplane \
                                                 --exclude operators/bird-adapter \
-                                                --exclude modules/balancer \
-                                                --exclude modules/route-mpls
+                                                --exclude modules/balancer

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,7 @@ proto-lint:
 	go run ./lint/protobuf/cmd/protolint/ --exclude subprojects \
 		--exclude common \
 		--exclude controlplane \
-		--exclude operators/bird-adapter \
-		--exclude modules/route-mpls
+		--exclude operators/bird-adapter
 
 go-cache-clean:
 	go clean -cache

--- a/buf.yaml
+++ b/buf.yaml
@@ -7,7 +7,6 @@ modules:
       - operators/bird-adapter
       # Modules not yet migrated.
       - controlplane
-      - modules/route-mpls
 lint:
   use:
     - STANDARD
@@ -18,6 +17,9 @@ lint:
     - RPC_RESPONSE_STANDARD_NAME
     - RPC_REQUEST_RESPONSE_UNIQUE
     - SERVICE_SUFFIX
+  ignore_only:
+    PACKAGE_DIRECTORY_MATCH:
+      - modules/route-mpls
   ignore:
     - common
 breaking:

--- a/modules/route-mpls/cli/build.rs
+++ b/modules/route-mpls/cli/build.rs
@@ -3,15 +3,16 @@ use core::error::Error;
 pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../../common/filterpb/filter.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/ipaddr.proto");
-    println!("cargo:rerun-if-changed=../controlplane/routemplspb/routempls.proto");
+    println!("cargo:rerun-if-changed=../controlplane/routemplspb/v1/routempls.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
         .extern_path(".commonpb", "::commonpb::pb")
+        .extern_path(".filterpb", "crate::filterpb")
         .message_attribute(".", "#[derive(Serialize)]")
         .enum_attribute(".", "#[derive(serde::Serialize)]")
-        .compile_protos(&["routempls.proto"], &["../../..", "../controlplane/routemplspb"])?;
+        .compile_protos(&["routemplspb/v1/routempls.proto"], &["../../..", "../controlplane"])?;
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -13,7 +13,7 @@ pub mod filterpb {
 pub mod routemplspb {
     use serde::Serialize;
 
-    tonic::include_proto!("routemplspb");
+    tonic::include_proto!("modules.route_mpls.controlplane.routemplspb.v1");
 }
 
 use clap::{ArgAction, CommandFactory, Parser};

--- a/modules/route-mpls/controlplane/mod.go
+++ b/modules/route-mpls/controlplane/mod.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb"
+	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
 )
 
 // RouteMPLSModule is a controlplane part of a module that is responsible for
@@ -21,7 +21,7 @@ type RouteMPLSModule struct {
 }
 
 func NewRouteMPLSModule(cfg *Config, log *zap.Logger) (*RouteMPLSModule, error) {
-	log = log.With(zap.String("module", "routemplspb.RouteService"))
+	log = log.With(zap.String("module", "modules.route_mpls.controlplane.routemplspb.v1.RouteMPLSService"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
@@ -60,7 +60,7 @@ func (m *RouteMPLSModule) Endpoint() string {
 
 func (m *RouteMPLSModule) ServicesNames() []string {
 	return []string{
-		"routemplspb.RouteMPLSService",
+		"modules.route_mpls.controlplane.routemplspb.v1.RouteMPLSService",
 	}
 }
 

--- a/modules/route-mpls/controlplane/routemplspb/meson.build
+++ b/modules/route-mpls/controlplane/routemplspb/meson.build
@@ -1,4 +1,4 @@
-proto_dir = meson.current_source_dir()
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
 root_dir = meson.project_source_root()
 
 proto_files = [

--- a/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
+++ b/modules/route-mpls/controlplane/routemplspb/v1/routempls.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
 
-package routemplspb;
+package modules.route_mpls.controlplane.routemplspb.v1;
 
 import "common/commonpb/ipaddr.proto";
 import "common/filterpb/filter.proto";
 
-option go_package = "github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb;routemplspb";
+option go_package = "github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1;routemplspb";
 
 service RouteMPLSService {
   // Create mpls route module

--- a/modules/route-mpls/controlplane/service.go
+++ b/modules/route-mpls/controlplane/service.go
@@ -16,7 +16,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/filterpb"
 	"github.com/yanet-platform/yanet2/common/go/maptrie"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb"
+	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
 )
 
 type RouteMPLSService struct {

--- a/operators/bird-adapter/internal/rib/routes.go
+++ b/operators/bird-adapter/internal/rib/routes.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/yanet-platform/yanet2/common/commonpb"
 	"github.com/yanet-platform/yanet2/common/filterpb"
-	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb"
+	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
 	routepb "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
 )
 

--- a/operators/bird-adapter/service.go
+++ b/operators/bird-adapter/service.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
 
-	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb"
+	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
 	adapterpb "github.com/yanet-platform/yanet2/operators/bird-adapter/adapterpb"
 	"github.com/yanet-platform/yanet2/operators/bird-adapter/internal/bird"
 	"github.com/yanet-platform/yanet2/operators/bird-adapter/internal/mpls"


### PR DESCRIPTION
Migrate the `route-mpls` module to a fully-qualified, versioned proto package (`modules.route_mpls.controlplane.routemplspb.v1`).

Part of the FQN + versioning series so shared services such as `MetricsService` and a future readiness `ReadyService` no longer collide on the gateway by fully-qualified name.

- Move the proto into a `v1/` directory and rename the package and `go_package`.
- The directory hyphen prevents a matching package segment, so `PACKAGE_DIRECTORY_MATCH` is disabled for this path only via buf `ignore_only`.
- Update the Go control plane and Rust CLI, and enable the remaining buf and protolint checks.