### PR TITLE
refactor(web): extract lane-page palette mixin for functions and pipelines

### DIFF
--- a/web/src/pages/builtin/_shared/lane-editor/_palette.scss
+++ b/web/src/pages/builtin/_shared/lane-editor/_palette.scss
@@ -1,0 +1,58 @@
+// Mixin that emits the warm dark-brown design-token palette for a lane-page.
+// $p    — prefix string, e.g. 'fn' or 'pl'.
+// $card — card class suffix, e.g. 'function-card' or 'pipeline-card'.
+@mixin lane-page-palette($p, $card) {
+    // Dark-mode warm-brown palette (default — app is locked to dark).
+    .#{$p}-page,
+    .#{$p}-drawer,
+    .#{$p}-#{$card} {
+        --#{$p}-page-bg:       #15110D;
+        --#{$p}-panel:         #1C1814;
+        --#{$p}-bg-2:          #181410;
+        --#{$p}-bg-3:          #221C16;
+        --#{$p}-line:          rgba(255, 199, 140, 0.02);
+        --#{$p}-line-2:        rgba(255, 200, 140, 0.12);
+        --#{$p}-text:          #F2EEE8;
+        --#{$p}-text-2:        #B8B0A4;
+        --#{$p}-text-3:        #7E7468;
+        --#{$p}-accent:        #FFC061;
+        --#{$p}-accent-soft:   rgba(255, 192, 97, 0.14);
+        --#{$p}-accent-strong: #FFC061;
+        --#{$p}-danger:        var(--g-color-text-danger);
+        --#{$p}-warn:          var(--g-color-text-warning);
+        --#{$p}-ok:            var(--g-color-text-positive);
+        --#{$p}-r-sm:          4px;
+        --#{$p}-r-md:          6px;
+        --#{$p}-r-lg:          10px;
+        --#{$p}-r-xl:          14px;
+        --#{$p}-font-mono:     'JetBrains Mono', ui-monospace, monospace;
+        --#{$p}-font-ui:       'Inter', system-ui, sans-serif;
+    }
+
+    // Light-mode overrides — scoped so other pages are unaffected.
+    [data-theme="light"] {
+        .#{$p}-page,
+        .#{$p}-drawer,
+        .#{$p}-#{$card} {
+            --#{$p}-page-bg:  #FAF7F2;
+            --#{$p}-panel:    #FFFFFF;
+            --#{$p}-bg-2:     #F3EFE9;
+            --#{$p}-bg-3:     #EBE6DE;
+            --#{$p}-line:     rgba(80, 60, 30, 0.08);
+            --#{$p}-line-2:   rgba(80, 60, 30, 0.16);
+            --#{$p}-text:     #1A1410;
+            --#{$p}-text-2:   #5C4E3A;
+            --#{$p}-text-3:   #9C8B74;
+        }
+    }
+
+    // Neutral lane-editor var aliases consumed by shared lane-editor.scss.
+    .#{$p}-page {
+        --lane-bg-3:        var(--#{$p}-bg-3);
+        --lane-line-2:      var(--#{$p}-line-2);
+        --lane-text-2:      var(--#{$p}-text-2);
+        --lane-accent:      var(--#{$p}-accent);
+        --lane-accent-soft: var(--#{$p}-accent-soft);
+        --lane-r-sm:        var(--#{$p}-r-sm);
+    }
+}

--- a/web/src/pages/builtin/functions/FunctionsPage.scss
+++ b/web/src/pages/builtin/functions/FunctionsPage.scss
@@ -1,64 +1,10 @@
 @use '../../../styles/variables' as *;
 @use '../../../styles/mixins' as *;
 @use '../_shared/lane-editor/lane-editor';
+@use '../_shared/lane-editor/palette' as palette;
 
-// Design tokens scoped to this page — warm dark-brown palette.
-// All fn-* tokens are overridden here so other pages stay Gravity-default.
-// Light-mode overrides are provided under [data-theme="light"] .fn-page.
-.fn-page,
-.fn-drawer,
-.fn-function-card {
-    // Dark-mode warm-brown palette (default — app is locked to dark).
-    --fn-page-bg:       #15110D;
-    --fn-panel:         #1C1814;
-    --fn-bg-2:          #181410;
-    --fn-bg-3:          #221C16;
-    --fn-line:          rgba(255, 199, 140, 0.02);
-    --fn-line-2:        rgba(255, 200, 140, 0.12);
-    --fn-text:          #F2EEE8;
-    --fn-text-2:        #B8B0A4;
-    --fn-text-3:        #7E7468;
-    --fn-accent:        #FFC061;
-    --fn-accent-soft:   rgba(255, 192, 97, 0.14);
-    --fn-accent-strong: #FFC061;
-    --fn-danger:        var(--g-color-text-danger);
-    --fn-warn:          var(--g-color-text-warning);
-    --fn-ok:            var(--g-color-text-positive);
-    --fn-r-sm:          4px;
-    --fn-r-md:          6px;
-    --fn-r-lg:          10px;
-    --fn-r-xl:          14px;
-    --fn-font-mono:     'JetBrains Mono', ui-monospace, monospace;
-    --fn-font-ui:       'Inter', system-ui, sans-serif;
-}
-
-// Light-mode overrides — scoped to .fn-page so other pages are unaffected.
-[data-theme="light"] {
-    .fn-page,
-    .fn-drawer,
-    .fn-function-card {
-        --fn-page-bg:  #FAF7F2;
-        --fn-panel:    #FFFFFF;
-        --fn-bg-2:     #F3EFE9;
-        --fn-bg-3:     #EBE6DE;
-        --fn-line:     rgba(80, 60, 30, 0.08);
-        --fn-line-2:   rgba(80, 60, 30, 0.16);
-        --fn-text:     #1A1410;
-        --fn-text-2:   #5C4E3A;
-        --fn-text-3:   #9C8B74;
-    }
-}
-
-// ─── Neutral lane-editor var aliases (consumed by shared lane-editor.scss) ────
-
-.fn-page {
-    --lane-bg-3:        var(--fn-bg-3);
-    --lane-line-2:      var(--fn-line-2);
-    --lane-text-2:      var(--fn-text-2);
-    --lane-accent:      var(--fn-accent);
-    --lane-accent-soft: var(--fn-accent-soft);
-    --lane-r-sm:        var(--fn-r-sm);
-}
+// Design tokens — warm dark-brown palette scoped to this page.
+@include palette.lane-page-palette('fn', 'function-card');
 
 // ─── Page container ───────────────────────────────────────────────────────────
 

--- a/web/src/pages/builtin/pipelines/PipelinesPage.scss
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.scss
@@ -1,64 +1,10 @@
 @use '../../../styles/variables' as *;
 @use '../../../styles/mixins' as *;
 @use '../_shared/lane-editor/lane-editor';
+@use '../_shared/lane-editor/palette' as palette;
 
-// Design tokens scoped to this page — warm dark-brown palette.
-// All pl-* tokens are overridden here so other pages stay Gravity-default.
-// Light-mode overrides are provided under [data-theme="light"] .pl-page.
-.pl-page,
-.pl-drawer,
-.pl-pipeline-card {
-    // Dark-mode warm-brown palette (default — app is locked to dark).
-    --pl-page-bg:       #15110D;
-    --pl-panel:         #1C1814;
-    --pl-bg-2:          #181410;
-    --pl-bg-3:          #221C16;
-    --pl-line:          rgba(255, 199, 140, 0.02);
-    --pl-line-2:        rgba(255, 200, 140, 0.12);
-    --pl-text:          #F2EEE8;
-    --pl-text-2:        #B8B0A4;
-    --pl-text-3:        #7E7468;
-    --pl-accent:        #FFC061;
-    --pl-accent-soft:   rgba(255, 192, 97, 0.14);
-    --pl-accent-strong: #FFC061;
-    --pl-danger:        var(--g-color-text-danger);
-    --pl-warn:          var(--g-color-text-warning);
-    --pl-ok:            var(--g-color-text-positive);
-    --pl-r-sm:          4px;
-    --pl-r-md:          6px;
-    --pl-r-lg:          10px;
-    --pl-r-xl:          14px;
-    --pl-font-mono:     'JetBrains Mono', ui-monospace, monospace;
-    --pl-font-ui:       'Inter', system-ui, sans-serif;
-}
-
-// Light-mode overrides — scoped to .pl-page so other pages are unaffected.
-[data-theme="light"] {
-    .pl-page,
-    .pl-drawer,
-    .pl-pipeline-card {
-        --pl-page-bg:  #FAF7F2;
-        --pl-panel:    #FFFFFF;
-        --pl-bg-2:     #F3EFE9;
-        --pl-bg-3:     #EBE6DE;
-        --pl-line:     rgba(80, 60, 30, 0.08);
-        --pl-line-2:   rgba(80, 60, 30, 0.16);
-        --pl-text:     #1A1410;
-        --pl-text-2:   #5C4E3A;
-        --pl-text-3:   #9C8B74;
-    }
-}
-
-// ─── Neutral lane-editor var aliases (consumed by shared lane-editor.scss) ────
-
-.pl-page {
-    --lane-bg-3:        var(--pl-bg-3);
-    --lane-line-2:      var(--pl-line-2);
-    --lane-text-2:      var(--pl-text-2);
-    --lane-accent:      var(--pl-accent);
-    --lane-accent-soft: var(--pl-accent-soft);
-    --lane-r-sm:        var(--pl-r-sm);
-}
+// Design tokens — warm dark-brown palette scoped to this page.
+@include palette.lane-page-palette('pl', 'pipeline-card');
 
 // ─── Page container ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
- Extracted the identical functions/pipelines design-token palette into a prefix-parameterized lane-page-palette($prefix, $card) mixin under pages/builtin/_shared/lane-editor/_palette.scss.
- The mixin emits the dark token block, the per-page [data-theme="light"] overrides, and the lane-editor aliases; FunctionsPage and PipelinesPage each invoke it with their own prefix and card class.
- No behavior change: verified all 54 computed --fn-*/--pl-*/--lane-* token values are identical across dark and light themes, and a full-page zero pixel diff on both routes against main.