### PR TITLE
refactor(web): extract shared draft page state and derived-data hooks

### DIFF
--- a/web/src/components/draft/index.ts
+++ b/web/src/components/draft/index.ts
@@ -12,3 +12,7 @@ export type { UseDraftPageHandlersResult } from './useDraftPageHandlers';
 export { DRAWER_TRANSITION_MS } from './constants';
 export { computeRowStatuses } from './rowStatus';
 export type { RowStatusResult } from './rowStatus';
+export { useDraftPageState } from './useDraftPageState';
+export type { UseDraftPageStateOptions, UseDraftPageStateResult } from './useDraftPageState';
+export { useDraftPageDerived } from './useDraftPageDerived';
+export type { UseDraftPageDerivedOptions, UseDraftPageDerivedResult } from './useDraftPageDerived';

--- a/web/src/components/draft/useDraftPageDerived.ts
+++ b/web/src/components/draft/useDraftPageDerived.ts
@@ -1,0 +1,105 @@
+import { useEffect, useMemo } from 'react';
+import { useConfigQuerySync, useDirtyConfigSet } from '../../hooks';
+import { computeRowStatuses } from './rowStatus';
+import type { RowStatusResult } from './rowStatus';
+import type { UseDraftPageStateResult } from './useDraftPageState';
+import type { RowStatus } from '../VirtualTable';
+
+/** Options for the useDraftPageDerived hook. */
+export interface UseDraftPageDerivedOptions<T extends { id: string }> {
+    pageState: UseDraftPageStateResult;
+    draftRows: (config: string) => T[];
+    serverRows: (config: string) => T[];
+    isDirty: (config: string) => boolean;
+    draftConfigs: string[];
+    loading: boolean;
+    configParamKey: string;
+    matchesSearch: (row: T, query: string) => boolean;
+    rowsEqual: (server: T, local: T) => boolean;
+}
+
+/** Result returned by useDraftPageDerived. */
+export interface UseDraftPageDerivedResult<T extends { id: string }> {
+    rawRows: T[];
+    rawServerRows: T[];
+    currentIsDirty: boolean;
+    rowCounts: Map<string, number>;
+    dirtySet: Set<string>;
+    visibleRows: T[];
+    statusById: Map<string, RowStatus>;
+    removedRows: T[];
+}
+
+/**
+ * Derives row collections, row counts, dirty sets, and row statuses for a
+ * draft-based config page from the active config state.
+ */
+export const useDraftPageDerived = <T extends { id: string }>({
+    pageState,
+    draftRows,
+    serverRows,
+    isDirty,
+    draftConfigs,
+    loading,
+    configParamKey,
+    matchesSearch,
+    rowsEqual,
+}: UseDraftPageDerivedOptions<T>): UseDraftPageDerivedResult<T> => {
+    const { currentConfig, queryConfig, search, searchParams, updateParams, dragDrop } = pageState;
+    const { handleDragLeave } = dragDrop;
+    const {
+        setActiveRowId,
+        setEditingRowId,
+        setSelectedIds,
+        setDeleteConfirmOpen,
+        setDeleteConfigOpen,
+        setDiffModalOpen,
+    } = pageState;
+
+    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: configParamKey, searchParams, updateParams });
+
+    useEffect(() => {
+        setActiveRowId(null);
+        setEditingRowId(null);
+        setSelectedIds(new Set());
+        setDeleteConfirmOpen(false);
+        setDeleteConfigOpen(false);
+        setDiffModalOpen(false);
+        handleDragLeave();
+    }, [currentConfig, handleDragLeave, setActiveRowId, setEditingRowId, setSelectedIds, setDeleteConfirmOpen, setDeleteConfigOpen, setDiffModalOpen]);
+
+    const rawRows: T[] = draftRows(currentConfig);
+    const rawServerRows: T[] = serverRows(currentConfig);
+    const currentIsDirty = isDirty(currentConfig);
+
+    const rowCounts = useMemo((): Map<string, number> => {
+        const m = new Map<string, number>();
+        draftConfigs.forEach((c) => m.set(c, draftRows(c).length));
+        return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [draftConfigs, draftRows]);
+
+    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
+
+    const visibleRows = useMemo((): T[] => {
+        const q = search.trim().toLowerCase();
+        if (!q) return rawRows;
+        return rawRows.filter((r) => matchesSearch(r, q));
+    }, [rawRows, search, matchesSearch]);
+
+    const { statusById, removedRows }: RowStatusResult<T> = useMemo(
+        () => computeRowStatuses(rawRows, rawServerRows, rowsEqual),
+        [rawRows, rawServerRows, rowsEqual],
+    );
+
+    return {
+        rawRows,
+        rawServerRows,
+        currentIsDirty,
+        rowCounts,
+        dirtySet,
+        visibleRows,
+        statusById,
+        removedRows,
+    };
+};

