### PR TITLE
feat(gateway): classify registered backends by kind

### DIFF
--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -16,7 +16,7 @@ use ync::{
     errors::Error,
     output::{self, CommonFormat},
 };
-use ynpb::pb::{ListServicesRequest, RegisteredBackend, gateway_client::GatewayClient};
+use ynpb::pb::{BackendKind, ListServicesRequest, RegisteredBackend, gateway_client::GatewayClient};
 
 const GATEWAY_SERVICE: &str = "ynpb.Gateway";
 
@@ -111,6 +111,8 @@ impl GatewayService {
 pub struct ServiceRow {
     #[tabled(rename = "Name")]
     pub name: String,
+    #[tabled(rename = "Kind")]
+    pub kind: String,
     #[tabled(rename = "Endpoint")]
     pub endpoint: String,
     #[tabled(rename = "Last seen")]
@@ -125,11 +127,39 @@ impl From<&RegisteredBackend> for ServiceRow {
             .map(|b| (b.name.clone(), b.endpoint.clone()))
             .unwrap_or_default();
 
+        let kind = BackendKind::try_from(backend.kind).unwrap_or(BackendKind::Unspecified);
+
         Self {
             name,
+            kind: kind_display(kind),
             endpoint,
-            last_seen: format_age(backend.last_seen_at.as_ref()),
+            last_seen: last_seen_cell(kind, backend.last_seen_at.as_ref()),
         }
+    }
+}
+
+/// Returns the human-readable label for a `BackendKind`.
+fn kind_display(kind: BackendKind) -> String {
+    match kind {
+        BackendKind::Builtin => "built-in".to_string(),
+        BackendKind::InProcess => "in-process".to_string(),
+        BackendKind::External => "external".to_string(),
+        BackendKind::Unspecified => "unspecified".to_string(),
+    }
+}
+
+/// Returns the last-seen cell value for a row.
+///
+/// `Builtin` and `InProcess` register once and never heartbeat, so showing an
+/// age would be misleading — those arms return `—`. `External` backends
+/// heartbeat and always show the age. `Unspecified` also shows the age: when a
+/// newer CLI talks to an older gateway that predates the `kind` field, proto3
+/// decodes every backend's `kind` as `Unspecified`, so falling back to
+/// `format_age` preserves the pre-kind staleness signal for external services.
+fn last_seen_cell(kind: BackendKind, ts: Option<&prost_types::Timestamp>) -> String {
+    match kind {
+        BackendKind::Builtin | BackendKind::InProcess => "\u{2014}".to_string(),
+        BackendKind::External | BackendKind::Unspecified => format_age(ts),
     }
 }
 
@@ -231,5 +261,49 @@ mod test {
             nanos: 0,
         };
         assert_eq!("2h3m ago", format_age(Some(&ts)));
+    }
+
+    #[test]
+    fn kind_display_all_variants() {
+        assert_eq!("built-in", kind_display(BackendKind::Builtin));
+        assert_eq!("in-process", kind_display(BackendKind::InProcess));
+        assert_eq!("external", kind_display(BackendKind::External));
+        assert_eq!("unspecified", kind_display(BackendKind::Unspecified));
+    }
+
+    #[test]
+    fn last_seen_cell_builtin_shows_em_dash() {
+        let ts = prost_types::Timestamp { seconds: 1_000_000, nanos: 0 };
+        assert_eq!("\u{2014}", last_seen_cell(BackendKind::Builtin, Some(&ts)));
+    }
+
+    #[test]
+    fn last_seen_cell_in_process_shows_em_dash() {
+        let ts = prost_types::Timestamp { seconds: 1_000_000, nanos: 0 };
+        assert_eq!("\u{2014}", last_seen_cell(BackendKind::InProcess, Some(&ts)));
+    }
+
+    #[test]
+    fn last_seen_cell_external_shows_age() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let ts = prost_types::Timestamp {
+            seconds: now.as_secs() as i64 - 5,
+            nanos: 0,
+        };
+        assert_eq!("5s ago", last_seen_cell(BackendKind::External, Some(&ts)));
+    }
+
+    #[test]
+    fn last_seen_cell_unspecified_shows_age() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let ts = prost_types::Timestamp {
+            seconds: now.as_secs() as i64 - 5,
+            nanos: 0,
+        };
+        assert_eq!("5s ago", last_seen_cell(BackendKind::Unspecified, Some(&ts)));
     }
 }

