### PR TITLE
feat(buf): gate proto breaking changes against main

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -6,11 +6,13 @@ on:
       - '**/*.proto'
       - 'lint/protobuf/**'
       - 'buf.yaml'
+      - '.github/workflows/proto-lint.yml'
   pull_request:
     paths:
       - '**/*.proto'
       - 'lint/protobuf/**'
       - 'buf.yaml'
+      - '.github/workflows/proto-lint.yml'
 
 jobs:
   buf-lint:
@@ -25,6 +27,20 @@ jobs:
 
       - name: Run buf lint
         run: buf lint
+
+  buf-breaking:
+    name: Buf breaking
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+
+      - name: Run buf breaking
+        run: buf breaking --against "https://github.com/${{ github.repository }}.git#branch=main"
 
   protolint:
     name: Custom protolint linter

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ CLI_RELEASE_BINARIES := $(addprefix $(RELEASE_DIR)/,$(CLI_BINARIES))
 	clean \
 	go-cache-clean \
 	proto-lint \
+	proto-breaking \
 	test \
 	test-asan \
 	test-tsan \
@@ -86,6 +87,13 @@ proto-lint:
 	fi
 	go test ./lint/protobuf/cmd/protolint/
 	go run ./lint/protobuf/cmd/protolint/ --exclude subprojects
+
+proto-breaking:
+	@if command -v buf >/dev/null 2>&1; then \
+		buf breaking --against ".git#branch=main"; \
+	else \
+		echo "WARN: 'buf' not found, skipping buf breaking (install: https://buf.build/docs/installation)"; \
+	fi
 
 go-cache-clean:
 	go clean -cache

--- a/buf.yaml
+++ b/buf.yaml
@@ -23,3 +23,5 @@ lint:
 breaking:
   use:
     - PACKAGE
+  ignore:
+    - modules/balancer2


### PR DESCRIPTION
Now that every proto surface is on the `.v1` FQN convention and buf lint covers them all, freeze the v1 baseline with a `buf breaking` CI gate.

- Add a `buf-breaking` job to the proto-lint workflow that compares a pull request's protobuf definitions against `main` and fails on any wire-incompatible change. It runs on pull requests only.
- Exclude `modules/balancer2` from the breaking gate via `buf.yaml`, since that module is still under active rewrite and pre-v1. Removing this ignore later is the marker for balancer2 reaching v1.
- Add a `proto-breaking` Makefile target so contributors can run the same check locally.
- Add the workflow file to its own trigger `paths` so future changes to it self-trigger.

Closes #573. Together with the surface migrations (#1072, #1075, #1078, #1082) and lint coverage (#1086), this completes the proto v1 baseline groundwork. A compatibility policy doc follows for #574.