### PR TITLE
refactor: flatten fwstate page layout and unify background

### DIFF
--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -66,12 +66,11 @@ const DEFAULT_NS = {
 };
 
 const STATES_TABLE_ROW_HEIGHT = 38;
-const STATES_TABLE_HEADER_HEIGHT = 38;
-const STATES_TABLE_BOTTOM_OFFSET = 86;
 const STATES_TABLE_OVERSCAN = 12;
 const STATES_TABLE_LOAD_THRESHOLD = 60;
 const STATES_TABLE_MAX_BATCH_SIZE = 10000;
 const BACKWARD_RESET_CURSOR = Number.MAX_SAFE_INTEGER;
+const STATES_CURSORBAR_HEIGHT = 41;
 
 const zeroIPv6AddressWire = (): IPAddressWire => ({ addr: '::' });
 
@@ -689,11 +688,7 @@ const StatesTabBody: React.FC<StatesTabBodyProps> = ({
     const scrollRef = useRef<HTMLDivElement | null>(null);
     const headerInnerRef = useRef<HTMLDivElement | null>(null);
 
-    const [tableSlotNode, setTableSlotNode] = useState<HTMLDivElement | null>(null);
-    const tableSlotRef = useMemo(() => ({ current: tableSlotNode } as React.RefObject<HTMLElement | null>), [tableSlotNode]);
-    const tableSlotHeight = useContainerHeight(tableSlotRef, 300, STATES_TABLE_BOTTOM_OFFSET);
-    const tableScrollHeight = tableSlotHeight > 0 ? tableSlotHeight : undefined;
-    const bodyHeight = tableScrollHeight !== undefined ? tableScrollHeight - STATES_TABLE_HEADER_HEIGHT : undefined;
+    const bodyHeight = useContainerHeight(scrollRef as React.RefObject<HTMLElement | null>, 300, STATES_CURSORBAR_HEIGHT);
 
     const queryKey = useMemo(() => JSON.stringify({
         currentName,
@@ -951,11 +946,7 @@ const StatesTabBody: React.FC<StatesTabBodyProps> = ({
                 onToggle={() => setDistCollapsed((v) => !v)}
             />
 
-            <div
-                ref={setTableSlotNode}
-                className="fws-tablezone"
-                style={tableScrollHeight !== undefined ? { height: tableScrollHeight } : undefined}
-            >
+            <div className="fws-tablezone">
                 <div className="fws-tblshell">
                     <div className="fws-tblheader">
                         <div
@@ -985,7 +976,7 @@ const StatesTabBody: React.FC<StatesTabBodyProps> = ({
                     <div
                         className="fws-tablescroll"
                         ref={scrollRef}
-                        style={bodyHeight !== undefined ? { height: bodyHeight } : undefined}
+                        style={{ flex: '0 0 auto', height: bodyHeight, overflowY: 'auto' }}
                     >
                         {displayRows.length === 0 && !stateLoading && (
                             <div className="fws-tableempty">
@@ -1488,7 +1479,7 @@ const FWStatePage: React.FC = () => {
     );
 
     if (loading) {
-        return <PageLayout header={pageHeader}><PageLoader loading size="l" /></PageLayout>;
+        return <PageLayout header={pageHeader} className="yn-flat-layout"><PageLoader loading size="l" /></PageLayout>;
     }
 
     const configurationTab = current && (() => {
@@ -1710,8 +1701,8 @@ const FWStatePage: React.FC = () => {
     );
 
     return (
-        <PageLayout header={pageHeader}>
-            <div className="yn-page">
+        <PageLayout header={pageHeader} className="yn-flat-layout">
+            <div className="yn-page yn-flat-page">
                 {configNames.length === 0 ? (
                     <div className="yn-empty-page">
                         <div className="yn-empty-page__message">No FWState configurations found.</div>
@@ -1736,7 +1727,7 @@ const FWStatePage: React.FC = () => {
                             {current && (
                                 <div className="fwstate-settings-layout">
                                     <div
-                                        className={`fwstate-panel fwstate-subtab-panel ${activeSubTab === 'states' ? 'fwstate-subtab-panel--states' : 'fwstate-subtab-panel--scroll'}`}
+                                        className={`fwstate-subtab-panel ${activeSubTab === 'states' ? 'fwstate-subtab-panel--states' : 'fwstate-subtab-panel--scroll'}`}
                                         role="tabpanel"
                                         id="fwstate-subtab-panel"
                                     >

--- a/web/src/pages/modules/fwstate/fwstate.scss
+++ b/web/src/pages/modules/fwstate/fwstate.scss
@@ -180,7 +180,6 @@
 .fws-distrib {
     display: flex;
     align-items: stretch;
-    border-bottom: 1px solid var(--fws-border-soft);
     flex: none;
 }
 
@@ -357,8 +356,7 @@
     min-width: 0;
     display: flex;
     flex-direction: column;
-    border: 1px solid var(--fws-border);
-    border-radius: 8px 8px 0 0;
+    border-top: 1px solid var(--fws-border);
     overflow: hidden;
 }
 
@@ -373,11 +371,9 @@
 }
 
 .fws-tablescroll {
-    flex: 1;
     overflow: auto;
     position: relative;
     scroll-behavior: auto;
-    min-height: 0;
 }
 
 .fws-th {
@@ -565,11 +561,13 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    padding: 10px 20px;
+    padding: 0 20px;
+    height: 41px;
     flex: none;
     border-top: 1px solid var(--fws-border);
     background: var(--fws-panel-2);
-    flex-wrap: wrap;
+    box-sizing: border-box;
+    overflow: hidden;
 }
 
 .fws-pulled {
@@ -684,6 +682,7 @@
     flex: 1;
     overflow: hidden;
     min-height: 0;
+    padding: 0;
 }
 
 .fwstate-sub-tabs {
@@ -741,7 +740,7 @@
     justify-content: space-between;
     flex-wrap: nowrap;
     min-height: 36px;
-    padding-bottom: 9px;
+    padding: 0 20px 9px;
     margin-bottom: 12px;
     border-bottom: 1px solid var(--yn-line-2);
 }
@@ -797,6 +796,7 @@
     flex-direction: column;
     gap: 14px;
     min-width: 0;
+    padding: 0 20px 20px;
 }
 
 .fwstate-config-section__head {
@@ -813,13 +813,6 @@
     letter-spacing: .02em;
     margin-inline-end: 1px;
     margin-inline-start: 2px;
-}
-
-.fwstate-panel {
-    border: 1px solid var(--yn-line-2);
-    border-radius: 8px;
-    background: var(--yn-panel);
-    padding: 14px;
 }
 
 .fwstate-panel-head {
@@ -878,6 +871,7 @@
 
 .fwstate-acl-panel {
     min-height: 0;
+    padding: 0 20px 20px;
 }
 
 .fwstate-table-shell {
@@ -1030,6 +1024,24 @@
     color: var(--yn-text-2);
     font-size: 12px;
     line-height: 1.35;
+}
+
+.yn-flat-page {
+    .fws-tblheader {
+        background: transparent;
+    }
+
+    .fws-cursorbar {
+        background: transparent;
+    }
+
+    .fws-preset-btn {
+        background: rgba(255, 255, 255, .035);
+    }
+
+    .fws-preset-btn--on {
+        background: var(--fws-elev);
+    }
 }
 
 @media (max-width: 1280px) {


### PR DESCRIPTION
Remove the boxed, padded panel that wrapped the FWState sub-tab content so the content sits flush, matching the other module pages. The inset previously supplied by that panel is relocated onto each sub-tab's own container.

Pin the States tab cursor bar to the bottom of the page, and bound the virtualized state table to a fixed viewport height so it stays performant for large state sets.

Apply the shared flat surface to the whole page so the background matches the ACL page, blending the States tab chrome onto the unified surface.