### PR TITLE
feat(metrics): add predicate-based pruning to the metric map

### DIFF
--- a/common/go/metrics/map.go
+++ b/common/go/metrics/map.go
@@ -27,19 +27,20 @@ func NewMetricMap[T any]() *MetricMap[T] {
 	return &MetricMap[T]{entries: map[uint64][]metricEntry[T]{}}
 }
 
-func (m *MetricMap[T]) tryGet(id MetricID, h uint64) *T {
+func (m *MetricMap[T]) tryGet(id MetricID, h uint64) (T, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
 	if bucket, ok := m.entries[h]; ok {
 		for idx := range bucket {
 			if bucket[idx].id.Equals(id) {
-				return &bucket[idx].metric
+				return bucket[idx].metric, true
 			}
 		}
 	}
 
-	return nil
+	var zero T
+	return zero, false
 }
 
 func (m *MetricMap[T]) create(id MetricID, h uint64, create func() T) T {
@@ -62,11 +63,39 @@ func (m *MetricMap[T]) create(id MetricID, h uint64, create func() T) T {
 func (m *MetricMap[T]) GetOrCreate(id MetricID, create func() T) T {
 	h := hashID(id)
 
-	if existent := m.tryGet(id, h); existent != nil {
-		return *existent
+	if metric, ok := m.tryGet(id, h); ok {
+		return metric
 	}
 
 	return m.create(id, h, create)
+}
+
+// DeleteWhere removes every stored metric whose (ID, metric) satisfies pred.
+//
+// Returns the number of metrics removed.
+//
+// The predicate receives a cloned MetricID so it cannot mutate stored map
+// state. Buckets are compacted in place. Hash buckets that become empty are
+// deleted so the map does not accumulate empty slots.
+func (m *MetricMap[T]) DeleteWhere(pred func(MetricID, T) bool) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	removed := 0
+	for h, bucket := range m.entries {
+		kept := slices.DeleteFunc(bucket, func(entry metricEntry[T]) bool {
+			return pred(entry.id.Clone(), entry.metric)
+		})
+		removed += len(bucket) - len(kept)
+
+		if len(kept) == 0 {
+			delete(m.entries, h)
+		} else {
+			m.entries[h] = kept
+		}
+	}
+
+	return removed
 }
 
 // Metrics returns a slice of references of all stored metrics.

--- a/common/go/metrics/map_test.go
+++ b/common/go/metrics/map_test.go
@@ -181,6 +181,95 @@ func TestMetricMapIntegration(t *testing.T) {
 	})
 }
 
+// TestMetricMapDeleteWhere verifies that DeleteWhere removes exactly the entries
+// matching the predicate and cleans up empty internal buckets.
+func TestMetricMapDeleteWhere(t *testing.T) {
+	t.Run("DeleteNone", func(t *testing.T) {
+		m := NewMetricMap[*Counter]()
+		for idx := range 3 {
+			id := MetricID{Name: fmt.Sprintf("metric%d", idx)}
+			m.GetOrCreate(id, func() *Counter { return &Counter{} })
+		}
+
+		n := m.DeleteWhere(func(MetricID, *Counter) bool { return false })
+
+		assert.Equal(t, 0, n, "DeleteWhere(false) should remove nothing")
+		assert.Len(t, m.Metrics(), 3, "all metrics should remain")
+	})
+
+	t.Run("DeleteSome", func(t *testing.T) {
+		m := NewMetricMap[*Counter]()
+		for idx := range 4 {
+			id := MetricID{Name: fmt.Sprintf("metric%d", idx)}
+			m.GetOrCreate(id, func() *Counter { return &Counter{} })
+		}
+
+		n := m.DeleteWhere(func(id MetricID, _ *Counter) bool {
+			return id.Name == "metric1" || id.Name == "metric3"
+		})
+
+		assert.Equal(t, 2, n, "DeleteWhere should return count of removed metrics")
+		refs := m.Metrics()
+		assert.Len(t, refs, 2, "two metrics should remain")
+		for _, ref := range refs {
+			assert.NotEqual(t, "metric1", ref.ID.Name, "metric1 should be removed")
+			assert.NotEqual(t, "metric3", ref.ID.Name, "metric3 should be removed")
+		}
+	})
+
+	t.Run("DeleteAll", func(t *testing.T) {
+		m := NewMetricMap[*Counter]()
+		for idx := range 3 {
+			id := MetricID{Name: fmt.Sprintf("metric%d", idx)}
+			m.GetOrCreate(id, func() *Counter { return &Counter{} })
+		}
+
+		n := m.DeleteWhere(func(MetricID, *Counter) bool { return true })
+
+		assert.Equal(t, 3, n, "DeleteWhere(true) should remove all metrics")
+		assert.Empty(t, m.Metrics(), "map should be empty after deleting all")
+	})
+
+	t.Run("EmptyBucketCleanup", func(t *testing.T) {
+		m := NewMetricMap[*Counter]()
+		id := MetricID{Name: "only"}
+		m.GetOrCreate(id, func() *Counter { return &Counter{} })
+
+		m.DeleteWhere(func(MetricID, *Counter) bool { return true })
+
+		// The internal bucket map should have no entries after emptying.
+		m.mu.RLock()
+		bucketCount := len(m.entries)
+		m.mu.RUnlock()
+
+		assert.Equal(t, 0, bucketCount, "empty buckets should be removed from the map")
+	})
+
+	t.Run("DeleteByValue", func(t *testing.T) {
+		m := NewMetricMap[*Counter]()
+		for idx := range 4 {
+			id := MetricID{Name: fmt.Sprintf("metric%d", idx)}
+			c := m.GetOrCreate(id, func() *Counter { return &Counter{} })
+			// Give odd-indexed metrics a non-zero count.
+			if idx%2 != 0 {
+				c.Add(uint64(idx * 10))
+			}
+		}
+
+		// Delete only metrics whose counter value is zero (keying off the value).
+		n := m.DeleteWhere(func(_ MetricID, c *Counter) bool {
+			return c.Load() == 0
+		})
+
+		assert.Equal(t, 2, n, "should remove the two zero-value metrics")
+		refs := m.Metrics()
+		assert.Len(t, refs, 2, "two non-zero metrics should remain")
+		for _, ref := range refs {
+			assert.NotZero(t, ref.Value.Load(), "remaining metrics should have non-zero value")
+		}
+	})
+}
+
 // Benchmarks
 
 func BenchmarkGetOrCreate(b *testing.B) {


### PR DESCRIPTION
Add a concurrent-safe operation to remove metric-map entries matching a predicate, returning the count removed and dropping emptied buckets.

Have the internal lookup return metrics by value so the map can compact its storage in place without racing lock-free readers.