### PR TITLE
fix(xcfg): validate fields inside slice and array elements

### DIFF
--- a/operators/forward/internal/operator/cfg.go
+++ b/operators/forward/internal/operator/cfg.go
@@ -44,6 +44,19 @@ func (m *Config) Validate() error {
 	names := map[string]struct{}{}
 	modules := map[string]struct{}{}
 	for idx, fn := range m.Functions {
+		if fn.Name.Unwrap() == "" {
+			return fmt.Errorf("function at index %d: name is required", idx)
+		}
+		if fn.Chain.Unwrap() == "" {
+			return fmt.Errorf("function at index %d: chain is required", idx)
+		}
+		if fn.Module.Unwrap() == "" {
+			return fmt.Errorf("function at index %d: module is required", idx)
+		}
+		if fn.RulesFile.Unwrap() == "" {
+			return fmt.Errorf("function at index %d: rules_file is required", idx)
+		}
+
 		name := fn.Name.Unwrap()
 		if _, dup := names[name]; dup {
 			return fmt.Errorf("duplicate function name %q at index %d", name, idx)

--- a/operators/forward/internal/operator/cfg_test.go
+++ b/operators/forward/internal/operator/cfg_test.go
@@ -61,6 +61,66 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "function missing name",
+			build: func() *Config {
+				cfg := validConfig()
+				cfg.Functions = []FunctionConfig{
+					{
+						Chain:     xcfg.MustNonEmptyString("default"),
+						Module:    xcfg.MustNonEmptyString("vlan-phy"),
+						RulesFile: xcfg.MustNonEmptyString("/etc/yanet2/forward.d/vlan-phy-default.yaml"),
+					},
+				}
+				return cfg
+			},
+			wantErr: true,
+		},
+		{
+			name: "function missing chain",
+			build: func() *Config {
+				cfg := validConfig()
+				cfg.Functions = []FunctionConfig{
+					{
+						Name:      xcfg.MustNonEmptyString("fn:forward-vlan-phy"),
+						Module:    xcfg.MustNonEmptyString("vlan-phy"),
+						RulesFile: xcfg.MustNonEmptyString("/etc/yanet2/forward.d/vlan-phy-default.yaml"),
+					},
+				}
+				return cfg
+			},
+			wantErr: true,
+		},
+		{
+			name: "function missing module",
+			build: func() *Config {
+				cfg := validConfig()
+				cfg.Functions = []FunctionConfig{
+					{
+						Name:      xcfg.MustNonEmptyString("fn:forward-vlan-phy"),
+						Chain:     xcfg.MustNonEmptyString("default"),
+						RulesFile: xcfg.MustNonEmptyString("/etc/yanet2/forward.d/vlan-phy-default.yaml"),
+					},
+				}
+				return cfg
+			},
+			wantErr: true,
+		},
+		{
+			name: "function missing rules_file",
+			build: func() *Config {
+				cfg := validConfig()
+				cfg.Functions = []FunctionConfig{
+					{
+						Name:   xcfg.MustNonEmptyString("fn:forward-vlan-phy"),
+						Chain:  xcfg.MustNonEmptyString("default"),
+						Module: xcfg.MustNonEmptyString("vlan-phy"),
+					},
+				}
+				return cfg
+			},
+			wantErr: true,
+		},
+		{
 			name: "duplicate function name",
 			build: func() *Config {
 				cfg := validConfig()


### PR DESCRIPTION
The config validation walker only recursed into pointers and structs, so a `NonEmptyString` (or any validatable) inside a slice element was never checked. Its non-empty invariant relies on `Validate()` being invoked for absent fields, so an incomplete slice entry — e.g. a forward operator `functions:` item missing `rules_file` — could pass decoding with an empty value.

- Recurse into slice and array elements in the xcfg validation walker so the invariant is enforced everywhere, with an indexed error path (`items[0].name`).
- This is the root fix; the earlier per-field band-aid in the forward operator config has been dropped.
- Adds xcfg tests for slice-element validation and a forward integration test.