### PR TITLE
refactor(web): extract useDrawerFlush hook from rule drawers

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -43,3 +43,5 @@ export { usePageContribution } from './usePageContribution';
 
 export { useModuleCards } from './useModuleCards';
 export type { ModuleCardData } from './useModuleCards';
+
+export { useDrawerFlush } from './useDrawerFlush';

--- a/web/src/hooks/useDrawerFlush.ts
+++ b/web/src/hooks/useDrawerFlush.ts
@@ -1,0 +1,65 @@
+import { useCallback, useImperativeHandle } from 'react';
+import type { Ref, RefObject } from 'react';
+
+/** Minimal structural type for a chip input's imperative flush handle. */
+interface FlushHandle {
+    flush: () => string[];
+}
+
+interface DrawerFlushRefs {
+    deviceNames: RefObject<FlushHandle | null>;
+    sourceCidrs: RefObject<FlushHandle | null>;
+    dstCidrs: RefObject<FlushHandle | null>;
+}
+
+interface UseDrawerFlushParams<T extends { deviceNames: string[]; sourceCidrs: string[]; dstCidrs: string[] }> {
+    draft: T;
+    setDraft: (next: T) => void;
+    onSave: (next: T) => void;
+    refs: DrawerFlushRefs;
+    handleRef: Ref<{ flushAndApply: () => boolean }>;
+    open: boolean;
+    /** When false the imperative flushAndApply returns false without applying. Defaults to true. */
+    canApply?: boolean;
+}
+
+interface UseDrawerFlushResult<T> {
+    buildFlushedDraft: (base: T) => T;
+    handleApply: () => void;
+}
+
+/**
+ * Extracts the shared flush-pending-chip-text-then-apply logic used by rule drawers.
+ */
+export const useDrawerFlush = <T extends { deviceNames: string[]; sourceCidrs: string[]; dstCidrs: string[] }>({
+    draft,
+    setDraft,
+    onSave,
+    refs,
+    handleRef,
+    open,
+    canApply,
+}: UseDrawerFlushParams<T>): UseDrawerFlushResult<T> => {
+    const buildFlushedDraft = (base: T): T => ({
+        ...base,
+        deviceNames: [...base.deviceNames, ...(refs.deviceNames.current?.flush() ?? [])],
+        sourceCidrs: [...base.sourceCidrs, ...(refs.sourceCidrs.current?.flush() ?? [])],
+        dstCidrs:    [...base.dstCidrs,    ...(refs.dstCidrs.current?.flush()    ?? [])],
+    });
+
+    const handleApply = useCallback((): void => {
+        const finalDraft = buildFlushedDraft(draft);
+        setDraft(finalDraft);
+        onSave(finalDraft);
+    }, [draft, onSave]);
+
+    useImperativeHandle(handleRef, () => ({
+        flushAndApply() {
+            if (!open || canApply === false) return false;
+            handleApply();
+            return true;
+        },
+    }), [open, canApply, handleApply]);
+
+    return { buildFlushedDraft, handleApply };
+};

--- a/web/src/pages/modules/acl/RuleDrawer.tsx
+++ b/web/src/pages/modules/acl/RuleDrawer.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useDrawerFlush } from '../../../hooks';
 import { ActionKind, ACTION_KIND_LABELS } from '../../../api/acl';
 import { TrashIcon } from '../../../components/draft';
 import type { RuleDraft, RuleItem } from './types';
@@ -77,28 +78,14 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
         setIsDirty(true);
     };
 
-    const buildFlushedDraft = (base: RuleDraft): RuleDraft => {
-        return {
-            ...base,
-            deviceNames: [...base.deviceNames, ...(deviceNamesRef.current?.flush() ?? [])],
-            sourceCidrs: [...base.sourceCidrs, ...(sourceCidrsRef.current?.flush() ?? [])],
-            dstCidrs: [...base.dstCidrs, ...(dstCidrsRef.current?.flush() ?? [])],
-        };
-    };
-
-    const handleApply = useCallback((): void => {
-        const finalDraft = buildFlushedDraft(draft);
-        setDraft(finalDraft);
-        onSave(finalDraft);
-    }, [draft, onSave]);
-
-    useImperativeHandle(ref, () => ({
-        flushAndApply() {
-            if (!open) return false;
-            handleApply();
-            return true;
-        },
-    }), [open, handleApply]);
+    const { handleApply } = useDrawerFlush({
+        draft,
+        setDraft,
+        onSave,
+        refs: { deviceNames: deviceNamesRef, sourceCidrs: sourceCidrsRef, dstCidrs: dstCidrsRef },
+        handleRef: ref,
+        open,
+    });
 
     const handleClose = (): void => {
         if (isDirty) {

--- a/web/src/pages/modules/forward/RuleDrawer.tsx
+++ b/web/src/pages/modules/forward/RuleDrawer.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useDrawerFlush } from '../../../hooks';
 import { ForwardMode } from '../../../api/forward';
 import { MODE_LABELS } from './types';
 import type { RuleDraft, RuleItem } from './types';
@@ -67,31 +68,15 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
 
     const isValid = draft.target.trim().length > 0;
 
-    /**
-     * Build the final draft by merging any pending chip text that has not yet
-     * been committed via Enter/Tab. Called synchronously before onSave fires so
-     * that text typed without pressing Enter is never lost.
-     */
-    const buildFlushedDraft = (base: RuleDraft): RuleDraft => ({
-        ...base,
-        deviceNames: [...base.deviceNames, ...(deviceNamesRef.current?.flush() ?? [])],
-        sourceCidrs: [...base.sourceCidrs, ...(sourceCidrsRef.current?.flush() ?? [])],
-        dstCidrs:    [...base.dstCidrs,    ...(dstCidrsRef.current?.flush()    ?? [])],
+    const { handleApply } = useDrawerFlush({
+        draft,
+        setDraft,
+        onSave,
+        refs: { deviceNames: deviceNamesRef, sourceCidrs: sourceCidrsRef, dstCidrs: dstCidrsRef },
+        handleRef: ref,
+        open,
+        canApply: isValid,
     });
-
-    const handleApply = (): void => {
-        const finalDraft = buildFlushedDraft(draft);
-        setDraft(finalDraft);
-        onSave(finalDraft);
-    };
-
-    useImperativeHandle(ref, () => ({
-        flushAndApply() {
-            if (!open || !isValid) return false;
-            handleApply();
-            return true;
-        },
-    }), [open, isValid, handleApply]);
 
     const handleClose = (): void => {
         if (isDirty) {


### PR DESCRIPTION
- Pulled the shared flush-pending-chip-text-then-apply logic out of the forward and acl rule drawers into a reusable `useDrawerFlush` hook.
- The only behavioural divergence (forward gates on validity, acl does not) is preserved via an optional `canApply` flag.
- No rendered markup changed; this is a pure internal logic extraction.