### PR TITLE
feat(web): add keyboard row navigation to the neighbours table

### DIFF
--- a/web/src/components/VirtualTable/VirtualTable.tsx
+++ b/web/src/components/VirtualTable/VirtualTable.tsx
@@ -62,6 +62,8 @@ export interface VirtualTableProps<T> {
 
     onRowClick?: (id: string) => void;
     activeRowId?: string | null;
+    /** When true, scrolls the active row into view as activeRowId changes. Off by default so existing callers are unaffected. */
+    scrollActiveIntoView?: boolean;
 
     flashRowId?: string | null;
 
@@ -173,6 +175,7 @@ export function VirtualTable<T>({
     deleteIcon,
     onRowClick,
     activeRowId,
+    scrollActiveIntoView,
     flashRowId,
     headerActions,
     footerSummary,
@@ -228,6 +231,20 @@ export function VirtualTable<T>({
         const t = setTimeout(() => setFlashingId(null), 1200);
         return () => clearTimeout(t);
     }, [flashRowId, rows, rowVirtualizer, getRowId]);
+
+    const prevActiveRowId = useRef<string | null>(null);
+    useEffect(() => {
+        const prev = prevActiveRowId.current;
+        prevActiveRowId.current = activeRowId ?? null;
+        if (!scrollActiveIntoView || !activeRowId) return;
+        // Only scroll when the selection itself changed, not when a data refresh
+        // installs a new rows array.
+        if (activeRowId === prev) return;
+        const idx = rows.findIndex((r) => getRowId(r) === activeRowId);
+        if (idx >= 0) {
+            rowVirtualizer.scrollToIndex(idx, { align: 'auto' });
+        }
+    }, [scrollActiveIntoView, activeRowId, rows, rowVirtualizer, getRowId]);
 
     const isAllSelected = rows.length > 0 && rows.every((r) => selectedIds.has(getRowId(r)));
     const isIndeterminate = !isAllSelected && rows.some((r) => selectedIds.has(getRowId(r)));

--- a/web/src/pages/operators/neighbours/NeighbourTable.tsx
+++ b/web/src/pages/operators/neighbours/NeighbourTable.tsx
@@ -40,6 +40,7 @@ export interface NeighbourTableProps {
     cache?: Map<string, Neighbour[]>;
     tables?: NeighbourTableInfo[];
     flashRowId?: string | null;
+    activeRowId?: string | null;
 }
 
 interface StateBadgeProps {
@@ -152,6 +153,7 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
     cache,
     tables,
     flashRowId,
+    activeRowId,
 }): React.JSX.Element => {
     const columns: Column<Neighbour>[] = [
         {
@@ -322,6 +324,8 @@ export const NeighbourTable: React.FC<NeighbourTableProps> = ({
             editIcon={<Pencil width={14} height={14} />}
             deleteIcon={<TrashBin width={14} height={14} />}
             onRowClick={onRowClick}
+            activeRowId={activeRowId}
+            scrollActiveIntoView
             flashRowId={flashRowId}
             headerActions={headerActions}
             footerSummary={footerText}

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers } from '../../../hooks';
+import { useSearchParamHelpers, useListNavigation } from '../../../hooks';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus, Layers } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder } from '../../../components';
 import { BulkDeleteModal, DeleteConfigModal, CommandPaletteHeader } from '../../../components';
 import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter } from '../../../components/command-palette';
+import type { Command, RowAdapter, ShortcutSection } from '../../../components/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
 import { parseIPAddress } from '../../../utils';
@@ -66,6 +66,7 @@ const NeighboursPage: React.FC = () => {
 
     const [paused, setPaused] = useState(false);
     const [flashRowId, setFlashRowId] = useState<string | null>(null);
+    const [activeRowId, setActiveRowId] = useState<string | null>(null);
 
     const {
         tables,
@@ -148,6 +149,8 @@ const NeighboursPage: React.FC = () => {
         return res;
     }, [allRows, sortState, family, stateFilter]);
 
+    const navRows = useMemo(() => visibleRows.map((n) => ({ id: getNeighbourId(n) })), [visibleRows]);
+
     const counts = useMemo((): Map<string, number> => {
         const m = new Map<string, number>();
         m.set(MERGED_TAB, tables.reduce((sum, t) => sum + Number(t.entry_count ?? 0), 0));
@@ -174,7 +177,15 @@ const NeighboursPage: React.FC = () => {
         const neighbour = allRows.find((n) => getNeighbourId(n) === id) || null;
         const mode = isMergedView ? 'view' : 'edit';
         setPanel({ open: true, mode, neighbour });
+        setActiveRowId(id);
     }, [allRows, isMergedView]);
+
+    useListNavigation({
+        rows: navRows,
+        activeId: activeRowId,
+        setActiveId: setActiveRowId,
+        onActivate: (row) => handleRowClick(row.id),
+    });
 
     const handleSubmitNeighbour = useCallback(async (table: string, entry: Neighbour): Promise<void> => {
         if (panel.mode === 'add') {
@@ -489,15 +500,26 @@ const NeighboursPage: React.FC = () => {
         max: 7,
     }), [allRows, handleJumpToRow]);
 
+    const shortcuts: ShortcutSection[] = useMemo(() => [{
+        title: 'Neighbours',
+        items: [
+            { keys: '↑ ↓', desc: 'Select previous / next neighbour' },
+            { keys: 'Enter', desc: 'Open the neighbour panel' },
+            { keys: 'Esc', desc: 'Clear selection' },
+            { keys: '[ ]', desc: 'Switch table tab' },
+        ],
+    }], []);
+
     useEffect(() => {
         setPageContribution({
             commands: neighbourCommands,
             dynamicCommands: neighbourDynamicCommands,
             rowAdapter: neighbourRowAdapter as RowAdapter<unknown>,
             placeholder: 'Search neighbours or type an IP…',
+            shortcuts,
         });
         return () => setPageContribution(null);
-    }, [neighbourCommands, neighbourDynamicCommands, neighbourRowAdapter, setPageContribution]);
+    }, [neighbourCommands, neighbourDynamicCommands, neighbourRowAdapter, setPageContribution, shortcuts]);
 
     const searchActive = family !== 'all' || !!stateFilter;
 
@@ -628,6 +650,7 @@ const NeighboursPage: React.FC = () => {
                                 cache={cache}
                                 tables={tables}
                                 flashRowId={flashRowId}
+                                activeRowId={activeRowId}
                             />
                         </div>
                     </>


### PR DESCRIPTION
Brings keyboard row navigation to the first virtualized table page (Neighbours), and adds the one shared-table capability the remaining table pages will reuse.

- Arrow Up/Down move a highlighted neighbour row and scroll it into view; Enter opens the neighbour panel; Esc clears the selection.
- Mouse clicks set the same highlight, so arrow navigation continues from a clicked row.
- Adds an opt-in `scrollActiveIntoView` to the shared `VirtualTable` that scrolls the active row into view as it changes (align `auto`, so it only scrolls when off-screen). It is off by default, so the existing tables that already use `activeRowId` (forward, acl, decap, route) are byte-identical.
- The hook stands down while the neighbour panel (a drawer), command palette, or help overlay is open, and while typing.
- The page advertises the keys in the `?` shortcuts help overlay.