### PR TITLE
refactor(operator): split readiness Set into Set and SetWithReason

### DIFF
--- a/common/go/operator/readiness.go
+++ b/common/go/operator/readiness.go
@@ -143,12 +143,25 @@ func (m *Readiness) Observe(gatewayID string, err error) {
 	m.logTransition(s.name, prev, next, reason)
 }
 
-// Set transitions the named scope to the given state, creating the scope if it
-// does not yet exist.
+// Set transitions the named scope to the given state with no reason.
 //
-// last_transition_time is updated only when the state value changes. The
-// supplied reason replaces any existing reason on each call; pass nil for none.
-func (m *Readiness) Set(scope string, state readinesspb.State, reason *readinesspb.Reason) {
+// It creates the scope if absent. last_transition_time is updated only when
+// the state value changes.
+func (m *Readiness) Set(scope string, state readinesspb.State) {
+	m.set(scope, state, nil)
+}
+
+// SetWithReason transitions the named scope to the given state with the
+// supplied reason.
+//
+// It creates the scope if absent. last_transition_time is updated only when
+// the state value changes.
+func (m *Readiness) SetWithReason(scope string, state readinesspb.State, reason *readinesspb.Reason) {
+	m.set(scope, state, reason)
+}
+
+// set is the shared implementation for Set and SetWithReason.
+func (m *Readiness) set(scope string, state readinesspb.State, reason *readinesspb.Reason) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/common/go/operator/readiness_test.go
+++ b/common/go/operator/readiness_test.go
@@ -261,7 +261,7 @@ func TestReadiness_Set_UpsertNewScope(t *testing.T) {
 	r := operator.NewReadiness([]string{"gw-a"})
 
 	// Set a scope that was not in the initial list.
-	r.Set("rib", readinesspb.State_STATE_READY, nil)
+	r.Set("rib", readinesspb.State_STATE_READY)
 
 	resp := r.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp.Scopes, 2)
@@ -281,19 +281,19 @@ func TestReadiness_Set_UpsertNewScope(t *testing.T) {
 func TestReadiness_Set_TransitionTimeOnlyOnStateChange(t *testing.T) {
 	r := operator.NewReadiness([]string{"gw-a"})
 
-	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
+	r.Set("gw-a", readinesspb.State_STATE_READY)
 	resp1 := r.Ready(&readinesspb.ReadyRequest{})
 	ltt1 := resp1.Scopes[0].LastTransitionTime.AsTime()
 
 	// Second Set with same state must not advance last_transition_time.
-	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
+	r.Set("gw-a", readinesspb.State_STATE_READY)
 	resp2 := r.Ready(&readinesspb.ReadyRequest{})
 	ltt2 := resp2.Scopes[0].LastTransitionTime.AsTime()
 
 	assert.Equal(t, ltt1, ltt2, "last_transition_time must not change on same-state Set")
 
 	// Transition to NOT_READY must advance last_transition_time.
-	r.Set("gw-a", readinesspb.State_STATE_NOT_READY,
+	r.SetWithReason("gw-a", readinesspb.State_STATE_NOT_READY,
 		&readinesspb.Reason{Code: "SYNCING"})
 	resp3 := r.Ready(&readinesspb.ReadyRequest{})
 	ltt3 := resp3.Scopes[0].LastTransitionTime.AsTime()
@@ -305,7 +305,7 @@ func TestReadiness_Set_TransitionTimeOnlyOnStateChange(t *testing.T) {
 func TestReadiness_Set_ReasonsUpdated(t *testing.T) {
 	r := operator.NewReadiness([]string{"gw-a"})
 
-	r.Set("gw-a", readinesspb.State_STATE_NOT_READY,
+	r.SetWithReason("gw-a", readinesspb.State_STATE_NOT_READY,
 		&readinesspb.Reason{Code: "SYNCING"})
 
 	resp1 := r.Ready(&readinesspb.ReadyRequest{})
@@ -313,7 +313,7 @@ func TestReadiness_Set_ReasonsUpdated(t *testing.T) {
 	assert.Equal(t, "SYNCING", resp1.Scopes[0].Reasons[0].Code)
 
 	// Transition to READY clears reasons.
-	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
+	r.Set("gw-a", readinesspb.State_STATE_READY)
 
 	resp2 := r.Ready(&readinesspb.ReadyRequest{})
 	assert.Empty(t, resp2.Scopes[0].Reasons)
@@ -336,7 +336,7 @@ func newObservedReadiness(t *testing.T, scopes []string, operatorName string) (*
 func TestReadiness_Log_SetTransitionLogsEntry(t *testing.T) {
 	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
 
-	r.Set("gw-a", readinesspb.State_STATE_READY,
+	r.SetWithReason("gw-a", readinesspb.State_STATE_READY,
 		&readinesspb.Reason{Code: "SYNCED", Message: "all good"})
 
 	require.Equal(t, 1, logs.Len())
@@ -357,23 +357,23 @@ func TestReadiness_Log_SetNoopLogs_Nothing(t *testing.T) {
 	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
 
 	// First Set: UNKNOWN -> READY (transition, will log).
-	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
+	r.Set("gw-a", readinesspb.State_STATE_READY)
 	require.Equal(t, 1, logs.Len())
 
 	// Second Set: READY -> READY (no state change, must not log).
-	r.Set("gw-a", readinesspb.State_STATE_READY, nil)
+	r.Set("gw-a", readinesspb.State_STATE_READY)
 	assert.Equal(t, 1, logs.Len(), "no-op Set must not emit a log entry")
 }
 
 func TestReadiness_Log_SetReasonOnlyChange_LogsNothing(t *testing.T) {
 	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
 
-	r.Set("gw-a", readinesspb.State_STATE_DEGRADED,
+	r.SetWithReason("gw-a", readinesspb.State_STATE_DEGRADED,
 		&readinesspb.Reason{Code: "RECONNECTING"})
 	require.Equal(t, 1, logs.Len())
 
 	// Same state (DEGRADED), different reason — must not log.
-	r.Set("gw-a", readinesspb.State_STATE_DEGRADED,
+	r.SetWithReason("gw-a", readinesspb.State_STATE_DEGRADED,
 		&readinesspb.Reason{Code: "DOWN"})
 	assert.Equal(t, 1, logs.Len(), "reason-only change must not emit a log entry")
 }

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -82,26 +82,26 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	// Propagate the neighbours scope based on netlink monitor config.
 	var neighOpts []neigh.Option
 	if cfg.NetlinkMonitor.Disabled {
-		tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
+		tracker.Set("neighbours", readinesspb.State_STATE_READY)
 		neighOpts = []neigh.Option{neigh.WithOnSynced(func() {})}
 	} else {
 		// Seed the neighbours scope at NOT_READY(SYNCING) before the monitor starts.
-		tracker.Set("neighbours",
+		tracker.SetWithReason("neighbours",
 			readinesspb.State_STATE_NOT_READY,
 			&readinesspb.Reason{Code: "SYNCING"},
 		)
 		neighOpts = []neigh.Option{
 			neigh.WithOnSynced(func() {
-				tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
+				tracker.Set("neighbours", readinesspb.State_STATE_READY)
 			}),
 			neigh.WithOnError(func(err error) {
-				tracker.Set("neighbours",
+				tracker.SetWithReason("neighbours",
 					readinesspb.State_STATE_DEGRADED,
 					&readinesspb.Reason{Code: "RESYNC", Message: err.Error()},
 				)
 			}),
 			neigh.WithOnResynced(func() {
-				tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
+				tracker.Set("neighbours", readinesspb.State_STATE_READY)
 			}),
 		}
 	}

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -40,7 +40,7 @@ func TestReadiness_NeighboursDisabled_ImmediatelyReady(t *testing.T) {
 
 	// When netlink monitor is disabled, mark neighbours READY immediately.
 	if cfg.NetlinkMonitor.Disabled {
-		tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
+		tracker.Set("neighbours", readinesspb.State_STATE_READY)
 	}
 
 	s := requireScope(t, tracker, "neighbours")
@@ -51,7 +51,7 @@ func TestReadiness_ExpectBirdFalse_RibImmediatelyReady(t *testing.T) {
 	tracker := operator.NewReadiness([]string{"rib"})
 
 	// When BIRD is not expected, mark rib READY immediately.
-	tracker.Set("rib", readinesspb.State_STATE_READY, nil)
+	tracker.Set("rib", readinesspb.State_STATE_READY)
 
 	s := requireScope(t, tracker, "rib")
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
@@ -739,7 +739,7 @@ func TestNeighbours_SyncThenError(t *testing.T) {
 	tracker := operator.NewReadiness([]string{"neighbours"})
 
 	// Seed initial NOT_READY(SYNCING) as operator.go does.
-	tracker.Set("neighbours",
+	tracker.SetWithReason("neighbours",
 		readinesspb.State_STATE_NOT_READY,
 		&readinesspb.Reason{Code: "SYNCING"},
 	)
@@ -750,14 +750,14 @@ func TestNeighbours_SyncThenError(t *testing.T) {
 	assert.Equal(t, "SYNCING", s.Reasons[0].Code)
 
 	// First sync completes.
-	tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
+	tracker.Set("neighbours", readinesspb.State_STATE_READY)
 
 	s = requireScope(t, tracker, "neighbours")
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)
 	assert.Empty(t, s.Reasons)
 
 	// Error after sync transitions to DEGRADED(RESYNC).
-	tracker.Set("neighbours",
+	tracker.SetWithReason("neighbours",
 		readinesspb.State_STATE_DEGRADED,
 		&readinesspb.Reason{Code: "RESYNC"},
 	)
@@ -768,7 +768,7 @@ func TestNeighbours_SyncThenError(t *testing.T) {
 	assert.Equal(t, "RESYNC", s.Reasons[0].Code)
 
 	// Recovery transitions back to READY.
-	tracker.Set("neighbours", readinesspb.State_STATE_READY, nil)
+	tracker.Set("neighbours", readinesspb.State_STATE_READY)
 
 	s = requireScope(t, tracker, "neighbours")
 	assert.Equal(t, readinesspb.State_STATE_READY, s.State)

--- a/operators/route/internal/operator/rib_readiness.go
+++ b/operators/route/internal/operator/rib_readiness.go
@@ -90,11 +90,11 @@ func newBirdRIBReadiness(
 
 	// Seed initial states: bird-session starts DEGRADED(NO_SESSION),
 	// rib starts NOT_READY(SYNCING).
-	tracker.Set("bird-session",
+	tracker.SetWithReason("bird-session",
 		readinesspb.State_STATE_DEGRADED,
 		&readinesspb.Reason{Code: "NO_SESSION"},
 	)
-	tracker.Set("rib",
+	tracker.SetWithReason("rib",
 		readinesspb.State_STATE_NOT_READY,
 		&readinesspb.Reason{Code: "SYNCING"},
 	)
@@ -143,8 +143,8 @@ func (m *birdRIBReadiness) OnSessionStart(name string, sessionID uint64) {
 	m.bulkSettled = false
 	m.belowSince = time.Time{}
 
-	m.tracker.Set("bird-session", readinesspb.State_STATE_READY, nil)
-	m.tracker.Set("rib", m.ribSyncingState(),
+	m.tracker.Set("bird-session", readinesspb.State_STATE_READY)
+	m.tracker.SetWithReason("rib", m.ribSyncingState(),
 		&readinesspb.Reason{Code: "SYNCING"},
 	)
 }
@@ -177,11 +177,11 @@ func (m *birdRIBReadiness) OnSessionEnd(name string, sessionID uint64) {
 	m.bulkSettled = false
 	m.lastSessionEnd = time.Now()
 
-	m.tracker.Set("bird-session",
+	m.tracker.SetWithReason("bird-session",
 		readinesspb.State_STATE_DEGRADED,
 		&readinesspb.Reason{Code: "RECONNECTING"},
 	)
-	m.tracker.Set("rib",
+	m.tracker.SetWithReason("rib",
 		readinesspb.State_STATE_DEGRADED,
 		&readinesspb.Reason{Code: "SESSION_ENDED"},
 	)
@@ -235,7 +235,7 @@ func (m *birdRIBReadiness) tick(now time.Time, rate float64) {
 	if !m.sessionActive {
 		// Update the bird-session reason when the reconnect grace elapses.
 		if !m.lastSessionEnd.IsZero() && now.Sub(m.lastSessionEnd) >= m.reconnectGrace {
-			m.tracker.Set("bird-session",
+			m.tracker.SetWithReason("bird-session",
 				readinesspb.State_STATE_DEGRADED,
 				&readinesspb.Reason{Code: "DOWN"},
 			)
@@ -244,12 +244,12 @@ func (m *birdRIBReadiness) tick(now time.Time, rate float64) {
 		// Re-evaluate rib from route presence so that a TTL purge that
 		// empties the RIB is reflected without waiting for a new session.
 		if !m.hasRoutes() {
-			m.tracker.Set("rib",
+			m.tracker.SetWithReason("rib",
 				readinesspb.State_STATE_NOT_READY,
 				&readinesspb.Reason{Code: "NO_ROUTES"},
 			)
 		} else {
-			m.tracker.Set("rib",
+			m.tracker.SetWithReason("rib",
 				readinesspb.State_STATE_DEGRADED,
 				&readinesspb.Reason{Code: "SESSION_ENDED"},
 			)
@@ -273,7 +273,11 @@ func (m *birdRIBReadiness) tick(now time.Time, rate float64) {
 		nextState = readinesspb.State_STATE_READY
 	}
 
-	m.tracker.Set("rib", nextState, reason)
+	if reason == nil {
+		m.tracker.Set("rib", nextState)
+	} else {
+		m.tracker.SetWithReason("rib", nextState, reason)
+	}
 
 	m.log.Debug("rib readiness tick",
 		zap.Float64("rate", rate),
@@ -357,9 +361,9 @@ func (m *staticRIBReadiness) Run(ctx context.Context) error {
 func (m *staticRIBReadiness) evaluate() {
 	r, ok := m.store.Get(m.configName)
 	if ok && r.Stats().Routes > 0 {
-		m.tracker.Set("rib", readinesspb.State_STATE_READY, nil)
+		m.tracker.Set("rib", readinesspb.State_STATE_READY)
 	} else {
-		m.tracker.Set("rib",
+		m.tracker.SetWithReason("rib",
 			readinesspb.State_STATE_NOT_READY,
 			&readinesspb.Reason{Code: "NO_ROUTES"},
 		)


### PR DESCRIPTION
Replace the single readiness `Set(scope, state, reason)` with `Set(scope, state)` for transitions that carry no reason and `SetWithReason(scope, state, reason)` for those that do, so the common no-reason transitions no longer pass an explicit `nil`.

Both delegate to one shared implementation; behavior is unchanged.