### PR TITLE
fix(controlplane): release spawned counter storage when registry insert fails

### DIFF
--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -132,12 +132,15 @@ module_ectx_create(
 			cp_module->type,
 			cp_module->name
 		);
-		goto error;
+		goto error_storage;
 	}
 
 	SET_OFFSET_OF(&module_ectx->counter_storage, counter_storage);
 
 	return module_ectx;
+
+error_storage:
+	counter_storage_free(counter_storage);
 
 error:
 	memory_bfree(memory_context, module_ectx, ectx_size);


### PR DESCRIPTION
- Release the freshly spawned per-module counter storage when inserting it into the counter storage registry fails during execution context construction.
- Previously the storage was orphaned in the shared memory allocator with elevated reference counts on blocks shared with the previous generation, leaking on every failed configuration generation build.
- The release mirrors the unwind already used internally by the storage spawn path, so shared blocks return to their prior reference counts and newly created blocks are reclaimed.