### PR TITLE
refactor(web): extract shared DraftSaveDiffModal component

### DIFF
--- a/web/src/components/DraftSaveDiffModal.tsx
+++ b/web/src/components/DraftSaveDiffModal.tsx
@@ -1,0 +1,46 @@
+import React, { useMemo } from 'react';
+import { Text } from '@gravity-ui/uikit';
+import { SaveDiffModal } from './SaveDiffModal';
+
+export interface DraftSaveDiffModalProps<T> {
+    configName: string;
+    draftRows: T[];
+    serverRows: T[];
+    onClose: () => void;
+    onApply: () => Promise<void>;
+    rowsToDiffYaml: (rows: T[]) => string;
+    countInvalidRows: (rows: T[]) => number;
+}
+
+/** Generic draft save-diff modal, parameterized by row type and YAML/validation helpers. */
+export const DraftSaveDiffModal = <T,>({
+    configName,
+    draftRows,
+    serverRows,
+    onClose,
+    onApply,
+    rowsToDiffYaml,
+    countInvalidRows,
+}: DraftSaveDiffModalProps<T>): React.JSX.Element => {
+    const beforeYaml = useMemo(() => rowsToDiffYaml(serverRows), [serverRows]);
+    const afterYaml = useMemo(() => rowsToDiffYaml(draftRows), [draftRows]);
+    const invalidCount = useMemo(() => countInvalidRows(draftRows), [draftRows]);
+
+    const warning = invalidCount > 0 ? (
+        <Text variant="caption-1" color="warning">
+            {invalidCount} row{invalidCount === 1 ? '' : 's'} fail client-side validation — server may reject.
+        </Text>
+    ) : undefined;
+
+    return (
+        <SaveDiffModal
+            configName={configName}
+            beforeYaml={beforeYaml}
+            afterYaml={afterYaml}
+            warning={warning}
+            applyLabel="Commit"
+            onClose={onClose}
+            onApply={onApply}
+        />
+    );
+};

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -61,3 +61,5 @@ export type { ChipKind, ChipInputProps, ChipInputHandle } from './chip-input';
 export { default as CommandPaletteHeader } from './CommandPaletteHeader';
 export { default as DraftYamlIO } from './DraftYamlIO';
 export type { DraftYamlIOProps } from './DraftYamlIO';
+export { DraftSaveDiffModal } from './DraftSaveDiffModal';
+export type { DraftSaveDiffModalProps } from './DraftSaveDiffModal';

--- a/web/src/pages/modules/decap/PrefixSaveDiffModal.tsx
+++ b/web/src/pages/modules/decap/PrefixSaveDiffModal.tsx
@@ -1,9 +1,8 @@
-import React, { useMemo } from 'react';
-import { Text } from '@gravity-ui/uikit';
+import React from 'react';
 import type { PrefixRowItem } from './types';
 import { rowsToDiffYaml } from './yaml';
 import { countInvalidRows } from './validation';
-import { SaveDiffModal } from '../../../components';
+import { DraftSaveDiffModal } from '../../../components';
 
 interface PrefixSaveDiffModalProps {
     configName: string;
@@ -17,32 +16,10 @@ interface PrefixSaveDiffModalProps {
  * Modal showing a side-by-side YAML diff of server vs draft prefix rows,
  * with a Commit button that calls onApply and closes on success.
  */
-export const PrefixSaveDiffModal: React.FC<PrefixSaveDiffModalProps> = ({
-    configName,
-    draftRows,
-    serverRows,
-    onClose,
-    onApply,
-}) => {
-    const beforeYaml = useMemo(() => rowsToDiffYaml(serverRows), [serverRows]);
-    const afterYaml = useMemo(() => rowsToDiffYaml(draftRows), [draftRows]);
-    const invalidCount = useMemo(() => countInvalidRows(draftRows), [draftRows]);
-
-    const warning = invalidCount > 0 ? (
-        <Text variant="caption-1" color="warning">
-            {invalidCount} row{invalidCount === 1 ? '' : 's'} fail client-side validation — server may reject.
-        </Text>
-    ) : undefined;
-
-    return (
-        <SaveDiffModal
-            configName={configName}
-            beforeYaml={beforeYaml}
-            afterYaml={afterYaml}
-            warning={warning}
-            applyLabel="Commit"
-            onClose={onClose}
-            onApply={onApply}
-        />
-    );
-};
+export const PrefixSaveDiffModal: React.FC<PrefixSaveDiffModalProps> = (props) => (
+    <DraftSaveDiffModal<PrefixRowItem>
+        {...props}
+        rowsToDiffYaml={rowsToDiffYaml}
+        countInvalidRows={countInvalidRows}
+    />
+);

--- a/web/src/pages/modules/route/FIBSaveDiffModal.tsx
+++ b/web/src/pages/modules/route/FIBSaveDiffModal.tsx
@@ -1,9 +1,8 @@
-import React, { useMemo } from 'react';
-import { Text } from '@gravity-ui/uikit';
+import React from 'react';
 import type { FIBRowItem } from './types';
 import { rowsToDiffYaml } from './yaml';
 import { countInvalidRows } from './validation';
-import { SaveDiffModal } from '../../../components';
+import { DraftSaveDiffModal } from '../../../components';
 
 interface FIBSaveDiffModalProps {
     configName: string;
@@ -17,32 +16,10 @@ interface FIBSaveDiffModalProps {
  * Modal showing a side-by-side YAML diff of server vs draft FIB rows for a config,
  * with a Commit button that calls onApply (which calls API.route.updateFIB) and closes on success.
  */
-export const FIBSaveDiffModal: React.FC<FIBSaveDiffModalProps> = ({
-    configName,
-    draftRows,
-    serverRows,
-    onClose,
-    onApply,
-}) => {
-    const beforeYaml = useMemo(() => rowsToDiffYaml(serverRows), [serverRows]);
-    const afterYaml = useMemo(() => rowsToDiffYaml(draftRows), [draftRows]);
-    const invalidCount = useMemo(() => countInvalidRows(draftRows), [draftRows]);
-
-    const warning = invalidCount > 0 ? (
-        <Text variant="caption-1" color="warning">
-            {invalidCount} row{invalidCount === 1 ? '' : 's'} fail client-side validation — server may reject.
-        </Text>
-    ) : undefined;
-
-    return (
-        <SaveDiffModal
-            configName={configName}
-            beforeYaml={beforeYaml}
-            afterYaml={afterYaml}
-            warning={warning}
-            applyLabel="Commit"
-            onClose={onClose}
-            onApply={onApply}
-        />
-    );
-};
+export const FIBSaveDiffModal: React.FC<FIBSaveDiffModalProps> = (props) => (
+    <DraftSaveDiffModal<FIBRowItem>
+        {...props}
+        rowsToDiffYaml={rowsToDiffYaml}
+        countInvalidRows={countInvalidRows}
+    />
+);


### PR DESCRIPTION
- Extracted a generic DraftSaveDiffModal component into web/src/components/, hoisting the save/commit YAML-diff logic that decap PrefixSaveDiffModal and route FIBSaveDiffModal duplicated near-identically (differing only by row type and the module-local diff/validation helpers).
- The generic parameterizes the YAML serializer and the invalid-row counter; both module wrappers collapse to declarative pass-throughs that keep their existing props and named exports, so importers are unchanged.
- No behavior change: the memo deps, the invalid-row warning branch, and the Commit action are preserved verbatim; the diff rendering is fully delegated to the unchanged shared SaveDiffModal.