### PR TITLE
feat(dataplane): reference devices by name in connections config

### DIFF
--- a/dataplane.yaml
+++ b/dataplane.yaml
@@ -26,7 +26,7 @@ dataplane:
           rx_queue_len: 1024
           tx_queue_len: 1024
   connections:
-    - src_device_id: 0
-      dst_device_id: 1
-    - src_device_id: 1
-      dst_device_id: 0
+    - src_device: 01:00.0
+      dst_device: virtio_user_kni0
+    - src_device: virtio_user_kni0
+      dst_device: 01:00.0

--- a/dataplane/config.c
+++ b/dataplane/config.c
@@ -5,6 +5,45 @@
 
 #include "common/strutils.h"
 
+static int
+resolve_connections(struct dataplane_config *config) {
+	for (uint64_t conn_idx = 0; conn_idx < config->connection_count;
+	     ++conn_idx) {
+		struct dataplane_connection_config *conn =
+			config->connections + conn_idx;
+
+		if (conn->src_device[0] == '\0' ||
+		    conn->dst_device[0] == '\0') {
+			return -1;
+		}
+
+		int64_t src_id = -1, dst_id = -1;
+		for (uint64_t dev_idx = 0; dev_idx < config->device_count;
+		     ++dev_idx) {
+			const char *name = config->devices[dev_idx].device_name;
+			if (!strcmp(name, conn->src_device)) {
+				if (src_id >= 0) {
+					return -1;
+				}
+				src_id = (int64_t)dev_idx;
+			}
+			if (!strcmp(name, conn->dst_device)) {
+				if (dst_id >= 0) {
+					return -1;
+				}
+				dst_id = (int64_t)dev_idx;
+			}
+		}
+		if (src_id < 0 || dst_id < 0) {
+			return -1;
+		}
+
+		conn->src_device_id = (uint64_t)src_id;
+		conn->dst_device_id = (uint64_t)dst_id;
+	}
+	return 0;
+}
+
 enum state {
 	state_empty,
 	state_dataplane,
@@ -228,17 +267,15 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				break;
 
 			case state_connection_src:
-				connection->src_device_id =
-					strtol(start, &end, 10);
-				if (*end != '\0')
-					goto error;
+				strtcpy(connection->src_device,
+					start,
+					sizeof(connection->src_device));
 				state = state_connection;
 				break;
 			case state_connection_dst:
-				connection->dst_device_id =
-					strtol(start, &end, 10);
-				if (*end != '\0')
-					goto error;
+				strtcpy(connection->dst_device,
+					start,
+					sizeof(connection->dst_device));
 				state = state_connection;
 				break;
 
@@ -320,9 +357,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				}
 				break;
 			case state_connection: {
-				if (!strcmp("src_device_id", start)) {
+				if (!strcmp("src_device", start)) {
 					state = state_connection_src;
-				} else if (!strcmp("dst_device_id", start)) {
+				} else if (!strcmp("dst_device", start)) {
 					state = state_connection_dst;
 				} else {
 					goto error;
@@ -447,6 +484,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					       dataplane_connection_config
 					) * dataplane->connection_count
 				);
+				if (mem == NULL) {
+					goto error;
+				}
 				dataplane->connections =
 					(struct dataplane_connection_config *)
 						mem;
@@ -500,6 +540,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 		yaml_parser_parse(&parser, &event);
 	}
 	yaml_event_delete(&event);
+
+	if (resolve_connections(dataplane) != 0)
+		goto error;
 
 	yaml_parser_delete(&parser);
 

