### PR TITLE
fix(cli): adapt table output to terminal width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,6 +2204,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3084,6 +3094,7 @@ dependencies = [
  "simple_logger",
  "ssh-key",
  "tabled",
+ "terminal_size",
  "thiserror",
  "tokio",
  "tonic",

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4"
 simple_logger = { version = "5", features = ["timestamps", "stderr"] }
 colored = "3"
 tabled = { version = "0.18", features = ["ansi"] }
+terminal_size = "0.4"
 tokio = { version = "1", features = ["net", "io-util", "time", "sync"] }
 prost = "0.13"
 tonic = { version = "0.13", features = ["gzip"] }

--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -1,11 +1,13 @@
 use tabled::{
     settings::{
         object::{Columns, Rows},
+        peaker::Priority,
         style::{BorderColor, HorizontalLine},
-        Color, Style,
+        Color, Style, Width,
     },
     Table, Tabled,
 };
+use terminal_size::terminal_size_of;
 
 /// Print a table to stdout.
 pub fn print_table_from_entries<I, T>(entries: I)
@@ -19,7 +21,23 @@ where
 
 pub fn print_table(mut table: Table) {
     apply_style(&mut table);
+    fit_terminal_width(&mut table);
     println!("{table}");
+}
+
+/// Wrap the widest column(s) so the rendered table fits the current terminal
+/// width.
+///
+/// Width is detected from stdout. When stdout is not a TTY (piped or
+/// redirected) the width is unknown and the table is left unconstrained.
+pub fn fit_terminal_width(table: &mut Table) {
+    if let Some((terminal_size::Width(cols), _)) = terminal_size_of(std::io::stdout()) {
+        table.with(
+            Width::wrap(cols as usize)
+                .priority(Priority::max(false))
+                .keep_words(true),
+        );
+    }
 }
 
 /// Apply the standard YANET table style to `table`.

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -176,6 +176,7 @@ fn render_table(rows: &[ServiceRow]) {
         table.modify(Rows::first(), Color::BOLD);
     }
 
+    ync::display::fit_terminal_width(&mut table);
     println!("{table}");
 }
 

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -160,6 +160,7 @@ fn print_metrics_table(rows: Vec<MetricRow>) {
         table.modify(Rows::first(), Color::BOLD);
     }
 
+    ync::display::fit_terminal_width(&mut table);
     println!("{table}");
 }
 

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -206,6 +206,7 @@ fn print_readiness_table(rows: Vec<ReadinessRow>) {
         table.modify(Rows::first(), Color::BOLD);
     }
 
+    ync::display::fit_terminal_width(&mut table);
     println!("{table}");
 }
 

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -253,5 +253,6 @@ where
     table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
     table.modify(Rows::first(), Color::BOLD);
 
+    ync::display::fit_terminal_width(&mut table);
     println!("{table}");
 }

--- a/operators/forward/cli/src/main.rs
+++ b/operators/forward/cli/src/main.rs
@@ -292,6 +292,7 @@ fn print_readiness_table(rows: Vec<ReadinessRow>) {
         table.modify(Rows::first(), Color::BOLD);
     }
 
+    ync::display::fit_terminal_width(&mut table);
     println!("{table}");
 }
 

--- a/operators/pipeline/cli/src/main.rs
+++ b/operators/pipeline/cli/src/main.rs
@@ -321,6 +321,7 @@ fn print_readiness_table(rows: Vec<ReadinessRow>) {
         table.modify(Rows::first(), Color::BOLD);
     }
 
+    ync::display::fit_terminal_width(&mut table);
     println!("{table}");
 }
 

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -580,6 +580,7 @@ fn print_route_table(entries: Vec<RouteEntry>) {
         table.modify(Rows::first(), Color::BOLD);
     }
 
+    ync::display::fit_terminal_width(&mut table);
     println!("{table}");
 }
 
@@ -689,6 +690,7 @@ fn print_readiness_table(rows: Vec<ReadinessRow>) {
         table.modify(Rows::first(), Color::BOLD);
     }
 
+    ync::display::fit_terminal_width(&mut table);
     println!("{table}");
 }
 


### PR DESCRIPTION
Wrap the widest table column to fit the detected terminal width, so wide cells (e.g. the readiness `Reasons` column) no longer overflow and mangle CLI output.

- Add `fit_terminal_width` in the shared CLI display helper, detecting width from stdout via `terminal_size`. No hardcoded width.
- When stdout is not a TTY (piped or redirected), width is unknown and the table is left unconstrained.
- Apply it to every `tabled` render path: the shared `print_table` (covers acl/balancer2) plus the ready, gateway, metrics, route, and pipeline/forward/route operator CLIs.