### PR TITLE
refactor(web): make the Devices page device-type-agnostic via a registry

### DIFF
--- a/devices/plain/web/device.ts
+++ b/devices/plain/web/device.ts
@@ -1,0 +1,32 @@
+import { devices, toDevicePayload } from '@yanet/core/api';
+import type { BaseDevice, DeviceTypeManifest } from '@yanet/core/registry';
+import { IconPlain } from './icon';
+
+const save = async (device: BaseDevice): Promise<Record<string, unknown>> => {
+    const response = await devices.updatePlain({
+        name: device.id.name,
+        device: toDevicePayload(device.inputPipelines, device.outputPipelines),
+    });
+    if (response.error) {
+        throw new Error(response.error);
+    }
+    return {};
+};
+
+export const deviceType: DeviceTypeManifest = {
+    type: 'plain',
+    label: 'Physical',
+    pluralLabel: 'Physical',
+    navOrder: 10,
+    icon: IconPlain,
+    accentColor: 'var(--teal)',
+    kindTag: () => 'PHYSICAL',
+    typeDescription: 'physical (plain)',
+    rowSubtitle: () => '— · —',
+    parentMode: 'instances',
+    propertyRows: () => [
+        { label: 'Driver', value: '—', mono: true },
+        { label: 'PCI bus', value: '—', mono: true },
+    ],
+    save,
+};

--- a/devices/plain/web/icon.tsx
+++ b/devices/plain/web/icon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+/** NIC chip icon for physical (plain) devices. */
+export const IconPlain = ({
+    size = 16,
+    color = 'currentColor',
+}: {
+    size?: number;
+    color?: string;
+}): React.JSX.Element => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+        <rect x="3.5" y="3.5" width="9" height="9" rx="1.2" />
+        <path d="M6 3.5V2M8 3.5V2M10 3.5V2M6 14v-1.5M8 14v-1.5M10 14v-1.5M3.5 6H2M3.5 8H2M3.5 10H2M14 6h-1.5M14 8h-1.5M14 10h-1.5" />
+        <rect x="6" y="6" width="4" height="4" rx="0.5" fill={color} fillOpacity="0.18" stroke="none" />
+    </svg>
+);

--- a/devices/vlan/web/device.ts
+++ b/devices/vlan/web/device.ts
@@ -1,0 +1,58 @@
+import { devices, toDevicePayload } from '@yanet/core/api';
+import type { BaseDevice, DeviceTypeManifest } from '@yanet/core/registry';
+import { IconVlan } from './icon';
+
+interface VlanExt {
+    vlanId?: number;
+}
+
+const vlanExt = (device: BaseDevice): VlanExt =>
+    (device.ext.vlan as VlanExt | undefined) ?? {};
+
+const save = async (device: BaseDevice): Promise<Record<string, unknown>> => {
+    const { vlanId } = vlanExt(device);
+    const response = await devices.updateVlan({
+        name: device.id.name,
+        device: toDevicePayload(device.inputPipelines, device.outputPipelines),
+        vlan: vlanId ?? 0,
+    });
+    if (response.error) {
+        throw new Error(response.error);
+    }
+    return { vlanId: vlanId ?? 0 };
+};
+
+export const deviceType: DeviceTypeManifest = {
+    type: 'vlan',
+    label: 'VLAN',
+    pluralLabel: 'VLAN',
+    navOrder: 20,
+    icon: IconVlan,
+    accentColor: 'var(--violet)',
+    kindTag: (device) => {
+        const { vlanId } = vlanExt(device);
+        return `VLAN · ${vlanId ?? '—'}`;
+    },
+    typeDescription: 'logical (vlan)',
+    rowSubtitle: () => 'vlan · —',
+    rowBadge: (device) => {
+        const { vlanId } = vlanExt(device);
+        return vlanId !== undefined ? String(vlanId) : undefined;
+    },
+    parentGroupLabel: '∅ orphan VLANs',
+    propertyRows: (device) => {
+        const { vlanId } = vlanExt(device);
+        return [
+            { label: 'VLAN ID', value: vlanId !== undefined ? String(vlanId) : '—', mono: true },
+            { label: 'Parent device', value: '—', mono: true },
+        ];
+    },
+    createDefaults: () => ({ vlanId: 0 }),
+    extDirty: (device, snapshot) => {
+        const current = vlanExt(device);
+        const clean = snapshot ? vlanExt(snapshot) : undefined;
+        return device.isNew || (clean != null && current.vlanId !== clean.vlanId);
+    },
+    diffYaml: (device) => ({ vlan_id: vlanExt(device).vlanId ?? 0 }),
+    save,
+};

--- a/devices/vlan/web/icon.tsx
+++ b/devices/vlan/web/icon.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+/** Stacked-tag icon for VLAN (logical) devices. */
+export const IconVlan = ({
+    size = 16,
+    color = 'currentColor',
+}: {
+    size?: number;
+    color?: string;
+}): React.JSX.Element => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M2.5 5.5L5.5 2.5H10.5L13.5 5.5V10.5L10.5 13.5H5.5L2.5 10.5Z" opacity="0.35" />
+        <path d="M4.5 7.5L7 5H11.5L13.5 7V11L11.5 13.5H7L4.5 11Z" fill={color} fillOpacity="0.12" />
+        <circle cx="10.5" cy="9" r="0.9" fill={color} stroke="none" />
+    </svg>
+);

