### PR TITLE
refactor(web): share command palette trigger with platform-correct shortcut

### DIFF
--- a/web/src/pages/_shared/command-palette/CommandPaletteTrigger.tsx
+++ b/web/src/pages/_shared/command-palette/CommandPaletteTrigger.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Icon } from '@gravity-ui/uikit';
+import { Magnifier } from '@gravity-ui/icons';
+
+/** Platform-correct palette shortcut label: ⌘K on macOS, Ctrl+K elsewhere. */
+export const PALETTE_SHORTCUT_LABEL = /mac/i.test(navigator.platform || navigator.userAgent) ? '⌘K' : 'Ctrl+K';
+
+interface CommandPaletteTriggerProps {
+    placeholder: string;
+    onOpen: () => void;
+}
+
+/** Header pill that opens the command palette; shows the platform shortcut. */
+const CommandPaletteTrigger: React.FC<CommandPaletteTriggerProps> = ({ placeholder, onOpen }) => (
+    <button
+        type="button"
+        className="cp-trigger"
+        onClick={onOpen}
+        title={`Open command palette (${PALETTE_SHORTCUT_LABEL})`}
+    >
+        <Icon data={Magnifier} size={16} />
+        <span className="cp-trigger__placeholder">{placeholder}</span>
+        <kbd className="cp-kbd">{PALETTE_SHORTCUT_LABEL}</kbd>
+    </button>
+);
+
+export default CommandPaletteTrigger;

--- a/web/src/pages/_shared/command-palette/index.ts
+++ b/web/src/pages/_shared/command-palette/index.ts
@@ -3,3 +3,5 @@ export type { CommandPaletteProps } from './CommandPalette';
 export type { Command, RowAdapter } from './types';
 export { fuzzyMatch } from './fuzzy';
 export type { FuzzyMatchResult } from './fuzzy';
+export { default as CommandPaletteTrigger, PALETTE_SHORTCUT_LABEL } from './CommandPaletteTrigger';
+export { usePaletteShortcut } from './usePaletteShortcut';

--- a/web/src/pages/_shared/command-palette/usePaletteShortcut.ts
+++ b/web/src/pages/_shared/command-palette/usePaletteShortcut.ts
@@ -1,0 +1,20 @@
+import React, { useEffect } from 'react';
+
+/** Wires the ⌘K/Ctrl+K toggle and Escape-to-close for a command palette. */
+export const usePaletteShortcut = (
+    open: boolean,
+    setOpen: React.Dispatch<React.SetStateAction<boolean>>,
+): void => {
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+                e.preventDefault();
+                setOpen((prev) => !prev);
+            } else if (e.key === 'Escape' && open) {
+                setOpen(false);
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [open, setOpen]);
+};

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
-import { Funnel, Magnifier, Plus } from '@gravity-ui/icons';
+import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
@@ -22,7 +22,7 @@ import { SaveDiffModal } from './SaveDiffModal';
 import { useForwardRuleCounters } from './useForwardRuleCounters';
 import { AddConfigModal } from '../../_shared/draft';
 import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
-import { CommandPalette } from '../../_shared/command-palette';
+import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import '../../../styles/draft-page.scss';
 import './forward.scss';
@@ -238,25 +238,7 @@ const ForwardPage: React.FC = () => {
         setFlashRowId(null);
     }, [currentConfig]);
 
