### PR TITLE
refactor(web): dedupe lane add-button styles, counter map and reducer helper

### DIFF
--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -51,3 +51,5 @@ export type { UseRowDraftParams, UseRowDraftResult, RowDraftHandle } from './use
 
 export { useLaneTrackDnD } from './useLaneTrackDnD';
 export type { UseLaneTrackDnDOptions, UseLaneTrackDnDResult } from './useLaneTrackDnD';
+
+export { useInterpolatedCounterMap } from './useInterpolatedCounterMap';

--- a/web/src/hooks/useInterpolatedCounterMap.ts
+++ b/web/src/hooks/useInterpolatedCounterMap.ts
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import type { InterpolatedCounterData } from './useInterpolatedCounters';
+
+/**
+ * Copies a counters map into a new Map for stable identity and memoized lookup.
+ */
+export const useInterpolatedCounterMap = (
+    counters: Map<string, InterpolatedCounterData>,
+): Map<string, InterpolatedCounterData> =>
+    useMemo(() => {
+        const map = new Map<string, InterpolatedCounterData>();
+        for (const [key, val] of counters.entries()) {
+            map.set(key, val);
+        }
+        return map;
+    }, [counters]);

--- a/web/src/pages/builtin/functions/FunctionsPage.scss
+++ b/web/src/pages/builtin/functions/FunctionsPage.scss
@@ -1,5 +1,6 @@
 @use '../../../styles/variables' as *;
 @use '../../../styles/mixins' as *;
+@use '../../../styles/lane-chrome' as lane-chrome;
 @use '../_shared/lane-editor/lane-editor';
 @use '../_shared/lane-editor/palette' as palette;
 
@@ -254,26 +255,7 @@
 // ─── Add module / chain ghost buttons ─────────────────────────────────────────
 
 .fn-add-module-btn {
-    background: var(--fn-bg-2);
-    border: 1px dashed var(--fn-line-2);
-    border-radius: var(--fn-r-md);
-    color: var(--fn-text-3);
-    font-size: 12px;
-    font-family: var(--fn-font-ui);
-    padding: 10px 14px;
-    cursor: pointer;
-    white-space: nowrap;
-    flex-shrink: 0;
-    margin-left: 8px;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    transition: border-color 0.12s, color 0.12s;
-
-    &:hover {
-        border-color: var(--fn-accent);
-        color: var(--fn-accent);
-    }
+    @include lane-chrome.lane-add-btn('fn');
 }
 
 // ─── Inline edit ──────────────────────────────────────────────────────────────

--- a/web/src/pages/builtin/functions/components/FunctionCard.tsx
+++ b/web/src/pages/builtin/functions/components/FunctionCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
+import { useInterpolatedCounterMap } from '../../../../hooks';
 import type { NetworkFunction, FunctionsAction, DragPayload, Module, Chain } from '../types';
 import { useModuleCounters, type ModuleInfo } from '../hooks/useModuleCounters';
 import { getDragPayload, useSparklineHistory } from '../../_shared/lane-editor';
@@ -8,7 +9,6 @@ import { Lane } from './Lane';
 import { AddChainButton } from './AddChainButton';
 import { Drawer } from './Drawer';
 import { DiffModal } from './DiffModal';
