### PR TITLE
refactor(web): extract shared lane drawer shell

### DIFF
--- a/web/src/pages/builtin/_shared/lane-editor/DrawerAction.tsx
+++ b/web/src/pages/builtin/_shared/lane-editor/DrawerAction.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface DrawerActionProps {
+    prefix: 'fn' | 'pl';
+    icon: React.ReactNode;
+    label: string;
+    danger?: boolean;
+    onClick?: () => void;
+}
+
+/** Shared action button for drawer action sections. */
+export const DrawerAction = ({ prefix, icon, label, danger, onClick }: DrawerActionProps): React.JSX.Element => (
+    <button
+        className={`${prefix}-drawer__action-btn${danger ? ` ${prefix}-drawer__action-btn--danger` : ''}`}
+        type="button"
+        onClick={onClick}
+    >
+        {icon}
+        {label}
+    </button>
+);

--- a/web/src/pages/builtin/_shared/lane-editor/DrawerBigStat.tsx
+++ b/web/src/pages/builtin/_shared/lane-editor/DrawerBigStat.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface DrawerBigStatProps {
+    prefix: 'fn' | 'pl';
+    label: string;
+    value: string;
+    accent?: string;
+}
+
+/** Shared big-stat display for drawer counter sections. */
+export const DrawerBigStat = ({ prefix, label, value, accent }: DrawerBigStatProps): React.JSX.Element => (
+    <div className={`${prefix}-drawer__big-stat`}>
+        <div className={`${prefix}-drawer__big-stat-label`}>{label}</div>
+        <div
+            className={`${prefix}-drawer__big-stat-value`}
+            style={accent ? { color: accent } : undefined}
+        >
+            {value}
+        </div>
+    </div>
+);

--- a/web/src/pages/builtin/_shared/lane-editor/LaneDrawerShell.tsx
+++ b/web/src/pages/builtin/_shared/lane-editor/LaneDrawerShell.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+
+interface LaneDrawerShellProps {
+    prefix: 'fn' | 'pl';
+    ariaLabel: string;
+    onClose: () => void;
+    children: React.ReactNode;
+}
+
+/** Shared slide-in drawer chrome: backdrop, container div, and Escape-key handler. */
+export const LaneDrawerShell = ({ prefix, ariaLabel, onClose, children }: LaneDrawerShellProps): React.JSX.Element => {
+    useEffect(() => {
+        const handleKey = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape') {
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', handleKey);
+        return () => document.removeEventListener('keydown', handleKey);
+    }, [onClose]);
+
+    return (
+        <>
+            <div className={`${prefix}-drawer__backdrop`} onClick={onClose} />
+            <div className={`${prefix}-drawer`} role="dialog" aria-label={ariaLabel}>
+                {children}
+            </div>
+        </>
+    );
+};

--- a/web/src/pages/builtin/_shared/lane-editor/index.ts
+++ b/web/src/pages/builtin/_shared/lane-editor/index.ts
@@ -11,3 +11,6 @@ export { formatPps } from './laneFormat';
 export { LaneStat } from './LaneStat';
 export { LaneCardActions } from './LaneCardActions';
 export { LaneCollapseButton } from './LaneCollapseButton';
+export { LaneDrawerShell } from './LaneDrawerShell';
+export { DrawerBigStat } from './DrawerBigStat';
+export { DrawerAction } from './DrawerAction';

--- a/web/src/pages/builtin/functions/components/Drawer.tsx
+++ b/web/src/pages/builtin/functions/components/Drawer.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback } from 'react';
 import type { Module, Chain } from '../types';
 import { metaFor } from '../moduleMeta';
 import { InlineEdit } from './InlineEdit';
-import { Sparkline, useSparklineHistory } from '../../_shared/lane-editor';
+import { Sparkline, useSparklineHistory, LaneDrawerShell, DrawerBigStat, DrawerAction } from '../../_shared/lane-editor';
 import { CloseIcon, TrashIcon } from '../../_shared/icons';
 import { formatPps, formatBps } from '../../../../utils';
 import { ConfirmDialog } from '../../../../components';
