### PR TITLE
refactor(web): share row-validation and yaml helpers across draft pages

### DIFF
--- a/web/src/pages/_shared/draft/index.ts
+++ b/web/src/pages/_shared/draft/index.ts
@@ -17,3 +17,5 @@ export { useDraftDragDrop } from './useDraftDragDrop';
 export type { DragOverState, UseDraftDragDropResult } from './useDraftDragDrop';
 export { useDraftPageHandlers } from './useDraftPageHandlers';
 export type { UseDraftPageHandlersResult } from './useDraftPageHandlers';
+export { rowHasError, countInvalidRows } from './validation';
+export { dumpYamlDoc, parseYamlList } from './yaml';

--- a/web/src/pages/_shared/draft/validation.ts
+++ b/web/src/pages/_shared/draft/validation.ts
@@ -1,0 +1,9 @@
+/** Returns true if any field in the errors object has a truthy value. */
+export const rowHasError = <E extends object>(errs: E): boolean =>
+    Object.values(errs).some(Boolean);
+
+/** Count rows that fail validation according to the provided validate function. */
+export const countInvalidRows = <T, E extends object>(
+    rows: T[],
+    validate: (row: T) => E,
+): number => rows.filter((row) => rowHasError(validate(row))).length;

--- a/web/src/pages/_shared/draft/yaml.ts
+++ b/web/src/pages/_shared/draft/yaml.ts
@@ -1,0 +1,40 @@
+import jsYaml from 'js-yaml';
+
+/** Serialize a document object to YAML using the project-standard dump options. */
+export const dumpYamlDoc = (doc: unknown): string =>
+    jsYaml.dump(doc, { sortKeys: false, lineWidth: 120, noRefs: true });
+
+/**
+ * Parse a YAML string containing a named list into typed row items.
+ *
+ * Throws with a descriptive message on any parse or structural failure.
+ * Each row receives an id of the form `import-${idx}-${Date.now()}`.
+ */
+export const parseYamlList = <T extends { id: string }>(
+    text: string,
+    key: string,
+    mapRow: (raw: unknown, idx: number) => Omit<T, 'id'>,
+): T[] => {
+    let parsed: unknown;
+    try {
+        parsed = jsYaml.load(text);
+    } catch (e) {
+        throw new Error(`YAML parse error: ${(e as Error).message}`);
+    }
+
+    if (!parsed || typeof parsed !== 'object') {
+        throw new Error(`Expected a YAML object with a "${key}" list.`);
+    }
+
+    const doc = parsed as Record<string, unknown>;
+    const array = Array.isArray(doc[key]) ? (doc[key] as unknown[]) : null;
+
+    if (!array) {
+        throw new Error(`Expected a top-level "${key}" list.`);
+    }
+
+    return array.map((raw: unknown, idx: number) => ({
+        id: `import-${idx}-${Date.now()}`,
+        ...mapRow(raw, idx),
+    })) as T[];
+};

--- a/web/src/pages/modules/decap/validation.ts
+++ b/web/src/pages/modules/decap/validation.ts
@@ -1,4 +1,8 @@
 import { isValidCIDR } from '../../_shared/draft/cidr';
+import {
+    rowHasError as sharedRowHasError,
+    countInvalidRows as sharedCountInvalidRows,
+} from '../../_shared/draft/validation';
 import type { PrefixRowItem, PrefixRowErrors } from './types';
 
 /** Validate all fields of a prefix row. Returns null per field if valid. */
@@ -7,11 +11,8 @@ export const validateRow = (row: PrefixRowItem): PrefixRowErrors => ({
 });
 
 /** Returns true if the row has any validation error. */
-export const rowHasError = (row: PrefixRowItem): boolean => {
-    const errs = validateRow(row);
-    return Object.values(errs).some(Boolean);
-};
+export const rowHasError = (row: PrefixRowItem): boolean => sharedRowHasError(validateRow(row));
 
 /** Count invalid rows in a list. */
 export const countInvalidRows = (rows: PrefixRowItem[]): number =>
-    rows.filter(rowHasError).length;
+    sharedCountInvalidRows(rows, validateRow);

--- a/web/src/pages/modules/decap/yaml.ts
+++ b/web/src/pages/modules/decap/yaml.ts
@@ -1,4 +1,4 @@
-import jsYaml from 'js-yaml';
+import { dumpYamlDoc, parseYamlList } from '../../_shared/draft/yaml';
 import type { PrefixRowItem } from './types';
 
 interface DecapYamlDoc {
@@ -12,43 +12,20 @@ export const rowsToYaml = (configName: string, rows: PrefixRowItem[]): string =>
         config: configName,
         prefixes: rows.map((r) => r.prefix),
     };
-    return jsYaml.dump(doc, { sortKeys: false, lineWidth: 120, noRefs: true });
+    return dumpYamlDoc(doc);
 };
 
 /** Serialize prefix rows (without config wrapper) to YAML for diff display. */
 export const rowsToDiffYaml = (rows: PrefixRowItem[]): string => {
     const doc = { prefixes: rows.map((r) => r.prefix) };
-    return jsYaml.dump(doc, { sortKeys: false, lineWidth: 120, noRefs: true });
+    return dumpYamlDoc(doc);
 };
 
 /**
  * Parse YAML (either { config, prefixes } or just { prefixes }) into prefix rows.
  * Returns the parsed rows. Throws with a descriptive message on failure.
  */
