### PR TITLE
refactor(web): reuse the shared IP-net formatter in rule diff serializers

### DIFF
--- a/web/src/pages/modules/acl/SaveDiffModal.tsx
+++ b/web/src/pages/modules/acl/SaveDiffModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Dialog, Text } from '@gravity-ui/uikit';
 import type { Rule } from '../../../api/acl';
 import { ActionKind } from '../../../api/acl';
-import { formatIPNet, extractBytes, dumpYamlDoc } from '../../../utils';
+import { formatIPNetItem, dumpYamlDoc } from '../../../utils';
 
 // TODO(acl): structured diff disabled until the per-card layout is reworked.
 
@@ -18,14 +18,8 @@ const ACTION_KIND_YAML_NAMES: Record<ActionKind, string> = {
 /** Build the serialisable object array for a set of ACL rules. Used by both YAML and JSON export. */
 export const rulesToYamlObjects = (rules: Rule[]): Array<Record<string, unknown>> => {
     return rules.map(r => {
-        const fmtIPNet = (net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] }): string => {
-            const addrBytes = extractBytes(net.addr);
-            const maskBytes = extractBytes(net.mask);
-            if (!addrBytes) return '';
-            return formatIPNet(addrBytes, maskBytes);
-        };
-        const srcs = (r.srcs ?? []).map(fmtIPNet).filter(Boolean);
-        const dsts = (r.dsts ?? []).map(fmtIPNet).filter(Boolean);
+        const srcs = (r.srcs ?? []).map(formatIPNetItem).filter(Boolean);
+        const dsts = (r.dsts ?? []).map(formatIPNetItem).filter(Boolean);
         const fmtRange = (rng: { from?: number; to?: number }): { from: number; to: number } => ({
             from: rng.from ?? 0,
             to: rng.to ?? 0,

--- a/web/src/pages/modules/acl/chips.tsx
+++ b/web/src/pages/modules/acl/chips.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { Action } from '../../../api/acl';
 import { ActionKind, ACTION_KIND_LABELS } from '../../../api/acl';
-import { formatIPNet, toaster, copyToClipboard, extractBytes } from '../../../utils';
+import { toaster, copyToClipboard } from '../../../utils';
 import { getProtocolTone, IpAddressChip, ProtoChip as SharedProtoChip } from '../_shared/chips';
 
 // Protocol names per IANA IP protocol number.
@@ -119,14 +119,6 @@ interface IpNetChipProps {
 /** Renders a CIDR chip, colored differently for IPv4 vs IPv6. */
 export const IpNetChip: React.FC<IpNetChipProps> = ({ cidr }) => {
     return <IpAddressChip value={cidr} />;
-};
-
-/** Format an IPNet wire object to a CIDR string. */
-export const formatIPNetChip = (net: { addr?: string | Uint8Array | number[]; mask?: string | Uint8Array | number[] }): string => {
-    const addrBytes = extractBytes(net.addr);
-    const maskBytes = extractBytes(net.mask);
-    if (!addrBytes || addrBytes.length === 0) return '';
-    return formatIPNet(addrBytes, maskBytes);
 };
 
 interface ChipListModalProps<T> {

--- a/web/src/pages/modules/forward/SaveDiffModal.tsx
+++ b/web/src/pages/modules/forward/SaveDiffModal.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import type { Rule } from '../../../api/forward';
 import { ForwardMode } from '../../../api/forward';
-import { formatIPNet, extractBytes, dumpYamlDoc } from '../../../utils';
+import { formatIPNetItem, dumpYamlDoc } from '../../../utils';
 import { SaveDiffModal as SharedSaveDiffModal } from '../../../components';
 
 /** Serialize a rules array into the canonical YAML schema for diff display. */
@@ -14,18 +14,8 @@ export const rulesToDiffYaml = (rules: Rule[]): string => {
         };
 
         const devices = (r.devices ?? []).map(d => d.name ?? '').filter(Boolean);
-        const srcs = (r.srcs ?? []).map(net => {
-            const addrBytes = extractBytes(net.addr);
-            const maskBytes = extractBytes(net.mask);
-            if (!addrBytes) return '';
-            return formatIPNet(addrBytes, maskBytes);
-        }).filter(Boolean);
-        const dsts = (r.dsts ?? []).map(net => {
-            const addrBytes = extractBytes(net.addr);
-            const maskBytes = extractBytes(net.mask);
-            if (!addrBytes) return '';
-            return formatIPNet(addrBytes, maskBytes);
-        }).filter(Boolean);
+        const srcs = (r.srcs ?? []).map(formatIPNetItem).filter(Boolean);
+        const dsts = (r.dsts ?? []).map(formatIPNetItem).filter(Boolean);
         const vlan_ranges = (r.vlan_ranges ?? []).map(vr => ({
             from: vr.from ?? 0,
             to: vr.to ?? 0,


### PR DESCRIPTION
Consolidate three hand-reimplemented "wire IP-net to CIDR string" snippets onto the existing shared `formatIPNetItem` helper.

- Forward and acl save-diff serializers now map rows through `formatIPNetItem` instead of inline byte-extraction blocks.
- Drop the exported but unused duplicate formatter from the acl chips module.

The shared helper is behaviourally identical to the replaced snippets, so the rendered diffs are unchanged.