### PR TITLE
feat(controlplane): park retired devices instead of freeing on registry removal

### DIFF
--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -12,6 +12,7 @@ struct dp_config;
 struct cp_config;
 
 struct cp_module;
+struct cp_device;
 
 struct agent;
 
@@ -46,6 +47,15 @@ struct agent {
 	struct agent_storage *storage;
 
 	struct cp_module *unused_module;
+
+	// Devices unlinked from a config generation but not yet reclaimed.
+	//
+	// Like unused_module, a replaced/deleted device is parked here by its
+	// creating agent instead of being freed when it leaves the registry.
+	//
+	// The owning control plane drains this list once the retiring
+	// generation no longer references the device.
+	struct cp_device *unused_device;
 };
 
 struct dp_config *

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -331,8 +331,32 @@ cp_device_registry_item_free_cb(struct registry_item *item, void *data) {
 	(void)data;
 	struct cp_device *device =
 		container_of(item, struct cp_device, config_item);
-	cp_device_fini(device);
-	cp_device_free(device);
+
+	// Registry membership is not ownership: a device leaving the registry
+	// is not freed here.
+	//
+	// Another control plane may still reference this device through a
+	// shared generation, so freeing now would leave it a dangling pointer.
+	// Park the device on its creating agent's unused_device list instead;
+	// the agent reclaims it once no live generation references it.
+	struct agent *agent = ADDR_OF(&device->agent);
+	SET_OFFSET_OF(&device->prev, agent->unused_device);
+	SET_OFFSET_OF(&agent->unused_device, device);
+}
+
+void
+cp_device_agent_drain_unused(struct agent *agent, cp_device_free_fn free_fn) {
+	// Detach the whole list first so a device's own free cannot observe a
+	// half-walked list.
+	struct cp_device *device = ADDR_OF(&agent->unused_device);
+	SET_OFFSET_OF(&agent->unused_device, NULL);
+
+	while (device != NULL) {
+		struct cp_device *prev = ADDR_OF(&device->prev);
+		SET_OFFSET_OF(&device->prev, NULL);
+		free_fn(device);
+		device = prev;
+	}
 }
 
 void

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -11,6 +11,7 @@
 #include "lib/errors/errors.h"
 
 struct agent;
+struct cp_device;
 
 struct cp_device_pipeline {
 	char name[CP_PIPELINE_NAME_LEN];
@@ -21,6 +22,14 @@ struct cp_device_entry {
 	uint64_t pipeline_count;
 	struct cp_device_pipeline pipelines[];
 };
+
+// Teardown for a device subclass, run by the owning agent when it drains its
+// unused_device list.
+//
+// Passed in-process at drain time (never stored in shared memory), so it stays
+// valid across processes and restarts. It must release the subclass's own
+// allocations, then call cp_device_fini and cp_device_free.
+typedef void (*cp_device_free_fn)(struct cp_device *self);
 
 struct cp_device {
 	// Offset pointer to the memory_context used to allocate this struct.
@@ -59,6 +68,9 @@ struct cp_device {
 	uint64_t counter_packet_tx_count;
 	uint64_t counter_packet_rx_bytes;
 	uint64_t counter_packet_tx_bytes;
+
+	// Link to the previous parked device.
+	struct cp_device *prev;
 };
 
 struct dp_config;
@@ -124,11 +136,22 @@ cp_device_init(
 	yanet_error **err
 );
 
-// Tear down resources acquired by cp_device_init.
+// Tear down the base resources acquired by cp_device_init.
 //
-// Idempotent on zero-init.
+// Base only: a subclass frees its own allocations in its cp_device_free_fn
+// before calling this. Safe to call from an init-failure rollback. Idempotent
+// on zero-init.
 void
 cp_device_fini(struct cp_device *self);
+
+// Reclaim every device parked on the agent's unused_device list.
+//
+// Detaches the list and runs free_fn on each device. Call it from the owning
+// control plane after the retiring generation no longer references the parked
+// devices (i.e. after the device-update wait-for-gen), passing the device
+// type's free function.
+void
+cp_device_agent_drain_unused(struct agent *agent, cp_device_free_fn free_fn);
 
 /*
  * Pipeline registry contains all existing devices.


### PR DESCRIPTION
A device leaving the configuration registry is no longer freed immediately. It is parked on its creating agent's unused list, mirroring how replaced modules are handled.

This removes a dangling-pointer hazard: when two control planes manage a device of the same name and one replaces the other's generation, freeing on registry removal would leave the surviving generation pointing at released memory. Parking defers reclamation to the device's creating agent.

Adds an agent-level drain primitive so the owning control plane reclaims parked devices once no live generation references them, i.e. after the device-update wait-for-gen.

This lands the core mechanism only — no device type drains yet, so until the consumers are wired a replaced device is reclaimed at agent teardown, matching the existing module behavior. Preparatory: not intended to merge until the consumer wiring lands.