### PR TITLE
refactor(web): share delete and discard confirmation dialogs between card headers

### DIFF
--- a/web/src/components/EntityConfirmDialogs.tsx
+++ b/web/src/components/EntityConfirmDialogs.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ConfirmDialog } from './ConfirmDialog';
+
+interface EntityConfirmDialogsProps {
+    noun: string;
+    entityId: string;
+    deleteOpen: boolean;
+    discardOpen: boolean;
+    onDeleteClose: () => void;
+    onDiscardClose: () => void;
+    onDelete: () => void;
+    onDiscard: () => void;
+}
+
+/** Renders the standard delete and discard confirmation dialogs for a named entity. */
+export const EntityConfirmDialogs: React.FC<EntityConfirmDialogsProps> = ({
+    noun,
+    entityId,
+    deleteOpen,
+    discardOpen,
+    onDeleteClose,
+    onDiscardClose,
+    onDelete,
+    onDiscard,
+}) => (
+    <>
+        <ConfirmDialog
+            open={deleteOpen}
+            onClose={onDeleteClose}
+            onConfirm={() => { onDeleteClose(); onDelete(); }}
+            title={`Delete ${noun}`}
+            message={`Delete ${noun} "${entityId}"? This cannot be undone.`}
+            confirmText="Delete"
+            cancelText="Cancel"
+            danger
+        />
+        <ConfirmDialog
+            open={discardOpen}
+            onClose={onDiscardClose}
+            onConfirm={() => { onDiscardClose(); onDiscard(); }}
+            title={`Discard changes to "${entityId}"?`}
+            message={`All local edits to this ${noun} will be discarded.`}
+            confirmText="Discard"
+            cancelText="Cancel"
+            danger
+        />
+    </>
+);

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -8,6 +8,7 @@ export * from './FormField';
 export * from './InputFormField';
 export * from './FormDialog';
 export * from './ConfirmDialog';
+export * from './EntityConfirmDialogs';
 export * from './CreateEntityDialog';
 export * from './SortableTableHeader';
 export {

--- a/web/src/pages/builtin/functions/components/FunctionCardHeader.tsx
+++ b/web/src/pages/builtin/functions/components/FunctionCardHeader.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import type { NetworkFunction } from '../types';
 import { metaFor } from '../moduleMeta';
 import { Sparkline, formatPps, LaneStat, LaneCardActions, LaneCollapseButton } from '../../_shared/lane-editor';
-import { ConfirmDialog } from '../../../../components';
+import { EntityConfirmDialogs } from '../../../../components';
 
 interface FunctionCardHeaderProps {
     fn: NetworkFunction;
@@ -133,26 +133,15 @@ export const FunctionCardHeader: React.FC<FunctionCardHeaderProps> = ({
                 />
             </div>
 
-            <ConfirmDialog
-                open={confirmDelete}
-                onClose={() => setConfirmDelete(false)}
-                onConfirm={() => { setConfirmDelete(false); onDelete(); }}
-                title="Delete function"
-                message={`Delete function "${fn.id}"? This cannot be undone.`}
-                confirmText="Delete"
-                cancelText="Cancel"
-                danger
-            />
-
-            <ConfirmDialog
-                open={confirmDiscard}
-                onClose={() => setConfirmDiscard(false)}
-                onConfirm={() => { setConfirmDiscard(false); onDiscard(); }}
-                title={`Discard changes to "${fn.id}"?`}
-                message="All local edits to this function will be discarded."
-                confirmText="Discard"
-                cancelText="Cancel"
-                danger
+            <EntityConfirmDialogs
+                noun="function"
+                entityId={fn.id}
+                deleteOpen={confirmDelete}
+                discardOpen={confirmDiscard}
+                onDeleteClose={() => setConfirmDelete(false)}
+                onDiscardClose={() => setConfirmDiscard(false)}
+                onDelete={onDelete}
+                onDiscard={onDiscard}
             />
         </div>
     );

--- a/web/src/pages/builtin/pipelines/components/PipelineCardHeader.tsx
+++ b/web/src/pages/builtin/pipelines/components/PipelineCardHeader.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import type { Pipeline } from '../types';
 import { Sparkline, formatPps, LaneStat, LaneCardActions, LaneCollapseButton } from '../../_shared/lane-editor';
-import { ConfirmDialog } from '../../../../components';
+import { EntityConfirmDialogs } from '../../../../components';
 
 interface PipelineCardHeaderProps {
     pipeline: Pipeline;
@@ -80,26 +80,15 @@ export const PipelineCardHeader: React.FC<PipelineCardHeaderProps> = ({
                 />
             </div>
 
-            <ConfirmDialog
-                open={confirmDelete}
-                onClose={() => setConfirmDelete(false)}
-                onConfirm={() => { setConfirmDelete(false); onDelete(); }}
-                title="Delete pipeline"
-                message={`Delete pipeline "${pipeline.id}"? This cannot be undone.`}
-                confirmText="Delete"
-                cancelText="Cancel"
-                danger
-            />
-
-            <ConfirmDialog
-                open={confirmDiscard}
-                onClose={() => setConfirmDiscard(false)}
-                onConfirm={() => { setConfirmDiscard(false); onDiscard(); }}
-                title={`Discard changes to "${pipeline.id}"?`}
-                message="All local edits to this pipeline will be discarded."
-                confirmText="Discard"
-                cancelText="Cancel"
-                danger
+            <EntityConfirmDialogs
+                noun="pipeline"
+                entityId={pipeline.id}
+                deleteOpen={confirmDelete}
+                discardOpen={confirmDiscard}
+                onDeleteClose={() => setConfirmDelete(false)}
+                onDiscardClose={() => setConfirmDiscard(false)}
+                onDelete={onDelete}
+                onDiscard={onDiscard}
             />
         </div>
     );


### PR DESCRIPTION
- Extracts the duplicated delete and discard confirmation dialog pair from the functions and pipelines card headers into a shared component.
- The shared component reproduces every dialog title, message and action ordering exactly, so there is no visual or behavioral change.