### PR TITLE
refactor(vlan): rename device lifecycle constructors to match convention

### DIFF
--- a/devices/vlan/api/controlplane.c
+++ b/devices/vlan/api/controlplane.c
@@ -11,7 +11,7 @@
 #include "lib/errors/errors.h"
 
 struct cp_device *
-cp_device_vlan_create(
+cp_device_vlan_new(
 	struct agent *agent,
 	const struct cp_device_vlan_config *config,
 	yanet_error **err
@@ -58,7 +58,7 @@ cp_device_vlan_free(struct cp_device *cp_device) {
 }
 
 struct cp_device_vlan_config *
-cp_device_vlan_config_create(
+cp_device_vlan_config_new(
 	const char *name,
 	uint64_t input_count,
 	uint64_t output_count,

--- a/devices/vlan/api/controlplane.h
+++ b/devices/vlan/api/controlplane.h
@@ -14,7 +14,7 @@ struct cp_device_vlan_config {
 };
 
 struct cp_device *
-cp_device_vlan_create(
+cp_device_vlan_new(
 	struct agent *agent,
 	const struct cp_device_vlan_config *config,
 	yanet_error **err
@@ -24,7 +24,7 @@ void
 cp_device_vlan_free(struct cp_device *cp_device);
 
 struct cp_device_vlan_config *
-cp_device_vlan_config_create(
+cp_device_vlan_config_new(
 	const char *name,
 	uint64_t input_count,
 	uint64_t output_count,

--- a/devices/vlan/controlplane/ffi.go
+++ b/devices/vlan/controlplane/ffi.go
@@ -44,7 +44,7 @@ func NewDeviceConfig(
 	output := device.GetOutput()
 
 	var cErr *C.struct_yanet_error
-	cCfg := C.cp_device_vlan_config_create(cName, C.uint64_t(len(input)), C.uint64_t(len(output)), C.uint16_t(vlan), &cErr)
+	cCfg := C.cp_device_vlan_config_new(cName, C.uint64_t(len(input)), C.uint64_t(len(output)), C.uint16_t(vlan), &cErr)
 	if cCfg == nil {
 		return nil, fmt.Errorf("failed to initialize vlan device config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}
@@ -72,7 +72,7 @@ func NewDeviceConfig(
 		)
 	}
 
-	ptr := C.cp_device_vlan_create((*C.struct_agent)(agent.AsRawPtr()), cCfg, &cErr)
+	ptr := C.cp_device_vlan_new((*C.struct_agent)(agent.AsRawPtr()), cCfg, &cErr)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to create vlan device: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}

--- a/devices/vlan/tests/leak_test.c
+++ b/devices/vlan/tests/leak_test.c
@@ -7,10 +7,10 @@ main(void) {
 	yanet_error *err = NULL;
 
 	struct cp_device_vlan_config *cfg =
-		cp_device_vlan_config_create("test", 4, 4, 100, &err);
-	TEST_ASSERT_NOT_NULL(cfg, "cp_device_vlan_config_create returned NULL");
+		cp_device_vlan_config_new("test", 4, 4, 100, &err);
+	TEST_ASSERT_NOT_NULL(cfg, "cp_device_vlan_config_new returned NULL");
 	TEST_ASSERT_NULL(
-		err, "unexpected error from cp_device_vlan_config_create"
+		err, "unexpected error from cp_device_vlan_config_new"
 	);
 
 	int res = cp_device_vlan_config_set_input_pipeline(cfg, 0, "p0", 1);


### PR DESCRIPTION
- Renames the device and device config constructors to use the new suffix, matching the new/init/fini/free lifecycle convention.
- Updates the CGO call sites in the device control plane accordingly.
- Updates the leak test call site and its assertion messages.