### PR TITLE
fix(gateway): close backend connections on replace and shutdown

### DIFF
--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -174,13 +174,14 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	log.Info("registered service", zap.String("service", fmt.Sprintf("%T", authService)))
 
 	// Register Gateway and Auth as loopback backends for HTTP proxy access.
-	loopback, err := newLoopbackBackend(cfg.Server.Endpoint, cfg.Server.TLS)
+	loopback, loopbackGRPCConn, err := newLoopbackBackend(cfg.Server.Endpoint, cfg.Server.TLS)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create loopback backend for built-in services: %w", err)
 	}
-	registry.RegisterBackend("ynpb.Gateway", loopback, cfg.Server.Endpoint)
+	builtinConn := newBackendConn(cfg.Server.Endpoint, loopbackGRPCConn)
+	registry.RegisterBackend("ynpb.Gateway", loopback, builtinConn)
 	log.Debug("registered built-in service in registry", zap.String("service", "ynpb.Gateway"))
-	registry.RegisterBackend("ynpb.Auth", loopback, cfg.Server.Endpoint)
+	registry.RegisterBackend("ynpb.Auth", loopback, builtinConn)
 	log.Debug("registered built-in service in registry", zap.String("service", "ynpb.Auth"))
 
 	var allServices []Service
@@ -193,12 +194,13 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 			log.Info("registered in-process service", zap.String("service", service.Name()))
 
 			// Share one loopback backend across all service names for this service.
-			inprocBackend, err := newLoopbackBackend(cfg.Server.Endpoint, cfg.Server.TLS)
+			inprocBackend, inprocGRPCConn, err := newLoopbackBackend(cfg.Server.Endpoint, cfg.Server.TLS)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create loopback backend for service %q: %w", service.Name(), err)
 			}
+			inprocConn := newBackendConn(cfg.Server.Endpoint, inprocGRPCConn)
 			for _, name := range service.ServicesNames() {
-				registry.RegisterBackend(name, inprocBackend, cfg.Server.Endpoint)
+				registry.RegisterBackend(name, inprocBackend, inprocConn)
 				log.Debug("registered in-process service in registry", zap.String("service", name))
 			}
 		} else {
@@ -220,11 +222,12 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 }
 
 // newLoopbackBackend creates a gRPC proxy backend that dials back to the
-// gateway's own listener.
-func newLoopbackBackend(endpoint string, tlsCfg *TLSConfig) (proxy.Backend, error) {
+// gateway's own listener, and returns the underlying connection so the caller
+// can wrap it in a backendConn for registry tracking.
+func newLoopbackBackend(endpoint string, tlsCfg *TLSConfig) (proxy.Backend, *grpc.ClientConn, error) {
 	creds, err := TransportCredentials(tlsCfg, endpoint)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build loopback TLS credentials: %w", err)
+		return nil, nil, fmt.Errorf("failed to build loopback TLS credentials: %w", err)
 	}
 
 	conn, err := grpc.NewClient(
@@ -240,16 +243,17 @@ func newLoopbackBackend(endpoint string, tlsCfg *TLSConfig) (proxy.Backend, erro
 		grpc.WithTransportCredentials(creds),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create loopback gRPC client: %w", err)
+		return nil, nil, fmt.Errorf("failed to create loopback gRPC client: %w", err)
 	}
 
-	return &proxy.SingleBackend{
+	backend := &proxy.SingleBackend{
 		GetConn: func(ctx context.Context) (context.Context, *grpc.ClientConn, error) {
 			md, _ := metadata.FromIncomingContext(ctx)
 			outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
 			return outCtx, conn, nil
 		},
-	}, nil
+	}
+	return backend, conn, nil
 }
 
 // Close closes the gateway API.
@@ -265,6 +269,10 @@ func (m *Gateway) Close() error {
 				zap.Error(err),
 			)
 		}
+	}
+
+	if err := m.registry.Close(); err != nil {
+		m.log.Warn("failed to close backend registry", zap.Error(err))
 	}
 
 	return nil

--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"errors"
 	"sort"
 	"sync"
 	"time"
@@ -17,6 +18,15 @@ const (
 	RegistrationUpdated
 )
 
