### PR TITLE
refactor(web): deduplicate dashboard type definitions

### DIFF
--- a/web/src/pages/builtin/dashboard/Inspector.tsx
+++ b/web/src/pages/builtin/dashboard/Inspector.tsx
@@ -4,61 +4,7 @@ import { IconPort, IconTag, IconFn } from '../inspect/icons';
 import { fmtPps, fmtBps, fmtIEC } from '../inspect/formatters';
 import type { AgentUsage } from '../inspect/utils';
 import { MemoryBar } from '../inspect/MemoryBar';
-
-export interface SelectedItem {
-    kind: 'device' | 'pipeline' | 'fn';
-    id: string;
-}
-
-/** Structural device data derived from instance topology only. */
-export interface StructuralDevice {
-    id: string;
-    name: string;
-    kind: 'plain' | 'vlan';
-    vlan?: number;
-    parent?: string;
-    mtu?: number;
-    speed?: string;
-    pipeIn?: string;
-    pipeOut?: string;
-}
-
-/** Structural pipeline data derived from instance topology only. */
-export interface StructuralPipeline {
-    id: string;
-    name: string;
-    fns: string[];
-}
-
-/** Structural function data derived from instance topology only. */
-export interface StructuralFunction {
-    id: string;
-    mod: string;
-    chains: number;
-}
-
-/** Live per-frame snapshot of rates, trends, and statuses. */
-export interface LiveSnapshot {
-    devicesById: Map<string, {
-        rxPps: number;
-        rxBps: number;
-        txPps: number;
-        txBps: number;
-        status: 'ok' | 'idle';
-        trendRx: number[];
-        trendTx: number[];
-    }>;
-    pipelinesById: Map<string, {
-        pps: number;
-        trend: number[];
-        status: 'ok' | 'idle';
-    }>;
-    functionsById: Map<string, {
-        pps: number;
-        trend: number[];
-        status: 'ok' | 'idle';
-    }>;
-}
+import type { SelectedItem, StructuralDevice, StructuralPipeline, StructuralFunction, LiveSnapshot } from './types';
 
 export interface InspectorProps {
     selected: SelectedItem;

--- a/web/src/pages/builtin/dashboard/IsoScene3D.tsx
+++ b/web/src/pages/builtin/dashboard/IsoScene3D.tsx
@@ -5,7 +5,7 @@ import type { DeviceCounterData, DeviceAbsoluteData } from '../../../hooks';
 import { usePipelineCounters, useFunctionCounters, useDeviceTrendSeries } from '../inspect/hooks';
 import { fmtPps } from '../inspect/formatters';
 import { Inspector } from './Inspector';
-import type { SelectedItem } from './Inspector';
+import type { SelectedItem, StructuralDevice, StructuralPipeline, StructuralFunction, LiveSnapshot } from './types';
 import type { AgentUsage } from '../inspect/utils';
 import { metaFor } from '../functions/moduleMeta';
 
@@ -92,56 +92,6 @@ interface ThreeRefs {
     labelSources: Omit<LabelInfo, 'sx' | 'sy'>[];
     wires: WireEntry[];
     sceneCenter: THREE.Vector3 | null;
-}
-
-/** Structural device data derived only from instance topology (no live counters). */
-interface StructuralDevice {
-    id: string;
-    name: string;
-    kind: 'plain' | 'vlan';
-    vlan?: number;
-    parent?: string;
-    mtu?: number;
-    speed?: string;
-    pipeIn?: string;
-    pipeOut?: string;
-}
-
-/** Structural pipeline data derived only from instance topology. */
-interface StructuralPipeline {
-    id: string;
-    name: string;
-    fns: string[];
-}
-
-/** Structural function data derived only from instance topology. */
-interface StructuralFunction {
-    id: string;
-    mod: string;
-    chains: number;
-}
-
-/** Per-frame live snapshot: rates, trends, statuses. Updated every counter tick. */
-interface LiveSnapshot {
-    devicesById: Map<string, {
-        rxPps: number;
-        rxBps: number;
-        txPps: number;
-        txBps: number;
-        status: 'ok' | 'idle';
-        trendRx: number[];
-        trendTx: number[];
-    }>;
-    pipelinesById: Map<string, {
-        pps: number;
-        trend: number[];
-        status: 'ok' | 'idle';
-    }>;
-    functionsById: Map<string, {
-        pps: number;
-        trend: number[];
-        status: 'ok' | 'idle';
-    }>;
 }
 
 // Reference pps denominator and maximum height multiplier for fn cubes.

--- a/web/src/pages/builtin/dashboard/index.ts
+++ b/web/src/pages/builtin/dashboard/index.ts
@@ -6,5 +6,5 @@ export { Throughput } from './Throughput';
 export { SystemState } from './SystemState';
 export { DataplaneModules } from './DataplaneModules';
 export { SceneErrorBoundary } from './SceneErrorBoundary';
-export type { StructuralDevice, StructuralPipeline, StructuralFunction, SelectedItem, LiveSnapshot } from './Inspector';
+export type { StructuralDevice, StructuralPipeline, StructuralFunction, SelectedItem, LiveSnapshot } from './types';
 export { default } from './DashboardPage';

--- a/web/src/pages/builtin/dashboard/types.ts
+++ b/web/src/pages/builtin/dashboard/types.ts
@@ -1,0 +1,56 @@
+/** Shared structural and live-snapshot types for the dashboard scene and inspector. */
+
+export interface SelectedItem {
+    kind: 'device' | 'pipeline' | 'fn';
+    id: string;
+}
+
+/** Structural device data derived from instance topology only. */
+export interface StructuralDevice {
+    id: string;
+    name: string;
+    kind: 'plain' | 'vlan';
+    vlan?: number;
+    parent?: string;
+    mtu?: number;
+    speed?: string;
+    pipeIn?: string;
+    pipeOut?: string;
+}
+
+/** Structural pipeline data derived from instance topology only. */
+export interface StructuralPipeline {
+    id: string;
+    name: string;
+    fns: string[];
+}
+
+/** Structural function data derived from instance topology only. */
+export interface StructuralFunction {
+    id: string;
+    mod: string;
+    chains: number;
+}
+
+/** Live per-frame snapshot of rates, trends, and statuses. */
+export interface LiveSnapshot {
+    devicesById: Map<string, {
+        rxPps: number;
+        rxBps: number;
+        txPps: number;
+        txBps: number;
+        status: 'ok' | 'idle';
+        trendRx: number[];
+        trendTx: number[];
+    }>;
+    pipelinesById: Map<string, {
+        pps: number;
+        trend: number[];
+        status: 'ok' | 'idle';
+    }>;
+    functionsById: Map<string, {
+        pps: number;
+        trend: number[];
+        status: 'ok' | 'idle';
+    }>;
+}


### PR DESCRIPTION
- Moves the dashboard structural and live-snapshot interfaces into a shared types module instead of keeping a private duplicate copy in the 3D scene component.
- Updates the inspector, the 3D scene, and the dashboard barrel to import the types from the new module.
- Type-only change: the emitted bundle is byte-identical to main.