### PR TITLE
refactor(web): extract shared config palette command builder

### DIFF
--- a/web/src/components/command-palette/configCommands.test.ts
+++ b/web/src/components/command-palette/configCommands.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildConfigCommands } from './configCommands';
+
+describe('buildConfigCommands', () => {
+    it('acl parameterization — produces the correct trio', () => {
+        const onAddConfig = vi.fn();
+        const onDeleteConfig = vi.fn();
+        const onSwitchConfig = vi.fn();
+
+        const result = buildConfigCommands({
+            currentConfig: 'main',
+            draftConfigs: ['main', 'staging'],
+            dirtySet: new Set<string>(),
+            addConfigSub: 'Create a new ACL configuration',
+            withKeywords: true,
+            onAddConfig,
+            onDeleteConfig,
+            onSwitchConfig,
+        });
+
+        expect(result).toHaveLength(3);
+
+        expect(result[0]).toMatchObject({
+            id: '__add_config',
+            icon: '▤',
+            label: 'Add config',
+            sub: 'Create a new ACL configuration',
+            keywords: 'add config create new',
+            onSelect: expect.any(Function),
+        });
+
+        expect(result[1]).toMatchObject({
+            id: '__delete_config',
+            icon: '✕',
+            label: 'Delete config',
+            sub: 'Delete "main"',
+            keywords: 'delete remove config',
+            onSelect: expect.any(Function),
+        });
+
+        expect(result[2]).toMatchObject({
+            id: '__config_staging',
+            icon: '⇥',
+            label: 'Switch to config staging',
+            sub: undefined,
+            keywords: 'switch config tab staging',
+            onSelect: expect.any(Function),
+        });
+    });
+
+    it('forward parameterization — produces the correct trio', () => {
+        const onAddConfig = vi.fn();
+        const onDeleteConfig = vi.fn();
+        const onSwitchConfig = vi.fn();
+
+        const result = buildConfigCommands({
+            currentConfig: 'prod',
+            draftConfigs: ['prod', 'dev'],
+            dirtySet: new Set(['dev']),
+            addConfigSub: 'Create a new forward configuration',
+            withKeywords: true,
+            onAddConfig,
+            onDeleteConfig,
+            onSwitchConfig,
+        });
+
+        expect(result).toHaveLength(3);
+
+        expect(result[0]).toMatchObject({
+            id: '__add_config',
+            sub: 'Create a new forward configuration',
+            keywords: 'add config create new',
+        });
+
+        expect(result[1]).toMatchObject({
+            id: '__delete_config',
+            sub: 'Delete "prod"',
+            keywords: 'delete remove config',
+        });
+
+        expect(result[2]).toMatchObject({
+            id: '__config_dev',
+            label: 'Switch to config dev',
+            sub: 'unsaved changes',
+            keywords: 'switch config tab dev',
+        });
+    });
+
+    it('decap parameterization — produces the correct trio', () => {
+        const onAddConfig = vi.fn();
+        const onDeleteConfig = vi.fn();
+        const onSwitchConfig = vi.fn();
+
+        const result = buildConfigCommands({
+            currentConfig: 'main',
+            draftConfigs: ['main', 'backup'],
+            dirtySet: new Set<string>(),
+            addConfigSub: 'Create a new decap configuration',
+            withKeywords: true,
+            onAddConfig,
+            onDeleteConfig,
+            onSwitchConfig,
+        });
+
+        expect(result).toHaveLength(3);
+
+        expect(result[0]).toMatchObject({
+            id: '__add_config',
+            sub: 'Create a new decap configuration',
+            keywords: 'add config create new',
+        });
+
+        expect(result[1]).toMatchObject({
+            id: '__delete_config',
+            sub: 'Delete "main"',
+            keywords: 'delete remove config',
+        });
+
+        expect(result[2]).toMatchObject({
+            id: '__config_backup',
+            keywords: 'switch config tab backup',
+        });
+    });
+
+    it('route parameterization — no sub/keywords on Add, no keywords on Delete, switch has keywords', () => {
+        const onAddConfig = vi.fn();
+        const onDeleteConfig = vi.fn();
+        const onSwitchConfig = vi.fn();
+
+        const result = buildConfigCommands({
+            currentConfig: 'main',
+            draftConfigs: ['main', 'canary'],
+            dirtySet: new Set<string>(),
+            onAddConfig,
+            onDeleteConfig,
+            onSwitchConfig,
+        });
+
+        expect(result).toHaveLength(3);
+
+        expect(result[0].sub).toBeUndefined();
+        expect(result[0].keywords).toBeUndefined();
+
+        expect(result[1].sub).toBe('Delete "main"');
+        expect(result[1].keywords).toBeUndefined();
+
+        expect(result[2]).toMatchObject({
+            id: '__config_canary',
+            keywords: 'switch config tab canary',
+            sub: undefined,
+        });
+    });
+
+    it('omits the Delete item when currentConfig is empty', () => {
+        const result = buildConfigCommands({
+            currentConfig: '',
+            draftConfigs: ['alpha', 'beta'],
+            dirtySet: new Set<string>(),
+            withKeywords: true,
+            onAddConfig: vi.fn(),
+            onDeleteConfig: vi.fn(),
+            onSwitchConfig: vi.fn(),
+        });
+
+        expect(result.find((c) => c.id === '__delete_config')).toBeUndefined();
+    });
+
+    it('excludes the active config from switch items', () => {
+        const result = buildConfigCommands({
+            currentConfig: 'alpha',
+            draftConfigs: ['alpha', 'beta', 'gamma'],
+            dirtySet: new Set<string>(),
+            withKeywords: true,
+            onAddConfig: vi.fn(),
+            onDeleteConfig: vi.fn(),
+            onSwitchConfig: vi.fn(),
+        });
+
+        const switchIds = result.filter((c) => c.id.startsWith('__config_')).map((c) => c.id);
+        expect(switchIds).toEqual(['__config_beta', '__config_gamma']);
+        expect(switchIds).not.toContain('__config_alpha');
+    });
+
+    it('marks dirty switch items with "unsaved changes" sub', () => {
+        const result = buildConfigCommands({
+            currentConfig: 'clean',
+            draftConfigs: ['clean', 'dirty'],
+            dirtySet: new Set(['dirty']),
+            withKeywords: true,
+            onAddConfig: vi.fn(),
+            onDeleteConfig: vi.fn(),
+            onSwitchConfig: vi.fn(),
+        });
+
+        const switchItem = result.find((c) => c.id === '__config_dirty');
+        expect(switchItem?.sub).toBe('unsaved changes');
+    });
+
+    it('leaves sub undefined for non-dirty switch items', () => {
+        const result = buildConfigCommands({
+            currentConfig: 'x',
+            draftConfigs: ['x', 'y'],
+            dirtySet: new Set<string>(),
+            withKeywords: true,
+            onAddConfig: vi.fn(),
+            onDeleteConfig: vi.fn(),
+            onSwitchConfig: vi.fn(),
+        });
+
+        const switchItem = result.find((c) => c.id === '__config_y');
+        expect(switchItem?.sub).toBeUndefined();
+    });
+
+    it('onSelect on Add invokes onAddConfig', () => {
+        const onAddConfig = vi.fn();
+        const result = buildConfigCommands({
+            currentConfig: '',
+            draftConfigs: [],
+            dirtySet: new Set<string>(),
+            onAddConfig,
+            onDeleteConfig: vi.fn(),
+            onSwitchConfig: vi.fn(),
+        });
+
+        result[0].onSelect();
+        expect(onAddConfig).toHaveBeenCalledOnce();
+    });
+
+    it('onSelect on Delete invokes onDeleteConfig', () => {
+        const onDeleteConfig = vi.fn();
+        const result = buildConfigCommands({
+            currentConfig: 'main',
+            draftConfigs: ['main'],
+            dirtySet: new Set<string>(),
+            onAddConfig: vi.fn(),
+            onDeleteConfig,
+            onSwitchConfig: vi.fn(),
+        });
+
+        const deleteItem = result.find((c) => c.id === '__delete_config')!;
+        deleteItem.onSelect();
+        expect(onDeleteConfig).toHaveBeenCalledOnce();
+    });
+
+    it('onSelect on a switch item invokes onSwitchConfig with the correct name', () => {
+        const onSwitchConfig = vi.fn();
+        const result = buildConfigCommands({
+            currentConfig: 'a',
+            draftConfigs: ['a', 'b', 'c'],
+            dirtySet: new Set<string>(),
+            onAddConfig: vi.fn(),
+            onDeleteConfig: vi.fn(),
+            onSwitchConfig,
+        });
+
+        const switchB = result.find((c) => c.id === '__config_b')!;
+        switchB.onSelect();
+        expect(onSwitchConfig).toHaveBeenCalledWith('b');
+
+        const switchC = result.find((c) => c.id === '__config_c')!;
+        switchC.onSelect();
+        expect(onSwitchConfig).toHaveBeenCalledWith('c');
+    });
+});

