### PR TITLE
chore(claude): add ship-pr skill and drop phantom skill references

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: "architect"
 description: "Use this agent when the user asks for any development task in the YANET2 project — feature requests, bug fixes, refactoring, new modules, performance improvements, or architectural questions. This agent is the single entry point that analyzes requirements, plans implementation, and delegates to specialist agents."
-tools: Agent(coder-c, coder-go, coder-rust, coder-ui, networking-expert, reviewer, bug-hunter, performance-engineer, planner), AskUserQuestion, ExitPlanMode, Bash, Write, Read, WebFetch, WebSearch, LSP, Glob, Grep
+tools: Agent(coder-c, coder-go, coder-rust, coder-ui, networking-expert, reviewer, bug-hunter, performance-engineer, planner), AskUserQuestion, ExitPlanMode, Bash, Write, Read, WebFetch, WebSearch, LSP, Glob, Grep, Skill
 model: opus
 effort: high
 color: purple
@@ -173,21 +173,22 @@ The **throughput depth-first** counterpart to bug-hunter: where bug-hunter asks 
 
 It is read-mostly with **broad Bash** (build/run benches, `rte_rdtsc`/`perf` when present) and the same no-production-write guardrail as bug-hunter. **Measurement caveat:** this sandbox has no hugepage/NIC/traffic-gen rig — it measures microbenchmarks + rdtsc and does static hot-path analysis, NOT live line-rate; it labels every claim *measured* vs *analysis* and never fabricates a number.
 
-## Available Skills (Slash Commands)
+## Available Skills
 
-### `/go-bindings <module>`
+Skills are architect-driven runbooks for recurring, multi-phase workflows
+(scan → triage → delegate → verify → publish). They are auto-surfaced via their
+`SKILL.md` frontmatter. Current skills:
 
-Generates safe Go bindings for a module's C API. **Use when**: a module's C API has changed and Go bindings need updating, or when migrating from legacy `ffi.go` to `bindings/go/`.
-
-### `/refactor-module <module>`
-
-Refactors an existing module to match canonical patterns. **Use when**: user asks to bring a legacy module up to standard.
+- **`ship-pr`** — the canonical publish/merge runbook: branch from confirmed
+  `origin/main`, stage only intended files, open a scoped PR, drive CI to green,
+  address every review/Codex finding, and merge with the right squash/rebase
+  strategy. Use whenever work is ready to land.
+- **`raii-sweep`** — periodic C lifecycle-symmetry sweep (new/init/fini/free),
+  one prefix family per PR.
+- **`web-dedup`** — de-duplicate `web/` behind a mandatory zero-visual-diff
+  gate, one extraction per PR.
 
 ## Decision Framework
-
-### New module request
-
-→ Invoke `/new-module` skill. It handles everything.
 
 ### Bug fix in a single layer
 

--- a/.claude/agents/coder-go.md
+++ b/.claude/agents/coder-go.md
@@ -49,7 +49,7 @@ Key invariant: cache is ONLY updated AFTER backend call succeeds. Never optimist
 
 ### Current standard: `modules/*/bindings/go/c<name>/`
 
-Safe Go wrappers with separated `cgo.go` (raw C calls) and `safe.go` (Go-idiomatic API). Use `/go-bindings` skill to generate these.
+Safe Go wrappers with separated `cgo.go` (raw C calls) and `safe.go` (Go-idiomatic API).
 
 ### Legacy (migration target): `modules/*/controlplane/ffi.go`
 
@@ -94,16 +94,6 @@ Follow all Go conventions from project-level CLAUDE.md. Additional rules specifi
 - When creating `backend.go`, define the interface BEFORE writing `service.go` — the service depends on the backend interface.
 - When writing `service_test.go`, always include both table-driven unit tests AND concurrent race tests with goroutines calling the service under `go test -race`.
 - In FFI code: never pass Go slice headers to C — pass `unsafe.Pointer` to the underlying array with explicit length.
