### PR TITLE
refactor(web): tidy page header, tab strip, and forward header

### DIFF
--- a/web/src/MainMenu.scss
+++ b/web/src/MainMenu.scss
@@ -1,3 +1,9 @@
+// Overrides Gravity navigation divider offset to nudge the aside header bottom
+// divider up by 1px.
+.gn-aside-header .gn-aside-header__header::after {
+    bottom: 13px;
+}
+
 .main-menu__section-label {
     display: block;
     padding: 4px 12px;

--- a/web/src/components/ConfigTabStrip.scss
+++ b/web/src/components/ConfigTabStrip.scss
@@ -1,10 +1,16 @@
+// Tab strip vertical padding.
+//
+// The active-tab underline `bottom` is derived as its negative so the
+// underline sits on the strip's bottom border.
+$yn-tabs-pad-y: 4px;
+
 .yn-tabs {
     display: flex;
     align-items: center;
     gap: 4px;
-    padding: 8px 20px 0;
+    padding: $yn-tabs-pad-y 20px;
     border-bottom: 1px solid var(--yn-line-2);
-    background: var(--yn-page-bg);
+    background: #15110D;
     overflow-x: auto;
     flex-shrink: 0;
 }
@@ -32,9 +38,9 @@
         &::after {
             content: "";
             position: absolute;
-            left: 14px;
-            right: 14px;
-            bottom: -1px;
+            left: 0px;
+            right: 0px;
+            bottom: -$yn-tabs-pad-y;
             height: 3px;
             background: var(--yn-accent);
             border-radius: 2px 2px 0 0;

--- a/web/src/components/common.scss
+++ b/web/src/components/common.scss
@@ -43,7 +43,10 @@
 
 .page-layout__header {
     width: 100%;
-    min-height: 56px;
+    height: var(--yn-page-header-height);
+    min-height: var(--yn-page-header-height);
+    padding-top: 0;
+    padding-bottom: 0;
     display: flex;
     align-items: center;
 }

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
-import { Funnel, Magnifier, Pause, Play, Plus } from '@gravity-ui/icons';
+import { Funnel, Magnifier, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
@@ -44,7 +44,6 @@ const ForwardPage: React.FC = () => {
     } = useForwardDraft();
     const [searchParams, setSearchParams] = useSearchParams();
 
-    const [paused, setPaused] = useState(false);
     const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
     const [activeRowId, setActiveRowId] = useState<string | null>(null);
     const [drawer, setDrawer] = useState<{ open: boolean; mode: 'add' | 'edit'; item: RuleItem | null }>({
@@ -110,7 +109,7 @@ const ForwardPage: React.FC = () => {
     const rawRules: Rule[] = draftRules(currentConfig);
     const allItems = useMemo(() => rulesToNgItems(rawRules), [rawRules]);
 
-    const { rates } = useForwardRuleCounters(currentConfig, allItems, !paused);
+    const { rates } = useForwardRuleCounters(currentConfig, allItems, true);
 
     const ruleCounts = useMemo((): Map<string, number> => {
         const m = new Map<string, number>();
@@ -349,13 +348,6 @@ const ForwardPage: React.FC = () => {
             });
         }
         list.push({
-            id: '__pause',
-            icon: paused ? '▶' : '⏸',
-            label: paused ? 'Resume counters' : 'Pause counters',
-            keywords: 'pause resume counters pps',
-            onSelect: () => { setPaused((p) => !p); setPaletteOpen(false); },
-        });
-        list.push({
             id: '__filter_in',
             icon: '→',
             label: 'Filter: IN only',
@@ -384,7 +376,7 @@ const ForwardPage: React.FC = () => {
             onSelect: () => { setModeFilter('all'); handleSearchChange(''); setPaletteOpen(false); },
         });
         return list;
-    }, [currentIsDirty, currentConfig, paused, draftConfigs, dirtySet, handleTabSelect, openAdd, handleSavePress, handleDiscard, handleSearchChange]);
+    }, [currentIsDirty, currentConfig, draftConfigs, dirtySet, handleTabSelect, openAdd, handleSavePress, handleDiscard, handleSearchChange]);
 
     const rowAdapter: RowAdapter<RuleItem> = {
         rows: allItems,
@@ -422,15 +414,6 @@ const ForwardPage: React.FC = () => {
                     onImport={handleImportYaml}
                 />
             )}
-            <Button
-                view="flat"
-                size="m"
-                onClick={() => setPaused(p => !p)}
-                title={paused ? 'Resume counters' : 'Pause counters'}
-            >
-                <Icon data={paused ? Play : Pause} size={16} />
-                {paused ? 'Resume counters' : 'Pause counters'}
-            </Button>
             <Button view="action" onClick={openAdd}>
                 <Icon data={Plus} size={16} />
                 Add Rule

--- a/web/src/pages/operators/route/route.scss
+++ b/web/src/pages/operators/route/route.scss
@@ -299,20 +299,8 @@ $_ro-col-med:      42px;
     --ro-surface-bg: #1C1814;
 }
 
-// Header sits outside .yn-page so --yn-* tokens are not in scope there.
-// --ro-surface-bg is defined on .ro-layout and cascades to both subtrees.
-.ro-layout .page-layout__header {
-    background: var(--ro-surface-bg);
-}
-
-// Two-class specificity beats the `.yn-page { background: var(--yn-page-bg) }` rule.
 .yn-page.ro-page {
     background: var(--ro-surface-bg);
-}
-
-.ro-page .yn-tabs {
-    background: var(--ro-surface-bg);
-    border-bottom: none;
 }
 
 // Table flush: no outer padding and no card chrome.

--- a/web/src/styles/draft/_neighbours.scss
+++ b/web/src/styles/draft/_neighbours.scss
@@ -399,10 +399,6 @@
     border-bottom: none;
 }
 
-.nb-page .yn-tabs-row .yn-tabs {
-    border-bottom: none;
-}
-
 .nb-page .yn-content {
     padding: 0;
 }
@@ -414,13 +410,6 @@
     --nb-surface-bg: #1C1814;
 }
 
