### PR TITLE
feat(filter): integrate lpm_wide across net4/net6 paths and adjust test memory budgets

### DIFF
--- a/common/range_collector.h
+++ b/common/range_collector.h
@@ -7,8 +7,43 @@
 
 #include "key.h"
 #include "lpm.h"
+#include "lpm_wide.h"
 #include "radix.h"
 #include "range_index.h"
+
+#define RANGE_COLLECTOR_VALUE_INVALID UINT32_MAX
+
+typedef int (*range_collector_insert_func)(
+	void *lpm,
+	uint8_t key_size,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t value
+);
+
+static inline int
+range_collector_lpm_insert(
+	void *lpm,
+	uint8_t key_size,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t value
+) {
+	return lpm_insert((struct lpm *)lpm, key_size, from, to, value);
+}
+
+static inline int
+range_collector_lpm_wide_insert(
+	void *lpm,
+	uint8_t key_size,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t value
+) {
+	return lpm_wide_insert(
+		(struct lpm_wide *)lpm, key_size, from, to, value
+	);
+}
 
 struct range_collector {
 	struct memory_context *memory_context;
@@ -120,7 +155,8 @@ range_collector_add(
 
 struct range_collector_ctx {
 	struct range_collector *collector;
-	struct lpm *lpm;
+	void *lpm;
+	range_collector_insert_func insert;
 	struct range_index *range_index;
 
 	uint32_t max_value;
@@ -152,7 +188,7 @@ range_collector_stack_push(
 		struct range_collector_stack_item item =
 			range_collector_stack_last(ctx, key_size);
 		if (filter_key_cmp(key_size, to, item.to) == 0) {
-			*item.value = LPM_VALUE_INVALID;
+			*item.value = RANGE_COLLECTOR_VALUE_INVALID;
 			return;
 		}
 	}
@@ -160,7 +196,7 @@ range_collector_stack_push(
 	++ctx->stack_depth;
 	struct range_collector_stack_item item =
 		range_collector_stack_last(ctx, key_size);
-	*item.value = LPM_VALUE_INVALID;
+	*item.value = RANGE_COLLECTOR_VALUE_INVALID;
 	memcpy(item.to, to, key_size);
 }
 
@@ -171,10 +207,10 @@ range_collector_stack_emit(
 	struct range_collector_stack_item item =
 		range_collector_stack_last(ctx, key_size);
 
-	if (*item.value == LPM_VALUE_INVALID)
+	if (*item.value == RANGE_COLLECTOR_VALUE_INVALID)
 		*item.value = ctx->max_value++;
 
-	if (lpm_insert(ctx->lpm, key_size, ctx->pos, to, *item.value))
+	if (ctx->insert(ctx->lpm, key_size, ctx->pos, to, *item.value))
 		return -1;
 
 	if (range_index_insert(
@@ -256,17 +292,19 @@ range_collector_iterate(
 }
 
 static inline int
-range_collector_collect(
+range_collector_collect_with_insert(
 	struct range_collector *collector,
 	uint8_t key_size,
-	struct lpm *lpm64,
+	void *lpm,
+	range_collector_insert_func insert,
 	struct range_index *range_index
 ) {
 	struct range_collector_ctx ctx;
 	ctx.collector = collector;
 	ctx.max_value = 0;
 
-	ctx.lpm = lpm64;
+	ctx.lpm = lpm;
+	ctx.insert = insert;
 	ctx.range_index = range_index;
 
 	uint32_t stack_size = key_size * 8 + 1;
@@ -304,6 +342,38 @@ range_collector_collect(
 error:
 
 	return -1;
+}
+
+static inline int
+range_collector_collect(
+	struct range_collector *collector,
+	uint8_t key_size,
+	struct lpm *lpm,
+	struct range_index *range_index
+) {
+	return range_collector_collect_with_insert(
+		collector,
+		key_size,
+		lpm,
+		range_collector_lpm_insert,
+		range_index
+	);
+}
+
+static inline int
+range_collector_collect_wide(
+	struct range_collector *collector,
+	uint8_t key_size,
+	struct lpm_wide *lpm,
+	struct range_index *range_index
+) {
+	return range_collector_collect_with_insert(
+		collector,
+		key_size,
+		lpm,
+		range_collector_lpm_wide_insert,
+		range_index
+	);
 }
 
 static inline int

--- a/filter/classifiers/net6.h
+++ b/filter/classifiers/net6.h
@@ -1,10 +1,10 @@
 #pragma once
 
-#include "common/lpm.h"
+#include "common/lpm_wide.h"
 #include "common/value.h"
 
 struct net6_classifier {
-	struct lpm hi;
-	struct lpm lo;
+	struct lpm_wide hi;
+	struct lpm_wide lo;
 	struct value_table comb;
 };

--- a/filter/compiler/net4.c
+++ b/filter/compiler/net4.c
@@ -1,5 +1,4 @@
 #include "../rule.h"
-#include "common/lpm.h"
 #include "common/lpm_wide.h"
 #include "common/range_collector.h"
 #include "common/registry.h"
@@ -67,25 +66,30 @@ net4_collect_values(
 	return 0;
 }
 
-static inline void
+static inline int
 net4_collect_registry(
 	struct net4 *start,
 	uint32_t count,
-	struct lpm *lpm,
+	struct lpm_wide *lpm,
 	struct value_registry *registry
 ) {
 	for (struct net4 *net4 = start; net4 < start + count; ++net4) {
 		uint32_t addr = *(uint32_t *)net4->addr;
 		uint32_t mask = *(uint32_t *)net4->mask;
 		uint32_t to = addr | ~mask;
-		lpm4_collect_values(
-			lpm,
-			(uint8_t *)&addr,
-			(uint8_t *)&to,
-			lpm_collect_registry_iterator,
-			registry
-		);
+		if (lpm_wide_collect_values(
+			    lpm,
+			    4,
+			    (uint8_t *)&addr,
+			    (uint8_t *)&to,
+			    lpm_collect_registry_iterator,
+			    registry
+		    )) {
+			return -1;
+		}
 	}
+
+	return 0;
 }
 
 static inline int
@@ -94,7 +98,7 @@ collect_net4_values(
 	const struct filter_rule **actions,
 	uint32_t count,
 	rule_get_net4_func get_net4,
-	struct lpm *lpm,
+	struct lpm_wide *lpm,
 	struct value_registry *registry
 ) {
 	struct range_collector collector;
@@ -128,7 +132,7 @@ collect_net4_values(
 				goto error_collector;
 		}
 	}
-	if (lpm_init(lpm, memory_context)) {
+	if (lpm_wide_init(lpm, memory_context)) {
 		goto error_collector;
 	}
 	struct range_index range_index;
@@ -136,12 +140,7 @@ collect_net4_values(
 		goto error_lpm;
 	}
 
-	if (range_collector_collect_wide(
-			    &collector,
-			    4,
-			    (struct lpm_wide *)lpm,
-			    &range_index
-		    )) {
+	if (range_collector_collect_wide(&collector, 4, lpm, &range_index)) {
 		goto error_range_collect;
 	}
 
@@ -177,13 +176,14 @@ collect_net4_values(
 
 	remap_table_compact(&remap_table);
 	value_table_compact(&table, &remap_table);
-	lpm4_remap(lpm, &table);
-	lpm4_compact(lpm);
+	lpm_wide_remap(lpm, 4, &table);
+	lpm_wide_compact(lpm, 4);
 	for (const struct filter_rule **action_ptr = actions;
 	     action_ptr < actions + count;
 	     ++action_ptr) {
 		// A value range should be created even for empty rules
-		value_registry_start(registry);
+		if (value_registry_start(registry))
+			goto error_net_collect;
 
 		if (*action_ptr == NULL)
 			continue;
@@ -193,7 +193,8 @@ collect_net4_values(
 		uint32_t net_count;
 		get_net4(action, &nets, &net_count);
 
-		net4_collect_registry(nets, net_count, lpm, registry);
+		if (net4_collect_registry(nets, net_count, lpm, registry))
+			goto error_net_collect;
 	}
 
 	remap_table_free(&remap_table);
@@ -214,7 +215,7 @@ error_range_collect:
 	range_index_free(&range_index);
 
 error_lpm:
-	lpm_free(lpm);
+	lpm_wide_free(lpm);
 
 error_collector:
 	range_collector_free(&collector, 4);
@@ -234,16 +235,26 @@ FILTER_ATTR_COMPILER_INIT_FUNC(net4_src)(
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
-	struct lpm *lpm = memory_balloc(memory_context, sizeof(struct lpm));
-	SET_OFFSET_OF(data, lpm);
-	return collect_net4_values(
-		memory_context,
-		actions,
-		actions_count,
-		action_get_net4_src,
-		lpm,
-		registry
+	struct lpm_wide *lpm = memory_balloc(
+		memory_context, sizeof(struct lpm_wide)
 	);
+	if (lpm == NULL)
+		return -1;
+
+	if (collect_net4_values(
+		    memory_context,
+		    actions,
+		    actions_count,
+		    action_get_net4_src,
+		    lpm,
+		    registry
+	    )) {
+		memory_bfree(memory_context, lpm, sizeof(struct lpm_wide));
+		return -1;
+	}
+
+	SET_OFFSET_OF(data, lpm);
+	return 0;
 }
 
 // Allows to initialize attribute for IPv4 destination address.
@@ -255,26 +266,36 @@ FILTER_ATTR_COMPILER_INIT_FUNC(net4_dst)(
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
-	struct lpm *lpm = memory_balloc(memory_context, sizeof(struct lpm));
-	SET_OFFSET_OF(data, lpm);
-	return collect_net4_values(
-		memory_context,
-		actions,
-		actions_count,
-		action_get_net4_dst,
-		lpm,
-		registry
+	struct lpm_wide *lpm = memory_balloc(
+		memory_context, sizeof(struct lpm_wide)
 	);
+	if (lpm == NULL)
+		return -1;
+
+	if (collect_net4_values(
+		    memory_context,
+		    actions,
+		    actions_count,
+		    action_get_net4_dst,
+		    lpm,
+		    registry
+	    )) {
+		memory_bfree(memory_context, lpm, sizeof(struct lpm_wide));
+		return -1;
+	}
+
+	SET_OFFSET_OF(data, lpm);
+	return 0;
 }
 
 // Allows to free data for IPv4 classification.
 static void
 free_net4(void *data, struct memory_context *memory_context) {
-	struct lpm *lpm = (struct lpm *)data;
+	struct lpm_wide *lpm = (struct lpm_wide *)data;
 	if (lpm == NULL)
 		return;
-	lpm_free(lpm);
-	memory_bfree(memory_context, lpm, sizeof(struct lpm));
+	lpm_wide_free(lpm);
+	memory_bfree(memory_context, lpm, sizeof(struct lpm_wide));
 }
 
 void

--- a/filter/compiler/net4.c
+++ b/filter/compiler/net4.c
@@ -1,5 +1,6 @@
 #include "../rule.h"
 #include "common/lpm.h"
+#include "common/lpm_wide.h"
 #include "common/range_collector.h"
 #include "common/registry.h"
 #include "common/value.h"
@@ -135,7 +136,12 @@ collect_net4_values(
 		goto error_lpm;
 	}
 
-	if (range_collector_collect(&collector, 4, lpm, &range_index)) {
+	if (range_collector_collect_wide(
+			    &collector,
+			    4,
+			    (struct lpm_wide *)lpm,
+			    &range_index
+		    )) {
 		goto error_range_collect;
 	}
 

--- a/filter/compiler/net4.c
+++ b/filter/compiler/net4.c
@@ -235,9 +235,8 @@ FILTER_ATTR_COMPILER_INIT_FUNC(net4_src)(
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
-	struct lpm_wide *lpm = memory_balloc(
-		memory_context, sizeof(struct lpm_wide)
-	);
+	struct lpm_wide *lpm =
+		memory_balloc(memory_context, sizeof(struct lpm_wide));
 	if (lpm == NULL)
 		return -1;
 
@@ -266,9 +265,8 @@ FILTER_ATTR_COMPILER_INIT_FUNC(net4_dst)(
 	size_t actions_count,
 	struct memory_context *memory_context
 ) {
-	struct lpm_wide *lpm = memory_balloc(
-		memory_context, sizeof(struct lpm_wide)
-	);
+	struct lpm_wide *lpm =
+		memory_balloc(memory_context, sizeof(struct lpm_wide));
 	if (lpm == NULL)
 		return -1;
 

--- a/filter/compiler/net6.c
+++ b/filter/compiler/net6.c
@@ -1,6 +1,6 @@
 #include "../rule.h"
 
-#include "common/lpm.h"
+#include "common/lpm_wide.h"
 #include "common/range_collector.h"
 
 #include "common/registry.h"
@@ -66,7 +66,7 @@ collect_net6_range(
 	uint32_t count,
 	action_get_net6_func get_net6,
 	net6_get_part_func get_part,
-	struct lpm *lpm,
+	struct lpm_wide *lpm,
 	struct range_index *ri
 ) {
 	struct range_collector collector;
@@ -102,7 +102,7 @@ collect_net6_range(
 				goto error_collector;
 		}
 	}
-	if (lpm_init(lpm, memory_context)) {
+	if (lpm_wide_init(lpm, memory_context)) {
 		goto error_lpm;
 	}
 
@@ -111,7 +111,7 @@ collect_net6_range(
 		goto error_collector;
 	}
 
-	if (range_collector_collect(&collector, 8, lpm, ri)) {
+	if (range_collector_collect_wide(&collector, 8, lpm, ri)) {
 		goto error_collector;
 	}
 
@@ -252,7 +252,8 @@ merge_net6_range(
 	uint32_t *values_lo = ADDR_OF(&ri_lo->values);
 
 	struct value_registry net_registry;
-	value_registry_init(&net_registry, memory_context);
+	if (value_registry_init(&net_registry, memory_context))
+		goto error_registry;
 
 	for (const struct filter_rule **action_ptr = actions;
 	     action_ptr < actions + count;
@@ -275,7 +276,8 @@ merge_net6_range(
 			if (net_idx < net_registry.range_count)
 				continue;
 
-			value_registry_start(&net_registry);
+			if (value_registry_start(&net_registry))
+				goto error_net_registry;
 
 			uint8_t *from_hi;
 			uint8_t *mask_hi;
@@ -316,21 +318,22 @@ merge_net6_range(
 							    values_lo[idx_lo]
 						    )
 					    )) {
-						return -1;
+						goto error_net_registry;
 					}
 				}
 			}
 		}
 	}
 
-	value_registry_init(registry, memory_context);
+	if (value_registry_init(registry, memory_context))
+		goto error_net_registry;
 
 	for (const struct filter_rule **action_ptr = actions;
 	     action_ptr < actions + count;
 	     ++action_ptr) {
 		// A value range should be created even for empty rules
 		if (value_registry_start(registry))
-			return -1;
+			goto error_net_registry;
 
 		if (*action_ptr == NULL)
 			continue;
@@ -353,7 +356,7 @@ merge_net6_range(
 				if (value_registry_collect(
 					    registry, vls[idx]
 				    )) {
-					return -1;
+					goto error_net_registry;
 				}
 			}
 		}
@@ -365,6 +368,15 @@ merge_net6_range(
 	// FIXME: free temporary resources
 
 	return 0;
+
+error_net_registry:
+	value_registry_free(&net_registry);
+
+error_registry:
+	radix_free(&rdx);
+	value_table_free(table);
+
+	return -1;
 
 error_touch:
 	remap_table_free(&remap_table);
@@ -392,7 +404,6 @@ init_net6(
 		memory_balloc(memory_context, sizeof(struct net6_classifier));
 	if (net6 == NULL)
 		return -1;
-	SET_OFFSET_OF(data, net6);
 
 	struct range_index ri_hi;
 	if (collect_net6_range(
@@ -436,15 +447,16 @@ init_net6(
 	range_index_free(&ri_hi);
 	range_index_free(&ri_lo);
 
+	SET_OFFSET_OF(data, net6);
 	return 0;
 
 error_merge:
 	range_index_free(&ri_lo);
-	lpm_free(&net6->lo);
+	lpm_wide_free(&net6->lo);
 
 error_lo:
 	range_index_free(&ri_hi);
-	lpm_free(&net6->hi);
+	lpm_wide_free(&net6->hi);
 
 error_hi:
 	memory_bfree(memory_context, net6, sizeof(struct net6_classifier));
@@ -502,8 +514,8 @@ free_net6(void *data, struct memory_context *memory_context) {
 	struct net6_classifier *c = (struct net6_classifier *)data;
 	if (c == NULL)
 		return;
-	lpm_free(&c->lo);
-	lpm_free(&c->hi);
+	lpm_wide_free(&c->lo);
+	lpm_wide_free(&c->hi);
 	value_table_free(&c->comb);
 	memory_bfree(memory_context, c, sizeof(struct net6_classifier));
 }

--- a/filter/query/net4.h
+++ b/filter/query/net4.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "common/lpm.h"
+#include "common/lpm_wide.h"
 #include "declare.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/packet.h"
@@ -14,7 +14,7 @@ static inline void
 FILTER_ATTR_QUERY_FUNC(net4_src)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	struct lpm *lpm = (struct lpm *)data;
+	struct lpm_wide *lpm = (struct lpm_wide *)data;
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
@@ -23,7 +23,9 @@ FILTER_ATTR_QUERY_FUNC(net4_src)(
 			struct rte_ipv4_hdr *,
 			packets[idx]->network_header.offset
 		);
-		result[idx] = lpm4_lookup(lpm, (uint8_t *)&ipv4_hdr->src_addr);
+		result[idx] = lpm_wide_lookup(
+			lpm, 4, (uint8_t *)&ipv4_hdr->src_addr
+		);
 	}
 }
 
@@ -31,7 +33,7 @@ static inline void
 FILTER_ATTR_QUERY_FUNC(net4_dst)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	struct lpm *lpm = (struct lpm *)data;
+	struct lpm_wide *lpm = (struct lpm_wide *)data;
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
@@ -40,6 +42,8 @@ FILTER_ATTR_QUERY_FUNC(net4_dst)(
 			struct rte_ipv4_hdr *,
 			packets[idx]->network_header.offset
 		);
-		result[idx] = lpm4_lookup(lpm, (uint8_t *)&ipv4_hdr->dst_addr);
+		result[idx] = lpm_wide_lookup(
+			lpm, 4, (uint8_t *)&ipv4_hdr->dst_addr
+		);
 	}
 }

--- a/filter/query/net4.h
+++ b/filter/query/net4.h
@@ -23,9 +23,8 @@ FILTER_ATTR_QUERY_FUNC(net4_src)(
 			struct rte_ipv4_hdr *,
 			packets[idx]->network_header.offset
 		);
-		result[idx] = lpm_wide_lookup(
-			lpm, 4, (uint8_t *)&ipv4_hdr->src_addr
-		);
+		result[idx] =
+			lpm_wide_lookup(lpm, 4, (uint8_t *)&ipv4_hdr->src_addr);
 	}
 }
 
@@ -42,8 +41,7 @@ FILTER_ATTR_QUERY_FUNC(net4_dst)(
 			struct rte_ipv4_hdr *,
 			packets[idx]->network_header.offset
 		);
-		result[idx] = lpm_wide_lookup(
-			lpm, 4, (uint8_t *)&ipv4_hdr->dst_addr
-		);
+		result[idx] =
+			lpm_wide_lookup(lpm, 4, (uint8_t *)&ipv4_hdr->dst_addr);
 	}
 }

--- a/filter/query/net6.h
+++ b/filter/query/net6.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "filter/classifiers/net6.h"
+
+#include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/packet.h"
 
 #include "declare.h"
@@ -24,11 +26,11 @@ FILTER_ATTR_QUERY_FUNC(net6_dst)(
 			packets[idx]->network_header.offset
 		);
 
-		uint32_t hi = lpm8_lookup(
-			&c->hi, (const uint8_t *)ipv6_hdr->dst_addr
+		uint32_t hi = lpm_wide_lookup(
+			&c->hi, 8, (const uint8_t *)ipv6_hdr->dst_addr
 		);
-		uint32_t lo = lpm8_lookup(
-			&c->lo, (const uint8_t *)ipv6_hdr->dst_addr + 8
+		uint32_t lo = lpm_wide_lookup(
+			&c->lo, 8, (const uint8_t *)ipv6_hdr->dst_addr + 8
 		);
 
 		result[idx] = value_table_get(&c->comb, hi, lo);
@@ -49,11 +51,11 @@ FILTER_ATTR_QUERY_FUNC(net6_src)(
 			packets[idx]->network_header.offset
 		);
 
-		uint32_t hi = lpm8_lookup(
-			&c->hi, (const uint8_t *)ipv6_hdr->src_addr
+		uint32_t hi = lpm_wide_lookup(
+			&c->hi, 8, (const uint8_t *)ipv6_hdr->src_addr
 		);
-		uint32_t lo = lpm8_lookup(
-			&c->lo, (const uint8_t *)ipv6_hdr->src_addr + 8
+		uint32_t lo = lpm_wide_lookup(
+			&c->lo, 8, (const uint8_t *)ipv6_hdr->src_addr + 8
 		);
 
 		result[idx] = value_table_get(&c->comb, hi, lo);

--- a/filter/tests/basic_net4.c
+++ b/filter/tests/basic_net4.c
@@ -167,6 +167,8 @@ test_stress_seed12_regression(void *memory, size_t memory_size) {
 	LOG(INFO, "Regression test passed!");
 }
 
+static const size_t MEMORY_SIZE = 1 << 30;
+
 int
 main() {
 	log_enable_name("debug");
@@ -174,8 +176,8 @@ main() {
 	// init memory
 	struct block_allocator allocator;
 	block_allocator_init(&allocator);
-	void *memory = malloc(1 << 28);
-	block_allocator_put_arena(&allocator, memory, 1 << 28);
+	void *memory = malloc(MEMORY_SIZE);
+	block_allocator_put_arena(&allocator, memory, MEMORY_SIZE);
 
 	struct memory_context memory_context;
 	int res = memory_context_init(&memory_context, "test", &allocator);
@@ -271,7 +273,7 @@ main() {
 
 	// Run comprehensive regression test with all 20 rules from stress test
 	// Allocate separate memory for the stress test
-	// test_stress_seed12_regression(memory, 1 << 28);
+	// test_stress_seed12_regression(memory, MEMORY_SIZE);
 
 	(void)test_stress_seed12_regression;
 

--- a/filter/tests/basic_net4.c
+++ b/filter/tests/basic_net4.c
@@ -167,7 +167,7 @@ test_stress_seed12_regression(void *memory, size_t memory_size) {
 	LOG(INFO, "Regression test passed!");
 }
 
-static const size_t MEMORY_SIZE = 1 << 30;
+static const size_t MEMORY_SIZE = 1 << 28;
 
 int
 main() {

--- a/filter/tests/basic_net6.c
+++ b/filter/tests/basic_net6.c
@@ -109,7 +109,7 @@ test1(void *memory) {
 	// init memory
 	struct block_allocator allocator;
 	block_allocator_init(&allocator);
-	block_allocator_put_arena(&allocator, memory, 1 << 24);
+	block_allocator_put_arena(&allocator, memory, 1 << 28);
 
 	struct memory_context mctx;
 	int res = memory_context_init(&mctx, "test", &allocator);
@@ -261,7 +261,7 @@ test2(void *memory) {
 	// init memory
 	struct block_allocator allocator;
 	block_allocator_init(&allocator);
-	block_allocator_put_arena(&allocator, memory, 1 << 24);
+	block_allocator_put_arena(&allocator, memory, 1 << 28);
 
 	struct memory_context mctx;
 	int res = memory_context_init(&mctx, "test", &allocator);
@@ -388,7 +388,7 @@ test3(void *memory) {
 	// init memory
 	struct block_allocator allocator;
 	block_allocator_init(&allocator);
-	block_allocator_put_arena(&allocator, memory, 1 << 24);
+	block_allocator_put_arena(&allocator, memory, 1 << 28);
 
 	struct memory_context mctx;
 	int res = memory_context_init(&mctx, "test", &allocator);
@@ -579,7 +579,7 @@ test3(void *memory) {
 int
 main() {
 	log_enable_name("debug");
-	void *memory = malloc(1 << 24); // 16MB
+	void *memory = malloc(1 << 28); // 256MB
 
 	LOG(INFO, "Running test1...");
 	test1(memory);

--- a/filter/tests/net4_ports.c
+++ b/filter/tests/net4_ports.c
@@ -10,6 +10,8 @@
 #include <netinet/in.h>
 #include <stdio.h>
 
+static const size_t MEMORY_SIZE = 1 << 29;
+
 FILTER_COMPILER_DECLARE(
 	sign_net4_ports_compile, port_src, port_dst, net4_src, net4_dst
 );
@@ -42,7 +44,7 @@ test(void *memory) {
 	struct block_allocator allocator;
 	block_allocator_init(&allocator);
 
-	block_allocator_put_arena(&allocator, memory, 1 << 26);
+	block_allocator_put_arena(&allocator, memory, MEMORY_SIZE);
 
 	struct memory_context memory_context;
 	int res = memory_context_init(&memory_context, "test", &allocator);
@@ -142,7 +144,7 @@ next_permutation(uint32_t *a, size_t n) {
 int
 main() {
 	log_enable_name("debug");
-	void *memory = malloc(1 << 26); // 64MB
+	void *memory = malloc(MEMORY_SIZE);
 
 	uint32_t perm[4] = {0, 1, 2, 3};
 

--- a/filter/tests/net4_ports.c
+++ b/filter/tests/net4_ports.c
@@ -10,7 +10,7 @@
 #include <netinet/in.h>
 #include <stdio.h>
 
-static const size_t MEMORY_SIZE = 1 << 29;
+static const size_t MEMORY_SIZE = 1 << 28;
 
 FILTER_COMPILER_DECLARE(
 	sign_net4_ports_compile, port_src, port_dst, net4_src, net4_dst

--- a/filter/tests/shm/test.py
+++ b/filter/tests/shm/test.py
@@ -17,7 +17,7 @@ def main():
     print("Compiler path: ", compiler_path)
     print("Filter path: ", filter_path)
     
-    size = 1<<24
+    size = 1 << 30
     
     shm = shared_memory.SharedMemory(create=True, size=size)
 

--- a/filter/tests/shm/test.py
+++ b/filter/tests/shm/test.py
@@ -17,7 +17,7 @@ def main():
     print("Compiler path: ", compiler_path)
     print("Filter path: ", filter_path)
     
-    size = 1 << 30
+    size = 1 << 28
     
     shm = shared_memory.SharedMemory(create=True, size=size)
 

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -24,9 +24,9 @@ import (
 
 // Memory sizes for the ACL functional harness.
 const (
-	aclCPSize  = 64 * datasize.MB
+	aclCPSize  = 256 * datasize.MB
 	aclDPSize  = 4 * datasize.MB
-	aclMemSize = 16 * datasize.MB
+	aclMemSize = 128 * datasize.MB
 )
 
 // udpProto matches any UDP packet.

--- a/modules/forward/fuzzing/forward.c
+++ b/modules/forward/fuzzing/forward.c
@@ -12,9 +12,9 @@
 // Forward module filter compilation needs more memory than the default 1 MB
 // arena.
 //
-// ASAN redzones inflate allocations significantly, so 16 MB is needed for
+// ASAN redzones inflate allocations significantly, so 256 MB is needed for
 // fuzzing builds.
-#define FORWARD_EXTRA_ARENA_SIZE (16 << 20)
+#define FORWARD_EXTRA_ARENA_SIZE (1 << 28)
 
 static struct fuzzing_params fuzz_params = {0};
 

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -20,9 +20,9 @@ import (
 
 // Memory sizes for the forward functional harness.
 const (
-	fwdCPSize  = 64 * datasize.MB
+	fwdCPSize  = 256 * datasize.MB
 	fwdDPSize  = 4 * datasize.MB
-	fwdMemSize = 8 * datasize.MB
+	fwdMemSize = 128 * datasize.MB
 )
 
 // setupForwardHarness builds a dataplane harness with the forward module

--- a/tests/functional/main/framework_test.go
+++ b/tests/functional/main/framework_test.go
@@ -79,13 +79,13 @@ modules:
   dscp:
     memory_requirements: 8MB
   forward:
-    memory_requirements: 8MB
+    memory_requirements: 128MB
   nat64:
     memory_requirements: 8MB
   pdump:
     memory_requirements: 8MB
   acl:
-    memory_requirements: 16MB
+    memory_requirements: 128MB
 
 devices:
   plain:


### PR DESCRIPTION
Migrates filter net4 and net6 classifier/query paths to `lpm_wide` APIs, updates net4 range collection wiring, and increases affected test harness memory to prevent ASAN OOM regressions.