### PR TITLE
feat(web): apply the shared flat surface to the module route page

### DIFF
--- a/web/src/pages/_shared/draft/VirtualDraftTable.tsx
+++ b/web/src/pages/_shared/draft/VirtualDraftTable.tsx
@@ -197,6 +197,11 @@ export interface VirtualDraftTableProps<T extends { id: string }> {
     itemNoun: string;
     /** Message shown when visibleRows is empty. */
     emptyMessage: string;
+    /**
+     * When true the body height is calculated with zero extra gap below the footer,
+     * pinning the footer flush to the page bottom. Defaults to false (legacy +20px gap).
+     */
+    flushFooter?: boolean;
 }
 
 /** Generic virtualized draft table. Used by FIBTable and PrefixTable. */
@@ -227,10 +232,11 @@ export const VirtualDraftTable = <T extends { id: string }>({
     removedColumns,
     itemNoun,
     emptyMessage,
+    flushFooter = false,
 }: VirtualDraftTableProps<T>): React.JSX.Element => {
     const scrollRef = useRef<HTMLDivElement>(null);
     const wrapRef = useRef<HTMLDivElement>(null);
-    const bodyHeight = useContainerHeight(scrollRef, 300, FOOTER_HEIGHT + 20);
+    const bodyHeight = useContainerHeight(scrollRef, 300, flushFooter ? FOOTER_HEIGHT : FOOTER_HEIGHT + 20);
 
     const {
         hoveredRow,

--- a/web/src/pages/modules/route/FIBTable.tsx
+++ b/web/src/pages/modules/route/FIBTable.tsx
@@ -105,6 +105,7 @@ export const FIBTable: React.FC<FIBTableProps> = (props) => {
             removedColumns={REMOVED_COLUMNS}
             itemNoun="route"
             emptyMessage="No routes match your search."
+            flushFooter
         />
     );
 };

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -182,11 +182,11 @@ const RoutePage: React.FC = () => {
         />
     );
 
-    if (loading) return <PageLayout header={pageHeader}><PageLoader loading size="l" /></PageLayout>;
+    if (loading) return <PageLayout header={pageHeader} className="yn-flat-layout"><PageLoader loading size="l" /></PageLayout>;
 
     return (
-        <PageLayout header={pageHeader}>
-            <div className="yn-page">
+        <PageLayout header={pageHeader} className="yn-flat-layout">
+            <div className="yn-page yn-flat-page">
                 {draftConfigs.length === 0 ? (
                     <div className="yn-empty-page">
                         <div className="yn-empty-page__message">No FIB configurations found.</div>


### PR DESCRIPTION
Applies the shared flat-surface treatment to the module route page so its header, tabs, and table match the forward and operator pages: flat background, borderless tabs with a thicker active underline, a flush padding-less table, and a bottom-pinned footer.

Adds an opt-in flushFooter prop to the shared draft table so a page can pin its footer to the bottom; the decap page keeps its current spacing by default.