### PR TITLE
refactor(web): share command-palette open-state hook

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -25,3 +25,5 @@ export { useSearchParamHelpers } from './useSearchParamHelpers';
 export type { SearchParamUpdates } from './useSearchParamHelpers';
 
 export { usePageKeyboardShortcuts } from './usePageKeyboardShortcuts';
+
+export { useCommandPalette } from './useCommandPalette';

--- a/web/src/hooks/useCommandPalette.ts
+++ b/web/src/hooks/useCommandPalette.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+/** Command-palette open state plus keyboard wiring: Cmd/Ctrl+K toggles, Escape closes while open. */
+export const useCommandPalette = () => {
+    const [paletteOpen, setPaletteOpen] = useState(false);
+
+    useEffect(() => {
+        if (!paletteOpen) return;
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape') setPaletteOpen(false);
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [paletteOpen]);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+                e.preventDefault();
+                setPaletteOpen((prev) => !prev);
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, []);
+
+    return { paletteOpen, setPaletteOpen };
+};

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
+import { useSearchParamHelpers, usePageKeyboardShortcuts, useCommandPalette } from '../../../hooks';
 import { Funnel, Magnifier, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
@@ -57,7 +57,7 @@ const ForwardPage: React.FC = () => {
     const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
     const [deleteInFlightConfig, setDeleteInFlightConfig] = useState<string | null>(null);
     const [diffModalOpen, setDiffModalOpen] = useState(false);
-    const [paletteOpen, setPaletteOpen] = useState(false);
+    const { paletteOpen, setPaletteOpen } = useCommandPalette();
     const [modeFilter, setModeFilter] = useState<ModeFilterValue>('all');
     const [flashRowId, setFlashRowId] = useState<string | null>(null);
     const drawerRef = useRef<RuleDrawerHandle>(null);
@@ -237,26 +237,6 @@ const ForwardPage: React.FC = () => {
         setModeFilter('all');
         setFlashRowId(null);
     }, [currentConfig]);
-
-    useEffect(() => {
-        if (!paletteOpen) return;
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape') setPaletteOpen(false);
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [paletteOpen]);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                setPaletteOpen((prev) => !prev);
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, []);
 
     usePageKeyboardShortcuts({
         onNewRule: openAdd,

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers } from '../../../hooks';
+import { useSearchParamHelpers, useCommandPalette } from '../../../hooks';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { Plus, Layers, Magnifier } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
@@ -64,7 +64,7 @@ const NeighboursPage: React.FC = () => {
     const stateFilter = parseStateFilter(searchParams);
 
     const [paused, setPaused] = useState(false);
-    const [paletteOpen, setPaletteOpen] = useState(false);
+    const { paletteOpen, setPaletteOpen } = useCommandPalette();
     const [flashRowId, setFlashRowId] = useState<string | null>(null);
 
     const {
@@ -102,26 +102,6 @@ const NeighboursPage: React.FC = () => {
     const isBuiltIn = activeTableInfo?.built_in ?? false;
 
     const tabsList = [MERGED_TAB, ...tables.map((t) => t.name || '').filter(Boolean)];
-
-    useEffect(() => {
-        if (!paletteOpen) return;
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape') setPaletteOpen(false);
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [paletteOpen]);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                setPaletteOpen((prev) => !prev);
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, []);
 
     const { updateParams } = useSearchParamHelpers(setSearchParams);
 

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { ArrowRightToLine, Funnel, Magnifier, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
@@ -6,6 +6,7 @@ import { AddConfigModal } from '../../_shared/draft';
 import { BulkDeleteModal } from '../../../components';
 import { CommandPalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
+import { useCommandPalette } from '../../../hooks';
 import { API } from '../../../api';
 import { toaster, parseIPAddress } from '../../../utils';
 import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
@@ -38,7 +39,7 @@ const RoutePage: React.FC = () => {
         route: null,
     });
 
-    const [paletteOpen, setPaletteOpen] = useState(false);
+    const { paletteOpen, setPaletteOpen } = useCommandPalette();
     const [lookupOpen, setLookupOpen] = useState(false);
     const [lookupInitialQuery, setLookupInitialQuery] = useState('');
     const [family, setFamily] = useState<IPFamily>('all');
@@ -96,26 +97,6 @@ const RoutePage: React.FC = () => {
         configs.forEach((c) => m.set(c, (configRoutes.get(c) || []).length));
         return m;
     }, [configs, configRoutes]);
-
-    useEffect(() => {
-        if (!paletteOpen) return;
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if (e.key === 'Escape') setPaletteOpen(false);
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [paletteOpen]);
-
-    useEffect(() => {
-        const handleKeyDown = (e: KeyboardEvent): void => {
-            if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
-                e.preventDefault();
-                setPaletteOpen((prev) => !prev);
-            }
-        };
-        window.addEventListener('keydown', handleKeyDown);
-        return () => window.removeEventListener('keydown', handleKeyDown);
-    }, []);
 
     const handleSort = useCallback((col: RouteSortableColumn): void => {
         setSortState((prev) => {


### PR DESCRIPTION
Extracts the command-palette open state and its keyboard wiring (Cmd/Ctrl+K toggles, Escape closes) into a shared hook, replacing the identical boilerplate previously duplicated in the Forward, operators Route, and Neighbours pages. No behaviour change.