### PR TITLE
fix(fwstate): free all map layers on config release

### DIFF
--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -13,13 +13,21 @@
 static void
 fwstate_config_destroy(struct fwstate_config *config, struct agent *agent) {
 	if (config->fw4state != NULL) {
-		fwmap_t *fw4 = ADDR_OF(&config->fw4state);
-		fwmap_free(fw4, &agent->memory_context);
+		fwmap_t *node = ADDR_OF(&config->fw4state);
+		while (node != NULL) {
+			fwmap_t *next = (fwmap_t *)ADDR_OF(&node->next);
+			fwmap_free(node, &agent->memory_context);
+			node = next;
+		}
 		config->fw4state = NULL;
 	}
 	if (config->fw6state != NULL) {
-		fwmap_t *fw6 = ADDR_OF(&config->fw6state);
-		fwmap_free(fw6, &agent->memory_context);
+		fwmap_t *node = ADDR_OF(&config->fw6state);
+		while (node != NULL) {
+			fwmap_t *next = (fwmap_t *)ADDR_OF(&node->next);
+			fwmap_free(node, &agent->memory_context);
+			node = next;
+		}
 		config->fw6state = NULL;
 	}
 }


### PR DESCRIPTION
- FWState releases freed only the active map layer, so older layers accumulated by map resizes leaked in shared memory on every config delete or full release. Under the pipeline operator's continuous re-apply this grows unbounded.
- Free the entire map layer chain for both address families when FWState owns the maps, capturing the next link before each free.
- The borrowed-reference path to ACL is unchanged: ownership transfer NULLs the heads first, so the release path frees nothing ACL still references.

Closes #893.