### PR TITLE
refactor(web): extract shared rule drawer and rule table chrome

### DIFF
--- a/web/src/components/draft/RuleDrawerFootActions.tsx
+++ b/web/src/components/draft/RuleDrawerFootActions.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+/** Returns the footer meta text for a rule drawer based on mode and rule index. */
+const ruleDrawerFootMeta = (mode: 'add' | 'edit', ruleItem: { index: number } | null): string =>
+    mode === 'add' ? 'Will be appended to config.' : `Rule #${(ruleItem?.index ?? -1) + 1}`;
+
+interface RuleDrawerFootActionsProps {
+    onCancel: () => void;
+    onApply: () => void;
+    /** When true, the Apply button is disabled. Omit or pass undefined to leave it enabled. */
+    applyDisabled?: boolean;
+}
+
+/** Foot-action row shared by ACL and Forward rule drawers. */
+const RuleDrawerFootActions: React.FC<RuleDrawerFootActionsProps> = ({
+    onCancel,
+    onApply,
+    applyDisabled,
+}) => (
+    <>
+        <button type="button" className="yn-btn yn-btn--ghost" onClick={onCancel}>
+            Cancel
+        </button>
+        <button
+            type="button"
+            className="yn-btn yn-btn--primary"
+            disabled={applyDisabled}
+            onClick={onApply}
+        >
+            Apply
+        </button>
+    </>
+);
+
+export { ruleDrawerFootMeta };
+export default RuleDrawerFootActions;

--- a/web/src/components/draft/RuleDrawerHeadActions.tsx
+++ b/web/src/components/draft/RuleDrawerHeadActions.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+interface RuleDrawerHeadActionsProps {
+    /** When true, renders the duplicate and delete buttons. */
+    showEditActions: boolean;
+    onDuplicate: () => void;
+    onDelete: () => void;
+    /** Icon or text rendered inside the delete button. */
+    deleteIcon: React.ReactNode;
+    onClose: () => void;
+}
+
+/** Head-action row shared by ACL and Forward rule drawers. */
+const RuleDrawerHeadActions: React.FC<RuleDrawerHeadActionsProps> = ({
+    showEditActions,
+    onDuplicate,
+    onDelete,
+    deleteIcon,
+    onClose,
+}) => (
+    <>
+        {showEditActions && (
+            <>
+                <button
+                    type="button"
+                    className="yn-icon-btn"
+                    onClick={onDuplicate}
+                    title="Duplicate rule"
+                >
+                    ⎘
+                </button>
+                <button
+                    type="button"
+                    className="yn-icon-btn yn-icon-btn--danger"
+                    onClick={onDelete}
+                    title="Delete rule"
+                >
+                    {deleteIcon}
+                </button>
+            </>
+        )}
+        <button
+            type="button"
+            className="yn-icon-btn"
+            onClick={onClose}
+            aria-label="Close drawer"
+        >
+            ✕
+        </button>
+    </>
+);
+
+export default RuleDrawerHeadActions;

--- a/web/src/components/draft/index.ts
+++ b/web/src/components/draft/index.ts
@@ -1,3 +1,7 @@
+export { default as RuleDrawerHeadActions } from './RuleDrawerHeadActions';
+export { default as RuleDrawerFootActions, ruleDrawerFootMeta } from './RuleDrawerFootActions';
+export { ruleTableCommonProps } from './ruleTableProps';
+export type { RuleTableCommonOptions, RuleTableCommonResult } from './ruleTableProps';
 export { createDraftReducer } from './draftReducer';
 export type { DraftState, DraftAction, CreateDraftReducerOptions } from './draftReducer';
 export { default as DraftActionButtons, SaveIcon, TrashIcon } from './DraftActionButtons';

