### PR TITLE
feat(web): add keyboard row navigation to functions and pipelines

### DIFF
--- a/web/src/hooks/useListNavigation.ts
+++ b/web/src/hooks/useListNavigation.ts
@@ -18,7 +18,7 @@ interface UseListNavigationOptions<T extends { id: string }> {
     enabled?: boolean;
 }
 
-/** Adds Arrow Up/Down/Enter/Esc/d/Backspace keyboard navigation to a list of rows. */
+/** Adds Arrow Up/Down/Enter/Esc/d/Backspace keyboard navigation to a list of rows; ignores events whose target is or is inside a focused interactive control (button, select, link, role="button/menuitem"). */
 export const useListNavigation = <T extends { id: string }>({
     rows,
     activeId,
@@ -51,7 +51,8 @@ export const useListNavigation = <T extends { id: string }>({
             if (
                 target.tagName === 'INPUT' ||
                 target.tagName === 'TEXTAREA' ||
-                target.isContentEditable
+                target.isContentEditable ||
+                target.closest('button, select, a[href], [role="button"], [role="menuitem"]')
             ) {
                 return;
             }

--- a/web/src/pages/builtin/functions/FunctionsPage.scss
+++ b/web/src/pages/builtin/functions/FunctionsPage.scss
@@ -528,3 +528,7 @@
 .fn-function-card--flash {
     animation: fn-card-flash 1.2s ease-out forwards;
 }
+
+.fn-function-card--active {
+    box-shadow: 0 0 0 2px var(--fn-accent);
+}

--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -11,7 +11,8 @@ import type { NetworkFunction } from './types';
 import { isFnSaveable } from './validation';
 import { API } from '../../../api';
 import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter } from '../../../components/command-palette';
+import type { Command, RowAdapter, ShortcutSection } from '../../../components/command-palette';
+import { useListNavigation } from '../../../hooks';
 import './FunctionsPage.scss';
 
 /** Builds a space-joined search string for a function (id, type, chain names, module names/types). */
@@ -37,6 +38,7 @@ const FunctionsPage = (): React.JSX.Element => {
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [flashId, setFlashId] = useState<string | null>(null);
     const [diffOpenId, setDiffOpenId] = useState<string | null>(null);
+    const [activeId, setActiveId] = useState<string | null>(null);
     const { dragState, startDrag, endDrag } = useDragState();
 
     useEffect(() => {
@@ -99,6 +101,14 @@ const FunctionsPage = (): React.JSX.Element => {
         }, 0);
     }, []);
 
+    useListNavigation<NetworkFunction>({
+        rows: functions,
+        activeId,
+        setActiveId,
+        onActivate: (fn) => setDiffOpenId(fn.id),
+        getElementId: (id) => `fn-card-${id}`,
+    });
+
     const { setPageContribution } = usePalette();
 
     const commands = useMemo((): Command[] => {
@@ -138,14 +148,24 @@ const FunctionsPage = (): React.JSX.Element => {
         icon: '→',
     }), [functions, jumpToFn]);
 
+    const shortcuts = useMemo((): ShortcutSection[] => [{
+        title: 'Functions',
+        items: [
+            { keys: '↑ ↓', desc: 'Highlight a function' },
+            { keys: 'Enter', desc: 'Open the YAML diff' },
+            { keys: 'Esc', desc: 'Clear selection' },
+        ],
+    }], []);
+
     useEffect(() => {
         setPageContribution({
             commands,
             rowAdapter: rowAdapter as RowAdapter<unknown>,
             placeholder: 'Search functions or run an action…',
+            shortcuts,
         });
         return () => setPageContribution(null);
-    }, [commands, rowAdapter, setPageContribution]);
+    }, [commands, rowAdapter, setPageContribution, shortcuts]);
 
     const headerContent = (
         <CommandPaletteHeader
@@ -187,6 +207,7 @@ const FunctionsPage = (): React.JSX.Element => {
                                 onOpenDiff={() => setDiffOpenId(fn.id)}
                                 onCloseDiff={() => setDiffOpenId(null)}
                                 flash={flashId === fn.id}
+                                active={activeId === fn.id}
                             />
                         ))
                     )}

--- a/web/src/pages/builtin/functions/components/FunctionCard.tsx
+++ b/web/src/pages/builtin/functions/components/FunctionCard.tsx
@@ -28,6 +28,7 @@ interface FunctionCardProps {
     onOpenDiff: () => void;
     onCloseDiff: () => void;
     flash?: boolean;
+    active?: boolean;
 }
 
 import { validateFn, validateSave } from '../validation';
@@ -53,6 +54,7 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
     onOpenDiff,
     onCloseDiff,
     flash,
