### PR TITLE
feat(web): add pcap file parser to core

### DIFF
--- a/web/src/core/utils/pcapFile.test.ts
+++ b/web/src/core/utils/pcapFile.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { parsePcapFile } from './pcapFile';
+
+// Build a minimal, spec-faithful pcap byte buffer wrapping the given frames.
+//
+// A real pcap stores the magic value and record lengths in the file's own byte
+// order, so endian 'le' lands the magic d4 c3 b2 a1 on disk while 'be' lands
+// a1 b2 c3 d4. magicValue selects the microsecond (default) or nanosecond
+// (0xa1b23c4d) variant.
+const buildPcap = (
+    frames: Uint8Array[],
+    endian: 'le' | 'be' = 'le',
+    magicValue = 0xa1b2c3d4,
+): Uint8Array => {
+    const little = endian === 'le';
+    const total = 24 + frames.reduce((n, frame) => n + 16 + frame.length, 0);
+    const bytes = new Uint8Array(total);
+    const view = new DataView(bytes.buffer);
+
+    view.setUint32(0, magicValue, little);
+
+    let offset = 24;
+    for (const frame of frames) {
+        view.setUint32(offset + 8, frame.length, little);
+        view.setUint32(offset + 12, frame.length, little);
+        offset += 16;
+        bytes.set(frame, offset);
+        offset += frame.length;
+    }
+    return bytes;
+};
+
+describe('parsePcapFile', () => {
+    it('parses little-endian frames preserving bytes and order', () => {
+        const frames = [new Uint8Array([1, 2, 3]), new Uint8Array([9, 8, 7, 6])];
+        const parsed = parsePcapFile(buildPcap(frames, 'le'));
+        expect(parsed).toHaveLength(2);
+        expect(Array.from(parsed[0])).toEqual([1, 2, 3]);
+        expect(Array.from(parsed[1])).toEqual([9, 8, 7, 6]);
+    });
+
+    it('parses big-endian frames', () => {
+        const parsed = parsePcapFile(buildPcap([new Uint8Array([0xaa, 0xbb])], 'be'));
+        expect(parsed).toHaveLength(1);
+        expect(Array.from(parsed[0])).toEqual([0xaa, 0xbb]);
+    });
+
+    it('parses a nanosecond-timestamp capture', () => {
+        const parsed = parsePcapFile(buildPcap([new Uint8Array([5, 6, 7])], 'le', 0xa1b23c4d));
+        expect(parsed).toHaveLength(1);
+        expect(Array.from(parsed[0])).toEqual([5, 6, 7]);
+    });
+
+    it('returns no frames for a header-only file', () => {
+        expect(parsePcapFile(buildPcap([]))).toHaveLength(0);
+    });
+
+    it('stops at a truncated trailing record instead of overreading', () => {
+        const full = buildPcap([new Uint8Array([1, 2, 3, 4])]);
+        // Drop the last two payload bytes: the record claims 4 but only 2 remain.
+        const truncated = full.slice(0, full.length - 2);
+        expect(parsePcapFile(truncated)).toHaveLength(0);
+    });
+
+    it('throws on a buffer shorter than the global header', () => {
+        expect(() => parsePcapFile(new Uint8Array(10))).toThrow(/global header/);
+    });
+
+    it('throws on an unrecognised magic number', () => {
+        const bytes = new Uint8Array(24);
+        new DataView(bytes.buffer).setUint32(0, 0x12345678, false);
+        expect(() => parsePcapFile(bytes)).toThrow(/magic/i);
+    });
+});

--- a/web/src/core/utils/pcapFile.ts
+++ b/web/src/core/utils/pcapFile.ts
@@ -1,0 +1,65 @@
+// pcap global-header magic as seen by a big-endian read of the first four
+// bytes.
+//
+// The canonical value is 0xa1b2c3d4. A big-endian file stores it as the bytes
+// a1 b2 c3 d4, so a big-endian read yields 0xa1b2c3d4; a little-endian file
+// stores it byte-swapped as d4 c3 b2 a1, yielding 0xd4c3b2a1. The 0xa1b23c4d
+// pair is the nanosecond-timestamp variant.
+const MAGIC_MICRO_BE = 0xa1b2c3d4;
+const MAGIC_MICRO_LE = 0xd4c3b2a1;
+const MAGIC_NANO_BE = 0xa1b23c4d;
+const MAGIC_NANO_LE = 0x4d3cb2a1;
+
+const PCAP_GLOBAL_HEADER_BYTES = 24;
+const PCAP_RECORD_HEADER_BYTES = 16;
+
+/**
+ * Parse a raw .pcap file buffer and return an array of per-frame Uint8Arrays.
+ *
+ * Supports both little-endian and big-endian pcap files, and both microsecond
+ * and nanosecond timestamp variants.  Throws a descriptive Error if the magic
+ * number is not recognised or the buffer is truncated.
+ */
+export const parsePcapFile = (bytes: Uint8Array): Uint8Array[] => {
+    if (bytes.length < PCAP_GLOBAL_HEADER_BYTES) {
+        throw new Error('File is too short to be a valid pcap (need at least 24 bytes for the global header).');
+    }
+
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const magic = view.getUint32(0, false);
+
+    let littleEndian: boolean;
+    if (magic === MAGIC_MICRO_LE || magic === MAGIC_NANO_LE) {
+        littleEndian = true;
+    } else if (magic === MAGIC_MICRO_BE || magic === MAGIC_NANO_BE) {
+        littleEndian = false;
+    } else {
+        throw new Error(
+            `Unrecognised pcap magic 0x${magic.toString(16).padStart(8, '0')}. ` +
+            'Expected 0xa1b2c3d4 / 0xd4c3b2a1 (microsecond) or ' +
+            '0xa1b23c4d / 0x4d3cb2a1 (nanosecond).'
+        );
+    }
+
+    const frames: Uint8Array[] = [];
+    let offset = PCAP_GLOBAL_HEADER_BYTES;
+
+    while (offset < bytes.length) {
+        if (offset + PCAP_RECORD_HEADER_BYTES > bytes.length) {
+            break;
+        }
+
+        const inclLen = view.getUint32(offset + 8, littleEndian);
+
+        offset += PCAP_RECORD_HEADER_BYTES;
+
+        if (offset + inclLen > bytes.length) {
+            break;
+        }
+
+        frames.push(bytes.slice(offset, offset + inclLen));
+        offset += inclLen;
+    }
+
+    return frames;
+};


### PR DESCRIPTION
Adds a shared web-core utility that parses a raw .pcap byte buffer into its per-frame payloads.

- Supports little- and big-endian captures and both microsecond and nanosecond timestamp variants.
- Fails with a descriptive error on an unrecognised magic number or a buffer too short for the global header, and stops cleanly at a truncated trailing record.
- Covered by unit tests for the parsing, endianness, and malformed-input paths.