### PR TITLE
refactor(lib): rename config generation constructors to match lifecycle convention

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -374,7 +374,7 @@ dataplane_init(
 
 		// System agent for this instance.
 		//
-		// Owns the phy devices created in cp_config_gen_create
+		// Owns the phy devices created in cp_config_gen_new
 		// and lives in shm so their parent_memory_context offsets
 		// remain valid in every process that maps the same shm region.
 		//
@@ -471,7 +471,7 @@ dataplane_init(
 		}
 
 		struct cp_config_gen *cp_config_gen =
-			cp_config_gen_create(agent, &err);
+			cp_config_gen_new(agent, &err);
 		if (cp_config_gen == NULL) {
 			LOG(ERROR,
 			    "failed to create cp_config_gen: %s",

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -173,8 +173,8 @@ test_attach_initialised_segment_succeeds() {
 
 	yanet_error *setup_err = NULL;
 	struct cp_config_gen *cp_config_gen =
-		cp_config_gen_create(sys_agent, &setup_err);
-	TEST_ASSERT_NOT_NULL(cp_config_gen, "cp_config_gen_create failed");
+		cp_config_gen_new(sys_agent, &setup_err);
+	TEST_ASSERT_NOT_NULL(cp_config_gen, "cp_config_gen_new failed");
 	SET_OFFSET_OF(&cp_config->cp_config_gen, cp_config_gen);
 
 	dp_config->instance_count = 1;

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -56,15 +56,13 @@ cp_config_unlock(struct cp_config *cp_config) {
 	);
 }
 
-// ------------ cp_config_gen
-
 static inline void
 cp_config_gen_free(
 	struct cp_config *cp_config, struct cp_config_gen *config_gen
 );
 
 static inline struct cp_config_gen *
-cp_config_gen_create_from(
+cp_config_gen_new_from(
 	struct cp_config *cp_config,
 	struct cp_config_gen *old_config_gen,
 	yanet_error **err
@@ -220,7 +218,7 @@ cp_config_delete_module(
 		ADDR_OF(&cp_config->cp_config_gen);
 
 	struct cp_config_gen *new_config_gen =
-		cp_config_gen_create_from(cp_config, old_config_gen, err);
+		cp_config_gen_new_from(cp_config, old_config_gen, err);
 	if (new_config_gen == NULL) {
 		goto error_unlock;
 	}
@@ -264,7 +262,7 @@ cp_config_update_modules(
 	struct cp_config_gen *old_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
 	struct cp_config_gen *new_config_gen =
-		cp_config_gen_create_from(cp_config, old_config_gen, err);
+		cp_config_gen_new_from(cp_config, old_config_gen, err);
 	if (new_config_gen == NULL) {
 		goto error_unlock;
 	}
@@ -319,7 +317,7 @@ cp_config_update_functions(
 	struct cp_config_gen *old_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
 	struct cp_config_gen *new_config_gen =
-		cp_config_gen_create_from(cp_config, old_config_gen, err);
+		cp_config_gen_new_from(cp_config, old_config_gen, err);
 	if (new_config_gen == NULL) {
 		goto error_unlock;
 	}
@@ -396,7 +394,7 @@ cp_config_delete_function(
 		ADDR_OF(&cp_config->cp_config_gen);
 
 	struct cp_config_gen *new_config_gen =
-		cp_config_gen_create_from(cp_config, old_config_gen, err);
+		cp_config_gen_new_from(cp_config, old_config_gen, err);
 	if (new_config_gen == NULL) {
 		goto error_unlock;
 	}
@@ -438,7 +436,7 @@ cp_config_update_pipelines(
 	struct cp_config_gen *old_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
 	struct cp_config_gen *new_config_gen =
-		cp_config_gen_create_from(cp_config, old_config_gen, err);
+		cp_config_gen_new_from(cp_config, old_config_gen, err);
 
 	if (new_config_gen == NULL) {
 		goto error_unlock;
@@ -521,7 +519,7 @@ cp_config_delete_pipeline(
 	}
 
 	struct cp_config_gen *new_config_gen =
-		cp_config_gen_create_from(cp_config, old_config_gen, err);
+		cp_config_gen_new_from(cp_config, old_config_gen, err);
 	if (new_config_gen == NULL) {
 		goto error_unlock;
 	}
@@ -606,7 +604,7 @@ cp_config_update_devices(
 	struct cp_config_gen *old_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
 	struct cp_config_gen *new_config_gen =
-		cp_config_gen_create_from(cp_config, old_config_gen, err);
+		cp_config_gen_new_from(cp_config, old_config_gen, err);
 	if (new_config_gen == NULL) {
 		goto error_unlock;
 	}
@@ -642,7 +640,7 @@ error_unlock:
 }
 
 struct cp_config_gen *
-cp_config_gen_create(struct agent *agent, yanet_error **err) {
+cp_config_gen_new(struct agent *agent, yanet_error **err) {
 	struct dp_config *dp_config = ADDR_OF(&agent->dp_config);
 	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
 	struct cp_config_gen *cp_config_gen =

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -194,7 +194,7 @@ cp_config_update_devices(
 );
 
 struct cp_config_gen *
-cp_config_gen_create(struct agent *agent, yanet_error **err);
+cp_config_gen_new(struct agent *agent, yanet_error **err);
 
 static inline struct cp_module *
 cp_config_gen_get_module(struct cp_config_gen *config_gen, uint64_t index) {

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -207,10 +207,10 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	// Create the initial cp_config_gen so agents can register modules
 	// and pipelines.
 	yanet_error *err = NULL;
-	struct cp_config_gen *cp_config_gen = cp_config_gen_create(agent, &err);
+	struct cp_config_gen *cp_config_gen = cp_config_gen_new(agent, &err);
 	if (cp_config_gen == NULL) {
 		LOG(ERROR,
-		    "dataplane_ut_new: cp_config_gen_create failed: %s",
+		    "dataplane_ut_new: cp_config_gen_new failed: %s",
 		    yanet_error_message(err));
 		yanet_error_free(err);
 		dataplane_ut_free(ut);

--- a/tests/controlplane/config_gen_test.c
+++ b/tests/controlplane/config_gen_test.c
@@ -71,8 +71,8 @@ main(void) {
 	SET_OFFSET_OF(&agent.cp_config, cp);
 
 	yanet_error *err = NULL;
-	struct cp_config_gen *gen = cp_config_gen_create(&agent, &err);
-	TEST_ASSERT_NOT_NULL(gen, "cp_config_gen_create failed");
+	struct cp_config_gen *gen = cp_config_gen_new(&agent, &err);
+	TEST_ASSERT_NOT_NULL(gen, "cp_config_gen_new failed");
 
 	// Reproduce the worker's code path:
 	//   config_gen_ectx = ADDR_OF(&cp_config_gen->config_gen_ectx);


### PR DESCRIPTION
- Renames the config generation constructors to the canonical lifecycle naming, since both allocate the structure and return a pointer.
- Updates every caller, test assertion message, and the one comment referencing the old name.
- Removes a banner comment labeling the renamed family.

Part of the RAII symmetry sweep, following up on #1192, #1193, #1194, #1195, #1196, #1197.