### PR TITLE
refactor(web): dedup devices scrollbar block

### DIFF
--- a/web/src/pages/builtin/devices/devices.scss
+++ b/web/src/pages/builtin/devices/devices.scss
@@ -1,5 +1,21 @@
 @use '../../../styles/variables' as *;
 
+@mixin dv-thin-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--border-strong) transparent;
+
+    &::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: var(--border-strong);
+        border-radius: 4px;
+        border: 2px solid var(--bg);
+        background-clip: content-box;
+    }
+}
+
 // Design tokens scoped to this page only — do NOT bleed to other pages.
 .devices-page-v2 {
     --bg: #15110D;
@@ -245,19 +261,7 @@
         flex: 1;
         overflow-y: auto;
         min-height: 0;
-        scrollbar-width: thin;
-        scrollbar-color: var(--border-strong) transparent;
-
-        &::-webkit-scrollbar {
-            width: 8px;
-        }
-
-        &::-webkit-scrollbar-thumb {
-            background: var(--border-strong);
-            border-radius: 4px;
-            border: 2px solid var(--bg);
-            background-clip: content-box;
-        }
+        @include dv-thin-scrollbar;
     }
 
     .dv-grp-hd {
@@ -604,19 +608,7 @@
         overflow-y: auto;
         padding: 18px 24px 32px;
         min-height: 0;
-        scrollbar-width: thin;
-        scrollbar-color: var(--border-strong) transparent;
-
-        &::-webkit-scrollbar {
-            width: 8px;
-        }
-
-        &::-webkit-scrollbar-thumb {
-            background: var(--border-strong);
-            border-radius: 4px;
-            border: 2px solid var(--bg);
-            background-clip: content-box;
-        }
+        @include dv-thin-scrollbar;
     }
 
     // Metric grid


### PR DESCRIPTION
Extract the custom-scrollbar declaration cluster — duplicated verbatim in `.dv-list-scroll` and `.dv-detail-scroll` — into a file-local `dv-thin-scrollbar` mixin.

- Pure SCSS dedup: the emitted CSS is byte-for-byte identical (verified by comparing compiled CSS hashes across all chunks).