### PR TITLE
fix(common): make memory_bfree NULL-safe

### DIFF
--- a/common/memory.h
+++ b/common/memory.h
@@ -131,7 +131,7 @@ memory_balloc(struct memory_context *context, size_t size) {
 
 static inline void
 memory_bfree(struct memory_context *context, void *block, size_t size) {
-	if (!size)
+	if (block == NULL || !size)
 		return;
 	++context->bfree_count;
 	context->bfree_size += size;


### PR DESCRIPTION
- Make memory_bfree a no-op on a NULL block, matching free(3) semantics, so callers no longer have to guard every potentially-empty offset before releasing it.
- Previously a NULL block with a nonzero size reached the block allocator, which wrote the free-list link through the pointer and corrupted the arena. An audit of all current call sites found each one individually guarded, so this closes the hazard class at the primitive rather than fixing a live leak.
- Skip the NULL case before the allocation accounting, mirroring the allocator which never accounts a failed allocation, so the balloc/bfree balance is preserved.