### PR TITLE
refactor(web): extract shared iv-tokens palette partial

### DIFF
--- a/web/src/pages/builtin/dashboard/dashboard.scss
+++ b/web/src/pages/builtin/dashboard/dashboard.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/iv-tokens' as *;
+
 @mixin dash-ambient-scan {
     position: relative;
     overflow: hidden;
@@ -22,29 +24,7 @@
 }
 
 .dashboard-page {
-    // Warm dark-brown palette, mirrored from .inspect-page.
-    --iv-bg:             #15110D;
-    --iv-bg-2:           #181410;
-    --iv-surface:        #1C1814;
-    --iv-surface-strong: #1C1814;
-    --iv-bg-3:           #221C16;
-    --iv-border:         rgba(255, 199, 140, 0.02);
-    --iv-border-strong:  rgba(255, 200, 140, 0.12);
-    --iv-text:           #F2EEE8;
-    --iv-text-dim:       #B8B0A4;
-    --iv-mute:           #7E7468;
-    --iv-dim:            #7E7468;
-    --iv-accent:         #FFC061;
-    --iv-accent-soft:    rgba(255, 192, 97, 0.14);
-    --iv-accent-line:    rgba(255, 192, 97, 0.4);
-    --iv-link:           var(--g-color-text-info);
-    --iv-ok:             var(--g-color-text-positive);
-    --iv-idle:           var(--g-color-text-hint);
-    --iv-danger:         var(--g-color-text-danger);
-    --iv-warn:           var(--g-color-text-warning);
-    --iv-faint:          var(--iv-border-strong);
-    --iv-mono:           'JetBrains Mono', ui-monospace, monospace;
-    --iv-font-ui:        'Inter', system-ui, sans-serif;
+    @include iv-palette;
 
     font-family: var(--iv-mono);
     color: var(--iv-text);
@@ -401,17 +381,7 @@
 
 [data-theme="light"] {
     .dashboard-page {
-        --iv-bg:             #FAF7F2;
-        --iv-bg-2:           #F3EFE9;
-        --iv-surface:        #FFFFFF;
-        --iv-surface-strong: #FFFFFF;
-        --iv-bg-3:           #EBE6DE;
-        --iv-border:         rgba(80, 60, 30, 0.08);
-        --iv-border-strong:  rgba(80, 60, 30, 0.16);
-        --iv-text:           #1A1410;
-        --iv-text-dim:       #5C4E3A;
-        --iv-mute:           #9C8B74;
-        --iv-dim:            #9C8B74;
+        @include iv-palette-light;
     }
 }
 

--- a/web/src/pages/builtin/inspect/inspect.scss
+++ b/web/src/pages/builtin/inspect/inspect.scss
@@ -1,31 +1,11 @@
+@use '../../../styles/iv-tokens' as *;
+
 .inspect-page {
-    // Warm dark-brown palette, mirrored from .fn-page (FunctionsPage.scss).
-    --iv-bg:             #15110D;
-    --iv-bg-2:           #181410;
-    --iv-surface:        #1C1814;
-    --iv-surface-strong: #1C1814;
-    --iv-bg-3:           #221C16;
-    --iv-border:         rgba(255, 199, 140, 0.02);
-    --iv-border-strong:  rgba(255, 200, 140, 0.12);
-    --iv-text:           #F2EEE8;
-    --iv-text-dim:       #B8B0A4;
-    --iv-mute:           #7E7468;
-    --iv-dim:            #7E7468;
-    --iv-accent:         #FFC061;
-    --iv-accent-soft:    rgba(255, 192, 97, 0.14);
-    --iv-accent-line:    rgba(255, 192, 97, 0.4);
-    --iv-link:           var(--g-color-text-info);
-    --iv-ok:             var(--g-color-text-positive);
-    --iv-idle:           var(--g-color-text-hint);
-    --iv-danger:         var(--g-color-text-danger);
-    --iv-warn:           var(--g-color-text-warning);
-    --iv-faint:          var(--iv-border-strong);
+    @include iv-palette;
     --iv-r-sm:           4px;
     --iv-r-md:           6px;
     --iv-r-lg:           10px;
     --iv-r-xl:           14px;
-    --iv-mono:           'JetBrains Mono', ui-monospace, monospace;
-    --iv-font-ui:        'Inter', system-ui, sans-serif;
 
     font-family: var(--iv-mono);
     color: var(--iv-text);
@@ -583,17 +563,7 @@
 // Light-mode palette overrides — neutral tiers flip to warm light, accents stay.
 [data-theme="light"] {
     .inspect-page {
-        --iv-bg:             #FAF7F2;
-        --iv-bg-2:           #F3EFE9;
-        --iv-surface:        #FFFFFF;
-        --iv-surface-strong: #FFFFFF;
-        --iv-bg-3:           #EBE6DE;
-        --iv-border:         rgba(80, 60, 30, 0.08);
-        --iv-border-strong:  rgba(80, 60, 30, 0.16);
-        --iv-text:           #1A1410;
-        --iv-text-dim:       #5C4E3A;
-        --iv-mute:           #9C8B74;
-        --iv-dim:            #9C8B74;
+        @include iv-palette-light;
     }
 }
 

--- a/web/src/styles/_iv-tokens.scss
+++ b/web/src/styles/_iv-tokens.scss
@@ -1,0 +1,40 @@
+// Shared warm-dark palette tokens used by .inspect-page and .dashboard-page.
+
+@mixin iv-palette {
+    --iv-bg:             #15110D;
+    --iv-bg-2:           #181410;
+    --iv-surface:        #1C1814;
+    --iv-surface-strong: #1C1814;
+    --iv-bg-3:           #221C16;
+    --iv-border:         rgba(255, 199, 140, 0.02);
+    --iv-border-strong:  rgba(255, 200, 140, 0.12);
+    --iv-text:           #F2EEE8;
+    --iv-text-dim:       #B8B0A4;
+    --iv-mute:           #7E7468;
+    --iv-dim:            #7E7468;
+    --iv-accent:         #FFC061;
+    --iv-accent-soft:    rgba(255, 192, 97, 0.14);
+    --iv-accent-line:    rgba(255, 192, 97, 0.4);
+    --iv-link:           var(--g-color-text-info);
+    --iv-ok:             var(--g-color-text-positive);
+    --iv-idle:           var(--g-color-text-hint);
+    --iv-danger:         var(--g-color-text-danger);
+    --iv-warn:           var(--g-color-text-warning);
+    --iv-faint:          var(--iv-border-strong);
+    --iv-mono:           'JetBrains Mono', ui-monospace, monospace;
+    --iv-font-ui:        'Inter', system-ui, sans-serif;
+}
+
+@mixin iv-palette-light {
+    --iv-bg:             #FAF7F2;
+    --iv-bg-2:           #F3EFE9;
+    --iv-surface:        #FFFFFF;
+    --iv-surface-strong: #FFFFFF;
+    --iv-bg-3:           #EBE6DE;
+    --iv-border:         rgba(80, 60, 30, 0.08);
+    --iv-border-strong:  rgba(80, 60, 30, 0.16);
+    --iv-text:           #1A1410;
+    --iv-text-dim:       #5C4E3A;
+    --iv-mute:           #9C8B74;
+    --iv-dim:            #9C8B74;
+}


### PR DESCRIPTION
- Extracted the identical --iv-* warm-dark palette shared by the inspect and dashboard pages into a shared styles/_iv-tokens.scss partial (iv-palette for the dark tokens, iv-palette-light for the light-mode overrides).
- The four inspect-only radius tokens stay inline in .inspect-page; dashboard never referenced them.
- No behavior change: verified all 57 computed --iv-* token values are identical baseline-vs-candidate across dark and light themes on both pages.