### PR TITLE
refactor(web): extract shared rule page state hook

### DIFF
--- a/web/src/components/draft/index.ts
+++ b/web/src/components/draft/index.ts
@@ -22,3 +22,5 @@ export { useDraftPageDerived } from './useDraftPageDerived';
 export type { UseDraftPageDerivedOptions, UseDraftPageDerivedResult } from './useDraftPageDerived';
 export { useConfigPersistence } from './useConfigPersistence';
 export type { UseConfigPersistenceOptions, UseConfigPersistenceResult, ConfigPersistenceDispatch } from './useConfigPersistence';
+export { useRulePageState } from './useRulePageState';
+export type { UseRulePageStateOptions, UseRulePageStateResult } from './useRulePageState';

--- a/web/src/components/draft/useRulePageState.ts
+++ b/web/src/components/draft/useRulePageState.ts
@@ -1,0 +1,259 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet, useConfigQuerySync, useTabCycle, useUnsavedChangesBlocker } from '../../hooks';
+import { DRAWER_TRANSITION_MS } from './constants';
+
+/** Minimal drawer handle interface required by the save-press handler. */
+interface DrawerHandle {
+    flushAndApply(): void;
+}
+
+/** Dispatch actions emitted by useRulePageState for draft mutation. */
+type RuleDispatchAction<TRule> =
+    | { type: 'ADD_RULE'; configName: string; rule: TRule }
+    | { type: 'UPDATE_RULE_AT_INDEX'; configName: string; index: number; rule: TRule }
+    | { type: 'REMOVE_RULES'; configName: string; indices: number[] };
+
+/** Options for useRulePageState. */
+export interface UseRulePageStateOptions<TRule, TItem extends { id: string; index: number }, TDraft> {
+    draftConfigs: string[];
+    loading: boolean;
+    anyDirty: boolean;
+    isDirty: (config: string) => boolean;
+    draftRules: (config: string) => TRule[];
+    dispatchDraft: (action: RuleDispatchAction<TRule>) => void;
+    saveConfig: (config: string) => Promise<void>;
+    discardConfig: (config: string) => void;
+    toRule: (draft: TDraft) => TRule;
+    cloneItem: (item: TItem) => TItem;
+    requireConfigForAdd: boolean;
+    clearSelectionOnTabSelect: boolean;
+}
+
+/** Result returned by useRulePageState. */
+export interface UseRulePageStateResult<TItem extends { id: string; index: number }, TDraft, THandle extends DrawerHandle = DrawerHandle> {
+    currentConfig: string;
+    search: string;
+    updateParams: (updates: Record<string, string | null>) => void;
+    clearConfigParamIfCurrent: (name: string) => void;
+    selectedIds: Set<string>;
+    setSelectedIds: React.Dispatch<React.SetStateAction<Set<string>>>;
+    activeRowId: string | null;
+    setActiveRowId: React.Dispatch<React.SetStateAction<string | null>>;
+    drawer: { open: boolean; mode: 'add' | 'edit'; item: TItem | null };
+    setDrawer: React.Dispatch<React.SetStateAction<{ open: boolean; mode: 'add' | 'edit'; item: TItem | null }>>;
+    deleteConfirmOpen: boolean;
+    setDeleteConfirmOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    addConfigOpen: boolean;
+    setAddConfigOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    deleteConfigOpen: boolean;
+    setDeleteConfigOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    diffModalOpen: boolean;
+    setDiffModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    flashRowId: string | null;
+    setFlashRowId: React.Dispatch<React.SetStateAction<string | null>>;
+    setDeleteInFlightConfig: React.Dispatch<React.SetStateAction<string | null>>;
+    drawerRef: React.RefObject<THandle | null>;
+    ruleCounts: Map<string, number>;
+    dirtySet: Set<string>;
+    currentIsDirty: boolean;
+    openAdd: () => void;
+    openEdit: (item: TItem) => void;
+    closeDrawer: () => void;
+    handleDrawerApply: (draft: TDraft) => void;
+    handleDeleteItem: (item: TItem) => void;
+    handleDuplicate: (item: TItem) => void;
+    handleSave: () => Promise<void>;
+    handleSavePress: () => void;
+    handleDiscard: () => void;
+    handleSearchChange: (value: string) => void;
+    handleJumpToRow: (id: string) => void;
+    handleTabSelect: (cfg: string) => void;
+}
+
+/** Manages the shared URL-param, modal, drawer, and handler plumbing common to AclPage and ForwardPage. */
+export const useRulePageState = <TRule, TItem extends { id: string; index: number }, TDraft, THandle extends DrawerHandle = DrawerHandle>({
+    draftConfigs,
+    loading,
+    anyDirty,
+    isDirty,
+    draftRules,
+    dispatchDraft,
+    saveConfig,
+    discardConfig,
+    toRule,
+    cloneItem,
+    requireConfigForAdd,
+    clearSelectionOnTabSelect,
+}: UseRulePageStateOptions<TRule, TItem, TDraft>): UseRulePageStateResult<TItem, TDraft, THandle> => {
+    const QP_CONFIG = 'config';
+    const QP_SEARCH = 'search';
+
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+    const [activeRowId, setActiveRowId] = useState<string | null>(null);
+    const [drawer, setDrawer] = useState<{ open: boolean; mode: 'add' | 'edit'; item: TItem | null }>({
+        open: false,
+        mode: 'add',
+        item: null,
+    });
+    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+    const [addConfigOpen, setAddConfigOpen] = useState(false);
+    const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
+    const [diffModalOpen, setDiffModalOpen] = useState(false);
+    const [flashRowId, setFlashRowId] = useState<string | null>(null);
+    const [deleteInFlightConfig, setDeleteInFlightConfig] = useState<string | null>(null);
+    const drawerRef = useRef<THandle>(null);
+
+    const queryConfig = useMemo(() => searchParams.get(QP_CONFIG), [searchParams]);
+    const search = useMemo(() => searchParams.get(QP_SEARCH) || '', [searchParams]);
+
+    const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig) || queryConfig === deleteInFlightConfig))
+        ? queryConfig
+        : (draftConfigs[0] || '');
+
+    const { updateParams, clearConfigParamIfCurrent } = useSearchParamHelpers(setSearchParams, QP_CONFIG);
+
+    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: QP_CONFIG, searchParams, updateParams });
+
+    useUnsavedChangesBlocker(anyDirty);
+
+    const ruleCounts = useMemo((): Map<string, number> => {
+        const m = new Map<string, number>();
+        draftConfigs.forEach(c => m.set(c, draftRules(c).length));
+        return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [draftConfigs, draftRules]);
+
+    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
+
+    const currentIsDirty = isDirty(currentConfig);
+
+    const openAdd = useCallback((): void => {
+        if (requireConfigForAdd && !currentConfig) {
+            return;
+        }
+        setActiveRowId(null);
+        setDrawer({ open: true, mode: 'add', item: null });
+    }, [requireConfigForAdd, currentConfig]);
+
+    const openEdit = useCallback((item: TItem): void => {
+        setActiveRowId(item.id);
+        setDrawer({ open: true, mode: 'edit', item });
+    }, []);
+
+    const closeDrawer = useCallback((): void => {
+        setDrawer(d => ({ ...d, open: false }));
+        setTimeout(() => {
+            setActiveRowId(null);
+            setDrawer(d => ({ ...d, item: null }));
+        }, DRAWER_TRANSITION_MS);
+    }, []);
+
+    const handleDrawerApply = useCallback((draft: TDraft): void => {
+        const rule = toRule(draft);
+        if (drawer.mode === 'add') {
+            dispatchDraft({ type: 'ADD_RULE', configName: currentConfig, rule });
+        } else if (drawer.item) {
+            dispatchDraft({ type: 'UPDATE_RULE_AT_INDEX', configName: currentConfig, index: drawer.item.index, rule });
+        }
+        closeDrawer();
+    }, [drawer, currentConfig, dispatchDraft, toRule, closeDrawer]);
+
+    const handleDeleteItem = useCallback((item: TItem): void => {
+        dispatchDraft({ type: 'REMOVE_RULES', configName: currentConfig, indices: [item.index] });
+        closeDrawer();
+    }, [currentConfig, dispatchDraft, closeDrawer]);
+
+    const handleDuplicate = useCallback((item: TItem): void => {
+        setActiveRowId(null);
+        setDrawer({ open: true, mode: 'add', item: cloneItem(item) });
+    }, [cloneItem]);
+
+    const handleSave = useCallback(async (): Promise<void> => {
+        await saveConfig(currentConfig);
+        setDiffModalOpen(false);
+    }, [currentConfig, saveConfig]);
+
+    const handleSavePress = useCallback((): void => {
+        if (drawer.open) {
+            drawerRef.current?.flushAndApply();
+        }
+        setDiffModalOpen(true);
+    }, [drawer.open]);
+
+    const handleDiscard = useCallback((): void => {
+        discardConfig(currentConfig);
+    }, [currentConfig, discardConfig]);
+
+    const handleSearchChange = useCallback((value: string): void => {
+        updateParams({ [QP_SEARCH]: value || null });
+    }, [updateParams]);
+
+    const handleJumpToRow = useCallback((id: string): void => {
+        setFlashRowId(null);
+        setTimeout(() => setFlashRowId(id), 0);
+    }, []);
+
+    const handleTabSelect = useCallback((cfg: string): void => {
+        updateParams({ [QP_CONFIG]: cfg || null });
+        if (clearSelectionOnTabSelect) {
+            setSelectedIds(new Set());
+            setActiveRowId(null);
+        }
+    }, [updateParams, clearSelectionOnTabSelect]);
+
+    useTabCycle({
+        tabs: draftConfigs,
+        activeTab: currentConfig,
+        onSelect: handleTabSelect,
+        enabled: !loading,
+    });
+
+    usePageKeyboardShortcuts({
+        onNewRule: openAdd,
+        onEscape: closeDrawer,
+        drawerOpen: drawer.open,
+    });
+
+    return {
+        currentConfig,
+        search,
+        updateParams,
+        clearConfigParamIfCurrent,
+        selectedIds,
+        setSelectedIds,
+        activeRowId,
+        setActiveRowId,
+        drawer,
+        setDrawer,
+        deleteConfirmOpen,
+        setDeleteConfirmOpen,
+        addConfigOpen,
+        setAddConfigOpen,
+        deleteConfigOpen,
+        setDeleteConfigOpen,
+        diffModalOpen,
+        setDiffModalOpen,
+        flashRowId,
+        setFlashRowId,
+        setDeleteInFlightConfig,
+        drawerRef,
+        ruleCounts,
+        dirtySet,
+        currentIsDirty,
+        openAdd,
+        openEdit,
+        closeDrawer,
+        handleDrawerApply,
+        handleDeleteItem,
+        handleDuplicate,
+        handleSave,
+        handleSavePress,
+        handleDiscard,
+        handleSearchChange,
+        handleJumpToRow,
+        handleTabSelect,
+    };
+};

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { Button, Icon, Label } from '@gravity-ui/uikit';
 import { Funnel, Pause, Play, Plus } from '@gravity-ui/icons';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
