### PR TITLE
fix(buf): cover migrated common and controlplane proto surfaces

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -41,7 +41,4 @@ jobs:
 
       - name: Run linter
         run: |
-          go run ./lint/protobuf/cmd/protolint/ --exclude subprojects \
-                                                --exclude common \
-                                                --exclude controlplane \
-                                                --exclude modules/balancer
+          go run ./lint/protobuf/cmd/protolint/ --exclude subprojects

--- a/Makefile
+++ b/Makefile
@@ -85,9 +85,7 @@ proto-lint:
 		echo "WARN: 'buf' not found, skipping buf lint (install: https://buf.build/docs/installation)"; \
 	fi
 	go test ./lint/protobuf/cmd/protolint/
-	go run ./lint/protobuf/cmd/protolint/ --exclude subprojects \
-		--exclude common \
-		--exclude controlplane
+	go run ./lint/protobuf/cmd/protolint/ --exclude subprojects
 
 go-cache-clean:
 	go clean -cache

--- a/buf.yaml
+++ b/buf.yaml
@@ -3,8 +3,7 @@ modules:
   - path: .
     excludes:
       - subprojects
-      # Modules not yet migrated.
-      - controlplane
+      - .claude
 lint:
   use:
     - STANDARD
@@ -19,8 +18,8 @@ lint:
     PACKAGE_DIRECTORY_MATCH:
       - modules/route-mpls
       - operators/bird-adapter
-  ignore:
-    - common
+    ENUM_VALUE_UPPER_SNAKE_CASE:
+      - common/filterpb
 breaking:
   use:
     - PACKAGE

--- a/modules/fwstate/cli/build.rs
+++ b/modules/fwstate/cli/build.rs
@@ -2,8 +2,8 @@ use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/fwstatepb/v1/fwstate.proto");
-    println!("cargo:rerun-if-changed=../../../common/commonpb/ipaddr.proto");
-    println!("cargo:rerun-if-changed=../../../common/commonpb/macaddr.proto");
+    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
+    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/macaddr.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)

--- a/modules/route-mpls/cli/build.rs
+++ b/modules/route-mpls/cli/build.rs
@@ -2,7 +2,7 @@ use core::error::Error;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../../common/filterpb/v1/filter.proto");
-    println!("cargo:rerun-if-changed=../../../common/commonpb/ipaddr.proto");
+    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
     println!("cargo:rerun-if-changed=../controlplane/routemplspb/v1/routempls.proto");
 
     tonic_build::configure()

--- a/operators/pipeline/cli/build.rs
+++ b/operators/pipeline/cli/build.rs
@@ -4,7 +4,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../../../operators/pipeline/operatorpb/v1/operator.proto");
     println!("cargo:rerun-if-changed=../../../operators/pipeline/operatorpb/v1/readiness.proto");
     println!("cargo:rerun-if-changed=../../../common/readinesspb/v1/readiness.proto");
-    println!("cargo:rerun-if-changed=../../../common/commonpb/metric.proto");
+    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/metric.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)


### PR DESCRIPTION
Now that all four laggard proto surfaces (commonpb #1072, filterpb #1075, readinesspb #1078, ynpb #1082) are on the `.v1` FQN convention, re-enable lint coverage over them.

- Drop the `common` and `controlplane` exclusions from `buf.yaml`, the `Makefile` proto-lint target, and the proto-lint workflow's custom linter job.
- Remove the stale `modules/balancer` exclude (the active module is `balancer2`).
- Scope-ignore `ENUM_VALUE_UPPER_SNAKE_CASE` for `common/filterpb` so its legacy wire enum values are covered without being renamed.
- Exclude `.claude` agent worktrees from buf so local runs do not see duplicate proto copies.
- Correct stale `rerun-if-changed` paths left by the commonpb move.

Part of #574, #573. Precedes the `buf breaking` CI gate, which lands last.