### PR TITLE
refactor(gateway): own backend connections in the registry

### DIFF
--- a/controlplane/gateway/backend.go
+++ b/controlplane/gateway/backend.go
@@ -1,0 +1,90 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/siderolabs/grpc-proxy/proxy"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/metadata"
+)
+
+// backend is a live proxying connection to a registered upstream: the gRPC
+// connection plus the endpoint the registry tracks it by.
+type backend struct {
+	endpoint  string
+	conn      *grpc.ClientConn
+	closeOnce sync.Once
+	closeErr  error
+}
+
+// dialBackend creates a backend that proxies to endpoint.
+func dialBackend(endpoint string, creds credentials.TransportCredentials) (*backend, error) {
+	conn, err := grpc.NewClient(
+		"passthrough:target",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			dialer := net.Dialer{}
+			if strings.HasPrefix(endpoint, "/") {
+				return dialer.DialContext(ctx, "unix", endpoint)
+			}
+			return dialer.DialContext(ctx, "tcp", endpoint)
+		}),
+		grpc.WithDefaultCallOptions(
+			grpc.ForceCodecV2(proxy.Codec()),
+			grpc.UseCompressor(gzip.Name),
+			grpc.MaxCallRecvMsgSize(int(256*datasize.MB)),
+			grpc.MaxCallSendMsgSize(int(256*datasize.MB)),
+		),
+		grpc.WithTransportCredentials(creds),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gRPC client to backend: %w", err)
+	}
+
+	return &backend{endpoint: endpoint, conn: conn}, nil
+}
+
+// String returns the endpoint for logging.
+func (m *backend) String() string {
+	return m.Endpoint()
+}
+
+// Endpoint returns the endpoint address this backend connects to.
+func (m *backend) Endpoint() string {
+	return m.endpoint
+}
+
+// GetConnection returns the underlying gRPC connection, forwarding incoming
+// metadata as outgoing metadata.
+func (m *backend) GetConnection(ctx context.Context, _ string) (context.Context, *grpc.ClientConn, error) {
+	md, _ := metadata.FromIncomingContext(ctx)
+	return metadata.NewOutgoingContext(ctx, md.Copy()), m.conn, nil
+}
+
+// AppendInfo passes the response bytes through unchanged.
+func (m *backend) AppendInfo(_ bool, resp []byte) ([]byte, error) {
+	return resp, nil
+}
+
+// BuildError satisfies proxy.Backend; the gateway never synthesises error frames.
+func (m *backend) BuildError(bool, error) ([]byte, error) {
+	return nil, nil
+}
+
+// Close closes the underlying connection.
+//
+// It is idempotent: the loopback backend is shared across several registry
+// entries, so the shutdown sweep may close it more than once.
+func (m *backend) Close() error {
+	m.closeOnce.Do(func() {
+		m.closeErr = m.conn.Close()
+	})
+
+	return m.closeErr
+}

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -12,8 +12,6 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/encoding/gzip"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/controlplane/httpproxy"
@@ -173,87 +171,63 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	ynpb.RegisterAuthServiceServer(server, authService)
 	log.Info("registered service", zap.String("service", fmt.Sprintf("%T", authService)))
 
-	// Register Gateway and Auth as loopback backends for HTTP proxy access.
-	loopback, loopbackGRPCConn, err := newLoopbackBackend(cfg.Server.Endpoint, cfg.Server.TLS)
+	// Dial a single loopback connection shared by all built-in and in-process
+	// services.
+	//
+	// Out-of-process module backends (from the Register RPC) each get their
+	// own connection via RegisterBackend in the registration loop.
+	creds, err := TransportCredentials(cfg.Server.TLS, cfg.Server.Endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build loopback TLS credentials: %w", err)
+	}
+
+	loopback, err := dialBackend(cfg.Server.Endpoint, creds)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create loopback backend for built-in services: %w", err)
 	}
-	builtinConn := newBackendConn(cfg.Server.Endpoint, loopbackGRPCConn)
-	registry.RegisterBackend("ynpb.Gateway", loopback, builtinConn)
-	log.Debug("registered built-in service in registry", zap.String("service", "ynpb.Gateway"))
-	registry.RegisterBackend("ynpb.Auth", loopback, builtinConn)
-	log.Debug("registered built-in service in registry", zap.String("service", "ynpb.Auth"))
 
