### PR TITLE
refactor(web): extract shared lane card-header primitives

### DIFF
--- a/web/src/pages/builtin/_shared/lane-editor/LaneCardActions.tsx
+++ b/web/src/pages/builtin/_shared/lane-editor/LaneCardActions.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { TrashIcon, SaveIcon, DiscardIcon } from '../icons';
+
+interface LaneCardActionsProps {
+    prefix: 'fn' | 'pl';
+    isDirty: boolean;
+    saveDisabled: boolean;
+    deleteTitle: string;
+    deleteAriaLabel: string;
+    onDiscard: () => void;
+    onOpenDiff: () => void;
+    onDelete: () => void;
+}
+
+export const LaneCardActions = ({
+    prefix,
+    isDirty,
+    saveDisabled,
+    deleteTitle,
+    deleteAriaLabel,
+    onDiscard,
+    onOpenDiff,
+    onDelete,
+}: LaneCardActionsProps): React.JSX.Element => (
+    <div className={`${prefix}-card-header__actions`}>
+        {isDirty && (
+            <button
+                className={`${prefix}-card-header__icon-btn ${prefix}-card-header__icon-btn--discard`}
+                type="button"
+                title="Discard changes"
+                aria-label="Discard local changes"
+                onClick={onDiscard}
+            >
+                <DiscardIcon />
+            </button>
+        )}
+        <button
+            className={`${prefix}-card-header__icon-btn ${prefix}-card-header__icon-btn--save`}
+            onClick={onOpenDiff}
+            disabled={saveDisabled}
+            type="button"
+            title={isDirty ? 'Review & apply' : 'No changes to save'}
+            aria-label="Review and apply changes"
+        >
+            <SaveIcon />
+        </button>
+        <button
+            className={`${prefix}-card-header__icon-btn ${prefix}-card-header__icon-btn--delete`}
+            onClick={onDelete}
+            type="button"
+            title={deleteTitle}
+            aria-label={deleteAriaLabel}
+        >
+            <TrashIcon size={18} />
+        </button>
+    </div>
+);

--- a/web/src/pages/builtin/_shared/lane-editor/LaneCollapseButton.tsx
+++ b/web/src/pages/builtin/_shared/lane-editor/LaneCollapseButton.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ChevronDownIcon } from '../icons';
+
+interface LaneCollapseButtonProps {
+    prefix: 'fn' | 'pl';
+    collapsed: boolean;
+    onToggle: () => void;
+    expandLabel: string;
+    collapseLabel: string;
+}
+
+export const LaneCollapseButton = ({
+    prefix,
+    collapsed,
+    onToggle,
+    expandLabel,
+    collapseLabel,
+}: LaneCollapseButtonProps): React.JSX.Element => (
+    <button
+        className={`${prefix}-card-header__collapse-btn`}
+        onClick={onToggle}
+        type="button"
+        aria-expanded={!collapsed}
+        aria-label={collapsed ? expandLabel : collapseLabel}
+    >
+        <span
+            className={`${prefix}-card-header__chevron${collapsed ? '' : ` ${prefix}-card-header__chevron--open`}`}
+        >
+            <ChevronDownIcon />
+        </span>
+    </button>
+);

--- a/web/src/pages/builtin/_shared/lane-editor/LaneStat.tsx
+++ b/web/src/pages/builtin/_shared/lane-editor/LaneStat.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface LaneStatProps {
+    prefix: 'fn' | 'pl';
+    label: string;
+    value: string | number;
+    accent?: boolean;
+}
+
+export const LaneStat = ({ prefix, label, value, accent }: LaneStatProps): React.JSX.Element => (
+    <div className={`${prefix}-card-header__stat`}>
+        <span
+            className={`${prefix}-card-header__stat-value`}
+            style={accent ? { color: `var(--${prefix}-accent)` } : undefined}
+        >
+            {value}
+        </span>
+        <span className={`${prefix}-card-header__stat-label`}>{label}</span>
+    </div>
+);

