### PR TITLE
refactor(forward): manage multiple network functions in one operator

### DIFF
--- a/debian/yanet2-forward-operator.install
+++ b/debian/yanet2-forward-operator.install
@@ -1,3 +1,4 @@
 usr/bin/yanet-forward-operator
 etc/yanet2/forward.d/vlan-phy-default.yaml
 etc/yanet2/forward.d/phy-vlan-default.yaml
+etc/yanet2/yanet-forward-operator-default.yaml

--- a/debian/yanet2-forward-operator.service
+++ b/debian/yanet2-forward-operator.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=yanet2 forward operator (function: %i)
+Description=yanet2 forward operator
 After=yanet2-controlplane.service
 Wants=yanet2-controlplane.service
 StartLimitBurst=3600000
@@ -8,10 +8,12 @@ StartLimitIntervalSec=0
 [Service]
 User=root
 Group=yanet
-ExecStart=/usr/bin/yanet-forward-operator /etc/yanet2/forward.d/%i.yaml
+
+ExecStart=/usr/bin/yanet-forward-operator -c /etc/yanet2/yanet-forward-operator.yaml
 TimeoutSec=1200
 Restart=always
 RestartSec=1
+LimitCORE=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/operators/forward/cmd/yanet-forward-operator/main.go
+++ b/operators/forward/cmd/yanet-forward-operator/main.go
@@ -1,152 +1,27 @@
 package main
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"os"
-	"os/signal"
-	"path/filepath"
-	"strings"
-	"syscall"
-	"time"
 
-	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	_ "google.golang.org/grpc/encoding/gzip"
 
