### PR TITLE
perf(dataplane): maintain an O(1) byte count on packet lists

### DIFF
--- a/devices/vlan/dataplane/dataplane.c
+++ b/devices/vlan/dataplane/dataplane.c
@@ -94,6 +94,7 @@ vlan_output_handle(
 				rte_pktmbuf_mtod(mbuf, char *),
 				sizeof(struct rte_ether_hdr));
 			rte_pktmbuf_adj(mbuf, sizeof(struct rte_vlan_hdr));
+			packet_refresh_data_len(packet);
 
 			packet_front_output(packet_front, packet);
 			goto next;
@@ -123,6 +124,7 @@ vlan_output_handle(
 		// Inject new vlan header
 		// FIXME: check error
 		rte_pktmbuf_prepend(mbuf, sizeof(struct rte_vlan_hdr));
+		packet_refresh_data_len(packet);
 		memmove(rte_pktmbuf_mtod(mbuf, char *),
 			rte_pktmbuf_mtod_offset(
 				mbuf, char *, sizeof(struct rte_vlan_hdr)

--- a/lib/dataplane/packet/data.h
+++ b/lib/dataplane/packet/data.h
@@ -32,3 +32,8 @@ static inline uint16_t
 packet_data_offset(struct packet *packet) {
 	return packet_to_mbuf(packet)->data_off;
 }
+
+static inline void
+packet_refresh_data_len(struct packet *packet) {
+	packet->data_len = rte_pktmbuf_data_len(packet_to_mbuf(packet));
+}

--- a/lib/dataplane/packet/decap.c
+++ b/lib/dataplane/packet/decap.c
@@ -88,6 +88,7 @@ packet_decap(struct packet *packet) {
 	}
 	/* Copy ether header (and vlans) over rather than moving whole packet */
 	memmove(new_start, prev_start, packet->network_header.offset);
+	packet_refresh_data_len(packet);
 
 	// Update ether type
 	uint16_t *prev_eth_type = rte_pktmbuf_mtod_offset(

--- a/lib/dataplane/packet/encap.c
+++ b/lib/dataplane/packet/encap.c
@@ -22,6 +22,7 @@ packet_prepend(struct packet *packet, const void *header, const size_t size) {
 
 	packet->network_header.offset += size;
 	packet->transport_header.offset += size;
+	packet_refresh_data_len(packet);
 
 	return 0;
 }
@@ -49,6 +50,7 @@ packet_network_prepend(
 	packet->network_header.type = type;
 
 	packet->transport_header.offset += size;
+	packet_refresh_data_len(packet);
 
 	// FIXME previous header type (ex: vlan)
 	uint16_t *next_hdr_type = rte_pktmbuf_mtod_offset(

--- a/lib/dataplane/packet/mss.c
+++ b/lib/dataplane/packet/mss.c
@@ -241,6 +241,7 @@ insert_mss_option(
 	if (unlikely(rc != packet_set_mss_ok)) {
 		return rc;
 	}
+	packet_refresh_data_len(packet);
 
 	struct tcp_option *opt =
 		write_into_mss_gap(mbuf, prefix_len, insert_mss);

--- a/lib/dataplane/packet/packet.c
+++ b/lib/dataplane/packet/packet.c
@@ -214,6 +214,7 @@ parse_packet(struct packet *packet) {
 	packet->hash = 0;
 	packet->flags = 0;
 	packet->fragment_offset = 0;
+	packet->data_len = rte_pktmbuf_data_len(packet_to_mbuf(packet));
 
 	if (parse_ether_header(packet, &type, &offset)) {
 		return -1;
@@ -553,15 +554,6 @@ logtrace_rte_mbuf(struct rte_mbuf *mbuf) {
 #else
 	(void)mbuf;
 #endif // ENABLE_TRACE_LOG
-}
-
-uint64_t
-packet_list_bytes_sum(struct packet_list *list) {
-	uint64_t bytes = 0;
-	for (struct packet *pkt = list->first; pkt != NULL; pkt = pkt->next) {
-		bytes += packet_data_len(pkt);
-	}
-	return bytes;
 }
 
 void

--- a/lib/dataplane/packet/packet.h
+++ b/lib/dataplane/packet/packet.h
@@ -48,6 +48,10 @@ struct packet {
 
 	uint16_t fragment_offset;
 
+	// Cached first-segment byte length; mirrors the mbuf so packet_list
+	// can sum bytes without touching DPDK.
+	uint16_t data_len;
+
 	struct network_header network_header;
 	struct transport_header transport_header;
 };
@@ -56,6 +60,7 @@ struct packet_list {
 	struct packet *first;
 	struct packet **last;
 	uint64_t count;
+	uint64_t bytes;
 };
 
 static inline void
@@ -63,6 +68,7 @@ packet_list_init(struct packet_list *list) {
 	list->first = NULL;
 	list->last = &list->first;
 	list->count = 0;
+	list->bytes = 0;
 }
 
 static inline void
@@ -71,6 +77,7 @@ packet_list_add(struct packet_list *list, struct packet *packet) {
 	packet->next = NULL;
 	list->last = &packet->next;
 	list->count += 1;
+	list->bytes += packet->data_len;
 }
 
 static inline struct packet *
@@ -93,6 +100,7 @@ packet_list_concat(struct packet_list *dst, struct packet_list *src) {
 	*dst->last = packet_list_first(src);
 	dst->last = src->last;
 	dst->count += src->count;
+	dst->bytes += src->bytes;
 }
 
 static inline struct packet *
@@ -105,6 +113,7 @@ packet_list_pop(struct packet_list *packets) {
 	if (packets->first == NULL)
 		packets->last = &packets->first;
 	packets->count -= 1;
+	packets->bytes -= res->data_len;
 
 	return res;
 }
@@ -112,6 +121,11 @@ packet_list_pop(struct packet_list *packets) {
 static inline uint64_t
 packet_list_count(struct packet_list *packets) {
 	return packets->count;
+}
+
+static inline uint64_t
+packet_list_bytes_sum(struct packet_list *list) {
+	return list->bytes;
 }
 
 int
@@ -125,18 +139,6 @@ parse_packet(struct packet *packet);
 
 void
 packet_list_print(struct packet_list *list);
-
-/**
- * @brief Calculate total bytes in a packet list
- *
- * Traverses the linked list of packets and sums up the data length of each
- * packet.
- *
- * @param list Pointer to packet list structure to sum bytes for
- * @return Total bytes of all packets in the list
- */
-uint64_t
-packet_list_bytes_sum(struct packet_list *list);
 
 /**
  * @brief Print contents of an rte_mbuf packet in a detailed format if

--- a/lib/dataplane/worker/worker.c
+++ b/lib/dataplane/worker/worker.c
@@ -30,6 +30,7 @@ worker_clone_packet(struct dp_worker *dp_worker, struct packet *packet) {
 	packet_clone->next = NULL;
 
 	mbuf_copy(packet_clone->mbuf, packet->mbuf);
+	packet_refresh_data_len(packet_clone);
 	return packet_clone;
 }
 

--- a/lib/fwstate/sync.c
+++ b/lib/fwstate/sync.c
@@ -216,6 +216,7 @@ fwstate_craft_state_sync_packet(
 	sync_pkt->network_header.offset = ipv6_offset;
 	sync_pkt->transport_header.type = IPPROTO_UDP;
 	sync_pkt->transport_header.offset = udp_offset;
+	packet_refresh_data_len(sync_pkt);
 
 	return 0;
 }

--- a/modules/nat64/dataplane/nat64dp.c
+++ b/modules/nat64/dataplane/nat64dp.c
@@ -1143,6 +1143,7 @@ icmp_v6_to_v4(
 			RTE_LOG(ERR, NAT64, "Failed to trim mbuf\n");
 			return -1;
 		}
+		packet_refresh_data_len(packet);
 		new_ipv4_header->total_length = rte_cpu_to_be_16(
 			rte_be_to_cpu_16(new_ipv4_header->total_length) - delta
 		);
@@ -1897,6 +1898,7 @@ nat64_handle_v6(
 		RTE_LOG(ERR, NAT64, "adjust mbuf failed. Delta: %d\n", delta);
 		return -1;
 	}
+	packet_refresh_data_len(packet);
 
 	// adjust new transport header offset
 	packet->transport_header.offset =
@@ -2450,6 +2452,7 @@ icmp_v4_to_v6(
 				return -1;
 			}
 		}
+		packet_refresh_data_len(packet);
 
 		uint16_t move_len =
 			new_payload_len - sizeof(struct rte_icmp_hdr);
@@ -2869,6 +2872,7 @@ nat64_handle_v4(
 		RTE_LOG(ERR, NAT64, "Failed to resize mbuf\n");
 		return -1;
 	}
+	packet_refresh_data_len(packet);
 
 	rte_memcpy(
 		rte_pktmbuf_mtod(mbuf, char *),


### PR DESCRIPTION
Per-module byte metrics summed each packet list with an O(n) linked-list walk on the hot path, on the order of 18 times per pipeline round. The byte count is now maintained incrementally on the list (O(1)), fed by a per-packet cached length set wherever the mbuf length is established or changed. The cgo-facing packet headers stay free of DPDK includes.

Measured on the live rig (fast sender, acl0.yaml):
- The byte-sum routine fell from 10.6% (the #1 hot-worker self-time symbol) to 0% (perf record).
- Throughput rose from 1034 to 1211 Kpps (+17%, yanet-cli counters workers).
- Microbenchmark byte-sum cost went from ~108 cyc/op at batch 32 and ~320 at batch 64 to ~5 cyc/op flat, O(n) to O(1) (dataplane_ut).
- Byte counters are unchanged, the cached count is identical to the prior walk.