### PR TITLE
refactor(decap): rename module config lifecycle functions to match convention

### DIFF
--- a/modules/decap/api/controlplane.c
+++ b/modules/decap/api/controlplane.c
@@ -13,7 +13,7 @@
 #include "dataplane/config/zone.h"
 
 struct cp_module *
-decap_module_config_create(
+decap_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 ) {
 	struct decap_module_config *config =
@@ -58,7 +58,7 @@ decap_module_config_free(struct cp_module *cp_module) {
 	struct decap_module_config *config =
 		container_of(cp_module, struct decap_module_config, cp_module);
 
-	decap_module_config_data_destroy(config);
+	decap_module_config_data_fini(config);
 
 	struct agent *agent = ADDR_OF(&cp_module->agent);
 
@@ -90,7 +90,7 @@ error_lpm_v6:
 }
 
 void
-decap_module_config_data_destroy(struct decap_module_config *config) {
+decap_module_config_data_fini(struct decap_module_config *config) {
 	lpm_free(&config->prefixes4);
 	lpm_free(&config->prefixes6);
 }

--- a/modules/decap/api/controlplane.h
+++ b/modules/decap/api/controlplane.h
@@ -10,7 +10,7 @@ struct memory_context;
 struct decap_module_config;
 
 struct cp_module *
-decap_module_config_create(
+decap_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 );
 
@@ -24,7 +24,7 @@ decap_module_config_data_init(
 );
 
 void
-decap_module_config_data_destroy(struct decap_module_config *config);
+decap_module_config_data_fini(struct decap_module_config *config);
 
 int
 decap_module_config_add_prefix_v4(

--- a/modules/decap/bindings/go/cdecap/cgo.go
+++ b/modules/decap/bindings/go/cdecap/cgo.go
@@ -27,7 +27,7 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	defer C.free(unsafe.Pointer(cName))
 
 	var cErr *C.yanet_error
-	ptr := C.decap_module_config_create((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	ptr := C.decap_module_config_new((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to initialize module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}


### PR DESCRIPTION
- Renames the module config constructor to the canonical lifecycle naming, since it allocates the structure and returns a pointer.
- Renames the config data destructor to fini, since it releases field memory while the structure itself survives.
- Updates the single Go binding call site in step with the C rename.

Part of the RAII symmetry sweep, following up on #1192, #1193, #1194, #1195, #1196, #1197.