### PR TITLE
refactor(web): collapse internal duplication in acl styles and the iso scene

### DIFF
--- a/web/src/pages/builtin/dashboard/IsoScene3D.tsx
+++ b/web/src/pages/builtin/dashboard/IsoScene3D.tsx
@@ -609,18 +609,28 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
             scene.add(grid);
         }
 
-        const wires: WireEntry[] = [];
-        structuralDevices.forEach((d) => {
-            if (!d.pipeIn) return;
+        const deviceEntry = (d: StructuralDevice): {
+            pi: number;
+            pts: THREE.Vector3[];
+        } | null => {
+            if (!d.pipeIn) return null;
             const pi = structuralPipelines.findIndex((p) => p.id === d.pipeIn);
-            if (pi < 0) return;
+            if (pi < 0) return null;
             const pos = devicePositions[d.id];
-            if (!pos) return;
+            if (!pos) return null;
             const pts = [
                 new THREE.Vector3(pos.x + devW, devH / 2, pos.z + devD / 2),
                 new THREE.Vector3(X0 - 6, devH / 2, pos.z + devD / 2),
                 new THREE.Vector3(X0, LANE_THICK + 1, pipeZ[pi]),
             ];
+            return { pi, pts };
+        };
+
+        const wires: WireEntry[] = [];
+        structuralDevices.forEach((d) => {
+            const entry = deviceEntry(d);
+            if (!entry) return;
+            const { pts } = entry;
             const geo = new THREE.BufferGeometry().setFromPoints(pts);
             const mat = new THREE.LineBasicMaterial({
                 color: 0x3a3731,
@@ -629,22 +639,15 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
             });
             const line = new THREE.Line(geo, mat);
             scene.add(line);
-            wires.push({ line, deviceId: d.id, pipeId: d.pipeIn });
+            wires.push({ line, deviceId: d.id, pipeId: d.pipeIn! });
         });
 
         const fwdPaths: FwdPath[] = [];
         structuralDevices.forEach((d) => {
-            if (!d.pipeIn) return;
-            const pi = structuralPipelines.findIndex((p) => p.id === d.pipeIn);
-            if (pi < 0) return;
-            const pos = devicePositions[d.id];
-            if (!pos) return;
-            const pts = [
-                new THREE.Vector3(pos.x + devW, devH / 2, pos.z + devD / 2),
-                new THREE.Vector3(X0 - 6, devH / 2, pos.z + devD / 2),
-                new THREE.Vector3(X0, LANE_THICK + 1, pipeZ[pi]),
-                new THREE.Vector3(X0 + LANE_LEN, LANE_THICK + 1, pipeZ[pi]),
-            ];
+            const entry = deviceEntry(d);
+            if (!entry) return;
+            const { pi, pts } = entry;
+            pts.push(new THREE.Vector3(X0 + LANE_LEN, LANE_THICK + 1, pipeZ[pi]));
             const lens: number[] = [];
             let total = 0;
             for (let i = 1; i < pts.length; i++) {

--- a/web/src/pages/modules/acl/acl.scss
+++ b/web/src/pages/modules/acl/acl.scss
@@ -5,6 +5,13 @@
 // web/src/styles/chrome.scss which this page imports. This file covers only
 // ACL-specific chip colors, action chain, editor elements, and override tweaks.
 
+@mixin diff-status-border {
+    &--add   { border-left: 3px solid var(--g-color-base-positive-medium); }
+    &--mod   { border-left: 3px solid var(--g-color-base-warning-medium); }
+    &--rem   { border-left: 3px solid var(--g-color-base-danger-medium); }
+    &--reord { border-left: 3px solid var(--g-color-base-misc-medium); }
+}
+
 // Chip list container.
 .acl-chip-list {
     display: inline-flex;
@@ -337,10 +344,7 @@
     overflow: hidden;
     border: 1px solid var(--yn-line);
 
-    &--add  { border-left: 3px solid var(--g-color-base-positive-medium); }
-    &--mod  { border-left: 3px solid var(--g-color-base-warning-medium); }
-    &--rem  { border-left: 3px solid var(--g-color-base-danger-medium); }
-    &--reord { border-left: 3px solid var(--g-color-base-misc-medium); }
+    @include diff-status-border;
 }
 
 .acl-diff-section-head {
@@ -392,10 +396,7 @@
     border-radius: 5px;
     overflow: hidden;
 
-    &--add  { border-left: 3px solid var(--g-color-base-positive-medium); }
-    &--mod  { border-left: 3px solid var(--g-color-base-warning-medium); }
-    &--rem  { border-left: 3px solid var(--g-color-base-danger-medium); }
-    &--reord { border-left: 3px solid var(--g-color-base-misc-medium); }
+    @include diff-status-border;
 }
 
 .acl-diff-card-ref {


### PR DESCRIPTION
- Extracts the repeated diff-status border modifiers in the acl stylesheet into a file-local mixin; emitted CSS is byte-identical to the baseline.
- Extracts the shared device wire-point prologue of the dashboard iso scene's wires and forwarding-path loops into a scope-local helper.