### PR TITLE
feat(route-operator): accept multiple nexthops in route insert and delete API

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -25,3 +25,4 @@ breaking:
     - PACKAGE
   ignore:
     - modules/balancer2
+    - operators/route/operatorpb

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -116,8 +116,9 @@ pub struct RouteInsertCmd {
     /// Configuration name.
     #[arg(long = "name", short = 'n')]
     pub name: String,
-    /// Next-hop IP address(es); repeat to specify multiple nexthops for ECMP.
-    #[arg(long = "via", num_args = 1.., required = true)]
+    /// Next-hop IP address(es); repeat `--via` to specify multiple nexthops for
+    /// ECMP.
+    #[arg(long = "via", required = true)]
     pub nexthop_addrs: Vec<IpAddr>,
     /// Route source type (static or bird). Defaults to static.
     #[arg(long = "source", default_value = "static")]
@@ -131,8 +132,9 @@ pub struct RouteRemoveCmd {
     /// Configuration name.
     #[arg(long = "name", short = 'n')]
     pub name: String,
-    /// Next-hop IP address(es); repeat to specify multiple nexthops for ECMP.
-    #[arg(long = "via", num_args = 1.., required = true)]
+    /// Next-hop IP address(es); repeat `--via` to specify multiple nexthops for
+    /// ECMP.
+    #[arg(long = "via", required = true)]
     pub nexthop_addrs: Vec<IpAddr>,
     /// Route source type (static or bird). Defaults to static.
     #[arg(long = "source", default_value = "static")]
@@ -749,6 +751,80 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// `--via ADDR PREFIX` must not consume the positional prefix as a second
+    /// nexthop.
+    #[test]
+    fn insert_via_does_not_consume_prefix() {
+        let cmd = Cmd::try_parse_from([
+            "yanet-cli-operator-route",
+            "insert",
+            "--via",
+            "192.0.2.1",
+            "10.0.0.0/8",
+            "-n",
+            "cfg",
+        ])
+        .expect("parse must succeed");
+
+        let ModeCmd::Insert(insert) = cmd.mode else {
+            panic!("expected Insert variant");
+        };
+
+        assert_eq!("10.0.0.0/8", insert.prefix.to_string());
+        assert_eq!(1, insert.nexthop_addrs.len());
+        assert_eq!("192.0.2.1", insert.nexthop_addrs[0].to_string());
+    }
+
+    /// Repeating `--via` accumulates nexthops for ECMP routes.
+    #[test]
+    fn insert_via_repeated_accumulates_nexthops() {
+        let cmd = Cmd::try_parse_from([
+            "yanet-cli-operator-route",
+            "insert",
+            "--via",
+            "192.0.2.1",
+            "--via",
+            "192.0.2.2",
+            "10.0.0.0/8",
+            "-n",
+            "cfg",
+        ])
+        .expect("parse must succeed");
+
+        let ModeCmd::Insert(insert) = cmd.mode else {
+            panic!("expected Insert variant");
+        };
+
+        assert_eq!("10.0.0.0/8", insert.prefix.to_string());
+        assert_eq!(2, insert.nexthop_addrs.len());
+        assert_eq!("192.0.2.1", insert.nexthop_addrs[0].to_string());
+        assert_eq!("192.0.2.2", insert.nexthop_addrs[1].to_string());
+    }
+
+    /// `--via ADDR PREFIX` in remove must not consume the positional prefix as
+    /// a second nexthop.
+    #[test]
+    fn remove_via_does_not_consume_prefix() {
+        let cmd = Cmd::try_parse_from([
+            "yanet-cli-operator-route",
+            "remove",
+            "--via",
+            "192.0.2.1",
+            "10.0.0.0/8",
+            "-n",
+            "cfg",
+        ])
+        .expect("parse must succeed");
+
+        let ModeCmd::Remove(remove) = cmd.mode else {
+            panic!("expected Remove variant");
+        };
+
+        assert_eq!("10.0.0.0/8", remove.prefix.to_string());
+        assert_eq!(1, remove.nexthop_addrs.len());
+        assert_eq!("192.0.2.1", remove.nexthop_addrs[0].to_string());
+    }
 
     #[test]
     fn format_age_none_returns_dash() {

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -116,9 +116,9 @@ pub struct RouteInsertCmd {
     /// Configuration name.
     #[arg(long = "name", short = 'n')]
     pub name: String,
-    /// Next-hop IP address.
-    #[arg(long = "via")]
-    pub nexthop_addr: IpAddr,
+    /// Next-hop IP address(es); repeat to specify multiple nexthops for ECMP.
+    #[arg(long = "via", num_args = 1.., required = true)]
+    pub nexthop_addrs: Vec<IpAddr>,
     /// Route source type (static or bird). Defaults to static.
     #[arg(long = "source", default_value = "static")]
     pub source: RouteSource,
@@ -131,9 +131,9 @@ pub struct RouteRemoveCmd {
     /// Configuration name.
     #[arg(long = "name", short = 'n')]
     pub name: String,
-    /// Next-hop IP address.
-    #[arg(long = "via")]
-    pub nexthop_addr: IpAddr,
+    /// Next-hop IP address(es); repeat to specify multiple nexthops for ECMP.
+    #[arg(long = "via", num_args = 1.., required = true)]
+    pub nexthop_addrs: Vec<IpAddr>,
     /// Route source type (static or bird). Defaults to static.
     #[arg(long = "source", default_value = "static")]
     pub source: RouteSource,
@@ -312,10 +312,12 @@ impl RouteService {
     }
 
     pub async fn insert_route(&mut self, cmd: RouteInsertCmd) -> Result<(), Error> {
+        let nexthop_addrs = cmd.nexthop_addrs.iter().copied().map(Into::into).collect();
+
         let request = InsertRouteRequest {
             name: cmd.name.clone(),
             prefix: cmd.prefix.to_string(),
-            nexthop_addr: Some(cmd.nexthop_addr.into()),
+            nexthop_addrs,
             do_flush: true,
             source_id: cmd.source.to_proto().into(),
         };
@@ -325,12 +327,19 @@ impl RouteService {
             .await
             .map_err(self.map_err("insert"))?;
 
+        let via = cmd
+            .nexthop_addrs
+            .iter()
+            .map(|a| a.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+
         output::success(
             "insert",
             format_args!(
                 "inserted {} via {} in {} (source: {})",
                 cmd.prefix,
-                cmd.nexthop_addr,
+                via,
                 cmd.name,
                 cmd.source.as_str()
             ),
@@ -340,10 +349,12 @@ impl RouteService {
     }
 
     pub async fn remove_route(&mut self, cmd: RouteRemoveCmd) -> Result<(), Error> {
+        let nexthop_addrs = cmd.nexthop_addrs.iter().copied().map(Into::into).collect();
+
         let request = DeleteRouteRequest {
             name: cmd.name.clone(),
             prefix: cmd.prefix.to_string(),
-            nexthop_addr: Some(cmd.nexthop_addr.into()),
+            nexthop_addrs,
             do_flush: true,
             source_id: cmd.source.to_proto().into(),
         };
@@ -353,12 +364,19 @@ impl RouteService {
             .await
             .map_err(self.map_err("remove"))?;
 
+        let via = cmd
+            .nexthop_addrs
+            .iter()
+            .map(|a| a.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+
         output::success(
             "remove",
             format_args!(
                 "removed {} via {} from {} (source: {})",
                 cmd.prefix,
-                cmd.nexthop_addr,
+                via,
                 cmd.name,
                 cmd.source.as_str()
             ),

--- a/operators/route/internal/operator/service_route.go
+++ b/operators/route/internal/operator/service_route.go
@@ -195,6 +195,15 @@ func (m *RouteService) InsertRoute(
 	}
 
 	sourceID := req.RouteSourceID()
+
+	// Non-static sources use peer identity to distinguish routes: the unary
+	// InsertRoute API carries no peer, so consecutive AddUnicastRoute calls
+	// for the same (prefix, source) would silently replace one another.
+	// Reject the ambiguous case early rather than keeping only the last nexthop.
+	if sourceID != rib.RouteSourceStatic && len(nexthops) > 1 {
+		return nil, status.Error(codes.InvalidArgument, "multiple nexthops are only supported for static routes")
+	}
+
 	holder := m.getOrCreateRib(name)
 
 	for _, nexthopAddr := range nexthops {

--- a/operators/route/internal/operator/service_route.go
+++ b/operators/route/internal/operator/service_route.go
@@ -180,16 +180,27 @@ func (m *RouteService) InsertRoute(
 		return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix %q: %v", req.GetPrefix(), err)
 	}
 
-	nexthopAddr, err := req.GetNexthopAddr().ToAddr()
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid nexthop_addr (bytes=%x): %v", req.GetNexthopAddr().GetAddr(), err)
+	addrs := req.GetNexthopAddrs()
+	if len(addrs) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "at least one nexthop address is required")
+	}
+
+	nexthops := make([]netip.Addr, 0, len(addrs))
+	for _, a := range addrs {
+		nexthop, parseErr := a.ToAddr()
+		if parseErr != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid nexthop_addrs entry (bytes=%x): %v", a.GetAddr(), parseErr)
+		}
+		nexthops = append(nexthops, nexthop)
 	}
 
 	sourceID := req.RouteSourceID()
 	holder := m.getOrCreateRib(name)
 
-	if err := holder.AddUnicastRoute(prefix, nexthopAddr, sourceID); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to add unicast route: %v", err)
+	for _, nexthopAddr := range nexthops {
+		if err := holder.AddUnicastRoute(prefix, nexthopAddr, sourceID); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to add unicast route: %v", err)
+		}
 	}
 
 	// Wake the reconcile loop only when the caller explicitly asks for a
@@ -215,9 +226,18 @@ func (m *RouteService) DeleteRoute(
 		return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
 	}
 
-	nexthopAddr, err := req.GetNexthopAddr().ToAddr()
-	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "invalid nexthop_addr (bytes=%x): %v", req.GetNexthopAddr().GetAddr(), err)
+	addrs := req.GetNexthopAddrs()
+	if len(addrs) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "at least one nexthop address is required")
+	}
+
+	nexthops := make([]netip.Addr, 0, len(addrs))
+	for _, a := range addrs {
+		nexthop, parseErr := a.ToAddr()
+		if parseErr != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid nexthop_addrs entry (bytes=%x): %v", a.GetAddr(), parseErr)
+		}
+		nexthops = append(nexthops, nexthop)
 	}
 
 	sourceID := req.RouteSourceID()
@@ -226,8 +246,10 @@ func (m *RouteService) DeleteRoute(
 		return &operatorpb.DeleteRouteResponse{}, nil
 	}
 
-	if err := holder.RemoveUnicastRoute(prefix, nexthopAddr, sourceID); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to remove unicast route: %v", err)
+	for _, nexthopAddr := range nexthops {
+		if err := holder.RemoveUnicastRoute(prefix, nexthopAddr, sourceID); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to remove unicast route: %v", err)
+		}
 	}
 
 	// Wake the reconcile loop only when the caller explicitly asks for a

--- a/operators/route/internal/operator/service_route_test.go
+++ b/operators/route/internal/operator/service_route_test.go
@@ -1,0 +1,35 @@
+package operator
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
+	operatorpb "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
+)
+
+func TestInsertRoute_NonStaticMultipleNexthops_InvalidArgument(t *testing.T) {
+	svc := NewRouteService(neigh.NewNeighTable())
+
+	req := &operatorpb.InsertRouteRequest{
+		Name:   "route0",
+		Prefix: "10.0.0.0/24",
+		NexthopAddrs: []*commonpb.IPAddress{
+			commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.1")),
+			commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.2")),
+		},
+		SourceId: operatorpb.RouteSourceID_ROUTE_SOURCE_ID_BIRD,
+	}
+
+	_, err := svc.InsertRoute(context.Background(), req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+}

--- a/operators/route/operatorpb/v1/convert.go
+++ b/operators/route/operatorpb/v1/convert.go
@@ -2,6 +2,7 @@ package operatorpb
 
 import (
 	"fmt"
+	"math"
 	"net/netip"
 	"time"
 
@@ -90,9 +91,11 @@ func ToRIBRoute(route *Route, toRemove bool) (*rib.Route, error) {
 		OriginAS:         route.GetOriginAs(),
 		Med:              route.GetMed(),
 		Pref:             route.GetPref(),
-		ASPathLen:        uint8(route.GetAsPathLen()),
-		SourceID:         sourceID,
-		ToRemove:         toRemove,
+		// Wire field is uint32; saturate so absurdly long paths stay worst
+		// instead of wrapping to best.
+		ASPathLen: uint8(min(route.GetAsPathLen(), uint32(math.MaxUint8))),
+		SourceID:  sourceID,
+		ToRemove:  toRemove,
 	}, nil
 }
 

--- a/operators/route/operatorpb/v1/route.proto
+++ b/operators/route/operatorpb/v1/route.proto
@@ -69,8 +69,8 @@ message InsertRouteRequest {
   string name = 1;
   // The destination prefix of the route.
   string prefix = 2;
-  // The IP address of the nexthop router.
-  common.commonpb.v1.IPAddress nexthop_addr = 3;
+  // NexthopAddrs is the list of nexthop IP addresses.
+  repeated common.commonpb.v1.IPAddress nexthop_addrs = 3;
 
   // Indicates whether the RIB should be flushed to the FIB after this
   // request.
@@ -87,7 +87,8 @@ message InsertRouteResponse {}
 message DeleteRouteRequest {
   string name = 1;
   string prefix = 2;
-  common.commonpb.v1.IPAddress nexthop_addr = 3;
+  // NexthopAddrs is the list of nexthop IP addresses.
+  repeated common.commonpb.v1.IPAddress nexthop_addrs = 3;
 
   bool do_flush = 4;
   RouteSourceID source_id = 5;

--- a/web/src/api/routes.ts
+++ b/web/src/api/routes.ts
@@ -47,7 +47,7 @@ export interface ShowRoutesResponse {
 export interface InsertRouteRequest {
     name?: string;
     prefix?: string;
-    nexthop_addr?: IPAddressWire;
+    nexthop_addrs?: IPAddressWire[];
     do_flush?: boolean;
     source_id?: RouteSourceID;
 }
@@ -58,7 +58,7 @@ export interface InsertRouteResponse {
 export interface DeleteRouteRequest {
     name?: string;
     prefix?: string;
-    nexthop_addr?: IPAddressWire;
+    nexthop_addrs?: IPAddressWire[];
     do_flush?: boolean;
     source_id?: RouteSourceID;
 }

--- a/web/src/pages/operators/route/RouteDrawer.tsx
+++ b/web/src/pages/operators/route/RouteDrawer.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Switch } from '@gravity-ui/uikit';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Button, Icon, Switch } from '@gravity-ui/uikit';
+import { Plus, TrashBin } from '@gravity-ui/icons';
 import { DraftItemDrawer } from '../../../components/draft';
 import { ipAddressToString } from '../../../utils/netip';
 import { validatePrefix, validateNexthop } from './utils';
@@ -12,11 +13,11 @@ export interface RouteDrawerProps {
     route: Route | null;
     configName: string;
     onClose: () => void;
-    onSubmit: (params: { prefix: string; nexthopAddr: string; doFlush: boolean }) => Promise<void>;
+    onSubmit: (params: { prefix: string; nexthopAddrs: string[]; doFlush: boolean }) => Promise<void>;
     onDelete?: (route: Route) => Promise<void>;
 }
 
-/** Drawer for adding or editing a single RIB route. */
+/** Drawer for adding or editing a RIB route with one or more ECMP nexthops. */
 const RouteDrawer: React.FC<RouteDrawerProps> = ({
     open,
     mode,
@@ -27,28 +28,52 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
     onDelete,
 }) => {
     const [prefix, setPrefix] = useState('');
-    const [nexthopAddr, setNexthopAddr] = useState('');
+    const [nexthopRows, setNexthopRows] = useState<string[]>(['']);
     const [doFlush, setDoFlush] = useState(false);
     const [submitting, setSubmitting] = useState(false);
 
     useEffect(() => {
         if (open) {
             setPrefix(mode === 'edit' && route ? (route.prefix || '') : '');
-            setNexthopAddr(mode === 'edit' && route ? ipAddressToString(route.next_hop) : '');
+            setNexthopRows(mode === 'edit' && route ? [ipAddressToString(route.next_hop)] : ['']);
             setDoFlush(false);
             setSubmitting(false);
         }
     }, [open, mode, route?.prefix, route?.next_hop]);
 
+    const nexthopErrors = nexthopRows.map((v) => validateNexthop(v));
     const prefixError = validatePrefix(prefix);
-    const nexthopError = validateNexthop(nexthopAddr);
-    const canSubmit = prefix.trim() !== '' && nexthopAddr.trim() !== '' && !prefixError && !nexthopError && !submitting;
+
+    const allFilled = nexthopRows.length > 0
+        && nexthopRows.every((v) => v.trim() !== '')
+        && nexthopErrors.every((e) => !e);
+
+    const canSubmit = prefix.trim() !== ''
+        && !prefixError
+        && allFilled
+        && !submitting;
+
+    const handleChangeRow = useCallback((idx: number, value: string): void => {
+        setNexthopRows((prev) => prev.map((v, i) => (i === idx ? value : v)));
+    }, []);
+
+    const handleAddRow = useCallback((): void => {
+        setNexthopRows((prev) => [...prev, '']);
+    }, []);
+
+    const handleRemoveRow = useCallback((idx: number): void => {
+        setNexthopRows((prev) => prev.length > 1 ? prev.filter((_, i) => i !== idx) : prev);
+    }, []);
 
     const handleApply = async (): Promise<void> => {
         if (!canSubmit) return;
         setSubmitting(true);
         try {
-            await onSubmit({ prefix: prefix.trim(), nexthopAddr: nexthopAddr.trim(), doFlush });
+            await onSubmit({
+                prefix: prefix.trim(),
+                nexthopAddrs: nexthopRows.map((v) => v.trim()),
+                doFlush,
+            });
             onClose();
         } finally {
             setSubmitting(false);
@@ -115,21 +140,46 @@ const RouteDrawer: React.FC<RouteDrawerProps> = ({
             </section>
 
             <section className="yn-section">
-                <div className="yn-section-h">Next Hop</div>
+                <div className="yn-section-h">
+                    Next Hops
+                    <span className="ro-nexthop-section-hint">ECMP — one per row</span>
+                </div>
                 <div className="yn-section__body">
-                    <div className="yn-field">
-                        <label className="yn-field__label">
-                            Next Hop IP <span className="yn-field__req">*</span>
-                        </label>
-                        <input
-                            className={`yn-input yn-input--mono${nexthopError ? ' yn-input--invalid' : ''}`}
-                            value={nexthopAddr}
-                            placeholder="192.168.1.1 or 2001:db8::1"
-                            onChange={(e) => setNexthopAddr(e.target.value)}
-                        />
-                        {nexthopError && (
-                            <span className="yn-field__hint yn-field__error">{nexthopError}</span>
-                        )}
+                    <div className="ro-nexthop-list">
+                        {nexthopRows.map((val, idx) => (
+                            <div key={idx} className="ro-nexthop-row">
+                                <div className="yn-field ro-nexthop-row__field">
+                                    <label className="yn-field__label">
+                                        Next Hop IP <span className="yn-field__req">*</span>
+                                    </label>
+                                    <input
+                                        className={`yn-input yn-input--mono${nexthopErrors[idx] ? ' yn-input--invalid' : ''}`}
+                                        value={val}
+                                        placeholder="192.168.1.1 or 2001:db8::1"
+                                        onChange={(e) => handleChangeRow(idx, e.target.value)}
+                                    />
+                                    {nexthopErrors[idx] && (
+                                        <span className="yn-field__hint yn-field__error">{nexthopErrors[idx]}</span>
+                                    )}
+                                </div>
+                                {nexthopRows.length > 1 && (
+                                    <button
+                                        type="button"
+                                        className="ro-nexthop-row__remove"
+                                        title="Remove this nexthop"
+                                        onClick={() => handleRemoveRow(idx)}
+                                    >
+                                        <Icon data={TrashBin} size={14} />
+                                    </button>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                    <div className="ro-nexthop-add-row">
+                        <Button view="outlined" size="s" onClick={handleAddRow}>
+                            <Icon data={Plus} size={14} />
+                            Add nexthop
+                        </Button>
                     </div>
                 </div>
             </section>

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -8,7 +8,7 @@ import type { Command, RowAdapter, ShortcutSection, PagePaletteContribution } fr
 import { useListNavigation, usePageContribution, useTabCycle } from '../../../hooks';
 import { API } from '../../../api';
 import { toaster, parseIPAddress } from '../../../utils';
-import { stringToIPAddress, ipAddressToString } from '../../../utils/netip';
+import { stringToIPAddress, ipAddressToString, type IPAddressWire } from '../../../utils/netip';
 import { RouteSourceID, type Route } from '../../../api/routes';
 import { useRIB } from './useRIB';
 import { RIBTable } from './RIBTable';
@@ -138,20 +138,21 @@ const RoutePage: React.FC = () => {
         setDrawer((prev) => ({ ...prev, open: false }));
     }, []);
 
-    const handleSubmitRoute = useCallback(async (params: { prefix: string; nexthopAddr: string; doFlush: boolean }): Promise<void> => {
-        const nexthopIp = stringToIPAddress(params.nexthopAddr);
-        if (!nexthopIp) {
-            toaster.error('route-nexthop-error', 'Invalid next-hop address');
+    const handleSubmitRoute = useCallback(async (params: { prefix: string; nexthopAddrs: string[]; doFlush: boolean }): Promise<void> => {
+        const parsed = params.nexthopAddrs.map((addr) => stringToIPAddress(addr));
+        if (parsed.some((ip) => !ip) || parsed.length === 0) {
+            toaster.error('route-nexthop-error', 'One or more next-hop addresses are invalid');
             return;
         }
+        const nexthopIps = parsed as IPAddressWire[];
 
         const isEdit = drawer.mode === 'edit';
         const original = drawer.route;
-        const newNexthopStr = ipAddressToString(nexthopIp);
+        const newNexthopStr = ipAddressToString(nexthopIps[0]);
         const originalNexthopStr = ipAddressToString(original?.next_hop);
         const ops = planRouteSubmit(
             drawer.mode,
-            { prefix: params.prefix, nexthopIp, doFlush: params.doFlush },
+            { prefix: params.prefix, nexthopIps, doFlush: params.doFlush },
             newNexthopStr,
             original,
             originalNexthopStr,
@@ -163,7 +164,7 @@ const RoutePage: React.FC = () => {
                     await API.route.deleteRoute({
                         name: currentConfig,
                         prefix: op.prefix,
-                        nexthop_addr: op.nexthop,
+                        nexthop_addrs: [op.nexthop],
                         do_flush: false,
                         source_id: RouteSourceID.STATIC,
                     });
@@ -171,7 +172,7 @@ const RoutePage: React.FC = () => {
                     await API.route.insertRoute({
                         name: currentConfig,
                         prefix: op.prefix,
-                        nexthop_addr: op.nexthop,
+                        nexthop_addrs: op.nexthops,
                         do_flush: op.doFlush,
                         source_id: RouteSourceID.STATIC,
                     });
@@ -195,7 +196,7 @@ const RoutePage: React.FC = () => {
             await API.route.deleteRoute({
                 name: currentConfig,
                 prefix: route.prefix,
-                nexthop_addr: route.next_hop,
+                nexthop_addrs: [route.next_hop],
                 do_flush: true,
                 source_id: RouteSourceID.STATIC,
             });
@@ -243,7 +244,7 @@ const RoutePage: React.FC = () => {
                 await API.route.deleteRoute({
                     name: currentConfig,
                     prefix: route.prefix,
-                    nexthop_addr: route.next_hop,
+                    nexthop_addrs: [route.next_hop],
                     do_flush: true,
                     source_id: RouteSourceID.STATIC,
                 });

--- a/web/src/pages/operators/route/route.scss
+++ b/web/src/pages/operators/route/route.scss
@@ -48,6 +48,58 @@
     @include toggle-chip-badge;
 }
 
+.ro-nexthop-section-hint {
+    margin-left: 8px;
+    font-size: 11px;
+    font-weight: 400;
+    color: var(--yn-text-3);
+    text-transform: none;
+    letter-spacing: 0;
+}
+
+.ro-nexthop-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.ro-nexthop-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+
+    &__field {
+        flex: 1;
+        margin: 0 !important;
+    }
+
+    &__remove {
+        flex-shrink: 0;
+        margin-top: 22px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        border: none;
+        background: none;
+        border-radius: var(--yn-r-sm);
+        color: var(--yn-text-3);
+        cursor: pointer;
+        transition: color 0.1s, background 0.1s;
+
+        &:hover {
+            color: var(--g-color-text-danger);
+            background: color-mix(in srgb, var(--g-color-text-danger) 10%, transparent);
+        }
+    }
+}
+
+.ro-nexthop-add-row {
+    display: flex;
+}
+
 // ─── Lookup drawer ─────────────────────────────────────────────────────────────
 
 .ro-lookup-drawer {

--- a/web/src/pages/operators/route/utils.test.ts
+++ b/web/src/pages/operators/route/utils.test.ts
@@ -10,10 +10,10 @@ import type { Route } from '../../../api/routes';
 describe('planRouteSubmit', () => {
     const ip = (s: string) => stringToIPAddress(s)!;
 
-    it('add mode: produces a single insert op', () => {
+    it('add mode: produces a single insert op with one nexthop', () => {
         const ops = planRouteSubmit(
             'add',
-            { prefix: '10.0.0.0/8', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            { prefix: '10.0.0.0/8', nexthopIps: [ip('192.168.1.1')], doFlush: false },
             '192.168.1.1',
             null,
             '',
@@ -22,7 +22,23 @@ describe('planRouteSubmit', () => {
         expect(ops[0].type).toBe('insert');
         if (ops[0].type === 'insert') {
             expect(ops[0].prefix).toBe('10.0.0.0/8');
+            expect(ops[0].nexthops).toHaveLength(1);
             expect(ops[0].doFlush).toBe(false);
+        }
+    });
+
+    it('add mode: produces a single insert op with multiple ECMP nexthops', () => {
+        const ops = planRouteSubmit(
+            'add',
+            { prefix: '10.0.0.0/8', nexthopIps: [ip('192.168.1.1'), ip('192.168.1.2')], doFlush: false },
+            '192.168.1.1',
+            null,
+            '',
+        );
+        expect(ops).toHaveLength(1);
+        expect(ops[0].type).toBe('insert');
+        if (ops[0].type === 'insert') {
+            expect(ops[0].nexthops).toHaveLength(2);
         }
     });
 
@@ -30,7 +46,7 @@ describe('planRouteSubmit', () => {
         const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
         const ops = planRouteSubmit(
             'edit',
-            { prefix: '10.0.0.0/8', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            { prefix: '10.0.0.0/8', nexthopIps: [ip('192.168.1.1')], doFlush: false },
             '192.168.1.1',
             original,
             '192.168.1.1',
@@ -43,7 +59,7 @@ describe('planRouteSubmit', () => {
         const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
         const ops = planRouteSubmit(
             'edit',
-            { prefix: '172.16.0.0/12', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            { prefix: '172.16.0.0/12', nexthopIps: [ip('192.168.1.1')], doFlush: false },
             '192.168.1.1',
             original,
             '192.168.1.1',
@@ -63,7 +79,7 @@ describe('planRouteSubmit', () => {
         const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
         const ops = planRouteSubmit(
             'edit',
-            { prefix: '10.0.0.0/8', nexthopIp: ip('10.0.0.1'), doFlush: true },
+            { prefix: '10.0.0.0/8', nexthopIps: [ip('10.0.0.1')], doFlush: true },
             '10.0.0.1',
             original,
             '192.168.1.1',
@@ -80,7 +96,7 @@ describe('planRouteSubmit', () => {
         const original: Route = { prefix: '10.0.0.0/8', next_hop: ip('192.168.1.1') };
         const ops = planRouteSubmit(
             'edit',
-            { prefix: '172.16.0.0/12', nexthopIp: ip('10.0.0.1'), doFlush: false },
+            { prefix: '172.16.0.0/12', nexthopIps: [ip('10.0.0.1')], doFlush: false },
             '10.0.0.1',
             original,
             '192.168.1.1',
@@ -94,7 +110,7 @@ describe('planRouteSubmit', () => {
         const original: Route = { next_hop: ip('192.168.1.1') };
         const ops = planRouteSubmit(
             'edit',
-            { prefix: '10.0.0.0/8', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            { prefix: '10.0.0.0/8', nexthopIps: [ip('192.168.1.1')], doFlush: false },
             '192.168.1.1',
             original,
             '192.168.1.1',
@@ -107,7 +123,7 @@ describe('planRouteSubmit', () => {
         const original: Route = { prefix: '10.0.0.0/8' };
         const ops = planRouteSubmit(
             'edit',
-            { prefix: '172.16.0.0/12', nexthopIp: ip('192.168.1.1'), doFlush: false },
+            { prefix: '172.16.0.0/12', nexthopIps: [ip('192.168.1.1')], doFlush: false },
             '192.168.1.1',
             original,
             '',

--- a/web/src/pages/operators/route/utils.ts
+++ b/web/src/pages/operators/route/utils.ts
@@ -5,17 +5,18 @@ import type { RouteSortableColumn, IPFamily } from './types';
 
 export interface RouteSubmitParams {
     prefix: string;
-    nexthopIp: IPAddressWire;
+    nexthopIps: IPAddressWire[];
     doFlush: boolean;
 }
 
 export type RouteSubmitOp =
     | { type: 'delete'; prefix: string; nexthop: IPAddressWire }
-    | { type: 'insert'; prefix: string; nexthop: IPAddressWire; doFlush: boolean };
+    | { type: 'insert'; prefix: string; nexthops: IPAddressWire[]; doFlush: boolean };
 
 /** Plan API operations for submitting a route. In add mode, just insert.
  *
- * In edit mode, delete the original first when its key changed. */
+ * In edit mode, delete the original first when its key changed. The insert
+ * carries all nexthop addresses for ECMP. */
 export const planRouteSubmit = (
     mode: 'add' | 'edit',
     params: RouteSubmitParams,
@@ -30,7 +31,7 @@ export const planRouteSubmit = (
     if (keyChanged && original?.prefix && original.next_hop) {
         ops.push({ type: 'delete', prefix: original.prefix, nexthop: original.next_hop });
     }
-    ops.push({ type: 'insert', prefix: params.prefix, nexthop: params.nexthopIp, doFlush: params.doFlush });
+    ops.push({ type: 'insert', prefix: params.prefix, nexthops: params.nexthopIps, doFlush: params.doFlush });
     return ops;
 };
 


### PR DESCRIPTION
- The route operator API now takes a repeated list of nexthop addresses in insert and delete requests, enabling ECMP static routes end to end.
- The previous singular nexthop field is removed without backward compatibility since the API is consumed only by the bundled CLI and web UI; the operator proto package is excluded from buf breaking checks for this transition.
- The CLI accepts multiple --via values and the web UI insert form supports a dynamic list of nexthop rows.

Based on #1214 and should be reviewed and merged after it.