--- a/common/rust/ynpb/build.rs
+++ b/common/rust/ynpb/build.rs
@@ -8,6 +8,10 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             ".ynpb.RegisteredBackend.last_seen_at",
             "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
         )
+        .field_attribute(
+            ".ynpb.RegisteredBackend.kind",
+            "#[serde(serialize_with = \"crate::serialize_backend_kind\")]",
+        )
         .extern_path(".common.commonpb.v1", "::commonpb::pb")
         .compile_protos(
             &[

--- a/common/rust/ynpb/src/lib.rs
+++ b/common/rust/ynpb/src/lib.rs
@@ -5,6 +5,22 @@ pub mod pb {
 
 mod function;
 
+/// Serializes a `BackendKind` discriminant as its lowercased short name
+/// (e.g. `builtin`, `in_process`, `external`), or `unspecified` when unknown.
+pub fn serialize_backend_kind<S>(value: &i32, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let name = pb::BackendKind::try_from(*value)
+        .unwrap_or_default()
+        .as_str_name()
+        .strip_prefix("BACKEND_KIND_")
+        .unwrap_or("UNSPECIFIED")
+        .to_lowercase();
+
+    serializer.serialize_str(&name)
+}
+
 /// Serializes an `Option<prost_types::Timestamp>` as `{"seconds": i64, "nanos":
 /// i32}` or `null` when absent.
 pub fn serialize_timestamp<S>(value: &Option<prost_types::Timestamp>, serializer: S) -> Result<S::Ok, S::Error>

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -22,14 +22,14 @@ import (
 
 // Service is the interface that gateway services must implement.
 //
-// When Endpoint returns an empty string the service is in-process:
-// it shares the gateway's gRPC server. When Endpoint returns a
-// non-empty host:port or unix path the service runs its own listener
-// and registers itself with the gateway client.
+// When Endpoint returns an empty string the service shares the gateway's own
+// gRPC server. When Endpoint returns a non-empty host:port or unix path the
+// service runs its own listener and registers itself with the gateway client.
 type Service interface {
 	Name() string
-	// Endpoint returns "" for in-process services, or a host:port / unix
-	// path for out-of-process services that run their own listener.
+	// Endpoint returns "" when the service shares the gateway's own gRPC
+	// server, or a host:port / unix path when the service runs its own
+	// listener.
 	Endpoint() string
 	ServicesNames() []string
 	RegisterService(server *grpc.Server)
@@ -47,8 +47,14 @@ type ClosableService interface {
 	Close() error
 }
 
+// serviceEntry pairs a service with its declared backend kind.
+type serviceEntry struct {
+	service Service
+	kind    BackendKind
+}
+
 type gatewayOptions struct {
-	Services []Service
+	Services []serviceEntry
 	Log      *zap.Logger
 	LogLevel *zap.AtomicLevel
 }
@@ -62,10 +68,17 @@ func newGatewayOptions() *gatewayOptions {
 // GatewayOption is a function that configures the Gateway.
 type GatewayOption func(*gatewayOptions)
 
-// WithService adds a service to the Gateway.
+// WithService adds an in-process module or device service to the Gateway.
 func WithService(service Service) GatewayOption {
 	return func(o *gatewayOptions) {
-		o.Services = append(o.Services, service)
+		o.Services = append(o.Services, serviceEntry{service: service, kind: BackendKindInProcess})
+	}
+}
+
+// WithBuiltinService adds a framework service that shares the gateway's own gRPC server.
+func WithBuiltinService(service Service) GatewayOption {
+	return func(o *gatewayOptions) {
+		o.Services = append(o.Services, serviceEntry{service: service, kind: BackendKindBuiltin})
 	}
 }
 
@@ -171,8 +184,8 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	ynpb.RegisterAuthServiceServer(server, authService)
 	log.Info("registered service", zap.String("service", fmt.Sprintf("%T", authService)))
 
-	// Dial a single loopback connection shared by all built-in and in-process
-	// services.
+	// Dial a single loopback connection shared by services hosted on the
+	// gateway's own gRPC server.
 	//
 	// Out-of-process module backends (from the Register RPC) each get their
 	// own connection via RegisterBackend in the registration loop.
@@ -183,11 +196,11 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 
 	loopback, err := dialBackend(cfg.Server.Endpoint, creds)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create loopback backend for built-in services: %w", err)
+		return nil, fmt.Errorf("failed to create loopback backend for gateway-hosted services: %w", err)
 	}
 
 	for _, service := range []string{"ynpb.Gateway", "ynpb.Auth"} {
-		registry.RegisterBackend(service, loopback)
+		registry.RegisterBackend(service, loopback, BackendKindBuiltin)
 		log.Info("registered built-in service in registry",
 			zap.String("service", service),
 		)
@@ -196,28 +209,36 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	var services []Service
 	var serviceRunners []*ServiceRunner
 
-	for _, service := range opts.Services {
-		if service.Endpoint() == "" {
-			// In-process: register on the shared server and point every
-			// service name at the shared loopback backend.
-			service.RegisterService(server)
-			log.Info("registered in-process service in registry",
-				zap.String("service", service.Name()),
+	for _, entry := range opts.Services {
+		if entry.service.Endpoint() == "" {
+			// Shared-server service: register on the gateway's gRPC server and
+			// point every service name at the shared loopback backend using the
+			// declared kind.
+			entry.service.RegisterService(server)
+			var msg string
+			switch entry.kind {
+			case BackendKindBuiltin:
+				msg = "registered built-in service in registry"
+			default:
+				msg = "registered in-process service in registry"
+			}
+			log.Info(msg,
+				zap.String("service", entry.service.Name()),
 			)
 
-			for _, name := range service.ServicesNames() {
-				registry.RegisterBackend(name, loopback)
-				log.Debug("registered in-process service in registry",
+			for _, name := range entry.service.ServicesNames() {
+				registry.RegisterBackend(name, loopback, entry.kind)
+				log.Debug(msg,
 					zap.String("service", name),
 				)
 			}
 		} else {
 			// Out-of-process: wrap in a ServiceRunner.
-			runner := NewServiceRunner(service, cfg.Server.Endpoint, cfg.Server.TLS, log)
+			runner := NewServiceRunner(entry.service, cfg.Server.Endpoint, cfg.Server.TLS, log)
 			serviceRunners = append(serviceRunners, runner)
 		}
 
-		services = append(services, service)
+		services = append(services, entry.service)
 	}
 
 	return &Gateway{

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -1,0 +1,59 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// sharedServerService is a test Service whose Endpoint returns "" so it is
+// hosted on the gateway's own gRPC server.
+type sharedServerService struct {
+	name     string
+	svcNames []string
+}
+
+func (m *sharedServerService) Name() string                   { return m.name }
+func (m *sharedServerService) Endpoint() string               { return "" }
+func (m *sharedServerService) ServicesNames() []string        { return m.svcNames }
+func (m *sharedServerService) RegisterService(_ *grpc.Server) {}
+
+// TestNewGateway_DeclaredKindsWired verifies that WithBuiltinService records
+// BackendKindBuiltin and WithService records BackendKindInProcess for services
+// that share the gateway's own gRPC server, regardless of endpoint being empty
+// in both cases.
+func TestNewGateway_DeclaredKindsWired(t *testing.T) {
+	t.Parallel()
+
+	builtinSvc := &sharedServerService{
+		name:     "builtin-framework",
+		svcNames: []string{"test.BuiltinService"},
+	}
+	inprocSvc := &sharedServerService{
+		name:     "inproc-module",
+		svcNames: []string{"test.InProcessService"},
+	}
+
+	cfg := DefaultConfig()
+	gw, err := NewGateway(cfg,
+		WithBuiltinService(builtinSvc),
+		WithService(inprocSvc),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	entries := gw.registry.ListBackends()
+	kinds := map[string]BackendKind{}
+	for _, e := range entries {
+		kinds[e.Service()] = e.Kind()
+	}
+
+	// Framework services registered with WithBuiltinService must be built-in.
+	require.Equal(t, BackendKindBuiltin, kinds["ynpb.Gateway"], "ynpb.Gateway must be built-in")
+	require.Equal(t, BackendKindBuiltin, kinds["ynpb.Auth"], "ynpb.Auth must be built-in")
+	require.Equal(t, BackendKindBuiltin, kinds["test.BuiltinService"], "WithBuiltinService must yield built-in kind")
+
+	// Module/device services registered with WithService must be in-process.
+	require.Equal(t, BackendKindInProcess, kinds["test.InProcessService"], "WithService must yield in-process kind")
+}

--- a/controlplane/gateway/registrar.go
+++ b/controlplane/gateway/registrar.go
@@ -17,6 +17,7 @@ import (
 type gatewayRegistrarOptions struct {
 	Backoff        func() backoff.BackOff
 	MaxElapsedTime time.Duration
+	InProcess      bool
 	Log            *zap.Logger
 }
 
@@ -59,6 +60,14 @@ func WithMaxElapsedTime(d time.Duration) GatewayRegistrarOption {
 	}
 }
 
+// WithInProcess marks every RegisterRequest sent by this registrar as
+// originating from inside the gateway process.
+func WithInProcess(inProcess bool) GatewayRegistrarOption {
+	return func(o *gatewayRegistrarOptions) {
+		o.InProcess = inProcess
+	}
+}
+
 // GatewayRegistrar registers service backends in a single gateway endpoint.
 //
 // A single GatewayRegistrar instance is tied to exactly one endpoint.
@@ -68,6 +77,7 @@ type GatewayRegistrar struct {
 	conn           *grpc.ClientConn
 	backoff        func() backoff.BackOff
 	maxElapsedTime time.Duration
+	inProcess      bool
 	log            *zap.Logger
 }
 
@@ -102,6 +112,7 @@ func NewGatewayRegistrar(
 		conn:           conn,
 		backoff:        opts.Backoff,
 		maxElapsedTime: opts.MaxElapsedTime,
+		inProcess:      opts.InProcess,
 		log:            opts.Log,
 	}, nil
 }
@@ -130,6 +141,7 @@ func (m *GatewayRegistrar) RegisterServices(
 				Name:     name,
 				Endpoint: backendEndpoint,
 			},
+			InProcess: m.inProcess,
 		}
 
 		wg.Go(func() error {

--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -19,6 +19,15 @@ const (
 	RegistrationUpdated
 )
 
+// BackendKind classifies how a backend is hosted relative to the gateway.
+type BackendKind int
+
+const (
+	BackendKindBuiltin BackendKind = iota + 1
+	BackendKindInProcess
+	BackendKindExternal
+)
+
 // Backend is a routable, closeable upstream connection tracked by the registry.
 type Backend interface {
 	proxy.Backend
@@ -30,6 +39,7 @@ type Backend interface {
 type BackendEntry struct {
 	service    string
 	backend    Backend
+	kind       BackendKind
 	lastSeenAt time.Time
 }
 
@@ -46,6 +56,11 @@ func (m *BackendEntry) Endpoint() string {
 // LastSeenAt returns the time the entry was last registered.
 func (m *BackendEntry) LastSeenAt() time.Time {
 	return m.lastSeenAt
+}
+
+// Kind returns the hosting classification of the entry.
+func (m *BackendEntry) Kind() BackendKind {
+	return m.kind
 }
 
 // GetBackend returns the proxy.Backend for this entry.
@@ -84,12 +99,11 @@ func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, bool) {
 // redundant new one on an unchanged-endpoint re-registration) is closed after
 // the lock is released.
 //
-// This close-on-displace path applies only to 1:1 out-of-process module
-// backends.
+// This close-on-displace path applies only to 1:1 external module backends.
 // The shared loopback backend is registered once under distinct keys and is
 // never displaced, so it is only closed by Close().
-func (m *BackendRegistry) RegisterBackend(service string, b Backend) RegistrationStatus {
-	status, evicted := m.registerBackend(service, b)
+func (m *BackendRegistry) RegisterBackend(service string, b Backend, kind BackendKind) RegistrationStatus {
+	status, evicted := m.registerBackend(service, b, kind)
 	if evicted != nil {
 		_ = evicted.Close()
 	}
@@ -97,7 +111,7 @@ func (m *BackendRegistry) RegisterBackend(service string, b Backend) Registratio
 	return status
 }
 
-func (m *BackendRegistry) registerBackend(service string, b Backend) (RegistrationStatus, Backend) {
+func (m *BackendRegistry) registerBackend(service string, b Backend, kind BackendKind) (RegistrationStatus, Backend) {
 	now := time.Now().UTC()
 
 	m.mu.Lock()
@@ -106,29 +120,31 @@ func (m *BackendRegistry) registerBackend(service string, b Backend) (Registrati
 	existing, ok := m.backends[service]
 	switch {
 	case ok && existing.backend.Endpoint() == b.Endpoint():
+		existing.kind = kind
 		existing.lastSeenAt = now
 		m.backends[service] = existing
 		return RegistrationRenewed, b
 	case ok:
-		m.backends[service] = BackendEntry{service: service, backend: b, lastSeenAt: now}
+		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
 		return RegistrationUpdated, existing.backend
 	default:
-		m.backends[service] = BackendEntry{service: service, backend: b, lastSeenAt: now}
+		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
 		return RegistrationRegistered, nil
 	}
 }
 
-// Renew refreshes the last-seen time when service is already registered at
-// endpoint and reports whether it did.
+// Renew refreshes the last-seen timestamp and hosting kind when service is
+// already registered at endpoint, and reports whether it did.
 //
 // A false result means the caller must dial a new backend and call
 // RegisterBackend (new service or changed endpoint).
-func (m *BackendRegistry) Renew(service, endpoint string) bool {
+func (m *BackendRegistry) Renew(service, endpoint string, kind BackendKind) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	entry, ok := m.backends[service]
 	if ok && entry.backend.Endpoint() == endpoint {
+		entry.kind = kind
 		entry.lastSeenAt = time.Now().UTC()
 		m.backends[service] = entry
 		return true

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -8,9 +8,12 @@ import (
 
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/yanet-platform/yanet2/controlplane/ynpb"
 )
 
 // fakeBackend is a test double for the Backend interface.
@@ -50,7 +53,7 @@ func TestBackendRegistry_FirstRegistration(t *testing.T) {
 	reg := NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
-	status := reg.RegisterBackend("svc.Foo", b)
+	status := reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
 
 	require.Equal(t, RegistrationRegistered, status)
 	require.False(t, b.closed)
@@ -63,12 +66,12 @@ func TestBackendRegistry_FirstRegistration(t *testing.T) {
 func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
 	reg := NewBackendRegistry()
 	original := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", original)
+	reg.RegisterBackend("svc.Foo", original, BackendKindExternal)
 
-	// Re-register with a different object but the same endpoint.
+	// Re-register with a different object but the same endpoint and a changed kind.
 	second := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
-	status := reg.RegisterBackend("svc.Foo", second)
+	status := reg.RegisterBackend("svc.Foo", second, BackendKindInProcess)
 
 	require.Equal(t, RegistrationRenewed, status)
 
@@ -81,16 +84,19 @@ func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
 	entry, ok := reg.backends["svc.Foo"]
 	require.True(t, ok)
 	require.Equal(t, original, entry.backend)
+
+	// A changed kind on the same-endpoint path must be reflected.
+	require.Equal(t, BackendKindInProcess, entry.Kind())
 }
 
 func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
 	reg := NewBackendRegistry()
 	prev := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", prev)
+	reg.RegisterBackend("svc.Foo", prev, BackendKindExternal)
 
 	next := &fakeBackend{endpoint: "127.0.0.1:9001"}
 
-	status := reg.RegisterBackend("svc.Foo", next)
+	status := reg.RegisterBackend("svc.Foo", next, BackendKindExternal)
 
 	require.Equal(t, RegistrationUpdated, status)
 
@@ -111,8 +117,8 @@ func TestBackendRegistry_Close(t *testing.T) {
 	bA := &fakeBackend{endpoint: "127.0.0.1:9000"}
 	bB := &fakeBackend{endpoint: "127.0.0.1:9001"}
 
-	reg.RegisterBackend("svc.A", bA)
-	reg.RegisterBackend("svc.B", bB)
+	reg.RegisterBackend("svc.A", bA, BackendKindExternal)
+	reg.RegisterBackend("svc.B", bB, BackendKindExternal)
 
 	err := reg.Close()
 	require.NoError(t, err)
@@ -130,8 +136,8 @@ func TestBackendRegistry_CloseSharedBackendOnce(t *testing.T) {
 
 	// Register the same backend instance under two different service names,
 	// simulating the shared loopback backend used by built-in services.
-	reg.RegisterBackend("svc.A", shared)
-	reg.RegisterBackend("svc.B", shared)
+	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
 
 	err := reg.Close()
 	require.NoError(t, err)
@@ -147,23 +153,23 @@ func TestBackendRegistry_CloseSharedBackendOnce(t *testing.T) {
 func TestBackendRegistry_Renew(t *testing.T) {
 	reg := NewBackendRegistry()
 	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-	reg.RegisterBackend("svc.Foo", b)
+	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
 
 	before := reg.backends["svc.Foo"].lastSeenAt
 
 	// Sleep briefly so lastSeenAt can advance.
 	time.Sleep(time.Millisecond)
 
-	ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
+	ok := reg.Renew("svc.Foo", "127.0.0.1:9000", BackendKindExternal)
 	require.True(t, ok, "Renew should return true for matching endpoint")
 	require.True(t, reg.backends["svc.Foo"].lastSeenAt.After(before), "lastSeenAt should advance")
 
 	// Wrong endpoint: Renew must return false.
-	ok = reg.Renew("svc.Foo", "127.0.0.1:9999")
+	ok = reg.Renew("svc.Foo", "127.0.0.1:9999", BackendKindExternal)
 	require.False(t, ok, "Renew should return false for different endpoint")
 
 	// Absent service: Renew must return false.
-	ok = reg.Renew("svc.Missing", "127.0.0.1:9000")
+	ok = reg.Renew("svc.Missing", "127.0.0.1:9000", BackendKindExternal)
 	require.False(t, ok, "Renew should return false for absent service")
 }
 
@@ -185,8 +191,8 @@ func TestBackendRegistry_ConcurrentRace(t *testing.T) {
 		go func() {
 			defer func() { done <- struct{}{} }()
 			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
-			reg.RegisterBackend("svc.Race", b)
-			reg.Renew("svc.Race", "127.0.0.1:9000")
+			reg.RegisterBackend("svc.Race", b, BackendKindExternal)
+			reg.Renew("svc.Race", "127.0.0.1:9000", BackendKindExternal)
 			reg.GetBackend("svc.Race")
 			reg.ListBackends()
 		}()
@@ -196,4 +202,90 @@ func TestBackendRegistry_ConcurrentRace(t *testing.T) {
 	}
 
 	_ = reg.Close()
+}
+
+func TestBackendRegistry_KindIsPreserved(t *testing.T) {
+	reg := NewBackendRegistry()
+
+	builtin := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	inProc := &fakeBackend{endpoint: "127.0.0.1:9001"}
+	ext := &fakeBackend{endpoint: "127.0.0.1:9002"}
+
+	reg.RegisterBackend("svc.Builtin", builtin, BackendKindBuiltin)
+	reg.RegisterBackend("svc.InProcess", inProc, BackendKindInProcess)
+	reg.RegisterBackend("svc.External", ext, BackendKindExternal)
+
+	entries := reg.ListBackends()
+	kinds := map[string]BackendKind{}
+	for _, e := range entries {
+		kinds[e.Service()] = e.Kind()
+	}
+
+	require.Equal(t, BackendKindBuiltin, kinds["svc.Builtin"])
+	require.Equal(t, BackendKindInProcess, kinds["svc.InProcess"])
+	require.Equal(t, BackendKindExternal, kinds["svc.External"])
+}
+
+func TestBackendRegistry_RenewUpdatesKind(t *testing.T) {
+	cases := []struct {
+		name     string
+		initial  BackendKind
+		renewed  BackendKind
+		wantKind BackendKind
+	}{
+		{"same kind preserved", BackendKindExternal, BackendKindExternal, BackendKindExternal},
+		{"external to in-process", BackendKindExternal, BackendKindInProcess, BackendKindInProcess},
+		{"in-process to external", BackendKindInProcess, BackendKindExternal, BackendKindExternal},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := NewBackendRegistry()
+			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+			reg.RegisterBackend("svc.Foo", b, tc.initial)
+
+			ok := reg.Renew("svc.Foo", "127.0.0.1:9000", tc.renewed)
+			require.True(t, ok)
+
+			entries := reg.ListBackends()
+			require.Len(t, entries, 1)
+			require.Equal(t, tc.wantKind, entries[0].Kind())
+		})
+	}
+}
+
+// TestGatewayService_RegisterKindResolution verifies that the Register RPC
+// maps in_process=true to BackendKindInProcess and in_process=false (or unset)
+// to BackendKindExternal.
+func TestGatewayService_RegisterKindResolution(t *testing.T) {
+	cases := []struct {
+		name      string
+		inProcess bool
+		wantKind  BackendKind
+	}{
+		{"external when unset", false, BackendKindExternal},
+		{"in-process when set", true, BackendKindInProcess},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := NewBackendRegistry()
+			svc := NewGatewayService(reg, zap.NewNop())
+
+			_, err := svc.Register(t.Context(), &ynpb.RegisterRequest{
+				Backend: &ynpb.BackendDesc{
+					Name:     "svc.Test",
+					Endpoint: "passthrough:test-endpoint",
+				},
+				InProcess: tc.inProcess,
+			})
+			require.NoError(t, err)
+
+			entry, ok := reg.backends["svc.Test"]
+			require.True(t, ok)
+			require.Equal(t, tc.wantKind, entry.Kind())
+
+			_ = reg.Close()
+		})
+	}
 }

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -126,6 +126,7 @@ func (m *ServiceRunner) register(ctx context.Context, addr net.Addr) error {
 		m.gatewayEndpoint,
 		m.gatewayTLS,
 		WithRegistrarLog(m.log.With(zap.String("gateway", m.gatewayEndpoint))),
+		WithInProcess(true),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize gateway registrar: %w", err)

--- a/controlplane/gateway/service.go
+++ b/controlplane/gateway/service.go
@@ -12,6 +12,19 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/ynpb"
 )
 
+func backendKindToProto(k BackendKind) ynpb.BackendKind {
+	switch k {
+	case BackendKindBuiltin:
+		return ynpb.BackendKind_BACKEND_KIND_BUILTIN
+	case BackendKindInProcess:
+		return ynpb.BackendKind_BACKEND_KIND_IN_PROCESS
+	case BackendKindExternal:
+		return ynpb.BackendKind_BACKEND_KIND_EXTERNAL
+	default:
+		return ynpb.BackendKind_BACKEND_KIND_UNSPECIFIED
+	}
+}
+
 func registrationStatusToProto(s RegistrationStatus) ynpb.RegistrationStatus {
 	switch s {
 	case RegistrationRegistered:
@@ -55,6 +68,7 @@ func (m *GatewayService) ListServices(
 				Endpoint: b.Endpoint(),
 			},
 			LastSeenAt: timestamppb.New(b.LastSeenAt()),
+			Kind:       backendKindToProto(b.Kind()),
 		}
 
 		services = append(services, registeredBackend)
@@ -90,12 +104,17 @@ func (m *GatewayService) Register(
 	)
 	log.Debug("registering backend")
 
+	kind := BackendKindExternal
+	if req.GetInProcess() {
+		kind = BackendKindInProcess
+	}
+
 	// Fast path: skip dialing when the endpoint is unchanged.
 	//
 	// A registration that races in between this check and RegisterBackend
 	// below is resolved there authoritatively (the redundant connection is
 	// closed), so this check need not be the linearization point.
-	if m.registry.Renew(backendDesc.GetName(), backendDesc.GetEndpoint()) {
+	if m.registry.Renew(backendDesc.GetName(), backendDesc.GetEndpoint(), kind) {
 		log.Debug("renewed backend registration")
 		return &ynpb.RegisterResponse{Status: registrationStatusToProto(RegistrationRenewed)}, nil
 	}
@@ -105,7 +124,7 @@ func (m *GatewayService) Register(
 		return nil, err
 	}
 
-	regStatus := m.registry.RegisterBackend(backendDesc.GetName(), b)
+	regStatus := m.registry.RegisterBackend(backendDesc.GetName(), b, kind)
 	switch regStatus {
 	case RegistrationRegistered:
 		log.Info("registered backend")

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -80,19 +80,19 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 	}
 
 	gatewayOptions := []gateway.GatewayOption{
-		gateway.WithService(
+		gateway.WithBuiltinService(
 			builtin.NewLogging(opts.LogLevel, log),
 		),
-		gateway.WithService(
+		gateway.WithBuiltinService(
 			builtin.NewInspect(cfg.Gateway.InstanceID, shm),
 		),
-		gateway.WithService(
+		gateway.WithBuiltinService(
 			builtin.NewPipeline(cfg.Gateway.InstanceID, shm, log),
 		),
-		gateway.WithService(
+		gateway.WithBuiltinService(
 			builtin.NewFunction(cfg.Gateway.InstanceID, shm, log),
 		),
-		gateway.WithService(
+		gateway.WithBuiltinService(
 			builtin.NewCounters(cfg.Gateway.InstanceID, shm),
 		),
 		gateway.WithLog(log),

--- a/controlplane/ynpb/gateway.proto
+++ b/controlplane/ynpb/gateway.proto
@@ -25,12 +25,29 @@ message BackendDesc {
   string endpoint = 2;
 }
 
+// BackendKind classifies how a registered backend is hosted relative to the
+// gateway, which determines whether its last-seen time reflects a heartbeat.
+enum BackendKind {
+  // Default, unused value.
+  BACKEND_KIND_UNSPECIFIED = 0;
+  // Service compiled into the gateway and sharing its gRPC server. Registered
+  // once at startup; it does not heartbeat.
+  BACKEND_KIND_BUILTIN = 1;
+  // Service launched in the gateway process and registered locally over its
+  // own listener. Registered once; it does not heartbeat.
+  BACKEND_KIND_IN_PROCESS = 2;
+  // Service registered from a separate process and refreshed on a heartbeat
+  // interval.
+  BACKEND_KIND_EXTERNAL = 3;
+}
+
 // RegisteredBackend identifies a registered backend in the Gateway registry.
 message RegisteredBackend {
   BackendDesc backend = 1;
   // LastSeenAt is the timestamp when the service was last successfully
   // registered or updated.
   google.protobuf.Timestamp last_seen_at = 2;
+  BackendKind kind = 3;
 }
 
 // ListServicesResponse contains all known services in the registry.
@@ -49,7 +66,13 @@ enum RegistrationStatus {
 }
 
 // RegisterRequest is the request to register a new module.
-message RegisterRequest { BackendDesc backend = 1; }
+message RegisterRequest {
+  BackendDesc backend = 1;
+  // in_process is set by registrants that run inside the gateway process
+  // (the director's in-process service runner). Separate-process registrants
+  // leave it false.
+  bool in_process = 2;
+}
 
 // RegisterResponse is the response to the RegisterRequest.
 message RegisterResponse { RegistrationStatus status = 1; }


### PR DESCRIPTION
Built-in and in-process gateway services never heartbeat, so their last-seen timestamp is frozen at registration and they appear perpetually stale in `gateway list`. The gateway also could not tell a service launched in its own process apart from one registered by a separate process. Record how each backend is hosted and surface it.

- Add a `BackendKind` to the registry with three values: built-in (compiled into the gateway, shares its gRPC server), in-process (launched in the gateway process by the director, registers once over its own listener), and external (registered from a separate process and refreshed on a heartbeat interval).
- Let registrants declare whether they run inside the gateway process via a new `RegisterRequest.in_process` flag. The director's in-process service runner sets it; separate-process registrants such as operators leave it false and become external. The gateway marks its own services built-in.
- Extend `Gateway.ListServices` with the resolved kind.
- Show a Kind column in `yanet-cli gateway list` and report a heartbeat age only for external backends; built-in and in-process backends show a dash, since they register once and their liveness equals the gateway's. JSON output carries the kind as a self-describing string.