### PR TITLE
feat(route): model operator readiness as per-scope state machines

### DIFF
--- a/common/go/operator/readiness.go
+++ b/common/go/operator/readiness.go
@@ -44,11 +44,9 @@ func NewReadiness(gatewayIDs []string) *Readiness {
 
 // Observe records the outcome of one apply attempt for the named gateway.
 //
-// When err is nil the scope transitions to STATE_READY with no reasons.
-// When err is non-nil the scope transitions to STATE_NOT_READY with an
-// APPLY_FAILED reason carrying the error message. The observed_at timestamp
-// is always updated; last_transition_time is updated only when the state
-// value changes.
+// A failed apply holds the scope at DEGRADED when it was previously applied,
+// and drops to NOT_READY only when it was never applied. observed_at always
+// advances; last_transition_time changes only on a state transition.
 func (m *Readiness) Observe(gatewayID string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -68,8 +66,15 @@ func (m *Readiness) Observe(gatewayID string, err error) {
 	if err == nil {
 		next = readinesspb.State_STATE_READY
 	} else {
-		next = readinesspb.State_STATE_NOT_READY
 		reasons = []*readinesspb.Reason{{Code: "APPLY_FAILED", Message: err.Error()}}
+		switch s.state {
+		case readinesspb.State_STATE_READY, readinesspb.State_STATE_DEGRADED:
+			// Last successfully applied state is still live — hold at DEGRADED.
+			next = readinesspb.State_STATE_DEGRADED
+		default:
+			// Never successfully applied — no valid state to fall back to.
+			next = readinesspb.State_STATE_NOT_READY
+		}
 	}
 
 	if s.observedAt.IsZero() || s.state != next {

--- a/common/go/operator/readiness_test.go
+++ b/common/go/operator/readiness_test.go
@@ -39,8 +39,9 @@ func TestReadiness_Transitions(t *testing.T) {
 			wantState:     readinesspb.State_STATE_READY,
 			wantReasonLen: 0,
 		},
+		// From UNKNOWN (never programmed), a failure must yield NOT_READY.
 		{
-			name:          "failure -> NOT_READY with APPLY_FAILED",
+			name:          "UNKNOWN + failure -> NOT_READY with APPLY_FAILED",
 			observeErr:    applyErr,
 			wantState:     readinesspb.State_STATE_NOT_READY,
 			wantReasonLen: 1,
@@ -71,6 +72,93 @@ func TestReadiness_Transitions(t *testing.T) {
 	}
 }
 
+// TestReadiness_ObserveHoldOnRegression verifies the state-aware Observe
+// semantics: a failure from READY or DEGRADED holds at DEGRADED (last-good
+// state live), while a failure from UNKNOWN or NOT_READY produces NOT_READY.
+func TestReadiness_ObserveHoldOnRegression(t *testing.T) {
+	boom := errors.New("push failed")
+
+	tests := []struct {
+		name       string
+		seed       func(r *operator.Readiness) // sets up pre-condition
+		wantState  readinesspb.State
+		wantReason string
+	}{
+		{
+			name:       "UNKNOWN + err -> NOT_READY",
+			seed:       func(_ *operator.Readiness) {},
+			wantState:  readinesspb.State_STATE_NOT_READY,
+			wantReason: "APPLY_FAILED",
+		},
+		{
+			name: "READY + err -> DEGRADED",
+			seed: func(r *operator.Readiness) {
+				r.Observe("gw", nil) // UNKNOWN -> READY
+			},
+			wantState:  readinesspb.State_STATE_DEGRADED,
+			wantReason: "APPLY_FAILED",
+		},
+		{
+			name: "DEGRADED + err -> DEGRADED",
+			seed: func(r *operator.Readiness) {
+				r.Observe("gw", nil)  // UNKNOWN -> READY
+				r.Observe("gw", boom) // READY -> DEGRADED
+			},
+			wantState:  readinesspb.State_STATE_DEGRADED,
+			wantReason: "APPLY_FAILED",
+		},
+		{
+			name: "NOT_READY + err -> NOT_READY",
+			seed: func(r *operator.Readiness) {
+				r.Observe("gw", boom) // UNKNOWN -> NOT_READY
+			},
+			wantState:  readinesspb.State_STATE_NOT_READY,
+			wantReason: "APPLY_FAILED",
+		},
+		{
+			name: "DEGRADED + ok -> READY",
+			seed: func(r *operator.Readiness) {
+				r.Observe("gw", nil)  // UNKNOWN -> READY
+				r.Observe("gw", boom) // READY -> DEGRADED
+			},
+			wantState:  readinesspb.State_STATE_READY,
+			wantReason: "",
+		},
+		{
+			name: "NOT_READY + ok -> READY",
+			seed: func(r *operator.Readiness) {
+				r.Observe("gw", boom) // UNKNOWN -> NOT_READY
+			},
+			wantState:  readinesspb.State_STATE_READY,
+			wantReason: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := operator.NewReadiness([]string{"gw"})
+			tt.seed(r)
+
+			var finalErr error
+			if tt.wantState != readinesspb.State_STATE_READY {
+				finalErr = boom
+			}
+			r.Observe("gw", finalErr)
+
+			resp := r.Ready(&readinesspb.ReadyRequest{})
+			require.Len(t, resp.Scopes, 1)
+			s := resp.Scopes[0]
+			assert.Equal(t, tt.wantState, s.State)
+			if tt.wantReason != "" {
+				require.Len(t, s.Reasons, 1)
+				assert.Equal(t, tt.wantReason, s.Reasons[0].Code)
+			} else {
+				assert.Empty(t, s.Reasons)
+			}
+		})
+	}
+}
+
 func TestReadiness_LastTransitionTime_OnlyChangesOnStateChange(t *testing.T) {
 	r := operator.NewReadiness([]string{"gw-a"})
 
@@ -93,14 +181,14 @@ func TestReadiness_LastTransitionTime_OnlyChangesOnStateChange(t *testing.T) {
 	// ensure it is not before the first observation.
 	assert.False(t, obs2.Before(obs1))
 
-	// Third observation with failure (READY -> NOT_READY): ltt must change.
+	// Third observation with failure (READY -> DEGRADED): ltt must change.
 	r.Observe("gw-a", errors.New("boom"))
 	resp3 := r.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp3.Scopes, 1)
 	ltt3 := resp3.Scopes[0].LastTransitionTime.AsTime()
 
 	assert.True(t, ltt3.Equal(ltt2) || ltt3.After(ltt2),
-		"last_transition_time must advance on READY -> NOT_READY")
+		"last_transition_time must advance on READY -> DEGRADED")
 }
 
 func TestReadiness_ScopeFilter(t *testing.T) {

--- a/operators/route/etc/yanet/yanet-route-operator-default.yaml
+++ b/operators/route/etc/yanet/yanet-route-operator-default.yaml
@@ -73,7 +73,7 @@ netlink_monitor:
 # expect_bird: set to true when a BIRD adapter is expected; the rib scope
 # stays NOT_READY (SYNCING) until the FeedRIB update rate settles, then
 # becomes READY for the duration of the session. Set false for static-only
-# deployments; rib becomes READY immediately at startup.
+# deployments; rib scope is driven by route presence only.
 readiness:
   expect_bird: false
   # rate_threshold: maximum RIB updates/sec below which the bulk-load
@@ -84,3 +84,8 @@ readiness:
   stability_window: 5s
   # sample_interval: how often the rate helper samples the update counter.
   sample_interval: 1s
+  # reconnect_grace: diagnostics-only — after a BIRD session ends, the
+  # bird-session reason flips from RECONNECTING to DOWN once this duration
+  # elapses without a new session. Has no effect on the rib scope or on
+  # announce decisions; tune for observability only.
+  reconnect_grace: 15s

--- a/operators/route/internal/discovery/neigh/neigh.go
+++ b/operators/route/internal/discovery/neigh/neigh.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/netip"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -59,10 +60,36 @@ func WithOnSynced(fn func()) Option {
 	}
 }
 
+// WithOnError registers a callback invoked once per degradation episode.
+//
+// It fires on the first update failure after the initial sync has completed,
+// signalling that the neighbour table may be stale. Subsequent failures in the
+// same episode do not re-fire. The callback is not called before the first
+// successful sync.
+func WithOnError(fn func(error)) Option {
+	return func(o *options) {
+		o.OnError = fn
+	}
+}
+
+// WithOnResynced registers a callback invoked once when an update succeeds
+// after a degradation episode.
+//
+// It fires on the first successful update following an OnError event, marking
+// the transition back to healthy. Subsequent successes in the same healthy
+// run do not re-fire.
+func WithOnResynced(fn func()) Option {
+	return func(o *options) {
+		o.OnResynced = fn
+	}
+}
+
 type options struct {
 	UpdateInterval time.Duration
 	LinkMap        map[string]string
 	OnSynced       func()
+	OnError        func(error)
+	OnResynced     func()
 	Log            *zap.Logger
 }
 
@@ -71,6 +98,8 @@ func newOptions() *options {
 		UpdateInterval: 5 * time.Minute,
 		LinkMap:        make(map[string]string),
 		OnSynced:       func() {},
+		OnError:        func(error) {},
+		OnResynced:     func() {},
 		Log:            zap.NewNop(),
 	}
 }
