### PR TITLE
refactor(web): adopt shared dumpYamlDoc at inline yaml.dump sites

### DIFF
--- a/web/src/pages/builtin/devices/components/DeviceDiffModal.tsx
+++ b/web/src/pages/builtin/devices/components/DeviceDiffModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import * as yaml from 'js-yaml';
 import type { LocalDevice } from '../types';
 import { SaveDiffModal } from '../../../../components';
+import { dumpYamlDoc } from '../../../../utils';
 
 export interface DeviceDiffModalProps {
     device: LocalDevice;
@@ -28,7 +28,7 @@ const toYaml = (device: LocalDevice): string => {
     if (device.type === 'vlan') {
         obj.vlan_id = device.vlanId ?? 0;
     }
-    return yaml.dump(obj, { sortKeys: false, lineWidth: 120, noRefs: true });
+    return dumpYamlDoc(obj);
 };
 
 /** Modal showing a side-by-side YAML diff of server vs local device edits. */

--- a/web/src/pages/builtin/functions/components/DiffModal.tsx
+++ b/web/src/pages/builtin/functions/components/DiffModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import * as yaml from 'js-yaml';
 import type { NetworkFunction } from '../types';
 import { localToApi } from '../wire';
 import { SaveDiffModal } from '../../../../components';
+import { dumpYamlDoc } from '../../../../utils';
 
 interface DiffModalProps {
     fn: NetworkFunction;
@@ -13,13 +13,10 @@ interface DiffModalProps {
 }
 
 const toYaml = (fn: NetworkFunction): string =>
-    yaml.dump(
-        (() => {
-            const { id, ...fnBody } = localToApi(fn);
-            return { name: id?.name ?? '', ...fnBody };
-        })(),
-        { sortKeys: false, lineWidth: 120, noRefs: true },
-    );
+    dumpYamlDoc((() => {
+        const { id, ...fnBody } = localToApi(fn);
+        return { name: id?.name ?? '', ...fnBody };
+    })());
 
 /** Modal showing a side-by-side YAML diff of server vs local function edits. */
 export const DiffModal: React.FC<DiffModalProps> = ({

--- a/web/src/pages/builtin/pipelines/components/DiffModal.tsx
+++ b/web/src/pages/builtin/pipelines/components/DiffModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import * as yaml from 'js-yaml';
 import type { Pipeline } from '../types';
 import { localToApi } from '../wire';
 import { SaveDiffModal } from '../../../../components';
+import { dumpYamlDoc } from '../../../../utils';
 
 interface DiffModalProps {
     pipeline: Pipeline;
@@ -12,13 +12,10 @@ interface DiffModalProps {
 }
 
 const toYaml = (pl: Pipeline): string =>
-    yaml.dump(
-        (() => {
-            const { id, ...body } = localToApi(pl);
-            return { name: id?.name ?? '', ...body };
-        })(),
-        { sortKeys: false, lineWidth: 120, noRefs: true },
-    );
+    dumpYamlDoc((() => {
+        const { id, ...body } = localToApi(pl);
+        return { name: id?.name ?? '', ...body };
+    })());
 
 /** Modal showing a side-by-side YAML diff of server vs local pipeline edits. */
 export const DiffModal: React.FC<DiffModalProps> = ({

--- a/web/src/pages/modules/acl/SaveDiffModal.tsx
+++ b/web/src/pages/modules/acl/SaveDiffModal.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { Dialog, Text } from '@gravity-ui/uikit';
-import * as yaml from 'js-yaml';
 import type { Rule } from '../../../api/acl';
 import { ActionKind } from '../../../api/acl';
-import { formatIPNet, extractBytes } from '../../../utils';
+import { formatIPNet, extractBytes, dumpYamlDoc } from '../../../utils';
 
 // TODO(acl): structured diff disabled until the per-card layout is reworked.
 
@@ -56,10 +55,7 @@ export const rulesToYamlObjects = (rules: Rule[]): Array<Record<string, unknown>
 
 /** Serialize ACL rules to the canonical YAML schema matching yanet-cli acl show output. */
 export const rulesToDiffYaml = (rules: Rule[]): string =>
-    yaml.dump(
-        { rules: rulesToYamlObjects(rules) },
-        { sortKeys: false, lineWidth: 120, noRefs: true },
-    );
+    dumpYamlDoc({ rules: rulesToYamlObjects(rules) });
 
 interface SaveDiffModalProps {
     configName: string;

--- a/web/src/pages/modules/forward/SaveDiffModal.tsx
+++ b/web/src/pages/modules/forward/SaveDiffModal.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo } from 'react';
-import * as yaml from 'js-yaml';
 import type { Rule } from '../../../api/forward';
 import { ForwardMode } from '../../../api/forward';
-import { formatIPNet, extractBytes } from '../../../utils';
+import { formatIPNet, extractBytes, dumpYamlDoc } from '../../../utils';
 import { SaveDiffModal as SharedSaveDiffModal } from '../../../components';
 
 /** Serialize a rules array into the canonical YAML schema for diff display. */
@@ -55,10 +54,7 @@ export const rulesToDiffYaml = (rules: Rule[]): string => {
         return entry;
     });
 
-    return yaml.dump(
-        { rules: yamlRules },
-        { sortKeys: false, lineWidth: 120, noRefs: true },
-    );
+    return dumpYamlDoc({ rules: yamlRules });
 };
 
 interface SaveDiffModalProps {


### PR DESCRIPTION
- Replaced five re-inlined js-yaml dump option objects with the canonical `dumpYamlDoc` util.
- Removed the now-dead `js-yaml` imports where they were no longer referenced.
- Output is byte-identical: `dumpYamlDoc` is exactly the same `dump` call with the same options.