### PR TITLE
refactor: center command palette in page headers

### DIFF
--- a/web/src/components/common.scss
+++ b/web/src/components/common.scss
@@ -33,6 +33,29 @@
     flex: initial;
 }
 
+/* Page header 3-column grid: title | search pill (centered) | actions */
+.page-header-bar {
+    --cp-max: 520px;
+    --hdr-gap: 16px;
+    display: grid;
+    grid-template-columns:
+        minmax(min-content, calc(50% - var(--cp-max) / 2 - var(--gn-aside-header-size, 56px) / 2 - var(--hdr-gap)))
+        minmax(0, var(--cp-max))
+        minmax(min-content, 1fr);
+    align-items: center;
+    gap: var(--hdr-gap);
+    width: 100%;
+    min-width: 0;
+}
+
+.page-header-bar__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--hdr-gap);
+    justify-content: flex-end;
+    min-width: 0;
+}
+
 /* PageLayout */
 .page-layout {
     flex: 1;

--- a/web/src/pages/_shared/command-palette/command-palette.scss
+++ b/web/src/pages/_shared/command-palette/command-palette.scss
@@ -10,10 +10,9 @@
     display: inline-flex;
     align-items: center;
     gap: 10px;
-    flex: 1;
+    width: 100%;
     max-width: 520px;
     min-width: 0;
-    margin: 0 auto;
     height: 40px;
     padding: 0 14px;
     border-radius: var(--yn-r-md, 6px);

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { Funnel, Magnifier, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
@@ -394,7 +394,7 @@ const ForwardPage: React.FC = () => {
     };
 
     const pageHeader = (
-        <Flex alignItems="center" gap={4} style={{ width: '100%' }}>
+        <div className="page-header-bar">
             <Text variant="header-1">Forward</Text>
             <button
                 type="button"
@@ -406,18 +406,20 @@ const ForwardPage: React.FC = () => {
                 <span className="cp-trigger__placeholder">Search rules or run an action…</span>
                 <kbd className="cp-kbd">⌘K</kbd>
             </button>
-            <YamlIO
-                key={currentConfig || '__none'}
-                configName={currentConfig}
-                rules={rawRules}
-                onImport={handleImportYaml}
-                disabled={!currentConfig}
-            />
-            <Button view="action" onClick={openAdd}>
-                <Icon data={Plus} size={16} />
-                Add Rule
-            </Button>
-        </Flex>
+            <div className="page-header-bar__actions">
+                <YamlIO
+                    key={currentConfig || '__none'}
+                    configName={currentConfig}
+                    rules={rawRules}
+                    onImport={handleImportYaml}
+                    disabled={!currentConfig}
+                />
+                <Button view="action" onClick={openAdd}>
+                    <Icon data={Plus} size={16} />
+                    Add Rule
+                </Button>
+            </div>
+        </div>
     );
 
     if (loading) {

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { Plus, Layers, Magnifier } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
 import { BulkDeleteModal, DeleteConfigModal } from '../../../components';
@@ -515,7 +515,7 @@ const NeighboursPage: React.FC = () => {
     const searchActive = family !== 'all' || !!stateFilter;
 
     const pageHeader = (
-        <Flex alignItems="center" gap={4} style={{ width: '100%' }}>
+        <div className="page-header-bar">
             <Text variant="header-1">Neighbours</Text>
             <button
                 type="button"
@@ -527,15 +527,17 @@ const NeighboursPage: React.FC = () => {
                 <span className="cp-trigger__placeholder">Search neighbours or type an IP…</span>
                 <kbd className="cp-kbd">⌘K</kbd>
             </button>
-            <Button view="outlined" onClick={() => setCreateTableOpen(true)}>
-                <Icon data={Plus} size={16} />
-                Add Table
-            </Button>
-            <Button view="action" onClick={openAdd} disabled={tables.length === 0}>
-                <Icon data={Plus} size={16} />
-                Add Neighbour
-            </Button>
-        </Flex>
+            <div className="page-header-bar__actions">
+                <Button view="outlined" onClick={() => setCreateTableOpen(true)}>
+                    <Icon data={Plus} size={16} />
+                    Add Table
+                </Button>
+                <Button view="action" onClick={openAdd} disabled={tables.length === 0}>
+                    <Icon data={Plus} size={16} />
+                    Add Neighbour
+                </Button>
+            </div>
+        </div>
     );
 
     if (loading) {

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { ArrowRightToLine, Funnel, Magnifier, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { AddConfigModal } from '../../_shared/draft';
@@ -383,7 +383,7 @@ const RoutePage: React.FC = () => {
     };
 
     const pageHeader = (
-        <Flex alignItems="center" gap={4} style={{ width: '100%' }}>
+        <div className="page-header-bar">
             <Text variant="header-1">Routing Table</Text>
             <button
                 type="button"
@@ -395,15 +395,17 @@ const RoutePage: React.FC = () => {
                 <span className="cp-trigger__placeholder">Search or look up an IP…</span>
                 <kbd className="cp-kbd">⌘K</kbd>
             </button>
-            <Button view="outlined" onClick={handleFlush} disabled={!currentConfig}>
-                <Icon data={ArrowRightToLine} size={16} />
-                Flush RIB → FIB
-            </Button>
-            <Button view="action" onClick={openAdd} disabled={configs.length === 0}>
-                <Icon data={Plus} size={16} />
-                Add Route
-            </Button>
-        </Flex>
+            <div className="page-header-bar__actions">
+                <Button view="outlined" onClick={handleFlush} disabled={!currentConfig}>
+                    <Icon data={ArrowRightToLine} size={16} />
+                    Flush RIB → FIB
+                </Button>
+                <Button view="action" onClick={openAdd} disabled={configs.length === 0}>
+                    <Icon data={Plus} size={16} />
+                    Add Route
+                </Button>
+            </div>
+        </div>
     );
 
     if (loading && configs.length === 0) {


### PR DESCRIPTION
Center the command palette trigger and its popup on the screen center, compensating for the side menu, so both sit on the same vertical axis. The trigger now lives in a three-column header grid that keeps the title and action controls from crowding or overlapping it, and the alignment tracks the side menu collapsing or expanding automatically.