### PR TITLE
feat(trafgen): add a pcap-replay traffic generator device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,6 +3219,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "yanet-cli-device-trafgen"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "prost",
+ "serde",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "yanet-cli",
+ "yanet-commonpb",
+]
+
+[[package]]
 name = "yanet-cli-device-vlan"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "modules/route-mpls/cli",
     "devices/plain/cli",
     "devices/vlan/cli",
+    "devices/trafgen/cli",
     "operators/decap/cli",
     "operators/forward/cli",
     "operators/pipeline/cli",

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ CLI_MODULES := \
 	decap \
 	device-plain \
 	device-vlan \
+	device-trafgen \
 	dscp \
 	fwstate \
 	route \

--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -10,6 +10,7 @@ import (
 	// operatorpb services.
 	"github.com/yanet-platform/yanet2/controlplane/gateway"
 	plain "github.com/yanet-platform/yanet2/devices/plain/controlplane"
+	trafgen "github.com/yanet-platform/yanet2/devices/trafgen/controlplane"
 	vlan "github.com/yanet-platform/yanet2/devices/vlan/controlplane"
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
 	blackhole "github.com/yanet-platform/yanet2/modules/blackhole/controlplane"
@@ -130,6 +131,12 @@ func buildServices(
 			name: "vlan device",
 			new: func() (gateway.Service, error) {
 				return vlan.NewDeviceVlanDevice(devicesCfg.Vlan, log)
+			},
+		},
+		{
+			name: "trafgen device",
+			new: func() (gateway.Service, error) {
+				return trafgen.NewTrafgenDevice(devicesCfg.Trafgen, trafgen.WithLog(log))
 			},
 		},
 	}

--- a/controlplane/bundle/cfg.go
+++ b/controlplane/bundle/cfg.go
@@ -15,6 +15,7 @@ import (
 	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
 
 	plain "github.com/yanet-platform/yanet2/devices/plain/controlplane"
+	trafgen "github.com/yanet-platform/yanet2/devices/trafgen/controlplane"
 	vlan "github.com/yanet-platform/yanet2/devices/vlan/controlplane"
 )
 
@@ -48,6 +49,8 @@ type DevicesConfig struct {
 	Plain *plain.Config `yaml:"plain"`
 	// Vlan is the configuration for the vlan device.
 	Vlan *vlan.Config `yaml:"vlan"`
+	// Trafgen is the configuration for the traffic generator device.
+	Trafgen *trafgen.Config `yaml:"trafgen"`
 }
 
 // DefaultModulesConfig returns the default config for the bundled modules.
