### PR TITLE
fix(route-operator): flag every member of the per-source best group as best

### DIFF
--- a/operators/route/internal/operator/service_route.go
+++ b/operators/route/internal/operator/service_route.go
@@ -119,9 +119,9 @@ func (m *RouteService) ShowRoutes(
 				continue
 			}
 
+			bestMask := routesList.BestPerSourceMask()
 			for idx, r := range routesList.Routes {
-				isBest := idx == 0
-				response.Routes = append(response.Routes, operatorpb.FromRIBRoute(&r, isBest))
+				response.Routes = append(response.Routes, operatorpb.FromRIBRoute(&r, bestMask[idx]))
 			}
 		}
 	}
@@ -158,9 +158,9 @@ func (m *RouteService) LookupRoute(
 		Routes: make([]*operatorpb.Route, 0, len(routes.Routes)),
 	}
 
+	bestMask := routes.BestPerSourceMask()
 	for idx, r := range routes.Routes {
-		isBest := idx == 0
-		response.Routes = append(response.Routes, operatorpb.FromRIBRoute(&r, isBest))
+		response.Routes = append(response.Routes, operatorpb.FromRIBRoute(&r, bestMask[idx]))
 	}
 
 	return response, nil

--- a/operators/route/internal/operator/service_route_test.go
+++ b/operators/route/internal/operator/service_route_test.go
@@ -11,8 +11,77 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
+	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
 	operatorpb "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
 )