-// Header sits outside .yn-page so --yn-* tokens are not in scope there.
-// Match route page: same background (#1C1814) and same rendered height (64px).
-.nb-layout .page-layout__header {
-    background: var(--nb-surface-bg);
-    min-height: 64px;
-}
-
 // Two-class specificity beats `.yn-page { background: var(--yn-page-bg) }`.
 .yn-page.nb-page {
     background: var(--nb-surface-bg);
@@ -428,10 +417,6 @@
 
 // Tab strip and tabs-row sit on the same flat surface.
 .nb-page .yn-tabs-row {
-    background: var(--nb-surface-bg);
-}
-
-.nb-page .yn-tabs {
     background: var(--nb-surface-bg);
 }
 

--- a/web/src/styles/draft/_surface.scss
+++ b/web/src/styles/draft/_surface.scss
@@ -73,18 +73,8 @@
     --yn-surface-bg: #1C1814;
 }
 
-.yn-flat-layout .page-layout__header {
-    background: var(--yn-surface-bg);
-    min-height: 64px;
-}
-
 .yn-page.yn-flat-page {
     background: var(--yn-surface-bg);
-}
-
-.yn-flat-page .yn-tabs {
-    background: var(--yn-surface-bg);
-    border-bottom: none;
 }
 
 .yn-flat-page .yn-content {

--- a/web/src/styles/tokens.scss
+++ b/web/src/styles/tokens.scss
@@ -24,6 +24,8 @@
     --yn-r-lg:          10px;
     --yn-font-mono:     'JetBrains Mono', ui-monospace, monospace;
 
+    --yn-page-header-height: 56px;
+
     // Direction badge colors — recomputed against new warm accent.
     --yn-dir-in:        var(--g-color-text-positive);
     --yn-dir-in-bg:     rgba(110, 198, 140, 0.12);


### PR DESCRIPTION
- Tie the page header height to a new \`--yn-page-header-height\` token so its trailing divider aligns with the Gravity aside header divider, and override the aside header divider offset to match.
- Give the tab strip its own surface color and derive the active-tab underline offset from the strip's vertical padding via a single variable.
- Drop the now-redundant per-page header and tab-strip background overrides on the route, neighbours, and flat surfaces.
- Remove the Forward "Pause counters" control; counters now always update.