### PR TITLE
chore(raii-sweep): refine lifecycle convention and add structural scanner

### DIFF
--- a/.claude/skills/raii-sweep/SKILL.md
+++ b/.claude/skills/raii-sweep/SKILL.md
@@ -1,21 +1,25 @@
 ---
 name: raii-sweep
 description: >-
-  Weekly maintenance sweep that restores RAII symmetry in the YANET2 C code:
-  every lifecycle pair must follow new/init/fini/free semantics (new allocates
-  the struct, init fills fields, fini releases field memory, free deallocates
-  the struct). Finds misnamed destructors (free that is semantically fini),
-  non-canonical names (create/destroy/cleanup/release/deinit), missing
-  destructors (leaks), and unpaired allocators — then fixes a bounded batch per
-  run, one prefix family per PR. Use this skill whenever the user invokes the
-  weekly RAII sweep, asks to "fix RAII symmetry", "приведи lifecycle-функции к
-  паттерну", "найди несимметричные init/fini", or wants a C lifecycle cleanup
-  pass.
+  Weekly maintenance sweep that restores RAII symmetry in the YANET2 C code.
+  The convention is four orthogonal primitives: new allocates ONLY the struct,
+  init fills fields (and on any error jumps to a single err: label that calls
+  fini), fini releases ONLY field memory and is idempotent, free deallocates
+  ONLY the struct and is NULL-safe — paired new<->free and init<->fini. The
+  sweep has two axes: a NAMING axis (misnamed/non-canonical destructors, found
+  by scan.sh) and a STRUCTURAL axis (init error-path leaks/double-free/UAF,
+  non-idempotent fini, non-NULL-safe free, new/free orthogonality, found by
+  structural-scan.sh plus the leak-hunt workflow). It fixes a bounded batch per
+  run, one prefix family per PR, with a persistent ledger. Use whenever the user
+  invokes the weekly RAII sweep, asks to "fix RAII symmetry", "приведи
+  lifecycle-функции к паттерну", "найди несимметричные init/fini", "сделай
+  fini/free идемпотентными", wants the single-err-label init discipline, or
+  wants a C lifecycle cleanup pass.
 ---
 
 # raii-sweep
 
-Run the periodic RAII-symmetry sweep over the C codebase: scan for lifecycle asymmetries, triage them semantically against the project convention, fix 2–3 prefix families per run (one family = one PR), and keep a persistent ledger so weekly runs never re-litigate old verdicts.
+Run the periodic RAII-symmetry sweep over the C codebase: scan for lifecycle asymmetries on two axes (naming, structure), triage them semantically against the project convention, fix a bounded batch per run (one family = one PR), and keep a persistent ledger so weekly runs never re-litigate old verdicts.
 
 You (the architect) drive this. You never edit C or Go code yourself — fixes are delegated to **coder-c** (and **coder-go** when renamed symbols cross the CGO boundary); you own scanning, triage, verification gates, and the publish workflow.
 
@@ -23,21 +27,44 @@ You (the architect) drive this. You never edit C or Go code yourself — fixes a
 
 ## The convention (target state)
 
-- `<prefix>_new` — allocates the struct, returns a pointer (typically calls init). Pairs with `free`.
-- `<prefix>_init` — initializes fields in place, may allocate field memory. Pairs with `fini`.
-- `<prefix>_fini` — releases field memory, does NOT free the struct itself. Idempotent on zero-init.
-- `<prefix>_free` — deallocates the struct (typically calls fini first). NULL-safe.
-- `_create`/`_destroy`/`_cleanup`/`_release`/`_deinit` are banned names. `_attach`/`_detach` are legitimate only for shared-memory multi-process attach semantics (yanet_shm, agent).
+Four orthogonal primitives. `new`/`free` deal ONLY with the struct's own storage; `init`/`fini` deal ONLY with its fields. The pairs are symmetric — `new`↔`free`, `init`↔`fini` — and composable: a heap object is built with `new` then `init`, and torn down with `fini` then `free`.
 
-This matches coder-c's standardized lifecycle lessons (`lifecycle-classes.md`, `lifecycle-fini-special-cases.md` in its memory) — the skill enforces repo-wide what coder-c already applies to new code.
+- `<prefix>_new(args) -> *self` — allocates the struct and returns the pointer; returns NULL on OOM. Does **nothing else** — no field initialization, no child allocation. `new` is expected to be RARE (most structs are caller-owned and only have `init`/`fini`).
+- `<prefix>_init(self, args) -> int` — fills fields in place, may allocate field memory. First arg is `self`. On **any** failure it jumps to a single `err:` label that calls `<prefix>_fini(self)` and returns -1. It must establish `fini`'s precondition first (zero-init `self`, or rely on `new` having memset it) so `fini` is safe at every failure point.
+- `<prefix>_fini(self, args) -> void` — releases field memory; does **NOT** free the struct. First arg is `self`. Idempotent: NULL-guards each child before releasing, resets it to NULL/zero afterward, and is safe on a zero/partially-initialized struct and safe to call twice.
+- `<prefix>_free(self) -> void` — deallocates the struct; does **NOT** call `fini`. Single arg `self`. NULL-safe (`if (self == NULL) return;`).
+
+The reference quartet is **`lib/controlplane/config/cp_chain.c`**: pure `cp_chain_new` (balloc + memset + NULL-on-OOM), single-`err_out:` `cp_chain_init` → `cp_chain_fini`, field-releasing `cp_chain_fini`, NULL-safe pure `cp_chain_free`. The whole `cp_*` config family (`cp_function`, `cp_pipeline`, `cp_device`) follows it.
+
+Why idempotency is mandatory: it is the precondition for the single-`err:` label. Because `init` zero-inits `self` and `fini` resets every child, the same `fini` cleans up correctly whether `init` failed on the first child or the last — so cleanup lives in exactly one place, never scattered across per-error gotos. `memory_bfree(ctx, ptr, size)` is NULL-safe (a NULL block is a no-op, like `free(3)`) and ignores `size == 0`, so `fini` does NOT need to pre-guard NULL purely for the free — but it MUST still `SET_OFFSET_OF(&self->x, NULL)` (or zero the field) after releasing each child, so a second `fini` does not double-free the still-non-NULL pointer. (Historically `memory_bfree` was not NULL-safe: a NULL block with nonzero size wrote the free-list link through the pointer and corrupted the arena — the L-RIDX class, now closed at the primitive.)
+
+Banned names: `_create`/`_destroy`/`_cleanup`/`_release`/`_deinit`/`_teardown`. `_attach`/`_detach` are legitimate only for shared-memory multi-process attach semantics (`yanet_shm`, `agent`).
+
+## The two axes & their violation classes
+
+Triage rules, false-positive criteria, and the priority ladder for both axes live in `references/triage.md`. Summary:
+
+**Naming axis (A)** — symbol renames, surfaced by `scan.sh`, tracked in `LEDGER.md`:
+- A1 misnamed `fini` (a `_free` that releases fields but never frees the struct).
+- A2 non-canonical name (`create`/`destroy`/`cleanup`/`release`/`deinit`/`teardown`).
+- A3 `free`/`fini` with no visible allocator pair.
+
+**Structural axis (B)** — correctness & contract, surfaced by `structural-scan.sh` + the leak-hunt workflow, tracked in `LEAKS.md`:
+- B1 missing destructor entirely (init/new allocates, nothing releases → leak).
+- B2 init error-path defect (leak, double-free, or UAF on a failure path — the filter-compiler `*_attr_init` family is the archetype).
+- B3 non-idempotent `fini` (frees a child unconditionally, or does not reset it → unsafe on partial/zero state or on a second call).
+- B4 non-NULL-safe `free`.
+- B5 orthogonality break (`new` that also inits/allocates children; `free` that calls `fini`).
+
+Structural defects outrank renames: a leak/double-free/UAF (B1/B2) is a real bug; A-class and B5 are hygiene.
 
 ## Non-negotiables
 
