### PR TITLE
feat(dataplane): add configurable IOVA mode for EAL

### DIFF
--- a/dataplane/config.c
+++ b/dataplane/config.c
@@ -49,6 +49,7 @@ enum state {
 	state_dataplane,
 	state_dataplane_storage,
 	state_dataplane_dpdk_memory,
+	state_dataplane_iova_mode,
 
 	state_instances,
 	state_instance,
@@ -145,6 +146,12 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					strtol(start, &end, 10);
 				if (*end != '\0')
 					goto error;
+				state = state_dataplane;
+				break;
+			case state_dataplane_iova_mode:
+				strtcpy(dataplane->iova_mode,
+					start,
+					sizeof(dataplane->iova_mode));
 				state = state_dataplane;
 				break;
 			case state_loglevel:
@@ -291,6 +298,8 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					state = state_dataplane_storage;
 				} else if (!strcmp("dpdk_memory", start)) {
 					state = state_dataplane_dpdk_memory;
+				} else if (!strcmp("iova_mode", start)) {
+					state = state_dataplane_iova_mode;
 				} else if (!strcmp("instances", start)) {
 					state = state_instances;
 				} else if (!strcmp("devices", start)) {

--- a/dataplane/config.h
+++ b/dataplane/config.h
@@ -45,6 +45,13 @@ struct dataplane_config {
 	char storage[80];
 	uint64_t dpdk_memory;
 
+	// IOVA mode passed to DPDK EAL via --iova-mode.
+	// Empty string means "do not pass the flag" (EAL autodetect).
+	// Valid values: "pa" (physical addresses, required for vfio
+	// no-iommu / uio in VMs without an IOMMU) or "va" (virtual
+	// addresses, required by virtio_user with the vhost-net backend).
+	char iova_mode[8];
+
 	uint16_t numa_count;
 
 	uint16_t instance_count;

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -505,7 +505,11 @@ dataplane_init(
 
 	LOG(INFO, "initialize dpdk");
 	int rc = dpdk_init(
-		binary, config->dpdk_memory, pci_port_count, pci_port_names
+		binary,
+		config->dpdk_memory,
+		config->iova_mode,
+		pci_port_count,
+		pci_port_names
 	);
 	free(pci_port_names);
 	if (rc == -1) {

--- a/dataplane/dpdk.c
+++ b/dataplane/dpdk.c
@@ -48,6 +48,7 @@ int
 dpdk_init(
 	const char *binary,
 	uint64_t dpdk_memory,
+	const char *iova_mode,
 	size_t port_count,
 	const char *const *port_names
 ) {
@@ -71,6 +72,19 @@ dpdk_init(
 	}
 	if (eal_args_add(&args, "%lu", dpdk_memory)) {
 		goto error;
+	}
+
+	// Explicitly pin the IOVA mode when requested via configuration.
+	// This is required inside VMs without an IOMMU, where devices are
+	// bound to vfio-pci in no-iommu mode (or uio): such devices need
+	// IOVA as physical addresses ("pa"), but EAL may otherwise pick
+	// "va" (e.g. because of a virtio_user/vhost-net port), which makes
+	// the no-iommu PCI device fail to probe.
+	if (iova_mode != NULL && iova_mode[0] != '\0') {
+		LOG(INFO, "force DPDK IOVA mode to '%s'", iova_mode);
+		if (eal_args_add(&args, "--iova-mode=%s", iova_mode)) {
+			goto error;
+		}
 	}
 
 	args.argv[args.argc] = NULL;

--- a/dataplane/dpdk.h
+++ b/dataplane/dpdk.h
@@ -9,6 +9,7 @@ int
 dpdk_init(
 	const char *binary,
 	uint64_t dpdk_memory,
+	const char *iova_mode,
 	size_t port_count,
 	const char *const *port_names
 );


### PR DESCRIPTION
Add an optional iova_mode field to the dataplane config that is passed to DPDK EAL via --iova-mode. When unset, EAL autodetection is preserved. This allows pinning physical-address IOVA inside VMs without an IOMMU, where vfio-pci no-iommu devices fail to probe if EAL selects virtual addresses because of a virtio_user vhost-net port.