### PR TITLE
refactor(fwstate): rename module config lifecycle functions to match convention

### DIFF
--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -11,7 +11,7 @@
 #include "modules/fwstate/dataplane/config.h"
 
 static void
-fwstate_config_destroy(struct fwstate_config *config, struct agent *agent) {
+fwstate_config_fini(struct fwstate_config *config, struct agent *agent) {
 	if (config->fw4state != NULL) {
 		fwmap_t *node = ADDR_OF(&config->fw4state);
 		while (node != NULL) {
@@ -45,7 +45,7 @@ fwstate_config_set_defaults(struct fwstate_config *config) {
 }
 
 struct cp_module *
-fwstate_module_config_init(
+fwstate_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 ) {
 	struct fwstate_module_config *config =
@@ -99,7 +99,7 @@ fwstate_module_config_free(struct cp_module *cp_module) {
 	// Capture agent before fini zeroes it.
 	struct agent *agent = ADDR_OF(&cp_module->agent);
 
-	fwstate_config_destroy(&config->cfg, agent);
+	fwstate_config_fini(&config->cfg, agent);
 
 	cp_module_fini(cp_module);
 
@@ -455,7 +455,7 @@ fwstate_config_resolve_map(
 }
 
 int
-fwstate_config_cursor_create(
+fwstate_config_cursor_init(
 	struct cp_module *cp_module,
 	fwstate_cursor_t *cursor,
 	bool is_ipv6,

--- a/modules/fwstate/api/fwstate_cp.h
+++ b/modules/fwstate/api/fwstate_cp.h
@@ -17,7 +17,7 @@ struct layermap_list;
 typedef struct fwstate_outdated_layers fwstate_outdated_layers_t;
 
 struct cp_module *
-fwstate_module_config_init(
+fwstate_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
 );
 
@@ -85,7 +85,7 @@ fwstate_config_resolve_map(
 // Sets key_pos from the provided `index` parameter.
 // Returns 0 on success, -1 if map/layer cannot be resolved.
 int
-fwstate_config_cursor_create(
+fwstate_config_cursor_init(
 	struct cp_module *cp_module,
 	fwstate_cursor_t *cursor,
 	bool is_ipv6,

--- a/modules/fwstate/bindings/go/cfwstate/cgo.go
+++ b/modules/fwstate/bindings/go/cfwstate/cgo.go
@@ -35,7 +35,7 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	defer C.free(unsafe.Pointer(cName))
 
 	var cErr *C.yanet_error
-	ptr := C.fwstate_module_config_init((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
+	ptr := C.fwstate_module_config_new((*C.struct_agent)(agent.AsRawPtr()), cName, &cErr)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to initialize FWState module config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
 	}

--- a/modules/fwstate/bindings/go/cfwstate/safe.go
+++ b/modules/fwstate/bindings/go/cfwstate/safe.go
@@ -270,7 +270,7 @@ func (m *ModuleConfig) readEntries(
 	backward bool,
 ) ([]CursorEntry, int64, bool, error) {
 	var cursor C.fwstate_cursor_t
-	rc := C.fwstate_config_cursor_create(
+	rc := C.fwstate_config_cursor_init(
 		m.asRawPtr(), &cursor,
 		C.bool(isIPv6), C.uint32_t(layerIndex),
 		C.int64_t(index), C.bool(includeExpired),

--- a/modules/fwstate/tests/dataplane/cursor_test_helper.go
+++ b/modules/fwstate/tests/dataplane/cursor_test_helper.go
@@ -80,13 +80,13 @@ func readCursorForward(
 	now uint64, count uint32,
 ) ([]CursorResult, int64, error) {
 	var cursor C.fwstate_cursor_t
-	rc := C.fwstate_config_cursor_create(
+	rc := C.fwstate_config_cursor_init(
 		cpModule, &cursor,
 		C.bool(isIPv6), C.uint32_t(layerIndex),
 		C.int64_t(index), C.bool(includeExpired),
 	)
 	if rc != 0 {
-		return nil, 0, fmt.Errorf("fwstate_config_cursor_create failed: %d", rc)
+		return nil, 0, fmt.Errorf("fwstate_config_cursor_init failed: %d", rc)
 	}
 
 	fwmap := C.fwstate_config_resolve_map(cpModule, C.bool(isIPv6), C.uint32_t(layerIndex))
@@ -132,13 +132,13 @@ func readCursorBackward(
 	now uint64, count uint32,
 ) ([]CursorResult, int64, error) {
 	var cursor C.fwstate_cursor_t
-	rc := C.fwstate_config_cursor_create(
+	rc := C.fwstate_config_cursor_init(
 		cpModule, &cursor,
 		C.bool(isIPv6), C.uint32_t(layerIndex),
 		C.int64_t(index), C.bool(includeExpired),
 	)
 	if rc != 0 {
-		return nil, 0, fmt.Errorf("fwstate_config_cursor_create failed: %d", rc)
+		return nil, 0, fmt.Errorf("fwstate_config_cursor_init failed: %d", rc)
 	}
 
 	fwmap := C.fwstate_config_resolve_map(cpModule, C.bool(isIPv6), C.uint32_t(layerIndex))

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -134,7 +134,7 @@ func fwstateModuleConfig(memCtx testutils.MemoryContext) *C.struct_cp_module {
 	defer C.free(unsafe.Pointer(cName))
 
 	var cErr *C.yanet_error
-	cpModule := C.fwstate_module_config_init(agent, cName, &cErr)
+	cpModule := C.fwstate_module_config_new(agent, cName, &cErr)
 	if cpModule == nil {
 		panic(fmt.Sprintf("failed to initialize fwstate module config: %v", cerrors.FromC(unsafe.Pointer(cErr))))
 	}


### PR DESCRIPTION
- Renames the module config constructor to use the new suffix since it allocates the structure and returns it, matching the new/init/fini/free lifecycle convention.
- Renames the internal config destructor to the fini suffix since it releases field memory without deallocating the struct.
- Renames the cursor constructor to the init suffix since it fills a caller-owned cursor without allocating.
- Updates the CGO call sites in the Go bindings and dataplane test helpers accordingly.