@@ -69,8 +72,9 @@ func DefaultModulesConfig() ModulesConfig {
 // DefaultDevicesConfig returns the default config for the bundled devices.
 func DefaultDevicesConfig() DevicesConfig {
 	return DevicesConfig{
-		Plain: plain.DefaultConfig(),
-		Vlan:  vlan.DefaultConfig(),
+		Plain:   plain.DefaultConfig(),
+		Vlan:    vlan.DefaultConfig(),
+		Trafgen: trafgen.DefaultConfig(),
 	}
 }
 

--- a/controlplane/meson.build
+++ b/controlplane/meson.build
@@ -28,6 +28,7 @@ custom_target(
         route_mpls_protoc_gen,
         pdump_protoc_gen,
         acl_protoc_gen,
+        trafgen_protoc_gen,
         plain_protoc_gen,
         vlan_protoc_gen,
 
@@ -52,6 +53,8 @@ custom_target(
         lib_route_dp,
         lib_blackhole_cp,
         lib_blackhole_dp,
+        lib_dev_trafgen_api,
+        lib_dev_trafgen_dp,
         lib_filter_compiler,
     ],
     install: true,

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -547,7 +547,7 @@ dataplane_init(
 			}
 		}
 
-		static const char *devices[] = {"plain", "vlan"};
+		static const char *devices[] = {"plain", "vlan", "trafgen"};
 		for (size_t i = 0; i < sizeof(devices) / sizeof(devices[0]);
 		     ++i) {
 			if (dp_load_device(

--- a/dataplane/meson.build
+++ b/dataplane/meson.build
@@ -55,6 +55,7 @@ dependencies = lib_dependencies + [
   #devices
   lib_dev_plain_dp_dep,
   lib_dev_vlan_dp_dep,
+  lib_dev_trafgen_dp_dep,
 ]
 
 sources = files(

--- a/debian/yanet2-cli.install
+++ b/debian/yanet2-cli.install
@@ -18,6 +18,7 @@ usr/bin/yanet-cli-metrics
 usr/bin/yanet-cli-counters
 usr/bin/yanet-cli-device-plain
 usr/bin/yanet-cli-device-vlan
+usr/bin/yanet-cli-device-trafgen
 usr/bin/yanet-cli-balancer2
 usr/bin/yanet-cli-operator-pipeline
 usr/bin/yanet-cli-operator-neighbour

--- a/devices/meson.build
+++ b/devices/meson.build
@@ -1,3 +1,4 @@
 subdir('plain')
 subdir('vlan')
+subdir('trafgen')
 

--- a/devices/trafgen/api/controlplane.c
+++ b/devices/trafgen/api/controlplane.c
@@ -1,0 +1,262 @@
+#include <stdlib.h>
+
+#include "controlplane.h"
+
+#include <string.h>
+
+#include "config.h"
+
+#include "common/container_of.h"
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "lib/errors/errors.h"
+
+#include "controlplane/agent/agent.h"
+#include "dataplane/config/zone.h"
+
+struct cp_device *
+cp_device_trafgen_new(
+	struct agent *agent,
+	const struct cp_device_trafgen_config *config,
+	yanet_error **err
+) {
+	struct cp_device_trafgen *cp_device_trafgen =
+		(struct cp_device_trafgen *)memory_balloc(
+			&agent->memory_context, sizeof(struct cp_device_trafgen)
+		);
+	if (cp_device_trafgen == NULL) {
+		yanet_error_add(err, "memory allocation failed");
+		return NULL;
+	}
+
+	memset(cp_device_trafgen, 0, sizeof(struct cp_device_trafgen));
+	SET_OFFSET_OF(
+		&cp_device_trafgen->cp_device.parent_memory_context,
+		&agent->memory_context
+	);
+	cp_device_trafgen->cp_device.alloc_size =
+		sizeof(struct cp_device_trafgen);
+
+	if (cp_device_init(
+		    &cp_device_trafgen->cp_device,
+		    agent,
+		    &config->cp_device_config,
+		    err
+	    )) {
+		memory_bfree(
+			&agent->memory_context,
+			cp_device_trafgen,
+			sizeof(struct cp_device_trafgen)
+		);
+		return NULL;
+	}
+
+	struct dp_config *dp_config = ADDR_OF(&agent->dp_config);
+	uint64_t worker_count = dp_config->worker_count;
+	if (worker_count > 0) {
+		uint64_t states_size =
+			sizeof(struct trafgen_worker_state) * worker_count;
+		struct trafgen_worker_state *states = memory_balloc(
+			&cp_device_trafgen->cp_device.memory_context,
+			states_size
+		);
+		if (states == NULL) {
+			yanet_error_add(err, "failed to allocate worker state");
+			cp_device_fini(&cp_device_trafgen->cp_device);
+			memory_bfree(
+				&agent->memory_context,
+				cp_device_trafgen,
+				sizeof(struct cp_device_trafgen)
+			);
+			return NULL;
+		}
+		memset(states, 0, states_size);
+		SET_OFFSET_OF(&cp_device_trafgen->worker_states, states);
+		cp_device_trafgen->worker_count = worker_count;
+	}
+
+	return &cp_device_trafgen->cp_device;
+}
+
+void
+cp_device_trafgen_free(struct cp_device *cp_device) {
+	struct cp_device_trafgen *config =
+		container_of(cp_device, struct cp_device_trafgen, cp_device);
+	struct memory_context *memory_context = &cp_device->memory_context;
+
+	// Release the subclass-owned buffers before the base teardown, then the
+	// base resources, then the wrapper struct.
+	struct trafgen_worker_state *states = ADDR_OF(&config->worker_states);
+	if (states != NULL) {
+		memory_bfree(
+			memory_context,
+			states,
+			sizeof(struct trafgen_worker_state) *
+				config->worker_count
+		);
+	}
+
+	uint8_t *frames = ADDR_OF(&config->frames);
+	if (frames != NULL) {
+		memory_bfree(memory_context, frames, config->frames_size);
+	}
+
+	uint32_t *lengths = ADDR_OF(&config->frame_lengths);
+	if (lengths != NULL) {
+		memory_bfree(
+			memory_context,
+			lengths,
+			sizeof(uint32_t) * config->frame_count
+		);
+	}
+
+	uint32_t *offsets = ADDR_OF(&config->frame_offsets);
+	if (offsets != NULL) {
+		memory_bfree(
+			memory_context,
+			offsets,
+			sizeof(uint32_t) * config->frame_count
+		);
+	}
+
+	cp_device_fini(cp_device);
+	cp_device_free(cp_device);
+}
+
+void
+cp_device_trafgen_drain_unused(struct agent *agent) {
+	cp_device_agent_drain_unused(agent, cp_device_trafgen_free);
+}
+
+struct cp_device_trafgen_config *
+cp_device_trafgen_config_new(
+	const char *name,
+	uint64_t input_count,
+	uint64_t output_count,
+	yanet_error **err
+) {
+	struct cp_device_trafgen_config *cp_device_trafgen_config =
+		(struct cp_device_trafgen_config *)malloc(
+			sizeof(struct cp_device_trafgen_config)
+		);
+	if (cp_device_trafgen_config == NULL) {
+		yanet_error_add(err, "memory allocation failed");
+		return NULL;
+	}
+
+	if (cp_device_config_init(
+		    &cp_device_trafgen_config->cp_device_config,
+		    "trafgen",
+		    name,
+		    input_count,
+		    output_count,
+		    err
+	    )) {
+		goto error_init;
+	}
+
+	return cp_device_trafgen_config;
+
+error_init:
+	free(cp_device_trafgen_config);
+	return NULL;
+}
+
+int
+cp_device_trafgen_config_set_input_pipeline(
+	struct cp_device_trafgen_config *cp_device_trafgen_config,
+	uint64_t index,
+	const char *name,
+	uint64_t weight
+) {
+	return cp_device_config_set_input_pipeline(
+		&cp_device_trafgen_config->cp_device_config, index, name, weight
+	);
+}
+
+int
+cp_device_trafgen_config_set_output_pipeline(
+	struct cp_device_trafgen_config *cp_device_trafgen_config,
+	uint64_t index,
+	const char *name,
+	uint64_t weight
+) {
+	return cp_device_config_set_output_pipeline(
+		&cp_device_trafgen_config->cp_device_config, index, name, weight
+	);
+}
+
+void
+cp_device_trafgen_config_free(
+	struct cp_device_trafgen_config *cp_device_trafgen_config
+) {
+	cp_device_config_fini(&cp_device_trafgen_config->cp_device_config);
+	free(cp_device_trafgen_config);
+}
+
+int
+cp_device_trafgen_set_rate(struct cp_device *cp_device, uint64_t rate_pps) {
+	struct cp_device_trafgen *config =
+		container_of(cp_device, struct cp_device_trafgen, cp_device);
+	config->rate_pps = rate_pps;
+	return 0;
+}
+
+// Load the frames replayed by the generator.
+//
+// Called once on a freshly created device, so it only allocates. The buffers
+// live in the device's memory_context and are released by
+// cp_device_trafgen_free.
+int
+cp_device_trafgen_set_frames(
+	struct cp_device *cp_device,
+	const uint8_t *frames,
+	uint64_t frames_size,
+	const uint32_t *lengths,
+	uint32_t frame_count,
+	yanet_error **err
+) {
+	struct cp_device_trafgen *config =
+		container_of(cp_device, struct cp_device_trafgen, cp_device);
+	struct memory_context *memory_context = &cp_device->memory_context;
+
+	if (frame_count == 0 || frames_size == 0) {
+		return 0;
+	}
+
+	uint64_t index_size = sizeof(uint32_t) * frame_count;
+	uint8_t *frames_buf = memory_balloc(memory_context, frames_size);
+	uint32_t *lengths_buf = memory_balloc(memory_context, index_size);
+	uint32_t *offsets_buf = memory_balloc(memory_context, index_size);
+
+	if (frames_buf == NULL || lengths_buf == NULL || offsets_buf == NULL) {
+		yanet_error_add(err, "failed to allocate frame storage");
+		if (frames_buf != NULL) {
+			memory_bfree(memory_context, frames_buf, frames_size);
+		}
+		if (lengths_buf != NULL) {
+			memory_bfree(memory_context, lengths_buf, index_size);
+		}
+		if (offsets_buf != NULL) {
+			memory_bfree(memory_context, offsets_buf, index_size);
+		}
+		return -1;
+	}
+
+	memcpy(frames_buf, frames, frames_size);
+
+	uint32_t offset = 0;
+	for (uint32_t idx = 0; idx < frame_count; ++idx) {
+		lengths_buf[idx] = lengths[idx];
+		offsets_buf[idx] = offset;
+		offset += lengths[idx];
+	}
+
+	SET_OFFSET_OF(&config->frames, frames_buf);
+	SET_OFFSET_OF(&config->frame_lengths, lengths_buf);
+	SET_OFFSET_OF(&config->frame_offsets, offsets_buf);
+	config->frames_size = frames_size;
+	config->frame_count = frame_count;
+
+	return 0;
+}

--- a/devices/trafgen/api/controlplane.h
+++ b/devices/trafgen/api/controlplane.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "controlplane/config/cp_device.h"
+
+struct agent;
+struct cp_device;
+struct yanet_error;
+
+struct cp_device_trafgen_config {
+	struct cp_device_config cp_device_config;
+};
+
+struct cp_device *
+cp_device_trafgen_new(
+	struct agent *agent,
+	const struct cp_device_trafgen_config *config,
+	yanet_error **err
+);
+
+void
+cp_device_trafgen_free(struct cp_device *cp_device);
+
+// Reclaim trafgen devices parked on the agent's unused_device list.
+//
+// Call after a device update, once the retiring generation no longer
+// references the parked devices.
+void
+cp_device_trafgen_drain_unused(struct agent *agent);
+
+struct cp_device_trafgen_config *
+cp_device_trafgen_config_new(
+	const char *name,
+	uint64_t input_count,
+	uint64_t output_count,
+	yanet_error **err
+);
+
+int
+cp_device_trafgen_config_set_input_pipeline(
+	struct cp_device_trafgen_config *cp_device_trafgen_config,
+	uint64_t index,
+	const char *name,
+	uint64_t weight
+);
+
+int
+cp_device_trafgen_config_set_output_pipeline(
+	struct cp_device_trafgen_config *cp_device_trafgen_config,
+	uint64_t index,
+	const char *name,
+	uint64_t weight
+);
+
+void
+cp_device_trafgen_config_free(
+	struct cp_device_trafgen_config *cp_device_trafgen_config
+);
+
+// Set the target aggregate packet rate in packets per second.
+int
+cp_device_trafgen_set_rate(struct cp_device *cp_device, uint64_t rate_pps);
+
+// Replace the frame set replayed by the generator.
+//
+// frames is the concatenation of frame_count raw L2 frames whose individual
+// lengths are given by lengths; frames_size must equal the sum of lengths. The
+// data is copied into shared memory, so the caller keeps ownership of frames
+// and lengths.
+int
+cp_device_trafgen_set_frames(
+	struct cp_device *cp_device,
+	const uint8_t *frames,
+	uint64_t frames_size,
+	const uint32_t *lengths,
+	uint32_t frame_count,
+	yanet_error **err
+);

--- a/devices/trafgen/api/meson.build
+++ b/devices/trafgen/api/meson.build
@@ -1,0 +1,28 @@
+cp_dependencies = [
+  lib_common_dep,
+  lib_errors_dep,
+  lib_config_dp_dep,
+  lib_config_cp_dep,
+  lib_counters_dep,
+  lib_agent_cp_dep,
+]
+
+includes = include_directories('../dataplane')
+
+sources = files(
+    'controlplane.c',
+)
+
+lib_dev_trafgen_api = static_library(
+    'dev_trafgen_api',
+    sources,
+    c_args: yanet_c_args,
+    link_args: yanet_link_args,
+    dependencies: cp_dependencies,
+    include_directories: includes,
+    install: false,
+)
+
+lib_dev_trafgen_api_dep = declare_dependency(
+    link_with: lib_dev_trafgen_api,
+)

--- a/devices/trafgen/bindings/go/ctrafgen/cgo.go
+++ b/devices/trafgen/bindings/go/ctrafgen/cgo.go
@@ -1,0 +1,176 @@
+// Package ctrafgen is the Go binding for the trafgen device.
+package ctrafgen
+
+//#cgo CFLAGS: -I../../../../../ -I../../../../../lib
+//#cgo LDFLAGS: -L../../../../../build/devices/trafgen/api -ldev_trafgen_api
+//
+// #include "api/agent.h"
+// #include "devices/trafgen/api/controlplane.h"
+import "C"
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// Pipeline is a weighted input/output pipeline assignment for the device.
+type Pipeline struct {
+	Name   string
+	Weight uint64
+}
+
+// DeviceConfig is an opaque handle to the trafgen device configuration in
+// shared memory.
+type DeviceConfig struct {
+	ptr ffi.ShmDeviceConfig
+}
+
+// NewDeviceConfig allocates a trafgen device configuration via the C API.
+//
+// It binds the given input/output pipelines and loads the frames and rate, then
+// returns a handle ready to be published with (*ffi.Agent).UpdateDevices.
+func NewDeviceConfig(
+	agent *ffi.Agent,
+	name string,
+	input []Pipeline,
+	output []Pipeline,
+	frames []byte,
+	lengths []uint32,
+	ratePps uint64,
+) (*DeviceConfig, error) {
+	if agent == nil {
+		return nil, fmt.Errorf("agent cannot be nil")
+	}
+
+	cName := C.CString(name)
+	defer C.free(unsafe.Pointer(cName))
+
+	var cErr *C.struct_yanet_error
+	cCfg := C.cp_device_trafgen_config_new(
+		cName,
+		C.uint64_t(len(input)),
+		C.uint64_t(len(output)),
+		&cErr,
+	)
+	if cCfg == nil {
+		return nil, fmt.Errorf("failed to initialize trafgen device config: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+	defer C.cp_device_trafgen_config_free(cCfg)
+
+	for idx := range input {
+		pipeline := &input[idx]
+		cPipeline := C.CString(pipeline.Name)
+		defer C.free(unsafe.Pointer(cPipeline))
+		C.cp_device_trafgen_config_set_input_pipeline(
+			cCfg,
+			C.uint64_t(idx),
+			cPipeline,
+			C.uint64_t(pipeline.Weight),
+		)
+	}
+
+	for idx := range output {
+		pipeline := &output[idx]
+		cPipeline := C.CString(pipeline.Name)
+		defer C.free(unsafe.Pointer(cPipeline))
+		C.cp_device_trafgen_config_set_output_pipeline(
+			cCfg,
+			C.uint64_t(idx),
+			cPipeline,
+			C.uint64_t(pipeline.Weight),
+		)
+	}
+
+	ptr := C.cp_device_trafgen_new((*C.struct_agent)(agent.AsRawPtr()), cCfg, &cErr)
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to create trafgen device: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+
+	device := &DeviceConfig{
+		ptr: ffi.NewShmDeviceConfig(unsafe.Pointer(ptr)),
+	}
+
+	if err := device.setFrames(frames, lengths); err != nil {
+		device.Free()
+		return nil, err
+	}
+
+	if err := device.setRate(ratePps); err != nil {
+		device.Free()
+		return nil, err
+	}
+
+	return device, nil
+}
+
+func (m *DeviceConfig) asRawPtr() *C.struct_cp_device {
+	return (*C.struct_cp_device)(m.ptr.AsRawPtr())
+}
+
+// AsFFIDevice returns the underlying shared-memory device config handle.
+func (m *DeviceConfig) AsFFIDevice() ffi.ShmDeviceConfig {
+	return m.ptr
+}
+
+// Free releases the underlying C memory.
+//
+// Safe to call multiple times: subsequent calls are no-ops.
+func (m *DeviceConfig) Free() {
+	if ptr := m.asRawPtr(); ptr != nil {
+		C.cp_device_trafgen_free(ptr)
+		m.ptr = ffi.ShmDeviceConfig{}
+	}
+}
+
+// DrainUnusedDevices reclaims trafgen devices retired from the config
+// generation and parked on the agent's unused list.
+//
+// Call it after UpdateDevices, once the retiring generation no longer
+// references the parked devices.
+func DrainUnusedDevices(agent *ffi.Agent) {
+	C.cp_device_trafgen_drain_unused((*C.struct_agent)(agent.AsRawPtr()))
+}
+
+// setRate sets the target aggregate packet rate in packets per second.
+func (m *DeviceConfig) setRate(ratePps uint64) error {
+	if rc := C.cp_device_trafgen_set_rate(
+		m.asRawPtr(),
+		C.uint64_t(ratePps),
+	); rc != 0 {
+		return fmt.Errorf("failed to set rate: error code=%d", rc)
+	}
+	return nil
+}
+
+// setFrames replaces the frame set replayed by the generator.
+//
+// frames is the concatenation of the raw L2 frames whose individual lengths are
+// given by lengths. The C side copies the data, so the slices may be reused
+// after the call returns.
+func (m *DeviceConfig) setFrames(frames []byte, lengths []uint32) error {
+	var framesPtr *C.uint8_t
+	if len(frames) > 0 {
+		framesPtr = (*C.uint8_t)(unsafe.Pointer(&frames[0]))
+	}
+
+	var lengthsPtr *C.uint32_t
+	if len(lengths) > 0 {
+		lengthsPtr = (*C.uint32_t)(unsafe.Pointer(&lengths[0]))
+	}
+
+	var cErr *C.struct_yanet_error
+	if rc := C.cp_device_trafgen_set_frames(
+		m.asRawPtr(),
+		framesPtr,
+		C.uint64_t(len(frames)),
+		lengthsPtr,
+		C.uint32_t(len(lengths)),
+		&cErr,
+	); rc != 0 {
+		return fmt.Errorf("failed to set frames: %w", cerrors.FromC(unsafe.Pointer(cErr)))
+	}
+	return nil
+}

--- a/devices/trafgen/cli/Cargo.toml
+++ b/devices/trafgen/cli/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "yanet-cli-device-trafgen"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+rust-version = "1.85"
+
+[dependencies]
+commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
+ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
+clap = { version = "4.5", features = ["derive"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
+tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
+prost = "0.13"
+tonic = { version = "0.13", features = ["gzip"] }
+serde = { version = "1", features = ["derive"] }
+
+[build-dependencies]
+tonic-build = "0.13"

--- a/devices/trafgen/cli/build.rs
+++ b/devices/trafgen/cli/build.rs
@@ -1,0 +1,14 @@
+use core::error::Error;
+
+pub fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=../controlplane/trafgenpb/v1/trafgen.proto");
+
+    tonic_build::configure()
+        .emit_rerun_if_changed(false)
+        .build_server(false)
+        .extern_path(".common.commonpb.v1", "::commonpb::pb")
+        .message_attribute(".", "#[derive(Serialize)]")
+        .compile_protos(&["trafgenpb/v1/trafgen.proto"], &["../../..", "../controlplane"])?;
+
+    Ok(())
+}

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -1,0 +1,262 @@
+use std::path::PathBuf;
+
+use clap::{ArgAction, CommandFactory, Parser};
+use clap_complete::CompleteEnv;
+use commonpb::pb::Device;
+use tonic::codec::CompressionEncoding;
+use trafgenpb::{
+    ListConfigsRequest, SetRateRequest, ShowConfigRequest, UpdateDeviceRequest, UploadPcapRequest,
+    trafgen_service_client::TrafgenServiceClient,
+};
+use ync::{
+    client::{ConnectionArgs, LayeredChannel},
+    errors::Error,
+    output::{self, CommonFormat},
+};
+
+#[allow(non_snake_case)]
+pub mod trafgenpb {
+    use serde::Serialize;
+
+    tonic::include_proto!("devices.trafgen.controlplane.trafgenpb.v1");
+}
+
+/// Traffic generator device CLI.
+#[derive(Debug, Clone, Parser)]
+#[command(version, about)]
+#[command(flatten_help = true)]
+pub struct Cmd {
+    #[clap(subcommand)]
+    pub mode: ModeCmd,
+    #[command(flatten)]
+    pub connection: ConnectionArgs,
+    /// Output format.
+    #[arg(long, default_value = "human", global = true)]
+    pub format: CommonFormat,
+    /// Log verbosity level.
+    #[clap(short, action = ArgAction::Count, global = true)]
+    pub verbose: u8,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub enum ModeCmd {
+    /// Bind the input/output pipelines of a generator.
+    Update(UpdateCmd),
+    /// List all generator configurations.
+    List,
+    /// Show a generator configuration.
+    Show(ShowConfigCmd),
+    /// Upload a pcap whose packets are replayed.
+    Upload(UploadPcapCmd),
+    /// Set the target aggregate packet rate.
+    Rate(SetRateCmd),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct UpdateCmd {
+    /// Generator device name to operate on.
+    #[arg(long = "name", short = 'n')]
+    pub config_name: String,
+    /// Input pipeline assignments in "pipeline:weight" format.
+    #[arg(short, long)]
+    pub input: Vec<String>,
+    /// Output pipeline assignments in "pipeline:weight" format.
+    #[arg(short, long)]
+    pub output: Vec<String>,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ShowConfigCmd {
+    /// Generator device name to operate on.
+    #[arg(long = "name", short = 'n')]
+    pub config_name: String,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct UploadPcapCmd {
+    /// Generator device name to operate on.
+    #[arg(long = "name", short = 'n')]
+    pub config_name: String,
+    /// Path to the pcap file whose packets are replayed.
+    #[arg(long, short)]
+    pub pcap: PathBuf,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct SetRateCmd {
+    /// Generator device name to operate on.
+    #[arg(long = "name", short = 'n')]
+    pub config_name: String,
+    /// Target aggregate packet rate in packets per second.
+    #[arg(long, short = 'r')]
+    pub rate: u64,
+}
+
+/// The fully-qualified gRPC service name used in error messages.
+const SERVICE_NAME: &str = "devices.trafgen.controlplane.trafgenpb.v1.TrafgenService";
+
+pub struct TrafgenService {
+    client: TrafgenServiceClient<LayeredChannel>,
+    endpoint: String,
+}
+
+impl TrafgenService {
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
+        let channel = ync::client::connect(connection)
+            .await
+            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
+        let client = TrafgenServiceClient::new(channel)
+            .max_decoding_message_size(256 * 1024 * 1024)
+            .max_encoding_message_size(256 * 1024 * 1024)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip);
+
+        Ok(Self {
+            client,
+            endpoint: connection.endpoint.clone(),
+        })
+    }
+
+    fn map_err<'a>(&'a self, action: &'a str) -> impl FnOnce(tonic::Status) -> Error + 'a {
+        let endpoint = self.endpoint.clone();
+        move |status| Error::from_status(status, action, endpoint, SERVICE_NAME)
+    }
+
+    fn invalid_argument(&self, action: &'static str, message: String) -> Error {
+        Error::from_status(
+            tonic::Status::invalid_argument(message),
+            action,
+            self.endpoint.clone(),
+            SERVICE_NAME,
+        )
+    }
+
+    pub async fn update_device(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
+        let input = cmd
+            .input
+            .into_iter()
+            .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| self.invalid_argument("update", err.to_string()))?;
+        let output = cmd
+            .output
+            .into_iter()
+            .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| self.invalid_argument("update", err.to_string()))?;
+
+        let request = UpdateDeviceRequest {
+            name: cmd.config_name.clone(),
+            device: Some(Device { input, output }),
+        };
+        self.client
+            .update_device(request)
+            .await
+            .map_err(self.map_err("update"))?
+            .into_inner();
+
+        output::success("update", format_args!("Updated device {}.", cmd.config_name));
+
+        Ok(())
+    }
+
+    pub async fn list_configs(&mut self) -> Result<(), Error> {
+        let response = self
+            .client
+            .list_configs(ListConfigsRequest {})
+            .await
+            .map_err(self.map_err("list"))?
+            .into_inner();
+
+        output::data(
+            &response.configs,
+            response.configs.is_empty(),
+            format_args!("no configurations"),
+            || {
+                for name in &response.configs {
+                    println!("{name}");
+                }
+            },
+        );
+
+        Ok(())
+    }
+
+    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
+        let request = ShowConfigRequest { name: cmd.config_name.clone() };
+        let response = self
+            .client
+            .show_config(request)
+            .await
+            .map_err(self.map_err("show"))?
+            .into_inner();
+
+        output::data(&response, false, format_args!(""), || {
+            println!("rate (pps):  {}", response.rate_pps);
+            println!("frame count: {}", response.frame_count);
+            println!("total bytes: {}", response.total_bytes);
+        });
+
+        Ok(())
+    }
+
+    pub async fn upload_pcap(&mut self, cmd: UploadPcapCmd) -> Result<(), Error> {
+        let pcap = std::fs::read(&cmd.pcap).map_err(|err| {
+            self.invalid_argument("upload", format!("failed to read pcap {}: {err}", cmd.pcap.display()))
+        })?;
+
+        let request = UploadPcapRequest { name: cmd.config_name.clone(), pcap };
+        self.client
+            .upload_pcap(request)
+            .await
+            .map_err(self.map_err("upload"))?
+            .into_inner();
+
+        output::success("upload", format_args!("Uploaded pcap to {}.", cmd.config_name));
+
+        Ok(())
+    }
+
+    pub async fn set_rate(&mut self, cmd: SetRateCmd) -> Result<(), Error> {
+        let request = SetRateRequest {
+            name: cmd.config_name.clone(),
+            rate_pps: cmd.rate,
+        };
+        self.client
+            .set_rate(request)
+            .await
+            .map_err(self.map_err("rate"))?
+            .into_inner();
+
+        output::success(
+            "rate",
+            format_args!("Set rate of {} to {} pps.", cmd.config_name, cmd.rate),
+        );
+
+        Ok(())
+    }
+}
+
+async fn run(cmd: Cmd) -> Result<(), Error> {
+    let mut service = TrafgenService::new(&cmd.connection).await?;
+
+    match cmd.mode {
+        ModeCmd::Update(cmd) => service.update_device(cmd).await,
+        ModeCmd::List => service.list_configs().await,
+        ModeCmd::Show(cmd) => service.show_config(cmd).await,
+        ModeCmd::Upload(cmd) => service.upload_pcap(cmd).await,
+        ModeCmd::Rate(cmd) => service.set_rate(cmd).await,
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() {
+    CompleteEnv::with_factory(Cmd::command).complete();
+    let cmd = Cmd::parse();
+    ync::init(cmd.verbose, cmd.format);
+
+    if let Err(err) = run(cmd).await {
+        output::failure(&err);
+        std::process::exit(err.exit_code());
+    }
+}

--- a/devices/trafgen/controlplane/backend.go
+++ b/devices/trafgen/controlplane/backend.go
@@ -1,0 +1,73 @@
+package trafgen
+
+import (
+	"fmt"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/devices/trafgen/bindings/go/ctrafgen"
+)
+
+// backend is the real Backend implementation backed by shared memory.
+type backend struct {
+	agent *ffi.Agent
+}
+
+// NewBackend creates a Backend that operates on real shared memory.
+func NewBackend(agent *ffi.Agent) Backend {
+	return &backend{
+		agent: agent,
+	}
+}
+
+func (m *backend) UpdateDevice(
+	name string,
+	input []Pipeline,
+	output []Pipeline,
+	frames []byte,
+	lengths []uint32,
+	ratePps uint64,
+) error {
+	device, err := ctrafgen.NewDeviceConfig(
+		m.agent,
+		name,
+		toBindingPipelines(input),
+		toBindingPipelines(output),
+		frames,
+		lengths,
+		ratePps,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create device config: %w", err)
+	}
+
+	// Reclaim devices parked on the agent's unused list once the update
+	// settles, regardless of outcome.
+	//
+	// A device leaving the config generation is parked rather than freed: the
+	// one replaced by a successful update, or the new one rejected mid-install
+	// by a failed update (e.g. an unknown pipeline), both land on the unused
+	// list. Draining on every exit frees them and keeps repeated failed updates
+	// from accumulating dead devices in the agent arena.
+	defer ctrafgen.DrainUnusedDevices(m.agent)
+
+	if err := m.agent.UpdateDevices(
+		[]ffi.ShmDeviceConfig{device.AsFFIDevice()},
+	); err != nil {
+		return fmt.Errorf("failed to update device %q: %w", name, err)
+	}
+
+	return nil
+}
+
+// toBindingPipelines converts service pipeline assignments into the binding
+// representation consumed by the C API.
+func toBindingPipelines(pipelines []Pipeline) []ctrafgen.Pipeline {
+	out := make([]ctrafgen.Pipeline, 0, len(pipelines))
+	for idx := range pipelines {
+		out = append(out, ctrafgen.Pipeline{
+			Name:   pipelines[idx].Name,
+			Weight: pipelines[idx].Weight,
+		})
+	}
+	return out
+}

--- a/devices/trafgen/controlplane/cfg.go
+++ b/devices/trafgen/controlplane/cfg.go
@@ -1,0 +1,30 @@
+package trafgen
+
+import (
+	"github.com/c2h5oh/datasize"
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+// Config represents trafgen device configuration.
+type Config struct {
+	// InstanceID specifies which dataplane instance this device serves.
+	InstanceID uint32 `yaml:"instance_id"`
+	// MemoryPath is the path to the shared-memory file that is used to
+	// communicate with dataplane.
+	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
+	// MemoryRequirements is the amount of memory that is required for a single
+	// transaction.
+	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+
+	Endpoint        xcfg.NonEmptyString `yaml:"endpoint"`
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
+}
+
+func DefaultConfig() *Config {
+	return &Config{
+		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
+		MemoryRequirements: xcfg.MustNonZero(16 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
+	}
+}

--- a/devices/trafgen/controlplane/meson.build
+++ b/devices/trafgen/controlplane/meson.build
@@ -1,0 +1,1 @@
+subdir('trafgenpb')

--- a/devices/trafgen/controlplane/mod.go
+++ b/devices/trafgen/controlplane/mod.go
@@ -1,0 +1,115 @@
+// Package trafgen implements the control plane of the traffic generator device.
+package trafgen
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	trafgenpb "github.com/yanet-platform/yanet2/devices/trafgen/controlplane/trafgenpb/v1"
+)
+
+const (
+	agentName   = "trafgen"
+	deviceName  = "trafgen"
+	serviceName = "devices.trafgen.controlplane.trafgenpb.v1.TrafgenService"
+)
+
+// Option configures the TrafgenDevice constructor.
+type Option func(*deviceOptions)
+
+type deviceOptions struct {
+	Log *zap.Logger
+}
+
+func newDeviceOptions() *deviceOptions {
+	return &deviceOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the trafgen device.
+func WithLog(log *zap.Logger) Option {
+	return func(o *deviceOptions) {
+		o.Log = log
+	}
+}
+
+// TrafgenDevice is the control-plane component of the traffic generator device.
+type TrafgenDevice struct {
+	cfg     *Config
+	shm     *ffi.SharedMemory
+	agent   *ffi.Agent
+	service *TrafgenService
+	log     *zap.Logger
+}
+
+// NewTrafgenDevice creates a new TrafgenDevice.
+func NewTrafgenDevice(cfg *Config, options ...Option) (*TrafgenDevice, error) {
+	opts := newDeviceOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("device", deviceName))
+
+	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
+	if err != nil {
+		return nil, fmt.Errorf("failed to attach shared memory: %w", err)
+	}
+
+	log.Debug("mapping shared memory",
+		zap.Uint32("instance_id", cfg.InstanceID),
+		zap.Stringer("size", cfg.MemoryRequirements),
+	)
+
+	agent, err := shm.AgentAttach(agentName, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	if err != nil {
+		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
+	}
+
+	service := NewTrafgenService(NewBackend(agent))
+
+	return &TrafgenDevice{
+		cfg:     cfg,
+		shm:     shm,
+		agent:   agent,
+		service: service,
+		log:     log,
+	}, nil
+}
+
+// Name returns the device name.
+func (m *TrafgenDevice) Name() string {
+	return deviceName
+}
+
+// Endpoint returns the gRPC endpoint for the trafgen device.
+func (m *TrafgenDevice) Endpoint() string {
+	return m.cfg.Endpoint.Unwrap()
+}
+
+// ServicesNames returns the gRPC service names exposed by the device.
+func (m *TrafgenDevice) ServicesNames() []string {
+	return []string{serviceName}
+}
+
+// RegisterService registers the trafgen device's gRPC service.
+func (m *TrafgenDevice) RegisterService(server *grpc.Server) {
+	trafgenpb.RegisterTrafgenServiceServer(server, m.service)
+}
+
+// Close releases shared memory resources held by the device.
+func (m *TrafgenDevice) Close() error {
+	if err := m.agent.Close(); err != nil {
+		m.log.Warn("failed to close shared memory agent", zap.Error(err))
+	}
+
+	if err := m.shm.Detach(); err != nil {
+		m.log.Warn("failed to detach from shared memory mapping", zap.Error(err))
+	}
+
+	return nil
+}

--- a/devices/trafgen/controlplane/service.go
+++ b/devices/trafgen/controlplane/service.go
@@ -19,6 +19,12 @@ import (
 
 var errConfigNameRequired = status.Error(codes.InvalidArgument, "config name is required")
 
+// maxFrameLen is the largest replay frame the dataplane can emit.
+//
+// The dataplane reserves mbuf tailroom with a 16-bit length, so a frame above
+// this bound would wrap and corrupt the mbuf; reject such frames at upload.
+const maxFrameLen = 65535
+
 // Pipeline is a weighted input/output pipeline assignment for the generator.
 type Pipeline struct {
 	Name   string
@@ -319,6 +325,12 @@ func parsePcap(pcap []byte) ([][]byte, error) {
 		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to read packet: %w", err)
+		}
+		if len(data) > maxFrameLen {
+			return nil, fmt.Errorf(
+				"frame %d is %d bytes, exceeds the %d-byte limit",
+				len(packets), len(data), maxFrameLen,
+			)
 		}
 		frame := make([]byte, len(data))
 		copy(frame, data)

--- a/devices/trafgen/controlplane/service.go
+++ b/devices/trafgen/controlplane/service.go
@@ -1,0 +1,329 @@
+package trafgen
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gopacket/gopacket/pcapgo"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	trafgenpb "github.com/yanet-platform/yanet2/devices/trafgen/controlplane/trafgenpb/v1"
+)
+
+var errConfigNameRequired = status.Error(codes.InvalidArgument, "config name is required")
+
+// Pipeline is a weighted input/output pipeline assignment for the generator.
+type Pipeline struct {
+	Name   string
+	Weight uint64
+}
+
+// Backend abstracts shared memory operations.
+type Backend interface {
+	// UpdateDevice publishes a device config with the given pipelines,
+	// frames and rate to the dataplane.
+	//
+	// The published config is owned by the dataplane's config-generation
+	// registry, which reclaims it when the generation is retired; the caller
+	// must not free it.
+	UpdateDevice(name string, input, output []Pipeline, frames []byte, lengths []uint32, ratePps uint64) error
+}
+
+type config struct {
+	RatePps    uint64
+	FrameCount uint32
+	TotalBytes uint64
+	Packets    [][]byte
+	Input      []Pipeline
+	Output     []Pipeline
+}
+
+// TrafgenService implements the TrafgenService gRPC server.
+type TrafgenService struct {
+	trafgenpb.UnimplementedTrafgenServiceServer
+
+	mu      sync.Mutex
+	backend Backend
+	configs map[string]*config
+}
+
+// NewTrafgenService constructs a TrafgenService backed by the given Backend.
+func NewTrafgenService(backend Backend) *TrafgenService {
+	return &TrafgenService{
+		backend: backend,
+		configs: map[string]*config{},
+	}
+}
+
+// UpdateDevice binds the input/output pipelines of the named generator.
+//
+// The loaded frames and the target rate are preserved; generated traffic is
+// demultiplexed into the configured input pipelines by the dataplane.
+func (m *TrafgenService) UpdateDevice(
+	ctx context.Context,
+	req *trafgenpb.UpdateDeviceRequest,
+) (*trafgenpb.UpdateDeviceResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	input := pipelinesFromProto(req.GetDevice().GetInput())
+	output := pipelinesFromProto(req.GetDevice().GetOutput())
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var packets [][]byte
+	var ratePps uint64
+	if old, ok := m.configs[name]; ok {
+		packets = old.Packets
+		ratePps = old.RatePps
+	}
+
+	if err := m.apply(name, packets, ratePps, input, output); err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to update device config %q: %v", name, err,
+		)
+	}
+
+	return &trafgenpb.UpdateDeviceResponse{}, nil
+}
+
+// ListConfigs returns all known config names of the dataplane instance.
+func (m *TrafgenService) ListConfigs(
+	ctx context.Context,
+	req *trafgenpb.ListConfigsRequest,
+) (*trafgenpb.ListConfigsResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	names := make([]string, 0, len(m.configs))
+	for name := range m.configs {
+		names = append(names, name)
+	}
+
+	return &trafgenpb.ListConfigsResponse{Configs: names}, nil
+}
+
+// ShowConfig returns the loaded frame statistics and target rate for a config.
+func (m *TrafgenService) ShowConfig(
+	ctx context.Context,
+	req *trafgenpb.ShowConfigRequest,
+) (*trafgenpb.ShowConfigResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.configs[name]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "no config found")
+	}
+
+	return &trafgenpb.ShowConfigResponse{
+		RatePps:    entry.RatePps,
+		FrameCount: entry.FrameCount,
+		TotalBytes: entry.TotalBytes,
+	}, nil
+}
+
+// ShowPackets returns every loaded frame for the named config.
+func (m *TrafgenService) ShowPackets(
+	ctx context.Context,
+	req *trafgenpb.ShowPacketsRequest,
+) (*trafgenpb.ShowPacketsResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.configs[name]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "no config found")
+	}
+
+	out := make([][]byte, len(entry.Packets))
+	copy(out, entry.Packets)
+
+	return &trafgenpb.ShowPacketsResponse{Packets: out, Truncated: false}, nil
+}
+
+// UploadPcap loads the frames to replay from a pcap, preserving the rate and
+// the configured pipelines.
+func (m *TrafgenService) UploadPcap(
+	ctx context.Context,
+	req *trafgenpb.UploadPcapRequest,
+) (*trafgenpb.UploadPcapResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	packets, err := parsePcap(req.GetPcap())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "failed to parse pcap: %v", err)
+	}
+	if len(packets) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "pcap contains no packets")
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var ratePps uint64
+	var input, output []Pipeline
+	if old, ok := m.configs[name]; ok {
+		ratePps = old.RatePps
+		input = old.Input
+		output = old.Output
+	}
+
+	if err := m.apply(name, packets, ratePps, input, output); err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to update device config %q: %v", name, err,
+		)
+	}
+
+	return &trafgenpb.UploadPcapResponse{}, nil
+}
+
+// SetRate sets the target aggregate rate, preserving the loaded pcap and the
+// configured pipelines.
+func (m *TrafgenService) SetRate(
+	ctx context.Context,
+	req *trafgenpb.SetRateRequest,
+) (*trafgenpb.SetRateResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var packets [][]byte
+	var input, output []Pipeline
+	if old, ok := m.configs[name]; ok {
+		packets = old.Packets
+		input = old.Input
+		output = old.Output
+	}
+
+	if err := m.apply(name, packets, req.GetRatePps(), input, output); err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to update device config %q: %v", name, err,
+		)
+	}
+
+	return &trafgenpb.SetRateResponse{}, nil
+}
+
+// apply publishes the full device state through the backend and, on success,
+// stores the new config. The caller must hold m.mu.
+//
+// The previously published device is reclaimed by the dataplane's config
+// generation registry, so nothing is freed here.
+func (m *TrafgenService) apply(
+	name string,
+	packets [][]byte,
+	ratePps uint64,
+	input, output []Pipeline,
+) error {
+	frames, lengths := flattenFrames(packets)
+
+	if err := m.backend.UpdateDevice(name, input, output, frames, lengths, ratePps); err != nil {
+		return fmt.Errorf("failed to update device config %q: %w", name, err)
+	}
+
+	m.configs[name] = &config{
+		RatePps:    ratePps,
+		FrameCount: uint32(len(packets)),
+		TotalBytes: uint64(len(frames)),
+		Packets:    packets,
+		Input:      input,
+		Output:     output,
+	}
+
+	return nil
+}
+
+// pipelinesFromProto converts the wire pipeline assignments into the service
+// representation.
+func pipelinesFromProto(pipelines []*commonpb.DevicePipeline) []Pipeline {
+	out := make([]Pipeline, 0, len(pipelines))
+	for _, pipeline := range pipelines {
+		out = append(out, Pipeline{
+			Name:   pipeline.GetName(),
+			Weight: pipeline.GetWeight(),
+		})
+	}
+	return out
+}
+
+// flattenFrames concatenates the per-packet frames into a single buffer and
+// returns it together with the per-frame lengths.
+func flattenFrames(packets [][]byte) ([]byte, []uint32) {
+	if len(packets) == 0 {
+		return nil, nil
+	}
+
+	lengths := make([]uint32, len(packets))
+	total := 0
+	for idx, packet := range packets {
+		lengths[idx] = uint32(len(packet))
+		total += len(packet)
+	}
+
+	frames := make([]byte, 0, total)
+	for _, packet := range packets {
+		frames = append(frames, packet...)
+	}
+
+	return frames, lengths
+}
+
+// parsePcap reads every packet from a pcap file's raw bytes, returning the
+// list of raw L2 frames in capture order.
+func parsePcap(pcap []byte) ([][]byte, error) {
+	reader, err := pcapgo.NewReader(bytes.NewReader(pcap))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read pcap header: %w", err)
+	}
+
+	if linkType := reader.LinkType(); linkType != layers.LinkTypeEthernet {
+		return nil, fmt.Errorf("unsupported link type %s: only ethernet is supported", linkType)
+	}
+
+	var packets [][]byte
+	for {
+		data, _, err := reader.ReadPacketData()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to read packet: %w", err)
+		}
+		frame := make([]byte, len(data))
+		copy(frame, data)
+		packets = append(packets, frame)
+	}
+
+	return packets, nil
+}

