### PR TITLE
fix(web): correct neighbour delete-table dialog wording and add modal shortcuts

### DIFF
--- a/web/src/hooks/useDialogKeyboardShortcut.ts
+++ b/web/src/hooks/useDialogKeyboardShortcut.ts
@@ -7,18 +7,21 @@ export interface UseDialogKeyboardShortcutOptions {
     canSubmit: boolean;
     /** Callback to execute on Ctrl+Enter / Cmd+Enter */
     onConfirm: () => void;
+    /** Optional callback to execute on Escape. When provided and the dialog is open, pressing Escape calls this and prevents default browser handling. */
+    onCancel?: () => void;
 }
 
 /**
- * Hook that adds Ctrl+Enter / Cmd+Enter keyboard shortcut for dialog submission.
+ * Hook that adds Ctrl+Enter / Cmd+Enter keyboard shortcut for dialog submission,
+ * and optionally wires Escape to a cancel callback.
  *
  * @example
  * ```tsx
- * const MyDialog = ({ open, onConfirm }) => {
+ * const MyDialog = ({ open, onConfirm, onClose }) => {
  *   const [canSubmit, setCanSubmit] = useState(false);
  *   const handleConfirm = useCallback(() => { ... }, []);
  *
- *   useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm });
+ *   useDialogKeyboardShortcut({ open, canSubmit, onConfirm: handleConfirm, onCancel: onClose });
  *
  *   return <Dialog>...</Dialog>;
  * };
@@ -28,6 +31,7 @@ export const useDialogKeyboardShortcut = ({
     open,
     canSubmit,
     onConfirm,
+    onCancel,
 }: UseDialogKeyboardShortcutOptions) => {
     useEffect(() => {
         if (!open) return;
@@ -36,11 +40,16 @@ export const useDialogKeyboardShortcut = ({
             if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
                 if (!canSubmit) return;
                 e.preventDefault();
+                e.stopPropagation();
                 onConfirm();
+            } else if (e.key === 'Escape' && onCancel) {
+                e.preventDefault();
+                e.stopPropagation();
+                onCancel();
             }
         };
 
         document.addEventListener('keydown', handleKeyDown);
         return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, canSubmit, onConfirm]);
+    }, [open, canSubmit, onConfirm, onCancel]);
 };

--- a/web/src/pages/_shared/draft/BulkDeleteModal.tsx
+++ b/web/src/pages/_shared/draft/BulkDeleteModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDialogKeyboardShortcut } from '../../../hooks';
 
 interface BulkDeleteModalProps {
     open: boolean;
@@ -21,6 +22,7 @@ const BulkDeleteModal: React.FC<BulkDeleteModalProps> = ({
     onConfirm,
     immediate = false,
 }) => {
+    useDialogKeyboardShortcut({ open, canSubmit: true, onConfirm, onCancel: onClose });
     if (!open) return null;
     return (
         <div className="yn-modal-backdrop" onClick={onClose}>

--- a/web/src/pages/_shared/draft/DeleteConfigModal.test.tsx
+++ b/web/src/pages/_shared/draft/DeleteConfigModal.test.tsx
@@ -1,18 +1,16 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
-import BulkDeleteModal from './BulkDeleteModal';
+import DeleteConfigModal from './DeleteConfigModal';
 
-describe('BulkDeleteModal', () => {
+describe('DeleteConfigModal', () => {
     afterEach(() => {
         cleanup();
     });
 
     it('renders nothing when open is false', () => {
         const { container } = render(
-            <BulkDeleteModal
+            <DeleteConfigModal
                 open={false}
-                count={3}
-                itemNoun="route"
                 configName="main"
                 onClose={() => {}}
                 onConfirm={() => {}}
@@ -21,57 +19,53 @@ describe('BulkDeleteModal', () => {
         expect(container.firstChild).toBeNull();
     });
 
-    it('shows "This action cannot be undone" when immediate is true', () => {
-        render(
-            <BulkDeleteModal
+    it('shows "Delete config" title by default', () => {
+        const { container } = render(
+            <DeleteConfigModal
                 open
-                count={2}
-                itemNoun="route"
                 configName="main"
                 onClose={() => {}}
                 onConfirm={() => {}}
-                immediate
             />,
         );
-        expect(screen.getByText(/This action cannot be undone/i)).toBeInTheDocument();
+        const title = container.querySelector('.yn-modal__title');
+        expect(title?.textContent).toBe('Delete config');
     });
 
-    it('shows draft staging text when immediate is omitted', () => {
-        render(
-            <BulkDeleteModal
+    it('shows "Delete table" title when noun="table"', () => {
+        const { container } = render(
+            <DeleteConfigModal
                 open
-                count={2}
-                itemNoun="route"
-                configName="main"
+                configName="my-table"
                 onClose={() => {}}
                 onConfirm={() => {}}
+                noun="table"
             />,
         );
-        expect(screen.getByText(/Changes are staged in the draft/i)).toBeInTheDocument();
+        const title = container.querySelector('.yn-modal__title');
+        expect(title?.textContent).toBe('Delete table');
     });
 
-    it('shows draft staging text when immediate is explicitly false', () => {
-        render(
-            <BulkDeleteModal
+    it('uses the noun in the body text', () => {
+        const { container } = render(
+            <DeleteConfigModal
                 open
-                count={2}
-                itemNoun="route"
-                configName="main"
+                configName="my-table"
                 onClose={() => {}}
                 onConfirm={() => {}}
-                immediate={false}
+                noun="table"
             />,
         );
-        expect(screen.getByText(/Changes are staged in the draft/i)).toBeInTheDocument();
+        const body = container.querySelector('.yn-modal__body p');
+        expect(body?.textContent).toMatch(/Delete table/);
+        expect(screen.getByText('my-table')).toBeInTheDocument();
     });
 
     it('calls onConfirm when Ctrl+Enter is pressed', () => {
         const onConfirm = vi.fn();
         render(
-            <BulkDeleteModal
+            <DeleteConfigModal
                 open
-                count={3}
-                itemNoun="route"
                 configName="main"
                 onClose={() => {}}
                 onConfirm={onConfirm}
@@ -84,10 +78,8 @@ describe('BulkDeleteModal', () => {
     it('calls onConfirm when Cmd+Enter is pressed', () => {
         const onConfirm = vi.fn();
         render(
-            <BulkDeleteModal
+            <DeleteConfigModal
                 open
-                count={3}
-                itemNoun="route"
                 configName="main"
                 onClose={() => {}}
                 onConfirm={onConfirm}
@@ -100,10 +92,8 @@ describe('BulkDeleteModal', () => {
     it('calls onClose when Escape is pressed', () => {
         const onClose = vi.fn();
         render(
-            <BulkDeleteModal
+            <DeleteConfigModal
                 open
-                count={3}
-                itemNoun="route"
                 configName="main"
                 onClose={onClose}
                 onConfirm={() => {}}
@@ -116,10 +106,8 @@ describe('BulkDeleteModal', () => {
     it('does not call onConfirm when dialog is closed and Ctrl+Enter is pressed', () => {
         const onConfirm = vi.fn();
         render(
-            <BulkDeleteModal
+            <DeleteConfigModal
                 open={false}
-                count={3}
-                itemNoun="route"
                 configName="main"
                 onClose={() => {}}
                 onConfirm={onConfirm}
@@ -132,10 +120,8 @@ describe('BulkDeleteModal', () => {
     it('does not call onClose when dialog is closed and Escape is pressed', () => {
         const onClose = vi.fn();
         render(
-            <BulkDeleteModal
+            <DeleteConfigModal
                 open={false}
-                count={3}
-                itemNoun="route"
                 configName="main"
                 onClose={onClose}
                 onConfirm={() => {}}
@@ -143,5 +129,49 @@ describe('BulkDeleteModal', () => {
         );
         fireEvent.keyDown(document, { key: 'Escape' });
         expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('stops propagation to window on Ctrl+Enter so draft page shortcuts are not triggered', () => {
+        const onConfirm = vi.fn();
+        const onClose = vi.fn();
+        const windowSpy = vi.fn();
+        window.addEventListener('keydown', windowSpy);
+        try {
+            render(
+                <DeleteConfigModal
+                    open
+                    configName="main"
+                    onClose={onClose}
+                    onConfirm={onConfirm}
+                />,
+            );
+            fireEvent.keyDown(document, { key: 'Enter', ctrlKey: true, bubbles: true });
+            expect(onConfirm).toHaveBeenCalledTimes(1);
+            expect(windowSpy).not.toHaveBeenCalled();
+        } finally {
+            window.removeEventListener('keydown', windowSpy);
+        }
+    });
+
+    it('stops propagation to window on Escape so draft page shortcuts are not triggered', () => {
+        const onConfirm = vi.fn();
+        const onClose = vi.fn();
+        const windowSpy = vi.fn();
+        window.addEventListener('keydown', windowSpy);
+        try {
+            render(
+                <DeleteConfigModal
+                    open
+                    configName="main"
+                    onClose={onClose}
+                    onConfirm={onConfirm}
+                />,
+            );
+            fireEvent.keyDown(document, { key: 'Escape', bubbles: true });
+            expect(onClose).toHaveBeenCalledTimes(1);
+            expect(windowSpy).not.toHaveBeenCalled();
+        } finally {
+            window.removeEventListener('keydown', windowSpy);
+        }
     });
 });

--- a/web/src/pages/_shared/draft/DeleteConfigModal.tsx
+++ b/web/src/pages/_shared/draft/DeleteConfigModal.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import { useDialogKeyboardShortcut } from '../../../hooks';
 
 interface DeleteConfigModalProps {
     open: boolean;
     configName: string;
     onClose: () => void;
     onConfirm: () => void;
+    /** The noun used in the title and body. Defaults to "config". */
+    noun?: string;
 }
 
 /** Modal confirming deletion of an entire config. */
