### PR TITLE
feat(gateway): add ReadinessService

### DIFF
--- a/controlplane/etc/yanet/auth/permissions.yaml
+++ b/controlplane/etc/yanet/auth/permissions.yaml
@@ -7,3 +7,4 @@ permissions:
     - username: anonymous
       permissions:
         - "/controlplane.ynpb.v1.Gateway/Register"
+        - "/controlplane.ynpb.v1.ReadinessService/Ready"

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -115,6 +115,7 @@ type Gateway struct {
 	services       []Service
 	serviceRunners []*ServiceRunner
 	registry       *BackendRegistry
+	readiness      *readinessTracker
 	log            *zap.Logger
 }
 
@@ -184,6 +185,11 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	ynpb.RegisterAuthServiceServer(server, authService)
 	log.Info("registered service", zap.String("service", fmt.Sprintf("%T", authService)))
 
+	readinessTracker := newReadinessTracker(log)
+	readinessSvc := NewReadinessService(readinessTracker)
+	ynpb.RegisterReadinessServiceServer(server, readinessSvc)
+	log.Info("registered service", zap.String("service", fmt.Sprintf("%T", readinessSvc)))
+
 	// Dial a single loopback connection shared by services hosted on the
 	// gateway's own gRPC server.
 	//
@@ -199,7 +205,11 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 		return nil, fmt.Errorf("failed to create loopback backend for gateway-hosted services: %w", err)
 	}
 
-	for _, service := range []string{"controlplane.ynpb.v1.Gateway", "controlplane.ynpb.v1.Auth"} {
+	for _, service := range []string{
+		"controlplane.ynpb.v1.Gateway",
+		"controlplane.ynpb.v1.Auth",
+		ynpb.ReadinessService_ServiceDesc.ServiceName,
+	} {
 		registry.RegisterBackend(service, loopback, BackendKindBuiltin)
 		log.Info("registered built-in service in registry",
 			zap.String("service", service),
@@ -247,6 +257,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 		services:       services,
 		serviceRunners: serviceRunners,
 		registry:       registry,
+		readiness:      readinessTracker,
 		log:            log,
 	}, nil
 }
@@ -330,13 +341,17 @@ func (m *Gateway) Run(ctx context.Context) error {
 			m.log.Info("all built-in modules ready",
 				zap.Int("count", len(m.serviceRunners)),
 			)
+			m.readiness.Ready()
 			return nil
 		})
 	} else {
 		m.log.Info("all built-in modules ready", zap.Int("count", 0))
+		m.readiness.Ready()
 	}
 
 	<-ctx.Done()
+
+	m.readiness.Drain()
 
 	m.log.Info("stopping gRPC gateway", zap.Stringer("addr", listener.Addr()))
 	defer m.log.Info("stopped gRPC gateway", zap.Stringer("addr", listener.Addr()))

