### PR TITLE
refactor(web): extract usePageContribution hook

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -38,3 +38,4 @@ export { useLagInterpolated } from './useLagInterpolated';
 export { useRollingWindow } from './useRollingWindow';
 
 export { useListNavigation } from './useListNavigation';
+export { usePageContribution } from './usePageContribution';

--- a/web/src/hooks/usePageContribution.ts
+++ b/web/src/hooks/usePageContribution.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { usePalette } from '../components/command-palette';
+import type { PagePaletteContribution } from '../components/command-palette';
+
+/** Registers the active page's command-palette contribution and clears it on unmount. */
+export const usePageContribution = (contribution: PagePaletteContribution): void => {
+    const { setPageContribution } = usePalette();
+    useEffect(() => {
+        setPageContribution(contribution);
+        return () => setPageContribution(null);
+    }, [contribution, setPageContribution]);
+};

--- a/web/src/pages/builtin/dashboard/DashboardPage.tsx
+++ b/web/src/pages/builtin/dashboard/DashboardPage.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { toaster } from '../../../utils';
 import { API } from '../../../api';
 import type { InstanceInfo } from '../../../api/inspect';
 import { PageLoader, EmptyState } from '../../../components';
-import { usePalette } from '../../../components/command-palette';
+import type { PagePaletteContribution } from '../../../components/command-palette';
+import { usePageContribution } from '../../../hooks';
 import { InstanceCard } from './InstanceCard';
 import './dashboard.scss';
 
@@ -11,7 +12,6 @@ import './dashboard.scss';
 const DashboardPage = (): React.JSX.Element => {
     const [instanceInfo, setInstanceInfo] = useState<InstanceInfo | null>(null);
     const [initialLoading, setInitialLoading] = useState<boolean>(true);
-    const { setPageContribution } = usePalette();
 
     const loadInspect = useCallback(async (): Promise<void> => {
         try {
@@ -28,29 +28,27 @@ const DashboardPage = (): React.JSX.Element => {
         loadInspect();
     }, [loadInspect]);
 
-    useEffect(() => {
-        setPageContribution({
-            placeholder: 'Search or jump to a page…',
-            commands: [
-                {
-                    id: '__reload_dashboard',
-                    icon: '⟳',
-                    label: 'Reload dashboard',
-                    keywords: 'reload refresh dashboard',
-                    onSelect: () => { loadInspect(); },
-                },
-            ],
-            shortcuts: [
-                {
-                    title: 'Dashboard',
-                    items: [
-                        { keys: '⌘K', desc: 'Search or jump to a page' },
-                    ],
-                },
-            ],
-        });
-        return () => setPageContribution(null);
-    }, [setPageContribution, loadInspect]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        placeholder: 'Search or jump to a page…',
+        commands: [
+            {
+                id: '__reload_dashboard',
+                icon: '⟳',
+                label: 'Reload dashboard',
+                keywords: 'reload refresh dashboard',
+                onSelect: () => { loadInspect(); },
+            },
+        ],
+        shortcuts: [
+            {
+                title: 'Dashboard',
+                items: [
+                    { keys: '⌘K', desc: 'Search or jump to a page' },
+                ],
+            },
+        ],
+    }), [loadInspect]);
+    usePageContribution(contribution);
 
     return (
         <div className="dashboard-page">

--- a/web/src/pages/builtin/devices/DevicesPage.tsx
+++ b/web/src/pages/builtin/devices/DevicesPage.tsx
@@ -2,15 +2,14 @@ import React, { useState, useCallback, useMemo, useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
-import { useSearchParamHelpers, useListNavigation } from '../../../hooks';
+import { useSearchParamHelpers, useListNavigation, usePageContribution } from '../../../hooks';
 import { PageLayout, PageLoader, EmptyState, CommandPaletteHeader } from '../../../components';
 import type { DeviceType } from '../../../api/devices';
 import type { LocalDevice } from './types';
 import { useDeviceCounters } from '../../../hooks';
 import { useCounterHistory } from '../../../hooks/useCounterHistory';
 import { useUnsavedChangesBlocker } from '../_shared/lane-editor';
-import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter, ShortcutSection } from '../../../components/command-palette';
+import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } from '../../../components/command-palette';
 import {
     DevicesList,
     DeviceDetails,
@@ -124,8 +123,6 @@ const DevicesPage: React.FC = () => {
 
     const canCreate = !loading && !(error && devices.length === 0);
 
-    const { setPageContribution } = usePalette();
-
     const commands = useMemo((): Command[] => {
         const list: Command[] = [];
         if (canCreate) {
@@ -189,15 +186,13 @@ const DevicesPage: React.FC = () => {
         items: [{ keys: '↑ ↓', desc: 'Select previous / next device' }],
     }], []);
 
-    useEffect(() => {
-        setPageContribution({
-            commands,
-            rowAdapter: rowAdapter as RowAdapter<unknown>,
-            placeholder: 'Search devices or run an action…',
-            shortcuts,
-        });
-        return () => setPageContribution(null);
-    }, [commands, rowAdapter, setPageContribution, shortcuts]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        rowAdapter: rowAdapter as RowAdapter<unknown>,
+        placeholder: 'Search devices or run an action…',
+        shortcuts,
+    }), [commands, rowAdapter, shortcuts]);
+    usePageContribution(contribution);
 
     const existingDeviceNames = devices.map(d => d.id.name || '');
 

--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -10,9 +10,8 @@ import { getAvailableModuleTypesFromInspect } from './moduleTypeOptions';
 import type { NetworkFunction } from './types';
 import { isFnSaveable } from './validation';
 import { API } from '../../../api';
-import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter, ShortcutSection } from '../../../components/command-palette';
-import { useListNavigation } from '../../../hooks';
+import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } from '../../../components/command-palette';
+import { useListNavigation, usePageContribution } from '../../../hooks';
 import './FunctionsPage.scss';
 
 /** Builds a space-joined search string for a function (id, type, chain names, module names/types). */
