### PR TITLE
fix(web): preserve zero pref and as_path_len metrics in route table

### DIFF
--- a/web/src/pages/operators/route/RIBTable.tsx
+++ b/web/src/pages/operators/route/RIBTable.tsx
@@ -286,10 +286,10 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                                         <BestPill isBest={route.is_best ?? false} />
                                     </div>
                                     <div>
-                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: route.pref ? 'var(--fw-text-2)' : 'var(--fw-text-3)' }}>{route.pref || '—'}</span>
+                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: route.pref != null ? 'var(--fw-text-2)' : 'var(--fw-text-3)' }}>{route.pref ?? '—'}</span>
                                     </div>
                                     <div>
-                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: route.as_path_len ? 'var(--fw-text-2)' : 'var(--fw-text-3)' }}>{route.as_path_len || '—'}</span>
+                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: route.as_path_len != null ? 'var(--fw-text-2)' : 'var(--fw-text-3)' }}>{route.as_path_len ?? '—'}</span>
                                     </div>
                                     <div style={{ overflow: 'hidden' }}>
                                         <SourceChip source={route.source} />


### PR DESCRIPTION
The route table rendered legitimate `pref` or `as_path_len` values of 0 as an em dash and styled them as missing, because the cells used truthiness. Use a nullish check so only absent metrics render as missing, keeping the display consistent with the underlying data and with sorting.

Addresses review feedback on #985.