--- a/web/src/components/command-palette/configCommands.ts
+++ b/web/src/components/command-palette/configCommands.ts
@@ -1,0 +1,77 @@
+import type { Command } from './types';
+
+/** Options for building the standard config management command trio. */
+export interface ConfigCommandsOptions {
+    /** Currently active config name; falsy means no config is selected. */
+    currentConfig: string;
+    /** All draft config names, including the active one. */
+    draftConfigs: string[];
+    /** Set of config names that have unsaved changes. */
+    dirtySet: Set<string>;
+    /** Optional secondary line for the Add config item. */
+    addConfigSub?: string;
+    /** Whether to attach keywords to the Add and Delete items for fuzzy search. */
+    withKeywords?: boolean;
+    /** Called when the user selects "Add config". */
+    onAddConfig: () => void;
+    /** Called when the user selects "Delete config". */
+    onDeleteConfig: () => void;
+    /** Called with the target config name when the user selects a switch item. */
+    onSwitchConfig: (name: string) => void;
+}
+
+/**
+ * Builds the standard Add / Delete / Switch config command trio for module pages.
+ *
+ * Switch items always carry keywords regardless of withKeywords, matching the
+ * behavior common to all four module pages that use this pattern.
+ */
+export const buildConfigCommands = (options: ConfigCommandsOptions): Command[] => {
+    const {
+        currentConfig,
+        draftConfigs,
+        dirtySet,
+        addConfigSub,
+        withKeywords,
+        onAddConfig,
+        onDeleteConfig,
+        onSwitchConfig,
+    } = options;
+
+    const list: Command[] = [];
+
+    list.push({
+        id: '__add_config',
+        icon: '▤',
+        label: 'Add config',
+        sub: addConfigSub,
+        keywords: withKeywords ? 'add config create new' : undefined,
+        onSelect: onAddConfig,
+    });
+
+    if (currentConfig) {
+        list.push({
+            id: '__delete_config',
+            icon: '✕',
+            label: 'Delete config',
+            sub: `Delete "${currentConfig}"`,
+            keywords: withKeywords ? 'delete remove config' : undefined,
+            onSelect: onDeleteConfig,
+        });
+    }
+
+    for (const cfg of draftConfigs) {
+        if (cfg === currentConfig) continue;
+        const name = cfg;
+        list.push({
+            id: `__config_${name}`,
+            icon: '⇥',
+            label: `Switch to config ${name}`,
+            sub: dirtySet.has(name) ? 'unsaved changes' : undefined,
+            keywords: `switch config tab ${name}`,
+            onSelect: () => onSwitchConfig(name),
+        });
+    }
+
+    return list;
+};