@@ -109,8 +108,6 @@ const FunctionsPage = (): React.JSX.Element => {
         getElementId: (id) => `fn-card-${id}`,
     });
 
-    const { setPageContribution } = usePalette();
-
     const commands = useMemo((): Command[] => {
         const list: Command[] = [];
         if (!loading) {
@@ -157,15 +154,13 @@ const FunctionsPage = (): React.JSX.Element => {
         ],
     }], []);
 
-    useEffect(() => {
-        setPageContribution({
-            commands,
-            rowAdapter: rowAdapter as RowAdapter<unknown>,
-            placeholder: 'Search functions or run an action…',
-            shortcuts,
-        });
-        return () => setPageContribution(null);
-    }, [commands, rowAdapter, setPageContribution, shortcuts]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        rowAdapter: rowAdapter as RowAdapter<unknown>,
+        placeholder: 'Search functions or run an action…',
+        shortcuts,
+    }), [commands, rowAdapter, shortcuts]);
+    usePageContribution(contribution);
 
     const headerContent = (
         <CommandPaletteHeader

--- a/web/src/pages/builtin/inspect/InspectPage.tsx
+++ b/web/src/pages/builtin/inspect/InspectPage.tsx
@@ -3,8 +3,8 @@ import { toaster } from '../../../utils';
 import { API } from '../../../api';
 import type { InstanceInfo } from '../../../api/inspect';
 import { PageLayout, PageLoader, EmptyState, CommandPaletteHeader } from '../../../components';
-import { usePalette } from '../../../components/command-palette';
-import type { Command } from '../../../components/command-palette';
+import type { Command, PagePaletteContribution } from '../../../components/command-palette';
+import { usePageContribution } from '../../../hooks';
 import { InspectPageFooter } from './InspectPageFooter';
 import { InstanceCard } from './InstanceCard';
 import './inspect.scss';
@@ -46,8 +46,6 @@ const InspectPage = (): React.JSX.Element => {
         loadInspect();
     }, [loadInspect]);
 
-    const { setPageContribution } = usePalette();
-
     const commands = useMemo((): Command[] => {
         if (!instanceInfo) {
             return [];
@@ -64,10 +62,11 @@ const InspectPage = (): React.JSX.Element => {
         }));
     }, [instanceInfo]);
 
