### PR TITLE
fix(web): delete forward config immediately instead of deferring

### DIFF
--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -39,6 +39,7 @@ const ForwardPage: React.FC = () => {
         anyDirty,
         dispatchDraft,
         saveConfig,
+        commitDeleteConfig,
         discardConfig,
     } = useForwardDraft();
     const [searchParams, setSearchParams] = useSearchParams();
@@ -54,6 +55,7 @@ const ForwardPage: React.FC = () => {
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
     const [addConfigOpen, setAddConfigOpen] = useState(false);
     const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
+    const [deleteInFlightConfig, setDeleteInFlightConfig] = useState<string | null>(null);
     const [diffModalOpen, setDiffModalOpen] = useState(false);
     const [paletteOpen, setPaletteOpen] = useState(false);
     const [modeFilter, setModeFilter] = useState<ModeFilterValue>('all');
@@ -61,7 +63,7 @@ const ForwardPage: React.FC = () => {
     const drawerRef = useRef<RuleDrawerHandle>(null);
     const queryConfig = useMemo(() => searchParams.get(QP_CONFIG), [searchParams]);
     const search = useMemo(() => searchParams.get(QP_SEARCH) || '', [searchParams]);
-    const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig))) ? queryConfig : (draftConfigs[0] || '');
+    const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig) || queryConfig === deleteInFlightConfig)) ? queryConfig : (draftConfigs[0] || '');
     const updateParams = useCallback((updates: Record<string, string | null>): void => {
         setSearchParams((prev) => {
             const next = new URLSearchParams(prev);
@@ -72,6 +74,17 @@ const ForwardPage: React.FC = () => {
                     next.set(key, value);
                 }
             }
+            return next;
+        }, { replace: true });
+    }, [setSearchParams]);
+
+    const clearConfigParamIfCurrent = useCallback((name: string): void => {
+        setSearchParams((prev) => {
+            if (prev.get(QP_CONFIG) !== name) {
+                return prev;
+            }
+            const next = new URLSearchParams(prev);
+            next.delete(QP_CONFIG);
             return next;
         }, { replace: true });
     }, [setSearchParams]);
@@ -186,10 +199,19 @@ const ForwardPage: React.FC = () => {
         setDeleteConfirmOpen(false);
     }, [selectedIds, visibleItems, currentConfig, dispatchDraft]);
 
