### PR TITLE
feat(readiness): add reactive Watch streaming RPC

### DIFF
--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -122,3 +122,67 @@ where
         .map(|response| response.into_inner())
         .map_err(|status| Error::from_status(status, action, endpoint, service))
 }
+
+/// Invoke a server-streaming RPC on an arbitrary gRPC service by its
+/// fully-qualified name, without a generated client.
+///
+/// `action` is the user-facing verb used in error messages (e.g. `"ready"`),
+/// `service` is the service FQN, `method` is the wire method name (e.g.
+/// `"Watch"`). Each received message is delivered to `on_message`; the
+/// function returns `Ok(())` when the server closes the stream cleanly.
+/// `tonic::Streaming` never leaks to the caller — all stream state is
+/// contained here.
+pub async fn invoke_server_stream<Req, Resp, F>(
+    connection: &ConnectionArgs,
+    action: &str,
+    service: &str,
+    method: &str,
+    request: Req,
+    mut on_message: F,
+) -> Result<(), Error>
+where
+    Req: Message + Send + Sync + 'static,
+    Resp: Message + Default + Send + Sync + 'static,
+    F: FnMut(Resp),
+{
+    let endpoint = connection.endpoint.clone();
+
+    let channel = connect(connection)
+        .await
+        .map_err(|err| Error::from_connection(err, action, endpoint.clone()))?;
+
+    let mut grpc = Grpc::new(channel)
+        .send_compressed(CompressionEncoding::Gzip)
+        .accept_compressed(CompressionEncoding::Gzip);
+
+    let path = PathAndQuery::try_from(format!("/{service}/{method}")).map_err(|err| {
+        Error::from_status(
+            Status::invalid_argument(err.to_string()),
+            action,
+            endpoint.clone(),
+            service,
+        )
+    })?;
+
+    grpc.ready()
+        .await
+        .map_err(|err| Error::from_status(Status::unavailable(err.to_string()), action, endpoint.clone(), service))?;
+
+    let codec: ProstCodec<Req, Resp> = ProstCodec::default();
+
+    let mut stream = grpc
+        .server_streaming(Request::new(request), path, codec)
+        .await
+        .map_err(|status| Error::from_status(status, action, endpoint.clone(), service))?
+        .into_inner();
+
+    while let Some(message) = stream
+        .message()
+        .await
+        .map_err(|status| Error::from_status(status, action, endpoint.clone(), service))?
+    {
+        on_message(message);
+    }
+
+    Ok(())
+}

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -46,6 +46,10 @@ pub struct Cmd {
     /// Be verbose: shows debug log lines and raw gRPC error details.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
+    /// Stream readiness changes until interrupted instead of exiting after one
+    /// snapshot.
+    #[arg(long, default_value_t = false)]
+    pub watch: bool,
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -66,8 +70,17 @@ pub async fn main() {
     }
 }
 
-/// Run the readiness probe.
+/// Run the readiness probe, dispatching to one-shot or streaming mode.
 async fn run(cmd: Cmd) -> Result<bool, Error> {
+    if cmd.watch {
+        run_watch(cmd).await.map(|()| true)
+    } else {
+        run_once(cmd).await
+    }
+}
+
+/// Run a single unary `Ready` call and return whether all scopes are ready.
+async fn run_once(cmd: Cmd) -> Result<bool, Error> {
     let response: ReadyResponse = ync::client::invoke_unary(
         &cmd.connection,
         "ready",
@@ -132,6 +145,32 @@ async fn run(cmd: Cmd) -> Result<bool, Error> {
     );
 
     Ok(all_ready)
+}
+
+/// Stream readiness updates via `Watch` until the server closes the connection.
+///
+/// The first message is a full snapshot of all selected scopes; each
+/// subsequent message carries only the scopes that changed. Returns `Ok(())`
+/// on clean stream close.
+async fn run_watch(cmd: Cmd) -> Result<(), Error> {
+    ync::client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
+        &cmd.connection,
+        "ready",
+        &cmd.name,
+        "Watch",
+        ReadyRequest { scopes: cmd.scopes.clone() },
+        |resp| {
+            let mut rows: Vec<ReadinessRow> = resp.scopes.iter().map(ReadinessRow::from).collect();
+            rows.sort_by(|a, b| a.scope.cmp(&b.scope));
+
+            output::data(&resp.scopes, resp.scopes.is_empty(), format_args!("no scopes"), || {
+                if !rows.is_empty() {
+                    print_readiness_table(rows);
+                }
+            });
+        },
+    )
+    .await
 }
 
 /// Wraps a readiness state for colored display in the table.

