### PR TITLE
refactor(web): extract shared bordered-toolbar class

### DIFF
--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -470,7 +470,7 @@ const AclPage: React.FC = () => {
                             onSelect={handleTabSelect}
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
-                        <div className="acl-toolbar">
+                        <div className="yn-toolbar-bordered">
                             {currentFwStateName && (
                                 <Button size="s" view="outlined" onClick={handleOpenLinkedFwstate}>
                                     FWState: {currentFwStateName}

--- a/web/src/pages/modules/acl/acl.scss
+++ b/web/src/pages/modules/acl/acl.scss
@@ -5,11 +5,6 @@
 // web/src/styles/draft-page.scss which this page imports. This file covers only
 // ACL-specific chip colors, action chain, editor elements, and override tweaks.
 
-.acl-toolbar {
-    @include yn-toolbar;
-    border-bottom: 1px solid var(--yn-line);
-}
-
 // Chip list container.
 .acl-chip-list {
     display: inline-flex;

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -268,7 +268,7 @@ const DecapPage: React.FC = () => {
                             onSelect={setActiveConfig}
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
-                        <div className="decap-toolbar">
+                        <div className="yn-toolbar-bordered">
                             <div style={{ flex: 1 }} />
                             <div style={{ flexBasis: 230, flexShrink: 1 }}>
                                 <SearchInput

--- a/web/src/pages/modules/decap/decap.scss
+++ b/web/src/pages/modules/decap/decap.scss
@@ -1,7 +1,3 @@
 @use '../../../styles/variables' as *;
 @use '../../../styles/mixins' as *;
 
-.decap-toolbar {
-    @include yn-toolbar;
-    border-bottom: 1px solid var(--yn-line);
-}

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -399,7 +399,7 @@ const ForwardPage: React.FC = () => {
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
 
-                        <div className="fw-toolbar">
+                        <div className="yn-toolbar-bordered">
                             <ModeFilter value={modeFilter} onChange={setModeFilter} />
                             <div style={{ flex: 1 }} />
                             <div style={{ flexBasis: 230, flexShrink: 1 }}>

--- a/web/src/pages/modules/forward/forward.scss
+++ b/web/src/pages/modules/forward/forward.scss
@@ -1,13 +1,6 @@
 @use '../../../styles/variables' as *;
 @use '../../../styles/mixins' as *;
 
-// Toolbar + count — mirroring route.scss layout
-
-.fw-toolbar {
-    @include yn-toolbar;
-    border-bottom: 1px solid var(--yn-line);
-}
-
 // Forward-specific styles — direction badges, sparkline, chip-input, segmented control.
 // Shared page chrome (yn-page, yn-tabs, yn-table-*, yn-modal*, yn-drawer*, yn-bulk-bar, etc.)
 // lives in web/src/styles/draft-page.scss.

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -298,7 +298,7 @@ const RoutePage: React.FC = () => {
                             onSelect={handleConfigSelect}
                             onAddConfig={() => setAddConfigOpen(true)}
                         />
-                        <div className="rt-toolbar">
+                        <div className="yn-toolbar-bordered">
                             <div style={{ flex: 1 }} />
                             <div style={{ flexBasis: 230, flexShrink: 1 }}>
                                 <SearchInput

--- a/web/src/pages/modules/route/route.scss
+++ b/web/src/pages/modules/route/route.scss
@@ -1,7 +1,3 @@
 @use '../../../styles/variables' as *;
 @use '../../../styles/mixins' as *;
 
-.rt-toolbar {
-    @include yn-toolbar;
-    border-bottom: 1px solid var(--yn-line);
-}

--- a/web/src/styles/draft/_surface.scss
+++ b/web/src/styles/draft/_surface.scss
@@ -1,3 +1,5 @@
+@use '../mixins' as *;
+
 // Page container
 
 .yn-page {
@@ -89,4 +91,9 @@
 
 .yn-flat-page .yn-content {
     padding: 0;
+}
+
+.yn-toolbar-bordered {
+    @include yn-toolbar;
+    border-bottom: 1px solid var(--yn-line);
 }


### PR DESCRIPTION
- Replaced the four byte-identical page toolbar classes (acl, forward, route, decap) with a single shared .yn-toolbar-bordered chrome class in styles/draft/_surface.scss.
- The operator-route and neighbours toolbars are left untouched since they add their own flex-wrap/background rules.
- No behavior change: the shared class composes the same yn-toolbar mixin plus bottom border; verified zero visual diff on all four pages against main.