### PR TITLE
refactor(common): rename data pipe destructor to match lifecycle convention

### DIFF
--- a/common/data_pipe.h
+++ b/common/data_pipe.h
@@ -114,9 +114,9 @@ data_pipe_init(struct data_pipe *pipe, size_t size) {
 	return 0;
 }
 
-// Free resources allocated by data_pipe_init().
+// Release resources allocated by data_pipe_init().
 static inline void
-data_pipe_free(struct data_pipe *pipe) {
+data_pipe_fini(struct data_pipe *pipe) {
 	free(pipe->data);
 	free(pipe->w_pos);
 }

--- a/tests/common/data_pipe_tsan.c
+++ b/tests/common/data_pipe_tsan.c
@@ -92,7 +92,7 @@ main(void) {
 	pthread_join(prod, NULL);
 	pthread_join(cons, NULL);
 
-	data_pipe_free(&shared_pipe);
+	data_pipe_fini(&shared_pipe);
 
 	printf("Done.\n");
 	return 0;


### PR DESCRIPTION
- Renames the data pipe destructor from free to fini: it releases only the malloc'd field buffers of the caller-owned structure, so the init/fini naming pair now reflects the actual ownership.
- The item-level slot-reclaim helper keeps its name since it is not a lifecycle destructor.
- Pure rename, no behavior changes.