### PR TITLE
refactor(ynpb): adopt .v1 FQN package

### DIFF
--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -10,7 +10,7 @@ use ync::{
 };
 use ynpb::pb::{logging_client::LoggingClient, UpdateLevelRequest};
 
-const LOGGING_SERVICE: &str = "ynpb.Logging";
+const LOGGING_SERVICE: &str = "controlplane.ynpb.v1.Logging";
 
 /// Common functionality.
 #[derive(Debug, Clone, Parser)]

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -17,7 +17,7 @@ use ynpb::pb::{
     WorkerCountersResponse,
 };
 
-const COUNTERS_SERVICE: &str = "ynpb.CountersService";
+const COUNTERS_SERVICE: &str = "controlplane.ynpb.v1.CountersService";
 
 /// Counters module - displays counters information.
 #[derive(Debug, Clone, Parser)]

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -14,7 +14,7 @@ use ynpb::pb::{
     ListFunctionsRequest, UpdateFunctionRequest,
 };
 
-const FUNCTION_SERVICE: &str = "ynpb.FunctionService";
+const FUNCTION_SERVICE: &str = "controlplane.ynpb.v1.FunctionService";
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(FUNCTION_SERVICE, "requested function");
 
 /// Function module.

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -18,7 +18,7 @@ use ync::{
 };
 use ynpb::pb::{BackendKind, ListServicesRequest, RegisteredBackend, gateway_client::GatewayClient};
 
-const GATEWAY_SERVICE: &str = "ynpb.Gateway";
+const GATEWAY_SERVICE: &str = "controlplane.ynpb.v1.Gateway";
 
 /// Gateway - inspects the gateway service registry.
 #[derive(Debug, Clone, Parser)]

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -12,7 +12,7 @@ use ync::{
 };
 use ynpb::pb::{inspect_service_client::InspectServiceClient, InspectRequest, InspectResponse};
 
-const INSPECT_SERVICE: &str = "ynpb.InspectService";
+const INSPECT_SERVICE: &str = "controlplane.ynpb.v1.InspectService";
 
 /// Inspect module - displays system introspection information.
 #[derive(Debug, Clone, Parser)]

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -14,7 +14,7 @@ use ynpb::pb::{
     Pipeline, UpdatePipelineRequest,
 };
 
-const PIPELINE_SERVICE: &str = "ynpb.PipelineService";
+const PIPELINE_SERVICE: &str = "controlplane.ynpb.v1.PipelineService";
 const NOT_FOUND: NotFoundMapper = NotFoundMapper::new(PIPELINE_SERVICE, "requested pipeline");
 
 /// Pipeline module.

--- a/common/go/operator/function.go
+++ b/common/go/operator/function.go
@@ -8,7 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 // FunctionChainSpec is the desired single-chain function definition that