--- a/web/src/pages/builtin/_shared/lane-editor/index.ts
+++ b/web/src/pages/builtin/_shared/lane-editor/index.ts
@@ -7,3 +7,7 @@ export type { DragPayload, DragState } from './useDragState';
 export { useSparklineHistory } from './useSparklineHistory';
 export { useUnsavedChangesBlocker } from './useUnsavedChangesBlocker';
 export { AddSlotButton } from './AddSlotButton';
+export { formatPps } from './laneFormat';
+export { LaneStat } from './LaneStat';
+export { LaneCardActions } from './LaneCardActions';
+export { LaneCollapseButton } from './LaneCollapseButton';

--- a/web/src/pages/builtin/functions/components/FunctionCardHeader.tsx
+++ b/web/src/pages/builtin/functions/components/FunctionCardHeader.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import type { NetworkFunction } from '../types';
 import { metaFor } from '../moduleMeta';
-import { Sparkline } from '../../_shared/lane-editor';
-import { TrashIcon, SaveIcon, DiscardIcon, ChevronDownIcon } from '../../_shared/icons';
+import { Sparkline, formatPps, LaneStat, LaneCardActions, LaneCollapseButton } from '../../_shared/lane-editor';
 import { ConfirmDialog } from '../../../../components';
 
 interface FunctionCardHeaderProps {
@@ -17,32 +16,6 @@ interface FunctionCardHeaderProps {
     onDiscard: () => void;
     onDelete: () => void;
 }
-
-/** Format a pps number with K/M suffix. */
-const fmtPps = (v: number): string => {
-    if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M`;
-    if (v >= 1_000) return `${(v / 1_000).toFixed(1)}K`;
-    return String(Math.round(v));
-};
-
-interface MiniStatProps {
-    label: string;
-    value: string | number;
-    accent?: boolean;
-}
-
-/** Stat cell: value on top, label on bottom, right-aligned. */
-const MiniStat = ({ label, value, accent }: MiniStatProps): React.JSX.Element => (
-    <div className="fn-card-header__stat">
-        <span
-            className="fn-card-header__stat-value"
-            style={accent ? { color: 'var(--fn-accent)' } : undefined}
-        >
-            {value}
-        </span>
-        <span className="fn-card-header__stat-label">{label}</span>
-    </div>
-);
 
 /**
  * Header row of a function card: type chip, function id, unsaved pill,
@@ -84,19 +57,13 @@ export const FunctionCardHeader: React.FC<FunctionCardHeaderProps> = ({
     return (
         <div className="fn-card-header">
             <div className="fn-card-header__main-row">
-                <button
-                    className="fn-card-header__collapse-btn"
-                    onClick={onToggleCollapse}
-                    type="button"
-                    aria-expanded={!collapsed}
-                    aria-label={collapsed ? 'Expand function' : 'Collapse function'}
-                >
-                    <span
-                        className={`fn-card-header__chevron${collapsed ? '' : ' fn-card-header__chevron--open'}`}
-                    >
-                        <ChevronDownIcon />
-                    </span>
-                </button>
+                <LaneCollapseButton
+                    prefix="fn"
+                    collapsed={collapsed}
+                    onToggle={onToggleCollapse}
+                    expandLabel="Expand function"
+                    collapseLabel="Collapse function"
+                />
 
                 {distinctTypes.length === 1 && (() => {
                     const meta = metaFor(distinctTypes[0]);
@@ -139,11 +106,11 @@ export const FunctionCardHeader: React.FC<FunctionCardHeaderProps> = ({
                 <div className="fn-card-header__spacer" />
 
                 <div className="fn-card-header__stats">
-                    <MiniStat label="CHAINS" value={totalChains} />
+                    <LaneStat prefix="fn" label="CHAINS" value={totalChains} />
                     <div className="fn-card-header__stat-sep" />
-                    <MiniStat label="MODULES" value={totalModules} />
+                    <LaneStat prefix="fn" label="MODULES" value={totalModules} />
                     <div className="fn-card-header__stat-sep" />
-                    <MiniStat label="PPS" value={fmtPps(totalPps)} accent />
+                    <LaneStat prefix="fn" label="PPS" value={formatPps(totalPps)} accent />
                     <div className="fn-card-header__sparkline">
                         <Sparkline
                             data={sparklineData}
@@ -154,38 +121,16 @@ export const FunctionCardHeader: React.FC<FunctionCardHeaderProps> = ({
                     </div>
                 </div>
 
-                <div className="fn-card-header__actions">
-                    {isDirty && (
-                        <button
-                            className="fn-card-header__icon-btn fn-card-header__icon-btn--discard"
-                            type="button"
-                            title="Discard changes"
-                            aria-label="Discard local changes"
-                            onClick={() => setConfirmDiscard(true)}
-                        >
-                            <DiscardIcon />
-                        </button>
-                    )}
-                    <button
-                        className="fn-card-header__icon-btn fn-card-header__icon-btn--save"
-                        onClick={onOpenDiff}
-                        disabled={!isDirty || hasErrors}
-                        type="button"
-                        title={isDirty ? 'Review & apply' : 'No changes to save'}
-                        aria-label="Review and apply changes"
-                    >
-                        <SaveIcon />
-                    </button>
-                    <button
-                        className="fn-card-header__icon-btn fn-card-header__icon-btn--delete"
-                        onClick={() => setConfirmDelete(true)}
-                        type="button"
-                        title="Delete function"
-                        aria-label="Delete function"
-                    >
-                        <TrashIcon size={18} />
-                    </button>
-                </div>
+                <LaneCardActions
+                    prefix="fn"
+                    isDirty={isDirty}
+                    saveDisabled={!isDirty || hasErrors}
+                    deleteTitle="Delete function"
+                    deleteAriaLabel="Delete function"
+                    onDiscard={() => setConfirmDiscard(true)}
+                    onOpenDiff={onOpenDiff}
+                    onDelete={() => setConfirmDelete(true)}
+                />
             </div>
 
             <ConfirmDialog

--- a/web/src/pages/builtin/pipelines/components/PipelineCardHeader.tsx
+++ b/web/src/pages/builtin/pipelines/components/PipelineCardHeader.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import type { Pipeline } from '../types';
-import { Sparkline } from '../../_shared/lane-editor';
-import { TrashIcon, SaveIcon, DiscardIcon, ChevronDownIcon } from '../../_shared/icons';
+import { Sparkline, formatPps, LaneStat, LaneCardActions, LaneCollapseButton } from '../../_shared/lane-editor';
 import { ConfirmDialog } from '../../../../components';
 
 interface PipelineCardHeaderProps {
@@ -15,31 +14,6 @@ interface PipelineCardHeaderProps {
     onDiscard: () => void;
     onDelete: () => void;
 }
-
-/** Format a pps number with K/M suffix. */
-const fmtPps = (v: number): string => {
-    if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(2)}M`;
-    if (v >= 1_000) return `${(v / 1_000).toFixed(1)}K`;
-    return String(Math.round(v));
-};
-
-interface MiniStatProps {
-    label: string;
-    value: string | number;
-    accent?: boolean;
-}
-
-const MiniStat = ({ label, value, accent }: MiniStatProps): React.JSX.Element => (
-    <div className="pl-card-header__stat">
-        <span
-            className="pl-card-header__stat-value"
-            style={accent ? { color: 'var(--pl-accent)' } : undefined}
-        >
-            {value}
-        </span>
-        <span className="pl-card-header__stat-label">{label}</span>
-    </div>
-);
 
 /**
  * Header row of a pipeline card: pipeline name (read-only), unsaved pill,
@@ -64,19 +38,13 @@ export const PipelineCardHeader: React.FC<PipelineCardHeaderProps> = ({
     return (
         <div className="pl-card-header">
             <div className="pl-card-header__main-row">
-                <button
-                    className="pl-card-header__collapse-btn"
-                    onClick={onToggleCollapse}
-                    type="button"
-                    aria-expanded={!collapsed}
-                    aria-label={collapsed ? 'Expand pipeline' : 'Collapse pipeline'}
-                >
-                    <span
-                        className={`pl-card-header__chevron${collapsed ? '' : ' pl-card-header__chevron--open'}`}
-                    >
-                        <ChevronDownIcon />
-                    </span>
-                </button>
+                <LaneCollapseButton
+                    prefix="pl"
+                    collapsed={collapsed}
+                    onToggle={onToggleCollapse}
+                    expandLabel="Expand pipeline"
+                    collapseLabel="Collapse pipeline"
+                />
 
                 <span className="pl-card-header__pipeline-id">{pipeline.id}</span>
 
@@ -87,9 +55,9 @@ export const PipelineCardHeader: React.FC<PipelineCardHeaderProps> = ({
                 <div className="pl-card-header__spacer" />
 
                 <div className="pl-card-header__stats">
-                    <MiniStat label="FUNCTIONS" value={totalFunctions} />
+                    <LaneStat prefix="pl" label="FUNCTIONS" value={totalFunctions} />
                     <div className="pl-card-header__stat-sep" />
-                    <MiniStat label="PPS" value={fmtPps(totalPps)} accent />
+                    <LaneStat prefix="pl" label="PPS" value={formatPps(totalPps)} accent />
                     <div className="pl-card-header__sparkline">
                         <Sparkline
                             data={sparklineData}
@@ -100,38 +68,16 @@ export const PipelineCardHeader: React.FC<PipelineCardHeaderProps> = ({
                     </div>
                 </div>
 
-                <div className="pl-card-header__actions">
-                    {isDirty && (
-                        <button
-                            className="pl-card-header__icon-btn pl-card-header__icon-btn--discard"
-                            type="button"
-                            title="Discard changes"
-                            aria-label="Discard local changes"
-                            onClick={() => setConfirmDiscard(true)}
-                        >
-                            <DiscardIcon />
-                        </button>
-                    )}
-                    <button
-                        className="pl-card-header__icon-btn pl-card-header__icon-btn--save"
-                        onClick={onOpenDiff}
-                        disabled={!isDirty}
-                        type="button"
-                        title={isDirty ? 'Review & apply' : 'No changes to save'}
-                        aria-label="Review and apply changes"
-                    >
-                        <SaveIcon />
-                    </button>
-                    <button
-                        className="pl-card-header__icon-btn pl-card-header__icon-btn--delete"
-                        onClick={() => setConfirmDelete(true)}
-                        type="button"
-                        title="Delete pipeline"
-                        aria-label="Delete pipeline"
-                    >
-                        <TrashIcon size={18} />
-                    </button>
-                </div>
+                <LaneCardActions
+                    prefix="pl"
+                    isDirty={isDirty}
+                    saveDisabled={!isDirty}
+                    deleteTitle="Delete pipeline"
+                    deleteAriaLabel="Delete pipeline"
+                    onDiscard={() => setConfirmDiscard(true)}
+                    onOpenDiff={onOpenDiff}
+                    onDelete={() => setConfirmDelete(true)}
+                />
             </div>
 
             <ConfirmDialog


### PR DESCRIPTION
`FunctionCardHeader` and `PipelineCardHeader` duplicated several pieces of chrome:

- The `fmtPps` formatter (byte-identical).
- The `MiniStat` value/label cell.
- The collapse-chevron button.
- The discard/save/delete actions cluster.

Extract them into the shared `lane-editor` as `formatPps`, `LaneStat`, `LaneCollapseButton`, and `LaneCardActions`, parameterised by a `fn`/`pl` prefix so the emitted markup and CSS classes are unchanged. Each header keeps its page-specific body (type chips, description, error pill, etc.).

Pure refactor: the functions and pipelines pages render pixel-identically (verified with before/after screenshots).