-- **Symbol renames only, never layout changes.** This sweep renames and restructures lifecycle functions; it NEVER alters shared-memory struct layout, field order, or sizes. If a fix seems to require a layout change, defer the candidate and flag it to the user.
+- **Symbol renames and error-path restructuring only — never layout changes.** This sweep renames lifecycle functions and rewrites their internal cleanup; it NEVER alters shared-memory struct layout, field order, or sizes. If a fix seems to require a layout change, defer the candidate and flag it to the user.
 - **A rename ships with ALL its consumers in the same PR**: every C caller, Go bindings (`bindings/go/*/cgo.go` or legacy `controlplane/ffi.go`), tests, fuzzing targets, comments. Zero references to the old name may remain repo-wide.
-- **Semantic verdicts are read-code verdicts.** Never classify from the scan table alone — read the function bodies before deciding rename vs. real bug vs. false positive.
-- **One prefix family = one PR**, each in its own worktree. Closely coupled clones (e.g. `btree_u16/u32/u64`) count as one family.
-- **Budget: 2–3 PRs per run.** Semantic bugs (leaks, ownership traps) outrank pure renames when picking.
+- **Verdicts are read-code verdicts.** Never classify from a scan table alone — read the function bodies before deciding rename vs. real bug vs. false positive. The scanners point; reading decides.
+- **One prefix family = one PR; one B-class defect = one PR** — each in its own worktree. Closely coupled clones (e.g. `btree_u16/u32/u64`) count as one family.
+- **Budget: 2–3 PRs per run.** Structural defects (B1/B2/B3) outrank pure renames and B5 orthogonality when picking.
 - **Never touch**: `new_module_<name>` defsym entry points, DPDK `rte_*` APIs, vendored code under `subprojects/`.
 
 ## Pipeline
@@ -45,33 +72,30 @@ This matches coder-c's standardized lifecycle lessons (`lifecycle-classes.md`, `
 ### Phase 1 — Scan & ledger sync
 
 1. `git fetch origin main`; work off `origin/main`.
-2. Run the scan: `bash .claude/skills/raii-sweep/references/scan.sh`. It inventories lifecycle function definitions across `lib/ dataplane/ common/ api/ modules/ devices/` and pairs them by prefix, flagging asymmetries.
-3. Sync the ledger at `.arch/raii-sweep/LEDGER.md` (gitignored; create on first run):
-   - Add newly flagged prefixes as `pending`.
-   - Mark entries whose asymmetry disappeared from the scan as `resolved-externally`.
-   - Preserve all existing verdicts (`merged`, `deferred`, `fp-*`) — never re-triage a prefix with a false-positive verdict unless its code changed.
+2. Run both scanners (read-only):
+   - `bash .claude/skills/raii-sweep/references/scan.sh` — naming axis (A): inventories lifecycle definitions across `lib/ dataplane/ common/ api/ modules/ devices/` and pairs them by prefix, flagging asymmetries.
+   - `bash .claude/skills/raii-sweep/references/structural-scan.sh` — structural axis. Two precision tiers: LIKELY-DEFECT (`D-ZEROINIT` constructor with no zero-init before its error path, `D-OOM` unchecked alloc, `D-IDEMP` fini that bfrees a member without reset) and DECISION/STYLE INVENTORY (`S-STYLE` multi-label inits, `S-NULLSAFE` frees that deref self unguarded, `S-ORTHO-NEW` fused constructors, `S-ORTHO-FREE` composite teardowns). The inventory tier is mostly conforming/decision-gated — read it for the orthogonality decision, not as a bug oracle.
+3. Sync the ledgers (both gitignored; create on first run):
+   - `.arch/raii-sweep/LEDGER.md` — naming-axis verdicts (A). Add newly flagged prefixes as `pending`; mark vanished asymmetries `resolved-externally`; preserve `merged`/`deferred`/`fp-*` verdicts — never re-triage an `fp-*` prefix unless its code changed.
+   - `.arch/raii-sweep/LEAKS.md` — structural-axis backlog (B), one entry per confirmed defect (each fixed as its own PR). Mark fixed entries; rebase deferred entries when their blocking PR lands.
 
-Ledger format — one table:
+Naming ledger format — one table: `| prefix | area | class | priority | status | notes |`. `status` ∈ `pending` / `in-progress` / `merged #PR` / `deferred` / `fp-no-fini-needed` / `fp-other` / `resolved-externally`.
 
-```
-| prefix | area | class | priority | status | notes |
-```
+### Phase 2a — Triage the naming axis (semantic, bounded)
 
-`status` ∈ `pending` / `in-progress` / `merged #PR` / `deferred` / `fp-no-fini-needed` / `fp-other` / `resolved-externally`.
+Take `pending` A-entries in priority order and read the actual code until you have confirmed candidates. For each record: violation class, exact rename map (old → new symbol list), full consumer list (`grep -rn` across C, Go, tests, fuzzing, comments), and blast-radius notes (FFI-crossing? hot-path header?). Skip (and mark) candidates whose files overlap an open PR (`gh pr list --json files`).
 
-### Phase 2 — Triage (semantic, bounded)
+### Phase 2b — Hunt the structural axis (read-the-code, workflow)
 
