### PR TITLE
refactor(operator): single reason per readiness scope

### DIFF
--- a/common/go/operator/readiness.go
+++ b/common/go/operator/readiness.go
@@ -14,7 +14,7 @@ import (
 type scopeState struct {
 	name               string
 	state              readinesspb.State
-	reasons            []*readinesspb.Reason
+	reason             *readinesspb.Reason
 	observedAt         time.Time
 	lastTransitionTime time.Time
 }
@@ -77,8 +77,8 @@ func NewReadiness(gatewayIDs []string, options ...ReadinessOption) *Readiness {
 }
 
 // logTransition logs a state change for a scope at Info level when prev and
-// next differ. The first reason's code and message are included when present.
-func (m *Readiness) logTransition(name string, prev, next readinesspb.State, reasons []*readinesspb.Reason) {
+// next differ. The reason code and message are included when reason is non-nil.
+func (m *Readiness) logTransition(name string, prev, next readinesspb.State, reason *readinesspb.Reason) {
 	if prev == next {
 		return
 	}
@@ -88,10 +88,10 @@ func (m *Readiness) logTransition(name string, prev, next readinesspb.State, rea
 		zap.String("from", prev.String()),
 		zap.String("to", next.String()),
 	}
-	if len(reasons) > 0 && reasons[0] != nil {
-		fields = append(fields, zap.String("reason", reasons[0].GetCode()))
-		if reasons[0].GetMessage() != "" {
-			fields = append(fields, zap.String("reason_message", reasons[0].GetMessage()))
+	if reason != nil {
+		fields = append(fields, zap.String("reason", reason.GetCode()))
+		if reason.GetMessage() != "" {
+			fields = append(fields, zap.String("reason_message", reason.GetMessage()))
 		}
 	}
 	m.log.Info("readiness scope transitioned", fields...)
@@ -114,14 +114,14 @@ func (m *Readiness) Observe(gatewayID string, err error) {
 	now := time.Now()
 
 	var (
-		next    readinesspb.State
-		reasons []*readinesspb.Reason
+		next   readinesspb.State
+		reason *readinesspb.Reason
 	)
 
 	if err == nil {
 		next = readinesspb.State_STATE_READY
 	} else {
-		reasons = []*readinesspb.Reason{{Code: "APPLY_FAILED", Message: err.Error()}}
+		reason = &readinesspb.Reason{Code: "APPLY_FAILED", Message: err.Error()}
 		switch s.state {
 		case readinesspb.State_STATE_READY, readinesspb.State_STATE_DEGRADED:
 			// Last successfully applied state is still live — hold at DEGRADED.
@@ -137,18 +137,18 @@ func (m *Readiness) Observe(gatewayID string, err error) {
 		s.lastTransitionTime = now
 	}
 	s.state = next
-	s.reasons = reasons
+	s.reason = reason
 	s.observedAt = now
 
-	m.logTransition(s.name, prev, next, reasons)
+	m.logTransition(s.name, prev, next, reason)
 }
 
 // Set transitions the named scope to the given state, creating the scope if it
 // does not yet exist.
 //
-// last_transition_time is updated only when the state value changes. Supplied
-// reasons replace any existing reasons on each call.
-func (m *Readiness) Set(scope string, state readinesspb.State, reasons ...*readinesspb.Reason) {
+// last_transition_time is updated only when the state value changes. The
+// supplied reason replaces any existing reason on each call; pass nil for none.
+func (m *Readiness) Set(scope string, state readinesspb.State, reason *readinesspb.Reason) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -165,10 +165,10 @@ func (m *Readiness) Set(scope string, state readinesspb.State, reasons ...*readi
 		s.lastTransitionTime = now
 	}
 	s.state = state
-	s.reasons = reasons
+	s.reason = reason
 	s.observedAt = now
 
-	m.logTransition(s.name, prev, state, reasons)
+	m.logTransition(s.name, prev, state, reason)
 }
 
 // Drain marks every scope as STATE_NOT_READY with a SHUTTING_DOWN reason.
@@ -179,17 +179,17 @@ func (m *Readiness) Drain() {
 	defer m.mu.Unlock()
 
 	now := time.Now()
-	reasons := []*readinesspb.Reason{{Code: "SHUTTING_DOWN"}}
+	reason := &readinesspb.Reason{Code: "SHUTTING_DOWN"}
 	for _, s := range m.scopes {
 		prev := s.state
 		if s.state != readinesspb.State_STATE_NOT_READY {
 			s.lastTransitionTime = now
 		}
 		s.state = readinesspb.State_STATE_NOT_READY
-		s.reasons = reasons
+		s.reason = reason
 		s.observedAt = now
 
-		m.logTransition(s.name, prev, readinesspb.State_STATE_NOT_READY, reasons)
+		m.logTransition(s.name, prev, readinesspb.State_STATE_NOT_READY, reason)
 	}
 }
 
@@ -212,10 +212,14 @@ func (m *Readiness) Ready(req *readinesspb.ReadyRequest) *readinesspb.ReadyRespo
 			}
 		}
 
+		var reasons []*readinesspb.Reason
+		if s.reason != nil {
+			reasons = []*readinesspb.Reason{s.reason}
+		}
 		scope := &readinesspb.Scope{
 			Name:    s.name,
 			State:   s.state,
-			Reasons: s.reasons,
+			Reasons: reasons,
 		}
 		if !s.observedAt.IsZero() {
 			scope.ObservedAt = timestamppb.New(s.observedAt)

--- a/common/go/operator/readiness_test.go
+++ b/common/go/operator/readiness_test.go
@@ -261,7 +261,7 @@ func TestReadiness_Set_UpsertNewScope(t *testing.T) {
 	r := operator.NewReadiness([]string{"gw-a"})
 
 	// Set a scope that was not in the initial list.
-	r.Set("rib", readinesspb.State_STATE_READY)
+	r.Set("rib", readinesspb.State_STATE_READY, nil)
 
 	resp := r.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp.Scopes, 2)
@@ -281,12 +281,12 @@ func TestReadiness_Set_UpsertNewScope(t *testing.T) {
 func TestReadiness_Set_TransitionTimeOnlyOnStateChange(t *testing.T) {
 	r := operator.NewReadiness([]string{"gw-a"})
 
-	r.Set("gw-a", readinesspb.State_STATE_READY)
+	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
 	resp1 := r.Ready(&readinesspb.ReadyRequest{})
 	ltt1 := resp1.Scopes[0].LastTransitionTime.AsTime()
 
 	// Second Set with same state must not advance last_transition_time.
-	r.Set("gw-a", readinesspb.State_STATE_READY)
+	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
 	resp2 := r.Ready(&readinesspb.ReadyRequest{})
 	ltt2 := resp2.Scopes[0].LastTransitionTime.AsTime()
 
@@ -313,7 +313,7 @@ func TestReadiness_Set_ReasonsUpdated(t *testing.T) {
 	assert.Equal(t, "SYNCING", resp1.Scopes[0].Reasons[0].Code)
 
 	// Transition to READY clears reasons.
-	r.Set("gw-a", readinesspb.State_STATE_READY)
+	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
 
 	resp2 := r.Ready(&readinesspb.ReadyRequest{})
 	assert.Empty(t, resp2.Scopes[0].Reasons)
@@ -357,11 +357,11 @@ func TestReadiness_Log_SetNoopLogs_Nothing(t *testing.T) {
 	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
 
 	// First Set: UNKNOWN -> READY (transition, will log).
-	r.Set("gw-a", readinesspb.State_STATE_READY)
+	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
 	require.Equal(t, 1, logs.Len())
 
 	// Second Set: READY -> READY (no state change, must not log).
-	r.Set("gw-a", readinesspb.State_STATE_READY)
+	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
 	assert.Equal(t, 1, logs.Len(), "no-op Set must not emit a log entry")
 }
 

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -80,7 +80,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	// Propagate the neighbours scope based on netlink monitor config.
 	var neighOpts []neigh.Option
 	if cfg.NetlinkMonitor.Disabled {
-		tracker.Set("neighbours", readinesspb.State_STATE_READY)
+		tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
 		neighOpts = []neigh.Option{neigh.WithOnSynced(func() {})}
 	} else {
 		// Seed the neighbours scope at NOT_READY(SYNCING) before the monitor starts.
@@ -90,7 +90,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		)
 		neighOpts = []neigh.Option{
 			neigh.WithOnSynced(func() {
-				tracker.Set("neighbours", readinesspb.State_STATE_READY)
+				tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
 			}),
 			neigh.WithOnError(func(err error) {
 				tracker.Set("neighbours",
@@ -99,7 +99,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 				)
 			}),
 			neigh.WithOnResynced(func() {
-				tracker.Set("neighbours", readinesspb.State_STATE_READY)
+				tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
 			}),
 		}
 	}

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -40,7 +40,7 @@ func TestReadiness_NeighboursDisabled_ImmediatelyReady(t *testing.T) {
 
 	// When netlink monitor is disabled, mark neighbours READY immediately.
 	if cfg.NetlinkMonitor.Disabled {
-		tracker.Set("neighbours", readinesspb.State_STATE_READY)
+		tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
 	}
 
 	s := requireScope(t, tracker, "neighbours")
@@ -51,7 +51,7 @@ func TestReadiness_ExpectBirdFalse_RibImmediatelyReady(t *testing.T) {
 	tracker := operator.NewReadiness([]string{"rib"})
 
 	// When BIRD is not expected, mark rib READY immediately.
-	tracker.Set("rib", readinesspb.State_STATE_READY)
+	tracker.Set("rib", readinesspb.State_STATE_READY, nil)
 
 	s := requireScope(t, tracker, "rib")
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
@@ -750,7 +750,7 @@ func TestNeighbours_SyncThenError(t *testing.T) {
 	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
 
 	// First sync completes.
-	tracker.Set("neighbours", readinesspb.State_STATE_READY)
+	tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
 
 	s = requireScope(t, tracker, "neighbours")
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
@@ -768,7 +768,7 @@ func TestNeighbours_SyncThenError(t *testing.T) {
 	assert.Equal(t, "RESYNC", s.Reasons[0].Code)
 
 	// Recovery transitions back to READY.
-	tracker.Set("neighbours", readinesspb.State_STATE_READY)
+	tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
 
 	s = requireScope(t, tracker, "neighbours")
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)

--- a/operators/route/internal/operator/rib_readiness.go
+++ b/operators/route/internal/operator/rib_readiness.go
@@ -143,7 +143,7 @@ func (m *birdRIBReadiness) OnSessionStart(name string, sessionID uint64) {
 	m.bulkSettled = false
 	m.belowSince = time.Time{}
 
-	m.tracker.Set("bird-session", readinesspb.State_STATE_READY)
+	m.tracker.Set("bird-session", readinesspb.State_STATE_READY, nil)
 	m.tracker.Set("rib", m.ribSyncingState(),
 		&readinesspb.Reason{Code: "SYNCING"},
 	)
@@ -273,11 +273,7 @@ func (m *birdRIBReadiness) tick(now time.Time, rate float64) {
 		nextState = readinesspb.State_STATE_READY
 	}
 
-	if nextState == readinesspb.State_STATE_READY {
-		m.tracker.Set("rib", nextState)
-	} else {
-		m.tracker.Set("rib", nextState, reason)
-	}
+	m.tracker.Set("rib", nextState, reason)
 
 	m.log.Debug("rib readiness tick",
 		zap.Float64("rate", rate),
@@ -361,7 +357,7 @@ func (m *staticRIBReadiness) Run(ctx context.Context) error {
 func (m *staticRIBReadiness) evaluate() {
 	r, ok := m.store.Get(m.configName)
 	if ok && r.Stats().Routes > 0 {
-		m.tracker.Set("rib", readinesspb.State_STATE_READY)
+		m.tracker.Set("rib", readinesspb.State_STATE_READY, nil)
 	} else {
 		m.tracker.Set("rib",
 			readinesspb.State_STATE_NOT_READY,


### PR DESCRIPTION
Carry a single reason per readiness scope instead of a slice, since no producer ever set more than one. The in-memory model and the Set / Observe / Drain / transition-logging API now use one optional reason rather than a variadic slice.

The wire proto stays `repeated Reason reasons`, with `Ready` emitting a zero-or-one element slice, so the CLIs and the web UI are unaffected.