### PR TITLE
fix(filter): free proto-range classifier on init failure

### DIFF
--- a/lib/filter/compiler/proto_range.c
+++ b/lib/filter/compiler/proto_range.c
@@ -129,6 +129,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(proto_range)(
 		    mctx, rules, rule_count, &classifier->table, registry
 	    )) {
 		SET_OFFSET_OF(data, NULL);
+		memory_bfree(mctx, classifier, sizeof(*classifier));
 		return -1;
 	}
 


### PR DESCRIPTION
The proto-range attribute compiler reset its published pointer on a build failure but never released the classifier wrapper struct it had allocated, leaking it on every failed filter rebuild.

- Release the wrapper struct on the failure path, pairing the allocation with a free as the device, vlan and ip-fragment compilers do.