### PR TITLE
refactor(web): extract lane-editor card shell mixin

### DIFF
--- a/web/src/pages/builtin/_shared/lane-editor/_palette.scss
+++ b/web/src/pages/builtin/_shared/lane-editor/_palette.scss
@@ -57,6 +57,98 @@
     }
 }
 
+// Mixin that emits the draggable card shell shared between the functions and
+// pipelines lane-editor pages. The 7 selectors (container, accent-bar,
+// content, top-row, sparkline-row, counter, counter-unit) are byte-identical
+// modulo prefix and card-class name.
+// $p    — prefix string, e.g. 'fn' or 'pl'.
+// $card — card class suffix, e.g. 'module-card' or 'ref-card'.
+@mixin lane-card($p, $card) {
+    .#{$p}-#{$card} {
+        position: relative;
+        display: flex;
+        flex-shrink: 0;
+        width: 192px;
+        background: var(--#{$p}-bg-3);
+        border: 1px solid var(--#{$p}-line-2);
+        border-radius: 8px;
+        cursor: pointer;
+        user-select: none;
+        transition: box-shadow 0.12s, opacity 0.12s;
+        overflow: hidden;
+
+        &:hover {
+            box-shadow: 0 0 0 1px var(--#{$p}-accent-soft);
+        }
+
+        &--dragging {
+            opacity: 0.4;
+        }
+
+        &--drag-source {
+            opacity: 0.4;
+            box-shadow: 0 0 0 1px var(--#{$p}-line-2);
+            cursor: no-drop;
+        }
+
+        &--invalid-target {
+            box-shadow: 0 0 0 1px var(--#{$p}-danger);
+        }
+    }
+
+    .#{$p}-#{$card}__accent-bar {
+        width: 3px;
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        flex-shrink: 0;
+    }
+
+    .#{$p}-#{$card}__content {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 7px 8px 7px 14px;
+        flex: 1;
+        min-width: 0;
+    }
+
+    .#{$p}-#{$card}__top-row {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        min-width: 0;
+    }
+
+    .#{$p}-#{$card}__sparkline-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        min-height: 15px;
+
+        svg {
+            flex: 1;
+            min-width: 0;
+            width: 100% !important;
+            height: 15px;
+        }
+    }
+
+    .#{$p}-#{$card}__counter {
+        font-family: var(--#{$p}-font-mono);
+        font-size: 11px;
+        color: var(--#{$p}-text-2);
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+        flex-shrink: 0;
+    }
+
+    .#{$p}-#{$card}__counter-unit {
+        color: var(--#{$p}-text-3);
+    }
+}
+
 // Mixin that emits the drawer shell rules shared between the functions and
 // pipelines lane-editor pages. Emits ~19 shell selectors + the slide-in
 // keyframes. Per-page divergent selectors (chain-info, loading, module-list,

--- a/web/src/pages/builtin/functions/FunctionsPage.scss
+++ b/web/src/pages/builtin/functions/FunctionsPage.scss
@@ -221,65 +221,7 @@
     font-family: var(--fn-font-mono);
 }
 