--- a/common/go/readiness/readiness.go
+++ b/common/go/readiness/readiness.go
@@ -234,6 +234,46 @@ func (m *Tracker) unsubscribe(sub *subscriber) {
 	delete(m.subscribers, sub)
 }
 
+// applyLocked writes next and reason onto s, advancing timestamps, logging
+// the transition, and notifying Watch subscribers.
+//
+// observed_at always advances; last_transition_time changes only on a state
+// change; subscribers are notified only when state or reason changed. Must
+// be called with m.mu held.
+func (m *Tracker) applyLocked(s *scopeState, next readinesspb.State, reason *readinesspb.Reason) {
+	now := time.Now()
+	prevState := s.state
+	prevReason := s.reason
+	if s.observedAt.IsZero() || s.state != next {
+		s.lastTransitionTime = now
+	}
+	s.state = next
+	s.reason = reason
+	s.observedAt = now
+	m.logTransition(s.name, prevState, next, reason)
+	if prevState != next || !reasonEqual(prevReason, reason) {
+		m.notifySubscribersLocked([]*readinesspb.Scope{scopeToProto(s)})
+	}
+}
+
+// observeOutcome derives the next state and reason for an apply attempt
+// whose result is err, given the scope's current state.
+//
+// A nil err yields READY. A failure holds a previously-applied scope at
+// DEGRADED and drops a never-applied scope to NOT_READY.
+func observeOutcome(current readinesspb.State, err error) (readinesspb.State, *readinesspb.Reason) {
+	if err == nil {
+		return readinesspb.State_STATE_READY, nil
+	}
+	reason := &readinesspb.Reason{Code: "APPLY_FAILED", Message: err.Error()}
+	switch current {
+	case readinesspb.State_STATE_READY, readinesspb.State_STATE_DEGRADED:
+		return readinesspb.State_STATE_DEGRADED, reason
+	default:
+		return readinesspb.State_STATE_NOT_READY, reason
+	}
+}
+
 // Observe records the outcome of one apply attempt for the named gateway.
 //
 // A failed apply holds the scope at DEGRADED when it was previously applied,
@@ -252,41 +292,8 @@ func (m *Tracker) Observe(gatewayID string, err error) {
 		return
 	}
 
-	now := time.Now()
-
-	var (
-		next   readinesspb.State
-		reason *readinesspb.Reason
-	)
-
-	if err == nil {
-		next = readinesspb.State_STATE_READY
-	} else {
-		reason = &readinesspb.Reason{Code: "APPLY_FAILED", Message: err.Error()}
-		switch s.state {
-		case readinesspb.State_STATE_READY, readinesspb.State_STATE_DEGRADED:
-			// Last successfully applied state is still live — hold at DEGRADED.
-			next = readinesspb.State_STATE_DEGRADED
-		default:
-			// Never successfully applied — no valid state to fall back to.
-			next = readinesspb.State_STATE_NOT_READY
-		}
-	}
-
-	prevState := s.state
-	prevReason := s.reason
-	if s.observedAt.IsZero() || s.state != next {
-		s.lastTransitionTime = now
-	}
-	s.state = next
-	s.reason = reason
-	s.observedAt = now
-
-	m.logTransition(s.name, prevState, next, reason)
-
-	if prevState != next || !reasonEqual(prevReason, reason) {
-		m.notifySubscribersLocked([]*readinesspb.Scope{scopeToProto(s)})
-	}
+	next, reason := observeOutcome(s.state, err)
+	m.applyLocked(s, next, reason)
 }
 
 // Set transitions the named scope to the given state with no reason.
@@ -315,28 +322,13 @@ func (m *Tracker) set(scope string, state readinesspb.State, reason *readinesspb
 		return
 	}
 
-	now := time.Now()
-
 	s, ok := m.scopes[scope]
 	if !ok {
 		s = &scopeState{name: scope}
 		m.scopes[scope] = s
 	}
 
-	prevState := s.state
-	prevReason := s.reason
-	if s.observedAt.IsZero() || s.state != state {
-		s.lastTransitionTime = now
-	}
-	s.state = state
-	s.reason = reason
-	s.observedAt = now
-
-	m.logTransition(s.name, prevState, state, reason)
-
-	if prevState != state || !reasonEqual(prevReason, reason) {
-		m.notifySubscribersLocked([]*readinesspb.Scope{scopeToProto(s)})
-	}
+	m.applyLocked(s, state, reason)
 }
 
 // Touch advances observed_at for an existing scope without changing its state.

