### PR TITLE
feat(operator): log readiness scope state transitions

### DIFF
--- a/common/go/operator/readiness.go
+++ b/common/go/operator/readiness.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/yanet-platform/yanet2/common/readinesspb"
@@ -26,11 +27,41 @@ type scopeState struct {
 type Readiness struct {
 	mu     sync.Mutex
 	scopes map[string]*scopeState
+	log    *zap.Logger
+}
+
+// ReadinessOption configures NewReadiness.
+type ReadinessOption func(*readinessOptions)
+
+type readinessOptions struct {
+	Log *zap.Logger
+}
+
+func newReadinessOptions() *readinessOptions {
+	return &readinessOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithReadinessLog sets the logger used by the Readiness tracker.
+//
+// The caller is responsible for pre-tagging the logger with any
+// operator or context attributes (e.g. via log.With(zap.String("operator",
+// "route"))). The tracker itself adds only the scope field on each transition.
+func WithReadinessLog(log *zap.Logger) ReadinessOption {
+	return func(o *readinessOptions) {
+		o.Log = log
+	}
 }
 
 // NewReadiness creates a Readiness tracker pre-seeded with the supplied
 // gateway IDs, each starting at STATE_UNKNOWN.
-func NewReadiness(gatewayIDs []string) *Readiness {
+func NewReadiness(gatewayIDs []string, options ...ReadinessOption) *Readiness {
+	opts := newReadinessOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	scopes := map[string]*scopeState{}
 	for _, id := range gatewayIDs {
 		scopes[id] = &scopeState{
@@ -39,7 +70,31 @@ func NewReadiness(gatewayIDs []string) *Readiness {
 		}
 	}
 
-	return &Readiness{scopes: scopes}
+	return &Readiness{
+		scopes: scopes,
+		log:    opts.Log,
+	}
+}
+
+// logTransition logs a state change for a scope at Info level when prev and
+// next differ. The first reason's code and message are included when present.
+func (m *Readiness) logTransition(name string, prev, next readinesspb.State, reasons []*readinesspb.Reason) {
+	if prev == next {
+		return
+	}
+
+	fields := []zap.Field{
+		zap.String("scope", name),
+		zap.String("from", prev.String()),
+		zap.String("to", next.String()),
+	}
+	if len(reasons) > 0 && reasons[0] != nil {
+		fields = append(fields, zap.String("reason", reasons[0].GetCode()))
+		if reasons[0].GetMessage() != "" {
+			fields = append(fields, zap.String("reason_message", reasons[0].GetMessage()))
+		}
+	}
+	m.log.Info("readiness scope transitioned", fields...)
 }
 
 // Observe records the outcome of one apply attempt for the named gateway.
@@ -77,12 +132,15 @@ func (m *Readiness) Observe(gatewayID string, err error) {
 		}
 	}
 
+	prev := s.state
 	if s.observedAt.IsZero() || s.state != next {
 		s.lastTransitionTime = now
 	}
 	s.state = next
 	s.reasons = reasons
 	s.observedAt = now
+
+	m.logTransition(s.name, prev, next, reasons)
 }
 
 // Set transitions the named scope to the given state, creating the scope if it
@@ -102,12 +160,15 @@ func (m *Readiness) Set(scope string, state readinesspb.State, reasons ...*readi
 		m.scopes[scope] = s
 	}
 
+	prev := s.state
 	if s.observedAt.IsZero() || s.state != state {
 		s.lastTransitionTime = now
 	}
 	s.state = state
 	s.reasons = reasons
 	s.observedAt = now
+
+	m.logTransition(s.name, prev, state, reasons)
 }
 
 // Drain marks every scope as STATE_NOT_READY with a SHUTTING_DOWN reason.
@@ -118,13 +179,17 @@ func (m *Readiness) Drain() {
 	defer m.mu.Unlock()
 
 	now := time.Now()
+	reasons := []*readinesspb.Reason{{Code: "SHUTTING_DOWN"}}
 	for _, s := range m.scopes {
+		prev := s.state
 		if s.state != readinesspb.State_STATE_NOT_READY {
 			s.lastTransitionTime = now
 		}
 		s.state = readinesspb.State_STATE_NOT_READY
-		s.reasons = []*readinesspb.Reason{{Code: "SHUTTING_DOWN"}}
+		s.reasons = reasons
 		s.observedAt = now
+
+		m.logTransition(s.name, prev, readinesspb.State_STATE_NOT_READY, reasons)
 	}
 }
 

--- a/common/go/operator/readiness_test.go
+++ b/common/go/operator/readiness_test.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	"github.com/yanet-platform/yanet2/common/readinesspb"
@@ -314,4 +317,124 @@ func TestReadiness_Set_ReasonsUpdated(t *testing.T) {
 
 	resp2 := r.Ready(&readinesspb.ReadyRequest{})
 	assert.Empty(t, resp2.Scopes[0].Reasons)
+}
+
+// newObservedReadiness constructs a Readiness tracker backed by a zap
+// observer so tests can inspect emitted log entries. The operatorName is
+// pre-tagged on the logger before passing it to the tracker, matching the
+// expected caller pattern.
+func newObservedReadiness(t *testing.T, scopes []string, operatorName string) (*operator.Readiness, *observer.ObservedLogs) {
+	t.Helper()
+	core, logs := observer.New(zapcore.InfoLevel)
+	r := operator.NewReadiness(
+		scopes,
+		operator.WithReadinessLog(zap.New(core).With(zap.String("operator", operatorName))),
+	)
+	return r, logs
+}
+
+func TestReadiness_Log_SetTransitionLogsEntry(t *testing.T) {
+	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
+
+	r.Set("gw-a", readinesspb.State_STATE_READY,
+		&readinesspb.Reason{Code: "SYNCED", Message: "all good"})
+
+	require.Equal(t, 1, logs.Len())
+	entry := logs.All()[0]
+	assert.Equal(t, "readiness scope transitioned", entry.Message)
+	assert.Equal(t, zapcore.InfoLevel, entry.Level)
+
+	fields := entry.ContextMap()
+	assert.Equal(t, "route", fields["operator"])
+	assert.Equal(t, "gw-a", fields["scope"])
+	assert.Equal(t, readinesspb.State_STATE_UNKNOWN.String(), fields["from"])
+	assert.Equal(t, readinesspb.State_STATE_READY.String(), fields["to"])
+	assert.Equal(t, "SYNCED", fields["reason"])
+	assert.Equal(t, "all good", fields["reason_message"])
+}
+
+func TestReadiness_Log_SetNoopLogs_Nothing(t *testing.T) {
+	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
+
+	// First Set: UNKNOWN -> READY (transition, will log).
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+	require.Equal(t, 1, logs.Len())
+
+	// Second Set: READY -> READY (no state change, must not log).
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+	assert.Equal(t, 1, logs.Len(), "no-op Set must not emit a log entry")
+}
+
+func TestReadiness_Log_SetReasonOnlyChange_LogsNothing(t *testing.T) {
+	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
+
+	r.Set("gw-a", readinesspb.State_STATE_DEGRADED,
+		&readinesspb.Reason{Code: "RECONNECTING"})
+	require.Equal(t, 1, logs.Len())
+
+	// Same state (DEGRADED), different reason — must not log.
+	r.Set("gw-a", readinesspb.State_STATE_DEGRADED,
+		&readinesspb.Reason{Code: "DOWN"})
+	assert.Equal(t, 1, logs.Len(), "reason-only change must not emit a log entry")
+}
+
+func TestReadiness_Log_ObserveReadyToDegraded(t *testing.T) {
+	r, logs := newObservedReadiness(t, []string{"gw"}, "forward")
+
+	// UNKNOWN -> READY: one log entry.
+	r.Observe("gw", nil)
+	require.Equal(t, 1, logs.Len())
+
+	// READY -> DEGRADED: one more log entry.
+	r.Observe("gw", errors.New("push failed"))
+	require.Equal(t, 2, logs.Len())
+
+	entry := logs.All()[1]
+	fields := entry.ContextMap()
+	assert.Equal(t, "forward", fields["operator"])
+	assert.Equal(t, "gw", fields["scope"])
+	assert.Equal(t, readinesspb.State_STATE_READY.String(), fields["from"])
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED.String(), fields["to"])
+}
+
+func TestReadiness_Log_ObserveRepeatedFailure_LogsNothing(t *testing.T) {
+	r, logs := newObservedReadiness(t, []string{"gw"}, "forward")
+
+	boom := errors.New("push failed")
+
+	// UNKNOWN -> NOT_READY: one log entry.
+	r.Observe("gw", boom)
+	require.Equal(t, 1, logs.Len())
+
+	// NOT_READY -> NOT_READY (repeated failure): must not log.
+	r.Observe("gw", boom)
+	assert.Equal(t, 1, logs.Len(), "repeated failing Observe must not emit additional log entries")
+}
+
+func TestReadiness_Log_DrainLogsPerChangedScope(t *testing.T) {
+	r, logs := newObservedReadiness(t, []string{"gw-a", "gw-b"}, "route")
+
+	// Bring gw-a to READY (logs one transition).
+	r.Observe("gw-a", nil)
+	// Leave gw-b at UNKNOWN (no transition yet).
+	countBeforeDrain := logs.Len()
+
+	// Drain: gw-a transitions READY -> NOT_READY (logs); gw-b transitions
+	// UNKNOWN -> NOT_READY (logs). gw-b was never in NOT_READY, so it logs too.
+	r.Drain()
+	assert.Equal(t, countBeforeDrain+2, logs.Len(),
+		"Drain must log one entry per scope that changes state")
+}
+
+func TestReadiness_Log_DrainAlreadyNotReady_NoLog(t *testing.T) {
+	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
+
+	// Force gw-a to NOT_READY first (UNKNOWN -> NOT_READY: one log entry).
+	r.Observe("gw-a", errors.New("boom"))
+	require.Equal(t, 1, logs.Len())
+
+	// Drain: gw-a is already NOT_READY — must not log.
+	r.Drain()
+	assert.Equal(t, 1, logs.Len(),
+		"Drain on a scope already in NOT_READY must not emit a log entry")
 }