-import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet, useConfigQuerySync, usePageContribution, useTabCycle, useUnsavedChangesBlocker } from '../../../hooks';
+import { usePageContribution } from '../../../hooks';
 import { useAclDraft } from './useAclDraft';
 import type { Rule } from '../../../api/acl';
 import { ActionKind } from '../../../api/acl';
@@ -16,14 +16,15 @@ import YamlIO, { type ImportMode } from './YamlIO';
 import { SaveDiffModal } from './SaveDiffModal';
 import { useAclRuleCounters } from './useAclRuleCounters';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
-import { DRAWER_TRANSITION_MS } from '../../../components/draft';
+import { useRulePageState } from '../../../components/draft';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
 import { buildConfigCommands } from '../../../components/command-palette';
 import '../../../styles/chrome.scss';
 import './acl.scss';
 
 const QP_CONFIG = 'config';
-const QP_SEARCH = 'search';
+
+const cloneRuleItem = (item: RuleItem): RuleItem => ({ ...item, rule: { ...item.rule } });
 
 const AclPage: React.FC = () => {
     const {
@@ -40,39 +41,66 @@ const AclPage: React.FC = () => {
         commitDeleteConfig,
         discardConfig,
     } = useAclDraft();
-    const [searchParams, setSearchParams] = useSearchParams();
 
     const [paused, setPaused] = useState(false);
     const [enabledCounterNames, setEnabledCounterNames] = useState<Set<string>>(new Set());
-    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-    const [activeRowId, setActiveRowId] = useState<string | null>(null);
-    const [drawer, setDrawer] = useState<{ open: boolean; mode: 'add' | 'edit'; item: RuleItem | null }>({
-        open: false,
-        mode: 'add',
-        item: null,
-    });
-    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-    const [addConfigOpen, setAddConfigOpen] = useState(false);
-    const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
-    const [diffModalOpen, setDiffModalOpen] = useState(false);
-    const [flashRowId, setFlashRowId] = useState<string | null>(null);
     const [deleteConfigTarget, setDeleteConfigTarget] = useState<string | null>(null);
-    const [deleteInFlightConfig, setDeleteInFlightConfig] = useState<string | null>(null);
     const [bulkDeleteConfig, setBulkDeleteConfig] = useState<string | null>(null);
     const [bulkDeleteRuleIds, setBulkDeleteRuleIds] = useState<string[]>([]);
-    const drawerRef = useRef<RuleDrawerHandle>(null);
     const navigate = useNavigate();
-    const queryConfig = useMemo(() => searchParams.get(QP_CONFIG), [searchParams]);
-    const search = useMemo(() => searchParams.get(QP_SEARCH) || '', [searchParams]);
 
-    const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig) || queryConfig === deleteInFlightConfig))
-        ? queryConfig
-        : (draftConfigs[0] || '');
-    const { updateParams, clearConfigParamIfCurrent } = useSearchParamHelpers(setSearchParams, QP_CONFIG);
-
-    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: QP_CONFIG, searchParams, updateParams });
-
-    useUnsavedChangesBlocker(anyDirty);
+    const {
+        currentConfig,
+        search,
+        updateParams,
+        clearConfigParamIfCurrent,
+        selectedIds,
+        setSelectedIds,
+        activeRowId,
+        setActiveRowId,
+        drawer,
+        setDrawer,
+        deleteConfirmOpen,
+        setDeleteConfirmOpen,
+        addConfigOpen,
+        setAddConfigOpen,
+        deleteConfigOpen,
+        setDeleteConfigOpen,
+        diffModalOpen,
+        setDiffModalOpen,
+        flashRowId,
+        setFlashRowId,
+        setDeleteInFlightConfig,
+        drawerRef,
+        ruleCounts,
+        dirtySet,
+        currentIsDirty,
+        openAdd,
+        openEdit,
+        closeDrawer,
+        handleDrawerApply,
+        handleDeleteItem,
+        handleDuplicate,
+        handleSave,
+        handleSavePress,
+        handleDiscard,
+        handleSearchChange,
+        handleJumpToRow,
+        handleTabSelect,
+    } = useRulePageState<Rule, RuleItem, RuleDraft, RuleDrawerHandle>({
+        draftConfigs,
+        loading,
+        anyDirty,
+        isDirty,
+        draftRules,
+        dispatchDraft,
+        saveConfig,
+        discardConfig,
+        toRule: draftToRule,
+        cloneItem: cloneRuleItem,
+        requireConfigForAdd: true,
+        clearSelectionOnTabSelect: false,
+    });
 
     useEffect(() => {
         setSelectedIds(new Set());
@@ -96,15 +124,6 @@ const AclPage: React.FC = () => {
 
     const { rates } = useAclRuleCounters(currentConfig, allItems, enabledCounterNames, !paused);
 
-    const ruleCounts = useMemo((): Map<string, number> => {
-        const m = new Map<string, number>();
-        draftConfigs.forEach(c => m.set(c, draftRules(c).length));
-        return m;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [draftConfigs, draftRules]);
-
-    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
-
     const deferredSearch = useDeferredValue(search);
 
     const visibleItems = useMemo((): RuleItem[] => {
@@ -112,47 +131,6 @@ const AclPage: React.FC = () => {
         if (!q) return allItems;
         return allItems.filter(item => item.searchText.includes(q));
     }, [allItems, deferredSearch]);
-
-    const openAdd = useCallback((): void => {
-        if (!currentConfig) {
-            return;
-        }
-        setActiveRowId(null);
-        setDrawer({ open: true, mode: 'add', item: null });
-    }, [currentConfig]);
-
-    const openEdit = useCallback((item: RuleItem): void => {
-        setActiveRowId(item.id);
-        setDrawer({ open: true, mode: 'edit', item });
-    }, []);
-
-    const closeDrawer = useCallback((): void => {
-        setDrawer(d => ({ ...d, open: false }));
-        setTimeout(() => {
-            setActiveRowId(null);
-            setDrawer(d => ({ ...d, item: null }));
-        }, DRAWER_TRANSITION_MS);
-    }, []);
-
-    const handleDrawerApply = useCallback((draft: RuleDraft): void => {
-        const rule = draftToRule(draft);
-        if (drawer.mode === 'add') {
-            dispatchDraft({ type: 'ADD_RULE', configName: currentConfig, rule });
-        } else if (drawer.item) {
-            dispatchDraft({ type: 'UPDATE_RULE_AT_INDEX', configName: currentConfig, index: drawer.item.index, rule });
-        }
-        closeDrawer();
-    }, [drawer, currentConfig, dispatchDraft, closeDrawer]);
-
-    const handleDeleteItem = useCallback((item: RuleItem): void => {
-        dispatchDraft({ type: 'REMOVE_RULES', configName: currentConfig, indices: [item.index] });
-        closeDrawer();
-    }, [currentConfig, dispatchDraft, closeDrawer]);
-
-    const handleDuplicate = useCallback((item: RuleItem): void => {
-        setActiveRowId(null);
-        setDrawer({ open: true, mode: 'add', item: { ...item, rule: { ...item.rule } } });
-    }, []);
 
     const handleOpenBulkDelete = useCallback((): void => {
         if (!currentConfig) {
@@ -218,18 +196,6 @@ const AclPage: React.FC = () => {
         }
     }, [deleteConfigTarget, commitDeleteConfig, clearConfigParamIfCurrent]);
 
-    const handleSave = useCallback(async (): Promise<void> => {
-        await saveConfig(currentConfig);
-        setDiffModalOpen(false);
-    }, [currentConfig, saveConfig]);
-
-    const handleSavePress = useCallback((): void => {
-        if (drawer.open) {
-            drawerRef.current?.flushAndApply();
-        }
-        setDiffModalOpen(true);
-    }, [drawer.open]);
-
     const handleToggleCounter = useCallback((counterName: string): void => {
         setEnabledCounterNames(prev => {
             const next = new Set(prev);
@@ -242,10 +208,6 @@ const AclPage: React.FC = () => {
         });
     }, []);
 
-    const handleDiscard = useCallback((): void => {
-        discardConfig(currentConfig);
-    }, [currentConfig, discardConfig]);
-
     const handleImportYaml = useCallback((importedConfigName: string, rules: Rule[], mode: ImportMode): void => {
         const target = importedConfigName || currentConfig;
         if (mode === 'append') {
@@ -257,40 +219,12 @@ const AclPage: React.FC = () => {
         updateParams({ [QP_CONFIG]: target || null });
     }, [currentConfig, draftRules, dispatchDraft, updateParams]);
 
-    const handleTabSelect = useCallback((cfg: string): void => {
-        updateParams({ [QP_CONFIG]: cfg || null });
-    }, [updateParams]);
-
-    useTabCycle({
-        tabs: draftConfigs,
-        activeTab: currentConfig,
-        onSelect: handleTabSelect,
-        enabled: !loading,
-    });
-
-    const handleSearchChange = useCallback((value: string): void => {
-        updateParams({ [QP_SEARCH]: value || null });
-    }, [updateParams]);
-
-    const handleJumpToRow = useCallback((id: string): void => {
-        setFlashRowId(null);
-        setTimeout(() => setFlashRowId(id), 0);
-    }, []);
-
     const handleOpenLinkedFwstate = useCallback((): void => {
         if (!currentFwStateName) {
             return;
         }
         navigate(`/modules/fwstate?config=${encodeURIComponent(currentFwStateName)}`);
     }, [currentFwStateName, navigate]);
-
-    usePageKeyboardShortcuts({
-        onNewRule: openAdd,
-        onEscape: closeDrawer,
-        drawerOpen: drawer.open,
-    });
-
-    const currentIsDirty = isDirty(currentConfig);
 
     const commands = useMemo((): Command[] => {
         const list: Command[] = [];

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,7 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
-import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, usePageKeyboardShortcuts, useDirtyConfigSet, useConfigQuerySync, usePageContribution, useTabCycle, useUnsavedChangesBlocker } from '../../../hooks';
+import { usePageContribution } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
@@ -19,14 +18,15 @@ import YamlIO from './YamlIO';
 import { SaveDiffModal } from './SaveDiffModal';
 import { useForwardRuleCounters } from './useForwardRuleCounters';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
-import { DRAWER_TRANSITION_MS } from '../../../components/draft';
+import { useRulePageState } from '../../../components/draft';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
 import { buildConfigCommands } from '../../../components/command-palette';
 import '../../../styles/chrome.scss';
 import './forward.scss';
 
 const QP_CONFIG = 'config';
-const QP_SEARCH = 'search';
+
+const cloneRuleItem = (item: RuleItem): RuleItem => ({ ...item });
 
 const ForwardPage: React.FC = () => {
     const {
@@ -42,45 +42,66 @@ const ForwardPage: React.FC = () => {
         commitDeleteConfig,
         discardConfig,
     } = useForwardDraft();
-    const [searchParams, setSearchParams] = useSearchParams();
 
-    const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
-    const [activeRowId, setActiveRowId] = useState<string | null>(null);
-    const [drawer, setDrawer] = useState<{ open: boolean; mode: 'add' | 'edit'; item: RuleItem | null }>({
-        open: false,
-        mode: 'add',
-        item: null,
-    });
-    const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-    const [addConfigOpen, setAddConfigOpen] = useState(false);
-    const [deleteConfigOpen, setDeleteConfigOpen] = useState(false);
-    const [deleteInFlightConfig, setDeleteInFlightConfig] = useState<string | null>(null);
-    const [diffModalOpen, setDiffModalOpen] = useState(false);
     const [modeFilter, setModeFilter] = useState<ModeFilterValue>('all');
-    const [flashRowId, setFlashRowId] = useState<string | null>(null);
-    const drawerRef = useRef<RuleDrawerHandle>(null);
-    const queryConfig = useMemo(() => searchParams.get(QP_CONFIG), [searchParams]);
-    const search = useMemo(() => searchParams.get(QP_SEARCH) || '', [searchParams]);
-    const currentConfig = (queryConfig && (loading || draftConfigs.includes(queryConfig) || queryConfig === deleteInFlightConfig)) ? queryConfig : (draftConfigs[0] || '');
-    const { updateParams, clearConfigParamIfCurrent } = useSearchParamHelpers(setSearchParams, QP_CONFIG);
 
-    useUnsavedChangesBlocker(anyDirty);
-
-    useConfigQuerySync({ currentConfig, loading, queryConfig, paramKey: QP_CONFIG, searchParams, updateParams });
+    const {
+        currentConfig,
+        search,
+        updateParams,
+        clearConfigParamIfCurrent,
+        selectedIds,
+        setSelectedIds,
+        activeRowId,
+        setActiveRowId,
+        drawer,
+        setDrawer,
+        deleteConfirmOpen,
+        setDeleteConfirmOpen,
+        addConfigOpen,
+        setAddConfigOpen,
+        deleteConfigOpen,
+        setDeleteConfigOpen,
+        diffModalOpen,
+        setDiffModalOpen,
+        flashRowId,
+        setFlashRowId,
+        setDeleteInFlightConfig,
+        drawerRef,
+        ruleCounts,
+        dirtySet,
+        currentIsDirty,
+        openAdd,
+        openEdit,
+        closeDrawer,
+        handleDrawerApply,
+        handleDeleteItem,
+        handleDuplicate,
+        handleSave,
+        handleSavePress,
+        handleDiscard,
+        handleSearchChange,
+        handleJumpToRow,
+        handleTabSelect,
+    } = useRulePageState<Rule, RuleItem, RuleDraft, RuleDrawerHandle>({
+        draftConfigs,
+        loading,
+        anyDirty,
+        isDirty,
+        draftRules,
+        dispatchDraft,
+        saveConfig,
+        discardConfig,
+        toRule: draftToRule,
+        cloneItem: cloneRuleItem,
+        requireConfigForAdd: false,
+        clearSelectionOnTabSelect: true,
+    });
 
     const rawRules: Rule[] = draftRules(currentConfig);
     const allItems = useMemo(() => rulesToNgItems(rawRules), [rawRules]);
 
     const { rates } = useForwardRuleCounters(currentConfig, allItems, true);
-
-    const ruleCounts = useMemo((): Map<string, number> => {
-        const m = new Map<string, number>();
-        draftConfigs.forEach(c => m.set(c, draftRules(c).length));
-        return m;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [draftConfigs, draftRules]);
-
-    const dirtySet = useDirtyConfigSet(draftConfigs, isDirty);
 
     const visibleItems = useMemo((): RuleItem[] => {
         let res = allItems;
@@ -108,45 +129,6 @@ const ForwardPage: React.FC = () => {
         return res;
     }, [allItems, search, modeFilter]);
 
-    const openAdd = useCallback((): void => {
-        setActiveRowId(null);
-        setDrawer({ open: true, mode: 'add', item: null });
-    }, []);
-
-    const openEdit = useCallback((item: RuleItem): void => {
-        setActiveRowId(item.id);
-        setDrawer({ open: true, mode: 'edit', item });
-    }, []);
-
-    const closeDrawer = useCallback((): void => {
-        setDrawer((d) => ({ ...d, open: false }));
-        setTimeout(() => {
-            setActiveRowId(null);
-            setDrawer((d) => ({ ...d, item: null }));
-        }, DRAWER_TRANSITION_MS);
-    }, []);
-
-    /** Apply a rule draft to local state only; no API call. */
-    const handleDrawerApply = useCallback((draft: RuleDraft): void => {
-        const rule = draftToRule(draft);
-        if (drawer.mode === 'add') {
-            dispatchDraft({ type: 'ADD_RULE', configName: currentConfig, rule });
-        } else if (drawer.item) {
-            dispatchDraft({ type: 'UPDATE_RULE_AT_INDEX', configName: currentConfig, index: drawer.item.index, rule });
-        }
-        closeDrawer();
-    }, [drawer, currentConfig, dispatchDraft, closeDrawer]);
-
-    const handleDeleteItem = useCallback((item: RuleItem): void => {
-        dispatchDraft({ type: 'REMOVE_RULES', configName: currentConfig, indices: [item.index] });
-        closeDrawer();
-    }, [currentConfig, dispatchDraft, closeDrawer]);
-
-    const handleDuplicate = useCallback((item: RuleItem): void => {
-        setActiveRowId(null);
-        setDrawer({ open: true, mode: 'add', item: { ...item } });
-    }, []);
-
     const handleBulkDelete = useCallback((): void => {
         const indices = visibleItems
             .filter((item) => selectedIds.has(item.id))
@@ -170,42 +152,11 @@ const ForwardPage: React.FC = () => {
         }
     }, [currentConfig, commitDeleteConfig, clearConfigParamIfCurrent]);
 
-    const handleSave = useCallback(async (): Promise<void> => {
-        await saveConfig(currentConfig);
-        setDiffModalOpen(false);
-    }, [currentConfig, saveConfig]);
-
-    const handleSavePress = useCallback((): void => {
-        if (drawer.open) {
-            drawerRef.current?.flushAndApply();
-        }
-        setDiffModalOpen(true);
-    }, [drawer.open]);
-
-    const handleDiscard = useCallback((): void => {
-        discardConfig(currentConfig);
-    }, [currentConfig, discardConfig]);
-
     const handleImportYaml = useCallback((importedConfigName: string, rules: Rule[]): void => {
         const target = importedConfigName || currentConfig;
         dispatchDraft({ type: 'REPLACE_ALL_RULES', configName: target, rules });
         updateParams({ [QP_CONFIG]: target || null });
     }, [currentConfig, dispatchDraft, updateParams]);
-
-    const handleTabSelect = useCallback((cfg: string): void => {
-        updateParams({ [QP_CONFIG]: cfg || null });
-        setSelectedIds(new Set());
-        setActiveRowId(null);
-    }, [updateParams]);
-
-    const handleSearchChange = useCallback((value: string): void => {
-        updateParams({ [QP_SEARCH]: value || null });
-    }, [updateParams]);
-
-    const handleJumpToRow = useCallback((id: string): void => {
-        setFlashRowId(null);
-        setTimeout(() => setFlashRowId(id), 0);
-    }, []);
 
     useEffect(() => {
         setSelectedIds(new Set());
@@ -218,22 +169,7 @@ const ForwardPage: React.FC = () => {
         setFlashRowId(null);
     }, [currentConfig]);
 
-    usePageKeyboardShortcuts({
-        onNewRule: openAdd,
-        onEscape: closeDrawer,
-        drawerOpen: drawer.open,
-    });
-
-    useTabCycle({
-        tabs: draftConfigs,
-        activeTab: currentConfig,
-        onSelect: handleTabSelect,
-        enabled: !loading,
-    });
-
     const canCreate = !loading && !loadFailed;
-
-    const currentIsDirty = isDirty(currentConfig);
 
     const commands = useMemo((): Command[] => {
         const list: Command[] = [


### PR DESCRIPTION
- Extracts the verbatim-shared page plumbing of the ACL and Forward pages into one generic hook covering URL-param syncing, drawer and modal state, dirty tracking, and the common handlers.
- The three behavioral differences between the pages are reproduced through explicit parameters: the add guard, the duplicate clone strategy, and selection clearing on tab switch.
- Rendered output is unchanged: the JSX of both pages is byte-identical to main, and page-specific logic stays in the pages.