### PR TITLE
fix(controlplane): plug shared-memory leak on device config update

### DIFF
--- a/common/memory_address.h
+++ b/common/memory_address.h
@@ -31,8 +31,9 @@
  */
 #define SET_OFFSET_OF(PTR, ADDR)                                               \
 	do {                                                                   \
-		*(PTR) = ((typeof(ADDR))((uintptr_t)(ADDR) -                   \
-					 (uintptr_t)((ADDR) ? (PTR) : NULL))); \
+		typeof(ADDR) _addr = (ADDR);                                   \
+		*(PTR) = (typeof(_addr))((uintptr_t)_addr -                    \
+					 (uintptr_t)(_addr ? (PTR) : NULL));   \
 	} while (0)
 
 /**
@@ -64,9 +65,12 @@
 	})
 
 #define ATOMIC_SET_OFFSET_OF(PTR, ADDR)                                        \
-	atomic_store_explicit(                                                 \
-		(_Atomic(typeof(*PTR)) *)PTR,                                  \
-		(typeof(ADDR))((uintptr_t)(ADDR) -                             \
-			       (uintptr_t)((ADDR) ? (PTR) : NULL)),            \
-		memory_order_release                                           \
-	)
+	do {                                                                   \
+		typeof(ADDR) _addr = (ADDR);                                   \
+		atomic_store_explicit(                                         \
+			(_Atomic(typeof(*PTR)) *)PTR,                          \
+			(typeof(_addr))((uintptr_t)_addr -                     \
+					(uintptr_t)(_addr ? (PTR) : NULL)),    \
+			memory_order_release                                   \
+		);                                                             \
+	} while (0)

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -169,13 +169,10 @@ cp_device_init(
 
 	struct memory_context *memory_context = &self->memory_context;
 
-	SET_OFFSET_OF(
-		&self->input_pipelines,
-		cp_device_entry_create(
-			memory_context, cfg->input_pipelines, err
-		)
+	struct cp_device_entry *input = cp_device_entry_create(
+		memory_context, cfg->input_pipelines, err
 	);
-	if (self->input_pipelines == NULL) {
+	if (input == NULL) {
 		yanet_error_add(
 			err,
 			"failed to create input pipelines for device '%s'",
@@ -183,14 +180,12 @@ cp_device_init(
 		);
 		goto err_out;
 	}
+	SET_OFFSET_OF(&self->input_pipelines, input);
 
-	SET_OFFSET_OF(
-		&self->output_pipelines,
-		cp_device_entry_create(
-			memory_context, cfg->output_pipelines, err
-		)
+	struct cp_device_entry *output = cp_device_entry_create(
+		memory_context, cfg->output_pipelines, err
 	);
-	if (self->output_pipelines == NULL) {
+	if (output == NULL) {
 		yanet_error_add(
 			err,
 			"failed to create output pipelines for device '%s'",
@@ -198,6 +193,7 @@ cp_device_init(
 		);
 		goto err_out;
 	}
+	SET_OFFSET_OF(&self->output_pipelines, output);
 
 	registry_item_init(&self->config_item);
 


### PR DESCRIPTION
- Repeated plain/vlan device updates leaked shared memory on every pass because a relative-pointer helper double-evaluated its argument, allocating each device's pipeline tables twice while keeping only one copy.
- Under the pipeline operator's continuous re-apply this grew unboundedly (about 1 KiB per device per update); the leaked blocks stayed reachable, so sanitizers never flagged it.
- Fixes the helper to evaluate its argument once and binds the allocation before storing it at the device-config site.