### PR TITLE
fix(common): avoid freeing an empty range index

### DIFF
--- a/common/range_index.h
+++ b/common/range_index.h
@@ -107,6 +107,10 @@ range_index_remap(
 
 static inline void
 range_index_free(struct range_index *range_index) {
+	if (range_index->count == 0) {
+		radix_free(&range_index->radix);
+		return;
+	}
 	uint64_t capacity = 1 << uint64_log_up(range_index->count);
 	memory_bfree(
 		ADDR_OF(&range_index->memory_context),


### PR DESCRIPTION
range_index_free assumed the value array was always allocated, but an index that was initialized and never grown keeps a null array. On that path it still computed a non-zero size and asked the allocator to free a null block, corrupting the arena free list.

- This is reachable when filter compilation runs out of memory before inserting any range into the index.
- Skip the value-array free when the index is empty, releasing only the radix (which is always initialized).