### PR TITLE
refactor(bird-adapter): rename gateway endpoint config to route operator endpoint

### DIFF
--- a/operators/bird-adapter/cmd/yanet-bird-adapter/README.md
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/README.md
@@ -15,10 +15,10 @@ BIRD daemon → Unix Socket → bird-adapter server → gRPC → route service �
 ### Server ([`server.go`](server.go:1))
 gRPC server managing BIRD route imports:
 - Listens on `listen_addr` for configuration requests
-- Connects to `gateway_endpoint` (route service) to send route updates
+- Connects to `route_operator_endpoint` (route service) to send route updates
 - Manages multiple imports simultaneously
 
-**Note:** `gateway_endpoint` is the address where the controlplane gateway listens. The gateway knows how to forward requests to the route module agent.
+**Note:** `route_operator_endpoint` is the endpoint serving the route operator's RouteService. The adapter can connect to the route operator directly or through the gateway, which proxies by service name. MPLS route updates (RouteMPLSService) are only available through the gateway.
 
 ### Client ([`client.go`](client.go:1))
 CLI for configuring the server:
@@ -45,7 +45,7 @@ yanet-bird-adapter server -c config.yaml
 logging:
   level: info
 listen_addr: "localhost:50051"
-gateway_endpoint: "localhost:8080"
+route_operator_endpoint: "localhost:8080"
 ```
 
 ### Configure Import

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
@@ -51,8 +51,10 @@ type ServerConfig struct {
 	Logging logging.Config `yaml:"logging"`
 	// ListenAddr is the gRPC endpoint to listen on (e.g., "localhost:50051").
 	ListenAddr string `yaml:"listen_addr"`
-	// GatewayEndpoint is the gRPC endpoint of the RouteService gateway for RIB updates.
-	GatewayEndpoint string `yaml:"gateway_endpoint"`
+	// RouteOperatorEndpoint is the gRPC endpoint serving the route operator's
+	// RouteService for RIB updates — either the route operator directly or the
+	// gateway that proxies it.
+	RouteOperatorEndpoint string `yaml:"route_operator_endpoint"`
 }
 
 func (m *ServerConfig) Default() {
@@ -65,8 +67,8 @@ func DefaultServerConfig() *ServerConfig {
 		Logging: logging.Config{
 			Level: zapcore.InfoLevel,
 		},
-		ListenAddr:      "localhost:50051",
-		GatewayEndpoint: "localhost:50052",
+		ListenAddr:            "localhost:50051",
+		RouteOperatorEndpoint: "localhost:50052",
 	}
 }
 
@@ -84,11 +86,11 @@ func runServer() error {
 
 	log.Info("starting BIRD adapter service",
 		zap.String("listen_addr", cfg.ListenAddr),
-		zap.String("gateway_endpoint", cfg.GatewayEndpoint),
+		zap.String("route_operator_endpoint", cfg.RouteOperatorEndpoint),
 	)
 
 	// Create the adapter service
-	adapterService := birdAdapter.NewAdapterService(cfg.GatewayEndpoint, log)
+	adapterService := birdAdapter.NewAdapterService(cfg.RouteOperatorEndpoint, log)
 
 	// Create gRPC server
 	grpcServer := grpc.NewServer()

--- a/operators/bird-adapter/etc/yanet/bird-adapter-default.yaml
+++ b/operators/bird-adapter/etc/yanet/bird-adapter-default.yaml
@@ -8,5 +8,6 @@ logging:
 # gRPC endpoint to listen on for adapter service
 listen_addr: "localhost:50051"
 
-# gRPC endpoint of the RouteService gateway for RIB updates
-gateway_endpoint: "localhost:8080"
+# gRPC endpoint serving the route operator's RouteService for RIB updates.
+# Connect directly to the route operator or to the gateway that proxies it.
+route_operator_endpoint: "localhost:8080"

--- a/operators/bird-adapter/service.go
+++ b/operators/bird-adapter/service.go
@@ -47,22 +47,22 @@ func (c *levelFilterCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *za
 type AdapterService struct {
 	adapterpb.UnimplementedAdapterServiceServer
 
-	importsMu       sync.Mutex
-	imports         map[string]*importHolder
-	gatewayEndpoint string    // gRPC endpoint of the RouteService (gateway) for RIB updates
-	quitCh          chan bool // Signals all background BIRD import loops to stop
-	log             *zap.Logger
+	importsMu             sync.Mutex
+	imports               map[string]*importHolder
+	routeOperatorEndpoint string    // gRPC endpoint of the route operator's RouteService for RIB updates
+	quitCh                chan bool // Signals all background BIRD import loops to stop
+	log                   *zap.Logger
 }
 
 func NewAdapterService(
-	gatewayEndpoint string,
+	routeOperatorEndpoint string,
 	log *zap.Logger,
 ) *AdapterService {
 	return &AdapterService{
-		imports:         make(map[string]*importHolder),
-		gatewayEndpoint: gatewayEndpoint,
-		quitCh:          make(chan bool),
-		log:             log,
+		imports:               make(map[string]*importHolder),
+		routeOperatorEndpoint: routeOperatorEndpoint,
+		quitCh:                make(chan bool),
+		log:                   log,
 	}
 }
 
@@ -167,12 +167,12 @@ func (m *AdapterService) SetupConfig(
 	}
 
 	conn, err := grpc.NewClient(
-		m.gatewayEndpoint,
+		m.routeOperatorEndpoint,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(grpc.UseCompressor(gzip.Name)),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to the gateway: %w", err)
+		return nil, fmt.Errorf("failed to connect to the route operator endpoint: %w", err)
 	}
 
 	// And then add dynamic routes, if any.
@@ -192,7 +192,7 @@ var errStreamClosed = fmt.Errorf("stream closed")
 type importHolder struct {
 	export        *bird.Export                                                       // Reads/parses routes from BIRD
 	cancel        context.CancelFunc                                                 // Stops this import's goroutines (runBirdImportLoop, export.Run)
-	conn          *grpc.ClientConn                                                   // gRPC connection to RouteService (gateway)
+	conn          *grpc.ClientConn                                                   // gRPC connection to the route operator's RouteService
 	currentStream *grpc.ClientStreamingClient[routepb.Update, routepb.UpdateSummary] // Active gRPC stream for RIB updates; replaced on reconnect
 	sockets       []string                                                           // Unix socket paths being read from
 	createdAt     time.Time                                                          // Timestamp when the session was created
@@ -200,9 +200,11 @@ type importHolder struct {
 }
 
 // processBirdImport streams BIRD route updates to the control plane RIB.
+//
 // Handles automatic reconnection and graceful cleanup of existing imports.
-// It establishes the initial gRPC stream to the RouteService (gateway), sets up
-// callbacks for the bird.Export reader, and manages replacement of existing imports.
+// It establishes the initial gRPC stream to the route operator's RouteService,
+// sets up callbacks for the bird.Export reader, and manages replacement of
+// existing imports.
 func (m *AdapterService) processBirdImport(
 	conn *grpc.ClientConn,
 	cfg *bird.Config,


### PR DESCRIPTION
- Renames the bird-adapter configuration field gateway_endpoint to route_operator_endpoint: it points at the endpoint serving the route operator RouteService for RIB updates, which can be the route operator directly or the gateway that proxies it by service name — not necessarily the gateway.
- Fixes the misleading comments and the README note that claimed the field is the controlplane gateway address.
- Documents that MPLS route updates (RouteMPLSService) are only available through the gateway, so connecting directly to the route operator works only when no MPLS routes are involved.
- Note for deployments: existing bird-adapter configs must rename the key accordingly.