### PR TITLE
refactor(plain): rename device lifecycle constructors to match convention

### DIFF
--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -63,7 +63,7 @@ type ShmDeviceConfig struct {
 // NewShmDeviceConfig wraps a raw C pointer into a ShmDeviceConfig.
 //
 // The pointer must originate from a device-specific C constructor (e.g.
-// cp_device_plain_create).
+// cp_device_plain_new).
 // The caller is responsible for ensuring the pointer's validity and lifetime.
 func NewShmDeviceConfig(ptr unsafe.Pointer) ShmDeviceConfig {
 	return ShmDeviceConfig{
@@ -202,7 +202,7 @@ func (m *Agent) UpdatePlainDevices(devices []DeviceConfig) error {
 		defer C.free(unsafe.Pointer(cName))
 
 		var cErr *C.struct_yanet_error
-		cCfg := C.cp_device_plain_config_create(
+		cCfg := C.cp_device_plain_config_new(
 			cName,
 			C.uint64_t(len(input)),
 			C.uint64_t(len(output)),
@@ -237,7 +237,7 @@ func (m *Agent) UpdatePlainDevices(devices []DeviceConfig) error {
 			)
 		}
 
-		ptr := C.cp_device_plain_create(
+		ptr := C.cp_device_plain_new(
 			(*C.struct_agent)(m.AsRawPtr()),
 			cCfg,
 			&cErr,

--- a/devices/plain/api/controlplane.c
+++ b/devices/plain/api/controlplane.c
@@ -11,7 +11,7 @@
 #include "lib/errors/errors.h"
 
 struct cp_device *
-cp_device_plain_create(
+cp_device_plain_new(
 	struct agent *agent,
 	const struct cp_device_plain_config *config,
 	yanet_error **err
@@ -56,7 +56,7 @@ cp_device_plain_free(struct cp_device *cp_device) {
 }
 
 struct cp_device_plain_config *
-cp_device_plain_config_create(
+cp_device_plain_config_new(
 	const char *name,
 	uint64_t input_count,
 	uint64_t output_count,

--- a/devices/plain/api/controlplane.h
+++ b/devices/plain/api/controlplane.h
@@ -13,7 +13,7 @@ struct cp_device_plain_config {
 };
 
 struct cp_device *
-cp_device_plain_create(
+cp_device_plain_new(
 	struct agent *agent,
 	const struct cp_device_plain_config *config,
 	yanet_error **err
@@ -23,7 +23,7 @@ void
 cp_device_plain_free(struct cp_device *cp_device);
 
 struct cp_device_plain_config *
-cp_device_plain_config_create(
+cp_device_plain_config_new(
 	const char *name,
 	uint64_t input_count,
 	uint64_t output_count,

--- a/devices/plain/controlplane/ffi.go
+++ b/devices/plain/controlplane/ffi.go
@@ -43,7 +43,7 @@ func NewDeviceConfig(
 	output := device.GetOutput()
 
 	var cErr *C.struct_yanet_error
-	cCfg := C.cp_device_plain_config_create(cName, C.uint64_t(len(input)), C.uint64_t(len(output)), &cErr)
+	cCfg := C.cp_device_plain_config_new(cName, C.uint64_t(len(input)), C.uint64_t(len(output)), &cErr)
 	if cCfg == nil {
 		return nil, fmt.Errorf("failed to initialize plain device config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}
@@ -71,7 +71,7 @@ func NewDeviceConfig(
 		)
 	}
 
-	ptr := C.cp_device_plain_create((*C.struct_agent)(agent.AsRawPtr()), cCfg, &cErr)
+	ptr := C.cp_device_plain_new((*C.struct_agent)(agent.AsRawPtr()), cCfg, &cErr)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to create plain device: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}

--- a/devices/plain/tests/leak_test.c
+++ b/devices/plain/tests/leak_test.c
@@ -7,12 +7,10 @@ main(void) {
 	yanet_error *err = NULL;
 
 	struct cp_device_plain_config *cfg =
-		cp_device_plain_config_create("test", 4, 4, &err);
-	TEST_ASSERT_NOT_NULL(
-		cfg, "cp_device_plain_config_create returned NULL"
-	);
+		cp_device_plain_config_new("test", 4, 4, &err);
+	TEST_ASSERT_NOT_NULL(cfg, "cp_device_plain_config_new returned NULL");
 	TEST_ASSERT_NULL(
-		err, "unexpected error from cp_device_plain_config_create"
+		err, "unexpected error from cp_device_plain_config_new"
 	);
 
 	int res = cp_device_plain_config_set_input_pipeline(cfg, 0, "p0", 1);


### PR DESCRIPTION
- Renames the device and device config constructors to use the new suffix, matching the new/init/fini/free lifecycle convention.
- Updates the CGO call sites in the device control plane and the root FFI bindings accordingly.
- Updates the leak test call site and its assertion messages.