### PR TITLE
refactor(web): consolidate IPNet to CIDR formatter

### DIFF
--- a/web/src/pages/modules/acl/hooks.ts
+++ b/web/src/pages/modules/acl/hooks.ts
@@ -1,6 +1,6 @@
 import type { Rule, PortRange, VlanRange, ProtoRange, Action } from '../../../api/acl';
 import { ActionKind } from '../../../api/acl';
-import { formatIPNet, extractBytes } from '../../../utils';
+import { extractBytes, formatIPNetItem } from '../../../utils';
 import type { RuleDraft, RuleItem } from './types';
 import { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
 export { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
@@ -14,14 +14,6 @@ export { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parse
  */
 export const normalizeActionKind = (kind: ActionKind | undefined): ActionKind =>
     kind ?? ActionKind.ACTION_KIND_PASS;
-
-/** Format a single IPNet (base64 bytes) to a CIDR string. */
-const formatIPNetItem = (net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] }): string => {
-    const addrBytes = extractBytes(net.addr);
-    const maskBytes = extractBytes(net.mask);
-    if (!addrBytes || addrBytes.length === 0) return '';
-    return formatIPNet(addrBytes, maskBytes);
-};
 
 /** Format a PortRange or ProtoRange {from, to} to a string like "80" or "80-90". */
 const formatRange = (r: { from?: number; to?: number }): string => {

--- a/web/src/pages/modules/acl/structuredDiff.ts
+++ b/web/src/pages/modules/acl/structuredDiff.ts
@@ -1,13 +1,5 @@
 import type { Rule, Action } from '../../../api/acl';
-import { formatIPNet, extractBytes } from '../../../utils';
-
-/** Format an IPNet wire object to a CIDR string for comparison purposes. */
-const fmtIPNet = (net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] }): string => {
-    const addrBytes = extractBytes(net.addr);
-    const maskBytes = extractBytes(net.mask);
-    if (!addrBytes || addrBytes.length === 0) return '';
-    return formatIPNet(addrBytes, maskBytes);
-};
+import { formatIPNetItem } from '../../../utils';
 
 /** Serialize a range {from, to} to a canonical string for equality comparison. */
 const fmtRange = (r: { from?: number; to?: number }): string =>
@@ -61,9 +53,9 @@ const fieldValues = (rule: Rule, field: RuleField): string[] => {
         case 'counter':
             return [rule.counter ?? ''];
         case 'srcs':
-            return (rule.srcs ?? []).map(fmtIPNet).filter(Boolean);
+            return (rule.srcs ?? []).map(formatIPNetItem).filter(Boolean);
         case 'dsts':
-            return (rule.dsts ?? []).map(fmtIPNet).filter(Boolean);
+            return (rule.dsts ?? []).map(formatIPNetItem).filter(Boolean);
         case 'src_port_ranges':
             return (rule.src_port_ranges ?? []).map(fmtRange);
         case 'dst_port_ranges':

--- a/web/src/pages/modules/forward/hooks.ts
+++ b/web/src/pages/modules/forward/hooks.ts
@@ -1,15 +1,7 @@
 import type { Rule, IPNet, VlanRange } from '../../../api/forward';
 import { ForwardMode } from '../../../api/forward';
-import { formatIPNet, parseIPToBytes, prefixLengthToMaskBytes, bytesToBase64, extractBytes } from '../../../utils';
+import { parseIPToBytes, prefixLengthToMaskBytes, bytesToBase64, formatIPNetItem } from '../../../utils';
 import type { RuleItem, RuleDraft } from './types';
-
-/** Format an IPNet to a CIDR string. */
-const formatIPNetItem = (net: IPNet): string => {
-    const addrBytes = extractBytes(net.addr);
-    const maskBytes = extractBytes(net.mask);
-    if (!addrBytes || addrBytes.length === 0) return '';
-    return formatIPNet(addrBytes, maskBytes);
-};
 
 /** Format VlanRange array to a display string. */
 const formatVlanRanges = (ranges: VlanRange[] | undefined): string => {

--- a/web/src/utils/netip.ts
+++ b/web/src/utils/netip.ts
@@ -1,3 +1,5 @@
+import { extractBytes } from './bytes';
+
 // Result types for error handling
 export type Ok<T> = { ok: true; value: T };
 export type Err<E> = { ok: false; error: E };
@@ -673,6 +675,18 @@ export const formatIPNet = (
         const maskStr = formatIPFromBytes(maskBytes);
         return `${ipStr}/${maskStr}`;
     }
+};
+
+/** Format a wire IPNet ({addr, mask} as base64/bytes) to a CIDR string. */
+export const formatIPNetItem = (
+    net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] },
+): string => {
+    const addrBytes = extractBytes(net.addr);
+    const maskBytes = extractBytes(net.mask);
+    if (!addrBytes || addrBytes.length === 0) {
+        return '';
+    }
+    return formatIPNet(addrBytes, maskBytes);
 };
 
 // Wire-format shape of commonpb.IPAddress as it arrives from the


### PR DESCRIPTION
- Hoisted the identical IPNet-to-CIDR helper (duplicated as formatIPNetItem in the acl and forward hooks and as fmtIPNet in the acl structuredDiff) into a single shared formatIPNetItem in utils/netip.ts.
- No behavior change: the body is preserved verbatim and forward's IPNet type is structurally assignable; verified zero pixel diff on the acl and forward rule tables against main.