### PR TITLE
fix(web): populate function module types from inspect

### DIFF
--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -6,6 +6,7 @@ import { useFunctionsData } from './hooks/useFunctionsData';
 import { useDragState, useUnsavedChangesBlocker } from '../_shared/lane-editor';
 import { FunctionCard } from './components/FunctionCard';
 import { CreateFunctionDialog } from './dialogs';
+import { getAvailableModuleTypesFromInspect } from './moduleTypeOptions';
 import type { NetworkFunction } from './types';
 import { API } from '../../../api';
 import './FunctionsPage.scss';
@@ -48,17 +49,14 @@ const FunctionsPage = (): React.JSX.Element => {
         const fetchTypes = async (): Promise<void> => {
             try {
                 const resp = await API.inspect.inspect();
+                const moduleTypes = getAvailableModuleTypesFromInspect(resp.instance_info?.dp_modules ?? []);
                 const cpConfigs = resp.instance_info?.cp_configs ?? [];
                 const namesByType = new Map<string, Set<string>>();
-                const types = new Set<string>();
                 const allNames = new Set<string>();
 
                 cpConfigs.forEach(cfg => {
                     const type = cfg.type?.trim() ?? '';
                     const name = cfg.name?.trim() ?? '';
-                    if (type) {
-                        types.add(type);
-                    }
                     if (!name) {
                         return;
                     }
@@ -73,17 +71,16 @@ const FunctionsPage = (): React.JSX.Element => {
                     namesByType.set(type, names);
                 });
 
-                const typeList = [...types].sort((a, b) => a.localeCompare(b));
                 const byType: Record<string, string[]> = {};
                 namesByType.forEach((names, type) => {
                     byType[type] = [...names].sort((a, b) => a.localeCompare(b));
                 });
 
-                setAvailableModuleTypes(typeList);
+                setAvailableModuleTypes(moduleTypes);
                 setAvailableModuleConfigNamesByType(byType);
                 setAvailableModuleConfigNames([...allNames].sort((a, b) => a.localeCompare(b)));
             } catch {
-                // Non-critical; drawer will show current module type only.
+                setAvailableModuleTypes([]);
             }
         };
         fetchTypes();

--- a/web/src/pages/builtin/functions/moduleTypeOptions.test.ts
+++ b/web/src/pages/builtin/functions/moduleTypeOptions.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { getAvailableModuleTypesFromInspect } from './moduleTypeOptions';
+
+describe('getAvailableModuleTypesFromInspect', () => {
+    it('trims, de-duplicates, and sorts module types from inspect', () => {
+        const options = getAvailableModuleTypesFromInspect([
+            { name: ' route ' },
+            { name: 'acl' },
+            { name: 'fwstate' },
+            { name: 'acl' },
+            { name: '  ' },
+            {},
+            { name: null },
+        ]);
+
+        expect(options).toEqual(['acl', 'fwstate', 'route']);
+    });
+
+    it('returns an empty list when inspect provides no usable module names', () => {
+        const options = getAvailableModuleTypesFromInspect([
+            { name: ' ' },
+            {},
+            { name: null },
+        ]);
+
+        expect(options).toEqual([]);
+    });
+});

--- a/web/src/pages/builtin/functions/moduleTypeOptions.ts
+++ b/web/src/pages/builtin/functions/moduleTypeOptions.ts
@@ -1,0 +1,16 @@
+export interface ModuleTypeSource {
+    name?: string | null;
+}
+
+export const getAvailableModuleTypesFromInspect = (moduleTypes: ModuleTypeSource[]): string[] => {
+    const types = new Set<string>();
+
+    moduleTypes.forEach(moduleType => {
+        const name = moduleType.name?.trim() ?? '';
+        if (name) {
+            types.add(name);
+        }
+    });
+
+    return [...types].sort((a, b) => a.localeCompare(b));
+};


### PR DESCRIPTION
- Populate Functions module type options from Inspect dataplane modules instead of existing configs.
- Keep config-name suggestions sourced from `cp_configs`.
- Cover module type normalization with focused tests.