### PR TITLE
fix(web): keep the row selection background on hover

### DIFF
--- a/web/src/components/VirtualTable/table.scss
+++ b/web/src/components/VirtualTable/table.scss
@@ -164,6 +164,11 @@
 
     &:hover { background-color: var(--yn-bg-hover) !important; }
 
+    &--selected:hover,
+    &--active:hover {
+        background-color: var(--yn-accent-soft) !important;
+    }
+
     &--active {
         box-shadow: inset 2px 0 0 var(--yn-accent);
     }


### PR DESCRIPTION
In the shared virtual table, a selected or active row lost its accent background while hovered: the hover rule (a class plus a pseudo-class) outranked the single-class selection rule, so hover won.

- Add a `.yn-vrow--selected:hover` / `.yn-vrow--active:hover` rule that keeps the accent background, placed after the plain hover rule so it wins at equal specificity.
- Affects every page using the shared virtual table (forward, acl, decap, route, neighbours).