### PR TITLE
refactor(web): extract shared EntityDiffModal component

### DIFF
--- a/web/src/components/EntityDiffModal.tsx
+++ b/web/src/components/EntityDiffModal.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { SaveDiffModal } from './SaveDiffModal';
+
+export interface EntityDiffModalProps<T> {
+    configName: string;
+    current: T;
+    server: T | null;
+    toYaml: (entity: T) => string;
+    saveErrors?: string[];
+    onClose: () => void;
+    onApply: () => Promise<void>;
+}
+
+/** Side-by-side YAML diff modal for a single editable entity. */
+export const EntityDiffModal = <T,>({
+    configName,
+    current,
+    server,
+    toYaml,
+    saveErrors,
+    onClose,
+    onApply,
+}: EntityDiffModalProps<T>): React.ReactElement => (
+    <SaveDiffModal
+        configName={configName}
+        beforeYaml={server != null ? toYaml(server) : ''}
+        afterYaml={toYaml(current)}
+        onApply={onApply}
+        onClose={onClose}
+        headerError={saveErrors != null && saveErrors.length > 0 ? saveErrors[0] : undefined}
+    />
+);

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -67,3 +67,5 @@ export type { DraftSaveDiffModalProps } from './DraftSaveDiffModal';
 export { CidrPrefixField } from './CidrPrefixField';
 export { default as AddConfigModal } from './AddConfigModal';
 export * from './draft';
+export { EntityDiffModal } from './EntityDiffModal';
+export type { EntityDiffModalProps } from './EntityDiffModal';

--- a/web/src/pages/builtin/functions/components/DiffModal.tsx
+++ b/web/src/pages/builtin/functions/components/DiffModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { NetworkFunction } from '../types';
 import { localToApi } from '../wire';
-import { SaveDiffModal } from '../../../../components';
+import { EntityDiffModal } from '../../../../components';
 import { dumpYamlDoc } from '../../../../utils';
 
 interface DiffModalProps {
@@ -26,12 +26,13 @@ export const DiffModal: React.FC<DiffModalProps> = ({
     onClose,
     onApply,
 }) => (
-    <SaveDiffModal
+    <EntityDiffModal
         configName={fn.id}
-        beforeYaml={serverFn != null ? toYaml(serverFn) : ''}
-        afterYaml={toYaml(fn)}
-        onApply={onApply}
+        current={fn}
+        server={serverFn}
+        toYaml={toYaml}
+        saveErrors={saveErrors}
         onClose={onClose}
-        headerError={saveErrors.length > 0 ? saveErrors[0] : undefined}
+        onApply={onApply}
     />
 );

--- a/web/src/pages/builtin/pipelines/components/DiffModal.tsx
+++ b/web/src/pages/builtin/pipelines/components/DiffModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { Pipeline } from '../types';
 import { localToApi } from '../wire';
-import { SaveDiffModal } from '../../../../components';
+import { EntityDiffModal } from '../../../../components';
 import { dumpYamlDoc } from '../../../../utils';
 
 interface DiffModalProps {
@@ -24,11 +24,12 @@ export const DiffModal: React.FC<DiffModalProps> = ({
     onClose,
     onApply,
 }) => (
-    <SaveDiffModal
+    <EntityDiffModal
         configName={pipeline.id}
-        beforeYaml={serverPipeline != null ? toYaml(serverPipeline) : ''}
-        afterYaml={toYaml(pipeline)}
-        onApply={onApply}
+        current={pipeline}
+        server={serverPipeline}
+        toYaml={toYaml}
         onClose={onClose}
+        onApply={onApply}
     />
 );


### PR DESCRIPTION
- Unified the near-identical functions and pipelines diff-modal wrappers around a generic `EntityDiffModal` that delegates to the existing `SaveDiffModal`.
- Each page keeps its own module-specific `toYaml`; only the shared before/after/headerError wiring is extracted.
- No visual change: the props passed to `SaveDiffModal` are identical at both call sites.