-Take `pending` entries in priority order and read the actual code until you have 2–3 confirmed candidates. Classification rules, false-positive criteria, and the priority ladder live in `references/triage.md`. For each confirmed candidate record in the ledger: violation class, exact rename map (old → new symbol list) or fix description, full consumer list (`grep -rn` across C, Go, tests, fuzzing, comments), and blast-radius notes (FFI-crossing? hot-path header?).
-
-Skip (and mark) candidates whose files overlap an open PR (`gh pr list --json files`) — cross-PR rename conflicts are not worth it.
+Grep cannot prove a B1/B2/B3 defect — it can only point. Run the **leak-hunt workflow** to find them: fan out area finders (one per subsystem: `lib/filter/compiler`, `lib/controlplane`, `lib/counters`, `lib/dataplane`, each module's `api/`, etc.), each READING the init/fini/free functions in its area against the convention contract, then adversarially verify every candidate (independent skeptic prompted to refute, default-to-false on doubt) before it enters `LEAKS.md`. Drive each finder with the explicit contract: init must establish fini's zero-init precondition and unwind cleanly on every error path; fini must be idempotent; free must be NULL-safe; `*data`/offset children must never dangle past their free. The archetype is the `*_attr_init`/driver contract in `lib/filter/compiler/` (see `references/triage.md` § B2). Record each confirmed defect in `LEAKS.md` with file:line, the exact mechanism (leak / double-free / UAF / OOM-deref), severity, the fix shape, and blockers.
 
 ### Phase 3 — Execute (delegate, one worktree per candidate)
 
 For each candidate:
 
-1. `git worktree add .claude/worktrees/raii-<prefix> -b refactor/raii-<prefix> origin/main`.
+1. `git worktree add .claude/worktrees/raii-<prefix> -b refactor/raii-<prefix> origin/main` (use `fix/raii-<slug>` for B-class defect fixes).
 2. If the candidate touches Go bindings, seed gitignored generated files first: `rsync` the `*.pb.go` files from the main checkout into the worktree (a fresh worktree cannot run `go build ./...` without them).
-3. Delegate to **coder-c** with a brief that names: the absolute worktree path (cd there, `git rev-parse --show-toplevel` to confirm), the exact rename map / fix, the full consumer list from Phase 2, and the relevant guardrails (see `references/triage.md` § Brief template). The brief MUST forbid destructive git ops (`stash`/`checkout`/`restore`/`reset`/index ops) and `git commit`, and restate coder-c's minimal-fix discipline: only the named symbols, no adjacent restructuring, no gratuitous doc comments.
+3. Delegate to **coder-c** with a brief that names: the absolute worktree path (cd there, `git rev-parse --show-toplevel` to confirm), the exact rename map / fix shape, the full consumer list from Phase 2, and the relevant guardrails (see `references/triage.md` § Brief template). The brief MUST forbid destructive git ops (`stash`/`checkout`/`restore`/`reset`/index ops) and `git commit`, and restate coder-c's minimal-fix discipline: only the named symbols / the named defect, no adjacent restructuring, no gratuitous doc comments.
 4. If renamed symbols cross the CGO boundary, delegate the Go side to **coder-go** afterwards (same worktree, same constraints; receiver naming `m`, no comment drift).
 5. Sequence strictly: coder-c → your build check → coder-go (if needed) → your build check. Never run a coder and its reviewer in the same batch.
 
@@ -79,23 +103,23 @@ For each candidate:
 
 From the worktree root:
 
-1. `grep -rn '<old_symbol>' .` for EVERY renamed symbol — zero hits allowed (code, comments, meson, Go, fuzzing).
+1. For renames: `grep -rn '<old_symbol>' .` for EVERY renamed symbol — zero hits allowed (code, comments, meson, Go, fuzzing).
 2. C gate: `meson setup build` (or reuse) + `meson compile -C build` + `meson test -C build`.
 3. Go gate when bindings changed: `go build ./...` in `controlplane/` and the touched module.
-4. Local ASan (`make test-asan` or targeted `meson test -C build-asan <name>`) is required only when the change ALTERS BEHAVIOR — a destructor added (V3), ownership/free semantics changed, call order changed. Pure renames (most V1/V2) skip it: repo CI runs build-asan-test, build-tsan-test, and functional tests on every PR anyway.
+4. Local ASan (`make test-asan` or targeted `meson test -C build-asan <name>`) is **mandatory** for any B-class fix and for any change that ALTERS BEHAVIOR (destructor added, ownership/free semantics changed, call order changed, error path rewritten). Pure renames (most A1/A2) skip it: repo CI runs build-asan-test, build-tsan-test, and functional tests on every PR anyway. For a hard-to-see B1/B2 leak, a `bug-hunter confirm` (ASan/fault-injection repro) before the fix and a `bug-hunter validate` after are encouraged.
 5. Reviewer pass: launch **reviewer** WITHOUT isolation, read-only, pointed at the worktree's absolute paths (work is uncommitted). Address findings via the Review-Fix loop (max 3 rounds).
 
 ### Phase 5 — Publish & close the loop
 
 1. Stage only the candidate's files; verify each with `git diff --cached -- <file>` and confirm no untracked stragglers.
-2. Commit as `refactor(<scope>): <short description>` (scope = `lib`, `common`, module name…). No Claude footers.
-3. Push, open the PR with a scoped title; body is capitalized period-ended bullets, no `## Summary`, no `Test plan`.
-4. `gh pr checks <pr> --watch`; if it exits with "no checks reported" you ran it before CI registered — re-run it once after a minute. Read PR reviews AND Codex inline comments; fix or reply to every finding.
+2. Commit: renames `refactor(<scope>): <desc>`; B-class fixes `fix(<scope>): <desc>` (scope = `lib`, `common`, module name…). No Claude footers.
+3. Push, open the PR with a scoped title; body is capitalized period-ended bullets, no `## Summary`, no `Test plan`. Add `Closes #<n>.` when applicable.
+4. `gh pr checks <pr> --watch`; if it exits with "no checks reported" you ran it before CI registered — re-run it once after a minute. Read PR reviews AND Codex inline comments; fix or reply to every finding. Honor the user's merge policy (e.g. "leave open for Codex + team" vs. "merge after green").
 5. Merge (single-commit → squash `--admin`; multi-commit → rebase) WITHOUT `--delete-branch` — it fails while the branch is checked out in a worktree. Then `git worktree remove` from the main checkout, `git branch -D`, and `git push origin --delete <branch>`.
 6. **Merge one PR at a time** — these PRs rename callers across wide files; rebase remaining branches onto `origin/main` after each merge.
-7. **Stacked families** (candidate B's files depend on candidate A's pending rename, e.g. btree on big_array): branch B off A's branch, do the work in parallel, and after A squash-merges rebase with `git rebase --onto origin/main <A-branch-sha> refactor/raii-<B>` — A's commit drops out, B replays cleanly.
+7. **Stacked families** (candidate B's files depend on candidate A's pending change): branch B off A's branch, work in parallel, and after A squash-merges rebase with `git rebase --onto origin/main <A-branch-sha> refactor/raii-<B>`.
 8. Update the ledger: `merged #PR`, date. Append a one-line run summary (date, PRs, verdicts changed) to the ledger's `## Run log`.
 
 ### End of run
 
-Report to the user: PRs shipped, new verdicts (especially `deferred` ones needing a human call), remaining queue depth, and an ETA at the current budget.
+Report to the user: PRs shipped, new verdicts (especially `deferred` ones needing a human call), remaining queue depth on each axis, and an ETA at the current budget.

--- a/.claude/skills/raii-sweep/references/structural-scan.sh
+++ b/.claude/skills/raii-sweep/references/structural-scan.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Flag STRUCTURAL lifecycle smells the naming scanner (scan.sh) cannot see.
+# Read-only: prints a report, writes nothing. Every flag is a candidate to
+# READ, not a verdict — grep cannot prove a leak, it can only point at one.
+#
+# Output is split by PRECISION. The "likely-defect" heuristics aim to point at
+# real bugs (read to confirm). The "decision/style inventory" heuristics point
+# at the orthogonality/style surface, which is mostly conforming-or-decision-
+# gated — use it to drive the new/free-orthogonality decision, NOT as a bug
+# oracle. Genuine init error-path leaks / double-free / UAF still need the
+# read-the-code leak-hunt workflow (SKILL.md Phase 2b).
+set -euo pipefail
+cd "$(git rev-parse --show-toplevel)"
+
+python3 - <<'EOF'
+import glob
+import re
+
+SCOPE = "lib dataplane common api modules devices".split()
+
+# Constructor verbs reach beyond new/create: spawn/copy/clone/dup/build own an
+# allocation + error path too (counter_storage_spawn was invisible to the
+# old suffix list and held a real garbage-read defect).
+CTOR = "new|create|spawn|copy|clone|dup|build|make"
+DTOR = "fini|free|destroy|release|cleanup|deinit"
+LIFECYCLE = re.compile(rf"_({CTOR}|{DTOR})$")
+
+
+def is_noise(path):
+    return bool(
+        re.search(r"(^|/)(tests?|fuzzing|unittest)/", path)
+        or path.endswith("_test.c")
+        or path.endswith("tests.c")
+        or "/bench" in path
+    )
+
+
+files = []
+for d in SCOPE:
+    files += glob.glob(f"{d}/**/*.c", recursive=True)
+prod = [f for f in files if "subprojects/" not in f and not is_noise(f)]
+
+defn = re.compile(r"^([a-z_][a-z0-9_]*)\(")
+rettype = re.compile(r"^(void|int|struct|[a-z_].*\*|uint\d+_t|size_t|bool)")
+
+funcs = []
+for f in prod:
+    lines = open(f, errors="replace").read().split("\n")
+    idx = 0
+    while idx < len(lines):
+        m = defn.match(lines[idx])
+        if m and LIFECYCLE.search(m.group(1)) and idx > 0 and rettype.match(
+            lines[idx - 1].strip()
+        ):
+            name, ret = m.group(1), lines[idx - 1].strip()
+            cursor, depth, opened, body = idx, 0, False, []
+            while cursor < len(lines):
+                body.append(lines[cursor])
+                depth += lines[cursor].count("{") - lines[cursor].count("}")
+                if "{" in lines[cursor]:
+                    opened = True
+                if opened and depth <= 0:
+                    break
+                cursor += 1
+            funcs.append((name, ret, f, idx + 1, "\n".join(body)))
+            idx = cursor + 1
+        else:
+            idx += 1
+
+
+def first_arg(body):
+    sig = body.split(")")[0]
+    a0 = sig.split(",")[0]
+    return a0.split("*")[-1].strip().split()[-1] if "*" in a0 else None
+
+
+def has_cleanup_label(body):
+    return bool(re.search(r"^\s*(err\w*|error\w*)\s*:", body, re.M))
+
+
+no_zero, unchecked, leaf_idemp = [], [], []
+multi_label, no_guard, fused, free_fini = [], [], [], []
+
+for name, ret, f, ln, body in funcs:
+    verb = LIFECYCLE.search(name).group(1)
+    head = name[: LIFECYCLE.search(name).start()]
+    is_ctor = bool(re.match(rf".*_({CTOR})$", name))
+    is_dtor = bool(re.match(rf".*_({DTOR})$", name))
+
+    if is_ctor:
+        allocs = re.search(r"=\s*(?:\([^)]*\)\s*)?(memory_balloc|malloc|calloc)\b", body)
+        zeroes = re.search(r"\bmemset\s*\(", body) or re.search(r"=\s*\{\s*0?\s*\}", body)
+        if allocs and has_cleanup_label(body) and not zeroes:
+            no_zero.append((name, f"{f}:{ln}"))
+
+        for am in re.finditer(
+            r"\b([A-Za-z_]\w*)\s*=\s*(?:\([^)]*\)\s*)?"
+            r"(memory_balloc|malloc|calloc|rte_zmalloc|rte_malloc|rte_calloc)\b",
+            body,
+        ):
+            v = am.group(1)
+            if v in ("void", "struct", "const"):
+                continue
+            checked = (
+                re.search(rf"\b{re.escape(v)}\s*(==|!=)\s*NULL", body)
+                or re.search(rf"\(\s*!\s*{re.escape(v)}\s*\)", body)
+                or re.search(rf"\(\s*!?\(?\s*{re.escape(v)}\s*=", body)
+                or re.search(rf"\bif\s*\(\s*!?{re.escape(v)}\s*\)", body)
+            )
+            if not checked:
+                unchecked.append((name, f"{f}:{ln}", v))
+
+        if verb in ("new", "create"):
+            looks_fused = (
+                re.search(rf"\b{re.escape(head)}_init\s*\(", body)
+                or len(re.findall(r"memory_balloc|\b\w+_init\s*\(", body)) >= 2
+                or re.search(r"\bfor\s*\(|\bwhile\s*\(", body)
+            )
+            if looks_fused:
+                fused.append((name, f"{f}:{ln}"))
+
+    if verb in ("init", "create") or name.endswith("_init"):
+        labels = sorted(set(re.findall(r"^\s*(err\w*|error\w*)\s*:", body, re.M)))
+        if len(labels) > 1:
+            multi_label.append((name, f"{f}:{ln}", ",".join(labels)))
+
+    if is_dtor:
+        arg = first_arg(body)
+        inner = body.split("{", 1)[1] if "{" in body else ""
+        # NULL self-safety: free(NULL)/memory_bfree(NULL,0) are already no-ops,
+        # so a guardless free is a B4 defect ONLY when the body DEREFERENCES the
+        # param (`arg->` / `arg[`). Token-precise guard match: a bare `<arg>)`
+        # (e.g. container_of(<arg>, ...)) is NOT a guard — that bug cleared
+        # route_module_config_free while flagging its identical sibling.
+        if arg and name.endswith("_free"):
+            derefs_self = re.search(rf"\b{re.escape(arg)}\s*(->|\[)", inner)
+            guarded = (
+                re.search(rf"{re.escape(arg)}\s*==\s*NULL", inner[:300])
+                or re.search(rf"\(\s*!\s*{re.escape(arg)}\s*\)", inner[:300])
+                or re.search(rf"\bif\s*\(\s*{re.escape(arg)}\s*\)\s*\{{?\s*$", inner[:300], re.M)
+            )
+            if derefs_self and not guarded:
+                no_guard.append((name, f"{f}:{ln}", arg))
+
+        # free that calls ANY child fini/free (name-agnostic) — the composite
+        # teardown surface. `<head>_fini` alone missed `_data_fini` infixes and
+        # cross-prefix `cp_module_fini`.
+        if name.endswith("_free"):
+            children = sorted(set(re.findall(r"\b(\w+_(?:fini|free|destroy))\s*\(", body)) - {name})
+            if children:
+                free_fini.append((name, f"{f}:{ln}", ",".join(children)[:60]))
+
+        # Leaf idempotency: a fini-SEMANTICS destructor (fini/destroy — NOT
+        # _free, which deallocs the struct itself) that bfrees a MEMBER without
+        # a SET_OFFSET reset or a trailing memset may double-free on a second
+        # call (the lpm_free class — note header-only static-inline leaves in
+        # common/*.h escape this .c-only scan; the leak-hunt workflow covers
+        # transitive idempotency there).
+        if re.search(r"_(fini|destroy)$", name):
+            bfrees_member = False
+            for bm in re.finditer(r"memory_bfree\s*\(\s*[^,]+,\s*([^,]+),", body):
+                target = bm.group(1).strip()
+                if arg and re.fullmatch(rf"(\(\w[\w ]*\*\)\s*)?{re.escape(arg)}", target):
+                    continue  # frees self -> pure dealloc, fine
+                bfrees_member = True
+            if bfrees_member and not re.search(r"SET_OFFSET_OF\s*\(", body) and not re.search(r"\bmemset\s*\(", body):
+                leaf_idemp.append((name, f"{f}:{ln}"))
+
+
+def section(title, rows):
+    print(f"\n## {title}  ({len(rows)})")
+    for r in rows:
+        print("    " + "  ".join(str(c) for c in r))
+
+
+print(f"lifecycle definitions scanned: {len(funcs)}")
+print("\n=== LIKELY DEFECT (read to confirm) ===")
+section("D-ZEROINIT  constructor allocs + has error path but never memsets (teardown may read garbage)", no_zero)
+section("D-OOM  unchecked allocation inside a constructor body (multi-line aware)", unchecked)
+section("D-IDEMP  fini bfrees a member with no reset/memset (may double-free on 2nd call)", leaf_idemp)
+print("\n=== DECISION / STYLE INVENTORY (mostly conforming or decision-gated) ===")
+section("S-STYLE  init/create with >1 cleanup label (stacked ladder -> single err: candidate)", multi_label)
+section("S-NULLSAFE  free without a NULL self-guard (mostly FP: container_of frees are guarded by the Go binding)", no_guard)
+section("S-ORTHO-NEW  fused new/create (convention: new = pure alloc; many are FAM-fill false positives)", fused)
+section("S-ORTHO-FREE  free that calls a child fini/free (composite teardown; mostly conforming)", free_fini)
+print("\nGenuine init error-path leak / double-free / UAF and fini idempotency on")
+print("partial state need read-the-code judgement — run the leak-hunt workflow.")
+EOF

--- a/.claude/skills/raii-sweep/references/triage.md
+++ b/.claude/skills/raii-sweep/references/triage.md
@@ -1,68 +1,165 @@
 # raii-sweep triage rules
 
-How to turn a scan flag into a verdict. Every verdict requires reading the function bodies — the scan only points, it never decides.
+How to turn a scan flag into a verdict. Every verdict requires reading the function bodies — the scanners only point, they never decide.
 
-## Violation classes
+## The contract (canonical target shapes)
 
-### V1 — misnamed fini (`free` that does not free the struct)
+Four orthogonal primitives. `new`/`free` touch only the struct's storage; `init`/`fini` touch only its fields. Reference family: `lib/controlplane/config/cp_chain.c`.
 
-The most common and most dangerous class: `<prefix>_free` releases field memory and finalizes the memory context but never deallocates the struct itself — the caller owns it. By convention this function is `fini`. The misleading name is an ownership trap (readers assume the struct is gone; double-free and use-after-free hazards at call sites).
+`new` — allocate the struct, nothing else, NULL on OOM:
 
-Detection: read the `free` body — if there is no `memory_bfree(ctx, self, sizeof(*self))` / `free(self)` on the struct pointer itself, it is a fini. Confirmed examples at first scan: `lpm_free`, `btree_u*_free`, `radix_free`, `value_table_free`, `remap_table_free`, `filter_free`.
+```c
+struct foo *
+foo_new(struct memory_context *mctx, ...) {
+	struct foo *self = memory_balloc(mctx, sizeof(*self));
+	if (self == NULL) {
+		return NULL;
+	}
+	memset(self, 0, sizeof(*self));        // establishes fini's precondition
+	SET_OFFSET_OF(&self->memory_context, mctx);
+	return self;                            // NO field init, NO child alloc
+}
+```
 
-Fix: rename `free` → `fini` (and verify init/fini invariants: idempotent on zero-init, self-cleanup on constructor error paths). If some call sites actually need heap deallocation, that is a separate finding — check what owns the struct there.
+`init` — fill fields; one `err:` label that calls `fini`:
 
-### V2 — non-canonical names (`create`/`destroy`/`cleanup`/`release`/`deinit`/`teardown`)
+```c
+int
+foo_init(struct foo *self, ...) {
+	// self is zero-initialized (by foo_new, or memset here for caller-owned
+	// structs) so foo_fini is safe at every failure point below.
+	if (child_init(&self->child, ...) != 0) {
+		goto err;                       // every error path: goto err
+	}
+	self->buf = memory_balloc(mctx, n);
+	if (self->buf == NULL) {
+		goto err;
+	}
+	return 0;
+err:
+	foo_fini(self);                         // the ONLY cleanup site
+	return -1;
+}
+```
 
-Map by semantics, never mechanically:
+`fini` — release fields, idempotent, struct survives:
 
-- allocates struct + returns pointer → `_new`
-- initializes caller-owned struct in place → `_init`
-- releases fields, struct survives → `_fini`
-- deallocates struct → `_free`
+```c
+void
+foo_fini(struct foo *self) {
+	struct buf *b = ADDR_OF(&self->buf);
+	memory_bfree(mctx, b, n);               // memory_bfree is NULL-safe (no-op on NULL)
+	SET_OFFSET_OF(&self->buf, NULL);        // reset is mandatory: else 2nd fini double-frees
+	child_fini(&self->child);               // child_fini must itself be idempotent
+}
+```
 
-A `create` that both allocates and initializes is simply `new` (new is expected to call init or inline it). A `destroy` that finis and frees is simply `free`. Watch for `cleanup` functions that mix both halves — split is optional; pick the name matching what callers rely on.
+`free` — deallocate the struct, NULL-safe, does NOT call fini:
 
-### V3 — missing destructor (init/new allocates, nothing releases)
+```c
+void
+foo_free(struct foo *self) {
+	if (self == NULL) {
+		return;
+	}
+	memory_bfree(ADDR_OF(&self->memory_context), self, sizeof(*self));
+}
+```
 
-Real bug class (leak), not a rename. Confirm: does init/new allocate memory (directly or via embedded children with their own fini)? Does any code path release it? If not — add the missing `fini`/`free` and wire it into every owner's teardown path.
+Full teardown of a heap object is `foo_fini(p); foo_free(p);` (two calls). `new` is expected to be RARE — most structs are caller-owned and expose only `init`/`fini`.
 
-Before burning budget on a non-obvious leak, a `bug-hunter confirm` dispatch (ASan repro) is allowed but optional — the ASan test gate in Phase 4 is mandatory either way.
+## Naming axis (A) — renames, tracked in LEDGER.md
 
-### V4 — free without visible allocator pair
+### A1 — misnamed fini (`free` that does not free the struct)
 
-`<prefix>_free` exists but nothing named `<prefix>_new/init/create` allocates it (e.g. `cp_*_list_info_free`, `yanet_counter_handle_list_free`). Find the actual allocating function. Verdict is one of:
+A `<prefix>_free` releases field memory but never deallocates the struct itself — the caller owns it. By convention this is `fini`. The misleading name is an ownership trap (readers assume the struct is gone; double-free / UAF at call sites). Detection: read the `free` body — no `memory_bfree(ctx, self, sizeof(*self))` / `free(self)` on the struct pointer → it is a `fini`. Fix: rename `free` → `fini`. If some call sites actually need heap deallocation, that is a separate finding — check what owns the struct there.
 
-- allocator is a collector/getter whose primary job is not allocation → acceptable, record `fp-other` with the pairing in notes;
-- allocator deserves the `_new` name → V2 rename.
+### A2 — non-canonical names (`create`/`destroy`/`cleanup`/`release`/`deinit`/`teardown`)
+
+Map by semantics, never mechanically: allocates struct + returns pointer → `_new`; fills caller-owned struct → `_init`; releases fields, struct survives → `_fini`; deallocates struct → `_free`. A `destroy` that finis-and-frees is a `free` only if it also deallocates the struct; if it merely releases fields it is a `fini`. Watch `cleanup` that mixes both halves.
+
+### A3 — free/fini without a visible allocator pair
+
+A `_free`/`_fini` exists but nothing named `_new`/`_init`/`_create` allocates it. Find the actual allocating function. Verdict: allocator is a collector/getter whose primary job is not allocation → `fp-other` (record the pairing); or the allocator deserves the `_new` name → A2 rename.
+
+## Structural axis (B) — correctness, tracked in LEAKS.md
+
+### B1 — missing destructor (leak)
+
+`init`/`new` allocates (directly or via children with their own fini) but no code path releases it. Confirm with a read; add the missing `fini`/`free` and wire it into every owner's teardown. A `bug-hunter confirm` (ASan/LSan repro) before the fix is encouraged; the ASan gate (Phase 4) is mandatory.
+
+### B2 — init error-path defect (leak / double-free / UAF) — the archetype
+
+The `lib/filter/compiler/` `*_attr_init` family is the model. Each init allocates a wrapper with `memory_balloc`, publishes it via `SET_OFFSET_OF(data, wrapper)`, runs a builder. The driver `filter_init` (`compiler.h`) calls each `.init`; on any failure it calls each lookup's `.free` via `if (v->data != NULL) free(ADDR_OF(&v->data))`. So the init contract is: **on failure, either leave `*data` pointing at a fully-owned object the free func can release, OR reset `*data` to NULL (`SET_OFFSET_OF(data, NULL)` stores 0, gating the free off) and release everything yourself.** `device.c`/`ipfrag.c`/`vlan.c` honor it (reference). The two failure modes:
+
+- **dangling `*data`** — init frees the wrapper/children but leaves `*data` pointing at freed memory → the driver re-enters the free func → double-free / UAF.
+- **leaked wrapper** — init nulls `*data` but forgets to `memory_bfree` the wrapper struct → leak each failed update.
+
+Canonical fix (match `device.c`): NULL-check the `memory_balloc`; on builder failure `SET_OFFSET_OF(data, NULL)` then `memory_bfree(ctx, wrapper, sizeof(*wrapper))`; ensure the free func early-returns on NULL. Reachability: ACL/forward config-update under arena/OOM exhaustion (`filter_init` runs on every filter rebuild). This same shape generalizes beyond the compiler: any init whose error path leaves an offset/child dangling, or leaks a partial allocation, is B2.
+
+### B3 — non-idempotent fini
+
+`fini` frees a child but does not reset it to NULL/zero after release, so a second fini double-frees the still-non-NULL pointer (and a fini on a partially-initialized struct dereferences garbage). `memory_bfree` is now NULL-safe (a NULL block is a no-op), so the *bfree itself* no longer corrupts on NULL — but the **reset is still mandatory** because the offset is still non-NULL after the free. Fix: release each child (`memory_bfree`/child-fini) then `SET_OFFSET_OF(&self->x, NULL)`. A trailing `memset(self, 0, sizeof(*self))` is the blunt form and is fine for POD-shaped finis. (The L-RIDX class — `memory_bfree(ctx, NULL, nonzero)` corrupting the arena — is closed at the primitive as of the `memory_bfree` NULL-safety change; verified by a full 87-site audit that found zero live breaches, all sites saved by either count-tracks-pointer or an explicit guard.)
+
+**Idempotency is transitive.** A fini is idempotent only if every child fini/free it calls is itself idempotent. A fini may legitimately delegate — `cp_chain_fini` just calls `counter_registry_fini`, which ends in `memset(registry, 0, ...)`; that is conforming, not a B3, because the child resets internally. The defect is a *leaf* fini that frees a member but never resets it: `lpm_free` (`common/lpm.h`) bfrees `lpm->pages` without `SET_OFFSET_OF(&lpm->pages, NULL)`, so a second call double-frees and it poisons every parent fini that embeds a `struct lpm` (nat64/route/forward). Header-only static-inline leaves (`lpm`, `btree_*`, `radix`) escape the `.c`-only scanner — the leak-hunt workflow checks them.
+
+### B4 — non-NULL-safe free (dereferences self without a guard)
+
+A `_free(self)` **dereferences** `self` (`self->x` / `self[i]`) without `if (self == NULL) return;`. Note `free(NULL)` and `memory_bfree(ctx, NULL, 0)` are already no-ops, so a `_free` that merely passes `self` to `free`/`memory_bfree` is NULL-safe even without an explicit guard — only a real dereference is the defect. The archetype is the agent.c info-list collectors: `cp_function_list_info_free` / `cp_agent_list_info_free` loop over `self->count` before the final `free`, and their producers return NULL on OOM into a Go `defer ..._free(ptr)` with no nil check. The bare-`free` siblings (`dp_module_list_info_free`) are correctly NULL-tolerant. Fix: add the guard (and ideally make the Go caller/producer nil-safe too). **Applies to `_free` only.** A `_fini` gets a valid `self` by contract — its idempotency concern is partial/zero *fields*, not a NULL `self` — so a `_fini` without a `self == NULL` guard is NOT a B4.
+
+### B5 — orthogonality break
+
+`new` that also initializes fields / allocates children (should be pure alloc), or `free` that calls `fini` (should be pure dealloc). **Decision-gated, low priority.**
+
+**Settled policy (2026-06-20):** `new = pure alloc` binds leaf/utility structs (`lpm`, `btree_*`, `value_table`, …) and the `cp_*` config quartet (`cp_chain`/`cp_function`/`cp_pipeline`/`cp_device`). Module-config and device **vtable constructors may stay fused** (`new` = `balloc + cp_module_init + *_data_init`) — that is an accepted shape, NOT a B5 defect; do not flag or split it. Only flag B5 when a genuinely-leaf/util or `cp_*`-family `new` fuses init, or for a brand-new constructor written fused.
+
+The codebase tolerates fused module-config constructors (`decap/dscp/route/pdump/route-mpls/blackhole/fwstate_module_config_new`, `cp_device_plain/vlan_new` — all renamed `create→new` in earlier runs while staying fused) and composite `free = fini + free` destructors. Note a `free` calling `fini` is often **conforming**, not a defect: it is the documented "full teardown of a heap object = fini then free" when an orthogonal `fini` already exists and is independently reused on stack/embedded instances (`cp_device_config_fini` at `zone.c`; `route_mpls_module_config_fini` reused by the `_update` error path). Splitting those would break the registry/Go-binding single-callback contract. Do NOT mass-split without the user's explicit call; splitting `new` into `new`+`init` is wide churn and reverses recently-merged work. Flag and record; pick up only when the user opts in or when a family is already open for another reason.
+
+### B6 — constructor reads uninitialized fields on its error path (garbage-read)
+
+A constructor allocates the struct WITHOUT zero-init (no `memset`, no full per-field init) and its error path calls a destructor that reads a field the init never set → wild read / wild free. Archetype: `counter_storage_spawn` (`lib/counters/counters.c`) `memory_balloc`s without memset, `counter_storage_init` sets only 3 offsets (never `counter_value_handles`), and any early `goto error` calls `counter_storage_free` which reads `ADDR_OF(&storage->counter_value_handles)` on garbage. This is the most dangerous shape because the teardown call is correct in *form*. Fix: zero-init the struct up front (so the destructor's field reads are well-defined) or have init set every field before the first failure point. Non-canonical constructor verbs (`spawn`/`copy`/`clone`/`build`) hide this class — they are now in the scanner's constructor vocabulary.
+
+## Cross-cutting invariants (assumed by the contract, checked by reading)
+
+These are not separate scan buckets — they are the properties the single-`err:`/idempotent-`fini` discipline silently depends on. Verify them when auditing any non-trivial init/fini:
+
+- **Zero-init before the first goto.** A caller-owned `init` must `memset`/zero `self` (or `new` must have) before any error path can call `fini` — else fini reads garbage (B6). The reference `cp_chain_new` memsets; `cp_chain_init` then relies on it.
+- **Partial-publish pairing.** Every field published via `SET_OFFSET_OF(&self->x, child)` must, on every later error path, be either un-published (`SET_OFFSET_OF(&self->x, NULL)`) or owned-and-released by exactly one path. The B2 `device.c` shape generalizes: publish late, or null on error. A field published early and freed both locally and by the fini is a double-free.
+- **memory_context teardown ordering.** When a struct embeds a `memory_context` and charges child allocations to it, the fini must free those children BEFORE `memory_context_fini` (which reclaims the whole context). `route_module_config_free` calls `data_fini` (frees arrays from the module's context) before `cp_module_fini` (finis that context); reversing them is a use-after-fini.
+- **Non-owning aliases / borrowed offsets.** A child may be referenced from an owning tree AND a non-owning registry/index. Exactly one owner frees it; the registry's fini must free only its own items array, never the borrowed objects (`cp_counter.c` counter-storage registry deliberately does not free the storages the ectx tree owns). The safety rests on a free-order invariant — flag any registry fini that frees borrowed offsets, and treat a registry that hands out live offsets into another subsystem's objects as a latent-UAF note, not a clean pass.
 
 ## False positives (record verdict, never re-triage)
 
-From coder-c's `lifecycle-fini-special-cases.md`:
-
-- **No-resource init** — init only assigns scalars/pointers into caller-owned memory and allocates nothing (`spinlock_init`, `tsc_clock_init`, `packet_list_init`, `packet_front_init` into arena memory): no fini needed → `fp-no-fini-needed`.
-- **Process-lifetime init** — `dataplane_init`, fuzz-harness `LLVMFuzzerInitialize` call sites: adding fini without a parent teardown is dead code → `fp-no-fini-needed` until the parent gains teardown.
+- **No-resource init** — init only assigns scalars/pointers into caller-owned memory and allocates nothing (`spinlock_init`, `tsc_clock_init`, `packet_front_init` into arena): no fini needed → `fp-no-fini-needed`.
+- **Process-lifetime init** — `dataplane_init`, `dp_storage_init`, fuzz `LLVMFuzzerInitialize`: adding fini without a parent teardown is dead code → `fp-no-fini-needed` until the parent gains teardown. (`dp_storage_init`'s unchecked `cp_agent_registry` alloc is in this class — process-lifetime bootstrap.)
+- **Stacked-ladder init is NOT a defect.** A leak-free init with multiple fall-through `error_xxx:` labels (e.g. `nat64_module_config_data_init`, `cp_device_config_init`) is correct — it is merely not the preferred single-`err:`+idempotent-`fini` shape. The read-test that separates a leak-free ladder from a leaky one: each error label must free *exactly* the resources live at its entry point, none twice, in reverse allocation order. If that holds it is style-only — convert opportunistically (low priority); NEVER record it as a leak. A fused `_create`/`_new` paired with a matching `_free` that every `goto error` reaches is the same: leak-free, decision-gated, not a defect.
+- **container_of module-config free guarded by the Go binding.** A `<mod>_module_config_free(struct cp_module *cp_module)` recovers the struct via `container_of` and dereferences it without a C-side NULL guard, but its only caller is the Go binding `ModuleConfig.Free()` which guards `if ptr := m.asRawPtr(); ptr != nil` before the CGO call. The C side never sees NULL → adding a guard is redundant, not a fix → `fp-other` (note the Go guard). The genuine B4s are the agent.c info-list collectors whose NULL flows from an OOM producer into a guardless Go `defer`.
+- **Bare `free(self)` / `memory_bfree(ctx, self, sizeof)` with no deref** — NULL-safe already (libc `free(NULL)` and `memory_bfree(.,.,0)` are no-ops); a missing explicit guard is not a B4 unless the body dereferences `self`.
 - **Factory structs** — own nothing directly (pages live in downstream containers); an empty placeholder fini that zeroes fields is correct and must say so in a comment.
-- **Internal helpers** — double-underscore or clearly-private helpers (`__ttlmap_lock_init`) follow the convention of their owner; flag only if the owner family is broken.
+- **Slot-reclaim / collector / DPDK callback frees** — `worker_packet_free` (mbuf returned to pool), `data_pipe_item_free` (ring slot), `fwstate_outdated_layers_free` (collector pair), `sock_dev_queue_release` (DPDK `eth_dev_ops` callback): not heap lifecycle → `fp-other`, do not touch DPDK callbacks at all.
+- **Internal helpers** — double-underscore / clearly-private helpers (`__ttlmap_lock_init`) follow their owner's convention; flag only if the owner family is broken.
 - **Test fixtures** (`test_mempool_create`, `test_ring_init`, …) — lowest value; rename only opportunistically when their family is already in a PR.
 
 ## Priority ladder (low risk first)
 
-1. **V3 leaks anywhere** — real bugs outrank all renames.
+1. **B1/B2/B3 structural defects anywhere** — real leaks/double-free/UAF outrank all renames and all B5.
 2. **common/ and lib/ leaf utilities** (header-only, all callers in-tree C, no FFI): `lpm`, `radix`, `btree_u*`, `value_table`, `remap_table`, segments classifiers.
-3. **lib/controlplane and lib/dataplane families** (`cp_*_create/free`, ectx families) — wide caller fan-out, still C-only.
-4. **modules/*/api and devices/*/api** — renames cross the CGO boundary; Go bindings (`bindings/go/*/cgo.go` or legacy `controlplane/ffi.go`) updated in the same PR by coder-go.
-5. **dataplane core init paths** (`dpdk_init`, `worker`, `device`) — highest blast radius, take last and only with a clear teardown story.
+3. **lib/controlplane and lib/dataplane families** (`cp_*`, ectx families) — wide caller fan-out, still C-only.
+4. **modules/*/api and devices/*/api** — renames cross the CGO boundary; Go bindings updated in the same PR by coder-go.
+5. **dataplane core init paths** (`dpdk_init`, `worker`, `device`) — highest blast radius, take last with a clear teardown story.
+6. **B5 orthogonality + style (stacked→single-label)** — decision-gated / opportunistic, lowest priority.
 
 ## Brief template (coder-c)
 
-The Phase 3 brief must contain:
+For a **rename** the brief must contain:
 
 - absolute worktree path; first action `cd` + `git rev-parse --show-toplevel` to confirm;
 - the exact rename map: every `old_symbol → new_symbol`;
-- the full consumer list (file:line) you collected in Phase 2 — the coder verifies it, not discovers it;
-- invariants to enforce while touching the family: fini idempotent on zero-init, free NULL-safe, constructor self-cleanup on error paths, `// FIXME free X` comments are bugs to resolve, POD-shaped fini may use release-resources + memset;
+- the full consumer list (file:line) from Phase 2 — the coder verifies it, not discovers it;
+- invariants to enforce while touching the family: fini idempotent (NULL-guard + reset each child), free NULL-safe, init zero-inits self and unwinds via a single `err:` → fini, `// FIXME free X` comments are bugs to resolve;
 - prohibitions: no struct layout changes, no adjacent restructuring, no gratuitous doc comments, no banner comments, `//` comment style, no destructive git ops, no `git commit`;
-- the closing check the coder must run: `grep -rn '<old_symbol>'` from repo root → zero hits.
+- closing check: `grep -rn '<old_symbol>'` from repo root → zero hits.
 
-For coder-go (when FFI symbols renamed): same worktree, only the `C.<symbol>` call sites and any Go wrapper names; receiver `m`; do not touch unrelated lines or comments.
+For a **B-class fix** the brief instead names: the exact defect (file:line, mechanism — leak / double-free / UAF / OOM-deref), the canonical fix shape (e.g. the B2 `SET_OFFSET_OF(data, NULL)` + `memory_bfree(wrapper)` pattern), the reference function it should match (`device.c`, `cp_chain.c`), and the same prohibitions. Require an ASan-clean local run.
+
+For **coder-go** (when FFI symbols renamed): same worktree, only the `C.<symbol>` call sites and any Go wrapper names; receiver `m`; do not touch unrelated lines or comments.


### PR DESCRIPTION
- Restate the RAII convention as four strictly orthogonal primitives: new allocates the struct, init fills fields via a single error label that calls fini, fini releases field memory idempotently, and free deallocates the struct.
- Split the sweep into a naming axis and a structural-correctness axis, each driven by its own read-only scanner.
- Add a structural scanner that flags error-path, NULL-safety, new/free orthogonality, and fini idempotency smells the naming scanner cannot see.
- Expand the triage rules with the validated violation classes, cross-cutting lifecycle invariants, and false-positive criteria.