### PR TITLE
feat(route-operator): install only per-source best routes into FIB

### DIFF
--- a/operators/route/internal/operator/fib_build.go
+++ b/operators/route/internal/operator/fib_build.go
@@ -34,6 +34,8 @@ type FIBBuildStats struct {
 	NeighbourNotFound int
 	HardwareRoutes    int
 	PrefixesAdded     int
+	// FilteredRoutes counts routes excluded by the per-source best-group filter.
+	FilteredRoutes int
 }
 
 // BuildFIB resolves a RIB dump against the supplied neighbour view and
@@ -56,8 +58,11 @@ func BuildFIB(
 
 			stats.TotalRoutes += len(routesList.Routes)
 
-			nexthops := make([]neigh.HardwareRoute, 0, len(routesList.Routes))
-			for _, r := range routesList.Routes {
+			bestRoutes := routesList.BestPerSource()
+			stats.FilteredRoutes += len(routesList.Routes) - len(bestRoutes)
+
+			nexthops := make([]neigh.HardwareRoute, 0, len(bestRoutes))
+			for _, r := range bestRoutes {
 				entry, ok := neighbours.Lookup(r.NextHop.Unmap())
 				if !ok {
 					stats.NeighbourNotFound++

--- a/operators/route/internal/operator/fib_build_test.go
+++ b/operators/route/internal/operator/fib_build_test.go
@@ -23,6 +23,119 @@ func mustParseMAC(t *testing.T, value string) [6]byte {
 	return [6]byte(mac)
 }
 
+// Test_BuildFIB_BestPerSourceFiltersWorse verifies that lower-cost routes from
+// the same source are excluded when a strictly better route exists for that source.
+func Test_BuildFIB_BestPerSourceFiltersWorse(t *testing.T) {
+	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
+	routeFor := func(addr, sourceMAC, destinationMAC string, device string) {
+		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
+			HardwareRoute: neigh.HardwareRoute{
+				SourceMAC:      mustParseMAC(t, sourceMAC),
+				DestinationMAC: mustParseMAC(t, destinationMAC),
+				Device:         device,
+			},
+		})
+	}
+
+	routeFor("10.0.0.1", "0a:00:00:00:00:01", "0a:00:00:00:10:00", "eth1")
+	routeFor("10.0.0.2", "0a:00:00:00:00:02", "0a:00:00:00:20:00", "eth2")
+
+	p1 := netip.MustParseAddr("192.0.2.1")
+	p2 := netip.MustParseAddr("192.0.2.2")
+
+	ribDump := maptrie.NewMapTrie[netip.Prefix, netip.Addr, rib.RoutesList](2)
+	ribDump[24][netip.MustParsePrefix("10.0.0.0/24")] = rib.RoutesList{
+		Routes: []rib.Route{
+			// Best bird route (Pref=200) — should be in FIB.
+			{NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: rib.RouteSourceBird, Pref: 200},
+			// Worse bird route (Pref=100) — should be filtered out.
+			{NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: rib.RouteSourceBird, Pref: 100},
+		},
+	}
+
+	fib, stats := BuildFIB(ribDump, cache.View())
+
+	require.Equal(t, 2, stats.TotalRoutes)
+	require.Equal(t, 1, stats.FilteredRoutes)
+	require.Len(t, fib.Entries, 1)
+	require.Len(t, fib.Entries[0].Nexthops, 1)
+}
+
+// Test_BuildFIB_EqualCostECMPPreserved verifies that equal-cost routes from
+// different peers are all included in the FIB as ECMP nexthops.
+func Test_BuildFIB_EqualCostECMPPreserved(t *testing.T) {
+	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
+	routeFor := func(addr, sourceMAC, destinationMAC string, device string) {
+		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
+			HardwareRoute: neigh.HardwareRoute{
+				SourceMAC:      mustParseMAC(t, sourceMAC),
+				DestinationMAC: mustParseMAC(t, destinationMAC),
+				Device:         device,
+			},
+		})
+	}
+
+	routeFor("10.0.0.1", "0a:00:00:00:00:01", "0a:00:00:00:10:00", "eth1")
+	routeFor("10.0.0.2", "0a:00:00:00:00:02", "0a:00:00:00:20:00", "eth2")
+
+	p1 := netip.MustParseAddr("192.0.2.1")
+	p2 := netip.MustParseAddr("192.0.2.2")
+
+	ribDump := maptrie.NewMapTrie[netip.Prefix, netip.Addr, rib.RoutesList](2)
+	ribDump[24][netip.MustParsePrefix("10.0.0.0/24")] = rib.RoutesList{
+		Routes: []rib.Route{
+			// Both bird routes have equal cost — ECMP must be preserved.
+			{NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: rib.RouteSourceBird, Pref: 100},
+			{NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: rib.RouteSourceBird, Pref: 100},
+		},
+	}
+
+	fib, stats := BuildFIB(ribDump, cache.View())
+
+	require.Equal(t, 2, stats.TotalRoutes)
+	require.Equal(t, 0, stats.FilteredRoutes)
+	require.Len(t, fib.Entries, 1)
+	require.Len(t, fib.Entries[0].Nexthops, 2)
+}
+
+// Test_BuildFIB_StaticAndBirdBothInFIB verifies that static and BGP routes for
+// the same prefix each contribute their best nexthop to the FIB independently.
+func Test_BuildFIB_StaticAndBirdBothInFIB(t *testing.T) {
+	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
+	routeFor := func(addr, sourceMAC, destinationMAC string, device string) {
+		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
+			HardwareRoute: neigh.HardwareRoute{
+				SourceMAC:      mustParseMAC(t, sourceMAC),
+				DestinationMAC: mustParseMAC(t, destinationMAC),
+				Device:         device,
+			},
+		})
+	}
+
+	routeFor("10.0.0.1", "0a:00:00:00:00:01", "0a:00:00:00:10:00", "eth1")
+	routeFor("10.0.0.2", "0a:00:00:00:00:02", "0a:00:00:00:20:00", "eth2")
+
+	birdPeer := netip.MustParseAddr("192.0.2.1")
+	unspec := netip.IPv6Unspecified()
+
+	ribDump := maptrie.NewMapTrie[netip.Prefix, netip.Addr, rib.RoutesList](2)
+	ribDump[24][netip.MustParsePrefix("10.0.0.0/24")] = rib.RoutesList{
+		Routes: []rib.Route{
+			// Bird route is best overall (Pref=200).
+			{NextHop: netip.MustParseAddr("10.0.0.1"), Peer: birdPeer, SourceID: rib.RouteSourceBird, Pref: 200},
+			// Static route has lower overall Pref (100) but is its own source.
+			{NextHop: netip.MustParseAddr("10.0.0.2"), Peer: unspec, SourceID: rib.RouteSourceStatic, Pref: 100},
+		},
+	}
+
+	fib, stats := BuildFIB(ribDump, cache.View())
+
+	require.Equal(t, 2, stats.TotalRoutes)
+	require.Equal(t, 0, stats.FilteredRoutes, "static route is its own source's best — not filtered")
+	require.Len(t, fib.Entries, 1)
+	require.Len(t, fib.Entries[0].Nexthops, 2, "both sources' nexthops should be in FIB")
+}
+
 func Test_BuildFIB_DedupsNexthops(t *testing.T) {
 	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
 	routeFor := func(addr, sourceMAC, destinationMAC string, device string) {

--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -132,6 +132,33 @@ func (m *RoutesList) Insert(route Route) bool {
 	return insertedIdx == -1
 }
 
+// BestPerSource returns the best-cost group of routes for each distinct
+// SourceID.
+//
+// The list is assumed to be sorted best-first by routeCompareRev. For each
+// source, the method takes the first (best) route and every other route of
+// the same source whose cost is equal to that source's best cost. The returned
+// slice preserves the original order, which is deterministic because the input
+// slice is always sorted.
+func (m *RoutesList) BestPerSource() []Route {
+	// best stores the lowest-cost route seen so far for each SourceID.
+	best := map[RouteSourceID]Route{}
+
+	var result []Route
+	for _, r := range m.Routes {
+		b, seen := best[r.SourceID]
+		if !seen {
+			best[r.SourceID] = r
+			result = append(result, r)
+			continue
+		}
+		if routeCompare(r, b) == 0 {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
 func (m *RoutesList) Remove(route Route) bool {
 	// Sorting is not need on removing
 	for idx, r := range m.Routes {

--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -98,7 +98,8 @@ func routeCompare(a Route, b Route) int {
 	if asPathLenDiff := int(b.ASPathLen) - int(a.ASPathLen); asPathLenDiff != 0 {
 		return asPathLenDiff
 	}
-	return int(a.Med) - int(b.Med)
+	// lower MED is better (RFC 4271 §9.1.2.2)
+	return int(b.Med) - int(a.Med)
 }
 
 func routeCompareRev(a Route, b Route) int {

--- a/operators/route/internal/rib/routes_test.go
+++ b/operators/route/internal/rib/routes_test.go
@@ -37,14 +37,16 @@ func TestRouteComparator(t *testing.T) {
 
 	b.ASPathLen = 2
 	a.Med = 1
-	require.True(t, routeCompare(a, b) > 0)
+	// a has Med=1, b has Med=0; lower MED is better, so b beats a
+	require.True(t, routeCompare(a, b) < 0)
+	// c has ASPathLen=0 which beats both a and b (ASPathLen=2)
 	require.True(t, routeCompare(c, a) > 0)
 	require.True(t, routeCompare(c, b) > 0)
 
 	routes := []Route{a, b, c}
 	slices.SortFunc(routes, routeCompareRev)
-	// c hash ASPathLen == 0 so it is the best route now!
-	require.Equal(t, s(c, a, b), s(routes...))
+	// c has ASPathLen=0 so it is the best; among equal ASPathLen, b (Med=0) beats a (Med=1)
+	require.Equal(t, s(c, b, a), s(routes...))
 
 	b.Pref = 100
 	routes = []Route{a, b, c}
@@ -190,6 +192,21 @@ func TestBestPerSource(t *testing.T) {
 
 		best := list.BestPerSource()
 		require.Len(t, best, 2, "both sources should appear in the best-per-source union")
+	})
+
+	t.Run("lower MED route wins when Pref and ASPathLen are equal", func(t *testing.T) {
+		list := RoutesList{
+			Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 100, Med: 10},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: RouteSourceBird, Pref: 100, Med: 20},
+			},
+		}
+		slices.SortFunc(list.Routes, routeCompareRev)
+
+		best := list.BestPerSource()
+		require.Len(t, best, 1, "only the lower-MED route should survive")
+		require.Equal(t, netip.MustParseAddr("10.0.0.1"), best[0].NextHop)
+		require.Equal(t, uint32(10), best[0].Med)
 	})
 
 	t.Run("all equal-cost nothing filtered", func(t *testing.T) {

--- a/operators/route/internal/rib/routes_test.go
+++ b/operators/route/internal/rib/routes_test.go
@@ -140,6 +140,72 @@ func TestRoutesListStaticECMP(t *testing.T) {
 	})
 }
 
+// TestBestPerSource verifies that BestPerSource returns the equal-cost group
+// for each source and filters routes that are strictly worse than the source's best.
+func TestBestPerSource(t *testing.T) {
+	pfx := netip.MustParsePrefix("10.0.0.0/24")
+	unspec := netip.IPv6Unspecified()
+	p1 := netip.MustParseAddr("192.0.2.1")
+	p2 := netip.MustParseAddr("192.0.2.2")
+
+	t.Run("routes with different Pref only best group survives", func(t *testing.T) {
+		list := RoutesList{
+			Routes: []Route{
+				// best (Pref=200)
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 200},
+				// worse (Pref=100)
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: RouteSourceBird, Pref: 100},
+			},
+		}
+		slices.SortFunc(list.Routes, routeCompareRev)
+
+		best := list.BestPerSource()
+		require.Len(t, best, 1)
+		require.Equal(t, netip.MustParseAddr("10.0.0.1"), best[0].NextHop)
+	})
+
+	t.Run("equal-cost routes from different peers all included", func(t *testing.T) {
+		list := RoutesList{
+			Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 100},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: RouteSourceBird, Pref: 100},
+			},
+		}
+		slices.SortFunc(list.Routes, routeCompareRev)
+
+		best := list.BestPerSource()
+		require.Len(t, best, 2)
+	})
+
+	t.Run("static and bird on one prefix both groups in result", func(t *testing.T) {
+		list := RoutesList{
+			Routes: []Route{
+				// bird route is the overall best
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 200},
+				// static route has lower overall Pref but is its own source
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: unspec, SourceID: RouteSourceStatic, Pref: 100},
+			},
+		}
+		slices.SortFunc(list.Routes, routeCompareRev)
+
+		best := list.BestPerSource()
+		require.Len(t, best, 2, "both sources should appear in the best-per-source union")
+	})
+
+	t.Run("all equal-cost nothing filtered", func(t *testing.T) {
+		list := RoutesList{
+			Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 100},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: RouteSourceBird, Pref: 100},
+			},
+		}
+		slices.SortFunc(list.Routes, routeCompareRev)
+
+		best := list.BestPerSource()
+		require.Len(t, best, len(list.Routes))
+	})
+}
+
 func TestRoutesListDeletion(t *testing.T) {
 	list := RoutesList{
 		Routes: []Route{


### PR DESCRIPTION
- FIB build now keeps, for each route source, only the routes that are equal in cost to that source's best route; the FIB is the union of these per-source best groups.
- Behavioral change for BIRD-fed setups: paths with worse LocalPref, longer AS path or higher MED no longer receive traffic; ECMP remains for equal-cost paths. Previously every route of a prefix was installed as an ECMP nexthop regardless of cost.
- Static routes form their own group and are not displaced by BGP routes with higher LocalPref.
- A new FIB build counter reports how many routes were filtered out, and tests cover filtering, equal-cost ECMP preservation and the static plus BGP union.

Based on #1215 and should be reviewed and merged after it.