### PR TITLE
feat(metrics): add grpcmetrics gRPC call-metrics helper and adopt it in acl

### DIFF
--- a/common/go/grpcmetrics/grpcmetrics.go
+++ b/common/go/grpcmetrics/grpcmetrics.go
@@ -1,0 +1,285 @@
+// Package grpcmetrics provides an opt-in gRPC unary server interceptor that
+// records per-call metrics and renders them to commonpb.Metric.
+//
+// Each ServerMetrics instance tracks three metric families:
+//   - grpc_server_started_total    — counter per {grpc_type, grpc_service, grpc_method[, config]}
+//   - grpc_server_handled_total    — counter per {grpc_type, grpc_service, grpc_method, grpc_code[, config]}
+//   - grpc_server_handling_seconds — histogram per {grpc_type, grpc_service, grpc_method[, config]}
+//
+// Label names follow the go-grpc-prometheus (go-grpc-middleware/providers/prometheus)
+// server convention. grpc_type is always "unary"; streaming is a documented
+// future follow-up. The optional "config" label is emitted when the
+// Labeler provides it.
+//
+// Stale series are pruned via a retention predicate.
+package grpcmetrics
+
+import (
+	"context"
+	"maps"
+	"strings"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+)
+
+const (
+	labelType    = "grpc_type"
+	labelService = "grpc_service"
+	labelMethod  = "grpc_method"
+	labelCode    = "grpc_code"
+)
+
+const grpcTypeUnary = "unary"
+
+// DefaultBuckets is the default histogram bucket boundary set in seconds.
+//
+// The ladder covers sub-millisecond to multi-second latencies and matches the
+// boundaries the ACL module used before migration to this library.
+var DefaultBuckets = []float64{
+	0.001, 0.002, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.15, 0.2,
+	0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 3, 4, 5,
+}
+
+// Labeler derives extra per-call labels from a unary request.
+//
+// It is called once per RPC before the handler runs. A nil return means no
+// extra labels are attached.
+type Labeler func(fullMethod string, req any) metrics.Labels
+
+// Retention reports which series to keep when pruning stale metrics.
+//
+// It is invoked once per Collect, OUTSIDE the metric maps' lock, and returns a
+// pure predicate that the collector then applies to each series under the
+// lock.
+//
+// Snapshot any external state (e.g. the set of live configs) in the outer
+// function so the returned predicate takes no locks of its own.
+type Retention func() func(metrics.MetricID) bool
+
+type callSeries struct {
+	started  metrics.Counter
+	handling *metrics.Histogram
+}
+
+// newCallSeries creates a callSeries with a latency histogram over buckets.
+func newCallSeries(buckets []float64) *callSeries {
+	return &callSeries{handling: metrics.NewHistogram(buckets)}
+}
+
+// AppendTo appends this series' metrics, labelled with labels, to out.
+func (m *callSeries) AppendTo(out []*commonpb.Metric, labels []*commonpb.Label) []*commonpb.Metric {
+	return append(out,
+		&commonpb.Metric{
+			Name:   "grpc_server_started_total",
+			Labels: labels,
+			Value:  commonpb.MetricValueToProto(&m.started),
+		},
+		&commonpb.Metric{
+			Name:   "grpc_server_handling_seconds",
+			Labels: labels,
+			Value:  commonpb.MetricValueToProto(m.handling),
+		},
+	)
+}
+
+// RecordStart counts a started call.
+func (m *callSeries) RecordStart() {
+	m.started.Inc()
+}
+
+// RecordFinish observes the handling latency in seconds.
+func (m *callSeries) RecordFinish(seconds float64) {
+	m.handling.Observe(seconds)
+}
+
+type codeSeries struct {
+	count metrics.Counter
+}
+
+// AppendTo appends this series' metric, labelled with labels, to out.
+func (m *codeSeries) AppendTo(out []*commonpb.Metric, labels []*commonpb.Label) []*commonpb.Metric {
+	return append(out, &commonpb.Metric{
+		Name:   "grpc_server_handled_total",
+		Labels: labels,
+		Value:  commonpb.MetricValueToProto(&m.count),
+	})
+}
+
+// Record counts a handled call (by status code).
+func (m *codeSeries) Record() {
+	m.count.Inc()
+}
+
+// ServerMetrics records unary gRPC server call metrics.
+type ServerMetrics struct {
+	buckets   []float64
+	labeler   Labeler
+	retention Retention
+	clock     func() time.Time
+
+	calls   *metrics.MetricMap[*callSeries]
+	handled *metrics.MetricMap[*codeSeries]
+}
+
+// Factory builds a ServerMetrics bound to a caller-supplied retention
+// provider.
+//
+// It lets the construction site own label extraction and buckets while
+// the service injects its own retention provider, breaking the otherwise
+// cyclic dependency between a service and its metrics collector.
+type Factory func(retention Retention) *ServerMetrics
+
+// NewFactory returns a Factory that applies the given options plus the
+// retention provider supplied when the factory is invoked.
+//
+// Pass construction options here (labeler, buckets) but not WithRetention —
+// the provider is appended at call time.
+func NewFactory(options ...Option) Factory {
+	return func(retention Retention) *ServerMetrics {
+		opts := make([]Option, 0, len(options)+1)
+		opts = append(opts, options...)
+		opts = append(opts, WithRetention(retention))
+		return New(opts...)
+	}
+}
+
+// New creates a new ServerMetrics with the supplied options.
+func New(options ...Option) *ServerMetrics {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+	return &ServerMetrics{
+		buckets:   opts.Buckets,
+		labeler:   opts.Labeler,
+		retention: opts.Retention,
+		clock:     opts.Clock,
+		calls:     metrics.NewMetricMap[*callSeries](),
+		handled:   metrics.NewMetricMap[*codeSeries](),
+	}
+}
+
+// UnaryServerInterceptor returns a gRPC unary server interceptor that records
+// started, handled, and handling-latency metrics for every call.
+func (m *ServerMetrics) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp any, err error) {
+		start := m.clock()
+
+		extra := m.labeler(info.FullMethod, req)
+
+		service, method := splitFullMethod(info.FullMethod)
+		callID := m.callID(service, method, extra)
+		call := m.calls.GetOrCreate(callID, func() *callSeries {
+			return newCallSeries(m.buckets)
+		})
+		call.RecordStart()
+
+		defer func() {
+			r := recover()
+			var code codes.Code
+			if r != nil {
+				code = codes.Unknown
+			} else {
+				code = status.Code(err)
+			}
+			m.recordExit(call, service, method, extra, code, start)
+			if r != nil {
+				panic(r)
+			}
+		}()
+
+		resp, err = handler(ctx, req)
+		return resp, err
+	}
+}
+
+func (m *ServerMetrics) recordExit(
+	call *callSeries,
+	service string,
+	method string,
+	extra metrics.Labels,
+	code codes.Code,
+	start time.Time,
+) {
+	durationSeconds := m.clock().Sub(start).Seconds()
+	call.RecordFinish(durationSeconds)
+
+	handledID := m.handledID(service, method, code.String(), extra)
+	handled := m.handled.GetOrCreate(handledID, func() *codeSeries {
+		return &codeSeries{}
+	})
+	handled.Record()
+}
+
+// Collect returns the current snapshot of all metric series as commonpb.Metric
+// values, pruning stale series first.
+func (m *ServerMetrics) Collect() []*commonpb.Metric {
+	m.reconcile()
+
+	var out []*commonpb.Metric
+	for _, entry := range m.calls.Metrics() {
+		out = entry.Value.AppendTo(out, commonpb.MetricLabelsToProto(entry.ID.Labels))
+	}
+	for _, entry := range m.handled.Metrics() {
+		out = entry.Value.AppendTo(out, commonpb.MetricLabelsToProto(entry.ID.Labels))
+	}
+
+	return out
+}
+
+// reconcile prunes series the retention predicate no longer keeps.
+func (m *ServerMetrics) reconcile() {
+	keep := m.retention()
+	m.calls.DeleteWhere(func(id metrics.MetricID, _ *callSeries) bool {
+		return !keep(id)
+	})
+	m.handled.DeleteWhere(func(id metrics.MetricID, _ *codeSeries) bool {
+		return !keep(id)
+	})
+}
+
+func (m *ServerMetrics) callID(service, method string, extra metrics.Labels) metrics.MetricID {
+	labels := metrics.Labels{
+		labelType:    grpcTypeUnary,
+		labelService: service,
+		labelMethod:  method,
+	}
+	maps.Copy(labels, extra)
+	return metrics.MetricID{Labels: labels}
+}
+
+func (m *ServerMetrics) handledID(service, method, code string, extra metrics.Labels) metrics.MetricID {
+	labels := metrics.Labels{
+		labelType:    grpcTypeUnary,
+		labelService: service,
+		labelMethod:  method,
+		labelCode:    code,
+	}
+	maps.Copy(labels, extra)
+	return metrics.MetricID{Labels: labels}
+}
+
+// splitFullMethod splits a gRPC full method ("/pkg.Service/Method") into its
+// fully-qualified service and method names.
+//
+// A malformed input with no service segment yields an empty service and the
+// whole remainder as the method.
+func splitFullMethod(fullMethod string) (service, method string) {
+	trimmed := strings.TrimPrefix(fullMethod, "/")
+	if idx := strings.LastIndex(trimmed, "/"); idx >= 0 {
+		return trimmed[:idx], trimmed[idx+1:]
+	}
+
+	return "", trimmed
+}