-import type { InterpolatedCounterData } from '../../../../hooks';
 
 interface FunctionCardProps {
     fn: NetworkFunction;
@@ -85,13 +85,7 @@ export const FunctionCard: React.FC<FunctionCardProps> = ({
 
     const { counters } = useModuleCounters(fn.id, moduleInfoList);
 
-    const counterMap: Map<string, InterpolatedCounterData> = useMemo(() => {
-        const map = new Map<string, InterpolatedCounterData>();
-        for (const [key, val] of counters.entries()) {
-            map.set(key, val);
-        }
-        return map;
-    }, [counters]);
+    const counterMap = useInterpolatedCounterMap(counters);
 
     const totalPps = useMemo(() => {
         let sum = 0;

--- a/web/src/pages/builtin/functions/reducer.ts
+++ b/web/src/pages/builtin/functions/reducer.ts
@@ -1,4 +1,4 @@
-import type { NetworkFunction, Chain, FunctionsAction } from './types';
+import type { NetworkFunction, Chain, Module, FunctionsAction } from './types';
 import { localToApi } from './wire';
 import type { EntityState, BaseEntityAction } from '../_shared/editableEntityStore';
 import {
@@ -16,6 +16,26 @@ const findFn = (state: FunctionsState, fnId: string): NetworkFunction | undefine
 
 const updateFn = (state: FunctionsState, fnId: string, updated: NetworkFunction): FunctionsState =>
     applyEntityUpdate(state, fnId, updated, localToApi);
+
+const updateModuleIn = (
+    state: FunctionsState,
+    fnId: string,
+    moduleId: string,
+    transform: (m: Module) => Module,
+): FunctionsState => {
+    const fn = findFn(state, fnId);
+    if (!fn) {
+        return state;
+    }
+    const updated: NetworkFunction = {
+        ...fn,
+        chains: fn.chains.map(c => ({
+            ...c,
+            modules: c.modules.map(m => (m.id === moduleId ? transform(m) : m)),
+        })),
+    };
+    return updateFn(state, fnId, updated);
+};
 
 const mapChains = (fn: NetworkFunction, chainId: string, mapper: (c: Chain) => Chain): NetworkFunction => ({
     ...fn,
@@ -116,39 +136,11 @@ export const functionsReducer = (
             return updateFn(state, action.fnId, updated);
         }
 
-        case 'RENAME_MODULE': {
-            const fn = findFn(state, action.fnId);
-            if (!fn) {
-                return state;
-            }
-            const updated: NetworkFunction = {
-                ...fn,
-                chains: fn.chains.map(c => ({
-                    ...c,
-                    modules: c.modules.map(m =>
-                        m.id === action.moduleId ? { ...m, name: action.name } : m
-                    ),
-                })),
-            };
-            return updateFn(state, action.fnId, updated);
-        }
+        case 'RENAME_MODULE':
+            return updateModuleIn(state, action.fnId, action.moduleId, m => ({ ...m, name: action.name }));
 
-        case 'UPDATE_MODULE_CONFIG': {
-            const fn = findFn(state, action.fnId);
-            if (!fn) {
-                return state;
-            }
-            const updated: NetworkFunction = {
-                ...fn,
-                chains: fn.chains.map(c => ({
-                    ...c,
-                    modules: c.modules.map(m =>
-                        m.id === action.moduleId ? { ...m, ...action.patch } : m
-                    ),
-                })),
-            };
-            return updateFn(state, action.fnId, updated);
-        }
+        case 'UPDATE_MODULE_CONFIG':
+            return updateModuleIn(state, action.fnId, action.moduleId, m => ({ ...m, ...action.patch }));
 
         case 'UPDATE_CHAIN': {
             const fn = findFn(state, action.fnId);

--- a/web/src/pages/builtin/pipelines/PipelinesPage.scss
+++ b/web/src/pages/builtin/pipelines/PipelinesPage.scss
@@ -1,5 +1,6 @@
 @use '../../../styles/variables' as *;
 @use '../../../styles/mixins' as *;
+@use '../../../styles/lane-chrome' as lane-chrome;
 @use '../_shared/lane-editor/lane-editor';
 @use '../_shared/lane-editor/palette' as palette;
 
@@ -76,26 +77,7 @@
 // ─── Add function ref ghost button ────────────────────────────────────────────
 
 .pl-add-ref-btn {
-    background: var(--pl-bg-2);
-    border: 1px dashed var(--pl-line-2);
-    border-radius: var(--pl-r-md);
-    color: var(--pl-text-3);
-    font-size: 12px;
-    font-family: var(--pl-font-ui);
-    padding: 10px 14px;
-    cursor: pointer;
-    white-space: nowrap;
-    flex-shrink: 0;
-    margin-left: 8px;
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    transition: border-color 0.12s, color 0.12s;
-
-    &:hover {
-        border-color: var(--pl-accent);
-        color: var(--pl-accent);
-    }
+    @include lane-chrome.lane-add-btn('pl');
 }
 
 @include palette.lane-drawer('pl');

--- a/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
+++ b/web/src/pages/builtin/pipelines/components/PipelineCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
+import { useInterpolatedCounterMap } from '../../../../hooks';
 import type { Pipeline, PipelinesAction, DragPayload, FunctionRef } from '../types';
 import { useFunctionRefCounters, type FunctionRefInfo, PIPELINE_COUNTER_KEY } from '../hooks/useFunctionRefCounters';
 import { getDragPayload, useSparklineHistory } from '../../_shared/lane-editor';
@@ -6,7 +7,6 @@ import { PipelineCardHeader } from './PipelineCardHeader';
 import { LaneTrack } from './LaneTrack';
 import { Drawer } from './Drawer';
 import { DiffModal } from './DiffModal';
-import type { InterpolatedCounterData } from '../../../../hooks';
 import type { FunctionId } from '../../../../api/pipelines';
 import type { DragState } from '../../_shared/lane-editor';
 
@@ -60,13 +60,7 @@ export const PipelineCard: React.FC<PipelineCardProps> = ({
 
     const { counters } = useFunctionRefCounters(pipeline.id, refInfoList);
 
-    const counterMap: Map<string, InterpolatedCounterData> = useMemo(() => {
-        const map = new Map<string, InterpolatedCounterData>();
-        for (const [key, val] of counters.entries()) {
-            map.set(key, val);
-        }
-        return map;
-    }, [counters]);
+    const counterMap = useInterpolatedCounterMap(counters);
 
     const totalPps = useMemo(() => {
         if (pipeline.functions.length === 0) {

--- a/web/src/styles/_lane-chrome.scss
+++ b/web/src/styles/_lane-chrome.scss
@@ -1,0 +1,22 @@
+@mixin lane-add-btn($p) {
+    background: var(--#{$p}-bg-2);
+    border: 1px dashed var(--#{$p}-line-2);
+    border-radius: var(--#{$p}-r-md);
+    color: var(--#{$p}-text-3);
+    font-size: 12px;
+    font-family: var(--#{$p}-font-ui);
+    padding: 10px 14px;
+    cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin-left: 8px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: border-color 0.12s, color 0.12s;
+
+    &:hover {
+        border-color: var(--#{$p}-accent);
+        color: var(--#{$p}-accent);
+    }
+}


### PR DESCRIPTION
- Extracts the identical add-button style blocks of the functions and pipelines pages into a prefix-parameterized mixin; emitted CSS is byte-identical to the baseline.
- Extracts the duplicated interpolated-counter map construction of the function and pipeline cards into a shared hook.
- Collapses two structurally identical module-update cases in the functions reducer into a local helper.