### PR TITLE
fix(route-operator): respect peer identity when removing routes

### DIFF
--- a/operators/route/internal/rib/rib.go
+++ b/operators/route/internal/rib/rib.go
@@ -77,14 +77,20 @@ func (m *RIB) RemoveUnicastRoute(prefix netip.Prefix, nexthopAddr netip.Addr, so
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	candidate := Route{
+		Prefix:   prefix,
+		NextHop:  nexthopAddr,
+		Peer:     netip.IPv6Unspecified(),
+		SourceID: sourceID,
+	}
+
 	found := 0
 	m.routes.UpdateOrDelete(
 		prefix,
 		func(routesList RoutesList) (RoutesList, bool) {
-			// Filter out only static routes with matching nexthop.
 			newRoutes := make([]Route, 0, len(routesList.Routes))
 			for _, r := range routesList.Routes {
-				if r.NextHop.Unmap() == nexthopAddr.Unmap() && r.SourceID == sourceID {
+				if r.isSameIdentity(candidate) {
 					found++
 					continue // skip means remove
 				}

--- a/operators/route/internal/rib/rib_test.go
+++ b/operators/route/internal/rib/rib_test.go
@@ -1,0 +1,102 @@
+package rib
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// newTestRIB constructs a RIB suitable for unit tests.
+func newTestRIB(t *testing.T) *RIB {
+	t.Helper()
+	return NewRIB(zap.NewNop())
+}
+
+// routesForPrefix returns the routes stored for the given prefix, or nil if the
+// prefix is absent.
+func routesForPrefix(t *testing.T, r *RIB, prefix netip.Prefix) []Route {
+	t.Helper()
+	dump := r.DumpRoutes()
+	for _, level := range dump {
+		for k, v := range level {
+			if k == prefix {
+				return v.Routes
+			}
+		}
+	}
+	return nil
+}
+
+// TestRemoveUnicastRoute_BGPPeerIsolation verifies that calling RemoveUnicastRoute
+// with a Bird source does not remove BGP routes from distinct peers even when
+// the nexthop matches.
+//
+// BGP route identity is peer-scoped; the unary API carries no peer, so the
+// candidate Peer is IPv6Unspecified. A real BGP route has a non-unspecified
+// Peer, so isSameIdentity must return false and neither route may be removed.
+func TestRemoveUnicastRoute_BGPPeerIsolation(t *testing.T) {
+	pfx := netip.MustParsePrefix("10.0.0.0/24")
+	nh := netip.MustParseAddr("192.0.2.1")
+	peer1 := netip.MustParseAddr("10.1.1.1")
+	peer2 := netip.MustParseAddr("10.1.1.2")
+
+	r := newTestRIB(t)
+
+	r.Update(
+		Route{Prefix: pfx, NextHop: nh, Peer: peer1, SourceID: RouteSourceBird},
+		Route{Prefix: pfx, NextHop: nh, Peer: peer2, SourceID: RouteSourceBird},
+	)
+
+	routes := routesForPrefix(t, r, pfx)
+	require.Len(t, routes, 2, "setup: both BGP routes must be present before removal attempt")
+
+	err := r.RemoveUnicastRoute(pfx, nh, RouteSourceBird)
+	require.NoError(t, err)
+
+	routes = routesForPrefix(t, r, pfx)
+	require.Len(t, routes, 2,
+		"RemoveUnicastRoute must not remove BGP routes from distinct peers")
+}
+
+// TestRemoveUnicastRoute_StaticECMP verifies that removing one nexthop from a
+// static ECMP set leaves the remaining nexthop intact.
+func TestRemoveUnicastRoute_StaticECMP(t *testing.T) {
+	pfx := netip.MustParsePrefix("10.0.0.0/24")
+	nh1 := netip.MustParseAddr("192.0.2.1")
+	nh2 := netip.MustParseAddr("192.0.2.2")
+
+	r := newTestRIB(t)
+
+	require.NoError(t, r.AddUnicastRoute(pfx, nh1, RouteSourceStatic))
+	require.NoError(t, r.AddUnicastRoute(pfx, nh2, RouteSourceStatic))
+
+	routes := routesForPrefix(t, r, pfx)
+	require.Len(t, routes, 2, "setup: both static nexthops must be present")
+
+	require.NoError(t, r.RemoveUnicastRoute(pfx, nh1, RouteSourceStatic))
+
+	routes = routesForPrefix(t, r, pfx)
+	require.Len(t, routes, 1, "exactly one nexthop must remain after removing the other")
+	require.Equal(t, nh2, routes[0].NextHop)
+}
+
+// TestRemoveUnicastRoute_StaticSingle verifies that removing the sole static
+// nexthop for a prefix deletes the prefix entry entirely.
+func TestRemoveUnicastRoute_StaticSingle(t *testing.T) {
+	pfx := netip.MustParsePrefix("10.0.0.0/24")
+	nh := netip.MustParseAddr("192.0.2.1")
+
+	r := newTestRIB(t)
+
+	require.NoError(t, r.AddUnicastRoute(pfx, nh, RouteSourceStatic))
+
+	routes := routesForPrefix(t, r, pfx)
+	require.Len(t, routes, 1, "setup: static route must be present")
+
+	require.NoError(t, r.RemoveUnicastRoute(pfx, nh, RouteSourceStatic))
+
+	routes = routesForPrefix(t, r, pfx)
+	require.Nil(t, routes, "prefix entry must be absent after removing the sole nexthop")
+}


### PR DESCRIPTION
`RemoveUnicastRoute` filtered routes by nexthop and source only, ignoring the BGP peer, while route identity everywhere else (insert, stream remove) is peer-aware. As a result the unary delete path could remove routes belonging to other peers that happened to share a nexthop.

- Delegate the removal predicate to the shared route-identity check so insertion and removal agree on what makes a route unique.
- Static routes keep matching by nexthop, and removing one nexthop of a static ECMP set leaves the others intact.
- Add regression coverage for peer isolation, static ECMP removal, and single-route removal.