### PR TITLE
refactor(web): dedup shared filter api types

### DIFF
--- a/web/src/api/acl.ts
+++ b/web/src/api/acl.ts
@@ -3,10 +3,8 @@ import { createService, type CallOptions } from './client';
 // Types matching aclpb/acl.proto and filterpb/filter.proto exactly.
 // No Action.counter, no keep_state, no MapConfig, no SyncConfig, no DUMP kind.
 
-export interface IPNet {
-    addr?: string | Uint8Array | number[];
-    mask?: string | Uint8Array | number[];
-}
+import type { IPNet, VlanRange, Device, ListConfigsResponse } from './shared';
+export type { IPNet, VlanRange, Device, ListConfigsResponse };
 
 export interface PortRange {
     from?: number;
@@ -16,15 +14,6 @@ export interface PortRange {
 export interface ProtoRange {
     from?: number;
     to?: number;
-}
-
-export interface VlanRange {
-    from?: number;
-    to?: number;
-}
-
-export interface Device {
-    name?: string;
 }
 
 export enum ActionKind {
@@ -60,10 +49,6 @@ export interface Rule {
     proto_ranges?: ProtoRange[];
     src_port_ranges?: PortRange[];
     dst_port_ranges?: PortRange[];
-}
-
-export interface ListConfigsResponse {
-    configs?: string[];
 }
 
 export interface ShowConfigRequest {

--- a/web/src/api/forward.ts
+++ b/web/src/api/forward.ts
@@ -2,19 +2,8 @@ import { createService, type CallOptions } from './client';
 
 // Forward types based on forwardpb/forward.proto
 
-export interface Device {
-    name?: string;
-}
-
-export interface VlanRange {
-    from?: number;
-    to?: number;
-}
-
-export interface IPNet {
-    addr?: string | Uint8Array | number[]; // Base64 encoded bytes or raw bytes
-    mask?: string | Uint8Array | number[]; // Base64 encoded bytes or raw bytes
-}
+import type { Device, VlanRange, IPNet, ListConfigsResponse } from './shared';
+export type { Device, VlanRange, IPNet, ListConfigsResponse };
 
 export enum ForwardMode {
     NONE = 0,
@@ -45,10 +34,6 @@ export interface Rule {
 // Request/Response types
 
 export interface ListConfigsRequest { }
-
-export interface ListConfigsResponse {
-    configs?: string[];
-}
 
 export interface ShowConfigRequest {
     name?: string;

--- a/web/src/api/fwstate.ts
+++ b/web/src/api/fwstate.ts
@@ -29,9 +29,8 @@ export interface ShowConfigResponse {
     sync_config?: SyncConfig;
 }
 
-export interface ListConfigsResponse {
-    configs?: string[];
-}
+import type { ListConfigsResponse } from './shared';
+export type { ListConfigsResponse };
 
 export interface LinkFWStateRequest {
     fwstate_name?: string;

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -31,9 +31,8 @@ export interface Route {
     is_best?: boolean;
 }
 
-export interface ListConfigsResponse {
-    configs?: string[];
-}
+import type { ListConfigsResponse } from './shared';
+export type { ListConfigsResponse };
 
 export interface ShowRoutesRequest {
     name?: string;

--- a/web/src/api/shared.ts
+++ b/web/src/api/shared.ts
@@ -1,0 +1,19 @@
+// Shared filter/config wire types used by multiple module api files.
+
+export interface Device {
+    name?: string;
+}
+
+export interface VlanRange {
+    from?: number;
+    to?: number;
+}
+
+export interface IPNet {
+    addr?: string | Uint8Array | number[]; // Base64 encoded bytes or raw bytes
+    mask?: string | Uint8Array | number[]; // Base64 encoded bytes or raw bytes
+}
+
+export interface ListConfigsResponse {
+    configs?: string[];
+}


### PR DESCRIPTION
Extract the `Device`, `VlanRange`, `IPNet` and `ListConfigsResponse` wire-type interfaces — previously duplicated byte-for-byte across the forward, acl, fwstate and routes api modules — into a single `web/src/api/shared.ts`, re-exported via type-only re-exports so existing call sites keep resolving.

- Type-only change: zero runtime/JS-bundle delta.
- Also resolves one pre-existing `ListConfigsResponse` wildcard-re-export ambiguity in `api/index.ts`.