### PR TITLE
refactor(web): extract shared CommandPaletteHeader component

### DIFF
--- a/web/src/components/CommandPaletteHeader.scss
+++ b/web/src/components/CommandPaletteHeader.scss
@@ -1,0 +1,21 @@
+.page-header-bar {
+    --cp-max: 520px;
+    --hdr-gap: 16px;
+    display: grid;
+    grid-template-columns:
+        minmax(min-content, calc(50% - var(--cp-max) / 2 - var(--gn-aside-header-size, 56px) / 2 - var(--hdr-gap)))
+        minmax(0, var(--cp-max))
+        minmax(min-content, 1fr);
+    align-items: center;
+    gap: var(--hdr-gap);
+    width: 100%;
+    min-width: 0;
+}
+
+.page-header-bar__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--hdr-gap);
+    justify-content: flex-end;
+    min-width: 0;
+}

--- a/web/src/components/CommandPaletteHeader.tsx
+++ b/web/src/components/CommandPaletteHeader.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Text } from '@gravity-ui/uikit';
+import { CommandPaletteTrigger, usePalette } from '../pages/_shared/command-palette';
+import './CommandPaletteHeader.scss';
+
+interface CommandPaletteHeaderProps {
+    /** Page title shown in the left column. */
+    title: React.ReactNode;
+    /** Placeholder text for the command-palette trigger pill. */
+    placeholder: string;
+    /** Optional right-aligned action controls. */
+    actions?: React.ReactNode;
+}
+
+/** Standard page header: title, centered command-palette trigger, and actions.
+ *
+ * Wraps the shared `page-header-bar` grid and wires the trigger to the global
+ * palette via usePalette, so every page renders the trigger in the identical
+ * centered position without duplicating the markup or the open handler.
+ */
+const CommandPaletteHeader: React.FC<CommandPaletteHeaderProps> = ({ title, placeholder, actions }) => {
+    const { openPalette } = usePalette();
+    return (
+        <div className="page-header-bar">
+            <Text variant="header-1">{title}</Text>
+            <CommandPaletteTrigger placeholder={placeholder} onOpen={openPalette} />
+            <div className="page-header-bar__actions">{actions}</div>
+        </div>
+    );
+};
+
+export default CommandPaletteHeader;

--- a/web/src/components/common.scss
+++ b/web/src/components/common.scss
@@ -33,29 +33,6 @@
     flex: initial;
 }
 