--- a/common/go/readiness/readiness.go
+++ b/common/go/readiness/readiness.go
@@ -1,6 +1,8 @@
 package readiness
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -9,6 +11,12 @@ import (
 
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 )
+
+// readinessWatchBuffer is the per-subscriber channel capacity.
+const readinessWatchBuffer = 16
+
+// errSlowConsumer is returned by Watch when a subscriber's buffer overflows.
+var errSlowConsumer = errors.New("readiness watch subscriber too slow")
 
 // scopeState holds the mutable readiness state for one scope.
 type scopeState struct {
@@ -19,6 +27,14 @@ type scopeState struct {
 	lastTransitionTime time.Time
 }
 
+// subscriber holds state for one active Watch call.
+type subscriber struct {
+	// filter is the set of scope names this subscriber wants; empty means all.
+	filter  map[string]struct{}
+	ch      chan *readinesspb.ReadyResponse
+	dropped chan struct{}
+}
+
 // Tracker tracks readiness state across named scopes.
 //
 // Each scope is an independent readiness dimension (e.g. "neighbours", "rib",
@@ -27,6 +43,7 @@ type scopeState struct {
 type Tracker struct {
 	mu           sync.Mutex
 	scopes       map[string]*scopeState
+	subscribers  map[*subscriber]struct{}
 	latchOnDrain bool
 	drained      bool
 	log          *zap.Logger
@@ -86,6 +103,7 @@ func NewTracker(scopeNames []string, options ...Option) *Tracker {
 
 	return &Tracker{
 		scopes:       scopes,
+		subscribers:  map[*subscriber]struct{}{},
 		latchOnDrain: opts.LatchOnDrain,
 		log:          opts.Log,
 	}
@@ -110,6 +128,110 @@ func (m *Tracker) logTransition(name string, prev, next readinesspb.State, reaso
 		}
 	}
 	m.log.Info("readiness scope transitioned", fields...)
+}
+
+// reasonEqual reports whether two Reason values are equal by Code and Message.
+func reasonEqual(a, b *readinesspb.Reason) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.GetCode() == b.GetCode() && a.GetMessage() == b.GetMessage()
+}
+
+// scopeToProto converts a scopeState to its proto representation.
+func scopeToProto(s *scopeState) *readinesspb.Scope {
+	var reasons []*readinesspb.Reason
+	if s.reason != nil {
+		reasons = []*readinesspb.Reason{s.reason}
+	}
+	scope := &readinesspb.Scope{
+		Name:    s.name,
+		State:   s.state,
+		Reasons: reasons,
+	}
+	if !s.observedAt.IsZero() {
+		scope.ObservedAt = timestamppb.New(s.observedAt)
+		scope.LastTransitionTime = timestamppb.New(s.lastTransitionTime)
+	}
+	return scope
+}
+
+// snapshotLocked builds a ReadyResponse from the current state of all scopes
+// matching filter. An empty filter returns all scopes. Caller must hold m.mu.
+func (m *Tracker) snapshotLocked(filter map[string]struct{}) *readinesspb.ReadyResponse {
+	var out []*readinesspb.Scope
+	for _, s := range m.scopes {
+		if len(filter) > 0 {
+			if _, ok := filter[s.name]; !ok {
+				continue
+			}
+		}
+		out = append(out, scopeToProto(s))
+	}
+	return &readinesspb.ReadyResponse{Scopes: out}
+}
+
+// notifySubscribersLocked fans out changed scopes to all registered subscribers.
+//
+// Each subscriber receives only the subset of changed scopes that match its
+// filter. The send is non-blocking: a subscriber whose channel is full is
+// dropped (its dropped channel is closed and it is removed from the registry).
+// Caller must hold m.mu.
+func (m *Tracker) notifySubscribersLocked(changed []*readinesspb.Scope) {
+	if len(m.subscribers) == 0 || len(changed) == 0 {
+		return
+	}
+
+	for sub := range m.subscribers {
+		var matching []*readinesspb.Scope
+		for _, sc := range changed {
+			if len(sub.filter) == 0 {
+				matching = append(matching, sc)
+				continue
+			}
+			if _, ok := sub.filter[sc.Name]; ok {
+				matching = append(matching, sc)
+			}
+		}
+		if len(matching) == 0 {
+			continue
+		}
+		resp := &readinesspb.ReadyResponse{Scopes: matching}
+		select {
+		case sub.ch <- resp:
+		default:
+			close(sub.dropped)
+			delete(m.subscribers, sub)
+		}
+	}
+}
+
+// subscribe registers a new subscriber and atomically captures the initial
+// snapshot. It returns the subscriber and the snapshot to send as the first
+// streamed message.
+func (m *Tracker) subscribe(filter map[string]struct{}) (*subscriber, *readinesspb.ReadyResponse) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sub := &subscriber{
+		filter:  filter,
+		ch:      make(chan *readinesspb.ReadyResponse, readinessWatchBuffer),
+		dropped: make(chan struct{}),
+	}
+	m.subscribers[sub] = struct{}{}
+	snapshot := m.snapshotLocked(filter)
+	return sub, snapshot
+}
+
+// unsubscribe removes a subscriber from the registry. It is idempotent.
+func (m *Tracker) unsubscribe(sub *subscriber) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.subscribers, sub)
 }
 
 // Observe records the outcome of one apply attempt for the named gateway.
