### PR TITLE
fix(controlplane): fix leak and null dereference on function list info error paths

### DIFF
--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -893,6 +893,9 @@ yanet_get_cp_function_list_info(struct dp_config *dp_config) {
 				sizeof(struct cp_chain_info *) *
 					cp_function->chain_count
 			);
+		if (function_info == NULL) {
+			goto error_free;
+		}
 
 		strtcpy(function_info->name,
 			cp_function->name,
@@ -914,6 +917,7 @@ yanet_get_cp_function_list_info(struct dp_config *dp_config) {
 						cp_chain->length
 				);
 			if (chain_info == NULL) {
+				cp_function_info_free(function_info);
 				goto error_free;
 			}
 


### PR DESCRIPTION
- Add a missing allocation failure check when building per-function info, previously causing a null dereference under out-of-memory conditions.
- Release the partially built function info together with its already collected chain entries when a chain allocation fails, previously leaked because the list cleanup only covers fully stored entries.
- Both defects are reachable only on allocation failure while serving the function list query and were confirmed with a fault-injection harness under LeakSanitizer.