### PR TITLE
refactor(web): share VirtualDraftTable base props

### DIFF
--- a/web/src/components/VirtualTable/VirtualDraftTable.tsx
+++ b/web/src/components/VirtualTable/VirtualDraftTable.tsx
@@ -203,6 +203,38 @@ export interface VirtualDraftTableProps<T extends { id: string }> {
     headerActions?: React.ReactNode;
 }
 
+/**
+ * Props a draft page supplies to a VirtualDraftTable wrapper.
+ *
+ * The page-supplied subset of VirtualDraftTableProps plus the draft-action
+ * controls; the table-internal layout props (column descriptors, widths,
+ * nouns, footer) are filled in by the concrete table component.
+ */
+export type VirtualDraftTableBaseProps<T extends { id: string }> = Pick<
+    VirtualDraftTableProps<T>,
+    | 'allRows'
+    | 'visibleRows'
+    | 'statusById'
+    | 'removedRows'
+    | 'activeRowId'
+    | 'editingRowId'
+    | 'selectedIds'
+    | 'dragOverState'
+    | 'onRowClick'
+    | 'onEditRow'
+    | 'onRestoreRow'
+    | 'onSelectionChange'
+    | 'onDragStart'
+    | 'onDragOver'
+    | 'onDragLeave'
+    | 'onDrop'
+> & {
+    currentIsDirty: boolean;
+    onSave: () => void;
+    onDiscard: () => void;
+    onDeleteConfig: () => void;
+};
+
 /** Generic virtualized draft table. Used by FIBTable and PrefixTable. */
 export const VirtualDraftTable = <T extends { id: string }>({
     allRows,

--- a/web/src/components/VirtualTable/index.ts
+++ b/web/src/components/VirtualTable/index.ts
@@ -2,7 +2,7 @@ export { VirtualTable, ROW_HEIGHT, HEADER_HEIGHT, FOOTER_HEIGHT, OVERSCAN, SortI
 export type { Column, SortState, VirtualTableProps } from './VirtualTable';
 
 export { VirtualDraftTable, LEADING_CELL_WIDTHS, LEADING_TOTAL_WIDTH } from './VirtualDraftTable';
-export type { VirtualDraftTableProps, TableColumnHeader, RowStatus, RenderDataCells } from './VirtualDraftTable';
+export type { VirtualDraftTableProps, VirtualDraftTableBaseProps, TableColumnHeader, RowStatus, RenderDataCells } from './VirtualDraftTable';
 
 export { default as RowHoverEditOverlay } from './RowHoverEditOverlay';
 export { useRowHoverOverlay } from './useRowHoverOverlay';

--- a/web/src/pages/modules/decap/PrefixTable.tsx
+++ b/web/src/pages/modules/decap/PrefixTable.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
-import type { PrefixRowItem, PrefixRowStatus } from './types';
+import type { PrefixRowItem } from './types';
 import { validateRow } from './validation';
 import { VirtualDraftTable, LEADING_TOTAL_WIDTH } from '../../../components/VirtualTable';
-import type { RemovedColumnDescriptor, TableColumnHeader, RowStatus } from '../../../components/VirtualTable';
+import type { RemovedColumnDescriptor, TableColumnHeader, RowStatus, VirtualDraftTableBaseProps } from '../../../components/VirtualTable';
 import { DraftActionButtons } from '../../_shared/draft';
 
 const PREFIX_WIDTH = 480;
@@ -43,28 +43,7 @@ const renderPrefixDataCells = (row: PrefixRowItem): React.ReactNode => {
     );
 };
 
-export interface PrefixTableProps {
-    allRows: PrefixRowItem[];
-    visibleRows: PrefixRowItem[];
-    statusById: Map<string, PrefixRowStatus>;
-    removedRows: PrefixRowItem[];
-    activeRowId: string | null;
-    editingRowId: string | null;
-    selectedIds: Set<string>;
-    dragOverState: { id: string | null; where: 'top' | 'bottom' | null };
-    onRowClick: (id: string) => void;
-    onEditRow: (id: string) => void;
-    onRestoreRow: (row: PrefixRowItem) => void;
-    onSelectionChange: (ids: Set<string>) => void;
-    onDragStart: (id: string, e: React.DragEvent) => void;
-    onDragOver: (id: string, e: React.DragEvent) => void;
-    onDragLeave: () => void;
-    onDrop: (id: string, e: React.DragEvent) => void;
-    currentIsDirty: boolean;
-    onSave: () => void;
-    onDiscard: () => void;
-    onDeleteConfig: () => void;
-}
+export type PrefixTableProps = VirtualDraftTableBaseProps<PrefixRowItem>;
 
 /** Virtualized prefix table backed by VirtualDraftTable. */
 export const PrefixTable: React.FC<PrefixTableProps> = (props) => {

--- a/web/src/pages/modules/route/FIBTable.tsx
+++ b/web/src/pages/modules/route/FIBTable.tsx
@@ -1,8 +1,8 @@
 import React, { useMemo } from 'react';
-import type { FIBRowItem, FIBRowStatus } from './types';
+import type { FIBRowItem } from './types';
 import { validateRow } from './validation';
 import { VirtualDraftTable, LEADING_TOTAL_WIDTH } from '../../../components/VirtualTable';
-import type { RemovedColumnDescriptor, TableColumnHeader, RowStatus } from '../../../components/VirtualTable';
+import type { RemovedColumnDescriptor, TableColumnHeader, RowStatus, VirtualDraftTableBaseProps } from '../../../components/VirtualTable';
 import { DraftActionButtons } from '../../_shared/draft';
 
 const COLUMN_WIDTHS = {
@@ -66,28 +66,7 @@ const renderFIBDataCells = (row: FIBRowItem): React.ReactNode => {
     );
 };
 
-export interface FIBTableProps {
-    allRows: FIBRowItem[];
-    visibleRows: FIBRowItem[];
-    statusById: Map<string, FIBRowStatus>;
-    removedRows: FIBRowItem[];
-    activeRowId: string | null;
-    editingRowId: string | null;
-    selectedIds: Set<string>;
-    dragOverState: { id: string | null; where: 'top' | 'bottom' | null };
-    onRowClick: (id: string) => void;
-    onEditRow: (id: string) => void;
-    onRestoreRow: (row: FIBRowItem) => void;
-    onSelectionChange: (ids: Set<string>) => void;
-    onDragStart: (id: string, e: React.DragEvent) => void;
-    onDragOver: (id: string, e: React.DragEvent) => void;
-    onDragLeave: () => void;
-    onDrop: (id: string, e: React.DragEvent) => void;
-    currentIsDirty: boolean;
-    onSave: () => void;
-    onDiscard: () => void;
-    onDeleteConfig: () => void;
-}
+export type FIBTableProps = VirtualDraftTableBaseProps<FIBRowItem>;
 
 /** Virtualized FIB table backed by VirtualDraftTable. */
 export const FIBTable: React.FC<FIBTableProps> = (props) => {


### PR DESCRIPTION
Extract the identical 20-field props interface of the decap `PrefixTable` and route `FIBTable` into a generic `VirtualDraftTableBaseProps<T>` type, derived by `Pick`ing the page-supplied fields from `VirtualDraftTableProps` plus the draft-action controls.

- Type-only change: the emitted JS+CSS bundle is byte-for-byte identical (verified across all 78 build assets).