### PR TITLE
feat(gateway): distinguish in-process and out-of-process backends

### DIFF
--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -16,7 +16,7 @@ use ync::{
     errors::Error,
     output::{self, CommonFormat},
 };
-use ynpb::pb::{ListServicesRequest, RegisteredBackend, gateway_client::GatewayClient};
+use ynpb::pb::{BackendKind, ListServicesRequest, RegisteredBackend, gateway_client::GatewayClient};
 
 const GATEWAY_SERVICE: &str = "ynpb.Gateway";
 
@@ -111,6 +111,8 @@ impl GatewayService {
 pub struct ServiceRow {
     #[tabled(rename = "Name")]
     pub name: String,
+    #[tabled(rename = "Kind")]
+    pub kind: String,
     #[tabled(rename = "Endpoint")]
     pub endpoint: String,
     #[tabled(rename = "Last seen")]
@@ -125,11 +127,35 @@ impl From<&RegisteredBackend> for ServiceRow {
             .map(|b| (b.name.clone(), b.endpoint.clone()))
             .unwrap_or_default();
 
+        let kind = BackendKind::try_from(backend.kind).unwrap_or(BackendKind::Unspecified);
+
         Self {
             name,
+            kind: kind_display(kind),
             endpoint,
-            last_seen: format_age(backend.last_seen_at.as_ref()),
+            last_seen: last_seen_cell(kind, backend.last_seen_at.as_ref()),
         }
+    }
+}
+
+/// Maps a `BackendKind` to its human-readable display string.
+pub fn kind_display(kind: BackendKind) -> String {
+    match kind {
+        BackendKind::InProcess => "in-process".to_string(),
+        BackendKind::OutOfProcess => "module".to_string(),
+        BackendKind::Unspecified => "unspecified".to_string(),
+    }
+}
+
+/// Returns the "Last seen" cell for a row.
+///
+/// In-process backends never heartbeat, so showing a timestamp age is
+/// misleading — returns `"—"` for `InProcess` and `Unspecified` kinds.
+/// Out-of-process backends heartbeat regularly; returns the formatted age.
+pub fn last_seen_cell(kind: BackendKind, ts: Option<&prost_types::Timestamp>) -> String {
+    match kind {
+        BackendKind::OutOfProcess => format_age(ts),
+        BackendKind::InProcess | BackendKind::Unspecified => "\u{2014}".to_string(),
     }
 }
 
@@ -231,5 +257,35 @@ mod test {
             nanos: 0,
         };
         assert_eq!("2h3m ago", format_age(Some(&ts)));
+    }
+
+    #[test]
+    fn kind_display_maps_correctly() {
+        assert_eq!("in-process", kind_display(BackendKind::InProcess));
+        assert_eq!("module", kind_display(BackendKind::OutOfProcess));
+        assert_eq!("unspecified", kind_display(BackendKind::Unspecified));
+    }
+
+    #[test]
+    fn last_seen_cell_in_process_returns_em_dash() {
+        let ts = prost_types::Timestamp { seconds: 1_000_000, nanos: 0 };
+        assert_eq!("\u{2014}", last_seen_cell(BackendKind::InProcess, Some(&ts)));
+    }
+
+    #[test]
+    fn last_seen_cell_unspecified_returns_em_dash() {
+        assert_eq!("\u{2014}", last_seen_cell(BackendKind::Unspecified, None));
+    }
+
+    #[test]
+    fn last_seen_cell_out_of_process_returns_age() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let ts = prost_types::Timestamp {
+            seconds: now.as_secs() as i64 - 30,
+            nanos: 0,
+        };
+        assert_eq!("30s ago", last_seen_cell(BackendKind::OutOfProcess, Some(&ts)));
     }
 }

--- a/common/rust/ynpb/build.rs
+++ b/common/rust/ynpb/build.rs
@@ -8,6 +8,10 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             ".ynpb.RegisteredBackend.last_seen_at",
             "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
         )
