### PR TITLE
refactor(web): extract natural-sort comparator

### DIFF
--- a/web/src/pages/modules/acl/useAclDraft.ts
+++ b/web/src/pages/modules/acl/useAclDraft.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useReducer, useState } from 'react';
 import { API } from '../../../api';
-import { toaster } from '../../../utils';
+import { toaster, compareNatural } from '../../../utils';
 import type { Rule } from '../../../api/acl';
 import {
     aclDraftReducer,
@@ -135,7 +135,7 @@ export const useAclDraft = (): UseAclDraftResult => {
     const draftConfigs = [
         ...state.serverConfigs.filter(n => !state.pendingDeleteConfigs.has(n)),
         ...state.localOnlyConfigs,
-    ].sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }));
+    ].sort((a, b) => compareNatural(a, b));
 
     const anyDirty = state.dirty.size > 0;
 

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -22,7 +22,7 @@ import { useContainerHeight } from '../../../hooks';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import { ipAddressToString, isValidIPAddress, parseIPToBytes, stringToIPAddress, type IPAddressWire } from '../../../utils/netip';
 import { parseMACToBytes } from '../../../utils/mac';
-import { formatBytes, toaster } from '../../../utils';
+import { formatBytes, toaster, compareNatural } from '../../../utils';
 import { AddConfigModal } from '../../_shared/draft';
 import { DeleteConfigModal, CommandPaletteHeader } from '../../../components';
 import { SaveIcon, TrashIcon } from '../../_shared/draft/DraftActionButtons';
@@ -1087,7 +1087,7 @@ const FWStatePage: React.FC = () => {
     const dirtyConfigsRef = useRef(dirtyConfigs);
     const statsRequestIdRef = useRef(0);
 
-    const configNames = useMemo(() => Object.keys(configs).sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })), [configs]);
+    const configNames = useMemo(() => Object.keys(configs).sort((a, b) => compareNatural(a, b)), [configs]);
     const queryConfig = useMemo(() => searchParams.get(QP_CONFIG), [searchParams]);
     const currentName = useMemo(() => {
         if (queryConfig && (loading || configNames.includes(queryConfig))) {

--- a/web/src/pages/operators/route/useRIB.ts
+++ b/web/src/pages/operators/route/useRIB.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { API } from '../../../api';
-import { toaster } from '../../../utils';
+import { toaster, compareNatural } from '../../../utils';
 import type { Route } from '../../../api/routes';
 
 export interface UseRIBResult {
@@ -15,7 +15,7 @@ export interface UseRIBResult {
 }
 
 const sortConfigs = (a: string, b: string): number =>
-    a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+    compareNatural(a, b);
 
 /** Loads route configs and their routes from the operator backend. */
 export const useRIB = (): UseRIBResult => {

--- a/web/src/utils/sorting.ts
+++ b/web/src/utils/sorting.ts
@@ -1,3 +1,7 @@
+/** Compare two strings with natural (numeric-aware, case-insensitive) ordering. */
+export const compareNatural = (a: string, b: string): number =>
+    a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+
 type NullableString = string | null | undefined;
 type NullableNumber = number | null | undefined;
 type NullableBoolean = boolean | null | undefined;


### PR DESCRIPTION
- Extract the duplicated numeric-aware, case-insensitive `localeCompare` comparator into a shared `compareNatural` helper in `web/src/utils/sorting.ts`.
- Replace three inline copies in the acl, fwstate, and route-operator config-name sorts.
- No behavior change: verified zero visual diff on `/modules/acl` and `/modules/fwstate` via dual-server Playwright pixel comparison (0 mismatched pixels); route-operator ordering confirmed unchanged by source inspection.