-    useEffect(() => {
-        setPageContribution({ commands, placeholder: PLACEHOLDER });
-        return () => setPageContribution(null);
-    }, [commands, setPageContribution]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        placeholder: PLACEHOLDER,
+    }), [commands]);
+    usePageContribution(contribution);
 
     const header = (
         <CommandPaletteHeader title="Inspect" placeholder={PLACEHOLDER} />

--- a/web/src/pages/builtin/pipelines/PipelinesPage.tsx
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, EmptyState, CommandPaletteHeader } from '../../../components';
@@ -7,9 +7,8 @@ import { useDragState, useUnsavedChangesBlocker } from '../_shared/lane-editor';
 import { PipelineCard } from './components/PipelineCard';
 import { CreateEntityDialog } from '../../../components';
 import type { Pipeline } from './types';
-import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter, ShortcutSection } from '../../../components/command-palette';
-import { useListNavigation } from '../../../hooks';
+import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } from '../../../components/command-palette';
+import { useListNavigation, usePageContribution } from '../../../hooks';
 import './PipelinesPage.scss';
 
 /** Builds a space-joined search string for a pipeline (id and function names). */
@@ -52,8 +51,6 @@ const PipelinesPage = (): React.JSX.Element => {
         onActivate: (pl) => setDiffOpenId(pl.id),
         getElementId: (id) => `pl-card-${id}`,
     });
-
-    const { setPageContribution } = usePalette();
 
     const commands = useMemo((): Command[] => {
         const list: Command[] = [];
@@ -101,15 +98,13 @@ const PipelinesPage = (): React.JSX.Element => {
         ],
     }], []);
 
-    useEffect(() => {
-        setPageContribution({
-            commands,
-            rowAdapter: rowAdapter as RowAdapter<unknown>,
-            placeholder: 'Search pipelines or run an action…',
-            shortcuts,
-        });
-        return () => setPageContribution(null);
-    }, [commands, rowAdapter, setPageContribution, shortcuts]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        rowAdapter: rowAdapter as RowAdapter<unknown>,
+        placeholder: 'Search pipelines or run an action…',
+        shortcuts,
+    }), [commands, rowAdapter, shortcuts]);
+    usePageContribution(contribution);
 
     const headerContent = (
         <CommandPaletteHeader

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -3,7 +3,7 @@ import { Button, Icon, Label } from '@gravity-ui/uikit';
 import { Funnel, Pause, Play, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
-import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet, useConfigQuerySync } from '../../../hooks';
+import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet, useConfigQuerySync, usePageContribution } from '../../../hooks';
 import { useAclDraft } from './useAclDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { Rule } from '../../../api/acl';
@@ -18,8 +18,7 @@ import { SaveDiffModal } from './SaveDiffModal';
 import { useAclRuleCounters } from './useAclRuleCounters';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { DRAWER_TRANSITION_MS } from '../../../components/draft';
-import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter } from '../../../components/command-palette';
+import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/chrome.scss';
 import './acl.scss';
@@ -294,8 +293,6 @@ const AclPage: React.FC = () => {
 
     const currentIsDirty = isDirty(currentConfig);
 
-    const { setPageContribution } = usePalette();
-
     const commands = useMemo((): Command[] => {
         const list: Command[] = [];
         if (currentConfig) {
@@ -404,14 +401,12 @@ const AclPage: React.FC = () => {
         icon: '→',
     }), [allItems, handleSearchChange, handleJumpToRow]);
 
-    useEffect(() => {
-        setPageContribution({
-            commands,
-            rowAdapter: rowAdapter as RowAdapter<unknown>,
-            placeholder: 'Search rules or run an action…',
-        });
-        return () => setPageContribution(null);
-    }, [commands, rowAdapter, setPageContribution]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        rowAdapter: rowAdapter as RowAdapter<unknown>,
+        placeholder: 'Search rules or run an action…',
+    }), [commands, rowAdapter]);
+    usePageContribution(contribution);
 
     const hasStatefulRules = useMemo(() =>
         rawRules.some((rule) => (rule.actions ?? []).some((action) =>

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Funnel, Plus } from '@gravity-ui/icons';
-import { useSearchParamHelpers, useDirtyConfigSet, useConfigQuerySync } from '../../../hooks';
+import { useSearchParamHelpers, useDirtyConfigSet, useConfigQuerySync, usePageContribution } from '../../../hooks';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder, SearchInput, RowCountDisplay } from '../../../components';
 import { usePrefixDraft } from './usePrefixDraft';
 import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
@@ -15,8 +15,7 @@ import { PrefixSaveDiffModal } from './PrefixSaveDiffModal';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers, computeRowStatuses } from '../../../components/draft';
 import { useTabCycle } from '../../_shared/useTabCycle';
