### PR TITLE
feat(forward): per-gateway readiness service

### DIFF
--- a/common/go/operator/observed_actuator.go
+++ b/common/go/operator/observed_actuator.go
@@ -1,0 +1,43 @@
+package operator
+
+import "context"
+
+// ObservedActuator wraps an inner Actuator and invokes a callback with the
+// per-gateway apply outcome after each Apply call.
+//
+// The inner error is returned unchanged so FanOutActuator error joining
+// and reconcile backoff are preserved.
+type ObservedActuator[T any] struct {
+	inner   Actuator[T]
+	id      string
+	observe func(id string, err error)
+}
+
+// NewObservedActuator wraps inner with an observe callback keyed by id.
+//
+// After each Apply, observe is called with the gateway id and the error
+// returned by the inner actuator (nil on success).
+func NewObservedActuator[T any](
+	inner Actuator[T],
+	id string,
+	observe func(string, error),
+) *ObservedActuator[T] {
+	return &ObservedActuator[T]{
+		inner:   inner,
+		id:      id,
+		observe: observe,
+	}
+}
+
+// Apply calls the inner actuator, reports the outcome via the observe
+// callback, and returns the inner error unchanged.
+func (m *ObservedActuator[T]) Apply(ctx context.Context, state T) error {
+	err := m.inner.Apply(ctx, state)
+	m.observe(m.id, err)
+	return err
+}
+
+// Close delegates to the inner actuator.
+func (m *ObservedActuator[T]) Close() error {
+	return m.inner.Close()
+}

--- a/common/go/operator/observed_actuator_test.go
+++ b/common/go/operator/observed_actuator_test.go
@@ -1,0 +1,65 @@
+package operator_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+)
+
+// fakeActuator is an Actuator that returns a fixed error.
+type fakeActuator struct {
+	err error
+}
+
+func (m *fakeActuator) Apply(_ context.Context, _ struct{}) error {
+	return m.err
+}
+
+func (m *fakeActuator) Close() error {
+	return nil
+}
+
+func TestObservedActuator_PropagatesInnerError(t *testing.T) {
+	inner := &fakeActuator{err: errors.New("apply failed")}
+
+	var (
+		observedID  string
+		observedErr error
+	)
+	callback := func(id string, err error) {
+		observedID = id
+		observedErr = err
+	}
+
+	oa := operator.NewObservedActuator(inner, "gw-test", callback)
+	err := oa.Apply(t.Context(), struct{}{})
+
+	require.Error(t, err)
+	assert.Equal(t, inner.err, err, "inner error must be returned unchanged")
+	assert.Equal(t, "gw-test", observedID)
+	assert.Equal(t, inner.err, observedErr)
+}
+
+func TestObservedActuator_NilErrorOnSuccess(t *testing.T) {
+	inner := &fakeActuator{err: nil}
+
+	var callbackErr error
+	oa := operator.NewObservedActuator(inner, "gw-ok", func(_ string, err error) {
+		callbackErr = err
+	})
+
+	err := oa.Apply(t.Context(), struct{}{})
+	require.NoError(t, err)
+	assert.NoError(t, callbackErr)
+}
+
+func TestObservedActuator_Close_DelegatesToInner(t *testing.T) {
+	inner := &fakeActuator{}
+	oa := operator.NewObservedActuator(inner, "gw-close", func(_ string, _ error) {})
+	assert.NoError(t, oa.Close())
+}

