### PR TITLE
refactor(acl): align CLI and web config with faithful proto wire format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3487,6 +3487,7 @@ dependencies = [
  "netip",
  "prost",
  "serde",
+ "serde_json",
  "tonic",
  "tonic-build",
 ]

--- a/common/rust/filterpb/Cargo.toml
+++ b/common/rust/filterpb/Cargo.toml
@@ -11,5 +11,8 @@ prost = "0.13"
 serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.13", features = ["gzip"] }
 
+[dev-dependencies]
+serde_json = "1"
+
 [build-dependencies]
 tonic-build = "0.13"

--- a/common/rust/filterpb/build.rs
+++ b/common/rust/filterpb/build.rs
@@ -1,20 +1,17 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    // `IpNet` is intentionally excluded from the blanket `Serialize` derive
-    // because its prost-generated form (raw `addr`/`mask` byte vectors) is not
-    // a useful JSON representation. A manual `Serialize` impl that emits
-    // `"a.b.c.d/len"` strings lives in `src/network.rs`.
     let serialize = "#[derive(serde::Serialize)]";
+    let serialize_deserialize = "#[derive(serde::Serialize, serde::Deserialize)]";
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
-        .message_attribute(".filterpb.Device", serialize)
-        .message_attribute(".filterpb.VlanRange", serialize)
         .message_attribute(".filterpb.IPPrefix", serialize)
-        .message_attribute(".filterpb.ProtoRange", serialize)
-        .message_attribute(".filterpb.PortRange", serialize)
+        .message_attribute(".filterpb.Device", serialize_deserialize)
+        .message_attribute(".filterpb.PortRange", serialize_deserialize)
+        .message_attribute(".filterpb.ProtoRange", serialize_deserialize)
+        .message_attribute(".filterpb.VlanRange", serialize_deserialize)
         .compile_protos(&["common/filterpb/filter.proto"], &["../../.."])?;
 
     Ok(())

--- a/common/rust/filterpb/src/network.rs
+++ b/common/rust/filterpb/src/network.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display, Formatter};
 
 use netip::{Contiguous, IpNetwork, Ipv4Network, Ipv6Network};
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 use crate::pb::{Device, IpNet};
 
@@ -29,6 +29,15 @@ impl Serialize for IpNet {
     }
 }
 
