### PR TITLE
fix(fwstate): guard UDP payload length before uint16 underflow

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -155,6 +155,16 @@ type Result struct {
 	Drop   []*framework.PacketInfo
 }
 
+// RawResult holds the raw first-segment bytes of each output and drop packet
+// from one pipeline round, without gopacket parsing.
+//
+// Use this when the packets under test cannot be decoded by gopacket (e.g.
+// malformed or multi-segment packets that are passed through as-is).
+type RawResult struct {
+	Output [][]byte
+	Drop   [][]byte
+}
+
 // Harness is a handle to an in-process dataplane harness.
 //
 // Never move this object in memory after construction — the underlying C
@@ -276,6 +286,58 @@ func (m *Harness) HandlePacketsWithHashes(
 		)
 	}
 	return m.handlePackets(0, hashes, packets...)
+}
+
+// HandleSegmentedPackets runs one pipeline round on worker 0 where each input
+// packet is supplied as an ordered list of byte segments, producing a chained
+// multi-segment mbuf. The result is returned unparsed so callers can inspect
+// packets that gopacket cannot decode.
+func (m *Harness) HandleSegmentedPackets(packets ...[][]byte) (*RawResult, error) {
+	pinner := runtime.Pinner{}
+	defer pinner.Unpin()
+
+	builtPackets := make([]*dataplane.Packet, 0, len(packets))
+	for idx := range packets {
+		pkt, err := dataplane.NewPacketFromSegments(packets[idx], 0, 0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build segmented packet at index %d: %w", idx, err)
+		}
+		pinner.Pin(pkt)
+		builtPackets = append(builtPackets, pkt)
+	}
+
+	packetList := dataplane.NewPacketList(&pinner, builtPackets)
+
+	pinner.Pin(m)
+
+	var result C.struct_dataplane_ut_round_result
+	C.dataplane_ut_run(
+		m.ptr,
+		C.size_t(0),
+		(*C.struct_packet_list)(unsafe.Pointer(packetList)),
+		&result,
+	)
+
+	pinner.Pin(&result)
+
+	output := (*dataplane.PacketList)(unsafe.Pointer(&result.output))
+	drop := (*dataplane.PacketList)(unsafe.Pointer(&result.drop))
+
+	rawBytes := func(list *dataplane.PacketList) [][]byte {
+		data := list.Data()
+		out := make([][]byte, 0, len(data))
+		for idx := range data {
+			b := make([]byte, len(data[idx].Payload))
+			copy(b, data[idx].Payload)
+			out = append(out, b)
+		}
+		return out
+	}
+
+	return &RawResult{
+		Output: rawBytes(output),
+		Drop:   rawBytes(drop),
+	}, nil
 }
 
 // handlePackets is the shared implementation for all HandlePackets variants.

