### PR TITLE
feat(decap): make prefix configuration declarative

### DIFF
--- a/docs/virtual-run.org
+++ b/docs/virtual-run.org
@@ -132,7 +132,7 @@ yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 0 --dst 1 --net ff02:
 yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 1 --dst 0 --net 0.0.0.0/0
 yanet-cli forward l3-add --cfg=forward0 --instance 0 --src 1 --dst 0 --net ::/0
 
-yanet-cli decap prefix-add --cfg decap0 --instance 0 -p $DECAP_PREFIX
+yanet-cli-decap update --name decap0 -p $DECAP_PREFIX
 
 yanet-cli route insert --cfg route0 --instance 0 --via $DEFGW6 ::/0
 

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -57,9 +57,9 @@ pub struct UpdateConfigCmd {
     /// Decap module name to operate on.
     #[arg(long = "name", short = 'n')]
     pub config_name: String,
-    /// Prefix in the full desired set, replacing the current one entirely.
+    /// Prefixes in the full desired set, replacing the current one entirely.
     #[arg(long, short)]
-    pub prefix: Vec<Contiguous<IpNetwork>>,
+    pub prefixes: Vec<Contiguous<IpNetwork>>,
 }
 
 /// Output format options.
@@ -138,7 +138,7 @@ impl DecapService {
     pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Box<dyn Error>> {
         let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),
-            prefixes: cmd.prefix.iter().map(|p| p.to_string()).collect(),
+            prefixes: cmd.prefixes.iter().map(|p| p.to_string()).collect(),
         };
         log::trace!("update config request: {request:?}");
         let response = self.client.update_config(request).await?.into_inner();

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -3,7 +3,7 @@ use core::error::Error;
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::CompleteEnv;
 use decappb::{
-    AddPrefixesRequest, ListConfigsRequest, RemovePrefixesRequest, ShowConfigRequest, ShowConfigResponse,
+    ListConfigsRequest, ShowConfigRequest, ShowConfigResponse, UpdateConfigRequest,
     decap_service_client::DecapServiceClient,
 };
 use netip::{Contiguous, IpNetwork};
