### PR TITLE
feat(route): add readiness service to the route operator

### DIFF
--- a/common/go/operator/readiness.go
+++ b/common/go/operator/readiness.go
@@ -18,10 +18,11 @@ type scopeState struct {
 	lastTransitionTime time.Time
 }
 
-// Readiness tracks per-gateway readiness state for the forward operator.
+// Readiness tracks readiness state across named scopes.
 //
-// Each gateway is represented as a named scope. State transitions and
-// observation timestamps are maintained independently per gateway.
+// Each scope is an independent readiness dimension (e.g. "neighbours", "rib",
+// or a gateway ID). State transitions and observation timestamps are
+// maintained independently per scope.
 type Readiness struct {
 	mu     sync.Mutex
 	scopes map[string]*scopeState
@@ -75,6 +76,31 @@ func (m *Readiness) Observe(gatewayID string, err error) {
 		s.lastTransitionTime = now
 	}
 	s.state = next
+	s.reasons = reasons
+	s.observedAt = now
+}
+
+// Set transitions the named scope to the given state, creating the scope if it
+// does not yet exist.
+//
+// last_transition_time is updated only when the state value changes. Supplied
+// reasons replace any existing reasons on each call.
+func (m *Readiness) Set(scope string, state readinesspb.State, reasons ...*readinesspb.Reason) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+
+	s, ok := m.scopes[scope]
+	if !ok {
+		s = &scopeState{name: scope}
+		m.scopes[scope] = s
+	}
+
+	if s.observedAt.IsZero() || s.state != state {
+		s.lastTransitionTime = now
+	}
+	s.state = state
 	s.reasons = reasons
 	s.observedAt = now
 }

--- a/common/go/operator/readiness_test.go
+++ b/common/go/operator/readiness_test.go
@@ -165,3 +165,65 @@ func TestReadiness_Drain_TransitionTimeOnlyOnChange(t *testing.T) {
 	assert.Equal(t, ltt1, ltt2,
 		"draining a scope already in NOT_READY must not update last_transition_time")
 }
+
+func TestReadiness_Set_UpsertNewScope(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a"})
+
+	// Set a scope that was not in the initial list.
+	r.Set("rib", readinesspb.State_STATE_READY)
+
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.Scopes, 2)
+
+	var ribScope *readinesspb.Scope
+	for _, s := range resp.Scopes {
+		if s.Name == "rib" {
+			ribScope = s
+		}
+	}
+	require.NotNil(t, ribScope)
+	assert.Equal(t, readinesspb.State_STATE_READY, ribScope.State)
+	assert.NotNil(t, ribScope.ObservedAt)
+	assert.NotNil(t, ribScope.LastTransitionTime)
+}
+
+func TestReadiness_Set_TransitionTimeOnlyOnStateChange(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a"})
+
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+	resp1 := r.Ready(&readinesspb.ReadyRequest{})
+	ltt1 := resp1.Scopes[0].LastTransitionTime.AsTime()
+
+	// Second Set with same state must not advance last_transition_time.
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+	resp2 := r.Ready(&readinesspb.ReadyRequest{})
+	ltt2 := resp2.Scopes[0].LastTransitionTime.AsTime()
+
+	assert.Equal(t, ltt1, ltt2, "last_transition_time must not change on same-state Set")
+
+	// Transition to NOT_READY must advance last_transition_time.
+	r.Set("gw-a", readinesspb.State_STATE_NOT_READY,
+		&readinesspb.Reason{Code: "SYNCING"})
+	resp3 := r.Ready(&readinesspb.ReadyRequest{})
+	ltt3 := resp3.Scopes[0].LastTransitionTime.AsTime()
+
+	assert.True(t, ltt3.Equal(ltt2) || ltt3.After(ltt2),
+		"last_transition_time must advance on state change via Set")
+}
+
+func TestReadiness_Set_ReasonsUpdated(t *testing.T) {
+	r := operator.NewReadiness([]string{"gw-a"})
+
+	r.Set("gw-a", readinesspb.State_STATE_NOT_READY,
+		&readinesspb.Reason{Code: "SYNCING"})
+
+	resp1 := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp1.Scopes[0].Reasons, 1)
+	assert.Equal(t, "SYNCING", resp1.Scopes[0].Reasons[0].Code)
+
+	// Transition to READY clears reasons.
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	resp2 := r.Ready(&readinesspb.ReadyRequest{})
+	assert.Empty(t, resp2.Scopes[0].Reasons)
+}

--- a/operators/route/etc/yanet/yanet-route-operator-default.yaml
+++ b/operators/route/etc/yanet/yanet-route-operator-default.yaml
@@ -67,3 +67,20 @@ netlink_monitor:
   disabled: false
   table_name: kernel
   default_priority: 100
+
+# Readiness probes reported to the gateway.
+#
+# expect_bird: set to true when a BIRD adapter is expected; the rib scope
+# stays NOT_READY (SYNCING) until the FeedRIB update rate settles, then
+# becomes READY for the duration of the session. Set false for static-only
+# deployments; rib becomes READY immediately at startup.
+readiness:
+  expect_bird: false
+  # rate_threshold: maximum RIB updates/sec below which the bulk-load
+  # gate starts counting toward the stability window.
+  rate_threshold: 50
+  # stability_window: how long the update rate must stay below
+  # rate_threshold before the "rib" scope is marked ready.
+  stability_window: 5s
+  # sample_interval: how often the rate helper samples the update counter.
+  sample_interval: 1s