--- a/dataplane/config.h
+++ b/dataplane/config.h
@@ -37,6 +37,8 @@ struct dataplane_device_config {
 struct dataplane_connection_config {
 	uint64_t src_device_id;
 	uint64_t dst_device_id;
+	char src_device[80];
+	char dst_device[80];
 };
 
 struct dataplane_config {

--- a/dataplane/unittest/config/dataplane.yaml
+++ b/dataplane/unittest/config/dataplane.yaml
@@ -32,7 +32,7 @@ dataplane:
           rx_queue_len: 128
           tx_queue_len: 4096
   connections:
-    - src_device_id: 0
-      dst_device_id: 1
-    - src_device_id: 1
-      dst_device_id: 0
+    - src_device: 07:00.0
+      dst_device: virtio_user_kni0
+    - src_device: virtio_user_kni0
+      dst_device: 07:00.0

--- a/dataplane/unittest/config/main.c
+++ b/dataplane/unittest/config/main.c
@@ -1,11 +1,10 @@
 #include "assert.h"
 #include "config.h"
 
-#include "config.h"
-
 #include <fcntl.h>
+#include <string.h>
 
-void
+static void
 check_instance(
 	struct dataplane_instance_config *config,
 	uint16_t numa_idx,
@@ -17,23 +16,101 @@ check_instance(
 	assert(config->cp_memory == cp_memory);
 }
 
-int
-main(int argc, char **argv) {
-	(void)argc;
-	(void)argv;
+static void
+test_resolve_connections_unknown_device(void) {
+	const char yaml[] = "dataplane:\n"
+			    "  devices:\n"
+			    "    - port_name: eth0\n"
+			    "  connections:\n"
+			    "    - src_device: eth0\n"
+			    "      dst_device: does_not_exist\n";
 
-	FILE *dataplane_config_file = fopen(CONFIG_PATH, "r");
+	FILE *f = fmemopen((void *)yaml, strlen(yaml), "r");
+	assert(f != NULL);
 
 	struct dataplane_config *config = NULL;
+	int rc = dataplane_config_init(f, &config);
+	assert(rc == -1);
+	assert(config == NULL);
 
-	int init_result = dataplane_config_init(dataplane_config_file, &config);
-	assert(init_result == 0);
+	fclose(f);
+}
+
+static void
+test_resolve_connections_duplicate_device(void) {
+	const char yaml[] = "dataplane:\n"
+			    "  devices:\n"
+			    "    - port_name: eth0\n"
+			    "    - port_name: eth0\n"
+			    "  connections:\n"
+			    "    - src_device: eth0\n"
+			    "      dst_device: eth0\n";
+
+	FILE *f = fmemopen((void *)yaml, strlen(yaml), "r");
+	assert(f != NULL);
+
+	struct dataplane_config *config = NULL;
+	int rc = dataplane_config_init(f, &config);
+	assert(rc == -1);
+	assert(config == NULL);
+
+	fclose(f);
+}
+
+static void
+test_resolve_connections_empty_device_name(void) {
+	const char yaml[] = "dataplane:\n"
+			    "  devices:\n"
+			    "    - port_name: eth0\n"
+			    "  connections:\n"
+			    "    - src_device: eth0\n"
+			    "      dst_device: \"\"\n";
+
+	FILE *f = fmemopen((void *)yaml, strlen(yaml), "r");
+	assert(f != NULL);
+
+	struct dataplane_config *config = NULL;
+	int rc = dataplane_config_init(f, &config);
+	assert(rc == -1);
+	assert(config == NULL);
+
+	fclose(f);
+}
+
+static void
+test_valid_config(void) {
+	FILE *f = fopen(CONFIG_PATH, "r");
+	assert(f != NULL);
+
+	struct dataplane_config *config = NULL;
+	int rc = dataplane_config_init(f, &config);
+	assert(rc == 0);
 
 	assert(config->instance_count == 3);
 	check_instance(config->instances, 0, 1024, 2048);
 	check_instance(config->instances + 1, 1, 512, 128);
 	check_instance(config->instances + 2, 0, 123, 124);
 
+	assert(config->connection_count == 2);
+	assert(config->connections[0].src_device_id == 0);
+	assert(config->connections[0].dst_device_id == 1);
+	assert(config->connections[1].src_device_id == 1);
+	assert(config->connections[1].dst_device_id == 0);
+
 	dataplane_config_free(config);
+
+	fclose(f);
+}
+
+int
+main(int argc, char **argv) {
+	(void)argc;
+	(void)argv;
+
+	test_valid_config();
+	test_resolve_connections_unknown_device();
+	test_resolve_connections_duplicate_device();
+	test_resolve_connections_empty_device_name();
+
 	return 0;
 }

--- a/tests/functional/main/framework_test.go
+++ b/tests/functional/main/framework_test.go
@@ -49,10 +49,10 @@ dataplane:
           tx_queue_len: 1024
           num_mbufs: 2048
   connections:
-    - src_device_id: 0
-      dst_device_id: 1
-    - src_device_id: 1
-      dst_device_id: 0
+    - src_device: 01:00.0
+      dst_device: virtio_user_kni0
+    - src_device: virtio_user_kni0
+      dst_device: 01:00.0
 `
 }
 


### PR DESCRIPTION
Dataplane connections previously referenced devices by their position in the devices list, so reordering devices silently rewired the topology. Connections now reference devices by name.

Before:
```yaml
connections:
  - src_device_id: 0
    dst_device_id: 1 
```

After:
```yaml
connections:
  - src_device: 01:00.0
    dst_device: virtio_user_kni0
```

What changed:

- Connections now use src_device/dst_device names instead of src_device_id/dst_device_id indices.
- Names are resolved to device indices after the whole config is parsed, so connections no longer have to appear after devices.
- Unknown, empty, or duplicated device names are now rejected at load time, instead of silently indexing past the device array.

Migrated the sample, unit-test, and functional-test configs, and added parser coverage for the new failure cases.