### PR TITLE
feat(web): blend the side menu gradient into the surface background

### DIFF
--- a/web/src/MainMenu.scss
+++ b/web/src/MainMenu.scss
@@ -4,6 +4,14 @@
     bottom: 13px;
 }
 
+// Match the sidebar background to the warm-dark surface so the header
+// decoration gradient fades smoothly into the page rather than into Gravity's
+// default background.
+.gn-aside-header {
+    --gn-aside-header-background-color: var(--yn-surface-bg);
+    background-color: var(--yn-surface-bg);
+}
+
 .main-menu__section-label {
     display: block;
     padding: 4px 12px;

--- a/web/src/styles/draft/_surface.scss
+++ b/web/src/styles/draft/_surface.scss
@@ -79,10 +79,6 @@
 // Pages that apply .yn-flat-layout (on PageLayout) and .yn-flat-page (on .yn-page)
 // get the unified #1C1814 surface and flush content area (padding: 0).
 
-.yn-flat-layout {
-    --yn-surface-bg: #1C1814;
-}
-
 .yn-page.yn-flat-page {
     background: var(--yn-surface-bg);
 }

--- a/web/src/styles/tokens.scss
+++ b/web/src/styles/tokens.scss
@@ -9,6 +9,7 @@
     --yn-bg-2:          #181410;
     --yn-bg-3:          #221C16;
     --yn-bg-hover:      #221C16;
+    --yn-surface-bg:    #1C1814;
     --yn-line:          rgba(255, 199, 140, 0.02);
     --yn-line-2:        rgba(255, 200, 140, 0.12);
     --yn-text:          #F2EEE8;


### PR DESCRIPTION
- Promote `--yn-surface-bg` (#1C1814) to a global `.g-root` token so it resolves outside flat-layout pages, including the sidebar.
- Override the Gravity `AsideHeader` background to `--yn-surface-bg` so the header decoration gradient fades smoothly into the page surface instead of Gravity's default background.
- Remove the now-redundant local `--yn-surface-bg` declaration in `_surface.scss` (inherited from the global token; identical value).