### PR TITLE
fix(bird-adapter): populate AS path length when exporting routes

### DIFF
--- a/operators/bird-adapter/internal/bird/update.go
+++ b/operators/bird-adapter/internal/bird/update.go
@@ -58,10 +58,10 @@ const (
 	// AIGP           AttributeType = 0x1a /* RFC 7311 */
 	// OnlyToCustomer AttributeType = 0x23 /* RFC 9234 */
 
-	// ASPathSet      = 1 /* Types of path segments */
+	ASPathSet            = 1 /* Types of path segments */
 	ASPathSequence       = 2
 	ASPathConfedSequence = 3
-	// ASPathConfedSet      = 4
+	ASPathConfedSet      = 4
 
 	OpInsert Operation = 1
 	OpRemove Operation = 2
@@ -353,7 +353,11 @@ func (m *updateDecoder) decodeComplexAttribute(route *rib.Route, data []byte, ty
 	case AttrOrigin, AttrLocalPref, AttrMultiExitDisc, AttrOriginatorID:
 	case AttrASPath:
 		// https://datatracker.ietf.org/doc/html/rfc4271#section-5.1.2
-		for len(data) >= 2 { // traverse all segments
+		// Traverse all segments to compute the decision-process path length per
+		// RFC 4271 §9.1.2.2 and RFC 5065 §5.3, and extract ASNs from the first
+		// AS_SEQUENCE or AS_CONFED_SEQUENCE for peer/origin AS determination.
+		asPathExtracted := false
+		for len(data) >= 2 {
 			segmentType := data[0]
 			asPathLen := data[1]
 			if asPathLen == 0 {
@@ -362,30 +366,30 @@ func (m *updateDecoder) decodeComplexAttribute(route *rib.Route, data []byte, ty
 			data = data[2:]
 			asPathBytesSize := int(asPathLen) * int(sizeOfUint32)
 
-			// OriginAS is the last one
 			if asPathBytesSize > len(data) {
 				return fmt.Errorf("ASPath attribute truncated want=%d, actual=%d: %w",
 					asPathBytesSize, len(data), ErrAttrsUnexpectedEOD)
 			}
 
-			if segmentType != ASPathSequence && segmentType != ASPathConfedSequence {
-				// return fmt.Errorf("unsupported ASPath segment type: %d", segmentType)
-				// Silently skip unsupported AS path segment types (e.g., AS_SET, AS_CONFED_SET).
-				// These segment types are valid per RFC 4271, but we only process sequence types
-				// for determining peer and origin AS values.
-				// Note: Routes with only AS_SET or AS_CONFED_SET segments (no sequence types)
-				// will have empty peer/origin AS values, which is acceptable as these routes
-				// typically represent aggregated paths where specific AS information is less relevant.
-				data = data[asPathBytesSize:]
-				continue
+			// Accumulate decision-process path length: AS_SEQUENCE counts each ASN,
+			// AS_SET counts as 1, AS_CONFED_SEQUENCE and AS_CONFED_SET count as 0.
+			switch segmentType {
+			case ASPathSequence:
+				route.ASPathLen += uint32(asPathLen)
+			case ASPathSet:
+				route.ASPathLen++
 			}
 
-			for idx := uint8(0); idx < asPathLen; idx++ {
-				route.ASPath = append(route.ASPath, binary.BigEndian.Uint32(data[int(idx)*int(sizeOfUint32):]))
+			// Extract ASNs from the first AS_SEQUENCE or AS_CONFED_SEQUENCE segment
+			// to populate route.ASPath for peer/origin AS resolution.
+			if !asPathExtracted && (segmentType == ASPathSequence || segmentType == ASPathConfedSequence) {
+				for idx := uint8(0); idx < asPathLen; idx++ {
+					route.ASPath = append(route.ASPath, binary.BigEndian.Uint32(data[int(idx)*int(sizeOfUint32):]))
+				}
+				asPathExtracted = true
 			}
 
-			// stop decoding upon encountering the first successful match
-			return nil
+			data = data[asPathBytesSize:]
 		}
 		if len(data) != 0 {
 			return fmt.Errorf("unhandled ASPath attribute data len=%d: %#v: %w", len(data), data, ErrAttrsUnexpectedEOD)

--- a/operators/bird-adapter/internal/bird/update_test.go
+++ b/operators/bird-adapter/internal/bird/update_test.go
@@ -108,12 +108,13 @@ func TestDecodeUpdate(t *testing.T) {
 			name: "OK ipv6 update",
 			data: dataIPv6WithLargeCommunities,
 			expected: rib.Route{
-				Prefix:  netip.MustParsePrefix("2001:200:c000::/35"),
-				NextHop: netip.MustParseAddr("2a02:2891:9:200::13"),
-				Peer:    netip.MustParseAddr("::1"),
-				ASPath:  []uint32{51185, 7500, 23634},
-				Med:     0,
-				Pref:    100,
+				Prefix:    netip.MustParsePrefix("2001:200:c000::/35"),
+				NextHop:   netip.MustParseAddr("2a02:2891:9:200::13"),
+				Peer:      netip.MustParseAddr("::1"),
+				ASPath:    []uint32{51185, 7500, 23634},
+				ASPathLen: 3,
+				Med:       0,
+				Pref:      100,
 				Communities: []rib.Community{
 					rib.Community{
 						ASN:   2,
@@ -220,11 +221,12 @@ func TestDecodeUpdate(t *testing.T) {
 				0x13, 0x5, 0, 0x0,
 			},
 			expected: rib.Route{
-				Prefix:  netip.MustParsePrefix("1.0.4.0/22"),
-				NextHop: netip.AddrFrom16([16]byte{10: 0xff, 11: 0xff, 12: 0xc3, 0x42, 0xe2, 0xfe}),
-				Peer:    netip.IPv6Loopback(),
-				ASPath:  []uint32{0x0000bbc6, 1299, 7545, 2764, 38803, 38803, 0x00009793},
-				Pref:    0x64,
+				Prefix:    netip.MustParsePrefix("1.0.4.0/22"),
+				NextHop:   netip.AddrFrom16([16]byte{10: 0xff, 11: 0xff, 12: 0xc3, 0x42, 0xe2, 0xfe}),
+				Peer:      netip.IPv6Loopback(),
+				ASPath:    []uint32{0x0000bbc6, 1299, 7545, 2764, 38803, 38803, 0x00009793},
+				ASPathLen: 7,
+				Pref:      0x64,
 				Communities: []rib.Community{
 					rib.Community{
 						ASN:   100,
@@ -251,10 +253,11 @@ func TestDecodeUpdate(t *testing.T) {
 				0, 0, 0, 8, 4, 0, 0, 4, 0, 0, 0, 0xb8, 0x88, 0x13, 0x5,
 			},
 			expected: rib.Route{
-				Prefix:  netip.MustParsePrefix("1.0.7.0/24"),
-				NextHop: netip.MustParseAddr("::ffff:206.82.104.185"),
-				Peer:    netip.IPv6Loopback(),
-				ASPath:  []uint32{398465, 1299, 7545, 38803},
+				Prefix:    netip.MustParsePrefix("1.0.7.0/24"),
+				NextHop:   netip.MustParseAddr("::ffff:206.82.104.185"),
+				Peer:      netip.IPv6Loopback(),
+				ASPath:    []uint32{398465, 1299, 7545, 38803},
+				ASPathLen: 4,
 				Communities: []rib.Community{
 					rib.Community{
 						ASN:   35000,
@@ -263,6 +266,104 @@ func TestDecodeUpdate(t *testing.T) {
 				},
 				Pref:     100,
 				ToRemove: true, // NOTE: ToRemove test
+			},
+		},
+		{
+			// AS_SEQUENCE of 3 ASNs: decision length = 3.
+			name: "OK ASPathLen plain AS_SEQUENCE",
+			data: []byte{
+				0: 0x1,    // NetIP4
+				1: 0x8,    // prefix len 8
+				2: 0x8, 0, // NetAddrUnion length 8
+				4: 0, 0, 0, 1, // prefix 1.0.0.0 LE u32
+				40: 0x1, 0, 0, 0, // opType insert
+				// peer addr all zero
+				60: 22, 0, 0, 0, // attrsAreaSize = 4+4+14 = 22
+				// AS_PATH attr: type + PROTOCOL_BGP
+				64: 0x2, 0x4, 0, 0,
+				// attr data size = 14 bytes
+				68: 14, 0, 0, 0,
+				// AS_SEQUENCE, 3 ASNs
+				72: 2, 3,
+				// ASN 1 (BE u32)
+				74: 0, 0, 0, 1,
+				// ASN 2 (BE u32)
+				78: 0, 0, 0, 2,
+				// ASN 3 (BE u32)
+				82: 0, 0, 0, 3,
+			},
+			expected: rib.Route{
+				Prefix:    netip.MustParsePrefix("1.0.0.0/8"),
+				Peer:      netip.IPv6Unspecified(),
+				ASPath:    []uint32{1, 2, 3},
+				ASPathLen: 3,
+			},
+		},
+		{
+			// AS_CONFED_SEQUENCE(2) followed by AS_SEQUENCE(3): decision length = 3
+			// (confed contributes 0). ASPath extracted from first CONFED_SEQUENCE segment.
+			name: "OK ASPathLen confed-sequence then sequence",
+			data: []byte{
+				0: 0x1,    // NetIP4
+				1: 0x8,    // prefix len 8
+				2: 0x8, 0, // NetAddrUnion length 8
+				4: 0, 0, 0, 1, // prefix 1.0.0.0 LE u32
+				40: 0x1, 0, 0, 0, // opType insert
+				// peer addr all zero
+				60: 32, 0, 0, 0, // attrsAreaSize = 4+4+24 = 32
+				// AS_PATH attr: type + PROTOCOL_BGP
+				64: 0x2, 0x4, 0, 0,
+				// attr data size = 24 bytes (2+8 + 2+12)
+				68: 24, 0, 0, 0,
+				// AS_CONFED_SEQUENCE, 2 ASNs
+				72: 3, 2,
+				// ASN 10 (BE u32)
+				74: 0, 0, 0, 10,
+				// ASN 20 (BE u32)
+				78: 0, 0, 0, 20,
+				// AS_SEQUENCE, 3 ASNs
+				82: 2, 3,
+				// ASN 100 (BE u32)
+				84: 0, 0, 0, 100,
+				// ASN 200 (BE u32)
+				88: 0, 0, 0, 200,
+				// ASN 300 (BE u32)
+				92: 0, 0, 1, 44,
+			},
+			expected: rib.Route{
+				Prefix:    netip.MustParsePrefix("1.0.0.0/8"),
+				Peer:      netip.IPv6Unspecified(),
+				ASPath:    []uint32{10, 20},
+				ASPathLen: 3,
+			},
+		},
+		{
+			// AS_SET with 2 ASNs contributes exactly 1 to decision length.
+			// No sequence segment → ASPath remains nil.
+			name: "OK ASPathLen AS_SET contributes 1",
+			data: []byte{
+				0: 0x1,    // NetIP4
+				1: 0x8,    // prefix len 8
+				2: 0x8, 0, // NetAddrUnion length 8
+				4: 0, 0, 0, 1, // prefix 1.0.0.0 LE u32
+				40: 0x1, 0, 0, 0, // opType insert
+				// peer addr all zero
+				60: 18, 0, 0, 0, // attrsAreaSize = 4+4+10 = 18
+				// AS_PATH attr: type + PROTOCOL_BGP
+				64: 0x2, 0x4, 0, 0,
+				// attr data size = 10 bytes (2+8)
+				68: 10, 0, 0, 0,
+				// AS_SET, 2 ASNs
+				72: 1, 2,
+				// ASN 1 (BE u32)
+				74: 0, 0, 0, 1,
+				// ASN 2 (BE u32)
+				78: 0, 0, 0, 2,
+			},
+			expected: rib.Route{
+				Prefix:    netip.MustParsePrefix("1.0.0.0/8"),
+				Peer:      netip.IPv6Unspecified(),
+				ASPathLen: 1,
 			},
 		},
 		{

--- a/operators/bird-adapter/internal/rib/routes.go
+++ b/operators/bird-adapter/internal/rib/routes.go
@@ -71,8 +71,12 @@ type Route struct {
 	//
 	// This field participates in route cost calculation.
 	Pref uint32
-	// Encode sequence of ASes to reach the target
+	// ASPath encodes the sequence of ASes to reach the target.
 	ASPath []uint32
+	// ASPathLen is the BGP decision-process AS-path length per RFC 4271 §9.1.2.2
+	// and RFC 5065 §5.3: AS_SEQUENCE segments contribute their ASN count,
+	// AS_SET contributes 1, AS_CONFED_SEQUENCE and AS_CONFED_SET contribute 0.
+	ASPathLen uint32
 	// Label stack corresponding to the route
 	MplsLabelStack []uint32
 	// Cluster list used to detect announce loops
@@ -118,7 +122,7 @@ func ToPBRoute(route *Route) *routepb.Route {
 		OriginAs:         originAS,
 		Med:              route.Med,
 		Pref:             route.Pref,
-		AsPathLen:        uint32(len(route.ASPath)),
+		AsPathLen:        route.ASPathLen,
 		Source:           routepb.RouteSourceID(route.SourceID),
 		LargeCommunities: communities,
 	}

--- a/operators/bird-adapter/internal/rib/routes.go
+++ b/operators/bird-adapter/internal/rib/routes.go
@@ -118,6 +118,7 @@ func ToPBRoute(route *Route) *routepb.Route {
 		OriginAs:         originAS,
 		Med:              route.Med,
 		Pref:             route.Pref,
+		AsPathLen:        uint32(len(route.ASPath)),
 		Source:           routepb.RouteSourceID(route.SourceID),
 		LargeCommunities: communities,
 	}


### PR DESCRIPTION
- The adapter now fills the AS path length field when converting BIRD routes for export, so downstream route selection can apply the shortest-AS-path criterion.
- Previously the field was always left at zero, which made paths with different AS path lengths compare as equal.