### PR TITLE
feat: keyboard navigation via the command palette

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,8 @@ import MainMenu from './MainMenu';
 import { PageLoader } from './components';
 import type { PageId, SidebarContextValue } from './types';
 import { PAGE_IDS, SidebarContext } from './types';
+import { PaletteProvider, usePalette, CommandPalette, navigationCommands } from './pages/_shared/command-palette';
+import type { RowAdapter } from './pages/_shared/command-palette';
 
 const importInspect = () => import('./pages/builtin/inspect/InspectPage');
 const importDashboard = () => import('./pages/builtin/dashboard/DashboardPage');
@@ -52,6 +54,37 @@ const NeighboursPage = lazy(importNeighbours);
 type IdleHandle = number;
 type RequestIdleCallback = (cb: () => void, opts?: { timeout: number }) => IdleHandle;
 type CancelIdleCallback = (id: IdleHandle) => void;
+
+/** Global command palette instance that reads contributions from context at render time. */
+const GlobalPalette = ({ handlePageChange }: { handlePageChange: (id: PageId) => void }): React.JSX.Element => {
+    const { open, closePalette, contribution } = usePalette();
+    const navCmds = useMemo(() => navigationCommands(handlePageChange), [handlePageChange]);
+
+    const commands = useMemo(() => {
+        const pageCmds = contribution?.commands ?? [];
+        return [...pageCmds, ...navCmds];
+    }, [contribution, navCmds]);
+
+    const dynamicCommands = useMemo(() => {
+        const pageDynamic = contribution?.dynamicCommands;
+        if (!pageDynamic) return undefined;
+        return pageDynamic;
+    }, [contribution]);
+
+    const rowAdapter = contribution?.rowAdapter as RowAdapter<unknown> | undefined;
+    const placeholder = contribution?.placeholder ?? 'Search or jump to a page…';
+
+    return (
+        <CommandPalette<unknown>
+            open={open}
+            onClose={closePalette}
+            placeholder={placeholder}
+            commands={commands}
+            dynamicCommands={dynamicCommands}
+            rowAdapter={rowAdapter}
+        />
+    );
+};
 
 const AppContent = (): React.JSX.Element => {
     const location = useLocation();
@@ -110,7 +143,7 @@ const AppContent = (): React.JSX.Element => {
 
     const currentPage = getCurrentPage();
 
-    const handlePageChange = (pageId: PageId): void => {
+    const handlePageChange = useCallback((pageId: PageId): void => {
         const guard = unsavedGuardRef.current;
         if (guard && guard()) {
             const ok = window.confirm('You have unsaved changes. Leave this page anyway?');
@@ -119,7 +152,7 @@ const AppContent = (): React.JSX.Element => {
             }
         }
         navigate(`/${pageId}`);
-    };
+    }, [navigate]);
 
     const handleSetSidebarDisabled = useCallback((disabled: boolean) => {
         setSidebarDisabled(disabled);
@@ -136,46 +169,49 @@ const AppContent = (): React.JSX.Element => {
 
     return (
         <SidebarContext.Provider value={sidebarContextValue}>
-            <MainMenu
-                currentPage={currentPage}
-                onPageChange={handlePageChange}
-                disabled={sidebarDisabled}
-                renderContent={() => (
-                    <div className="app-surface">
-                        <Suspense fallback={<PageLoader loading size="l" />}>
-                            <Routes>
-                                <Route path="/" element={<Navigate to="/builtin/dashboard" replace />} />
-                                <Route path="/builtin/inspect" element={<InspectPage />} />
-                                <Route path="/builtin/dashboard" element={<DashboardPage />} />
-                                <Route path="/builtin/functions" element={<FunctionsPage />} />
-                                <Route path="/builtin/functions-ng" element={<Navigate to="/builtin/functions" replace />} />
-                                <Route path="/builtin/pipelines" element={<PipelinesPage />} />
-                                <Route path="/builtin/devices" element={<DevicesPage />} />
-                                <Route path="/modules/forward" element={<ForwardPage />} />
-                                <Route path="/modules/decap" element={<DecapPage />} />
-                                <Route path="/modules/acl" element={<AclPage />} />
-                                <Route path="/modules/fwstate" element={<FWStatePage />} />
-                                <Route path="/modules/pdump" element={<PdumpPage />} />
-                                <Route path="/modules/route" element={<ModulesRoutePage />} />
-                                <Route path="/operators/route" element={<OperatorsRoutePage />} />
-                                <Route path="/operators/neighbours" element={<NeighboursPage />} />
-                                <Route path="/inspect" element={<Navigate to="/builtin/inspect" replace />} />
-                                <Route path="/dashboard" element={<Navigate to="/builtin/dashboard" replace />} />
-                                <Route path="/functions" element={<Navigate to="/builtin/functions" replace />} />
-                                <Route path="/pipelines" element={<Navigate to="/builtin/pipelines" replace />} />
-                                <Route path="/devices" element={<Navigate to="/builtin/devices" replace />} />
-                                <Route path="/forward" element={<Navigate to="/modules/forward" replace />} />
-                                <Route path="/decap" element={<Navigate to="/modules/decap" replace />} />
-                                <Route path="/acl" element={<Navigate to="/modules/acl" replace />} />
-                                <Route path="/fwstate" element={<Navigate to="/modules/fwstate" replace />} />
-                                <Route path="/pdump" element={<Navigate to="/modules/pdump" replace />} />
-                                <Route path="/route" element={<Navigate to="/operators/route" replace />} />
-                                <Route path="/neighbours" element={<Navigate to="/operators/neighbours" replace />} />
-                            </Routes>
-                        </Suspense>
-                    </div>
-                )}
-            />
+            <PaletteProvider>
+                <GlobalPalette handlePageChange={handlePageChange} />
+                <MainMenu
+                    currentPage={currentPage}
+                    onPageChange={handlePageChange}
+                    disabled={sidebarDisabled}
+                    renderContent={() => (
+                        <div className="app-surface">
+                            <Suspense fallback={<PageLoader loading size="l" />}>
+                                <Routes>
+                                    <Route path="/" element={<Navigate to="/builtin/dashboard" replace />} />
+                                    <Route path="/builtin/inspect" element={<InspectPage />} />
+                                    <Route path="/builtin/dashboard" element={<DashboardPage />} />
+                                    <Route path="/builtin/functions" element={<FunctionsPage />} />
+                                    <Route path="/builtin/functions-ng" element={<Navigate to="/builtin/functions" replace />} />
+                                    <Route path="/builtin/pipelines" element={<PipelinesPage />} />
+                                    <Route path="/builtin/devices" element={<DevicesPage />} />
+                                    <Route path="/modules/forward" element={<ForwardPage />} />
+                                    <Route path="/modules/decap" element={<DecapPage />} />
+                                    <Route path="/modules/acl" element={<AclPage />} />
+                                    <Route path="/modules/fwstate" element={<FWStatePage />} />
+                                    <Route path="/modules/pdump" element={<PdumpPage />} />
+                                    <Route path="/modules/route" element={<ModulesRoutePage />} />
+                                    <Route path="/operators/route" element={<OperatorsRoutePage />} />
+                                    <Route path="/operators/neighbours" element={<NeighboursPage />} />
+                                    <Route path="/inspect" element={<Navigate to="/builtin/inspect" replace />} />
+                                    <Route path="/dashboard" element={<Navigate to="/builtin/dashboard" replace />} />
+                                    <Route path="/functions" element={<Navigate to="/builtin/functions" replace />} />
+                                    <Route path="/pipelines" element={<Navigate to="/builtin/pipelines" replace />} />
+                                    <Route path="/devices" element={<Navigate to="/builtin/devices" replace />} />
+                                    <Route path="/forward" element={<Navigate to="/modules/forward" replace />} />
+                                    <Route path="/decap" element={<Navigate to="/modules/decap" replace />} />
+                                    <Route path="/acl" element={<Navigate to="/modules/acl" replace />} />
+                                    <Route path="/fwstate" element={<Navigate to="/modules/fwstate" replace />} />
+                                    <Route path="/pdump" element={<Navigate to="/modules/pdump" replace />} />
+                                    <Route path="/route" element={<Navigate to="/operators/route" replace />} />
+                                    <Route path="/neighbours" element={<Navigate to="/operators/neighbours" replace />} />
+                                </Routes>
+                            </Suspense>
+                        </div>
+                    )}
+                />
+            </PaletteProvider>
         </SidebarContext.Provider>
     );
 };

--- a/web/src/MainMenu.tsx
+++ b/web/src/MainMenu.tsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { AsideHeader } from '@gravity-ui/navigation';
 import type { MenuItem as AsideHeaderMenuItem } from '@gravity-ui/navigation';
-import { Link, Eye, Route, CurlyBracketsFunction, ListUl, HardDrive, LayoutCellsLarge, CirclePlay, Shield, ArrowRight } from '@gravity-ui/icons';
 import Logo from './icons/Logo';
 import type { PageId } from './types';
+import { navItems } from './navItems';
+import type { NavSection } from './navItems';
 import './MainMenu.scss';
 
 interface MainMenuProps {
@@ -58,25 +59,20 @@ const MainMenu = ({ currentPage, onPageChange, renderContent, disabled = false }
         onItemClick: undefined,
     });
 
-    const menuItems: NavMenuItem[] = [
-        createSectionHeader('__section_builtin', 'Builtin'),
-        createMenuItem('builtin/inspect', 'Inspect', Eye),
-        createMenuItem('builtin/functions', 'Functions', CurlyBracketsFunction),
-        createMenuItem('builtin/pipelines', 'Pipelines', ListUl),
-        createMenuItem('builtin/devices', 'Devices', HardDrive),
-        createDivider('__div_1'),
-        createSectionHeader('__section_modules', 'Modules'),
-        createMenuItem('modules/forward', 'Forward', ArrowRight),
-        createMenuItem('modules/route', 'Route', Route),
-        createMenuItem('modules/decap', 'Decap', LayoutCellsLarge),
-        createMenuItem('modules/acl', 'ACL', Shield),
-        createMenuItem('modules/fwstate', 'FWState', Shield),
-        createMenuItem('modules/pdump', 'Pdump', CirclePlay),
-        createDivider('__div_2'),
-        createSectionHeader('__section_operators', 'Operators'),
-        createMenuItem('operators/route', 'Route', Route),
-        createMenuItem('operators/neighbours', 'Neighbours', Link),
-    ];
+    const menuItems: NavMenuItem[] = [];
+    let lastSection: NavSection | null = null;
+    let dividerIdx = 0;
+
+    for (const item of navItems) {
+        if (item.section !== lastSection) {
+            if (lastSection !== null) {
+                menuItems.push(createDivider(`__div_${dividerIdx++}`));
+            }
+            menuItems.push(createSectionHeader(`__section_${item.section}`, item.section));
+            lastSection = item.section;
+        }
+        menuItems.push(createMenuItem(item.id, item.title, item.icon));
+    }
 
     return (
         <AsideHeader

--- a/web/src/navItems.ts
+++ b/web/src/navItems.ts
@@ -1,0 +1,28 @@
+import { Eye, CurlyBracketsFunction, ListUl, HardDrive, ArrowRight, Route, LayoutCellsLarge, Shield, CirclePlay, Link } from '@gravity-ui/icons';
+import type { MenuItem } from '@gravity-ui/navigation';
+import type { PageId } from './types';
+
+export type NavSection = 'Builtin' | 'Modules' | 'Operators';
+
+export interface NavItem {
+    id: PageId;
+    title: string;
+    section: NavSection;
+    icon: MenuItem['icon'];
+}
+
+/** Ordered list of navigable pages, shared between MainMenu and the command palette. */
+export const navItems: NavItem[] = [
+    { id: 'builtin/inspect', title: 'Inspect', section: 'Builtin', icon: Eye },
+    { id: 'builtin/functions', title: 'Functions', section: 'Builtin', icon: CurlyBracketsFunction },
+    { id: 'builtin/pipelines', title: 'Pipelines', section: 'Builtin', icon: ListUl },
+    { id: 'builtin/devices', title: 'Devices', section: 'Builtin', icon: HardDrive },
+    { id: 'modules/forward', title: 'Forward', section: 'Modules', icon: ArrowRight },
+    { id: 'modules/route', title: 'Route', section: 'Modules', icon: Route },
+    { id: 'modules/decap', title: 'Decap', section: 'Modules', icon: LayoutCellsLarge },
+    { id: 'modules/acl', title: 'ACL', section: 'Modules', icon: Shield },
+    { id: 'modules/fwstate', title: 'FWState', section: 'Modules', icon: Shield },
+    { id: 'modules/pdump', title: 'Pdump', section: 'Modules', icon: CirclePlay },
+    { id: 'operators/route', title: 'Route', section: 'Operators', icon: Route },
+    { id: 'operators/neighbours', title: 'Neighbours', section: 'Operators', icon: Link },
+];

--- a/web/src/pages/_shared/command-palette/CommandPalette.tsx
+++ b/web/src/pages/_shared/command-palette/CommandPalette.tsx
@@ -9,6 +9,7 @@ interface PaletteItem {
     label: string;
     labelRanges: Array<[number, number]>;
     sub?: string;
+    group?: string;
     onSelect: () => void;
 }
 
@@ -86,31 +87,43 @@ const CommandPalette = <T,>({
                 label: cmd.label,
                 labelRanges: [],
                 sub: cmd.sub,
+                group: cmd.group,
                 onSelect: cmd.onSelect,
             });
         }
     } else {
-        const scored: Array<{ item: PaletteItem; score: number }> = [];
+        const scoredPage: Array<{ item: PaletteItem; score: number }> = [];
+        const scoredNav: Array<{ item: PaletteItem; score: number }> = [];
         for (const cmd of commands) {
             const searchTarget = cmd.label + (cmd.keywords ? ' ' + cmd.keywords : '');
             const match = fuzzyMatch(q, searchTarget);
             if (match !== null) {
                 const labelMatch = fuzzyMatch(q, cmd.label);
-                scored.push({
+                const entry = {
                     item: {
                         id: cmd.id,
                         icon: cmd.icon,
                         label: cmd.label,
                         labelRanges: labelMatch ? labelMatch.ranges : [],
                         sub: cmd.sub,
+                        group: cmd.group,
                         onSelect: cmd.onSelect,
                     },
                     score: match.score,
-                });
+                };
+                if (cmd.group === 'Go to') {
+                    scoredNav.push(entry);
+                } else {
+                    scoredPage.push(entry);
+                }
             }
         }
-        scored.sort((a, b) => b.score - a.score);
-        for (const entry of scored) {
+        scoredPage.sort((a, b) => b.score - a.score);
+        scoredNav.sort((a, b) => b.score - a.score);
+        for (const entry of scoredPage) {
+            items.push(entry.item);
+        }
+        for (const entry of scoredNav) {
             items.push(entry.item);
         }
     }
@@ -163,7 +176,7 @@ const CommandPalette = <T,>({
 
     useEffect(() => {
         if (!open) return;
-        const el = listRef.current?.children[activeIdx] as HTMLElement | undefined;
+        const el = listRef.current?.querySelector<HTMLElement>(`[data-palette-idx="${activeIdx}"]`);
         el?.scrollIntoView({ block: 'nearest' });
     }, [activeIdx, open]);
 
@@ -183,6 +196,7 @@ const CommandPalette = <T,>({
             const item = items[activeIdx];
             if (item) {
                 item.onSelect();
+                onClose();
             }
         }
     }, [items, activeIdx, onClose]);
@@ -210,28 +224,37 @@ const CommandPalette = <T,>({
                 </div>
                 {items.length > 0 && (
                     <div ref={listRef} className="cp-list">
-                        {items.map((item, idx) => (
-                            <button
-                                key={item.id}
-                                type="button"
-                                className={`cp-item${idx === activeIdx ? ' cp-item--active' : ''}`}
-                                onMouseMove={() => { if (activeIdx !== idx) setActiveIdx(idx); }}
-                                onMouseDown={(e) => { e.preventDefault(); item.onSelect(); }}
-                            >
-                                <span className="cp-item__icon">{item.icon}</span>
-                                <span className="cp-item__body">
-                                    <span className="cp-item__label">
-                                        <HighlightedLabel label={item.label} ranges={item.labelRanges} />
-                                    </span>
-                                    {item.sub && (
-                                        <span className="cp-item__sub">{item.sub}</span>
+                        {items.map((item, idx) => {
+                            const showGroupHeader = item.group !== undefined &&
+                                (idx === 0 || items[idx - 1].group !== item.group);
+                            return (
+                                <React.Fragment key={item.id}>
+                                    {showGroupHeader && (
+                                        <div className="cp-group-label">{item.group}</div>
                                     )}
-                                </span>
-                                {idx === activeIdx && (
-                                    <kbd className="cp-item__enter">↵</kbd>
-                                )}
-                            </button>
-                        ))}
+                                    <button
+                                        type="button"
+                                        data-palette-idx={idx}
+                                        className={`cp-item${idx === activeIdx ? ' cp-item--active' : ''}`}
+                                        onMouseMove={() => { if (activeIdx !== idx) setActiveIdx(idx); }}
+                                        onMouseDown={(e) => { e.preventDefault(); item.onSelect(); onClose(); }}
+                                    >
+                                        <span className="cp-item__icon">{item.icon}</span>
+                                        <span className="cp-item__body">
+                                            <span className="cp-item__label">
+                                                <HighlightedLabel label={item.label} ranges={item.labelRanges} />
+                                            </span>
+                                            {item.sub && (
+                                                <span className="cp-item__sub">{item.sub}</span>
+                                            )}
+                                        </span>
+                                        {idx === activeIdx && (
+                                            <kbd className="cp-item__enter">↵</kbd>
+                                        )}
+                                    </button>
+                                </React.Fragment>
+                            );
+                        })}
                     </div>
                 )}
                 {items.length === 0 && q && (

--- a/web/src/pages/_shared/command-palette/PaletteContext.tsx
+++ b/web/src/pages/_shared/command-palette/PaletteContext.tsx
@@ -1,0 +1,74 @@
+import React, { createContext, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import type { Command, RowAdapter } from './types';
+import { usePaletteShortcut } from './usePaletteShortcut';
+
+/** The contribution that the active page registers with the global palette. */
+export interface PagePaletteContribution {
+    commands?: Command[];
+    dynamicCommands?: (query: string) => Command[];
+    rowAdapter?: RowAdapter<unknown>;
+    placeholder?: string;
+}
+
+interface PaletteContextValue {
+    open: boolean;
+    openPalette: () => void;
+    closePalette: () => void;
+    /** Register (or clear) the active page's palette contribution. */
+    setPageContribution: (contribution: PagePaletteContribution | null) => void;
+    /** The snapshotted page contribution at the time the palette was opened, or null. */
+    contribution: PagePaletteContribution | null;
+}
+
+const PaletteContext = createContext<PaletteContextValue>({
+    open: false,
+    openPalette: () => {},
+    closePalette: () => {},
+    setPageContribution: () => {},
+    contribution: null,
+});
+
+interface PaletteProviderProps {
+    children: React.ReactNode;
+}
+
+/** Provides the global palette open state and page-contribution API. */
+export const PaletteProvider: React.FC<PaletteProviderProps> = ({ children }) => {
+    const [open, setOpen] = useState(false);
+    const contributionRef = useRef<PagePaletteContribution | null>(null);
+    const [activeContribution, setActiveContribution] = useState<PagePaletteContribution | null>(null);
+
+    usePaletteShortcut(open, setOpen);
+
+    const openPalette = useCallback(() => setOpen(true), []);
+    const closePalette = useCallback(() => setOpen(false), []);
+
+    // Writing the ref is always stable and never triggers a re-render, so pages
+    // whose memos produce a new identity on every render cannot cause a loop.
+    const setPageContribution = useCallback((c: PagePaletteContribution | null) => {
+        contributionRef.current = c;
+    }, []);
+
+    // Snapshot the live ref into state when the palette opens or closes so the
+    // rendered palette always sees a consistent contribution without any flash.
+    useLayoutEffect(() => {
+        setActiveContribution(open ? contributionRef.current : null);
+    }, [open]);
+
+    const value = useMemo((): PaletteContextValue => ({
+        open,
+        openPalette,
+        closePalette,
+        setPageContribution,
+        contribution: activeContribution,
+    }), [open, openPalette, closePalette, setPageContribution, activeContribution]);
+
+    return (
+        <PaletteContext.Provider value={value}>
+            {children}
+        </PaletteContext.Provider>
+    );
+};
+
+/** Access the global palette open state and page-contribution API. */
+export const usePalette = (): PaletteContextValue => useContext(PaletteContext);

--- a/web/src/pages/_shared/command-palette/command-palette.scss
+++ b/web/src/pages/_shared/command-palette/command-palette.scss
@@ -211,6 +211,17 @@
     font-family: var(--yn-font-mono);
 }
 
+.cp-group-label {
+    padding: 5px 10px 2px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--yn-text-3);
+    pointer-events: none;
+    user-select: none;
+}
+
 .cp-empty {
     padding: 20px;
     text-align: center;

--- a/web/src/pages/_shared/command-palette/index.ts
+++ b/web/src/pages/_shared/command-palette/index.ts
@@ -5,3 +5,6 @@ export { fuzzyMatch } from './fuzzy';
 export type { FuzzyMatchResult } from './fuzzy';
 export { default as CommandPaletteTrigger, PALETTE_SHORTCUT_LABEL } from './CommandPaletteTrigger';
 export { usePaletteShortcut } from './usePaletteShortcut';
+export { PaletteProvider, usePalette } from './PaletteContext';
+export type { PagePaletteContribution } from './PaletteContext';
+export { navigationCommands } from './navigationCommands';

--- a/web/src/pages/_shared/command-palette/navigationCommands.ts
+++ b/web/src/pages/_shared/command-palette/navigationCommands.ts
@@ -1,0 +1,23 @@
+import type { PageId } from '../../../types';
+import { navItems } from '../../../navItems';
+import type { Command } from './types';
+
+/** Builds "Go to" navigation commands from the shared navItems list. */
+export const navigationCommands = (onNavigate: (id: PageId) => void): Command[] => {
+    const titleCounts = new Map<string, number>();
+    for (const item of navItems) {
+        titleCounts.set(item.title, (titleCounts.get(item.title) ?? 0) + 1);
+    }
+    return navItems.map((item) => {
+        const isDuplicate = (titleCounts.get(item.title) ?? 0) > 1;
+        const label = isDuplicate ? `Go to ${item.title} (${item.section})` : `Go to ${item.title}`;
+        return {
+            id: `__nav_${item.id}`,
+            icon: '→',
+            label,
+            keywords: `go to navigate ${item.title} ${item.section}`,
+            group: 'Go to',
+            onSelect: () => onNavigate(item.id),
+        };
+    });
+};

--- a/web/src/pages/_shared/command-palette/types.ts
+++ b/web/src/pages/_shared/command-palette/types.ts
@@ -10,6 +10,8 @@ export interface Command {
     sub?: string;
     /** Extra text fed to fuzzy matching beyond label (not displayed). */
     keywords?: string;
+    /** Optional group label; consecutive items with the same group are visually grouped. */
+    group?: string;
     /** Called when the command is selected. */
     onSelect: () => void;
 }

--- a/web/src/pages/_shared/draft/useDraft.ts
+++ b/web/src/pages/_shared/draft/useDraft.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { toaster } from '../../../utils';
 import type { DraftState, DraftAction } from './draftReducer';
 
@@ -104,10 +104,10 @@ export function useDraft<T extends { id?: unknown }>({
         [state.dirty],
     );
 
-    const draftConfigs = [
-        ...state.serverConfigs,
-        ...state.localOnlyConfigs,
-    ];
+    const draftConfigs = useMemo(
+        () => [...state.serverConfigs, ...state.localOnlyConfigs],
+        [state.serverConfigs, state.localOnlyConfigs],
+    );
 
     const anyDirty = state.dirty.size > 0;
 

--- a/web/src/pages/_shared/useTabCycle.ts
+++ b/web/src/pages/_shared/useTabCycle.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { usePalette } from './command-palette';
+
+interface UseTabCycleOptions {
+    /** Ordered list of tab identifiers. */
+    tabs: string[];
+    /** Currently active tab. */
+    activeTab: string;
+    /** Called with the new tab identifier when the user cycles. */
+    onSelect: (tab: string) => void;
+    /** When false, the hook does nothing. Use to gate cycling on page readiness. */
+    enabled?: boolean;
+}
+
+/** Cycles config tabs with [ (prev) and ] (next) keys. No-ops when fewer than two tabs
+ * are registered, when the command palette is open, when a modal or drawer overlay is
+ * open (Gravity UI Dialog/Modal or the app's own yn-modal/yn-drawer variants), when a
+ * modifier key (Meta, Ctrl, Alt) is held, or when the event target is an input, textarea,
+ * or contentEditable element. */
+export const useTabCycle = ({ tabs, activeTab, onSelect, enabled = true }: UseTabCycleOptions): void => {
+    const { open: paletteOpen } = usePalette();
+
+    useEffect(() => {
+        if (!enabled || tabs.length < 2) return;
+
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if (e.key !== '[' && e.key !== ']') return;
+            if (paletteOpen) return;
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+            const target = e.target as HTMLElement;
+            if (
+                target.tagName === 'INPUT' ||
+                target.tagName === 'TEXTAREA' ||
+                target.isContentEditable
+            ) {
+                return;
+            }
+
+            if (document.querySelector('.g-modal, .yn-modal-backdrop, .yn-drawer--open')) {
+                return;
+            }
+
+            const currentIdx = tabs.indexOf(activeTab);
+            if (currentIdx === -1) return;
+
+            e.preventDefault();
+
+            if (e.key === '[') {
+                const prev = (currentIdx - 1 + tabs.length) % tabs.length;
+                onSelect(tabs[prev]);
+            } else {
+                const next = (currentIdx + 1) % tabs.length;
+                onSelect(tabs[next]);
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [tabs, activeTab, onSelect, enabled, paletteOpen]);
+};

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -19,6 +19,7 @@ import { SaveDiffModal } from './SaveDiffModal';
 import { useAclRuleCounters } from './useAclRuleCounters';
 import { AddConfigModal } from '../../_shared/draft';
 import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
+import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/draft-page.scss';
 import './acl.scss';
 
@@ -273,6 +274,13 @@ const AclPage: React.FC = () => {
     const handleTabSelect = useCallback((cfg: string): void => {
         updateParams({ [QP_CONFIG]: cfg || null });
     }, [updateParams]);
+
+    useTabCycle({
+        tabs: draftConfigs,
+        activeTab: currentConfig,
+        onSelect: handleTabSelect,
+        enabled: !loading,
+    });
 
     const handleSearchChange = useCallback((value: string): void => {
         updateParams({ [QP_SEARCH]: value || null });

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -16,6 +16,7 @@ import {
     DraftPageToolbar, useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers,
 } from '../../_shared/draft';
 import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
+import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/draft-page.scss';
 
 let idCounter = 0;
@@ -53,6 +54,13 @@ const DecapPage: React.FC = () => {
     }, [updateParams]);
 
     const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig))) ? queryConfig : (draftConfigs[0] || '');
+
+    useTabCycle({
+        tabs: draftConfigs,
+        activeTab: currentConfig,
+        onSelect: setActiveConfig,
+        enabled: !loading,
+    });
 
     useEffect(() => {
         const updates: Record<string, string | null> = {};

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -22,8 +22,9 @@ import { SaveDiffModal } from './SaveDiffModal';
 import { useForwardRuleCounters } from './useForwardRuleCounters';
 import { AddConfigModal } from '../../_shared/draft';
 import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
-import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
+import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
+import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/draft-page.scss';
 import './forward.scss';
 
@@ -57,7 +58,6 @@ const ForwardPage: React.FC = () => {
     const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
     const [deleteInFlightConfig, setDeleteInFlightConfig] = useState<string | null>(null);
     const [diffModalOpen, setDiffModalOpen] = useState(false);
-    const [paletteOpen, setPaletteOpen] = useState(false);
     const [modeFilter, setModeFilter] = useState<ModeFilterValue>('all');
     const [flashRowId, setFlashRowId] = useState<string | null>(null);
     const drawerRef = useRef<RuleDrawerHandle>(null);
@@ -238,12 +238,19 @@ const ForwardPage: React.FC = () => {
         setFlashRowId(null);
     }, [currentConfig]);
 
-    usePaletteShortcut(paletteOpen, setPaletteOpen);
+    const { openPalette, setPageContribution } = usePalette();
 
     usePageKeyboardShortcuts({
         onNewRule: openAdd,
         onEscape: closeDrawer,
         drawerOpen: drawer.open,
+    });
+
+    useTabCycle({
+        tabs: draftConfigs,
+        activeTab: currentConfig,
+        onSelect: handleTabSelect,
+        enabled: !loading,
     });
 
     const currentIsDirty = isDirty(currentConfig);
@@ -256,7 +263,7 @@ const ForwardPage: React.FC = () => {
                 label: 'Add rule',
                 sub: 'Open the add-rule drawer',
                 keywords: 'add rule insert new',
-                onSelect: () => { openAdd(); setPaletteOpen(false); },
+                onSelect: () => openAdd(),
             },
         ];
         if (currentIsDirty) {
@@ -266,7 +273,7 @@ const ForwardPage: React.FC = () => {
                 label: 'Save changes',
                 sub: 'Open the diff and save dialog',
                 keywords: 'save commit apply',
-                onSelect: () => { handleSavePress(); setPaletteOpen(false); },
+                onSelect: () => handleSavePress(),
             });
             list.push({
                 id: '__discard',
@@ -274,7 +281,7 @@ const ForwardPage: React.FC = () => {
                 label: 'Discard changes',
                 sub: 'Revert to the last saved state',
                 keywords: 'discard revert undo reset',
-                onSelect: () => { handleDiscard(); setPaletteOpen(false); },
+                onSelect: () => handleDiscard(),
             });
         }
         list.push({
@@ -283,7 +290,7 @@ const ForwardPage: React.FC = () => {
             label: 'Add config',
             sub: 'Create a new forward configuration',
             keywords: 'add config create new',
-            onSelect: () => { setAddConfigOpen(true); setPaletteOpen(false); },
+            onSelect: () => setAddConfigOpen(true),
         });
         if (currentConfig) {
             list.push({
@@ -292,7 +299,7 @@ const ForwardPage: React.FC = () => {
                 label: 'Delete config',
                 sub: `Delete "${currentConfig}"`,
                 keywords: 'delete remove config',
-                onSelect: () => { setDeleteConfigOpen(true); setPaletteOpen(false); },
+                onSelect: () => setDeleteConfigOpen(true),
             });
         }
         for (const cfg of draftConfigs) {
@@ -304,7 +311,7 @@ const ForwardPage: React.FC = () => {
                 label: `Switch to config ${name}`,
                 sub: dirtySet.has(name) ? 'unsaved changes' : undefined,
                 keywords: `switch config tab ${name}`,
-                onSelect: () => { handleTabSelect(name); setPaletteOpen(false); },
+                onSelect: () => handleTabSelect(name),
             });
         }
         list.push({
@@ -312,33 +319,33 @@ const ForwardPage: React.FC = () => {
             icon: '→',
             label: 'Filter: IN only',
             keywords: 'filter mode in direction',
-            onSelect: () => { setModeFilter('in'); setPaletteOpen(false); },
+            onSelect: () => setModeFilter('in'),
         });
         list.push({
             id: '__filter_out',
             icon: '→',
             label: 'Filter: OUT only',
             keywords: 'filter mode out direction',
-            onSelect: () => { setModeFilter('out'); setPaletteOpen(false); },
+            onSelect: () => setModeFilter('out'),
         });
         list.push({
             id: '__filter_none',
             icon: '→',
             label: 'Filter: NONE only',
             keywords: 'filter mode none direction',
-            onSelect: () => { setModeFilter('none'); setPaletteOpen(false); },
+            onSelect: () => setModeFilter('none'),
         });
         list.push({
             id: '__clear',
             icon: '✕',
             label: 'Clear filters',
             keywords: 'clear reset filter all',
-            onSelect: () => { setModeFilter('all'); handleSearchChange(''); setPaletteOpen(false); },
+            onSelect: () => { setModeFilter('all'); handleSearchChange(''); },
         });
         return list;
     }, [currentIsDirty, currentConfig, draftConfigs, dirtySet, handleTabSelect, openAdd, handleSavePress, handleDiscard, handleSearchChange]);
 
-    const rowAdapter: RowAdapter<RuleItem> = {
+    const rowAdapter = useMemo((): RowAdapter<RuleItem> => ({
         rows: allItems,
         getId: (it) => it.id,
         getLabel: (it) => it.target || '(no target)',
@@ -349,14 +356,23 @@ const ForwardPage: React.FC = () => {
             return parts.join(' · ');
         },
         searchText: (it) => [it.target, it.counter, ...it.deviceNames, ...it.sourceCidrs, ...it.dstCidrs].join(' '),
-        onSelect: (id) => { setModeFilter('all'); handleSearchChange(''); handleJumpToRow(id); setPaletteOpen(false); },
+        onSelect: (id) => { setModeFilter('all'); handleSearchChange(''); handleJumpToRow(id); },
         icon: '→',
-    };
+    }), [allItems, handleSearchChange, handleJumpToRow]);
+
+    useEffect(() => {
+        setPageContribution({
+            commands,
+            rowAdapter: rowAdapter as RowAdapter<unknown>,
+            placeholder: 'Search rules or run an action…',
+        });
+        return () => setPageContribution(null);
+    }, [commands, rowAdapter, setPageContribution]);
 
     const pageHeader = (
         <div className="page-header-bar">
             <Text variant="header-1">Forward</Text>
-            <CommandPaletteTrigger placeholder="Search rules or run an action…" onOpen={() => setPaletteOpen(true)} />
+            <CommandPaletteTrigger placeholder="Search rules or run an action…" onOpen={openPalette} />
             <div className="page-header-bar__actions">
                 <YamlIO
                     key={currentConfig || '__none'}
@@ -499,13 +515,6 @@ const ForwardPage: React.FC = () => {
                     />
                 )}
 
-                <CommandPalette<RuleItem>
-                    open={paletteOpen}
-                    onClose={() => setPaletteOpen(false)}
-                    placeholder="Search rules or run an action…"
-                    commands={commands}
-                    rowAdapter={rowAdapter}
-                />
             </div>
         </PageLayout>
     );

--- a/web/src/pages/modules/forward/useForwardDraft.ts
+++ b/web/src/pages/modules/forward/useForwardDraft.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { API } from '../../../api';
 import { toaster } from '../../../utils';
 import type { Rule } from '../../../api/forward';
@@ -166,10 +166,13 @@ export const useForwardDraft = (): UseForwardDraftResult => {
         state.dirty.has(configName), [state.dirty]);
 
     // Visible configs: server configs (minus pending deletes) plus local-only configs.
-    const draftConfigs = [
-        ...state.serverConfigs.filter(n => !state.pendingDeleteConfigs.has(n)),
-        ...state.localOnlyConfigs,
-    ];
+    const draftConfigs = useMemo(
+        () => [
+            ...state.serverConfigs.filter(n => !state.pendingDeleteConfigs.has(n)),
+            ...state.localOnlyConfigs,
+        ],
+        [state.serverConfigs, state.pendingDeleteConfigs, state.localOnlyConfigs],
+    );
 
     const anyDirty = state.dirty.size > 0;
 

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -27,6 +27,7 @@ import { formatBytes, toaster } from '../../../utils';
 import { AddConfigModal } from '../../_shared/draft';
 import { DeleteConfigModal } from '../../../components';
 import { SaveIcon, TrashIcon } from '../../_shared/draft/DraftActionButtons';
+import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/draft-page.scss';
 import './fwstate.scss';
 
@@ -1104,6 +1105,13 @@ const FWStatePage: React.FC = () => {
     const updateActiveConfig = useCallback((name: string): void => {
         updateParams({ [QP_CONFIG]: name || null });
     }, [updateParams]);
+
+    useTabCycle({
+        tabs: configNames,
+        activeTab: currentName,
+        onSelect: updateActiveConfig,
+        enabled: !loading,
+    });
 
     const updateActiveSubTab = useCallback((tab: StateSubTab): void => {
         updateParams({ [QP_TAB]: tab });

--- a/web/src/pages/modules/pdump/PdumpPage.tsx
+++ b/web/src/pages/modules/pdump/PdumpPage.tsx
@@ -17,6 +17,7 @@ import ConfigStrip from './ConfigStrip';
 import PacketDrawer from './PacketDrawer';
 import DeleteConfigDialog from './DeleteConfigDialog';
 import type { PdumpConfigInfo, CapturedPacket } from './types';
+import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/draft-page.scss';
 import './pdump.scss';
 
@@ -339,6 +340,13 @@ const PdumpPage: React.FC = () => {
     const handleSelectTab = useCallback((name: string) => {
         updateSearchParams({ [QP_CONFIG]: name || null });
     }, [updateSearchParams]);
+
+    useTabCycle({
+        tabs: configs.map((c) => c.name),
+        activeTab: currentConfig,
+        onSelect: handleSelectTab,
+        enabled: !loading,
+    });
 
     const handleOpenDeleteDialog = useCallback((configName: string) => {
         setDeletingConfigName(configName);

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -16,8 +16,9 @@ import {
     AddConfigModal, isValidCIDR, useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers,
 } from '../../_shared/draft';
 import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
-import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
+import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
+import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/draft-page.scss';
 import './route.scss';
 
@@ -44,8 +45,6 @@ const RoutePage: React.FC = () => {
     const [diffModalOpen, setDiffModalOpen] = useState(false);
     const [addConfigOpen, setAddConfigOpen] = useState(false);
     const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
-    const [paletteOpen, setPaletteOpen] = useState(false);
-
     const drawerRef = useRef<FIBDrawerHandle>(null);
     const dragDrop = useDraftDragDrop();
     const { handleDragLeave } = dragDrop;
@@ -142,7 +141,7 @@ const RoutePage: React.FC = () => {
         dragDrop,
     });
 
-    usePaletteShortcut(paletteOpen, setPaletteOpen);
+    const { openPalette, setPageContribution } = usePalette();
 
     const openAdd = useCallback((prefix = ''): void => {
         const newRow: FIBRowItem = { id: makeRowId(), prefix, dst_mac: '', src_mac: '', device: '' };
@@ -159,6 +158,13 @@ const RoutePage: React.FC = () => {
         setActiveConfig(cfg);
     }, [setActiveConfig]);
 
+    useTabCycle({
+        tabs: draftConfigs,
+        activeTab: currentConfig,
+        onSelect: handleConfigSelect,
+        enabled: !loading,
+    });
+
     useDraftShortcuts({
         rows: rawRows, activeRowId, setActiveRowId, editingRowId, setEditingRowId,
         onDeleteRow: handlers.handleDeleteRow,
@@ -171,7 +177,7 @@ const RoutePage: React.FC = () => {
                 icon: '+',
                 label: 'Add route',
                 keywords: 'add route insert new',
-                onSelect: () => { openAdd(); setPaletteOpen(false); },
+                onSelect: () => openAdd(),
             },
         ];
         if (currentIsDirty) {
@@ -179,20 +185,20 @@ const RoutePage: React.FC = () => {
                 id: '__save',
                 icon: '✓',
                 label: 'Save changes',
-                onSelect: () => { handlers.handleCommitPress(); setPaletteOpen(false); },
+                onSelect: () => handlers.handleCommitPress(),
             });
             list.push({
                 id: '__discard',
                 icon: '⟲',
                 label: 'Discard changes',
-                onSelect: () => { handlers.handleDiscard(); setPaletteOpen(false); },
+                onSelect: () => handlers.handleDiscard(),
             });
         }
         list.push({
             id: '__add_config',
             icon: '▤',
             label: 'Add config',
-            onSelect: () => { setAddConfigOpen(true); setPaletteOpen(false); },
+            onSelect: () => setAddConfigOpen(true),
         });
         if (currentConfig) {
             list.push({
@@ -200,7 +206,7 @@ const RoutePage: React.FC = () => {
                 icon: '✕',
                 label: 'Delete config',
                 sub: `Delete "${currentConfig}"`,
-                onSelect: () => { setDeleteConfigOpen(true); setPaletteOpen(false); },
+                onSelect: () => setDeleteConfigOpen(true),
             });
         }
         for (const cfg of draftConfigs) {
@@ -212,7 +218,7 @@ const RoutePage: React.FC = () => {
                 label: `Switch to config ${name}`,
                 sub: dirtySet.has(name) ? 'unsaved changes' : undefined,
                 keywords: `switch config tab ${name}`,
-                onSelect: () => { handleConfigSelect(name); setPaletteOpen(false); },
+                onSelect: () => handleConfigSelect(name),
             });
         }
         if (search) {
@@ -221,7 +227,7 @@ const RoutePage: React.FC = () => {
                 icon: '✕',
                 label: 'Clear search',
                 keywords: 'clear reset search',
-                onSelect: () => { handleSearchChange(''); setPaletteOpen(false); },
+                onSelect: () => handleSearchChange(''),
             });
         }
         return list;
@@ -235,28 +241,38 @@ const RoutePage: React.FC = () => {
                     icon: '⌖',
                     label: `Add route for ${q.trim()}`,
                     sub: 'Pre-fill a new route with this prefix',
-                    onSelect: () => { openAdd(q.trim()); setPaletteOpen(false); },
+                    onSelect: () => openAdd(q.trim()),
                 },
             ];
         }
         return [];
     }, [openAdd]);
 
-    const rowAdapter: RowAdapter<FIBRowItem> = {
+    const rowAdapter = useMemo((): RowAdapter<FIBRowItem> => ({
         rows: rawRows,
         getId: (r) => r.id,
         getLabel: (r) => r.prefix || '(no prefix)',
         getSub: (r) => `${r.dst_mac || '—'} · ${r.device || '—'}`,
         searchText: (r) => [r.prefix, r.dst_mac, r.src_mac, r.device].join(' '),
-        onSelect: (id) => { setActiveRowId(id); setEditingRowId(id); setPaletteOpen(false); },
+        onSelect: (id) => { setActiveRowId(id); setEditingRowId(id); },
         icon: '→',
         max: 7,
-    };
+    }), [rawRows]);
+
+    useEffect(() => {
+        setPageContribution({
+            commands,
+            dynamicCommands,
+            rowAdapter: rowAdapter as RowAdapter<unknown>,
+            placeholder: 'Search routes or run an action…',
+        });
+        return () => setPageContribution(null);
+    }, [commands, dynamicCommands, rowAdapter, setPageContribution]);
 
     const pageHeader = (
         <div className="page-header-bar">
             <Text variant="header-1">Route FIB</Text>
-            <CommandPaletteTrigger placeholder="Search routes or run an action…" onOpen={() => setPaletteOpen(true)} />
+            <CommandPaletteTrigger placeholder="Search routes or run an action…" onOpen={openPalette} />
             <div className="page-header-bar__actions">
                 <FIBYamlIO
                     key={currentConfig || '__none'}
@@ -366,14 +382,6 @@ const RoutePage: React.FC = () => {
 
                 <DeleteConfigModal open={deleteConfigOpen} configName={currentConfig} onClose={() => setDeleteConfigOpen(false)} onConfirm={handlers.handleDeleteConfig} />
 
-                <CommandPalette<FIBRowItem>
-                    open={paletteOpen}
-                    onClose={() => setPaletteOpen(false)}
-                    placeholder="Search routes or run an action…"
-                    commands={commands}
-                    dynamicCommands={dynamicCommands}
-                    rowAdapter={rowAdapter}
-                />
             </div>
         </PageLayout>
     );

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,12 +1,13 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { Plus, Layers } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar } from '../../../components';
 import { BulkDeleteModal, DeleteConfigModal } from '../../../components';
-import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
+import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
+import { useTabCycle } from '../../_shared/useTabCycle';
 import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
 import { parseIPAddress } from '../../../utils';
 import type { Neighbour, NeighbourTableInfo } from '../../../api/neighbours';
@@ -64,7 +65,6 @@ const NeighboursPage: React.FC = () => {
     const stateFilter = parseStateFilter(searchParams);
 
     const [paused, setPaused] = useState(false);
-    const [paletteOpen, setPaletteOpen] = useState(false);
     const [flashRowId, setFlashRowId] = useState<string | null>(null);
 
     const {
@@ -103,7 +103,7 @@ const NeighboursPage: React.FC = () => {
 
     const tabsList = [MERGED_TAB, ...tables.map((t) => t.name || '').filter(Boolean)];
 
-    usePaletteShortcut(paletteOpen, setPaletteOpen);
+    const { openPalette, setPageContribution } = usePalette();
 
     const { updateParams } = useSearchParamHelpers(setSearchParams);
 
@@ -114,6 +114,13 @@ const NeighboursPage: React.FC = () => {
         setPanel((prev) => ({ ...prev, open: false }));
         fetchTab(tab).catch(() => {});
     }, [updateParams, fetchTab]);
+
+    useTabCycle({
+        tabs: tabsList,
+        activeTab,
+        onSelect: handleTabSelect,
+        enabled: !loading,
+    });
 
     const handleSort = useCallback((col: SortableColumn): void => {
         const newDirection: SortState['direction'] =
@@ -283,7 +290,7 @@ const NeighboursPage: React.FC = () => {
                 label: 'Add neighbour',
                 sub: 'Open the add-neighbour panel',
                 keywords: 'add neighbour create new',
-                onSelect: () => { openAdd(); setPaletteOpen(false); },
+                onSelect: () => { openAdd(); },
             });
         }
 
@@ -293,7 +300,7 @@ const NeighboursPage: React.FC = () => {
             label: 'Add table',
             sub: 'Create a new neighbour table',
             keywords: 'add table create new',
-            onSelect: () => { setCreateTableOpen(true); setPaletteOpen(false); },
+            onSelect: () => { setCreateTableOpen(true); },
         });
 
         if (canEditTable) {
@@ -303,7 +310,7 @@ const NeighboursPage: React.FC = () => {
                 label: 'Edit current table',
                 sub: activeTableInfo?.name,
                 keywords: 'edit table settings priority',
-                onSelect: () => { setEditTableOpen(true); setPaletteOpen(false); },
+                onSelect: () => { setEditTableOpen(true); },
             });
         }
 
@@ -314,7 +321,7 @@ const NeighboursPage: React.FC = () => {
                 label: 'Delete current table',
                 sub: activeTableInfo?.name,
                 keywords: 'delete remove table',
-                onSelect: () => { setDeleteTableOpen(true); setPaletteOpen(false); },
+                onSelect: () => { setDeleteTableOpen(true); },
             });
         }
 
@@ -324,7 +331,7 @@ const NeighboursPage: React.FC = () => {
                 icon: '⊕',
                 label: 'Switch to Merged view',
                 keywords: 'merged view all tables',
-                onSelect: () => { handleTabSelect(MERGED_TAB); setPaletteOpen(false); },
+                onSelect: () => { handleTabSelect(MERGED_TAB); },
             });
         }
 
@@ -336,7 +343,7 @@ const NeighboursPage: React.FC = () => {
                 icon: '⇥',
                 label: `Switch to table ${name}`,
                 keywords: `switch table ${name}`,
-                onSelect: () => { handleTabSelect(name); setPaletteOpen(false); },
+                onSelect: () => { handleTabSelect(name); },
             });
         }
 
@@ -345,7 +352,7 @@ const NeighboursPage: React.FC = () => {
             icon: '4',
             label: 'Filter IPv4 only',
             keywords: 'ipv4 filter family',
-            onSelect: () => { updateParams({ [QP_FAMILY]: 'v4' }); setPaletteOpen(false); },
+            onSelect: () => { updateParams({ [QP_FAMILY]: 'v4' }); },
         });
 
         cmds.push({
@@ -353,7 +360,7 @@ const NeighboursPage: React.FC = () => {
             icon: '6',
             label: 'Filter IPv6 only',
             keywords: 'ipv6 filter family',
-            onSelect: () => { updateParams({ [QP_FAMILY]: 'v6' }); setPaletteOpen(false); },
+            onSelect: () => { updateParams({ [QP_FAMILY]: 'v6' }); },
         });
 
         cmds.push({
@@ -361,7 +368,7 @@ const NeighboursPage: React.FC = () => {
             icon: '✕',
             label: 'Clear filters',
             keywords: 'clear reset filters all',
-            onSelect: () => { updateParams({ [QP_FAMILY]: null, [QP_STATE]: null }); setPaletteOpen(false); },
+            onSelect: () => { updateParams({ [QP_FAMILY]: null, [QP_STATE]: null }); },
         });
 
         for (const stateName of distinctStates) {
@@ -371,7 +378,7 @@ const NeighboursPage: React.FC = () => {
                 icon: '◉',
                 label: `Filter state: ${sn}`,
                 keywords: `filter state nud ${sn.toLowerCase()}`,
-                onSelect: () => { updateParams({ [QP_STATE]: sn }); setPaletteOpen(false); },
+                onSelect: () => { updateParams({ [QP_STATE]: sn }); },
             });
         }
 
@@ -381,7 +388,7 @@ const NeighboursPage: React.FC = () => {
                 icon: '✕',
                 label: 'Clear state filter',
                 keywords: 'clear state filter nud',
-                onSelect: () => { updateParams({ [QP_STATE]: null }); setPaletteOpen(false); },
+                onSelect: () => { updateParams({ [QP_STATE]: null }); },
             });
         }
 
@@ -390,7 +397,7 @@ const NeighboursPage: React.FC = () => {
             icon: '⟳',
             label: 'Refresh now',
             keywords: 'refresh reload update now',
-            onSelect: () => { refreshNow().catch(() => {}); setPaletteOpen(false); },
+            onSelect: () => { refreshNow().catch(() => {}); },
         });
 
         cmds.push({
@@ -398,7 +405,7 @@ const NeighboursPage: React.FC = () => {
             icon: paused ? '▶' : '⏸',
             label: paused ? 'Resume auto-refresh' : 'Pause auto-refresh',
             keywords: 'pause resume auto refresh toggle',
-            onSelect: () => { setPaused((v) => !v); setPaletteOpen(false); },
+            onSelect: () => { setPaused((v) => !v); },
         });
 
         if (selectedIds.size > 0 && !isMergedView) {
@@ -408,7 +415,7 @@ const NeighboursPage: React.FC = () => {
                 label: 'Delete selected neighbours',
                 sub: `${selectedIds.size} selected`,
                 keywords: 'delete remove selected bulk',
-                onSelect: () => { setBulkRemoveOpen(true); setPaletteOpen(false); },
+                onSelect: () => { setBulkRemoveOpen(true); },
             });
 
             cmds.push({
@@ -416,7 +423,7 @@ const NeighboursPage: React.FC = () => {
                 icon: '☐',
                 label: 'Clear selection',
                 keywords: 'clear deselect selection',
-                onSelect: () => { setSelectedIds(new Set()); setPaletteOpen(false); },
+                onSelect: () => { setSelectedIds(new Set()); },
             });
         }
 
@@ -450,7 +457,7 @@ const NeighboursPage: React.FC = () => {
                     icon: '⌖',
                     label: `Jump to ${ip}`,
                     sub: 'Scroll to this neighbour in the table',
-                    onSelect: () => { handleJumpToRow(id); setPaletteOpen(false); },
+                    onSelect: () => { handleJumpToRow(id); },
                 },
             ];
         }
@@ -466,29 +473,38 @@ const NeighboursPage: React.FC = () => {
                     if (wire) {
                         setPanel({ open: true, mode: 'add', neighbour: { next_hop: wire } });
                     }
-                    setPaletteOpen(false);
                 },
             },
         ];
     }, [allRows, handleJumpToRow, tables.length]);
 
-    const neighbourRowAdapter: RowAdapter<Neighbour> = {
+    const neighbourRowAdapter = useMemo((): RowAdapter<Neighbour> => ({
         rows: allRows,
         getId: getNeighbourId,
         getLabel: (n) => ipAddressToString(n.next_hop) || '—',
         getSub: (n) => [n.device, n.source, nudStateToName(n.state)].filter(Boolean).join(' · '),
         searchText: (n) => ipAddressToString(n.next_hop) + ' ' + (n.device || '') + ' ' + (n.source || ''),
-        onSelect: (id) => { handleJumpToRow(id); setPaletteOpen(false); },
+        onSelect: (id) => handleJumpToRow(id),
         icon: '→',
         max: 7,
-    };
+    }), [allRows, handleJumpToRow]);
+
+    useEffect(() => {
+        setPageContribution({
+            commands: neighbourCommands,
+            dynamicCommands: neighbourDynamicCommands,
+            rowAdapter: neighbourRowAdapter as RowAdapter<unknown>,
+            placeholder: 'Search neighbours or type an IP…',
+        });
+        return () => setPageContribution(null);
+    }, [neighbourCommands, neighbourDynamicCommands, neighbourRowAdapter, setPageContribution]);
 
     const searchActive = family !== 'all' || !!stateFilter;
 
     const pageHeader = (
         <div className="page-header-bar">
             <Text variant="header-1">Neighbours</Text>
-            <CommandPaletteTrigger placeholder="Search neighbours or type an IP…" onOpen={() => setPaletteOpen(true)} />
+            <CommandPaletteTrigger placeholder="Search neighbours or type an IP…" onOpen={openPalette} />
             <div className="page-header-bar__actions">
                 <Button view="outlined" onClick={() => setCreateTableOpen(true)}>
                     <Icon data={Plus} size={16} />
@@ -684,14 +700,6 @@ const NeighboursPage: React.FC = () => {
                     tableInfo={activeTableInfo}
                 />
 
-                <CommandPalette<Neighbour>
-                    open={paletteOpen}
-                    onClose={() => setPaletteOpen(false)}
-                    placeholder="Search neighbours or type an IP…"
-                    commands={neighbourCommands}
-                    dynamicCommands={neighbourDynamicCommands}
-                    rowAdapter={neighbourRowAdapter}
-                />
             </div>
         </PageLayout>
     );

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,11 +1,12 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Icon, Text } from '@gravity-ui/uikit';
 import { ArrowRightToLine, Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput } from '../../../components';
 import { AddConfigModal } from '../../_shared/draft';
 import { BulkDeleteModal } from '../../../components';
-import { CommandPalette, CommandPaletteTrigger, usePaletteShortcut } from '../../_shared/command-palette';
+import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
+import { useTabCycle } from '../../_shared/useTabCycle';
 import { API } from '../../../api';
 import { toaster, parseIPAddress } from '../../../utils';
 import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
@@ -38,7 +39,6 @@ const RoutePage: React.FC = () => {
         route: null,
     });
 
