### PR TITLE
fix(gateway): reuse backend connection across registration renewals

### DIFF
--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -178,9 +178,17 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create loopback backend for built-in services: %w", err)
 	}
-	registry.RegisterBackend("ynpb.Gateway", loopback, cfg.Server.Endpoint)
+	if _, err := registry.RegisterBackend("ynpb.Gateway", cfg.Server.Endpoint, func() (proxy.Backend, *grpc.ClientConn, error) {
+		return loopback, nil, nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register built-in gateway service: %w", err)
+	}
 	log.Debug("registered built-in service in registry", zap.String("service", "ynpb.Gateway"))
-	registry.RegisterBackend("ynpb.Auth", loopback, cfg.Server.Endpoint)
+	if _, err := registry.RegisterBackend("ynpb.Auth", cfg.Server.Endpoint, func() (proxy.Backend, *grpc.ClientConn, error) {
+		return loopback, nil, nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register built-in auth service: %w", err)
+	}
 	log.Debug("registered built-in service in registry", zap.String("service", "ynpb.Auth"))
 
 	var allServices []Service
@@ -198,7 +206,12 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 				return nil, fmt.Errorf("failed to create loopback backend for service %q: %w", service.Name(), err)
 			}
 			for _, name := range service.ServicesNames() {
-				registry.RegisterBackend(name, inprocBackend, cfg.Server.Endpoint)
+				captured := inprocBackend
+				if _, err := registry.RegisterBackend(name, cfg.Server.Endpoint, func() (proxy.Backend, *grpc.ClientConn, error) {
+					return captured, nil, nil
+				}); err != nil {
+					return nil, fmt.Errorf("failed to register in-process service %q: %w", name, err)
+				}
 				log.Debug("registered in-process service in registry", zap.String("service", name))
 			}
 		} else {

--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/siderolabs/grpc-proxy/proxy"
+	"google.golang.org/grpc"
 )
 
 // RegistrationStatus describes how a Register call changed the registry.
@@ -27,6 +28,7 @@ type BackendRegistry struct {
 type BackendEntry struct {
 	service    string
 	backend    proxy.Backend
+	conn       *grpc.ClientConn
 	endpoint   string
 	lastSeenAt time.Time
 }
@@ -65,37 +67,50 @@ func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, bool) {
 	return backend, ok
 }
 
-// RegisterBackend registers a backend for the given service.
+// RegisterBackend registers or refreshes the backend for the given service.
 //