-import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter } from '../../../components/command-palette';
+import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
 import '../../../styles/chrome.scss';
 import './decap.scss';
 
@@ -74,8 +73,6 @@ const DecapPage: React.FC = () => {
         setDiffModalOpen(false);
         handleDragLeave();
     }, [currentConfig, handleDragLeave]);
-
-    const { setPageContribution } = usePalette();
 
     const rawRows: PrefixRowItem[] = draftRows(currentConfig);
     const rawServerRows: PrefixRowItem[] = serverRows(currentConfig);
@@ -210,14 +207,12 @@ const DecapPage: React.FC = () => {
         icon: '→',
     }), [rawRows, updateParams, setActiveRowId, setEditingRowId]);
 
-    useEffect(() => {
-        setPageContribution({
-            commands,
-            rowAdapter: rowAdapter as RowAdapter<unknown>,
-            placeholder: 'Search prefixes or run an action…',
-        });
-        return () => setPageContribution(null);
-    }, [commands, rowAdapter, setPageContribution]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        rowAdapter: rowAdapter as RowAdapter<unknown>,
+        placeholder: 'Search prefixes or run an action…',
+    }), [commands, rowAdapter]);
+    usePageContribution(contribution);
 
     const pageHeader = (
         <CommandPaletteHeader

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet, useConfigQuerySync } from '../../../hooks';
+import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet, useConfigQuerySync, usePageContribution } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
@@ -21,8 +21,7 @@ import { SaveDiffModal } from './SaveDiffModal';
 import { useForwardRuleCounters } from './useForwardRuleCounters';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { DRAWER_TRANSITION_MS } from '../../../components/draft';
-import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter } from '../../../components/command-palette';
+import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/chrome.scss';
 import './forward.scss';
@@ -219,8 +218,6 @@ const ForwardPage: React.FC = () => {
         setFlashRowId(null);
     }, [currentConfig]);
 
-    const { setPageContribution } = usePalette();
-
     usePageKeyboardShortcuts({
         onNewRule: openAdd,
         onEscape: closeDrawer,
@@ -341,14 +338,12 @@ const ForwardPage: React.FC = () => {
         icon: '→',
     }), [allItems, handleSearchChange, handleJumpToRow]);
 
-    useEffect(() => {
-        setPageContribution({
-            commands,
-            rowAdapter: rowAdapter as RowAdapter<unknown>,
-            placeholder: 'Search rules or run an action…',
-        });
-        return () => setPageContribution(null);
-    }, [commands, rowAdapter, setPageContribution]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        rowAdapter: rowAdapter as RowAdapter<unknown>,
+        placeholder: 'Search rules or run an action…',
+    }), [commands, rowAdapter]);
+    usePageContribution(contribution);
 
     const pageHeader = (
         <CommandPaletteHeader

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@gravity-ui/uikit';
 import { CircleInfo, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers } from '../../../hooks';
+import { useSearchParamHelpers, usePageContribution } from '../../../hooks';
 import { API } from '../../../api';
 import { Direction, type FwStateEntry, type ListEntriesRequest, type MapStats } from '../../../api/fwstate';
 import { ConfirmDialog, ConfigTabStrip, PageLayout, PageLoader, EmptyPagePlaceholder } from '../../../components';
@@ -26,8 +26,7 @@ import { formatBytes, toaster, compareNatural } from '../../../utils';
 import { AddConfigModal, DeleteConfigModal, CommandPaletteHeader } from '../../../components';
 import { SaveIcon, TrashIcon } from '../../../components/draft';
 import { useTabCycle } from '../../_shared/useTabCycle';
-import { usePalette } from '../../../components/command-palette';
-import type { Command } from '../../../components/command-palette';
+import type { Command, PagePaletteContribution } from '../../../components/command-palette';
 import '../../../styles/chrome.scss';
 import './fwstate.scss';
 
@@ -1113,8 +1112,6 @@ const FWStatePage: React.FC = () => {
         enabled: !loading,
     });
 
-    const { setPageContribution } = usePalette();
-
     const updateActiveSubTab = useCallback((tab: StateSubTab): void => {
         updateParams({ [QP_TAB]: tab });
     }, [updateParams]);