--- a/operators/route/internal/discovery/neigh/neigh.go
+++ b/operators/route/internal/discovery/neigh/neigh.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"sync"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -47,9 +48,21 @@ func WithLog(log *zap.Logger) Option {
 	}
 }
 
+// WithOnSynced registers a callback invoked exactly once after the first
+// successful neighbour sync.
+//
+// The synchronous bootstrap in NewNeighMonitor fires it immediately on
+// success. A failed bootstrap defers it to the first periodic success.
+func WithOnSynced(fn func()) Option {
+	return func(o *options) {
+		o.OnSynced = fn
+	}
+}
+
 type options struct {
 	UpdateInterval time.Duration
 	LinkMap        map[string]string
+	OnSynced       func()
 	Log            *zap.Logger
 }
 
@@ -57,6 +70,7 @@ func newOptions() *options {
 	return &options{
 		UpdateInterval: 5 * time.Minute,
 		LinkMap:        make(map[string]string),
+		OnSynced:       func() {},
 		Log:            zap.NewNop(),
 	}
 }
@@ -72,6 +86,8 @@ type NeighMonitor struct {
 	source         *NeighSource
 	updateInterval time.Duration
 	linkMap        map[string]string
+	onSynced       sync.Once
+	onSyncedFn     func()
 	log            *zap.Logger
 }
 
@@ -87,11 +103,19 @@ func NewNeighMonitor(neighTable *NeighTable, source *NeighSource, options ...Opt
 		source:         source,
 		linkMap:        opts.LinkMap,
 		updateInterval: opts.UpdateInterval,
+		onSyncedFn:     opts.OnSynced,
 		log:            opts.Log,
 	}
 
 	// Bootstrap neighbours synchronously here.
-	m.updateNeighbours()
+	//
+	// If the bootstrap succeeds, fire the onSynced callback immediately so
+	// callers can observe the first-sync signal without waiting for the
+	// periodic ticker.
+	if err := m.updateNeighbours(); err == nil {
+		m.onSynced.Do(m.onSyncedFn)
+	}
+
 	return m
 }
 
@@ -142,6 +166,8 @@ func (m *NeighMonitor) runNeighPeriodicUpdate(ctx context.Context) error {
 		case <-timer.C:
 			if err := m.updateNeighbours(); err != nil {
 				m.log.Warn("failed to update neighbours", zap.Error(err))
+			} else {
+				m.onSynced.Do(m.onSyncedFn)
 			}
 		}
 	}
