### PR TITLE
fix(filter): release segment classifier btree on init failure

### DIFF
--- a/lib/filter/compiler/segments.c
+++ b/lib/filter/compiler/segments.c
@@ -212,6 +212,7 @@ segments_classifier_u16_init(
 	if (fill_registry_from_segments_u16(
 		    classifier, registry, segment_count, segments, x_coords
 	    ) != 0) {
+		btree_u16_fini(&classifier->btree);
 		memory_bfree(
 			mctx,
 			ADDR_OF(&classifier->open),
@@ -407,6 +408,7 @@ segments_classifier_u32_init(
 	if (fill_registry_from_segments_u32(
 		    classifier, registry, segment_count, segments, x_coords
 	    ) != 0) {
+		btree_u32_fini(&classifier->btree);
 		memory_bfree(
 			mctx,
 			ADDR_OF(&classifier->open),
@@ -603,6 +605,7 @@ segments_classifier_u64_init(
 	if (fill_registry_from_segments_u64(
 		    classifier, registry, segment_count, segments, x_coords
 	    ) != 0) {
+		btree_u64_fini(&classifier->btree);
 		memory_bfree(
 			mctx,
 			ADDR_OF(&classifier->open),


### PR DESCRIPTION
The segment classifier compilers built their search tree before populating the value registry but did not release that tree when the registry population failed, leaking it on the error path.

- Finalize the search tree in each error path before returning, for all three classifier widths.
- These classifiers currently feed only the fast-path attributes, so the impact is limited, but the lifecycle is now correct.