### PR TITLE
refactor(web): extract keyboard-event guard predicates

### DIFF
--- a/web/src/components/command-palette/useHelpShortcut.ts
+++ b/web/src/components/command-palette/useHelpShortcut.ts
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { isTypingTarget, isOverlayOpen } from '../../utils/keyboard';
 
 /** Wires the ? key to toggle the keyboard-shortcuts help overlay, and Escape to close it. */
 export const useHelpShortcut = (
@@ -18,15 +19,11 @@ export const useHelpShortcut = (
                 if (e.metaKey || e.ctrlKey || e.altKey) return;
 
                 const target = e.target as HTMLElement;
-                if (
-                    target.tagName === 'INPUT' ||
-                    target.tagName === 'TEXTAREA' ||
-                    target.isContentEditable
-                ) {
+                if (isTypingTarget(target)) {
                     return;
                 }
 
-                if (document.querySelector('.g-modal, .yn-modal-backdrop, .yn-drawer--open')) return;
+                if (isOverlayOpen()) return;
                 e.preventDefault();
                 setHelpOpen((prev) => !prev);
             }

--- a/web/src/hooks/useListNavigation.ts
+++ b/web/src/hooks/useListNavigation.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { usePalette } from '../components/command-palette';
+import { isTypingTarget, isOverlayOpen } from '../utils/keyboard';
 
 interface UseListNavigationOptions<T extends { id: string }> {
     /** Rows to navigate over. */
@@ -48,15 +49,11 @@ export const useListNavigation = <T extends { id: string }>({
             if (e.metaKey || e.ctrlKey || e.altKey) return;
 
             const target = e.target as HTMLElement;
-            if (
-                target.tagName === 'INPUT' ||
-                target.tagName === 'TEXTAREA' ||
-                target.isContentEditable
-            ) {
+            if (isTypingTarget(target)) {
                 return;
             }
 
-            if (document.querySelector('.g-modal, .yn-modal-backdrop, .yn-drawer--open')) {
+            if (isOverlayOpen()) {
                 return;
             }
 

--- a/web/src/pages/_shared/useTabCycle.ts
+++ b/web/src/pages/_shared/useTabCycle.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { usePalette } from '../../components/command-palette';
+import { isTypingTarget, isOverlayOpen } from '../../utils/keyboard';
 
 interface UseTabCycleOptions {
     /** Ordered list of tab identifiers. */
@@ -29,15 +30,11 @@ export const useTabCycle = ({ tabs, activeTab, onSelect, enabled = true }: UseTa
             if (e.metaKey || e.ctrlKey || e.altKey) return;
 
             const target = e.target as HTMLElement;
-            if (
-                target.tagName === 'INPUT' ||
-                target.tagName === 'TEXTAREA' ||
-                target.isContentEditable
-            ) {
+            if (isTypingTarget(target)) {
                 return;
             }
 
-            if (document.querySelector('.g-modal, .yn-modal-backdrop, .yn-drawer--open')) {
+            if (isOverlayOpen()) {
                 return;
             }
 

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -13,3 +13,4 @@ export * from './validation';
 export * from './yaml';
 export * from './ranges';
 export * from './interpolation';
+export * from './keyboard';

--- a/web/src/utils/keyboard.ts
+++ b/web/src/utils/keyboard.ts
@@ -1,0 +1,9 @@
+/** Returns true when the event target is a focusable text-entry element. */
+export const isTypingTarget = (target: EventTarget | null): boolean => {
+    const el = target as HTMLElement | null;
+    return !!el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable);
+};
+
+/** Returns true when a modal or drawer overlay is currently open. */
+export const isOverlayOpen = (): boolean =>
+    document.querySelector('.g-modal, .yn-modal-backdrop, .yn-drawer--open') !== null;


### PR DESCRIPTION
Move the duplicated typing-target and overlay-open keyboard guards into a shared utils/keyboard module and reuse them in the list-navigation, tab-cycle and help-shortcut hooks.
Only byte-equivalent inline occurrences were replaced; sites with a different guard are left untouched.