--- a/web/src/components/command-palette/index.ts
+++ b/web/src/components/command-palette/index.ts
@@ -9,4 +9,6 @@ export { useHelpShortcut } from './useHelpShortcut';
 export { PaletteProvider, usePalette } from './PaletteContext';
 export type { PagePaletteContribution } from './PaletteContext';
 export { navigationCommands } from './navigationCommands';
+export { buildConfigCommands } from './configCommands';
+export type { ConfigCommandsOptions } from './configCommands';
 export { default as ShortcutsHelp } from './ShortcutsHelp';

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -19,6 +19,7 @@ import { useAclRuleCounters } from './useAclRuleCounters';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { DRAWER_TRANSITION_MS } from '../../../components/draft';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
+import { buildConfigCommands } from '../../../components/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/chrome.scss';
 import './acl.scss';
@@ -323,36 +324,16 @@ const AclPage: React.FC = () => {
                 onSelect: () => { closeDrawer(); handleDiscard(); },
             });
         }
-        list.push({
-            id: '__add_config',
-            icon: '▤',
-            label: 'Add config',
-            sub: 'Create a new ACL configuration',
-            keywords: 'add config create new',
-            onSelect: () => setAddConfigOpen(true),
-        });
-        if (currentConfig) {
-            list.push({
-                id: '__delete_config',
-                icon: '✕',
-                label: 'Delete config',
-                sub: `Delete "${currentConfig}"`,
-                keywords: 'delete remove config',
-                onSelect: () => handleOpenDeleteConfig(),
-            });
-        }
-        for (const cfg of draftConfigs) {
-            if (cfg === currentConfig) continue;
-            const name = cfg;
-            list.push({
-                id: `__config_${name}`,
-                icon: '⇥',
-                label: `Switch to config ${name}`,
-                sub: dirtySet.has(name) ? 'unsaved changes' : undefined,
-                keywords: `switch config tab ${name}`,
-                onSelect: () => handleTabSelect(name),
-            });
-        }
+        list.push(...buildConfigCommands({
+            currentConfig,
+            draftConfigs,
+            dirtySet,
+            addConfigSub: 'Create a new ACL configuration',
+            withKeywords: true,
+            onAddConfig: () => setAddConfigOpen(true),
+            onDeleteConfig: () => handleOpenDeleteConfig(),
+            onSwitchConfig: (name) => handleTabSelect(name),
+        }));
         if (enabledCounterNames.size > 0) {
             list.push({
                 id: '__pause_resume',

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -16,6 +16,7 @@ import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeade
 import { useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers, computeRowStatuses } from '../../../components/draft';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
+import { buildConfigCommands } from '../../../components/command-palette';
 import '../../../styles/chrome.scss';
 import './decap.scss';
 
@@ -151,36 +152,16 @@ const DecapPage: React.FC = () => {
                 onSelect: () => handlers.handleDiscard(),
             });
         }
-        list.push({
-            id: '__add_config',
-            icon: '▤',
-            label: 'Add config',
-            sub: 'Create a new decap configuration',
-            keywords: 'add config create new',
-            onSelect: () => setAddConfigOpen(true),
-        });
-        if (currentConfig) {
-            list.push({
-                id: '__delete_config',
-                icon: '✕',
-                label: 'Delete config',
-                sub: `Delete "${currentConfig}"`,
-                keywords: 'delete remove config',
-                onSelect: () => setDeleteConfigOpen(true),
-            });
-        }
-        for (const cfg of draftConfigs) {
-            if (cfg === currentConfig) continue;
-            const name = cfg;
-            list.push({
-                id: `__config_${name}`,
-                icon: '⇥',
-                label: `Switch to config ${name}`,
-                sub: dirtySet.has(name) ? 'unsaved changes' : undefined,
-                keywords: `switch config tab ${name}`,
-                onSelect: () => setActiveConfig(name),
-            });
-        }
+        list.push(...buildConfigCommands({
+            currentConfig,
+            draftConfigs,
+            dirtySet,
+            addConfigSub: 'Create a new decap configuration',
+            withKeywords: true,
+            onAddConfig: () => setAddConfigOpen(true),
+            onDeleteConfig: () => setDeleteConfigOpen(true),
+            onSwitchConfig: (name) => setActiveConfig(name),
+        }));
         list.push({
             id: '__clear_search',
             icon: '✕',

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -22,6 +22,7 @@ import { useForwardRuleCounters } from './useForwardRuleCounters';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { DRAWER_TRANSITION_MS } from '../../../components/draft';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
+import { buildConfigCommands } from '../../../components/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/chrome.scss';
 import './forward.scss';
@@ -262,36 +263,16 @@ const ForwardPage: React.FC = () => {
                 onSelect: () => handleDiscard(),
             });
         }
-        list.push({
-            id: '__add_config',
-            icon: '▤',
-            label: 'Add config',
-            sub: 'Create a new forward configuration',
-            keywords: 'add config create new',
-            onSelect: () => setAddConfigOpen(true),
-        });
-        if (currentConfig) {
-            list.push({
-                id: '__delete_config',
-                icon: '✕',
-                label: 'Delete config',
-                sub: `Delete "${currentConfig}"`,
-                keywords: 'delete remove config',
-                onSelect: () => setDeleteConfigOpen(true),
-            });
-        }
-        for (const cfg of draftConfigs) {
-            if (cfg === currentConfig) continue;
-            const name = cfg;
-            list.push({
-                id: `__config_${name}`,
-                icon: '⇥',
-                label: `Switch to config ${name}`,
-                sub: dirtySet.has(name) ? 'unsaved changes' : undefined,
-                keywords: `switch config tab ${name}`,
-                onSelect: () => handleTabSelect(name),
-            });
-        }
+        list.push(...buildConfigCommands({
+            currentConfig,
+            draftConfigs,
+            dirtySet,
+            addConfigSub: 'Create a new forward configuration',
+            withKeywords: true,
+            onAddConfig: () => setAddConfigOpen(true),
+            onDeleteConfig: () => setDeleteConfigOpen(true),
+            onSwitchConfig: (name) => handleTabSelect(name),
+        }));
         list.push({
             id: '__filter_in',
             icon: '→',

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -16,6 +16,7 @@ import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeade
 import { useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers, computeRowStatuses } from '../../../components/draft';
 import { isValidCidr as isValidCIDR } from '../../../utils';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
+import { buildConfigCommands } from '../../../components/command-palette';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import '../../../styles/chrome.scss';
 import './route.scss';
@@ -164,33 +165,14 @@ const RoutePage: React.FC = () => {
                 onSelect: () => handlers.handleDiscard(),
             });
         }
-        list.push({
-            id: '__add_config',
-            icon: '▤',
-            label: 'Add config',
-            onSelect: () => setAddConfigOpen(true),
-        });
-        if (currentConfig) {
-            list.push({
-                id: '__delete_config',
-                icon: '✕',
-                label: 'Delete config',
-                sub: `Delete "${currentConfig}"`,
-                onSelect: () => setDeleteConfigOpen(true),
-            });
-        }
-        for (const cfg of draftConfigs) {
-            if (cfg === currentConfig) continue;
-            const name = cfg;
-            list.push({
-                id: `__config_${name}`,
-                icon: '⇥',
-                label: `Switch to config ${name}`,
-                sub: dirtySet.has(name) ? 'unsaved changes' : undefined,
-                keywords: `switch config tab ${name}`,
-                onSelect: () => handleConfigSelect(name),
-            });
-        }
+        list.push(...buildConfigCommands({
+            currentConfig,
+            draftConfigs,
+            dirtySet,
+            onAddConfig: () => setAddConfigOpen(true),
+            onDeleteConfig: () => setDeleteConfigOpen(true),
+            onSwitchConfig: (name) => handleConfigSelect(name),
+        }));
         if (search) {
             list.push({
                 id: '__clear',


### PR DESCRIPTION
- Extracts the duplicated Add config / Delete config / Switch to config command-palette trio from the acl, forward, decap and route module pages into a shared builder in the command-palette component module.
- Preserves each page's exact command output, including the route page's intentionally absent search keywords and add-config subtitle.
- Adds unit tests asserting the builder reproduces every page's original command list and callback wiring.