### PR TITLE
refactor(blackhole): rename module config constructor to match convention

### DIFF
--- a/modules/blackhole/api/controlplane.c
+++ b/modules/blackhole/api/controlplane.c
@@ -6,7 +6,7 @@
 #include "common/memory.h"
 
 struct cp_module *
-blackhole_module_config_init(
+blackhole_module_config_new(
 	struct agent *agent, const char *name, yanet_error **error
 ) {
 	struct cp_module *config = (struct cp_module *)memory_balloc(

--- a/modules/blackhole/api/controlplane.h
+++ b/modules/blackhole/api/controlplane.h
@@ -6,7 +6,7 @@ struct agent;
 #include "lib/errors/errors.h"
 
 struct cp_module *
-blackhole_module_config_init(
+blackhole_module_config_new(
 	struct agent *agent, const char *name, yanet_error **error
 );
 

--- a/modules/blackhole/bindings/go/cblackhole/bindings.go
+++ b/modules/blackhole/bindings/go/cblackhole/bindings.go
@@ -29,7 +29,7 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	defer C.free(unsafe.Pointer(cName))
 
 	var cErr *C.yanet_error
-	ptr := C.blackhole_module_config_init((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	ptr := C.blackhole_module_config_new((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
 	if ptr == nil {
 		return nil, fmt.Errorf(
 			"failed to initialize module config: %w",


### PR DESCRIPTION
- Renames the module config constructor to use the new suffix since it allocates the structure and returns it, matching the new/init/fini/free lifecycle convention.
- Updates the CGO call site in the Go bindings accordingly.