@@ -88,7 +117,18 @@ type NeighMonitor struct {
 	linkMap        map[string]string
 	onSynced       sync.Once
 	onSyncedFn     func()
-	log            *zap.Logger
+	onErrorFn      func(error)
+	onResyncedFn   func()
+
+	// synced is set to true once the first successful update completes and
+	// never reverts.
+	synced atomic.Bool
+
+	// degraded is flipped episode-once via CAS: error path sets it
+	// false→true (only after synced), success path clears it true→false.
+	degraded atomic.Bool
+
+	log *zap.Logger
 }
 
 // NewNeighMonitor creates a new neighbour monitor.
@@ -104,6 +144,8 @@ func NewNeighMonitor(neighTable *NeighTable, source *NeighSource, options ...Opt
 		linkMap:        opts.LinkMap,
 		updateInterval: opts.UpdateInterval,
 		onSyncedFn:     opts.OnSynced,
+		onErrorFn:      opts.OnError,
+		onResyncedFn:   opts.OnResynced,
 		log:            opts.Log,
 	}
 
@@ -114,6 +156,7 @@ func NewNeighMonitor(neighTable *NeighTable, source *NeighSource, options ...Opt
 	// periodic ticker.
 	if err := m.updateNeighbours(); err == nil {
 		m.onSynced.Do(m.onSyncedFn)
+		m.synced.Store(true)
 	}
 
 	return m
@@ -166,8 +209,11 @@ func (m *NeighMonitor) runNeighPeriodicUpdate(ctx context.Context) error {
 		case <-timer.C:
 			if err := m.updateNeighbours(); err != nil {
 				m.log.Warn("failed to update neighbours", zap.Error(err))
+				m.notifyError(err)
 			} else {
 				m.onSynced.Do(m.onSyncedFn)
+				m.synced.Store(true)
+				m.notifyResynced()
 			}
 		}
 	}