-
-## Available Skills
-
-### `/go-bindings <module>`
-
-Generates safe Go bindings for a module's C API. Use when a module's C API has been modified and Go bindings need updating, or when migrating from legacy `ffi.go` to `bindings/go/`.
-
-### `/refactor-module <module>`
-
-Refactors an existing module to canonical patterns. Use when bringing a legacy module up to standard.
 
 ## Self-Review Checklist
 

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: ship-pr
+description: >-
+  The canonical publish/merge runbook for landing a verified change on main:
+  branch from confirmed origin/main, stage ONLY the intended files, open a
+  scoped PR (no Claude footers), drive CI to green, address EVERY review/Codex
+  finding, and merge with the correct squash/rebase strategy — then clean up the
+  branch and worktree. Use this skill WHENEVER the user asks to ship, land,
+  publish, or merge work: "create a PR", "open a PR", "create and merge", "ship
+  this", "land this change", "оформи PR", "сделай PR", "залей", "влей в main",
+  "добейся вливания в main", "смержи", or any time finished, reviewer-approved
+  code needs to reach main. Covers parallel PRs, stacked PRs, prerequisite-
+  refactor splits, workflow-file OAuth scope, CI-flake reruns, and the recovery
+  recipes when a push/merge goes wrong.
+---
+
+# ship-pr
+
+Take a verified, reviewer-approved change and land it on `main` cleanly: branch from confirmed `origin/main`, stage exactly the intended files, open a scoped PR, drive CI green, address every review finding, and merge with the right strategy — then tear down the branch and worktree.
+
+You (the architect) drive this. You never write the code — that was already delegated to the coders and verified. This skill is purely the **publish workflow**: the git/`gh` choreography and the discipline that keeps a parallel, worktree-heavy repo from corrupting itself.
+
+**Invoking this skill is the explicit publish authorization.** The standing rule is "never commit/push/merge unless the user asks in the current turn" — asking to ship/land/merge IS that ask. Scope follows the verb: **"create a PR"** authorizes commit + push + PR + CI + addressing findings (NOT merge); **"create and merge" / "влей в main"** also authorizes the merge + cleanup. Delegated agents still never commit — you do.
+
+## Non-negotiables
+
+- **Don't publish unverified work.** Before branching, the change must have passed its verification gates AND a `reviewer` APPROVED pass (Phase 0). If either is missing, do that first — never ship unreviewed code.
+- **Branch from CONFIRMED `origin/main`**, never the session-start branch line and never a bare `git checkout -b` (HEAD may be on a parallel WIP branch and drag its commits in).
+- **Stage ONLY this change's files.** Never `git add -A`. Never stage pre-existing/unrelated dirty files. `git diff --cached -- <file>` each one, and cross-check every new untracked (`??`) file the change created is included.
+- **No destructive git with a dirty tree or without explicit permission** — no `reset --hard`/`checkout`/`restore`/`stash`/index ops that could wipe unrelated uncommitted work. Recovery recipes are in `references/branching-and-recovery.md`.
+- **Verify `git branch --show-current` before EVERY commit/amend/push** — a parallel actor can switch branches under you and land your amend on `main`.
+- **No `Co-Authored-By` / "Generated with Claude Code" footers** in commit messages or PR bodies. The harness suggests them; CLAUDE.md and the user forbid them. Check the body before `gh pr create`.
+- **Conventional, scoped subjects.** Commit + PR title: `<feat|fix|refactor|chore|perf|docs>(<scope>): <short description>`. A scopeless title is a convention violation.
+- **PR body**: capitalized, period-ended bullets; high-level (no symbol names, no code-level detail); `Closes #<n>.` when applicable. No `## Summary` header, no `Test plan` section.
+- **One logical change = one PR.** Out-of-scope prerequisites get their own PR first (see special cases).
+- **NEVER merge with an unaddressed review finding** — read BOTH PR-level reviews and inline Codex comments; fix or reply to every one.
+- **Never delete a branch (local or remote) until `gh pr merge` reports MERGED** — a failed merge on a torn-down branch auto-closes the PR.
+
+## Pipeline
+
+### Phase 0 — Precondition: is it ready to ship?
+
+1. **Gates green, run from repo ROOT** (each catches what the narrower command misses):
+   - Go → `go build ./...` (per-module CGO test pkgs under `modules/*/tests/...` are missed from `controlplane/`).
+   - C → `meson compile -C build` AND `meson test -C build` AND `make fuzz`.
+   - Rust → `cargo test --workspace`.
+   - For C changes reachable across the CGO boundary (`lib/controlplane`, `api/`, anything called from `controlplane/ffi` or `bindings/go`) → also `make test-asan` (meson-only ASan never crosses into the Go cgo tests).
+2. **A `reviewer` APPROVED pass exists** for this change. If the work is uncommitted, the reviewer ran WITHOUT isolation at main-tree paths; never in the same batch as the coder. If not yet done, run it now.
+3. If the change touched any `Cargo.toml` dependency, regenerate and stage the root `Cargo.lock` in THIS PR (`cargo build`, then `git diff -- Cargo.lock`) — CI passes without it, so the omission is silent.
+
+### Phase 1 — Branch from confirmed origin/main
+
+1. `git fetch origin main`.
+2. Create the branch off confirmed `origin/main`. Use a **shell-safe** name — `<type>/<scope>-<what>` (e.g. `chore/claude-ship-pr`): no `(`/`)` (bash mis-parses them unquoted in the `git`/`gh` commands below), and avoid a name that is also a path prefix of another branch (see stacked-PR ref):
+   - Worktree (preferred for isolation): `git worktree add .claude/worktrees/<name> -b <branch> origin/main` (gitignored location, never sibling dirs).
+   - Main checkout: `git checkout main && git fetch origin main && git checkout -b <branch> origin/main`.
+3. If the work already lives on a coder's worktree branch, just confirm that branch was forked from current `origin/main`; rebase it if stale (`git rebase origin/main`, never `git merge origin/main`).
+4. To run `go build`/`go test` inside a fresh worktree you must seed gitignored generated files — see `worktree-pb-seeding` (architect memory): rsync the `*.pb.go` and symlink `build/`.
+
+### Phase 2 — Stage exactly this change
+
+`git add` the explicit file list (never `-A`). `git diff --cached -- <file>` EACH staged file — an index entry can pick up unrelated hunks from a concurrent dirty file. Cross-check every new untracked (`??`) file is staged: omitting one ships a dangling import, and web CI is vitest-only (no build/tsc gate) so it stays green on a broken module graph.
+
+### Phase 3 — Commit
+
+Verify the branch first. Commit with a conventional scoped subject, high-level body, no footers. (Authorized only because invoking this skill is the publish ask.)
+
+### Phase 4 — Push & open the PR
+
+1. `git push -u origin <branch>` (from inside the worktree if used).
+2. `gh pr create` with explicit `--head <branch> --base main` (from a main checkout on `main`, omitting these errors head==base). Scoped title; body per the non-negotiables; **check the body for footers before creating**.
+3. `gh pr view <pr> --json files` — confirm ONLY this change's files are present. Extras (inherited WIP) → `git rebase --onto origin/main <wip-tip> <branch>`, force-push-with-lease, re-verify.
+4. **Workflow-file PRs**: pushing a commit touching `.github/workflows/` needs the git token to have `workflow` OAuth scope — you can't self-grant; the user must run `gh auth refresh -h github.com -s workflow`. A path-filtered workflow won't run when only its own YAML changes — its file must be in its own `paths:` filter to self-trigger.
+
+### Phase 5 — CI & review
+
+1. Wait on CI with `gh pr checks <pr> --watch` DIRECTLY — no upfront `sleep`, no sleep+re-poll loops. (Only justified extra: one short retry if `--watch` exits immediately with "no checks" right after a push.)
+2. **Flaky/infra failure** not attributable to the change: verify by reading the log and comparing the SAME workflow on the LATEST `origin/main` runs (a flake window can span several consecutive main runs and mimic determinism), then `gh run rerun <run-id> --failed`. The standalone `funtests` pull_request workflow is chronically broken — distinct from the build-matrix `Run Functional Tests` job.
+3. **Review findings**: read BOTH `gh pr view <pr> --json reviews` AND inline `gh api repos/yanet-platform/yanet2/pulls/<pr>/comments`. The `chatgpt-codex-connector` reviewer's inline P1/P2/P3 findings are often REAL. For each: FIX (amend pre-merge or follow-up) or REPLY why it's wrong. Main's ruleset requires thread resolution — after a fix, resolve the thread via GraphQL `resolveReviewThread(threadId)` and re-summon with a `@codex review` comment (force-push alone doesn't retrigger). After one addressed round per PR, merge — don't re-summon endlessly.
+
+### Phase 6 — Merge (only if "merge" was authorized)
+
+- **Single-commit PR** → `gh pr merge --admin --squash`.
+- **Multi-commit, deliberately structured history** → `--rebase` (preserve it).
+- **Multi-commit where extras are review fixups** → `--squash` WITH an explicit clean message: `--subject "<type>(<scope>): <title> (#N)" --body "<high-level or empty>"`. Never let GitHub's default squash body (a bullet list of every intermediate commit) land — the user calls that "каша" and it is a convention violation.
+- Updating the branch with newer main before merge → REBASE + force-with-lease, never `git merge origin/main`.
+
+### Phase 7 — Cleanup (from the MAIN checkout)
+
+Run all of this from the main checkout, never with cwd inside the worktree (removing it yanks cwd and chained git dies):
+
+1. `git worktree remove .claude/worktrees/<name>` (if used).
+2. `git checkout main && git pull`.
+3. Delete the branch local + remote: `git branch -D <branch>` and `git push origin --delete <branch>` (auto-delete is unreliable; ignore "remote ref does not exist"). Confirm no survivor with `git ls-remote --heads origin '<pattern>'`.
+
+## Special cases & recovery
+
+Detailed recipes live in `references/branching-and-recovery.md`:
+
+- **Parallel PRs touching a shared barrel** (`web/src/components/index.ts`, `hooks/index.ts`) — merge one at a time, rebase the rest first; never tear down a branch before MERGED.
+- **Stacked PRs** — child off parent branch, restack after a parent rebase with the OLD parent tip SHA.
+- **Prerequisite refactor** — split out-of-scope cleanup into its own PR first, merge, rebase the feature.
+- **Iterating an open PR's design** — amend + force-push, never close-and-reopen.
+- **Recovery** — amend landed on the wrong branch; wrong hunks staged; branch deleted before merge; never `reset --hard` with unrelated dirty files present.
+
+## End of run
+
+Report to the user: PR number(s) and state (open / merged), any review findings addressed, any flakes you re-ran, and (if "create a PR" not "merge") that CI is green and it's ready to merge on their word.

