### PR TITLE
refactor(route-mpls): canonicalize controlplane structure

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -68,7 +68,7 @@ func buildServices(
 		{
 			name: "route mpls module",
 			new: func() (gateway.Service, error) {
-				return route_mpls.NewRouteMPLSModule(modulesCfg.RouteMPLS, log)
+				return route_mpls.NewRouteMPLSModule(modulesCfg.RouteMPLS, route_mpls.WithLog(log))
 			},
 		},
 		{

--- a/modules/route-mpls/bindings/go/croutempls/cgo.go
+++ b/modules/route-mpls/bindings/go/croutempls/cgo.go
@@ -1,13 +1,10 @@
-package route_mpls
+package croutempls
 
-//#cgo CFLAGS: -I../../../ -I../../../lib
-//#cgo LDFLAGS: -L../../../build/modules/route-mpls/api -lroute_mpls_cp
+//#cgo CFLAGS: -I../../../../../ -I../../../../../lib
+//#cgo LDFLAGS: -L../../../../../build/modules/route-mpls/api -lroute_mpls_cp
+//#cgo LDFLAGS: -L../../../../../build/lib/filter -lfilter_compiler
 //
 //#include <errno.h>
-//
-//static void reset_errno() {
-//    errno = 0;
-//}
 //
 //#include "api/agent.h"
 //#include "modules/route-mpls/api/controlplane.h"
@@ -27,7 +24,6 @@ import "C"
 
 import (
 	"fmt"
-	"net/netip"
 	"runtime"
 	"unsafe"
 
@@ -36,10 +32,13 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
 
+// ModuleConfig is an opaque handle to the route-mpls module configuration in
+// shared memory.
 type ModuleConfig struct {
 	ptr ffi.ModuleConfig
 }
 
+// NewModuleConfig allocates a new route-mpls module configuration via the C API.
 func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
@@ -59,75 +58,51 @@ func (m *ModuleConfig) asRawPtr() *C.struct_cp_module {
 	return (*C.struct_cp_module)(m.ptr.AsRawPtr())
 }
 
+// AsFFIModule returns the underlying common module config handle.
 func (m *ModuleConfig) AsFFIModule() ffi.ModuleConfig {
 	return m.ptr
 }
 
-// Free frees the route module configuration
+// Free releases the underlying C memory.
+//
+// Safe to call multiple times: subsequent calls are no-ops.
 func (m *ModuleConfig) Free() {
-	C.route_mpls_module_config_free(m.asRawPtr())
+	if ptr := m.asRawPtr(); ptr != nil {
+		C.route_mpls_module_config_free(ptr)
+		m.ptr = ffi.ModuleConfig{}
+	}
 }
 
-type routeMPLSKind uint16
-
-const (
-	routeMPLSKindNone routeMPLSKind = iota
-	routeMPLSKindTun
-)
-
-type routeMPLSNextHop struct {
-	Kind        routeMPLSKind
-	Source      netip.Addr
-	Destination netip.Addr
-	MPLSLabel   uint32
-	Weight      uint64
-	Counter     string
-}
-
-type routeMPLSRule struct {
-	Dst4s    filter.IPNets
-	Dst6s    filter.IPNets
-	NextHops []routeMPLSNextHop
-}
-
-func (m *routeMPLSRule) CBuild(pinner *runtime.Pinner) C.struct_route_mpls_rule {
-	cRule := C.struct_route_mpls_rule{}
-
-	filter.CBuildNet4s(&cRule.net4s, m.Dst4s, pinner)
-	filter.CBuildNet6s(&cRule.net6s, m.Dst6s, pinner)
-
-	return cRule
-}
-
-func (m *ModuleConfig) Update(rules []routeMPLSRule) error {
+// Update marshals rules into C structs and calls route_mpls_module_config_update.
+func (m *ModuleConfig) Update(rules []Rule) error {
 	pinner := &runtime.Pinner{}
 	defer pinner.Unpin()
 
 	cRules := make([]C.struct_route_mpls_rule, len(rules))
 
 	for idx, rule := range rules {
-		cNextHops := make([]C.struct_route_mpls_nexthop, len(rule.NextHops))
+		cNextHops := make([]C.struct_route_mpls_nexthop, len(rule.Nexthops))
 
-		for idx, nextHop := range rule.NextHops {
-			cNextHops[idx].weight = C.uint64_t(nextHop.Weight)
-			cCounter := C.CString(nextHop.Counter)
-			C.strncpy(&cNextHops[idx].counter[0], cCounter, C.COUNTER_NAME_LEN)
+		for jdx, nexthop := range rule.Nexthops {
+			cNextHops[jdx].weight = C.uint64_t(nexthop.Weight)
+			cCounter := C.CString(nexthop.Counter)
+			C.strncpy(&cNextHops[jdx].counter[0], cCounter, C.COUNTER_NAME_LEN)
 			C.free(unsafe.Pointer(cCounter))
 
-			if nextHop.Kind == routeMPLSKindNone {
-				cNextHops[idx].kind = C.ROUTE_MPLS_TYPE_NONE
+			if nexthop.Kind == KindNone {
+				cNextHops[jdx].kind = C.ROUTE_MPLS_TYPE_NONE
 				continue
 			}
 
-			if nextHop.Destination.BitLen() == 32 {
-				cNextHops[idx].kind = C.ROUTE_MPLS_TYPE_V4
-				C.set_ip4_tunnel(&cNextHops[idx], (*C.uint8_t)(&nextHop.Source.AsSlice()[0]), (*C.uint8_t)(&nextHop.Destination.AsSlice()[0]))
+			if nexthop.Destination.BitLen() == 32 {
+				cNextHops[jdx].kind = C.ROUTE_MPLS_TYPE_V4
+				C.set_ip4_tunnel(&cNextHops[jdx], (*C.uint8_t)(&nexthop.Source.AsSlice()[0]), (*C.uint8_t)(&nexthop.Destination.AsSlice()[0]))
 			} else {
-				cNextHops[idx].kind = C.ROUTE_MPLS_TYPE_V6
-				C.set_ip6_tunnel(&cNextHops[idx], (*C.uint8_t)(&nextHop.Source.AsSlice()[0]), (*C.uint8_t)(&nextHop.Destination.AsSlice()[0]))
+				cNextHops[jdx].kind = C.ROUTE_MPLS_TYPE_V6
+				C.set_ip6_tunnel(&cNextHops[jdx], (*C.uint8_t)(&nexthop.Source.AsSlice()[0]), (*C.uint8_t)(&nexthop.Destination.AsSlice()[0]))
 			}
 
-			cNextHops[idx].mpls_label = C.uint32_t(nextHop.MPLSLabel)
+			cNextHops[jdx].mpls_label = C.uint32_t(nexthop.MPLSLabel)
 		}
 
 		cRule := &cRules[idx]

--- a/modules/route-mpls/bindings/go/croutempls/safe.go
+++ b/modules/route-mpls/bindings/go/croutempls/safe.go
@@ -1,0 +1,44 @@
+package croutempls
+
+import (
+	"net/netip"
+
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
+)
+
+// Kind identifies the forwarding action for an MPLS nexthop.
+type Kind uint16
+
+const (
+	// KindNone indicates a drop/no-route action.
+	KindNone Kind = iota
+	// KindTun indicates a tunnel encapsulation action.
+	KindTun
+)
+
+// Nexthop describes a single MPLS forwarding nexthop.
+type Nexthop struct {
+	// Kind identifies the forwarding action.
+	Kind Kind
+	// Source is the tunnel source IP address.
+	Source netip.Addr
+	// Destination is the tunnel destination IP address.
+	Destination netip.Addr
+	// MPLSLabel is the outgoing MPLS label.
+	MPLSLabel uint32
+	// Weight is the ECMP load-balancing weight.
+	Weight uint64
+	// Counter is the counter name for traffic accounting.
+	Counter string
+}
+
+// Rule describes a single route-mpls forwarding rule with its prefix
+// match criteria and nexthop list.
+type Rule struct {
+	// Dst4s is the set of IPv4 destination prefixes to match.
+	Dst4s filter.IPNets
+	// Dst6s is the set of IPv6 destination prefixes to match.
+	Dst6s filter.IPNets
+	// Nexthops is the ordered list of nexthops for this rule.
+	Nexthops []Nexthop
+}

--- a/modules/route-mpls/controlplane/backend.go
+++ b/modules/route-mpls/controlplane/backend.go
@@ -1,0 +1,63 @@
+package route_mpls
+
+import (
+	"fmt"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/route-mpls/bindings/go/croutempls"
+)
+
+// ModuleHandle is a handle to a route-mpls module configuration in shared
+// memory.
+type ModuleHandle interface {
+	Free()
+}
+
+// Compile-time assertion that *croutempls.ModuleConfig satisfies the
+// ModuleHandle interface; catches drift in the bindings layer.
+var _ ModuleHandle = (*croutempls.ModuleConfig)(nil)
+
+// Backend abstracts shared memory write-path operations for the route-mpls
+// module.
+type Backend interface {
+	// UpdateModule builds a fresh ModuleConfig from the supplied rules and
+	// publishes it to the dataplane atomically.
+	UpdateModule(name string, rules []croutempls.Rule) (ModuleHandle, error)
+	// DeleteModule removes a module config from the dataplane.
+	DeleteModule(name string) error
+}
+
+// backend is the real Backend implementation backed by shared memory.
+type backend struct {
+	agent *ffi.Agent
+}
+
+// NewBackend creates a Backend that operates on real shared memory.
+func NewBackend(agent *ffi.Agent) Backend {
+	return &backend{
+		agent: agent,
+	}
+}
+
+func (m *backend) UpdateModule(name string, rules []croutempls.Rule) (ModuleHandle, error) {
+	module, err := croutempls.NewModuleConfig(m.agent, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create module config: %w", err)
+	}
+
+	if err := module.Update(rules); err != nil {
+		module.Free()
+		return nil, fmt.Errorf("failed to update module config: %w", err)
+	}
+
+	if err := m.agent.UpdateModules([]ffi.ModuleConfig{module.AsFFIModule()}); err != nil {
+		module.Free()
+		return nil, fmt.Errorf("failed to publish module config: %w", err)
+	}
+
+	return module, nil
+}
+
+func (m *backend) DeleteModule(name string) error {
+	return m.agent.DeleteModuleConfig(name)
+}

--- a/modules/route-mpls/controlplane/cfg.go
+++ b/modules/route-mpls/controlplane/cfg.go
@@ -5,24 +5,25 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
 
+// Config holds the configuration for the route-mpls control-plane module.
 type Config struct {
 	// InstanceID specifies which dataplane instance this module serves.
 	InstanceID uint32 `yaml:"instance_id"`
-	// MemoryPath is the path to the shared-memory file that is used to
-	// communicate with dataplane.
+	// MemoryPath is the path to the shared-memory file used to communicate
+	// with the dataplane.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements is the amount of memory that is required for a single
+	// MemoryRequirements is the amount of shared memory required for a single
 	// transaction.
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
-	Endpoint           xcfg.NonEmptyString             `yaml:"endpoint"`
-	GatewayEndpoint    xcfg.NonEmptyString             `yaml:"gateway_endpoint"`
+	// Endpoint is the gRPC listen address for this module.
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
 }
 
+// DefaultConfig returns a Config populated with sensible defaults.
 func DefaultConfig() *Config {
 	return &Config{
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
 		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
-		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/route-mpls/controlplane/mod.go
+++ b/modules/route-mpls/controlplane/mod.go
@@ -6,66 +6,99 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	cpffi "github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
 )
 
-// RouteMPLSModule is a controlplane part of a module that is responsible for
-// routing configuration.
-type RouteMPLSModule struct {
-	cfg              *Config
-	shm              *ffi.SharedMemory
-	agent            *ffi.Agent
-	routeMPLSService *RouteMPLSService
-	log              *zap.Logger
+const (
+	agentName = "route-mpls"
+)
+
+// Option configures the RouteMPLSModule constructor.
+type Option func(*moduleOptions)
+
+type moduleOptions struct {
+	Log *zap.Logger
 }
 
-func NewRouteMPLSModule(cfg *Config, log *zap.Logger) (*RouteMPLSModule, error) {
-	log = log.With(zap.String("module", "modules.route_mpls.controlplane.routemplspb.v1.RouteMPLSService"))
+func newModuleOptions() *moduleOptions {
+	return &moduleOptions{
+		Log: zap.NewNop(),
+	}
+}
 
-	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+// WithLog sets the logger for the route-mpls module.
+func WithLog(log *zap.Logger) Option {
+	return func(o *moduleOptions) {
+		o.Log = log
+	}
+}
+
+// RouteMPLSModule is the controlplane part of the route-mpls module that owns
+// shared memory and exposes the routemplspb.RouteMPLSService gRPC surface.
+type RouteMPLSModule struct {
+	cfg     *Config
+	shm     *cpffi.SharedMemory
+	agent   *cpffi.Agent
+	service *RouteMPLSService
+	log     *zap.Logger
+}
+
+// NewRouteMPLSModule creates a new RouteMPLSModule.
+func NewRouteMPLSModule(cfg *Config, options ...Option) (*RouteMPLSModule, error) {
+	opts := newModuleOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", "modules.route_mpls.controlplane.routemplspb.v1.RouteMPLSService"))
+
+	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to shared memory %q: %w", cfg.MemoryPath, err)
 	}
 
-	log.Debug(
-		"mapping shared memory",
+	log.Debug("mapping shared memory",
 		zap.Uint32("instance_id", cfg.InstanceID),
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("route-mpls", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
 
-	routeMPLSService := NewRouteMPLSService(agent, log)
+	service := NewRouteMPLSService(NewBackend(agent), WithRouteMPLSServiceLog(log))
 
 	return &RouteMPLSModule{
-		cfg:              cfg,
-		shm:              shm,
-		agent:            agent,
-		routeMPLSService: routeMPLSService,
-		log:              log,
+		cfg:     cfg,
+		shm:     shm,
+		agent:   agent,
+		service: service,
+		log:     log,
 	}, nil
 }
 
+// Name returns the module name.
 func (m *RouteMPLSModule) Name() string {
-	return "route-mpls"
+	return agentName
 }
 
+// Endpoint returns the gRPC endpoint for the route-mpls module.
 func (m *RouteMPLSModule) Endpoint() string {
 	return m.cfg.Endpoint.Unwrap()
 }
 
+// ServicesNames returns the gRPC service names exposed by the module.
 func (m *RouteMPLSModule) ServicesNames() []string {
 	return []string{
 		"modules.route_mpls.controlplane.routemplspb.v1.RouteMPLSService",
 	}
 }
 
+// RegisterService registers the route-mpls module's gRPC service.
 func (m *RouteMPLSModule) RegisterService(server *grpc.Server) {
-	routemplspb.RegisterRouteMPLSServiceServer(server, m.routeMPLSService)
+	routemplspb.RegisterRouteMPLSServiceServer(server, m.service)
 }
 
 // Close closes the module.
@@ -73,10 +106,8 @@ func (m *RouteMPLSModule) Close() error {
 	if err := m.agent.Close(); err != nil {
 		m.log.Warn("failed to close shared memory agent", zap.Error(err))
 	}
-
 	if err := m.shm.Detach(); err != nil {
 		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
 	}
-
 	return nil
 }

--- a/modules/route-mpls/controlplane/service.go
+++ b/modules/route-mpls/controlplane/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/netip"
 	"slices"
+	"sort"
 	"sync"
 
 	"go.uber.org/zap"
@@ -15,30 +16,61 @@ import (
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/maptrie"
-	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/route-mpls/bindings/go/croutempls"
 	"github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
 )
 
+// RouteMPLSServiceOption configures the RouteMPLSService constructor.
+type RouteMPLSServiceOption func(*routeMPLSServiceOptions)
+
+type routeMPLSServiceOptions struct {
+	Log *zap.Logger
+}
+
+func newRouteMPLSServiceOptions() *routeMPLSServiceOptions {
+	return &routeMPLSServiceOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithRouteMPLSServiceLog sets the logger for the RouteMPLSService.
+func WithRouteMPLSServiceLog(log *zap.Logger) RouteMPLSServiceOption {
+	return func(o *routeMPLSServiceOptions) {
+		o.Log = log
+	}
+}
+
+// RouteMPLSService is the gRPC service implementation for the route-mpls
+// module.
 type RouteMPLSService struct {
 	routemplspb.UnimplementedRouteMPLSServiceServer
 
-	mu      sync.Mutex
-	agent   *ffi.Agent
+	backend Backend
+
+	// shmLock serializes shared-memory mutations and protects the
+	// configs map.
+	shmLock sync.RWMutex
 	configs map[string]routeMPLSConfig
 
 	log *zap.Logger
 }
 
+// NextHop holds a single MPLS forwarding nexthop in the service's domain
+// model.
 type NextHop struct {
-	Source      netip.Addr
+	// Source is the tunnel source IP address.
+	Source netip.Addr
+	// Destination is the tunnel destination IP address.
 	Destination netip.Addr
-	MPLSLabel   uint32
-
+	// MPLSLabel is the outgoing MPLS label.
+	MPLSLabel uint32
+	// Weight is the ECMP load-balancing weight.
 	Weight uint64
-
+	// Counter is the counter name for traffic accounting.
 	Counter string
 }
 
+// NextHopList is a mutable list of nexthops associated with a single prefix.
 type NextHopList struct {
 	NextHops []NextHop
 }
@@ -50,10 +82,10 @@ func (m *NextHopList) lookup(destination netip.Addr, mplsLabel uint32) int {
 			return idx
 		}
 	}
-
 	return -1
 }
 
+// Insert adds or replaces a nexthop in the list.
 func (m *NextHopList) Insert(nextHop NextHop) {
 	if idx := m.lookup(nextHop.Destination, nextHop.MPLSLabel); idx != -1 {
 		m.NextHops[idx] = nextHop
@@ -62,6 +94,7 @@ func (m *NextHopList) Insert(nextHop NextHop) {
 	}
 }
 
+// Remove removes a nexthop from the list by destination and MPLS label.
 func (m *NextHopList) Remove(nextHop NextHop) {
 	if idx := m.lookup(nextHop.Destination, nextHop.MPLSLabel); idx != -1 {
 		m.NextHops = slices.Delete(m.NextHops, idx, idx+1)
@@ -69,164 +102,41 @@ func (m *NextHopList) Remove(nextHop NextHop) {
 }
 
 type routeMPLSConfig struct {
-	prefixes  maptrie.MapTrie[netip.Prefix, netip.Addr, NextHopList]
-	routeMPLS *ModuleConfig
+	prefixes maptrie.MapTrie[netip.Prefix, netip.Addr, NextHopList]
+	handle   ModuleHandle
 }
 
-func NewRouteMPLSService(
-	agent *ffi.Agent,
-	log *zap.Logger,
-) *RouteMPLSService {
-	return &RouteMPLSService{
-		agent:   agent,
-		configs: make(map[string]routeMPLSConfig),
-		log:     log,
-	}
-}
-
-func (m *RouteMPLSService) ListConfigs(
-	ctx context.Context,
-	request *routemplspb.ListConfigsRequest,
-) (*routemplspb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	response := &routemplspb.ListConfigsResponse{
-		Configs: make([]string, 0, len(m.configs)),
-	}
-
-	for name := range m.configs {
-		response.Configs = append(response.Configs, name)
-	}
-
-	return response, nil
-}
-
-func (m *RouteMPLSService) ShowConfig(
-	ctx context.Context,
-	req *routemplspb.ShowConfigRequest,
-) (*routemplspb.ShowConfigResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	name := req.GetName()
-	if name == "" {
-		return nil, status.Error(codes.InvalidArgument, "module config name is required")
-	}
-
-	config, ok := m.configs[name]
-	if !ok {
-		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
-	}
-
-	rules := make([]*routemplspb.Rule, 0)
-
-	for _, prefixes := range config.prefixes {
-		for prefix, nexthops := range prefixes {
-			for _, nexthop := range nexthops.NextHops {
-				rules = append(
-					rules,
-					&routemplspb.Rule{
-						Prefix: &filterpb.IPPrefix{
-							Addr:   prefix.Addr().AsSlice(),
-							Length: uint32(prefix.Bits()),
-						},
-						Nexthop: &routemplspb.NextHop{
-							Label:         nexthop.MPLSLabel,
-							SourceIp:      commonpb.NewIPAddressFromAddr(nexthop.Source),
-							DestinationIp: commonpb.NewIPAddressFromAddr(nexthop.Destination),
-							Weight:        nexthop.Weight,
-							Counter:       nexthop.Counter,
-						},
-					},
-				)
-			}
-		}
-	}
-
-	response := &routemplspb.ShowConfigResponse{
-		Name:  name,
-		Rules: rules,
-	}
-
-	return response, nil
-}
-
-func (m *RouteMPLSService) DeleteConfig(
-	ctx context.Context,
-	req *routemplspb.DeleteConfigRequest,
-) (*routemplspb.DeleteConfigResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	name := req.GetName()
-	if name == "" {
-		return nil, status.Error(codes.InvalidArgument, "module config name is required")
-	}
-
-	config, ok := m.configs[name]
-	if !ok {
-		return nil, status.Error(codes.InvalidArgument, "not found")
-	}
-
-	if config.routeMPLS != nil {
-		if err := m.agent.DeleteModuleConfig(name); err != nil {
-			return nil, status.Errorf(codes.Internal, "could not delete acl module config '%s': %v", name, err)
-		}
-		m.log.Info("successfully deleted ACL module config", zap.String("name", name))
-		config.routeMPLS.Free()
-	}
-
-	delete(m.configs, name)
-
-	response := &routemplspb.DeleteConfigResponse{}
-
-	return response, nil
-}
-
-func (m *NextHop) toFFI() routeMPLSNextHop {
-	return routeMPLSNextHop{
-		Kind:        routeMPLSKindTun,
-		Source:      m.Source,
-		Destination: m.Destination,
-		MPLSLabel:   m.MPLSLabel,
-		Weight:      m.Weight,
-		Counter:     m.Counter,
-	}
-}
-
-func (m *routeMPLSConfig) submit() error {
-	ffiRules := make([]routeMPLSRule, 0)
+// buildRules iterates the maptrie from longest to shortest prefix and
+// assembles the croutempls.Rule slice, appending default drop rules for both
+// IPv4 and IPv6 at the end.
+func (m *routeMPLSConfig) buildRules() []croutempls.Rule {
+	rules := make([]croutempls.Rule, 0)
 
 	for prefixLen := 128; prefixLen >= 0; prefixLen-- {
 		for prefix, nextHopList := range m.prefixes[prefixLen] {
-			ffiNextHops := make([]routeMPLSNextHop, 0, len(nextHopList.NextHops))
-			for _, nexthop := range nextHopList.NextHops {
-				ffiNextHops = append(
-					ffiNextHops,
-					nexthop.toFFI(),
-				)
+			nexthops := make([]croutempls.Nexthop, 0, len(nextHopList.NextHops))
+			for _, nh := range nextHopList.NextHops {
+				nexthops = append(nexthops, nh.toFFI())
 			}
 
 			dst4s, _ := filter.Net4sFromPrefixes([]netip.Prefix{prefix})
 			dst6s, _ := filter.Net6sFromPrefixes([]netip.Prefix{prefix})
 
-			ffiRule := routeMPLSRule{
+			rules = append(rules, croutempls.Rule{
 				Dst4s:    dst4s,
 				Dst6s:    dst6s,
-				NextHops: ffiNextHops,
-			}
-			ffiRules = append(ffiRules, ffiRule)
+				Nexthops: nexthops,
+			})
 		}
 	}
 
 	default4Prefix := netip.PrefixFrom(netip.AddrFrom4([4]byte{}), 0)
 	default4Dst, _ := filter.Net4sFromPrefixes([]netip.Prefix{default4Prefix})
-	ffiRules = append(ffiRules, routeMPLSRule{
+	rules = append(rules, croutempls.Rule{
 		Dst4s: default4Dst,
-		NextHops: []routeMPLSNextHop{
-			routeMPLSNextHop{
-				Kind:    routeMPLSKindNone,
+		Nexthops: []croutempls.Nexthop{
+			{
+				Kind:    croutempls.KindNone,
 				Weight:  1,
 				Counter: "no route mpls v4",
 			},
@@ -235,27 +145,292 @@ func (m *routeMPLSConfig) submit() error {
 
 	default16Prefix := netip.PrefixFrom(netip.AddrFrom16([16]byte{}), 0)
 	default16Dst, _ := filter.Net6sFromPrefixes([]netip.Prefix{default16Prefix})
-
-	ffiRules = append(ffiRules, routeMPLSRule{
+	rules = append(rules, croutempls.Rule{
 		Dst6s: default16Dst,
-		NextHops: []routeMPLSNextHop{
-			routeMPLSNextHop{
-				Kind:    routeMPLSKindNone,
+		Nexthops: []croutempls.Nexthop{
+			{
+				Kind:    croutempls.KindNone,
 				Weight:  1,
 				Counter: "no route mpls v6",
 			},
 		},
 	})
 
-	return m.routeMPLS.Update(ffiRules)
+	return rules
+}
+
+func (m *NextHop) toFFI() croutempls.Nexthop {
+	return croutempls.Nexthop{
+		Kind:        croutempls.KindTun,
+		Source:      m.Source,
+		Destination: m.Destination,
+		MPLSLabel:   m.MPLSLabel,
+		Weight:      m.Weight,
+		Counter:     m.Counter,
+	}
+}
+
+// NewRouteMPLSService builds a RouteMPLSService bound to the supplied backend.
+func NewRouteMPLSService(backend Backend, options ...RouteMPLSServiceOption) *RouteMPLSService {
+	opts := newRouteMPLSServiceOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	return &RouteMPLSService{
+		backend: backend,
+		configs: map[string]routeMPLSConfig{},
+		log:     opts.Log,
+	}
+}
+
+// ListConfigs returns the names of all route-mpls module configurations
+// currently known to the service.
+func (m *RouteMPLSService) ListConfigs(
+	ctx context.Context,
+	request *routemplspb.ListConfigsRequest,
+) (*routemplspb.ListConfigsResponse, error) {
+	m.shmLock.RLock()
+	defer m.shmLock.RUnlock()
+
+	response := &routemplspb.ListConfigsResponse{
+		Configs: make([]string, 0, len(m.configs)),
+	}
+	for name := range m.configs {
+		response.Configs = append(response.Configs, name)
+	}
+	sort.Strings(response.Configs)
+	return response, nil
+}
+
+// ShowConfig returns the rules currently stored for the requested configuration.
+func (m *RouteMPLSService) ShowConfig(
+	ctx context.Context,
+	req *routemplspb.ShowConfigRequest,
+) (*routemplspb.ShowConfigResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "module config name is required")
+	}
+
+	m.shmLock.RLock()
+	defer m.shmLock.RUnlock()
+
+	config, ok := m.configs[name]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
+	}
+
+	rules := make([]*routemplspb.Rule, 0)
+	for _, prefixes := range config.prefixes {
+		for prefix, nexthops := range prefixes {
+			for _, nexthop := range nexthops.NextHops {
+				rules = append(rules, &routemplspb.Rule{
+					Prefix: &filterpb.IPPrefix{
+						Addr:   prefix.Addr().AsSlice(),
+						Length: uint32(prefix.Bits()),
+					},
+					Nexthop: &routemplspb.NextHop{
+						Label:         nexthop.MPLSLabel,
+						SourceIp:      commonpb.NewIPAddressFromAddr(nexthop.Source),
+						DestinationIp: commonpb.NewIPAddressFromAddr(nexthop.Destination),
+						Weight:        nexthop.Weight,
+						Counter:       nexthop.Counter,
+					},
+				})
+			}
+		}
+	}
+
+	return &routemplspb.ShowConfigResponse{
+		Name:  name,
+		Rules: rules,
+	}, nil
+}
+
+// DeleteConfig removes a route-mpls module configuration from the service and
+// the dataplane.
+func (m *RouteMPLSService) DeleteConfig(
+	ctx context.Context,
+	req *routemplspb.DeleteConfigRequest,
+) (*routemplspb.DeleteConfigResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "module config name is required")
+	}
+
+	m.shmLock.Lock()
+	defer m.shmLock.Unlock()
+
+	config, ok := m.configs[name]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "not found")
+	}
+
+	if err := m.backend.DeleteModule(name); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
+	}
+
+	if config.handle != nil {
+		config.handle.Free()
+	}
+	delete(m.configs, name)
+
+	return &routemplspb.DeleteConfigResponse{}, nil
+}
+
+// CreateConfig creates a new route-mpls module configuration and publishes it
+// to the dataplane.
+func (m *RouteMPLSService) CreateConfig(
+	ctx context.Context,
+	req *routemplspb.CreateConfigRequest,
+) (*routemplspb.CreateConfigResponse, error) {
+	name := req.Name
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "module config name is required")
+	}
+
+	prefixes := maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0)
+
+	for _, rule := range req.Rules {
+		prefix, err := makePrefix(rule.Prefix)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
+		}
+
+		nextHop, err := makeNextHop(rule.Nexthop)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
+		}
+
+		prefixes.InsertOrUpdate(
+			prefix,
+			func() NextHopList {
+				return NextHopList{
+					NextHops: append(make([]NextHop, 0, 1), nextHop),
+				}
+			},
+			func(list NextHopList) NextHopList {
+				list.Insert(nextHop)
+				return list
+			},
+		)
+	}
+
+	config := routeMPLSConfig{
+		prefixes: prefixes,
+	}
+
+	m.shmLock.Lock()
+	defer m.shmLock.Unlock()
+
+	handle, err := m.backend.UpdateModule(name, config.buildRules())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+	}
+
+	if old, ok := m.configs[name]; ok && old.handle != nil {
+		old.handle.Free()
+	}
+
+	config.handle = handle
+	m.configs[name] = config
+
+	return &routemplspb.CreateConfigResponse{}, nil
+}
+
+// UpdateConfig applies incremental prefix updates or withdrawals to an
+// existing route-mpls module configuration.
+func (m *RouteMPLSService) UpdateConfig(
+	ctx context.Context,
+	req *routemplspb.UpdateConfigRequest,
+) (*routemplspb.UpdateConfigResponse, error) {
+	name := req.Name
+	if name == "" {
+		return nil, status.Error(codes.InvalidArgument, "module config name is required")
+	}
+
+	m.shmLock.Lock()
+	defer m.shmLock.Unlock()
+
+	oldConfig, ok := m.configs[name]
+	if !ok {
+		oldConfig = routeMPLSConfig{
+			prefixes: maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0),
+		}
+	}
+
+	config := routeMPLSConfig{
+		prefixes: oldConfig.prefixes.Clone(),
+	}
+
+	for _, update := range req.Updates {
+		if u := update.GetUpdate(); u != nil {
+			prefix, err := makePrefix(u.Prefix)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
+			}
+
+			nextHop, err := makeNextHop(u.Nexthop)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
+			}
+
+			config.prefixes.InsertOrUpdate(
+				prefix,
+				func() NextHopList {
+					return NextHopList{
+						NextHops: append(make([]NextHop, 0, 1), nextHop),
+					}
+				},
+				func(list NextHopList) NextHopList {
+					list.Insert(nextHop)
+					return list
+				},
+			)
+		}
+
+		if w := update.GetWithdraw(); w != nil {
+			prefix, err := makePrefix(w.Prefix)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "failed to parse prefix: %v", err)
+			}
+
+			nextHop, err := makeNextHop(w.Nexthop)
+			if err != nil {
+				return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
+			}
+
+			config.prefixes.UpdateOrDelete(
+				prefix,
+				func(list NextHopList) (NextHopList, bool) {
+					list.Remove(nextHop)
+					return list, len(list.NextHops) == 0
+				},
+			)
+		}
+	}
+
+	handle, err := m.backend.UpdateModule(name, config.buildRules())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
+	}
+
+	if oldConfig.handle != nil {
+		oldConfig.handle.Free()
+	}
+
+	config.handle = handle
+	m.configs[name] = config
+
+	return &routemplspb.UpdateConfigResponse{}, nil
 }
 
 func makePrefix(prefix *filterpb.IPPrefix) (netip.Prefix, error) {
-	addr, err := netip.AddrFromSlice(prefix.Addr)
-	if !err {
+	addr, ok := netip.AddrFromSlice(prefix.Addr)
+	if !ok {
 		return netip.Prefix{}, fmt.Errorf("invalid address length")
 	}
-
 	return netip.PrefixFrom(addr, int(prefix.Length)), nil
 }
 
@@ -273,180 +448,7 @@ func makeNextHop(nexthop *routemplspb.NextHop) (NextHop, error) {
 		Source:      src,
 		Destination: dst,
 		MPLSLabel:   nexthop.Label,
-
-		Weight: nexthop.Weight,
-
-		Counter: nexthop.Counter,
+		Weight:      nexthop.Weight,
+		Counter:     nexthop.Counter,
 	}, nil
-}
-
-func (m *RouteMPLSService) CreateConfig(
-	ctx context.Context,
-	req *routemplspb.CreateConfigRequest,
-) (*routemplspb.CreateConfigResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	name := req.Name
-	if name == "" {
-		return nil, status.Error(codes.InvalidArgument, "module config name is required")
-	}
-
-	prefixes := maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0)
-
-	for _, rule := range req.Rules {
-		prefix, err := makePrefix(rule.Prefix)
-		if err != nil {
-			return nil, err
-		}
-
-		nextHop, err := makeNextHop(rule.Nexthop)
-		if err != nil {
-			return nil, err
-		}
-
-		prefixes.InsertOrUpdate(
-			prefix,
-			func() NextHopList {
-				return NextHopList{
-					NextHops: append(make([]NextHop, 0, 1), nextHop),
-				}
-			},
-			func(m NextHopList) NextHopList {
-				m.Insert(nextHop)
-
-				return m
-			},
-		)
-	}
-
-	module, err := NewModuleConfig(m.agent, name)
-
-	if err != nil {
-		return nil, err
-	}
-
-	config := routeMPLSConfig{
-		prefixes:  prefixes,
-		routeMPLS: module,
-	}
-
-	if err := config.submit(); err != nil {
-		module.Free()
-		return nil, err
-	}
-
-	if oldConfig, ok := m.configs[name]; ok {
-		oldConfig.routeMPLS.Free()
-	}
-
-	m.configs[name] = config
-
-	response := &routemplspb.CreateConfigResponse{}
-
-	return response, nil
-}
-
-func (m *RouteMPLSService) UpdateConfig(
-	ctx context.Context,
-	req *routemplspb.UpdateConfigRequest,
-) (*routemplspb.UpdateConfigResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	name := req.Name
-	if name == "" {
-		return nil, status.Error(codes.InvalidArgument, "module config name is required")
-	}
-
-	oldConfig, ok := m.configs[name]
-	if !ok {
-		oldConfig = routeMPLSConfig{
-			prefixes:  maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0),
-			routeMPLS: nil,
-		}
-	}
-
-	config := routeMPLSConfig{
-		prefixes:  oldConfig.prefixes.Clone(),
-		routeMPLS: nil,
-	}
-
-	for _, update := range req.Updates {
-		if update := update.GetUpdate(); update != nil {
-			prefix, err := makePrefix(update.Prefix)
-			if err != nil {
-				return nil, err
-			}
-
-			nextHop, err := makeNextHop(update.Nexthop)
-			if err != nil {
-				return nil, err
-			}
-
-			config.prefixes.InsertOrUpdate(
-				prefix,
-				func() NextHopList {
-					return NextHopList{
-						NextHops: append(make([]NextHop, 0, 1), nextHop),
-					}
-				},
-				func(m NextHopList) NextHopList {
-					m.Insert(nextHop)
-
-					return m
-				},
-			)
-
-		}
-
-		if withdraw := update.GetWithdraw(); withdraw != nil {
-			prefix, err := makePrefix(withdraw.Prefix)
-			if err != nil {
-				return nil, err
-			}
-
-			nextHop, err := makeNextHop(withdraw.Nexthop)
-			if err != nil {
-				return nil, err
-			}
-
-			config.prefixes.UpdateOrDelete(
-				prefix,
-				func(m NextHopList) (NextHopList, bool) {
-					m.Remove(nextHop)
-					return m, len(m.NextHops) == 0
-				},
-			)
-
-		}
-	}
-
-	module, err := NewModuleConfig(m.agent, name)
-	if err != nil {
-		return nil, err
-	}
-
-	config.routeMPLS = module
-
-	if err := config.submit(); err != nil {
-		config.routeMPLS.Free()
-		return nil, err
-	}
-
-	if err := m.agent.UpdateModules([]ffi.ModuleConfig{config.routeMPLS.AsFFIModule()}); err != nil {
-		config.routeMPLS.Free()
-		return nil, status.Errorf(codes.Internal, "failed to update module: %v", err)
-	}
-
-	if oldConfig.routeMPLS != nil {
-		oldConfig.routeMPLS.Free()
-	}
-
-	m.configs[name] = config
-
-	response := &routemplspb.UpdateConfigResponse{}
-
-	return response, nil
-
 }

--- a/modules/route-mpls/controlplane/service_test.go
+++ b/modules/route-mpls/controlplane/service_test.go
@@ -1,0 +1,292 @@
+package route_mpls
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
+	"github.com/yanet-platform/yanet2/modules/route-mpls/bindings/go/croutempls"
+	routemplspb "github.com/yanet-platform/yanet2/modules/route-mpls/controlplane/routemplspb/v1"
+)
+
+var errInjectedBackend = errors.New("injected backend failure")
+
+type mockModuleHandle struct{}
+
+func (m *mockModuleHandle) Free() {}
+
+type mockBackend struct{}
+
+func (m *mockBackend) UpdateModule(name string, rules []croutempls.Rule) (ModuleHandle, error) {
+	return &mockModuleHandle{}, nil
+}
+
+func (m *mockBackend) DeleteModule(name string) error {
+	return nil
+}
+
+// flakyBackend succeeds on the first UpdateModule call and fails thereafter.
+type flakyBackend struct {
+	numCalls atomic.Int64
+}
+
+func (m *flakyBackend) UpdateModule(name string, rules []croutempls.Rule) (ModuleHandle, error) {
+	if m.numCalls.Add(1) >= 2 {
+		return nil, errInjectedBackend
+	}
+	return &mockModuleHandle{}, nil
+}
+
+func (m *flakyBackend) DeleteModule(name string) error {
+	return nil
+}
+
+func newTestService(t *testing.T) *RouteMPLSService {
+	t.Helper()
+	return NewRouteMPLSService(&mockBackend{})
+}
+
+// makeRule builds a proto Rule for use in test requests.
+func makeRule(t *testing.T, cidr string, dst string, label uint32) *routemplspb.Rule {
+	t.Helper()
+
+	p := netip.MustParsePrefix(cidr)
+	addrBytes := p.Addr().AsSlice()
+
+	return &routemplspb.Rule{
+		Prefix: &filterpb.IPPrefix{
+			Addr:   addrBytes,
+			Length: uint32(p.Bits()),
+		},
+		Nexthop: &routemplspb.NextHop{
+			Label:         label,
+			SourceIp:      commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.0.2.1")),
+			DestinationIp: commonpb.NewIPAddressFromAddr(netip.MustParseAddr(dst)),
+			Weight:        1,
+			Counter:       "test-counter",
+		},
+	}
+}
+
+func Test_RouteMPLSService_CreateConfig_HappyPath(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.CreateConfig(t.Context(), &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	list, err := svc.ListConfigs(t.Context(), &routemplspb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mpls0"}, list.Configs)
+}
+
+func Test_RouteMPLSService_CreateConfig_EmptyName(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.CreateConfig(t.Context(), &routemplspb.CreateConfigRequest{
+		Name:  "",
+		Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func Test_RouteMPLSService_UpdateConfig_UpdateAndWithdraw(t *testing.T) {
+	svc := newTestService(t)
+	ctx := t.Context()
+
+	// Create initial config with one prefix.
+	_, err := svc.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+	})
+	require.NoError(t, err)
+
+	// Add a second prefix via UpdateConfig.
+	_, err = svc.UpdateConfig(ctx, &routemplspb.UpdateConfigRequest{
+		Name: "mpls0",
+		Updates: []*routemplspb.UpdateEvent{
+			{Event: &routemplspb.UpdateEvent_Update{
+				Update: makeRule(t, "10.0.1.0/24", "203.0.113.2", 200),
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	show, err := svc.ShowConfig(ctx, &routemplspb.ShowConfigRequest{Name: "mpls0"})
+	require.NoError(t, err)
+	assert.Len(t, show.Rules, 2)
+
+	// Withdraw the first prefix.
+	_, err = svc.UpdateConfig(ctx, &routemplspb.UpdateConfigRequest{
+		Name: "mpls0",
+		Updates: []*routemplspb.UpdateEvent{
+			{Event: &routemplspb.UpdateEvent_Withdraw{
+				Withdraw: makeRule(t, "10.0.0.0/24", "203.0.113.1", 100),
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	show, err = svc.ShowConfig(ctx, &routemplspb.ShowConfigRequest{Name: "mpls0"})
+	require.NoError(t, err)
+	assert.Len(t, show.Rules, 1)
+}
+
+func Test_RouteMPLSService_ShowConfig_NotFound(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.ShowConfig(t.Context(), &routemplspb.ShowConfigRequest{Name: "nonexistent"})
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func Test_RouteMPLSService_ShowConfig_EmptyName(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.ShowConfig(t.Context(), &routemplspb.ShowConfigRequest{Name: ""})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func Test_RouteMPLSService_ListConfigs_Sorted(t *testing.T) {
+	svc := newTestService(t)
+	ctx := t.Context()
+
+	for _, name := range []string{"mpls2", "mpls0", "mpls1"} {
+		_, err := svc.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+			Name:  name,
+			Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+		})
+		require.NoError(t, err)
+	}
+
+	list, err := svc.ListConfigs(ctx, &routemplspb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"mpls0", "mpls1", "mpls2"}, list.Configs)
+}
+
+func Test_RouteMPLSService_DeleteConfig_NotFound(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.DeleteConfig(t.Context(), &routemplspb.DeleteConfigRequest{Name: "nonexistent"})
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func Test_RouteMPLSService_DeleteConfig_HappyPath(t *testing.T) {
+	svc := newTestService(t)
+	ctx := t.Context()
+
+	_, err := svc.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+	})
+	require.NoError(t, err)
+
+	resp, err := svc.DeleteConfig(ctx, &routemplspb.DeleteConfigRequest{Name: "mpls0"})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	list, err := svc.ListConfigs(ctx, &routemplspb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, list.Configs)
+}
+
+func Test_RouteMPLSService_CreateConfig_BackendFailure(t *testing.T) {
+	svc := NewRouteMPLSService(&flakyBackend{})
+	ctx := t.Context()
+
+	// First call succeeds.
+	_, err := svc.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+	})
+	require.NoError(t, err)
+
+	// Second call fails; old config must be preserved.
+	_, err = svc.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+		Name:  "mpls0",
+		Rules: []*routemplspb.Rule{makeRule(t, "10.0.1.0/24", "203.0.113.2", 200)},
+	})
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+
+	// The original config is still accessible.
+	show, err := svc.ShowConfig(ctx, &routemplspb.ShowConfigRequest{Name: "mpls0"})
+	require.NoError(t, err)
+	assert.Len(t, show.Rules, 1)
+}
+
+// Test_RouteMPLSService_ConcurrentAccess runs with -race to detect data races.
+func Test_RouteMPLSService_ConcurrentAccess(t *testing.T) {
+	svc := newTestService(t)
+
+	const goroutines = 10
+	const iterations = 100
+
+	g, ctx := errgroup.WithContext(t.Context())
+
+	for idx := range goroutines {
+		g.Go(func() error {
+			for jdx := range iterations {
+				name := fmt.Sprintf("config-%d-%d", idx, jdx)
+				_, err := svc.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
+					Name:  name,
+					Rules: []*routemplspb.Rule{makeRule(t, "10.0.0.0/24", "203.0.113.1", 100)},
+				})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	for range goroutines {
+		g.Go(func() error {
+			for range iterations {
+				_, err := svc.ListConfigs(ctx, &routemplspb.ListConfigsRequest{})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	for idx := range goroutines {
+		g.Go(func() error {
+			for jdx := range iterations {
+				name := fmt.Sprintf("config-%d-%d", idx, jdx)
+				svc.ShowConfig(ctx, &routemplspb.ShowConfigRequest{Name: name})
+			}
+			return nil
+		})
+	}
+
+	for idx := range goroutines {
+		g.Go(func() error {
+			for jdx := range iterations {
+				name := fmt.Sprintf("config-%d-%d", idx, jdx)
+				svc.DeleteConfig(ctx, &routemplspb.DeleteConfigRequest{Name: name})
+			}
+			return nil
+		})
+	}
+
+	require.NoError(t, g.Wait())
+}


### PR DESCRIPTION
Brings the route-mpls controlplane in line with the canonical module layout used by route, decap and forward. This is a purely structural refactor: the stateful gRPC API (Create/Update/Show/Delete/ListConfigs) that the bird-adapter operator depends on is preserved unchanged.

- Move the CGO layer out of the controlplane package into a dedicated croutempls bindings package, split into a low-level cgo wrapper and a Go-friendly safe layer, matching route's croute.
- Introduce a Backend interface and a ModuleHandle seam so the service can be tested without shared memory, and add table-driven service tests with a fake backend, including a race test.
- Convert the module and service constructors to the functional-options pattern.
- Publish both freshly created and updated configurations through the same shared-memory path, fixing a latent case where a newly created configuration was applied locally but never pushed to the dataplane.
- Drop the unused gateway endpoint configuration field for parity with route.