### PR TITLE
fix(web): gate draft config creation on a successful load

### DIFF
--- a/web/src/components/ConfigTabStrip.tsx
+++ b/web/src/components/ConfigTabStrip.tsx
@@ -16,6 +16,8 @@ export interface ConfigTabStripProps {
     onSelect: (configName: string) => void;
     /** Called when the user clicks the "+" add-config button. */
     onAddConfig: () => void;
+    /** When true the "+" add-config button is rendered disabled. */
+    addConfigDisabled?: boolean;
     /** Accessible label for the "add config" button tooltip. Defaults to "Add config". */
     addLabel?: string;
     /** Optional leading icon renderer — return a node to prepend before the tab label. */
@@ -36,6 +38,7 @@ export const ConfigTabStrip: React.FC<ConfigTabStripProps> = ({
     dirtyConfigs,
     onSelect,
     onAddConfig,
+    addConfigDisabled,
     addLabel = 'Add config',
     leadingIcon,
     trailingIcon,
@@ -59,7 +62,7 @@ export const ConfigTabStrip: React.FC<ConfigTabStripProps> = ({
                 <span className="yn-tab__count">{counts.get(cfg) ?? 0}</span>
             </button>
         ))}
-        <Button view="flat" size="s" onClick={onAddConfig} className="yn-tabs__add" title={addLabel}>
+        <Button view="flat" size="s" onClick={onAddConfig} disabled={addConfigDisabled} className="yn-tabs__add" title={addLabel}>
             <Icon data={Plus} size={14} />
         </Button>
     </div>

--- a/web/src/components/EmptyPagePlaceholder.tsx
+++ b/web/src/components/EmptyPagePlaceholder.tsx
@@ -5,12 +5,14 @@ export interface EmptyPagePlaceholderProps {
     message: string;
     actionLabel: string;
     onAction: () => void;
+    /** When true the action button is rendered disabled. Omit or pass false to keep it enabled. */
+    actionDisabled?: boolean;
 }
 
 /** Full-page placeholder shown when a module/operator page has no configs yet. */
-export const EmptyPagePlaceholder: React.FC<EmptyPagePlaceholderProps> = ({ message, actionLabel, onAction }) => (
+export const EmptyPagePlaceholder: React.FC<EmptyPagePlaceholderProps> = ({ message, actionLabel, onAction, actionDisabled }) => (
     <div className="yn-empty-page">
         <div className="yn-empty-page__message">{message}</div>
-        <Button view="action" onClick={onAction}>{actionLabel}</Button>
+        <Button view="action" onClick={onAction} disabled={actionDisabled}>{actionLabel}</Button>
     </div>
 );

--- a/web/src/components/command-palette/configCommands.ts
+++ b/web/src/components/command-palette/configCommands.ts
@@ -14,6 +14,8 @@ export interface ConfigCommandsOptions {
     withKeywords?: boolean;
     /** Called when the user selects "Add config". */
     onAddConfig: () => void;
+    /** When true the "Add config" command is omitted from the palette. */
+    addConfigDisabled?: boolean;
     /** Called when the user selects "Delete config". */
     onDeleteConfig: () => void;
     /** Called with the target config name when the user selects a switch item. */
@@ -34,20 +36,23 @@ export const buildConfigCommands = (options: ConfigCommandsOptions): Command[] =
         addConfigSub,
         withKeywords,
         onAddConfig,
+        addConfigDisabled,
         onDeleteConfig,
         onSwitchConfig,
     } = options;
 
     const list: Command[] = [];
 
-    list.push({
-        id: '__add_config',
-        icon: '▤',
-        label: 'Add config',
-        sub: addConfigSub,
-        keywords: withKeywords ? 'add config create new' : undefined,
-        onSelect: onAddConfig,
-    });
+    if (!addConfigDisabled) {
+        list.push({
+            id: '__add_config',
+            icon: '▤',
+            label: 'Add config',
+            sub: addConfigSub,
+            keywords: withKeywords ? 'add config create new' : undefined,
+            onSelect: onAddConfig,
+        });
+    }
 
     if (currentConfig) {
         list.push({

--- a/web/src/components/draft/useDraft.ts
+++ b/web/src/components/draft/useDraft.ts
@@ -20,6 +20,8 @@ interface UseDraftOpts<T> {
 export interface UseDraftResult<T> {
     draftConfigs: string[];
     loading: boolean;
+    /** True when the initial load failed and no configs were seeded; cleared on a successful reload. */
+    loadFailed: boolean;
     draftRows: (configName: string) => T[];
     serverRows: (configName: string) => T[];
     isDirty: (configName: string) => boolean;
@@ -47,6 +49,7 @@ export function useDraft<T extends { id?: unknown }>({
 }: UseDraftOpts<T>): UseDraftResult<T> {
     const [state, rawDispatch] = useReducer(reducer, initialState);
     const [loading, setLoading] = useState(true);
+    const [loadFailed, setLoadFailed] = useState(false);
 
     const dispatchDraft = useCallback((action: DraftAction<T>): void => {
         rawDispatch(action);
@@ -57,8 +60,10 @@ export function useDraft<T extends { id?: unknown }>({
         try {
             const configs = await load();
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });
+            setLoadFailed(false);
         } catch (err) {
             toaster.error(`${toastSubject}-draft-load`, `Failed to load ${errorSubject} configurations`, err);
+            setLoadFailed(true);
         } finally {
             setLoading(false);
         }
@@ -114,6 +119,7 @@ export function useDraft<T extends { id?: unknown }>({
     return {
         draftConfigs,
         loading,
+        loadFailed,
         draftRows: draftRowsFor,
         serverRows: serverRowsFor,
         isDirty,

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -31,7 +31,7 @@ const prefixRowsEqual = (s: PrefixRowItem, r: PrefixRowItem): boolean =>
 
 const DecapPage: React.FC = () => {
     const {
-        draftConfigs, loading, draftRows, serverRows, isDirty, anyDirty,
+        draftConfigs, loading, loadFailed, draftRows, serverRows, isDirty, anyDirty,
         dispatchDraft, commitConfig, discardConfig,
     } = usePrefixDraft();
 
@@ -99,6 +99,8 @@ const DecapPage: React.FC = () => {
         onDeleteRow: handlers.handleDeleteRow,
     });
 
+    const canCreate = !loading && !loadFailed;
+
     const commands = useMemo((): Command[] => {
         const list: Command[] = [
             {
@@ -135,6 +137,7 @@ const DecapPage: React.FC = () => {
             addConfigSub: 'Create a new decap configuration',
             withKeywords: true,
             onAddConfig: () => setAddConfigOpen(true),
+            addConfigDisabled: !canCreate,
             onDeleteConfig: () => setDeleteConfigOpen(true),
             onSwitchConfig: (name) => setActiveConfig(name),
         }));
@@ -147,7 +150,7 @@ const DecapPage: React.FC = () => {
         });
         return list;
     }, [
-        currentIsDirty, currentConfig, draftConfigs, dirtySet,
+        canCreate, currentIsDirty, currentConfig, draftConfigs, dirtySet,
         openAdd, handlers, setAddConfigOpen, setDeleteConfigOpen, setActiveConfig, updateParams,
     ]);
 
@@ -195,6 +198,7 @@ const DecapPage: React.FC = () => {
                         message="No decap configurations found."
                         actionLabel="Add Config"
                         onAction={() => setAddConfigOpen(true)}
+                        actionDisabled={!canCreate}
                     />
                 ) : (
                     <>
@@ -205,6 +209,7 @@ const DecapPage: React.FC = () => {
                             dirtyConfigs={dirtySet}
                             onSelect={setActiveConfig}
                             onAddConfig={() => setAddConfigOpen(true)}
+                            addConfigDisabled={!canCreate}
                         />
                         <div className="yn-toolbar-bordered">
                             <div style={{ flex: 1 }} />

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -34,6 +34,7 @@ const ForwardPage: React.FC = () => {
     const {
         draftConfigs,
         loading,
+        loadFailed,
         draftRules,
         serverRules,
         isDirty,
@@ -232,6 +233,8 @@ const ForwardPage: React.FC = () => {
         enabled: !loading,
     });
 
+    const canCreate = !loading && !loadFailed;
+
     const currentIsDirty = isDirty(currentConfig);
 
     const commands = useMemo((): Command[] => {
@@ -270,6 +273,7 @@ const ForwardPage: React.FC = () => {
             addConfigSub: 'Create a new forward configuration',
             withKeywords: true,
             onAddConfig: () => setAddConfigOpen(true),
+            addConfigDisabled: !canCreate,
             onDeleteConfig: () => setDeleteConfigOpen(true),
             onSwitchConfig: (name) => handleTabSelect(name),
         }));
@@ -302,7 +306,7 @@ const ForwardPage: React.FC = () => {
             onSelect: () => { setModeFilter('all'); handleSearchChange(''); },
         });
         return list;
-    }, [currentIsDirty, currentConfig, draftConfigs, dirtySet, handleTabSelect, openAdd, handleSavePress, handleDiscard, handleSearchChange]);
+    }, [canCreate, currentIsDirty, currentConfig, draftConfigs, dirtySet, handleTabSelect, openAdd, handleSavePress, handleDiscard, handleSearchChange]);
 
     const rowAdapter = useMemo((): RowAdapter<RuleItem> => ({
         rows: allItems,
@@ -362,6 +366,7 @@ const ForwardPage: React.FC = () => {
                         message="No forward configurations found."
                         actionLabel="Add Config"
                         onAction={() => setAddConfigOpen(true)}
+                        actionDisabled={!canCreate}
                     />
                 ) : (
                     <>
@@ -372,6 +377,7 @@ const ForwardPage: React.FC = () => {
                             dirtyConfigs={dirtySet}
                             onSelect={handleTabSelect}
                             onAddConfig={() => setAddConfigOpen(true)}
+                            addConfigDisabled={!canCreate}
                         />
 
                         <div className="yn-toolbar-bordered">

--- a/web/src/pages/modules/forward/useForwardDraft.ts
+++ b/web/src/pages/modules/forward/useForwardDraft.ts
@@ -73,12 +73,8 @@ export const useForwardDraft = (): UseForwardDraftResult => {
 
             const configs: Array<{ name: string; rules: Rule[] }> = await Promise.all(
                 forwardNames.map(async (name): Promise<{ name: string; rules: Rule[] }> => {
-                    try {
-                        const resp = await API.forward.showConfig({ name });
-                        return { name, rules: resp.rules ?? [] };
-                    } catch {
-                        return { name, rules: [] };
-                    }
+                    const resp = await API.forward.showConfig({ name });
+                    return { name, rules: resp.rules ?? [] };
                 }),
             );
 

--- a/web/src/pages/modules/forward/useForwardDraft.ts
+++ b/web/src/pages/modules/forward/useForwardDraft.ts
@@ -22,6 +22,8 @@ export interface UseForwardDraftResult {
     draftConfigs: string[];
     /** Loading flag — true until the first server fetch completes. */
     loading: boolean;
+    /** True when the initial load failed and no configs were seeded; cleared on a successful reload. */
+    loadFailed: boolean;
     /** Returns the current draft rules for a config. */
     draftRules: (configName: string) => Rule[];
     /** Returns the server snapshot rules for a config. */
@@ -56,6 +58,7 @@ export interface UseForwardDraftResult {
 export const useForwardDraft = (): UseForwardDraftResult => {
     const [state, rawDispatch] = useReducer(forwardDraftReducer, initialDraftState);
     const [loading, setLoading] = useState(true);
+    const [loadFailed, setLoadFailed] = useState(false);
 
     const dispatchDraft = useCallback((action: ForwardDraftAction): void => {
         rawDispatch(action);
@@ -79,8 +82,10 @@ export const useForwardDraft = (): UseForwardDraftResult => {
             );
 
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });
+            setLoadFailed(false);
         } catch (err) {
             toaster.error('yn-draft-load', 'Failed to load forward configurations', err);
+            setLoadFailed(true);
         } finally {
             setLoading(false);
         }
@@ -146,6 +151,7 @@ export const useForwardDraft = (): UseForwardDraftResult => {
     return {
         draftConfigs,
         loading,
+        loadFailed,
         draftRules: draftRulesFor,
         serverRules: serverRulesFor,
         isDirty,

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -39,7 +39,7 @@ const fibRowsEqual = (s: FIBRowItem, r: FIBRowItem): boolean =>
 
 const RoutePage: React.FC = () => {
     const {
-        draftConfigs, loading, draftRows, serverRows, isDirty, anyDirty,
+        draftConfigs, loading, loadFailed, draftRows, serverRows, isDirty, anyDirty,
         dispatchDraft, commitConfig, discardConfig,
     } = useFIBDraft();
 
@@ -115,6 +115,8 @@ const RoutePage: React.FC = () => {
         onDeleteRow: handlers.handleDeleteRow,
     });
 
+    const canCreate = !loading && !loadFailed;
+
     const commands = useMemo((): Command[] => {
         const list: Command[] = [
             {
@@ -144,6 +146,7 @@ const RoutePage: React.FC = () => {
             draftConfigs,
             dirtySet,
             onAddConfig: () => setAddConfigOpen(true),
+            addConfigDisabled: !canCreate,
             onDeleteConfig: () => setDeleteConfigOpen(true),
             onSwitchConfig: (name) => handleConfigSelect(name),
         }));
@@ -157,7 +160,7 @@ const RoutePage: React.FC = () => {
             });
         }
         return list;
-    }, [currentIsDirty, currentConfig, draftConfigs, dirtySet, search, handlers, handleConfigSelect, handleSearchChange, openAdd]);
+    }, [canCreate, currentIsDirty, currentConfig, draftConfigs, dirtySet, search, handlers, handleConfigSelect, handleSearchChange, openAdd]);
 
     const dynamicCommands = useCallback((q: string): Command[] => {
         if (isValidCIDR(q.trim())) {
@@ -229,6 +232,7 @@ const RoutePage: React.FC = () => {
                         message="No FIB configurations found."
                         actionLabel="Add Config"
                         onAction={() => setAddConfigOpen(true)}
+                        actionDisabled={!canCreate}
                     />
                 ) : (
                     <>
@@ -239,6 +243,7 @@ const RoutePage: React.FC = () => {
                             dirtyConfigs={dirtySet}
                             onSelect={handleConfigSelect}
                             onAddConfig={() => setAddConfigOpen(true)}
+                            addConfigDisabled={!canCreate}
                         />
                         <div className="yn-toolbar-bordered">
                             <div style={{ flex: 1 }} />

--- a/web/src/pages/modules/route/useFIBDraft.ts
+++ b/web/src/pages/modules/route/useFIBDraft.ts
@@ -70,12 +70,8 @@ export const useFIBDraft = (): UseFIBDraftResult => {
         const configNames = configsResp.configs ?? [];
         return Promise.all(
             configNames.map(async (name): Promise<{ name: string; rows: FIBRowItem[] }> => {
-                try {
-                    const fibResp = await API.route.showFIB({ name });
-                    return { name, rows: flattenFIBEntries(fibResp.entries ?? []) };
-                } catch {
-                    return { name, rows: [] };
-                }
+                const fibResp = await API.route.showFIB({ name });
+                return { name, rows: flattenFIBEntries(fibResp.entries ?? []) };
             }),
         );
     }, []);


### PR DESCRIPTION
- A per-config load failure was silently swallowed by the forward and route draft loaders, seeding an empty set that a later save would push via the full-replace update, wiping the server config whose rules merely failed to load. Failed loads now propagate to the draft error handler and leave the state untouched.
- After a failed load the pages stayed interactive with an empty config list, so a config created under an existing server name would silently overwrite it on save. The draft hooks now report a failed load and the forward, decap and route pages disable config creation until a load succeeds.
- Same defect class as the decap loader fix in #1169.