### PR TITLE
feat(route-operator): support ECMP for static routes in RIB

### DIFF
--- a/operators/route/internal/rib/rib.go
+++ b/operators/route/internal/rib/rib.go
@@ -84,7 +84,7 @@ func (m *RIB) RemoveUnicastRoute(prefix netip.Prefix, nexthopAddr netip.Addr, so
 			// Filter out only static routes with matching nexthop.
 			newRoutes := make([]Route, 0, len(routesList.Routes))
 			for _, r := range routesList.Routes {
-				if r.NextHop == nexthopAddr && r.SourceID == sourceID {
+				if r.NextHop.Unmap() == nexthopAddr.Unmap() && r.SourceID == sourceID {
 					found++
 					continue // skip means remove
 				}

--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -69,6 +69,24 @@ type Route struct {
 	ToRemove bool
 }
 
+// isSameIdentity reports whether two routes share the same RIB identity.
+//
+// BGP-sourced routes are identified by peer because of BGP implicit replace:
+// a peer re-announcing a prefix with a new nexthop must replace its previous
+// path (RFC 4271), so BGP ECMP arises across peers. Static routes are
+// peerless independent entries, so their identity includes the nexthop,
+// allowing multiple static routes for the same prefix with distinct nexthops
+// to coexist.
+func (m Route) isSameIdentity(other Route) bool {
+	if m.SourceID != other.SourceID || m.Peer != other.Peer {
+		return false
+	}
+	if m.SourceID == RouteSourceStatic {
+		return m.NextHop == other.NextHop
+	}
+	return true
+}
+
 func routeCompare(a Route, b Route) int {
 	// higher priority is better
 	if prefDiff := int(a.Pref) - int(b.Pref); prefDiff != 0 {
@@ -97,7 +115,7 @@ type RoutesList struct {
 func (m *RoutesList) Insert(route Route) bool {
 	insertedIdx := -1
 	for idx, r := range m.Routes {
-		if r.Peer == route.Peer && r.SourceID == route.SourceID {
+		if r.isSameIdentity(route) {
 			m.Routes[idx] = route
 			insertedIdx = idx
 			break
@@ -116,7 +134,7 @@ func (m *RoutesList) Insert(route Route) bool {
 func (m *RoutesList) Remove(route Route) bool {
 	// Sorting is not need on removing
 	for idx, r := range m.Routes {
-		if r.Peer == route.Peer && r.SourceID == route.SourceID {
+		if r.isSameIdentity(route) {
 			// Delete with preserving order
 			m.Routes = slices.Delete(m.Routes, idx, idx+1)
 

--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -76,13 +76,14 @@ type Route struct {
 // path (RFC 4271), so BGP ECMP arises across peers. Static routes are
 // peerless independent entries, so their identity includes the nexthop,
 // allowing multiple static routes for the same prefix with distinct nexthops
-// to coexist.
+// to coexist. Static nexthops are compared in normalized (unmapped) form
+// because the API accepts both native IPv4 and IPv4-in-IPv6 encodings.
 func (m Route) isSameIdentity(other Route) bool {
 	if m.SourceID != other.SourceID || m.Peer != other.Peer {
 		return false
 	}
 	if m.SourceID == RouteSourceStatic {
-		return m.NextHop == other.NextHop
+		return m.NextHop.Unmap() == other.NextHop.Unmap()
 	}
 	return true
 }

--- a/operators/route/internal/rib/routes_test.go
+++ b/operators/route/internal/rib/routes_test.go
@@ -100,6 +100,31 @@ func TestRoutesListStaticECMP(t *testing.T) {
 		require.Equal(t, nh2, list.Routes[0].NextHop)
 	})
 
+	t.Run("ipv4-mapped encoding treated as same nexthop", func(t *testing.T) {
+		mapped := netip.MustParseAddr("::ffff:10.0.0.1")
+		var list RoutesList
+		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: unspec, SourceID: RouteSourceStatic}
+		rMapped := Route{Prefix: pfx, NextHop: mapped, Peer: unspec, SourceID: RouteSourceStatic}
+
+		list.Insert(r1)
+		added := list.Insert(rMapped)
+
+		require.False(t, added, "mapped encoding of same nexthop should replace, not append")
+		require.Len(t, list.Routes, 1)
+	})
+
+	t.Run("removal via ipv4-mapped encoding removes native entry", func(t *testing.T) {
+		mapped := netip.MustParseAddr("::ffff:10.0.0.1")
+		var list RoutesList
+		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: unspec, SourceID: RouteSourceStatic}
+
+		list.Insert(r1)
+		removed := list.Remove(Route{Prefix: pfx, NextHop: mapped, Peer: unspec, SourceID: RouteSourceStatic})
+
+		require.True(t, removed, "remove with mapped encoding must find the native entry")
+		require.Empty(t, list.Routes)
+	})
+
 	t.Run("bird implicit replace preserves list length", func(t *testing.T) {
 		birdPeer := netip.MustParseAddr("192.0.2.1")
 		var list RoutesList

--- a/operators/route/internal/rib/routes_test.go
+++ b/operators/route/internal/rib/routes_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func addr(s string) netip.Addr {
+	return netip.MustParseAddr(s)
+}
+
+func peer(s string) netip.Addr {
+	return netip.MustParseAddr(s)
+}
+
 func TestRouteComparator(t *testing.T) {
 	a, b, c := Route{}, Route{}, Route{}
 	a.Prefix = netip.MustParsePrefix("::aaaa/128")
@@ -50,6 +58,69 @@ func TestRouteComparator(t *testing.T) {
 	routes = []Route{a, b, c}
 	slices.SortFunc(routes, routeCompareRev)
 	require.Equal(t, s(b, c, a), s(routes...))
+}
+
+// TestRoutesListStaticECMP verifies that static routes with distinct nexthops
+// coexist as ECMP entries while a re-announced nexthop replaces in place.
+func TestRoutesListStaticECMP(t *testing.T) {
+	pfx := netip.MustParsePrefix("10.0.0.0/24")
+	nh1 := addr("10.0.0.1")
+	nh2 := addr("10.0.0.2")
+	unspec := netip.IPv6Unspecified()
+
+	t.Run("two static routes different nexthops both present", func(t *testing.T) {
+		var list RoutesList
+		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: unspec, SourceID: RouteSourceStatic}
+		r2 := Route{Prefix: pfx, NextHop: nh2, Peer: unspec, SourceID: RouteSourceStatic}
+
+		added1 := list.Insert(r1)
+		added2 := list.Insert(r2)
+
+		require.True(t, added1, "first static route should be added")
+		require.True(t, added2, "second static route with different nexthop should be added")
+		require.Len(t, list.Routes, 2)
+	})
+
+	t.Run("re-insert same static nexthop replaces in place", func(t *testing.T) {
+		var list RoutesList
+		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: unspec, SourceID: RouteSourceStatic}
+		r1Updated := Route{Prefix: pfx, NextHop: nh1, Peer: unspec, SourceID: RouteSourceStatic, Pref: 100}
+
+		list.Insert(r1)
+		added := list.Insert(r1Updated)
+
+		require.False(t, added, "re-insert of same nexthop should return false")
+		require.Len(t, list.Routes, 1)
+		require.Equal(t, uint32(100), list.Routes[0].Pref)
+	})
+
+	t.Run("remove one static nexthop leaves the other", func(t *testing.T) {
+		var list RoutesList
+		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: unspec, SourceID: RouteSourceStatic}
+		r2 := Route{Prefix: pfx, NextHop: nh2, Peer: unspec, SourceID: RouteSourceStatic}
+		list.Insert(r1)
+		list.Insert(r2)
+
+		removed := list.Remove(r1)
+
+		require.True(t, removed)
+		require.Len(t, list.Routes, 1)
+		require.Equal(t, nh2, list.Routes[0].NextHop)
+	})
+
+	t.Run("bird implicit replace preserves list length", func(t *testing.T) {
+		birdPeer := peer("192.0.2.1")
+		var list RoutesList
+		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: birdPeer, SourceID: RouteSourceBird}
+		r2 := Route{Prefix: pfx, NextHop: nh2, Peer: birdPeer, SourceID: RouteSourceBird}
+
+		list.Insert(r1)
+		added := list.Insert(r2)
+
+		require.False(t, added, "bird re-announce from same peer should replace, not append")
+		require.Len(t, list.Routes, 1)
+		require.Equal(t, nh2, list.Routes[0].NextHop)
+	})
 }
 
 func TestRoutesListDeletion(t *testing.T) {

--- a/operators/route/internal/rib/routes_test.go
+++ b/operators/route/internal/rib/routes_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func addr(s string) netip.Addr {
-	return netip.MustParseAddr(s)
-}
-
-func peer(s string) netip.Addr {
-	return netip.MustParseAddr(s)
-}
-
 func TestRouteComparator(t *testing.T) {
 	a, b, c := Route{}, Route{}, Route{}
 	a.Prefix = netip.MustParsePrefix("::aaaa/128")
@@ -64,8 +56,8 @@ func TestRouteComparator(t *testing.T) {
 // coexist as ECMP entries while a re-announced nexthop replaces in place.
 func TestRoutesListStaticECMP(t *testing.T) {
 	pfx := netip.MustParsePrefix("10.0.0.0/24")
-	nh1 := addr("10.0.0.1")
-	nh2 := addr("10.0.0.2")
+	nh1 := netip.MustParseAddr("10.0.0.1")
+	nh2 := netip.MustParseAddr("10.0.0.2")
 	unspec := netip.IPv6Unspecified()
 
 	t.Run("two static routes different nexthops both present", func(t *testing.T) {
@@ -109,7 +101,7 @@ func TestRoutesListStaticECMP(t *testing.T) {
 	})
 
 	t.Run("bird implicit replace preserves list length", func(t *testing.T) {
-		birdPeer := peer("192.0.2.1")
+		birdPeer := netip.MustParseAddr("192.0.2.1")
 		var list RoutesList
 		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: birdPeer, SourceID: RouteSourceBird}
 		r2 := Route{Prefix: pfx, NextHop: nh2, Peer: birdPeer, SourceID: RouteSourceBird}


### PR DESCRIPTION
- Static routes for the same prefix with distinct nexthops no longer overwrite each other: route identity now includes the nexthop for peerless static routes, while BGP-fed routes keep their peer-based identity to preserve implicit-replace semantics.
- Insert and remove paths share a single identity helper so they cannot diverge.
- Covered by tests: static ECMP coexistence, in-place replacement of the same nexthop, removal of a single nexthop, and BGP implicit replace.