### PR TITLE
fix(route): refresh readiness observed_at for edge-driven scopes

### DIFF
--- a/common/go/operator/readiness.go
+++ b/common/go/operator/readiness.go
@@ -184,6 +184,24 @@ func (m *Readiness) set(scope string, state readinesspb.State, reason *readiness
 	m.logTransition(s.name, prev, state, reason)
 }
 
+// Touch advances observed_at for an existing scope without changing its state.
+//
+// It records that the underlying source was successfully re-evaluated, so
+// freshness consumers can distinguish a live scope from one whose last event
+// was long ago. Touch is a no-op for unknown scopes — it never creates a
+// scope. state, reason, and lastTransitionTime are left unchanged.
+func (m *Readiness) Touch(scope string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	s, ok := m.scopes[scope]
+	if !ok {
+		return
+	}
+
+	s.observedAt = time.Now()
+}
+
 // Drain marks every scope as STATE_NOT_READY with a SHUTTING_DOWN reason.
 //
 // last_transition_time is updated only for scopes that change state.

--- a/common/go/operator/readiness_test.go
+++ b/common/go/operator/readiness_test.go
@@ -3,6 +3,7 @@ package operator_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -317,6 +318,54 @@ func TestReadiness_Set_ReasonsUpdated(t *testing.T) {
 
 	resp2 := r.Ready(&readinesspb.ReadyRequest{})
 	assert.Empty(t, resp2.Scopes[0].Reasons)
+}
+
+func TestReadiness_Touch_AdvancesObservedAt(t *testing.T) {
+	r := operator.NewReadiness([]string{"neighbours"})
+
+	// Drive the scope to a known state.
+	r.SetWithReason("neighbours",
+		readinesspb.State_STATE_READY,
+		&readinesspb.Reason{Code: "SYNCED"},
+	)
+
+	resp1 := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp1.Scopes, 1)
+	s1 := resp1.Scopes[0]
+
+	obs1 := s1.ObservedAt.AsTime()
+	ltt1 := s1.LastTransitionTime.AsTime()
+	wantState := s1.State
+	wantReason := s1.Reasons[0].Code
+
+	// Sleep a small amount so the clock advances reliably.
+	time.Sleep(2 * time.Millisecond)
+
+	r.Touch("neighbours")
+
+	resp2 := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp2.Scopes, 1)
+	s2 := resp2.Scopes[0]
+
+	obs2 := s2.ObservedAt.AsTime()
+	ltt2 := s2.LastTransitionTime.AsTime()
+
+	assert.True(t, obs2.After(obs1), "Touch must advance observed_at")
+	assert.Equal(t, ltt1, ltt2, "Touch must not change last_transition_time")
+	assert.Equal(t, wantState, s2.State, "Touch must not change state")
+	require.Len(t, s2.Reasons, 1)
+	assert.Equal(t, wantReason, s2.Reasons[0].Code, "Touch must not change reason")
+}
+
+func TestReadiness_Touch_UnknownScope_NoOp(t *testing.T) {
+	r := operator.NewReadiness([]string{"neighbours"})
+
+	// Touch an unknown scope must not panic and must not create the scope.
+	r.Touch("bird-session")
+
+	resp := r.Ready(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.Scopes, 1)
+	assert.Equal(t, "neighbours", resp.Scopes[0].Name)
 }
 
 // newObservedReadiness constructs a Readiness tracker backed by a zap

--- a/operators/route/internal/discovery/neigh/neigh.go
+++ b/operators/route/internal/discovery/neigh/neigh.go
@@ -84,12 +84,27 @@ func WithOnResynced(fn func()) Option {
 	}
 }
 
+// WithOnHealthy registers a callback invoked after every successful neighbour
+// table refresh.
+//
+// It fires after each successful refresh — whether during bootstrap, the
+// periodic ticker, or an event-driven update — signalling that the source is
+// live. This is distinct from OnSynced and OnResynced, which are
+// episode-edged (fire once per initial sync or once per recovery). OnHealthy
+// fires on every success regardless of episode state.
+func WithOnHealthy(fn func()) Option {
+	return func(o *options) {
+		o.OnHealthy = fn
+	}
+}
+
 type options struct {
 	UpdateInterval time.Duration
 	LinkMap        map[string]string
 	OnSynced       func()
 	OnError        func(error)
 	OnResynced     func()
+	OnHealthy      func()
 	Log            *zap.Logger
 }
 
@@ -100,6 +115,7 @@ func newOptions() *options {
 		OnSynced:       func() {},
 		OnError:        func(error) {},
 		OnResynced:     func() {},
+		OnHealthy:      func() {},
 		Log:            zap.NewNop(),
 	}
 }
@@ -119,6 +135,7 @@ type NeighMonitor struct {
 	onSyncedFn     func()
 	onErrorFn      func(error)
 	onResyncedFn   func()
+	onHealthyFn    func()
 
 	// synced is set to true once the first successful update completes and
 	// never reverts.
@@ -146,6 +163,7 @@ func NewNeighMonitor(neighTable *NeighTable, source *NeighSource, options ...Opt
 		onSyncedFn:     opts.OnSynced,
 		onErrorFn:      opts.OnError,
 		onResyncedFn:   opts.OnResynced,
+		onHealthyFn:    opts.OnHealthy,
 		log:            opts.Log,
 	}
 
@@ -376,5 +394,6 @@ func (m *NeighMonitor) updateNeighbours() error {
 	}
 
 	m.log.Info("updated nexthop cache", zap.Int("size", len(nexthopCache)))
+	m.onHealthyFn()
 	return nil
 }

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -103,6 +103,9 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			neigh.WithOnResynced(func() {
 				tracker.Set("neighbours", readinesspb.State_STATE_READY)
 			}),
+			neigh.WithOnHealthy(func() {
+				tracker.Touch("neighbours")
+			}),
 		}
 	}
 

--- a/operators/route/internal/operator/rib_readiness.go
+++ b/operators/route/internal/operator/rib_readiness.go
@@ -219,6 +219,9 @@ func (m *birdRIBReadiness) tick(now time.Time, rate float64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Re-stamp bird-session freshness each tick; tick re-confirms session liveness.
+	m.tracker.Touch("bird-session")
+
 	if !m.bulkSettled {
 		if rate < m.rateThreshold {
 			if m.belowSince.IsZero() {


### PR DESCRIPTION
- The readiness tracker's `observed_at` only advanced when a scope was written, so the polling-driven `fib:*` and `rib` scopes stayed fresh while the edge-driven `neighbours` and `bird-session` scopes froze their timestamp at the last state transition, making the CLI `Observed` column misleading.
- Added a `Touch` primitive to the shared readiness tracker that advances a scope's `observed_at` without changing its state, reason, or last transition time, and is a no-op for unknown scopes.
- Fired it on each genuine periodic re-confirmation: every successful neighbour table refresh re-stamps `neighbours`, and each BIRD/RIB sampling tick re-stamps `bird-session`. No blanket ticker — each re-stamp corresponds to a real successful re-check, so the column reflects true liveness rather than synthetic freshness.
- Added unit tests for `Touch` covering the observed-only invariant and the unknown-scope no-op.