### PR TITLE
fix(web): require a mask in route and decap CIDR prefix validation

### DIFF
--- a/web/src/pages/modules/decap/validation.ts
+++ b/web/src/pages/modules/decap/validation.ts
@@ -1,9 +1,9 @@
-import { isValidCidr, rowHasError as sharedRowHasError, countInvalidRows as sharedCountInvalidRows } from '../../../utils';
+import { isValidCidrPrefix, rowHasError as sharedRowHasError, countInvalidRows as sharedCountInvalidRows } from '../../../utils';
 import type { PrefixRowItem, PrefixRowErrors } from './types';
 
 /** Validate all fields of a prefix row. Returns null per field if valid. */
 export const validateRow = (row: PrefixRowItem): PrefixRowErrors => ({
-    prefix: isValidCidr(row.prefix) ? null : (row.prefix ? 'Invalid CIDR' : 'Required'),
+    prefix: isValidCidrPrefix(row.prefix) ? null : (row.prefix ? 'Invalid CIDR' : 'Required'),
 });
 
 /** Returns true if the row has any validation error. */

--- a/web/src/pages/modules/route/validation.ts
+++ b/web/src/pages/modules/route/validation.ts
@@ -1,8 +1,8 @@
 import type { FIBRowItem, FIBRowErrors } from './types';
-import { isValidCidr, rowHasError as sharedRowHasError, countInvalidRows as sharedCountInvalidRows } from '../../../utils';
+import { isValidCidrPrefix, rowHasError as sharedRowHasError, countInvalidRows as sharedCountInvalidRows } from '../../../utils';
 
-/** Returns true if s is a valid IPv4 or IPv6 CIDR prefix. */
-export const isValidPrefix = isValidCidr;
+/** Returns true if s is a valid IPv4 or IPv6 CIDR prefix with a /mask. */
+export const isValidPrefix = isValidCidrPrefix;
 
 /** Returns true if s is a valid MAC address (colon-separated hex). */
 export const isValidMac = (s: string): boolean =>

--- a/web/src/utils/validation.ts
+++ b/web/src/utils/validation.ts
@@ -17,6 +17,18 @@ export const isValidCidr = (s: string): boolean => {
     return false;
 };
 
+/**
+ * Validate a CIDR prefix (IPv4 or IPv6) that must include a /mask.
+ *
+ * Unlike isValidCidr, the mask is mandatory — bare host addresses are
+ * rejected.
+ */
+export const isValidCidrPrefix = (s: string): boolean => {
+    const trimmed = s.trim();
+    if (!trimmed.includes('/')) return false;
+    return isValidCidr(trimmed);
+};
+
 /** Validate device name string. */
 export const isValidDeviceName = (s: string): boolean => /^[a-zA-Z0-9_:.\-]+$/.test(s.trim());
 


### PR DESCRIPTION
PR #1143 deduped the CIDR validator and switched the route FIB and decap prefix fields onto the optional-mask `isValidCidr`, which let bare host addresses (e.g. `10.0.0.1`, `2001:db8::1`) pass fields that require a CIDR prefix with a mask.

Add a dedicated `isValidCidrPrefix` helper that mandates the slash, and use it for the route and decap prefix validators. Forward and ACL intentionally keep the optional-mask validator.

Addresses the Codex review finding on #1143.