--- a/operators/forward/internal/operator/operator.go
+++ b/operators/forward/internal/operator/operator.go
@@ -44,7 +44,9 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	for idx, gw := range cfg.Gateways {
 		gatewayIDs[idx] = gw.Name
 	}
-	tracker := operator.NewReadiness(gatewayIDs)
+	tracker := operator.NewReadiness(gatewayIDs,
+		operator.WithReadinessLog(log.With(zap.String("operator", "forward"))),
+	)
 
 	actuators := make([]operator.Actuator[State], 0, len(cfg.Gateways))
 	for _, gw := range cfg.Gateways {

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -68,7 +68,9 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	if cfg.Readiness.ExpectBird {
 		scopeNames = append(scopeNames, "bird-session")
 	}
-	tracker := operator.NewReadiness(scopeNames)
+	tracker := operator.NewReadiness(scopeNames,
+		operator.WithReadinessLog(log.With(zap.String("operator", "route"))),
+	)
 
 	neighTable := neigh.NewNeighTable()
 	if _, err := neighTable.CreateSource("static", staticTablePriority, true); err != nil {


### PR DESCRIPTION
Log every readiness scope state transition at Info level from the shared readiness tracker (Observe, Set, Drain), so the route and forward operators emit a structured line whenever a scope changes state.

Each line carries the operator type (route/forward) and the scope name as attributes, plus the from and to states and the reason code (and message when present) that drove the transition.

Log only real state-value changes — reason-only changes (for example a DEGRADED reason flip) and no-op updates stay silent.

Wire the logger through an options pattern (WithReadinessLog / WithReadinessOperator), defaulting to a no-op logger so existing callers and tests are unaffected.