### PR TITLE
feat(dataplane): pin instance storage to its NUMA node

### DIFF
--- a/common/hugepages.h
+++ b/common/hugepages.h
@@ -2,6 +2,7 @@
 
 #include <linux/magic.h>
 #include <sys/statfs.h>
+#include <unistd.h>
 
 // Checks whether the file backed by given file descriptor is mounted on
 // hugepages.
@@ -16,4 +17,19 @@ is_file_on_hugepages_fs(int fd) {
 	}
 
 	return (fs_stat.f_type == HUGETLBFS_MAGIC) ? 1 : 0;
+}
+
+// Returns the fault granularity (bytes) of the filesystem backing fd:
+// the huge page size for hugetlbfs, otherwise the base page size.
+// Returns -1 on error.
+static inline long
+file_page_size(int fd) {
+	struct statfs fs_stat;
+	if (fstatfs(fd, &fs_stat) == -1) {
+		return -1;
+	}
+	if (fs_stat.f_type == HUGETLBFS_MAGIC) {
+		return fs_stat.f_bsize;
+	}
+	return sysconf(_SC_PAGESIZE);
 }

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -1,9 +1,7 @@
 #include "dataplane.h"
 
 #include "config.h"
-#include "logging/log.h"
-
-#include <stdint.h>
+#include "numa.h"
 
 #include <dlfcn.h>
 #include <pthread.h>
@@ -14,7 +12,6 @@
 #include "dpdk.h"
 
 #include "common/data_pipe.h"
-#include "common/exp_array.h"
 #include "common/strutils.h"
 
 #include "common/hugepages.h"
@@ -33,12 +30,12 @@
 #include "lib/dataplane/config/topology.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/packet.h"
-#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
 
 #include <unistd.h>
 
-#include "sys/mman.h"
 #include <fcntl.h>
