### PR TITLE
refactor(web): extract shared CidrPrefixField component

### DIFF
--- a/web/src/components/CidrPrefixField.tsx
+++ b/web/src/components/CidrPrefixField.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface CidrPrefixFieldProps {
+    label: string;
+    value: string;
+    placeholder: string;
+    error?: string | null;
+    onChange: (value: string) => void;
+}
+
+export const CidrPrefixField = ({ label, value, placeholder, error, onChange }: CidrPrefixFieldProps): React.JSX.Element => (
+    <div className="yn-field">
+        <label className="yn-field__label">
+            {label} <span className="yn-field__req">*</span>
+        </label>
+        <input
+            className={`yn-input yn-input--mono${error ? ' yn-input--invalid' : ''}`}
+            value={value}
+            placeholder={placeholder}
+            onChange={(e) => onChange(e.target.value)}
+        />
+        {error
+            ? <span className="yn-field__hint yn-field__error">{error}</span>
+            : <span className="yn-field__hint">IPv4 or IPv6 with mask.</span>}
+    </div>
+);

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -64,3 +64,4 @@ export { default as RowCountDisplay } from './RowCountDisplay';
 export type { DraftYamlIOProps } from './DraftYamlIO';
 export { DraftSaveDiffModal } from './DraftSaveDiffModal';
 export type { DraftSaveDiffModalProps } from './DraftSaveDiffModal';
+export { CidrPrefixField } from './CidrPrefixField';

--- a/web/src/pages/modules/decap/PrefixDrawer.tsx
+++ b/web/src/pages/modules/decap/PrefixDrawer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useImperativeHandle, useState } from 'react';
 import type { PrefixRowItem, PrefixRowErrors } from './types';
 import { validateRow } from './validation';
 import { DraftItemDrawer } from '../../_shared/draft';
+import { CidrPrefixField } from '../../../components';
 
 interface PrefixDrawerProps {
     open: boolean;
@@ -79,21 +80,13 @@ const PrefixDrawer = React.forwardRef<PrefixDrawerHandle, PrefixDrawerProps>(({
             <section className="yn-section">
                 <div className="yn-section-h">Prefix</div>
                 <div className="yn-section__body">
-                    <div className="yn-field">
-                        <label className="yn-field__label">
-                            CIDR <span className="yn-field__req">*</span>
-                        </label>
-                        <input
-                            className={`yn-input yn-input--mono${errors.prefix ? ' yn-input--invalid' : ''}`}
-                            value={draft?.prefix ?? ''}
-                            placeholder="10.0.0.0/8 or 2a02:6b8::/32"
-                            onChange={(e) => updateField('prefix', e.target.value.trim())}
-                        />
-                        {errors.prefix
-                            ? <span className="yn-field__hint yn-field__error">{errors.prefix}</span>
-                            : <span className="yn-field__hint">IPv4 or IPv6 with mask.</span>
-                        }
-                    </div>
+                    <CidrPrefixField
+                        label="CIDR"
+                        placeholder="10.0.0.0/8 or 2a02:6b8::/32"
+                        value={draft?.prefix ?? ''}
+                        error={errors.prefix}
+                        onChange={(v) => updateField('prefix', v.trim())}
+                    />
                 </div>
             </section>
         </DraftItemDrawer>

--- a/web/src/pages/modules/route/FIBDrawer.tsx
+++ b/web/src/pages/modules/route/FIBDrawer.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useImperativeHandle, useState } from 'react';
 import type { FIBRowItem, FIBRowErrors } from './types';
 import { validateRow } from './validation';
 import { DraftItemDrawer } from '../../_shared/draft';
+import { CidrPrefixField } from '../../../components';
 
 interface FIBDrawerProps {
     open: boolean;
@@ -79,21 +80,13 @@ const FIBDrawer = React.forwardRef<FIBDrawerHandle, FIBDrawerProps>(({
             <section className="yn-section">
                 <div className="yn-section-h">Destination</div>
                 <div className="yn-section__body">
-                    <div className="yn-field">
-                        <label className="yn-field__label">
-                            Prefix <span className="yn-field__req">*</span>
-                        </label>
-                        <input
-                            className={`yn-input yn-input--mono${errors.prefix ? ' yn-input--invalid' : ''}`}
-                            value={draft?.prefix ?? ''}
-                            placeholder="10.0.0.0/8 or 2a02:6b8::/32"
-                            onChange={(e) => updateField('prefix', e.target.value.trim())}
-                        />
-                        {errors.prefix
-                            ? <span className="yn-field__hint yn-field__error">{errors.prefix}</span>
-                            : <span className="yn-field__hint">IPv4 or IPv6 with mask.</span>
-                        }
-                    </div>
+                    <CidrPrefixField
+                        label="Prefix"
+                        placeholder="10.0.0.0/8 or 2a02:6b8::/32"
+                        value={draft?.prefix ?? ''}
+                        error={errors.prefix}
+                        onChange={(v) => updateField('prefix', v.trim())}
+                    />
                 </div>
             </section>
 

--- a/web/src/pages/operators/route/RouteDrawer.tsx
+++ b/web/src/pages/operators/route/RouteDrawer.tsx
@@ -4,6 +4,7 @@ import { DraftItemDrawer } from '../../_shared/draft';
 import { ipAddressToString } from '../../../utils/netip';
 import { validatePrefix, validateNexthop } from './utils';
 import type { Route } from '../../../api/routes';
+import { CidrPrefixField } from '../../../components';
 
 export interface RouteDrawerProps {
     open: boolean;
@@ -103,21 +104,13 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
             <section className="yn-section">
                 <div className="yn-section-h">Destination</div>
                 <div className="yn-section__body">
-                    <div className="yn-field">
-                        <label className="yn-field__label">
-                            Prefix <span className="yn-field__req">*</span>
-                        </label>
-                        <input
-                            className={`yn-input yn-input--mono${prefixError ? ' yn-input--invalid' : ''}`}
-                            value={prefix}
-                            placeholder="10.0.0.0/8 or 2001:db8::/32"
-                            onChange={(e) => setPrefix(e.target.value)}
-                        />
-                        {prefixError
-                            ? <span className="yn-field__hint yn-field__error">{prefixError}</span>
-                            : <span className="yn-field__hint">IPv4 or IPv6 with mask.</span>
-                        }
-                    </div>
+                    <CidrPrefixField
+                        label="Prefix"
+                        placeholder="10.0.0.0/8 or 2001:db8::/32"
+                        value={prefix}
+                        error={prefixError}
+                        onChange={(v) => setPrefix(v)}
+                    />
                 </div>
             </section>
 


### PR DESCRIPTION
- Replace the repeated `yn-field` CIDR/Prefix input fragment in the decap, route, and route-operator drawers with a shared `CidrPrefixField` component in `web/src/components/`.
- Label, placeholder, value, error, and the caller's trim behavior are passed as props, so each call site's rendered markup and behavior are unchanged (including the decap "CIDR" label, the operator's distinct placeholder, and the operator's no-trim onChange).
- Verified zero visual diff: drawer-open Playwright pixel diff is 0 on `/modules/decap`, `/modules/route`, and `/operators/route`, and the rendered `.yn-field` DOM is byte-identical on all three.