### PR TITLE
fix(filter): fix double-free and leak in port classifier init

### DIFF
--- a/lib/filter/compiler/port.c
+++ b/lib/filter/compiler/port.c
@@ -150,14 +150,19 @@ FILTER_ATTR_COMPILER_INIT_FUNC(port_dst)(
 		return -1;
 	}
 	SET_OFFSET_OF(data, table);
-	return collect_port_values(
-		memory_context,
-		actions,
-		actions_count,
-		get_port_range_dst,
-		table,
-		registry
-	);
+	if (collect_port_values(
+		    memory_context,
+		    actions,
+		    actions_count,
+		    get_port_range_dst,
+		    table,
+		    registry
+	    )) {
+		SET_OFFSET_OF(data, NULL);
+		memory_bfree(memory_context, table, sizeof(struct value_table));
+		return -1;
+	}
+	return 0;
 }
 
 int
@@ -183,6 +188,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(port_src)(
 		    registry
 	    )) {
 		SET_OFFSET_OF(data, NULL);
+		memory_bfree(memory_context, table, sizeof(struct value_table));
 		return -1;
 	}
 


### PR DESCRIPTION
The port attribute compilers mishandled allocation failures during a filter rebuild.

- The destination-port compiler left its value-table pointer published after the collector had already released the table, so the filter teardown path freed it a second time.
- The source-port compiler reset the pointer but never released the table wrapper struct, leaking it on every failed rebuild.
- Reset the published pointer and free the wrapper on failure in both compilers, matching the device, vlan and ip-fragment compilers.