-// ─── Module card ──────────────────────────────────────────────────────────────
-
-.fn-module-card {
-    position: relative;
-    display: flex;
-    flex-shrink: 0;
-    width: 192px;
-    background: var(--fn-bg-3);
-    border: 1px solid var(--fn-line-2);
-    border-radius: 8px;
-    cursor: pointer;
-    user-select: none;
-    transition: box-shadow 0.12s, opacity 0.12s;
-    overflow: hidden;
-
-    &:hover {
-        box-shadow: 0 0 0 1px var(--fn-accent-soft);
-    }
-
-    &--dragging {
-        opacity: 0.4;
-    }
-
-    &--drag-source {
-        opacity: 0.4;
-        box-shadow: 0 0 0 1px var(--fn-line-2);
-        cursor: no-drop;
-    }
-
-    &--invalid-target {
-        box-shadow: 0 0 0 1px var(--fn-danger);
-    }
-}
-
-.fn-module-card__accent-bar {
-    width: 3px;
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    flex-shrink: 0;
-}
-
-.fn-module-card__content {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    padding: 7px 8px 7px 14px;
-    flex: 1;
-    min-width: 0;
-}
-
-// Row 1: [type-chip] [name] [kebab]
-.fn-module-card__top-row {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    min-width: 0;
-}
+@include palette.lane-card('fn', 'module-card');
 
 .fn-module-card__type-chip {
     display: inline-flex;
@@ -329,34 +271,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-}
-
-// Row 2: [sparkline grow] [pps]
-.fn-module-card__sparkline-row {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    min-height: 15px;
-
-    svg {
-        flex: 1;
-        min-width: 0;
-        width: 100% !important;
-        height: 15px;
-    }
-}
-
-.fn-module-card__counter {
-    font-family: var(--fn-font-mono);
-    font-size: 11px;
-    color: var(--fn-text-2);
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-
-.fn-module-card__counter-unit {
-    color: var(--fn-text-3);
 }
 
 // ─── Weight badge ─────────────────────────────────────────────────────────────

--- a/web/src/pages/builtin/pipelines/PipelinesPage.scss
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.scss
@@ -105,64 +105,7 @@
     font-family: var(--pl-font-mono);
 }
 
-// ─── Function reference card ──────────────────────────────────────────────────
-
-.pl-ref-card {
-    position: relative;
-    display: flex;
-    flex-shrink: 0;
-    width: 192px;
-    background: var(--pl-bg-3);
-    border: 1px solid var(--pl-line-2);
-    border-radius: 8px;
-    cursor: pointer;
-    user-select: none;
-    transition: box-shadow 0.12s, opacity 0.12s;
-    overflow: hidden;
-
-    &:hover {
-        box-shadow: 0 0 0 1px var(--pl-accent-soft);
-    }
-
-    &--dragging {
-        opacity: 0.4;
-    }
-
-    &--drag-source {
-        opacity: 0.4;
-        box-shadow: 0 0 0 1px var(--pl-line-2);
-        cursor: no-drop;
-    }
-
-    &--invalid-target {
-        box-shadow: 0 0 0 1px var(--pl-danger);
-    }
-}
-
-.pl-ref-card__accent-bar {
-    width: 3px;
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    flex-shrink: 0;
-}
-
-.pl-ref-card__content {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    padding: 7px 8px 7px 14px;
-    flex: 1;
-    min-width: 0;
-}
-
-.pl-ref-card__top-row {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    min-width: 0;
-}
+@include palette.lane-card('pl', 'ref-card');
 
 .pl-ref-card__name {
     flex: 1;
@@ -211,33 +154,6 @@
             color: var(--pl-danger);
         }
     }
-}
-
-.pl-ref-card__sparkline-row {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    min-height: 15px;
-
-    svg {
-        flex: 1;
-        min-width: 0;
-        width: 100% !important;
-        height: 15px;
-    }
-}
-
-.pl-ref-card__counter {
-    font-family: var(--pl-font-mono);
-    font-size: 11px;
-    color: var(--pl-text-2);
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-    flex-shrink: 0;
-}
-
-.pl-ref-card__counter-unit {
-    color: var(--pl-text-3);
 }
 
 // ─── Add function ref ghost button ────────────────────────────────────────────


### PR DESCRIPTION
- Extracted the seven byte-identical functions/pipelines lane-card shell selectors (container, accent-bar, content, top-row, sparkline-row, counter, counter-unit) into a prefix- and card-class-parameterized lane-card mixin in pages/builtin/_shared/lane-editor/_palette.scss.
- The selectors that genuinely diverge stay inline: each page keeps its own __name, functions keeps its type-chip/kebab, pipelines keeps its icon-button.
- No behavior change: verified zero pixel diff on the card chrome of both pages against main (pipelines byte-identical, functions differing only in live-counter values).