### PR TITLE
refactor(web): classify traffic-source devices via the registry

### DIFF
--- a/devices/plain/web/device.ts
+++ b/devices/plain/web/device.ts
@@ -22,6 +22,7 @@ export const deviceType: DeviceTypeManifest = {
     accentColor: 'var(--teal)',
     kindTag: () => 'PHYSICAL',
     typeDescription: 'physical (plain)',
+    trafficSource: true,
     rowSubtitle: () => '— · —',
     parentMode: 'instances',
     propertyRows: () => [

--- a/web/builtin/_shared/useInstanceData.ts
+++ b/web/builtin/_shared/useInstanceData.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import type { InstanceInfo } from '@yanet/core/api/inspect';
 import { useDeviceCounters } from '@yanet/core/hooks';
+import { deviceTypeManifest } from '@yanet/core/registry';
 import { computeAgentUsage, computeMemoryTotals } from '../inspect/utils';
 
 /** Shared data preamble for dashboard and inspect InstanceCard components. */
@@ -17,10 +18,15 @@ export const useInstanceData = (instance: InstanceInfo) => {
         devices.length > 0,
     );
 
-    const physicalDeviceNames = useMemo(() => {
+    // Names of devices that originate traffic into the dataplane, taken from
+    // each device type's registry trafficSource flag.
+    //
+    // Stacked virtual devices (e.g. vlan) are excluded because their packets
+    // also count on the parent physical device, which would double-count.
+    const sourceDeviceNames = useMemo(() => {
         const result = new Set<string>();
         devices.forEach((d, idx) => {
-            if (d.type === 'plain') {
+            if (d.type && deviceTypeManifest(d.type)?.trafficSource) {
                 result.add(d.name ?? `device-${idx}`);
             }
         });
@@ -30,5 +36,5 @@ export const useInstanceData = (instance: InstanceInfo) => {
     const usage = useMemo(() => computeAgentUsage(instance), [instance]);
     const memTotals = useMemo(() => computeMemoryTotals(usage), [usage]);
 
-    return { devices, deviceNames, rateCounters, absoluteCounters, physicalDeviceNames, usage, memTotals };
+    return { devices, deviceNames, rateCounters, absoluteCounters, sourceDeviceNames, usage, memTotals };
 };

--- a/web/builtin/dashboard/InstanceCard.tsx
+++ b/web/builtin/dashboard/InstanceCard.tsx
@@ -16,7 +16,7 @@ export interface InstanceCardProps {
 
 /** Root layout for a single YANET instance: system state, KPI strip, 3D scene, modules. */
 export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
-    const { deviceNames, rateCounters, absoluteCounters, physicalDeviceNames, usage, memTotals } = useInstanceData(instance);
+    const { deviceNames, rateCounters, absoluteCounters, sourceDeviceNames, usage, memTotals } = useInstanceData(instance);
 
     const workerCount = useWorkerCount(deviceNames);
 
@@ -28,7 +28,7 @@ export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
                     <KpiStrip instance={instance} />
                 </div>
                 <div className="dash-top-row__right">
-                    <Throughput rateCounters={rateCounters} physicalDeviceNames={physicalDeviceNames} />
+                    <Throughput rateCounters={rateCounters} sourceDeviceNames={sourceDeviceNames} />
                 </div>
             </div>
             <SceneErrorBoundary>

--- a/web/builtin/dashboard/Throughput.tsx
+++ b/web/builtin/dashboard/Throughput.tsx
@@ -6,12 +6,12 @@ import { fmtBps, fmtPps } from '../inspect/formatters';
 
 export interface ThroughputProps {
     rateCounters: Map<string, DeviceCounterData>;
-    physicalDeviceNames: Set<string>;
+    sourceDeviceNames: Set<string>;
 }
 
 /** Aggregate throughput hero with a full-width sparkline beneath. */
-export const Throughput: React.FC<ThroughputProps> = ({ rateCounters, physicalDeviceNames }) => {
-    const { aggregatePps, aggregateBps } = useAggregateThroughput(rateCounters, physicalDeviceNames);
+export const Throughput: React.FC<ThroughputProps> = ({ rateCounters, sourceDeviceNames }) => {
+    const { aggregatePps, aggregateBps } = useAggregateThroughput(rateCounters, sourceDeviceNames);
 
     const throughputSeries = useRollingSeries(aggregatePps, 60);
 

--- a/web/builtin/inspect/HudHero.tsx
+++ b/web/builtin/inspect/HudHero.tsx
@@ -13,7 +13,7 @@ import type { MemoryTotals } from './utils';
 export interface HudHeroProps {
     instance: InstanceInfo;
     rateCounters: Map<string, DeviceCounterData>;
-    physicalDeviceNames: Set<string>;
+    sourceDeviceNames: Set<string>;
     memTotals: MemoryTotals;
 }
 
@@ -58,7 +58,7 @@ const SideKpiMemory: React.FC<SideKpiMemoryProps> = ({ totals }) => (
 export const HudHero: React.FC<HudHeroProps> = ({
     instance,
     rateCounters,
-    physicalDeviceNames,
+    sourceDeviceNames,
     memTotals,
 }) => {
     const devices = instance.devices ?? [];
@@ -67,7 +67,7 @@ export const HudHero: React.FC<HudHeroProps> = ({
     const modules = instance.dp_modules ?? [];
     const configs = instance.cp_configs ?? [];
 
-    const { aggregatePps, aggregateBps } = useAggregateThroughput(rateCounters, physicalDeviceNames);
+    const { aggregatePps, aggregateBps } = useAggregateThroughput(rateCounters, sourceDeviceNames);
 
     const throughputSeries = useRollingSeries(aggregatePps, 90);
 

--- a/web/builtin/inspect/InstanceCard.tsx
+++ b/web/builtin/inspect/InstanceCard.tsx
@@ -14,14 +14,14 @@ export interface InstanceCardProps {
 
 /** Root HUD layout for a single YANET instance. */
 export const InstanceCard: React.FC<InstanceCardProps> = ({ instance }) => {
-    const { rateCounters, absoluteCounters, physicalDeviceNames, usage: agentUsage, memTotals } = useInstanceData(instance);
+    const { rateCounters, absoluteCounters, sourceDeviceNames, usage: agentUsage, memTotals } = useInstanceData(instance);
 
     return (
         <div className="iv-instance">
             <HudHero
                 instance={instance}
                 rateCounters={rateCounters}
-                physicalDeviceNames={physicalDeviceNames}
+                sourceDeviceNames={sourceDeviceNames}
                 memTotals={memTotals}
             />
             <DeviceWall

--- a/web/builtin/inspect/hooks.ts
+++ b/web/builtin/inspect/hooks.ts
@@ -7,25 +7,25 @@ import { useRollingWindow } from '@yanet/core/hooks/useRollingWindow';
 import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '@yanet/core/utils';
 
 /**
- * Aggregate RX packet-rate and bit-rate across physical devices only.
+ * Aggregate RX packet-rate and bit-rate across traffic-source devices.
  *
- * Filters by physicalDeviceNames to avoid double-counting traffic that also
+ * Filters by sourceDeviceNames to avoid double-counting traffic that also
  * appears on stacked virtual devices (e.g. vlan).
  */
 export const useAggregateThroughput = (
     rateCounters: Map<string, DeviceCounterData>,
-    physicalDeviceNames: Set<string>,
+    sourceDeviceNames: Set<string>,
 ): { aggregatePps: number; aggregateBps: number } => {
     return useMemo(() => {
         let pps = 0;
         let bps = 0;
         rateCounters.forEach((d, name) => {
-            if (!physicalDeviceNames.has(name)) return;
+            if (!sourceDeviceNames.has(name)) return;
             pps += d.rx?.pps ?? 0;
             bps += d.rx?.bps ?? 0;
         });
         return { aggregatePps: pps, aggregateBps: bps };
-    }, [rateCounters, physicalDeviceNames]);
+    }, [rateCounters, sourceDeviceNames]);
 };
 
 const DEFAULT_INTERVAL_MS = 1500;
@@ -52,18 +52,18 @@ export const useRollingSeries = (
 };
 
 /**
- * Aggregate device pps over physical devices only and produce a rolling
- * throughput series. Restricting to physical devices avoids double-counting
+ * Aggregate device pps over traffic-source devices and produce a rolling
+ * throughput series. Restricting to source devices avoids double-counting
  * traffic that also appears on stacked virtual devices (e.g. vlan).
  */
 export const useThroughputSeries = (
     deviceCounters: Map<string, DeviceCounterData>,
-    physicalDeviceNames: Set<string>,
+    sourceDeviceNames: Set<string>,
     maxLen: number = DEFAULT_MAX_LEN,
 ): { current: number; series: number[] } => {
     let current = 0;
     deviceCounters.forEach((d, name) => {
-        if (!physicalDeviceNames.has(name)) return;
+        if (!sourceDeviceNames.has(name)) return;
         current += (d.rx?.pps ?? 0) + (d.tx?.pps ?? 0);
     });
     const series = useRollingSeries(current, maxLen);

--- a/web/src/core/registry/deviceType.ts
+++ b/web/src/core/registry/deviceType.ts
@@ -72,6 +72,14 @@ export interface DeviceTypeManifest {
     /** Human description for the Properties "Type" row. */
     typeDescription: string;
 
+    /** Whether this device originates traffic into the dataplane.
+     *
+     * A root interface (a NIC or a generator) sets this so its counters are
+     * summed into aggregate throughput. Stacked/virtual devices (e.g. vlan)
+     * omit it to avoid double-counting traffic already counted on their parent.
+     */
+    trafficSource?: boolean;
+
     /** One-line subtitle for a list row. */
     rowSubtitle?: (device: BaseDevice) => string;
 


### PR DESCRIPTION
Add a trafficSource capability to the device-type registry: a device type declares whether it originates traffic into the dataplane, so its counters are summed into aggregate throughput. Physical devices set it; stacked virtual devices such as vlan omit it to avoid double-counting traffic already counted on their parent.

The dashboard and inspect throughput aggregation now reads this flag from the registry instead of hardcoding device types, and the device-name set is renamed to reflect the broader meaning.

Behavior is unchanged on its own; a new device type can now opt into throughput aggregation without touching the shared code.