### PR TITLE
refactor(web): extract useDirtyConfigSet hook

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -28,3 +28,5 @@ export { usePageKeyboardShortcuts } from './usePageKeyboardShortcuts';
 
 export { useModuleRuleCounters } from './useModuleRuleCounters';
 export type { RuleRate, ModuleRuleCountersParams } from './useModuleRuleCounters';
+
+export { useDirtyConfigSet } from './useDirtyConfigSet';

--- a/web/src/hooks/useDirtyConfigSet.ts
+++ b/web/src/hooks/useDirtyConfigSet.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+
+/** Returns the set of config names that currently have unsaved draft changes. */
+export const useDirtyConfigSet = (
+    draftConfigs: string[],
+    isDirty: (config: string) => boolean,
+): Set<string> =>
+    useMemo(() => {
+        const s = new Set<string>();
+        draftConfigs.forEach((c) => {
+            if (isDirty(c)) {
+                s.add(c);
+            }
+        });
+        return s;
+    }, [draftConfigs, isDirty]);

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -3,7 +3,7 @@ import { Button, Icon, Label } from '@gravity-ui/uikit';
 import { Funnel, Pause, Play, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
-import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
+import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet } from '../../../hooks';
 import { useAclDraft } from './useAclDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { Rule } from '../../../api/acl';
@@ -120,11 +120,7 @@ const AclPage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [draftConfigs, draftRules]);
 
-    const dirtySet = useMemo((): Set<string> => {
-        const s = new Set<string>();
-        draftConfigs.forEach(c => { if (isDirty(c)) s.add(c); });
-        return s;
-    }, [draftConfigs, isDirty]);
+    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
 
     const deferredSearch = useDeferredValue(search);
 

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Funnel, Plus } from '@gravity-ui/icons';
-import { useSearchParamHelpers } from '../../../hooks';
+import { useSearchParamHelpers, useDirtyConfigSet } from '../../../hooks';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder, SearchInput, RowCountDisplay } from '../../../components';
 import { usePrefixDraft } from './usePrefixDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
@@ -105,11 +105,7 @@ const DecapPage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [draftConfigs, draftRows]);
 
-    const dirtySet = useMemo((): Set<string> => {
-        const s = new Set<string>();
-        draftConfigs.forEach((c) => { if (isDirty(c)) s.add(c); });
-        return s;
-    }, [draftConfigs, isDirty]);
+    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
 
     const visibleRows = useMemo((): PrefixRowItem[] => {
         const q = search.trim().toLowerCase();

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, usePageKeyboardShortcuts } from '../../../hooks';
+import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
@@ -96,11 +96,7 @@ const ForwardPage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [draftConfigs, draftRules]);
 
-    const dirtySet = useMemo((): Set<string> => {
-        const s = new Set<string>();
-        draftConfigs.forEach(c => { if (isDirty(c)) s.add(c); });
-        return s;
-    }, [draftConfigs, isDirty]);
+    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
 
     const visibleItems = useMemo((): RuleItem[] => {
         let res = allItems;

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers } from '../../../hooks';
+import { useSearchParamHelpers, useDirtyConfigSet } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useFIBDraft } from './useFIBDraft';
@@ -96,11 +96,7 @@ const RoutePage: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [draftConfigs, draftRows]);
 
-    const dirtySet = useMemo((): Set<string> => {
-        const s = new Set<string>();
-        draftConfigs.forEach((c) => { if (isDirty(c)) s.add(c); });
-        return s;
-    }, [draftConfigs, isDirty]);
+    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
 
     const visibleRows = useMemo((): FIBRowItem[] => {
         const q = search.trim().toLowerCase();


### PR DESCRIPTION
- Extracted a useDirtyConfigSet hook into web/src/hooks/, replacing the identical useMemo that the forward, acl, decap and route module pages each used to compute the set of config names with unsaved draft changes.
- No behavior change: the hook preserves the original memoization deps ([draftConfigs, isDirty]); verified zero visual diff on all four pages against main.