### PR TITLE
fix(counters): raise CLI gRPC message-size limit to 256 MiB

### DIFF
--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -326,6 +326,8 @@ impl CountersService {
             .await
             .map_err(|err| Error::from_connection(err, action, connection.endpoint.clone()))?;
         let client = CountersServiceClient::new(channel)
+            .max_decoding_message_size(256 * 1024 * 1024)
+            .max_encoding_message_size(256 * 1024 * 1024)
             .send_compressed(CompressionEncoding::Gzip)
             .accept_compressed(CompressionEncoding::Gzip);
 


### PR DESCRIPTION
The counters CLI kept the default 4 MiB gRPC decoding limit, so a full counter dump on a large ACL deployment was rejected with a decoded-message-too-large error before it could be displayed.

- Raise the counters CLI decoding and encoding message-size limits to 256 MiB, matching the gateway server, the gateway backend, and the other module CLIs.