### PR TITLE
feat(web): add keyboard shortcuts help overlay and list-nav hook

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,8 +4,8 @@ import MainMenu from './MainMenu';
 import { PageLoader } from './components';
 import type { PageId, SidebarContextValue } from './types';
 import { PAGE_IDS, SidebarContext } from './types';
-import { PaletteProvider, usePalette, CommandPalette, navigationCommands } from './components/command-palette';
-import type { RowAdapter } from './components/command-palette';
+import { PaletteProvider, usePalette, CommandPalette, navigationCommands, ShortcutsHelp } from './components/command-palette';
+import type { RowAdapter, Command } from './components/command-palette';
 
 const importInspect = () => import('./pages/builtin/inspect/InspectPage');
 const importDashboard = () => import('./pages/builtin/dashboard/DashboardPage');
@@ -57,13 +57,23 @@ type CancelIdleCallback = (id: IdleHandle) => void;
 
 /** Global command palette instance that reads contributions from context at render time. */
 const GlobalPalette = ({ handlePageChange }: { handlePageChange: (id: PageId) => void }): React.JSX.Element => {
-    const { open, closePalette, contribution } = usePalette();
+    const { open, closePalette, contribution, helpOpen, closeHelp, helpShortcuts, openHelp } = usePalette();
     const navCmds = useMemo(() => navigationCommands(handlePageChange), [handlePageChange]);
+
+    const showShortcutsCmd = useMemo((): Command => ({
+        id: '__show_shortcuts',
+        icon: '?',
+        label: 'Keyboard shortcuts',
+        keywords: 'help keys shortcuts hotkeys',
+        group: 'Go to',
+        // Defer so the palette's auto-close on select runs before the help opens.
+        onSelect: () => setTimeout(openHelp, 0),
+    }), [openHelp]);
 
     const commands = useMemo(() => {
         const pageCmds = contribution?.commands ?? [];
-        return [...pageCmds, ...navCmds];
-    }, [contribution, navCmds]);
+        return [...pageCmds, ...navCmds, showShortcutsCmd];
+    }, [contribution, navCmds, showShortcutsCmd]);
 
     const dynamicCommands = useMemo(() => {
         const pageDynamic = contribution?.dynamicCommands;
@@ -75,14 +85,21 @@ const GlobalPalette = ({ handlePageChange }: { handlePageChange: (id: PageId) =>
     const placeholder = contribution?.placeholder ?? 'Search or jump to a page…';
 
     return (
-        <CommandPalette<unknown>
-            open={open}
-            onClose={closePalette}
-            placeholder={placeholder}
-            commands={commands}
-            dynamicCommands={dynamicCommands}
-            rowAdapter={rowAdapter}
-        />
+        <>
+            <CommandPalette<unknown>
+                open={open}
+                onClose={closePalette}
+                placeholder={placeholder}
+                commands={commands}
+                dynamicCommands={dynamicCommands}
+                rowAdapter={rowAdapter}
+            />
+            <ShortcutsHelp
+                open={helpOpen}
+                onClose={closeHelp}
+                pageSections={helpShortcuts}
+            />
+        </>
     );
 };
 

--- a/web/src/components/command-palette/PaletteContext.tsx
+++ b/web/src/components/command-palette/PaletteContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import type { Command, RowAdapter } from './types';
+import type { Command, RowAdapter, ShortcutSection } from './types';
 import { usePaletteShortcut } from './usePaletteShortcut';
+import { useHelpShortcut } from './useHelpShortcut';
 
 /** The contribution that the active page registers with the global palette. */
 export interface PagePaletteContribution {
@@ -8,6 +9,8 @@ export interface PagePaletteContribution {
     dynamicCommands?: (query: string) => Command[];
     rowAdapter?: RowAdapter<unknown>;
     placeholder?: string;
+    /** Shortcut sections to display in the keyboard-shortcuts help overlay. */
+    shortcuts?: ShortcutSection[];
 }
 
 interface PaletteContextValue {
@@ -18,6 +21,11 @@ interface PaletteContextValue {
     setPageContribution: (contribution: PagePaletteContribution | null) => void;
     /** The snapshotted page contribution at the time the palette was opened, or null. */
     contribution: PagePaletteContribution | null;
+    helpOpen: boolean;
+    openHelp: () => void;
+    closeHelp: () => void;
+    /** Snapshotted shortcut sections at the time the help overlay was opened, or null. */
+    helpShortcuts: ShortcutSection[] | null;
 }
 
 const PaletteContext = createContext<PaletteContextValue>({
@@ -26,6 +34,10 @@ const PaletteContext = createContext<PaletteContextValue>({
     closePalette: () => {},
     setPageContribution: () => {},
     contribution: null,
+    helpOpen: false,
+    openHelp: () => {},
+    closeHelp: () => {},
+    helpShortcuts: null,
 });
 
 interface PaletteProviderProps {
@@ -35,13 +47,18 @@ interface PaletteProviderProps {
 /** Provides the global palette open state and page-contribution API. */
 export const PaletteProvider: React.FC<PaletteProviderProps> = ({ children }) => {
     const [open, setOpen] = useState(false);
+    const [helpOpen, setHelpOpen] = useState(false);
     const contributionRef = useRef<PagePaletteContribution | null>(null);
     const [activeContribution, setActiveContribution] = useState<PagePaletteContribution | null>(null);
+    const [helpShortcuts, setHelpShortcuts] = useState<ShortcutSection[] | null>(null);
 
     usePaletteShortcut(open, setOpen);
+    useHelpShortcut(open, helpOpen, setHelpOpen);
 
     const openPalette = useCallback(() => setOpen(true), []);
     const closePalette = useCallback(() => setOpen(false), []);
+    const openHelp = useCallback(() => setHelpOpen(true), []);
+    const closeHelp = useCallback(() => setHelpOpen(false), []);
 
     // Writing the ref is always stable and never triggers a re-render, so pages
     // whose memos produce a new identity on every render cannot cause a loop.
@@ -55,13 +72,23 @@ export const PaletteProvider: React.FC<PaletteProviderProps> = ({ children }) =>
         setActiveContribution(open ? contributionRef.current : null);
     }, [open]);
 
+    // Snapshot shortcut sections when the help overlay opens or closes.
+    useLayoutEffect(() => {
+        setHelpShortcuts(helpOpen ? (contributionRef.current?.shortcuts ?? null) : null);
+    }, [helpOpen]);
+
     const value = useMemo((): PaletteContextValue => ({
         open,
         openPalette,
         closePalette,
         setPageContribution,
         contribution: activeContribution,
-    }), [open, openPalette, closePalette, setPageContribution, activeContribution]);
+        helpOpen,
+        openHelp,
+        closeHelp,
+        helpShortcuts,
+    }), [open, openPalette, closePalette, setPageContribution, activeContribution,
+        helpOpen, openHelp, closeHelp, helpShortcuts]);
 
     return (
         <PaletteContext.Provider value={value}>

--- a/web/src/components/command-palette/ShortcutsHelp.tsx
+++ b/web/src/components/command-palette/ShortcutsHelp.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import type { ShortcutSection } from './types';
+import './shortcuts-help.scss';
+
+const GLOBAL_SECTION: ShortcutSection = {
+    title: 'Global',
+    items: [
+        { keys: '⌘K / Ctrl+K', desc: 'Open command palette' },
+        { keys: '?', desc: 'Show this help' },
+        { keys: '[ ]', desc: 'Cycle config tabs' },
+        { keys: '↑ ↓', desc: 'Move selection in a list' },
+        { keys: 'Enter', desc: 'Open the selected item' },
+        { keys: 'Esc', desc: 'Close overlay / clear selection' },
+        { keys: '⌘↵ / Ctrl+Enter', desc: 'Submit a dialog' },
+    ],
+};
+
+interface ShortcutsHelpProps {
+    open: boolean;
+    onClose: () => void;
+    pageSections: ShortcutSection[] | null;
+}
+
+/** Keyboard-shortcuts help overlay. Renders null when closed. */
+const ShortcutsHelp: React.FC<ShortcutsHelpProps> = ({ open, onClose, pageSections }) => {
+    if (!open) return null;
+
+    const sections = pageSections ? [GLOBAL_SECTION, ...pageSections] : [GLOBAL_SECTION];
+
+    return (
+        <div
+            className="cp-backdrop sh-backdrop"
+            onMouseDown={(e) => { if (e.target === e.currentTarget) onClose(); }}
+        >
+            <div className="sh-card">
+                <div className="sh-header">
+                    <span className="sh-title">Keyboard shortcuts</span>
+                    <kbd className="cp-esc-hint sh-esc">esc</kbd>
+                </div>
+                <div className="sh-body">
+                    {sections.map((section) => (
+                        <div key={section.title} className="sh-section">
+                            <div className="sh-section-title">{section.title}</div>
+                            {section.items.map((item) => (
+                                <div key={item.keys} className="sh-row">
+                                    <span className="sh-keys">
+                                        {item.keys.split('/').map((k, idx) => (
+                                            <React.Fragment key={idx}>
+                                                {idx > 0 && <span className="sh-sep">/</span>}
+                                                <kbd className="cp-kbd">{k.trim()}</kbd>
+                                            </React.Fragment>
+                                        ))}
+                                    </span>
+                                    <span className="sh-desc">{item.desc}</span>
+                                </div>
+                            ))}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ShortcutsHelp;

--- a/web/src/components/command-palette/index.ts
+++ b/web/src/components/command-palette/index.ts
@@ -1,10 +1,12 @@
 export { default as CommandPalette } from './CommandPalette';
 export type { CommandPaletteProps } from './CommandPalette';
-export type { Command, RowAdapter } from './types';
+export type { Command, RowAdapter, ShortcutSection, ShortcutItem } from './types';
 export { fuzzyMatch } from './fuzzy';
 export type { FuzzyMatchResult } from './fuzzy';
 export { default as CommandPaletteTrigger, PALETTE_SHORTCUT_LABEL } from './CommandPaletteTrigger';
 export { usePaletteShortcut } from './usePaletteShortcut';
+export { useHelpShortcut } from './useHelpShortcut';
 export { PaletteProvider, usePalette } from './PaletteContext';
 export type { PagePaletteContribution } from './PaletteContext';
 export { navigationCommands } from './navigationCommands';
+export { default as ShortcutsHelp } from './ShortcutsHelp';

--- a/web/src/components/command-palette/shortcuts-help.scss
+++ b/web/src/components/command-palette/shortcuts-help.scss
@@ -1,0 +1,99 @@
+@use '../../styles/variables' as *;
+@use '../../styles/mixins' as *;
+
+.sh-backdrop {
+    align-items: center;
+    padding-top: 0;
+}
+
+.sh-card {
+    width: 520px;
+    max-width: calc(100vw - 40px);
+    max-height: calc(100vh - 80px);
+    background: var(--yn-panel);
+    border: 1px solid var(--yn-line-2);
+    border-radius: var(--yn-r-lg);
+    box-shadow: 0 24px 72px rgba(0, 0, 0, 0.65);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    animation: cp-popin 0.14s ease-out both;
+    outline: none;
+}
+
+.sh-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 16px 12px;
+    border-bottom: 1px solid var(--yn-line-2);
+    flex-shrink: 0;
+}
+
+.sh-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--yn-text);
+    letter-spacing: 0.01em;
+}
+
+.sh-esc {
+    margin-left: 8px;
+}
+
+.sh-body {
+    overflow-y: auto;
+    padding: 8px 0 12px;
+}
+
+.sh-section {
+    padding: 0 6px 4px;
+
+    & + .sh-section {
+        margin-top: 4px;
+        padding-top: 4px;
+        border-top: 1px solid var(--yn-line-2);
+    }
+}
+
+.sh-section-title {
+    padding: 5px 10px 2px;
+    font-size: 10.5px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--yn-text-3);
+    user-select: none;
+}
+
+.sh-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 10px;
+    border-radius: var(--yn-r-md);
+
+    &:hover {
+        background: var(--yn-accent-soft);
+    }
+}
+
+.sh-keys {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 140px;
+    flex-shrink: 0;
+}
+
+.sh-sep {
+    font-size: 11px;
+    color: var(--yn-text-3);
+    padding: 0 2px;
+}
+
+.sh-desc {
+    font-size: 12.5px;
+    color: var(--yn-text-2);
+    flex: 1;
+}

--- a/web/src/components/command-palette/types.ts
+++ b/web/src/components/command-palette/types.ts
@@ -1,3 +1,19 @@
+/** A single shortcut entry shown in the help overlay. */
+export interface ShortcutItem {
+    /** Key combination label, e.g. "⌘K" or "↑ ↓". */
+    keys: string;
+    /** Short description of what the shortcut does. */
+    desc: string;
+}
+
+/** A grouped section of shortcut items shown in the help overlay. */
+export interface ShortcutSection {
+    /** Section heading, e.g. "Dashboard" or "Global". */
+    title: string;
+    /** Shortcut items in this section. */
+    items: ShortcutItem[];
+}
+
 /** A command item displayed in the palette. */
 export interface Command {
     /** Unique identifier for this command. */

--- a/web/src/components/command-palette/useHelpShortcut.ts
+++ b/web/src/components/command-palette/useHelpShortcut.ts
@@ -1,0 +1,38 @@
+import React, { useEffect } from 'react';
+
+/** Wires the ? key to toggle the keyboard-shortcuts help overlay, and Escape to close it. */
+export const useHelpShortcut = (
+    paletteOpen: boolean,
+    helpOpen: boolean,
+    setHelpOpen: React.Dispatch<React.SetStateAction<boolean>>,
+): void => {
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            if (e.key === 'Escape' && helpOpen) {
+                setHelpOpen(false);
+                return;
+            }
+
+            if (e.key === '?') {
+                if (paletteOpen) return;
+                if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+                const target = e.target as HTMLElement;
+                if (
+                    target.tagName === 'INPUT' ||
+                    target.tagName === 'TEXTAREA' ||
+                    target.isContentEditable
+                ) {
+                    return;
+                }
+
+                if (document.querySelector('.g-modal, .yn-modal-backdrop, .yn-drawer--open')) return;
+                e.preventDefault();
+                setHelpOpen((prev) => !prev);
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [paletteOpen, helpOpen, setHelpOpen]);
+};

--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -36,3 +36,5 @@ export type { UseConfigQuerySyncOptions } from './useConfigQuerySync';
 
 export { useLagInterpolated } from './useLagInterpolated';
 export { useRollingWindow } from './useRollingWindow';
+
+export { useListNavigation } from './useListNavigation';

--- a/web/src/hooks/useListNavigation.ts
+++ b/web/src/hooks/useListNavigation.ts
@@ -1,0 +1,119 @@
+import { useEffect } from 'react';
+import { usePalette } from '../components/command-palette';
+
+interface UseListNavigationOptions<T extends { id: string }> {
+    /** Rows to navigate over. */
+    rows: T[];
+    /** The currently active row id, or null if none. */
+    activeId: string | null;
+    /** Called to change the active row. */
+    setActiveId: (id: string | null) => void;
+    /** Called when Enter is pressed on the active row. */
+    onActivate?: (row: T) => void;
+    /** Called when d/Backspace is pressed on the active row. Only handled when provided. */
+    onDelete?: (row: T) => void;
+    /** Maps a row id to a DOM element id for scrollIntoView after navigation. */
+    getElementId?: (id: string) => string;
+    /** When false the hook is a no-op. Defaults to true. */
+    enabled?: boolean;
+}
+
+/** Adds Arrow Up/Down/Enter/Esc/d/Backspace keyboard navigation to a list of rows. */
+export const useListNavigation = <T extends { id: string }>({
+    rows,
+    activeId,
+    setActiveId,
+    onActivate,
+    onDelete,
+    getElementId,
+    enabled = true,
+}: UseListNavigationOptions<T>): void => {
+    const { open: paletteOpen, helpOpen } = usePalette();
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        const handleKeyDown = (e: KeyboardEvent): void => {
+            const key = e.key;
+            const isNavKey =
+                key === 'ArrowDown' ||
+                key === 'ArrowUp' ||
+                key === 'Enter' ||
+                key === 'Escape' ||
+                key === 'd' ||
+                key === 'Backspace';
+            if (!isNavKey) return;
+
+            if (paletteOpen || helpOpen) return;
+            if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+            const target = e.target as HTMLElement;
+            if (
+                target.tagName === 'INPUT' ||
+                target.tagName === 'TEXTAREA' ||
+                target.isContentEditable
+            ) {
+                return;
+            }
+
+            if (document.querySelector('.g-modal, .yn-modal-backdrop, .yn-drawer--open')) {
+                return;
+            }
+
+            if (key === 'ArrowDown' || key === 'ArrowUp') {
+                e.preventDefault();
+                if (rows.length === 0) return;
+
+                let nextId: string;
+                if (activeId === null) {
+                    nextId = key === 'ArrowDown' ? rows[0].id : rows[rows.length - 1].id;
+                } else {
+                    const idx = rows.findIndex((r) => r.id === activeId);
+                    if (idx === -1) {
+                        nextId = rows[0].id;
+                    } else if (key === 'ArrowDown') {
+                        nextId = rows[Math.min(rows.length - 1, idx + 1)].id;
+                    } else {
+                        nextId = rows[Math.max(0, idx - 1)].id;
+                    }
+                }
+
+                setActiveId(nextId);
+
+                if (getElementId) {
+                    document.getElementById(getElementId(nextId))?.scrollIntoView({ block: 'nearest' });
+                }
+                return;
+            }
+
+            if (key === 'Enter') {
+                if (activeId === null) return;
+                const row = rows.find((r) => r.id === activeId);
+                if (row && onActivate) {
+                    onActivate(row);
+                }
+                return;
+            }
+
+            if (key === 'Escape') {
+                if (activeId === null) return;
+                setActiveId(null);
+                return;
+            }
+
+            if (key === 'd' || key === 'Backspace') {
+                if (!onDelete) return;
+                if (activeId === null) return;
+                const row = rows.find((r) => r.id === activeId);
+                if (row) {
+                    e.preventDefault();
+                    onDelete(row);
+                }
+                return;
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [rows, activeId, setActiveId, onActivate, onDelete, getElementId, enabled, paletteOpen, helpOpen]);
+};

--- a/web/src/pages/_shared/draft/useDraftShortcuts.ts
+++ b/web/src/pages/_shared/draft/useDraftShortcuts.ts
@@ -25,6 +25,8 @@ export function useDraftShortcuts<T extends { id: string }>({
 }: UseDraftShortcutsOpts<T>): void {
     useEffect(() => {
         const onKey = (e: KeyboardEvent): void => {
+            // Suppress all shortcuts while any overlay backdrop (palette or help) is open.
+            if (document.querySelector('.cp-backdrop')) return;
             if (e.key === 'Escape') {
                 if (editingRowId) { setEditingRowId(null); return; }
             }

--- a/web/src/pages/_shared/useTabCycle.ts
+++ b/web/src/pages/_shared/useTabCycle.ts
@@ -18,14 +18,14 @@ interface UseTabCycleOptions {
  * modifier key (Meta, Ctrl, Alt) is held, or when the event target is an input, textarea,
  * or contentEditable element. */
 export const useTabCycle = ({ tabs, activeTab, onSelect, enabled = true }: UseTabCycleOptions): void => {
-    const { open: paletteOpen } = usePalette();
+    const { open: paletteOpen, helpOpen } = usePalette();
 
     useEffect(() => {
         if (!enabled || tabs.length < 2) return;
 
         const handleKeyDown = (e: KeyboardEvent): void => {
             if (e.key !== '[' && e.key !== ']') return;
-            if (paletteOpen) return;
+            if (paletteOpen || helpOpen) return;
             if (e.metaKey || e.ctrlKey || e.altKey) return;
 
             const target = e.target as HTMLElement;
@@ -57,5 +57,5 @@ export const useTabCycle = ({ tabs, activeTab, onSelect, enabled = true }: UseTa
 
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [tabs, activeTab, onSelect, enabled, paletteOpen]);
+    }, [tabs, activeTab, onSelect, enabled, paletteOpen, helpOpen]);
 };

--- a/web/src/pages/builtin/dashboard/DashboardPage.tsx
+++ b/web/src/pages/builtin/dashboard/DashboardPage.tsx
@@ -3,6 +3,7 @@ import { toaster } from '../../../utils';
 import { API } from '../../../api';
 import type { InstanceInfo } from '../../../api/inspect';
 import { PageLoader, EmptyState } from '../../../components';
+import { usePalette } from '../../../components/command-palette';
 import { InstanceCard } from './InstanceCard';
 import './dashboard.scss';
 
@@ -10,6 +11,7 @@ import './dashboard.scss';
 const DashboardPage = (): React.JSX.Element => {
     const [instanceInfo, setInstanceInfo] = useState<InstanceInfo | null>(null);
     const [initialLoading, setInitialLoading] = useState<boolean>(true);
+    const { setPageContribution } = usePalette();
 
     const loadInspect = useCallback(async (): Promise<void> => {
         try {
@@ -25,6 +27,30 @@ const DashboardPage = (): React.JSX.Element => {
     useEffect(() => {
         loadInspect();
     }, [loadInspect]);
+
+    useEffect(() => {
+        setPageContribution({
+            placeholder: 'Search or jump to a page…',
+            commands: [
+                {
+                    id: '__reload_dashboard',
+                    icon: '⟳',
+                    label: 'Reload dashboard',
+                    keywords: 'reload refresh dashboard',
+                    onSelect: () => { loadInspect(); },
+                },
+            ],
+            shortcuts: [
+                {
+                    title: 'Dashboard',
+                    items: [
+                        { keys: '⌘K', desc: 'Search or jump to a page' },
+                    ],
+                },
+            ],
+        });
+        return () => setPageContribution(null);
+    }, [setPageContribution, loadInspect]);
 
     return (
         <div className="dashboard-page">


### PR DESCRIPTION
Foundation for making the Web UI fully keyboard-controllable, building on the existing command palette.

- Add a `?` keyboard-shortcuts help overlay that lists the global keys (palette, tab cycling, list navigation, dialog submit) plus any shortcuts the active page contributes, reusing the command-palette visual language.
- Add a global "Keyboard shortcuts" command-palette entry as a second way to open the overlay.
- Add a generic `useListNavigation` hook (Arrow Up/Down to move a highlighted row, Enter to open, Esc to clear, optional d/Backspace delete, optional scroll-into-view) for list and table pages to consume in follow-up PRs.
- Register a minimal command-palette contribution on the Dashboard so every page is consistent.
- The new key handlers honor the same focus/overlay guards as tab cycling, so they never fire while typing or with the palette or a modal open.