--- a/common/go/operator/readiness.go
+++ b/common/go/operator/readiness.go
@@ -1,0 +1,132 @@
+package operator
+
+import (
+	"sync"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/yanet-platform/yanet2/common/readinesspb"
+)
+
+// scopeState holds the mutable readiness state for one gateway scope.
+type scopeState struct {
+	name               string
+	state              readinesspb.State
+	reasons            []*readinesspb.Reason
+	observedAt         time.Time
+	lastTransitionTime time.Time
+}
+
+// Readiness tracks per-gateway readiness state for the forward operator.
+//
+// Each gateway is represented as a named scope. State transitions and
+// observation timestamps are maintained independently per gateway.
+type Readiness struct {
+	mu     sync.Mutex
+	scopes map[string]*scopeState
+}
+
+// NewReadiness creates a Readiness tracker pre-seeded with the supplied
+// gateway IDs, each starting at STATE_UNKNOWN.
+func NewReadiness(gatewayIDs []string) *Readiness {
+	scopes := map[string]*scopeState{}
+	for _, id := range gatewayIDs {
+		scopes[id] = &scopeState{
+			name:  id,
+			state: readinesspb.State_STATE_UNKNOWN,
+		}
+	}
+
+	return &Readiness{scopes: scopes}
+}
+
+// Observe records the outcome of one apply attempt for the named gateway.
+//
+// When err is nil the scope transitions to STATE_READY with no reasons.
+// When err is non-nil the scope transitions to STATE_NOT_READY with an
+// APPLY_FAILED reason carrying the error message. The observed_at timestamp
+// is always updated; last_transition_time is updated only when the state
+// value changes.
+func (m *Readiness) Observe(gatewayID string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.scopes[gatewayID]
+	if !ok {
+		return
+	}
+
+	now := time.Now()
+
+	var (
+		next    readinesspb.State
+		reasons []*readinesspb.Reason
+	)
+
+	if err == nil {
+		next = readinesspb.State_STATE_READY
+	} else {
+		next = readinesspb.State_STATE_NOT_READY
+		reasons = []*readinesspb.Reason{{Code: "APPLY_FAILED", Message: err.Error()}}
+	}
+
+	if s.observedAt.IsZero() || s.state != next {
+		s.lastTransitionTime = now
+	}
+	s.state = next
+	s.reasons = reasons
+	s.observedAt = now
+}
+
+// Drain marks every scope as STATE_NOT_READY with a SHUTTING_DOWN reason.
+//
+// last_transition_time is updated only for scopes that change state.
+func (m *Readiness) Drain() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	for _, s := range m.scopes {
+		if s.state != readinesspb.State_STATE_NOT_READY {
+			s.lastTransitionTime = now
+		}
+		s.state = readinesspb.State_STATE_NOT_READY
+		s.reasons = []*readinesspb.Reason{{Code: "SHUTTING_DOWN"}}
+		s.observedAt = now
+	}
+}
+
+// Ready builds a ReadyResponse for the given request, honoring the scope
+// filter. An empty scopes list in the request returns all known scopes.
+func (m *Readiness) Ready(req *readinesspb.ReadyRequest) *readinesspb.ReadyResponse {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	filter := map[string]struct{}{}
+	for _, name := range req.GetScopes() {
+		filter[name] = struct{}{}
+	}
+
+	var out []*readinesspb.Scope
+	for _, s := range m.scopes {
+		if len(filter) > 0 {
+			if _, ok := filter[s.name]; !ok {
+				continue
+			}
+		}
+
+		scope := &readinesspb.Scope{
+			Name:    s.name,
+			State:   s.state,
+			Reasons: s.reasons,
+		}
+		if !s.observedAt.IsZero() {
+			scope.ObservedAt = timestamppb.New(s.observedAt)
+			scope.LastTransitionTime = timestamppb.New(s.lastTransitionTime)
+		}
+		out = append(out, scope)
+	}
+
+	return &readinesspb.ReadyResponse{Scopes: out}
+}