@@ -157,7 +183,12 @@ func (m *NeighMonitor) processNeighUpdate(update netlink.NeighUpdate) error {
 
 	switch update.Type {
 	case unix.RTM_NEWNEIGH:
-		return m.updateNeighbours()
+		if err := m.updateNeighbours(); err != nil {
+			return err
+		}
+
+		m.onSynced.Do(m.onSyncedFn)
+		return nil
 	case unix.RTM_DELNEIGH:
 		// We don't process neighbour deletion events to avoid flaps.
 		//

--- a/operators/route/internal/operator/cfg.go
+++ b/operators/route/internal/operator/cfg.go
@@ -12,6 +12,20 @@ import (
 )
 
 const (
+	// defaultRateThreshold is the default RIB update rate (updates/sec) below
+	// which the operator considers bulk loading complete.
+	defaultRateThreshold = 50.0
+
+	// defaultStabilityWindow is how long the rate must stay below
+	// defaultRateThreshold before the RIB scope is marked ready.
+	defaultStabilityWindow = 5 * time.Second
+
+	// defaultSampleInterval is the period between rate samples taken by the
+	// RIB readiness helper.
+	defaultSampleInterval = 1 * time.Second
+)
+
+const (
 	DefaultRIBTTL = 5 * time.Minute
 )
 
@@ -29,6 +43,32 @@ type Config struct {
 	LinkMap        map[string]string    `yaml:"link_map"`
 	RIBTTL         time.Duration        `yaml:"rib_ttl"`
 	NetlinkMonitor NetlinkMonitorConfig `yaml:"netlink_monitor"`
+	Readiness      ReadinessConfig      `yaml:"readiness"`
+}
+
+// ReadinessConfig controls the operator's readiness reporting.
+type ReadinessConfig struct {
+	// ExpectBird gates the rib scope on BIRD connectivity.
+	//
+	// When false (static-only deployments with no BIRD adapter running), the rib
+	// scope becomes READY immediately at startup.
+	ExpectBird bool `yaml:"expect_bird"`
+
+	// RateThreshold is the maximum RIB-update rate (updates per second) still
+	// considered settled.
+	//
+	// The rate must stay below this value continuously for StabilityWindow before
+	// the bulk-load gate clears. Tune upward in deployments with high
+	// steady-state BGP churn.
+	RateThreshold float64 `yaml:"rate_threshold"`
+
+	// StabilityWindow is the continuous duration the update rate must remain
+	// below RateThreshold before the bulk-load gate is considered cleared.
+	StabilityWindow time.Duration `yaml:"stability_window"`
+
+	// SampleInterval is the period at which the rate helper samples the
+	// RIB update counter.
+	SampleInterval time.Duration `yaml:"sample_interval"`
 }
 
 func (m *Config) Default() {
@@ -77,6 +117,12 @@ func DefaultConfig() *Config {
 		NetlinkMonitor: NetlinkMonitorConfig{
 			TableName:       "kernel",
 			DefaultPriority: 100,
+		},
+		Readiness: ReadinessConfig{
+			ExpectBird:      true,
+			RateThreshold:   defaultRateThreshold,
+			StabilityWindow: defaultStabilityWindow,
+			SampleInterval:  defaultSampleInterval,
 		},
 	}
 }

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/readinesspb"
 	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
 	"github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
@@ -48,12 +49,32 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	log := opts.Log
 	metrics := NewMetrics()
 
+	// Build the readiness tracker scope list: one gateway scope per gateway,
+	// plus a neighbours scope and a rib scope.
+	scopeNames := make([]string, 0, len(cfg.Gateways)+2)
+	for _, gw := range cfg.Gateways {
+		scopeNames = append(scopeNames, "gateway:"+gw.Name)
+	}
+	scopeNames = append(scopeNames, "neighbours", "rib")
+	tracker := operator.NewReadiness(scopeNames)
+
 	neighTable := neigh.NewNeighTable()
 	if _, err := neighTable.CreateSource("static", staticTablePriority, true); err != nil {
 		return nil, fmt.Errorf("failed to create static neighbour source: %w", err)
 	}
 
-	neighMonitor, err := newNeighbourMonitor(cfg, neighTable, log)
+	// Propagate the neighbours scope based on netlink monitor config.
+	var neighOnSynced neigh.Option
+	if cfg.NetlinkMonitor.Disabled {
+		tracker.Set("neighbours", readinesspb.State_STATE_READY)
+		neighOnSynced = neigh.WithOnSynced(func() {})
+	} else {
+		neighOnSynced = neigh.WithOnSynced(func() {
+			tracker.Set("neighbours", readinesspb.State_STATE_READY)
+		})
+	}
+
+	neighMonitor, err := newNeighbourMonitor(cfg, neighTable, log, neighOnSynced)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create neighbour monitor: %w", err)
 	}
@@ -62,12 +83,36 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	source := NewRouteSource(neighTable, routeRIBStore)
 	wake := source.WakeFunc()
 
+	// Build the RIB readiness helper when BIRD is expected; otherwise mark the
+	// rib scope ready immediately.
+	moduleName := cfg.Function.Module.Unwrap()
+	var ribHelper *ribReadinessHelper
+	var ribRouteServiceOpts []RouteServiceOption
+	if !cfg.Readiness.ExpectBird {
+		tracker.Set("rib", readinesspb.State_STATE_READY)
+	} else {
+		ribHelper = newRIBReadinessHelper(
+			cfg.Readiness,
+			routeRIBStore,
+			moduleName,
+			tracker,
+			log,
+		)
+		ribRouteServiceOpts = []RouteServiceOption{
+			WithRouteServiceOnRIBSessionStart(ribHelper.OnSessionStart),
+			WithRouteServiceOnRIBUpdate(ribHelper.OnUpdate),
+			WithRouteServiceOnRIBSessionEnd(ribHelper.OnSessionEnd),
+		}
+	}
+
 	routeSvc := NewRouteService(
 		neighTable,
-		WithRouteServiceRIBStore(routeRIBStore),
-		WithRouteServiceRIBTTL(ribTTL(cfg)),
-		WithRouteServiceOnChanged(wake),
-		WithRouteServiceLog(log),
+		append([]RouteServiceOption{
+			WithRouteServiceRIBStore(routeRIBStore),
+			WithRouteServiceRIBTTL(ribTTL(cfg)),
+			WithRouteServiceOnChanged(wake),
+			WithRouteServiceLog(log),
+		}, ribRouteServiceOpts...)...,
 	)
 
 	neighbourSvc := NewNeighbourService(
@@ -93,13 +138,17 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			return nil, fmt.Errorf("failed to construct gateway actuator %q: %w", gw.Name, err)
 		}
 
-		actuators = append(actuators, actuator)
+		// Wrap each actuator so that apply outcomes drive the per-gateway scope.
+		observed := operator.NewObservedActuator(actuator, "gateway:"+gw.Name, tracker.Observe)
+		actuators = append(actuators, observed)
 	}
 
 	fanOut := operator.NewFanOutActuator(
 		actuators,
 		operator.WithFanOutLog(log),
 	)
+
+	readinessSvc := NewReadinessService(tracker)
 
 	services := []operator.ServiceRegistrar{
 		func(s *grpc.Server) string {
@@ -118,6 +167,24 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			operatorpb.RegisterRouteOperatorServiceServer(s, operatorSvc)
 			return operatorpb.RouteOperatorService_ServiceDesc.ServiceName
 		},
+		func(s *grpc.Server) string {
+			operatorpb.RegisterReadinessServiceServer(s, readinessSvc)
+			return operatorpb.ReadinessService_ServiceDesc.ServiceName
+		},
+	}
+
+	// Build the worker list: always include the neighbour monitor and the
+	// drain worker; add the RIB readiness ticker when BIRD is expected.
+	workers := []operator.Runner{
+		neighbourMonitorRunner(neighMonitor),
+		func(ctx context.Context) error {
+			<-ctx.Done()
+			tracker.Drain()
+			return nil
+		},
+	}
+	if ribHelper != nil {
+		workers = append(workers, ribHelper.Run)
 	}
 
 	app := operator.NewOperator(
@@ -141,7 +208,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 
 			return nil
 		}),
