### PR TITLE
feat: redesign route operator page

### DIFF
--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -105,6 +105,16 @@ export interface FIBNexthop {
 const routeService = createService('modules.route.controlplane.routepb.v1.RouteService');
 const operatorRouteService = createService('operators.route.operatorpb.v1.RouteService');
 
+export interface LookupRouteRequest {
+    name?: string;
+    ip_addr?: IPAddressWire;
+}
+
+export interface LookupRouteResponse {
+    prefix?: string;
+    routes?: Route[];
+}
+
 export const route = {
     listConfigs: (options?: CallOptions): Promise<ListConfigsResponse> => {
         return routeService.call<ListConfigsResponse>('ListConfigs', options);
@@ -120,6 +130,9 @@ export const route = {
     },
     flushRoutes: (request: FlushRoutesRequest, options?: CallOptions): Promise<FlushRoutesResponse> => {
         return operatorRouteService.callWithBody<FlushRoutesResponse>('FlushRoutes', request, options);
+    },
+    lookupRoute: (request: LookupRouteRequest, options?: CallOptions): Promise<LookupRouteResponse> => {
+        return operatorRouteService.callWithBody<LookupRouteResponse>('LookupRoute', request, options);
     },
     showFIB: (request: ShowFIBRequest, options?: CallOptions): Promise<ShowFIBResponse> => {
         return routeService.callWithBody<ShowFIBResponse>('ShowFIB', request, options);

--- a/web/src/components/PageLayout.tsx
+++ b/web/src/components/PageLayout.tsx
@@ -9,11 +9,13 @@ export interface PageLayoutProps {
     header?: React.ReactNode;
     /** Main page content */
     children: React.ReactNode;
+    /** Optional extra class applied to the root element for page-scoped overrides. */
+    className?: string;
 }
 
-export const PageLayout = ({ title, header, children }: PageLayoutProps): React.JSX.Element => {
+export const PageLayout = ({ title, header, children, className }: PageLayoutProps): React.JSX.Element => {
     return (
-        <Flex direction="column" className="page-layout">
+        <Flex direction="column" className={`page-layout${className ? ' ' + className : ''}`}>
             {(title || header) && (
                 <>
                     <Box spacing={{ px: 5, py: 3 }} className="page-layout__header">

--- a/web/src/components/SearchInput.tsx
+++ b/web/src/components/SearchInput.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 import { Magnifier } from '@gravity-ui/icons';
 import { Flex, Icon, TextInput } from '@gravity-ui/uikit';
+import type { IconData } from '@gravity-ui/uikit';
 
 interface SearchInputProps {
     value: string;
@@ -9,6 +10,8 @@ interface SearchInputProps {
     controlRef?: React.RefObject<HTMLInputElement | null>;
     enableFocusShortcut?: boolean;
     showShortcutHint?: boolean;
+    /** Overrides the leading icon. Defaults to the magnifier. */
+    icon?: IconData;
 }
 
 const isMacPlatform = (): boolean => {
@@ -58,6 +61,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
     controlRef,
     enableFocusShortcut = true,
     showShortcutHint = true,
+    icon,
 }) => {
     const fallbackRef = useRef<HTMLInputElement | null>(null);
     const inputRef = controlRef ?? fallbackRef;
@@ -94,7 +98,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
             placeholder={placeholderWithHint}
             startContent={
                 <Flex alignItems="center" justifyContent="center" style={{ paddingInline: 8, color: 'var(--g-color-text-hint)' }}>
-                    <Icon data={Magnifier} size={16} />
+                    <Icon data={icon ?? Magnifier} size={16} />
                 </Flex>
             }
             hasClear

--- a/web/src/pages/operators/route/CommandPalette.tsx
+++ b/web/src/pages/operators/route/CommandPalette.tsx
@@ -1,0 +1,253 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { parseIPAddress } from '../../../utils';
+import type { Route } from '../../../api/routes';
+import { ipAddressToString } from '../../../utils/netip';
+import { getRouteId } from './utils';
+import type { IPFamily } from './types';
+
+export interface PaletteAction {
+    id: string;
+    label: string;
+    description?: string;
+    onSelect: () => void;
+}
+
+export interface CommandPaletteProps {
+    open: boolean;
+    onClose: () => void;
+    rows: Route[];
+    onLookupIP: (ip: string) => void;
+    onAddRoute: () => void;
+    onFlush: () => void;
+    onOpenLookup: () => void;
+    onSetFamily: (f: IPFamily) => void;
+    onToggleBestOnly: () => void;
+    onToggleConflicts: () => void;
+    onClearFilters: () => void;
+    onJumpToRow: (id: string) => void;
+}
+
+interface PaletteItem {
+    id: string;
+    icon: string;
+    label: string;
+    sub?: string;
+    onSelect: () => void;
+}
+
+const MAX_ROW_RESULTS = 7;
+
+/** Route-scoped ⌘K command palette. */
+const CommandPalette: React.FC<CommandPaletteProps> = ({
+    open,
+    onClose,
+    rows,
+    onLookupIP,
+    onAddRoute,
+    onFlush,
+    onOpenLookup,
+    onSetFamily,
+    onToggleBestOnly,
+    onToggleConflicts,
+    onClearFilters,
+    onJumpToRow,
+}) => {
+    const [query, setQuery] = useState('');
+    const [activeIdx, setActiveIdx] = useState(0);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const listRef = useRef<HTMLDivElement>(null);
+
+    const isIPQuery = query.trim() !== '' && parseIPAddress(query.trim()).ok;
+
+    const items: PaletteItem[] = [];
+
+    if (isIPQuery) {
+        const ip = query.trim();
+        items.push({
+            id: '__lookup_ip',
+            icon: '⌖',
+            label: `Look up ${ip}`,
+            sub: 'Route Lookup — longest prefix match',
+            onSelect: () => { onLookupIP(ip); onClose(); },
+        });
+    }
+
+    if (!query.trim() || 'add route'.includes(query.toLowerCase())) {
+        items.push({
+            id: '__add',
+            icon: '+',
+            label: 'Add route',
+            sub: 'Open the add-route drawer',
+            onSelect: () => { onAddRoute(); onClose(); },
+        });
+    }
+    if (!query.trim() || 'flush rib fib'.includes(query.toLowerCase())) {
+        items.push({
+            id: '__flush',
+            icon: '⟳',
+            label: 'Flush RIB → FIB',
+            sub: 'Push best routes to the dataplane',
+            onSelect: () => { onFlush(); onClose(); },
+        });
+    }
+    if (!query.trim() || 'route lookup'.includes(query.toLowerCase())) {
+        items.push({
+            id: '__open_lookup',
+            icon: '⌖',
+            label: 'Open Route Lookup',
+            sub: 'Look up an IP address in the RIB',
+            onSelect: () => { onOpenLookup(); onClose(); },
+        });
+    }
+    if (!query.trim() || 'best paths only'.includes(query.toLowerCase())) {
+        items.push({
+            id: '__best_only',
+            icon: '★',
+            label: 'Show best paths only',
+            onSelect: () => { onToggleBestOnly(); onClose(); },
+        });
+    }
+    if (!query.trim() || 'conflicts'.includes(query.toLowerCase())) {
+        items.push({
+            id: '__conflicts',
+            icon: '⚡',
+            label: 'Show conflicts only',
+            sub: 'Prefixes with more than one candidate route',
+            onSelect: () => { onToggleConflicts(); onClose(); },
+        });
+    }
+    if (!query.trim() || 'ipv6 only'.includes(query.toLowerCase())) {
+        items.push({
+            id: '__v6',
+            icon: '6',
+            label: 'Filter IPv6 only',
+            onSelect: () => { onSetFamily('v6'); onClose(); },
+        });
+    }
+    if (!query.trim() || 'ipv4 only'.includes(query.toLowerCase())) {
+        items.push({
+            id: '__v4',
+            icon: '4',
+            label: 'Filter IPv4 only',
+            onSelect: () => { onSetFamily('v4'); onClose(); },
+        });
+    }
+    if (!query.trim() || 'clear filters'.includes(query.toLowerCase())) {
+        items.push({
+            id: '__clear',
+            icon: '✕',
+            label: 'Clear filters',
+            onSelect: () => { onClearFilters(); onClose(); },
+        });
+    }
+
+    if (query.trim() && !isIPQuery) {
+        const q = query.trim().toLowerCase();
+        let count = 0;
+        for (let idx = 0; idx < rows.length && count < MAX_ROW_RESULTS; idx++) {
+            const r = rows[idx];
+            const prefix = r.prefix || '';
+            const nh = ipAddressToString(r.next_hop);
+            if (prefix.toLowerCase().includes(q) || nh.toLowerCase().includes(q)) {
+                const id = getRouteId(r);
+                items.push({
+                    id: `__row_${id}`,
+                    icon: '→',
+                    label: prefix || '(no prefix)',
+                    sub: nh || '—',
+                    onSelect: () => { onJumpToRow(id); onClose(); },
+                });
+                count++;
+            }
+        }
+    }
+
+    useEffect(() => {
+        if (open) {
+            setQuery('');
+            setActiveIdx(0);
+            setTimeout(() => inputRef.current?.focus(), 20);
+        }
+    }, [open]);
+
+    useEffect(() => {
+        setActiveIdx(0);
+    }, [query]);
+
+    useEffect(() => {
+        if (!open) return;
+        const el = listRef.current?.children[activeIdx] as HTMLElement | undefined;
+        el?.scrollIntoView({ block: 'nearest' });
+    }, [activeIdx, open]);
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent): void => {
+        if (e.key === 'Escape') {
+            onClose();
+            return;
+        }
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            setActiveIdx((prev) => Math.min(prev + 1, items.length - 1));
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            setActiveIdx((prev) => Math.max(prev - 1, 0));
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+            items[activeIdx]?.onSelect();
+        }
+    }, [items, activeIdx, onClose]);
+
+    if (!open) return null;
+
+    return (
+        <div
+            className="ro-palette-backdrop"
+            onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
+        >
+            <div className="ro-palette-card" onKeyDown={handleKeyDown}>
+                <div className="ro-palette-input-row">
+                    <span className="ro-palette-search-icon">⌘</span>
+                    <input
+                        ref={inputRef}
+                        className="ro-palette-input"
+                        placeholder="Search routes, prefixes, or type an IP…"
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        autoComplete="off"
+                        spellCheck={false}
+                    />
+                    <kbd className="ro-palette-esc-hint">esc</kbd>
+                </div>
+                {items.length > 0 && (
+                    <div ref={listRef} className="ro-palette-list">
+                        {items.map((item, idx) => (
+                            <button
+                                key={item.id}
+                                type="button"
+                                className={`ro-palette-item${idx === activeIdx ? ' ro-palette-item--active' : ''}`}
+                                onMouseEnter={() => setActiveIdx(idx)}
+                                onMouseDown={(e) => { e.preventDefault(); item.onSelect(); }}
+                            >
+                                <span className="ro-palette-item__icon">{item.icon}</span>
+                                <span className="ro-palette-item__body">
+                                    <span className="ro-palette-item__label">{item.label}</span>
+                                    {item.sub && (
+                                        <span className="ro-palette-item__sub">{item.sub}</span>
+                                    )}
+                                </span>
+                                {idx === activeIdx && (
+                                    <kbd className="ro-palette-item__enter">↵</kbd>
+                                )}
+                            </button>
+                        ))}
+                    </div>
+                )}
+                {items.length === 0 && query.trim() && (
+                    <div className="ro-palette-empty">No results for "{query}"</div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default CommandPalette;

--- a/web/src/pages/operators/route/LookupDrawer.tsx
+++ b/web/src/pages/operators/route/LookupDrawer.tsx
@@ -1,0 +1,261 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { API } from '../../../api';
+import { toaster } from '../../../utils';
+import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
+import { parseIPAddress } from '../../../utils';
+import type { Route } from '../../../api/routes';
+import { bestPathReason } from './utils';
+import { BestPill, SourceChip } from './cells';
+
+export interface LookupDrawerProps {
+    open: boolean;
+    configName: string;
+    initialQuery?: string;
+    onClose: () => void;
+    onShowInTable: (prefix: string) => void;
+}
+
+const EXAMPLE_IPS = ['::1', '2a02:6b8:c15::1', '87.250.250.17'];
+
+/** Side drawer for IP route lookup — shows matched prefix and candidate routes best-first. */
+const LookupDrawer: React.FC<LookupDrawerProps> = ({
+    open,
+    configName,
+    initialQuery,
+    onClose,
+    onShowInTable,
+}) => {
+    const [query, setQuery] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [result, setResult] = useState<{ prefix: string; routes: Route[] } | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (open) {
+            if (initialQuery) {
+                setQuery(initialQuery);
+                setResult(null);
+            } else {
+                setQuery('');
+                setResult(null);
+            }
+            setTimeout(() => inputRef.current?.focus(), 30);
+        }
+    }, [open, initialQuery]);
+
+    const performLookup = useCallback(async (ip: string): Promise<void> => {
+        const trimmed = ip.trim();
+        if (!trimmed) return;
+
+        const parsed = parseIPAddress(trimmed);
+        if (!parsed.ok) {
+            toaster.error('lookup-invalid-ip', 'Invalid IP address format');
+            return;
+        }
+
+        const ipAddr = stringToIPAddress(trimmed);
+        if (!ipAddr) {
+            toaster.error('lookup-invalid-ip', 'Failed to encode IP address');
+            return;
+        }
+
+        setLoading(true);
+        setResult(null);
+        try {
+            const res = await API.route.lookupRoute({
+                name: configName,
+                ip_addr: ipAddr,
+            });
+            setResult({
+                prefix: res.prefix ?? '',
+                routes: res.routes ?? [],
+            });
+        } catch (err) {
+            toaster.error('lookup-error', 'Route lookup failed', err);
+        } finally {
+            setLoading(false);
+        }
+    }, [configName]);
+
+    useEffect(() => {
+        if (open && initialQuery) {
+            void performLookup(initialQuery);
+        }
+    }, [open, initialQuery, performLookup]);
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLInputElement>): void => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            void performLookup(query);
+        } else if (e.key === 'Escape') {
+            onClose();
+        }
+    }, [query, performLookup, onClose]);
+
+    const reasonLine = result && result.routes.length > 1
+        ? bestPathReason(result.routes)
+        : '';
+
+    return (
+        <>
+            <div
+                className={`fw-backdrop${open ? ' fw-backdrop--open' : ''}`}
+                onClick={onClose}
+            />
+            <div className={`fw-drawer ro-lookup-drawer${open ? ' fw-drawer--open' : ''}`}>
+                <div className="fw-drawer__head">
+                    <h2 className="fw-drawer__title">Route Lookup</h2>
+                    <button
+                        type="button"
+                        className="fw-icon-btn"
+                        onClick={onClose}
+                        aria-label="Close"
+                    >
+                        ✕
+                    </button>
+                </div>
+
+                <div className="fw-drawer__body">
+                    <div className="ro-lookup-input-row">
+                        <input
+                            ref={inputRef}
+                            className="fw-input fw-input--mono"
+                            placeholder="Enter IPv4 or IPv6 address…"
+                            value={query}
+                            onChange={(e) => setQuery(e.target.value)}
+                            onKeyDown={handleKeyDown}
+                            autoComplete="off"
+                            spellCheck={false}
+                        />
+                        <button
+                            type="button"
+                            className="fw-btn fw-btn--primary"
+                            onClick={() => void performLookup(query)}
+                            disabled={loading || !query.trim()}
+                        >
+                            {loading ? '…' : 'Look up'}
+                        </button>
+                    </div>
+
+                    <div className="ro-lookup-examples">
+                        <span className="ro-lookup-examples__label">Examples:</span>
+                        {EXAMPLE_IPS.map((ip) => (
+                            <button
+                                key={ip}
+                                type="button"
+                                className="ro-lookup-example-chip"
+                                onClick={() => {
+                                    setQuery(ip);
+                                    void performLookup(ip);
+                                }}
+                            >
+                                {ip}
+                            </button>
+                        ))}
+                    </div>
+
+                    {loading && (
+                        <div className="ro-lookup-loading">Looking up…</div>
+                    )}
+
+                    {result && !loading && (
+                        <div className="ro-lookup-result">
+                            <div className="ro-lookup-result__matched">
+                                <span className="ro-lookup-result__label">Matched prefix</span>
+                                <span className="ro-lookup-result__prefix">
+                                    {result.prefix || '(none)'}
+                                </span>
+                                {result.prefix && (
+                                    <button
+                                        type="button"
+                                        className="ro-lookup-show-in-table"
+                                        onClick={() => {
+                                            onShowInTable(result.prefix);
+                                            onClose();
+                                        }}
+                                    >
+                                        Show in table →
+                                    </button>
+                                )}
+                            </div>
+
+                            {reasonLine && (
+                                <div className="ro-lookup-reason">
+                                    Best because: {reasonLine}
+                                </div>
+                            )}
+
+                            {result.routes.length > 0 ? (
+                                <div className="ro-lookup-table-wrap">
+                                    <table className="ro-lookup-table">
+                                        <thead>
+                                            <tr>
+                                                <th></th>
+                                                <th>Prefix</th>
+                                                <th>Next Hop</th>
+                                                <th>Peer</th>
+                                                <th>Source</th>
+                                                <th>Peer AS</th>
+                                                <th>Origin</th>
+                                                <th>Pref</th>
+                                                <th>MED</th>
+                                                <th>Communities</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {result.routes.map((r, idx) => (
+                                                <tr
+                                                    key={idx}
+                                                    className={idx === 0 ? 'ro-lookup-table__best-row' : ''}
+                                                >
+                                                    <td>
+                                                        <BestPill isBest={idx === 0} />
+                                                    </td>
+                                                    <td className="fw-cell-mono fw-cell-strong">
+                                                        {r.prefix || '—'}
+                                                    </td>
+                                                    <td className="fw-cell-mono fw-cell-muted">
+                                                        {ipAddressToString(r.next_hop) || '—'}
+                                                    </td>
+                                                    <td className="fw-cell-mono fw-cell-muted">
+                                                        {ipAddressToString(r.peer) || '—'}
+                                                    </td>
+                                                    <td>
+                                                        <SourceChip source={r.source} />
+                                                    </td>
+                                                    <td className="fw-cell-muted">
+                                                        {r.peer_as ?? '—'}
+                                                    </td>
+                                                    <td className="fw-cell-muted">
+                                                        {r.origin_as ?? '—'}
+                                                    </td>
+                                                    <td className="fw-cell-muted">
+                                                        {r.pref ?? '—'}
+                                                    </td>
+                                                    <td className="fw-cell-muted">
+                                                        {r.med ?? '—'}
+                                                    </td>
+                                                    <td className="fw-cell-muted ro-lookup-communities">
+                                                        {r.large_communities && r.large_communities.length > 0
+                                                            ? r.large_communities
+                                                                .map((c) => `${c.global_administrator ?? 0}:${c.local_data_part1 ?? 0}:${c.local_data_part2 ?? 0}`)
+                                                                .join(' ')
+                                                            : '—'}
+                                                    </td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            ) : (
+                                <div className="ro-lookup-no-match">No matching routes found.</div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </>
+    );
+};
+
+export default LookupDrawer;

--- a/web/src/pages/operators/route/RIBTable.tsx
+++ b/web/src/pages/operators/route/RIBTable.tsx
@@ -1,11 +1,12 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Checkbox } from '@gravity-ui/uikit';
-import { useContainerHeight } from '../../../hooks';
 import { useRowHoverOverlay, RowHoverEditOverlay } from '../../_shared/draft';
 import type { Route } from '../../../api/routes';
 import { ipAddressToString } from '../../../utils/netip';
-import { ROUTE_SOURCES, getRouteId } from './utils';
+import { useContainerHeight } from '../../../hooks/useContainerHeight';
+import { getRouteId } from './utils';
+import { BestPill, SourceChip, FamilyBadge, ConflictBadge } from './cells';
 import type { RouteSortableColumn, RouteSortState } from './types';
 
 const ROW_HEIGHT = 44;
@@ -13,65 +14,84 @@ const HEADER_HEIGHT = 40;
 const FOOTER_HEIGHT = 28;
 const OVERSCAN = 15;
 
-const COL_CHECKBOX = 38;
-const COL_INDEX = 48;
-const COL_PREFIX = 260;
-const COL_NEXT_HOP = 200;
-const COL_PEER = 200;
-const COL_BEST = 60;
-const COL_PREF = 60;
-const COL_AS_PATH = 80;
-const COL_SOURCE = 90;
+/** Minimum total width before a horizontal scrollbar appears on very narrow viewports. */
+const RIB_MIN_WIDTH = 860;
 
-export const RIB_TOTAL_WIDTH =
-    COL_CHECKBOX + COL_INDEX + COL_PREFIX + COL_NEXT_HOP + COL_PEER +
-    COL_BEST + COL_PREF + COL_AS_PATH + COL_SOURCE;
+/** CSS grid template for both the header row and each data row. */
+const GRID_TEMPLATE = '38px 52px minmax(190px, 1.3fr) 150px minmax(120px, 0.8fr) 92px 64px 78px 116px';
+const GRID_COLUMN_GAP = 14;
+
+/** @deprecated Use GRID_TEMPLATE instead. Kept for external callers. */
+export const RIB_TOTAL_WIDTH = RIB_MIN_WIDTH;
 
 export interface RIBTableProps {
     rows: Route[];
     selectedIds: Set<string>;
-    activeRowId: string | null;
-    editingRowId: string | null;
     sortState: RouteSortState;
     onSort: (col: RouteSortableColumn) => void;
-    onRowClick: (id: string) => void;
     onEditRow: (id: string) => void;
     onSelectionChange: (ids: Set<string>) => void;
     emptyMessage: string;
     onDeleteRow: (id: string) => void;
+    conflictMap?: Map<string, number>;
+    flashRowId?: string | null;
 }
 
 interface SortButtonProps {
     col: RouteSortableColumn;
     label: string;
-    width: number;
     sortState: RouteSortState;
     onSort: (col: RouteSortableColumn) => void;
 }
 
-const SortButton: React.FC<SortButtonProps> = ({ col, label, width, sortState, onSort }) => {
+/** SVG sort icon — double arrow (unsorted), up arrow (asc), down arrow (desc). */
+const SortIcon: React.FC<{ variant: 'sort' | 'sortUp' | 'sortDown'; active: boolean }> = ({ variant, active }) => {
+    const paths: Record<typeof variant, string[]> = {
+        sort: ['M8 3v18', 'M5 8l3-3 3 3', 'M16 21V3', 'M13 16l3 3 3-3'],
+        sortUp: ['M8 5l4-4 4 4', 'M12 1v22'],
+        sortDown: ['M8 19l4 4 4-4', 'M12 23V1'],
+    };
+    return (
+        <svg
+            width={12}
+            height={12}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{ display: 'block', flexShrink: 0, opacity: active ? 1 : 0.5 }}
+        >
+            {paths[variant].map((d) => <path key={d} d={d} />)}
+        </svg>
+    );
+};
+
+const SortButton: React.FC<SortButtonProps> = ({ col, label, sortState, onSort }) => {
     const isActive = sortState.column === col;
-    const arrow = isActive ? (sortState.direction === 'asc' ? '▲' : '▼') : '↕';
+    const iconVariant = isActive
+        ? (sortState.direction === 'asc' ? 'sortUp' : 'sortDown')
+        : 'sort';
     return (
         <button
             type="button"
             style={{
-                width,
-                minWidth: width,
-                flexShrink: 0,
                 display: 'flex',
                 alignItems: 'center',
                 gap: 4,
                 background: 'none',
                 border: 'none',
                 cursor: 'pointer',
-                color: 'inherit',
-                padding: '0 8px 0 0',
+                color: isActive ? 'var(--fw-accent)' : 'inherit',
+                padding: 0,
+                width: '100%',
+                minWidth: 0,
             }}
             onClick={() => onSort(col)}
         >
-            <span className="fw-th-text">{label}</span>
-            <span style={{ fontSize: 10, opacity: isActive ? 1 : 0.35 }}>{arrow}</span>
+            <span className="fw-th-text" style={{ color: isActive ? 'var(--fw-accent)' : undefined }}>{label}</span>
+            <SortIcon variant={iconVariant} active={isActive} />
         </button>
     );
 };
@@ -80,18 +100,18 @@ const SortButton: React.FC<SortButtonProps> = ({ col, label, width, sortState, o
 export const RIBTable: React.FC<RIBTableProps> = ({
     rows,
     selectedIds,
-    activeRowId,
-    editingRowId,
     sortState,
     onSort,
-    onRowClick,
     onEditRow,
     onSelectionChange,
     emptyMessage,
     onDeleteRow,
+    conflictMap,
+    flashRowId,
 }) => {
     const scrollRef = useRef<HTMLDivElement>(null);
-    const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT + 20);
+    const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT);
+    const [flashingId, setFlashingId] = React.useState<string | null>(null);
 
     const {
         hoveredRow,
@@ -114,6 +134,17 @@ export const RIBTable: React.FC<RIBTableProps> = ({
         overscan: OVERSCAN,
     });
 
+    useEffect(() => {
+        if (!flashRowId) return;
+        const idx = rows.findIndex((r) => getRouteId(r) === flashRowId);
+        if (idx >= 0) {
+            rowVirtualizer.scrollToIndex(idx, { align: 'center' });
+        }
+        setFlashingId(flashRowId);
+        const t = setTimeout(() => setFlashingId(null), 1200);
+        return () => clearTimeout(t);
+    }, [flashRowId, rows, rowVirtualizer]);
+
     const isAllSelected = rows.length > 0 && rows.every((r) => selectedIds.has(getRouteId(r)));
     const isIndeterminate = !isAllSelected && rows.some((r) => selectedIds.has(getRouteId(r)));
 
@@ -129,11 +160,9 @@ export const RIBTable: React.FC<RIBTableProps> = ({
 
     const handleOverlayEdit = useCallback((): void => {
         if (hoveredRow) {
-            const id = getRouteId(hoveredRow);
-            onRowClick(id);
-            onEditRow(id);
+            onEditRow(getRouteId(hoveredRow));
         }
-    }, [hoveredRow, onRowClick, onEditRow]);
+    }, [hoveredRow, onEditRow]);
 
     const virtualRows = rowVirtualizer.getVirtualItems();
 
@@ -144,71 +173,82 @@ export const RIBTable: React.FC<RIBTableProps> = ({
         return `Shown ${first.toLocaleString()}–${last.toLocaleString()} of ${rows.length.toLocaleString()}`;
     }, [virtualRows, rows.length]);
 
+    const gridStyle: React.CSSProperties = {
+        display: 'grid',
+        gridTemplateColumns: GRID_TEMPLATE,
+        columnGap: GRID_COLUMN_GAP,
+        alignItems: 'center',
+        paddingLeft: 16,
+        paddingRight: 22,
+        minWidth: RIB_MIN_WIDTH,
+    };
+
     return (
         <div className="fw-tbl-wrap">
             <div className="fw-tbl-header-row">
-                <div className="fw-vtbl-header" style={{ height: HEADER_HEIGHT, minWidth: RIB_TOTAL_WIDTH }}>
+                <div
+                    className="fw-vtbl-header"
+                    style={{ ...gridStyle, height: HEADER_HEIGHT, flex: '1 1 auto', overflow: 'hidden' }}
+                >
                     <div
-                        style={{ width: COL_CHECKBOX, minWidth: COL_CHECKBOX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                         onClick={(e) => e.stopPropagation()}
                     >
                         <Checkbox checked={isAllSelected} indeterminate={isIndeterminate} onUpdate={handleSelectAll} size="m" />
                     </div>
-                    <div style={{ width: COL_INDEX, minWidth: COL_INDEX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                         <span className="fw-th-text">#</span>
                     </div>
-                    <SortButton col="prefix" label="Prefix" width={COL_PREFIX} sortState={sortState} onSort={onSort} />
-                    <SortButton col="next_hop" label="Next Hop" width={COL_NEXT_HOP} sortState={sortState} onSort={onSort} />
-                    <SortButton col="peer" label="Peer" width={COL_PEER} sortState={sortState} onSort={onSort} />
-                    <SortButton col="is_best" label="Best" width={COL_BEST} sortState={sortState} onSort={onSort} />
-                    <SortButton col="pref" label="Pref" width={COL_PREF} sortState={sortState} onSort={onSort} />
-                    <SortButton col="as_path_len" label="AS Path" width={COL_AS_PATH} sortState={sortState} onSort={onSort} />
-                    <SortButton col="source" label="Source" width={COL_SOURCE} sortState={sortState} onSort={onSort} />
+                    <SortButton col="prefix" label="Prefix" sortState={sortState} onSort={onSort} />
+                    <SortButton col="next_hop" label="Next Hop" sortState={sortState} onSort={onSort} />
+                    <SortButton col="peer" label="Peer" sortState={sortState} onSort={onSort} />
+                    <SortButton col="is_best" label="Best" sortState={sortState} onSort={onSort} />
+                    <SortButton col="pref" label="Pref" sortState={sortState} onSort={onSort} />
+                    <SortButton col="as_path_len" label="AS Path" sortState={sortState} onSort={onSort} />
+                    <SortButton col="source" label="Source" sortState={sortState} onSort={onSort} />
                 </div>
             </div>
 
             <div
                 ref={setScrollRef}
                 className="fw-vtbl-body"
-                style={bodyHeight > 0 ? { flex: '0 0 auto', height: bodyHeight } : undefined}
+                style={{ flex: '0 0 auto', height: bodyHeight, overflowY: 'auto' }}
             >
                 {rows.length === 0 ? (
                     <div className="fw-table-empty">{emptyMessage}</div>
                 ) : (
-                    <div style={{ height: rowVirtualizer.getTotalSize(), minWidth: RIB_TOTAL_WIDTH, position: 'relative' }}>
+                    <div style={{ height: rowVirtualizer.getTotalSize(), minWidth: RIB_MIN_WIDTH, position: 'relative' }}>
                         {virtualRows.map((virtualRow) => {
                             const route = rows[virtualRow.index];
                             if (!route) return null;
                             const id = getRouteId(route);
                             const isSelected = selectedIds.has(id);
-                            const isActive = activeRowId === id || editingRowId === id;
+                            const isFlashing = flashingId === id;
                             let rowBg = 'transparent';
-                            if (isSelected || isActive) rowBg = 'var(--fw-accent-soft)';
+                            if (isFlashing) rowBg = 'color-mix(in srgb, var(--g-color-text-positive) 14%, transparent)';
+                            else if (isSelected) rowBg = 'var(--fw-accent-soft)';
+                            const prefixConflictCount = conflictMap?.get(route.prefix || '') ?? 1;
                             return (
                                 <div
                                     key={id}
-                                    className={`fw-vrow${isActive ? ' fw-vrow--active' : ''}${isSelected ? ' fw-vrow--selected' : ''}`}
+                                    className={`fw-vrow${isSelected ? ' fw-vrow--selected' : ''}`}
                                     data-row-id={id}
                                     onMouseEnter={() => handleHoverChange(route, virtualRow.start)}
                                     onMouseLeave={() => handleHoverChange(null, 0)}
-                                    onClick={() => onRowClick(id)}
                                     style={{
                                         position: 'absolute',
                                         top: virtualRow.start,
                                         left: 0,
                                         height: ROW_HEIGHT,
-                                        minWidth: RIB_TOTAL_WIDTH,
                                         width: '100%',
-                                        display: 'flex',
-                                        alignItems: 'center',
                                         borderBottom: '1px solid var(--fw-line)',
                                         backgroundColor: rowBg,
-                                        paddingLeft: 4,
                                         cursor: 'default',
+                                        ...gridStyle,
                                     }}
                                 >
                                     <div
-                                        style={{ width: COL_CHECKBOX, minWidth: COL_CHECKBOX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                                        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                                         onClick={(e) => e.stopPropagation()}
                                     >
                                         <Checkbox
@@ -217,31 +257,42 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                                             size="m"
                                         />
                                     </div>
-                                    <div style={{ width: COL_INDEX, minWidth: COL_INDEX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--fw-text-3)', fontVariantNumeric: 'tabular-nums' }}>
-                                        <span style={{ fontSize: 12 }}>{virtualRow.index + 1}</span>
+                                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--fw-text-3)', fontVariantNumeric: 'tabular-nums', fontFamily: 'var(--fw-font-mono)' }}>
+                                        <span style={{ fontSize: 12.5 }}>{virtualRow.index + 1}</span>
                                     </div>
-                                    <div style={{ width: COL_PREFIX, minWidth: COL_PREFIX, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-mono fw-cell-strong">{route.prefix || '-'}</span>
+                                    <div style={{ display: 'flex', alignItems: 'center', gap: 9, overflow: 'hidden' }}>
+                                        {route.prefix && <FamilyBadge prefix={route.prefix} />}
+                                        <span
+                                            className="fw-cell-mono"
+                                            style={{
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                whiteSpace: 'nowrap',
+                                                flexShrink: 1,
+                                                fontSize: 13.5,
+                                                fontWeight: route.is_best ? 600 : 500,
+                                                color: route.is_best ? 'var(--fw-text)' : 'var(--fw-text-2)',
+                                            }}
+                                        >{route.prefix || '-'}</span>
+                                        {prefixConflictCount > 1 && <ConflictBadge count={prefixConflictCount} />}
                                     </div>
-                                    <div style={{ width: COL_NEXT_HOP, minWidth: COL_NEXT_HOP, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-mono fw-cell-muted">{ipAddressToString(route.next_hop) || '-'}</span>
+                                    <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: 'var(--fw-text-2)' }}>{ipAddressToString(route.next_hop) || '-'}</span>
                                     </div>
-                                    <div style={{ width: COL_PEER, minWidth: COL_PEER, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-mono fw-cell-muted">{ipAddressToString(route.peer) || '-'}</span>
+                                    <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: 'var(--fw-text-3)' }}>{ipAddressToString(route.peer) || '-'}</span>
                                     </div>
-                                    <div style={{ width: COL_BEST, minWidth: COL_BEST, flexShrink: 0, paddingRight: 8 }}>
-                                        <span className="fw-cell-muted">{route.is_best ? 'Yes' : 'No'}</span>
+                                    <div style={{ display: 'flex', alignItems: 'center' }}>
+                                        <BestPill isBest={route.is_best ?? false} />
                                     </div>
-                                    <div style={{ width: COL_PREF, minWidth: COL_PREF, flexShrink: 0, paddingRight: 8 }}>
-                                        <span className="fw-cell-muted">{route.pref ?? '-'}</span>
+                                    <div>
+                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: route.pref ? 'var(--fw-text-2)' : 'var(--fw-text-3)' }}>{route.pref || '—'}</span>
                                     </div>
-                                    <div style={{ width: COL_AS_PATH, minWidth: COL_AS_PATH, flexShrink: 0, paddingRight: 8 }}>
-                                        <span className="fw-cell-muted">{route.as_path_len ?? '-'}</span>
+                                    <div>
+                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: route.as_path_len ? 'var(--fw-text-2)' : 'var(--fw-text-3)' }}>{route.as_path_len || '—'}</span>
                                     </div>
-                                    <div style={{ width: COL_SOURCE, minWidth: COL_SOURCE, flexShrink: 0, paddingRight: 8 }}>
-                                        <span className="fw-cell-muted">
-                                            {route.source !== undefined ? (ROUTE_SOURCES[route.source] ?? 'Unknown') : '-'}
-                                        </span>
+                                    <div style={{ overflow: 'hidden' }}>
+                                        <SourceChip source={route.source} />
                                     </div>
                                 </div>
                             );

--- a/web/src/pages/operators/route/RouteDrawer.tsx
+++ b/web/src/pages/operators/route/RouteDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Switch } from '@gravity-ui/uikit';
 import { DraftItemDrawer } from '../../_shared/draft';
 import { ipAddressToString } from '../../../utils/netip';
@@ -64,6 +64,25 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
             setSubmitting(false);
         }
     };
+
+    // Keep a ref so the keydown handler always sees the latest canSubmit/handleApply
+    // without re-registering on every render (react-compiler safe).
+    const submitRef = useRef({ canSubmit, apply: handleApply });
+    submitRef.current = { canSubmit, apply: handleApply };
+
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: KeyboardEvent): void => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+                e.preventDefault();
+                if (submitRef.current.canSubmit) {
+                    void submitRef.current.apply();
+                }
+            }
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [open]);
 
     const title = mode === 'add' ? 'Add route' : 'Edit route';
 

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
-import { Plus } from '@gravity-ui/icons';
+import { ArrowRightToLine, Funnel, Magnifier, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { AddConfigModal, BulkDeleteModal } from '../../_shared/draft';
 import { API } from '../../../api';
@@ -10,9 +10,12 @@ import { RouteSourceID, type Route } from '../../../api/routes';
 import { useRIB } from './useRIB';
 import { RIBTable } from './RIBTable';
 import RouteDrawer from './RouteDrawer';
-import { getRouteId, sortComparators, planRouteSubmit } from './utils';
-import type { RouteSortState, RouteSortableColumn } from './types';
+import CommandPalette from './CommandPalette';
+import LookupDrawer from './LookupDrawer';
+import { getRouteId, sortComparators, planRouteSubmit, groupByPrefix, filterByFamily } from './utils';
+import type { RouteSortState, RouteSortableColumn, IPFamily } from './types';
 import '../../../styles/draft-page.scss';
+import './route.scss';
 
 const RoutePage: React.FC = () => {
     const { configs, configRoutes, selectedIds, loading, reload, addLocalConfig, setSelected } = useRIB();
@@ -27,20 +30,49 @@ const RoutePage: React.FC = () => {
     });
     const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
     const [addConfigOpen, setAddConfigOpen] = useState(false);
-    const [activeRowId, setActiveRowId] = useState<string | null>(null);
-    const [editingRowId, setEditingRowId] = useState<string | null>(null);
     const [rowDeleteConfirm, setRowDeleteConfirm] = useState<{ open: boolean; route: Route | null }>({
         open: false,
         route: null,
     });
 
+    const [paletteOpen, setPaletteOpen] = useState(false);
+    const [lookupOpen, setLookupOpen] = useState(false);
+    const [lookupInitialQuery, setLookupInitialQuery] = useState('');
+    const [family, setFamily] = useState<IPFamily>('all');
+    const [bestOnly, setBestOnly] = useState(false);
+    const [conflictsOnly, setConflictsOnly] = useState(false);
+    const [flashRowId, setFlashRowId] = useState<string | null>(null);
 
     const currentConfig = activeConfig || configs[0] || '';
     const allRows = configRoutes.get(currentConfig) || [];
     const currentSelected = selectedIds.get(currentConfig) || new Set<string>();
 
+    const conflictMap = useMemo((): Map<string, number> => {
+        const groups = groupByPrefix(allRows);
+        const m = new Map<string, number>();
+        groups.forEach((group, prefix) => m.set(prefix, group.length));
+        return m;
+    }, [allRows]);
+
+    const conflictCount = useMemo((): number => {
+        let count = 0;
+        conflictMap.forEach((n) => { if (n > 1) count++; });
+        return count;
+    }, [conflictMap]);
+
     const visibleRows = useMemo(() => {
         let res = allRows;
+
+        res = filterByFamily(res, family);
+
+        if (bestOnly) {
+            res = res.filter((r) => r.is_best === true);
+        }
+
+        if (conflictsOnly) {
+            res = res.filter((r) => (conflictMap.get(r.prefix || '') ?? 1) > 1);
+        }
+
         const q = search.trim().toLowerCase();
         if (q) {
             res = res.filter((r) =>
@@ -54,7 +86,7 @@ const RoutePage: React.FC = () => {
             res = [...res].sort(sortState.direction === 'desc' ? (a, b) => cmp(b, a) : cmp);
         }
         return res;
-    }, [allRows, search, sortState]);
+    }, [allRows, search, sortState, family, bestOnly, conflictsOnly, conflictMap]);
 
     const counts = useMemo((): Map<string, number> => {
         const m = new Map<string, number>();
@@ -62,11 +94,36 @@ const RoutePage: React.FC = () => {
         return m;
     }, [configs, configRoutes]);
 
+    useEffect(() => {
+        if (!paletteOpen) return;
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape') setPaletteOpen(false);
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [paletteOpen]);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+                e.preventDefault();
+                setPaletteOpen((prev) => !prev);
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, []);
+
     const handleSort = useCallback((col: RouteSortableColumn): void => {
-        setSortState((prev) => ({
-            column: col,
-            direction: prev.column === col && prev.direction === 'asc' ? 'desc' : 'asc',
-        }));
+        setSortState((prev) => {
+            if (prev.column !== col) {
+                return { column: col, direction: 'asc' };
+            }
+            if (prev.direction === 'asc') {
+                return { column: col, direction: 'desc' };
+            }
+            return { column: null, direction: 'asc' };
+        });
     }, []);
 
     const openAdd = useCallback((): void => {
@@ -76,17 +133,10 @@ const RoutePage: React.FC = () => {
     const handleEditRow = useCallback((id: string): void => {
         const route = allRows.find((r) => getRouteId(r) === id) || null;
         setDrawer({ open: true, mode: 'edit', route });
-        setActiveRowId(id);
-        setEditingRowId(id);
     }, [allRows]);
 
     const handleCloseDrawer = useCallback((): void => {
         setDrawer((prev) => ({ ...prev, open: false }));
-        setEditingRowId(null);
-    }, []);
-
-    const handleRowClick = useCallback((id: string): void => {
-        setActiveRowId(id);
     }, []);
 
     const handleSubmitRoute = useCallback(async (params: { prefix: string; nexthopAddr: string; doFlush: boolean }): Promise<void> => {
@@ -214,18 +264,47 @@ const RoutePage: React.FC = () => {
         }
     }, [allRows, currentSelected, currentConfig, reload, setSelected]);
 
+    const handleLookupIP = useCallback((ip: string): void => {
+        setLookupInitialQuery(ip);
+        setLookupOpen(true);
+    }, []);
+
+    const handleShowInTable = useCallback((prefix: string): void => {
+        const matchedRow = allRows.find((r) => r.prefix === prefix);
+        if (matchedRow) {
+            const id = getRouteId(matchedRow);
+            setFlashRowId(null);
+            setTimeout(() => setFlashRowId(id), 0);
+        }
+    }, [allRows]);
+
+    const handleClearFilters = useCallback((): void => {
+        setFamily('all');
+        setBestOnly(false);
+        setConflictsOnly(false);
+        setSearch('');
+    }, []);
+
+    const handleJumpToRow = useCallback((id: string): void => {
+        setFlashRowId(null);
+        setTimeout(() => setFlashRowId(id), 0);
+    }, []);
+
     const pageHeader = (
         <Flex alignItems="center" gap={4} style={{ width: '100%' }}>
             <Text variant="header-1">Routing Table</Text>
-            <Flex grow />
-            <div style={{ flexBasis: 380, flexShrink: 1 }}>
-                <SearchInput
-                    value={search}
-                    onUpdate={setSearch}
-                    placeholder="Search prefix, nexthop or peer…"
-                />
-            </div>
+            <button
+                type="button"
+                className="ro-search-btn"
+                onClick={() => setPaletteOpen(true)}
+                title="Open command palette (⌘K)"
+            >
+                <Icon data={Magnifier} size={16} />
+                <span className="ro-search-placeholder">Search or look up an IP…</span>
+                <kbd className="ro-kbd">⌘K</kbd>
+            </button>
             <Button view="outlined" onClick={handleFlush} disabled={!currentConfig}>
+                <Icon data={ArrowRightToLine} size={16} />
                 Flush RIB → FIB
             </Button>
             <Button view="action" onClick={openAdd} disabled={configs.length === 0}>
@@ -237,15 +316,15 @@ const RoutePage: React.FC = () => {
 
     if (loading) {
         return (
-            <PageLayout header={pageHeader}>
+            <PageLayout header={pageHeader} className="ro-layout">
                 <PageLoader loading size="l" />
             </PageLayout>
         );
     }
 
     return (
-        <PageLayout header={pageHeader}>
-            <div className="fw-page">
+        <PageLayout header={pageHeader} className="ro-layout">
+            <div className="fw-page ro-page">
                 {configs.length === 0 ? (
                     <div className="fw-empty-page">
                         <div className="fw-empty-page__message">No route configurations found.</div>
@@ -260,24 +339,78 @@ const RoutePage: React.FC = () => {
                             dirtyConfigs={new Set()}
                             onSelect={(c) => {
                                 setActiveConfig(c);
-                                setActiveRowId(null);
-                                setEditingRowId(null);
                             }}
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
+                        <div className="ro-toolbar">
+                            <div className="ro-seg">
+                                {(['all', 'v4', 'v6'] as IPFamily[]).map((f) => (
+                                    <button
+                                        key={f}
+                                        type="button"
+                                        className={`ro-seg__btn${family === f ? ' ro-seg__btn--active' : ''}`}
+                                        onClick={() => setFamily(f)}
+                                    >
+                                        {f === 'all' ? 'All' : f === 'v4' ? 'IPv4' : 'IPv6'}
+                                    </button>
+                                ))}
+                            </div>
+                            <button
+                                type="button"
+                                className={`ro-chip ro-chip--best${bestOnly ? ' ro-chip--active' : ''}`}
+                                onClick={() => setBestOnly((v) => !v)}
+                                title="Show only the best route for each prefix"
+                            >
+                                <svg width={13} height={13} viewBox="0 0 24 24" fill={bestOnly ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+                                    <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8Z" />
+                                </svg>
+                                Best only
+                            </button>
+                            <button
+                                type="button"
+                                className={`ro-chip ro-chip--conflict${conflictsOnly ? ' ro-chip--active' : ''}`}
+                                onClick={() => setConflictsOnly((v) => !v)}
+                                title="Show only prefixes with multiple candidate routes"
+                            >
+                                <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+                                    <path d="M6 3v12" />
+                                    <path d="M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
+                                    <path d="M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
+                                    <path d="M15 6a9 9 0 0 1-9 9" />
+                                </svg>
+                                Conflicts
+                                {conflictCount > 0 && (
+                                    <span className="ro-chip__badge">{conflictCount}</span>
+                                )}
+                            </button>
+                            <div style={{ flex: 1 }} />
+                            <div style={{ flexBasis: 230, flexShrink: 1 }}>
+                                <SearchInput
+                                    value={search}
+                                    onUpdate={setSearch}
+                                    placeholder="Filter rows…"
+                                    enableFocusShortcut={false}
+                                    showShortcutHint={false}
+                                    icon={Funnel}
+                                />
+                            </div>
+                            <span className="ro-count">
+                                <span style={{ color: 'var(--fw-text)', fontWeight: 600 }}>{visibleRows.length.toLocaleString()}</span>
+                                {' / '}{allRows.length.toLocaleString()}
+                            </span>
+                        </div>
                         <div className="fw-content">
                             <RIBTable
                                 rows={visibleRows}
                                 selectedIds={currentSelected}
-                                activeRowId={activeRowId}
-                                editingRowId={editingRowId}
                                 sortState={sortState}
                                 onSort={handleSort}
-                                onRowClick={handleRowClick}
                                 onEditRow={handleEditRow}
                                 onSelectionChange={(ids) => setSelected(currentConfig, ids)}
-                                emptyMessage={search ? 'No routes match your search.' : 'No routes.'}
+                                emptyMessage={search || family !== 'all' || bestOnly || conflictsOnly ? 'No routes match the current filters.' : 'No routes.'}
                                 onDeleteRow={handleDeleteRowRequest}
+                                conflictMap={conflictMap}
+                                flashRowId={flashRowId}
                             />
                         </div>
                     </>
@@ -334,6 +467,30 @@ const RoutePage: React.FC = () => {
                     placeholder="e.g. route0"
                     existingNames={configs}
                 />
+
+                <CommandPalette
+                    open={paletteOpen}
+                    onClose={() => setPaletteOpen(false)}
+                    rows={allRows}
+                    onLookupIP={handleLookupIP}
+                    onAddRoute={openAdd}
+                    onFlush={handleFlush}
+                    onOpenLookup={() => { setLookupInitialQuery(''); setLookupOpen(true); }}
+                    onSetFamily={setFamily}
+                    onToggleBestOnly={() => setBestOnly((v) => !v)}
+                    onToggleConflicts={() => setConflictsOnly((v) => !v)}
+                    onClearFilters={handleClearFilters}
+                    onJumpToRow={handleJumpToRow}
+                />
+
+                <LookupDrawer
+                    open={lookupOpen}
+                    configName={currentConfig}
+                    initialQuery={lookupInitialQuery}
+                    onClose={() => setLookupOpen(false)}
+                    onShowInTable={handleShowInTable}
+                />
+
             </div>
         </PageLayout>
     );

--- a/web/src/pages/operators/route/cells.tsx
+++ b/web/src/pages/operators/route/cells.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { ROUTE_SOURCES } from './utils';
+
+/** Inline checkmark SVG for the Best column. */
+const CheckIcon: React.FC = () => (
+    <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.4} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+        <path d="M20 6 9 17l-5-5" />
+    </svg>
+);
+
+/** Green "Best" indicator shown in the Best column for the best route. */
+export const BestPill: React.FC<{ isBest: boolean }> = ({ isBest }) => {
+    if (!isBest) {
+        return <span style={{ color: 'var(--fw-text-3)', fontSize: 12.5 }}>—</span>;
+    }
+    return (
+        <span
+            style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 5,
+                fontSize: 12.5,
+                fontWeight: 600,
+                color: 'var(--g-color-text-positive)',
+                whiteSpace: 'nowrap',
+            }}
+        >
+            <CheckIcon /> Best
+        </span>
+    );
+};
+
+/** Source chip: BIRD in blue, Static in amber, Unknown muted — with leading colored dot. */
+export const SourceChip: React.FC<{ source: number | undefined }> = ({ source }) => {
+    const label = source !== undefined ? (ROUTE_SOURCES[source] ?? '::') : '—';
+    if (label === 'BIRD') {
+        return (
+            <span
+                style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '2px 9px 2px 7px',
+                    borderRadius: 999,
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    letterSpacing: '0.02em',
+                    color: 'var(--g-color-text-info)',
+                    background: 'color-mix(in srgb, var(--g-color-text-info) 12%, transparent)',
+                    whiteSpace: 'nowrap',
+                    fontFamily: 'var(--fw-font-mono)',
+                }}
+            >
+                <span style={{ width: 5, height: 5, borderRadius: 999, background: 'var(--g-color-text-info)', flexShrink: 0 }} />
+                {label}
+            </span>
+        );
+    }
+    if (label === 'Static') {
+        return (
+            <span
+                style={{
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 6,
+                    padding: '2px 9px 2px 7px',
+                    borderRadius: 999,
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    letterSpacing: '0.02em',
+                    color: 'var(--fw-accent)',
+                    background: 'var(--fw-accent-soft)',
+                    whiteSpace: 'nowrap',
+                    fontFamily: 'var(--fw-font-mono)',
+                }}
+            >
+                <span style={{ width: 5, height: 5, borderRadius: 999, background: 'var(--fw-accent)', flexShrink: 0 }} />
+                {label}
+            </span>
+        );
+    }
+    return <span style={{ color: 'var(--fw-text-3)', fontFamily: 'var(--fw-font-mono)' }}>—</span>;
+};
+
+/** Small v4/v6 family badge derived from the prefix string. */
+export const FamilyBadge: React.FC<{ prefix: string }> = ({ prefix }) => {
+    const isV6 = prefix.includes(':');
+    return (
+        <span
+            style={{
+                display: 'inline-block',
+                fontSize: 9.5,
+                fontWeight: 700,
+                fontFamily: 'var(--fw-font-mono)',
+                color: isV6 ? 'var(--g-color-text-info)' : 'var(--g-color-text-warning)',
+                opacity: 0.8,
+                width: 16,
+                flexShrink: 0,
+                whiteSpace: 'nowrap',
+            }}
+        >
+            {isV6 ? 'v6' : 'v4'}
+        </span>
+    );
+};
+
+/** Badge shown when a prefix has multiple candidate routes. */
+export const ConflictBadge: React.FC<{ count: number }> = ({ count }) => {
+    if (count <= 1) return null;
+    return (
+        <span
+            style={{
+                display: 'inline-block',
+                padding: '1px 6px',
+                borderRadius: 999,
+                fontSize: 10.5,
+                fontFamily: 'var(--fw-font-mono)',
+                fontWeight: 700,
+                color: 'var(--fw-accent)',
+                background: 'var(--fw-accent-soft)',
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+            }}
+            title={`${count} candidate routes for this prefix`}
+        >
+            ×{count}
+        </span>
+    );
+};

--- a/web/src/pages/operators/route/route.scss
+++ b/web/src/pages/operators/route/route.scss
@@ -1,0 +1,616 @@
+@use '../../../styles/variables' as *;
+@use '../../../styles/mixins' as *;
+
+// Route Operator page – ro-* class prefix.
+// All colors use existing --fw-* tokens or Gravity --g-color-* tokens.
+// No raw oklch/hex values from the prototype.
+
+// ─── Toolbar ─────────────────────────────────────────────────────────────────
+
+.ro-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 20px;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+    border-bottom: 1px solid var(--fw-line);
+}
+
+.ro-toolbar__right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: auto;
+}
+
+// ─── Segmented family filter ──────────────────────────────────────────────────
+
+.ro-seg {
+    display: inline-flex;
+    align-items: center;
+    background: var(--fw-bg-2);
+    border-radius: var(--fw-r-md);
+    padding: 3px;
+    gap: 2px;
+    box-shadow: inset 0 0 0 1px var(--fw-line-2);
+    flex-shrink: 0;
+}
+
+.ro-seg__btn {
+    height: 26px;
+    padding: 0 12px;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--fw-text-2);
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.12s;
+    white-space: nowrap;
+
+    &:hover:not(.ro-seg__btn--active) {
+        background: var(--fw-bg-3);
+        color: var(--fw-text);
+    }
+
+    &--active {
+        background: var(--fw-accent);
+        color: var(--fw-bg-3);
+        font-weight: 600;
+
+        &:hover {
+            background: var(--fw-accent);
+            color: var(--fw-bg-3);
+        }
+    }
+}
+
+// ─── Toggle chips ─────────────────────────────────────────────────────────────
+
+.ro-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 12px;
+    border-radius: var(--fw-r-md);
+    border: none;
+    box-shadow: inset 0 0 0 1px var(--fw-line-2);
+    background: var(--fw-bg-2);
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--fw-text-2);
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, box-shadow 0.12s;
+    white-space: nowrap;
+    flex-shrink: 0;
+
+    &:hover {
+        background: var(--fw-bg-2);
+        color: var(--fw-text);
+    }
+
+    &--best.ro-chip--active {
+        background: color-mix(in srgb, var(--g-color-text-positive) 14%, transparent);
+        color: var(--g-color-text-positive);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--g-color-text-positive) 30%, transparent);
+    }
+
+    &--conflict.ro-chip--active {
+        background: var(--fw-accent-soft);
+        color: var(--fw-accent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fw-accent) 30%, transparent);
+    }
+}
+
+.ro-chip__badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 700;
+    opacity: 0.8;
+    font-family: var(--fw-font-mono);
+    font-variant-numeric: tabular-nums;
+}
+
+// ─── Search kbd button ────────────────────────────────────────────────────────
+
+.ro-search-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    max-width: 520px;
+    min-width: 0;
+    margin: 0 auto;
+    height: 40px;
+    padding: 0 14px;
+    border-radius: var(--fw-r-md, 6px);
+    // .ro-search-btn sits in the page header, outside .fw-page where --fw-*
+    // tokens are defined, so each property includes a hard-coded fallback that
+    // matches the token value from draft-page.scss.
+    border: 1px solid color-mix(in srgb, var(--fw-text-3, #7E7468) 55%, transparent);
+    background: var(--fw-bg-3, oklch(0.212 0.01 56));
+    font-size: 13.5px;
+    color: var(--fw-text-3, #7E7468);
+    cursor: text;
+    transition: border-color 0.08s, color 0.08s;
+
+    &:hover {
+        border-color: var(--fw-text-3, #7E7468);
+        color: var(--fw-text-2, #B8B0A4);
+    }
+}
+
+.ro-search-placeholder {
+    flex: 1;
+    text-align: left;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ro-kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 20px;
+    padding: 0 6px;
+    border-radius: 4px;
+    font-size: 12.5px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: var(--fw-text-3, #7e7468);
+    background: var(--fw-bg-2, #1a1410);
+    border: 1px solid var(--fw-line-2, rgba(120, 108, 96, 0.28));
+    font-family: var(--fw-font-mono);
+    line-height: 1;
+}
+
+// ─── Row count ────────────────────────────────────────────────────────────────
+
+.ro-count {
+    font-size: 12.5px;
+    color: var(--fw-text-3);
+    white-space: nowrap;
+    flex-shrink: 0;
+    font-family: var(--fw-font-mono);
+    font-variant-numeric: tabular-nums;
+}
+
+// ─── Command palette ──────────────────────────────────────────────────────────
+
+.ro-palette-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.52);
+    backdrop-filter: blur(3px);
+    z-index: 200;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding-top: 16vh;
+}
+
+.ro-palette-card {
+    width: 580px;
+    max-width: calc(100vw - 40px);
+    background: var(--fw-panel);
+    border: 1px solid var(--fw-line-2);
+    border-radius: var(--fw-r-lg);
+    box-shadow: 0 24px 72px rgba(0, 0, 0, 0.65);
+    overflow: hidden;
+    animation: ro-palette-popin 0.14s ease-out both;
+}
+
+@keyframes ro-palette-popin {
+    from { opacity: 0; transform: translateY(6px) scale(0.985); }
+    to   { opacity: 1; transform: none; }
+}
+
+.ro-palette-input-row {
+    display: flex;
+    align-items: center;
+    padding: 0 14px;
+    border-bottom: 1px solid var(--fw-line-2);
+    height: 52px;
+    gap: 10px;
+}
+
+.ro-palette-search-icon {
+    font-size: 16px;
+    color: var(--fw-accent);
+    flex-shrink: 0;
+    font-family: var(--fw-font-mono);
+}
+
+.ro-palette-input {
+    flex: 1;
+    background: none;
+    border: none;
+    outline: none;
+    font-size: 15px;
+    color: var(--fw-text);
+    font-family: var(--fw-font-mono);
+
+    &::placeholder {
+        color: var(--fw-text-3);
+        font-family: inherit;
+    }
+}
+
+.ro-palette-esc-hint {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    height: 18px;
+    padding: 0 6px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--fw-text-3);
+    background: var(--fw-bg-2);
+    border: 1px solid var(--fw-line-2);
+    font-family: var(--fw-font-mono);
+}
+
+.ro-palette-list {
+    max-height: 340px;
+    overflow-y: auto;
+    padding: 6px;
+}
+
+.ro-palette-item {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 9px 10px;
+    border-radius: var(--fw-r-md);
+    border: none;
+    background: none;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.06s;
+
+    &--active {
+        background: var(--fw-accent-soft);
+
+        .ro-palette-item__icon { color: var(--fw-accent); }
+        .ro-palette-item__label { color: var(--fw-text); }
+    }
+}
+
+.ro-palette-item__icon {
+    width: 26px;
+    height: 26px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--fw-r-sm);
+    font-size: 13px;
+    color: var(--fw-text-3);
+    background: var(--fw-bg-2);
+    border: 1px solid var(--fw-line-2);
+    flex-shrink: 0;
+    font-family: var(--fw-font-mono);
+}
+
+.ro-palette-item__body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.ro-palette-item__label {
+    font-size: 13px;
+    color: var(--fw-text-2);
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ro-palette-item__sub {
+    font-size: 11px;
+    color: var(--fw-text-3);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.ro-palette-item__enter {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    height: 18px;
+    padding: 0 5px;
+    border-radius: 4px;
+    font-size: 11px;
+    color: var(--fw-accent);
+    background: var(--fw-accent-soft);
+    border: 1px solid rgba(255, 192, 97, 0.3);
+    font-family: var(--fw-font-mono);
+}
+
+.ro-palette-empty {
+    padding: 20px;
+    text-align: center;
+    font-size: 13px;
+    color: var(--fw-text-3);
+}
+
+// ─── Lookup drawer ─────────────────────────────────────────────────────────────
+
+.ro-lookup-drawer {
+    width: 680px;
+}
+
+.ro-lookup-input-row {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+
+    .fw-input { flex: 1; }
+}
+
+.ro-lookup-examples {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.ro-lookup-examples__label {
+    font-size: 11px;
+    color: var(--fw-text-3);
+    flex-shrink: 0;
+}
+
+.ro-lookup-example-chip {
+    display: inline-flex;
+    align-items: center;
+    height: 24px;
+    padding: 0 10px;
+    border-radius: 999px;
+    font-size: 11.5px;
+    font-family: var(--fw-font-mono);
+    color: var(--fw-text-2);
+    background: var(--fw-bg-2);
+    border: 1px solid var(--fw-line-2);
+    cursor: pointer;
+    transition: background 0.08s, color 0.08s;
+    white-space: nowrap;
+
+    &:hover {
+        background: var(--fw-accent-soft);
+        color: var(--fw-accent);
+        border-color: rgba(255, 192, 97, 0.3);
+    }
+}
+
+.ro-lookup-loading {
+    padding: 24px;
+    text-align: center;
+    color: var(--fw-text-3);
+    font-size: 13px;
+}
+
+.ro-lookup-result {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.ro-lookup-result__matched {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    border-radius: var(--fw-r-md);
+    background: var(--fw-bg-2);
+    border: 1px solid var(--fw-line-2);
+}
+
+.ro-lookup-result__label {
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--fw-text-3);
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.ro-lookup-result__prefix {
+    font-family: var(--fw-font-mono);
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--fw-text);
+    flex: 1;
+}
+
+.ro-lookup-show-in-table {
+    font-size: 12px;
+    color: var(--fw-accent);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0;
+    flex-shrink: 0;
+    transition: opacity 0.1s;
+
+    &:hover { opacity: 0.75; }
+}
+
+.ro-lookup-reason {
+    font-size: 12px;
+    color: var(--fw-text-3);
+    padding: 7px 12px;
+    background: var(--fw-accent-soft);
+    border: 1px solid rgba(255, 192, 97, 0.22);
+    border-radius: var(--fw-r-sm);
+
+    &::before {
+        content: '★ ';
+        color: var(--fw-accent);
+    }
+}
+
+.ro-lookup-table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--fw-line-2);
+    border-radius: var(--fw-r-md);
+}
+
+// Column widths — shared by th and td via table-layout: fixed.
+// Track order: marker | prefix | next-hop | peer | source | peer-as | origin | pref | med | communities
+// Drawer body inner width = 680px drawer − 40px body-padding − 2px wrap-border = 638px usable.
+// Fixed cols sum: 28+100+86+64+64+68+56+44+42 = 552px; remaining ~86px goes to communities.
+// "COMMUNITIES" header at 9.5px uppercase needs ~85px — this keeps it just inside clientWidth.
+$_ro-col-marker:  28px;
+$_ro-col-prefix:  100px;
+$_ro-col-nexthop:  86px;
+$_ro-col-peer:     64px;
+$_ro-col-source:   64px;
+$_ro-col-peeras:   68px;
+$_ro-col-origin:   56px;
+$_ro-col-pref:     44px;
+$_ro-col-med:      42px;
+// Communities column (#10) has no explicit width so it auto-fills remaining space.
+
+.ro-lookup-table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+    font-size: 12.5px;
+
+    // Explicit column widths — header and body share these via table-layout: fixed.
+    th:nth-child(1), td:nth-child(1) { width: $_ro-col-marker;  }
+    th:nth-child(2), td:nth-child(2) { width: $_ro-col-prefix;  }
+    th:nth-child(3), td:nth-child(3) { width: $_ro-col-nexthop; }
+    th:nth-child(4), td:nth-child(4) { width: $_ro-col-peer;    }
+    th:nth-child(5), td:nth-child(5) { width: $_ro-col-source;  }
+    th:nth-child(6), td:nth-child(6) { width: $_ro-col-peeras;  }
+    th:nth-child(7), td:nth-child(7) { width: $_ro-col-origin;  }
+    th:nth-child(8), td:nth-child(8) { width: $_ro-col-pref;    }
+    th:nth-child(9), td:nth-child(9) { width: $_ro-col-med;     }
+    // Communities — last column, no explicit width so it fills remaining space.
+
+    th {
+        padding: 6px 8px;
+        text-align: left;
+        font-size: 9.5px;
+        font-weight: 700;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+        color: var(--fw-text-3);
+        background: var(--fw-bg-2);
+        border-bottom: 1px solid var(--fw-line-2);
+        white-space: nowrap;
+        // No overflow:hidden or text-overflow:ellipsis on headers — labels must
+        // always be fully visible. Only body td values truncate.
+        overflow: visible;
+    }
+
+    td {
+        // Restore table-cell display in case a .fw-cell-mono class (display:inline-block)
+        // is applied directly to the <td> element — table-layout:fixed still sizes the
+        // column from the <th> width, but we want content to flow normally inside.
+        display: table-cell;
+        padding: 8px 8px;
+        border-bottom: 1px solid var(--fw-line-2);
+        vertical-align: middle;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    tr:last-child td { border-bottom: none; }
+
+    &__best-row td {
+        background: color-mix(in srgb, var(--g-color-text-positive) 7%, transparent);
+    }
+}
+
+.ro-lookup-communities {
+    font-family: var(--fw-font-mono);
+    font-size: 11px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    // max-width is removed — the column width is governed by table-layout:fixed.
+}
+
+.ro-lookup-no-match {
+    padding: 24px;
+    text-align: center;
+    color: var(--fw-text-3);
+    font-size: 13px;
+}
+
+// ─── Surface color — single control point for the whole route page ───────────
+
+// Flip to #15110D for the flat (page-bg) look; #1C1814 for the panel look.
+.ro-layout {
+    --ro-surface-bg: #1C1814;
+}
+
+// Header sits outside .fw-page so --fw-* tokens are not in scope there.
+// --ro-surface-bg is defined on .ro-layout and cascades to both subtrees.
+.ro-layout .page-layout__header {
+    background: var(--ro-surface-bg);
+}
+
+// Two-class specificity beats the `.fw-page { background: var(--fw-page-bg) }` rule.
+.fw-page.ro-page {
+    background: var(--ro-surface-bg);
+}
+
+.ro-page .fw-tabs {
+    background: var(--ro-surface-bg);
+    border-bottom: none;
+}
+
+.ro-page .fw-tab--active::after {
+    height: 3px;
+}
+
+// ─── Route-page scoped overrides (.ro-page modifier on .fw-page) ─────────────
+
+// Gold count badge on the active config tab, scoped to route only.
+// The shared rule in draft-page.scss scopes gold badges to .fw-tabs-row only
+// (neighbours). This rule targets the route page root without touching that.
+.ro-page .fw-tab--active .fw-tab__count {
+    color: var(--fw-accent);
+    background: var(--fw-accent-soft);
+}
+
+// Table flush: no outer padding and no card chrome.
+// Keeps per-row separators and the header bottom border.
+.ro-page .fw-content {
+    padding: 0;
+}
+
+.ro-page .fw-tbl-wrap {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+}
+
+.ro-page .fw-tbl-header-row {
+    background: transparent;
+    border-top: 1px solid var(--fw-line-2);
+}
+
+.ro-page .fw-vtbl-footer {
+    background: transparent;
+}
+

--- a/web/src/pages/operators/route/types.ts
+++ b/web/src/pages/operators/route/types.ts
@@ -1,5 +1,6 @@
 export type RouteSortableColumn = 'prefix' | 'next_hop' | 'peer' | 'is_best' | 'pref' | 'as_path_len' | 'source';
 export type SortDirection = 'asc' | 'desc';
+export type IPFamily = 'all' | 'v4' | 'v6';
 
 export interface RouteSortState {
     column: RouteSortableColumn | null;

--- a/web/src/pages/operators/route/utils.test.ts
+++ b/web/src/pages/operators/route/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { planRouteSubmit, validatePrefix, validateNexthop, sortComparators } from './utils';
+import { planRouteSubmit, validatePrefix, validateNexthop, sortComparators, prefixIPFamily, groupByPrefix, filterByFamily, bestPathReason, getRouteId } from './utils';
 import { stringToIPAddress } from '../../../utils/netip';
 import type { Route } from '../../../api/routes';
 
@@ -197,5 +197,151 @@ describe('sortComparators', () => {
         const a = makeRoute({ is_best: false });
         const b = makeRoute({ is_best: true });
         expect(sortComparators.is_best(a, b)).toBeLessThan(0);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// prefixIPFamily
+// ---------------------------------------------------------------------------
+
+describe('prefixIPFamily', () => {
+    it('returns v6 for IPv6 prefix', () => {
+        expect(prefixIPFamily('::/0')).toBe('v6');
+        expect(prefixIPFamily('2001:db8::/32')).toBe('v6');
+    });
+
+    it('returns v4 for IPv4 prefix', () => {
+        expect(prefixIPFamily('0.0.0.0/0')).toBe('v4');
+        expect(prefixIPFamily('192.168.1.0/24')).toBe('v4');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// groupByPrefix
+// ---------------------------------------------------------------------------
+
+describe('groupByPrefix', () => {
+    it('groups routes with the same prefix together', () => {
+        const routes: Route[] = [
+            { prefix: '10.0.0.0/8' },
+            { prefix: '::/0' },
+            { prefix: '10.0.0.0/8' },
+        ];
+        const m = groupByPrefix(routes);
+        expect(m.get('10.0.0.0/8')).toHaveLength(2);
+        expect(m.get('::/0')).toHaveLength(1);
+    });
+
+    it('returns empty map for empty input', () => {
+        expect(groupByPrefix([])).toEqual(new Map());
+    });
+});
+
+// ---------------------------------------------------------------------------
+// filterByFamily
+// ---------------------------------------------------------------------------
+
+describe('filterByFamily', () => {
+    const routes: Route[] = [
+        { prefix: '::/0' },
+        { prefix: '0.0.0.0/0' },
+        { prefix: '2001:db8::/32' },
+    ];
+
+    it('returns all routes for family "all"', () => {
+        expect(filterByFamily(routes, 'all')).toHaveLength(3);
+    });
+
+    it('returns only IPv6 routes for family "v6"', () => {
+        const v6 = filterByFamily(routes, 'v6');
+        expect(v6).toHaveLength(2);
+        expect(v6.every((r) => r.prefix?.includes(':'))).toBe(true);
+    });
+
+    it('returns only IPv4 routes for family "v4"', () => {
+        const v4 = filterByFamily(routes, 'v4');
+        expect(v4).toHaveLength(1);
+        expect(v4[0].prefix).toBe('0.0.0.0/0');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// bestPathReason
+// ---------------------------------------------------------------------------
+
+describe('bestPathReason', () => {
+    it('returns empty string for fewer than two candidates', () => {
+        expect(bestPathReason([])).toBe('');
+        expect(bestPathReason([{ pref: 100 }])).toBe('');
+    });
+
+    it('reports higher Local Pref as the deciding factor', () => {
+        const best: Route = { pref: 100 };
+        const other: Route = { pref: 0 };
+        expect(bestPathReason([best, other])).toMatch(/Local Pref/);
+        expect(bestPathReason([best, other])).toContain('100');
+    });
+
+    it('reports shorter AS path when prefs are equal', () => {
+        const best: Route = { pref: 100, as_path_len: 2 };
+        const other: Route = { pref: 100, as_path_len: 4 };
+        expect(bestPathReason([best, other])).toMatch(/AS path/);
+    });
+
+    it('reports lower MED when pref and as_path_len are equal', () => {
+        const best: Route = { pref: 100, as_path_len: 2, med: 0 };
+        const other: Route = { pref: 100, as_path_len: 2, med: 50 };
+        expect(bestPathReason([best, other])).toMatch(/MED/);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// getRouteId
+// ---------------------------------------------------------------------------
+
+describe('getRouteId', () => {
+    const base: Route = {
+        prefix: '::/0',
+        next_hop: { addr: 'fe80::a1a' },
+        peer: { addr: '::' },
+        route_distinguisher: '',
+        pref: 100,
+        peer_as: 65000,
+        origin_as: 65001,
+        med: 0,
+        as_path_len: 2,
+    };
+
+    it('produces a stable id for a basic route', () => {
+        const id = getRouteId(base);
+        // Format: prefix_nextHop_peer_rd_source_pref_peerAs_originAs_med_asPathLen
+        expect(id).toBe('::/0_fe80::a1a_::__0_100_65000_65001_0_2');
+        expect(getRouteId(base)).toBe(id);
+    });
+
+    it('BIRD vs Static: same prefix/next_hop/peer but different source yields different ids', () => {
+        const bird: Route = { ...base, source: 2 };   // RouteSourceID.BIRD
+        const staticRoute: Route = { ...base, source: 1 }; // RouteSourceID.STATIC
+        expect(getRouteId(bird)).not.toBe(getRouteId(staticRoute));
+    });
+
+    it('different pref yields different ids', () => {
+        const a: Route = { ...base, pref: 100 };
+        const b: Route = { ...base, pref: 200 };
+        expect(getRouteId(a)).not.toBe(getRouteId(b));
+    });
+
+    it('different peer_as yields different ids', () => {
+        const a: Route = { ...base, peer_as: 65000 };
+        const b: Route = { ...base, peer_as: 65001 };
+        expect(getRouteId(a)).not.toBe(getRouteId(b));
+    });
+
+    it('missing optional fields fall back to 0 or empty string, not "undefined"', () => {
+        const minimal: Route = { prefix: '10.0.0.0/8' };
+        const id = getRouteId(minimal);
+        expect(id).not.toContain('undefined');
+        // next_hop.addr='' peer.addr='' rd='' source=0 pref=0 peerAs=0 originAs=0 med=0 asPathLen=0
+        expect(id).toBe('10.0.0.0/8____0_0_0_0_0_0');
     });
 });

--- a/web/src/pages/operators/route/utils.ts
+++ b/web/src/pages/operators/route/utils.ts
@@ -1,7 +1,7 @@
 import type { Route } from '../../../api/routes';
 import { parseCIDRPrefix, parseIPAddress, CIDRParseError, IPParseError } from '../../../utils';
 import { ipAddressToString, type IPAddressWire } from '../../../utils/netip';
-import type { RouteSortableColumn } from './types';
+import type { RouteSortableColumn, IPFamily } from './types';
 
 export interface RouteSubmitParams {
     prefix: string;
@@ -38,7 +38,7 @@ export const ROUTE_SOURCES = ['Unknown', 'Static', 'BIRD'] as const;
 
 /** Returns a stable string key for a route row. */
 export const getRouteId = (route: Route): string =>
-    `${route.prefix || ''}_${String(route.next_hop?.addr || '')}_${String(route.peer?.addr || '')}_${route.route_distinguisher || ''}`;
+    `${route.prefix ?? ''}_${String(route.next_hop?.addr ?? '')}_${String(route.peer?.addr ?? '')}_${route.route_distinguisher ?? ''}_${route.source ?? 0}_${route.pref ?? 0}_${route.peer_as ?? 0}_${route.origin_as ?? 0}_${route.med ?? 0}_${route.as_path_len ?? 0}`;
 
 /** Validates a CIDR prefix string. Returns an error message or undefined when valid. */
 export const validatePrefix = (prefix: string): string | undefined => {
@@ -80,6 +80,72 @@ export const validateNexthop = (nexthop: string): string | undefined => {
         }
     }
     return undefined;
+};
+
+/** Returns the IP family of a prefix string. Detects ':' for IPv6, else IPv4. */
+export const prefixIPFamily = (prefix: string): IPFamily => {
+    return prefix.includes(':') ? 'v6' : 'v4';
+};
+
+/** Groups routes by prefix, returning a map from prefix → route array. */
+export const groupByPrefix = (routes: Route[]): Map<string, Route[]> => {
+    const m = new Map<string, Route[]>();
+    for (const r of routes) {
+        const key = r.prefix || '';
+        const group = m.get(key);
+        if (group) {
+            group.push(r);
+        } else {
+            m.set(key, [r]);
+        }
+    }
+    return m;
+};
+
+/** Filters routes by IP family. Returns all routes when family is 'all'. */
+export const filterByFamily = (routes: Route[], family: IPFamily): Route[] => {
+    if (family === 'all') return routes;
+    return routes.filter((r) => prefixIPFamily(r.prefix || '') === family);
+};
+
+/** Returns a human-readable reason why the first candidate beats the second,
+ *  walking the BGP decision ladder: pref > as_path_len > med > origin_as > peer_as. */
+export const bestPathReason = (cands: Route[]): string => {
+    if (cands.length < 2) return '';
+    const best = cands[0];
+    const runner = cands[1];
+
+    const bestPref = best.pref ?? 0;
+    const runnerPref = runner.pref ?? 0;
+    if (bestPref !== runnerPref) {
+        return `higher Local Pref (${bestPref} vs ${runnerPref})`;
+    }
+
+    const bestLen = best.as_path_len ?? 0;
+    const runnerLen = runner.as_path_len ?? 0;
+    if (bestLen !== runnerLen) {
+        return `shorter AS path (${bestLen} vs ${runnerLen})`;
+    }
+
+    const bestMed = best.med ?? 0;
+    const runnerMed = runner.med ?? 0;
+    if (bestMed !== runnerMed) {
+        return `lower MED (${bestMed} vs ${runnerMed})`;
+    }
+
+    const bestOrigin = best.origin_as ?? 0;
+    const runnerOrigin = runner.origin_as ?? 0;
+    if (bestOrigin !== runnerOrigin) {
+        return `lower Origin AS (${bestOrigin} vs ${runnerOrigin})`;
+    }
+
+    const bestPeerAs = best.peer_as ?? 0;
+    const runnerPeerAs = runner.peer_as ?? 0;
+    if (bestPeerAs !== runnerPeerAs) {
+        return `lower Peer AS (${bestPeerAs} vs ${runnerPeerAs})`;
+    }
+
+    return '';
 };
 
 /** Sort comparators for each sortable column. */


### PR DESCRIPTION
Redesign the route operator page around a debug-first, command-driven workflow while keeping the existing brown visual language.

- Add a command palette (Ctrl/Cmd+K) for searching prefixes and next hops, running route actions, and launching IP lookups.
- Add a route lookup drawer backed by the operator lookup API, showing the matched prefix and candidate routes best-path first.
- Elevate the routing table with source and best-path indicators, IPv4/IPv6 and conflict awareness, tri-state column sorting, and full-width responsive columns, all on a fixed-height virtualized scroll area.
- Add IPv4/IPv6 family and best/conflict filters to the toolbar.
- Unify the header, tabs, and table onto a single configurable surface color, and submit the add-route form on Ctrl+Enter.