### PR TITLE
refactor(dscp): rename module config lifecycle functions to match convention

### DIFF
--- a/modules/dscp/api/controlplane.c
+++ b/modules/dscp/api/controlplane.c
@@ -13,7 +13,7 @@
 #include "dataplane/config/zone.h"
 
 struct cp_module *
-dscp_module_config_create(
+dscp_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 ) {
 	// Allocate a new dscp module config
@@ -59,7 +59,7 @@ dscp_module_config_free(struct cp_module *cp_module) {
 	struct dscp_module_config *config =
 		container_of(cp_module, struct dscp_module_config, cp_module);
 
-	dscp_module_config_data_destroy(config);
+	dscp_module_config_data_fini(config);
 
 	struct agent *agent = ADDR_OF(&cp_module->agent);
 
@@ -91,7 +91,7 @@ dscp_module_config_data_init(
 }
 
 void
-dscp_module_config_data_destroy(struct dscp_module_config *config) {
+dscp_module_config_data_fini(struct dscp_module_config *config) {
 	lpm_free(&config->lpm_v4);
 	lpm_free(&config->lpm_v6);
 }

--- a/modules/dscp/api/controlplane.h
+++ b/modules/dscp/api/controlplane.h
@@ -11,7 +11,7 @@ struct dscp_module_config;
 
 // Create a new configuration for the DSCP module
 struct cp_module *
-dscp_module_config_create(
+dscp_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 );
 
@@ -24,7 +24,7 @@ dscp_module_config_data_init(
 );
 
 void
-dscp_module_config_data_destroy(struct dscp_module_config *config);
+dscp_module_config_data_fini(struct dscp_module_config *config);
 
 // Add IPv4 prefix to the DSCP module configuration
 int

--- a/modules/dscp/bindings/go/cdscp/cgo.go
+++ b/modules/dscp/bindings/go/cdscp/cgo.go
@@ -24,7 +24,7 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	defer C.free(unsafe.Pointer(cName))
 
 	var cErr *C.yanet_error
-	ptr := C.dscp_module_config_create((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	ptr := C.dscp_module_config_new((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to initialize module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}


### PR DESCRIPTION
- Renames the module config constructor to use the new suffix, matching the new/init/fini/free lifecycle convention.
- Renames the config data destructor to the fini suffix since it releases field memory without deallocating the struct.
- Updates the CGO call site in the Go bindings accordingly.