### PR TITLE
refactor(common): rename big array destructor to match lifecycle convention

### DIFF
--- a/common/big_array.h
+++ b/common/big_array.h
@@ -61,7 +61,7 @@
  * *ptr = 0x42;
  *
  * // Cleanup
- * big_array_free(&array);
+ * big_array_fini(&array);
  * ```
  *
  * ## Performance Characteristics
@@ -136,7 +136,7 @@ struct big_array {
 };
 
 static inline void
-big_array_free(struct big_array *array);
+big_array_fini(struct big_array *array);
 
 /**
  * @brief Initialize a big_array with the specified size
@@ -153,7 +153,7 @@ big_array_free(struct big_array *array);
  *
  * @return 0 on success, -1 on allocation failure
  *
- * @note On failure, the function calls big_array_free() to clean up any
+ * @note On failure, the function calls big_array_fini() to clean up any
  *       partial allocations, so the array is left in a safe state.
  * @note If size is 0, the function succeeds but allocates no subarrays.
  *
@@ -212,7 +212,7 @@ big_array_init(
 	return 0;
 
 free_on_error:
-	big_array_free(array);
+	big_array_fini(array);
 	return -1;
 }
 
@@ -231,7 +231,7 @@ free_on_error:
  * @warning The caller must ensure that index is within the bounds of the
  *          array size passed to big_array_init(). No bounds checking is
  *          performed for performance reasons.
- * @warning The returned pointer is only valid until big_array_free() is called.
+ * @warning The returned pointer is only valid until big_array_fini() is called.
  *
  * Implementation details:
  * - Uses bit shift (index >> subarray_len_exp) to find subarray index
@@ -259,7 +259,7 @@ big_array_get(struct big_array *array, size_t index) {
 }
 
 /**
- * @brief Free all memory associated with a big_array
+ * @brief Release all memory associated with a big_array
  *
  * Releases all subarrays and the subarray pointer array, then zeros out
  * the big_array structure. This function is safe to call multiple times
@@ -269,7 +269,7 @@ big_array_get(struct big_array *array, size_t index) {
  * may have a smaller size than the others if the total array size was not
  * evenly divisible by MEMORY_BLOCK_ALLOCATOR_MAX_SIZE.
  *
- * @param array Pointer to big_array to free
+ * @param array Pointer to big_array to finalize
  *
  * @note After calling this function, the array structure is zeroed and
  *       cannot be used until re-initialized with big_array_init().
@@ -279,12 +279,12 @@ big_array_get(struct big_array *array, size_t index) {
  *
  * Example:
  * ```c
- * big_array_free(&array);
+ * big_array_fini(&array);
  * // array is now safe to re-initialize or discard
  * ```
  */
 static inline void
-big_array_free(struct big_array *array) {
+big_array_fini(struct big_array *array) {
 	if (array->subarrays != NULL) {
 		void **subarrays = ADDR_OF(&array->subarrays);
 		size_t subarray_size = 1 << array->subarray_len_exp;

--- a/common/btree/u16.h
+++ b/common/btree/u16.h
@@ -340,7 +340,7 @@ btree_u16_init(
  */
 static inline void
 btree_u16_free(struct btree_u16 *btree) {
-	big_array_free(&btree->array);
+	big_array_fini(&btree->array);
 }
 
 static inline size_t

--- a/common/btree/u32.h
+++ b/common/btree/u32.h
@@ -329,7 +329,7 @@ btree_u32_init(
  */
 static inline void
 btree_u32_free(struct btree_u32 *btree) {
-	big_array_free(&btree->array);
+	big_array_fini(&btree->array);
 }
 
 static inline size_t

--- a/common/btree/u64.h
+++ b/common/btree/u64.h
@@ -339,7 +339,7 @@ btree_u64_init(
  */
 static inline void
 btree_u64_free(struct btree_u64 *btree) {
-	big_array_free(&btree->array);
+	big_array_fini(&btree->array);
 }
 
 static inline size_t

--- a/tests/common/big_array_test.c
+++ b/tests/common/big_array_test.c
@@ -77,7 +77,7 @@ test_init_and_free_basic(void) {
 	);
 
 	// Free the array
-	big_array_free(&array);
+	big_array_fini(&array);
 
 	// Verify cleanup
 	TEST_ASSERT(
@@ -147,7 +147,7 @@ test_init_large_array(void) {
 	    array.subarrays_count,
 	    subarray_size);
 
-	big_array_free(&array);
+	big_array_fini(&array);
 	memory_context_fini(&mctx);
 	free(raw_mem);
 	return TEST_SUCCESS;
@@ -191,7 +191,7 @@ test_init_exact_boundary(void) {
 		array.subarrays_count
 	);
 
-	big_array_free(&array);
+	big_array_fini(&array);
 	memory_context_fini(&mctx);
 	free(raw_mem);
 	return TEST_SUCCESS;
@@ -231,7 +231,7 @@ test_init_zero_size(void) {
 	);
 
 	// Free should be safe even with zero size
-	big_array_free(&array);
+	big_array_fini(&array);
 
 	memory_context_fini(&mctx);
 	free(raw_mem);
@@ -305,7 +305,7 @@ test_get_access_patterns(void) {
 		);
 	}
 
-	big_array_free(&array);
+	big_array_fini(&array);
 	memory_context_fini(&mctx);
 	free(raw_mem);
 	return TEST_SUCCESS;
@@ -376,7 +376,7 @@ test_get_multiple_subarrays(void) {
 	    array.subarrays_count,
 	    subarray_size);
 
-	big_array_free(&array);
+	big_array_fini(&array);
 	memory_context_fini(&mctx);
 	free(raw_mem);
 	return TEST_SUCCESS;
@@ -409,10 +409,10 @@ test_double_free_safety(void) {
 	TEST_ASSERT(res == 0, "big_array_init failed");
 
 	// First free
-	big_array_free(&array);
+	big_array_fini(&array);
 
 	// Second free should be safe (no crash)
-	big_array_free(&array);
+	big_array_fini(&array);
 
 	// Verify array is properly zeroed
 	TEST_ASSERT(
@@ -503,7 +503,7 @@ test_size_bigger_than_max(void) {
 		}
 	}
 
-	big_array_free(&array);
+	big_array_fini(&array);
 	memory_context_fini(&mctx);
 	free(raw_mem);
 	return TEST_SUCCESS;
@@ -549,7 +549,7 @@ test_last_subarray_size_optimization(void) {
 	size_t balloc_size_before_free = array.mctx.balloc_size;
 
 	// Free and verify memory accounting
-	big_array_free(&array);
+	big_array_fini(&array);
 
 	// Verify all memory was freed in child context
 	TEST_ASSERT(


### PR DESCRIPTION
- Renames the big array destructor from free to fini: it releases only the subarray field memory and never deallocates the caller-owned structure, so per the project lifecycle convention (init/fini for in-place structures, new/free for heap-allocated ones) the old name was an ownership trap.
- Updates all call sites: btree headers and the unit test, plus the surrounding documentation examples.
- Pure rename, no behavior or memory layout changes.