@@ -48,42 +48,6 @@ const DownIcon = (): React.JSX.Element => (
     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
         <path d="M12 5v14M19 12l-7 7-7-7" />
     </svg>
-);
-
-interface DrawerActionProps {
-    icon: React.ReactNode;
-    label: string;
-    danger?: boolean;
-    onClick?: () => void;
-}
-
-const DrawerAction = ({ icon, label, danger, onClick }: DrawerActionProps): React.JSX.Element => (
-    <button
-        className={`fn-drawer__action-btn${danger ? ' fn-drawer__action-btn--danger' : ''}`}
-        type="button"
-        onClick={onClick}
-    >
-        {icon}
-        {label}
-    </button>
-);
-
-interface BigStatProps {
-    label: string;
-    value: string;
-    accent?: string;
-}
-
-const BigStat = ({ label, value, accent }: BigStatProps): React.JSX.Element => (
-    <div className="fn-drawer__big-stat">
-        <div className="fn-drawer__big-stat-label">{label}</div>
-        <div
-            className="fn-drawer__big-stat-value"
-            style={accent ? { color: accent } : undefined}
-        >
-            {value}
-        </div>
-    </div>
 );
 
 /** Module-mode drawer content. */
@@ -144,8 +108,8 @@ const ModuleDrawerContent = ({
             <div className="fn-drawer__section">
                 <div className="fn-drawer__section-label">Live counters</div>
                 <div className="fn-drawer__counters-grid">
-                    <BigStat label="PPS" value={counter ? formatPps(counter.pps) : '—'} accent={accent} />
-                    <BigStat label="BPS" value={counter ? formatBps(counter.bps) : '—'} />
+                    <DrawerBigStat prefix="fn" label="PPS" value={counter ? formatPps(counter.pps) : '—'} accent={accent} />
+                    <DrawerBigStat prefix="fn" label="BPS" value={counter ? formatBps(counter.bps) : '—'} />
                 </div>
                 {sparklineData.length >= 4 && (
                     <div>
@@ -202,6 +166,7 @@ const ModuleDrawerContent = ({
                 <div className="fn-drawer__section-label">Actions</div>
                 <div className="fn-drawer__actions" style={{ padding: 0 }}>
                     <DrawerAction
+                        prefix="fn"
                         icon={<TrashIcon />}
                         label="Remove from chain"
                         danger
@@ -358,6 +323,7 @@ const ChainDrawerContent = ({
                 <div className="fn-drawer__section-label">Actions</div>
                 <div className="fn-drawer__actions" style={{ padding: 0 }}>
                     <DrawerAction
+                        prefix="fn"
                         icon={<TrashIcon />}
                         label="Delete chain"
                         danger
@@ -386,17 +352,6 @@ const ChainDrawerContent = ({
  */
 export const Drawer: React.FC<DrawerProps> = (props) => {
     const [confirmAction, setConfirmAction] = React.useState(false);
-    const drawerRef = useRef<HTMLDivElement>(null);
-
-    useEffect(() => {
-        const handleKey = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape') {
-                props.onClose();
-            }
-        };
-        document.addEventListener('keydown', handleKey);
-        return () => document.removeEventListener('keydown', handleKey);
-    }, [props.onClose]);
 
     const validateName = useCallback((name: string): string | null => {
         if (props.mode !== 'module') {
@@ -409,29 +364,25 @@ export const Drawer: React.FC<DrawerProps> = (props) => {
     }, [props.mode]);
 
     return (
-        <>
-            <div className="fn-drawer__backdrop" onClick={props.onClose} />
-            <div
-                className="fn-drawer"
-                ref={drawerRef}
-                role="dialog"
-                aria-label={props.mode === 'module' ? 'Module inspector' : 'Chain inspector'}
-            >
-                {props.mode === 'module' ? (
-                    <ModuleDrawerContent
-                        props={props}
-                        confirmRemove={confirmAction}
-                        setConfirmRemove={setConfirmAction}
-                        validateName={validateName}
-                    />
-                ) : (
-                    <ChainDrawerContent
-                        props={props}
-                        confirmDelete={confirmAction}
-                        setConfirmDelete={setConfirmAction}
-                    />
-                )}
-            </div>
-        </>
+        <LaneDrawerShell
+            prefix="fn"
+            ariaLabel={props.mode === 'module' ? 'Module inspector' : 'Chain inspector'}
+            onClose={props.onClose}
+        >
+            {props.mode === 'module' ? (
+                <ModuleDrawerContent
+                    props={props}
+                    confirmRemove={confirmAction}
+                    setConfirmRemove={setConfirmAction}
+                    validateName={validateName}
+                />
+            ) : (
+                <ChainDrawerContent
+                    props={props}
+                    confirmDelete={confirmAction}
+                    setConfirmDelete={setConfirmAction}
+                />
+            )}
+        </LaneDrawerShell>
     );
 };

--- a/web/src/pages/builtin/pipelines/components/Drawer.tsx
+++ b/web/src/pages/builtin/pipelines/components/Drawer.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import type { FunctionRef } from '../types';
-import { Sparkline, useSparklineHistory } from '../../_shared/lane-editor';
+import { Sparkline, useSparklineHistory, LaneDrawerShell, DrawerBigStat, DrawerAction } from '../../_shared/lane-editor';
 import { CloseIcon, TrashIcon } from '../../_shared/icons';
 import { formatPps, formatBps } from '../../../../utils';
 import { ConfirmDialog } from '../../../../components';
@@ -28,23 +28,12 @@ export const Drawer: React.FC<DrawerProps> = ({
     onChangeFunction,
     onRemove,
 }) => {
-    const drawerRef = useRef<HTMLDivElement>(null);
     const [confirmRemove, setConfirmRemove] = useState(false);
     const [functionList, setFunctionList] = useState<FunctionId[]>([]);
     const [listLoading, setListLoading] = useState(true);
 
     const sparklineData = useSparklineHistory(ref_.id, counter?.pps ?? 0);
     const accent = 'var(--pl-accent)';
-
-    useEffect(() => {
-        const handleKey = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape') {
-                onClose();
-            }
-        };
-        document.addEventListener('keydown', handleKey);
-        return () => document.removeEventListener('keydown', handleKey);
-    }, [onClose]);
 
     useEffect(() => {
         let cancelled = false;
@@ -64,115 +53,93 @@ export const Drawer: React.FC<DrawerProps> = ({
     }, [onRemove, onClose]);
 
     return (
-        <>
-            <div className="pl-drawer__backdrop" onClick={onClose} />
-            <div
-                className="pl-drawer"
-                ref={drawerRef}
-                role="dialog"
-                aria-label="Function reference inspector"
-            >
-                <div className="pl-drawer__header">
-                    <div className="pl-drawer__title">
-                        <div className="pl-drawer__subtitle">
-                            FUNCTION REFERENCE
-                        </div>
-                        <div className="pl-drawer__name-edit">
-                            {ref_.name || <span style={{ color: 'var(--pl-text-3)' }}>(unset)</span>}
-                        </div>
+        <LaneDrawerShell prefix="pl" ariaLabel="Function reference inspector" onClose={onClose}>
+            <div className="pl-drawer__header">
+                <div className="pl-drawer__title">
+                    <div className="pl-drawer__subtitle">
+                        FUNCTION REFERENCE
                     </div>
-                    <button
-                        className="pl-drawer__close-btn"
-                        onClick={onClose}
-                        type="button"
-                        aria-label="Close drawer"
-                    >
-                        <CloseIcon />
-                    </button>
+                    <div className="pl-drawer__name-edit">
+                        {ref_.name || <span style={{ color: 'var(--pl-text-3)' }}>(unset)</span>}
+                    </div>
                 </div>
+                <button
+                    className="pl-drawer__close-btn"
+                    onClick={onClose}
+                    type="button"
+                    aria-label="Close drawer"
+                >
+                    <CloseIcon />
+                </button>
+            </div>
 
-                <div className="pl-drawer__section">
-                    <div className="pl-drawer__section-label">Live counters</div>
-                    <div className="pl-drawer__counters-grid">
-                        <div className="pl-drawer__big-stat">
-                            <div className="pl-drawer__big-stat-label">PPS</div>
-                            <div
-                                className="pl-drawer__big-stat-value"
-                                style={{ color: accent }}
-                            >
-                                {counter ? formatPps(counter.pps) : '—'}
-                            </div>
-                        </div>
-                        <div className="pl-drawer__big-stat">
-                            <div className="pl-drawer__big-stat-label">BPS</div>
-                            <div className="pl-drawer__big-stat-value">
-                                {counter ? formatBps(counter.bps) : '—'}
-                            </div>
+            <div className="pl-drawer__section">
+                <div className="pl-drawer__section-label">Live counters</div>
+                <div className="pl-drawer__counters-grid">
+                    <DrawerBigStat prefix="pl" label="PPS" value={counter ? formatPps(counter.pps) : '—'} accent={accent} />
+                    <DrawerBigStat prefix="pl" label="BPS" value={counter ? formatBps(counter.bps) : '—'} />
+                </div>
+                {sparklineData.length >= 4 && (
+                    <div>
+                        <div className="pl-drawer__sparkline-label">pps · last {sparklineData.length} samples</div>
+                        <div className="pl-drawer__sparkline">
+                            <Sparkline
+                                data={sparklineData}
+                                width={364}
+                                height={48}
+                                color={accent}
+                            />
                         </div>
                     </div>
-                    {sparklineData.length >= 4 && (
-                        <div>
-                            <div className="pl-drawer__sparkline-label">pps · last {sparklineData.length} samples</div>
-                            <div className="pl-drawer__sparkline">
-                                <Sparkline
-                                    data={sparklineData}
-                                    width={364}
-                                    height={48}
-                                    color={accent}
-                                />
-                            </div>
-                        </div>
+                )}
+            </div>
+
+            <div className="pl-drawer__section">
+                <div className="pl-drawer__section-label">Configuration</div>
+                <div className="pl-drawer__field">
+                    <div className="pl-drawer__field-label">Function</div>
+                    {listLoading ? (
+                        <div className="pl-drawer__loading">Loading functions…</div>
+                    ) : (
+                        <select
+                            className="pl-drawer__type-select"
+                            value={ref_.name}
+                            onChange={e => onChangeFunction(e.target.value)}
+                        >
+                            {!ref_.name && (
+                                <option value="">(unset)</option>
+                            )}
+                            {functionList.map(fn => (
+                                <option key={fn.name} value={fn.name ?? ''}>{fn.name}</option>
+                            ))}
+                        </select>
                     )}
                 </div>
-
-                <div className="pl-drawer__section">
-                    <div className="pl-drawer__section-label">Configuration</div>
-                    <div className="pl-drawer__field">
-                        <div className="pl-drawer__field-label">Function</div>
-                        {listLoading ? (
-                            <div className="pl-drawer__loading">Loading functions…</div>
-                        ) : (
-                            <select
-                                className="pl-drawer__type-select"
-                                value={ref_.name}
-                                onChange={e => onChangeFunction(e.target.value)}
-                            >
-                                {!ref_.name && (
-                                    <option value="">(unset)</option>
-                                )}
-                                {functionList.map(fn => (
-                                    <option key={fn.name} value={fn.name ?? ''}>{fn.name}</option>
-                                ))}
-                            </select>
-                        )}
-                    </div>
-                </div>
-
-                <div className="pl-drawer__section">
-                    <div className="pl-drawer__section-label">Actions</div>
-                    <div className="pl-drawer__actions" style={{ padding: 0 }}>
-                        <button
-                            className="pl-drawer__action-btn pl-drawer__action-btn--danger"
-                            type="button"
-                            onClick={() => setConfirmRemove(true)}
-                        >
-                            <TrashIcon />
-                            Remove from pipeline
-                        </button>
-                    </div>
-                </div>
-
-                <ConfirmDialog
-                    open={confirmRemove}
-                    onClose={() => setConfirmRemove(false)}
-                    onConfirm={() => { setConfirmRemove(false); handleRemove(); }}
-                    title="Remove function reference"
-                    message={`Remove "${ref_.name || '(unset)'}" from the pipeline? This cannot be undone.`}
-                    confirmText="Remove"
-                    cancelText="Cancel"
-                    danger
-                />
             </div>
-        </>
+
+            <div className="pl-drawer__section">
+                <div className="pl-drawer__section-label">Actions</div>
+                <div className="pl-drawer__actions" style={{ padding: 0 }}>
+                    <DrawerAction
+                        prefix="pl"
+                        icon={<TrashIcon />}
+                        label="Remove from pipeline"
+                        danger
+                        onClick={() => setConfirmRemove(true)}
+                    />
+                </div>
+            </div>
+
+            <ConfirmDialog
+                open={confirmRemove}
+                onClose={() => setConfirmRemove(false)}
+                onConfirm={() => { setConfirmRemove(false); handleRemove(); }}
+                title="Remove function reference"
+                message={`Remove "${ref_.name || '(unset)'}" from the pipeline? This cannot be undone.`}
+                confirmText="Remove"
+                cancelText="Cancel"
+                danger
+            />
+        </LaneDrawerShell>
     );
 };


### PR DESCRIPTION
`FunctionDrawer` and `PipelineDrawer` duplicated the slide-in drawer chrome:

- The backdrop + container + `role="dialog"` wrapper and the Escape-to-close effect → `LaneDrawerShell`.
- The PPS/BPS big-stat cell → `DrawerBigStat`.
- The danger action button → `DrawerAction`.

All three live in the shared `lane-editor` and are parameterised by an `fn`/`pl` prefix so the emitted markup and CSS classes are unchanged. Each drawer keeps its page-specific body (module/chain modes, function picker, etc.).

Pure refactor: the open module drawer and function-reference drawer render pixel-identically (verified with before/after screenshots, identical md5).