### PR TITLE
feat(dataplane_ut): add passthrough pipeline helper for harness tests

### DIFF
--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -14,6 +14,7 @@
 #include "common/memory_address.h"
 #include "common/strutils.h"
 #include "lib/controlplane/agent/agent.h"
+#include "lib/controlplane/config/cp_device.h"
 #include "lib/controlplane/config/zone.h"
 #include "lib/counters/counters.h"
 #include "lib/dataplane/config/agent.h"
@@ -34,6 +35,7 @@ struct dataplane_ut {
 	size_t arena_size;
 	struct dp_config *dp_config;
 	struct cp_config *cp_config;
+	struct agent *agent;
 	struct rte_mempool *mempool;
 	uint64_t mock_time_ns;
 };
@@ -183,6 +185,7 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		dataplane_ut_free(ut);
 		return NULL;
 	}
+	ut->agent = agent;
 
 	// Populate dp_topology with the logical port names from cfg.
 	if (cfg->device_count > 0) {
@@ -400,4 +403,167 @@ dataplane_ut_run(
 
 	packet_list_concat(&result->output, &packet_front.output);
 	packet_list_concat(&result->drop, &packet_front.drop);
+}
+
+int
+dataplane_ut_add_passthrough_pipeline(
+	struct dataplane_ut *ut,
+	const char *device_name,
+	const char *pipeline_name,
+	uint64_t *out_tx_device_id
+) {
+	yanet_error *err = NULL;
+
+	// Names for the synthetic chain and function created to back this
+	// passthrough pipeline. Both are empty (zero modules / one chain with
+	// weight 1) so packets traverse the counters and emerge unchanged.
+	static const char *chain_name = "passthrough_chain";
+	static const char *function_name = "passthrough_func";
+
+	// Empty chain: zero modules, so packets pass straight through.
+	struct cp_chain_config *chain_cfg =
+		cp_chain_config_create(chain_name, 0, NULL, NULL);
+	if (chain_cfg == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "cp_chain_config_create failed");
+		return -1;
+	}
+
+	struct cp_function_config *fn_cfg =
+		cp_function_config_create(function_name, 1);
+	if (fn_cfg == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "cp_function_config_create failed");
+		cp_chain_config_free(chain_cfg);
+		return -1;
+	}
+	// cp_function_config_set_chain takes ownership of chain_cfg.
+	if (cp_function_config_set_chain(fn_cfg, 0, chain_cfg, 1) != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "cp_function_config_set_chain failed");
+		cp_function_config_free(fn_cfg);
+		cp_chain_config_free(chain_cfg);
+		return -1;
+	}
+
+	struct cp_function_config *fn_cfgs[] = {fn_cfg};
+	if (agent_update_functions(ut->agent, 1, fn_cfgs, &err) != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "agent_update_functions failed: %s",
+		    yanet_error_message(err));
+		yanet_error_free(err);
+		cp_function_config_free(fn_cfg);
+		return -1;
+	}
+	cp_function_config_free(fn_cfg);
+
+	struct cp_pipeline_config *pl_cfg =
+		cp_pipeline_config_create(pipeline_name, 1);
+	if (pl_cfg == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "cp_pipeline_config_create failed");
+		return -1;
+	}
+	if (cp_pipeline_config_set_function(pl_cfg, 0, function_name) != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "cp_pipeline_config_set_function failed");
+		cp_pipeline_config_free(pl_cfg);
+		return -1;
+	}
+
+	struct cp_pipeline_config *pl_cfgs[] = {pl_cfg};
+	if (agent_update_pipelines(ut->agent, 1, pl_cfgs, &err) != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "agent_update_pipelines failed: %s",
+		    yanet_error_message(err));
+		yanet_error_free(err);
+		cp_pipeline_config_free(pl_cfg);
+		return -1;
+	}
+	cp_pipeline_config_free(pl_cfg);
+
+	// cp_device_config_init allocates input/output pipeline arrays on the
+	// heap; cp_device_config_fini frees them.
+	struct cp_device_config device_cfg;
+	if (cp_device_config_init(
+		    &device_cfg, "plain", device_name, 1, 0, &err
+	    ) != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "cp_device_config_init failed: %s",
+		    yanet_error_message(err));
+		yanet_error_free(err);
+		return -1;
+	}
+	if (cp_device_config_set_input_pipeline(
+		    &device_cfg, 0, pipeline_name, 1
+	    ) != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "cp_device_config_set_input_pipeline failed");
+		cp_device_config_fini(&device_cfg);
+		return -1;
+	}
+
+	struct cp_device *cp_device = cp_device_new(&ut->agent->memory_context);
+	if (cp_device == NULL) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "cp_device_new failed");
+		cp_device_config_fini(&device_cfg);
+		return -1;
+	}
+	if (cp_device_init(cp_device, ut->agent, &device_cfg, &err) != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "cp_device_init failed: %s",
+		    yanet_error_message(err));
+		yanet_error_free(err);
+		cp_device_free(cp_device);
+		cp_device_config_fini(&device_cfg);
+		return -1;
+	}
+	cp_device_config_fini(&device_cfg);
+
+	struct cp_device *devices[] = {cp_device};
+	if (agent_update_devices(ut->agent, 1, devices, &err) != 0) {
+		LOG(ERROR,
+		    "dataplane_ut_add_passthrough_pipeline: "
+		    "agent_update_devices failed: %s",
+		    yanet_error_message(err));
+		yanet_error_free(err);
+		// Do not fini/free cp_device here: agent_update_devices upserts
+		// it into a new config gen, and cp_config_gen_free frees it on
+		// install failure. Freeing it again would be a double-free.
+		return -1;
+	}
+
+	// Find the device's topology index so the caller knows which
+	// tx_device_id to set on packets destined for this device.
+	// The topology order matches the registry slot order established by
+	// cp_config_gen_create, so the topology index IS the correct
+	// tx_device_id.
+	struct dp_topology *topo = &ut->dp_config->dp_topology;
+	struct dp_port *ports = ADDR_OF(&topo->devices);
+	for (uint64_t idx = 0; idx < topo->device_count; ++idx) {
+		if (strncmp(ports[idx].device_name,
+			    device_name,
+			    sizeof(ports[idx].device_name)) == 0) {
+			*out_tx_device_id = idx;
+			return 0;
+		}
+	}
+
+	LOG(ERROR,
+	    "dataplane_ut_add_passthrough_pipeline: "
+	    "device '%s' not found in dp_topology",
+	    device_name);
+	return -1;
 }

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -67,6 +67,26 @@ struct dataplane_ut_round_result {
 	struct packet_list drop;
 };
 
