### PR TITLE
feat(controlplane): export agent memory-context tree in the info API

### DIFF
--- a/api/info.h
+++ b/api/info.h
@@ -188,6 +188,26 @@ yanet_get_cp_device_output_pipeline_info(
 
 // Instance
 
+// Length of a memory_context name, matching sizeof(memory_context::name).
+#define CP_MCTX_NAME_LEN 64
+
+// One node of an agent's memory_context tree.
+//
+// Copied to the heap by the info API so the caller never touches shared
+// memory.
+struct cp_memory_node_info {
+	char name[CP_MCTX_NAME_LEN];
+	// Index of this node's parent within the enclosing memory_nodes array.
+	//
+	// UINT32_MAX marks the root node, the agent's own context.
+	uint32_t parent_idx;
+	uint32_t _pad;
+	uint64_t balloc_count;
+	uint64_t bfree_count;
+	uint64_t balloc_size;
+	uint64_t bfree_size;
+};
+
 struct cp_agent_instance_info {
 	pid_t pid;
 	uint64_t memory_limit;
@@ -197,12 +217,22 @@ struct cp_agent_instance_info {
 	// Subtract from memory_limit to see how much memory the agent is
 	// currently using.
 	uint64_t free_bytes;
+	// Flat depth-first snapshot of the agent instance's memory-context
+	// subtree.
+	//
+	// Node 0 is the root, the agent's own context. Every later node's
+	// parent_idx points back into this array. Best-effort: a concurrent
+	// update may make a node appear or vanish between passes.
+	uint64_t memory_node_count;
+	struct cp_memory_node_info memory_nodes[];
 };
 
 struct cp_agent_info {
 	char name[80];
 	uint64_t instance_count;
-	struct cp_agent_instance_info instances[];
+	// Each element is a separately allocated block holding the
+	// cp_agent_instance_info header and its trailing memory_nodes array.
+	struct cp_agent_instance_info *instances[];
 };
 
 struct cp_agent_list_info {

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -1,5 +1,7 @@
 //! CLI for YANET "inspect" module.
 
+use core::cmp::Reverse;
+
 use bytesize::ByteSize;
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
@@ -10,7 +12,7 @@ use ync::{
     errors::Error,
     output::{self, CommonFormat},
 };
-use ynpb::pb::{inspect_service_client::InspectServiceClient, InspectRequest, InspectResponse};
+use ynpb::pb::{inspect_service_client::InspectServiceClient, InspectRequest, InspectResponse, MemoryNode};
 
 const INSPECT_SERVICE: &str = "controlplane.ynpb.v1.InspectService";
 
@@ -131,6 +133,9 @@ fn render_tree(response: &InspectResponse) {
             tree.add_empty_child(format!("Used:         {}", ByteSize::b(used)));
             tree.add_empty_child(format!("Free:         {}", ByteSize::b(instance.free_bytes)));
             tree.add_empty_child(format!("Generation: {}", instance.generation));
+            if !instance.memory_tree.is_empty() {
+                add_memory_tree(&mut tree, &instance.memory_tree);
+            }
             tree.end_child();
         }
 
@@ -216,4 +221,65 @@ fn render_tree(response: &InspectResponse) {
 
     let tree = tree.build();
     let _ = ptree::print_tree(&tree);
+}
+
+/// Live bytes held by a memory node: allocated minus freed, floored at zero.
+fn node_live(node: &MemoryNode) -> u64 {
+    node.balloc_size.saturating_sub(node.bfree_size)
+}
+
+/// Subtree total: a node's own live bytes plus the live bytes of all its
+/// descendants.
+fn subtree_live(nodes: &[MemoryNode], children_of: &[Vec<usize>], idx: usize) -> u64 {
+    let self_live = node_live(&nodes[idx]);
+    let children_total: u64 = children_of[idx]
+        .iter()
+        .map(|&child| subtree_live(nodes, children_of, child))
+        .sum();
+
+    self_live.saturating_add(children_total)
+}
+
+/// Render one node and its children into the tree builder.
+///
+/// Children are ordered by subtree total descending so the heaviest
+/// subtrees come first; zero-total subtrees are skipped.
+fn render_memory_node(tree: &mut TreeBuilder, nodes: &[MemoryNode], idx: usize, children_of: &[Vec<usize>]) {
+    let node = &nodes[idx];
+    let total = subtree_live(nodes, children_of, idx);
+    tree.begin_child(format!("{} (Used: {})", node.name, ByteSize::b(total)));
+
+    let mut children = children_of[idx].clone();
+    children.sort_by_key(|&child| Reverse(subtree_live(nodes, children_of, child)));
+    for child in children {
+        if subtree_live(nodes, children_of, child) > 0 {
+            render_memory_node(tree, nodes, child, children_of);
+        }
+    }
+
+    tree.end_child();
+}
+
+/// Render the memory-context tree under a `Memory tree:` branch.
+fn add_memory_tree(tree: &mut TreeBuilder, nodes: &[MemoryNode]) {
+    let mut children_of: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
+    let mut root_idx: Option<usize> = None;
+    for (idx, node) in nodes.iter().enumerate() {
+        if node.parent_idx == u32::MAX {
+            root_idx = Some(idx);
+        } else {
+            let parent = node.parent_idx as usize;
+            if parent < nodes.len() {
+                children_of[parent].push(idx);
+            }
+        }
+    }
+
+    let Some(root) = root_idx else {
+        return;
+    };
+
+    tree.begin_child("Memory tree:".to_string());
+    render_memory_node(tree, nodes, root, &children_of);
+    tree.end_child();
 }

--- a/controlplane/builtin/inspect.go
+++ b/controlplane/builtin/inspect.go
@@ -155,11 +155,23 @@ func (m *Inspect) agents(dpConfig *ffi.DPConfig) []*ynpb.AgentInfo {
 		}
 
 		for instanceIdx, instance := range agent.Instances {
+			memoryTree := make([]*ynpb.MemoryNode, len(instance.MemoryTree))
+			for nodeIdx, node := range instance.MemoryTree {
+				memoryTree[nodeIdx] = &ynpb.MemoryNode{
+					Name:        node.Name,
+					ParentIdx:   node.ParentIdx,
+					BallocCount: node.BAllocCount,
+					BfreeCount:  node.BFreeCount,
+					BallocSize:  node.BAllocSize,
+					BfreeSize:   node.BFreeSize,
+				}
+			}
 			agentInfo.Instances[instanceIdx] = &ynpb.AgentInstanceInfo{
 				Pid:         instance.PID,
 				MemoryLimit: instance.MemoryLimit,
 				FreeBytes:   instance.FreeBytes,
 				Generation:  instance.Gen,
+				MemoryTree:  memoryTree,
 			}
 		}
 

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -261,6 +261,9 @@ func (m *DPConfig) Pipelines() []Pipeline {
 // Agents returns all agent information from the dataplane.
 func (m *DPConfig) Agents() []AgentInfo {
 	agentListInfo := C.yanet_get_cp_agent_list_info(m.ptr)
+	if agentListInfo == nil {
+		return nil
+	}
 	defer C.cp_agent_list_info_free(agentListInfo)
 
 	out := make([]AgentInfo, agentListInfo.count)
@@ -283,11 +286,37 @@ func (m *DPConfig) Agents() []AgentInfo {
 				panic("FFI corruption: agent instance index became invalid")
 			}
 
+			nodeCount := uint64(instanceInfo.memory_node_count)
+			memoryTree := make([]AgentMemoryNode, nodeCount)
+			if nodeCount > 0 {
+				cNodes := unsafe.Slice(
+					(*C.struct_cp_memory_node_info)(
+						unsafe.Add(
+							unsafe.Pointer(instanceInfo),
+							unsafe.Sizeof(*instanceInfo),
+						),
+					),
+					nodeCount,
+				)
+				for nodeIdx := range memoryTree {
+					n := &cNodes[nodeIdx]
+					memoryTree[nodeIdx] = AgentMemoryNode{
+						Name:        C.GoString(&n.name[0]),
+						ParentIdx:   uint32(n.parent_idx),
+						BAllocCount: uint64(n.balloc_count),
+						BFreeCount:  uint64(n.bfree_count),
+						BAllocSize:  uint64(n.balloc_size),
+						BFreeSize:   uint64(n.bfree_size),
+					}
+				}
+			}
+
 			instances[instIdx] = AgentInstanceInfo{
 				PID:         uint32(instanceInfo.pid),
 				MemoryLimit: uint64(instanceInfo.memory_limit),
 				FreeBytes:   uint64(instanceInfo.free_bytes),
 				Gen:         uint64(instanceInfo.gen),
+				MemoryTree:  memoryTree,
 			}
 		}
 
@@ -326,12 +355,33 @@ type AgentInfo struct {
 	Instances []AgentInstanceInfo
 }
 
+// AgentMemoryNode is one entry in a flat depth-first snapshot of an agent's
+// memory-context tree.
+//
+// Copied from shared memory by the C info API; the caller never accesses
+// shared memory directly through this type.
+type AgentMemoryNode struct {
+	Name        string
+	ParentIdx   uint32
+	BAllocCount uint64
+	BFreeCount  uint64
+	BAllocSize  uint64
+	BFreeSize   uint64
+}
+
 // AgentInstanceInfo contains details about a specific agent instance.
 type AgentInstanceInfo struct {
 	PID         uint32
 	MemoryLimit uint64
 	FreeBytes   uint64
 	Gen         uint64
+	// MemoryTree is a flat depth-first snapshot of the agent's
+	// memory-context tree.
+	//
+	// Index 0 is the root; each later node references its parent via
+	// ParentIdx. Best-effort: a concurrent update may make a node appear or
+	// vanish between traversal passes.
+	MemoryTree []AgentMemoryNode
 }
 
 // Name returns the name of the dataplane module.

--- a/controlplane/ynpb/v1/inspect.proto
+++ b/controlplane/ynpb/v1/inspect.proto
@@ -185,10 +185,38 @@ message AgentInfo {
   repeated AgentInstanceInfo instances = 2;
 }
 
+// MemoryNode is one entry in a flat depth-first snapshot of an agent's
+// memory-context tree.
+//
+// The tree is produced by the C info API and copied to the heap before
+// being returned, so no shared-memory lifetime concerns apply.
+message MemoryNode {
+  // Human-readable name of this memory context.
+  string name = 1;
+
+  // Index of the parent node within the same memory_tree array.
+  //
+  // UINT32_MAX (0xFFFFFFFF) marks the root node, the agent's own context.
+  uint32 parent_idx = 2;
+
+  // Number of allocation calls made through this context.
+  uint64 balloc_count = 3;
+
+  // Number of free calls made through this context.
+  uint64 bfree_count = 4;
+
+  // Total bytes allocated through this context.
+  uint64 balloc_size = 5;
+
+  // Total bytes freed through this context.
+  uint64 bfree_size = 6;
+}
+
 // AgentInstanceInfo contains runtime information about a specific agent process
 // instance.
 message AgentInstanceInfo {
   // Operating system process ID of the agent instance.
+  //
   // Can be used for monitoring and debugging purposes.
   uint32 pid = 1;
   // Maximum memory (in bytes) this agent instance is allowed to allocate
@@ -204,8 +232,15 @@ message AgentInstanceInfo {
   // allowing the dataplane to coordinate atomic configuration switches.
   uint64 generation = 5;
   // Bytes still available for allocation in this agent instance.
+  //
   // Subtract from memory_limit to find how much memory is currently in use.
   uint64 free_bytes = 6;
+  // Flat depth-first snapshot of the agent's memory-context tree.
+  //
+  // Index 0 is the root; each later node references its parent via
+  // parent_idx. Best-effort: a concurrent update may make a node appear or
+  // vanish between traversal passes.
+  repeated MemoryNode memory_tree = 7;
 }
 
 // DeviceInfo contains information about a network device.

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -13,6 +13,7 @@
 #include "common/memory.h"
 #include "common/memory_address.h"
 #include "common/memory_block.h"
+#include "common/spinlock.h"
 #include "common/strutils.h"
 
 #include "controlplane/config/cp_module.h"
@@ -25,6 +26,7 @@
 #include "lib/errors/errors.h"
 
 #include "api/agent.h"
+#include "api/info.h"
 
 #include <stdio.h>
 
@@ -1227,6 +1229,109 @@ yanet_get_cp_device_output_pipeline_info(
 	return device_info->pipelines + device_info->input_count + idx;
 }
 
+// Count the nodes of a memory_context subtree, depth-first.
+static uint64_t
+memory_context_count_nodes(struct memory_context *ctx) {
+	uint64_t count = 1;
+	struct memory_context *child = ADDR_OF(&ctx->first_child);
+	while (child != NULL) {
+		count += memory_context_count_nodes(child);
+		child = ADDR_OF(&child->next_sibling);
+	}
+	return count;
+}
+
+// Snapshot a memory_context subtree into nodes, depth-first, capped at
+// capacity entries.
+static void
+memory_context_fill_nodes(
+	struct memory_context *ctx,
+	struct cp_memory_node_info *nodes,
+	uint32_t parent_idx,
+	uint32_t *next_idx,
+	uint32_t capacity
+) {
+	if (*next_idx >= capacity) {
+		return;
+	}
+	uint32_t my_idx = (*next_idx)++;
+	struct cp_memory_node_info *node = &nodes[my_idx];
+	strtcpy(node->name, ctx->name, sizeof(node->name));
+	node->parent_idx = parent_idx;
+	node->_pad = 0;
+	node->balloc_count =
+		__atomic_load_n(&ctx->balloc_count, __ATOMIC_RELAXED);
+	node->bfree_count =
+		__atomic_load_n(&ctx->bfree_count, __ATOMIC_RELAXED);
+	node->balloc_size =
+		__atomic_load_n(&ctx->balloc_size, __ATOMIC_RELAXED);
+	node->bfree_size = __atomic_load_n(&ctx->bfree_size, __ATOMIC_RELAXED);
+
+	struct memory_context *child = ADDR_OF(&ctx->first_child);
+	while (child != NULL) {
+		struct memory_context *sibling = ADDR_OF(&child->next_sibling);
+		memory_context_fill_nodes(
+			child, nodes, my_idx, next_idx, capacity
+		);
+		child = sibling;
+	}
+}
+
+// Build the heap-side instance info for one agent, including its
+// memory-context tree snapshot.
+//
+// The tree is a two-phase best-effort read: count under lock, malloc outside
+// it, then fill under lock again bounded by the counted capacity. Config
+// compilation is now parallel, so the tree can legitimately change between
+// the two passes -- a node appearing or vanishing is not a bug, it is the
+// documented best-effort semantics of memory_node_count.
+static struct cp_agent_instance_info *
+build_instance_info(struct agent *agent) {
+	// The allocator backing agent->memory_context also guards the
+	// context-tree splices (see the lock's own comment in
+	// common/memory_block.h). For agent_attach'd agents that allocator is
+	// the agent's own block_allocator; for dp_system_agent_new agents the
+	// context is rooted in cp_config's context instead, so its tree is
+	// guarded by cp_config's allocator lock. Reading the lock off the
+	// context itself covers both cases uniformly.
+	struct block_allocator *alloc =
+		ADDR_OF(&agent->memory_context.block_allocator);
+
+	spinlock_lock(&alloc->lock);
+	uint64_t node_count =
+		memory_context_count_nodes(&agent->memory_context);
+	spinlock_unlock(&alloc->lock);
+
+	struct cp_agent_instance_info *info = (struct cp_agent_instance_info *)
+		malloc(sizeof(struct cp_agent_instance_info) +
+		       sizeof(struct cp_memory_node_info) * node_count);
+	if (info == NULL) {
+		return NULL;
+	}
+	info->pid = agent->pid;
+	info->memory_limit = agent->memory_limit;
+	info->gen = agent->gen;
+	// For agent_attach'd agents, &agent->block_allocator is the same
+	// allocator as alloc above, and its spinlock is not reentrant, so this
+	// call must run strictly outside the locked sections above and below.
+	// For dp_system_agent_new agents the two allocators differ, but running
+	// it here uniformly keeps the call site the same for both shapes.
+	info->free_bytes = block_allocator_free_size(&agent->block_allocator);
+
+	uint32_t next_idx = 0;
+	spinlock_lock(&alloc->lock);
+	memory_context_fill_nodes(
+		&agent->memory_context,
+		info->memory_nodes,
+		UINT32_MAX,
+		&next_idx,
+		(uint32_t)node_count
+	);
+	spinlock_unlock(&alloc->lock);
+	info->memory_node_count = next_idx;
+	return info;
+}
+
 int
 yanet_get_cp_agent_instance_info(
 	struct cp_agent_info *agent_info,
@@ -1238,7 +1343,7 @@ yanet_get_cp_agent_instance_info(
 		return -1;
 	}
 
-	*instance_info = agent_info->instances + index;
+	*instance_info = agent_info->instances[index];
 
 	return 0;
 }
@@ -1259,11 +1364,23 @@ yanet_get_cp_agent_info(
 
 void
 cp_agent_list_info_free(struct cp_agent_list_info *agent_list_info) {
+	if (agent_list_info == NULL) {
+		return;
+	}
 	for (uint64_t agent_idx = 0; agent_idx < agent_list_info->count;
 	     ++agent_idx) {
-		free(agent_list_info->agents[agent_idx]);
+		struct cp_agent_info *agent_info =
+			agent_list_info->agents[agent_idx];
+		if (agent_info == NULL) {
+			continue;
+		}
+		for (uint64_t inst_idx = 0;
+		     inst_idx < agent_info->instance_count;
+		     ++inst_idx) {
+			free(agent_info->instances[inst_idx]);
+		}
+		free(agent_info);
 	}
-
 	free(agent_list_info);
 }
 
@@ -1298,7 +1415,7 @@ yanet_get_cp_agent_list_info(struct dp_config *dp_config) {
 
 		struct cp_agent_info *agent_info = (struct cp_agent_info *)
 			malloc(sizeof(struct cp_agent_info) +
-			       sizeof(struct cp_agent_instance_info) *
+			       sizeof(struct cp_agent_instance_info *) *
 				       instance_count);
 		if (agent_info == NULL) {
 			cp_agent_list_info_free(agent_list_info);
@@ -1311,14 +1428,20 @@ yanet_get_cp_agent_list_info(struct dp_config *dp_config) {
 		agent_info->instance_count = 0;
 		while (agent_info->instance_count < instance_count) {
 			struct cp_agent_instance_info *instance =
-				agent_info->instances +
-				agent_info->instance_count++;
-			instance->pid = agent->pid;
-			instance->memory_limit = agent->memory_limit;
-			instance->gen = agent->gen;
-			instance->free_bytes = block_allocator_free_size(
-				&agent->block_allocator
-			);
+				build_instance_info(agent);
+			if (instance == NULL) {
+				for (uint64_t k = 0;
+				     k < agent_info->instance_count;
+				     ++k) {
+					free(agent_info->instances[k]);
+				}
+				free(agent_info);
+				cp_agent_list_info_free(agent_list_info);
+				agent_list_info = NULL;
+				goto unlock;
+			}
+			agent_info->instances[agent_info->instance_count++] =
+				instance;
 
 			agent = ADDR_OF(&agent->prev);
 		}

--- a/tests/controlplane/agent_memory_tree_test.c
+++ b/tests/controlplane/agent_memory_tree_test.c
@@ -1,0 +1,345 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "api/info.h"
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/memory_block.h"
+#include "common/strutils.h"
+#include "common/test_assert.h"
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/zone.h"
+#include "dataplane/config/agent.h"
+#include "dataplane/config/bootstrap.h"
+#include "dataplane/config/zone.h"
+#include "lib/errors/errors.h"
+#include "lib/logging/log.h"
+
+#define DP_MEMORY (4 << 20)
+#define CP_MEMORY (4 << 20)
+#define STORAGE_SIZE (DP_MEMORY + CP_MEMORY)
+
+// Verifies that memory_context_count_nodes and memory_context_fill_nodes
+// export a correct depth-first tree via yanet_get_cp_agent_list_info. Models
+// an agent_attach'd agent: the memory_context tree is rooted at the agent's
+// own block_allocator, the same allocator build_instance_info queries via
+// block_allocator_free_size, so a future regression that moves that call
+// inside the tree-walk lock would deadlock this test instead of passing.
+static int
+test_memory_tree_exported(void) {
+	void *storage = calloc(1, STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp = NULL;
+	struct cp_config *cp = NULL;
+	int rc = dp_storage_init(0, 0, storage, DP_MEMORY, CP_MEMORY, &dp, &cp);
+	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+
+	struct agent *sys = dp_system_agent_new(cp, dp, "dataplane");
+	TEST_ASSERT_NOT_NULL(sys, "dp_system_agent_new failed");
+
+	yanet_error *err = NULL;
+	struct cp_config_gen *gen = cp_config_gen_new(sys, &err);
+	TEST_ASSERT_NOT_NULL(gen, "cp_config_gen_new failed");
+	SET_OFFSET_OF(&cp->cp_config_gen, gen);
+
+	// Build a small named agent directly in shared memory.
+	struct agent *ag =
+		(struct agent *)memory_balloc(&cp->memory_context, sizeof(*ag));
+	TEST_ASSERT_NOT_NULL(ag, "agent alloc failed");
+	memset(ag, 0, sizeof(*ag));
+	strtcpy(ag->name, "myagent", sizeof(ag->name));
+	ag->memory_limit = 65536;
+	ag->pid = 42;
+	ag->gen = 1;
+	SET_OFFSET_OF(&ag->dp_config, dp);
+	SET_OFFSET_OF(&ag->cp_config, cp);
+	block_allocator_init(&ag->block_allocator);
+	memory_context_init(
+		&ag->memory_context, "myagent", &ag->block_allocator
+	);
+
+	// Seed the agent's own allocator with a real arena, as agent_attach
+	// does, so the child contexts below actually allocate from it.
+	void *arena = memory_balloc(&cp->memory_context, ag->memory_limit);
+	TEST_ASSERT_NOT_NULL(arena, "arena alloc failed");
+	block_allocator_put_arena(
+		&ag->block_allocator, arena, ag->memory_limit
+	);
+
+	// Add a child context "mod" and a grandchild "lpm".
+	struct memory_context *mod_ctx = (struct memory_context *)memory_balloc(
+		&cp->memory_context, sizeof(*mod_ctx)
+	);
+	TEST_ASSERT_NOT_NULL(mod_ctx, "mod_ctx alloc failed");
+	memory_context_init_from(mod_ctx, &ag->memory_context, "mod");
+
+	struct memory_context *lpm_ctx = (struct memory_context *)memory_balloc(
+		&cp->memory_context, sizeof(*lpm_ctx)
+	);
+	TEST_ASSERT_NOT_NULL(lpm_ctx, "lpm_ctx alloc failed");
+	memory_context_init_from(lpm_ctx, mod_ctx, "lpm");
+
+	// Do a couple of allocations so balloc_size is non-zero.
+	void *b1 = memory_balloc(mod_ctx, 128);
+	TEST_ASSERT_NOT_NULL(b1, "mod alloc failed");
+	void *b2 = memory_balloc(lpm_ctx, 256);
+	TEST_ASSERT_NOT_NULL(b2, "lpm alloc failed");
+
+	// Register the agent in the registry.
+	struct cp_agent_registry *old_reg = ADDR_OF(&cp->agent_registry);
+	struct cp_agent_registry *new_reg =
+		(struct cp_agent_registry *)memory_balloc(
+			&cp->memory_context,
+			sizeof(struct cp_agent_registry) +
+				(old_reg->count + 1) * sizeof(struct agent *)
+		);
+	TEST_ASSERT_NOT_NULL(new_reg, "registry alloc failed");
+	for (uint64_t idx = 0; idx < old_reg->count; ++idx) {
+		SET_OFFSET_OF(
+			&new_reg->agents[idx], ADDR_OF(&old_reg->agents[idx])
+		);
+	}
+	SET_OFFSET_OF(&new_reg->agents[old_reg->count], ag);
+	new_reg->count = old_reg->count + 1;
+	SET_OFFSET_OF(&cp->agent_registry, new_reg);
+
+	dp->instance_count = 1;
+	cp_config_unlock(cp);
+	dp_config_mark_ready(dp);
+
+	struct cp_agent_list_info *list = yanet_get_cp_agent_list_info(dp);
+	TEST_ASSERT_NOT_NULL(
+		list, "yanet_get_cp_agent_list_info returned NULL"
+	);
+
+	// Find our agent in the list.
+	struct cp_agent_info *ai = NULL;
+	for (uint64_t idx = 0; idx < list->count; ++idx) {
+		struct cp_agent_info *candidate = list->agents[idx];
+		if (strncmp(candidate->name, "myagent", 80) == 0) {
+			ai = candidate;
+			break;
+		}
+	}
+	TEST_ASSERT_NOT_NULL(ai, "myagent not found in agent list");
+	TEST_ASSERT(ai->instance_count >= 1, "instance_count must be >= 1");
+
+	struct cp_agent_instance_info *inst = NULL;
+	rc = yanet_get_cp_agent_instance_info(ai, 0, &inst);
+	TEST_ASSERT(rc == 0, "yanet_get_cp_agent_instance_info failed");
+	TEST_ASSERT_NOT_NULL(inst, "instance info is NULL");
+
+	// The tree has root "myagent", child "mod", grandchild "lpm" — 3 nodes.
+	TEST_ASSERT(inst->memory_node_count == 3, "expected 3 memory nodes");
+
+	// Node 0 must be the root with UINT32_MAX parent and name "myagent".
+	TEST_ASSERT(
+		inst->memory_nodes[0].parent_idx == UINT32_MAX,
+		"root node must have parent_idx == UINT32_MAX"
+	);
+	TEST_ASSERT(
+		strncmp(inst->memory_nodes[0].name, "myagent", CP_MCTX_NAME_LEN
+		) == 0,
+		"root node name must be myagent"
+	);
+
+	// The child "mod" has parent_idx 0 (the root) and non-zero balloc_size.
+	int found_mod = 0;
+	int found_lpm = 0;
+	uint64_t mod_idx = UINT64_MAX;
+	for (uint64_t n = 1; n < inst->memory_node_count; ++n) {
+		struct cp_memory_node_info *node = &inst->memory_nodes[n];
+		if (strncmp(node->name, "mod", CP_MCTX_NAME_LEN) == 0) {
+			found_mod = 1;
+			mod_idx = n;
+			TEST_ASSERT(
+				node->parent_idx == 0,
+				"mod parent_idx must be 0"
+			);
+			TEST_ASSERT(
+				node->balloc_size > 0,
+				"mod must have non-zero balloc_size"
+			);
+		} else if (strncmp(node->name, "lpm", CP_MCTX_NAME_LEN) == 0) {
+			found_lpm = 1;
+			TEST_ASSERT(
+				node->balloc_size > 0,
+				"lpm must have non-zero balloc_size"
+			);
+			TEST_ASSERT(
+				node->parent_idx == mod_idx,
+				"lpm parent_idx must be mod's node index"
+			);
+		}
+	}
+	TEST_ASSERT(found_mod, "mod node not found");
+	TEST_ASSERT(found_lpm, "lpm node not found");
+
+	cp_agent_list_info_free(list);
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verifies that cp_agent_list_info_free(NULL) does not crash.
+static int
+test_free_null_safe(void) {
+	cp_agent_list_info_free(NULL);
+	return TEST_SUCCESS;
+}
+
+// Verifies that after memory_context_fini on the grandchild a fresh snapshot
+// no longer reports that node and the root name is still intact. Models a
+// dp_system_agent_new agent: the memory_context tree is rooted at cp_config's
+// allocator, distinct from the agent's own block_allocator, covering the
+// other of the two allocator shapes build_instance_info handles.
+static int
+test_memory_tree_after_fini(void) {
+	void *storage = calloc(1, STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp = NULL;
+	struct cp_config *cp = NULL;
+	int rc = dp_storage_init(0, 0, storage, DP_MEMORY, CP_MEMORY, &dp, &cp);
+	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+
+	struct agent *sys = dp_system_agent_new(cp, dp, "dataplane");
+	TEST_ASSERT_NOT_NULL(sys, "dp_system_agent_new failed");
+
+	yanet_error *err = NULL;
+	struct cp_config_gen *gen = cp_config_gen_new(sys, &err);
+	TEST_ASSERT_NOT_NULL(gen, "cp_config_gen_new failed");
+	SET_OFFSET_OF(&cp->cp_config_gen, gen);
+
+	struct agent *ag =
+		(struct agent *)memory_balloc(&cp->memory_context, sizeof(*ag));
+	TEST_ASSERT_NOT_NULL(ag, "agent alloc failed");
+	memset(ag, 0, sizeof(*ag));
+	strtcpy(ag->name, "fini-agent", sizeof(ag->name));
+	ag->memory_limit = 65536;
+	ag->pid = 7;
+	ag->gen = 1;
+	SET_OFFSET_OF(&ag->dp_config, dp);
+	SET_OFFSET_OF(&ag->cp_config, cp);
+	block_allocator_init(&ag->block_allocator);
+	memory_context_init(
+		&ag->memory_context, "fini-agent", &cp->block_allocator
+	);
+
+	struct memory_context *child_ctx = (struct memory_context *)
+		memory_balloc(&cp->memory_context, sizeof(*child_ctx));
+	TEST_ASSERT_NOT_NULL(child_ctx, "child_ctx alloc failed");
+	memory_context_init_from(child_ctx, &ag->memory_context, "child");
+
+	struct memory_context *grand_ctx = (struct memory_context *)
+		memory_balloc(&cp->memory_context, sizeof(*grand_ctx));
+	TEST_ASSERT_NOT_NULL(grand_ctx, "grand_ctx alloc failed");
+	memory_context_init_from(grand_ctx, child_ctx, "grand");
+
+	struct cp_agent_registry *old_reg = ADDR_OF(&cp->agent_registry);
+	struct cp_agent_registry *new_reg =
+		(struct cp_agent_registry *)memory_balloc(
+			&cp->memory_context,
+			sizeof(struct cp_agent_registry) +
+				(old_reg->count + 1) * sizeof(struct agent *)
+		);
+	TEST_ASSERT_NOT_NULL(new_reg, "registry alloc failed");
+	for (uint64_t idx = 0; idx < old_reg->count; ++idx) {
+		SET_OFFSET_OF(
+			&new_reg->agents[idx], ADDR_OF(&old_reg->agents[idx])
+		);
+	}
+	SET_OFFSET_OF(&new_reg->agents[old_reg->count], ag);
+	new_reg->count = old_reg->count + 1;
+	SET_OFFSET_OF(&cp->agent_registry, new_reg);
+
+	dp->instance_count = 1;
+	cp_config_unlock(cp);
+	dp_config_mark_ready(dp);
+
+	// Tear down the grandchild context, then re-snapshot.
+	memory_context_fini(grand_ctx);
+
+	struct cp_agent_list_info *list = yanet_get_cp_agent_list_info(dp);
+	TEST_ASSERT_NOT_NULL(
+		list, "yanet_get_cp_agent_list_info returned NULL"
+	);
+
+	struct cp_agent_info *ai = NULL;
+	for (uint64_t idx = 0; idx < list->count; ++idx) {
+		struct cp_agent_info *candidate = list->agents[idx];
+		if (strncmp(candidate->name, "fini-agent", 80) == 0) {
+			ai = candidate;
+			break;
+		}
+	}
+	TEST_ASSERT_NOT_NULL(ai, "fini-agent not found in agent list");
+
+	struct cp_agent_instance_info *inst = NULL;
+	rc = yanet_get_cp_agent_instance_info(ai, 0, &inst);
+	TEST_ASSERT(rc == 0, "yanet_get_cp_agent_instance_info failed");
+	TEST_ASSERT_NOT_NULL(inst, "instance info is NULL");
+
+	// After fini of grand, only root + child remain — 2 nodes.
+	TEST_ASSERT(
+		inst->memory_node_count == 2,
+		"expected 2 memory nodes after fini"
+	);
+
+	// Root name must still be intact.
+	TEST_ASSERT(
+		strncmp(inst->memory_nodes[0].name,
+			"fini-agent",
+			CP_MCTX_NAME_LEN) == 0,
+		"root node name must still be fini-agent after grandchild fini"
+	);
+
+	// "grand" must not appear.
+	for (uint64_t n = 0; n < inst->memory_node_count; ++n) {
+		TEST_ASSERT(
+			strncmp(inst->memory_nodes[n].name,
+				"grand",
+				CP_MCTX_NAME_LEN) != 0,
+			"grand must not appear after memory_context_fini"
+		);
+	}
+
+	cp_agent_list_info_free(list);
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	size_t tests_count = 0;
+	size_t tests_failed = 0;
+
+	++tests_count;
+	if (test_memory_tree_exported() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_memory_tree_exported failed");
+	}
+
+	++tests_count;
+	if (test_free_null_safe() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_free_null_safe failed");
+	}
+
+	++tests_count;
+	if (test_memory_tree_after_fini() != TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR, "test_memory_tree_after_fini failed");
+	}
+
+	if (tests_failed != 0) {
+		LOG(ERROR, "%zu/%zu tests failed", tests_failed, tests_count);
+		return -1;
+	}
+
+	LOG(INFO, "all %zu tests passed", tests_count);
+	return 0;
+}

--- a/tests/controlplane/meson.build
+++ b/tests/controlplane/meson.build
@@ -12,3 +12,19 @@ config_gen_test = executable(
   include_directories: yanet_libdir,
 )
 test('config_gen', config_gen_test, suite: ['controlplane'])
+
+agent_memory_tree_test = executable(
+  'agent_memory_tree_test',
+  ['agent_memory_tree_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_common_dep,
+    lib_logging_dep,
+    lib_config_cp_dep,
+    lib_config_dp_dep,
+    lib_agent_cp_dep,
+  ],
+  include_directories: [yanet_libdir, yanet_rootdir],
+)
+test('agent_memory_tree', agent_memory_tree_test, suite: ['controlplane'])


### PR DESCRIPTION
Make the inspect view show the per-subsystem memory hierarchy of each agent, so memory consumption can be attributed to the exact subsystem that allocated it — for example an ACL config&#39;s filters and their LPMs. Builds on the memory-context tree from #1226, re-derived on top of #1648: the allocator lock introduced there already serializes the tree bookkeeping, so this change carries no locking machinery of its own.

- Snapshot each agent instance&#39;s memory-context subtree into the control-plane info API under the allocator lock of the agent&#39;s context, in two capacity-bounded best-effort phases, so the lock is never held across a configuration build and no module code changes.
- Surface the tree through the FFI layer, the inspect protobuf, and the inspect gRPC service.
- Render it under each agent instance in the inspect CLI, sorted by subtree total so the heaviest consumers stand out.
- No shared-memory layout change and no ABI bump: the exported structures are heap-side info-API surface only.

Sample output captured from a local dev stack (agents with empty trees elided for brevity):

```
Agents
├─ route
│  └─ Instance (PID: 4154887)
│     ├─ Memory limit: 16.0 MiB
│     ├─ Used:         172.1 KiB
│     ├─ Free:         15.8 MiB
│     ├─ Generation: 0
│     └─ Memory tree:
│        └─ route (Used: 167.9 KiB)
│           ├─ route1 (Used: 99.2 KiB)
│           │  ├─ lpm (Used: 64.0 KiB)
│           │  └─ lpm (Used: 32.0 KiB)
│           └─ route0 (Used: 66.9 KiB)
│              ├─ lpm (Used: 32.0 KiB)
│              └─ lpm (Used: 32.0 KiB)
├─ decap
│  └─ Instance (PID: 4154887)
│     ├─ Used:         69.6 KiB
│     └─ Memory tree:
│        └─ decap (Used: 67.6 KiB)
│           └─ decap0 (Used: 66.8 KiB)
│              ├─ lpm (Used: 32.0 KiB)
│              └─ lpm (Used: 32.0 KiB)
├─ forward
│  └─ Instance (PID: 4154887)
│     ├─ Used:         2.6 MiB
│     └─ Memory tree:
│        └─ forward (Used: 2.6 MiB)
│           ├─ phy-vlan (Used: 1.4 MiB)
│           │  ├─ filter (Used: 770.4 KiB)
│           │  └─ filter (Used: 385.9 KiB)
│           └─ vlan-phy (Used: 1.2 MiB)
│              ├─ filter (Used: 576.9 KiB)
│              └─ filter (Used: 384.5 KiB)
└─ acl
   └─ Instance (PID: 4154887)
      ├─ Memory limit: 8.0 GiB
      ├─ Used:         278.5 MiB
      ├─ Free:         7.7 GiB
      ├─ Generation: 0
      └─ Memory tree:
         └─ acl (Used: 174.3 MiB)
            ├─ acl0 (Used: 6.2 MiB)
            │  ├─ filter (Used: 1.9 MiB)
            │  ├─ filter (Used: 1.7 MiB)
            │  └─ filter (Used: 1.3 MiB)
            └─ fwstate0 (Used: 2.8 KiB)
```

The JSON format (--format json) returns the same tree as a flat node array with parent_idx linkage and per-node allocation counters.