### PR TITLE
refactor(web): share draft row-status computation

### DIFF
--- a/web/src/pages/_shared/draft/index.ts
+++ b/web/src/pages/_shared/draft/index.ts
@@ -14,3 +14,5 @@ export type { UseDraftPageHandlersResult } from './useDraftPageHandlers';
 export { rowHasError, countInvalidRows } from './validation';
 export { dumpYamlDoc, parseYamlList } from './yaml';
 export { DRAWER_TRANSITION_MS } from './constants';
+export { computeRowStatuses } from './rowStatus';
+export type { RowStatusResult } from './rowStatus';

--- a/web/src/pages/_shared/draft/rowStatus.ts
+++ b/web/src/pages/_shared/draft/rowStatus.ts
@@ -1,0 +1,34 @@
+import type { RowStatus } from '../../../components';
+
+/** Per-row draft status plus the removed-rows list, against a server snapshot. */
+export interface RowStatusResult<T> {
+    statusById: Map<string, RowStatus>;
+    removedRows: T[];
+}
+
+/**
+ * Classify each draft row against the server snapshot.
+ *
+ * A row present locally but not on the server is 'added'; one present in both
+ * is 'same' or 'changed' per the caller's equality check; a server row absent
+ * locally is collected into removedRows.
+ */
+export const computeRowStatuses = <T extends { id: string }>(
+    rawRows: T[],
+    rawServerRows: T[],
+    isEqual: (server: T, local: T) => boolean,
+): RowStatusResult<T> => {
+    const statusById = new Map<string, RowStatus>();
+    const serverById = new Map(rawServerRows.map((r) => [r.id, r]));
+    for (const r of rawRows) {
+        const s = serverById.get(r.id);
+        if (!s) {
+            statusById.set(r.id, 'added');
+        } else {
+            statusById.set(r.id, isEqual(s, r) ? 'same' : 'changed');
+        }
+    }
+    const localIds = new Set(rawRows.map((r) => r.id));
+    const removedRows = rawServerRows.filter((r) => !localIds.has(r.id));
+    return { statusById, removedRows };
+};

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -14,7 +14,7 @@ import PrefixYamlIO from './PrefixYamlIO';
 import { PrefixSaveDiffModal } from './PrefixSaveDiffModal';
 import {
     AddConfigModal,
-    useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers,
+    useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers, computeRowStatuses,
 } from '../../_shared/draft';
 import { DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { useTabCycle } from '../../_shared/useTabCycle';
@@ -99,21 +99,10 @@ const DecapPage: React.FC = () => {
         return rawRows.filter((r) => r.prefix.toLowerCase().includes(q));
     }, [rawRows, search]);
 
-    const statusById = useMemo((): Map<string, import('./types').PrefixRowStatus> => {
-        const m = new Map<string, import('./types').PrefixRowStatus>();
-        const serverById = new Map(rawServerRows.map((r) => [r.id, r]));
-        for (const r of rawRows) {
-            const s = serverById.get(r.id);
-            if (!s) m.set(r.id, 'added');
-            else m.set(r.id, s.prefix === r.prefix ? 'same' : 'changed');
-        }
-        return m;
-    }, [rawRows, rawServerRows]);
-
-    const removedRows = useMemo((): PrefixRowItem[] => {
-        const localIds = new Set(rawRows.map((r) => r.id));
-        return rawServerRows.filter((r) => !localIds.has(r.id));
-    }, [rawRows, rawServerRows]);
+    const { statusById, removedRows } = useMemo(
+        () => computeRowStatuses(rawRows, rawServerRows, (s, r) => s.prefix === r.prefix),
+        [rawRows, rawServerRows],
+    );
 
     const editingIndex = editingRowId ? rawRows.findIndex((r) => r.id === editingRowId) : -1;
     const editingRow = editingIndex >= 0 ? rawRows[editingIndex] : null;

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -13,7 +13,7 @@ import type { FIBDrawerHandle } from './FIBDrawer';
 import FIBYamlIO from './FIBYamlIO';
 import { FIBSaveDiffModal } from './FIBSaveDiffModal';
 import {
-    AddConfigModal, isValidCIDR, useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers,
+    AddConfigModal, isValidCIDR, useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers, computeRowStatuses,
 } from '../../_shared/draft';
 import { DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { usePalette } from '../../_shared/command-palette';
@@ -95,21 +95,13 @@ const RoutePage: React.FC = () => {
         );
     }, [rawRows, search]);
 
-    const statusById = useMemo((): Map<string, import('./types').FIBRowStatus> => {
-        const m = new Map<string, import('./types').FIBRowStatus>();
-        const serverById = new Map(rawServerRows.map((r) => [r.id, r]));
-        for (const r of rawRows) {
-            const s = serverById.get(r.id);
-            if (!s) m.set(r.id, 'added');
-            else m.set(r.id, (s.prefix === r.prefix && s.dst_mac === r.dst_mac && s.src_mac === r.src_mac && s.device === r.device) ? 'same' : 'changed');
-        }
-        return m;
-    }, [rawRows, rawServerRows]);
-
-    const removedRows = useMemo((): FIBRowItem[] => {
-        const localIds = new Set(rawRows.map((r) => r.id));
-        return rawServerRows.filter((r) => !localIds.has(r.id));
-    }, [rawRows, rawServerRows]);
+    const { statusById, removedRows } = useMemo(
+        () => computeRowStatuses(
+            rawRows, rawServerRows,
+            (s, r) => s.prefix === r.prefix && s.dst_mac === r.dst_mac && s.src_mac === r.src_mac && s.device === r.device,
+        ),
+        [rawRows, rawServerRows],
+    );
 
     const editingIndex = editingRowId ? rawRows.findIndex((r) => r.id === editingRowId) : -1;
     const editingRow = editingIndex >= 0 ? rawRows[editingIndex] : null;


### PR DESCRIPTION
Extract the `statusById`/`removedRows` computation — duplicated between the decap and route draft pages — into a generic `computeRowStatuses` helper in `_shared/draft`, parameterized by a per-row equality predicate (decap compares prefix; route compares prefix + MACs + device).

- Behaviour-preserving logic extraction: the rendered draft-status badges and removed-rows section are identical for the same, added, changed and removed states.
- The two per-page `useMemo` blocks collapse into one combined memo with the same dependencies.