### PR TITLE
Separate memory contexts for counter and ectx engine

### DIFF
--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -11,7 +11,7 @@ module_ectx_free(
 	struct cp_config_gen *cp_config_gen, struct module_ectx *module_ectx
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	struct counter_storage *counter_storage =
 		ADDR_OF(&module_ectx->counter_storage);
@@ -53,7 +53,7 @@ module_ectx_create(
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct dp_config *dp_config = ADDR_OF(&cp_config->dp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	size_t ectx_size = sizeof(struct module_ectx);
 	struct module_ectx *module_ectx =
@@ -100,7 +100,7 @@ module_ectx_create(
 		);
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
-		memory_context,
+		&cp_config->counter_storage_memory_context,
 		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_module->counter_registry
@@ -150,7 +150,7 @@ chain_ectx_free(
 	struct cp_config_gen *cp_config_gen, struct chain_ectx *chain_ectx
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
 		struct module_ectx *module_ectx =
@@ -186,7 +186,7 @@ chain_ectx_create(
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	uint64_t ectx_size =
 		sizeof(struct chain_ectx) +
@@ -219,7 +219,7 @@ chain_ectx_create(
 		);
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
-		memory_context,
+		&cp_config->counter_storage_memory_context,
 		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_chain->counter_registry
@@ -315,7 +315,7 @@ function_ectx_free(
 	struct cp_config_gen *cp_config_gen, struct function_ectx *function_ectx
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
 	if (chains != NULL) {
@@ -356,7 +356,7 @@ function_ectx_create(
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	uint64_t weight_sum = 0;
 	for (uint64_t idx = 0; idx < cp_function->chain_count; ++idx) {
@@ -411,7 +411,7 @@ function_ectx_create(
 		);
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
-		memory_context,
+		&cp_config->counter_storage_memory_context,
 		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_function->counter_registry
@@ -495,7 +495,7 @@ pipeline_ectx_free(
 	struct cp_config_gen *cp_config_gen, struct pipeline_ectx *pipeline_ectx
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
 		struct function_ectx *function_ectx =
@@ -527,7 +527,7 @@ pipeline_ectx_create(
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	size_t ectx_size = sizeof(struct pipeline_ectx) +
 			   sizeof(struct function_ectx *) * cp_pipeline->length;
@@ -556,7 +556,7 @@ pipeline_ectx_create(
 		);
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
-		memory_context,
+		&cp_config->counter_storage_memory_context,
 		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_pipeline->counter_registry
@@ -643,7 +643,7 @@ device_entry_ectx_free(
 	struct device_entry_ectx *device_entry_ectx
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	struct pipeline_ectx **pipelines =
 		ADDR_OF(&device_entry_ectx->pipelines);
@@ -683,7 +683,7 @@ device_entry_ectx_create(
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&new_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	uint64_t weight_sum = 0;
 	for (uint64_t idx = 0; idx < cp_device_entry->pipeline_count; ++idx) {
@@ -782,7 +782,7 @@ device_ectx_free(
 	struct cp_config_gen *cp_config_gen, struct device_ectx *device_ectx
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	struct device_entry_ectx *input =
 		ADDR_OF(&device_ectx->input_pipelines);
@@ -812,7 +812,7 @@ device_ectx_create(
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
 	struct dp_config *dp_config = ADDR_OF(&cp_config->dp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	size_t ectx_size = sizeof(struct device_ectx);
 
@@ -836,7 +836,7 @@ device_ectx_create(
 		);
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
-		memory_context,
+		&cp_config->counter_storage_memory_context,
 		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_device->counter_registry
@@ -919,7 +919,7 @@ config_gen_ectx_free(
 	struct config_gen_ectx *config_gen_ectx
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	for (uint64_t device_idx = 0;
 	     device_idx < config_gen_ectx->device_count;
@@ -960,7 +960,7 @@ link_module_ectx(
 	struct cp_config_gen *cp_config_gen =
 		ADDR_OF(&config_gen_ectx->cp_config_gen);
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	struct cp_module *cp_module = ADDR_OF(&module_ectx->cp_module);
 
@@ -1236,7 +1236,7 @@ config_gen_ectx_create(
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
-	struct memory_context *memory_context = &cp_config->memory_context;
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
 
 	size_t ectx_size = sizeof(struct config_gen_ectx) +
 			   sizeof(struct device_ectx *) *

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -78,6 +78,14 @@ struct cp_config {
 	 */
 	struct memory_context memory_context;
 	/*
+	 * Controlplane memory context used for econtext placement.
+	 */
+	struct memory_context ectx_memory_context;
+	/*
+	 * Controlplane memory context used for counter storage placement.
+	 */
+	struct memory_context counter_storage_memory_context;
+	/*
 	 * Relative porinter to the corresponding dataplane memory zone
 	 * structure.
 	 */

--- a/lib/counters/counters.c
+++ b/lib/counters/counters.c
@@ -233,8 +233,10 @@ counter_storage_allocator_init(
 	struct memory_context *memory_context,
 	uint64_t instance_count
 ) {
-	SET_OFFSET_OF(
-		&counter_storage_allocator->memory_context, memory_context
+	memory_context_init_from(
+		&counter_storage_allocator->memory_context,
+		memory_context,
+		"counter storage pages"
 	);
 	counter_storage_allocator->instance_count = instance_count;
 }
@@ -245,14 +247,7 @@ counter_storage_allocator_fini(struct counter_storage_allocator *self) {
 		return;
 	}
 
-	// Nothing is owned directly here.
-	//
-	// The allocator is a factory: pages it produces are owned by
-	// counter_storage_block objects inside counter_storage_pool and are
-	// freed through counter_storage_free / counter_storage_pool_fini.
-	//
-	// Zero the fields for idempotency.
-	SET_OFFSET_OF(&self->memory_context, NULL);
+	memory_context_fini(&self->memory_context);
 	self->instance_count = 0;
 }
 
@@ -261,7 +256,7 @@ counter_storage_allocator_new_pages(struct counter_storage_allocator *allocator
 ) {
 	struct counter_storage_page *pages =
 		(struct counter_storage_page *)memory_balloc(
-			ADDR_OF(&allocator->memory_context),
+			&allocator->memory_context,
 			sizeof(struct counter_storage_page) *
 				allocator->instance_count
 		);
@@ -279,7 +274,7 @@ counter_storage_allocator_free_pages(
 	struct counter_storage_page *pages
 ) {
 	memory_bfree(
-		ADDR_OF(&allocator->memory_context),
+		&allocator->memory_context,
 		pages,
 		sizeof(struct counter_storage_page) * allocator->instance_count
 	);
@@ -501,6 +496,8 @@ counter_storage_free(struct counter_storage *storage) {
 		struct counter_storage_pool *pool = storage->pools + pool_idx;
 		counter_storage_pool_fini(storage, pool);
 	}
+
+	memory_bfree(memory_context, storage, sizeof(struct counter_storage));
 }
 
 void

--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -74,7 +74,7 @@ struct counter_storage_pool {
 };
 
 struct counter_storage_allocator {
-	struct memory_context *memory_context;
+	struct memory_context memory_context;
 	uint64_t instance_count;
 };
 

--- a/lib/dataplane/config/bootstrap.c
+++ b/lib/dataplane/config/bootstrap.c
@@ -54,6 +54,18 @@ dp_storage_init(
 		&cp_config->memory_context, "cp", &cp_config->block_allocator
 	);
 
+	memory_context_init_from(
+		&cp_config->ectx_memory_context,
+		&cp_config->memory_context,
+		"ectx"
+	);
+
+	memory_context_init_from(
+		&cp_config->counter_storage_memory_context,
+		&cp_config->memory_context,
+		"counter_storage"
+	);
+
 	// FIXME: cp_config bootstrap routine
 	struct cp_agent_registry *cp_agent_registry =
 		(struct cp_agent_registry *)memory_balloc(


### PR DESCRIPTION
The commit introduces separate memory context to allocate
 - econtext data items
 - counter storages
 - counter storage pages

Also some memory leaks were fixed