### PR TITLE
fix(web): prevent spurious counter rate spikes under slow polling

### DIFF
--- a/web/src/hooks/useInterpolatedCounters.ts
+++ b/web/src/hooks/useInterpolatedCounters.ts
@@ -96,6 +96,14 @@ export const useInterpolatedCounters = <K extends string = string>(
     const [ppsSamples, setPpsSamples] = useState<Map<K, number>>(() => new Map());
     // bps samples fed into useLagInterpolated.
     const [bpsSamples, setBpsSamples] = useState<Map<K, number>>(() => new Map());
+
+    // Mirror refs so doFetch can read the latest published maps without
+    // capturing stale closure values (the effect deps list only needs keysKey,
+    // not these maps).
+    const ppsSamplesRef = useRef<Map<K, number>>(ppsSamples);
+    const bpsSamplesRef = useRef<Map<K, number>>(bpsSamples);
+    ppsSamplesRef.current = ppsSamples;
+    bpsSamplesRef.current = bpsSamples;
     // Absolute packet samples (cumulative BigInt -> Number snapshot).
     const [packetSamples, setPacketSamples] = useState<Map<K, number>>(() => new Map());
     // Absolute byte samples.
@@ -113,8 +121,12 @@ export const useInterpolatedCounters = <K extends string = string>(
     // across config switches.
     useEffect(() => {
         snapshotsRef.current = [];
-        setPpsSamples(new Map());
-        setBpsSamples(new Map());
+        const emptyPps = new Map<K, number>();
+        const emptyBps = new Map<K, number>();
+        ppsSamplesRef.current = emptyPps;
+        bpsSamplesRef.current = emptyBps;
+        setPpsSamples(emptyPps);
+        setBpsSamples(emptyBps);
         setPacketSamples(new Map());
         setBytesSamples(new Map());
     }, [keysKey]);
@@ -124,6 +136,7 @@ export const useInterpolatedCounters = <K extends string = string>(
         if (!enabled || keys.length === 0) return;
 
         let cancelled = false;
+        let timerId: ReturnType<typeof setTimeout> | undefined;
 
         const doFetch = async (): Promise<void> => {
             if (cancelled) return;
@@ -134,7 +147,7 @@ export const useInterpolatedCounters = <K extends string = string>(
                 const newValues = await fetchCountersRef.current();
                 if (cancelled) return;
 
-                const now = Date.now();
+                const now = performance.now();
                 const newSnapshot: RawCounterSnapshot<K> = {
                     timestamp: now,
                     values: newValues,
@@ -145,26 +158,29 @@ export const useInterpolatedCounters = <K extends string = string>(
                 if (prevSnapshot) {
                     const dtSeconds = (now - prevSnapshot.timestamp) / 1000;
 
-                    if (dtSeconds > 0) {
-                        const nextPps = new Map<K, number>();
-                        const nextBps = new Map<K, number>();
+                    let updatedPps: Map<K, number> | null = null;
+                    let updatedBps: Map<K, number> | null = null;
 
-                        for (const key of currentKeys) {
-                            const prev = prevSnapshot.values.get(key);
-                            const cur = newValues.get(key);
+                    for (const key of currentKeys) {
+                        const prev = prevSnapshot.values.get(key);
+                        const cur = newValues.get(key);
 
-                            if (prev && cur) {
-                                const { pps, bps } = computeRate(prev, cur, dtSeconds);
-                                nextPps.set(key, pps);
-                                nextBps.set(key, bps);
-                            } else {
-                                nextPps.set(key, 0);
-                                nextBps.set(key, 0);
+                        if (prev && cur) {
+                            const rate = computeRate(prev, cur, dtSeconds);
+                            if (rate !== null) {
+                                if (updatedPps === null) {
+                                    updatedPps = new Map<K, number>(ppsSamplesRef.current);
+                                    updatedBps = new Map<K, number>(bpsSamplesRef.current);
+                                }
+                                updatedPps.set(key, rate.pps);
+                                updatedBps!.set(key, rate.bps);
                             }
                         }
+                    }
 
-                        setPpsSamples(nextPps);
-                        setBpsSamples(nextBps);
+                    if (updatedPps !== null) {
+                        setPpsSamples(updatedPps);
+                        setBpsSamples(updatedBps!);
                     }
                 }
 
@@ -185,14 +201,17 @@ export const useInterpolatedCounters = <K extends string = string>(
                 }
             } catch {
                 // tolerate fetch failures.
+            } finally {
+                if (!cancelled) {
+                    timerId = setTimeout(() => { void doFetch(); }, pollingInterval);
+                }
             }
         };
 
-        doFetch();
-        const id = setInterval(doFetch, pollingInterval);
+        void doFetch();
         return () => {
             cancelled = true;
-            clearInterval(id);
+            clearTimeout(timerId);
         };
     }, [enabled, keysKey, pollingInterval]);
 

--- a/web/src/utils/interpolation.test.ts
+++ b/web/src/utils/interpolation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { lerp, clampProgress, computeRate } from './interpolation';
+import { lerp, clampProgress, computeRate, MIN_DT_SECONDS } from './interpolation';
 
 describe('lerp', () => {
     it('returns a at t=0', () => {
@@ -51,47 +51,77 @@ describe('computeRate', () => {
         const prev = { packets: BigInt(0), bytes: BigInt(0) };
         const cur = { packets: BigInt(1000), bytes: BigInt(125000) };
         const result = computeRate(prev, cur, 1);
-        expect(result.pps).toBe(1000);
-        expect(result.bps).toBe(125000);
+        expect(result).not.toBeNull();
+        expect(result!.pps).toBe(1000);
+        expect(result!.bps).toBe(125000);
     });
 
     it('divides by dtSeconds correctly', () => {
         const prev = { packets: BigInt(0), bytes: BigInt(0) };
         const cur = { packets: BigInt(3000), bytes: BigInt(6000) };
         const result = computeRate(prev, cur, 3);
-        expect(result.pps).toBe(1000);
-        expect(result.bps).toBe(2000);
+        expect(result).not.toBeNull();
+        expect(result!.pps).toBe(1000);
+        expect(result!.bps).toBe(2000);
     });
 
     it('returns 0 pps on negative packet delta (counter reset)', () => {
         const prev = { packets: BigInt(5000), bytes: BigInt(0) };
         const cur = { packets: BigInt(100), bytes: BigInt(1000) };
         const result = computeRate(prev, cur, 1);
-        expect(result.pps).toBe(0);
-        expect(result.bps).toBeGreaterThan(0);
+        expect(result).not.toBeNull();
+        expect(result!.pps).toBe(0);
+        expect(result!.bps).toBeGreaterThan(0);
     });
 
     it('returns 0 bps on negative byte delta (counter reset)', () => {
         const prev = { packets: BigInt(0), bytes: BigInt(5000) };
         const cur = { packets: BigInt(100), bytes: BigInt(0) };
         const result = computeRate(prev, cur, 1);
-        expect(result.pps).toBeGreaterThan(0);
-        expect(result.bps).toBe(0);
+        expect(result).not.toBeNull();
+        expect(result!.pps).toBeGreaterThan(0);
+        expect(result!.bps).toBe(0);
     });
 
-    it('returns zeros when dtSeconds is 0', () => {
+    it('returns null when dtSeconds is 0', () => {
         const prev = { packets: BigInt(0), bytes: BigInt(0) };
         const cur = { packets: BigInt(1000), bytes: BigInt(1000) };
-        const result = computeRate(prev, cur, 0);
-        expect(result.pps).toBe(0);
-        expect(result.bps).toBe(0);
+        expect(computeRate(prev, cur, 0)).toBeNull();
     });
 
-    it('returns zeros when dtSeconds is negative', () => {
+    it('returns null when dtSeconds is negative', () => {
         const prev = { packets: BigInt(0), bytes: BigInt(0) };
         const cur = { packets: BigInt(1000), bytes: BigInt(1000) };
-        const result = computeRate(prev, cur, -1);
-        expect(result.pps).toBe(0);
-        expect(result.bps).toBe(0);
+        expect(computeRate(prev, cur, -1)).toBeNull();
+    });
+
+    it('returns null for a tiny dt that would produce impossible rates', () => {
+        const prev = { packets: BigInt(0), bytes: BigInt(0) };
+        const cur = { packets: BigInt(1_000_000), bytes: BigInt(1_000_000) };
+        expect(computeRate(prev, cur, 0.001)).toBeNull();
+    });
+
+    it('returns null for dt just below MIN_DT_SECONDS', () => {
+        const prev = { packets: BigInt(0), bytes: BigInt(0) };
+        const cur = { packets: BigInt(100), bytes: BigInt(100) };
+        expect(computeRate(prev, cur, MIN_DT_SECONDS - 0.001)).toBeNull();
+    });
+
+    it('computes normally at exactly MIN_DT_SECONDS', () => {
+        const prev = { packets: BigInt(0), bytes: BigInt(0) };
+        const cur = { packets: BigInt(100), bytes: BigInt(200) };
+        const result = computeRate(prev, cur, MIN_DT_SECONDS);
+        expect(result).not.toBeNull();
+        expect(result!.pps).toBeCloseTo(100 / MIN_DT_SECONDS);
+        expect(result!.bps).toBeCloseTo(200 / MIN_DT_SECONDS);
+    });
+
+    it('computes normally for dt above MIN_DT_SECONDS', () => {
+        const prev = { packets: BigInt(0), bytes: BigInt(0) };
+        const cur = { packets: BigInt(500), bytes: BigInt(1000) };
+        const result = computeRate(prev, cur, 0.5);
+        expect(result).not.toBeNull();
+        expect(result!.pps).toBe(1000);
+        expect(result!.bps).toBe(2000);
     });
 });

--- a/web/src/utils/interpolation.ts
+++ b/web/src/utils/interpolation.ts
@@ -19,18 +19,28 @@ export const clampProgress = (now: number, sampleTs: number, intervalMs: number)
 };
 
 /**
- * Compute per-second packet and byte rates from two cumulative counter
- * snapshots.
+ * Minimum elapsed time (in seconds) required to compute a valid rate sample.
  *
- * A negative delta (counter reset) is mapped to 0 rather than producing a
- * large negative spike.
+ * Samples with a shorter dt are discarded to prevent division by a tiny
+ * number producing physically-impossible rates when two fetches settle close
+ * together.
+ */
+export const MIN_DT_SECONDS = 0.1;
+
+/**
+ * Compute per-second packet and byte rates from two cumulative counter snapshots.
+ *
+ * Returns null when dtSeconds is below MIN_DT_SECONDS (including zero and
+ * negative values) so the caller can carry forward the previous sample instead
+ * of publishing a bogus rate. A negative delta (counter reset) is mapped to 0
+ * on the normal path rather than producing a large negative spike.
  */
 export const computeRate = (
     prev: { packets: bigint; bytes: bigint },
     cur: { packets: bigint; bytes: bigint },
     dtSeconds: number,
-): { pps: number; bps: number } => {
-    if (dtSeconds <= 0) return { pps: 0, bps: 0 };
+): { pps: number; bps: number } | null => {
+    if (dtSeconds < MIN_DT_SECONDS) return null;
     const dp = Number(cur.packets - prev.packets);
     const db = Number(cur.bytes - prev.bytes);
     return {


### PR DESCRIPTION
The Web UI occasionally displayed physically-impossible counter rates (hundreds of millions of packets per second) when there was little or no traffic.

The shared rate-polling hook scheduled fetches on a fixed interval without waiting for the previous request to finish. When the backend was slow to respond, requests overlapped and resolved within milliseconds of each other, collapsing the measured interval between samples and inflating the computed rate.

Polling is now strictly sequential, so each sample spans the real elapsed time since the previous one. Timestamps use a monotonic clock that is immune to wall-clock adjustments, and any sample taken over an implausibly short interval is discarded in favour of carrying forward the last known rate.