+impl<'de> Deserialize<'de> for IpNet {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        IpNetwork::parse(&s)
+            .map(IpNet::from)
+            .map_err(|e| de::Error::custom(format!("invalid network address `{s}`: {e}")))
+    }
+}
+
 impl From<IpNetwork> for IpNet {
     fn from(net: IpNetwork) -> Self {
         match net {
@@ -53,5 +62,47 @@ impl From<Contiguous<IpNetwork>> for IpNet {
 impl From<String> for Device {
     fn from(name: String) -> Self {
         Self { name }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn ipnet_v4_cidr_roundtrip() {
+        let net: IpNet = serde_json::from_str("\"192.0.2.0/24\"").expect("IpNet parse must not fail");
+        let serialized = serde_json::to_string(&net).expect("IpNet serialization must not fail");
+        assert_eq!("\"192.0.2.0/24\"", serialized);
+    }
+
+    #[test]
+    fn ipnet_v4_mask_parse() {
+        let net: IpNet = serde_json::from_str("\"192.0.2.0/255.255.255.0\"").expect("IpNet mask parse must not fail");
+        let serialized = serde_json::to_string(&net).expect("IpNet serialization must not fail");
+        assert_eq!("\"192.0.2.0/24\"", serialized);
+    }
+
+    #[test]
+    fn ipnet_v6_cidr_roundtrip() {
+        let net: IpNet = serde_json::from_str("\"2001:db8::/32\"").expect("IpNet parse must not fail");
+        let serialized = serde_json::to_string(&net).expect("IpNet serialization must not fail");
+        assert_eq!("\"2001:db8::/32\"", serialized);
+    }
+
+    #[test]
+    fn device_object_roundtrip() {
+        let device: Device = serde_json::from_str(r#"{"name":"eth0"}"#).expect("Device parse must not fail");
+        assert_eq!("eth0", device.name);
+        let serialized = serde_json::to_string(&device).expect("Device serialization must not fail");
+        assert_eq!(r#"{"name":"eth0"}"#, serialized);
+    }
+
+    #[test]
+    fn device_empty_name_object_roundtrip() {
+        let device: Device = serde_json::from_str(r#"{"name":""}"#).expect("Device parse must not fail");
+        assert_eq!("", device.name);
+        let serialized = serde_json::to_string(&device).expect("Device serialization must not fail");
+        assert_eq!(r#"{"name":""}"#, serialized);
     }
 }

--- a/modules/acl/cli/build.rs
+++ b/modules/acl/cli/build.rs
@@ -8,6 +8,26 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         .build_server(false)
         .extern_path(".commonpb", "::commonpb::pb")
         .extern_path(".filterpb", "::filterpb::pb")
+        .message_attribute(
+            ".modules.acl.controlplane.aclpb.v1.Rule",
+            "#[derive(serde::Serialize, serde::Deserialize)] #[serde(default)]",
+        )
+        .message_attribute(
+            ".modules.acl.controlplane.aclpb.v1.Action",
+            "#[derive(serde::Serialize, serde::Deserialize)]",
+        )
+        .message_attribute(
+            ".modules.acl.controlplane.aclpb.v1.ShowConfigResponse",
+            "#[derive(serde::Serialize)]",
+        )
+        .field_attribute(
+            ".modules.acl.controlplane.aclpb.v1.Action.kind",
+            "#[serde(with = \"crate::action_kind\")]",
+        )
+        .field_attribute(
+            ".modules.acl.controlplane.aclpb.v1.ShowConfigResponse.fwstate_name",
+            "#[serde(skip)]",
+        )
         .compile_protos(&["aclpb/v1/acl.proto"], &["../../..", "../controlplane"])?;
 
     Ok(())

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -8,9 +8,7 @@ use aclpb::{
 use args::{DeleteCmd, MetricsCmd, ModeCmd, OutputFormat, ShowCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use filterpb::pb::{Device, IpNet, PortRange, ProtoRange, VlanRange};
 use metric::Metric;
-use netip::IpNetwork;
 use serde::{Deserialize, Serialize};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
@@ -30,28 +28,23 @@ pub mod aclpb {
     tonic::include_proto!("modules.acl.controlplane.aclpb.v1");
 }
 
-#[derive(Serialize)]
-struct SerializableShowConfigResponse {
-    name: String,
-    rules: Vec<SerializableRule>,
-}
+pub(crate) mod action_kind {
+    use serde::{Deserialize, Deserializer, Serializer, de};
 
-#[derive(Serialize)]
-struct SerializableRule {
-    srcs: Vec<String>,
-    dsts: Vec<String>,
-    src_port_ranges: Vec<String>,
-    dst_port_ranges: Vec<String>,
-    proto_ranges: Vec<String>,
-    vlan_ranges: Vec<String>,
-    devices: Vec<String>,
-    counter: String,
-    actions: Vec<SerializableAction>,
-}
+    use super::aclpb;
 
-#[derive(Serialize)]
-struct SerializableAction {
-    kind: String,
+    pub fn serialize<S: Serializer>(kind: &i32, s: S) -> Result<S::Ok, S::Error> {
+        let action_kind = aclpb::ActionKind::try_from(*kind)
+            .map_err(|_| serde::ser::Error::custom(format!("unknown ActionKind value {kind}")))?;
+        s.serialize_str(action_kind.as_str_name())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<i32, D::Error> {
+        let s = String::deserialize(d)?;
+        let action_kind = aclpb::ActionKind::from_str_name(&s)
+            .ok_or_else(|| de::Error::custom(format!("unknown ActionKind name `{s}`")))?;
+        Ok(action_kind as i32)
+    }
 }
 
 #[derive(Tabled)]
@@ -357,6 +350,23 @@ fn print_metrics_table(metrics: &[Metric]) {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ACLConfig {
+    rules: Vec<aclpb::Rule>,
+}
+
+impl ACLConfig {
+    pub fn load<P>(path: P) -> Result<Self, Box<dyn Error>>
+    where
+        P: AsRef<Path>,
+    {
+        let file = File::open(path)?;
+        let config = serde_yaml::from_reader(file)?;
+
+        Ok(config)
+    }
+}
+
 /// ACL module
 #[derive(Debug, Clone, Parser)]
 #[command(version, about)]
@@ -368,160 +378,6 @@ pub struct Cmd {
     /// Log verbosity level.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
-}
-
-/// Local range type for YAML deserialization
-#[derive(Debug, Serialize, Deserialize)]
-struct Range {
-    from: u16,
-    to: u16,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-enum ActionKind {
-    Allow,
-    Deny,
-    Count,
-    CheckState,
-    CreateState,
-    Log,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct ACLAction {
-    kind: ActionKind,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct ACLRule {
-    srcs: Vec<String>,
-    dsts: Vec<String>,
-    src_ports: Vec<Range>,
-    dst_ports: Vec<Range>,
-    proto_ranges: Vec<Range>,
-    vlan_ranges: Vec<Range>,
-    devices: Vec<String>,
-    #[serde(default)]
-    counter: String,
-    actions: Vec<ACLAction>,
-}
-
-/// Converts a YAML `Range` to a protobuf `PortRange`, validating that
-/// `from <= to`.
-fn port_range(r: &Range) -> Result<PortRange, Box<dyn Error>> {
-    if r.from > r.to {
-        return Err(format!("port 'from' value {} is greater than 'to' value {}", r.from, r.to).into());
-    }
-    Ok(PortRange {
-        from: u32::from(r.from),
-        to: u32::from(r.to),
-    })
-}
-
-/// Converts a YAML `Range` to a protobuf `ProtoRange`, validating that
-/// `from <= to`.
-fn proto_range(r: &Range) -> Result<ProtoRange, Box<dyn Error>> {
-    if r.from > r.to {
-        return Err(format!("protocol 'from' value {} is greater than 'to' value {}", r.from, r.to).into());
-    }
-    Ok(ProtoRange {
-        from: u32::from(r.from),
-        to: u32::from(r.to),
-    })
-}
-
-/// Converts a YAML `Range` to a protobuf `VlanRange`, validating both the
-/// 12-bit VLAN-id bound (4095) and `from <= to`.
-fn vlan_range(r: &Range) -> Result<VlanRange, Box<dyn Error>> {
-    if r.from > 4095 {
-        return Err(format!("VLAN 'from' value {} exceeds maximum 4095", r.from).into());
-    }
-    if r.to > 4095 {
-        return Err(format!("VLAN 'to' value {} exceeds maximum 4095", r.to).into());
-    }
-    if r.from > r.to {
-        return Err(format!("VLAN 'from' value {} is greater than 'to' value {}", r.from, r.to).into());
-    }
-    Ok(VlanRange {
-        from: u32::from(r.from),
-        to: u32::from(r.to),
-    })
-}
-
-impl TryFrom<ACLRule> for aclpb::Rule {
-    type Error = Box<dyn Error>;
-
-    fn try_from(acl_rule: ACLRule) -> Result<Self, Self::Error> {
-        Ok(Self {
-            srcs: acl_rule
-                .srcs
-                .iter()
-                .map(|s| IpNetwork::parse(s).map(IpNet::from))
-                .collect::<Result<_, _>>()?,
-            dsts: acl_rule
-                .dsts
-                .iter()
-                .map(|s| IpNetwork::parse(s).map(IpNet::from))
-                .collect::<Result<_, _>>()?,
-            src_port_ranges: acl_rule.src_ports.iter().map(port_range).collect::<Result<_, _>>()?,
-            dst_port_ranges: acl_rule.dst_ports.iter().map(port_range).collect::<Result<_, _>>()?,
-            proto_ranges: acl_rule
-                .proto_ranges
-                .iter()
-                .map(proto_range)
-                .collect::<Result<_, _>>()?,
-            vlan_ranges: acl_rule.vlan_ranges.iter().map(vlan_range).collect::<Result<_, _>>()?,
-            devices: acl_rule.devices.iter().cloned().map(Device::from).collect(),
-            counter: acl_rule.counter.clone(),
-            actions: acl_rule
-                .actions
-                .iter()
-                .map(|a| aclpb::Action {
-                    kind: match a.kind {
-                        ActionKind::Allow => aclpb::ActionKind::Pass,
-                        ActionKind::Deny => aclpb::ActionKind::Deny,
-                        ActionKind::Count => aclpb::ActionKind::Count,
-                        ActionKind::CheckState => aclpb::ActionKind::CheckState,
-                        ActionKind::CreateState => aclpb::ActionKind::CreateState,
-                        ActionKind::Log => aclpb::ActionKind::Log,
-                    }
-                    .into(),
-                })
-                .collect(),
-        })
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct ACLConfig {
-    rules: Vec<ACLRule>,
-}
-
-impl TryFrom<ACLConfig> for Vec<aclpb::Rule> {
-    type Error = Box<dyn Error>;
-
-    fn try_from(config: ACLConfig) -> Result<Self, Self::Error> {
-        config
-            .rules
-            .into_iter()
-            .enumerate()
-            .map(|(i, rule)| {
-                rule.try_into().map_err(|e: Box<dyn Error>| -> Box<dyn Error> {
-                    format!("failed to parse rule #{}: {}", i + 1, e).into()
-                })
-            })
-            .collect()
-    }
-}
-
-impl ACLConfig {
-    pub fn from_file<P>(path: P) -> Result<Self, Box<dyn Error>>
-    where
-        P: AsRef<Path>,
-    {
-        let rd = File::open(path)?;
-        Ok(serde_yaml::from_reader(rd)?)
-    }
 }
 
 pub struct ACLService {
@@ -549,50 +405,10 @@ impl ACLService {
     pub async fn show_config(&mut self, cmd: ShowCmd) -> Result<(), Box<dyn Error>> {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self.client.show_config(request).await?.into_inner();
-
-        let out = SerializableShowConfigResponse {
-            name: response.name,
-            rules: response
-                .rules
-                .into_iter()
-                .map(|rule| SerializableRule {
-                    srcs: rule.srcs.iter().map(IpNet::to_string).collect(),
-                    dsts: rule.dsts.iter().map(IpNet::to_string).collect(),
-                    src_port_ranges: rule
-                        .src_port_ranges
-                        .iter()
-                        .map(|r| format!("{}-{}", r.from, r.to))
-                        .collect(),
-                    dst_port_ranges: rule
-                        .dst_port_ranges
-                        .iter()
-                        .map(|r| format!("{}-{}", r.from, r.to))
-                        .collect(),
-                    proto_ranges: rule
-                        .proto_ranges
-                        .iter()
-                        .map(|r| format!("{}-{}", r.from, r.to))
-                        .collect(),
-                    vlan_ranges: rule
-                        .vlan_ranges
-                        .iter()
-                        .map(|r| format!("{}-{}", r.from, r.to))
-                        .collect(),
-                    devices: rule.devices.iter().map(|d| d.name.clone()).collect(),
-                    counter: rule.counter.clone(),
-                    actions: rule
-                        .actions
-                        .iter()
-                        .map(|a| SerializableAction {
-                            kind: aclpb::ActionKind::try_from(a.kind)
-                                .map(|k| k.as_str_name().to_string())
-                                .unwrap_or_else(|_| a.kind.to_string()),
-                        })
-                        .collect(),
-                })
-                .collect(),
-        };
-        println!("{}", serde_json::to_string(&out)?);
+        println!(
+            "{}",
+            serde_json::to_string(&response).expect("ShowConfigResponse serialization must not fail")
+        );
         Ok(())
     }
 
@@ -603,9 +419,11 @@ impl ACLService {
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Box<dyn Error>> {
-        let config = ACLConfig::from_file(&cmd.rules)?;
-        let rules: Vec<aclpb::Rule> = config.try_into()?;
-        let request = UpdateConfigRequest { name: cmd.config_name.clone(), rules };
+        let config = ACLConfig::load(&cmd.rules)?;
+        let request = UpdateConfigRequest {
+            name: cmd.config_name.clone(),
+            rules: config.rules,
+        };
         log::trace!("UpdateConfigRequest: {request:?}");
         let response = self.client.update_config(request).await?.into_inner();
         log::debug!("UpdateConfigResponse: {response:?}");
@@ -667,5 +485,24 @@ pub async fn main() {
     if let Err(err) = run(cmd).await {
         log::error!("ERROR: {err}");
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn deserialize_fixture_acl_yaml() {
+        let content = include_str!("../../../../tests/functional/testdata/acl.yaml");
+        let config: ACLConfig = serde_yaml::from_str(content).expect("acl.yaml fixture must deserialize");
+        assert!(!config.rules.is_empty());
+    }
+
+    #[test]
+    fn deserialize_fixture_acl_fwstate_yaml() {
+        let content = include_str!("../../../../tests/functional/testdata/acl+fwstate.yaml");
+        let config: ACLConfig = serde_yaml::from_str(content).expect("acl+fwstate.yaml fixture must deserialize");
+        assert!(!config.rules.is_empty());
     }
 }

--- a/tests/functional/main/fwstate_test.go
+++ b/tests/functional/main/fwstate_test.go
@@ -57,7 +57,7 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 	// 2. Link fwstate to an ACL config so the dataplane module is active.
 	fw.Run("Link_fwstate_to_acl", func(fw *framework.TestFramework, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --name acl_fw --rules /mnt/yanet2/acl+fwstate.yaml",
+			framework.CLIACL + " update --name acl_fw --rules /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml",
 			framework.CLIFWState + " link --name fwstate0 --acl acl_fw",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_fw,fwstate:fwstate0,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
@@ -383,7 +383,7 @@ func testFWStateUDPEndianness(t *testing.T, fw *framework.TestFramework) {
 
 	fw.Run("Link_fwstate_to_acl", func(fw *framework.TestFramework, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --name acl_udp --rules /mnt/yanet2/acl+fwstate.yaml",
+			framework.CLIACL + " update --name acl_udp --rules /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml",
 			framework.CLIFWState + " link --name fwstate_udp --acl acl_udp",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_udp,fwstate:fwstate_udp,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",
@@ -630,7 +630,7 @@ func testFWStateExternalSyncFrame(t *testing.T, fw *framework.TestFramework) {
 	// 2. Link fwstate to ACL with the sync frame allow rule.
 	fw.Run("Link_fwstate_to_acl", func(fw *framework.TestFramework, t *testing.T) {
 		commands := []string{
-			framework.CLIACL + " update --name acl_ext --rules /mnt/yanet2/acl+fwstate.yaml",
+			framework.CLIACL + " update --name acl_ext --rules /mnt/yanet2/tests/functional/testdata/acl+fwstate.yaml",
 			framework.CLIFWState + " link --name fwstate_ext --acl acl_ext",
 			framework.CLIFunction + " update --name=test --chains ch0:2=acl:acl_ext,fwstate:fwstate_ext,route:route0",
 			framework.CLIPipeline + " update --name=test --functions test",

--- a/tests/functional/testdata/acl+fwstate.yaml
+++ b/tests/functional/testdata/acl+fwstate.yaml
@@ -14,10 +14,10 @@ rules:
 
   # Create state for outgoing TCP to port 80
   - actions:
-      - kind: CreateState
-      - kind: Allow
+      - kind: ACTION_KIND_CREATE_STATE
+      - kind: ACTION_KIND_PASS
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 80
         to: 80
     dsts:
@@ -25,7 +25,7 @@ rules:
     proto_ranges:
       - from: 1536
         to: 1791
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -34,10 +34,10 @@ rules:
 
   # Check state for return traffic
   - actions:
-      - kind: CheckState
-      - kind: Deny
+      - kind: ACTION_KIND_CHECK_STATE
+      - kind: ACTION_KIND_DENY
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -45,7 +45,7 @@ rules:
     proto_ranges:
       - from: 1536
         to: 1791
-    src_ports:
+    src_port_ranges:
       - from: 80
         to: 80
     srcs:
@@ -54,10 +54,10 @@ rules:
 
   # Create state for outgoing UDP to port 80
   - actions:
-      - kind: CreateState
-      - kind: Allow
+      - kind: ACTION_KIND_CREATE_STATE
+      - kind: ACTION_KIND_PASS
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 80
         to: 80
     dsts:
@@ -65,7 +65,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -74,10 +74,10 @@ rules:
 
   # Check state for return UDP traffic
   - actions:
-      - kind: CheckState
-      - kind: Deny
+      - kind: ACTION_KIND_CHECK_STATE
+      - kind: ACTION_KIND_DENY
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -85,7 +85,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 80
         to: 80
     srcs:
@@ -96,10 +96,10 @@ rules:
 
   # Create state for outgoing TCPv6 to port 80
   - actions:
-      - kind: CreateState
-      - kind: Allow
+      - kind: ACTION_KIND_CREATE_STATE
+      - kind: ACTION_KIND_PASS
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 80
         to: 80
     dsts:
@@ -107,7 +107,7 @@ rules:
     proto_ranges:
       - from: 1536
         to: 1791
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -116,10 +116,10 @@ rules:
 
   # Check state for return TCPv6 traffic
   - actions:
-      - kind: CheckState
-      - kind: Deny
+      - kind: ACTION_KIND_CHECK_STATE
+      - kind: ACTION_KIND_DENY
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -127,7 +127,7 @@ rules:
     proto_ranges:
       - from: 1536
         to: 1791
-    src_ports:
+    src_port_ranges:
       - from: 80
         to: 80
     srcs:
@@ -140,9 +140,9 @@ rules:
   # These packets are processed by the fwstate module to create external state
   # entries and then dropped.
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 9999
         to: 9999
     dsts:
@@ -150,7 +150,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 9999
         to: 9999
     srcs:

--- a/tests/functional/testdata/acl-mbuf-leak.yaml
+++ b/tests/functional/testdata/acl-mbuf-leak.yaml
@@ -1,9 +1,9 @@
 rules:
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     counter: "count_udp"
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -11,7 +11,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -19,11 +19,11 @@ rules:
     vlan_ranges: []
 
   - actions:
-      - kind: CreateState
-      - kind: Allow
+      - kind: ACTION_KIND_CREATE_STATE
+      - kind: ACTION_KIND_PASS
     counter: "create_state_tcp"
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 80
         to: 80
     dsts:
@@ -31,7 +31,7 @@ rules:
     proto_ranges:
       - from: 1536
         to: 1791
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -39,10 +39,10 @@ rules:
     vlan_ranges: []
 
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     counter: "allow"
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -50,7 +50,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:

--- a/tests/functional/testdata/acl.yaml
+++ b/tests/functional/testdata/acl.yaml
@@ -1,28 +1,19 @@
 # ACL Rules Configuration
-# =============================================
 #
 # Format: YAML
 #
 # Structure:
 # rules:
 #   - actions:                                    # List of actions (last one is terminal)
-#       - kind: Allow|Deny|Count|...              # Action kind
+#       - kind: ACTION_KIND_PASS|ACTION_KIND_DENY|...   # Action kind
 #     counter: string                         # Optional counter name
-#     devices: [string]                         # List of devices (currently empty array)
-#     dst_ports: array                          # Destination port ranges
-#       - from: int                               # Start of port range
-#         to: int                                 # End of port range
-#     dsts: [string]                            # Destination addresses (address/mask)
-#     proto_ranges: array                       # Protocol ranges
-#       - from: int                               # Start of protocol range
-#         to: int                                 # End of protocol range
-#     src_ports: array                          # Source port ranges
-#       - from: int                               # Start of port range
-#         to: int                                 # End of port range
-#     srcs: [string]                            # Source addresses (address/mask)
-#     vlan_ranges: array                        # VLAN ranges (0–4095)
-#       - from: int                               # Start of vlan range
-#         to: int                                 # End of vlan range
+#     devices: [{name: string}]                 # List of devices (objects with a name)
+#     dst_port_ranges: [{from: N, to: M}]       # Destination port ranges
+#     dsts: [string]                            # Destination addresses (address/mask or CIDR)
+#     proto_ranges: [{from: N, to: M}]          # Protocol ranges
+#     src_port_ranges: [{from: N, to: M}]       # Source port ranges
+#     srcs: [string]                            # Source addresses (address/mask or CIDR)
+#     vlan_ranges: [{from: N, to: M}]           # VLAN ranges (0-4095)
 
 rules:
   # ===== BASIC ALLOW/DENY RULES =====
@@ -30,9 +21,9 @@ rules:
   # 1
   # add allow udp from 192.0.2.2 to 192.0.3.1 150-450,600
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 150
         to: 450
       - from: 600
@@ -42,7 +33,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -53,9 +44,9 @@ rules:
   # 2
   # add deny udp from 192.0.2.99 to 192.0.3.1 600
   - actions:
-      - kind: Deny
+      - kind: ACTION_KIND_DENY
     devices: []
-    dst_ports:
+    dst_port_ranges:
       - from: 600
         to: 600
     dsts:
@@ -63,7 +54,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -75,10 +66,10 @@ rules:
   # 3
   # add allow tcp from 192.0.2.2 to 192.0.3.1 600 tcpflags syn
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 600
         to: 600
     dsts:
@@ -212,7 +203,7 @@ rules:
         to: 1787
       - from: 1790
         to: 1791
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -223,10 +214,10 @@ rules:
   # 4
   # add deny tcp from any to any tcpflags rst
   - actions:
-      - kind: Deny
+      - kind: ACTION_KIND_DENY
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -297,7 +288,7 @@ rules:
         to: 1783
       - from: 1788
         to: 1791
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -309,10 +300,10 @@ rules:
   # 5
   # add allow icmp from 192.0.2.2 to 192.0.3.1 icmptypes 8
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -320,7 +311,7 @@ rules:
     proto_ranges:
       - from: 264
         to: 264
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -332,10 +323,10 @@ rules:
   # 6
   # add allow udp from 192.0.2.0/24 to 192.0.3.1 600
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 600
         to: 600
     dsts:
@@ -343,7 +334,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -354,10 +345,10 @@ rules:
   # 7
   # add deny udp from 192.0.99.0/24 to any
   - actions:
-      - kind: Deny
+      - kind: ACTION_KIND_DENY
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -366,7 +357,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -378,10 +369,10 @@ rules:
   # 8
   # add allow tcp from 2001:db8::1 to 2001:db8::2 600
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 600
         to: 600
     dsts:
@@ -389,7 +380,7 @@ rules:
     proto_ranges:
       - from: 1536
         to: 1791
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -400,10 +391,10 @@ rules:
   # 9
   # add allow ipv6-icmp from 2001:db8::1 to 2001:db8::2 icmp6types 128,129
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -413,7 +404,7 @@ rules:
         to: 14976
       - from: 14977
         to: 14977
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -424,10 +415,10 @@ rules:
   # 10
   # add deny udp from 2001:db8::99 to 2001:db8::2 600
   - actions:
-      - kind: Deny
+      - kind: ACTION_KIND_DENY
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 600
         to: 600
     dsts:
@@ -435,7 +426,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -447,10 +438,10 @@ rules:
   # 11
   # add allow udp from 192.0.2.0/31 to any 100-200
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -459,7 +450,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -469,10 +460,10 @@ rules:
   # 12
   # add deny udp from 192.0.2.0/28 to any
   - actions:
-      - kind: Deny
+      - kind: ACTION_KIND_DENY
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -481,7 +472,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -491,10 +482,10 @@ rules:
   # 13
   # add allow udp from 192.0.2.0/24 to any
   - actions:
-      - kind: Allow
+      - kind: ACTION_KIND_PASS
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -503,7 +494,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -513,10 +504,10 @@ rules:
   # 14
   # add deny udp from 192.0.0.0/16 to any
   - actions:
-      - kind: Deny
+      - kind: ACTION_KIND_DENY
     devices:
-      - ""
-    dst_ports:
+      - name: ""
+    dst_port_ranges:
       - from: 0
         to: 65535
     dsts:
@@ -525,7 +516,7 @@ rules:
     proto_ranges:
       - from: 4352
         to: 4607
-    src_ports:
+    src_port_ranges:
       - from: 0
         to: 65535
     srcs:
@@ -535,20 +526,17 @@ rules:
 #   - action: Deny
 #     counter: ""
 #     devices:
-#       - ""
-#     dst_ports:
-#       - from: 0
-#         to: 65535
+#       - {name: ""}
+#     dst_port_ranges:
+#       - {from: 0, to: 65535}
 #     dsts:
 #       - 0.0.0.0/0.0.0.0
-#       - '::/::'
+#       - '::/0'
 #     proto_ranges:
-#       - from: 0
-#         to: 65535
-#     src_ports:
-#       - from: 0
-#         to: 65535
+#       - {from: 0, to: 65535}
+#     src_port_ranges:
+#       - {from: 0, to: 65535}
 #     srcs:
 #       - 0.0.0.0/0.0.0.0
-#       - '::/::'
+#       - '::/0'
 #     vlan_ranges: []

--- a/web/src/pages/modules/acl/SaveDiffModal.tsx
+++ b/web/src/pages/modules/acl/SaveDiffModal.tsx
@@ -28,17 +28,15 @@ export const rulesToYamlObjects = (rules: Rule[]): Array<Record<string, unknown>
         };
         const srcs = (r.srcs ?? []).map(fmtIPNet).filter(Boolean);
         const dsts = (r.dsts ?? []).map(fmtIPNet).filter(Boolean);
-        const fmtRange = (rng: { from?: number; to?: number }): string => {
-            const from = rng.from ?? 0;
-            const to = rng.to ?? 0;
-            if (from === to) return String(from);
-            return `${from}-${to}`;
-        };
+        const fmtRange = (rng: { from?: number; to?: number }): { from: number; to: number } => ({
+            from: rng.from ?? 0,
+            to: rng.to ?? 0,
+        });
         const src_port_ranges = (r.src_port_ranges ?? []).map(fmtRange);
         const dst_port_ranges = (r.dst_port_ranges ?? []).map(fmtRange);
         const proto_ranges = (r.proto_ranges ?? []).map(fmtRange);
         const vlan_ranges = (r.vlan_ranges ?? []).map(fmtRange);
-        const devices = (r.devices ?? []).map(d => d.name ?? '').filter(Boolean);
+        const devices = (r.devices ?? []).map(d => ({ name: d.name ?? '' })).filter(d => d.name !== '');
         const actions = (r.actions ?? []).map(a => ({
             kind: ACTION_KIND_YAML_NAMES[a.kind ?? ActionKind.ACTION_KIND_PASS] ?? 'ACTION_KIND_PASS',
         }));

--- a/web/src/pages/modules/acl/YamlIO.tsx
+++ b/web/src/pages/modules/acl/YamlIO.tsx
@@ -113,9 +113,11 @@ const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport }) => {
                 '    dsts:\n' +
                 '      - 192.0.3.0/24\n' +
                 '    dst_port_ranges:\n' +
-                '      - "80-80"\n' +
+                '      - from: 80\n' +
+                '        to: 80\n' +
                 '    proto_ranges:\n' +
-                '      - "1536-1791"\n' +
+                '      - from: 1536\n' +
+                '        to: 1791\n' +
                 '    actions:\n' +
                 '      - kind: ACTION_KIND_PASS'
             }

--- a/web/src/pages/modules/acl/yamlImport.worker.ts
+++ b/web/src/pages/modules/acl/yamlImport.worker.ts
@@ -11,7 +11,7 @@
 import yaml from 'js-yaml';
 import { ActionKind } from '../../../api/acl';
 import type { Rule } from '../../../api/acl';
-import { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
+import { parseCidrsToIPNets } from './parseHelpers';
 
 /** Raw shape of an action entry in the YAML schema. */
 interface YamlAction {
@@ -45,6 +45,21 @@ const parseStringArray = (val: unknown): string[] => {
     return (val as unknown[]).filter((s): s is string => typeof s === 'string');
 };
 
+/** Convert an array of {from, to} YAML objects to wire range objects. */
+const rangesFromObjects = (val: unknown): Array<{ from: number; to: number }> => {
+    if (!Array.isArray(val)) return [];
+    const results: Array<{ from: number; to: number }> = [];
+    for (const item of val as unknown[]) {
+        if (!item || typeof item !== 'object') continue;
+        const obj = item as Record<string, unknown>;
+        const from = typeof obj['from'] === 'number' ? obj['from'] : Number(obj['from'] ?? 0);
+        const to = typeof obj['to'] === 'number' ? obj['to'] : Number(obj['to'] ?? 0);
+        if (isNaN(from) || isNaN(to)) continue;
+        results.push({ from, to });
+    }
+    return results;
+};
+
 const convertRow = (r: unknown): Rule => {
     if (!r || typeof r !== 'object') return {};
     const row = r as YamlRule;
@@ -52,19 +67,16 @@ const convertRow = (r: unknown): Rule => {
     const srcs = parseCidrsToIPNets(parseStringArray(row.srcs));
     const dsts = parseCidrsToIPNets(parseStringArray(row.dsts));
 
-    const srcPortStrings = parseStringArray(row.src_port_ranges);
-    const src_port_ranges = srcPortStrings.length > 0 ? parseRangesRaw(srcPortStrings.join(', ')) : [];
+    const src_port_ranges = rangesFromObjects(row.src_port_ranges);
+    const dst_port_ranges = rangesFromObjects(row.dst_port_ranges);
+    const proto_ranges = rangesFromObjects(row.proto_ranges);
+    const vlan_ranges = rangesFromObjects(row.vlan_ranges);
 
-    const dstPortStrings = parseStringArray(row.dst_port_ranges);
-    const dst_port_ranges = dstPortStrings.length > 0 ? parseRangesRaw(dstPortStrings.join(', ')) : [];
-
-    const protoStrings = parseStringArray(row.proto_ranges);
-    const proto_ranges = protoStrings.length > 0 ? parseProtoRangesRaw(protoStrings.join(', ')) : [];
-
-    const vlanStrings = parseStringArray(row.vlan_ranges);
-    const vlan_ranges = vlanStrings.length > 0 ? parseRangesRaw(vlanStrings.join(', ')) : [];
-
-    const devices = parseStringArray(row.devices).map(name => ({ name }));
+    const devicesRaw = Array.isArray(row.devices) ? row.devices as unknown[] : [];
+    const devices = devicesRaw
+        .filter((d): d is Record<string, unknown> => !!d && typeof d === 'object')
+        .map(d => ({ name: typeof d['name'] === 'string' ? d['name'] : '' }))
+        .filter(d => d.name !== '');
     const counter = typeof row.counter === 'string' ? row.counter : undefined;
 
     const actionsRaw = Array.isArray(row.actions) ? row.actions as unknown[] : [];


### PR DESCRIPTION
Aligns the ACL configuration format across the CLI, the web UI, and the stored fixtures so YAML/JSON exported from one imports cleanly into the other.

- Replace the ACL CLI's hand-written import and export wrapper types with serde derived directly on the proto messages.
- Serialize numeric port, protocol, and VLAN ranges and devices in their faithful wire shape, while keeping IP networks as CIDR strings and action kinds as enum-name strings.
- Drop the duplicated client-side range bound checks and rely on the existing control-plane validation.
- Update the web ACL export and import paths to the same shape; the rule editor's free-text parsers are unchanged.
- Convert the functional test fixtures to the new format and move the acl+fwstate fixture into the functional test data directory.