### PR TITLE
refactor(readiness): unify gateway and operator readiness trackers

### DIFF
--- a/common/go/readiness/readiness.go
+++ b/common/go/readiness/readiness.go
@@ -1,4 +1,4 @@
-package operator
+package readiness
 
 import (
 	"sync"
@@ -10,7 +10,7 @@ import (
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
 
-// scopeState holds the mutable readiness state for one gateway scope.
+// scopeState holds the mutable readiness state for one scope.
 type scopeState struct {
 	name               string
 	state              readinesspb.State
@@ -19,66 +19,81 @@ type scopeState struct {
 	lastTransitionTime time.Time
 }
 
-// Readiness tracks readiness state across named scopes.
+// Tracker tracks readiness state across named scopes.
 //
 // Each scope is an independent readiness dimension (e.g. "neighbours", "rib",
 // or a gateway ID). State transitions and observation timestamps are
 // maintained independently per scope.
-type Readiness struct {
-	mu     sync.Mutex
-	scopes map[string]*scopeState
-	log    *zap.Logger
+type Tracker struct {
+	mu           sync.Mutex
+	scopes       map[string]*scopeState
+	latchOnDrain bool
+	drained      bool
+	log          *zap.Logger
 }
 
-// ReadinessOption configures NewReadiness.
-type ReadinessOption func(*readinessOptions)
+// Option configures NewTracker.
+type Option func(*options)
 
-type readinessOptions struct {
-	Log *zap.Logger
+type options struct {
+	Log          *zap.Logger
+	LatchOnDrain bool
 }
 
-func newReadinessOptions() *readinessOptions {
-	return &readinessOptions{
+func newOptions() *options {
+	return &options{
 		Log: zap.NewNop(),
 	}
 }
 
-// WithReadinessLog sets the logger used by the Readiness tracker.
+// WithLog sets the logger used by the Tracker.
 //
 // The caller is responsible for pre-tagging the logger with any
 // operator or context attributes (e.g. via log.With(zap.String("operator",
 // "route"))). The tracker itself adds only the scope field on each transition.
-func WithReadinessLog(log *zap.Logger) ReadinessOption {
-	return func(o *readinessOptions) {
+func WithLog(log *zap.Logger) Option {
+	return func(o *options) {
 		o.Log = log
 	}
 }
 
-// NewReadiness creates a Readiness tracker pre-seeded with the supplied
-// gateway IDs, each starting at STATE_UNKNOWN.
-func NewReadiness(gatewayIDs []string, options ...ReadinessOption) *Readiness {
-	opts := newReadinessOptions()
+// WithDrainLatch enables the drain latch.
+//
+// When active, once Drain has been called any subsequent Set or Observe calls
+// on the tracker are no-ops. This prevents a late Ready signal from flipping a
+// drained tracker back to READY.
+func WithDrainLatch() Option {
+	return func(o *options) {
+		o.LatchOnDrain = true
+	}
+}
+
+// NewTracker creates a Tracker pre-seeded with the supplied scope names, each
+// starting at STATE_UNKNOWN.
+func NewTracker(scopeNames []string, options ...Option) *Tracker {
+	opts := newOptions()
 	for _, o := range options {
 		o(opts)
 	}
 
 	scopes := map[string]*scopeState{}
-	for _, id := range gatewayIDs {
+	for _, id := range scopeNames {
 		scopes[id] = &scopeState{
 			name:  id,
 			state: readinesspb.State_STATE_UNKNOWN,
 		}
 	}
 
-	return &Readiness{
-		scopes: scopes,
-		log:    opts.Log,
+	return &Tracker{
+		scopes:       scopes,
+		latchOnDrain: opts.LatchOnDrain,
+		log:          opts.Log,
 	}
 }
 
 // logTransition logs a state change for a scope at Info level when prev and
 // next differ. The reason code and message are included when reason is non-nil.
-func (m *Readiness) logTransition(name string, prev, next readinesspb.State, reason *readinesspb.Reason) {
+func (m *Tracker) logTransition(name string, prev, next readinesspb.State, reason *readinesspb.Reason) {
 	if prev == next {
 		return
 	}
@@ -102,9 +117,13 @@ func (m *Readiness) logTransition(name string, prev, next readinesspb.State, rea
 // A failed apply holds the scope at DEGRADED when it was previously applied,
 // and drops to NOT_READY only when it was never applied. observed_at always
 // advances; last_transition_time changes only on a state transition.
-func (m *Readiness) Observe(gatewayID string, err error) {
+func (m *Tracker) Observe(gatewayID string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.drained {
+		return
+	}
 
 	s, ok := m.scopes[gatewayID]
 	if !ok {
@@ -147,7 +166,7 @@ func (m *Readiness) Observe(gatewayID string, err error) {
 //
 // It creates the scope if absent. last_transition_time is updated only when
 // the state value changes.
-func (m *Readiness) Set(scope string, state readinesspb.State) {
+func (m *Tracker) Set(scope string, state readinesspb.State) {
 	m.set(scope, state, nil)
 }
 
@@ -156,14 +175,18 @@ func (m *Readiness) Set(scope string, state readinesspb.State) {
 //
 // It creates the scope if absent. last_transition_time is updated only when
 // the state value changes.
-func (m *Readiness) SetWithReason(scope string, state readinesspb.State, reason *readinesspb.Reason) {
+func (m *Tracker) SetWithReason(scope string, state readinesspb.State, reason *readinesspb.Reason) {
 	m.set(scope, state, reason)
 }
 
 // set is the shared implementation for Set and SetWithReason.
-func (m *Readiness) set(scope string, state readinesspb.State, reason *readinesspb.Reason) {
+func (m *Tracker) set(scope string, state readinesspb.State, reason *readinesspb.Reason) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.drained {
+		return
+	}
 
 	now := time.Now()
 
@@ -190,7 +213,7 @@ func (m *Readiness) set(scope string, state readinesspb.State, reason *readiness
 // freshness consumers can distinguish a live scope from one whose last event
 // was long ago. Touch is a no-op for unknown scopes — it never creates a
 // scope. state, reason, and lastTransitionTime are left unchanged.
-func (m *Readiness) Touch(scope string) {
+func (m *Tracker) Touch(scope string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -204,8 +227,10 @@ func (m *Readiness) Touch(scope string) {
 
 // Drain marks every scope as STATE_NOT_READY with a SHUTTING_DOWN reason.
 //
-// last_transition_time is updated only for scopes that change state.
-func (m *Readiness) Drain() {
+// last_transition_time is updated only for scopes that change state. When
+// the Tracker was constructed with WithDrainLatch, subsequent Set and Observe
+// calls become no-ops after Drain returns.
+func (m *Tracker) Drain() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -222,11 +247,15 @@ func (m *Readiness) Drain() {
 
 		m.logTransition(s.name, prev, readinesspb.State_STATE_NOT_READY, reason)
 	}
+
+	if m.latchOnDrain {
+		m.drained = true
+	}
 }
 
 // Ready builds a ReadyResponse for the given request, honoring the scope
 // filter. An empty scopes list in the request returns all known scopes.
-func (m *Readiness) Ready(req *readinesspb.ReadyRequest) *readinesspb.ReadyResponse {
+func (m *Tracker) Ready(req *readinesspb.ReadyRequest) *readinesspb.ReadyResponse {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/common/go/readiness/readiness_test.go
+++ b/common/go/readiness/readiness_test.go
@@ -1,4 +1,4 @@
-package operator_test
+package readiness_test
 
 import (
 	"errors"
@@ -11,12 +11,12 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
 
-	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
 
-func TestReadiness_InitialState(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a", "gw-b"})
+func TestTracker_InitialState(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
 	resp := r.Ready(&readinesspb.ReadyRequest{})
 
 	require.Len(t, resp.Scopes, 2)
@@ -28,7 +28,7 @@ func TestReadiness_InitialState(t *testing.T) {
 	}
 }
 
-func TestReadiness_Transitions(t *testing.T) {
+func TestTracker_Transitions(t *testing.T) {
 	applyErr := errors.New("connection refused")
 
 	tests := []struct {
@@ -54,7 +54,7 @@ func TestReadiness_Transitions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := operator.NewReadiness([]string{"gw-a"})
+			r := readiness.NewTracker([]string{"gw-a"})
 			r.Observe("gw-a", tt.observeErr)
 
 			resp := r.Ready(&readinesspb.ReadyRequest{})
@@ -76,27 +76,27 @@ func TestReadiness_Transitions(t *testing.T) {
 	}
 }
 
-// TestReadiness_ObserveHoldOnRegression verifies the state-aware Observe
+// TestTracker_ObserveHoldOnRegression verifies the state-aware Observe
 // semantics: a failure from READY or DEGRADED holds at DEGRADED (last-good
 // state live), while a failure from UNKNOWN or NOT_READY produces NOT_READY.
-func TestReadiness_ObserveHoldOnRegression(t *testing.T) {
+func TestTracker_ObserveHoldOnRegression(t *testing.T) {
 	boom := errors.New("push failed")
 
 	tests := []struct {
 		name       string
-		seed       func(r *operator.Readiness) // sets up pre-condition
+		seed       func(r *readiness.Tracker) // sets up pre-condition
 		wantState  readinesspb.State
 		wantReason string
 	}{
 		{
 			name:       "UNKNOWN + err -> NOT_READY",
-			seed:       func(_ *operator.Readiness) {},
+			seed:       func(_ *readiness.Tracker) {},
 			wantState:  readinesspb.State_STATE_NOT_READY,
 			wantReason: "APPLY_FAILED",
 		},
 		{
 			name: "READY + err -> DEGRADED",
-			seed: func(r *operator.Readiness) {
+			seed: func(r *readiness.Tracker) {
 				r.Observe("gw", nil) // UNKNOWN -> READY
 			},
 			wantState:  readinesspb.State_STATE_DEGRADED,
@@ -104,7 +104,7 @@ func TestReadiness_ObserveHoldOnRegression(t *testing.T) {
 		},
 		{
 			name: "DEGRADED + err -> DEGRADED",
-			seed: func(r *operator.Readiness) {
+			seed: func(r *readiness.Tracker) {
 				r.Observe("gw", nil)  // UNKNOWN -> READY
 				r.Observe("gw", boom) // READY -> DEGRADED
 			},
@@ -113,7 +113,7 @@ func TestReadiness_ObserveHoldOnRegression(t *testing.T) {
 		},
 		{
 			name: "NOT_READY + err -> NOT_READY",
-			seed: func(r *operator.Readiness) {
+			seed: func(r *readiness.Tracker) {
 				r.Observe("gw", boom) // UNKNOWN -> NOT_READY
 			},
 			wantState:  readinesspb.State_STATE_NOT_READY,
@@ -121,7 +121,7 @@ func TestReadiness_ObserveHoldOnRegression(t *testing.T) {
 		},
 		{
 			name: "DEGRADED + ok -> READY",
-			seed: func(r *operator.Readiness) {
+			seed: func(r *readiness.Tracker) {
 				r.Observe("gw", nil)  // UNKNOWN -> READY
 				r.Observe("gw", boom) // READY -> DEGRADED
 			},
@@ -130,7 +130,7 @@ func TestReadiness_ObserveHoldOnRegression(t *testing.T) {
 		},
 		{
 			name: "NOT_READY + ok -> READY",
-			seed: func(r *operator.Readiness) {
+			seed: func(r *readiness.Tracker) {
 				r.Observe("gw", boom) // UNKNOWN -> NOT_READY
 			},
 			wantState:  readinesspb.State_STATE_READY,
@@ -140,7 +140,7 @@ func TestReadiness_ObserveHoldOnRegression(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			r := operator.NewReadiness([]string{"gw"})
+			r := readiness.NewTracker([]string{"gw"})
 			tt.seed(r)
 
 			var finalErr error
@@ -163,8 +163,8 @@ func TestReadiness_ObserveHoldOnRegression(t *testing.T) {
 	}
 }
 
-func TestReadiness_LastTransitionTime_OnlyChangesOnStateChange(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a"})
+func TestTracker_LastTransitionTime_OnlyChangesOnStateChange(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
 
 	// First observation: UNKNOWN -> READY.
 	r.Observe("gw-a", nil)
@@ -195,8 +195,8 @@ func TestReadiness_LastTransitionTime_OnlyChangesOnStateChange(t *testing.T) {
 		"last_transition_time must advance on READY -> DEGRADED")
 }
 
-func TestReadiness_ScopeFilter(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a", "gw-b", "gw-c"})
+func TestTracker_ScopeFilter(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b", "gw-c"})
 	r.Observe("gw-a", nil)
 	r.Observe("gw-b", errors.New("down"))
 
@@ -206,14 +206,14 @@ func TestReadiness_ScopeFilter(t *testing.T) {
 	assert.Equal(t, readinesspb.State_STATE_NOT_READY, resp.Scopes[0].State)
 }
 
-func TestReadiness_ScopeFilter_Empty_ReturnsAll(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a", "gw-b"})
+func TestTracker_ScopeFilter_Empty_ReturnsAll(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
 	resp := r.Ready(&readinesspb.ReadyRequest{})
 	assert.Len(t, resp.Scopes, 2)
 }
 
-func TestReadiness_UnknownGatewayIgnored(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a"})
+func TestTracker_UnknownGatewayIgnored(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
 	// Observe on an unknown id must not panic.
 	r.Observe("gw-x", nil)
 
@@ -223,8 +223,8 @@ func TestReadiness_UnknownGatewayIgnored(t *testing.T) {
 	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, resp.Scopes[0].State)
 }
 
-func TestReadiness_Drain(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a", "gw-b"})
+func TestTracker_Drain(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
 
 	// Bring gw-a to READY.
 	r.Observe("gw-a", nil)
@@ -241,8 +241,8 @@ func TestReadiness_Drain(t *testing.T) {
 	}
 }
 
-func TestReadiness_Drain_TransitionTimeOnlyOnChange(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a"})
+func TestTracker_Drain_TransitionTimeOnlyOnChange(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
 
 	// Put gw-a in NOT_READY already via a failed observe.
 	r.Observe("gw-a", errors.New("boom"))
@@ -258,8 +258,8 @@ func TestReadiness_Drain_TransitionTimeOnlyOnChange(t *testing.T) {
 		"draining a scope already in NOT_READY must not update last_transition_time")
 }
 
-func TestReadiness_Set_UpsertNewScope(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a"})
+func TestTracker_Set_UpsertNewScope(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
 
 	// Set a scope that was not in the initial list.
 	r.Set("rib", readinesspb.State_STATE_READY)
@@ -279,8 +279,8 @@ func TestReadiness_Set_UpsertNewScope(t *testing.T) {
 	assert.NotNil(t, ribScope.LastTransitionTime)
 }
 
-func TestReadiness_Set_TransitionTimeOnlyOnStateChange(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a"})
+func TestTracker_Set_TransitionTimeOnlyOnStateChange(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
 
 	r.Set("gw-a", readinesspb.State_STATE_READY)
 	resp1 := r.Ready(&readinesspb.ReadyRequest{})
@@ -303,8 +303,8 @@ func TestReadiness_Set_TransitionTimeOnlyOnStateChange(t *testing.T) {
 		"last_transition_time must advance on state change via Set")
 }
 
-func TestReadiness_Set_ReasonsUpdated(t *testing.T) {
-	r := operator.NewReadiness([]string{"gw-a"})
+func TestTracker_Set_ReasonsUpdated(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
 
 	r.SetWithReason("gw-a", readinesspb.State_STATE_NOT_READY,
 		&readinesspb.Reason{Code: "SYNCING"})
@@ -320,8 +320,8 @@ func TestReadiness_Set_ReasonsUpdated(t *testing.T) {
 	assert.Empty(t, resp2.Scopes[0].Reasons)
 }
 
-func TestReadiness_Touch_AdvancesObservedAt(t *testing.T) {
-	r := operator.NewReadiness([]string{"neighbours"})
+func TestTracker_Touch_AdvancesObservedAt(t *testing.T) {
+	r := readiness.NewTracker([]string{"neighbours"})
 
 	// Drive the scope to a known state.
 	r.SetWithReason("neighbours",
@@ -357,8 +357,8 @@ func TestReadiness_Touch_AdvancesObservedAt(t *testing.T) {
 	assert.Equal(t, wantReason, s2.Reasons[0].Code, "Touch must not change reason")
 }
 
-func TestReadiness_Touch_UnknownScope_NoOp(t *testing.T) {
-	r := operator.NewReadiness([]string{"neighbours"})
+func TestTracker_Touch_UnknownScope_NoOp(t *testing.T) {
+	r := readiness.NewTracker([]string{"neighbours"})
 
 	// Touch an unknown scope must not panic and must not create the scope.
 	r.Touch("bird-session")
@@ -368,22 +368,21 @@ func TestReadiness_Touch_UnknownScope_NoOp(t *testing.T) {
 	assert.Equal(t, "neighbours", resp.Scopes[0].Name)
 }
 
-// newObservedReadiness constructs a Readiness tracker backed by a zap
-// observer so tests can inspect emitted log entries. The operatorName is
-// pre-tagged on the logger before passing it to the tracker, matching the
-// expected caller pattern.
-func newObservedReadiness(t *testing.T, scopes []string, operatorName string) (*operator.Readiness, *observer.ObservedLogs) {
+// newObservedTracker constructs a Tracker backed by a zap observer so tests
+// can inspect emitted log entries. The operatorName is pre-tagged on the
+// logger before passing it to the tracker, matching the expected caller pattern.
+func newObservedTracker(t *testing.T, scopes []string, operatorName string) (*readiness.Tracker, *observer.ObservedLogs) {
 	t.Helper()
 	core, logs := observer.New(zapcore.InfoLevel)
-	r := operator.NewReadiness(
+	r := readiness.NewTracker(
 		scopes,
-		operator.WithReadinessLog(zap.New(core).With(zap.String("operator", operatorName))),
+		readiness.WithLog(zap.New(core).With(zap.String("operator", operatorName))),
 	)
 	return r, logs
 }
 
-func TestReadiness_Log_SetTransitionLogsEntry(t *testing.T) {
-	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
+func TestTracker_Log_SetTransitionLogsEntry(t *testing.T) {
+	r, logs := newObservedTracker(t, []string{"gw-a"}, "route")
 
 	r.SetWithReason("gw-a", readinesspb.State_STATE_READY,
 		&readinesspb.Reason{Code: "SYNCED", Message: "all good"})
@@ -402,8 +401,8 @@ func TestReadiness_Log_SetTransitionLogsEntry(t *testing.T) {
 	assert.Equal(t, "all good", fields["reason_message"])
 }
 
-func TestReadiness_Log_SetNoopLogs_Nothing(t *testing.T) {
-	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
+func TestTracker_Log_SetNoopLogs_Nothing(t *testing.T) {
+	r, logs := newObservedTracker(t, []string{"gw-a"}, "route")
 
 	// First Set: UNKNOWN -> READY (transition, will log).
 	r.Set("gw-a", readinesspb.State_STATE_READY)
@@ -414,8 +413,8 @@ func TestReadiness_Log_SetNoopLogs_Nothing(t *testing.T) {
 	assert.Equal(t, 1, logs.Len(), "no-op Set must not emit a log entry")
 }
 
-func TestReadiness_Log_SetReasonOnlyChange_LogsNothing(t *testing.T) {
-	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
+func TestTracker_Log_SetReasonOnlyChange_LogsNothing(t *testing.T) {
+	r, logs := newObservedTracker(t, []string{"gw-a"}, "route")
 
 	r.SetWithReason("gw-a", readinesspb.State_STATE_DEGRADED,
 		&readinesspb.Reason{Code: "RECONNECTING"})
@@ -427,8 +426,8 @@ func TestReadiness_Log_SetReasonOnlyChange_LogsNothing(t *testing.T) {
 	assert.Equal(t, 1, logs.Len(), "reason-only change must not emit a log entry")
 }
 
-func TestReadiness_Log_ObserveReadyToDegraded(t *testing.T) {
-	r, logs := newObservedReadiness(t, []string{"gw"}, "forward")
+func TestTracker_Log_ObserveReadyToDegraded(t *testing.T) {
+	r, logs := newObservedTracker(t, []string{"gw"}, "forward")
 
 	// UNKNOWN -> READY: one log entry.
 	r.Observe("gw", nil)
@@ -446,8 +445,8 @@ func TestReadiness_Log_ObserveReadyToDegraded(t *testing.T) {
 	assert.Equal(t, readinesspb.State_STATE_DEGRADED.String(), fields["to"])
 }
 
-func TestReadiness_Log_ObserveRepeatedFailure_LogsNothing(t *testing.T) {
-	r, logs := newObservedReadiness(t, []string{"gw"}, "forward")
+func TestTracker_Log_ObserveRepeatedFailure_LogsNothing(t *testing.T) {
+	r, logs := newObservedTracker(t, []string{"gw"}, "forward")
 
 	boom := errors.New("push failed")
 
@@ -460,8 +459,8 @@ func TestReadiness_Log_ObserveRepeatedFailure_LogsNothing(t *testing.T) {
 	assert.Equal(t, 1, logs.Len(), "repeated failing Observe must not emit additional log entries")
 }
 
-func TestReadiness_Log_DrainLogsPerChangedScope(t *testing.T) {
-	r, logs := newObservedReadiness(t, []string{"gw-a", "gw-b"}, "route")
+func TestTracker_Log_DrainLogsPerChangedScope(t *testing.T) {
+	r, logs := newObservedTracker(t, []string{"gw-a", "gw-b"}, "route")
 
 	// Bring gw-a to READY (logs one transition).
 	r.Observe("gw-a", nil)
@@ -475,8 +474,8 @@ func TestReadiness_Log_DrainLogsPerChangedScope(t *testing.T) {
 		"Drain must log one entry per scope that changes state")
 }
 
-func TestReadiness_Log_DrainAlreadyNotReady_NoLog(t *testing.T) {
-	r, logs := newObservedReadiness(t, []string{"gw-a"}, "route")
+func TestTracker_Log_DrainAlreadyNotReady_NoLog(t *testing.T) {
+	r, logs := newObservedTracker(t, []string{"gw-a"}, "route")
 
 	// Force gw-a to NOT_READY first (UNKNOWN -> NOT_READY: one log entry).
 	r.Observe("gw-a", errors.New("boom"))
@@ -486,4 +485,56 @@ func TestReadiness_Log_DrainAlreadyNotReady_NoLog(t *testing.T) {
 	r.Drain()
 	assert.Equal(t, 1, logs.Len(),
 		"Drain on a scope already in NOT_READY must not emit a log entry")
+}
+
+// TestTracker_DrainLatch_SetAfterDrainIsNoop verifies that with WithDrainLatch,
+// a Set call after Drain is silently ignored (the latch prevents mutation).
+//
+// Without WithDrainLatch, Set after Drain takes effect normally (documents the
+// opt-in nature of the latch).
+func TestTracker_DrainLatch_SetAfterDrainIsNoop(t *testing.T) {
+	tests := []struct {
+		name       string
+		latch      bool
+		wantState  readinesspb.State
+		wantReason string
+	}{
+		{
+			name:       "with latch: Set after Drain is no-op",
+			latch:      true,
+			wantState:  readinesspb.State_STATE_NOT_READY,
+			wantReason: "SHUTTING_DOWN",
+		},
+		{
+			name:       "without latch: Set after Drain takes effect",
+			latch:      false,
+			wantState:  readinesspb.State_STATE_READY,
+			wantReason: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []readiness.Option{}
+			if tt.latch {
+				opts = append(opts, readiness.WithDrainLatch())
+			}
+			r := readiness.NewTracker([]string{"gw"}, opts...)
+
+			r.Drain()
+			r.Set("gw", readinesspb.State_STATE_READY)
+
+			resp := r.Ready(&readinesspb.ReadyRequest{})
+			require.Len(t, resp.Scopes, 1)
+			s := resp.Scopes[0]
+
+			assert.Equal(t, tt.wantState, s.State)
+			if tt.wantReason != "" {
+				require.Len(t, s.Reasons, 1)
+				assert.Equal(t, tt.wantReason, s.Reasons[0].Code)
+			} else {
+				assert.Empty(t, s.Reasons)
+			}
+		})
+	}
 }

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/yanet-platform/yanet2/common/go/readiness"
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/httpproxy"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth"
 	"github.com/yanet-platform/yanet2/controlplane/internal/xgrpc"
@@ -110,13 +112,13 @@ func WithAtomicLogLevel(level *zap.AtomicLevel) GatewayOption {
 //
 // Think of it as gRPC middleware if it were a single process.
 type Gateway struct {
-	cfg            *Config
-	server         *grpc.Server
-	services       []Service
-	serviceRunners []*ServiceRunner
-	registry       *BackendRegistry
-	readiness      *readinessTracker
-	log            *zap.Logger
+	cfg              *Config
+	server           *grpc.Server
+	services         []Service
+	serviceRunners   []*ServiceRunner
+	registry         *BackendRegistry
+	readinessTracker *readiness.Tracker
+	log              *zap.Logger
 }
 
 // NewGateway creates a new Gateway API.
@@ -185,8 +187,12 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	ynpb.RegisterAuthServiceServer(server, authService)
 	log.Info("registered service", zap.String("service", fmt.Sprintf("%T", authService)))
 
-	readinessTracker := newReadinessTracker(log)
-	readinessSvc := NewReadinessService(readinessTracker)
+	rdTracker := readiness.NewTracker(
+		[]string{gatewayReadinessScope},
+		readiness.WithDrainLatch(),
+		readiness.WithLog(log),
+	)
+	readinessSvc := NewReadinessService(rdTracker)
 	ynpb.RegisterReadinessServiceServer(server, readinessSvc)
 	log.Info("registered service", zap.String("service", fmt.Sprintf("%T", readinessSvc)))
 
@@ -252,13 +258,13 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	}
 
 	return &Gateway{
-		cfg:            cfg,
-		server:         server,
-		services:       services,
-		serviceRunners: serviceRunners,
-		registry:       registry,
-		readiness:      readinessTracker,
-		log:            log,
+		cfg:              cfg,
+		server:           server,
+		services:         services,
+		serviceRunners:   serviceRunners,
+		registry:         registry,
+		readinessTracker: rdTracker,
+		log:              log,
 	}, nil
 }
 
@@ -341,17 +347,17 @@ func (m *Gateway) Run(ctx context.Context) error {
 			m.log.Info("all built-in modules ready",
 				zap.Int("count", len(m.serviceRunners)),
 			)
-			m.readiness.Ready()
+			m.readinessTracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
 			return nil
 		})
 	} else {
 		m.log.Info("all built-in modules ready", zap.Int("count", 0))
-		m.readiness.Ready()
+		m.readinessTracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
 	}
 
 	<-ctx.Done()
 
-	m.readiness.Drain()
+	m.readinessTracker.Drain()
 
 	m.log.Info("stopping gRPC gateway", zap.Stringer("addr", listener.Addr()))
 	defer m.log.Info("stopped gRPC gateway", zap.Stringer("addr", listener.Addr()))

--- a/controlplane/gateway/readiness.go
+++ b/controlplane/gateway/readiness.go
@@ -2,154 +2,25 @@ package gateway
 
 import (
 	"context"
-	"sync"
-	"time"
 
-	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/timestamppb"
-
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
-// readinessTracker holds the mutable readiness state for the gateway scope.
-type readinessTracker struct {
-	mu                 sync.Mutex
-	state              readinesspb.State
-	reason             *readinesspb.Reason
-	observedAt         time.Time
-	lastTransitionTime time.Time
-	drained            bool
-	log                *zap.Logger
-}
-
-// newReadinessTracker creates a readinessTracker seeded at STATE_UNKNOWN.
-func newReadinessTracker(log *zap.Logger) *readinessTracker {
-	return &readinessTracker{
-		state: readinesspb.State_STATE_UNKNOWN,
-		log:   log,
-	}
-}
-
-// Ready transitions the tracker to STATE_READY.
-//
-// It is a no-op once Drain has been called; a late Ready must not flip a
-// drained tracker back to READY.
-func (m *readinessTracker) Ready() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if m.drained {
-		return
-	}
-
-	now := time.Now()
-	prev := m.state
-	next := readinesspb.State_STATE_READY
-
-	if m.observedAt.IsZero() || m.state != next {
-		m.lastTransitionTime = now
-	}
-	m.state = next
-	m.reason = nil
-	m.observedAt = now
-
-	m.logTransition(prev, next, nil)
-}
-
-// Drain transitions the tracker to STATE_NOT_READY with a SHUTTING_DOWN reason
-// and latches it so that subsequent Ready calls are no-ops.
-func (m *readinessTracker) Drain() {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	now := time.Now()
-	prev := m.state
-	next := readinesspb.State_STATE_NOT_READY
-	reason := &readinesspb.Reason{Code: "SHUTTING_DOWN"}
-
-	if m.observedAt.IsZero() || m.state != next {
-		m.lastTransitionTime = now
-	}
-	m.state = next
-	m.reason = reason
-	m.observedAt = now
-	m.drained = true
-
-	m.logTransition(prev, next, reason)
-}
-
-// Snapshot builds a ReadyResponse for the given request, honoring the scope
-// filter.
-//
-// An empty scopes list returns the gateway scope. A non-empty filter that
-// does not include "gateway" returns an empty scopes list.
-func (m *readinessTracker) Snapshot(req *readinesspb.ReadyRequest) *readinesspb.ReadyResponse {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	filter := req.GetScopes()
-	if len(filter) > 0 {
-		found := false
-		for _, name := range filter {
-			if name == "gateway" {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return &readinesspb.ReadyResponse{}
-		}
-	}
-
-	var reasons []*readinesspb.Reason
-	if m.reason != nil {
-		reasons = []*readinesspb.Reason{m.reason}
-	}
-
-	scope := &readinesspb.Scope{
-		Name:    "gateway",
-		State:   m.state,
-		Reasons: reasons,
-	}
-	if !m.observedAt.IsZero() {
-		scope.ObservedAt = timestamppb.New(m.observedAt)
-		scope.LastTransitionTime = timestamppb.New(m.lastTransitionTime)
-	}
-
-	return &readinesspb.ReadyResponse{Scopes: []*readinesspb.Scope{scope}}
-}
-
-// logTransition logs a state change at Info level when prev and next differ.
-// Must be called with m.mu held.
-func (m *readinessTracker) logTransition(prev, next readinesspb.State, reason *readinesspb.Reason) {
-	if prev == next {
-		return
-	}
-
-	fields := []zap.Field{
-		zap.String("from", prev.String()),
-		zap.String("to", next.String()),
-	}
-	if reason != nil {
-		fields = append(fields, zap.String("reason", reason.GetCode()))
-		if reason.GetMessage() != "" {
-			fields = append(fields, zap.String("reason_message", reason.GetMessage()))
-		}
-	}
-	m.log.Info("readiness state transitioned", fields...)
-}
+// gatewayReadinessScope is the single scope name used by the gateway tracker.
+const gatewayReadinessScope = "gateway"
 
 // ReadinessService implements ynpb.ReadinessServiceServer by delegating to a
-// readinessTracker.
+// shared readiness.Tracker constructed with WithDrainLatch.
 type ReadinessService struct {
 	ynpb.UnimplementedReadinessServiceServer
 
-	tracker *readinessTracker
+	tracker *readiness.Tracker
 }
 
 // NewReadinessService constructs a ReadinessService backed by tracker.
-func NewReadinessService(tracker *readinessTracker) *ReadinessService {
+func NewReadinessService(tracker *readiness.Tracker) *ReadinessService {
 	return &ReadinessService{tracker: tracker}
 }
 
@@ -158,5 +29,5 @@ func (m *ReadinessService) Ready(
 	ctx context.Context,
 	req *readinesspb.ReadyRequest,
 ) (*readinesspb.ReadyResponse, error) {
-	return m.tracker.Snapshot(req), nil
+	return m.tracker.Ready(req), nil
 }

--- a/controlplane/gateway/readiness_test.go
+++ b/controlplane/gateway/readiness_test.go
@@ -6,17 +6,22 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
 
-func newTestTracker() *readinessTracker {
-	return newReadinessTracker(zap.NewNop())
+func newTestTracker() *readiness.Tracker {
+	return readiness.NewTracker(
+		[]string{gatewayReadinessScope},
+		readiness.WithDrainLatch(),
+		readiness.WithLog(zap.NewNop()),
+	)
 }
 
 func TestReadinessTracker_InitialState(t *testing.T) {
 	tracker := newTestTracker()
 
-	resp := tracker.Snapshot(&readinesspb.ReadyRequest{})
+	resp := tracker.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp.GetScopes(), 1)
 
 	scope := resp.GetScopes()[0]
@@ -28,9 +33,9 @@ func TestReadinessTracker_InitialState(t *testing.T) {
 
 func TestReadinessTracker_AfterReady(t *testing.T) {
 	tracker := newTestTracker()
-	tracker.Ready()
+	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
 
-	resp := tracker.Snapshot(&readinesspb.ReadyRequest{})
+	resp := tracker.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp.GetScopes(), 1)
 
 	scope := resp.GetScopes()[0]
@@ -42,10 +47,10 @@ func TestReadinessTracker_AfterReady(t *testing.T) {
 
 func TestReadinessTracker_AfterDrain(t *testing.T) {
 	tracker := newTestTracker()
-	tracker.Ready()
+	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
 	tracker.Drain()
 
-	resp := tracker.Snapshot(&readinesspb.ReadyRequest{})
+	resp := tracker.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp.GetScopes(), 1)
 
 	scope := resp.GetScopes()[0]
@@ -85,9 +90,9 @@ func TestReadinessTracker_SnapshotFilter(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			tracker := newTestTracker()
-			tracker.Ready()
+			tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
 
-			resp := tracker.Snapshot(&readinesspb.ReadyRequest{Scopes: tc.filter})
+			resp := tracker.Ready(&readinesspb.ReadyRequest{Scopes: tc.filter})
 			require.Len(t, resp.GetScopes(), tc.wantScopes)
 
 			if tc.wantGateway {
@@ -99,11 +104,11 @@ func TestReadinessTracker_SnapshotFilter(t *testing.T) {
 
 func TestReadinessTracker_ReadyAfterDrainIsNoop(t *testing.T) {
 	tracker := newTestTracker()
-	tracker.Ready()
+	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
 	tracker.Drain()
-	tracker.Ready()
+	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
 
-	resp := tracker.Snapshot(&readinesspb.ReadyRequest{})
+	resp := tracker.Ready(&readinesspb.ReadyRequest{})
 	require.Len(t, resp.GetScopes(), 1)
 
 	scope := resp.GetScopes()[0]
@@ -114,7 +119,7 @@ func TestReadinessTracker_ReadyAfterDrainIsNoop(t *testing.T) {
 
 func TestReadinessService_Ready(t *testing.T) {
 	tracker := newTestTracker()
-	tracker.Ready()
+	tracker.Set(gatewayReadinessScope, readinesspb.State_STATE_READY)
 
 	svc := NewReadinessService(tracker)
 	resp, err := svc.Ready(t.Context(), &readinesspb.ReadyRequest{})

--- a/operators/decap/internal/operator/operator.go
+++ b/operators/decap/internal/operator/operator.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	operatorpb "github.com/yanet-platform/yanet2/operators/decap/operatorpb/v1"
 )
 
@@ -45,8 +46,8 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	for idx, gw := range cfg.Gateways {
 		scopeNames[idx] = fmt.Sprintf("config:%s", gw.Name)
 	}
-	tracker := operator.NewReadiness(scopeNames,
-		operator.WithReadinessLog(log.With(zap.String("operator", "decap"))),
+	tracker := readiness.NewTracker(scopeNames,
+		readiness.WithLog(log.With(zap.String("operator", "decap"))),
 	)
 
 	actuators := make([]operator.Actuator[State], 0, len(cfg.Gateways))

--- a/operators/decap/internal/operator/readiness_service.go
+++ b/operators/decap/internal/operator/readiness_service.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"context"
 
-	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/decap/operatorpb/v1"
 )
@@ -14,11 +14,11 @@ import (
 type ReadinessService struct {
 	operatorpb.UnimplementedReadinessServiceServer
 
-	tracker *operator.Readiness
+	tracker *readiness.Tracker
 }
 
 // NewReadinessService constructs a ReadinessService backed by tracker.
-func NewReadinessService(tracker *operator.Readiness) *ReadinessService {
+func NewReadinessService(tracker *readiness.Tracker) *ReadinessService {
 	return &ReadinessService{tracker: tracker}
 }
 

--- a/operators/forward/internal/operator/operator.go
+++ b/operators/forward/internal/operator/operator.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	operatorpb "github.com/yanet-platform/yanet2/operators/forward/operatorpb/v1"
 )
 
@@ -45,8 +46,8 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	for idx, gw := range cfg.Gateways {
 		scopeNames[idx] = fmt.Sprintf("config:%s", gw.Name)
 	}
-	tracker := operator.NewReadiness(scopeNames,
-		operator.WithReadinessLog(log.With(zap.String("operator", "forward"))),
+	tracker := readiness.NewTracker(scopeNames,
+		readiness.WithLog(log.With(zap.String("operator", "forward"))),
 	)
 
 	actuators := make([]operator.Actuator[State], 0, len(cfg.Gateways))

--- a/operators/forward/internal/operator/readiness_service.go
+++ b/operators/forward/internal/operator/readiness_service.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"context"
 
-	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/forward/operatorpb/v1"
 )
@@ -14,11 +14,11 @@ import (
 type ReadinessService struct {
 	operatorpb.UnimplementedReadinessServiceServer
 
-	tracker *operator.Readiness
+	tracker *readiness.Tracker
 }
 
 // NewReadinessService constructs a ReadinessService backed by tracker.
-func NewReadinessService(tracker *operator.Readiness) *ReadinessService {
+func NewReadinessService(tracker *readiness.Tracker) *ReadinessService {
 	return &ReadinessService{tracker: tracker}
 }
 

--- a/operators/pipeline/internal/operator/operator.go
+++ b/operators/pipeline/internal/operator/operator.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	operatorpb "github.com/yanet-platform/yanet2/operators/pipeline/operatorpb/v1"
 )
 
@@ -45,8 +46,8 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	for idx, gw := range cfg.Gateways {
 		scopeNames[idx] = fmt.Sprintf("pipeline:%s", gw.Name)
 	}
-	tracker := operator.NewReadiness(scopeNames,
-		operator.WithReadinessLog(log.With(zap.String("operator", "pipeline"))),
+	tracker := readiness.NewTracker(scopeNames,
+		readiness.WithLog(log.With(zap.String("operator", "pipeline"))),
 	)
 
 	actuators := make([]Actuator, 0, len(cfg.Gateways))

--- a/operators/pipeline/internal/operator/readiness_service.go
+++ b/operators/pipeline/internal/operator/readiness_service.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"context"
 
-	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/pipeline/operatorpb/v1"
 )
@@ -14,11 +14,11 @@ import (
 type ReadinessService struct {
 	operatorpb.UnimplementedReadinessServiceServer
 
-	tracker *operator.Readiness
+	tracker *readiness.Tracker
 }
 
 // NewReadinessService constructs a ReadinessService backed by tracker.
-func NewReadinessService(tracker *operator.Readiness) *ReadinessService {
+func NewReadinessService(tracker *readiness.Tracker) *ReadinessService {
 	return &ReadinessService{tracker: tracker}
 }
 

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
@@ -70,8 +71,8 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	if cfg.Readiness.ExpectBird {
 		scopeNames = append(scopeNames, "bird-session")
 	}
-	tracker := operator.NewReadiness(scopeNames,
-		operator.WithReadinessLog(log.With(zap.String("operator", "route"))),
+	tracker := readiness.NewTracker(scopeNames,
+		readiness.WithLog(log.With(zap.String("operator", "route"))),
 	)
 
 	neighTable := neigh.NewNeighTable()

--- a/operators/route/internal/operator/readiness_service.go
+++ b/operators/route/internal/operator/readiness_service.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"context"
 
-	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
 )
@@ -15,11 +15,11 @@ import (
 type ReadinessService struct {
 	operatorpb.UnimplementedReadinessServiceServer
 
-	tracker *operator.Readiness
+	tracker *readiness.Tracker
 }
 
 // NewReadinessService constructs a ReadinessService backed by tracker.
-func NewReadinessService(tracker *operator.Readiness) *ReadinessService {
+func NewReadinessService(tracker *readiness.Tracker) *ReadinessService {
 	return &ReadinessService{tracker: tracker}
 }
 

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -12,13 +12,14 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
 )
 
 // requireScope fetches the named scope from the tracker. Fails the test when
 // the scope is absent.
-func requireScope(t *testing.T, tracker *operator.Readiness, name string) *readinesspb.Scope {
+func requireScope(t *testing.T, tracker *readiness.Tracker, name string) *readinesspb.Scope {
 	t.Helper()
 	resp := tracker.Ready(&readinesspb.ReadyRequest{})
 	for _, s := range resp.Scopes {
@@ -36,7 +37,7 @@ func TestReadiness_NeighboursDisabled_ImmediatelyReady(t *testing.T) {
 	cfg.Readiness.ExpectBird = false
 	cfg.Gateways = []operator.GatewayConfig{{Name: "gw0"}}
 
-	tracker := operator.NewReadiness([]string{"fib:gw0:route0", "neighbours", "rib"})
+	tracker := readiness.NewTracker([]string{"fib:gw0:route0", "neighbours", "rib"})
 
 	// When netlink monitor is disabled, mark neighbours READY immediately.
 	if cfg.NetlinkMonitor.Disabled {
@@ -48,7 +49,7 @@ func TestReadiness_NeighboursDisabled_ImmediatelyReady(t *testing.T) {
 }
 
 func TestReadiness_ExpectBirdFalse_RibImmediatelyReady(t *testing.T) {
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 
 	// When BIRD is not expected, mark rib READY immediately.
 	tracker.Set("rib", readinesspb.State_STATE_READY)
@@ -58,7 +59,7 @@ func TestReadiness_ExpectBirdFalse_RibImmediatelyReady(t *testing.T) {
 }
 
 func TestReadiness_FIBObserve(t *testing.T) {
-	tracker := operator.NewReadiness([]string{"fib:gw0:route0"})
+	tracker := readiness.NewTracker([]string{"fib:gw0:route0"})
 
 	// Initial state is UNKNOWN.
 	s := requireScope(t, tracker, "fib:gw0:route0")
@@ -99,7 +100,7 @@ func TestRIBReadiness_SessionStart_SYNCING(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -119,7 +120,7 @@ func TestRIBReadiness_HighRate_SYNCING(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -167,7 +168,7 @@ func TestRIBReadiness_LowRate_READY(t *testing.T) {
 	store := newRIBStore(zap.NewNop())
 	// Seed a route so that settled && routes>0 produces READY.
 	seedRoute(t, store, "route0")
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -198,7 +199,7 @@ func TestRIBReadiness_MidWindowSpike_ResetsBelowSince(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -241,7 +242,7 @@ func TestRIBReadiness_SessionEnd_Degraded(t *testing.T) {
 	// Seed a route so that the settled state produces READY and the session
 	// end with live routes produces DEGRADED(SESSION_ENDED).
 	seedRoute(t, store, "route0")
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -315,7 +316,7 @@ func TestRIBReadiness_Syncing(t *testing.T) {
 			}
 
 			store := newRIBStore(zap.NewNop())
-			tracker := operator.NewReadiness([]string{"rib"})
+			tracker := readiness.NewTracker([]string{"rib"})
 			helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 			if tc.seedRoutes {
@@ -381,7 +382,7 @@ func TestRIBReadiness_SupersededSession(t *testing.T) {
 	store := newRIBStore(zap.NewNop())
 	// Seed a route so that the settled state produces READY.
 	seedRoute(t, store, "route0")
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	// Session A starts (id=1) — routes are present so tracker enters
@@ -439,7 +440,7 @@ func TestBirdSession_InitialDegraded(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
 	newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	s := requireScope(t, tracker, "bird-session")
@@ -459,7 +460,7 @@ func TestBirdSession_SessionStartReady(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -480,7 +481,7 @@ func TestBirdSession_SessionEndReconnecting(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -503,7 +504,7 @@ func TestBirdSession_GraceExpiry(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -538,7 +539,7 @@ func TestBirdSession_NeverNotReady(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -572,7 +573,7 @@ func TestBirdSession_ReconnectFromDown(t *testing.T) {
 	}
 
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -612,7 +613,7 @@ func TestRIBReadiness_SettledNoRoutes(t *testing.T) {
 
 	store := newRIBStore(zap.NewNop())
 	// No routes seeded — empty RIB.
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -647,7 +648,7 @@ func TestRIBReadiness_SessionEndedWithRoutes(t *testing.T) {
 
 	store := newRIBStore(zap.NewNop())
 	seedRoute(t, store, "route0")
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -688,7 +689,7 @@ func TestRIBReadiness_TTLPurgeAfterSessionEnd(t *testing.T) {
 
 	store := newRIBStore(zap.NewNop())
 	seedRoute(t, store, "route0")
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -736,7 +737,7 @@ func TestRIBReadiness_TTLPurgeAfterSessionEnd(t *testing.T) {
 // NOT_READY(SYNCING) -> READY on first sync, then DEGRADED(RESYNC) on error,
 // then READY on recovery.
 func TestNeighbours_SyncThenError(t *testing.T) {
-	tracker := operator.NewReadiness([]string{"neighbours"})
+	tracker := readiness.NewTracker([]string{"neighbours"})
 
 	// Seed initial NOT_READY(SYNCING) as operator.go does.
 	tracker.SetWithReason("neighbours",
@@ -788,7 +789,7 @@ func TestBirdRestartHoldInvariant(t *testing.T) {
 
 	store := newRIBStore(zap.NewNop())
 	seedRoute(t, store, "route0")
-	tracker := operator.NewReadiness([]string{"bird-session", "rib"})
+	tracker := readiness.NewTracker([]string{"bird-session", "rib"})
 	helper := newBirdRIBReadiness(cfg, store, "route0", tracker, zap.NewNop())
 
 	helper.OnSessionStart("route0", 1)
@@ -842,7 +843,7 @@ func TestStaticRIBReadiness_ReadyWhenRoutesPresent(t *testing.T) {
 	seedRoute(t, store, "route0")
 
 	// Register both rib and bird-session so we can assert bird-session is never set.
-	tracker := operator.NewReadiness([]string{"rib", "bird-session"})
+	tracker := readiness.NewTracker([]string{"rib", "bird-session"})
 
 	helper := newStaticRIBReadiness(store, "route0", tracker, 20*time.Millisecond, zap.NewNop())
 
@@ -886,7 +887,7 @@ func TestStaticRIBReadiness_ReadyWhenRoutesPresent(t *testing.T) {
 // rib=NOT_READY(NO_ROUTES) on construction when the store is empty.
 func TestStaticRIBReadiness_ColdStart(t *testing.T) {
 	store := newRIBStore(zap.NewNop())
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 
 	newStaticRIBReadiness(store, "route0", tracker, 20*time.Millisecond, zap.NewNop())
 
@@ -905,7 +906,7 @@ func TestStaticRIBReadiness_PostPreRunReady(t *testing.T) {
 
 	// Empty store at construction — seeds NOT_READY(NO_ROUTES), mirroring the
 	// real operator where PreRun has not yet populated static.routes.
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 	helper := newStaticRIBReadiness(store, "route0", tracker, 500*time.Millisecond, zap.NewNop())
 
 	s := requireScope(t, tracker, "rib")
@@ -941,7 +942,7 @@ func TestStaticRIBReadiness_PostPreRunReady(t *testing.T) {
 func TestStaticRIBReadiness_NoopsIgnored(t *testing.T) {
 	store := newRIBStore(zap.NewNop())
 	seedRoute(t, store, "route0")
-	tracker := operator.NewReadiness([]string{"rib"})
+	tracker := readiness.NewTracker([]string{"rib"})
 
 	helper := newStaticRIBReadiness(store, "route0", tracker, 20*time.Millisecond, zap.NewNop())
 

--- a/operators/route/internal/operator/rib_readiness.go
+++ b/operators/route/internal/operator/rib_readiness.go
@@ -8,7 +8,7 @@ import (
 
 	"go.uber.org/zap"
 
-	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
 
@@ -18,7 +18,7 @@ func newRIBReadiness(
 	cfg ReadinessConfig,
 	store *RIBStore,
 	name string,
-	tracker *operator.Readiness,
+	tracker *readiness.Tracker,
 	log *zap.Logger,
 ) ribReadiness {
 	if cfg.ExpectBird {
@@ -40,7 +40,7 @@ func newRIBReadiness(
 type birdRIBReadiness struct {
 	store      *RIBStore
 	configName string
-	tracker    *operator.Readiness
+	tracker    *readiness.Tracker
 
 	// counter is the total number of route updates applied in the current
 	// session. Written by OnUpdate on the FeedRIB hot path; read by Run.
@@ -74,7 +74,7 @@ func newBirdRIBReadiness(
 	cfg ReadinessConfig,
 	store *RIBStore,
 	configName string,
-	tracker *operator.Readiness,
+	tracker *readiness.Tracker,
 	log *zap.Logger,
 ) *birdRIBReadiness {
 	m := &birdRIBReadiness{
@@ -301,7 +301,7 @@ func (m *birdRIBReadiness) tick(now time.Time, rate float64) {
 type staticRIBReadiness struct {
 	store          *RIBStore
 	configName     string
-	tracker        *operator.Readiness
+	tracker        *readiness.Tracker
 	sampleInterval time.Duration
 	log            *zap.Logger
 }
@@ -314,7 +314,7 @@ type staticRIBReadiness struct {
 func newStaticRIBReadiness(
 	store *RIBStore,
 	configName string,
-	tracker *operator.Readiness,
+	tracker *readiness.Tracker,
 	sampleInterval time.Duration,
 	log *zap.Logger,
 ) *staticRIBReadiness {


### PR DESCRIPTION
- Consolidate the readiness state tracker into a new shared package, removing the near-duplicate implementations previously maintained separately by the gateway and the operator framework.
- Preserve the gateway's drain latch — a late ready signal must not override a drained tracker — through an opt-in option on the shared tracker.
- The only externally observable change is that the gateway readiness transition log line now carries a scope field.