### PR TITLE
refactor(route): rename module config lifecycle functions to match convention

### DIFF
--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -22,7 +22,7 @@ struct fib_iter {
 };
 
 struct cp_module *
-route_module_config_create(
+route_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 ) {
 	struct route_module_config *config =
@@ -86,7 +86,7 @@ route_module_config_data_init(
 }
 
 void
-route_module_config_data_destroy(struct route_module_config *config) {
+route_module_config_data_fini(struct route_module_config *config) {
 	struct route *routes = ADDR_OF(&config->routes);
 	mem_array_free_exp(
 		&config->cp_module.memory_context,
@@ -120,7 +120,7 @@ route_module_config_free(struct cp_module *cp_module) {
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
 
-	route_module_config_data_destroy(config);
+	route_module_config_data_fini(config);
 
 	struct agent *agent = ADDR_OF(&cp_module->agent);
 

--- a/modules/route/api/controlplane.h
+++ b/modules/route/api/controlplane.h
@@ -23,7 +23,7 @@ struct route_module_config;
 struct fib_iter;
 
 struct cp_module *
-route_module_config_create(
+route_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 );
 

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -27,7 +27,7 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	defer C.free(unsafe.Pointer(cName))
 
 	var cErr *C.yanet_error
-	ptr := C.route_module_config_create((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	ptr := C.route_module_config_new((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to initialize module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}

--- a/modules/route/tests/route_api_test.c
+++ b/modules/route/tests/route_api_test.c
@@ -1,5 +1,5 @@
 /*
- * Tests that route_module_config_create does not leak memory when
+ * Tests that route_module_config_new does not leak memory when
  * route_module_config_data_init fails due to OOM after cp_module_init
  * succeeds.
  *
@@ -42,7 +42,7 @@ run_test(struct yanet_shm *shm) {
 
 	size_t baseline = block_allocator_free_size(&agent->block_allocator);
 
-	struct cp_module *cp = route_module_config_create(agent, "probe", &err);
+	struct cp_module *cp = route_module_config_new(agent, "probe", &err);
 	TEST_ASSERT_NULL(cp, "create unexpectedly succeeded");
 
 	const char *errmsg = (err != NULL) ? yanet_error_message(err) : "";


### PR DESCRIPTION
- Renames the module config constructor to use the new suffix, matching the new/init/fini/free lifecycle convention.
- Renames the config data destructor to the fini suffix since it releases field memory without deallocating the struct.
- Updates the CGO call site in the Go bindings and the API test accordingly.