### PR TITLE
refactor(common): remove unused recursive spinlock

### DIFF
--- a/common/spinlock.h
+++ b/common/spinlock.h
@@ -3,9 +3,6 @@
 #include <sched.h>
 #include <stdatomic.h>
 #include <stdbool.h>
-#include <unistd.h>
-
-#include <sys/syscall.h>
 
 struct spinlock {
 	atomic_bool locked;
@@ -66,74 +63,4 @@ spinlock_lock(struct spinlock *lock) {
 static inline void
 spinlock_unlock(struct spinlock *lock) {
 	atomic_store_explicit(&lock->locked, false, memory_order_release);
-}
-
-struct recursive_spinlock {
-	atomic_int owner;
-	uint32_t recursion;
-};
-
-static inline void
-recursive_spinlock_init(struct recursive_spinlock *lock) {
-	atomic_init(&lock->owner, 0);
-	lock->recursion = 0;
-}
-
-static inline int
-tid() {
-	return syscall(SYS_gettid);
-}
-
-static inline int
-recursive_spinlock_try_lock(struct recursive_spinlock *lock) {
-	int me = tid();
-	if (atomic_load_explicit(&lock->owner, memory_order_relaxed) == me) {
-		lock->recursion++;
-		return 1;
-	}
-
-	int expected = 0;
-	if (atomic_compare_exchange_weak_explicit(
-		    &lock->owner,
-		    &expected,
-		    me,
-		    memory_order_acquire,
-		    memory_order_relaxed
-	    )) {
-		lock->recursion = 1;
-		return 1;
-	}
-
-	return 0;
-}
-
-static inline void
-recursive_spinlock_lock(struct recursive_spinlock *lock) {
-	int me = tid();
-	if (atomic_load_explicit(&lock->owner, memory_order_relaxed) == me) {
-		++lock->recursion;
-		return;
-	}
-
-	for (;;) {
-		int expected = 0;
-		if (atomic_compare_exchange_weak_explicit(
-			    &lock->owner,
-			    &expected,
-			    me,
-			    memory_order_acquire,
-			    memory_order_relaxed
-		    )) {
-			lock->recursion = 1;
-			return;
-		}
-		spinlock_cpu_relax();
-	}
-}
-
-static inline void
-recursive_spinlock_unlock(struct recursive_spinlock *lock) {
-	if (--lock->recursion == 0) {
-		atomic_store_explicit(&lock->owner, 0, memory_order_release);
-	}
 }


### PR DESCRIPTION
The recursive spinlock variant in the shared spinlock header has no consumers anywhere in the tree. Removing it deletes dead code and drops the header's dependency on the unistd and syscall system headers, which keeps it safe to include from low-level, widely-included headers.