### PR TITLE
refactor(web): extract useInstanceData hook from InstanceCard

### DIFF
--- a/web/src/pages/builtin/_shared/useInstanceData.ts
+++ b/web/src/pages/builtin/_shared/useInstanceData.ts
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import type { InstanceInfo } from '../../../api/inspect';
+import { useDeviceCounters } from '../../../hooks';
+import { computeAgentUsage, computeMemoryTotals } from '../inspect/utils';
+
+/** Shared data preamble for dashboard and inspect InstanceCard components. */
+export const useInstanceData = (instance: InstanceInfo) => {
+    const devices = instance.devices ?? [];
+
+    const deviceNames = useMemo(
+        () => devices.map((d, idx) => d.name ?? `device-${idx}`),
+        [devices],
+    );
+
+    const { counters: rateCounters, absoluteCounters } = useDeviceCounters(
+        deviceNames,
+        devices.length > 0,
+    );
+
+    const physicalDeviceNames = useMemo(() => {
+        const result = new Set<string>();
+        devices.forEach((d, idx) => {
+            if (d.type === 'plain') {
+                result.add(d.name ?? `device-${idx}`);
+            }
+        });
+        return result;
+    }, [devices]);
+
+    const usage = useMemo(() => computeAgentUsage(instance), [instance]);
+    const memTotals = useMemo(() => computeMemoryTotals(usage), [usage]);
+
+    return { devices, deviceNames, rateCounters, absoluteCounters, physicalDeviceNames, usage, memTotals };
+};

--- a/web/src/pages/builtin/dashboard/InstanceCard.tsx
+++ b/web/src/pages/builtin/dashboard/InstanceCard.tsx
@@ -1,6 +1,5 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import type { InstanceInfo } from '../../../api/inspect';
-import { useDeviceCounters } from '../../../hooks';
 import { SystemState } from './SystemState';
 import { useWorkerCount } from './hooks';
 import { KpiStrip } from './KpiStrip';
@@ -9,7 +8,7 @@ import { SceneErrorBoundary } from './SceneErrorBoundary';
 import { Throughput } from './Throughput';
 import { DataplaneModules } from './DataplaneModules';
 import { SystemAgents } from '../inspect/SystemAgents';
-import { computeAgentUsage, computeMemoryTotals } from '../inspect/utils';
+import { useInstanceData } from '../_shared/useInstanceData';
 
 export interface InstanceCardProps {
     instance: InstanceInfo;
@@ -17,32 +16,9 @@ export interface InstanceCardProps {
 
 /** Root layout for a single YANET instance: system state, KPI strip, 3D scene, modules. */
 export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
-    const devices = instance.devices ?? [];
-
-    const deviceNames = useMemo(
-        () => devices.map((d, idx) => d.name ?? `device-${idx}`),
-        [devices],
-    );
-
-    const { counters: rateCounters, absoluteCounters } = useDeviceCounters(
-        deviceNames,
-        devices.length > 0,
-    );
+    const { deviceNames, rateCounters, absoluteCounters, physicalDeviceNames, usage, memTotals } = useInstanceData(instance);
 
     const workerCount = useWorkerCount(deviceNames);
-
-    const usage = useMemo(() => computeAgentUsage(instance), [instance]);
-    const memTotals = useMemo(() => computeMemoryTotals(usage), [usage]);
-
-    const physicalDeviceNames = useMemo(() => {
-        const result = new Set<string>();
-        devices.forEach((d, idx) => {
-            if (d.type === 'plain') {
-                result.add(d.name ?? `device-${idx}`);
-            }
-        });
-        return result;
-    }, [devices]);
 
     return (
         <>

--- a/web/src/pages/builtin/inspect/InstanceCard.tsx
+++ b/web/src/pages/builtin/inspect/InstanceCard.tsx
@@ -1,13 +1,12 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import type { InstanceInfo } from '../../../api/inspect';
-import { useDeviceCounters } from '../../../hooks';
 import { HudHero } from './HudHero';
 import { DeviceWall } from './DeviceWall';
 import { ModuleStrip } from './ModuleStrip';
 import { SystemAgents } from './SystemAgents';
 import { PipeWall } from './PipeWall';
 import { FnWall } from './FnWall';
-import { computeAgentUsage, computeMemoryTotals } from './utils';
+import { useInstanceData } from '../_shared/useInstanceData';
 
 export interface InstanceCardProps {
     instance: InstanceInfo;
@@ -15,30 +14,7 @@ export interface InstanceCardProps {
 
 /** Root HUD layout for a single YANET instance. */
 export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
-    const devices = instance.devices ?? [];
-
-    const deviceNames = useMemo(
-        () => devices.map((d, idx) => d.name ?? `device-${idx}`),
-        [devices],
-    );
-
-    const { counters: rateCounters, absoluteCounters } = useDeviceCounters(
-        deviceNames,
-        devices.length > 0,
-    );
-
-    const physicalDeviceNames = useMemo(() => {
-        const result = new Set<string>();
-        devices.forEach((d, idx) => {
-            if (d.type === 'plain') {
-                result.add(d.name ?? `device-${idx}`);
-            }
-        });
-        return result;
-    }, [devices]);
-
-    const agentUsage = useMemo(() => computeAgentUsage(instance), [instance]);
-    const memTotals = useMemo(() => computeMemoryTotals(agentUsage), [agentUsage]);
+    const { rateCounters, absoluteCounters, physicalDeviceNames, usage: agentUsage, memTotals } = useInstanceData(instance);
 
     return (
         <div className="iv-instance">


### PR DESCRIPTION
The dashboard and inspect `InstanceCard` components shared a near-identical data preamble (device names, device counters, physical-device set, agent usage, memory totals).

- Extract it into a shared `useInstanceData` hook under `pages/builtin/_shared/`.
- Both cards keep their distinct render trees unchanged; only the computation preamble moved.