### PR TITLE
refactor(web): share a dot-badge for route source and neighbour state

### DIFF
--- a/web/src/pages/_shared/table/DotBadge.tsx
+++ b/web/src/pages/_shared/table/DotBadge.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Tooltip } from '@gravity-ui/uikit';
+
+export interface DotBadgeProps {
+    label: string;
+    color: string;
+    tooltip?: React.ReactNode;
+    tooltipClassName?: string;
+}
+
+/** Colored pill badge with a leading dot, themed via a single `color` prop. */
+export const DotBadge: React.FC<DotBadgeProps> = ({ label, color, tooltip, tooltipClassName }) => {
+    const pill = (
+        <span
+            className="yn-dot-badge"
+            style={{
+                '--yn-dotb-c': color,
+                '--yn-dotb-bg': `color-mix(in srgb, ${color} 14%, transparent)`,
+                '--yn-dotb-bd': `color-mix(in srgb, ${color} 32%, transparent)`,
+            } as React.CSSProperties}
+        >
+            <span className="yn-dot-badge__dot" />
+            {label}
+        </span>
+    );
+
+    if (!tooltip) return pill;
+
+    return (
+        <Tooltip content={tooltip} openDelay={200} placement="bottom" className={tooltipClassName}>
+            {pill}
+        </Tooltip>
+    );
+};

--- a/web/src/pages/operators/neighbours/NeighbourPanel.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Bulb, CircleInfo, Layers } from '@gravity-ui/icons';
 import { Select } from '@gravity-ui/uikit';
+import { DotBadge } from '../../_shared/table/DotBadge';
 import { ipAddressToString, stringToIPAddress } from '../../../utils/netip';
 import { formatUnixSeconds } from '../../../utils';
 import type { Neighbour, NeighbourTableInfo } from '../../../api/neighbours';
@@ -78,19 +79,7 @@ interface StateBadgeInlineProps {
 const StateBadgeInline: React.FC<StateBadgeInlineProps> = ({ state }) => {
     const name = nudStateToName(state);
     const meta = getStateMeta(state);
-    return (
-        <span
-            className="nb-state-badge"
-            style={{
-                '--nb-stb-c': meta.color,
-                '--nb-stb-bg': `color-mix(in srgb, ${meta.color} 14%, transparent)`,
-                '--nb-stb-bd': `color-mix(in srgb, ${meta.color} 32%, transparent)`,
-            } as React.CSSProperties}
-        >
-            <span className="nb-state-badge__dot" />
-            {name}
-        </span>
-    );
+    return <DotBadge label={name} color={meta.color} />;
 };
 
 export type NeighbourPanelMode = 'add' | 'edit' | 'view';

--- a/web/src/pages/operators/neighbours/NeighbourTable.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Tooltip } from '@gravity-ui/uikit';
 import { Pencil, TrashBin } from '@gravity-ui/icons';
+import { Tooltip } from '@gravity-ui/uikit';
+import { DotBadge } from '../../_shared/table/DotBadge';
 import type { Neighbour, NeighbourTableInfo } from '../../../api/neighbours';
 import { formatUnixSeconds } from '../../../utils';
 import { ipAddressToString } from '../../../utils/netip';
@@ -50,23 +51,7 @@ const StateBadge: React.FC<StateBadgeProps> = ({ state, withTooltip }) => {
     const name = nudStateToName(state);
     const meta = getStateMeta(state);
 
-    const badge = (
-        <span
-            className="nb-state-badge"
-            style={{
-                '--nb-stb-c': meta.color,
-                '--nb-stb-bg': `color-mix(in srgb, ${meta.color} 14%, transparent)`,
-                '--nb-stb-bd': `color-mix(in srgb, ${meta.color} 32%, transparent)`,
-            } as React.CSSProperties}
-        >
-            <span className="nb-state-badge__dot" />
-            {name}
-        </span>
-    );
-
-    if (!withTooltip) return badge;
-
-    const tooltipContent = (
+    const tooltipContent = withTooltip ? (
         <div className="nb-state-tip">
             <div className="nb-state-tip__head">
                 <span className="nb-state-tip__dot" style={{ background: meta.color }} />
@@ -77,12 +62,15 @@ const StateBadge: React.FC<StateBadgeProps> = ({ state, withTooltip }) => {
                 <strong>What to do:</strong> {meta.action}
             </div>
         </div>
-    );
+    ) : undefined;
 
     return (
-        <Tooltip content={tooltipContent} openDelay={200} placement="bottom" className="nb-state-tip-popup">
-            {badge}
-        </Tooltip>
+        <DotBadge
+            label={name}
+            color={meta.color}
+            tooltip={tooltipContent}
+            tooltipClassName={withTooltip ? 'nb-state-tip-popup' : undefined}
+        />
     );
 };
 

--- a/web/src/pages/operators/route/cells.tsx
+++ b/web/src/pages/operators/route/cells.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ROUTE_SOURCES } from './utils';
 import { FamilyBadge as SharedFamilyBadge } from '../../_shared/table/cells';
