### PR TITLE
refactor(lib): rename segments classifier destructors to match lifecycle convention

### DIFF
--- a/lib/filter/compiler/net4_fast.c
+++ b/lib/filter/compiler/net4_fast.c
@@ -170,7 +170,7 @@ FILTER_ATTR_COMPILER_FREE_FUNC(net4_fast_src)(
 ) {
 	struct segments_u32_classifier *classifier =
 		(struct segments_u32_classifier *)data;
-	segments_classifier_u32_free(classifier, memory_context);
+	segments_classifier_u32_fini(classifier, memory_context);
 	memory_bfree(
 		memory_context,
 		classifier,
@@ -184,7 +184,7 @@ FILTER_ATTR_COMPILER_FREE_FUNC(net4_fast_dst)(
 ) {
 	struct segments_u32_classifier *classifier =
 		(struct segments_u32_classifier *)data;
-	segments_classifier_u32_free(classifier, memory_context);
+	segments_classifier_u32_fini(classifier, memory_context);
 	memory_bfree(
 		memory_context,
 		classifier,

--- a/lib/filter/compiler/net6_fast.c
+++ b/lib/filter/compiler/net6_fast.c
@@ -111,7 +111,7 @@ static void
 free_classifier_part(
 	struct segments_u64_classifier *classifier, struct memory_context *mctx
 ) {
-	segments_classifier_u64_free(classifier, mctx);
+	segments_classifier_u64_fini(classifier, mctx);
 }
 
 static int

--- a/lib/filter/compiler/port_fast.c
+++ b/lib/filter/compiler/port_fast.c
@@ -133,7 +133,7 @@ FILTER_ATTR_COMPILER_FREE_FUNC(port_fast_src)(
 ) {
 	struct segment_u16_classifier *classifier =
 		(struct segment_u16_classifier *)data;
-	segments_classifier_u16_free(classifier, memory_context);
+	segments_classifier_u16_fini(classifier, memory_context);
 	memory_bfree(
 		memory_context,
 		classifier,
@@ -147,7 +147,7 @@ FILTER_ATTR_COMPILER_FREE_FUNC(port_fast_dst)(
 ) {
 	struct segment_u16_classifier *classifier =
 		(struct segment_u16_classifier *)data;
-	segments_classifier_u16_free(classifier, memory_context);
+	segments_classifier_u16_fini(classifier, memory_context);
 	memory_bfree(
 		memory_context,
 		classifier,

--- a/lib/filter/compiler/proto_range_fast.c
+++ b/lib/filter/compiler/proto_range_fast.c
@@ -102,7 +102,7 @@ FILTER_ATTR_COMPILER_FREE_FUNC(proto_range_fast)(
 		return;
 	struct proto_range_fast_classifier *c =
 		(struct proto_range_fast_classifier *)data;
-	segments_classifier_u16_free(&c->classifier, memory_context);
+	segments_classifier_u16_fini(&c->classifier, memory_context);
 	memory_bfree(memory_context, c, sizeof(*c));
 }
 

--- a/lib/filter/compiler/segments.c
+++ b/lib/filter/compiler/segments.c
@@ -229,7 +229,7 @@ segments_classifier_u16_init(
 }
 
 void
-segments_classifier_u16_free(
+segments_classifier_u16_fini(
 	struct segment_u16_classifier *classifier, struct memory_context *mctx
 ) {
 	btree_u16_fini(&classifier->btree);
@@ -424,7 +424,7 @@ segments_classifier_u32_init(
 }
 
 void
-segments_classifier_u32_free(
+segments_classifier_u32_fini(
 	struct segments_u32_classifier *classifier, struct memory_context *mctx
 ) {
 	btree_u32_fini(&classifier->btree);
@@ -620,7 +620,7 @@ segments_classifier_u64_init(
 }
 
 void
-segments_classifier_u64_free(
+segments_classifier_u64_fini(
 	struct segments_u64_classifier *classifier, struct memory_context *mctx
 ) {
 	btree_u64_fini(&classifier->btree);

--- a/lib/filter/compiler/segments.h
+++ b/lib/filter/compiler/segments.h
@@ -21,7 +21,7 @@ segments_classifier_u16_init(
 );
 
 void
-segments_classifier_u16_free(
+segments_classifier_u16_fini(
 	struct segment_u16_classifier *classifier, struct memory_context *mctx
 );
 
@@ -43,7 +43,7 @@ segments_classifier_u32_init(
 );
 
 void
-segments_classifier_u32_free(
+segments_classifier_u32_fini(
 	struct segments_u32_classifier *classifier, struct memory_context *mctx
 );
 
@@ -64,6 +64,6 @@ segments_classifier_u64_init(
 );
 
 void
-segments_classifier_u64_free(
+segments_classifier_u64_fini(
 	struct segments_u64_classifier *classifier, struct memory_context *mctx
 );


### PR DESCRIPTION
- Renames the segments classifier destructors from free to fini across all three width clones: each one finalizes the embedded btree and releases the open ranges array through the caller-supplied memory context, never deallocating the caller-owned classifier itself.
- Updates all call sites in the filter compiler.
- Pure rename, no behavior changes.