### PR TITLE
fix(web): serve the SPA shell for built-in page reloads in dev

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,14 +1,44 @@
 /// <reference types="vitest" />
 import { fileURLToPath } from 'node:url';
-import { defineConfig, searchForWorkspaceRoot } from 'vite';
+import { defineConfig, searchForWorkspaceRoot, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 
 const ReactCompilerConfig = {};
 
 const rootDir = fileURLToPath(new URL('.', import.meta.url));
 
+// Serve the SPA shell for HTML navigations whose path collides with a
+// co-located source directory.
+//
+// Built-in pages live under web/builtin/<page>/ with an index.ts barrel while
+// their routes are /builtin/<page>. On a hard reload the dev server otherwise
+// resolves the bare path to that directory's index module and serves it as
+// JavaScript instead of index.html. Rewriting extensionless HTML GET requests
+// to / forces the SPA fallback before that directory-index resolution runs.
+const spaHtmlFallback = (): Plugin => ({
+    name: 'yanet-spa-html-fallback',
+    configureServer(server) {
+        server.middlewares.use((req, _res, next) => {
+            const accept = String(req.headers.accept ?? '');
+            const url = (req.url ?? '').split('?')[0];
+            if (
+                req.method === 'GET' &&
+                accept.includes('text/html') &&
+                url !== '/' &&
+                !url.startsWith('/@') &&
+                !url.startsWith('/api') &&
+                !/\.[^/]+$/.test(url)
+            ) {
+                req.url = '/';
+            }
+            next();
+        });
+    },
+});
+
 export default defineConfig({
     plugins: [
+        spaHtmlFallback(),
         react({
             babel: {
                 plugins: [['babel-plugin-react-compiler', ReactCompilerConfig]],


### PR DESCRIPTION
A hard reload of a built-in page route such as /builtin/devices resolved to the co-located source directory web/builtin/devices and was served as that directory's index module (JavaScript) instead of the SPA shell, because the route path collides with the source directory. The page then rendered as raw module text.

A small dev-server middleware now rewrites extensionless HTML navigations to the SPA entry before vite's directory-index resolution runs, so reloads land on the correct page. This affects the dev server only; production builds are unchanged.