+import { DotBadge } from '../../_shared/table/DotBadge';
 
 /** Inline checkmark SVG for the Best column. */
 const CheckIcon: React.FC = () => (
@@ -31,54 +32,14 @@ export const BestPill: React.FC<{ isBest: boolean }> = ({ isBest }) => {
     );
 };
 
-/** Source chip: BIRD in blue, Static in amber, Unknown muted — with leading colored dot. */
+/** Source chip: BIRD in blue, Static in amber, Unknown/undefined renders an em-dash. */
 export const SourceChip: React.FC<{ source: number | undefined }> = ({ source }) => {
     const label = source !== undefined ? (ROUTE_SOURCES[source] ?? '::') : '—';
     if (label === 'BIRD') {
-        return (
-            <span
-                style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 6,
-                    padding: '2px 9px 2px 7px',
-                    borderRadius: 999,
-                    fontSize: 11.5,
-                    fontWeight: 600,
-                    letterSpacing: '0.02em',
-                    color: 'var(--g-color-text-info)',
-                    background: 'color-mix(in srgb, var(--g-color-text-info) 12%, transparent)',
-                    whiteSpace: 'nowrap',
-                    fontFamily: 'var(--yn-font-mono)',
-                }}
-            >
-                <span style={{ width: 5, height: 5, borderRadius: 999, background: 'var(--g-color-text-info)', flexShrink: 0 }} />
-                {label}
-            </span>
-        );
+        return <DotBadge label="BIRD" color="var(--g-color-text-info)" />;
     }
     if (label === 'Static') {
-        return (
-            <span
-                style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 6,
-                    padding: '2px 9px 2px 7px',
-                    borderRadius: 999,
-                    fontSize: 11.5,
-                    fontWeight: 600,
-                    letterSpacing: '0.02em',
-                    color: 'var(--yn-accent)',
-                    background: 'var(--yn-accent-soft)',
-                    whiteSpace: 'nowrap',
-                    fontFamily: 'var(--yn-font-mono)',
-                }}
-            >
-                <span style={{ width: 5, height: 5, borderRadius: 999, background: 'var(--yn-accent)', flexShrink: 0 }} />
-                {label}
-            </span>
-        );
+        return <DotBadge label="Static" color="var(--yn-accent)" />;
     }
     return <span style={{ color: 'var(--yn-text-3)', fontFamily: 'var(--yn-font-mono)' }}>—</span>;
 };

--- a/web/src/styles/draft-page.scss
+++ b/web/src/styles/draft-page.scss
@@ -970,8 +970,8 @@
     }
 }
 
-// State badge pill.
-.nb-state-badge {
+// Shared dot-badge pill — used by state badges, source chips, etc.
+.yn-dot-badge {
     display: inline-flex;
     align-items: center;
     gap: 6px;
@@ -982,16 +982,16 @@
     font-weight: 500;
     letter-spacing: 0.02em;
     white-space: nowrap;
-    background: var(--nb-stb-bg);
-    color: var(--nb-stb-c);
-    border: 1px solid var(--nb-stb-bd);
+    background: var(--yn-dotb-bg);
+    color: var(--yn-dotb-c);
+    border: 1px solid var(--yn-dotb-bd);
     cursor: default;
 
     &__dot {
         width: 6px;
         height: 6px;
         border-radius: 50%;
-        background: var(--nb-stb-c);
+        background: var(--yn-dotb-c);
         flex-shrink: 0;
     }
 }


### PR DESCRIPTION
Extracts a shared dot-badge pill component and renders the route source chip, the neighbour state badge, and the neighbour panel inline state badge through it, so they share one consistent style.

The route source pills now adopt the neighbour state-badge shape: a rounded-rect with a border and a colored dot.