--- a/web/src/components/draft/useDraftPageState.ts
+++ b/web/src/components/draft/useDraftPageState.ts
@@ -1,0 +1,101 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useSearchParamHelpers } from '../../hooks';
+import { useUnsavedChangesBlocker } from '../../pages/builtin/_shared/lane-editor';
+import { useDraftDragDrop } from './useDraftDragDrop';
+import type { UseDraftDragDropResult } from './useDraftDragDrop';
+
+/** Options for the useDraftPageState hook. */
+export interface UseDraftPageStateOptions {
+    loading: boolean;
+    draftConfigs: string[];
+    anyDirty: boolean;
+    configParamKey: string;
+    searchParamKey: string;
+}
+
+/** Result returned by useDraftPageState. */
+export interface UseDraftPageStateResult {
+    searchParams: URLSearchParams;
+    queryConfig: string | null;
+    search: string;
+    activeRowId: string | null;
+    setActiveRowId: React.Dispatch<React.SetStateAction<string | null>>;
+    editingRowId: string | null;
+    setEditingRowId: React.Dispatch<React.SetStateAction<string | null>>;
+    selectedIds: Set<string>;
+    setSelectedIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+    deleteConfirmOpen: boolean;
+    setDeleteConfirmOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    diffModalOpen: boolean;
+    setDiffModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    addConfigOpen: boolean;
+    setAddConfigOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    deleteConfigOpen: boolean;
+    setDeleteConfigOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    dragDrop: UseDraftDragDropResult;
+    updateParams: (updates: Record<string, string | null>) => void;
+    setActiveConfig: (configName: string) => void;
+    currentConfig: string;
+}
+
+/**
+ * Manages URL search-param state, modal toggles, drag-drop, and the active-config
+ * derivation common to draft-based config pages.
+ */
+export const useDraftPageState = ({
+    loading,
+    draftConfigs,
+    anyDirty,
+    configParamKey,
+    searchParamKey,
+}: UseDraftPageStateOptions): UseDraftPageStateResult => {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const queryConfig = useMemo(() => searchParams.get(configParamKey), [searchParams, configParamKey]);
+    const search = useMemo(() => searchParams.get(searchParamKey) || '', [searchParams, searchParamKey]);
+
+    const [activeRowId, setActiveRowId] = useState<string | null>(null);
+    const [editingRowId, setEditingRowId] = useState<string | null>(null);
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+    const [diffModalOpen, setDiffModalOpen] = useState(false);
+    const [addConfigOpen, setAddConfigOpen] = useState(false);
+    const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
+
+    const dragDrop = useDraftDragDrop();
+
+    useUnsavedChangesBlocker(anyDirty);
+
+    const { updateParams } = useSearchParamHelpers(setSearchParams);
+
+    const setActiveConfig = useCallback((configName: string): void => {
+        updateParams({ [configParamKey]: configName || null });
+    }, [updateParams, configParamKey]);
+
+    const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig))) ? queryConfig : (draftConfigs[0] || '');
+
+    return {
+        searchParams,
+        queryConfig,
+        search,
+        activeRowId,
+        setActiveRowId,
+        editingRowId,
+        setEditingRowId,
+        selectedIds,
+        setSelectedIds,
+        deleteConfirmOpen,
+        setDeleteConfirmOpen,
+        diffModalOpen,
+        setDiffModalOpen,
+        addConfigOpen,
+        setAddConfigOpen,
+        deleteConfigOpen,
+        setDeleteConfigOpen,
+        dragDrop,
+        updateParams,
+        setActiveConfig,
+        currentConfig,
+    };
+};

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -1,11 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Funnel, Plus } from '@gravity-ui/icons';
-import { useSearchParamHelpers, useDirtyConfigSet, useConfigQuerySync, usePageContribution } from '../../../hooks';
+import { usePageContribution } from '../../../hooks';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder, SearchInput, RowCountDisplay } from '../../../components';
 import { usePrefixDraft } from './usePrefixDraft';
