### PR TITLE
refactor(web): share toggle-chip count badge via mixin

### DIFF
--- a/web/src/pages/operators/route/route.scss
+++ b/web/src/pages/operators/route/route.scss
@@ -59,18 +59,7 @@
 }
 
 .ro-chip__badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 16px;
-    height: 16px;
-    padding: 0 4px;
-    border-radius: 999px;
-    font-size: 11px;
-    font-weight: 700;
-    opacity: 0.8;
-    font-family: var(--yn-font-mono);
-    font-variant-numeric: tabular-nums;
+    @include toggle-chip-badge;
 }
 
 // ─── Lookup drawer ─────────────────────────────────────────────────────────────

--- a/web/src/styles/_mixins.scss
+++ b/web/src/styles/_mixins.scss
@@ -120,6 +120,22 @@
     }
 }
 
+/** Count badge pill shared by the toggle chips (route + neighbours). */
+@mixin toggle-chip-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 700;
+    opacity: 0.8;
+    font-family: var(--yn-font-mono);
+    font-variant-numeric: tabular-nums;
+}
+
 /** Side-by-side diff dialog chrome — shared by fn-diff-dialog and pl-diff-dialog. */
 @mixin diff-dialog($page-bg, $line) {
     // Override Gravity's size="l" to be wide enough for side-by-side split view.

--- a/web/src/styles/draft/_neighbours.scss
+++ b/web/src/styles/draft/_neighbours.scss
@@ -440,16 +440,5 @@
 }
 
 .nb-state-chip__badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 16px;
-    height: 16px;
-    padding: 0 4px;
-    border-radius: 999px;
-    font-size: 11px;
-    font-weight: 700;
-    opacity: 0.8;
-    font-family: var(--yn-font-mono);
-    font-variant-numeric: tabular-nums;
+    @include toggle-chip-badge;
 }


### PR DESCRIPTION
- Extract the byte-identical count-badge pill shared by `.ro-chip__badge` and `.nb-state-chip__badge` into a `toggle-chip-badge` SCSS mixin.
- The diverging chip bodies, hovers, and active modifiers are left untouched.
- Compiled CSS bundles are byte-identical (content-hashed filenames unchanged); Playwright pixel diff on `/operators/neighbours` is 0 with the state-chip badges rendered.