### PR TITLE
feat(operator-forward): add readiness CLI command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,6 +3338,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "yanet-cli-operator-forward"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "colored",
+ "log",
+ "prost",
+ "prost-types",
+ "tabled",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "yanet-cli",
+ "yanet-readinesspb",
+]
+
+[[package]]
 name = "yanet-cli-operator-neighbour"
 version = "0.1.0"
 dependencies = [
@@ -3488,6 +3506,17 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
+name = "yanet-readinesspb"
+version = "0.1.0"
+dependencies = [
+ "prost",
+ "prost-types",
+ "serde",
  "tonic",
  "tonic-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ resolver = "2"
 members = [
     "common/rust/commonpb",
     "common/rust/filterpb",
+    "common/rust/readinesspb",
     "common/rust/ynpb",
     "cli/core",
     "cli/modules/common",
@@ -24,6 +25,7 @@ members = [
     "modules/route-mpls/cli",
     "devices/plain/cli",
     "devices/vlan/cli",
+    "operators/forward/cli",
     "operators/pipeline/cli",
     "operators/route/cli/route",
     "operators/route/cli/neighbour",

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ CLI_MODULES := \
 	forward \
 	nat64 \
 	pdump \
+	operator-forward \
 	operator-neighbour \
 	operator-pipeline \
 	operator-route

--- a/common/rust/readinesspb/Cargo.toml
+++ b/common/rust/readinesspb/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "yanet-readinesspb"
+version = "0.1.0"
+edition = "2024"
+publish = false
+rust-version = "1.85"
+
+[dependencies]
+prost = "0.13"
+prost-types = "0.13"
+serde = { version = "1", features = ["derive"] }
+tonic = { version = "0.13", features = ["gzip"] }
+
+[build-dependencies]
+tonic-build = "0.13"

--- a/common/rust/readinesspb/build.rs
+++ b/common/rust/readinesspb/build.rs
@@ -1,0 +1,28 @@
+use core::error::Error;
+
+pub fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=common/readinesspb/readiness.proto");
+
+    tonic_build::configure()
+        .emit_rerun_if_changed(false)
+        .build_server(false)
+        .message_attribute("readinesspb.Reason", "#[derive(serde::Serialize)]")
+        .message_attribute("readinesspb.ReadyRequest", "#[derive(serde::Serialize)]")
+        .message_attribute("readinesspb.ReadyResponse", "#[derive(serde::Serialize)]")
+        .message_attribute("readinesspb.Scope", "#[derive(serde::Serialize)]")
+        .field_attribute(
+            "readinesspb.Scope.state",
+            "#[serde(serialize_with = \"crate::serialize_state\")]",
+        )
+        .field_attribute(
+            "readinesspb.Scope.observed_at",
+            "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
+        )
+        .field_attribute(
+            "readinesspb.Scope.last_transition_time",
+            "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
+        )
+        .enum_attribute(".", "#[derive(serde::Serialize)]")
+        .compile_protos(&["common/readinesspb/readiness.proto"], &["../../.."])
+        .map_err(Into::into)
+}

--- a/common/rust/readinesspb/src/lib.rs
+++ b/common/rust/readinesspb/src/lib.rs
@@ -1,0 +1,47 @@
+//! Compiled proto types for the shared readiness API.
+//!
+//! Exposes `pb::ReadyRequest`, `pb::ReadyResponse`, `pb::Scope`,
+//! `pb::State`, and `pb::Reason` generated from
+//! `common/readinesspb/readiness.proto`.
+
+#[allow(clippy::all, non_snake_case)]
+pub mod pb {
+    tonic::include_proto!("readinesspb");
+}
+
+/// Serializes a `readinesspb.State` discriminant as its lowercase name (e.g.
+/// `"ready"`).
+pub fn serialize_state<S>(value: &i32, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let name = pb::State::try_from(*value)
+        .unwrap_or_default()
+        .as_str_name()
+        .strip_prefix("STATE_")
+        .unwrap_or("unspecified")
+        .to_lowercase();
+
+    serializer.serialize_str(&name)
+}
+
+/// Serializes an `Option<prost_types::Timestamp>` as `{"seconds": i64, "nanos":
+/// i32}` or `null` when absent.
+pub fn serialize_timestamp<S>(value: &Option<prost_types::Timestamp>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use serde::Serialize;
+
+    match value {
+        Some(ts) => {
+            #[derive(serde::Serialize)]
+            struct Ts {
+                seconds: i64,
+                nanos: i32,
+            }
+            Ts { seconds: ts.seconds, nanos: ts.nanos }.serialize(serializer)
+        }
+        None => serializer.serialize_none(),
+    }
+}

--- a/debian/yanet2-cli.install
+++ b/debian/yanet2-cli.install
@@ -19,3 +19,4 @@ usr/bin/yanet-cli-balancer2
 usr/bin/yanet-cli-operator-pipeline
 usr/bin/yanet-cli-operator-neighbour
 usr/bin/yanet-cli-operator-route
+usr/bin/yanet-cli-operator-forward

--- a/operators/forward/cli/Cargo.toml
+++ b/operators/forward/cli/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "yanet-cli-operator-forward"
+version = "0.1.0"
+edition = "2024"
+publish = false
+rust-version = "1.85"
+
+[[bin]]
+name = "yanet-cli-operator-forward"
+path = "src/main.rs"
+
+[dependencies]
+ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
+readinesspb = { path = "../../../common/rust/readinesspb", version = "0.1", package = "yanet-readinesspb" }
+clap = { version = "4.5", features = ["derive"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
+prost = "0.13"
+prost-types = "0.13"
+log = "0.4"
+colored = "3"
+tabled = { version = "0.18", features = ["ansi"] }
+tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
+tonic = { version = "0.13", features = ["gzip"] }
+
+[build-dependencies]
+tonic-build = "0.13"

--- a/operators/forward/cli/build.rs
+++ b/operators/forward/cli/build.rs
@@ -1,0 +1,16 @@
+use core::error::Error;
+
+pub fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=../../../operators/forward/operatorpb/v1/readiness.proto");
+    println!("cargo:rerun-if-changed=../../../common/readinesspb/readiness.proto");
+
+    tonic_build::configure()
+        .emit_rerun_if_changed(false)
+        .build_server(false)
+        .extern_path(".readinesspb", "::readinesspb::pb")
+        .compile_protos(
+            &["../../../operators/forward/operatorpb/v1/readiness.proto"],
+            &["../../../"],
+        )
+        .map_err(Into::into)
+}

--- a/operators/forward/cli/src/main.rs
+++ b/operators/forward/cli/src/main.rs
@@ -1,0 +1,348 @@
+//! CLI for the YANET forward operator (readiness commands).
+//!
+//! Connects to a gRPC endpoint exposing the operator's `ReadinessService`
+//! and reports per-gateway readiness state.
+
+use core::fmt::{self, Display, Formatter};
+
+use clap::{ArgAction, CommandFactory, Parser};
+use clap_complete::CompleteEnv;
+use colored::Colorize;
+use tabled::{
+    Table, Tabled,
+    settings::{
+        Color, Style,
+        object::{Columns, Rows},
+        style::{BorderColor, HorizontalLine},
+    },
+};
+use tonic::codec::CompressionEncoding;
+use ync::{
+    client::{ConnectionArgs, LayeredChannel},
+    errors::Error,
+    output::{self, CommonFormat},
+};
+
+use crate::operatorpb::readiness_service_client::ReadinessServiceClient;
+
+#[allow(clippy::all, non_snake_case)]
+pub mod operatorpb {
+    tonic::include_proto!("operators.forward.operatorpb.v1");
+}
+
+/// The fully-qualified gRPC service name used in error messages.
+const SERVICE_NAME: &str = "operators.forward.operatorpb.v1.ReadinessService";
+
+/// Exit code used when the RPC succeeds but not all scopes are `STATE_READY`.
+const EXIT_NOT_READY: i32 = 2;
+
+/// Forward operator CLI (readiness commands).
+#[derive(Debug, Clone, Parser)]
+#[command(version, about)]
+#[command(flatten_help = true)]
+pub struct Cmd {
+    #[clap(subcommand)]
+    pub mode: ModeCmd,
+    #[command(flatten)]
+    pub connection: ConnectionArgs,
+    #[arg(long, default_value = "human", global = true)]
+    pub format: CommonFormat,
+    /// Be verbose: shows debug log lines and raw gRPC error details.
+    #[clap(short, action = ArgAction::Count, global = true)]
+    pub verbose: u8,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub enum ModeCmd {
+    /// Show per-gateway readiness of the forward operator.
+    Ready(ReadyCmd),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ReadyCmd {
+    /// Restrict output to these gateway names; empty means all.
+    pub gateways: Vec<String>,
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() {
+    CompleteEnv::with_factory(Cmd::command).complete();
+
+    let cmd = Cmd::parse();
+
+    ync::init(cmd.verbose, cmd.format);
+
+    match run(cmd).await {
+        Ok(true) => {}
+        Ok(false) => std::process::exit(EXIT_NOT_READY),
+        Err(err) => {
+            output::failure(&err);
+            std::process::exit(err.exit_code());
+        }
+    }
+}
+
+/// Run the requested subcommand.
+///
+/// Returns `Ok(true)` when the RPC succeeded and every returned scope is
+/// `STATE_READY`, `Ok(false)` when the RPC succeeded but at least one scope
+/// is not ready, and `Err(_)` on transport or RPC failure.
+async fn run(cmd: Cmd) -> Result<bool, Error> {
+    let mut service = ForwardOperatorService::new(&cmd.connection).await?;
+
+    match cmd.mode {
+        ModeCmd::Ready(cmd) => service.ready(cmd).await,
+    }
+}
+
+pub struct ForwardOperatorService {
+    client: ReadinessServiceClient<LayeredChannel>,
+    endpoint: String,
+}
+
+impl ForwardOperatorService {
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
+        let channel = ync::client::connect(connection)
+            .await
+            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
+        let client = ReadinessServiceClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip);
+
+        Ok(Self {
+            client,
+            endpoint: connection.endpoint.clone(),
+        })
+    }
+
+    pub async fn ready(&mut self, cmd: ReadyCmd) -> Result<bool, Error> {
+        let request = readinesspb::pb::ReadyRequest { scopes: cmd.gateways.clone() };
+
+        let response = self
+            .client
+            .ready(request)
+            .await
+            .map_err(|status| Error::from_status(status, "ready", self.endpoint.clone(), SERVICE_NAME))?
+            .into_inner();
+
+        let returned_names: std::collections::HashSet<&str> =
+            response.scopes.iter().map(|scope| scope.name.as_str()).collect();
+
+        let missing: Vec<&str> = cmd
+            .gateways
+            .iter()
+            .map(String::as_str)
+            .filter(|name| !returned_names.contains(name))
+            .collect();
+
+        let all_scopes_ready = response
+            .scopes
+            .iter()
+            .all(|scope| scope.state == readinesspb::pb::State::Ready as i32);
+
+        let all_ready = all_scopes_ready && missing.is_empty();
+
+        let total = response.scopes.len();
+        let ready_count = response
+            .scopes
+            .iter()
+            .filter(|scope| scope.state == readinesspb::pb::State::Ready as i32)
+            .count();
+
+        output::data(
+            &response.scopes,
+            response.scopes.is_empty() && missing.is_empty(),
+            format_args!("no gateways"),
+            || {
+                let mut rows: Vec<ReadinessRow> = response.scopes.iter().map(ReadinessRow::from).collect();
+                rows.sort_by(|a, b| a.gateway.cmp(&b.gateway));
+
+                if !rows.is_empty() {
+                    print_readiness_table(rows);
+                }
+
+                if !missing.is_empty() {
+                    let missing_list = missing.join(", ");
+                    let label = "missing (not registered):";
+
+                    if output::is_colored() {
+                        println!("{} {}", label.red(), missing_list.red());
+                    } else {
+                        println!("{label} {missing_list}");
+                    }
+                }
+
+                let missing_count = missing.len();
+
+                if missing_count > 0 {
+                    println!("summary: {ready_count}/{total} ready, {missing_count} requested gateway missing");
+                } else {
+                    println!("summary: {ready_count}/{total} ready");
+                }
+            },
+        );
+
+        Ok(all_ready)
+    }
+}
+
+/// Wraps a readiness state for colored display in the table.
+pub struct StateCell(readinesspb::pb::State);
+
+impl Display for StateCell {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        let StateCell(state) = self;
+        let name = state.as_str_name().strip_prefix("STATE_").unwrap_or_default();
+
+        if output::is_colored() {
+            let colored = match state {
+                readinesspb::pb::State::Ready => name.green().to_string(),
+                readinesspb::pb::State::Degraded => name.yellow().to_string(),
+                readinesspb::pb::State::NotReady => name.red().to_string(),
+                readinesspb::pb::State::Unspecified | readinesspb::pb::State::Unknown => {
+                    name.truecolor(127, 127, 127).to_string()
+                }
+            };
+            write!(f, "{colored}")
+        } else {
+            write!(f, "{name}")
+        }
+    }
+}
+
+#[derive(Debug, Tabled)]
+pub struct ReadinessRow {
+    #[tabled(rename = "Gateway")]
+    pub gateway: String,
+    #[tabled(rename = "State")]
+    pub state: String,
+    #[tabled(rename = "Last Transition")]
+    pub last_transition: String,
+    #[tabled(rename = "Observed")]
+    pub observed: String,
+    #[tabled(rename = "Reasons")]
+    pub reasons: String,
+}
+
+impl From<&readinesspb::pb::Scope> for ReadinessRow {
+    fn from(scope: &readinesspb::pb::Scope) -> Self {
+        let state = readinesspb::pb::State::try_from(scope.state).unwrap_or_default();
+        let state_cell = StateCell(state);
+
+        let reasons = scope
+            .reasons
+            .iter()
+            .map(|reason| format!("{}: {}", reason.code, reason.message))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        Self {
+            gateway: scope.name.clone(),
+            state: state_cell.to_string(),
+            last_transition: format_age(scope.last_transition_time.as_ref()),
+            observed: format_age(scope.observed_at.as_ref()),
+            reasons,
+        }
+    }
+}
+
+/// Formats a `prost_types::Timestamp` as a human-readable relative age.
+///
+/// Returns `"-"` when `ts` is `None` or the zero sentinel
+/// (`seconds == 0 && nanos == 0`). Otherwise formats as `Xs ago`,
+/// `XmYs ago`, or `XhYm ago` depending on magnitude.
+pub fn format_age(ts: Option<&prost_types::Timestamp>) -> String {
+    let ts = match ts {
+        Some(ts) if ts.seconds != 0 || ts.nanos != 0 => ts,
+        _ => return "-".to_string(),
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+
+    let ts_secs = ts.seconds.max(0) as u64;
+    let now_secs = now.as_secs();
+
+    let secs = now_secs.saturating_sub(ts_secs);
+
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        let minutes = secs / 60;
+        let remainder = secs % 60;
+        format!("{minutes}m{remainder}s ago")
+    } else {
+        let hours = secs / 3600;
+        let minutes = (secs % 3600) / 60;
+        format!("{hours}h{minutes}m ago")
+    }
+}
+
+fn print_readiness_table(rows: Vec<ReadinessRow>) {
+    let mut table = Table::new(&rows);
+    table.with(
+        Style::modern()
+            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
+            .remove_horizontal(),
+    );
+
+    if output::is_colored() {
+        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
+        table.modify(Rows::first(), Color::BOLD);
+    }
+
+    println!("{table}");
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn format_age_none_returns_dash() {
+        assert_eq!("-", format_age(None));
+    }
+
+    #[test]
+    fn format_age_zero_sentinel_returns_dash() {
+        let ts = prost_types::Timestamp { seconds: 0, nanos: 0 };
+        assert_eq!("-", format_age(Some(&ts)));
+    }
+
+    #[test]
+    fn format_age_seconds() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let ts = prost_types::Timestamp {
+            seconds: now.as_secs() as i64 - 30,
+            nanos: 0,
+        };
+        assert_eq!("30s ago", format_age(Some(&ts)));
+    }
+
+    #[test]
+    fn format_age_minutes() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let ts = prost_types::Timestamp {
+            seconds: now.as_secs() as i64 - 64,
+            nanos: 0,
+        };
+        assert_eq!("1m4s ago", format_age(Some(&ts)));
+    }
+
+    #[test]
+    fn format_age_hours() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let ts = prost_types::Timestamp {
+            seconds: now.as_secs() as i64 - (2 * 3600 + 3 * 60),
+            nanos: 0,
+        };
+        assert_eq!("2h3m ago", format_age(Some(&ts)));
+    }
+}


### PR DESCRIPTION
- Add the \`yanet-cli-operator-forward\` binary with a \`ready\` subcommand that queries the forward operator's ReadinessService and renders per-gateway readiness as a colored table.
- Exit non-zero unless every gateway reports ready, so the command doubles as a health probe; transport and RPC errors keep their own failure path.
- Support a JSON output format and an optional gateway-name filter.
- Introduce a shared \`yanet-readinesspb\` Rust crate for the common readiness proto, consumed via extern path to avoid recompiling the proto in the CLI.
- Register the new binary in the cargo workspace, the Makefile CLI module list, and the Debian cli package manifest.