### PR TITLE
refactor(web): extract shared packet table and inspector into core

### DIFF
--- a/modules/pdump/web/PacketDrawer.tsx
+++ b/modules/pdump/web/PacketDrawer.tsx
@@ -1,8 +1,5 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { ChevronDown } from '@gravity-ui/icons';
-import { Icon } from '@gravity-ui/uikit';
-import { formatTCPFlags } from '@yanet/core/utils';
-import type { ParsedPacket } from '@yanet/core/utils/packetParser';
+import React from 'react';
+import { PacketInspector, Section, KV } from '@yanet/core/components/packet';
 import type { CapturedPacket } from './types';
 
 interface PacketDrawerProps {
@@ -16,97 +13,6 @@ interface PacketDrawerProps {
     onNext: () => void;
 }
 
-type SectionKind = 'meta' | 'eth' | 'vlan' | 'ipv4' | 'ipv6' | 'tcp' | 'udp' | 'icmp' | 'http';
-
-interface SectionProps {
-    kind: SectionKind;
-    title: string;
-    sub?: string;
-    children: React.ReactNode;
-}
-
-const Section: React.FC<SectionProps> = ({ kind, title, sub, children }) => {
-    const [collapsed, setCollapsed] = useState(false);
-
-    return (
-        <div className={`pdump-section pdump-section--${kind}${collapsed ? ' pdump-section--collapsed' : ''}`}>
-            <div className="pdump-section__head" onClick={() => setCollapsed(c => !c)}>
-                <div className="pdump-section__head-left">
-                    <span className="pdump-section__marker" />
-                    <span className="pdump-section__title">{title}</span>
-                    {sub && <span className="pdump-section__sub">{sub}</span>}
-                </div>
-                <span className="pdump-section__chevron">
-                    <Icon data={ChevronDown} size={14} />
-                </span>
-            </div>
-            <div className="pdump-section__body">
-                {children}
-            </div>
-        </div>
-    );
-};
-
-interface KVProps {
-    k: string;
-    v: React.ReactNode;
-}
-
-const KV: React.FC<KVProps> = ({ k, v }) => (
-    <div className="pdump-kv-row">
-        <span className="pdump-kv-k">{k}</span>
-        <span className="pdump-kv-v">{v}</span>
-    </div>
-);
-
-interface HexDumpProps {
-    bytes: Uint8Array;
-    parsed: ParsedPacket;
-}
-
-const HexDump: React.FC<HexDumpProps> = ({ bytes, parsed }) => {
-    const ethEnd = 14 + (parsed.vlans?.length ?? 0) * 4;
-    const ipEnd = parsed.ipv4
-        ? ethEnd + parsed.ipv4.ihl * 4
-        : parsed.ipv6
-        ? ethEnd + 40
-        : ethEnd;
-    const l4End = parsed.payloadOffset;
-
-    const rows: React.ReactNode[] = [];
-    for (let i = 0; i < bytes.length; i += 16) {
-        const slice = bytes.slice(i, i + 16);
-        const offset = i.toString(16).padStart(4, '0');
-
-        const hexSpans: React.ReactNode[] = [];
-        const asciiChars: string[] = [];
-
-        slice.forEach((b, j) => {
-            const idx = i + j;
-            let cls = 'hl-payload';
-            if (idx < ethEnd) cls = 'hl-eth';
-            else if (idx < ipEnd) cls = 'hl-ip';
-            else if (idx < l4End) cls = 'hl-l4';
-
-            hexSpans.push(<span key={j} className={cls}>{b.toString(16).padStart(2, '0')}</span>);
-            hexSpans.push(' ');
-
-            const ch = b >= 32 && b < 127 ? String.fromCharCode(b) : '.';
-            asciiChars.push(ch);
-        });
-
-        rows.push(
-            <div className="pdump-hex-line" key={i}>
-                <span className="pdump-hex-offset">{offset}</span>
-                <span className="pdump-hex-bytes">{hexSpans}</span>
-                <span className="pdump-hex-ascii">{asciiChars.join('')}</span>
-            </div>
-        );
-    }
-
-    return <div className="pdump-hex-dump">{rows}</div>;
-};
-
 const formatTime = (date: Date): string =>
     date.toLocaleTimeString('en-US', {
         hour12: false,
@@ -117,8 +23,10 @@ const formatTime = (date: Date): string =>
     } as Intl.DateTimeFormatOptions);
 
 /**
- * Right-side drawer for inspecting a captured packet.
- * Keyboard: Esc closes, arrow-up / k = previous, arrow-down / j = next.
+ * Right-side drawer for inspecting a captured pdump packet.
+ *
+ * Wraps the shared PacketInspector and injects capture metadata
+ * (worker, queue, rx/tx device, timestamp) via the metaSection prop.
  */
 const PacketDrawer: React.FC<PacketDrawerProps> = ({
     open,
@@ -130,249 +38,35 @@ const PacketDrawer: React.FC<PacketDrawerProps> = ({
     onPrev,
     onNext,
 }) => {
-    const handleKeyDown = useCallback((e: KeyboardEvent) => {
-        const target = document.activeElement;
-        if (target instanceof HTMLElement) {
-            if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
-        }
-        switch (e.key) {
-            case 'Escape':
-                onClose();
-                break;
-            case 'ArrowUp':
-            case 'k':
-                e.preventDefault();
-                onPrev();
-                break;
-            case 'ArrowDown':
-            case 'j':
-                e.preventDefault();
-                onNext();
-                break;
-        }
-    }, [onClose, onPrev, onNext]);
+    const packetRow = packet
+        ? { id: packet.id, parsed: packet.parsed, timestamp: packet.timestamp }
+        : null;
 
-    useEffect(() => {
-        if (!open) return;
-        document.addEventListener('keydown', handleKeyDown);
-        return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [open, handleKeyDown]);
-
-    const tcp = packet?.parsed.tcp;
-    const udp = packet?.parsed.udp;
-
-    const tcpFlagTokens = (() => {
-        if (!tcp) return null;
-        const raw = formatTCPFlags(tcp.flags);
-        if (!raw) return <span>none</span>;
-        const flags = raw.replace(/^\[|\]$/g, '').split(', ').filter(Boolean);
-        return (
-            <>
-                {flags.map((f, idx) => (
-                    <span key={idx} className="pdump-kv-flag">{f}</span>
-                ))}
-            </>
-        );
-    })();
+    const metaSection = packet ? (
+        <Section kind="meta" title="Capture" sub={configName ?? undefined}>
+            <KV k="Time" v={formatTime(packet.timestamp)} />
+            <KV k="Worker" v={packet.record.meta?.worker_idx ?? 'N/A'} />
+            <KV k="Queue" v={packet.record.meta?.queue ?? 'N/A'} />
+            <KV k="RX device" v={packet.record.meta?.rx_device_id ?? 'N/A'} />
+            <KV k="TX device" v={packet.record.meta?.tx_device_id ?? 'N/A'} />
+            <KV
+                k="Length"
+                v={`${packet.record.meta?.packet_len ?? packet.parsed.raw.length} bytes (captured ${packet.record.meta?.data_size ?? packet.parsed.raw.length})`}
+            />
+        </Section>
+    ) : undefined;
 
     return (
-        <aside
-            className={`yn-drawer${open ? ' yn-drawer--open' : ''}`}
-            role="dialog"
-            aria-modal="true"
-            aria-label="Packet details"
-        >
-            <header className="yn-drawer__head">
-                <h2 className="yn-drawer__title">
-                    {packet ? (
-                        <>
-                            Packet <span className="yn-drawer__rule-num">#{packet.id + 1}</span>
-                            <span className="pdump-drawer-timestamp">{formatTime(packet.timestamp)}</span>
-                        </>
-                    ) : (
-                        'Packet details'
-                    )}
-                </h2>
-                <div className="yn-drawer__head-actions">
-                    <button
-                        type="button"
-                        className="yn-icon-btn"
-                        onClick={onPrev}
-                        disabled={packetIndex <= 0}
-                        title="Previous packet (↑ / k)"
-                        aria-label="Previous packet"
-                    >
-                        ↑
-                    </button>
-                    <button
-                        type="button"
-                        className="yn-icon-btn"
-                        onClick={onNext}
-                        disabled={packetIndex < 0 || packetIndex >= totalPackets - 1}
-                        title="Next packet (↓ / j)"
-                        aria-label="Next packet"
-                    >
-                        ↓
-                    </button>
-                    <button
-                        type="button"
-                        className="yn-icon-btn"
-                        onClick={onClose}
-                        aria-label="Close drawer"
-                        title="Close (Esc)"
-                    >
-                        ✕
-                    </button>
-                </div>
-            </header>
-
-            <div className="yn-drawer__body">
-                {packet ? (
-                    <>
-                        <Section kind="meta" title="Capture" sub={configName ?? ''}>
-                            <KV k="Worker" v={packet.record.meta?.worker_idx ?? 'N/A'} />
-                            <KV k="Queue" v={packet.record.meta?.queue ?? 'N/A'} />
-                            <KV k="RX device" v={packet.record.meta?.rx_device_id ?? 'N/A'} />
-                            <KV k="TX device" v={packet.record.meta?.tx_device_id ?? 'N/A'} />
-                            <KV
-                                k="Length"
-                                v={`${packet.record.meta?.packet_len ?? packet.parsed.raw.length} bytes (captured ${packet.record.meta?.data_size ?? packet.parsed.raw.length})`}
-                            />
-                        </Section>
-
-                        {packet.parsed.ethernet && (
-                            <Section kind="eth" title="Ethernet II">
-                                <KV k="Source MAC" v={packet.parsed.ethernet.srcMac} />
-                                <KV k="Dest MAC" v={packet.parsed.ethernet.dstMac} />
-                                <KV k="EtherType" v={`${packet.parsed.ethernet.etherTypeName} (0x${packet.parsed.ethernet.etherType.toString(16)})`} />
-                            </Section>
-                        )}
-
-                        {packet.parsed.vlans && packet.parsed.vlans.length > 0 && (
-                            <Section kind="vlan" title="VLAN / 802.1Q" sub={`${packet.parsed.vlans.length} tag${packet.parsed.vlans.length > 1 ? 's' : ''}`}>
-                                {packet.parsed.vlans.map((tag, idx) => (
-                                    <React.Fragment key={idx}>
-                                        <KV k="Tag" v={`#${idx + 1}`} />
-                                        <KV k="TPID" v={`${tag.tpidName} (0x${tag.tpid.toString(16)})`} />
-                                        <KV k="TCI" v={`0x${tag.tci.toString(16).padStart(4, '0')}`} />
-                                        <KV k="PCP" v={tag.pcp} />
-                                        <KV k="DEI" v={tag.dei ? '1' : '0'} />
-                                        <KV k="VLAN ID" v={tag.vlanId} />
-                                        <KV k="Inner EtherType" v={`${tag.innerEtherTypeName} (0x${tag.innerEtherType.toString(16)})`} />
-                                    </React.Fragment>
-                                ))}
-                            </Section>
-                        )}
-
-                        {packet.parsed.ipv4 && (
-                            <Section kind="ipv4" title="Internet Protocol v4">
-                                <KV k="Source" v={packet.parsed.ipv4.srcAddr} />
-                                <KV k="Destination" v={packet.parsed.ipv4.dstAddr} />
-                                <KV k="Protocol" v={`${packet.parsed.ipv4.protocolName} (${packet.parsed.ipv4.protocol})`} />
-                                <KV k="TTL" v={packet.parsed.ipv4.ttl} />
-                                <KV k="Total length" v={packet.parsed.ipv4.totalLength} />
-                                <KV k="ID" v={`0x${packet.parsed.ipv4.identification.toString(16)}`} />
-                                <KV k="DSCP" v={packet.parsed.ipv4.dscp} />
-                                <KV k="ECN" v={packet.parsed.ipv4.ecn} />
-                                <KV k="Don't fragment" v={packet.parsed.ipv4.flags.dontFragment ? 'true' : 'false'} />
-                                <KV k="More fragments" v={packet.parsed.ipv4.flags.moreFragments ? 'true' : 'false'} />
-                                <KV k="Fragment offset" v={packet.parsed.ipv4.fragmentOffset} />
-                            </Section>
-                        )}
-
-                        {packet.parsed.ipv6 && (
-                            <Section kind="ipv6" title="Internet Protocol v6">
-                                <KV k="Source" v={packet.parsed.ipv6.srcAddr} />
-                                <KV k="Destination" v={packet.parsed.ipv6.dstAddr} />
-                                <KV k="Next header" v={`${packet.parsed.ipv6.nextHeaderName} (${packet.parsed.ipv6.nextHeader})`} />
-                                <KV k="Hop limit" v={packet.parsed.ipv6.hopLimit} />
-                                <KV k="Payload len" v={packet.parsed.ipv6.payloadLength} />
-                                <KV k="Flow label" v={`0x${packet.parsed.ipv6.flowLabel.toString(16)}`} />
-                            </Section>
-                        )}
-
-                        {tcp && (
-                            <Section kind="tcp" title="Transmission Control Protocol" sub={`${tcp.srcPort} → ${tcp.dstPort}`}>
-                                <KV k="Source port" v={tcp.srcPort} />
-                                <KV k="Dest port" v={tcp.dstPort} />
-                                <KV k="Sequence" v={tcp.seqNum} />
-                                <KV k="Acknowledgment" v={tcp.ackNum} />
-                                <KV k="Window" v={tcp.windowSize} />
-                                <KV k="Flags" v={tcpFlagTokens} />
-                                <KV k="Checksum" v={`0x${tcp.checksum.toString(16)}`} />
-                            </Section>
-                        )}
-
-                        {udp && (
-                            <Section kind="udp" title="User Datagram Protocol" sub={`${udp.srcPort} → ${udp.dstPort}`}>
-                                <KV k="Source port" v={udp.srcPort} />
-                                <KV k="Dest port" v={udp.dstPort} />
-                                <KV k="Length" v={udp.length} />
-                                <KV k="Checksum" v={`0x${udp.checksum.toString(16)}`} />
-                            </Section>
-                        )}
-
-                        {packet.parsed.icmp && (
-                            <Section kind="icmp" title="ICMP">
-                                <KV k="Type" v={`${packet.parsed.icmp.typeName} (${packet.parsed.icmp.type})`} />
-                                <KV k="Code" v={packet.parsed.icmp.code} />
-                                <KV k="Checksum" v={`0x${packet.parsed.icmp.checksum.toString(16)}`} />
-                            </Section>
-                        )}
-
-                        {packet.parsed.http && (() => {
-                            const http = packet.parsed.http;
-                            const sub = http.isRequest
-                                ? `${http.method} ${http.target}`
-                                : `${http.statusCode} ${http.reasonPhrase}`;
-                            return (
-                                <Section kind="http" title="Hypertext Transfer Protocol" sub={sub}>
-                                    {http.isRequest ? (
-                                        <>
-                                            <KV k="Method" v={http.method} />
-                                            <KV k="Target" v={http.target} />
-                                            <KV k="Version" v={http.version} />
-                                        </>
-                                    ) : (
-                                        <>
-                                            <KV k="Version" v={http.version} />
-                                            <KV k="Status" v={http.statusCode} />
-                                            <KV k="Reason" v={http.reasonPhrase} />
-                                        </>
-                                    )}
-                                    {http.headers.map((h, idx) => (
-                                        <KV key={idx} k={h.name} v={h.value} />
-                                    ))}
-                                </Section>
-                            );
-                        })()}
-
-                        <Section kind="meta" title="Raw bytes" sub={`${packet.parsed.raw.length} B`}>
-                            <HexDump bytes={packet.parsed.raw} parsed={packet.parsed} />
-                        </Section>
-                    </>
-                ) : (
-                    <div className="pdump-drawer-empty">
-                        Select a packet to inspect.
-                    </div>
-                )}
-            </div>
-
-            {packet && (
-                <footer className="yn-drawer__foot">
-                    <span className="yn-drawer__foot-meta">
-                        {packetIndex >= 0
-                            ? `${packetIndex + 1} / ${totalPackets} packets`
-                            : `evicted / ${totalPackets} packets`}
-                    </span>
-                    <div className="yn-drawer__foot-actions">
-                        <button type="button" className="yn-btn yn-btn--ghost" onClick={onClose}>
-                            Close
-                        </button>
-                    </div>
-                </footer>
-            )}
-        </aside>
+        <PacketInspector
+            open={open}
+            packet={packetRow}
+            packetIndex={packetIndex}
+            totalPackets={totalPackets}
+            onClose={onClose}
+            onPrev={onPrev}
+            onNext={onNext}
+            metaSection={metaSection}
+        />
     );
 };
 

--- a/modules/pdump/web/PacketTable.tsx
+++ b/modules/pdump/web/PacketTable.tsx
@@ -1,81 +1,7 @@
-import React, { useRef, useMemo, useCallback, useEffect, useState } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
-import { TextInput } from '@gravity-ui/uikit';
-import { EmptyState } from '@yanet/core/components';
-import { useContainerHeight } from '@yanet/core/hooks';
-import { ROW_HEIGHT, SEARCH_BAR_HEIGHT, HEADER_HEIGHT, FOOTER_HEIGHT, OVERSCAN, TOTAL_WIDTH } from './constants';
-import { PacketTableRow } from './PacketTableRow';
-import { PacketTableHeader } from './PacketTableHeader';
-import type { CapturedPacket, PacketSortState, PacketSortColumn } from './types';
-import './pdump.scss';
-
-const getPacketSortValues = (packet: CapturedPacket) => {
-    const { parsed } = packet;
-
-    let source = '';
-    let destination = '';
-    let protocol = '';
-
-    if (parsed.ipv4) {
-        source = parsed.ipv4.srcAddr;
-        destination = parsed.ipv4.dstAddr;
-        protocol = parsed.ipv4.protocolName;
-    } else if (parsed.ipv6) {
-        source = parsed.ipv6.srcAddr;
-        destination = parsed.ipv6.dstAddr;
-        protocol = parsed.ipv6.nextHeaderName;
-    } else if (parsed.ethernet) {
-        source = parsed.ethernet.srcMac;
-        destination = parsed.ethernet.dstMac;
-        protocol = parsed.ethernet.etherTypeName;
-    }
-
-    if (parsed.tcp) {
-        source = `${source}:${parsed.tcp.srcPort}`;
-        destination = `${destination}:${parsed.tcp.dstPort}`;
-        protocol = 'TCP';
-    } else if (parsed.udp) {
-        source = `${source}:${parsed.udp.srcPort}`;
-        destination = `${destination}:${parsed.udp.dstPort}`;
-        protocol = 'UDP';
-    } else if (parsed.icmp) {
-        protocol = 'ICMP';
-    }
-
-    return { source, destination, protocol, length: parsed.raw.length };
-};
-
-const createComparator = (column: PacketSortColumn, direction: 'asc' | 'desc') => {
-    const mult = direction === 'asc' ? 1 : -1;
-
-    return (a: CapturedPacket, b: CapturedPacket): number => {
-        switch (column) {
-            case 'index':
-                return mult * (a.id - b.id);
-            case 'time':
-                return mult * (a.timestamp.getTime() - b.timestamp.getTime());
-            case 'length':
-                return mult * (a.parsed.raw.length - b.parsed.raw.length);
-            case 'source': {
-                const aVal = getPacketSortValues(a);
-                const bVal = getPacketSortValues(b);
-                return mult * aVal.source.localeCompare(bVal.source);
-            }
-            case 'destination': {
-                const aVal = getPacketSortValues(a);
-                const bVal = getPacketSortValues(b);
-                return mult * aVal.destination.localeCompare(bVal.destination);
-            }
-            case 'protocol': {
-                const aVal = getPacketSortValues(a);
-                const bVal = getPacketSortValues(b);
-                return mult * aVal.protocol.localeCompare(bVal.protocol);
-            }
-            default:
-                return 0;
-        }
-    };
-};
+import React, { useMemo } from 'react';
+import { PacketTable as SharedPacketTable } from '@yanet/core/components/packet';
+import type { PacketRow } from '@yanet/core/components/packet';
+import type { CapturedPacket } from './types';
 
 export interface PacketTableProps {
     packets: CapturedPacket[];
@@ -98,6 +24,13 @@ export interface PacketTableProps {
     onAutoScrollChange: (value: boolean) => void;
 }
 
+/**
+ * Pdump-specific packet table adapter.
+ *
+ * Converts CapturedPacket[] (which carries pdump capture metadata) to the
+ * generic PacketRow[] shape accepted by the shared PacketTable component,
+ * then delegates all rendering.
+ */
 export const PacketTable: React.FC<PacketTableProps> = ({
     packets,
     selectedPacketId,
@@ -113,255 +46,43 @@ export const PacketTable: React.FC<PacketTableProps> = ({
     autoScroll,
     onAutoScrollChange,
 }) => {
-    const containerRef = useRef<HTMLDivElement>(null);
-    const parentRef = useRef<HTMLDivElement>(null);
-    const containerHeight = useContainerHeight(containerRef);
-    const [sortState, setSortState] = useState<PacketSortState>({ column: null, direction: 'asc' });
+    const packetRows = useMemo((): PacketRow[] =>
+        packets.map(p => ({ id: p.id, parsed: p.parsed, timestamp: p.timestamp })),
+        [packets]
+    );
 
-    const handleSort = useCallback((column: PacketSortColumn) => {
-        setSortState(prev => ({
-            column,
-            direction: prev.column === column && prev.direction === 'asc' ? 'desc' : 'asc',
-        }));
-        onAutoScrollChange(false);
-    }, [onAutoScrollChange]);
-
-    const filteredPackets = useMemo(() => {
-        if (!searchQuery.trim()) return packets;
-
-        const lowerQuery = searchQuery.toLowerCase();
-        return packets.filter(packet => {
-            const { parsed } = packet;
-
-            if (parsed.ipv4) {
-                if (parsed.ipv4.srcAddr.includes(lowerQuery) || parsed.ipv4.dstAddr.includes(lowerQuery)) {
-                    return true;
-                }
-            }
-            if (parsed.ipv6) {
-                if (parsed.ipv6.srcAddr.toLowerCase().includes(lowerQuery) ||
-                    parsed.ipv6.dstAddr.toLowerCase().includes(lowerQuery)) {
-                    return true;
-                }
-            }
-
-            if (parsed.tcp) {
-                if (parsed.tcp.srcPort.toString().includes(lowerQuery) ||
-                    parsed.tcp.dstPort.toString().includes(lowerQuery)) {
-                    return true;
-                }
-            }
-            if (parsed.udp) {
-                if (parsed.udp.srcPort.toString().includes(lowerQuery) ||
-                    parsed.udp.dstPort.toString().includes(lowerQuery)) {
-                    return true;
-                }
-            }
-
-            const protocol = parsed.tcp ? 'tcp' : parsed.udp ? 'udp' : parsed.icmp ? 'icmp' : '';
-            if (protocol.includes(lowerQuery)) {
-                return true;
-            }
-
-            if (parsed.ethernet) {
-                if (parsed.ethernet.srcMac.toLowerCase().includes(lowerQuery) ||
-                    parsed.ethernet.dstMac.toLowerCase().includes(lowerQuery)) {
-                    return true;
-                }
-            }
-
-            return false;
-        });
-    }, [packets, searchQuery]);
-
-    const sortedPackets = useMemo(() => {
-        if (!sortState.column) return filteredPackets;
-
-        const comparator = createComparator(sortState.column, sortState.direction);
-        return [...filteredPackets].sort(comparator);
-    }, [filteredPackets, sortState]);
-
-    const rowVirtualizer = useVirtualizer({
-        count: sortedPackets.length,
-        getScrollElement: () => parentRef.current,
-        estimateSize: () => ROW_HEIGHT,
-        overscan: OVERSCAN,
-    });
-
-    // Use the id of the newest packet rather than sortedPackets.length so this
-    // effect re-fires after every flush even when the ring buffer is full and
-    // length stays pinned at MAX_PACKETS.
-    const lastPacketId = sortedPackets.length > 0 ? sortedPackets[sortedPackets.length - 1]?.id : null;
-
-    useEffect(() => {
-        if (autoScroll && !paused && isCapturing && sortedPackets.length > 0 && parentRef.current && !sortState.column) {
-            rowVirtualizer.scrollToIndex(sortedPackets.length - 1, { align: 'end' });
+    const handleSelectPacket = (row: PacketRow | null): void => {
+        if (row === null) {
+            onSelectPacket(null);
+            return;
         }
-    }, [lastPacketId, autoScroll, paused, isCapturing, rowVirtualizer, sortState.column]);
-
-    const STICKY_BOTTOM_THRESHOLD_PX = 24;
-
-    useEffect(() => {
-        const element = parentRef.current;
-        if (!element || !isCapturing) return;
-
-        const handleScroll = () => {
-            const el = parentRef.current;
-            if (!el) return;
-            const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
-            const atBottom = distance < STICKY_BOTTOM_THRESHOLD_PX;
-            onAutoScrollChange(atBottom);
-        };
-
-        element.addEventListener('scroll', handleScroll, { passive: true });
-        return () => element.removeEventListener('scroll', handleScroll);
-    }, [isCapturing, onAutoScrollChange]);
-
-    const selectedPacketIdRef = useRef(selectedPacketId);
-    selectedPacketIdRef.current = selectedPacketId;
-
-    const handleSelectPacket = useCallback((packet: CapturedPacket) => {
-        onSelectPacket(packet.id === selectedPacketIdRef.current ? null : packet);
-    }, [onSelectPacket]);
-
-    const handleSearchChange = useCallback((value: string) => {
-        onSearchQueryChange(value);
-    }, [onSearchQueryChange]);
-
-    const handleToggleAutoScroll = useCallback(() => {
-        onAutoScrollChange(!autoScroll);
-    }, [onAutoScrollChange, autoScroll]);
-
-    const statsText = useMemo(() => {
-        const total = packets.length;
-        const filtered = sortedPackets.length;
-        if (searchQuery.trim() && filtered !== total) {
-            return `${filtered.toLocaleString()} / ${total.toLocaleString()} packets`;
-        }
-        return `${total.toLocaleString()} packets`;
-    }, [packets.length, sortedPackets.length, searchQuery]);
-
-    if (containerHeight === 0) {
-        return <div ref={containerRef} className="packet-table__container" />;
-    }
-
-    const tableBodyHeight = containerHeight - SEARCH_BAR_HEIGHT - HEADER_HEIGHT - FOOTER_HEIGHT - 2;
-    const virtualRows = rowVirtualizer.getVirtualItems();
-
-    const footerText = virtualRows.length > 0
-        ? `Rows ${(virtualRows[0].index + 1).toLocaleString()} – ${(virtualRows[virtualRows.length - 1].index + 1).toLocaleString()} of ${sortedPackets.length.toLocaleString()}`
-        : '';
+        const original = packets.find(p => p.id === row.id) ?? null;
+        onSelectPacket(original);
+    };
 
     return (
-        <div ref={containerRef} className="packet-table" style={{ height: containerHeight }}>
-            <div className="packet-table__toolbar" style={{ height: SEARCH_BAR_HEIGHT }}>
-                <div className="packet-table__search">
-                    <TextInput
-                        placeholder="Filter by IP, port, protocol..."
-                        value={searchQuery}
-                        onUpdate={handleSearchChange}
-                        size="m"
-                        hasClear
-                    />
-                </div>
-                <div className="packet-table__toolbar-info">
-                    <span className="packet-table__stats">{statsText}</span>
-                    {configName && isCapturing && (
-                        <span className={`packet-table__live-badge${paused ? ' packet-table__live-badge--paused' : ''}`}>
-                            {paused ? 'PAUSED' : 'LIVE'}
-                        </span>
-                    )}
-                </div>
-                <div className="packet-table__toolbar-actions">
-                    {isCapturing && (
-                        <button
-                            type="button"
-                            className={`yn-btn yn-btn--ghost yn-btn--sm${autoScroll ? ' packet-table__btn--active' : ''}`}
-                            onClick={handleToggleAutoScroll}
-                            title="Toggle auto-scroll to new packets"
-                        >
-                            Auto-scroll
-                        </button>
-                    )}
-                    <button
-                        type="button"
-                        className={`yn-btn yn-btn--ghost yn-btn--sm${paused ? ' packet-table__btn--active' : ''}`}
-                        onClick={onTogglePause}
-                        title="Pause / resume view updates"
-                    >
-                        {paused ? 'Resume' : 'Pause'}
-                    </button>
-                    <button
-                        type="button"
-                        className="yn-btn yn-btn--ghost yn-btn--sm"
-                        onClick={onClearPackets}
-                        disabled={packets.length === 0}
-                        title="Clear all captured packets"
-                    >
-                        Clear
-                    </button>
-                </div>
-            </div>
-
-            <div className="packet-table__wrapper">
-                <PacketTableHeader
-                    sortState={sortState}
-                    onSort={handleSort}
-                />
-
-                <div
-                    ref={parentRef}
-                    className="packet-table__body"
-                    style={{ height: tableBodyHeight }}
-                >
-                    {sortedPackets.length === 0 ? (
-                        <div className="packet-table__empty">
-                            <EmptyState message={
-                                !configName
-                                    ? 'Select a config and start capture to see packets.'
-                                    : packets.length === 0
-                                        ? 'Waiting for packets matching the filter...'
-                                        : 'No packets match the filter'
-                            } />
-                        </div>
-                    ) : (
-                        <div
-                            className="packet-table__virtual-container"
-                            style={{
-                                height: rowVirtualizer.getTotalSize(),
-                                minWidth: TOTAL_WIDTH,
-                            }}
-                        >
-                            {virtualRows.map(virtualRow => {
-                                const packet = sortedPackets[virtualRow.index];
-                                if (!packet) return null;
-
-                                const isSelected = packet.id === selectedPacketId;
-                                const isNew = newPacketIds.has(packet.id) && !paused;
-
-                                return (
-                                    <PacketTableRow
-                                        key={packet.id}
-                                        packet={packet}
-                                        index={virtualRow.index}
-                                        start={virtualRow.start}
-                                        isSelected={isSelected}
-                                        isNew={isNew}
-                                        onSelect={handleSelectPacket}
-                                    />
-                                );
-                            })}
-                        </div>
-                    )}
-                </div>
-            </div>
-
-            <div className="packet-table__footer" style={{ height: FOOTER_HEIGHT }}>
-                <span className="packet-table__footer-text">{footerText}</span>
-                <span className="packet-table__footer-text">
-                    {sortState.column ? `Sorted by ${sortState.column} · ` : ''}Click to inspect
-                </span>
-            </div>
-        </div>
+        <SharedPacketTable
+            key={configName ?? 'empty'}
+            packets={packetRows}
+            selectedPacketId={selectedPacketId}
+            onSelectPacket={handleSelectPacket}
+            searchQuery={searchQuery}
+            onSearchQueryChange={onSearchQueryChange}
+            newPacketIds={newPacketIds}
+            paused={paused}
+            onTogglePause={onTogglePause}
+            autoScroll={autoScroll}
+            onAutoScrollChange={onAutoScrollChange}
+            onClearPackets={onClearPackets}
+            isLive={isCapturing && configName !== null}
+            emptyMessage={
+                !configName
+                    ? 'Select a config and start capture to see packets.'
+                    : 'Waiting for packets matching the filter...'
+            }
+            emptyFilterMessage="No packets match the filter"
+            showToolbarActions
+            showTimeColumn
+        />
     );
 };

--- a/modules/pdump/web/index.ts
+++ b/modules/pdump/web/index.ts
@@ -1,6 +1,5 @@
 export * from './types';
 export * from './hooks';
-export * from './constants';
 export { ConfigDialog } from './ConfigDialog';
 export { PacketTable } from './PacketTable';
 export { default as FilterRow } from './FilterRow';

--- a/modules/pdump/web/pdump.scss
+++ b/modules/pdump/web/pdump.scss
@@ -16,30 +16,6 @@
     50%       { opacity: 0.45; transform: scale(0.75); }
 }
 
-// Row-flash animation for newly arrived packets.
-@keyframes pdump-row-in {
-    from { background-color: rgba(110, 198, 140, 0.1); }
-    to   { background-color: transparent; }
-}
-
-.packet-table__row--new {
-    animation: pdump-row-in .5s ease-out forwards;
-}
-
-.packet-table__row {
-    transition: background-color 0.08s;
-}
-
-// !important overrides the per-row inline backgroundColor (stripe tint).
-.packet-table__row--selected {
-    background-color: var(--yn-accent-soft) !important;
-}
-
-// Hover must not clobber selected or new-flash states.
-.packet-table__row:not(.packet-table__row--selected):not(.packet-table__row--new):hover {
-    background-color: var(--yn-bg-hover) !important; // !important beats the inline stripe tint
-}
-
 // BPF filter full-width card.
 .pdump-filter-card {
     display: flex;
@@ -321,186 +297,64 @@
     }
 }
 
-// Protocol colour badges in table cells.
-.pdump-proto-badge {
-    display: inline-block;
-    font-size: 11px;
-    font-weight: 600;
-    padding: 1px 6px;
-    border-radius: 3px;
-    font-family: var(--yn-font-mono);
-    letter-spacing: 0.03em;
-}
-
-.pdump-proto-tcp {
-    color: #6a9ed1;
-    background: rgba(106, 158, 209, 0.13);
-}
-
-.pdump-proto-udp {
-    color: #a98ad6;
-    background: rgba(169, 138, 214, 0.13);
-}
-
-.pdump-proto-icmp {
-    color: #d9a154;
-    background: rgba(217, 161, 84, 0.12);
-}
-
-.pdump-proto-arp {
-    color: #4cb685;
-    background: rgba(76, 182, 133, 0.10);
-}
-
 // Drawer scroll fix — yn-drawer__body has flex:1 but needs min-height:0 to constrain it.
 .yn-drawer__body {
     min-height: 0;
-}
-
-// Collapsible packet-detail sections.
-.pdump-section {
-    border: 1px solid var(--yn-line-2);
-    border-radius: 8px;
-    margin-bottom: 10px;
-    background: var(--yn-bg-2);
-
-    &__head {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 9px 14px;
-        cursor: pointer;
-        user-select: none;
-    }
-
-    &__head-left {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-    }
-
-    &__marker {
-        width: 8px;
-        height: 8px;
-        border-radius: 2px;
-        background: var(--yn-text-3);
-        flex-shrink: 0;
-    }
-
-    &__title {
-        font-size: 12.5px;
-        font-weight: 600;
-        color: var(--yn-text);
-    }
-
-    &__sub {
-        font-family: var(--yn-font-mono);
-        font-size: 11.5px;
-        color: var(--yn-text-3);
-    }
-
-    &__chevron {
-        color: var(--yn-text-3);
-        transition: transform 0.18s ease;
-        display: flex;
-        align-items: center;
-    }
-
-    &__body {
-        padding: 6px 14px 12px;
-    }
-
-    &--collapsed {
-        .pdump-section__body { display: none; }
-        .pdump-section__chevron { transform: rotate(-90deg); }
-    }
-
-    &--eth   .pdump-section__marker { background: var(--yn-text-3); }
-    &--vlan  .pdump-section__marker { background: #d9a154; }
-    &--ipv4  .pdump-section__marker { background: var(--g-color-text-positive); }
-    &--ipv6  .pdump-section__marker { background: var(--g-color-text-positive); }
-    &--tcp   .pdump-section__marker { background: var(--g-color-text-info); }
-    &--udp   .pdump-section__marker { background: var(--g-color-text-misc); }
-    &--icmp  .pdump-section__marker { background: #c07a45; }
-    &--meta  .pdump-section__marker { background: var(--yn-accent); }
-    &--http  .pdump-section__marker { background: var(--yn-accent); }
 }
 
 .pdump-page .yn-drawer {
     width: 640px;
 }
 
-// KV rows inside sections.
-.pdump-kv-row {
-    display: grid;
-    grid-template-columns: 130px 1fr;
-    gap: 14px;
-    padding: 4px 0;
-    font-family: var(--yn-font-mono);
-    font-size: 12px;
+// Pdump page container.
+.pdump-page {
+    overflow: hidden;
+
+    &__content {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+    }
+
+    &__table {
+        flex: 1;
+        min-height: 0;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+    }
 }
 
-.pdump-kv-k { color: var(--yn-text-3); }
+// Flat-surface overrides.
+.yn-flat-page {
+    .pdump-filter-card {
+        background: transparent;
+        border-color: var(--yn-line-2);
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+        border-top: 1px solid var(--yn-line-2);
+        border-bottom: 1px solid var(--yn-line-2);
 
-.pdump-kv-v {
-    color: var(--yn-text);
-    word-break: break-all;
-}
+        &__expr-wrap::after {
+            background: linear-gradient(to right, transparent, var(--yn-surface-bg));
+        }
+    }
 
-.pdump-kv-flag {
-    display: inline-block;
-    padding: 0 5px;
-    border-radius: 3px;
-    background: rgba(106, 158, 209, 0.14);
-    color: var(--g-color-text-info);
-    margin-right: 4px;
-    font-size: 10.5px;
-}
-
-// Colourised hex dump component.
-.pdump-hex-dump {
-    font-family: var(--yn-font-mono);
-    font-size: 11.5px;
-    line-height: 1.55;
-    padding: 10px 0 4px;
-    color: var(--yn-text-3);
-    overflow-x: auto;
-}
-
-.pdump-hex-line {
-    display: flex;
-    gap: 16px;
-}
-
-.pdump-hex-offset { color: var(--yn-text-3); }
-.pdump-hex-bytes  { color: var(--yn-text); letter-spacing: 0.02em; }
-.pdump-hex-ascii  { color: var(--yn-text-3); }
-
-.pdump-hex-bytes {
-    .hl-eth     { color: var(--yn-text-2); background: rgba(255, 255, 255, 0.04); padding: 0 1px; border-radius: 1px; }
-    .hl-ip      { color: var(--g-color-text-positive); background: rgba(76, 182, 133, 0.12); padding: 0 1px; }
-    .hl-l4      { color: var(--g-color-text-info); background: rgba(106, 158, 209, 0.14); padding: 0 1px; }
-    .hl-payload { color: var(--yn-accent); background: rgba(217, 161, 84, 0.12); padding: 0 1px; }
-}
-
-.pdump-drawer-timestamp {
-    font-family: var(--yn-font-mono);
-    font-size: 12px;
-    color: var(--yn-text-3);
-    font-weight: 400;
-    margin-left: 6px;
-}
-
-.pdump-drawer-empty {
-    color: var(--yn-text-3);
-    font-size: 13px;
-    text-align: center;
-    padding: 40px 0;
+    .pdump-strip {
+        background: transparent;
+        border-color: var(--yn-line-2);
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+        border-top: none;
+        border-bottom: 1px solid var(--yn-line-2);
+    }
 }
 
 // Custom modal chrome.
-// CSS variables are declared here rather than inheriting from .yn-modal,
-// because that class also carries width:640px which breaks full-viewport coverage.
 .pdump-modal-backdrop {
     --yn-panel:       #1C1814;
     --yn-bg-2:        #181410;
@@ -574,7 +428,6 @@
         border-top: 1px solid var(--yn-line-2);
         background: rgba(0, 0, 0, 0.2);
     }
-
 }
 
 // Modal form fields.
@@ -698,189 +551,6 @@
     }
 }
 
-// Packet table overrides for yn-page chrome.
-.packet-table {
-    @include flex-column;
-    background: var(--yn-panel);
-    border: 1px solid var(--yn-line-2);
-    border-radius: var(--yn-r-lg, 10px);
-    overflow: hidden;
-
-    &__container { height: 100%; }
-
-    &__toolbar {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        padding: 0 12px;
-        border-bottom: 1px solid var(--yn-line-2);
-        background: var(--yn-panel);
-        flex-shrink: 0;
-    }
-
-    &__search { width: 280px; flex-shrink: 0; }
-
-    &__toolbar-info {
-        flex: 1;
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        min-width: 0;
-    }
-
-    &__stats {
-        font-size: 12px;
-        color: var(--yn-text-3);
-        font-variant-numeric: tabular-nums;
-        white-space: nowrap;
-    }
-
-    &__live-badge {
-        font-size: 10px;
-        font-weight: 700;
-        letter-spacing: 0.08em;
-        padding: 2px 6px;
-        border-radius: 3px;
-        background: rgba(76, 182, 133, 0.14);
-        color: #4cb685;
-        border: 1px solid rgba(76, 182, 133, 0.28);
-
-        &--paused {
-            background: rgba(217, 161, 84, 0.12);
-            color: var(--yn-accent);
-            border-color: rgba(255, 192, 97, 0.22);
-        }
-    }
-
-    &__toolbar-actions {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        flex-shrink: 0;
-    }
-
-    &__btn--active {
-        color: var(--yn-accent) !important;
-        border-color: rgba(255, 192, 97, 0.3) !important;
-        background: var(--yn-accent-soft) !important;
-    }
-
-    &__wrapper {
-        flex: 1;
-        @include flex-column;
-        overflow: hidden;
-        min-height: 0;
-    }
-
-    &__body {
-        overflow: auto;
-        contain: strict;
-        flex: 1;
-        user-select: none;
-        -webkit-user-select: none;
-    }
-
-    &__virtual-container { position: relative; }
-
-    &__empty {
-        padding: 40px 20px;
-        text-align: center;
-    }
-
-    &__footer {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        padding: 0 12px;
-        border-top: 1px solid var(--yn-line-2);
-        background: var(--yn-panel);
-        flex-shrink: 0;
-    }
-
-    &__footer-text {
-        font-size: 11px;
-        color: var(--yn-text-3);
-    }
-}
-
-// Packet table header row.
-.packet-table-header {
-    @include flex-row($spacing-sm);
-    padding: 0 $spacing-sm;
-    border-bottom: 1px solid var(--yn-line-2);
-    background: var(--yn-bg-2);
-    font-weight: $font-weight-medium;
-    box-sizing: border-box;
-    flex-shrink: 0;
-}
-
-// Pdump page container.
-.pdump-page {
-    overflow: hidden;
-
-    &__content {
-        display: flex;
-        flex-direction: column;
-        flex: 1;
-        min-height: 0;
-        overflow: hidden;
-    }
-
-    &__table {
-        flex: 1;
-        min-height: 0;
-        overflow: hidden;
-        display: flex;
-        flex-direction: column;
-    }
-}
-
-// Flat-surface overrides: re-apply insets and strip boxed-panel chrome
-// so the filter card, config strip, and packet table read flush on #1C1814.
-.yn-flat-page {
-    .pdump-filter-card {
-        background: transparent;
-        border-color: var(--yn-line-2);
-        border-radius: 0;
-        border-left: none;
-        border-right: none;
-        border-top: 1px solid var(--yn-line-2);
-        border-bottom: 1px solid var(--yn-line-2);
-
-        &__expr-wrap::after {
-            background: linear-gradient(to right, transparent, var(--yn-surface-bg));
-        }
-    }
-
-    .pdump-strip {
-        background: transparent;
-        border-color: var(--yn-line-2);
-        border-radius: 0;
-        border-left: none;
-        border-right: none;
-        border-top: none;
-        border-bottom: 1px solid var(--yn-line-2);
-    }
-
-    .packet-table {
-        background: transparent;
-        border: none;
-        border-radius: 0;
-    }
-
-    .packet-table__toolbar {
-        background: transparent;
-    }
-
-    .packet-table__footer {
-        background: transparent;
-    }
-
-    .packet-table-header {
-        background: transparent;
-    }
-}
-
 // Config dialog row layout.
 .config-dialog {
     &__row {
@@ -892,7 +562,7 @@
     }
 }
 
-// Search bar (legacy — kept for any remaining reference; content merged into packet-table__toolbar).
+// Search bar (legacy — kept for any remaining reference).
 .packet-search-bar {
     @include flex-row($spacing-lg);
     flex-shrink: 0;

--- a/web/src/core/components/index.ts
+++ b/web/src/core/components/index.ts
@@ -69,3 +69,5 @@ export { EntityDiffModal } from './EntityDiffModal';
 export type { EntityDiffModalProps } from './EntityDiffModal';
 export { DrawerShell } from './DrawerShell';
 export type { DrawerShellProps } from './DrawerShell';
+export { PacketTable, PacketInspector } from './packet';
+export type { PacketTableProps, PacketInspectorProps, PacketRow, PacketSortColumn, PacketSortDirection, PacketSortState } from './packet';

--- a/web/src/core/components/packet/PacketInspector.tsx
+++ b/web/src/core/components/packet/PacketInspector.tsx
@@ -1,0 +1,372 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { ChevronDown } from '@gravity-ui/icons';
+import { Icon } from '@gravity-ui/uikit';
+import { formatTCPFlags } from '../../utils';
+import type { ParsedPacket } from '../../utils/packetParser';
+import type { PacketRow } from './types';
+import './packet.scss';
+
+type SectionKind = 'meta' | 'eth' | 'vlan' | 'ipv4' | 'ipv6' | 'tcp' | 'udp' | 'icmp' | 'http';
+
+interface SectionProps {
+    kind: SectionKind;
+    title: string;
+    sub?: string;
+    children: React.ReactNode;
+}
+
+export const Section: React.FC<SectionProps> = ({ kind, title, sub, children }) => {
+    const [collapsed, setCollapsed] = useState(false);
+
+    return (
+        <div className={`pdump-section pdump-section--${kind}${collapsed ? ' pdump-section--collapsed' : ''}`}>
+            <div className="pdump-section__head" onClick={() => setCollapsed(c => !c)}>
+                <div className="pdump-section__head-left">
+                    <span className="pdump-section__marker" />
+                    <span className="pdump-section__title">{title}</span>
+                    {sub && <span className="pdump-section__sub">{sub}</span>}
+                </div>
+                <span className="pdump-section__chevron">
+                    <Icon data={ChevronDown} size={14} />
+                </span>
+            </div>
+            <div className="pdump-section__body">
+                {children}
+            </div>
+        </div>
+    );
+};
+
+interface KVProps {
+    k: string;
+    v: React.ReactNode;
+}
+
+export const KV: React.FC<KVProps> = ({ k, v }) => (
+    <div className="pdump-kv-row">
+        <span className="pdump-kv-k">{k}</span>
+        <span className="pdump-kv-v">{v}</span>
+    </div>
+);
+
+interface HexDumpProps {
+    bytes: Uint8Array;
+    parsed: ParsedPacket;
+}
+
+const HexDump: React.FC<HexDumpProps> = ({ bytes, parsed }) => {
+    const ethEnd = 14 + (parsed.vlans?.length ?? 0) * 4;
+    const ipEnd = parsed.ipv4
+        ? ethEnd + parsed.ipv4.ihl * 4
+        : parsed.ipv6
+        ? ethEnd + 40
+        : ethEnd;
+    const l4End = parsed.payloadOffset;
+
+    const rows: React.ReactNode[] = [];
+    for (let i = 0; i < bytes.length; i += 16) {
+        const slice = bytes.slice(i, i + 16);
+        const offset = i.toString(16).padStart(4, '0');
+
+        const hexSpans: React.ReactNode[] = [];
+        const asciiChars: string[] = [];
+
+        slice.forEach((b, j) => {
+            const idx = i + j;
+            let cls = 'hl-payload';
+            if (idx < ethEnd) cls = 'hl-eth';
+            else if (idx < ipEnd) cls = 'hl-ip';
+            else if (idx < l4End) cls = 'hl-l4';
+
+            hexSpans.push(<span key={j} className={cls}>{b.toString(16).padStart(2, '0')}</span>);
+            hexSpans.push(' ');
+
+            const ch = b >= 32 && b < 127 ? String.fromCharCode(b) : '.';
+            asciiChars.push(ch);
+        });
+
+        rows.push(
+            <div className="pdump-hex-line" key={i}>
+                <span className="pdump-hex-offset">{offset}</span>
+                <span className="pdump-hex-bytes">{hexSpans}</span>
+                <span className="pdump-hex-ascii">{asciiChars.join('')}</span>
+            </div>
+        );
+    }
+
+    return <div className="pdump-hex-dump">{rows}</div>;
+};
+
+export interface PacketInspectorProps {
+    open: boolean;
+    packet: PacketRow | null;
+    packetIndex: number;
+    totalPackets: number;
+    onClose: () => void;
+    onPrev: () => void;
+    onNext: () => void;
+    /**
+     * Optional section rendered at the top of the inspector body, before the
+     * protocol layers.  Pass capture metadata here, or omit it when there is
+     * no per-packet metadata to show.
+     */
+    metaSection?: React.ReactNode;
+    /** Title shown in the drawer header next to the packet number. */
+    title?: string;
+}
+
+/**
+ * Right-side drawer for inspecting a single decoded packet.
+ *
+ * Keyboard: Esc closes, arrow-up / k = previous, arrow-down / j = next.
+ * The optional metaSection prop lets callers inject capture-specific metadata
+ * at the top without re-implementing the rest of the layout.
+ */
+const PacketInspector: React.FC<PacketInspectorProps> = ({
+    open,
+    packet,
+    packetIndex,
+    totalPackets,
+    onClose,
+    onPrev,
+    onNext,
+    metaSection,
+    title,
+}) => {
+    const handleKeyDown = useCallback((e: KeyboardEvent) => {
+        const target = document.activeElement;
+        if (target instanceof HTMLElement) {
+            if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
+        }
+        switch (e.key) {
+            case 'Escape':
+                onClose();
+                break;
+            case 'ArrowUp':
+            case 'k':
+                e.preventDefault();
+                onPrev();
+                break;
+            case 'ArrowDown':
+            case 'j':
+                e.preventDefault();
+                onNext();
+                break;
+        }
+    }, [onClose, onPrev, onNext]);
+
+    useEffect(() => {
+        if (!open) return;
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [open, handleKeyDown]);
+
+    const tcp = packet?.parsed.tcp;
+    const udp = packet?.parsed.udp;
+
+    const tcpFlagTokens = (() => {
+        if (!tcp) return null;
+        const raw = formatTCPFlags(tcp.flags);
+        if (!raw) return <span>none</span>;
+        const flags = raw.replace(/^\[|\]$/g, '').split(', ').filter(Boolean);
+        return (
+            <>
+                {flags.map((f, idx) => (
+                    <span key={idx} className="pdump-kv-flag">{f}</span>
+                ))}
+            </>
+        );
+    })();
+
+    return (
+        <aside
+            className={`yn-drawer${open ? ' yn-drawer--open' : ''}`}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Packet details"
+        >
+            <header className="yn-drawer__head">
+                <h2 className="yn-drawer__title">
+                    {packet ? (
+                        <>
+                            {title ?? 'Packet'} <span className="yn-drawer__rule-num">#{packet.id + 1}</span>
+                        </>
+                    ) : (
+                        'Packet details'
+                    )}
+                </h2>
+                <div className="yn-drawer__head-actions">
+                    <button
+                        type="button"
+                        className="yn-icon-btn"
+                        onClick={onPrev}
+                        disabled={packetIndex <= 0}
+                        title="Previous packet (↑ / k)"
+                        aria-label="Previous packet"
+                    >
+                        ↑
+                    </button>
+                    <button
+                        type="button"
+                        className="yn-icon-btn"
+                        onClick={onNext}
+                        disabled={packetIndex < 0 || packetIndex >= totalPackets - 1}
+                        title="Next packet (↓ / j)"
+                        aria-label="Next packet"
+                    >
+                        ↓
+                    </button>
+                    <button
+                        type="button"
+                        className="yn-icon-btn"
+                        onClick={onClose}
+                        aria-label="Close drawer"
+                        title="Close (Esc)"
+                    >
+                        ✕
+                    </button>
+                </div>
+            </header>
+
+            <div className="yn-drawer__body">
+                {packet ? (
+                    <>
+                        {metaSection}
+
+                        {packet.parsed.ethernet && (
+                            <Section kind="eth" title="Ethernet II">
+                                <KV k="Source MAC" v={packet.parsed.ethernet.srcMac} />
+                                <KV k="Dest MAC" v={packet.parsed.ethernet.dstMac} />
+                                <KV k="EtherType" v={`${packet.parsed.ethernet.etherTypeName} (0x${packet.parsed.ethernet.etherType.toString(16)})`} />
+                            </Section>
+                        )}
+
+                        {packet.parsed.vlans && packet.parsed.vlans.length > 0 && (
+                            <Section kind="vlan" title="VLAN / 802.1Q" sub={`${packet.parsed.vlans.length} tag${packet.parsed.vlans.length > 1 ? 's' : ''}`}>
+                                {packet.parsed.vlans.map((tag, idx) => (
+                                    <React.Fragment key={idx}>
+                                        <KV k="Tag" v={`#${idx + 1}`} />
+                                        <KV k="TPID" v={`${tag.tpidName} (0x${tag.tpid.toString(16)})`} />
+                                        <KV k="TCI" v={`0x${tag.tci.toString(16).padStart(4, '0')}`} />
+                                        <KV k="PCP" v={tag.pcp} />
+                                        <KV k="DEI" v={tag.dei ? '1' : '0'} />
+                                        <KV k="VLAN ID" v={tag.vlanId} />
+                                        <KV k="Inner EtherType" v={`${tag.innerEtherTypeName} (0x${tag.innerEtherType.toString(16)})`} />
+                                    </React.Fragment>
+                                ))}
+                            </Section>
+                        )}
+
+                        {packet.parsed.ipv4 && (
+                            <Section kind="ipv4" title="Internet Protocol v4">
+                                <KV k="Source" v={packet.parsed.ipv4.srcAddr} />
+                                <KV k="Destination" v={packet.parsed.ipv4.dstAddr} />
+                                <KV k="Protocol" v={`${packet.parsed.ipv4.protocolName} (${packet.parsed.ipv4.protocol})`} />
+                                <KV k="TTL" v={packet.parsed.ipv4.ttl} />
+                                <KV k="Total length" v={packet.parsed.ipv4.totalLength} />
+                                <KV k="ID" v={`0x${packet.parsed.ipv4.identification.toString(16)}`} />
+                                <KV k="DSCP" v={packet.parsed.ipv4.dscp} />
+                                <KV k="ECN" v={packet.parsed.ipv4.ecn} />
+                                <KV k="Don't fragment" v={packet.parsed.ipv4.flags.dontFragment ? 'true' : 'false'} />
+                                <KV k="More fragments" v={packet.parsed.ipv4.flags.moreFragments ? 'true' : 'false'} />
+                                <KV k="Fragment offset" v={packet.parsed.ipv4.fragmentOffset} />
+                            </Section>
+                        )}
+
+                        {packet.parsed.ipv6 && (
+                            <Section kind="ipv6" title="Internet Protocol v6">
+                                <KV k="Source" v={packet.parsed.ipv6.srcAddr} />
+                                <KV k="Destination" v={packet.parsed.ipv6.dstAddr} />
+                                <KV k="Next header" v={`${packet.parsed.ipv6.nextHeaderName} (${packet.parsed.ipv6.nextHeader})`} />
+                                <KV k="Hop limit" v={packet.parsed.ipv6.hopLimit} />
+                                <KV k="Payload len" v={packet.parsed.ipv6.payloadLength} />
+                                <KV k="Flow label" v={`0x${packet.parsed.ipv6.flowLabel.toString(16)}`} />
+                            </Section>
+                        )}
+
+                        {tcp && (
+                            <Section kind="tcp" title="Transmission Control Protocol" sub={`${tcp.srcPort} → ${tcp.dstPort}`}>
+                                <KV k="Source port" v={tcp.srcPort} />
+                                <KV k="Dest port" v={tcp.dstPort} />
+                                <KV k="Sequence" v={tcp.seqNum} />
+                                <KV k="Acknowledgment" v={tcp.ackNum} />
+                                <KV k="Window" v={tcp.windowSize} />
+                                <KV k="Flags" v={tcpFlagTokens} />
+                                <KV k="Checksum" v={`0x${tcp.checksum.toString(16)}`} />
+                            </Section>
+                        )}
+
+                        {udp && (
+                            <Section kind="udp" title="User Datagram Protocol" sub={`${udp.srcPort} → ${udp.dstPort}`}>
+                                <KV k="Source port" v={udp.srcPort} />
+                                <KV k="Dest port" v={udp.dstPort} />
+                                <KV k="Length" v={udp.length} />
+                                <KV k="Checksum" v={`0x${udp.checksum.toString(16)}`} />
+                            </Section>
+                        )}
+
+                        {packet.parsed.icmp && (
+                            <Section kind="icmp" title="ICMP">
+                                <KV k="Type" v={`${packet.parsed.icmp.typeName} (${packet.parsed.icmp.type})`} />
+                                <KV k="Code" v={packet.parsed.icmp.code} />
+                                <KV k="Checksum" v={`0x${packet.parsed.icmp.checksum.toString(16)}`} />
+                            </Section>
+                        )}
+
+                        {packet.parsed.http && (() => {
+                            const http = packet.parsed.http;
+                            const sub = http.isRequest
+                                ? `${http.method} ${http.target}`
+                                : `${http.statusCode} ${http.reasonPhrase}`;
+                            return (
+                                <Section kind="http" title="Hypertext Transfer Protocol" sub={sub}>
+                                    {http.isRequest ? (
+                                        <>
+                                            <KV k="Method" v={http.method} />
+                                            <KV k="Target" v={http.target} />
+                                            <KV k="Version" v={http.version} />
+                                        </>
+                                    ) : (
+                                        <>
+                                            <KV k="Version" v={http.version} />
+                                            <KV k="Status" v={http.statusCode} />
+                                            <KV k="Reason" v={http.reasonPhrase} />
+                                        </>
+                                    )}
+                                    {http.headers.map((h, idx) => (
+                                        <KV key={idx} k={h.name} v={h.value} />
+                                    ))}
+                                </Section>
+                            );
+                        })()}
+
+                        <Section kind="meta" title="Raw bytes" sub={`${packet.parsed.raw.length} B`}>
+                            <HexDump bytes={packet.parsed.raw} parsed={packet.parsed} />
+                        </Section>
+                    </>
+                ) : (
+                    <div className="pdump-drawer-empty">
+                        Select a packet to inspect.
+                    </div>
+                )}
+            </div>
+
+            {packet && (
+                <footer className="yn-drawer__foot">
+                    <span className="yn-drawer__foot-meta">
+                        {packetIndex >= 0
+                            ? `${packetIndex + 1} / ${totalPackets} packets`
+                            : `evicted / ${totalPackets} packets`}
+                    </span>
+                    <div className="yn-drawer__foot-actions">
+                        <button type="button" className="yn-btn yn-btn--ghost" onClick={onClose}>
+                            Close
+                        </button>
+                    </div>
+                </footer>
+            )}
+        </aside>
+    );
+};
+
+export default React.memo(PacketInspector);

--- a/web/src/core/components/packet/PacketTable.tsx
+++ b/web/src/core/components/packet/PacketTable.tsx
@@ -1,0 +1,385 @@
+import React, { useRef, useMemo, useCallback, useEffect, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { TextInput } from '@gravity-ui/uikit';
+import { EmptyState } from '../EmptyState';
+import { useContainerHeight } from '../../hooks';
+import { PKT_ROW_HEIGHT, PKT_SEARCH_BAR_HEIGHT, PKT_HEADER_HEIGHT, PKT_FOOTER_HEIGHT, PKT_OVERSCAN, PKT_TOTAL_WIDTH } from './constants';
+import { SharedPacketTableRow } from './PacketTableRow';
+import { SharedPacketTableHeader } from './PacketTableHeader';
+import type { PacketRow, PacketSortState, PacketSortColumn } from './types';
+import './packet.scss';
+
+const getPacketSortValues = (packet: PacketRow) => {
+    const { parsed } = packet;
+
+    let source = '';
+    let destination = '';
+    let protocol = '';
+
+    if (parsed.ipv4) {
+        source = parsed.ipv4.srcAddr;
+        destination = parsed.ipv4.dstAddr;
+        protocol = parsed.ipv4.protocolName;
+    } else if (parsed.ipv6) {
+        source = parsed.ipv6.srcAddr;
+        destination = parsed.ipv6.dstAddr;
+        protocol = parsed.ipv6.nextHeaderName;
+    } else if (parsed.ethernet) {
+        source = parsed.ethernet.srcMac;
+        destination = parsed.ethernet.dstMac;
+        protocol = parsed.ethernet.etherTypeName;
+    }
+
+    if (parsed.tcp) {
+        source = `${source}:${parsed.tcp.srcPort}`;
+        destination = `${destination}:${parsed.tcp.dstPort}`;
+        protocol = 'TCP';
+    } else if (parsed.udp) {
+        source = `${source}:${parsed.udp.srcPort}`;
+        destination = `${destination}:${parsed.udp.dstPort}`;
+        protocol = 'UDP';
+    } else if (parsed.icmp) {
+        protocol = 'ICMP';
+    }
+
+    return { source, destination, protocol, length: parsed.raw.length };
+};
+
+const createComparator = (column: PacketSortColumn, direction: 'asc' | 'desc') => {
+    const mult = direction === 'asc' ? 1 : -1;
+
+    return (a: PacketRow, b: PacketRow): number => {
+        switch (column) {
+            case 'index':
+                return mult * (a.id - b.id);
+            case 'time': {
+                const at = a.timestamp?.getTime() ?? 0;
+                const bt = b.timestamp?.getTime() ?? 0;
+                return mult * (at - bt);
+            }
+            case 'length':
+                return mult * (a.parsed.raw.length - b.parsed.raw.length);
+            case 'source': {
+                const aVal = getPacketSortValues(a);
+                const bVal = getPacketSortValues(b);
+                return mult * aVal.source.localeCompare(bVal.source);
+            }
+            case 'destination': {
+                const aVal = getPacketSortValues(a);
+                const bVal = getPacketSortValues(b);
+                return mult * aVal.destination.localeCompare(bVal.destination);
+            }
+            case 'protocol': {
+                const aVal = getPacketSortValues(a);
+                const bVal = getPacketSortValues(b);
+                return mult * aVal.protocol.localeCompare(bVal.protocol);
+            }
+            default:
+                return 0;
+        }
+    };
+};
+
+export interface PacketTableProps {
+    /** Rows to display. Each item must have a unique numeric id. */
+    packets: PacketRow[];
+    selectedPacketId: number | null;
+    onSelectPacket: (packet: PacketRow | null) => void;
+    searchQuery: string;
+    onSearchQueryChange: (value: string) => void;
+    /** IDs of packets that should flash the "new" animation. */
+    newPacketIds?: Set<number>;
+    /** Whether the view is paused (hides LIVE badge, disables auto-scroll). */
+    paused?: boolean;
+    onTogglePause?: () => void;
+    autoScroll?: boolean;
+    onAutoScrollChange?: (value: boolean) => void;
+    onClearPackets?: () => void;
+    /** If truthy and isLive is true, shows the LIVE/PAUSED badge next to the packet count. */
+    isLive?: boolean;
+    /** Message to show when there are no packets at all. */
+    emptyMessage?: string;
+    /** Message to show when search filters out everything. */
+    emptyFilterMessage?: string;
+    /** If false, no auto-scroll or clear toolbar actions are rendered. Default true. */
+    showToolbarActions?: boolean;
+    /** Whether to show the Time column. Defaults to true. */
+    showTimeColumn?: boolean;
+    /** Optional note to show in the footer right slot (e.g. "truncated" warning). */
+    footerNote?: React.ReactNode;
+}
+
+/**
+ * Generic virtualized packet table shared across packet-display surfaces.
+ *
+ * Handles filtering, sorting, virtualisation, auto-scroll, and selection.
+ * Rendering of capture-specific metadata is the caller's responsibility.
+ */
+export const PacketTable: React.FC<PacketTableProps> = ({
+    packets,
+    selectedPacketId,
+    onSelectPacket,
+    searchQuery,
+    onSearchQueryChange,
+    newPacketIds = new Set(),
+    paused = false,
+    onTogglePause,
+    autoScroll = false,
+    onAutoScrollChange,
+    onClearPackets,
+    isLive = false,
+    emptyMessage = 'No packets to display.',
+    emptyFilterMessage = 'No packets match the filter.',
+    showToolbarActions = true,
+    showTimeColumn = true,
+    footerNote,
+}) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const parentRef = useRef<HTMLDivElement>(null);
+    const containerHeight = useContainerHeight(containerRef);
+    const [sortState, setSortState] = useState<PacketSortState>({ column: null, direction: 'asc' });
+
+    const handleSort = useCallback((column: PacketSortColumn) => {
+        setSortState(prev => ({
+            column,
+            direction: prev.column === column && prev.direction === 'asc' ? 'desc' : 'asc',
+        }));
+        onAutoScrollChange?.(false);
+    }, [onAutoScrollChange]);
+
+    const filteredPackets = useMemo(() => {
+        if (!searchQuery.trim()) return packets;
+
+        const lowerQuery = searchQuery.toLowerCase();
+        return packets.filter(packet => {
+            const { parsed } = packet;
+
+            if (parsed.ipv4) {
+                if (parsed.ipv4.srcAddr.includes(lowerQuery) || parsed.ipv4.dstAddr.includes(lowerQuery)) {
+                    return true;
+                }
+            }
+            if (parsed.ipv6) {
+                if (parsed.ipv6.srcAddr.toLowerCase().includes(lowerQuery) ||
+                    parsed.ipv6.dstAddr.toLowerCase().includes(lowerQuery)) {
+                    return true;
+                }
+            }
+            if (parsed.tcp) {
+                if (parsed.tcp.srcPort.toString().includes(lowerQuery) ||
+                    parsed.tcp.dstPort.toString().includes(lowerQuery)) {
+                    return true;
+                }
+            }
+            if (parsed.udp) {
+                if (parsed.udp.srcPort.toString().includes(lowerQuery) ||
+                    parsed.udp.dstPort.toString().includes(lowerQuery)) {
+                    return true;
+                }
+            }
+            const protocol = parsed.tcp ? 'tcp' : parsed.udp ? 'udp' : parsed.icmp ? 'icmp' : '';
+            if (protocol.includes(lowerQuery)) {
+                return true;
+            }
+            if (parsed.ethernet) {
+                if (parsed.ethernet.srcMac.toLowerCase().includes(lowerQuery) ||
+                    parsed.ethernet.dstMac.toLowerCase().includes(lowerQuery)) {
+                    return true;
+                }
+            }
+            return false;
+        });
+    }, [packets, searchQuery]);
+
+    const sortedPackets = useMemo(() => {
+        if (!sortState.column) return filteredPackets;
+        const comparator = createComparator(sortState.column, sortState.direction);
+        return [...filteredPackets].sort(comparator);
+    }, [filteredPackets, sortState]);
+
+    const rowVirtualizer = useVirtualizer({
+        count: sortedPackets.length,
+        getScrollElement: () => parentRef.current,
+        estimateSize: () => PKT_ROW_HEIGHT,
+        overscan: PKT_OVERSCAN,
+    });
+
+    const lastPacketId = sortedPackets.length > 0 ? sortedPackets[sortedPackets.length - 1]?.id : null;
+
+    useEffect(() => {
+        if (autoScroll && !paused && isLive && sortedPackets.length > 0 && parentRef.current && !sortState.column) {
+            rowVirtualizer.scrollToIndex(sortedPackets.length - 1, { align: 'end' });
+        }
+    }, [lastPacketId, autoScroll, paused, isLive, rowVirtualizer, sortState.column]);
+
+    const STICKY_BOTTOM_THRESHOLD_PX = 24;
+
+    useEffect(() => {
+        const element = parentRef.current;
+        if (!element || !isLive) return;
+
+        const handleScroll = (): void => {
+            const el = parentRef.current;
+            if (!el) return;
+            const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+            onAutoScrollChange?.(distance < STICKY_BOTTOM_THRESHOLD_PX);
+        };
+
+        element.addEventListener('scroll', handleScroll, { passive: true });
+        return () => element.removeEventListener('scroll', handleScroll);
+    }, [isLive, onAutoScrollChange]);
+
+    const selectedPacketIdRef = useRef(selectedPacketId);
+    selectedPacketIdRef.current = selectedPacketId;
+
+    const handleSelectPacket = useCallback((packet: PacketRow) => {
+        onSelectPacket(packet.id === selectedPacketIdRef.current ? null : packet);
+    }, [onSelectPacket]);
+
+    const handleSearchChange = useCallback((value: string) => {
+        onSearchQueryChange(value);
+    }, [onSearchQueryChange]);
+
+    const handleToggleAutoScroll = useCallback(() => {
+        onAutoScrollChange?.(!autoScroll);
+    }, [onAutoScrollChange, autoScroll]);
+
+    const statsText = useMemo(() => {
+        const total = packets.length;
+        const filtered = sortedPackets.length;
+        if (searchQuery.trim() && filtered !== total) {
+            return `${filtered.toLocaleString()} / ${total.toLocaleString()} packets`;
+        }
+        return `${total.toLocaleString()} packets`;
+    }, [packets.length, sortedPackets.length, searchQuery]);
+
+    if (containerHeight === 0) {
+        return <div ref={containerRef} className="packet-table__container" />;
+    }
+
+    const tableBodyHeight = containerHeight - PKT_SEARCH_BAR_HEIGHT - PKT_HEADER_HEIGHT - PKT_FOOTER_HEIGHT - 2;
+    const virtualRows = rowVirtualizer.getVirtualItems();
+
+    const footerLeft = virtualRows.length > 0
+        ? `Rows ${(virtualRows[0].index + 1).toLocaleString()} – ${(virtualRows[virtualRows.length - 1].index + 1).toLocaleString()} of ${sortedPackets.length.toLocaleString()}`
+        : '';
+
+    const footerRight = footerNote ?? (
+        sortState.column ? `Sorted by ${sortState.column} · Click to inspect` : 'Click to inspect'
+    );
+
+    return (
+        <div ref={containerRef} className="packet-table" style={{ height: containerHeight }}>
+            <div className="packet-table__toolbar" style={{ height: PKT_SEARCH_BAR_HEIGHT }}>
+                <div className="packet-table__search">
+                    <TextInput
+                        placeholder="Filter by IP, port, protocol..."
+                        value={searchQuery}
+                        onUpdate={handleSearchChange}
+                        size="m"
+                        hasClear
+                    />
+                </div>
+                <div className="packet-table__toolbar-info">
+                    <span className="packet-table__stats">{statsText}</span>
+                    {isLive && (
+                        <span className={`packet-table__live-badge${paused ? ' packet-table__live-badge--paused' : ''}`}>
+                            {paused ? 'PAUSED' : 'LIVE'}
+                        </span>
+                    )}
+                </div>
+                {showToolbarActions && (
+                    <div className="packet-table__toolbar-actions">
+                        {isLive && onAutoScrollChange && (
+                            <button
+                                type="button"
+                                className={`yn-btn yn-btn--ghost yn-btn--sm${autoScroll ? ' packet-table__btn--active' : ''}`}
+                                onClick={handleToggleAutoScroll}
+                                title="Toggle auto-scroll to new packets"
+                            >
+                                Auto-scroll
+                            </button>
+                        )}
+                        {onTogglePause && (
+                            <button
+                                type="button"
+                                className={`yn-btn yn-btn--ghost yn-btn--sm${paused ? ' packet-table__btn--active' : ''}`}
+                                onClick={onTogglePause}
+                                title="Pause / resume view updates"
+                            >
+                                {paused ? 'Resume' : 'Pause'}
+                            </button>
+                        )}
+                        {onClearPackets && (
+                            <button
+                                type="button"
+                                className="yn-btn yn-btn--ghost yn-btn--sm"
+                                onClick={onClearPackets}
+                                disabled={packets.length === 0}
+                                title="Clear all packets"
+                            >
+                                Clear
+                            </button>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            <div className="packet-table__wrapper">
+                <SharedPacketTableHeader
+                    sortState={sortState}
+                    onSort={handleSort}
+                    showTime={showTimeColumn}
+                />
+
+                <div
+                    ref={parentRef}
+                    className="packet-table__body"
+                    style={{ height: tableBodyHeight }}
+                >
+                    {sortedPackets.length === 0 ? (
+                        <div className="packet-table__empty">
+                            <EmptyState message={
+                                packets.length === 0 ? emptyMessage : emptyFilterMessage
+                            } />
+                        </div>
+                    ) : (
+                        <div
+                            className="packet-table__virtual-container"
+                            style={{
+                                height: rowVirtualizer.getTotalSize(),
+                                minWidth: PKT_TOTAL_WIDTH,
+                            }}
+                        >
+                            {virtualRows.map(virtualRow => {
+                                const packet = sortedPackets[virtualRow.index];
+                                if (!packet) return null;
+
+                                const isSelected = packet.id === selectedPacketId;
+                                const isNew = newPacketIds.has(packet.id) && !paused;
+
+                                return (
+                                    <SharedPacketTableRow
+                                        key={packet.id}
+                                        packet={packet}
+                                        index={virtualRow.index}
+                                        start={virtualRow.start}
+                                        isSelected={isSelected}
+                                        isNew={isNew}
+                                        onSelect={handleSelectPacket}
+                                        showTime={showTimeColumn}
+                                    />
+                                );
+                            })}
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            <div className="packet-table__footer" style={{ height: PKT_FOOTER_HEIGHT }}>
+                <span className="packet-table__footer-text">{footerLeft}</span>
+                <span className="packet-table__footer-text">{footerRight}</span>
+            </div>
+        </div>
+    );
+};

--- a/web/src/core/components/packet/PacketTableHeader.tsx
+++ b/web/src/core/components/packet/PacketTableHeader.tsx
@@ -1,63 +1,67 @@
 import React from 'react';
 import { Box, Text } from '@gravity-ui/uikit';
-import { SortableTableHeader } from '@yanet/core/components';
-import { cellStyles, TOTAL_WIDTH, HEADER_HEIGHT } from './constants';
+import { SortableTableHeader } from '../SortableTableHeader';
+import { pktCellStyles, PKT_TOTAL_WIDTH, PKT_HEADER_HEIGHT } from './constants';
 import type { PacketSortState, PacketSortColumn } from './types';
-import './pdump.scss';
 
-export interface PacketTableHeaderProps {
+export interface SharedPacketTableHeaderProps {
     sortState: PacketSortState;
     onSort: (column: PacketSortColumn) => void;
+    /** Whether to render the Time column. Defaults to true. */
+    showTime?: boolean;
 }
 
-export const PacketTableHeader: React.FC<PacketTableHeaderProps> = ({
+export const SharedPacketTableHeader: React.FC<SharedPacketTableHeaderProps> = ({
     sortState,
     onSort,
+    showTime = true,
 }) => {
     return (
         <Box
             className="packet-table-header"
-            style={{ height: HEADER_HEIGHT, minWidth: TOTAL_WIDTH }}
+            style={{ height: PKT_HEADER_HEIGHT, minWidth: PKT_TOTAL_WIDTH }}
         >
-            <Box style={cellStyles.index}>
+            <Box style={pktCellStyles.index}>
                 <Text variant="subheader-1">#</Text>
             </Box>
-            <SortableTableHeader
-                column="time"
-                label="Time"
-                style={cellStyles.time}
-                sortState={sortState}
-                onSort={onSort}
-            />
+            {showTime && (
+                <SortableTableHeader
+                    column="time"
+                    label="Time"
+                    style={pktCellStyles.time}
+                    sortState={sortState}
+                    onSort={onSort}
+                />
+            )}
             <SortableTableHeader
                 column="source"
                 label="Source"
-                style={cellStyles.source}
+                style={pktCellStyles.source}
                 sortState={sortState}
                 onSort={onSort}
             />
             <SortableTableHeader
                 column="destination"
                 label="Destination"
-                style={cellStyles.destination}
+                style={pktCellStyles.destination}
                 sortState={sortState}
                 onSort={onSort}
             />
             <SortableTableHeader
                 column="protocol"
                 label="Protocol"
-                style={cellStyles.protocol}
+                style={pktCellStyles.protocol}
                 sortState={sortState}
                 onSort={onSort}
             />
             <SortableTableHeader
                 column="length"
                 label="Length"
-                style={cellStyles.length}
+                style={pktCellStyles.length}
                 sortState={sortState}
                 onSort={onSort}
             />
-            <Box style={cellStyles.info}>
+            <Box style={pktCellStyles.info}>
                 <Text variant="subheader-1">Info</Text>
             </Box>
         </Box>

--- a/web/src/core/components/packet/PacketTableRow.tsx
+++ b/web/src/core/components/packet/PacketTableRow.tsx
@@ -1,19 +1,21 @@
 import React from 'react';
-import { formatTCPFlags } from '@yanet/core/utils';
-import { cellStyles, TOTAL_WIDTH, ROW_HEIGHT } from './constants';
-import type { CapturedPacket } from './types';
+import { formatTCPFlags } from '../../utils';
+import { pktCellStyles, PKT_TOTAL_WIDTH, PKT_ROW_HEIGHT } from './constants';
+import type { PacketRow } from './types';
 
-export interface PacketTableRowProps {
-    packet: CapturedPacket;
+export interface SharedPacketTableRowProps {
+    packet: PacketRow;
     index: number;
     start: number;
     isSelected: boolean;
     isNew: boolean;
-    onSelect: (packet: CapturedPacket) => void;
+    onSelect: (packet: PacketRow) => void;
+    /** Whether to render the Time cell. Must match the header's showTime. */
+    showTime?: boolean;
 }
 
 const formatTime = (date: Date): string => {
-    const pad = (n: number, len: number = 2) => n.toString().padStart(len, '0');
+    const pad = (n: number, len: number = 2): string => n.toString().padStart(len, '0');
     return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}.${pad(date.getMilliseconds(), 3)}`;
 };
 
@@ -26,13 +28,14 @@ const getProtocolClass = (protocol: string): string => {
     return '';
 };
 
-const PacketTableRowImpl: React.FC<PacketTableRowProps> = ({
+const SharedPacketTableRowImpl: React.FC<SharedPacketTableRowProps> = ({
     packet,
     index,
     start,
     isSelected,
     isNew,
     onSelect,
+    showTime = true,
 }) => {
     const { parsed } = packet;
 
@@ -97,8 +100,8 @@ const PacketTableRowImpl: React.FC<PacketTableRowProps> = ({
                 top: 0,
                 left: 0,
                 width: '100%',
-                minWidth: TOTAL_WIDTH,
-                height: ROW_HEIGHT,
+                minWidth: PKT_TOTAL_WIDTH,
+                height: PKT_ROW_HEIGHT,
                 transform: `translateY(${start}px)`,
                 display: 'flex',
                 alignItems: 'center',
@@ -109,21 +112,25 @@ const PacketTableRowImpl: React.FC<PacketTableRowProps> = ({
                 cursor: 'pointer',
             }}
         >
-            <div style={cellStyles.index}>{packet.id + 1}</div>
-            <div style={cellStyles.time}>{formatTime(packet.timestamp)}</div>
-            <div style={cellStyles.source} title={src}>{src || '-'}</div>
-            <div style={cellStyles.destination} title={dst}>{dst || '-'}</div>
-            <div style={cellStyles.protocol}>
+            <div style={pktCellStyles.index}>{packet.id + 1}</div>
+            {showTime && (
+                <div style={pktCellStyles.time}>
+                    {packet.timestamp ? formatTime(packet.timestamp) : '—'}
+                </div>
+            )}
+            <div style={pktCellStyles.source} title={src}>{src || '-'}</div>
+            <div style={pktCellStyles.destination} title={dst}>{dst || '-'}</div>
+            <div style={pktCellStyles.protocol}>
                 {protocol ? (
                     <span className={`pdump-proto-badge${protoClass ? ` ${protoClass}` : ''}`}>
                         {protocol}
                     </span>
                 ) : '-'}
             </div>
-            <div style={cellStyles.length}>{parsed.raw.length}</div>
-            <div style={cellStyles.info} title={info}>{info || '-'}</div>
+            <div style={pktCellStyles.length}>{parsed.raw.length}</div>
+            <div style={pktCellStyles.info} title={info}>{info || '-'}</div>
         </div>
     );
 };
 
-export const PacketTableRow = React.memo(PacketTableRowImpl);
+export const SharedPacketTableRow = React.memo(SharedPacketTableRowImpl);

--- a/web/src/core/components/packet/constants.ts
+++ b/web/src/core/components/packet/constants.ts
@@ -1,33 +1,35 @@
 import type React from 'react';
 
-// Table dimensions
-export const ROW_HEIGHT = 32;
-export const HEADER_HEIGHT = 40;
-export const SEARCH_BAR_HEIGHT = 52;
-export const TOOLBAR_HEIGHT = 48;
-export const FOOTER_HEIGHT = 28;
-export const OVERSCAN = 20;
+/** Height of a single packet row in pixels. */
+export const PKT_ROW_HEIGHT = 32;
+/** Height of the column header bar in pixels. */
+export const PKT_HEADER_HEIGHT = 40;
+/** Height of the search/toolbar bar in pixels. */
+export const PKT_SEARCH_BAR_HEIGHT = 52;
+/** Height of the footer status bar in pixels. */
+export const PKT_FOOTER_HEIGHT = 28;
+/** Number of rows to render outside the visible window. */
+export const PKT_OVERSCAN = 20;
+/** Minimum total table width in pixels. */
+export const PKT_TOTAL_WIDTH = 800;
 
-// Column widths for packet table (flexible layout)
-export const COLUMN_WIDTHS = {
+/** Column widths for the shared packet table. */
+export const PKT_COLUMN_WIDTHS = {
     index: 50,
     time: 100,
-    source: 1, // flex
-    destination: 1, // flex
+    source: 1,       // flex
+    destination: 1,  // flex
     protocol: 70,
     length: 55,
-    info: 2, // flex (wider)
+    info: 2,         // flex (wider)
 } as const;
 
-// Fixed columns total width (for min-width calculation)
-export const FIXED_COLUMNS_WIDTH = 50 + 100 + 70 + 55 + 16; // index + time + protocol + length + padding
-
-// Pre-computed cell styles
-export const cellStyles: Record<keyof typeof COLUMN_WIDTHS, React.CSSProperties> = {
+/** Pre-computed cell styles shared across header and rows. */
+export const pktCellStyles: Record<keyof typeof PKT_COLUMN_WIDTHS, React.CSSProperties> = {
     index: {
-        width: COLUMN_WIDTHS.index,
-        minWidth: COLUMN_WIDTHS.index,
-        maxWidth: COLUMN_WIDTHS.index,
+        width: PKT_COLUMN_WIDTHS.index,
+        minWidth: PKT_COLUMN_WIDTHS.index,
+        maxWidth: PKT_COLUMN_WIDTHS.index,
         paddingRight: 8,
         textAlign: 'right',
         color: 'var(--g-color-text-secondary)',
@@ -36,9 +38,9 @@ export const cellStyles: Record<keyof typeof COLUMN_WIDTHS, React.CSSProperties>
         flexShrink: 0,
     },
     time: {
-        width: COLUMN_WIDTHS.time,
-        minWidth: COLUMN_WIDTHS.time,
-        maxWidth: COLUMN_WIDTHS.time,
+        width: PKT_COLUMN_WIDTHS.time,
+        minWidth: PKT_COLUMN_WIDTHS.time,
+        maxWidth: PKT_COLUMN_WIDTHS.time,
         paddingRight: 8,
         fontFamily: 'var(--g-font-family-monospace)',
         fontSize: 12,
@@ -65,18 +67,18 @@ export const cellStyles: Record<keyof typeof COLUMN_WIDTHS, React.CSSProperties>
         fontSize: 12,
     },
     protocol: {
-        width: COLUMN_WIDTHS.protocol,
-        minWidth: COLUMN_WIDTHS.protocol,
-        maxWidth: COLUMN_WIDTHS.protocol,
+        width: PKT_COLUMN_WIDTHS.protocol,
+        minWidth: PKT_COLUMN_WIDTHS.protocol,
+        maxWidth: PKT_COLUMN_WIDTHS.protocol,
         paddingRight: 8,
         fontFamily: 'var(--g-font-family-monospace)',
         fontSize: 12,
         flexShrink: 0,
     },
     length: {
-        width: COLUMN_WIDTHS.length,
-        minWidth: COLUMN_WIDTHS.length,
-        maxWidth: COLUMN_WIDTHS.length,
+        width: PKT_COLUMN_WIDTHS.length,
+        minWidth: PKT_COLUMN_WIDTHS.length,
+        maxWidth: PKT_COLUMN_WIDTHS.length,
         paddingRight: 8,
         textAlign: 'right',
         fontFamily: 'var(--g-font-family-monospace)',
@@ -95,6 +97,3 @@ export const cellStyles: Record<keyof typeof COLUMN_WIDTHS, React.CSSProperties>
         fontSize: 12,
     },
 };
-
-// Minimum total width
-export const TOTAL_WIDTH = 800;

--- a/web/src/core/components/packet/index.ts
+++ b/web/src/core/components/packet/index.ts
@@ -1,0 +1,6 @@
+export { PacketTable } from './PacketTable';
+export type { PacketTableProps } from './PacketTable';
+export { default as PacketInspector, Section, KV } from './PacketInspector';
+export type { PacketInspectorProps } from './PacketInspector';
+export type { PacketRow, PacketSortColumn, PacketSortDirection, PacketSortState } from './types';
+export { PKT_ROW_HEIGHT, PKT_HEADER_HEIGHT, PKT_FOOTER_HEIGHT, PKT_SEARCH_BAR_HEIGHT, PKT_OVERSCAN, PKT_TOTAL_WIDTH, pktCellStyles } from './constants';

--- a/web/src/core/components/packet/packet.scss
+++ b/web/src/core/components/packet/packet.scss
@@ -1,0 +1,324 @@
+@use '../../styles/variables' as *;
+@use '../../styles/mixins' as *;
+
+// Row-flash animation for newly arrived packets.
+@keyframes pkt-row-in {
+    from { background-color: rgba(110, 198, 140, 0.1); }
+    to   { background-color: transparent; }
+}
+
+.packet-table__row--new {
+    animation: pkt-row-in .5s ease-out forwards;
+}
+
+.packet-table__row {
+    transition: background-color 0.08s;
+}
+
+// !important overrides the per-row inline backgroundColor (stripe tint).
+.packet-table__row--selected {
+    background-color: var(--yn-accent-soft) !important;
+}
+
+// Hover must not clobber selected or new-flash states.
+.packet-table__row:not(.packet-table__row--selected):not(.packet-table__row--new):hover {
+    background-color: var(--yn-bg-hover) !important;
+}
+
+// Protocol colour badges in table cells.
+.pdump-proto-badge {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-family: var(--yn-font-mono);
+    letter-spacing: 0.03em;
+}
+
+.pdump-proto-tcp {
+    color: #6a9ed1;
+    background: rgba(106, 158, 209, 0.13);
+}
+
+.pdump-proto-udp {
+    color: #a98ad6;
+    background: rgba(169, 138, 214, 0.13);
+}
+
+.pdump-proto-icmp {
+    color: #d9a154;
+    background: rgba(217, 161, 84, 0.12);
+}
+
+.pdump-proto-arp {
+    color: #4cb685;
+    background: rgba(76, 182, 133, 0.10);
+}
+
+// Packet table chrome.
+.packet-table {
+    @include flex-column;
+    background: var(--yn-panel);
+    border: 1px solid var(--yn-line-2);
+    border-radius: var(--yn-r-lg, 10px);
+    overflow: hidden;
+
+    &__container { height: 100%; }
+
+    &__toolbar {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 0 12px;
+        border-bottom: 1px solid var(--yn-line-2);
+        background: var(--yn-panel);
+        flex-shrink: 0;
+    }
+
+    &__search { width: 280px; flex-shrink: 0; }
+
+    &__toolbar-info {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+    }
+
+    &__stats {
+        font-size: 12px;
+        color: var(--yn-text-3);
+        font-variant-numeric: tabular-nums;
+        white-space: nowrap;
+    }
+
+    &__live-badge {
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        padding: 2px 6px;
+        border-radius: 3px;
+        background: rgba(76, 182, 133, 0.14);
+        color: #4cb685;
+        border: 1px solid rgba(76, 182, 133, 0.28);
+
+        &--paused {
+            background: rgba(217, 161, 84, 0.12);
+            color: var(--yn-accent);
+            border-color: rgba(255, 192, 97, 0.22);
+        }
+    }
+
+    &__toolbar-actions {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        flex-shrink: 0;
+    }
+
+    &__btn--active {
+        color: var(--yn-accent) !important;
+        border-color: rgba(255, 192, 97, 0.3) !important;
+        background: var(--yn-accent-soft) !important;
+    }
+
+    &__wrapper {
+        flex: 1;
+        @include flex-column;
+        overflow: hidden;
+        min-height: 0;
+    }
+
+    &__body {
+        overflow: auto;
+        contain: strict;
+        flex: 1;
+        user-select: none;
+        -webkit-user-select: none;
+    }
+
+    &__virtual-container { position: relative; }
+
+    &__empty {
+        padding: 40px 20px;
+        text-align: center;
+    }
+
+    &__footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 12px;
+        border-top: 1px solid var(--yn-line-2);
+        background: var(--yn-panel);
+        flex-shrink: 0;
+    }
+
+    &__footer-text {
+        font-size: 11px;
+        color: var(--yn-text-3);
+    }
+}
+
+// Packet table header row.
+.packet-table-header {
+    @include flex-row($spacing-sm);
+    padding: 0 $spacing-sm;
+    border-bottom: 1px solid var(--yn-line-2);
+    background: var(--yn-bg-2);
+    font-weight: $font-weight-medium;
+    box-sizing: border-box;
+    flex-shrink: 0;
+}
+
+// Flat-surface overrides: re-apply insets and strip boxed-panel chrome
+// so the packet table reads flush on the flat background.
+.yn-flat-page {
+    .packet-table {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+    }
+
+    .packet-table__toolbar {
+        background: transparent;
+    }
+
+    .packet-table__footer {
+        background: transparent;
+    }
+
+    .packet-table-header {
+        background: transparent;
+    }
+}
+
+// Collapsible packet-detail sections (shared across packet inspectors).
+.pdump-section {
+    border: 1px solid var(--yn-line-2);
+    border-radius: 8px;
+    margin-bottom: 10px;
+    background: var(--yn-bg-2);
+
+    &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 9px 14px;
+        cursor: pointer;
+        user-select: none;
+    }
+
+    &__head-left {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    &__marker {
+        width: 8px;
+        height: 8px;
+        border-radius: 2px;
+        background: var(--yn-text-3);
+        flex-shrink: 0;
+    }
+
+    &__title {
+        font-size: 12.5px;
+        font-weight: 600;
+        color: var(--yn-text);
+    }
+
+    &__sub {
+        font-family: var(--yn-font-mono);
+        font-size: 11.5px;
+        color: var(--yn-text-3);
+    }
+
+    &__chevron {
+        color: var(--yn-text-3);
+        transition: transform 0.18s ease;
+        display: flex;
+        align-items: center;
+    }
+
+    &__body {
+        padding: 6px 14px 12px;
+    }
+
+    &--collapsed {
+        .pdump-section__body { display: none; }
+        .pdump-section__chevron { transform: rotate(-90deg); }
+    }
+
+    &--eth   .pdump-section__marker { background: var(--yn-text-3); }
+    &--vlan  .pdump-section__marker { background: #d9a154; }
+    &--ipv4  .pdump-section__marker { background: var(--g-color-text-positive); }
+    &--ipv6  .pdump-section__marker { background: var(--g-color-text-positive); }
+    &--tcp   .pdump-section__marker { background: var(--g-color-text-info); }
+    &--udp   .pdump-section__marker { background: var(--g-color-text-misc); }
+    &--icmp  .pdump-section__marker { background: #c07a45; }
+    &--meta  .pdump-section__marker { background: var(--yn-accent); }
+    &--http  .pdump-section__marker { background: var(--yn-accent); }
+}
+
+// KV rows inside sections.
+.pdump-kv-row {
+    display: grid;
+    grid-template-columns: 130px 1fr;
+    gap: 14px;
+    padding: 4px 0;
+    font-family: var(--yn-font-mono);
+    font-size: 12px;
+}
+
+.pdump-kv-k { color: var(--yn-text-3); }
+
+.pdump-kv-v {
+    color: var(--yn-text);
+    word-break: break-all;
+}
+
+.pdump-kv-flag {
+    display: inline-block;
+    padding: 0 5px;
+    border-radius: 3px;
+    background: rgba(106, 158, 209, 0.14);
+    color: var(--g-color-text-info);
+    margin-right: 4px;
+    font-size: 10.5px;
+}
+
+// Colourised hex dump component.
+.pdump-hex-dump {
+    font-family: var(--yn-font-mono);
+    font-size: 11.5px;
+    line-height: 1.55;
+    padding: 10px 0 4px;
+    color: var(--yn-text-3);
+    overflow-x: auto;
+}
+
+.pdump-hex-line {
+    display: flex;
+    gap: 16px;
+}
+
+.pdump-hex-offset { color: var(--yn-text-3); }
+.pdump-hex-bytes  { color: var(--yn-text); letter-spacing: 0.02em; }
+.pdump-hex-ascii  { color: var(--yn-text-3); }
+
+.pdump-hex-bytes {
+    .hl-eth     { color: var(--yn-text-2); background: rgba(255, 255, 255, 0.04); padding: 0 1px; border-radius: 1px; }
+    .hl-ip      { color: var(--g-color-text-positive); background: rgba(76, 182, 133, 0.12); padding: 0 1px; }
+    .hl-l4      { color: var(--g-color-text-info); background: rgba(106, 158, 209, 0.14); padding: 0 1px; }
+    .hl-payload { color: var(--yn-accent); background: rgba(217, 161, 84, 0.12); padding: 0 1px; }
+}
+
+.pdump-drawer-empty {
+    color: var(--yn-text-3);
+    font-size: 13px;
+    text-align: center;
+    padding: 40px 0;
+}

--- a/web/src/core/components/packet/types.ts
+++ b/web/src/core/components/packet/types.ts
@@ -1,0 +1,18 @@
+import type { ParsedPacket } from '../../utils/packetParser';
+
+/** A generic displayable packet — id for virtual-list keying, parsed for rendering. */
+export interface PacketRow {
+    id: number;
+    parsed: ParsedPacket;
+    /** Optional timestamp to show in the Time column. */
+    timestamp?: Date;
+}
+
+/** Columns that can be used to sort the packet table. */
+export type PacketSortColumn = 'index' | 'time' | 'source' | 'destination' | 'protocol' | 'length';
+export type PacketSortDirection = 'asc' | 'desc';
+
+export interface PacketSortState {
+    column: PacketSortColumn | null;
+    direction: PacketSortDirection;
+}


### PR DESCRIPTION
Promotes the packet table and packet detail inspector out of the pdump module into the shared web core, so other packet-display surfaces can reuse them as generic, capture-agnostic components.

- Adds a shared, virtualized packet table and a collapsible packet inspector under the web core, operating on a generic packet-row shape.
- Refactors the pdump page to adapt its captured packets onto the shared components and inject its capture metadata through the inspector's optional section.
- Keeps the pdump capture section collapsible and consistent with the protocol sections; the capture timestamp now reads as a row within that section rather than in the title bar.
- Removes the pdump-local packet table parts and dead styles left redundant by the extraction.