### PR TITLE
docs(claude): sync agent config with current modules and operators

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -49,7 +49,7 @@ modules/<NAME>/
 
 ### Active modules
 
-acl, balancer, decap, dscp, forward, fwstate, nat64, pdump, route, route-mpls
+acl, balancer2, blackhole, decap, dscp, forward, fwstate, nat64, pdump, route, route-mpls
 
 ### Active devices
 
@@ -286,7 +286,7 @@ Never consider a perf fix done without a `performance-engineer` `regression` con
 - **Canonical (reference)**: `decap`, `forward`, `dscp`
 - **Partially canonical**: `route` (has backend.go + bindings, no service_test.go)
 - **Legacy structure**: `acl`, `fwstate`, `nat64`, `pdump`, `route-mpls` (ffi.go in controlplane/, no backend interface)
-- **Unique**: `balancer` (uses `agent/` dir, entirely different structure)
+- **Early-stage**: `balancer2` (only `api/` + `dataplane/`), `blackhole` (canonical skeleton — `api/`, `bindings/go/`, `controlplane/` with only cfg.go+mod.go, `dataplane/`, `tests/`; no service.go/cli/fuzzing yet)
 
 ## Output Format
 

--- a/.claude/agents/coder-go.md
+++ b/.claude/agents/coder-go.md
@@ -19,7 +19,7 @@ You own these directories:
 - `modules/*/bindings/go/` — Safe Go bindings via generated wrappers (newest pattern)
 - `controlplane/` — Gateway server, director, common FFI
 - `common/go/` — Shared Go libraries (metrics, xgrpc, logging, dataplane, etc.)
-- `operators/` — External operators (bird-adapter, route, pipeline)
+- `operators/` — External operators (bird-adapter, pipeline, decap, forward, route)
 - All `*.proto` files (in `modules/*/controlplane/*pb/`, `controlplane/ynpb/`, `common/*pb/`)
 - `go.mod`, `go.sum`
 

--- a/.claude/agents/coder-rust.md
+++ b/.claude/agents/coder-rust.md
@@ -1,6 +1,6 @@
 ---
 name: "coder-rust"
-description: "Use this agent when working on Rust code: CLI tools, tonic gRPC clients, clap argument parsing. Covers cli/, modules/*/cli/, common/rust/, and Cargo.toml files."
+description: "Use this agent when working on Rust code: CLI tools, tonic gRPC clients, clap argument parsing. Covers cli/, modules/*/cli/, operators/*/cli/, common/rust/, and Cargo.toml files."
 tools: Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, WebFetch, TaskGet, TaskList, TaskUpdate
 model: sonnet
 color: blue
@@ -13,6 +13,7 @@ You are a Rust specialist for the YANET2 software router. You write and modify R
 
 - `cli/` — Core CLI library and shared CLI modules
 - `modules/*/cli/` — Per-module CLI crates
+- `operators/*/cli/` — Operator CLI crates (decap, forward, pipeline, and route's `cli/route` + `cli/neighbour`)
 - `common/rust/` — Shared Rust libraries
 - Root `Cargo.toml` — Workspace members
 - `modules/*/cli/build.rs` — tonic-build proto compilation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,12 +123,14 @@ modules/<name>/
 **Legacy** (acl, fwstate, nat64, pdump, route-mpls): no `bindings/`,
 CGO calls live directly in `controlplane/ffi.go`, no `backend.go`.
 
-**Special**: `balancer2` is an early-stage module — only `api/` and `dataplane/`
-exist today.
+**Early-stage**: `balancer2` has only `api/` and `dataplane/`. `blackhole` has
+the canonical skeleton (`api/`, `bindings/go/`, `controlplane/`, `dataplane/`,
+`tests/`) but its `controlplane/` is only `cfg.go` + `mod.go` so far — no
+`service.go`/`backend.go`/`cli/`/`fuzzing/` yet.
 
 Module dataplane symbols are exported via meson linker defsym: `new_module_<name>`.
 
-Active modules: `route, acl, balancer2, forward, decap, nat64,
+Active modules: `route, acl, balancer2, blackhole, forward, decap, nat64,
 fwstate, dscp, pdump, route-mpls`.
 
 ### Devices
@@ -142,9 +144,11 @@ Active devices: `plain`, `vlan`.
 `operators/` holds long-running Go control-plane processes that orchestrate
 the dataplane through the gateway, distinct from per-module gRPC services.
 
-- `operators/yanet-pipeline-operator` — declarative reconciliation operator
-  (`cmd/`, `internal/`, `operatorpb/`). Structural template for future
-  operators (route, acl).
+- `operators/pipeline` — declarative reconciliation operator (`cmd/`,
+  `internal/`, `operatorpb/`, Rust `cli/`). Its structural template has been
+  replicated by per-module operators `operators/{decap,forward,route}`, each
+  with `cmd/` + `internal/` + `operatorpb/` + a Rust `cli/` (route ships two
+  CLI crates: `cli/route` and `cli/neighbour`).
 - `operators/bird-adapter` — BIRD routing-daemon adapter (canonical agent
   layout: `adapterpb/`, `internal/`, `service.go`). Note:
   `modules/route/bird-adapter/` is a separate proto-contract subtree


### PR DESCRIPTION
Add the blackhole module and the balancer2 rename to the active-module lists in the project guide and the architect agent definition.

Refresh the operators documentation to cover the per-module operators (decap, forward, route) that now exist alongside the pipeline operator and the bird adapter, including their Go and Rust layout.

Extend the Rust specialist's scope to own the operator CLI crates and complete the Go specialist's operator list.