### PR TITLE
fix(web): make devices page fill full height

### DIFF
--- a/web/src/pages/builtin/devices/devices.scss
+++ b/web/src/pages/builtin/devices/devices.scss
@@ -37,7 +37,8 @@
 
     display: flex;
     flex-direction: column;
-    height: 100%;
+    flex: 1;
+    min-height: 0;
     width: 100%;
     background: var(--bg);
     color: var(--fg);


### PR DESCRIPTION
The devices page root filled vertically via a percentage height (`height: 100%`), which only resolves when every ancestor in the chain has a definite height. The page shell mixes flex-grow sizing with `min-height`, so the percentage stopped resolving and the page collapsed to content height instead of filling the area below the header.

Switch the page root to the canonical flex-fill pattern used by every other page (`flex: 1; min-height: 0;`), so it grows into its flex-column slot regardless of ancestor height definiteness.