### PR TITLE
feat(route-operator): scope pushed FIB to each gateway's devices

### DIFF
--- a/operators/route/etc/yanet/yanet-route-operator-default.yaml
+++ b/operators/route/etc/yanet/yanet-route-operator-default.yaml
@@ -9,12 +9,17 @@ server:
   endpoint: "[::1]:50002"
 
 # One entry per dataplane instance (typically one per NUMA node).
-#
-# The operator pushes the same computed FIB to every gateway listed
-# below via the route-module UpdateFIB RPC.
 gateways:
   - name: numa0
     endpoint: "[::1]:8080"
+
+# Per-gateway device ownership: maps a gateway name to the devices its
+# dataplane instance owns. The operator pushes each gateway only the FIB
+# nexthops on its devices. An empty or unlisted gateway gets the full FIB.
+#
+#   gateway_devices:
+#     numa0: [kni0, eth0]
+gateway_devices: {}
 
 # Heartbeat interval for self-registration with each gateway's module
 # registry.

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -22,6 +22,7 @@ type GatewayActuator struct {
 	conn        *grpc.ClientConn
 	routes      routepb.RouteServiceClient
 	funcApplier *operator.FunctionApplier
+	devices     map[string]struct{}
 	log         *zap.Logger
 }
 
@@ -49,6 +50,13 @@ func NewGatewayActuator(
 		return nil, fmt.Errorf("failed to dial gateway %q at %q: %w", cfg.Name, endpoint, err)
 	}
 