+#include <sys/mman.h>
 
 static int
 dataplane_worker_connect(
@@ -293,7 +290,15 @@ dataplane_init(
 		close(mem_fd);
 		return -1;
 	}
+
+	long page_size = file_page_size(mem_fd);
 	close(mem_fd);
+	if (page_size <= 0) {
+		LOG(ERROR, "failed to get storage page size");
+		return -1;
+	}
+
+	assert((uintptr_t)storage % page_size == 0);
 
 	off_t instance_offset = 0;
 	for (uint32_t instance_idx = 0;
@@ -304,8 +309,36 @@ dataplane_init(
 		struct dataplane_instance_config *instance_config =
 			config->instances + instance_idx;
 
+		size_t instance_size =
+			instance_config->dp_memory + instance_config->cp_memory;
+		if (instance_size == 0 || instance_size % page_size != 0) {
+			LOG(ERROR,
+			    "instance size must be positive and divisible by "
+			    "page size");
+			return -1;
+		}
+
 		LOG(INFO, "initialize storage for instance %u", instance_idx);
-		int rc = dp_storage_init(
+
+		yanet_error *err = NULL;
+		int rc = allocate_pages_on_numa(
+			storage + instance_offset,
+			instance_size,
+			instance_config->numa_idx,
+			page_size,
+			&err
+		);
+		if (rc != 0) {
+			LOG(ERROR,
+			    "failed to allocate instance %u on numa %u: %s",
+			    instance_idx,
+			    instance_config->numa_idx,
+			    yanet_error_message(err));
+			yanet_error_free(err);
+			return -1;
+		}
+
+		rc = dp_storage_init(
 			instance_config->numa_idx,
 			instance_idx,
 			storage + instance_offset,
@@ -389,7 +422,6 @@ dataplane_init(
 			}
 		}
 
-		yanet_error *err = NULL;
 		struct cp_config_gen *cp_config_gen =
 			cp_config_gen_create(agent, &err);
 		if (cp_config_gen == NULL) {
@@ -403,8 +435,7 @@ dataplane_init(
 			&instance->cp_config->cp_config_gen, cp_config_gen
 		);
 
-		instance_offset +=
-			instance_config->dp_memory + instance_config->cp_memory;
+		instance_offset += instance_size;
 	}
 
 	size_t pci_port_count = 0;

--- a/dataplane/meson.build
+++ b/dataplane/meson.build
@@ -18,6 +18,7 @@ lib_sources = files(
   'dataplane.c',
   'device.c',
   'worker.c',
+  'numa.c',
 )
 
 lib_dataplane = static_library(

--- a/dataplane/numa.c
+++ b/dataplane/numa.c
@@ -1,0 +1,80 @@
+#include "errors.h"
+
+#include <errno.h>
+#include <numaif.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+int
+allocate_pages_on_numa(
+	void *start,
+	size_t size,
+	uint16_t numa_idx,
+	size_t page_size,
+	yanet_error **err
+) {
+	if (numa_idx >= sizeof(uint64_t) * 8) {
+		yanet_error_add(
+			err,
+			"numa index %u exceeds maximum %zu",
+			numa_idx,
+			sizeof(uint64_t) * 8 - 1
+		);
+		return -1;
+	}
+	uint64_t numa_mask = 1ull << numa_idx;
+
+	if ((uintptr_t)start % page_size != 0) {
+		yanet_error_add(
+			err, "start address must be divisible by page size"
+		);
+		return -1;
+	}
+	if (size % page_size != 0) {
+		yanet_error_add(err, "size must be divisible by page_size");
+		return -1;
+	}
+
+	int orig_mode = MPOL_DEFAULT;
+	uint64_t orig_mask = 0;
+	if (get_mempolicy(
+		    &orig_mode, &orig_mask, sizeof(orig_mask) * 8, NULL, 0
+	    ) != 0) {
+		yanet_error_add(
+			err,
+			"failed to read current memory policy: %s",
+			strerror(errno)
+		);
+		return -1;
+	}
+
+	if (set_mempolicy(
+		    MPOL_BIND | MPOL_F_STATIC_NODES,
+		    &numa_mask,
+		    sizeof(numa_mask) * 8
+	    ) != 0) {
+		yanet_error_add(
+			err,
+			"failed to bind memory to numa node: %s",
+			strerror(errno)
+		);
+		return -1;
+	}
+
+	// TODO: intercept SIGBUS
+	for (size_t i = 0; i < size; i += page_size) {
+		((char *)start)[i] = 0;
+	}
+
+	if (set_mempolicy(orig_mode, &orig_mask, sizeof(orig_mask) * 8) != 0) {
+		yanet_error_add(
+			err,
+			"failed to restore memory policy: %s",
+			strerror(errno)
+		);
+		return -1;
+	}
+
+	return 0;
+}

--- a/dataplane/numa.h
+++ b/dataplane/numa.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "errors.h"
+#include <stddef.h>
+#include <stdint.h>
+
+// Allocates the pages of [start, start+size) on NUMA node numa_idx.
+//
+// Pages of a shared mapping follow the memory policy of the thread that
+// first touches them. So this binds the calling thread to numa_idx and
+// touches every page to fault it in there. Pre-faulting here also pins the
+// pages before another process (e.g. the controlplane) can touch them first.
+//
+// The pages must not be touched previously: an already-faulted page keeps
+// its current node, as first-touch no longer applies to it.
+//
+// The bind is strict, so the touch raises SIGBUS when numa_idx has no free
+// (huge)pages left.
+//
+// The start and size must be divisible by page_size.
+int
+allocate_pages_on_numa(
+	void *start,
+	size_t size,
+	uint16_t numa_idx,
+	size_t page_size,
+	yanet_error **err
+);

--- a/lib/dataplane/config/bootstrap.c
+++ b/lib/dataplane/config/bootstrap.c
@@ -15,8 +15,6 @@ dp_storage_init(
 	struct dp_config **res_dp_config,
 	struct cp_config **res_cp_config
 ) {
-	// TODO: move pages to requested numa node
-
 	struct dp_config *dp_config = (struct dp_config *)storage;
 
 	dp_config->numa_idx = numa_idx;


### PR DESCRIPTION
Allocate each dataplane instance's storage on its configured NUMA node by faulting in its pages under a bind memory policy. Allocation is strict: if the node cannot back the instance's storage, initialization fails.