--- a/common/go/dataplane/packet.go
+++ b/common/go/dataplane/packet.go
@@ -47,6 +47,65 @@ func PacketsData(txDeviceId uint16, rxDeviceId uint16, packets ...gopacket.Packe
 
 type Packet C.struct_packet
 
+// NewPacketFromSegments builds a chained (multi-segment) packet from the given
+// segments, copied in order into separate tightly-sized mbuf segments.
+//
+// Each element of segments becomes one mbuf segment allocated at exactly that
+// segment's length, so an over-read past a segment boundary is detectable by
+// AddressSanitizer. parse_packet is run on the assembled head mbuf.
+// Returns an error if segments is empty, the total payload is zero, or the
+// underlying C call fails.
+func NewPacketFromSegments(segments [][]byte, txDeviceId, rxDeviceId uint16) (*Packet, error) {
+	if len(segments) == 0 {
+		return nil, fmt.Errorf("failed to create segmented packet: no segments provided")
+	}
+
+	// Concatenate all segments into one contiguous payload buffer.
+	total := 0
+	for idx := range segments {
+		total += len(segments[idx])
+	}
+	if total == 0 {
+		return nil, fmt.Errorf("failed to create segmented packet: total payload size is zero")
+	}
+
+	payload := make([]byte, 0, total)
+	for idx := range segments {
+		payload = append(payload, segments[idx]...)
+	}
+
+	// Build the per-segment size array.
+	segSizes := make([]uint16, len(segments))
+	for idx := range segments {
+		segSizes[idx] = uint16(len(segments[idx]))
+	}
+
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+	pinner.Pin(&payload[0])
+	pinner.Pin(&segSizes[0])
+
+	packet := C.struct_packet{}
+	packetInfo := C.struct_packet_info{
+		data:         (*C.uint8_t)(&payload[0]),
+		size:         C.uint16_t(len(payload)),
+		tx_device_id: C.uint16_t(txDeviceId),
+		rx_device_id: C.uint16_t(rxDeviceId),
+	}
+
+	rc := C.fill_packet_from_segments(
+		&packet,
+		&packetInfo,
+		(*C.uint16_t)(&segSizes[0]),
+		C.size_t(len(segSizes)),
+	)
+	if rc != 0 {
+		return nil, fmt.Errorf("failed to create segmented packet: rc=%d", rc)
+	}
+
+	return (*Packet)(&packet), nil
+}
+
 func NewPacketFromData(data PacketData) (*Packet, error) {
 	packet := C.struct_packet{}
 	packetData := C.struct_packet_info{

--- a/lib/utils/packet.c
+++ b/lib/utils/packet.c
@@ -230,7 +230,12 @@ fill_packet(
 
 void
 free_packet(struct packet *packet) {
-	free(packet->mbuf);
+	struct rte_mbuf *seg = packet->mbuf;
+	while (seg != NULL) {
+		struct rte_mbuf *next = seg->next;
+		free(seg);
+		seg = next;
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -357,6 +362,109 @@ fill_packet_from_data(struct packet *packet, struct packet_info *data) {
 	init_mbuf(mbuf, data, buf_len);
 	init_packet_with_mbuf(packet, mbuf, data);
 	return parse_packet(packet);
+}
+
+// Allocate one mbuf segment, copy len bytes from src into its data area.
+//
+// buf_len is the total buffer length (sizeof rte_mbuf is NOT included).
+// data_off is the data offset within the buffer (headroom for seg 0, 0 for the
+// rest). Returns the allocated mbuf, or NULL on failure.
+static struct rte_mbuf *
+alloc_seg(const uint8_t *src, uint16_t len, size_t buf_len, uint16_t data_off) {
+	size_t align = alignof(struct rte_mbuf);
+	size_t alloc_size = sizeof(struct rte_mbuf) + buf_len;
+	if (alloc_size % align != 0) {
+		alloc_size += align - alloc_size % align;
+	}
+	struct rte_mbuf *m = aligned_alloc(align, alloc_size);
+	if (m == NULL) {
+		return NULL;
+	}
+	memset(m, 0, sizeof(struct rte_mbuf));
+	m->priv_size = 0;
+	m->buf_addr = (char *)m + sizeof(struct rte_mbuf);
+	m->buf_len = (uint16_t)buf_len;
+	m->data_off = data_off;
+	m->data_len = len;
+	m->pkt_len = len;
+	m->nb_segs = 1;
+	m->pool = NULL;
+	m->port = 1;
+	m->next = NULL;
+	rte_mbuf_refcnt_set(m, 1);
+	memcpy(rte_pktmbuf_mtod(m, uint8_t *), src, len);
+	return m;
+}
+
+int
+fill_packet_from_segments(
+	struct packet *packet,
+	struct packet_info *data,
+	const uint16_t *seg_sizes,
+	size_t seg_count
+) {
+	if (seg_count == 0) {
+		return -1;
+	}
+
+	// Validate that the segment sizes sum to the total packet size.
+	uint32_t total = 0;
+	for (size_t i = 0; i < seg_count; i++) {
+		total += seg_sizes[i];
+	}
+	if (total != data->size) {
+		return -1;
+	}
+
+	// Allocate all segments, chaining as we go.
+	struct rte_mbuf *head = NULL;
+	struct rte_mbuf *prev = NULL;
+	uint32_t offset = 0;
+
+	for (size_t i = 0; i < seg_count; i++) {
+		uint16_t seg_len = seg_sizes[i];
+		size_t buf_len;
+		uint16_t data_off;
+
+		if (i == 0) {
+			buf_len = RTE_PKTMBUF_HEADROOM + seg_len;
+			data_off =
+				RTE_MIN(RTE_PKTMBUF_HEADROOM,
+					(uint16_t)buf_len);
+		} else {
+			buf_len = seg_len;
+			data_off = 0;
+		}
+
+		struct rte_mbuf *seg = alloc_seg(
+			data->data + offset, seg_len, buf_len, data_off
+		);
+		if (seg == NULL) {
+			// Free everything allocated so far.
+			struct rte_mbuf *s = head;
+			while (s != NULL) {
+				struct rte_mbuf *next = s->next;
+				free(s);
+				s = next;
+			}
+			return -1;
+		}
+
+		if (head == NULL) {
+			head = seg;
+		}
+		if (prev != NULL) {
+			prev->next = seg;
+		}
+		prev = seg;
+		offset += seg_len;
+	}
+
+	// Fix up the head: nb_segs and pkt_len cover the whole chain.
+	head->nb_segs = (uint16_t)seg_count;
+	head->pkt_len = data->size;
+
+	return init_packet_with_mbuf(packet, head, data);
 }
 
 int

--- a/lib/utils/packet.h
+++ b/lib/utils/packet.h
@@ -102,6 +102,24 @@ free_packet_list_custom_alloc(
 int
 fill_packet_from_data(struct packet *packet, struct packet_info *data);
 
+// Build a multi-segment (chained) packet from one contiguous buffer split
+// into seg_count segments of the given byte sizes (sum must equal data->size).
+//
+// Each segment mbuf is allocated tightly to its own segment length, so an
+// over-read past a segment's bytes is detectable by AddressSanitizer. The head
+// mbuf carries nb_segs and pkt_len (the total size); each segment carries its
+// own data_len and the next-pointer chain. Runs parse_packet on the head.
+//
+// Returns parse_packet's result, or -1 on allocation failure or when the
+// segment sizes do not sum to data->size.
+int
+fill_packet_from_segments(
+	struct packet *packet,
+	struct packet_info *data,
+	const uint16_t *seg_sizes,
+	size_t seg_count
+);
+
 void
 init_mbuf(struct rte_mbuf *m, struct packet_info *data, uint16_t buf_len);
 

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -25,6 +25,40 @@ struct fwstate {
 	struct fw_state_value value;
 };
 
+// Validate and return the sync-frame payload length from the IPv6 header.
+//
+// Returns false when the packet must be rejected — the header stack is not
+// fully resident (runt), the UDP claimed length is below the UDP header size
+// (underflow), or the claimed payload exceeds the bytes actually resident in
+// the first mbuf segment (over-claim / truncated).
+//
+// On success, *out is the claimed UDP payload length and is fully resident.
+// Callers must still check that *out is a non-zero multiple of the frame size.
+static inline bool
+fwstate_sync_payload_len(
+	const struct rte_mbuf *mbuf,
+	const struct rte_ipv6_hdr *ipv6_hdr,
+	uint16_t payload_offset,
+	uint16_t *out
+) {
+	uint16_t avail = rte_pktmbuf_data_len(mbuf);
+	if (avail < payload_offset) {
+		return false; // runt
+	}
+	uint16_t usable = avail - payload_offset;
+	uint16_t claimed = rte_be_to_cpu_16(ipv6_hdr->payload_len);
+	if (claimed < sizeof(struct rte_udp_hdr)) {
+		return false; // underflow
+	}
+	uint16_t claimed_payload =
+		claimed - (uint16_t)sizeof(struct rte_udp_hdr);
+	if (claimed_payload > usable) {
+		return false; // over-claim / truncated
+	}
+	*out = claimed_payload;
+	return true;
+}
+
 // Helper function to check if packet is a fw state sync packet
 static bool
 is_fw_state_sync_packet(
@@ -83,9 +117,17 @@ is_fw_state_sync_packet(
 		return false;
 	}
 
-	// Check if UDP payload size is a multiple of fw_state_sync_frame
-	uint16_t udp_payload_len = rte_be_to_cpu_16(ipv6_hdr->payload_len) -
-				   sizeof(struct rte_udp_hdr);
+	// Check if UDP payload size is a multiple of fw_state_sync_frame.
+	// Computes a bounded length to guard against underflow and over-claim.
+	const uint16_t payload_offset =
+		sizeof(struct rte_ether_hdr) + sizeof(struct rte_vlan_hdr) +
+		sizeof(struct rte_ipv6_hdr) + sizeof(struct rte_udp_hdr);
+	uint16_t udp_payload_len;
+	if (!fwstate_sync_payload_len(
+		    mbuf, ipv6_hdr, payload_offset, &udp_payload_len
+	    )) {
+		return false;
+	}
 	if (udp_payload_len % sizeof(struct fw_state_sync_frame) != 0) {
 		return false;
 	}
@@ -260,9 +302,13 @@ fwstate_handle_packets(
 		bool is_external =
 			(memcmp(ipv6_hdr->src_addr, (uint8_t[16]){0}, 16) != 0);
 
-		uint16_t udp_payload_len =
-			rte_be_to_cpu_16(ipv6_hdr->payload_len) -
-			sizeof(struct rte_udp_hdr);
+		uint16_t udp_payload_len;
+		if (!fwstate_sync_payload_len(
+			    mbuf, ipv6_hdr, payload_offset, &udp_payload_len
+		    )) {
+			packet_front_output(packet_front, packet);
+			continue;
+		}
 		size_t frame_count =
 			udp_payload_len / sizeof(struct fw_state_sync_frame);
 

--- a/modules/fwstate/tests/functional/fwstate_test.go
+++ b/modules/fwstate/tests/functional/fwstate_test.go
@@ -1,0 +1,281 @@
+package fwstate_test
+
+import (
+	"encoding/binary"
+	"net"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
+)
+
+// Memory sizes for the fwstate functional harness.
+const (
+	fwsCPSize  = 64 * datasize.MB
+	fwsDPSize  = 4 * datasize.MB
+	fwsMemSize = 16 * datasize.MB
+)
+
+// syncMulticastAddr is the IPv6 multicast destination configured on the fwstate module.
+var syncMulticastAddr = net.IP{0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+
+// syncPort is the UDP destination port for fwstate sync packets (host byte order).
+const syncPort = 9999
+
+// setupFWStateHarness builds a dataplane harness with the fwstate module and
+// a plain device, attaches a control-plane agent, and wires a minimal pipeline.
+// The returned agent and module config are ready for UpdateModules.
+func setupFWStateHarness(t *testing.T) (*dataplaneut.Harness, *ffi.Agent) {
+	t.Helper()
+
+	cfg := dataplaneut.Config{
+		CPMemory:      uint64(fwsCPSize),
+		DPMemory:      uint64(fwsDPSize),
+		WorkerCount:   1,
+		Devices:       []string{"port0"},
+		Modules:       []string{"fwstate"},
+		DevicesToLoad: []string{"plain"},
+	}
+	h, err := dataplaneut.NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("fwstate-test", 0, fwsMemSize)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	return h, agent
+}
+
+// configureFWState creates and publishes a fwstate module config with sync
+// enabled for syncMulticastAddr:syncPort, one worker, 1024-entry maps.
+func configureFWState(t *testing.T, agent *ffi.Agent, name string) {
+	t.Helper()
+
+	modCfg, err := cfwstate.NewModuleConfig(agent, name)
+	require.NoError(t, err)
+	t.Cleanup(modCfg.Free)
+
+	modCfg.SetSyncConfig(cfwstate.SyncConfig{
+		DstAddrMulticast: [16]byte{
+			0xff, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01,
+		},
+		PortMulticast: syncPort,
+		TcpSynAck:     uint64(120e9),
+		TcpSyn:        uint64(120e9),
+		TcpFin:        uint64(120e9),
+		Tcp:           uint64(120e9),
+		Udp:           uint64(30e9),
+		Default:       uint64(16e9),
+	})
+
+	require.NoError(t, modCfg.CreateMaps(cfwstate.MapConfig{
+		IndexSize:        1024,
+		ExtraBucketCount: 64,
+	}, 1))
+
+	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{modCfg.AsFFIModule()}))
+}
+
+// wireFWSPipeline wires chain[fwstate:name] into a pipeline bound to port0.
+func wireFWSPipeline(t *testing.T, agent *ffi.Agent, name string) {
+	t.Helper()
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: name,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name: name + "_chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "fwstate", Name: name},
+				},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      name,
+		Functions: []string{name},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name: "dummy",
+	}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: name, Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+}
+
+// buildSyncPacketLayers returns the gopacket layers for a fwstate sync packet:
+// Ethernet (VLAN) -> 802.1Q (IPv6) -> IPv6 (UDP) -> UDP -> syncFrame payload.
+//
+// srcIP6 is the IPv6 source address. An all-zero source marks an internal
+// originator; any non-zero source is external.
+func buildSyncPacketLayers(srcIP6 net.IP, syncFrame []byte) []gopacket.SerializableLayer {
+	eth := &layers.Ethernet{
+		SrcMAC:       net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+		DstMAC:       net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0x01}, // multicast
+		EthernetType: layers.EthernetTypeDot1Q,
+	}
+	dot1q := &layers.Dot1Q{
+		Type: layers.EthernetTypeIPv6,
+	}
+	// IPv6 payload_len = sizeof(UDP header) + sizeof(sync frame) = 8 + 56 = 64.
+	ip6 := &layers.IPv6{
+		Version:    6,
+		NextHeader: layers.IPProtocolUDP,
+		HopLimit:   64,
+		SrcIP:      srcIP6,
+		DstIP:      syncMulticastAddr,
+	}
+	udp := &layers.UDP{
+		SrcPort: layers.UDPPort(12345),
+		DstPort: layers.UDPPort(syncPort),
+	}
+	_ = udp.SetNetworkLayerForChecksum(ip6)
+	payload := gopacket.Payload(syncFrame)
+	return []gopacket.SerializableLayer{eth, dot1q, ip6, udp, payload}
+}
+
+// buildSyncFrame builds a 56-byte fw_state_sync_frame with the given addresses.
+// addr_type=6 indicates an IPv6 state entry.
+func buildSyncFrame(srcIP6, dstIP6 net.IP) []byte {
+	// fw_state_sync_frame layout (56 bytes, packed):
+	//   dst_ip      uint32  [0:4]
+	//   src_ip      uint32  [4:8]
+	//   dst_port    uint16  [8:10]
+	//   src_port    uint16  [10:12]
+	//   fib         uint8   [12]
+	//   proto       uint8   [13]
+	//   flags       uint8   [14]   (union, 1 byte)
+	//   addr_type   uint8   [15]
+	//   dst_ip6     [16]byte [16:32]
+	//   src_ip6     [16]byte [32:48]
+	//   flow_id6    uint32  [48:52]
+	//   extra       uint32  [52:56]
+	frame := make([]byte, 56)
+	frame[13] = uint8(layers.IPProtocolUDP) // proto
+	frame[15] = 6                           // addr_type = IPv6
+	copy(frame[16:32], dstIP6.To16())
+	copy(frame[32:48], srcIP6.To16())
+	return frame
+}
+
+// buildSyncHeaderBytes returns the 66 on-wire bytes that precede the UDP payload
+// for a fwstate sync packet (Ethernet 14 + VLAN 4 + IPv6 40 + UDP 8).
+//
+// payloadLen is the UDP payload length in bytes (IPv6 payload_len = 8 + payloadLen).
+func buildSyncHeaderBytes(srcIP6 net.IP, payloadLen uint16) []byte {
+	hdr := make([]byte, 66)
+
+	// Ethernet header (14 bytes): dst, src, ether_type=0x8100 (VLAN)
+	copy(hdr[0:6], []byte{0x33, 0x33, 0x00, 0x00, 0x00, 0x01}) // multicast dst
+	copy(hdr[6:12], []byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff})
+	binary.BigEndian.PutUint16(hdr[12:14], 0x8100) // EtherType VLAN
+
+	// 802.1Q header (4 bytes): TCI=0, ether_type=0x86DD (IPv6)
+	binary.BigEndian.PutUint16(hdr[14:16], 0x0000) // TCI (VLAN 0, priority 0)
+	binary.BigEndian.PutUint16(hdr[16:18], 0x86dd) // EtherType IPv6
+
+	// IPv6 header (40 bytes) at offset 18.
+	// version=6, traffic class=0, flow label=0
+	hdr[18] = 0x60
+	// payload_len = 8 (UDP header) + payloadLen
+	ip6PayloadLen := uint16(8) + payloadLen
+	binary.BigEndian.PutUint16(hdr[22:24], ip6PayloadLen)
+	hdr[24] = uint8(layers.IPProtocolUDP) // next header
+	hdr[25] = 64                          // hop limit
+	copy(hdr[26:42], net.IPv6zero)        // src
+	if len(srcIP6) > 0 {
+		copy(hdr[26:42], srcIP6.To16())
+	}
+	copy(hdr[42:58], syncMulticastAddr.To16()) // dst
+
+	// UDP header (8 bytes) at offset 58.
+	binary.BigEndian.PutUint16(hdr[58:60], 12345)    // src port
+	binary.BigEndian.PutUint16(hdr[60:62], syncPort) // dst port
+	udpLen := uint16(8) + payloadLen
+	binary.BigEndian.PutUint16(hdr[62:64], udpLen) // length
+	binary.BigEndian.PutUint16(hdr[64:66], 0)      // checksum (zero, not verified)
+
+	return hdr
+}
+
+// TestFWStateSyncPacketOOBGuard is a regression test for the fwstate
+// sync-packet OOB read (#568).
+//
+// Pre-fix, fwstate accessed sync frames contiguously from segment 0 of the
+// mbuf via rte_pktmbuf_mtod_offset, walking off segment 0's tight buffer when
+// the payload was in segment 1. Post-fix, the rte_pktmbuf_data_len bound check
+// in fwstate_sync_payload_len rejects such packets as non-contiguous-sync and
+// passes them to output unchanged.
+func TestFWStateSyncPacketOOBGuard(t *testing.T) {
+	externalSrc := net.IP{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	internalSrc := net.IPv6zero
+	syncFrame := buildSyncFrame(externalSrc, syncMulticastAddr)
+
+	t.Run("well_formed_external", func(t *testing.T) {
+		// A fully contiguous, well-formed sync packet from an external source
+		// must be consumed by fwstate: it is processed and dropped (not forwarded).
+		h, agent := setupFWStateHarness(t)
+		configureFWState(t, agent, "test")
+		wireFWSPipeline(t, agent, "test")
+
+		pkt := xpacket.LayersToPacket(t, buildSyncPacketLayers(externalSrc, syncFrame)...)
+		result, err := h.HandlePackets(pkt)
+		require.NoError(t, err)
+		require.Len(t, result.Drop, 1, "external sync packet must be consumed (dropped)")
+		require.Empty(t, result.Output, "external sync packet must not reach output")
+	})
+
+	t.Run("multiseg_external", func(t *testing.T) {
+		// THE reproducer: headers in segment 0, sync frame in segment 1.
+		//
+		// The IPv6 payload_len field is set consistently (8+56=64) so parse_packet
+		// accepts the packet. Post-fix, fwstate_sync_payload_len rejects it because
+		// claimed_payload (56) > bytes resident in segment 0 (0 past the headers),
+		// so the packet is passed to output. Pre-fix, fwstate walks off segment 0.
+		h, agent := setupFWStateHarness(t)
+		configureFWState(t, agent, "test")
+		wireFWSPipeline(t, agent, "test")
+
+		seg0 := buildSyncHeaderBytes(externalSrc, uint16(len(syncFrame)))
+		seg1 := make([]byte, len(syncFrame))
+		copy(seg1, syncFrame)
+
+		rawResult, err := h.HandleSegmentedPackets([][]byte{seg0, seg1})
+		require.NoError(t, err)
+		// Post-fix: packet is rejected as non-contiguous-sync and passed through.
+		require.Len(t, rawResult.Output, 1, "multi-segment external sync must be passed through post-fix")
+		require.Empty(t, rawResult.Drop, "multi-segment external sync must not be dropped post-fix")
+	})
+
+	t.Run("multiseg_internal", func(t *testing.T) {
+		// Same two-segment split but with an all-zero IPv6 source (internal
+		// originator). Post-fix, the rte_pktmbuf_data_len bound rejects it
+		// before the internal/external check, so the packet reaches output.
+		h, agent := setupFWStateHarness(t)
+		configureFWState(t, agent, "test")
+		wireFWSPipeline(t, agent, "test")
+
+		internalFrame := buildSyncFrame(internalSrc, syncMulticastAddr)
+		seg0 := buildSyncHeaderBytes(internalSrc, uint16(len(internalFrame)))
+		seg1 := make([]byte, len(internalFrame))
+		copy(seg1, internalFrame)
+
+		rawResult, err := h.HandleSegmentedPackets([][]byte{seg0, seg1})
+		require.NoError(t, err)
+		// Post-fix: non-contiguous packet is passed through regardless of source.
+		require.Len(t, rawResult.Output, 1, "multi-segment internal sync must be passed through post-fix")
+		require.Empty(t, rawResult.Drop, "multi-segment internal sync must not be dropped post-fix")
+	})
+}


### PR DESCRIPTION
The fwstate sync-packet parser computed the UDP payload length by subtracting the UDP header size from the IPv6 payload length with no bounds check, so a truncated, underflowing, or over-claiming packet drove a frame-count loop that read past the mbuf — an out-of-bounds read on attacker-influenced input.

Add a single helper that validates the claimed length against the bytes actually resident in the first mbuf segment and rejects runt, underflow, and over-claim packets, routing both parse sites through it. Rejected packets are treated as non-sync and passed through unchanged, so they reach neither the frame loop nor the internal-packet checksum recompute.

Closes #568.