### PR TITLE
refactor(web): extract useLaneCardNavigation hook

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -38,4 +38,5 @@ export { useLagInterpolated } from './useLagInterpolated';
 export { useRollingWindow } from './useRollingWindow';
 
 export { useListNavigation } from './useListNavigation';
+export { useLaneCardNavigation } from './useLaneCardNavigation';
 export { usePageContribution } from './usePageContribution';

--- a/web/src/hooks/useLaneCardNavigation.ts
+++ b/web/src/hooks/useLaneCardNavigation.ts
@@ -1,0 +1,48 @@
+import { useCallback, useState } from 'react';
+import { useListNavigation } from './useListNavigation';
+
+interface UseLaneCardNavigationOptions<T extends { id: string }> {
+    /** Rows to navigate over. */
+    rows: T[];
+    /** DOM id prefix for each card element, e.g. 'fn' yields 'fn-card-<id>'. */
+    cardIdPrefix: string;
+    /** Called when Enter is pressed on the active row. */
+    onActivate: (row: T) => void;
+}
+
+interface LaneCardNavigation {
+    /** Currently highlighted row id, or null. */
+    activeId: string | null;
+    /** Row id to flash after a jump, or null. */
+    flashId: string | null;
+    /** Flashes and scrolls the card with the given id into view. */
+    jumpTo: (id: string) => void;
+}
+
+/** Keyboard navigation plus flash-and-scroll-to-card for a vertical list of lane cards. */
+export const useLaneCardNavigation = <T extends { id: string }>({
+    rows,
+    cardIdPrefix,
+    onActivate,
+}: UseLaneCardNavigationOptions<T>): LaneCardNavigation => {
+    const [activeId, setActiveId] = useState<string | null>(null);
+    const [flashId, setFlashId] = useState<string | null>(null);
+
+    const jumpTo = useCallback((id: string): void => {
+        setFlashId(null);
+        setTimeout(() => {
+            setFlashId(id);
+            document.getElementById(`${cardIdPrefix}-card-${id}`)?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }, 0);
+    }, [cardIdPrefix]);
+
+    useListNavigation<T>({
+        rows,
+        activeId,
+        setActiveId,
+        onActivate,
+        getElementId: (id) => `${cardIdPrefix}-card-${id}`,
+    });
+
+    return { activeId, flashId, jumpTo };
+};

--- a/web/src/pages/builtin/functions/FunctionsPage.tsx
+++ b/web/src/pages/builtin/functions/FunctionsPage.tsx
@@ -11,7 +11,7 @@ import type { NetworkFunction } from './types';
 import { isFnSaveable } from './validation';
 import { API } from '../../../api';
 import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } from '../../../components/command-palette';
-import { useListNavigation, usePageContribution } from '../../../hooks';
+import { useLaneCardNavigation, usePageContribution } from '../../../hooks';
 import './FunctionsPage.scss';
 
 /** Builds a space-joined search string for a function (id, type, chain names, module names/types). */
@@ -35,9 +35,7 @@ const FunctionsPage = (): React.JSX.Element => {
     const [availableModuleConfigNamesByType, setAvailableModuleConfigNamesByType] = useState<Record<string, string[]>>({});
     const [availableModuleConfigNames, setAvailableModuleConfigNames] = useState<string[]>([]);
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
-    const [flashId, setFlashId] = useState<string | null>(null);
     const [diffOpenId, setDiffOpenId] = useState<string | null>(null);
-    const [activeId, setActiveId] = useState<string | null>(null);
     const { dragState, startDrag, endDrag } = useDragState();
 
     useEffect(() => {
@@ -92,20 +90,10 @@ const FunctionsPage = (): React.JSX.Element => {
     const handleDiscard = useCallback((fnId: string) => (): void => discardFn(fnId), [discardFn]);
     const handleDelete = useCallback((fnId: string) => (): Promise<boolean> => deleteFn(fnId), [deleteFn]);
 
-    const jumpToFn = useCallback((id: string): void => {
-        setFlashId(null);
-        setTimeout(() => {
-            setFlashId(id);
-            document.getElementById(`fn-card-${id}`)?.scrollIntoView({ block: 'center', behavior: 'smooth' });
-        }, 0);
-    }, []);
-
-    useListNavigation<NetworkFunction>({
+    const { activeId, flashId, jumpTo: jumpToFn } = useLaneCardNavigation<NetworkFunction>({
         rows: functions,
-        activeId,
-        setActiveId,
+        cardIdPrefix: 'fn',
         onActivate: (fn) => setDiffOpenId(fn.id),
-        getElementId: (id) => `fn-card-${id}`,
     });
 
     const commands = useMemo((): Command[] => {

--- a/web/src/pages/builtin/pipelines/PipelinesPage.tsx
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.tsx
@@ -8,7 +8,7 @@ import { PipelineCard } from './components/PipelineCard';
 import { CreateEntityDialog } from '../../../components';
 import type { Pipeline } from './types';
 import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } from '../../../components/command-palette';
-import { useListNavigation, usePageContribution } from '../../../hooks';
+import { useLaneCardNavigation, usePageContribution } from '../../../hooks';
 import './PipelinesPage.scss';
 
 /** Builds a space-joined search string for a pipeline (id and function names). */
@@ -20,9 +20,7 @@ const plSearchText = (pl: Pipeline): string => [pl.id, ...pl.functions.map(f => 
 const PipelinesPage = (): React.JSX.Element => {
     const { pipelines, loading, isDirty, getServerPipeline, dispatch, savePipeline, discardPipeline, createPipeline, deletePipeline, loadFunctionList } = usePipelinesData();
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
-    const [flashId, setFlashId] = useState<string | null>(null);
     const [diffOpenId, setDiffOpenId] = useState<string | null>(null);
-    const [activeId, setActiveId] = useState<string | null>(null);
     const { dragState, startDrag, endDrag } = useDragState();
 
     const anyDirty = useMemo(
@@ -36,20 +34,10 @@ const PipelinesPage = (): React.JSX.Element => {
     const handleDiscard = useCallback((pipelineId: string) => (): void => discardPipeline(pipelineId), [discardPipeline]);
     const handleDelete = useCallback((pipelineId: string) => (): Promise<boolean> => deletePipeline(pipelineId), [deletePipeline]);
 
-    const jumpToPipeline = useCallback((id: string): void => {
-        setFlashId(null);
-        setTimeout(() => {
-            setFlashId(id);
-            document.getElementById(`pl-card-${id}`)?.scrollIntoView({ block: 'center', behavior: 'smooth' });
-        }, 0);
-    }, []);
-
-    useListNavigation<Pipeline>({
+    const { activeId, flashId, jumpTo: jumpToPipeline } = useLaneCardNavigation<Pipeline>({
         rows: pipelines,
-        activeId,
-        setActiveId,
+        cardIdPrefix: 'pl',
         onActivate: (pl) => setDiffOpenId(pl.id),
-        getElementId: (id) => `pl-card-${id}`,
     });
 
     const commands = useMemo((): Command[] => {


### PR DESCRIPTION
- Share the keyboard-navigation and flash-on-jump wiring duplicated between the Functions and Pipelines lane pages via a `useLaneCardNavigation` hook in `web/src/hooks`.
- Each page passes its row list, card-id prefix, and activate callback, and consumes the returned active id, flash id, and jump helper.
- No behavior change: verified with a Playwright A/B pixel comparison across default, arrow-key highlight, Enter-to-diff, and palette-jump states on both pages (zero pixel diff after render settles).