--- a/common/go/grpcmetrics/grpcmetrics_test.go
+++ b/common/go/grpcmetrics/grpcmetrics_test.go
@@ -1,0 +1,384 @@
+package grpcmetrics
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+)
+
+// fakeInfo builds a grpc.UnaryServerInfo for tests.
+func fakeInfo(method string) *grpc.UnaryServerInfo {
+	return &grpc.UnaryServerInfo{FullMethod: method}
+}
+
+// okHandler is a gRPC handler that succeeds.
+func okHandler(_ context.Context, req any) (any, error) {
+	return req, nil
+}
+
+// errHandler returns a gRPC status error with the given code.
+func errHandler(code codes.Code) grpc.UnaryHandler {
+	return func(_ context.Context, _ any) (any, error) {
+		return nil, status.Errorf(code, "test error")
+	}
+}
+
+// panicHandler panics with a string value.
+func panicHandler(_ context.Context, _ any) (any, error) {
+	panic("test panic")
+}
+
+// findMetric returns the metric from out matching name and the exact label set, or nil.
+func findMetric(metrics []*commonpb.Metric, name string, labels map[string]string) *commonpb.Metric {
+	for _, m := range metrics {
+		if m.Name != name {
+			continue
+		}
+		got := map[string]string{}
+		for _, l := range m.Labels {
+			got[l.Name] = l.Value
+		}
+		match := true
+		for k, v := range labels {
+			if got[k] != v {
+				match = false
+				break
+			}
+		}
+		if match && len(got) == len(labels) {
+			return m
+		}
+	}
+	return nil
+}
+
+func counterValue(m *commonpb.Metric) uint64 {
+	if c, ok := m.Value.(*commonpb.Metric_Counter); ok {
+		return c.Counter
+	}
+	return 0
+}
+
+func histogramTotal(m *commonpb.Metric) uint64 {
+	if h, ok := m.Value.(*commonpb.Metric_Histogram); ok {
+		return h.Histogram.TotalCount
+	}
+	return 0
+}
+
+// TestInterceptorOK verifies a successful unary call records started, the
+// handling-seconds observation, and handled with grpc_code=OK.
+func TestInterceptorOK(t *testing.T) {
+	serverMetrics := New()
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	_, err := interceptor(t.Context(), nil, fakeInfo("/svc/Method"), okHandler)
+	require.NoError(t, err)
+
+	out := serverMetrics.Collect()
+	baseLabels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "Method",
+	}
+
+	started := findMetric(out, "grpc_server_started_total", baseLabels)
+	require.NotNil(t, started, "grpc_server_started_total should be present")
+	assert.Equal(t, uint64(1), counterValue(started))
+
+	handling := findMetric(out, "grpc_server_handling_seconds", baseLabels)
+	require.NotNil(t, handling, "grpc_server_handling_seconds should be present")
+	assert.Equal(t, uint64(1), histogramTotal(handling))
+
+	handledLabels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "Method",
+		"grpc_code":    codes.OK.String(),
+	}
+	handled := findMetric(out, "grpc_server_handled_total", handledLabels)
+	require.NotNil(t, handled, "grpc_server_handled_total should be present")
+	assert.Equal(t, uint64(1), counterValue(handled))
+}
+
+// TestInterceptorErrorCode verifies that a handler returning a gRPC status
+// error records handled with the matching grpc_code and no OK series.
+func TestInterceptorErrorCode(t *testing.T) {
+	serverMetrics := New()
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	_, err := interceptor(t.Context(), nil, fakeInfo("/svc/Method"), errHandler(codes.NotFound))
+	require.Error(t, err)
+
+	out := serverMetrics.Collect()
+
+	handledLabels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "Method",
+		"grpc_code":    codes.NotFound.String(),
+	}
+	handled := findMetric(out, "grpc_server_handled_total", handledLabels)
+	require.NotNil(t, handled, "grpc_server_handled_total[NotFound] should be present")
+	assert.Equal(t, uint64(1), counterValue(handled))
+
+	okLabels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "Method",
+		"grpc_code":    codes.OK.String(),
+	}
+	assert.Nil(t, findMetric(out, "grpc_server_handled_total", okLabels), "OK series should not exist")
+}
+
+// TestInterceptorLabeler verifies that extra labels from the Labeler are
+// attached to all three metric families.
+func TestInterceptorLabeler(t *testing.T) {
+	serverMetrics := New(
+		WithLabeler(func(_ string, req any) metrics.Labels {
+			if s, ok := req.(string); ok {
+				return metrics.Labels{"config": s}
+			}
+			return nil
+		}),
+	)
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	_, err := interceptor(t.Context(), "mycfg", fakeInfo("/svc/Foo"), okHandler)
+	require.NoError(t, err)
+
+	out := serverMetrics.Collect()
+	labels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "Foo",
+		"config":       "mycfg",
+	}
+
+	started := findMetric(out, "grpc_server_started_total", labels)
+	require.NotNil(t, started, "grpc_server_started_total should carry config label")
+	assert.Equal(t, uint64(1), counterValue(started))
+
+	handling := findMetric(out, "grpc_server_handling_seconds", labels)
+	require.NotNil(t, handling, "grpc_server_handling_seconds should carry config label")
+
+	handledLabels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "Foo",
+		"grpc_code":    codes.OK.String(),
+		"config":       "mycfg",
+	}
+	handled := findMetric(out, "grpc_server_handled_total", handledLabels)
+	require.NotNil(t, handled, "grpc_server_handled_total should carry config label")
+	assert.Equal(t, uint64(1), counterValue(handled))
+}
+
+// TestInterceptorPanicRecordedAndRePanics verifies that a panicking handler is
+// recorded as grpc_code=Unknown and the panic propagates to the caller.
+func TestInterceptorPanicRecordedAndRePanics(t *testing.T) {
+	serverMetrics := New()
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	assert.Panics(t, func() {
+		_, _ = interceptor(t.Context(), nil, fakeInfo("/svc/Panic"), panicHandler)
+	}, "interceptor should re-panic")
+
+	out := serverMetrics.Collect()
+
+	handledLabels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "Panic",
+		"grpc_code":    codes.Unknown.String(),
+	}
+	handled := findMetric(out, "grpc_server_handled_total", handledLabels)
+	require.NotNil(t, handled, "panic should be recorded as Unknown code")
+	assert.Equal(t, uint64(1), counterValue(handled))
+
+	histLabels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "Panic",
+	}
+	handling := findMetric(out, "grpc_server_handling_seconds", histLabels)
+	require.NotNil(t, handling, "handling histogram should be recorded even on panic")
+	assert.Equal(t, uint64(1), histogramTotal(handling))
+}
+
+// TestReconcileRetention verifies that Collect() prunes series whose config
+// label is absent from the retention predicate while preserving live and
+// no-config series.
+func TestReconcileRetention(t *testing.T) {
+	alive := map[string]struct{}{"alive": {}}
+
+	serverMetrics := New(
+		WithLabeler(func(_ string, req any) metrics.Labels {
+			if s, ok := req.(string); ok {
+				return metrics.Labels{"config": s}
+			}
+			return nil
+		}),
+		WithRetention(func() func(metrics.MetricID) bool {
+			snapshot := alive
+			return func(id metrics.MetricID) bool {
+				config := id.Labels["config"]
+				if config == "" {
+					return true
+				}
+				_, ok := snapshot[config]
+				return ok
+			}
+		}),
+	)
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	// Record calls for two configs.
+	_, _ = interceptor(t.Context(), "alive", fakeInfo("/svc/M"), okHandler)
+	_, _ = interceptor(t.Context(), "dead", fakeInfo("/svc/M"), okHandler)
+	// Record a call without a config label.
+	_, _ = interceptor(t.Context(), nil, fakeInfo("/svc/NoConfig"), okHandler)
+
+	// Remove "dead" from the live set.
+	alive = map[string]struct{}{"alive": {}}
+
+	out := serverMetrics.Collect()
+
+	aliveStarted := findMetric(out, "grpc_server_started_total",
+		map[string]string{
+			"grpc_type":    "unary",
+			"grpc_service": "svc",
+			"grpc_method":  "M",
+			"config":       "alive",
+		})
+	require.NotNil(t, aliveStarted, "alive config series should be kept")
+
+	deadStarted := findMetric(out, "grpc_server_started_total",
+		map[string]string{
+			"grpc_type":    "unary",
+			"grpc_service": "svc",
+			"grpc_method":  "M",
+			"config":       "dead",
+		})
+	assert.Nil(t, deadStarted, "dead config series should be pruned")
+
+	noConfig := findMetric(out, "grpc_server_started_total",
+		map[string]string{
+			"grpc_type":    "unary",
+			"grpc_service": "svc",
+			"grpc_method":  "NoConfig",
+		})
+	require.NotNil(t, noConfig, "no-config series should not be pruned by retention")
+}
+
+// TestNewFactory verifies that the retention provider injected at call time
+// drives pruning: the alive series is kept and the dead series is removed on
+// Collect().
+func TestNewFactory(t *testing.T) {
+	alive := map[string]struct{}{"alive": {}}
+
+	factory := NewFactory(
+		WithLabeler(func(_ string, req any) metrics.Labels {
+			if s, ok := req.(string); ok {
+				return metrics.Labels{"config": s}
+			}
+			return nil
+		}),
+	)
+
+	serverMetrics := factory(func() func(metrics.MetricID) bool {
+		snapshot := alive
+		return func(id metrics.MetricID) bool {
+			config := id.Labels["config"]
+			if config == "" {
+				return true
+			}
+			_, ok := snapshot[config]
+			return ok
+		}
+	})
+	require.NotNil(t, serverMetrics)
+
+	interceptor := serverMetrics.UnaryServerInterceptor()
+	_, err := interceptor(t.Context(), "alive", fakeInfo("/svc/M"), okHandler)
+	require.NoError(t, err)
+	_, err = interceptor(t.Context(), "dead", fakeInfo("/svc/M"), okHandler)
+	require.NoError(t, err)
+
+	out := serverMetrics.Collect()
+
+	aliveMetric := findMetric(out, "grpc_server_started_total",
+		map[string]string{
+			"grpc_type":    "unary",
+			"grpc_service": "svc",
+			"grpc_method":  "M",
+			"config":       "alive",
+		})
+	deadMetric := findMetric(out, "grpc_server_started_total",
+		map[string]string{
+			"grpc_type":    "unary",
+			"grpc_service": "svc",
+			"grpc_method":  "M",
+			"config":       "dead",
+		})
+
+	require.NotNil(t, aliveMetric, "alive config series should be kept")
+	assert.Nil(t, deadMetric, "dead config series should be pruned")
+}
+
+// TestParallelCallsRace exercises concurrent interceptor calls and Collect()
+// invocations under the race detector to catch data races.
+func TestParallelCallsRace(t *testing.T) {
+	serverMetrics := New(
+		WithLabeler(func(_ string, req any) metrics.Labels {
+			if s, ok := req.(string); ok {
+				return metrics.Labels{"config": s}
+			}
+			return nil
+		}),
+	)
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	configs := []string{"a", "b", "c", ""}
+	methods := []string{"/svc/One", "/svc/Two"}
+
+	var wg sync.WaitGroup
+	for range 50 {
+		for _, config := range configs {
+			for _, method := range methods {
+				wg.Add(1)
+				go func(config, method string) {
+					defer wg.Done()
+					var req any
+					if config != "" {
+						req = config
+					}
+					_, _ = interceptor(t.Context(), req, fakeInfo(method), okHandler)
+				}(config, method)
+			}
+		}
+	}
+
+	// Concurrent Collect() calls alongside the interceptors.
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = serverMetrics.Collect()
+		}()
+	}
+
+	wg.Wait()
+
+	out := serverMetrics.Collect()
+	assert.NotEmpty(t, out)
+}

