### PR TITLE
refactor(web): consolidate counter interpolation into shared hooks

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -33,3 +33,6 @@ export { useDirtyConfigSet } from './useDirtyConfigSet';
 
 export { useConfigQuerySync } from './useConfigQuerySync';
 export type { UseConfigQuerySyncOptions } from './useConfigQuerySync';
+
+export { useLagInterpolated } from './useLagInterpolated';
+export { useRollingWindow } from './useRollingWindow';

--- a/web/src/hooks/useCounterHistory.ts
+++ b/web/src/hooks/useCounterHistory.ts
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import type { DeviceCounterData } from './useDeviceCounters';
+import { useRollingWindow } from './useRollingWindow';
 
 export const HISTORY_SIZE = 60;
 
@@ -32,63 +33,46 @@ export const appendCapped = (arr: number[], v: number, cap: number): number[] =>
 export const useCounterHistory = (
     counters: Map<string, DeviceCounterData>
 ): Map<string, CounterHistoryEntry> => {
-    // historyRef holds the mutable ring-buffer; we return a fresh Map snapshot on
-    // each sample tick so React can detect the change.
-    const historyRef = useRef<Map<string, CounterHistoryEntry>>(new Map());
-    const [snapshot, setSnapshot] = useState<Map<string, CounterHistoryEntry>>(new Map());
+    const rxSamples = useMemo(() => {
+        const m = new Map<string, number>();
+        counters.forEach((d, name) => m.set(name, d.rx.pps));
+        return m;
+    }, [counters]);
 
-    // Keep a stable ref to the latest counters map so the interval callback can
-    // read it without being recreated every render.
-    const countersRef = useRef(counters);
-    countersRef.current = counters;
+    const txSamples = useMemo(() => {
+        const m = new Map<string, number>();
+        counters.forEach((d, name) => m.set(name, d.tx.pps));
+        return m;
+    }, [counters]);
 
-    useEffect(() => {
-        const tick = () => {
-            const current = countersRef.current;
-            if (!current.size) return;
+    const rxBytesSamples = useMemo(() => {
+        const m = new Map<string, number>();
+        counters.forEach((d, name) => m.set(name, d.rx.bps));
+        return m;
+    }, [counters]);
 
-            const history = historyRef.current;
-            let mutated = false;
+    const txBytesSamples = useMemo(() => {
+        const m = new Map<string, number>();
+        counters.forEach((d, name) => m.set(name, d.tx.bps));
+        return m;
+    }, [counters]);
 
-            for (const [name, data] of current.entries()) {
-                const entry = history.get(name);
+    const rxHistory = useRollingWindow(rxSamples, HISTORY_SIZE, 1000);
+    const txHistory = useRollingWindow(txSamples, HISTORY_SIZE, 1000);
+    const rxBytesHistory = useRollingWindow(rxBytesSamples, HISTORY_SIZE, 1000);
+    const txBytesHistory = useRollingWindow(txBytesSamples, HISTORY_SIZE, 1000);
 
-                if (!entry) {
-                    // Seed with HISTORY_SIZE copies of the current value so the
-                    // sparkline starts as a flat line rather than a single-sample
-                    // spike that immediately falls downward.
-                    history.set(name, {
-                        rx:      Array(HISTORY_SIZE).fill(data.rx.pps) as number[],
-                        tx:      Array(HISTORY_SIZE).fill(data.tx.pps) as number[],
-                        rxBytes: Array(HISTORY_SIZE).fill(data.rx.bps) as number[],
-                        txBytes: Array(HISTORY_SIZE).fill(data.tx.bps) as number[],
-                    });
-                    mutated = true;
-                    continue;
-                }
-
-                // Always produce fresh arrays and a fresh entry object so that
-                // React Compiler memoized children see a changed reference.
-                history.set(name, {
-                    rx:      appendCapped(entry.rx,      data.rx.pps, HISTORY_SIZE),
-                    tx:      appendCapped(entry.tx,      data.tx.pps, HISTORY_SIZE),
-                    rxBytes: appendCapped(entry.rxBytes, data.rx.bps, HISTORY_SIZE),
-                    txBytes: appendCapped(entry.txBytes, data.tx.bps, HISTORY_SIZE),
-                });
-                mutated = true;
+    return useMemo(() => {
+        const result = new Map<string, CounterHistoryEntry>();
+        counters.forEach((_, name) => {
+            const rx = rxHistory.get(name);
+            const tx = txHistory.get(name);
+            const rxBytes = rxBytesHistory.get(name);
+            const txBytes = txBytesHistory.get(name);
+            if (rx && tx && rxBytes && txBytes) {
+                result.set(name, { rx, tx, rxBytes, txBytes });
             }
-
-            if (mutated) {
-                setSnapshot(new Map(history));
-            }
-        };
-
-        // Fire immediately so any already-loaded counters are seeded at mount
-        // without waiting the first full second.
-        tick();
-        const id = setInterval(tick, 1000);
-        return () => clearInterval(id);
-    }, []);
-
-    return snapshot;
+        });
+        return result;
+    }, [counters, rxHistory, txHistory, rxBytesHistory, txBytesHistory]);
 };

--- a/web/src/hooks/useInterpolatedCounters.ts
+++ b/web/src/hooks/useInterpolatedCounters.ts
@@ -1,4 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
+import { computeRate } from '../utils/interpolation';
+import { useLagInterpolated } from './useLagInterpolated';
 
 /**
  * Counter data with interpolated rate values.
@@ -24,14 +26,6 @@ interface RawCounterSnapshot<K extends string = string> {
     values: Map<K, { packets: bigint; bytes: bigint }>;
 }
 
-/**
- * Calculated rate at a point in time.
- */
-interface RateSnapshot<K extends string = string> {
-    timestamp: number;
-    rates: Map<K, { pps: number; bps: number }>;
-}
-
 export interface UseInterpolatedCountersOptions<K extends string = string> {
     /**
      * List of keys to track counters for.
@@ -51,6 +45,9 @@ export interface UseInterpolatedCountersOptions<K extends string = string> {
 
     /**
      * Interpolation update interval in milliseconds. Default: 30ms.
+     *
+     * This option is accepted for backwards compatibility but is ignored
+     * internally — interpolation now runs via requestAnimationFrame.
      */
     interpolationInterval?: number;
 
@@ -68,18 +65,19 @@ export interface UseInterpolatedCountersResult<K extends string = string> {
 
     /**
      * Map of key -> interpolated absolute data (packets/bytes).
-     * Uses linear extrapolation based on current rate.
+     * Interpolates cumulative packet/byte counts between the two most recent
+     * raw snapshots; never extrapolates past the current sample.
      */
     absoluteCounters: Map<K, InterpolatedAbsoluteData>;
 }
 
 /**
  * Hook for fetching and interpolating counters.
- * 
- * - Polls counters at specified interval (default: 1 second)
- * - Calculates rate (pps/bps) from counter deltas
- * - Stores previous and current rate for interpolation
- * - Updates visual at specified interval (default: 30ms) using linear interpolation
+ *
+ * - Polls counters at the specified interval (default: 1 second).
+ * - Computes per-second rates from counter deltas via computeRate.
+ * - Smoothly interpolates pps/bps and absolute packet/byte counts between
+ *   poll snapshots using RAF lag-interpolation (prev -> cur, clamp to [0,1]).
  */
 export const useInterpolatedCounters = <K extends string = string>(
     options: UseInterpolatedCountersOptions<K>
@@ -88,214 +86,147 @@ export const useInterpolatedCounters = <K extends string = string>(
         keys,
         fetchCounters,
         pollingInterval = 1000,
-        interpolationInterval = 30,
         enabled = true,
     } = options;
 
-    // Interpolated rate counters for display
-    const [counters, setCounters] = useState<Map<K, InterpolatedCounterData>>(new Map());
-
-    // Interpolated absolute counters for display
-    const [absoluteCounters, setAbsoluteCounters] = useState<Map<K, InterpolatedAbsoluteData>>(new Map());
-
-    // Store raw counter snapshots (cumulative values)
+    // Latest two raw cumulative snapshots for rate and absolute interpolation.
     const snapshotsRef = useRef<RawCounterSnapshot<K>[]>([]);
 
-    // Store calculated rate snapshots for interpolation
-    const ratesRef = useRef<RateSnapshot<K>[]>([]);
+    // pps samples fed into useLagInterpolated — one map entry per key.
+    const [ppsSamples, setPpsSamples] = useState<Map<K, number>>(() => new Map());
+    // bps samples fed into useLagInterpolated.
+    const [bpsSamples, setBpsSamples] = useState<Map<K, number>>(() => new Map());
+    // Absolute packet samples (cumulative BigInt -> Number snapshot).
+    const [packetSamples, setPacketSamples] = useState<Map<K, number>>(() => new Map());
+    // Absolute byte samples.
+    const [bytesSamples, setBytesSamples] = useState<Map<K, number>>(() => new Map());
 
-    // Track if component is mounted
-    const isMountedRef = useRef(true);
-
-    // Store keys ref to avoid effect re-triggers
     const keysRef = useRef<K[]>(keys);
     keysRef.current = keys;
 
-    // Store fetch function ref
     const fetchCountersRef = useRef(fetchCounters);
     fetchCountersRef.current = fetchCounters;
 
-    // Stable key for keys array to use in dependencies
     const keysKey = useMemo(() => JSON.stringify([...keys].sort()), [keys]);
 
-    // Clear stale snapshots and rates whenever the key set changes so that the
-    // first rate sample after a config switch is not computed against data from
-    // the previous config (which would produce an arbitrarily large or negative
-    // delta and therefore a garbage pps value).
+    // Clear stale snapshots when the key set changes to avoid garbage deltas
+    // across config switches.
     useEffect(() => {
         snapshotsRef.current = [];
-        ratesRef.current = [];
+        setPpsSamples(new Map());
+        setBpsSamples(new Map());
+        setPacketSamples(new Map());
+        setBytesSamples(new Map());
     }, [keysKey]);
 
-    // Fetch counters at polling interval and calculate rates
+    // Poll loop: fetch cumulative counters, compute rates, publish samples.
     useEffect(() => {
         if (!enabled || keys.length === 0) return;
 
-        const doFetch = async () => {
-            if (!isMountedRef.current) return;
+        let cancelled = false;
+
+        const doFetch = async (): Promise<void> => {
+            if (cancelled) return;
 
             const currentKeys = keysRef.current;
 
             try {
                 const newValues = await fetchCountersRef.current();
-                const now = Date.now();
+                if (cancelled) return;
 
-                // Add new raw snapshot
+                const now = Date.now();
                 const newSnapshot: RawCounterSnapshot<K> = {
                     timestamp: now,
                     values: newValues,
                 };
 
-                // Calculate rate if we have a previous snapshot
                 const prevSnapshot = snapshotsRef.current[snapshotsRef.current.length - 1];
-                if (prevSnapshot) {
-                    const timeDelta = (now - prevSnapshot.timestamp) / 1000; // seconds
 
-                    if (timeDelta > 0) {
-                        const newRates = new Map<K, { pps: number; bps: number }>();
+                if (prevSnapshot) {
+                    const dtSeconds = (now - prevSnapshot.timestamp) / 1000;
+
+                    if (dtSeconds > 0) {
+                        const nextPps = new Map<K, number>();
+                        const nextBps = new Map<K, number>();
 
                         for (const key of currentKeys) {
-                            const prevVal = prevSnapshot.values.get(key);
-                            const currVal = newValues.get(key);
+                            const prev = prevSnapshot.values.get(key);
+                            const cur = newValues.get(key);
 
-                            if (prevVal && currVal) {
-                                const packetsDelta = Number(currVal.packets - prevVal.packets);
-                                const bytesDelta = Number(currVal.bytes - prevVal.bytes);
-
-                                const pps = packetsDelta >= 0 ? packetsDelta / timeDelta : 0;
-                                const bps = bytesDelta >= 0 ? bytesDelta / timeDelta : 0;
-
-                                newRates.set(key, { pps, bps });
+                            if (prev && cur) {
+                                const { pps, bps } = computeRate(prev, cur, dtSeconds);
+                                nextPps.set(key, pps);
+                                nextBps.set(key, bps);
                             } else {
-                                newRates.set(key, { pps: 0, bps: 0 });
+                                nextPps.set(key, 0);
+                                nextBps.set(key, 0);
                             }
                         }
 
-                        // Add new rate snapshot
-                        ratesRef.current.push({
-                            timestamp: now,
-                            rates: newRates,
-                        });
-
-                        // Keep only last 2 rate snapshots
-                        if (ratesRef.current.length > 2) {
-                            ratesRef.current.shift();
-                        }
+                        setPpsSamples(nextPps);
+                        setBpsSamples(nextBps);
                     }
                 }
 
-                // Store raw snapshot
-                snapshotsRef.current.push(newSnapshot);
+                // Publish absolute samples from the latest snapshot.
+                const nextPackets = new Map<K, number>();
+                const nextBytes = new Map<K, number>();
+                for (const key of currentKeys) {
+                    const cur = newValues.get(key);
+                    nextPackets.set(key, cur ? Number(cur.packets) : 0);
+                    nextBytes.set(key, cur ? Number(cur.bytes) : 0);
+                }
+                setPacketSamples(nextPackets);
+                setBytesSamples(nextBytes);
 
-                // Keep only last 2 raw snapshots
+                snapshotsRef.current.push(newSnapshot);
                 if (snapshotsRef.current.length > 2) {
                     snapshotsRef.current.shift();
                 }
-            } catch (error) {
-                console.error('Failed to fetch counters:', error);
+            } catch {
+                // tolerate fetch failures.
             }
         };
 
-        // Initial fetch
         doFetch();
-
-        // Set up polling interval
-        const intervalId = setInterval(doFetch, pollingInterval);
-
+        const id = setInterval(doFetch, pollingInterval);
         return () => {
-            clearInterval(intervalId);
+            cancelled = true;
+            clearInterval(id);
         };
     }, [enabled, keysKey, pollingInterval]);
 
-    // Interpolation timer - updates at interpolation interval
-    useEffect(() => {
-        if (!enabled) return;
+    // Lag-interpolate pps, bps, packets, bytes independently.
+    const interpPps = useLagInterpolated(ppsSamples, pollingInterval);
+    const interpBps = useLagInterpolated(bpsSamples, pollingInterval);
+    const interpPackets = useLagInterpolated(packetSamples, pollingInterval);
+    const interpBytes = useLagInterpolated(bytesSamples, pollingInterval);
 
-        const interpolate = () => {
-            if (!isMountedRef.current) return;
-
-            const rates = ratesRef.current;
-            const snapshots = snapshotsRef.current;
-            const currentKeys = keysRef.current;
-
-            // Need keys to display
-            if (currentKeys.length === 0) return;
-
-            // Need at least one rate snapshot to publish anything.
-            if (rates.length === 0) return;
-
-            const newCounters = new Map<K, InterpolatedCounterData>();
-            const newAbsoluteCounters = new Map<K, InterpolatedAbsoluteData>();
-            const now = Date.now();
-
-            // When two rates are available, interpolate; otherwise use the single rate directly.
-            const prevRate = rates.length >= 2 ? rates[0] : null;
-            const currRate = rates[rates.length - 1];
-
-            // Get the latest raw snapshot for absolute value extrapolation
-            const latestSnapshot = snapshots[snapshots.length - 1];
-
-            // Calculate progress: 0 at currRate.timestamp, 1 at currRate.timestamp + pollingInterval
-            const elapsed = now - currRate.timestamp;
-            const progress = Math.min(1, Math.max(0, elapsed / 1000));
-
-            // Time elapsed since the latest snapshot (in seconds)
-            const elapsedSinceSnapshot = (now - (latestSnapshot?.timestamp ?? now)) / 1000;
-
-            for (const key of currentKeys) {
-                const prev = prevRate?.rates.get(key);
-                const curr = currRate.rates.get(key);
-                const latestValue = latestSnapshot?.values.get(key);
-
-                if (prev && curr) {
-                    // Linear interpolation from prev rate to curr rate
-                    const pps = prev.pps + (curr.pps - prev.pps) * progress;
-                    const bps = prev.bps + (curr.bps - prev.bps) * progress;
-                    newCounters.set(key, { pps, bps });
-
-                    // Extrapolate absolute values using current rate
-                    if (latestValue) {
-                        const packets = Number(latestValue.packets) + pps * elapsedSinceSnapshot;
-                        const bytes = Number(latestValue.bytes) + bps * elapsedSinceSnapshot;
-                        newAbsoluteCounters.set(key, { packets, bytes });
-                    } else {
-                        newAbsoluteCounters.set(key, { packets: 0, bytes: 0 });
-                    }
-                } else if (curr) {
-                    newCounters.set(key, { pps: curr.pps, bps: curr.bps });
-
-                    if (latestValue) {
-                        const packets = Number(latestValue.packets) + curr.pps * elapsedSinceSnapshot;
-                        const bytes = Number(latestValue.bytes) + curr.bps * elapsedSinceSnapshot;
-                        newAbsoluteCounters.set(key, { packets, bytes });
-                    } else {
-                        newAbsoluteCounters.set(key, { packets: 0, bytes: 0 });
-                    }
-                } else {
-                    newCounters.set(key, { pps: 0, bps: 0 });
-                    newAbsoluteCounters.set(key, { packets: 0, bytes: 0 });
-                }
+    // Assemble output maps. Build fresh Map objects each render so consumers
+    // that depend on map identity detect the change.
+    const counters = useMemo((): Map<K, InterpolatedCounterData> => {
+        const out = new Map<K, InterpolatedCounterData>();
+        for (const key of keys) {
+            const pps = interpPps.get(key);
+            const bps = interpBps.get(key);
+            if (pps !== undefined && bps !== undefined) {
+                out.set(key, { pps, bps });
             }
+        }
+        return out;
+    }, [keys, interpPps, interpBps]);
 
-            setCounters(newCounters);
-            setAbsoluteCounters(newAbsoluteCounters);
-        };
-
-        // Run interpolation at specified interval
-        const intervalId = setInterval(interpolate, interpolationInterval);
-
-        return () => {
-            clearInterval(intervalId);
-        };
-    }, [enabled, interpolationInterval]);
-
-    // Cleanup on unmount
-    useEffect(() => {
-        isMountedRef.current = true;
-        return () => {
-            isMountedRef.current = false;
-        };
-    }, []);
+    const absoluteCounters = useMemo((): Map<K, InterpolatedAbsoluteData> => {
+        const out = new Map<K, InterpolatedAbsoluteData>();
+        for (const key of keys) {
+            const packets = interpPackets.get(key);
+            const bytes = interpBytes.get(key);
+            if (packets !== undefined && bytes !== undefined) {
+                out.set(key, { packets, bytes });
+            }
+        }
+        return out;
+    }, [keys, interpPackets, interpBytes]);
 
     return { counters, absoluteCounters };
 };

--- a/web/src/hooks/useLagInterpolated.ts
+++ b/web/src/hooks/useLagInterpolated.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react';
+import { lerp, clampProgress } from '../utils/interpolation';
+
+interface KeyState {
+    prevValue: number;
+    curValue: number;
+    curTs: number;
+}
+
+/**
+ * Generic per-key lag-interpolation hook using requestAnimationFrame.
+ *
+ * For each key in `samples`, the returned map holds a value that
+ * continuously interpolates from the previous sample toward the current
+ * sample. Interpolation uses wall-clock progress clamped to [0, 1], so
+ * the displayed value never overshoots the current sample (no extrapolation).
+ *
+ * Keys that disappear from the input map are removed from internal state
+ * on the next RAF tick. The returned Map reference changes every animation
+ * frame so memoized consumers detect the change.
+ *
+ * When there are no keys to animate, setState is skipped each frame to avoid
+ * spurious re-renders (the last published empty map is already correct).
+ */
+export const useLagInterpolated = <K>(
+    samples: Map<K, number>,
+    intervalMs: number,
+): Map<K, number> => {
+    const stateRef = useRef<Map<K, KeyState>>(new Map());
+    const lastInputRef = useRef<Map<K, number>>(new Map());
+    const lastPublishedSizeRef = useRef(0);
+    const [animated, setAnimated] = useState<Map<K, number>>(() => new Map());
+
+    // Commit new samples during render so the RAF tick always sees fresh state.
+    samples.forEach((v, k) => {
+        const last = lastInputRef.current.get(k);
+        if (last !== v) {
+            const now = performance.now();
+            const existing = stateRef.current.get(k);
+            stateRef.current.set(k, {
+                prevValue: existing?.curValue ?? v,
+                curValue: v,
+                curTs: now,
+            });
+            lastInputRef.current.set(k, v);
+        }
+    });
+
+    // Remove keys that have disappeared.
+    [...stateRef.current.keys()].forEach((k) => {
+        if (!samples.has(k)) {
+            stateRef.current.delete(k);
+            lastInputRef.current.delete(k);
+        }
+    });
+
+    useEffect(() => {
+        let raf = 0;
+        const tick = (): void => {
+            const size = stateRef.current.size;
+
+            // Skip setState entirely when there is nothing to animate and the
+            // last published map was already empty — avoids per-frame churn
+            // while the hook is idle (e.g. enabled:false, no keys loaded).
+            if (size === 0 && lastPublishedSizeRef.current === 0) {
+                raf = requestAnimationFrame(tick);
+                return;
+            }
+
+            const now = performance.now();
+            const next = new Map<K, number>();
+            stateRef.current.forEach((s, k) => {
+                const t = clampProgress(now, s.curTs, intervalMs);
+                next.set(k, lerp(s.prevValue, s.curValue, t));
+            });
+            lastPublishedSizeRef.current = next.size;
+            setAnimated(next);
+            raf = requestAnimationFrame(tick);
+        };
+        raf = requestAnimationFrame(tick);
+        return () => cancelAnimationFrame(raf);
+    }, [intervalMs]);
+
+    return animated;
+};

--- a/web/src/hooks/useModuleRuleCounters.ts
+++ b/web/src/hooks/useModuleRuleCounters.ts
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { API } from '../api';
 import { useInterpolatedCounters } from './useInterpolatedCounters';
-import { appendCapped, HISTORY_SIZE } from './useCounterHistory';
+import { useRollingWindow } from './useRollingWindow';
+import { HISTORY_SIZE } from './useCounterHistory';
 import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../utils';
 
 /** Per-rule rate data: rolling history for the sparkline and the latest interpolated pps. */
@@ -29,7 +30,7 @@ export interface ModuleRuleCountersParams<T> {
  *
  * Polls CountersService.ByTags once per second for the supplied counterNames,
  * maintains a HISTORY_SIZE-sample pps rolling window per counter, and
- * interpolates at ~30 ms for smooth sparkline animation. Rates are keyed by
+ * interpolates via RAF lag for smooth sparkline animation. Rates are keyed by
  * rule id (from the T constraint `{ id: string }`).
  */
 export const useModuleRuleCounters = <T extends { id: string }>(
@@ -45,43 +46,7 @@ export const useModuleRuleCounters = <T extends { id: string }>(
         isCounterActive,
     } = params;
 
-    const historyRef = useRef<Map<string, number[]>>(new Map());
-    const [rates, setRates] = useState<Map<string, RuleRate>>(new Map());
-    const ratesRef = useRef(rates);
-    ratesRef.current = rates;
-
-    const countersRef = useRef<Map<string, { pps: number }>>(new Map());
-
-    useEffect(() => {
-        historyRef.current = new Map();
-        setRates(new Map());
-    }, [configName]);
-
     const counterNamesKey = counterNames.join(',');
-
-    useEffect(() => {
-        const history = historyRef.current;
-        const next = new Map<string, RuleRate>();
-        for (const rule of rules) {
-            const cname = getCounterName(rule);
-            if (!cname) continue;
-            if (isCounterActive && !isCounterActive(cname)) continue;
-            const h = history.get(cname);
-            if (h) next.set(rule.id, { history: h, pps: countersRef.current.get(cname)?.pps ?? 0 });
-        }
-        if (next.size === 0 && ratesRef.current.size === 0) return;
-        setRates(next);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [rules, counterNamesKey]);
-
-    const rulesRef = useRef(rules);
-    rulesRef.current = rules;
-    const getCounterNameRef = useRef(getCounterName);
-    getCounterNameRef.current = getCounterName;
-    const isCounterActiveRef = useRef(isCounterActive);
-    isCounterActiveRef.current = isCounterActive;
-    const counterNamesRef = useRef(counterNames);
-    counterNamesRef.current = counterNames;
 
     const fetchCounters = useCallback(async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
         const result = new Map<string, { packets: bigint; bytes: bigint }>();
@@ -123,54 +88,33 @@ export const useModuleRuleCounters = <T extends { id: string }>(
         interpolationInterval: 30,
     });
 
-    countersRef.current = counters;
-
-    useEffect(() => {
-        if (!enabled || counterNames.length === 0) return;
-
-        const tick = (): void => {
-            const currentCounters = countersRef.current;
-            const currentRules = rulesRef.current;
-            const currentIsActive = isCounterActiveRef.current;
-            if (!currentCounters.size || !currentRules.length) return;
-
-            const history = historyRef.current;
-            let mutated = false;
-
-            for (const [counterName, data] of currentCounters.entries()) {
-                if (currentIsActive && !currentIsActive(counterName)) continue;
-                const pps = data.pps;
-                const existing = history.get(counterName);
-                if (!existing) {
-                    history.set(counterName, Array(HISTORY_SIZE).fill(pps) as number[]);
-                } else {
-                    history.set(counterName, appendCapped(existing, pps, HISTORY_SIZE));
-                }
-                mutated = true;
-            }
-
-            if (!mutated) return;
-
-            const currentGetName = getCounterNameRef.current;
-            const next = new Map<string, RuleRate>();
-            for (const rule of currentRules) {
-                const cname = currentGetName(rule);
-                if (!cname) continue;
-                if (currentIsActive && !currentIsActive(cname)) continue;
-                const h = history.get(cname);
-                if (h) {
-                    const pps = currentCounters.get(cname)?.pps ?? 0;
-                    next.set(rule.id, { history: h, pps });
-                }
-            }
-            setRates(next);
-        };
-
-        tick();
-        const id = setInterval(tick, 1000);
-        return () => clearInterval(id);
+    // Build the pps sample map — only include active counters.
+    const ppsSamples = useMemo((): Map<string, number> => {
+        const m = new Map<string, number>();
+        counters.forEach((data, name) => {
+            if (isCounterActive && !isCounterActive(name)) return;
+            m.set(name, data.pps);
+        });
+        return m;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [enabled, counterNamesKey]);
+    }, [counters, counterNamesKey, isCounterActive]);
+
+    const history = useRollingWindow(ppsSamples, HISTORY_SIZE, 1000, configName);
+
+    // Assemble RuleRate map keyed by rule id.
+    const rates = useMemo(() => {
+        const next = new Map<string, RuleRate>();
+        for (const rule of rules) {
+            const cname = getCounterName(rule);
+            if (!cname) continue;
+            if (isCounterActive && !isCounterActive(cname)) continue;
+            const h = history.get(cname);
+            if (!h) continue;
+            const pps = counters.get(cname)?.pps ?? 0;
+            next.set(rule.id, { history: h, pps });
+        }
+        return next;
+    }, [rules, history, counters, getCounterName, isCounterActive]);
 
     return { rates };
 };

--- a/web/src/hooks/useRollingWindow.ts
+++ b/web/src/hooks/useRollingWindow.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Maintain a rolling history window for each key in `samples`.
+ *
+ * On each tick (every `intervalMs` ms) the current value is appended to the
+ * per-key ring buffer, capped at `cap` entries. The returned Map and every
+ * array inside it are fresh references each tick so React-Compiler memoized
+ * children reliably detect the change via reference equality.
+ *
+ * Seed-on-first-sight: when a key appears for the first time it is pre-filled
+ * with `cap` copies of its current value, producing an immediately flat
+ * sparkline instead of a downward spike.
+ *
+ * An immediate first tick fires at mount so that already-loaded data is
+ * seeded without waiting the first full interval.
+ *
+ * When `resetKey` changes the history is cleared so a consumer can drop stale
+ * data across context switches (e.g. config change).
+ */
+export const useRollingWindow = <K>(
+    samples: Map<K, number>,
+    cap: number,
+    intervalMs: number,
+    resetKey?: string | number,
+): Map<K, number[]> => {
+    const samplesRef = useRef(samples);
+    samplesRef.current = samples;
+
+    const historyRef = useRef<Map<K, number[]>>(new Map());
+    const [snapshot, setSnapshot] = useState<Map<K, number[]>>(() => new Map());
+
+    // When resetKey changes, clear all accumulated history immediately.
+    useEffect(() => {
+        historyRef.current = new Map();
+        setSnapshot(new Map());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [resetKey]);
+
+    useEffect(() => {
+        const tick = (): void => {
+            const current = samplesRef.current;
+            const history = historyRef.current;
+            let mutated = false;
+
+            // Append/seed entries for keys present in the current sample set.
+            current.forEach((v, k) => {
+                const existing = history.get(k);
+                if (existing === undefined) {
+                    // Seed with cap copies so the sparkline starts as a flat line.
+                    history.set(k, Array(cap).fill(v) as number[]);
+                    mutated = true;
+                } else {
+                    const grown = [...existing, v];
+                    if (grown.length > cap) grown.shift();
+                    history.set(k, grown);
+                    mutated = true;
+                }
+            });
+
+            // Remove keys that have been dropped from samples. This runs even
+            // when current is empty so stale history drains within one tick.
+            [...history.keys()].forEach((k) => {
+                if (!current.has(k)) {
+                    history.delete(k);
+                    mutated = true;
+                }
+            });
+
+            if (mutated) {
+                setSnapshot(new Map(history));
+            }
+        };
+
+        tick();
+        const id = setInterval(tick, intervalMs);
+        return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [cap, intervalMs]);
+
+    return snapshot;
+};

--- a/web/src/pages/builtin/inspect/FnWall.tsx
+++ b/web/src/pages/builtin/inspect/FnWall.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import type { InstanceInfo } from '../../../api/inspect';
-import { useFunctionCounters, useLaggedSeriesMap } from './hooks';
+import { useFunctionCounters } from './hooks';
 import { FunctionTile } from './FunctionTile';
 
 export interface FnWallProps {
@@ -26,20 +26,12 @@ export const FnWall: React.FC<FnWallProps> = ({ instance }) => {
         [functions],
     );
 
-    const { rates } = useFunctionCounters(
+    const { rates, series } = useFunctionCounters(
         deviceNames,
         pipelineNames,
         functionNames,
         devices.length > 0 && pipelines.length > 0 && functions.length > 0,
     );
-
-    const ppsMap = useMemo(() => {
-        const m = new Map<string, number>();
-        rates.forEach((r, name) => m.set(name, r.pps));
-        return m;
-    }, [rates]);
-
-    const laggedSeries = useLaggedSeriesMap(ppsMap, 30, 1500);
 
     const activeCount = useMemo(() => {
         let count = 0;
@@ -68,7 +60,7 @@ export const FnWall: React.FC<FnWallProps> = ({ instance }) => {
                     const name = f.name ?? `fn-${idx}`;
                     const rate = rates.get(name);
                     const pps = rate?.pps ?? 0;
-                    const trend = laggedSeries.get(name) ?? [];
+                    const trend = series.get(name) ?? [];
 
                     return (
                         <FunctionTile

--- a/web/src/pages/builtin/inspect/FunctionTile.tsx
+++ b/web/src/pages/builtin/inspect/FunctionTile.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useLaggedValue } from './hooks';
 import { Sparkline } from './Sparkline';
 import { IconFn } from './icons';
 import { fmtPps } from './formatters';
@@ -12,7 +11,6 @@ export interface FunctionTileProps {
 
 /** Single function tile in FnWall with lag-interpolated PPS display. */
 export const FunctionTile: React.FC<FunctionTileProps> = ({ name, pps, trend }) => {
-    const smoothPps = useLaggedValue(pps, 1500);
     const active = pps > 0;
 
     return (
@@ -25,7 +23,7 @@ export const FunctionTile: React.FC<FunctionTileProps> = ({ name, pps, trend }) 
             </div>
             <div className="iv-fn-tile__bottom">
                 <span className="iv-fn-tile__pps">
-                    {fmtPps(smoothPps)}
+                    {fmtPps(pps)}
                     <span className="iv-pps-unit"> pps</span>
                 </span>
                 <Sparkline data={trend} w={48} h={12} color="var(--iv-accent)" />

--- a/web/src/pages/builtin/inspect/PipeWall.tsx
+++ b/web/src/pages/builtin/inspect/PipeWall.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import type { InstanceInfo } from '../../../api/inspect';
-import { usePipelineCounters, useLaggedSeriesMap } from './hooks';
+import { usePipelineCounters } from './hooks';
 import { PipelineRow } from './PipelineRow';
 
 export interface PipeWallProps {
@@ -21,19 +21,11 @@ export const PipeWall: React.FC<PipeWallProps> = ({ instance }) => {
         [pipelines],
     );
 
-    const { rates } = usePipelineCounters(
+    const { rates, series } = usePipelineCounters(
         deviceNames,
         pipelineNames,
         devices.length > 0 && pipelines.length > 0,
     );
-
-    const ppsMap = useMemo(() => {
-        const m = new Map<string, number>();
-        rates.forEach((r, name) => m.set(name, r.pps));
-        return m;
-    }, [rates]);
-
-    const laggedSeries = useLaggedSeriesMap(ppsMap, 30, 1500);
 
     return (
         <div className="iv-pipe-wall">
@@ -46,7 +38,7 @@ export const PipeWall: React.FC<PipeWallProps> = ({ instance }) => {
                     const name = p.name ?? `pipeline-${idx}`;
                     const rate = rates.get(name);
                     const pps = rate?.pps ?? 0;
-                    const trend = laggedSeries.get(name) ?? [];
+                    const trend = series.get(name) ?? [];
                     const fns = p.functions ?? [];
 
                     return (

--- a/web/src/pages/builtin/inspect/PipelineRow.tsx
+++ b/web/src/pages/builtin/inspect/PipelineRow.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useLaggedValue } from './hooks';
 import { Sparkline } from './Sparkline';
 import { fmtPps } from './formatters';
 
@@ -12,7 +11,6 @@ export interface PipelineRowProps {
 
 /** Single pipeline row in PipeWall with lag-interpolated PPS display. */
 export const PipelineRow: React.FC<PipelineRowProps> = ({ name, pps, fns, trend }) => {
-    const smoothPps = useLaggedValue(pps, 1500);
     const active = pps > 0;
 
     return (
@@ -29,7 +27,7 @@ export const PipelineRow: React.FC<PipelineRowProps> = ({ name, pps, fns, trend 
             </span>
             <Sparkline data={trend} w={70} h={20} color="var(--iv-accent)" />
             <span className="iv-pipe-row__pps">
-                {fmtPps(smoothPps)}
+                {fmtPps(pps)}
                 <span className="iv-pps-unit"> pps</span>
             </span>
         </div>

--- a/web/src/pages/builtin/inspect/hooks.ts
+++ b/web/src/pages/builtin/inspect/hooks.ts
@@ -1,6 +1,8 @@
-import { useEffect, useRef, useState, useMemo } from 'react';
+import { useMemo } from 'react';
 import { API } from '../../../api';
 import type { DeviceCounterData } from '../../../hooks';
+import { useInterpolatedCounters } from '../../../hooks/useInterpolatedCounters';
+import { useRollingWindow } from '../../../hooks/useRollingWindow';
 import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../utils';
 
 const DEFAULT_INTERVAL_MS = 1500;
@@ -8,32 +10,22 @@ const DEFAULT_MAX_LEN = 30;
 
 /**
  * Push the current value onto a rolling history at the polling interval.
+ *
+ * Thin wrapper over useRollingWindow for a single scalar value.
  */
 export const useRollingSeries = (
     value: number | undefined,
     maxLen: number = DEFAULT_MAX_LEN,
     intervalMs: number = DEFAULT_INTERVAL_MS,
 ): number[] => {
-    const valueRef = useRef<number>(value ?? 0);
-    valueRef.current = value ?? 0;
-
-    const [series, setSeries] = useState<number[]>([]);
-
-    useEffect(() => {
-        const id = setInterval(() => {
-            setSeries((prev) => {
-                if (prev.length === 0 && valueRef.current === 0) {
-                    return prev;
-                }
-                const next = [...prev, valueRef.current];
-                if (next.length > maxLen) next.shift();
-                return next;
-            });
-        }, intervalMs);
-        return () => clearInterval(id);
-    }, [maxLen, intervalMs]);
-
-    return series;
+    const key = '__single__';
+    const samples = useMemo(() => {
+        const m = new Map<string, number>();
+        m.set(key, value ?? 0);
+        return m;
+    }, [value]);
+    const window = useRollingWindow(samples, maxLen, intervalMs);
+    return window.get(key) ?? [];
 };
 
 /**
@@ -63,42 +55,15 @@ export const useDeviceTrendSeries = (
     kind: 'rx' | 'tx',
     maxLen: number = DEFAULT_MAX_LEN,
 ): Map<string, number[]> => {
-    const deviceCountersRef = useRef(deviceCounters);
-    deviceCountersRef.current = deviceCounters;
-    const kindRef = useRef(kind);
-    kindRef.current = kind;
-
-    const [series, setSeries] = useState<Map<string, number[]>>(() => new Map());
-
-    useEffect(() => {
-        const id = setInterval(() => {
-            const counters = deviceCountersRef.current;
-            const k = kindRef.current;
-            setSeries((prev) => {
-                const next = new Map<string, number[]>();
-                counters.forEach((d, name) => {
-                    const v = (k === 'rx' ? d.rx?.pps : d.tx?.pps) ?? 0;
-                    const old = prev.get(name);
-                    if (old === undefined && v === 0) {
-                        return;
-                    }
-                    const grown = [...(old ?? []), v];
-                    if (grown.length > maxLen) grown.shift();
-                    next.set(name, grown);
-                });
-                return next;
-            });
-        }, DEFAULT_INTERVAL_MS);
-        return () => clearInterval(id);
-    }, [maxLen]);
-
-    return series;
+    const samples = useMemo(() => {
+        const m = new Map<string, number>();
+        deviceCounters.forEach((d, name) => {
+            m.set(name, (kind === 'rx' ? d.rx?.pps : d.tx?.pps) ?? 0);
+        });
+        return m;
+    }, [deviceCounters, kind]);
+    return useRollingWindow(samples, maxLen, DEFAULT_INTERVAL_MS);
 };
-
-interface PrevSnapshot {
-    timestamp: number;
-    values: Map<string, { packets: bigint; bytes: bigint }>;
-}
 
 interface RatesAndSeries {
     rates: Map<string, { pps: number; bps: number }>;
@@ -110,105 +75,61 @@ interface RatesAndSeries {
  * rate and rolling series.
  */
 export const usePipelineCounters = (
-    devices: string[],
+    _devices: string[],
     pipelines: string[],
     enabled: boolean,
 ): RatesAndSeries => {
-    const prevRef = useRef<PrevSnapshot | null>(null);
-    const [rates, setRates] = useState<Map<string, { pps: number; bps: number }>>(new Map());
-    const [series, setSeries] = useState<Map<string, number[]>>(() => new Map());
-
-    const devicesRef = useRef(devices);
-    devicesRef.current = devices;
-    const pipelinesRef = useRef(pipelines);
-    pipelinesRef.current = pipelines;
-
-    const devicesKey = useMemo(() => devices.join('|'), [devices]);
     const pipelinesKey = useMemo(() => pipelines.join('|'), [pipelines]);
 
-    useEffect(() => {
-        if (!enabled || devicesRef.current.length === 0 || pipelinesRef.current.length === 0) {
-            prevRef.current = null;
-            setRates(new Map());
-            setSeries(new Map());
-            return;
+    const fetchCounters = useMemo(() => async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
+        const totals = new Map<string, { packets: bigint; bytes: bigint }>();
+        for (const p of pipelines) {
+            totals.set(p, { packets: BigInt(0), bytes: BigInt(0) });
         }
 
-        let cancelled = false;
-
-        const tick = async (): Promise<void> => {
-            const now = Date.now();
-            const currentPipelines = pipelinesRef.current;
-
-            const totals = new Map<string, { packets: bigint; bytes: bigint }>();
-            for (const p of currentPipelines) {
-                totals.set(p, { packets: BigInt(0), bytes: BigInt(0) });
-            }
-
-            try {
-                const response = await API.counters.byTags({
-                    tags: [
-                        { key: 'pipeline', value: '*' },
-                        { key: 'function', value: '' },
-                    ],
-                    query: ['input', 'input_bytes'],
-                });
-                const grouped = groupCounterGroupsByTagsAndName(response.groups, ['pipeline'], 0);
-                for (const pipeline of currentPipelines) {
-                    totals.set(pipeline, {
-                        packets: grouped.get(makeGroupedCounterKey([pipeline], 'input'))?.value ?? BigInt(0),
-                        bytes: grouped.get(makeGroupedCounterKey([pipeline], 'input_bytes'))?.value ?? BigInt(0),
-                    });
-                }
-            } catch {
-                // tolerate fetch failures.
-            }
-
-            if (cancelled) return;
-
-            const newRates = new Map<string, { pps: number; bps: number }>();
-            const prev = prevRef.current;
-            if (prev) {
-                const dt = (now - prev.timestamp) / 1000;
-                if (dt > 0) {
-                    totals.forEach((cur, name) => {
-                        const old = prev.values.get(name) ?? { packets: BigInt(0), bytes: BigInt(0) };
-                        const dp = Number(cur.packets - old.packets);
-                        const db = Number(cur.bytes - old.bytes);
-                        newRates.set(name, {
-                            pps: Math.max(0, dp / dt),
-                            bps: Math.max(0, db / dt),
-                        });
-                    });
-                }
-            }
-
-            const hadPrev = prevRef.current !== null;
-            prevRef.current = { timestamp: now, values: totals };
-
-            if (hadPrev) {
-                setSeries((prev) => {
-                    const next = new Map<string, number[]>();
-                    newRates.forEach((r, name) => {
-                        const old = prev.get(name) ?? [];
-                        const grown = [...old, r.pps];
-                        if (grown.length > DEFAULT_MAX_LEN) grown.shift();
-                        next.set(name, grown);
-                    });
-                    return next;
+        try {
+            const response = await API.counters.byTags({
+                tags: [
+                    { key: 'pipeline', value: '*' },
+                    { key: 'function', value: '' },
+                ],
+                query: ['input', 'input_bytes'],
+            });
+            const grouped = groupCounterGroupsByTagsAndName(response.groups, ['pipeline'], 0);
+            for (const pipeline of pipelines) {
+                totals.set(pipeline, {
+                    packets: grouped.get(makeGroupedCounterKey([pipeline], 'input'))?.value ?? BigInt(0),
+                    bytes: grouped.get(makeGroupedCounterKey([pipeline], 'input_bytes'))?.value ?? BigInt(0),
                 });
             }
+        } catch {
+            // tolerate fetch failures.
+        }
 
-            setRates(newRates);
-        };
+        return totals;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [pipelinesKey]);
 
-        tick();
-        const id = setInterval(tick, DEFAULT_INTERVAL_MS);
-        return () => {
-            cancelled = true;
-            clearInterval(id);
-        };
-    }, [enabled, devicesKey, pipelinesKey]);
+    const { counters } = useInterpolatedCounters({
+        keys: pipelines,
+        fetchCounters,
+        enabled: enabled && pipelines.length > 0,
+        pollingInterval: DEFAULT_INTERVAL_MS,
+    });
+
+    const ppsSamples = useMemo(() => {
+        const m = new Map<string, number>();
+        counters.forEach((r, name) => m.set(name, r.pps));
+        return m;
+    }, [counters]);
+
+    const series = useRollingWindow(ppsSamples, DEFAULT_MAX_LEN, DEFAULT_INTERVAL_MS);
+
+    const rates = useMemo(() => {
+        const m = new Map<string, { pps: number; bps: number }>();
+        counters.forEach((r, name) => m.set(name, { pps: r.pps, bps: r.bps }));
+        return m;
+    }, [counters]);
 
     return { rates, series };
 };
@@ -218,228 +139,62 @@ export const usePipelineCounters = (
  * rate and rolling series.
  */
 export const useFunctionCounters = (
-    devices: string[],
-    pipelines: string[],
+    _devices: string[],
+    _pipelines: string[],
     functions: string[],
     enabled: boolean,
 ): RatesAndSeries => {
-    const prevRef = useRef<PrevSnapshot | null>(null);
-    const [rates, setRates] = useState<Map<string, { pps: number; bps: number }>>(new Map());
-    const [series, setSeries] = useState<Map<string, number[]>>(() => new Map());
-
-    const devicesRef = useRef(devices);
-    devicesRef.current = devices;
-    const pipelinesRef = useRef(pipelines);
-    pipelinesRef.current = pipelines;
-    const functionsRef = useRef(functions);
-    functionsRef.current = functions;
-
-    const devicesKey = useMemo(() => devices.join('|'), [devices]);
-    const pipelinesKey = useMemo(() => pipelines.join('|'), [pipelines]);
     const functionsKey = useMemo(() => functions.join('|'), [functions]);
 
-    useEffect(() => {
-        if (
-            !enabled ||
-            devicesRef.current.length === 0 ||
-            pipelinesRef.current.length === 0 ||
-            functionsRef.current.length === 0
-        ) {
-            prevRef.current = null;
-            setRates(new Map());
-            setSeries(new Map());
-            return;
+    const fetchCounters = useMemo(() => async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
+        const totals = new Map<string, { packets: bigint; bytes: bigint }>();
+        for (const f of functions) {
+            totals.set(f, { packets: BigInt(0), bytes: BigInt(0) });
         }
 
-        let cancelled = false;
-
-        const tick = async (): Promise<void> => {
-            const now = Date.now();
-            const currentFunctions = functionsRef.current;
-
-            const totals = new Map<string, { packets: bigint; bytes: bigint }>();
-            currentFunctions.forEach((f) => totals.set(f, { packets: BigInt(0), bytes: BigInt(0) }));
-
-            try {
-                const response = await API.counters.byTags({
-                    tags: [
-                        { key: 'function', value: '*' },
-                        { key: 'chain', value: '' },
-                    ],
-                    query: ['input', 'input_bytes'],
-                });
-                const grouped = groupCounterGroupsByTagsAndName(response.groups, ['function'], 0);
-                for (const functionName of currentFunctions) {
-                    totals.set(functionName, {
-                        packets: grouped.get(makeGroupedCounterKey([functionName], 'input'))?.value ?? BigInt(0),
-                        bytes: grouped.get(makeGroupedCounterKey([functionName], 'input_bytes'))?.value ?? BigInt(0),
-                    });
-                }
-            } catch {
-                // tolerate fetch failures.
-            }
-
-            if (cancelled) return;
-
-            const newRates = new Map<string, { pps: number; bps: number }>();
-            const prev = prevRef.current;
-            if (prev) {
-                const dt = (now - prev.timestamp) / 1000;
-                if (dt > 0) {
-                    totals.forEach((cur, name) => {
-                        const old = prev.values.get(name) ?? { packets: BigInt(0), bytes: BigInt(0) };
-                        const dp = Number(cur.packets - old.packets);
-                        const db = Number(cur.bytes - old.bytes);
-                        newRates.set(name, {
-                            pps: Math.max(0, dp / dt),
-                            bps: Math.max(0, db / dt),
-                        });
-                    });
-                }
-            }
-
-            const hadPrev = prevRef.current !== null;
-            prevRef.current = { timestamp: now, values: totals };
-
-            if (hadPrev) {
-                setSeries((prev) => {
-                    const next = new Map<string, number[]>();
-                    newRates.forEach((r, name) => {
-                        const old = prev.get(name) ?? [];
-                        const grown = [...old, r.pps];
-                        if (grown.length > DEFAULT_MAX_LEN) grown.shift();
-                        next.set(name, grown);
-                    });
-                    return next;
+        try {
+            const response = await API.counters.byTags({
+                tags: [
+                    { key: 'function', value: '*' },
+                    { key: 'chain', value: '' },
+                ],
+                query: ['input', 'input_bytes'],
+            });
+            const grouped = groupCounterGroupsByTagsAndName(response.groups, ['function'], 0);
+            for (const functionName of functions) {
+                totals.set(functionName, {
+                    packets: grouped.get(makeGroupedCounterKey([functionName], 'input'))?.value ?? BigInt(0),
+                    bytes: grouped.get(makeGroupedCounterKey([functionName], 'input_bytes'))?.value ?? BigInt(0),
                 });
             }
+        } catch {
+            // tolerate fetch failures.
+        }
 
-            setRates(newRates);
-        };
+        return totals;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [functionsKey]);
 
-        tick();
-        const id = setInterval(tick, DEFAULT_INTERVAL_MS);
-        return () => {
-            cancelled = true;
-            clearInterval(id);
-        };
-    }, [enabled, devicesKey, pipelinesKey, functionsKey]);
+    const { counters } = useInterpolatedCounters({
+        keys: functions,
+        fetchCounters,
+        enabled: enabled && functions.length > 0,
+        pollingInterval: DEFAULT_INTERVAL_MS,
+    });
+
+    const ppsSamples = useMemo(() => {
+        const m = new Map<string, number>();
+        counters.forEach((r, name) => m.set(name, r.pps));
+        return m;
+    }, [counters]);
+
+    const series = useRollingWindow(ppsSamples, DEFAULT_MAX_LEN, DEFAULT_INTERVAL_MS);
+
+    const rates = useMemo(() => {
+        const m = new Map<string, { pps: number; bps: number }>();
+        counters.forEach((r, name) => m.set(name, { pps: r.pps, bps: r.bps }));
+        return m;
+    }, [counters]);
 
     return { rates, series };
-};
-
-/**
- * Animate a numeric value by lagging one sample behind real time and linearly
- * interpolating from the previous committed sample toward the current one as
- * wall clock advances. Matches the "buffer 2 seconds, draw 0..1 with interp"
- * pattern: the returned value always sits inside [previous, current], never
- * extrapolating past current.
- *
- * The hook commits a new sample only when `value` changes — so the source
- * upstream MUST tick on each poll (which it does for pipeline/function rates).
- * `intervalMs` is the expected cadence between source updates; it sets the
- * animation duration of the trailing segment.
- */
-export const useLaggedValue = (value: number, intervalMs: number = 1500): number => {
-    const prevRef = useRef<{ value: number; ts: number }>({ value, ts: performance.now() });
-    const curRef = useRef<{ value: number; ts: number }>({ value, ts: performance.now() });
-    const lastInputRef = useRef<number>(value);
-    const [animated, setAnimated] = useState<number>(value);
-
-    if (lastInputRef.current !== value) {
-        prevRef.current = curRef.current;
-        curRef.current = { value, ts: performance.now() };
-        lastInputRef.current = value;
-    }
-
-    useEffect(() => {
-        let raf = 0;
-        const tick = (): void => {
-            const now = performance.now();
-            const dt = now - curRef.current.ts;
-            const t = Math.max(0, Math.min(1, dt / intervalMs));
-            const next = prevRef.current.value + (curRef.current.value - prevRef.current.value) * t;
-            setAnimated(next);
-            raf = requestAnimationFrame(tick);
-        };
-        raf = requestAnimationFrame(tick);
-        return () => cancelAnimationFrame(raf);
-    }, [intervalMs]);
-
-    return animated;
-};
-
-/**
- * Per-key lag-interpolated rolling series: takes a Map<string, number> of
- * latest sample values (one per key) and returns a Map<string, number[]> where
- * each series is built with lag-interpolation.
- */
-export const useLaggedSeriesMap = (
-    values: Map<string, number>,
-    maxLen: number = DEFAULT_MAX_LEN,
-    intervalMs: number = DEFAULT_INTERVAL_MS,
-): Map<string, number[]> => {
-    const samplesMapRef = useRef<Map<string, number[]>>(new Map());
-    const prevMapRef = useRef<Map<string, { value: number; ts: number }>>(new Map());
-    const curMapRef = useRef<Map<string, { value: number; ts: number }>>(new Map());
-    const lastInputsRef = useRef<Map<string, number>>(new Map());
-    const [, force] = useState(0);
-
-    values.forEach((v, k) => {
-        const last = lastInputsRef.current.get(k);
-        if (last !== v) {
-            const now = performance.now();
-            const cur = curMapRef.current.get(k);
-            const samples = samplesMapRef.current.get(k) ?? [];
-            if (cur !== undefined) {
-                const next = [...samples, cur.value];
-                if (next.length > Math.max(1, maxLen - 1)) {
-                    next.shift();
-                }
-                samplesMapRef.current.set(k, next);
-            } else if (samples.length === 0 && v === 0) {
-                lastInputsRef.current.set(k, v);
-                return;
-            }
-            prevMapRef.current.set(k, cur ?? { value: v, ts: now });
-            curMapRef.current.set(k, { value: v, ts: now });
-            lastInputsRef.current.set(k, v);
-        }
-    });
-    [...samplesMapRef.current.keys()].forEach((k) => {
-        if (!values.has(k)) {
-            samplesMapRef.current.delete(k);
-            prevMapRef.current.delete(k);
-            curMapRef.current.delete(k);
-            lastInputsRef.current.delete(k);
-        }
-    });
-
-    useEffect(() => {
-        let raf = 0;
-        const tick = (): void => {
-            force((n) => (n + 1) | 0);
-            raf = requestAnimationFrame(tick);
-        };
-        raf = requestAnimationFrame(tick);
-        return () => cancelAnimationFrame(raf);
-    }, []);
-
-    const out = new Map<string, number[]>();
-    const now = performance.now();
-    values.forEach((_, k) => {
-        const cur = curMapRef.current.get(k);
-        const prev = prevMapRef.current.get(k);
-        const samples = samplesMapRef.current.get(k) ?? [];
-        if (cur === undefined) {
-            if (samples.length > 0) out.set(k, samples);
-            return;
-        }
-        const dt = now - cur.ts;
-        const t = Math.max(0, Math.min(1, dt / intervalMs));
-        const prevVal = prev?.value ?? cur.value;
-        const interp = prevVal + (cur.value - prevVal) * t;
-        out.set(k, [...samples, interp]);
-    });
-    return out;
 };

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -11,3 +11,4 @@ export * from './clipboard';
 export * from './counterGroups';
 export * from './validation';
 export * from './ranges';
+export * from './interpolation';

--- a/web/src/utils/interpolation.test.ts
+++ b/web/src/utils/interpolation.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { lerp, clampProgress, computeRate } from './interpolation';
+
+describe('lerp', () => {
+    it('returns a at t=0', () => {
+        expect(lerp(0, 100, 0)).toBe(0);
+    });
+
+    it('returns b at t=1', () => {
+        expect(lerp(0, 100, 1)).toBe(100);
+    });
+
+    it('returns midpoint at t=0.5', () => {
+        expect(lerp(0, 100, 0.5)).toBe(50);
+    });
+
+    it('does not clamp: allows t outside [0,1]', () => {
+        expect(lerp(0, 100, 1.5)).toBe(150);
+        expect(lerp(0, 100, -0.5)).toBe(-50);
+    });
+});
+
+describe('clampProgress', () => {
+    it('returns 0 at sample time', () => {
+        expect(clampProgress(1000, 1000, 500)).toBe(0);
+    });
+
+    it('returns 0.5 halfway through interval', () => {
+        expect(clampProgress(1250, 1000, 500)).toBe(0.5);
+    });
+
+    it('returns 1 at exactly one interval', () => {
+        expect(clampProgress(1500, 1000, 500)).toBe(1);
+    });
+
+    it('clamps to 1 past the interval', () => {
+        expect(clampProgress(2000, 1000, 500)).toBe(1);
+    });
+
+    it('clamps to 0 before the sample', () => {
+        expect(clampProgress(900, 1000, 500)).toBe(0);
+    });
+
+    it('returns 1 when intervalMs is 0', () => {
+        expect(clampProgress(1000, 1000, 0)).toBe(1);
+    });
+});
+
+describe('computeRate', () => {
+    it('computes pps and bps from positive deltas', () => {
+        const prev = { packets: BigInt(0), bytes: BigInt(0) };
+        const cur = { packets: BigInt(1000), bytes: BigInt(125000) };
+        const result = computeRate(prev, cur, 1);
+        expect(result.pps).toBe(1000);
+        expect(result.bps).toBe(125000);
+    });
+
+    it('divides by dtSeconds correctly', () => {
+        const prev = { packets: BigInt(0), bytes: BigInt(0) };
+        const cur = { packets: BigInt(3000), bytes: BigInt(6000) };
+        const result = computeRate(prev, cur, 3);
+        expect(result.pps).toBe(1000);
+        expect(result.bps).toBe(2000);
+    });
+
+    it('returns 0 pps on negative packet delta (counter reset)', () => {
+        const prev = { packets: BigInt(5000), bytes: BigInt(0) };
+        const cur = { packets: BigInt(100), bytes: BigInt(1000) };
+        const result = computeRate(prev, cur, 1);
+        expect(result.pps).toBe(0);
+        expect(result.bps).toBeGreaterThan(0);
+    });
+
+    it('returns 0 bps on negative byte delta (counter reset)', () => {
+        const prev = { packets: BigInt(0), bytes: BigInt(5000) };
+        const cur = { packets: BigInt(100), bytes: BigInt(0) };
+        const result = computeRate(prev, cur, 1);
+        expect(result.pps).toBeGreaterThan(0);
+        expect(result.bps).toBe(0);
+    });
+
+    it('returns zeros when dtSeconds is 0', () => {
+        const prev = { packets: BigInt(0), bytes: BigInt(0) };
+        const cur = { packets: BigInt(1000), bytes: BigInt(1000) };
+        const result = computeRate(prev, cur, 0);
+        expect(result.pps).toBe(0);
+        expect(result.bps).toBe(0);
+    });
+
+    it('returns zeros when dtSeconds is negative', () => {
+        const prev = { packets: BigInt(0), bytes: BigInt(0) };
+        const cur = { packets: BigInt(1000), bytes: BigInt(1000) };
+        const result = computeRate(prev, cur, -1);
+        expect(result.pps).toBe(0);
+        expect(result.bps).toBe(0);
+    });
+});

--- a/web/src/utils/interpolation.ts
+++ b/web/src/utils/interpolation.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure interpolation math helpers — no React dependency.
+ */
+
+/** Linear interpolation between a and b by factor t (not clamped). */
+export const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+/**
+ * Compute normalised animation progress in [0, 1].
+ *
+ * Returns 0 when wall clock equals sampleTs and 1 when it reaches
+ * sampleTs + intervalMs. Clamps strictly to [0, 1] so the displayed value
+ * never overshoots the current sample.
+ */
+export const clampProgress = (now: number, sampleTs: number, intervalMs: number): number => {
+    if (intervalMs <= 0) return 1;
+    const elapsed = now - sampleTs;
+    return Math.max(0, Math.min(1, elapsed / intervalMs));
+};
+
+/**
+ * Compute per-second packet and byte rates from two cumulative counter
+ * snapshots.
+ *
+ * A negative delta (counter reset) is mapped to 0 rather than producing a
+ * large negative spike.
+ */
+export const computeRate = (
+    prev: { packets: bigint; bytes: bigint },
+    cur: { packets: bigint; bytes: bigint },
+    dtSeconds: number,
+): { pps: number; bps: number } => {
+    if (dtSeconds <= 0) return { pps: 0, bps: 0 };
+    const dp = Number(cur.packets - prev.packets);
+    const db = Number(cur.bytes - prev.bytes);
+    return {
+        pps: dp >= 0 ? dp / dtSeconds : 0,
+        bps: db >= 0 ? db / dtSeconds : 0,
+    };
+};


### PR DESCRIPTION
- Consolidate the duplicated counter-interpolation logic into a single shared engine: pure interpolation math plus two generic hooks for smooth value animation and rolling sparkline history.
- Migrate every counter surface — devices, forward, acl, functions, pipelines, and the inspect and dashboard views — onto the shared helpers, removing a second parallel interpolation implementation and roughly 400 lines of duplication.
- Standardise on requestAnimationFrame lag-interpolation as the single smoothing algorithm. Animated values now trail one poll sample and no longer overshoot it, a small intentional change to the on-screen numbers.
- Add unit coverage for the interpolation math.