### PR TITLE
feat(web): add command palette to functions and pipelines pages

### DIFF
--- a/web/src/pages/builtin/functions/FunctionsPage.scss
+++ b/web/src/pages/builtin/functions/FunctionsPage.scss
@@ -518,3 +518,13 @@
 .fn-diff-dialog {
     @include diff-dialog(var(--fn-page-bg), var(--fn-line));
 }
+
+@keyframes fn-card-flash {
+    0%   { box-shadow: 0 0 0 2px var(--fn-accent); }
+    80%  { box-shadow: 0 0 0 2px var(--fn-accent); }
+    100% { box-shadow: 0 0 0 2px transparent; }
+}
+
+.fn-function-card--flash {
+    animation: fn-card-flash 1.2s ease-out forwards;
+}

--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -1,40 +1,33 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
+import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
-import { PageLayout, PageLoader, EmptyState, SearchInput } from '../../../components';
+import { PageLayout, PageLoader, EmptyState, CommandPaletteHeader } from '../../../components';
 import { useFunctionsData } from './hooks/useFunctionsData';
 import { useDragState, useUnsavedChangesBlocker } from '../_shared/lane-editor';
 import { FunctionCard } from './components/FunctionCard';
 import { CreateEntityDialog } from '../../../components';
 import { getAvailableModuleTypesFromInspect } from './moduleTypeOptions';
 import type { NetworkFunction } from './types';
+import { isFnSaveable } from './validation';
 import { API } from '../../../api';
+import { usePalette } from '../../_shared/command-palette';
+import type { Command, RowAdapter } from '../../_shared/command-palette';
 import './FunctionsPage.scss';
 
