### PR TITLE
refactor(web): unify table content inset in shared SCSS

### DIFF
--- a/web/src/pages/_shared/draft/RemovedRowsSection.tsx
+++ b/web/src/pages/_shared/draft/RemovedRowsSection.tsx
@@ -72,14 +72,13 @@ const RemovedRowsSection = <T extends { id: string }>({
             {rows.map((r) => (
                 <div
                     key={r.id}
-                    className="yn-vrow"
+                    className="yn-vrow yn-tbl-line"
                     style={{
                         display: 'flex',
                         alignItems: 'center',
                         height: rowHeight,
                         minWidth: totalWidth,
                         borderBottom: '1px solid var(--yn-line)',
-                        paddingLeft: 4,
                         opacity: 0.55,
                         background: 'rgba(224, 122, 110, 0.04)',
                         position: 'relative',

--- a/web/src/pages/_shared/draft/VirtualDraftTable.tsx
+++ b/web/src/pages/_shared/draft/VirtualDraftTable.tsx
@@ -111,7 +111,7 @@ const VirtualRowShell = memo(<T extends { id: string }>({
 
     return (
         <div
-            className={`yn-vrow${active ? ' yn-vrow--active' : ''}${dragCls}${selected ? ' yn-vrow--selected' : ''}`}
+            className={`yn-vrow yn-tbl-line${active ? ' yn-vrow--active' : ''}${dragCls}${selected ? ' yn-vrow--selected' : ''}`}
             data-row-id={row.id}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
@@ -129,7 +129,6 @@ const VirtualRowShell = memo(<T extends { id: string }>({
                 alignItems: 'center',
                 borderBottom: '1px solid var(--yn-line)',
                 backgroundColor: rowBg,
-                paddingLeft: 4,
             }}
         >
             <div
@@ -291,7 +290,7 @@ export const VirtualDraftTable = <T extends { id: string }>({
     return (
         <div ref={wrapRef} className="yn-table-wrap">
             <div className="yn-table-header-row">
-                <div className="yn-vtbl-header" style={{ height: HEADER_HEIGHT, minWidth: totalWidth }}>
+                <div className="yn-vtbl-header yn-tbl-line" style={{ height: HEADER_HEIGHT, minWidth: totalWidth }}>
                     <div
                         style={{ width: LEADING_CELL_WIDTHS.checkbox, minWidth: LEADING_CELL_WIDTHS.checkbox, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                         onClick={(e) => e.stopPropagation()}

--- a/web/src/pages/_shared/table/VirtualTable.tsx
+++ b/web/src/pages/_shared/table/VirtualTable.tsx
@@ -244,8 +244,6 @@ export function VirtualTable<T>({
         gridTemplateColumns,
         columnGap: GRID_COLUMN_GAP,
         alignItems: 'center',
-        paddingLeft: 16,
-        paddingRight: 22,
         minWidth,
     };
 
@@ -265,7 +263,7 @@ export function VirtualTable<T>({
                     className="yn-vtbl-header yn-vtbl-header--grid"
                     style={{ flex: '1 1 auto', height: HEADER_HEIGHT, overflowX: 'scroll', overflowY: 'hidden', minWidth: 0 }}
                 >
-                    <div style={{ ...gridStyle, height: HEADER_HEIGHT, display: 'grid' }}>
+                    <div className="yn-tbl-line" style={{ ...gridStyle, height: HEADER_HEIGHT, display: 'grid' }}>
                         <div
                             style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
                             onClick={(e) => e.stopPropagation()}
@@ -352,7 +350,7 @@ export function VirtualTable<T>({
                             return (
                                 <div
                                     key={id || virtualRow.index}
-                                    className={rowClasses}
+                                    className={`${rowClasses} yn-tbl-line`}
                                     data-row-id={id}
                                     onMouseEnter={() => handleHoverChange(row, virtualRow.start)}
                                     onMouseLeave={() => handleHoverChange(null, 0)}

--- a/web/src/pages/modules/acl/RuleTable.tsx
+++ b/web/src/pages/modules/acl/RuleTable.tsx
@@ -99,7 +99,7 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
 
     return (
         <div
-            className={`yn-vrow${selected ? ' yn-vrow--selected' : ''}${active ? ' yn-vrow--active' : ''}`}
+            className={`yn-vrow yn-tbl-line${selected ? ' yn-vrow--selected' : ''}${active ? ' yn-vrow--active' : ''}`}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             style={{
@@ -113,7 +113,6 @@ const VirtualRow: React.FC<VirtualRowProps> = memo(({
                 alignItems: 'center',
                 borderBottom: '1px solid var(--yn-line)',
                 backgroundColor: rowBg,
-                paddingLeft: 4,
             }}
         >
             <div style={cellStyle('checkbox')} onClick={e => e.stopPropagation()}>
@@ -439,7 +438,7 @@ const RuleTable: React.FC<RuleTableProps> = ({
                     className="yn-vtbl-header"
                     style={{ height: HEADER_HEIGHT }}
                 >
-                    <div ref={headerInnerRef} style={{ display: 'flex', minWidth: TOTAL_WIDTH, height: '100%', alignItems: 'center', willChange: 'transform' }}>
+                    <div ref={headerInnerRef} className="yn-tbl-line" style={{ display: 'flex', minWidth: TOTAL_WIDTH, height: '100%', alignItems: 'center', willChange: 'transform' }}>
                     <div style={cellStyle('checkbox')}>
                         <Checkbox
                             indeterminate={isIndeterminate}

--- a/web/src/styles/draft-page.scss
+++ b/web/src/styles/draft-page.scss
@@ -198,6 +198,16 @@
     flex-direction: column;
     overflow: hidden;
     position: relative;
+    --yn-tbl-pad-left: 16px;
+    --yn-tbl-pad-right: 22px;
+}
+
+// Canonical outer horizontal inset for every table row and header line.
+// Apply to any element that must start at --yn-tbl-pad-left from the
+// wrap's left edge and end --yn-tbl-pad-right from its right edge.
+.yn-tbl-line {
+    padding-left: var(--yn-tbl-pad-left);
+    padding-right: var(--yn-tbl-pad-right);
 }
 
 // Outer wrapper that aligns column-header row with the action button cluster.
@@ -272,14 +282,12 @@
 }
 
 // Sticky header row for the virtualized table.
-// Base: flex row with 4px L/R padding — consumed by VirtualDraftTable (FIBTable,
-// PrefixTable) and the legacy ACL/Forward RuleTables that place header cells as
-// direct flex children.
+// Base: flex row — consumed by VirtualDraftTable (FIBTable, PrefixTable) and the
+// legacy ACL RuleTable.  Horizontal padding is applied via .yn-tbl-line so it
+// matches the row inset exactly.
 .yn-vtbl-header {
     display: flex;
     align-items: center;
-    padding-left: 4px;
-    padding-right: 4px;
     flex: 1 1 auto;
     overflow-x: auto;
     overflow-y: hidden;


### PR DESCRIPTION
Moves the virtualized tables' horizontal content inset out of inline component styles into a shared SCSS rule, so every table uses the same left and right padding. Previously the operator and forward tables inset their content differently from the route, decap, and ACL tables; the leading column now starts at the same position across all table pages.