### PR TITLE
refactor(web): share empty-page placeholder component

### DIFF
--- a/web/src/components/EmptyPagePlaceholder.tsx
+++ b/web/src/components/EmptyPagePlaceholder.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Button } from '@gravity-ui/uikit';
+
+export interface EmptyPagePlaceholderProps {
+    message: string;
+    actionLabel: string;
+    onAction: () => void;
+}
+
+/** Full-page placeholder shown when a module/operator page has no configs yet. */
+export const EmptyPagePlaceholder: React.FC<EmptyPagePlaceholderProps> = ({ message, actionLabel, onAction }) => (
+    <div className="yn-empty-page">
+        <div className="yn-empty-page__message">{message}</div>
+        <Button view="action" onClick={onAction}>{actionLabel}</Button>
+    </div>
+);

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './PageLoader';
 export * from './PageHeader';
 export * from './CardHeader';
 export * from './EmptyState';
+export * from './EmptyPagePlaceholder';
 export * from './FormField';
 export * from './InputFormField';
 export * from './FormDialog';

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useSt
 import { Button, Flex, Icon, Label, Text } from '@gravity-ui/uikit';
 import { Pause, Play, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
 import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
 import { useAclDraft } from './useAclDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
@@ -339,14 +339,11 @@ const AclPage: React.FC = () => {
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
                 {draftConfigs.length === 0 ? (
-                    <div className="yn-empty-page">
-                        <div className="yn-empty-page__message">
-                            No ACL configurations found.
-                        </div>
-                        <Button view="action" onClick={() => setAddConfigOpen(true)}>
-                            Add Config
-                        </Button>
-                    </div>
+                    <EmptyPagePlaceholder
+                        message="No ACL configurations found."
+                        actionLabel="Add Config"
+                        onAction={() => setAddConfigOpen(true)}
+                    />
                 ) : (
                     <>
                         <ConfigTabStrip

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Button } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder } from '../../../components';
 import { usePrefixDraft } from './usePrefixDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { PrefixRowItem } from './types';
@@ -163,10 +162,11 @@ const DecapPage: React.FC = () => {
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
                 {draftConfigs.length === 0 ? (
-                    <div className="yn-empty-page">
-                        <div className="yn-empty-page__message">No decap configurations found.</div>
-                        <Button view="action" onClick={() => setAddConfigOpen(true)}>Add Config</Button>
-                    </div>
+                    <EmptyPagePlaceholder
+                        message="No decap configurations found."
+                        actionLabel="Add Config"
+                        onAction={() => setAddConfigOpen(true)}
+                    />
                 ) : (
                     <>
                         <ConfigTabStrip

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -3,7 +3,7 @@ import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { Rule } from '../../../api/forward';
@@ -385,14 +385,11 @@ const ForwardPage: React.FC = () => {
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
                 {draftConfigs.length === 0 ? (
-                    <div className="yn-empty-page">
-                        <div className="yn-empty-page__message">
-                            No forward configurations found.
-                        </div>
-                        <Button view="action" onClick={() => setAddConfigOpen(true)}>
-                            Add Config
-                        </Button>
-                    </div>
+                    <EmptyPagePlaceholder
+                        message="No forward configurations found."
+                        actionLabel="Add Config"
+                        onAction={() => setAddConfigOpen(true)}
+                    />
                 ) : (
                     <>
                         <ConfigTabStrip

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -18,7 +18,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
 import { API } from '../../../api';
 import { Direction, type FwStateEntry, type ListEntriesRequest, type MapStats } from '../../../api/fwstate';
-import { ConfirmDialog, ConfigTabStrip, PageLayout, PageLoader } from '../../../components';
+import { ConfirmDialog, ConfigTabStrip, PageLayout, PageLoader, EmptyPagePlaceholder } from '../../../components';
 import { useContainerHeight } from '../../../hooks';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import { ipAddressToString, isValidIPAddress, parseIPToBytes, stringToIPAddress, type IPAddressWire } from '../../../utils/netip';
@@ -1694,10 +1694,11 @@ const FWStatePage: React.FC = () => {
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
                 {configNames.length === 0 ? (
-                    <div className="yn-empty-page">
-                        <div className="yn-empty-page__message">No FWState configurations found.</div>
-                        <Button view="action" onClick={() => setAddConfigOpen(true)}>Add Config</Button>
-                    </div>
+                    <EmptyPagePlaceholder
+                        message="No FWState configurations found."
+                        actionLabel="Add Config"
+                        onAction={() => setAddConfigOpen(true)}
+                    />
                 ) : (
                     <>
                         <div className="fwstate-config-bar">

--- a/web/src/pages/modules/pdump/PdumpPage.tsx
+++ b/web/src/pages/modules/pdump/PdumpPage.tsx
@@ -3,7 +3,7 @@ import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
 import { ArrowDownToLine, Plus } from '@gravity-ui/icons';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
-import { PageLayout, PageLoader, ConfigTabStrip } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, EmptyPagePlaceholder } from '../../../components';
 import { toaster } from '../../../utils';
 import {
     usePdumpConfigs,
@@ -424,14 +424,11 @@ const PdumpPage: React.FC = () => {
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page pdump-page yn-flat-page">
                 {configs.length === 0 ? (
-                    <div className="yn-empty-page">
-                        <div className="yn-empty-page__message">
-                            No pdump configurations found.
-                        </div>
-                        <Button view="action" onClick={() => setIsCreateDialogOpen(true)}>
-                            New Configuration
-                        </Button>
-                    </div>
+                    <EmptyPagePlaceholder
+                        message="No pdump configurations found."
+                        actionLabel="New Configuration"
+                        onAction={() => setIsCreateDialogOpen(true)}
+                    />
                 ) : (
                     <>
                         <ConfigTabStrip

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -3,7 +3,7 @@ import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
 import { useFIBDraft } from './useFIBDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { FIBRowItem } from './types';
@@ -285,10 +285,11 @@ const RoutePage: React.FC = () => {
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
                 {draftConfigs.length === 0 ? (
-                    <div className="yn-empty-page">
-                        <div className="yn-empty-page__message">No FIB configurations found.</div>
-                        <Button view="action" onClick={() => setAddConfigOpen(true)}>Add Config</Button>
-                    </div>
+                    <EmptyPagePlaceholder
+                        message="No FIB configurations found."
+                        actionLabel="Add Config"
+                        onAction={() => setAddConfigOpen(true)}
+                    />
                 ) : (
                     <>
                         <ConfigTabStrip

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { Plus, Layers } from '@gravity-ui/icons';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder } from '../../../components';
 import { BulkDeleteModal, DeleteConfigModal } from '../../../components';
 import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
@@ -514,10 +514,11 @@ const NeighboursPage: React.FC = () => {
         <PageLayout header={pageHeader} className="nb-layout">
             <div className="yn-page nb-page">
                 {tables.length === 0 ? (
-                    <div className="yn-empty-page">
-                        <div className="yn-empty-page__message">No neighbour tables found.</div>
-                        <Button view="action" onClick={() => setCreateTableOpen(true)}>Create table</Button>
-                    </div>
+                    <EmptyPagePlaceholder
+                        message="No neighbour tables found."
+                        actionLabel="Create table"
+                        onAction={() => setCreateTableOpen(true)}
+                    />
                 ) : (
                     <>
                         <div className="yn-tabs-row">

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { ArrowRightToLine, Funnel, Plus } from '@gravity-ui/icons';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
 import { AddConfigModal } from '../../_shared/draft';
 import { BulkDeleteModal } from '../../../components';
 import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
@@ -393,10 +393,11 @@ const RoutePage: React.FC = () => {
         <PageLayout header={pageHeader} className="ro-layout">
             <div className="yn-page ro-page" aria-busy={refreshing}>
                 {configs.length === 0 ? (
-                    <div className="yn-empty-page">
-                        <div className="yn-empty-page__message">No route configurations found.</div>
-                        <Button view="action" onClick={() => setAddConfigOpen(true)}>Add Config</Button>
-                    </div>
+                    <EmptyPagePlaceholder
+                        message="No route configurations found."
+                        actionLabel="Add Config"
+                        onAction={() => setAddConfigOpen(true)}
+                    />
                 ) : (
                     <>
                         <ConfigTabStrip


### PR DESCRIPTION
Extracts the repeated no-configurations empty state (message plus a create-action button) into a single shared component, adopted across the eight module and operator pages that each carried an identical inline copy. Markup is byte-identical, so rendering is unchanged.