### PR TITLE
refactor(readinesspb): adopt .v1 FQN package

### DIFF
--- a/common/go/operator/readiness.go
+++ b/common/go/operator/readiness.go
@@ -7,7 +7,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/yanet-platform/yanet2/common/readinesspb"
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
 
 // scopeState holds the mutable readiness state for one gateway scope.

--- a/common/go/operator/readiness_test.go
+++ b/common/go/operator/readiness_test.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/common/readinesspb"
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
 
 func TestReadiness_InitialState(t *testing.T) {

--- a/common/readinesspb/meson.build
+++ b/common/readinesspb/meson.build
@@ -2,7 +2,7 @@ readiness_proto_dir = meson.current_source_dir()
 root_dir = meson.project_source_root()
 
 readiness_proto_files = [
-    join_paths(readiness_proto_dir, 'readiness.proto'),
+    join_paths(readiness_proto_dir, 'v1', 'readiness.proto'),
 ]
 
 readiness_protoc_gen = custom_target(
@@ -13,9 +13,8 @@ readiness_protoc_gen = custom_target(
     input: readiness_proto_files,
     command: [
         protoc,
-        '-I', readiness_proto_dir,
         '-I', root_dir,
-        '--go_out=paths=source_relative:' + readiness_proto_dir,
+        '--go_out=paths=source_relative:' + root_dir,
         '@INPUT@',
     ],
     build_by_default: true,

--- a/common/readinesspb/v1/readiness.proto
+++ b/common/readinesspb/v1/readiness.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package readinesspb;
+package common.readinesspb.v1;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/yanet-platform/yanet2/common/readinesspb;readinesspb";
+option go_package = "github.com/yanet-platform/yanet2/common/readinesspb/v1;readinesspb";
 
 // ReadyRequest selects which scopes to query.
 //

--- a/common/rust/readinesspb/build.rs
+++ b/common/rust/readinesspb/build.rs
@@ -1,28 +1,28 @@
 use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=common/readinesspb/readiness.proto");
+    println!("cargo:rerun-if-changed=common/readinesspb/v1/readiness.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
-        .message_attribute("readinesspb.Reason", "#[derive(serde::Serialize)]")
-        .message_attribute("readinesspb.ReadyRequest", "#[derive(serde::Serialize)]")
-        .message_attribute("readinesspb.ReadyResponse", "#[derive(serde::Serialize)]")
-        .message_attribute("readinesspb.Scope", "#[derive(serde::Serialize)]")
+        .message_attribute("common.readinesspb.v1.Reason", "#[derive(serde::Serialize)]")
+        .message_attribute("common.readinesspb.v1.ReadyRequest", "#[derive(serde::Serialize)]")
+        .message_attribute("common.readinesspb.v1.ReadyResponse", "#[derive(serde::Serialize)]")
+        .message_attribute("common.readinesspb.v1.Scope", "#[derive(serde::Serialize)]")
         .field_attribute(
-            "readinesspb.Scope.state",
+            "common.readinesspb.v1.Scope.state",
             "#[serde(serialize_with = \"crate::serialize_state\")]",
         )
         .field_attribute(
-            "readinesspb.Scope.observed_at",
+            "common.readinesspb.v1.Scope.observed_at",
             "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
         )
         .field_attribute(
-            "readinesspb.Scope.last_transition_time",
+            "common.readinesspb.v1.Scope.last_transition_time",
             "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
         )
         .enum_attribute(".", "#[derive(serde::Serialize)]")
-        .compile_protos(&["common/readinesspb/readiness.proto"], &["../../.."])
+        .compile_protos(&["common/readinesspb/v1/readiness.proto"], &["../../.."])
         .map_err(Into::into)
 }

--- a/common/rust/readinesspb/src/lib.rs
+++ b/common/rust/readinesspb/src/lib.rs
@@ -2,11 +2,11 @@
 //!
 //! Exposes `pb::ReadyRequest`, `pb::ReadyResponse`, `pb::Scope`,
 //! `pb::State`, and `pb::Reason` generated from
-//! `common/readinesspb/readiness.proto`.
+//! `common/readinesspb/v1/readiness.proto`.
 
 #[allow(clippy::all, non_snake_case)]
 pub mod pb {
-    tonic::include_proto!("readinesspb");
+    tonic::include_proto!("common.readinesspb.v1");
 }
 
 /// Serializes a `readinesspb.State` discriminant as its lowercase name (e.g.

--- a/operators/forward/cli/build.rs
+++ b/operators/forward/cli/build.rs
@@ -2,12 +2,12 @@ use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../../operators/forward/operatorpb/v1/readiness.proto");
-    println!("cargo:rerun-if-changed=../../../common/readinesspb/readiness.proto");
+    println!("cargo:rerun-if-changed=../../../common/readinesspb/v1/readiness.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .build_server(false)
-        .extern_path(".readinesspb", "::readinesspb::pb")
+        .extern_path(".common.readinesspb.v1", "::readinesspb::pb")
         .compile_protos(
             &["../../../operators/forward/operatorpb/v1/readiness.proto"],
             &["../../../"],

--- a/operators/forward/internal/operator/readiness_service.go
+++ b/operators/forward/internal/operator/readiness_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/common/readinesspb"
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/forward/operatorpb/v1"
 )
 

--- a/operators/forward/operatorpb/v1/readiness.proto
+++ b/operators/forward/operatorpb/v1/readiness.proto
@@ -4,10 +4,10 @@ package operators.forward.operatorpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/operators/forward/operatorpb/v1;operatorpb";
 
-import "common/readinesspb/readiness.proto";
+import "common/readinesspb/v1/readiness.proto";
 
 // ReadinessService exposes per-gateway readiness of the forward operator.
 service ReadinessService {
   // Ready returns the current per-gateway readiness state.
-  rpc Ready(readinesspb.ReadyRequest) returns (readinesspb.ReadyResponse);
+  rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/pipeline/cli/build.rs
+++ b/operators/pipeline/cli/build.rs
@@ -3,13 +3,13 @@ use core::error::Error;
 pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../../operators/pipeline/operatorpb/v1/operator.proto");
     println!("cargo:rerun-if-changed=../../../operators/pipeline/operatorpb/v1/readiness.proto");
-    println!("cargo:rerun-if-changed=../../../common/readinesspb/readiness.proto");
+    println!("cargo:rerun-if-changed=../../../common/readinesspb/v1/readiness.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/metric.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)
         .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .extern_path(".readinesspb", "::readinesspb::pb")
+        .extern_path(".common.readinesspb.v1", "::readinesspb::pb")
         .build_server(false)
         .message_attribute(".", "#[derive(serde::Serialize)]")
         .enum_attribute(".", "#[derive(serde::Serialize)]")

--- a/operators/pipeline/internal/operator/readiness_service.go
+++ b/operators/pipeline/internal/operator/readiness_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/common/readinesspb"
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/pipeline/operatorpb/v1"
 )
 

--- a/operators/pipeline/operatorpb/v1/readiness.proto
+++ b/operators/pipeline/operatorpb/v1/readiness.proto
@@ -4,10 +4,10 @@ package operators.pipeline.operatorpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/operators/pipeline/operatorpb/v1;operatorpb";
 
-import "common/readinesspb/readiness.proto";
+import "common/readinesspb/v1/readiness.proto";
 
 // ReadinessService exposes per-gateway readiness of the pipeline operator.
 service ReadinessService {
   // Ready returns the current per-gateway readiness state.
-  rpc Ready(readinesspb.ReadyRequest) returns (readinesspb.ReadyResponse);
+  rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/route/cli/route/build.rs
+++ b/operators/route/cli/route/build.rs
@@ -21,7 +21,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             "#[serde(serialize_with = \"crate::serialize_ip_addr\")]",
         )
         .extern_path(".common.commonpb.v1", "::commonpb::pb")
-        .extern_path(".readinesspb", "::readinesspb::pb")
+        .extern_path(".common.readinesspb.v1", "::readinesspb::pb")
         .compile_protos(
             &[
                 "../../../../operators/route/operatorpb/v1/route.proto",

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/common/readinesspb"
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
 	"github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"

--- a/operators/route/internal/operator/readiness_service.go
+++ b/operators/route/internal/operator/readiness_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/common/readinesspb"
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
 )
 

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/common/readinesspb"
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
 )
 

--- a/operators/route/internal/operator/rib_readiness.go
+++ b/operators/route/internal/operator/rib_readiness.go
@@ -9,7 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/common/readinesspb"
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
 
 // newRIBReadiness returns a birdRIBReadiness when cfg.ExpectBird is true,

--- a/operators/route/operatorpb/v1/readiness.proto
+++ b/operators/route/operatorpb/v1/readiness.proto
@@ -4,10 +4,10 @@ package operators.route.operatorpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1;operatorpb";
 
-import "common/readinesspb/readiness.proto";
+import "common/readinesspb/v1/readiness.proto";
 
 // ReadinessService exposes per-scope readiness of the route operator.
 service ReadinessService {
   // Ready returns the current readiness state for all scopes.
-  rpc Ready(readinesspb.ReadyRequest) returns (readinesspb.ReadyResponse);
+  rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
 }


### PR DESCRIPTION
Migrate the shared `readinesspb` proto surface to the `.v1` FQN convention, completing the `.v1` migration of the `common/*` shared types (after commonpb #1072 and filterpb #1075).

- Move `readiness.proto` into `common/readinesspb/v1/`, renaming the package `readinesspb` to `common.readinesspb.v1`.
- Keep the generated Go package name `readinesspb` via the `go_package` alias, so consumers only gain a `/v1` import path.
- Switch the meson build to the collision-safe `-I root_dir` strategy with a bare-basename output.
- Update importing protos, Go importers, and Rust `extern_path`/`include_proto!`/attribute wiring, including the consumer `rerun-if-changed` paths.

Groundwork for the protobuf v1 baseline and `buf breaking` CI gate (part of #574, #573).