--- a/common/go/grpcmetrics/options.go
+++ b/common/go/grpcmetrics/options.go
@@ -1,0 +1,66 @@
+package grpcmetrics
+
+import (
+	"time"
+
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+)
+
+// Option configures a ServerMetrics instance.
+type Option func(*options)
+
+type options struct {
+	Buckets   []float64
+	Labeler   Labeler
+	Retention Retention
+	Clock     func() time.Time
+}
+
+func newOptions() *options {
+	return &options{
+		Buckets: DefaultBuckets,
+		Labeler: func(string, any) metrics.Labels {
+			return nil
+		},
+		Retention: func() func(metrics.MetricID) bool {
+			return func(metrics.MetricID) bool {
+				return true
+			}
+		},
+		Clock: time.Now,
+	}
+}
+
+// WithBuckets sets the histogram bucket boundaries in seconds.
+func WithBuckets(buckets []float64) Option {
+	return func(o *options) {
+		o.Buckets = buckets
+	}
+}
+
+// WithLabeler sets a function that derives extra labels from each request.
+func WithLabeler(labeler Labeler) Option {
+	return func(o *options) {
+		o.Labeler = labeler
+	}
+}
+
+// WithRetention sets the retention provider used to prune stale series.
+//
+// The provider is called once per Collect, outside the metric maps' lock.
+func WithRetention(retention Retention) Option {
+	return func(o *options) {
+		o.Retention = retention
+	}
+}
+
+// WithClock overrides the time source used for latency measurement.
+//
+// Primarily useful in tests for deterministic time control.
+func WithClock(fn func() time.Time) Option {
+	return func(o *options) {
+		if fn != nil {
+			o.Clock = fn
+		}
+	}
+}

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -15,6 +15,14 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/internal/xgrpc"
 )
 
