### PR TITLE
fix(web): keep config tabs mounted across page navigation

### DIFF
--- a/web/src/components/draft/useDraft.ts
+++ b/web/src/components/draft/useDraft.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
+import { useConfigListCache } from '../../hooks/useConfigListCache';
 import { toaster } from '../../utils';
 import type { DraftState, DraftAction } from './draftReducer';
 
@@ -15,6 +16,8 @@ interface UseDraftOpts<T> {
     toastSubject: string;
     /** Human-readable subject used in error messages (e.g. 'FIB' or 'decap prefix'). */
     errorSubject: string;
+    /** Gateway-scoped cache key for the config tab strip (e.g. 'decap' or 'route'). */
+    cacheKey: string;
 }
 
 export interface UseDraftResult<T> {
@@ -46,10 +49,12 @@ export function useDraft<T extends { id?: unknown }>({
     initialState,
     toastSubject,
     errorSubject,
+    cacheKey,
 }: UseDraftOpts<T>): UseDraftResult<T> {
     const [state, rawDispatch] = useReducer(reducer, initialState);
     const [loading, setLoading] = useState(true);
     const [loadFailed, setLoadFailed] = useState(false);
+    const { write: writeCache } = useConfigListCache(cacheKey);
 
     const dispatchDraft = useCallback((action: DraftAction<T>): void => {
         rawDispatch(action);
@@ -60,6 +65,10 @@ export function useDraft<T extends { id?: unknown }>({
         try {
             const configs = await load();
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });
+            writeCache({
+                configs: configs.map((cfg) => cfg.name),
+                counts: Object.fromEntries(configs.map((cfg) => [cfg.name, cfg.rows.length])),
+            });
             setLoadFailed(false);
         } catch (err) {
             toaster.error(`${toastSubject}-draft-load`, `Failed to load ${errorSubject} configurations`, err);
@@ -67,7 +76,7 @@ export function useDraft<T extends { id?: unknown }>({
         } finally {
             setLoading(false);
         }
-    }, [load, toastSubject, errorSubject]);
+    }, [load, toastSubject, errorSubject, writeCache]);
 
     useEffect(() => {
         doLoad();

--- a/web/src/hooks/index.ts
+++ b/web/src/hooks/index.ts
@@ -59,4 +59,7 @@ export { useInterpolatedCounterMap } from './useInterpolatedCounterMap';
 
 export { useTabCycle } from './useTabCycle';
 
+export { useConfigListCache } from './useConfigListCache';
+export type { ConfigListSnapshot, UseConfigListCacheResult } from './useConfigListCache';
+
 export { useUnsavedChangesBlocker } from './useUnsavedChangesBlocker';

--- a/web/src/hooks/useConfigListCache.ts
+++ b/web/src/hooks/useConfigListCache.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo } from 'react';
+import { useGateways } from '../gateways';
+
+/**
+ * Lightweight, gateway-scoped snapshot of a page's config tab strip.
+ *
+ * Holds only the config names and their per-tab counts — never the row
+ * payloads — so the cache stays small regardless of how much data a
+ * config carries.
+ */
+export interface ConfigListSnapshot {
+    /** Config names in display order. */
+    configs: string[];
+
+    /** Per-config item count keyed by config name, for the tab badge. */
+    counts: Record<string, number>;
+}
+
+const MAX_ENTRIES = 64;
+
+const store = new Map<string, ConfigListSnapshot>();
+
+const composeKey = (gatewayId: string, baseUrl: string, moduleKey: string): string =>
+    [gatewayId, baseUrl, moduleKey].join('::');
+
+export interface UseConfigListCacheResult {
+    /** Cached snapshot for the active gateway, or null on a cold cache. */
+    snapshot: ConfigListSnapshot | null;
+
+    /** Cached config names, or an empty array on a cold cache. */
+    configs: string[];
+
+    /** Cached tab counts as a map, empty on a cold cache. */
+    counts: Map<string, number>;
+
+    /** Stores the latest snapshot for the active gateway. */
+    write: (snapshot: ConfigListSnapshot) => void;
+}
+
+const EMPTY_CONFIGS: string[] = [];
+
+/**
+ * Gateway-scoped cache of a page's config-name list and tab counts.
+ *
+ * Lets a page render its ConfigTabStrip instantly on remount instead of
+ * blanking behind a full-page loader while the per-config data refetches.
+ * The cache is keyed by the active gateway, so switching gateways yields a
+ * cold cache (and a one-time loader) rather than another gateway's tabs.
+ */
+export const useConfigListCache = (moduleKey: string): UseConfigListCacheResult => {
+    const { activeGateway } = useGateways();
+    const key = composeKey(activeGateway?.id ?? '', activeGateway?.baseUrl ?? '', moduleKey);
+
+    const snapshot = store.get(key) ?? null;
+
+    const counts = useMemo(() => {
+        const map = new Map<string, number>();
+        if (snapshot) {
+            for (const [name, count] of Object.entries(snapshot.counts)) {
+                map.set(name, count);
+            }
+        }
+        return map;
+    }, [snapshot]);
+
+    const write = useCallback((next: ConfigListSnapshot): void => {
+        if (!store.has(key) && store.size >= MAX_ENTRIES) {
+            const oldest = store.keys().next().value;
+            if (oldest !== undefined) {
+                store.delete(oldest);
+            }
+        }
+        store.set(key, next);
+    }, [key]);
+
+    return { snapshot, configs: snapshot?.configs ?? EMPTY_CONFIGS, counts, write };
+};

--- a/web/src/pages/modules/acl/AclPage.tsx
+++ b/web/src/pages/modules/acl/AclPage.tsx
@@ -3,7 +3,7 @@ import { Button, Icon, Label } from '@gravity-ui/uikit';
 import { Funnel, Pause, Play, Plus } from '@gravity-ui/icons';
 import { useNavigate } from 'react-router-dom';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
-import { useListNavigation, usePageContribution } from '../../../hooks';
+import { useConfigListCache, useListNavigation, usePageContribution } from '../../../hooks';
 import { useAclDraft } from './useAclDraft';
 import type { Rule } from '../../../api/acl';
 import { ActionKind } from '../../../api/acl';
@@ -41,6 +41,8 @@ const AclPage: React.FC = () => {
         commitDeleteConfig,
         discardConfig,
     } = useAclDraft();
+
+    const { configs: cachedConfigs, counts: cachedCounts } = useConfigListCache('acl');
 
     const [paused, setPaused] = useState(false);
     const [enabledCounterNames, setEnabledCounterNames] = useState<Set<string>>(new Set());
@@ -267,6 +269,7 @@ const AclPage: React.FC = () => {
             addConfigSub: 'Create a new ACL configuration',
             withKeywords: true,
             onAddConfig: () => setAddConfigOpen(true),
+            addConfigDisabled: loading,
             onDeleteConfig: () => handleOpenDeleteConfig(),
             onSwitchConfig: (name) => handleTabSelect(name),
         }));
@@ -298,7 +301,7 @@ const AclPage: React.FC = () => {
         });
         return list;
     }, [
-        currentIsDirty, currentConfig, draftConfigs, dirtySet,
+        loading, currentIsDirty, currentConfig, draftConfigs, dirtySet,
         enabledCounterNames, paused, currentFwStateName,
         openAdd, handleSavePress, handleDiscard, closeDrawer,
         handleTabSelect, handleOpenDeleteConfig, handleSearchChange, handleOpenLinkedFwstate,
@@ -354,7 +357,12 @@ const AclPage: React.FC = () => {
         />
     );
 
-    if (loading) {
+    // While a warm cache exists, keep the tab strip mounted from cached names
+    // and counts so it does not blink on remount; only the rows below reload.
+    const tabConfigs = loading ? cachedConfigs : draftConfigs;
+    const tabCounts = loading ? cachedCounts : ruleCounts;
+
+    if (loading && cachedConfigs.length === 0) {
         return (
             <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
@@ -365,7 +373,7 @@ const AclPage: React.FC = () => {
     return (
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
-                {draftConfigs.length === 0 ? (
+                {tabConfigs.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No ACL configurations found."
                         actionLabel="Add Config"
@@ -374,53 +382,60 @@ const AclPage: React.FC = () => {
                 ) : (
                     <>
                         <ConfigTabStrip
-                            configs={draftConfigs}
+                            configs={tabConfigs}
                             activeConfig={currentConfig}
-                            counts={ruleCounts}
+                            counts={tabCounts}
                             dirtyConfigs={dirtySet}
                             onSelect={handleTabSelect}
                             onAddConfig={() => setAddConfigOpen(true)}
+                            addConfigDisabled={loading}
                         />
-                        <div className="yn-toolbar-bordered">
-                            {currentFwStateName && (
-                                <Button size="s" view="outlined" onClick={handleOpenLinkedFwstate}>
-                                    FWState: {currentFwStateName}
-                                </Button>
-                            )}
-                            {!currentFwStateName && hasStatefulRules && (
-                                <Label theme="warning">Stateful rules without FWState</Label>
-                            )}
-                            <div style={{ flex: 1 }} />
-                            <div style={{ flexBasis: 320, flexShrink: 1 }}>
-                                <SearchInput
-                                    value={search}
-                                    onUpdate={handleSearchChange}
-                                    placeholder="Search rules…"
-                                    icon={Funnel}
-                                    enableFocusShortcut={false}
-                                    showShortcutHint={false}
-                                />
-                            </div>
-                            <RowCountDisplay filtered={visibleItems.length} total={allItems.length} />
-                        </div>
+                        {loading ? (
+                            <PageLoader loading size="l" />
+                        ) : (
+                            <>
+                                <div className="yn-toolbar-bordered">
+                                    {currentFwStateName && (
+                                        <Button size="s" view="outlined" onClick={handleOpenLinkedFwstate}>
+                                            FWState: {currentFwStateName}
+                                        </Button>
+                                    )}
+                                    {!currentFwStateName && hasStatefulRules && (
+                                        <Label theme="warning">Stateful rules without FWState</Label>
+                                    )}
+                                    <div style={{ flex: 1 }} />
+                                    <div style={{ flexBasis: 320, flexShrink: 1 }}>
+                                        <SearchInput
+                                            value={search}
+                                            onUpdate={handleSearchChange}
+                                            placeholder="Search rules…"
+                                            icon={Funnel}
+                                            enableFocusShortcut={false}
+                                            showShortcutHint={false}
+                                        />
+                                    </div>
+                                    <RowCountDisplay filtered={visibleItems.length} total={allItems.length} />
+                                </div>
 
-                        <div className="yn-content">
-                            <RuleTable
-                                items={visibleItems}
-                                selectedIds={selectedIds}
-                                activeRowId={activeRowId}
-                                flashRowId={flashRowId}
-                                onSelectionChange={setSelectedIds}
-                                onEditRule={openEdit}
-                                currentIsDirty={currentIsDirty}
-                                onSave={handleSavePress}
-                                onDiscard={handleDiscard}
-                                onDeleteConfig={handleOpenDeleteConfig}
-                                rates={rates}
-                                enabledCounterNames={enabledCounterNames}
-                                onToggleCounter={handleToggleCounter}
-                            />
-                        </div>
+                                <div className="yn-content">
+                                    <RuleTable
+                                        items={visibleItems}
+                                        selectedIds={selectedIds}
+                                        activeRowId={activeRowId}
+                                        flashRowId={flashRowId}
+                                        onSelectionChange={setSelectedIds}
+                                        onEditRule={openEdit}
+                                        currentIsDirty={currentIsDirty}
+                                        onSave={handleSavePress}
+                                        onDiscard={handleDiscard}
+                                        onDeleteConfig={handleOpenDeleteConfig}
+                                        rates={rates}
+                                        enabledCounterNames={enabledCounterNames}
+                                        onToggleCounter={handleToggleCounter}
+                                    />
+                                </div>
+                            </>
+                        )}
                     </>
                 )}
 

--- a/web/src/pages/modules/acl/useAclDraft.ts
+++ b/web/src/pages/modules/acl/useAclDraft.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useReducer, useState } from 'react';
 import { API } from '../../../api';
+import { useConfigListCache } from '../../../hooks';
 import { toaster, compareNatural } from '../../../utils';
 import type { Rule } from '../../../api/acl';
 import {
@@ -44,6 +45,7 @@ export interface UseAclDraftResult {
 export const useAclDraft = (): UseAclDraftResult => {
     const [state, rawDispatch] = useReducer(aclDraftReducer, initialAclDraftState);
     const [loading, setLoading] = useState(true);
+    const { write: writeCache } = useConfigListCache('acl');
 
     const dispatchDraft = useCallback((action: AclDraftAction): void => {
         rawDispatch(action);
@@ -67,12 +69,16 @@ export const useAclDraft = (): UseAclDraftResult => {
             );
 
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });
+            writeCache({
+                configs: [...names].sort((a, b) => compareNatural(a, b)),
+                counts: Object.fromEntries(configs.map(cfg => [cfg.name, cfg.rules.length])),
+            });
         } catch (err) {
             toaster.error('acl-load', 'Failed to load ACL configurations', err);
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [writeCache]);
 
     useEffect(() => {
         load();

--- a/web/src/pages/modules/decap/DecapPage.tsx
+++ b/web/src/pages/modules/decap/DecapPage.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Funnel, Plus } from '@gravity-ui/icons';
-import { useListNavigation, usePageContribution, useTabCycle } from '../../../hooks';
+import { useConfigListCache, useListNavigation, usePageContribution, useTabCycle } from '../../../hooks';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder, SearchInput, RowCountDisplay } from '../../../components';
 import { usePrefixDraft } from './usePrefixDraft';
 import type { PrefixRowItem } from './types';
@@ -33,6 +33,8 @@ const DecapPage: React.FC = () => {
         draftConfigs, loading, loadFailed, draftRows, serverRows, isDirty, anyDirty,
         dispatchDraft, commitConfig, discardConfig,
     } = usePrefixDraft();
+
+    const { configs: cachedConfigs, counts: cachedCounts } = useConfigListCache('decap');
 
     const pageState = useDraftPageState({
         loading,
@@ -182,12 +184,19 @@ const DecapPage: React.FC = () => {
         />
     );
 
-    if (loading) return <PageLayout header={pageHeader} className="yn-flat-layout"><PageLoader loading size="l" /></PageLayout>;
+    // While a warm cache exists, keep the tab strip mounted from cached names
+    // and counts so it does not blink on remount; only the rows below reload.
+    const tabConfigs = loading ? cachedConfigs : draftConfigs;
+    const tabCounts = loading ? cachedCounts : prefixCounts;
+
+    if (loading && cachedConfigs.length === 0) {
+        return <PageLayout header={pageHeader} className="yn-flat-layout"><PageLoader loading size="l" /></PageLayout>;
+    }
 
     return (
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
-                {draftConfigs.length === 0 ? (
+                {tabConfigs.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No decap configurations found."
                         actionLabel="Add Config"
@@ -197,52 +206,58 @@ const DecapPage: React.FC = () => {
                 ) : (
                     <>
                         <ConfigTabStrip
-                            configs={draftConfigs}
+                            configs={tabConfigs}
                             activeConfig={currentConfig}
-                            counts={prefixCounts}
+                            counts={tabCounts}
                             dirtyConfigs={dirtySet}
                             onSelect={setActiveConfig}
                             onAddConfig={() => setAddConfigOpen(true)}
                             addConfigDisabled={!canCreate}
                         />
-                        <div className="yn-toolbar-bordered">
-                            <div style={{ flex: 1 }} />
-                            <div style={{ flexBasis: 230, flexShrink: 1 }}>
-                                <SearchInput
-                                    value={search}
-                                    onUpdate={(value) => updateParams({ [QP_SEARCH]: value || null })}
-                                    placeholder="Filter prefixes…"
-                                    enableFocusShortcut={false}
-                                    showShortcutHint={false}
-                                    icon={Funnel}
-                                />
-                            </div>
-                            <RowCountDisplay filtered={visibleRows.length} total={rawRows.length} />
-                        </div>
-                        <div className="yn-content">
-                            <PrefixTable
-                                allRows={rawRows}
-                                visibleRows={visibleRows}
-                                statusById={statusById}
-                                removedRows={search ? [] : removedRows}
-                                activeRowId={activeRowId}
-                                editingRowId={editingRowId}
-                                selectedIds={selectedIds}
-                                dragOverState={dragDrop.dragOverState}
-                                onRowClick={setActiveRowId}
-                                onEditRow={(id) => { setActiveRowId(id); setEditingRowId(id); }}
-                                onRestoreRow={handlers.handleRestoreRow}
-                                onSelectionChange={setSelectedIds}
-                                onDragStart={dragDrop.handleDragStart}
-                                onDragOver={dragDrop.handleDragOver}
-                                onDragLeave={dragDrop.handleDragLeave}
-                                onDrop={handlers.handleDrop}
-                                currentIsDirty={currentIsDirty}
-                                onSave={handlers.handleCommitPress}
-                                onDiscard={handlers.handleDiscard}
-                                onDeleteConfig={() => setDeleteConfigOpen(true)}
-                            />
-                        </div>
+                        {loading ? (
+                            <PageLoader loading size="l" />
+                        ) : (
+                            <>
+                                <div className="yn-toolbar-bordered">
+                                    <div style={{ flex: 1 }} />
+                                    <div style={{ flexBasis: 230, flexShrink: 1 }}>
+                                        <SearchInput
+                                            value={search}
+                                            onUpdate={(value) => updateParams({ [QP_SEARCH]: value || null })}
+                                            placeholder="Filter prefixes…"
+                                            enableFocusShortcut={false}
+                                            showShortcutHint={false}
+                                            icon={Funnel}
+                                        />
+                                    </div>
+                                    <RowCountDisplay filtered={visibleRows.length} total={rawRows.length} />
+                                </div>
+                                <div className="yn-content">
+                                    <PrefixTable
+                                        allRows={rawRows}
+                                        visibleRows={visibleRows}
+                                        statusById={statusById}
+                                        removedRows={search ? [] : removedRows}
+                                        activeRowId={activeRowId}
+                                        editingRowId={editingRowId}
+                                        selectedIds={selectedIds}
+                                        dragOverState={dragDrop.dragOverState}
+                                        onRowClick={setActiveRowId}
+                                        onEditRow={(id) => { setActiveRowId(id); setEditingRowId(id); }}
+                                        onRestoreRow={handlers.handleRestoreRow}
+                                        onSelectionChange={setSelectedIds}
+                                        onDragStart={dragDrop.handleDragStart}
+                                        onDragOver={dragDrop.handleDragOver}
+                                        onDragLeave={dragDrop.handleDragLeave}
+                                        onDrop={handlers.handleDrop}
+                                        currentIsDirty={currentIsDirty}
+                                        onSave={handlers.handleCommitPress}
+                                        onDiscard={handlers.handleDiscard}
+                                        onDeleteConfig={() => setDeleteConfigOpen(true)}
+                                    />
+                                </div>
+                            </>
+                        )}
                     </>
                 )}
 

--- a/web/src/pages/modules/decap/usePrefixDraft.ts
+++ b/web/src/pages/modules/decap/usePrefixDraft.ts
@@ -46,5 +46,6 @@ export const usePrefixDraft = (): UsePrefixDraftResult => {
         initialState: initialPrefixDraftState,
         toastSubject: 'prefix',
         errorSubject: 'Decap',
+        cacheKey: 'decap',
     });
 };

--- a/web/src/pages/modules/forward/ForwardPage.tsx
+++ b/web/src/pages/modules/forward/ForwardPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
-import { useListNavigation, usePageContribution } from '../../../hooks';
+import { useConfigListCache, useListNavigation, usePageContribution } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useForwardDraft } from './useForwardDraft';
@@ -42,6 +42,8 @@ const ForwardPage: React.FC = () => {
         commitDeleteConfig,
         discardConfig,
     } = useForwardDraft();
+
+    const { configs: cachedConfigs, counts: cachedCounts } = useConfigListCache('forward');
 
     const [modeFilter, setModeFilter] = useState<ModeFilterValue>('all');
 
@@ -288,7 +290,12 @@ const ForwardPage: React.FC = () => {
         />
     );
 
-    if (loading) {
+    // While a warm cache exists, keep the tab strip mounted from cached names
+    // and counts so it does not blink on remount; only the rows below reload.
+    const tabConfigs = loading ? cachedConfigs : draftConfigs;
+    const tabCounts = loading ? cachedCounts : ruleCounts;
+
+    if (loading && cachedConfigs.length === 0) {
         return (
             <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
@@ -299,7 +306,7 @@ const ForwardPage: React.FC = () => {
     return (
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
-                {draftConfigs.length === 0 ? (
+                {tabConfigs.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No forward configurations found."
                         actionLabel="Add Config"
@@ -309,46 +316,52 @@ const ForwardPage: React.FC = () => {
                 ) : (
                     <>
                         <ConfigTabStrip
-                            configs={draftConfigs}
+                            configs={tabConfigs}
                             activeConfig={currentConfig}
-                            counts={ruleCounts}
+                            counts={tabCounts}
                             dirtyConfigs={dirtySet}
                             onSelect={handleTabSelect}
                             onAddConfig={() => setAddConfigOpen(true)}
                             addConfigDisabled={!canCreate}
                         />
 
-                        <div className="yn-toolbar-bordered">
-                            <ModeFilter value={modeFilter} onChange={setModeFilter} />
-                            <div style={{ flex: 1 }} />
-                            <div style={{ flexBasis: 230, flexShrink: 1 }}>
-                                <SearchInput
-                                    value={search}
-                                    onUpdate={handleSearchChange}
-                                    placeholder="Filter rows…"
-                                    enableFocusShortcut={false}
-                                    showShortcutHint={false}
-                                    icon={Funnel}
-                                />
-                            </div>
-                            <RowCountDisplay filtered={visibleItems.length} total={allItems.length} />
-                        </div>
+                        {loading ? (
+                            <PageLoader loading size="l" />
+                        ) : (
+                            <>
+                                <div className="yn-toolbar-bordered">
+                                    <ModeFilter value={modeFilter} onChange={setModeFilter} />
+                                    <div style={{ flex: 1 }} />
+                                    <div style={{ flexBasis: 230, flexShrink: 1 }}>
+                                        <SearchInput
+                                            value={search}
+                                            onUpdate={handleSearchChange}
+                                            placeholder="Filter rows…"
+                                            enableFocusShortcut={false}
+                                            showShortcutHint={false}
+                                            icon={Funnel}
+                                        />
+                                    </div>
+                                    <RowCountDisplay filtered={visibleItems.length} total={allItems.length} />
+                                </div>
 
-                        <div className="yn-content">
-                            <RuleTable
-                                items={visibleItems}
-                                selectedIds={selectedIds}
-                                activeRowId={activeRowId}
-                                rateValues={rates}
-                                onSelectionChange={setSelectedIds}
-                                onEditRule={openEdit}
-                                currentIsDirty={currentIsDirty}
-                                onSave={handleSavePress}
-                                onDiscard={handleDiscard}
-                                onDeleteConfig={() => setDeleteConfigOpen(true)}
-                                flashRowId={flashRowId}
-                            />
-                        </div>
+                                <div className="yn-content">
+                                    <RuleTable
+                                        items={visibleItems}
+                                        selectedIds={selectedIds}
+                                        activeRowId={activeRowId}
+                                        rateValues={rates}
+                                        onSelectionChange={setSelectedIds}
+                                        onEditRule={openEdit}
+                                        currentIsDirty={currentIsDirty}
+                                        onSave={handleSavePress}
+                                        onDiscard={handleDiscard}
+                                        onDeleteConfig={() => setDeleteConfigOpen(true)}
+                                        flashRowId={flashRowId}
+                                    />
+                                </div>
+                            </>
+                        )}
                     </>
                 )}
 

--- a/web/src/pages/modules/forward/useForwardDraft.ts
+++ b/web/src/pages/modules/forward/useForwardDraft.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 import { API } from '../../../api';
+import { useConfigListCache } from '../../../hooks';
 import { toaster } from '../../../utils';
 import type { Rule } from '../../../api/forward';
 import {
@@ -59,6 +60,7 @@ export const useForwardDraft = (): UseForwardDraftResult => {
     const [state, rawDispatch] = useReducer(forwardDraftReducer, initialDraftState);
     const [loading, setLoading] = useState(true);
     const [loadFailed, setLoadFailed] = useState(false);
+    const { write: writeCache } = useConfigListCache('forward');
 
     const dispatchDraft = useCallback((action: ForwardDraftAction): void => {
         rawDispatch(action);
@@ -82,6 +84,10 @@ export const useForwardDraft = (): UseForwardDraftResult => {
             );
 
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });
+            writeCache({
+                configs: configs.map(cfg => cfg.name),
+                counts: Object.fromEntries(configs.map(cfg => [cfg.name, cfg.rules.length])),
+            });
             setLoadFailed(false);
         } catch (err) {
             toaster.error('yn-draft-load', 'Failed to load forward configurations', err);
@@ -89,7 +95,7 @@ export const useForwardDraft = (): UseForwardDraftResult => {
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [writeCache]);
 
     useEffect(() => {
         load();

--- a/web/src/pages/modules/fwstate/FWStatePage.tsx
+++ b/web/src/pages/modules/fwstate/FWStatePage.tsx
@@ -14,7 +14,7 @@ import {
 } from '@gravity-ui/uikit';
 import { CircleInfo, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, usePageContribution, useContainerHeight, useTabCycle, useUnsavedChangesBlocker } from '../../../hooks';
+import { useConfigListCache, useSearchParamHelpers, usePageContribution, useContainerHeight, useTabCycle, useUnsavedChangesBlocker } from '../../../hooks';
 import { API } from '../../../api';
 import { Direction, type FwStateEntry, type ListEntriesRequest, type MapStats } from '../../../api/fwstate';
 import { ConfirmDialog, ConfigTabStrip, PageLayout, PageLoader, EmptyPagePlaceholder } from '../../../components';
@@ -1297,6 +1297,19 @@ const FWStatePage: React.FC = () => {
         return m;
     }, [configNames, configs]);
 
+    const { configs: cachedConfigs, counts: cachedCounts, write: writeCache } = useConfigListCache('fwstate');
+
+    // Cache config names and linked-ACL counts so the config tab strip renders
+    // instantly on remount instead of blanking while ListConfigs refetches.
+    useEffect(() => {
+        if (!loading && configNames.length > 0) {
+            writeCache({
+                configs: configNames,
+                counts: Object.fromEntries(configNames.map((name) => [name, configs[name]?.linkedAcls.length ?? 0])),
+            });
+        }
+    }, [loading, configNames, configs, writeCache]);
+
     const updateCurrent = (patch: Partial<DraftConfig>): void => {
         if (!currentName) return;
         setConfigs((prev) => ({ ...prev, [currentName]: { ...prev[currentName], ...patch } }));
@@ -1582,7 +1595,12 @@ const FWStatePage: React.FC = () => {
         />
     );
 
-    if (loading) {
+    // While a warm cache exists, keep the config tab strip mounted from cached
+    // names and counts so it does not blink on remount; only the body reloads.
+    const tabConfigs = loading ? cachedConfigs : configNames;
+    const tabCounts = loading ? cachedCounts : counts;
+
+    if (loading && cachedConfigs.length === 0) {
         return <PageLayout header={pageHeader} className="yn-flat-layout"><PageLoader loading size="l" /></PageLayout>;
     }
 
@@ -1807,7 +1825,7 @@ const FWStatePage: React.FC = () => {
     return (
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
-                {configNames.length === 0 ? (
+                {tabConfigs.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No FWState configurations found."
                         actionLabel="Add Config"
@@ -1818,16 +1836,20 @@ const FWStatePage: React.FC = () => {
                         <div className="fwstate-config-bar">
                             <div className="fwstate-config-bar__tabs">
                                 <ConfigTabStrip
-                                    configs={configNames}
+                                    configs={tabConfigs}
                                     activeConfig={currentName}
-                                    counts={counts}
+                                    counts={tabCounts}
                                     dirtyConfigs={dirtyConfigs}
                                     onSelect={updateActiveConfig}
                                     onAddConfig={() => setAddConfigOpen(true)}
+                                    addConfigDisabled={loading}
                                 />
                             </div>
                         </div>
 
+                        {loading ? (
+                            <PageLoader loading size="l" />
+                        ) : (
                         <div className="yn-content fwstate-content">
                             {current && (
                                 <div className="fwstate-settings-layout">
@@ -1876,6 +1898,7 @@ const FWStatePage: React.FC = () => {
                                 </div>
                             )}
                         </div>
+                        )}
                     </>
                 )}
             </div>

--- a/web/src/pages/modules/pdump/PdumpPage.tsx
+++ b/web/src/pages/modules/pdump/PdumpPage.tsx
@@ -76,7 +76,7 @@ const createPcapBuffer = (records: CapturedPacket[]): ArrayBuffer => {
 };
 
 const PdumpPage: React.FC = () => {
-    const { configs, loading, refetch, deleteConfig } = usePdumpConfigs();
+    const { configs, cachedConfigs, loading, refetch, deleteConfig } = usePdumpConfigs();
     const [searchParams, setSearchParams] = useSearchParams();
     const queryConfig = useMemo(() => searchParams.get(QP_CONFIG), [searchParams]);
     const searchQuery = useMemo(() => searchParams.get(QP_SEARCH) || '', [searchParams]);
@@ -550,7 +550,11 @@ const PdumpPage: React.FC = () => {
         />
     );
 
-    if (loading) {
+    // While a warm cache exists, keep the tab strip mounted from cached names
+    // so it does not blink on remount; only the body below reloads.
+    const tabConfigs = loading ? cachedConfigs : configs.map(c => c.name);
+
+    if (loading && cachedConfigs.length === 0) {
         return (
             <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
@@ -561,7 +565,7 @@ const PdumpPage: React.FC = () => {
     return (
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page pdump-page yn-flat-page">
-                {configs.length === 0 ? (
+                {tabConfigs.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No pdump configurations found."
                         actionLabel="New Configuration"
@@ -570,15 +574,19 @@ const PdumpPage: React.FC = () => {
                 ) : (
                     <>
                         <ConfigTabStrip
-                            configs={configs.map(c => c.name)}
+                            configs={tabConfigs}
                             activeConfig={currentConfig}
                             counts={packetCounts}
                             dirtyConfigs={EMPTY_DIRTY_SET}
                             onSelect={handleSelectTab}
                             onAddConfig={() => setIsCreateDialogOpen(true)}
+                            addConfigDisabled={loading}
                             leadingIcon={(cfg) => cfg === capture.liveConfig ? <span className="yn-tab__dot yn-tab__dot--live" aria-label="live capture" /> : null}
                         />
 
+                        {loading ? (
+                            <PageLoader loading size="l" />
+                        ) : (
                         <div className="yn-content pdump-page__content">
                             {currentConfigInfo && (
                                 <>
@@ -616,6 +624,7 @@ const PdumpPage: React.FC = () => {
                                 />
                             </div>
                         </div>
+                        )}
                     </>
                 )}
 

--- a/web/src/pages/modules/pdump/hooks.ts
+++ b/web/src/pages/modules/pdump/hooks.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState, useEffect } from 'react';
 import { useAsyncData } from '../../../hooks/useAsyncData';
+import { useConfigListCache } from '../../../hooks/useConfigListCache';
 import { pdumpApi, type PdumpConfig, type PdumpRecord } from '../../../api/pdump';
 import { base64ToUint8Array, parsePacket, toaster } from '../../../utils';
 import type { PdumpConfigInfo, CapturedPacket } from './types';
@@ -38,6 +39,16 @@ export const usePdumpConfigs = () => {
         errorMessage: 'Failed to load pdump configs',
     });
 
+    // Cache the config-name list so the tab strip renders instantly on remount
+    // instead of blanking while ListConfigs refetches. Counts come from live
+    // capture state, so only names are cached.
+    const { configs: cachedConfigs, write: writeCache } = useConfigListCache('pdump');
+    useEffect(() => {
+        if (data) {
+            writeCache({ configs: data.map((c) => c.name), counts: {} });
+        }
+    }, [data, writeCache]);
+
     const deleteConfig = useCallback(async (configName: string): Promise<boolean> => {
         try {
             await pdumpApi.deleteConfig(configName);
@@ -52,6 +63,7 @@ export const usePdumpConfigs = () => {
 
     return {
         configs: data ?? [],
+        cachedConfigs,
         loading,
         error,
         refetch,

--- a/web/src/pages/modules/route/RoutePage.tsx
+++ b/web/src/pages/modules/route/RoutePage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useRef } from 'react';
 import { Button, Icon } from '@gravity-ui/uikit';
-import { useListNavigation, usePageContribution, useTabCycle } from '../../../hooks';
+import { useConfigListCache, useListNavigation, usePageContribution, useTabCycle } from '../../../hooks';
 import { Funnel, Plus } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, SearchInput, EmptyPagePlaceholder, RowCountDisplay } from '../../../components';
 import { useFIBDraft } from './useFIBDraft';
@@ -41,6 +41,8 @@ const RoutePage: React.FC = () => {
         draftConfigs, loading, loadFailed, draftRows, serverRows, isDirty, anyDirty,
         dispatchDraft, commitConfig, discardConfig,
     } = useFIBDraft();
+
+    const { configs: cachedConfigs, counts: cachedCounts } = useConfigListCache('route');
 
     const pageState = useDraftPageState({
         loading,
@@ -223,7 +225,12 @@ const RoutePage: React.FC = () => {
         />
     );
 
-    if (loading) {
+    // While a warm cache exists, keep the tab strip mounted from cached names
+    // and counts so it does not blink on remount; only the rows below reload.
+    const tabConfigs = loading ? cachedConfigs : draftConfigs;
+    const tabCounts = loading ? cachedCounts : routeCounts;
+
+    if (loading && cachedConfigs.length === 0) {
         return (
             <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
@@ -234,7 +241,7 @@ const RoutePage: React.FC = () => {
     return (
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page">
-                {draftConfigs.length === 0 ? (
+                {tabConfigs.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No FIB configurations found."
                         actionLabel="Add Config"
@@ -244,52 +251,58 @@ const RoutePage: React.FC = () => {
                 ) : (
                     <>
                         <ConfigTabStrip
-                            configs={draftConfigs}
+                            configs={tabConfigs}
                             activeConfig={currentConfig}
-                            counts={routeCounts}
+                            counts={tabCounts}
                             dirtyConfigs={dirtySet}
                             onSelect={handleConfigSelect}
                             onAddConfig={() => setAddConfigOpen(true)}
                             addConfigDisabled={!canCreate}
                         />
-                        <div className="yn-toolbar-bordered">
-                            <div style={{ flex: 1 }} />
-                            <div style={{ flexBasis: 230, flexShrink: 1 }}>
-                                <SearchInput
-                                    value={search}
-                                    onUpdate={handleSearchChange}
-                                    placeholder="Filter routes…"
-                                    enableFocusShortcut={false}
-                                    showShortcutHint={false}
-                                    icon={Funnel}
-                                />
-                            </div>
-                            <RowCountDisplay filtered={visibleRows.length} total={rawRows.length} />
-                        </div>
-                        <div className="yn-content">
-                            <FIBTable
-                                allRows={rawRows}
-                                visibleRows={visibleRows}
-                                statusById={statusById}
-                                removedRows={search ? [] : removedRows}
-                                activeRowId={activeRowId}
-                                editingRowId={editingRowId}
-                                selectedIds={selectedIds}
-                                dragOverState={dragDrop.dragOverState}
-                                onRowClick={setActiveRowId}
-                                onEditRow={(id) => { setActiveRowId(id); setEditingRowId(id); }}
-                                onRestoreRow={handlers.handleRestoreRow}
-                                onSelectionChange={setSelectedIds}
-                                onDragStart={dragDrop.handleDragStart}
-                                onDragOver={dragDrop.handleDragOver}
-                                onDragLeave={dragDrop.handleDragLeave}
-                                onDrop={handlers.handleDrop}
-                                currentIsDirty={currentIsDirty}
-                                onSave={handlers.handleCommitPress}
-                                onDiscard={handlers.handleDiscard}
-                                onDeleteConfig={() => setDeleteConfigOpen(true)}
-                            />
-                        </div>
+                        {loading ? (
+                            <PageLoader loading size="l" />
+                        ) : (
+                            <>
+                                <div className="yn-toolbar-bordered">
+                                    <div style={{ flex: 1 }} />
+                                    <div style={{ flexBasis: 230, flexShrink: 1 }}>
+                                        <SearchInput
+                                            value={search}
+                                            onUpdate={handleSearchChange}
+                                            placeholder="Filter routes…"
+                                            enableFocusShortcut={false}
+                                            showShortcutHint={false}
+                                            icon={Funnel}
+                                        />
+                                    </div>
+                                    <RowCountDisplay filtered={visibleRows.length} total={rawRows.length} />
+                                </div>
+                                <div className="yn-content">
+                                    <FIBTable
+                                        allRows={rawRows}
+                                        visibleRows={visibleRows}
+                                        statusById={statusById}
+                                        removedRows={search ? [] : removedRows}
+                                        activeRowId={activeRowId}
+                                        editingRowId={editingRowId}
+                                        selectedIds={selectedIds}
+                                        dragOverState={dragDrop.dragOverState}
+                                        onRowClick={setActiveRowId}
+                                        onEditRow={(id) => { setActiveRowId(id); setEditingRowId(id); }}
+                                        onRestoreRow={handlers.handleRestoreRow}
+                                        onSelectionChange={setSelectedIds}
+                                        onDragStart={dragDrop.handleDragStart}
+                                        onDragOver={dragDrop.handleDragOver}
+                                        onDragLeave={dragDrop.handleDragLeave}
+                                        onDrop={handlers.handleDrop}
+                                        currentIsDirty={currentIsDirty}
+                                        onSave={handlers.handleCommitPress}
+                                        onDiscard={handlers.handleDiscard}
+                                        onDeleteConfig={() => setDeleteConfigOpen(true)}
+                                    />
+                                </div>
+                            </>
+                        )}
                     </>
                 )}
 

--- a/web/src/pages/modules/route/useFIBDraft.ts
+++ b/web/src/pages/modules/route/useFIBDraft.ts
@@ -88,5 +88,6 @@ export const useFIBDraft = (): UseFIBDraftResult => {
         initialState: initialFIBDraftState,
         toastSubject: 'fib',
         errorSubject: 'FIB',
+        cacheKey: 'route',
     });
 };

--- a/web/src/pages/operators/neighbours/NeighboursPage.tsx
+++ b/web/src/pages/operators/neighbours/NeighboursPage.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useSearchParamHelpers, useListNavigation, usePageContribution, useTabCycle } from '../../../hooks';
+import { useConfigListCache, useSearchParamHelpers, useListNavigation, usePageContribution, useTabCycle } from '../../../hooks';
 import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus, Layers } from '@gravity-ui/icons';
 import { PageLayout, PageLoader, ConfigTabStrip, BulkBar, EmptyPagePlaceholder } from '../../../components';
@@ -97,11 +97,30 @@ const NeighboursPage: React.FC = () => {
     const [editTableOpen, setEditTableOpen] = useState(false);
     const [deleteTableOpen, setDeleteTableOpen] = useState(false);
 
+    const { configs: cachedConfigs, counts: cachedCounts, write: writeCache } = useConfigListCache('neighbours');
+
+    // Cache table names and entry counts so the tab strip renders instantly on
+    // remount instead of blanking while ListTables refetches.
+    useEffect(() => {
+        if (!loading && tables.length > 0) {
+            writeCache({
+                configs: tables.map((t) => t.name || '').filter(Boolean),
+                counts: Object.fromEntries([
+                    [MERGED_TAB, tables.reduce((sum, t) => sum + Number(t.entry_count ?? 0), 0)],
+                    ...tables.filter((t) => t.name).map((t) => [t.name as string, Number(t.entry_count ?? 0)]),
+                ]),
+            });
+        }
+    }, [tables, loading, writeCache]);
+
     const isMergedView = activeTab === MERGED_TAB;
     const activeTableInfo: NeighbourTableInfo | null = tables.find((t) => t.name === activeTab) ?? null;
     const isBuiltIn = activeTableInfo?.built_in ?? false;
 
-    const tabsList = [MERGED_TAB, ...tables.map((t) => t.name || '').filter(Boolean)];
+    // While a warm cache exists, drive the tab strip from cached table names so
+    // it does not blink on remount; the rows below still reload.
+    const effectiveTableNames = loading ? cachedConfigs : tables.map((t) => t.name || '').filter(Boolean);
+    const tabsList = [MERGED_TAB, ...effectiveTableNames];
 
     const { updateParams } = useSearchParamHelpers(setSearchParams);
 
@@ -156,6 +175,8 @@ const NeighboursPage: React.FC = () => {
         });
         return m;
     }, [tables]);
+
+    const effectiveCounts = loading ? cachedCounts : counts;
 
     const openAdd = useCallback((): void => {
         setPanel({ open: true, mode: 'add', neighbour: null });
@@ -532,7 +553,7 @@ const NeighboursPage: React.FC = () => {
         />
     );
 
-    if (loading) {
+    if (loading && cachedConfigs.length === 0) {
         return (
             <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
@@ -543,7 +564,7 @@ const NeighboursPage: React.FC = () => {
     return (
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page nb-page yn-flat-page">
-                {tables.length === 0 ? (
+                {effectiveTableNames.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No neighbour tables found."
                         actionLabel="Create table"
@@ -558,7 +579,7 @@ const NeighboursPage: React.FC = () => {
                                 counts={(() => {
                                     const m = new Map<string, number>();
                                     tabsList.forEach((t) => {
-                                        m.set(displayLabel(t), counts.get(t) ?? 0);
+                                        m.set(displayLabel(t), effectiveCounts.get(t) ?? 0);
                                     });
                                     return m;
                                 })()}
@@ -568,6 +589,7 @@ const NeighboursPage: React.FC = () => {
                                     handleTabSelect(tab);
                                 }}
                                 onAddConfig={() => setCreateTableOpen(true)}
+                                addConfigDisabled={loading}
                                 addLabel="Add table"
                                 leadingIcon={(label) =>
                                     label === 'Merged' ? (
@@ -580,68 +602,74 @@ const NeighboursPage: React.FC = () => {
                                 }
                             />
                         </div>
-                        <div className="nb-toolbar">
-                            <FamilyFilter
-                                value={family}
-                                onChange={(f) => updateParams({ [QP_FAMILY]: f === 'all' ? null : f })}
-                            />
-                            {distinctStates.length > 0 && (
-                                <>
-                                    <div className="nb-toolbar-sep" />
-                                    {distinctStates.map((stateName) => {
-                                        const isActive = stateFilter === stateName;
-                                        const color = STATE_META[stateName]?.color ?? STATE_META['UNKNOWN'].color;
-                                        const count = stateCounts.get(stateName) ?? 0;
-                                        return (
-                                            <button
-                                                key={stateName}
-                                                type="button"
-                                                className={`nb-state-chip${isActive ? ' nb-state-chip--active' : ''}`}
-                                                style={{ '--chip-color': color } as React.CSSProperties}
-                                                onClick={() => updateParams({ [QP_STATE]: isActive ? null : stateName })}
-                                                title={isActive ? `Clear state filter (${stateName})` : `Filter by state: ${stateName}`}
-                                            >
-                                                {stateName}
-                                                <span className="nb-state-chip__badge">{count}</span>
-                                            </button>
-                                        );
-                                    })}
-                                </>
-                            )}
-                        </div>
-                        <div className="yn-content">
-                            <NeighbourTable
-                                rows={visibleRows}
-                                totalCount={allRows.length}
-                                searchActive={searchActive}
-                                readOnlyNote={
-                                    isMergedView ? (
-                                        <span className="nb-footer-note">
-                                            Merged is read-only — resolved by priority (lower value wins) across {tables.length} tables
-                                        </span>
-                                    ) : activeTableInfo?.name === 'kernel' ? (
-                                        <span className="nb-footer-note">
-                                            kernel is populated from netlink — manual edits are overwritten
-                                        </span>
-                                    ) : undefined
-                                }
-                                selectedIds={selectedIds}
-                                sortState={sortState}
-                                onSort={handleSort}
-                                onRowClick={handleRowClick}
-                                onSelectionChange={setSelectedIds}
-                                emptyMessage={searchActive ? 'No neighbours match the current filters.' : 'No neighbours.'}
-                                canEditTable={canEditTable}
-                                canDeleteTable={canDeleteTable}
-                                onEditTable={() => setEditTableOpen(true)}
-                                onDeleteTable={() => setDeleteTableOpen(true)}
-                                isMergedView={isMergedView}
-                                cache={cache}
-                                tables={tables}
-                                flashRowId={flashRowId}
-                                activeRowId={activeRowId}
-                            />
-                        </div>
+                        {loading ? (
+                            <PageLoader loading size="l" />
+                        ) : (
+                            <>
+                                <div className="nb-toolbar">
+                                    <FamilyFilter
+                                        value={family}
+                                        onChange={(f) => updateParams({ [QP_FAMILY]: f === 'all' ? null : f })}
+                                    />
+                                    {distinctStates.length > 0 && (
+                                        <>
+                                            <div className="nb-toolbar-sep" />
+                                            {distinctStates.map((stateName) => {
+                                                const isActive = stateFilter === stateName;
+                                                const color = STATE_META[stateName]?.color ?? STATE_META['UNKNOWN'].color;
+                                                const count = stateCounts.get(stateName) ?? 0;
+                                                return (
+                                                    <button
+                                                        key={stateName}
+                                                        type="button"
+                                                        className={`nb-state-chip${isActive ? ' nb-state-chip--active' : ''}`}
+                                                        style={{ '--chip-color': color } as React.CSSProperties}
+                                                        onClick={() => updateParams({ [QP_STATE]: isActive ? null : stateName })}
+                                                        title={isActive ? `Clear state filter (${stateName})` : `Filter by state: ${stateName}`}
+                                                    >
+                                                        {stateName}
+                                                        <span className="nb-state-chip__badge">{count}</span>
+                                                    </button>
+                                                );
+                                            })}
+                                        </>
+                                    )}
+                                </div>
+                                <div className="yn-content">
+                                    <NeighbourTable
+                                        rows={visibleRows}
+                                        totalCount={allRows.length}
+                                        searchActive={searchActive}
+                                        readOnlyNote={
+                                            isMergedView ? (
+                                                <span className="nb-footer-note">
+                                                    Merged is read-only — resolved by priority (lower value wins) across {tables.length} tables
+                                                </span>
+                                            ) : activeTableInfo?.name === 'kernel' ? (
+                                                <span className="nb-footer-note">
+                                                    kernel is populated from netlink — manual edits are overwritten
+                                                </span>
+                                            ) : undefined
+                                        }
+                                        selectedIds={selectedIds}
+                                        sortState={sortState}
+                                        onSort={handleSort}
+                                        onRowClick={handleRowClick}
+                                        onSelectionChange={setSelectedIds}
+                                        emptyMessage={searchActive ? 'No neighbours match the current filters.' : 'No neighbours.'}
+                                        canEditTable={canEditTable}
+                                        canDeleteTable={canDeleteTable}
+                                        onEditTable={() => setEditTableOpen(true)}
+                                        onDeleteTable={() => setDeleteTableOpen(true)}
+                                        isMergedView={isMergedView}
+                                        cache={cache}
+                                        tables={tables}
+                                        flashRowId={flashRowId}
+                                        activeRowId={activeRowId}
+                                    />
+                                </div>
+                            </>
+                        )}
                     </>
                 )}
 

--- a/web/src/pages/operators/route/RoutePage.tsx
+++ b/web/src/pages/operators/route/RoutePage.tsx
@@ -21,7 +21,7 @@ import '../../../styles/chrome.scss';
 import './route.scss';
 
 const RoutePage: React.FC = () => {
-    const { configs, configRoutes, selectedIds, loading, refreshing, reload, addLocalConfig, setSelected } = useRIB();
+    const { configs, configRoutes, selectedIds, loading, refreshing, reload, addLocalConfig, setSelected, cachedConfigs, cachedCounts } = useRIB();
 
     const [activeConfig, setActiveConfig] = useState('');
     const [search, setSearch] = useState('');
@@ -417,7 +417,12 @@ const RoutePage: React.FC = () => {
         />
     );
 
-    if (loading && configs.length === 0) {
+    // While a warm cache exists, keep the tab strip mounted from cached names
+    // and counts so it does not blink on remount; only the body below reloads.
+    const tabConfigs = loading ? cachedConfigs : configs;
+    const tabCounts = loading ? cachedCounts : counts;
+
+    if (loading && cachedConfigs.length === 0) {
         return (
             <PageLayout header={pageHeader} className="yn-flat-layout">
                 <PageLoader loading size="l" />
@@ -428,7 +433,7 @@ const RoutePage: React.FC = () => {
     return (
         <PageLayout header={pageHeader} className="yn-flat-layout">
             <div className="yn-page yn-flat-page" aria-busy={refreshing}>
-                {configs.length === 0 ? (
+                {tabConfigs.length === 0 ? (
                     <EmptyPagePlaceholder
                         message="No route configurations found."
                         actionLabel="Add Config"
@@ -437,72 +442,79 @@ const RoutePage: React.FC = () => {
                 ) : (
                     <>
                         <ConfigTabStrip
-                            configs={configs}
+                            configs={tabConfigs}
                             activeConfig={currentConfig}
-                            counts={counts}
+                            counts={tabCounts}
                             dirtyConfigs={new Set()}
                             onSelect={(c) => {
                                 setActiveConfig(c);
                             }}
                             onAddConfig={() => setAddConfigOpen(true)}
+                            addConfigDisabled={loading}
                         />
-                        <div className="ro-toolbar">
-                            <FamilyFilter value={family} onChange={setFamily} />
-                            <button
-                                type="button"
-                                className={`ro-chip ro-chip--best${bestOnly ? ' ro-chip--active' : ''}`}
-                                onClick={() => setBestOnly((v) => !v)}
-                                title="Show only the best route for each prefix"
-                            >
-                                <svg width={13} height={13} viewBox="0 0 24 24" fill={bestOnly ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
-                                    <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8Z" />
-                                </svg>
-                                Best only
-                            </button>
-                            <button
-                                type="button"
-                                className={`ro-chip ro-chip--conflict${conflictsOnly ? ' ro-chip--active' : ''}`}
-                                onClick={() => setConflictsOnly((v) => !v)}
-                                title="Show only prefixes with multiple candidate routes"
-                            >
-                                <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
-                                    <path d="M6 3v12" />
-                                    <path d="M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
-                                    <path d="M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
-                                    <path d="M15 6a9 9 0 0 1-9 9" />
-                                </svg>
-                                Conflicts
-                                {conflictCount > 0 && (
-                                    <span className="ro-chip__badge">{conflictCount}</span>
-                                )}
-                            </button>
-                            <div style={{ flex: 1 }} />
-                            <div style={{ flexBasis: 230, flexShrink: 1 }}>
-                                <SearchInput
-                                    value={search}
-                                    onUpdate={setSearch}
-                                    placeholder="Filter rows…"
-                                    enableFocusShortcut={false}
-                                    showShortcutHint={false}
-                                    icon={Funnel}
-                                />
-                            </div>
-                            <RowCountDisplay filtered={visibleRows.length} total={allRows.length} />
-                        </div>
-                        <div className="yn-content">
-                            <RIBTable
-                                rows={visibleRows}
-                                selectedIds={currentSelected}
-                                sortState={sortState}
-                                onSort={handleSort}
-                                onRowClick={handleEditRow}
-                                onSelectionChange={(ids) => setSelected(currentConfig, ids)}
-                                emptyMessage={search || family !== 'all' || bestOnly || conflictsOnly ? 'No routes match the current filters.' : 'No routes.'}
-                                conflictMap={conflictMap}
-                                flashRowId={flashRowId}
-                                activeRowId={activeRowId}
-                            />
-                        </div>
+                        {loading ? (
+                            <PageLoader loading size="l" />
+                        ) : (
+                            <>
+                                <div className="ro-toolbar">
+                                    <FamilyFilter value={family} onChange={setFamily} />
+                                    <button
+                                        type="button"
+                                        className={`ro-chip ro-chip--best${bestOnly ? ' ro-chip--active' : ''}`}
+                                        onClick={() => setBestOnly((v) => !v)}
+                                        title="Show only the best route for each prefix"
+                                    >
+                                        <svg width={13} height={13} viewBox="0 0 24 24" fill={bestOnly ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+                                            <path d="M13 2 3 14h9l-1 8 10-12h-9l1-8Z" />
+                                        </svg>
+                                        Best only
+                                    </button>
+                                    <button
+                                        type="button"
+                                        className={`ro-chip ro-chip--conflict${conflictsOnly ? ' ro-chip--active' : ''}`}
+                                        onClick={() => setConflictsOnly((v) => !v)}
+                                        title="Show only prefixes with multiple candidate routes"
+                                    >
+                                        <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+                                            <path d="M6 3v12" />
+                                            <path d="M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
+                                            <path d="M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
+                                            <path d="M15 6a9 9 0 0 1-9 9" />
+                                        </svg>
+                                        Conflicts
+                                        {conflictCount > 0 && (
+                                            <span className="ro-chip__badge">{conflictCount}</span>
+                                        )}
+                                    </button>
+                                    <div style={{ flex: 1 }} />
+                                    <div style={{ flexBasis: 230, flexShrink: 1 }}>
+                                        <SearchInput
+                                            value={search}
+                                            onUpdate={setSearch}
+                                            placeholder="Filter rows…"
+                                            enableFocusShortcut={false}
+                                            showShortcutHint={false}
+                                            icon={Funnel}
+                                        />
+                                    </div>
+                                    <RowCountDisplay filtered={visibleRows.length} total={allRows.length} />
+                                </div>
+                                <div className="yn-content">
+                                    <RIBTable
+                                        rows={visibleRows}
+                                        selectedIds={currentSelected}
+                                        sortState={sortState}
+                                        onSort={handleSort}
+                                        onRowClick={handleEditRow}
+                                        onSelectionChange={(ids) => setSelected(currentConfig, ids)}
+                                        emptyMessage={search || family !== 'all' || bestOnly || conflictsOnly ? 'No routes match the current filters.' : 'No routes.'}
+                                        conflictMap={conflictMap}
+                                        flashRowId={flashRowId}
+                                        activeRowId={activeRowId}
+                                    />
+                                </div>
+                            </>
+                        )}
                     </>
                 )}
 

--- a/web/src/pages/operators/route/useRIB.ts
+++ b/web/src/pages/operators/route/useRIB.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { API } from '../../../api';
+import { useConfigListCache } from '../../../hooks';
 import { toaster, compareNatural } from '../../../utils';
 import type { Route } from '../../../api/routes';
 
@@ -12,6 +13,10 @@ export interface UseRIBResult {
     reload: () => Promise<void>;
     addLocalConfig: (name: string) => void;
     setSelected: (configName: string, ids: Set<string>) => void;
+    /** Cached config names from the previous visit, for an instant tab strip. */
+    cachedConfigs: string[];
+    /** Cached per-config route counts, for instant tab badges. */
+    cachedCounts: Map<string, number>;
 }
 
 const sortConfigs = (a: string, b: string): number =>
@@ -24,6 +29,7 @@ export const useRIB = (): UseRIBResult => {
     const [selectedIds, setSelectedIds] = useState<Map<string, Set<string>>>(new Map());
     const [loading, setLoading] = useState(true);
     const [refreshing, setRefreshing] = useState(false);
+    const { configs: cachedConfigs, counts: cachedCounts, write: writeCache } = useConfigListCache('operators-route');
 
     const loadAll = useCallback(async (opts?: { initial?: boolean; isCancelled?: () => boolean }): Promise<void> => {
         const isInitial = opts?.initial !== false;
@@ -51,6 +57,10 @@ export const useRIB = (): UseRIBResult => {
             if (opts?.isCancelled?.()) return;
             setConfigs([...configsList].sort(sortConfigs));
             setConfigRoutes(routesMap);
+            writeCache({
+                configs: [...configsList].sort(sortConfigs),
+                counts: Object.fromEntries(configsList.map((name) => [name, routesMap.get(name)?.length ?? 0])),
+            });
         } catch (err) {
             if (opts?.isCancelled?.()) return;
             toaster.error('rib-configs-error', 'Failed to fetch RIB configs', err);
@@ -63,7 +73,7 @@ export const useRIB = (): UseRIBResult => {
                 }
             }
         }
-    }, []);
+    }, [writeCache]);
 
     useEffect(() => {
         let cancelled = false;
@@ -92,5 +102,5 @@ export const useRIB = (): UseRIBResult => {
         });
     }, []);
 
-    return { configs, configRoutes, selectedIds, loading, refreshing, reload, addLocalConfig, setSelected };
+    return { configs, configRoutes, selectedIds, loading, refreshing, reload, addLocalConfig, setSelected, cachedConfigs, cachedCounts };
 };


### PR DESCRIPTION
Switching pages in the sidebar made the config tab strip blink. Every page is lazily loaded and fully unmounts on navigation, then refetches its data from scratch and gates the whole body — the tab strip included — behind a full-page loader until the load completes. With no cache, every return to a page blanked the tabs and re-rendered them, producing a visible flicker.

This adds a small gateway-scoped cache that holds only each page's config-name list and per-tab counts, never the row payloads, so it stays tiny regardless of how much data a config carries. Pages now render the tab strip instantly from the cache on remount and revalidate in the background, while a localized loader covers only the rows below. The full-page loader still shows once on a genuine cold load.

The cache is display-only and never seeds the draft state, so unsaved edits, dirty tracking, and local-only configs are unchanged. It is keyed per gateway, so switching gateways yields a one-time loader rather than another gateway's tabs.

Applied across all multi-config pages: forward, acl, decap, route, fwstate, pdump, and the route and neighbours operators.