### PR TITLE
refactor(web): share counter-history sampling constants

### DIFF
--- a/web/src/hooks/useCounterHistory.ts
+++ b/web/src/hooks/useCounterHistory.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { DeviceCounterData } from './useDeviceCounters';
 
-const HISTORY_SIZE = 60;
+export const HISTORY_SIZE = 60;
 
 export interface CounterHistoryEntry {
     rx: number[];
@@ -11,7 +11,7 @@ export interface CounterHistoryEntry {
 }
 
 /** Returns a new array with v appended, capped at cap elements. */
-const appendCapped = (arr: number[], v: number, cap: number): number[] =>
+export const appendCapped = (arr: number[], v: number, cap: number): number[] =>
     arr.length < cap ? [...arr, v] : [...arr.slice(1), v];
 
 /**

--- a/web/src/pages/modules/acl/useAclRuleCounters.ts
+++ b/web/src/pages/modules/acl/useAclRuleCounters.ts
@@ -1,14 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { API } from '../../../api';
 import { useInterpolatedCounters } from '../../../hooks';
+import { appendCapped, HISTORY_SIZE } from '../../../hooks/useCounterHistory';
 import type { RuleItem } from './types';
 import { effectiveCounterName } from './hooks';
 import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../utils';
-
-const HISTORY_SIZE = 60;
-
-const appendCapped = (arr: number[], v: number, cap: number): number[] =>
-    arr.length < cap ? [...arr, v] : [...arr.slice(1), v];
 
 /** Per-rule rate data: rolling history for the sparkline and the latest interpolated pps. */
 export interface RuleRate {

--- a/web/src/pages/modules/forward/useForwardRuleCounters.ts
+++ b/web/src/pages/modules/forward/useForwardRuleCounters.ts
@@ -1,14 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { API } from '../../../api';
 import { useInterpolatedCounters } from '../../../hooks';
+import { appendCapped, HISTORY_SIZE } from '../../../hooks/useCounterHistory';
 import type { RuleItem } from './types';
 import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../utils';
-
-const HISTORY_SIZE = 60;
-
-/** Returns a new array with v appended, capped at cap elements. */
-const appendCapped = (arr: number[], v: number, cap: number): number[] =>
-    arr.length < cap ? [...arr, v] : [...arr.slice(1), v];
 
 /** Per-rule rate data: rolling history for the sparkline and the latest interpolated pps. */
 export interface RuleRate {


### PR DESCRIPTION
Removes the triplicated rolling-history window size and append helper by exporting them once from the counter-history hook and importing them in the ACL and Forward rule-counter hooks. No behaviour change.