### PR TITLE
fix(fwstate): bound ListEntries batch size

### DIFF
--- a/modules/fwstate/bindings/go/cfwstate/safe.go
+++ b/modules/fwstate/bindings/go/cfwstate/safe.go
@@ -15,6 +15,10 @@ import (
 // TTL48Max is the largest TTL (ns) storable in fw_state_value::last_ttl.
 const TTL48Max = uint64(C.FWSTATE_TTL48_MAX)
 
+// maxCursorBatch caps the allocation made by readEntries regardless of the
+// caller-supplied count, providing a defence-in-depth limit at the binding layer.
+const maxCursorBatch uint32 = 10000
+
 type MapConfig struct {
 	IndexSize        uint32
 	ExtraBucketCount uint32
@@ -284,6 +288,9 @@ func (m *ModuleConfig) readEntries(
 
 	if count == 0 {
 		return nil, int64(cursor.key_pos), false, nil
+	}
+	if count > maxCursorBatch {
+		count = maxCursorBatch
 	}
 
 	buf := make([]C.fwstate_cursor_entry_t, count)

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -15,6 +15,30 @@ import (
 	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
 )
 
+const (
+	// defaultListEntriesBatchSize is the batch size used when the caller
+	// sends zero in the request.
+	defaultListEntriesBatchSize uint32 = 100
+
+	// maxListEntriesBatchSize caps the number of entries fetched per
+	// ListEntries round-trip to prevent unbounded allocation under the
+	// service mutex.
+	maxListEntriesBatchSize uint32 = 10000
+)
+
+// clampBatchSize returns a batch size that is within the allowed range:
+// zero is replaced with defaultListEntriesBatchSize, and values above
+// maxListEntriesBatchSize are clamped to maxListEntriesBatchSize.
+func clampBatchSize(n uint32) uint32 {
+	if n == 0 {
+		return defaultListEntriesBatchSize
+	}
+	if n > maxListEntriesBatchSize {
+		return maxListEntriesBatchSize
+	}
+	return n
+}
+
 // ACLServiceProvider is the interface through which the fwstate service drives
 // ACL config lifecycle. Implementations must be safe for concurrent use.
 type ACLServiceProvider interface {
@@ -363,10 +387,7 @@ func (m *FWStateService) ListEntries(
 			return status.Error(codes.InvalidArgument, "config_name is required")
 		}
 
-		count := req.GetBatchSize()
-		if count == 0 {
-			count = 100
-		}
+		count := clampBatchSize(req.GetBatchSize())
 
 		m.mu.Lock()
 		config, ok := m.configs[configName]

--- a/modules/fwstate/controlplane/service_test.go
+++ b/modules/fwstate/controlplane/service_test.go
@@ -10,6 +10,47 @@ import (
 	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
 )
 
+// TestClampBatchSize verifies zero defaulting and upper-bound clamping.
+func TestClampBatchSize(t *testing.T) {
+	cases := []struct {
+		name  string
+		input uint32
+		want  uint32
+	}{
+		{
+			name:  "zero becomes default",
+			input: 0,
+			want:  defaultListEntriesBatchSize,
+		},
+		{
+			name:  "below max passes through",
+			input: 500,
+			want:  500,
+		},
+		{
+			name:  "exactly max passes through",
+			input: maxListEntriesBatchSize,
+			want:  maxListEntriesBatchSize,
+		},
+		{
+			name:  "above max is clamped to max",
+			input: maxListEntriesBatchSize + 1,
+			want:  maxListEntriesBatchSize,
+		},
+		{
+			name:  "large value is clamped to max",
+			input: 1<<32 - 1,
+			want:  maxListEntriesBatchSize,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, clampBatchSize(tc.input))
+		})
+	}
+}
+
 // TestValidateSyncConfigDstEther checks that dst_ether validation
 // distinguishes between absent and explicitly-zero MAC values.
 func TestValidateSyncConfigDstEther(t *testing.T) {


### PR DESCRIPTION
Clamp the `ListEntries` per-request batch size so a large or zero batch can no longer trigger an unbounded allocation while the service mutex is held, which could exhaust memory and stall all fwstate operations.

- Default a zero batch size and cap large values to a bounded maximum before acquiring the service mutex.
- Apply a defence-in-depth cap in the cursor binding so any caller of the read path is bounded.
- Add a table-driven test for the clamp.

Closes #898.