### PR TITLE
fix(web): address gateway selector review findings

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -61,12 +61,14 @@ type CancelIdleCallback = (id: IdleHandle) => void;
 const GlobalPalette = ({
     handlePageChange,
     onOpenGatewayDrawer,
+    onSetActiveGateway,
 }: {
     handlePageChange: (id: PageId) => void;
     onOpenGatewayDrawer: () => void;
+    onSetActiveGateway: (id: string) => void;
 }): React.JSX.Element => {
     const { open, closePalette, contribution, helpOpen, closeHelp, helpShortcuts, openHelp } = usePalette();
-    const { gateways, activeGateway, setActive } = useGateways();
+    const { gateways, activeGateway } = useGateways();
     const navCmds = useMemo(() => navigationCommands(handlePageChange), [handlePageChange]);
 
     const showShortcutsCmd = useMemo((): Command => ({
@@ -80,8 +82,8 @@ const GlobalPalette = ({
     }), [openHelp]);
 
     const gwCmds = useMemo(
-        () => gatewayCommands(gateways, activeGateway?.id ?? null, setActive, onOpenGatewayDrawer),
-        [gateways, activeGateway, setActive, onOpenGatewayDrawer],
+        () => gatewayCommands(gateways, activeGateway?.id ?? null, onSetActiveGateway, onOpenGatewayDrawer),
+        [gateways, activeGateway, onSetActiveGateway, onOpenGatewayDrawer],
     );
 
     const commands = useMemo(() => {
@@ -124,13 +126,13 @@ const AppContentInner = (): React.JSX.Element => {
     const [gatewayDrawerOpen, setGatewayDrawerOpen] = useState(false);
     const [asideSize, setAsideSize] = useState<number>(0);
     const unsavedGuardRef = useRef<(() => boolean) | null>(null);
-    const { activeGateway } = useGateways();
+    const { activeGateway, setActive } = useGateways();
 
-    useEffect(() => {
-        if (activeGateway) {
-            setApiBase(activeGateway.baseUrl);
-        }
-    }, [activeGateway]);
+    // Apply the base URL synchronously so it's already set before the keyed
+    // <Routes> subtree mounts — page mount effects must not see a stale base.
+    if (activeGateway) {
+        setApiBase(activeGateway.baseUrl);
+    }
 
     const handleOpenGatewayDrawer = useCallback(() => {
         setGatewayDrawerOpen(true);
@@ -206,6 +208,18 @@ const AppContentInner = (): React.JSX.Element => {
         navigate(`/${pageId}`);
     }, [navigate]);
 
+    /** Switches the active gateway with the same unsaved-changes guard as page navigation. */
+    const handleSetActiveGateway = useCallback((id: string): void => {
+        const guard = unsavedGuardRef.current;
+        if (guard && guard()) {
+            const ok = window.confirm('You have unsaved changes. Leave this page anyway?');
+            if (!ok) {
+                return;
+            }
+        }
+        setActive(id);
+    }, [setActive]);
+
     const handleSetSidebarDisabled = useCallback((disabled: boolean) => {
         setSidebarDisabled(disabled);
     }, []);
@@ -222,8 +236,8 @@ const AppContentInner = (): React.JSX.Element => {
     return (
         <SidebarContext.Provider value={sidebarContextValue}>
             <PaletteProvider>
-                <GlobalPalette handlePageChange={handlePageChange} onOpenGatewayDrawer={handleOpenGatewayDrawer} />
-                <GatewayDrawer open={gatewayDrawerOpen} onClose={handleCloseGatewayDrawer} asideSize={asideSize} />
+                <GlobalPalette handlePageChange={handlePageChange} onOpenGatewayDrawer={handleOpenGatewayDrawer} onSetActiveGateway={handleSetActiveGateway} />
+                <GatewayDrawer open={gatewayDrawerOpen} onClose={handleCloseGatewayDrawer} asideSize={asideSize} onSetActive={handleSetActiveGateway} />
                 <MainMenu
                     currentPage={currentPage}
                     onPageChange={handlePageChange}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -49,7 +49,9 @@ const callGRPCServiceWithBody = async <T>(
 
     let requestBody: string | Blob = jsonBody;
 
-    if (options?.compress) {
+    // Only compress for same-origin requests; cross-origin gateways don't allow
+    // Content-Encoding in CORS preflight, so skip compression when apiBase is set.
+    if (options?.compress && !apiBase) {
         requestBody = await compressGzip(jsonBody);
         headers['Content-Encoding'] = 'gzip';
     }

--- a/web/src/gateways/GatewayDrawer.tsx
+++ b/web/src/gateways/GatewayDrawer.tsx
@@ -256,10 +256,17 @@ interface GatewayDrawerProps {
     onClose: () => void;
     /** Measured sidebar pixel width used to position the drawer flush to the sidebar edge. */
     asideSize?: number;
+    /**
+     * Called when the user clicks a gateway card to activate it.
+     *
+     * Defaults to the context's setActive when omitted. App passes a guarded
+     * handler that checks for unsaved changes before switching.
+     */
+    onSetActive?: (id: string) => void;
 }
 
 /** Full-overlay drawer listing all gateway nodes, grouped by host. */
-export const GatewayDrawer: React.FC<GatewayDrawerProps> = ({ open, onClose, asideSize }) => {
+export const GatewayDrawer: React.FC<GatewayDrawerProps> = ({ open, onClose, asideSize, onSetActive }) => {
     const { gateways, activeGateway, addGateway, updateGateway, deleteGateway, setActive } = useGateways();
     const [isAdding, setIsAdding] = useState(false);
     const [editingId, setEditingId] = useState<string | null>(null);
@@ -325,8 +332,8 @@ export const GatewayDrawer: React.FC<GatewayDrawerProps> = ({ open, onClose, asi
     }, [deleteGateway]);
 
     const handleSetActive = useCallback((id: string) => {
-        setActive(id);
-    }, [setActive]);
+        (onSetActive ?? setActive)(id);
+    }, [onSetActive, setActive]);
 
     const onlineCount = gateways.filter((g) => g.status === 'online').length;
     const degradedCount = gateways.filter((g) => g.status === 'degraded').length;


### PR DESCRIPTION
Apply the active gateway's base URL synchronously before the routed page subtree remounts, so a freshly mounted page's first request always targets the selected gateway instead of the previous one.

Route gateway switching through the same unsaved-changes prompt as page navigation, so switching no longer silently discards in-progress edits.

Skip request compression for non-same-origin gateways, since the gateway CORS policy does not permit the Content-Encoding header on cross-origin requests.

Follow-up to #1262, addressing the automated review findings raised there.