-	"github.com/yanet-platform/yanet2/common/go/logging"
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/common/go/xcfg"
-	forwardop "github.com/yanet-platform/yanet2/operators/forward/internal/operator"
+	op "github.com/yanet-platform/yanet2/operators/forward/internal/operator"
 )
 
 func main() {
-	var (
-		gateways    []string
-		interval    time.Duration
-		prefix      string
-		ignorePdump bool
-		logLevel    string
-	)
-
-	cmd := &cobra.Command{
-		Use:   "yanet-forward-operator RULES_FILE",
-		Short: "Reconciler that applies a forward function to one or more gateways",
-		Long: `Manages exactly ONE forward function on the gateway. Run multiple
-instances (e.g. via systemd template yanet2-forward-operator@) to
-manage multiple functions.
-
-RULES_FILE must be a path to a *.yaml forward-rules file. The function
-is named <prefix><basename> where <basename> is the filename without .yaml.`,
-		Args:         cobra.ExactArgs(1),
-		SilenceUsage: true,
-		RunE: func(_ *cobra.Command, args []string) error {
-			return run(args[0], gateways, interval, prefix, ignorePdump, logLevel)
-		},
-	}
-
-	cmd.Flags().StringArrayVarP(&gateways, "gateway", "g", nil, "gRPC endpoint, repeatable (default: grpc://[::1]:8080)")
-	cmd.Flags().DurationVarP(&interval, "interval", "i", 30*time.Second, "pause between iterations")
-	cmd.Flags().StringVarP(&prefix, "function-prefix", "p", "fn:forward-", "function name prefix")
-	cmd.Flags().BoolVar(&ignorePdump, "ignore-pdump", false, "preserve pdump modules already present in the function's default chain")
-	cmd.Flags().StringVar(&logLevel, "log-level", "info", "log level: debug, info, warn, error")
-
-	if err := cmd.Execute(); err != nil {
+	if err := operator.Run(
+		"yanet-forward-operator",
+		"YANET forward operator — owns N forward functions across gateways",
+		factory,
+	); err != nil {
+		fmt.Printf("ERROR: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-// run validates flags and drives the reconcile loop until interrupted.
-func run(
-	rulesFile string,
-	gateways []string,
-	interval time.Duration,
-	prefix string,
-	ignorePdump bool,
-	logLevel string,
-) error {
-	if err := validateRulesFile(rulesFile); err != nil {
-		return err
-	}
-	if len(gateways) == 0 {
-		gateways = []string{"grpc://[::1]:8080"}
-	}
-	cfgName := strings.TrimSuffix(filepath.Base(rulesFile), ".yaml")
-	functionName := prefix + cfgName
-
-	var level zapcore.Level
-	if err := level.UnmarshalText([]byte(logLevel)); err != nil {
-		return fmt.Errorf("invalid log level %q: %w", logLevel, err)
-	}
-
-	log, _, err := logging.Init(&logging.Config{Level: level})
-	if err != nil {
-		return fmt.Errorf("failed to initialize logging: %w", err)
-	}
-	defer func() { _ = log.Sync() }()
-
-	rules, err := forwardop.LoadForwardRules(rulesFile)
-	if err != nil {
-		return fmt.Errorf("failed to load rules: %w", err)
-	}
-
-	// Build per-gateway actuators. Each one dials once and holds the
-	// connection for its lifetime.
-	actuators := make([]operator.Actuator[forwardop.State], 0, len(gateways))
-	closeActuators := func() {
-		for _, a := range actuators {
-			if err := a.Close(); err != nil {
-				log.Warn("failed to close gateway actuator", zap.Error(err))
-			}
-		}
-	}
-	for _, gw := range gateways {
-		a, err := forwardop.NewGatewayActuator(gw, cfgName, functionName, ignorePdump, forwardop.WithLog(log))
-		if err != nil {
-			closeActuators()
-			return err
-		}
-		actuators = append(actuators, a)
-	}
-
-	fanOut := operator.NewFanOutActuator(actuators, operator.WithFanOutLog(log))
-
-	source := forwardop.NewStaticSource(rules, forwardop.WithSourceLog(log))
-
-	op := operator.NewOperator(
-		fanOut,
-		source,
-		operator.WithLog(log),
-		operator.WithReconcile(operator.ReconcileConfig{
-			Interval:       xcfg.MustNonZero(interval),
-			InitialBackoff: xcfg.MustNonZero(operator.DefaultReconcileInitialBackoff),
-			MaxBackoff:     xcfg.MustNonZero(operator.DefaultReconcileMaxBackoff),
-		}),
-	)
-	defer func() {
-		if err := op.Close(); err != nil {
-			log.Warn("failed to close operator", zap.Error(err))
-		}
-	}()
-
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel()
-
-	if err := op.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
-		return err
-	}
-	return nil
-}
-
-// validateRulesFile rejects paths that do not end in .yaml or that do
-// not exist on disk.
-func validateRulesFile(path string) error {
-	if !strings.HasSuffix(path, ".yaml") {
-		return fmt.Errorf("RULES_FILE must end with .yaml: %s", path)
-	}
-	if _, err := os.Stat(path); err != nil {
-		return fmt.Errorf("not a file: %s", path)
-	}
-	return nil
+func factory(cfg *op.Config, log *zap.Logger) (operator.Runnable, error) {
+	return op.NewOperator(cfg, op.WithLog(log))
 }

--- a/operators/forward/etc/yanet/yanet-forward-operator-default.yaml
+++ b/operators/forward/etc/yanet/yanet-forward-operator-default.yaml
@@ -1,0 +1,29 @@
+logging:
+  level: info
+
+server:
+  endpoint: "[::1]:50003"
+
+gateways:
+  - name: numa0
+    endpoint: "[::1]:8080"
+
+register:
+  interval: 30s
+
+reconcile:
+  interval: 30s
+  initial_backoff: 500ms
+  max_backoff: 30s
+
+functions:
+  - name: "fn:forward-vlan-phy"
+    chain: "default"
+    weight: 1
+    module: "vlan-phy"
+    rules_file: "/etc/yanet2/forward.d/vlan-phy-default.yaml"
+  - name: "fn:forward-phy-vlan"
+    chain: "default"
+    weight: 1
+    module: "phy-vlan"
+    rules_file: "/etc/yanet2/forward.d/phy-vlan-default.yaml"

--- a/operators/forward/internal/operator/actuator_gateway.go
+++ b/operators/forward/internal/operator/actuator_gateway.go
@@ -2,8 +2,8 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -15,96 +15,121 @@ import (
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
-// GatewayActuator publishes the desired forward state to a single gateway.
-type GatewayActuator struct {
-	endpoint    string
-	conn        *grpc.ClientConn
-	forward     forwardpb.ForwardServiceClient
-	funcApplier *operator.FunctionApplier
-	configName  string
-	log         *zap.Logger
+// funcApplierEntry bundles a FunctionApplier with its function name for
+// logging.
+type funcApplierEntry struct {
+	name    string
+	applier *operator.FunctionApplier
 }
 
-// NewGatewayActuator dials the gateway endpoint and returns a ready-to-use
-// actuator. The connection is kept open for the lifetime of the actuator;
-// call Close to release it. functionName is the gateway-side function
-// identifier; configName is the forward module config name.
+// GatewayActuator publishes the desired forward state to a single gateway.
+type GatewayActuator struct {
+	name     string
+	conn     *grpc.ClientConn
+	forward  forwardpb.ForwardServiceClient
+	appliers []funcApplierEntry
+	log      *zap.Logger
+}
+
+// NewGatewayActuator dials the gateway endpoint and returns a
+// ready-to-use actuator for all configured functions. The connection is
+// kept open for the lifetime of the actuator; call Close to release it.
 func NewGatewayActuator(
-	endpoint, configName, functionName string,
-	ignorePdump bool,
-	options ...Option,
+	cfg operator.GatewayConfig,
+	functions []FunctionConfig,
+	options ...GatewayActuatorOption,
 ) (*GatewayActuator, error) {
-	opts := newOptions()
+	opts := newGatewayActuatorOptions()
 	for _, o := range options {
 		o(opts)
 	}
 
-	dialTarget := strings.TrimPrefix(endpoint, "grpc://")
+	endpoint := cfg.Endpoint.Unwrap()
 	conn, err := grpc.NewClient(
-		dialTarget,
+		endpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial gateway %q: %w", endpoint, err)
+		return nil, fmt.Errorf("failed to dial gateway %q at %q: %w", cfg.Name, endpoint, err)
 	}
+
+	fnClient := ynpb.NewFunctionServiceClient(conn)
+	appliers := make([]funcApplierEntry, 0, len(functions))
+	for _, fn := range functions {
+		spec := operator.FunctionChainSpec{
+			Name:   fn.Name.Unwrap(),
+			Chain:  fn.Chain.Unwrap(),
+			Weight: fn.Weight,
+			Modules: []*commonpb.ModuleId{{
+				Type: "forward",
+				Name: fn.Module.Unwrap(),
+			}},
+		}
+		appliers = append(appliers, funcApplierEntry{
+			name: fn.Name.Unwrap(),
+			applier: operator.NewFunctionApplier(
+				fnClient,
+				spec,
+				operator.WithIgnorePdump(fn.IgnorePdump),
+			),
+		})
+	}
+
 	return &GatewayActuator{
-		endpoint: endpoint,
+		name:     cfg.Name,
 		conn:     conn,
 		forward:  forwardpb.NewForwardServiceClient(conn),
-		funcApplier: operator.NewFunctionApplier(
-			ynpb.NewFunctionServiceClient(conn),
-			newFuncSpec(functionName, configName),
-			operator.WithIgnorePdump(ignorePdump),
-		),
-		configName: configName,
-		log: opts.Log.With(
-			zap.String("gateway", endpoint),
-			zap.String("function", functionName),
-		),
+		appliers: appliers,
+		log:      opts.Log.With(zap.String("gateway", cfg.Name)),
 	}, nil
 }
 
-// Apply pushes the module config and then ensures the function definition
-// is correct on the gateway.
+// Apply pushes every module config and then ensures all function
+// definitions are correct on the gateway.
+//
+// Errors from individual modules or functions are joined; the reconcile
+// loop applies backoff, so each Apply pass tries everything regardless
+// of partial failures.
 func (m *GatewayActuator) Apply(ctx context.Context, state State) error {
-	_, err := m.forward.UpdateConfig(ctx, &forwardpb.UpdateConfigRequest{
-		Name:  m.configName,
-		Rules: state.Rules,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to apply module-config %q: %w", m.configName, err)
+	var err error
+
+	for _, mc := range state.Modules {
+		_, e := m.forward.UpdateConfig(ctx, &forwardpb.UpdateConfigRequest{
+			Name:  mc.Name,
+			Rules: mc.Rules,
+		})
+		if e != nil {
+			err = errors.Join(err, fmt.Errorf(
+				"failed to apply module config %q to gateway %q: %w",
+				mc.Name, m.name, e,
+			))
+		}
 	}
 
-	m.log.Info("applied module config",
-		zap.String("name", m.configName),
-	)
-
-	skipped, err := m.funcApplier.Apply(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to update function: %w", err)
+	for _, entry := range m.appliers {
+		skipped, e := entry.applier.Apply(ctx)
+		if e != nil {
+			err = errors.Join(err, fmt.Errorf(
+				"failed to update function %q on gateway %q: %w",
+				entry.name, m.name, e,
+			))
+			continue
+		}
+		if skipped {
+			m.log.Debug("function already correct, skipped",
+				zap.String("function", entry.name),
+			)
+		} else {
+			m.log.Info("updated function",
+				zap.String("function", entry.name),
+			)
+		}
 	}
 
-	if skipped {
-		m.log.Info("function already correct, skipped")
-	} else {
-		m.log.Info("updated function")
-	}
-
-	return nil
+	return err
 }
 
 // Close releases the underlying gRPC connection.
 func (m *GatewayActuator) Close() error {
 	return m.conn.Close()
-}
-
-// newFuncSpec builds the FunctionChainSpec for the forward operator from
-// the supplied function name, config name, and module type.
-func newFuncSpec(functionName, configName string) operator.FunctionChainSpec {
-	return operator.FunctionChainSpec{
-		Name:    functionName,
-		Chain:   "default",
-		Weight:  1,
-		Modules: []*commonpb.ModuleId{{Type: "forward", Name: configName}},
-	}
 }

--- a/operators/forward/internal/operator/cfg.go
+++ b/operators/forward/internal/operator/cfg.go
@@ -1,0 +1,102 @@
+package operator
+
+import (
+	"errors"
+	"fmt"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/yanet-platform/yanet2/common/go/logging"
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+// Config is the top-level YAML configuration for yanet-forward-operator.
+type Config struct {
+	Logging   logging.Config             `yaml:"logging"`
+	Server    *operator.GRPCServerConfig `yaml:"server"`
+	Gateways  []operator.GatewayConfig   `yaml:"gateways"`
+	Register  operator.RegisterConfig    `yaml:"register"`
+	Reconcile operator.ReconcileConfig   `yaml:"reconcile"`
+	Functions []FunctionConfig           `yaml:"functions"`
+}
+
+// Default resets the config to built-in defaults.
+func (m *Config) Default() {
+	*m = *DefaultConfig()
+}
+
+// LoggingConfig exposes the embedded logging configuration to the
+// generic operator CLI helper.
+func (m *Config) LoggingConfig() *logging.Config {
+	return &m.Logging
+}
+
+// Validate checks that the config is structurally sound.
+func (m *Config) Validate() error {
+	if len(m.Gateways) == 0 {
+		return errors.New("at least one gateway must be configured")
+	}
+	if len(m.Functions) == 0 {
+		return errors.New("at least one function must be configured")
+	}
+
+	names := map[string]struct{}{}
+	modules := map[string]struct{}{}
+	for idx, fn := range m.Functions {
+		name := fn.Name.Unwrap()
+		if _, dup := names[name]; dup {
+			return fmt.Errorf("duplicate function name %q at index %d", name, idx)
+		}
+		names[name] = struct{}{}
+
+		mod := fn.Module.Unwrap()
+		if _, dup := modules[mod]; dup {
+			return fmt.Errorf("duplicate module name %q at index %d", mod, idx)
+		}
+		modules[mod] = struct{}{}
+	}
+
+	return nil
+}
+
+// DefaultConfig returns a Config populated with sensible defaults.
+func DefaultConfig() *Config {
+	return &Config{
+		Logging: logging.Config{
+			Level: zapcore.InfoLevel,
+		},
+		Server: &operator.GRPCServerConfig{
+			Endpoint: xcfg.MustNonEmptyString("[::1]:50003"),
+		},
+		Reconcile: operator.ReconcileConfig{
+			Interval:       xcfg.MustNonZero(operator.DefaultReconcileInterval),
+			InitialBackoff: xcfg.MustNonZero(operator.DefaultReconcileInitialBackoff),
+			MaxBackoff:     xcfg.MustNonZero(operator.DefaultReconcileMaxBackoff),
+		},
+		Register: operator.RegisterConfig{
+			Interval: xcfg.MustNonZero(operator.DefaultRegisterInterval),
+		},
+		Functions: []FunctionConfig{},
+	}
+}
+
+// FunctionConfig describes one gateway-side network function managed by
+// this operator.
+type FunctionConfig struct {
+	// Name is the function identifier (e.g. "fn:forward-vlan-phy").
+	Name xcfg.NonEmptyString `yaml:"name"`
+	// Chain is the chain name (e.g. "default").
+	Chain xcfg.NonEmptyString `yaml:"chain"`
+	// Weight is the chain weight inside the function.
+	Weight uint64 `yaml:"weight"`
+	// Module is the forward module config name this function targets
+	// (e.g. "vlan-phy").
+	Module xcfg.NonEmptyString `yaml:"module"`
+	// RulesFile is the path to the forward rules YAML file for this
+	// function.
+	RulesFile xcfg.NonEmptyString `yaml:"rules_file"`
+	// IgnorePdump skips function updates when the existing chain already
+	// matches Modules once every pdump:* module is filtered out.
+	IgnorePdump bool `yaml:"ignore_pdump"`
+}

--- a/operators/forward/internal/operator/cfg_test.go
+++ b/operators/forward/internal/operator/cfg_test.go
@@ -1,0 +1,105 @@
+package operator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+func validConfig() *Config {
+	return &Config{
+		Gateways: []operator.GatewayConfig{
+			{Name: "numa0", Endpoint: xcfg.MustNonEmptyString("[::1]:8080")},
+		},
+		Reconcile: operator.ReconcileConfig{
+			Interval:       xcfg.MustNonZero(operator.DefaultReconcileInterval),
+			InitialBackoff: xcfg.MustNonZero(operator.DefaultReconcileInitialBackoff),
+			MaxBackoff:     xcfg.MustNonZero(operator.DefaultReconcileMaxBackoff),
+		},
+		Functions: []FunctionConfig{
+			{
+				Name:      xcfg.MustNonEmptyString("fn:forward-vlan-phy"),
+				Chain:     xcfg.MustNonEmptyString("default"),
+				Weight:    1,
+				Module:    xcfg.MustNonEmptyString("vlan-phy"),
+				RulesFile: xcfg.MustNonEmptyString("/etc/yanet2/forward.d/vlan-phy-default.yaml"),
+			},
+		},
+	}
+}
+
+func TestConfigValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		build   func() *Config
+		wantErr bool
+	}{
+		{
+			name:    "valid config",
+			build:   validConfig,
+			wantErr: false,
+		},
+		{
+			name: "zero gateways",
+			build: func() *Config {
+				cfg := validConfig()
+				cfg.Gateways = nil
+				return cfg
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero functions",
+			build: func() *Config {
+				cfg := validConfig()
+				cfg.Functions = nil
+				return cfg
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate function name",
+			build: func() *Config {
+				cfg := validConfig()
+				cfg.Functions = append(cfg.Functions, FunctionConfig{
+					Name:      xcfg.MustNonEmptyString("fn:forward-vlan-phy"),
+					Chain:     xcfg.MustNonEmptyString("default"),
+					Weight:    1,
+					Module:    xcfg.MustNonEmptyString("other-module"),
+					RulesFile: xcfg.MustNonEmptyString("/etc/yanet2/forward.d/other.yaml"),
+				})
+				return cfg
+			},
+			wantErr: true,
+		},
+		{
+			name: "duplicate module name",
+			build: func() *Config {
+				cfg := validConfig()
+				cfg.Functions = append(cfg.Functions, FunctionConfig{
+					Name:      xcfg.MustNonEmptyString("fn:forward-other"),
+					Chain:     xcfg.MustNonEmptyString("default"),
+					Weight:    1,
+					Module:    xcfg.MustNonEmptyString("vlan-phy"),
+					RulesFile: xcfg.MustNonEmptyString("/etc/yanet2/forward.d/other.yaml"),
+				})
+				return cfg
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.build().Validate()
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/operators/forward/internal/operator/operator.go
+++ b/operators/forward/internal/operator/operator.go
@@ -1,0 +1,79 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+)
+
+// Operator is the forward operator's thin wrapper around the generic
+// operator framework.
+type Operator struct {
+	cfg *Config
+	app *operator.Operator[State]
+	log *zap.Logger
+}
+
+// NewOperator constructs an Operator from the supplied configuration.
+func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log
+
+	modules := make([]ModuleConfig, 0, len(cfg.Functions))
+	for _, fn := range cfg.Functions {
+		rules, err := LoadForwardRules(fn.RulesFile.Unwrap())
+		if err != nil {
+			return nil, fmt.Errorf("failed to load rules file %q: %w", fn.RulesFile.Unwrap(), err)
+		}
+		modules = append(modules, ModuleConfig{
+			Name:  fn.Module.Unwrap(),
+			Rules: rules,
+		})
+	}
+
+	actuators := make([]operator.Actuator[State], 0, len(cfg.Gateways))
+	for _, gw := range cfg.Gateways {
+		actuator, err := NewGatewayActuator(gw, cfg.Functions, WithGatewayActuatorLog(log))
+		if err != nil {
+			for _, a := range actuators {
+				_ = a.Close()
+			}
+			return nil, fmt.Errorf("failed to construct gateway actuator %q: %w", gw.Name, err)
+		}
+		actuators = append(actuators, actuator)
+	}
+
+	fanOut := operator.NewFanOutActuator(actuators, operator.WithFanOutLog(log))
+	source := NewStaticSource(modules, WithSourceLog(log))
+
+	app := operator.NewOperator(
+		fanOut,
+		source,
+		operator.WithGRPCServer(cfg.Server),
+		operator.WithLog(log),
+		operator.WithReconcile(cfg.Reconcile),
+	)
+
+	return &Operator{
+		cfg: cfg,
+		app: app,
+		log: log,
+	}, nil
+}
+
+// Run drives the operator until the supplied context is cancelled.
+func (m *Operator) Run(ctx context.Context) error {
+	return m.app.Run(ctx)
+}
+
+// Close releases resources owned by the operator.
+func (m *Operator) Close() error {
+	return m.app.Close()
+}

--- a/operators/forward/internal/operator/options.go
+++ b/operators/forward/internal/operator/options.go
@@ -2,6 +2,7 @@ package operator
 
 import "go.uber.org/zap"
 
+// options holds operator-level configuration.
 type options struct {
 	Log *zap.Logger
 }
@@ -12,16 +13,38 @@ func newOptions() *options {
 	}
 }
 
-// Option configures NewGatewayActuator.
+// Option configures NewOperator.
 type Option func(*options)
 
-// WithLog sets the logger for the GatewayActuator.
+// WithLog sets the logger for the Operator and all sub-components.
 func WithLog(log *zap.Logger) Option {
 	return func(o *options) {
 		o.Log = log
 	}
 }
 
+// gatewayActuatorOptions holds configuration for a single GatewayActuator.
+type gatewayActuatorOptions struct {
+	Log *zap.Logger
+}
+
+func newGatewayActuatorOptions() *gatewayActuatorOptions {
+	return &gatewayActuatorOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// GatewayActuatorOption configures NewGatewayActuator.
+type GatewayActuatorOption func(*gatewayActuatorOptions)
+
+// WithGatewayActuatorLog sets the logger for a single gateway actuator.
+func WithGatewayActuatorLog(log *zap.Logger) GatewayActuatorOption {
+	return func(o *gatewayActuatorOptions) {
+		o.Log = log
+	}
+}
+
+// staticSourceOptions holds configuration for the staticSource.
 type staticSourceOptions struct {
 	Log *zap.Logger
 }

--- a/operators/forward/internal/operator/source.go
+++ b/operators/forward/internal/operator/source.go
@@ -7,39 +7,45 @@ import (
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
-// State is the desired payload pushed by each reconcile pass.
-type State struct {
+// ModuleConfig holds the desired rule set for one forward module config.
+type ModuleConfig struct {
+	Name  string
 	Rules []*forwardpb.Rule
 }
 
-// staticSource is a StateSource that holds a fixed set of rules loaded
-// once at construction time. Snapshot always returns the same slice.
-// Wake is never signalled — the reconcile interval is the sole pacing
-// mechanism.
-type staticSource struct {
-	rules []*forwardpb.Rule
-	wake  chan struct{}
-	log   *zap.Logger
+// State is the desired payload pushed by each reconcile pass.
+type State struct {
+	Modules []ModuleConfig
 }
 
-// NewStaticSource constructs a staticSource holding the supplied rules.
-// The rules slice is not copied; callers must not modify it after
+// staticSource is a StateSource that holds a fixed set of module configs
+// loaded once at construction time. Snapshot always returns the same
+// slice. Wake is never signalled — the reconcile interval is the sole
+// pacing mechanism.
+type staticSource struct {
+	modules []ModuleConfig
+	wake    chan struct{}
+	log     *zap.Logger
+}
+
+// NewStaticSource constructs a staticSource holding the supplied module
+// configs. The slice is not copied; callers must not modify it after
 // passing it in.
-func NewStaticSource(rules []*forwardpb.Rule, options ...StaticSourceOption) operator.StateSource[State] {
+func NewStaticSource(modules []ModuleConfig, options ...StaticSourceOption) operator.StateSource[State] {
 	opts := newStaticSourceOptions()
 	for _, o := range options {
 		o(opts)
 	}
 	return &staticSource{
-		rules: rules,
-		wake:  make(chan struct{}),
-		log:   opts.Log,
+		modules: modules,
+		wake:    make(chan struct{}),
+		log:     opts.Log,
 	}
 }
 
-// Snapshot returns the fixed rules as the current desired state.
+// Snapshot returns the fixed module configs as the current desired state.
 func (m *staticSource) Snapshot() (State, bool) {
-	return State{Rules: m.rules}, true
+	return State{Modules: m.modules}, true
 }
 
 // Wake returns the channel the Reconciler monitors for eager wakeups.
@@ -47,5 +53,6 @@ func (m *staticSource) Snapshot() (State, bool) {
 // pacing mechanism.
 func (m *staticSource) Wake() <-chan struct{} { return m.wake }
 
-// Advance is a no-op: the rules are fixed for the lifetime of the source.
+// Advance is a no-op: the module configs are fixed for the lifetime of
+// the source.
 func (m *staticSource) Advance(_ State) {}

--- a/operators/forward/meson.build
+++ b/operators/forward/meson.build
@@ -4,6 +4,11 @@ install_data(
     install_dir: '/etc/yanet2/forward.d',
 )
 
+install_data(
+    'etc/yanet/yanet-forward-operator-default.yaml',
+    install_dir: '/etc/yanet2',
+)
+
 if not get_option('fuzzing').enabled()
   custom_target(
       'yanet-forward-operator',


### PR DESCRIPTION
Replace the flag-driven "one operator = one network function" model with a config-driven forward operator that owns many functions in a single process.

- The binary now takes a YAML config (`-c`) describing its gRPC server, the downstream gateways, and the set of functions it publishes.
- Each function entry maps one forward module config (name + rules file) to a gateway-side function definition, mirroring the route operator config shape.
- The gRPC server is enabled but registers no services yet — a slot for the future readiness service.
- The per-function systemd template `yanet2-forward-operator@.service` is replaced by a single `yanet2-forward-operator.service` unit.
- A default example config is installed to `/etc/yanet2/yanet-forward-operator-default.yaml`.