--- a/web/builtin/devices/DeviceDetails.tsx
+++ b/web/builtin/devices/DeviceDetails.tsx
@@ -1,7 +1,5 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import React, { useState, useCallback, useEffect, useMemo, lazy, Suspense } from 'react';
 import {
-    IconPlain,
-    IconVlan,
     IconHdd,
     IconArrowDown,
     IconArrowUp,
@@ -11,6 +9,7 @@ import { DeviceDiffModal } from './components/DeviceDiffModal';
 import { BigSpark } from './components/BigSpark';
 import { formatBps, formatPps } from '@yanet/core/utils';
 import { PipelineTable } from './PipelineTable';
+import { deviceTypeManifest } from '@yanet/core/registry';
 import type { LocalDevice } from './types';
 import type { PipelineId } from '@yanet/core/api/pipelines';
 import type { DevicePipeline } from '@yanet/core/api/devices';
@@ -20,6 +19,7 @@ import type { CounterHistoryEntry } from '@yanet/core/hooks/useCounterHistory';
 export interface DeviceDetailsProps {
     device: LocalDevice | null;
     loadPipelineList: () => Promise<PipelineId[]>;
+    loadDeviceExt: (device: LocalDevice) => Promise<void>;
     counterData: DeviceCounterData | undefined;
     history: CounterHistoryEntry | undefined;
     onUpdate: (updates: Partial<LocalDevice>) => void;
@@ -80,9 +80,186 @@ const PropCell = ({ label, value, mono = false }: PropCellProps): React.JSX.Elem
     </div>
 );
 
+interface DeviceMetricsProps {
+    deviceId: string;
+    counterData: DeviceCounterData | undefined;
+    history: CounterHistoryEntry | undefined;
+}
+
+// Live RX/TX metric grid for the selected device.
+//
+// This is the only part of the detail panel that consumes interpolated
+// counters, which refresh on every animation frame. Keeping it in its own
+// component lets the compiler skip re-rendering the heavier config sections
+// (DeviceBody) when only the counters tick.
+const DeviceMetrics = ({ deviceId, counterData, history }: DeviceMetricsProps): React.JSX.Element => {
+    const rxPps = counterData?.rx.pps ?? 0;
+    const rxBps = counterData?.rx.bps ?? 0;
+    const txPps = counterData?.tx.pps ?? 0;
+    const txBps = counterData?.tx.bps ?? 0;
+
+    const rxPpsHistory = history?.rx ?? [];
+    const txPpsHistory = history?.tx ?? [];
+    const rxBpsHistory = history?.rxBytes ?? [];
+    const txBpsHistory = history?.txBytes ?? [];
+
+    return (
+        <div className="dv-metric-grid">
+            <MetricBlock
+                subLabel="packets / sec"
+                isRx={true}
+                isPps={true}
+                value={rxPps}
+                deviceId={deviceId}
+                series="rx-pps"
+                color="var(--teal)"
+                history={rxPpsHistory}
+            />
+            <MetricBlock
+                subLabel="bytes / sec"
+                isRx={true}
+                isPps={false}
+                value={rxBps}
+                deviceId={deviceId}
+                series="rx-bps"
+                color="var(--teal)"
+                history={rxBpsHistory}
+            />
+            <MetricBlock
+                subLabel="packets / sec"
+                isRx={false}
+                isPps={true}
+                value={txPps}
+                deviceId={deviceId}
+                series="tx-pps"
+                color="var(--blue)"
+                history={txPpsHistory}
+            />
+            <MetricBlock
+                subLabel="bytes / sec"
+                isRx={false}
+                isPps={false}
+                value={txBps}
+                deviceId={deviceId}
+                series="tx-bps"
+                color="var(--blue)"
+                history={txBpsHistory}
+            />
+        </div>
+    );
+};
+
+interface DeviceBodyProps {
+    device: LocalDevice;
+    availablePipelines: PipelineId[];
+    loadingPipelines: boolean;
+    onUpdate: (updates: Partial<LocalDevice>) => void;
+}
+
+// Static config sections of the detail panel: counters, properties, pipelines,
+// and the type-specific detail extension.
+//
+// None of these depend on the live counters, so the compiler keeps this subtree
+// mounted across counter ticks and only re-renders it on an actual edit.
+const DeviceBody = ({
+    device,
+    availablePipelines,
+    loadingPipelines,
+    onUpdate,
+}: DeviceBodyProps): React.JSX.Element => {
+    const manifest = deviceTypeManifest(device.type);
+    const extraRows = manifest?.propertyRows?.(device) ?? [];
+
+    const Detail = useMemo(() => {
+        const loader = deviceTypeManifest(device.type)?.loadDetail;
+        return loader ? lazy(loader) : null;
+    }, [device.type]);
+
+    const handleInputPipelinesChange = useCallback((pipelines: DevicePipeline[]) => {
+        onUpdate({ inputPipelines: pipelines });
+    }, [onUpdate]);
+
+    const handleOutputPipelinesChange = useCallback((pipelines: DevicePipeline[]) => {
+        onUpdate({ outputPipelines: pipelines });
+    }, [onUpdate]);
+
+    const handleUpdateExt = useCallback((patch: Record<string, unknown>) => {
+        const current = (device.ext[device.type] as Record<string, unknown> | undefined) ?? {};
+        onUpdate({ ext: { ...device.ext, [device.type]: { ...current, ...patch } } });
+    }, [onUpdate, device.ext, device.type]);
+
+    return (
+        <>
+            <div className="dv-section">
+                <div className="dv-section-hd"><span>Counters</span></div>
+                <div className="dv-err-strip">
+                    <div className="dv-err-chip">
+                        <span className="dv-err-chip-lbl">Errors</span>
+                        <span className="dv-err-chip-val mono">0</span>
+                    </div>
+                    <div className="dv-err-chip">
+                        <span className="dv-err-chip-lbl">Drops</span>
+                        <span className="dv-err-chip-val mono">0</span>
+                    </div>
+                    <div className="dv-err-chip">
+                        <span className="dv-err-chip-lbl">Discards</span>
+                        <span className="dv-err-chip-val mono">0</span>
+                    </div>
+                </div>
+            </div>
+
+            <div className="dv-section">
+                <div className="dv-section-hd"><span>Properties</span></div>
+                <div className="dv-prop-grid">
+                    <PropCell label="MAC address" value="—" mono />
+                    <PropCell label="MTU" value="—" mono />
+                    {extraRows.map(row => (
+                        <PropCell key={row.label} label={row.label} value={row.value} mono={row.mono} />
+                    ))}
+                    <PropCell label="NUMA node" value="—" mono />
+                    <PropCell label="Type" value={manifest?.typeDescription ?? device.type} />
+                </div>
+            </div>
+
+            <div className="dv-section">
+                <div className="dv-section-hd"><span>Pipelines</span></div>
+                <div className="dv-pipe-cols">
+                    <PipelineTable
+                        pipelineLabel="RX Pipeline"
+                        pipelines={device.inputPipelines}
+                        availablePipelines={availablePipelines}
+                        loadingPipelines={loadingPipelines}
+                        color="var(--teal)"
+                        onChange={handleInputPipelinesChange}
+                    />
+                    <PipelineTable
+                        pipelineLabel="TX Pipeline"
+                        pipelines={device.outputPipelines}
+                        availablePipelines={availablePipelines}
+                        loadingPipelines={loadingPipelines}
+                        color="var(--blue)"
+                        onChange={handleOutputPipelinesChange}
+                    />
+                </div>
+            </div>
+
+            {Detail && (
+                <Suspense fallback={null}>
+                    <Detail
+                        device={device}
+                        ext={device.ext[device.type]}
+                        onUpdateExt={handleUpdateExt}
+                    />
+                </Suspense>
+            )}
+        </>
+    );
+};
+
 export const DeviceDetails: React.FC<DeviceDetailsProps> = ({
     device,
     loadPipelineList,
+    loadDeviceExt,
     counterData,
     history,
     onUpdate,
@@ -105,9 +282,27 @@ export const DeviceDetails: React.FC<DeviceDetailsProps> = ({
         load();
     }, [device, loadPipelineList]);
 
-    const handleSaveClick = useCallback(() => {
+    // Lazily hydrate the device's type-specific ext the first time it opens.
+    useEffect(() => {
+        if (device && !device.loaded) {
+            loadDeviceExt(device);
+        }
+    }, [device, loadDeviceExt]);
+
+    const handleSaveClick = useCallback(async () => {
+        // A type that opts out of the diff modal commits whatever changed
+        // directly (e.g. rate or uploaded frames that are not part of the YAML).
+        if (device && deviceTypeManifest(device.type)?.confirmViaDiff === false) {
+            setSaving(true);
+            try {
+                await onSave();
+            } finally {
+                setSaving(false);
+            }
+            return;
+        }
         setDiffOpen(true);
-    }, []);
+    }, [device, onSave]);
 
     const handleDiffApply = useCallback(async (): Promise<void> => {
         setSaving(true);
@@ -125,19 +320,6 @@ export const DeviceDetails: React.FC<DeviceDetailsProps> = ({
         setDiffOpen(false);
     }, []);
 
-    const handleInputPipelinesChange = useCallback((pipelines: DevicePipeline[]) => {
-        onUpdate({ inputPipelines: pipelines });
-    }, [onUpdate]);
-
-    const handleOutputPipelinesChange = useCallback((pipelines: DevicePipeline[]) => {
-        onUpdate({ outputPipelines: pipelines });
-    }, [onUpdate]);
-
-    const rxPpsHistory = useMemo(() => history?.rx ?? [], [history]);
-    const txPpsHistory = useMemo(() => history?.tx ?? [], [history]);
-    const rxBpsHistory = useMemo(() => history?.rxBytes ?? [], [history]);
-    const txBpsHistory = useMemo(() => history?.txBytes ?? [], [history]);
-
     if (!device) {
         return (
             <div className="dv-detail dv-detail-empty">
@@ -154,13 +336,11 @@ export const DeviceDetails: React.FC<DeviceDetailsProps> = ({
         );
     }
 
-    const isVlan = device.type === 'vlan';
+    const manifest = deviceTypeManifest(device.type);
+    const Icon = manifest?.icon;
     const name = device.id.name || '';
-    const iconColor = isVlan ? 'var(--violet)' : 'var(--teal)';
-    const rxPps = counterData?.rx.pps ?? 0;
-    const rxBps = counterData?.rx.bps ?? 0;
-    const txPps = counterData?.tx.pps ?? 0;
-    const txBps = counterData?.tx.bps ?? 0;
+    const iconColor = manifest?.accentColor ?? 'var(--teal)';
+    const kindTag = manifest?.kindTag(device) ?? device.type.toUpperCase();
     const canSave = (device.isDirty || device.isNew) && !saving;
     const serverDevice = name ? getServerDevice(name) : null;
 
@@ -169,13 +349,13 @@ export const DeviceDetails: React.FC<DeviceDetailsProps> = ({
             <div className="dv-detail-hd">
                 <div className="dv-detail-hd-left">
                     <span className="dv-detail-icon" style={{ color: iconColor }}>
-                        {isVlan ? <IconVlan size={20} /> : <IconPlain size={20} />}
+                        {Icon && <Icon size={20} />}
                     </span>
                     <div className="dv-detail-title-wrap">
                         <div className="dv-detail-title">
                             <span className="dv-detail-name">{name}</span>
-                            <span className={"dv-kind-tag " + (isVlan ? 'kind-vlan' : 'kind-plain')}>
-                                {isVlan ? "VLAN · " + (device.vlanId ?? '—') : 'PHYSICAL'}
+                            <span className={"dv-kind-tag kind-" + device.type}>
+                                {kindTag}
                             </span>
                             {(device.isDirty || device.isNew) && (
                                 <span className="dv-unsaved">unsaved changes</span>
@@ -187,11 +367,7 @@ export const DeviceDetails: React.FC<DeviceDetailsProps> = ({
                                 Link unknown
                             </span>
                             <span className="dv-meta-sep">·</span>
-                            {isVlan ? (
-                                <span className="muted">no parent</span>
-                            ) : (
-                                <span>— · —</span>
-                            )}
+                            <span>— · —</span>
                             <span className="dv-meta-sep">·</span>
                             <span>NUMA —</span>
                         </div>
@@ -210,109 +386,13 @@ export const DeviceDetails: React.FC<DeviceDetailsProps> = ({
             </div>
 
             <div className="dv-detail-scroll">
-                <div className="dv-metric-grid">
-                    <MetricBlock
-                        subLabel="packets / sec"
-                        isRx={true}
-                        isPps={true}
-                        value={rxPps}
-                        deviceId={name}
-                        series="rx-pps"
-                        color="var(--teal)"
-                        history={rxPpsHistory}
-                    />
-                    <MetricBlock
-                        subLabel="bytes / sec"
-                        isRx={true}
-                        isPps={false}
-                        value={rxBps}
-                        deviceId={name}
-                        series="rx-bps"
-                        color="var(--teal)"
-                        history={rxBpsHistory}
-                    />
-                    <MetricBlock
-                        subLabel="packets / sec"
-                        isRx={false}
-                        isPps={true}
-                        value={txPps}
-                        deviceId={name}
-                        series="tx-pps"
-                        color="var(--blue)"
-                        history={txPpsHistory}
-                    />
-                    <MetricBlock
-                        subLabel="bytes / sec"
-                        isRx={false}
-                        isPps={false}
-                        value={txBps}
-                        deviceId={name}
-                        series="tx-bps"
-                        color="var(--blue)"
-                        history={txBpsHistory}
-                    />
-                </div>
-
-                <div className="dv-section">
-                    <div className="dv-section-hd"><span>Counters</span></div>
-                    <div className="dv-err-strip">
-                        <div className="dv-err-chip">
-                            <span className="dv-err-chip-lbl">Errors</span>
-                            <span className="dv-err-chip-val mono">0</span>
-                        </div>
-                        <div className="dv-err-chip">
-                            <span className="dv-err-chip-lbl">Drops</span>
-                            <span className="dv-err-chip-val mono">0</span>
-                        </div>
-                        <div className="dv-err-chip">
-                            <span className="dv-err-chip-lbl">Discards</span>
-                            <span className="dv-err-chip-val mono">0</span>
-                        </div>
-                    </div>
-                </div>
-
-                <div className="dv-section">
-                    <div className="dv-section-hd"><span>Properties</span></div>
-                    <div className="dv-prop-grid">
-                        <PropCell label="MAC address" value="—" mono />
-                        <PropCell label="MTU" value="—" mono />
-                        {isVlan ? (
-                            <>
-                                <PropCell label="VLAN ID" value={device.vlanId !== undefined ? String(device.vlanId) : '—'} mono />
-                                <PropCell label="Parent device" value="—" mono />
-                            </>
-                        ) : (
-                            <>
-                                <PropCell label="Driver" value="—" mono />
-                                <PropCell label="PCI bus" value="—" mono />
-                            </>
-                        )}
-                        <PropCell label="NUMA node" value="—" mono />
-                        <PropCell label="Type" value={isVlan ? 'logical (vlan)' : 'physical (plain)'} />
-                    </div>
-                </div>
-
-                <div className="dv-section">
-                    <div className="dv-section-hd"><span>Pipelines</span></div>
-                    <div className="dv-pipe-cols">
-                        <PipelineTable
-                            pipelineLabel="RX Pipeline"
-                            pipelines={device.inputPipelines}
-                            availablePipelines={availablePipelines}
-                            loadingPipelines={loadingPipelines}
-                            color="var(--teal)"
-                            onChange={handleInputPipelinesChange}
-                        />
-                        <PipelineTable
-                            pipelineLabel="TX Pipeline"
-                            pipelines={device.outputPipelines}
-                            availablePipelines={availablePipelines}
-                            loadingPipelines={loadingPipelines}
-                            color="var(--blue)"
-                            onChange={handleOutputPipelinesChange}
-                        />
-                    </div>
-                </div>
+                <DeviceMetrics deviceId={name} counterData={counterData} history={history} />
+                <DeviceBody
+                    device={device}
+                    availablePipelines={availablePipelines}
+                    loadingPipelines={loadingPipelines}
+                    onUpdate={onUpdate}
+                />
             </div>
 
             {diffOpen && (

--- a/web/builtin/devices/DeviceListItem.tsx
+++ b/web/builtin/devices/DeviceListItem.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { IconPlain, IconVlan } from './components/Icons';
 import { MiniSpark } from './components/MiniSpark';
 import { formatPps } from '@yanet/core/utils';
+import { deviceTypeManifest } from '@yanet/core/registry';
 import type { LocalDevice } from './types';
 import type { CounterHistoryEntry } from '@yanet/core/hooks/useCounterHistory';
 import type { DeviceCounterData } from '@yanet/core/hooks/useDeviceCounters';
@@ -21,8 +21,11 @@ export const DeviceListItem: React.FC<DeviceListItemProps> = ({
     history,
     onClick,
 }) => {
-    const isVlan = device.type === 'vlan';
-    const iconColor = isVlan ? 'var(--violet)' : 'var(--teal)';
+    const manifest = deviceTypeManifest(device.type);
+    const Icon = manifest?.icon;
+    const iconColor = manifest?.accentColor ?? 'var(--teal)';
+    const badge = manifest?.rowBadge?.(device);
+    const subtitle = manifest?.rowSubtitle?.(device) ?? '— · —';
     const name = device.id.name || '';
     const rxPps = counterData?.rx.pps ?? 0;
     const txPps = counterData?.tx.pps ?? 0;
@@ -36,23 +39,17 @@ export const DeviceListItem: React.FC<DeviceListItemProps> = ({
             onClick={onClick}
         >
             <span className="dv-row-icon" style={{ color: iconColor }}>
-                {isVlan ? <IconVlan /> : <IconPlain />}
+                {Icon && <Icon />}
             </span>
 
             <span className="dv-row-main">
                 <span className="dv-row-name">
                     <span className="dv-row-name-text">{name}</span>
-                    {isVlan && device.vlanId !== undefined && (
-                        <span className="dv-vid">{device.vlanId}</span>
+                    {badge !== undefined && (
+                        <span className="dv-vid">{badge}</span>
                     )}
                 </span>
-                <span className="dv-row-sub">
-                    {isVlan ? (
-                        <>vlan · <span className="muted">—</span></>
-                    ) : (
-                        <>— · —</>
-                    )}
-                </span>
+                <span className="dv-row-sub">{subtitle}</span>
             </span>
 
             <span className="dv-row-spark">

--- a/web/builtin/devices/DevicesList.tsx
+++ b/web/builtin/devices/DevicesList.tsx
@@ -1,11 +1,13 @@
 import React, { useMemo } from 'react';
 import { DeviceListItem } from './DeviceListItem';
 import { IconStack } from './components/Icons';
+import { deviceTypes } from '@yanet/core/registry';
 import type { LocalDevice } from './types';
 import type { CounterHistoryEntry } from '@yanet/core/hooks/useCounterHistory';
 import type { DeviceCounterData } from '@yanet/core/hooks/useDeviceCounters';
 
-export type FilterKind = 'all' | 'plain' | 'vlan';
+// Active device-type filter: 'all', or a registered device type.
+export type FilterKind = string;
 type GroupingMode = 'flat' | 'type' | 'parent';
 
 export interface DevicesListProps {
@@ -33,30 +35,28 @@ const nextGrouping = (current: GroupingMode): GroupingMode => {
 };
 
 export const filterDevices = (devices: LocalDevice[], filter: FilterKind): LocalDevice[] =>
-    devices.filter(d => {
-        if (filter === 'plain' && d.type !== 'plain') return false;
-        if (filter === 'vlan' && d.type !== 'vlan') return false;
-        return true;
-    });
+    filter === 'all' ? devices : devices.filter(d => d.type === filter);
 
 export const buildGroups = (devices: LocalDevice[], grouping: GroupingMode): DeviceGroup[] => {
     if (grouping === 'type') {
-        return [
-            { key: 'plain', label: 'Physical', items: devices.filter(d => d.type === 'plain') },
-            { key: 'vlan', label: 'VLAN', items: devices.filter(d => d.type === 'vlan') },
-        ].filter(g => g.items.length > 0);
+        return deviceTypes
+            .map(m => ({ key: m.type, label: m.pluralLabel, items: devices.filter(d => d.type === m.type) }))
+            .filter(g => g.items.length > 0);
     }
     if (grouping === 'parent') {
-        // Plain devices each get their own group; all vlans go under one group.
+        // Types with parentMode 'instances' get one group per device; the rest
+        // collapse into a single group under their parent label.
         const groups: DeviceGroup[] = [];
-        for (const d of devices) {
-            if (d.type === 'plain') {
-                groups.push({ key: d.id.name || '', label: d.id.name || '', items: [d] });
+        for (const m of deviceTypes) {
+            const items = devices.filter(d => d.type === m.type);
+            if (items.length === 0) continue;
+            if (m.parentMode === 'instances') {
+                for (const d of items) {
+                    groups.push({ key: d.id.name || '', label: d.id.name || '', items: [d] });
+                }
+            } else {
+                groups.push({ key: m.type, label: m.parentGroupLabel ?? m.pluralLabel, items });
             }
-        }
-        const vlans = devices.filter(d => d.type === 'vlan');
-        if (vlans.length > 0) {
-            groups.push({ key: 'vlan', label: '∅ orphan VLANs', items: vlans });
         }
         return groups;
     }
@@ -75,11 +75,18 @@ export const DevicesList: React.FC<DevicesListProps> = ({
     onFilterChange,
 }) => {
 
-    const counts = useMemo(() => ({
-        all: devices.length,
-        plain: devices.filter(d => d.type === 'plain').length,
-        vlan: devices.filter(d => d.type === 'vlan').length,
-    }), [devices]);
+    const counts = useMemo(() => {
+        const byType: Record<string, number> = {};
+        for (const m of deviceTypes) {
+            byType[m.type] = 0;
+        }
+        for (const d of devices) {
+            if (byType[d.type] !== undefined) {
+                byType[d.type] += 1;
+            }
+        }
+        return { all: devices.length, byType };
+    }, [devices]);
 
     const filtered = useMemo(() => filterDevices(devices, filter), [devices, filter]);
 
@@ -87,15 +94,18 @@ export const DevicesList: React.FC<DevicesListProps> = ({
 
     const chipDefs: [FilterKind, string, number][] = [
         ['all', 'All', counts.all],
-        ['plain', 'Physical', counts.plain],
-        ['vlan', 'VLAN', counts.vlan],
+        ...deviceTypes.map(m => [m.type, m.pluralLabel, counts.byType[m.type] ?? 0] as [FilterKind, string, number]),
     ];
+
+    const summary = deviceTypes
+        .map(m => `${counts.byType[m.type] ?? 0} ${m.pluralLabel.toLowerCase()}`)
+        .join(' · ');
 
     return (
         <div className="dv-list">
             <div className="dv-list-hd">
                 <div className="dv-list-counts">
-                    {counts.plain} physical · {counts.vlan} vlan
+                    {summary}
                 </div>
                 <div className="dv-filter-row">
                     <div className="dv-chips">

--- a/web/builtin/devices/DevicesPage.tsx
+++ b/web/builtin/devices/DevicesPage.tsx
@@ -4,6 +4,7 @@ import { Button, Icon } from '@gravity-ui/uikit';
 import { Plus } from '@gravity-ui/icons';
 import { useSearchParamHelpers, useListNavigation, usePageContribution, useUnsavedChangesBlocker } from '@yanet/core/hooks';
 import { PageLayout, PageLoader, EmptyState, CommandPaletteHeader } from '@yanet/core/components';
+import { deviceTypeManifest } from '@yanet/core/registry';
 import type { DeviceType } from '@yanet/core/api/devices';
 import type { LocalDevice } from './types';
 import { useDeviceCounters } from '@yanet/core/hooks';
@@ -33,6 +34,7 @@ const DevicesPage: React.FC = () => {
         updateDevice,
         saveDevice,
         loadPipelineList,
+        loadDeviceExt,
         getServerDevice,
     } = useDeviceData();
 
@@ -172,10 +174,8 @@ const DevicesPage: React.FC = () => {
         rows: devices,
         getId: (d) => d.id.name || '',
         getLabel: (d) => d.id.name || '(unnamed)',
-        getSub: (d) => d.type === 'vlan'
-            ? `vlan${d.vlanId !== undefined ? ' · ' + d.vlanId : ''}`
-            : 'physical',
-        searchText: (d) => [d.id.name, d.type, d.vlanId].filter(Boolean).join(' '),
+        getSub: (d) => deviceTypeManifest(d.type)?.label.toLowerCase() ?? d.type,
+        searchText: (d) => [d.id.name, d.type].filter(Boolean).join(' '),
         onSelect: (id) => { setDeviceFilter('all'); handleSelectDevice(id); },
         icon: '→',
     }), [devices, handleSelectDevice]);
@@ -237,6 +237,7 @@ const DevicesPage: React.FC = () => {
                         <DeviceDetails
                             device={selectedDevice}
                             loadPipelineList={loadPipelineList}
+                            loadDeviceExt={loadDeviceExt}
                             counterData={selectedCounterData}
                             history={selectedHistory}
                             onUpdate={handleUpdateDevice}

--- a/web/builtin/devices/components/DeviceDiffModal.tsx
+++ b/web/builtin/devices/components/DeviceDiffModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { LocalDevice } from '../types';
 import { SaveDiffModal } from '@yanet/core/components';
+import { deviceTypeManifest } from '@yanet/core/registry';
 import { dumpYamlDoc } from '@yanet/core/utils';
 
 export interface DeviceDiffModalProps {
@@ -10,24 +11,14 @@ export interface DeviceDiffModalProps {
     onApply: () => Promise<void>;
 }
 
-interface DeviceYaml {
-    name: string;
-    type: string;
-    vlan_id?: number;
-    input_pipelines: { name: string; weight: number }[];
-    output_pipelines: { name: string; weight: number }[];
-}
-
 const toYaml = (device: LocalDevice): string => {
-    const obj: DeviceYaml = {
+    const obj: Record<string, unknown> = {
         name: device.id.name || '',
         type: device.type,
         input_pipelines: device.inputPipelines.map(p => ({ name: p.name || '', weight: typeof p.weight === 'number' ? p.weight : parseInt(String(p.weight), 10) || 0 })),
         output_pipelines: device.outputPipelines.map(p => ({ name: p.name || '', weight: typeof p.weight === 'number' ? p.weight : parseInt(String(p.weight), 10) || 0 })),
+        ...(deviceTypeManifest(device.type)?.diffYaml?.(device) ?? {}),
     };
-    if (device.type === 'vlan') {
-        obj.vlan_id = device.vlanId ?? 0;
-    }
     return dumpYamlDoc(obj);
 };
 

--- a/web/builtin/devices/components/Icons.tsx
+++ b/web/builtin/devices/components/Icons.tsx
@@ -1,23 +1,5 @@
 import React from 'react';
 
-/** NIC chip icon for physical (plain) devices. */
-export const IconPlain = ({ size = 16, color = 'currentColor' }: { size?: number; color?: string }): React.JSX.Element => (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-        <rect x="3.5" y="3.5" width="9" height="9" rx="1.2" />
-        <path d="M6 3.5V2M8 3.5V2M10 3.5V2M6 14v-1.5M8 14v-1.5M10 14v-1.5M3.5 6H2M3.5 8H2M3.5 10H2M14 6h-1.5M14 8h-1.5M14 10h-1.5" />
-        <rect x="6" y="6" width="4" height="4" rx="0.5" fill={color} fillOpacity="0.18" stroke="none" />
-    </svg>
-);
-
-/** Stacked-tag icon for VLAN (logical) devices. */
-export const IconVlan = ({ size = 16, color = 'currentColor' }: { size?: number; color?: string }): React.JSX.Element => (
-    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M2.5 5.5L5.5 2.5H10.5L13.5 5.5V10.5L10.5 13.5H5.5L2.5 10.5Z" opacity="0.35" />
-        <path d="M4.5 7.5L7 5H11.5L13.5 7V11L11.5 13.5H7L4.5 11Z" fill={color} fillOpacity="0.12" />
-        <circle cx="10.5" cy="9" r="0.9" fill={color} stroke="none" />
-    </svg>
-);
-
 /** Warning triangle icon. */
 export const IconWarning = ({ size = 12 }: { size?: number }): React.JSX.Element => (
     <svg width={size} height={size} viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2">

--- a/web/builtin/devices/dialogs/CreateDeviceDialog.tsx
+++ b/web/builtin/devices/dialogs/CreateDeviceDialog.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { Box, TextInput, Select, Text } from '@gravity-ui/uikit';
 import { FormDialog } from '@yanet/core/components';
-import { DEVICE_TYPES, type DeviceType } from '@yanet/core/api/devices';
+import type { DeviceType } from '@yanet/core/api/devices';
+import { deviceTypes } from '@yanet/core/registry';
 import '../devices.scss';
 
 export interface CreateDeviceDialogProps {
@@ -18,14 +19,14 @@ export const CreateDeviceDialog: React.FC<CreateDeviceDialogProps> = ({
     existingNames = [],
 }) => {
     const [name, setName] = useState('');
-    const [type, setType] = useState<DeviceType>('plain');
+    const [type, setType] = useState<DeviceType>(deviceTypes[0]?.type ?? '');
     const [error, setError] = useState<string | null>(null);
 
     // Reset form when dialog opens
     useEffect(() => {
         if (open) {
             setName('');
-            setType('plain');
+            setType(deviceTypes[0]?.type ?? '');
             setError(null);
         }
     }, [open]);
@@ -56,14 +57,14 @@ export const CreateDeviceDialog: React.FC<CreateDeviceDialogProps> = ({
     }, []);
 
     const handleTypeChange = useCallback((value: string[]) => {
-        if (value.length > 0 && DEVICE_TYPES.includes(value[0] as DeviceType)) {
-            setType(value[0] as DeviceType);
+        if (value.length > 0 && deviceTypes.some(m => m.type === value[0])) {
+            setType(value[0]);
         }
     }, []);
 
-    const typeOptions = DEVICE_TYPES.map(t => ({
-        value: t,
-        content: t,
+    const typeOptions = deviceTypes.map(m => ({
+        value: m.type,
+        content: m.label,
     }));
 
     return (

--- a/web/builtin/devices/hooks.ts
+++ b/web/builtin/devices/hooks.ts
@@ -1,8 +1,9 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { API } from '@yanet/core/api';
-import type { DeviceType } from '@yanet/core/api/devices';
+import { parseWeight, type DeviceType } from '@yanet/core/api/devices';
 import type { PipelineId } from '@yanet/core/api/pipelines';
 import type { InspectResponse, DeviceInfo } from '@yanet/core/api/inspect';
+import { deviceTypeManifest } from '@yanet/core/registry';
 import { toaster } from '@yanet/core/utils';
 import type { LocalDevice } from './types';
 
@@ -15,19 +16,15 @@ export interface UseDeviceDataResult {
     updateDevice: (deviceName: string, updates: Partial<LocalDevice>) => void;
     saveDevice: (device: LocalDevice) => Promise<boolean>;
     loadPipelineList: () => Promise<PipelineId[]>;
+    loadDeviceExt: (device: LocalDevice) => Promise<void>;
     getServerDevice: (name: string) => LocalDevice | null;
 }
 
-const parseWeight = (weight: string | number | undefined): number => {
-    if (weight === undefined) return 0;
-    if (typeof weight === 'number') return weight;
-    return parseInt(weight, 10) || 0;
-};
-
-/** Returns true when two LocalDevice values are structurally equal (same type, vlanId, and pipeline arrays in order). */
-const localDeviceEquals = (a: LocalDevice, b: LocalDevice): boolean => {
+// Returns true when two devices have equal type and pipeline arrays in order.
+//
+// Type-specific ext is compared separately by each type's extDirty hook.
+const pipelinesEqual = (a: LocalDevice, b: LocalDevice): boolean => {
     if (a.type !== b.type) return false;
-    if (a.vlanId !== b.vlanId) return false;
     if (a.inputPipelines.length !== b.inputPipelines.length) return false;
     if (a.outputPipelines.length !== b.outputPipelines.length) return false;
     for (let idx = 0; idx < a.inputPipelines.length; idx++) {
@@ -43,8 +40,16 @@ const localDeviceEquals = (a: LocalDevice, b: LocalDevice): boolean => {
     return true;
 };
 
+// Recompute the dirty flag across pipelines and the type-specific ext.
+const computeDirty = (device: LocalDevice, snapshot: LocalDevice | undefined): boolean => {
+    if (device.isNew || !snapshot || !pipelinesEqual(device, snapshot)) {
+        return true;
+    }
+    return deviceTypeManifest(device.type)?.extDirty?.(device, snapshot) ?? false;
+};
+
 const deviceInfoToLocal = (info: DeviceInfo): LocalDevice => {
-    const type = (info.type === 'vlan' ? 'vlan' : 'plain') as DeviceType;
+    const type = info.type ?? '';
     return {
         id: { type: info.type, name: info.name },
         type,
@@ -58,6 +63,8 @@ const deviceInfoToLocal = (info: DeviceInfo): LocalDevice => {
         })),
         isNew: false,
         isDirty: false,
+        loaded: !deviceTypeManifest(type)?.loadData,
+        ext: {},
     };
 };
 
@@ -104,14 +111,16 @@ export const useDeviceData = (): UseDeviceDataResult => {
     }, [loadDevices]);
 
     const createDevice = useCallback((name: string, type: DeviceType): void => {
+        const extDefaults = deviceTypeManifest(type)?.createDefaults?.();
         const newDevice: LocalDevice = {
             id: { type, name },
             type,
             inputPipelines: [],
             outputPipelines: [],
-            vlanId: type === 'vlan' ? 0 : undefined,
             isNew: true,
             isDirty: true,
+            loaded: true,
+            ext: extDefaults ? { [type]: extDefaults } : {},
         };
 
         setDevices(prev => [...prev, newDevice]);
@@ -124,68 +133,79 @@ export const useDeviceData = (): UseDeviceDataResult => {
         setDevices(prev => prev.map(device => {
             if (device.id.name === deviceName) {
                 const updated = { ...device, ...updates };
-                const serverSnapshot = serverSnapshotRef.current.get(deviceName);
-                const isDirty = updated.isNew
-                    || !serverSnapshot
-                    || !localDeviceEquals(updated, serverSnapshot);
-                return { ...updated, isDirty };
+                const snapshot = serverSnapshotRef.current.get(deviceName);
+                return { ...updated, isDirty: computeDirty(updated, snapshot) };
             }
             return device;
+        }));
+    }, []);
+
+    // loadDeviceExt hydrates a device's type-specific ext from the server the
+    // first time it is opened, for types that declare a loadData hook.
+    //
+    // Types without loadData and already-loaded devices are a no-op.
+    const loadDeviceExt = useCallback(async (device: LocalDevice): Promise<void> => {
+        const manifest = deviceTypeManifest(device.type);
+        if (!manifest?.loadData || device.loaded) {
+            return;
+        }
+
+        const name = device.id.name || '';
+        const ext = await manifest.loadData(device);
+
+        // Refresh the clean snapshot first so the dirty check below compares
+        // against the freshly loaded server ext, not the empty baseline.
+        const snapshot = serverSnapshotRef.current.get(name);
+        if (snapshot) {
+            const newSnapshot: LocalDevice = {
+                ...snapshot,
+                ext: { ...snapshot.ext, [device.type]: ext },
+                loaded: true,
+            };
+            serverSnapshotRef.current = new Map(serverSnapshotRef.current).set(name, newSnapshot);
+        }
+
+        setDevices(prev => prev.map(d => {
+            if (d.id.name !== name) return d;
+            const next: LocalDevice = {
+                ...d,
+                ext: { ...d.ext, [device.type]: ext },
+                loaded: true,
+            };
+            return { ...next, isDirty: computeDirty(next, serverSnapshotRef.current.get(name)) };
         }));
     }, []);
 
     const saveDevice = useCallback(async (
         device: LocalDevice
     ): Promise<boolean> => {
+        const name = device.id.name || '';
+        const manifest = deviceTypeManifest(device.type);
+        if (!manifest) {
+            toaster.error('device-save-error', `Unknown device type "${device.type}"`);
+            return false;
+        }
+
         try {
-            const devicePayload = {
-                input: device.inputPipelines.map(p => ({
-                    name: p.name,
-                    weight: parseWeight(p.weight),
-                })),
-                output: device.outputPipelines.map(p => ({
-                    name: p.name,
-                    weight: parseWeight(p.weight),
-                })),
+            const snapshot = serverSnapshotRef.current.get(name);
+            const ext = await manifest.save(device, snapshot);
+
+            const savedDevice: LocalDevice = {
+                ...device,
+                isDirty: false,
+                isNew: false,
+                loaded: true,
+                ext: { ...device.ext, [device.type]: ext },
             };
-
-            let response;
-            if (device.type === 'vlan') {
-                response = await API.devices.updateVlan({
-                    name: device.id.name,
-                    device: devicePayload,
-                    vlan: device.vlanId ?? 0,
-                });
-            } else {
-                response = await API.devices.updatePlain({
-                    name: device.id.name,
-                    device: devicePayload,
-                });
+            if (name) {
+                serverSnapshotRef.current = new Map(serverSnapshotRef.current).set(name, savedDevice);
             }
+            setDevices(prev => prev.map(d => (d.id.name === name ? savedDevice : d)));
 
-            if (response.error) {
-                throw new Error(response.error);
-            }
-
-            // Mark device as clean and update the server snapshot.
-            const savedDevice = { ...device, isDirty: false, isNew: false };
-            if (device.id.name) {
-                serverSnapshotRef.current = new Map(serverSnapshotRef.current).set(
-                    device.id.name,
-                    savedDevice,
-                );
-            }
-            setDevices(prev => prev.map(d => {
-                if (d.id.name === device.id.name) {
-                    return savedDevice;
-                }
-                return d;
-            }));
-
-            toaster.success('device-save-success', `Device "${device.id.name}" saved`);
+            toaster.success('device-save-success', `Device "${name}" saved`);
             return true;
         } catch (err) {
-            toaster.error('device-save-error', `Failed to save device "${device.id.name}"`, err);
+            toaster.error('device-save-error', `Failed to save device "${name}"`, err);
             return false;
         }
     }, []);
@@ -213,6 +233,7 @@ export const useDeviceData = (): UseDeviceDataResult => {
         updateDevice,
         saveDevice,
         loadPipelineList,
+        loadDeviceExt,
         getServerDevice,
     };
 };

--- a/web/builtin/devices/types.ts
+++ b/web/builtin/devices/types.ts
@@ -1,11 +1,1 @@
-import type { DeviceId, DevicePipeline, DeviceType } from '@yanet/core/api/devices';
-
-export interface LocalDevice {
-    id: DeviceId;
-    type: DeviceType;
-    inputPipelines: DevicePipeline[];
-    outputPipelines: DevicePipeline[];
-    vlanId?: number; // Only for vlan devices
-    isNew: boolean; // True if device was created locally but not saved yet
-    isDirty: boolean;
-}
+export type { BaseDevice as LocalDevice } from '@yanet/core/registry';

--- a/web/src/core/api/devices.ts
+++ b/web/src/core/api/devices.ts
@@ -45,9 +45,24 @@ export interface UpdateDeviceVlanResponse {
     error?: string;
 }
 
-// Device types enum
-export const DEVICE_TYPES = ['plain', 'vlan'] as const;
-export type DeviceType = typeof DEVICE_TYPES[number];
+/** Device type discriminator; the concrete set is owned by the device registry. */
+export type DeviceType = string;
+
+/** Parse a pipeline weight that may arrive as a uint64 string or a number. */
+export const parseWeight = (weight: string | number | undefined): number => {
+    if (weight === undefined) return 0;
+    if (typeof weight === 'number') return weight;
+    return parseInt(weight, 10) || 0;
+};
+
+/** Build the wire Device payload from a device's input/output pipelines. */
+export const toDevicePayload = (
+    inputPipelines: DevicePipeline[],
+    outputPipelines: DevicePipeline[],
+): Device => ({
+    input: inputPipelines.map((p) => ({ name: p.name, weight: parseWeight(p.weight) })),
+    output: outputPipelines.map((p) => ({ name: p.name, weight: parseWeight(p.weight) })),
+});
 
 const deviceService = createService('controlplane.ynpb.v1.DeviceService');
 const plainService = createService('devices.plain.controlplane.plainpb.v1.DevicePlainService');

--- a/web/src/core/registry/deviceRegistry.ts
+++ b/web/src/core/registry/deviceRegistry.ts
@@ -1,0 +1,20 @@
+import type { DeviceTypeManifest } from './deviceType';
+
+const discovered = import.meta.glob<DeviceTypeManifest>(
+    '../../../../devices/*/web/device.ts',
+    { eager: true, import: 'deviceType' },
+);
+
+/** All registered device types, ordered for list grouping and filter chips. */
+export const deviceTypes: DeviceTypeManifest[] = Object.values(discovered).sort(
+    (a, b) => a.navOrder - b.navOrder,
+);
+
+const byType = new Map<string, DeviceTypeManifest>(
+    deviceTypes.map((manifest) => [manifest.type, manifest]),
+);
+
+/** Look up the manifest for a device type, or undefined if none is registered. */
+export const deviceTypeManifest = (
+    type: string,
+): DeviceTypeManifest | undefined => byType.get(type);

--- a/web/src/core/registry/deviceType.ts
+++ b/web/src/core/registry/deviceType.ts
@@ -1,0 +1,113 @@
+import type { ComponentType } from 'react';
+import type { DeviceId, DevicePipeline } from '../api/devices';
+
+/** A device managed by the Devices page, independent of its concrete type.
+ *
+ * Type-specific editable state lives in `ext`, keyed by device type and owned
+ * by that type's plugin; the core treats it as opaque.
+ */
+export interface BaseDevice {
+    id: DeviceId;
+    type: string;
+    inputPipelines: DevicePipeline[];
+    outputPipelines: DevicePipeline[];
+    isNew: boolean;
+    isDirty: boolean;
+
+    /** True once the type-specific ext slice has been hydrated from the server.
+     *
+     * Types without a `loadData` hook are considered loaded immediately.
+     */
+    loaded: boolean;
+
+    /** Per-type editable state keyed by device type; each plugin owns its slice. */
+    ext: Record<string, unknown>;
+}
+
+/** Icon component contributed by a device type, matching the shared icon shape. */
+export type DeviceIcon = ComponentType<{ size?: number; color?: string }>;
+
+/** One row in the device Properties grid. */
+export interface DevicePropertyRow {
+    label: string;
+    value: string;
+    mono?: boolean;
+}
+
+/** Props passed to a device type's detail-panel extension component.
+ *
+ * `ext` is this device's slice for the type; `onUpdateExt` merges a patch into
+ * it without the component needing to know the surrounding device shape.
+ */
+export interface DeviceDetailProps {
+    device: BaseDevice;
+    ext: unknown;
+    onUpdateExt: (patch: Record<string, unknown>) => void;
+}
+
+/** How a device type is laid out under the "by parent" grouping.
+ *
+ * `instances` emits one group per device (e.g. physical NICs); `group` collects
+ * every device of the type into a single group.
+ */
+export type DeviceParentMode = 'group' | 'instances';
+
+/** Everything the Devices page needs to render and manage one device type.
+ *
+ * A device type registers by exporting one of these as `deviceType` from its
+ * `devices/<name>/web/device.ts`. The core discovers it at build time, so a new
+ * type plugs into the shared Devices page without any edits to the core.
+ */
+export interface DeviceTypeManifest {
+    type: string;
+    label: string;
+    pluralLabel: string;
+    navOrder: number;
+    icon: DeviceIcon;
+    accentColor: string;
+
+    /** Tag shown next to the device name, e.g. "PHYSICAL" or "VLAN · 10". */
+    kindTag: (device: BaseDevice) => string;
+
+    /** Human description for the Properties "Type" row. */
+    typeDescription: string;
+
+    /** One-line subtitle for a list row. */
+    rowSubtitle?: (device: BaseDevice) => string;
+
+    /** Small inline badge for a list row, e.g. the vlan id. */
+    rowBadge?: (device: BaseDevice) => string | undefined;
+
+    /** Grouping behaviour under the "by parent" view; defaults to `group`. */
+    parentMode?: DeviceParentMode;
+
+    /** Group label under the "by parent" view; defaults to `pluralLabel`. */
+    parentGroupLabel?: string;
+
+    /** Extra Properties rows specific to this type. */
+    propertyRows?: (device: BaseDevice) => DevicePropertyRow[];
+
+    /** Detail-panel section rendered below the shared sections, loaded lazily. */
+    loadDetail?: () => Promise<{ default: ComponentType<DeviceDetailProps> }>;
+
+    /** Seed the ext slice when a device is created locally. */
+    createDefaults?: () => Record<string, unknown>;
+
+    /** Fetch the server-side ext slice the first time the device is opened. */
+    loadData?: (device: BaseDevice) => Promise<Record<string, unknown>>;
+
+    /** Persist the device; returns the server-confirmed ext slice. */
+    save: (
+        device: BaseDevice,
+        snapshot: BaseDevice | undefined,
+    ) => Promise<Record<string, unknown>>;
+
+    /** Whether the ext slice differs from the clean snapshot. */
+    extDirty?: (device: BaseDevice, snapshot: BaseDevice | undefined) => boolean;
+
+    /** When false, Save commits directly instead of opening the YAML diff modal. */
+    confirmViaDiff?: boolean;
+
+    /** Extra keys merged into the YAML diff for this type, e.g. vlan_id. */
+    diffYaml?: (device: BaseDevice) => Record<string, unknown>;
+}

--- a/web/src/core/registry/index.ts
+++ b/web/src/core/registry/index.ts
@@ -1,1 +1,10 @@
 export type { PageManifest, NavItem, NavSection } from './manifest';
+export type {
+    BaseDevice,
+    DeviceIcon,
+    DevicePropertyRow,
+    DeviceDetailProps,
+    DeviceParentMode,
+    DeviceTypeManifest,
+} from './deviceType';
+export { deviceTypes, deviceTypeManifest } from './deviceRegistry';


### PR DESCRIPTION
Introduce a device-type registry in the web core: each device type contributes a manifest (identity, icon, properties, save, dirty-checking, and an optional detail panel) discovered at build time, mirroring the existing page-manifest mechanism. The shared Devices page dispatches through the registry instead of branching on concrete device types.

Move the physical and VLAN device types out of the core page into co-located web plugins under devices/*/web. Per-type editable state now lives in an opaque ext bag on the device, owned by each type's plugin, so the core no longer carries type-specific fields.

Split the detail panel so the live RX/TX counters re-render independently of the static configuration sections.

Adding a new device type now needs no changes to the core Devices page; the registry exposes the extension points (server-side state loading, a lazy detail panel, custom save confirmation) that a future device type plugs into.