### PR TITLE
refactor(web): rename fw- chrome prefix to yn-

### DIFF
--- a/web/src/components/BulkBar.tsx
+++ b/web/src/components/BulkBar.tsx
@@ -11,12 +11,12 @@ interface BulkBarProps {
 
 /** Floating bulk-action bar that appears when items are selected. */
 const BulkBar: React.FC<BulkBarProps> = ({ count, itemNoun = 'item', onDelete, onClear }) => (
-    <div className="fw-bulk-bar">
-        <span className="fw-bulk-bar__count">{count} selected</span>
-        <button type="button" className="fw-btn fw-btn--danger fw-btn--sm" onClick={onDelete}>
+    <div className="yn-bulk-bar">
+        <span className="yn-bulk-bar__count">{count} selected</span>
+        <button type="button" className="yn-btn yn-btn--danger yn-btn--sm" onClick={onDelete}>
             Delete {count} {itemNoun}{count !== 1 ? 's' : ''}
         </button>
-        <button type="button" className="fw-icon-btn fw-icon-btn--sm" onClick={onClear} aria-label="Clear selection">
+        <button type="button" className="yn-icon-btn yn-icon-btn--sm" onClick={onClear} aria-label="Clear selection">
             ✕
         </button>
     </div>

--- a/web/src/components/ConfigTabStrip.tsx
+++ b/web/src/components/ConfigTabStrip.tsx
@@ -26,7 +26,7 @@ export interface ConfigTabStripProps {
 /**
  * Horizontal tab strip for multi-config pages. Shows a dirty dot and item count badge
  * per tab, and a "+" button to add a new config.
- * Consumes the fw-* CSS design tokens from forward.scss.
+ * Consumes the yn-* CSS design tokens from forward.scss.
  */
 export const ConfigTabStrip: React.FC<ConfigTabStripProps> = ({
     configs,
@@ -39,26 +39,26 @@ export const ConfigTabStrip: React.FC<ConfigTabStripProps> = ({
     leadingIcon,
     trailingIcon,
 }) => (
-    <div className="fw-tabs" role="tablist">
+    <div className="yn-tabs" role="tablist">
         {configs.map((cfg) => (
             <button
                 key={cfg}
                 type="button"
                 role="tab"
                 aria-selected={cfg === activeConfig}
-                className={`fw-tab${cfg === activeConfig ? ' fw-tab--active' : ''}${dirtyConfigs.has(cfg) ? ' fw-tab--dirty' : ''}`}
+                className={`yn-tab${cfg === activeConfig ? ' yn-tab--active' : ''}${dirtyConfigs.has(cfg) ? ' yn-tab--dirty' : ''}`}
                 onClick={() => onSelect(cfg)}
             >
                 {leadingIcon?.(cfg)}
-                <span className="fw-tab__label">{cfg}</span>
+                <span className="yn-tab__label">{cfg}</span>
                 {dirtyConfigs.has(cfg) && (
-                    <span className="fw-tab__dot" aria-label="unsaved changes" />
+                    <span className="yn-tab__dot" aria-label="unsaved changes" />
                 )}
                 {trailingIcon?.(cfg)}
-                <span className="fw-tab__count">{counts.get(cfg) ?? 0}</span>
+                <span className="yn-tab__count">{counts.get(cfg) ?? 0}</span>
             </button>
         ))}
-        <Button view="flat" size="s" onClick={onAddConfig} className="fw-tabs__add" title={addLabel}>
+        <Button view="flat" size="s" onClick={onAddConfig} className="yn-tabs__add" title={addLabel}>
             <Icon data={Plus} size={14} />
         </Button>
     </div>

--- a/web/src/components/MetricSparkline.tsx
+++ b/web/src/components/MetricSparkline.tsx
@@ -61,9 +61,9 @@ export const MetricSparkline: React.FC<MetricSparklineBaseProps> = ({
     values,
     width = 64,
     height = 18,
-    color = 'var(--fw-accent)',
+    color = 'var(--yn-accent)',
     fill = true,
-    className = 'fw-spark-svg',
+    className = 'yn-spark-svg',
     children,
 }) => {
     const hasData = values !== null && values.length >= 2;

--- a/web/src/components/YamlIOModal.tsx
+++ b/web/src/components/YamlIOModal.tsx
@@ -37,7 +37,7 @@ export interface YamlIOModalProps {
      * Either onImport or onImportAsync must be supplied.
      */
     onImportAsync?: (text: string, onProgress: (p: ParseProgress) => void, format: 'yaml' | 'json') => Promise<void>;
-    /** Toast key prefix, e.g. "fw-yaml" or "fib-yaml". */
+    /** Toast key prefix, e.g. "yn-yaml" or "fib-yaml". */
     toastPrefix: string;
     /** Placeholder YAML shown in import textarea. */
     importPlaceholder: string;
@@ -66,7 +66,7 @@ export interface YamlIOModalProps {
  * Reusable YAML (and optionally JSON) import/export modal chrome used by multi-config draft pages.
  * Renders Import and Export buttons; clicking either opens the modal.
  * Callers supply the serialisation and parsing logic via props.
- * Consumes fw-* CSS classes from draft-page.scss.
+ * Consumes yn-* CSS classes from draft-page.scss.
  */
 const YamlIOModal: React.FC<YamlIOModalProps> = ({
     configName,
@@ -276,12 +276,12 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                 const pct = total > 0 ? Math.round((done / total) * 100) : 0;
                 return (
                     <div style={{ marginTop: 6 }}>
-                        <div style={{ color: 'var(--fw-text-3)', fontSize: 12, marginBottom: 4 }}>
+                        <div style={{ color: 'var(--yn-text-3)', fontSize: 12, marginBottom: 4 }}>
                             Parsing… {done < total ? '' : '100%'}
                         </div>
-                        <div className="fw-parse-progress">
+                        <div className="yn-parse-progress">
                             <div
-                                className="fw-parse-progress__bar"
+                                className="yn-parse-progress__bar"
                                 style={{ width: `${pct}%` }}
                             />
                         </div>
@@ -292,12 +292,12 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                 const pct = total > 0 ? Math.round((done / total) * 100) : 0;
                 return (
                     <div style={{ marginTop: 6 }}>
-                        <div style={{ color: 'var(--fw-text-3)', fontSize: 12, marginBottom: 4 }}>
+                        <div style={{ color: 'var(--yn-text-3)', fontSize: 12, marginBottom: 4 }}>
                             Converting rules: {done.toLocaleString()} / {total.toLocaleString()} ({pct}%)
                         </div>
-                        <div className="fw-parse-progress">
+                        <div className="yn-parse-progress">
                             <div
-                                className="fw-parse-progress__bar"
+                                className="yn-parse-progress__bar"
                                 style={{ width: `${pct}%` }}
                             />
                         </div>
@@ -307,7 +307,7 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
         }
 
         return (
-            <div style={{ marginTop: 6, color: 'var(--fw-text-3)', fontSize: 12 }}>
+            <div style={{ marginTop: 6, color: 'var(--yn-text-3)', fontSize: 12 }}>
                 Parsing…
             </div>
         );
@@ -319,14 +319,14 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
             <div style={{ display: 'flex', gap: 4 }}>
                 <button
                     type="button"
-                    className={exportFormat === 'json' ? 'fw-btn fw-btn--sm' : 'fw-btn fw-btn--ghost fw-btn--sm'}
+                    className={exportFormat === 'json' ? 'yn-btn yn-btn--sm' : 'yn-btn yn-btn--ghost yn-btn--sm'}
                     onClick={() => handleExportFormatChange('json')}
                 >
                     JSON
                 </button>
                 <button
                     type="button"
-                    className={exportFormat === 'yaml' ? 'fw-btn fw-btn--sm' : 'fw-btn fw-btn--ghost fw-btn--sm'}
+                    className={exportFormat === 'yaml' ? 'yn-btn yn-btn--sm' : 'yn-btn yn-btn--ghost yn-btn--sm'}
                     onClick={() => handleExportFormatChange('yaml')}
                 >
                     YAML
@@ -347,22 +347,22 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
             </Button>
 
             {showModal && (
-                <div className="fw-modal-backdrop" onClick={closeModal}>
-                    <div className="fw-modal" onClick={(e) => e.stopPropagation()}>
-                        <header className="fw-modal__head">
-                            <div className="fw-modal__title-row">
-                                <span className="fw-modal__title">
+                <div className="yn-modal-backdrop" onClick={closeModal}>
+                    <div className="yn-modal" onClick={(e) => e.stopPropagation()}>
+                        <header className="yn-modal__head">
+                            <div className="yn-modal__title-row">
+                                <span className="yn-modal__title">
                                     {showModal === 'import' ? importLabel : exportLabel}
                                 </span>
                                 {showModal === 'export' && (
-                                    <span className="fw-modal__meta">
+                                    <span className="yn-modal__meta">
                                         {configName} · {itemCount} {itemLabel}
                                     </span>
                                 )}
                             </div>
                             <button
                                 type="button"
-                                className="fw-icon-btn"
+                                className="yn-icon-btn"
                                 onClick={closeModal}
                                 aria-label="Close"
                             >
@@ -370,11 +370,11 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                             </button>
                         </header>
 
-                        <div className="fw-modal__body">
+                        <div className="yn-modal__body">
                             {showModal === 'import' && (
-                                <div className="fw-modal__import-header">
+                                <div className="yn-modal__import-header">
                                     <label
-                                        className="fw-btn fw-btn--ghost fw-btn--sm"
+                                        className="yn-btn yn-btn--ghost yn-btn--sm"
                                         style={{ cursor: 'pointer' }}
                                     >
                                         Choose file
@@ -389,25 +389,25 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                                         />
                                     </label>
                                     {loadProgress !== null && (
-                                        <span className="fw-modal__load-progress">
+                                        <span className="yn-modal__load-progress">
                                             Reading… {loadProgress}%
                                         </span>
                                     )}
                                     {loadProgress === null && (
-                                        <span className="fw-modal__or">or paste below</span>
+                                        <span className="yn-modal__or">or paste below</span>
                                     )}
                                     {importExtraControls}
                                 </div>
                             )}
                             {showModal === 'export' && renderExportFormatToggle()}
                             {isLargeFile ? (
-                                <div className="fw-modal__large-file-notice">
+                                <div className="yn-modal__large-file-notice">
                                     Large file loaded ({(textContent.current.length / 1_048_576).toFixed(1)} MB) — preview suppressed to avoid browser slowdown.
                                 </div>
                             ) : (
                                 <textarea
                                     ref={textareaRef}
-                                    className="fw-code-area"
+                                    className="yn-code-area"
                                     value={previewText}
                                     onChange={(e) => {
                                         const v = e.target.value;
@@ -428,14 +428,14 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                             )}
                         </div>
 
-                        <footer className="fw-modal__foot">
-                            <span className="fw-modal__foot-hint">
+                        <footer className="yn-modal__foot">
+                            <span className="yn-modal__foot-hint">
                                 {showModal === 'export' ? exportFooterHint : importFooterHint}
                             </span>
-                            <div className="fw-modal__foot-actions">
+                            <div className="yn-modal__foot-actions">
                                 <button
                                     type="button"
-                                    className="fw-btn fw-btn--ghost"
+                                    className="yn-btn yn-btn--ghost"
                                     onClick={closeModal}
                                 >
                                     Close
@@ -444,14 +444,14 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                                     <>
                                         <button
                                             type="button"
-                                            className="fw-btn fw-btn--ghost"
+                                            className="yn-btn yn-btn--ghost"
                                             onClick={handleCopy}
                                         >
                                             Copy
                                         </button>
                                         <button
                                             type="button"
-                                            className="fw-btn fw-btn--primary"
+                                            className="yn-btn yn-btn--primary"
                                             onClick={handleDownload}
                                         >
                                             {showFormatToggle
@@ -462,7 +462,7 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                                 ) : (
                                     <button
                                         type="button"
-                                        className="fw-btn fw-btn--primary"
+                                        className="yn-btn yn-btn--primary"
                                         onClick={handleImport}
                                         disabled={!hasContent || isParsing || loadProgress !== null}
                                     >

--- a/web/src/pages/_shared/draft/AddConfigModal.tsx
+++ b/web/src/pages/_shared/draft/AddConfigModal.tsx
@@ -39,20 +39,20 @@ const AddConfigModal: React.FC<AddConfigModalProps> = ({
     };
 
     return (
-        <div className="fw-modal-backdrop" onClick={handleClose}>
-            <div className="fw-modal fw-modal--sm" onClick={(e) => e.stopPropagation()}>
-                <header className="fw-modal__head">
-                    <span className="fw-modal__title">{title}</span>
-                    <button type="button" className="fw-icon-btn" onClick={handleClose} aria-label="Close">✕</button>
+        <div className="yn-modal-backdrop" onClick={handleClose}>
+            <div className="yn-modal yn-modal--sm" onClick={(e) => e.stopPropagation()}>
+                <header className="yn-modal__head">
+                    <span className="yn-modal__title">{title}</span>
+                    <button type="button" className="yn-icon-btn" onClick={handleClose} aria-label="Close">✕</button>
                 </header>
-                <div className="fw-modal__body fw-modal__body--confirm">
-                    <div className="fw-field">
-                        <label className="fw-field__label" htmlFor="draft-new-config-name">
-                            {label} <span className="fw-field__req">*</span>
+                <div className="yn-modal__body yn-modal__body--confirm">
+                    <div className="yn-field">
+                        <label className="yn-field__label" htmlFor="draft-new-config-name">
+                            {label} <span className="yn-field__req">*</span>
                         </label>
                         <input
                             id="draft-new-config-name"
-                            className="fw-input"
+                            className="yn-input"
                             type="text"
                             value={name}
                             onChange={(e) => setName(e.target.value)}
@@ -65,13 +65,13 @@ const AddConfigModal: React.FC<AddConfigModalProps> = ({
                         />
                     </div>
                 </div>
-                <footer className="fw-modal__foot">
+                <footer className="yn-modal__foot">
                     <span />
-                    <div className="fw-modal__foot-actions">
-                        <button type="button" className="fw-btn fw-btn--ghost" onClick={handleClose}>Cancel</button>
+                    <div className="yn-modal__foot-actions">
+                        <button type="button" className="yn-btn yn-btn--ghost" onClick={handleClose}>Cancel</button>
                         <button
                             type="button"
-                            className="fw-btn fw-btn--primary"
+                            className="yn-btn yn-btn--primary"
                             onClick={handleCreate}
                             disabled={isDisabled}
                         >

--- a/web/src/pages/_shared/draft/BulkDeleteModal.tsx
+++ b/web/src/pages/_shared/draft/BulkDeleteModal.tsx
@@ -23,13 +23,13 @@ const BulkDeleteModal: React.FC<BulkDeleteModalProps> = ({
 }) => {
     if (!open) return null;
     return (
-        <div className="fw-modal-backdrop" onClick={onClose}>
-            <div className="fw-modal fw-modal--sm" onClick={(e) => e.stopPropagation()}>
-                <header className="fw-modal__head">
-                    <span className="fw-modal__title">Delete {itemNoun}s</span>
-                    <button type="button" className="fw-icon-btn" onClick={onClose} aria-label="Close">✕</button>
+        <div className="yn-modal-backdrop" onClick={onClose}>
+            <div className="yn-modal yn-modal--sm" onClick={(e) => e.stopPropagation()}>
+                <header className="yn-modal__head">
+                    <span className="yn-modal__title">Delete {itemNoun}s</span>
+                    <button type="button" className="yn-icon-btn" onClick={onClose} aria-label="Close">✕</button>
                 </header>
-                <div className="fw-modal__body fw-modal__body--confirm">
+                <div className="yn-modal__body yn-modal__body--confirm">
                     <p>
                         Delete <strong>{count}</strong> selected {itemNoun}(s) from <code>{configName}</code>?
                         {' '}
@@ -38,11 +38,11 @@ const BulkDeleteModal: React.FC<BulkDeleteModalProps> = ({
                             : 'Changes are staged in the draft; discard the draft to revert.'}
                     </p>
                 </div>
-                <footer className="fw-modal__foot">
+                <footer className="yn-modal__foot">
                     <span />
-                    <div className="fw-modal__foot-actions">
-                        <button type="button" className="fw-btn fw-btn--ghost" onClick={onClose}>Cancel</button>
-                        <button type="button" className="fw-btn fw-btn--danger" onClick={onConfirm}>
+                    <div className="yn-modal__foot-actions">
+                        <button type="button" className="yn-btn yn-btn--ghost" onClick={onClose}>Cancel</button>
+                        <button type="button" className="yn-btn yn-btn--danger" onClick={onConfirm}>
                             Delete {count} {itemNoun}(s)
                         </button>
                     </div>

--- a/web/src/pages/_shared/draft/DeleteConfigModal.tsx
+++ b/web/src/pages/_shared/draft/DeleteConfigModal.tsx
@@ -16,20 +16,20 @@ const DeleteConfigModal: React.FC<DeleteConfigModalProps> = ({
 }) => {
     if (!open) return null;
     return (
-        <div className="fw-modal-backdrop" onClick={onClose}>
-            <div className="fw-modal fw-modal--sm" onClick={(e) => e.stopPropagation()}>
-                <header className="fw-modal__head">
-                    <span className="fw-modal__title">Delete config</span>
-                    <button type="button" className="fw-icon-btn" onClick={onClose} aria-label="Close">✕</button>
+        <div className="yn-modal-backdrop" onClick={onClose}>
+            <div className="yn-modal yn-modal--sm" onClick={(e) => e.stopPropagation()}>
+                <header className="yn-modal__head">
+                    <span className="yn-modal__title">Delete config</span>
+                    <button type="button" className="yn-icon-btn" onClick={onClose} aria-label="Close">✕</button>
                 </header>
-                <div className="fw-modal__body fw-modal__body--confirm">
+                <div className="yn-modal__body yn-modal__body--confirm">
                     <p>Delete config <code>{configName}</code>? This cannot be undone.</p>
                 </div>
-                <footer className="fw-modal__foot">
+                <footer className="yn-modal__foot">
                     <span />
-                    <div className="fw-modal__foot-actions">
-                        <button type="button" className="fw-btn fw-btn--ghost" onClick={onClose}>Cancel</button>
-                        <button type="button" className="fw-btn fw-btn--danger" onClick={onConfirm}>
+                    <div className="yn-modal__foot-actions">
+                        <button type="button" className="yn-btn yn-btn--ghost" onClick={onClose}>Cancel</button>
+                        <button type="button" className="yn-btn yn-btn--danger" onClick={onConfirm}>
                             Delete
                         </button>
                     </div>

--- a/web/src/pages/_shared/draft/DraftActionButtons.tsx
+++ b/web/src/pages/_shared/draft/DraftActionButtons.tsx
@@ -30,11 +30,11 @@ const DraftActionButtons: React.FC<DraftActionButtonsProps> = ({
     onDiscard,
     onDeleteConfig,
 }) => (
-    <div className="fw-tbl-actions">
+    <div className="yn-table-actions">
         {currentIsDirty && (
             <button
                 type="button"
-                className="fw-tbl-action-btn fw-tbl-action-btn--discard"
+                className="yn-table-action-btn yn-table-action-btn--discard"
                 title="Discard changes"
                 aria-label="Discard local changes"
                 onClick={onDiscard}
@@ -44,7 +44,7 @@ const DraftActionButtons: React.FC<DraftActionButtonsProps> = ({
         )}
         <button
             type="button"
-            className="fw-tbl-action-btn fw-tbl-action-btn--save"
+            className="yn-table-action-btn yn-table-action-btn--save"
             title={currentIsDirty ? 'Review & apply' : 'No changes to save'}
             aria-label="Review and apply changes"
             disabled={!currentIsDirty}
@@ -54,7 +54,7 @@ const DraftActionButtons: React.FC<DraftActionButtonsProps> = ({
         </button>
         <button
             type="button"
-            className="fw-tbl-action-btn fw-tbl-action-btn--delete"
+            className="yn-table-action-btn yn-table-action-btn--delete"
             title="Delete config"
             aria-label="Delete config"
             onClick={onDeleteConfig}

--- a/web/src/pages/_shared/draft/DraftItemDrawer.tsx
+++ b/web/src/pages/_shared/draft/DraftItemDrawer.tsx
@@ -52,32 +52,32 @@ const DraftItemDrawer: React.FC<DraftItemDrawerProps> = ({
     return (
     <>
         <div
-            className={`fw-backdrop${open ? ' fw-backdrop--open' : ''}`}
+            className={`yn-backdrop${open ? ' yn-backdrop--open' : ''}`}
             onClick={onClose}
             aria-hidden="true"
         />
         <aside
-            className={`fw-drawer${open ? ' fw-drawer--open' : ''}`}
+            className={`yn-drawer${open ? ' yn-drawer--open' : ''}`}
             role="dialog"
             aria-modal="true"
             aria-label={ariaLabel}
         >
             {open && children !== null && (
                 <>
-                    <header className="fw-drawer__head">
-                        <h2 className="fw-drawer__title">
+                    <header className="yn-drawer__head">
+                        <h2 className="yn-drawer__title">
                             {titleVerb ?? 'Edit'} {titleSingular}
                             {!hideIndex && (
                                 <>
                                     {' '}
-                                    <span className="fw-drawer__rule-num">#{index + 1}</span>
+                                    <span className="yn-drawer__rule-num">#{index + 1}</span>
                                 </>
                             )}
                         </h2>
-                        <div className="fw-drawer__head-actions">
+                        <div className="yn-drawer__head-actions">
                             <button
                                 type="button"
-                                className="fw-icon-btn"
+                                className="yn-icon-btn"
                                 onClick={() => onJump(-1)}
                                 disabled={index === 0}
                                 title="Previous row (↑)"
@@ -86,7 +86,7 @@ const DraftItemDrawer: React.FC<DraftItemDrawerProps> = ({
                             </button>
                             <button
                                 type="button"
-                                className="fw-icon-btn"
+                                className="yn-icon-btn"
                                 onClick={() => onJump(1)}
                                 disabled={index === total - 1}
                                 title="Next row (↓)"
@@ -96,7 +96,7 @@ const DraftItemDrawer: React.FC<DraftItemDrawerProps> = ({
                             {onDelete && (
                                 <button
                                     type="button"
-                                    className="fw-icon-btn fw-icon-btn--danger"
+                                    className="yn-icon-btn yn-icon-btn--danger"
                                     onClick={onDelete}
                                     title="Delete row"
                                 >
@@ -105,7 +105,7 @@ const DraftItemDrawer: React.FC<DraftItemDrawerProps> = ({
                             )}
                             <button
                                 type="button"
-                                className="fw-icon-btn"
+                                className="yn-icon-btn"
                                 onClick={onClose}
                                 aria-label="Close drawer"
                             >
@@ -114,21 +114,21 @@ const DraftItemDrawer: React.FC<DraftItemDrawerProps> = ({
                         </div>
                     </header>
 
-                    <div className="fw-drawer__body">
+                    <div className="yn-drawer__body">
                         {children}
                     </div>
 
-                    <footer className="fw-drawer__foot">
-                        <span className="fw-drawer__foot-meta">
-                            Row <span className="fw-cell-mono fw-cell-strong">#{index + 1}</span> of {total}
+                    <footer className="yn-drawer__foot">
+                        <span className="yn-drawer__foot-meta">
+                            Row <span className="yn-cell-mono yn-cell-strong">#{index + 1}</span> of {total}
                         </span>
-                        <div className="fw-drawer__foot-actions">
-                            <button type="button" className="fw-btn fw-btn--ghost" onClick={onClose}>
+                        <div className="yn-drawer__foot-actions">
+                            <button type="button" className="yn-btn yn-btn--ghost" onClick={onClose}>
                                 Cancel
                             </button>
                             <button
                                 type="button"
-                                className="fw-btn fw-btn--primary"
+                                className="yn-btn yn-btn--primary"
                                 onClick={onApply}
                             >
                                 Apply

--- a/web/src/pages/_shared/draft/RemovedRowsSection.tsx
+++ b/web/src/pages/_shared/draft/RemovedRowsSection.tsx
@@ -72,13 +72,13 @@ const RemovedRowsSection = <T extends { id: string }>({
             {rows.map((r) => (
                 <div
                     key={r.id}
-                    className="fw-vrow"
+                    className="yn-vrow"
                     style={{
                         display: 'flex',
                         alignItems: 'center',
                         height: rowHeight,
                         minWidth: totalWidth,
-                        borderBottom: '1px solid var(--fw-line)',
+                        borderBottom: '1px solid var(--yn-line)',
                         paddingLeft: 4,
                         opacity: 0.55,
                         background: 'rgba(224, 122, 110, 0.04)',
@@ -87,17 +87,17 @@ const RemovedRowsSection = <T extends { id: string }>({
                 >
                     <div style={leadingCellStyle(leadingWidths.checkbox)} />
                     <div style={leadingCellStyle(leadingWidths.handle)}>
-                        <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--fw-danger)', fontSize: 11 }}>✕</span>
+                        <span style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--yn-danger)', fontSize: 11 }}>✕</span>
                     </div>
                     <div style={leadingCellStyle(leadingWidths.index)}>
-                        <span style={{ fontSize: 12, color: 'var(--fw-text-3)' }}>—</span>
+                        <span style={{ fontSize: 12, color: 'var(--yn-text-3)' }}>—</span>
                     </div>
                     <div style={leadingCellStyle(leadingWidths.status)}>
-                        <span className="fw-status-dot fw-status-dot--removed" title="Removed in draft" />
+                        <span className="yn-status-dot yn-status-dot--removed" title="Removed in draft" />
                     </div>
                     {columns.map((col, idx) => (
                         <div key={idx} style={dataCellStyle(col.width)}>
-                            <span style={{ textDecoration: 'line-through', textDecorationColor: 'var(--fw-danger)' }}>
+                            <span style={{ textDecoration: 'line-through', textDecorationColor: 'var(--yn-danger)' }}>
                                 {col.render(r)}
                             </span>
                         </div>
@@ -105,7 +105,7 @@ const RemovedRowsSection = <T extends { id: string }>({
                     <div style={{ marginLeft: 'auto', paddingRight: 8 }}>
                         <button
                             type="button"
-                            className="fw-row-edit-btn fw-row-edit-btn--visible"
+                            className="yn-row-edit-btn yn-row-edit-btn--visible"
                             onClick={() => onRestore(r)}
                             title="Restore row"
                             aria-label="Restore removed row"

--- a/web/src/pages/_shared/draft/RowHoverEditOverlay.test.tsx
+++ b/web/src/pages/_shared/draft/RowHoverEditOverlay.test.tsx
@@ -36,8 +36,8 @@ describe('RowHoverEditOverlay', () => {
                 onMouseLeave={() => {}}
             />,
         );
-        expect(container.querySelector('.fw-row-action-slot--wide')).toBeNull();
-        expect(container.querySelector('.fw-row-action-slot')).not.toBeNull();
+        expect(container.querySelector('.yn-row-action-slot--wide')).toBeNull();
+        expect(container.querySelector('.yn-row-action-slot')).not.toBeNull();
     });
 
     it('renders two buttons when onDelete is provided', () => {
@@ -74,7 +74,7 @@ describe('RowHoverEditOverlay', () => {
                 onMouseLeave={() => {}}
             />,
         );
-        const dangerBtn = document.querySelector('.fw-row-edit-btn--danger') as HTMLElement;
+        const dangerBtn = document.querySelector('.yn-row-edit-btn--danger') as HTMLElement;
         expect(dangerBtn).not.toBeNull();
         expect(dangerBtn.getAttribute('aria-label')).toBe('Delete row 1');
     });
@@ -94,7 +94,7 @@ describe('RowHoverEditOverlay', () => {
                 onMouseLeave={() => {}}
             />,
         );
-        expect(container.querySelector('.fw-row-action-slot--wide')).not.toBeNull();
+        expect(container.querySelector('.yn-row-action-slot--wide')).not.toBeNull();
     });
 
     it('fires onEdit when the edit button is clicked', () => {
@@ -146,7 +146,7 @@ describe('RowHoverEditOverlay', () => {
                 onMouseLeave={() => {}}
             />,
         );
-        const slot = container.querySelector('.fw-row-action-slot') as HTMLElement;
+        const slot = container.querySelector('.yn-row-action-slot') as HTMLElement;
         expect(slot.style.top).toBe('128px');
         expect(slot.style.height).toBe('48px');
     });

--- a/web/src/pages/_shared/draft/RowHoverEditOverlay.tsx
+++ b/web/src/pages/_shared/draft/RowHoverEditOverlay.tsx
@@ -43,14 +43,14 @@ const RowHoverEditOverlay: React.FC<RowHoverEditOverlayProps> = ({
     deleteIcon,
 }) => (
     <div
-        className={`fw-row-action-slot${onDelete ? ' fw-row-action-slot--wide' : ''}`}
+        className={`yn-row-action-slot${onDelete ? ' yn-row-action-slot--wide' : ''}`}
         style={{ top, height: rowHeight }}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
     >
         <button
             type="button"
-            className="fw-row-edit-btn fw-row-edit-btn--visible"
+            className="yn-row-edit-btn yn-row-edit-btn--visible"
             onClick={onEdit}
             aria-label={editAriaLabel}
             title={editTitle}
@@ -60,7 +60,7 @@ const RowHoverEditOverlay: React.FC<RowHoverEditOverlayProps> = ({
         {onDelete && (
             <button
                 type="button"
-                className="fw-row-edit-btn fw-row-edit-btn--visible fw-row-edit-btn--danger"
+                className="yn-row-edit-btn yn-row-edit-btn--visible yn-row-edit-btn--danger"
                 onClick={onDelete}
                 aria-label={deleteAriaLabel ?? 'Delete'}
                 title={deleteTitle ?? 'Delete'}

--- a/web/src/pages/_shared/draft/VirtualDraftTable.tsx
+++ b/web/src/pages/_shared/draft/VirtualDraftTable.tsx
@@ -100,18 +100,18 @@ const VirtualRowShell = memo(<T extends { id: string }>({
     }, [onHoverChange]);
 
     let rowBg = 'transparent';
-    if (selected) rowBg = 'var(--fw-accent-soft)';
-    else if (active || editing) rowBg = 'var(--fw-accent-soft)';
+    if (selected) rowBg = 'var(--yn-accent-soft)';
+    else if (active || editing) rowBg = 'var(--yn-accent-soft)';
 
     const dragCls = dragOver === 'top'
-        ? ' fw-vrow--drag-top'
+        ? ' yn-vrow--drag-top'
         : dragOver === 'bottom'
-            ? ' fw-vrow--drag-bottom'
+            ? ' yn-vrow--drag-bottom'
             : '';
 
     return (
         <div
-            className={`fw-vrow${active ? ' fw-vrow--active' : ''}${dragCls}${selected ? ' fw-vrow--selected' : ''}`}
+            className={`yn-vrow${active ? ' yn-vrow--active' : ''}${dragCls}${selected ? ' yn-vrow--selected' : ''}`}
             data-row-id={row.id}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
@@ -127,7 +127,7 @@ const VirtualRowShell = memo(<T extends { id: string }>({
                 width: '100%',
                 display: 'flex',
                 alignItems: 'center',
-                borderBottom: '1px solid var(--fw-line)',
+                borderBottom: '1px solid var(--yn-line)',
                 backgroundColor: rowBg,
                 paddingLeft: 4,
             }}
@@ -143,18 +143,18 @@ const VirtualRowShell = memo(<T extends { id: string }>({
                 style={{ width: LEADING_CELL_WIDTHS.handle, minWidth: LEADING_CELL_WIDTHS.handle, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                 onClick={(e) => e.stopPropagation()}
             >
-                <div className="fw-drag-handle" draggable onDragStart={onDragStart} title="Drag to reorder">
+                <div className="yn-drag-handle" draggable onDragStart={onDragStart} title="Drag to reorder">
                     {DRAG_ICON}
                 </div>
             </div>
 
-            <div style={{ width: LEADING_CELL_WIDTHS.index, minWidth: LEADING_CELL_WIDTHS.index, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--fw-text-3)', fontVariantNumeric: 'tabular-nums' }}>
+            <div style={{ width: LEADING_CELL_WIDTHS.index, minWidth: LEADING_CELL_WIDTHS.index, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--yn-text-3)', fontVariantNumeric: 'tabular-nums' }}>
                 <span style={{ fontSize: 12 }}>{realIndex + 1}</span>
             </div>
 
             <div style={{ width: LEADING_CELL_WIDTHS.status, minWidth: LEADING_CELL_WIDTHS.status, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                {status === 'added' && <span className="fw-status-dot fw-status-dot--added" title="Added (not yet committed)" />}
-                {status === 'changed' && <span className="fw-status-dot fw-status-dot--changed" title="Modified (not yet committed)" />}
+                {status === 'added' && <span className="yn-status-dot yn-status-dot--added" title="Added (not yet committed)" />}
+                {status === 'changed' && <span className="yn-status-dot yn-status-dot--changed" title="Modified (not yet committed)" />}
             </div>
 
             {renderDataCells(row)}
@@ -283,9 +283,9 @@ export const VirtualDraftTable = <T extends { id: string }>({
     }, [virtualRows, visibleRows.length]);
 
     return (
-        <div ref={wrapRef} className="fw-tbl-wrap">
-            <div className="fw-tbl-header-row">
-                <div className="fw-vtbl-header" style={{ height: HEADER_HEIGHT, minWidth: totalWidth }}>
+        <div ref={wrapRef} className="yn-table-wrap">
+            <div className="yn-table-header-row">
+                <div className="yn-vtbl-header" style={{ height: HEADER_HEIGHT, minWidth: totalWidth }}>
                     <div
                         style={{ width: LEADING_CELL_WIDTHS.checkbox, minWidth: LEADING_CELL_WIDTHS.checkbox, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                         onClick={(e) => e.stopPropagation()}
@@ -294,12 +294,12 @@ export const VirtualDraftTable = <T extends { id: string }>({
                     </div>
                     <div style={{ width: LEADING_CELL_WIDTHS.handle, minWidth: LEADING_CELL_WIDTHS.handle, flexShrink: 0 }} />
                     <div style={{ width: LEADING_CELL_WIDTHS.index, minWidth: LEADING_CELL_WIDTHS.index, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                        <span className="fw-th-text">#</span>
+                        <span className="yn-th-text">#</span>
                     </div>
                     <div style={{ width: LEADING_CELL_WIDTHS.status, minWidth: LEADING_CELL_WIDTHS.status, flexShrink: 0 }} />
                     {columnHeaders.map((col) => (
                         <div key={col.label} style={{ width: col.width, minWidth: col.width, flexShrink: 0, display: 'flex', alignItems: 'center', paddingRight: 8 }}>
-                            <span className="fw-th-text">{col.label}</span>
+                            <span className="yn-th-text">{col.label}</span>
                         </div>
                     ))}
                 </div>
@@ -313,11 +313,11 @@ export const VirtualDraftTable = <T extends { id: string }>({
 
             <div
                 ref={setScrollRef}
-                className="fw-vtbl-body"
+                className="yn-vtbl-body"
                 style={bodyHeight > 0 ? { flex: '0 0 auto', height: bodyHeight } : undefined}
             >
                 {visibleRows.length === 0 ? (
-                    <div className="fw-table-empty">{emptyMessage}</div>
+                    <div className="yn-table-empty">{emptyMessage}</div>
                 ) : (
                     <div style={{ height: rowVirtualizer.getTotalSize(), minWidth: totalWidth, position: 'relative' }}>
                         {virtualRows.map((virtualRow) => {
@@ -359,8 +359,8 @@ export const VirtualDraftTable = <T extends { id: string }>({
                 />
             </div>
 
-            <div className="fw-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
-                <span className="fw-toolbar__count">{footerText}</span>
+            <div className="yn-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
+                <span className="yn-toolbar__count">{footerText}</span>
             </div>
 
             {hoveredRow !== null && (

--- a/web/src/pages/_shared/draft/useRowHoverOverlay.ts
+++ b/web/src/pages/_shared/draft/useRowHoverOverlay.ts
@@ -5,7 +5,7 @@ export interface UseRowHoverOverlayResult<T> {
     hoveredRow: T | null;
     /** Virtualizer start offset (px) of the hovered row. */
     hoveredStart: number;
-    /** Top offset of the overlay relative to .fw-tbl-wrap. */
+    /** Top offset of the overlay relative to .yn-table-wrap. */
     overlayTopOffset: number;
     /** Call from the row's onMouseEnter/onMouseLeave. Pass null to begin the hide delay. */
     handleHoverChange: (row: T | null, start: number) => void;

--- a/web/src/pages/modules/_shared/chips.scss
+++ b/web/src/pages/modules/_shared/chips.scss
@@ -3,12 +3,12 @@
     align-items: center;
     padding: 1px 7px;
     border-radius: 4px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 12px;
     font-weight: 500;
     white-space: nowrap;
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
     flex-shrink: 0;
 }
 
@@ -53,7 +53,7 @@
 }
 
 .shared-chip--proto-dim {
-    background: var(--fw-bg-2);
-    color: var(--fw-text-3);
-    border-color: var(--fw-line-2);
+    background: var(--yn-bg-2);
+    color: var(--yn-text-3);
+    border-color: var(--yn-line-2);
 }

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -365,10 +365,10 @@ const AclPage: React.FC = () => {
 
     return (
         <PageLayout header={pageHeader}>
-            <div className="fw-page">
+            <div className="yn-page">
                 {draftConfigs.length === 0 ? (
-                    <div className="fw-empty-page">
-                        <div className="fw-empty-page__message">
+                    <div className="yn-empty-page">
+                        <div className="yn-empty-page__message">
                             No ACL configurations found.
                         </div>
                         <Button view="action" onClick={() => setAddConfigOpen(true)}>
@@ -386,7 +386,7 @@ const AclPage: React.FC = () => {
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
 
-                        <div className="fw-content">
+                        <div className="yn-content">
                             <RuleTable
                                 items={visibleItems}
                                 selectedIds={selectedIds}

--- a/web/src/pages/modules/acl/ChipInput.tsx
+++ b/web/src/pages/modules/acl/ChipInput.tsx
@@ -73,46 +73,46 @@ const BulkPasteModal: React.FC<BulkPasteModalProps> = ({ existing, validate, onC
         <Dialog open onClose={onClose} size="m">
             <Dialog.Header caption="Bulk paste" />
             <Dialog.Body>
-                <p style={{ margin: '0 0 10px', fontSize: 12.5, color: 'var(--fw-text-3)' }}>
+                <p style={{ margin: '0 0 10px', fontSize: 12.5, color: 'var(--yn-text-3)' }}>
                     Whitespace, comma, or newline separated values.
                 </p>
                 <textarea
                     autoFocus
-                    className="fw-input fw-input--mono"
-                    style={{ width: '100%', height: 220, resize: 'vertical', fontFamily: 'var(--fw-font-mono)', fontSize: 12 }}
+                    className="yn-input yn-input--mono"
+                    style={{ width: '100%', height: 220, resize: 'vertical', fontFamily: 'var(--yn-font-mono)', fontSize: 12 }}
                     value={text}
                     placeholder={'10.0.0.0/24\n10.0.1.0/24, 10.0.2.0/24\n2001:db8::/32'}
                     onChange={e => setText(e.target.value)}
                     spellCheck={false}
                 />
                 <div style={{ display: 'flex', gap: 14, marginTop: 10, fontSize: 12.5, flexWrap: 'wrap', alignItems: 'center' }}>
-                    <span style={{ color: 'var(--fw-text-3)' }}>parsed:</span>
-                    <span style={{ fontFamily: 'var(--fw-font-mono)' }}>{parsed.length} total</span>
+                    <span style={{ color: 'var(--yn-text-3)' }}>parsed:</span>
+                    <span style={{ fontFamily: 'var(--yn-font-mono)' }}>{parsed.length} total</span>
                     {invalid.length > 0 && (
-                        <span style={{ color: 'var(--g-color-text-danger)', fontFamily: 'var(--fw-font-mono)' }}>
+                        <span style={{ color: 'var(--g-color-text-danger)', fontFamily: 'var(--yn-font-mono)' }}>
                             {invalid.length} invalid
                         </span>
                     )}
                     {dupCount > 0 && (
-                        <span style={{ color: 'var(--fw-text-3)', fontFamily: 'var(--fw-font-mono)' }}>
+                        <span style={{ color: 'var(--yn-text-3)', fontFamily: 'var(--yn-font-mono)' }}>
                             {dupCount} duplicate
                         </span>
                     )}
-                    <span style={{ fontFamily: 'var(--fw-font-mono)', color: 'var(--g-color-text-warning)' }}>
+                    <span style={{ fontFamily: 'var(--yn-font-mono)', color: 'var(--g-color-text-warning)' }}>
                         {validCount} will be {mode === 'replace' ? 'set' : 'added'}
                     </span>
                 </div>
                 <div style={{ display: 'flex', gap: 8, marginTop: 12 }}>
                     <button
                         type="button"
-                        className={`fw-btn ${mode === 'append' ? 'fw-btn--primary' : 'fw-btn--ghost'}`}
+                        className={`yn-btn ${mode === 'append' ? 'yn-btn--primary' : 'yn-btn--ghost'}`}
                         onClick={() => setMode('append')}
                     >
                         Append
                     </button>
                     <button
                         type="button"
-                        className={`fw-btn ${mode === 'replace' ? 'fw-btn--primary' : 'fw-btn--ghost'}`}
+                        className={`yn-btn ${mode === 'replace' ? 'yn-btn--primary' : 'yn-btn--ghost'}`}
                         onClick={() => setMode('replace')}
                     >
                         Replace all
@@ -158,7 +158,7 @@ const ListPopover: React.FC<ListPopoverProps> = ({ items, label, onClose }) => {
             <Dialog.Header caption={label} />
             <Dialog.Body>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 10, minHeight: 0, maxHeight: '50vh' }}>
-                    <div style={{ fontSize: 12, color: 'var(--fw-text-3)', marginBottom: 4 }}>{stats}</div>
+                    <div style={{ fontSize: 12, color: 'var(--yn-text-3)', marginBottom: 4 }}>{stats}</div>
                     <TextInput
                         autoFocus
                         value={q}
@@ -170,8 +170,8 @@ const ListPopover: React.FC<ListPopoverProps> = ({ items, label, onClose }) => {
                     <div style={{
                         flex: 1,
                         overflow: 'auto',
-                        background: 'var(--fw-bg-2)',
-                        border: '1px solid var(--fw-line)',
+                        background: 'var(--yn-bg-2)',
+                        border: '1px solid var(--yn-line)',
                         borderRadius: 6,
                         padding: 8,
                         display: 'flex',
@@ -182,7 +182,7 @@ const ListPopover: React.FC<ListPopoverProps> = ({ items, label, onClose }) => {
                         maxHeight: 320,
                     }}>
                         {filtered.length === 0 ? (
-                            <span style={{ color: 'var(--fw-text-3)', fontSize: 12, padding: 12 }}>No matches.</span>
+                            <span style={{ color: 'var(--yn-text-3)', fontSize: 12, padding: 12 }}>No matches.</span>
                         ) : (
                             filtered.map((s, idx) => {
                                 const isV6 = s.includes(':');
@@ -196,10 +196,10 @@ const ListPopover: React.FC<ListPopoverProps> = ({ items, label, onClose }) => {
                         )}
                     </div>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 12 }}>
-                        <span style={{ color: 'var(--fw-text-3)' }}>
+                        <span style={{ color: 'var(--yn-text-3)' }}>
                             Showing {filtered.length} of {items.length}
                         </span>
-                        <button type="button" className="fw-btn fw-btn--ghost" style={{ fontSize: 12, padding: '2px 10px' }} onClick={copyAll}>
+                        <button type="button" className="yn-btn yn-btn--ghost" style={{ fontSize: 12, padding: '2px 10px' }} onClick={copyAll}>
                             Copy all
                         </button>
                     </div>
@@ -328,7 +328,7 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                     </div>
                     <button
                         type="button"
-                        className="fw-btn fw-btn--ghost"
+                        className="yn-btn yn-btn--ghost"
                         style={{ fontSize: 11, padding: '2px 8px' }}
                         onClick={() => setBulkOpen(true)}
                     >
@@ -337,7 +337,7 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                     {isBig && (
                         <button
                             type="button"
-                            className="fw-btn fw-btn--ghost"
+                            className="yn-btn yn-btn--ghost"
                             style={{ fontSize: 11, padding: '2px 8px' }}
                             onClick={() => setPopoverOpen(true)}
                             title="View full list"
@@ -347,21 +347,21 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                     )}
                     <button
                         type="button"
-                        className="fw-btn fw-btn--ghost"
+                        className="yn-btn yn-btn--ghost"
                         style={{ fontSize: 11, padding: '2px 8px', color: 'var(--g-color-text-danger)' }}
                         onClick={() => onChange([])}
                         title="Remove all"
                     >
                         Clear
                     </button>
-                    <span style={{ fontSize: 11, color: 'var(--fw-text-3)', fontFamily: 'var(--fw-font-mono)' }}>
+                    <span style={{ fontSize: 11, color: 'var(--yn-text-3)', fontFamily: 'var(--yn-font-mono)' }}>
                         {value.length}
                     </span>
                 </div>
             )}
 
             <div
-                className={`fw-chip-input${isMany ? ' fw-chip-input--many' : ''}`}
+                className={`yn-chip-input${isMany ? ' yn-chip-input--many' : ''}`}
                 onClick={() => !filter && inputRef.current?.focus()}
             >
                 {wildcardLabel && value.length === 0 && (
@@ -371,9 +371,9 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                     const v = value[idx];
                     const valid = validator(v);
                     return (
-                        <span key={idx} className={`fw-chip${valid ? '' : ' fw-chip--invalid'}`}>
+                        <span key={idx} className={`yn-chip${valid ? '' : ' yn-chip--invalid'}`}>
                             <span
-                                className="fw-chip__label"
+                                className="yn-chip__label"
                                 role="button"
                                 tabIndex={0}
                                 title="Click to edit"
@@ -398,7 +398,7 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                             </span>
                             <button
                                 type="button"
-                                className="fw-chip__x"
+                                className="yn-chip__x"
                                 onClick={(e) => {
                                     e.stopPropagation();
                                     onChange(value.filter((_, j) => j !== idx));
@@ -411,7 +411,7 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                     );
                 })}
                 {filter && filteredIndices.length === 0 && (
-                    <span style={{ fontSize: 12, color: 'var(--fw-text-3)', fontFamily: 'var(--fw-font-mono)' }}>
+                    <span style={{ fontSize: 12, color: 'var(--yn-text-3)', fontFamily: 'var(--yn-font-mono)' }}>
                         no matches
                     </span>
                 )}
@@ -425,7 +425,7 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                         onKeyDown={handleKeyDown}
                         onBlur={handleBlur}
                         onPaste={handlePaste}
-                        className="fw-chip-input__raw"
+                        className="yn-chip-input__raw"
                     />
                 )}
             </div>
@@ -433,7 +433,7 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
             {!isMany && (
                 <button
                     type="button"
-                    className="fw-btn fw-btn--ghost"
+                    className="yn-btn yn-btn--ghost"
                     style={{ fontSize: 11, alignSelf: 'flex-start', padding: '2px 8px' }}
                     onClick={() => setBulkOpen(true)}
                 >

--- a/web/src/pages/modules/acl/RuleDrawer.tsx
+++ b/web/src/pages/modules/acl/RuleDrawer.tsx
@@ -135,20 +135,20 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
     return (
         <>
             <div
-                className={`fw-backdrop${open ? ' fw-backdrop--open' : ''}`}
+                className={`yn-backdrop${open ? ' yn-backdrop--open' : ''}`}
                 onClick={handleClose}
                 aria-hidden="true"
             />
             <aside
-                className={`fw-drawer${open ? ' fw-drawer--open' : ''}`}
+                className={`yn-drawer${open ? ' yn-drawer--open' : ''}`}
                 role="dialog"
                 aria-modal="true"
                 aria-label={mode === 'add' ? 'Add ACL rule' : 'Edit ACL rule'}
             >
-                <header className="fw-drawer__head">
-                    <h2 className="fw-drawer__title">
+                <header className="yn-drawer__head">
+                    <h2 className="yn-drawer__title">
                         {mode === 'add' ? 'New rule' : (
-                            <>Edit rule <span className="fw-drawer__rule-num">#{ruleItem?.index !== undefined ? ruleItem.index + 1 : ''}</span></>
+                            <>Edit rule <span className="yn-drawer__rule-num">#{ruleItem?.index !== undefined ? ruleItem.index + 1 : ''}</span></>
                         )}
                         {draftClassification.isDead && (
                             <span
@@ -167,12 +167,12 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                             </span>
                         )}
                     </h2>
-                    <div className="fw-drawer__head-actions">
+                    <div className="yn-drawer__head-actions">
                         {mode === 'edit' && ruleItem && (
                             <>
                                 <button
                                     type="button"
-                                    className="fw-icon-btn"
+                                    className="yn-icon-btn"
                                     onClick={() => onDuplicate(ruleItem)}
                                     title="Duplicate rule"
                                 >
@@ -180,7 +180,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                 </button>
                                 <button
                                     type="button"
-                                    className="fw-icon-btn fw-icon-btn--danger"
+                                    className="yn-icon-btn yn-icon-btn--danger"
                                     onClick={() => onDelete(ruleItem)}
                                     title="Delete rule"
                                 >
@@ -190,7 +190,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                         )}
                         <button
                             type="button"
-                            className="fw-icon-btn"
+                            className="yn-icon-btn"
                             onClick={handleClose}
                             aria-label="Close drawer"
                         >
@@ -199,21 +199,21 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                     </div>
                 </header>
 
-                <div className="fw-drawer__body">
-                    <section className="fw-section">
-                        <div className="fw-section-h">Actions</div>
-                        <div className="fw-section__body">
-                            <div className="fw-field">
-                                <label className="fw-field__label">
+                <div className="yn-drawer__body">
+                    <section className="yn-section">
+                        <div className="yn-section-h">Actions</div>
+                        <div className="yn-section__body">
+                            <div className="yn-field">
+                                <label className="yn-field__label">
                                     Action chain
-                                    <span className="fw-field__count">{draft.actions.length} step{draft.actions.length !== 1 ? 's' : ''}</span>
+                                    <span className="yn-field__count">{draft.actions.length} step{draft.actions.length !== 1 ? 's' : ''}</span>
                                 </label>
                                 <div className="acl-action-editor">
                                     {draft.actions.map((kind, idx) => (
                                         <div key={idx} className="acl-action-row">
                                             <span className="acl-action-row__idx">{idx + 1}.</span>
                                             <select
-                                                className="fw-input acl-action-select"
+                                                className="yn-input acl-action-select"
                                                 value={kind}
                                                 onChange={e => changeAction(idx, parseInt(e.target.value, 10) as ActionKind)}
                                             >
@@ -225,7 +225,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                             </select>
                                             <button
                                                 type="button"
-                                                className="fw-icon-btn fw-icon-btn--danger"
+                                                className="yn-icon-btn yn-icon-btn--danger"
                                                 onClick={() => removeAction(idx)}
                                                 aria-label={`Remove step ${idx + 1}`}
                                                 title="Remove step"
@@ -239,7 +239,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                             <button
                                                 key={kind}
                                                 type="button"
-                                                className="fw-btn fw-btn--ghost acl-action-preset"
+                                                className="yn-btn yn-btn--ghost acl-action-preset"
                                                 onClick={() => addAction(kind)}
                                             >
                                                 + {ACTION_KIND_LABELS[kind]}
@@ -248,29 +248,29 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                     </div>
                                 </div>
                                 {hasNoTerminal && (
-                                    <span className="fw-field__hint acl-hint--warn">
+                                    <span className="yn-field__hint acl-hint--warn">
                                         No terminal action (pass/deny) — traffic will fall through.
                                     </span>
                                 )}
                                 {hasUnreachable && (
-                                    <span className="fw-field__hint acl-hint--warn">
+                                    <span className="yn-field__hint acl-hint--warn">
                                         Steps after step {terminalIdx + 1} are unreachable.
                                     </span>
                                 )}
                             </div>
-                            <div className="fw-field">
-                                <label className="fw-field__label">
-                                    Counter <span className="fw-field__optional">optional</span>
+                            <div className="yn-field">
+                                <label className="yn-field__label">
+                                    Counter <span className="yn-field__optional">optional</span>
                                 </label>
                                 <input
-                                    className="fw-input"
+                                    className="yn-input"
                                     placeholder={mode === 'edit' && ruleItem !== null
                                         ? `${defaultCounterName(ruleItem.index)} (default)`
                                         : `${defaultCounterName(nextIndex)} (default)`}
                                     value={draft.counter}
                                     onChange={e => updateField('counter', e.target.value)}
                                 />
-                                <span className="fw-field__hint">
+                                <span className="yn-field__hint">
                                     Counter name shown in /stats.
                                     {ruleItem !== null
                                         ? ' Leave empty to use the auto-assigned default name (shifts with rule position).'
@@ -280,17 +280,17 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                         </div>
                     </section>
 
-                    <section className="fw-section">
-                        <div className="fw-section-h">Match — addresses</div>
-                        <div className="fw-section__body">
-                            <div className="fw-fgrid">
-                                <div className="fw-field">
-                                    <label className="fw-field__label">
+                    <section className="yn-section">
+                        <div className="yn-section-h">Match — addresses</div>
+                        <div className="yn-section__body">
+                            <div className="yn-fgrid">
+                                <div className="yn-field">
+                                    <label className="yn-field__label">
                                         Sources
                                         <div className="acl-field-label-actions">
                                             <button
                                                 type="button"
-                                                className="fw-btn fw-btn--ghost fw-btn--sm acl-any-btn"
+                                                className="yn-btn yn-btn--ghost yn-btn--sm acl-any-btn"
                                                 onClick={() => {
                                                     updateField('sourceCidrs', addWildcards(draft.sourceCidrs));
                                                 }}
@@ -298,7 +298,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                             >
                                                 + any
                                             </button>
-                                            <span className="fw-field__count">{draft.sourceCidrs.length}</span>
+                                            <span className="yn-field__count">{draft.sourceCidrs.length}</span>
                                         </div>
                                     </label>
                                     <ChipInput
@@ -309,15 +309,15 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                         kind="cidr"
                                         validator={isValidCidr}
                                     />
-                                    <span className="fw-field__hint">Empty = no IP match.</span>
+                                    <span className="yn-field__hint">Empty = no IP match.</span>
                                 </div>
-                                <div className="fw-field">
-                                    <label className="fw-field__label">
+                                <div className="yn-field">
+                                    <label className="yn-field__label">
                                         Destinations
                                         <div className="acl-field-label-actions">
                                             <button
                                                 type="button"
-                                                className="fw-btn fw-btn--ghost fw-btn--sm acl-any-btn"
+                                                className="yn-btn yn-btn--ghost yn-btn--sm acl-any-btn"
                                                 onClick={() => {
                                                     updateField('dstCidrs', addWildcards(draft.dstCidrs));
                                                 }}
@@ -325,7 +325,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                             >
                                                 + any
                                             </button>
-                                            <span className="fw-field__count">{draft.dstCidrs.length}</span>
+                                            <span className="yn-field__count">{draft.dstCidrs.length}</span>
                                         </div>
                                     </label>
                                     <ChipInput
@@ -336,44 +336,44 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                         kind="cidr"
                                         validator={isValidCidr}
                                     />
-                                    <span className="fw-field__hint">Empty = no IP match.</span>
+                                    <span className="yn-field__hint">Empty = no IP match.</span>
                                 </div>
                             </div>
                         </div>
                     </section>
 
-                    <section className="fw-section">
-                        <div className="fw-section-h">Match — ports and protocols</div>
-                        <div className="fw-section__body">
-                            <div className="fw-fgrid">
-                                <div className="fw-field">
-                                    <label className="fw-field__label">Src port ranges</label>
+                    <section className="yn-section">
+                        <div className="yn-section-h">Match — ports and protocols</div>
+                        <div className="yn-section__body">
+                            <div className="yn-fgrid">
+                                <div className="yn-field">
+                                    <label className="yn-field__label">Src port ranges</label>
                                     <input
-                                        className="fw-input fw-input--mono"
+                                        className="yn-input yn-input--mono"
                                         placeholder="0-65535"
                                         value={draft.srcPortRaw}
                                         onChange={e => updateField('srcPortRaw', e.target.value)}
                                     />
-                                    <span className="fw-field__hint">e.g. <code>80</code>, <code>80-90</code>, <code>80, 443</code>. Empty = any.</span>
+                                    <span className="yn-field__hint">e.g. <code>80</code>, <code>80-90</code>, <code>80, 443</code>. Empty = any.</span>
                                 </div>
-                                <div className="fw-field">
-                                    <label className="fw-field__label">Dst port ranges</label>
+                                <div className="yn-field">
+                                    <label className="yn-field__label">Dst port ranges</label>
                                     <input
-                                        className="fw-input fw-input--mono"
+                                        className="yn-input yn-input--mono"
                                         placeholder="0-65535"
                                         value={draft.dstPortRaw}
                                         onChange={e => updateField('dstPortRaw', e.target.value)}
                                     />
-                                    <span className="fw-field__hint">e.g. <code>80</code>, <code>443</code>, <code>8080-8443</code>. Empty = any.</span>
+                                    <span className="yn-field__hint">e.g. <code>80</code>, <code>443</code>, <code>8080-8443</code>. Empty = any.</span>
                                 </div>
                             </div>
-                            <div className="fw-field">
-                                <label className="fw-field__label">
+                            <div className="yn-field">
+                                <label className="yn-field__label">
                                     Protocol ranges
                                     <div className="acl-field-label-actions">
                                         <button
                                             type="button"
-                                            className="fw-btn fw-btn--ghost fw-btn--sm acl-any-btn"
+                                            className="yn-btn yn-btn--ghost yn-btn--sm acl-any-btn"
                                             onClick={() => updateField('protoRaw', '0-65535')}
                                             title="Set to full range (any protocol)"
                                         >
@@ -382,12 +382,12 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                     </div>
                                 </label>
                                 <input
-                                    className="fw-input fw-input--mono"
+                                    className="yn-input yn-input--mono"
                                     placeholder="1536-1791"
                                     value={draft.protoRaw}
                                     onChange={e => updateField('protoRaw', e.target.value)}
                                 />
-                                <span className="fw-field__hint">
+                                <span className="yn-field__hint">
                                     Encoded as <code>(ip_proto &lt;&lt; 8) | subtype</code>.
                                     TCP=<code>1536-1791</code>, UDP=<code>4352-4607</code>, ICMP=<code>256-511</code>.
                                     Empty = no match.
@@ -404,7 +404,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                         <button
                                             key={range}
                                             type="button"
-                                            className="fw-btn fw-btn--ghost acl-proto-preset"
+                                            className="yn-btn yn-btn--ghost acl-proto-preset"
                                             onClick={() => {
                                                 const current = draft.protoRaw.trim();
                                                 if (!current) {
@@ -422,25 +422,25 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                         </div>
                     </section>
 
-                    <section className="fw-section">
-                        <div className="fw-section-h">Match — L2 / device</div>
-                        <div className="fw-section__body">
-                            <div className="fw-field">
-                                <label className="fw-field__label">VLAN ranges</label>
+                    <section className="yn-section">
+                        <div className="yn-section-h">Match — L2 / device</div>
+                        <div className="yn-section__body">
+                            <div className="yn-field">
+                                <label className="yn-field__label">VLAN ranges</label>
                                 <input
-                                    className="fw-input fw-input--mono"
+                                    className="yn-input yn-input--mono"
                                     placeholder="0-4095"
                                     value={draft.vlanRaw}
                                     onChange={e => updateField('vlanRaw', e.target.value)}
                                 />
-                                <span className="fw-field__hint">
+                                <span className="yn-field__hint">
                                     Single <code>100</code>, range <code>100-200</code>, list <code>100, 200, 300-400</code>. Empty = all VLANs.
                                 </span>
                             </div>
-                            <div className="fw-field">
-                                <label className="fw-field__label">
+                            <div className="yn-field">
+                                <label className="yn-field__label">
                                     Devices
-                                    <span className="fw-field__count">{draft.deviceNames.length || 'any'}</span>
+                                    <span className="yn-field__count">{draft.deviceNames.length || 'any'}</span>
                                 </label>
                                 <ChipInput
                                     ref={deviceNamesRef}
@@ -456,19 +456,19 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                     </section>
                 </div>
 
-                <footer className="fw-drawer__foot">
-                    <span className="fw-drawer__foot-meta">
+                <footer className="yn-drawer__foot">
+                    <span className="yn-drawer__foot-meta">
                         {mode === 'add'
                             ? 'Will be appended to config.'
                             : `Rule #${(ruleItem?.index ?? -1) + 1}`}
                     </span>
-                    <div className="fw-drawer__foot-actions">
-                        <button type="button" className="fw-btn fw-btn--ghost" onClick={handleClose}>
+                    <div className="yn-drawer__foot-actions">
+                        <button type="button" className="yn-btn yn-btn--ghost" onClick={handleClose}>
                             Cancel
                         </button>
                         <button
                             type="button"
-                            className="fw-btn fw-btn--primary"
+                            className="yn-btn yn-btn--primary"
                             onClick={handleApply}
                         >
                             Apply

--- a/web/src/pages/modules/acl/RuleTable.tsx
+++ b/web/src/pages/modules/acl/RuleTable.tsx
@@ -95,11 +95,11 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
     }, [onHoverChange]);
 
     let rowBg = 'transparent';
-    if (active || selected) rowBg = 'var(--fw-accent-soft)';
+    if (active || selected) rowBg = 'var(--yn-accent-soft)';
 
     return (
         <div
-            className={`fw-vrow${selected ? ' fw-vrow--selected' : ''}${active ? ' fw-vrow--active' : ''}`}
+            className={`yn-vrow${selected ? ' yn-vrow--selected' : ''}${active ? ' yn-vrow--active' : ''}`}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             style={{
@@ -111,7 +111,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 width: '100%',
                 display: 'flex',
                 alignItems: 'center',
-                borderBottom: '1px solid var(--fw-line)',
+                borderBottom: '1px solid var(--yn-line)',
                 backgroundColor: rowBg,
                 paddingLeft: 4,
             }}
@@ -124,7 +124,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 />
             </div>
 
-            <div style={{ ...cellStyle('index'), color: 'var(--fw-text-3)', fontVariantNumeric: 'tabular-nums', flexDirection: 'column', gap: 2 }}>
+            <div style={{ ...cellStyle('index'), color: 'var(--yn-text-3)', fontVariantNumeric: 'tabular-nums', flexDirection: 'column', gap: 2 }}>
                 <span style={{ fontSize: 12 }}>{item.index + 1}</span>
                 {expanded.isDead && (
                     <span
@@ -146,7 +146,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
 
             <div style={cellStyle('srcs')}>
                 {expanded.isEmptySrc
-                    ? <span className="fw-cell-mono fw-cell-muted">—</span>
+                    ? <span className="yn-cell-mono yn-cell-muted">—</span>
                     : <ChipList
                         items={expanded.sourceCidrs}
                         renderChip={(cidr, idx) => <IpNetChip key={idx} cidr={cidr} />}
@@ -161,7 +161,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
 
             <div style={cellStyle('dsts')}>
                 {expanded.dstCidrs.length === 0
-                    ? <span className="fw-cell-mono fw-cell-muted">—</span>
+                    ? <span className="yn-cell-mono yn-cell-muted">—</span>
                     : <ChipList
                         items={expanded.dstCidrs}
                         renderChip={(cidr, idx) => <IpNetChip key={idx} cidr={cidr} />}
@@ -202,7 +202,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
 
             <div style={cellStyle('protos')}>
                 {expanded.protoRanges.length === 0
-                    ? <span className="fw-cell-mono fw-cell-muted">—</span>
+                    ? <span className="yn-cell-mono yn-cell-muted">—</span>
                     : <ChipList
                         items={expanded.protoRanges}
                         isAny={expanded.isAnyProto}
@@ -245,8 +245,8 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
 
             <div style={cellStyle('counter')} title={item.counter || `rule ${item.index} (default)`}>
                 {item.counter
-                    ? <span className="fw-cell-mono">{item.counter}</span>
-                    : <span className="fw-cell-mono fw-cell-muted">rule {item.index}</span>
+                    ? <span className="yn-cell-mono">{item.counter}</span>
+                    : <span className="yn-cell-mono yn-cell-muted">rule {item.index}</span>
                 }
             </div>
 
@@ -256,7 +256,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                         {rate ? (
                             <>
                                 <Sparkline values={rate.history} width={120} height={22} />
-                                <span className="fw-cell-pps acl-cell-pps" title={`${rate.pps.toFixed(0)} pps`}>
+                                <span className="yn-cell-pps acl-cell-pps" title={`${rate.pps.toFixed(0)} pps`}>
                                     {rate.pps >= 1000
                                         ? `${(rate.pps / 1000).toFixed(1)}k`
                                         : rate.pps.toFixed(0)}
@@ -265,7 +265,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                         ) : (
                             <>
                                 <Sparkline values={null} width={120} height={22} />
-                                <span className="fw-cell-pps acl-cell-pps acl-pps-loading" title="Waiting for counter data">…</span>
+                                <span className="yn-cell-pps acl-cell-pps acl-pps-loading" title="Waiting for counter data">…</span>
                             </>
                         )}
                         <button
@@ -281,7 +281,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 ) : (
                     <>
                         <Sparkline values={null} width={120} height={22} />
-                        <span className="fw-cell-pps acl-cell-pps" style={{ color: 'var(--fw-text-3)' }}>—</span>
+                        <span className="yn-cell-pps acl-cell-pps" style={{ color: 'var(--yn-text-3)' }}>—</span>
                         <button
                             type="button"
                             className={`acl-counter-toggle acl-counter-toggle--off${!item.counter ? ' acl-counter-toggle--default' : ''}`}
@@ -432,11 +432,11 @@ const RuleTable: React.FC<RuleTableProps> = ({
     return (
         <div
             ref={wrapRef}
-            className="fw-tbl-wrap acl-table"
+            className="yn-table-wrap acl-table"
         >
-            <div className="fw-tbl-header-row">
+            <div className="yn-table-header-row">
                 <div
-                    className="fw-vtbl-header"
+                    className="yn-vtbl-header"
                     style={{ height: HEADER_HEIGHT }}
                 >
                     <div ref={headerInnerRef} style={{ display: 'flex', minWidth: TOTAL_WIDTH, height: '100%', alignItems: 'center', willChange: 'transform' }}>
@@ -450,37 +450,37 @@ const RuleTable: React.FC<RuleTableProps> = ({
                         />
                     </div>
                     <div style={{ ...cellStyle('index'), justifyContent: 'center' }}>
-                        <span className="fw-th-text">#</span>
+                        <span className="yn-th-text">#</span>
                     </div>
                     <div style={cellStyle('srcs')}>
-                        <span className="fw-th-text">Sources</span>
+                        <span className="yn-th-text">Sources</span>
                     </div>
                     <div style={cellStyle('dsts')}>
-                        <span className="fw-th-text">Destinations</span>
+                        <span className="yn-th-text">Destinations</span>
                     </div>
                     <div style={cellStyle('src_ports')}>
-                        <span className="fw-th-text">Src ports</span>
+                        <span className="yn-th-text">Src ports</span>
                     </div>
                     <div style={cellStyle('dst_ports')}>
-                        <span className="fw-th-text">Dst ports</span>
+                        <span className="yn-th-text">Dst ports</span>
                     </div>
                     <div style={cellStyle('protos')}>
-                        <span className="fw-th-text">Protocols</span>
+                        <span className="yn-th-text">Protocols</span>
                     </div>
                     <div style={cellStyle('vlans')}>
-                        <span className="fw-th-text">VLANs</span>
+                        <span className="yn-th-text">VLANs</span>
                     </div>
                     <div style={cellStyle('devices')}>
-                        <span className="fw-th-text">Devices</span>
+                        <span className="yn-th-text">Devices</span>
                     </div>
                     <div style={cellStyle('counter')}>
-                        <span className="fw-th-text">Counter</span>
+                        <span className="yn-th-text">Counter</span>
                     </div>
                     <div style={cellStyle('sparkline')}>
-                        <span className="fw-th-text">pps</span>
+                        <span className="yn-th-text">pps</span>
                     </div>
                     <div style={cellStyle('actions')}>
-                        <span className="fw-th-text">Actions</span>
+                        <span className="yn-th-text">Actions</span>
                     </div>
                     </div>
                 </div>
@@ -494,11 +494,11 @@ const RuleTable: React.FC<RuleTableProps> = ({
 
             <div
                 ref={scrollRef}
-                className="fw-vtbl-body"
+                className="yn-vtbl-body"
                 style={bodyHeight > 0 ? { flex: '0 0 auto', height: bodyHeight } : undefined}
             >
                 {items.length === 0 ? (
-                    <div className="fw-table-empty">No rules match your search.</div>
+                    <div className="yn-table-empty">No rules match your search.</div>
                 ) : (
                     <div
                         style={{
@@ -529,10 +529,10 @@ const RuleTable: React.FC<RuleTableProps> = ({
                 )}
             </div>
 
-            <div className="fw-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
-                <span className="fw-toolbar__count">{footerText}</span>
+            <div className="yn-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
+                <span className="yn-toolbar__count">{footerText}</span>
                 {selectedIds.size > 0 && (
-                    <span className="fw-toolbar__count" style={{ color: 'var(--fw-accent)' }}>
+                    <span className="yn-toolbar__count" style={{ color: 'var(--yn-accent)' }}>
                         {selectedIds.size.toLocaleString()} selected
                     </span>
                 )}

--- a/web/src/pages/modules/acl/Sparkline.tsx
+++ b/web/src/pages/modules/acl/Sparkline.tsx
@@ -14,7 +14,7 @@ const Sparkline: React.FC<SparklineProps> = ({
     values,
     width = 64,
     height = 18,
-    color = 'var(--fw-accent)',
+    color = 'var(--yn-accent)',
     fill = true,
 }) => {
     return (
@@ -25,7 +25,7 @@ const Sparkline: React.FC<SparklineProps> = ({
                 }
                 return (
                     <span
-                        className="fw-spark-empty"
+                        className="yn-spark-empty"
                         title="No counter history available"
                         style={{
                             display: 'inline-flex',

--- a/web/src/pages/modules/acl/YamlIO.tsx
+++ b/web/src/pages/modules/acl/YamlIO.tsx
@@ -82,14 +82,14 @@ const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport }) => {
         <div style={{ display: 'flex', gap: 4 }}>
             <button
                 type="button"
-                className={mode === 'replace' ? 'fw-btn fw-btn--sm' : 'fw-btn fw-btn--ghost fw-btn--sm'}
+                className={mode === 'replace' ? 'yn-btn yn-btn--sm' : 'yn-btn yn-btn--ghost yn-btn--sm'}
                 onClick={() => setMode('replace')}
             >
                 Replace all
             </button>
             <button
                 type="button"
-                className={mode === 'append' ? 'fw-btn fw-btn--sm' : 'fw-btn fw-btn--ghost fw-btn--sm'}
+                className={mode === 'append' ? 'yn-btn yn-btn--sm' : 'yn-btn yn-btn--ghost yn-btn--sm'}
                 onClick={() => setMode('append')}
             >
                 Append

--- a/web/src/pages/modules/acl/acl.scss
+++ b/web/src/pages/modules/acl/acl.scss
@@ -1,7 +1,7 @@
 @use '../../../styles/variables' as *;
 @use '../../../styles/mixins' as *;
 
-// ACL page styles. Shared chrome (fw-page, fw-tabs, fw-tbl-*, etc.) lives in
+// ACL page styles. Shared chrome (yn-page, yn-tabs, yn-table-*, etc.) lives in
 // web/src/styles/draft-page.scss which this page imports. This file covers only
 // ACL-specific chip colors, action chain, editor elements, and override tweaks.
 
@@ -15,13 +15,13 @@
     max-width: 100%;
 }
 
-// Base chip — inherits mono font from fw-cell-mono via composition.
+// Base chip — inherits mono font from yn-cell-mono via composition.
 .acl-chip {
     display: inline-flex;
     align-items: center;
     padding: 1px 7px;
     border-radius: 4px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 11.5px;
     font-weight: 500;
     white-space: nowrap;
@@ -30,9 +30,9 @@
     flex-shrink: 0;
 
     &--overflow {
-        color: var(--fw-text-3);
-        background: var(--fw-bg-2);
-        border-color: var(--fw-line-2);
+        color: var(--yn-text-3);
+        background: var(--yn-bg-2);
+        border-color: var(--yn-line-2);
         font-size: 11px;
     }
 
@@ -44,8 +44,8 @@
         transition: background .12s, border-color .12s;
 
         &:hover {
-            background: var(--fw-accent-soft, rgba(255, 192, 97, 0.14));
-            border-color: var(--fw-accent, rgba(255, 192, 97, 0.55));
+            background: var(--yn-accent-soft, rgba(255, 192, 97, 0.14));
+            border-color: var(--yn-accent, rgba(255, 192, 97, 0.55));
         }
     }
 
@@ -53,13 +53,13 @@
         cursor: pointer;
         font-family: inherit;
         background: transparent;
-        border-color: var(--fw-line-2);
-        color: var(--fw-text-3);
+        border-color: var(--yn-line-2);
+        color: var(--yn-text-3);
         transition: border-color .12s, color .12s;
 
         &:hover {
-            color: var(--fw-text-1, var(--fw-text));
-            border-color: var(--fw-text-3);
+            color: var(--yn-text-1, var(--yn-text));
+            border-color: var(--yn-text-3);
         }
 
         &:focus-visible {
@@ -97,9 +97,9 @@
 
     // Port chips — neutral.
     &--port {
-        background: var(--fw-bg-3);
-        color: var(--fw-text-2);
-        border-color: var(--fw-line-2);
+        background: var(--yn-bg-3);
+        color: var(--yn-text-2);
+        border-color: var(--yn-line-2);
     }
 
     // VLAN chips — subtle amber.
@@ -111,9 +111,9 @@
 
     // Device chips — muted mono style.
     &--device {
-        background: var(--fw-bg-2);
-        color: var(--fw-text-2);
-        border-color: var(--fw-line-2);
+        background: var(--yn-bg-2);
+        color: var(--yn-text-2);
+        border-color: var(--yn-line-2);
     }
 
     // Proto chips by tone.
@@ -143,9 +143,9 @@
         }
 
         &-dim {
-            background: var(--fw-bg-2);
-            color: var(--fw-text-3);
-            border-color: var(--fw-line-2);
+            background: var(--yn-bg-2);
+            color: var(--yn-text-3);
+            border-color: var(--yn-line-2);
         }
     }
 }
@@ -160,13 +160,13 @@
 }
 
 .acl-action-empty {
-    color: var(--fw-text-3);
-    font-family: var(--fw-font-mono);
+    color: var(--yn-text-3);
+    font-family: var(--yn-font-mono);
     font-size: 12px;
 }
 
 .acl-action-arrow {
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-size: 11px;
     flex-shrink: 0;
 }
@@ -176,14 +176,14 @@
     align-items: center;
     padding: 1px 7px;
     border-radius: 4px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 11.5px;
     font-weight: 500;
     white-space: nowrap;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.03);
-    color: var(--fw-text-2);
-    border-color: var(--fw-line-2);
+    color: var(--yn-text-2);
+    border-color: var(--yn-line-2);
 
     &--pass {
         font-weight: 600;
@@ -226,8 +226,8 @@
 }
 
 .acl-action-row__idx {
-    color: var(--fw-text-3);
-    font-family: var(--fw-font-mono);
+    color: var(--yn-text-3);
+    font-family: var(--yn-font-mono);
     font-size: 12px;
     min-width: 20px;
 }
@@ -276,7 +276,7 @@
     margin-left: auto;
     width: 32px;
     height: 32px;
-    border: 1px solid var(--fw-line-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 6px;
     background: transparent;
     cursor: pointer;
@@ -286,12 +286,12 @@
     transition: background 0.1s, border-color 0.1s;
 
     &--off {
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
 
         &:hover {
-            background: var(--fw-bg-2);
-            border-color: var(--fw-accent);
-            color: var(--fw-accent);
+            background: var(--yn-bg-2);
+            border-color: var(--yn-accent);
+            color: var(--yn-accent);
         }
     }
 
@@ -302,12 +302,12 @@
     }
 
     &--on {
-        color: var(--fw-accent);
-        border-color: var(--fw-accent);
-        background: color-mix(in srgb, var(--fw-accent) 10%, transparent);
+        color: var(--yn-accent);
+        border-color: var(--yn-accent);
+        background: color-mix(in srgb, var(--yn-accent) 10%, transparent);
 
         &:hover {
-            background: color-mix(in srgb, var(--fw-accent) 20%, transparent);
+            background: color-mix(in srgb, var(--yn-accent) 20%, transparent);
         }
     }
 }
@@ -319,8 +319,8 @@
 }
 
 .acl-pps-loading {
-    color: var(--fw-text-3);
-    font-family: var(--fw-font-mono);
+    color: var(--yn-text-3);
+    font-family: var(--yn-font-mono);
     font-size: 11px;
 }
 
@@ -331,18 +331,18 @@
     align-items: center;
     padding: 8px 12px;
     margin-bottom: 16px;
-    background: var(--fw-bg-2);
+    background: var(--yn-bg-2);
     border-radius: 6px;
-    border: 1px solid var(--fw-line);
+    border: 1px solid var(--yn-line);
     flex-wrap: wrap;
 }
 
 .acl-diff-stat {
     font-size: 13px;
     font-weight: 600;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
 
-    &--same { color: var(--fw-text-3); }
+    &--same { color: var(--yn-text-3); }
     &--add  { color: var(--g-color-text-positive); }
     &--mod  { color: var(--g-color-text-warning); }
     &--rem  { color: var(--g-color-text-danger); }
@@ -351,7 +351,7 @@
 
 .acl-diff-empty-state {
     text-align: center;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-size: 13px;
     padding: 32px 0;
 }
@@ -365,7 +365,7 @@
 .acl-diff-section {
     border-radius: 6px;
     overflow: hidden;
-    border: 1px solid var(--fw-line);
+    border: 1px solid var(--yn-line);
 
     &--add  { border-left: 3px solid var(--g-color-base-positive-medium); }
     &--mod  { border-left: 3px solid var(--g-color-base-warning-medium); }
@@ -378,16 +378,16 @@
     align-items: center;
     gap: 8px;
     padding: 8px 12px;
-    background: var(--fw-bg-2);
+    background: var(--yn-bg-2);
     cursor: pointer;
     font-size: 12.5px;
     font-weight: 600;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     border: none;
     width: 100%;
     text-align: left;
 
-    &:hover { background: var(--fw-bg-3); }
+    &:hover { background: var(--yn-bg-3); }
 }
 
 .acl-diff-pill {
@@ -397,15 +397,15 @@
     border-radius: 10px;
     font-size: 11px;
     font-weight: 600;
-    background: var(--fw-bg-3);
-    color: var(--fw-text-2);
-    border: 1px solid var(--fw-line-2);
+    background: var(--yn-bg-3);
+    color: var(--yn-text-2);
+    border: 1px solid var(--yn-line-2);
 }
 
 .acl-diff-chevron {
     margin-left: auto;
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
 }
 
 .acl-diff-section-body {
@@ -413,12 +413,12 @@
     flex-direction: column;
     gap: 6px;
     padding: 8px;
-    background: var(--fw-bg);
+    background: var(--yn-bg);
 }
 
 .acl-diff-card {
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line);
     border-radius: 5px;
     overflow: hidden;
 
@@ -433,15 +433,15 @@
     align-items: center;
     gap: 8px;
     padding: 5px 10px;
-    border-bottom: 1px solid var(--fw-line);
-    background: var(--fw-bg-3);
+    border-bottom: 1px solid var(--yn-line);
+    background: var(--yn-bg-3);
 }
 
 .acl-diff-num {
     font-size: 12px;
     font-weight: 700;
-    font-family: var(--fw-font-mono);
-    color: var(--fw-text-2);
+    font-family: var(--yn-font-mono);
+    color: var(--yn-text-2);
 }
 
 .acl-diff-badge {
@@ -459,7 +459,7 @@
 }
 
 .acl-diff-arrow {
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-size: 11px;
 }
 
@@ -483,7 +483,7 @@
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     min-width: 52px;
     padding-top: 2px;
     flex-shrink: 0;
@@ -494,7 +494,7 @@
     align-items: flex-start;
     gap: 8px;
     padding: 4px 0;
-    border-bottom: 1px solid var(--fw-line);
+    border-bottom: 1px solid var(--yn-line);
 
     &:last-child { border-bottom: none; }
 }
@@ -525,7 +525,7 @@
 }
 
 // Scrollable chip container for many chips.
-.fw-chip-input--many {
+.yn-chip-input--many {
     max-height: 180px;
     overflow-y: auto;
     align-content: flex-start;
@@ -537,17 +537,17 @@
     height: 32px;
     padding: 0 10px;
     border-radius: 6px;
-    border: 1px solid var(--fw-line-2);
-    background: var(--fw-bg-2);
-    color: var(--fw-text);
+    border: 1px solid var(--yn-line-2);
+    background: var(--yn-bg-2);
+    color: var(--yn-text);
     font-size: 13px;
     font-family: inherit;
     outline: none;
     box-sizing: border-box;
     flex-shrink: 0;
 
-    &::placeholder { color: var(--fw-text-3); }
-    &:focus { border-color: var(--fw-accent); }
+    &::placeholder { color: var(--yn-text-3); }
+    &:focus { border-color: var(--yn-accent); }
 }
 
 // Chip modal backdrop needs a higher z-index than the inline modals because it
@@ -560,7 +560,7 @@
 // The header outer div is a clipping container only — the inner div is
 // translated horizontally in sync with the body scroll via transform.
 // overflow-x: hidden overrides the auto set by draft-page.scss.
-.acl-table .fw-vtbl-header {
+.acl-table .yn-vtbl-header {
     overflow-x: hidden !important;
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -592,9 +592,9 @@
     }
 
     &--l2 {
-        color: var(--fw-text-3);
-        background: var(--fw-bg-3);
-        border: 1px solid var(--fw-line-2);
+        color: var(--yn-text-3);
+        background: var(--yn-bg-3);
+        border: 1px solid var(--yn-line-2);
     }
 }
 

--- a/web/src/pages/modules/acl/chips.tsx
+++ b/web/src/pages/modules/acl/chips.tsx
@@ -189,21 +189,21 @@ const ChipListModal = <T,>({
     }, [onClose]);
 
     const modal = (
-        <div className="fw-modal-backdrop acl-chip-modal-backdrop" onClick={handleBackdropClick}>
+        <div className="yn-modal-backdrop acl-chip-modal-backdrop" onClick={handleBackdropClick}>
             <div
-                className="fw-modal"
+                className="yn-modal"
                 style={{ maxWidth: 560, maxHeight: '70vh', display: 'flex', flexDirection: 'column' }}
                 onClick={(e) => e.stopPropagation()}
             >
-                <header className="fw-modal__head" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: 4 }}>
+                <header className="yn-modal__head" style={{ flexDirection: 'column', alignItems: 'flex-start', gap: 4 }}>
                     <div style={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between' }}>
-                        <span className="fw-modal__title" style={{ textTransform: 'capitalize' }}>{label}</span>
-                        <button type="button" className="fw-icon-btn" onClick={onClose} aria-label="Close">✕</button>
+                        <span className="yn-modal__title" style={{ textTransform: 'capitalize' }}>{label}</span>
+                        <button type="button" className="yn-icon-btn" onClick={onClose} aria-label="Close">✕</button>
                     </div>
-                    <span className="fw-modal__meta">{statsText}</span>
+                    <span className="yn-modal__meta">{statsText}</span>
                 </header>
 
-                <div className="fw-modal__body" style={{ gap: 8 }}>
+                <div className="yn-modal__body" style={{ gap: 8 }}>
                     <input
                         ref={searchRef}
                         autoFocus
@@ -220,10 +220,10 @@ const ChipListModal = <T,>({
                             display: 'flex',
                             alignItems: 'center',
                             justifyContent: 'center',
-                            color: 'var(--fw-text-3)',
+                            color: 'var(--yn-text-3)',
                             fontSize: 13,
                             minHeight: 80,
-                            border: '1px solid var(--fw-line)',
+                            border: '1px solid var(--yn-line)',
                             borderRadius: 6,
                         }}>
                             No matches.
@@ -237,30 +237,30 @@ const ChipListModal = <T,>({
                             gap: 6,
                             padding: 8,
                             alignContent: 'flex-start',
-                            border: '1px solid var(--fw-line)',
+                            border: '1px solid var(--yn-line)',
                             borderRadius: 6,
-                            background: 'var(--fw-bg-2)',
+                            background: 'var(--yn-bg-2)',
                         }}>
                             {filtered.map((item, idx) => renderChip(item, idx))}
                         </div>
                     )}
                 </div>
 
-                <footer className="fw-modal__foot">
-                    <span className="fw-modal__foot-hint">
+                <footer className="yn-modal__foot">
+                    <span className="yn-modal__foot-hint">
                         Showing {filtered.length} of {items.length}
                     </span>
-                    <div className="fw-modal__foot-actions">
+                    <div className="yn-modal__foot-actions">
                         <button
                             type="button"
-                            className="fw-btn fw-btn--ghost fw-btn--sm"
+                            className="yn-btn yn-btn--ghost yn-btn--sm"
                             onClick={handleCopyAll}
                         >
                             Copy all
                         </button>
                         <button
                             type="button"
-                            className="fw-btn fw-btn--primary fw-btn--sm"
+                            className="yn-btn yn-btn--primary yn-btn--sm"
                             onClick={onClose}
                         >
                             Close

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -173,10 +173,10 @@ const DecapPage: React.FC = () => {
 
     return (
         <PageLayout header={pageHeader}>
-            <div className="fw-page">
+            <div className="yn-page">
                 {draftConfigs.length === 0 ? (
-                    <div className="fw-empty-page">
-                        <div className="fw-empty-page__message">No decap configurations found.</div>
+                    <div className="yn-empty-page">
+                        <div className="yn-empty-page__message">No decap configurations found.</div>
                         <Button view="action" onClick={() => setAddConfigOpen(true)}>Add Config</Button>
                     </div>
                 ) : (
@@ -189,7 +189,7 @@ const DecapPage: React.FC = () => {
                             onSelect={setActiveConfig}
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
-                        <div className="fw-content">
+                        <div className="yn-content">
                             <PrefixTable
                                 allRows={rawRows}
                                 visibleRows={visibleRows}

--- a/web/src/pages/modules/decap/PrefixDrawer.tsx
+++ b/web/src/pages/modules/decap/PrefixDrawer.tsx
@@ -76,22 +76,22 @@ const PrefixDrawer = React.forwardRef<PrefixDrawerHandle, PrefixDrawerProps>(({
             onJump={onJump}
             ariaLabel="Edit prefix"
         >
-            <section className="fw-section">
-                <div className="fw-section-h">Prefix</div>
-                <div className="fw-section__body">
-                    <div className="fw-field">
-                        <label className="fw-field__label">
-                            CIDR <span className="fw-field__req">*</span>
+            <section className="yn-section">
+                <div className="yn-section-h">Prefix</div>
+                <div className="yn-section__body">
+                    <div className="yn-field">
+                        <label className="yn-field__label">
+                            CIDR <span className="yn-field__req">*</span>
                         </label>
                         <input
-                            className={`fw-input fw-input--mono${errors.prefix ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input yn-input--mono${errors.prefix ? ' yn-input--invalid' : ''}`}
                             value={draft?.prefix ?? ''}
                             placeholder="10.0.0.0/8 or 2a02:6b8::/32"
                             onChange={(e) => updateField('prefix', e.target.value.trim())}
                         />
                         {errors.prefix
-                            ? <span className="fw-field__hint fw-field__error">{errors.prefix}</span>
-                            : <span className="fw-field__hint">IPv4 or IPv6 with mask.</span>
+                            ? <span className="yn-field__hint yn-field__error">{errors.prefix}</span>
+                            : <span className="yn-field__hint">IPv4 or IPv6 with mask.</span>
                         }
                     </div>
                 </div>

--- a/web/src/pages/modules/decap/PrefixTable.tsx
+++ b/web/src/pages/modules/decap/PrefixTable.tsx
@@ -13,7 +13,7 @@ const COLUMN_HEADERS: TableColumnHeader[] = [
 ];
 
 const REMOVED_COLUMNS: RemovedColumnDescriptor<PrefixRowItem>[] = [
-    { width: PREFIX_WIDTH, render: (r) => <span className="fw-cell-mono">{r.prefix}</span> },
+    { width: PREFIX_WIDTH, render: (r) => <span className="yn-cell-mono">{r.prefix}</span> },
 ];
 
 const renderPrefixDataCells = (row: PrefixRowItem): React.ReactNode => {
@@ -31,12 +31,12 @@ const renderPrefixDataCells = (row: PrefixRowItem): React.ReactNode => {
                 paddingRight: 8,
                 display: 'flex',
                 alignItems: 'center',
-                ...(errors.prefix ? { color: 'var(--fw-danger)' } : {}),
+                ...(errors.prefix ? { color: 'var(--yn-danger)' } : {}),
             }}
             title={row.prefix || undefined}
         >
-            <span className="fw-cell-mono fw-cell-strong">
-                {row.prefix || <span style={{ color: 'var(--fw-text-3)', fontStyle: 'italic' }}>prefix?</span>}
+            <span className="yn-cell-mono yn-cell-strong">
+                {row.prefix || <span style={{ color: 'var(--yn-text-3)', fontStyle: 'italic' }}>prefix?</span>}
             </span>
         </div>
     );

--- a/web/src/pages/modules/decap/PrefixYamlIO.tsx
+++ b/web/src/pages/modules/decap/PrefixYamlIO.tsx
@@ -23,17 +23,17 @@ const PrefixYamlIO: React.FC<PrefixYamlIOProps> = ({ configName, rows, onImport 
     const importExtraControls = (
         <>
             <div style={{ flex: 1 }} />
-            <span style={{ fontSize: 12, color: 'var(--fw-text-3)' }}>Mode:</span>
+            <span style={{ fontSize: 12, color: 'var(--yn-text-3)' }}>Mode:</span>
             <button
                 type="button"
-                className={`fw-btn fw-btn--sm${importMode === 'replace' ? '' : ' fw-btn--ghost'}`}
+                className={`yn-btn yn-btn--sm${importMode === 'replace' ? '' : ' yn-btn--ghost'}`}
                 onClick={() => setImportMode('replace')}
             >
                 Replace all
             </button>
             <button
                 type="button"
-                className={`fw-btn fw-btn--sm${importMode === 'append' ? '' : ' fw-btn--ghost'}`}
+                className={`yn-btn yn-btn--sm${importMode === 'append' ? '' : ' yn-btn--ghost'}`}
                 onClick={() => setImportMode('append')}
             >
                 Append

--- a/web/src/pages/modules/forward/AnyBadge.tsx
+++ b/web/src/pages/modules/forward/AnyBadge.tsx
@@ -6,7 +6,7 @@ interface AnyBadgeProps {
 
 /** Muted pill badge used for wildcard values such as "any". */
 const AnyBadge: React.FC<AnyBadgeProps> = ({ label }) => (
-    <span className="fw-badge-any">{label}</span>
+    <span className="yn-badge-any">{label}</span>
 );
 
 export default AnyBadge;

--- a/web/src/pages/modules/forward/ChipInput.tsx
+++ b/web/src/pages/modules/forward/ChipInput.tsx
@@ -100,18 +100,18 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
 
     return (
         <div
-            className="fw-chip-input"
+            className="yn-chip-input"
             onClick={() => inputRef.current?.focus()}
         >
             {isWildcard && wildcardLabel && (
-                <span className="fw-badge-any">{wildcardLabel}</span>
+                <span className="yn-badge-any">{wildcardLabel}</span>
             )}
             {value.map((v, idx) => {
                 const valid = validator(v);
                 return (
-                    <span key={idx} className={`fw-chip${valid ? '' : ' fw-chip--invalid'}`}>
+                    <span key={idx} className={`yn-chip${valid ? '' : ' yn-chip--invalid'}`}>
                         <span
-                            className="fw-chip__label"
+                            className="yn-chip__label"
                             role="button"
                             tabIndex={0}
                             title="Click to edit"
@@ -137,7 +137,7 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                         </span>
                         <button
                             type="button"
-                            className="fw-chip__x"
+                            className="yn-chip__x"
                             onClick={(e) => {
                                 e.stopPropagation();
                                 onChange(value.filter((_, j) => j !== idx));
@@ -158,7 +158,7 @@ const ChipInput = React.forwardRef<ChipInputHandle, ChipInputProps>(({
                 onKeyDown={handleKeyDown}
                 onBlur={handleBlur}
                 onPaste={handlePaste}
-                className="fw-chip-input__raw"
+                className="yn-chip-input__raw"
             />
         </div>
     );

--- a/web/src/pages/modules/forward/DirectionBadge.tsx
+++ b/web/src/pages/modules/forward/DirectionBadge.tsx
@@ -10,10 +10,10 @@ interface DirectionBadgeProps {
 
 /** Colored pill badge showing direction mode (IN / OUT / NONE) with equal width. */
 const DirectionBadge: React.FC<DirectionBadgeProps> = ({ mode }) => {
-    let cls = 'fw-badge-dir';
-    if (mode === ForwardMode.IN) cls += ' fw-badge-dir--in';
-    else if (mode === ForwardMode.OUT) cls += ' fw-badge-dir--out';
-    else cls += ' fw-badge-dir--none';
+    let cls = 'yn-badge-dir';
+    if (mode === ForwardMode.IN) cls += ' yn-badge-dir--in';
+    else if (mode === ForwardMode.OUT) cls += ' yn-badge-dir--out';
+    else cls += ' yn-badge-dir--none';
 
     return (
         <span className={cls}>

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -261,10 +261,10 @@ const ForwardPage: React.FC = () => {
 
     return (
         <PageLayout header={pageHeader}>
-            <div className="fw-page">
+            <div className="yn-page">
                 {draftConfigs.length === 0 ? (
-                    <div className="fw-empty-page">
-                        <div className="fw-empty-page__message">
+                    <div className="yn-empty-page">
+                        <div className="yn-empty-page__message">
                             No forward configurations found.
                         </div>
                         <Button view="action" onClick={() => setAddConfigOpen(true)}>
@@ -282,7 +282,7 @@ const ForwardPage: React.FC = () => {
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
 
-                        <div className="fw-content">
+                        <div className="yn-content">
                             <RuleTable
                                 items={visibleItems}
                                 selectedIds={selectedIds}

--- a/web/src/pages/modules/forward/RuleDrawer.tsx
+++ b/web/src/pages/modules/forward/RuleDrawer.tsx
@@ -109,28 +109,28 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
     return (
         <>
             <div
-                className={`fw-backdrop${open ? ' fw-backdrop--open' : ''}`}
+                className={`yn-backdrop${open ? ' yn-backdrop--open' : ''}`}
                 onClick={handleClose}
                 aria-hidden="true"
             />
             <aside
-                className={`fw-drawer${open ? ' fw-drawer--open' : ''}`}
+                className={`yn-drawer${open ? ' yn-drawer--open' : ''}`}
                 role="dialog"
                 aria-modal="true"
                 aria-label={mode === 'add' ? 'Add rule' : 'Edit rule'}
             >
-                <header className="fw-drawer__head">
-                    <h2 className="fw-drawer__title">
+                <header className="yn-drawer__head">
+                    <h2 className="yn-drawer__title">
                         {mode === 'add' ? 'New rule' : (
-                            <>Edit rule <span className="fw-drawer__rule-num">#{ruleItem?.index !== undefined ? ruleItem.index + 1 : ''}</span></>
+                            <>Edit rule <span className="yn-drawer__rule-num">#{ruleItem?.index !== undefined ? ruleItem.index + 1 : ''}</span></>
                         )}
                     </h2>
-                    <div className="fw-drawer__head-actions">
+                    <div className="yn-drawer__head-actions">
                         {mode === 'edit' && ruleItem && (
                             <>
                                 <button
                                     type="button"
-                                    className="fw-icon-btn"
+                                    className="yn-icon-btn"
                                     onClick={() => onDuplicate(ruleItem)}
                                     title="Duplicate rule"
                                 >
@@ -138,7 +138,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                 </button>
                                 <button
                                     type="button"
-                                    className="fw-icon-btn fw-icon-btn--danger"
+                                    className="yn-icon-btn yn-icon-btn--danger"
                                     onClick={() => onDelete(ruleItem)}
                                     title="Delete rule"
                                 >
@@ -148,7 +148,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                         )}
                         <button
                             type="button"
-                            className="fw-icon-btn"
+                            className="yn-icon-btn"
                             onClick={handleClose}
                             aria-label="Close drawer"
                         >
@@ -157,68 +157,68 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                     </div>
                 </header>
 
-                <div className="fw-drawer__body">
-                    <section className="fw-section">
-                        <div className="fw-section-h">Identity</div>
-                        <div className="fw-section__body">
-                            <div className="fw-fgrid">
-                                <div className="fw-field">
-                                    <label className="fw-field__label">
-                                        Target <span className="fw-field__req">*</span>
+                <div className="yn-drawer__body">
+                    <section className="yn-section">
+                        <div className="yn-section-h">Identity</div>
+                        <div className="yn-section__body">
+                            <div className="yn-fgrid">
+                                <div className="yn-field">
+                                    <label className="yn-field__label">
+                                        Target <span className="yn-field__req">*</span>
                                     </label>
                                     <input
-                                        className="fw-input"
+                                        className="yn-input"
                                         placeholder="e.g. eth0"
                                         value={draft.target}
                                         onChange={(e) => updateField('target', e.target.value)}
                                     />
-                                    <span className="fw-field__hint">Output target device matched traffic is forwarded to.</span>
+                                    <span className="yn-field__hint">Output target device matched traffic is forwarded to.</span>
                                 </div>
-                                <div className="fw-field">
-                                    <label className="fw-field__label">Mode</label>
-                                    <div className="fw-segmented" role="radiogroup" aria-label="Direction mode">
+                                <div className="yn-field">
+                                    <label className="yn-field__label">Mode</label>
+                                    <div className="yn-segmented" role="radiogroup" aria-label="Direction mode">
                                         {modeOptions.map((opt) => (
                                             <button
                                                 key={opt.value}
                                                 type="button"
                                                 role="radio"
                                                 aria-checked={draft.mode === opt.value}
-                                                className={`fw-segmented__opt fw-segmented__opt--${opt.cls}${draft.mode === opt.value ? ' fw-segmented__opt--on' : ''}`}
+                                                className={`yn-segmented__opt yn-segmented__opt--${opt.cls}${draft.mode === opt.value ? ' yn-segmented__opt--on' : ''}`}
                                                 onClick={() => updateField('mode', opt.value)}
                                             >
                                                 {opt.label}
                                             </button>
                                         ))}
                                     </div>
-                                    <span className="fw-field__hint">
+                                    <span className="yn-field__hint">
                                         {draft.mode === ForwardMode.IN && 'Match traffic entering the device.'}
                                         {draft.mode === ForwardMode.OUT && 'Match traffic exiting the device.'}
                                         {draft.mode === ForwardMode.NONE && 'Match without direction binding.'}
                                     </span>
                                 </div>
                             </div>
-                            <div className="fw-field">
-                                <label className="fw-field__label">
-                                    Counter <span className="fw-field__optional">optional</span>
+                            <div className="yn-field">
+                                <label className="yn-field__label">
+                                    Counter <span className="yn-field__optional">optional</span>
                                 </label>
                                 <input
-                                    className="fw-input"
+                                    className="yn-input"
                                     placeholder={draft.target ? `to_${draft.target}` : 'e.g. my_counter'}
                                     value={draft.counter}
                                     onChange={(e) => updateField('counter', e.target.value)}
                                 />
-                                <span className="fw-field__hint">Name shown in /stats. Leave empty to skip counting.</span>
+                                <span className="yn-field__hint">Name shown in /stats. Leave empty to skip counting.</span>
                             </div>
                         </div>
                     </section>
 
-                    <section className="fw-section">
-                        <div className="fw-section-h">Match criteria</div>
-                        <div className="fw-section__body">
-                            <div className="fw-field">
-                                <label className="fw-field__label">
+                    <section className="yn-section">
+                        <div className="yn-section-h">Match criteria</div>
+                        <div className="yn-section__body">
+                            <div className="yn-field">
+                                <label className="yn-field__label">
                                     Devices
-                                    <span className="fw-field__count">{draft.deviceNames.length || 'any'}</span>
+                                    <span className="yn-field__count">{draft.deviceNames.length || 'any'}</span>
                                 </label>
                                 <ChipInput
                                     ref={deviceNamesRef}
@@ -230,23 +230,23 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                     validator={isValidDeviceName}
                                 />
                             </div>
-                            <div className="fw-field">
-                                <label className="fw-field__label">VLAN ranges</label>
+                            <div className="yn-field">
+                                <label className="yn-field__label">VLAN ranges</label>
                                 <input
-                                    className="fw-input fw-input--mono"
+                                    className="yn-input yn-input--mono"
                                     placeholder="0-4095"
                                     value={draft.vlansRaw}
                                     onChange={(e) => updateField('vlansRaw', e.target.value)}
                                 />
-                                <span className="fw-field__hint">
+                                <span className="yn-field__hint">
                                     Single value <code>100</code>, range <code>100-200</code>, list <code>100, 200, 300-400</code>. Empty = all VLANs.
                                 </span>
                             </div>
-                            <div className="fw-fgrid">
-                                <div className="fw-field">
-                                    <label className="fw-field__label">
+                            <div className="yn-fgrid">
+                                <div className="yn-field">
+                                    <label className="yn-field__label">
                                         Sources
-                                        <span className="fw-field__count">{draft.sourceCidrs.length || 'any'}</span>
+                                        <span className="yn-field__count">{draft.sourceCidrs.length || 'any'}</span>
                                     </label>
                                     <ChipInput
                                         ref={sourceCidrsRef}
@@ -258,10 +258,10 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                         validator={isValidCidr}
                                     />
                                 </div>
-                                <div className="fw-field">
-                                    <label className="fw-field__label">
+                                <div className="yn-field">
+                                    <label className="yn-field__label">
                                         Destinations
-                                        <span className="fw-field__count">{draft.dstCidrs.length || 'any'}</span>
+                                        <span className="yn-field__count">{draft.dstCidrs.length || 'any'}</span>
                                     </label>
                                     <ChipInput
                                         ref={dstCidrsRef}
@@ -278,19 +278,19 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                     </section>
                 </div>
 
-                <footer className="fw-drawer__foot">
-                    <span className="fw-drawer__foot-meta">
+                <footer className="yn-drawer__foot">
+                    <span className="yn-drawer__foot-meta">
                         {mode === 'add'
                             ? 'Will be appended to config.'
                             : `Rule #${(ruleItem?.index ?? -1) + 1}`}
                     </span>
-                    <div className="fw-drawer__foot-actions">
-                        <button type="button" className="fw-btn fw-btn--ghost" onClick={handleClose}>
+                    <div className="yn-drawer__foot-actions">
+                        <button type="button" className="yn-btn yn-btn--ghost" onClick={handleClose}>
                             Cancel
                         </button>
                         <button
                             type="button"
-                            className="fw-btn fw-btn--primary"
+                            className="yn-btn yn-btn--primary"
                             disabled={!isValid}
                             onClick={handleApply}
                         >

--- a/web/src/pages/modules/forward/RuleTable.tsx
+++ b/web/src/pages/modules/forward/RuleTable.tsx
@@ -10,7 +10,7 @@ import Sparkline from './Sparkline';
 import { formatPps } from '../../../utils';
 import { DraftActionButtons, RowHoverEditOverlay } from '../../_shared/draft';
 
-/** Duration in ms of the CSS transition on .fw-drawer — keep in sync with SCSS. */
+/** Duration in ms of the CSS transition on .yn-drawer — keep in sync with SCSS. */
 const DRAWER_TRANSITION_MS = 220;
 export { DRAWER_TRANSITION_MS };
 
@@ -57,11 +57,11 @@ const ValueCell: React.FC<{ values: string[] }> = ({ values }) => {
     const visible = values.slice(0, 3);
     const rest = values.length - visible.length;
     return (
-        <span className="fw-cell-values" title={values.join(', ')}>
+        <span className="yn-cell-values" title={values.join(', ')}>
             {visible.map((v, idx) => (
-                <span key={idx} className="fw-cell-mono">{v}</span>
+                <span key={idx} className="yn-cell-mono">{v}</span>
             ))}
-            {rest > 0 && <span className="fw-cell-more">+{rest}</span>}
+            {rest > 0 && <span className="yn-cell-more">+{rest}</span>}
         </span>
     );
 };
@@ -99,12 +99,12 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
     }, [onHoverChange]);
 
     let rowBg = 'transparent';
-    if (active) rowBg = 'var(--fw-accent-soft)';
-    else if (selected) rowBg = 'var(--fw-accent-soft)';
+    if (active) rowBg = 'var(--yn-accent-soft)';
+    else if (selected) rowBg = 'var(--yn-accent-soft)';
 
     return (
         <div
-            className={`fw-vrow${selected ? ' fw-vrow--selected' : ''}${active ? ' fw-vrow--active' : ''}`}
+            className={`yn-vrow${selected ? ' yn-vrow--selected' : ''}${active ? ' yn-vrow--active' : ''}`}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             style={{
@@ -116,7 +116,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 width: '100%',
                 display: 'flex',
                 alignItems: 'center',
-                borderBottom: '1px solid var(--fw-line)',
+                borderBottom: '1px solid var(--yn-line)',
                 backgroundColor: rowBg,
                 paddingLeft: 4,
             }}
@@ -132,12 +132,12 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 />
             </div>
 
-            <div style={{ ...cellStyle('index'), color: 'var(--fw-text-3)', fontVariantNumeric: 'tabular-nums' }}>
+            <div style={{ ...cellStyle('index'), color: 'var(--yn-text-3)', fontVariantNumeric: 'tabular-nums' }}>
                 <span style={{ fontSize: 12 }}>{item.index + 1}</span>
             </div>
 
             <div style={cellStyle('target')} title={item.target}>
-                <span className="fw-cell-mono fw-cell-strong">{item.target || '—'}</span>
+                <span className="yn-cell-mono yn-cell-strong">{item.target || '—'}</span>
             </div>
 
             <div style={cellStyle('mode')}>
@@ -145,7 +145,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
             </div>
 
             <div style={cellStyle('counter')} title={item.counter}>
-                <span className="fw-cell-mono fw-cell-muted">{item.counter || '—'}</span>
+                <span className="yn-cell-mono yn-cell-muted">{item.counter || '—'}</span>
             </div>
 
             <div style={cellStyle('devices')}>
@@ -158,7 +158,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
             <div style={cellStyle('vlans')}>
                 {item.isAllVlans
                     ? <AnyBadge label="any" />
-                    : <span className="fw-cell-mono fw-cell-muted">{item.vlansDisplay || '—'}</span>
+                    : <span className="yn-cell-mono yn-cell-muted">{item.vlansDisplay || '—'}</span>
                 }
             </div>
 
@@ -178,7 +178,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
 
             <div style={{ ...cellStyle('sparkline'), gap: 8 }}>
                 <Sparkline values={rateData?.history ?? null} width={56} height={16} />
-                <span className="fw-cell-pps">
+                <span className="yn-cell-pps">
                     {rateData ? formatPps(rateData.pps) : '— pps'}
                 </span>
             </div>
@@ -236,7 +236,7 @@ const RuleTable: React.FC<RuleTableProps> = ({
 
     /**
      * Tracks the vertical scroll offset of the body so the overlay (which is
-     * a child of .fw-tbl-wrap, not the scroll body) can compute its correct
+     * a child of .yn-table-wrap, not the scroll body) can compute its correct
      * top position: HEADER_HEIGHT + virtualizer_start - scrollTop.
      */
     const [bodyScrollTop, setBodyScrollTop] = useState(0);
@@ -329,10 +329,10 @@ const RuleTable: React.FC<RuleTableProps> = ({
     }, [virtualRows, items.length]);
 
     /**
-     * Edit-button overlay y-offset relative to .fw-tbl-wrap (position:relative).
+     * Edit-button overlay y-offset relative to .yn-table-wrap (position:relative).
      *
-     * The overlay is a child of .fw-tbl-wrap, NOT the scroll body.  This means:
-     *   • right: 0 resolves against .fw-tbl-wrap's right edge = wrap_right (fixed).
+     * The overlay is a child of .yn-table-wrap, NOT the scroll body.  This means:
+     *   • right: 0 resolves against .yn-table-wrap's right edge = wrap_right (fixed).
      *   • top must account for the header height and the current scroll position:
      *       top = HEADER_HEIGHT + virtualizer_start - scrollTop
      *
@@ -343,16 +343,16 @@ const RuleTable: React.FC<RuleTableProps> = ({
      *     = 16 + 8 = 24px from slot_right = wrap_right − 24px  ✓
      *
      * Horizontal scrolling: the overlay is outside the scroll body so h-scroll
-     * never moves it — it stays permanently at right: 0 of .fw-tbl-wrap.
+     * never moves it — it stays permanently at right: 0 of .yn-table-wrap.
      */
     const overlayTopOffset = HEADER_HEIGHT + hoveredStart - bodyScrollTop;
 
     return (
-        <div ref={wrapRef} className="fw-tbl-wrap">
+        <div ref={wrapRef} className="yn-table-wrap">
             {/* Sticky header row */}
-            <div className="fw-tbl-header-row">
+            <div className="yn-table-header-row">
                 <div
-                    className="fw-vtbl-header"
+                    className="yn-vtbl-header"
                     style={{ height: HEADER_HEIGHT, minWidth: TOTAL_WIDTH }}
                 >
                     <div style={cellStyle('checkbox')}>
@@ -365,31 +365,31 @@ const RuleTable: React.FC<RuleTableProps> = ({
                         />
                     </div>
                     <div style={{ ...cellStyle('index'), justifyContent: 'center' }}>
-                        <span className="fw-th-text">#</span>
+                        <span className="yn-th-text">#</span>
                     </div>
                     <div style={cellStyle('target')}>
-                        <span className="fw-th-text">Target</span>
+                        <span className="yn-th-text">Target</span>
                     </div>
                     <div style={cellStyle('mode')}>
-                        <span className="fw-th-text">Mode</span>
+                        <span className="yn-th-text">Mode</span>
                     </div>
                     <div style={cellStyle('counter')}>
-                        <span className="fw-th-text">Counter</span>
+                        <span className="yn-th-text">Counter</span>
                     </div>
                     <div style={cellStyle('devices')}>
-                        <span className="fw-th-text">Devices</span>
+                        <span className="yn-th-text">Devices</span>
                     </div>
                     <div style={cellStyle('vlans')}>
-                        <span className="fw-th-text">VLANs</span>
+                        <span className="yn-th-text">VLANs</span>
                     </div>
                     <div style={cellStyle('srcs')}>
-                        <span className="fw-th-text">Sources</span>
+                        <span className="yn-th-text">Sources</span>
                     </div>
                     <div style={cellStyle('dsts')}>
-                        <span className="fw-th-text">Destinations</span>
+                        <span className="yn-th-text">Destinations</span>
                     </div>
                     <div style={cellStyle('sparkline')}>
-                        <span className="fw-th-text">pps</span>
+                        <span className="yn-th-text">pps</span>
                     </div>
                 </div>
                 <DraftActionButtons
@@ -403,11 +403,11 @@ const RuleTable: React.FC<RuleTableProps> = ({
             {/* Virtualized scroll body */}
             <div
                 ref={scrollRef}
-                className="fw-vtbl-body"
+                className="yn-vtbl-body"
                 style={bodyHeight > 0 ? { flex: '0 0 auto', height: bodyHeight } : undefined}
             >
                 {items.length === 0 ? (
-                    <div className="fw-table-empty">No rules match your search.</div>
+                    <div className="yn-table-empty">No rules match your search.</div>
                 ) : (
                     <div
                         style={{
@@ -438,17 +438,17 @@ const RuleTable: React.FC<RuleTableProps> = ({
             </div>
 
             {/* Footer */}
-            <div className="fw-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
-                <span className="fw-toolbar__count">{footerText}</span>
+            <div className="yn-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
+                <span className="yn-toolbar__count">{footerText}</span>
                 {selectedIds.size > 0 && (
-                    <span className="fw-toolbar__count" style={{ color: 'var(--fw-accent)' }}>
+                    <span className="yn-toolbar__count" style={{ color: 'var(--yn-accent)' }}>
                         {selectedIds.size.toLocaleString()} selected
                     </span>
                 )}
             </div>
 
             {/*
-              * Floating edit button overlay — direct child of .fw-tbl-wrap
+              * Floating edit button overlay — direct child of .yn-table-wrap
               * (position:relative), NOT inside the scroll body.
               *
               *  right: 0  → always at wrap_right, regardless of horizontal scroll.
@@ -461,7 +461,7 @@ const RuleTable: React.FC<RuleTableProps> = ({
               *   button: 26px centered in 32px → center offset from slot right = 8 + 3 + 13 = 24px
               *   wrap right − 24px  =  header delete button center  ✓
               *
-              * The overlay is clipped by .fw-tbl-wrap (overflow:hidden) so it never
+              * The overlay is clipped by .yn-table-wrap (overflow:hidden) so it never
               * bleeds into the header or footer — rows at the very top/bottom that scroll
               * into the boundary just have the button disappear naturally.
               */}

--- a/web/src/pages/modules/forward/Sparkline.tsx
+++ b/web/src/pages/modules/forward/Sparkline.tsx
@@ -14,7 +14,7 @@ const Sparkline: React.FC<SparklineProps> = ({
     values,
     width = 64,
     height = 18,
-    color = 'var(--fw-accent)',
+    color = 'var(--yn-accent)',
     fill = true,
 }) => {
     return (
@@ -25,7 +25,7 @@ const Sparkline: React.FC<SparklineProps> = ({
                 }
                 return (
                     <span
-                        className="fw-spark-empty"
+                        className="yn-spark-empty"
                         title="No counter history available from backend"
                     >
                         --

--- a/web/src/pages/modules/forward/YamlIO.tsx
+++ b/web/src/pages/modules/forward/YamlIO.tsx
@@ -113,23 +113,23 @@ const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport }) => {
         const parsed = parseYamlToRules(text);
         const targetConfig = importConfigName.trim() || configName;
         onImport(targetConfig, parsed);
-        toaster.success('fw-yaml-import', `Imported ${parsed.length} rules into "${targetConfig}".`);
+        toaster.success('yn-yaml-import', `Imported ${parsed.length} rules into "${targetConfig}".`);
     };
 
     const importExtraControls = (
-        <div className="fw-field" style={{ marginBottom: 0, minWidth: 200 }}>
-            <label className="fw-field__label" htmlFor="fw-import-config-name">
+        <div className="yn-field" style={{ marginBottom: 0, minWidth: 200 }}>
+            <label className="yn-field__label" htmlFor="yn-import-config-name">
                 Config name
             </label>
             <input
-                id="fw-import-config-name"
-                className="fw-input"
+                id="yn-import-config-name"
+                className="yn-input"
                 type="text"
                 value={importConfigName}
                 onChange={(e) => setImportConfigName(e.target.value)}
                 placeholder={configName}
             />
-            <span className="fw-field__hint">
+            <span className="yn-field__hint">
                 Rules will be imported into this config (creates it locally if new).
             </span>
         </div>
@@ -142,7 +142,7 @@ const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport }) => {
             itemLabel="rules"
             exportYaml={() => rulesToDiffYaml(rules)}
             onImport={handleImport}
-            toastPrefix="fw-yaml"
+            toastPrefix="yn-yaml"
             importPlaceholder={'rules:\n  - target: eth0\n    mode: Out\n    srcs:\n      - 10.0.0.0/8'}
             exportFooterHint="Exports current draft rules (unsaved changes included)."
             importFooterHint="Importing replaces all rules in the target config locally. Use Save to push to the server."

--- a/web/src/pages/modules/forward/forward.scss
+++ b/web/src/pages/modules/forward/forward.scss
@@ -2,11 +2,11 @@
 @use '../../../styles/mixins' as *;
 
 // Forward-specific styles — direction badges, sparkline, chip-input, segmented control.
-// Shared page chrome (fw-page, fw-tabs, fw-tbl-*, fw-modal*, fw-drawer*, fw-bulk-bar, etc.)
+// Shared page chrome (yn-page, yn-tabs, yn-table-*, yn-modal*, yn-drawer*, yn-bulk-bar, etc.)
 // lives in web/src/styles/draft-page.scss.
 
 // Direction badges
-.fw-badge-dir {
+.yn-badge-dir {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -16,81 +16,81 @@
     border-radius: 999px;
     font-size: 11.5px;
     font-weight: 600;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     letter-spacing: 0.03em;
     border: 1px solid transparent;
 
     &--in {
-        background: var(--fw-dir-in-bg);
-        color: var(--fw-dir-in);
-        border-color: var(--fw-dir-in-bd);
+        background: var(--yn-dir-in-bg);
+        color: var(--yn-dir-in);
+        border-color: var(--yn-dir-in-bd);
     }
 
     &--out {
-        background: var(--fw-dir-out-bg);
-        color: var(--fw-dir-out);
-        border-color: var(--fw-dir-out-bd);
+        background: var(--yn-dir-out-bg);
+        color: var(--yn-dir-out);
+        border-color: var(--yn-dir-out-bd);
     }
 
     &--none {
-        background: var(--fw-dir-none-bg);
-        color: var(--fw-dir-none);
-        border-color: var(--fw-dir-none-bd);
+        background: var(--yn-dir-none-bg);
+        color: var(--yn-dir-none);
+        border-color: var(--yn-dir-none-bd);
     }
 }
 
 // Any/ALL badge
-.fw-badge-any {
+.yn-badge-any {
     display: inline-flex;
     align-items: center;
     padding: 2px 8px;
     border-radius: 999px;
     font-size: 11px;
     font-weight: 500;
-    color: var(--fw-text-2);
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+    color: var(--yn-text-2);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
     white-space: nowrap;
 }
 
 // Sparkline
-.fw-spark-empty {
-    font-family: var(--fw-font-mono);
+.yn-spark-empty {
+    font-family: var(--yn-font-mono);
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
 }
 
-.fw-spark-svg { display: block; }
+.yn-spark-svg { display: block; }
 
-.fw-cell-pps {
-    font-family: var(--fw-font-mono);
+.yn-cell-pps {
+    font-family: var(--yn-font-mono);
     font-size: 11.5px;
     font-variant-numeric: tabular-nums;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     white-space: nowrap;
     flex-shrink: 0;
 }
 
 // Segmented control for mode
-.fw-segmented {
+.yn-segmented {
     display: flex;
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 6px;
     padding: 2px;
     gap: 2px;
 }
 
-.fw-segmented__opt {
+.yn-segmented__opt {
     flex: 1;
     padding: 0 10px;
     height: 28px;
     border-radius: 4px;
     font-size: 12px;
     font-weight: 600;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     letter-spacing: 0.04em;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     background: none;
     border: none;
     cursor: pointer;
@@ -99,22 +99,22 @@
     justify-content: center;
     transition: background 0.08s, color 0.08s;
 
-    &:hover { color: var(--fw-text); }
+    &:hover { color: var(--yn-text); }
 
     &--on {
-        background: var(--fw-bg-3);
-        color: var(--fw-text);
+        background: var(--yn-bg-3);
+        color: var(--yn-text);
     }
 
-    &--on#{&}--in { color: var(--fw-dir-in); }
-    &--on#{&}--out { color: var(--fw-dir-out); }
-    &--on#{&}--none { color: var(--fw-text); }
+    &--on#{&}--in { color: var(--yn-dir-in); }
+    &--on#{&}--out { color: var(--yn-dir-out); }
+    &--on#{&}--none { color: var(--yn-text); }
 }
 
 // Chip input
-.fw-chip-input {
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+.yn-chip-input {
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 6px;
     padding: 5px;
     min-height: 34px;
@@ -126,57 +126,57 @@
     transition: border-color 0.1s, box-shadow 0.1s;
 
     &:focus-within {
-        border-color: var(--fw-accent);
-        box-shadow: 0 0 0 2px var(--fw-accent-soft);
+        border-color: var(--yn-accent);
+        box-shadow: 0 0 0 2px var(--yn-accent-soft);
     }
 }
 
-.fw-chip-input__raw {
+.yn-chip-input__raw {
     flex: 1;
     min-width: 80px;
     background: none;
     border: none;
     outline: none;
     padding: 2px 4px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 12px;
-    color: var(--fw-text);
+    color: var(--yn-text);
 
-    &::placeholder { color: var(--fw-text-3); }
+    &::placeholder { color: var(--yn-text-3); }
 }
 
-.fw-chip {
+.yn-chip {
     display: inline-flex;
     align-items: center;
     gap: 3px;
-    background: var(--fw-bg-3);
-    border: 1px solid var(--fw-line-2);
+    background: var(--yn-bg-3);
+    border: 1px solid var(--yn-line-2);
     border-radius: 4px;
     padding: 1px 4px 1px 7px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 11.5px;
-    color: var(--fw-text);
+    color: var(--yn-text);
     line-height: 1.6;
 
     &--invalid {
         background: rgba(224, 122, 110, 0.1);
         border-color: rgba(224, 122, 110, 0.4);
-        color: var(--fw-danger);
+        color: var(--yn-danger);
     }
 }
 
-.fw-chip__label {
+.yn-chip__label {
     flex: 1;
     cursor: text;
 
     &:hover { text-decoration: underline; text-decoration-style: dotted; }
 }
 
-.fw-chip__x {
+.yn-chip__x {
     width: 14px;
     height: 14px;
     border-radius: 3px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     background: none;
     border: none;
     cursor: pointer;
@@ -188,5 +188,5 @@
     padding: 0;
     transition: background 0.08s, color 0.08s;
 
-    &:hover { background: var(--fw-bg-hover); color: var(--fw-text); }
+    &:hover { background: var(--yn-bg-hover); color: var(--yn-text); }
 }

--- a/web/src/pages/modules/forward/useForwardDraft.ts
+++ b/web/src/pages/modules/forward/useForwardDraft.ts
@@ -75,7 +75,7 @@ export const useForwardDraft = (): UseForwardDraftResult => {
 
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });
         } catch (err) {
-            toaster.error('fw-draft-load', 'Failed to load forward configurations', err);
+            toaster.error('yn-draft-load', 'Failed to load forward configurations', err);
         } finally {
             setLoading(false);
         }
@@ -92,9 +92,9 @@ export const useForwardDraft = (): UseForwardDraftResult => {
             try {
                 await API.forward.deleteConfig({ name: configName });
                 rawDispatch({ type: 'MARK_SAVED', configName });
-                toaster.success(`fw-save-${configName}`, `Config "${configName}" deleted.`);
+                toaster.success(`yn-save-${configName}`, `Config "${configName}" deleted.`);
             } catch (err) {
-                toaster.error(`fw-save-err-${configName}`, `Failed to delete "${configName}"`, err);
+                toaster.error(`yn-save-err-${configName}`, `Failed to delete "${configName}"`, err);
                 throw err;
             }
             return;
@@ -104,9 +104,9 @@ export const useForwardDraft = (): UseForwardDraftResult => {
         try {
             await API.forward.updateConfig({ name: configName, rules });
             rawDispatch({ type: 'MARK_SAVED', configName });
-            toaster.success(`fw-save-${configName}`, `Config "${configName}" saved.`);
+            toaster.success(`yn-save-${configName}`, `Config "${configName}" saved.`);
         } catch (err) {
-            toaster.error(`fw-save-err-${configName}`, `Failed to save "${configName}"`, err);
+            toaster.error(`yn-save-err-${configName}`, `Failed to save "${configName}"`, err);
             throw err;
         }
     }, [state.draft, state.pendingDeleteConfigs]);

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -1453,7 +1453,7 @@ const FWStatePage: React.FC = () => {
         <>
             <button
                 type="button"
-                className="fw-tbl-action-btn fw-tbl-action-btn--save"
+                className="yn-table-action-btn yn-table-action-btn--save"
                 title="Save config"
                 aria-label="Save config"
                 disabled={!currentIsDirty}
@@ -1463,7 +1463,7 @@ const FWStatePage: React.FC = () => {
             </button>
             <button
                 type="button"
-                className="fw-tbl-action-btn fw-tbl-action-btn--delete"
+                className="yn-table-action-btn yn-table-action-btn--delete"
                 title="Delete config"
                 aria-label="Delete config"
                 disabled={!current || currentHasLinkedAcls}
@@ -1711,10 +1711,10 @@ const FWStatePage: React.FC = () => {
 
     return (
         <PageLayout header={pageHeader}>
-            <div className="fw-page">
+            <div className="yn-page">
                 {configNames.length === 0 ? (
-                    <div className="fw-empty-page">
-                        <div className="fw-empty-page__message">No FWState configurations found.</div>
+                    <div className="yn-empty-page">
+                        <div className="yn-empty-page__message">No FWState configurations found.</div>
                         <Button view="action" onClick={() => setAddConfigOpen(true)}>Add Config</Button>
                     </div>
                 ) : (
@@ -1732,7 +1732,7 @@ const FWStatePage: React.FC = () => {
                             </div>
                         </div>
 
-                        <div className="fw-content fwstate-content">
+                        <div className="yn-content fwstate-content">
                             {current && (
                                 <div className="fwstate-settings-layout">
                                     <div
@@ -1742,7 +1742,7 @@ const FWStatePage: React.FC = () => {
                                     >
                                         <div className="fwstate-subtab-frame">
                                             <div className="fwstate-subtab-frame__head">
-                                                <div className="fw-tabs fwstate-sub-tabs" role="tablist" aria-label="FWState sub tabs">
+                                                <div className="yn-tabs fwstate-sub-tabs" role="tablist" aria-label="FWState sub tabs">
                                                     {STATE_SUB_TABS.map((tab) => {
                                                         const isActive = tab.id === activeSubTab;
                                                         return (
@@ -1752,10 +1752,10 @@ const FWStatePage: React.FC = () => {
                                                                 role="tab"
                                                                 aria-selected={isActive}
                                                                 aria-controls="fwstate-subtab-panel"
-                                                                className={`fw-tab${isActive ? ' fw-tab--active' : ''}`}
+                                                                className={`yn-tab${isActive ? ' yn-tab--active' : ''}`}
                                                                 onClick={() => updateActiveSubTab(tab.id)}
                                                             >
-                                                                <span className="fw-tab__label">{tab.label}</span>
+                                                                <span className="yn-tab__label">{tab.label}</span>
                                                             </button>
                                                         );
                                                     })}

--- a/web/src/pages/modules/fwstate/fwstate.scss
+++ b/web/src/pages/modules/fwstate/fwstate.scss
@@ -625,17 +625,17 @@
 }
 
 .fws-statcard {
-    border: 1px solid var(--fw-line-2, rgba(255, 200, 140, .12));
+    border: 1px solid var(--yn-line-2, rgba(255, 200, 140, .12));
     border-radius: 10px;
     padding: 16px 18px;
-    background: var(--fw-bg-2, #181410);
+    background: var(--yn-bg-2, #181410);
     min-width: 0;
 
     &__lbl {
         font-size: 10.5px;
         letter-spacing: .12em;
         text-transform: uppercase;
-        color: var(--fw-text-3, #7e7468);
+        color: var(--yn-text-3, #7e7468);
         font-weight: 600;
     }
 
@@ -643,7 +643,7 @@
         font-size: 24px;
         font-weight: 600;
         margin-top: 8px;
-        color: var(--fw-text, #f2eee8);
+        color: var(--yn-text, #f2eee8);
         font-family: 'JetBrains Mono', ui-monospace, monospace;
         letter-spacing: -.01em;
         white-space: nowrap;
@@ -658,14 +658,14 @@
 
     &__meta {
         font-size: 12px;
-        color: var(--fw-text-3, #7e7468);
+        color: var(--yn-text-3, #7e7468);
         margin-top: 4px;
     }
 }
 
 .fws-link-note {
     font-size: 12.5px;
-    color: var(--fw-text-3, #7e7468);
+    color: var(--yn-text-3, #7e7468);
     margin: 14px 0 0;
     line-height: 1.55;
 
@@ -703,23 +703,23 @@
 
     &::-webkit-scrollbar { display: none; }
 
-    .fw-tab {
+    .yn-tab {
         background: transparent;
         border-radius: 0;
-        color: var(--fw-text-2);
+        color: var(--yn-text-2);
         box-shadow: none;
     }
 
-    .fw-tab--active {
+    .yn-tab--active {
         background: transparent;
-        color: var(--fw-text);
+        color: var(--yn-text);
         box-shadow: none;
     }
 
-    .fw-tab:hover { background: transparent; }
+    .yn-tab:hover { background: transparent; }
 
-    .fw-tab::before,
-    .fw-tab--active::before { display: none; }
+    .yn-tab::before,
+    .yn-tab--active::before { display: none; }
 }
 
 .fwstate-subtab-header__actions {
@@ -743,7 +743,7 @@
     min-height: 36px;
     padding-bottom: 9px;
     margin-bottom: 12px;
-    border-bottom: 1px solid var(--fw-line-2);
+    border-bottom: 1px solid var(--yn-line-2);
 }
 
 .fwstate-subtab-frame__actions {
@@ -787,9 +787,9 @@
     flex-direction: column;
     gap: 10px;
     padding: 12px;
-    border: 1px solid color-mix(in srgb, var(--fw-line-2) 75%, transparent);
+    border: 1px solid color-mix(in srgb, var(--yn-line-2) 75%, transparent);
     border-radius: 10px;
-    background: color-mix(in srgb, var(--fw-panel) 86%, var(--fw-bg-2) 14%);
+    background: color-mix(in srgb, var(--yn-panel) 86%, var(--yn-bg-2) 14%);
 }
 
 .fwstate-config-panel {
@@ -801,14 +801,14 @@
 
 .fwstate-config-section__head {
     padding: 0 0 8px;
-    border-bottom: 1px solid color-mix(in srgb, var(--fw-line-2) 72%, transparent);
+    border-bottom: 1px solid color-mix(in srgb, var(--yn-line-2) 72%, transparent);
 }
 
 .fwstate-timeout-unit {
     line-height: 1;
     display: inline-flex;
     align-items: center;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-size: 12px;
     letter-spacing: .02em;
     margin-inline-end: 1px;
@@ -816,9 +816,9 @@
 }
 
 .fwstate-panel {
-    border: 1px solid var(--fw-line-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 8px;
-    background: var(--fw-panel);
+    background: var(--yn-panel);
     padding: 14px;
 }
 
@@ -881,10 +881,10 @@
 }
 
 .fwstate-table-shell {
-    border: 1px solid var(--fw-line-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 8px;
     overflow: hidden;
-    background: color-mix(in srgb, var(--fw-panel) 70%, var(--fw-bg-2) 30%);
+    background: color-mix(in srgb, var(--yn-panel) 70%, var(--yn-bg-2) 30%);
 
     .g-table,
     table { width: 100%; min-width: 100%; }
@@ -896,20 +896,20 @@
     .g-table__th {
         font-size: 10.5px;
         font-weight: 500;
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
         letter-spacing: .06em;
         text-transform: uppercase;
         line-height: 1.35;
-        border-bottom: 1px solid var(--fw-line-2);
+        border-bottom: 1px solid var(--yn-line-2);
     }
 
     .g-table td,
     .g-table__td,
     table td {
         font-size: 12.5px;
-        color: var(--fw-text-2);
+        color: var(--yn-text-2);
         line-height: 1.35;
-        border-bottom: 1px solid var(--fw-line);
+        border-bottom: 1px solid var(--yn-line);
         padding-top: 8px;
         padding-bottom: 8px;
     }
@@ -924,10 +924,10 @@
 .fwstate-acl-link-btn {
     --g-button-border-width: 0px;
     --g-button-border-color: transparent;
-    --g-button-text-color: color-mix(in srgb, var(--fw-text-2) 88%, var(--fw-accent) 12%);
-    --g-button-background-color: color-mix(in srgb, var(--fw-bg-2) 86%, var(--fw-panel) 14%);
-    --g-button-background-color-hover: color-mix(in srgb, var(--fw-bg-2) 76%, var(--fw-panel) 24%);
-    border: 1px solid color-mix(in srgb, var(--fw-accent) 55%, transparent);
+    --g-button-text-color: color-mix(in srgb, var(--yn-text-2) 88%, var(--yn-accent) 12%);
+    --g-button-background-color: color-mix(in srgb, var(--yn-bg-2) 86%, var(--yn-panel) 14%);
+    --g-button-background-color-hover: color-mix(in srgb, var(--yn-bg-2) 76%, var(--yn-panel) 24%);
+    border: 1px solid color-mix(in srgb, var(--yn-accent) 55%, transparent);
     border-radius: var(--g-button-border-radius, var(--g-border-radius-s));
     position: relative;
     transition: color .15s ease;
@@ -936,25 +936,25 @@
     &::before { border-width: 0; }
 
     &:hover {
-        --g-button-text-color: color-mix(in srgb, var(--fw-text) 92%, var(--fw-accent) 8%);
-        border-color: color-mix(in srgb, var(--fw-accent) 75%, transparent);
+        --g-button-text-color: color-mix(in srgb, var(--yn-text) 92%, var(--yn-accent) 8%);
+        border-color: color-mix(in srgb, var(--yn-accent) 75%, transparent);
     }
 
     &:focus-visible {
         outline: none;
-        box-shadow: 0 0 0 1px color-mix(in srgb, var(--fw-accent) 55%, transparent);
+        box-shadow: 0 0 0 1px color-mix(in srgb, var(--yn-accent) 55%, transparent);
     }
 
-    &.g-button:focus-visible::before { border-color: var(--fw-accent); }
+    &.g-button:focus-visible::before { border-color: var(--yn-accent); }
 }
 
 .fwstate-stats-compare {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    border: 1px solid var(--fw-line-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 8px;
     overflow: hidden;
-    background: color-mix(in srgb, var(--fw-bg-2) 82%, var(--fw-panel) 18%);
+    background: color-mix(in srgb, var(--yn-bg-2) 82%, var(--yn-panel) 18%);
 
     > :nth-last-child(-n + 3) { border-bottom: 0; }
 }
@@ -965,17 +965,17 @@
     min-height: 38px;
     padding: 10px 12px;
     min-width: 0;
-    border-bottom: 1px solid var(--fw-line-2);
+    border-bottom: 1px solid var(--yn-line-2);
     font-size: 12px;
     line-height: 1.35;
 }
 
 .fwstate-stats-compare__head {
-    background: color-mix(in srgb, var(--fw-bg-2) 70%, var(--fw-panel) 30%);
+    background: color-mix(in srgb, var(--yn-bg-2) 70%, var(--yn-panel) 30%);
     text-transform: uppercase;
     letter-spacing: .06em;
     font-weight: 500;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
 
     &--metric {
         display: flex;
@@ -992,7 +992,7 @@
     width: 15px;
     height: 15px;
     border-radius: 999px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     cursor: help;
     flex: 0 0 auto;
 
@@ -1004,30 +1004,30 @@
 .fwstate-stats-compare__value {
     overflow-wrap: anywhere;
     word-break: break-word;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
 }
 
 .fwstate-stats-compare__metric {
     font-size: 13px;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
 }
 
 .fwstate-stats-compare__value {
     font-size: 14px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-variant-numeric: tabular-nums;
-    color: var(--fw-text);
+    color: var(--yn-text);
 }
 
 .fwstate-mono {
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 12px;
     font-variant-numeric: tabular-nums;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
 }
 
 .fwstate-table-cell {
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     font-size: 12px;
     line-height: 1.35;
 }

--- a/web/src/pages/modules/pdump/ConfigDialog.tsx
+++ b/web/src/pages/modules/pdump/ConfigDialog.tsx
@@ -122,12 +122,12 @@ export const ConfigDialog: React.FC<ConfigDialogProps> = ({
 
     const footer = (
         <>
-            <button type="button" className="fw-btn fw-btn--ghost" onClick={onClose} disabled={loading}>
+            <button type="button" className="yn-btn yn-btn--ghost" onClick={onClose} disabled={loading}>
                 Cancel
             </button>
             <button
                 type="button"
-                className="fw-btn fw-btn--primary"
+                className="yn-btn yn-btn--primary"
                 onClick={handleConfirm}
                 disabled={!valid || loading}
                 style={{ opacity: valid && !loading ? 1 : 0.5 }}

--- a/web/src/pages/modules/pdump/ConfigStrip.tsx
+++ b/web/src/pages/modules/pdump/ConfigStrip.tsx
@@ -88,7 +88,7 @@ const ConfigStrip: React.FC<ConfigStripProps> = ({
             <div className="pdump-strip__actions">
                 <button
                     type="button"
-                    className="fw-btn fw-btn--ghost fw-btn--sm"
+                    className="yn-btn yn-btn--ghost yn-btn--sm"
                     onClick={onEdit}
                     title="Edit configuration"
                 >
@@ -96,7 +96,7 @@ const ConfigStrip: React.FC<ConfigStripProps> = ({
                 </button>
                 <button
                     type="button"
-                    className="fw-btn fw-btn--ghost fw-btn--sm fw-btn--danger"
+                    className="yn-btn yn-btn--ghost yn-btn--sm yn-btn--danger"
                     onClick={onDelete}
                     disabled={isCaptureActive}
                     title="Delete configuration"
@@ -106,7 +106,7 @@ const ConfigStrip: React.FC<ConfigStripProps> = ({
                 {isCaptureActive ? (
                     <button
                         type="button"
-                        className="fw-btn fw-btn--sm pdump-strip__stop-btn"
+                        className="yn-btn yn-btn--sm pdump-strip__stop-btn"
                         onClick={onStopCapture}
                     >
                         Stop
@@ -114,7 +114,7 @@ const ConfigStrip: React.FC<ConfigStripProps> = ({
                 ) : (
                     <button
                         type="button"
-                        className="fw-btn fw-btn--sm pdump-strip__start-btn"
+                        className="yn-btn yn-btn--sm pdump-strip__start-btn"
                         onClick={onStartCapture}
                         disabled={isCapturing}
                         title={isCapturing ? 'Another capture is active' : 'Start capture'}

--- a/web/src/pages/modules/pdump/DeleteConfigDialog.tsx
+++ b/web/src/pages/modules/pdump/DeleteConfigDialog.tsx
@@ -13,12 +13,12 @@ interface DeleteConfigDialogProps {
 const DeleteConfigDialog: React.FC<DeleteConfigDialogProps> = ({ name, isDeleting, onClose, onConfirm }) => {
     const footer = (
         <>
-            <button type="button" className="fw-btn fw-btn--ghost" onClick={onClose} disabled={isDeleting}>
+            <button type="button" className="yn-btn yn-btn--ghost" onClick={onClose} disabled={isDeleting}>
                 Cancel
             </button>
             <button
                 type="button"
-                className="fw-btn pdump-modal-btn--danger"
+                className="yn-btn pdump-modal-btn--danger"
                 onClick={onConfirm}
                 disabled={isDeleting}
             >

--- a/web/src/pages/modules/pdump/PacketDrawer.tsx
+++ b/web/src/pages/modules/pdump/PacketDrawer.tsx
@@ -177,26 +177,26 @@ const PacketDrawer: React.FC<PacketDrawerProps> = ({
 
     return (
         <aside
-            className={`fw-drawer${open ? ' fw-drawer--open' : ''}`}
+            className={`yn-drawer${open ? ' yn-drawer--open' : ''}`}
             role="dialog"
             aria-modal="true"
             aria-label="Packet details"
         >
-            <header className="fw-drawer__head">
-                <h2 className="fw-drawer__title">
+            <header className="yn-drawer__head">
+                <h2 className="yn-drawer__title">
                     {packet ? (
                         <>
-                            Packet <span className="fw-drawer__rule-num">#{packet.id + 1}</span>
+                            Packet <span className="yn-drawer__rule-num">#{packet.id + 1}</span>
                             <span className="pdump-drawer-timestamp">{formatTime(packet.timestamp)}</span>
                         </>
                     ) : (
                         'Packet details'
                     )}
                 </h2>
-                <div className="fw-drawer__head-actions">
+                <div className="yn-drawer__head-actions">
                     <button
                         type="button"
-                        className="fw-icon-btn"
+                        className="yn-icon-btn"
                         onClick={onPrev}
                         disabled={packetIndex <= 0}
                         title="Previous packet (↑ / k)"
@@ -206,7 +206,7 @@ const PacketDrawer: React.FC<PacketDrawerProps> = ({
                     </button>
                     <button
                         type="button"
-                        className="fw-icon-btn"
+                        className="yn-icon-btn"
                         onClick={onNext}
                         disabled={packetIndex < 0 || packetIndex >= totalPackets - 1}
                         title="Next packet (↓ / j)"
@@ -216,7 +216,7 @@ const PacketDrawer: React.FC<PacketDrawerProps> = ({
                     </button>
                     <button
                         type="button"
-                        className="fw-icon-btn"
+                        className="yn-icon-btn"
                         onClick={onClose}
                         aria-label="Close drawer"
                         title="Close (Esc)"
@@ -226,7 +226,7 @@ const PacketDrawer: React.FC<PacketDrawerProps> = ({
                 </div>
             </header>
 
-            <div className="fw-drawer__body">
+            <div className="yn-drawer__body">
                 {packet ? (
                     <>
                         <Section kind="meta" title="Capture" sub={configName ?? ''}>
@@ -359,14 +359,14 @@ const PacketDrawer: React.FC<PacketDrawerProps> = ({
             </div>
 
             {packet && (
-                <footer className="fw-drawer__foot">
-                    <span className="fw-drawer__foot-meta">
+                <footer className="yn-drawer__foot">
+                    <span className="yn-drawer__foot-meta">
                         {packetIndex >= 0
                             ? `${packetIndex + 1} / ${totalPackets} packets`
                             : `evicted / ${totalPackets} packets`}
                     </span>
-                    <div className="fw-drawer__foot-actions">
-                        <button type="button" className="fw-btn fw-btn--ghost" onClick={onClose}>
+                    <div className="yn-drawer__foot-actions">
+                        <button type="button" className="yn-btn yn-btn--ghost" onClick={onClose}>
                             Close
                         </button>
                     </div>

--- a/web/src/pages/modules/pdump/PacketTable.tsx
+++ b/web/src/pages/modules/pdump/PacketTable.tsx
@@ -276,7 +276,7 @@ export const PacketTable: React.FC<PacketTableProps> = ({
                     {isCapturing && (
                         <button
                             type="button"
-                            className={`fw-btn fw-btn--ghost fw-btn--sm${autoScroll ? ' packet-table__btn--active' : ''}`}
+                            className={`yn-btn yn-btn--ghost yn-btn--sm${autoScroll ? ' packet-table__btn--active' : ''}`}
                             onClick={handleToggleAutoScroll}
                             title="Toggle auto-scroll to new packets"
                         >
@@ -285,7 +285,7 @@ export const PacketTable: React.FC<PacketTableProps> = ({
                     )}
                     <button
                         type="button"
-                        className={`fw-btn fw-btn--ghost fw-btn--sm${paused ? ' packet-table__btn--active' : ''}`}
+                        className={`yn-btn yn-btn--ghost yn-btn--sm${paused ? ' packet-table__btn--active' : ''}`}
                         onClick={onTogglePause}
                         title="Pause / resume view updates"
                     >
@@ -293,7 +293,7 @@ export const PacketTable: React.FC<PacketTableProps> = ({
                     </button>
                     <button
                         type="button"
-                        className="fw-btn fw-btn--ghost fw-btn--sm"
+                        className="yn-btn yn-btn--ghost yn-btn--sm"
                         onClick={onClearPackets}
                         disabled={packets.length === 0}
                         title="Clear all captured packets"

--- a/web/src/pages/modules/pdump/PacketTableRow.tsx
+++ b/web/src/pages/modules/pdump/PacketTableRow.tsx
@@ -103,8 +103,8 @@ const PacketTableRowImpl: React.FC<PacketTableRowProps> = ({
                 display: 'flex',
                 alignItems: 'center',
                 padding: '0 8px',
-                borderBottom: '1px solid var(--fw-line-2)',
-                backgroundColor: index % 2 === 0 ? 'transparent' : 'var(--fw-bg-2)',
+                borderBottom: '1px solid var(--yn-line-2)',
+                backgroundColor: index % 2 === 0 ? 'transparent' : 'var(--yn-bg-2)',
                 boxSizing: 'border-box',
                 cursor: 'pointer',
             }}

--- a/web/src/pages/modules/pdump/PdumpConfigTabs.tsx
+++ b/web/src/pages/modules/pdump/PdumpConfigTabs.tsx
@@ -29,7 +29,7 @@ const PdumpConfigTabs: React.FC<PdumpConfigTabsProps> = ({
     onSelect,
     onAddConfig,
 }) => (
-    <div className="fw-tabs" role="tablist">
+    <div className="yn-tabs" role="tablist">
         {configs.map((cfg) => {
             const isActive = cfg === activeConfig;
             const isLive = cfg === liveConfig;
@@ -39,21 +39,21 @@ const PdumpConfigTabs: React.FC<PdumpConfigTabsProps> = ({
                     type="button"
                     role="tab"
                     aria-selected={isActive}
-                    className={`fw-tab${isActive ? ' fw-tab--active' : ''}`}
+                    className={`yn-tab${isActive ? ' yn-tab--active' : ''}`}
                     onClick={() => onSelect(cfg)}
                 >
                     {isLive && (
                         <span
-                            className="fw-tab__dot fw-tab__dot--live"
+                            className="yn-tab__dot yn-tab__dot--live"
                             aria-label="live capture"
                         />
                     )}
-                    <span className="fw-tab__label">{cfg}</span>
-                    <span className="fw-tab__count">{counts.get(cfg) ?? 0}</span>
+                    <span className="yn-tab__label">{cfg}</span>
+                    <span className="yn-tab__count">{counts.get(cfg) ?? 0}</span>
                 </button>
             );
         })}
-        <Button view="flat" size="s" onClick={onAddConfig} className="fw-tabs__add" title="Add config">
+        <Button view="flat" size="s" onClick={onAddConfig} className="yn-tabs__add" title="Add config">
             <Icon data={Plus} size={14} />
         </Button>
     </div>

--- a/web/src/pages/modules/pdump/PdumpModal.tsx
+++ b/web/src/pages/modules/pdump/PdumpModal.tsx
@@ -28,7 +28,7 @@ const PdumpModal: React.FC<PdumpModalProps> = ({ title, width = '620px', onClose
             >
                 <div className="pdump-modal__header">
                     <div className="pdump-modal__title">{title}</div>
-                    <button type="button" className="fw-icon-btn" onClick={onClose} aria-label="Close">✕</button>
+                    <button type="button" className="yn-icon-btn" onClick={onClose} aria-label="Close">✕</button>
                 </div>
                 <div className="pdump-modal__body">
                     {children}

--- a/web/src/pages/modules/pdump/PdumpPage.tsx
+++ b/web/src/pages/modules/pdump/PdumpPage.tsx
@@ -444,10 +444,10 @@ const PdumpPage: React.FC = () => {
 
     return (
         <PageLayout header={pageHeader}>
-            <div className="fw-page pdump-page">
+            <div className="yn-page pdump-page">
                 {configs.length === 0 ? (
-                    <div className="fw-empty-page">
-                        <div className="fw-empty-page__message">
+                    <div className="yn-empty-page">
+                        <div className="yn-empty-page__message">
                             No pdump configurations found.
                         </div>
                         <Button view="action" onClick={() => setIsCreateDialogOpen(true)}>
@@ -465,7 +465,7 @@ const PdumpPage: React.FC = () => {
                             onAddConfig={() => setIsCreateDialogOpen(true)}
                         />
 
-                        <div className="fw-content pdump-page__content">
+                        <div className="yn-content pdump-page__content">
                             {currentConfigInfo && (
                                 <>
                                     <FilterRow filter={currentConfigInfo.config?.filter ?? ''} />

--- a/web/src/pages/modules/pdump/Sparkline.tsx
+++ b/web/src/pages/modules/pdump/Sparkline.tsx
@@ -14,7 +14,7 @@ const Sparkline: React.FC<SparklineProps> = ({
     values,
     width = 64,
     height = 18,
-    color = 'var(--fw-accent)',
+    color = 'var(--yn-accent)',
     fill = true,
 }) => {
     return <MetricSparkline values={values} width={width} height={height} color={color} fill={fill} />;

--- a/web/src/pages/modules/pdump/pdump.scss
+++ b/web/src/pages/modules/pdump/pdump.scss
@@ -2,11 +2,11 @@
 @use '../../../styles/mixins' as *;
 
 // Live tab dot — pulsing green indicator for the streaming config tab.
-.fw-tab__dot--live {
+.yn-tab__dot--live {
     width: 7px;
     height: 7px;
     border-radius: 50%;
-    background: var(--fw-ok, var(--g-color-text-positive));
+    background: var(--yn-ok, var(--g-color-text-positive));
     flex-shrink: 0;
     animation: pdump-pulse 1.6s ease-in-out infinite;
 }
@@ -32,12 +32,12 @@
 
 // !important overrides the per-row inline backgroundColor (stripe tint).
 .packet-table__row--selected {
-    background-color: var(--fw-accent-soft) !important;
+    background-color: var(--yn-accent-soft) !important;
 }
 
 // Hover must not clobber selected or new-flash states.
 .packet-table__row:not(.packet-table__row--selected):not(.packet-table__row--new):hover {
-    background-color: var(--fw-bg-hover) !important; // !important beats the inline stripe tint
+    background-color: var(--yn-bg-hover) !important; // !important beats the inline stripe tint
 }
 
 // BPF filter full-width card.
@@ -46,9 +46,9 @@
     align-items: center;
     gap: 12px;
     padding: 10px 16px;
-    background: var(--fw-panel);
-    border: 1px solid var(--fw-line-2);
-    border-radius: var(--fw-r-md, 6px);
+    background: var(--yn-panel);
+    border: 1px solid var(--yn-line-2);
+    border-radius: var(--yn-r-md, 6px);
     margin-bottom: 8px;
     flex-shrink: 0;
 
@@ -57,7 +57,7 @@
         font-weight: 700;
         letter-spacing: 0.1em;
         text-transform: uppercase;
-        color: var(--fw-accent);
+        color: var(--yn-accent);
         flex-shrink: 0;
     }
 
@@ -74,7 +74,7 @@
             right: 0;
             width: 48px;
             height: 100%;
-            background: linear-gradient(to right, transparent, var(--fw-panel));
+            background: linear-gradient(to right, transparent, var(--yn-panel));
             pointer-events: none;
         }
 
@@ -86,7 +86,7 @@
     &__expr {
         overflow-x: auto;
         white-space: nowrap;
-        font-family: var(--fw-font-mono);
+        font-family: var(--yn-font-mono);
         font-size: 13px;
         line-height: 1.5;
         padding-bottom: 2px;
@@ -101,17 +101,17 @@
         font-weight: 500;
         padding: 4px 10px;
         border-radius: 5px;
-        border: 1px solid var(--fw-line-2);
-        background: var(--fw-bg-2);
-        color: var(--fw-text-2);
+        border: 1px solid var(--yn-line-2);
+        background: var(--yn-bg-2);
+        color: var(--yn-text-2);
         cursor: pointer;
         transition: color 0.1s, background 0.1s, border-color 0.1s;
         white-space: nowrap;
 
-        &:hover { background: var(--fw-bg-3); color: var(--fw-text); }
+        &:hover { background: var(--yn-bg-3); color: var(--yn-text); }
 
         &--copied {
-            color: var(--fw-ok, var(--g-color-text-positive));
+            color: var(--yn-ok, var(--g-color-text-positive));
             border-color: rgba(110, 198, 140, 0.3);
             background: rgba(110, 198, 140, 0.08);
         }
@@ -120,23 +120,23 @@
 
 // BPF token colours.
 .pdump-bpf-tok {
-    &--kw   { color: var(--fw-accent); }
+    &--kw   { color: var(--yn-accent); }
     &--proto { color: #8ab4f8; }
     &--num  { color: #ce9178; }
     &--host { color: #9cdcfe; }
-    &--txt  { color: var(--fw-text-2); }
+    &--txt  { color: var(--yn-text-2); }
 }
 
-.pdump-bpf-empty { color: var(--fw-text-3); font-style: italic; }
+.pdump-bpf-empty { color: var(--yn-text-3); font-style: italic; }
 
 // BPF preview and suggestion chips in ConfigDialog.
 .pdump-bpf-preview {
     margin-top: 6px;
     padding: 6px 10px;
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 5px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 12.5px;
     white-space: nowrap;
     overflow-x: auto;
@@ -151,19 +151,19 @@
 
 .pdump-bpf-suggestion {
     font-size: 11.5px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     padding: 3px 8px;
     border-radius: 4px;
-    border: 1px solid var(--fw-line-2);
-    background: var(--fw-bg-2);
-    color: var(--fw-text-2);
+    border: 1px solid var(--yn-line-2);
+    background: var(--yn-bg-2);
+    color: var(--yn-text-2);
     cursor: pointer;
     white-space: nowrap;
     transition: background 0.08s, color 0.08s, border-color 0.08s;
 
     &:hover {
-        background: var(--fw-bg-3);
-        color: var(--fw-accent);
+        background: var(--yn-bg-3);
+        color: var(--yn-accent);
         border-color: rgba(255, 192, 97, 0.25);
     }
 }
@@ -174,7 +174,7 @@
 
 .pdump-bpf-recents__label {
     font-size: 11px;
-    color: var(--fw-muted, #8a8580);
+    color: var(--yn-muted, #8a8580);
     text-transform: uppercase;
     letter-spacing: 0.04em;
     margin-bottom: 4px;
@@ -186,9 +186,9 @@
     align-items: center;
     gap: 16px;
     padding: 8px 16px;
-    background: var(--fw-panel);
-    border: 1px solid var(--fw-line-2);
-    border-radius: var(--fw-r-md, 6px);
+    background: var(--yn-panel);
+    border: 1px solid var(--yn-line-2);
+    border-radius: var(--yn-r-md, 6px);
     margin-bottom: 8px;
     flex-shrink: 0;
 
@@ -227,9 +227,9 @@
         }
 
         &--none {
-            color: var(--fw-text-3);
-            background: var(--fw-bg-2);
-            border-color: var(--fw-line-2);
+            color: var(--yn-text-3);
+            background: var(--yn-bg-2);
+            border-color: var(--yn-line-2);
         }
     }
 
@@ -241,12 +241,12 @@
     }
 
     &__param-label {
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
     }
 
     &__param-value {
-        color: var(--fw-text-2);
-        font-family: var(--fw-font-mono);
+        color: var(--yn-text-2);
+        font-family: var(--yn-font-mono);
         font-size: 12px;
     }
 
@@ -291,8 +291,8 @@
     align-items: center;
     gap: 16px;
     padding: 0 14px;
-    border-left: 1px solid var(--fw-line-2);
-    border-right: 1px solid var(--fw-line-2);
+    border-left: 1px solid var(--yn-line-2);
+    border-right: 1px solid var(--yn-line-2);
 }
 
 .pdump-stat {
@@ -304,7 +304,7 @@
 
     &__label {
         font-size: 10px;
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
         text-transform: uppercase;
         letter-spacing: 0.08em;
         font-weight: 500;
@@ -313,11 +313,11 @@
     &__value {
         font-size: 13px;
         font-weight: 600;
-        font-family: var(--fw-font-mono);
-        color: var(--fw-text);
+        font-family: var(--yn-font-mono);
+        color: var(--yn-text);
         font-variant-numeric: tabular-nums;
 
-        &--muted { color: var(--fw-text-3); }
+        &--muted { color: var(--yn-text-3); }
     }
 }
 
@@ -328,7 +328,7 @@
     font-weight: 600;
     padding: 1px 6px;
     border-radius: 3px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     letter-spacing: 0.03em;
 }
 
@@ -352,17 +352,17 @@
     background: rgba(76, 182, 133, 0.10);
 }
 
-// Drawer scroll fix — fw-drawer__body has flex:1 but needs min-height:0 to constrain it.
-.fw-drawer__body {
+// Drawer scroll fix — yn-drawer__body has flex:1 but needs min-height:0 to constrain it.
+.yn-drawer__body {
     min-height: 0;
 }
 
 // Collapsible packet-detail sections.
 .pdump-section {
-    border: 1px solid var(--fw-line-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 8px;
     margin-bottom: 10px;
-    background: var(--fw-bg-2);
+    background: var(--yn-bg-2);
 
     &__head {
         display: flex;
@@ -383,24 +383,24 @@
         width: 8px;
         height: 8px;
         border-radius: 2px;
-        background: var(--fw-text-3);
+        background: var(--yn-text-3);
         flex-shrink: 0;
     }
 
     &__title {
         font-size: 12.5px;
         font-weight: 600;
-        color: var(--fw-text);
+        color: var(--yn-text);
     }
 
     &__sub {
-        font-family: var(--fw-font-mono);
+        font-family: var(--yn-font-mono);
         font-size: 11.5px;
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
     }
 
     &__chevron {
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
         transition: transform 0.18s ease;
         display: flex;
         align-items: center;
@@ -415,18 +415,18 @@
         .pdump-section__chevron { transform: rotate(-90deg); }
     }
 
-    &--eth   .pdump-section__marker { background: var(--fw-text-3); }
+    &--eth   .pdump-section__marker { background: var(--yn-text-3); }
     &--vlan  .pdump-section__marker { background: #d9a154; }
     &--ipv4  .pdump-section__marker { background: var(--g-color-text-positive); }
     &--ipv6  .pdump-section__marker { background: var(--g-color-text-positive); }
     &--tcp   .pdump-section__marker { background: var(--g-color-text-info); }
     &--udp   .pdump-section__marker { background: var(--g-color-text-misc); }
     &--icmp  .pdump-section__marker { background: #c07a45; }
-    &--meta  .pdump-section__marker { background: var(--fw-accent); }
-    &--http  .pdump-section__marker { background: var(--fw-accent); }
+    &--meta  .pdump-section__marker { background: var(--yn-accent); }
+    &--http  .pdump-section__marker { background: var(--yn-accent); }
 }
 
-.pdump-page .fw-drawer {
+.pdump-page .yn-drawer {
     width: 640px;
 }
 
@@ -436,14 +436,14 @@
     grid-template-columns: 130px 1fr;
     gap: 14px;
     padding: 4px 0;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 12px;
 }
 
-.pdump-kv-k { color: var(--fw-text-3); }
+.pdump-kv-k { color: var(--yn-text-3); }
 
 .pdump-kv-v {
-    color: var(--fw-text);
+    color: var(--yn-text);
     word-break: break-all;
 }
 
@@ -459,11 +459,11 @@
 
 // Colourised hex dump component.
 .pdump-hex-dump {
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 11.5px;
     line-height: 1.55;
     padding: 10px 0 4px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     overflow-x: auto;
 }
 
@@ -472,50 +472,50 @@
     gap: 16px;
 }
 
-.pdump-hex-offset { color: var(--fw-text-3); }
-.pdump-hex-bytes  { color: var(--fw-text); letter-spacing: 0.02em; }
-.pdump-hex-ascii  { color: var(--fw-text-3); }
+.pdump-hex-offset { color: var(--yn-text-3); }
+.pdump-hex-bytes  { color: var(--yn-text); letter-spacing: 0.02em; }
+.pdump-hex-ascii  { color: var(--yn-text-3); }
 
 .pdump-hex-bytes {
-    .hl-eth     { color: var(--fw-text-2); background: rgba(255, 255, 255, 0.04); padding: 0 1px; border-radius: 1px; }
+    .hl-eth     { color: var(--yn-text-2); background: rgba(255, 255, 255, 0.04); padding: 0 1px; border-radius: 1px; }
     .hl-ip      { color: var(--g-color-text-positive); background: rgba(76, 182, 133, 0.12); padding: 0 1px; }
     .hl-l4      { color: var(--g-color-text-info); background: rgba(106, 158, 209, 0.14); padding: 0 1px; }
-    .hl-payload { color: var(--fw-accent); background: rgba(217, 161, 84, 0.12); padding: 0 1px; }
+    .hl-payload { color: var(--yn-accent); background: rgba(217, 161, 84, 0.12); padding: 0 1px; }
 }
 
 .pdump-drawer-timestamp {
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 12px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-weight: 400;
     margin-left: 6px;
 }
 
 .pdump-drawer-empty {
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-size: 13px;
     text-align: center;
     padding: 40px 0;
 }
 
 // Custom modal chrome.
-// CSS variables are declared here rather than inheriting from .fw-modal,
+// CSS variables are declared here rather than inheriting from .yn-modal,
 // because that class also carries width:640px which breaks full-viewport coverage.
 .pdump-modal-backdrop {
-    --fw-panel:       #1C1814;
-    --fw-bg-2:        #181410;
-    --fw-bg-3:        #221C16;
-    --fw-bg-hover:    #221C16;
-    --fw-line-2:      rgba(255, 200, 140, 0.12);
-    --fw-text:        #F2EEE8;
-    --fw-text-2:      #B8B0A4;
-    --fw-text-3:      #7E7468;
-    --fw-accent:      #FFC061;
-    --fw-accent-soft: rgba(255, 192, 97, 0.14);
-    --fw-r-sm:        4px;
-    --fw-r-md:        6px;
-    --fw-r-lg:        10px;
-    --fw-font-mono:   'JetBrains Mono', ui-monospace, monospace;
+    --yn-panel:       #1C1814;
+    --yn-bg-2:        #181410;
+    --yn-bg-3:        #221C16;
+    --yn-bg-hover:    #221C16;
+    --yn-line-2:      rgba(255, 200, 140, 0.12);
+    --yn-text:        #F2EEE8;
+    --yn-text-2:      #B8B0A4;
+    --yn-text-3:      #7E7468;
+    --yn-accent:      #FFC061;
+    --yn-accent-soft: rgba(255, 192, 97, 0.14);
+    --yn-r-sm:        4px;
+    --yn-r-md:        6px;
+    --yn-r-lg:        10px;
+    --yn-font-mono:   'JetBrains Mono', ui-monospace, monospace;
 
     position: fixed;
     inset: 0;
@@ -527,20 +527,20 @@
 }
 
 [data-theme="light"] .pdump-modal-backdrop {
-    --fw-panel:    #FFFFFF;
-    --fw-bg-2:     #F3EFE9;
-    --fw-bg-3:     #EBE6DE;
-    --fw-bg-hover: #EBE6DE;
-    --fw-line-2:   rgba(80, 60, 30, 0.16);
-    --fw-text:     #1A1410;
-    --fw-text-2:   #5C4E3A;
-    --fw-text-3:   #9C8B74;
+    --yn-panel:    #FFFFFF;
+    --yn-bg-2:     #F3EFE9;
+    --yn-bg-3:     #EBE6DE;
+    --yn-bg-hover: #EBE6DE;
+    --yn-line-2:   rgba(80, 60, 30, 0.16);
+    --yn-text:     #1A1410;
+    --yn-text-2:   #5C4E3A;
+    --yn-text-3:   #9C8B74;
 }
 
 .pdump-modal {
     max-width: calc(100vw - 40px);
-    background: var(--fw-panel);
-    border: 1px solid var(--fw-line-2);
+    background: var(--yn-panel);
+    border: 1px solid var(--yn-line-2);
     border-radius: 12px;
     box-shadow: 0 30px 80px rgba(0, 0, 0, 0.5);
     overflow: hidden;
@@ -550,13 +550,13 @@
         align-items: center;
         justify-content: space-between;
         padding: 16px 20px;
-        border-bottom: 1px solid var(--fw-line-2);
+        border-bottom: 1px solid var(--yn-line-2);
     }
 
     &__title {
         font-size: 15px;
         font-weight: 600;
-        color: var(--fw-text);
+        color: var(--yn-text);
     }
 
     &__body {
@@ -571,21 +571,21 @@
         justify-content: flex-end;
         gap: 10px;
         padding: 14px 20px;
-        border-top: 1px solid var(--fw-line-2);
+        border-top: 1px solid var(--yn-line-2);
         background: rgba(0, 0, 0, 0.2);
     }
 
     &__delete-text {
         margin: 0;
         font-size: 13px;
-        color: var(--fw-text);
+        color: var(--yn-text);
     }
 
     &__code {
-        font-family: var(--fw-font-mono);
+        font-family: var(--yn-font-mono);
         font-size: 12.5px;
-        color: var(--fw-accent);
-        background: var(--fw-bg-2);
+        color: var(--yn-accent);
+        background: var(--yn-bg-2);
         padding: 1px 5px;
         border-radius: 3px;
     }
@@ -629,7 +629,7 @@
 
     &__label {
         font-size: 12px;
-        color: var(--fw-text);
+        color: var(--yn-text);
         font-weight: 500;
     }
 
@@ -640,7 +640,7 @@
 
     &__hint {
         font-size: 11.5px;
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
     }
 }
 
@@ -655,22 +655,22 @@
     width: 100%;
     box-sizing: border-box;
     background: #0d0d10;
-    border: 1px solid var(--fw-line-2);
-    border-radius: var(--fw-r-md, 6px);
-    color: var(--fw-text);
+    border: 1px solid var(--yn-line-2);
+    border-radius: var(--yn-r-md, 6px);
+    color: var(--yn-text);
     font-size: 13px;
     padding: 0 12px;
     outline: none;
     transition: border-color 0.1s;
 
-    &:focus { border-color: var(--fw-accent); }
+    &:focus { border-color: var(--yn-accent); }
 
-    &--mono { font-family: var(--fw-font-mono); }
+    &--mono { font-family: var(--yn-font-mono); }
 }
 
 .pdump-bpf-input {
     height: 38px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 13px;
 }
 
@@ -685,8 +685,8 @@
     display: flex;
     align-items: flex-start;
     gap: 10px;
-    border: 1px solid var(--fw-line-2);
-    background: var(--fw-bg-2);
+    border: 1px solid var(--yn-line-2);
+    background: var(--yn-bg-2);
     border-radius: 6px;
     padding: 10px 12px;
     cursor: pointer;
@@ -696,14 +696,14 @@
     &:hover { border-color: rgba(255, 192, 97, 0.3); }
 
     &--checked {
-        border-color: var(--fw-accent);
-        background: var(--fw-accent-soft);
+        border-color: var(--yn-accent);
+        background: var(--yn-accent-soft);
     }
 
     &__box {
         width: 16px;
         height: 16px;
-        border: 1.5px solid var(--fw-line-2);
+        border: 1.5px solid var(--yn-line-2);
         border-radius: 3px;
         margin-top: 2px;
         display: grid;
@@ -712,8 +712,8 @@
         transition: all 0.12s;
 
         .pdump-mode-check--checked & {
-            background: var(--fw-accent);
-            border-color: var(--fw-accent);
+            background: var(--yn-accent);
+            border-color: var(--yn-accent);
         }
     }
 
@@ -728,26 +728,26 @@
     &__label {
         font-size: 12px;
         font-weight: 600;
-        font-family: var(--fw-font-mono);
+        font-family: var(--yn-font-mono);
         letter-spacing: 0.05em;
-        color: var(--fw-text);
+        color: var(--yn-text);
 
-        .pdump-mode-check--checked & { color: var(--fw-accent); }
+        .pdump-mode-check--checked & { color: var(--yn-accent); }
     }
 
     &__hint {
         font-size: 11px;
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
         margin-top: 2px;
     }
 }
 
-// Packet table overrides for fw-page chrome.
+// Packet table overrides for yn-page chrome.
 .packet-table {
     @include flex-column;
-    background: var(--fw-panel);
-    border: 1px solid var(--fw-line-2);
-    border-radius: var(--fw-r-lg, 10px);
+    background: var(--yn-panel);
+    border: 1px solid var(--yn-line-2);
+    border-radius: var(--yn-r-lg, 10px);
     overflow: hidden;
 
     &__container { height: 100%; }
@@ -757,8 +757,8 @@
         align-items: center;
         gap: 10px;
         padding: 0 12px;
-        border-bottom: 1px solid var(--fw-line-2);
-        background: var(--fw-panel);
+        border-bottom: 1px solid var(--yn-line-2);
+        background: var(--yn-panel);
         flex-shrink: 0;
     }
 
@@ -774,7 +774,7 @@
 
     &__stats {
         font-size: 12px;
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
         font-variant-numeric: tabular-nums;
         white-space: nowrap;
     }
@@ -791,7 +791,7 @@
 
         &--paused {
             background: rgba(217, 161, 84, 0.12);
-            color: var(--fw-accent);
+            color: var(--yn-accent);
             border-color: rgba(255, 192, 97, 0.22);
         }
     }
@@ -804,9 +804,9 @@
     }
 
     &__btn--active {
-        color: var(--fw-accent) !important;
+        color: var(--yn-accent) !important;
         border-color: rgba(255, 192, 97, 0.3) !important;
-        background: var(--fw-accent-soft) !important;
+        background: var(--yn-accent-soft) !important;
     }
 
     &__wrapper {
@@ -836,14 +836,14 @@
         align-items: center;
         justify-content: space-between;
         padding: 0 12px;
-        border-top: 1px solid var(--fw-line-2);
-        background: var(--fw-panel);
+        border-top: 1px solid var(--yn-line-2);
+        background: var(--yn-panel);
         flex-shrink: 0;
     }
 
     &__footer-text {
         font-size: 11px;
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
     }
 }
 
@@ -851,8 +851,8 @@
 .packet-table-header {
     @include flex-row($spacing-sm);
     padding: 0 $spacing-sm;
-    border-bottom: 1px solid var(--fw-line-2);
-    background: var(--fw-bg-2);
+    border-bottom: 1px solid var(--yn-line-2);
+    background: var(--yn-bg-2);
     font-weight: $font-weight-medium;
     box-sizing: border-box;
     flex-shrink: 0;

--- a/web/src/pages/modules/route/FIBDrawer.tsx
+++ b/web/src/pages/modules/route/FIBDrawer.tsx
@@ -76,76 +76,76 @@ const FIBDrawer = React.forwardRef<FIBDrawerHandle, FIBDrawerProps>(({
             onJump={onJump}
             ariaLabel="Edit route"
         >
-            <section className="fw-section">
-                <div className="fw-section-h">Destination</div>
-                <div className="fw-section__body">
-                    <div className="fw-field">
-                        <label className="fw-field__label">
-                            Prefix <span className="fw-field__req">*</span>
+            <section className="yn-section">
+                <div className="yn-section-h">Destination</div>
+                <div className="yn-section__body">
+                    <div className="yn-field">
+                        <label className="yn-field__label">
+                            Prefix <span className="yn-field__req">*</span>
                         </label>
                         <input
-                            className={`fw-input fw-input--mono${errors.prefix ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input yn-input--mono${errors.prefix ? ' yn-input--invalid' : ''}`}
                             value={draft?.prefix ?? ''}
                             placeholder="10.0.0.0/8 or 2a02:6b8::/32"
                             onChange={(e) => updateField('prefix', e.target.value.trim())}
                         />
                         {errors.prefix
-                            ? <span className="fw-field__hint fw-field__error">{errors.prefix}</span>
-                            : <span className="fw-field__hint">IPv4 or IPv6 with mask.</span>
+                            ? <span className="yn-field__hint yn-field__error">{errors.prefix}</span>
+                            : <span className="yn-field__hint">IPv4 or IPv6 with mask.</span>
                         }
                     </div>
                 </div>
             </section>
 
-            <section className="fw-section">
-                <div className="fw-section-h">L2 Rewrite</div>
-                <div className="fw-section__body">
-                    <div className="fw-field">
-                        <label className="fw-field__label">
-                            Destination MAC <span className="fw-field__req">*</span>
+            <section className="yn-section">
+                <div className="yn-section-h">L2 Rewrite</div>
+                <div className="yn-section__body">
+                    <div className="yn-field">
+                        <label className="yn-field__label">
+                            Destination MAC <span className="yn-field__req">*</span>
                         </label>
                         <input
-                            className={`fw-input fw-input--mono${errors.dst_mac ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input yn-input--mono${errors.dst_mac ? ' yn-input--invalid' : ''}`}
                             value={draft?.dst_mac ?? ''}
                             placeholder="52:54:00:00:1c:57"
                             onChange={(e) => updateField('dst_mac', e.target.value.trim())}
                         />
                         {errors.dst_mac && (
-                            <span className="fw-field__hint fw-field__error">{errors.dst_mac}</span>
+                            <span className="yn-field__hint yn-field__error">{errors.dst_mac}</span>
                         )}
                     </div>
-                    <div className="fw-field">
-                        <label className="fw-field__label">
-                            Source MAC <span className="fw-field__req">*</span>
+                    <div className="yn-field">
+                        <label className="yn-field__label">
+                            Source MAC <span className="yn-field__req">*</span>
                         </label>
                         <input
-                            className={`fw-input fw-input--mono${errors.src_mac ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input yn-input--mono${errors.src_mac ? ' yn-input--invalid' : ''}`}
                             value={draft?.src_mac ?? ''}
                             placeholder="52:54:00:12:34:56"
                             onChange={(e) => updateField('src_mac', e.target.value.trim())}
                         />
                         {errors.src_mac && (
-                            <span className="fw-field__hint fw-field__error">{errors.src_mac}</span>
+                            <span className="yn-field__hint yn-field__error">{errors.src_mac}</span>
                         )}
                     </div>
                 </div>
             </section>
 
-            <section className="fw-section">
-                <div className="fw-section-h">Egress</div>
-                <div className="fw-section__body">
-                    <div className="fw-field">
-                        <label className="fw-field__label">
-                            Device <span className="fw-field__req">*</span>
+            <section className="yn-section">
+                <div className="yn-section-h">Egress</div>
+                <div className="yn-section__body">
+                    <div className="yn-field">
+                        <label className="yn-field__label">
+                            Device <span className="yn-field__req">*</span>
                         </label>
                         <input
-                            className={`fw-input${errors.device ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input${errors.device ? ' yn-input--invalid' : ''}`}
                             value={draft?.device ?? ''}
                             placeholder="eth0"
                             onChange={(e) => updateField('device', e.target.value.trim())}
                         />
                         {errors.device && (
-                            <span className="fw-field__hint fw-field__error">{errors.device}</span>
+                            <span className="yn-field__hint yn-field__error">{errors.device}</span>
                         )}
                     </div>
                 </div>

--- a/web/src/pages/modules/route/FIBTable.tsx
+++ b/web/src/pages/modules/route/FIBTable.tsx
@@ -23,10 +23,10 @@ const COLUMN_HEADERS: TableColumnHeader[] = [
 ];
 
 const REMOVED_COLUMNS: RemovedColumnDescriptor<FIBRowItem>[] = [
-    { width: COLUMN_WIDTHS.prefix, render: (r) => <span className="fw-cell-mono">{r.prefix}</span> },
-    { width: COLUMN_WIDTHS.dst_mac, render: (r) => <span className="fw-cell-mono fw-cell-muted">{r.dst_mac}</span> },
-    { width: COLUMN_WIDTHS.src_mac, render: (r) => <span className="fw-cell-mono fw-cell-muted">{r.src_mac}</span> },
-    { width: COLUMN_WIDTHS.device, render: (r) => <span className="fw-cell-mono fw-cell-muted">{r.device}</span> },
+    { width: COLUMN_WIDTHS.prefix, render: (r) => <span className="yn-cell-mono">{r.prefix}</span> },
+    { width: COLUMN_WIDTHS.dst_mac, render: (r) => <span className="yn-cell-mono yn-cell-muted">{r.dst_mac}</span> },
+    { width: COLUMN_WIDTHS.src_mac, render: (r) => <span className="yn-cell-mono yn-cell-muted">{r.src_mac}</span> },
+    { width: COLUMN_WIDTHS.device, render: (r) => <span className="yn-cell-mono yn-cell-muted">{r.device}</span> },
 ];
 
 const dataCellStyle = (width: number, hasError: boolean): React.CSSProperties => ({
@@ -40,7 +40,7 @@ const dataCellStyle = (width: number, hasError: boolean): React.CSSProperties =>
     paddingRight: 8,
     display: 'flex',
     alignItems: 'center',
-    ...(hasError ? { color: 'var(--fw-danger)' } : {}),
+    ...(hasError ? { color: 'var(--yn-danger)' } : {}),
 });
 
 const renderFIBDataCells = (row: FIBRowItem): React.ReactNode => {
@@ -48,18 +48,18 @@ const renderFIBDataCells = (row: FIBRowItem): React.ReactNode => {
     return (
         <>
             <div style={dataCellStyle(COLUMN_WIDTHS.prefix, !!errors.prefix)} title={row.prefix || undefined}>
-                <span className="fw-cell-mono fw-cell-strong">
-                    {row.prefix || <span style={{ color: 'var(--fw-text-3)', fontStyle: 'italic' }}>prefix?</span>}
+                <span className="yn-cell-mono yn-cell-strong">
+                    {row.prefix || <span style={{ color: 'var(--yn-text-3)', fontStyle: 'italic' }}>prefix?</span>}
                 </span>
             </div>
             <div style={dataCellStyle(COLUMN_WIDTHS.dst_mac, !!errors.dst_mac)} title={row.dst_mac || undefined}>
-                <span className="fw-cell-mono fw-cell-muted">{row.dst_mac || '—'}</span>
+                <span className="yn-cell-mono yn-cell-muted">{row.dst_mac || '—'}</span>
             </div>
             <div style={dataCellStyle(COLUMN_WIDTHS.src_mac, !!errors.src_mac)} title={row.src_mac || undefined}>
-                <span className="fw-cell-mono fw-cell-muted">{row.src_mac || '—'}</span>
+                <span className="yn-cell-mono yn-cell-muted">{row.src_mac || '—'}</span>
             </div>
             <div style={dataCellStyle(COLUMN_WIDTHS.device, !!errors.device)} title={row.device || undefined}>
-                <span className="fw-cell-mono fw-cell-muted">{row.device || '—'}</span>
+                <span className="yn-cell-mono yn-cell-muted">{row.device || '—'}</span>
             </div>
         </>
     );

--- a/web/src/pages/modules/route/FIBYamlIO.tsx
+++ b/web/src/pages/modules/route/FIBYamlIO.tsx
@@ -23,17 +23,17 @@ const FIBYamlIO: React.FC<FIBYamlIOProps> = ({ configName, rows, onImport }) => 
     const importExtraControls = (
         <>
             <div style={{ flex: 1 }} />
-            <span style={{ fontSize: 12, color: 'var(--fw-text-3)' }}>Mode:</span>
+            <span style={{ fontSize: 12, color: 'var(--yn-text-3)' }}>Mode:</span>
             <button
                 type="button"
-                className={`fw-btn fw-btn--sm${importMode === 'replace' ? '' : ' fw-btn--ghost'}`}
+                className={`yn-btn yn-btn--sm${importMode === 'replace' ? '' : ' yn-btn--ghost'}`}
                 onClick={() => setImportMode('replace')}
             >
                 Replace all
             </button>
             <button
                 type="button"
-                className={`fw-btn fw-btn--sm${importMode === 'append' ? '' : ' fw-btn--ghost'}`}
+                className={`yn-btn yn-btn--sm${importMode === 'append' ? '' : ' yn-btn--ghost'}`}
                 onClick={() => setImportMode('append')}
             >
                 Append

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -186,10 +186,10 @@ const RoutePage: React.FC = () => {
 
     return (
         <PageLayout header={pageHeader}>
-            <div className="fw-page">
+            <div className="yn-page">
                 {draftConfigs.length === 0 ? (
-                    <div className="fw-empty-page">
-                        <div className="fw-empty-page__message">No FIB configurations found.</div>
+                    <div className="yn-empty-page">
+                        <div className="yn-empty-page__message">No FIB configurations found.</div>
                         <Button view="action" onClick={() => setAddConfigOpen(true)}>Add Config</Button>
                     </div>
                 ) : (
@@ -202,7 +202,7 @@ const RoutePage: React.FC = () => {
                             onSelect={handleConfigSelect}
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
-                        <div className="fw-content">
+                        <div className="yn-content">
                             <FIBTable
                                 allRows={rawRows}
                                 visibleRows={visibleRows}

--- a/web/src/pages/operators/neighbours/CreateTableModal.tsx
+++ b/web/src/pages/operators/neighbours/CreateTableModal.tsx
@@ -60,20 +60,20 @@ const CreateTableModal: React.FC<CreateTableModalProps> = ({
     };
 
     return (
-        <div className="fw-modal-backdrop" onClick={handleClose}>
-            <div className="fw-modal fw-modal--sm" onClick={(e) => e.stopPropagation()}>
-                <header className="fw-modal__head">
-                    <span className="fw-modal__title">Create neighbour table</span>
-                    <button type="button" className="fw-icon-btn" onClick={handleClose} aria-label="Close">✕</button>
+        <div className="yn-modal-backdrop" onClick={handleClose}>
+            <div className="yn-modal yn-modal--sm" onClick={(e) => e.stopPropagation()}>
+                <header className="yn-modal__head">
+                    <span className="yn-modal__title">Create neighbour table</span>
+                    <button type="button" className="yn-icon-btn" onClick={handleClose} aria-label="Close">✕</button>
                 </header>
-                <div className="fw-modal__body fw-modal__body--confirm">
-                    <div className="fw-field">
-                        <label className="fw-field__label" htmlFor="ct-name">
-                            Name <span className="fw-field__req">*</span>
+                <div className="yn-modal__body yn-modal__body--confirm">
+                    <div className="yn-field">
+                        <label className="yn-field__label" htmlFor="ct-name">
+                            Name <span className="yn-field__req">*</span>
                         </label>
                         <input
                             id="ct-name"
-                            className={`fw-input${nameError && trimmedName ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input${nameError && trimmedName ? ' yn-input--invalid' : ''}`}
                             type="text"
                             value={name}
                             onChange={(e) => setName(e.target.value)}
@@ -85,16 +85,16 @@ const CreateTableModal: React.FC<CreateTableModalProps> = ({
                             autoFocus
                         />
                         {nameError && trimmedName && (
-                            <span className="fw-field__hint fw-field__error">{nameError}</span>
+                            <span className="yn-field__hint yn-field__error">{nameError}</span>
                         )}
                     </div>
-                    <div className="fw-field">
-                        <label className="fw-field__label" htmlFor="ct-priority">
-                            Default Priority <span className="fw-field__req">*</span>
+                    <div className="yn-field">
+                        <label className="yn-field__label" htmlFor="ct-priority">
+                            Default Priority <span className="yn-field__req">*</span>
                         </label>
                         <input
                             id="ct-priority"
-                            className={`fw-input${priorityError && defaultPriority ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input${priorityError && defaultPriority ? ' yn-input--invalid' : ''}`}
                             type="number"
                             value={defaultPriority}
                             onChange={(e) => setDefaultPriority(e.target.value)}
@@ -105,21 +105,21 @@ const CreateTableModal: React.FC<CreateTableModalProps> = ({
                             placeholder="100"
                         />
                         {priorityError && defaultPriority ? (
-                            <span className="fw-field__hint fw-field__error">{priorityError}</span>
+                            <span className="yn-field__hint yn-field__error">{priorityError}</span>
                         ) : (
-                            <span className="fw-field__hint">Lower value wins on merge.</span>
+                            <span className="yn-field__hint">Lower value wins on merge.</span>
                         )}
                     </div>
                 </div>
-                <footer className="fw-modal__foot">
+                <footer className="yn-modal__foot">
                     <span />
-                    <div className="fw-modal__foot-actions">
-                        <button type="button" className="fw-btn fw-btn--ghost" onClick={handleClose} disabled={submitting}>
+                    <div className="yn-modal__foot-actions">
+                        <button type="button" className="yn-btn yn-btn--ghost" onClick={handleClose} disabled={submitting}>
                             Cancel
                         </button>
                         <button
                             type="button"
-                            className="fw-btn fw-btn--primary"
+                            className="yn-btn yn-btn--primary"
                             onClick={handleCreate}
                             disabled={!canCreate}
                         >

--- a/web/src/pages/operators/neighbours/EditTableModal.tsx
+++ b/web/src/pages/operators/neighbours/EditTableModal.tsx
@@ -51,30 +51,30 @@ const EditTableModal: React.FC<EditTableModalProps> = ({
     };
 
     return (
-        <div className="fw-modal-backdrop" onClick={handleClose}>
-            <div className="fw-modal fw-modal--sm" onClick={(e) => e.stopPropagation()}>
-                <header className="fw-modal__head">
-                    <span className="fw-modal__title">Edit table — {tableInfo?.name}</span>
-                    <button type="button" className="fw-icon-btn" onClick={handleClose} aria-label="Close">✕</button>
+        <div className="yn-modal-backdrop" onClick={handleClose}>
+            <div className="yn-modal yn-modal--sm" onClick={(e) => e.stopPropagation()}>
+                <header className="yn-modal__head">
+                    <span className="yn-modal__title">Edit table — {tableInfo?.name}</span>
+                    <button type="button" className="yn-icon-btn" onClick={handleClose} aria-label="Close">✕</button>
                 </header>
-                <div className="fw-modal__body fw-modal__body--confirm">
-                    <div className="fw-field">
-                        <label className="fw-field__label">Name</label>
+                <div className="yn-modal__body yn-modal__body--confirm">
+                    <div className="yn-field">
+                        <label className="yn-field__label">Name</label>
                         <input
-                            className="fw-input"
+                            className="yn-input"
                             type="text"
                             value={tableInfo?.name || ''}
                             disabled
                         />
-                        <span className="fw-field__hint">Name can't be changed</span>
+                        <span className="yn-field__hint">Name can't be changed</span>
                     </div>
-                    <div className="fw-field">
-                        <label className="fw-field__label" htmlFor="et-priority">
-                            Default Priority <span className="fw-field__req">*</span>
+                    <div className="yn-field">
+                        <label className="yn-field__label" htmlFor="et-priority">
+                            Default Priority <span className="yn-field__req">*</span>
                         </label>
                         <input
                             id="et-priority"
-                            className={`fw-input${priorityError && defaultPriority ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input${priorityError && defaultPriority ? ' yn-input--invalid' : ''}`}
                             type="number"
                             value={defaultPriority}
                             onChange={(e) => setDefaultPriority(e.target.value)}
@@ -86,21 +86,21 @@ const EditTableModal: React.FC<EditTableModalProps> = ({
                             autoFocus
                         />
                         {priorityError && defaultPriority ? (
-                            <span className="fw-field__hint fw-field__error">{priorityError}</span>
+                            <span className="yn-field__hint yn-field__error">{priorityError}</span>
                         ) : (
-                            <span className="fw-field__hint">Lower value wins on merge.</span>
+                            <span className="yn-field__hint">Lower value wins on merge.</span>
                         )}
                     </div>
                 </div>
-                <footer className="fw-modal__foot">
+                <footer className="yn-modal__foot">
                     <span />
-                    <div className="fw-modal__foot-actions">
-                        <button type="button" className="fw-btn fw-btn--ghost" onClick={handleClose} disabled={submitting}>
+                    <div className="yn-modal__foot-actions">
+                        <button type="button" className="yn-btn yn-btn--ghost" onClick={handleClose} disabled={submitting}>
                             Cancel
                         </button>
                         <button
                             type="button"
-                            className="fw-btn fw-btn--primary"
+                            className="yn-btn yn-btn--primary"
                             onClick={handleSave}
                             disabled={!canSave}
                         >

--- a/web/src/pages/operators/neighbours/NeighbourPanel.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourPanel.tsx
@@ -57,7 +57,7 @@ const CopyVal: React.FC<CopyValProps> = ({ value, muted }) => {
 
     return (
         <span className="nb-copy-val">
-            <span className={`fw-cell-mono${muted ? ' nb-copy-val--muted' : ''}`}>{value}</span>
+            <span className={`yn-cell-mono${muted ? ' nb-copy-val--muted' : ''}`}>{value}</span>
             <button
                 type="button"
                 className="nb-copy-btn"
@@ -258,21 +258,21 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
     return (
         <>
             <div
-                className={`fw-backdrop${open ? ' fw-backdrop--open' : ''}`}
+                className={`yn-backdrop${open ? ' yn-backdrop--open' : ''}`}
                 onClick={onClose}
                 aria-hidden="true"
             />
             <aside
-                className={`fw-drawer${open ? ' fw-drawer--open' : ''} nb-detail-panel`}
+                className={`yn-drawer${open ? ' yn-drawer--open' : ''} nb-detail-panel`}
                 role="dialog"
                 aria-modal="true"
                 aria-label={ariaLabel}
             >
                 {open && (
                     <>
-                        <div className="fw-drawer__head">
+                        <div className="yn-drawer__head">
                             <div className="nb-detail-panel__header-info">
-                                <div className="nb-detail-panel__ip fw-cell-mono">{headerTitle}</div>
+                                <div className="nb-detail-panel__ip yn-cell-mono">{headerTitle}</div>
                                 {mode !== 'add' && (
                                     <div className="nb-detail-panel__subtitle">
                                         on {deviceDisplay}{family ? ` · ${family}` : ''}
@@ -289,7 +289,7 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                             )}
                             <button
                                 type="button"
-                                className="fw-icon-btn"
+                                className="yn-icon-btn"
                                 onClick={onClose}
                                 aria-label="Close panel"
                             >
@@ -297,11 +297,11 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                             </button>
                         </div>
 
-                        <div className="fw-drawer__body">
+                        <div className="yn-drawer__body">
                             {mode === 'view' && neighbour && (
                                 <>
-                                    <div className="fw-section">
-                                        <div className="fw-section-h">Resolved entry</div>
+                                    <div className="yn-section">
+                                        <div className="yn-section-h">Resolved entry</div>
                                         <dl className="nb-kv">
                                             <dt>Next hop</dt>
                                             <dd><CopyVal value={ip} /></dd>
@@ -314,7 +314,7 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                                 <CopyVal value={interfaceMac} muted={interfaceMac === ZERO_MAC} />
                                             </dd>
                                             <dt>Device</dt>
-                                            <dd className="fw-cell-mono">{deviceDisplay}</dd>
+                                            <dd className="yn-cell-mono">{deviceDisplay}</dd>
                                             <dt>Source</dt>
                                             <dd>
                                                 <span className={`nb-src-name${isStatic ? ' nb-src-name--static' : ''}`}>
@@ -323,30 +323,30 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                                 {' · priority '}{priorityDisplay}
                                             </dd>
                                             <dt>Updated at</dt>
-                                            <dd className="fw-cell-mono">{updatedAt}</dd>
+                                            <dd className="yn-cell-mono">{updatedAt}</dd>
                                         </dl>
                                     </div>
 
-                                    <div className="fw-section">
-                                        <div className="fw-section-h">State — {stateName}</div>
+                                    <div className="yn-section">
+                                        <div className="yn-section-h">State — {stateName}</div>
                                         <div className="nb-state-explain">
                                             <div className="nb-state-explain__head">
                                                 <StateBadgeInline state={neighbour.state} />
                                             </div>
                                             <p className="nb-state-explain__desc">{meta.desc}</p>
                                             <div className="nb-state-explain__action">
-                                                <span className="nb-state-explain__action-icon" style={{ color: 'var(--fw-accent)' }}><Bulb width={13} height={13} /></span>
+                                                <span className="nb-state-explain__action-icon" style={{ color: 'var(--yn-accent)' }}><Bulb width={13} height={13} /></span>
                                                 <span>{meta.action}</span>
                                             </div>
                                         </div>
                                     </div>
 
                                     {isMergedView && (
-                                        <div className="fw-section">
-                                            <div className="fw-section-h">Merge resolution</div>
+                                        <div className="yn-section">
+                                            <div className="yn-section-h">Merge resolution</div>
                                             {hasShadowed ? (
                                                 <div className="nb-why-box">
-                                                    <span className="nb-why-box__icon" style={{ color: 'var(--fw-accent)' }}><Layers width={13} height={13} /></span>
+                                                    <span className="nb-why-box__icon" style={{ color: 'var(--yn-accent)' }}><Layers width={13} height={13} /></span>
                                                     <p>
                                                         <strong>{source}</strong> wins with the lowest priority{' '}
                                                         <strong>{priorityDisplay}</strong> (higher precedence), shadowing {shadowed.length}{' '}
@@ -357,7 +357,7 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                                 </div>
                                             ) : (
                                                 <div className="nb-why-box">
-                                                    <span className="nb-why-box__icon" style={{ color: 'var(--fw-text-3)' }}><CircleInfo width={13} height={13} /></span>
+                                                    <span className="nb-why-box__icon" style={{ color: 'var(--yn-text-3)' }}><CircleInfo width={13} height={13} /></span>
                                                     <p>
                                                         Only one table provides this neighbour (<strong>{source}</strong>).
                                                         Nothing to merge.
@@ -368,9 +368,9 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                             <div className="nb-cand-stack">
                                                 <div className="nb-cand nb-cand--winner">
                                                     <div className="nb-cand__top">
-                                                        <span className="nb-cand__table fw-cell-mono">{source}</span>
+                                                        <span className="nb-cand__table yn-cell-mono">{source}</span>
                                                         <span className="nb-cand__tag nb-cand__tag--winner">winner</span>
-                                                        <span className="nb-cand__prio fw-cell-mono">priority {priorityDisplay}</span>
+                                                        <span className="nb-cand__prio yn-cell-mono">priority {priorityDisplay}</span>
                                                     </div>
                                                     <div className="nb-cand__grid">
                                                         <div className="nb-cand__cell">
@@ -379,15 +379,15 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                                         </div>
                                                         <div className="nb-cand__cell">
                                                             <span>Updated</span>
-                                                            <b className="fw-cell-mono">{updatedAt}</b>
+                                                            <b className="yn-cell-mono">{updatedAt}</b>
                                                         </div>
                                                         <div className="nb-cand__cell">
                                                             <span>Neighbour MAC</span>
-                                                            <b className="fw-cell-mono">{neighbourMac}</b>
+                                                            <b className="yn-cell-mono">{neighbourMac}</b>
                                                         </div>
                                                         <div className="nb-cand__cell">
                                                             <span>Interface MAC</span>
-                                                            <b className="fw-cell-mono">{interfaceMac}</b>
+                                                            <b className="yn-cell-mono">{interfaceMac}</b>
                                                         </div>
                                                     </div>
                                                 </div>
@@ -399,9 +399,9 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                                     return (
                                                         <div key={cand.table} className="nb-cand">
                                                             <div className="nb-cand__top">
-                                                                <span className="nb-cand__table fw-cell-mono">{cand.table}</span>
+                                                                <span className="nb-cand__table yn-cell-mono">{cand.table}</span>
                                                                 <span className="nb-cand__tag nb-cand__tag--shadow">shadowed</span>
-                                                                <span className="nb-cand__prio fw-cell-mono">priority {cand.priority}</span>
+                                                                <span className="nb-cand__prio yn-cell-mono">priority {cand.priority}</span>
                                                             </div>
                                                             <div className="nb-cand__grid">
                                                                 <div className="nb-cand__cell">
@@ -410,17 +410,17 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                                                 </div>
                                                                 <div className="nb-cand__cell">
                                                                     <span>Updated</span>
-                                                                    <b className="fw-cell-mono">{candUpdated}</b>
+                                                                    <b className="yn-cell-mono">{candUpdated}</b>
                                                                 </div>
                                                                 <div className="nb-cand__cell">
                                                                     <span>Neighbour MAC</span>
-                                                                    <b className={`fw-cell-mono${cand.macDiffers ? ' nb-cand__diff' : ''}`}>
+                                                                    <b className={`yn-cell-mono${cand.macDiffers ? ' nb-cand__diff' : ''}`}>
                                                                         {candMac}
                                                                     </b>
                                                                 </div>
                                                                 <div className="nb-cand__cell">
                                                                     <span>Interface MAC</span>
-                                                                    <b className="fw-cell-mono">{candImac}</b>
+                                                                    <b className="yn-cell-mono">{candImac}</b>
                                                                 </div>
                                                             </div>
                                                         </div>
@@ -435,12 +435,12 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                             {(mode === 'add' || mode === 'edit') && (
                                 <>
                                     {isMergedAdd && (
-                                        <section className="fw-section">
-                                            <div className="fw-section-h">Target</div>
-                                            <div className="fw-section__body">
-                                                <div className="fw-field">
-                                                    <label className="fw-field__label">
-                                                        Table <span className="fw-field__req">*</span>
+                                        <section className="yn-section">
+                                            <div className="yn-section-h">Target</div>
+                                            <div className="yn-section__body">
+                                                <div className="yn-field">
+                                                    <label className="yn-field__label">
+                                                        Table <span className="yn-field__req">*</span>
                                                     </label>
                                                     <Select
                                                         value={selectedTable}
@@ -453,82 +453,82 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                         </section>
                                     )}
 
-                                    <section className="fw-section">
-                                        <div className="fw-section-h">Identity</div>
-                                        <div className="fw-section__body">
-                                            <div className="fw-field">
-                                                <label className="fw-field__label">
+                                    <section className="yn-section">
+                                        <div className="yn-section-h">Identity</div>
+                                        <div className="yn-section__body">
+                                            <div className="yn-field">
+                                                <label className="yn-field__label">
                                                     Next Hop
-                                                    {mode === 'add' && <span className="fw-field__req">*</span>}
+                                                    {mode === 'add' && <span className="yn-field__req">*</span>}
                                                 </label>
                                                 <input
                                                     ref={nextHopRef}
-                                                    className={`fw-input fw-input--mono${nextHopError ? ' fw-input--invalid' : ''}`}
+                                                    className={`yn-input yn-input--mono${nextHopError ? ' yn-input--invalid' : ''}`}
                                                     value={nextHop}
                                                     placeholder="192.168.1.1 or fe80::1"
                                                     onChange={(e) => setNextHop(e.target.value)}
                                                     disabled={mode === 'edit'}
                                                 />
                                                 {nextHopError && (
-                                                    <span className="fw-field__hint fw-field__error">{nextHopError}</span>
+                                                    <span className="yn-field__hint yn-field__error">{nextHopError}</span>
                                                 )}
                                                 {mode === 'edit' && (
-                                                    <span className="fw-field__hint">Primary key — delete and recreate to change.</span>
+                                                    <span className="yn-field__hint">Primary key — delete and recreate to change.</span>
                                                 )}
                                             </div>
                                         </div>
                                     </section>
 
-                                    <section className="fw-section">
-                                        <div className="fw-section-h">L2</div>
-                                        <div className="fw-section__body">
-                                            <div className="fw-field">
-                                                <label className="fw-field__label">
-                                                    Neighbour MAC <span className="fw-field__req">*</span>
+                                    <section className="yn-section">
+                                        <div className="yn-section-h">L2</div>
+                                        <div className="yn-section__body">
+                                            <div className="yn-field">
+                                                <label className="yn-field__label">
+                                                    Neighbour MAC <span className="yn-field__req">*</span>
                                                 </label>
                                                 <input
-                                                    className={`fw-input fw-input--mono${linkAddrError ? ' fw-input--invalid' : ''}`}
+                                                    className={`yn-input yn-input--mono${linkAddrError ? ' yn-input--invalid' : ''}`}
                                                     value={linkAddr}
                                                     placeholder="52:54:00:12:34:56"
                                                     onChange={(e) => setLinkAddr(e.target.value)}
                                                 />
                                                 {linkAddrError && (
-                                                    <span className="fw-field__hint fw-field__error">{linkAddrError}</span>
+                                                    <span className="yn-field__hint yn-field__error">{linkAddrError}</span>
                                                 )}
                                             </div>
-                                            <div className="fw-field">
-                                                <label className="fw-field__label">
-                                                    Interface MAC <span className="fw-field__req">*</span>
+                                            <div className="yn-field">
+                                                <label className="yn-field__label">
+                                                    Interface MAC <span className="yn-field__req">*</span>
                                                 </label>
                                                 <input
-                                                    className={`fw-input fw-input--mono${hardwareAddrError ? ' fw-input--invalid' : ''}`}
+                                                    className={`yn-input yn-input--mono${hardwareAddrError ? ' yn-input--invalid' : ''}`}
                                                     value={hardwareAddr}
                                                     placeholder="52:54:00:12:34:56"
                                                     onChange={(e) => setHardwareAddr(e.target.value)}
                                                 />
                                                 {hardwareAddrError && (
-                                                    <span className="fw-field__hint fw-field__error">{hardwareAddrError}</span>
+                                                    <span className="yn-field__hint yn-field__error">{hardwareAddrError}</span>
                                                 )}
                                             </div>
                                         </div>
                                     </section>
 
-                                    <section className="fw-section">
-                                        <div className="fw-section-h">Egress</div>
-                                        <div className="fw-section__body">
-                                            <div className="fw-field">
-                                                <label className="fw-field__label">Device</label>
+                                    <section className="yn-section">
+                                        <div className="yn-section-h">Egress</div>
+                                        <div className="yn-section__body">
+                                            <div className="yn-field">
+                                                <label className="yn-field__label">Device</label>
                                                 <input
-                                                    className="fw-input"
+                                                    className="yn-input"
                                                     value={device}
                                                     placeholder="eth0"
                                                     onChange={(e) => setDevice(e.target.value)}
                                                 />
                                             </div>
-                                            <div className="fw-field">
-                                                <label className="fw-field__label">Priority</label>
+                                            <div className="yn-field">
+                                                <label className="yn-field__label">Priority</label>
                                                 <input
-                                                    className="fw-input"
+                                                    className="yn-input"
                                                     type="number"
                                                     value={priority}
                                                     placeholder="100"
@@ -539,15 +539,15 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                     </section>
 
                                     {mode === 'edit' && neighbour && (
-                                        <div className="fw-section">
-                                            <div className="fw-section-h">State — {stateName}</div>
+                                        <div className="yn-section">
+                                            <div className="yn-section-h">State — {stateName}</div>
                                             <div className="nb-state-explain">
                                                 <div className="nb-state-explain__head">
                                                     <StateBadgeInline state={neighbour.state} />
                                                 </div>
                                                 <p className="nb-state-explain__desc">{meta.desc}</p>
                                                 <div className="nb-state-explain__action">
-                                                    <span className="nb-state-explain__action-icon" style={{ color: 'var(--fw-accent)' }}><Bulb width={13} height={13} /></span>
+                                                    <span className="nb-state-explain__action-icon" style={{ color: 'var(--yn-accent)' }}><Bulb width={13} height={13} /></span>
                                                     <span>{meta.action}</span>
                                                 </div>
                                             </div>
@@ -557,20 +557,20 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                             )}
                         </div>
 
-                        <div className="fw-drawer__foot">
+                        <div className="yn-drawer__foot">
                             {mode === 'add' && (
                                 <>
-                                    <div className="fw-drawer__foot-actions">
+                                    <div className="yn-drawer__foot-actions">
                                         <button
                                             type="button"
-                                            className="fw-btn fw-btn--ghost fw-btn--sm"
+                                            className="yn-btn yn-btn--ghost yn-btn--sm"
                                             onClick={onClose}
                                         >
                                             Cancel
                                         </button>
                                         <button
                                             type="button"
-                                            className="fw-btn fw-btn--primary fw-btn--sm"
+                                            className="yn-btn yn-btn--primary yn-btn--sm"
                                             onClick={() => void handleApply()}
                                             disabled={!canSubmit}
                                         >
@@ -582,27 +582,27 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
 
                             {mode === 'edit' && (
                                 <>
-                                    <div className="fw-drawer__foot-actions">
+                                    <div className="yn-drawer__foot-actions">
                                         <button
                                             type="button"
-                                            className="fw-btn fw-btn--danger fw-btn--sm"
+                                            className="yn-btn yn-btn--danger yn-btn--sm"
                                             onClick={handleDeleteRequest}
                                             disabled={submitting}
                                         >
                                             Delete
                                         </button>
                                     </div>
-                                    <div className="fw-drawer__foot-actions">
+                                    <div className="yn-drawer__foot-actions">
                                         <button
                                             type="button"
-                                            className="fw-btn fw-btn--ghost fw-btn--sm"
+                                            className="yn-btn yn-btn--ghost yn-btn--sm"
                                             onClick={onClose}
                                         >
                                             Cancel
                                         </button>
                                         <button
                                             type="button"
-                                            className="fw-btn fw-btn--primary fw-btn--sm"
+                                            className="yn-btn yn-btn--primary yn-btn--sm"
                                             onClick={() => void handleApply()}
                                             disabled={!canSubmit}
                                         >
@@ -614,11 +614,11 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
 
                             {mode === 'view' && (
                                 <>
-                                    <div className="fw-drawer__foot-actions">
+                                    <div className="yn-drawer__foot-actions">
                                         {!isStatic && neighbour && (
                                             <button
                                                 type="button"
-                                                className="fw-btn fw-btn--ghost fw-btn--sm"
+                                                className="yn-btn yn-btn--ghost yn-btn--sm"
                                                 onClick={() => onPinAsStatic(neighbour)}
                                             >
                                                 📌 Pin as static
@@ -627,7 +627,7 @@ const NeighbourPanel: React.FC<NeighbourPanelProps> = ({
                                     </div>
                                     <button
                                         type="button"
-                                        className="fw-btn fw-btn--ghost fw-btn--sm"
+                                        className="yn-btn yn-btn--ghost yn-btn--sm"
                                         onClick={onClose}
                                     >
                                         Close

--- a/web/src/pages/operators/neighbours/NeighbourTable.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourTable.tsx
@@ -189,7 +189,7 @@ const SortButton: React.FC<SortButtonProps> = ({ col, label, width, sortState, o
             }}
             onClick={() => onSort(col)}
         >
-            <span className="fw-th-text">{label}</span>
+            <span className="yn-th-text">{label}</span>
             <span style={{ fontSize: 10, opacity: isActive ? 1 : 0.35 }}>{arrow}</span>
         </button>
     );
@@ -286,9 +286,9 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
     const showTableActions = canEditTable || canDeleteTable;
 
     return (
-        <div className="fw-tbl-wrap">
-            <div className="fw-tbl-header-row">
-                <div ref={headerRef} className="fw-vtbl-header nb-vtbl-header" style={{ height: HEADER_HEIGHT }}>
+        <div className="yn-table-wrap">
+            <div className="yn-table-header-row">
+                <div ref={headerRef} className="yn-vtbl-header nb-vtbl-header" style={{ height: HEADER_HEIGHT }}>
                     <div style={{ display: 'flex', alignItems: 'center', minWidth: totalWidth, height: '100%', paddingLeft: 4, paddingRight: 4 }}>
                         <div
                             style={{ width: COL_CHECKBOX, minWidth: COL_CHECKBOX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
@@ -303,7 +303,7 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
                             )}
                         </div>
                         <div style={{ width: COL_INDEX, minWidth: COL_INDEX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                            <span className="fw-th-text">#</span>
+                            <span className="yn-th-text">#</span>
                         </div>
                         <SortButton col="next_hop" label="Next Hop" width={COL_NEXT_HOP} sortState={sortState} onSort={onSort} />
                         <SortButton col="link_addr" label="Neighbour MAC" width={COL_LINK_ADDR} sortState={sortState} onSort={onSort} />
@@ -320,10 +320,10 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
                     </div>
                 </div>
                 {showTableActions && (
-                    <div className="fw-tbl-actions">
+                    <div className="yn-table-actions">
                         <button
                             type="button"
-                            className="fw-row-edit-btn fw-row-edit-btn--visible"
+                            className="yn-row-edit-btn yn-row-edit-btn--visible"
                             title="Edit table"
                             aria-label="Edit table settings"
                             disabled={!canEditTable}
@@ -333,7 +333,7 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
                         </button>
                         <button
                             type="button"
-                            className="fw-row-edit-btn fw-row-edit-btn--visible fw-row-edit-btn--danger"
+                            className="yn-row-edit-btn yn-row-edit-btn--visible yn-row-edit-btn--danger"
                             title={canDeleteTable ? 'Delete table' : 'Cannot remove built-in table'}
                             aria-label="Delete table"
                             disabled={!canDeleteTable}
@@ -347,12 +347,12 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
 
             <div
                 ref={setScrollRef}
-                className="fw-vtbl-body"
+                className="yn-vtbl-body"
                 style={bodyHeight > 0 ? { flex: '0 0 auto', height: bodyHeight } : undefined}
                 onScroll={handleBodyScroll}
             >
                 {rows.length === 0 ? (
-                    <div className="fw-table-empty">{emptyMessage}</div>
+                    <div className="yn-table-empty">{emptyMessage}</div>
                 ) : (
                     <div style={{ height: rowVirtualizer.getTotalSize(), minWidth: totalWidth, position: 'relative' }}>
                         {virtualRows.map((virtualRow) => {
@@ -361,11 +361,11 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
                             const id = getNeighbourId(neighbour);
                             const isSelected = selectedIds.has(id);
                             const isActive = activeRowId === id || editingRowId === id;
-                            const rowBg = (isSelected || isActive) ? 'var(--fw-accent-soft)' : 'transparent';
+                            const rowBg = (isSelected || isActive) ? 'var(--yn-accent-soft)' : 'transparent';
                             return (
                                 <div
                                     key={id || virtualRow.index}
-                                    className={`fw-vrow${isActive ? ' fw-vrow--active' : ''}${isSelected ? ' fw-vrow--selected' : ''}`}
+                                    className={`yn-vrow${isActive ? ' yn-vrow--active' : ''}${isSelected ? ' yn-vrow--selected' : ''}`}
                                     data-row-id={id}
                                     onMouseEnter={() => handleHoverChange(neighbour, virtualRow.start)}
                                     onMouseLeave={() => handleHoverChange(null, 0)}
@@ -379,7 +379,7 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
                                         width: '100%',
                                         display: 'flex',
                                         alignItems: 'center',
-                                        borderBottom: '1px solid var(--fw-line)',
+                                        borderBottom: '1px solid var(--yn-line)',
                                         backgroundColor: rowBg,
                                         paddingLeft: 4,
                                         cursor: 'pointer',
@@ -401,20 +401,20 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
                                             />
                                         )}
                                     </div>
-                                    <div style={{ width: COL_INDEX, minWidth: COL_INDEX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--fw-text-3)', fontVariantNumeric: 'tabular-nums' }}>
+                                    <div style={{ width: COL_INDEX, minWidth: COL_INDEX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--yn-text-3)', fontVariantNumeric: 'tabular-nums' }}>
                                         <span style={{ fontSize: 12 }}>{virtualRow.index + 1}</span>
                                     </div>
                                     <div style={{ width: COL_NEXT_HOP, minWidth: COL_NEXT_HOP, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-mono fw-cell-strong">{ipAddressToString(neighbour.next_hop) || '-'}</span>
+                                        <span className="yn-cell-mono yn-cell-strong">{ipAddressToString(neighbour.next_hop) || '-'}</span>
                                     </div>
                                     <div style={{ width: COL_LINK_ADDR, minWidth: COL_LINK_ADDR, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-mono fw-cell-muted">{neighbour.link_addr?.addr || '-'}</span>
+                                        <span className="yn-cell-mono yn-cell-muted">{neighbour.link_addr?.addr || '-'}</span>
                                     </div>
                                     <div style={{ width: COL_HW_ADDR, minWidth: COL_HW_ADDR, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-mono fw-cell-muted">{neighbour.hardware_addr?.addr || '-'}</span>
+                                        <span className="yn-cell-mono yn-cell-muted">{neighbour.hardware_addr?.addr || '-'}</span>
                                     </div>
                                     <div style={{ width: COL_DEVICE, minWidth: COL_DEVICE, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-muted">{neighbour.device || '-'}</span>
+                                        <span className="yn-cell-muted">{neighbour.device || '-'}</span>
                                     </div>
                                     <div style={{ width: COL_STATE, minWidth: COL_STATE, flexShrink: 0, paddingRight: 8, overflow: 'hidden', whiteSpace: 'nowrap' }}>
                                         <StateBadge state={neighbour.state} withTooltip />
@@ -428,10 +428,10 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
                                         />
                                     </div>
                                     <div style={{ width: COL_PRIORITY, minWidth: COL_PRIORITY, flexShrink: 0, paddingRight: 8 }}>
-                                        <span className="fw-cell-muted">{neighbour.priority ?? '-'}</span>
+                                        <span className="yn-cell-muted">{neighbour.priority ?? '-'}</span>
                                     </div>
                                     <div style={{ width: COL_UPDATED, minWidth: COL_UPDATED, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-muted">{formatUnixSeconds(neighbour.updated_at)}</span>
+                                        <span className="yn-cell-muted">{formatUnixSeconds(neighbour.updated_at)}</span>
                                     </div>
                                 </div>
                             );
@@ -440,8 +440,8 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
                 )}
             </div>
 
-            <div className="fw-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
-                <span className="fw-toolbar__count">{footerText}</span>
+            <div className="yn-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
+                <span className="yn-toolbar__count">{footerText}</span>
                 {readOnlyNote}
             </div>
 

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -298,15 +298,15 @@ const NeighboursPage: React.FC = () => {
 
     return (
         <PageLayout header={pageHeader}>
-            <div className="fw-page">
+            <div className="yn-page">
                 {tables.length === 0 ? (
-                    <div className="fw-empty-page">
-                        <div className="fw-empty-page__message">No neighbour tables found.</div>
+                    <div className="yn-empty-page">
+                        <div className="yn-empty-page__message">No neighbour tables found.</div>
                         <Button view="action" onClick={() => setCreateTableOpen(true)}>Create table</Button>
                     </div>
                 ) : (
                     <>
-                        <div className="fw-tabs-row">
+                        <div className="yn-tabs-row">
                             <ConfigTabStrip
                                 configs={displayConfigs}
                                 activeConfig={activeDisplayConfig}
@@ -329,7 +329,7 @@ const NeighboursPage: React.FC = () => {
                                         <Layers
                                             width={13}
                                             height={13}
-                                            style={{ color: 'var(--fw-text-3)', flexShrink: 0 }}
+                                            style={{ color: 'var(--yn-text-3)', flexShrink: 0 }}
                                         />
                                     ) : undefined
                                 }
@@ -349,7 +349,7 @@ const NeighboursPage: React.FC = () => {
                                 </button>
                             </div>
                         </div>
-                        <div className="fw-content">
+                        <div className="yn-content">
                             <NeighbourTable
                                 rows={visibleRows}
                                 totalCount={allRows.length}

--- a/web/src/pages/operators/neighbours/stateMeta.ts
+++ b/web/src/pages/operators/neighbours/stateMeta.ts
@@ -2,7 +2,7 @@ import { NUD_STATE_MAP } from '../../../utils/nud';
 
 /** Metadata for a single NUD state — descriptions and action guidance. */
 export interface StateMetaEntry {
-    /** CSS color token for this state (uses existing fw-* / g-color-* tokens). */
+    /** CSS color token for this state (uses existing yn-* / g-color-* tokens). */
     color: string;
     /** Short human-readable description of what the state means. */
     desc: string;
@@ -18,7 +18,7 @@ export const STATE_META: Record<string, StateMetaEntry> = {
         action: 'Healthy. No action needed.',
     },
     PERMANENT: {
-        color: 'var(--fw-accent)',
+        color: 'var(--yn-accent)',
         desc: 'Static entry pinned by an administrator. Never expires and is not subject to ARP/ND timers.',
         action: 'Managed manually. Edit or delete via the static table.',
     },
@@ -48,17 +48,17 @@ export const STATE_META: Record<string, StateMetaEntry> = {
         action: 'Check link/cabling, that the peer is up, and that ARP/ND is not filtered. A static entry can override this.',
     },
     NOARP: {
-        color: 'var(--fw-text-3)',
+        color: 'var(--yn-text-3)',
         desc: 'No L2 resolution is required for this entry (loopback, point-to-point, or multicast). This is expected, not an error.',
         action: 'Expected for lo / multicast / kni interfaces.',
     },
     NONE: {
-        color: 'var(--fw-text-3)',
+        color: 'var(--yn-text-3)',
         desc: 'No state recorded for this entry.',
         action: '—',
     },
     UNKNOWN: {
-        color: 'var(--fw-text-3)',
+        color: 'var(--yn-text-3)',
         desc: 'Unrecognized state value.',
         action: '—',
     },

--- a/web/src/pages/operators/route/LookupDrawer.tsx
+++ b/web/src/pages/operators/route/LookupDrawer.tsx
@@ -99,15 +99,15 @@ const LookupDrawer: React.FC<LookupDrawerProps> = ({
     return (
         <>
             <div
-                className={`fw-backdrop${open ? ' fw-backdrop--open' : ''}`}
+                className={`yn-backdrop${open ? ' yn-backdrop--open' : ''}`}
                 onClick={onClose}
             />
-            <div className={`fw-drawer ro-lookup-drawer${open ? ' fw-drawer--open' : ''}`}>
-                <div className="fw-drawer__head">
-                    <h2 className="fw-drawer__title">Route Lookup</h2>
+            <div className={`yn-drawer ro-lookup-drawer${open ? ' yn-drawer--open' : ''}`}>
+                <div className="yn-drawer__head">
+                    <h2 className="yn-drawer__title">Route Lookup</h2>
                     <button
                         type="button"
-                        className="fw-icon-btn"
+                        className="yn-icon-btn"
                         onClick={onClose}
                         aria-label="Close"
                     >
@@ -115,11 +115,11 @@ const LookupDrawer: React.FC<LookupDrawerProps> = ({
                     </button>
                 </div>
 
-                <div className="fw-drawer__body">
+                <div className="yn-drawer__body">
                     <div className="ro-lookup-input-row">
                         <input
                             ref={inputRef}
-                            className="fw-input fw-input--mono"
+                            className="yn-input yn-input--mono"
                             placeholder="Enter IPv4 or IPv6 address…"
                             value={query}
                             onChange={(e) => setQuery(e.target.value)}
@@ -129,7 +129,7 @@ const LookupDrawer: React.FC<LookupDrawerProps> = ({
                         />
                         <button
                             type="button"
-                            className="fw-btn fw-btn--primary"
+                            className="yn-btn yn-btn--primary"
                             onClick={() => void performLookup(query)}
                             disabled={loading || !query.trim()}
                         >
@@ -211,31 +211,31 @@ const LookupDrawer: React.FC<LookupDrawerProps> = ({
                                                     <td>
                                                         <BestPill isBest={idx === 0} />
                                                     </td>
-                                                    <td className="fw-cell-mono fw-cell-strong">
+                                                    <td className="yn-cell-mono yn-cell-strong">
                                                         {r.prefix || '—'}
                                                     </td>
-                                                    <td className="fw-cell-mono fw-cell-muted">
+                                                    <td className="yn-cell-mono yn-cell-muted">
                                                         {ipAddressToString(r.next_hop) || '—'}
                                                     </td>
-                                                    <td className="fw-cell-mono fw-cell-muted">
+                                                    <td className="yn-cell-mono yn-cell-muted">
                                                         {ipAddressToString(r.peer) || '—'}
                                                     </td>
                                                     <td>
                                                         <SourceChip source={r.source} />
                                                     </td>
-                                                    <td className="fw-cell-muted">
+                                                    <td className="yn-cell-muted">
                                                         {r.peer_as ?? '—'}
                                                     </td>
-                                                    <td className="fw-cell-muted">
+                                                    <td className="yn-cell-muted">
                                                         {r.origin_as ?? '—'}
                                                     </td>
-                                                    <td className="fw-cell-muted">
+                                                    <td className="yn-cell-muted">
                                                         {r.pref ?? '—'}
                                                     </td>
-                                                    <td className="fw-cell-muted">
+                                                    <td className="yn-cell-muted">
                                                         {r.med ?? '—'}
                                                     </td>
-                                                    <td className="fw-cell-muted ro-lookup-communities">
+                                                    <td className="yn-cell-muted ro-lookup-communities">
                                                         {r.large_communities && r.large_communities.length > 0
                                                             ? r.large_communities
                                                                 .map((c) => `${c.global_administrator ?? 0}:${c.local_data_part1 ?? 0}:${c.local_data_part2 ?? 0}`)

--- a/web/src/pages/operators/route/RIBTable.tsx
+++ b/web/src/pages/operators/route/RIBTable.tsx
@@ -83,14 +83,14 @@ const SortButton: React.FC<SortButtonProps> = ({ col, label, sortState, onSort }
                 background: 'none',
                 border: 'none',
                 cursor: 'pointer',
-                color: isActive ? 'var(--fw-accent)' : 'inherit',
+                color: isActive ? 'var(--yn-accent)' : 'inherit',
                 padding: 0,
                 width: '100%',
                 minWidth: 0,
             }}
             onClick={() => onSort(col)}
         >
-            <span className="fw-th-text" style={{ color: isActive ? 'var(--fw-accent)' : undefined }}>{label}</span>
+            <span className="yn-th-text" style={{ color: isActive ? 'var(--yn-accent)' : undefined }}>{label}</span>
             <SortIcon variant={iconVariant} active={isActive} />
         </button>
     );
@@ -184,10 +184,10 @@ export const RIBTable: React.FC<RIBTableProps> = ({
     };
 
     return (
-        <div className="fw-tbl-wrap">
-            <div className="fw-tbl-header-row">
+        <div className="yn-table-wrap">
+            <div className="yn-table-header-row">
                 <div
-                    className="fw-vtbl-header"
+                    className="yn-vtbl-header"
                     style={{ ...gridStyle, height: HEADER_HEIGHT, flex: '1 1 auto', overflow: 'hidden' }}
                 >
                     <div
@@ -197,7 +197,7 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                         <Checkbox checked={isAllSelected} indeterminate={isIndeterminate} onUpdate={handleSelectAll} size="m" />
                     </div>
                     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                        <span className="fw-th-text">#</span>
+                        <span className="yn-th-text">#</span>
                     </div>
                     <SortButton col="prefix" label="Prefix" sortState={sortState} onSort={onSort} />
                     <SortButton col="next_hop" label="Next Hop" sortState={sortState} onSort={onSort} />
@@ -211,11 +211,11 @@ export const RIBTable: React.FC<RIBTableProps> = ({
 
             <div
                 ref={setScrollRef}
-                className="fw-vtbl-body"
+                className="yn-vtbl-body"
                 style={{ flex: '0 0 auto', height: bodyHeight, overflowY: 'auto' }}
             >
                 {rows.length === 0 ? (
-                    <div className="fw-table-empty">{emptyMessage}</div>
+                    <div className="yn-table-empty">{emptyMessage}</div>
                 ) : (
                     <div style={{ height: rowVirtualizer.getTotalSize(), minWidth: RIB_MIN_WIDTH, position: 'relative' }}>
                         {virtualRows.map((virtualRow) => {
@@ -226,12 +226,12 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                             const isFlashing = flashingId === id;
                             let rowBg = 'transparent';
                             if (isFlashing) rowBg = 'color-mix(in srgb, var(--g-color-text-positive) 14%, transparent)';
-                            else if (isSelected) rowBg = 'var(--fw-accent-soft)';
+                            else if (isSelected) rowBg = 'var(--yn-accent-soft)';
                             const prefixConflictCount = conflictMap?.get(route.prefix || '') ?? 1;
                             return (
                                 <div
                                     key={id}
-                                    className={`fw-vrow${isSelected ? ' fw-vrow--selected' : ''}`}
+                                    className={`yn-vrow${isSelected ? ' yn-vrow--selected' : ''}`}
                                     data-row-id={id}
                                     onMouseEnter={() => handleHoverChange(route, virtualRow.start)}
                                     onMouseLeave={() => handleHoverChange(null, 0)}
@@ -241,7 +241,7 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                                         left: 0,
                                         height: ROW_HEIGHT,
                                         width: '100%',
-                                        borderBottom: '1px solid var(--fw-line)',
+                                        borderBottom: '1px solid var(--yn-line)',
                                         backgroundColor: rowBg,
                                         cursor: 'default',
                                         ...gridStyle,
@@ -257,13 +257,13 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                                             size="m"
                                         />
                                     </div>
-                                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--fw-text-3)', fontVariantNumeric: 'tabular-nums', fontFamily: 'var(--fw-font-mono)' }}>
+                                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--yn-text-3)', fontVariantNumeric: 'tabular-nums', fontFamily: 'var(--yn-font-mono)' }}>
                                         <span style={{ fontSize: 12.5 }}>{virtualRow.index + 1}</span>
                                     </div>
                                     <div style={{ display: 'flex', alignItems: 'center', gap: 9, overflow: 'hidden' }}>
                                         {route.prefix && <FamilyBadge prefix={route.prefix} />}
                                         <span
-                                            className="fw-cell-mono"
+                                            className="yn-cell-mono"
                                             style={{
                                                 overflow: 'hidden',
                                                 textOverflow: 'ellipsis',
@@ -271,25 +271,25 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                                                 flexShrink: 1,
                                                 fontSize: 13.5,
                                                 fontWeight: route.is_best ? 600 : 500,
-                                                color: route.is_best ? 'var(--fw-text)' : 'var(--fw-text-2)',
+                                                color: route.is_best ? 'var(--yn-text)' : 'var(--yn-text-2)',
                                             }}
                                         >{route.prefix || '-'}</span>
                                         {prefixConflictCount > 1 && <ConflictBadge count={prefixConflictCount} />}
                                     </div>
                                     <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: 'var(--fw-text-2)' }}>{ipAddressToString(route.next_hop) || '-'}</span>
+                                        <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-2)' }}>{ipAddressToString(route.next_hop) || '-'}</span>
                                     </div>
                                     <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: 'var(--fw-text-3)' }}>{ipAddressToString(route.peer) || '-'}</span>
+                                        <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-3)' }}>{ipAddressToString(route.peer) || '-'}</span>
                                     </div>
                                     <div style={{ display: 'flex', alignItems: 'center' }}>
                                         <BestPill isBest={route.is_best ?? false} />
                                     </div>
                                     <div>
-                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: route.pref != null ? 'var(--fw-text-2)' : 'var(--fw-text-3)' }}>{route.pref ?? '—'}</span>
+                                        <span className="yn-cell-mono" style={{ fontSize: 12.5, color: route.pref != null ? 'var(--yn-text-2)' : 'var(--yn-text-3)' }}>{route.pref ?? '—'}</span>
                                     </div>
                                     <div>
-                                        <span className="fw-cell-mono" style={{ fontSize: 12.5, color: route.as_path_len != null ? 'var(--fw-text-2)' : 'var(--fw-text-3)' }}>{route.as_path_len ?? '—'}</span>
+                                        <span className="yn-cell-mono" style={{ fontSize: 12.5, color: route.as_path_len != null ? 'var(--yn-text-2)' : 'var(--yn-text-3)' }}>{route.as_path_len ?? '—'}</span>
                                     </div>
                                     <div style={{ overflow: 'hidden' }}>
                                         <SourceChip source={route.source} />
@@ -301,8 +301,8 @@ export const RIBTable: React.FC<RIBTableProps> = ({
                 )}
             </div>
 
-            <div className="fw-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
-                <span className="fw-toolbar__count">{footerText}</span>
+            <div className="yn-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
+                <span className="yn-toolbar__count">{footerText}</span>
             </div>
 
             {hoveredRow !== null && (

--- a/web/src/pages/operators/route/RouteDrawer.tsx
+++ b/web/src/pages/operators/route/RouteDrawer.tsx
@@ -100,51 +100,51 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
             onJump={() => {}}
             ariaLabel={title}
         >
-            <section className="fw-section">
-                <div className="fw-section-h">Destination</div>
-                <div className="fw-section__body">
-                    <div className="fw-field">
-                        <label className="fw-field__label">
-                            Prefix <span className="fw-field__req">*</span>
+            <section className="yn-section">
+                <div className="yn-section-h">Destination</div>
+                <div className="yn-section__body">
+                    <div className="yn-field">
+                        <label className="yn-field__label">
+                            Prefix <span className="yn-field__req">*</span>
                         </label>
                         <input
-                            className={`fw-input fw-input--mono${prefixError ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input yn-input--mono${prefixError ? ' yn-input--invalid' : ''}`}
                             value={prefix}
                             placeholder="10.0.0.0/8 or 2001:db8::/32"
                             onChange={(e) => setPrefix(e.target.value)}
                         />
                         {prefixError
-                            ? <span className="fw-field__hint fw-field__error">{prefixError}</span>
-                            : <span className="fw-field__hint">IPv4 or IPv6 with mask.</span>
+                            ? <span className="yn-field__hint yn-field__error">{prefixError}</span>
+                            : <span className="yn-field__hint">IPv4 or IPv6 with mask.</span>
                         }
                     </div>
                 </div>
             </section>
 
-            <section className="fw-section">
-                <div className="fw-section-h">Next Hop</div>
-                <div className="fw-section__body">
-                    <div className="fw-field">
-                        <label className="fw-field__label">
-                            Next Hop IP <span className="fw-field__req">*</span>
+            <section className="yn-section">
+                <div className="yn-section-h">Next Hop</div>
+                <div className="yn-section__body">
+                    <div className="yn-field">
+                        <label className="yn-field__label">
+                            Next Hop IP <span className="yn-field__req">*</span>
                         </label>
                         <input
-                            className={`fw-input fw-input--mono${nexthopError ? ' fw-input--invalid' : ''}`}
+                            className={`yn-input yn-input--mono${nexthopError ? ' yn-input--invalid' : ''}`}
                             value={nexthopAddr}
                             placeholder="192.168.1.1 or 2001:db8::1"
                             onChange={(e) => setNexthopAddr(e.target.value)}
                         />
                         {nexthopError && (
-                            <span className="fw-field__hint fw-field__error">{nexthopError}</span>
+                            <span className="yn-field__hint yn-field__error">{nexthopError}</span>
                         )}
                     </div>
                 </div>
             </section>
 
-            <section className="fw-section">
-                <div className="fw-section-h">Apply</div>
-                <div className="fw-section__body">
-                    <div className="fw-field">
+            <section className="yn-section">
+                <div className="yn-section-h">Apply</div>
+                <div className="yn-section__body">
+                    <div className="yn-field">
                         <Switch
                             checked={doFlush}
                             onUpdate={setDoFlush}

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -325,10 +325,10 @@ const RoutePage: React.FC = () => {
 
     return (
         <PageLayout header={pageHeader} className="ro-layout">
-            <div className="fw-page ro-page" aria-busy={refreshing}>
+            <div className="yn-page ro-page" aria-busy={refreshing}>
                 {configs.length === 0 ? (
-                    <div className="fw-empty-page">
-                        <div className="fw-empty-page__message">No route configurations found.</div>
+                    <div className="yn-empty-page">
+                        <div className="yn-empty-page__message">No route configurations found.</div>
                         <Button view="action" onClick={() => setAddConfigOpen(true)}>Add Config</Button>
                     </div>
                 ) : (
@@ -396,11 +396,11 @@ const RoutePage: React.FC = () => {
                                 />
                             </div>
                             <span className="ro-count">
-                                <span style={{ color: 'var(--fw-text)', fontWeight: 600 }}>{visibleRows.length.toLocaleString()}</span>
+                                <span style={{ color: 'var(--yn-text)', fontWeight: 600 }}>{visibleRows.length.toLocaleString()}</span>
                                 {' / '}{allRows.length.toLocaleString()}
                             </span>
                         </div>
-                        <div className="fw-content">
+                        <div className="yn-content">
                             <RIBTable
                                 rows={visibleRows}
                                 selectedIds={currentSelected}

--- a/web/src/pages/operators/route/cells.tsx
+++ b/web/src/pages/operators/route/cells.tsx
@@ -11,7 +11,7 @@ const CheckIcon: React.FC = () => (
 /** Green "Best" indicator shown in the Best column for the best route. */
 export const BestPill: React.FC<{ isBest: boolean }> = ({ isBest }) => {
     if (!isBest) {
-        return <span style={{ color: 'var(--fw-text-3)', fontSize: 12.5 }}>—</span>;
+        return <span style={{ color: 'var(--yn-text-3)', fontSize: 12.5 }}>—</span>;
     }
     return (
         <span
@@ -48,7 +48,7 @@ export const SourceChip: React.FC<{ source: number | undefined }> = ({ source })
                     color: 'var(--g-color-text-info)',
                     background: 'color-mix(in srgb, var(--g-color-text-info) 12%, transparent)',
                     whiteSpace: 'nowrap',
-                    fontFamily: 'var(--fw-font-mono)',
+                    fontFamily: 'var(--yn-font-mono)',
                 }}
             >
                 <span style={{ width: 5, height: 5, borderRadius: 999, background: 'var(--g-color-text-info)', flexShrink: 0 }} />
@@ -68,18 +68,18 @@ export const SourceChip: React.FC<{ source: number | undefined }> = ({ source })
                     fontSize: 11.5,
                     fontWeight: 600,
                     letterSpacing: '0.02em',
-                    color: 'var(--fw-accent)',
-                    background: 'var(--fw-accent-soft)',
+                    color: 'var(--yn-accent)',
+                    background: 'var(--yn-accent-soft)',
                     whiteSpace: 'nowrap',
-                    fontFamily: 'var(--fw-font-mono)',
+                    fontFamily: 'var(--yn-font-mono)',
                 }}
             >
-                <span style={{ width: 5, height: 5, borderRadius: 999, background: 'var(--fw-accent)', flexShrink: 0 }} />
+                <span style={{ width: 5, height: 5, borderRadius: 999, background: 'var(--yn-accent)', flexShrink: 0 }} />
                 {label}
             </span>
         );
     }
-    return <span style={{ color: 'var(--fw-text-3)', fontFamily: 'var(--fw-font-mono)' }}>—</span>;
+    return <span style={{ color: 'var(--yn-text-3)', fontFamily: 'var(--yn-font-mono)' }}>—</span>;
 };
 
 /** Small v4/v6 family badge derived from the prefix string. */
@@ -91,7 +91,7 @@ export const FamilyBadge: React.FC<{ prefix: string }> = ({ prefix }) => {
                 display: 'inline-block',
                 fontSize: 9.5,
                 fontWeight: 700,
-                fontFamily: 'var(--fw-font-mono)',
+                fontFamily: 'var(--yn-font-mono)',
                 color: isV6 ? 'var(--g-color-text-info)' : 'var(--g-color-text-warning)',
                 opacity: 0.8,
                 width: 16,
@@ -114,10 +114,10 @@ export const ConflictBadge: React.FC<{ count: number }> = ({ count }) => {
                 padding: '1px 6px',
                 borderRadius: 999,
                 fontSize: 10.5,
-                fontFamily: 'var(--fw-font-mono)',
+                fontFamily: 'var(--yn-font-mono)',
                 fontWeight: 700,
-                color: 'var(--fw-accent)',
-                background: 'var(--fw-accent-soft)',
+                color: 'var(--yn-accent)',
+                background: 'var(--yn-accent-soft)',
                 whiteSpace: 'nowrap',
                 flexShrink: 0,
             }}

--- a/web/src/pages/operators/route/route.scss
+++ b/web/src/pages/operators/route/route.scss
@@ -2,7 +2,7 @@
 @use '../../../styles/mixins' as *;
 
 // Route Operator page – ro-* class prefix.
-// All colors use existing --fw-* tokens or Gravity --g-color-* tokens.
+// All colors use existing --yn-* tokens or Gravity --g-color-* tokens.
 // No raw oklch/hex values from the prototype.
 
 // ─── Toolbar ─────────────────────────────────────────────────────────────────
@@ -14,7 +14,7 @@
     padding: 12px 20px;
     flex-wrap: wrap;
     flex-shrink: 0;
-    border-bottom: 1px solid var(--fw-line);
+    border-bottom: 1px solid var(--yn-line);
 }
 
 .ro-toolbar__right {
@@ -29,11 +29,11 @@
 .ro-seg {
     display: inline-flex;
     align-items: center;
-    background: var(--fw-bg-2);
-    border-radius: var(--fw-r-md);
+    background: var(--yn-bg-2);
+    border-radius: var(--yn-r-md);
     padding: 3px;
     gap: 2px;
-    box-shadow: inset 0 0 0 1px var(--fw-line-2);
+    box-shadow: inset 0 0 0 1px var(--yn-line-2);
     flex-shrink: 0;
 }
 
@@ -42,7 +42,7 @@
     padding: 0 12px;
     font-size: 12.5px;
     font-weight: 600;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     background: transparent;
     border: none;
     border-radius: 6px;
@@ -51,18 +51,18 @@
     white-space: nowrap;
 
     &:hover:not(.ro-seg__btn--active) {
-        background: var(--fw-bg-3);
-        color: var(--fw-text);
+        background: var(--yn-bg-3);
+        color: var(--yn-text);
     }
 
     &--active {
-        background: var(--fw-accent);
-        color: var(--fw-bg-3);
+        background: var(--yn-accent);
+        color: var(--yn-bg-3);
         font-weight: 600;
 
         &:hover {
-            background: var(--fw-accent);
-            color: var(--fw-bg-3);
+            background: var(--yn-accent);
+            color: var(--yn-bg-3);
         }
     }
 }
@@ -74,21 +74,21 @@
     align-items: center;
     gap: 7px;
     padding: 6px 12px;
-    border-radius: var(--fw-r-md);
+    border-radius: var(--yn-r-md);
     border: none;
-    box-shadow: inset 0 0 0 1px var(--fw-line-2);
-    background: var(--fw-bg-2);
+    box-shadow: inset 0 0 0 1px var(--yn-line-2);
+    background: var(--yn-bg-2);
     font-size: 12.5px;
     font-weight: 600;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     cursor: pointer;
     transition: background 0.12s, color 0.12s, box-shadow 0.12s;
     white-space: nowrap;
     flex-shrink: 0;
 
     &:hover {
-        background: var(--fw-bg-2);
-        color: var(--fw-text);
+        background: var(--yn-bg-2);
+        color: var(--yn-text);
     }
 
     &--best.ro-chip--active {
@@ -98,9 +98,9 @@
     }
 
     &--conflict.ro-chip--active {
-        background: var(--fw-accent-soft);
-        color: var(--fw-accent);
-        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fw-accent) 30%, transparent);
+        background: var(--yn-accent-soft);
+        color: var(--yn-accent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--yn-accent) 30%, transparent);
     }
 }
 
@@ -115,7 +115,7 @@
     font-size: 11px;
     font-weight: 700;
     opacity: 0.8;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-variant-numeric: tabular-nums;
 }
 
@@ -131,20 +131,20 @@
     margin: 0 auto;
     height: 40px;
     padding: 0 14px;
-    border-radius: var(--fw-r-md, 6px);
-    // .ro-search-btn sits in the page header, outside .fw-page where --fw-*
+    border-radius: var(--yn-r-md, 6px);
+    // .ro-search-btn sits in the page header, outside .yn-page where --yn-*
     // tokens are defined, so each property includes a hard-coded fallback that
     // matches the token value from draft-page.scss.
-    border: 1px solid color-mix(in srgb, var(--fw-text-3, #7E7468) 55%, transparent);
-    background: var(--fw-bg-3, oklch(0.212 0.01 56));
+    border: 1px solid color-mix(in srgb, var(--yn-text-3, #7E7468) 55%, transparent);
+    background: var(--yn-bg-3, oklch(0.212 0.01 56));
     font-size: 13.5px;
-    color: var(--fw-text-3, #7E7468);
+    color: var(--yn-text-3, #7E7468);
     cursor: text;
     transition: border-color 0.08s, color 0.08s;
 
     &:hover {
-        border-color: var(--fw-text-3, #7E7468);
-        color: var(--fw-text-2, #B8B0A4);
+        border-color: var(--yn-text-3, #7E7468);
+        color: var(--yn-text-2, #B8B0A4);
     }
 }
 
@@ -166,10 +166,10 @@
     font-size: 12.5px;
     font-weight: 600;
     letter-spacing: 0.02em;
-    color: var(--fw-text-3, #7e7468);
-    background: var(--fw-bg-2, #1a1410);
-    border: 1px solid var(--fw-line-2, rgba(120, 108, 96, 0.28));
-    font-family: var(--fw-font-mono);
+    color: var(--yn-text-3, #7e7468);
+    background: var(--yn-bg-2, #1a1410);
+    border: 1px solid var(--yn-line-2, rgba(120, 108, 96, 0.28));
+    font-family: var(--yn-font-mono);
     line-height: 1;
 }
 
@@ -177,10 +177,10 @@
 
 .ro-count {
     font-size: 12.5px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     white-space: nowrap;
     flex-shrink: 0;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-variant-numeric: tabular-nums;
 }
 
@@ -201,9 +201,9 @@
 .ro-palette-card {
     width: 580px;
     max-width: calc(100vw - 40px);
-    background: var(--fw-panel);
-    border: 1px solid var(--fw-line-2);
-    border-radius: var(--fw-r-lg);
+    background: var(--yn-panel);
+    border: 1px solid var(--yn-line-2);
+    border-radius: var(--yn-r-lg);
     box-shadow: 0 24px 72px rgba(0, 0, 0, 0.65);
     overflow: hidden;
     animation: ro-palette-popin 0.14s ease-out both;
@@ -218,16 +218,16 @@
     display: flex;
     align-items: center;
     padding: 0 14px;
-    border-bottom: 1px solid var(--fw-line-2);
+    border-bottom: 1px solid var(--yn-line-2);
     height: 52px;
     gap: 10px;
 }
 
 .ro-palette-search-icon {
     font-size: 16px;
-    color: var(--fw-accent);
+    color: var(--yn-accent);
     flex-shrink: 0;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
 }
 
 .ro-palette-input {
@@ -236,11 +236,11 @@
     border: none;
     outline: none;
     font-size: 15px;
-    color: var(--fw-text);
-    font-family: var(--fw-font-mono);
+    color: var(--yn-text);
+    font-family: var(--yn-font-mono);
 
     &::placeholder {
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
         font-family: inherit;
     }
 }
@@ -254,10 +254,10 @@
     border-radius: 4px;
     font-size: 10px;
     font-weight: 600;
-    color: var(--fw-text-3);
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
-    font-family: var(--fw-font-mono);
+    color: var(--yn-text-3);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
+    font-family: var(--yn-font-mono);
 }
 
 .ro-palette-list {
@@ -272,7 +272,7 @@
     align-items: center;
     gap: 10px;
     padding: 9px 10px;
-    border-radius: var(--fw-r-md);
+    border-radius: var(--yn-r-md);
     border: none;
     background: none;
     cursor: pointer;
@@ -280,10 +280,10 @@
     transition: background 0.06s;
 
     &--active {
-        background: var(--fw-accent-soft);
+        background: var(--yn-accent-soft);
 
-        .ro-palette-item__icon { color: var(--fw-accent); }
-        .ro-palette-item__label { color: var(--fw-text); }
+        .ro-palette-item__icon { color: var(--yn-accent); }
+        .ro-palette-item__label { color: var(--yn-text); }
     }
 }
 
@@ -293,13 +293,13 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: var(--fw-r-sm);
+    border-radius: var(--yn-r-sm);
     font-size: 13px;
-    color: var(--fw-text-3);
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+    color: var(--yn-text-3);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
     flex-shrink: 0;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
 }
 
 .ro-palette-item__body {
@@ -312,7 +312,7 @@
 
 .ro-palette-item__label {
     font-size: 13px;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     font-weight: 500;
     white-space: nowrap;
     overflow: hidden;
@@ -321,7 +321,7 @@
 
 .ro-palette-item__sub {
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -335,17 +335,17 @@
     padding: 0 5px;
     border-radius: 4px;
     font-size: 11px;
-    color: var(--fw-accent);
-    background: var(--fw-accent-soft);
+    color: var(--yn-accent);
+    background: var(--yn-accent-soft);
     border: 1px solid rgba(255, 192, 97, 0.3);
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
 }
 
 .ro-palette-empty {
     padding: 20px;
     text-align: center;
     font-size: 13px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
 }
 
 // ─── Lookup drawer ─────────────────────────────────────────────────────────────
@@ -359,7 +359,7 @@
     gap: 8px;
     align-items: stretch;
 
-    .fw-input { flex: 1; }
+    .yn-input { flex: 1; }
 }
 
 .ro-lookup-examples {
@@ -371,7 +371,7 @@
 
 .ro-lookup-examples__label {
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     flex-shrink: 0;
 }
 
@@ -382,17 +382,17 @@
     padding: 0 10px;
     border-radius: 999px;
     font-size: 11.5px;
-    font-family: var(--fw-font-mono);
-    color: var(--fw-text-2);
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+    font-family: var(--yn-font-mono);
+    color: var(--yn-text-2);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
     cursor: pointer;
     transition: background 0.08s, color 0.08s;
     white-space: nowrap;
 
     &:hover {
-        background: var(--fw-accent-soft);
-        color: var(--fw-accent);
+        background: var(--yn-accent-soft);
+        color: var(--yn-accent);
         border-color: rgba(255, 192, 97, 0.3);
     }
 }
@@ -400,7 +400,7 @@
 .ro-lookup-loading {
     padding: 24px;
     text-align: center;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-size: 13px;
 }
 
@@ -415,31 +415,31 @@
     align-items: center;
     gap: 10px;
     padding: 10px 14px;
-    border-radius: var(--fw-r-md);
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+    border-radius: var(--yn-r-md);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
 }
 
 .ro-lookup-result__label {
     font-size: 10.5px;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-weight: 600;
     flex-shrink: 0;
 }
 
 .ro-lookup-result__prefix {
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 14px;
     font-weight: 600;
-    color: var(--fw-text);
+    color: var(--yn-text);
     flex: 1;
 }
 
 .ro-lookup-show-in-table {
     font-size: 12px;
-    color: var(--fw-accent);
+    color: var(--yn-accent);
     background: none;
     border: none;
     cursor: pointer;
@@ -452,22 +452,22 @@
 
 .ro-lookup-reason {
     font-size: 12px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     padding: 7px 12px;
-    background: var(--fw-accent-soft);
+    background: var(--yn-accent-soft);
     border: 1px solid rgba(255, 192, 97, 0.22);
-    border-radius: var(--fw-r-sm);
+    border-radius: var(--yn-r-sm);
 
     &::before {
         content: '★ ';
-        color: var(--fw-accent);
+        color: var(--yn-accent);
     }
 }
 
 .ro-lookup-table-wrap {
     overflow-x: auto;
-    border: 1px solid var(--fw-line-2);
-    border-radius: var(--fw-r-md);
+    border: 1px solid var(--yn-line-2);
+    border-radius: var(--yn-r-md);
 }
 
 // Column widths — shared by th and td via table-layout: fixed.
@@ -511,9 +511,9 @@ $_ro-col-med:      42px;
         font-weight: 700;
         letter-spacing: 0.07em;
         text-transform: uppercase;
-        color: var(--fw-text-3);
-        background: var(--fw-bg-2);
-        border-bottom: 1px solid var(--fw-line-2);
+        color: var(--yn-text-3);
+        background: var(--yn-bg-2);
+        border-bottom: 1px solid var(--yn-line-2);
         white-space: nowrap;
         // No overflow:hidden or text-overflow:ellipsis on headers — labels must
         // always be fully visible. Only body td values truncate.
@@ -521,12 +521,12 @@ $_ro-col-med:      42px;
     }
 
     td {
-        // Restore table-cell display in case a .fw-cell-mono class (display:inline-block)
+        // Restore table-cell display in case a .yn-cell-mono class (display:inline-block)
         // is applied directly to the <td> element — table-layout:fixed still sizes the
         // column from the <th> width, but we want content to flow normally inside.
         display: table-cell;
         padding: 8px 8px;
-        border-bottom: 1px solid var(--fw-line-2);
+        border-bottom: 1px solid var(--yn-line-2);
         vertical-align: middle;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -541,7 +541,7 @@ $_ro-col-med:      42px;
 }
 
 .ro-lookup-communities {
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 11px;
     white-space: nowrap;
     overflow: hidden;
@@ -552,7 +552,7 @@ $_ro-col-med:      42px;
 .ro-lookup-no-match {
     padding: 24px;
     text-align: center;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-size: 13px;
 }
 
@@ -563,54 +563,54 @@ $_ro-col-med:      42px;
     --ro-surface-bg: #1C1814;
 }
 
-// Header sits outside .fw-page so --fw-* tokens are not in scope there.
+// Header sits outside .yn-page so --yn-* tokens are not in scope there.
 // --ro-surface-bg is defined on .ro-layout and cascades to both subtrees.
 .ro-layout .page-layout__header {
     background: var(--ro-surface-bg);
 }
 
-// Two-class specificity beats the `.fw-page { background: var(--fw-page-bg) }` rule.
-.fw-page.ro-page {
+// Two-class specificity beats the `.yn-page { background: var(--yn-page-bg) }` rule.
+.yn-page.ro-page {
     background: var(--ro-surface-bg);
 }
 
-.ro-page .fw-tabs {
+.ro-page .yn-tabs {
     background: var(--ro-surface-bg);
     border-bottom: none;
 }
 
-.ro-page .fw-tab--active::after {
+.ro-page .yn-tab--active::after {
     height: 3px;
 }
 
-// ─── Route-page scoped overrides (.ro-page modifier on .fw-page) ─────────────
+// ─── Route-page scoped overrides (.ro-page modifier on .yn-page) ─────────────
 
 // Gold count badge on the active config tab, scoped to route only.
-// The shared rule in draft-page.scss scopes gold badges to .fw-tabs-row only
+// The shared rule in draft-page.scss scopes gold badges to .yn-tabs-row only
 // (neighbours). This rule targets the route page root without touching that.
-.ro-page .fw-tab--active .fw-tab__count {
-    color: var(--fw-accent);
-    background: var(--fw-accent-soft);
+.ro-page .yn-tab--active .yn-tab__count {
+    color: var(--yn-accent);
+    background: var(--yn-accent-soft);
 }
 
 // Table flush: no outer padding and no card chrome.
 // Keeps per-row separators and the header bottom border.
-.ro-page .fw-content {
+.ro-page .yn-content {
     padding: 0;
 }
 
-.ro-page .fw-tbl-wrap {
+.ro-page .yn-table-wrap {
     background: transparent;
     border: none;
     border-radius: 0;
 }
 
-.ro-page .fw-tbl-header-row {
+.ro-page .yn-table-header-row {
     background: transparent;
-    border-top: 1px solid var(--fw-line-2);
+    border-top: 1px solid var(--yn-line-2);
 }
 
-.ro-page .fw-vtbl-footer {
+.ro-page .yn-vtbl-footer {
     background: transparent;
 }
 

--- a/web/src/styles/draft-page.scss
+++ b/web/src/styles/draft-page.scss
@@ -2,39 +2,39 @@
 @use './mixins' as *;
 
 // Shared page chrome for draft-edit pages (Forward, Route).
-// The fw- prefix is historical — these classes are consumed by both pages.
+// The yn- prefix is historical — these classes are consumed by both pages.
 // Design tokens are defined globally in tokens.scss (imported from main.tsx).
 
 // Page container
-.fw-page {
+.yn-page {
     display: flex;
     flex-direction: column;
     flex: 1;
     min-height: 0;
-    background: var(--fw-page-bg);
-    color: var(--fw-text);
+    background: var(--yn-page-bg);
+    color: var(--yn-text);
     font-size: 13px;
     line-height: 1.45;
     position: relative;
 }
 
 // Config tabs
-.fw-tabs {
+.yn-tabs {
     display: flex;
     align-items: center;
     gap: 4px;
     padding: 8px 20px 0;
-    border-bottom: 1px solid var(--fw-line-2);
-    background: var(--fw-page-bg);
+    border-bottom: 1px solid var(--yn-line-2);
+    background: var(--yn-page-bg);
     overflow-x: auto;
     flex-shrink: 0;
 }
 
-.fw-tab {
+.yn-tab {
     position: relative;
     padding: 10px 14px;
     font-size: 13px;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     border-radius: 6px 6px 0 0;
     display: flex;
     align-items: center;
@@ -45,10 +45,10 @@
     white-space: nowrap;
     transition: color 0.1s;
 
-    &:hover { color: var(--fw-text); }
+    &:hover { color: var(--yn-text); }
 
     &--active {
-        color: var(--fw-text);
+        color: var(--yn-text);
 
         &::after {
             content: "";
@@ -57,55 +57,55 @@
             right: 14px;
             bottom: -1px;
             height: 2px;
-            background: var(--fw-accent);
+            background: var(--yn-accent);
             border-radius: 2px 2px 0 0;
         }
     }
 }
 
-.fw-tab__label { flex: 1; }
+.yn-tab__label { flex: 1; }
 
 
-.fw-tabs__add {
+.yn-tabs__add {
     margin-left: 4px;
-    color: var(--fw-text-3) !important;
+    color: var(--yn-text-3) !important;
     flex-shrink: 0;
 
     &:hover {
-        color: var(--fw-text) !important;
+        color: var(--yn-text) !important;
     }
 }
 
-.fw-tab__dot {
+.yn-tab__dot {
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: var(--fw-accent);
+    background: var(--yn-accent);
     flex-shrink: 0;
 }
 
-.fw-tab__count {
+.yn-tab__count {
     font-size: 11px;
-    color: var(--fw-text-3);
-    background: var(--fw-bg-2);
+    color: var(--yn-text-3);
+    background: var(--yn-bg-2);
     padding: 1px 6px;
     border-radius: 999px;
     font-variant-numeric: tabular-nums;
 
-    .fw-tab--active & {
-        color: var(--fw-text-2);
-        background: var(--fw-bg-3);
+    .yn-tab--active & {
+        color: var(--yn-text-2);
+        background: var(--yn-bg-3);
     }
 }
 
 // Fix 6 — gold count badge on the active tab, scoped to neighbours only.
-.fw-tabs-row .fw-tab--active .fw-tab__count {
-    color: var(--fw-accent);
-    background: var(--fw-accent-soft);
+.yn-tabs-row .yn-tab--active .yn-tab__count {
+    color: var(--yn-accent);
+    background: var(--yn-accent-soft);
 }
 
 // Content area
-.fw-content {
+.yn-content {
     display: flex;
     flex-direction: column;
     padding: 16px 20px 20px;
@@ -116,7 +116,7 @@
 }
 
 // Buttons
-.fw-btn {
+.yn-btn {
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -132,27 +132,27 @@
     text-decoration: none;
 
     &--primary {
-        background: var(--fw-accent);
+        background: var(--yn-accent);
         color: #1a140a;
-        border-color: var(--fw-accent);
+        border-color: var(--yn-accent);
 
         &:hover { background: #f3bd73; border-color: #f3bd73; }
         &:disabled { opacity: 0.45; cursor: not-allowed; }
     }
 
     &--ghost {
-        color: var(--fw-text-2);
-        border-color: var(--fw-line-2);
-        background: var(--fw-panel);
+        color: var(--yn-text-2);
+        border-color: var(--yn-line-2);
+        background: var(--yn-panel);
 
-        &:hover { color: var(--fw-text); background: var(--fw-bg-2); border-color: var(--fw-text-3); }
+        &:hover { color: var(--yn-text); background: var(--yn-bg-2); border-color: var(--yn-text-3); }
         &:disabled { opacity: 0.45; cursor: not-allowed; }
     }
 
     &--danger {
-        color: var(--fw-danger);
-        border-color: var(--fw-line-2);
-        background: var(--fw-panel);
+        color: var(--yn-danger);
+        border-color: var(--yn-line-2);
+        background: var(--yn-panel);
 
         &:hover { background: rgba(224, 122, 110, 0.1); border-color: rgba(224, 122, 110, 0.3); }
     }
@@ -160,7 +160,7 @@
     &--sm { height: 26px; padding: 0 10px; font-size: 12px; }
 }
 
-.fw-icon-btn {
+.yn-icon-btn {
     width: 28px;
     height: 28px;
     border-radius: 6px;
@@ -168,16 +168,16 @@
     align-items: center;
     justify-content: center;
     font-size: 14px;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     background: none;
     border: none;
     cursor: pointer;
     transition: background 0.08s, color 0.08s;
 
-    &:hover { background: var(--fw-bg-2); color: var(--fw-text); }
+    &:hover { background: var(--yn-bg-2); color: var(--yn-text); }
 
     &--danger {
-        color: var(--fw-danger);
+        color: var(--yn-danger);
         &:hover { background: rgba(224, 122, 110, 0.1); }
     }
 
@@ -186,14 +186,14 @@
 
 // Virtualized table container.
 // position:relative is required so the floating edit-button overlay
-// (.fw-row-action-slot) can use position:absolute with right:0 to
+// (.yn-row-action-slot) can use position:absolute with right:0 to
 // pin to the wrap's right edge — unaffected by the body's h-scroll.
-.fw-tbl-wrap {
+.yn-table-wrap {
     flex: 1;
     min-height: 0;
-    border: 1px solid var(--fw-line-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 8px;
-    background: var(--fw-panel);
+    background: var(--yn-panel);
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -201,17 +201,17 @@
 }
 
 // Outer wrapper that aligns column-header row with the action button cluster.
-.fw-tbl-header-row {
+.yn-table-header-row {
     display: flex;
     align-items: center;
     width: 100%;
-    background: var(--fw-panel);
-    border-bottom: 1px solid var(--fw-line-2);
+    background: var(--yn-panel);
+    border-bottom: 1px solid var(--yn-line-2);
     flex-shrink: 0;
 }
 
 // Action button cluster — sits flush-right of the column-header row.
-.fw-tbl-actions {
+.yn-table-actions {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -220,11 +220,11 @@
     margin-left: auto;
 }
 
-.fw-tbl-action-btn {
+.yn-table-action-btn {
     background: none;
-    border: 1px solid var(--fw-line);
+    border: 1px solid var(--yn-line);
     border-radius: 6px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     width: 32px;
     height: 32px;
     display: flex;
@@ -234,8 +234,8 @@
     transition: color 0.1s, border-color 0.1s, background 0.1s;
 
     &:hover:not(:disabled) {
-        color: var(--fw-text-2);
-        background: var(--fw-bg-3);
+        color: var(--yn-text-2);
+        background: var(--yn-bg-3);
     }
 
     &:disabled {
@@ -244,35 +244,35 @@
     }
 
     &--save {
-        color: var(--fw-accent);
+        color: var(--yn-accent);
         border-color: rgba(255, 192, 97, 0.3);
 
         &:hover:not(:disabled) {
-            background: var(--fw-accent-soft);
-            border-color: var(--fw-accent);
-            color: var(--fw-accent);
+            background: var(--yn-accent-soft);
+            border-color: var(--yn-accent);
+            color: var(--yn-accent);
         }
     }
 
     &--discard:hover:not(:disabled) {
-        color: var(--fw-danger);
+        color: var(--yn-danger);
         border-color: color-mix(in srgb, var(--g-color-text-danger) 40%, transparent);
         background: color-mix(in srgb, var(--g-color-text-danger) 8%, transparent);
     }
 
     &--delete {
-        color: var(--fw-danger);
+        color: var(--yn-danger);
         border-color: color-mix(in srgb, var(--g-color-text-danger) 25%, transparent);
 
         &:hover {
             background: color-mix(in srgb, var(--g-color-text-danger) 8%, transparent);
-            border-color: var(--fw-danger);
+            border-color: var(--yn-danger);
         }
     }
 }
 
 // Sticky header row for the virtualized table.
-.fw-vtbl-header {
+.yn-vtbl-header {
     display: flex;
     align-items: center;
     padding-left: 4px;
@@ -282,17 +282,17 @@
     overflow-y: hidden;
 }
 
-.fw-th-text {
+.yn-th-text {
     font-size: 10.5px;
     font-weight: 500;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     letter-spacing: 0.12em;
     text-transform: uppercase;
     white-space: nowrap;
 }
 
 // Scroll body for virtualizer.
-.fw-vtbl-body {
+.yn-vtbl-body {
     flex: 1;
     min-height: 0;
     overflow: auto;
@@ -300,72 +300,72 @@
 }
 
 // Footer row
-.fw-vtbl-footer {
+.yn-vtbl-footer {
     display: flex;
     align-items: center;
     justify-content: space-between;
     padding: 0 12px;
-    border-top: 1px solid var(--fw-line-2);
-    background: var(--fw-panel);
+    border-top: 1px solid var(--yn-line-2);
+    background: var(--yn-panel);
     flex-shrink: 0;
 
-    .fw-toolbar__count {
-        color: var(--fw-text-3);
+    .yn-toolbar__count {
+        color: var(--yn-text-3);
         font-size: 11px;
         font-weight: 400;
     }
 }
 
 // Virtual rows
-.fw-vrow {
+.yn-vrow {
     cursor: default;
     transition: background-color 0.06s;
 
-    &:hover { background-color: var(--fw-bg-hover) !important; }
+    &:hover { background-color: var(--yn-bg-hover) !important; }
 
     &--active {
-        box-shadow: inset 2px 0 0 var(--fw-accent);
+        box-shadow: inset 2px 0 0 var(--yn-accent);
     }
 
     &--selected {
-        background-color: var(--fw-accent-soft) !important;
+        background-color: var(--yn-accent-soft) !important;
     }
 
     // Drag indicator inset shadows.
-    &--drag-top    { box-shadow: inset 0 2px 0 var(--fw-accent); }
-    &--drag-bottom { box-shadow: inset 0 -2px 0 var(--fw-accent); }
+    &--drag-top    { box-shadow: inset 0 2px 0 var(--yn-accent); }
+    &--drag-bottom { box-shadow: inset 0 -2px 0 var(--yn-accent); }
 }
 
 // Drag handle cell.
-.fw-drag-handle {
+.yn-drag-handle {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     cursor: grab;
     width: 100%;
     height: 100%;
     user-select: none;
 
     &:active { cursor: grabbing; }
-    &:hover  { color: var(--fw-text-2); }
+    &:hover  { color: var(--yn-text-2); }
 }
 
 // Status dot (added / changed / removed).
-.fw-status-dot {
+.yn-status-dot {
     display: inline-block;
     width: 7px;
     height: 7px;
     border-radius: 50%;
     flex-shrink: 0;
 
-    &--added   { background: var(--fw-ok); }
-    &--changed { background: var(--fw-accent); }
-    &--removed { background: var(--fw-danger); }
+    &--added   { background: var(--yn-ok); }
+    &--changed { background: var(--yn-accent); }
+    &--removed { background: var(--yn-danger); }
 }
 
-.fw-cell-mono {
-    font-family: var(--fw-font-mono);
+.yn-cell-mono {
+    font-family: var(--yn-font-mono);
     font-size: 12.5px;
     letter-spacing: -0.005em;
     display: inline-block;
@@ -378,10 +378,10 @@
     min-width: 0;
 }
 
-.fw-cell-strong { color: var(--fw-text); font-weight: 500; }
-.fw-cell-muted { color: var(--fw-text-2); }
+.yn-cell-strong { color: var(--yn-text); font-weight: 500; }
+.yn-cell-muted { color: var(--yn-text-2); }
 
-.fw-cell-values {
+.yn-cell-values {
     display: flex;
     flex-wrap: nowrap;
     gap: 3px;
@@ -390,20 +390,20 @@
     min-width: 0;
 }
 
-.fw-cell-more {
+.yn-cell-more {
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     padding: 1px 5px;
-    background: var(--fw-bg-2);
+    background: var(--yn-bg-2);
     border-radius: 999px;
-    border: 1px solid var(--fw-line-2);
+    border: 1px solid var(--yn-line-2);
 }
 
 /*
- * Floating edit-button overlay.  Direct child of .fw-tbl-wrap (position:relative,
+ * Floating edit-button overlay.  Direct child of .yn-table-wrap (position:relative,
  * overflow:hidden).
  *
- *   right: 0   — resolves against .fw-tbl-wrap's right edge = wrap_right.
+ *   right: 0   — resolves against .yn-table-wrap's right edge = wrap_right.
  *                Never shifts during horizontal scroll because the overlay lives
  *                OUTSIDE the scroll body.
  *   top        — set from JS: HEADER_HEIGHT + virtualizer_start − body.scrollTop
@@ -417,13 +417,13 @@
  *     button center from slot right = 8 + 3 + 13 = 24px
  *   slot_right = wrap_right  →  button center = wrap_right − 24px
  *
- *   header delete: 32px wide, .fw-tbl-actions padding-right: 8px
+ *   header delete: 32px wide, .yn-table-actions padding-right: 8px
  *     → delete center = wrap_right − 8 − 16 = wrap_right − 24px  ✓
  *
- * The overlay is clipped by .fw-tbl-wrap (overflow:hidden) at the header/footer
+ * The overlay is clipped by .yn-table-wrap (overflow:hidden) at the header/footer
  * boundaries, so the button disappears naturally when the row scrolls out of view.
  */
-.fw-row-action-slot {
+.yn-row-action-slot {
     position: absolute;
     right: 0;
     width: 40px;
@@ -441,7 +441,7 @@
     }
 }
 
-.fw-row-edit-btn {
+.yn-row-edit-btn {
     width: 32px;
     height: 32px;
     display: inline-flex;
@@ -449,18 +449,18 @@
     justify-content: center;
     border-radius: 6px;
     font-size: 20px;
-    color: var(--fw-text-2);
-    background: var(--fw-bg-3);
-    border: 1px solid var(--fw-line-2);
+    color: var(--yn-text-2);
+    background: var(--yn-bg-3);
+    border: 1px solid var(--yn-line-2);
     cursor: pointer;
     transition: background 0.08s, color 0.08s, border-color 0.08s;
 
     &--visible { opacity: 1; }
 
     &:hover:not(:disabled) {
-        background: var(--fw-bg-2);
-        color: var(--fw-text);
-        border-color: var(--fw-text-3);
+        background: var(--yn-bg-2);
+        color: var(--yn-text);
+        border-color: var(--yn-text-3);
     }
 
     &:disabled {
@@ -469,27 +469,27 @@
     }
 
     &--danger {
-        color: var(--fw-danger);
+        color: var(--yn-danger);
         border-color: color-mix(in srgb, var(--g-color-text-danger) 25%, transparent);
 
         &:hover:not(:disabled) {
             background: color-mix(in srgb, var(--g-color-text-danger) 8%, transparent);
-            border-color: var(--fw-danger);
-            color: var(--fw-danger);
+            border-color: var(--yn-danger);
+            color: var(--yn-danger);
         }
     }
 
 }
 
-.fw-table-empty {
+.yn-table-empty {
     padding: 40px;
     text-align: center;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-size: 13px;
 }
 
 // Bulk action bar — centered over the content area, accounting for the sidebar.
-.fw-bulk-bar {
+.yn-bulk-bar {
     position: fixed;
     bottom: 24px;
     left: calc(50% + var(--gn-aside-header-size, 56px) / 2);
@@ -497,8 +497,8 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    background: var(--fw-bg-3);
-    border: 1px solid var(--fw-line-2);
+    background: var(--yn-bg-3);
+    border: 1px solid var(--yn-line-2);
     border-radius: 10px;
     padding: 8px 14px;
     box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
@@ -506,15 +506,15 @@
     white-space: nowrap;
 }
 
-.fw-bulk-bar__count {
+.yn-bulk-bar__count {
     font-size: 12px;
     font-weight: 600;
-    color: var(--fw-accent);
+    color: var(--yn-accent);
     padding-right: 4px;
 }
 
 // Empty page state
-.fw-empty-page {
+.yn-empty-page {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -523,13 +523,13 @@
     gap: 16px;
 }
 
-.fw-empty-page__message {
+.yn-empty-page__message {
     font-size: 14px;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
 }
 
 // Drawer backdrop
-.fw-backdrop {
+.yn-backdrop {
     position: fixed;
     inset: 0;
     background: rgba(0, 0, 0, 0.38);
@@ -545,15 +545,15 @@
 }
 
 // Side drawer
-.fw-drawer {
+.yn-drawer {
     position: fixed;
     top: 0;
     right: 0;
     height: 100vh;
     width: 520px;
     max-width: 92vw;
-    background: var(--fw-panel);
-    border-left: 1px solid var(--fw-line-2);
+    background: var(--yn-panel);
+    border-left: 1px solid var(--yn-line-2);
     display: flex;
     flex-direction: column;
     transform: translateX(100%);
@@ -564,17 +564,17 @@
     &--open { transform: translateX(0); }
 }
 
-.fw-drawer__head {
+.yn-drawer__head {
     padding: 16px 20px;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    border-bottom: 1px solid var(--fw-line-2);
+    border-bottom: 1px solid var(--yn-line-2);
     flex-shrink: 0;
 }
 
-.fw-drawer__title {
+.yn-drawer__title {
     font-size: 15px;
     font-weight: 600;
     margin: 0;
@@ -583,19 +583,19 @@
     gap: 6px;
 }
 
-.fw-drawer__rule-num {
-    font-family: var(--fw-font-mono);
-    color: var(--fw-text-2);
+.yn-drawer__rule-num {
+    font-family: var(--yn-font-mono);
+    color: var(--yn-text-2);
     font-weight: 400;
 }
 
-.fw-drawer__head-actions {
+.yn-drawer__head-actions {
     display: flex;
     align-items: center;
     gap: 4px;
 }
 
-.fw-drawer__body {
+.yn-drawer__body {
     flex: 1;
     overflow-y: auto;
     padding: 20px;
@@ -604,36 +604,36 @@
     gap: 24px;
 }
 
-.fw-drawer__foot {
+.yn-drawer__foot {
     padding: 14px 20px;
-    border-top: 1px solid var(--fw-line-2);
+    border-top: 1px solid var(--yn-line-2);
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    background: var(--fw-panel);
+    background: var(--yn-panel);
     flex-shrink: 0;
 }
 
-.fw-drawer__foot-meta {
+.yn-drawer__foot-meta {
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
 }
 
-.fw-drawer__foot-actions {
+.yn-drawer__foot-actions {
     display: flex;
     align-items: center;
     gap: 8px;
 }
 
 // Form sections
-.fw-section {
+.yn-section {
     display: flex;
     flex-direction: column;
     gap: 0;
 }
 
-.fw-section-h {
+.yn-section-h {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -641,42 +641,42 @@
     font-weight: 600;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     margin-bottom: 12px;
 
     &::after {
         content: "";
         flex: 1;
         height: 1px;
-        background: var(--fw-line-2);
+        background: var(--yn-line-2);
     }
 }
 
-.fw-section__body {
+.yn-section__body {
     display: flex;
     flex-direction: column;
     gap: 14px;
 }
 
 // Two-column form grid
-.fw-fgrid {
+.yn-fgrid {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 14px;
 }
 
 // Form field
-.fw-field {
+.yn-field {
     display: flex;
     flex-direction: column;
     gap: 5px;
     min-width: 0;
 }
 
-.fw-field__label {
+.yn-field__label {
     font-size: 11px;
     font-weight: 600;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -684,80 +684,80 @@
     text-transform: uppercase;
 }
 
-.fw-field__req {
-    color: var(--fw-danger);
+.yn-field__req {
+    color: var(--yn-danger);
     margin-left: 2px;
 }
 
-.fw-field__optional {
-    color: var(--fw-text-3);
+.yn-field__optional {
+    color: var(--yn-text-3);
     font-weight: 400;
     text-transform: none;
     letter-spacing: 0;
     font-size: 11px;
 }
 
-.fw-field__count {
-    color: var(--fw-text-3);
+.yn-field__count {
+    color: var(--yn-text-3);
     font-weight: 400;
     font-size: 11px;
 }
 
-.fw-field__hint {
+.yn-field__hint {
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     line-height: 1.4;
 
     code {
-        font-family: var(--fw-font-mono);
-        background: var(--fw-bg-2);
+        font-family: var(--yn-font-mono);
+        background: var(--yn-bg-2);
         padding: 0 3px;
         border-radius: 3px;
     }
 }
 
 // Text input
-.fw-input {
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+.yn-input {
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 6px;
     padding: 0 10px;
     height: 34px;
     font-size: 13px;
-    color: var(--fw-text);
+    color: var(--yn-text);
     outline: none;
     width: 100%;
     transition: border-color 0.1s, box-shadow 0.1s;
 
-    &--mono { font-family: var(--fw-font-mono); }
+    &--mono { font-family: var(--yn-font-mono); }
 
     &--invalid {
-        border-color: var(--fw-danger) !important;
+        border-color: var(--yn-danger) !important;
         box-shadow: 0 0 0 2px rgba(224, 122, 110, 0.18) !important;
     }
 
     &:focus {
-        border-color: var(--fw-accent);
-        box-shadow: 0 0 0 2px var(--fw-accent-soft);
+        border-color: var(--yn-accent);
+        box-shadow: 0 0 0 2px var(--yn-accent-soft);
     }
 
-    &::placeholder { color: var(--fw-text-3); }
+    &::placeholder { color: var(--yn-text-3); }
 
     &:disabled {
         opacity: 0.55;
-        background: var(--fw-bg-2);
-        color: var(--fw-text-3);
+        background: var(--yn-bg-2);
+        color: var(--yn-text-3);
         cursor: not-allowed;
-        border-color: var(--fw-line-2);
+        border-color: var(--yn-line-2);
     }
 }
 
-.fw-field__error {
-    color: var(--fw-danger);
+.yn-field__error {
+    color: var(--yn-danger);
 }
 
 // Modal (YAML import/export, confirmations)
-.fw-modal-backdrop {
+.yn-modal-backdrop {
     position: fixed;
     inset: 0;
     background: rgba(0, 0, 0, 0.55);
@@ -768,9 +768,9 @@
     padding: 24px;
 }
 
-.fw-modal {
-    background: var(--fw-panel);
-    border: 1px solid var(--fw-line-2);
+.yn-modal {
+    background: var(--yn-panel);
+    border: 1px solid var(--yn-line-2);
     border-radius: 10px;
     width: 640px;
     max-width: 100%;
@@ -782,34 +782,34 @@
     &--sm { width: 420px; }
 }
 
-.fw-modal__head {
+.yn-modal__head {
     padding: 16px 20px;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    border-bottom: 1px solid var(--fw-line-2);
+    border-bottom: 1px solid var(--yn-line-2);
     flex-shrink: 0;
 }
 
-.fw-modal__title-row {
+.yn-modal__title-row {
     display: flex;
     align-items: center;
     gap: 10px;
 }
 
-.fw-modal__title {
+.yn-modal__title {
     font-size: 15px;
     font-weight: 600;
 }
 
-.fw-modal__meta {
-    font-family: var(--fw-font-mono);
+.yn-modal__meta {
+    font-family: var(--yn-font-mono);
     font-size: 11.5px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
 }
 
-.fw-modal__body {
+.yn-modal__body {
     flex: 1;
     overflow: auto;
     padding: 16px 20px;
@@ -820,13 +820,13 @@
 
     &--confirm {
         font-size: 13px;
-        color: var(--fw-text-2);
+        color: var(--yn-text-2);
 
         p { margin: 0 0 10px; }
-        strong { color: var(--fw-text); }
+        strong { color: var(--yn-text); }
         code {
-            font-family: var(--fw-font-mono);
-            background: var(--fw-bg-2);
+            font-family: var(--yn-font-mono);
+            background: var(--yn-bg-2);
             padding: 1px 5px;
             border-radius: 3px;
             font-size: 12px;
@@ -834,74 +834,74 @@
     }
 }
 
-.fw-modal__import-header {
+.yn-modal__import-header {
     display: flex;
     align-items: center;
     gap: 8px;
     font-size: 12px;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
 }
 
-.fw-modal__or { color: var(--fw-text-3); }
+.yn-modal__or { color: var(--yn-text-3); }
 
-.fw-modal__load-progress {
+.yn-modal__load-progress {
     font-size: 12px;
-    color: var(--fw-accent);
+    color: var(--yn-accent);
     font-variant-numeric: tabular-nums;
 }
 
-.fw-parse-progress {
+.yn-parse-progress {
     height: 4px;
-    background: var(--fw-line-2);
+    background: var(--yn-line-2);
     border-radius: 2px;
     overflow: hidden;
 
     &__bar {
         height: 100%;
-        background: var(--fw-accent);
+        background: var(--yn-accent);
         border-radius: 2px;
         transition: width 0.15s ease;
         min-width: 2px;
     }
 }
 
-.fw-modal__large-file-notice {
+.yn-modal__large-file-notice {
     flex: 1;
     display: flex;
     align-items: center;
     justify-content: center;
     min-height: 120px;
-    border: 1px dashed var(--fw-line-2);
+    border: 1px dashed var(--yn-line-2);
     border-radius: 6px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     font-size: 13px;
     padding: 16px 24px;
     text-align: center;
-    background: var(--fw-bg-2);
+    background: var(--yn-bg-2);
 }
 
-.fw-code-area {
+.yn-code-area {
     flex: 1;
-    background: var(--fw-bg-2);
-    border: 1px solid var(--fw-line-2);
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
     border-radius: 6px;
     padding: 12px 14px;
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 12px;
-    color: var(--fw-text);
+    color: var(--yn-text);
     outline: none;
     resize: none;
     min-height: 280px;
     line-height: 1.55;
 
-    &:focus { border-color: var(--fw-accent); }
+    &:focus { border-color: var(--yn-accent); }
 
-    &::placeholder { color: var(--fw-text-3); }
+    &::placeholder { color: var(--yn-text-3); }
 }
 
-.fw-modal__foot {
+.yn-modal__foot {
     padding: 14px 20px;
-    border-top: 1px solid var(--fw-line-2);
+    border-top: 1px solid var(--yn-line-2);
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -909,19 +909,19 @@
     flex-shrink: 0;
 }
 
-.fw-modal__foot-hint {
+.yn-modal__foot-hint {
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
 }
 
-.fw-modal__foot-actions {
+.yn-modal__foot-actions {
     display: flex;
     align-items: center;
     gap: 8px;
 }
 
 // Neighbours page extensions.
-// Scoped to .fw-page to avoid bleeding into other pages.
+// Scoped to .yn-page to avoid bleeding into other pages.
 
 // Neighbours-specific header modifier — constrains the header to the visible
 // flex width (no minWidth override) and hides its scrollbar, relying on JS
@@ -942,20 +942,20 @@
     align-items: center;
     gap: 7px;
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     white-space: nowrap;
 }
 
 // Tabs row wrapper — aligns ConfigTabStrip with the live pill.
-.fw-tabs-row {
+.yn-tabs-row {
     display: flex;
     align-items: center;
-    border-bottom: 1px solid var(--fw-line-2);
-    background: var(--fw-page-bg);
+    border-bottom: 1px solid var(--yn-line-2);
+    background: var(--yn-page-bg);
     flex-shrink: 0;
     padding-right: 16px;
 
-    .fw-tabs {
+    .yn-tabs {
         flex: 1;
         border-bottom: none;
         // Fix 2 — overflow-x:auto promotes overflow-y to auto by default,
@@ -971,8 +971,8 @@
     align-items: center;
     gap: 6px;
     padding: 2px 9px 2px 7px;
-    border-radius: var(--fw-r-md);
-    font-family: var(--fw-font-mono);
+    border-radius: var(--yn-r-md);
+    font-family: var(--yn-font-mono);
     font-size: 11px;
     font-weight: 500;
     letter-spacing: 0.02em;
@@ -992,19 +992,19 @@
 }
 
 // Fix 1 — warm tooltip surface for state and override-badge tooltips.
-// Gravity renders the popup as a .g-popup element in a portal outside .fw-page,
-// so CSS variables defined on .fw-page do not cascade into the portal.
+// Gravity renders the popup as a .g-popup element in a portal outside .yn-page,
+// so CSS variables defined on .yn-page do not cascade into the portal.
 // We hardcode the warm dark-mode values (app is locked to dark) here.
 // The className prop on Gravity Tooltip lands directly on the .g-popup root,
 // which also acts as the tooltip surface itself — so we style it directly.
 .nb-state-tip-popup,
 .nb-ovr-tip-popup {
-    --fw-text:       #F2EEE8;
-    --fw-text-2:     #B8B0A4;
-    --fw-text-3:     #7E7468;
-    --fw-accent:     #FFC061;
-    --fw-line-2:     rgba(255, 200, 140, 0.12);
-    --fw-font-mono:  'JetBrains Mono', ui-monospace, monospace;
+    --yn-text:       #F2EEE8;
+    --yn-text-2:     #B8B0A4;
+    --yn-text-3:     #7E7468;
+    --yn-accent:     #FFC061;
+    --yn-line-2:     rgba(255, 200, 140, 0.12);
+    --yn-font-mono:  'JetBrains Mono', ui-monospace, monospace;
     background: #221C16 !important;
     color: #F2EEE8 !important;
     border-radius: 10px !important;
@@ -1023,8 +1023,8 @@
         align-items: center;
         gap: 7px;
         font-weight: 600;
-        color: var(--fw-text);
-        font-family: var(--fw-font-mono);
+        color: var(--yn-text);
+        font-family: var(--yn-font-mono);
         font-size: 12px;
         margin-bottom: 5px;
     }
@@ -1039,17 +1039,17 @@
     &__desc {
         font-size: 12px;
         line-height: 1.5;
-        color: var(--fw-text-2);
+        color: var(--yn-text-2);
     }
 
     &__action {
         margin-top: 7px;
         padding-top: 7px;
-        border-top: 1px solid var(--fw-line-2);
-        color: var(--fw-text-3);
+        border-top: 1px solid var(--yn-line-2);
+        color: var(--yn-text-3);
         font-size: 11px;
 
-        strong { color: var(--fw-text-2); font-weight: 600; }
+        strong { color: var(--yn-text-2); font-weight: 600; }
     }
 }
 
@@ -1064,14 +1064,14 @@
 }
 
 .nb-src-name {
-    font-family: var(--fw-font-mono);
+    font-family: var(--yn-font-mono);
     font-size: 12px;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 
-    &--static { color: var(--fw-accent); }
+    &--static { color: var(--yn-accent); }
 }
 
 // Override badge (shown under source name in Merged tab).
@@ -1084,9 +1084,9 @@
     text-transform: uppercase;
     letter-spacing: 0.04em;
     padding: 1px 5px;
-    border-radius: var(--fw-r-sm);
-    background: var(--fw-accent-soft);
-    color: var(--fw-accent);
+    border-radius: var(--yn-r-sm);
+    background: var(--yn-accent-soft);
+    color: var(--yn-accent);
     border: 1px solid rgba(255, 192, 97, 0.3);
     white-space: nowrap;
     cursor: default;
@@ -1105,28 +1105,28 @@
 .nb-ovr-tip {
     font-size: 12px;
     line-height: 1.5;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
 
     &__head {
         display: flex;
         align-items: center;
         gap: 7px;
         font-weight: 600;
-        color: var(--fw-text);
+        color: var(--yn-text);
         margin-bottom: 5px;
     }
 
     &__conflict {
         margin-top: 7px;
         padding-top: 7px;
-        border-top: 1px solid var(--fw-line-2);
+        border-top: 1px solid var(--yn-line-2);
         color: var(--g-color-text-warning);
         font-size: 11px;
 
         strong { font-weight: 600; }
     }
 
-    strong { color: var(--fw-text); font-weight: 600; }
+    strong { color: var(--yn-text); font-weight: 600; }
 }
 
 // Live freshness pill.
@@ -1136,18 +1136,18 @@
     gap: 8px;
     height: 30px;
     padding: 0 10px;
-    border-radius: var(--fw-r-md);
-    border: 1px solid var(--fw-line-2);
-    background: var(--fw-panel);
+    border-radius: var(--yn-r-md);
+    border: 1px solid var(--yn-line-2);
+    background: var(--yn-panel);
     font-size: 11.5px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     flex-shrink: 0;
 
     &__dot {
         width: 7px;
         height: 7px;
         border-radius: 50%;
-        background: var(--fw-text-3);
+        background: var(--yn-text-3);
         flex-shrink: 0;
         position: relative;
     }
@@ -1159,15 +1159,15 @@
         place-items: center;
         width: 18px;
         height: 18px;
-        border-radius: var(--fw-r-sm);
-        color: var(--fw-text-3);
+        border-radius: var(--yn-r-sm);
+        color: var(--yn-text-3);
         background: none;
         border: none;
         cursor: pointer;
         font-size: 11px;
         padding: 0;
 
-        &:hover { background: var(--fw-bg-2); color: var(--fw-text); }
+        &:hover { background: var(--yn-bg-2); color: var(--yn-text); }
     }
 
     &--on {
@@ -1185,7 +1185,7 @@
             }
         }
 
-        .nb-live-pill__label { color: var(--fw-text-2); }
+        .nb-live-pill__label { color: var(--yn-text-2); }
     }
 }
 
@@ -1195,7 +1195,7 @@
     100% { opacity: 0; }
 }
 
-// Detail panel — read-only aside using existing fw-drawer chrome.
+// Detail panel — read-only aside using existing yn-drawer chrome.
 .nb-detail-panel {
     width: 480px;
 
@@ -1211,7 +1211,7 @@
 
     &__subtitle {
         font-size: 11.5px;
-        color: var(--fw-text-2);
+        color: var(--yn-text-2);
         margin-top: 2px;
     }
 }
@@ -1227,12 +1227,12 @@
         font-size: 10.5px;
         text-transform: uppercase;
         letter-spacing: 0.06em;
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
     }
 
     dd {
         font-size: 12.5px;
-        color: var(--fw-text);
+        color: var(--yn-text);
         line-height: 1.5;
         overflow-wrap: anywhere;
         display: flex;
@@ -1248,7 +1248,7 @@
     align-items: center;
     gap: 4px;
 
-    &--muted { color: var(--fw-text-3); }
+    &--muted { color: var(--yn-text-3); }
 }
 
 .nb-copy-btn {
@@ -1257,22 +1257,22 @@
     justify-content: center;
     width: 18px;
     height: 18px;
-    border-radius: var(--fw-r-sm);
+    border-radius: var(--yn-r-sm);
     font-size: 11px;
-    color: var(--fw-text-3);
+    color: var(--yn-text-3);
     background: none;
     border: none;
     cursor: pointer;
     flex-shrink: 0;
 
-    &:hover { color: var(--fw-accent); background: var(--fw-bg-2); }
+    &:hover { color: var(--yn-accent); background: var(--yn-bg-2); }
 }
 
 // State explanation block.
 .nb-state-explain {
-    border-radius: var(--fw-r-md);
-    border: 1px solid var(--fw-line-2);
-    background: var(--fw-bg-2);
+    border-radius: var(--yn-r-md);
+    border: 1px solid var(--yn-line-2);
+    background: var(--yn-bg-2);
     padding: 12px 14px;
 
     &__head {
@@ -1282,16 +1282,16 @@
     &__desc {
         font-size: 12.5px;
         line-height: 1.55;
-        color: var(--fw-text-2);
+        color: var(--yn-text-2);
         margin: 0;
     }
 
     &__action {
         margin-top: 10px;
         padding-top: 10px;
-        border-top: 1px solid var(--fw-line-2);
+        border-top: 1px solid var(--yn-line-2);
         font-size: 12px;
-        color: var(--fw-text-2);
+        color: var(--yn-text-2);
         display: flex;
         align-items: flex-start;
         gap: 7px;
@@ -1308,15 +1308,15 @@
     display: flex;
     gap: 9px;
     padding: 11px 13px;
-    border-radius: var(--fw-r-md);
-    background: var(--fw-accent-soft);
+    border-radius: var(--yn-r-md);
+    background: var(--yn-accent-soft);
     border: 1px solid rgba(255, 192, 97, 0.22);
     margin-bottom: 14px;
     font-size: 12.5px;
     line-height: 1.55;
-    color: var(--fw-text-2);
+    color: var(--yn-text-2);
 
-    strong { color: var(--fw-text); font-weight: 600; }
+    strong { color: var(--yn-text); font-weight: 600; }
 
     &__icon {
         font-size: 14px;
@@ -1335,14 +1335,14 @@
 }
 
 .nb-cand {
-    border: 1px solid var(--fw-line-2);
-    border-radius: var(--fw-r-md);
+    border: 1px solid var(--yn-line-2);
+    border-radius: var(--yn-r-md);
     padding: 11px 13px;
-    background: var(--fw-bg-2);
+    background: var(--yn-bg-2);
 
     &--winner {
         border-color: rgba(255, 192, 97, 0.3);
-        background: var(--fw-accent-soft);
+        background: var(--yn-accent-soft);
     }
 
     &__top {
@@ -1355,7 +1355,7 @@
     &__table {
         font-weight: 600;
         font-size: 13px;
-        color: var(--fw-text);
+        color: var(--yn-text);
     }
 
     &__tag {
@@ -1364,23 +1364,23 @@
         letter-spacing: 0.07em;
         text-transform: uppercase;
         padding: 2px 6px;
-        border-radius: var(--fw-r-sm);
+        border-radius: var(--yn-r-sm);
 
         &--winner {
-            background: var(--fw-accent);
+            background: var(--yn-accent);
             color: #1a140a;
         }
 
         &--shadow {
-            background: var(--fw-bg-3);
-            color: var(--fw-text-3);
+            background: var(--yn-bg-3);
+            color: var(--yn-text-3);
         }
     }
 
     &__prio {
         margin-left: auto;
         font-size: 11px;
-        color: var(--fw-text-3);
+        color: var(--yn-text-3);
     }
 
     &__grid {
@@ -1398,13 +1398,13 @@
             font-size: 9.5px;
             text-transform: uppercase;
             letter-spacing: 0.06em;
-            color: var(--fw-text-3);
+            color: var(--yn-text-3);
         }
 
         b {
             font-size: 11.5px;
             font-weight: 500;
-            color: var(--fw-text-2);
+            color: var(--yn-text-2);
         }
     }
 

--- a/web/src/styles/tokens.scss
+++ b/web/src/styles/tokens.scss
@@ -1,56 +1,56 @@
 // Global design tokens — warm dark-brown palette.
 // Scoped to .g-root so they are available on every page,
-// not only those that mount a .fw-page element.
+// not only those that mount a .yn-page element.
 
 .g-root {
     // Dark-mode warm-brown palette (default — app is locked to dark).
-    --fw-page-bg:       #15110D;
-    --fw-panel:         #1C1814;
-    --fw-bg-2:          #181410;
-    --fw-bg-3:          #221C16;
-    --fw-bg-hover:      #221C16;
-    --fw-line:          rgba(255, 199, 140, 0.02);
-    --fw-line-2:        rgba(255, 200, 140, 0.12);
-    --fw-text:          #F2EEE8;
-    --fw-text-2:        #B8B0A4;
-    --fw-text-3:        #7E7468;
-    --fw-accent:        #FFC061;
-    --fw-accent-soft:   rgba(255, 192, 97, 0.14);
-    --fw-danger:        var(--g-color-text-danger);
-    --fw-warn:          var(--g-color-text-warning);
-    --fw-ok:            var(--g-color-text-positive);
-    --fw-r-sm:          4px;
-    --fw-r-md:          6px;
-    --fw-r-lg:          10px;
-    --fw-font-mono:     'JetBrains Mono', ui-monospace, monospace;
+    --yn-page-bg:       #15110D;
+    --yn-panel:         #1C1814;
+    --yn-bg-2:          #181410;
+    --yn-bg-3:          #221C16;
+    --yn-bg-hover:      #221C16;
+    --yn-line:          rgba(255, 199, 140, 0.02);
+    --yn-line-2:        rgba(255, 200, 140, 0.12);
+    --yn-text:          #F2EEE8;
+    --yn-text-2:        #B8B0A4;
+    --yn-text-3:        #7E7468;
+    --yn-accent:        #FFC061;
+    --yn-accent-soft:   rgba(255, 192, 97, 0.14);
+    --yn-danger:        var(--g-color-text-danger);
+    --yn-warn:          var(--g-color-text-warning);
+    --yn-ok:            var(--g-color-text-positive);
+    --yn-r-sm:          4px;
+    --yn-r-md:          6px;
+    --yn-r-lg:          10px;
+    --yn-font-mono:     'JetBrains Mono', ui-monospace, monospace;
 
     // Direction badge colors — recomputed against new warm accent.
-    --fw-dir-in:        var(--g-color-text-positive);
-    --fw-dir-in-bg:     rgba(110, 198, 140, 0.12);
-    --fw-dir-in-bd:     rgba(110, 198, 140, 0.22);
-    --fw-dir-out:       var(--fw-accent);
-    --fw-dir-out-bg:    var(--fw-accent-soft);
-    --fw-dir-out-bd:    rgba(255, 192, 97, 0.22);
-    --fw-dir-none:      var(--fw-text-3);
-    --fw-dir-none-bg:   rgba(126, 116, 104, 0.12);
-    --fw-dir-none-bd:   rgba(126, 116, 104, 0.22);
+    --yn-dir-in:        var(--g-color-text-positive);
+    --yn-dir-in-bg:     rgba(110, 198, 140, 0.12);
+    --yn-dir-in-bd:     rgba(110, 198, 140, 0.22);
+    --yn-dir-out:       var(--yn-accent);
+    --yn-dir-out-bg:    var(--yn-accent-soft);
+    --yn-dir-out-bd:    rgba(255, 192, 97, 0.22);
+    --yn-dir-none:      var(--yn-text-3);
+    --yn-dir-none-bg:   rgba(126, 116, 104, 0.12);
+    --yn-dir-none-bd:   rgba(126, 116, 104, 0.22);
 }
 
 // Light-mode overrides.
 [data-theme="light"] {
-    .fw-page,
-    .fw-drawer,
-    .fw-modal {
-        --fw-page-bg:  #FAF7F2;
-        --fw-panel:    #FFFFFF;
-        --fw-bg-2:     #F3EFE9;
-        --fw-bg-3:     #EBE6DE;
-        --fw-bg-hover: #EBE6DE;
-        --fw-line:     rgba(80, 60, 30, 0.08);
-        --fw-line-2:   rgba(80, 60, 30, 0.16);
-        --fw-text:     #1A1410;
-        --fw-text-2:   #5C4E3A;
-        --fw-text-3:   #9C8B74;
+    .yn-page,
+    .yn-drawer,
+    .yn-modal {
+        --yn-page-bg:  #FAF7F2;
+        --yn-panel:    #FFFFFF;
+        --yn-bg-2:     #F3EFE9;
+        --yn-bg-3:     #EBE6DE;
+        --yn-bg-hover: #EBE6DE;
+        --yn-line:     rgba(80, 60, 30, 0.08);
+        --yn-line-2:   rgba(80, 60, 30, 0.16);
+        --yn-text:     #1A1410;
+        --yn-text-2:   #5C4E3A;
+        --yn-text-3:   #9C8B74;
     }
 }
 
@@ -61,5 +61,5 @@
     flex: 1;
     min-width: 0;
     min-height: 100%;
-    background: var(--fw-page-bg);
+    background: var(--yn-page-bg);
 }


### PR DESCRIPTION
Renames the historical forward-derived shared-chrome CSS prefix to a universal yanet prefix across the web UI, covering both class names and the design-system custom properties. Also normalizes the table class abbreviation to the spelled-out form for consistency.

Pure rename with no behavioral or visual change. The neighbours tab-row wrapper is preserved as a distinct element; genuine tab and table unification is a later step.