### PR TITLE
refactor(web): unify dashboard and inspect module card grids

### DIFF
--- a/web/src/pages/builtin/dashboard/DataplaneModules.tsx
+++ b/web/src/pages/builtin/dashboard/DataplaneModules.tsx
@@ -1,117 +1,29 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import type { InstanceInfo } from '../../../api/inspect';
-import {
-    getModuleCardAgentUsage,
-    getModuleRoute,
-    type AgentUsage,
-} from '../inspect/utils';
-import { useModuleCards } from '../../../hooks/useModuleCards';
-import { MemoryBar } from '../inspect/MemoryBar';
-import { fmtIEC } from '../inspect/formatters';
+import type { AgentUsage } from '../inspect/utils';
+import { ModuleCardsGrid, type ModuleCardsChrome } from '../inspect/ModuleCardsGrid';
 
 export interface DataplaneModulesProps {
     instance: InstanceInfo;
     usage: Map<string, AgentUsage>;
 }
 
-/** Full-width dataplane modules grid with routing and active-state indicators. */
-export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance, usage }) => {
-    const navigate = useNavigate();
-    const modules = instance.dp_modules ?? [];
-    const moduleData = useModuleCards(instance);
-
-    const colCount = Math.min(9, Math.max(1, modules.length));
-
-    return (
-        <div className="dash-modules">
-            <div className="dash-modules__head">
-                <span>
-                    DATAPLANE MODULES{' '}
-                    <span style={{ color: 'var(--iv-text-dim)' }}>{modules.length}</span>
-                </span>
-                <span>
-                    <span style={{ color: 'var(--iv-ok)' }}>●</span>
-                    {' in use   '}
-                    <span style={{ color: 'var(--iv-idle)' }}>○</span>
-                    {' available'}
-                </span>
-            </div>
-            <div
-                className="dash-modules__grid"
-                style={{ gridTemplateColumns: `repeat(${colCount}, minmax(0, 1fr))` }}
-            >
-                {moduleData.map((m) => {
-                    const href = getModuleRoute(m.name);
-                    const isClickable = Boolean(href);
-                    const className = [
-                        'dash-module-card',
-                        m.inUse && 'dash-module-card--active',
-                        isClickable && 'dash-module-card--clickable',
-                    ].filter(Boolean).join(' ');
-                    const handleClick = href ? () => navigate(href) : undefined;
-                    const handleKeyDown = href
-                        ? (e: React.KeyboardEvent<HTMLDivElement>) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                  e.preventDefault();
-                                  navigate(href);
-                              }
-                          }
-                        : undefined;
-                    return (
-                        <div
-                            key={m.key}
-                            className={className}
-                            onClick={handleClick}
-                            onKeyDown={handleKeyDown}
-                            tabIndex={isClickable ? 0 : undefined}
-                            role={isClickable ? 'link' : undefined}
-                        >
-                            <div className="dash-module-card__top">
-                                <span className="dash-module-card__name">{m.name}</span>
-                                <span
-                                    className="dash-dot"
-                                    style={{
-                                        background: m.inUse ? 'var(--iv-ok)' : 'var(--iv-idle)',
-                                    }}
-                                />
-                            </div>
-                            <div className="dash-module-card__desc">{m.desc}</div>
-                            <div className="dash-module-card__stats">{m.cfg}cfg · {m.pipe}pipe</div>
-                            {(() => {
-                                const ag = getModuleCardAgentUsage(usage, m.name);
-                                if (!ag) return null;
-                                return (
-                                    <div className="dash-module-card__mem">
-                                        <div className="dash-module-card__mem-row">
-                                            <span
-                                                style={{
-                                                    color: ag.used > 0
-                                                        ? 'var(--iv-text)'
-                                                        : 'var(--iv-mute)',
-                                                    fontVariantNumeric: 'tabular-nums',
-                                                }}
-                                            >
-                                                {fmtIEC(ag.used)}
-                                            </span>
-                                            <span
-                                                style={{
-                                                    color: 'var(--iv-mute)',
-                                                    fontSize: 9,
-                                                    fontVariantNumeric: 'tabular-nums',
-                                                }}
-                                            >
-                                                {fmtIEC(ag.limit)}
-                                            </span>
-                                        </div>
-                                        <MemoryBar used={ag.used} limit={ag.limit} height={4} cells={20} />
-                                    </div>
-                                );
-                            })()}
-                        </div>
-                    );
-                })}
-            </div>
-        </div>
-    );
+const chrome: ModuleCardsChrome = {
+    rootClass: 'dash-modules',
+    headClass: 'dash-modules__head',
+    gridClass: 'dash-modules__grid',
+    gridTemplateColumns: (n) => `repeat(${Math.min(9, Math.max(1, n))}, minmax(0, 1fr))`,
+    cardClass: 'dash-module-card',
+    dotClass: 'dash-dot',
+    countStyle: { color: 'var(--iv-text-dim)' },
+    memUsedStyle: (used) => ({
+        color: used > 0 ? 'var(--iv-text)' : 'var(--iv-mute)',
+        fontVariantNumeric: 'tabular-nums',
+    }),
+    memLimitStyle: { color: 'var(--iv-mute)', fontSize: 9, fontVariantNumeric: 'tabular-nums' },
 };
