### PR TITLE
fix: stabilize YAML control in module page headers

### DIFF
--- a/web/src/components/YamlIOModal.tsx
+++ b/web/src/components/YamlIOModal.tsx
@@ -60,6 +60,8 @@ export interface YamlIOModalProps {
      * If not provided alongside supportJson, the toggle is hidden and export falls back to YAML.
      */
     exportJson?: () => string;
+    /** When true, the Import and Export trigger buttons are disabled. Default: false. */
+    disabled?: boolean;
 }
 
 /**
@@ -84,6 +86,7 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
     importButtonLabel = 'Import',
     importExtraControls,
     supportJson = false,
+    disabled = false,
 }) => {
     const [showModal, setShowModal] = useState<YamlIOMode>(null);
     // textContent holds the actual text string; textarea only shows it when small.
@@ -337,11 +340,11 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
 
     return (
         <>
-            <Button view="outlined" onClick={() => setShowModal('import')}>
+            <Button view="outlined" onClick={() => setShowModal('import')} disabled={disabled}>
                 <Icon data={ArrowDownToLine} size={14} />
                 {importLabel}
             </Button>
-            <Button view="outlined" onClick={() => setShowModal('export')}>
+            <Button view="outlined" onClick={() => setShowModal('export')} disabled={disabled}>
                 <Icon data={ArrowUpFromLine} size={14} />
                 {exportLabel}
             </Button>

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -341,14 +341,7 @@ const AclPage: React.FC = () => {
                     {paused ? 'Resume' : 'Pause'}
                 </Button>
             )}
-            {currentConfig && (
-                <YamlIO
-                    key={currentConfig}
-                    configName={currentConfig}
-                    rules={rawRules}
-                    onImport={handleImportYaml}
-                />
-            )}
+            <YamlIO key={currentConfig || '__none'} configName={currentConfig} rules={rawRules} onImport={handleImportYaml} disabled={!currentConfig} />
             <Button view="action" onClick={openAdd}>
                 <Icon data={Plus} size={16} />
                 Add Rule

--- a/web/src/pages/modules/acl/YamlIO.tsx
+++ b/web/src/pages/modules/acl/YamlIO.tsx
@@ -54,13 +54,14 @@ interface YamlIOProps {
     configName: string;
     rules: Rule[];
     onImport: (configName: string, rules: Rule[], mode: ImportMode) => void;
+    disabled?: boolean;
 }
 
 const rulesToInAclJson = (configName: string, rules: Rule[]): string =>
     JSON.stringify({ name: configName, rules: rulesToYamlObjects(rules) }, null, 2) + '\n';
 
 /** YAML/JSON import/export controls for the ACL NG page header. */
