### PR TITLE
fix(pdump): write exactly the requested number of packets

### DIFF
--- a/modules/pdump/cli/src/writer.rs
+++ b/modules/pdump/cli/src/writer.rs
@@ -206,11 +206,7 @@ pub fn pdump_write(
         }
     };
     let mut count = 0;
-    while let Some(rec) = rx.blocking_recv() {
-        if let Err(e) = writer.write(rec) {
-            log::error!("failed to write record: {e}");
-            break;
-        };
+    loop {
         if let Some(limit) = packet_limit
             && count >= limit
         {
@@ -218,6 +214,16 @@ pub fn pdump_write(
 
             break;
         }
+
+        let Some(rec) = rx.blocking_recv() else {
+            break;
+        };
+
+        if let Err(e) = writer.write(rec) {
+            log::error!("failed to write record: {e}");
+            break;
+        };
+
         count += 1;
     }
     _ = writer.flush().map_err(|e| {


### PR DESCRIPTION
The packet-capture limit was checked before the write counter was incremented, so a capture started with a limit of N wrote N+1 packets. Count each written packet before the limit check so the boundary is exact.

Closes #572.