### PR TITLE
fix(web): clear forward filters before palette row jump

### DIFF
--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -375,7 +375,7 @@ const ForwardPage: React.FC = () => {
             return parts.join(' · ');
         },
         searchText: (it) => [it.target, it.counter, ...it.deviceNames, ...it.sourceCidrs, ...it.dstCidrs].join(' '),
-        onSelect: (id) => { handleJumpToRow(id); setPaletteOpen(false); },
+        onSelect: (id) => { setModeFilter('all'); handleSearchChange(''); handleJumpToRow(id); setPaletteOpen(false); },
         icon: '→',
     };
 


### PR DESCRIPTION
The Forward command palette searches across all rules, but the table only renders rows passing the active mode and search filters. Selecting a palette match that was filtered out called the jump handler against a row absent from the rendered list, so nothing scrolled or flashed.

- Clear the mode filter and search box before jumping to a row, so the target is always visible when the flash fires.

Addresses the Codex review comment on #1019.