-    const handleDeleteConfig = useCallback((): void => {
-        dispatchDraft({ type: 'DELETE_CONFIG', configName: currentConfig });
+    const handleDeleteConfig = useCallback(async (): Promise<void> => {
         setDeleteConfigOpen(false);
-    }, [currentConfig, dispatchDraft]);
+        setDeleteInFlightConfig(currentConfig);
+        const name = currentConfig;
+        try {
+            await commitDeleteConfig(name);
+            clearConfigParamIfCurrent(name);
+        } catch {
+            // Toast already surfaced by the hook.
+        } finally {
+            setDeleteInFlightConfig(null);
+        }
+    }, [currentConfig, commitDeleteConfig, clearConfigParamIfCurrent]);
 
     const handleSave = useCallback(async (): Promise<void> => {
         await saveConfig(currentConfig);

--- a/web/src/pages/modules/forward/draftReducer.ts
+++ b/web/src/pages/modules/forward/draftReducer.ts
@@ -35,6 +35,7 @@ export type ForwardDraftAction =
     | { type: 'ADD_CONFIG'; configName: string }
     | { type: 'DELETE_CONFIG'; configName: string }
     | { type: 'DISCARD_CONFIG'; configName: string }
+    | { type: 'CANCEL_PENDING_DELETE'; configName: string }
     | { type: 'MARK_SAVED'; configName: string };
 
 /** Recompute the dirty set by comparing JSON of draft vs server for every known config. */
@@ -223,13 +224,24 @@ export const forwardDraftReducer = (
             return { ...next, dirty: recomputeDirty(next) };
         }
 
+        case 'CANCEL_PENDING_DELETE': {
+            const pendingDeleteConfigs = new Set(state.pendingDeleteConfigs);
+            pendingDeleteConfigs.delete(action.configName);
+            const next: Omit<ForwardDraftState, 'dirty'> = {
+                ...state,
+                pendingDeleteConfigs,
+            };
+            return { ...next, dirty: recomputeDirty(next) };
+        }
+
         case 'MARK_SAVED': {
             const draftRules = state.draft[action.configName];
+            const wasPendingDelete = state.pendingDeleteConfigs.has(action.configName);
             const pendingDeleteConfigs = new Set(state.pendingDeleteConfigs);
             pendingDeleteConfigs.delete(action.configName);
 
-            if (draftRules === undefined) {
-                // Config was deleted.
+            if (wasPendingDelete || draftRules === undefined) {
+                // Config was deleted (pending delete just persisted, or never had a draft entry).
                 const { [action.configName]: _s, ...serverRest } = state.server;
                 const { [action.configName]: _d, ...draftRest } = state.draft;
                 const next: Omit<ForwardDraftState, 'dirty'> = {

--- a/web/src/pages/modules/forward/useForwardDraft.ts
+++ b/web/src/pages/modules/forward/useForwardDraft.ts
@@ -27,6 +27,8 @@ export interface UseForwardDraftResult {
     dispatchDraft: (action: ForwardDraftAction) => void;
     /** Save one config to the server, then mark it clean. */
     saveConfig: (configName: string) => Promise<void>;
+    /** Immediately delete a config: dispatches DELETE_CONFIG, calls the API for server configs, toasts on completion. */
+    commitDeleteConfig: (configName: string) => Promise<void>;
     /** Revert one config's draft back to the server snapshot. */
     discardConfig: (configName: string) => void;
     /** Save all dirty configs sequentially. */
@@ -111,6 +113,23 @@ export const useForwardDraft = (): UseForwardDraftResult => {
         }
     }, [state.draft, state.pendingDeleteConfigs]);
 
+    const commitDeleteConfig = useCallback(async (configName: string): Promise<void> => {
+        const isLocalOnly = state.localOnlyConfigs.includes(configName);
+        rawDispatch({ type: 'DELETE_CONFIG', configName });
+        if (isLocalOnly) {
+            return;
+        }
+        try {
+            await API.forward.deleteConfig({ name: configName });
+            rawDispatch({ type: 'MARK_SAVED', configName });
+            toaster.success(`yn-save-${configName}`, `Config "${configName}" deleted.`);
+        } catch (err) {
+            rawDispatch({ type: 'CANCEL_PENDING_DELETE', configName });
+            toaster.error(`yn-save-err-${configName}`, `Failed to delete "${configName}"`, err);
+            throw err;
+        }
+    }, [state.localOnlyConfigs]);
+
     const discardConfig = useCallback((configName: string): void => {
         rawDispatch({ type: 'DISCARD_CONFIG', configName });
     }, []);
@@ -163,6 +182,7 @@ export const useForwardDraft = (): UseForwardDraftResult => {
         anyDirty,
         dispatchDraft,
         saveConfig,
+        commitDeleteConfig,
         discardConfig,
         saveAll,
         discardAll,


### PR DESCRIPTION
Delete config on the Forward page (both the table button and the command-palette action) did nothing: a server config was only marked pending-delete locally, the delete RPC never fired, the config was never removed, and no toaster appeared.

- Add `commitDeleteConfig` to the forward draft hook, mirroring the ACL module: dispatch the delete, call `API.forward.deleteConfig` for server configs, toast on completion, and roll back with an error toast on RPC failure.
- Make `handleDeleteConfig` await the commit, guard the active config while the delete RPC is in flight, and drop a stale `config` query param once the config is gone.
- Fix the `MARK_SAVED` reducer to honour the pending-delete flag so a successfully deleted server config is removed rather than re-added to the config list.