-    const [paletteOpen, setPaletteOpen] = useState(false);
     const [lookupOpen, setLookupOpen] = useState(false);
     const [lookupInitialQuery, setLookupInitialQuery] = useState('');
     const [family, setFamily] = useState<IPFamily>('all');
@@ -97,7 +97,14 @@ const RoutePage: React.FC = () => {
         return m;
     }, [configs, configRoutes]);
 
-    usePaletteShortcut(paletteOpen, setPaletteOpen);
+    const { openPalette, setPageContribution } = usePalette();
+
+    useTabCycle({
+        tabs: configs,
+        activeTab: currentConfig,
+        onSelect: setActiveConfig,
+        enabled: !loading,
+    });
 
     const handleSort = useCallback((col: RouteSortableColumn): void => {
         setSortState((prev) => {
@@ -276,14 +283,14 @@ const RoutePage: React.FC = () => {
         setTimeout(() => setFlashRowId(id), 0);
     }, []);
 
-    const routeCommands: Command[] = [
+    const routeCommands = useMemo((): Command[] => [
         {
             id: '__add',
             icon: '+',
             label: 'Add route',
             sub: 'Open the add-route drawer',
             keywords: 'add route insert',
-            onSelect: () => { openAdd(); setPaletteOpen(false); },
+            onSelect: () => openAdd(),
         },
         {
             id: '__flush',
@@ -291,7 +298,7 @@ const RoutePage: React.FC = () => {
             label: 'Flush RIB → FIB',
             sub: 'Push best routes to the dataplane',
             keywords: 'flush rib fib push',
-            onSelect: () => { handleFlush(); setPaletteOpen(false); },
+            onSelect: () => handleFlush(),
         },
         {
             id: '__open_lookup',
@@ -299,14 +306,14 @@ const RoutePage: React.FC = () => {
             label: 'Open Route Lookup',
             sub: 'Look up an IP address in the RIB',
             keywords: 'route lookup ip search',
-            onSelect: () => { setLookupInitialQuery(''); setLookupOpen(true); setPaletteOpen(false); },
+            onSelect: () => { setLookupInitialQuery(''); setLookupOpen(true); },
         },
         {
             id: '__best_only',
             icon: '★',
             label: 'Show best paths only',
             keywords: 'best paths only filter',
-            onSelect: () => { setBestOnly((v) => !v); setPaletteOpen(false); },
+            onSelect: () => setBestOnly((v) => !v),
         },
         {
             id: '__conflicts',
@@ -314,30 +321,30 @@ const RoutePage: React.FC = () => {
             label: 'Show conflicts only',
             sub: 'Prefixes with more than one candidate route',
             keywords: 'conflicts duplicate prefix',
-            onSelect: () => { setConflictsOnly((v) => !v); setPaletteOpen(false); },
+            onSelect: () => setConflictsOnly((v) => !v),
         },
         {
             id: '__v6',
             icon: '6',
             label: 'Filter IPv6 only',
             keywords: 'ipv6 filter family',
-            onSelect: () => { setFamily('v6'); setPaletteOpen(false); },
+            onSelect: () => setFamily('v6'),
         },
         {
             id: '__v4',
             icon: '4',
             label: 'Filter IPv4 only',
             keywords: 'ipv4 filter family',
-            onSelect: () => { setFamily('v4'); setPaletteOpen(false); },
+            onSelect: () => setFamily('v4'),
         },
         {
             id: '__clear',
             icon: '✕',
             label: 'Clear filters',
             keywords: 'clear reset filters all',
-            onSelect: () => { handleClearFilters(); setPaletteOpen(false); },
+            onSelect: () => handleClearFilters(),
         },
-    ];
+    ], [openAdd, handleFlush, handleClearFilters]);
 
     const routeDynamicCommands = useCallback((q: string): Command[] => {
         if (!parseIPAddress(q.trim()).ok) return [];
@@ -348,26 +355,36 @@ const RoutePage: React.FC = () => {
                 icon: '⌖',
                 label: `Look up ${ip}`,
                 sub: 'Route Lookup — longest prefix match',
-                onSelect: () => { handleLookupIP(ip); setPaletteOpen(false); },
+                onSelect: () => handleLookupIP(ip),
             },
         ];
     }, [handleLookupIP]);
 
-    const routeRowAdapter: RowAdapter<Route> = {
+    const routeRowAdapter = useMemo((): RowAdapter<Route> => ({
         rows: allRows,
         getId: getRouteId,
         getLabel: (r) => r.prefix || '(no prefix)',
         getSub: (r) => ipAddressToString(r.next_hop) || '—',
         searchText: (r) => (r.prefix || '') + ' ' + ipAddressToString(r.next_hop),
-        onSelect: (id) => { handleJumpToRow(id); setPaletteOpen(false); },
+        onSelect: (id) => handleJumpToRow(id),
         icon: '→',
         max: 7,
-    };
+    }), [allRows, handleJumpToRow]);
+
+    useEffect(() => {
+        setPageContribution({
+            commands: routeCommands,
+            dynamicCommands: routeDynamicCommands,
+            rowAdapter: routeRowAdapter as RowAdapter<unknown>,
+            placeholder: 'Search routes, prefixes, or type an IP…',
+        });
+        return () => setPageContribution(null);
+    }, [routeCommands, routeDynamicCommands, routeRowAdapter, setPageContribution]);
 
     const pageHeader = (
         <div className="page-header-bar">
             <Text variant="header-1">Routing Table</Text>
-            <CommandPaletteTrigger placeholder="Search or look up an IP…" onOpen={() => setPaletteOpen(true)} />
+            <CommandPaletteTrigger placeholder="Search or look up an IP…" onOpen={openPalette} />
             <div className="page-header-bar__actions">
                 <Button view="outlined" onClick={handleFlush} disabled={!currentConfig}>
                     <Icon data={ArrowRightToLine} size={16} />
@@ -522,15 +539,6 @@ const RoutePage: React.FC = () => {
                     title="Add route config"
                     placeholder="e.g. route0"
                     existingNames={configs}
-                />
-
-                <CommandPalette<Route>
-                    open={paletteOpen}
-                    onClose={() => setPaletteOpen(false)}
-                    placeholder="Search routes, prefixes, or type an IP…"
-                    commands={routeCommands}
-                    dynamicCommands={routeDynamicCommands}
-                    rowAdapter={routeRowAdapter}
                 />
 
                 <LookupDrawer


### PR DESCRIPTION
Makes the web UI fully keyboard-navigable through a single global command palette.

- Mounts one command palette at the app level so ⌘K/Ctrl+K works on every page, including pages that previously had none.
- Adds a "Go to" section for jumping between pages; entries with duplicate titles are disambiguated by section (e.g. Route under Modules vs Operators).
- Lets each page register its own actions and row search; page actions are listed above the navigation section in both the default list and search results.
- Routes palette navigation through the existing unsaved-changes guard.
- Adds bracket-key cycling of config tabs on pages that have a config tab strip, guarded against text inputs and open modals/drawers.
- Derives the sidebar and the navigation commands from a single source of page definitions to avoid drift.
