### PR TITLE
refactor(common): rename value registry destructors to match lifecycle convention

### DIFF
--- a/common/registry.h
+++ b/common/registry.h
@@ -42,7 +42,7 @@ value_collector_init(
 }
 
 static inline void
-value_collector_free(struct value_collector *collector) {
+value_collector_fini(struct value_collector *collector) {
 	uint32_t **use_map = ADDR_OF(&collector->use_map);
 
 	if (use_map != NULL) {
@@ -267,8 +267,8 @@ value_registry_collect(struct value_registry *registry, uint32_t value) {
 }
 
 static inline void
-value_registry_free(struct value_registry *registry) {
-	value_collector_free(&registry->collector);
+value_registry_fini(struct value_registry *registry) {
+	value_collector_fini(&registry->collector);
 
 	for (uint64_t idx = 0; idx < registry->range_count; ++idx) {
 		struct value_range *range = ADDR_OF(&registry->ranges) + idx;

--- a/lib/filter/compiler.h
+++ b/lib/filter/compiler.h
@@ -53,14 +53,14 @@ filter_free(
 		SET_OFFSET_OF(&v->data, NULL);
 	}
 	for (size_t i = 1; i < 2 * filter_compiler->lookup_count; ++i) {
-		value_registry_free(&filter->v[i].registry);
+		value_registry_fini(&filter->v[i].registry);
 	}
 	for (size_t i = 1; i < filter_compiler->lookup_count; ++i) {
 		value_table_free(&filter->v[i].table);
 	}
 	if (filter_compiler->lookup_count == 1) {
 		struct filter_vertex *v0 = filter->v;
-		value_registry_free(&v0->registry);
+		value_registry_fini(&v0->registry);
 		value_table_free(&v0->table);
 	}
 	memory_context_fini(&filter->memory_context);
@@ -135,7 +135,7 @@ filter_init(
 				err,
 				"out of memory: failed to init dummy registry"
 			);
-			value_registry_free(&dummy);
+			value_registry_fini(&dummy);
 			goto init_failed;
 		}
 
@@ -149,11 +149,11 @@ filter_init(
 				err,
 				"out of memory: failed to merge registry values"
 			);
-			value_registry_free(&dummy);
+			value_registry_fini(&dummy);
 			goto init_failed;
 		}
 
-		value_registry_free(&dummy);
+		value_registry_fini(&dummy);
 		goto init_finish;
 	}
 

--- a/lib/filter/compiler/helper.c
+++ b/lib/filter/compiler/helper.c
@@ -15,12 +15,12 @@ init_dummy_registry(
 	for (uint32_t i = 0; i < actions; ++i) {
 		res = value_registry_start(registry);
 		if (res < 0) {
-			value_registry_free(registry);
+			value_registry_fini(registry);
 			return res;
 		}
 		res = value_registry_collect(registry, 0);
 		if (res < 0) {
-			value_registry_free(registry);
+			value_registry_fini(registry);
 			return res;
 		}
 	}

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -360,7 +360,7 @@ merge_net6_range(
 	}
 
 	radix_free(&rdx);
-	value_registry_free(&net_registry);
+	value_registry_fini(&net_registry);
 
 	// FIXME: free temporary resources
 

--- a/lib/filter/compiler/net6_fast.c
+++ b/lib/filter/compiler/net6_fast.c
@@ -143,13 +143,13 @@ init_classifier(
 		    rules,
 		    rules_count
 	    ) != 0) {
-		value_registry_free(&high_registry);
+		value_registry_fini(&high_registry);
 		return -1;
 	}
 
 	struct value_registry low_registry;
 	if (value_registry_init(&low_registry, mctx) != 0) {
-		value_registry_free(&high_registry);
+		value_registry_fini(&high_registry);
 		free_classifier_part(&classifier->high, mctx);
 		return -1;
 	}
@@ -164,8 +164,8 @@ init_classifier(
 		    rules,
 		    rules_count
 	    ) != 0) {
-		value_registry_free(&high_registry);
-		value_registry_free(&low_registry);
+		value_registry_fini(&high_registry);
+		value_registry_fini(&low_registry);
 		free_classifier_part(&classifier->high, mctx);
 		return -1;
 	}
@@ -177,15 +177,15 @@ init_classifier(
 		    &classifier->comb,
 		    registry
 	    ) != 0) {
-		value_registry_free(&high_registry);
-		value_registry_free(&low_registry);
+		value_registry_fini(&high_registry);
+		value_registry_fini(&low_registry);
 		free_classifier_part(&classifier->high, mctx);
 		free_classifier_part(&classifier->low, mctx);
 		return -1;
 	}
 
-	value_registry_free(&high_registry);
-	value_registry_free(&low_registry);
+	value_registry_fini(&high_registry);
+	value_registry_fini(&low_registry);
 
 	return 0;
 }


### PR DESCRIPTION
- Renames the value collector and value registry destructors from free to fini: both release only field memory of caller-owned structures, so the init/fini naming pair now reflects the actual ownership.
- Updates all call sites in the filter compiler.
- Pure rename, no behavior changes.