### PR TITLE
refactor(web): share iv section-label typography

### DIFF
--- a/web/src/pages/builtin/dashboard/dashboard.scss
+++ b/web/src/pages/builtin/dashboard/dashboard.scss
@@ -287,9 +287,7 @@
     .dash-section-header {
         margin-top: 12px;
         margin-bottom: 6px;
-        color: var(--iv-mute);
-        font-size: 10px;
-        letter-spacing: 1.6px;
+        @include iv-section-label;
         display: flex;
         align-items: baseline;
         gap: 8px;
@@ -407,9 +405,7 @@
     }
 
     &__label {
-        color: var(--iv-mute);
-        font-size: 10px;
-        letter-spacing: 1.6px;
+        @include iv-section-label;
         flex-shrink: 0;
     }
 
@@ -506,9 +502,7 @@
         justify-content: space-between;
         align-items: baseline;
         margin-bottom: 10px;
-        color: var(--iv-mute);
-        font-size: 10px;
-        letter-spacing: 1.6px;
+        @include iv-section-label;
     }
 
     &__grid {
@@ -602,9 +596,7 @@
 }
 
 .dash-system__label {
-    color: var(--iv-mute);
-    font-size: 10px;
-    letter-spacing: 1.6px;
+    @include iv-section-label;
     flex-shrink: 0;
 }
 

--- a/web/src/pages/builtin/inspect/SystemAgents.scss
+++ b/web/src/pages/builtin/inspect/SystemAgents.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/iv-tokens' as *;
+
 .iv-system-agents {
     border: 1px solid var(--iv-border-strong);
     background: var(--iv-surface);
@@ -46,9 +48,7 @@
 }
 
 .iv-system-agents__title {
-    color: var(--iv-mute);
-    font-size: 10px;
-    letter-spacing: 1.6px;
+    @include iv-section-label;
 }
 
 .iv-system-agents__dot {

--- a/web/src/pages/builtin/inspect/inspect.scss
+++ b/web/src/pages/builtin/inspect/inspect.scss
@@ -58,9 +58,7 @@
     }
 
     .iv-label {
-        color: var(--iv-mute);
-        font-size: 10px;
-        letter-spacing: 1.6px;
+        @include iv-section-label;
 
         .iv-label__count {
             color: var(--iv-text-dim);
@@ -228,9 +226,7 @@
         padding-left: 14px;
 
         .iv-side-kpi__label {
-            color: var(--iv-mute);
-            font-size: 10px;
-            letter-spacing: 1.6px;
+            @include iv-section-label;
         }
 
         .iv-side-kpi__primary {

--- a/web/src/styles/_iv-tokens.scss
+++ b/web/src/styles/_iv-tokens.scss
@@ -38,3 +38,9 @@
     --iv-mute:           #9C8B74;
     --iv-dim:            #9C8B74;
 }
+
+@mixin iv-section-label {
+    color: var(--iv-mute);
+    font-size: 10px;
+    letter-spacing: 1.6px;
+}


### PR DESCRIPTION
Extract the repeated section-label typography cluster (`color: var(--iv-mute); font-size: 10px; letter-spacing: 1.6px;`) into an `iv-section-label` mixin in the shared `_iv-tokens.scss` partial, applied across 7 selectors in the inspect, dashboard and system-agents styles.

- Pure SCSS dedup: the emitted CSS is byte-for-byte identical (verified by comparing compiled CSS hashes across all chunks).
- The one selector with a different declaration order (`.dash-kpi-counts__label`) is intentionally left inline.