### PR TITLE
refactor(web): share draft save and discard command palette entries

### DIFF
--- a/web/src/components/command-palette/configCommands.ts
+++ b/web/src/components/command-palette/configCommands.ts
@@ -80,3 +80,45 @@ export const buildConfigCommands = (options: ConfigCommandsOptions): Command[] =
 
     return list;
 };
+
+/** Options for building the draft save/discard command pair. */
+export interface DraftCommandsOptions {
+    /** Whether the active config has unsaved changes. */
+    currentIsDirty: boolean;
+    /** Called when the user selects "Save changes". */
+    onSave: () => void;
+    /** Called when the user selects "Discard changes". */
+    onDiscard: () => void;
+}
+
+/**
+ * Builds the Save / Discard command pair shown when the active draft config
+ * has unsaved changes.
+ *
+ * Returns an empty list when the config is clean, so call sites can always
+ * spread the result unconditionally.
+ */
+export const buildDraftCommands = (options: DraftCommandsOptions): Command[] => {
+    const { currentIsDirty, onSave, onDiscard } = options;
+    if (!currentIsDirty) {
+        return [];
+    }
+    return [
+        {
+            id: '__save',
+            icon: '✓',
+            label: 'Save changes',
+            sub: 'Open the diff and save dialog',
+            keywords: 'save commit apply',
+            onSelect: onSave,
+        },
+        {
+            id: '__discard',
+            icon: '⟲',
+            label: 'Discard changes',
+            sub: 'Revert to the last saved state',
+            keywords: 'discard revert undo reset',
+            onSelect: onDiscard,
+        },
+    ];
+};

--- a/web/src/components/command-palette/index.ts
+++ b/web/src/components/command-palette/index.ts
@@ -9,6 +9,6 @@ export { useHelpShortcut } from './useHelpShortcut';
 export { PaletteProvider, usePalette } from './PaletteContext';
 export type { PagePaletteContribution } from './PaletteContext';
 export { navigationCommands } from './navigationCommands';
-export { buildConfigCommands } from './configCommands';
-export type { ConfigCommandsOptions } from './configCommands';
+export { buildConfigCommands, buildDraftCommands } from './configCommands';
+export type { ConfigCommandsOptions, DraftCommandsOptions } from './configCommands';
 export { default as ShortcutsHelp } from './ShortcutsHelp';

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -18,7 +18,7 @@ import { useAclRuleCounters } from './useAclRuleCounters';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { useRulePageState } from '../../../components/draft';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
-import { buildConfigCommands } from '../../../components/command-palette';
+import { buildConfigCommands, buildDraftCommands } from '../../../components/command-palette';
 import '../../../styles/chrome.scss';
 import './acl.scss';
 
@@ -238,24 +238,11 @@ const AclPage: React.FC = () => {
                 onSelect: () => openAdd(),
             });
         }
-        if (currentIsDirty) {
-            list.push({
-                id: '__save',
-                icon: '✓',
-                label: 'Save changes',
-                sub: 'Open the diff and save dialog',
-                keywords: 'save commit apply',
-                onSelect: () => handleSavePress(),
-            });
-            list.push({
-                id: '__discard',
-                icon: '⟲',
-                label: 'Discard changes',
-                sub: 'Revert to the last saved state',
-                keywords: 'discard revert undo reset',
-                onSelect: () => { closeDrawer(); handleDiscard(); },
-            });
-        }
+        list.push(...buildDraftCommands({
+            currentIsDirty,
+            onSave: () => handleSavePress(),
+            onDiscard: () => { closeDrawer(); handleDiscard(); },
+        }));
         list.push(...buildConfigCommands({
             currentConfig,
             draftConfigs,

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -13,7 +13,7 @@ import { PrefixSaveDiffModal } from './PrefixSaveDiffModal';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { useDraftShortcuts, useDraftPageHandlers, useDraftPageState, useDraftPageDerived } from '../../../components/draft';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
-import { buildConfigCommands } from '../../../components/command-palette';
+import { buildConfigCommands, buildDraftCommands } from '../../../components/command-palette';
 import '../../../styles/chrome.scss';
 import './decap.scss';
 
@@ -111,24 +111,11 @@ const DecapPage: React.FC = () => {
                 onSelect: () => openAdd(),
             },
         ];
-        if (currentIsDirty) {
-            list.push({
-                id: '__save',
-                icon: '✓',
-                label: 'Save changes',
-                sub: 'Open the diff and save dialog',
-                keywords: 'save commit apply',
-                onSelect: () => handlers.handleCommitPress(),
-            });
-            list.push({
-                id: '__discard',
-                icon: '⟲',
-                label: 'Discard changes',
-                sub: 'Revert to the last saved state',
-                keywords: 'discard revert undo reset',
-                onSelect: () => handlers.handleDiscard(),
-            });
-        }
+        list.push(...buildDraftCommands({
+            currentIsDirty,
+            onSave: () => handlers.handleCommitPress(),
+            onDiscard: () => handlers.handleDiscard(),
+        }));
         list.push(...buildConfigCommands({
             currentConfig,
             draftConfigs,

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -20,7 +20,7 @@ import { useForwardRuleCounters } from './useForwardRuleCounters';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '../../../components';
 import { useRulePageState } from '../../../components/draft';
 import type { Command, RowAdapter, PagePaletteContribution } from '../../../components/command-palette';
-import { buildConfigCommands } from '../../../components/command-palette';
+import { buildConfigCommands, buildDraftCommands } from '../../../components/command-palette';
 import '../../../styles/chrome.scss';
 import './forward.scss';
 
@@ -182,24 +182,11 @@ const ForwardPage: React.FC = () => {
                 onSelect: () => openAdd(),
             },
         ];
-        if (currentIsDirty) {
-            list.push({
-                id: '__save',
-                icon: '✓',
-                label: 'Save changes',
-                sub: 'Open the diff and save dialog',
-                keywords: 'save commit apply',
-                onSelect: () => handleSavePress(),
-            });
-            list.push({
-                id: '__discard',
-                icon: '⟲',
-                label: 'Discard changes',
-                sub: 'Revert to the last saved state',
-                keywords: 'discard revert undo reset',
-                onSelect: () => handleDiscard(),
-            });
-        }
+        list.push(...buildDraftCommands({
+            currentIsDirty,
+            onSave: () => handleSavePress(),
+            onDiscard: () => handleDiscard(),
+        }));
         list.push(...buildConfigCommands({
             currentConfig,
             draftConfigs,


### PR DESCRIPTION
Extract the duplicated "Save changes" and "Discard changes" command palette entries into a shared `buildDraftCommands` helper alongside `buildConfigCommands`.

- Adopt the helper in the forward, acl, and decap pages, keeping each page's own save/discard callbacks.
- The route and fwstate pages keep their own entries, which intentionally differ in labels and metadata.

The emitted command objects are byte-identical to the previous inline literals, so the command palette behaviour is unchanged.