+// Conn is a backend connection tracked by the registry.
+//
+// Target identifies the backend endpoint for change detection; Close releases
+// the connection.
+type Conn interface {
+	Target() string
+	Close() error
+}
+
 // BackendRegistry is a registry of backends for Gateway API.
 type BackendRegistry struct {
 	mu       sync.RWMutex
@@ -27,7 +37,7 @@ type BackendRegistry struct {
 type BackendEntry struct {
 	service    string
 	backend    proxy.Backend
-	endpoint   string
+	conn       Conn
 	lastSeenAt time.Time
 }
 
@@ -38,7 +48,7 @@ func (m *BackendEntry) Service() string {
 
 // Endpoint returns the endpoint of the entry.
 func (m *BackendEntry) Endpoint() string {
-	return m.endpoint
+	return m.conn.Target()
 }
 
 // LastSeenAt returns the time the entry was last registered.
@@ -65,37 +75,59 @@ func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, bool) {
 	return backend, ok
 }
 
-// RegisterBackend registers a backend for the given service.
+// RegisterBackend registers a backend connection for the given service.
 //
-// It reports whether the service was newly registered, renewed with the same
-// endpoint, or updated with a new endpoint.
+// On a same-target re-registration the new conn is closed and the existing
+// entry is retained. On an endpoint change the previous conn is closed and the
+// new entry replaces it. The obsolete connection is closed after the lock is
+// released.
 func (m *BackendRegistry) RegisterBackend(
 	service string,
 	backend proxy.Backend,
-	endpoint string,
+	conn Conn,
 ) RegistrationStatus {
+	status, obsolete := m.registerBackend(service, backend, conn)
+	if obsolete != nil {
+		_ = obsolete.Close()
+	}
+	return status
+}
+
+func (m *BackendRegistry) registerBackend(
+	service string,
+	backend proxy.Backend,
+	conn Conn,
+) (RegistrationStatus, Conn) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var status RegistrationStatus
+	now := time.Now().UTC()
 	existing, ok := m.backends[service]
 	switch {
-	case !ok:
-		status = RegistrationRegistered
-	case existing.endpoint == endpoint:
-		status = RegistrationRenewed
+	case ok && existing.conn.Target() == conn.Target():
+		existing.lastSeenAt = now
+		m.backends[service] = existing
+		return RegistrationRenewed, conn
+	case ok:
+		m.backends[service] = BackendEntry{service: service, backend: backend, conn: conn, lastSeenAt: now}
+		return RegistrationUpdated, existing.conn
 	default:
-		status = RegistrationUpdated
+		m.backends[service] = BackendEntry{service: service, backend: backend, conn: conn, lastSeenAt: now}
+		return RegistrationRegistered, nil
 	}
+}
 
-	m.backends[service] = BackendEntry{
-		service:    service,
-		backend:    backend,
-		endpoint:   endpoint,
-		lastSeenAt: time.Now().UTC(),
+// Close closes all tracked backend connections and clears the registry.
+func (m *BackendRegistry) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var err error
+	for _, entry := range m.backends {
+		err = errors.Join(err, entry.conn.Close())
 	}
-
-	return status
+	m.backends = map[string]BackendEntry{}
+	return err
 }
 
 // ListBackends returns metadata for all currently registered backends.

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -1,0 +1,125 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/siderolabs/grpc-proxy/proxy"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeConn is a test double for the Conn interface.
+type fakeConn struct {
+	target string
+	closed bool
+}
+
+func (m *fakeConn) Target() string { return m.target }
+func (m *fakeConn) Close() error {
+	m.closed = true
+	return nil
+}
+
+// noopBackend is a proxy.Backend that does nothing, used where the backend
+// value is stored by the registry but never invoked.
+var noopBackend proxy.Backend
+
+func TestBackendRegistry_FirstRegistration(t *testing.T) {
+	reg := NewBackendRegistry()
+	conn := &fakeConn{target: "127.0.0.1:9000"}
+
+	status := reg.RegisterBackend("svc.Foo", noopBackend, conn)
+
+	require.Equal(t, RegistrationRegistered, status)
+	require.False(t, conn.closed)
+
+	entry, ok := reg.backends["svc.Foo"]
+	require.True(t, ok)
+	require.Equal(t, "127.0.0.1:9000", entry.Endpoint())
+}
+
+func TestBackendRegistry_SameTargetRenews(t *testing.T) {
+	reg := NewBackendRegistry()
+	original := &fakeConn{target: "127.0.0.1:9000"}
+
+	reg.RegisterBackend("svc.Foo", noopBackend, original)
+
+	// Re-register with a different conn object but the same target.
+	second := &fakeConn{target: "127.0.0.1:9000"}
+
+	status := reg.RegisterBackend("svc.Foo", noopBackend, second)
+
+	require.Equal(t, RegistrationRenewed, status)
+
+	// The redundant new conn must be closed.
+	require.True(t, second.closed, "redundant conn should be closed")
+
+	// The original conn must still be open and retained.
+	require.False(t, original.closed, "original conn must remain open")
+
+	entry, ok := reg.backends["svc.Foo"]
+	require.True(t, ok)
+	// Stored entry still points at the original conn.
+	require.Equal(t, original, entry.conn)
+}
+
+func TestBackendRegistry_DifferentTargetUpdates(t *testing.T) {
+	reg := NewBackendRegistry()
+	prev := &fakeConn{target: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", noopBackend, prev)
+
+	next := &fakeConn{target: "127.0.0.1:9001"}
+
+	status := reg.RegisterBackend("svc.Foo", noopBackend, next)
+
+	require.Equal(t, RegistrationUpdated, status)
+
+	// The previous conn must be closed.
+	require.True(t, prev.closed, "previous conn should be closed")
+
+	// The new conn must be open.
+	require.False(t, next.closed, "new conn must remain open")
+
+	entry, ok := reg.backends["svc.Foo"]
+	require.True(t, ok)
+	require.Equal(t, next, entry.conn)
+	require.Equal(t, "127.0.0.1:9001", entry.Endpoint())
+}
+
+func TestBackendRegistry_Close(t *testing.T) {
+	reg := NewBackendRegistry()
+	connA := &fakeConn{target: "127.0.0.1:9000"}
+	connB := &fakeConn{target: "127.0.0.1:9001"}
+
+	reg.RegisterBackend("svc.A", noopBackend, connA)
+	reg.RegisterBackend("svc.B", noopBackend, connB)
+
+	err := reg.Close()
+	require.NoError(t, err)
+
+	require.True(t, connA.closed, "connA should be closed")
+	require.True(t, connB.closed, "connB should be closed")
+
+	// Registry must be empty after Close.
+	require.Empty(t, reg.backends)
+}
+
+func TestBackendRegistry_ConcurrentRace(t *testing.T) {
+	reg := NewBackendRegistry()
+
+	const goroutines = 20
+	done := make(chan struct{})
+	for idx := 0; idx < goroutines; idx++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			conn := &fakeConn{target: "127.0.0.1:9000"}
+			reg.RegisterBackend("svc.Race", noopBackend, conn)
+			reg.GetBackend("svc.Race")
+			reg.ListBackends()
+		}()
+	}
+	for idx := 0; idx < goroutines; idx++ {
+		<-done
+	}
+
+	_ = reg.Close()
+}