+// UnaryInterceptedService is implemented by services that contribute their own
+// unary interceptors to their out-of-process gRPC server.
+//
+// ServiceRunner appends these after the framework access-log interceptor.
+type UnaryInterceptedService interface {
+	UnaryServerInterceptors() []grpc.UnaryServerInterceptor
+}
+
 // ServiceRunner runs an out-of-process Service on its own listener and
 // registers it with the gateway.
 type ServiceRunner struct {
@@ -35,12 +43,17 @@ func NewServiceRunner(
 ) *ServiceRunner {
 	log = log.Named(module.Name()).With(zap.String("module", module.Name()))
 
+	interceptors := []grpc.UnaryServerInterceptor{xgrpc.AccessLogInterceptor(log)}
+	if provider, ok := module.(UnaryInterceptedService); ok {
+		interceptors = append(interceptors, provider.UnaryServerInterceptors()...)
+	}
+
 	return &ServiceRunner{
 		module:          module,
 		gatewayEndpoint: gatewayEndpoint,
 		gatewayTLS:      gatewayTLS,
 		server: grpc.NewServer(
-			grpc.ChainUnaryInterceptor(xgrpc.AccessLogInterceptor(log)),
+			grpc.ChainUnaryInterceptor(interceptors...),
 			grpc.MaxRecvMsgSize(1024*1024*256), grpc.MaxSendMsgSize(1024*1024*256),
 		),
 		ready: make(chan struct{}),

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fs::File, path::Path};
 
 use aclpb::{
     DeleteConfigRequest, GetMetricsRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
-    acl_service_client::AclServiceClient,
+    acl_service_client::AclServiceClient, metrics_service_client::MetricsServiceClient,
 };
 use args::{DeleteCmd, MetricsCmd, ModeCmd, ShowCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
@@ -66,9 +66,19 @@ struct GaugeRow {
 }
 
 #[derive(Tabled)]
-struct HistRow {
-    #[tabled(rename = "Handler")]
-    handler: String,
+struct GrpcCallRow {
+    #[tabled(rename = "Method")]
+    method: String,
+    #[tabled(rename = "Code")]
+    code: String,
+    #[tabled(rename = "Handled")]
+    handled: String,
+}
+
+#[derive(Tabled)]
+struct GrpcLatRow {
+    #[tabled(rename = "Method")]
+    method: String,
     #[tabled(rename = "Total Calls")]
     total: String,
     #[tabled(rename = "P50")]
@@ -175,11 +185,21 @@ fn print_metrics_table(metrics: &[Metric]) {
     let mut location_map: HashMap<String, Vec<&Metric>> = HashMap::new();
     let mut gauge_keys: Vec<String> = Vec::new();
     let mut gauge_map: HashMap<String, Vec<&Metric>> = HashMap::new();
-    let mut histograms: Vec<&Metric> = Vec::new();
+    let mut grpc_counters: Vec<&Metric> = Vec::new();
+    let mut grpc_histograms: Vec<&Metric> = Vec::new();
 
     for m in metrics {
+        if m.name.starts_with("grpc_") {
+            match m.kind {
+                metric::Kind::Counter => grpc_counters.push(m),
+                metric::Kind::Histogram => grpc_histograms.push(m),
+                _ => {}
+            }
+            continue;
+        }
+
         match m.kind {
-            metric::Kind::Histogram => histograms.push(m),
+            metric::Kind::Histogram => {}
             metric::Kind::Gauge => {
                 let cfg = m.label_value("config").unwrap_or("global").to_string();
                 if !gauge_map.contains_key(&cfg) {
@@ -316,23 +336,74 @@ fn print_metrics_table(metrics: &[Metric]) {
         println!();
     }
 
-    if !histograms.is_empty() {
-        println!("ACL HANDLER LATENCIES");
+    if !grpc_counters.is_empty() {
+        // Collect started counts keyed by grpc_method.
+        let mut started: HashMap<String, u64> = HashMap::new();
+        // Collect handled counts keyed by (grpc_method, grpc_code), preserving order.
+        let mut handled_keys: Vec<(String, String)> = Vec::new();
+        let mut handled: HashMap<(String, String), u64> = HashMap::new();
+
+        for m in &grpc_counters {
+            let method = m.label_value("grpc_method").unwrap_or("").to_string();
+            if m.name == "grpc_server_started_total" {
+                let count = m.value.unwrap_or(0.0) as u64;
+                *started.entry(method).or_default() += count;
+            } else if m.name == "grpc_server_handled_total" {
+                let code = m.label_value("grpc_code").unwrap_or("").to_string();
+                let key = (method, code);
+                if !handled.contains_key(&key) {
+                    handled_keys.push(key.clone());
+                }
+                *handled.entry(key).or_default() += m.value.unwrap_or(0.0) as u64;
+            }
+        }
+
+        if !handled_keys.is_empty() || !started.is_empty() {
+            println!();
+            println!("GRPC CALLS");
+            println!();
+        }
+
+        if !handled_keys.is_empty() {
+            let rows: Vec<GrpcCallRow> = handled_keys
+                .iter()
+                .map(|(method, code)| GrpcCallRow {
+                    method: method.clone(),
+                    code: code.clone(),
+                    handled: format_number(handled[&(method.clone(), code.clone())]),
+                })
+                .collect();
+            print_table_from_entries(rows);
+        }
+
+        if !started.is_empty() {
+            println!();
+            let mut started_methods: Vec<&String> = started.keys().collect();
+            started_methods.sort();
+            for method in started_methods {
+                println!("  started  {method}: {}", format_number(started[method]));
+            }
+        }
+    }
+
+    if !grpc_histograms.is_empty() {
         println!();
-        let rows: Vec<HistRow> = histograms
+        println!("GRPC HANDLING LATENCIES");
+        println!();
+        let rows: Vec<GrpcLatRow> = grpc_histograms
             .iter()
             .map(|m| {
-                let handler = m.label_value("handler").unwrap_or("unknown").to_string();
+                let method = m.label_value("grpc_method").unwrap_or("unknown").to_string();
                 match &m.histogram {
-                    Some(h) => HistRow {
-                        handler,
+                    Some(h) => GrpcLatRow {
+                        method,
                         total: format_number(h.total_count),
                         p50: metric::histogram_percentile(&h.buckets, h.total_count, 50.0),
                         p95: metric::histogram_percentile(&h.buckets, h.total_count, 95.0),
                         p99: metric::histogram_percentile(&h.buckets, h.total_count, 99.0),
                     },
-                    None => HistRow {
-                        handler,
+                    None => GrpcLatRow {
+                        method,
                         total: "-".into(),
                         p50: "-".into(),
                         p95: "-".into(),
@@ -382,6 +453,7 @@ const SERVICE_NAME: &str = "modules.acl.controlplane.aclpb.v1.ACLService";
 
 pub struct ACLService {
     client: AclServiceClient<LayeredChannel>,
+    metrics_client: MetricsServiceClient<LayeredChannel>,
     endpoint: String,
 }
 
@@ -390,7 +462,12 @@ impl ACLService {
         let channel = ync::client::connect(connection)
             .await
             .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
-        let client = AclServiceClient::new(channel)
+        let client = AclServiceClient::new(channel.clone())
+            .max_decoding_message_size(256 * 1024 * 1024)
+            .max_encoding_message_size(256 * 1024 * 1024)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip);
+        let metrics_client = MetricsServiceClient::new(channel)
             .max_decoding_message_size(256 * 1024 * 1024)
             .max_encoding_message_size(256 * 1024 * 1024)
             .send_compressed(CompressionEncoding::Gzip)
@@ -398,6 +475,7 @@ impl ACLService {
 
         Ok(Self {
             client,
+            metrics_client,
             endpoint: connection.endpoint.clone(),
         })
     }
@@ -495,7 +573,7 @@ impl ACLService {
 
     pub async fn metrics(&mut self, cmd: MetricsCmd) -> Result<(), Error> {
         let response = self
-            .client
+            .metrics_client
             .get_metrics(GetMetricsRequest {})
             .await
             .map_err(self.map_err("metrics"))?

--- a/modules/acl/cli/src/metric.rs
+++ b/modules/acl/cli/src/metric.rs
@@ -97,6 +97,8 @@ impl Metric {
     }
 }
 
+/// Computes the p-th percentile bucket label for a histogram whose upper
+/// bounds are in seconds.
 pub fn histogram_percentile(buckets: &[Bucket], total: u64, p: f64) -> String {
     if total == 0 || buckets.is_empty() {
         return "-".to_string();
@@ -105,9 +107,10 @@ pub fn histogram_percentile(buckets: &[Bucket], total: u64, p: f64) -> String {
     for b in buckets {
         if b.count >= target {
             return if b.upper_bound.is_infinite() {
-                format!(">{}ms", buckets[buckets.len().saturating_sub(2)].upper_bound as u64)
+                let prev = buckets[buckets.len().saturating_sub(2)].upper_bound;
+                format!(">{:.3}s", prev)
             } else {
-                format!("≤{}ms", b.upper_bound as u64)
+                format!("≤{:.3}s", b.upper_bound)
             };
         }
     }

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -18,7 +18,11 @@ service ACLService {
   rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse);
   // List all ACL configurations across instances
   rpc ListConfigs(ListConfigsRequest) returns (ListConfigsResponse);
-  // Returns module-level metrics
+}
+
+// MetricsService exposes ACL module metrics.
+service MetricsService {
+  // GetMetrics returns a snapshot of ACL module metrics.
   rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
 }
 

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -1,88 +1,37 @@
 package acl
 
 import (
-	"time"
+	"context"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
-	"github.com/yanet-platform/yanet2/common/go/metrics"
+	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
 )
 
-type handlersMetrics struct {
-	callLatencies *metrics.MetricMap[*metrics.Histogram]
+// metricsSource provides the module's collected metrics.
+type metricsSource interface {
+	Metrics() ([]*commonpb.Metric, error)
 }
 
-func newHandlersMetrics() handlersMetrics {
-	return handlersMetrics{
-		callLatencies: metrics.NewMetricMap[*metrics.Histogram](),
+// MetricsService exposes ACL module metrics over its own gRPC service.
+type MetricsService struct {
+	aclpb.UnimplementedMetricsServiceServer
+
+	source metricsSource
+}
+
+// NewMetricsService creates a MetricsService backed by source.
+func NewMetricsService(source metricsSource) *MetricsService {
+	return &MetricsService{source: source}
+}
+
+// GetMetrics returns a snapshot of all ACL module metrics.
+func (m *MetricsService) GetMetrics(ctx context.Context, req *aclpb.GetMetricsRequest) (*aclpb.GetMetricsResponse, error) {
+	all, err := m.source.Metrics()
+	if err != nil {
+		return nil, err
 	}
-}
 
-func (m *handlersMetrics) collect() []*commonpb.Metric {
-	return commonpb.MetricRefsToProto(m.callLatencies.Metrics())
-}
-
-var defaultLatencyBoundsMS = []float64{
-	1,
-	2,
-	5,
-	10,
-	25,
-	50,
-	75,
-	100,
-	150,
-	200,
-	300,
-	400,
-	500,
-	600,
-	700,
-	800,
-	900,
-	1000,
-	1500,
-	2000,
-	3000,
-	4000,
-	5000,
-}
-
-type handlerMetricTracker struct {
-	metricID  metrics.MetricID
-	startTime time.Time
-	metrics   *handlersMetrics
-	latencies []float64
-}
-
-func newHandlerMetricTracker(
-	handlerName string,
-	handlerMetrics *handlersMetrics,
-	latencies []float64,
-	labels metrics.Labels,
-) *handlerMetricTracker {
-	if handlerMetrics == nil || latencies == nil {
-		return nil
-	}
-	id := metrics.MetricID{
-		Name:   handlerName,
-		Labels: labels,
-	}
-	return &handlerMetricTracker{
-		metricID:  id,
-		startTime: time.Now(),
-		metrics:   handlerMetrics,
-		latencies: latencies,
-	}
-}
-
-func (m *handlerMetricTracker) Fix() {
-	if m == nil {
-		return
-	}
-	duration := time.Since(m.startTime)
-	m.metrics.callLatencies.GetOrCreate(m.metricID, func() *metrics.Histogram {
-		return metrics.NewHistogram(m.latencies)
-	}).Observe(float64(duration.Milliseconds()))
+	return &aclpb.GetMetricsResponse{Metrics: all}, nil
 }
 
 func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
@@ -101,27 +50,38 @@ func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb
 	}
 }
 
-// Metrics collects all ACL module metrics including per-pipeline packet counters,
-// per-rule counters, ACL compilation info, and handler call latencies
+// Metrics returns all ACL module metrics: per-pipeline packet counters,
+// per-rule counters, ACL compilation info, and gRPC call metrics.
 //
-// All metric names are prefixed with "acl_". Counter metrics are omitted when
-// all worker values are zero to reduce noise in the output
+// Counter metrics are omitted when all worker values are zero to reduce output
+// noise.
 //
 // Labels:
-//   - config:   ACL config name (all counter metrics)
-//   - device:   dataplane device name (all counter metrics)
-//   - pipeline: pipeline name (all counter metrics)
-//   - function: pipeline function name (all counter metrics)
-//   - chain:    pipeline chain name (all counter metrics)
-//   - counter:  ACL rule counter name (acl_rule_packets / acl_rule_bytes only)
-//   - handler:  gRPC handler name (acl_handler_call_latency_ms only)
+//   - config:        ACL config name (all counter metrics)
+//   - device:        dataplane device name (all counter metrics)
+//   - pipeline:      pipeline name (all counter metrics)
+//   - function:      pipeline function name (all counter metrics)
+//   - chain:         pipeline chain name (all counter metrics)
+//   - counter:       ACL rule counter name (acl_rule_packets / acl_rule_bytes only)
+//   - grpc_type:     always "unary" (gRPC metrics)
+//   - grpc_service:  fully-qualified gRPC service name (gRPC metrics)
+//   - grpc_method:   RPC name (gRPC metrics)
+//   - grpc_code:     gRPC status code string (grpc_server_handled_total only)
 func (m *ACLService) Metrics() ([]*commonpb.Metric, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.collectMetrics()
+	metrics, err := m.collectDataplaneMetrics()
+	if err != nil {
+		return nil, err
+	}
+	if m.metrics != nil {
+		metrics = append(metrics, m.metrics.Collect()...)
+	}
+	return metrics, nil
 }
 
-func (m *ACLService) collectMetrics() ([]*commonpb.Metric, error) {
+func (m *ACLService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	dpConfig := m.backend.DPConfig()
 	if dpConfig == nil {
 		return []*commonpb.Metric{}, nil
@@ -153,7 +113,6 @@ func (m *ACLService) collectMetrics() ([]*commonpb.Metric, error) {
 		)
 
 		for _, counter := range counters {
-			// Sum values across all workers
 			var packets, bytes uint64
 			for _, workerVals := range counter.Values {
 				if len(workerVals) > 0 {
@@ -164,7 +123,6 @@ func (m *ACLService) collectMetrics() ([]*commonpb.Metric, error) {
 				}
 			}
 
-			// Skip counters with no traffic to reduce output noise
 			if packets == 0 && bytes == 0 {
 				continue
 			}
@@ -267,8 +225,6 @@ func (m *ACLService) collectMetrics() ([]*commonpb.Metric, error) {
 			}
 		}
 	}
-
-	result = append(result, m.handlerMetrics.collect()...)
 
 	return result, nil
 }

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -6,10 +6,11 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
+	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
 	fwstate "github.com/yanet-platform/yanet2/modules/fwstate/controlplane"
-	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
+	fwstatepb "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
 )
 
 const (
@@ -19,17 +20,18 @@ const (
 )
 
 // ACLModule is a control-plane component for ACL (Access Control List) module
-// with integrated firewall state management
+// with integrated firewall state management.
 type ACLModule struct {
 	cfg            *Config
 	shm            *ffi.SharedMemory
 	agent          *ffi.Agent
 	aclService     *ACLService
+	metricsService *MetricsService
 	fwstateService *fwstate.FWStateService
 	log            *zap.Logger
 }
 
-// NewACLModule creates a new ACL module instance
+// NewACLModule creates a new ACL module instance.
 func NewACLModule(cfg *Config, log *zap.Logger) (*ACLModule, error) {
 	log = log.With(zap.String("module", serviceName))
 
@@ -48,7 +50,16 @@ func NewACLModule(cfg *Config, log *zap.Logger) (*ACLModule, error) {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
 
-	aclService := NewACLService(NewBackend(agent, uint64(cfg.MemoryRequirements.Unwrap().Bytes())), log)
+	aclService := NewACLService(
+		NewBackend(agent, uint64(cfg.MemoryRequirements.Unwrap().Bytes())),
+		WithLog(log),
+		WithMetrics(grpcmetrics.NewFactory(
+			grpcmetrics.WithLabeler(labeler),
+		)),
+	)
+
+	metricsService := NewMetricsService(aclService)
+
 	aclAdapter := NewACLAdapter(aclService)
 	fwstateService := fwstate.NewFWStateService(agent, aclAdapter, log)
 
@@ -57,6 +68,7 @@ func NewACLModule(cfg *Config, log *zap.Logger) (*ACLModule, error) {
 		shm:            shm,
 		agent:          agent,
 		aclService:     aclService,
+		metricsService: metricsService,
 		fwstateService: fwstateService,
 		log:            log,
 	}, nil
@@ -71,15 +83,26 @@ func (m *ACLModule) Endpoint() string {
 }
 
 func (m *ACLModule) ServicesNames() []string {
-	return []string{serviceName, fwstateServiceName}
+	return []string{serviceName, aclpb.MetricsService_ServiceDesc.ServiceName, fwstateServiceName}
 }
 
 func (m *ACLModule) RegisterService(server *grpc.Server) {
 	aclpb.RegisterACLServiceServer(server, m.aclService)
+	aclpb.RegisterMetricsServiceServer(server, m.metricsService)
 	fwstatepb.RegisterFWStateServiceServer(server, m.fwstateService)
 }
 
-// ACLAdapter returns an adapter for fwstate module integration
+// UnaryServerInterceptors returns the gRPC unary interceptors for this module.
+func (m *ACLModule) UnaryServerInterceptors() []grpc.UnaryServerInterceptor {
+	si := m.aclService.UnaryServerInterceptor()
+	if si == nil {
+		return nil
+	}
+
+	return []grpc.UnaryServerInterceptor{si}
+}
+
+// ACLAdapter returns an adapter for fwstate module integration.
 func (m *ACLModule) ACLAdapter() *ACLAdapter {
 	return NewACLAdapter(m.aclService)
 }

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -5,16 +5,18 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"google.golang.org/protobuf/proto"
 
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
-	"github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
+	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
 )
 
 // ModuleHandle is a handle to an ACL module configuration written to
@@ -46,15 +48,35 @@ type Backend interface {
 	DPConfig() *ffi.DPConfig
 }
 
-type ACLService struct {
-	aclpb.UnimplementedACLServiceServer
+// Option configures an ACLService.
+type Option func(*options)
 
-	mu             sync.Mutex
-	backend        Backend
-	configs        map[string]aclConfig
-	handlerMetrics handlersMetrics
+// options holds the optional parameters for ACLService construction.
+type options struct {
+	Metrics grpcmetrics.Factory
+	Log     *zap.Logger
+}
 
-	log *zap.Logger
+func newOptions() *options {
+	return &options{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the service logger.
+func WithLog(log *zap.Logger) Option {
+	return func(o *options) {
+		o.Log = log
+	}
+}
+
+// WithMetrics sets the gRPC metrics factory.
+//
+// When unset, no metrics are collected.
+func WithMetrics(factory grpcmetrics.Factory) Option {
+	return func(o *options) {
+		o.Metrics = factory
+	}
 }
 
 type aclConfig struct {
@@ -63,35 +85,79 @@ type aclConfig struct {
 	fwstateName string
 }
 
+// ACLService implements the gRPC ACL service.
+type ACLService struct {
+	aclpb.UnimplementedACLServiceServer
+
+	mu      sync.Mutex
+	backend Backend
+	configs map[string]aclConfig
+	metrics *grpcmetrics.ServerMetrics
+
+	log *zap.Logger
+}
+
 // NewACLService creates an ACL gRPC service backed by the given Backend.
-func NewACLService(backend Backend, log *zap.Logger) *ACLService {
-	return &ACLService{
-		backend:        backend,
-		configs:        map[string]aclConfig{},
-		handlerMetrics: newHandlersMetrics(),
-		log:            log,
+func NewACLService(backend Backend, options ...Option) *ACLService {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	m := &ACLService{
+		backend: backend,
+		configs: map[string]aclConfig{},
+		log:     opts.Log,
+	}
+	if opts.Metrics != nil {
+		m.metrics = opts.Metrics(m.retention)
+	}
+
+	return m
+}
+
+// UnaryServerInterceptor returns the service's gRPC metrics interceptor, or nil
+// when metrics are not configured.
+func (m *ACLService) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	if m.metrics == nil {
+		return nil
+	}
+
+	return m.metrics.UnaryServerInterceptor()
+}
+
+// retention snapshots the live ACL config names and returns a predicate that
+// keeps series whose "config" label is still live (or absent).
+func (m *ACLService) retention() func(metrics.MetricID) bool {
+	m.mu.Lock()
+	configNames := make(map[string]struct{}, len(m.configs))
+	for name := range m.configs {
+		configNames[name] = struct{}{}
+	}
+	m.mu.Unlock()
+
+	return func(id metrics.MetricID) bool {
+		config := id.Labels["config"]
+		if config == "" {
+			return true
+		}
+
+		_, ok := configNames[config]
+		return ok
 	}
 }
 
-// newHandlerTracker creates a latency tracker for a gRPC handler.
-//
-// Usage pattern in handlers:
-//
-//	tracker := m.newHandlerTracker("HandlerName")
-//	m.mu.Lock()
-//	defer m.mu.Unlock()
-//	defer tracker.Fix()
-//
-// Defers execute LIFO, so tracker.Fix() runs before m.mu.Unlock().
-// This is intentional: the recorded latency covers the full time the
-// handler holds the lock, which is where the actual work happens.
-func (m *ACLService) newHandlerTracker(name string) *handlerMetricTracker {
-	return newHandlerMetricTracker(
-		"acl_handler_call_latency_ms",
-		&m.handlerMetrics,
-		defaultLatencyBoundsMS,
-		metrics.Labels{"handler": name},
-	)
+func labeler(fullMethod string, req any) metrics.Labels {
+	switch r := req.(type) {
+	case *aclpb.UpdateConfigRequest:
+		return metrics.Labels{"config": r.GetName()}
+	case *aclpb.DeleteConfigRequest:
+		return metrics.Labels{"config": r.GetName()}
+	case *aclpb.ShowConfigRequest:
+		return metrics.Labels{"config": r.GetName()}
+	default:
+		return nil
+	}
 }
 
 func convertRules(reqRules []*aclpb.Rule) ([]cacl.AclRule, error) {
@@ -181,10 +247,8 @@ func (m *ACLService) UpdateConfig(
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	tracker := m.newHandlerTracker("UpdateConfig")
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	defer tracker.Fix()
 
 	if existing, ok := m.configs[name]; ok && rulesEqual(existing.rules, req.Rules) {
 		return &aclpb.UpdateConfigResponse{}, nil
@@ -233,10 +297,8 @@ func (m *ACLService) ShowConfig(
 	ctx context.Context,
 	req *aclpb.ShowConfigRequest,
 ) (*aclpb.ShowConfigResponse, error) {
-	tracker := m.newHandlerTracker("ShowConfig")
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	defer tracker.Fix()
 
 	name := req.GetName()
 	if name == "" {
@@ -261,10 +323,8 @@ func (m *ACLService) ListConfigs(
 	ctx context.Context,
 	req *aclpb.ListConfigsRequest,
 ) (*aclpb.ListConfigsResponse, error) {
-	tracker := m.newHandlerTracker("ListConfigs")
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	defer tracker.Fix()
 
 	response := &aclpb.ListConfigsResponse{
 		Configs: make([]string, 0, len(m.configs)),
@@ -281,10 +341,8 @@ func (m *ACLService) DeleteConfig(
 	ctx context.Context,
 	req *aclpb.DeleteConfigRequest,
 ) (*aclpb.DeleteConfigResponse, error) {
-	tracker := m.newHandlerTracker("DeleteConfig")
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	defer tracker.Fix()
 
 	name := req.GetName()
 	if name == "" {
@@ -323,23 +381,4 @@ func (m *ACLService) GetInfo(name string) *cacl.AclConfigInfo {
 	}
 
 	return cfg.acl.GetInfo()
-}
-
-func (m *ACLService) GetMetrics(
-	ctx context.Context,
-	req *aclpb.GetMetricsRequest,
-) (*aclpb.GetMetricsResponse, error) {
-	tracker := m.newHandlerTracker("GetMetrics")
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	defer tracker.Fix()
-
-	metrics, err := m.collectMetrics()
-	if err != nil {
-		return nil, err
-	}
-
-	return &aclpb.GetMetricsResponse{
-		Metrics: metrics,
-	}, nil
 }

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -135,7 +134,7 @@ func (m *fakeBackend) SetNewModuleErr(err error) {
 }
 
 func newTestService(b Backend) *ACLService {
-	return NewACLService(b, zap.NewNop())
+	return NewACLService(b)
 }
 
 // TestConvertRulesCounter verifies that the counter field from a proto Rule

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gopacket/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
@@ -281,7 +280,7 @@ func TestACL_EmptyRules_Drop(t *testing.T) {
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &udp)
 
 	h, agent, backend := setupACLHarness(t, []string{"port0"})
-	svc := acl.NewACLService(backend, zap.NewNop())
+	svc := acl.NewACLService(backend)
 	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
 		Name:  "test",
 		Rules: nil,


### PR DESCRIPTION
Add a shared gRPC server-call metrics helper: an opt-in unary interceptor that records call counts, status codes, and handling latency, rendered in the common metric format.

Follow the go-grpc-prometheus naming and label conventions, with per-request labelling and retention-based pruning of stale series.

Let a service contribute the interceptor to its own gRPC server through an opt-in gateway hook.

Adopt the helper in the acl module and expose its metrics through a dedicated metrics service with its own gRPC name.

Point the acl CLI metrics command at the new metrics service.