### PR TITLE
refactor(web): share proto-chip color tones via mixin

### DIFF
--- a/web/src/pages/modules/_shared/chips.scss
+++ b/web/src/pages/modules/_shared/chips.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/mixins' as *;
+
 .shared-chip {
     display: inline-flex;
     align-items: center;
@@ -28,32 +30,4 @@
     font-size: 12px;
 }
 
-.shared-chip--proto-tcp {
-    background: color-mix(in srgb, var(--g-color-base-positive-light) 55%, transparent);
-    color: var(--g-color-text-positive);
-    border-color: color-mix(in srgb, var(--g-color-base-positive-medium) 40%, transparent);
-}
-
-.shared-chip--proto-udp {
-    background: color-mix(in srgb, var(--g-color-base-info-light) 55%, transparent);
-    color: var(--g-color-text-info);
-    border-color: color-mix(in srgb, var(--g-color-base-info-medium) 40%, transparent);
-}
-
-.shared-chip--proto-icmp {
-    background: color-mix(in srgb, var(--g-color-base-warning-light) 55%, transparent);
-    color: var(--g-color-text-warning);
-    border-color: color-mix(in srgb, var(--g-color-base-warning-medium) 40%, transparent);
-}
-
-.shared-chip--proto-misc {
-    background: color-mix(in srgb, var(--g-color-base-misc-light) 55%, transparent);
-    color: var(--g-color-text-misc);
-    border-color: color-mix(in srgb, var(--g-color-base-misc-medium) 40%, transparent);
-}
-
-.shared-chip--proto-dim {
-    background: var(--yn-bg-2);
-    color: var(--yn-text-3);
-    border-color: var(--yn-line-2);
-}
+@include proto-chip-tones('.shared-chip');

--- a/web/src/pages/modules/acl/acl.scss
+++ b/web/src/pages/modules/acl/acl.scss
@@ -116,39 +116,9 @@
         border-color: var(--yn-line-2);
     }
 
-    // Proto chips by tone.
-    &--proto {
-        &-tcp {
-            background: color-mix(in srgb, var(--g-color-base-positive-light) 55%, transparent);
-            color: var(--g-color-text-positive);
-            border-color: color-mix(in srgb, var(--g-color-base-positive-medium) 40%, transparent);
-        }
-
-        &-udp {
-            background: color-mix(in srgb, var(--g-color-base-info-light) 55%, transparent);
-            color: var(--g-color-text-info);
-            border-color: color-mix(in srgb, var(--g-color-base-info-medium) 40%, transparent);
-        }
-
-        &-icmp {
-            background: color-mix(in srgb, var(--g-color-base-warning-light) 55%, transparent);
-            color: var(--g-color-text-warning);
-            border-color: color-mix(in srgb, var(--g-color-base-warning-medium) 40%, transparent);
-        }
-
-        &-misc {
-            background: color-mix(in srgb, var(--g-color-base-misc-light) 55%, transparent);
-            color: var(--g-color-text-misc);
-            border-color: color-mix(in srgb, var(--g-color-base-misc-medium) 40%, transparent);
-        }
-
-        &-dim {
-            background: var(--yn-bg-2);
-            color: var(--yn-text-3);
-            border-color: var(--yn-line-2);
-        }
-    }
 }
+
+@include proto-chip-tones('.acl-chip');
 
 // Action chain in table cells.
 .acl-action-chain {

--- a/web/src/styles/_mixins.scss
+++ b/web/src/styles/_mixins.scss
@@ -91,6 +91,35 @@
     }
 }
 
+/** Emit the shared protocol-chip color tones for a given chip base selector. */
+@mixin proto-chip-tones($base) {
+    #{$base}--proto-tcp {
+        background: color-mix(in srgb, var(--g-color-base-positive-light) 55%, transparent);
+        color: var(--g-color-text-positive);
+        border-color: color-mix(in srgb, var(--g-color-base-positive-medium) 40%, transparent);
+    }
+    #{$base}--proto-udp {
+        background: color-mix(in srgb, var(--g-color-base-info-light) 55%, transparent);
+        color: var(--g-color-text-info);
+        border-color: color-mix(in srgb, var(--g-color-base-info-medium) 40%, transparent);
+    }
+    #{$base}--proto-icmp {
+        background: color-mix(in srgb, var(--g-color-base-warning-light) 55%, transparent);
+        color: var(--g-color-text-warning);
+        border-color: color-mix(in srgb, var(--g-color-base-warning-medium) 40%, transparent);
+    }
+    #{$base}--proto-misc {
+        background: color-mix(in srgb, var(--g-color-base-misc-light) 55%, transparent);
+        color: var(--g-color-text-misc);
+        border-color: color-mix(in srgb, var(--g-color-base-misc-medium) 40%, transparent);
+    }
+    #{$base}--proto-dim {
+        background: var(--yn-bg-2);
+        color: var(--yn-text-3);
+        border-color: var(--yn-line-2);
+    }
+}
+
 /** Side-by-side diff dialog chrome — shared by fn-diff-dialog and pl-diff-dialog. */
 @mixin diff-dialog($page-bg, $line) {
     // Override Gravity's size="l" to be wide enough for side-by-side split view.


### PR DESCRIPTION
- Extract the byte-identical tcp/udp/icmp/misc/dim protocol-chip color tones into a `proto-chip-tones` SCSS mixin in `styles/_mixins.scss`.
- Both `.shared-chip--proto-*` and `.acl-chip--proto-*` now include the mixin instead of duplicating the color blocks.
- Compiled CSS is byte-identical (verified) and Playwright pixel diff on `/modules/acl` is 0 with proto chips rendered.