+
+// TestShowRoutes_StaticECMP_BothBest verifies that two static ECMP nexthops
+// for the same prefix both carry is_best=true.
+func TestShowRoutes_StaticECMP_BothBest(t *testing.T) {
+	svc := NewRouteService(neigh.NewNeighTable())
+
+	nh1 := commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.1"))
+	nh2 := commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.2"))
+
+	_, err := svc.InsertRoute(t.Context(), &operatorpb.InsertRouteRequest{
+		Name:         "route0",
+		Prefix:       "10.0.0.0/24",
+		NexthopAddrs: []*commonpb.IPAddress{nh1, nh2},
+		SourceId:     operatorpb.RouteSourceID_ROUTE_SOURCE_ID_STATIC,
+	})
+	require.NoError(t, err)
+
+	resp, err := svc.ShowRoutes(t.Context(), &operatorpb.ShowRoutesRequest{Name: "route0"})
+	require.NoError(t, err)
+	require.Len(t, resp.Routes, 2, "both ECMP nexthops must appear")
+	for _, r := range resp.Routes {
+		require.True(t, r.GetIsBest(), "static ECMP nexthop must have is_best=true")
+	}
+}
+
+// TestShowRoutes_BirdDifferentPref_OnlyBetterIsBest verifies that when two
+// bird routes for the same prefix differ in Pref, only the higher-Pref route
+// carries is_best=true.
+func TestShowRoutes_BirdDifferentPref_OnlyBetterIsBest(t *testing.T) {
+	svc := NewRouteService(neigh.NewNeighTable())
+
+	// Insert the lower-Pref route first so ordering is not insertion-order.
+	_, err := svc.InsertRoute(t.Context(), &operatorpb.InsertRouteRequest{
+		Name:         "route0",
+		Prefix:       "10.1.0.0/24",
+		NexthopAddrs: []*commonpb.IPAddress{commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.2"))},
+		SourceId:     operatorpb.RouteSourceID_ROUTE_SOURCE_ID_STATIC,
+	})
+	require.NoError(t, err)
+
+	// Use the RIB directly to insert two bird routes with distinct Prefs via
+	// the operator's RIB, accessed through the service internals.
+	ribRef := svc.getOrCreateRib("route0")
+
+	p1 := netip.MustParseAddr("192.0.2.1")
+	p2 := netip.MustParseAddr("192.0.2.2")
+	pfx := netip.MustParsePrefix("10.1.0.0/24")
+
+	ribRef.Update(
+		rib.Route{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.10"), Peer: p1, SourceID: rib.RouteSourceBird, Pref: 200},
+		rib.Route{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.20"), Peer: p2, SourceID: rib.RouteSourceBird, Pref: 100},
+	)
+
+	resp, err := svc.ShowRoutes(t.Context(), &operatorpb.ShowRoutesRequest{Name: "route0"})
+	require.NoError(t, err)
+
+	// Collect is_best flags by nexthop address string for deterministic assertions.
+	bestByNexthop := map[string]bool{}
+	for _, r := range resp.Routes {
+		addr, addrErr := r.GetNextHop().ToAddr()
+		require.NoError(t, addrErr)
+		bestByNexthop[addr.String()] = r.GetIsBest()
+	}
+
+	require.True(t, bestByNexthop["10.0.0.10"], "higher-Pref bird route must be best")
+	require.False(t, bestByNexthop["10.0.0.20"], "lower-Pref bird route must not be best")
+	require.True(t, bestByNexthop["10.0.0.2"], "static route must be best within its source")
+}
 
 func TestInsertRoute_NonStaticMultipleNexthops_InvalidArgument(t *testing.T) {
 	svc := NewRouteService(neigh.NewNeighTable())

--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -133,6 +133,32 @@ func (m *RoutesList) Insert(route Route) bool {
 	return insertedIdx == -1
 }
 
+// BestPerSourceMask returns a boolean slice, aligned index-for-index with
+// Routes, where true means the route at that index is a member of its
+// source's best-cost group.
+//
+// The list is assumed to be sorted best-first by routeCompareRev. For each
+// source, the first route seen establishes the best cost; every subsequent
+// route of the same source with equal cost is also marked true. Routes
+// strictly worse than their source's best are false.
+func (m *RoutesList) BestPerSourceMask() []bool {
+	mask := make([]bool, len(m.Routes))
+	best := map[RouteSourceID]Route{}
+
+	for idx, r := range m.Routes {
+		b, seen := best[r.SourceID]
+		if !seen {
+			best[r.SourceID] = r
+			mask[idx] = true
+			continue
+		}
+		if routeCompare(r, b) == 0 {
+			mask[idx] = true
+		}
+	}
+	return mask
+}
+
 // BestPerSource returns the best-cost group of routes for each distinct
 // SourceID.
 //
@@ -142,18 +168,11 @@ func (m *RoutesList) Insert(route Route) bool {
 // slice preserves the original order, which is deterministic because the input
 // slice is always sorted.
 func (m *RoutesList) BestPerSource() []Route {
-	// best stores the lowest-cost route seen so far for each SourceID.
-	best := map[RouteSourceID]Route{}
+	mask := m.BestPerSourceMask()
 
 	var result []Route
-	for _, r := range m.Routes {
-		b, seen := best[r.SourceID]
-		if !seen {
-			best[r.SourceID] = r
-			result = append(result, r)
-			continue
-		}
-		if routeCompare(r, b) == 0 {
+	for idx, r := range m.Routes {
+		if mask[idx] {
 			result = append(result, r)
 		}
 	}

--- a/operators/route/internal/rib/routes_test.go
+++ b/operators/route/internal/rib/routes_test.go
@@ -223,6 +223,112 @@ func TestBestPerSource(t *testing.T) {
 	})
 }
 
+// TestBestPerSourceMask verifies that BestPerSourceMask returns a mask
+// aligned with Routes that matches the set returned by BestPerSource.
+func TestBestPerSourceMask(t *testing.T) {
+	pfx := netip.MustParsePrefix("10.0.0.0/24")
+	unspec := netip.IPv6Unspecified()
+	p1 := netip.MustParseAddr("192.0.2.1")
+	p2 := netip.MustParseAddr("192.0.2.2")
+
+	t.Run("worse-Pref route masked false", func(t *testing.T) {
+		list := RoutesList{
+			Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 200},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: RouteSourceBird, Pref: 100},
+			},
+		}
+		slices.SortFunc(list.Routes, routeCompareRev)
+
+		mask := list.BestPerSourceMask()
+		require.Len(t, mask, 2)
+		require.True(t, mask[0], "best route must be true")
+		require.False(t, mask[1], "worse-Pref route must be false")
+	})
+
+	t.Run("equal-cost peers all true", func(t *testing.T) {
+		list := RoutesList{
+			Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 100},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: RouteSourceBird, Pref: 100},
+			},
+		}
+		slices.SortFunc(list.Routes, routeCompareRev)
+
+		mask := list.BestPerSourceMask()
+		require.Len(t, mask, 2)
+		require.True(t, mask[0])
+		require.True(t, mask[1])
+	})
+
+	t.Run("static and bird both sources true", func(t *testing.T) {
+		list := RoutesList{
+			Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 200},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: unspec, SourceID: RouteSourceStatic, Pref: 100},
+			},
+		}
+		slices.SortFunc(list.Routes, routeCompareRev)
+
+		mask := list.BestPerSourceMask()
+		require.Len(t, mask, 2)
+		require.True(t, mask[0], "bird best must be true")
+		require.True(t, mask[1], "static best must be true")
+	})
+
+	t.Run("lower-MED wins higher-MED masked false", func(t *testing.T) {
+		list := RoutesList{
+			Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 100, Med: 10},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: RouteSourceBird, Pref: 100, Med: 20},
+			},
+		}
+		slices.SortFunc(list.Routes, routeCompareRev)
+
+		mask := list.BestPerSourceMask()
+		require.Len(t, mask, 2)
+		require.True(t, mask[0], "lower-MED route must be true")
+		require.False(t, mask[1], "higher-MED route must be false")
+	})
+
+	t.Run("mask aligns with BestPerSource on all scenarios", func(t *testing.T) {
+		scenarios := []RoutesList{
+			{Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 200},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: RouteSourceBird, Pref: 100},
+			}},
+			{Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 100},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: RouteSourceBird, Pref: 100},
+			}},
+			{Routes: []Route{
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: RouteSourceBird, Pref: 200},
+				{Prefix: pfx, NextHop: netip.MustParseAddr("10.0.0.2"), Peer: unspec, SourceID: RouteSourceStatic, Pref: 100},
+			}},
+		}
+
+		for _, list := range scenarios {
+			slices.SortFunc(list.Routes, routeCompareRev)
+			mask := list.BestPerSourceMask()
+			best := list.BestPerSource()
+
+			// Collect nexthops flagged true by the mask.
+			var masked []netip.Addr
+			for idx, r := range list.Routes {
+				if mask[idx] {
+					masked = append(masked, r.NextHop)
+				}
+			}
+			// Collect nexthops from BestPerSource.
+			var fromBest []netip.Addr
+			for _, r := range best {
+				fromBest = append(fromBest, r.NextHop)
+			}
+			require.Equal(t, fromBest, masked, "mask must agree with BestPerSource")
+		}
+	})
+}
+
 func TestRoutesListDeletion(t *testing.T) {
 	list := RoutesList{
 		Routes: []Route{

--- a/operators/route/operatorpb/v1/route.proto
+++ b/operators/route/operatorpb/v1/route.proto
@@ -134,6 +134,10 @@ message Route {
   uint32 as_path_len = 9;
   RouteSourceID source = 10;
   repeated LargeCommunity large_communities = 11;
+  // IsBest reports whether this route is a member of its source's best-cost
+  // group and is therefore selected for forwarding (installed into the FIB).
+  // All equal-cost members of the per-source best group carry this flag,
+  // including every static ECMP nexthop and every equal-cost BIRD path.
   bool is_best = 12;
 }
 

--- a/web/src/pages/operators/route/LookupDrawer.tsx
+++ b/web/src/pages/operators/route/LookupDrawer.tsx
@@ -206,10 +206,10 @@ const LookupDrawer: React.FC<LookupDrawerProps> = ({
                                             {result.routes.map((r, idx) => (
                                                 <tr
                                                     key={idx}
-                                                    className={idx === 0 ? 'ro-lookup-table__best-row' : ''}
+                                                    className={r.is_best ? 'ro-lookup-table__best-row' : ''}
                                                 >
                                                     <td>
-                                                        <BestPill isBest={idx === 0} />
+                                                        <BestPill isBest={r.is_best ?? false} />
                                                     </td>
                                                     <td className="yn-cell-mono yn-cell-strong">
                                                         {r.prefix || '—'}


### PR DESCRIPTION
- Show and lookup responses now mark a route as best when it belongs to its source's best-cost group, matching the set that is actually installed into the FIB, so all ECMP members are shown as selected instead of only the first one.
- The web lookup drawer renders the server flag instead of assuming the first row is best; the routes table and CLI already used the flag and pick the change up automatically.
- Covered by RIB mask tests and service-level tests for static ECMP and unequal-cost BIRD routes.