### PR TITLE
feat(web): add control-plane gateway selector

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,8 @@ import type { PageId, SidebarContextValue } from './types';
 import { PAGE_IDS, SidebarContext } from './types';
 import { PaletteProvider, usePalette, CommandPalette, navigationCommands, ShortcutsHelp } from './components/command-palette';
 import type { RowAdapter, Command } from './components/command-palette';
+import { GatewayProvider, GatewayDrawer, useGateways, gatewayCommands } from './gateways';
+import { setApiBase } from './api';
 
 const importInspect = () => import('./pages/builtin/inspect/InspectPage');
 const importDashboard = () => import('./pages/builtin/dashboard/DashboardPage');
@@ -56,8 +58,15 @@ type RequestIdleCallback = (cb: () => void, opts?: { timeout: number }) => IdleH
 type CancelIdleCallback = (id: IdleHandle) => void;
 
 /** Global command palette instance that reads contributions from context at render time. */
-const GlobalPalette = ({ handlePageChange }: { handlePageChange: (id: PageId) => void }): React.JSX.Element => {
+const GlobalPalette = ({
+    handlePageChange,
+    onOpenGatewayDrawer,
+}: {
+    handlePageChange: (id: PageId) => void;
+    onOpenGatewayDrawer: () => void;
+}): React.JSX.Element => {
     const { open, closePalette, contribution, helpOpen, closeHelp, helpShortcuts, openHelp } = usePalette();
+    const { gateways, activeGateway, setActive } = useGateways();
     const navCmds = useMemo(() => navigationCommands(handlePageChange), [handlePageChange]);
 
     const showShortcutsCmd = useMemo((): Command => ({
@@ -70,10 +79,15 @@ const GlobalPalette = ({ handlePageChange }: { handlePageChange: (id: PageId) =>
         onSelect: () => setTimeout(openHelp, 0),
     }), [openHelp]);
 
+    const gwCmds = useMemo(
+        () => gatewayCommands(gateways, activeGateway?.id ?? null, setActive, onOpenGatewayDrawer),
+        [gateways, activeGateway, setActive, onOpenGatewayDrawer],
+    );
+
     const commands = useMemo(() => {
         const pageCmds = contribution?.commands ?? [];
-        return [...pageCmds, ...navCmds, showShortcutsCmd];
-    }, [contribution, navCmds, showShortcutsCmd]);
+        return [...pageCmds, ...navCmds, showShortcutsCmd, ...gwCmds];
+    }, [contribution, gwCmds, navCmds, showShortcutsCmd]);
 
     const dynamicCommands = useMemo(() => {
         const pageDynamic = contribution?.dynamicCommands;
@@ -103,11 +117,32 @@ const GlobalPalette = ({ handlePageChange }: { handlePageChange: (id: PageId) =>
     );
 };
 
-const AppContent = (): React.JSX.Element => {
+const AppContentInner = (): React.JSX.Element => {
     const location = useLocation();
     const navigate = useNavigate();
     const [sidebarDisabled, setSidebarDisabled] = useState(false);
+    const [gatewayDrawerOpen, setGatewayDrawerOpen] = useState(false);
+    const [asideSize, setAsideSize] = useState<number>(0);
     const unsavedGuardRef = useRef<(() => boolean) | null>(null);
+    const { activeGateway } = useGateways();
+
+    useEffect(() => {
+        if (activeGateway) {
+            setApiBase(activeGateway.baseUrl);
+        }
+    }, [activeGateway]);
+
+    const handleOpenGatewayDrawer = useCallback(() => {
+        setGatewayDrawerOpen(true);
+    }, []);
+
+    const handleCloseGatewayDrawer = useCallback(() => {
+        setGatewayDrawerOpen(false);
+    }, []);
+
+    const handleToggleGatewayDrawer = useCallback(() => {
+        setGatewayDrawerOpen((prev) => !prev);
+    }, []);
 
     useEffect(() => {
         let cancelled = false;
@@ -187,15 +222,20 @@ const AppContent = (): React.JSX.Element => {
     return (
         <SidebarContext.Provider value={sidebarContextValue}>
             <PaletteProvider>
-                <GlobalPalette handlePageChange={handlePageChange} />
+                <GlobalPalette handlePageChange={handlePageChange} onOpenGatewayDrawer={handleOpenGatewayDrawer} />
+                <GatewayDrawer open={gatewayDrawerOpen} onClose={handleCloseGatewayDrawer} asideSize={asideSize} />
                 <MainMenu
                     currentPage={currentPage}
                     onPageChange={handlePageChange}
                     disabled={sidebarDisabled}
+                    onOpenGatewayDrawer={handleOpenGatewayDrawer}
+                    onToggleGatewayDrawer={handleToggleGatewayDrawer}
+                    gatewayDrawerOpen={gatewayDrawerOpen}
+                    onAsideSize={setAsideSize}
                     renderContent={() => (
                         <div className="app-surface">
                             <Suspense fallback={<PageLoader loading size="l" />}>
-                                <Routes>
+                                <Routes key={`${activeGateway?.id ?? ''}:${activeGateway?.baseUrl ?? ''}`}>
                                     <Route path="/" element={<Navigate to="/builtin/dashboard" replace />} />
                                     <Route path="/builtin/inspect" element={<InspectPage />} />
                                     <Route path="/builtin/dashboard" element={<DashboardPage />} />
@@ -232,6 +272,12 @@ const AppContent = (): React.JSX.Element => {
         </SidebarContext.Provider>
     );
 };
+
+const AppContent = (): React.JSX.Element => (
+    <GatewayProvider>
+        <AppContentInner />
+    </GatewayProvider>
+);
 
 const App = (): React.JSX.Element => {
     return (

--- a/web/src/MainMenu.scss
+++ b/web/src/MainMenu.scss
@@ -12,6 +12,11 @@
     background-color: var(--yn-surface-bg);
 }
 
+// Stack the sidebar above the gw-drawer (z-index 110) so it slides under rather than over the nav items.
+.gn-aside-header__aside {
+    --gn-aside-header-z-index: 120;
+}
+
 .main-menu__section-label {
     display: block;
     padding: 4px 12px;

--- a/web/src/MainMenu.tsx
+++ b/web/src/MainMenu.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { AsideHeader } from '@gravity-ui/navigation';
+import { AsideHeader, FooterItem } from '@gravity-ui/navigation';
 import type { MenuItem as AsideHeaderMenuItem } from '@gravity-ui/navigation';
+import { Server } from '@gravity-ui/icons';
 import Logo from './icons/Logo';
 import type { PageId } from './types';
 import { navItems } from './navItems';
 import type { NavSection } from './navItems';
+import { useGateways } from './gateways';
 import './MainMenu.scss';
 
 interface MainMenuProps {
@@ -13,6 +15,10 @@ interface MainMenuProps {
     onPageChange: (pageId: PageId) => void;
     renderContent: () => React.JSX.Element;
     disabled?: boolean;
+    onOpenGatewayDrawer?: () => void;
+    onToggleGatewayDrawer?: () => void;
+    gatewayDrawerOpen?: boolean;
+    onAsideSize?: (size: number) => void;
 }
 
 type NavMenuItem = AsideHeaderMenuItem & {
@@ -20,9 +26,19 @@ type NavMenuItem = AsideHeaderMenuItem & {
     current: boolean;
 };
 
-const MainMenu = ({ currentPage, onPageChange, renderContent, disabled = false }: MainMenuProps): React.JSX.Element => {
+const MainMenu = ({
+    currentPage,
+    onPageChange,
+    renderContent,
+    disabled = false,
+    onOpenGatewayDrawer,
+    onToggleGatewayDrawer,
+    gatewayDrawerOpen = false,
+    onAsideSize,
+}: MainMenuProps): React.JSX.Element => {
     const [compact, setCompact] = useState<boolean>(false);
     const navigate = useNavigate();
+    const { activeGateway } = useGateways();
 
     const createMenuItem = (id: PageId, title: string, icon: NavMenuItem['icon']): NavMenuItem => ({
         id,
@@ -74,6 +90,8 @@ const MainMenu = ({ currentPage, onPageChange, renderContent, disabled = false }
         menuItems.push(createMenuItem(item.id, item.title, item.icon));
     }
 
+    const gatewayTitle = activeGateway ? `Gateway: ${activeGateway.host}` : 'Gateways';
+
     return (
         <AsideHeader
             headerDecoration
@@ -91,6 +109,27 @@ const MainMenu = ({ currentPage, onPageChange, renderContent, disabled = false }
                     }
                 },
             }}
+            renderFooter={(onOpenGatewayDrawer || onToggleGatewayDrawer)
+                ? ({ size, compact: isCompact }) => {
+                    if (onAsideSize) {
+                        onAsideSize(size);
+                    }
+                    const handleGatewayClick = onToggleGatewayDrawer ?? onOpenGatewayDrawer;
+                    return (
+                        <FooterItem
+                            compact={isCompact}
+                            item={{
+                                id: '__gateways',
+                                title: gatewayTitle,
+                                tooltipText: gatewayTitle,
+                                icon: Server,
+                                current: gatewayDrawerOpen,
+                                onItemClick: disabled ? undefined : handleGatewayClick,
+                            }}
+                        />
+                    );
+                }
+                : undefined}
             renderContent={renderContent}
         />
     );

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -3,6 +3,13 @@ export interface CallOptions {
     compress?: boolean;
 }
 
+let apiBase = '';
+
+/** Set the base URL prefix for all API calls. An empty string means same-origin. */
+export const setApiBase = (base: string): void => {
+    apiBase = base;
+};
+
 const compressGzip = async (data: string): Promise<Blob> => {
     const stream = new Blob([data]).stream();
     const compressedStream = stream.pipeThrough(new CompressionStream('gzip'));
@@ -47,7 +54,7 @@ const callGRPCServiceWithBody = async <T>(
         headers['Content-Encoding'] = 'gzip';
     }
 
-    const response = await fetch(`/api/${servicePath}`, {
+    const response = await fetch(`${apiBase}/api/${servicePath}`, {
         method: 'POST',
         headers,
         body: requestBody,
@@ -130,7 +137,7 @@ const streamGRPCService = async <T>(
     signal?: AbortSignal
 ): Promise<void> => {
     try {
-        const response = await fetch(`/api/${servicePath}`, {
+        const response = await fetch(`${apiBase}/api/${servicePath}`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -1,4 +1,4 @@
-export { type CallOptions } from './client';
+export { type CallOptions, setApiBase } from './client';
 export * from './common';
 export * from './routes';
 export * from './neighbours';

--- a/web/src/components/command-palette/CommandPalette.tsx
+++ b/web/src/components/command-palette/CommandPalette.tsx
@@ -94,6 +94,7 @@ const CommandPalette = <T,>({
     } else {
         const scoredPage: Array<{ item: PaletteItem; score: number }> = [];
         const scoredNav: Array<{ item: PaletteItem; score: number }> = [];
+        const scoredGateways: Array<{ item: PaletteItem; score: number }> = [];
         for (const cmd of commands) {
             const searchTarget = cmd.label + (cmd.keywords ? ' ' + cmd.keywords : '');
             const match = fuzzyMatch(q, searchTarget);
@@ -113,6 +114,8 @@ const CommandPalette = <T,>({
                 };
                 if (cmd.group === 'Go to') {
                     scoredNav.push(entry);
+                } else if (cmd.group === 'Gateways') {
+                    scoredGateways.push(entry);
                 } else {
                     scoredPage.push(entry);
                 }
@@ -120,10 +123,14 @@ const CommandPalette = <T,>({
         }
         scoredPage.sort((a, b) => b.score - a.score);
         scoredNav.sort((a, b) => b.score - a.score);
+        scoredGateways.sort((a, b) => b.score - a.score);
         for (const entry of scoredPage) {
             items.push(entry.item);
         }
         for (const entry of scoredNav) {
+            items.push(entry.item);
+        }
+        for (const entry of scoredGateways) {
             items.push(entry.item);
         }
     }

--- a/web/src/gateways/GatewayContext.tsx
+++ b/web/src/gateways/GatewayContext.tsx
@@ -1,0 +1,90 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { Gateway } from './types';
+import { loadFromStorage, saveToStorage } from './storage';
+
+export interface GatewayContextValue {
+    gateways: Gateway[];
+    activeGateway: Gateway | null;
+    addGateway: (gw: Omit<Gateway, 'id'>) => void;
+    updateGateway: (id: string, updates: Partial<Omit<Gateway, 'id'>>) => void;
+    deleteGateway: (id: string) => void;
+    setActive: (id: string) => void;
+}
+
+export const GatewayContext = createContext<GatewayContextValue>({
+    gateways: [],
+    activeGateway: null,
+    addGateway: () => {},
+    updateGateway: () => {},
+    deleteGateway: () => {},
+    setActive: () => {},
+});
+
+/** Provides gateway list and active-selection state to the entire app. */
+export const GatewayProvider = ({ children }: { children: React.ReactNode }): React.JSX.Element => {
+    const initial = useMemo(() => loadFromStorage(), []);
+    const [gateways, setGateways] = useState<Gateway[]>(initial.gateways);
+    const [activeId, setActiveId] = useState<string>(initial.activeId);
+
+    const addGateway = useCallback((gw: Omit<Gateway, 'id'>) => {
+        const newGateway: Gateway = { ...gw, id: `gw-${Date.now()}` };
+        setGateways((prev) => {
+            const next = [...prev, newGateway];
+            saveToStorage(next, activeId);
+            return next;
+        });
+    }, [activeId]);
+
+    const updateGateway = useCallback((id: string, updates: Partial<Omit<Gateway, 'id'>>) => {
+        setGateways((prev) => {
+            const target = prev.find((g) => g.id === id);
+            if (target?.builtin) {
+                return prev;
+            }
+            const next = prev.map((g) => (g.id === id ? { ...g, ...updates } : g));
+            saveToStorage(next, activeId);
+            return next;
+        });
+    }, [activeId]);
+
+    const deleteGateway = useCallback((id: string) => {
+        if (gateways.find((g) => g.id === id)?.builtin) {
+            return;
+        }
+        const nextList = gateways.filter((g) => g.id !== id);
+        const nextActiveId = activeId !== id
+            ? activeId
+            : (nextList.find((g) => g.status === 'online') ?? nextList[0])?.id ?? '';
+        saveToStorage(nextList, nextActiveId);
+        setGateways(nextList);
+        setActiveId(nextActiveId);
+    }, [gateways, activeId]);
+
+    const setActive = useCallback((id: string) => {
+        setActiveId(id);
+        saveToStorage(gateways, id);
+    }, [gateways]);
+
+    const activeGateway = useMemo(
+        () => gateways.find((g) => g.id === activeId) ?? gateways[0] ?? null,
+        [gateways, activeId],
+    );
+
+    const value = useMemo<GatewayContextValue>(() => ({
+        gateways,
+        activeGateway,
+        addGateway,
+        updateGateway,
+        deleteGateway,
+        setActive,
+    }), [gateways, activeGateway, addGateway, updateGateway, deleteGateway, setActive]);
+
+    return (
+        <GatewayContext.Provider value={value}>
+            {children}
+        </GatewayContext.Provider>
+    );
+};
+
+/** Access the gateway context. Must be used inside GatewayProvider. */
+export const useGateways = (): GatewayContextValue => useContext(GatewayContext);

--- a/web/src/gateways/GatewayDrawer.scss
+++ b/web/src/gateways/GatewayDrawer.scss
@@ -1,0 +1,381 @@
+// Status indicator colors — the one set not covered by global --yn-* tokens.
+// These are intentionally stable across themes (they map to semantic signal colors).
+:root {
+    --gw-status-online:   #54c98a;
+    --gw-status-degraded: #e6a34d;
+    --gw-status-offline:  #d4675a;
+    --gw-status-checking: #5e8fd0;
+}
+
+@keyframes gwFadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+@keyframes gwPulseDot {
+    0%, 100% { opacity: 1; }
+    50%       { opacity: 0.35; }
+}
+
+.gw-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 98;
+    background: rgba(0, 0, 0, 0.55);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.15s ease-out;
+
+    &--open {
+        opacity: 1;
+        pointer-events: auto;
+        animation: gwFadeIn 0.15s ease-out;
+    }
+}
+
+// Left-edge drawer — slides in from the left flush to the sidebar.
+// Carries yn-drawer so --yn-* light-mode overrides cascade to children.
+.gw-drawer {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    width: 620px;
+    z-index: 110;
+    background: var(--yn-panel);
+    border-right: 1px solid var(--yn-line-2);
+    box-shadow: 30px 0 60px rgba(0, 0, 0, 0.4);
+    display: flex;
+    flex-direction: column;
+    transform: translateX(-100%);
+    transition: transform 0.22s cubic-bezier(0.16, 1, 0.3, 1);
+    pointer-events: none;
+
+    &--open {
+        transform: translateX(0);
+        pointer-events: auto;
+    }
+}
+
+.gw-drawer__header {
+    flex: none;
+    padding: 24px 28px 18px;
+    border-bottom: 1px solid var(--yn-line-2);
+}
+
+.gw-drawer__header-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.gw-drawer__title {
+    margin: 0 0 6px;
+    font-size: 21px;
+    font-weight: 600;
+    color: var(--yn-text);
+    letter-spacing: -0.01em;
+}
+
+.gw-drawer__subtitle {
+    margin: 0;
+    font-size: 13px;
+    color: var(--yn-text-3);
+    line-height: 1.5;
+    max-width: 440px;
+}
+
+.gw-drawer__header-bottom {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-top: 18px;
+}
+
+.gw-drawer__body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 28px 28px;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+.gw-close-btn {
+    flex: none;
+    width: 34px;
+    height: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
+    border-radius: 9px;
+    color: var(--yn-text-2);
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+
+    &:hover {
+        background: var(--yn-bg-hover);
+        color: var(--yn-text);
+    }
+}
+
+.gw-legend {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    font-size: 12.5px;
+    color: var(--yn-text-2);
+}
+
+.gw-legend__item {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+}
+
+.gw-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex: none;
+
+    &--sm {
+        width: 8px;
+        height: 8px;
+    }
+
+    &--pulse {
+        animation: gwPulseDot 1.2s ease-in-out infinite;
+    }
+}
+
+.gw-group {
+    margin-bottom: 24px;
+}
+
+.gw-group__header {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    margin-bottom: 12px;
+}
+
+.gw-group__host {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    color: var(--yn-text-3);
+    font-family: var(--yn-font-mono);
+}
+
+.gw-group__count {
+    font-size: 11px;
+    color: var(--yn-text-3);
+}
+
+.gw-group__line {
+    flex: 1;
+    height: 1px;
+    background: var(--yn-line-2);
+}
+
+.gw-group__nodes {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.gw-card {
+    border: 1px solid var(--yn-line-2);
+    background: var(--yn-bg-2);
+    border-radius: 13px;
+    padding: 16px 18px;
+    transition: border-color 0.15s, background 0.15s;
+
+    &--active {
+        border-color: rgba(255, 192, 97, 0.45);
+        background: var(--yn-accent-soft);
+    }
+
+    &--activatable {
+        cursor: pointer;
+
+        &:hover {
+            border-color: var(--yn-line-2);
+            background: var(--yn-bg-hover);
+        }
+    }
+
+    &--offline {
+        cursor: default;
+        opacity: 0.65;
+    }
+}
+
+.gw-card__header {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+
+.gw-card__info {
+    flex: 1;
+    min-width: 0;
+}
+
+.gw-card__title-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 3px;
+}
+
+.gw-card__numa {
+    font-size: 15.5px;
+    font-weight: 600;
+    color: var(--yn-text);
+}
+
+.gw-card__status {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: capitalize;
+}
+
+.gw-card__addr {
+    font-size: 13px;
+    color: var(--yn-text-2);
+    font-family: var(--yn-font-mono);
+}
+
+.gw-card__actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: none;
+}
+
+.gw-badge {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    padding: 2px 8px;
+    border-radius: 6px;
+    text-transform: uppercase;
+
+    &--active {
+        color: #1a140a;
+        background: var(--yn-accent);
+    }
+
+    &--hidden {
+        visibility: hidden;
+    }
+}
+
+// "Add gateway" accent button — uses the accent-tinted style from the design.
+.gw-btn--add {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    font-size: 13px;
+    font-family: inherit;
+    font-weight: 600;
+    border-radius: 8px;
+    cursor: pointer;
+    background: var(--yn-accent-soft);
+    border: 1px solid rgba(255, 192, 97, 0.32);
+    color: var(--yn-accent);
+    transition: background 0.15s;
+
+    &:hover { background: rgba(255, 192, 97, 0.22); }
+}
+
+.gw-form {
+    display: flex;
+    flex-direction: column;
+    gap: 11px;
+    border: 1px solid rgba(255, 192, 97, 0.45);
+    background: var(--yn-accent-soft);
+    border-radius: 13px;
+    padding: 16px 18px;
+    animation: gwFadeIn 0.13s ease-out;
+}
+
+.gw-form__title {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--yn-text);
+    margin-bottom: 3px;
+}
+
+.gw-form__row {
+    display: flex;
+    gap: 10px;
+}
+
+.gw-form__field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    &--grow { flex: 1; }
+    &--numa { width: 104px; }
+}
+
+.gw-form__label {
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    color: var(--yn-text-2);
+    text-transform: uppercase;
+}
+
+.gw-form__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 3px;
+}
+
+.gw-add-form-wrapper {
+    margin-bottom: 24px;
+}
+
+.gw-config-note {
+    display: flex;
+    align-items: flex-start;
+    gap: 11px;
+    padding: 14px 16px;
+    background: var(--yn-bg-2);
+    border: 1px solid var(--yn-line-2);
+    border-radius: 11px;
+    font-size: 12.5px;
+    color: var(--yn-text-3);
+    line-height: 1.55;
+    margin-top: 4px;
+}
+
+// Light-mode token overrides scoped to .gw-drawer, matching the
+// same surface values that tokens.scss applies to .yn-drawer.
+[data-theme="light"] .gw-drawer {
+    --yn-page-bg:  #FAF7F2;
+    --yn-panel:    #FFFFFF;
+    --yn-bg-2:     #F3EFE9;
+    --yn-bg-3:     #EBE6DE;
+    --yn-bg-hover: #EBE6DE;
+    --yn-line:     rgba(80, 60, 30, 0.08);
+    --yn-line-2:   rgba(80, 60, 30, 0.16);
+    --yn-text:     #1A1410;
+    --yn-text-2:   #5C4E3A;
+    --yn-text-3:   #9C8B74;
+}

--- a/web/src/gateways/GatewayDrawer.tsx
+++ b/web/src/gateways/GatewayDrawer.tsx
@@ -1,0 +1,453 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import { useGateways } from './GatewayContext';
+import type { Gateway, GatewayStatus } from './types';
+import './GatewayDrawer.scss';
+
+/** Derives a base URL from a raw address string entered by the user. */
+export const deriveBaseUrl = (addr: string): string => {
+    const trimmed = addr.trim();
+    if (!trimmed) {
+        return '';
+    }
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+        return trimmed;
+    }
+    return `http://${trimmed}`;
+};
+
+const statusColor = (status: GatewayStatus): string => {
+    switch (status) {
+        case 'online': return 'var(--gw-status-online)';
+        case 'degraded': return 'var(--gw-status-degraded)';
+        case 'checking': return 'var(--gw-status-checking)';
+        default: return 'var(--gw-status-offline)';
+    }
+};
+
+interface GatewayFormState {
+    host: string;
+    numa: string;
+    addr: string;
+}
+
+const emptyForm = (): GatewayFormState => ({ host: '', numa: '0', addr: '' });
+
+interface GatewayFormProps {
+    title: string;
+    saveLabel: string;
+    initial: GatewayFormState;
+    onSave: (values: GatewayFormState) => void;
+    onCancel: () => void;
+}
+
+const GatewayForm: React.FC<GatewayFormProps> = ({ title, saveLabel, initial, onSave, onCancel }) => {
+    const [values, setValues] = useState<GatewayFormState>(initial);
+
+    const set = (field: keyof GatewayFormState) => (e: React.ChangeEvent<HTMLInputElement>) =>
+        setValues((prev) => ({ ...prev, [field]: e.target.value }));
+
+    const handleSave = () => {
+        onSave(values);
+    };
+
+    return (
+        <div
+            className="gw-form"
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => e.stopPropagation()}
+        >
+            <div className="gw-form__title">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="var(--yn-accent)" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+                <span>{title}</span>
+            </div>
+            <div className="gw-form__row">
+                <label className="gw-form__field gw-form__field--grow">
+                    <span className="gw-form__label">Host / name</span>
+                    <input
+                        className="yn-input yn-input--mono"
+                        value={values.host}
+                        onChange={set('host')}
+                        placeholder="gateway-01"
+                    />
+                </label>
+                <label className="gw-form__field gw-form__field--numa">
+                    <span className="gw-form__label">NUMA</span>
+                    <input
+                        className="yn-input yn-input--mono"
+                        type="number"
+                        min={0}
+                        value={values.numa}
+                        onChange={set('numa')}
+                        placeholder="0"
+                    />
+                </label>
+            </div>
+            <label className="gw-form__field">
+                <span className="gw-form__label">API address</span>
+                <input
+                    className="yn-input yn-input--mono"
+                    value={values.addr}
+                    onChange={set('addr')}
+                    placeholder="10.0.0.10:8080"
+                />
+            </label>
+            <div className="gw-form__actions">
+                <button className="yn-btn yn-btn--ghost" onClick={onCancel}>Cancel</button>
+                <button className="yn-btn yn-btn--primary" onClick={handleSave}>{saveLabel}</button>
+            </div>
+        </div>
+    );
+};
+
+interface GatewayCardProps {
+    gateway: Gateway;
+    isActive: boolean;
+    editingId: string | null;
+    onSetActive: (id: string) => void;
+    onStartEdit: (gw: Gateway) => void;
+    onDelete: (id: string) => void;
+    onSaveEdit: (id: string, values: GatewayFormState) => void;
+    onCancelEdit: () => void;
+}
+
+const GatewayCard: React.FC<GatewayCardProps> = ({
+    gateway,
+    isActive,
+    editingId,
+    onSetActive,
+    onStartEdit,
+    onDelete,
+    onSaveEdit,
+    onCancelEdit,
+}) => {
+    const isEditing = editingId === gateway.id;
+    const dotColor = statusColor(gateway.status);
+    const isActivatable = !isActive && gateway.status !== 'offline';
+
+    const handleCardClick = () => {
+        if (isActivatable) {
+            onSetActive(gateway.id);
+        }
+    };
+
+    const handleCardKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (isActivatable && (e.key === 'Enter' || e.key === ' ')) {
+            e.preventDefault();
+            onSetActive(gateway.id);
+        }
+    };
+
+    const handleEditClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onStartEdit(gateway);
+    };
+
+    const handleDeleteClick = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onDelete(gateway.id);
+    };
+
+    const handleEditKeyDown = (e: React.KeyboardEvent) => {
+        e.stopPropagation();
+    };
+
+    const handleDeleteKeyDown = (e: React.KeyboardEvent) => {
+        e.stopPropagation();
+    };
+
+    const cardClass = [
+        'gw-card',
+        isActive ? 'gw-card--active' : '',
+        isActivatable ? 'gw-card--activatable' : '',
+        gateway.status === 'offline' ? 'gw-card--offline' : '',
+    ].filter(Boolean).join(' ');
+
+    return (
+        <div
+            className={cardClass}
+            onClick={handleCardClick}
+            onKeyDown={handleCardKeyDown}
+            role={isActivatable ? 'button' : undefined}
+            tabIndex={isActivatable ? 0 : undefined}
+            aria-pressed={isActivatable ? isActive : undefined}
+        >
+            {isEditing ? (
+                <GatewayForm
+                    title="Edit gateway"
+                    saveLabel="Save"
+                    initial={{ host: gateway.host, numa: String(gateway.numa), addr: gateway.addr }}
+                    onSave={(vals) => onSaveEdit(gateway.id, vals)}
+                    onCancel={onCancelEdit}
+                />
+            ) : (
+                <>
+                    <div className="gw-card__header">
+                        <span
+                            className={`gw-dot${gateway.status === 'checking' ? ' gw-dot--pulse' : ''}`}
+                            style={{ background: dotColor, boxShadow: `0 0 9px ${dotColor}70` }}
+                        />
+                        <div className="gw-card__info">
+                            <div className="gw-card__title-row">
+                                <span className="gw-card__numa">NUMA {gateway.numa}</span>
+                                <span className="gw-card__status" style={{ color: dotColor }}>
+                                    {gateway.status}
+                                </span>
+                                <span className={`gw-badge gw-badge--active${isActive ? '' : ' gw-badge--hidden'}`}>
+                                    Active
+                                </span>
+                            </div>
+                            <div className="gw-card__addr">{gateway.addr}</div>
+                        </div>
+                        {!gateway.builtin && (
+                            <div className="gw-card__actions">
+                                <button
+                                    className="yn-icon-btn"
+                                    onClick={handleEditClick}
+                                    onKeyDown={handleEditKeyDown}
+                                    aria-label="Edit"
+                                >
+                                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                                        <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                                        <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+                                    </svg>
+                                </button>
+                                <button
+                                    className="yn-icon-btn yn-icon-btn--danger"
+                                    onClick={handleDeleteClick}
+                                    onKeyDown={handleDeleteKeyDown}
+                                    aria-label="Delete"
+                                >
+                                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                                        <polyline points="3 6 5 6 21 6" />
+                                        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                                    </svg>
+                                </button>
+                            </div>
+                        )}
+                    </div>
+                </>
+            )}
+        </div>
+    );
+};
+
+interface GatewayGroup {
+    host: string;
+    nodes: Gateway[];
+}
+
+const groupByHost = (gateways: Gateway[]): GatewayGroup[] => {
+    const order: string[] = [];
+    const byHost: Record<string, Gateway[]> = {};
+    for (const gw of gateways) {
+        if (!byHost[gw.host]) {
+            byHost[gw.host] = [];
+            order.push(gw.host);
+        }
+        byHost[gw.host].push(gw);
+    }
+    return order.map((host) => ({ host, nodes: byHost[host] }));
+};
+
+interface GatewayDrawerProps {
+    open: boolean;
+    onClose: () => void;
+    /** Measured sidebar pixel width used to position the drawer flush to the sidebar edge. */
+    asideSize?: number;
+}
+
+/** Full-overlay drawer listing all gateway nodes, grouped by host. */
+export const GatewayDrawer: React.FC<GatewayDrawerProps> = ({ open, onClose, asideSize }) => {
+    const { gateways, activeGateway, addGateway, updateGateway, deleteGateway, setActive } = useGateways();
+    const [isAdding, setIsAdding] = useState(false);
+    const [editingId, setEditingId] = useState<string | null>(null);
+
+    const handleClose = useCallback(() => {
+        setIsAdding(false);
+        setEditingId(null);
+        onClose();
+    }, [onClose]);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                handleClose();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [open, handleClose]);
+
+    const handleStartAdd = useCallback(() => {
+        setEditingId(null);
+        setIsAdding(true);
+    }, []);
+
+    const handleCancelForm = useCallback(() => {
+        setIsAdding(false);
+        setEditingId(null);
+    }, []);
+
+    const handleSaveAdd = useCallback((vals: GatewayFormState) => {
+        const host = vals.host.trim() || 'unnamed';
+        const numa = parseInt(vals.numa, 10) || 0;
+        const addr = vals.addr.trim() || '0.0.0.0:8080';
+        addGateway({
+            host,
+            numa,
+            addr,
+            baseUrl: deriveBaseUrl(addr),
+            status: 'online',
+        });
+        setIsAdding(false);
+    }, [addGateway]);
+
+    const handleSaveEdit = useCallback((id: string, vals: GatewayFormState) => {
+        const host = vals.host.trim() || 'unnamed';
+        const numa = parseInt(vals.numa, 10) || 0;
+        const addr = vals.addr.trim() || '0.0.0.0:8080';
+        updateGateway(id, { host, numa, addr, baseUrl: deriveBaseUrl(addr) });
+        setEditingId(null);
+    }, [updateGateway]);
+
+    const handleStartEdit = useCallback((gw: Gateway) => {
+        setIsAdding(false);
+        setEditingId(gw.id);
+    }, []);
+
+    const handleDelete = useCallback((id: string) => {
+        deleteGateway(id);
+    }, [deleteGateway]);
+
+    const handleSetActive = useCallback((id: string) => {
+        setActive(id);
+    }, [setActive]);
+
+    const onlineCount = gateways.filter((g) => g.status === 'online').length;
+    const degradedCount = gateways.filter((g) => g.status === 'degraded').length;
+    const offlineCount = gateways.filter((g) => g.status === 'offline').length;
+    const groups = groupByHost(gateways);
+
+    const positionStyle = asideSize && asideSize > 0
+        ? { left: `${asideSize}px`, maxWidth: `calc(100vw - ${asideSize}px)` }
+        : undefined;
+
+    const backdropStyle = asideSize && asideSize > 0
+        ? { left: `${asideSize}px` }
+        : undefined;
+
+    return (
+        <>
+            <div
+                className={`gw-backdrop${open ? ' gw-backdrop--open' : ''}`}
+                style={backdropStyle}
+                onClick={handleClose}
+                aria-hidden="true"
+            />
+            <section
+                className={`gw-drawer${open ? ' gw-drawer--open' : ''}`}
+                style={positionStyle}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Gateways"
+            >
+                <div className="gw-drawer__header">
+                    <div className="gw-drawer__header-top">
+                        <div>
+                            <h2 className="gw-drawer__title">Gateways</h2>
+                            <p className="gw-drawer__subtitle">
+                                Control-plane endpoints — one per NUMA node. Each gateway owns a single NUMA; pick which one this UI talks to.
+                            </p>
+                        </div>
+                        <button className="gw-close-btn" onClick={handleClose} aria-label="Close">
+                            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                                <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+                            </svg>
+                        </button>
+                    </div>
+                    <div className="gw-drawer__header-bottom">
+                        <div className="gw-legend">
+                            <span className="gw-legend__item">
+                                <span className="gw-dot gw-dot--sm" style={{ background: 'var(--gw-status-online)' }} />
+                                {onlineCount} online
+                            </span>
+                            <span className="gw-legend__item">
+                                <span className="gw-dot gw-dot--sm" style={{ background: 'var(--gw-status-degraded)' }} />
+                                {degradedCount} degraded
+                            </span>
+                            <span className="gw-legend__item">
+                                <span className="gw-dot gw-dot--sm" style={{ background: 'var(--gw-status-offline)' }} />
+                                {offlineCount} offline
+                            </span>
+                        </div>
+                        <button className="gw-btn--add" onClick={handleStartAdd}>
+                            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                                <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+                            </svg>
+                            Add gateway
+                        </button>
+                    </div>
+                </div>
+
+                <div className="gw-drawer__body">
+                    {isAdding && (
+                        <div className="gw-add-form-wrapper">
+                            <GatewayForm
+                                title="New gateway"
+                                saveLabel="Add gateway"
+                                initial={emptyForm()}
+                                onSave={handleSaveAdd}
+                                onCancel={handleCancelForm}
+                            />
+                        </div>
+                    )}
+
+                    {groups.map((group) => (
+                        <div key={group.host} className="gw-group">
+                            <div className="gw-group__header">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--yn-text-3)" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round">
+                                    <rect x="2" y="2" width="20" height="8" rx="2" />
+                                    <rect x="2" y="14" width="20" height="8" rx="2" />
+                                    <line x1="6" y1="6" x2="6.01" y2="6" /><line x1="6" y1="18" x2="6.01" y2="18" />
+                                </svg>
+                                <span className="gw-group__host">{group.host.toUpperCase()}</span>
+                                <span className="gw-group__count">{group.nodes.length} NUMA</span>
+                                <div className="gw-group__line" />
+                            </div>
+                            <div className="gw-group__nodes">
+                                {group.nodes.map((gw) => (
+                                    <GatewayCard
+                                        key={gw.id}
+                                        gateway={gw}
+                                        isActive={gw.id === activeGateway?.id}
+                                        editingId={editingId}
+                                        onSetActive={handleSetActive}
+                                        onStartEdit={handleStartEdit}
+                                        onDelete={handleDelete}
+                                        onSaveEdit={handleSaveEdit}
+                                        onCancelEdit={handleCancelForm}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+
+                    <div className="gw-config-note">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--yn-text-3)" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 1 }}>
+                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                            <polyline points="14 2 14 8 20 8" />
+                        </svg>
+                        <span>
+                            Stored in this browser. Edits here are saved locally.
+                        </span>
+                    </div>
+                </div>
+            </section>
+        </>
+    );
+};

--- a/web/src/gateways/deriveBaseUrl.test.ts
+++ b/web/src/gateways/deriveBaseUrl.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { deriveBaseUrl } from './GatewayDrawer';
+
+describe('deriveBaseUrl', () => {
+    it('returns empty string for an empty input', () => {
+        expect(deriveBaseUrl('')).toBe('');
+    });
+
+    it('returns empty string for whitespace-only input', () => {
+        expect(deriveBaseUrl('   ')).toBe('');
+    });
+
+    it('prepends http:// to a bare host:port', () => {
+        expect(deriveBaseUrl('10.0.0.10:8080')).toBe('http://10.0.0.10:8080');
+    });
+
+    it('prepends http:// to a bare hostname', () => {
+        expect(deriveBaseUrl('gateway-01')).toBe('http://gateway-01');
+    });
+
+    it('leaves an http:// URL unchanged', () => {
+        expect(deriveBaseUrl('http://10.0.0.10:8080')).toBe('http://10.0.0.10:8080');
+    });
+
+    it('leaves an https:// URL unchanged', () => {
+        expect(deriveBaseUrl('https://gateway.example.com')).toBe('https://gateway.example.com');
+    });
+
+    it('trims leading and trailing whitespace before processing', () => {
+        expect(deriveBaseUrl('  10.0.0.1:9090  ')).toBe('http://10.0.0.1:9090');
+    });
+});

--- a/web/src/gateways/gatewayCommands.ts
+++ b/web/src/gateways/gatewayCommands.ts
@@ -1,0 +1,44 @@
+import type { Command } from '../components/command-palette/types';
+import type { Gateway } from './types';
+
+/**
+ * Builds the "Gateways" command group for the global command palette.
+ *
+ * Returns an "Edit gateways…" command first, followed by one "Switch gateway:"
+ * command per gateway. The currently-active gateway is labelled with "(active)".
+ */
+export const gatewayCommands = (
+    gateways: Gateway[],
+    activeId: string | null,
+    onSetActive: (id: string) => void,
+    onOpenDrawer: () => void,
+): Command[] => {
+    const editCmd: Command = {
+        id: '__gw_edit',
+        icon: '⚙',
+        label: 'Edit gateways…',
+        keywords: 'gateways manage edit endpoints control plane add',
+        group: 'Gateways',
+        onSelect: () => onOpenDrawer(),
+    };
+
+    const switchCmds: Command[] = gateways
+        .filter((gw) => gw.status !== 'offline')
+        .map((gw) => {
+            const isActive = gw.id === activeId;
+            const label = isActive
+                ? `Switch gateway: ${gw.host} · NUMA ${gw.numa} (active)`
+                : `Switch gateway: ${gw.host} · NUMA ${gw.numa}`;
+            return {
+                id: `__gw_switch_${gw.id}`,
+                icon: '⇄',
+                label,
+                sub: `${gw.addr} · ${gw.status}`,
+                keywords: `gateway switch select activate ${gw.host} NUMA ${gw.numa} ${gw.addr}`,
+                group: 'Gateways',
+                onSelect: () => onSetActive(gw.id),
+            };
+        });
+
+    return [editCmd, ...switchCmds];
+};

--- a/web/src/gateways/index.ts
+++ b/web/src/gateways/index.ts
@@ -1,0 +1,5 @@
+export type { Gateway, GatewayStatus } from './types';
+export { GatewayProvider, useGateways } from './GatewayContext';
+export type { GatewayContextValue } from './GatewayContext';
+export { GatewayDrawer } from './GatewayDrawer';
+export { gatewayCommands } from './gatewayCommands';

--- a/web/src/gateways/seed.ts
+++ b/web/src/gateways/seed.ts
@@ -1,0 +1,25 @@
+import type { Gateway } from './types';
+
+/**
+ * Default gateway inventory seeded on first load.
+ *
+ * The builtin localhost entry is always first and carries an empty baseUrl
+ * so same-origin API calls work out of the box against the dev server or
+ * production host. It is non-deletable and non-editable.
+ */
+export const SEED_GATEWAYS: Gateway[] = [
+    {
+        id: 'localhost',
+        host: 'localhost',
+        numa: 0,
+        addr: 'same-origin',
+        baseUrl: '',
+        status: 'online',
+        builtin: true,
+    }
+];
+
+/** The builtin localhost entry that is always present. */
+export const BUILTIN_GATEWAY: Gateway = SEED_GATEWAYS[0];
+
+export const SEED_ACTIVE_ID = 'localhost';

--- a/web/src/gateways/storage.test.ts
+++ b/web/src/gateways/storage.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { loadFromStorage, saveToStorage } from './storage';
+import { SEED_GATEWAYS, SEED_ACTIVE_ID, BUILTIN_GATEWAY } from './seed';
+
+const STORAGE_KEY = 'yanet_gateways_v1';
+
+const makeMockStorage = (): Storage => {
+    const store: Record<string, string> = {};
+    return {
+        getItem: (key: string) => store[key] ?? null,
+        setItem: (key: string, value: string) => { store[key] = value; },
+        removeItem: (key: string) => { delete store[key]; },
+        clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+        get length() { return Object.keys(store).length; },
+        key: (idx: number) => Object.keys(store)[idx] ?? null,
+    };
+};
+
+describe('loadFromStorage', () => {
+    let mockStorage: Storage;
+
+    beforeEach(() => {
+        mockStorage = makeMockStorage();
+        vi.stubGlobal('localStorage', mockStorage);
+    });
+
+    it('returns seed data when localStorage is empty', () => {
+        const result = loadFromStorage();
+        expect(result.gateways).toEqual(SEED_GATEWAYS);
+        expect(result.activeId).toBe(SEED_ACTIVE_ID);
+    });
+
+    it('returns seed data when localStorage contains invalid JSON', () => {
+        mockStorage.setItem(STORAGE_KEY, 'not-json{{{');
+        const result = loadFromStorage();
+        expect(result.gateways).toEqual(SEED_GATEWAYS);
+        expect(result.activeId).toBe(SEED_ACTIVE_ID);
+    });
+
+    it('returns seed data when stored state has wrong shape', () => {
+        mockStorage.setItem(STORAGE_KEY, JSON.stringify({ wrong: true }));
+        const result = loadFromStorage();
+        expect(result.gateways).toEqual(SEED_GATEWAYS);
+        expect(result.activeId).toBe(SEED_ACTIVE_ID);
+    });
+
+    it('returns seed data when gateways field is not an array', () => {
+        mockStorage.setItem(STORAGE_KEY, JSON.stringify({ gateways: 'nope', activeId: 'x' }));
+        const result = loadFromStorage();
+        expect(result.gateways).toEqual(SEED_GATEWAYS);
+    });
+
+    it('returns persisted data when storage is valid', () => {
+        const extra = { id: 'gw-01', host: 'gateway-01', numa: 0, addr: '10.0.0.10:8080', baseUrl: 'http://10.0.0.10:8080', status: 'online' as const };
+        const stored = { gateways: [...SEED_GATEWAYS, extra], activeId: 'gw-01' };
+        mockStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+        const result = loadFromStorage();
+        expect(result.gateways).toHaveLength(2);
+        expect(result.activeId).toBe('gw-01');
+    });
+
+    it('re-injects the builtin gateway when stored list lacks one', () => {
+        const withoutBuiltin = SEED_GATEWAYS.filter((g) => !g.builtin);
+        mockStorage.setItem(STORAGE_KEY, JSON.stringify({ gateways: withoutBuiltin, activeId: 'fra01-n0' }));
+        const result = loadFromStorage();
+        expect(result.gateways[0]).toEqual(BUILTIN_GATEWAY);
+        expect(result.gateways.some((g) => g.builtin === true)).toBe(true);
+    });
+});
+
+describe('saveToStorage + loadFromStorage round-trip', () => {
+    let mockStorage: Storage;
+
+    beforeEach(() => {
+        mockStorage = makeMockStorage();
+        vi.stubGlobal('localStorage', mockStorage);
+    });
+
+    it('persists and reloads the gateway list', () => {
+        saveToStorage(SEED_GATEWAYS, 'fra01-n1');
+        const result = loadFromStorage();
+        expect(result.gateways).toEqual(SEED_GATEWAYS);
+        expect(result.activeId).toBe('fra01-n1');
+    });
+
+    it('builtin gateway survives a save/load round-trip with its flag intact', () => {
+        saveToStorage(SEED_GATEWAYS, SEED_ACTIVE_ID);
+        const result = loadFromStorage();
+        const builtin = result.gateways.find((g) => g.builtin === true);
+        expect(builtin).toBeDefined();
+        expect(builtin).toEqual(BUILTIN_GATEWAY);
+    });
+});

--- a/web/src/gateways/storage.ts
+++ b/web/src/gateways/storage.ts
@@ -1,0 +1,54 @@
+import type { Gateway } from './types';
+import { SEED_GATEWAYS, SEED_ACTIVE_ID, BUILTIN_GATEWAY } from './seed';
+
+const STORAGE_KEY = 'yanet_gateways_v1';
+
+interface StoredState {
+    gateways: Gateway[];
+    activeId: string;
+}
+
+/**
+ * Ensures the builtin localhost gateway is always the first entry.
+ *
+ * If the stored list has no builtin entry (e.g. saved before this feature was
+ * added), the builtin is prepended so the invariant holds after every load.
+ */
+const ensureBuiltin = (gateways: Gateway[]): Gateway[] => {
+    if (gateways.some((g) => g.builtin === true)) {
+        return gateways;
+    }
+    return [BUILTIN_GATEWAY, ...gateways];
+};
+
+/** Load gateways and active id from localStorage, falling back to the seed on any error. */
+export const loadFromStorage = (): StoredState => {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) {
+            return { gateways: SEED_GATEWAYS, activeId: SEED_ACTIVE_ID };
+        }
+        const parsed = JSON.parse(raw) as unknown;
+        if (
+            typeof parsed !== 'object' ||
+            parsed === null ||
+            !Array.isArray((parsed as StoredState).gateways) ||
+            typeof (parsed as StoredState).activeId !== 'string'
+        ) {
+            return { gateways: SEED_GATEWAYS, activeId: SEED_ACTIVE_ID };
+        }
+        const state = parsed as StoredState;
+        return { gateways: ensureBuiltin(state.gateways), activeId: state.activeId };
+    } catch {
+        return { gateways: SEED_GATEWAYS, activeId: SEED_ACTIVE_ID };
+    }
+};
+
+/** Persist gateways and active id to localStorage. */
+export const saveToStorage = (gateways: Gateway[], activeId: string): void => {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify({ gateways, activeId }));
+    } catch {
+        // Storage quota exceeded or private browsing — ignore.
+    }
+};

--- a/web/src/gateways/types.ts
+++ b/web/src/gateways/types.ts
@@ -1,0 +1,25 @@
+/** Status of a gateway control-plane endpoint. */
+export type GatewayStatus = 'online' | 'degraded' | 'offline' | 'checking';
+
+/** A single control-plane endpoint, scoped to one NUMA node. */
+export interface Gateway {
+    id: string;
+    host: string;
+    numa: number;
+    /** API address shown in the UI, e.g. "10.20.0.11:8080". */
+    addr: string;
+    /**
+     * Absolute origin used to re-point API fetch calls.
+     *
+     * An empty string means same-origin (the current dev server or production host).
+     */
+    baseUrl: string;
+    status: GatewayStatus;
+    /**
+     * Whether this is a built-in, non-deletable system entry.
+     *
+     * Built-in gateways (e.g. the localhost same-origin entry) are always present,
+     * cannot be edited or deleted, and survive localStorage upgrades.
+     */
+    builtin?: boolean;
+}


### PR DESCRIPTION
Add a Gateways panel in the sidebar for choosing which control-plane endpoint the web UI talks to. The endpoint list and the active selection are seeded from a built-in same-origin entry and persisted in the browser.

Selecting a gateway re-points API requests to its base URL and reloads the current page against it. The built-in same-origin entry is permanent and cannot be edited or removed.

Add command-palette actions to switch the active gateway or open the manager, ranked below page and navigation commands.