### PR TITLE
chore(claude): tune agent models/effort, add conventions and raii-sweep skill

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -2,7 +2,7 @@
 name: "architect"
 description: "Use this agent when the user asks for any development task in the YANET2 project — feature requests, bug fixes, refactoring, new modules, performance improvements, or architectural questions. This agent is the single entry point that analyzes requirements, plans implementation, and delegates to specialist agents."
 tools: Agent(coder-c, coder-go, coder-rust, coder-ui, networking-expert, reviewer, bug-hunter, performance-engineer, planner), AskUserQuestion, ExitPlanMode, Bash, Write, Read, WebFetch, WebSearch, LSP, Glob, Grep
-model: fable
+model: opus
 effort: high
 color: purple
 memory: project

--- a/.claude/agents/coder-c.md
+++ b/.claude/agents/coder-c.md
@@ -3,6 +3,7 @@ name: "coder-c"
 description: "Use this agent when the task involves writing or modifying C code in the YANET2 dataplane, module packet handlers, C API layers (shared memory FFI), Meson build files, fuzzing targets, or C-level tests. Covers dataplane/, modules/*/dataplane/, modules/*/api/, lib/, common/*.h, filter/, modules/*/fuzzing/, modules/*/tests/, and meson.build files."
 tools: Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, TaskGet, TaskList, TaskUpdate
 model: sonnet
+effort: high
 color: blue
 memory: project
 ---

--- a/.claude/agents/coder-go.md
+++ b/.claude/agents/coder-go.md
@@ -3,7 +3,7 @@ name: "coder-go"
 description: "Use this agent when working on Go code in the YANET2 control plane: module gRPC services, CGO/FFI bindings, protobuf definitions, gateway code, shared Go libraries, Go tests. Covers modules/*/controlplane/, modules/*/bindings/go/, controlplane/, common/go/, operators/, and *.proto files."
 tools: Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, WebFetch, TaskGet, TaskList, TaskUpdate
 model: sonnet
-effort: medium
+effort: high
 color: blue
 memory: project
 ---