-/** Returns true if the function matches the query string (case-insensitive substring). */
-const matchesFn = (fn: NetworkFunction, query: string): boolean => {
-    const q = query.toLowerCase();
-    if (fn.id.toLowerCase().includes(q)) {
-        return true;
-    }
-    if (fn.type.toLowerCase().includes(q)) {
-        return true;
-    }
+/** Builds a space-joined search string for a function (id, type, chain names, module names/types). */
+const fnSearchText = (fn: NetworkFunction): string => {
+    const parts: string[] = [fn.id, fn.type];
     for (const chain of fn.chains) {
-        if (chain.name.toLowerCase().includes(q)) {
-            return true;
-        }
+        parts.push(chain.name);
         for (const m of chain.modules) {
-            if (m.name.toLowerCase().includes(q) || m.type.toLowerCase().includes(q)) {
-                return true;
-            }
+            parts.push(m.name, m.type);
         }
     }
-    return false;
+    return parts.join(' ');
 };
 
 /**
- * Functions page: Tracks editor with horizontal lanes, inline edit, DnD and live counters.
+ * Functions page: tracks editor with horizontal lanes, inline edit, DnD and live counters.
  */
 const FunctionsPage = (): React.JSX.Element => {
     const { functions, loading, isDirty, getServerFn, dispatch, saveFn, discardFn, createFn, deleteFn } = useFunctionsData();
@@ -42,7 +35,7 @@ const FunctionsPage = (): React.JSX.Element => {
     const [availableModuleConfigNamesByType, setAvailableModuleConfigNamesByType] = useState<Record<string, string[]>>({});
     const [availableModuleConfigNames, setAvailableModuleConfigNames] = useState<string[]>([]);
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
-    const [searchQuery, setSearchQuery] = useState('');
+    const [flashId, setFlashId] = useState<string | null>(null);
     const { dragState, startDrag, endDrag } = useDragState();
 
     useEffect(() => {
@@ -86,13 +79,6 @@ const FunctionsPage = (): React.JSX.Element => {
         fetchTypes();
     }, []);
 
-    const filteredFunctions = useMemo(() => {
-        if (!searchQuery.trim()) {
-            return functions;
-        }
-        return functions.filter(fn => matchesFn(fn, searchQuery));
-    }, [functions, searchQuery]);
-
     const anyDirty = useMemo(
         () => functions.some(fn => isDirty(fn.id)),
         [functions, isDirty],
@@ -104,46 +90,87 @@ const FunctionsPage = (): React.JSX.Element => {
     const handleDiscard = useCallback((fnId: string) => (): void => discardFn(fnId), [discardFn]);
     const handleDelete = useCallback((fnId: string) => (): Promise<boolean> => deleteFn(fnId), [deleteFn]);
 
-    const pageHeader = (
-        <Flex alignItems="center" gap={4} style={{ width: '100%' }}>
-            <Text variant="header-1">Functions</Text>
-            <Flex grow />
-            <div style={{ flexBasis: 380, flexShrink: 1 }}>
-                <SearchInput
-                    value={searchQuery}
-                    onUpdate={setSearchQuery}
-                    placeholder="Search functions, chains, modules…"
-                />
-            </div>
-            <Button
-                view="action"
-                onClick={() => setCreateDialogOpen(true)}
-            >
+    const jumpToFn = useCallback((id: string): void => {
+        setFlashId(null);
+        setTimeout(() => {
+            setFlashId(id);
+            document.getElementById(`fn-card-${id}`)?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }, 0);
+    }, []);
+
+    const { setPageContribution } = usePalette();
+
+    const commands = useMemo((): Command[] => {
+        const list: Command[] = [
+            {
+                id: '__create_function',
+                icon: '+',
+                label: 'Create function',
+                sub: 'Open the create function dialog',
+                keywords: 'create new function add',
+                onSelect: () => setCreateDialogOpen(true),
+            },
+        ];
+        for (const fn of functions) {
+            if (isDirty(fn.id) && isFnSaveable(fn)) {
+                list.push({
+                    id: `__save_${fn.id}`,
+                    icon: '✓',
+                    label: `Save ${fn.id}`,
+                    sub: 'Save unsaved changes',
+                    keywords: 'save commit apply',
+                    onSelect: () => saveFn(fn.id),
+                });
+            }
+        }
+        return list;
+    }, [functions, isDirty, saveFn]);
+
+    const rowAdapter = useMemo((): RowAdapter<NetworkFunction> => ({
+        rows: functions,
+        getId: (fn) => fn.id,
+        getLabel: (fn) => fn.id,
+        getSub: (fn) => `${fn.type} · ${fn.chains.length} chains`,
+        searchText: fnSearchText,
+        onSelect: (id) => jumpToFn(id),
+        icon: '→',
+    }), [functions, jumpToFn]);
+
+    useEffect(() => {
+        setPageContribution({
+            commands,
+            rowAdapter: rowAdapter as RowAdapter<unknown>,
+            placeholder: 'Search functions or run an action…',
+        });
+        return () => setPageContribution(null);
+    }, [commands, rowAdapter, setPageContribution]);
+
+    const headerContent = (
+        <CommandPaletteHeader
+            title="Functions"
+            placeholder="Search functions or run an action…"
+            actions={<Button view="action" onClick={() => setCreateDialogOpen(true)}>
                 <Icon data={Plus} size={16} />
                 Create function
-            </Button>
-        </Flex>
+            </Button>}
+        />
     );
 
     if (loading) {
         return (
-            <PageLayout header={pageHeader}>
+            <PageLayout title="Functions">
                 <PageLoader loading size="l" />
             </PageLayout>
         );
     }
 
     return (
-        <PageLayout header={pageHeader}>
+        <PageLayout header={headerContent}>
             <div className="fn-page">
-                {filteredFunctions.length === 0 ? (
-                    <EmptyState message={
-                        searchQuery.trim()
-                            ? `No functions match "${searchQuery}".`
-                            : 'No functions found. Click "Create function" to add one.'
-                    } />
+                {functions.length === 0 ? (
+                    <EmptyState message='No functions found. Click "Create function" to add one.' />
                 ) : (
-                    filteredFunctions.map(fn => (
+                    functions.map(fn => (
                         <FunctionCard
                             key={fn.id}
                             fn={fn}
@@ -159,6 +186,7 @@ const FunctionsPage = (): React.JSX.Element => {
                             onSave={handleSave(fn.id)}
                             onDiscard={handleDiscard(fn.id)}
                             onDelete={handleDelete(fn.id)}
+                            flash={flashId === fn.id}
                         />
                     ))
                 )}

--- a/web/src/pages/builtin/functions/components/FunctionCard.tsx
+++ b/web/src/pages/builtin/functions/components/FunctionCard.tsx
@@ -24,32 +24,10 @@ interface FunctionCardProps {
     onSave: () => Promise<void>;
     onDiscard: () => void;
     onDelete: () => Promise<boolean>;
+    flash?: boolean;
 }
 
-/** Validate a single function, returning error messages (editing-time only; weight=0 is allowed). */
-const validateFn = (fn: NetworkFunction): string[] => {
-    const errors: string[] = [];
-    for (const chain of fn.chains) {
-        const names = new Set<string>();
-        for (const m of chain.modules) {
-            if (names.has(m.name)) {
-                errors.push(`Chain "${chain.name}": duplicate module name "${m.name}"`);
-            }
-            names.add(m.name);
-        }
-    }
-    return errors;
-};
-
-/** Check save-time constraints (weight sum > 0 required). */
-const validateSave = (fn: NetworkFunction): string[] => {
-    const errors: string[] = [];
-    const totalWeight = fn.chains.reduce((s, c) => s + c.weight, 0);
-    if (totalWeight === 0 && fn.chains.length > 0) {
-        errors.push('Total chain weight is 0 — at least one chain must have weight > 0 before saving.');
-    }
-    return errors;
-};
+import { validateFn, validateSave } from '../validation';
 
 /**
  * A full function card with collapsible lanes, drag-and-drop, drawer, and per-function save.
@@ -68,6 +46,7 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
     onSave,
     onDiscard,
     onDelete,
+    flash,
 }) => {
     const [collapsed, setCollapsed] = useState(false);
     const [diffOpen, setDiffOpen] = useState(false);
@@ -241,7 +220,10 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
     }, []);
 
     return (
-        <div className={`fn-function-card${collapsed ? ' fn-function-card--collapsed' : ''}`}>
+        <div
+            id={`fn-card-${fn.id}`}
+            className={`fn-function-card${collapsed ? ' fn-function-card--collapsed' : ''}${flash ? ' fn-function-card--flash' : ''}`}
+        >
             <FunctionCardHeader
                 fn={fn}
                 isDirty={isDirty}

--- a/web/src/pages/builtin/functions/validation.ts
+++ b/web/src/pages/builtin/functions/validation.ts
@@ -1,0 +1,30 @@
+import type { NetworkFunction } from './types';
+
+/** Validate a single function, returning error messages (editing-time only; weight=0 is allowed). */
+export const validateFn = (fn: NetworkFunction): string[] => {
+    const errors: string[] = [];
+    for (const chain of fn.chains) {
+        const names = new Set<string>();
+        for (const m of chain.modules) {
+            if (names.has(m.name)) {
+                errors.push(`Chain "${chain.name}": duplicate module name "${m.name}"`);
+            }
+            names.add(m.name);
+        }
+    }
+    return errors;
+};
+
+/** Check save-time constraints (weight sum > 0 required). */
+export const validateSave = (fn: NetworkFunction): string[] => {
+    const errors: string[] = [];
+    const totalWeight = fn.chains.reduce((s, c) => s + c.weight, 0);
+    if (totalWeight === 0 && fn.chains.length > 0) {
+        errors.push('Total chain weight is 0 — at least one chain must have weight > 0 before saving.');
+    }
+    return errors;
+};
+
+/** Returns true if a function passes all editing- and save-time validation. */
+export const isFnSaveable = (fn: NetworkFunction): boolean =>
+    validateFn(fn).length === 0 && validateSave(fn).length === 0;

--- a/web/src/pages/builtin/pipelines/PipelinesPage.scss
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.scss
@@ -109,3 +109,13 @@
 .pl-diff-dialog {
     @include diff-dialog(var(--pl-page-bg), var(--pl-line));
 }
+
+@keyframes pl-card-flash {
+    0%   { box-shadow: 0 0 0 2px var(--pl-accent); }
+    80%  { box-shadow: 0 0 0 2px var(--pl-accent); }
+    100% { box-shadow: 0 0 0 2px transparent; }
+}
+
+.pl-pipeline-card--flash {
+    animation: pl-card-flash 1.2s ease-out forwards;
+}

--- a/web/src/pages/builtin/pipelines/PipelinesPage.tsx
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.tsx
@@ -1,27 +1,18 @@
-import React, { useState, useCallback, useMemo } from 'react';
-import { Button, Flex, Icon, Text } from '@gravity-ui/uikit';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
-import { PageLayout, PageLoader, EmptyState, SearchInput } from '../../../components';
+import { PageLayout, PageLoader, EmptyState, CommandPaletteHeader } from '../../../components';
 import { usePipelinesData } from './hooks/usePipelinesData';
 import { useDragState, useUnsavedChangesBlocker } from '../_shared/lane-editor';
 import { PipelineCard } from './components/PipelineCard';
 import { CreateEntityDialog } from '../../../components';
 import type { Pipeline } from './types';
+import { usePalette } from '../../_shared/command-palette';
+import type { Command, RowAdapter } from '../../_shared/command-palette';
 import './PipelinesPage.scss';
 
-/** Returns true if the pipeline matches the query string (case-insensitive substring). */
-const matchesPipeline = (pl: Pipeline, query: string): boolean => {
-    const q = query.toLowerCase();
-    if (pl.id.toLowerCase().includes(q)) {
-        return true;
-    }
-    for (const ref of pl.functions) {
-        if (ref.name.toLowerCase().includes(q)) {
-            return true;
-        }
-    }
-    return false;
-};
+/** Builds a space-joined search string for a pipeline (id and function names). */
+const plSearchText = (pl: Pipeline): string => [pl.id, ...pl.functions.map(f => f.name)].join(' ');
 
 /**
  * Pipelines page: track editor with function references, drag-and-drop, and live counters.
@@ -29,15 +20,8 @@ const matchesPipeline = (pl: Pipeline, query: string): boolean => {
 const PipelinesPage = (): React.JSX.Element => {
     const { pipelines, loading, isDirty, getServerPipeline, dispatch, savePipeline, discardPipeline, createPipeline, deletePipeline, loadFunctionList } = usePipelinesData();
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
-    const [searchQuery, setSearchQuery] = useState('');
+    const [flashId, setFlashId] = useState<string | null>(null);
     const { dragState, startDrag, endDrag } = useDragState();
-
-    const filteredPipelines = useMemo(() => {
-        if (!searchQuery.trim()) {
-            return pipelines;
-        }
-        return pipelines.filter(pl => matchesPipeline(pl, searchQuery));
-    }, [pipelines, searchQuery]);
 
     const anyDirty = useMemo(
         () => pipelines.some(pl => isDirty(pl.id)),
@@ -50,46 +34,87 @@ const PipelinesPage = (): React.JSX.Element => {
     const handleDiscard = useCallback((pipelineId: string) => (): void => discardPipeline(pipelineId), [discardPipeline]);
     const handleDelete = useCallback((pipelineId: string) => (): Promise<boolean> => deletePipeline(pipelineId), [deletePipeline]);
 
-    const pageHeader = (
-        <Flex alignItems="center" gap={4} style={{ width: '100%' }}>
-            <Text variant="header-1">Pipelines</Text>
-            <Flex grow />
-            <div style={{ flexBasis: 380, flexShrink: 1 }}>
-                <SearchInput
-                    value={searchQuery}
-                    onUpdate={setSearchQuery}
-                    placeholder="Search pipelines, functions…"
-                />
-            </div>
-            <Button
-                view="action"
-                onClick={() => setCreateDialogOpen(true)}
-            >
+    const jumpToPipeline = useCallback((id: string): void => {
+        setFlashId(null);
+        setTimeout(() => {
+            setFlashId(id);
+            document.getElementById(`pl-card-${id}`)?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }, 0);
+    }, []);
+
+    const { setPageContribution } = usePalette();
+
+    const commands = useMemo((): Command[] => {
+        const list: Command[] = [
+            {
+                id: '__create_pipeline',
+                icon: '+',
+                label: 'Create pipeline',
+                sub: 'Open the create pipeline dialog',
+                keywords: 'create new pipeline add',
+                onSelect: () => setCreateDialogOpen(true),
+            },
+        ];
+        for (const pl of pipelines) {
+            if (isDirty(pl.id)) {
+                list.push({
+                    id: `__save_${pl.id}`,
+                    icon: '✓',
+                    label: `Save ${pl.id}`,
+                    sub: 'Save unsaved changes',
+                    keywords: 'save commit apply',
+                    onSelect: () => savePipeline(pl.id),
+                });
+            }
+        }
+        return list;
+    }, [pipelines, isDirty, savePipeline]);
+
+    const rowAdapter = useMemo((): RowAdapter<Pipeline> => ({
+        rows: pipelines,
+        getId: (pl) => pl.id,
+        getLabel: (pl) => pl.id,
+        getSub: (pl) => `${pl.functions.length} functions`,
+        searchText: plSearchText,
+        onSelect: (id) => jumpToPipeline(id),
+        icon: '→',
+    }), [pipelines, jumpToPipeline]);
+
+    useEffect(() => {
+        setPageContribution({
+            commands,
+            rowAdapter: rowAdapter as RowAdapter<unknown>,
+            placeholder: 'Search pipelines or run an action…',
+        });
+        return () => setPageContribution(null);
+    }, [commands, rowAdapter, setPageContribution]);
+
+    const headerContent = (
+        <CommandPaletteHeader
+            title="Pipelines"
+            placeholder="Search pipelines or run an action…"
+            actions={<Button view="action" onClick={() => setCreateDialogOpen(true)}>
                 <Icon data={Plus} size={16} />
                 Create pipeline
-            </Button>
-        </Flex>
+            </Button>}
+        />
     );
 
     if (loading) {
         return (
-            <PageLayout header={pageHeader}>
+            <PageLayout title="Pipelines">
                 <PageLoader loading size="l" />
             </PageLayout>
         );
     }
 
     return (
-        <PageLayout header={pageHeader}>
+        <PageLayout header={headerContent}>
             <div className="pl-page">
-                {filteredPipelines.length === 0 ? (
-                    <EmptyState message={
-                        searchQuery.trim()
-                            ? `No pipelines match "${searchQuery}".`
-                            : 'No pipelines found. Click "Create pipeline" to add one.'
-                    } />
+                {pipelines.length === 0 ? (
+                    <EmptyState message='No pipelines found. Click "Create pipeline" to add one.' />
                 ) : (
-                    filteredPipelines.map(pl => (
+                    pipelines.map(pl => (
                         <PipelineCard
                             key={pl.id}
                             pipeline={pl}
@@ -103,6 +128,7 @@ const PipelinesPage = (): React.JSX.Element => {
                             onDiscard={handleDiscard(pl.id)}
                             onDelete={handleDelete(pl.id)}
                             loadFunctionList={loadFunctionList}
+                            flash={flashId === pl.id}
                         />
                     ))
                 )}

--- a/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
+++ b/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
@@ -22,6 +22,7 @@ interface PipelineCardProps {
     onDiscard: () => void;
     onDelete: () => Promise<boolean>;
     loadFunctionList: () => Promise<FunctionId[]>;
+    flash?: boolean;
 }
 
 /**
@@ -39,6 +40,7 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
     onDiscard,
     onDelete,
     loadFunctionList,
+    flash,
 }) => {
     const [collapsed, setCollapsed] = useState(false);
     const [diffOpen, setDiffOpen] = useState(false);
@@ -112,7 +114,10 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
     }, [pipeline.functions, drawerRefId]);
 
     return (
-        <div className={`pl-pipeline-card${collapsed ? ' pl-pipeline-card--collapsed' : ''}`}>
+        <div
+            id={`pl-card-${pipeline.id}`}
+            className={`pl-pipeline-card${collapsed ? ' pl-pipeline-card--collapsed' : ''}${flash ? ' pl-pipeline-card--flash' : ''}`}
+        >
             <PipelineCardHeader
                 pipeline={pipeline}
                 isDirty={isDirty}


### PR DESCRIPTION
- Replace the legacy search bar on the Functions and Pipelines pages with the shared command-palette header, bringing them in line with the other list pages.
- Register a palette contribution per page: a Create action, a per-dirty Save action for each function/pipeline with unsaved changes, and fuzzy row search over functions/pipelines.
- Selecting a row from the palette scrolls to and briefly flashes the matching card; all cards stay rendered.
- Remove the now-unused in-page text filter; the palette's fuzzy search replaces it.