-const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport }) => {
+const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport, disabled }) => {
     const [mode, setMode] = useState<ImportMode>('replace');
 
     useEffect(() => {
@@ -106,6 +107,7 @@ const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport }) => {
             exportJson={() => rulesToInAclJson(configName, rules)}
             onImportAsync={handleImportAsync}
             toastPrefix="acl-yaml"
+            disabled={disabled}
             importPlaceholder={
                 'rules:\n' +
                 '  - srcs:\n' +

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -162,9 +162,7 @@ const DecapPage: React.FC = () => {
                     updateParams({ [QP_SEARCH]: value || null });
                 }}
                 searchPlaceholder="Search prefix…"
-                yamlSlot={currentConfig ? (
-                <PrefixYamlIO key={currentConfig} configName={currentConfig} rows={rawRows} onImport={handlers.handleImportYaml} />
-            ) : undefined}
+                yamlSlot={<PrefixYamlIO key={currentConfig || '__none'} configName={currentConfig} rows={rawRows} onImport={handlers.handleImportYaml} disabled={!currentConfig} />}
             addLabel="Add Prefix"
             onAdd={openAdd}
         />

--- a/web/src/pages/modules/decap/PrefixYamlIO.tsx
+++ b/web/src/pages/modules/decap/PrefixYamlIO.tsx
@@ -8,10 +8,11 @@ interface PrefixYamlIOProps {
     configName: string;
     rows: PrefixRowItem[];
     onImport: (rows: PrefixRowItem[], mode: 'replace' | 'append') => void;
+    disabled?: boolean;
 }
 
 /** YAML import/export controls for the decap page header. */
-const PrefixYamlIO: React.FC<PrefixYamlIOProps> = ({ configName, rows, onImport }) => {
+const PrefixYamlIO: React.FC<PrefixYamlIOProps> = ({ configName, rows, onImport, disabled }) => {
     const [importMode, setImportMode] = useState<'replace' | 'append'>('replace');
 
     const handleImport = (text: string): void => {
@@ -55,6 +56,7 @@ const PrefixYamlIO: React.FC<PrefixYamlIOProps> = ({ configName, rows, onImport 
             importFooterHint="Loads into current config as draft. Use Commit to push to server."
             importButtonLabel="Load as draft"
             importExtraControls={importExtraControls}
+            disabled={disabled}
         />
     );
 };

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -406,14 +406,13 @@ const ForwardPage: React.FC = () => {
                 <span className="cp-trigger__placeholder">Search rules or run an action…</span>
                 <kbd className="cp-kbd">⌘K</kbd>
             </button>
-            {currentConfig && (
-                <YamlIO
-                    key={currentConfig}
-                    configName={currentConfig}
-                    rules={rawRules}
-                    onImport={handleImportYaml}
-                />
-            )}
+            <YamlIO
+                key={currentConfig || '__none'}
+                configName={currentConfig}
+                rules={rawRules}
+                onImport={handleImportYaml}
+                disabled={!currentConfig}
+            />
             <Button view="action" onClick={openAdd}>
                 <Icon data={Plus} size={16} />
                 Add Rule

--- a/web/src/pages/modules/forward/YamlIO.tsx
+++ b/web/src/pages/modules/forward/YamlIO.tsx
@@ -103,10 +103,12 @@ interface YamlIOProps {
     rules: Rule[];
     /** Called when user imports rules into a config. Receives the target config name and parsed rules. */
     onImport: (configName: string, rules: Rule[]) => void;
+    /** When true, the Import and Export trigger buttons are disabled. Default: false. */
+    disabled?: boolean;
 }
 
 /** YAML import/export controls rendered inline in the page header. */
-const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport }) => {
+const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport, disabled }) => {
     const [importConfigName, setImportConfigName] = useState(configName);
 
     const handleImport = (text: string): void => {
@@ -148,6 +150,7 @@ const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport }) => {
             importFooterHint="Importing replaces all rules in the target config locally. Use Save to push to the server."
             importButtonLabel="Import"
             importExtraControls={importExtraControls}
+            disabled={disabled}
         />
     );
 };

--- a/web/src/pages/modules/route/FIBYamlIO.tsx
+++ b/web/src/pages/modules/route/FIBYamlIO.tsx
@@ -8,10 +8,11 @@ interface FIBYamlIOProps {
     configName: string;
     rows: FIBRowItem[];
     onImport: (rows: FIBRowItem[], mode: 'replace' | 'append') => void;
+    disabled?: boolean;
 }
 
 /** YAML import/export controls for the FIB page header. */
-const FIBYamlIO: React.FC<FIBYamlIOProps> = ({ configName, rows, onImport }) => {
+const FIBYamlIO: React.FC<FIBYamlIOProps> = ({ configName, rows, onImport, disabled }) => {
     const [importMode, setImportMode] = useState<'replace' | 'append'>('replace');
 
     const handleImport = (text: string): void => {
@@ -55,6 +56,7 @@ const FIBYamlIO: React.FC<FIBYamlIOProps> = ({ configName, rows, onImport }) => 
             importFooterHint="Loads into current config as draft. Use Commit to push to server."
             importButtonLabel="Load as draft"
             importExtraControls={importExtraControls}
+            disabled={disabled}
         />
     );
 };

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -175,9 +175,7 @@ const RoutePage: React.FC = () => {
                 searchValue={search}
                 onSearchChange={handleSearchChange}
                 searchPlaceholder="Search prefix, MAC or device…"
-                yamlSlot={currentConfig ? (
-                    <FIBYamlIO key={currentConfig} configName={currentConfig} rows={rawRows} onImport={handlers.handleImportYaml} />
-                ) : undefined}
+                yamlSlot={<FIBYamlIO key={currentConfig || '__none'} configName={currentConfig} rows={rawRows} onImport={handlers.handleImportYaml} disabled={!currentConfig} />}
             addLabel="Add Route"
             onAdd={openAdd}
         />


### PR DESCRIPTION
The forward, route, decap and acl module pages each render a YAML import/export control in the page header. Because each page reloads its draft state on every mount and the active configuration is only known after the first fetch resolves, the control was absent for the first frames and then popped into the header, causing a visible flicker when switching pages.

The control is now rendered unconditionally and disabled while no configuration is active, keeping the header layout stable across the loading transition.