--- a/web/src/components/draft/ruleTableProps.tsx
+++ b/web/src/components/draft/ruleTableProps.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import DraftActionButtons from './DraftActionButtons';
+
+/** Minimum shape required of a rule item to build common table props. */
+interface RuleItemShape {
+    id: string;
+    index: number;
+}
+
+interface RuleTableCommonOptions<T extends RuleItemShape> {
+    items: T[];
+    onEditRule: (item: T) => void;
+    selectedIds: Set<string>;
+    onSelectionChange: (ids: Set<string>) => void;
+    activeRowId: string | null;
+    flashRowId?: string | null;
+    currentIsDirty: boolean;
+    onSave: () => void;
+    onDiscard: () => void;
+    onDeleteConfig: () => void;
+}
+
+interface RuleTableCommonResult<T extends RuleItemShape> {
+    emptyMessage: string;
+    selectedIds: Set<string>;
+    onSelectionChange: (ids: Set<string>) => void;
+    sortState: { column: null; direction: 'asc' };
+    onSort: () => void;
+    onEditRow: (id: string) => void;
+    editAriaLabel: (item: T) => string;
+    editTitle: string;
+    activeRowId: string | null;
+    flashRowId?: string | null;
+    headerActions: React.ReactNode;
+    footerExtra: React.ReactNode;
+}
+
+/** Returns the VirtualTable prop subset that is identical across ACL and Forward rule tables. */
+const ruleTableCommonProps = <T extends RuleItemShape>(
+    options: RuleTableCommonOptions<T>,
+): RuleTableCommonResult<T> => {
+    const {
+        items,
+        onEditRule,
+        selectedIds,
+        onSelectionChange,
+        activeRowId,
+        flashRowId,
+        currentIsDirty,
+        onSave,
+        onDiscard,
+        onDeleteConfig,
+    } = options;
+
+    return {
+        emptyMessage: 'No rules match your search.',
+        selectedIds,
+        onSelectionChange,
+        sortState: { column: null, direction: 'asc' },
+        onSort: () => {},
+        onEditRow: (id: string) => {
+            const it = items.find((item) => item.id === id);
+            if (it) onEditRule(it);
+        },
+        editAriaLabel: (item: T) => `Edit rule ${item.index + 1}`,
+        editTitle: 'Edit rule',
+        activeRowId,
+        flashRowId,
+        headerActions: (
+            <DraftActionButtons
+                currentIsDirty={currentIsDirty}
+                onSave={onSave}
+                onDiscard={onDiscard}
+                onDeleteConfig={onDeleteConfig}
+            />
+        ),
+        footerExtra: selectedIds.size > 0 ? (
+            <span className="yn-toolbar__count" style={{ color: 'var(--yn-accent)' }}>
+                {selectedIds.size.toLocaleString()} selected
+            </span>
+        ) : undefined,
+    };
+};
+
+export { ruleTableCommonProps };
+export type { RuleTableCommonOptions, RuleTableCommonResult };

--- a/web/src/pages/modules/acl/RuleDrawer.tsx
+++ b/web/src/pages/modules/acl/RuleDrawer.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useDrawerFlush } from '../../../hooks';
 import { ActionKind, ACTION_KIND_LABELS } from '../../../api/acl';
-import { TrashIcon } from '../../../components/draft';
+import { TrashIcon, RuleDrawerHeadActions, RuleDrawerFootActions, ruleDrawerFootMeta } from '../../../components/draft';
 import type { RuleDraft, RuleItem } from './types';
 import { emptyDraft } from './types';
 import { itemToDraft, defaultCounterName, draftToRule, expandRule, deadReasonText } from './hooks';
@@ -147,51 +147,18 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                     </span>
                 )}
             </>}
-            headActions={<>
-                {mode === 'edit' && ruleItem && (
-                    <>
-                        <button
-                            type="button"
-                            className="yn-icon-btn"
-                            onClick={() => onDuplicate(ruleItem)}
-                            title="Duplicate rule"
-                        >
-                            ⎘
-                        </button>
-                        <button
-                            type="button"
-                            className="yn-icon-btn yn-icon-btn--danger"
-                            onClick={() => onDelete(ruleItem)}
-                            title="Delete rule"
-                        >
-                            <TrashIcon />
-                        </button>
-                    </>
-                )}
-                <button
-                    type="button"
-                    className="yn-icon-btn"
-                    onClick={handleClose}
-                    aria-label="Close drawer"
-                >
-                    ✕
-                </button>
-            </>}
-            footMeta={mode === 'add'
-                ? 'Will be appended to config.'
-                : `Rule #${(ruleItem?.index ?? -1) + 1}`}
-            footActions={<>
-                <button type="button" className="yn-btn yn-btn--ghost" onClick={handleClose}>
-                    Cancel
-                </button>
-                <button
-                    type="button"
-                    className="yn-btn yn-btn--primary"
-                    onClick={handleApply}
-                >
-                    Apply
-                </button>
-            </>}
+            headActions={<RuleDrawerHeadActions
+                showEditActions={mode === 'edit' && !!ruleItem}
+                onDuplicate={() => { if (ruleItem) onDuplicate(ruleItem); }}
+                onDelete={() => { if (ruleItem) onDelete(ruleItem); }}
+                deleteIcon={<TrashIcon />}
+                onClose={handleClose}
+            />}
+            footMeta={ruleDrawerFootMeta(mode, ruleItem)}
+            footActions={<RuleDrawerFootActions
+                onCancel={handleClose}
+                onApply={handleApply}
+            />}
         >
             <section className="yn-section">
                 <div className="yn-section-h">Actions</div>

