### PR TITLE
refactor(cli): normalize success message wording

### DIFF
--- a/cli/modules/common/src/main.rs
+++ b/cli/modules/common/src/main.rs
@@ -111,7 +111,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                 .await
                 .map_err(|status| Error::from_status(status, action, endpoint.clone(), LOGGING_SERVICE))?;
 
-            output::success(action, format_args!("set log level to {:?}", cmd.level));
+            output::success(action, format_args!("Set log level to {:?}.", cmd.level));
         }
     }
 

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -535,7 +535,7 @@ impl ACLService {
             .map_err(self.map_err("delete"))?
             .into_inner();
 
-        output::success("delete", format_args!("deleted {}", cmd.config_name));
+        output::success("delete", format_args!("Deleted {}.", cmd.config_name));
 
         Ok(())
     }
@@ -565,7 +565,7 @@ impl ACLService {
 
         output::success(
             "update",
-            format_args!("updated {} ({} rules)", cmd.config_name, rule_count),
+            format_args!("Updated {} ({} rules).", cmd.config_name, rule_count),
         );
 
         Ok(())

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -342,7 +342,7 @@ impl RouteService {
         output::success(
             "insert",
             format_args!(
-                "inserted {} via {} in {} (source: {})",
+                "Inserted {} via {} in {} (source: {}).",
                 cmd.prefix,
                 via,
                 cmd.name,
@@ -379,7 +379,7 @@ impl RouteService {
         output::success(
             "remove",
             format_args!(
-                "removed {} via {} from {} (source: {})",
+                "Removed {} via {} from {} (source: {}).",
                 cmd.prefix,
                 via,
                 cmd.name,
@@ -395,7 +395,7 @@ impl RouteService {
 
         self.client.flush_routes(request).await.map_err(self.map_err("flush"))?;
 
-        output::success("flush", format_args!("flushed {}", cmd.name));
+        output::success("flush", format_args!("Flushed {}.", cmd.name));
 
         Ok(())
     }


### PR DESCRIPTION
Capitalize the first letter and add a trailing period to the CLI success messages emitted through the output facade, so they read consistently with the function and pipeline command output.

Affected commands: acl delete and update, common logging set-level, and the route operator route insert, remove, and flush.