@@ -151,7 +273,8 @@ func (m *Tracker) Observe(gatewayID string, err error) {
 		}
 	}
 
-	prev := s.state
+	prevState := s.state
+	prevReason := s.reason
 	if s.observedAt.IsZero() || s.state != next {
 		s.lastTransitionTime = now
 	}
@@ -159,7 +282,11 @@ func (m *Tracker) Observe(gatewayID string, err error) {
 	s.reason = reason
 	s.observedAt = now
 
-	m.logTransition(s.name, prev, next, reason)
+	m.logTransition(s.name, prevState, next, reason)
+
+	if prevState != next || !reasonEqual(prevReason, reason) {
+		m.notifySubscribersLocked([]*readinesspb.Scope{scopeToProto(s)})
+	}
 }
 
 // Set transitions the named scope to the given state with no reason.
@@ -196,7 +323,8 @@ func (m *Tracker) set(scope string, state readinesspb.State, reason *readinesspb
 		m.scopes[scope] = s
 	}
 
-	prev := s.state
+	prevState := s.state
+	prevReason := s.reason
 	if s.observedAt.IsZero() || s.state != state {
 		s.lastTransitionTime = now
 	}
@@ -204,7 +332,11 @@ func (m *Tracker) set(scope string, state readinesspb.State, reason *readinesspb
 	s.reason = reason
 	s.observedAt = now
 
-	m.logTransition(s.name, prev, state, reason)
+	m.logTransition(s.name, prevState, state, reason)
+
+	if prevState != state || !reasonEqual(prevReason, reason) {
+		m.notifySubscribersLocked([]*readinesspb.Scope{scopeToProto(s)})
+	}
 }
 
 // Touch advances observed_at for an existing scope without changing its state.
@@ -236,8 +368,11 @@ func (m *Tracker) Drain() {
 
 	now := time.Now()
 	reason := &readinesspb.Reason{Code: "SHUTTING_DOWN"}
+
+	var changed []*readinesspb.Scope
 	for _, s := range m.scopes {
-		prev := s.state
+		prevState := s.state
+		prevReason := s.reason
 		if s.state != readinesspb.State_STATE_NOT_READY {
 			s.lastTransitionTime = now
 		}
@@ -245,8 +380,14 @@ func (m *Tracker) Drain() {
 		s.reason = reason
 		s.observedAt = now
 
-		m.logTransition(s.name, prev, readinesspb.State_STATE_NOT_READY, reason)
+		m.logTransition(s.name, prevState, readinesspb.State_STATE_NOT_READY, reason)
+
+		if prevState != readinesspb.State_STATE_NOT_READY || !reasonEqual(prevReason, reason) {
+			changed = append(changed, scopeToProto(s))
+		}
 	}
+
+	m.notifySubscribersLocked(changed)
 
 	if m.latchOnDrain {
 		m.drained = true
@@ -264,29 +405,50 @@ func (m *Tracker) Ready(req *readinesspb.ReadyRequest) *readinesspb.ReadyRespons
 		filter[name] = struct{}{}
 	}
 
-	var out []*readinesspb.Scope
-	for _, s := range m.scopes {
-		if len(filter) > 0 {
-			if _, ok := filter[s.name]; !ok {
-				continue
-			}
-		}
+	return m.snapshotLocked(filter)
+}
 
-		var reasons []*readinesspb.Reason
-		if s.reason != nil {
-			reasons = []*readinesspb.Reason{s.reason}
-		}
-		scope := &readinesspb.Scope{
-			Name:    s.name,
-			State:   s.state,
-			Reasons: reasons,
-		}
-		if !s.observedAt.IsZero() {
-			scope.ObservedAt = timestamppb.New(s.observedAt)
-			scope.LastTransitionTime = timestamppb.New(s.lastTransitionTime)
-		}
-		out = append(out, scope)
+// Watch streams readiness state changes to the caller via send.
+//
+// The first message carries the current state of every scope matching the
+// request filter (same semantics as Ready). Each subsequent message carries
+// only the scopes whose state or reason changed since the previous message.
+// A pure observed_at refresh (Touch) never emits. A no-op mutation (same
+// state and same reason) never emits.
+//
+// Watch returns nil on ctx cancellation, returns the send error on stream
+// write failure, and returns errSlowConsumer if the subscriber's buffer
+// overflows.
+func (m *Tracker) Watch(
+	ctx context.Context,
+	req *readinesspb.ReadyRequest,
+	send func(*readinesspb.ReadyResponse) error,
+) error {
+	filter := map[string]struct{}{}
+	for _, name := range req.GetScopes() {
+		filter[name] = struct{}{}
 	}
 
-	return &readinesspb.ReadyResponse{Scopes: out}
+	sub, snapshot := m.subscribe(filter)
+	defer m.unsubscribe(sub)
+
+	if err := send(snapshot); err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-sub.dropped:
+			return errSlowConsumer
+		case resp, ok := <-sub.ch:
+			if !ok {
+				return errSlowConsumer
+			}
+			if err := send(resp); err != nil {
+				return err
+			}
+		}
+	}
 }