--- a/devices/trafgen/controlplane/service_test.go
+++ b/devices/trafgen/controlplane/service_test.go
@@ -286,6 +286,28 @@ func Test_TrafgenService_InvalidPcap(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+func Test_TrafgenService_OversizedFrame(t *testing.T) {
+	svc, _ := newTestService()
+
+	var buf bytes.Buffer
+	writer := pcapgo.NewWriter(&buf)
+	require.NoError(t, writer.WriteFileHeader(maxFrameLen+1, layers.LinkTypeEthernet))
+
+	frame := bytes.Repeat([]byte{0x01}, maxFrameLen+1)
+	require.NoError(t, writer.WritePacket(gopacket.CaptureInfo{
+		Timestamp:     time.Unix(0, 0),
+		CaptureLength: len(frame),
+		Length:        len(frame),
+	}, frame))
+
+	resp, err := svc.UploadPcap(t.Context(), &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: buf.Bytes(),
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 func Test_TrafgenService_EmptyPcap(t *testing.T) {
 	svc, _ := newTestService()
 

--- a/devices/trafgen/controlplane/service_test.go
+++ b/devices/trafgen/controlplane/service_test.go
@@ -1,0 +1,298 @@
+package trafgen
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/gopacket/gopacket/pcapgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	trafgenpb "github.com/yanet-platform/yanet2/devices/trafgen/controlplane/trafgenpb/v1"
+)
+
+// recordingBackend captures the arguments of the most recent UpdateDevice call.
+type recordingBackend struct {
+	frames  []byte
+	lengths []uint32
+	ratePps uint64
+	input   []Pipeline
+	output  []Pipeline
+	calls   int
+}
+
+func (m *recordingBackend) UpdateDevice(
+	name string,
+	input, output []Pipeline,
+	frames []byte,
+	lengths []uint32,
+	ratePps uint64,
+) error {
+	m.calls++
+	m.frames = frames
+	m.lengths = lengths
+	m.ratePps = ratePps
+	m.input = input
+	m.output = output
+	return nil
+}
+
+// buildPcap encodes the given ethernet frames into an in-memory pcap file.
+func buildPcap(t *testing.T, frames [][]byte) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := pcapgo.NewWriter(&buf)
+	require.NoError(t, writer.WriteFileHeader(65535, layers.LinkTypeEthernet))
+
+	for _, frame := range frames {
+		ci := gopacket.CaptureInfo{
+			Timestamp:     time.Unix(0, 0),
+			CaptureLength: len(frame),
+			Length:        len(frame),
+		}
+		require.NoError(t, writer.WritePacket(ci, frame))
+	}
+
+	return buf.Bytes()
+}
+
+func newTestService() (*TrafgenService, *recordingBackend) {
+	backend := &recordingBackend{}
+	return NewTrafgenService(backend), backend
+}
+
+func Test_TrafgenService_UploadSetRateShow(t *testing.T) {
+	svc, backend := newTestService()
+	ctx := t.Context()
+
+	frames := [][]byte{
+		bytes.Repeat([]byte{0xaa}, 20),
+		bytes.Repeat([]byte{0xbb}, 30),
+	}
+
+	_, err := svc.UploadPcap(ctx, &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: buildPcap(t, frames),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint32{20, 30}, backend.lengths)
+	require.Len(t, backend.frames, 50)
+
+	_, err = svc.SetRate(ctx, &trafgenpb.SetRateRequest{
+		Name:    "trafgen0",
+		RatePps: 1_000_000,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1_000_000), backend.ratePps)
+
+	show, err := svc.ShowConfig(ctx, &trafgenpb.ShowConfigRequest{Name: "trafgen0"})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1_000_000), show.RatePps)
+	require.Equal(t, uint32(2), show.FrameCount)
+	require.Equal(t, uint64(50), show.TotalBytes)
+}
+
+func Test_TrafgenService_SetRateKeepsPcap(t *testing.T) {
+	svc, backend := newTestService()
+	ctx := t.Context()
+
+	_, err := svc.UploadPcap(ctx, &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: buildPcap(t, [][]byte{bytes.Repeat([]byte{0x01}, 64)}),
+	})
+	require.NoError(t, err)
+
+	// Changing the rate must republish the same frames without a re-upload.
+	_, err = svc.SetRate(ctx, &trafgenpb.SetRateRequest{Name: "trafgen0", RatePps: 500})
+	require.NoError(t, err)
+	require.Equal(t, []uint32{64}, backend.lengths)
+	require.Len(t, backend.frames, 64)
+	require.Equal(t, uint64(500), backend.ratePps)
+
+	show, err := svc.ShowConfig(ctx, &trafgenpb.ShowConfigRequest{Name: "trafgen0"})
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), show.FrameCount)
+	require.Equal(t, uint64(500), show.RatePps)
+}
+
+func Test_TrafgenService_UpdateDeviceKeepsFramesAndRate(t *testing.T) {
+	svc, backend := newTestService()
+	ctx := t.Context()
+
+	_, err := svc.UploadPcap(ctx, &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: buildPcap(t, [][]byte{bytes.Repeat([]byte{0x01}, 64)}),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.SetRate(ctx, &trafgenpb.SetRateRequest{Name: "trafgen0", RatePps: 700})
+	require.NoError(t, err)
+
+	// Binding pipelines must republish the same frames and rate.
+	_, err = svc.UpdateDevice(ctx, &trafgenpb.UpdateDeviceRequest{
+		Name: "trafgen0",
+		Device: &commonpb.Device{
+			Input:  []*commonpb.DevicePipeline{{Name: "p0", Weight: 1}},
+			Output: []*commonpb.DevicePipeline{{Name: "p1", Weight: 2}},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []Pipeline{{Name: "p0", Weight: 1}}, backend.input)
+	require.Equal(t, []Pipeline{{Name: "p1", Weight: 2}}, backend.output)
+	require.Len(t, backend.frames, 64)
+	require.Equal(t, uint64(700), backend.ratePps)
+
+	// A later rate change must preserve the bound pipelines.
+	_, err = svc.SetRate(ctx, &trafgenpb.SetRateRequest{Name: "trafgen0", RatePps: 900})
+	require.NoError(t, err)
+	require.Equal(t, []Pipeline{{Name: "p0", Weight: 1}}, backend.input)
+	require.Equal(t, []Pipeline{{Name: "p1", Weight: 2}}, backend.output)
+}
+
+func Test_TrafgenService_SetRateBeforeUpload(t *testing.T) {
+	svc, _ := newTestService()
+	ctx := t.Context()
+
+	_, err := svc.SetRate(ctx, &trafgenpb.SetRateRequest{Name: "trafgen0", RatePps: 42})
+	require.NoError(t, err)
+
+	show, err := svc.ShowConfig(ctx, &trafgenpb.ShowConfigRequest{Name: "trafgen0"})
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), show.RatePps)
+	require.Equal(t, uint32(0), show.FrameCount)
+
+	packets, err := svc.ShowPackets(ctx, &trafgenpb.ShowPacketsRequest{Name: "trafgen0"})
+	require.NoError(t, err)
+	require.Empty(t, packets.Packets)
+}
+
+func Test_TrafgenService_ShowPackets(t *testing.T) {
+	svc, _ := newTestService()
+	ctx := t.Context()
+
+	frames := [][]byte{
+		bytes.Repeat([]byte{0xaa}, 20),
+		bytes.Repeat([]byte{0xbb}, 30),
+	}
+	_, err := svc.UploadPcap(ctx, &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: buildPcap(t, frames),
+	})
+	require.NoError(t, err)
+
+	resp, err := svc.ShowPackets(ctx, &trafgenpb.ShowPacketsRequest{Name: "trafgen0"})
+	require.NoError(t, err)
+	require.False(t, resp.Truncated)
+	require.Equal(t, frames, resp.Packets)
+}
+
+func Test_TrafgenService_UploadReplaces(t *testing.T) {
+	svc, backend := newTestService()
+	ctx := t.Context()
+
+	_, err := svc.UploadPcap(ctx, &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: buildPcap(t, [][]byte{bytes.Repeat([]byte{0x01}, 64)}),
+	})
+	require.NoError(t, err)
+
+	_, err = svc.UploadPcap(ctx, &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: buildPcap(t, [][]byte{bytes.Repeat([]byte{0x02}, 100), bytes.Repeat([]byte{0x03}, 100)}),
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, 2, backend.calls)
+
+	show, err := svc.ShowConfig(ctx, &trafgenpb.ShowConfigRequest{Name: "trafgen0"})
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), show.FrameCount)
+	require.Equal(t, uint64(200), show.TotalBytes)
+}
+
+func Test_TrafgenService_ListConfigs(t *testing.T) {
+	svc, _ := newTestService()
+	ctx := t.Context()
+
+	list, err := svc.ListConfigs(ctx, &trafgenpb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, list.Configs)
+
+	_, err = svc.UploadPcap(ctx, &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: buildPcap(t, [][]byte{bytes.Repeat([]byte{0x01}, 64)}),
+	})
+	require.NoError(t, err)
+
+	list, err = svc.ListConfigs(ctx, &trafgenpb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"trafgen0"}, list.Configs)
+}
+
+func Test_TrafgenService_EmptyConfigName(t *testing.T) {
+	svc, _ := newTestService()
+	ctx := t.Context()
+
+	t.Run("UpdateDevice", func(t *testing.T) {
+		resp, err := svc.UpdateDevice(ctx, &trafgenpb.UpdateDeviceRequest{
+			Device: &commonpb.Device{},
+		})
+		require.Nil(t, resp)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("UploadPcap", func(t *testing.T) {
+		resp, err := svc.UploadPcap(ctx, &trafgenpb.UploadPcapRequest{
+			Pcap: buildPcap(t, [][]byte{bytes.Repeat([]byte{0x01}, 64)}),
+		})
+		require.Nil(t, resp)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("SetRate", func(t *testing.T) {
+		resp, err := svc.SetRate(ctx, &trafgenpb.SetRateRequest{RatePps: 1})
+		require.Nil(t, resp)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("ShowConfig", func(t *testing.T) {
+		resp, err := svc.ShowConfig(ctx, &trafgenpb.ShowConfigRequest{})
+		require.Nil(t, resp)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("ShowPackets", func(t *testing.T) {
+		resp, err := svc.ShowPackets(ctx, &trafgenpb.ShowPacketsRequest{})
+		require.Nil(t, resp)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+}
+
+func Test_TrafgenService_InvalidPcap(t *testing.T) {
+	svc, _ := newTestService()
+
+	resp, err := svc.UploadPcap(t.Context(), &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: []byte("not a pcap file"),
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func Test_TrafgenService_EmptyPcap(t *testing.T) {
+	svc, _ := newTestService()
+
+	resp, err := svc.UploadPcap(t.Context(), &trafgenpb.UploadPcapRequest{
+		Name: "trafgen0",
+		Pcap: buildPcap(t, nil),
+	})
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/devices/trafgen/controlplane/trafgenpb/meson.build
+++ b/devices/trafgen/controlplane/trafgenpb/meson.build
@@ -1,0 +1,19 @@
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
+root_dir = meson.project_source_root()
+proto_files = [join_paths(proto_dir, 'trafgen.proto')]
+
+protoc_gen = custom_target(
+    'trafgen-protoc',
+    output: ['trafgen.pb.go', 'trafgen_grpc.pb.go'],
+    input: proto_files,
+    command: [
+        protoc,
+        '-I', proto_dir,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + proto_dir,
+        '--go-grpc_out=paths=source_relative:' + proto_dir,
+        '@INPUT@',
+    ],
+    build_by_default: true,
+)
+trafgen_protoc_gen = protoc_gen

--- a/devices/trafgen/controlplane/trafgenpb/v1/trafgen.proto
+++ b/devices/trafgen/controlplane/trafgenpb/v1/trafgen.proto
@@ -1,0 +1,99 @@
+syntax = "proto3";
+
+package devices.trafgen.controlplane.trafgenpb.v1;
+
+import "common/commonpb/v1/target.proto";
+
+option go_package = "github.com/yanet-platform/yanet2/devices/trafgen/controlplane/trafgenpb/v1;trafgenpb";
+
+// TrafgenService configures the traffic generator device.
+//
+// Pipeline routing, the pcap and the target rate are configured independently:
+// UpdateDevice binds the input/output pipelines the generated traffic flows
+// into, UploadPcap loads the frames to replay, and SetRate sets the constant
+// aggregate packet rate. Each can change without disturbing the others.
+service TrafgenService {
+  // UpdateDevice binds the input and output pipelines of the named generator,
+  // exactly like a physical device.
+  //
+  // Generated traffic is demultiplexed into the configured input pipelines, so
+  // a generator with no input pipeline emits nothing usable.
+  rpc UpdateDevice(UpdateDeviceRequest) returns (UpdateDeviceResponse);
+
+  // ListConfigs returns all generator configurations of the dataplane
+  // instance.
+  rpc ListConfigs(ListConfigsRequest) returns (ListConfigsResponse);
+
+  // ShowConfig returns the current configuration for the named generator.
+  rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse) {}
+
+  // ShowPackets returns the raw frames loaded for the named generator so a
+  // client can decode and display them.
+  rpc ShowPackets(ShowPacketsRequest) returns (ShowPacketsResponse) {}
+
+  // UploadPcap loads the frames to replay from a pcap, keeping the current
+  // rate.
+  rpc UploadPcap(UploadPcapRequest) returns (UploadPcapResponse) {}
+
+  // SetRate sets the constant aggregate packet rate without touching the
+  // loaded pcap.
+  rpc SetRate(SetRateRequest) returns (SetRateResponse) {}
+}
+
+// UpdateDeviceRequest binds the input/output pipelines of a generator.
+message UpdateDeviceRequest {
+  string name = 1;
+  common.commonpb.v1.Device device = 2;
+}
+
+// UpdateDeviceResponse is the response to an UpdateDevice call.
+message UpdateDeviceResponse {}
+
+message ListConfigsRequest {}
+
+// ListConfigsResponse contains existing configuration names.
+message ListConfigsResponse { repeated string configs = 1; }
+
+// ShowConfigRequest retrieves the runtime configuration for a generator.
+message ShowConfigRequest { string name = 1; }
+
+// ShowConfigResponse describes the loaded frames and the target rate.
+message ShowConfigResponse {
+  // Target aggregate packet rate in packets per second.
+  uint64 rate_pps = 1;
+  // Number of frames extracted from the loaded pcap.
+  uint32 frame_count = 2;
+  // Total byte length of the loaded frames.
+  uint64 total_bytes = 3;
+}
+
+// ShowPacketsRequest retrieves the loaded frames for a generator.
+message ShowPacketsRequest { string name = 1; }
+
+// ShowPacketsResponse carries the raw frames in pcap order.
+message ShowPacketsResponse {
+  // Raw L2 frames; one entry per loaded packet.
+  repeated bytes packets = 1;
+  // True when the returned list was capped and omits trailing frames.
+  bool truncated = 2;
+}
+
+// UploadPcapRequest carries the raw pcap bytes whose packets become the frames.
+message UploadPcapRequest {
+  string name = 1;
+  // Raw contents of a pcap file to replay.
+  bytes pcap = 2;
+}
+
+// UploadPcapResponse is the response to an UploadPcap call.
+message UploadPcapResponse {}
+
+// SetRateRequest carries the target aggregate packet rate.
+message SetRateRequest {
+  string name = 1;
+  // Target aggregate packet rate in packets per second; 0 stops generation.
+  uint64 rate_pps = 2;
+}
+
+// SetRateResponse is the response to a SetRate call.
+message SetRateResponse {}

--- a/devices/trafgen/dataplane/config.h
+++ b/devices/trafgen/dataplane/config.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "controlplane/config/zone.h"
+
+// Per-worker generation state.
+//
+// Each worker advances its own cursor and token bucket independently, so the
+// slots live in a per-worker array indexed by dp_worker->idx with no
+// cross-worker contention.
+struct trafgen_worker_state {
+	// Index of the next frame to emit; wraps modulo frame_count.
+	uint64_t cursor;
+
+	// Token bucket accumulator in packet-nanosecond units.
+	//
+	// Each tick adds elapsed_ns * rate_pps; one packet is emitted per
+	// 1e9 * worker_count credit, which spreads rate_pps evenly across
+	// all workers.
+	uint64_t credit;
+
+	// Worker time of the last token bucket refill, in nanoseconds.
+	uint64_t last_time;
+};
+
+// Shared-memory configuration of the trafgen device.
+//
+// Frames extracted from the source pcap are stored as a single concatenated
+// blob plus per-frame offset and length arrays. The dataplane replays them in
+// order, cycling like a ring buffer, pacing emission to the target rate. The
+// device embeds a cp_device, so the generated traffic is demultiplexed into the
+// configured input pipelines exactly like a physical RX device.
+struct cp_device_trafgen {
+	struct cp_device cp_device;
+
+	// Target aggregate packet rate in packets per second; 0 stops emission.
+	uint64_t rate_pps;
+
+	// Number of frames loaded from the source pcap.
+	uint32_t frame_count;
+	uint32_t pad;
+
+	// Total byte length of the concatenated frames blob.
+	uint64_t frames_size;
+
+	// Concatenated raw L2 frame bytes (relative pointer).
+	uint8_t *frames;
+	// Per-frame byte offset into frames (relative pointer, frame_count
+	// items).
+	uint32_t *frame_offsets;
+	// Per-frame byte length (relative pointer, frame_count items).
+	uint32_t *frame_lengths;
+
+	// Per-worker generation cursor (relative pointer, worker_count items).
+	struct trafgen_worker_state *worker_states;
+	uint64_t worker_count;
+};

--- a/devices/trafgen/dataplane/dataplane.c
+++ b/devices/trafgen/dataplane/dataplane.c
@@ -19,13 +19,7 @@
 
 #define TRAFGEN_NS_PER_SEC 1000000000ULL
 
-// Fallback per-tick packet cap when the worker has no configured burst size.
-//
-// The cap bounds packets emitted in a single tick and the token bucket depth,
-// so a worker that was idle (or had its config just swapped) cannot release a
-// huge burst on the next tick. The worker's rx_burst_size is preferred when
-// set, matching the dataplane's RX batching.
-#define TRAFGEN_DEFAULT_MAX_BURST 32
+#define TRAFGEN_MAX_BURST 1024
 
 struct device_trafgen {
 	struct device device;
@@ -120,9 +114,7 @@ trafgen_input_handle(
 	// One packet costs 1e9 * worker_count credit, so each worker emits
 	// rate_pps / worker_count packets per second.
 	uint64_t threshold = TRAFGEN_NS_PER_SEC * config->worker_count;
-	uint64_t max_burst = dp_worker->rx_burst_size != 0
-				     ? dp_worker->rx_burst_size
-				     : TRAFGEN_DEFAULT_MAX_BURST;
+	uint64_t max_burst = TRAFGEN_MAX_BURST;
 	uint64_t credit_cap = threshold * max_burst;
 
 	uint64_t credit = state->credit + elapsed * config->rate_pps;

--- a/devices/trafgen/dataplane/dataplane.c
+++ b/devices/trafgen/dataplane/dataplane.c
@@ -1,0 +1,189 @@
+#include "dataplane.h"
+
+#include <string.h>
+
+#include "config.h"
+
+#include "common/container_of.h"
+#include "common/memory_address.h"
+
+#include "lib/dataplane/device/device.h"
+#include "lib/dataplane/module/packet_front.h"
+#include "lib/dataplane/packet/data.h"
+#include "lib/dataplane/packet/packet.h"
+#include "lib/dataplane/pipeline/econtext.h"
+#include "lib/dataplane/worker/worker.h"
+
+#include <rte_mbuf.h>
+#include <rte_memcpy.h>
+
+#define TRAFGEN_NS_PER_SEC 1000000000ULL
+
+// Fallback per-tick packet cap when the worker has no configured burst size.
+//
+// The cap bounds packets emitted in a single tick and the token bucket depth,
+// so a worker that was idle (or had its config just swapped) cannot release a
+// huge burst on the next tick. The worker's rx_burst_size is preferred when
+// set, matching the dataplane's RX batching.
+#define TRAFGEN_DEFAULT_MAX_BURST 32
+
+struct device_trafgen {
+	struct device device;
+};
+
+// Build one packet from the frame at frame_idx and enqueue it for output.
+//
+// Returns 0 on success, -1 when the mbuf pool is exhausted (caller should stop
+// the current burst) and 1 when the frame is malformed (caller should skip it).
+static int
+trafgen_emit_frame(
+	struct dp_worker *dp_worker,
+	struct cp_device_trafgen *config,
+	struct packet_front *packet_front,
+	uint32_t frame_idx
+) {
+	const uint8_t *frames = ADDR_OF(&config->frames);
+	const uint32_t *offsets = ADDR_OF(&config->frame_offsets);
+	const uint32_t *lengths = ADDR_OF(&config->frame_lengths);
+
+	uint32_t len = lengths[frame_idx];
+
+	struct packet *packet = worker_packet_alloc(dp_worker);
+	if (packet == NULL) {
+		return -1;
+	}
+
+	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+	char *data = rte_pktmbuf_append(mbuf, len);
+	if (data == NULL) {
+		worker_packet_free(packet);
+		return 1;
+	}
+	rte_memcpy(data, frames + offsets[frame_idx], len);
+
+	memset(packet, 0, sizeof(*packet));
+	packet->mbuf = mbuf;
+	packet->rx_device_id = dp_worker->device_id;
+	packet->tx_device_id = dp_worker->device_id;
+
+	if (parse_packet(packet)) {
+		worker_packet_free(packet);
+		return 1;
+	}
+
+	packet_front_output(packet_front, packet);
+	return 0;
+}
+
+// Replay the loaded frames on the device input path, pacing to the target rate.
+//
+// The device registry force-polls every device input handler once per worker
+// tick, so the generator sources fresh traffic even when no packet arrives from
+// a NIC. The emitted packets land in packet_front->output and are demultiplexed
+// into the device's configured input pipelines by the pipeline runtime. A
+// per-worker token bucket accrues elapsed_ns * rate_pps and releases one packet
+// per 1e9 * worker_count credit, which divides rate_pps evenly across all
+// workers.
+static void
+trafgen_input_handle(
+	struct dp_worker *dp_worker,
+	struct device_ectx *device_ectx,
+	struct packet_front *packet_front
+) {
+	struct cp_device_trafgen *config = container_of(
+		ADDR_OF(&device_ectx->cp_device),
+		struct cp_device_trafgen,
+		cp_device
+	);
+
+	// Forward anything that arrived on this device unchanged; a generator
+	// has no real RX, so this is normally empty.
+	packet_list_concat(&packet_front->output, &packet_front->input);
+
+	if (config->frame_count == 0 || config->rate_pps == 0 ||
+	    config->worker_count == 0) {
+		return;
+	}
+
+	struct trafgen_worker_state *state =
+		ADDR_OF(&config->worker_states) + dp_worker->idx;
+
+	uint64_t now = dp_worker->current_time;
+	if (state->last_time == 0) {
+		// First tick after (re)load: anchor the clock, emit nothing.
+		state->last_time = now;
+		return;
+	}
+	uint64_t elapsed = now > state->last_time ? now - state->last_time : 0;
+	state->last_time = now;
+
+	// One packet costs 1e9 * worker_count credit, so each worker emits
+	// rate_pps / worker_count packets per second.
+	uint64_t threshold = TRAFGEN_NS_PER_SEC * config->worker_count;
+	uint64_t max_burst = dp_worker->rx_burst_size != 0
+				     ? dp_worker->rx_burst_size
+				     : TRAFGEN_DEFAULT_MAX_BURST;
+	uint64_t credit_cap = threshold * max_burst;
+
+	uint64_t credit = state->credit + elapsed * config->rate_pps;
+	if (credit > credit_cap) {
+		credit = credit_cap;
+	}
+
+	uint64_t cursor = state->cursor;
+	uint64_t emitted = 0;
+	while (credit >= threshold && emitted < max_burst) {
+		uint32_t frame_idx = cursor % config->frame_count;
+		cursor += 1;
+
+		int rc = trafgen_emit_frame(
+			dp_worker, config, packet_front, frame_idx
+		);
+		if (rc < 0) {
+			// Mbuf pool exhausted; keep the unspent credit.
+			break;
+		}
+		credit -= threshold;
+		emitted += 1;
+	}
+
+	state->cursor = cursor;
+	state->credit = credit;
+}
+
+// Pass packets routed to this device for transmission straight through.
+//
+// A generator has no real TX queue, so the output path simply forwards anything
+// a pipeline scheduled onto it without modification.
+static void
+trafgen_output_handle(
+	struct dp_worker *dp_worker,
+	struct device_ectx *device_ectx,
+	struct packet_front *packet_front
+) {
+	(void)dp_worker;
+	(void)device_ectx;
+
+	packet_list_concat(&packet_front->output, &packet_front->input);
+}
+
+struct device *
+new_device_trafgen() {
+	struct device_trafgen *device =
+		(struct device_trafgen *)malloc(sizeof(struct device_trafgen));
+
+	if (device == NULL) {
+		return NULL;
+	}
+
+	snprintf(
+		device->device.name,
+		sizeof(device->device.name),
+		"%s",
+		"trafgen"
+	);
+	device->device.input_handler = trafgen_input_handle;
+	device->device.output_handler = trafgen_output_handle;
+
+	return &device->device;
+}

--- a/devices/trafgen/dataplane/dataplane.c
+++ b/devices/trafgen/dataplane/dataplane.c
@@ -1,5 +1,6 @@
 #include "dataplane.h"
 
+#include <stdint.h>
 #include <string.h>
 
 #include "config.h"
@@ -41,6 +42,14 @@ trafgen_emit_frame(
 	const uint32_t *lengths = ADDR_OF(&config->frame_lengths);
 
 	uint32_t len = lengths[frame_idx];
+
+	// rte_pktmbuf_append() reserves tailroom with a 16-bit length, so a
+	// larger frame would wrap and let the copy below overrun the mbuf. The
+	// control plane rejects such frames at upload; guard the copy
+	// regardless.
+	if (len > UINT16_MAX) {
+		return 1;
+	}
 
 	struct packet *packet = worker_packet_alloc(dp_worker);
 	if (packet == NULL) {

--- a/devices/trafgen/dataplane/dataplane.h
+++ b/devices/trafgen/dataplane/dataplane.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "lib/dataplane/device/device.h"
+
+struct device *
+new_device_trafgen();

--- a/devices/trafgen/dataplane/meson.build
+++ b/devices/trafgen/dataplane/meson.build
@@ -1,0 +1,28 @@
+dp_dependencies = [
+  lib_common_dep,
+  lib_packet_dp_dep,
+  lib_module_dp_dep,
+  lib_worker_dp_dep,
+]
+
+dp_sources = files(
+    'dataplane.c',
+)
+
+lib_dev_trafgen_dp = static_library(
+    'trafgen_dp',
+    dp_sources,
+    c_args: yanet_c_args,
+    link_args: yanet_link_args,
+    dependencies: dp_dependencies,
+    install: false,
+)
+
+lib_dev_trafgen_dp_dep = declare_dependency(
+    link_with: lib_dev_trafgen_dp,
+    link_args: [
+        '-Wl,--defsym',
+        '-Wl,new_device_trafgen=new_device_trafgen',
+        '-Wl,--export-dynamic-symbol=new_device_trafgen',
+    ],
+)

--- a/devices/trafgen/meson.build
+++ b/devices/trafgen/meson.build
@@ -1,0 +1,7 @@
+subdir('dataplane')
+
+if not dataplane_only
+  subdir('api')
+  subdir('controlplane')
+  subdir('tests')
+endif

--- a/devices/trafgen/tests/leak_test.c
+++ b/devices/trafgen/tests/leak_test.c
@@ -1,0 +1,29 @@
+#include "common/test_assert.h"
+#include "devices/trafgen/api/controlplane.h"
+#include "lib/errors/errors.h"
+
+int
+main(void) {
+	yanet_error *err = NULL;
+
+	struct cp_device_trafgen_config *cfg =
+		cp_device_trafgen_config_new("test", 4, 4, &err);
+	TEST_ASSERT_NOT_NULL(cfg, "cp_device_trafgen_config_new returned NULL");
+	TEST_ASSERT_NULL(
+		err, "unexpected error from cp_device_trafgen_config_new"
+	);
+
+	int res = cp_device_trafgen_config_set_input_pipeline(cfg, 0, "p0", 1);
+	TEST_ASSERT_EQUAL(
+		res, 0, "cp_device_trafgen_config_set_input_pipeline failed"
+	);
+
+	res = cp_device_trafgen_config_set_output_pipeline(cfg, 0, "p0", 1);
+	TEST_ASSERT_EQUAL(
+		res, 0, "cp_device_trafgen_config_set_output_pipeline failed"
+	);
+
+	cp_device_trafgen_config_free(cfg);
+
+	return 0;
+}

--- a/devices/trafgen/tests/meson.build
+++ b/devices/trafgen/tests/meson.build
@@ -1,0 +1,16 @@
+trafgen_leak_test = executable(
+  'trafgen_leak_test',
+  'leak_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_dev_trafgen_api_dep,
+    lib_config_cp_dep,
+    lib_agent_cp_dep,
+    lib_common_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+  ],
+  include_directories: yanet_rootdir,
+)
+test('trafgen_leak', trafgen_leak_test, suite: 'devices')

--- a/devices/trafgen/web/TrafgenDetail.tsx
+++ b/devices/trafgen/web/TrafgenDetail.tsx
@@ -1,0 +1,183 @@
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { PacketTable, PacketInspector } from '@yanet/core/components/packet';
+import type { PacketRow } from '@yanet/core/components/packet';
+import { parsePacket } from '@yanet/core/utils/packetParser';
+import { parsePcapFile } from '@yanet/core/utils/pcapFile';
+import { toaster } from '@yanet/core/utils';
+import type { DeviceDetailProps } from '@yanet/core/registry';
+import { trafgenExt } from './types';
+
+/** Generator controls + Frames + inspector panel for trafgen devices. */
+const TrafgenDetail = (props: DeviceDetailProps): React.JSX.Element => {
+    const { device, onUpdateExt } = props;
+
+    // Read via the helper, which supplies defaults: a server-loaded generator
+    // has no ext slice until loadDeviceExt hydrates it asynchronously.
+    const ext = trafgenExt(device);
+
+    const deviceName = device.id.name ?? '';
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const [selectedFrameId, setSelectedFrameId] = useState<number | null>(null);
+    const [frameDrawerOpen, setFrameDrawerOpen] = useState(false);
+    const [frameSearch, setFrameSearch] = useState('');
+
+    // Reset the frame inspector whenever the selected generator changes.
+    useEffect(() => {
+        setSelectedFrameId(null);
+        setFrameDrawerOpen(false);
+        setFrameSearch('');
+    }, [deviceName]);
+
+    const handleRateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const val = parseInt(e.target.value, 10);
+        onUpdateExt({ ratePps: isNaN(val) ? 0 : Math.max(0, val) });
+    }, [onUpdateExt]);
+
+    const handleChoosePcap = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) { return; }
+        const reader = new FileReader();
+        reader.onload = (ev) => {
+            try {
+                const buffer = ev.target?.result;
+                if (!(buffer instanceof ArrayBuffer)) { return; }
+                const bytes = new Uint8Array(buffer);
+                const frames = parsePcapFile(bytes);
+                let idx = 0;
+                const rows: PacketRow[] = frames.map(frame => ({ id: idx++, parsed: parsePacket(frame) }));
+                onUpdateExt({ stagedPcapBytes: bytes, stagedFramePackets: rows });
+                setSelectedFrameId(null);
+                setFrameDrawerOpen(false);
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                toaster.error('trafgen-pcap-parse', `Failed to parse pcap: ${msg}`);
+            }
+        };
+        reader.onerror = () => toaster.error('trafgen-pcap-read', 'Failed to read file.');
+        reader.readAsArrayBuffer(file);
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
+    }, [onUpdateExt]);
+
+    const handleCancelStagedPcap = useCallback(() => {
+        onUpdateExt({ stagedPcapBytes: null, stagedFramePackets: undefined });
+        setSelectedFrameId(null);
+        setFrameDrawerOpen(false);
+    }, [onUpdateExt]);
+
+    const effectiveFrames = useMemo(
+        () => ext.stagedFramePackets ?? ext.framePackets ?? [],
+        [ext.stagedFramePackets, ext.framePackets],
+    );
+
+    const handleSelectFrame = useCallback((packet: PacketRow | null) => {
+        if (packet) {
+            setSelectedFrameId(packet.id);
+            setFrameDrawerOpen(true);
+        } else {
+            setSelectedFrameId(null);
+            setFrameDrawerOpen(false);
+        }
+    }, []);
+
+    const selectedFrameIndex = useMemo(
+        () => effectiveFrames.findIndex(p => p.id === selectedFrameId),
+        [effectiveFrames, selectedFrameId],
+    );
+
+    const inspectorFrame = selectedFrameId !== null
+        ? effectiveFrames.find(p => p.id === selectedFrameId) ?? null
+        : null;
+
+    const stagedFrameCount = ext.stagedFramePackets?.length ?? 0;
+    const pcapStaged = ext.stagedPcapBytes != null;
+
+    return (
+        <>
+            <div className="dv-section">
+                <div className="dv-section-hd"><span>Generator</span></div>
+                <div className="dv-gen-controls">
+                    <div className="dv-gen-group">
+                        <label className="dv-gen-lbl" htmlFor="dv-gen-rate">Rate</label>
+                        <input
+                            id="dv-gen-rate"
+                            className="dv-gen-rate mono"
+                            type="number"
+                            min={0}
+                            step={1}
+                            value={String(ext.ratePps ?? 0)}
+                            onChange={handleRateChange}
+                        />
+                        <span className="dv-gen-unit">pps</span>
+                    </div>
+                    <div className="dv-gen-group">
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept=".pcap,.pcapng"
+                            style={{ display: 'none' }}
+                            onChange={handleChoosePcap}
+                        />
+                        <button className="btn-secondary" onClick={() => fileInputRef.current?.click()}>
+                            Choose pcap…
+                        </button>
+                        {pcapStaged && (
+                            <>
+                                <span className="dv-gen-hint">
+                                    {stagedFrameCount} frame{stagedFrameCount !== 1 ? 's' : ''} staged · saves on Save
+                                </span>
+                                <button className="btn-secondary" onClick={handleCancelStagedPcap}>
+                                    Cancel
+                                </button>
+                            </>
+                        )}
+                    </div>
+                </div>
+                {ext.truncated && !pcapStaged && (
+                    <div className="dv-gen-note">The preview shows a capped subset of the uploaded frames.</div>
+                )}
+            </div>
+
+            <div className="dv-section">
+                <div className="dv-section-hd"><span>Frames</span></div>
+                <div className="dv-gen-frames">
+                    <PacketTable
+                        key={deviceName || 'empty'}
+                        packets={effectiveFrames}
+                        selectedPacketId={selectedFrameId}
+                        onSelectPacket={handleSelectFrame}
+                        searchQuery={frameSearch}
+                        onSearchQueryChange={setFrameSearch}
+                        isLive={false}
+                        emptyMessage="No frames loaded. Choose a pcap file to stage one."
+                        emptyFilterMessage="No frames match the filter."
+                        showTimeColumn={false}
+                        showToolbarActions={false}
+                        footerNote={<span>{effectiveFrames.length > 0 ? 'Click to inspect' : ''}</span>}
+                    />
+                </div>
+            </div>
+
+            <PacketInspector
+                open={frameDrawerOpen}
+                packet={inspectorFrame}
+                packetIndex={selectedFrameIndex}
+                totalPackets={effectiveFrames.length}
+                onClose={() => { setSelectedFrameId(null); setFrameDrawerOpen(false); }}
+                onPrev={() => {
+                    const idx = effectiveFrames.findIndex(p => p.id === selectedFrameId);
+                    if (idx > 0) { setSelectedFrameId(effectiveFrames[idx - 1].id); }
+                }}
+                onNext={() => {
+                    const idx = effectiveFrames.findIndex(p => p.id === selectedFrameId);
+                    if (idx >= 0 && idx < effectiveFrames.length - 1) { setSelectedFrameId(effectiveFrames[idx + 1].id); }
+                }}
+                title="Frame"
+            />
+        </>
+    );
+};
+
+export default TrafgenDetail;

--- a/devices/trafgen/web/api.ts
+++ b/devices/trafgen/web/api.ts
@@ -1,0 +1,61 @@
+import { createService, type CallOptions } from '@yanet/core/api/client';
+import type { Device } from '@yanet/core/api/devices';
+
+export interface TrafgenListConfigsResponse {
+    configs?: string[];
+}
+
+export interface TrafgenUpdateDeviceRequest {
+    name: string;
+    /** Input/output pipeline assignments the generated traffic flows into. */
+    device: Device;
+}
+
+export interface TrafgenShowConfigResponse {
+    /** Target aggregate rate in packets per second (arrives as string — uint64 on the wire). */
+    rate_pps?: string;
+    frame_count?: number;
+    /** Total bytes of the loaded pcap frames (arrives as string — uint64 on the wire). */
+    total_bytes?: string;
+}
+
+export interface TrafgenShowPacketsResponse {
+    /** Each entry is a base64-encoded raw L2 frame. */
+    packets?: string[];
+    /** True when the server returned a capped subset of the available frames. */
+    truncated?: boolean;
+}
+
+export interface TrafgenUploadPcapRequest {
+    name: string;
+    /** Base64-encoded raw .pcap file bytes. */
+    pcap: string;
+}
+
+export interface TrafgenSetRateRequest {
+    name: string;
+    /** Target aggregate rate in packets per second. */
+    rate_pps: number;
+}
+
+const trafgenService = createService('devices.trafgen.controlplane.trafgenpb.v1.TrafgenService');
+
+export const trafgen = {
+    updateDevice: (request: TrafgenUpdateDeviceRequest, options?: CallOptions): Promise<Record<string, never>> =>
+        trafgenService.callWithBody<Record<string, never>>('UpdateDevice', request, options),
+
+    listConfigs: (options?: CallOptions): Promise<TrafgenListConfigsResponse> =>
+        trafgenService.call<TrafgenListConfigsResponse>('ListConfigs', options),
+
+    showConfig: (name: string, options?: CallOptions): Promise<TrafgenShowConfigResponse> =>
+        trafgenService.callWithBody<TrafgenShowConfigResponse>('ShowConfig', { name }, options),
+
+    showPackets: (name: string, options?: CallOptions): Promise<TrafgenShowPacketsResponse> =>
+        trafgenService.callWithBody<TrafgenShowPacketsResponse>('ShowPackets', { name }, options),
+
+    uploadPcap: (request: TrafgenUploadPcapRequest, options?: CallOptions): Promise<Record<string, never>> =>
+        trafgenService.callWithBody<Record<string, never>>('UploadPcap', request, options),
+
+    setRate: (request: TrafgenSetRateRequest, options?: CallOptions): Promise<Record<string, never>> =>
+        trafgenService.callWithBody<Record<string, never>>('SetRate', request, options),
+};

--- a/devices/trafgen/web/device.ts
+++ b/devices/trafgen/web/device.ts
@@ -1,0 +1,122 @@
+import './trafgen.scss';
+import { toDevicePayload } from '@yanet/core/api';
+import { base64ToUint8Array, parsePacket } from '@yanet/core/utils/packetParser';
+import type { PacketRow } from '@yanet/core/components/packet';
+import type { BaseDevice, DeviceTypeManifest } from '@yanet/core/registry';
+import { trafgen } from './api';
+import { trafgenExt } from './types';
+import { IconGenerator } from './icon';
+
+/** Encode a Uint8Array as base64. */
+const uint8ArrayToBase64 = (bytes: Uint8Array): string => {
+    let binary = '';
+    for (let idx = 0; idx < bytes.length; idx++) {
+        binary += String.fromCharCode(bytes[idx]);
+    }
+    return btoa(binary);
+};
+
+/** Decode base64 L2 frames into displayable packet rows. */
+const framesToPackets = (frames: string[] | undefined): PacketRow[] => {
+    let idx = 0;
+    return (frames ?? []).map(b64 => ({ id: idx++, parsed: parsePacket(base64ToUint8Array(b64)) }));
+};
+
+const loadData = async (device: BaseDevice): Promise<Record<string, unknown>> => {
+    const name = device.id.name ?? '';
+    let ratePps = 0;
+    let framePackets: PacketRow[] = [];
+    let truncated = false;
+    try {
+        const [cfg, pkts] = await Promise.all([
+            trafgen.showConfig(name),
+            trafgen.showPackets(name),
+        ]);
+        ratePps = Number(cfg.rate_pps ?? '0');
+        framePackets = framesToPackets(pkts.packets);
+        truncated = pkts.truncated ?? false;
+    } catch {
+        // No server-side config yet; fall through with the empty defaults.
+    }
+    return { ratePps, framePackets, truncated, stagedPcapBytes: null };
+};
+
+const save = async (
+    device: BaseDevice,
+    snapshot: BaseDevice | undefined,
+): Promise<Record<string, unknown>> => {
+    const name = device.id.name ?? '';
+    const ext = trafgenExt(device);
+    const snapExt = snapshot ? trafgenExt(snapshot) : undefined;
+
+    const pipelinesDirty = device.isNew || !snapshot
+        || JSON.stringify(device.inputPipelines) !== JSON.stringify(snapshot.inputPipelines)
+        || JSON.stringify(device.outputPipelines) !== JSON.stringify(snapshot.outputPipelines);
+    const rateDirty = device.isNew
+        || (snapExt != null && ext.ratePps !== snapExt.ratePps);
+    const pcapStaged = ext.stagedPcapBytes != null;
+
+    if (pipelinesDirty) {
+        await trafgen.updateDevice({
+            name,
+            device: toDevicePayload(device.inputPipelines, device.outputPipelines),
+        });
+    }
+    if (rateDirty) {
+        await trafgen.setRate({ name, rate_pps: ext.ratePps });
+    }
+
+    let framePackets = ext.framePackets;
+    let truncated = ext.truncated;
+    if (pcapStaged && ext.stagedPcapBytes) {
+        await trafgen.uploadPcap({ name, pcap: uint8ArrayToBase64(ext.stagedPcapBytes) });
+        const pkts = await trafgen.showPackets(name);
+        framePackets = framesToPackets(pkts.packets);
+        truncated = pkts.truncated ?? false;
+    }
+
+    return {
+        ratePps: ext.ratePps,
+        framePackets,
+        truncated,
+        stagedPcapBytes: null,
+        stagedFramePackets: undefined,
+    };
+};
+
+export const deviceType: DeviceTypeManifest = {
+    type: 'trafgen',
+    label: 'Generator',
+    pluralLabel: 'Generators',
+    navOrder: 30,
+    icon: IconGenerator,
+    accentColor: '#e8a13c',
+    kindTag: () => 'GENERATOR',
+    typeDescription: 'generator (trafgen)',
+    trafficSource: true,
+    rowSubtitle: () => 'generator · —',
+    propertyRows: (device) => {
+        const ext = trafgenExt(device);
+        return [
+            { label: 'Rate', value: `${ext.ratePps} pps`, mono: true },
+            { label: 'Frames', value: String(ext.framePackets.length), mono: true },
+        ];
+    },
+    createDefaults: () => ({
+        ratePps: 0,
+        framePackets: [],
+        truncated: false,
+        stagedPcapBytes: null,
+    }),
+    loadData,
+    save,
+    extDirty: (device, snapshot) => {
+        const ext = trafgenExt(device);
+        const snapExt = snapshot ? trafgenExt(snapshot) : undefined;
+        return device.isNew
+            || (snapExt != null && ext.ratePps !== snapExt.ratePps)
+            || ext.stagedPcapBytes != null;
+    },
+    confirmViaDiff: false,
+    loadDetail: () => import('./TrafgenDetail'),
+};

--- a/devices/trafgen/web/icon.tsx
+++ b/devices/trafgen/web/icon.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/** Waveform icon for trafgen (traffic generator) devices. */
+export const IconGenerator = ({
+    size = 16,
+    color = 'currentColor',
+}: {
+    size?: number;
+    color?: string;
+}): React.JSX.Element => (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none" stroke={color} strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M1.5 8h2L5 4l2 8 2-10 2 12 1.5-6h2" />
+    </svg>
+);

--- a/devices/trafgen/web/trafgen.scss
+++ b/devices/trafgen/web/trafgen.scss
@@ -1,0 +1,97 @@
+.devices-page-v2 {
+    .dv-kind-tag.kind-trafgen {
+        background: rgba(232, 161, 60, 0.1);
+        color: #e8a13c;
+        border: 1px solid rgba(232, 161, 60, 0.22);
+    }
+
+    .dv-gen-controls {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        flex-wrap: wrap;
+    }
+
+    .dv-gen-group {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+
+    .btn-secondary {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        height: 30px;
+        box-sizing: border-box;
+        padding: 0 12px;
+        background: var(--bg-2);
+        color: var(--fg-1);
+        border: 1px solid var(--border-strong);
+        border-radius: 5px;
+        font-family: var(--sans);
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
+
+        &:hover {
+            background: var(--bg-3);
+            border-color: var(--accent);
+            color: var(--fg);
+        }
+
+        &:active {
+            background: var(--bg-3);
+        }
+    }
+
+    .dv-gen-lbl {
+        font-size: 12px;
+        color: var(--fg-2);
+    }
+
+    .dv-gen-rate {
+        width: 130px;
+        height: 30px;
+        box-sizing: border-box;
+        background: var(--bg-2);
+        border: 1px solid var(--border-strong);
+        border-radius: 5px;
+        color: var(--fg);
+        font-family: var(--mono);
+        font-size: 13px;
+        padding: 0 10px;
+        outline: none;
+
+        &:focus {
+            border-color: var(--accent);
+        }
+    }
+
+    .dv-gen-unit {
+        font-size: 12px;
+        color: var(--fg-3);
+    }
+
+    .dv-gen-hint {
+        font-size: 11px;
+        color: var(--fg-3);
+    }
+
+    .dv-gen-note {
+        font-size: 11.5px;
+        color: var(--fg-3);
+        margin-top: 8px;
+    }
+
+    .dv-gen-frames {
+        // Full-bleed past the scroll padding so the shared packet table
+        // (min-width 800px) fits without clipping or horizontal scroll.
+        // The table sizes its own height and carries its own border.
+        margin: 0 -16px;
+        min-height: 300px;
+        display: flex;
+        flex-direction: column;
+    }
+}

--- a/devices/trafgen/web/types.ts
+++ b/devices/trafgen/web/types.ts
@@ -1,0 +1,24 @@
+import type { PacketRow } from '@yanet/core/components/packet';
+import type { BaseDevice } from '@yanet/core/registry';
+
+export type { PacketRow };
+
+/** Per-device editable state for trafgen generators. */
+export interface TrafgenExt {
+    ratePps: number;
+    framePackets: PacketRow[];
+    truncated: boolean;
+    stagedPcapBytes: Uint8Array | null;
+    stagedFramePackets?: PacketRow[];
+}
+
+/** Read the trafgen ext slice from a BaseDevice with safe defaults. */
+export const trafgenExt = (device: BaseDevice): TrafgenExt => {
+    const raw = device.ext.trafgen as TrafgenExt | undefined;
+    return raw ?? {
+        ratePps: 0,
+        framePackets: [],
+        truncated: false,
+        stagedPcapBytes: null,
+    };
+};


### PR DESCRIPTION
Add the trafgen device across the stack: a dataplane pcap-replay generator, its control plane and CLI, and a web UI.

The web UI registers with the device-type registry as a co-located plugin under devices/trafgen/web — generator rate, pcap upload, a frame inspector, and traffic-source throughput classification — with no changes to the core Devices page. It builds on the registry, the device park/drain reclamation mechanism, and the trafficSource capability already on main.

Changes outside devices/trafgen are limited to the build glue needed to register a new device (Makefile, meson, Cargo, the control-plane bundle, and the dataplane device table).