### PR TITLE
refactor(route): rename gateway readiness scope to fib:<gateway>:<module>

### DIFF
--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -58,11 +58,13 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	log := opts.Log
 	metrics := NewMetrics()
 
-	// Build the readiness tracker scope list: one gateway scope per gateway,
-	// plus a neighbours scope, a rib scope, and optionally a bird-session scope.
+	moduleName := cfg.Function.Module.Unwrap()
+
+	// Build the readiness tracker scope list: one fib:<gateway>:<module> scope per
+	// gateway, plus a neighbours scope, a rib scope, and optionally a bird-session scope.
 	scopeNames := make([]string, 0, len(cfg.Gateways)+3)
 	for _, gw := range cfg.Gateways {
-		scopeNames = append(scopeNames, "gateway:"+gw.Name)
+		scopeNames = append(scopeNames, fmt.Sprintf("fib:%s:%s", gw.Name, moduleName))
 	}
 	scopeNames = append(scopeNames, "neighbours", "rib")
 	if cfg.Readiness.ExpectBird {
@@ -112,8 +114,6 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	routeRIBStore := newRIBStore(log)
 	source := NewRouteSource(neighTable, routeRIBStore)
 	wake := source.WakeFunc()
-
-	moduleName := cfg.Function.Module.Unwrap()
 	ribHelper := newRIBReadiness(cfg.Readiness, routeRIBStore, moduleName, tracker, log)
 
 	routeSvc := NewRouteService(
@@ -150,8 +150,8 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			return nil, fmt.Errorf("failed to construct gateway actuator %q: %w", gw.Name, err)
 		}
 
-		// Wrap each actuator so that apply outcomes drive the per-gateway scope.
-		observed := operator.NewObservedActuator(actuator, "gateway:"+gw.Name, tracker.Observe)
+		// Wrap each actuator so that apply outcomes drive the per-gateway fib scope.
+		observed := operator.NewObservedActuator(actuator, fmt.Sprintf("fib:%s:%s", gw.Name, moduleName), tracker.Observe)
 		actuators = append(actuators, observed)
 	}
 

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -36,7 +36,7 @@ func TestReadiness_NeighboursDisabled_ImmediatelyReady(t *testing.T) {
 	cfg.Readiness.ExpectBird = false
 	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}}
 
-	tracker := operator.NewReadiness([]string{"gateway:gw0", "neighbours", "rib"})
+	tracker := operator.NewReadiness([]string{"fib:gw0:route0", "neighbours", "rib"})
 
 	// When netlink monitor is disabled, mark neighbours READY immediately.
 	if cfg.NetlinkMonitor.Disabled {
@@ -57,36 +57,36 @@ func TestReadiness_ExpectBirdFalse_RibImmediatelyReady(t *testing.T) {
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
 }
 
-func TestReadiness_GatewayObserve(t *testing.T) {
-	tracker := operator.NewReadiness([]string{"gateway:gw0"})
+func TestReadiness_FIBObserve(t *testing.T) {
+	tracker := operator.NewReadiness([]string{"fib:gw0:route0"})
 
 	// Initial state is UNKNOWN.
-	s := requireScope(t, tracker, "gateway:gw0")
+	s := requireScope(t, tracker, "fib:gw0:route0")
 	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, s.State)
 
 	// From UNKNOWN, a failed apply transitions to NOT_READY (never programmed).
-	tracker.Observe("gateway:gw0", assert.AnError)
-	s = requireScope(t, tracker, "gateway:gw0")
+	tracker.Observe("fib:gw0:route0", assert.AnError)
+	s = requireScope(t, tracker, "fib:gw0:route0")
 	assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
 	require.Len(t, s.Reasons, 1)
 	assert.Equal(t, "APPLY_FAILED", s.Reasons[0].Code)
 
 	// Successful apply transitions to READY.
-	tracker.Observe("gateway:gw0", nil)
-	s = requireScope(t, tracker, "gateway:gw0")
+	tracker.Observe("fib:gw0:route0", nil)
+	s = requireScope(t, tracker, "fib:gw0:route0")
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
 	assert.Empty(t, s.Reasons)
 
 	// Failed apply from READY transitions to DEGRADED (last-good FIB still live).
-	tracker.Observe("gateway:gw0", assert.AnError)
-	s = requireScope(t, tracker, "gateway:gw0")
+	tracker.Observe("fib:gw0:route0", assert.AnError)
+	s = requireScope(t, tracker, "fib:gw0:route0")
 	assert.Equal(t, readinesspb.State_STATE_DEGRADED, s.State)
 	require.Len(t, s.Reasons, 1)
 	assert.Equal(t, "APPLY_FAILED", s.Reasons[0].Code)
 
 	// Recovery: successful apply from DEGRADED transitions back to READY.
-	tracker.Observe("gateway:gw0", nil)
-	s = requireScope(t, tracker, "gateway:gw0")
+	tracker.Observe("fib:gw0:route0", nil)
+	s = requireScope(t, tracker, "fib:gw0:route0")
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
 	assert.Empty(t, s.Reasons)
 }


### PR DESCRIPTION
Rename the route operator per-gateway readiness apply scope from `gateway:<name>` to `fib:<gateway>:<module>`, using the managed module config name.

The name is more descriptive — the scope reflects a FIB push outcome — and the format leaves room for the config name as the operator grows toward managing multiple configs.

Granularity is unchanged: still one scope per gateway, covering every FIB pushed there.