### PR TITLE
refactor(web): share diff-dialog styling via mixin

### DIFF
--- a/web/src/pages/builtin/functions/FunctionsPage.scss
+++ b/web/src/pages/builtin/functions/FunctionsPage.scss
@@ -1162,33 +1162,6 @@
     text-align: center;
 }
 
-// ─── Diff dialog ──────────────────────────────────────────────────────────────
-
 .fn-diff-dialog {
-    // Override Gravity's size="l" to be wide enough for side-by-side split view.
-    .g-dialog__content {
-        width: min(1100px, 92vw);
-        max-width: none;
-    }
-}
-
-.fn-diff-dialog__body {
-    padding: 0 !important;
-}
-
-.fn-diff-dialog__content {
-    background: var(--fn-page-bg);
-}
-
-.fn-diff-dialog__error-bar {
-    padding: 6px 16px;
-    background: color-mix(in srgb, var(--g-color-text-danger) 8%, transparent);
-    border-bottom: 1px solid var(--fn-line);
-    flex-shrink: 0;
-}
-
-.fn-diff-dialog__scroll {
-    overflow: auto;
-    max-height: min(70vh, 600px);
-    padding: 12px 16px 16px;
+    @include diff-dialog(var(--fn-page-bg), var(--fn-line));
 }

--- a/web/src/pages/builtin/pipelines/PipelinesPage.scss
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.scss
@@ -731,32 +731,6 @@
     gap: 6px;
 }
 
-// ─── Diff dialog ──────────────────────────────────────────────────────────────
-
 .pl-diff-dialog {
-    .g-dialog__content {
-        width: min(1100px, 92vw);
-        max-width: none;
-    }
-}
-
-.pl-diff-dialog__body {
-    padding: 0 !important;
-}
-
-.pl-diff-dialog__content {
-    background: var(--pl-page-bg);
-}
-
-.pl-diff-dialog__error-bar {
-    padding: 6px 16px;
-    background: color-mix(in srgb, var(--g-color-text-danger) 8%, transparent);
-    border-bottom: 1px solid var(--pl-line);
-    flex-shrink: 0;
-}
-
-.pl-diff-dialog__scroll {
-    overflow: auto;
-    max-height: min(70vh, 600px);
-    padding: 12px 16px 16px;
+    @include diff-dialog(var(--pl-page-bg), var(--pl-line));
 }

--- a/web/src/styles/_mixins.scss
+++ b/web/src/styles/_mixins.scss
@@ -38,3 +38,33 @@
     padding: 12px 20px;
     flex-shrink: 0;
 }
+
+/** Side-by-side diff dialog chrome — shared by fn-diff-dialog and pl-diff-dialog. */
+@mixin diff-dialog($page-bg, $line) {
+    // Override Gravity's size="l" to be wide enough for side-by-side split view.
+    .g-dialog__content {
+        width: min(1100px, 92vw);
+        max-width: none;
+    }
+
+    &__body {
+        padding: 0 !important;
+    }
+
+    &__content {
+        background: $page-bg;
+    }
+
+    &__error-bar {
+        padding: 6px 16px;
+        background: color-mix(in srgb, var(--g-color-text-danger) 8%, transparent);
+        border-bottom: 1px solid $line;
+        flex-shrink: 0;
+    }
+
+    &__scroll {
+        overflow: auto;
+        max-height: min(70vh, 600px);
+        padding: 12px 16px 16px;
+    }
+}


### PR DESCRIPTION
Extracts the duplicated side-by-side diff-dialog styling shared by the Functions and Pipelines pages into a parameterized SCSS mixin. The page-specific palette tokens are passed as mixin arguments, so the compiled CSS is unchanged.