--- a/common/go/readiness/readiness_test.go
+++ b/common/go/readiness/readiness_test.go
@@ -1,6 +1,7 @@
 package readiness_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
@@ -537,4 +539,342 @@ func TestTracker_DrainLatch_SetAfterDrainIsNoop(t *testing.T) {
 			}
 		})
 	}
+}
+
+// collectWatch starts a Watch goroutine that feeds received messages into a
+// buffered channel. The caller reads from the returned channel to inspect
+// messages in order. The goroutine terminates when ctx is cancelled, which
+// also unblocks the returned errgroup entry. eg must be waited on by the
+// caller after cancelling ctx.
+func collectWatch(
+	t *testing.T,
+	ctx context.Context,
+	tracker *readiness.Tracker,
+	req *readinesspb.ReadyRequest,
+	bufSize int,
+) (<-chan *readinesspb.ReadyResponse, *errgroup.Group) {
+	t.Helper()
+	ch := make(chan *readinesspb.ReadyResponse, bufSize)
+	eg, ctx2 := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return tracker.Watch(ctx2, req, func(resp *readinesspb.ReadyResponse) error {
+			ch <- resp
+			return nil
+		})
+	})
+	return ch, eg
+}
+
+// scopeByName finds a Scope by name in a ReadyResponse, returning nil if not
+// present.
+func scopeByName(resp *readinesspb.ReadyResponse, name string) *readinesspb.Scope {
+	for _, s := range resp.GetScopes() {
+		if s.GetName() == name {
+			return s
+		}
+	}
+	return nil
+}
+
+// recvTimeout reads one message from ch, failing the test if nothing arrives
+// within the given timeout.
+func recvTimeout(t *testing.T, ch <-chan *readinesspb.ReadyResponse, timeout time.Duration) *readinesspb.ReadyResponse {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		return msg
+	case <-time.After(timeout):
+		t.Fatal("timed out waiting for Watch message")
+		return nil
+	}
+}
+
+// assertNoMsg asserts that no message arrives on ch within the given window.
+func assertNoMsg(t *testing.T, ch <-chan *readinesspb.ReadyResponse, window time.Duration) {
+	t.Helper()
+	select {
+	case msg := <-ch:
+		t.Fatalf("unexpected Watch message: %v", msg)
+	case <-time.After(window):
+	}
+}
+
+const watchTimeout = 200 * time.Millisecond
+const watchQuietWindow = 30 * time.Millisecond
+
+func TestWatch_InitialSnapshot_AllScopes(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
+
+	snap := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, snap.Scopes, 2)
+
+	sa := scopeByName(snap, "gw-a")
+	require.NotNil(t, sa)
+	assert.Equal(t, readinesspb.State_STATE_READY, sa.State)
+
+	sb := scopeByName(snap, "gw-b")
+	require.NotNil(t, sb)
+	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, sb.State)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_InitialSnapshot_HonorsFilter(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b", "gw-c"})
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+	r.Set("gw-b", readinesspb.State_STATE_NOT_READY)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{Scopes: []string{"gw-a"}}, 8)
+
+	snap := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, snap.Scopes, 1)
+	assert.Equal(t, "gw-a", snap.Scopes[0].Name)
+	assert.Equal(t, readinesspb.State_STATE_READY, snap.Scopes[0].State)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_StateChange_EmitsDelta(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
+
+	// Consume the initial snapshot.
+	recvTimeout(t, ch, watchTimeout)
+
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, delta.Scopes, 1)
+	assert.Equal(t, "gw-a", delta.Scopes[0].Name)
+	assert.Equal(t, readinesspb.State_STATE_READY, delta.Scopes[0].State)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_ReasonOnlyChange_EmitsDelta(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
+	r.SetWithReason("gw-a", readinesspb.State_STATE_DEGRADED, &readinesspb.Reason{Code: "OLD"})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
+
+	// Consume the initial snapshot.
+	recvTimeout(t, ch, watchTimeout)
+
+	// Same state, different reason — must emit.
+	r.SetWithReason("gw-a", readinesspb.State_STATE_DEGRADED, &readinesspb.Reason{Code: "NEW"})
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, delta.Scopes, 1)
+	assert.Equal(t, "gw-a", delta.Scopes[0].Name)
+	assert.Equal(t, readinesspb.State_STATE_DEGRADED, delta.Scopes[0].State)
+	require.Len(t, delta.Scopes[0].Reasons, 1)
+	assert.Equal(t, "NEW", delta.Scopes[0].Reasons[0].Code)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_Touch_EmitsNothing(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
+
+	recvTimeout(t, ch, watchTimeout)
+
+	r.Touch("gw-a")
+
+	assertNoMsg(t, ch, watchQuietWindow)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_NoopSet_EmitsNothing(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
+
+	recvTimeout(t, ch, watchTimeout)
+
+	// Same state, same reason (nil) — must not emit.
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	assertNoMsg(t, ch, watchQuietWindow)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_DeltaFilteredForDifferentScope(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Watch only gw-b.
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{Scopes: []string{"gw-b"}}, 8)
+
+	recvTimeout(t, ch, watchTimeout)
+
+	// Mutate gw-a — subscriber watches gw-b only, so no message.
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	assertNoMsg(t, ch, watchQuietWindow)
+
+	// Mutate gw-b — now a message must arrive.
+	r.Set("gw-b", readinesspb.State_STATE_NOT_READY)
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, delta.Scopes, 1)
+	assert.Equal(t, "gw-b", delta.Scopes[0].Name)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_Drain_EmitsChangedScopes(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+	r.Set("gw-a", readinesspb.State_STATE_READY)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
+
+	recvTimeout(t, ch, watchTimeout)
+
+	r.Drain()
+
+	delta := recvTimeout(t, ch, watchTimeout)
+	// Both scopes transitioned: gw-a READY->NOT_READY, gw-b UNKNOWN->NOT_READY.
+	require.Len(t, delta.Scopes, 2)
+	for _, s := range delta.Scopes {
+		assert.Equal(t, readinesspb.State_STATE_NOT_READY, s.State)
+		require.Len(t, s.Reasons, 1)
+		assert.Equal(t, "SHUTTING_DOWN", s.Reasons[0].Code)
+	}
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_CtxCancel_ReturnsNil(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a"})
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	eg, ctx2 := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return r.Watch(ctx2, &readinesspb.ReadyRequest{}, func(_ *readinesspb.ReadyResponse) error {
+			return nil
+		})
+	})
+
+	// Give Watch time to register and send the snapshot.
+	time.Sleep(5 * time.Millisecond)
+	cancel()
+
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_GatewayStyle_DrainLatch(t *testing.T) {
+	r := readiness.NewTracker([]string{"gateway"}, readiness.WithDrainLatch())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ch, eg := collectWatch(t, ctx, r, &readinesspb.ReadyRequest{}, 8)
+
+	// Initial snapshot: gateway is UNKNOWN.
+	snap := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, snap.Scopes, 1)
+	assert.Equal(t, readinesspb.State_STATE_UNKNOWN, snap.Scopes[0].State)
+
+	// Set to READY — delta must arrive.
+	r.Set("gateway", readinesspb.State_STATE_READY)
+	delta1 := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, delta1.Scopes, 1)
+	assert.Equal(t, readinesspb.State_STATE_READY, delta1.Scopes[0].State)
+
+	// Drain — NOT_READY + SHUTTING_DOWN delta.
+	r.Drain()
+	delta2 := recvTimeout(t, ch, watchTimeout)
+	require.Len(t, delta2.Scopes, 1)
+	assert.Equal(t, readinesspb.State_STATE_NOT_READY, delta2.Scopes[0].State)
+	require.Len(t, delta2.Scopes[0].Reasons, 1)
+	assert.Equal(t, "SHUTTING_DOWN", delta2.Scopes[0].Reasons[0].Code)
+
+	// With latch active, Set is a no-op — no more messages.
+	r.Set("gateway", readinesspb.State_STATE_READY)
+	assertNoMsg(t, ch, watchQuietWindow)
+
+	cancel()
+	require.NoError(t, eg.Wait())
+}
+
+func TestWatch_ConcurrentSubscribersAndMutators(t *testing.T) {
+	r := readiness.NewTracker([]string{"gw-a", "gw-b"})
+
+	const (
+		numSubscribers = 8
+		numMutations   = 50
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	subEg, _ := errgroup.WithContext(t.Context())
+	for range numSubscribers {
+		subEg.Go(func() error {
+			_ = r.Watch(ctx, &readinesspb.ReadyRequest{}, func(_ *readinesspb.ReadyResponse) error {
+				return nil
+			})
+			return nil
+		})
+	}
+
+	eg, _ := errgroup.WithContext(t.Context())
+	eg.Go(func() error {
+		for idx := range numMutations {
+			if idx%3 == 0 {
+				r.Set("gw-a", readinesspb.State_STATE_READY)
+			} else if idx%3 == 1 {
+				r.Set("gw-b", readinesspb.State_STATE_NOT_READY)
+			} else {
+				r.Touch("gw-a")
+			}
+		}
+		return nil
+	})
+	require.NoError(t, eg.Wait())
+
+	cancel()
+	require.NoError(t, subEg.Wait())
 }

--- a/controlplane/gateway/readiness.go
+++ b/controlplane/gateway/readiness.go
@@ -3,6 +3,8 @@ package gateway
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
@@ -30,4 +32,12 @@ func (m *ReadinessService) Ready(
 	req *readinesspb.ReadyRequest,
 ) (*readinesspb.ReadyResponse, error) {
 	return m.tracker.Ready(req), nil
+}
+
+// Watch streams readiness changes for the gateway scope.
+func (m *ReadinessService) Watch(
+	req *readinesspb.ReadyRequest,
+	stream grpc.ServerStreamingServer[readinesspb.ReadyResponse],
+) error {
+	return m.tracker.Watch(stream.Context(), req, stream.Send)
 }

--- a/controlplane/ynpb/v1/readiness.proto
+++ b/controlplane/ynpb/v1/readiness.proto
@@ -10,4 +10,11 @@ import "common/readinesspb/v1/readiness.proto";
 service ReadinessService {
   // Ready returns the current readiness state of the gateway.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
+
+  // Watch streams readiness state changes.
+  //
+  // The first message carries the current state of every selected scope;
+  // each subsequent message carries only the scopes whose state or reason
+  // changed.
+  rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/decap/internal/operator/readiness_service.go
+++ b/operators/decap/internal/operator/readiness_service.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/decap/operatorpb/v1"
@@ -28,4 +30,12 @@ func (m *ReadinessService) Ready(
 	req *readinesspb.ReadyRequest,
 ) (*readinesspb.ReadyResponse, error) {
 	return m.tracker.Ready(req), nil
+}
+
+// Watch streams readiness changes for the decap operator scopes.
+func (m *ReadinessService) Watch(
+	req *readinesspb.ReadyRequest,
+	stream grpc.ServerStreamingServer[readinesspb.ReadyResponse],
+) error {
+	return m.tracker.Watch(stream.Context(), req, stream.Send)
 }

--- a/operators/decap/operatorpb/v1/readiness.proto
+++ b/operators/decap/operatorpb/v1/readiness.proto
@@ -10,4 +10,11 @@ import "common/readinesspb/v1/readiness.proto";
 service ReadinessService {
   // Ready returns the current per-gateway readiness state.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
+
+  // Watch streams readiness state changes.
+  //
+  // The first message carries the current state of every selected scope;
+  // each subsequent message carries only the scopes whose state or reason
+  // changed.
+  rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/forward/internal/operator/readiness_service.go
+++ b/operators/forward/internal/operator/readiness_service.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/forward/operatorpb/v1"
@@ -28,4 +30,12 @@ func (m *ReadinessService) Ready(
 	req *readinesspb.ReadyRequest,
 ) (*readinesspb.ReadyResponse, error) {
 	return m.tracker.Ready(req), nil
+}
+
+// Watch streams readiness changes for the forward operator scopes.
+func (m *ReadinessService) Watch(
+	req *readinesspb.ReadyRequest,
+	stream grpc.ServerStreamingServer[readinesspb.ReadyResponse],
+) error {
+	return m.tracker.Watch(stream.Context(), req, stream.Send)
 }

--- a/operators/forward/operatorpb/v1/readiness.proto
+++ b/operators/forward/operatorpb/v1/readiness.proto
@@ -10,4 +10,11 @@ import "common/readinesspb/v1/readiness.proto";
 service ReadinessService {
   // Ready returns the current per-gateway readiness state.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
+
+  // Watch streams readiness state changes.
+  //
+  // The first message carries the current state of every selected scope;
+  // each subsequent message carries only the scopes whose state or reason
+  // changed.
+  rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/pipeline/internal/operator/readiness_service.go
+++ b/operators/pipeline/internal/operator/readiness_service.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/pipeline/operatorpb/v1"
@@ -28,4 +30,12 @@ func (m *ReadinessService) Ready(
 	req *readinesspb.ReadyRequest,
 ) (*readinesspb.ReadyResponse, error) {
 	return m.tracker.Ready(req), nil
+}
+
+// Watch streams readiness changes for the pipeline operator scopes.
+func (m *ReadinessService) Watch(
+	req *readinesspb.ReadyRequest,
+	stream grpc.ServerStreamingServer[readinesspb.ReadyResponse],
+) error {
+	return m.tracker.Watch(stream.Context(), req, stream.Send)
 }

--- a/operators/pipeline/operatorpb/v1/readiness.proto
+++ b/operators/pipeline/operatorpb/v1/readiness.proto
@@ -10,4 +10,11 @@ import "common/readinesspb/v1/readiness.proto";
 service ReadinessService {
   // Ready returns the current per-gateway readiness state.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
+
+  // Watch streams readiness state changes.
+  //
+  // The first message carries the current state of every selected scope;
+  // each subsequent message carries only the scopes whose state or reason
+  // changed.
+  rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }

--- a/operators/route/internal/operator/readiness_service.go
+++ b/operators/route/internal/operator/readiness_service.go
@@ -3,6 +3,8 @@ package operator
 import (
 	"context"
 
+	"google.golang.org/grpc"
+
 	"github.com/yanet-platform/yanet2/common/go/readiness"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	operatorpb "github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
@@ -29,4 +31,12 @@ func (m *ReadinessService) Ready(
 	req *readinesspb.ReadyRequest,
 ) (*readinesspb.ReadyResponse, error) {
 	return m.tracker.Ready(req), nil
+}
+
+// Watch streams readiness changes for the route operator scopes.
+func (m *ReadinessService) Watch(
+	req *readinesspb.ReadyRequest,
+	stream grpc.ServerStreamingServer[readinesspb.ReadyResponse],
+) error {
+	return m.tracker.Watch(stream.Context(), req, stream.Send)
 }

--- a/operators/route/operatorpb/v1/readiness.proto
+++ b/operators/route/operatorpb/v1/readiness.proto
@@ -10,4 +10,11 @@ import "common/readinesspb/v1/readiness.proto";
 service ReadinessService {
   // Ready returns the current readiness state for all scopes.
   rpc Ready(common.readinesspb.v1.ReadyRequest) returns (common.readinesspb.v1.ReadyResponse);
+
+  // Watch streams readiness state changes.
+  //
+  // The first message carries the current state of every selected scope;
+  // each subsequent message carries only the scopes whose state or reason
+  // changed.
+  rpc Watch(common.readinesspb.v1.ReadyRequest) returns (stream common.readinesspb.v1.ReadyResponse);
 }


### PR DESCRIPTION
- Add a server-streaming `Watch` RPC to the readiness service exposed by the gateway and every operator. The first message carries the current state of the selected scopes, and each subsequent message carries only the scopes whose state or reason changed.
- Implement the streaming logic once on the shared readiness tracker, with each service delegating to it; a pure freshness refresh does not produce a message.
- Extend the readiness CLI with a `--watch` mode that streams changes until interrupted, reusing the existing rendering for both human and JSON output.
- Add a reusable server-streaming helper to the shared CLI core.