### PR TITLE
refactor(web): flatten pdump page layout and unify background

### DIFF
--- a/web/src/pages/modules/pdump/PdumpPage.tsx
+++ b/web/src/pages/modules/pdump/PdumpPage.tsx
@@ -436,15 +436,15 @@ const PdumpPage: React.FC = () => {
 
     if (loading) {
         return (
-            <PageLayout header={pageHeader}>
+            <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
             </PageLayout>
         );
     }
 
     return (
-        <PageLayout header={pageHeader}>
-            <div className="yn-page pdump-page">
+        <PageLayout header={pageHeader} className="yn-flat-layout">
+            <div className="yn-page pdump-page yn-flat-page">
                 {configs.length === 0 ? (
                     <div className="yn-empty-page">
                         <div className="yn-empty-page__message">

--- a/web/src/pages/modules/pdump/pdump.scss
+++ b/web/src/pages/modules/pdump/pdump.scss
@@ -879,6 +879,52 @@
     }
 }
 
+// Flat-surface overrides: re-apply insets and strip boxed-panel chrome
+// so the filter card, config strip, and packet table read flush on #1C1814.
+.yn-flat-page {
+    .pdump-filter-card {
+        background: transparent;
+        border-color: var(--yn-line-2);
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+        border-top: 1px solid var(--yn-line-2);
+        border-bottom: 1px solid var(--yn-line-2);
+
+        &__expr-wrap::after {
+            background: linear-gradient(to right, transparent, var(--yn-surface-bg));
+        }
+    }
+
+    .pdump-strip {
+        background: transparent;
+        border-color: var(--yn-line-2);
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+        border-top: none;
+        border-bottom: 1px solid var(--yn-line-2);
+    }
+
+    .packet-table {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+    }
+
+    .packet-table__toolbar {
+        background: transparent;
+    }
+
+    .packet-table__footer {
+        background: transparent;
+    }
+
+    .packet-table-header {
+        background: transparent;
+    }
+}
+
 // Config dialog row layout.
 .config-dialog {
     &__row {


### PR DESCRIPTION
Apply the shared flat-surface treatment to the Pdump page so it matches the ACL and FWState pages.

- Add `yn-flat-layout` to the page layout and `yn-flat-page` to the page root.
- Strip the boxed panel chrome from the filter card, config strip, and packet table so they read flush on the unified `#1C1814` surface.