### PR TITLE
fix(web): restore missing laneFormat.ts in lane-editor

### DIFF
--- a/web/src/pages/builtin/_shared/lane-editor/laneFormat.ts
+++ b/web/src/pages/builtin/_shared/lane-editor/laneFormat.ts
@@ -1,0 +1,10 @@
+/** Format a pps number with a K/M suffix. */
+export const formatPps = (v: number): string => {
+    if (v >= 1_000_000) {
+        return `${(v / 1_000_000).toFixed(2)}M`;
+    }
+    if (v >= 1_000) {
+        return `${(v / 1_000).toFixed(1)}K`;
+    }
+    return String(Math.round(v));
+};


### PR DESCRIPTION
The lane-editor barrel (`index.ts`) re-exports `formatPps` from `./laneFormat`, but `laneFormat.ts` was accidentally omitted from the commit that introduced it (#1029), breaking the module graph for `FunctionCardHeader` and `PipelineCardHeader`.

Restore the standalone formatter (intentionally distinct from `utils` `formatPps`, which appends a ` pps` suffix and uses 1-decimal M).