### PR TITLE
refactor(web): share page keyboard-shortcut hook

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -23,3 +23,5 @@ export type { CounterHistoryEntry } from './useCounterHistory';
 
 export { useSearchParamHelpers } from './useSearchParamHelpers';
 export type { SearchParamUpdates } from './useSearchParamHelpers';
+
+export { usePageKeyboardShortcuts } from './usePageKeyboardShortcuts';

--- a/web/src/hooks/usePageKeyboardShortcuts.ts
+++ b/web/src/hooks/usePageKeyboardShortcuts.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+/** Register page-level keyboard shortcuts: Escape closes the drawer, n opens the new-rule form. */
+export const usePageKeyboardShortcuts = (opts: {
+    onNewRule: () => void;
+    onEscape: () => void;
+    drawerOpen: boolean;
+}): void => {
+    const { onNewRule, onEscape, drawerOpen } = opts;
+
+    useEffect(() => {
+        const onKey = (e: KeyboardEvent): void => {
+            // Escape always closes the drawer regardless of focus position.
+            if (e.key === 'Escape' && drawerOpen) {
+                onEscape();
+                return;
+            }
+            // n is gated: do not fire when focus is inside a text field.
+            const tag = (e.target as HTMLElement).tagName;
+            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+            if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+                onNewRule();
+            }
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [onNewRule, onEscape, drawerOpen]);
+};

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -3,13 +3,13 @@ import { Button, Flex, Icon, Label, Text } from '@gravity-ui/uikit';
 import { Pause, Play, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
-import { useSearchParamHelpers } from '../../../hooks';
+import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
 import { useAclDraft } from './useAclDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { Rule } from '../../../api/acl';
 import { ActionKind } from '../../../api/acl';
 import type { RuleItem, RuleDraft } from './types';
-import { rulesToNgItems, draftToRule, useKeyboardShortcuts } from './hooks';
+import { rulesToNgItems, draftToRule } from './hooks';
 import { DRAWER_TRANSITION_MS } from './RuleTable';
 import RuleTable from './RuleTable';
 import RuleDrawer from './RuleDrawer';
@@ -278,7 +278,7 @@ const AclPage: React.FC = () => {
         updateParams({ [QP_SEARCH]: value || null });
     }, [updateParams]);
 
-    useKeyboardShortcuts({
+    usePageKeyboardShortcuts({
         onNewRule: openAdd,
         onEscape: closeDrawer,
         drawerOpen: drawer.open,

--- a/web/src/pages/modules/acl/hooks.ts
+++ b/web/src/pages/modules/acl/hooks.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import type { Rule, PortRange, VlanRange, ProtoRange, Action } from '../../../api/acl';
 import { ActionKind } from '../../../api/acl';
 import { formatIPNet, extractBytes } from '../../../utils';
@@ -251,29 +250,4 @@ export const ruleToDraft = (rule: Rule): RuleDraft => {
         counter: rule.counter ?? '',
         actions: (rule.actions ?? []).map(a => normalizeActionKind(a.kind)),
     };
-};
-
-/** Keyboard shortcuts for the ACL page. */
-export const useKeyboardShortcuts = (opts: {
-    onNewRule: () => void;
-    onEscape: () => void;
-    drawerOpen: boolean;
-}): void => {
-    const { onNewRule, onEscape, drawerOpen } = opts;
-
-    useEffect(() => {
-        const onKey = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape' && drawerOpen) {
-                onEscape();
-                return;
-            }
-            const tag = (e.target as HTMLElement).tagName;
-            if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-            if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
-                onNewRule();
-            }
-        };
-        window.addEventListener('keydown', onKey);
-        return () => window.removeEventListener('keydown', onKey);
-    }, [onNewRule, onEscape, drawerOpen]);
 };

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers } from '../../../hooks';
+import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
 import { Funnel, Magnifier, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
@@ -12,7 +12,7 @@ import type { RuleItem, RuleDraft } from './types';
 import { MODE_LABELS } from './types';
 import { ModeFilter } from './ModeFilter';
 import type { ModeFilterValue } from './ModeFilter';
-import { rulesToNgItems, draftToRule, useKeyboardShortcuts } from './hooks';
+import { rulesToNgItems, draftToRule } from './hooks';
 import { DRAWER_TRANSITION_MS } from './RuleTable';
 import RuleTable from './RuleTable';
 import RuleDrawer from './RuleDrawer';
@@ -258,7 +258,7 @@ const ForwardPage: React.FC = () => {
         return () => window.removeEventListener('keydown', handleKeyDown);
     }, []);
 
-    useKeyboardShortcuts({
+    usePageKeyboardShortcuts({
         onNewRule: openAdd,
         onEscape: closeDrawer,
         drawerOpen: drawer.open,

--- a/web/src/pages/modules/forward/hooks.ts
+++ b/web/src/pages/modules/forward/hooks.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import type { Rule, IPNet, VlanRange } from '../../../api/forward';
 import { ForwardMode } from '../../../api/forward';
 import { formatIPNet, parseIPToBytes, prefixLengthToMaskBytes, bytesToBase64, extractBytes } from '../../../utils';
@@ -120,33 +119,6 @@ export const itemToDraft = (item: RuleItem): RuleDraft => ({
     sourceCidrs: [...item.sourceCidrs],
     dstCidrs: [...item.dstCidrs],
 });
-
-/** Register keyboard shortcuts for the forward page. */
-export const useKeyboardShortcuts = (opts: {
-    onNewRule: () => void;
-    onEscape: () => void;
-    drawerOpen: boolean;
-}): void => {
-    const { onNewRule, onEscape, drawerOpen } = opts;
-
-    useEffect(() => {
-        const onKey = (e: KeyboardEvent): void => {
-            // Escape always closes the drawer regardless of focus position.
-            if (e.key === 'Escape' && drawerOpen) {
-                onEscape();
-                return;
-            }
-            // n is gated: do not fire when focus is inside a text field.
-            const tag = (e.target as HTMLElement).tagName;
-            if (tag === 'INPUT' || tag === 'TEXTAREA') return;
-            if (e.key === 'n' && !e.metaKey && !e.ctrlKey && !e.altKey) {
-                onNewRule();
-            }
-        };
-        window.addEventListener('keydown', onKey);
-        return () => window.removeEventListener('keydown', onKey);
-    }, [onNewRule, onEscape, drawerOpen]);
-};
 
 /** Validate VLAN token (single value or range, 0-4095). */
 export const isValidVlanToken = (s: string): boolean => {


### PR DESCRIPTION
Extracts the rule-page keyboard-shortcut handler (Escape closes the drawer, `n` opens a new rule) that was duplicated in the ACL and Forward pages into a single shared hook.

The two copies differed only in their form-field guard: ACL also suppressed the shortcut when a select element was focused. The shared hook adopts that stricter guard, so the Forward page now ignores the shortcut while a select is focused as well.