### PR TITLE
refactor(web): share URL search-param update helpers

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -20,3 +20,6 @@ export { useContainerHeight } from './useContainerHeight';
 
 export { useCounterHistory } from './useCounterHistory';
 export type { CounterHistoryEntry } from './useCounterHistory';
+
+export { useSearchParamHelpers } from './useSearchParamHelpers';
+export type { SearchParamUpdates } from './useSearchParamHelpers';

--- a/web/src/hooks/useSearchParamHelpers.ts
+++ b/web/src/hooks/useSearchParamHelpers.ts
@@ -1,0 +1,41 @@
+import { useCallback } from 'react';
+import type { SetURLSearchParams } from 'react-router-dom';
+
+/** Batch of URL search-param mutations where null or empty string removes the key. */
+export type SearchParamUpdates = Record<string, string | null>;
+
+/** Returns stable helpers for mutating URL search params with replace navigation. */
+export const useSearchParamHelpers = (
+    setSearchParams: SetURLSearchParams,
+    configKey = 'config',
+): {
+    updateParams: (updates: SearchParamUpdates) => void;
+    clearConfigParamIfCurrent: (name: string) => void;
+} => {
+    const updateParams = useCallback((updates: SearchParamUpdates): void => {
+        setSearchParams((prev) => {
+            const next = new URLSearchParams(prev);
+            for (const [key, value] of Object.entries(updates)) {
+                if (value === null || value === '') {
+                    next.delete(key);
+                } else {
+                    next.set(key, value);
+                }
+            }
+            return next;
+        }, { replace: true });
+    }, [setSearchParams]);
+
+    const clearConfigParamIfCurrent = useCallback((name: string): void => {
+        setSearchParams((prev) => {
+            if (prev.get(configKey) !== name) {
+                return prev;
+            }
+            const next = new URLSearchParams(prev);
+            next.delete(configKey);
+            return next;
+        }, { replace: true });
+    }, [setSearchParams, configKey]);
+
+    return { updateParams, clearConfigParamIfCurrent };
+};

--- a/web/src/pages/builtin/devices/DevicesPage.tsx
+++ b/web/src/pages/builtin/devices/DevicesPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useSearchParamHelpers } from '../../../hooks';
 import { PageLayout, PageLoader, EmptyState } from '../../../components';
 import type { DeviceType } from '../../../api/devices';
 import type { LocalDevice } from './types';
