### PR TITLE
docs(dataplane): document packet_refresh_data_len list-desync contract

### DIFF
--- a/lib/dataplane/packet/data.h
+++ b/lib/dataplane/packet/data.h
@@ -33,6 +33,12 @@ packet_data_offset(struct packet *packet) {
 	return packet_to_mbuf(packet)->data_off;
 }
 
+// Refresh the cached first-segment length after the mbuf was resized.
+//
+// Call this only while the packet is not linked in a metered packet_list
+// (between a pop and the next add): packet_list.bytes is kept in sync
+// incrementally from data_len, so refreshing it in place inside a list
+// would desync that list's cached byte sum.
 static inline void
 packet_refresh_data_len(struct packet *packet) {
 	packet->data_len = rte_pktmbuf_data_len(packet_to_mbuf(packet));


### PR DESCRIPTION
Document the calling contract of `packet_refresh_data_len`: it may only run while the packet is unlinked from a metered packet list, because that list keeps an incrementally-maintained byte sum fed from each packet's cached first-segment length. Refreshing the length in place inside a list would desync the cached byte total introduced in #1258.