### PR TITLE
fix(counters): copy counters on read to avoid controlplane update race

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -8,8 +8,6 @@
 
 struct dp_config;
 
-struct counter_value_handle;
-
 struct counter_tag {
 	const char *key;
 	const char *value;
@@ -21,7 +19,11 @@ struct counter_handle {
 	uint64_t gen;
 	struct counter_tag *tags;
 	size_t tag_count;
-	struct counter_value_handle *value_handle;
+
+	// Per-instance snapshot arrays: values[i] holds size values for
+	// instance i, copied when the list was acquired, remaining valid and
+	// unchanged across controlplane updates until the list is freed.
+	uint64_t **values;
 };
 
 struct counter_handle_list {
@@ -124,24 +126,22 @@ yanet_get_counter(struct counter_handle_list *counters, uint64_t idx);
 
 uint64_t
 yanet_get_counter_value(
-	struct counter_value_handle *value_handle,
-	uint64_t value_idx,
-	uint64_t worker_idx
+	uint64_t **values, uint64_t value_idx, uint64_t worker_idx
 );
 
 // Copy all values for every instance of a counter into a flat caller-supplied
 // buffer in a single call.
 //
-// values must have room for instance_count * size uint64 elements and is
-// filled instance-major: instance i occupies values[i*size .. i*size + size).
-// Performs the same reads as yanet_get_counter_value but batched into one
-// call, avoiding per-value CGO overhead when reading counters from Go.
+// values_out must have room for instance_count * size uint64 elements and is
+// filled instance-major: instance i occupies values_out[i*size .. i*size +
+// size). Performs the same reads as yanet_get_counter_value but batched into
+// one call, avoiding per-value CGO overhead when reading counters from Go.
 void
 yanet_get_counter_values(
-	struct counter_value_handle *value_handle,
+	uint64_t **values,
 	uint64_t size,
 	uint64_t instance_count,
-	uint64_t *values
+	uint64_t *values_out
 );
 
 // Return counters that satisfy every predicate in tags and match at

--- a/controlplane/ffi/port.go
+++ b/controlplane/ffi/port.go
@@ -47,7 +47,7 @@ func (m *DPConfig) PortCounters() ([]PortGroup, error) {
 				PortCounter{
 					Name: C.GoString(&handle.name[0]),
 					Value: uint64(C.yanet_get_counter_value(
-						handle.value_handle,
+						handle.values,
 						0,
 						0,
 					)),

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -439,7 +439,7 @@ func decodeCounterHandle(
 	if total := instances * size; total > 0 {
 		flat := make([]uint64, total)
 		C.yanet_get_counter_values(
-			handle.value_handle,
+			handle.values,
 			handle.size,
 			instanceCount,
 			(*C.uint64_t)(unsafe.Pointer(&flat[0])),

--- a/controlplane/ffi/worker.go
+++ b/controlplane/ffi/worker.go
@@ -71,52 +71,52 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 		worker := WorkerCounter{
 			WorkerIdx: uint32(idx),
 			Iterations: uint64(C.yanet_get_counter_value(
-				iterationsHandle.value_handle,
+				iterationsHandle.values,
 				workerCounterSingleValueIdx,
 				idx,
 			)),
 			RxPackets: uint64(C.yanet_get_counter_value(
-				rxHandle.value_handle,
+				rxHandle.values,
 				workerCounterPacketsValueIdx,
 				idx,
 			)),
 			RxBytes: uint64(C.yanet_get_counter_value(
-				rxHandle.value_handle,
+				rxHandle.values,
 				workerCounterBytesValueIdx,
 				idx,
 			)),
 			TxPackets: uint64(C.yanet_get_counter_value(
-				txHandle.value_handle,
+				txHandle.values,
 				workerCounterPacketsValueIdx,
 				idx,
 			)),
 			TxBytes: uint64(C.yanet_get_counter_value(
-				txHandle.value_handle,
+				txHandle.values,
 				workerCounterBytesValueIdx,
 				idx,
 			)),
 			RemoteRxPackets: uint64(C.yanet_get_counter_value(
-				remoteRxHandle.value_handle,
+				remoteRxHandle.values,
 				workerCounterPacketsValueIdx,
 				idx,
 			)),
 			RemoteTxPackets: uint64(C.yanet_get_counter_value(
-				remoteTxHandle.value_handle,
+				remoteTxHandle.values,
 				workerCounterPacketsValueIdx,
 				idx,
 			)),
 			LocalTxDrops: uint64(C.yanet_get_counter_value(
-				localTxDropsHandle.value_handle,
+				localTxDropsHandle.values,
 				workerCounterSingleValueIdx,
 				idx,
 			)),
 			RemoteTxDrops: uint64(C.yanet_get_counter_value(
-				remoteTxDropsHandle.value_handle,
+				remoteTxDropsHandle.values,
 				workerCounterSingleValueIdx,
 				idx,
 			)),
 			Drops: uint64(C.yanet_get_counter_value(
-				dropsHandle.value_handle,
+				dropsHandle.values,
 				workerCounterSingleValueIdx,
 				idx,
 			)),
@@ -126,7 +126,7 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 		worker.RxBursts = make([]uint64, rxBurstSize)
 		for burstIdx := C.uint64_t(0); burstIdx < rxBurstsHandle.size; burstIdx++ {
 			worker.RxBursts[burstIdx] = uint64(C.yanet_get_counter_value(
-				rxBurstsHandle.value_handle,
+				rxBurstsHandle.values,
 				burstIdx,
 				idx,
 			))

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1481,19 +1481,44 @@ cp_counter_storage_copy_tags(const struct cp_counter_storage *storage) {
 		return NULL;
 	}
 	for (size_t i = 0; i < storage->tag_count; ++i) {
-		tags[i].key = storage->tags[i].key;
-		tags[i].value = storage->tags[i].value;
+		tags[i].key = NULL;
+		tags[i].value = NULL;
+	}
+	for (size_t i = 0; i < storage->tag_count; ++i) {
+		tags[i].key = strdup(storage->tags[i].key);
+		tags[i].value = strdup(storage->tags[i].value);
+		if (tags[i].key == NULL || tags[i].value == NULL) {
+			for (size_t j = 0; j < storage->tag_count; ++j) {
+				free((void *)tags[j].key);
+				free((void *)tags[j].value);
+			}
+			free(tags);
+			return NULL;
+		}
 	}
 	return tags;
 }
 
-// Build a per-worker value-handle array for one counter and stash it behind
-// the opaque counter_handle.value_handle.
+// Free a per-instance snapshot array as produced by fill_counter_handle.
+static void
+free_counter_values(uint64_t **values, uint64_t instance_count) {
+	if (values == NULL) {
+		return;
+	}
+	for (uint64_t i = 0; i < instance_count; ++i) {
+		free(values[i]);
+	}
+	free(values);
+}
+
+// Snapshot a counter's per-worker values into heap memory and stash the
+// result behind the opaque counter_handle.values.
 //
 // Each worker has its own single-instance storage. The caller gathers one
 // storage per worker into worker_storages (a plain C-pointer array). The
-// result (worker_count entries) is read back by yanet_get_counter_value(s)
-// and released by yanet_counter_handle_list_free.
+// values are copied out of generation-owned shm while the caller still holds
+// cp_config_lock, so the snapshot (worker_count entries) stays valid across
+// controlplane updates until it is released by yanet_counter_handle_list_free.
 static int
 fill_counter_handle(
 	struct counter_handle *dst,
@@ -1515,17 +1540,28 @@ fill_counter_handle(
 	dst->tags = tags;
 	dst->tag_count = tag_count;
 
-	struct counter_value_handle **bases =
-		malloc(worker_count * sizeof(*bases));
-	if (bases == NULL) {
+	uint64_t **values = calloc(worker_count, sizeof(*values));
+	if (values == NULL) {
 		return -1;
 	}
 	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
-		bases[worker_idx] = counter_get_value_handle(
+		if (counters[idx].size == 0) {
+			continue;
+		}
+		values[worker_idx] =
+			malloc(counters[idx].size * sizeof(uint64_t));
+		if (values[worker_idx] == NULL) {
+			free_counter_values(values, worker_count);
+			return -1;
+		}
+		struct counter_value_handle *handle = counter_get_value_handle(
 			idx, worker_storages[worker_idx]
 		);
+		memcpy(values[worker_idx],
+		       counter_handle_get_value(handle),
+		       counters[idx].size * sizeof(uint64_t));
 	}
-	dst->value_handle = (struct counter_value_handle *)bases;
+	dst->values = values;
 	return 0;
 }
 
@@ -1619,21 +1655,21 @@ yanet_get_counters_by_tags(
 			    )) {
 				continue;
 			}
+			struct counter_storage **worker_storages =
+				malloc(worker_count * sizeof(*worker_storages));
+			if (worker_storages == NULL) {
+				yanet_error_add(err, "malloc failed");
+				goto err_list;
+			}
 			if (storage_tags == NULL) {
 				storage_tags =
 					cp_counter_storage_copy_tags(cp_storage
 					);
 				if (storage_tags == NULL) {
+					free(worker_storages);
 					yanet_error_add(err, "malloc failed");
 					goto err_list;
 				}
-			}
-			struct counter_storage **worker_storages =
-				malloc(worker_count * sizeof(*worker_storages));
-			if (worker_storages == NULL) {
-				free(worker_storages);
-				yanet_error_add(err, "malloc failed");
-				goto err_list;
 			}
 			for (uint64_t worker_idx = 0; worker_idx < worker_count;
 			     ++worker_idx) {
@@ -1743,27 +1779,25 @@ yanet_get_counter(struct counter_handle_list *counters, uint64_t idx) {
 
 uint64_t
 yanet_get_counter_value(
-	struct counter_value_handle *value_handle,
-	uint64_t value_idx,
-	uint64_t worker_idx
+	uint64_t **values, uint64_t value_idx, uint64_t worker_idx
 ) {
-	struct counter_value_handle **bases =
-		(struct counter_value_handle **)value_handle;
-	return counter_handle_get_value(bases[worker_idx])[value_idx];
+	return values[worker_idx][value_idx];
 }
 
 void
 yanet_get_counter_values(
-	struct counter_value_handle *value_handle,
+	uint64_t **values,
 	uint64_t size,
 	uint64_t instance_count,
-	uint64_t *values
+	uint64_t *values_out
 ) {
-	struct counter_value_handle **bases =
-		(struct counter_value_handle **)value_handle;
+	if (size == 0) {
+		return;
+	}
 	for (uint64_t iidx = 0; iidx < instance_count; ++iidx) {
-		uint64_t *src = counter_handle_get_value(bases[iidx]);
-		memcpy(values + iidx * size, src, size * sizeof(uint64_t));
+		memcpy(values_out + iidx * size,
+		       values[iidx],
+		       size * sizeof(uint64_t));
 	}
 }
 
@@ -1789,7 +1823,7 @@ counter_handle_list_build(
 	for (uint64_t idx = 0; idx < count; ++idx) {
 		handlers[idx].tag_count = 0;
 		handlers[idx].tags = NULL;
-		handlers[idx].value_handle = NULL;
+		handlers[idx].values = NULL;
 	}
 
 	// storages holds one offset-pointer cell per worker; materialize a
@@ -1930,10 +1964,16 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 	struct counter_handle *handles = counters->counters;
 	for (size_t i = 0; i < counters->count; ++i) {
 		if (i == 0 || handles[i].tags != handles[i - 1].tags) {
+			for (size_t j = 0; j < handles[i].tag_count; ++j) {
+				free((void *)handles[i].tags[j].key);
+				free((void *)handles[i].tags[j].value);
+			}
 			free(handles[i].tags);
 		}
-		// Each counter owns its own per-worker value-handle array.
-		free(handles[i].value_handle);
+		// Each counter owns its own per-worker snapshot array.
+		free_counter_values(
+			handles[i].values, counters->instance_count
+		);
 	}
 	free(counters);
 }

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -480,10 +480,6 @@ cp_module_parse_performance_counter(
 	counter->min_batch_size = batch_sizes[counter_idx];
 	counter->latency_ranges_count = hist_buckets;
 
-	// Per-worker value handles are stored behind the opaque handle.
-	struct counter_value_handle **bases =
-		(struct counter_value_handle **)counter_handle->value_handle;
-
 	// Salc summary tx and summary latency
 	counter->summary_latency = 0;
 	counter->packets = 0;
@@ -491,7 +487,7 @@ cp_module_parse_performance_counter(
 	for (size_t instance_idx = 0; instance_idx < workers; ++instance_idx) {
 		struct module_ectx_perf_counter_layout *perf_counter =
 			(struct module_ectx_perf_counter_layout *)
-				counter_handle_get_value(bases[instance_idx]);
+				counter_handle->values[instance_idx];
 		counter->summary_latency += perf_counter->summary_latency;
 		counter->packets += perf_counter->packets;
 		counter->bytes += perf_counter->bytes;
@@ -514,9 +510,7 @@ cp_module_parse_performance_counter(
 		     ++worker_idx) {
 			struct module_ectx_perf_counter_layout *perf_counter =
 				(struct module_ectx_perf_counter_layout *)
-					counter_handle_get_value(
-						bases[worker_idx]
-					);
+					counter_handle->values[worker_idx];
 			latency_range->batches +=
 				perf_counter->batch_count[range_idx];
 		}
@@ -562,13 +556,10 @@ cp_module_parse_tx_rx(
 		return -1;
 	}
 
-	struct counter_value_handle **bases =
-		(struct counter_value_handle **)counter_handle->value_handle;
 	uint64_t total_packets = 0;
 	uint64_t total_bytes = 0;
 	for (size_t worker_idx = 0; worker_idx < workers; ++worker_idx) {
-		uint64_t *counter_values =
-			counter_handle_get_value(bases[worker_idx]);
+		uint64_t *counter_values = counter_handle->values[worker_idx];
 		// size-2 counter: [0] = packets, [1] = bytes
 		total_packets += counter_values[0];
 		total_bytes += counter_values[1];

--- a/lib/controlplane/tests/counters_test.c
+++ b/lib/controlplane/tests/counters_test.c
@@ -1,0 +1,258 @@
+/*
+ * Regression tests for GH#885: counter_handle snapshots must stay valid
+ * across controlplane generation swaps that free or unshare the storage a
+ * handle was acquired against.
+ *
+ * These port two confirmed use-after-free repros against the copy-on-read
+ * fix: a value-page surface (the agent counters API snapshots
+ * handle->values under cp_config_lock) and a tag-string surface (tags are
+ * strdup'd instead of borrowed from the freed generation arena).
+ */
+
+#include "api/agent.h"
+#include "api/counter.h"
+
+#include "common/test_assert.h"
+#include "controlplane/agent/agent.h"
+#include "devices/plain/api/controlplane.h"
+#include "lib/controlplane/config/cp_pipeline.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/errors/errors.h"
+#include "logging/log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CNT_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
+
+static int
+install_empty_pipeline(
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *name
+) {
+	yanet_error *err = NULL;
+	struct cp_pipeline_config *cfg =
+		calloc(1, sizeof(struct cp_pipeline_config));
+	TEST_ASSERT_NOT_NULL(cfg, "failed to allocate pipeline config");
+	strncpy(cfg->name, name, CP_PIPELINE_NAME_LEN - 1);
+	cfg->length = 0;
+	struct cp_pipeline_config *cfgs[] = {cfg};
+	int rc =
+		cp_config_update_pipelines(dp_config, cp_config, 1, cfgs, &err);
+	free(cfg);
+	TEST_ASSERT_SUCCESS(
+		rc,
+		"update_pipelines failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	return TEST_SUCCESS;
+}
+
+// Install "dev0", optionally wiring input_pipeline as its single input
+// pipeline.
+//
+// Passing NULL for input_pipeline drops the reference, which is how the
+// value-snapshot test removes the pipeline's counter storage.
+static int
+install_device(
+	struct agent *agent,
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *name,
+	const char *input_pipeline
+) {
+	yanet_error *err = NULL;
+	uint64_t input_count = (input_pipeline != NULL) ? 1 : 0;
+	struct cp_device_plain_config *cfg =
+		cp_device_plain_config_new(name, input_count, 0, &err);
+	TEST_ASSERT_NOT_NULL(
+		cfg,
+		"device config new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	if (input_pipeline != NULL) {
+		cp_device_plain_config_set_input_pipeline(
+			cfg, 0, input_pipeline, 1
+		);
+	}
+	struct cp_device *dev = cp_device_plain_new(agent, cfg, &err);
+	cp_device_plain_config_free(cfg);
+	TEST_ASSERT_NOT_NULL(
+		dev,
+		"device new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	struct cp_device *devs[] = {dev};
+	int rc = cp_config_update_devices(dp_config, cp_config, 1, devs, &err);
+	TEST_ASSERT_SUCCESS(
+		rc,
+		"update_devices failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a counter_handle's value snapshot stays readable and
+// unchanged after an update removes the entity the handle was acquired
+// against, both through the single-value read and the batched read.
+static int
+test_value_snapshot_survives_removal(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent =
+		agent_attach(shm, 0, "cnt-885v", CNT_TEST_MEMORY_LIMIT, &err);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	TEST_ASSERT_SUCCESS(
+		install_empty_pipeline(dp_config, cp_config, "pipe0"),
+		"failed to install pipe0"
+	);
+	TEST_ASSERT_SUCCESS(
+		install_device(agent, dp_config, cp_config, "dev0", "pipe0"),
+		"failed to install dev0 with input pipeline pipe0"
+	);
+
+	struct counter_handle_list *list =
+		yanet_get_pipeline_counters(dp_config, "dev0", "pipe0");
+	TEST_ASSERT_NOT_NULL(list, "yanet_get_pipeline_counters returned NULL");
+	TEST_ASSERT(
+		list->count > 0,
+		"no pipeline counter storage matched dev0/pipe0"
+	);
+
+	struct counter_handle *handle = yanet_get_counter(list, 0);
+	uint64_t before = yanet_get_counter_value(handle->values, 0, 0);
+
+	// Re-install dev0 with no input pipeline: pipe0's counter storage is
+	// not respawned, so its value block's refcount drops to zero and the
+	// old generation's value pages are freed.
+	TEST_ASSERT_SUCCESS(
+		install_device(agent, dp_config, cp_config, "dev0", NULL),
+		"failed to remove dev0's input pipeline"
+	);
+
+	uint64_t after = yanet_get_counter_value(handle->values, 0, 0);
+	TEST_ASSERT_EQUAL(
+		after, before, "snapshot value changed after entity removal"
+	);
+
+	uint64_t *batched =
+		calloc(list->instance_count * handle->size, sizeof(uint64_t));
+	TEST_ASSERT_NOT_NULL(batched, "failed to allocate batched read buffer");
+	yanet_get_counter_values(
+		handle->values, handle->size, list->instance_count, batched
+	);
+	TEST_ASSERT_EQUAL(
+		batched[0],
+		before,
+		"batched read returned a different snapshot value"
+	);
+	free(batched);
+
+	yanet_counter_handle_list_free(list);
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a counter_handle's tag strings stay readable and correct
+// after a controlplane generation swap frees the arena they were
+// originally borrowed from.
+static int
+test_tag_strings_survive_generation_swap(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent =
+		agent_attach(shm, 0, "cnt-885t", CNT_TEST_MEMORY_LIMIT, &err);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	TEST_ASSERT_SUCCESS(
+		install_device(agent, dp_config, cp_config, "dev0", NULL),
+		"failed to install dev0"
+	);
+
+	struct counter_handle_list *list =
+		yanet_get_device_counters(dp_config, "dev0");
+	TEST_ASSERT_NOT_NULL(list, "yanet_get_device_counters returned NULL");
+	TEST_ASSERT(list->count > 0, "no counter storage matched dev0");
+
+	struct counter_handle *handle = yanet_get_counter(list, 0);
+	TEST_ASSERT(handle->tag_count > 0, "handle has no tags to verify");
+
+	// Trigger: any controlplane update installs a new generation and
+	// synchronously frees the old one, which pre-fix left handle->tags
+	// pointing into freed shm.
+	int rc = cp_config_update_modules(dp_config, cp_config, 0, NULL, &err);
+	TEST_ASSERT_SUCCESS(
+		rc,
+		"update_modules trigger failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	int found = 0;
+	for (size_t i = 0; i < handle->tag_count; ++i) {
+		if (strcmp(handle->tags[i].key, "device") == 0) {
+			TEST_ASSERT(
+				strcmp(handle->tags[i].value, "dev0") == 0,
+				"device tag value mismatch after swap: got %s",
+				handle->tags[i].value
+			);
+			found = 1;
+		}
+	}
+	TEST_ASSERT(found, "device tag missing after generation swap");
+
+	yanet_counter_handle_list_free(list);
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	const char *port_names[] = {"01:00.0"};
+	const char *devs_to_load[] = {"plain"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = NULL,
+		.module_count = 0,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	if (ut == NULL) {
+		fprintf(stderr, "dataplane_ut_new failed\n");
+		return 1;
+	}
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	if (shm == NULL) {
+		fprintf(stderr, "dataplane_ut_shm returned NULL\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+
+	int res = test_value_snapshot_survives_removal(shm);
+	if (res == TEST_SUCCESS) {
+		res = test_tag_strings_survive_generation_swap(shm);
+	}
+
+	dataplane_ut_free(ut);
+
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -1,0 +1,21 @@
+counters_test = executable(
+  'counters_test',
+  ['counters_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_dev_plain_api,
+    libdpdk_dep,
+  ],
+  link_with: [lib_dev_plain_dp],
+  include_directories: yanet_rootdir,
+)
+
+test('counters_uaf', counters_test, suite: ['lib'])

--- a/meson.build
+++ b/meson.build
@@ -150,6 +150,7 @@ subdir('lib/dataplane_ut/tests')
 subdir('dataplane')
 
 if not dataplane_only
+  subdir('lib/controlplane/tests')
   # Operator proto targets must exist before their consumers are declared.
   #
   # Meson resolves variables in subdir traversal order, so the control-plane


### PR DESCRIPTION
- The counters API returned handles that referenced live controlplane configuration memory (counter value pages and tag strings), so a configuration update while the handles were still in use freed the storage under the reader.
- Take a self-owned snapshot at acquire time: counter values are copied into per-instance heap arrays and tag strings are duplicated while the configuration lock is held, so the returned list no longer aliases generation-owned memory.
- Update the internal performance-counter parsing and the Go FFI readers to consume the snapshot.
- Add a regression test covering both dangling surfaces: value pages freed when an update removes the matched entity, and tag strings freed by any generation swap.
- Supersedes #944, which instead held the configuration lock for the whole lifetime of the returned list; that approach was not accepted.
- Closes #885.