### PR TITLE
fix(web): unify filter toolbar row height across pages

### DIFF
--- a/web/src/styles/_mixins.scss
+++ b/web/src/styles/_mixins.scss
@@ -37,6 +37,13 @@
     gap: 10px;
     padding: 12px 20px;
     flex-shrink: 0;
+
+    // Grow the filter/search input to a 32px box (30px control + 1px top and
+    // bottom border) so it matches the 32px segmented filter control, keeping
+    // every toolbar row the same height across pages.
+    .g-text-input_size_m .g-text-input__control {
+        height: 30px;
+    }
 }
 
 /** Function/pipeline card-header chrome — shared by fn-card-header and pl-card-header. */


### PR DESCRIPTION
Page toolbar rows rendered at slightly different heights between pages: those with the segmented filter control sat a few pixels taller than pages whose only control was the filter search input. This grows the toolbar filter input to match the segmented filter control, so every toolbar row keeps the same height across pages while the rows stay flexibly sized.

Verified live across all affected pages: every toolbar row now measures the same height and the filter inputs match the segmented control, with the page-header search and form inputs left unchanged.