-export const yamlToRows = (text: string): PrefixRowItem[] => {
-    let parsed: unknown;
-    try {
-        parsed = jsYaml.load(text);
-    } catch (e) {
-        throw new Error(`YAML parse error: ${(e as Error).message}`);
-    }
-
-    if (!parsed || typeof parsed !== 'object') {
-        throw new Error('Expected a YAML object with a "prefixes" list.');
-    }
-
-    const doc = parsed as Record<string, unknown>;
-    const prefixesRaw = Array.isArray(doc['prefixes']) ? doc['prefixes'] : null;
-
-    if (!prefixesRaw) {
-        throw new Error('Expected a top-level "prefixes" list.');
-    }
-
-    return prefixesRaw.map((p: unknown, idx: number): PrefixRowItem => {
-        const prefix = typeof p === 'string' ? p : '';
-        return {
-            id: `import-${idx}-${Date.now()}`,
-            prefix,
-        };
-    });
-};
+export const yamlToRows = (text: string): PrefixRowItem[] =>
+    parseYamlList<PrefixRowItem>(text, 'prefixes', (p) => ({
+        prefix: typeof p === 'string' ? p : '',
+    }));

--- a/web/src/pages/modules/route/validation.ts
+++ b/web/src/pages/modules/route/validation.ts
@@ -1,5 +1,9 @@
 import type { FIBRowItem, FIBRowErrors } from './types';
 import { isValidCIDR } from '../../_shared/draft/cidr';
+import {
+    rowHasError as sharedRowHasError,
+    countInvalidRows as sharedCountInvalidRows,
+} from '../../_shared/draft/validation';
 
 /** Returns true if s is a valid IPv4 or IPv6 CIDR prefix. */
 export const isValidPrefix = isValidCIDR;
@@ -21,11 +25,8 @@ export const validateRow = (row: FIBRowItem): FIBRowErrors => ({
 });
 
 /** Returns true if the row has any validation error. */
-export const rowHasError = (row: FIBRowItem): boolean => {
-    const errs = validateRow(row);
-    return Object.values(errs).some(Boolean);
-};
+export const rowHasError = (row: FIBRowItem): boolean => sharedRowHasError(validateRow(row));
 
 /** Count invalid rows in a list. */
 export const countInvalidRows = (rows: FIBRowItem[]): number =>
-    rows.filter(rowHasError).length;
+    sharedCountInvalidRows(rows, validateRow);

--- a/web/src/pages/modules/route/yaml.ts
+++ b/web/src/pages/modules/route/yaml.ts
@@ -1,4 +1,4 @@
-import jsYaml from 'js-yaml';
+import { dumpYamlDoc, parseYamlList } from '../../_shared/draft/yaml';
 import type { FIBRowItem } from './types';
 
 /** Single-config YAML shape: { config, routes: [...] }. Mirrors Forward's envelope style. */
@@ -25,7 +25,7 @@ export const rowsToYaml = (configName: string, rows: FIBRowItem[]): string => {
             device: r.device,
         })),
     };
-    return jsYaml.dump(doc, { sortKeys: false, lineWidth: 120, noRefs: true });
+    return dumpYamlDoc(doc);
 };
 
 /** Serialize FIB rows (without config wrapper) to YAML for diff display. */
@@ -38,40 +38,20 @@ export const rowsToDiffYaml = (rows: FIBRowItem[]): string => {
             device: r.device,
         })),
     };
-    return jsYaml.dump(doc, { sortKeys: false, lineWidth: 120, noRefs: true });
+    return dumpYamlDoc(doc);
 };
 
 /**
  * Parse YAML (either the full { config, routes } doc or just { routes }) into FIB rows.
  * Returns the parsed rows. Throws with a descriptive message on failure.
  */
-export const yamlToRows = (text: string): FIBRowItem[] => {
-    let parsed: unknown;
-    try {
-        parsed = jsYaml.load(text);
-    } catch (e) {
-        throw new Error(`YAML parse error: ${(e as Error).message}`);
-    }
-
-    if (!parsed || typeof parsed !== 'object') {
-        throw new Error('Expected a YAML object with a "routes" list.');
-    }
-
-    const doc = parsed as Record<string, unknown>;
-    const routesRaw = Array.isArray(doc['routes']) ? doc['routes'] : null;
-
-    if (!routesRaw) {
-        throw new Error('Expected a top-level "routes" list.');
-    }
-
-    return routesRaw.map((r: unknown, idx: number): FIBRowItem => {
+export const yamlToRows = (text: string): FIBRowItem[] =>
+    parseYamlList<FIBRowItem>(text, 'routes', (r) => {
         const row = (r && typeof r === 'object') ? (r as Record<string, unknown>) : {};
         return {
-            id: `import-${idx}-${Date.now()}`,
             prefix: typeof row['prefix'] === 'string' ? row['prefix'] : '',
             dst_mac: typeof row['dst_mac'] === 'string' ? row['dst_mac'] : '',
             src_mac: typeof row['src_mac'] === 'string' ? row['src_mac'] : '',
             device: typeof row['device'] === 'string' ? row['device'] : '',
         };
     });
-};


### PR DESCRIPTION
decap and route draft pages duplicated two helper families:

- Identical `rowHasError`/`countInvalidRows` logic — extracted into a generic `_shared/draft/validation.ts` (each module keeps its own `validateRow`).
- A parallel YAML dump/parse envelope — extracted into `_shared/draft/yaml.ts` (`dumpYamlDoc` + generic `parseYamlList`), with each module keeping its per-row schema mapping.

Pure refactor: YAML output, validation results, and all module export signatures are unchanged.