--- a/.claude/skills/ship-pr/references/branching-and-recovery.md
+++ b/.claude/skills/ship-pr/references/branching-and-recovery.md
@@ -1,0 +1,93 @@
+# ship-pr — special cases & recovery recipes
+
+Reach for these when a PR is not a single self-contained slice off `main`, or
+when a push/merge has gone wrong. The core linear flow is in `SKILL.md`; this
+file holds the situational branches.
+
+## Parallel PRs touching a shared barrel
+
+Multiple in-flight PRs that ALL append to the same barrel file
+(`web/src/components/index.ts`, `web/src/hooks/index.ts`, a Go re-export, a
+`mod.rs`) will CONFLICT on merge once the first lands.
+
+- Merge them **one at a time**. Before each subsequent merge, REBASE that
+  branch onto `origin/main` (never `git merge origin/main`) and force-push-with-lease.
+- **Never `git worktree remove` or delete a branch (local OR remote) until
+  `gh pr merge` reports the PR MERGED.** A `--squash` that hits a barrel
+  conflict fails mid-command; if you already tore down, you may delete an
+  UNMERGED branch and auto-close its PR.
+- Recovery if that happened: the commit survives in the object store —
+  `git branch <b> <sha>`, rebase onto `origin/main`, resolve the barrel
+  conflict (delegate the edit — it's code), re-push, open a fresh PR.
+- `gh pr merge --delete-branch` skips the REMOTE delete when the LOCAL delete
+  errors on a worktree-held branch — always `git ls-remote --heads origin
+  '<pattern>'` after cleanup and `git push origin --delete` any survivor.
+
+## Stacked PRs (child depends on parent's unmerged change)
+
+When PR-B's files depend on PR-A's not-yet-merged change:
+
+1. Build each branch in its own worktree. Fork B off A's branch
+   (`git worktree add .claude/worktrees/<b> -b <b-branch> <a-branch>`), and
+   populate B's worktree by copying the FINAL intended files so B's
+   diff-vs-base is exactly its own slice. Only the first PR usually needs a
+   trimmed-file edit via a coder.
+2. Open B with `gh pr edit --base <a-branch>` (or `--base` on create) so its
+   diff shows only B's slice.
+3. After A merges OR is rewritten (force-pushed): restack B with the OLD parent
+   tip SHA B was forked from, not the branch name —
+   `git rebase --onto origin/main <old-A-tip-sha> <b-branch>`, then
+   `git push --force-with-lease` and `gh pr edit --base main`. Passing the
+   branch name breaks once A itself has been rebased.
+4. **Branch names use dashes, not a name that is also a path prefix**: a branch
+   `bird-adapter/x` is rejected by the remote when a branch `bird-adapter`
+   exists (ref-directory conflict). Use `bird-adapter-x`.
+
+## Prerequisite refactor blocking a feature
+
+When a feature is blocked by a cleanup in shared/low-level code (dead-code
+removal, a shared-infra rename, an enum collision), land the cleanup as its OWN
+scoped `refactor`/`chore` PR first, merge it, then rebase the feature on top.
+Do NOT bundle the cleanup into the feature PR — the user explicitly prefers this
+decomposition ("that's out of scope") so each diff is independently justified.
+
+## Iterating an open PR's design
+
+Refining a design on an already-open PR → amend that branch + force-push-with-lease.
+Never close-and-reopen (churns PR numbers and loses the review thread).
+
+## Recovery recipes
+
+All of these avoid `git reset --hard`, which must NEVER run while unrelated
+dirty files sit in the tree (a partial `git stash push <paths>` covers only the
+named paths; everything else is wiped). To drop a stale local commit, use
+`git reset --soft`/`--mixed`, or `git stash push` WITHOUT paths then pop.
+
+### Amend landed on the wrong branch (parallel `git checkout main` under you)
+
+A parallel actor checked out `main` between your push and amend, so the amend
+clobbered upstream main and dropped your files. Recover without `reset --hard`:
+
+```
+git switch <intended-branch>
+git checkout <bad-commit> -- <path>     # pull your files off the stray commit
+# re-amend the correct branch
+git branch -f main origin/main          # restore main
+git push --force-with-lease
+gh pr view <pr> --json files            # verify the PR file list
+```
+
+### Wrong hunks got staged
+
+`git restore --staged <file>`, then `git apply --cached` a hand-crafted patch of
+just the intended hunks. Preserves any parallel dirty work in the same file.
+
+### Branch deleted before merge / PR auto-closed
+
+The commit is still in the object store: `git branch <b> <sha>` (find the SHA in
+the reflog or `gh`/CI logs), rebase onto `origin/main`, re-push, open a fresh PR.
+
+### A file was wrongly reverted
+
+Reconstruct from the captured diff in the conversation context; regenerate
+`go.sum` via `go` tooling (not by hand) and `Cargo.lock` via `cargo build`.


### PR DESCRIPTION
- Add the ship-pr skill: the canonical publish/merge runbook the architect follows to land a verified change on main, covering branching from confirmed origin/main, precise staging, scoped PRs, CI and review handling, merge strategy, and recovery recipes.
- Remove documentation of three skills (go-bindings, refactor-module, new-module) that were referenced in the architect and Go coder agent definitions but never existed as files.