### PR TITLE
fix(cli): preserve unknown-service errors in not-found mapping

### DIFF
--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -136,7 +136,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn map_not_found(status: Status, action: &'static str, endpoint: &str, resource: Option<&str>) -> Error {
-    if status.code() == Code::NotFound {
+    if status.code() == Code::NotFound && !status.message().contains("unknown service") {
         let resource = resource.unwrap_or("requested function");
 
         return Error::from_status(

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -136,7 +136,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 fn map_not_found(status: Status, action: &'static str, endpoint: &str, resource: Option<&str>) -> Error {
-    if status.code() == Code::NotFound {
+    if status.code() == Code::NotFound && !status.message().contains("unknown service") {
         let resource = resource.unwrap_or("requested pipeline");
 
         return Error::from_status(


### PR DESCRIPTION
Follow-up to #970. Detecting a missing resource purely by `NotFound` code also captured the gateway's `unknown service` `NotFound` (returned when no backend is registered), which `cli/core` classifies as an unregistered-service error with an operator hint. Rewriting every `NotFound` into a resource-specific message hid that case — e.g. `yanet-cli function list` against a gateway with the function service down reported a missing function instead of an unregistered service.

- Exclude messages containing `unknown service` from the resource-not-found rewrite so they pass through to the correct `ServiceUnregistered` classification.
- Addresses the Codex review on #970.