### PR TITLE
refactor(web): extract shared range formatter

### DIFF
--- a/web/src/pages/modules/acl/hooks.ts
+++ b/web/src/pages/modules/acl/hooks.ts
@@ -1,6 +1,6 @@
 import type { Rule, PortRange, VlanRange, ProtoRange, Action } from '../../../api/acl';
 import { ActionKind } from '../../../api/acl';
-import { extractBytes, formatIPNetItem } from '../../../utils';
+import { extractBytes, formatIPNetItem, formatRange } from '../../../utils';
 import type { RuleDraft, RuleItem } from './types';
 import { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
 export { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parseHelpers';
@@ -14,14 +14,6 @@ export { parseCidrsToIPNets, parseRangesRaw, parseProtoRangesRaw } from './parse
  */
 export const normalizeActionKind = (kind: ActionKind | undefined): ActionKind =>
     kind ?? ActionKind.ACTION_KIND_PASS;
-
-/** Format a PortRange or ProtoRange {from, to} to a string like "80" or "80-90". */
-const formatRange = (r: { from?: number; to?: number }): string => {
-    const from = r.from ?? 0;
-    const to = r.to ?? 0;
-    if (from === to) return String(from);
-    return `${from}-${to}`;
-};
 
 /** Returns true when port ranges cover the full 0-65535 domain. */
 const coversAllPorts = (ranges: PortRange[]): boolean => {
@@ -205,12 +197,7 @@ export const rulesToNgItems = (rules: Rule[], ids: string[]): RuleItem[] =>
 export const itemToDraft = (item: RuleItem): RuleDraft => ruleToDraft(item.rule);
 
 /** Convert a ProtoRange wire object to the encoded-range string "A-B". */
-export const protoRangeToStr = (r: ProtoRange): string => {
-    const from = r.from ?? 0;
-    const to = r.to ?? 0;
-    if (from === to) return String(from);
-    return `${from}-${to}`;
-};
+export const protoRangeToStr = (r: ProtoRange): string => formatRange(r);
 
 /** Convert a RuleDraft to a wire Rule. */
 export const draftToRule = (draft: RuleDraft): Rule => {

--- a/web/src/pages/modules/acl/parseHelpers.ts
+++ b/web/src/pages/modules/acl/parseHelpers.ts
@@ -34,9 +34,4 @@ export const parseRangesRaw = (raw: string): Array<{ from: number; to: number }>
 };
 
 /** Parse encoded proto ranges (e.g. "1536-1791") to ProtoRange wire objects. */
-export const parseProtoRangesRaw = (raw: string): ProtoRange[] => {
-    if (!raw.trim()) return [];
-    return raw.split(/[,\n]+/)
-        .map(s => parseRangeStr(s))
-        .filter((r): r is { from: number; to: number } => r !== null);
-};
+export const parseProtoRangesRaw = (raw: string): ProtoRange[] => parseRangesRaw(raw) as ProtoRange[];

--- a/web/src/pages/modules/forward/hooks.ts
+++ b/web/src/pages/modules/forward/hooks.ts
@@ -1,17 +1,12 @@
 import type { Rule, VlanRange } from '../../../api/forward';
 import { ForwardMode } from '../../../api/forward';
-import { formatIPNetItem, parseCidrsToIPNets } from '../../../utils';
+import { formatIPNetItem, formatRange, parseCidrsToIPNets } from '../../../utils';
 import type { RuleItem, RuleDraft } from './types';
 
 /** Format VlanRange array to a display string. */
 const formatVlanRanges = (ranges: VlanRange[] | undefined): string => {
     if (!ranges || ranges.length === 0) return '';
-    return ranges.map((r) => {
-        const from = r.from ?? 0;
-        const to = r.to ?? 0;
-        if (from === to) return String(from);
-        return `${from}-${to}`;
-    }).join(', ');
+    return ranges.map((r) => formatRange(r)).join(', ');
 };
 
 /** Returns true if the VLAN ranges represent the full 0-4095 range or no restriction. */

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -10,3 +10,4 @@ export * from './packetParser';
 export * from './clipboard';
 export * from './counterGroups';
 export * from './validation';
+export * from './ranges';

--- a/web/src/utils/ranges.ts
+++ b/web/src/utils/ranges.ts
@@ -1,0 +1,7 @@
+/** Format a {from, to} range to "80" (when from===to) or "80-90". */
+export const formatRange = (r: { from?: number; to?: number }): string => {
+    const from = r.from ?? 0;
+    const to = r.to ?? 0;
+    if (from === to) return String(from);
+    return `${from}-${to}`;
+};


### PR DESCRIPTION
- Extract the duplicated `{from, to}` range-to-string logic into a shared `formatRange` helper in `web/src/utils/ranges.ts`.
- Replace three byte-identical copies: acl `formatRange`, acl `protoRangeToStr`, and the forward inner block in `formatVlanRanges`.
- Collapse the byte-identical acl `parseProtoRangesRaw` onto `parseRangesRaw`.
- No behavior change: verified zero visual diff on `/modules/acl` and `/modules/forward` via dual-server Playwright pixel comparison (0 mismatched pixels).