-		operator.WithWorkers(neighbourMonitorRunner(neighMonitor)),
+		operator.WithWorkers(workers...),
 	)
 
 	return &Operator{
@@ -170,6 +237,7 @@ func newNeighbourMonitor(
 	cfg *Config,
 	neighTable *neigh.NeighTable,
 	log *zap.Logger,
+	extraOpts ...neigh.Option,
 ) (*neigh.NeighMonitor, error) {
 	if cfg.NetlinkMonitor.Disabled {
 		return nil, nil
@@ -184,12 +252,12 @@ func newNeighbourMonitor(
 		return nil, fmt.Errorf("failed to create kernel neighbour source: %w", err)
 	}
 
-	monitor := neigh.NewNeighMonitor(
-		neighTable,
-		source,
+	opts := append([]neigh.Option{
 		neigh.WithLog(log),
 		neigh.WithLinkMap(cfg.LinkMap),
-	)
+	}, extraOpts...)
+
+	monitor := neigh.NewNeighMonitor(neighTable, source, opts...)
 
 	return monitor, nil
 }

--- a/operators/route/internal/operator/options.go
+++ b/operators/route/internal/operator/options.go
@@ -29,18 +29,24 @@ func WithLog(log *zap.Logger) Option {
 }
 
 type routeServiceOptions struct {
-	RIBs      *RIBStore
-	RIBTTL    time.Duration
-	OnChanged func()
-	Log       *zap.Logger
+	RIBs              *RIBStore
+	RIBTTL            time.Duration
+	OnChanged         func()
+	OnRIBSessionStart func(name string, sessionID uint64)
+	OnRIBUpdate       func(n int)
+	OnRIBSessionEnd   func(name string, sessionID uint64)
+	Log               *zap.Logger
 }
 
 func newRouteServiceOptions() *routeServiceOptions {
 	return &routeServiceOptions{
-		RIBs:      newRIBStore(zap.NewNop()),
-		RIBTTL:    DefaultRIBTTL,
-		OnChanged: func() {},
-		Log:       zap.NewNop(),
+		RIBs:              newRIBStore(zap.NewNop()),
+		RIBTTL:            DefaultRIBTTL,
+		OnChanged:         func() {},
+		OnRIBSessionStart: func(string, uint64) {},
+		OnRIBUpdate:       func(int) {},
+		OnRIBSessionEnd:   func(string, uint64) {},
+		Log:               zap.NewNop(),
 	}
 }
 
@@ -73,6 +79,38 @@ func WithRouteServiceOnChanged(fn func()) RouteServiceOption {
 func WithRouteServiceLog(log *zap.Logger) RouteServiceOption {
 	return func(o *routeServiceOptions) {
 		o.Log = log
+	}
+}
+
+// WithRouteServiceOnRIBSessionStart registers a callback invoked when a new
+// FeedRIB stream session begins for the named config.
+//
+// The callback receives the config name and the session id assigned by
+// ribRef.NewSession for the new stream.
+func WithRouteServiceOnRIBSessionStart(fn func(name string, sessionID uint64)) RouteServiceOption {
+	return func(o *routeServiceOptions) {
+		o.OnRIBSessionStart = fn
+	}
+}
+
+// WithRouteServiceOnRIBUpdate registers a callback invoked after each
+// successfully applied route update.
+//
+// The callback receives the count of routes applied in that batch.
+func WithRouteServiceOnRIBUpdate(fn func(n int)) RouteServiceOption {
+	return func(o *routeServiceOptions) {
+		o.OnRIBUpdate = fn
+	}
+}
+
+// WithRouteServiceOnRIBSessionEnd registers a callback invoked when a
+// FeedRIB stream session ends for the named config.
+//
+// The callback receives the config name and the session id that ended, so
+// the callee can discard events from superseded sessions.
+func WithRouteServiceOnRIBSessionEnd(fn func(name string, sessionID uint64)) RouteServiceOption {
+	return func(o *routeServiceOptions) {
+		o.OnRIBSessionEnd = fn
 	}
 }
 

--- a/operators/route/internal/operator/readiness_service.go
+++ b/operators/route/internal/operator/readiness_service.go
@@ -1,0 +1,32 @@
+package operator
+
+import (
+	"context"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/readinesspb"
+	operatorpb "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
+)
+
+// ReadinessService implements operatorpb.ReadinessServiceServer.
+//
+// All state is delegated to a Readiness tracker that records per-scope
+// readiness outcomes.
+type ReadinessService struct {
+	operatorpb.UnimplementedReadinessServiceServer
+
+	tracker *operator.Readiness
+}
+
+// NewReadinessService constructs a ReadinessService backed by tracker.
+func NewReadinessService(tracker *operator.Readiness) *ReadinessService {
+	return &ReadinessService{tracker: tracker}
+}
+
+// Ready returns the current per-scope readiness state.
+func (m *ReadinessService) Ready(
+	ctx context.Context,
+	req *readinesspb.ReadyRequest,
+) (*readinesspb.ReadyResponse, error) {
+	return m.tracker.Ready(req), nil
+}

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -1,0 +1,408 @@
+package operator
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/readinesspb"
+	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
+)
+
+// requireScope fetches the named scope from the tracker. Fails the test when
+// the scope is absent.
+func requireScope(t *testing.T, tracker *operator.Readiness, name string) *readinesspb.Scope {
+	t.Helper()
+	resp := tracker.Ready(&readinesspb.ReadyRequest{})
+	for _, s := range resp.Scopes {
+		if s.Name == name {
+			return s
+		}
+	}
+	t.Fatalf("scope %q not found in readiness response", name)
+	return nil
+}
+
+func TestReadiness_NeighboursDisabled_ImmediatelyReady(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NetlinkMonitor.Disabled = true
+	cfg.Readiness.ExpectBird = false
+	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}}
+
+	tracker := operator.NewReadiness([]string{"gateway:gw0", "neighbours", "rib"})
+
+	// When netlink monitor is disabled, mark neighbours READY immediately.
+	if cfg.NetlinkMonitor.Disabled {
+		tracker.Set("neighbours", readinesspb.State_STATE_READY)
+	}
+
+	s := requireScope(t, tracker, "neighbours")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+}
+
+func TestReadiness_ExpectBirdFalse_RibImmediatelyReady(t *testing.T) {
+	tracker := operator.NewReadiness([]string{"rib"})
+
+	// When BIRD is not expected, mark rib READY immediately.
+	tracker.Set("rib", readinesspb.State_STATE_READY)
+
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+}
+
+func TestReadiness_GatewayObserve(t *testing.T) {
+	tracker := operator.NewReadiness([]string{"gateway:gw0"})
+
+	// Initial state is UNKNOWN.
+	s := requireScope(t, tracker, "gateway:gw0")
+	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, s.State)
+
+	// Successful apply transitions to READY.
+	tracker.Observe("gateway:gw0", nil)
+	s = requireScope(t, tracker, "gateway:gw0")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+	assert.Empty(t, s.Reasons)
+
+	// Failed apply transitions to NOT_READY with APPLY_FAILED.
+	tracker.Observe("gateway:gw0", assert.AnError)
+	s = requireScope(t, tracker, "gateway:gw0")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "APPLY_FAILED", s.Reasons[0].Code)
+}
+
+func TestRIBReadiness_SessionStart_SYNCING(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 50 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	// Immediately after session start the scope must be NOT_READY SYNCING.
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.NotEmpty(t, s.Reasons)
+	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
+}
+
+func TestRIBReadiness_HighRate_SYNCING(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   5,
+		StabilityWindow: 200 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Drive a high update rate: > 5 per 20ms sample means more than 0.1 per tick.
+	// We push 3 updates every 10ms to stay well above threshold.
+	go func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				helper.OnUpdate(3)
+			}
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.NotEmpty(t, s.Reasons)
+	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
+
+	cancel()
+	_ = eg.Wait()
+}
+
+func TestRIBReadiness_LowRate_READY(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 50 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Rate is 0 (well below 1000), so the stability window passes quickly.
+	time.Sleep(200 * time.Millisecond)
+
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+
+	cancel()
+	_ = eg.Wait()
+}
+
+func TestRIBReadiness_MidWindowSpike_ResetsBelowSince(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold: 5,
+		// Long window so a single spike definitely resets it.
+		StabilityWindow: 500 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Let the below-threshold window start (low rate for ~60ms).
+	time.Sleep(60 * time.Millisecond)
+
+	// Inject a spike: 300 updates in one shot means ~15000/sec for the next tick.
+	helper.OnUpdate(300)
+
+	// Even after 60ms more (well into where the window would have closed), the
+	// spike must have reset belowSince so the helper is still SYNCING.
+	time.Sleep(100 * time.Millisecond)
+
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	if len(s.Reasons) > 0 {
+		assert.Equal(t, "SYNCING", s.Reasons[0].Code)
+	}
+
+	cancel()
+	_ = eg.Wait()
+}
+
+func TestRIBReadiness_SessionEnd_Degraded(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 30 * time.Millisecond,
+		SampleInterval:  15 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Wait for READY.
+	time.Sleep(120 * time.Millisecond)
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+
+	// Session ends — routes remain in the RIB until TTL cleanup, so the scope
+	// must flip to DEGRADED (not NOT_READY) immediately.
+	helper.OnSessionEnd("route0", 1)
+
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
+	require.NotEmpty(t, s.Reasons)
+	assert.Equal(t, "SESSION_ENDED", s.Reasons[0].Code)
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// seedRoute adds a single static unicast route to the named RIB in the store.
+//
+// This makes Stats().Routes > 0 so that syncingState returns DEGRADED rather
+// than NOT_READY for the syncing path.
+func seedRoute(t *testing.T, store *RIBStore, configName string) {
+	t.Helper()
+	ribRef := store.GetOrCreate(configName)
+	prefix := netip.MustParsePrefix("10.0.0.0/24")
+	nexthop := netip.MustParseAddr("192.168.1.1")
+	require.NoError(t, ribRef.AddUnicastRoute(prefix, nexthop, rib.RouteSourceStatic))
+}
+
+// TestRIBReadiness_Syncing tests the NOT_READY / DEGRADED branch depending on
+// whether the RIB holds routes at the moment of syncing.
+func TestRIBReadiness_Syncing(t *testing.T) {
+	tests := []struct {
+		name           string
+		seedRoutes     bool
+		wantState      readinesspb.State
+		wantReasonCode string
+	}{
+		{
+			name:           "cold start empty rib",
+			seedRoutes:     false,
+			wantState:      readinesspb.State_STATE_NOT_READY,
+			wantReasonCode: "SYNCING",
+		},
+		{
+			name:           "resync with routes present",
+			seedRoutes:     true,
+			wantState:      readinesspb.State_STATE_DEGRADED,
+			wantReasonCode: "SYNCING",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := ReadinessConfig{
+				RateThreshold:   5,
+				StabilityWindow: 500 * time.Millisecond,
+				SampleInterval:  20 * time.Millisecond,
+			}
+
+			store := newRIBStore(zap.NewNop())
+			tracker := operator.NewReadiness([]string{"rib"})
+			helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+
+			if tc.seedRoutes {
+				seedRoute(t, store, "route0")
+			}
+
+			// Start the session — this calls syncingState() immediately.
+			helper.OnSessionStart("route0", 1)
+
+			// Verify the state set by OnSessionStart.
+			s := requireScope(t, tracker, "rib")
+			assert.Equal(t, tc.wantState, s.State)
+			require.NotEmpty(t, s.Reasons)
+			assert.Equal(t, tc.wantReasonCode, s.Reasons[0].Code)
+
+			// Now run the loop with a high update rate so it stays unsettled and
+			// confirm the per-tick path also produces the expected state.
+			ctx, cancel := context.WithCancel(t.Context())
+
+			eg, _ := errgroup.WithContext(ctx)
+			eg.Go(func() error {
+				return helper.Run(ctx)
+			})
+
+			// Drive a high rate to stay above the threshold (5/s).
+			go func() {
+				ticker := time.NewTicker(10 * time.Millisecond)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case <-ticker.C:
+						helper.OnUpdate(3)
+					}
+				}
+			}()
+
+			time.Sleep(100 * time.Millisecond)
+
+			s = requireScope(t, tracker, "rib")
+			assert.Equal(t, tc.wantState, s.State)
+			require.NotEmpty(t, s.Reasons)
+			assert.Equal(t, tc.wantReasonCode, s.Reasons[0].Code)
+
+			cancel()
+			_ = eg.Wait()
+		})
+	}
+}
+
+// TestRIBReadiness_SupersededSession tests the P2 concurrency fix: when a
+// second FeedRIB stream starts (session B) and the old stream (session A) ends
+// afterwards, the stale OnSessionEnd from A must be ignored so that session B
+// can still progress to READY.
+func TestRIBReadiness_SupersededSession(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 50 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+
+	// Session A starts (id=1) — tracker enters SYNCING.
+	helper.OnSessionStart("route0", 1)
+
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.NotEmpty(t, s.Reasons)
+	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
+
+	// Session B starts (id=2), superseding A.
+	helper.OnSessionStart("route0", 2)
+
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.NotEmpty(t, s.Reasons)
+	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
+
+	// Session A's stale end arrives — must be ignored because currentSession is 2.
+	helper.OnSessionEnd("route0", 1)
+
+	// State must still reflect an active session (SYNCING), not DEGRADED/inactive.
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.NotEmpty(t, s.Reasons)
+	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
+
+	// Run the sampling loop: with rate=0 (well below 1000/s), session B should
+	// settle and reach READY within the stability window.
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	time.Sleep(200 * time.Millisecond)
+
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+
+	cancel()
+	_ = eg.Wait()
+}

