### PR TITLE
refactor(pdump): rename module config constructor to match convention

### DIFF
--- a/modules/pdump/api/controlplane.c
+++ b/modules/pdump/api/controlplane.c
@@ -102,7 +102,7 @@ pdump_module_config_data_init(
 }
 
 struct cp_module *
-pdump_module_config_create(
+pdump_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 ) {
 	struct pdump_module_config *config =

--- a/modules/pdump/api/controlplane.h
+++ b/modules/pdump/api/controlplane.h
@@ -39,7 +39,7 @@ enum pdump_log_level {
 
 // Create a new configuration for the pdump module
 struct cp_module *
-pdump_module_config_create(
+pdump_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 );
 

--- a/modules/pdump/controlplane/ffi.go
+++ b/modules/pdump/controlplane/ffi.go
@@ -106,7 +106,7 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 
 	// Create a new module config using the C API
 	var cErr *C.yanet_error
-	ptr := C.pdump_module_config_create((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	ptr := C.pdump_module_config_new((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to create module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}


### PR DESCRIPTION
- Renames the module config constructor to use the new suffix, matching the new/init/fini/free lifecycle convention.
- Updates the CGO call site in the control plane accordingly.