### PR TITLE
refactor(web): extract shared RowCountDisplay component

### DIFF
--- a/web/src/components/RowCountDisplay.tsx
+++ b/web/src/components/RowCountDisplay.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface Props {
+    filtered: number;
+    total: number;
+}
+
+/** Displays a filtered/total row count in the toolbar, e.g. "42 / 1 000". */
+const RowCountDisplay = ({ filtered, total }: Props): React.JSX.Element => (
+    <span className="yn-count">
+        <span style={{ color: 'var(--yn-text)', fontWeight: 600 }}>{filtered.toLocaleString()}</span>
+        {' / '}{total.toLocaleString()}
+    </span>
+);
+
+export default RowCountDisplay;

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -60,6 +60,7 @@ export { useChipInput, Chip } from './chip-input';
 export type { ChipKind, ChipInputProps, ChipInputHandle } from './chip-input';
 export { default as CommandPaletteHeader } from './CommandPaletteHeader';
 export { default as DraftYamlIO } from './DraftYamlIO';
+export { default as RowCountDisplay } from './RowCountDisplay';
 export type { DraftYamlIOProps } from './DraftYamlIO';
 export { DraftSaveDiffModal } from './DraftSaveDiffModal';
 export type { DraftSaveDiffModalProps } from './DraftSaveDiffModal';

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useSt
 import { Button, Icon, Label } from '@gravity-ui/uikit';
 import { Funnel, Pause, Play, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
 import { useAclDraft } from './useAclDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
@@ -508,10 +508,7 @@ const AclPage: React.FC = () => {
                                     showShortcutHint={false}
                                 />
                             </div>
-                            <span className="acl-count">
-                                <span style={{ color: 'var(--yn-text)', fontWeight: 600 }}>{visibleItems.length.toLocaleString()}</span>
-                                {' / '}{allItems.length.toLocaleString()}
-                            </span>
+                            <RowCountDisplay filtered={visibleItems.length} total={allItems.length} />
                         </div>
 
                         <div className="yn-content">

--- a/web/src/pages/modules/acl/acl.scss
+++ b/web/src/pages/modules/acl/acl.scss
@@ -10,15 +10,6 @@
     border-bottom: 1px solid var(--yn-line);
 }
 
-.acl-count {
-    font-size: 12.5px;
-    color: var(--yn-text-3);
-    white-space: nowrap;
-    flex-shrink: 0;
-    font-family: var(--yn-font-mono);
-    font-variant-numeric: tabular-nums;
-}
-
 // Chip list container.
 .acl-chip-list {
     display: inline-flex;

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { useSearchParamHelpers } from '../../../hooks';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder, SearchInput } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder, SearchInput, RowCountDisplay } from '../../../components';
 import { usePrefixDraft } from './usePrefixDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { PrefixRowItem } from './types';
@@ -298,10 +298,7 @@ const DecapPage: React.FC = () => {
                                     icon={Funnel}
                                 />
                             </div>
-                            <span className="decap-count">
-                                <span style={{ color: 'var(--yn-text)', fontWeight: 600 }}>{visibleRows.length.toLocaleString()}</span>
-                                {' / '}{rawRows.length.toLocaleString()}
-                            </span>
+                            <RowCountDisplay filtered={visibleRows.length} total={rawRows.length} />
                         </div>
                         <div className="yn-content">
                             <PrefixTable

--- a/web/src/pages/modules/decap/decap.scss
+++ b/web/src/pages/modules/decap/decap.scss
@@ -5,12 +5,3 @@
     @include yn-toolbar;
     border-bottom: 1px solid var(--yn-line);
 }
-
-.decap-count {
-    font-size: 12.5px;
-    color: var(--yn-text-3);
-    white-space: nowrap;
-    flex-shrink: 0;
-    font-family: var(--yn-font-mono);
-    font-variant-numeric: tabular-nums;
-}

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -3,7 +3,7 @@ import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { Rule } from '../../../api/forward';
@@ -430,10 +430,7 @@ const ForwardPage: React.FC = () => {
                                     icon={Funnel}
                                 />
                             </div>
-                            <span className="fw-count">
-                                <span style={{ color: 'var(--yn-text)', fontWeight: 600 }}>{visibleItems.length.toLocaleString()}</span>
-                                {' / '}{allItems.length.toLocaleString()}
-                            </span>
+                            <RowCountDisplay filtered={visibleItems.length} total={allItems.length} />
                         </div>
 
                         <div className="yn-content">

--- a/web/src/pages/modules/forward/forward.scss
+++ b/web/src/pages/modules/forward/forward.scss
@@ -8,15 +8,6 @@
     border-bottom: 1px solid var(--yn-line);
 }
 
