### PR TITLE
feat(web): apply a shared flat surface to the forward page

### DIFF
--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -253,15 +253,15 @@ const ForwardPage: React.FC = () => {
 
     if (loading) {
         return (
-            <PageLayout header={pageHeader}>
+            <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
             </PageLayout>
         );
     }
 
     return (
-        <PageLayout header={pageHeader}>
-            <div className="yn-page">
+        <PageLayout header={pageHeader} className="yn-flat-layout">
+            <div className="yn-page yn-flat-page">
                 {draftConfigs.length === 0 ? (
                     <div className="yn-empty-page">
                         <div className="yn-empty-page__message">

--- a/web/src/pages/modules/forward/RuleTable.tsx
+++ b/web/src/pages/modules/forward/RuleTable.tsx
@@ -217,7 +217,7 @@ const RuleTable: React.FC<RuleTableProps> = ({
 }) => {
     const scrollRef = useRef<HTMLDivElement>(null);
     const wrapRef = useRef<HTMLDivElement>(null);
-    const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT + 20);
+    const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT);
 
     /**
      * Pending hide timeout id. When the cursor leaves a row we schedule a

--- a/web/src/styles/draft-page.scss
+++ b/web/src/styles/draft-page.scss
@@ -1352,6 +1352,58 @@
     }
 }
 
+// Shared flat-surface layout treatment.
+// Pages that apply .yn-flat-layout (on PageLayout) and .yn-flat-page (on .yn-page)
+// get the same unified #1C1814 surface, flush table, and 3px active underline.
+// Route (.ro-layout/.ro-page) and neighbours (.nb-layout/.nb-page) are temporary
+// duplicates that will migrate onto these shared classes in a later PR.
+
+.yn-flat-layout {
+    --yn-surface-bg: #1C1814;
+}
+
+.yn-flat-layout .page-layout__header {
+    background: var(--yn-surface-bg);
+    min-height: 64px;
+}
+
+.yn-page.yn-flat-page {
+    background: var(--yn-surface-bg);
+}
+
+.yn-flat-page .yn-tabs {
+    background: var(--yn-surface-bg);
+    border-bottom: none;
+}
+
+.yn-flat-page .yn-tab--active::after {
+    height: 3px;
+}
+
+.yn-flat-page .yn-tab--active .yn-tab__count {
+    color: var(--yn-accent);
+    background: var(--yn-accent-soft);
+}
+
+.yn-flat-page .yn-content {
+    padding: 0;
+}
+
+.yn-flat-page .yn-table-wrap {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+}
+
+.yn-flat-page .yn-table-header-row {
+    background: transparent;
+    border-top: 1px solid var(--yn-line-2);
+}
+
+.yn-flat-page .yn-vtbl-footer {
+    background: transparent;
+}
+
 // Neighbours page flush + borderless-tab overrides.
 // Mirrors the .ro-page treatment in route.scss, scoped to .nb-page only.
 


### PR DESCRIPTION
Introduces a shared flat-surface layout treatment and applies it to the forward page so its header, tabs, and table share the same flat background, borderless tabs, and flush, padding-less table as the route and neighbour operator pages. Pins the forward table footer to the bottom of the page.

This shared treatment is the basis for migrating the decap and ACL pages onto the same look in follow-up changes.