### PR TITLE
refactor(web): extract shared useRowDraft hook for row-editing drawers

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -45,3 +45,6 @@ export { useModuleCards } from './useModuleCards';
 export type { ModuleCardData } from './useModuleCards';
 
 export { useDrawerFlush } from './useDrawerFlush';
+
+export { useRowDraft } from './useRowDraft';
+export type { UseRowDraftParams, UseRowDraftResult, RowDraftHandle } from './useRowDraft';

--- a/web/src/hooks/useRowDraft.ts
+++ b/web/src/hooks/useRowDraft.ts
@@ -1,0 +1,67 @@
+import { useEffect, useImperativeHandle, useState } from 'react';
+import type { Ref } from 'react';
+
+export interface RowDraftHandle {
+    flushAndApply(): boolean;
+}
+
+export interface UseRowDraftParams<Row extends { id: string }, Errors extends object> {
+    open: boolean;
+    row: Row | null;
+    emptyErrors: Errors;
+    validateRow: (row: Row) => Errors;
+    onChange: (row: Row) => void;
+    onClose: () => void;
+    handleRef: Ref<RowDraftHandle>;
+}
+
+export interface UseRowDraftResult<Row, Errors> {
+    draft: Row | null;
+    errors: Errors;
+    updateField: <K extends keyof Row>(key: K, val: Row[K]) => void;
+    handleApply: () => void;
+}
+
+/** Generic hook that manages draft state, validation, and imperative handle for row-editing drawers. */
+export const useRowDraft = <Row extends { id: string }, Errors extends object>(
+    params: UseRowDraftParams<Row, Errors>,
+): UseRowDraftResult<Row, Errors> => {
+    const { open, row, emptyErrors, validateRow, onChange, onClose, handleRef } = params;
+
+    const [draft, setDraft] = useState<Row | null>(null);
+    const [errors, setErrors] = useState<Errors>(emptyErrors);
+
+    useEffect(() => {
+        if (open && row) {
+            setDraft({ ...row });
+            setErrors(emptyErrors);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, row?.id]);
+
+    const updateField = <K extends keyof Row>(key: K, val: Row[K]): void => {
+        setDraft((prev) => {
+            if (!prev) return prev;
+            const next = { ...prev, [key]: val };
+            setErrors(validateRow(next));
+            return next;
+        });
+    };
+
+    const handleApply = (): void => {
+        if (!draft) return;
+        onChange(draft);
+        onClose();
+    };
+
+    useImperativeHandle(handleRef, () => ({
+        flushAndApply() {
+            if (!open || !draft) return false;
+            onChange(draft);
+            return true;
+        },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }), [open, draft, onChange]);
+
+    return { draft, errors, updateField, handleApply };
+};

--- a/web/src/pages/modules/decap/PrefixDrawer.tsx
+++ b/web/src/pages/modules/decap/PrefixDrawer.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useImperativeHandle, useState } from 'react';
+import React from 'react';
 import type { PrefixRowItem, PrefixRowErrors } from './types';
 import { validateRow } from './validation';
 import { DraftItemDrawer } from '../../../components/draft';
 import { CidrPrefixField } from '../../../components';
+import { useRowDraft } from '../../../hooks';
 
 interface PrefixDrawerProps {
     open: boolean;
@@ -32,38 +33,9 @@ const PrefixDrawer = React.forwardRef<PrefixDrawerHandle, PrefixDrawerProps>(({
     onDelete,
     onJump,
 }, ref) => {
-    const [draft, setDraft] = useState<PrefixRowItem | null>(null);
-    const [errors, setErrors] = useState<PrefixRowErrors>({ prefix: null });
-
-    useEffect(() => {
-        if (open && row) {
-            setDraft({ ...row });
-            setErrors({ prefix: null });
-        }
-    }, [open, row?.id]);
-
-    const updateField = <K extends keyof PrefixRowItem>(key: K, val: PrefixRowItem[K]): void => {
-        setDraft((prev) => {
-            if (!prev) return prev;
-            const next = { ...prev, [key]: val };
-            setErrors(validateRow(next));
-            return next;
-        });
-    };
-
-    const handleApply = (): void => {
-        if (!draft) return;
-        onChange(draft);
-        onClose();
-    };
-
-    useImperativeHandle(ref, () => ({
-        flushAndApply() {
-            if (!open || !draft) return false;
-            onChange(draft);
-            return true;
-        },
-    }), [open, draft, onChange]);
+    const { draft, errors, updateField, handleApply } = useRowDraft<PrefixRowItem, PrefixRowErrors>({
+        open, row, emptyErrors: { prefix: null }, validateRow, onChange, onClose, handleRef: ref,
+    });
 
     return (
         <DraftItemDrawer

--- a/web/src/pages/modules/route/FIBDrawer.tsx
+++ b/web/src/pages/modules/route/FIBDrawer.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useImperativeHandle, useState } from 'react';
+import React from 'react';
 import type { FIBRowItem, FIBRowErrors } from './types';
 import { validateRow } from './validation';
 import { DraftItemDrawer } from '../../../components/draft';
 import { CidrPrefixField } from '../../../components';
+import { useRowDraft } from '../../../hooks';
 
 interface FIBDrawerProps {
     open: boolean;
@@ -32,38 +33,9 @@ const FIBDrawer = React.forwardRef<FIBDrawerHandle, FIBDrawerProps>(({
     onDelete,
     onJump,
 }, ref) => {
-    const [draft, setDraft] = useState<FIBRowItem | null>(null);
-    const [errors, setErrors] = useState<FIBRowErrors>({ prefix: null, dst_mac: null, src_mac: null, device: null });
-
-    useEffect(() => {
-        if (open && row) {
-            setDraft({ ...row });
-            setErrors({ prefix: null, dst_mac: null, src_mac: null, device: null });
-        }
-    }, [open, row?.id]);
-
-    const updateField = <K extends keyof FIBRowItem>(key: K, val: FIBRowItem[K]): void => {
-        setDraft((prev) => {
-            if (!prev) return prev;
-            const next = { ...prev, [key]: val };
-            setErrors(validateRow(next));
-            return next;
-        });
-    };
-
-    const handleApply = (): void => {
-        if (!draft) return;
-        onChange(draft);
-        onClose();
-    };
-
-    useImperativeHandle(ref, () => ({
-        flushAndApply() {
-            if (!open || !draft) return false;
-            onChange(draft);
-            return true;
-        },
-    }), [open, draft, onChange]);
+    const { draft, errors, updateField, handleApply } = useRowDraft<FIBRowItem, FIBRowErrors>({
+        open, row, emptyErrors: { prefix: null, dst_mac: null, src_mac: null, device: null }, validateRow, onChange, onClose, handleRef: ref,
+    });
 
     return (
         <DraftItemDrawer


### PR DESCRIPTION
Extract the row-draft plumbing shared verbatim by the decap prefix drawer and the route FIB drawer into a generic `useRowDraft` hook.

- Both drawers carried character-identical draft state, init effect, field updater, apply handler, and imperative `flushAndApply` handle, differing only in the empty-errors literal.
- The new hook in `web/src/hooks` is parameterized by that literal plus the per-module validator and callbacks; the drawers' rendered output is unchanged.
- Pure refactor with no behavior change.