### PR TITLE
refactor(cli): extract generic unary invoke helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,6 +3078,7 @@ dependencies = [
  "erased-serde",
  "http",
  "log",
+ "prost",
  "serde",
  "serde_json",
  "simple_logger",
@@ -3477,7 +3478,6 @@ dependencies = [
  "prost-types",
  "tabled",
  "tokio",
- "tonic",
  "yanet-cli",
  "yanet-readinesspb",
 ]

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -14,7 +14,8 @@ simple_logger = { version = "5", features = ["timestamps", "stderr"] }
 colored = "3"
 tabled = { version = "0.18", features = ["ansi"] }
 tokio = { version = "1", features = ["net", "io-util", "time", "sync"] }
-tonic = "0.13"
+prost = "0.13"
+tonic = { version = "0.13", features = ["gzip"] }
 tower = "0.5"
 http = "1"
 ssh-key = "0.6"

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -21,10 +21,20 @@
 //!     .accept_compressed(CompressionEncoding::Gzip);
 //! ```
 
-use tonic::transport::Channel;
+use http::uri::PathAndQuery;
+use prost::Message;
+use tonic::{
+    client::Grpc,
+    codec::{CompressionEncoding, ProstCodec},
+    transport::Channel,
+    Request, Status,
+};
 use tower::Layer;
 
-use crate::auth::{self, interceptor::AuthService, AuthArgs};
+use crate::{
+    auth::{self, interceptor::AuthService, AuthArgs},
+    errors::Error,
+};
 
 /// Channel type with all interceptors applied.
 ///
@@ -62,4 +72,53 @@ pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, Connection
     let auth = auth::create_layer(&args.auth).await?;
 
     Ok(auth.layer(channel))
+}
+
+/// Invoke a unary RPC on an arbitrary gRPC service by its fully-qualified
+/// name, without a generated client.
+///
+/// `action` is the user-facing verb used in error messages (e.g. `"ready"`),
+/// `service` is the service FQN, `method` is the wire method name (e.g.
+/// `"Ready"`). The request and response are any `prost` messages — the
+/// shared codec is built from them.
+pub async fn invoke_unary<Req, Resp>(
+    connection: &ConnectionArgs,
+    action: &str,
+    service: &str,
+    method: &str,
+    request: Req,
+) -> Result<Resp, Error>
+where
+    Req: Message + 'static,
+    Resp: Message + Default + 'static,
+{
+    let endpoint = connection.endpoint.clone();
+
+    let channel = connect(connection)
+        .await
+        .map_err(|err| Error::from_connection(err, action, endpoint.clone()))?;
+
+    let mut grpc = Grpc::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip);
+
+    let path = PathAndQuery::try_from(format!("/{service}/{method}")).map_err(|err| {
+        Error::from_status(
+            Status::invalid_argument(err.to_string()),
+            action,
+            endpoint.clone(),
+            service,
+        )
+    })?;
+
+    grpc.ready()
+        .await
+        .map_err(|err| Error::from_status(Status::unavailable(err.to_string()), action, endpoint.clone(), service))?;
+
+    let codec: ProstCodec<Req, Resp> = ProstCodec::default();
+
+    grpc.unary(Request::new(request), path, codec)
+        .await
+        .map(|response| response.into_inner())
+        .map_err(|status| Error::from_status(status, action, endpoint, service))
 }