+
+/** Full-width dataplane modules grid with routing and active-state indicators. */
+export const DataplaneModules: React.FC<DataplaneModulesProps> = ({ instance, usage }) => (
+    <ModuleCardsGrid instance={instance} usage={usage} chrome={chrome} />
+);

--- a/web/src/pages/builtin/inspect/ModuleCardsGrid.tsx
+++ b/web/src/pages/builtin/inspect/ModuleCardsGrid.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import type { InstanceInfo } from '../../../api/inspect';
+import { fmtIEC } from './formatters';
+import { MemoryBar } from './MemoryBar';
+import { getModuleCardAgentUsage, getModuleRoute } from './utils';
+import type { AgentUsage } from './utils';
+import { useModuleCards } from '../../../hooks/useModuleCards';
+
+/** Visual knobs that differ between the inspect and dashboard renderings. */
+export interface ModuleCardsChrome {
+    rootId?: string;
+    rootClass: string;
+    headClass: string;
+    labelClass?: string;
+    countClass?: string;
+    countStyle?: React.CSSProperties;
+    legendClass?: string;
+    gridClass: string;
+    gridTemplateColumns: (moduleCount: number) => string;
+    cardClass: string;
+    dotClass: string;
+    memUsedStyle: (used: number) => React.CSSProperties;
+    memLimitClass?: string;
+    memLimitStyle?: React.CSSProperties;
+}
+
+export interface ModuleCardsGridProps {
+    instance: InstanceInfo;
+    usage: Map<string, AgentUsage>;
+    chrome: ModuleCardsChrome;
+}
+
+/** Shared module-card grid renderer used by ModuleStrip and DataplaneModules. */
+export const ModuleCardsGrid: React.FC<ModuleCardsGridProps> = ({ instance, usage, chrome }) => {
+    const navigate = useNavigate();
+    const modules = instance.dp_modules ?? [];
+    const moduleData = useModuleCards(instance);
+
+    return (
+        <div id={chrome.rootId} className={chrome.rootClass}>
+            <div className={chrome.headClass}>
+                <span className={chrome.labelClass}>
+                    DATAPLANE MODULES{' '}
+                    <span className={chrome.countClass} style={chrome.countStyle}>
+                        {modules.length}
+                    </span>
+                </span>
+                <span className={chrome.legendClass}>
+                    <span style={{ color: 'var(--iv-ok)' }}>●</span>
+                    {' in use   '}
+                    <span style={{ color: 'var(--iv-idle)' }}>○</span>
+                    {' available'}
+                </span>
+            </div>
+            <div
+                className={chrome.gridClass}
+                style={{ gridTemplateColumns: chrome.gridTemplateColumns(modules.length) }}
+            >
+                {moduleData.map((m) => {
+                    const href = getModuleRoute(m.name);
+                    const isClickable = Boolean(href);
+                    const cardClassName = [
+                        chrome.cardClass,
+                        m.inUse && chrome.cardClass + '--active',
+                        isClickable && chrome.cardClass + '--clickable',
+                    ].filter(Boolean).join(' ');
+                    const handleClick = href ? () => navigate(href) : undefined;
+                    const handleKeyDown = href
+                        ? (e: React.KeyboardEvent<HTMLDivElement>) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  navigate(href);
+                              }
+                          }
+                        : undefined;
+                    return (
+                        <div
+                            key={m.key}
+                            className={cardClassName}
+                            onClick={handleClick}
+                            onKeyDown={handleKeyDown}
+                            tabIndex={isClickable ? 0 : undefined}
+                            role={isClickable ? 'link' : undefined}
+                        >
+                            <div className={chrome.cardClass + '__top'}>
+                                <span className={chrome.cardClass + '__name'}>{m.name}</span>
+                                <span
+                                    className={chrome.dotClass}
+                                    style={{ background: m.inUse ? 'var(--iv-ok)' : 'var(--iv-idle)' }}
+                                />
+                            </div>
+                            <div className={chrome.cardClass + '__desc'}>{m.desc}</div>
+                            <div className={chrome.cardClass + '__stats'}>{m.cfg}cfg · {m.pipe}pipe</div>
+                            {(() => {
+                                const mem = getModuleCardAgentUsage(usage, m.name);
+                                if (!mem) return null;
+                                return (
+                                    <div className={chrome.cardClass + '__mem'}>
+                                        <div className={chrome.cardClass + '__mem-row'}>
+                                            <span style={chrome.memUsedStyle(mem.used)}>
+                                                {fmtIEC(mem.used)}
+                                            </span>
+                                            <span
+                                                className={chrome.memLimitClass}
+                                                style={chrome.memLimitStyle}
+                                            >
+                                                {fmtIEC(mem.limit)}
+                                            </span>
+                                        </div>
+                                        <MemoryBar
+                                            used={mem.used}
+                                            limit={mem.limit}
+                                            height={4}
+                                            cells={20}
+                                        />
+                                    </div>
+                                );
+                            })()}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/web/src/pages/builtin/inspect/ModuleStrip.tsx
+++ b/web/src/pages/builtin/inspect/ModuleStrip.tsx
@@ -1,109 +1,31 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
 import type { InstanceInfo } from '../../../api/inspect';
-import { fmtIEC } from './formatters';
-import { MemoryBar } from './MemoryBar';
-import { getModuleCardAgentUsage, getModuleRoute } from './utils';
 import type { AgentUsage } from './utils';
-import { useModuleCards } from '../../../hooks/useModuleCards';
+import { ModuleCardsGrid, type ModuleCardsChrome } from './ModuleCardsGrid';
 
 export interface ModuleStripProps {
     instance: InstanceInfo;
     usage: Map<string, AgentUsage>;
 }
 
-/** Horizontal strip showing all dataplane modules with usage indicators. */
-export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance, usage }) => {
-    const navigate = useNavigate();
-    const modules = instance.dp_modules ?? [];
-    const moduleData = useModuleCards(instance);
-
-    return (
-        <div id="iv-section-modules" className="iv-module-strip">
-            <div className="iv-module-strip__header">
-                <span className="iv-label">
-                    DATAPLANE MODULES{' '}
-                    <span className="iv-label__count">{modules.length}</span>
-                </span>
-                <span className="iv-module-strip__legend">
-                    <span style={{ color: 'var(--iv-ok)' }}>●</span>
-                    {' in use   '}
-                    <span style={{ color: 'var(--iv-idle)' }}>○</span>
-                    {' available'}
-                </span>
-            </div>
-            <div
-                className="iv-module-strip__grid"
-                style={{ gridTemplateColumns: `repeat(${modules.length || 1}, minmax(0, 1fr))` }}
-            >
-                {moduleData.map((m) => {
-                    const href = getModuleRoute(m.name);
-                    const isClickable = Boolean(href);
-                    const className = [
-                        'iv-module-card',
-                        m.inUse && 'iv-module-card--active',
-                        isClickable && 'iv-module-card--clickable',
-                    ].filter(Boolean).join(' ');
-                    const handleClick = href ? () => navigate(href) : undefined;
-                    const handleKeyDown = href
-                        ? (e: React.KeyboardEvent<HTMLDivElement>) => {
-                              if (e.key === 'Enter' || e.key === ' ') {
-                                  e.preventDefault();
-                                  navigate(href);
-                              }
-                          }
-                        : undefined;
-                    return (
-                        <div
-                            key={m.key}
-                            className={className}
-                            onClick={handleClick}
-                            onKeyDown={handleKeyDown}
-                            tabIndex={isClickable ? 0 : undefined}
-                            role={isClickable ? 'link' : undefined}
-                        >
-                            <div className="iv-module-card__top">
-                                <span className="iv-module-card__name">{m.name}</span>
-                                <span
-                                    className="iv-dot"
-                                    style={{ background: m.inUse ? 'var(--iv-ok)' : 'var(--iv-idle)' }}
-                                />
-                            </div>
-                            <div className="iv-module-card__desc">{m.desc}</div>
-                            <div className="iv-module-card__stats">{m.cfg}cfg · {m.pipe}pipe</div>
-                            {(() => {
-                                const mem = getModuleCardAgentUsage(usage, m.name);
-                                if (!mem) return null;
-                                return (
-                                    <div className="iv-module-card__mem">
-                                        <div className="iv-module-card__mem-row">
-                                            <span
-                                                style={{
-                                                    color:
-                                                        mem.used > 0
-                                                            ? 'var(--iv-text)'
-                                                            : 'var(--iv-mute)',
-                                                }}
-                                            >
-                                                {fmtIEC(mem.used)}
-                                            </span>
-                                            <span className="iv-module-card__mem-limit">
-                                                {fmtIEC(mem.limit)}
-                                            </span>
-                                        </div>
-                                        <MemoryBar
-                                            used={mem.used}
-                                            limit={mem.limit}
-                                            height={4}
-                                            cells={20}
-                                        />
-                                    </div>
-                                );
-                            })()}
-                        </div>
-                    );
-                })}
-            </div>
-        </div>
-    );
+const chrome: ModuleCardsChrome = {
+    rootId: 'iv-section-modules',
+    rootClass: 'iv-module-strip',
+    headClass: 'iv-module-strip__header',
+    labelClass: 'iv-label',
+    countClass: 'iv-label__count',
+    legendClass: 'iv-module-strip__legend',
+    gridClass: 'iv-module-strip__grid',
+    gridTemplateColumns: (n) => `repeat(${n || 1}, minmax(0, 1fr))`,
+    cardClass: 'iv-module-card',
+    dotClass: 'iv-dot',
+    memUsedStyle: (used) => ({
+        color: used > 0 ? 'var(--iv-text)' : 'var(--iv-mute)',
+    }),
+    memLimitClass: 'iv-module-card__mem-limit',
 };
+
+/** Horizontal strip showing all dataplane modules with usage indicators. */
+export const ModuleStrip: React.FC<ModuleStripProps> = ({ instance, usage }) => (
+    <ModuleCardsGrid instance={instance} usage={usage} chrome={chrome} />
+);


### PR DESCRIPTION
- Unifies the near-duplicate module card grid of the inspect page and the dashboard page into one shared renderer parameterized by a chrome config object.
- Preserves each page's intentional differences exactly: column cap formula, root element id, class-based versus inline styling and numeric formatting details.
- Reduces the two components to thin wrappers holding their chrome constants.