### PR TITLE
fix(controlplane): return NotFound status from function Get

### DIFF
--- a/controlplane/builtin/function.go
+++ b/controlplane/builtin/function.go
@@ -7,6 +7,8 @@ import (
 	"github.com/c2h5oh/datasize"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/commonpb"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -122,7 +124,7 @@ func (m *Function) Get(
 		}
 	}
 
-	return nil, fmt.Errorf("not found")
+	return nil, status.Error(codes.NotFound, "not found")
 }
 
 // Update updates or inserts a function.


### PR DESCRIPTION
The function service `Get` returned a plain error for a missing function, which gRPC reports as `Unknown`. Operators reconciling a function via `FunctionApplier` only treat `NotFound` as "absent, create it", so they could never create a missing function and looped on reconcile backoff (observed with the forward operator owning its functions).

- Return a proper `NotFound` status from `function.Get`.
- The status message is left unchanged so existing CLI absence detection is unaffected.