### PR TITLE
refactor(web): share CIDR and device-name validators

### DIFF
--- a/web/src/pages/modules/acl/RuleDrawer.tsx
+++ b/web/src/pages/modules/acl/RuleDrawer.tsx
@@ -3,7 +3,8 @@ import { ActionKind, ACTION_KIND_LABELS } from '../../../api/acl';
 import { TrashIcon } from '../../_shared/draft/DraftActionButtons';
 import type { RuleDraft, RuleItem } from './types';
 import { emptyDraft } from './types';
-import { itemToDraft, isValidCidr, isValidDeviceName, defaultCounterName, draftToRule, expandRule, deadReasonText } from './hooks';
+import { itemToDraft, defaultCounterName, draftToRule, expandRule, deadReasonText } from './hooks';
+import { isValidCidr, isValidDeviceName } from '../../../utils';
 import ChipInput from './ChipInput';
 import type { ChipInputHandle } from './ChipInput';
 

--- a/web/src/pages/modules/acl/hooks.ts
+++ b/web/src/pages/modules/acl/hooks.ts
@@ -253,28 +253,6 @@ export const ruleToDraft = (rule: Rule): RuleDraft => {
     };
 };
 
-/** Validate CIDR string (IPv4 or IPv6). Returns true if valid. */
-export const isValidCidr = (s: string): boolean => {
-    const trimmed = s.trim();
-    if (!trimmed) return false;
-    const ipv4 = trimmed.match(/^(\d{1,3}(?:\.\d{1,3}){3})(?:\/(\d{1,2}))?$/);
-    if (ipv4) {
-        const parts = ipv4[1].split('.').map(Number);
-        if (parts.some(n => n > 255)) return false;
-        if (ipv4[2] !== undefined && (Number(ipv4[2]) < 0 || Number(ipv4[2]) > 32)) return false;
-        return true;
-    }
-    const ipv6 = trimmed.match(/^([0-9a-fA-F:]+)(?:\/(\d{1,3}))?$/);
-    if (ipv6 && trimmed.includes(':')) {
-        if (ipv6[2] !== undefined && (Number(ipv6[2]) < 0 || Number(ipv6[2]) > 128)) return false;
-        return true;
-    }
-    return false;
-};
-
-/** Validate device name string. */
-export const isValidDeviceName = (s: string): boolean => /^[a-zA-Z0-9_:.\-]+$/.test(s.trim());
-
 /** Keyboard shortcuts for the ACL page. */
 export const useKeyboardShortcuts = (opts: {
     onNewRule: () => void;

--- a/web/src/pages/modules/forward/RuleDrawer.tsx
+++ b/web/src/pages/modules/forward/RuleDrawer.tsx
@@ -3,7 +3,8 @@ import { ForwardMode } from '../../../api/forward';
 import { MODE_LABELS } from './types';
 import type { RuleDraft, RuleItem } from './types';
 import { emptyDraft } from './types';
-import { itemToDraft, isValidCidr, isValidDeviceName } from './hooks';
+import { itemToDraft } from './hooks';
+import { isValidCidr, isValidDeviceName } from '../../../utils';
 import ChipInput from './ChipInput';
 import type { ChipInputHandle } from './ChipInput';
 

--- a/web/src/pages/modules/forward/hooks.ts
+++ b/web/src/pages/modules/forward/hooks.ts
@@ -148,28 +148,6 @@ export const useKeyboardShortcuts = (opts: {
     }, [onNewRule, onEscape, drawerOpen]);
 };
 
-/** Validate CIDR string (IPv4 or IPv6). Returns true if valid. */
-export const isValidCidr = (s: string): boolean => {
-    const trimmed = s.trim();
-    if (!trimmed) return false;
-    const ipv4 = trimmed.match(/^(\d{1,3}(?:\.\d{1,3}){3})(?:\/(\d{1,2}))?$/);
-    if (ipv4) {
-        const parts = ipv4[1].split('.').map(Number);
-        if (parts.some((n) => n > 255)) return false;
-        if (ipv4[2] !== undefined && (Number(ipv4[2]) < 0 || Number(ipv4[2]) > 32)) return false;
-        return true;
-    }
-    const ipv6 = trimmed.match(/^([0-9a-fA-F:]+)(?:\/(\d{1,3}))?$/);
-    if (ipv6 && trimmed.includes(':')) {
-        if (ipv6[2] !== undefined && (Number(ipv6[2]) < 0 || Number(ipv6[2]) > 128)) return false;
-        return true;
-    }
-    return false;
-};
-
-/** Validate device name string. */
-export const isValidDeviceName = (s: string): boolean => /^[a-zA-Z0-9_:.\-]+$/.test(s.trim());
-
 /** Validate VLAN token (single value or range, 0-4095). */
 export const isValidVlanToken = (s: string): boolean => {
     const trimmed = s.trim();

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -9,3 +9,4 @@ export * from './sorting';
 export * from './packetParser';
 export * from './clipboard';
 export * from './counterGroups';
+export * from './validation';

--- a/web/src/utils/validation.ts
+++ b/web/src/utils/validation.ts
@@ -1,0 +1,21 @@
+/** Validate CIDR string (IPv4 or IPv6). Returns true if valid. */
+export const isValidCidr = (s: string): boolean => {
+    const trimmed = s.trim();
+    if (!trimmed) return false;
+    const ipv4 = trimmed.match(/^(\d{1,3}(?:\.\d{1,3}){3})(?:\/(\d{1,2}))?$/);
+    if (ipv4) {
+        const parts = ipv4[1].split('.').map(Number);
+        if (parts.some((n) => n > 255)) return false;
+        if (ipv4[2] !== undefined && (Number(ipv4[2]) < 0 || Number(ipv4[2]) > 32)) return false;
+        return true;
+    }
+    const ipv6 = trimmed.match(/^([0-9a-fA-F:]+)(?:\/(\d{1,3}))?$/);
+    if (ipv6 && trimmed.includes(':')) {
+        if (ipv6[2] !== undefined && (Number(ipv6[2]) < 0 || Number(ipv6[2]) > 128)) return false;
+        return true;
+    }
+    return false;
+};
+
+/** Validate device name string. */
+export const isValidDeviceName = (s: string): boolean => /^[a-zA-Z0-9_:.\-]+$/.test(s.trim());


### PR DESCRIPTION
Extracts the duplicated `isValidCidr` and `isValidDeviceName` validators from the ACL and Forward module hooks into a shared `utils/validation` module. The implementations were byte-identical apart from arrow-parameter style; behaviour is unchanged.

Part of an ongoing effort to decompose duplicated web code into shared modules.