--- a/common/go/operator/readiness_test.go
+++ b/common/go/operator/readiness_test.go
@@ -1,0 +1,167 @@
+package operator_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/readinesspb"
+)
+
+func TestReadiness_InitialState(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a", "gw-b"})
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+
+	require.Len(t, resp.Scopes, 2)
+	for _, s := range resp.Scopes {
+		assert.Equal(t, readinesspb.State_STATE_UNKNOWN, s.State)
+		assert.Nil(t, s.ObservedAt, "never-observed scope must have nil observed_at")
+		assert.Nil(t, s.LastTransitionTime, "never-observed scope must have nil last_transition_time")
+		assert.Empty(t, s.Reasons)
+	}
+}
+
+func TestReadiness_Transitions(t *testing.T) {
+	applyErr := errors.New("connection refused")
+
+	tests := []struct {
+		name          string
+		observeErr    error
+		wantState     readinesspb.State
+		wantReasonLen int
+	}{
+		{
+			name:          "success -> READY",
+			observeErr:    nil,
+			wantState:     readinesspb.State_STATE_READY,
+			wantReasonLen: 0,
+		},
+		{
+			name:          "failure -> NOT_READY with APPLY_FAILED",
+			observeErr:    applyErr,
+			wantState:     readinesspb.State_STATE_NOT_READY,
+			wantReasonLen: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := operator.NewReadiness([]string{"gw-a"})
+			r.Observe("gw-a", tt.observeErr)
+
+			resp := r.Ready(&readinesspb.ReadyRequest{})
+			require.Len(t, resp.Scopes, 1)
+
+			s := resp.Scopes[0]
+			assert.Equal(t, tt.wantState, s.State)
+			assert.Len(t, s.Reasons, tt.wantReasonLen)
+
+			if tt.observeErr != nil {
+				require.Len(t, s.Reasons, 1)
+				assert.Equal(t, "APPLY_FAILED", s.Reasons[0].Code)
+				assert.Equal(t, applyErr.Error(), s.Reasons[0].Message)
+			}
+
+			assert.NotNil(t, s.ObservedAt)
+			assert.NotNil(t, s.LastTransitionTime)
+		})
+	}
+}
+
+func TestReadiness_LastTransitionTime_OnlyChangesOnStateChange(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a"})
+
+	// First observation: UNKNOWN -> READY.
+	r.Observe("gw-a", nil)
+	resp1 := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp1.Scopes, 1)
+	ltt1 := resp1.Scopes[0].LastTransitionTime.AsTime()
+	obs1 := resp1.Scopes[0].ObservedAt.AsTime()
+
+	// Second observation with same outcome (READY -> READY): ltt must not change.
+	r.Observe("gw-a", nil)
+	resp2 := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp2.Scopes, 1)
+	ltt2 := resp2.Scopes[0].LastTransitionTime.AsTime()
+	obs2 := resp2.Scopes[0].ObservedAt.AsTime()
+
+	assert.Equal(t, ltt1, ltt2, "last_transition_time must not change when state stays READY")
+	// observed_at may or may not advance depending on clock resolution; just
+	// ensure it is not before the first observation.
+	assert.False(t, obs2.Before(obs1))
+
+	// Third observation with failure (READY -> NOT_READY): ltt must change.
+	r.Observe("gw-a", errors.New("boom"))
+	resp3 := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp3.Scopes, 1)
+	ltt3 := resp3.Scopes[0].LastTransitionTime.AsTime()
+
+	assert.True(t, ltt3.Equal(ltt2) || ltt3.After(ltt2),
+		"last_transition_time must advance on READY -> NOT_READY")
+}
+
+func TestReadiness_ScopeFilter(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a", "gw-b", "gw-c"})
+	r.Observe("gw-a", nil)
+	r.Observe("gw-b", errors.New("down"))
+
+	resp := r.Ready(&readinesspb.ReadyRequest{Scopes: []string{"gw-b"}})
+	require.Len(t, resp.Scopes, 1)
+	assert.Equal(t, "gw-b", resp.Scopes[0].Name)
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, resp.Scopes[0].State)
+}
+
+func TestReadiness_ScopeFilter_Empty_ReturnsAll(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a", "gw-b"})
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+	assert.Len(t, resp.Scopes, 2)
+}
+
+func TestReadiness_UnknownGatewayIgnored(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a"})
+	// Observe on an unknown id must not panic.
+	r.Observe("gw-x", nil)
+
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.Scopes, 1)
+	assert.Equal(t, "gw-a", resp.Scopes[0].Name)
+	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, resp.Scopes[0].State)
+}
+
+func TestReadiness_Drain(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a", "gw-b"})
+
+	// Bring gw-a to READY.
+	r.Observe("gw-a", nil)
+
+	r.Drain()
+
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.Scopes, 2)
+	for _, s := range resp.Scopes {
+		assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+		require.Len(t, s.Reasons, 1)
+		assert.Equal(t, "SHUTTING_DOWN", s.Reasons[0].Code)
+		assert.NotNil(t, s.ObservedAt)
+	}
+}
+
+func TestReadiness_Drain_TransitionTimeOnlyOnChange(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a"})
+
+	// Put gw-a in NOT_READY already via a failed observe.
+	r.Observe("gw-a", errors.New("boom"))
+	resp1 := r.Ready(&readinesspb.ReadyRequest{})
+	ltt1 := resp1.Scopes[0].LastTransitionTime.AsTime()
+
+	// Drain: already NOT_READY, so last_transition_time must stay the same.
+	r.Drain()
+	resp2 := r.Ready(&readinesspb.ReadyRequest{})
+	ltt2 := resp2.Scopes[0].LastTransitionTime.AsTime()
+
+	assert.Equal(t, ltt1, ltt2,
+		"draining a scope already in NOT_READY must not update last_transition_time")
+}