@@ -13,17 +16,19 @@ const DeleteConfigModal: React.FC<DeleteConfigModalProps> = ({
     configName,
     onClose,
     onConfirm,
+    noun = 'config',
 }) => {
+    useDialogKeyboardShortcut({ open, canSubmit: true, onConfirm, onCancel: onClose });
     if (!open) return null;
     return (
         <div className="yn-modal-backdrop" onClick={onClose}>
             <div className="yn-modal yn-modal--sm" onClick={(e) => e.stopPropagation()}>
                 <header className="yn-modal__head">
-                    <span className="yn-modal__title">Delete config</span>
+                    <span className="yn-modal__title">Delete {noun}</span>
                     <button type="button" className="yn-icon-btn" onClick={onClose} aria-label="Close">✕</button>
                 </header>
                 <div className="yn-modal__body yn-modal__body--confirm">
-                    <p>Delete config <code>{configName}</code>? This cannot be undone.</p>
+                    <p>Delete {noun} <code>{configName}</code>? This cannot be undone.</p>
                 </div>
                 <footer className="yn-modal__foot">
                     <span />

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -687,6 +687,7 @@ const NeighboursPage: React.FC = () => {
                     configName={activeTableInfo?.name || ''}
                     onClose={() => setDeleteTableOpen(false)}
                     onConfirm={handleDeleteTable}
+                    noun="table"
                 />
 
                 <NeighbourPanel


### PR DESCRIPTION
The Neighbours operator page used the shared delete dialog, which said "config" — it now says "table" when deleting a neighbour table.

Delete-confirmation modals (`DeleteConfigModal`, `BulkDeleteModal`) now confirm on Ctrl/Cmd+Enter and close on Escape, matching the keyboard behaviour of the rest of the UI dialogs. Other pages that reuse these modals gain the shortcuts with no wording change.