--- a/controlplane/gateway/service.go
+++ b/controlplane/gateway/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"go.uber.org/zap"
@@ -30,6 +31,30 @@ func registrationStatusToProto(s RegistrationStatus) ynpb.RegistrationStatus {
 	default:
 		return ynpb.RegistrationStatus_REGISTRATION_STATUS_UNSPECIFIED
 	}
+}
+
+// backendConn adapts a backend's *grpc.ClientConn to the registry Conn
+// interface, reporting the real backend endpoint rather than the dial target.
+//
+// Close is idempotent: a single connection may back several registry entries
+// (e.g. the loopback connection shared across built-in service names), so the
+// registry's shutdown sweep can call Close more than once.
+type backendConn struct {
+	endpoint  string
+	conn      *grpc.ClientConn
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func newBackendConn(endpoint string, conn *grpc.ClientConn) *backendConn {
+	return &backendConn{endpoint: endpoint, conn: conn}
+}
+
+func (m *backendConn) Target() string { return m.endpoint }
+
+func (m *backendConn) Close() error {
+	m.closeOnce.Do(func() { m.closeErr = m.conn.Close() })
+	return m.closeErr
 }
 
 // GatewayService is the gRPC service for the Gateway API.
@@ -131,7 +156,7 @@ func (m *GatewayService) Register(
 	status := m.registry.RegisterBackend(
 		backendDesc.GetName(),
 		backend,
-		backendDesc.GetEndpoint(),
+		newBackendConn(backendDesc.GetEndpoint(), conn),
 	)
 
 	switch status {


### PR DESCRIPTION
- The gateway dialed a new backend connection on every Register call, including each 30s re-registration heartbeat, and overwrote the registry entry without closing the previous connection, leaking connections (and their resolver/balancer goroutines) over time. gRPC has no automatic cleanup for an orphaned ClientConn.
- The registry now tracks connections behind a small Conn interface and owns their lifecycle: an unchanged-endpoint re-registration keeps the existing connection (in-flight requests undisturbed) and closes the redundant new one, an endpoint change closes the superseded connection, and graceful shutdown closes all of them.
- Built-in and in-process backends register a no-op Conn, so the registry treats them uniformly without owning a closable connection.
- Added registry tests covering first registration, same-endpoint renewal, endpoint change, and shutdown close.