--- a/operators/route/internal/operator/rib_readiness.go
+++ b/operators/route/internal/operator/rib_readiness.go
@@ -1,0 +1,209 @@
+package operator
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/readinesspb"
+)
+
+// ribReadinessHelper drives the "rib" readiness scope based on the FeedRIB
+// update rate and plateau settle.
+//
+// The scope becomes READY when the update rate has stayed below RateThreshold
+// continuously for StabilityWindow. The bulkSettled flag is sticky within a
+// session: a spike after settling does not flip the scope back to NOT_READY.
+type ribReadinessHelper struct {
+	store      *RIBStore
+	configName string
+	tracker    *operator.Readiness
+
+	// counter is the total number of route updates applied in the current
+	// session. Driven by OnUpdate from the FeedRIB hot path; read by Run.
+	counter atomic.Int64
+
+	mu             sync.Mutex
+	currentSession uint64
+	sessionActive  bool
+	belowSince     time.Time // zero when rate is currently above threshold
+	bulkSettled    bool
+
+	rateThreshold   float64
+	stabilityWindow time.Duration
+	sampleInterval  time.Duration
+
+	log *zap.Logger
+}
+
+// newRIBReadinessHelper constructs a helper from the supplied config.
+//
+// The helper is wired to the given tracker's "rib" scope.
+func newRIBReadinessHelper(
+	cfg ReadinessConfig,
+	store *RIBStore,
+	configName string,
+	tracker *operator.Readiness,
+	log *zap.Logger,
+) *ribReadinessHelper {
+	return &ribReadinessHelper{
+		store:           store,
+		configName:      configName,
+		tracker:         tracker,
+		rateThreshold:   cfg.RateThreshold,
+		stabilityWindow: cfg.StabilityWindow,
+		sampleInterval:  cfg.SampleInterval,
+		log:             log,
+	}
+}
+
+// hasRoutes reports whether the tracked config's RIB currently holds any
+// routes.
+//
+// It uses the O(1) RIB stats snapshot, so it is cheap to call every tick.
+func (m *ribReadinessHelper) hasRoutes() bool {
+	r, ok := m.store.Get(m.configName)
+	return ok && r.Stats().Routes > 0
+}
+
+// syncingState returns the state to report while a session is still syncing.
+//
+// While routes are present we report DEGRADED so the announcer keeps serving
+// the still-valid routes; an empty RIB (cold start with nothing to announce)
+// reports NOT_READY.
+func (m *ribReadinessHelper) syncingState() readinesspb.State {
+	if m.hasRoutes() {
+		return readinesspb.State_STATE_DEGRADED
+	}
+	return readinesspb.State_STATE_NOT_READY
+}
+
+// OnSessionStart is called by FeedRIB after ribRef.NewSession() opens a new
+// BIRD import stream for the given config name.
+//
+// sessionID is the id returned by ribRef.NewSession and is stored so that a
+// stale OnSessionEnd from the superseded stream can be ignored. Reports
+// DEGRADED rather than NOT_READY when routes are already present, so a resync
+// does not withdraw live announcements.
+func (m *ribReadinessHelper) OnSessionStart(name string, sessionID uint64) {
+	if name != m.configName {
+		return
+	}
+
+	m.mu.Lock()
+	m.currentSession = sessionID
+	m.sessionActive = true
+	m.bulkSettled = false
+	m.belowSince = time.Time{}
+	m.mu.Unlock()
+	m.counter.Store(0)
+
+	m.tracker.Set("rib", m.syncingState(),
+		&readinesspb.Reason{Code: "SYNCING"},
+	)
+}
+
+// OnUpdate is called by FeedRIB after each successfully applied route, with n
+// equal to the number of routes applied in that batch.
+func (m *ribReadinessHelper) OnUpdate(n int) {
+	m.counter.Add(int64(n))
+}
+
+// OnSessionEnd is called by FeedRIB when the stream ends for the given config.
+//
+// sessionID must match the id passed to the most recent OnSessionStart for
+// name; if it does not, the call is from a superseded stream and is silently
+// ignored, preventing a stale end from clobbering the state of the active
+// session. When the session id matches, the scope is set to DEGRADED rather
+// than NOT_READY because routes remain in the RIB and the dataplane continues
+// forwarding; they are purged only later by the TTL-based CleanupTask.
+func (m *ribReadinessHelper) OnSessionEnd(name string, sessionID uint64) {
+	if name != m.configName {
+		return
+	}
+
+	m.mu.Lock()
+	if sessionID != m.currentSession {
+		m.mu.Unlock()
+		return
+	}
+	m.sessionActive = false
+	m.bulkSettled = false
+	m.mu.Unlock()
+
+	m.tracker.Set("rib", readinesspb.State_STATE_DEGRADED,
+		&readinesspb.Reason{Code: "SESSION_ENDED"},
+	)
+}
+
+// Run drives the periodic sampling loop. It returns when ctx is cancelled.
+func (m *ribReadinessHelper) Run(ctx context.Context) error {
+	ticker := time.NewTicker(m.sampleInterval)
+	defer ticker.Stop()
+
+	var prevCount int64
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case now := <-ticker.C:
+			cur := m.counter.Load()
+			delta := cur - prevCount
+			prevCount = cur
+
+			rate := float64(delta) / m.sampleInterval.Seconds()
+
+			m.mu.Lock()
+			active := m.sessionActive
+			settled := m.bulkSettled
+
+			if !settled {
+				if rate < m.rateThreshold {
+					if m.belowSince.IsZero() {
+						m.belowSince = now
+					} else if now.Sub(m.belowSince) >= m.stabilityWindow {
+						m.bulkSettled = true
+						settled = true
+					}
+				} else {
+					// Rate spiked above threshold; reset the continuous window.
+					m.belowSince = time.Time{}
+				}
+			}
+			m.mu.Unlock()
+
+			var (
+				nextState readinesspb.State
+				reason    *readinesspb.Reason
+			)
+
+			switch {
+			case !active:
+				// No active session — keep the DEGRADED state OnSessionEnd set.
+				continue
+			case !settled:
+				nextState = m.syncingState()
+				reason = &readinesspb.Reason{Code: "SYNCING"}
+			default:
+				nextState = readinesspb.State_STATE_READY
+			}
+
+			if nextState == readinesspb.State_STATE_READY {
+				m.tracker.Set("rib", nextState)
+			} else {
+				m.tracker.Set("rib", nextState, reason)
+			}
+
+			m.log.Debug("rib readiness tick",
+				zap.Float64("rate", rate),
+				zap.Bool("bulk_settled", settled),
+				zap.String("state", nextState.String()),
+			)
+		}
+	}
+}

