### PR TITLE
refactor(web): move VirtualDraftTable into the shared table directory

### DIFF
--- a/web/src/pages/_shared/draft/index.ts
+++ b/web/src/pages/_shared/draft/index.ts
@@ -15,8 +15,6 @@ export { default as DraftPageToolbar } from './DraftPageToolbar';
 export { useDraftShortcuts } from './useDraftShortcuts';
 export { useDraft } from './useDraft';
 export type { UseDraftResult } from './useDraft';
-export { VirtualDraftTable, LEADING_CELL_WIDTHS, LEADING_TOTAL_WIDTH } from './VirtualDraftTable';
-export type { VirtualDraftTableProps, TableColumnHeader, RenderDataCells, RowStatus } from './VirtualDraftTable';
 export { useDraftDragDrop } from './useDraftDragDrop';
 export type { DragOverState, UseDraftDragDropResult } from './useDraftDragDrop';
 export { useDraftPageHandlers } from './useDraftPageHandlers';

--- a/web/src/pages/_shared/table/VirtualDraftTable.tsx
+++ b/web/src/pages/_shared/table/VirtualDraftTable.tsx
@@ -2,11 +2,11 @@ import React, { useCallback, useMemo, useRef, memo } from 'react';
 import { useContainerHeight } from '../../../hooks';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Checkbox } from '@gravity-ui/uikit';
-import DraftActionButtons from './DraftActionButtons';
-import { useRowHoverOverlay } from './useRowHoverOverlay';
-import RemovedRowsSection from './RemovedRowsSection';
-import RowHoverEditOverlay from './RowHoverEditOverlay';
-import type { RemovedColumnDescriptor } from './RemovedRowsSection';
+import DraftActionButtons from '../draft/DraftActionButtons';
+import { useRowHoverOverlay } from '../draft/useRowHoverOverlay';
+import RemovedRowsSection from '../draft/RemovedRowsSection';
+import RowHoverEditOverlay from '../draft/RowHoverEditOverlay';
+import type { RemovedColumnDescriptor } from '../draft/RemovedRowsSection';
 
 const ROW_HEIGHT = 44;
 const HEADER_HEIGHT = 40;

--- a/web/src/pages/modules/decap/PrefixTable.tsx
+++ b/web/src/pages/modules/decap/PrefixTable.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
 import type { PrefixRowItem, PrefixRowStatus } from './types';
 import { validateRow } from './validation';
-import { VirtualDraftTable, LEADING_TOTAL_WIDTH } from '../../_shared/draft';
-import type { RemovedColumnDescriptor, TableColumnHeader } from '../../_shared/draft';
+import { VirtualDraftTable, LEADING_TOTAL_WIDTH } from '../../_shared/table/VirtualDraftTable';
+import type { RemovedColumnDescriptor } from '../../_shared/draft/RemovedRowsSection';
+import type { TableColumnHeader } from '../../_shared/table/VirtualDraftTable';
 
 const PREFIX_WIDTH = 480;
 
@@ -68,7 +69,7 @@ export interface PrefixTableProps {
 /** Virtualized prefix table backed by VirtualDraftTable. */
 export const PrefixTable: React.FC<PrefixTableProps> = (props) => {
     const statusById = useMemo(
-        () => props.statusById as Map<string, import('../../_shared/draft').RowStatus>,
+        () => props.statusById as Map<string, import('../../_shared/table/VirtualDraftTable').RowStatus>,
         [props.statusById],
     );
 

--- a/web/src/pages/modules/route/FIBTable.tsx
+++ b/web/src/pages/modules/route/FIBTable.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from 'react';
 import type { FIBRowItem, FIBRowStatus } from './types';
 import { validateRow } from './validation';
-import { VirtualDraftTable, LEADING_TOTAL_WIDTH } from '../../_shared/draft';
-import type { RemovedColumnDescriptor, TableColumnHeader } from '../../_shared/draft';
+import { VirtualDraftTable, LEADING_TOTAL_WIDTH } from '../../_shared/table/VirtualDraftTable';
+import type { RemovedColumnDescriptor } from '../../_shared/draft/RemovedRowsSection';
+import type { TableColumnHeader } from '../../_shared/table/VirtualDraftTable';
 
 const COLUMN_WIDTHS = {
     prefix: 220,
@@ -91,7 +92,7 @@ export interface FIBTableProps {
 /** Virtualized FIB table backed by VirtualDraftTable. */
 export const FIBTable: React.FC<FIBTableProps> = (props) => {
     const statusById = useMemo(
-        () => props.statusById as Map<string, import('../../_shared/draft').RowStatus>,
+        () => props.statusById as Map<string, import('../../_shared/table/VirtualDraftTable').RowStatus>,
         [props.statusById],
     );
 


### PR DESCRIPTION
Relocates the draft table shell from the draft helpers directory to the shared table directory, alongside the read-only table shell, so both virtualized table shells live together.

Pure move with no behavior change; the draft barrel and the two consumers (route FIB table, decap prefix table) are updated to import it from the new location.