### PR TITLE
fix(controlplane): wait for dataplane shared memory before attaching

### DIFF
--- a/api/agent.h
+++ b/api/agent.h
@@ -64,6 +64,17 @@ yanet_shm_detach(struct yanet_shm *shm);
 struct dp_config *
 yanet_shm_dp_config(struct yanet_shm *shm, uint32_t instance_idx);
 
+// Returns 1 if the dataplane instance has finished initialising its shared
+// memory, 0 otherwise.
+//
+// Safe to call on a zeroed (not yet initialised) segment — the magic field
+// will simply read 0. Does not allocate an agent or acquire any lock.
+//
+// @param shm Handle to shared memory segment
+// @param instance_idx Index of the dataplane instance
+int
+agent_dp_config_ready(struct yanet_shm *shm, uint32_t instance_idx);
+
 // Attaches a module agent to shared memory.
 //
 // Creates a new agent for a specific module in the given dataplane instance.

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -70,6 +70,12 @@ func (m *SharedMemory) DPConfig(instanceIdx uint32) *DPConfig {
 	return &DPConfig{ptr: ptr}
 }
 
+// DataplaneReady reports whether the dataplane instance has finished
+// initializing its shared memory.
+func (m *SharedMemory) DataplaneReady(instanceIdx uint32) bool {
+	return C.agent_dp_config_ready(m.ptr, C.uint32_t(instanceIdx)) != 0
+}
+
 // AgentAttach attaches a module agent to shared memory on the dataplane instance.
 func (m *SharedMemory) AgentAttach(
 	name string,

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -2,15 +2,22 @@ package yncp
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 
+	"github.com/yanet-platform/yanet2/common/go/xbackoff"
 	"github.com/yanet-platform/yanet2/controlplane/builtin"
 	"github.com/yanet-platform/yanet2/controlplane/bundle"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/controlplane/gateway"
 )
