### PR TITLE
refactor(route): rename FIB iterator lifecycle functions to match convention

### DIFF
--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -249,7 +249,7 @@ route_module_config_add_prefix_v6(
 }
 
 struct fib_iter *
-fib_iter_create(struct cp_module *cp_module) {
+fib_iter_new(struct cp_module *cp_module) {
 	struct fib_iter *it = calloc(1, sizeof(*it));
 	if (it == NULL)
 		return NULL;
@@ -259,7 +259,7 @@ fib_iter_create(struct cp_module *cp_module) {
 }
 
 void
-fib_iter_destroy(struct fib_iter *it) {
+fib_iter_free(struct fib_iter *it) {
 	free(it);
 }
 

--- a/modules/route/api/controlplane.h
+++ b/modules/route/api/controlplane.h
@@ -70,11 +70,11 @@ route_module_config_add_prefix_v6(
 //
 // Returns NULL on allocation failure.
 struct fib_iter *
-fib_iter_create(struct cp_module *cp_module);
+fib_iter_new(struct cp_module *cp_module);
 
-// Destroy a FIB iterator created by fib_iter_create.
+// Free a FIB iterator created by fib_iter_new.
 void
-fib_iter_destroy(struct fib_iter *it);
+fib_iter_free(struct fib_iter *it);
 
 // Advance to the next LPM range.
 //

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -129,18 +129,18 @@ type fibIter struct {
 	ptr *C.struct_fib_iter
 }
 
-// newFIBIter maps 1:1 to fib_iter_create.
+// newFIBIter maps 1:1 to fib_iter_new.
 func newFIBIter(config *ModuleConfig) (*fibIter, error) {
-	ptr := C.fib_iter_create(config.asRawPtr())
+	ptr := C.fib_iter_new(config.asRawPtr())
 	if ptr == nil {
-		return nil, fmt.Errorf("fib_iter_create: allocation failure")
+		return nil, fmt.Errorf("fib_iter_new: allocation failure")
 	}
 	return &fibIter{ptr: ptr}, nil
 }
 
-// destroy maps 1:1 to fib_iter_destroy.
+// destroy maps 1:1 to fib_iter_free.
 func (m *fibIter) destroy() {
-	C.fib_iter_destroy(m.ptr)
+	C.fib_iter_free(m.ptr)
 }
 
 // next maps 1:1 to fib_iter_next.


### PR DESCRIPTION
- Renames the FIB iterator constructor to use the new suffix and its destructor to the free suffix, matching the new/init/fini/free lifecycle convention.
- Updates the CGO call sites and related comments in the Go bindings accordingly.