### PR TITLE
refactor(web): extract shared throughput hook and clickable-card mixin

### DIFF
--- a/web/src/pages/builtin/dashboard/Throughput.tsx
+++ b/web/src/pages/builtin/dashboard/Throughput.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import type { DeviceCounterData } from '../../../hooks';
-import { useRollingSeries } from '../inspect/hooks';
+import { useAggregateThroughput, useRollingSeries } from '../inspect/hooks';
 import { Sparkline } from '../inspect/Sparkline';
 import { fmtBps, fmtPps } from '../inspect/formatters';
 
@@ -11,16 +11,7 @@ export interface ThroughputProps {
 
 /** Aggregate throughput hero with a full-width sparkline beneath. */
 export const Throughput: React.FC<ThroughputProps> = ({ rateCounters, physicalDeviceNames }) => {
-    const { aggregatePps, aggregateBps } = useMemo(() => {
-        let pps = 0;
-        let bps = 0;
-        rateCounters.forEach((d, name) => {
-            if (!physicalDeviceNames.has(name)) return;
-            pps += d.rx?.pps ?? 0;
-            bps += d.rx?.bps ?? 0;
-        });
-        return { aggregatePps: pps, aggregateBps: bps };
-    }, [rateCounters, physicalDeviceNames]);
+    const { aggregatePps, aggregateBps } = useAggregateThroughput(rateCounters, physicalDeviceNames);
 
     const throughputSeries = useRollingSeries(aggregatePps, 60);
 

--- a/web/src/pages/builtin/dashboard/dashboard.scss
+++ b/web/src/pages/builtin/dashboard/dashboard.scss
@@ -509,18 +509,7 @@
     }
 
     &--clickable {
-        cursor: pointer;
-
-        &:hover {
-            border-top-color: var(--iv-text-dim);
-            border-right-color: var(--iv-text-dim);
-            border-bottom-color: var(--iv-text-dim);
-        }
-
-        &:focus-visible {
-            outline: 1px solid var(--iv-accent);
-            outline-offset: 1px;
-        }
+        @include module-card-clickable;
     }
 
     &__top {

--- a/web/src/pages/builtin/inspect/HudHero.tsx
+++ b/web/src/pages/builtin/inspect/HudHero.tsx
@@ -1,7 +1,7 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import type { InstanceInfo } from '../../../api/inspect';
 import type { DeviceCounterData } from '../../../hooks';
-import { useRollingSeries } from './hooks';
+import { useAggregateThroughput, useRollingSeries } from './hooks';
 import { HeroSparkline } from './HeroSparkline';
 import { Crosshair } from './Crosshair';
 import { RadialPulse } from './RadialPulse';
@@ -67,16 +67,7 @@ export const HudHero: React.FC<HudHeroProps> = ({
     const modules = instance.dp_modules ?? [];
     const configs = instance.cp_configs ?? [];
 
-    const { aggregatePps, aggregateBps } = useMemo(() => {
-        let pps = 0;
-        let bps = 0;
-        rateCounters.forEach((d, name) => {
-            if (!physicalDeviceNames.has(name)) return;
-            pps += d.rx?.pps ?? 0;
-            bps += d.rx?.bps ?? 0;
-        });
-        return { aggregatePps: pps, aggregateBps: bps };
-    }, [rateCounters, physicalDeviceNames]);
+    const { aggregatePps, aggregateBps } = useAggregateThroughput(rateCounters, physicalDeviceNames);
 
     const throughputSeries = useRollingSeries(aggregatePps, 90);
 

--- a/web/src/pages/builtin/inspect/hooks.ts
+++ b/web/src/pages/builtin/inspect/hooks.ts
@@ -6,6 +6,28 @@ import { useInterpolatedCounters } from '../../../hooks/useInterpolatedCounters'
 import { useRollingWindow } from '../../../hooks/useRollingWindow';
 import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../../../utils';
 
+/**
+ * Aggregate RX packet-rate and bit-rate across physical devices only.
+ *
+ * Filters by physicalDeviceNames to avoid double-counting traffic that also
+ * appears on stacked virtual devices (e.g. vlan).
+ */
+export const useAggregateThroughput = (
+    rateCounters: Map<string, DeviceCounterData>,
+    physicalDeviceNames: Set<string>,
+): { aggregatePps: number; aggregateBps: number } => {
+    return useMemo(() => {
+        let pps = 0;
+        let bps = 0;
+        rateCounters.forEach((d, name) => {
+            if (!physicalDeviceNames.has(name)) return;
+            pps += d.rx?.pps ?? 0;
+            bps += d.rx?.bps ?? 0;
+        });
+        return { aggregatePps: pps, aggregateBps: bps };
+    }, [rateCounters, physicalDeviceNames]);
+};
+
 const DEFAULT_INTERVAL_MS = 1500;
 const DEFAULT_MAX_LEN = 30;
 

--- a/web/src/pages/builtin/inspect/inspect.scss
+++ b/web/src/pages/builtin/inspect/inspect.scss
@@ -336,18 +336,7 @@
         gap: 2px;
 
         &--clickable {
-            cursor: pointer;
-
-            &:hover {
-                border-top-color: var(--iv-text-dim);
-                border-right-color: var(--iv-text-dim);
-                border-bottom-color: var(--iv-text-dim);
-            }
-
-            &:focus-visible {
-                outline: 1px solid var(--iv-accent);
-                outline-offset: 1px;
-            }
+            @include module-card-clickable;
         }
 
         &--active {

--- a/web/src/styles/_iv-tokens.scss
+++ b/web/src/styles/_iv-tokens.scss
@@ -45,6 +45,21 @@
     letter-spacing: 1.6px;
 }
 
+@mixin module-card-clickable {
+    cursor: pointer;
+
+    &:hover {
+        border-top-color: var(--iv-text-dim);
+        border-right-color: var(--iv-text-dim);
+        border-bottom-color: var(--iv-text-dim);
+    }
+
+    &:focus-visible {
+        outline: 1px solid var(--iv-accent);
+        outline-offset: 1px;
+    }
+}
+
 @mixin iv-thin-scrollbar($thumb-radius: null) {
     scrollbar-width: thin;
     scrollbar-color: var(--iv-border-strong) transparent;


### PR DESCRIPTION
- Extracts the aggregate throughput computation duplicated between the dashboard hero and the inspect hero into a shared hook that sums RX rates across physical devices only.
- Extracts the identical clickable module-card style block of the dashboard and inspect pages into a shared mixin in the iv-tokens partial.
- Emitted CSS is byte-identical: the dist stylesheet hash sets match the baseline exactly.