--- a/.claude/skills/raii-sweep/SKILL.md
+++ b/.claude/skills/raii-sweep/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: raii-sweep
+description: >-
+  Weekly maintenance sweep that restores RAII symmetry in the YANET2 C code:
+  every lifecycle pair must follow new/init/fini/free semantics (new allocates
+  the struct, init fills fields, fini releases field memory, free deallocates
+  the struct). Finds misnamed destructors (free that is semantically fini),
+  non-canonical names (create/destroy/cleanup/release/deinit), missing
+  destructors (leaks), and unpaired allocators — then fixes a bounded batch per
+  run, one prefix family per PR. Use this skill whenever the user invokes the
+  weekly RAII sweep, asks to "fix RAII symmetry", "приведи lifecycle-функции к
+  паттерну", "найди несимметричные init/fini", or wants a C lifecycle cleanup
+  pass.
+---
+
+# raii-sweep
+
+Run the periodic RAII-symmetry sweep over the C codebase: scan for lifecycle asymmetries, triage them semantically against the project convention, fix 2–3 prefix families per run (one family = one PR), and keep a persistent ledger so weekly runs never re-litigate old verdicts.
+
+You (the architect) drive this. You never edit C or Go code yourself — fixes are delegated to **coder-c** (and **coder-go** when renamed symbols cross the CGO boundary); you own scanning, triage, verification gates, and the publish workflow.
+
+**Invoking this skill is the explicit publish request**: commits, pushes, PR creation, and merges (after green CI and addressed review findings) are authorized within the run's budget. Delegated agents still never commit — you do.
+
+## The convention (target state)
+
+- `<prefix>_new` — allocates the struct, returns a pointer (typically calls init). Pairs with `free`.
+- `<prefix>_init` — initializes fields in place, may allocate field memory. Pairs with `fini`.
+- `<prefix>_fini` — releases field memory, does NOT free the struct itself. Idempotent on zero-init.
+- `<prefix>_free` — deallocates the struct (typically calls fini first). NULL-safe.
+- `_create`/`_destroy`/`_cleanup`/`_release`/`_deinit` are banned names. `_attach`/`_detach` are legitimate only for shared-memory multi-process attach semantics (yanet_shm, agent).
+
+This matches coder-c's standardized lifecycle lessons (`lifecycle-classes.md`, `lifecycle-fini-special-cases.md` in its memory) — the skill enforces repo-wide what coder-c already applies to new code.
+
+## Non-negotiables
+
+- **Symbol renames only, never layout changes.** This sweep renames and restructures lifecycle functions; it NEVER alters shared-memory struct layout, field order, or sizes. If a fix seems to require a layout change, defer the candidate and flag it to the user.
+- **A rename ships with ALL its consumers in the same PR**: every C caller, Go bindings (`bindings/go/*/cgo.go` or legacy `controlplane/ffi.go`), tests, fuzzing targets, comments. Zero references to the old name may remain repo-wide.
+- **Semantic verdicts are read-code verdicts.** Never classify from the scan table alone — read the function bodies before deciding rename vs. real bug vs. false positive.
+- **One prefix family = one PR**, each in its own worktree. Closely coupled clones (e.g. `btree_u16/u32/u64`) count as one family.
+- **Budget: 2–3 PRs per run.** Semantic bugs (leaks, ownership traps) outrank pure renames when picking.
+- **Never touch**: `new_module_<name>` defsym entry points, DPDK `rte_*` APIs, vendored code under `subprojects/`.
+
+## Pipeline
+
+### Phase 1 — Scan & ledger sync
+
+1. `git fetch origin main`; work off `origin/main`.
+2. Run the scan: `bash .claude/skills/raii-sweep/references/scan.sh`. It inventories lifecycle function definitions across `lib/ dataplane/ common/ api/ modules/ devices/` and pairs them by prefix, flagging asymmetries.
+3. Sync the ledger at `.arch/raii-sweep/LEDGER.md` (gitignored; create on first run):
+   - Add newly flagged prefixes as `pending`.
+   - Mark entries whose asymmetry disappeared from the scan as `resolved-externally`.
+   - Preserve all existing verdicts (`merged`, `deferred`, `fp-*`) — never re-triage a prefix with a false-positive verdict unless its code changed.
+
+Ledger format — one table:
+
+```
+| prefix | area | class | priority | status | notes |
+```
+
+`status` ∈ `pending` / `in-progress` / `merged #PR` / `deferred` / `fp-no-fini-needed` / `fp-other` / `resolved-externally`.
+
+### Phase 2 — Triage (semantic, bounded)
+
+Take `pending` entries in priority order and read the actual code until you have 2–3 confirmed candidates. Classification rules, false-positive criteria, and the priority ladder live in `references/triage.md`. For each confirmed candidate record in the ledger: violation class, exact rename map (old → new symbol list) or fix description, full consumer list (`grep -rn` across C, Go, tests, fuzzing, comments), and blast-radius notes (FFI-crossing? hot-path header?).
+
+Skip (and mark) candidates whose files overlap an open PR (`gh pr list --json files`) — cross-PR rename conflicts are not worth it.
+
+### Phase 3 — Execute (delegate, one worktree per candidate)
+
+For each candidate:
+
+1. `git worktree add .claude/worktrees/raii-<prefix> -b refactor/raii-<prefix> origin/main`.
+2. If the candidate touches Go bindings, seed gitignored generated files first: `rsync` the `*.pb.go` files from the main checkout into the worktree (a fresh worktree cannot run `go build ./...` without them).
+3. Delegate to **coder-c** with a brief that names: the absolute worktree path (cd there, `git rev-parse --show-toplevel` to confirm), the exact rename map / fix, the full consumer list from Phase 2, and the relevant guardrails (see `references/triage.md` § Brief template). The brief MUST forbid destructive git ops (`stash`/`checkout`/`restore`/`reset`/index ops) and `git commit`, and restate coder-c's minimal-fix discipline: only the named symbols, no adjacent restructuring, no gratuitous doc comments.
+4. If renamed symbols cross the CGO boundary, delegate the Go side to **coder-go** afterwards (same worktree, same constraints; receiver naming `m`, no comment drift).
+5. Sequence strictly: coder-c → your build check → coder-go (if needed) → your build check. Never run a coder and its reviewer in the same batch.
+
+### Phase 4 — Verify (you run the gates)
+
+From the worktree root:
+
+1. `grep -rn '<old_symbol>' .` for EVERY renamed symbol — zero hits allowed (code, comments, meson, Go, fuzzing).
+2. C gate: `meson setup build` (or reuse) + `meson compile -C build` + `meson test -C build`.
+3. Go gate when bindings changed: `go build ./...` in `controlplane/` and the touched module.
+4. Local ASan (`make test-asan` or targeted `meson test -C build-asan <name>`) is required only when the change ALTERS BEHAVIOR — a destructor added (V3), ownership/free semantics changed, call order changed. Pure renames (most V1/V2) skip it: repo CI runs build-asan-test, build-tsan-test, and functional tests on every PR anyway.
+5. Reviewer pass: launch **reviewer** WITHOUT isolation, read-only, pointed at the worktree's absolute paths (work is uncommitted). Address findings via the Review-Fix loop (max 3 rounds).
+
+### Phase 5 — Publish & close the loop
+
+1. Stage only the candidate's files; verify each with `git diff --cached -- <file>` and confirm no untracked stragglers.
+2. Commit as `refactor(<scope>): <short description>` (scope = `lib`, `common`, module name…). No Claude footers.
+3. Push, open the PR with a scoped title; body is capitalized period-ended bullets, no `## Summary`, no `Test plan`.
+4. `gh pr checks <pr> --watch`; if it exits with "no checks reported" you ran it before CI registered — re-run it once after a minute. Read PR reviews AND Codex inline comments; fix or reply to every finding.
+5. Merge (single-commit → squash `--admin`; multi-commit → rebase) WITHOUT `--delete-branch` — it fails while the branch is checked out in a worktree. Then `git worktree remove` from the main checkout, `git branch -D`, and `git push origin --delete <branch>`.
+6. **Merge one PR at a time** — these PRs rename callers across wide files; rebase remaining branches onto `origin/main` after each merge.
+7. **Stacked families** (candidate B's files depend on candidate A's pending rename, e.g. btree on big_array): branch B off A's branch, do the work in parallel, and after A squash-merges rebase with `git rebase --onto origin/main <A-branch-sha> refactor/raii-<B>` — A's commit drops out, B replays cleanly.
+8. Update the ledger: `merged #PR`, date. Append a one-line run summary (date, PRs, verdicts changed) to the ledger's `## Run log`.
+
+### End of run
+
+Report to the user: PRs shipped, new verdicts (especially `deferred` ones needing a human call), remaining queue depth, and an ETA at the current budget.