@@ -1508,13 +1505,11 @@ const FWStatePage: React.FC = () => {
         handleOpenAcl,
     ]);
 
-    useEffect(() => {
-        setPageContribution({
-            commands,
-            placeholder: 'Search FWState actions…',
-        });
-        return () => setPageContribution(null);
-    }, [commands, setPageContribution]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        placeholder: 'Search FWState actions…',
+    }), [commands]);
+    usePageContribution(contribution);
 
     const aclRows = useMemo(() => aclMeta.map((row) => ({ ...row, isLinkedHere: row.fwstateName === currentName })), [aclMeta, currentName]);
 

--- a/web/src/pages/modules/pdump/PdumpPage.tsx
+++ b/web/src/pages/modules/pdump/PdumpPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { Button, Icon } from '@gravity-ui/uikit';
 import { ArrowDownToLine, Plus } from '@gravity-ui/icons';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers } from '../../../hooks';
+import { useSearchParamHelpers, usePageContribution } from '../../../hooks';
 import { PageLayout, PageLoader, ConfigTabStrip, EmptyPagePlaceholder, CommandPaletteHeader } from '../../../components';
 import { toaster } from '../../../utils';
 import {
@@ -17,8 +17,7 @@ import ConfigStrip from './ConfigStrip';
 import PacketDrawer from './PacketDrawer';
 import DeleteConfigDialog from './DeleteConfigDialog';
 import type { PdumpConfigInfo, CapturedPacket } from './types';
-import { usePalette } from '../../../components/command-palette';
-import type { Command } from '../../../components/command-palette';
+import type { Command, PagePaletteContribution } from '../../../components/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/chrome.scss';
 import './pdump.scss';
@@ -350,8 +349,6 @@ const PdumpPage: React.FC = () => {
         enabled: !loading,
     });
 
-    const { setPageContribution } = usePalette();
-
     const handleOpenDeleteDialog = useCallback((configName: string) => {
         setDeletingConfigName(configName);
     }, []);
@@ -531,10 +528,11 @@ const PdumpPage: React.FC = () => {
         handleOpenDeleteDialog,
     ]);
 
-    useEffect(() => {
-        setPageContribution({ commands, placeholder: 'Search pdump actions…' });
-        return () => setPageContribution(null);
-    }, [commands, setPageContribution]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        placeholder: 'Search pdump actions…',
+    }), [commands]);
+    usePageContribution(contribution);
 
     const pageHeader = (
         <CommandPaletteHeader

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, useDirtyConfigSet, useConfigQuerySync } from '../../../hooks';
+import { useSearchParamHelpers, useDirtyConfigSet, useConfigQuerySync, usePageContribution } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useFIBDraft } from './useFIBDraft';
@@ -15,8 +15,7 @@ import { FIBSaveDiffModal } from './FIBSaveDiffModal';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers, computeRowStatuses } from '../../../components/draft';
 import { isValidCidr as isValidCIDR } from '../../../utils';
-import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter } from '../../../components/command-palette';
+import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/chrome.scss';
 import './route.scss';
@@ -113,8 +112,6 @@ const RoutePage: React.FC = () => {
         setDiffModalOpen, setDeleteConfirmOpen, setDeleteConfigOpen,
         dragDrop,
     });
-
-    const { setPageContribution } = usePalette();
 
     const openAdd = useCallback((prefix = ''): void => {
         const newRow: FIBRowItem = { id: makeRowId(), prefix, dst_mac: '', src_mac: '', device: '' };
@@ -232,15 +229,13 @@ const RoutePage: React.FC = () => {
         max: 7,
     }), [rawRows]);
 
-    useEffect(() => {
-        setPageContribution({
-            commands,
-            dynamicCommands,
-            rowAdapter: rowAdapter as RowAdapter<unknown>,
-            placeholder: 'Search routes or run an action…',
-        });
-        return () => setPageContribution(null);
-    }, [commands, dynamicCommands, rowAdapter, setPageContribution]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands,
+        dynamicCommands,
+        rowAdapter: rowAdapter as RowAdapter<unknown>,
+        placeholder: 'Search routes or run an action…',
+    }), [commands, dynamicCommands, rowAdapter]);
+    usePageContribution(contribution);
 
     const pageHeader = (
         <CommandPaletteHeader

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,12 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, useListNavigation } from '../../../hooks';
+import { useSearchParamHelpers, useListNavigation, usePageContribution } from '../../../hooks';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus, Layers } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder } from '../../../components';
 import { BulkDeleteModal, DeleteConfigModal, CommandPaletteHeader } from '../../../components';
