### PR TITLE
feat(web): unify neighbours table with route and extract a shared virtual table

### DIFF
--- a/web/src/pages/_shared/table/FamilyFilter.tsx
+++ b/web/src/pages/_shared/table/FamilyFilter.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export type IPFamily = 'all' | 'v4' | 'v6';
+
+const LABELS: Record<IPFamily, string> = {
+    all: 'All',
+    v4: 'IPv4',
+    v6: 'IPv6',
+};
+
+export interface FamilyFilterProps {
+    value: IPFamily;
+    onChange: (family: IPFamily) => void;
+}
+
+/** Segmented All / IPv4 / IPv6 control for filtering rows by IP address family. */
+export const FamilyFilter: React.FC<FamilyFilterProps> = ({ value, onChange }) => (
+    <div className="yn-seg">
+        {(['all', 'v4', 'v6'] as IPFamily[]).map((f) => (
+            <button
+                key={f}
+                type="button"
+                className={`yn-seg__btn${value === f ? ' yn-seg__btn--active' : ''}`}
+                onClick={() => onChange(f)}
+            >
+                {LABELS[f]}
+            </button>
+        ))}
+    </div>
+);

--- a/web/src/pages/_shared/table/VirtualTable.tsx
+++ b/web/src/pages/_shared/table/VirtualTable.tsx
@@ -1,0 +1,424 @@
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { Checkbox, Tooltip } from '@gravity-ui/uikit';
+import { useRowHoverOverlay, RowHoverEditOverlay } from '../draft';
+import { useContainerHeight } from '../../../hooks/useContainerHeight';
+
+export const ROW_HEIGHT = 44;
+export const HEADER_HEIGHT = 40;
+export const FOOTER_HEIGHT = 28;
+export const OVERSCAN = 15;
+
+const CHECKBOX_TRACK = '38px';
+const INDEX_TRACK = '52px';
+
+/** Column definition for VirtualTable. */
+export interface Column<T> {
+    /** Unique key, used as React key. */
+    key: string;
+    /** Header label text. */
+    header: string;
+    /** CSS grid track size, e.g. 'minmax(190px,1.3fr)' or '150px'. */
+    gridTrack: string;
+    /** When provided, the header becomes a sort button for this key. */
+    sortKey?: string;
+    /** Optional text alignment for the cell. */
+    align?: 'left' | 'center' | 'right';
+    /** Render the cell for a given row. */
+    renderCell: (row: T, index: number) => React.ReactNode;
+}
+
+export interface SortState<K extends string> {
+    column: K | null;
+    direction: 'asc' | 'desc';
+}
+
+export interface VirtualTableProps<T> {
+    rows: T[];
+    columns: Column<T>[];
+    getRowId: (row: T) => string;
+    emptyMessage?: string;
+
+    selectedIds: Set<string>;
+    onSelectionChange: (ids: Set<string>) => void;
+    selectionDisabled?: boolean;
+    selectionDisabledTooltip?: React.ReactNode;
+
+    sortState: SortState<string>;
+    onSort: (key: string) => void;
+
+    onEditRow: (id: string) => void;
+    onDeleteRow?: (id: string) => void;
+    canEditRow?: boolean;
+    editAriaLabel?: (row: T, idx: number) => string;
+    deleteAriaLabel?: (row: T, idx: number) => string;
+    editTitle?: string;
+    deleteTitle?: string;
+    editIcon?: React.ReactNode;
+    deleteIcon?: React.ReactNode;
+
+    onRowClick?: (id: string) => void;
+    activeRowId?: string | null;
+
+    flashRowId?: string | null;
+
+    headerActions?: React.ReactNode;
+
+    footerSummary?: string;
+    footerExtra?: React.ReactNode;
+
+    minWidth: number;
+}
+
+/** SVG sort icon — double arrow (unsorted), up arrow (asc), down arrow (desc). */
+export const SortIcon: React.FC<{ variant: 'sort' | 'sortUp' | 'sortDown'; active: boolean }> = ({ variant, active }) => {
+    const paths: Record<typeof variant, string[]> = {
+        sort: ['M8 3v18', 'M5 8l3-3 3 3', 'M16 21V3', 'M13 16l3 3 3-3'],
+        sortUp: ['M8 5l4-4 4 4', 'M12 1v22'],
+        sortDown: ['M8 19l4 4 4-4', 'M12 23V1'],
+    };
+    return (
+        <svg
+            width={12}
+            height={12}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{ display: 'block', flexShrink: 0, opacity: active ? 1 : 0.5 }}
+        >
+            {paths[variant].map((d) => <path key={d} d={d} />)}
+        </svg>
+    );
+};
+
+interface SortButtonProps {
+    sortKey: string;
+    label: string;
+    sortState: SortState<string>;
+    onSort: (key: string) => void;
+}
+
+const SortButton: React.FC<SortButtonProps> = ({ sortKey, label, sortState, onSort }) => {
+    const isActive = sortState.column === sortKey;
+    const iconVariant = isActive
+        ? (sortState.direction === 'asc' ? 'sortUp' : 'sortDown')
+        : 'sort';
+    return (
+        <button
+            type="button"
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 4,
+                background: 'none',
+                border: 'none',
+                cursor: 'pointer',
+                color: isActive ? 'var(--yn-accent)' : 'inherit',
+                padding: 0,
+                width: '100%',
+                minWidth: 0,
+            }}
+            onClick={() => onSort(sortKey)}
+        >
+            <span className="yn-th-text" style={{ color: isActive ? 'var(--yn-accent)' : undefined }}>{label}</span>
+            <SortIcon variant={iconVariant} active={isActive} />
+        </button>
+    );
+};
+
+/**
+ * Generic virtualized read-only table with CSS-grid columns, shared hover-edit overlay,
+ * selection, sort, flash, active-row, and optional per-row click.
+ */
+export function VirtualTable<T>({
+    rows,
+    columns,
+    getRowId,
+    emptyMessage = 'No data.',
+    selectedIds,
+    onSelectionChange,
+    selectionDisabled,
+    selectionDisabledTooltip,
+    sortState,
+    onSort,
+    onEditRow,
+    onDeleteRow,
+    canEditRow,
+    editAriaLabel,
+    deleteAriaLabel,
+    editTitle = 'Edit',
+    deleteTitle = 'Delete',
+    editIcon,
+    deleteIcon,
+    onRowClick,
+    activeRowId,
+    flashRowId,
+    headerActions,
+    footerSummary,
+    footerExtra,
+    minWidth,
+}: VirtualTableProps<T>): React.JSX.Element {
+    const scrollRef = useRef<HTMLDivElement | null>(null);
+    const headerRef = useRef<HTMLDivElement | null>(null);
+    const bodyHeight = useContainerHeight(scrollRef as React.RefObject<HTMLElement | null>, 300, FOOTER_HEIGHT);
+    const [flashingId, setFlashingId] = React.useState<string | null>(null);
+
+    const {
+        hoveredRow,
+        overlayTopOffset,
+        handleHoverChange,
+        handleOverlayMouseEnter,
+        handleOverlayMouseLeave,
+        attachScrollEl,
+    } = useRowHoverOverlay<T>(HEADER_HEIGHT);
+
+    const setScrollRef = useCallback((el: HTMLDivElement | null): void => {
+        (scrollRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+        attachScrollEl(el);
+    }, [attachScrollEl]);
+
+    const handleBodyScroll = useCallback((e: React.UIEvent<HTMLDivElement>): void => {
+        const body = e.currentTarget;
+        const header = headerRef.current;
+        if (header !== null) {
+            header.scrollLeft = body.scrollLeft;
+        }
+    }, []);
+
+    const rowVirtualizer = useVirtualizer({
+        count: rows.length,
+        getScrollElement: () => scrollRef.current,
+        estimateSize: () => ROW_HEIGHT,
+        overscan: OVERSCAN,
+    });
+
+    useEffect(() => {
+        if (!flashRowId) return;
+        const idx = rows.findIndex((r) => getRowId(r) === flashRowId);
+        if (idx >= 0) {
+            rowVirtualizer.scrollToIndex(idx, { align: 'center' });
+        }
+        setFlashingId(flashRowId);
+        const t = setTimeout(() => setFlashingId(null), 1200);
+        return () => clearTimeout(t);
+    }, [flashRowId, rows, rowVirtualizer, getRowId]);
+
+    const isAllSelected = rows.length > 0 && rows.every((r) => selectedIds.has(getRowId(r)));
+    const isIndeterminate = !isAllSelected && rows.some((r) => selectedIds.has(getRowId(r)));
+
+    const handleSelectAll = useCallback((checked: boolean): void => {
+        onSelectionChange(checked ? new Set(rows.map(getRowId)) : new Set());
+    }, [rows, onSelectionChange, getRowId]);
+
+    const handleRowCheckbox = useCallback((id: string, checked: boolean): void => {
+        const next = new Set(selectedIds);
+        if (checked) next.add(id); else next.delete(id);
+        onSelectionChange(next);
+    }, [selectedIds, onSelectionChange]);
+
+    const handleOverlayEdit = useCallback((): void => {
+        if (hoveredRow) {
+            onEditRow(getRowId(hoveredRow));
+        }
+    }, [hoveredRow, onEditRow, getRowId]);
+
+    const virtualRows = rowVirtualizer.getVirtualItems();
+
+    const defaultFooterText = useMemo(() => {
+        if (rows.length === 0 || virtualRows.length === 0) return '';
+        const first = virtualRows[0].index + 1;
+        const last = virtualRows[virtualRows.length - 1].index + 1;
+        return `Shown ${first.toLocaleString()}–${last.toLocaleString()} of ${rows.length.toLocaleString()}`;
+    }, [virtualRows, rows.length]);
+
+    const footerText = footerSummary ?? defaultFooterText;
+
+    const gridTemplateColumns = [CHECKBOX_TRACK, INDEX_TRACK, ...columns.map((c) => c.gridTrack)].join(' ');
+    const GRID_COLUMN_GAP = 14;
+
+    const gridStyle: React.CSSProperties = {
+        display: 'grid',
+        gridTemplateColumns,
+        columnGap: GRID_COLUMN_GAP,
+        alignItems: 'center',
+        paddingLeft: 16,
+        paddingRight: 22,
+        minWidth,
+    };
+
+    const headerCheckbox = selectionDisabled ? (
+        <Tooltip content={selectionDisabledTooltip ?? 'Selection disabled'} placement="bottom" openDelay={200}>
+            <Checkbox checked={false} indeterminate={false} onUpdate={() => {}} size="m" disabled />
+        </Tooltip>
+    ) : (
+        <Checkbox checked={isAllSelected} indeterminate={isIndeterminate} onUpdate={handleSelectAll} size="m" />
+    );
+
+    return (
+        <div className="yn-table-wrap">
+            <div className="yn-table-header-row">
+                <div
+                    ref={headerRef}
+                    className="yn-vtbl-header yn-vtbl-header--grid"
+                    style={{ flex: '1 1 auto', height: HEADER_HEIGHT, overflowX: 'scroll', overflowY: 'hidden', minWidth: 0 }}
+                >
+                    <div style={{ ...gridStyle, height: HEADER_HEIGHT, display: 'grid' }}>
+                        <div
+                            style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                            onClick={(e) => e.stopPropagation()}
+                        >
+                            {headerCheckbox}
+                        </div>
+                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                            <span className="yn-th-text">#</span>
+                        </div>
+                        {columns.map((col) => (
+                            <div
+                                key={col.key}
+                                style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: col.align === 'center' ? 'center' : col.align === 'right' ? 'flex-end' : 'flex-start',
+                                    overflow: 'hidden',
+                                }}
+                            >
+                                {col.sortKey ? (
+                                    <SortButton
+                                        sortKey={col.sortKey}
+                                        label={col.header}
+                                        sortState={sortState}
+                                        onSort={onSort}
+                                    />
+                                ) : (
+                                    <span className="yn-th-text">{col.header}</span>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </div>
+                {headerActions && (
+                    <div className="yn-table-actions">
+                        {headerActions}
+                    </div>
+                )}
+            </div>
+
+            <div
+                ref={setScrollRef}
+                className="yn-vtbl-body"
+                style={{ flex: '0 0 auto', height: bodyHeight, overflowY: 'auto' }}
+                onScroll={handleBodyScroll}
+            >
+                {rows.length === 0 ? (
+                    <div className="yn-table-empty">{emptyMessage}</div>
+                ) : (
+                    <div style={{ height: rowVirtualizer.getTotalSize(), minWidth, position: 'relative' }}>
+                        {virtualRows.map((virtualRow) => {
+                            const row = rows[virtualRow.index];
+                            if (!row) return null;
+                            const id = getRowId(row);
+                            const isSelected = selectedIds.has(id);
+                            const isActive = activeRowId === id;
+                            const isFlashing = flashingId === id;
+                            let rowBg = 'transparent';
+                            if (isFlashing) rowBg = 'color-mix(in srgb, var(--g-color-text-positive) 14%, transparent)';
+                            else if (isSelected || isActive) rowBg = 'var(--yn-accent-soft)';
+
+                            const rowClasses = [
+                                'yn-vrow',
+                                isActive ? 'yn-vrow--active' : '',
+                                isSelected ? 'yn-vrow--selected' : '',
+                            ].filter(Boolean).join(' ');
+
+                            const rowCheckbox = selectionDisabled ? (
+                                <Tooltip
+                                    content={selectionDisabledTooltip ?? 'Selection disabled'}
+                                    placement="bottom"
+                                    openDelay={200}
+                                >
+                                    <Checkbox checked={false} onUpdate={() => {}} size="m" disabled />
+                                </Tooltip>
+                            ) : (
+                                <Checkbox
+                                    checked={isSelected}
+                                    onUpdate={(checked) => handleRowCheckbox(id, checked)}
+                                    size="m"
+                                />
+                            );
+
+                            return (
+                                <div
+                                    key={id || virtualRow.index}
+                                    className={rowClasses}
+                                    data-row-id={id}
+                                    onMouseEnter={() => handleHoverChange(row, virtualRow.start)}
+                                    onMouseLeave={() => handleHoverChange(null, 0)}
+                                    onClick={onRowClick ? () => onRowClick(id) : undefined}
+                                    style={{
+                                        position: 'absolute',
+                                        top: virtualRow.start,
+                                        left: 0,
+                                        height: ROW_HEIGHT,
+                                        width: '100%',
+                                        borderBottom: '1px solid var(--yn-line)',
+                                        backgroundColor: rowBg,
+                                        cursor: onRowClick ? 'pointer' : 'default',
+                                        ...gridStyle,
+                                    }}
+                                >
+                                    <div
+                                        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                                        onClick={(e) => e.stopPropagation()}
+                                    >
+                                        {rowCheckbox}
+                                    </div>
+                                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--yn-text-3)', fontVariantNumeric: 'tabular-nums', fontFamily: 'var(--yn-font-mono)' }}>
+                                        <span style={{ fontSize: 12.5 }}>{virtualRow.index + 1}</span>
+                                    </div>
+                                    {columns.map((col) => (
+                                        <div
+                                            key={col.key}
+                                            style={{
+                                                overflow: 'hidden',
+                                                display: 'flex',
+                                                alignItems: 'center',
+                                                justifyContent: col.align === 'center' ? 'center' : col.align === 'right' ? 'flex-end' : 'flex-start',
+                                            }}
+                                        >
+                                            {col.renderCell(row, virtualRow.index)}
+                                        </div>
+                                    ))}
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+
+            <div className="yn-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
+                <span className="yn-toolbar__count">{footerText}</span>
+                {footerExtra}
+            </div>
+
+            {canEditRow !== false && hoveredRow !== null && (
+                <RowHoverEditOverlay
+                    top={overlayTopOffset}
+                    rowHeight={ROW_HEIGHT}
+                    onEdit={handleOverlayEdit}
+                    editAriaLabel={editAriaLabel ? editAriaLabel(hoveredRow, rows.indexOf(hoveredRow)) : editTitle}
+                    editTitle={editTitle}
+                    onDelete={onDeleteRow ? () => onDeleteRow(getRowId(hoveredRow)) : undefined}
+                    deleteAriaLabel={deleteAriaLabel ? deleteAriaLabel(hoveredRow, rows.indexOf(hoveredRow)) : deleteTitle}
+                    deleteTitle={deleteTitle}
+                    onMouseEnter={handleOverlayMouseEnter}
+                    onMouseLeave={handleOverlayMouseLeave}
+                    editIcon={editIcon}
+                    deleteIcon={deleteIcon}
+                />
+            )}
+        </div>
+    );
+}

--- a/web/src/pages/_shared/table/cells.tsx
+++ b/web/src/pages/_shared/table/cells.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+/** Small v4/v6 family badge derived from an IP string. Detects ':' for IPv6, else IPv4. */
+export const FamilyBadge: React.FC<{ address: string }> = ({ address }) => {
+    const isV6 = address.includes(':');
+    return (
+        <span
+            style={{
+                display: 'inline-block',
+                fontSize: 9.5,
+                fontWeight: 700,
+                fontFamily: 'var(--yn-font-mono)',
+                color: isV6 ? 'var(--g-color-text-info)' : 'var(--g-color-text-warning)',
+                opacity: 0.8,
+                width: 16,
+                flexShrink: 0,
+                whiteSpace: 'nowrap',
+            }}
+        >
+            {isV6 ? 'v6' : 'v4'}
+        </span>
+    );
+};

--- a/web/src/pages/operators/neighbours/NeighbourTable.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourTable.tsx
@@ -1,9 +1,6 @@
-import React, { useCallback, useMemo, useRef } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import { Checkbox, Tooltip } from '@gravity-ui/uikit';
+import React from 'react';
+import { Tooltip } from '@gravity-ui/uikit';
 import { Pencil, TrashBin } from '@gravity-ui/icons';
-import { useContainerHeight } from '../../../hooks';
-import { useRowHoverOverlay, RowHoverEditOverlay } from '../../_shared/draft';
 import type { Neighbour, NeighbourTableInfo } from '../../../api/neighbours';
 import { formatUnixSeconds } from '../../../utils';
 import { ipAddressToString } from '../../../utils/netip';
@@ -11,26 +8,11 @@ import { getNeighbourId } from './utils';
 import { nudStateToName, getStateMeta } from './stateMeta';
 import { getMergeDebug } from './mergeDebug';
 import type { SortableColumn, SortState } from './types';
+import { VirtualTable } from '../../_shared/table/VirtualTable';
+import type { Column, SortState as VTSortState } from '../../_shared/table/VirtualTable';
+import { FamilyBadge } from '../../_shared/table/cells';
 
-const ROW_HEIGHT = 44;
-const HEADER_HEIGHT = 40;
-const FOOTER_HEIGHT = 28;
-const OVERSCAN = 15;
-
-const COL_CHECKBOX = 38;
-const COL_INDEX = 48;
-const COL_NEXT_HOP = 230;
-const COL_LINK_ADDR = 150;
-const COL_HW_ADDR = 150;
-const COL_DEVICE = 90;
-const COL_STATE = 140;
-const COL_SOURCE = 160;
-const COL_PRIORITY = 70;
-const COL_UPDATED = 160;
-
-const NEIGH_TOTAL_WIDTH =
-    COL_CHECKBOX + COL_INDEX + COL_NEXT_HOP + COL_LINK_ADDR + COL_HW_ADDR +
-    COL_DEVICE + COL_STATE + COL_SOURCE + COL_PRIORITY + COL_UPDATED;
+const NEIGH_MIN_WIDTH = 1256;
 
 export interface NeighbourTableProps {
     rows: Neighbour[];
@@ -41,8 +23,6 @@ export interface NeighbourTableProps {
     /** Optional right-side footer note (e.g. read-only warning). */
     readOnlyNote?: React.ReactNode;
     selectedIds: Set<string>;
-    activeRowId: string | null;
-    editingRowId: string | null;
     sortState: SortState;
     onSort: (col: SortableColumn) => void;
     onRowClick: (id: string) => void;
@@ -160,41 +140,6 @@ const SourceCell: React.FC<SourceCellProps> = ({ neighbour, isMergedView, cache,
     );
 };
 
-interface SortButtonProps {
-    col: SortableColumn;
-    label: string;
-    width: number;
-    sortState: SortState;
-    onSort: (col: SortableColumn) => void;
-}
-
-const SortButton: React.FC<SortButtonProps> = ({ col, label, width, sortState, onSort }) => {
-    const isActive = sortState.column === col;
-    const arrow = isActive ? (sortState.direction === 'asc' ? '▲' : '▼') : '↕';
-    return (
-        <button
-            type="button"
-            style={{
-                width,
-                minWidth: width,
-                flexShrink: 0,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                background: 'none',
-                border: 'none',
-                cursor: 'pointer',
-                color: 'inherit',
-                padding: '0 8px 0 0',
-            }}
-            onClick={() => onSort(col)}
-        >
-            <span className="yn-th-text">{label}</span>
-            <span style={{ fontSize: 10, opacity: isActive ? 1 : 0.35 }}>{arrow}</span>
-        </button>
-    );
-};
-
 /** Read-only virtualized table for the Neighbour list. */
 export const NeighbourTable: React.FC<NeighbourTableProps> = ({
     rows,
@@ -202,8 +147,6 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
     searchActive,
     readOnlyNote,
     selectedIds,
-    activeRowId,
-    editingRowId,
     sortState,
     onSort,
     onRowClick,
@@ -219,248 +162,180 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
     isMergedView,
     cache,
     tables,
-}) => {
-    const scrollRef = useRef<HTMLDivElement>(null);
-    const headerRef = useRef<HTMLDivElement>(null);
-    const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT + 20);
+}): React.JSX.Element => {
+    const columns: Column<Neighbour>[] = [
+        {
+            key: 'next_hop',
+            header: 'Next Hop',
+            gridTrack: '230px',
+            sortKey: 'next_hop',
+            renderCell: (neighbour) => {
+                const addr = ipAddressToString(neighbour.next_hop) || '-';
+                return (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 5, overflow: 'hidden', width: '100%' }}>
+                        {addr !== '-' && <FamilyBadge address={addr} />}
+                        <span className="yn-cell-mono yn-cell-strong" style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{addr}</span>
+                    </div>
+                );
+            },
+        },
+        {
+            key: 'link_addr',
+            header: 'Neighbour MAC',
+            gridTrack: '150px',
+            sortKey: 'link_addr',
+            renderCell: (neighbour) => (
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: '100%' }}>
+                    <span className="yn-cell-mono yn-cell-muted">{neighbour.link_addr?.addr || '-'}</span>
+                </div>
+            ),
+        },
+        {
+            key: 'hardware_addr',
+            header: 'Interface MAC',
+            gridTrack: '150px',
+            sortKey: 'hardware_addr',
+            renderCell: (neighbour) => (
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: '100%' }}>
+                    <span className="yn-cell-mono yn-cell-muted">{neighbour.hardware_addr?.addr || '-'}</span>
+                </div>
+            ),
+        },
+        {
+            key: 'device',
+            header: 'Device',
+            gridTrack: '90px',
+            sortKey: 'device',
+            renderCell: (neighbour) => (
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: '100%' }}>
+                    <span className="yn-cell-muted">{neighbour.device || '-'}</span>
+                </div>
+            ),
+        },
+        {
+            key: 'state',
+            header: 'State',
+            gridTrack: '140px',
+            sortKey: 'state',
+            renderCell: (neighbour) => (
+                <div style={{ overflow: 'hidden', whiteSpace: 'nowrap' }}>
+                    <StateBadge state={neighbour.state} withTooltip />
+                </div>
+            ),
+        },
+        {
+            key: 'source',
+            header: 'Source',
+            gridTrack: '160px',
+            sortKey: 'source',
+            renderCell: (neighbour) => (
+                <div style={{ overflow: 'hidden', width: '100%' }}>
+                    <SourceCell
+                        neighbour={neighbour}
+                        isMergedView={isMergedView ?? false}
+                        cache={cache}
+                        tables={tables}
+                    />
+                </div>
+            ),
+        },
+        {
+            key: 'priority',
+            header: 'Priority',
+            gridTrack: '70px',
+            sortKey: 'priority',
+            renderCell: (neighbour) => (
+                <span className="yn-cell-muted">{neighbour.priority ?? '-'}</span>
+            ),
+        },
+        {
+            key: 'updated_at',
+            header: 'Updated At',
+            gridTrack: '160px',
+            sortKey: 'updated_at',
+            renderCell: (neighbour) => (
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', width: '100%' }}>
+                    <span className="yn-cell-muted">{formatUnixSeconds(neighbour.updated_at)}</span>
+                </div>
+            ),
+        },
+    ];
 
-    const {
-        hoveredRow,
-        overlayTopOffset,
-        handleHoverChange,
-        handleOverlayMouseEnter,
-        handleOverlayMouseLeave,
-        attachScrollEl,
-    } = useRowHoverOverlay<Neighbour>(HEADER_HEIGHT);
+    const adaptedSortState: VTSortState<string> = {
+        column: sortState.column,
+        direction: sortState.direction,
+    };
 
-    const setScrollRef = useCallback((el: HTMLDivElement | null): void => {
-        (scrollRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
-        attachScrollEl(el);
-    }, [attachScrollEl]);
+    const handleSort = (key: string): void => {
+        onSort(key as SortableColumn);
+    };
 
-    const handleBodyScroll = useCallback((): void => {
-        const bodyEl = scrollRef.current;
-        const hdrEl = headerRef.current;
-        if (bodyEl && hdrEl) {
-            hdrEl.scrollLeft = bodyEl.scrollLeft;
-        }
-    }, []);
+    const handleEditRow = (id: string): void => {
+        onRowClick(id);
+        onEditRow(id);
+    };
 
-    const rowVirtualizer = useVirtualizer({
-        count: rows.length,
-        getScrollElement: () => scrollRef.current,
-        estimateSize: () => ROW_HEIGHT,
-        overscan: OVERSCAN,
-    });
-
-    const isAllSelected = rows.length > 0 && rows.every((r) => selectedIds.has(getNeighbourId(r)));
-    const isIndeterminate = !isAllSelected && rows.some((r) => selectedIds.has(getNeighbourId(r)));
-
-    const handleSelectAll = useCallback((checked: boolean): void => {
-        onSelectionChange(checked ? new Set(rows.map(getNeighbourId)) : new Set());
-    }, [rows, onSelectionChange]);
-
-    const handleRowCheckbox = useCallback((id: string, checked: boolean): void => {
-        const next = new Set(selectedIds);
-        if (checked) next.add(id); else next.delete(id);
-        onSelectionChange(next);
-    }, [selectedIds, onSelectionChange]);
-
-    const handleOverlayEdit = useCallback((): void => {
-        if (hoveredRow) {
-            const id = getNeighbourId(hoveredRow);
-            onRowClick(id);
-            onEditRow(id);
-        }
-    }, [hoveredRow, onRowClick, onEditRow]);
-
-    const virtualRows = rowVirtualizer.getVirtualItems();
-    const totalWidth = NEIGH_TOTAL_WIDTH;
-
-    const footerText = useMemo(() => {
-        const mergedSuffix = isMergedView ? ' merged' : '';
-        const filteredSuffix = searchActive && rows.length < totalCount ? ' (filtered)' : '';
-        return `Shown ${rows.length.toLocaleString()} of ${totalCount.toLocaleString()}${mergedSuffix}${filteredSuffix}`;
-    }, [rows.length, totalCount, isMergedView, searchActive]);
+    const mergedDisabledTooltip = 'Merged is read-only — open a table tab to select and delete.';
 
     const showTableActions = canEditTable || canDeleteTable;
 
-    return (
-        <div className="yn-table-wrap">
-            <div className="yn-table-header-row">
-                <div ref={headerRef} className="yn-vtbl-header nb-vtbl-header" style={{ height: HEADER_HEIGHT }}>
-                    <div style={{ display: 'flex', alignItems: 'center', minWidth: totalWidth, height: '100%', paddingLeft: 4, paddingRight: 4 }}>
-                        <div
-                            style={{ width: COL_CHECKBOX, minWidth: COL_CHECKBOX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                            onClick={(e) => e.stopPropagation()}
-                        >
-                            {isMergedView ? (
-                                <Tooltip content="Merged is read-only — open a table tab to select and delete." placement="bottom" openDelay={200}>
-                                    <Checkbox checked={false} indeterminate={false} onUpdate={() => {}} size="m" disabled />
-                                </Tooltip>
-                            ) : (
-                                <Checkbox checked={isAllSelected} indeterminate={isIndeterminate} onUpdate={handleSelectAll} size="m" />
-                            )}
-                        </div>
-                        <div style={{ width: COL_INDEX, minWidth: COL_INDEX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                            <span className="yn-th-text">#</span>
-                        </div>
-                        <SortButton col="next_hop" label="Next Hop" width={COL_NEXT_HOP} sortState={sortState} onSort={onSort} />
-                        <SortButton col="link_addr" label="Neighbour MAC" width={COL_LINK_ADDR} sortState={sortState} onSort={onSort} />
-                        <SortButton col="hardware_addr" label="Interface MAC" width={COL_HW_ADDR} sortState={sortState} onSort={onSort} />
-                        <SortButton col="device" label="Device" width={COL_DEVICE} sortState={sortState} onSort={onSort} />
-                        <SortButton col="state" label="State" width={COL_STATE} sortState={sortState} onSort={onSort} />
-                        <SortButton col="source" label="Source" width={COL_SOURCE} sortState={sortState} onSort={onSort} />
-                        <Tooltip content="Lower value wins the merge (higher precedence)." placement="bottom" openDelay={200}>
-                            <span style={{ display: 'contents' }}>
-                                <SortButton col="priority" label="Priority" width={COL_PRIORITY} sortState={sortState} onSort={onSort} />
-                            </span>
-                        </Tooltip>
-                        <SortButton col="updated_at" label="Updated At" width={COL_UPDATED} sortState={sortState} onSort={onSort} />
-                    </div>
-                </div>
-                {showTableActions && (
-                    <div className="yn-table-actions">
-                        <button
-                            type="button"
-                            className="yn-row-edit-btn yn-row-edit-btn--visible"
-                            title="Edit table"
-                            aria-label="Edit table settings"
-                            disabled={!canEditTable}
-                            onClick={onEditTable}
-                        >
-                            <Pencil width={14} height={14} />
-                        </button>
-                        <button
-                            type="button"
-                            className="yn-row-edit-btn yn-row-edit-btn--visible yn-row-edit-btn--danger"
-                            title={canDeleteTable ? 'Delete table' : 'Cannot remove built-in table'}
-                            aria-label="Delete table"
-                            disabled={!canDeleteTable}
-                            onClick={onDeleteTable}
-                        >
-                            <TrashBin width={14} height={14} />
-                        </button>
-                    </div>
-                )}
-            </div>
+    const footerText = (() => {
+        const mergedSuffix = isMergedView ? ' merged' : '';
+        const filteredSuffix = searchActive && rows.length < totalCount ? ' (filtered)' : '';
+        return `Shown ${rows.length.toLocaleString()} of ${totalCount.toLocaleString()}${mergedSuffix}${filteredSuffix}`;
+    })();
 
-            <div
-                ref={setScrollRef}
-                className="yn-vtbl-body"
-                style={bodyHeight > 0 ? { flex: '0 0 auto', height: bodyHeight } : undefined}
-                onScroll={handleBodyScroll}
+    const headerActions = showTableActions ? (
+        <>
+            <button
+                type="button"
+                className="yn-row-edit-btn yn-row-edit-btn--visible"
+                title="Edit table"
+                aria-label="Edit table settings"
+                disabled={!canEditTable}
+                onClick={onEditTable}
             >
-                {rows.length === 0 ? (
-                    <div className="yn-table-empty">{emptyMessage}</div>
-                ) : (
-                    <div style={{ height: rowVirtualizer.getTotalSize(), minWidth: totalWidth, position: 'relative' }}>
-                        {virtualRows.map((virtualRow) => {
-                            const neighbour = rows[virtualRow.index];
-                            if (!neighbour) return null;
-                            const id = getNeighbourId(neighbour);
-                            const isSelected = selectedIds.has(id);
-                            const isActive = activeRowId === id || editingRowId === id;
-                            const rowBg = (isSelected || isActive) ? 'var(--yn-accent-soft)' : 'transparent';
-                            return (
-                                <div
-                                    key={id || virtualRow.index}
-                                    className={`yn-vrow${isActive ? ' yn-vrow--active' : ''}${isSelected ? ' yn-vrow--selected' : ''}`}
-                                    data-row-id={id}
-                                    onMouseEnter={() => handleHoverChange(neighbour, virtualRow.start)}
-                                    onMouseLeave={() => handleHoverChange(null, 0)}
-                                    onClick={() => onRowClick(id)}
-                                    style={{
-                                        position: 'absolute',
-                                        top: virtualRow.start,
-                                        left: 0,
-                                        height: ROW_HEIGHT,
-                                        minWidth: totalWidth,
-                                        width: '100%',
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        borderBottom: '1px solid var(--yn-line)',
-                                        backgroundColor: rowBg,
-                                        paddingLeft: 4,
-                                        cursor: 'pointer',
-                                    }}
-                                >
-                                    <div
-                                        style={{ width: COL_CHECKBOX, minWidth: COL_CHECKBOX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                                        onClick={(e) => e.stopPropagation()}
-                                    >
-                                        {isMergedView ? (
-                                            <Tooltip content="Merged is read-only — open a table tab to select and delete." placement="bottom" openDelay={200}>
-                                                <Checkbox checked={false} onUpdate={() => {}} size="m" disabled />
-                                            </Tooltip>
-                                        ) : (
-                                            <Checkbox
-                                                checked={isSelected}
-                                                onUpdate={(checked) => handleRowCheckbox(id, checked)}
-                                                size="m"
-                                            />
-                                        )}
-                                    </div>
-                                    <div style={{ width: COL_INDEX, minWidth: COL_INDEX, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--yn-text-3)', fontVariantNumeric: 'tabular-nums' }}>
-                                        <span style={{ fontSize: 12 }}>{virtualRow.index + 1}</span>
-                                    </div>
-                                    <div style={{ width: COL_NEXT_HOP, minWidth: COL_NEXT_HOP, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="yn-cell-mono yn-cell-strong">{ipAddressToString(neighbour.next_hop) || '-'}</span>
-                                    </div>
-                                    <div style={{ width: COL_LINK_ADDR, minWidth: COL_LINK_ADDR, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="yn-cell-mono yn-cell-muted">{neighbour.link_addr?.addr || '-'}</span>
-                                    </div>
-                                    <div style={{ width: COL_HW_ADDR, minWidth: COL_HW_ADDR, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="yn-cell-mono yn-cell-muted">{neighbour.hardware_addr?.addr || '-'}</span>
-                                    </div>
-                                    <div style={{ width: COL_DEVICE, minWidth: COL_DEVICE, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="yn-cell-muted">{neighbour.device || '-'}</span>
-                                    </div>
-                                    <div style={{ width: COL_STATE, minWidth: COL_STATE, flexShrink: 0, paddingRight: 8, overflow: 'hidden', whiteSpace: 'nowrap' }}>
-                                        <StateBadge state={neighbour.state} withTooltip />
-                                    </div>
-                                    <div style={{ width: COL_SOURCE, minWidth: COL_SOURCE, flexShrink: 0, paddingRight: 8, overflow: 'hidden' }}>
-                                        <SourceCell
-                                            neighbour={neighbour}
-                                            isMergedView={isMergedView ?? false}
-                                            cache={cache}
-                                            tables={tables}
-                                        />
-                                    </div>
-                                    <div style={{ width: COL_PRIORITY, minWidth: COL_PRIORITY, flexShrink: 0, paddingRight: 8 }}>
-                                        <span className="yn-cell-muted">{neighbour.priority ?? '-'}</span>
-                                    </div>
-                                    <div style={{ width: COL_UPDATED, minWidth: COL_UPDATED, flexShrink: 0, paddingRight: 8, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="yn-cell-muted">{formatUnixSeconds(neighbour.updated_at)}</span>
-                                    </div>
-                                </div>
-                            );
-                        })}
-                    </div>
-                )}
-            </div>
+                <Pencil width={14} height={14} />
+            </button>
+            <button
+                type="button"
+                className="yn-row-edit-btn yn-row-edit-btn--visible yn-row-edit-btn--danger"
+                title={canDeleteTable ? 'Delete table' : 'Cannot remove built-in table'}
+                aria-label="Delete table"
+                disabled={!canDeleteTable}
+                onClick={onDeleteTable}
+            >
+                <TrashBin width={14} height={14} />
+            </button>
+        </>
+    ) : undefined;
 
-            <div className="yn-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
-                <span className="yn-toolbar__count">{footerText}</span>
-                {readOnlyNote}
-            </div>
-
-            {canEditRow !== false && hoveredRow !== null && (
-                <RowHoverEditOverlay
-                    top={overlayTopOffset}
-                    rowHeight={ROW_HEIGHT}
-                    onEdit={handleOverlayEdit}
-                    editAriaLabel={`Edit neighbour ${ipAddressToString(hoveredRow.next_hop) || (rows.indexOf(hoveredRow) + 1)}`}
-                    editTitle="Edit neighbour"
-                    onDelete={onDeleteRow ? () => onDeleteRow(getNeighbourId(hoveredRow)) : undefined}
-                    deleteAriaLabel={`Delete neighbour ${ipAddressToString(hoveredRow.next_hop) || ''}`.trim()}
-                    deleteTitle="Delete neighbour"
-                    onMouseEnter={handleOverlayMouseEnter}
-                    onMouseLeave={handleOverlayMouseLeave}
-                    editIcon={<Pencil width={14} height={14} />}
-                    deleteIcon={<TrashBin width={14} height={14} />}
-                />
-            )}
-        </div>
+    return (
+        <VirtualTable<Neighbour>
+            rows={rows}
+            columns={columns}
+            getRowId={getNeighbourId}
+            emptyMessage={emptyMessage}
+            selectedIds={selectedIds}
+            onSelectionChange={onSelectionChange}
+            selectionDisabled={isMergedView}
+            selectionDisabledTooltip={mergedDisabledTooltip}
+            sortState={adaptedSortState}
+            onSort={handleSort}
+            onEditRow={handleEditRow}
+            onDeleteRow={onDeleteRow ? (id) => onDeleteRow(id) : undefined}
+            canEditRow={canEditRow}
+            editAriaLabel={(neighbour) => `Edit neighbour ${ipAddressToString(neighbour.next_hop) || ''}`}
+            deleteAriaLabel={(neighbour) => `Delete neighbour ${ipAddressToString(neighbour.next_hop) || ''}`.trim()}
+            editTitle="Edit neighbour"
+            deleteTitle="Delete neighbour"
+            editIcon={<Pencil width={14} height={14} />}
+            deleteIcon={<TrashBin width={14} height={14} />}
+            onRowClick={onRowClick}
+            headerActions={headerActions}
+            footerSummary={footerText}
+            footerExtra={readOnlyNote}
+            minWidth={NEIGH_MIN_WIDTH}
+        />
     );
 };

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { Plus, Layers } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { BulkDeleteModal, DeleteConfigModal } from '../../_shared/draft';
-import { stringToIPAddress } from '../../../utils/netip';
+import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
 import type { Neighbour, NeighbourTableInfo } from '../../../api/neighbours';
 import { NeighbourTable } from './NeighbourTable';
 import NeighbourPanel from './NeighbourPanel';
@@ -14,12 +14,20 @@ import { useNeighbours } from './useNeighbours';
 import { getNeighbourId, isSortableColumn, isSortDirection, sortComparators } from './utils';
 import { MERGED_TAB, DEFAULT_SORT } from './types';
 import type { SortState, SortableColumn } from './types';
+import { FamilyFilter, type IPFamily } from '../../_shared/table/FamilyFilter';
 import '../../../styles/draft-page.scss';
 
 const QP_TAB = 'tab';
 const QP_SORT = 'sort';
 const QP_ORDER = 'order';
 const QP_SEARCH = 'search';
+const QP_FAMILY = 'family';
+
+const parseFamily = (params: URLSearchParams): IPFamily => {
+    const v = params.get(QP_FAMILY);
+    if (v === 'v4' || v === 'v6') return v;
+    return 'all';
+};
 
 const parseSortState = (params: URLSearchParams): SortState => {
     const col = params.get(QP_SORT);
@@ -46,14 +54,12 @@ const NeighboursPage: React.FC = () => {
     const activeTab = parseTab(searchParams);
     const sortState = parseSortState(searchParams);
     const search = parseSearch(searchParams);
+    const family = parseFamily(searchParams);
 
     const {
         tables,
         cache,
         loading,
-        lastSync,
-        paused,
-        setPaused,
         addNeighbour,
         updateNeighbour,
         removeNeighbours,
@@ -78,14 +84,6 @@ const NeighboursPage: React.FC = () => {
     const [createTableOpen, setCreateTableOpen] = useState(false);
     const [editTableOpen, setEditTableOpen] = useState(false);
     const [deleteTableOpen, setDeleteTableOpen] = useState(false);
-    const [activeRowId, setActiveRowId] = useState<string | null>(null);
-    const [editingRowId, setEditingRowId] = useState<string | null>(null);
-    const [tick, setTick] = useState(0);
-
-    useEffect(() => {
-        const id = window.setInterval(() => setTick((t) => t + 1), 1000);
-        return () => window.clearInterval(id);
-    }, []);
 
     const isMergedView = activeTab === MERGED_TAB;
     const activeTableInfo: NeighbourTableInfo | null = tables.find((t) => t.name === activeTab) ?? null;
@@ -111,8 +109,6 @@ const NeighboursPage: React.FC = () => {
         const tab = cfg === MERGED_TAB ? MERGED_TAB : cfg;
         updateParams({ [QP_TAB]: tab === MERGED_TAB ? null : tab });
         setSelectedIds(new Set());
-        setActiveRowId(null);
-        setEditingRowId(null);
         setPanel((prev) => ({ ...prev, open: false }));
         fetchTab(tab).catch(() => {});
     }, [updateParams, fetchTab]);
@@ -127,6 +123,12 @@ const NeighboursPage: React.FC = () => {
 
     const visibleRows = useMemo(() => {
         let res = allRows;
+        if (family !== 'all') {
+            res = res.filter((n) => {
+                const addr = ipAddressToString(n.next_hop);
+                return family === 'v6' ? addr.includes(':') : !addr.includes(':');
+            });
+        }
         const q = search.trim().toLowerCase();
         if (q) {
             res = res.filter((n) =>
@@ -140,7 +142,7 @@ const NeighboursPage: React.FC = () => {
             res = [...res].sort(sortState.direction === 'desc' ? (a, b) => cmp(b, a) : cmp);
         }
         return res;
-    }, [allRows, search, sortState]);
+    }, [allRows, search, sortState, family]);
 
     const counts = useMemo((): Map<string, number> => {
         const m = new Map<string, number>();
@@ -153,31 +155,21 @@ const NeighboursPage: React.FC = () => {
 
     const openAdd = useCallback((): void => {
         setPanel({ open: true, mode: 'add', neighbour: null });
-        setEditingRowId(null);
     }, []);
 
     const handleEditRow = useCallback((id: string): void => {
         const neighbour = allRows.find((n) => getNeighbourId(n) === id) || null;
         setPanel({ open: true, mode: 'edit', neighbour });
-        setActiveRowId(id);
-        setEditingRowId(id);
     }, [allRows]);
 
     const handleClosePanel = useCallback((): void => {
         setPanel((prev) => ({ ...prev, open: false }));
-        setEditingRowId(null);
     }, []);
 
     const handleRowClick = useCallback((id: string): void => {
-        setActiveRowId(id);
         const neighbour = allRows.find((n) => getNeighbourId(n) === id) || null;
         const mode = isMergedView ? 'view' : 'edit';
         setPanel({ open: true, mode, neighbour });
-        if (mode === 'edit') {
-            setEditingRowId(id);
-        } else {
-            setEditingRowId(null);
-        }
     }, [allRows, isMergedView]);
 
     const handleSubmitNeighbour = useCallback(async (table: string, entry: Neighbour): Promise<void> => {
@@ -251,15 +243,7 @@ const NeighboursPage: React.FC = () => {
         updateParams({ [QP_TAB]: 'static' });
         fetchTab('static').catch(() => {});
         setPanel({ open: true, mode: 'add', neighbour });
-        setEditingRowId(null);
     }, [updateParams, fetchTab]);
-
-    const syncAgoLabel = useMemo((): string => {
-        const s = Math.max(0, Math.floor((Date.now() - lastSync) / 1000));
-        if (s < 5) return 'just now';
-        if (s < 60) return `${s}s ago`;
-        return `${Math.floor(s / 60)}m ago`;
-    }, [lastSync, tick]);
 
     const displayLabel = (cfg: string): string => cfg === MERGED_TAB ? 'Merged' : cfg;
 
@@ -290,15 +274,15 @@ const NeighboursPage: React.FC = () => {
 
     if (loading) {
         return (
-            <PageLayout header={pageHeader}>
+            <PageLayout header={pageHeader} className="nb-layout">
                 <PageLoader loading size="l" />
             </PageLayout>
         );
     }
 
     return (
-        <PageLayout header={pageHeader}>
-            <div className="yn-page">
+        <PageLayout header={pageHeader} className="nb-layout">
+            <div className="yn-page nb-page">
                 {tables.length === 0 ? (
                     <div className="yn-empty-page">
                         <div className="yn-empty-page__message">No neighbour tables found.</div>
@@ -334,26 +318,18 @@ const NeighboursPage: React.FC = () => {
                                     ) : undefined
                                 }
                             />
-                            <div className={`nb-live-pill${paused ? '' : ' nb-live-pill--on'}`}>
-                                <span className="nb-live-pill__dot" />
-                                <span className="nb-live-pill__label">
-                                    {paused ? 'Paused' : `Live · synced ${syncAgoLabel}`}
-                                </span>
-                                <button
-                                    type="button"
-                                    className="nb-live-pill__btn"
-                                    title={paused ? 'Resume polling' : 'Pause polling'}
-                                    onClick={() => setPaused(!paused)}
-                                >
-                                    {paused ? '▶' : '⏸'}
-                                </button>
-                            </div>
+                        </div>
+                        <div className="nb-toolbar">
+                            <FamilyFilter
+                                value={family}
+                                onChange={(f) => updateParams({ [QP_FAMILY]: f === 'all' ? null : f })}
+                            />
                         </div>
                         <div className="yn-content">
                             <NeighbourTable
                                 rows={visibleRows}
                                 totalCount={allRows.length}
-                                searchActive={search.trim().length > 0}
+                                searchActive={search.trim().length > 0 || family !== 'all'}
                                 readOnlyNote={
                                     isMergedView ? (
                                         <span className="nb-footer-note">
@@ -366,14 +342,12 @@ const NeighboursPage: React.FC = () => {
                                     ) : undefined
                                 }
                                 selectedIds={selectedIds}
-                                activeRowId={activeRowId}
-                                editingRowId={editingRowId}
                                 sortState={sortState}
                                 onSort={handleSort}
                                 onRowClick={handleRowClick}
                                 onEditRow={handleEditRow}
                                 onSelectionChange={setSelectedIds}
-                                emptyMessage={search ? 'No neighbours match your search.' : 'No neighbours.'}
+                                emptyMessage={search || family !== 'all' ? 'No neighbours match the current filters.' : 'No neighbours.'}
                                 canEditTable={canEditTable}
                                 canDeleteTable={canDeleteTable}
                                 onEditTable={() => setEditTableOpen(true)}

--- a/web/src/pages/operators/neighbours/useNeighbours.ts
+++ b/web/src/pages/operators/neighbours/useNeighbours.ts
@@ -12,9 +12,6 @@ export interface UseNeighboursResult {
     cache: Map<string, Neighbour[]>;
     loading: boolean;
     activeTabRef: React.MutableRefObject<string>;
-    lastSync: number;
-    paused: boolean;
-    setPaused: (paused: boolean) => void;
     addNeighbour: (table: string, entry: Neighbour) => Promise<void>;
     updateNeighbour: (table: string, entry: Neighbour) => Promise<void>;
     removeNeighbours: (table: string, nextHopWires: (IPAddressWire | undefined)[]) => Promise<void>;
@@ -30,8 +27,6 @@ export const useNeighbours = (activeTab: string): UseNeighboursResult => {
     const [tables, setTables] = useState<NeighbourTableInfo[]>([]);
     const [cache, setCache] = useState<Map<string, Neighbour[]>>(new Map());
     const [loading, setLoading] = useState(true);
-    const [lastSync, setLastSync] = useState<number>(() => Date.now());
-    const [paused, setPaused] = useState(false);
 
     const activeTabRef = useRef(activeTab);
     activeTabRef.current = activeTab;
@@ -108,19 +103,18 @@ export const useNeighbours = (activeTab: string): UseNeighboursResult => {
     }, [loadTables, prefetchAll]);
 
     useEffect(() => {
-        if (loading || paused) return;
+        if (loading) return;
         const intervalId = window.setInterval(async () => {
             const tab = activeTabRef.current;
             try {
                 await fetchTab(tab);
-                setLastSync(Date.now());
             } catch {
                 // fetchTab already toasted; swallow here to avoid unhandled rejection.
             }
             loadTables();
         }, REFRESH_INTERVAL_MS);
         return () => window.clearInterval(intervalId);
-    }, [loading, paused, fetchTab, loadTables]);
+    }, [loading, fetchTab, loadTables]);
 
     const addNeighbour = useCallback(async (table: string, entry: Neighbour): Promise<void> => {
         try {
@@ -197,9 +191,6 @@ export const useNeighbours = (activeTab: string): UseNeighboursResult => {
         cache,
         loading,
         activeTabRef,
-        lastSync,
-        paused,
-        setPaused,
         addNeighbour,
         updateNeighbour,
         removeNeighbours,

--- a/web/src/pages/operators/route/RIBTable.tsx
+++ b/web/src/pages/operators/route/RIBTable.tsx
@@ -1,28 +1,15 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import { Checkbox } from '@gravity-ui/uikit';
-import { useRowHoverOverlay, RowHoverEditOverlay } from '../../_shared/draft';
+import React from 'react';
 import type { Route } from '../../../api/routes';
 import { ipAddressToString } from '../../../utils/netip';
-import { useContainerHeight } from '../../../hooks/useContainerHeight';
 import { getRouteId } from './utils';
 import { BestPill, SourceChip, FamilyBadge, ConflictBadge } from './cells';
 import type { RouteSortableColumn, RouteSortState } from './types';
-
-const ROW_HEIGHT = 44;
-const HEADER_HEIGHT = 40;
-const FOOTER_HEIGHT = 28;
-const OVERSCAN = 15;
+import { VirtualTable } from '../../_shared/table/VirtualTable';
+import type { Column, SortState } from '../../_shared/table/VirtualTable';
 
 /** Minimum total width before a horizontal scrollbar appears on very narrow viewports. */
 const RIB_MIN_WIDTH = 860;
 
-/** CSS grid template for both the header row and each data row. */
-const GRID_TEMPLATE = '38px 52px minmax(190px, 1.3fr) 150px minmax(120px, 0.8fr) 92px 64px 78px 116px';
-const GRID_COLUMN_GAP = 14;
-
-/** @deprecated Use GRID_TEMPLATE instead. Kept for external callers. */
-export const RIB_TOTAL_WIDTH = RIB_MIN_WIDTH;
 
 export interface RIBTableProps {
     rows: Route[];
@@ -37,65 +24,6 @@ export interface RIBTableProps {
     flashRowId?: string | null;
 }
 
-interface SortButtonProps {
-    col: RouteSortableColumn;
-    label: string;
-    sortState: RouteSortState;
-    onSort: (col: RouteSortableColumn) => void;
-}
-
-/** SVG sort icon — double arrow (unsorted), up arrow (asc), down arrow (desc). */
-const SortIcon: React.FC<{ variant: 'sort' | 'sortUp' | 'sortDown'; active: boolean }> = ({ variant, active }) => {
-    const paths: Record<typeof variant, string[]> = {
-        sort: ['M8 3v18', 'M5 8l3-3 3 3', 'M16 21V3', 'M13 16l3 3 3-3'],
-        sortUp: ['M8 5l4-4 4 4', 'M12 1v22'],
-        sortDown: ['M8 19l4 4 4-4', 'M12 23V1'],
-    };
-    return (
-        <svg
-            width={12}
-            height={12}
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            style={{ display: 'block', flexShrink: 0, opacity: active ? 1 : 0.5 }}
-        >
-            {paths[variant].map((d) => <path key={d} d={d} />)}
-        </svg>
-    );
-};
-
-const SortButton: React.FC<SortButtonProps> = ({ col, label, sortState, onSort }) => {
-    const isActive = sortState.column === col;
-    const iconVariant = isActive
-        ? (sortState.direction === 'asc' ? 'sortUp' : 'sortDown')
-        : 'sort';
-    return (
-        <button
-            type="button"
-            style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                background: 'none',
-                border: 'none',
-                cursor: 'pointer',
-                color: isActive ? 'var(--yn-accent)' : 'inherit',
-                padding: 0,
-                width: '100%',
-                minWidth: 0,
-            }}
-            onClick={() => onSort(col)}
-        >
-            <span className="yn-th-text" style={{ color: isActive ? 'var(--yn-accent)' : undefined }}>{label}</span>
-            <SortIcon variant={iconVariant} active={isActive} />
-        </button>
-    );
-};
-
 /** Read-only virtualized table for the RIB (Route Information Base). */
 export const RIBTable: React.FC<RIBTableProps> = ({
     rows,
@@ -109,216 +37,126 @@ export const RIBTable: React.FC<RIBTableProps> = ({
     conflictMap,
     flashRowId,
 }) => {
-    const scrollRef = useRef<HTMLDivElement>(null);
-    const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT);
-    const [flashingId, setFlashingId] = React.useState<string | null>(null);
+    const columns: Column<Route>[] = [
+        {
+            key: 'prefix',
+            header: 'Prefix',
+            gridTrack: 'minmax(190px, 1.3fr)',
+            sortKey: 'prefix',
+            renderCell: (route) => {
+                const prefixConflictCount = conflictMap?.get(route.prefix || '') ?? 1;
+                return (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 9, overflow: 'hidden' }}>
+                        {route.prefix && <FamilyBadge prefix={route.prefix} />}
+                        <span
+                            className="yn-cell-mono"
+                            style={{
+                                overflow: 'hidden',
+                                textOverflow: 'ellipsis',
+                                whiteSpace: 'nowrap',
+                                flexShrink: 1,
+                                fontSize: 13.5,
+                                fontWeight: route.is_best ? 600 : 500,
+                                color: route.is_best ? 'var(--yn-text)' : 'var(--yn-text-2)',
+                            }}
+                        >{route.prefix || '-'}</span>
+                        {prefixConflictCount > 1 && <ConflictBadge count={prefixConflictCount} />}
+                    </div>
+                );
+            },
+        },
+        {
+            key: 'next_hop',
+            header: 'Next Hop',
+            gridTrack: '150px',
+            sortKey: 'next_hop',
+            renderCell: (route) => (
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-2)' }}>{ipAddressToString(route.next_hop) || '-'}</span>
+                </div>
+            ),
+        },
+        {
+            key: 'peer',
+            header: 'Peer',
+            gridTrack: 'minmax(120px, 0.8fr)',
+            sortKey: 'peer',
+            renderCell: (route) => (
+                <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-3)' }}>{ipAddressToString(route.peer) || '-'}</span>
+                </div>
+            ),
+        },
+        {
+            key: 'is_best',
+            header: 'Best',
+            gridTrack: '92px',
+            sortKey: 'is_best',
+            renderCell: (route) => (
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <BestPill isBest={route.is_best ?? false} />
+                </div>
+            ),
+        },
+        {
+            key: 'pref',
+            header: 'Pref',
+            gridTrack: '64px',
+            sortKey: 'pref',
+            renderCell: (route) => (
+                <span className="yn-cell-mono" style={{ fontSize: 12.5, color: route.pref != null ? 'var(--yn-text-2)' : 'var(--yn-text-3)' }}>{route.pref ?? '—'}</span>
+            ),
+        },
+        {
+            key: 'as_path_len',
+            header: 'AS Path',
+            gridTrack: '78px',
+            sortKey: 'as_path_len',
+            renderCell: (route) => (
+                <span className="yn-cell-mono" style={{ fontSize: 12.5, color: route.as_path_len != null ? 'var(--yn-text-2)' : 'var(--yn-text-3)' }}>{route.as_path_len ?? '—'}</span>
+            ),
+        },
+        {
+            key: 'source',
+            header: 'Source',
+            gridTrack: '116px',
+            sortKey: 'source',
+            renderCell: (route) => (
+                <div style={{ overflow: 'hidden' }}>
+                    <SourceChip source={route.source} />
+                </div>
+            ),
+        },
+    ];
 
-    const {
-        hoveredRow,
-        overlayTopOffset,
-        handleHoverChange,
-        handleOverlayMouseEnter,
-        handleOverlayMouseLeave,
-        attachScrollEl,
-    } = useRowHoverOverlay<Route>(HEADER_HEIGHT);
+    const adaptedSortState: SortState<string> = {
+        column: sortState.column,
+        direction: sortState.direction,
+    };
 
-    const setScrollRef = useCallback((el: HTMLDivElement | null): void => {
-        (scrollRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
-        attachScrollEl(el);
-    }, [attachScrollEl]);
-
-    const rowVirtualizer = useVirtualizer({
-        count: rows.length,
-        getScrollElement: () => scrollRef.current,
-        estimateSize: () => ROW_HEIGHT,
-        overscan: OVERSCAN,
-    });
-
-    useEffect(() => {
-        if (!flashRowId) return;
-        const idx = rows.findIndex((r) => getRouteId(r) === flashRowId);
-        if (idx >= 0) {
-            rowVirtualizer.scrollToIndex(idx, { align: 'center' });
-        }
-        setFlashingId(flashRowId);
-        const t = setTimeout(() => setFlashingId(null), 1200);
-        return () => clearTimeout(t);
-    }, [flashRowId, rows, rowVirtualizer]);
-
-    const isAllSelected = rows.length > 0 && rows.every((r) => selectedIds.has(getRouteId(r)));
-    const isIndeterminate = !isAllSelected && rows.some((r) => selectedIds.has(getRouteId(r)));
-
-    const handleSelectAll = useCallback((checked: boolean): void => {
-        onSelectionChange(checked ? new Set(rows.map(getRouteId)) : new Set());
-    }, [rows, onSelectionChange]);
-
-    const handleRowCheckbox = useCallback((id: string, checked: boolean): void => {
-        const next = new Set(selectedIds);
-        if (checked) next.add(id); else next.delete(id);
-        onSelectionChange(next);
-    }, [selectedIds, onSelectionChange]);
-
-    const handleOverlayEdit = useCallback((): void => {
-        if (hoveredRow) {
-            onEditRow(getRouteId(hoveredRow));
-        }
-    }, [hoveredRow, onEditRow]);
-
-    const virtualRows = rowVirtualizer.getVirtualItems();
-
-    const footerText = useMemo(() => {
-        if (rows.length === 0 || virtualRows.length === 0) return '';
-        const first = virtualRows[0].index + 1;
-        const last = virtualRows[virtualRows.length - 1].index + 1;
-        return `Shown ${first.toLocaleString()}–${last.toLocaleString()} of ${rows.length.toLocaleString()}`;
-    }, [virtualRows, rows.length]);
-
-    const gridStyle: React.CSSProperties = {
-        display: 'grid',
-        gridTemplateColumns: GRID_TEMPLATE,
-        columnGap: GRID_COLUMN_GAP,
-        alignItems: 'center',
-        paddingLeft: 16,
-        paddingRight: 22,
-        minWidth: RIB_MIN_WIDTH,
+    const handleSort = (key: string): void => {
+        onSort(key as RouteSortableColumn);
     };
 
     return (
-        <div className="yn-table-wrap">
-            <div className="yn-table-header-row">
-                <div
-                    className="yn-vtbl-header"
-                    style={{ ...gridStyle, height: HEADER_HEIGHT, flex: '1 1 auto', overflow: 'hidden' }}
-                >
-                    <div
-                        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                        onClick={(e) => e.stopPropagation()}
-                    >
-                        <Checkbox checked={isAllSelected} indeterminate={isIndeterminate} onUpdate={handleSelectAll} size="m" />
-                    </div>
-                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                        <span className="yn-th-text">#</span>
-                    </div>
-                    <SortButton col="prefix" label="Prefix" sortState={sortState} onSort={onSort} />
-                    <SortButton col="next_hop" label="Next Hop" sortState={sortState} onSort={onSort} />
-                    <SortButton col="peer" label="Peer" sortState={sortState} onSort={onSort} />
-                    <SortButton col="is_best" label="Best" sortState={sortState} onSort={onSort} />
-                    <SortButton col="pref" label="Pref" sortState={sortState} onSort={onSort} />
-                    <SortButton col="as_path_len" label="AS Path" sortState={sortState} onSort={onSort} />
-                    <SortButton col="source" label="Source" sortState={sortState} onSort={onSort} />
-                </div>
-            </div>
-
-            <div
-                ref={setScrollRef}
-                className="yn-vtbl-body"
-                style={{ flex: '0 0 auto', height: bodyHeight, overflowY: 'auto' }}
-            >
-                {rows.length === 0 ? (
-                    <div className="yn-table-empty">{emptyMessage}</div>
-                ) : (
-                    <div style={{ height: rowVirtualizer.getTotalSize(), minWidth: RIB_MIN_WIDTH, position: 'relative' }}>
-                        {virtualRows.map((virtualRow) => {
-                            const route = rows[virtualRow.index];
-                            if (!route) return null;
-                            const id = getRouteId(route);
-                            const isSelected = selectedIds.has(id);
-                            const isFlashing = flashingId === id;
-                            let rowBg = 'transparent';
-                            if (isFlashing) rowBg = 'color-mix(in srgb, var(--g-color-text-positive) 14%, transparent)';
-                            else if (isSelected) rowBg = 'var(--yn-accent-soft)';
-                            const prefixConflictCount = conflictMap?.get(route.prefix || '') ?? 1;
-                            return (
-                                <div
-                                    key={id}
-                                    className={`yn-vrow${isSelected ? ' yn-vrow--selected' : ''}`}
-                                    data-row-id={id}
-                                    onMouseEnter={() => handleHoverChange(route, virtualRow.start)}
-                                    onMouseLeave={() => handleHoverChange(null, 0)}
-                                    style={{
-                                        position: 'absolute',
-                                        top: virtualRow.start,
-                                        left: 0,
-                                        height: ROW_HEIGHT,
-                                        width: '100%',
-                                        borderBottom: '1px solid var(--yn-line)',
-                                        backgroundColor: rowBg,
-                                        cursor: 'default',
-                                        ...gridStyle,
-                                    }}
-                                >
-                                    <div
-                                        style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                                        onClick={(e) => e.stopPropagation()}
-                                    >
-                                        <Checkbox
-                                            checked={isSelected}
-                                            onUpdate={(checked) => handleRowCheckbox(id, checked)}
-                                            size="m"
-                                        />
-                                    </div>
-                                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--yn-text-3)', fontVariantNumeric: 'tabular-nums', fontFamily: 'var(--yn-font-mono)' }}>
-                                        <span style={{ fontSize: 12.5 }}>{virtualRow.index + 1}</span>
-                                    </div>
-                                    <div style={{ display: 'flex', alignItems: 'center', gap: 9, overflow: 'hidden' }}>
-                                        {route.prefix && <FamilyBadge prefix={route.prefix} />}
-                                        <span
-                                            className="yn-cell-mono"
-                                            style={{
-                                                overflow: 'hidden',
-                                                textOverflow: 'ellipsis',
-                                                whiteSpace: 'nowrap',
-                                                flexShrink: 1,
-                                                fontSize: 13.5,
-                                                fontWeight: route.is_best ? 600 : 500,
-                                                color: route.is_best ? 'var(--yn-text)' : 'var(--yn-text-2)',
-                                            }}
-                                        >{route.prefix || '-'}</span>
-                                        {prefixConflictCount > 1 && <ConflictBadge count={prefixConflictCount} />}
-                                    </div>
-                                    <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-2)' }}>{ipAddressToString(route.next_hop) || '-'}</span>
-                                    </div>
-                                    <div style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                                        <span className="yn-cell-mono" style={{ fontSize: 12.5, color: 'var(--yn-text-3)' }}>{ipAddressToString(route.peer) || '-'}</span>
-                                    </div>
-                                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                                        <BestPill isBest={route.is_best ?? false} />
-                                    </div>
-                                    <div>
-                                        <span className="yn-cell-mono" style={{ fontSize: 12.5, color: route.pref != null ? 'var(--yn-text-2)' : 'var(--yn-text-3)' }}>{route.pref ?? '—'}</span>
-                                    </div>
-                                    <div>
-                                        <span className="yn-cell-mono" style={{ fontSize: 12.5, color: route.as_path_len != null ? 'var(--yn-text-2)' : 'var(--yn-text-3)' }}>{route.as_path_len ?? '—'}</span>
-                                    </div>
-                                    <div style={{ overflow: 'hidden' }}>
-                                        <SourceChip source={route.source} />
-                                    </div>
-                                </div>
-                            );
-                        })}
-                    </div>
-                )}
-            </div>
-
-            <div className="yn-vtbl-footer" style={{ height: FOOTER_HEIGHT }}>
-                <span className="yn-toolbar__count">{footerText}</span>
-            </div>
-
-            {hoveredRow !== null && (
-                <RowHoverEditOverlay
-                    top={overlayTopOffset}
-                    rowHeight={ROW_HEIGHT}
-                    onEdit={handleOverlayEdit}
-                    editAriaLabel={`Edit route ${rows.indexOf(hoveredRow) + 1}`}
-                    editTitle="Edit route"
-                    onDelete={() => onDeleteRow(getRouteId(hoveredRow))}
-                    deleteAriaLabel={`Delete route ${hoveredRow.prefix || ''}`.trim()}
-                    deleteTitle="Delete route"
-                    onMouseEnter={handleOverlayMouseEnter}
-                    onMouseLeave={handleOverlayMouseLeave}
-                />
-            )}
-        </div>
+        <VirtualTable<Route>
+            rows={rows}
+            columns={columns}
+            getRowId={getRouteId}
+            emptyMessage={emptyMessage}
+            selectedIds={selectedIds}
+            onSelectionChange={onSelectionChange}
+            sortState={adaptedSortState}
+            onSort={handleSort}
+            onEditRow={onEditRow}
+            onDeleteRow={onDeleteRow}
+            canEditRow={true}
+            editAriaLabel={(_route, idx) => `Edit route ${idx + 1}`}
+            deleteAriaLabel={(route) => `Delete route ${route.prefix || ''}`.trim()}
+            editTitle="Edit route"
+            deleteTitle="Delete route"
+            flashRowId={flashRowId}
+            minWidth={RIB_MIN_WIDTH}
+        />
     );
 };

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -14,6 +14,7 @@ import CommandPalette from './CommandPalette';
 import LookupDrawer from './LookupDrawer';
 import { getRouteId, sortComparators, planRouteSubmit, groupByPrefix, filterByFamily } from './utils';
 import type { RouteSortState, RouteSortableColumn, IPFamily } from './types';
+import { FamilyFilter } from '../../_shared/table/FamilyFilter';
 import '../../../styles/draft-page.scss';
 import './route.scss';
 
@@ -344,18 +345,7 @@ const RoutePage: React.FC = () => {
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
                         <div className="ro-toolbar">
-                            <div className="ro-seg">
-                                {(['all', 'v4', 'v6'] as IPFamily[]).map((f) => (
-                                    <button
-                                        key={f}
-                                        type="button"
-                                        className={`ro-seg__btn${family === f ? ' ro-seg__btn--active' : ''}`}
-                                        onClick={() => setFamily(f)}
-                                    >
-                                        {f === 'all' ? 'All' : f === 'v4' ? 'IPv4' : 'IPv6'}
-                                    </button>
-                                ))}
-                            </div>
+                            <FamilyFilter value={family} onChange={setFamily} />
                             <button
                                 type="button"
                                 className={`ro-chip ro-chip--best${bestOnly ? ' ro-chip--active' : ''}`}

--- a/web/src/pages/operators/route/cells.tsx
+++ b/web/src/pages/operators/route/cells.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ROUTE_SOURCES } from './utils';
+import { FamilyBadge as SharedFamilyBadge } from '../../_shared/table/cells';
 
 /** Inline checkmark SVG for the Best column. */
 const CheckIcon: React.FC = () => (
@@ -83,26 +84,9 @@ export const SourceChip: React.FC<{ source: number | undefined }> = ({ source })
 };
 
 /** Small v4/v6 family badge derived from the prefix string. */
-export const FamilyBadge: React.FC<{ prefix: string }> = ({ prefix }) => {
-    const isV6 = prefix.includes(':');
-    return (
-        <span
-            style={{
-                display: 'inline-block',
-                fontSize: 9.5,
-                fontWeight: 700,
-                fontFamily: 'var(--yn-font-mono)',
-                color: isV6 ? 'var(--g-color-text-info)' : 'var(--g-color-text-warning)',
-                opacity: 0.8,
-                width: 16,
-                flexShrink: 0,
-                whiteSpace: 'nowrap',
-            }}
-        >
-            {isV6 ? 'v6' : 'v4'}
-        </span>
-    );
-};
+export const FamilyBadge: React.FC<{ prefix: string }> = ({ prefix }) => (
+    <SharedFamilyBadge address={prefix} />
+);
 
 /** Badge shown when a prefix has multiple candidate routes. */
 export const ConflictBadge: React.FC<{ count: number }> = ({ count }) => {

--- a/web/src/pages/operators/route/route.scss
+++ b/web/src/pages/operators/route/route.scss
@@ -8,12 +8,8 @@
 // ─── Toolbar ─────────────────────────────────────────────────────────────────
 
 .ro-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 12px 20px;
+    @include yn-toolbar;
     flex-wrap: wrap;
-    flex-shrink: 0;
     border-bottom: 1px solid var(--yn-line);
 }
 
@@ -22,49 +18,6 @@
     align-items: center;
     gap: 8px;
     margin-left: auto;
-}
-
-// ─── Segmented family filter ──────────────────────────────────────────────────
-
-.ro-seg {
-    display: inline-flex;
-    align-items: center;
-    background: var(--yn-bg-2);
-    border-radius: var(--yn-r-md);
-    padding: 3px;
-    gap: 2px;
-    box-shadow: inset 0 0 0 1px var(--yn-line-2);
-    flex-shrink: 0;
-}
-
-.ro-seg__btn {
-    height: 26px;
-    padding: 0 12px;
-    font-size: 12.5px;
-    font-weight: 600;
-    color: var(--yn-text-2);
-    background: transparent;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-    transition: all 0.12s;
-    white-space: nowrap;
-
-    &:hover:not(.ro-seg__btn--active) {
-        background: var(--yn-bg-3);
-        color: var(--yn-text);
-    }
-
-    &--active {
-        background: var(--yn-accent);
-        color: var(--yn-bg-3);
-        font-weight: 600;
-
-        &:hover {
-            background: var(--yn-accent);
-            color: var(--yn-bg-3);
-        }
-    }
 }
 
 // ─── Toggle chips ─────────────────────────────────────────────────────────────

--- a/web/src/pages/operators/route/types.ts
+++ b/web/src/pages/operators/route/types.ts
@@ -1,6 +1,6 @@
 export type RouteSortableColumn = 'prefix' | 'next_hop' | 'peer' | 'is_best' | 'pref' | 'as_path_len' | 'source';
 export type SortDirection = 'asc' | 'desc';
-export type IPFamily = 'all' | 'v4' | 'v6';
+export type { IPFamily } from '../../_shared/table/FamilyFilter';
 
 export interface RouteSortState {
     column: RouteSortableColumn | null;

--- a/web/src/styles/_mixins.scss
+++ b/web/src/styles/_mixins.scss
@@ -29,3 +29,12 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+/** Base layout for page toolbar rows — shared by ro-toolbar and nb-toolbar. */
+@mixin yn-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 20px;
+    flex-shrink: 0;
+}

--- a/web/src/styles/draft-page.scss
+++ b/web/src/styles/draft-page.scss
@@ -272,6 +272,9 @@
 }
 
 // Sticky header row for the virtualized table.
+// Base: flex row with 4px L/R padding — consumed by VirtualDraftTable (FIBTable,
+// PrefixTable) and the legacy ACL/Forward RuleTables that place header cells as
+// direct flex children.
 .yn-vtbl-header {
     display: flex;
     align-items: center;
@@ -280,6 +283,21 @@
     flex: 1 1 auto;
     overflow-x: auto;
     overflow-y: hidden;
+}
+
+// Modifier for the VirtualTable grid shell.  The shell sets overflow/height inline;
+// this resets the base flex/padding so the inner CSS-grid aligns pixel-perfect
+// with the body rows (which also have zero outer horizontal padding).
+// scrollbar-width:none hides the bar while allowing scrollLeft sync via JS.
+.yn-vtbl-header--grid {
+    display: block;
+    padding-left: 0;
+    padding-right: 0;
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+        display: none;
+    }
 }
 
 .yn-th-text {
@@ -923,19 +941,6 @@
 // Neighbours page extensions.
 // Scoped to .yn-page to avoid bleeding into other pages.
 
-// Neighbours-specific header modifier — constrains the header to the visible
-// flex width (no minWidth override) and hides its scrollbar, relying on JS
-// scrollLeft sync from the body scroll event to keep columns aligned.
-.nb-vtbl-header {
-    overflow-x: scroll;
-    min-width: 0 !important;
-    scrollbar-width: none; // Firefox
-
-    &::-webkit-scrollbar {
-        display: none; // Chrome/Safari/Edge
-    }
-}
-
 // Right-side footer note (read-only warning) for the neighbours table.
 .nb-footer-note {
     display: inline-flex;
@@ -946,7 +951,7 @@
     white-space: nowrap;
 }
 
-// Tabs row wrapper — aligns ConfigTabStrip with the live pill.
+// Tabs row wrapper — contains the ConfigTabStrip for neighbours.
 .yn-tabs-row {
     display: flex;
     align-items: center;
@@ -1127,72 +1132,6 @@
     }
 
     strong { color: var(--yn-text); font-weight: 600; }
-}
-
-// Live freshness pill.
-.nb-live-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    height: 30px;
-    padding: 0 10px;
-    border-radius: var(--yn-r-md);
-    border: 1px solid var(--yn-line-2);
-    background: var(--yn-panel);
-    font-size: 11.5px;
-    color: var(--yn-text-3);
-    flex-shrink: 0;
-
-    &__dot {
-        width: 7px;
-        height: 7px;
-        border-radius: 50%;
-        background: var(--yn-text-3);
-        flex-shrink: 0;
-        position: relative;
-    }
-
-    &__label { white-space: nowrap; }
-
-    &__btn {
-        display: grid;
-        place-items: center;
-        width: 18px;
-        height: 18px;
-        border-radius: var(--yn-r-sm);
-        color: var(--yn-text-3);
-        background: none;
-        border: none;
-        cursor: pointer;
-        font-size: 11px;
-        padding: 0;
-
-        &:hover { background: var(--yn-bg-2); color: var(--yn-text); }
-    }
-
-    &--on {
-        .nb-live-pill__dot {
-            background: var(--g-color-text-positive);
-
-            &::after {
-                content: '';
-                position: absolute;
-                inset: -4px;
-                border-radius: 50%;
-                background: var(--g-color-text-positive);
-                opacity: 0.35;
-                animation: nb-pulse 1.8s ease-out infinite;
-            }
-        }
-
-        .nb-live-pill__label { color: var(--yn-text-2); }
-    }
-}
-
-@keyframes nb-pulse {
-    0%   { transform: scale(0.6); opacity: 0.5; }
-    70%  { transform: scale(1.9); opacity: 0; }
-    100% { opacity: 0; }
 }
 
 // Detail panel — read-only aside using existing yn-drawer chrome.
@@ -1411,4 +1350,125 @@
     &__diff {
         color: var(--g-color-text-warning) !important;
     }
+}
+
+// Neighbours page flush + borderless-tab overrides.
+// Mirrors the .ro-page treatment in route.scss, scoped to .nb-page only.
+
+.yn-page.nb-page {
+    background: var(--yn-page-bg);
+}
+
+.nb-page .yn-tabs-row {
+    border-bottom: none;
+}
+
+.nb-page .yn-tabs-row .yn-tabs {
+    border-bottom: none;
+}
+
+.nb-page .yn-tab--active::after {
+    height: 3px;
+}
+
+.nb-page .yn-tab--active .yn-tab__count {
+    color: var(--yn-accent);
+    background: var(--yn-accent-soft);
+}
+
+.nb-page .yn-content {
+    padding: 0;
+}
+
+.nb-page .yn-table-wrap {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+}
+
+.nb-page .yn-table-header-row {
+    background: transparent;
+    border-top: 1px solid var(--yn-line-2);
+}
+
+.nb-page .yn-vtbl-footer {
+    background: transparent;
+}
+
+// Surface color — mirrors the ro-layout/ro-page pattern from route.scss, scoped to neighbours.
+// The --nb-surface-bg token cascades from .nb-layout to both the header subtree
+// and the .nb-page content subtree, keeping both on the same flat #1C1814 plane.
+.nb-layout {
+    --nb-surface-bg: #1C1814;
+}
+
+// Header sits outside .yn-page so --yn-* tokens are not in scope there.
+// Match route page: same background (#1C1814) and same rendered height (64px).
+.nb-layout .page-layout__header {
+    background: var(--nb-surface-bg);
+    min-height: 64px;
+}
+
+// Two-class specificity beats `.yn-page { background: var(--yn-page-bg) }`.
+.yn-page.nb-page {
+    background: var(--nb-surface-bg);
+}
+
+// Tab strip and tabs-row sit on the same flat surface.
+.nb-page .yn-tabs-row {
+    background: var(--nb-surface-bg);
+}
+
+.nb-page .yn-tabs {
+    background: var(--nb-surface-bg);
+}
+
+// Shared segmented family filter — yn-seg / yn-seg__btn.
+// Used by both the route page and the neighbours page.
+.yn-seg {
+    display: inline-flex;
+    align-items: center;
+    background: var(--yn-bg-2);
+    border-radius: var(--yn-r-md);
+    padding: 3px;
+    gap: 2px;
+    box-shadow: inset 0 0 0 1px var(--yn-line-2);
+    flex-shrink: 0;
+}
+
+.yn-seg__btn {
+    height: 26px;
+    padding: 0 12px;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--yn-text-2);
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.12s;
+    white-space: nowrap;
+
+    &:hover:not(.yn-seg__btn--active) {
+        background: var(--yn-bg-3);
+        color: var(--yn-text);
+    }
+
+    &--active {
+        background: var(--yn-accent);
+        color: var(--yn-bg-3);
+        font-weight: 600;
+
+        &:hover {
+            background: var(--yn-accent);
+            color: var(--yn-bg-3);
+        }
+    }
+}
+
+// Neighbours toolbar row — hosts the family filter below the tabs-row.
+.nb-toolbar {
+    @include yn-toolbar;
+    border-bottom: 1px solid var(--yn-line);
+    background: var(--nb-surface-bg, var(--yn-page-bg));
 }


### PR DESCRIPTION
Extracts a shared virtualized table shell and rebuilds the route and neighbours tables on top of it, removing the duplicated virtualization, selection, sort, and hover-edit mechanics.

Redesigns the neighbours page to match the route operator page: grid columns, sort icons, flush layout, borderless tabs, and the same flat surface and header height.

Adds an IP-family filter and v4/v6 badges to the neighbours table, sharing the family controls and badge with the route page. Removes the neighbours pause control in favor of always-on background polling.