--- a/cli/modules/ready/Cargo.toml
+++ b/cli/modules/ready/Cargo.toml
@@ -17,6 +17,5 @@ clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost-types = "0.13"
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
-tonic = { version = "0.13", features = ["gzip"] }
 colored = "3"
 tabled = { version = "0.18", features = ["ansi"] }

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -5,6 +5,8 @@ use core::fmt::{self, Display, Formatter};
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use colored::Colorize;
+use prost_types::Timestamp;
+use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope, State};
 use tabled::{
     Table, Tabled,
     settings::{
@@ -12,10 +14,6 @@ use tabled::{
         object::{Columns, Rows},
         style::{BorderColor, HorizontalLine},
     },
-};
-use tonic::{
-    client::Grpc,
-    codec::{CompressionEncoding, ProstCodec},
 };
 use ync::{
     client::ConnectionArgs,
@@ -70,43 +68,14 @@ pub async fn main() {
 
 /// Run the readiness probe.
 async fn run(cmd: Cmd) -> Result<bool, Error> {
-    let endpoint = cmd.connection.endpoint.clone();
-
-    let channel = ync::client::connect(&cmd.connection)
-        .await
-        .map_err(|err| Error::from_connection(err, "ready", endpoint.clone()))?;
-
-    let mut grpc = Grpc::new(channel)
-        .send_compressed(CompressionEncoding::Gzip)
-        .accept_compressed(CompressionEncoding::Gzip);
-
-    let path = tonic::codegen::http::uri::PathAndQuery::try_from(format!("/{}/Ready", cmd.name)).map_err(|err| {
-        Error::from_status(
-            tonic::Status::invalid_argument(err.to_string()),
-            "ready",
-            endpoint.clone(),
-            cmd.name.clone(),
-        )
-    })?;
-
-    grpc.ready().await.map_err(|err| {
-        Error::from_status(
-            tonic::Status::unavailable(err.to_string()),
-            "ready",
-            endpoint.clone(),
-            cmd.name.clone(),
-        )
-    })?;
-
-    let codec: ProstCodec<readinesspb::pb::ReadyRequest, readinesspb::pb::ReadyResponse> = ProstCodec::default();
-
-    let request = tonic::Request::new(readinesspb::pb::ReadyRequest { scopes: cmd.scopes.clone() });
-
-    let response = grpc
-        .unary(request, path, codec)
-        .await
-        .map_err(|status| Error::from_status(status, "ready", endpoint.clone(), &cmd.name))?
-        .into_inner();
+    let response: ReadyResponse = ync::client::invoke_unary(
+        &cmd.connection,
+        "ready",
+        &cmd.name,
+        "Ready",
+        ReadyRequest { scopes: cmd.scopes.clone() },
+    )
+    .await?;
 
     let returned_names: std::collections::HashSet<&str> =
         response.scopes.iter().map(|scope| scope.name.as_str()).collect();
@@ -118,10 +87,7 @@ async fn run(cmd: Cmd) -> Result<bool, Error> {
         .filter(|name| !returned_names.contains(name))
         .collect();
 
-    let all_scopes_ready = response
-        .scopes
-        .iter()
-        .all(|scope| scope.state == readinesspb::pb::State::Ready as i32);
+    let all_scopes_ready = response.scopes.iter().all(|scope| scope.state == State::Ready as i32);
 
     let all_ready = all_scopes_ready && missing.is_empty();
 
@@ -129,7 +95,7 @@ async fn run(cmd: Cmd) -> Result<bool, Error> {
     let ready_count = response
         .scopes
         .iter()
-        .filter(|scope| scope.state == readinesspb::pb::State::Ready as i32)
+        .filter(|scope| scope.state == State::Ready as i32)
         .count();
 
     output::data(
@@ -169,7 +135,7 @@ async fn run(cmd: Cmd) -> Result<bool, Error> {
 }
 
 /// Wraps a readiness state for colored display in the table.
-pub struct StateCell(readinesspb::pb::State);
+pub struct StateCell(State);
 
 impl Display for StateCell {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
@@ -178,12 +144,10 @@ impl Display for StateCell {
 
         if output::is_colored() {
             let colored = match state {
-                readinesspb::pb::State::Ready => name.green().to_string(),
-                readinesspb::pb::State::Degraded => name.yellow().to_string(),
-                readinesspb::pb::State::NotReady => name.red().to_string(),
-                readinesspb::pb::State::Unspecified | readinesspb::pb::State::Unknown => {
-                    name.truecolor(127, 127, 127).to_string()
-                }
+                State::Ready => name.green().to_string(),
+                State::Degraded => name.yellow().to_string(),
+                State::NotReady => name.red().to_string(),
+                State::Unspecified | State::Unknown => name.truecolor(127, 127, 127).to_string(),
             };
             write!(f, "{colored}")
         } else {
@@ -207,9 +171,9 @@ pub struct ReadinessRow {
     pub reasons: String,
 }
 
-impl From<&readinesspb::pb::Scope> for ReadinessRow {
-    fn from(scope: &readinesspb::pb::Scope) -> Self {
-        let state = readinesspb::pb::State::try_from(scope.state).unwrap_or_default();
+impl From<&Scope> for ReadinessRow {
+    fn from(scope: &Scope) -> Self {
+        let state = State::try_from(scope.state).unwrap_or_default();
         let state_cell = StateCell(state);
 
         let reasons = scope
@@ -245,12 +209,12 @@ fn print_readiness_table(rows: Vec<ReadinessRow>) {
     println!("{table}");
 }
 
-/// Formats a `prost_types::Timestamp` as a human-readable relative age.
+/// Formats a `Timestamp` as a human-readable relative age.
 ///
 /// Returns `"-"` when `ts` is `None` or the zero sentinel
 /// (`seconds == 0 && nanos == 0`). Otherwise formats as `Xs ago`,
 /// `XmYs ago`, or `XhYm ago` depending on magnitude.
-pub fn format_age(ts: Option<&prost_types::Timestamp>) -> String {
+pub fn format_age(ts: Option<&Timestamp>) -> String {
     let ts = match ts {
         Some(ts) if ts.seconds != 0 || ts.nanos != 0 => ts,
         _ => return "-".to_string(),
@@ -289,7 +253,7 @@ mod test {
 
     #[test]
     fn format_age_zero_sentinel_returns_dash() {
-        let ts = prost_types::Timestamp { seconds: 0, nanos: 0 };
+        let ts = Timestamp { seconds: 0, nanos: 0 };
         assert_eq!("-", format_age(Some(&ts)));
     }
 
@@ -298,7 +262,7 @@ mod test {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap();
-        let ts = prost_types::Timestamp {
+        let ts = Timestamp {
             seconds: now.as_secs() as i64 - 30,
             nanos: 0,
         };
@@ -310,7 +274,7 @@ mod test {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap();
-        let ts = prost_types::Timestamp {
+        let ts = Timestamp {
             seconds: now.as_secs() as i64 - 64,
             nanos: 0,
         };
@@ -322,7 +286,7 @@ mod test {
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap();
-        let ts = prost_types::Timestamp {
+        let ts = Timestamp {
             seconds: now.as_secs() as i64 - (2 * 3600 + 3 * 60),
             nanos: 0,
         };


### PR DESCRIPTION
Move the dynamic gRPC unary dispatch used by the `ready` command into a reusable `invoke_unary` helper on the shared CLI client (`ync::client`).

Any command can now call an arbitrary service by its fully-qualified name without a generated per-service client — only the path and message types vary. The `ready` command is migrated onto the helper with no change in behavior, in preparation for a second generic command that reuses it.