--- a/.claude/skills/raii-sweep/references/scan.sh
+++ b/.claude/skills/raii-sweep/references/scan.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Inventory C lifecycle function definitions and flag asymmetric prefix
+# families. Read-only: prints a report, writes nothing.
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+SCOPE="lib dataplane common api modules devices"
+SUFFIXES='new|init|fini|free|destroy|create|release|cleanup|deinit|teardown'
+
+# Definitions: this codebase puts the return type on its own line, so a
+# definition is a line that STARTS with the function name. Prototypes in
+# headers match too, which is fine — we dedupe by name.
+grep -rEn --include='*.h' --include='*.c' \
+	"^([a-z_][a-z0-9_]*_(${SUFFIXES}))\(" ${SCOPE} 2>/dev/null \
+	| sed -E 's/^([^:]+):([0-9]+):([a-z_][a-z0-9_]*)\(.*/\3\t\1:\2/' \
+	| sort -u > /tmp/raii_defs.tsv
+
+python3 - "$SUFFIXES" <<'EOF'
+import collections
+import re
+import sys
+
+suffix_re = re.compile(r"^(.*)_(%s)$" % sys.argv[1])
+defs = collections.defaultdict(list)
+for line in open("/tmp/raii_defs.tsv"):
+    name, loc = line.rstrip("\n").split("\t")
+    defs[name].append(loc)
+
+groups = collections.defaultdict(dict)
+for name, locs in defs.items():
+    m = suffix_re.match(name)
+    if m:
+        groups[m.group(1)][m.group(2)] = locs
+
+flagged = 0
+print(f"{'PREFIX':40} {'SUFFIXES':28} FLAGS")
+for prefix in sorted(groups):
+    s = set(groups[prefix])
+    flags = []
+    if "init" in s and "fini" not in s:
+        flags.append("init-without-fini")
+    if "fini" in s and "init" not in s:
+        flags.append("fini-without-init")
+    if "new" in s and "free" not in s:
+        flags.append("new-without-free")
+    if "free" in s and not s & {"new", "init", "create"}:
+        flags.append("free-without-allocator")
+    bad = sorted(s & {"create", "destroy", "release", "cleanup", "deinit", "teardown"})
+    if bad:
+        flags.append("non-canonical:" + ",".join(bad))
+    if flags:
+        flagged += 1
+        print(f"{prefix:40} {','.join(sorted(s)):28} {'; '.join(flags)}")
+        for suf in sorted(s):
+            for loc in groups[prefix][suf]:
+                print(f"    {prefix}_{suf}  {loc}")
+
+print(f"\ntotal prefixes: {len(groups)}, flagged: {flagged}")
+EOF

