### PR TITLE
feat(web): add keyboard device selection to the devices page

### DIFF
--- a/web/src/hooks/useListNavigation.ts
+++ b/web/src/hooks/useListNavigation.ts
@@ -18,7 +18,7 @@ interface UseListNavigationOptions<T extends { id: string }> {
     enabled?: boolean;
 }
 
-/** Adds Arrow Up/Down/Enter/Esc/d/Backspace keyboard navigation to a list of rows; ignores events whose target is or is inside a focused interactive control (button, select, link, role="button/menuitem"). */
+/** Adds Arrow Up/Down/Enter/Esc/d/Backspace keyboard navigation to a list of rows; arrows defer only to arrow-consuming controls (select, listbox, combobox, menu, slider, spinbutton); Enter and delete keys defer to any focused interactive control. */
 export const useListNavigation = <T extends { id: string }>({
     rows,
     activeId,
@@ -51,8 +51,7 @@ export const useListNavigation = <T extends { id: string }>({
             if (
                 target.tagName === 'INPUT' ||
                 target.tagName === 'TEXTAREA' ||
-                target.isContentEditable ||
-                target.closest('button, select, a[href], [role="button"], [role="menuitem"]')
+                target.isContentEditable
             ) {
                 return;
             }
@@ -62,6 +61,8 @@ export const useListNavigation = <T extends { id: string }>({
             }
 
             if (key === 'ArrowDown' || key === 'ArrowUp') {
+                // Controls that consume arrow keys themselves take precedence.
+                if (target.closest('select, [role="listbox"], [role="combobox"], [role="menu"], [role="menubar"], [role="slider"], [role="spinbutton"]')) return;
                 e.preventDefault();
                 if (rows.length === 0) return;
 
@@ -88,6 +89,8 @@ export const useListNavigation = <T extends { id: string }>({
             }
 
             if (key === 'Enter') {
+                // Defer activation to a focused interactive control.
+                if (target.closest('button, select, a[href], [role="button"], [role="menuitem"]')) return;
                 if (activeId === null) return;
                 const row = rows.find((r) => r.id === activeId);
                 if (row && onActivate) {
@@ -103,6 +106,8 @@ export const useListNavigation = <T extends { id: string }>({
             }
 
             if (key === 'd' || key === 'Backspace') {
+                // Defer activation to a focused interactive control.
+                if (target.closest('button, select, a[href], [role="button"], [role="menuitem"]')) return;
                 if (!onDelete) return;
                 if (activeId === null) return;
                 const row = rows.find((r) => r.id === activeId);

--- a/web/src/pages/builtin/devices/DeviceListItem.tsx
+++ b/web/src/pages/builtin/devices/DeviceListItem.tsx
@@ -31,6 +31,7 @@ export const DeviceListItem: React.FC<DeviceListItemProps> = ({
 
     return (
         <button
+            id={`dv-row-${device.id.name || ''}`}
             className={`dv-row${isSelected ? ' row-sel' : ''}`}
             onClick={onClick}
         >

--- a/web/src/pages/builtin/devices/DevicesList.tsx
+++ b/web/src/pages/builtin/devices/DevicesList.tsx
@@ -32,7 +32,14 @@ const nextGrouping = (current: GroupingMode): GroupingMode => {
     return 'flat';
 };
 
-const buildGroups = (devices: LocalDevice[], grouping: GroupingMode): DeviceGroup[] => {
+export const filterDevices = (devices: LocalDevice[], filter: FilterKind): LocalDevice[] =>
+    devices.filter(d => {
+        if (filter === 'plain' && d.type !== 'plain') return false;
+        if (filter === 'vlan' && d.type !== 'vlan') return false;
+        return true;
+    });
+
+export const buildGroups = (devices: LocalDevice[], grouping: GroupingMode): DeviceGroup[] => {
     if (grouping === 'type') {
         return [
             { key: 'plain', label: 'Physical', items: devices.filter(d => d.type === 'plain') },
@@ -74,13 +81,7 @@ export const DevicesList: React.FC<DevicesListProps> = ({
         vlan: devices.filter(d => d.type === 'vlan').length,
     }), [devices]);
 
-    const filtered = useMemo(() => {
-        return devices.filter(d => {
-            if (filter === 'plain' && d.type !== 'plain') return false;
-            if (filter === 'vlan' && d.type !== 'vlan') return false;
-            return true;
-        });
-    }, [devices, filter]);
+    const filtered = useMemo(() => filterDevices(devices, filter), [devices, filter]);
 
     const groups = useMemo(() => buildGroups(filtered, grouping), [filtered, grouping]);
 

--- a/web/src/pages/builtin/devices/DevicesPage.tsx
+++ b/web/src/pages/builtin/devices/DevicesPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
-import { useSearchParamHelpers } from '../../../hooks';
+import { useSearchParamHelpers, useListNavigation } from '../../../hooks';
 import { PageLayout, PageLoader, EmptyState, CommandPaletteHeader } from '../../../components';
 import type { DeviceType } from '../../../api/devices';
 import type { LocalDevice } from './types';
@@ -10,12 +10,14 @@ import { useDeviceCounters } from '../../../hooks';
 import { useCounterHistory } from '../../../hooks/useCounterHistory';
 import { useUnsavedChangesBlocker } from '../_shared/lane-editor';
 import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter } from '../../../components/command-palette';
+import type { Command, RowAdapter, ShortcutSection } from '../../../components/command-palette';
 import {
     DevicesList,
     DeviceDetails,
     CreateDeviceDialog,
     useDeviceData,
+    filterDevices,
+    buildGroups,
 } from '.';
 import type { FilterKind } from '.';
 import './devices.scss';
@@ -57,6 +59,11 @@ const DevicesPage: React.FC = () => {
         return devices.find(d => d.id.name === selectedDeviceName) || null;
     }, [devices, selectedDeviceName]);
 
+    const visibleDevices = useMemo(
+        () => buildGroups(filterDevices(devices, deviceFilter), grouping).flatMap(g => g.items),
+        [devices, deviceFilter, grouping],
+    );
+
     const anyDirty = useMemo(() => devices.some(d => d.isDirty), [devices]);
     useUnsavedChangesBlocker(anyDirty);
 
@@ -89,6 +96,18 @@ const DevicesPage: React.FC = () => {
     const handleSelectDevice = useCallback((deviceName: string) => {
         updateParams({ [QP_DEVICE]: deviceName || null });
     }, [updateParams]);
+
+    const visibleNavRows = useMemo(
+        () => visibleDevices.map(d => ({ id: d.id.name || '' })),
+        [visibleDevices],
+    );
+
+    useListNavigation({
+        rows: visibleNavRows,
+        activeId: selectedDeviceName,
+        setActiveId: (id) => { if (id) handleSelectDevice(id); },
+        getElementId: (name) => `dv-row-${name}`,
+    });
 
     const handleUpdateDevice = useCallback((updates: Partial<LocalDevice>) => {
         if (selectedDeviceName) {
@@ -165,14 +184,20 @@ const DevicesPage: React.FC = () => {
         icon: '→',
     }), [devices, handleSelectDevice]);
 
+    const shortcuts = useMemo((): ShortcutSection[] => [{
+        title: 'Devices',
+        items: [{ keys: '↑ ↓', desc: 'Select previous / next device' }],
+    }], []);
+
     useEffect(() => {
         setPageContribution({
             commands,
             rowAdapter: rowAdapter as RowAdapter<unknown>,
             placeholder: 'Search devices or run an action…',
+            shortcuts,
         });
         return () => setPageContribution(null);
-    }, [commands, rowAdapter, setPageContribution]);
+    }, [commands, rowAdapter, setPageContribution, shortcuts]);
 
     const existingDeviceNames = devices.map(d => d.id.name || '');
 


### PR DESCRIPTION
Extends the keyboard-control work to the Devices master-detail page.

- Arrow Up/Down move the device selection through the visible filtered and grouped order and scroll the selected row into view; the detail pane follows the selection live.
- The visible order is derived from the same `filterDevices`/`buildGroups` helpers the list renders with, so keyboard order always matches the screen across every grouping mode and filter.
- Refines the shared `useListNavigation` guard: arrows now defer only to controls that consume arrows themselves (select, listbox, slider, etc.), while Enter and delete still defer to any focused interactive control. This lets arrows keep navigating while a device row button holds focus, without re-introducing Enter activating a focused button.
- The devices page advertises the keys in the `?` shortcuts help overlay.