### PR TITLE
refactor(cli): extract NotFoundMapper into shared core

### DIFF
--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -9,7 +9,7 @@
 
 use core::fmt::{self, Display, Formatter};
 
-use tonic::Code;
+use tonic::{Code, Status};
 
 use crate::client::ConnectionError;
 
@@ -178,5 +178,86 @@ fn default_hint(kind: ErrorKind) -> Option<String> {
         ),
         ErrorKind::Connection => Some("verify the endpoint is reachable and the gateway is up".to_owned()),
         _ => None,
+    }
+}
+
+/// Maps a gRPC status to a resource-specific not-found error for one service.
+pub struct NotFoundMapper {
+    service: &'static str,
+    default_resource: &'static str,
+}
+
+impl NotFoundMapper {
+    /// Creates a mapper for the given service and default resource label.
+    pub const fn new(service: &'static str, default_resource: &'static str) -> Self {
+        Self { service, default_resource }
+    }
+
+    /// Maps `status` to an [`Error`], rewriting a genuine resource `NotFound`
+    /// into a friendly `"<resource> not found"` message and passing everything
+    /// else (including the gateway's "unknown service" `NotFound`) through
+    /// unchanged.
+    pub fn map(
+        &self,
+        status: Status,
+        action: impl Into<String>,
+        endpoint: impl Into<String>,
+        resource: Option<&str>,
+    ) -> Error {
+        if status.code() == Code::NotFound && !status.message().contains("unknown service") {
+            let resource = resource.unwrap_or(self.default_resource);
+
+            return Error::from_status(
+                Status::not_found(format!("{resource} not found")),
+                action,
+                endpoint,
+                self.service,
+            );
+        }
+
+        Error::from_status(status, action, endpoint, self.service)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use tonic::Status;
+
+    use super::{ErrorKind, NotFoundMapper};
+
+    const MAPPER: NotFoundMapper = NotFoundMapper::new("test.Service", "requested item");
+
+    #[test]
+    fn not_found_resource_is_rewritten() {
+        let status = Status::not_found("some resource missing");
+        let err = MAPPER.map(status, "show item", "http://localhost:50051", Some("item 'x'"));
+
+        assert_eq!(ErrorKind::NotFound, err.kind);
+        assert_eq!("item 'x' not found", err.message);
+    }
+
+    #[test]
+    fn not_found_uses_default_resource_when_none_given() {
+        let status = Status::not_found("some resource missing");
+        let err = MAPPER.map(status, "show item", "http://localhost:50051", None);
+
+        assert_eq!(ErrorKind::NotFound, err.kind);
+        assert_eq!("requested item not found", err.message);
+    }
+
+    #[test]
+    fn unknown_service_not_found_passes_through_as_service_unregistered() {
+        let status = Status::not_found("unknown service test.Service");
+        let err = MAPPER.map(status, "show item", "http://localhost:50051", None);
+
+        assert_eq!(ErrorKind::ServiceUnregistered, err.kind);
+    }
+
+    #[test]
+    fn non_not_found_status_passes_through_unchanged() {
+        let status = Status::unavailable("backend down");
+        let err = MAPPER.map(status, "show item", "http://localhost:50051", None);
+
+        assert_eq!(ErrorKind::Unavailable, err.kind);
     }
 }

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -3,10 +3,10 @@
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use commonpb::pb::FunctionId;
-use tonic::{codec::CompressionEncoding, Code, Status};
+use tonic::{codec::CompressionEncoding, Status};
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
-    errors::Error,
+    errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
 use ynpb::pb::{
@@ -15,6 +15,7 @@ use ynpb::pb::{
 };
 
 const FUNCTION_SERVICE: &str = "ynpb.FunctionService";
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(FUNCTION_SERVICE, "requested function");
 
 /// Function module.
 #[derive(Debug, Clone, Parser)]
@@ -135,21 +136,6 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     Ok(())
 }
 
-fn map_not_found(status: Status, action: &'static str, endpoint: &str, resource: Option<&str>) -> Error {
-    if status.code() == Code::NotFound && !status.message().contains("unknown service") {
-        let resource = resource.unwrap_or("requested function");
-
-        return Error::from_status(
-            Status::not_found(format!("{resource} not found")),
-            action,
-            endpoint.to_owned(),
-            FUNCTION_SERVICE,
-        );
-    }
-
-    Error::from_status(status, action, endpoint.to_owned(), FUNCTION_SERVICE)
-}
-
 pub struct FunctionService {
     client: FunctionServiceClient<LayeredChannel>,
     endpoint: String,
@@ -175,7 +161,7 @@ impl FunctionService {
             .client
             .list(ListFunctionsRequest {})
             .await
-            .map_err(|status| map_not_found(status, "list functions", &self.endpoint, None))?
+            .map_err(|status| NOT_FOUND.map(status, "list functions", &self.endpoint, None))?
             .into_inner();
 
         Ok(response.ids)
@@ -191,7 +177,7 @@ impl FunctionService {
             .get(request)
             .await
             .map_err(|status| {
-                map_not_found(
+                NOT_FOUND.map(
                     status,
                     "show function",
                     &self.endpoint,
@@ -221,7 +207,7 @@ impl FunctionService {
         };
 
         self.client.update(request).await.map_err(|status| {
-            map_not_found(
+            NOT_FOUND.map(
                 status,
                 "update function",
                 &self.endpoint,
@@ -241,7 +227,7 @@ impl FunctionService {
             })
             .await
             .map_err(|status| {
-                map_not_found(
+                NOT_FOUND.map(
                     status,
                     "delete function",
                     &self.endpoint,

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -3,10 +3,10 @@
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use commonpb::pb::{FunctionId, PipelineId};
-use tonic::{codec::CompressionEncoding, Code, Status};
+use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
-    errors::Error,
+    errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
 use ynpb::pb::{
@@ -15,6 +15,7 @@ use ynpb::pb::{
 };
 
 const PIPELINE_SERVICE: &str = "ynpb.PipelineService";
+const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(PIPELINE_SERVICE, "requested pipeline");
 
 /// Pipeline module.
 #[derive(Debug, Clone, Parser)]
@@ -135,21 +136,6 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     Ok(())
 }
 
-fn map_not_found(status: Status, action: &'static str, endpoint: &str, resource: Option<&str>) -> Error {
-    if status.code() == Code::NotFound && !status.message().contains("unknown service") {
-        let resource = resource.unwrap_or("requested pipeline");
-
-        return Error::from_status(
-            Status::not_found(format!("{resource} not found")),
-            action,
-            endpoint.to_owned(),
-            PIPELINE_SERVICE,
-        );
-    }
-
-    Error::from_status(status, action, endpoint.to_owned(), PIPELINE_SERVICE)
-}
-
 pub struct PipelineService {
     client: PipelineServiceClient<LayeredChannel>,
     endpoint: String,
@@ -177,7 +163,7 @@ impl PipelineService {
             .client
             .list(ListPipelinesRequest {})
             .await
-            .map_err(|status| map_not_found(status, self.action, &self.endpoint, Some("pipeline service")))?
+            .map_err(|status| NOT_FOUND.map(status, self.action, &self.endpoint, Some("pipeline service")))?
             .into_inner();
 
         Ok(response.ids)
@@ -191,7 +177,7 @@ impl PipelineService {
             .client
             .get(request)
             .await
-            .map_err(|status| map_not_found(status, self.action, &self.endpoint, Some(&format!("pipeline '{name}'"))))?
+            .map_err(|status| NOT_FOUND.map(status, self.action, &self.endpoint, Some(&format!("pipeline '{name}'"))))?
             .into_inner();
 
         let pipeline = response.pipeline.ok_or_else(|| {
@@ -220,7 +206,7 @@ impl PipelineService {
         };
 
         self.client.update(request).await.map_err(|status| {
-            map_not_found(
+            NOT_FOUND.map(
                 status,
                 self.action,
                 &self.endpoint,
@@ -238,7 +224,7 @@ impl PipelineService {
 
         let name = request.id.as_ref().expect("pipeline id").name.clone();
         self.client.delete(request).await.map_err(|status| {
-            map_not_found(status, self.action, &self.endpoint, Some(&format!("pipeline '{name}'")))
+            NOT_FOUND.map(status, self.action, &self.endpoint, Some(&format!("pipeline '{name}'")))
         })?;
 
         Ok(())


### PR DESCRIPTION
The function and pipeline CLIs each carried a near-identical `map_not_found` helper that differed only by service name and default resource label.

- Add a reusable `NotFoundMapper` to the shared core crate, configured once per CLI via a `const`.
- Replace both local helpers with `NOT_FOUND.map(...)`; behavior is unchanged (including the unknown-service pass-through from #972).
- Add unit tests for the resource rewrite, default-resource fallback, unknown-service pass-through, and non-NotFound pass-through.