### PR TITLE
refactor(web): share fn/pl lane-page structure

### DIFF
--- a/web/src/pages/builtin/_shared/lane-editor/_palette.scss
+++ b/web/src/pages/builtin/_shared/lane-editor/_palette.scss
@@ -361,3 +361,111 @@
         gap: 6px;
     }
 }
+
+// Mixin that emits the page-shell and card-shell selectors shared between the
+// functions and pipelines lane-editor pages. Covers the page container, the
+// top-level card (collapsed state), and the card body.
+// $p    — prefix string, e.g. 'fn' or 'pl'.
+// $card — card class suffix, e.g. 'function-card' or 'pipeline-card'.
+@mixin lane-page-shell($p, $card) {
+    .#{$p}-page {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        padding: 20px;
+        overflow-y: auto;
+        flex: 1;
+        min-height: 0;
+        background: var(--#{$p}-page-bg);
+    }
+
+    .#{$p}-#{$card} {
+        background: var(--#{$p}-panel);
+        border: 1px solid var(--#{$p}-line-2);
+        border-radius: var(--#{$p}-r-lg);
+        overflow: hidden;
+
+        &--collapsed {
+            .#{$p}-#{$card}__body {
+                display: none;
+            }
+        }
+    }
+
+    .#{$p}-#{$card}__body {
+        display: flex;
+        flex-direction: column;
+    }
+}
+
+// Mixin that emits the sub-header row selectors shared between the functions
+// and pipelines lane-editor pages. Covers sub-header container, item, and
+// separator.
+// $p    — prefix string, e.g. 'fn' or 'pl'.
+// $card — card class suffix, e.g. 'function-card' or 'pipeline-card'.
+@mixin lane-page-subheader($p, $card) {
+    .#{$p}-#{$card}__sub-header {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+        padding: 10px 16px;
+        border-bottom: 1px solid var(--#{$p}-line);
+        background: var(--#{$p}-bg-2);
+        font-family: var(--#{$p}-font-mono);
+        font-size: 12px;
+        color: var(--#{$p}-text-3);
+    }
+
+    .#{$p}-#{$card}__sub-header-item {
+        color: var(--#{$p}-text-3);
+
+        &--bold {
+            color: var(--#{$p}-text-2);
+            font-weight: 600;
+        }
+    }
+
+    .#{$p}-#{$card}__sub-header-sep {
+        width: 1px;
+        height: 12px;
+        background: var(--#{$p}-line-2);
+        flex-shrink: 0;
+    }
+}
+
+// Mixin that emits the lane-track and lane-track__empty selectors shared
+// between the functions and pipelines lane-editor pages.
+// $p      — prefix string, e.g. 'fn' or 'pl'.
+// $pad-v  — vertical padding for the track row (default 0).
+@mixin lane-track($p, $pad-v: 0) {
+    .#{$p}-lane-track {
+        display: flex;
+        flex-wrap: nowrap;
+        align-items: center;
+        column-gap: 0;
+        padding: $pad-v 16px;
+        flex: 1;
+        min-width: 0;
+        overflow-x: auto;
+        overflow-y: hidden;
+        transition: box-shadow 0.15s;
+        // Subtle column guide lines.
+        background-image:
+            linear-gradient(to right, transparent 0, transparent calc(100% - 1px), var(--#{$p}-line) 100%),
+            repeating-linear-gradient(to right, transparent 0 22px, var(--#{$p}-line) 22px 23px);
+
+        &--reject {
+            box-shadow: inset 0 0 0 1px var(--#{$p}-danger);
+        }
+    }
+
+    .#{$p}-lane-track__empty {
+        background: var(--#{$p}-bg-3);
+        padding: 8px 16px;
+        border: 1px dashed var(--#{$p}-line-2);
+        border-radius: var(--#{$p}-r-md);
+        color: var(--#{$p}-text-3);
+        font-size: 12px;
+        font-family: var(--#{$p}-font-mono);
+    }
+}

--- a/web/src/pages/builtin/functions/FunctionsPage.scss
+++ b/web/src/pages/builtin/functions/FunctionsPage.scss
@@ -6,38 +6,9 @@
 // Design tokens — warm dark-brown palette scoped to this page.
 @include palette.lane-page-palette('fn', 'function-card');
 
-// ─── Page container ───────────────────────────────────────────────────────────
+// ─── Page container + Function card ──────────────────────────────────────────
 
-.fn-page {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding: 20px;
-    overflow-y: auto;
-    flex: 1;
-    min-height: 0;
-    background: var(--fn-page-bg);
-}
-
-// ─── Function card ────────────────────────────────────────────────────────────
-
-.fn-function-card {
-    background: var(--fn-panel);
-    border: 1px solid var(--fn-line-2);
-    border-radius: var(--fn-r-lg);
-    overflow: hidden;
-
-    &--collapsed {
-        .fn-function-card__body {
-            display: none;
-        }
-    }
-}
-
-.fn-function-card__body {
-    display: flex;
-    flex-direction: column;
-}
+@include palette.lane-page-shell('fn', 'function-card');
 
 .fn-function-card__errors {
     padding: 8px 16px;
@@ -52,33 +23,7 @@
     padding: 2px 0;
 }
 
-.fn-function-card__sub-header {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    padding: 10px 16px;
-    border-bottom: 1px solid var(--fn-line);
-    background: var(--fn-bg-2);
-    font-family: var(--fn-font-mono);
-    font-size: 12px;
-    color: var(--fn-text-3);
-}
-
-.fn-function-card__sub-header-item {
-    color: var(--fn-text-3);
-
-    &--bold {
-        color: var(--fn-text-2);
-        font-weight: 600;
-    }
-}
-
-.fn-function-card__sub-header-sep {
-    width: 1px;
-    height: 12px;
-    background: var(--fn-line-2);
-    flex-shrink: 0;
-}
+@include palette.lane-page-subheader('fn', 'function-card');
 
 .fn-function-card__sub-header-hint {
     color: var(--fn-text-3);
@@ -190,36 +135,7 @@
 
 // ─── Lane track ───────────────────────────────────────────────────────────────
 
-.fn-lane-track {
-    display: flex;
-    flex-wrap: nowrap;
-    align-items: center;
-    column-gap: 0;
-    padding: 0 16px;
-    flex: 1;
-    min-width: 0;
-    overflow-x: auto;
-    overflow-y: hidden;
-    transition: box-shadow 0.15s;
-    // Subtle column guide lines.
-    background-image:
-        linear-gradient(to right, transparent 0, transparent calc(100% - 1px), var(--fn-line) 100%),
-        repeating-linear-gradient(to right, transparent 0 22px, var(--fn-line) 22px 23px);
-
-    &--reject {
-        box-shadow: inset 0 0 0 1px var(--fn-danger);
-    }
-}
-
-.fn-lane-track__empty {
-    background: var(--fn-bg-3);
-    padding: 8px 16px;
-    border: 1px dashed var(--fn-line-2);
-    border-radius: var(--fn-r-md);
-    color: var(--fn-text-3);
-    font-size: 12px;
-    font-family: var(--fn-font-mono);
-}
+@include palette.lane-track('fn');
 
 @include palette.lane-card('fn', 'module-card');
 

--- a/web/src/pages/builtin/pipelines/PipelinesPage.scss
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.scss
@@ -6,66 +6,11 @@
 // Design tokens — warm dark-brown palette scoped to this page.
 @include palette.lane-page-palette('pl', 'pipeline-card');
 
-// ─── Page container ───────────────────────────────────────────────────────────
+// ─── Page container + Pipeline card ──────────────────────────────────────────
 
-.pl-page {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding: 20px;
-    overflow-y: auto;
-    flex: 1;
-    min-height: 0;
-    background: var(--pl-page-bg);
-}
+@include palette.lane-page-shell('pl', 'pipeline-card');
 
-// ─── Pipeline card ────────────────────────────────────────────────────────────
-
-.pl-pipeline-card {
-    background: var(--pl-panel);
-    border: 1px solid var(--pl-line-2);
-    border-radius: var(--pl-r-lg);
-    overflow: hidden;
-
-    &--collapsed {
-        .pl-pipeline-card__body {
-            display: none;
-        }
-    }
-}
-
-.pl-pipeline-card__body {
-    display: flex;
-    flex-direction: column;
-}
-
-.pl-pipeline-card__sub-header {
-    display: flex;
-    align-items: center;
-    gap: 14px;
-    padding: 10px 16px;
-    border-bottom: 1px solid var(--pl-line);
-    background: var(--pl-bg-2);
-    font-family: var(--pl-font-mono);
-    font-size: 12px;
-    color: var(--pl-text-3);
-}
-
-.pl-pipeline-card__sub-header-item {
-    color: var(--pl-text-3);
-
-    &--bold {
-        color: var(--pl-text-2);
-        font-weight: 600;
-    }
-}
-
-.pl-pipeline-card__sub-header-sep {
-    width: 1px;
-    height: 12px;
-    background: var(--pl-line-2);
-    flex-shrink: 0;
-}
+@include palette.lane-page-subheader('pl', 'pipeline-card');
 
 // ─── Pipeline card header ─────────────────────────────────────────────────────
 
@@ -75,35 +20,7 @@
 
 // ─── Lane track ───────────────────────────────────────────────────────────────
 
-.pl-lane-track {
-    display: flex;
-    flex-wrap: nowrap;
-    align-items: center;
-    column-gap: 0;
-    padding: 12px 16px;
-    flex: 1;
-    min-width: 0;
-    overflow-x: auto;
-    overflow-y: hidden;
-    transition: box-shadow 0.15s;
-    background-image:
-        linear-gradient(to right, transparent 0, transparent calc(100% - 1px), var(--pl-line) 100%),
-        repeating-linear-gradient(to right, transparent 0 22px, var(--pl-line) 22px 23px);
-
-    &--reject {
-        box-shadow: inset 0 0 0 1px var(--pl-danger);
-    }
-}
-
-.pl-lane-track__empty {
-    background: var(--pl-bg-3);
-    padding: 8px 16px;
-    border: 1px dashed var(--pl-line-2);
-    border-radius: var(--pl-r-md);
-    color: var(--pl-text-3);
-    font-size: 12px;
-    font-family: var(--pl-font-mono);
-}
+@include palette.lane-track('pl', 12px);
 
 @include palette.lane-card('pl', 'ref-card');
 


### PR DESCRIPTION
Extract the structural selector blocks duplicated between `FunctionsPage.scss` and `PipelinesPage.scss` — page container, card shell, card body, sub-header cluster, and lane track — into three order-preserving mixins (`lane-page-shell`, `lane-page-subheader`, `lane-track`) in the shared `lane-editor/_palette.scss` partial.

- The lane track's only divergence (fn 0 vs pl 12px vertical padding) is threaded through a `$pad-v` parameter.
- Pure SCSS dedup: the emitted CSS is byte-for-byte identical (verified by comparing compiled CSS hashes across all chunks).