### PR TITLE
fix(xcfg): validate fields inside slice and array elements

### DIFF
--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -93,6 +93,15 @@ func validate(v reflect.Value, path string) error {
 		}
 	}
 
+	// Recurse into slice and array elements.
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		for idx := 0; idx < v.Len(); idx++ {
+			if err := validate(v.Index(idx), fmt.Sprintf("%s[%d]", path, idx)); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/common/go/xcfg/load_test.go
+++ b/common/go/xcfg/load_test.go
@@ -125,6 +125,75 @@ func Test_Load_PreservesDefaults(t *testing.T) {
 	require.Equal(t, "/default/path", cfg.Path.Unwrap())
 }
 
+func Test_Load_SliceElement_MissingField(t *testing.T) {
+	type Item struct {
+		Name NonEmptyString `yaml:"name"`
+	}
+	type Config struct {
+		Items []Item `yaml:"items"`
+	}
+
+	// The first element omits "name" entirely — zero value NonEmptyString must
+	// be caught by the walker.
+	yaml := "items:\n  - {}\n"
+	var cfg Config
+	err := Decode([]byte(yaml), &cfg)
+
+	var pathErr *PathError
+	require.ErrorAs(t, err, &pathErr)
+	require.Equal(t, "items[0].name", pathErr.Path)
+}
+
+func Test_Load_SliceElement_ExplicitEmptyField(t *testing.T) {
+	type Item struct {
+		Name NonEmptyString `yaml:"name"`
+	}
+	type Config struct {
+		Items []Item `yaml:"items"`
+	}
+
+	// An explicit empty string is rejected at UnmarshalYAML; Decode must still
+	// surface an error.
+	yaml := "items:\n  - name: \"\"\n"
+	var cfg Config
+	err := Decode([]byte(yaml), &cfg)
+	require.Error(t, err)
+}
+
+func Test_Load_SliceElement_Valid(t *testing.T) {
+	type Item struct {
+		Name NonEmptyString `yaml:"name"`
+	}
+	type Config struct {
+		Items []Item `yaml:"items"`
+	}
+
+	yaml := "items:\n  - name: alpha\n  - name: beta\n"
+	var cfg Config
+	require.NoError(t, Decode([]byte(yaml), &cfg))
+	require.Equal(t, "alpha", cfg.Items[0].Name.Unwrap())
+	require.Equal(t, "beta", cfg.Items[1].Name.Unwrap())
+}
+
+func Test_Load_SliceElement_SecondElementMissingField(t *testing.T) {
+	type Item struct {
+		Name  NonEmptyString `yaml:"name"`
+		Value NonEmptyString `yaml:"value"`
+	}
+	type Config struct {
+		Items []Item `yaml:"items"`
+	}
+
+	// The second element omits "value" — the walker must catch it.
+	yaml := "items:\n  - name: alpha\n    value: v1\n  - name: beta\n"
+	var cfg Config
+	err := Decode([]byte(yaml), &cfg)
+
+	var pathErr *PathError
+	require.ErrorAs(t, err, &pathErr)
+	require.Equal(t, "items[1].value", pathErr.Path)
+}
+
 func Test_Load_LineErrorUnwrapsFromPathError(t *testing.T) {
 	// Verify that LineError from UnmarshalYAML is accessible via
 	// errors.As through the error chain, even when Decode doesn't

--- a/operators/forward/internal/operator/cfg_test.go
+++ b/operators/forward/internal/operator/cfg_test.go
@@ -9,6 +9,37 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
+// TestDecode_FunctionMissingRequiredField verifies that xcfg.Decode catches a
+// functions entry that omits a required NonEmptyString field, surfacing it as a
+// *xcfg.PathError with a path rooted at the slice element.
+func TestDecode_FunctionMissingRequiredField(t *testing.T) {
+	// Minimal valid YAML except the single functions entry omits rules_file.
+	yaml := `
+logging:
+  level: info
+server:
+  endpoint: "[::1]:50003"
+gateways:
+  - name: numa0
+    endpoint: "[::1]:8080"
+reconcile:
+  interval: 5s
+  initial_backoff: 1s
+  max_backoff: 30s
+functions:
+  - name: fn:forward-vlan-phy
+    chain: default
+    weight: 1
+    module: vlan-phy
+`
+	cfg := DefaultConfig()
+	err := xcfg.Decode([]byte(yaml), cfg)
+
+	var pathErr *xcfg.PathError
+	require.ErrorAs(t, err, &pathErr)
+	require.Contains(t, pathErr.Path, "functions[0]")
+}
+
 func validConfig() *Config {
 	return &Config{
 		Gateways: []operator.GatewayConfig{


### PR DESCRIPTION
The config validation walker only recursed into pointers and structs, so a `NonEmptyString` (or any validatable) inside a slice element was never checked. Its non-empty invariant relies on `Validate()` being invoked for absent fields, so an incomplete slice entry — e.g. a forward operator `functions:` item missing `rules_file` — could pass decoding with an empty value.

- Recurse into slice and array elements in the xcfg validation walker so the invariant is enforced everywhere, with an indexed error path (`items[0].name`).
- This is the root fix; the earlier per-field band-aid in the forward operator config (closed #973) has been dropped.
- Adds xcfg tests for slice-element validation and a forward integration test.

Supersedes #973.