@@ -55,19 +56,7 @@ const DevicesPage: React.FC = () => {
     const anyDirty = useMemo(() => devices.some(d => d.isDirty), [devices]);
     useUnsavedChangesBlocker(anyDirty);
 
-    const updateParams = useCallback((updates: Record<string, string | null>): void => {
-        setSearchParams((prev) => {
-            const next = new URLSearchParams(prev);
-            for (const [key, value] of Object.entries(updates)) {
-                if (value === null || value === '') {
-                    next.delete(key);
-                } else {
-                    next.set(key, value);
-                }
-            }
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
+    const { updateParams } = useSearchParamHelpers(setSearchParams);
 
     useEffect(() => {
         if (loading) return;

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -3,6 +3,7 @@ import { Button, Flex, Icon, Label, Text } from '@gravity-ui/uikit';
 import { Pause, Play, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
+import { useSearchParamHelpers } from '../../../hooks';
 import { useAclDraft } from './useAclDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { Rule } from '../../../api/acl';
@@ -66,30 +67,7 @@ const AclPage: React.FC = () => {
     const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig) || queryConfig === deleteInFlightConfig))
         ? queryConfig
         : (draftConfigs[0] || '');
-    const updateParams = useCallback((updates: Record<string, string | null>): void => {
-        setSearchParams((prev) => {
-            const next = new URLSearchParams(prev);
-            for (const [key, value] of Object.entries(updates)) {
-                if (value === null || value === '') {
-                    next.delete(key);
-                } else {
-                    next.set(key, value);
-                }
-            }
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
-
-    const clearConfigParamIfCurrent = useCallback((name: string): void => {
-        setSearchParams((prev) => {
-            if (prev.get(QP_CONFIG) !== name) {
-                return prev;
-            }
-            const next = new URLSearchParams(prev);
-            next.delete(QP_CONFIG);
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
+    const { updateParams, clearConfigParamIfCurrent } = useSearchParamHelpers(setSearchParams, QP_CONFIG);
 
     useEffect(() => {
         const updates: Record<string, string | null> = {};

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
+import { useSearchParamHelpers } from '../../../hooks';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
 import { usePrefixDraft } from './usePrefixDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
@@ -45,19 +46,7 @@ const DecapPage: React.FC = () => {
 
     useUnsavedChangesBlocker(anyDirty);
 
-    const updateParams = useCallback((updates: Record<string, string | null>): void => {
-        setSearchParams((prev) => {
-            const next = new URLSearchParams(prev);
-            for (const [key, value] of Object.entries(updates)) {
-                if (value === null || value === '') {
-                    next.delete(key);
-                } else {
-                    next.set(key, value);
-                }
-            }
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
+    const { updateParams } = useSearchParamHelpers(setSearchParams);
 
     const setActiveConfig = useCallback((configName: string): void => {
         updateParams({ [QP_CONFIG]: configName || null });

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
+import { useSearchParamHelpers } from '../../../hooks';
 import { Funnel, Magnifier, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
@@ -63,30 +64,7 @@ const ForwardPage: React.FC = () => {
     const queryConfig = useMemo(() => searchParams.get(QP_CONFIG), [searchParams]);
     const search = useMemo(() => searchParams.get(QP_SEARCH) || '', [searchParams]);
     const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig) || queryConfig === deleteInFlightConfig)) ? queryConfig : (draftConfigs[0] || '');
-    const updateParams = useCallback((updates: Record<string, string | null>): void => {
-        setSearchParams((prev) => {
-            const next = new URLSearchParams(prev);
-            for (const [key, value] of Object.entries(updates)) {
-                if (value === null || value === '') {
-                    next.delete(key);
-                } else {
-                    next.set(key, value);
-                }
-            }
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
-
-    const clearConfigParamIfCurrent = useCallback((name: string): void => {
-        setSearchParams((prev) => {
-            if (prev.get(QP_CONFIG) !== name) {
-                return prev;
-            }
-            const next = new URLSearchParams(prev);
-            next.delete(QP_CONFIG);
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
+    const { updateParams, clearConfigParamIfCurrent } = useSearchParamHelpers(setSearchParams, QP_CONFIG);
 
     useUnsavedChangesBlocker(anyDirty);
 

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -15,6 +15,7 @@ import {
 } from '@gravity-ui/uikit';
 import { CircleInfo, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParamHelpers } from '../../../hooks';
 import { API } from '../../../api';
 import { Direction, type FwStateEntry, type ListEntriesRequest, type MapStats } from '../../../api/fwstate';
 import { ConfirmDialog, ConfigTabStrip, PageLayout, PageLoader } from '../../../components';
@@ -1098,19 +1099,7 @@ const FWStatePage: React.FC = () => {
     const currentHasLinkedAcls = (current?.linkedAcls.length ?? 0) > 0;
     const anyDirty = dirtyConfigs.size > 0;
 
-    const updateParams = useCallback((updates: Record<string, string | null>): void => {
-        setSearchParams((prev) => {
-            const next = new URLSearchParams(prev);
-            for (const [key, value] of Object.entries(updates)) {
-                if (value === null || value === '') {
-                    next.delete(key);
-                } else {
-                    next.set(key, value);
-                }
-            }
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
+    const { updateParams } = useSearchParamHelpers(setSearchParams);
 
     const updateActiveConfig = useCallback((name: string): void => {
         updateParams({ [QP_CONFIG]: name || null });

--- a/web/src/pages/modules/pdump/PdumpPage.tsx
+++ b/web/src/pages/modules/pdump/PdumpPage.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { ArrowDownToLine, Plus } from '@gravity-ui/icons';
 import { useSearchParams } from 'react-router-dom';
+import { useSearchParamHelpers } from '../../../hooks';
 import { PageLayout, PageLoader, ConfigTabStrip } from '../../../components';
 import { toaster } from '../../../utils';
 import {
@@ -105,30 +106,7 @@ const PdumpPage: React.FC = () => {
         setNewPacketIds(new Set());
     }, []);
 
-    const updateSearchParams = useCallback((updates: Record<string, string | null>): void => {
-        setSearchParams(prev => {
-            const next = new URLSearchParams(prev);
-            for (const [key, value] of Object.entries(updates)) {
-                if (value === null || value === '') {
-                    next.delete(key);
-                } else {
-                    next.set(key, value);
-                }
-            }
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
-
-    const clearConfigParamIfCurrent = useCallback((name: string): void => {
-        setSearchParams((prev) => {
-            if (prev.get(QP_CONFIG) !== name) {
-                return prev;
-            }
-            const next = new URLSearchParams(prev);
-            next.delete(QP_CONFIG);
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
+    const { updateParams: updateSearchParams, clearConfigParamIfCurrent } = useSearchParamHelpers(setSearchParams, QP_CONFIG);
 
     const handleTogglePause = useCallback(() => {
         setPaused(prev => {

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
+import { useSearchParamHelpers } from '../../../hooks';
 import { Funnel, Magnifier, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { useFIBDraft } from './useFIBDraft';
@@ -51,19 +52,7 @@ const RoutePage: React.FC = () => {
 
     useUnsavedChangesBlocker(anyDirty);
 
-    const updateParams = useCallback((updates: Record<string, string | null>): void => {
-        setSearchParams((prev) => {
-            const next = new URLSearchParams(prev);
-            for (const [key, value] of Object.entries(updates)) {
-                if (value === null || value === '') {
-                    next.delete(key);
-                } else {
-                    next.set(key, value);
-                }
-            }
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
+    const { updateParams } = useSearchParamHelpers(setSearchParams);
 
     const setActiveConfig = useCallback((configName: string): void => {
         updateParams({ [QP_CONFIG]: configName || null });

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useSearchParamHelpers } from '../../../hooks';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { Plus, Layers, Magnifier } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
@@ -122,19 +123,7 @@ const NeighboursPage: React.FC = () => {
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, []);
 
-    const updateParams = useCallback((updates: Record<string, string | null>): void => {
-        setSearchParams((prev) => {
-            const next = new URLSearchParams(prev);
-            for (const [key, value] of Object.entries(updates)) {
-                if (value === null || value === '') {
-                    next.delete(key);
-                } else {
-                    next.set(key, value);
-                }
-            }
-            return next;
-        }, { replace: true });
-    }, [setSearchParams]);
+    const { updateParams } = useSearchParamHelpers(setSearchParams);
 
     const handleTabSelect = useCallback((cfg: string): void => {
         const tab = cfg === MERGED_TAB ? MERGED_TAB : cfg;


### PR DESCRIPTION
Extracts the duplicated URL search-param updater (and the config-param clear helper) into a single shared hook, adopted across the eight pages that previously each carried a hand-rolled copy. Behaviour and callback-identity semantics are unchanged.