### PR TITLE
fix(web): stabilize page header across load states

### DIFF
--- a/web/src/pages/builtin/devices/DevicesPage.tsx
+++ b/web/src/pages/builtin/devices/DevicesPage.tsx
@@ -103,19 +103,22 @@ const DevicesPage: React.FC = () => {
         return false;
     }, [selectedDevice, saveDevice]);
 
+    const canCreate = !loading && !(error && devices.length === 0);
+
     const { setPageContribution } = usePalette();
 
     const commands = useMemo((): Command[] => {
-        const list: Command[] = [
-            {
+        const list: Command[] = [];
+        if (canCreate) {
+            list.push({
                 id: '__create_device',
                 icon: '+',
                 label: 'Create device',
                 sub: 'Open the create device dialog',
                 keywords: 'create new device add',
                 onSelect: () => handleCreateDevice(),
-            },
-        ];
+            });
+        }
         if (selectedDevice?.isDirty) {
             list.push({
                 id: '__save_device',
@@ -148,7 +151,7 @@ const DevicesPage: React.FC = () => {
             onSelect: () => setGrouping('parent'),
         });
         return list;
-    }, [selectedDevice, handleCreateDevice, handleSaveDevice]);
+    }, [canCreate, selectedDevice, handleCreateDevice, handleSaveDevice]);
 
     const rowAdapter = useMemo((): RowAdapter<LocalDevice> => ({
         rows: devices,
@@ -185,55 +188,45 @@ const DevicesPage: React.FC = () => {
         <CommandPaletteHeader
             title="Devices"
             placeholder="Search devices or run an action…"
-            actions={<Button view="action" onClick={handleCreateDevice}>
+            actions={<Button view="action" onClick={handleCreateDevice} disabled={!canCreate}>
                 <Icon data={Plus} size={16} />
                 Create Device
             </Button>}
         />
     );
 
-    if (loading) {
-        return (
-            <PageLayout title="Devices">
-                <PageLoader loading={loading} size="l" />
-            </PageLayout>
-        );
-    }
-
-    if (error && devices.length === 0) {
-        return (
-            <PageLayout title="Devices">
-                <EmptyState message={error} />
-            </PageLayout>
-        );
-    }
-
     return (
         <PageLayout header={headerContent}>
-            <div className="devices-page-v2">
-                <div className="dv-workspace">
-                    <DevicesList
-                        devices={devices}
-                        selectedDeviceName={selectedDeviceName}
-                        grouping={grouping}
-                        onGroupingChange={setGrouping}
-                        onSelectDevice={handleSelectDevice}
-                        counters={counters}
-                        history={history}
-                        filter={deviceFilter}
-                        onFilterChange={setDeviceFilter}
-                    />
-                    <DeviceDetails
-                        device={selectedDevice}
-                        loadPipelineList={loadPipelineList}
-                        counterData={selectedCounterData}
-                        history={selectedHistory}
-                        onUpdate={handleUpdateDevice}
-                        onSave={handleSaveDevice}
-                        getServerDevice={getServerDevice}
-                    />
+            {loading ? (
+                <PageLoader loading={loading} size="l" />
+            ) : (error && devices.length === 0) ? (
+                <EmptyState message={error} />
+            ) : (
+                <div className="devices-page-v2">
+                    <div className="dv-workspace">
+                        <DevicesList
+                            devices={devices}
+                            selectedDeviceName={selectedDeviceName}
+                            grouping={grouping}
+                            onGroupingChange={setGrouping}
+                            onSelectDevice={handleSelectDevice}
+                            counters={counters}
+                            history={history}
+                            filter={deviceFilter}
+                            onFilterChange={setDeviceFilter}
+                        />
+                        <DeviceDetails
+                            device={selectedDevice}
+                            loadPipelineList={loadPipelineList}
+                            counterData={selectedCounterData}
+                            history={selectedHistory}
+                            onUpdate={handleUpdateDevice}
+                            onSave={handleSaveDevice}
+                            getServerDevice={getServerDevice}
+                        />
+                    </div>
                 </div>
-            </div>
+            )}
 
             <CreateDeviceDialog
                 open={createDialogOpen}

--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -102,16 +102,17 @@ const FunctionsPage = (): React.JSX.Element => {
     const { setPageContribution } = usePalette();
 
     const commands = useMemo((): Command[] => {
-        const list: Command[] = [
-            {
+        const list: Command[] = [];
+        if (!loading) {
+            list.push({
                 id: '__create_function',
                 icon: '+',
                 label: 'Create function',
                 sub: 'Open the create function dialog',
                 keywords: 'create new function add',
                 onSelect: () => setCreateDialogOpen(true),
-            },
-        ];
+            });
+        }
         for (const fn of functions) {
             if (isDirty(fn.id) && isFnSaveable(fn)) {
                 list.push({
@@ -125,7 +126,7 @@ const FunctionsPage = (): React.JSX.Element => {
             }
         }
         return list;
-    }, [functions, isDirty]);
+    }, [loading, functions, isDirty]);
 
     const rowAdapter = useMemo((): RowAdapter<NetworkFunction> => ({
         rows: functions,
@@ -150,51 +151,47 @@ const FunctionsPage = (): React.JSX.Element => {
         <CommandPaletteHeader
             title="Functions"
             placeholder="Search functions or run an action…"
-            actions={<Button view="action" onClick={() => setCreateDialogOpen(true)}>
+            actions={<Button view="action" onClick={() => setCreateDialogOpen(true)} disabled={loading}>
                 <Icon data={Plus} size={16} />
                 Create function
             </Button>}
         />
     );
 
-    if (loading) {
-        return (
-            <PageLayout title="Functions">
-                <PageLoader loading size="l" />
-            </PageLayout>
-        );
-    }
-
     return (
         <PageLayout header={headerContent}>
-            <div className="fn-page">
-                {functions.length === 0 ? (
-                    <EmptyState message='No functions found. Click "Create function" to add one.' />
-                ) : (
-                    functions.map(fn => (
-                        <FunctionCard
-                            key={fn.id}
-                            fn={fn}
-                            serverFn={getServerFn(fn.id)}
-                            isDirty={isDirty(fn.id)}
-                            availableModuleTypes={availableModuleTypes}
-                            availableModuleConfigNamesByType={availableModuleConfigNamesByType}
-                            availableModuleConfigNames={availableModuleConfigNames}
-                            dispatch={dispatch}
-                            dragState={dragState}
-                            onDragStart={startDrag}
-                            onDragEnd={endDrag}
-                            onSave={handleSave(fn.id)}
-                            onDiscard={handleDiscard(fn.id)}
-                            onDelete={handleDelete(fn.id)}
-                            diffOpen={diffOpenId === fn.id}
-                            onOpenDiff={() => setDiffOpenId(fn.id)}
-                            onCloseDiff={() => setDiffOpenId(null)}
-                            flash={flashId === fn.id}
-                        />
-                    ))
-                )}
-            </div>
+            {loading ? (
+                <PageLoader loading size="l" />
+            ) : (
+                <div className="fn-page">
+                    {functions.length === 0 ? (
+                        <EmptyState message='No functions found. Click "Create function" to add one.' />
+                    ) : (
+                        functions.map(fn => (
+                            <FunctionCard
+                                key={fn.id}
+                                fn={fn}
+                                serverFn={getServerFn(fn.id)}
+                                isDirty={isDirty(fn.id)}
+                                availableModuleTypes={availableModuleTypes}
+                                availableModuleConfigNamesByType={availableModuleConfigNamesByType}
+                                availableModuleConfigNames={availableModuleConfigNames}
+                                dispatch={dispatch}
+                                dragState={dragState}
+                                onDragStart={startDrag}
+                                onDragEnd={endDrag}
+                                onSave={handleSave(fn.id)}
+                                onDiscard={handleDiscard(fn.id)}
+                                onDelete={handleDelete(fn.id)}
+                                diffOpen={diffOpenId === fn.id}
+                                onOpenDiff={() => setDiffOpenId(fn.id)}
+                                onCloseDiff={() => setDiffOpenId(null)}
+                                flash={flashId === fn.id}
+                            />
+                        ))
+                    )}
+                </div>
+            )}
 
             <CreateEntityDialog
                 entityType="Function"

--- a/web/src/pages/builtin/pipelines/PipelinesPage.tsx
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.tsx
@@ -46,16 +46,17 @@ const PipelinesPage = (): React.JSX.Element => {
     const { setPageContribution } = usePalette();
 
     const commands = useMemo((): Command[] => {
-        const list: Command[] = [
-            {
+        const list: Command[] = [];
+        if (!loading) {
+            list.push({
                 id: '__create_pipeline',
                 icon: '+',
                 label: 'Create pipeline',
                 sub: 'Open the create pipeline dialog',
                 keywords: 'create new pipeline add',
                 onSelect: () => setCreateDialogOpen(true),
-            },
-        ];
+            });
+        }
         for (const pl of pipelines) {
             if (isDirty(pl.id)) {
                 list.push({
@@ -69,7 +70,7 @@ const PipelinesPage = (): React.JSX.Element => {
             }
         }
         return list;
-    }, [pipelines, isDirty]);
+    }, [loading, pipelines, isDirty]);
 
     const rowAdapter = useMemo((): RowAdapter<Pipeline> => ({
         rows: pipelines,
@@ -94,49 +95,45 @@ const PipelinesPage = (): React.JSX.Element => {
         <CommandPaletteHeader
             title="Pipelines"
             placeholder="Search pipelines or run an action…"
-            actions={<Button view="action" onClick={() => setCreateDialogOpen(true)}>
+            actions={<Button view="action" onClick={() => setCreateDialogOpen(true)} disabled={loading}>
                 <Icon data={Plus} size={16} />
                 Create pipeline
             </Button>}
         />
     );
 
-    if (loading) {
-        return (
-            <PageLayout title="Pipelines">
-                <PageLoader loading size="l" />
-            </PageLayout>
-        );
-    }
-
     return (
         <PageLayout header={headerContent}>
-            <div className="pl-page">
-                {pipelines.length === 0 ? (
-                    <EmptyState message='No pipelines found. Click "Create pipeline" to add one.' />
-                ) : (
-                    pipelines.map(pl => (
-                        <PipelineCard
-                            key={pl.id}
-                            pipeline={pl}
-                            serverPipeline={getServerPipeline(pl.id)}
-                            isDirty={isDirty(pl.id)}
-                            dispatch={dispatch}
-                            dragState={dragState}
-                            onDragStart={startDrag}
-                            onDragEnd={endDrag}
-                            onSave={handleSave(pl.id)}
-                            onDiscard={handleDiscard(pl.id)}
-                            onDelete={handleDelete(pl.id)}
-                            loadFunctionList={loadFunctionList}
-                            diffOpen={diffOpenId === pl.id}
-                            onOpenDiff={() => setDiffOpenId(pl.id)}
-                            onCloseDiff={() => setDiffOpenId(null)}
-                            flash={flashId === pl.id}
-                        />
-                    ))
-                )}
-            </div>
+            {loading ? (
+                <PageLoader loading size="l" />
+            ) : (
+                <div className="pl-page">
+                    {pipelines.length === 0 ? (
+                        <EmptyState message='No pipelines found. Click "Create pipeline" to add one.' />
+                    ) : (
+                        pipelines.map(pl => (
+                            <PipelineCard
+                                key={pl.id}
+                                pipeline={pl}
+                                serverPipeline={getServerPipeline(pl.id)}
+                                isDirty={isDirty(pl.id)}
+                                dispatch={dispatch}
+                                dragState={dragState}
+                                onDragStart={startDrag}
+                                onDragEnd={endDrag}
+                                onSave={handleSave(pl.id)}
+                                onDiscard={handleDiscard(pl.id)}
+                                onDelete={handleDelete(pl.id)}
+                                loadFunctionList={loadFunctionList}
+                                diffOpen={diffOpenId === pl.id}
+                                onOpenDiff={() => setDiffOpenId(pl.id)}
+                                onCloseDiff={() => setDiffOpenId(null)}
+                                flash={flashId === pl.id}
+                            />
+                        ))
+                    )}
+                </div>
+            )}
 
             <CreateEntityDialog
                 entityType="Pipeline"


### PR DESCRIPTION
Devices, Functions and Pipelines pages rendered a plain-title header while loading and swapped to the command-palette header bar once data arrived, so the centered search pill and the action buttons flickered into view on every page load.

- Collapse each of these pages to a single `PageLayout` with a stable `CommandPaletteHeader`, switching only the content between the loading, error, empty and loaded states.
- Match the existing Inspect page and the module/operator pages, where the header is already stable across load states.
- No behavioral change to loaders, empty/error messages, loaded content, or mounted dialogs; Inspect is left untouched.