### PR TITLE
refactor(web): share iv thin-scrollbar

### DIFF
--- a/web/src/pages/builtin/dashboard/dashboard.scss
+++ b/web/src/pages/builtin/dashboard/dashboard.scss
@@ -37,25 +37,7 @@
     overflow-y: auto;
 
     .dash-scroll {
-        scrollbar-width: thin;
-        scrollbar-color: var(--iv-border-strong) transparent;
-
-        &::-webkit-scrollbar {
-            width: 6px;
-            height: 6px;
-        }
-
-        &::-webkit-scrollbar-track {
-            background: transparent;
-        }
-
-        &::-webkit-scrollbar-thumb {
-            background: var(--iv-border-strong);
-        }
-
-        &::-webkit-scrollbar-thumb:hover {
-            background: var(--iv-accent-line);
-        }
+        @include iv-thin-scrollbar;
     }
 
     // ── Scene Container ───────────────────────────────────────────────

--- a/web/src/pages/builtin/inspect/inspect.scss
+++ b/web/src/pages/builtin/inspect/inspect.scss
@@ -19,26 +19,7 @@
     min-height: 0;
 
     .iv-scroll {
-        scrollbar-width: thin;
-        scrollbar-color: var(--iv-border-strong) transparent;
-
-        &::-webkit-scrollbar {
-            width: 6px;
-            height: 6px;
-        }
-
-        &::-webkit-scrollbar-track {
-            background: transparent;
-        }
-
-        &::-webkit-scrollbar-thumb {
-            background: var(--iv-border-strong);
-            border-radius: 3px;
-        }
-
-        &::-webkit-scrollbar-thumb:hover {
-            background: var(--iv-accent-line);
-        }
+        @include iv-thin-scrollbar(3px);
     }
 
     .iv-instance {

--- a/web/src/styles/_iv-tokens.scss
+++ b/web/src/styles/_iv-tokens.scss
@@ -44,3 +44,28 @@
     font-size: 10px;
     letter-spacing: 1.6px;
 }
+
+@mixin iv-thin-scrollbar($thumb-radius: null) {
+    scrollbar-width: thin;
+    scrollbar-color: var(--iv-border-strong) transparent;
+
+    &::-webkit-scrollbar {
+        width: 6px;
+        height: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+        background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+        background: var(--iv-border-strong);
+        @if $thumb-radius != null {
+            border-radius: $thumb-radius;
+        }
+    }
+
+    &::-webkit-scrollbar-thumb:hover {
+        background: var(--iv-accent-line);
+    }
+}


### PR DESCRIPTION
Extract the custom thin-scrollbar rule shared by `.iv-scroll` and `.dash-scroll` into an `iv-thin-scrollbar` mixin in the shared `_iv-tokens.scss` partial.

- The sole divergence (thumb `border-radius: 3px` on inspect, none on dashboard) is threaded through a `$thumb-radius` parameter.
- Pure SCSS dedup: the emitted CSS is byte-for-byte identical (verified by comparing compiled CSS hashes across all chunks).