### PR TITLE
chore(route-operator): drop stale buf breaking-change ignore

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -25,4 +25,3 @@ breaking:
     - PACKAGE
   ignore:
     - modules/balancer2
-    - operators/route/operatorpb


### PR DESCRIPTION
The route operator proto package was added to the buf breaking-change ignore list to land the nexthop list field rename. That change is now on main, which is the baseline buf compares against, so the ignore entry no longer suppresses anything and only hides future breaking changes in those protos.

- Remove the stale ignore entry so breaking-change detection is restored for the route operator protos.