### PR TITLE
refactor(web): extract DrawerCounterSection shared component

### DIFF
--- a/web/src/pages/builtin/_shared/lane-editor/DrawerBigStat.tsx
+++ b/web/src/pages/builtin/_shared/lane-editor/DrawerBigStat.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface DrawerBigStatProps {
-    prefix: 'fn' | 'pl';
+    prefix: string;
     label: string;
     value: string;
     accent?: string;

--- a/web/src/pages/builtin/_shared/lane-editor/DrawerCounterSection.tsx
+++ b/web/src/pages/builtin/_shared/lane-editor/DrawerCounterSection.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import type { InterpolatedCounterData } from '../../../../hooks';
+import { formatPps, formatBps } from '../../../../utils';
+import { DrawerBigStat } from './DrawerBigStat';
+import { Sparkline } from './Sparkline';
+
+interface DrawerCounterSectionProps {
+    prefix: string;
+    counter: InterpolatedCounterData | undefined;
+    accent: string;
+    sparklineData: number[];
+}
+
+/** Live-counters section rendered inside a lane drawer. */
+export const DrawerCounterSection = ({ prefix, counter, accent, sparklineData }: DrawerCounterSectionProps): React.JSX.Element => (
+    <div className={`${prefix}-drawer__section`}>
+        <div className={`${prefix}-drawer__section-label`}>Live counters</div>
+        <div className={`${prefix}-drawer__counters-grid`}>
+            <DrawerBigStat prefix={prefix} label="PPS" value={counter ? formatPps(counter.pps) : '—'} accent={accent} />
+            <DrawerBigStat prefix={prefix} label="BPS" value={counter ? formatBps(counter.bps) : '—'} />
+        </div>
+        {sparklineData.length >= 4 && (
+            <div>
+                <div className={`${prefix}-drawer__sparkline-label`}>pps · last {sparklineData.length} samples</div>
+                <div className={`${prefix}-drawer__sparkline`}>
+                    <Sparkline data={sparklineData} width={364} height={48} color={accent} />
+                </div>
+            </div>
+        )}
+    </div>
+);

--- a/web/src/pages/builtin/_shared/lane-editor/index.ts
+++ b/web/src/pages/builtin/_shared/lane-editor/index.ts
@@ -13,4 +13,5 @@ export { LaneCardActions } from './LaneCardActions';
 export { LaneCollapseButton } from './LaneCollapseButton';
 export { LaneDrawerShell } from './LaneDrawerShell';
 export { DrawerBigStat } from './DrawerBigStat';
+export { DrawerCounterSection } from './DrawerCounterSection';
 export { DrawerAction } from './DrawerAction';

--- a/web/src/pages/builtin/functions/components/Drawer.tsx
+++ b/web/src/pages/builtin/functions/components/Drawer.tsx
@@ -2,9 +2,8 @@ import React, { useCallback } from 'react';
 import type { Module, Chain } from '../types';
 import { metaFor } from '../moduleMeta';
 import { InlineEdit } from './InlineEdit';
-import { Sparkline, useSparklineHistory, LaneDrawerShell, DrawerBigStat, DrawerAction } from '../../_shared/lane-editor';
+import { useSparklineHistory, LaneDrawerShell, DrawerAction, DrawerCounterSection } from '../../_shared/lane-editor';
 import { CloseIcon, TrashIcon } from '../../_shared/icons';
-import { formatPps, formatBps } from '../../../../utils';
 import { ConfirmDialog } from '../../../../components';
 import type { InterpolatedCounterData } from '../../../../hooks';
 
@@ -105,26 +104,7 @@ const ModuleDrawerContent = ({
                 </button>
             </div>
 
-            <div className="fn-drawer__section">
-                <div className="fn-drawer__section-label">Live counters</div>
-                <div className="fn-drawer__counters-grid">
-                    <DrawerBigStat prefix="fn" label="PPS" value={counter ? formatPps(counter.pps) : '—'} accent={accent} />
-                    <DrawerBigStat prefix="fn" label="BPS" value={counter ? formatBps(counter.bps) : '—'} />
-                </div>
-                {sparklineData.length >= 4 && (
-                    <div>
-                        <div className="fn-drawer__sparkline-label">pps · last {sparklineData.length} samples</div>
-                        <div className="fn-drawer__sparkline">
-                            <Sparkline
-                                data={sparklineData}
-                                width={364}
-                                height={48}
-                                color={accent}
-                            />
-                        </div>
-                    </div>
-                )}
-            </div>
+            <DrawerCounterSection prefix="fn" counter={counter} accent={accent} sparklineData={sparklineData} />
 
             <div className="fn-drawer__section">
                 <div className="fn-drawer__section-label">Configuration</div>

--- a/web/src/pages/builtin/pipelines/components/Drawer.tsx
+++ b/web/src/pages/builtin/pipelines/components/Drawer.tsx
@@ -1,8 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import type { FunctionRef } from '../types';
-import { Sparkline, useSparklineHistory, LaneDrawerShell, DrawerBigStat, DrawerAction } from '../../_shared/lane-editor';
+import { useSparklineHistory, LaneDrawerShell, DrawerAction, DrawerCounterSection } from '../../_shared/lane-editor';
 import { CloseIcon, TrashIcon } from '../../_shared/icons';
-import { formatPps, formatBps } from '../../../../utils';
 import { ConfirmDialog } from '../../../../components';
 import type { InterpolatedCounterData } from '../../../../hooks';
 import type { FunctionId } from '../../../../api/pipelines';
@@ -73,26 +72,7 @@ export const Drawer: React.FC<DrawerProps> = ({
                 </button>
             </div>
 
-            <div className="pl-drawer__section">
-                <div className="pl-drawer__section-label">Live counters</div>
-                <div className="pl-drawer__counters-grid">
-                    <DrawerBigStat prefix="pl" label="PPS" value={counter ? formatPps(counter.pps) : '—'} accent={accent} />
-                    <DrawerBigStat prefix="pl" label="BPS" value={counter ? formatBps(counter.bps) : '—'} />
-                </div>
-                {sparklineData.length >= 4 && (
-                    <div>
-                        <div className="pl-drawer__sparkline-label">pps · last {sparklineData.length} samples</div>
-                        <div className="pl-drawer__sparkline">
-                            <Sparkline
-                                data={sparklineData}
-                                width={364}
-                                height={48}
-                                color={accent}
-                            />
-                        </div>
-                    </div>
-                )}
-            </div>
+            <DrawerCounterSection prefix="pl" counter={counter} accent={accent} sparklineData={sparklineData} />
 
             <div className="pl-drawer__section">
                 <div className="pl-drawer__section-label">Configuration</div>


### PR DESCRIPTION
- Extracted the byte-identical "Live counters" drawer section (PPS/BPS big stats plus the conditional pps sparkline) from the functions and pipelines drawers into a shared DrawerCounterSection under pages/builtin/_shared/lane-editor.
- Widened DrawerBigStat's prefix prop from the fn/pl union to string so the shared section can pass its prefix; the prop only drives BEM class interpolation.
- No behavior change: verified the open-drawer Live-counters section is structurally identical on both pages against main.