+// Wire a passthrough pipeline to a device in the harness so that
+// config_gen_ectx becomes non-NULL and packets can flow.
+//
+// Creates an empty chain, a single-chain function, a pipeline with one
+// function stage, and binds that pipeline to the named device's input.
+// device_name must be one of the names supplied in dataplane_ut_config.devices.
+//
+// On success, writes the device's topology index to *out_tx_device_id.
+// The caller must set pkt->tx_device_id to this value for packets that
+// should be routed through the pipeline installed on this device.
+//
+// Returns 0 on success, -1 on failure (details logged via LOG(ERROR, ...)).
+int
+dataplane_ut_add_passthrough_pipeline(
+	struct dataplane_ut *ut,
+	const char *device_name,
+	const char *pipeline_name,
+	uint64_t *out_tx_device_id
+);
+
 // Run one pipeline round on worker_idx with the given input.
 //
 // input is drained to empty on return; result->output and result->drop

--- a/lib/dataplane_ut/tests/meson.build
+++ b/lib/dataplane_ut/tests/meson.build
@@ -16,3 +16,22 @@ smoke_test = executable(
   include_directories: yanet_rootdir,
 )
 test('dataplane_ut_smoke', smoke_test, suite: 'dataplane_ut')
+
+passthrough_test = executable(
+  'dataplane_ut_passthrough_test',
+  ['passthrough_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    libdpdk_dep,
+  ],
+  link_with: [lib_dev_plain_dp],
+  include_directories: yanet_rootdir,
+)
+test('dataplane_ut_passthrough', passthrough_test, suite: 'dataplane_ut')