--- a/operators/route/internal/operator/service_route.go
+++ b/operators/route/internal/operator/service_route.go
@@ -27,9 +27,12 @@ type RouteService struct {
 	ribs       *RIBStore
 	neighTable *neigh.NeighTable
 
-	ribTTL    time.Duration
-	quitCh    chan bool
-	onChanged func()
+	ribTTL            time.Duration
+	quitCh            chan bool
+	onChanged         func()
+	onRIBSessionStart func(name string, sessionID uint64)
+	onRIBUpdate       func(n int)
+	onRIBSessionEnd   func(name string, sessionID uint64)
 
 	log *zap.Logger
 }
@@ -46,12 +49,15 @@ func NewRouteService(
 	}
 
 	return &RouteService{
-		ribs:       opts.RIBs,
-		neighTable: neighTable,
-		ribTTL:     opts.RIBTTL,
-		quitCh:     make(chan bool),
-		onChanged:  opts.OnChanged,
-		log:        opts.Log,
+		ribs:              opts.RIBs,
+		neighTable:        neighTable,
+		ribTTL:            opts.RIBTTL,
+		quitCh:            make(chan bool),
+		onChanged:         opts.OnChanged,
+		onRIBSessionStart: opts.OnRIBSessionStart,
+		onRIBUpdate:       opts.OnRIBUpdate,
+		onRIBSessionEnd:   opts.OnRIBSessionEnd,
+		log:               opts.Log,
 	}
 }
 