--- a/controlplane/gateway/readiness.go
+++ b/controlplane/gateway/readiness.go
@@ -1,0 +1,162 @@
+package gateway
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// readinessTracker holds the mutable readiness state for the gateway scope.
+type readinessTracker struct {
+	mu                 sync.Mutex
+	state              readinesspb.State
+	reason             *readinesspb.Reason
+	observedAt         time.Time
+	lastTransitionTime time.Time
+	drained            bool
+	log                *zap.Logger
+}
+
+// newReadinessTracker creates a readinessTracker seeded at STATE_UNKNOWN.
+func newReadinessTracker(log *zap.Logger) *readinessTracker {
+	return &readinessTracker{
+		state: readinesspb.State_STATE_UNKNOWN,
+		log:   log,
+	}
+}
+
+// Ready transitions the tracker to STATE_READY.
+//
+// It is a no-op once Drain has been called; a late Ready must not flip a
+// drained tracker back to READY.
+func (m *readinessTracker) Ready() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.drained {
+		return
+	}
+
+	now := time.Now()
+	prev := m.state
+	next := readinesspb.State_STATE_READY
+
+	if m.observedAt.IsZero() || m.state != next {
+		m.lastTransitionTime = now
+	}
+	m.state = next
+	m.reason = nil
+	m.observedAt = now
+
+	m.logTransition(prev, next, nil)
+}
+
+// Drain transitions the tracker to STATE_NOT_READY with a SHUTTING_DOWN reason
+// and latches it so that subsequent Ready calls are no-ops.
+func (m *readinessTracker) Drain() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	prev := m.state
+	next := readinesspb.State_STATE_NOT_READY
+	reason := &readinesspb.Reason{Code: "SHUTTING_DOWN"}
+
+	if m.observedAt.IsZero() || m.state != next {
+		m.lastTransitionTime = now
+	}
+	m.state = next
+	m.reason = reason
+	m.observedAt = now
+	m.drained = true
+
+	m.logTransition(prev, next, reason)
+}
+
+// Snapshot builds a ReadyResponse for the given request, honoring the scope
+// filter.
+//
+// An empty scopes list returns the gateway scope. A non-empty filter that
+// does not include "gateway" returns an empty scopes list.
+func (m *readinessTracker) Snapshot(req *readinesspb.ReadyRequest) *readinesspb.ReadyResponse {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	filter := req.GetScopes()
+	if len(filter) > 0 {
+		found := false
+		for _, name := range filter {
+			if name == "gateway" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return &readinesspb.ReadyResponse{}
+		}
+	}
+
+	var reasons []*readinesspb.Reason
+	if m.reason != nil {
+		reasons = []*readinesspb.Reason{m.reason}
+	}
+
+	scope := &readinesspb.Scope{
+		Name:    "gateway",
+		State:   m.state,
+		Reasons: reasons,
+	}
+	if !m.observedAt.IsZero() {
+		scope.ObservedAt = timestamppb.New(m.observedAt)
+		scope.LastTransitionTime = timestamppb.New(m.lastTransitionTime)
+	}
+
+	return &readinesspb.ReadyResponse{Scopes: []*readinesspb.Scope{scope}}
+}
+
+// logTransition logs a state change at Info level when prev and next differ.
+// Must be called with m.mu held.
+func (m *readinessTracker) logTransition(prev, next readinesspb.State, reason *readinesspb.Reason) {
+	if prev == next {
+		return
+	}
+
+	fields := []zap.Field{
+		zap.String("from", prev.String()),
+		zap.String("to", next.String()),
+	}
+	if reason != nil {
+		fields = append(fields, zap.String("reason", reason.GetCode()))
+		if reason.GetMessage() != "" {
+			fields = append(fields, zap.String("reason_message", reason.GetMessage()))
+		}
+	}
+	m.log.Info("readiness state transitioned", fields...)
+}
+
+// ReadinessService implements ynpb.ReadinessServiceServer by delegating to a
+// readinessTracker.
+type ReadinessService struct {
+	ynpb.UnimplementedReadinessServiceServer
+
+	tracker *readinessTracker
+}
+
+// NewReadinessService constructs a ReadinessService backed by tracker.
+func NewReadinessService(tracker *readinessTracker) *ReadinessService {
+	return &ReadinessService{tracker: tracker}
+}
+
+// Ready returns the current readiness state of the gateway scope.
+func (m *ReadinessService) Ready(
+	ctx context.Context,
+	req *readinesspb.ReadyRequest,
+) (*readinesspb.ReadyResponse, error) {
+	return m.tracker.Snapshot(req), nil
+}

