### PR TITLE
refactor(web): extract module-card derivation into a hook

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -40,3 +40,6 @@ export { useRollingWindow } from './useRollingWindow';
 export { useListNavigation } from './useListNavigation';
 export { useLaneCardNavigation } from './useLaneCardNavigation';
 export { usePageContribution } from './usePageContribution';
+
+export { useModuleCards } from './useModuleCards';
+export type { ModuleCardData } from './useModuleCards';

--- a/web/src/hooks/useModuleCards.ts
+++ b/web/src/hooks/useModuleCards.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import type { InstanceInfo } from '../api/inspect';
+import {
+    computeModulePipelineUsage,
+    getModuleDescription,
+    normalizeModuleName,
+} from '../pages/builtin/inspect/utils';
+
+export interface ModuleCardData {
+    key: string;
+    name: string;
+    cfg: number;
+    pipe: number;
+    inUse: boolean;
+    desc: string;
+}
+
+/** Derives the per-module card data array from an instance snapshot. */
+export const useModuleCards = (instance: InstanceInfo): ModuleCardData[] => {
+    const modules = instance.dp_modules ?? [];
+    const configs = instance.cp_configs ?? [];
+
+    const pipeUsage = useMemo(() => computeModulePipelineUsage(instance), [instance]);
+
+    const moduleData = useMemo(
+        () =>
+            modules.map((m, idx) => {
+                const name = m.name ?? '';
+                const key = name || `module-${idx}`;
+                const moduleKey = normalizeModuleName(name);
+                const cfg = configs.filter(
+                    (c) => normalizeModuleName(c.type ?? '') === moduleKey,
+                ).length;
+                const pipe = pipeUsage.get(moduleKey) ?? 0;
+                const inUse = cfg > 0 || pipe > 0;
+                return { key, name, cfg, pipe, inUse, desc: getModuleDescription(name) };
+            }),
+        [modules, configs, pipeUsage],
+    );
+
+    return moduleData;
+};

--- a/web/src/pages/builtin/dashboard/DataplaneModules.tsx
+++ b/web/src/pages/builtin/dashboard/DataplaneModules.tsx
@@ -1,14 +1,12 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { InstanceInfo } from '../../../api/inspect';
 import {
-    computeModulePipelineUsage,
     getModuleCardAgentUsage,
-    getModuleDescription,
     getModuleRoute,
-    normalizeModuleName,
     type AgentUsage,
 } from '../inspect/utils';
+import { useModuleCards } from '../../../hooks/useModuleCards';
 import { MemoryBar } from '../inspect/MemoryBar';
 import { fmtIEC } from '../inspect/formatters';
 
@@ -21,25 +19,7 @@ export interface DataplaneModulesProps {
 export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance, usage }) => {
     const navigate = useNavigate();
     const modules = instance.dp_modules ?? [];
-    const configs = instance.cp_configs ?? [];
-
-    const pipeUsage = useMemo(() => computeModulePipelineUsage(instance), [instance]);
-
-    const moduleData = useMemo(
-        () =>
-            modules.map((m, idx) => {
-                const name = m.name ?? '';
-                const key = name || `module-${idx}`;
-                const moduleKey = normalizeModuleName(name);
-                const cfg = configs.filter(
-                    (c) => normalizeModuleName(c.type ?? '') === moduleKey,
-                ).length;
-                const pipe = pipeUsage.get(moduleKey) ?? 0;
-                const inUse = cfg > 0 || pipe > 0;
-                return { key, name, cfg, pipe, inUse, desc: getModuleDescription(name) };
-            }),
-        [modules, configs, pipeUsage],
-    );
+    const moduleData = useModuleCards(instance);
 
     const colCount = Math.min(9, Math.max(1, modules.length));
 

--- a/web/src/pages/builtin/inspect/ModuleStrip.tsx
+++ b/web/src/pages/builtin/inspect/ModuleStrip.tsx
@@ -1,16 +1,11 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { InstanceInfo } from '../../../api/inspect';
 import { fmtIEC } from './formatters';
 import { MemoryBar } from './MemoryBar';
-import {
-    computeModulePipelineUsage,
-    getModuleCardAgentUsage,
-    getModuleDescription,
-    getModuleRoute,
-    normalizeModuleName,
-} from './utils';
+import { getModuleCardAgentUsage, getModuleRoute } from './utils';
 import type { AgentUsage } from './utils';
+import { useModuleCards } from '../../../hooks/useModuleCards';
 
 export interface ModuleStripProps {
     instance: InstanceInfo;
@@ -21,23 +16,7 @@ export interface ModuleStripProps {
 export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance, usage }) => {
     const navigate = useNavigate();
     const modules = instance.dp_modules ?? [];
-    const configs = instance.cp_configs ?? [];
-
-    const pipeUsage = useMemo(() => computeModulePipelineUsage(instance), [instance]);
-
-    const moduleData = useMemo(
-        () =>
-            modules.map((m, idx) => {
-                const name = m.name ?? '';
-                const key = name || `module-${idx}`;
-                const moduleKey = normalizeModuleName(name);
-                const cfg = configs.filter((c) => normalizeModuleName(c.type ?? '') === moduleKey).length;
-                const pipe = pipeUsage.get(moduleKey) ?? 0;
-                const inUse = cfg > 0 || pipe > 0;
-                return { key, name, cfg, pipe, inUse, desc: getModuleDescription(name) };
-            }),
-        [modules, configs, pipeUsage],
-    );
+    const moduleData = useModuleCards(instance);
 
     return (
         <div id="iv-section-modules" className="iv-module-strip">


### PR DESCRIPTION
Pull the identical module-card data derivation out of DataplaneModules and ModuleStrip into a shared useModuleCards hook.
Each component keeps its own markup and column layout; the derived data is unchanged.