### PR TITLE
fix(pdump): propagate missing record metadata instead of panicking

### DIFF
--- a/modules/pdump/cli/src/writer.rs
+++ b/modules/pdump/cli/src/writer.rs
@@ -138,7 +138,9 @@ impl PdumpWriter {
     }
 
     fn write_text(writer: &mut Text, rec: pdumppb::Record) -> Result<usize, Box<dyn Error>> {
-        let mut meta = rec.meta.unwrap();
+        let mut meta = rec
+            .meta
+            .ok_or_else(|| -> Box<dyn Error> { "pdump record missing metadata".into() })?;
 
         let ts = match &writer.base_ts {
             None => {
@@ -163,14 +165,18 @@ impl PdumpWriter {
     }
 
     fn write_pcap(writer: &mut Pcap, rec: pdumppb::Record) -> Result<usize, Box<dyn Error>> {
-        let meta = rec.meta.unwrap();
+        let meta = rec
+            .meta
+            .ok_or_else(|| -> Box<dyn Error> { "pdump record missing metadata".into() })?;
         let ts = Duration::from_nanos(meta.timestamp);
         let packet = PcapPacket::new_owned(ts, meta.packet_len, rec.data);
         Ok(writer.inner.write_packet(&packet)?)
     }
 
     fn write_pcapng(writer: &mut PcapNg, rec: pdumppb::Record) -> Result<usize, Box<dyn Error>> {
-        let meta = rec.meta.unwrap();
+        let meta = rec
+            .meta
+            .ok_or_else(|| -> Box<dyn Error> { "pdump record missing metadata".into() })?;
         let ts = Duration::from_nanos(meta.timestamp);
 
         let mut packet_block = EnhancedPacketBlock::default();


### PR DESCRIPTION
The capture CLI called `.unwrap()` on the optional `meta` field of each streamed record. A server or malformed stream sending a record without metadata crashed the CLI process. Propagate an error on the missing field so the stream fails gracefully instead.

Closes #571.