+
+// dataplaneReadyTimeout is the maximum time NewDirector will wait for the
+// dataplane to finish initializing its shared memory before returning an error.
+const dataplaneReadyTimeout = 60 * time.Second
 
 type options struct {
 	Log      *zap.Logger
@@ -68,11 +75,36 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 	log.Info("initializing YANET controlplane ...")
 	log.Info("parsed config", zap.Any("config", cfg))
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to attach to shared memory %q: %w", cfg.MemoryPath, err)
+	log.Debug("waiting for dataplane shared memory",
+		zap.String("path", cfg.MemoryPath),
+		zap.Uint32("instance_id", cfg.Gateway.InstanceID),
+	)
+	waitCtx, cancel := context.WithTimeout(context.Background(), dataplaneReadyTimeout)
+	defer cancel()
+	var shm *ffi.SharedMemory
+	bo := xbackoff.New(100*time.Millisecond, xbackoff.WithMax(2*time.Second))
+	if err := bo.RunContext(waitCtx, func() error {
+		if shm == nil {
+			attached, err := ffi.AttachSharedMemory(cfg.MemoryPath)
+			if err != nil {
+				return fmt.Errorf("failed to attach to shared memory %q: %w", cfg.MemoryPath, err)
+			}
+			shm = attached
+		}
+		if !shm.DataplaneReady(cfg.Gateway.InstanceID) {
+			return errors.New("dataplane shared memory not ready")
+		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf(
+			"dataplane shared memory not ready after %s: %w",
+			dataplaneReadyTimeout,
+			err,
+		)
 	}
-	log.Debug("attached to shared memory", zap.String("path", cfg.MemoryPath))
+	log.Info("dataplane shared memory ready",
+		zap.Uint32("instance_id", cfg.Gateway.InstanceID),
+	)
 
 	bundle, err := bundle.NewBundle(cfg.Modules, cfg.Devices, log)
 	if err != nil {

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -498,6 +498,7 @@ dataplane_init(
 		}
 
 		cp_config_unlock(cp_config);
+		dp_config_mark_ready(dp_config);
 	}
 
 	return 0;

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -72,6 +72,19 @@ yanet_shm_dp_config(struct yanet_shm *shm, uint32_t instance_idx) {
 	return dp_config_nextk((struct dp_config *)shm, instance_idx);
 }
 
+int
+agent_dp_config_ready(struct yanet_shm *shm, uint32_t instance_idx) {
+	uint32_t count = __atomic_load_n(
+		&((struct dp_config *)shm)->instance_count, __ATOMIC_ACQUIRE
+	);
+	if (instance_idx >= count) {
+		return 0;
+	}
+	struct dp_config *dp_config = yanet_shm_dp_config(shm, instance_idx);
+	return __atomic_load_n(&dp_config->ready_magic, __ATOMIC_ACQUIRE) ==
+	       DP_CONFIG_READY_MAGIC;
+}
+
 uint32_t
 yanet_shm_instance_count(struct yanet_shm *shm) {
 	struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
@@ -97,6 +110,25 @@ agent_attach(
 	yanet_error **err
 ) {
 	struct dp_config *dp_config = yanet_shm_dp_config(shm, instance_idx);
+
+	// Guard against attaching before the dataplane finishes initialising
+	// the shared memory instance. A zeroed segment has ready_magic == 0,
+	// so ADDR_OF(&dp_config->cp_config) would yield NULL and the subsequent
+	// cp_config_lock call would fault. Acquire ordering pairs with the
+	// release store in dp_config_mark_ready, published once the dataplane
+	// has released cp_config, guaranteeing the cp_config offset pointer is
+	// fully visible once we pass this check.
+	uint64_t magic =
+		__atomic_load_n(&dp_config->ready_magic, __ATOMIC_ACQUIRE);
+	if (magic != DP_CONFIG_READY_MAGIC) {
+		yanet_error_add(
+			err,
+			"dataplane shared memory instance %u is not yet "
+			"initialised",
+			instance_idx
+		);
+		return NULL;
+	}
 
 	struct cp_config *cp_config = ADDR_OF(&dp_config->cp_config);
 
@@ -359,6 +391,19 @@ agent_reattach(
 	yanet_error **err
 ) {
 	struct dp_config *dp_config = yanet_shm_dp_config(shm, instance_idx);
+
+	// Same readiness guard as in agent_attach — see comment there.
+	uint64_t magic =
+		__atomic_load_n(&dp_config->ready_magic, __ATOMIC_ACQUIRE);
+	if (magic != DP_CONFIG_READY_MAGIC) {
+		yanet_error_add(
+			err,
+			"dataplane shared memory instance %u is not yet "
+			"initialised",
+			instance_idx
+		);
+		return NULL;
+	}
 
 	struct cp_config *cp_config = ADDR_OF(&dp_config->cp_config);
 

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -1,0 +1,248 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "api/agent.h"
+#include "common/memory_address.h"
+#include "common/test_assert.h"
+#include "controlplane/config/zone.h"
+#include "dataplane/config/agent.h"
+#include "dataplane/config/bootstrap.h"
+#include "dataplane/config/zone.h"
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+
+// Sizes chosen to be large enough for dp_storage_init internals but small
+// enough to keep the test fast and heap-only (no hugepages needed).
+#define TEST_DP_MEMORY (1 << 20)
+#define TEST_CP_MEMORY (1 << 20)
+#define TEST_STORAGE_SIZE (TEST_DP_MEMORY + TEST_CP_MEMORY)
+
+// Verify that agent_attach returns NULL with a non-NULL error when the
+// shared memory segment is zeroed (simulating the pre-init startup race).
+static int
+test_attach_zeroed_segment_returns_error() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct yanet_shm *shm = (struct yanet_shm *)storage;
+
+	yanet_error *err = NULL;
+	struct agent *result = agent_attach(shm, 0, "test-agent", 4096, &err);
+
+	TEST_ASSERT_NULL(
+		result, "agent_attach on zeroed segment must return NULL"
+	);
+	TEST_ASSERT_NOT_NULL(
+		err, "agent_attach on zeroed segment must set an error"
+	);
+
+	yanet_error_free(err);
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that the readiness sequence (dp_storage_init -> cp_config_unlock ->
+// dp_config_mark_ready) leaves ready_magic set and the cp_config offset
+// pointer navigable. This confirms the attach gate will open for a correctly
+// initialised segment.
+static int
+test_initialised_segment_magic_and_cp_config_valid() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp_config = NULL;
+	struct cp_config *cp_config = NULL;
+	int rc = dp_storage_init(
+		0,
+		0,
+		storage,
+		TEST_DP_MEMORY,
+		TEST_CP_MEMORY,
+		&dp_config,
+		&cp_config
+	);
+	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+
+	cp_config_unlock(cp_config);
+	dp_config_mark_ready(dp_config);
+
+	// The release store in dp_config_mark_ready must be visible once we
+	// load with acquire ordering.
+	uint64_t magic =
+		__atomic_load_n(&dp_config->ready_magic, __ATOMIC_ACQUIRE);
+	TEST_ASSERT(
+		magic == DP_CONFIG_READY_MAGIC,
+		"dp_config_mark_ready must write DP_CONFIG_READY_MAGIC"
+	);
+
+	// Confirm the cp_config offset pointer resolves to a non-NULL address,
+	// meaning ADDR_OF in agent_attach won't crash after passing the gate.
+	struct cp_config *resolved = ADDR_OF(&dp_config->cp_config);
+	TEST_ASSERT_NOT_NULL(
+		resolved, "cp_config offset must resolve to a non-NULL address"
+	);
+	TEST_ASSERT(
+		resolved == cp_config,
+		"resolved cp_config must match the value returned by "
+		"dp_storage_init"
+	);
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that agent_dp_config_ready returns 0 on a zeroed segment, where the
+// ready_magic field has never been written.
+static int
+test_ready_predicate_zeroed_segment_returns_false() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct yanet_shm *shm = (struct yanet_shm *)storage;
+	int ready = agent_dp_config_ready(shm, 0);
+	TEST_ASSERT(ready == 0, "predicate must return 0 on a zeroed segment");
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that agent_dp_config_ready returns 1 after the full readiness
+// sequence: dp_storage_init -> cp_config_unlock -> dp_config_mark_ready.
+// Also sets instance_count so the instance_idx bound check in the predicate
+// passes.
+static int
+test_ready_predicate_initialised_segment_returns_true() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp_config = NULL;
+	struct cp_config *cp_config = NULL;
+	int rc = dp_storage_init(
+		0,
+		0,
+		storage,
+		TEST_DP_MEMORY,
+		TEST_CP_MEMORY,
+		&dp_config,
+		&cp_config
+	);
+	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+
+	dp_config->instance_count = 1;
+	cp_config_unlock(cp_config);
+	dp_config_mark_ready(dp_config);
+
+	struct yanet_shm *shm = (struct yanet_shm *)storage;
+	int ready = agent_dp_config_ready(shm, 0);
+	TEST_ASSERT(
+		ready == 1,
+		"predicate must return 1 after the full readiness sequence"
+	);
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that agent_attach succeeds on a fully initialised segment. This
+// proves the attach gate opens once the instance is marked ready. Mirrors
+// the dataplane init sequence: dp_storage_init, system agent, cp_config_gen,
+// unlock, mark_ready.
+static int
+test_attach_initialised_segment_succeeds() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp_config = NULL;
+	struct cp_config *cp_config = NULL;
+	int rc = dp_storage_init(
+		0,
+		0,
+		storage,
+		TEST_DP_MEMORY,
+		TEST_CP_MEMORY,
+		&dp_config,
+		&cp_config
+	);
+	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+
+	// A system agent and cp_config_gen are required before agent_attach
+	// can succeed — agent_attach reads cp_config_gen->gen after locking.
+	struct agent *sys_agent =
+		dp_system_agent_new(cp_config, dp_config, "dataplane");
+	TEST_ASSERT_NOT_NULL(sys_agent, "dp_system_agent_new failed");
+
+	yanet_error *setup_err = NULL;
+	struct cp_config_gen *cp_config_gen =
+		cp_config_gen_create(sys_agent, &setup_err);
+	TEST_ASSERT_NOT_NULL(cp_config_gen, "cp_config_gen_create failed");
+	SET_OFFSET_OF(&cp_config->cp_config_gen, cp_config_gen);
+
+	dp_config->instance_count = 1;
+	cp_config_unlock(cp_config);
+	dp_config_mark_ready(dp_config);
+
+	struct yanet_shm *shm = (struct yanet_shm *)storage;
+	yanet_error *err = NULL;
+	struct agent *result = agent_attach(shm, 0, "test-agent", 4096, &err);
+
+	TEST_ASSERT_NOT_NULL(
+		result, "agent_attach must succeed on an initialised segment"
+	);
+	TEST_ASSERT_NULL(err, "agent_attach must not set an error on success");
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+int
+main() {
+	log_enable_name("error");
+
+	size_t tests_count = 0;
+	size_t tests_failed = 0;
+
+	++tests_count;
+	if (test_attach_zeroed_segment_returns_error() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_attach_zeroed_segment_returns_error failed");
+	}
+
+	++tests_count;
+	if (test_initialised_segment_magic_and_cp_config_valid() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_initialised_segment_magic_and_cp_config_valid failed"
+		);
+	}
+
+	++tests_count;
+	if (test_ready_predicate_zeroed_segment_returns_false() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_ready_predicate_zeroed_segment_returns_false failed");
+	}
+
+	++tests_count;
+	if (test_ready_predicate_initialised_segment_returns_true() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_ready_predicate_initialised_segment_returns_true "
+		    "failed");
+	}
+
+	++tests_count;
+	if (test_attach_initialised_segment_succeeds() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_attach_initialised_segment_succeeds failed");
+	}
+
+	if (tests_failed != 0) {
+		LOG(ERROR, "%zu/%zu tests failed", tests_failed, tests_count);
+		return 1;
+	}
+
+	return 0;
+}

--- a/lib/controlplane/agent/meson.build
+++ b/lib/controlplane/agent/meson.build
@@ -23,3 +23,14 @@ lib_agent_cp_dep = declare_dependency(
   dependencies: [lib_errors_dep],
   include_directories: yanet_libdir,
 )
+
+test_agent_attach = executable(
+  'agent_attach_test',
+  'agent_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [lib_agent_cp_dep, lib_config_dp_dep, lib_config_cp_dep, lib_logging_dep],
+  include_directories: yanet_rootdir,
+  link_language: 'c',
+)
+test('agent_attach', test_agent_attach, suite: ['lib'])

--- a/lib/dataplane/config/bootstrap.c
+++ b/lib/dataplane/config/bootstrap.c
@@ -83,3 +83,10 @@ dp_storage_init(
 
 	return 0;
 }
+
+void
+dp_config_mark_ready(struct dp_config *dp_config) {
+	__atomic_store_n(
+		&dp_config->ready_magic, DP_CONFIG_READY_MAGIC, __ATOMIC_RELEASE
+	);
+}

--- a/lib/dataplane/config/bootstrap.h
+++ b/lib/dataplane/config/bootstrap.h
@@ -22,3 +22,10 @@ dp_storage_init(
 	struct dp_config **res_dp_config,
 	struct cp_config **res_cp_config
 );
+
+// Publish the readiness marker for this instance.
+//
+// Call this after releasing cp_config, once the instance is fully initialised
+// and ready for attach.
+void
+dp_config_mark_ready(struct dp_config *dp_config);

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -67,6 +67,15 @@ struct dp_worker {
 	uint32_t queue_id;
 	uint32_t rx_burst_size;
 };
+
+// Value written to dp_config.ready_magic by dp_config_mark_ready once the
+// instance is fully initialised and cp_config has been released.
+//
+// The writer uses release ordering; readers use acquire ordering before
+// attempting to attach, so observing this value guarantees the instance is
+// ready and its cp_config lock is free.
+#define DP_CONFIG_READY_MAGIC UINT64_C(0xDEAD10CC00000001)
+
 struct dp_config {
 	uint32_t instance_count;
 	uint32_t instance_idx;
@@ -99,6 +108,14 @@ struct dp_config {
 	struct counter_storage_allocator counter_storage_allocator;
 	struct counter_registry worker_counters;
 	struct counter_storage *worker_counter_storage;
+
+	// Written by dp_config_mark_ready with release ordering after the
+	// dataplane releases cp_config and finishes initialising the instance.
+	//
+	// Readers check this with acquire ordering before attaching. Observing
+	// the magic guarantees the instance is fully initialised and that
+	// cp_config is not held, so an attacher will not block on the lock.
+	uint64_t ready_magic;
 };
 
 /*

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -244,6 +244,7 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	}
 
 	cp_config_unlock(ut->cp_config);
+	dp_config_mark_ready(ut->dp_config);
 
 	// Create the mock mempool now so step 2 can allocate mbufs.
 	ut->mempool = test_mempool_create();


### PR DESCRIPTION
The control plane crashed with a SIGSEGV at startup whenever it attached to the dataplane shared memory before the dataplane had finished initializing it — a startup ordering race present in both local dev and production (systemd orders the units but does not gate on shared-memory readiness).

The dataplane now publishes a readiness marker only after it has fully initialized an instance and released the configuration lock, so observing the marker guarantees the segment is complete and attachable. The agent attach path checks the marker with acquire ordering before touching the configuration and returns a clean, retryable error instead of dereferencing an uninitialized segment.

The control plane waits for the marker at startup (bounded and cancellable) before bringing modules up, so it self-heals regardless of start order instead of crashing or racing.

This appends a field to the dataplane configuration structure in shared memory, so the dataplane and control plane must be rebuilt and deployed together. A new control plane against an old dataplane refuses to attach until it times out, rather than crashing.

Unit tests cover the not-ready segment (clean error), the readiness predicate, and a successful attach once the instance is marked ready.