--- a/controlplane/gateway/readiness_test.go
+++ b/controlplane/gateway/readiness_test.go
@@ -1,0 +1,124 @@
+package gateway
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
+)
+
+func newTestTracker() *readinessTracker {
+	return newReadinessTracker(zap.NewNop())
+}
+
+func TestReadinessTracker_InitialState(t *testing.T) {
+	tracker := newTestTracker()
+
+	resp := tracker.Snapshot(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.GetScopes(), 1)
+
+	scope := resp.GetScopes()[0]
+	require.Equal(t, "gateway", scope.GetName())
+	require.Equal(t, readinesspb.State_STATE_UNKNOWN, scope.GetState())
+	require.Nil(t, scope.GetObservedAt())
+	require.Nil(t, scope.GetLastTransitionTime())
+}
+
+func TestReadinessTracker_AfterReady(t *testing.T) {
+	tracker := newTestTracker()
+	tracker.Ready()
+
+	resp := tracker.Snapshot(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.GetScopes(), 1)
+
+	scope := resp.GetScopes()[0]
+	require.Equal(t, readinesspb.State_STATE_READY, scope.GetState())
+	require.NotNil(t, scope.GetObservedAt())
+	require.NotNil(t, scope.GetLastTransitionTime())
+	require.Empty(t, scope.GetReasons())
+}
+
+func TestReadinessTracker_AfterDrain(t *testing.T) {
+	tracker := newTestTracker()
+	tracker.Ready()
+	tracker.Drain()
+
+	resp := tracker.Snapshot(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.GetScopes(), 1)
+
+	scope := resp.GetScopes()[0]
+	require.Equal(t, readinesspb.State_STATE_NOT_READY, scope.GetState())
+	require.Len(t, scope.GetReasons(), 1)
+	require.Equal(t, "SHUTTING_DOWN", scope.GetReasons()[0].GetCode())
+	require.NotNil(t, scope.GetObservedAt())
+	require.NotNil(t, scope.GetLastTransitionTime())
+}
+
+func TestReadinessTracker_SnapshotFilter(t *testing.T) {
+	tests := []struct {
+		name        string
+		filter      []string
+		wantScopes  int
+		wantGateway bool
+	}{
+		{
+			name:        "empty filter returns gateway scope",
+			filter:      nil,
+			wantScopes:  1,
+			wantGateway: true,
+		},
+		{
+			name:        "explicit gateway filter returns gateway scope",
+			filter:      []string{"gateway"},
+			wantScopes:  1,
+			wantGateway: true,
+		},
+		{
+			name:       "unrelated filter returns empty scopes",
+			filter:     []string{"other"},
+			wantScopes: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tracker := newTestTracker()
+			tracker.Ready()
+
+			resp := tracker.Snapshot(&readinesspb.ReadyRequest{Scopes: tc.filter})
+			require.Len(t, resp.GetScopes(), tc.wantScopes)
+
+			if tc.wantGateway {
+				require.Equal(t, "gateway", resp.GetScopes()[0].GetName())
+			}
+		})
+	}
+}
+
+func TestReadinessTracker_ReadyAfterDrainIsNoop(t *testing.T) {
+	tracker := newTestTracker()
+	tracker.Ready()
+	tracker.Drain()
+	tracker.Ready()
+
+	resp := tracker.Snapshot(&readinesspb.ReadyRequest{})
+	require.Len(t, resp.GetScopes(), 1)
+
+	scope := resp.GetScopes()[0]
+	require.Equal(t, readinesspb.State_STATE_NOT_READY, scope.GetState())
+	require.Len(t, scope.GetReasons(), 1)
+	require.Equal(t, "SHUTTING_DOWN", scope.GetReasons()[0].GetCode())
+}
+
+func TestReadinessService_Ready(t *testing.T) {
+	tracker := newTestTracker()
+	tracker.Ready()
+
+	svc := NewReadinessService(tracker)
+	resp, err := svc.Ready(t.Context(), &readinesspb.ReadyRequest{})
+	require.NoError(t, err)
+	require.Len(t, resp.GetScopes(), 1)
+	require.Equal(t, readinesspb.State_STATE_READY, resp.GetScopes()[0].GetState())
+}

--- a/controlplane/ynpb/meson.build
+++ b/controlplane/ynpb/meson.build
@@ -12,6 +12,7 @@ ynpb_proto_files = [
     join_paths(ynpb_dir, 'v1', 'device.proto'),
     join_paths(ynpb_dir, 'v1', 'counters.proto'),
     join_paths(ynpb_dir, 'v1', 'auth.proto'),
+    join_paths(ynpb_dir, 'v1', 'readiness.proto'),
 ]
 
 # Generate protobuf files
@@ -36,6 +37,8 @@ ynpb_gen = custom_target(
         'counters_grpc.pb.go',
         'auth.pb.go',
         'auth_grpc.pb.go',
+        'readiness.pb.go',
+        'readiness_grpc.pb.go',
     ],
     input: ynpb_proto_files,
     command: [

--- a/controlplane/ynpb/v1/readiness.proto
+++ b/controlplane/ynpb/v1/readiness.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package controlplane.ynpb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
+
+import "common/readinesspb/v1/readiness.proto";
+
+// ReadinessService exposes gateway readiness state to external probes.
+service ReadinessService {
+  // Ready returns the current readiness state of the gateway.
+  rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
+}


### PR DESCRIPTION
Add a ReadinessService to the gateway so external tooling can query over gRPC whether the gateway has finished bringing all its services up. Until now the only readiness signal was a log line.

Readiness is modeled as a single gateway scope that becomes ready at the exact point every service has registered, and transitions to not-ready while the gateway drains on shutdown. The endpoint reuses the shared readiness vocabulary already used by the operators.

The Ready RPC is reachable anonymously so health and liveness probes can call it without a token, and the service is exposed through both the gRPC server and the HTTP proxy.