### PR TITLE
refactor(web): extract shared DraftYamlIO component

### DIFF
--- a/web/src/components/DraftYamlIO.tsx
+++ b/web/src/components/DraftYamlIO.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import { toaster } from '../utils';
+import YamlIOModal from './YamlIOModal';
+
+export interface DraftYamlIOProps<T> {
+    configName: string;
+    rows: T[];
+    onImport: (rows: T[], mode: 'replace' | 'append') => void;
+    itemLabel: string;
+    downloadPrefix: string;
+    toastPrefix: string;
+    importPlaceholder: string;
+    exportYaml: () => string;
+    parseImport: (text: string) => T[];
+    disabled?: boolean;
+}
+
+/** Generic YAML import/export controls for draft config pages. */
+const DraftYamlIO = <T,>({
+    configName,
+    rows,
+    onImport,
+    itemLabel,
+    downloadPrefix,
+    toastPrefix,
+    importPlaceholder,
+    exportYaml,
+    parseImport,
+    disabled,
+}: DraftYamlIOProps<T>): React.JSX.Element => {
+    const [importMode, setImportMode] = useState<'replace' | 'append'>('replace');
+
+    const handleImport = (text: string): void => {
+        const imported = parseImport(text);
+        onImport(imported, importMode);
+        toaster.success(`${toastPrefix}-import`, `Imported ${imported.length} ${itemLabel} (${importMode}).`);
+    };
+
+    const importExtraControls = (
+        <>
+            <div style={{ flex: 1 }} />
+            <span style={{ fontSize: 12, color: 'var(--yn-text-3)' }}>Mode:</span>
+            <button
+                type="button"
+                className={`yn-btn yn-btn--sm${importMode === 'replace' ? '' : ' yn-btn--ghost'}`}
+                onClick={() => setImportMode('replace')}
+            >
+                Replace all
+            </button>
+            <button
+                type="button"
+                className={`yn-btn yn-btn--sm${importMode === 'append' ? '' : ' yn-btn--ghost'}`}
+                onClick={() => setImportMode('append')}
+            >
+                Append
+            </button>
+        </>
+    );
+
+    return (
+        <YamlIOModal
+            configName={configName}
+            itemCount={rows.length}
+            itemLabel={itemLabel}
+            downloadPrefix={downloadPrefix}
+            exportYaml={exportYaml}
+            onImport={handleImport}
+            toastPrefix={toastPrefix}
+            importPlaceholder={importPlaceholder}
+            exportFooterHint="Exports current draft (uncommitted changes included)."
+            importFooterHint="Loads into current config as draft. Use Commit to push to server."
+            importButtonLabel="Load as draft"
+            importExtraControls={importExtraControls}
+            disabled={disabled}
+        />
+    );
+};
+
+export default DraftYamlIO;

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -59,3 +59,5 @@ export { default as BulkDeleteModal } from './BulkDeleteModal';
 export { useChipInput, Chip } from './chip-input';
 export type { ChipKind, ChipInputProps, ChipInputHandle } from './chip-input';
 export { default as CommandPaletteHeader } from './CommandPaletteHeader';
+export { default as DraftYamlIO } from './DraftYamlIO';
+export type { DraftYamlIOProps } from './DraftYamlIO';

--- a/web/src/pages/modules/decap/PrefixYamlIO.tsx
+++ b/web/src/pages/modules/decap/PrefixYamlIO.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { PrefixRowItem } from './types';
 import { rowsToYaml, yamlToRows } from './yaml';