-// It reports whether the service was newly registered, renewed with the same
-// endpoint, or updated with a new endpoint.
+// dial is invoked, under the registry lock, only when a connection must be
+// established: for a newly registered service or an endpoint change. On an
+// unchanged endpoint the existing connection is reused and only the last-seen
+// time is refreshed; when the endpoint changes the previous connection is
+// closed.
 func (m *BackendRegistry) RegisterBackend(
 	service string,
-	backend proxy.Backend,
 	endpoint string,
-) RegistrationStatus {
+	dial func() (proxy.Backend, *grpc.ClientConn, error),
+) (RegistrationStatus, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var status RegistrationStatus
+	now := time.Now().UTC()
 	existing, ok := m.backends[service]
-	switch {
-	case !ok:
-		status = RegistrationRegistered
-	case existing.endpoint == endpoint:
-		status = RegistrationRenewed
-	default:
+	if ok && existing.endpoint == endpoint {
+		existing.lastSeenAt = now
+		m.backends[service] = existing
+		return RegistrationRenewed, nil
+	}
+
+	backend, conn, err := dial()
+	if err != nil {
+		return 0, err
+	}
+
+	status := RegistrationRegistered
+	if ok {
 		status = RegistrationUpdated
+		if existing.conn != nil {
+			_ = existing.conn.Close()
+		}
 	}
 
 	m.backends[service] = BackendEntry{
 		service:    service,
 		backend:    backend,
+		conn:       conn,
 		endpoint:   endpoint,
-		lastSeenAt: time.Now().UTC(),
+		lastSeenAt: now,
 	}
-
-	return status
+	return status, nil
 }
 
 // ListBackends returns metadata for all currently registered backends.

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -1,0 +1,106 @@
+package gateway
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/siderolabs/grpc-proxy/proxy"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	testSvc = "test.Service"
+	testEp1 = "127.0.0.1:1234"
+	testEp2 = "127.0.0.1:5678"
+)
+
+// newTestConn returns a real *grpc.ClientConn suitable for use as a tracked
+// prior connection in registry tests. grpc.NewClient performs no I/O until
+// the first RPC, so no real server is needed.
+func newTestConn(t *testing.T) *grpc.ClientConn {
+	t.Helper()
+	conn, err := grpc.NewClient("passthrough:fake",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	return conn
+}
+
+// simpleDial returns a dial function that succeeds, counts calls, and returns
+// a proxy.SingleBackend with a nil conn (no I/O needed for these tests).
+func simpleDial(calls *int32) func() (proxy.Backend, *grpc.ClientConn, error) {
+	return func() (proxy.Backend, *grpc.ClientConn, error) {
+		atomic.AddInt32(calls, 1)
+		return &proxy.SingleBackend{}, nil, nil
+	}
+}
+
+func TestBackendRegistry_RegisterBackend_firstRegistration(t *testing.T) {
+	t.Parallel()
+
+	var calls int32
+	reg := NewBackendRegistry()
+
+	status, err := reg.RegisterBackend(testSvc, testEp1, simpleDial(&calls))
+	require.NoError(t, err)
+	require.Equal(t, RegistrationRegistered, status)
+	require.EqualValues(t, 1, atomic.LoadInt32(&calls), "dial must be called exactly once on first registration")
+}
+
+func TestBackendRegistry_RegisterBackend_sameEndpointRenewal(t *testing.T) {
+	t.Parallel()
+
+	var calls int32
+	reg := NewBackendRegistry()
+
+	_, err := reg.RegisterBackend(testSvc, testEp1, simpleDial(&calls))
+	require.NoError(t, err)
+
+	// Re-register at the same endpoint; dial must not be called again.
+	status, err := reg.RegisterBackend(testSvc, testEp1, func() (proxy.Backend, *grpc.ClientConn, error) {
+		t.Fatal("dial must not be called on same-endpoint renewal")
+		return nil, nil, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, RegistrationRenewed, status)
+	require.EqualValues(t, 1, atomic.LoadInt32(&calls), "dial count must not increase on renewal")
+}
+
+func TestBackendRegistry_RegisterBackend_endpointChange(t *testing.T) {
+	t.Parallel()
+
+	reg := NewBackendRegistry()
+
+	// Prime with ep1, injecting a real conn we can inspect after the update.
+	prior := newTestConn(t)
+	_, err := reg.RegisterBackend(testSvc, testEp1, func() (proxy.Backend, *grpc.ClientConn, error) {
+		return &proxy.SingleBackend{}, prior, nil
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, connectivity.Shutdown, prior.GetState(), "conn must be open before endpoint change")
+
+	// Update to ep2; registry must close the prior conn.
+	var calls int32
+	status, err := reg.RegisterBackend(testSvc, testEp2, simpleDial(&calls))
+	require.NoError(t, err)
+	require.Equal(t, RegistrationUpdated, status)
+	require.EqualValues(t, 1, atomic.LoadInt32(&calls))
+	require.Equal(t, connectivity.Shutdown, prior.GetState(), "prior conn must be closed after endpoint change")
+}
+
+func TestBackendRegistry_RegisterBackend_dialFailure(t *testing.T) {
+	t.Parallel()
+
+	reg := NewBackendRegistry()
+	_, err := reg.RegisterBackend(testSvc, testEp1, func() (proxy.Backend, *grpc.ClientConn, error) {
+		return nil, nil, errors.New("dial failed")
+	})
+	require.Error(t, err)
+
+	_, ok := reg.GetBackend(testSvc)
+	require.False(t, ok, "failed dial must not leave an entry in the registry")
+}

--- a/controlplane/gateway/service.go
+++ b/controlplane/gateway/service.go
@@ -97,42 +97,45 @@ func (m *GatewayService) Register(
 	)
 	log.Debug("registering backend")
 
-	conn, err := grpc.NewClient(
-		"passthrough:target",
-		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			dialer := net.Dialer{}
-			endpoint := backendDesc.GetEndpoint()
-			if strings.HasPrefix(endpoint, "/") {
-				return dialer.DialContext(ctx, "unix", endpoint)
-			}
+	status, err := m.registry.RegisterBackend(
+		backendDesc.GetName(),
+		backendDesc.GetEndpoint(),
+		func() (proxy.Backend, *grpc.ClientConn, error) {
+			conn, err := grpc.NewClient(
+				"passthrough:target",
+				grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+					dialer := net.Dialer{}
+					endpoint := backendDesc.GetEndpoint()
+					if strings.HasPrefix(endpoint, "/") {
+						return dialer.DialContext(ctx, "unix", endpoint)
+					}
 
-			return dialer.DialContext(ctx, "tcp", endpoint)
-		}),
-		grpc.WithDefaultCallOptions(
-			grpc.ForceCodecV2(proxy.Codec()),
-			grpc.UseCompressor(gzip.Name),
-			grpc.MaxCallRecvMsgSize(1024*1024*256),
-			grpc.MaxCallSendMsgSize(1024*1024*256),
-		),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+					return dialer.DialContext(ctx, "tcp", endpoint)
+				}),
+				grpc.WithDefaultCallOptions(
+					grpc.ForceCodecV2(proxy.Codec()),
+					grpc.UseCompressor(gzip.Name),
+					grpc.MaxCallRecvMsgSize(1024*1024*256),
+					grpc.MaxCallSendMsgSize(1024*1024*256),
+				),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if err != nil {
+				return nil, nil, fmt.Errorf("failed to create gRPC client to backend: %w", err)
+			}
+			backend := &proxy.SingleBackend{
+				GetConn: func(ctx context.Context) (context.Context, *grpc.ClientConn, error) {
+					md, _ := metadata.FromIncomingContext(ctx)
+					outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
+					return outCtx, conn, nil
+				},
+			}
+			return backend, conn, nil
+		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create gRPC client to backend: %w", err)
+		return nil, err
 	}
-
-	backend := &proxy.SingleBackend{
-		GetConn: func(ctx context.Context) (context.Context, *grpc.ClientConn, error) {
-			md, _ := metadata.FromIncomingContext(ctx)
-			outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
-
-			return outCtx, conn, nil
-		},
-	}
-	status := m.registry.RegisterBackend(
-		backendDesc.GetName(),
-		backend,
-		backendDesc.GetEndpoint(),
-	)
 
 	switch status {
 	case RegistrationRegistered:


### PR DESCRIPTION
- The gateway dialed a new backend connection on every Register call, including each periodic re-registration heartbeat, and never closed the previous one, leaking connections and goroutines over time.
- The registry now owns the connection lifecycle: it dials only when a service is newly registered or registers with a changed endpoint, reuses the existing connection on an unchanged-endpoint renewal, and closes the previous connection when the endpoint changes.
- Built-in and in-process backends register with no owned connection, so the registry leaves them untouched on replacement.
- Added registry tests covering first registration, same-endpoint renewal (no redial), endpoint change (redial and prior-connection shutdown), and dial failure.