@@ -285,6 +291,7 @@ func (m *RouteService) FeedRIB(stream operatorpb.RouteService_FeedRIBServer) err
 				zap.Uint64("session_id", sessionID),
 				zap.String("name", name),
 			)
+			m.onRIBSessionStart(name, sessionID)
 		}
 
 		if terminated.Load() {
@@ -314,6 +321,7 @@ func (m *RouteService) FeedRIB(stream operatorpb.RouteService_FeedRIBServer) err
 		}
 		route.SessionID = sessionID
 		ribRef.Update(*route)
+		m.onRIBUpdate(1)
 	}
 
 	if ribRef != nil {
@@ -322,6 +330,7 @@ func (m *RouteService) FeedRIB(stream operatorpb.RouteService_FeedRIBServer) err
 			zap.String("name", name),
 			zap.Duration("ttl", m.ribTTL),
 		)
+		m.onRIBSessionEnd(name, sessionID)
 		go ribRef.CleanupTask(sessionID, m.quitCh, m.ribTTL)
 		m.onChanged()
 	}

--- a/operators/route/operatorpb/meson.build
+++ b/operators/route/operatorpb/meson.build
@@ -28,3 +28,30 @@ protoc_gen = custom_target(
     build_by_default: true,
 )
 route_operator_protoc_gen = protoc_gen