@@ -39,8 +39,7 @@ pub struct Cmd {
 pub enum ModeCmd {
     List,
     Show(ShowConfigCmd),
-    PrefixAdd(AddPrefixesCmd),
-    PrefixRemove(RemovePrefixesCmd),
+    Update(UpdateConfigCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -54,21 +53,11 @@ pub struct ShowConfigCmd {
 }
 
 #[derive(Debug, Clone, Parser)]
-pub struct AddPrefixesCmd {
+pub struct UpdateConfigCmd {
     /// Decap module name to operate on.
     #[arg(long = "name", short = 'n')]
     pub config_name: String,
-    /// Prefix to be added to the input filter of the decapsulation module.
-    #[arg(long, short)]
-    pub prefix: Vec<Contiguous<IpNetwork>>,
-}
-
-#[derive(Debug, Clone, Parser)]
-pub struct RemovePrefixesCmd {
-    /// Decap module name to operate on.
-    #[arg(long = "name", short = 'n')]
-    pub config_name: String,
-    /// Prefix to be removed from the input filter of the decapsulation module.
+    /// Prefix in the full desired set, replacing the current one entirely.
     #[arg(long, short)]
     pub prefix: Vec<Contiguous<IpNetwork>>,
 }
@@ -100,8 +89,7 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
     match cmd.mode {
         ModeCmd::List => service.list_configs().await,
         ModeCmd::Show(cmd) => service.show_config(cmd).await,
-        ModeCmd::PrefixAdd(cmd) => service.add_prefixes(cmd).await,
-        ModeCmd::PrefixRemove(cmd) => service.remove_prefixes(cmd).await,
+        ModeCmd::Update(cmd) => service.update_config(cmd).await,
     }
 }
 
@@ -147,25 +135,14 @@ impl DecapService {
         Ok(())
     }
 
-    pub async fn add_prefixes(&mut self, cmd: AddPrefixesCmd) -> Result<(), Box<dyn Error>> {
-        let request = AddPrefixesRequest {
+    pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Box<dyn Error>> {
+        let request = UpdateConfigRequest {
             name: cmd.config_name.clone(),
             prefixes: cmd.prefix.iter().map(|p| p.to_string()).collect(),
         };
-        log::trace!("AddPrefixesRequest: {request:?}");
-        let response = self.client.add_prefixes(request).await?.into_inner();
-        log::debug!("AddPrefixesResponse: {response:?}");
-        Ok(())
-    }
-
-    pub async fn remove_prefixes(&mut self, cmd: RemovePrefixesCmd) -> Result<(), Box<dyn Error>> {
-        let request = RemovePrefixesRequest {
-            name: cmd.config_name.clone(),
-            prefixes: cmd.prefix.iter().map(|p| p.to_string()).collect(),
-        };
-        log::trace!("RemovePrefixesRequest: {request:?}");
-        let response = self.client.remove_prefixes(request).await?.into_inner();
-        log::debug!("RemovePrefixesResponse: {response:?}");
+        log::trace!("update config request: {request:?}");
+        let response = self.client.update_config(request).await?.into_inner();
+        log::debug!("update config response: {response:?}");
         Ok(())
     }
 }

--- a/modules/decap/controlplane/decappb/v1/decap.proto
+++ b/modules/decap/controlplane/decappb/v1/decap.proto
@@ -13,10 +13,8 @@ service DecapService {
   // ShowConfig returns the current configuration for the decap module.
   rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse) {}
 
-  // AddPrefixes adds prefixes to the decap module configuration.
-  rpc AddPrefixes(AddPrefixesRequest) returns (AddPrefixesResponse) {}
-  // RemovePrefixes removes prefixes from the decap module configuration.
-  rpc RemovePrefixes(RemovePrefixesRequest) returns (RemovePrefixesResponse) {}
+  // UpdateConfig atomically replaces the whole prefix set of the named config.
+  rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse) {}
 }
 
 message ListConfigsRequest {}
@@ -24,23 +22,17 @@ message ListConfigsRequest {}
 // ListConfigsResponse contains existing configurations.
 message ListConfigsResponse { repeated string configs = 1; }
 
-// ShowConfigResponse retrieves the runtime configuration for the decap module.
+// ShowConfigRequest retrieves the runtime configuration for the decap module.
 message ShowConfigRequest { string name = 1; }
 
 // ShowConfigResponse contains the configuration details of the decap module.
 message ShowConfigResponse { repeated string prefixes = 1; }
 
-// AddPrefixesRequest adds prefixes to the input filter of the decap module.
-message AddPrefixesRequest {
+// UpdateConfigRequest carries the full desired prefix set for the named config.
+message UpdateConfigRequest {
   string name = 1;
   repeated string prefixes = 2;
 }
-message AddPrefixesResponse {}
 
-// RemovePrefixesRequest removes prefixes from the input filter of the decap
-// module.
-message RemovePrefixesRequest {
-  string name = 1;
-  repeated string prefixes = 2;
-}
-message RemovePrefixesResponse {}
+// UpdateConfigResponse is the response to an UpdateConfig call.
+message UpdateConfigResponse {}

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -35,21 +35,16 @@ type config struct {
 	Module   ModuleHandle
 }
 
-func (m *config) Clone() *config {
-	return &config{
-		Prefixes: slices.Clone(m.Prefixes),
-		Module:   m.Module,
-	}
-}
-
+// DecapService implements the DecapService gRPC server.
 type DecapService struct {
 	decappb.UnimplementedDecapServiceServer
 
-	mu      sync.RWMutex
+	mu      sync.Mutex
 	backend Backend
 	configs map[string]*config
 }
 
+// NewDecapService constructs a DecapService backed by the given Backend.
 func NewDecapService(backend Backend) *DecapService {
 	return &DecapService{
 		backend: backend,
@@ -57,63 +52,60 @@ func NewDecapService(backend Backend) *DecapService {
 	}
 }
 
+// ListConfigs returns all known config names across all dataplane instances.
 func (m *DecapService) ListConfigs(
 	ctx context.Context,
-	request *decappb.ListConfigsRequest,
+	req *decappb.ListConfigsRequest,
 ) (*decappb.ListConfigsResponse, error) {
-	response := &decappb.ListConfigsResponse{
-		Configs: make([]string, 0),
-	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
+	names := make([]string, 0, len(m.configs))
 	for name := range m.configs {
-		response.Configs = append(response.Configs, name)
+		names = append(names, name)
 	}
 
-	return response, nil
+	return &decappb.ListConfigsResponse{Configs: names}, nil
 }
 
+// ShowConfig returns the current prefix set for the named config.
 func (m *DecapService) ShowConfig(
 	ctx context.Context,
-	request *decappb.ShowConfigRequest,
+	req *decappb.ShowConfigRequest,
 ) (*decappb.ShowConfigResponse, error) {
-	name := request.GetName()
+	name := req.GetName()
 	if name == "" {
 		return nil, errConfigNameRequired
 	}
 
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	entry, ok := m.configs[name]
 	if !ok {
 		return nil, status.Error(codes.NotFound, "no config found")
 	}
 
-	response := &decappb.ShowConfigResponse{
-		Prefixes: make([]string, 0, len(entry.Prefixes)),
-	}
-
+	prefixes := make([]string, 0, len(entry.Prefixes))
 	for _, p := range entry.Prefixes {
-		response.Prefixes = append(response.Prefixes, p.String())
+		prefixes = append(prefixes, p.String())
 	}
 
-	return response, nil
+	return &decappb.ShowConfigResponse{Prefixes: prefixes}, nil
 }
 
-func (m *DecapService) AddPrefixes(
+// UpdateConfig atomically replaces the whole prefix set of the named config.
+func (m *DecapService) UpdateConfig(
 	ctx context.Context,
-	request *decappb.AddPrefixesRequest,
-) (*decappb.AddPrefixesResponse, error) {
-	name := request.GetName()
+	req *decappb.UpdateConfigRequest,
+) (*decappb.UpdateConfigResponse, error) {
+	name := req.GetName()
 	if name == "" {
 		return nil, errConfigNameRequired
 	}
 
-	toAdd := make([]netip.Prefix, 0, len(request.GetPrefixes()))
-	for _, p := range request.GetPrefixes() {
+	prefixes := make([]netip.Prefix, 0, len(req.GetPrefixes()))
+	for _, p := range req.GetPrefixes() {
 		prefix, err := netip.ParsePrefix(p)
 		if err != nil {
 			return nil, status.Errorf(
@@ -121,74 +113,20 @@ func (m *DecapService) AddPrefixes(
 				"failed to parse prefix %q: %v", p, err,
 			)
 		}
-
-		toAdd = append(toAdd, prefix.Masked())
+		prefixes = append(prefixes, prefix.Masked())
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Create a new config to-be-updated either from scratch or from the
-	// current config.
-	cfg := &config{}
-	if currConfig, ok := m.configs[name]; ok {
-		cfg = currConfig.Clone()
-	}
-
-	cfg.Prefixes = slices.Compact(
+	prefixes = slices.Compact(
 		slices.SortedFunc(
-			slices.Values(slices.Concat(cfg.Prefixes, toAdd)),
+			slices.Values(prefixes),
 			xnetip.PrefixCompare,
 		),
 	)
 
-	if err := m.updateConfig(name, cfg); err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"failed to update module config %q: %v", name, err,
-		)
-	}
-
-	return &decappb.AddPrefixesResponse{}, nil
-}
-
-func (m *DecapService) RemovePrefixes(
-	ctx context.Context,
-	request *decappb.RemovePrefixesRequest,
-) (*decappb.RemovePrefixesResponse, error) {
-	name := request.GetName()
-	if name == "" {
-		return nil, errConfigNameRequired
-	}
-
-	toRemove := make([]netip.Prefix, 0, len(request.GetPrefixes()))
-	for _, p := range request.GetPrefixes() {
-		prefix, err := netip.ParsePrefix(p)
-		if err != nil {
-			return nil, err
-		}
-		toRemove = append(toRemove, prefix.Masked())
-	}
-
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Create a new config to-be-updated either from scratch or from the
-	// current config.
-	cfg := &config{}
-	if currConfig, ok := m.configs[name]; ok {
-		cfg = currConfig.Clone()
-	}
-
-	cfg.Prefixes = slices.DeleteFunc(
-		cfg.Prefixes,
-		func(prefix netip.Prefix) bool {
-			return slices.Contains(toRemove, prefix)
-		},
-	)
-
-	// Note that we don't remove the FFI config in case of empty prefixes left.
-
+	cfg := &config{Prefixes: prefixes}
 	if err := m.updateConfig(name, cfg); err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
@@ -196,21 +134,21 @@ func (m *DecapService) RemovePrefixes(
 		)
 	}
 
-	return &decappb.RemovePrefixesResponse{}, nil
+	return &decappb.UpdateConfigResponse{}, nil
 }
 
+// updateConfig calls the backend to publish cfg and, on success, frees the old
+// module handle and stores the new config. The caller must hold m.mu.
 func (m *DecapService) updateConfig(name string, cfg *config) error {
 	mod, err := m.backend.UpdateModule(name, cfg.Prefixes)
 	if err != nil {
 		return fmt.Errorf("failed to update module config %q: %w", name, err)
 	}
 
-	if cfg.Module != nil {
-		cfg.Module.Free()
+	if old, ok := m.configs[name]; ok && old.Module != nil {
+		old.Module.Free()
 	}
 
-	// Atomic semantics: either we update the config or we don't in case of
-	// errors.
 	m.configs[name] = &config{
 		Prefixes: cfg.Prefixes,
 		Module:   mod,

--- a/modules/decap/controlplane/service_test.go
+++ b/modules/decap/controlplane/service_test.go
@@ -2,16 +2,18 @@ package decap
 
 import (
 	"errors"
+	"fmt"
 	"net/netip"
 	"sync/atomic"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
 
@@ -44,217 +46,187 @@ func (m *flakyBackend) UpdateModule(
 	name string,
 	prefixes []netip.Prefix,
 ) (ModuleHandle, error) {
-	numCalls := m.numCalls.Add(1)
-
-	if numCalls >= 2 {
+	if m.numCalls.Add(1) >= 2 {
 		return nil, errInjectedBackend
 	}
-
 	return &mockModuleHandle{}, nil
 }
 
-func Test_DecapService_AddShow(t *testing.T) {
-	service := newTestService(t)
+func Test_DecapService_UpdateAndShow(t *testing.T) {
+	svc := newTestService(t)
 	prefix := "10.0.0.0/24"
 
-	{
-		response, err := service.AddPrefixes(
-			t.Context(),
-			&decappb.AddPrefixesRequest{
-				Name:     "decap0",
-				Prefixes: []string{prefix},
-			},
-		)
-		require.NotNil(t, response)
-		require.NoError(t, err)
-	}
+	resp, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
+		Name:     "decap0",
+		Prefixes: []string{prefix},
+	})
+	require.NotNil(t, resp)
+	require.NoError(t, err)
 
-	{
-		response, err := service.ShowConfig(
-			t.Context(),
-			&decappb.ShowConfigRequest{
-				Name: "decap0",
-			},
-		)
-		require.NotNil(t, response)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff([]string{prefix}, response.Prefixes))
-	}
+	show, err := svc.ShowConfig(t.Context(), &decappb.ShowConfigRequest{Name: "decap0"})
+	require.NotNil(t, show)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]string{prefix}, show.Prefixes))
 }
 
-func Test_DecapService_AddRemovePartial(t *testing.T) {
-	service := newTestService(t)
+func Test_DecapService_UpdateFullyReplaces(t *testing.T) {
+	svc := newTestService(t)
 
-	{
-		response, err := service.AddPrefixes(
-			t.Context(),
-			&decappb.AddPrefixesRequest{
-				Name: "decap0",
-				Prefixes: []string{
-					"10.0.0.0/24",
-					"10.0.1.0/24",
-				},
-			},
-		)
-		require.NotNil(t, response)
-		require.NoError(t, err)
-	}
+	_, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
+		Name:     "decap0",
+		Prefixes: []string{"10.0.0.0/24", "10.0.1.0/24"},
+	})
+	require.NoError(t, err)
 
-	{
-		response, err := service.RemovePrefixes(
-			t.Context(),
-			&decappb.RemovePrefixesRequest{
-				Name:     "decap0",
-				Prefixes: []string{"10.0.0.0/24"},
-			},
-		)
-		require.NotNil(t, response)
-		require.NoError(t, err)
-	}
+	_, err = svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
+		Name:     "decap0",
+		Prefixes: []string{"192.168.0.0/16"},
+	})
+	require.NoError(t, err)
 
-	{
-		response, err := service.ShowConfig(
-			t.Context(),
-			&decappb.ShowConfigRequest{
-				Name: "decap0",
-			},
-		)
-		require.NotNil(t, response)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff([]string{"10.0.1.0/24"}, response.Prefixes))
-	}
+	show, err := svc.ShowConfig(t.Context(), &decappb.ShowConfigRequest{Name: "decap0"})
+	require.NotNil(t, show)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]string{"192.168.0.0/16"}, show.Prefixes))
 }
 