-import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { PrefixRowItem } from './types';
 import { PrefixTable } from './PrefixTable';
 import PrefixDrawer from './PrefixDrawer';
@@ -13,7 +11,7 @@ import type { PrefixDrawerHandle } from './PrefixDrawer';
 import PrefixYamlIO from './PrefixYamlIO';
 import { PrefixSaveDiffModal } from './PrefixSaveDiffModal';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
-import { useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers, computeRowStatuses } from '../../../components/draft';
+import { useDraftShortcuts, useDraftPageHandlers, useDraftPageState, useDraftPageDerived } from '../../../components/draft';
 import { useTabCycle } from '../../_shared/useTabCycle';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
 import { buildConfigCommands } from '../../../components/command-palette';
@@ -25,36 +23,34 @@ const makeRowId = (): string => `new-${++idCounter}-${Date.now()}`;
 const QP_CONFIG = 'config';
 const QP_SEARCH = 'search';
 
+const matchesPrefixSearch = (r: PrefixRowItem, q: string): boolean =>
+    r.prefix.toLowerCase().includes(q);
+
+const prefixRowsEqual = (s: PrefixRowItem, r: PrefixRowItem): boolean =>
+    s.prefix === r.prefix;
+
 const DecapPage: React.FC = () => {
     const {
         draftConfigs, loading, draftRows, serverRows, isDirty, anyDirty,
         dispatchDraft, commitConfig, discardConfig,
     } = usePrefixDraft();
-    const [searchParams, setSearchParams] = useSearchParams();
 
-    const queryConfig = useMemo(() => searchParams.get(QP_CONFIG), [searchParams]);
-    const search = useMemo(() => searchParams.get(QP_SEARCH) || '', [searchParams]);
-    const [activeRowId, setActiveRowId] = useState<string | null>(null);
-    const [editingRowId, setEditingRowId] = useState<string | null>(null);
-    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-    const [diffModalOpen, setDiffModalOpen] = useState(false);
-    const [addConfigOpen, setAddConfigOpen] = useState(false);
-    const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
+    const pageState = useDraftPageState({
+        loading,
+        draftConfigs,
+        anyDirty,
+        configParamKey: QP_CONFIG,
+        searchParamKey: QP_SEARCH,
+    });
+    const {
+        search, activeRowId, setActiveRowId, editingRowId, setEditingRowId,
+        selectedIds, setSelectedIds, deleteConfirmOpen, setDeleteConfirmOpen,
+        diffModalOpen, setDiffModalOpen, addConfigOpen, setAddConfigOpen,
+        deleteConfigOpen, setDeleteConfigOpen, dragDrop, updateParams,
+        setActiveConfig, currentConfig,
+    } = pageState;
 
     const drawerRef = useRef<PrefixDrawerHandle>(null);
-    const dragDrop = useDraftDragDrop();
-    const { handleDragLeave } = dragDrop;
-
-    useUnsavedChangesBlocker(anyDirty);
-
-    const { updateParams } = useSearchParamHelpers(setSearchParams);
-
-    const setActiveConfig = useCallback((configName: string): void => {
-        updateParams({ [QP_CONFIG]: configName || null });
-    }, [updateParams]);
-
-    const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig))) ? queryConfig : (draftConfigs[0] || '');
 
     useTabCycle({
         tabs: draftConfigs,
@@ -63,41 +59,21 @@ const DecapPage: React.FC = () => {
         enabled: !loading,
     });
 
-    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: QP_CONFIG, searchParams, updateParams });
-
-    useEffect(() => {
-        setActiveRowId(null);
-        setEditingRowId(null);
-        setSelectedIds(new Set());
-        setDeleteConfirmOpen(false);
-        setDeleteConfigOpen(false);
-        setDiffModalOpen(false);
-        handleDragLeave();
-    }, [currentConfig, handleDragLeave]);
-
-    const rawRows: PrefixRowItem[] = draftRows(currentConfig);
-    const rawServerRows: PrefixRowItem[] = serverRows(currentConfig);
-    const currentIsDirty = isDirty(currentConfig);
-
-    const prefixCounts = useMemo((): Map<string, number> => {
-        const m = new Map<string, number>();
-        draftConfigs.forEach((c) => m.set(c, draftRows(c).length));
-        return m;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [draftConfigs, draftRows]);
-
-    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
-
-    const visibleRows = useMemo((): PrefixRowItem[] => {
-        const q = search.trim().toLowerCase();
-        if (!q) return rawRows;
-        return rawRows.filter((r) => r.prefix.toLowerCase().includes(q));
-    }, [rawRows, search]);
-
-    const { statusById, removedRows } = useMemo(
-        () => computeRowStatuses(rawRows, rawServerRows, (s, r) => s.prefix === r.prefix),
-        [rawRows, rawServerRows],
-    );
+    const derived = useDraftPageDerived<PrefixRowItem>({
+        pageState,
+        draftRows,
+        serverRows,
+        isDirty,
+        draftConfigs,
+        loading,
+        configParamKey: QP_CONFIG,
+        matchesSearch: matchesPrefixSearch,
+        rowsEqual: prefixRowsEqual,
+    });
+    const {
+        rawRows, rawServerRows, currentIsDirty, rowCounts: prefixCounts,
+        dirtySet, visibleRows, statusById, removedRows,
+    } = derived;
 
     const editingIndex = editingRowId ? rawRows.findIndex((r) => r.id === editingRowId) : -1;
     const editingRow = editingIndex >= 0 ? rawRows[editingIndex] : null;

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -1,11 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
-import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, useDirtyConfigSet, useConfigQuerySync, usePageContribution } from '../../../hooks';
+import { usePageContribution } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useFIBDraft } from './useFIBDraft';
-import { useUnsavedChangesBlocker } from '../../builtin/_shared/lane-editor';
 import type { FIBRowItem } from './types';
 import { FIBTable } from './FIBTable';
 import FIBDrawer from './FIBDrawer';