+
+# Readiness proto imports common/readinesspb, so it must be compiled with
+# -I root_dir only, using paths=source_relative:root_dir so that the generated
+# source annotation embeds the full repo-relative path. A separate target
+# prevents the bare-basename collision that would occur if readiness.proto were
+# compiled under -I proto_dir alongside the common/readinesspb package.
+readiness_proto_files = [
+    join_paths(proto_dir, 'readiness.proto'),
+]
+
+readiness_protoc_gen = custom_target(
+    'route-operator-readiness-protoc',
+    output: [
+        'readiness.pb.go',
+        'readiness_grpc.pb.go',
+    ],
+    input: readiness_proto_files,
+    command: [
+        protoc,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + root_dir,
+        '--go-grpc_out=paths=source_relative:' + root_dir,
+        '@INPUT@',
+    ],
+    build_by_default: true,
+)
+route_operator_readiness_protoc_gen = readiness_protoc_gen

--- a/operators/route/operatorpb/v1/readiness.proto
+++ b/operators/route/operatorpb/v1/readiness.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package operators.route.operatorpb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1;operatorpb";
+
+import "common/readinesspb/readiness.proto";
+
+// ReadinessService exposes per-scope readiness of the route operator.
+service ReadinessService {
+  // Ready returns the current readiness state for all scopes.
+  rpc Ready(readinesspb.ReadyRequest) returns (readinesspb.ReadyResponse);
+}


### PR DESCRIPTION
- Add a readiness service to the route operator that reports overall readiness across three independent scopes: per-gateway config apply, neighbour initialisation, and BIRD route convergence.
- Drive per-gateway scopes from actuator apply outcomes (mirroring the forward operator), so a gateway is ready once the static config and current FIB are applied to the dataplane.
- Gate the neighbours scope on the first successful netlink sync; deployments with the netlink monitor disabled are ready immediately.
- Settle the route scope once the BIRD update rate stays below a configurable threshold for a stability window. While routes remain serviceable the scope reports degraded rather than not-ready, so the announcer does not withdraw live announcements; static-only deployments skip BIRD gating entirely.
- Default-route presence is intentionally not a readiness criterion — that validation belongs to the announcer.