### PR TITLE
feat(web): apply the shared flat surface to the decap page

### DIFF
--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -169,11 +169,11 @@ const DecapPage: React.FC = () => {
         />
     );
 
-    if (loading) return <PageLayout header={pageHeader}><PageLoader loading size="l" /></PageLayout>;
+    if (loading) return <PageLayout header={pageHeader} className="yn-flat-layout"><PageLoader loading size="l" /></PageLayout>;
 
     return (
-        <PageLayout header={pageHeader}>
-            <div className="yn-page">
+        <PageLayout header={pageHeader} className="yn-flat-layout">
+            <div className="yn-page yn-flat-page">
                 {draftConfigs.length === 0 ? (
                     <div className="yn-empty-page">
                         <div className="yn-empty-page__message">No decap configurations found.</div>

--- a/web/src/pages/modules/decap/PrefixTable.tsx
+++ b/web/src/pages/modules/decap/PrefixTable.tsx
@@ -82,6 +82,7 @@ export const PrefixTable: React.FC<PrefixTableProps> = (props) => {
             removedColumns={REMOVED_COLUMNS}
             itemNoun="prefix"
             emptyMessage="No prefixes match your search."
+            flushFooter
         />
     );
 };


### PR DESCRIPTION
Applies the shared flat-surface treatment to the decap module page so its header, tabs, and table match the forward and route pages: flat background, borderless tabs with a thicker active underline, a flush padding-less table, and a bottom-pinned footer (via the shared draft table's flushFooter option).