### PR TITLE
refactor(web): unify ACL and Forward rule-counter hooks

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -25,3 +25,6 @@ export { useSearchParamHelpers } from './useSearchParamHelpers';
 export type { SearchParamUpdates } from './useSearchParamHelpers';
 
 export { usePageKeyboardShortcuts } from './usePageKeyboardShortcuts';
+
+export { useModuleRuleCounters } from './useModuleRuleCounters';
+export type { RuleRate, ModuleRuleCountersParams } from './useModuleRuleCounters';

--- a/web/src/hooks/useModuleRuleCounters.ts
+++ b/web/src/hooks/useModuleRuleCounters.ts
@@ -1,0 +1,176 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { API } from '../api';
+import { useInterpolatedCounters } from './useInterpolatedCounters';
+import { appendCapped, HISTORY_SIZE } from './useCounterHistory';
+import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../utils';
+
+/** Per-rule rate data: rolling history for the sparkline and the latest interpolated pps. */
+export interface RuleRate {
+    history: number[];
+    pps: number;
+}
+
+/** Parameters for the generic module rule counters hook. */
+export interface ModuleRuleCountersParams<T> {
+    configName: string;
+    rules: T[];
+    moduleType: string;
+    enabled: boolean;
+    /** Counter names to poll; caller derives this list. */
+    counterNames: string[];
+    /** Returns the counter name for a given rule; empty string means the rule has no counter. */
+    getCounterName: (rule: T) => string;
+    /** When provided, only counters passing this predicate are sampled and included in rates. */
+    isCounterActive?: (name: string) => boolean;
+}
+
+/**
+ * Generic polling skeleton shared by ACL and forward rule-counter hooks.
+ *
+ * Polls CountersService.ByTags once per second for the supplied counterNames,
+ * maintains a HISTORY_SIZE-sample pps rolling window per counter, and
+ * interpolates at ~30 ms for smooth sparkline animation. Rates are keyed by
+ * rule id (from the T constraint `{ id: string }`).
+ */
+export const useModuleRuleCounters = <T extends { id: string }>(
+    params: ModuleRuleCountersParams<T>,
+): { rates: Map<string, RuleRate> } => {
+    const {
+        configName,
+        rules,
+        moduleType,
+        enabled,
+        counterNames,
+        getCounterName,
+        isCounterActive,
+    } = params;
+
+    const historyRef = useRef<Map<string, number[]>>(new Map());
+    const [rates, setRates] = useState<Map<string, RuleRate>>(new Map());
+    const ratesRef = useRef(rates);
+    ratesRef.current = rates;
+
+    const countersRef = useRef<Map<string, { pps: number }>>(new Map());
+
+    useEffect(() => {
+        historyRef.current = new Map();
+        setRates(new Map());
+    }, [configName]);
+
+    const counterNamesKey = counterNames.join(',');
+
+    useEffect(() => {
+        const history = historyRef.current;
+        const next = new Map<string, RuleRate>();
+        for (const rule of rules) {
+            const cname = getCounterName(rule);
+            if (!cname) continue;
+            if (isCounterActive && !isCounterActive(cname)) continue;
+            const h = history.get(cname);
+            if (h) next.set(rule.id, { history: h, pps: countersRef.current.get(cname)?.pps ?? 0 });
+        }
+        if (next.size === 0 && ratesRef.current.size === 0) return;
+        setRates(next);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [rules, counterNamesKey]);
+
+    const rulesRef = useRef(rules);
+    rulesRef.current = rules;
+    const getCounterNameRef = useRef(getCounterName);
+    getCounterNameRef.current = getCounterName;
+    const isCounterActiveRef = useRef(isCounterActive);
+    isCounterActiveRef.current = isCounterActive;
+    const counterNamesRef = useRef(counterNames);
+    counterNamesRef.current = counterNames;
+
+    const fetchCounters = useCallback(async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
+        const result = new Map<string, { packets: bigint; bytes: bigint }>();
+        for (const name of counterNames) {
+            result.set(name, { packets: BigInt(0), bytes: BigInt(0) });
+        }
+
+        if (!configName || counterNames.length === 0) {
+            return result;
+        }
+
+        try {
+            const response = await API.counters.byTags({
+                tags: [
+                    { key: 'module_type', value: moduleType },
+                    { key: 'module_name', value: configName },
+                ],
+                query: counterNames,
+            });
+            const grouped = groupCounterGroupsByTagsAndName(response.groups, [], 0);
+            for (const counterName of counterNames) {
+                result.set(counterName, {
+                    packets: grouped.get(makeGroupedCounterKey([], counterName))?.value ?? BigInt(0),
+                    bytes: BigInt(0),
+                });
+            }
+        } catch {
+            // tolerate fetch failures.
+        }
+
+        return result;
+    }, [configName, moduleType, counterNames]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const { counters } = useInterpolatedCounters({
+        keys: counterNames,
+        fetchCounters,
+        enabled: enabled && configName.length > 0 && counterNames.length > 0,
+        pollingInterval: 1000,
+        interpolationInterval: 30,
+    });
+
+    countersRef.current = counters;
+
+    useEffect(() => {
+        if (!enabled || counterNames.length === 0) return;
+
+        const tick = (): void => {
+            const currentCounters = countersRef.current;
+            const currentRules = rulesRef.current;
+            const currentIsActive = isCounterActiveRef.current;
+            if (!currentCounters.size || !currentRules.length) return;
+
+            const history = historyRef.current;
+            let mutated = false;
+
+            for (const [counterName, data] of currentCounters.entries()) {
+                if (currentIsActive && !currentIsActive(counterName)) continue;
+                const pps = data.pps;
+                const existing = history.get(counterName);
+                if (!existing) {
+                    history.set(counterName, Array(HISTORY_SIZE).fill(pps) as number[]);
+                } else {
+                    history.set(counterName, appendCapped(existing, pps, HISTORY_SIZE));
+                }
+                mutated = true;
+            }
+
+            if (!mutated) return;
+
+            const currentGetName = getCounterNameRef.current;
+            const next = new Map<string, RuleRate>();
+            for (const rule of currentRules) {
+                const cname = currentGetName(rule);
+                if (!cname) continue;
+                if (currentIsActive && !currentIsActive(cname)) continue;
+                const h = history.get(cname);
+                if (h) {
+                    const pps = currentCounters.get(cname)?.pps ?? 0;
+                    next.set(rule.id, { history: h, pps });
+                }
+            }
+            setRates(next);
+        };
+
+        tick();
+        const id = setInterval(tick, 1000);
+        return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enabled, counterNamesKey]);
+
+    return { rates };
+};

--- a/web/src/pages/modules/acl/useAclRuleCounters.ts
+++ b/web/src/pages/modules/acl/useAclRuleCounters.ts
@@ -1,16 +1,9 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { API } from '../../../api';
-import { useInterpolatedCounters } from '../../../hooks';
-import { appendCapped, HISTORY_SIZE } from '../../../hooks/useCounterHistory';
+import { useModuleRuleCounters } from '../../../hooks/useModuleRuleCounters';
+import type { RuleRate } from '../../../hooks/useModuleRuleCounters';
 import type { RuleItem } from './types';
 import { effectiveCounterName } from './hooks';
-import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../utils';
 
-/** Per-rule rate data: rolling history for the sparkline and the latest interpolated pps. */
-export interface RuleRate {
-    history: number[];
-    pps: number;
-}
+export type { RuleRate };
 
 export interface UseAclRuleCountersResult {
     /** Map from RuleItem.id to rate data (history + live pps). */
@@ -19,11 +12,10 @@ export interface UseAclRuleCountersResult {
 
 /**
  * Polls CountersService.ByTags once per second for the enabled subset of ACL rules.
- * Only rules whose counter name appears in enabledCounters are polled; if the set is
- * empty, no requests are made at all.
  *
- * When paused (enabled=false), polling stops but last-known values are preserved so
- * sparklines freeze rather than disappear.
+ * Only rules whose counter name appears in enabledCounters are polled; if the set is
+ * empty, no requests are made at all. When paused (enabled=false), polling stops but
+ * last-known values are preserved so sparklines freeze rather than disappear.
  */
 export const useAclRuleCounters = (
     configName: string,
@@ -31,125 +23,15 @@ export const useAclRuleCounters = (
     enabledCounters: Set<string>,
     enabled: boolean,
 ): UseAclRuleCountersResult => {
-    const historyRef = useRef<Map<string, number[]>>(new Map());
-    const [rates, setRates] = useState<Map<string, RuleRate>>(new Map());
-    const ratesRef = useRef(rates);
-    ratesRef.current = rates;
-
-    // Declared here so the effect below (which reads countersRef.current) can reference it safely.
-    const countersRef = useRef<Map<string, { pps: number }>>(new Map());
-
-    useEffect(() => {
-        historyRef.current = new Map();
-        setRates(new Map());
-    }, [configName]);
-
-    useEffect(() => {
-        const history = historyRef.current;
-        const next = new Map<string, RuleRate>();
-        for (const rule of rules) {
-            const cname = effectiveCounterName(rule.rule, rule.index);
-            if (!enabledCounters.has(cname)) continue;
-            const h = history.get(cname);
-            if (h) next.set(rule.id, { history: h, pps: countersRef.current.get(cname)?.pps ?? 0 });
-        }
-        if (next.size === 0 && ratesRef.current.size === 0) return;
-        setRates(next);
-    }, [rules, enabledCounters]); // eslint-disable-line react-hooks/exhaustive-deps
-
-    const rulesRef = useRef(rules);
-    rulesRef.current = rules;
-    const enabledCountersRef = useRef(enabledCounters);
-    enabledCountersRef.current = enabledCounters;
-
     const counterNames = Array.from(enabledCounters).filter(Boolean);
 
-    const fetchCounters = useCallback(async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
-        const result = new Map<string, { packets: bigint; bytes: bigint }>();
-        for (const name of counterNames) {
-            result.set(name, { packets: BigInt(0), bytes: BigInt(0) });
-        }
-
-        if (!configName || counterNames.length === 0) {
-            return result;
-        }
-
-        try {
-            const response = await API.counters.byTags({
-                tags: [
-                    { key: 'module_type', value: 'acl' },
-                    { key: 'module_name', value: configName },
-                ],
-                query: counterNames,
-            });
-            const grouped = groupCounterGroupsByTagsAndName(response.groups, [], 0);
-            for (const counterName of counterNames) {
-                result.set(counterName, {
-                    packets: grouped.get(makeGroupedCounterKey([], counterName))?.value ?? BigInt(0),
-                    bytes: BigInt(0),
-                });
-            }
-        } catch {
-            // tolerate fetch failures.
-        }
-
-        return result;
-    }, [configName, counterNames]);
-
-    const { counters } = useInterpolatedCounters({
-        keys: counterNames,
-        fetchCounters,
-        enabled: enabled && configName.length > 0 && counterNames.length > 0,
-        pollingInterval: 1000,
-        interpolationInterval: 30,
+    return useModuleRuleCounters({
+        configName,
+        rules,
+        moduleType: 'acl',
+        enabled,
+        counterNames,
+        getCounterName: (r) => effectiveCounterName(r.rule, r.index),
+        isCounterActive: (n) => enabledCounters.has(n),
     });
-
-    countersRef.current = counters;
-
-    useEffect(() => {
-        if (!enabled || counterNames.length === 0) return;
-
-        const tick = (): void => {
-            const currentCounters = countersRef.current;
-            const currentRules = rulesRef.current;
-            const currentEnabled = enabledCountersRef.current;
-            if (!currentCounters.size || !currentRules.length) return;
-
-            const history = historyRef.current;
-            let mutated = false;
-
-            for (const [counterName, data] of currentCounters.entries()) {
-                if (!currentEnabled.has(counterName)) continue;
-                const pps = data.pps;
-                const existing = history.get(counterName);
-                if (!existing) {
-                    history.set(counterName, Array(HISTORY_SIZE).fill(pps) as number[]);
-                } else {
-                    history.set(counterName, appendCapped(existing, pps, HISTORY_SIZE));
-                }
-                mutated = true;
-            }
-
-            if (!mutated) return;
-
-            const next = new Map<string, RuleRate>();
-            for (const rule of currentRules) {
-                const cname = effectiveCounterName(rule.rule, rule.index);
-                if (!currentEnabled.has(cname)) continue;
-                const h = history.get(cname);
-                if (h) {
-                    const pps = currentCounters.get(cname)?.pps ?? 0;
-                    next.set(rule.id, { history: h, pps });
-                }
-            }
-            setRates(next);
-        };
-
-        tick();
-        const id = setInterval(tick, 1000);
-        return () => clearInterval(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [enabled, counterNames.join(',')]);
-
-    return { rates };
 };

--- a/web/src/pages/modules/forward/useForwardRuleCounters.ts
+++ b/web/src/pages/modules/forward/useForwardRuleCounters.ts
@@ -1,15 +1,8 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { API } from '../../../api';
-import { useInterpolatedCounters } from '../../../hooks';
-import { appendCapped, HISTORY_SIZE } from '../../../hooks/useCounterHistory';
+import { useModuleRuleCounters } from '../../../hooks/useModuleRuleCounters';
+import type { RuleRate } from '../../../hooks/useModuleRuleCounters';
 import type { RuleItem } from './types';
-import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../utils';
 
-/** Per-rule rate data: rolling history for the sparkline and the latest interpolated pps. */
-export interface RuleRate {
-    history: number[];
-    pps: number;
-}
+export type { RuleRate };
 
 export interface UseForwardRuleCountersResult {
     /** Map from RuleItem.id to rate data (history + live pps). */
@@ -17,136 +10,27 @@ export interface UseForwardRuleCountersResult {
 }
 
 /**
- * Polls CountersService.ByTags once per second for all rules of the given
- * forward config, maintains a 60-sample pps rolling window per rule, and
- * interpolates at ~30ms for smooth sparkline animation.
+ * Polls CountersService.ByTags once per second for all rules of the given forward config.
  *
- * When enabled=false, polling and history sampling pause; the last known values are
- * preserved so sparklines freeze rather than disappear.
- *
- * Counter names are read from RuleItem.counter. Multiple rules sharing the same
- * counter name receive identical sparklines. The key for history is RuleItem.id.
+ * Maintains a 60-sample pps rolling window per rule and interpolates at ~30 ms for
+ * smooth sparkline animation. When enabled=false, polling and history sampling pause;
+ * the last known values are preserved so sparklines freeze rather than disappear.
+ * Counter names are read from RuleItem.counter; multiple rules sharing the same counter
+ * name receive identical sparklines.
  */
 export const useForwardRuleCounters = (
     configName: string,
     rules: RuleItem[],
     enabled: boolean,
 ): UseForwardRuleCountersResult => {
-    const historyRef = useRef<Map<string, number[]>>(new Map());
-
-    // Map<ruleId, RuleRate> — returned snapshot; reference changes on each sample.
-    const [rates, setRates] = useState<Map<string, RuleRate>>(new Map());
-    const ratesRef = useRef(rates);
-    ratesRef.current = rates;
-
-    useEffect(() => {
-        historyRef.current = new Map();
-        setRates(new Map());
-    }, [configName]);
-
-    useEffect(() => {
-        const history = historyRef.current;
-        const next = new Map<string, RuleRate>();
-        for (const rule of rules) {
-            const h = rule.counter ? history.get(rule.counter) : undefined;
-            if (h) {
-                next.set(rule.id, { history: h, pps: countersRef.current.get(rule.counter)?.pps ?? 0 });
-            }
-        }
-        if (next.size === 0 && ratesRef.current.size === 0) return;
-        setRates(next);
-    }, [rules]);
-
-    // Stable refs so callbacks don't need to re-create on every render.
-    const rulesRef = useRef(rules);
-    rulesRef.current = rules;
-
-    // Unique counter names across all rules — these are the keys for useInterpolatedCounters.
     const counterNames = Array.from(new Set(rules.map(r => r.counter).filter(Boolean)));
 
-    const fetchCounters = useCallback(async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
-        const result = new Map<string, { packets: bigint; bytes: bigint }>();
-        for (const name of counterNames) {
-            result.set(name, { packets: BigInt(0), bytes: BigInt(0) });
-        }
-
-        if (!configName || counterNames.length === 0) {
-            return result;
-        }
-
-        try {
-            const response = await API.counters.byTags({
-                tags: [
-                    { key: 'module_type', value: 'forward' },
-                    { key: 'module_name', value: configName },
-                ],
-                query: counterNames,
-            });
-            const grouped = groupCounterGroupsByTagsAndName(response.groups, [], 0);
-            for (const counterName of counterNames) {
-                result.set(counterName, {
-                    packets: grouped.get(makeGroupedCounterKey([], counterName))?.value ?? BigInt(0),
-                    bytes: BigInt(0),
-                });
-            }
-        } catch {
-            // tolerate fetch failures.
-        }
-
-        return result;
-    }, [configName, counterNames]);
-
-    const { counters } = useInterpolatedCounters({
-        keys: counterNames,
-        fetchCounters,
-        enabled: enabled && configName.length > 0 && counterNames.length > 0,
-        pollingInterval: 1000,
-        interpolationInterval: 30,
+    return useModuleRuleCounters({
+        configName,
+        rules,
+        moduleType: 'forward',
+        enabled,
+        counterNames,
+        getCounterName: (r) => r.counter ?? '',
     });
-
-    const countersRef = useRef(counters);
-    countersRef.current = counters;
-
-    useEffect(() => {
-        if (!enabled) return;
-
-        const tick = (): void => {
-            const currentCounters = countersRef.current;
-            const currentRules = rulesRef.current;
-            if (!currentCounters.size || !currentRules.length) return;
-
-            const history = historyRef.current;
-            let mutated = false;
-
-            for (const [counterName, data] of currentCounters.entries()) {
-                const pps = data.pps;
-                const existing = history.get(counterName);
-                if (!existing) {
-                    history.set(counterName, Array(HISTORY_SIZE).fill(pps) as number[]);
-                } else {
-                    history.set(counterName, appendCapped(existing, pps, HISTORY_SIZE));
-                }
-                mutated = true;
-            }
-
-            if (!mutated) return;
-
-            const next = new Map<string, RuleRate>();
-            for (const rule of currentRules) {
-                const h = rule.counter ? history.get(rule.counter) : undefined;
-                if (h) {
-                    const pps = rule.counter ? (currentCounters.get(rule.counter)?.pps ?? 0) : 0;
-                    next.set(rule.id, { history: h, pps });
-                }
-            }
-            setRates(next);
-        };
-
-        tick();
-        const id = setInterval(tick, 1000);
-        return () => clearInterval(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [enabled]);
-
-    return { rates };
 };


### PR DESCRIPTION
Extracts the shared live rule-counter polling logic (rolling history sampling plus interpolated rates) into a single generic hook. The ACL and Forward hooks become thin wrappers that supply their module-specific counter-name derivation and, for ACL, the enabled-counter filtering. Public signatures and behaviour are unchanged.