-func Test_DecapService_ListAddList(t *testing.T) {
-	service := newTestService(t)
+func Test_DecapService_ListUpdateList(t *testing.T) {
+	svc := newTestService(t)
 	ctx := t.Context()
 
-	{
-		response, err := service.ListConfigs(
-			ctx,
-			&decappb.ListConfigsRequest{},
-		)
-		require.NotNil(t, response)
-		require.NoError(t, err)
+	list, err := svc.ListConfigs(ctx, &decappb.ListConfigsRequest{})
+	require.NotNil(t, list)
+	require.NoError(t, err)
+	assert.Empty(t, list.Configs)
 
-		assert.Empty(t, response.Configs)
-	}
+	_, err = svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+		Name:     "decap0",
+		Prefixes: []string{"10.0.0.0/24"},
+	})
+	require.NoError(t, err)
 
-	{
-		response, err := service.AddPrefixes(
-			ctx, &decappb.AddPrefixesRequest{
-				Name:     "decap0",
-				Prefixes: []string{"10.0.0.0/24"},
-			},
-		)
-		require.NotNil(t, response)
-		require.NoError(t, err)
-	}
-
-	{
-		response, err := service.ListConfigs(ctx, &decappb.ListConfigsRequest{})
-		require.NotNil(t, response)
-		require.NoError(t, err)
-
-		assert.Equal(t, []string{"decap0"}, response.Configs)
-	}
+	list, err = svc.ListConfigs(ctx, &decappb.ListConfigsRequest{})
+	require.NotNil(t, list)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"decap0"}, list.Configs)
 }
 
 func Test_DecapService_EmptyConfigName(t *testing.T) {
-	service := newTestService(t)
+	svc := newTestService(t)
 	ctx := t.Context()
 
-	t.Run("AddPrefixes", func(t *testing.T) {
-		response, err := service.AddPrefixes(
-			ctx,
-			&decappb.AddPrefixesRequest{
-				Name:     "",
-				Prefixes: []string{"10.0.0.0/24"},
-			},
-		)
-		require.Nil(t, response)
+	t.Run("UpdateConfig", func(t *testing.T) {
+		resp, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+			Name:     "",
+			Prefixes: []string{"10.0.0.0/24"},
+		})
+		require.Nil(t, resp)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
 
 	t.Run("ShowConfig", func(t *testing.T) {
-		response, err := service.ShowConfig(
-			ctx,
-			&decappb.ShowConfigRequest{},
-		)
-		require.Nil(t, response)
+		resp, err := svc.ShowConfig(ctx, &decappb.ShowConfigRequest{})
+		require.Nil(t, resp)
 		require.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
+}
 
-	t.Run("RemovePrefixes", func(t *testing.T) {
-		response, err := service.RemovePrefixes(
-			ctx,
-			&decappb.RemovePrefixesRequest{
-				Name:     "",
-				Prefixes: []string{"10.0.0.0/24"},
-			},
-		)
-		require.Nil(t, response)
-		require.Equal(t, codes.InvalidArgument, status.Code(err))
+func Test_DecapService_InvalidPrefix(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
+		Name:     "decap0",
+		Prefixes: []string{"not-a-prefix"},
 	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 func Test_DecapService_UpdateFailureAtomic(t *testing.T) {
-	service := NewDecapService(&flakyBackend{})
+	svc := NewDecapService(&flakyBackend{})
 	ctx := t.Context()
 	name := "decap0"
 
-	{
-		response, err := service.AddPrefixes(ctx, &decappb.AddPrefixesRequest{
-			Name:     name,
-			Prefixes: []string{"10.0.0.0/24"},
-		})
-		require.NotNil(t, response)
-		require.NoError(t, err)
-	}
+	_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+		Name:     name,
+		Prefixes: []string{"10.0.0.0/24"},
+	})
+	require.NoError(t, err)
 
-	{
-		response, err := service.AddPrefixes(ctx, &decappb.AddPrefixesRequest{
-			Name: name,
-			Prefixes: []string{
-				"10.0.1.0/24",
-			},
-		})
-		require.Nil(t, response)
-		require.Error(t, err)
-		require.Equal(t, codes.Internal, status.Code(err))
-	}
+	_, err = svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+		Name:     name,
+		Prefixes: []string{"10.0.1.0/24"},
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
 
-	{
-		response, err := service.ShowConfig(ctx, &decappb.ShowConfigRequest{Name: name})
-		require.NotNil(t, response)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff([]string{"10.0.0.0/24"}, response.Prefixes))
-	}
+	show, err := svc.ShowConfig(ctx, &decappb.ShowConfigRequest{Name: name})
+	require.NotNil(t, show)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]string{"10.0.0.0/24"}, show.Prefixes))
 }
 
 func Test_DecapService_DeduplicatePrefixes(t *testing.T) {
-	service := newTestService(t)
+	svc := newTestService(t)
 	prefix := "10.0.0.0/24"
 
-	{
-		response, err := service.AddPrefixes(
-			t.Context(),
-			&decappb.AddPrefixesRequest{
-				Name:     "decap0",
-				Prefixes: []string{prefix, prefix, prefix},
-			},
-		)
-		require.NotNil(t, response)
-		require.NoError(t, err)
+	_, err := svc.UpdateConfig(t.Context(), &decappb.UpdateConfigRequest{
+		Name:     "decap0",
+		Prefixes: []string{prefix, prefix, prefix},
+	})
+	require.NoError(t, err)
+
+	show, err := svc.ShowConfig(t.Context(), &decappb.ShowConfigRequest{Name: "decap0"})
+	require.NotNil(t, show)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]string{prefix}, show.Prefixes))
+}
+
+func Test_DecapService_ConcurrentAccess(t *testing.T) {
+	svc := newTestService(t)
+
+	const goroutines = 10
+	const iterations = 100
+
+	g, ctx := errgroup.WithContext(t.Context())
+
+	for idx := range goroutines {
+		g.Go(func() error {
+			for jdx := range iterations {
+				name := fmt.Sprintf("config-%d-%d", idx, jdx)
+				_, err := svc.UpdateConfig(ctx, &decappb.UpdateConfigRequest{
+					Name:     name,
+					Prefixes: []string{"10.0.0.0/24"},
+				})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 	}
 
-	{
-		response, err := service.ShowConfig(
-			t.Context(),
-			&decappb.ShowConfigRequest{Name: "decap0"},
-		)
-		require.NotNil(t, response)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff([]string{prefix}, response.Prefixes))
+	for range goroutines {
+		g.Go(func() error {
+			for range iterations {
+				_, err := svc.ListConfigs(ctx, &decappb.ListConfigsRequest{})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
 	}
+
+	for idx := range goroutines {
+		g.Go(func() error {
+			for jdx := range iterations {
+				name := fmt.Sprintf("config-%d-%d", idx, jdx)
+				svc.ShowConfig(ctx, &decappb.ShowConfigRequest{Name: name})
+			}
+			return nil
+		})
+	}
+
+	require.NoError(t, g.Wait())
 }

--- a/tests/functional/main/002_decap_default_test.go
+++ b/tests/functional/main/002_decap_default_test.go
@@ -32,7 +32,7 @@ func TestTest_002_decap_default(t *testing.T) {
 		fw.Run("Step_000_Configure_Decap_Environment", func(fw *framework.TestFramework, t *testing.T) {
 			// Configure Decap module
 			commands := []string{
-				"/mnt/target/release/yanet-cli-decap prefix-add --name decap0 -p 1:2:3:4::abcd/128",
+				"/mnt/target/release/yanet-cli-decap update --name decap0 -p 1:2:3:4::abcd/128",
 
 				"/mnt/target/release/yanet-cli-function update --name=test --chains chain2:1=forward:forward0,decap:decap0,route:route0",
 				"/mnt/target/release/yanet-cli-pipeline update --name=test --functions test",

--- a/tests/functional/main/decap_test.go
+++ b/tests/functional/main/decap_test.go
@@ -25,8 +25,7 @@ func testDecap(t *testing.T, fw *framework.TestFramework) {
 	fw.Run("Configure_Decap_Module", func(fw *framework.TestFramework, t *testing.T) {
 		// Decap-specific configuration
 		commands := []string{
-			"/mnt/target/release/yanet-cli-decap prefix-add --name decap0 -p 4.5.6.7/32",
-			"/mnt/target/release/yanet-cli-decap prefix-add --name decap0 -p 1:2:3:4::abcd/128",
+			"/mnt/target/release/yanet-cli-decap update --name decap0 -p 4.5.6.7/32 -p 1:2:3:4::abcd/128",
 
 			"/mnt/target/release/yanet-cli-function update --name=test --chains c0:3=forward:forward0,decap:decap0,route:route0",
 			"/mnt/target/release/yanet-cli-pipeline update --name=test --functions test",

--- a/tests/migration/converter/lib/converter_templates.go
+++ b/tests/migration/converter/lib/converter_templates.go
@@ -452,20 +452,24 @@ func (c *Converter) generateACLTestTemplate(testData *GoTestData, functions []st
 func (c *Converter) generateDecapTestTemplate(testData *GoTestData, functions []string) string {
 	header := c.generateTestHeader(testData.TestName, testData.OriginalTestName, testData.TestType)
 
-	// Generate decap configuration commands from parsed config
+	// Generate decap configuration commands from parsed config.
+	//
+	// All prefixes for a single module are aggregated into one update command
+	// so that the dataplane receives the full desired set atomically.
 	var decapCommands []string
 	if testData.ParsedConfig != nil {
 		for moduleName, module := range testData.ParsedConfig.Modules {
 			if module.Type == "decap" {
-				// Add IPv4 destination prefixes
-				for _, prefix := range module.IPv4DestinationPrefixes {
+				var allPrefixes []string
+				allPrefixes = append(allPrefixes, module.IPv4DestinationPrefixes...)
+				allPrefixes = append(allPrefixes, module.IPv6DestinationPrefixes...)
+				if len(allPrefixes) > 0 {
+					var args []string
+					for _, prefix := range allPrefixes {
+						args = append(args, "-p "+prefix)
+					}
 					decapCommands = append(decapCommands,
-						fmt.Sprintf(`"%s prefix-add --cfg %s -p %s"`, framework.CLIDecap, moduleName, prefix))
-				}
-				// Add IPv6 destination prefixes
-				for _, prefix := range module.IPv6DestinationPrefixes {
-					decapCommands = append(decapCommands,
-						fmt.Sprintf(`"%s prefix-add --cfg %s -p %s"`, framework.CLIDecap, moduleName, prefix))
+						fmt.Sprintf(`"%s update --name %s %s"`, framework.CLIDecap, moduleName, strings.Join(args, " ")))
 				}
 			}
 		}

--- a/web/src/api/decap.ts
+++ b/web/src/api/decap.ts
@@ -1,7 +1,5 @@
 import { createService, type CallOptions } from './client';
 
-// Decap types based on decap.proto
-
 export interface ShowConfigRequest {
     name?: string;
 }
@@ -10,30 +8,18 @@ export interface ShowConfigResponse {
     prefixes?: string[];
 }
 
-export interface AddPrefixesRequest {
+export interface DecapUpdateConfigRequest {
     name?: string;
     prefixes?: string[];
 }
 
-export interface AddPrefixesResponse { }
-
-export interface RemovePrefixesRequest {
-    name?: string;
-    prefixes?: string[];
-}
-
-export interface RemovePrefixesResponse { }
+export interface DecapUpdateConfigResponse { }
 
 const decapService = createService('modules.decap.controlplane.decappb.v1.DecapService');
 
 export const decap = {
-    showConfig: (request: ShowConfigRequest, options?: CallOptions): Promise<ShowConfigResponse> => {
-        return decapService.callWithBody<ShowConfigResponse>('ShowConfig', request, options);
-    },
-    addPrefixes: (request: AddPrefixesRequest, options?: CallOptions): Promise<AddPrefixesResponse> => {
-        return decapService.callWithBody<AddPrefixesResponse>('AddPrefixes', request, options);
-    },
-    removePrefixes: (request: RemovePrefixesRequest, options?: CallOptions): Promise<RemovePrefixesResponse> => {
-        return decapService.callWithBody<RemovePrefixesResponse>('RemovePrefixes', request, options);
-    },
+    showConfig: (request: ShowConfigRequest, options?: CallOptions): Promise<ShowConfigResponse> =>
+        decapService.callWithBody<ShowConfigResponse>('ShowConfig', request, options),
+    updateConfig: (request: DecapUpdateConfigRequest, options?: CallOptions): Promise<DecapUpdateConfigResponse> =>
+        decapService.callWithBody<DecapUpdateConfigResponse>('UpdateConfig', request, options),
 };

--- a/web/src/pages/modules/decap/usePrefixDraft.ts
+++ b/web/src/pages/modules/decap/usePrefixDraft.ts
@@ -25,13 +25,9 @@ export const usePrefixDraft = (): UsePrefixDraftResult => {
             .filter(Boolean);
         return Promise.all(
             configNames.map(async (name): Promise<{ name: string; rows: PrefixRowItem[] }> => {
-                try {
-                    const resp = await API.decap.showConfig({ name });
-                    const rows: PrefixRowItem[] = (resp.prefixes ?? []).map((p) => ({ id: p, prefix: p }));
-                    return { name, rows };
-                } catch {
-                    return { name, rows: [] };
-                }
+                const resp = await API.decap.showConfig({ name });
+                const rows: PrefixRowItem[] = (resp.prefixes ?? []).map((p) => ({ id: p, prefix: p }));
+                return { name, rows };
             }),
         );
     }, []);

--- a/web/src/pages/modules/decap/usePrefixDraft.ts
+++ b/web/src/pages/modules/decap/usePrefixDraft.ts
@@ -12,8 +12,8 @@ export type UsePrefixDraftResult = UseDraftResult<PrefixRowItem>;
  *
  * Server state is fetched once on mount. All UI mutations go through
  * dispatchDraft and update only local state until the user explicitly calls
- * commitConfig. On commit the diff between draft and server is computed and
- * the minimal add/remove API calls are made.
+ * commitConfig. On commit the full draft prefix list is sent atomically via
+ * UpdateConfig, replacing the server state entirely.
  */
 export const usePrefixDraft = (): UsePrefixDraftResult => {
     const load = useCallback(async (): Promise<Array<{ name: string; rows: PrefixRowItem[] }>> => {
@@ -39,18 +39,8 @@ export const usePrefixDraft = (): UsePrefixDraftResult => {
     const commit = useCallback(async (
         configName: string,
         draftRows: PrefixRowItem[],
-        serverRowsArg: PrefixRowItem[],
     ): Promise<void> => {
-        const draftPrefixes = new Set(draftRows.map((r) => r.prefix));
-        const serverPrefixes = new Set(serverRowsArg.map((r) => r.prefix));
-        const added = [...draftPrefixes].filter((p) => !serverPrefixes.has(p));
-        const removed = [...serverPrefixes].filter((p) => !draftPrefixes.has(p));
-        if (added.length > 0) {
-            await API.decap.addPrefixes({ name: configName, prefixes: added });
-        }
-        if (removed.length > 0) {
-            await API.decap.removePrefixes({ name: configName, prefixes: removed });
-        }
+        await API.decap.updateConfig({ name: configName, prefixes: draftRows.map((r) => r.prefix) });
     }, []);
 
     return useDraft<PrefixRowItem>({


### PR DESCRIPTION
- Replace the granular add/remove prefix RPCs of the decap service with a single declarative update that atomically replaces the whole prefix set of a config, mirroring the forward module.
- Migrate the decap CLI to the new update command that takes the full desired prefix set.
- Migrate the web decap page commit path to a single update call, keeping the draft mechanism intact.
- Update functional tests and the migration converter to emit the new command.
