### PR TITLE
refactor(web): dedup VLAN and port range parsing into shared util

### DIFF
--- a/web/src/pages/modules/acl/parseHelpers.ts
+++ b/web/src/pages/modules/acl/parseHelpers.ts
@@ -6,32 +6,9 @@
  */
 
 import type { ProtoRange } from '../../../api/acl';
+import { parseRangesRaw } from '../../../utils';
 
-export { parseCidrsToIPNets } from '../../../utils';
-
-/** Parse a port/vlan range string (e.g. "80-90", "80") to a {from, to} object. */
-const parseRangeStr = (s: string): { from: number; to: number } | null => {
-    const trimmed = s.trim();
-    if (!trimmed) return null;
-    if (trimmed.includes('-')) {
-        const [fromStr, toStr] = trimmed.split('-');
-        const from = parseInt(fromStr, 10);
-        const to = parseInt(toStr, 10);
-        if (isNaN(from) || isNaN(to)) return null;
-        return { from, to };
-    }
-    const val = parseInt(trimmed, 10);
-    if (isNaN(val)) return null;
-    return { from: val, to: val };
-};
-
-/** Parse a raw range input string (comma or newline separated) to a range array. */
-export const parseRangesRaw = (raw: string): Array<{ from: number; to: number }> => {
-    if (!raw.trim()) return [];
-    return raw.split(/[,\n]+/)
-        .map(s => parseRangeStr(s))
-        .filter((r): r is { from: number; to: number } => r !== null);
-};
+export { parseCidrsToIPNets, parseRangesRaw } from '../../../utils';
 
 /** Parse encoded proto ranges (e.g. "1536-1791") to ProtoRange wire objects. */
 export const parseProtoRangesRaw = (raw: string): ProtoRange[] => parseRangesRaw(raw) as ProtoRange[];

--- a/web/src/pages/modules/forward/hooks.ts
+++ b/web/src/pages/modules/forward/hooks.ts
@@ -1,6 +1,6 @@
 import type { Rule, VlanRange } from '../../../api/forward';
 import { ForwardMode } from '../../../api/forward';
-import { formatIPNetItem, formatRange, parseCidrsToIPNets } from '../../../utils';
+import { formatIPNetItem, formatRange, parseCidrsToIPNets, parseRangesRaw } from '../../../utils';
 import type { RuleItem, RuleDraft } from './types';
 
 /** Format VlanRange array to a display string. */
@@ -47,19 +47,6 @@ export const rulesToNgItems = (rules: Rule[]): RuleItem[] => {
     });
 };
 
-/** Parse a VLAN range string (e.g. "100-200, 300") to VlanRange array. */
-export const parseVlanRangesStr = (input: string): VlanRange[] => {
-    if (!input.trim()) return [];
-    return input.split(',').map((s) => s.trim()).filter(Boolean).map((part) => {
-        if (part.includes('-')) {
-            const [fromStr, toStr] = part.split('-');
-            return { from: parseInt(fromStr, 10), to: parseInt(toStr, 10) };
-        }
-        const val = parseInt(part, 10);
-        return { from: val, to: val };
-    }).filter((r) => !isNaN(r.from ?? NaN) && !isNaN(r.to ?? NaN));
-};
-
 /** Convert a RuleDraft to a Rule for the API. */
 export const draftToRule = (draft: RuleDraft): Rule => ({
     action: {
@@ -68,7 +55,7 @@ export const draftToRule = (draft: RuleDraft): Rule => ({
         counter: draft.counter || undefined,
     },
     devices: draft.deviceNames.map((name) => ({ name })),
-    vlan_ranges: parseVlanRangesStr(draft.vlansRaw),
+    vlan_ranges: parseRangesRaw(draft.vlansRaw),
     srcs: parseCidrsToIPNets(draft.sourceCidrs),
     dsts: parseCidrsToIPNets(draft.dstCidrs),
 });

--- a/web/src/utils/ranges.ts
+++ b/web/src/utils/ranges.ts
@@ -1,3 +1,27 @@
+/** Parse a port/vlan range string (e.g. "80-90", "80") to a {from, to} object. */
+const parseRangeStr = (s: string): { from: number; to: number } | null => {
+    const trimmed = s.trim();
+    if (!trimmed) return null;
+    if (trimmed.includes('-')) {
+        const [fromStr, toStr] = trimmed.split('-');
+        const from = parseInt(fromStr, 10);
+        const to = parseInt(toStr, 10);
+        if (isNaN(from) || isNaN(to)) return null;
+        return { from, to };
+    }
+    const val = parseInt(trimmed, 10);
+    if (isNaN(val)) return null;
+    return { from: val, to: val };
+};
+
+/** Parse a raw range input string (comma or newline separated) to a range array. */
+export const parseRangesRaw = (raw: string): Array<{ from: number; to: number }> => {
+    if (!raw.trim()) return [];
+    return raw.split(/[,\n]+/)
+        .map(s => parseRangeStr(s))
+        .filter((r): r is { from: number; to: number } => r !== null);
+};
+
 /** Format a {from, to} range to "80" (when from===to) or "80-90". */
 export const formatRange = (r: { from?: number; to?: number }): string => {
     const from = r.from ?? 0;


### PR DESCRIPTION
- Moved `parseRangeStr`/`parseRangesRaw` from the acl page into `web/src/utils/ranges.ts` (already barrel-exported).
- The forward rule drawer now reuses the shared parser instead of its own `parseVlanRangesStr` copy.
- Behaviour is unchanged: forward feeds comma-separated VLAN tokens, verified identical against the old parser over a 200k-sample sweep.