### PR TITLE
feat(web): unify warm surface across all pages and fix route refresh flash

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -141,37 +141,39 @@ const AppContent = (): React.JSX.Element => {
                 onPageChange={handlePageChange}
                 disabled={sidebarDisabled}
                 renderContent={() => (
-                    <Suspense fallback={<PageLoader loading size="l" />}>
-                        <Routes>
-                            <Route path="/" element={<Navigate to="/builtin/dashboard" replace />} />
-                            <Route path="/builtin/inspect" element={<InspectPage />} />
-                            <Route path="/builtin/dashboard" element={<DashboardPage />} />
-                            <Route path="/builtin/functions" element={<FunctionsPage />} />
-                            <Route path="/builtin/functions-ng" element={<Navigate to="/builtin/functions" replace />} />
-                            <Route path="/builtin/pipelines" element={<PipelinesPage />} />
-                            <Route path="/builtin/devices" element={<DevicesPage />} />
-                            <Route path="/modules/forward" element={<ForwardPage />} />
-                            <Route path="/modules/decap" element={<DecapPage />} />
-                            <Route path="/modules/acl" element={<AclPage />} />
-                            <Route path="/modules/fwstate" element={<FWStatePage />} />
-                            <Route path="/modules/pdump" element={<PdumpPage />} />
-                            <Route path="/modules/route" element={<ModulesRoutePage />} />
-                            <Route path="/operators/route" element={<OperatorsRoutePage />} />
-                            <Route path="/operators/neighbours" element={<NeighboursPage />} />
-                            <Route path="/inspect" element={<Navigate to="/builtin/inspect" replace />} />
-                            <Route path="/dashboard" element={<Navigate to="/builtin/dashboard" replace />} />
-                            <Route path="/functions" element={<Navigate to="/builtin/functions" replace />} />
-                            <Route path="/pipelines" element={<Navigate to="/builtin/pipelines" replace />} />
-                            <Route path="/devices" element={<Navigate to="/builtin/devices" replace />} />
-                            <Route path="/forward" element={<Navigate to="/modules/forward" replace />} />
-                            <Route path="/decap" element={<Navigate to="/modules/decap" replace />} />
-                            <Route path="/acl" element={<Navigate to="/modules/acl" replace />} />
-                            <Route path="/fwstate" element={<Navigate to="/modules/fwstate" replace />} />
-                            <Route path="/pdump" element={<Navigate to="/modules/pdump" replace />} />
-                            <Route path="/route" element={<Navigate to="/operators/route" replace />} />
-                            <Route path="/neighbours" element={<Navigate to="/operators/neighbours" replace />} />
-                        </Routes>
-                    </Suspense>
+                    <div className="app-surface">
+                        <Suspense fallback={<PageLoader loading size="l" />}>
+                            <Routes>
+                                <Route path="/" element={<Navigate to="/builtin/dashboard" replace />} />
+                                <Route path="/builtin/inspect" element={<InspectPage />} />
+                                <Route path="/builtin/dashboard" element={<DashboardPage />} />
+                                <Route path="/builtin/functions" element={<FunctionsPage />} />
+                                <Route path="/builtin/functions-ng" element={<Navigate to="/builtin/functions" replace />} />
+                                <Route path="/builtin/pipelines" element={<PipelinesPage />} />
+                                <Route path="/builtin/devices" element={<DevicesPage />} />
+                                <Route path="/modules/forward" element={<ForwardPage />} />
+                                <Route path="/modules/decap" element={<DecapPage />} />
+                                <Route path="/modules/acl" element={<AclPage />} />
+                                <Route path="/modules/fwstate" element={<FWStatePage />} />
+                                <Route path="/modules/pdump" element={<PdumpPage />} />
+                                <Route path="/modules/route" element={<ModulesRoutePage />} />
+                                <Route path="/operators/route" element={<OperatorsRoutePage />} />
+                                <Route path="/operators/neighbours" element={<NeighboursPage />} />
+                                <Route path="/inspect" element={<Navigate to="/builtin/inspect" replace />} />
+                                <Route path="/dashboard" element={<Navigate to="/builtin/dashboard" replace />} />
+                                <Route path="/functions" element={<Navigate to="/builtin/functions" replace />} />
+                                <Route path="/pipelines" element={<Navigate to="/builtin/pipelines" replace />} />
+                                <Route path="/devices" element={<Navigate to="/builtin/devices" replace />} />
+                                <Route path="/forward" element={<Navigate to="/modules/forward" replace />} />
+                                <Route path="/decap" element={<Navigate to="/modules/decap" replace />} />
+                                <Route path="/acl" element={<Navigate to="/modules/acl" replace />} />
+                                <Route path="/fwstate" element={<Navigate to="/modules/fwstate" replace />} />
+                                <Route path="/pdump" element={<Navigate to="/modules/pdump" replace />} />
+                                <Route path="/route" element={<Navigate to="/operators/route" replace />} />
+                                <Route path="/neighbours" element={<Navigate to="/operators/neighbours" replace />} />
+                            </Routes>
+                        </Suspense>
+                    </div>
                 )}
             />
         </SidebarContext.Provider>

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import { toaster } from '@gravity-ui/uikit/toaster-singleton';
 import App from './App';
 import '@gravity-ui/uikit/styles/fonts.css';
 import '@gravity-ui/uikit/styles/styles.css';
+import './styles/tokens.scss';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -18,7 +18,7 @@ import '../../../styles/draft-page.scss';
 import './route.scss';
 
 const RoutePage: React.FC = () => {
-    const { configs, configRoutes, selectedIds, loading, reload, addLocalConfig, setSelected } = useRIB();
+    const { configs, configRoutes, selectedIds, loading, refreshing, reload, addLocalConfig, setSelected } = useRIB();
 
     const [activeConfig, setActiveConfig] = useState('');
     const [search, setSearch] = useState('');
@@ -314,7 +314,7 @@ const RoutePage: React.FC = () => {
         </Flex>
     );
 
-    if (loading) {
+    if (loading && configs.length === 0) {
         return (
             <PageLayout header={pageHeader} className="ro-layout">
                 <PageLoader loading size="l" />
@@ -324,7 +324,7 @@ const RoutePage: React.FC = () => {
 
     return (
         <PageLayout header={pageHeader} className="ro-layout">
-            <div className="fw-page ro-page">
+            <div className="fw-page ro-page" aria-busy={refreshing}>
                 {configs.length === 0 ? (
                     <div className="fw-empty-page">
                         <div className="fw-empty-page__message">No route configurations found.</div>

--- a/web/src/pages/operators/route/useRIB.ts
+++ b/web/src/pages/operators/route/useRIB.ts
@@ -8,6 +8,7 @@ export interface UseRIBResult {
     configRoutes: Map<string, Route[]>;
     selectedIds: Map<string, Set<string>>;
     loading: boolean;
+    refreshing: boolean;
     reload: () => Promise<void>;
     addLocalConfig: (name: string) => void;
     setSelected: (configName: string, ids: Set<string>) => void;
@@ -19,9 +20,15 @@ export const useRIB = (): UseRIBResult => {
     const [configRoutes, setConfigRoutes] = useState<Map<string, Route[]>>(new Map());
     const [selectedIds, setSelectedIds] = useState<Map<string, Set<string>>>(new Map());
     const [loading, setLoading] = useState(true);
+    const [refreshing, setRefreshing] = useState(false);
 
-    const loadAll = useCallback(async (opts?: { isCancelled?: () => boolean }): Promise<void> => {
-        setLoading(true);
+    const loadAll = useCallback(async (opts?: { initial?: boolean; isCancelled?: () => boolean }): Promise<void> => {
+        const isInitial = opts?.initial !== false;
+        if (isInitial) {
+            setLoading(true);
+        } else {
+            setRefreshing(true);
+        }
         try {
             const configsResponse = await API.routeOperator.listConfigs();
             const configsList = configsResponse.configs || [];
@@ -46,19 +53,23 @@ export const useRIB = (): UseRIBResult => {
             toaster.error('rib-configs-error', 'Failed to fetch RIB configs', err);
         } finally {
             if (!opts?.isCancelled?.()) {
-                setLoading(false);
+                if (isInitial) {
+                    setLoading(false);
+                } else {
+                    setRefreshing(false);
+                }
             }
         }
     }, []);
 
     useEffect(() => {
         let cancelled = false;
-        loadAll({ isCancelled: () => cancelled });
+        loadAll({ initial: true, isCancelled: () => cancelled });
         return () => { cancelled = true; };
     }, [loadAll]);
 
     const reload = useCallback(async (): Promise<void> => {
-        await loadAll();
+        await loadAll({ initial: false });
     }, [loadAll]);
 
     const addLocalConfig = useCallback((name: string): void => {
@@ -78,5 +89,5 @@ export const useRIB = (): UseRIBResult => {
         });
     }, []);
 
-    return { configs, configRoutes, selectedIds, loading, reload, addLocalConfig, setSelected };
+    return { configs, configRoutes, selectedIds, loading, refreshing, reload, addLocalConfig, setSelected };
 };

--- a/web/src/styles/draft-page.scss
+++ b/web/src/styles/draft-page.scss
@@ -3,63 +3,7 @@
 
 // Shared page chrome for draft-edit pages (Forward, Route).
 // The fw- prefix is historical — these classes are consumed by both pages.
-
-// Design tokens scoped to the forward page — warm dark-brown palette (matches functions page).
-// All fw-* tokens are overridden here so other pages stay Gravity-default.
-// Light-mode overrides are under [data-theme="light"] .fw-page.
-.fw-page,
-.fw-drawer,
-.fw-modal {
-    // Dark-mode warm-brown palette (default — app is locked to dark).
-    --fw-page-bg:       #15110D;
-    --fw-panel:         #1C1814;
-    --fw-bg-2:          #181410;
-    --fw-bg-3:          #221C16;
-    --fw-bg-hover:      #221C16;
-    --fw-line:          rgba(255, 199, 140, 0.02);
-    --fw-line-2:        rgba(255, 200, 140, 0.12);
-    --fw-text:          #F2EEE8;
-    --fw-text-2:        #B8B0A4;
-    --fw-text-3:        #7E7468;
-    --fw-accent:        #FFC061;
-    --fw-accent-soft:   rgba(255, 192, 97, 0.14);
-    --fw-danger:        var(--g-color-text-danger);
-    --fw-warn:          var(--g-color-text-warning);
-    --fw-ok:            var(--g-color-text-positive);
-    --fw-r-sm:          4px;
-    --fw-r-md:          6px;
-    --fw-r-lg:          10px;
-    --fw-font-mono:     'JetBrains Mono', ui-monospace, monospace;
-
-    // Direction badge colors — recomputed against new warm accent.
-    --fw-dir-in:        var(--g-color-text-positive);
-    --fw-dir-in-bg:     rgba(110, 198, 140, 0.12);
-    --fw-dir-in-bd:     rgba(110, 198, 140, 0.22);
-    --fw-dir-out:       var(--fw-accent);
-    --fw-dir-out-bg:    var(--fw-accent-soft);
-    --fw-dir-out-bd:    rgba(255, 192, 97, 0.22);
-    --fw-dir-none:      var(--fw-text-3);
-    --fw-dir-none-bg:   rgba(126, 116, 104, 0.12);
-    --fw-dir-none-bd:   rgba(126, 116, 104, 0.22);
-}
-
-// Light-mode overrides — scoped to .fw-page to avoid bleed.
-[data-theme="light"] {
-    .fw-page,
-    .fw-drawer,
-    .fw-modal {
-        --fw-page-bg:  #FAF7F2;
-        --fw-panel:    #FFFFFF;
-        --fw-bg-2:     #F3EFE9;
-        --fw-bg-3:     #EBE6DE;
-        --fw-bg-hover: #EBE6DE;
-        --fw-line:     rgba(80, 60, 30, 0.08);
-        --fw-line-2:   rgba(80, 60, 30, 0.16);
-        --fw-text:     #1A1410;
-        --fw-text-2:   #5C4E3A;
-        --fw-text-3:   #9C8B74;
-    }
-}
+// Design tokens are defined globally in tokens.scss (imported from main.tsx).
 
 // Page container
 .fw-page {

--- a/web/src/styles/tokens.scss
+++ b/web/src/styles/tokens.scss
@@ -1,0 +1,65 @@
+// Global design tokens — warm dark-brown palette.
+// Scoped to .g-root so they are available on every page,
+// not only those that mount a .fw-page element.
+
+.g-root {
+    // Dark-mode warm-brown palette (default — app is locked to dark).
+    --fw-page-bg:       #15110D;
+    --fw-panel:         #1C1814;
+    --fw-bg-2:          #181410;
+    --fw-bg-3:          #221C16;
+    --fw-bg-hover:      #221C16;
+    --fw-line:          rgba(255, 199, 140, 0.02);
+    --fw-line-2:        rgba(255, 200, 140, 0.12);
+    --fw-text:          #F2EEE8;
+    --fw-text-2:        #B8B0A4;
+    --fw-text-3:        #7E7468;
+    --fw-accent:        #FFC061;
+    --fw-accent-soft:   rgba(255, 192, 97, 0.14);
+    --fw-danger:        var(--g-color-text-danger);
+    --fw-warn:          var(--g-color-text-warning);
+    --fw-ok:            var(--g-color-text-positive);
+    --fw-r-sm:          4px;
+    --fw-r-md:          6px;
+    --fw-r-lg:          10px;
+    --fw-font-mono:     'JetBrains Mono', ui-monospace, monospace;
+
+    // Direction badge colors — recomputed against new warm accent.
+    --fw-dir-in:        var(--g-color-text-positive);
+    --fw-dir-in-bg:     rgba(110, 198, 140, 0.12);
+    --fw-dir-in-bd:     rgba(110, 198, 140, 0.22);
+    --fw-dir-out:       var(--fw-accent);
+    --fw-dir-out-bg:    var(--fw-accent-soft);
+    --fw-dir-out-bd:    rgba(255, 192, 97, 0.22);
+    --fw-dir-none:      var(--fw-text-3);
+    --fw-dir-none-bg:   rgba(126, 116, 104, 0.12);
+    --fw-dir-none-bd:   rgba(126, 116, 104, 0.22);
+}
+
+// Light-mode overrides.
+[data-theme="light"] {
+    .fw-page,
+    .fw-drawer,
+    .fw-modal {
+        --fw-page-bg:  #FAF7F2;
+        --fw-panel:    #FFFFFF;
+        --fw-bg-2:     #F3EFE9;
+        --fw-bg-3:     #EBE6DE;
+        --fw-bg-hover: #EBE6DE;
+        --fw-line:     rgba(80, 60, 30, 0.08);
+        --fw-line-2:   rgba(80, 60, 30, 0.16);
+        --fw-text:     #1A1410;
+        --fw-text-2:   #5C4E3A;
+        --fw-text-3:   #9C8B74;
+    }
+}
+
+// Always-present warm canvas — wraps the entire content region in App.tsx.
+.app-surface {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    min-height: 100%;
+    background: var(--fw-page-bg);
+}


### PR DESCRIPTION
Lifts the warm `--fw-*` design tokens to the theme root so they resolve on every page, not only those that mount a `.fw-page` element.

Paints a continuous warm-brown canvas on a stable app-level wrapper so the header, loading states, and all pages share one background — the Gravity-neutral background no longer shows through anywhere.

Decouples route data refresh from the full-screen loader so subsequent reloads keep the table mounted, eliminating the background flash when adding, deleting, or flushing routes.