### PR TITLE
Lookup unknown device as `any` one

### DIFF
--- a/filter/query/device.h
+++ b/filter/query/device.h
@@ -13,6 +13,8 @@ FILTER_ATTR_QUERY_FUNC(device)(
 	struct value_table *t = (struct value_table *)data;
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		uint64_t device_id = packets[idx]->module_device_id;
+		if (device_id >= t->v_dim)
+			device_id = 0;
 		result[idx] = value_table_get(t, 0, device_id);
 	}
 }


### PR DESCRIPTION
If a device is not referenced by a ruleset then its identifier may be greater than known max device identifier value. In such case the device should be trait as `any` device with zero-fixed id.