### PR TITLE
fix(gateway): emit a single gateway log key during registration

### DIFF
--- a/controlplane/gateway/registrar.go
+++ b/controlplane/gateway/registrar.go
@@ -133,10 +133,7 @@ func (m *GatewayRegistrar) RegisterServices(
 		}
 
 		wg.Go(func() error {
-			log := m.log.With(
-				zap.String("service", name),
-				zap.String("gateway", m.endpoint),
-			)
+			log := m.log.With(zap.String("service", name))
 			retryOpts := []backoff.RetryOption{
 				backoff.WithBackOff(m.backoff()),
 			}

--- a/controlplane/gateway/registration_loop.go
+++ b/controlplane/gateway/registration_loop.go
@@ -64,10 +64,7 @@ func NewRegistrationLoop(
 		o(opts)
 	}
 
-	log := opts.Log.With(
-		zap.String("gateway", registrar.Endpoint()),
-		zap.Strings("services", services),
-	)
+	log := opts.Log.With(zap.Strings("services", services))
 
 	return &RegistrationLoop{
 		registrar:       registrar,

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -125,7 +125,7 @@ func (m *ServiceRunner) register(ctx context.Context, addr net.Addr) error {
 	registrar, err := NewGatewayRegistrar(
 		m.gatewayEndpoint,
 		m.gatewayTLS,
-		WithRegistrarLog(m.log),
+		WithRegistrarLog(m.log.With(zap.String("gateway", m.gatewayEndpoint))),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize gateway registrar: %w", err)


### PR DESCRIPTION
- Operator gateway-registration logs carried the gateway field twice — once from the operator's per-gateway logger (the gateway name) and again from the registrar and the registration loop (the endpoint) — producing duplicate gateway keys on every line.
- The gateway identity is now owned solely by the caller's logger. The registrar's per-service logger and the registration loop no longer add their own gateway field, and the module runner injects it once for its own registration path (which has no caller-supplied gateway field).
- Each log line now carries exactly one gateway key; the operator path still reports the endpoint separately as gateway_endpoint.