-import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter, ShortcutSection } from '../../../components/command-palette';
+import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } from '../../../components/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
 import { parseIPAddress } from '../../../utils';
@@ -104,8 +103,6 @@ const NeighboursPage: React.FC = () => {
     const isBuiltIn = activeTableInfo?.built_in ?? false;
 
     const tabsList = [MERGED_TAB, ...tables.map((t) => t.name || '').filter(Boolean)];
-
-    const { setPageContribution } = usePalette();
 
     const { updateParams } = useSearchParamHelpers(setSearchParams);
 
@@ -511,16 +508,14 @@ const NeighboursPage: React.FC = () => {
         ],
     }], []);
 
-    useEffect(() => {
-        setPageContribution({
-            commands: neighbourCommands,
-            dynamicCommands: neighbourDynamicCommands,
-            rowAdapter: neighbourRowAdapter as RowAdapter<unknown>,
-            placeholder: 'Search neighbours or type an IP…',
-            shortcuts,
-        });
-        return () => setPageContribution(null);
-    }, [neighbourCommands, neighbourDynamicCommands, neighbourRowAdapter, setPageContribution, shortcuts]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands: neighbourCommands,
+        dynamicCommands: neighbourDynamicCommands,
+        rowAdapter: neighbourRowAdapter as RowAdapter<unknown>,
+        placeholder: 'Search neighbours or type an IP…',
+        shortcuts,
+    }), [neighbourCommands, neighbourDynamicCommands, neighbourRowAdapter, shortcuts]);
+    usePageContribution(contribution);
 
     const searchActive = family !== 'all' || !!stateFilter;
 

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -1,12 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { ArrowRightToLine, Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { AddConfigModal } from '../../../components';
 import { BulkDeleteModal, CommandPaletteHeader } from '../../../components';
-import { usePalette } from '../../../components/command-palette';
-import type { Command, RowAdapter, ShortcutSection } from '../../../components/command-palette';
-import { useListNavigation } from '../../../hooks';
+import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } from '../../../components/command-palette';
+import { useListNavigation, usePageContribution } from '../../../hooks';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import { API } from '../../../api';
 import { toaster, parseIPAddress } from '../../../utils';
@@ -100,8 +99,6 @@ const RoutePage: React.FC = () => {
         configs.forEach((c) => m.set(c, (configRoutes.get(c) || []).length));
         return m;
     }, [configs, configRoutes]);
-
-    const { setPageContribution } = usePalette();
 
     useTabCycle({
         tabs: configs,
@@ -392,16 +389,14 @@ const RoutePage: React.FC = () => {
         ],
     }], []);
 
-    useEffect(() => {
-        setPageContribution({
-            commands: routeCommands,
-            dynamicCommands: routeDynamicCommands,
-            rowAdapter: routeRowAdapter as RowAdapter<unknown>,
-            placeholder: 'Search routes, prefixes, or type an IP…',
-            shortcuts,
-        });
-        return () => setPageContribution(null);
-    }, [routeCommands, routeDynamicCommands, routeRowAdapter, setPageContribution, shortcuts]);
+    const contribution = useMemo<PagePaletteContribution>(() => ({
+        commands: routeCommands,
+        dynamicCommands: routeDynamicCommands,
+        rowAdapter: routeRowAdapter as RowAdapter<unknown>,
+        placeholder: 'Search routes, prefixes, or type an IP…',
+        shortcuts,
+    }), [routeCommands, routeDynamicCommands, routeRowAdapter, shortcuts]);
+    usePageContribution(contribution);
 
     const pageHeader = (
         <CommandPaletteHeader


### PR DESCRIPTION
- Replace the duplicated command-palette registration effect across thirteen pages with a shared `usePageContribution` hook in `web/src/hooks`.
- Each page now memoizes its contribution object and passes it to the hook, which owns the register-and-clear-on-unmount lifecycle.
- No behavior change: the contribution content and effect dependencies are preserved verbatim at every call site.