+    active,
 }) => {
     const [collapsed, setCollapsed] = useState(false);
     const [drawerSelection, setDrawerSelection] = useState<
@@ -219,7 +221,7 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
     return (
         <div
             id={`fn-card-${fn.id}`}
-            className={`fn-function-card${collapsed ? ' fn-function-card--collapsed' : ''}${flash ? ' fn-function-card--flash' : ''}`}
+            className={`fn-function-card${collapsed ? ' fn-function-card--collapsed' : ''}${flash ? ' fn-function-card--flash' : ''}${active ? ' fn-function-card--active' : ''}`}
         >
             <FunctionCardHeader
                 fn={fn}

--- a/web/src/pages/builtin/pipelines/PipelinesPage.scss
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.scss
@@ -119,3 +119,7 @@
 .pl-pipeline-card--flash {
     animation: pl-card-flash 1.2s ease-out forwards;
 }
+
+.pl-pipeline-card--active {
+    box-shadow: 0 0 0 2px var(--pl-accent);
+}

--- a/web/src/pages/builtin/pipelines/PipelinesPage.tsx
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.tsx
@@ -8,7 +8,8 @@ import { PipelineCard } from './components/PipelineCard';
 import { CreateEntityDialog } from '../../../components';
 import type { Pipeline } from './types';
 import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter } from '../../../components/command-palette';
+import type { Command, RowAdapter, ShortcutSection } from '../../../components/command-palette';
+import { useListNavigation } from '../../../hooks';
 import './PipelinesPage.scss';
 
 /** Builds a space-joined search string for a pipeline (id and function names). */
@@ -22,6 +23,7 @@ const PipelinesPage = (): React.JSX.Element => {
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [flashId, setFlashId] = useState<string | null>(null);
     const [diffOpenId, setDiffOpenId] = useState<string | null>(null);
+    const [activeId, setActiveId] = useState<string | null>(null);
     const { dragState, startDrag, endDrag } = useDragState();
 
     const anyDirty = useMemo(
@@ -42,6 +44,14 @@ const PipelinesPage = (): React.JSX.Element => {
             document.getElementById(`pl-card-${id}`)?.scrollIntoView({ block: 'center', behavior: 'smooth' });
         }, 0);
     }, []);
+
+    useListNavigation<Pipeline>({
+        rows: pipelines,
+        activeId,
+        setActiveId,
+        onActivate: (pl) => setDiffOpenId(pl.id),
+        getElementId: (id) => `pl-card-${id}`,
+    });
 
     const { setPageContribution } = usePalette();
 
@@ -82,14 +92,24 @@ const PipelinesPage = (): React.JSX.Element => {
         icon: '→',
     }), [pipelines, jumpToPipeline]);
 
+    const shortcuts = useMemo((): ShortcutSection[] => [{
+        title: 'Pipelines',
+        items: [
+            { keys: '↑ ↓', desc: 'Highlight a pipeline' },
+            { keys: 'Enter', desc: 'Open the YAML diff' },
+            { keys: 'Esc', desc: 'Clear selection' },
+        ],
+    }], []);
+
     useEffect(() => {
         setPageContribution({
             commands,
             rowAdapter: rowAdapter as RowAdapter<unknown>,
             placeholder: 'Search pipelines or run an action…',
+            shortcuts,
         });
         return () => setPageContribution(null);
-    }, [commands, rowAdapter, setPageContribution]);
+    }, [commands, rowAdapter, setPageContribution, shortcuts]);
 
     const headerContent = (
         <CommandPaletteHeader
@@ -129,6 +149,7 @@ const PipelinesPage = (): React.JSX.Element => {
                                 onOpenDiff={() => setDiffOpenId(pl.id)}
                                 onCloseDiff={() => setDiffOpenId(null)}
                                 flash={flashId === pl.id}
+                                active={activeId === pl.id}
                             />
                         ))
                     )}

--- a/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
+++ b/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
@@ -26,6 +26,7 @@ interface PipelineCardProps {
     onOpenDiff: () => void;
     onCloseDiff: () => void;
     flash?: boolean;
+    active?: boolean;
 }
 
 /**
@@ -47,6 +48,7 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
     onOpenDiff,
     onCloseDiff,
     flash,
+    active,
 }) => {
     const [collapsed, setCollapsed] = useState(false);
     const [drawerRefId, setDrawerRefId] = useState<string | null>(null);
@@ -121,7 +123,7 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
     return (
         <div
             id={`pl-card-${pipeline.id}`}
-            className={`pl-pipeline-card${collapsed ? ' pl-pipeline-card--collapsed' : ''}${flash ? ' pl-pipeline-card--flash' : ''}`}
+            className={`pl-pipeline-card${collapsed ? ' pl-pipeline-card--collapsed' : ''}${flash ? ' pl-pipeline-card--flash' : ''}${active ? ' pl-pipeline-card--active' : ''}`}
         >
             <PipelineCardHeader
                 pipeline={pipeline}


### PR DESCRIPTION
Extends the keyboard-control work to the Functions and Pipelines card lists.

- Arrow Up/Down highlight a card (a persistent selection ring) and scroll it into view.
- Enter opens the highlighted card's YAML diff; Esc clears the selection.
- Reuses the shared `useListNavigation` hook, which already suppresses itself while typing or with the palette, help overlay, or a modal/drawer open.
- The selection cursor is independent of the existing palette-jump flash pulse.
- Both pages advertise these keys in the `?` shortcuts help overlay.