### PR TITLE
fix(web): clear filters before flashing a looked-up route

### DIFF
--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -269,21 +269,22 @@ const RoutePage: React.FC = () => {
         setLookupOpen(true);
     }, []);
 
-    const handleShowInTable = useCallback((prefix: string): void => {
-        const matchedRow = allRows.find((r) => r.prefix === prefix);
-        if (matchedRow) {
-            const id = getRouteId(matchedRow);
-            setFlashRowId(null);
-            setTimeout(() => setFlashRowId(id), 0);
-        }
-    }, [allRows]);
-
     const handleClearFilters = useCallback((): void => {
         setFamily('all');
         setBestOnly(false);
         setConflictsOnly(false);
         setSearch('');
     }, []);
+
+    const handleShowInTable = useCallback((prefix: string): void => {
+        handleClearFilters();
+        const matchedRow = allRows.find((r) => r.prefix === prefix);
+        if (matchedRow) {
+            const id = getRouteId(matchedRow);
+            setFlashRowId(null);
+            setTimeout(() => setFlashRowId(id), 0);
+        }
+    }, [allRows, handleClearFilters]);
 
     const handleJumpToRow = useCallback((id: string): void => {
         setFlashRowId(null);


### PR DESCRIPTION
"Show in table" from the route lookup drawer only set the flash row id. When the matched prefix was hidden by an active family, best-only, conflicts, or search filter it was absent from the rendered rows, so the drawer closed and nothing was shown or scrolled to. Clear the active filters before flashing so the matched row is always visible.

Addresses review feedback on #985.