+	deviceSet := map[string]struct{}{}
+	for _, d := range opts.Devices {
+		if d != "" {
+			deviceSet[d] = struct{}{}
+		}
+	}
+
 	fn := opts.Function
 	spec := operator.FunctionChainSpec{
 		Name:   fn.Name.Unwrap(),
@@ -69,6 +77,7 @@ func NewGatewayActuator(
 			spec,
 			operator.WithIgnorePdump(fn.IgnorePdump),
 		),
+		devices: deviceSet,
 		log: opts.Log.With(
 			zap.String("gateway", cfg.Name),
 			zap.String("function", fn.Name.Unwrap()),
@@ -120,8 +129,9 @@ func (m *GatewayActuator) applyFunction(ctx context.Context) error {
 
 // pushFIB applies fib to the gateway via the UpdateFIB unary RPC.
 func (m *GatewayActuator) pushFIB(ctx context.Context, fib FIB) error {
-	entries := make([]*routepb.FIBEntry, len(fib.Entries))
-	for idx, entry := range fib.Entries {
+	filtered := filterFIBEntries(fib.Entries, m.devices)
+	entries := make([]*routepb.FIBEntry, len(filtered))
+	for idx, entry := range filtered {
 		entries[idx] = fibEntryToProto(entry)
 	}
 

--- a/operators/route/internal/operator/cfg.go
+++ b/operators/route/internal/operator/cfg.go
@@ -48,6 +48,12 @@ type Config struct {
 	RIBTTL         time.Duration        `yaml:"rib_ttl"`
 	NetlinkMonitor NetlinkMonitorConfig `yaml:"netlink_monitor"`
 	Readiness      ReadinessConfig      `yaml:"readiness"`
+	// GatewayDevices maps each gateway name to the egress device names its
+	// dataplane instance owns.
+	//
+	// A gateway absent from the map or mapped to an empty list owns every
+	// device and receives the full FIB unfiltered.
+	GatewayDevices map[string][]string `yaml:"gateway_devices"`
 }
 
 // ReadinessConfig controls the operator's readiness reporting.
@@ -124,8 +130,9 @@ func DefaultConfig() *Config {
 			Weight: 1,
 			Module: xcfg.MustNonEmptyString("route0"),
 		},
-		RIBTTL:  DefaultRIBTTL,
-		LinkMap: map[string]string{},
+		RIBTTL:         DefaultRIBTTL,
+		LinkMap:        map[string]string{},
+		GatewayDevices: map[string][]string{},
 		NetlinkMonitor: NetlinkMonitorConfig{
 			TableName:       "kernel",
 			DefaultPriority: 100,

--- a/operators/route/internal/operator/fib_build.go
+++ b/operators/route/internal/operator/fib_build.go
@@ -38,6 +38,34 @@ type FIBBuildStats struct {
 	FilteredRoutes int
 }
 
+// filterFIBEntries returns the subset of entries whose nexthops include at
+// least one device present in the given set.
+//
+// When the device set is empty every entry is returned unchanged.
+func filterFIBEntries(entries []FIBEntry, devices map[string]struct{}) []FIBEntry {
+	if len(devices) == 0 {
+		return entries
+	}
+
+	result := make([]FIBEntry, 0, len(entries))
+	for _, entry := range entries {
+		kept := make([]neigh.HardwareRoute, 0, len(entry.Nexthops))
+		for idx := range entry.Nexthops {
+			if _, ok := devices[entry.Nexthops[idx].Device]; ok {
+				kept = append(kept, entry.Nexthops[idx])
+			}
+		}
+		if len(kept) == 0 {
+			continue
+		}
+		result = append(result, FIBEntry{
+			Prefix:   entry.Prefix,
+			Nexthops: kept,
+		})
+	}
+	return result
+}
+
 // BuildFIB resolves a RIB dump against the supplied neighbour view and
 // produces a deduplicated FIB.
 func BuildFIB(

--- a/operators/route/internal/operator/fib_build_test.go
+++ b/operators/route/internal/operator/fib_build_test.go
@@ -136,6 +136,79 @@ func Test_BuildFIB_StaticAndBirdBothInFIB(t *testing.T) {
 	require.Len(t, fib.Entries[0].Nexthops, 2, "both sources' nexthops should be in FIB")
 }
 
+// Test_FilterFIBEntries verifies device-scoped nexthop filtering.
+func Test_FilterFIBEntries(t *testing.T) {
+	mac1 := mustParseMAC(t, "0a:00:00:00:00:01")
+	mac2 := mustParseMAC(t, "0a:00:00:00:00:02")
+	mac3 := mustParseMAC(t, "0a:00:00:00:00:03")
+
+	nh := func(device string, src [6]byte) neigh.HardwareRoute {
+		return neigh.HardwareRoute{SourceMAC: src, Device: device}
+	}
+
+	entries := []FIBEntry{
+		{
+			Prefix:   netip.MustParsePrefix("10.0.0.0/24"),
+			Nexthops: []neigh.HardwareRoute{nh("eth0", mac1), nh("eth1", mac2)},
+		},
+		{
+			Prefix:   netip.MustParsePrefix("10.0.1.0/24"),
+			Nexthops: []neigh.HardwareRoute{nh("eth1", mac3)},
+		},
+	}
+
+	tests := []struct {
+		name            string
+		devices         map[string]struct{}
+		wantPrefixes    []string
+		wantNexthopDevs [][]string
+	}{
+		{
+			name:            "empty device set returns all entries unchanged",
+			devices:         map[string]struct{}{},
+			wantPrefixes:    []string{"10.0.0.0/24", "10.0.1.0/24"},
+			wantNexthopDevs: [][]string{{"eth0", "eth1"}, {"eth1"}},
+		},
+		{
+			name:            "one entry dropped when its nexthops are all on other devices",
+			devices:         map[string]struct{}{"eth0": {}},
+			wantPrefixes:    []string{"10.0.0.0/24"},
+			wantNexthopDevs: [][]string{{"eth0"}},
+		},
+		{
+			name:            "all entries dropped when device owns no nexthops",
+			devices:         map[string]struct{}{"eth2": {}},
+			wantPrefixes:    []string{},
+			wantNexthopDevs: [][]string{},
+		},
+	}
+
+	// Capture nexthop counts before any call to detect mutations of the input.
+	nexthopCounts := make([]int, len(entries))
+	for idx := range entries {
+		nexthopCounts[idx] = len(entries[idx].Nexthops)
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterFIBEntries(entries, tc.devices)
+			require.Len(t, got, len(tc.wantPrefixes))
+			for idx, wantPrefix := range tc.wantPrefixes {
+				require.Equal(t, netip.MustParsePrefix(wantPrefix), got[idx].Prefix)
+				devs := make([]string, len(got[idx].Nexthops))
+				for hrIdx, hr := range got[idx].Nexthops {
+					devs[hrIdx] = hr.Device
+				}
+				require.Equal(t, tc.wantNexthopDevs[idx], devs)
+			}
+			// Verify the input entries were not mutated.
+			for idx := range entries {
+				require.Len(t, entries[idx].Nexthops, nexthopCounts[idx])
+			}
+		})
+	}
+}
+
 func Test_BuildFIB_DedupsNexthops(t *testing.T) {
 	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
 	routeFor := func(addr, sourceMAC, destinationMAC string, device string) {

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -146,6 +146,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			gw,
 			WithGatewayActuatorLog(log),
 			WithGatewayActuatorFunction(cfg.Function),
+			WithGatewayActuatorDevices(cfg.GatewayDevices[gw.Name]),
 		)
 		if err != nil {
 			for _, a := range actuators {

--- a/operators/route/internal/operator/options.go
+++ b/operators/route/internal/operator/options.go
@@ -176,6 +176,7 @@ type OperatorServiceOption func(*operatorServiceOptions)
 
 type gatewayActuatorOptions struct {
 	Function FunctionConfig
+	Devices  []string
 	Log      *zap.Logger
 }
 
@@ -200,5 +201,16 @@ func WithGatewayActuatorLog(log *zap.Logger) GatewayActuatorOption {
 func WithGatewayActuatorFunction(fn FunctionConfig) GatewayActuatorOption {
 	return func(o *gatewayActuatorOptions) {
 		o.Function = fn
+	}
+}
+
+// WithGatewayActuatorDevices restricts the actuator to nexthops on the named
+// egress devices.
+//
+// An empty slice means the actuator owns all devices and forwards the full FIB
+// unfiltered.
+func WithGatewayActuatorDevices(devices []string) GatewayActuatorOption {
+	return func(o *gatewayActuatorOptions) {
+		o.Devices = devices
 	}
 }


### PR DESCRIPTION
Previously the route operator pushed the same forwarding table to every gateway, which only fits a topology where all instances own the same ports. 

This adds a `gateway_devices` config map, keyed by gateway name, listing the devices each gateway's instance owns. Each gateway now gets only the routes for its own devices.  A gateway that is absent or empty owns every device and gets the full table, so existing deployments are unaffected.