-	var allServices []Service
+	for _, service := range []string{"ynpb.Gateway", "ynpb.Auth"} {
+		registry.RegisterBackend(service, loopback)
+		log.Info("registered built-in service in registry",
+			zap.String("service", service),
+		)
+	}
+
+	var services []Service
 	var serviceRunners []*ServiceRunner
 
 	for _, service := range opts.Services {
 		if service.Endpoint() == "" {
-			// In-process: register on the shared server.
+			// In-process: register on the shared server and point every
+			// service name at the shared loopback backend.
 			service.RegisterService(server)
-			log.Info("registered in-process service", zap.String("service", service.Name()))
+			log.Info("registered in-process service in registry",
+				zap.String("service", service.Name()),
+			)
 
-			// Share one loopback backend across all service names for this service.
-			inprocBackend, inprocGRPCConn, err := newLoopbackBackend(cfg.Server.Endpoint, cfg.Server.TLS)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create loopback backend for service %q: %w", service.Name(), err)
-			}
-			inprocConn := newBackendConn(cfg.Server.Endpoint, inprocGRPCConn)
 			for _, name := range service.ServicesNames() {
-				registry.RegisterBackend(name, inprocBackend, inprocConn)
-				log.Debug("registered in-process service in registry", zap.String("service", name))
+				registry.RegisterBackend(name, loopback)
+				log.Debug("registered in-process service in registry",
+					zap.String("service", name),
+				)
 			}
 		} else {
 			// Out-of-process: wrap in a ServiceRunner.
 			runner := NewServiceRunner(service, cfg.Server.Endpoint, cfg.Server.TLS, log)
 			serviceRunners = append(serviceRunners, runner)
 		}
-		allServices = append(allServices, service)
+
+		services = append(services, service)
 	}
 
 	return &Gateway{
 		cfg:            cfg,
 		server:         server,
-		services:       allServices,
+		services:       services,
 		serviceRunners: serviceRunners,
 		registry:       registry,
 		log:            log,
 	}, nil
-}
-
-// newLoopbackBackend creates a gRPC proxy backend that dials back to the
-// gateway's own listener, and returns the underlying connection so the caller
-// can wrap it in a backendConn for registry tracking.
-func newLoopbackBackend(endpoint string, tlsCfg *TLSConfig) (proxy.Backend, *grpc.ClientConn, error) {
-	creds, err := TransportCredentials(tlsCfg, endpoint)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to build loopback TLS credentials: %w", err)
-	}
-
-	conn, err := grpc.NewClient(
-		"passthrough:target",
-		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			dialer := net.Dialer{}
-			return dialer.DialContext(ctx, "tcp", endpoint)
-		}),
-		grpc.WithDefaultCallOptions(
-			grpc.ForceCodecV2(proxy.Codec()),
-			grpc.UseCompressor(gzip.Name),
-		),
-		grpc.WithTransportCredentials(creds),
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create loopback gRPC client: %w", err)
-	}
-
-	backend := &proxy.SingleBackend{
-		GetConn: func(ctx context.Context) (context.Context, *grpc.ClientConn, error) {
-			md, _ := metadata.FromIncomingContext(ctx)
-			outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
-			return outCtx, conn, nil
-		},
-	}
-	return backend, conn, nil
 }
 
 // Close closes the gateway API.
