### PR TITLE
refactor(web): migrate route and neighbours to shared flat-surface classes

### DIFF
--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -520,15 +520,15 @@ const NeighboursPage: React.FC = () => {
 
     if (loading) {
         return (
-            <PageLayout header={pageHeader} className="nb-layout">
+            <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
             </PageLayout>
         );
     }
 
     return (
-        <PageLayout header={pageHeader} className="nb-layout">
-            <div className="yn-page nb-page">
+        <PageLayout header={pageHeader} className="yn-flat-layout">
+            <div className="yn-page nb-page yn-flat-page">
                 {tables.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No neighbour tables found."

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -400,15 +400,15 @@ const RoutePage: React.FC = () => {
 
     if (loading && configs.length === 0) {
         return (
-            <PageLayout header={pageHeader} className="ro-layout">
+            <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
             </PageLayout>
         );
     }
 
     return (
-        <PageLayout header={pageHeader} className="ro-layout">
-            <div className="yn-page ro-page" aria-busy={refreshing}>
+        <PageLayout header={pageHeader} className="yn-flat-layout">
+            <div className="yn-page yn-flat-page" aria-busy={refreshing}>
                 {configs.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No route configurations found."

--- a/web/src/pages/operators/route/route.scss
+++ b/web/src/pages/operators/route/route.scss
@@ -281,20 +281,4 @@ $_ro-col-med:      42px;
     font-size: 13px;
 }
 
-// ─── Surface color — single control point for the whole route page ───────────
-
-// Flip to #15110D for the flat (page-bg) look; #1C1814 for the panel look.
-.ro-layout {
-    --ro-surface-bg: #1C1814;
-}
-
-.yn-page.ro-page {
-    background: var(--ro-surface-bg);
-}
-
-// Table flush: no outer padding and no card chrome.
-// Keeps per-row separators and the header bottom border.
-.ro-page .yn-content {
-    padding: 0;
-}
 

--- a/web/src/styles/draft/_neighbours.scss
+++ b/web/src/styles/draft/_neighbours.scss
@@ -388,36 +388,10 @@
     }
 }
 
-// Neighbours page flush + borderless-tab overrides.
-// Mirrors the .ro-page treatment in route.scss, scoped to .nb-page only.
-
-.yn-page.nb-page {
-    background: var(--yn-page-bg);
-}
-
+// Neighbours-specific tab-row overrides (flush border, no bottom rule).
 .nb-page .yn-tabs-row {
     border-bottom: none;
-}
-
-.nb-page .yn-content {
-    padding: 0;
-}
-
-// Surface color — mirrors the ro-layout/ro-page pattern from route.scss, scoped to neighbours.
-// The --nb-surface-bg token cascades from .nb-layout to both the header subtree
-// and the .nb-page content subtree, keeping both on the same flat #1C1814 plane.
-.nb-layout {
-    --nb-surface-bg: #1C1814;
-}
-
-// Two-class specificity beats `.yn-page { background: var(--yn-page-bg) }`.
-.yn-page.nb-page {
-    background: var(--nb-surface-bg);
-}
-
-// Tab strip and tabs-row sit on the same flat surface.
-.nb-page .yn-tabs-row {
-    background: var(--nb-surface-bg);
+    background: var(--yn-surface-bg);
 }
 
 // Neighbours toolbar row — hosts the family filter and state chips below the tabs-row.
@@ -425,7 +399,7 @@
     @include yn-toolbar;
     flex-wrap: wrap;
     border-bottom: 1px solid var(--yn-line);
-    background: var(--nb-surface-bg, var(--yn-page-bg));
+    background: var(--yn-surface-bg, var(--yn-page-bg));
 }
 
 // State filter chips row separator (thin vertical divider between FamilyFilter and chips).

--- a/web/src/styles/draft/_surface.scss
+++ b/web/src/styles/draft/_surface.scss
@@ -77,9 +77,7 @@
 
 // Shared flat-surface layout treatment.
 // Pages that apply .yn-flat-layout (on PageLayout) and .yn-flat-page (on .yn-page)
-// get the same unified #1C1814 surface, flush table, and 3px active underline.
-// Route (.ro-layout/.ro-page) and neighbours (.nb-layout/.nb-page) are temporary
-// duplicates that will migrate onto these shared classes in a later PR.
+// get the unified #1C1814 surface and flush content area (padding: 0).
 
 .yn-flat-layout {
     --yn-surface-bg: #1C1814;


### PR DESCRIPTION
- Migrated the operator-route and neighbours pages onto the shared .yn-flat-layout/.yn-flat-page classes, removing their duplicate --ro-surface-bg/--nb-surface-bg token blocks that re-implemented the same flat #1C1814 surface treatment.
- Repointed the neighbours-specific tabs-row and toolbar backgrounds at the shared --yn-surface-bg token (preserving the tabs-row border-bottom override).
- Updated the _surface.scss comment that previously marked these two pages as pending migration.
- No behavior change: verified zero visual diff on /operators/neighbours (full page) and on the /operators/route surface/chrome regions against main.