--- a/common/go/operator/function_test.go
+++ b/common/go/operator/function_test.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 type fakeFunctionClient struct {

--- a/common/rust/ynpb/build.rs
+++ b/common/rust/ynpb/build.rs
@@ -5,22 +5,22 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         .build_server(false)
         .message_attribute(".", "#[derive(serde::Serialize)]")
         .field_attribute(
-            ".ynpb.RegisteredBackend.last_seen_at",
+            ".controlplane.ynpb.v1.RegisteredBackend.last_seen_at",
             "#[serde(serialize_with = \"crate::serialize_timestamp\")]",
         )
         .field_attribute(
-            ".ynpb.RegisteredBackend.kind",
+            ".controlplane.ynpb.v1.RegisteredBackend.kind",
             "#[serde(serialize_with = \"crate::serialize_backend_kind\")]",
         )
         .extern_path(".common.commonpb.v1", "::commonpb::pb")
         .compile_protos(
             &[
-                "controlplane/ynpb/logging.proto",
-                "controlplane/ynpb/function.proto",
-                "controlplane/ynpb/pipeline.proto",
-                "controlplane/ynpb/inspect.proto",
-                "controlplane/ynpb/counters.proto",
-                "controlplane/ynpb/gateway.proto",
+                "controlplane/ynpb/v1/logging.proto",
+                "controlplane/ynpb/v1/function.proto",
+                "controlplane/ynpb/v1/pipeline.proto",
+                "controlplane/ynpb/v1/inspect.proto",
+                "controlplane/ynpb/v1/counters.proto",
+                "controlplane/ynpb/v1/gateway.proto",
             ],
             &["../../.."],
         )?;

--- a/common/rust/ynpb/src/lib.rs
+++ b/common/rust/ynpb/src/lib.rs
@@ -1,6 +1,6 @@
 #[allow(clippy::all, non_snake_case)]
 pub mod pb {
-    tonic::include_proto!("ynpb");
+    tonic::include_proto!("controlplane.ynpb.v1");
 }
 
 mod function;

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -6,7 +6,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 // Counters is an in-process gRPC service for retrieving counters.
@@ -32,7 +32,7 @@ func (m *Counters) Name() string { return "counters" }
 func (m *Counters) Endpoint() string { return "" }
 
 // ServicesNames returns the gRPC service names served by this service.
-func (m *Counters) ServicesNames() []string { return []string{"ynpb.CountersService"} }
+func (m *Counters) ServicesNames() []string { return []string{"controlplane.ynpb.v1.CountersService"} }
 
 // RegisterService registers the service on the given gRPC server.
 func (m *Counters) RegisterService(server *grpc.Server) {

--- a/controlplane/builtin/function.go
+++ b/controlplane/builtin/function.go
@@ -12,7 +12,7 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 const functionAgentName = "function"
@@ -50,7 +50,7 @@ func (m *Function) Name() string { return "function" }
 func (m *Function) Endpoint() string { return "" }
 
 // ServicesNames returns the gRPC service names served by this service.
-func (m *Function) ServicesNames() []string { return []string{"ynpb.FunctionService"} }
+func (m *Function) ServicesNames() []string { return []string{"controlplane.ynpb.v1.FunctionService"} }
 
 // RegisterService registers the service on the given gRPC server.
 func (m *Function) RegisterService(server *grpc.Server) {

--- a/controlplane/builtin/inspect.go
+++ b/controlplane/builtin/inspect.go
@@ -6,7 +6,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 // Inspect is an in-process gRPC service for inspecting the dataplane
@@ -33,7 +33,7 @@ func (m *Inspect) Name() string { return "inspect" }
 func (m *Inspect) Endpoint() string { return "" }
 
 // ServicesNames returns the gRPC service names served by this service.
-func (m *Inspect) ServicesNames() []string { return []string{"ynpb.InspectService"} }
+func (m *Inspect) ServicesNames() []string { return []string{"controlplane.ynpb.v1.InspectService"} }
 
 // RegisterService registers the service on the given gRPC server.
 func (m *Inspect) RegisterService(server *grpc.Server) {

--- a/controlplane/builtin/logging.go
+++ b/controlplane/builtin/logging.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 // Logging is an in-process gRPC service that exposes logging configuration
@@ -37,7 +37,7 @@ func (m *Logging) Name() string { return "logging" }
 func (m *Logging) Endpoint() string { return "" }
 
 // ServicesNames returns the gRPC service names served by this service.
-func (m *Logging) ServicesNames() []string { return []string{"ynpb.Logging"} }
+func (m *Logging) ServicesNames() []string { return []string{"controlplane.ynpb.v1.Logging"} }
 
 // RegisterService registers the service on the given gRPC server.
 func (m *Logging) RegisterService(server *grpc.Server) {

--- a/controlplane/builtin/pipeline.go
+++ b/controlplane/builtin/pipeline.go
@@ -12,7 +12,7 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 const agentName = "pipeline"
@@ -50,7 +50,7 @@ func (m *Pipeline) Name() string { return "pipeline" }
 func (m *Pipeline) Endpoint() string { return "" }
 
 // ServicesNames returns the gRPC service names served by this service.
-func (m *Pipeline) ServicesNames() []string { return []string{"ynpb.PipelineService"} }
+func (m *Pipeline) ServicesNames() []string { return []string{"controlplane.ynpb.v1.PipelineService"} }
 
 // RegisterService registers the service on the given gRPC server.
 func (m *Pipeline) RegisterService(server *grpc.Server) {

--- a/controlplane/etc/yanet/auth/permissions.yaml
+++ b/controlplane/etc/yanet/auth/permissions.yaml
@@ -6,4 +6,4 @@ permissions:
   users:
     - username: anonymous
       permissions:
-        - "/ynpb.Gateway/Register"
+        - "/controlplane.ynpb.v1.Gateway/Register"

--- a/controlplane/gateway/auth_service.go
+++ b/controlplane/gateway/auth_service.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 // AuthService provides authentication introspection.

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -17,7 +17,7 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/httpproxy"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth"
 	"github.com/yanet-platform/yanet2/controlplane/internal/xgrpc"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 // Service is the interface that gateway services must implement.
@@ -199,7 +199,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 		return nil, fmt.Errorf("failed to create loopback backend for gateway-hosted services: %w", err)
 	}
 
-	for _, service := range []string{"ynpb.Gateway", "ynpb.Auth"} {
+	for _, service := range []string{"controlplane.ynpb.v1.Gateway", "controlplane.ynpb.v1.Auth"} {
 		registry.RegisterBackend(service, loopback, BackendKindBuiltin)
 		log.Info("registered built-in service in registry",
 			zap.String("service", service),

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -50,8 +50,8 @@ func TestNewGateway_DeclaredKindsWired(t *testing.T) {
 	}
 
 	// Framework services registered with WithBuiltinService must be built-in.
-	require.Equal(t, BackendKindBuiltin, kinds["ynpb.Gateway"], "ynpb.Gateway must be built-in")
-	require.Equal(t, BackendKindBuiltin, kinds["ynpb.Auth"], "ynpb.Auth must be built-in")
+	require.Equal(t, BackendKindBuiltin, kinds["controlplane.ynpb.v1.Gateway"], "controlplane.ynpb.v1.Gateway must be built-in")
+	require.Equal(t, BackendKindBuiltin, kinds["controlplane.ynpb.v1.Auth"], "controlplane.ynpb.v1.Auth must be built-in")
 	require.Equal(t, BackendKindBuiltin, kinds["test.BuiltinService"], "WithBuiltinService must yield built-in kind")
 
 	// Module/device services registered with WithService must be in-process.

--- a/controlplane/gateway/registrar.go
+++ b/controlplane/gateway/registrar.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/encoding/gzip"
 
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 type gatewayRegistrarOptions struct {

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 // fakeBackend is a test double for the Backend interface.

--- a/controlplane/gateway/runner_test.go
+++ b/controlplane/gateway/runner_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/stretchr/testify/require"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 type fakeService struct{}

--- a/controlplane/gateway/service.go
+++ b/controlplane/gateway/service.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 func backendKindToProto(k BackendKind) ynpb.BackendKind {

--- a/controlplane/ynpb/meson.build
+++ b/controlplane/ynpb/meson.build
@@ -1,16 +1,17 @@
 ynpb_dir = meson.current_source_dir()
+root_dir = meson.project_source_root()
 
 # Proto files for the controlplane
 ynpb_proto_files = [
-    join_paths(ynpb_dir, 'gateway.proto'),
-    join_paths(ynpb_dir, 'logging.proto'),
-    join_paths(ynpb_dir, 'inspect.proto'),
-    join_paths(ynpb_dir, 'module.proto'),
-    join_paths(ynpb_dir, 'function.proto'),
-    join_paths(ynpb_dir, 'pipeline.proto'),
-    join_paths(ynpb_dir, 'device.proto'),
-    join_paths(ynpb_dir, 'counters.proto'),
-    join_paths(ynpb_dir, 'auth.proto'),
+    join_paths(ynpb_dir, 'v1', 'gateway.proto'),
+    join_paths(ynpb_dir, 'v1', 'logging.proto'),
+    join_paths(ynpb_dir, 'v1', 'inspect.proto'),
+    join_paths(ynpb_dir, 'v1', 'module.proto'),
+    join_paths(ynpb_dir, 'v1', 'function.proto'),
+    join_paths(ynpb_dir, 'v1', 'pipeline.proto'),
+    join_paths(ynpb_dir, 'v1', 'device.proto'),
+    join_paths(ynpb_dir, 'v1', 'counters.proto'),
+    join_paths(ynpb_dir, 'v1', 'auth.proto'),
 ]
 
 # Generate protobuf files
@@ -39,12 +40,10 @@ ynpb_gen = custom_target(
     input: ynpb_proto_files,
     command: [
         protoc,
-        '-I', ynpb_dir,
         '-I', root_dir,
-        '--go_out=paths=source_relative:' + ynpb_dir,
-        '--go-grpc_out=paths=source_relative:' + ynpb_dir,
+        '--go_out=paths=source_relative:' + root_dir,
+        '--go-grpc_out=paths=source_relative:' + root_dir,
         '@INPUT@',
     ],
     build_by_default: true,
 )
-

--- a/controlplane/ynpb/v1/auth.proto
+++ b/controlplane/ynpb/v1/auth.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package ynpb;
+package controlplane.ynpb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
 // Auth service provides authentication introspection.
 service AuthService {

--- a/controlplane/ynpb/v1/counters.proto
+++ b/controlplane/ynpb/v1/counters.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package ynpb;
+package controlplane.ynpb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
 service CountersService {
   rpc Perf(PerfCountersRequest) returns (PerfCountersResponse);

--- a/controlplane/ynpb/v1/device.proto
+++ b/controlplane/ynpb/v1/device.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package ynpb;
+package controlplane.ynpb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
 // TODO: docs
 service DeviceService {

--- a/controlplane/ynpb/v1/function.proto
+++ b/controlplane/ynpb/v1/function.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package ynpb;
+package controlplane.ynpb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
 import "common/commonpb/v1/target.proto";
 

--- a/controlplane/ynpb/v1/gateway.proto
+++ b/controlplane/ynpb/v1/gateway.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
 
-package ynpb;
+package controlplane.ynpb.v1;
 
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
 // Gateway API service.
 service Gateway {

--- a/controlplane/ynpb/v1/inspect.proto
+++ b/controlplane/ynpb/v1/inspect.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package ynpb;
+package controlplane.ynpb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
 // InspectService provides read-only introspection into the current state
 // of a YANET dataplane instance.

--- a/controlplane/ynpb/v1/logging.proto
+++ b/controlplane/ynpb/v1/logging.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package ynpb;
+package controlplane.ynpb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
 service Logging {
   // UpdateLevel updates the minimum logging level.

--- a/controlplane/ynpb/v1/module.proto
+++ b/controlplane/ynpb/v1/module.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package ynpb;
+package controlplane.ynpb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
 import "common/commonpb/v1/target.proto";
 

--- a/controlplane/ynpb/v1/pipeline.proto
+++ b/controlplane/ynpb/v1/pipeline.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-package ynpb;
+package controlplane.ynpb.v1;
 
-option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb;ynpb";
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
 import "common/commonpb/v1/target.proto";
 

--- a/operators/forward/internal/operator/actuator_gateway.go
+++ b/operators/forward/internal/operator/actuator_gateway.go
@@ -11,7 +11,7 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 

--- a/operators/pipeline/internal/operator/actuator_gateway.go
+++ b/operators/pipeline/internal/operator/actuator_gateway.go
@@ -9,7 +9,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
 	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )

--- a/operators/pipeline/internal/operator/convert.go
+++ b/operators/pipeline/internal/operator/convert.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
 	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -11,7 +11,7 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/operator"
-	"github.com/yanet-platform/yanet2/controlplane/ynpb"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
 

--- a/web/src/api/counters.ts
+++ b/web/src/api/counters.ts
@@ -29,7 +29,7 @@ export interface CountersByTagsResponse {
     groups?: CounterGroup[];
 }
 
-const countersService = createService('ynpb.CountersService');
+const countersService = createService('controlplane.ynpb.v1.CountersService');
 
 export const counters = {
     byTags: (request: CountersByTagsRequest, options?: CallOptions): Promise<CountersByTagsResponse> => {

--- a/web/src/api/devices.ts
+++ b/web/src/api/devices.ts
@@ -49,7 +49,7 @@ export interface UpdateDeviceVlanResponse {
 export const DEVICE_TYPES = ['plain', 'vlan'] as const;
 export type DeviceType = typeof DEVICE_TYPES[number];
 
-const deviceService = createService('ynpb.DeviceService');
+const deviceService = createService('controlplane.ynpb.v1.DeviceService');
 const plainService = createService('devices.plain.controlplane.plainpb.v1.DevicePlainService');
 const vlanService = createService('devices.vlan.controlplane.vlanpb.v1.DeviceVlanService');
 

--- a/web/src/api/functions.ts
+++ b/web/src/api/functions.ts
@@ -49,7 +49,7 @@ export interface DeleteFunctionRequest {
 
 export interface DeleteFunctionResponse { }
 
-const functionService = createService('ynpb.FunctionService');
+const functionService = createService('controlplane.ynpb.v1.FunctionService');
 
 export const functions = {
     list: (request: ListFunctionsRequest, options?: CallOptions): Promise<ListFunctionsResponse> => {

--- a/web/src/api/inspect.ts
+++ b/web/src/api/inspect.ts
@@ -71,7 +71,7 @@ export interface InspectResponse {
     instance_info?: InstanceInfo;
 }
 
-const inspectService = createService('ynpb.InspectService');
+const inspectService = createService('controlplane.ynpb.v1.InspectService');
 
 export const inspect = {
     inspect: (options?: CallOptions): Promise<InspectResponse> => {

--- a/web/src/api/pipelines.ts
+++ b/web/src/api/pipelines.ts
@@ -40,7 +40,7 @@ export interface DeletePipelineRequest {
 
 export interface DeletePipelineResponse { }
 
-const pipelineService = createService('ynpb.PipelineService');
+const pipelineService = createService('controlplane.ynpb.v1.PipelineService');
 
 export const pipelines = {
     list: (request: ListPipelinesRequest, options?: CallOptions): Promise<ListPipelinesResponse> => {


### PR DESCRIPTION
Migrate the gateway-core `ynpb` proto surface to the `.v1` FQN convention, completing the `.v1` migration of all proto surfaces (after commonpb #1072, filterpb #1075, readinesspb #1078).

- Move the 9 `controlplane/ynpb/*.proto` into `controlplane/ynpb/v1/`, renaming the package `ynpb` to `controlplane.ynpb.v1`.
- Keep the generated Go package name `ynpb` via the `go_package` alias, so Go consumers only gain a `/v1` import path.
- Switch the meson build to the collision-safe `-I root_dir` strategy with bare-basename outputs.
- The `ynpb` service names are the gateway's HTTP-to-gRPC wire routes, so the hardcoded service-name strings in the builtin services, the gateway registry, the Rust CLIs, and the web client are updated in lockstep with the package rename.
- Update Go importers and the Rust `ynpb` crate wiring.

This is the last surface migration before the buf coverage and `buf breaking` CI gate (part of #574, #573).