### PR TITLE
refactor(cli): detect missing resources by NotFound code

### DIFF
--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -3,7 +3,7 @@
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use commonpb::pb::FunctionId;
-use tonic::{codec::CompressionEncoding, Status};
+use tonic::{codec::CompressionEncoding, Code, Status};
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
     errors::Error,
@@ -136,7 +136,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn map_not_found(status: Status, action: &'static str, endpoint: &str, resource: Option<&str>) -> Error {
-    if status.message().trim().eq_ignore_ascii_case("not found") {
+    if status.code() == Code::NotFound {
         let resource = resource.unwrap_or("requested function");
 
         return Error::from_status(

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -3,7 +3,7 @@
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use commonpb::pb::{FunctionId, PipelineId};
-use tonic::{codec::CompressionEncoding, Status};
+use tonic::{codec::CompressionEncoding, Code, Status};
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
     errors::Error,
@@ -136,7 +136,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn map_not_found(status: Status, action: &'static str, endpoint: &str, resource: Option<&str>) -> Error {
-    if status.message().trim().eq_ignore_ascii_case("not found") {
+    if status.code() == Code::NotFound {
         let resource = resource.unwrap_or("requested pipeline");
 
         return Error::from_status(


### PR DESCRIPTION
The function and pipeline CLIs detected an absent resource by substring-matching the gRPC status message (`eq_ignore_ascii_case("not found")`). Now that both services return a proper `NotFound` status code (#968, #969), check `status.code() == Code::NotFound` instead.

- Stronger, more robust signal than matching the human-readable message text.
- No behavior change for users — the same resource-specific not-found error is produced.