@@ -184,10 +230,13 @@ func (m *NeighMonitor) processNeighUpdate(update netlink.NeighUpdate) error {
 	switch update.Type {
 	case unix.RTM_NEWNEIGH:
 		if err := m.updateNeighbours(); err != nil {
+			m.notifyError(err)
 			return err
 		}
 
 		m.onSynced.Do(m.onSyncedFn)
+		m.synced.Store(true)
+		m.notifyResynced()
 		return nil
 	case unix.RTM_DELNEIGH:
 		// We don't process neighbour deletion events to avoid flaps.
@@ -200,6 +249,26 @@ func (m *NeighMonitor) processNeighUpdate(update netlink.NeighUpdate) error {
 	}
 
 	return nil
+}
+
+// notifyError fires onErrorFn once per degradation episode.
+//
+// It is a no-op before the first successful sync and when the monitor is
+// already in the degraded state for the current episode.
+func (m *NeighMonitor) notifyError(err error) {
+	if !m.synced.Load() || !m.degraded.CompareAndSwap(false, true) {
+		return
+	}
+	m.onErrorFn(err)
+}
+
+// notifyResynced fires onResyncedFn once on recovery from a degradation
+// episode. It is a no-op when the monitor is not currently degraded.
+func (m *NeighMonitor) notifyResynced() {
+	if !m.degraded.CompareAndSwap(true, false) {
+		return
+	}
+	m.onResyncedFn()
 }
 
 func (m *NeighMonitor) updateNeighbours() error {

--- a/operators/route/internal/operator/cfg.go
+++ b/operators/route/internal/operator/cfg.go
@@ -23,6 +23,10 @@ const (
 	// defaultSampleInterval is the period between rate samples taken by the
 	// RIB readiness helper.
 	defaultSampleInterval = 1 * time.Second
+
+	// defaultReconnectGrace is the default time after a BIRD session ends
+	// before the bird-session reason flips from RECONNECTING to DOWN.
+	defaultReconnectGrace = 15 * time.Second
 )
 
 const (
@@ -69,6 +73,14 @@ type ReadinessConfig struct {
 	// SampleInterval is the period at which the rate helper samples the
 	// RIB update counter.
 	SampleInterval time.Duration `yaml:"sample_interval"`
+
+	// ReconnectGrace is a diagnostics-only duration.
+	//
+	// After a BIRD session ends, the bird-session scope reason flips from
+	// RECONNECTING to DOWN once this grace period elapses without a new
+	// session. It never changes the State (bird-session never reaches
+	// NOT_READY) and has no correctness coupling with RIBTTL.
+	ReconnectGrace time.Duration `yaml:"reconnect_grace"`
 }
 
 func (m *Config) Default() {
@@ -123,6 +135,7 @@ func DefaultConfig() *Config {
 			RateThreshold:   defaultRateThreshold,
 			StabilityWindow: defaultStabilityWindow,
 			SampleInterval:  defaultSampleInterval,
+			ReconnectGrace:  defaultReconnectGrace,
 		},
 	}
 }

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -17,6 +17,15 @@ import (
 	"github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
 )
 
+// ribReadiness drives the rib readiness scope (and, when BIRD is expected,
+// the bird-session scope) from FeedRIB session signals and a sampling loop.
+type ribReadiness interface {
+	OnSessionStart(name string, sessionID uint64)
+	OnUpdate(n int)
+	OnSessionEnd(name string, sessionID uint64)
+	Run(ctx context.Context) error
+}
+
 const (
 	// staticTablePriority is the default priority assigned to entries in
 	// the built-in "static" neighbour table.
@@ -50,12 +59,15 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	metrics := NewMetrics()
 
 	// Build the readiness tracker scope list: one gateway scope per gateway,
-	// plus a neighbours scope and a rib scope.
-	scopeNames := make([]string, 0, len(cfg.Gateways)+2)
+	// plus a neighbours scope, a rib scope, and optionally a bird-session scope.
+	scopeNames := make([]string, 0, len(cfg.Gateways)+3)
 	for _, gw := range cfg.Gateways {
 		scopeNames = append(scopeNames, "gateway:"+gw.Name)
 	}
 	scopeNames = append(scopeNames, "neighbours", "rib")
+	if cfg.Readiness.ExpectBird {
+		scopeNames = append(scopeNames, "bird-session")
+	}
 	tracker := operator.NewReadiness(scopeNames)
 
 	neighTable := neigh.NewNeighTable()
@@ -64,17 +76,33 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	}
 
 	// Propagate the neighbours scope based on netlink monitor config.
-	var neighOnSynced neigh.Option
+	var neighOpts []neigh.Option
 	if cfg.NetlinkMonitor.Disabled {
 		tracker.Set("neighbours", readinesspb.State_STATE_READY)
-		neighOnSynced = neigh.WithOnSynced(func() {})
+		neighOpts = []neigh.Option{neigh.WithOnSynced(func() {})}
 	} else {
-		neighOnSynced = neigh.WithOnSynced(func() {
-			tracker.Set("neighbours", readinesspb.State_STATE_READY)
-		})
+		// Seed the neighbours scope at NOT_READY(SYNCING) before the monitor starts.
+		tracker.Set("neighbours",
+			readinesspb.State_STATE_NOT_READY,
+			&readinesspb.Reason{Code: "SYNCING"},
+		)
+		neighOpts = []neigh.Option{
+			neigh.WithOnSynced(func() {
+				tracker.Set("neighbours", readinesspb.State_STATE_READY)
+			}),
+			neigh.WithOnError(func(err error) {
+				tracker.Set("neighbours",
+					readinesspb.State_STATE_DEGRADED,
+					&readinesspb.Reason{Code: "RESYNC", Message: err.Error()},
+				)
+			}),
+			neigh.WithOnResynced(func() {
+				tracker.Set("neighbours", readinesspb.State_STATE_READY)
+			}),
+		}
 	}
 
-	neighMonitor, err := newNeighbourMonitor(cfg, neighTable, log, neighOnSynced)
+	neighMonitor, err := newNeighbourMonitor(cfg, neighTable, log, neighOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create neighbour monitor: %w", err)
 	}
@@ -83,36 +111,18 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	source := NewRouteSource(neighTable, routeRIBStore)
 	wake := source.WakeFunc()
 
-	// Build the RIB readiness helper when BIRD is expected; otherwise mark the
-	// rib scope ready immediately.
 	moduleName := cfg.Function.Module.Unwrap()
-	var ribHelper *ribReadinessHelper
-	var ribRouteServiceOpts []RouteServiceOption
-	if !cfg.Readiness.ExpectBird {
-		tracker.Set("rib", readinesspb.State_STATE_READY)
-	} else {
-		ribHelper = newRIBReadinessHelper(
-			cfg.Readiness,
-			routeRIBStore,
-			moduleName,
-			tracker,
-			log,
-		)
-		ribRouteServiceOpts = []RouteServiceOption{
-			WithRouteServiceOnRIBSessionStart(ribHelper.OnSessionStart),
-			WithRouteServiceOnRIBUpdate(ribHelper.OnUpdate),
-			WithRouteServiceOnRIBSessionEnd(ribHelper.OnSessionEnd),
-		}
-	}
+	ribHelper := newRIBReadiness(cfg.Readiness, routeRIBStore, moduleName, tracker, log)
 
 	routeSvc := NewRouteService(
 		neighTable,
-		append([]RouteServiceOption{
-			WithRouteServiceRIBStore(routeRIBStore),
-			WithRouteServiceRIBTTL(ribTTL(cfg)),
-			WithRouteServiceOnChanged(wake),
-			WithRouteServiceLog(log),
-		}, ribRouteServiceOpts...)...,
+		WithRouteServiceRIBStore(routeRIBStore),
+		WithRouteServiceRIBTTL(ribTTL(cfg)),
+		WithRouteServiceOnChanged(wake),
+		WithRouteServiceLog(log),
+		WithRouteServiceOnRIBSessionStart(ribHelper.OnSessionStart),
+		WithRouteServiceOnRIBUpdate(ribHelper.OnUpdate),
+		WithRouteServiceOnRIBSessionEnd(ribHelper.OnSessionEnd),
 	)
 
 	neighbourSvc := NewNeighbourService(
@@ -173,8 +183,6 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		},
 	}
 
-	// Build the worker list: always include the neighbour monitor and the
-	// drain worker; add the RIB readiness ticker when BIRD is expected.
 	workers := []operator.Runner{
 		neighbourMonitorRunner(neighMonitor),
 		func(ctx context.Context) error {
@@ -182,9 +190,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			tracker.Drain()
 			return nil
 		},
-	}
-	if ribHelper != nil {
-		workers = append(workers, ribHelper.Run)
+		ribHelper.Run,
 	}
 
 	app := operator.NewOperator(

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -64,18 +64,31 @@ func TestReadiness_GatewayObserve(t *testing.T) {
 	s := requireScope(t, tracker, "gateway:gw0")
 	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, s.State)
 
+	// From UNKNOWN, a failed apply transitions to NOT_READY (never programmed).
+	tracker.Observe("gateway:gw0", assert.AnError)
+	s = requireScope(t, tracker, "gateway:gw0")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "APPLY_FAILED", s.Reasons[0].Code)
+
 	// Successful apply transitions to READY.
 	tracker.Observe("gateway:gw0", nil)
 	s = requireScope(t, tracker, "gateway:gw0")
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
 	assert.Empty(t, s.Reasons)
 
-	// Failed apply transitions to NOT_READY with APPLY_FAILED.
+	// Failed apply from READY transitions to DEGRADED (last-good FIB still live).
 	tracker.Observe("gateway:gw0", assert.AnError)
 	s = requireScope(t, tracker, "gateway:gw0")
-	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
 	require.Len(t, s.Reasons, 1)
 	assert.Equal(t, "APPLY_FAILED", s.Reasons[0].Code)
+
+	// Recovery: successful apply from DEGRADED transitions back to READY.
+	tracker.Observe("gateway:gw0", nil)
+	s = requireScope(t, tracker, "gateway:gw0")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+	assert.Empty(t, s.Reasons)
 }
 
 func TestRIBReadiness_SessionStart_SYNCING(t *testing.T) {
@@ -87,7 +100,7 @@ func TestRIBReadiness_SessionStart_SYNCING(t *testing.T) {
 
 	store := newRIBStore(zap.NewNop())
 	tracker := operator.NewReadiness([]string{"rib"})
-	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
 
@@ -107,7 +120,7 @@ func TestRIBReadiness_HighRate_SYNCING(t *testing.T) {
 
 	store := newRIBStore(zap.NewNop())
 	tracker := operator.NewReadiness([]string{"rib"})
-	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
 
@@ -152,8 +165,10 @@ func TestRIBReadiness_LowRate_READY(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
+	// Seed a route so that settled && routes>0 produces READY.
+	seedRoute(t, store, "route0")
 	tracker := operator.NewReadiness([]string{"rib"})
-	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
 
@@ -184,7 +199,7 @@ func TestRIBReadiness_MidWindowSpike_ResetsBelowSince(t *testing.T) {
 
 	store := newRIBStore(zap.NewNop())
 	tracker := operator.NewReadiness([]string{"rib"})
-	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
 
@@ -223,8 +238,11 @@ func TestRIBReadiness_SessionEnd_Degraded(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
+	// Seed a route so that the settled state produces READY and the session
+	// end with live routes produces DEGRADED(SESSION_ENDED).
+	seedRoute(t, store, "route0")
 	tracker := operator.NewReadiness([]string{"rib"})
-	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
 
@@ -298,7 +316,7 @@ func TestRIBReadiness_Syncing(t *testing.T) {
 
 			store := newRIBStore(zap.NewNop())
 			tracker := operator.NewReadiness([]string{"rib"})
-			helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+			helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 			if tc.seedRoutes {
 				seedRoute(t, store, "route0")
@@ -361,14 +379,17 @@ func TestRIBReadiness_SupersededSession(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
+	// Seed a route so that the settled state produces READY.
+	seedRoute(t, store, "route0")
 	tracker := operator.NewReadiness([]string{"rib"})
-	helper := newRIBReadinessHelper(cfg, store, "route0", tracker, zap.NewNop())
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
-	// Session A starts (id=1) — tracker enters SYNCING.
+	// Session A starts (id=1) — routes are present so tracker enters
+	// DEGRADED(SYNCING) rather than NOT_READY(SYNCING).
 	helper.OnSessionStart("route0", 1)
 
 	s := requireScope(t, tracker, "rib")
-	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
 	require.NotEmpty(t, s.Reasons)
 	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
 
@@ -376,16 +397,16 @@ func TestRIBReadiness_SupersededSession(t *testing.T) {
 	helper.OnSessionStart("route0", 2)
 
 	s = requireScope(t, tracker, "rib")
-	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
 	require.NotEmpty(t, s.Reasons)
 	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
 
 	// Session A's stale end arrives — must be ignored because currentSession is 2.
 	helper.OnSessionEnd("route0", 1)
 
-	// State must still reflect an active session (SYNCING), not DEGRADED/inactive.
+	// State must still reflect an active session (SYNCING), not SESSION_ENDED.
 	s = requireScope(t, tracker, "rib")
-	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
 	require.NotEmpty(t, s.Reasons)
 	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
 
@@ -405,4 +426,533 @@ func TestRIBReadiness_SupersededSession(t *testing.T) {
 
 	cancel()
 	_ = eg.Wait()
+}
+
+// TestBirdSession_InitialDegraded verifies that the bird-session scope starts
+// at DEGRADED(NO_SESSION) when the helper is constructed.
+func TestBirdSession_InitialDegraded(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 50 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+		ReconnectGrace:  100 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	s := requireScope(t, tracker, "bird-session")
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "NO_SESSION", s.Reasons[0].Code)
+}
+
+// TestBirdSession_SessionStartReady verifies that a session start transitions
+// the bird-session scope to READY.
+func TestBirdSession_SessionStartReady(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 50 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+		ReconnectGrace:  100 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	s := requireScope(t, tracker, "bird-session")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+	assert.Empty(t, s.Reasons)
+}
+
+// TestBirdSession_SessionEndReconnecting verifies that a session end
+// transitions bird-session to DEGRADED(RECONNECTING).
+func TestBirdSession_SessionEndReconnecting(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 50 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+		ReconnectGrace:  500 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+	helper.OnSessionEnd("route0", 1)
+
+	s := requireScope(t, tracker, "bird-session")
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "RECONNECTING", s.Reasons[0].Code)
+}
+
+// TestBirdSession_GraceExpiry verifies that the ticker flips bird-session
+// from RECONNECTING to DOWN after ReconnectGrace elapses.
+func TestBirdSession_GraceExpiry(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 50 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+		ReconnectGrace:  60 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+	helper.OnSessionEnd("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Wait well past grace to ensure the ticker fires after grace elapses.
+	time.Sleep(200 * time.Millisecond)
+
+	s := requireScope(t, tracker, "bird-session")
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "DOWN", s.Reasons[0].Code)
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// TestBirdSession_NeverNotReady verifies that bird-session never reaches
+// NOT_READY regardless of session events.
+func TestBirdSession_NeverNotReady(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 50 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+		ReconnectGrace:  30 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+	helper.OnSessionEnd("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Allow grace to expire.
+	time.Sleep(150 * time.Millisecond)
+
+	s := requireScope(t, tracker, "bird-session")
+	assert.NotEqual(t, readinesspb.State_STATE_NOT_READY, s.State,
+		"bird-session must never reach NOT_READY")
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// TestBirdSession_ReconnectFromDown verifies that a new session start from
+// DEGRADED(DOWN) transitions bird-session back to READY.
+func TestBirdSession_ReconnectFromDown(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 50 * time.Millisecond,
+		SampleInterval:  20 * time.Millisecond,
+		ReconnectGrace:  30 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+	helper.OnSessionEnd("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Allow grace to expire, reaching DOWN.
+	time.Sleep(150 * time.Millisecond)
+	s := requireScope(t, tracker, "bird-session")
+	assert.Equal(t, "DOWN", s.Reasons[0].Code)
+
+	// Reconnect — must return to READY.
+	helper.OnSessionStart("route0", 2)
+
+	s = requireScope(t, tracker, "bird-session")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+	assert.Empty(t, s.Reasons)
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// TestRIBReadiness_SettledNoRoutes verifies the key fix: when the session is
+// settled but the RIB is empty, the rib scope reports NOT_READY(NO_ROUTES).
+func TestRIBReadiness_SettledNoRoutes(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 40 * time.Millisecond,
+		SampleInterval:  15 * time.Millisecond,
+		ReconnectGrace:  500 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	// No routes seeded — empty RIB.
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Wait for the stability window to clear.
+	time.Sleep(200 * time.Millisecond)
+
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "NO_ROUTES", s.Reasons[0].Code)
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// TestRIBReadiness_SessionEndedWithRoutes verifies that READY→SessionEnd
+// transitions rib to DEGRADED(SESSION_ENDED) when routes are still present.
+func TestRIBReadiness_SessionEndedWithRoutes(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 30 * time.Millisecond,
+		SampleInterval:  15 * time.Millisecond,
+		ReconnectGrace:  500 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	seedRoute(t, store, "route0")
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Wait for READY.
+	time.Sleep(150 * time.Millisecond)
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+
+	helper.OnSessionEnd("route0", 1)
+
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "SESSION_ENDED", s.Reasons[0].Code)
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// TestRIBReadiness_TTLPurgeAfterSessionEnd verifies that when a session has
+// ended (rib = DEGRADED·SESSION_ENDED with routes present) and the TTL purge
+// subsequently empties the RIB, the next ticker evaluation transitions rib to
+// NOT_READY(NO_ROUTES) without waiting for a new session start.
+func TestRIBReadiness_TTLPurgeAfterSessionEnd(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 30 * time.Millisecond,
+		SampleInterval:  15 * time.Millisecond,
+		ReconnectGrace:  500 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	seedRoute(t, store, "route0")
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Wait for READY.
+	time.Sleep(150 * time.Millisecond)
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+
+	// Session ends — routes still present, so rib must be DEGRADED(SESSION_ENDED).
+	helper.OnSessionEnd("route0", 1)
+
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "SESSION_ENDED", s.Reasons[0].Code)
+
+	// Simulate TTL purge: remove the route from the store so that hasRoutes()
+	// returns false.
+	ribRef := store.GetOrCreate("route0")
+	prefix := netip.MustParsePrefix("10.0.0.0/24")
+	nexthop := netip.MustParseAddr("192.168.1.1")
+	require.NoError(t, ribRef.RemoveUnicastRoute(prefix, nexthop, rib.RouteSourceStatic))
+
+	// Advance at least one tick and verify rib transitions to NOT_READY(NO_ROUTES)
+	// without any new session start.
+	time.Sleep(60 * time.Millisecond)
+
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "NO_ROUTES", s.Reasons[0].Code)
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// TestNeighbours_SyncThenError verifies the neighbours scope edge:
+// NOT_READY(SYNCING) -> READY on first sync, then DEGRADED(RESYNC) on error,
+// then READY on recovery.
+func TestNeighbours_SyncThenError(t *testing.T) {
+	tracker := operator.NewReadiness([]string{"neighbours"})
+
+	// Seed initial NOT_READY(SYNCING) as operator.go does.
+	tracker.Set("neighbours",
+		readinesspb.State_STATE_NOT_READY,
+		&readinesspb.Reason{Code: "SYNCING"},
+	)
+
+	s := requireScope(t, tracker, "neighbours")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
+
+	// First sync completes.
+	tracker.Set("neighbours", readinesspb.State_STATE_READY)
+
+	s = requireScope(t, tracker, "neighbours")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+	assert.Empty(t, s.Reasons)
+
+	// Error after sync transitions to DEGRADED(RESYNC).
+	tracker.Set("neighbours",
+		readinesspb.State_STATE_DEGRADED,
+		&readinesspb.Reason{Code: "RESYNC"},
+	)
+
+	s = requireScope(t, tracker, "neighbours")
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
+	require.Len(t, s.Reasons, 1)
+	assert.Equal(t, "RESYNC", s.Reasons[0].Code)
+
+	// Recovery transitions back to READY.
+	tracker.Set("neighbours", readinesspb.State_STATE_READY)
+
+	s = requireScope(t, tracker, "neighbours")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+	assert.Empty(t, s.Reasons)
+}
+
+// TestBirdRestartHoldInvariant verifies the cross-scope invariant: during a
+// bird-adapter restart within grace+TTL, both bird-session and rib are at most
+// DEGRADED (never NOT_READY).
+func TestBirdRestartHoldInvariant(t *testing.T) {
+	cfg := ReadinessConfig{
+		RateThreshold:   1000,
+		StabilityWindow: 30 * time.Millisecond,
+		SampleInterval:  15 * time.Millisecond,
+		ReconnectGrace:  500 * time.Millisecond,
+	}
+
+	store := newRIBStore(zap.NewNop())
+	seedRoute(t, store, "route0")
+	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
+
+	helper.OnSessionStart("route0", 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Wait for both scopes to reach READY.
+	time.Sleep(150 * time.Millisecond)
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+	s = requireScope(t, tracker, "bird-session")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+
+	// Bird-adapter restarts — session ends. Both scopes must go to DEGRADED, not NOT_READY.
+	helper.OnSessionEnd("route0", 1)
+
+	s = requireScope(t, tracker, "bird-session")
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State,
+		"bird-session must be DEGRADED after session end, not NOT_READY")
+	assert.NotEqual(t, readinesspb.State_STATE_NOT_READY, s.State)
+
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State,
+		"rib must be DEGRADED after session end with live routes")
+	assert.NotEqual(t, readinesspb.State_STATE_NOT_READY, s.State)
+
+	// Within grace period — still DEGRADED.
+	time.Sleep(50 * time.Millisecond)
+	s = requireScope(t, tracker, "bird-session")
+	assert.NotEqual(t, readinesspb.State_STATE_NOT_READY, s.State,
+		"bird-session must not reach NOT_READY within grace period")
+
+	s = requireScope(t, tracker, "rib")
+	assert.NotEqual(t, readinesspb.State_STATE_NOT_READY, s.State,
+		"rib must not reach NOT_READY within grace period (routes still live)")
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// TestStaticRIBReadiness_ReadyWhenRoutesPresent verifies that staticRIBReadiness
+// sets rib=READY when a route is seeded before construction and then flips to
+// NOT_READY(NO_ROUTES) once the route is removed, all without ever touching the
+// bird-session scope.
+func TestStaticRIBReadiness_ReadyWhenRoutesPresent(t *testing.T) {
+	store := newRIBStore(zap.NewNop())
+	seedRoute(t, store, "route0")
+
+	// Register both rib and bird-session so we can assert bird-session is never set.
+	tracker := operator.NewReadiness([]string{"rib", "bird-session"})
+
+	helper := newStaticRIBReadiness(store, "route0", tracker, 20*time.Millisecond, zap.NewNop())
+
+	// The constructor must seed rib=READY immediately (route already present).
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// Confirm the polling loop keeps rib READY across several ticks.
+	time.Sleep(80 * time.Millisecond)
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+
+	// Remove the route: next tick must flip to NOT_READY(NO_ROUTES).
+	ribRef := store.GetOrCreate("route0")
+	prefix := netip.MustParsePrefix("10.0.0.0/24")
+	nexthop := netip.MustParseAddr("192.168.1.1")
+	require.NoError(t, ribRef.RemoveUnicastRoute(prefix, nexthop, rib.RouteSourceStatic))
+
+	time.Sleep(80 * time.Millisecond)
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.NotEmpty(t, s.Reasons)
+	assert.Equal(t, "NO_ROUTES", s.Reasons[0].Code)
+
+	// bird-session scope must never have been set (still UNKNOWN).
+	bs := requireScope(t, tracker, "bird-session")
+	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, bs.State,
+		"bird-session must never be touched by staticRIBReadiness")
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// TestStaticRIBReadiness_ColdStart verifies that staticRIBReadiness seeds
+// rib=NOT_READY(NO_ROUTES) on construction when the store is empty.
+func TestStaticRIBReadiness_ColdStart(t *testing.T) {
+	store := newRIBStore(zap.NewNop())
+	tracker := operator.NewReadiness([]string{"rib"})
+
+	newStaticRIBReadiness(store, "route0", tracker, 20*time.Millisecond, zap.NewNop())
+
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.NotEmpty(t, s.Reasons)
+	assert.Equal(t, "NO_ROUTES", s.Reasons[0].Code)
+}
+
+// TestStaticRIBReadiness_PostPreRunReady verifies the entry-evaluate fix: when
+// the store is empty at construction (seeding NOT_READY/NO_ROUTES) but a route
+// is added before Run starts, the first call to Run must flip rib to READY
+// immediately without waiting for the first ticker tick.
+func TestStaticRIBReadiness_PostPreRunReady(t *testing.T) {
+	store := newRIBStore(zap.NewNop())
+
+	// Empty store at construction — seeds NOT_READY(NO_ROUTES), mirroring the
+	// real operator where PreRun has not yet populated static.routes.
+	tracker := operator.NewReadiness([]string{"rib"})
+	helper := newStaticRIBReadiness(store, "route0", tracker, 500*time.Millisecond, zap.NewNop())
+
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+	require.NotEmpty(t, s.Reasons)
+	assert.Equal(t, "NO_ROUTES", s.Reasons[0].Code)
+
+	// Seed a route after construction, before Run — mirrors PreRun populating routes.
+	seedRoute(t, store, "route0")
+
+	// Start Run. The entry evaluate must fire synchronously before the ticker
+	// loop, so rib must be READY well before the 500ms sample_interval.
+	ctx, cancel := context.WithCancel(t.Context())
+	eg, _ := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return helper.Run(ctx)
+	})
+
+	// 50ms is far shorter than the 500ms sample_interval; any readiness change
+	// here can only come from the entry evaluate, not a ticker tick.
+	require.Eventually(t, func() bool {
+		s := requireScope(t, tracker, "rib")
+		return s.State == readinesspb.State_STATE_READY
+	}, 50*time.Millisecond, 2*time.Millisecond,
+		"rib must become READY from entry evaluate before first ticker tick")
+
+	cancel()
+	_ = eg.Wait()
+}
+
+// TestStaticRIBReadiness_NoopsIgnored verifies that OnSessionStart, OnUpdate,
+// and OnSessionEnd are all no-ops and do not change the rib scope.
+func TestStaticRIBReadiness_NoopsIgnored(t *testing.T) {
+	store := newRIBStore(zap.NewNop())
+	seedRoute(t, store, "route0")
+	tracker := operator.NewReadiness([]string{"rib"})
+
+	helper := newStaticRIBReadiness(store, "route0", tracker, 20*time.Millisecond, zap.NewNop())
+
+	s := requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
+
+	// Calling session callbacks must not change scope state.
+	helper.OnSessionStart("route0", 1)
+	helper.OnUpdate(100)
+	helper.OnSessionEnd("route0", 1)
+
+	s = requireScope(t, tracker, "rib")
+	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
 }

--- a/operators/route/internal/operator/rib_readiness.go
+++ b/operators/route/internal/operator/rib_readiness.go
@@ -12,104 +12,146 @@ import (
 	"github.com/yanet-platform/yanet2/common/readinesspb"
 )
 
-// ribReadinessHelper drives the "rib" readiness scope based on the FeedRIB
-// update rate and plateau settle.
+// newRIBReadiness returns a birdRIBReadiness when cfg.ExpectBird is true,
+// and a staticRIBReadiness otherwise.
+func newRIBReadiness(
+	cfg ReadinessConfig,
+	store *RIBStore,
+	name string,
+	tracker *operator.Readiness,
+	log *zap.Logger,
+) ribReadiness {
+	if cfg.ExpectBird {
+		return newBirdRIBReadiness(cfg, store, name, tracker, log)
+	}
+	return newStaticRIBReadiness(store, name, tracker, cfg.SampleInterval, log)
+}
+
+// birdRIBReadiness drives the "bird-session" and "rib" readiness scopes
+// from the shared FeedRIB callbacks and a single sampling ticker.
 //
-// The scope becomes READY when the update rate has stayed below RateThreshold
-// continuously for StabilityWindow. The bulkSettled flag is sticky within a
-// session: a spike after settling does not flip the scope back to NOT_READY.
-type ribReadinessHelper struct {
+// The "bird-session" scope reflects transport liveness and never reaches
+// NOT_READY. The "rib" scope reflects route-content readiness and gates
+// READY on both a settled update rate and a non-empty RIB.
+//
+// The bulk-settle gate (RateThreshold/StabilityWindow) is sticky within a
+// session — a rate spike after settling does not flip the rib scope back to
+// NOT_READY. It resets on each SessionStart.
+type birdRIBReadiness struct {
 	store      *RIBStore
 	configName string
 	tracker    *operator.Readiness
 
 	// counter is the total number of route updates applied in the current
-	// session. Driven by OnUpdate from the FeedRIB hot path; read by Run.
+	// session. Written by OnUpdate on the FeedRIB hot path; read by Run.
 	counter atomic.Int64
 
+	// mu guards session/settle fields and the consistency of rib/bird-session
+	// scope updates. tracker.Set calls for these two scopes are always made
+	// while holding mu so that a tick and a session-edge event cannot
+	// interleave and produce an inconsistent last-write.
 	mu             sync.Mutex
 	currentSession uint64
 	sessionActive  bool
+	lastSessionEnd time.Time // zero while a session is active
 	belowSince     time.Time // zero when rate is currently above threshold
 	bulkSettled    bool
 
 	rateThreshold   float64
 	stabilityWindow time.Duration
 	sampleInterval  time.Duration
+	reconnectGrace  time.Duration
 
 	log *zap.Logger
 }
 
-// newRIBReadinessHelper constructs a helper from the supplied config.
+// newBirdRIBReadiness constructs a helper from the supplied config.
 //
-// The helper is wired to the given tracker's "rib" scope.
-func newRIBReadinessHelper(
+// The helper drives both the "bird-session" and "rib" tracker scopes.
+// It seeds bird-session to DEGRADED(NO_SESSION) and rib to
+// NOT_READY(SYNCING) immediately on construction.
+func newBirdRIBReadiness(
 	cfg ReadinessConfig,
 	store *RIBStore,
 	configName string,
 	tracker *operator.Readiness,
 	log *zap.Logger,
-) *ribReadinessHelper {
-	return &ribReadinessHelper{
+) *birdRIBReadiness {
+	m := &birdRIBReadiness{
 		store:           store,
 		configName:      configName,
 		tracker:         tracker,
 		rateThreshold:   cfg.RateThreshold,
 		stabilityWindow: cfg.StabilityWindow,
 		sampleInterval:  cfg.SampleInterval,
+		reconnectGrace:  cfg.ReconnectGrace,
 		log:             log,
 	}
+
+	// Seed initial states: bird-session starts DEGRADED(NO_SESSION),
+	// rib starts NOT_READY(SYNCING).
+	tracker.Set("bird-session",
+		readinesspb.State_STATE_DEGRADED,
+		&readinesspb.Reason{Code: "NO_SESSION"},
+	)
+	tracker.Set("rib",
+		readinesspb.State_STATE_NOT_READY,
+		&readinesspb.Reason{Code: "SYNCING"},
+	)
+
+	return m
 }
 
-// hasRoutes reports whether the tracked config's RIB currently holds any
-// routes.
+// hasRoutes reports whether the tracked config's RIB currently holds any routes.
 //
 // It uses the O(1) RIB stats snapshot, so it is cheap to call every tick.
-func (m *ribReadinessHelper) hasRoutes() bool {
+func (m *birdRIBReadiness) hasRoutes() bool {
 	r, ok := m.store.Get(m.configName)
 	return ok && r.Stats().Routes > 0
 }
 
-// syncingState returns the state to report while a session is still syncing.
+// ribSyncingState returns the rib state to report while a session is still syncing.
 //
-// While routes are present we report DEGRADED so the announcer keeps serving
-// the still-valid routes; an empty RIB (cold start with nothing to announce)
-// reports NOT_READY.
-func (m *ribReadinessHelper) syncingState() readinesspb.State {
+// While routes are present the rib is DEGRADED (announcer keeps serving the
+// still-valid routes). An empty RIB reports NOT_READY.
+func (m *birdRIBReadiness) ribSyncingState() readinesspb.State {
 	if m.hasRoutes() {
 		return readinesspb.State_STATE_DEGRADED
 	}
 	return readinesspb.State_STATE_NOT_READY
 }
 
-// OnSessionStart is called by FeedRIB after ribRef.NewSession() opens a new
-// BIRD import stream for the given config name.
+// OnSessionStart is called by FeedRIB after a new BIRD import stream opens
+// for the given config name.
 //
 // sessionID is the id returned by ribRef.NewSession and is stored so that a
-// stale OnSessionEnd from the superseded stream can be ignored. Reports
-// DEGRADED rather than NOT_READY when routes are already present, so a resync
-// does not withdraw live announcements.
-func (m *ribReadinessHelper) OnSessionStart(name string, sessionID uint64) {
+// stale OnSessionEnd from a superseded stream can be ignored. The bird-session
+// scope transitions to READY; the rib scope resets the bulk-settle gate and
+// enters the syncing state.
+func (m *birdRIBReadiness) OnSessionStart(name string, sessionID uint64) {
 	if name != m.configName {
 		return
 	}
 
-	m.mu.Lock()
-	m.currentSession = sessionID
-	m.sessionActive = true
-	m.bulkSettled = false
-	m.belowSince = time.Time{}
-	m.mu.Unlock()
 	m.counter.Store(0)
 
-	m.tracker.Set("rib", m.syncingState(),
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.currentSession = sessionID
+	m.sessionActive = true
+	m.lastSessionEnd = time.Time{}
+	m.bulkSettled = false
+	m.belowSince = time.Time{}
+
+	m.tracker.Set("bird-session", readinesspb.State_STATE_READY)
+	m.tracker.Set("rib", m.ribSyncingState(),
 		&readinesspb.Reason{Code: "SYNCING"},
 	)
 }
 
-// OnUpdate is called by FeedRIB after each successfully applied route, with n
-// equal to the number of routes applied in that batch.
-func (m *ribReadinessHelper) OnUpdate(n int) {
+// OnUpdate is called by FeedRIB after each successfully applied route batch,
+// with n equal to the number of routes applied.
+func (m *birdRIBReadiness) OnUpdate(n int) {
 	m.counter.Add(int64(n))
 }
 
@@ -117,31 +159,36 @@ func (m *ribReadinessHelper) OnUpdate(n int) {
 //
 // sessionID must match the id passed to the most recent OnSessionStart for
 // name; if it does not, the call is from a superseded stream and is silently
-// ignored, preventing a stale end from clobbering the state of the active
-// session. When the session id matches, the scope is set to DEGRADED rather
-// than NOT_READY because routes remain in the RIB and the dataplane continues
-// forwarding; they are purged only later by the TTL-based CleanupTask.
-func (m *ribReadinessHelper) OnSessionEnd(name string, sessionID uint64) {
+// ignored to prevent a stale end from clobbering the active session state.
+// When the session id matches, bird-session transitions to
+// DEGRADED(RECONNECTING) and rib to DEGRADED(SESSION_ENDED) — routes remain
+// under TTL so no extinguish occurs.
+func (m *birdRIBReadiness) OnSessionEnd(name string, sessionID uint64) {
 	if name != m.configName {
 		return
 	}
 
 	m.mu.Lock()
+	defer m.mu.Unlock()
 	if sessionID != m.currentSession {
-		m.mu.Unlock()
 		return
 	}
 	m.sessionActive = false
 	m.bulkSettled = false
-	m.mu.Unlock()
+	m.lastSessionEnd = time.Now()
 
-	m.tracker.Set("rib", readinesspb.State_STATE_DEGRADED,
+	m.tracker.Set("bird-session",
+		readinesspb.State_STATE_DEGRADED,
+		&readinesspb.Reason{Code: "RECONNECTING"},
+	)
+	m.tracker.Set("rib",
+		readinesspb.State_STATE_DEGRADED,
 		&readinesspb.Reason{Code: "SESSION_ENDED"},
 	)
 }
 
 // Run drives the periodic sampling loop. It returns when ctx is cancelled.
-func (m *ribReadinessHelper) Run(ctx context.Context) error {
+func (m *birdRIBReadiness) Run(ctx context.Context) error {
 	ticker := time.NewTicker(m.sampleInterval)
 	defer ticker.Stop()
 
@@ -155,55 +202,170 @@ func (m *ribReadinessHelper) Run(ctx context.Context) error {
 			cur := m.counter.Load()
 			delta := cur - prevCount
 			prevCount = cur
-
 			rate := float64(delta) / m.sampleInterval.Seconds()
+			m.tick(now, rate)
+		}
+	}
+}
 
-			m.mu.Lock()
-			active := m.sessionActive
-			settled := m.bulkSettled
+// tick runs one sample-interval evaluation under m.mu.
+//
+// All tracker.Set calls for the rib and bird-session scopes are made while
+// the lock is held, so a concurrent session-edge event cannot interleave
+// with an in-flight tick and produce a stale clobber. hasRoutes and
+// tracker.Set are safe to call under m.mu — neither calls back into the
+// helper, so there is no lock-ordering issue.
+func (m *birdRIBReadiness) tick(now time.Time, rate float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-			if !settled {
-				if rate < m.rateThreshold {
-					if m.belowSince.IsZero() {
-						m.belowSince = now
-					} else if now.Sub(m.belowSince) >= m.stabilityWindow {
-						m.bulkSettled = true
-						settled = true
-					}
-				} else {
-					// Rate spiked above threshold; reset the continuous window.
-					m.belowSince = time.Time{}
-				}
+	if !m.bulkSettled {
+		if rate < m.rateThreshold {
+			if m.belowSince.IsZero() {
+				m.belowSince = now
+			} else if now.Sub(m.belowSince) >= m.stabilityWindow {
+				m.bulkSettled = true
 			}
-			m.mu.Unlock()
+		} else {
+			// Rate spiked above threshold; reset the continuous window.
+			m.belowSince = time.Time{}
+		}
+	}
 
-			var (
-				nextState readinesspb.State
-				reason    *readinesspb.Reason
-			)
-
-			switch {
-			case !active:
-				// No active session — keep the DEGRADED state OnSessionEnd set.
-				continue
-			case !settled:
-				nextState = m.syncingState()
-				reason = &readinesspb.Reason{Code: "SYNCING"}
-			default:
-				nextState = readinesspb.State_STATE_READY
-			}
-
-			if nextState == readinesspb.State_STATE_READY {
-				m.tracker.Set("rib", nextState)
-			} else {
-				m.tracker.Set("rib", nextState, reason)
-			}
-
-			m.log.Debug("rib readiness tick",
-				zap.Float64("rate", rate),
-				zap.Bool("bulk_settled", settled),
-				zap.String("state", nextState.String()),
+	if !m.sessionActive {
+		// Update the bird-session reason when the reconnect grace elapses.
+		if !m.lastSessionEnd.IsZero() && now.Sub(m.lastSessionEnd) >= m.reconnectGrace {
+			m.tracker.Set("bird-session",
+				readinesspb.State_STATE_DEGRADED,
+				&readinesspb.Reason{Code: "DOWN"},
 			)
 		}
+
+		// Re-evaluate rib from route presence so that a TTL purge that
+		// empties the RIB is reflected without waiting for a new session.
+		if !m.hasRoutes() {
+			m.tracker.Set("rib",
+				readinesspb.State_STATE_NOT_READY,
+				&readinesspb.Reason{Code: "NO_ROUTES"},
+			)
+		} else {
+			m.tracker.Set("rib",
+				readinesspb.State_STATE_DEGRADED,
+				&readinesspb.Reason{Code: "SESSION_ENDED"},
+			)
+		}
+		return
+	}
+
+	var (
+		nextState readinesspb.State
+		reason    *readinesspb.Reason
+	)
+
+	switch {
+	case !m.bulkSettled:
+		nextState = m.ribSyncingState()
+		reason = &readinesspb.Reason{Code: "SYNCING"}
+	case !m.hasRoutes():
+		nextState = readinesspb.State_STATE_NOT_READY
+		reason = &readinesspb.Reason{Code: "NO_ROUTES"}
+	default:
+		nextState = readinesspb.State_STATE_READY
+	}
+
+	if nextState == readinesspb.State_STATE_READY {
+		m.tracker.Set("rib", nextState)
+	} else {
+		m.tracker.Set("rib", nextState, reason)
+	}
+
+	m.log.Debug("rib readiness tick",
+		zap.Float64("rate", rate),
+		zap.Bool("bulk_settled", m.bulkSettled),
+		zap.String("state", nextState.String()),
+	)
+}
+
+// staticRIBReadiness drives only the "rib" readiness scope based on
+// whether the store holds any routes, without any BIRD session awareness.
+//
+// OnSessionStart, OnUpdate, and OnSessionEnd are no-ops: FeedRIB route
+// updates still get applied by RouteService regardless, but session events
+// carry no meaning for the readiness model when BIRD is not expected.
+// Run evaluates hasRoutes() once on entry and then on every SampleInterval
+// tick, setting rib=READY when routes>0, else NOT_READY(NO_ROUTES). The
+// bird-session scope is never touched.
+type staticRIBReadiness struct {
+	store          *RIBStore
+	configName     string
+	tracker        *operator.Readiness
+	sampleInterval time.Duration
+	log            *zap.Logger
+}
+
+// newStaticRIBReadiness constructs a static rib-readiness implementation.
+//
+// The initial rib scope is seeded immediately at construction — READY if
+// routes are already present, NOT_READY(NO_ROUTES) otherwise — so there is
+// no UNKNOWN gap before the first tick.
+func newStaticRIBReadiness(
+	store *RIBStore,
+	configName string,
+	tracker *operator.Readiness,
+	sampleInterval time.Duration,
+	log *zap.Logger,
+) *staticRIBReadiness {
+	m := &staticRIBReadiness{
+		store:          store,
+		configName:     configName,
+		tracker:        tracker,
+		sampleInterval: sampleInterval,
+		log:            log,
+	}
+
+	// Seed the initial rib state so there is no UNKNOWN window before Run starts.
+	m.evaluate()
+
+	return m
+}
+
+// OnSessionStart is a no-op for static deployments.
+func (m *staticRIBReadiness) OnSessionStart(_ string, _ uint64) {}
+
+// OnUpdate is a no-op for static deployments.
+func (m *staticRIBReadiness) OnUpdate(_ int) {}
+
+// OnSessionEnd is a no-op for static deployments.
+func (m *staticRIBReadiness) OnSessionEnd(_ string, _ uint64) {}
+
+// Run drives the periodic rib scope re-evaluation. It returns when ctx is cancelled.
+func (m *staticRIBReadiness) Run(ctx context.Context) error {
+	// Evaluate once on entry to reflect the post-PreRun state immediately, since
+	// static.routes are seeded by PreRun, which runs before Run starts.
+	m.evaluate()
+
+	ticker := time.NewTicker(m.sampleInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			m.evaluate()
+		}
+	}
+}
+
+// evaluate sets the rib scope to READY when routes are present, else NOT_READY(NO_ROUTES).
+func (m *staticRIBReadiness) evaluate() {
+	r, ok := m.store.Get(m.configName)
+	if ok && r.Stats().Routes > 0 {
+		m.tracker.Set("rib", readinesspb.State_STATE_READY)
+	} else {
+		m.tracker.Set("rib",
+			readinesspb.State_STATE_NOT_READY,
+			&readinesspb.Reason{Code: "NO_ROUTES"},
+		)
 	}
 }


### PR DESCRIPTION
Split route operator readiness into independent scopes — per-gateway apply outcome, neighbours, BIRD transport liveness (bird-session), and route content (rib) — each a small state machine.

Adopt one state spine: READY is ignite-eligible, DEGRADED holds the last-good state, NOT_READY is extinguish-eligible. Only the route-content, gateway and cold-start neighbour scopes can reach NOT_READY, so a transient BIRD or bird-adapter flap degrades instead of extinguishing the announce.

Close an empty-RIB false-ignite gap: a settled but empty route table now reports NOT_READY instead of READY.

Hold a gateway at DEGRADED rather than NOT_READY when a config push fails while its last-good forwarding state is still live; this shared readiness-tracker change also applies to the forward operator.

Add netlink resync hooks so the neighbours scope degrades and recovers instead of latching READY, plus a diagnostics-only reconnect_grace knob.

Unify the BIRD and static-only readiness paths behind a single interface with two implementations and a factory.