--- a/common/readinesspb/meson.build
+++ b/common/readinesspb/meson.build
@@ -9,7 +9,6 @@ readiness_protoc_gen = custom_target(
     'readiness-protoc',
     output: [
         'readiness.pb.go',
-        'readiness_grpc.pb.go',
     ],
     input: readiness_proto_files,
     command: [
@@ -17,7 +16,6 @@ readiness_protoc_gen = custom_target(
         '-I', readiness_proto_dir,
         '-I', root_dir,
         '--go_out=paths=source_relative:' + readiness_proto_dir,
-        '--go-grpc_out=paths=source_relative:' + readiness_proto_dir,
         '@INPUT@',
     ],
     build_by_default: true,

--- a/common/readinesspb/readiness.proto
+++ b/common/readinesspb/readiness.proto
@@ -6,25 +6,10 @@ import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/common/readinesspb;readinesspb";
 
-// ReadinessProbe allows external consumers to query whether a component is
-// ready to serve traffic. The concept is similar to Kubernetes readiness
-// probes: a component that reports NOT_READY should be excluded from the
-// serving path (e.g. removed from a load-balancer pool or withdrawn from BGP
-// announcements) until it becomes READY again.
-//
-// A single component implementing this service may expose multiple independent
-// scopes, each with its own readiness state.
-service ReadinessProbe {
-  // Ready returns the current readiness of all (or requested) scopes.
-  rpc Ready(ReadyRequest) returns (ReadyResponse);
-}
-
 // ReadyRequest selects which scopes to query.
 //
-// A component implementing ReadinessProbe may contain multiple scopes, each
-// representing an independent dimension of readiness. Callers may request a
-// subset of scopes by name; if the list is empty the component returns the
-// state of every known scope.
+// If the scopes list is empty, the component returns the state of every known
+// scope. Otherwise only the named scopes are returned.
 message ReadyRequest {
   // If empty, return state for all known scopes.
   // Otherwise, return only the requested scopes.
@@ -44,6 +29,8 @@ message Scope {
   repeated Reason reasons = 3;
   // Timestamp of the last observation, used for detecting stale answers.
   google.protobuf.Timestamp observed_at = 4;
+  // Timestamp of the last state transition for this scope.
+  google.protobuf.Timestamp last_transition_time = 5;
 }
 
 enum State {

--- a/operators/forward/internal/operator/cfg.go
+++ b/operators/forward/internal/operator/cfg.go
@@ -41,6 +41,14 @@ func (m *Config) Validate() error {
 		return errors.New("at least one function must be configured")
 	}
 
+	gatewayNames := map[string]struct{}{}
+	for idx, gw := range m.Gateways {
+		if _, dup := gatewayNames[gw.Name]; dup {
+			return fmt.Errorf("duplicate gateway name %q at index %d", gw.Name, idx)
+		}
+		gatewayNames[gw.Name] = struct{}{}
+	}
+
 	names := map[string]struct{}{}
 	modules := map[string]struct{}{}
 	for idx, fn := range m.Functions {

--- a/operators/forward/internal/operator/cfg_test.go
+++ b/operators/forward/internal/operator/cfg_test.go
@@ -90,6 +90,18 @@ func TestConfigValidate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "duplicate gateway name",
+			build: func() *Config {
+				cfg := validConfig()
+				cfg.Gateways = append(cfg.Gateways, operator.GatewayConfig{
+					Name:     "numa0",
+					Endpoint: xcfg.MustNonEmptyString("[::1]:8081"),
+				})
+				return cfg
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/operators/forward/internal/operator/operator.go
+++ b/operators/forward/internal/operator/operator.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	operatorpb "github.com/yanet-platform/yanet2/operators/forward/operatorpb/v1"
 )
 
 // Operator is the forward operator's thin wrapper around the generic
@@ -38,6 +40,12 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		})
 	}
 
+	gatewayIDs := make([]string, len(cfg.Gateways))
+	for idx, gw := range cfg.Gateways {
+		gatewayIDs[idx] = gw.Name
+	}
+	tracker := operator.NewReadiness(gatewayIDs)
+
 	actuators := make([]operator.Actuator[State], 0, len(cfg.Gateways))
 	for _, gw := range cfg.Gateways {
 		actuator, err := NewGatewayActuator(gw, cfg.Functions, WithGatewayActuatorLog(log))
@@ -47,16 +55,29 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			}
 			return nil, fmt.Errorf("failed to construct gateway actuator %q: %w", gw.Name, err)
 		}
-		actuators = append(actuators, actuator)
+		observed := operator.NewObservedActuator(actuator, gw.Name, tracker.Observe)
+		actuators = append(actuators, observed)
 	}
 
 	fanOut := operator.NewFanOutActuator(actuators, operator.WithFanOutLog(log))
 	source := NewStaticSource(modules, WithSourceLog(log))
 