-    useEffect(() => {
-        if (!paletteOpen) return;
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape') setPaletteOpen(false);
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [paletteOpen]);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                setPaletteOpen((prev) => !prev);
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, []);
+    usePaletteShortcut(paletteOpen, setPaletteOpen);
 
     usePageKeyboardShortcuts({
         onNewRule: openAdd,
@@ -374,16 +356,7 @@ const ForwardPage: React.FC = () => {
     const pageHeader = (
         <div className="page-header-bar">
             <Text variant="header-1">Forward</Text>
-            <button
-                type="button"
-                className="cp-trigger"
-                onClick={() => setPaletteOpen(true)}
-                title="Open command palette (⌘K)"
-            >
-                <Icon data={Magnifier} size={16} />
-                <span className="cp-trigger__placeholder">Search rules or run an action…</span>
-                <kbd className="cp-kbd">⌘K</kbd>
-            </button>
+            <CommandPaletteTrigger placeholder="Search rules or run an action…" onOpen={() => setPaletteOpen(true)} />
             <div className="page-header-bar__actions">
                 <YamlIO
                     key={currentConfig || '__none'}

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
-import { Funnel, Magnifier, Plus } from '@gravity-ui/icons';
+import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { useFIBDraft } from './useFIBDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
@@ -16,7 +16,7 @@ import {
     AddConfigModal, isValidCIDR, useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers,
 } from '../../_shared/draft';
 import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
-import { CommandPalette } from '../../_shared/command-palette';
+import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import '../../../styles/draft-page.scss';
 import './route.scss';
@@ -142,25 +142,7 @@ const RoutePage: React.FC = () => {
         dragDrop,
     });
 
-    useEffect(() => {
-        if (!paletteOpen) return;
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape') setPaletteOpen(false);
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [paletteOpen]);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                setPaletteOpen((prev) => !prev);
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, []);
+    usePaletteShortcut(paletteOpen, setPaletteOpen);
 
     const openAdd = useCallback((prefix = ''): void => {
         const newRow: FIBRowItem = { id: makeRowId(), prefix, dst_mac: '', src_mac: '', device: '' };
@@ -274,16 +256,7 @@ const RoutePage: React.FC = () => {
     const pageHeader = (
         <div className="page-header-bar">
             <Text variant="header-1">Route FIB</Text>
-            <button
-                type="button"
-                className="cp-trigger"
-                onClick={() => setPaletteOpen(true)}
-                title="Open command palette (⌘K)"
-            >
-                <Icon data={Magnifier} size={16} />
-                <span className="cp-trigger__placeholder">Search routes or run an action…</span>
-                <kbd className="cp-kbd">⌘K</kbd>
-            </button>
+            <CommandPaletteTrigger placeholder="Search routes or run an action…" onOpen={() => setPaletteOpen(true)} />
             <div className="page-header-bar__actions">
                 <FIBYamlIO
                     key={currentConfig || '__none'}

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,11 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
-import { Plus, Layers, Magnifier } from '@gravity-ui/icons';
+import { Plus, Layers } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
 import { BulkDeleteModal, DeleteConfigModal } from '../../../components';
-import { CommandPalette } from '../../_shared/command-palette';
+import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
 import { parseIPAddress } from '../../../utils';
@@ -103,25 +103,7 @@ const NeighboursPage: React.FC = () => {
 
     const tabsList = [MERGED_TAB, ...tables.map((t) => t.name || '').filter(Boolean)];
 
-    useEffect(() => {
-        if (!paletteOpen) return;
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape') setPaletteOpen(false);
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [paletteOpen]);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                setPaletteOpen((prev) => !prev);
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, []);
+    usePaletteShortcut(paletteOpen, setPaletteOpen);
 
     const { updateParams } = useSearchParamHelpers(setSearchParams);
 
@@ -506,16 +488,7 @@ const NeighboursPage: React.FC = () => {
     const pageHeader = (
         <div className="page-header-bar">
             <Text variant="header-1">Neighbours</Text>
-            <button
-                type="button"
-                className="cp-trigger"
-                onClick={() => setPaletteOpen(true)}
-                title="Open command palette (⌘K)"
-            >
-                <Icon data={Magnifier} size={16} />
-                <span className="cp-trigger__placeholder">Search neighbours or type an IP…</span>
-                <kbd className="cp-kbd">⌘K</kbd>
-            </button>
+            <CommandPaletteTrigger placeholder="Search neighbours or type an IP…" onOpen={() => setPaletteOpen(true)} />
             <div className="page-header-bar__actions">
                 <Button view="outlined" onClick={() => setCreateTableOpen(true)}>
                     <Icon data={Plus} size={16} />

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
-import { ArrowRightToLine, Funnel, Magnifier, Plus } from '@gravity-ui/icons';
+import { ArrowRightToLine, Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { AddConfigModal } from '../../_shared/draft';
 import { BulkDeleteModal } from '../../../components';
-import { CommandPalette } from '../../_shared/command-palette';
+import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import { API } from '../../../api';
 import { toaster, parseIPAddress } from '../../../utils';
@@ -97,25 +97,7 @@ const RoutePage: React.FC = () => {
         return m;
     }, [configs, configRoutes]);
 
-    useEffect(() => {
-        if (!paletteOpen) return;
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape') setPaletteOpen(false);
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [paletteOpen]);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                setPaletteOpen((prev) => !prev);
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, []);
+    usePaletteShortcut(paletteOpen, setPaletteOpen);
 
     const handleSort = useCallback((col: RouteSortableColumn): void => {
         setSortState((prev) => {
@@ -385,16 +367,7 @@ const RoutePage: React.FC = () => {
     const pageHeader = (
         <div className="page-header-bar">
             <Text variant="header-1">Routing Table</Text>
-            <button
-                type="button"
-                className="cp-trigger"
-                onClick={() => setPaletteOpen(true)}
-                title="Open command palette (⌘K)"
-            >
-                <Icon data={Magnifier} size={16} />
-                <span className="cp-trigger__placeholder">Search or look up an IP…</span>
-                <kbd className="cp-kbd">⌘K</kbd>
-            </button>
+            <CommandPaletteTrigger placeholder="Search or look up an IP…" onOpen={() => setPaletteOpen(true)} />
             <div className="page-header-bar__actions">
                 <Button view="outlined" onClick={handleFlush} disabled={!currentConfig}>
                     <Icon data={ArrowRightToLine} size={16} />


### PR DESCRIPTION
Follow-up to #1042.

- Extract the duplicated `⌘K` command-palette trigger pill and its keyboard handling into the shared `_shared/command-palette` module: a `CommandPaletteTrigger` component and a `usePaletteShortcut` hook.
- Show the platform-correct shortcut: `⌘K` on macOS, `Ctrl+K` on Windows/Linux, in both the trigger label and its tooltip. Previously the label was hard-coded to `⌘K` while the handler already accepted Ctrl+K.
- Migrate the forward module, route module, and route/neighbours operator pages to the shared component and hook, removing the per-page duplication (net −59 lines).

Addresses the Codex review comment on #1042 about the non-Mac shortcut label.