### PR TITLE
feat(gateway): report registration status to silence heartbeat logs

### DIFF
--- a/controlplane/gateway/registrar.go
+++ b/controlplane/gateway/registrar.go
@@ -133,6 +133,10 @@ func (m *GatewayRegistrar) RegisterServices(
 		}
 
 		wg.Go(func() error {
+			log := m.log.With(
+				zap.String("service", name),
+				zap.String("gateway", m.endpoint),
+			)
 			retryOpts := []backoff.RetryOption{
 				backoff.WithBackOff(m.backoff()),
 			}
@@ -143,18 +147,20 @@ func (m *GatewayRegistrar) RegisterServices(
 			_, err := backoff.Retry(ctx, func() (*ynpb.RegisterResponse, error) {
 				resp, err := m.client.Register(ctx, request)
 				if err != nil {
-					m.log.Warn("failed to register in gateway",
-						zap.String("service", name),
-						zap.String("gateway", m.endpoint),
-						zap.Error(err),
-					)
+					log.Warn("failed to register in gateway", zap.Error(err))
 					return nil, err
 				}
 
-				m.log.Info("successfully registered in gateway",
-					zap.String("service", name),
-					zap.String("gateway", m.endpoint),
-				)
+				switch resp.GetStatus() {
+				case ynpb.RegistrationStatus_REGISTRATION_STATUS_REGISTERED:
+					log.Info("registered in gateway")
+				case ynpb.RegistrationStatus_REGISTRATION_STATUS_UPDATED:
+					log.Info("updated registration in gateway")
+				case ynpb.RegistrationStatus_REGISTRATION_STATUS_RENEWED:
+					log.Debug("registration renewed in gateway")
+				default:
+					log.Info("registered in gateway")
+				}
 				return resp, nil
 			}, retryOpts...)
 

--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -8,6 +8,15 @@ import (
 	"github.com/siderolabs/grpc-proxy/proxy"
 )
 
+// RegistrationStatus describes how a Register call changed the registry.
+type RegistrationStatus int
+
+const (
+	RegistrationRegistered RegistrationStatus = iota + 1
+	RegistrationRenewed
+	RegistrationUpdated
+)
+
 // BackendRegistry is a registry of backends for Gateway API.
 type BackendRegistry struct {
 	mu       sync.RWMutex
@@ -57,13 +66,27 @@ func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, bool) {
 }
 
 // RegisterBackend registers a backend for the given service.
+//
+// It reports whether the service was newly registered, renewed with the same
+// endpoint, or updated with a new endpoint.
 func (m *BackendRegistry) RegisterBackend(
 	service string,
 	backend proxy.Backend,
 	endpoint string,
-) {
+) RegistrationStatus {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	var status RegistrationStatus
+	existing, ok := m.backends[service]
+	switch {
+	case !ok:
+		status = RegistrationRegistered
+	case existing.endpoint == endpoint:
+		status = RegistrationRenewed
+	default:
+		status = RegistrationUpdated
+	}
 
 	m.backends[service] = BackendEntry{
 		service:    service,
@@ -71,6 +94,8 @@ func (m *BackendRegistry) RegisterBackend(
 		endpoint:   endpoint,
 		lastSeenAt: time.Now().UTC(),
 	}
+
+	return status
 }
 
 // ListBackends returns metadata for all currently registered backends.

--- a/controlplane/gateway/service.go
+++ b/controlplane/gateway/service.go
@@ -19,6 +19,19 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/ynpb"
 )
 
+func registrationStatusToProto(s RegistrationStatus) ynpb.RegistrationStatus {
+	switch s {
+	case RegistrationRegistered:
+		return ynpb.RegistrationStatus_REGISTRATION_STATUS_REGISTERED
+	case RegistrationRenewed:
+		return ynpb.RegistrationStatus_REGISTRATION_STATUS_RENEWED
+	case RegistrationUpdated:
+		return ynpb.RegistrationStatus_REGISTRATION_STATUS_UPDATED
+	default:
+		return ynpb.RegistrationStatus_REGISTRATION_STATUS_UNSPECIFIED
+	}
+}
+
 // GatewayService is the gRPC service for the Gateway API.
 type GatewayService struct {
 	ynpb.UnimplementedGatewayServer
@@ -78,11 +91,11 @@ func (m *GatewayService) Register(
 		)
 	}
 
-	m.log.Info(
-		"registering backend",
+	log := m.log.With(
 		zap.String("name", backendDesc.GetName()),
 		zap.String("endpoint", backendDesc.GetEndpoint()),
 	)
+	log.Debug("registering backend")
 
 	conn, err := grpc.NewClient(
 		"passthrough:target",
@@ -115,11 +128,20 @@ func (m *GatewayService) Register(
 			return outCtx, conn, nil
 		},
 	}
-	m.registry.RegisterBackend(
+	status := m.registry.RegisterBackend(
 		backendDesc.GetName(),
 		backend,
 		backendDesc.GetEndpoint(),
 	)
 
-	return &ynpb.RegisterResponse{}, nil
+	switch status {
+	case RegistrationRegistered:
+		log.Info("registered backend")
+	case RegistrationUpdated:
+		log.Info("updated backend endpoint")
+	default:
+		log.Debug("renewed backend registration")
+	}
+
+	return &ynpb.RegisterResponse{Status: registrationStatusToProto(status)}, nil
 }

--- a/controlplane/ynpb/gateway.proto
+++ b/controlplane/ynpb/gateway.proto
@@ -36,8 +36,22 @@ message RegisteredBackend {
 // ListServicesResponse contains all known services in the registry.
 message ListServicesResponse { repeated RegisteredBackend services = 1; }
 
+// RegistrationStatus describes the outcome of a Register call.
+enum RegistrationStatus {
+  // Default, unused value.
+  REGISTRATION_STATUS_UNSPECIFIED = 0;
+  // Service was not previously known.
+  REGISTRATION_STATUS_REGISTERED = 1;
+  // Service re-registered with an unchanged endpoint.
+  REGISTRATION_STATUS_RENEWED = 2;
+  // Known service registered with a different endpoint.
+  REGISTRATION_STATUS_UPDATED = 3;
+}
+
 // RegisterRequest is the request to register a new module.
 message RegisterRequest { BackendDesc backend = 1; }
 
 // RegisterResponse is the response to the RegisterRequest.
-message RegisterResponse {}
+message RegisterResponse {
+  RegistrationStatus status = 1;
+}


### PR DESCRIPTION
The forward operator re-registers its services in the gateway every 30s, and both the client and the gateway logged at info level on every heartbeat, flooding the journal with identical lines that carried no signal.

The gateway now classifies each registration call against its registry: registered when the service was not previously known, renewed when it re-registers with an unchanged endpoint, and updated when the endpoint changes. The status is returned to the client so both sides can react to it.

- Add a registration status enum and carry it in the register response.
- Classify the call inside the registry under the existing lock.
- Log at info level only on a real transition (registered or updated); steady-state heartbeats drop to debug.
- A gateway restart empties the registry, so the next heartbeat re-registers and logs at info again, preserving the recovery signal.