@@ -13,7 +11,7 @@ import type { FIBDrawerHandle } from './FIBDrawer';
 import FIBYamlIO from './FIBYamlIO';
 import { FIBSaveDiffModal } from './FIBSaveDiffModal';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
-import { useDraftShortcuts, useDraftDragDrop, useDraftPageHandlers, computeRowStatuses } from '../../../components/draft';
+import { useDraftShortcuts, useDraftPageHandlers, useDraftPageState, useDraftPageDerived } from '../../../components/draft';
 import { isValidCidr as isValidCIDR } from '../../../utils';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
 import { buildConfigCommands } from '../../../components/command-palette';
@@ -27,80 +25,56 @@ const QP_SEARCH = 'search';
 let idCounter = 0;
 const makeRowId = (): string => `new-${++idCounter}-${Date.now()}`;
 
+const matchesFIBSearch = (r: FIBRowItem, q: string): boolean =>
+    r.prefix.toLowerCase().includes(q) ||
+    r.dst_mac.toLowerCase().includes(q) ||
+    r.src_mac.toLowerCase().includes(q) ||
+    r.device.toLowerCase().includes(q);
+
+const fibRowsEqual = (s: FIBRowItem, r: FIBRowItem): boolean =>
+    s.prefix === r.prefix &&
+    s.dst_mac === r.dst_mac &&
+    s.src_mac === r.src_mac &&
+    s.device === r.device;
+
 const RoutePage: React.FC = () => {
     const {
         draftConfigs, loading, draftRows, serverRows, isDirty, anyDirty,
         dispatchDraft, commitConfig, discardConfig,
     } = useFIBDraft();
-    const [searchParams, setSearchParams] = useSearchParams();
 
-    const queryConfig = useMemo(() => searchParams.get(QP_CONFIG), [searchParams]);
-    const search = useMemo(() => searchParams.get(QP_SEARCH) || '', [searchParams]);
+    const pageState = useDraftPageState({
+        loading,
+        draftConfigs,
+        anyDirty,
+        configParamKey: QP_CONFIG,
+        searchParamKey: QP_SEARCH,
+    });
+    const {
+        search, activeRowId, setActiveRowId, editingRowId, setEditingRowId,
+        selectedIds, setSelectedIds, deleteConfirmOpen, setDeleteConfirmOpen,
+        diffModalOpen, setDiffModalOpen, addConfigOpen, setAddConfigOpen,
+        deleteConfigOpen, setDeleteConfigOpen, dragDrop, updateParams,
+        setActiveConfig, currentConfig,
+    } = pageState;
 
-    const [activeRowId, setActiveRowId] = useState<string | null>(null);
-    const [editingRowId, setEditingRowId] = useState<string | null>(null);
-    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-    const [diffModalOpen, setDiffModalOpen] = useState(false);
-    const [addConfigOpen, setAddConfigOpen] = useState(false);
-    const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
     const drawerRef = useRef<FIBDrawerHandle>(null);
-    const dragDrop = useDraftDragDrop();
-    const { handleDragLeave } = dragDrop;
 
-    useUnsavedChangesBlocker(anyDirty);
-
-    const { updateParams } = useSearchParamHelpers(setSearchParams);
-
-    const setActiveConfig = useCallback((configName: string): void => {
-        updateParams({ [QP_CONFIG]: configName || null });
-    }, [updateParams]);
-
-    const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig))) ? queryConfig : (draftConfigs[0] || '');
-
-    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: QP_CONFIG, searchParams, updateParams });
-
-    useEffect(() => {
-        setActiveRowId(null);
-        setEditingRowId(null);
-        setSelectedIds(new Set());
-        setDeleteConfirmOpen(false);
-        setDeleteConfigOpen(false);
-        setDiffModalOpen(false);
-        handleDragLeave();
-    }, [currentConfig, handleDragLeave]);
-
-    const rawRows: FIBRowItem[] = draftRows(currentConfig);
-    const rawServerRows: FIBRowItem[] = serverRows(currentConfig);
-    const currentIsDirty = isDirty(currentConfig);
-
-    const routeCounts = useMemo((): Map<string, number> => {
-        const m = new Map<string, number>();
-        draftConfigs.forEach((c) => m.set(c, draftRows(c).length));
-        return m;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [draftConfigs, draftRows]);
-
-    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
-
-    const visibleRows = useMemo((): FIBRowItem[] => {
-        const q = search.trim().toLowerCase();
-        if (!q) return rawRows;
-        return rawRows.filter((r) =>
-            r.prefix.toLowerCase().includes(q) ||
-            r.dst_mac.toLowerCase().includes(q) ||
-            r.src_mac.toLowerCase().includes(q) ||
-            r.device.toLowerCase().includes(q),
-        );
-    }, [rawRows, search]);
-
-    const { statusById, removedRows } = useMemo(
-        () => computeRowStatuses(
-            rawRows, rawServerRows,
-            (s, r) => s.prefix === r.prefix && s.dst_mac === r.dst_mac && s.src_mac === r.src_mac && s.device === r.device,
-        ),
-        [rawRows, rawServerRows],
-    );
+    const derived = useDraftPageDerived<FIBRowItem>({
+        pageState,
+        draftRows,
+        serverRows,
+        isDirty,
+        draftConfigs,
+        loading,
+        configParamKey: QP_CONFIG,
+        matchesSearch: matchesFIBSearch,
+        rowsEqual: fibRowsEqual,
+    });
+    const {
+        rawRows, rawServerRows, currentIsDirty, rowCounts: routeCounts,
+        dirtySet, visibleRows, statusById, removedRows,
+    } = derived;
 
     const editingIndex = editingRowId ? rawRows.findIndex((r) => r.id === editingRowId) : -1;
     const editingRow = editingIndex >= 0 ? rawRows[editingIndex] : null;


### PR DESCRIPTION
- Extracts the near-identical page-level plumbing of the decap and route module pages into two shared hooks in the draft toolkit: one owning search-param state, modal toggles, drag-drop and active-config resolution, the other owning query sync, the reset-on-config-switch effect and derived row collections.
- Splits the extraction into two hooks so each page keeps its original React hook ordering, including the differing tab-cycle positions.
- Parameterizes the per-page search and row-equality predicates as module-level functions, preserving memoization behavior exactly.