### PR TITLE
feat(dataplane): runtime plugin loading system

### DIFF
--- a/dataplane/config.c
+++ b/dataplane/config.c
@@ -40,6 +40,9 @@ enum state {
 	state_connection_dst,
 
 	state_loglevel,
+
+	state_plugin_dir,
+	state_modules,
 };
 
 int
@@ -110,6 +113,22 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					start,
 					sizeof(dataplane->loglevel));
 				state = state_dataplane;
+				break;
+			case state_plugin_dir:
+				strtcpy(dataplane->plugin_dir,
+					start,
+					sizeof(dataplane->plugin_dir));
+				state = state_dataplane;
+				break;
+			case state_modules:
+				if (dataplane->module_count >=
+				    DATAPLANE_MAX_MODULES)
+					goto error;
+				strtcpy(dataplane->module_names
+						[dataplane->module_count],
+					start,
+					DATAPLANE_MODULE_NAME_LEN);
+				dataplane->module_count++;
 				break;
 
 			// handle new instance
@@ -243,6 +262,10 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					state = state_connections;
 				} else if (!strcmp("loglevel", start)) {
 					state = state_loglevel;
+				} else if (!strcmp("plugin_dir", start)) {
+					state = state_plugin_dir;
+				} else if (!strcmp("modules", start)) {
+					state = state_modules;
 				} else {
 					goto error;
 				}
@@ -323,6 +346,8 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				break;
 			case state_connections:
 				break;
+			case state_modules:
+				break;
 			default:
 				goto error;
 			}
@@ -339,6 +364,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				state = state_device;
 				break;
 			case state_connections:
+				state = state_dataplane;
+				break;
+			case state_modules:
 				state = state_dataplane;
 				break;
 			default:

--- a/dataplane/config.h
+++ b/dataplane/config.h
@@ -3,6 +3,10 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#define DATAPLANE_MODULE_NAME_LEN 80
+#define DATAPLANE_MAX_MODULES 64
+#define DATAPLANE_PLUGIN_DIR_LEN 256
+
 struct dataplane_instance_config {
 	uint16_t numa_idx;
 	uint64_t dp_memory;
@@ -49,6 +53,10 @@ struct dataplane_config {
 	uint64_t connection_count;
 	struct dataplane_connection_config *connections;
 	char loglevel[32];
+
+	char plugin_dir[DATAPLANE_PLUGIN_DIR_LEN];
+	uint64_t module_count;
+	char module_names[DATAPLANE_MAX_MODULES][DATAPLANE_MODULE_NAME_LEN];
 };
 
 int

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -27,6 +27,7 @@
 #include "lib/dataplane/config/bootstrap.h"
 #include "lib/dataplane/config/counter_storage.h"
 #include "lib/dataplane/config/module_loader.h"
+#include "lib/dataplane/config/plugin_loader.h"
 #include "lib/dataplane/config/topology.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/packet/packet.h"
@@ -300,6 +301,17 @@ dataplane_init(
 
 	assert((uintptr_t)storage % page_size == 0);
 
+	// Load external module plugins from .a files.
+	memset(&dataplane->plugins, 0, sizeof(dataplane->plugins));
+	if (config->plugin_dir[0] != '\0') {
+		if (dp_load_plugins(config->plugin_dir,
+		                    &dataplane->plugins) != 0) {
+			LOG(ERROR, "failed to load plugins from %s",
+			    config->plugin_dir);
+			return -1;
+		}
+	}
+
 	off_t instance_offset = 0;
 	for (uint32_t instance_idx = 0;
 	     instance_idx < dataplane->instance_count;
@@ -391,7 +403,9 @@ dataplane_init(
 		instance->dp_config->instance_idx = instance_idx;
 		instance->dp_config->instance_count = dataplane->instance_count;
 
-		static const char *modules[] = {
+		// Use module list from config if specified,
+		// otherwise fall back to built-in defaults.
+		static const char *default_modules[] = {
 			"forward",
 			"route",
 			"decap",
@@ -403,10 +417,29 @@ dataplane_init(
 			"route_mpls",
 			"blackhole"
 		};
-		for (size_t i = 0; i < sizeof(modules) / sizeof(modules[0]);
-		     ++i) {
+
+		const char **mod_list;
+		size_t mod_count;
+		const char *cfg_ptrs[DATAPLANE_MAX_MODULES];
+
+		if (config->module_count > 0) {
+			for (uint64_t i = 0;
+			     i < config->module_count; i++) {
+				cfg_ptrs[i] = config->module_names[i];
+			}
+			mod_list = cfg_ptrs;
+			mod_count = config->module_count;
+		} else {
+			mod_list = default_modules;
+			mod_count = sizeof(default_modules) /
+				    sizeof(default_modules[0]);
+		}
+
+		for (size_t i = 0; i < mod_count; ++i) {
 			if (dp_load_module(
-				    instance->dp_config, bin_hndl, modules[i]
+				    instance->dp_config, bin_hndl,
+				    &dataplane->plugins,
+				    mod_list[i]
 			    ) == -1) {
 				return -1;
 			}

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -1,8 +1,8 @@
 #include "dataplane.h"
 
 #include "config.h"
-#include "numa.h"
 #include "logging/log.h"
+#include "numa.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -306,12 +306,13 @@ dataplane_init(
 
 	assert((uintptr_t)storage % page_size == 0);
 
-	// Load external module plugins from .a files.
+	// Load external module plugins (.so shared libraries).
 	memset(&dataplane->plugins, 0, sizeof(dataplane->plugins));
 	if (config->plugin_dir[0] != '\0') {
-		if (dp_load_plugins(config->plugin_dir,
-		                    &dataplane->plugins) != 0) {
-			LOG(ERROR, "failed to load plugins from %s",
+		if (dp_load_plugins(config->plugin_dir, &dataplane->plugins) !=
+		    0) {
+			LOG(ERROR,
+			    "failed to load plugins from %s",
 			    config->plugin_dir);
 			return -1;
 		}
@@ -421,10 +422,12 @@ dataplane_init(
 			"blackhole"
 		};
 
-		for (size_t i = 0; i < sizeof(default_modules) /
-		     sizeof(default_modules[0]); ++i) {
+		for (size_t i = 0;
+		     i < sizeof(default_modules) / sizeof(default_modules[0]);
+		     ++i) {
 			if (dp_load_module(
-				    instance->dp_config, bin_hndl,
+				    instance->dp_config,
+				    bin_hndl,
 				    &dataplane->plugins,
 				    default_modules[i]
 			    ) == -1) {
@@ -434,8 +437,9 @@ dataplane_init(
 
 		for (uint64_t i = 0; i < config->module_count; ++i) {
 			bool is_default = false;
-			for (size_t j = 0; j < sizeof(default_modules) /
-			     sizeof(default_modules[0]); ++j) {
+			for (size_t j = 0; j < sizeof(default_modules
+					       ) / sizeof(default_modules[0]);
+			     ++j) {
 				if (strcmp(config->module_names[i],
 					   default_modules[j]) == 0) {
 					is_default = true;
@@ -447,7 +451,8 @@ dataplane_init(
 			}
 
 			if (dp_load_module(
-				    instance->dp_config, bin_hndl,
+				    instance->dp_config,
+				    bin_hndl,
 				    &dataplane->plugins,
 				    config->module_names[i]
 			    ) == -1) {

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -2,6 +2,11 @@
 
 #include "config.h"
 #include "numa.h"
+#include "logging/log.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
 
 #include <dlfcn.h>
 #include <pthread.h>
@@ -403,8 +408,6 @@ dataplane_init(
 		instance->dp_config->instance_idx = instance_idx;
 		instance->dp_config->instance_count = dataplane->instance_count;
 
-		// Use module list from config if specified,
-		// otherwise fall back to built-in defaults.
 		static const char *default_modules[] = {
 			"forward",
 			"route",
@@ -418,28 +421,35 @@ dataplane_init(
 			"blackhole"
 		};
 
-		const char **mod_list;
-		size_t mod_count;
-		const char *cfg_ptrs[DATAPLANE_MAX_MODULES];
-
-		if (config->module_count > 0) {
-			for (uint64_t i = 0;
-			     i < config->module_count; i++) {
-				cfg_ptrs[i] = config->module_names[i];
-			}
-			mod_list = cfg_ptrs;
-			mod_count = config->module_count;
-		} else {
-			mod_list = default_modules;
-			mod_count = sizeof(default_modules) /
-				    sizeof(default_modules[0]);
-		}
-
-		for (size_t i = 0; i < mod_count; ++i) {
+		for (size_t i = 0; i < sizeof(default_modules) /
+		     sizeof(default_modules[0]); ++i) {
 			if (dp_load_module(
 				    instance->dp_config, bin_hndl,
 				    &dataplane->plugins,
-				    mod_list[i]
+				    default_modules[i]
+			    ) == -1) {
+				return -1;
+			}
+		}
+
+		for (uint64_t i = 0; i < config->module_count; ++i) {
+			bool is_default = false;
+			for (size_t j = 0; j < sizeof(default_modules) /
+			     sizeof(default_modules[0]); ++j) {
+				if (strcmp(config->module_names[i],
+					   default_modules[j]) == 0) {
+					is_default = true;
+					break;
+				}
+			}
+			if (is_default) {
+				continue;
+			}
+
+			if (dp_load_module(
+				    instance->dp_config, bin_hndl,
+				    &dataplane->plugins,
+				    config->module_names[i]
 			    ) == -1) {
 				return -1;
 			}

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -5,6 +5,7 @@
 
 struct dataplane_config;
 struct dataplane_device;
+struct plugin_registry;
 
 struct dataplane_instance {
 	struct dp_config *dp_config;
@@ -19,6 +20,8 @@ struct dataplane {
 
 	struct dataplane_device *devices;
 	uint32_t device_count;
+
+	struct plugin_registry plugins;
 };
 
 int

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -3,9 +3,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "lib/dataplane/config/plugin_loader.h"
+
 struct dataplane_config;
 struct dataplane_device;
-struct plugin_registry;
 
 struct dataplane_instance {
 	struct dp_config *dp_config;

--- a/dataplane/meson.build
+++ b/dataplane/meson.build
@@ -67,6 +67,7 @@ executable(
   sources,
   dependencies: dependencies,
   install: true,
+  export_dynamic: true,
 )
 
 subdir('unittest')

--- a/lib/dataplane/config/meson.build
+++ b/lib/dataplane/config/meson.build
@@ -11,6 +11,7 @@ sources = files(
   'bootstrap.c',
   'counter_storage.c',
   'module_loader.c',
+  'plugin_loader.c',
   'topology.c',
   'zone.c',
 )

--- a/lib/dataplane/config/module_loader.c
+++ b/lib/dataplane/config/module_loader.c
@@ -14,22 +14,27 @@
 #include "lib/logging/log.h"
 
 int
-dp_load_module(struct dp_config *dp_config, void *bin_hndl,
-               const struct plugin_registry *plugins, const char *name) {
+dp_load_module(
+	struct dp_config *dp_config,
+	void *bin_hndl,
+	const struct plugin_registry *plugins,
+	const char *name
+) {
 	LOG(INFO, "load module %s", name);
 	char loader_name[128];
 	snprintf(loader_name, sizeof(loader_name), "%s%s", "new_module_", name);
 
-	// Try plugin handles first (external modules loaded from .a).
+	// Try plugin handles first (external .so modules).
 	module_load_handler loader = NULL;
 	if (plugins != NULL) {
 		for (uint64_t i = 0; i < plugins->count; i++) {
-			loader = (module_load_handler)dlsym(
-				plugins->plugins[i].dl_handle,
-				loader_name);
+			loader = (module_load_handler
+			)dlsym(plugins->plugins[i].dl_handle, loader_name);
 			if (loader != NULL) {
-				LOG(INFO, "module %s found in plugin %s",
-				    name, plugins->plugins[i].name);
+				LOG(INFO,
+				    "module %s found in plugin %s",
+				    name,
+				    plugins->plugins[i].name);
 				break;
 			}
 		}

--- a/lib/dataplane/config/module_loader.c
+++ b/lib/dataplane/config/module_loader.c
@@ -7,18 +7,39 @@
 #include "common/exp_array.h"
 #include "common/memory_address.h"
 #include "common/strutils.h"
+#include "lib/dataplane/config/plugin_loader.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/device/device.h"
 #include "lib/dataplane/module/module.h"
 #include "lib/logging/log.h"
 
 int
-dp_load_module(struct dp_config *dp_config, void *bin_hndl, const char *name) {
+dp_load_module(struct dp_config *dp_config, void *bin_hndl,
+               const struct plugin_registry *plugins, const char *name) {
 	LOG(INFO, "load module %s", name);
-	char loader_name[64];
+	char loader_name[128];
 	snprintf(loader_name, sizeof(loader_name), "%s%s", "new_module_", name);
-	module_load_handler loader =
-		(module_load_handler)dlsym(bin_hndl, loader_name);
+
+	// Try plugin handles first (external modules loaded from .a).
+	module_load_handler loader = NULL;
+	if (plugins != NULL) {
+		for (uint64_t i = 0; i < plugins->count; i++) {
+			loader = (module_load_handler)dlsym(
+				plugins->plugins[i].dl_handle,
+				loader_name);
+			if (loader != NULL) {
+				LOG(INFO, "module %s found in plugin %s",
+				    name, plugins->plugins[i].name);
+				break;
+			}
+		}
+	}
+
+	// Fallback to built-in (main binary).
+	if (loader == NULL) {
+		loader = (module_load_handler)dlsym(bin_hndl, loader_name);
+	}
+
 	if (loader == NULL) {
 		LOG(ERROR, "failed to load dyn symbol %s", loader_name);
 		return -1;
@@ -52,7 +73,7 @@ dp_load_module(struct dp_config *dp_config, void *bin_hndl, const char *name) {
 int
 dp_load_device(struct dp_config *dp_config, void *bin_hndl, const char *name) {
 	LOG(INFO, "load device %s", name);
-	char loader_name[64];
+	char loader_name[128];
 	snprintf(loader_name, sizeof(loader_name), "%s%s", "new_device_", name);
 	device_load_handler loader =
 		(device_load_handler)dlsym(bin_hndl, loader_name);

--- a/lib/dataplane/config/module_loader.h
+++ b/lib/dataplane/config/module_loader.h
@@ -1,12 +1,16 @@
 #pragma once
 
 struct dp_config;
+struct plugin_registry;
 
-// Load a packet-processing module via dlsym(bin_hndl, "new_module_<name>")
-// and append it to dp_config->dp_modules. Returns 0 on success, -1 on
-// dlsym miss or out-of-memory.
+// Load a packet-processing module by looking up
+// "new_module_<name>" -- first in the plugin registry (external .so
+// handles obtained from converted .a files), then in the main binary
+// via bin_hndl.  Appends the loaded module to dp_config->dp_modules.
+// Returns 0 on success, -1 on dlsym miss or out-of-memory.
 int
-dp_load_module(struct dp_config *dp_config, void *bin_hndl, const char *name);
+dp_load_module(struct dp_config *dp_config, void *bin_hndl,
+               const struct plugin_registry *plugins, const char *name);
 
 // Load a device adapter via dlsym(bin_hndl, "new_device_<name>") and append
 // it to dp_config->dp_devices, copying both input and output handlers.

--- a/lib/dataplane/config/module_loader.h
+++ b/lib/dataplane/config/module_loader.h
@@ -5,12 +5,16 @@ struct plugin_registry;
 
 // Load a packet-processing module by looking up
 // "new_module_<name>" -- first in the plugin registry (external .so
-// handles obtained from converted .a files), then in the main binary
+// modules loaded from plugin_dir), then in the main binary
 // via bin_hndl.  Appends the loaded module to dp_config->dp_modules.
 // Returns 0 on success, -1 on dlsym miss or out-of-memory.
 int
-dp_load_module(struct dp_config *dp_config, void *bin_hndl,
-               const struct plugin_registry *plugins, const char *name);
+dp_load_module(
+	struct dp_config *dp_config,
+	void *bin_hndl,
+	const struct plugin_registry *plugins,
+	const char *name
+);
 
 // Load a device adapter via dlsym(bin_hndl, "new_device_<name>") and append
 // it to dp_config->dp_devices, copying both input and output handlers.

--- a/lib/dataplane/config/plugin_loader.c
+++ b/lib/dataplane/config/plugin_loader.c
@@ -17,8 +17,7 @@
 // Extract module name from filename: "libnat44_dp.so" -> "nat44".
 // Returns 0 on success, -1 if the filename does not match.
 static int
-plugin_name_from_filename(const char *filename, char *name,
-                          size_t name_len) {
+plugin_name_from_filename(const char *filename, char *name, size_t name_len) {
 	size_t prefix_len = strlen(PLUGIN_SO_PREFIX);
 	size_t suffix_len = strlen(PLUGIN_SO_SUFFIX);
 	size_t fn_len = strlen(filename);
@@ -40,8 +39,7 @@ plugin_name_from_filename(const char *filename, char *name,
 }
 
 int
-dp_load_plugins(const char *plugin_dir,
-                struct plugin_registry *registry) {
+dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry) {
 	registry->plugins = NULL;
 	registry->count = 0;
 
@@ -50,21 +48,29 @@ dp_load_plugins(const char *plugin_dir,
 
 	DIR *dir = opendir(plugin_dir);
 	if (dir == NULL) {
-		LOG(WARN, "cannot open plugin directory %s: %s",
-		    plugin_dir, strerror(errno));
+		LOG(WARN,
+		    "cannot open plugin directory %s: %s",
+		    plugin_dir,
+		    strerror(errno));
 		return 0;
 	}
 
 	struct dirent *entry;
 	while ((entry = readdir(dir)) != NULL) {
 		char name[PLUGIN_NAME_LEN];
-		if (plugin_name_from_filename(entry->d_name,
-		                              name, sizeof(name)) != 0)
+		if (plugin_name_from_filename(
+			    entry->d_name, name, sizeof(name)
+		    ) != 0)
 			continue;
 
 		char so_path[512];
-		snprintf(so_path, sizeof(so_path), "%s/%s",
-		         plugin_dir, entry->d_name);
+		snprintf(
+			so_path,
+			sizeof(so_path),
+			"%s/%s",
+			plugin_dir,
+			entry->d_name
+		);
 
 		struct stat st;
 		if (stat(so_path, &st) != 0 || !S_ISREG(st.st_mode))
@@ -72,15 +78,14 @@ dp_load_plugins(const char *plugin_dir,
 
 		void *dl = dlopen(so_path, RTLD_NOW | RTLD_GLOBAL);
 		if (dl == NULL) {
-			LOG(ERROR, "dlopen(%s) failed: %s",
-			    so_path, dlerror());
+			LOG(ERROR, "dlopen(%s) failed: %s", so_path, dlerror());
 			continue;
 		}
 
-		struct plugin_handle *new_plugins = realloc(
-			registry->plugins,
-			sizeof(struct plugin_handle) *
-				(registry->count + 1));
+		struct plugin_handle *new_plugins =
+			realloc(registry->plugins,
+				sizeof(struct plugin_handle) *
+					(registry->count + 1));
 		if (new_plugins == NULL) {
 			LOG(ERROR, "out of memory for plugin %s", name);
 			dlclose(dl);
@@ -99,8 +104,10 @@ dp_load_plugins(const char *plugin_dir,
 
 	closedir(dir);
 
-	LOG(INFO, "loaded %lu external plugin(s) from %s",
-	    (unsigned long)registry->count, plugin_dir);
+	LOG(INFO,
+	    "loaded %lu external plugin(s) from %s",
+	    (unsigned long)registry->count,
+	    plugin_dir);
 	return 0;
 }
 

--- a/lib/dataplane/config/plugin_loader.c
+++ b/lib/dataplane/config/plugin_loader.c
@@ -1,0 +1,123 @@
+#include "plugin_loader.h"
+
+#include <dirent.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "common/strutils.h"
+#include "lib/logging/log.h"
+
+#define PLUGIN_SO_PREFIX "lib"
+#define PLUGIN_SO_SUFFIX "_dp.so"
+
+// Extract module name from filename: "libnat44_dp.so" -> "nat44".
+// Returns 0 on success, -1 if the filename does not match.
+static int
+plugin_name_from_filename(const char *filename, char *name,
+                          size_t name_len) {
+	size_t prefix_len = strlen(PLUGIN_SO_PREFIX);
+	size_t suffix_len = strlen(PLUGIN_SO_SUFFIX);
+	size_t fn_len = strlen(filename);
+
+	if (fn_len <= prefix_len + suffix_len)
+		return -1;
+	if (strncmp(filename, PLUGIN_SO_PREFIX, prefix_len) != 0)
+		return -1;
+	if (strcmp(filename + fn_len - suffix_len, PLUGIN_SO_SUFFIX) != 0)
+		return -1;
+
+	size_t mod_len = fn_len - prefix_len - suffix_len;
+	if (mod_len >= name_len)
+		return -1;
+
+	memcpy(name, filename + prefix_len, mod_len);
+	name[mod_len] = '\0';
+	return 0;
+}
+
+int
+dp_load_plugins(const char *plugin_dir,
+                struct plugin_registry *registry) {
+	registry->plugins = NULL;
+	registry->count = 0;
+
+	if (plugin_dir == NULL || plugin_dir[0] == '\0')
+		return 0;
+
+	DIR *dir = opendir(plugin_dir);
+	if (dir == NULL) {
+		LOG(WARN, "cannot open plugin directory %s: %s",
+		    plugin_dir, strerror(errno));
+		return 0;
+	}
+
+	struct dirent *entry;
+	while ((entry = readdir(dir)) != NULL) {
+		char name[PLUGIN_NAME_LEN];
+		if (plugin_name_from_filename(entry->d_name,
+		                              name, sizeof(name)) != 0)
+			continue;
+
+		char so_path[512];
+		snprintf(so_path, sizeof(so_path), "%s/%s",
+		         plugin_dir, entry->d_name);
+
+		struct stat st;
+		if (stat(so_path, &st) != 0 || !S_ISREG(st.st_mode))
+			continue;
+
+		void *dl = dlopen(so_path, RTLD_NOW | RTLD_GLOBAL);
+		if (dl == NULL) {
+			LOG(ERROR, "dlopen(%s) failed: %s",
+			    so_path, dlerror());
+			continue;
+		}
+
+		struct plugin_handle *new_plugins = realloc(
+			registry->plugins,
+			sizeof(struct plugin_handle) *
+				(registry->count + 1));
+		if (new_plugins == NULL) {
+			LOG(ERROR, "out of memory for plugin %s", name);
+			dlclose(dl);
+			continue;
+		}
+		registry->plugins = new_plugins;
+
+		struct plugin_handle *handle =
+			&registry->plugins[registry->count];
+		strtcpy(handle->name, name, sizeof(handle->name));
+		handle->dl_handle = dl;
+		registry->count++;
+
+		LOG(INFO, "loaded plugin %s from %s", name, so_path);
+	}
+
+	closedir(dir);
+
+	LOG(INFO, "loaded %lu external plugin(s) from %s",
+	    (unsigned long)registry->count, plugin_dir);
+	return 0;
+}
+
+void
+dp_unload_plugins(struct plugin_registry *registry) {
+	if (registry->plugins == NULL)
+		return;
+
+	for (uint64_t i = 0; i < registry->count; i++) {
+		struct plugin_handle *p = &registry->plugins[i];
+		if (p->dl_handle != NULL) {
+			dlclose(p->dl_handle);
+			p->dl_handle = NULL;
+		}
+	}
+
+	free(registry->plugins);
+	registry->plugins = NULL;
+	registry->count = 0;
+}

--- a/lib/dataplane/config/plugin_loader.h
+++ b/lib/dataplane/config/plugin_loader.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stdint.h>
+
+#define PLUGIN_NAME_LEN 80
+
+struct plugin_handle {
+	char name[PLUGIN_NAME_LEN];
+	void *dl_handle;
+};
+
+struct plugin_registry {
+	struct plugin_handle *plugins;
+	uint64_t count;
+};
+
+// Scan plugin_dir for lib*_dp.so files and dlopen each one.
+// Returns 0 on success, -1 on fatal error.
+// Individual plugin failures are logged but do not prevent other
+// plugins from loading.
+int
+dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry);
+
+// dlclose all plugin handles and free the registry.
+void
+dp_unload_plugins(struct plugin_registry *registry);

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -148,7 +148,7 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	// Load requested packet-processing modules.
 	for (size_t idx = 0; idx < cfg->module_count; ++idx) {
 		if (dp_load_module(
-			    ut->dp_config, bin_hndl, cfg->modules[idx]
+			    ut->dp_config, bin_hndl, NULL, cfg->modules[idx]
 		    ) == -1) {
 			LOG(ERROR,
 			    "dataplane_ut_new: failed to load module %s",

--- a/modules/balancer2/meson.build
+++ b/modules/balancer2/meson.build
@@ -1,1 +1,3 @@
-subdir('controlplane')
+if not dataplane_only
+  subdir('controlplane')
+endif


### PR DESCRIPTION
Add runtime plugin loading for out-of-tree dataplane modules (e.g. nat44).

- Plugin loader discovers and loads shared libraries from a configurable plugin_dir.
- Config module_loader extended to register plugin-provided modules alongside built-in ones.
- Dynamic symbol export for plugin entry points (new_module_*).

4 commits, 12 files changed (276 additions, 15 deletions).