-.fw-count {
-    font-size: 12.5px;
-    color: var(--yn-text-3);
-    white-space: nowrap;
-    flex-shrink: 0;
-    font-family: var(--yn-font-mono);
-    font-variant-numeric: tabular-nums;
-}
-
 // Forward-specific styles — direction badges, sparkline, chip-input, segmented control.
 // Shared page chrome (yn-page, yn-tabs, yn-table-*, yn-modal*, yn-drawer*, yn-bulk-bar, etc.)
 // lives in web/src/styles/draft-page.scss.

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -3,7 +3,7 @@ import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
 import { useSearchParamHelpers } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useFIBDraft } from './useFIBDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { FIBRowItem } from './types';
@@ -328,10 +328,7 @@ const RoutePage: React.FC = () => {
                                     icon={Funnel}
                                 />
                             </div>
-                            <span className="rt-count">
-                                <span style={{ color: 'var(--yn-text)', fontWeight: 600 }}>{visibleRows.length.toLocaleString()}</span>
-                                {' / '}{rawRows.length.toLocaleString()}
-                            </span>
+                            <RowCountDisplay filtered={visibleRows.length} total={rawRows.length} />
                         </div>
                         <div className="yn-content">
                             <FIBTable

--- a/web/src/pages/modules/route/route.scss
+++ b/web/src/pages/modules/route/route.scss
@@ -5,12 +5,3 @@
     @include yn-toolbar;
     border-bottom: 1px solid var(--yn-line);
 }
-
-.rt-count {
-    font-size: 12.5px;
-    color: var(--yn-text-3);
-    white-space: nowrap;
-    flex-shrink: 0;
-    font-family: var(--yn-font-mono);
-    font-variant-numeric: tabular-nums;
-}

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { ArrowRightToLine, Funnel, Plus } from '@gravity-ui/icons';
-import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder } from '../../../components';
+import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { AddConfigModal } from '../../_shared/draft';
 import { BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { usePalette } from '../../_shared/command-palette';
@@ -468,10 +468,7 @@ const RoutePage: React.FC = () => {
                                     icon={Funnel}
                                 />
                             </div>
-                            <span className="ro-count">
-                                <span style={{ color: 'var(--yn-text)', fontWeight: 600 }}>{visibleRows.length.toLocaleString()}</span>
-                                {' / '}{allRows.length.toLocaleString()}
-                            </span>
+                            <RowCountDisplay filtered={visibleRows.length} total={allRows.length} />
                         </div>
                         <div className="yn-content">
                             <RIBTable

--- a/web/src/pages/operators/route/route.scss
+++ b/web/src/pages/operators/route/route.scss
@@ -73,17 +73,6 @@
     font-variant-numeric: tabular-nums;
 }
 
-// ─── Row count ────────────────────────────────────────────────────────────────
-
-.ro-count {
-    font-size: 12.5px;
-    color: var(--yn-text-3);
-    white-space: nowrap;
-    flex-shrink: 0;
-    font-family: var(--yn-font-mono);
-    font-variant-numeric: tabular-nums;
-}
-
 // ─── Lookup drawer ─────────────────────────────────────────────────────────────
 
 .ro-lookup-drawer {

--- a/web/src/styles/draft/_surface.scss
+++ b/web/src/styles/draft/_surface.scss
@@ -63,6 +63,16 @@
     color: var(--yn-text-2);
 }
 
+// Row count display — shown in the toolbar beside the search input.
+.yn-count {
+    font-size: 12.5px;
+    color: var(--yn-text-3);
+    white-space: nowrap;
+    flex-shrink: 0;
+    font-family: var(--yn-font-mono);
+    font-variant-numeric: tabular-nums;
+}
+
 // Shared flat-surface layout treatment.
 // Pages that apply .yn-flat-layout (on PageLayout) and .yn-flat-page (on .yn-page)
 // get the same unified #1C1814 surface, flush table, and 3px active underline.


### PR DESCRIPTION
- Extracted a RowCountDisplay component into web/src/components/, replacing the identical visible/total count span duplicated across the forward, acl, decap, module-route and operator-route pages.
- Collapsed the five byte-identical *-count SCSS classes into a single shared .yn-count chrome class in styles/draft/_surface.scss.
- No behavior change: the rendered markup (including the inline value style) is preserved verbatim; verified zero visual diff on all five pages against main.