--- a/web/src/pages/modules/acl/RuleTable.tsx
+++ b/web/src/pages/modules/acl/RuleTable.tsx
@@ -12,7 +12,7 @@ import {
     ActionChain,
     ChipList,
 } from './chips';
-import { DraftActionButtons } from '../../../components/draft';
+import { ruleTableCommonProps } from '../../../components/draft';
 import type { RuleRate } from './useAclRuleCounters';
 import Sparkline from '../_shared/Sparkline';
 import { VirtualTable, type Column } from '../../../components/VirtualTable';
@@ -294,19 +294,18 @@ const RuleTable: React.FC<RuleTableProps> = ({
             indexWidth={48}
             cellPaddingRight={8}
             indexFontSize={12}
-            emptyMessage="No rules match your search."
-            selectedIds={selectedIds}
-            onSelectionChange={onSelectionChange}
-            sortState={{ column: null, direction: 'asc' }}
-            onSort={() => {}}
-            onEditRow={(id) => {
-                const it = items.find((item) => item.id === id);
-                if (it) onEditRule(it);
-            }}
-            editAriaLabel={(item) => `Edit rule ${item.index + 1}`}
-            editTitle="Edit rule"
-            activeRowId={activeRowId}
-            flashRowId={flashRowId}
+            {...ruleTableCommonProps({
+                items,
+                onEditRule,
+                selectedIds,
+                onSelectionChange,
+                activeRowId,
+                flashRowId,
+                currentIsDirty,
+                onSave,
+                onDiscard,
+                onDeleteConfig,
+            })}
             renderIndexAdornment={(item) => {
                 const expanded = expandRuleItem(item.rule);
                 if (expanded.isDead) {
@@ -331,21 +330,6 @@ const RuleTable: React.FC<RuleTableProps> = ({
                 }
                 return null;
             }}
-            headerActions={
-                <DraftActionButtons
-                    currentIsDirty={currentIsDirty}
-                    onSave={onSave}
-                    onDiscard={onDiscard}
-                    onDeleteConfig={onDeleteConfig}
-                />
-            }
-            footerExtra={
-                selectedIds.size > 0 ? (
-                    <span className="yn-toolbar__count" style={{ color: 'var(--yn-accent)' }}>
-                        {selectedIds.size.toLocaleString()} selected
-                    </span>
-                ) : undefined
-            }
         />
     );
 };

--- a/web/src/pages/modules/forward/RuleDrawer.tsx
+++ b/web/src/pages/modules/forward/RuleDrawer.tsx
@@ -9,6 +9,7 @@ import { isValidCidr, isValidDeviceName } from '../../../utils';
 import ChipInput from './ChipInput';
 import type { ChipInputHandle } from './ChipInput';
 import { DrawerShell } from '../../../components';
+import { RuleDrawerHeadActions, RuleDrawerFootActions, ruleDrawerFootMeta } from '../../../components/draft';
 
 interface RuleDrawerProps {
     open: boolean;
@@ -101,52 +102,19 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
             title={mode === 'add' ? 'New rule' : (
                 <>Edit rule <span className="yn-drawer__rule-num">#{ruleItem?.index !== undefined ? ruleItem.index + 1 : ''}</span></>
             )}
-            headActions={<>
-                {mode === 'edit' && ruleItem && (
-                    <>
-                        <button
-                            type="button"
-                            className="yn-icon-btn"
-                            onClick={() => onDuplicate(ruleItem)}
-                            title="Duplicate rule"
-                        >
-                            ⎘
-                        </button>
-                        <button
-                            type="button"
-                            className="yn-icon-btn yn-icon-btn--danger"
-                            onClick={() => onDelete(ruleItem)}
-                            title="Delete rule"
-                        >
-                            🗑
-                        </button>
-                    </>
-                )}
-                <button
-                    type="button"
-                    className="yn-icon-btn"
-                    onClick={handleClose}
-                    aria-label="Close drawer"
-                >
-                    ✕
-                </button>
-            </>}
-            footMeta={mode === 'add'
-                ? 'Will be appended to config.'
-                : `Rule #${(ruleItem?.index ?? -1) + 1}`}
-            footActions={<>
-                <button type="button" className="yn-btn yn-btn--ghost" onClick={handleClose}>
-                    Cancel
-                </button>
-                <button
-                    type="button"
-                    className="yn-btn yn-btn--primary"
-                    disabled={!isValid}
-                    onClick={handleApply}
-                >
-                    Apply
-                </button>
-            </>}
+            headActions={<RuleDrawerHeadActions
+                showEditActions={mode === 'edit' && !!ruleItem}
+                onDuplicate={() => { if (ruleItem) onDuplicate(ruleItem); }}
+                onDelete={() => { if (ruleItem) onDelete(ruleItem); }}
+                deleteIcon="🗑"
+                onClose={handleClose}
+            />}
+            footMeta={ruleDrawerFootMeta(mode, ruleItem)}
+            footActions={<RuleDrawerFootActions
+                onCancel={handleClose}
+                onApply={handleApply}
+                applyDisabled={!isValid}
+            />}
         >
             <section className="yn-section">
                 <div className="yn-section-h">Identity</div>

--- a/web/src/pages/modules/forward/RuleTable.tsx
+++ b/web/src/pages/modules/forward/RuleTable.tsx
@@ -5,7 +5,7 @@ import DirectionBadge from './DirectionBadge';
 import AnyBadge from './AnyBadge';
 import Sparkline from '../_shared/Sparkline';
 import { formatPps } from '../../../utils';
-import { DraftActionButtons } from '../../../components/draft';
+import { ruleTableCommonProps } from '../../../components/draft';
 import { VirtualTable, type Column } from '../../../components/VirtualTable';
 
 /** Compact mono list of values with overflow truncation. */
@@ -142,34 +142,18 @@ const RuleTable: React.FC<RuleTableProps> = ({
             columns={columns}
             getRowId={(item) => item.id}
             minWidth={MIN_WIDTH}
-            emptyMessage="No rules match your search."
-            selectedIds={selectedIds}
-            onSelectionChange={onSelectionChange}
-            sortState={{ column: null, direction: 'asc' }}
-            onSort={() => {}}
-            onEditRow={(id) => {
-                const it = items.find((item) => item.id === id);
-                if (it) onEditRule(it);
-            }}
-            editAriaLabel={(item) => `Edit rule ${item.index + 1}`}
-            editTitle="Edit rule"
-            activeRowId={activeRowId}
-            flashRowId={flashRowId}
-            headerActions={
-                <DraftActionButtons
-                    currentIsDirty={currentIsDirty}
-                    onSave={onSave}
-                    onDiscard={onDiscard}
-                    onDeleteConfig={onDeleteConfig}
-                />
-            }
-            footerExtra={
-                selectedIds.size > 0 ? (
-                    <span className="yn-toolbar__count" style={{ color: 'var(--yn-accent)' }}>
-                        {selectedIds.size.toLocaleString()} selected
-                    </span>
-                ) : undefined
-            }
+            {...ruleTableCommonProps({
+                items,
+                onEditRule,
+                selectedIds,
+                onSelectionChange,
+                activeRowId,
+                flashRowId,
+                currentIsDirty,
+                onSave,
+                onDiscard,
+                onDeleteConfig,
+            })}
         />
     );
 };


### PR DESCRIPTION
- Extracts the duplicated drawer head and foot action rows of the acl and forward rule drawers into shared components, parameterizing the delete icon and the apply-button disabled state.
- Extracts the identical footer meta expression into a small shared helper.
- Extracts the VirtualTable prop subset duplicated between the acl and forward rule tables into a shared props builder, leaving page-specific layout props inline.