### PR TITLE
refactor(web): consolidate parseCidrsToIPNets helper

### DIFF
--- a/web/src/pages/modules/acl/parseHelpers.ts
+++ b/web/src/pages/modules/acl/parseHelpers.ts
@@ -5,31 +5,9 @@
  * Both hooks.ts and yamlImport.worker.ts import from here.
  */
 
-import { parseIPToBytes, prefixLengthToMaskBytes, bytesToBase64 } from '../../../utils';
 import type { ProtoRange } from '../../../api/acl';
 
-/** Parse CIDR strings to IPNet array with base64-encoded bytes. */
-export const parseCidrsToIPNets = (cidrs: string[]): Array<{ addr: string; mask: string }> => {
-    const results: Array<{ addr: string; mask: string }> = [];
-    for (const cidr of cidrs) {
-        const parts = cidr.trim().split('/');
-        if (parts.length !== 2) continue;
-        const [ipPart, maskStr] = parts;
-        const prefixLength = parseInt(maskStr, 10);
-        if (isNaN(prefixLength)) continue;
-        const addrBytes = parseIPToBytes(ipPart);
-        if (!addrBytes) continue;
-        const isIPv4 = addrBytes.length === 4;
-        const maxPrefix = isIPv4 ? 32 : 128;
-        if (prefixLength < 0 || prefixLength > maxPrefix) continue;
-        const maskBytes = prefixLengthToMaskBytes(prefixLength, isIPv4 ? 4 : 16);
-        results.push({
-            addr: bytesToBase64(addrBytes),
-            mask: bytesToBase64(maskBytes),
-        });
-    }
-    return results;
-};
+export { parseCidrsToIPNets } from '../../../utils';
 
 /** Parse a port/vlan range string (e.g. "80-90", "80") to a {from, to} object. */
 const parseRangeStr = (s: string): { from: number; to: number } | null => {

--- a/web/src/pages/modules/forward/YamlIO.tsx
+++ b/web/src/pages/modules/forward/YamlIO.tsx
@@ -3,7 +3,7 @@ import yaml from 'js-yaml';
 import type { Rule } from '../../../api/forward';
 import { ForwardMode } from '../../../api/forward';
 import { toaster } from '../../../utils';
-import { parseCidrsToIPNets } from './hooks';
+import { parseCidrsToIPNets } from '../../../utils';
 import { rulesToDiffYaml } from './SaveDiffModal';
 import YamlIOModal from '../../../components/YamlIOModal';
 

--- a/web/src/pages/modules/forward/hooks.ts
+++ b/web/src/pages/modules/forward/hooks.ts
@@ -1,6 +1,6 @@
-import type { Rule, IPNet, VlanRange } from '../../../api/forward';
+import type { Rule, VlanRange } from '../../../api/forward';
 import { ForwardMode } from '../../../api/forward';
-import { parseIPToBytes, prefixLengthToMaskBytes, bytesToBase64, formatIPNetItem } from '../../../utils';
+import { formatIPNetItem, parseCidrsToIPNets } from '../../../utils';
 import type { RuleItem, RuleDraft } from './types';
 
 /** Format VlanRange array to a display string. */
@@ -63,29 +63,6 @@ export const parseVlanRangesStr = (input: string): VlanRange[] => {
         const val = parseInt(part, 10);
         return { from: val, to: val };
     }).filter((r) => !isNaN(r.from ?? NaN) && !isNaN(r.to ?? NaN));
-};
-
-/** Parse CIDR strings to IPNet array with base64-encoded bytes. */
-export const parseCidrsToIPNets = (cidrs: string[]): IPNet[] => {
-    const results: IPNet[] = [];
-    for (const cidr of cidrs) {
-        const parts = cidr.split('/');
-        if (parts.length !== 2) continue;
-        const [ipPart, maskStr] = parts;
-        const prefixLength = parseInt(maskStr, 10);
-        if (isNaN(prefixLength)) continue;
-        const addrBytes = parseIPToBytes(ipPart);
-        if (!addrBytes) continue;
-        const isIPv4 = addrBytes.length === 4;
-        const maxPrefix = isIPv4 ? 32 : 128;
-        if (prefixLength < 0 || prefixLength > maxPrefix) continue;
-        const maskBytes = prefixLengthToMaskBytes(prefixLength, isIPv4 ? 4 : 16);
-        results.push({
-            addr: bytesToBase64(addrBytes),
-            mask: bytesToBase64(maskBytes),
-        });
-    }
-    return results;
 };
 
 /** Convert a RuleDraft to a Rule for the API. */

--- a/web/src/utils/netip.ts
+++ b/web/src/utils/netip.ts
@@ -1,4 +1,4 @@
-import { extractBytes } from './bytes';
+import { bytesToBase64, extractBytes } from './bytes';
 
 // Result types for error handling
 export type Ok<T> = { ok: true; value: T };
@@ -811,4 +811,27 @@ export const ipRangeToString = (range: IPRangeWire | undefined): string => {
     const end = range.end ?? '';
     if (!start || !end) return '';
     return `[${start}, ${end}]`;
+};
+
+/** Parse CIDR strings to IPNet array with base64-encoded bytes. */
+export const parseCidrsToIPNets = (cidrs: string[]): Array<{ addr: string; mask: string }> => {
+    const results: Array<{ addr: string; mask: string }> = [];
+    for (const cidr of cidrs) {
+        const parts = cidr.trim().split('/');
+        if (parts.length !== 2) continue;
+        const [ipPart, maskStr] = parts;
+        const prefixLength = parseInt(maskStr, 10);
+        if (isNaN(prefixLength)) continue;
+        const addrBytes = parseIPToBytes(ipPart);
+        if (!addrBytes) continue;
+        const isIPv4 = addrBytes.length === 4;
+        const maxPrefix = isIPv4 ? 32 : 128;
+        if (prefixLength < 0 || prefixLength > maxPrefix) continue;
+        const maskBytes = prefixLengthToMaskBytes(prefixLength, isIPv4 ? 4 : 16);
+        results.push({
+            addr: bytesToBase64(addrBytes),
+            mask: bytesToBase64(maskBytes),
+        });
+    }
+    return results;
 };


### PR DESCRIPTION
- Hoisted the duplicated CIDR-to-IPNet parser (the acl parse-helpers and forward hooks copies, differing only by a leading trim) into a single shared parseCidrsToIPNets in utils/netip.ts, keeping the trimming variant.
- acl parseHelpers re-exports it so the acl YAML import worker's import chain stays worker-safe and unchanged; forward and its YAML importer now consume the shared helper.
- No behavior change: forward's inputs are already trimmed at the chip-input and API round-trip, so the added trim is a verified no-op; verified zero pixel diff on the acl and forward pages against main.