### PR TITLE
refactor(web): extract shared toggle-chip base mixin

### DIFF
--- a/web/src/pages/operators/neighbours/neighbours.scss
+++ b/web/src/pages/operators/neighbours/neighbours.scss
@@ -412,21 +412,7 @@
 
 // NUD-state toggle chips — one per distinct state present in the loaded data.
 .nb-state-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    padding: 6px 12px;
-    border-radius: var(--yn-r-md);
-    border: none;
-    box-shadow: inset 0 0 0 1px var(--yn-line-2);
-    background: var(--yn-bg-2);
-    font-size: 12.5px;
-    font-weight: 600;
-    color: var(--yn-text-2);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s, box-shadow 0.12s;
-    white-space: nowrap;
-    flex-shrink: 0;
+    @include toggle-chip-base;
 
     &:hover {
         color: var(--yn-text);

--- a/web/src/pages/operators/route/route.scss
+++ b/web/src/pages/operators/route/route.scss
@@ -24,21 +24,7 @@
 // ─── Toggle chips ─────────────────────────────────────────────────────────────
 
 .ro-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 7px;
-    padding: 6px 12px;
-    border-radius: var(--yn-r-md);
-    border: none;
-    box-shadow: inset 0 0 0 1px var(--yn-line-2);
-    background: var(--yn-bg-2);
-    font-size: 12.5px;
-    font-weight: 600;
-    color: var(--yn-text-2);
-    cursor: pointer;
-    transition: background 0.12s, color 0.12s, box-shadow 0.12s;
-    white-space: nowrap;
-    flex-shrink: 0;
+    @include toggle-chip-base;
 
     &:hover {
         background: var(--yn-bg-2);

--- a/web/src/styles/_mixins.scss
+++ b/web/src/styles/_mixins.scss
@@ -136,6 +136,25 @@
     font-variant-numeric: tabular-nums;
 }
 
+/** Base declarations shared by the toggle-chip selectors (route + neighbours). */
+@mixin toggle-chip-base {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 12px;
+    border-radius: var(--yn-r-md);
+    border: none;
+    box-shadow: inset 0 0 0 1px var(--yn-line-2);
+    background: var(--yn-bg-2);
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--yn-text-2);
+    cursor: pointer;
+    transition: background 0.12s, color 0.12s, box-shadow 0.12s;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
 /** Side-by-side diff dialog chrome — shared by fn-diff-dialog and pl-diff-dialog. */
 @mixin diff-dialog($page-bg, $line) {
     // Override Gravity's size="l" to be wide enough for side-by-side split view.


### PR DESCRIPTION
Replace the duplicated toggle-chip base declarations in the neighbours and route pages with a shared toggle-chip-base SCSS mixin, keeping each page's own hover and modifier rules.
Compiled CSS is byte-identical to before, verified via the dist CSS hash set.