### PR TITLE
refactor(forward): rename readiness scope to config:<numa>

### DIFF
--- a/operators/forward/cli/src/main.rs
+++ b/operators/forward/cli/src/main.rs
@@ -1,7 +1,7 @@
 //! CLI for the YANET forward operator (readiness commands).
 //!
 //! Connects to a gRPC endpoint exposing the operator's `ReadinessService`
-//! and reports per-gateway readiness state.
+//! and reports per-scope readiness state.
 
 use core::fmt::{self, Display, Formatter};
 
@@ -54,14 +54,14 @@ pub struct Cmd {
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
-    /// Show per-gateway readiness of the forward operator.
+    /// Show per-scope readiness of the forward operator.
     Ready(ReadyCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ReadyCmd {
-    /// Restrict output to these gateway names; empty means all.
-    pub gateways: Vec<String>,
+    /// Restrict output to these scope names; empty means all.
+    pub scopes: Vec<String>,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -116,7 +116,7 @@ impl ForwardOperatorService {
     }
 
     pub async fn ready(&mut self, cmd: ReadyCmd) -> Result<bool, Error> {
-        let request = readinesspb::pb::ReadyRequest { scopes: cmd.gateways.clone() };
+        let request = readinesspb::pb::ReadyRequest { scopes: cmd.scopes.clone() };
 
         let response = self
             .client
@@ -129,7 +129,7 @@ impl ForwardOperatorService {
             response.scopes.iter().map(|scope| scope.name.as_str()).collect();
 
         let missing: Vec<&str> = cmd
-            .gateways
+            .scopes
             .iter()
             .map(String::as_str)
             .filter(|name| !returned_names.contains(name))
@@ -152,10 +152,10 @@ impl ForwardOperatorService {
         output::data(
             &response.scopes,
             response.scopes.is_empty() && missing.is_empty(),
-            format_args!("no gateways"),
+            format_args!("no scopes"),
             || {
                 let mut rows: Vec<ReadinessRow> = response.scopes.iter().map(ReadinessRow::from).collect();
-                rows.sort_by(|a, b| a.gateway.cmp(&b.gateway));
+                rows.sort_by(|a, b| a.scope.cmp(&b.scope));
 
                 if !rows.is_empty() {
                     print_readiness_table(rows);
@@ -175,7 +175,7 @@ impl ForwardOperatorService {
                 let missing_count = missing.len();
 
                 if missing_count > 0 {
-                    println!("summary: {ready_count}/{total} ready, {missing_count} requested gateway missing");
+                    println!("summary: {ready_count}/{total} ready, {missing_count} requested scope missing");
                 } else {
                     println!("summary: {ready_count}/{total} ready");
                 }
@@ -212,8 +212,8 @@ impl Display for StateCell {
 
 #[derive(Debug, Tabled)]
 pub struct ReadinessRow {
-    #[tabled(rename = "Gateway")]
-    pub gateway: String,
+    #[tabled(rename = "Scope")]
+    pub scope: String,
     #[tabled(rename = "State")]
     pub state: String,
     #[tabled(rename = "Last Transition")]
@@ -237,7 +237,7 @@ impl From<&readinesspb::pb::Scope> for ReadinessRow {
             .join(", ");
 
         Self {
-            gateway: scope.name.clone(),
+            scope: scope.name.clone(),
             state: state_cell.to_string(),
             last_transition: format_age(scope.last_transition_time.as_ref()),
             observed: format_age(scope.observed_at.as_ref()),

--- a/operators/forward/internal/operator/operator.go
+++ b/operators/forward/internal/operator/operator.go
@@ -40,11 +40,12 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		})
 	}
 
-	gatewayIDs := make([]string, len(cfg.Gateways))
+	// One config:<gateway> scope per gateway, covering all module configs pushed there.
+	scopeNames := make([]string, len(cfg.Gateways))
 	for idx, gw := range cfg.Gateways {
-		gatewayIDs[idx] = gw.Name
+		scopeNames[idx] = fmt.Sprintf("config:%s", gw.Name)
 	}
-	tracker := operator.NewReadiness(gatewayIDs,
+	tracker := operator.NewReadiness(scopeNames,
 		operator.WithReadinessLog(log.With(zap.String("operator", "forward"))),
 	)
 
@@ -57,7 +58,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			}
 			return nil, fmt.Errorf("failed to construct gateway actuator %q: %w", gw.Name, err)
 		}
-		observed := operator.NewObservedActuator(actuator, gw.Name, tracker.Observe)
+		observed := operator.NewObservedActuator(actuator, fmt.Sprintf("config:%s", gw.Name), tracker.Observe)
 		actuators = append(actuators, observed)
 	}
 

--- a/operators/forward/internal/operator/readiness_service.go
+++ b/operators/forward/internal/operator/readiness_service.go
@@ -9,7 +9,8 @@ import (
 )
 
 // ReadinessService implements operatorpb.ReadinessServiceServer by delegating
-// to a Readiness tracker that records per-gateway apply outcomes.
+// to a Readiness tracker that records per-gateway apply outcomes under
+// config:<gateway> scopes.
 type ReadinessService struct {
 	operatorpb.UnimplementedReadinessServiceServer
 
@@ -21,7 +22,7 @@ func NewReadinessService(tracker *operator.Readiness) *ReadinessService {
 	return &ReadinessService{tracker: tracker}
 }
 
-// Ready returns the current per-gateway readiness state.
+// Ready returns the current readiness state for all config:<gateway> scopes.
 func (m *ReadinessService) Ready(
 	ctx context.Context,
 	req *readinesspb.ReadyRequest,


### PR DESCRIPTION
Rename the forward operator's per-gateway readiness apply scope from the bare gateway id (e.g. `numa0`) to `config:<numa>` (e.g. `config:numa0`).

- The name is self-describing — the scope reflects the outcome of pushing forward module configs to that gateway — and matches the route operator's namespaced scopes (`fib:<gateway>:<module>`).
- Granularity is unchanged: still one scope per gateway, covering every module config pushed there (a gateway applies all configs in one pass, yielding one observation per gateway).
- Both the seeded scope name and the `Observe` target use the identical `config:<gateway>` string, so the seeded scope and observed scope stay in lock-step.
- Update the forward CLI `ready` command to be scope-centric, mirroring the route operator CLI: it filters and displays raw scope names instead of bare gateway names, so `config:<numa>` filters work and the table column reflects the scope.

The readiness state machine is the shared `Observe` path and is unchanged: `UNKNOWN`→`READY` on first successful push, `READY`/`DEGRADED`→`DEGRADED` on a failed re-apply (holds the last-good config live, avoiding false extinguishes), `UNKNOWN`/`NOT_READY`→`NOT_READY` on a failure before any successful push, and `NOT_READY` on drain. There is intentionally no `DEGRADED`→`NOT_READY` grace-expiry — a transient apply failure must not extinguish a gateway already serving a good config.