-/* Page header 3-column grid: title | search pill (centered) | actions */
-.page-header-bar {
-    --cp-max: 520px;
-    --hdr-gap: 16px;
-    display: grid;
-    grid-template-columns:
-        minmax(min-content, calc(50% - var(--cp-max) / 2 - var(--gn-aside-header-size, 56px) / 2 - var(--hdr-gap)))
-        minmax(0, var(--cp-max))
-        minmax(min-content, 1fr);
-    align-items: center;
-    gap: var(--hdr-gap);
-    width: 100%;
-    min-width: 0;
-}
-
-.page-header-bar__actions {
-    display: flex;
-    align-items: center;
-    gap: var(--hdr-gap);
-    justify-content: flex-end;
-    min-width: 0;
-}
-
 /* PageLayout */
 .page-layout {
     flex: 1;

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -58,3 +58,4 @@ export { default as DeleteConfigModal } from './DeleteConfigModal';
 export { default as BulkDeleteModal } from './BulkDeleteModal';
 export { useChipInput, Chip } from './chip-input';
 export type { ChipKind, ChipInputProps, ChipInputHandle } from './chip-input';
+export { default as CommandPaletteHeader } from './CommandPaletteHeader';

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
-import { Button, Icon, Label, Text } from '@gravity-ui/uikit';
+import { Button, Icon, Label } from '@gravity-ui/uikit';
 import { Funnel, Pause, Play, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
@@ -18,8 +18,8 @@ import YamlIO, { type ImportMode } from './YamlIO';
 import { SaveDiffModal } from './SaveDiffModal';
 import { useAclRuleCounters } from './useAclRuleCounters';
 import { AddConfigModal } from '../../_shared/draft';
-import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
-import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
+import { DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
+import { usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/draft-page.scss';
@@ -313,7 +313,7 @@ const AclPage: React.FC = () => {
 
     const currentIsDirty = isDirty(currentConfig);
 
-    const { openPalette, setPageContribution } = usePalette();
+    const { setPageContribution } = usePalette();
 
     const commands = useMemo((): Command[] => {
         const list: Command[] = [];
@@ -438,10 +438,10 @@ const AclPage: React.FC = () => {
         )), [rawRules]);
 
     const pageHeader = (
-        <div className="page-header-bar">
-            <Text variant="header-1">ACL</Text>
-            <CommandPaletteTrigger placeholder="Search rules or run an action…" onOpen={openPalette} />
-            <div className="page-header-bar__actions">
+        <CommandPaletteHeader
+            title="ACL"
+            placeholder="Search rules or run an action…"
+            actions={<>
                 {enabledCounterNames.size > 0 && (
                     <Button
                         view="outlined"
@@ -457,8 +457,8 @@ const AclPage: React.FC = () => {
                     <Icon data={Plus} size={16} />
                     Add Rule
                 </Button>
-            </div>
-        </div>
+            </>}
+        />
     );
 
     if (loading) {

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Button, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Icon } from '@gravity-ui/uikit';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { useSearchParamHelpers } from '../../../hooks';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder, SearchInput } from '../../../components';
@@ -16,9 +16,9 @@ import {
     AddConfigModal,
     useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers,
 } from '../../_shared/draft';
-import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
+import { DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { useTabCycle } from '../../_shared/useTabCycle';
-import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
+import { usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import '../../../styles/draft-page.scss';
 import './decap.scss';
@@ -92,7 +92,7 @@ const DecapPage: React.FC = () => {
         handleDragLeave();
     }, [currentConfig, handleDragLeave]);
 
-    const { openPalette, setPageContribution } = usePalette();
+    const { setPageContribution } = usePalette();
 
     const rawRows: PrefixRowItem[] = draftRows(currentConfig);
     const rawServerRows: PrefixRowItem[] = serverRows(currentConfig);
@@ -252,17 +252,17 @@ const DecapPage: React.FC = () => {
     }, [commands, rowAdapter, setPageContribution]);
 
     const pageHeader = (
-        <div className="page-header-bar">
-            <Text variant="header-1">Decap</Text>
-            <CommandPaletteTrigger placeholder="Search prefixes or run an action…" onOpen={openPalette} />
-            <div className="page-header-bar__actions">
+        <CommandPaletteHeader
+            title="Decap"
+            placeholder="Search prefixes or run an action…"
+            actions={<>
                 <PrefixYamlIO key={currentConfig || '__none'} configName={currentConfig} rows={rawRows} onImport={handlers.handleImportYaml} disabled={!currentConfig} />
                 <Button view="action" onClick={openAdd}>
                     <Icon data={Plus} size={16} />
                     Add Prefix
                 </Button>
-            </div>
-        </div>
+            </>}
+        />
     );
 
     if (loading) return <PageLayout header={pageHeader} className="yn-flat-layout"><PageLoader loading size="l" /></PageLayout>;

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Button, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
@@ -21,8 +21,8 @@ import YamlIO from './YamlIO';
 import { SaveDiffModal } from './SaveDiffModal';
 import { useForwardRuleCounters } from './useForwardRuleCounters';
 import { AddConfigModal } from '../../_shared/draft';
-import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
-import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
+import { DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
+import { usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/draft-page.scss';
@@ -238,7 +238,7 @@ const ForwardPage: React.FC = () => {
         setFlashRowId(null);
     }, [currentConfig]);
 
-    const { openPalette, setPageContribution } = usePalette();
+    const { setPageContribution } = usePalette();
 
     usePageKeyboardShortcuts({
         onNewRule: openAdd,
@@ -370,10 +370,10 @@ const ForwardPage: React.FC = () => {
     }, [commands, rowAdapter, setPageContribution]);
 
     const pageHeader = (
-        <div className="page-header-bar">
-            <Text variant="header-1">Forward</Text>
-            <CommandPaletteTrigger placeholder="Search rules or run an action…" onOpen={openPalette} />
-            <div className="page-header-bar__actions">
+        <CommandPaletteHeader
+            title="Forward"
+            placeholder="Search rules or run an action…"
+            actions={<>
                 <YamlIO
                     key={currentConfig || '__none'}
                     configName={currentConfig}
@@ -385,8 +385,8 @@ const ForwardPage: React.FC = () => {
                     <Icon data={Plus} size={16} />
                     Add Rule
                 </Button>
-            </div>
-        </div>
+            </>}
+        />
     );
 
     if (loading) {

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -24,10 +24,10 @@ import { ipAddressToString, isValidIPAddress, parseIPToBytes, stringToIPAddress,
 import { parseMACToBytes } from '../../../utils/mac';
 import { formatBytes, toaster } from '../../../utils';
 import { AddConfigModal } from '../../_shared/draft';
-import { DeleteConfigModal } from '../../../components';
+import { DeleteConfigModal, CommandPaletteHeader } from '../../../components';
 import { SaveIcon, TrashIcon } from '../../_shared/draft/DraftActionButtons';
 import { useTabCycle } from '../../_shared/useTabCycle';
-import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
+import { usePalette } from '../../_shared/command-palette';
 import type { Command } from '../../_shared/command-palette';
 import '../../../styles/draft-page.scss';
 import './fwstate.scss';
@@ -1114,7 +1114,7 @@ const FWStatePage: React.FC = () => {
         enabled: !loading,
     });
 
-    const { openPalette, setPageContribution } = usePalette();
+    const { setPageContribution } = usePalette();
 
     const updateActiveSubTab = useCallback((tab: StateSubTab): void => {
         updateParams({ [QP_TAB]: tab });
@@ -1581,16 +1581,16 @@ const FWStatePage: React.FC = () => {
     ) : null;
 
     const pageHeader = (
-        <div className="page-header-bar">
-            <Text variant="header-1">FWState</Text>
-            <CommandPaletteTrigger placeholder="Search FWState actions…" onOpen={openPalette} />
-            <div className="page-header-bar__actions">
+        <CommandPaletteHeader
+            title="FWState"
+            placeholder="Search FWState actions…"
+            actions={<>
                 <Button view="action" onClick={() => setAddConfigOpen(true)}>
                     <Icon data={Plus} size={16} />
                     Add Config
                 </Button>
-            </div>
-        </div>
+            </>}
+        />
     );
 
     if (loading) {

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Button, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
@@ -15,8 +15,8 @@ import { FIBSaveDiffModal } from './FIBSaveDiffModal';
 import {
     AddConfigModal, isValidCIDR, useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers,
 } from '../../_shared/draft';
-import { DeleteConfigModal, BulkDeleteModal } from '../../../components';
-import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
+import { DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
+import { usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/draft-page.scss';
@@ -141,7 +141,7 @@ const RoutePage: React.FC = () => {
         dragDrop,
     });
 
-    const { openPalette, setPageContribution } = usePalette();
+    const { setPageContribution } = usePalette();
 
     const openAdd = useCallback((prefix = ''): void => {
         const newRow: FIBRowItem = { id: makeRowId(), prefix, dst_mac: '', src_mac: '', device: '' };
@@ -270,10 +270,10 @@ const RoutePage: React.FC = () => {
     }, [commands, dynamicCommands, rowAdapter, setPageContribution]);
 
     const pageHeader = (
-        <div className="page-header-bar">
-            <Text variant="header-1">Route FIB</Text>
-            <CommandPaletteTrigger placeholder="Search routes or run an action…" onOpen={openPalette} />
-            <div className="page-header-bar__actions">
+        <CommandPaletteHeader
+            title="Route FIB"
+            placeholder="Search routes or run an action…"
+            actions={<>
                 <FIBYamlIO
                     key={currentConfig || '__none'}
                     configName={currentConfig}
@@ -285,8 +285,8 @@ const RoutePage: React.FC = () => {
                     <Icon data={Plus} size={16} />
                     Add Route
                 </Button>
-            </div>
-        </div>
+            </>}
+        />
     );
 
     if (loading) {

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
-import { Button, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus, Layers } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder } from '../../../components';
-import { BulkDeleteModal, DeleteConfigModal } from '../../../components';
-import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
+import { BulkDeleteModal, DeleteConfigModal, CommandPaletteHeader } from '../../../components';
+import { usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
@@ -103,7 +103,7 @@ const NeighboursPage: React.FC = () => {
 
     const tabsList = [MERGED_TAB, ...tables.map((t) => t.name || '').filter(Boolean)];
 
-    const { openPalette, setPageContribution } = usePalette();
+    const { setPageContribution } = usePalette();
 
     const { updateParams } = useSearchParamHelpers(setSearchParams);
 
@@ -502,10 +502,10 @@ const NeighboursPage: React.FC = () => {
     const searchActive = family !== 'all' || !!stateFilter;
 
     const pageHeader = (
-        <div className="page-header-bar">
-            <Text variant="header-1">Neighbours</Text>
-            <CommandPaletteTrigger placeholder="Search neighbours or type an IP…" onOpen={openPalette} />
-            <div className="page-header-bar__actions">
+        <CommandPaletteHeader
+            title="Neighbours"
+            placeholder="Search neighbours or type an IP…"
+            actions={<>
                 <Button view="outlined" onClick={() => setCreateTableOpen(true)}>
                     <Icon data={Plus} size={16} />
                     Add Table
@@ -514,8 +514,8 @@ const NeighboursPage: React.FC = () => {
                     <Icon data={Plus} size={16} />
                     Add Neighbour
                 </Button>
-            </div>
-        </div>
+            </>}
+        />
     );
 
     if (loading) {

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Icon } from '@gravity-ui/uikit';
 import { ArrowRightToLine, Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
 import { AddConfigModal } from '../../_shared/draft';
-import { BulkDeleteModal } from '../../../components';
-import { CommandPaletteTrigger, usePalette } from '../../_shared/command-palette';
+import { BulkDeleteModal, CommandPaletteHeader } from '../../../components';
+import { usePalette } from '../../_shared/command-palette';
 import type { Command, RowAdapter } from '../../_shared/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import { API } from '../../../api';
@@ -97,7 +97,7 @@ const RoutePage: React.FC = () => {
         return m;
     }, [configs, configRoutes]);
 
-    const { openPalette, setPageContribution } = usePalette();
+    const { setPageContribution } = usePalette();
 
     useTabCycle({
         tabs: configs,
@@ -382,10 +382,10 @@ const RoutePage: React.FC = () => {
     }, [routeCommands, routeDynamicCommands, routeRowAdapter, setPageContribution]);
 
     const pageHeader = (
-        <div className="page-header-bar">
-            <Text variant="header-1">Routing Table</Text>
-            <CommandPaletteTrigger placeholder="Search or look up an IP…" onOpen={openPalette} />
-            <div className="page-header-bar__actions">
+        <CommandPaletteHeader
+            title="Routing Table"
+            placeholder="Search or look up an IP…"
+            actions={<>
                 <Button view="outlined" onClick={handleFlush} disabled={!currentConfig}>
                     <Icon data={ArrowRightToLine} size={16} />
                     Flush RIB → FIB
@@ -394,8 +394,8 @@ const RoutePage: React.FC = () => {
                     <Icon data={Plus} size={16} />
                     Add Route
                 </Button>
-            </div>
-        </div>
+            </>}
+        />
     );
 
     if (loading && configs.length === 0) {


### PR DESCRIPTION
- Replace the duplicated page-header markup across the ACL, Decap, Forward, FWState, Route, Neighbours, and operator Route pages with a single \`CommandPaletteHeader\` component.
- Render the page title, the centered command-palette trigger, and the right-aligned actions from one place, wiring the trigger to the global palette via \`usePalette\`.
- Move the \`page-header-bar\` grid styles out of \`common.scss\` into the new component's stylesheet so the layout lives next to its only consumer.