+        .field_attribute(
+            ".ynpb.RegisteredBackend.kind",
+            "#[serde(serialize_with = \"crate::serialize_backend_kind\")]",
+        )
         .extern_path(".commonpb", "::commonpb::pb")
         .compile_protos(
             &[

--- a/common/rust/ynpb/src/lib.rs
+++ b/common/rust/ynpb/src/lib.rs
@@ -5,6 +5,25 @@ pub mod pb {
 
 mod function;
 
+/// Serializes a `ynpb.BackendKind` discriminant as its lowercase short name
+/// (e.g. `"in_process"`, `"out_of_process"`, `"unspecified"`).
+///
+/// The `BACKEND_KIND_` prefix is stripped and the remainder lowercased. Unknown
+/// discriminants fall back to `"unspecified"`.
+pub fn serialize_backend_kind<S>(value: &i32, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let name = pb::BackendKind::try_from(*value)
+        .unwrap_or_default()
+        .as_str_name()
+        .strip_prefix("BACKEND_KIND_")
+        .unwrap_or("unspecified")
+        .to_lowercase();
+
+    serializer.serialize_str(&name)
+}
+
 /// Serializes an `Option<prost_types::Timestamp>` as `{"seconds": i64, "nanos":
 /// i32}` or `null` when absent.
 pub fn serialize_timestamp<S>(value: &Option<prost_types::Timestamp>, serializer: S) -> Result<S::Ok, S::Error>

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -187,7 +187,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	}
 
 	for _, service := range []string{"ynpb.Gateway", "ynpb.Auth"} {
-		registry.RegisterBackend(service, loopback)
+		registry.RegisterBackend(service, loopback, BackendKindInProcess)
 		log.Info("registered built-in service in registry",
 			zap.String("service", service),
 		)
@@ -206,7 +206,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 			)
 
 			for _, name := range service.ServicesNames() {
-				registry.RegisterBackend(name, loopback)
+				registry.RegisterBackend(name, loopback, BackendKindInProcess)
 				log.Debug("registered in-process service in registry",
 					zap.String("service", name),
 				)

--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -19,6 +19,14 @@ const (
 	RegistrationUpdated
 )
 
+// BackendKind classifies how a backend is hosted relative to the gateway.
+type BackendKind int
+
+const (
+	BackendKindInProcess BackendKind = iota + 1
+	BackendKindOutOfProcess
+)
+
 // Backend is a routable, closeable upstream connection tracked by the registry.
 type Backend interface {
 	proxy.Backend
@@ -30,6 +38,7 @@ type Backend interface {
 type BackendEntry struct {
 	service    string
 	backend    Backend
+	kind       BackendKind
 	lastSeenAt time.Time
 }
 
@@ -46,6 +55,11 @@ func (m *BackendEntry) Endpoint() string {
 // LastSeenAt returns the time the entry was last registered.
 func (m *BackendEntry) LastSeenAt() time.Time {
 	return m.lastSeenAt
+}
+
+// Kind returns the hosting classification of the entry.
+func (m *BackendEntry) Kind() BackendKind {
+	return m.kind
 }
 
 // GetBackend returns the proxy.Backend for this entry.
@@ -88,8 +102,8 @@ func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, bool) {
 // backends.
 // The shared loopback backend is registered once under distinct keys and is
 // never displaced, so it is only closed by Close().
-func (m *BackendRegistry) RegisterBackend(service string, b Backend) RegistrationStatus {
-	status, evicted := m.registerBackend(service, b)
+func (m *BackendRegistry) RegisterBackend(service string, b Backend, kind BackendKind) RegistrationStatus {
+	status, evicted := m.registerBackend(service, b, kind)
 	if evicted != nil {
 		_ = evicted.Close()
 	}
@@ -97,7 +111,7 @@ func (m *BackendRegistry) RegisterBackend(service string, b Backend) Registratio
 	return status
 }
 
-func (m *BackendRegistry) registerBackend(service string, b Backend) (RegistrationStatus, Backend) {
+func (m *BackendRegistry) registerBackend(service string, b Backend, kind BackendKind) (RegistrationStatus, Backend) {
 	now := time.Now().UTC()
 
 	m.mu.Lock()
@@ -110,10 +124,10 @@ func (m *BackendRegistry) registerBackend(service string, b Backend) (Registrati
 		m.backends[service] = existing
 		return RegistrationRenewed, b
 	case ok:
-		m.backends[service] = BackendEntry{service: service, backend: b, lastSeenAt: now}
+		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
 		return RegistrationUpdated, existing.backend
 	default:
-		m.backends[service] = BackendEntry{service: service, backend: b, lastSeenAt: now}
+		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
 		return RegistrationRegistered, nil
 	}
 }

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -50,7 +50,7 @@ func TestBackendRegistry_FirstRegistration(t *testing.T) {
 	reg := NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
-	status := reg.RegisterBackend("svc.Foo", b)
+	status := reg.RegisterBackend("svc.Foo", b, BackendKindOutOfProcess)
 
 	require.Equal(t, RegistrationRegistered, status)
 	require.False(t, b.closed)
@@ -63,12 +63,12 @@ func TestBackendRegistry_FirstRegistration(t *testing.T) {
 func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
 	reg := NewBackendRegistry()
 	original := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", original)
+	reg.RegisterBackend("svc.Foo", original, BackendKindOutOfProcess)
 
 	// Re-register with a different object but the same endpoint.
 	second := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
-	status := reg.RegisterBackend("svc.Foo", second)
+	status := reg.RegisterBackend("svc.Foo", second, BackendKindOutOfProcess)
 
 	require.Equal(t, RegistrationRenewed, status)
 
@@ -86,11 +86,11 @@ func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
 func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
 	reg := NewBackendRegistry()
 	prev := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", prev)
+	reg.RegisterBackend("svc.Foo", prev, BackendKindOutOfProcess)
 
 	next := &fakeBackend{endpoint: "127.0.0.1:9001"}
 
-	status := reg.RegisterBackend("svc.Foo", next)
+	status := reg.RegisterBackend("svc.Foo", next, BackendKindOutOfProcess)
 
 	require.Equal(t, RegistrationUpdated, status)
 
@@ -111,8 +111,8 @@ func TestBackendRegistry_Close(t *testing.T) {
 	bA := &fakeBackend{endpoint: "127.0.0.1:9000"}
 	bB := &fakeBackend{endpoint: "127.0.0.1:9001"}
 
-	reg.RegisterBackend("svc.A", bA)
-	reg.RegisterBackend("svc.B", bB)
+	reg.RegisterBackend("svc.A", bA, BackendKindOutOfProcess)
+	reg.RegisterBackend("svc.B", bB, BackendKindOutOfProcess)
 
 	err := reg.Close()
 	require.NoError(t, err)
@@ -130,8 +130,8 @@ func TestBackendRegistry_CloseSharedBackendOnce(t *testing.T) {
 
 	// Register the same backend instance under two different service names,
 	// simulating the shared loopback backend used by built-in services.
-	reg.RegisterBackend("svc.A", shared)
-	reg.RegisterBackend("svc.B", shared)
+	reg.RegisterBackend("svc.A", shared, BackendKindInProcess)
+	reg.RegisterBackend("svc.B", shared, BackendKindInProcess)
 
 	err := reg.Close()
 	require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestBackendRegistry_CloseSharedBackendOnce(t *testing.T) {
 func TestBackendRegistry_Renew(t *testing.T) {
 	reg := NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b)
+	reg.RegisterBackend("svc.Foo", b, BackendKindOutOfProcess)
 
 	before := reg.backends["svc.Foo"].lastSeenAt
 
@@ -185,7 +185,7 @@ func TestBackendRegistry_ConcurrentRace(t *testing.T) {
 		go func() {
 			defer func() { done <- struct{}{} }()
 			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-			reg.RegisterBackend("svc.Race", b)
+			reg.RegisterBackend("svc.Race", b, BackendKindOutOfProcess)
 			reg.Renew("svc.Race", "127.0.0.1:9000")
 			reg.GetBackend("svc.Race")
 			reg.ListBackends()
@@ -196,4 +196,37 @@ func TestBackendRegistry_ConcurrentRace(t *testing.T) {
 	}
 
 	_ = reg.Close()
+}
+
+func TestBackendRegistry_KindIsPreserved(t *testing.T) {
+	reg := NewBackendRegistry()
+
+	inProc := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	outProc := &fakeBackend{endpoint: "127.0.0.1:9001"}
+
+	reg.RegisterBackend("svc.InProcess", inProc, BackendKindInProcess)
+	reg.RegisterBackend("svc.OutOfProcess", outProc, BackendKindOutOfProcess)
+
+	entries := reg.ListBackends()
+	kinds := map[string]BackendKind{}
+	for _, e := range entries {
+		kinds[e.Service()] = e.Kind()
+	}
+
+	require.Equal(t, BackendKindInProcess, kinds["svc.InProcess"])
+	require.Equal(t, BackendKindOutOfProcess, kinds["svc.OutOfProcess"])
+}
+
+func TestBackendRegistry_RenewPreservesKind(t *testing.T) {
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, BackendKindInProcess)
+
+	// Renew must not reset the stored kind.
+	ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
+	require.True(t, ok)
+
+	entry, exists := reg.backends["svc.Foo"]
+	require.True(t, exists)
+	require.Equal(t, BackendKindInProcess, entry.Kind())
 }

--- a/controlplane/gateway/service.go
+++ b/controlplane/gateway/service.go
@@ -25,6 +25,17 @@ func registrationStatusToProto(s RegistrationStatus) ynpb.RegistrationStatus {
 	}
 }
 
+func backendKindToProto(k BackendKind) ynpb.BackendKind {
+	switch k {
+	case BackendKindInProcess:
+		return ynpb.BackendKind_BACKEND_KIND_IN_PROCESS
+	case BackendKindOutOfProcess:
+		return ynpb.BackendKind_BACKEND_KIND_OUT_OF_PROCESS
+	default:
+		return ynpb.BackendKind_BACKEND_KIND_UNSPECIFIED
+	}
+}
+
 // GatewayService is the gRPC service for the Gateway API.
 type GatewayService struct {
 	ynpb.UnimplementedGatewayServer
@@ -55,6 +66,7 @@ func (m *GatewayService) ListServices(
 				Endpoint: b.Endpoint(),
 			},
 			LastSeenAt: timestamppb.New(b.LastSeenAt()),
+			Kind:       backendKindToProto(b.Kind()),
 		}
 
 		services = append(services, registeredBackend)
@@ -105,7 +117,7 @@ func (m *GatewayService) Register(
 		return nil, err
 	}
 
-	regStatus := m.registry.RegisterBackend(backendDesc.GetName(), b)
+	regStatus := m.registry.RegisterBackend(backendDesc.GetName(), b, BackendKindOutOfProcess)
 	switch regStatus {
 	case RegistrationRegistered:
 		log.Info("registered backend")

--- a/controlplane/ynpb/gateway.proto
+++ b/controlplane/ynpb/gateway.proto
@@ -25,12 +25,25 @@ message BackendDesc {
   string endpoint = 2;
 }
 
+// BackendKind classifies how a backend is hosted relative to the gateway.
+enum BackendKind {
+  // Default, unused value.
+  BACKEND_KIND_UNSPECIFIED = 0;
+  // Built-in or in-process service sharing the gateway's own gRPC server. It
+  // does not heartbeat and is alive for as long as the gateway process is.
+  BACKEND_KIND_IN_PROCESS = 1;
+  // Out-of-process module backend that registers via the Register RPC and
+  // refreshes its registration on a heartbeat interval.
+  BACKEND_KIND_OUT_OF_PROCESS = 2;
+}
+
 // RegisteredBackend identifies a registered backend in the Gateway registry.
 message RegisteredBackend {
   BackendDesc backend = 1;
   // LastSeenAt is the timestamp when the service was last successfully
   // registered or updated.
   google.protobuf.Timestamp last_seen_at = 2;
+  BackendKind kind = 3;
 }
 
 // ListServicesResponse contains all known services in the registry.


### PR DESCRIPTION
Built-in and in-process gateway services never heartbeat, so their last-seen timestamp is frozen at gateway startup and they appear perpetually stale in `gateway list`. Record how each backend is hosted and surface it.

- Add a `BackendKind` to the backend registry, set at registration: built-in and in-process services (shared loopback) register as in-process, while module backends from the Register RPC register as out-of-process. The heartbeat renew path leaves the kind untouched.
- Extend the `Gateway.ListServices` proto and Go service with a `BackendKind kind` field (additive, no renames).
- Show a Kind column in `yanet-cli gateway list` and render the heartbeat age only for out-of-process backends; in-process backends show a dash, since their liveness equals the gateway's. JSON output carries the kind as a self-describing string.