### PR TITLE
refactor(web): deduplicate modal keyboard shortcut tests

### DIFF
--- a/web/src/components/BulkDeleteModal.test.tsx
+++ b/web/src/components/BulkDeleteModal.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import BulkDeleteModal from './BulkDeleteModal';
+import { describeDialogKeyboardShortcuts } from './dialogShortcutTests';
 
 describe('BulkDeleteModal', () => {
     afterEach(() => {
@@ -65,53 +66,16 @@ describe('BulkDeleteModal', () => {
         expect(screen.getByText(/Changes are staged in the draft/i)).toBeInTheDocument();
     });
 
-    it('calls onConfirm when Ctrl+Enter is pressed', () => {
-        const onConfirm = vi.fn();
-        render(
-            <BulkDeleteModal
-                open
-                count={3}
-                itemNoun="route"
-                configName="main"
-                onClose={() => {}}
-                onConfirm={onConfirm}
-            />,
-        );
-        fireEvent.keyDown(document, { key: 'Enter', ctrlKey: true });
-        expect(onConfirm).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls onConfirm when Cmd+Enter is pressed', () => {
-        const onConfirm = vi.fn();
-        render(
-            <BulkDeleteModal
-                open
-                count={3}
-                itemNoun="route"
-                configName="main"
-                onClose={() => {}}
-                onConfirm={onConfirm}
-            />,
-        );
-        fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
-        expect(onConfirm).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls onClose when Escape is pressed', () => {
-        const onClose = vi.fn();
-        render(
-            <BulkDeleteModal
-                open
-                count={3}
-                itemNoun="route"
-                configName="main"
-                onClose={onClose}
-                onConfirm={() => {}}
-            />,
-        );
-        fireEvent.keyDown(document, { key: 'Escape' });
-        expect(onClose).toHaveBeenCalledTimes(1);
-    });
+    describeDialogKeyboardShortcuts(({ onConfirm, onClose }) => (
+        <BulkDeleteModal
+            open
+            count={3}
+            itemNoun="route"
+            configName="main"
+            onClose={onClose}
+            onConfirm={onConfirm}
+        />
+    ));
 
     it('does not call onConfirm when dialog is closed and Ctrl+Enter is pressed', () => {
         const onConfirm = vi.fn();

--- a/web/src/components/DeleteConfigModal.test.tsx
+++ b/web/src/components/DeleteConfigModal.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import DeleteConfigModal from './DeleteConfigModal';
+import { describeDialogKeyboardShortcuts } from './dialogShortcutTests';
 
 describe('DeleteConfigModal', () => {
     afterEach(() => {
@@ -61,47 +62,14 @@ describe('DeleteConfigModal', () => {
         expect(screen.getByText('my-table')).toBeInTheDocument();
     });
 
-    it('calls onConfirm when Ctrl+Enter is pressed', () => {
-        const onConfirm = vi.fn();
-        render(
-            <DeleteConfigModal
-                open
-                configName="main"
-                onClose={() => {}}
-                onConfirm={onConfirm}
-            />,
-        );
-        fireEvent.keyDown(document, { key: 'Enter', ctrlKey: true });
-        expect(onConfirm).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls onConfirm when Cmd+Enter is pressed', () => {
-        const onConfirm = vi.fn();
-        render(
-            <DeleteConfigModal
-                open
-                configName="main"
-                onClose={() => {}}
-                onConfirm={onConfirm}
-            />,
-        );
-        fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
-        expect(onConfirm).toHaveBeenCalledTimes(1);
-    });
-
-    it('calls onClose when Escape is pressed', () => {
-        const onClose = vi.fn();
-        render(
-            <DeleteConfigModal
-                open
-                configName="main"
-                onClose={onClose}
-                onConfirm={() => {}}
-            />,
-        );
-        fireEvent.keyDown(document, { key: 'Escape' });
-        expect(onClose).toHaveBeenCalledTimes(1);
-    });
+    describeDialogKeyboardShortcuts(({ onConfirm, onClose }) => (
+        <DeleteConfigModal
+            open
+            configName="main"
+            onClose={onClose}
+            onConfirm={onConfirm}
+        />
+    ));
 
     it('does not call onConfirm when dialog is closed and Ctrl+Enter is pressed', () => {
         const onConfirm = vi.fn();

--- a/web/src/components/dialogShortcutTests.tsx
+++ b/web/src/components/dialogShortcutTests.tsx
@@ -1,0 +1,40 @@
+import { it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+
+interface Handlers {
+    onConfirm: () => void;
+    onClose: () => void;
+}
+
+/**
+ * Registers the three standard keyboard-shortcut specs for a dialog modal.
+ *
+ * Call inside a `describe` block and pass a factory that renders the modal
+ * with the provided handlers. Test names are intentionally stable so that
+ * vitest output stays consistent across suites.
+ */
+export const describeDialogKeyboardShortcuts = (
+    renderDialog: (handlers: Handlers) => React.ReactElement,
+): void => {
+    it('calls onConfirm when Ctrl+Enter is pressed', () => {
+        const onConfirm = vi.fn();
+        render(renderDialog({ onConfirm, onClose: () => {} }));
+        fireEvent.keyDown(document, { key: 'Enter', ctrlKey: true });
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onConfirm when Cmd+Enter is pressed', () => {
+        const onConfirm = vi.fn();
+        render(renderDialog({ onConfirm, onClose: () => {} }));
+        fireEvent.keyDown(document, { key: 'Enter', metaKey: true });
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when Escape is pressed', () => {
+        const onClose = vi.fn();
+        render(renderDialog({ onConfirm: () => {}, onClose }));
+        fireEvent.keyDown(document, { key: 'Escape' });
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+};


### PR DESCRIPTION
- Extracts the confirm and close keyboard-shortcut specs duplicated between the bulk delete and delete config modal suites into a shared test helper.
- Spec names, event payloads, and assertions are unchanged, and the suite still runs the same number of tests.
- Tests-only change: the production bundle is byte-identical to main.