### PR TITLE
feat: open YAML preview from command-palette save on functions and pipelines

### DIFF
--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -36,6 +36,7 @@ const FunctionsPage = (): React.JSX.Element => {
     const [availableModuleConfigNames, setAvailableModuleConfigNames] = useState<string[]>([]);
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [flashId, setFlashId] = useState<string | null>(null);
+    const [diffOpenId, setDiffOpenId] = useState<string | null>(null);
     const { dragState, startDrag, endDrag } = useDragState();
 
     useEffect(() => {
@@ -117,14 +118,14 @@ const FunctionsPage = (): React.JSX.Element => {
                     id: `__save_${fn.id}`,
                     icon: '✓',
                     label: `Save ${fn.id}`,
-                    sub: 'Save unsaved changes',
+                    sub: 'Preview YAML diff before saving',
                     keywords: 'save commit apply',
-                    onSelect: () => saveFn(fn.id),
+                    onSelect: () => setDiffOpenId(fn.id),
                 });
             }
         }
         return list;
-    }, [functions, isDirty, saveFn]);
+    }, [functions, isDirty]);
 
     const rowAdapter = useMemo((): RowAdapter<NetworkFunction> => ({
         rows: functions,
@@ -186,6 +187,9 @@ const FunctionsPage = (): React.JSX.Element => {
                             onSave={handleSave(fn.id)}
                             onDiscard={handleDiscard(fn.id)}
                             onDelete={handleDelete(fn.id)}
+                            diffOpen={diffOpenId === fn.id}
+                            onOpenDiff={() => setDiffOpenId(fn.id)}
+                            onCloseDiff={() => setDiffOpenId(null)}
                             flash={flashId === fn.id}
                         />
                     ))

--- a/web/src/pages/builtin/functions/components/FunctionCard.tsx
+++ b/web/src/pages/builtin/functions/components/FunctionCard.tsx
@@ -24,6 +24,9 @@ interface FunctionCardProps {
     onSave: () => Promise<void>;
     onDiscard: () => void;
     onDelete: () => Promise<boolean>;
+    diffOpen: boolean;
+    onOpenDiff: () => void;
+    onCloseDiff: () => void;
     flash?: boolean;
 }
 
@@ -46,10 +49,12 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
     onSave,
     onDiscard,
     onDelete,
+    diffOpen,
+    onOpenDiff,
+    onCloseDiff,
     flash,
 }) => {
     const [collapsed, setCollapsed] = useState(false);
-    const [diffOpen, setDiffOpen] = useState(false);
     const [drawerSelection, setDrawerSelection] = useState<
         { kind: 'module'; moduleId: string; chainId: string } |
         { kind: 'chain'; chainId: string } |
@@ -211,14 +216,6 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
 
     const saveErrors = useMemo(() => validateSave(fn), [fn]);
 
-    const handleOpenDiff = useCallback((): void => {
-        setDiffOpen(true);
-    }, []);
-
-    const handleCloseDiff = useCallback((): void => {
-        setDiffOpen(false);
-    }, []);
-
     return (
         <div
             id={`fn-card-${fn.id}`}
@@ -232,7 +229,7 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
                 totalPps={totalPps}
                 sparklineData={sparklineData}
                 onToggleCollapse={() => setCollapsed(c => !c)}
-                onOpenDiff={handleOpenDiff}
+                onOpenDiff={onOpenDiff}
                 onDiscard={onDiscard}
                 onDelete={onDelete}
             />
@@ -362,7 +359,7 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
                     fn={fn}
                     serverFn={serverFn}
                     saveErrors={saveErrors}
-                    onClose={handleCloseDiff}
+                    onClose={onCloseDiff}
                     onApply={onSave}
                 />
             )}

--- a/web/src/pages/builtin/pipelines/PipelinesPage.tsx
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.tsx
@@ -21,6 +21,7 @@ const PipelinesPage = (): React.JSX.Element => {
     const { pipelines, loading, isDirty, getServerPipeline, dispatch, savePipeline, discardPipeline, createPipeline, deletePipeline, loadFunctionList } = usePipelinesData();
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [flashId, setFlashId] = useState<string | null>(null);
+    const [diffOpenId, setDiffOpenId] = useState<string | null>(null);
     const { dragState, startDrag, endDrag } = useDragState();
 
     const anyDirty = useMemo(
@@ -61,14 +62,14 @@ const PipelinesPage = (): React.JSX.Element => {
                     id: `__save_${pl.id}`,
                     icon: '✓',
                     label: `Save ${pl.id}`,
-                    sub: 'Save unsaved changes',
+                    sub: 'Preview YAML diff before saving',
                     keywords: 'save commit apply',
-                    onSelect: () => savePipeline(pl.id),
+                    onSelect: () => setDiffOpenId(pl.id),
                 });
             }
         }
         return list;
-    }, [pipelines, isDirty, savePipeline]);
+    }, [pipelines, isDirty]);
 
     const rowAdapter = useMemo((): RowAdapter<Pipeline> => ({
         rows: pipelines,
@@ -128,6 +129,9 @@ const PipelinesPage = (): React.JSX.Element => {
                             onDiscard={handleDiscard(pl.id)}
                             onDelete={handleDelete(pl.id)}
                             loadFunctionList={loadFunctionList}
+                            diffOpen={diffOpenId === pl.id}
+                            onOpenDiff={() => setDiffOpenId(pl.id)}
+                            onCloseDiff={() => setDiffOpenId(null)}
                             flash={flashId === pl.id}
                         />
                     ))

--- a/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
+++ b/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
@@ -22,6 +22,9 @@ interface PipelineCardProps {
     onDiscard: () => void;
     onDelete: () => Promise<boolean>;
     loadFunctionList: () => Promise<FunctionId[]>;
+    diffOpen: boolean;
+    onOpenDiff: () => void;
+    onCloseDiff: () => void;
     flash?: boolean;
 }
 
@@ -40,10 +43,12 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
     onDiscard,
     onDelete,
     loadFunctionList,
+    diffOpen,
+    onOpenDiff,
+    onCloseDiff,
     flash,
 }) => {
     const [collapsed, setCollapsed] = useState(false);
-    const [diffOpen, setDiffOpen] = useState(false);
     const [drawerRefId, setDrawerRefId] = useState<string | null>(null);
 
     const refInfoList: FunctionRefInfo[] = useMemo(() =>
@@ -125,7 +130,7 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
                 totalPps={totalPps}
                 sparklineData={sparklineData}
                 onToggleCollapse={() => setCollapsed(c => !c)}
-                onOpenDiff={() => setDiffOpen(true)}
+                onOpenDiff={onOpenDiff}
                 onDiscard={onDiscard}
                 onDelete={onDelete}
             />
@@ -173,7 +178,7 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
                 <DiffModal
                     pipeline={pipeline}
                     serverPipeline={serverPipeline}
-                    onClose={() => setDiffOpen(false)}
+                    onClose={onCloseDiff}
                     onApply={onSave}
                 />
             )}


### PR DESCRIPTION
The command-palette "Save <id>" action on the Functions and Pipelines pages now opens the review-changes YAML preview dialog instead of committing immediately.

This matches the behaviour of the per-card save button and the Forward page, where save always routes through the YAML diff preview before applying. The diff-open state is lifted to the page level so the header save button and the command palette drive the same dialog.