### PR TITLE
feat: add ready subcommand to route operator CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,6 +3399,7 @@ dependencies = [
  "log",
  "netip",
  "prost",
+ "prost-types",
  "serde",
  "tabled",
  "tokio",
@@ -3406,6 +3407,7 @@ dependencies = [
  "tonic-build",
  "yanet-cli",
  "yanet-commonpb",
+ "yanet-readinesspb",
 ]
 
 [[package]]

--- a/operators/route/cli/route/Cargo.toml
+++ b/operators/route/cli/route/Cargo.toml
@@ -13,9 +13,11 @@ path = "src/main.rs"
 [dependencies]
 ync = { path = "../../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
+readinesspb = { path = "../../../../common/rust/readinesspb", version = "0.1", package = "yanet-readinesspb" }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
+prost-types = "0.13"
 log = "0.4"
 netip = "0.3"
 colored = "3"

--- a/operators/route/cli/route/build.rs
+++ b/operators/route/cli/route/build.rs
@@ -2,6 +2,7 @@ use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../operatorpb/v1/route.proto");
+    println!("cargo:rerun-if-changed=../../operatorpb/v1/readiness.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
@@ -20,8 +21,12 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             "#[serde(serialize_with = \"crate::serialize_ip_addr\")]",
         )
         .extern_path(".commonpb", "::commonpb::pb")
+        .extern_path(".readinesspb", "::readinesspb::pb")
         .compile_protos(
-            &["../../../../operators/route/operatorpb/v1/route.proto"],
+            &[
+                "../../../../operators/route/operatorpb/v1/route.proto",
+                "../../../../operators/route/operatorpb/v1/readiness.proto",
+            ],
             &["../../../../"],
         )
         .map_err(Into::into)

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -30,7 +30,7 @@ use ync::{
 
 use crate::operatorpb::{
     DeleteRouteRequest, FlushRoutesRequest, InsertRouteRequest, ListConfigsRequest, LookupRouteRequest, RouteSourceId,
-    ShowRoutesRequest, route_service_client::RouteServiceClient,
+    ShowRoutesRequest, readiness_service_client::ReadinessServiceClient, route_service_client::RouteServiceClient,
 };
 
 #[allow(clippy::all, non_snake_case)]
@@ -40,6 +40,12 @@ pub mod operatorpb {
 
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "operators.route.operatorpb.v1.RouteService";
+
+/// The fully-qualified gRPC readiness service name used in error messages.
+const READINESS_SERVICE_NAME: &str = "operators.route.operatorpb.v1.ReadinessService";
+
+/// Exit code used when the RPC succeeds but not all scopes are `STATE_READY`.
+const EXIT_NOT_READY: i32 = 2;
 
 /// Route operator CLI (RIB management).
 #[derive(Debug, Clone, Parser)]
@@ -71,6 +77,14 @@ pub enum ModeCmd {
     Remove(RouteRemoveCmd),
     /// Flush RIB to FIB for a configuration.
     Flush(RouteFlushCmd),
+    /// Show per-scope readiness of the route operator.
+    Ready(ReadyCmd),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ReadyCmd {
+    /// Restrict output to these scope names; empty means all.
+    pub scopes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -162,27 +176,38 @@ pub async fn main() {
 
     ync::init(cmd.verbose, cmd.format);
 
-    if let Err(err) = run(cmd).await {
-        output::failure(&err);
-        std::process::exit(err.exit_code());
+    match run(cmd).await {
+        Ok(true) => {}
+        Ok(false) => std::process::exit(EXIT_NOT_READY),
+        Err(err) => {
+            output::failure(&err);
+            std::process::exit(err.exit_code());
+        }
     }
 }
 
-async fn run(cmd: Cmd) -> Result<(), Error> {
+/// Run the requested subcommand.
+///
+/// Returns `Ok(true)` when the RPC succeeded and every returned scope is
+/// `STATE_READY`, `Ok(false)` when the RPC succeeded but at least one scope
+/// is not ready, and `Err(_)` on transport or RPC failure.
+async fn run(cmd: Cmd) -> Result<bool, Error> {
     let mut service = RouteService::new(&cmd.connection).await?;
 
     match cmd.mode {
-        ModeCmd::List => service.list_configs().await,
-        ModeCmd::Show(c) => service.show_routes(c).await,
-        ModeCmd::Lookup(c) => service.lookup_route(c).await,
-        ModeCmd::Insert(c) => service.insert_route(c).await,
-        ModeCmd::Remove(c) => service.remove_route(c).await,
-        ModeCmd::Flush(c) => service.flush_routes(c).await,
+        ModeCmd::List => service.list_configs().await.map(|()| true),
+        ModeCmd::Show(c) => service.show_routes(c).await.map(|()| true),
+        ModeCmd::Lookup(c) => service.lookup_route(c).await.map(|()| true),
+        ModeCmd::Insert(c) => service.insert_route(c).await.map(|()| true),
+        ModeCmd::Remove(c) => service.remove_route(c).await.map(|()| true),
+        ModeCmd::Flush(c) => service.flush_routes(c).await.map(|()| true),
+        ModeCmd::Ready(c) => service.ready(c).await,
     }
 }
 
 pub struct RouteService {
     client: RouteServiceClient<LayeredChannel>,
+    readiness: ReadinessServiceClient<LayeredChannel>,
     endpoint: String,
 }
 
@@ -191,12 +216,16 @@ impl RouteService {
         let channel = ync::client::connect(connection)
             .await
             .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
-        let client = RouteServiceClient::new(channel)
+        let client = RouteServiceClient::new(channel.clone())
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip);
+        let readiness = ReadinessServiceClient::new(channel)
             .send_compressed(CompressionEncoding::Gzip)
             .accept_compressed(CompressionEncoding::Gzip);
 
         Ok(Self {
             client,
+            readiness,
             endpoint: connection.endpoint.clone(),
         })
     }
@@ -347,6 +376,76 @@ impl RouteService {
 
         Ok(())
     }
+
+    pub async fn ready(&mut self, cmd: ReadyCmd) -> Result<bool, Error> {
+        let request = readinesspb::pb::ReadyRequest { scopes: cmd.scopes.clone() };
+
+        let response = self
+            .readiness
+            .ready(request)
+            .await
+            .map_err(|status| Error::from_status(status, "ready", self.endpoint.clone(), READINESS_SERVICE_NAME))?
+            .into_inner();
+
+        let returned_names: std::collections::HashSet<&str> =
+            response.scopes.iter().map(|scope| scope.name.as_str()).collect();
+
+        let missing: Vec<&str> = cmd
+            .scopes
+            .iter()
+            .map(String::as_str)
+            .filter(|name| !returned_names.contains(name))
+            .collect();
+
+        let all_scopes_ready = response
+            .scopes
+            .iter()
+            .all(|scope| scope.state == readinesspb::pb::State::Ready as i32);
+
+        let all_ready = all_scopes_ready && missing.is_empty();
+
+        let total = response.scopes.len();
+        let ready_count = response
+            .scopes
+            .iter()
+            .filter(|scope| scope.state == readinesspb::pb::State::Ready as i32)
+            .count();
+
+        output::data(
+            &response.scopes,
+            response.scopes.is_empty() && missing.is_empty(),
+            format_args!("no scopes"),
+            || {
+                let mut rows: Vec<ReadinessRow> = response.scopes.iter().map(ReadinessRow::from).collect();
+                rows.sort_by(|a, b| a.scope.cmp(&b.scope));
+
+                if !rows.is_empty() {
+                    print_readiness_table(rows);
+                }
+
+                if !missing.is_empty() {
+                    let missing_list = missing.join(", ");
+                    let label = "missing (not registered):";
+
+                    if output::is_colored() {
+                        println!("{} {}", label.red(), missing_list.red());
+                    } else {
+                        println!("{label} {missing_list}");
+                    }
+                }
+
+                let missing_count = missing.len();
+
+                if missing_count > 0 {
+                    println!("summary: {ready_count}/{total} ready, {missing_count} requested scope missing");
+                } else {
+                    println!("summary: {ready_count}/{total} ready");
+                }
+            },
+        );
+
+        Ok(all_ready)
+    }
 }
 
 #[derive(Debug)]
@@ -484,6 +583,115 @@ fn print_route_table(entries: Vec<RouteEntry>) {
     println!("{table}");
 }
 
+/// Wraps a readiness state for colored display in the table.
+pub struct StateCell(readinesspb::pb::State);
+
+impl Display for StateCell {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        let StateCell(state) = self;
+        let name = state.as_str_name().strip_prefix("STATE_").unwrap_or_default();
+
+        if output::is_colored() {
+            let colored = match state {
+                readinesspb::pb::State::Ready => name.green().to_string(),
+                readinesspb::pb::State::Degraded => name.yellow().to_string(),
+                readinesspb::pb::State::NotReady => name.red().to_string(),
+                readinesspb::pb::State::Unspecified | readinesspb::pb::State::Unknown => {
+                    name.truecolor(127, 127, 127).to_string()
+                }
+            };
+            write!(f, "{colored}")
+        } else {
+            write!(f, "{name}")
+        }
+    }
+}
+
+#[derive(Debug, Tabled)]
+pub struct ReadinessRow {
+    #[tabled(rename = "Scope")]
+    pub scope: String,
+    #[tabled(rename = "State")]
+    pub state: String,
+    #[tabled(rename = "Last Transition")]
+    pub last_transition: String,
+    #[tabled(rename = "Observed")]
+    pub observed: String,
+    #[tabled(rename = "Reasons")]
+    pub reasons: String,
+}
+
+impl From<&readinesspb::pb::Scope> for ReadinessRow {
+    fn from(scope: &readinesspb::pb::Scope) -> Self {
+        let state = readinesspb::pb::State::try_from(scope.state).unwrap_or_default();
+        let state_cell = StateCell(state);
+
+        let reasons = scope
+            .reasons
+            .iter()
+            .map(|reason| format!("{}: {}", reason.code, reason.message))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        Self {
+            scope: scope.name.clone(),
+            state: state_cell.to_string(),
+            last_transition: format_age(scope.last_transition_time.as_ref()),
+            observed: format_age(scope.observed_at.as_ref()),
+            reasons,
+        }
+    }
+}
+
+/// Formats a `prost_types::Timestamp` as a human-readable relative age.
+///
+/// Returns `"-"` when `ts` is `None` or the zero sentinel
+/// (`seconds == 0 && nanos == 0`). Otherwise formats as `Xs ago`,
+/// `XmYs ago`, or `XhYm ago` depending on magnitude.
+pub fn format_age(ts: Option<&prost_types::Timestamp>) -> String {
+    let ts = match ts {
+        Some(ts) if ts.seconds != 0 || ts.nanos != 0 => ts,
+        _ => return "-".to_string(),
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+
+    let ts_secs = ts.seconds.max(0) as u64;
+    let now_secs = now.as_secs();
+
+    let secs = now_secs.saturating_sub(ts_secs);
+
+    if secs < 60 {
+        format!("{secs}s ago")
+    } else if secs < 3600 {
+        let minutes = secs / 60;
+        let remainder = secs % 60;
+        format!("{minutes}m{remainder}s ago")
+    } else {
+        let hours = secs / 3600;
+        let minutes = (secs % 3600) / 60;
+        format!("{hours}h{minutes}m ago")
+    }
+}
+
+fn print_readiness_table(rows: Vec<ReadinessRow>) {
+    let mut table = Table::new(&rows);
+    table.with(
+        Style::modern()
+            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
+            .remove_horizontal(),
+    );
+
+    if output::is_colored() {
+        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
+        table.modify(Rows::first(), Color::BOLD);
+    }
+
+    println!("{table}");
+}
+
 /// Returns the lowercase display name for a `RouteSourceId` discriminant.
 ///
 /// Converts a raw `i32` source value to its lowercase string name by calling
@@ -515,5 +723,57 @@ where
     match value {
         Some(addr) => serializer.serialize_str(&addr.to_string()),
         None => serializer.serialize_none(),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn format_age_none_returns_dash() {
+        assert_eq!("-", format_age(None));
+    }
+
+    #[test]
+    fn format_age_zero_sentinel_returns_dash() {
+        let ts = prost_types::Timestamp { seconds: 0, nanos: 0 };
+        assert_eq!("-", format_age(Some(&ts)));
+    }
+
+    #[test]
+    fn format_age_seconds() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let ts = prost_types::Timestamp {
+            seconds: now.as_secs() as i64 - 30,
+            nanos: 0,
+        };
+        assert_eq!("30s ago", format_age(Some(&ts)));
+    }
+
+    #[test]
+    fn format_age_minutes() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let ts = prost_types::Timestamp {
+            seconds: now.as_secs() as i64 - 64,
+            nanos: 0,
+        };
+        assert_eq!("1m4s ago", format_age(Some(&ts)));
+    }
+
+    #[test]
+    fn format_age_hours() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let ts = prost_types::Timestamp {
+            seconds: now.as_secs() as i64 - (2 * 3600 + 3 * 60),
+            nanos: 0,
+        };
+        assert_eq!("2h3m ago", format_age(Some(&ts)));
     }
 }


### PR DESCRIPTION
Adds a `ready` subcommand to the `yanet-cli-operator-route` binary, so `yanet-cli operator route ready [SCOPES...]` reports the route operator's per-scope readiness.

The command calls the operator's `ReadinessService.Ready` RPC and prints a per-scope table (state, last transition, observed age, reasons). It exits with code 2 when the RPC succeeds but at least one scope is not ready or a requested scope is missing, making it usable as a health probe.

Modeled on the forward operator readiness CLI, adapted to the route operator's per-scope terminology. The server-side `ReadinessService` and shared readiness message types already exist, so this is a CLI-only change.