### PR TITLE
refactor(web): extract useConfigQuerySync hook

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -30,3 +30,6 @@ export { useModuleRuleCounters } from './useModuleRuleCounters';
 export type { RuleRate, ModuleRuleCountersParams } from './useModuleRuleCounters';
 
 export { useDirtyConfigSet } from './useDirtyConfigSet';
+
+export { useConfigQuerySync } from './useConfigQuerySync';
+export type { UseConfigQuerySyncOptions } from './useConfigQuerySync';

--- a/web/src/hooks/useConfigQuerySync.ts
+++ b/web/src/hooks/useConfigQuerySync.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+/** Options for the useConfigQuerySync hook. */
+export interface UseConfigQuerySyncOptions {
+    currentConfig: string;
+    loading: boolean;
+    queryConfig: string | null;
+    paramKey: string;
+    searchParams: URLSearchParams;
+    updateParams: (updates: Record<string, string | null>) => void;
+}
+
+/** Keeps the given URL query param in sync with the currently selected config. */
+export const useConfigQuerySync = ({
+    currentConfig, loading, queryConfig, paramKey, searchParams, updateParams,
+}: UseConfigQuerySyncOptions): void => {
+    useEffect(() => {
+        const updates: Record<string, string | null> = {};
+        if (!loading) {
+            if (!currentConfig) {
+                if (searchParams.get(paramKey) !== null) {
+                    updates[paramKey] = null;
+                }
+            } else if (queryConfig !== currentConfig) {
+                updates[paramKey] = currentConfig;
+            }
+        }
+        if (Object.keys(updates).length > 0) {
+            updateParams(updates);
+        }
+    }, [currentConfig, loading, queryConfig, paramKey, searchParams, updateParams]);
+};

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -3,7 +3,7 @@ import { Button, Icon, Label } from '@gravity-ui/uikit';
 import { Funnel, Pause, Play, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
-import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet } from '../../../hooks';
+import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet, useConfigQuerySync } from '../../../hooks';
 import { useAclDraft } from './useAclDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { Rule } from '../../../api/acl';
@@ -73,21 +73,7 @@ const AclPage: React.FC = () => {
         : (draftConfigs[0] || '');
     const { updateParams, clearConfigParamIfCurrent } = useSearchParamHelpers(setSearchParams, QP_CONFIG);
 
-    useEffect(() => {
-        const updates: Record<string, string | null> = {};
-        if (!loading) {
-            if (!currentConfig) {
-                if (searchParams.get(QP_CONFIG) !== null) {
-                    updates[QP_CONFIG] = null;
-                }
-            } else if (queryConfig !== currentConfig) {
-                updates[QP_CONFIG] = currentConfig;
-            }
-        }
-        if (Object.keys(updates).length > 0) {
-            updateParams(updates);
-        }
-    }, [currentConfig, loading, queryConfig, searchParams, updateParams]);
+    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: QP_CONFIG, searchParams, updateParams });
 
     useUnsavedChangesBlocker(anyDirty);
 

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Funnel, Plus } from '@gravity-ui/icons';
-import { useSearchParamHelpers, useDirtyConfigSet } from '../../../hooks';
+import { useSearchParamHelpers, useDirtyConfigSet, useConfigQuerySync } from '../../../hooks';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder, SearchInput, RowCountDisplay } from '../../../components';
 import { usePrefixDraft } from './usePrefixDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
@@ -66,21 +66,7 @@ const DecapPage: React.FC = () => {
         enabled: !loading,
     });
 
-    useEffect(() => {
-        const updates: Record<string, string | null> = {};
-        if (!loading) {
-            if (!currentConfig) {
-                if (searchParams.get(QP_CONFIG) !== null) {
-                    updates[QP_CONFIG] = null;
-                }
-            } else if (queryConfig !== currentConfig) {
-                updates[QP_CONFIG] = currentConfig;
-            }
-        }
-        if (Object.keys(updates).length > 0) {
-            updateParams(updates);
-        }
-    }, [currentConfig, loading, queryConfig, searchParams, updateParams]);
+    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: QP_CONFIG, searchParams, updateParams });
 
     useEffect(() => {
         setActiveRowId(null);

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet } from '../../../hooks';
+import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet, useConfigQuerySync } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
@@ -68,21 +68,7 @@ const ForwardPage: React.FC = () => {
 
     useUnsavedChangesBlocker(anyDirty);
 
-    useEffect(() => {
-        const updates: Record<string, string | null> = {};
-        if (!loading) {
-            if (!currentConfig) {
-                if (searchParams.get(QP_CONFIG) !== null) {
-                    updates[QP_CONFIG] = null;
-                }
-            } else if (queryConfig !== currentConfig) {
-                updates[QP_CONFIG] = currentConfig;
-            }
-        }
-        if (Object.keys(updates).length > 0) {
-            updateParams(updates);
-        }
-    }, [currentConfig, loading, queryConfig, searchParams, updateParams]);
+    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: QP_CONFIG, searchParams, updateParams });
 
     const rawRules: Rule[] = draftRules(currentConfig);
     const allItems = useMemo(() => rulesToNgItems(rawRules), [rawRules]);

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, useDirtyConfigSet } from '../../../hooks';
+import { useSearchParamHelpers, useDirtyConfigSet, useConfigQuerySync } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useFIBDraft } from './useFIBDraft';
@@ -59,21 +59,7 @@ const RoutePage: React.FC = () => {
 
     const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig))) ? queryConfig : (draftConfigs[0] || '');
 
-    useEffect(() => {
-        const updates: Record<string, string | null> = {};
-        if (!loading) {
-            if (!currentConfig) {
-                if (searchParams.get(QP_CONFIG) !== null) {
-                    updates[QP_CONFIG] = null;
-                }
-            } else if (queryConfig !== currentConfig) {
-                updates[QP_CONFIG] = currentConfig;
-            }
-        }
-        if (Object.keys(updates).length > 0) {
-            updateParams(updates);
-        }
-    }, [currentConfig, loading, queryConfig, searchParams, updateParams]);
+    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: QP_CONFIG, searchParams, updateParams });
 
     useEffect(() => {
         setActiveRowId(null);


### PR DESCRIPTION
- Extracted a useConfigQuerySync hook into web/src/hooks/, replacing the identical effect that the forward, acl, decap and route module pages each used to keep the ?config= URL query param in sync with the selected config.
- No behavior change: the effect logic and memoization deps are preserved (the config param key is now passed in but is a stable constant at every call site); verified zero visual diff and identical URL-sync behavior on all four pages against main.