### PR TITLE
fix(controlplane): return NotFound status from pipeline Get

### DIFF
--- a/controlplane/builtin/pipeline.go
+++ b/controlplane/builtin/pipeline.go
@@ -7,6 +7,8 @@ import (
 	"github.com/c2h5oh/datasize"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/commonpb"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -108,7 +110,7 @@ func (m *Pipeline) Get(
 		}
 	}
 
-	return nil, fmt.Errorf("not found")
+	return nil, status.Error(codes.NotFound, "not found")
 }
 
 // Update updates or inserts a pipeline.


### PR DESCRIPTION
The pipeline service `Get` returned a plain error for a missing pipeline, which gRPC reports as `Unknown`. Operators reconciling a pipeline only treat `NotFound` as "absent, create it", so they could never create a missing pipeline and would loop on reconcile backoff.

- Return a proper `NotFound` status from `pipeline.Get`, mirroring the function service fix (#968).
- The status message is left unchanged so existing CLI absence detection is unaffected.