--- a/lib/dataplane_ut/tests/passthrough_test.c
+++ b/lib/dataplane_ut/tests/passthrough_test.c
@@ -1,0 +1,184 @@
+#include "common/test_assert.h"
+#include "lib/dataplane/packet/data.h"
+#include "lib/dataplane_ut/dataplane_ut.h"
+
+#include <rte_mbuf.h>
+
+#include <string.h>
+
+#define PACKET_COUNT 4
+#define PACKET_DATA_LEN 64
+
+static int
+run_passthrough_test(void) {
+	const char *port_names[] = {"01:00.0"};
+	const char *devs_to_load[] = {"plain"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = NULL,
+		.module_count = 0,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+
+	uint64_t tx_device_id;
+	int rc = dataplane_ut_add_passthrough_pipeline(
+		ut, "01:00.0", "pt0", &tx_device_id
+	);
+	TEST_ASSERT_EQUAL((long)rc, 0L, "add_passthrough_pipeline failed");
+	TEST_ASSERT_EQUAL((long)tx_device_id, 0L, "device 0 must have index 0");
+
+	// Allocate PACKET_COUNT mbufs and build an input packet_list.
+	struct packet_list input;
+	packet_list_init(&input);
+
+	for (int idx = 0; idx < PACKET_COUNT; ++idx) {
+		struct rte_mbuf *mbuf = dataplane_ut_alloc_mbuf(ut);
+		TEST_ASSERT_NOT_NULL(
+			mbuf, "dataplane_ut_alloc_mbuf returned NULL"
+		);
+
+		// Append a small payload so data_len is non-zero.
+		char *buf = rte_pktmbuf_append(mbuf, PACKET_DATA_LEN);
+		TEST_ASSERT_NOT_NULL(buf, "rte_pktmbuf_append returned NULL");
+		memset(buf, 0, PACKET_DATA_LEN);
+
+		// Initialise the packet header that lives at buf_addr.
+		struct packet *pkt = mbuf_to_packet(mbuf);
+		memset(pkt, 0, sizeof(struct packet));
+		pkt->mbuf = mbuf;
+		pkt->tx_device_id = (uint16_t)tx_device_id;
+
+		packet_list_add(&input, pkt);
+	}
+
+	// Run one pipeline round.
+	struct dataplane_ut_round_result result;
+	dataplane_ut_run(ut, 0, &input, &result);
+
+	// A passthrough pipeline must forward every packet, none dropped.
+	TEST_ASSERT_EQUAL(
+		(long)packet_list_count(&result.output),
+		(long)PACKET_COUNT,
+		"passthrough must forward all packets"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)packet_list_count(&result.drop),
+		0L,
+		"passthrough must not drop any packet"
+	);
+
+	// Free the output mbufs returned by the pipeline.
+	struct packet *pkt;
+	while ((pkt = packet_list_pop(&result.output)) != NULL) {
+		rte_pktmbuf_free(pkt->mbuf);
+	}
+
+	dataplane_ut_free(ut);
+
+	return TEST_SUCCESS;
+}
+
+// Verify that a passthrough pipeline bound to the SECOND of two configured
+// devices correctly routes packets whose tx_device_id equals the second
+// device's topology index (1).  Before the P2 fix this would crash because
+// the device was inserted at the wrong registry slot.
+static int
+run_passthrough_test_two_devices(void) {
+	const char *port_names[] = {"01:00.0", "02:00.0"};
+	const char *devs_to_load[] = {"plain"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 2,
+		.modules = NULL,
+		.module_count = 0,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+
+	// Bind the passthrough pipeline to the SECOND device ("02:00.0").
+	uint64_t tx_device_id;
+	int rc = dataplane_ut_add_passthrough_pipeline(
+		ut, "02:00.0", "pt1", &tx_device_id
+	);
+	TEST_ASSERT_EQUAL((long)rc, 0L, "add_passthrough_pipeline failed");
+	// The second device must report topology index 1.
+	TEST_ASSERT_EQUAL(
+		(long)tx_device_id, 1L, "device 02:00.0 must have index 1"
+	);
+
+	// Allocate PACKET_COUNT mbufs and address them to the second device.
+	struct packet_list input;
+	packet_list_init(&input);
+
+	for (int idx = 0; idx < PACKET_COUNT; ++idx) {
+		struct rte_mbuf *mbuf = dataplane_ut_alloc_mbuf(ut);
+		TEST_ASSERT_NOT_NULL(
+			mbuf, "dataplane_ut_alloc_mbuf returned NULL"
+		);
+
+		char *buf = rte_pktmbuf_append(mbuf, PACKET_DATA_LEN);
+		TEST_ASSERT_NOT_NULL(buf, "rte_pktmbuf_append returned NULL");
+		memset(buf, 0, PACKET_DATA_LEN);
+
+		struct packet *pkt = mbuf_to_packet(mbuf);
+		memset(pkt, 0, sizeof(struct packet));
+		pkt->mbuf = mbuf;
+		pkt->tx_device_id = (uint16_t)tx_device_id;
+
+		packet_list_add(&input, pkt);
+	}
+
+	// Run one pipeline round.
+	struct dataplane_ut_round_result result;
+	dataplane_ut_run(ut, 0, &input, &result);
+
+	// All packets must exit via output, none dropped.
+	TEST_ASSERT_EQUAL(
+		(long)packet_list_count(&result.output),
+		(long)PACKET_COUNT,
+		"passthrough must forward all packets"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)packet_list_count(&result.drop),
+		0L,
+		"passthrough must not drop any packet"
+	);
+
+	struct packet *pkt;
+	while ((pkt = packet_list_pop(&result.output)) != NULL) {
+		rte_pktmbuf_free(pkt->mbuf);
+	}
+
+	dataplane_ut_free(ut);
+
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	if (run_passthrough_test() != TEST_SUCCESS) {
+		return 1;
+	}
+	if (run_passthrough_test_two_devices() != TEST_SUCCESS) {
+		return 1;
+	}
+	return 0;
+}


### PR DESCRIPTION
Add `dataplane_ut_add_passthrough_pipeline`, which wires an empty-chain pipeline to a device so `config_gen_ectx` becomes non-NULL and packets flow end-to-end through the in-process dataplane. This unlocks pipeline-level harness tests and benchmarks that previously could not run a real pipeline round.

Add a unit test exercising the helper: an empty passthrough pipeline forwards all input packets to the output with none dropped.