### PR TITLE
fix(web): reset device list filter when jumping via palette

### DIFF
--- a/web/src/pages/builtin/devices/DevicesList.tsx
+++ b/web/src/pages/builtin/devices/DevicesList.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { DeviceListItem } from './DeviceListItem';
 import { IconStack } from './components/Icons';
 import type { LocalDevice } from './types';
 import type { CounterHistoryEntry } from '../../../hooks/useCounterHistory';
 import type { DeviceCounterData } from '../../../hooks/useDeviceCounters';
 
-type FilterKind = 'all' | 'plain' | 'vlan';
+export type FilterKind = 'all' | 'plain' | 'vlan';
 type GroupingMode = 'flat' | 'type' | 'parent';
 
 export interface DevicesListProps {
@@ -16,6 +16,8 @@ export interface DevicesListProps {
     onSelectDevice: (deviceName: string) => void;
     counters: Map<string, DeviceCounterData>;
     history: Map<string, CounterHistoryEntry>;
+    filter: FilterKind;
+    onFilterChange: (filter: FilterKind) => void;
 }
 
 interface DeviceGroup {
@@ -62,8 +64,9 @@ export const DevicesList: React.FC<DevicesListProps> = ({
     onSelectDevice,
     counters,
     history,
+    filter,
+    onFilterChange,
 }) => {
-    const [filter, setFilter] = useState<FilterKind>('all');
 
     const counts = useMemo(() => ({
         all: devices.length,
@@ -99,7 +102,7 @@ export const DevicesList: React.FC<DevicesListProps> = ({
                             <button
                                 key={k}
                                 className={"dv-chip" + (filter === k ? ' chip-on' : '')}
-                                onClick={() => setFilter(k)}
+                                onClick={() => onFilterChange(k)}
                             >
                                 {label} <span className="dv-chip-n">{n}</span>
                             </button>

--- a/web/src/pages/builtin/devices/DevicesPage.tsx
+++ b/web/src/pages/builtin/devices/DevicesPage.tsx
@@ -17,6 +17,7 @@ import {
     CreateDeviceDialog,
     useDeviceData,
 } from '.';
+import type { FilterKind } from '.';
 import './devices.scss';
 
 type GroupingMode = 'flat' | 'type' | 'parent';
@@ -38,6 +39,7 @@ const DevicesPage: React.FC = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [grouping, setGrouping] = useState<GroupingMode>('type');
+    const [deviceFilter, setDeviceFilter] = useState<FilterKind>('all');
 
     const deviceNames = useMemo(() => devices.map(d => d.id.name || ''), [devices]);
 
@@ -156,7 +158,7 @@ const DevicesPage: React.FC = () => {
             ? `vlan${d.vlanId !== undefined ? ' · ' + d.vlanId : ''}`
             : 'physical',
         searchText: (d) => [d.id.name, d.type, d.vlanId].filter(Boolean).join(' '),
-        onSelect: (id) => handleSelectDevice(id),
+        onSelect: (id) => { setDeviceFilter('all'); handleSelectDevice(id); },
         icon: '→',
     }), [devices, handleSelectDevice]);
 
@@ -218,6 +220,8 @@ const DevicesPage: React.FC = () => {
                         onSelectDevice={handleSelectDevice}
                         counters={counters}
                         history={history}
+                        filter={deviceFilter}
+                        onFilterChange={setDeviceFilter}
                     />
                     <DeviceDetails
                         device={selectedDevice}


### PR DESCRIPTION
Follow-up to #1113 addressing a review finding.

- The devices command palette "jump to device" searches all devices, but the type-filter chips kept their state locally in the list, so jumping to a device of a hidden type updated the details pane while leaving no highlighted row visible.
- Lift the chip filter state into the page and reset it to "All" when a palette row is selected, mirroring how the forward page resets its filters before jumping. The target device is now always rendered and highlighted.