@@ -263,6 +237,7 @@ func (m *Gateway) Close() error {
 		if !ok {
 			continue
 		}
+
 		if err := closer.Close(); err != nil {
 			m.log.Warn("failed to close service",
 				zap.String("service", fmt.Sprintf("%T", service)),

--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"errors"
+	"io"
 	"sort"
 	"sync"
 	"time"
@@ -18,26 +19,17 @@ const (
 	RegistrationUpdated
 )
 
-// Conn is a backend connection tracked by the registry.
-//
-// Target identifies the backend endpoint for change detection; Close releases
-// the connection.
-type Conn interface {
-	Target() string
-	Close() error
-}
-
-// BackendRegistry is a registry of backends for Gateway API.
-type BackendRegistry struct {
-	mu       sync.RWMutex
-	backends map[string]BackendEntry
+// Backend is a routable, closeable upstream connection tracked by the registry.
+type Backend interface {
+	proxy.Backend
+	Endpoint() string
+	io.Closer
 }
 
 // BackendEntry holds metadata about a single registered backend.
 type BackendEntry struct {
 	service    string
-	backend    proxy.Backend
-	conn       Conn
+	backend    Backend
 	lastSeenAt time.Time
 }
 
@@ -48,12 +40,23 @@ func (m *BackendEntry) Service() string {
 
 // Endpoint returns the endpoint of the entry.
 func (m *BackendEntry) Endpoint() string {
-	return m.conn.Target()
+	return m.backend.Endpoint()
 }
 
 // LastSeenAt returns the time the entry was last registered.
 func (m *BackendEntry) LastSeenAt() time.Time {
 	return m.lastSeenAt
+}
+
+// GetBackend returns the proxy.Backend for this entry.
+func (m *BackendEntry) GetBackend() proxy.Backend {
+	return m.backend
+}
+
+// BackendRegistry is a registry of backends for Gateway API.
+type BackendRegistry struct {
+	mu       sync.RWMutex
+	backends map[string]BackendEntry
 }
 
 // NewBackendRegistry creates a new BackendRegistry.
@@ -71,63 +74,93 @@ func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, bool) {
 	defer m.mu.RUnlock()
 
 	entry, ok := m.backends[service]
-	backend := entry.backend
-	return backend, ok
+	return entry.backend, ok
 }
 
-// RegisterBackend registers a backend connection for the given service.
+// RegisterBackend stores or replaces the backend for service and reports how
+// the registry changed.
 //
-// On a same-target re-registration the new conn is closed and the existing
-// entry is retained. On an endpoint change the previous conn is closed and the
-// new entry replaces it. The obsolete connection is closed after the lock is
-// released.
-func (m *BackendRegistry) RegisterBackend(
-	service string,
-	backend proxy.Backend,
-	conn Conn,
-) RegistrationStatus {
-	status, obsolete := m.registerBackend(service, backend, conn)
-	if obsolete != nil {
-		_ = obsolete.Close()
+// The displaced backend (the previous one on an endpoint change, or the
+// redundant new one on an unchanged-endpoint re-registration) is closed after
+// the lock is released.
+//
+// This close-on-displace path applies only to 1:1 out-of-process module
+// backends.
+// The shared loopback backend is registered once under distinct keys and is
+// never displaced, so it is only closed by Close().
+func (m *BackendRegistry) RegisterBackend(service string, b Backend) RegistrationStatus {
+	status, evicted := m.registerBackend(service, b)
+	if evicted != nil {
+		_ = evicted.Close()
 	}
+
 	return status
 }
 
-func (m *BackendRegistry) registerBackend(
-	service string,
-	backend proxy.Backend,
-	conn Conn,
-) (RegistrationStatus, Conn) {
+func (m *BackendRegistry) registerBackend(service string, b Backend) (RegistrationStatus, Backend) {
+	now := time.Now().UTC()
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	now := time.Now().UTC()
 	existing, ok := m.backends[service]
 	switch {
-	case ok && existing.conn.Target() == conn.Target():
+	case ok && existing.backend.Endpoint() == b.Endpoint():
 		existing.lastSeenAt = now
 		m.backends[service] = existing
-		return RegistrationRenewed, conn
+		return RegistrationRenewed, b
 	case ok:
-		m.backends[service] = BackendEntry{service: service, backend: backend, conn: conn, lastSeenAt: now}
-		return RegistrationUpdated, existing.conn
+		m.backends[service] = BackendEntry{service: service, backend: b, lastSeenAt: now}
+		return RegistrationUpdated, existing.backend
 	default:
-		m.backends[service] = BackendEntry{service: service, backend: backend, conn: conn, lastSeenAt: now}
+		m.backends[service] = BackendEntry{service: service, backend: b, lastSeenAt: now}
 		return RegistrationRegistered, nil
 	}
 }
 
-// Close closes all tracked backend connections and clears the registry.
-func (m *BackendRegistry) Close() error {
+// Renew refreshes the last-seen time when service is already registered at
+// endpoint and reports whether it did.
+//
+// A false result means the caller must dial a new backend and call
+// RegisterBackend (new service or changed endpoint).
+func (m *BackendRegistry) Renew(service, endpoint string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	var err error
-	for _, entry := range m.backends {
-		err = errors.Join(err, entry.conn.Close())
+	entry, ok := m.backends[service]
+	if ok && entry.backend.Endpoint() == endpoint {
+		entry.lastSeenAt = time.Now().UTC()
+		m.backends[service] = entry
+		return true
 	}
-	m.backends = map[string]BackendEntry{}
+
+	return false
+}
+
+// Close closes all backend connections without holding the registry lock.
+//
+// A backend may be registered under several service names (the shared loopback
+// connection).
+//
+// backend.Close is idempotent, so closing every entry is safe.
+func (m *BackendRegistry) Close() error {
+	var err error
+	for _, entry := range m.takeBackends() {
+		err = errors.Join(err, entry.backend.Close())
+	}
+
 	return err
+}
+
+// takeBackends atomically returns the registered backends and clears the
+// registry.
+func (m *BackendRegistry) takeBackends() map[string]BackendEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	backends := m.backends
+	m.backends = map[string]BackendEntry{}
+	return backends
 }
 
 // ListBackends returns metadata for all currently registered backends.

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -1,106 +1,179 @@
 package gateway
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
-// fakeConn is a test double for the Conn interface.
-type fakeConn struct {
-	target string
-	closed bool
+// fakeBackend is a test double for the Backend interface.
+//
+// Close is idempotent via sync.Once, mirroring the real backend, so tests that
+// close it more than once still see closeCount == 1.
+type fakeBackend struct {
+	endpoint   string
+	closed     bool
+	closeCount int
+	closeOnce  sync.Once
 }
 
-func (m *fakeConn) Target() string { return m.target }
-func (m *fakeConn) Close() error {
-	m.closed = true
+func (m *fakeBackend) Endpoint() string { return m.endpoint }
+func (m *fakeBackend) String() string   { return m.endpoint }
+
+func (m *fakeBackend) GetConnection(ctx context.Context, _ string) (context.Context, *grpc.ClientConn, error) {
+	return ctx, nil, nil
+}
+
+func (m *fakeBackend) AppendInfo(_ bool, resp []byte) ([]byte, error) { return resp, nil }
+func (m *fakeBackend) BuildError(bool, error) ([]byte, error)         { return nil, nil }
+
+func (m *fakeBackend) Close() error {
+	m.closeOnce.Do(func() {
+		m.closed = true
+		m.closeCount++
+	})
 	return nil
 }
 
-// noopBackend is a proxy.Backend that does nothing, used where the backend
-// value is stored by the registry but never invoked.
-var noopBackend proxy.Backend
+// Ensure fakeBackend satisfies both interfaces at compile time.
+var _ proxy.Backend = (*fakeBackend)(nil)
+var _ Backend = (*fakeBackend)(nil)
 
 func TestBackendRegistry_FirstRegistration(t *testing.T) {
 	reg := NewBackendRegistry()
-	conn := &fakeConn{target: "127.0.0.1:9000"}
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
-	status := reg.RegisterBackend("svc.Foo", noopBackend, conn)
+	status := reg.RegisterBackend("svc.Foo", b)
 
 	require.Equal(t, RegistrationRegistered, status)
-	require.False(t, conn.closed)
+	require.False(t, b.closed)
 
 	entry, ok := reg.backends["svc.Foo"]
 	require.True(t, ok)
 	require.Equal(t, "127.0.0.1:9000", entry.Endpoint())
 }
 
-func TestBackendRegistry_SameTargetRenews(t *testing.T) {
+func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
 	reg := NewBackendRegistry()
-	original := &fakeConn{target: "127.0.0.1:9000"}
+	original := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", original)
 
-	reg.RegisterBackend("svc.Foo", noopBackend, original)
+	// Re-register with a different object but the same endpoint.
+	second := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
-	// Re-register with a different conn object but the same target.
-	second := &fakeConn{target: "127.0.0.1:9000"}
-
-	status := reg.RegisterBackend("svc.Foo", noopBackend, second)
+	status := reg.RegisterBackend("svc.Foo", second)
 
 	require.Equal(t, RegistrationRenewed, status)
 
-	// The redundant new conn must be closed.
-	require.True(t, second.closed, "redundant conn should be closed")
+	// The redundant new backend must be closed.
+	require.True(t, second.closed, "redundant backend should be closed")
 
-	// The original conn must still be open and retained.
-	require.False(t, original.closed, "original conn must remain open")
+	// The original backend must still be open and retained.
+	require.False(t, original.closed, "original backend must remain open")
 
 	entry, ok := reg.backends["svc.Foo"]
 	require.True(t, ok)
-	// Stored entry still points at the original conn.
-	require.Equal(t, original, entry.conn)
+	require.Equal(t, original, entry.backend)
 }
 
-func TestBackendRegistry_DifferentTargetUpdates(t *testing.T) {
+func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
 	reg := NewBackendRegistry()
-	prev := &fakeConn{target: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", noopBackend, prev)
+	prev := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", prev)
 
-	next := &fakeConn{target: "127.0.0.1:9001"}
+	next := &fakeBackend{endpoint: "127.0.0.1:9001"}
 
-	status := reg.RegisterBackend("svc.Foo", noopBackend, next)
+	status := reg.RegisterBackend("svc.Foo", next)
 
 	require.Equal(t, RegistrationUpdated, status)
 
-	// The previous conn must be closed.
-	require.True(t, prev.closed, "previous conn should be closed")
+	// The previous backend must be closed.
+	require.True(t, prev.closed, "previous backend should be closed")
 
-	// The new conn must be open.
-	require.False(t, next.closed, "new conn must remain open")
+	// The new backend must be open.
+	require.False(t, next.closed, "new backend must remain open")
 
 	entry, ok := reg.backends["svc.Foo"]
 	require.True(t, ok)
-	require.Equal(t, next, entry.conn)
+	require.Equal(t, next, entry.backend)
 	require.Equal(t, "127.0.0.1:9001", entry.Endpoint())
 }
 
 func TestBackendRegistry_Close(t *testing.T) {
 	reg := NewBackendRegistry()
-	connA := &fakeConn{target: "127.0.0.1:9000"}
-	connB := &fakeConn{target: "127.0.0.1:9001"}
+	bA := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	bB := &fakeBackend{endpoint: "127.0.0.1:9001"}
 
-	reg.RegisterBackend("svc.A", noopBackend, connA)
-	reg.RegisterBackend("svc.B", noopBackend, connB)
+	reg.RegisterBackend("svc.A", bA)
+	reg.RegisterBackend("svc.B", bB)
 
 	err := reg.Close()
 	require.NoError(t, err)
 
-	require.True(t, connA.closed, "connA should be closed")
-	require.True(t, connB.closed, "connB should be closed")
+	require.True(t, bA.closed, "bA should be closed")
+	require.True(t, bB.closed, "bB should be closed")
 
 	// Registry must be empty after Close.
 	require.Empty(t, reg.backends)
+}
+
+func TestBackendRegistry_CloseSharedBackendOnce(t *testing.T) {
+	reg := NewBackendRegistry()
+	shared := &fakeBackend{endpoint: "127.0.0.1:9000"}
+
+	// Register the same backend instance under two different service names,
+	// simulating the shared loopback backend used by built-in services.
+	reg.RegisterBackend("svc.A", shared)
+	reg.RegisterBackend("svc.B", shared)
+
+	err := reg.Close()
+	require.NoError(t, err)
+
+	// Close is called once per registry entry (two), but the backend's own
+	// idempotency (sync.Once) ensures the underlying work runs exactly once.
+	require.Equal(t, 1, shared.closeCount, "shared backend must be closed exactly once")
+
+	// Registry must be empty after Close.
+	require.Empty(t, reg.backends)
+}
+
+func TestBackendRegistry_Renew(t *testing.T) {
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b)
+
+	before := reg.backends["svc.Foo"].lastSeenAt
+
+	// Sleep briefly so lastSeenAt can advance.
+	time.Sleep(time.Millisecond)
+
+	ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
+	require.True(t, ok, "Renew should return true for matching endpoint")
+	require.True(t, reg.backends["svc.Foo"].lastSeenAt.After(before), "lastSeenAt should advance")
+
+	// Wrong endpoint: Renew must return false.
+	ok = reg.Renew("svc.Foo", "127.0.0.1:9999")
+	require.False(t, ok, "Renew should return false for different endpoint")
+
+	// Absent service: Renew must return false.
+	ok = reg.Renew("svc.Missing", "127.0.0.1:9000")
+	require.False(t, ok, "Renew should return false for absent service")
+}
+
+func TestBackend_CloseIdempotent(t *testing.T) {
+	b, err := dialBackend("passthrough:x", insecure.NewCredentials())
+	require.NoError(t, err)
+
+	require.NoError(t, b.Close(), "first Close must succeed")
+	require.NoError(t, b.Close(), "second Close must be a no-op")
+	require.Equal(t, connectivity.Shutdown, b.conn.GetState(), "conn must be in Shutdown state")
 }
 
 func TestBackendRegistry_ConcurrentRace(t *testing.T) {
@@ -108,16 +181,17 @@ func TestBackendRegistry_ConcurrentRace(t *testing.T) {
 
 	const goroutines = 20
 	done := make(chan struct{})
-	for idx := 0; idx < goroutines; idx++ {
+	for range goroutines {
 		go func() {
 			defer func() { done <- struct{}{} }()
-			conn := &fakeConn{target: "127.0.0.1:9000"}
-			reg.RegisterBackend("svc.Race", noopBackend, conn)
+			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+			reg.RegisterBackend("svc.Race", b)
+			reg.Renew("svc.Race", "127.0.0.1:9000")
 			reg.GetBackend("svc.Race")
 			reg.ListBackends()
 		}()
 	}
-	for idx := 0; idx < goroutines; idx++ {
+	for range goroutines {
 		<-done
 	}
 

--- a/controlplane/gateway/service.go
+++ b/controlplane/gateway/service.go
@@ -2,18 +2,10 @@ package gateway
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"strings"
-	"sync"
 
-	"github.com/siderolabs/grpc-proxy/proxy"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/encoding/gzip"
-	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -31,30 +23,6 @@ func registrationStatusToProto(s RegistrationStatus) ynpb.RegistrationStatus {
 	default:
 		return ynpb.RegistrationStatus_REGISTRATION_STATUS_UNSPECIFIED
 	}
-}
-
-// backendConn adapts a backend's *grpc.ClientConn to the registry Conn
-// interface, reporting the real backend endpoint rather than the dial target.
-//
-// Close is idempotent: a single connection may back several registry entries
-// (e.g. the loopback connection shared across built-in service names), so the
-// registry's shutdown sweep can call Close more than once.
-type backendConn struct {
-	endpoint  string
-	conn      *grpc.ClientConn
-	closeOnce sync.Once
-	closeErr  error
-}
-
-func newBackendConn(endpoint string, conn *grpc.ClientConn) *backendConn {
-	return &backendConn{endpoint: endpoint, conn: conn}
-}
-
-func (m *backendConn) Target() string { return m.endpoint }
-
-func (m *backendConn) Close() error {
-	m.closeOnce.Do(func() { m.closeErr = m.conn.Close() })
-	return m.closeErr
 }
 
 // GatewayService is the gRPC service for the Gateway API.
@@ -80,13 +48,13 @@ func (m *GatewayService) ListServices(
 	backends := m.registry.ListBackends()
 
 	services := make([]*ynpb.RegisteredBackend, 0, len(backends))
-	for _, backend := range backends {
+	for _, b := range backends {
 		registeredBackend := &ynpb.RegisteredBackend{
 			Backend: &ynpb.BackendDesc{
-				Name:     backend.Service(),
-				Endpoint: backend.Endpoint(),
+				Name:     b.Service(),
+				Endpoint: b.Endpoint(),
 			},
-			LastSeenAt: timestamppb.New(backend.LastSeenAt()),
+			LastSeenAt: timestamppb.New(b.LastSeenAt()),
 		}
 
 		services = append(services, registeredBackend)
@@ -100,9 +68,9 @@ func (m *GatewayService) ListServices(
 // Register registers a new module in the Gateway API.
 func (m *GatewayService) Register(
 	ctx context.Context,
-	request *ynpb.RegisterRequest,
+	req *ynpb.RegisterRequest,
 ) (*ynpb.RegisterResponse, error) {
-	backendDesc := request.GetBackend()
+	backendDesc := req.GetBackend()
 	if backendDesc == nil {
 		return nil, status.Error(
 			codes.InvalidArgument,
@@ -122,44 +90,23 @@ func (m *GatewayService) Register(
 	)
 	log.Debug("registering backend")
 
-	conn, err := grpc.NewClient(
-		"passthrough:target",
-		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
-			dialer := net.Dialer{}
-			endpoint := backendDesc.GetEndpoint()
-			if strings.HasPrefix(endpoint, "/") {
-				return dialer.DialContext(ctx, "unix", endpoint)
-			}
+	// Fast path: skip dialing when the endpoint is unchanged.
+	//
+	// A registration that races in between this check and RegisterBackend
+	// below is resolved there authoritatively (the redundant connection is
+	// closed), so this check need not be the linearization point.
+	if m.registry.Renew(backendDesc.GetName(), backendDesc.GetEndpoint()) {
+		log.Debug("renewed backend registration")
+		return &ynpb.RegisterResponse{Status: registrationStatusToProto(RegistrationRenewed)}, nil
+	}
 
-			return dialer.DialContext(ctx, "tcp", endpoint)
-		}),
-		grpc.WithDefaultCallOptions(
-			grpc.ForceCodecV2(proxy.Codec()),
-			grpc.UseCompressor(gzip.Name),
-			grpc.MaxCallRecvMsgSize(1024*1024*256),
-			grpc.MaxCallSendMsgSize(1024*1024*256),
-		),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	b, err := dialBackend(backendDesc.GetEndpoint(), insecure.NewCredentials())
 	if err != nil {
-		return nil, fmt.Errorf("failed to create gRPC client to backend: %w", err)
+		return nil, err
 	}
 
-	backend := &proxy.SingleBackend{
-		GetConn: func(ctx context.Context) (context.Context, *grpc.ClientConn, error) {
-			md, _ := metadata.FromIncomingContext(ctx)
-			outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
-
-			return outCtx, conn, nil
-		},
-	}
-	status := m.registry.RegisterBackend(
-		backendDesc.GetName(),
-		backend,
-		newBackendConn(backendDesc.GetEndpoint(), conn),
-	)
-
-	switch status {
+	regStatus := m.registry.RegisterBackend(backendDesc.GetName(), b)
+	switch regStatus {
 	case RegistrationRegistered:
 		log.Info("registered backend")
 	case RegistrationUpdated:
@@ -168,5 +115,5 @@ func (m *GatewayService) Register(
 		log.Debug("renewed backend registration")
 	}
 
-	return &ynpb.RegisterResponse{Status: registrationStatusToProto(status)}, nil
+	return &ynpb.RegisterResponse{Status: registrationStatusToProto(regStatus)}, nil
 }


### PR DESCRIPTION
- Replace the connection-adapter split (a separate Conn interface plus a backendConn wrapper) with a single backend abstraction and one dial helper, removing the three-return loopback constructor.
- The registry now owns connection lifetime: it closes the displaced backend on replacement and all backends on shutdown, and never holds its lock while closing a connection.
- An unchanged-endpoint re-registration (the steady-state heartbeat) skips dialing via a fast-path renewal check; a registration that races the check is still resolved authoritatively by the registry, which closes the redundant connection.
- Built-in and in-process services now share one loopback connection (its close is idempotent); out-of-process modules keep their own connection.