### PR TITLE
fix(web): restore typecheck for co-located sources and gate it in CI

### DIFF
--- a/.github/workflows/web-check.yml
+++ b/.github/workflows/web-check.yml
@@ -34,4 +34,5 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
       - run: npm ci
+      - run: npx tsc --noEmit -p web/tsconfig.json
       - run: npm run test -w web

--- a/web/builtin/inspect/utils.ts
+++ b/web/builtin/inspect/utils.ts
@@ -175,7 +175,6 @@ export const computeAgentUsage = (instance: InstanceInfo): Map<string, AgentUsag
             if (g > maxGen) maxGen = g;
         }
         const used = Math.max(0, limit - free);
-        const pct = limit > 0 ? used / limit : 0;
 
         const prev = result.get(resultName);
         result.set(resultName, {

--- a/web/src/core/api/index.ts
+++ b/web/src/core/api/index.ts
@@ -12,6 +12,13 @@ export * from './forward';
 export { fwstate } from './fwstate';
 export * from './counters';
 
+// Several module clients each declare their own ShowConfigRequest /
+// ShowConfigResponse / Device; re-export one explicitly so the barrel is
+// unambiguous. Consumers that need a specific module's shape import it from
+// that module's subpath rather than this barrel.
+export type { ShowConfigRequest, ShowConfigResponse } from './decap';
+export type { Device } from './devices';
+
 import { neighbours } from './neighbours';
 import { inspect } from './inspect';
 import { route, routeOperator } from './routes';

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -28,7 +28,11 @@
         "noFallthroughCasesInSwitch": true
     },
     "include": [
-        "src"
+        "src",
+        "builtin",
+        "../modules/*/web",
+        "../devices/*/web",
+        "../operators/*/web"
     ],
     "references": [
         {


### PR DESCRIPTION
After the web feature UIs moved out of `web/src/pages` into co-located `modules/<m>/web`, `operators/<m>/web`, and `web/builtin` directories, the TypeScript `include` still only covered `src`, so those sources were no longer type-checked. The web CI runs only the unit tests, so a type regression could land unnoticed — and in fact the project's typecheck had already gone red on main.

This widens the `include` to cover the co-located roots, fixes the outstanding type errors (an ambiguous re-export in the API barrel and a dead local), and adds a typecheck step to the web CI job so the build stays type-clean going forward. The barrel fix is type-only and has no runtime effect; no page behavior changes.