### PR TITLE
feat(dataplane): support --config flag for config path

### DIFF
--- a/dataplane/main.c
+++ b/dataplane/main.c
@@ -22,24 +22,35 @@ print_version(void) {
 
 static void
 print_usage(const char *prog) {
-	printf("Usage: %s [OPTIONS] CONFIG_PATH\n", prog);
+	printf("Usage: %s [OPTIONS] [CONFIG_PATH]\n", prog);
 	printf("Options:\n");
-	printf("  -v, --version   Print version information and exit\n");
-	printf("  -h, --help      Print this help message and exit\n");
+	printf("  -c, --config PATH   Path to the configuration file\n");
+	printf("  -v, --version       Print version information and exit\n");
+	printf("  -h, --help          Print this help message and exit\n");
+	printf("\n");
+	printf("The configuration file path may be passed either via the\n"
+	       "-c/--config option or as a positional CONFIG_PATH argument\n"
+	       "(kept for backward compatibility).\n");
 }
 
 int
 main(int argc, char **argv) {
 	static struct option long_options[] = {
+		{"config", required_argument, 0, 'c'},
 		{"version", no_argument, 0, 'v'},
 		{"help", no_argument, 0, 'h'},
 		{0, 0, 0, 0}
 	};
 
+	const char *config_path = NULL;
+
 	int opt;
-	while ((opt = getopt_long(argc, argv, "vh", long_options, NULL)) != -1
+	while ((opt = getopt_long(argc, argv, "c:vh", long_options, NULL)) != -1
 	) {
 		switch (opt) {
+		case 'c':
+			config_path = optarg;
+			break;
 		case 'v':
 			print_version();
 			return 0;
@@ -52,26 +63,35 @@ main(int argc, char **argv) {
 		}
 	}
 
-	if (optind >= argc) {
-		fprintf(stderr, "Error: CONFIG_PATH is required\n");
-		print_usage(argv[0]);
-		return -1;
+	// Fall back to the positional CONFIG_PATH argument for backward
+	// compatibility when -c/--config is not provided.
+	if (config_path == NULL) {
+		if (optind < argc) {
+			config_path = argv[optind];
+		} else {
+			fprintf(stderr,
+				"Error: configuration file path is required "
+				"(use -c/--config or pass it as a positional "
+				"argument)\n");
+			print_usage(argv[0]);
+			return -1;
+		}
 	}
 
 	// This function initializes and enables logging
 	log_enable_name("debug");
 
 	struct dataplane_config *config;
-	FILE *config_file = fopen(argv[optind], "r");
+	FILE *config_file = fopen(config_path, "r");
 	if (config_file == NULL) {
-		LOG(ERROR, "failed to open config file: %s", argv[optind]);
+		LOG(ERROR, "failed to open config file: %s", config_path);
 		return -1;
 	}
 	LOG(INFO, "initialize the dataplane config");
 	int rc = dataplane_config_init(config_file, &config);
 	fclose(config_file);
 	if (rc) {
-		LOG(ERROR, "invalid config file: %s", argv[optind]);
+		LOG(ERROR, "invalid config file: %s", config_path);
 		return -1;
 	}
 


### PR DESCRIPTION
Add a -c/--config option to specify the dataplane configuration file, matching how other YANET2 components accept their config. The previous positional CONFIG_PATH argument is still honored as a fallback for backward compatibility.