### PR TITLE
fix(web): keep nested controls from activating table rows

### DIFF
--- a/web/src/components/VirtualTable/VirtualTable.test.tsx
+++ b/web/src/components/VirtualTable/VirtualTable.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isInteractiveTarget } from './VirtualTable';
+
+const el = (html: string, selector: string): Element => {
+    const host = document.createElement('div');
+    host.innerHTML = html;
+    const found = host.querySelector(selector);
+    if (!found) throw new Error(`no element matched ${selector}`);
+    return found;
+};
+
+describe('isInteractiveTarget', () => {
+    it('returns false for null', () => {
+        expect(isInteractiveTarget(null)).toBe(false);
+    });
+
+    it('returns false for a plain text cell', () => {
+        expect(isInteractiveTarget(el('<span>Alpha</span>', 'span'))).toBe(false);
+    });
+
+    it('returns true for a button', () => {
+        expect(isInteractiveTarget(el('<button>toggle</button>', 'button'))).toBe(true);
+    });
+
+    it('returns true for an element nested inside a button', () => {
+        expect(isInteractiveTarget(el('<button><svg><title>icon</title></svg></button>', 'title'))).toBe(true);
+    });
+
+    it('returns true for a link with href', () => {
+        expect(isInteractiveTarget(el('<a href="/x">link</a>', 'a'))).toBe(true);
+    });
+
+    it('returns false for a link without href', () => {
+        expect(isInteractiveTarget(el('<a>anchor</a>', 'a'))).toBe(false);
+    });
+
+    it('returns true for a role=button element', () => {
+        expect(isInteractiveTarget(el('<div role="button">x</div>', '[role="button"]'))).toBe(true);
+    });
+});

--- a/web/src/components/VirtualTable/VirtualTable.tsx
+++ b/web/src/components/VirtualTable/VirtualTable.tsx
@@ -13,6 +13,19 @@ const CHECKBOX_TRACK = '38px';
 const DEFAULT_INDEX_TRACK = 52;
 const DEFAULT_COLUMN_GAP = 14;
 
+/** Selector matching interactive controls that handle their own clicks. */
+const INTERACTIVE_TARGET_SELECTOR = 'button, select, a[href], [role="button"], [role="menuitem"]';
+
+/**
+ * Reports whether an event target sits inside an interactive control.
+ *
+ * Used to keep row activation from firing when a nested button, link, or menu
+ * item inside the row was the real click target. Mirrors the keyboard
+ * activation guard in useListNavigation so mouse and keyboard behave alike.
+ */
+export const isInteractiveTarget = (target: EventTarget | null): boolean =>
+    target instanceof Element && target.closest(INTERACTIVE_TARGET_SELECTOR) !== null;
+
 /** Column definition for VirtualTable. */
 export interface Column<T> {
     /** Unique key, used as React key. */
@@ -360,7 +373,11 @@ export function VirtualTable<T>({
                                     key={id || virtualRow.index}
                                     className={`${rowClasses} yn-tbl-line`}
                                     data-row-id={id}
-                                    onClick={() => onRowClick(id)}
+                                    onClick={(e) => {
+                                        // Let nested controls handle their own clicks.
+                                        if (isInteractiveTarget(e.target)) return;
+                                        onRowClick(id);
+                                    }}
                                     style={{
                                         position: 'absolute',
                                         top: virtualRow.start,


### PR DESCRIPTION
Follow-up to #1264, which landed a Codex-flagged issue: clicking a counter play/pause button inside an ACL rule row also opened the rule drawer, because the shared table row handler received the bubbled click.

- Row activation now ignores clicks that originate from nested interactive controls (buttons, links, menu items), so those controls act independently.
- The guard mirrors the table's existing keyboard activation behaviour, keeping mouse and keyboard consistent.
- Adds a unit test covering the guard.