-import { toaster } from '../../../utils';
-import YamlIOModal from '../../../components/YamlIOModal';
+import DraftYamlIO from '../../../components/DraftYamlIO';
 
 interface PrefixYamlIOProps {
     configName: string;
@@ -12,53 +11,19 @@ interface PrefixYamlIOProps {
 }
 
 /** YAML import/export controls for the decap page header. */
-const PrefixYamlIO: React.FC<PrefixYamlIOProps> = ({ configName, rows, onImport, disabled }) => {
-    const [importMode, setImportMode] = useState<'replace' | 'append'>('replace');
-
-    const handleImport = (text: string): void => {
-        const imported = yamlToRows(text);
-        onImport(imported, importMode);
-        toaster.success('prefix-yaml-import', `Imported ${imported.length} prefixes (${importMode}).`);
-    };
-
-    const importExtraControls = (
-        <>
-            <div style={{ flex: 1 }} />
-            <span style={{ fontSize: 12, color: 'var(--yn-text-3)' }}>Mode:</span>
-            <button
-                type="button"
-                className={`yn-btn yn-btn--sm${importMode === 'replace' ? '' : ' yn-btn--ghost'}`}
-                onClick={() => setImportMode('replace')}
-            >
-                Replace all
-            </button>
-            <button
-                type="button"
-                className={`yn-btn yn-btn--sm${importMode === 'append' ? '' : ' yn-btn--ghost'}`}
-                onClick={() => setImportMode('append')}
-            >
-                Append
-            </button>
-        </>
-    );
-
-    return (
-        <YamlIOModal
-            configName={configName}
-            itemCount={rows.length}
-            itemLabel="prefixes"
-            downloadPrefix={`decap-${configName}`}
-            exportYaml={() => rowsToYaml(configName, rows)}
-            onImport={handleImport}
-            toastPrefix="prefix-yaml"
-            importPlaceholder={`config: ${configName}\nprefixes:\n  - 10.0.0.0/8\n  - 2a02:6b8::/32`}
-            exportFooterHint="Exports current draft (uncommitted changes included)."
-            importFooterHint="Loads into current config as draft. Use Commit to push to server."
-            importButtonLabel="Load as draft"
-            importExtraControls={importExtraControls}
-            disabled={disabled}
-        />
-    );
-};
+const PrefixYamlIO: React.FC<PrefixYamlIOProps> = ({ configName, rows, onImport, disabled }) => (
+    <DraftYamlIO<PrefixRowItem>
+        configName={configName}
+        rows={rows}
+        onImport={onImport}
+        itemLabel="prefixes"
+        downloadPrefix={`decap-${configName}`}
+        toastPrefix="prefix-yaml"
+        importPlaceholder={`config: ${configName}\nprefixes:\n  - 10.0.0.0/8\n  - 2a02:6b8::/32`}
+        exportYaml={() => rowsToYaml(configName, rows)}
+        parseImport={yamlToRows}
+        disabled={disabled}
+    />
+);
 
 export default PrefixYamlIO;

--- a/web/src/pages/modules/route/FIBYamlIO.tsx
+++ b/web/src/pages/modules/route/FIBYamlIO.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { FIBRowItem } from './types';
 import { rowsToYaml, yamlToRows } from './yaml';
-import { toaster } from '../../../utils';
-import YamlIOModal from '../../../components/YamlIOModal';
+import DraftYamlIO from '../../../components/DraftYamlIO';
 
 interface FIBYamlIOProps {
     configName: string;
@@ -12,53 +11,19 @@ interface FIBYamlIOProps {
 }
 
 /** YAML import/export controls for the FIB page header. */
-const FIBYamlIO: React.FC<FIBYamlIOProps> = ({ configName, rows, onImport, disabled }) => {
-    const [importMode, setImportMode] = useState<'replace' | 'append'>('replace');
-
-    const handleImport = (text: string): void => {
-        const imported = yamlToRows(text);
-        onImport(imported, importMode);
-        toaster.success('fib-yaml-import', `Imported ${imported.length} routes (${importMode}).`);
-    };
-
-    const importExtraControls = (
-        <>
-            <div style={{ flex: 1 }} />
-            <span style={{ fontSize: 12, color: 'var(--yn-text-3)' }}>Mode:</span>
-            <button
-                type="button"
-                className={`yn-btn yn-btn--sm${importMode === 'replace' ? '' : ' yn-btn--ghost'}`}
-                onClick={() => setImportMode('replace')}
-            >
-                Replace all
-            </button>
-            <button
-                type="button"
-                className={`yn-btn yn-btn--sm${importMode === 'append' ? '' : ' yn-btn--ghost'}`}
-                onClick={() => setImportMode('append')}
-            >
-                Append
-            </button>
-        </>
-    );
-
-    return (
-        <YamlIOModal
-            configName={configName}
-            itemCount={rows.length}
-            itemLabel="routes"
-            downloadPrefix={`fib-${configName}`}
-            exportYaml={() => rowsToYaml(configName, rows)}
-            onImport={handleImport}
-            toastPrefix="fib-yaml"
-            importPlaceholder={`config: ${configName}\nroutes:\n  - prefix: 10.0.0.0/8\n    dst_mac: 52:54:00:00:1c:57\n    src_mac: 52:54:00:12:34:56\n    device: eth0`}
-            exportFooterHint="Exports current draft (uncommitted changes included)."
-            importFooterHint="Loads into current config as draft. Use Commit to push to server."
-            importButtonLabel="Load as draft"
-            importExtraControls={importExtraControls}
-            disabled={disabled}
-        />
-    );
-};
+const FIBYamlIO: React.FC<FIBYamlIOProps> = ({ configName, rows, onImport, disabled }) => (
+    <DraftYamlIO<FIBRowItem>
+        configName={configName}
+        rows={rows}
+        onImport={onImport}
+        itemLabel="routes"
+        downloadPrefix={`fib-${configName}`}
+        toastPrefix="fib-yaml"
+        importPlaceholder={`config: ${configName}\nroutes:\n  - prefix: 10.0.0.0/8\n    dst_mac: 52:54:00:00:1c:57\n    src_mac: 52:54:00:12:34:56\n    device: eth0`}
+        exportYaml={() => rowsToYaml(configName, rows)}
+        parseImport={yamlToRows}
+        disabled={disabled}
+    />
+);
 
 export default FIBYamlIO;


### PR DESCRIPTION
- Extracted a generic DraftYamlIO component into web/src/components/, hoisting the shared YAML import/export logic that decap PrefixYamlIO and route FIBYamlIO duplicated byte-for-byte modulo type name and a few prop strings.
- Reduced both module wrappers to declarative pass-throughs that parameterize the row type, item label, download/toast prefixes, placeholder, and the YAML (de)serializers.
- No behavior change: toast ids, message nouns, footer hints, the replace/append mode toggle, and the disabled path are all preserved; verified zero visual diff on the decap and route YAML modals (import and export states) against main.