### PR TITLE
refactor(web): collapse formatBps onto formatBytesRate

### DIFF
--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -26,23 +26,6 @@ export const formatPps = (pps: number): string => {
 };
 
 /**
- * Format bytes per second value for display.
- * Examples: "500 B/s", "1.2 KB/s", "3.5 MB/s", "1.1 GB/s"
- */
-export const formatBps = (bps: number): string => {
-    if (bps < 1024) {
-        return `${Math.round(bps)} B/s`;
-    }
-    if (bps < 1024 * 1024) {
-        return `${(bps / 1024).toFixed(1)} KB/s`;
-    }
-    if (bps < 1024 * 1024 * 1024) {
-        return `${(bps / (1024 * 1024)).toFixed(1)} MB/s`;
-    }
-    return `${(bps / (1024 * 1024 * 1024)).toFixed(1)} GB/s`;
-};
-
-/**
  * Format a large number with SI suffixes.
  * Examples: "1.2K", "3.5M", "1.1G"
  */
@@ -75,3 +58,9 @@ export const formatBytesRate = (bytes: number, suffix: string = '/s'): string =>
     }
     return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB${suffix}`;
 };
+
+/**
+ * Format bytes per second value for display.
+ * Examples: "500 B/s", "1.2 KB/s", "3.5 MB/s", "1.1 GB/s"
+ */
+export const formatBps = (bps: number): string => formatBytesRate(bps);


### PR DESCRIPTION
- Reduced formatBps to a one-line delegate to formatBytesRate, removing the duplicated IEC byte-rate scaling body; formatBytesRate's default "/s" suffix yields byte-identical output ("B/s", "KB/s", "MB/s", "GB/s").
- Reordered the two so the delegate is defined after its target; no caller or signature change.
- No behavior change: verified an output-identity table across the full value range and zero pixel diff on the devices, functions and pipelines BPS displays against main.