--- a/.claude/skills/raii-sweep/references/triage.md
+++ b/.claude/skills/raii-sweep/references/triage.md
@@ -1,0 +1,68 @@
+# raii-sweep triage rules
+
+How to turn a scan flag into a verdict. Every verdict requires reading the function bodies — the scan only points, it never decides.
+
+## Violation classes
+
+### V1 — misnamed fini (`free` that does not free the struct)
+
+The most common and most dangerous class: `<prefix>_free` releases field memory and finalizes the memory context but never deallocates the struct itself — the caller owns it. By convention this function is `fini`. The misleading name is an ownership trap (readers assume the struct is gone; double-free and use-after-free hazards at call sites).
+
+Detection: read the `free` body — if there is no `memory_bfree(ctx, self, sizeof(*self))` / `free(self)` on the struct pointer itself, it is a fini. Confirmed examples at first scan: `lpm_free`, `btree_u*_free`, `radix_free`, `value_table_free`, `remap_table_free`, `filter_free`.
+
+Fix: rename `free` → `fini` (and verify init/fini invariants: idempotent on zero-init, self-cleanup on constructor error paths). If some call sites actually need heap deallocation, that is a separate finding — check what owns the struct there.
+
+### V2 — non-canonical names (`create`/`destroy`/`cleanup`/`release`/`deinit`/`teardown`)
+
+Map by semantics, never mechanically:
+
+- allocates struct + returns pointer → `_new`
+- initializes caller-owned struct in place → `_init`
+- releases fields, struct survives → `_fini`
+- deallocates struct → `_free`
+
+A `create` that both allocates and initializes is simply `new` (new is expected to call init or inline it). A `destroy` that finis and frees is simply `free`. Watch for `cleanup` functions that mix both halves — split is optional; pick the name matching what callers rely on.
+
+### V3 — missing destructor (init/new allocates, nothing releases)
+
+Real bug class (leak), not a rename. Confirm: does init/new allocate memory (directly or via embedded children with their own fini)? Does any code path release it? If not — add the missing `fini`/`free` and wire it into every owner's teardown path.
+
+Before burning budget on a non-obvious leak, a `bug-hunter confirm` dispatch (ASan repro) is allowed but optional — the ASan test gate in Phase 4 is mandatory either way.
+
+### V4 — free without visible allocator pair
+
+`<prefix>_free` exists but nothing named `<prefix>_new/init/create` allocates it (e.g. `cp_*_list_info_free`, `yanet_counter_handle_list_free`). Find the actual allocating function. Verdict is one of:
+
+- allocator is a collector/getter whose primary job is not allocation → acceptable, record `fp-other` with the pairing in notes;
+- allocator deserves the `_new` name → V2 rename.
+
+## False positives (record verdict, never re-triage)
+
+From coder-c's `lifecycle-fini-special-cases.md`:
+
+- **No-resource init** — init only assigns scalars/pointers into caller-owned memory and allocates nothing (`spinlock_init`, `tsc_clock_init`, `packet_list_init`, `packet_front_init` into arena memory): no fini needed → `fp-no-fini-needed`.
+- **Process-lifetime init** — `dataplane_init`, fuzz-harness `LLVMFuzzerInitialize` call sites: adding fini without a parent teardown is dead code → `fp-no-fini-needed` until the parent gains teardown.
+- **Factory structs** — own nothing directly (pages live in downstream containers); an empty placeholder fini that zeroes fields is correct and must say so in a comment.
+- **Internal helpers** — double-underscore or clearly-private helpers (`__ttlmap_lock_init`) follow the convention of their owner; flag only if the owner family is broken.
+- **Test fixtures** (`test_mempool_create`, `test_ring_init`, …) — lowest value; rename only opportunistically when their family is already in a PR.
+
+## Priority ladder (low risk first)
+
+1. **V3 leaks anywhere** — real bugs outrank all renames.
+2. **common/ and lib/ leaf utilities** (header-only, all callers in-tree C, no FFI): `lpm`, `radix`, `btree_u*`, `value_table`, `remap_table`, segments classifiers.
+3. **lib/controlplane and lib/dataplane families** (`cp_*_create/free`, ectx families) — wide caller fan-out, still C-only.
+4. **modules/*/api and devices/*/api** — renames cross the CGO boundary; Go bindings (`bindings/go/*/cgo.go` or legacy `controlplane/ffi.go`) updated in the same PR by coder-go.
+5. **dataplane core init paths** (`dpdk_init`, `worker`, `device`) — highest blast radius, take last and only with a clear teardown story.
+
+## Brief template (coder-c)
+
+The Phase 3 brief must contain:
+
+- absolute worktree path; first action `cd` + `git rev-parse --show-toplevel` to confirm;
+- the exact rename map: every `old_symbol → new_symbol`;
+- the full consumer list (file:line) you collected in Phase 2 — the coder verifies it, not discovers it;
+- invariants to enforce while touching the family: fini idempotent on zero-init, free NULL-safe, constructor self-cleanup on error paths, `// FIXME free X` comments are bugs to resolve, POD-shaped fini may use release-resources + memset;
+- prohibitions: no struct layout changes, no adjacent restructuring, no gratuitous doc comments, no banner comments, `//` comment style, no destructive git ops, no `git commit`;
+- the closing check the coder must run: `grep -rn '<old_symbol>'` from repo root → zero hits.
+
+For coder-go (when FFI symbols renamed): same worktree, only the `C.<symbol>` call sites and any Go wrapper names; receiver `m`; do not touch unrelated lines or comments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,16 @@ Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` 
   rule the user has repeated many times across C, Rust, Go, and shell; treat
   any occurrence as a blocking review finding, never a non-blocking nit.
 
+- **Doc-comment shape (fields, structs, functions) — every language.** A short
+  one-line brief (what/why), then a blank comment line, then the detail
+  paragraph (concise, no fanaticism). Never glue brief and detail into one
+  run-on block, and never cram multiple ideas onto consecutive comment lines
+  without the blank separator. Applies to `//`, `///`, `#`, and `/* */`.
+  Single-sentence comments need no blank line; inline implementation comments
+  inside function bodies are exempt. This is a hard rule the user has repeated
+  many times (C and Go alike); treat a crammed multi-idea doc comment as a
+  blocking review finding, not a nit.
+
 ### Go
 
 - **Receiver names**: always `m`. No type-letter mnemonics.
@@ -277,6 +287,11 @@ Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` 
   direct `self.0`. Trait bounds in `where` clauses, not inline.
   Import type names directly (`use serde::Serialize;` then `T: Serialize`),
   not module-qualified (`serde::Serialize`).
+- **Struct-literal field order**: list fields in the same order they are
+  declared in the struct definition. Applies to proto-generated structs
+  too — e.g. if the message declares `nexthop_addrs` (tag 3) before
+  `do_flush` (tag 4), the literal must place `nexthop_addrs` before
+  `do_flush`, not append it last. `rustfmt`/`clippy` do not catch this.
 
 ### C
 


### PR DESCRIPTION
Bump architect to opus and raise coder-c/coder-go effort to high.

Document the doc-comment shape and Rust struct-literal field-order conventions in CLAUDE.md.

Add the raii-sweep skill for C resource-cleanup audits.