+	svc := NewReadinessService(tracker)
+	registrar := func(s *grpc.Server) string {
+		operatorpb.RegisterReadinessServiceServer(s, svc)
+		return operatorpb.ReadinessService_ServiceDesc.ServiceName
+	}
+
 	app := operator.NewOperator(
 		fanOut,
 		source,
-		operator.WithGRPCServer(cfg.Server),
+		operator.WithGRPCServer(cfg.Server, registrar),
+		operator.WithGateways(cfg.Register, cfg.Gateways...),
+		operator.WithWorkers(func(ctx context.Context) error {
+			<-ctx.Done()
+			tracker.Drain()
+			return nil
+		}),
 		operator.WithLog(log),
 		operator.WithReconcile(cfg.Reconcile),
 	)

--- a/operators/forward/internal/operator/readiness_service.go
+++ b/operators/forward/internal/operator/readiness_service.go
@@ -1,0 +1,30 @@
+package operator
+
+import (
+	"context"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/readinesspb"
+	operatorpb "github.com/yanet-platform/yanet2/operators/forward/operatorpb/v1"
+)
+
+// ReadinessService implements operatorpb.ReadinessServiceServer by delegating
+// to a Readiness tracker that records per-gateway apply outcomes.
+type ReadinessService struct {
+	operatorpb.UnimplementedReadinessServiceServer
+
+	tracker *operator.Readiness
+}
+
+// NewReadinessService constructs a ReadinessService backed by tracker.
+func NewReadinessService(tracker *operator.Readiness) *ReadinessService {
+	return &ReadinessService{tracker: tracker}
+}
+
+// Ready returns the current per-gateway readiness state.
+func (m *ReadinessService) Ready(
+	ctx context.Context,
+	req *readinesspb.ReadyRequest,
+) (*readinesspb.ReadyResponse, error) {
+	return m.tracker.Ready(req), nil
+}

--- a/operators/forward/meson.build
+++ b/operators/forward/meson.build
@@ -1,3 +1,5 @@
+subdir('operatorpb')
+
 install_data(
     'etc/yanet/forward.d/vlan-phy-default.yaml',
     'etc/yanet/forward.d/phy-vlan-default.yaml',
@@ -27,6 +29,8 @@ if not get_option('fuzzing').enabled()
           ynpb_gen,
           common_protoc_gen,
           forward_protoc_gen,
+          forward_operator_protoc_gen,
+          readiness_protoc_gen,
       ],
       install: true,
       install_dir: get_option('bindir'),

--- a/operators/forward/operatorpb/meson.build
+++ b/operators/forward/operatorpb/meson.build
@@ -1,0 +1,23 @@
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
+root_dir = meson.project_source_root()
+proto_files = [
+    join_paths(proto_dir, 'readiness.proto'),
+]
+
+protoc_gen = custom_target(
+    'forward-operator-protoc',
+    output: [
+        'readiness.pb.go',
+        'readiness_grpc.pb.go',
+    ],
+    input: proto_files,
+    command: [
+        protoc,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + root_dir,
+        '--go-grpc_out=paths=source_relative:' + root_dir,
+        '@INPUT@',
+    ],
+    build_by_default: true,
+)
+forward_operator_protoc_gen = protoc_gen

--- a/operators/forward/operatorpb/v1/readiness.proto
+++ b/operators/forward/operatorpb/v1/readiness.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package operators.forward.operatorpb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/operators/forward/operatorpb/v1;operatorpb";
+
+import "common/readinesspb/readiness.proto";
+
+// ReadinessService exposes per-gateway readiness of the forward operator.
+service ReadinessService {
+  // Ready returns the current per-gateway readiness state.
+  rpc Ready(readinesspb.ReadyRequest) returns (readinesspb.ReadyResponse);
+}


### PR DESCRIPTION
Expose a `ReadinessService` on the forward operator that reports per-gateway reconcile readiness, so an external announcer can decide BGP announcements (the decision logic stays in the announcer; the operator only reports).

- Each configured gateway is a named scope reporting READY / NOT_READY / UNKNOWN, with the last observation and last-transition timestamps (k8s-condition symmetry).
- A generic `Readiness` tracker and `ObservedActuator` are added to the operator framework; the per-gateway actuator is wrapped so each gateway's apply outcome is recorded without disturbing fan-out error joining or reconcile backoff.
- The service is defined in the operator's own proto package and reuses the `readinesspb` messages; the `ReadinessProbe` service is removed from `readinesspb` so the shared name cannot collide at the gateway router.
- The service is registered with each gateway so it resolves through the gateway. With one operator now owning all forward functions, this registration is unambiguous.
- A SIGTERM drain flips every scope to NOT_READY before shutdown.