### PR TITLE
feat(route): select best routes per gateway from its local RIB

### DIFF
--- a/common/go/rcucache/cache.go
+++ b/common/go/rcucache/cache.go
@@ -76,3 +76,8 @@ func (m CacheView[K, V]) Lookup(key K) (V, bool) {
 func (m CacheView[K, V]) Entries() (iter.Seq[V], int) {
 	return maps.Values(m.cache), len(m.cache)
 }
+
+// All returns the cache entries as a key-value iterator.
+func (m CacheView[K, V]) All() (iter.Seq2[K, V], int) {
+	return maps.All(m.cache), len(m.cache)
+}

--- a/operators/route/internal/discovery/neigh/neigh.go
+++ b/operators/route/internal/discovery/neigh/neigh.go
@@ -24,6 +24,33 @@ type NexthopCache = rcucache.Cache[netip.Addr, NeighbourEntry]
 // NexthopCacheView is a read-only view of the nexthop cache.
 type NexthopCacheView = rcucache.CacheView[netip.Addr, NeighbourEntry]
 
+// FilterByDevices returns a view exposing only the entries whose hardware
+// route egresses through one of the named devices.
+//
+// An empty device list returns the original view unchanged, meaning the
+// caller accepts every neighbour regardless of egress device.
+func FilterByDevices(view NexthopCacheView, devices []string) NexthopCacheView {
+	set := make(map[string]struct{}, len(devices))
+	for _, d := range devices {
+		if d != "" {
+			set[d] = struct{}{}
+		}
+	}
+	if len(set) == 0 {
+		return view
+	}
+
+	entries, n := view.All()
+	filtered := make(map[netip.Addr]NeighbourEntry, n)
+	for addr, entry := range entries {
+		if _, ok := set[entry.HardwareRoute.Device]; ok {
+			filtered[addr] = entry
+		}
+	}
+
+	return rcucache.NewCache(filtered).View()
+}
+
 // Option is a function that configures the neighbour monitor.
 type Option func(*options)
 

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -13,6 +13,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
+	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 )
 
 // GatewayActuator applies route-operator state to a single Gateway via
@@ -22,7 +23,7 @@ type GatewayActuator struct {
 	conn        *grpc.ClientConn
 	routes      routepb.RouteServiceClient
 	funcApplier *operator.FunctionApplier
-	devices     map[string]struct{}
+	devices     []string
 	log         *zap.Logger
 }
 
@@ -50,13 +51,6 @@ func NewGatewayActuator(
 		return nil, fmt.Errorf("failed to dial gateway %q at %q: %w", cfg.Name, endpoint, err)
 	}
 
-	deviceSet := map[string]struct{}{}
-	for _, d := range opts.Devices {
-		if d != "" {
-			deviceSet[d] = struct{}{}
-		}
-	}
-
 	fn := opts.Function
 	spec := operator.FunctionChainSpec{
 		Name:   fn.Name.Unwrap(),
@@ -77,7 +71,7 @@ func NewGatewayActuator(
 			spec,
 			operator.WithIgnorePdump(fn.IgnorePdump),
 		),
-		devices: deviceSet,
+		devices: opts.Devices,
 		log: opts.Log.With(
 			zap.String("gateway", cfg.Name),
 			zap.String("function", fn.Name.Unwrap()),
@@ -90,18 +84,23 @@ func (m *GatewayActuator) Close() error {
 	return m.conn.Close()
 }
 
-// Apply pushes every FIB in fibs to the gateway via UpdateFIB.
+// Apply builds and pushes the FIB for each module config to the gateway,
+// then republishes the operator's network function.
 //
-// Errors from individual FIBs are joined; the reconcile loop applies
-// backoff, so each Apply pass tries every FIB regardless of partial
-// failures.
-func (m *GatewayActuator) Apply(ctx context.Context, fibs []FIB) error {
+// Every FIB is attempted and the function is published even on a partial
+// failure; the joined errors let the reconcile loop retry under backoff.
+func (m *GatewayActuator) Apply(ctx context.Context, snapshot RouteSnapshot) error {
+	neighbours := neigh.FilterByDevices(snapshot.Neighbours, m.devices)
+
 	var err error
-	for _, fib := range fibs {
-		if fib.Name == "" {
+	for name, dump := range snapshot.RIBs {
+		if name == "" {
 			err = errors.Join(err, fmt.Errorf("FIB is missing module config name"))
 			continue
 		}
+
+		fib, _ := BuildFIB(dump, neighbours)
+		fib.Name = name
 		if e := m.pushFIB(ctx, fib); e != nil {
 			err = errors.Join(err, fmt.Errorf("failed to push FIB to gateway %q: %w", m.name, e))
 		}
@@ -129,9 +128,8 @@ func (m *GatewayActuator) applyFunction(ctx context.Context) error {
 
 // pushFIB applies fib to the gateway via the UpdateFIB unary RPC.
 func (m *GatewayActuator) pushFIB(ctx context.Context, fib FIB) error {
-	filtered := filterFIBEntries(fib.Entries, m.devices)
-	entries := make([]*routepb.FIBEntry, len(filtered))
-	for idx, entry := range filtered {
+	entries := make([]*routepb.FIBEntry, len(fib.Entries))
+	for idx, entry := range fib.Entries {
 		entries[idx] = fibEntryToProto(entry)
 	}
 

--- a/operators/route/internal/operator/fib_build.go
+++ b/operators/route/internal/operator/fib_build.go
@@ -34,40 +34,19 @@ type FIBBuildStats struct {
 	NeighbourNotFound int
 	HardwareRoutes    int
 	PrefixesAdded     int
-	// FilteredRoutes counts routes excluded by the per-source best-group filter.
+	// FilteredRoutes counts eligible routes dropped because a better route
+	// of the same source exists.
 	FilteredRoutes int
-}
-
-// filterFIBEntries returns the subset of entries whose nexthops include at
-// least one device present in the given set.
-//
-// When the device set is empty every entry is returned unchanged.
-func filterFIBEntries(entries []FIBEntry, devices map[string]struct{}) []FIBEntry {
-	if len(devices) == 0 {
-		return entries
-	}
-
-	result := make([]FIBEntry, 0, len(entries))
-	for _, entry := range entries {
-		kept := make([]neigh.HardwareRoute, 0, len(entry.Nexthops))
-		for idx := range entry.Nexthops {
-			if _, ok := devices[entry.Nexthops[idx].Device]; ok {
-				kept = append(kept, entry.Nexthops[idx])
-			}
-		}
-		if len(kept) == 0 {
-			continue
-		}
-		result = append(result, FIBEntry{
-			Prefix:   entry.Prefix,
-			Nexthops: kept,
-		})
-	}
-	return result
 }
 
 // BuildFIB resolves a RIB dump against the supplied neighbour view and
 // produces a deduplicated FIB.
+//
+// A route is eligible only when its nexthop resolves in the neighbour view;
+// pass a device-filtered view to restrict a gateway to its own egress
+// devices. The best routes per source are chosen among the eligible routes,
+// so a gateway can fall back to a lower-priority route it can actually reach
+// rather than a globally best one it cannot.
 func BuildFIB(
 	ribDump maptrie.MapTrie[netip.Prefix, netip.Addr, rib.RoutesList],
 	neighbours neigh.NexthopCacheView,
@@ -86,23 +65,31 @@ func BuildFIB(
 
 			stats.TotalRoutes += len(routesList.Routes)
 
-			bestRoutes := routesList.BestPerSource()
-			stats.FilteredRoutes += len(routesList.Routes) - len(bestRoutes)
-
-			nexthops := make([]neigh.HardwareRoute, 0, len(bestRoutes))
-			for _, r := range bestRoutes {
-				entry, ok := neighbours.Lookup(r.NextHop.Unmap())
-				if !ok {
+			local := make([]rib.Route, 0, len(routesList.Routes))
+			for _, r := range routesList.Routes {
+				if _, ok := neighbours.Lookup(r.NextHop.Unmap()); !ok {
 					stats.NeighbourNotFound++
 					continue
 				}
 
-				routeHardware := entry.HardwareRoute
-				nexthops = append(nexthops, routeHardware)
+				local = append(local, r)
 			}
 
-			if len(nexthops) == 0 {
+			if len(local) == 0 {
 				continue
+			}
+
+			// The best route of each source is chosen among the resolvable
+			// routes only, so the gateway falls back to a reachable route
+			// when its source's best one has no neighbour.
+			localList := rib.RoutesList{Routes: local}
+			bestRoutes := localList.BestPerSource()
+			stats.FilteredRoutes += len(local) - len(bestRoutes)
+
+			nexthops := make([]neigh.HardwareRoute, 0, len(bestRoutes))
+			for _, r := range bestRoutes {
+				entry, _ := neighbours.Lookup(r.NextHop.Unmap())
+				nexthops = append(nexthops, entry.HardwareRoute)
 			}
 
 			slices.SortFunc(nexthops, neigh.HardwareRoute.Compare)

--- a/operators/route/internal/operator/fib_build_test.go
+++ b/operators/route/internal/operator/fib_build_test.go
@@ -27,7 +27,7 @@ func mustParseMAC(t *testing.T, value string) [6]byte {
 // the same source are excluded when a strictly better route exists for that source.
 func Test_BuildFIB_BestPerSourceFiltersWorse(t *testing.T) {
 	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
-	routeFor := func(addr, sourceMAC, destinationMAC string, device string) {
+	routeFor := func(addr, sourceMAC, destinationMAC, device string) {
 		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
 			HardwareRoute: neigh.HardwareRoute{
 				SourceMAC:      mustParseMAC(t, sourceMAC),
@@ -65,7 +65,7 @@ func Test_BuildFIB_BestPerSourceFiltersWorse(t *testing.T) {
 // different peers are all included in the FIB as ECMP nexthops.
 func Test_BuildFIB_EqualCostECMPPreserved(t *testing.T) {
 	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
-	routeFor := func(addr, sourceMAC, destinationMAC string, device string) {
+	routeFor := func(addr, sourceMAC, destinationMAC, device string) {
 		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
 			HardwareRoute: neigh.HardwareRoute{
 				SourceMAC:      mustParseMAC(t, sourceMAC),
@@ -102,7 +102,7 @@ func Test_BuildFIB_EqualCostECMPPreserved(t *testing.T) {
 // the same prefix each contribute their best nexthop to the FIB independently.
 func Test_BuildFIB_StaticAndBirdBothInFIB(t *testing.T) {
 	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
-	routeFor := func(addr, sourceMAC, destinationMAC string, device string) {
+	routeFor := func(addr, sourceMAC, destinationMAC, device string) {
 		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
 			HardwareRoute: neigh.HardwareRoute{
 				SourceMAC:      mustParseMAC(t, sourceMAC),
@@ -136,82 +136,259 @@ func Test_BuildFIB_StaticAndBirdBothInFIB(t *testing.T) {
 	require.Len(t, fib.Entries[0].Nexthops, 2, "both sources' nexthops should be in FIB")
 }
 
-// Test_FilterFIBEntries verifies device-scoped nexthop filtering.
-func Test_FilterFIBEntries(t *testing.T) {
-	mac1 := mustParseMAC(t, "0a:00:00:00:00:01")
-	mac2 := mustParseMAC(t, "0a:00:00:00:00:02")
-	mac3 := mustParseMAC(t, "0a:00:00:00:00:03")
-
-	nh := func(device string, src [6]byte) neigh.HardwareRoute {
-		return neigh.HardwareRoute{SourceMAC: src, Device: device}
+// Test_BuildFIB_PerGatewayDeviceFilter verifies that best-per-source
+// selection runs over the gateway's device-scoped local RIB.
+//
+// A gateway whose device set excludes the globally best route must fall
+// back to a lower-priority route on one of its own devices rather than
+// being starved.
+func Test_BuildFIB_PerGatewayDeviceFilter(t *testing.T) {
+	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
+	routeFor := func(addr, sourceMAC, destinationMAC, device string) {
+		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
+			HardwareRoute: neigh.HardwareRoute{
+				SourceMAC:      mustParseMAC(t, sourceMAC),
+				DestinationMAC: mustParseMAC(t, destinationMAC),
+				Device:         device,
+			},
+		})
 	}
 
-	entries := []FIBEntry{
-		{
-			Prefix:   netip.MustParsePrefix("10.0.0.0/24"),
-			Nexthops: []neigh.HardwareRoute{nh("eth0", mac1), nh("eth1", mac2)},
-		},
-		{
-			Prefix:   netip.MustParsePrefix("10.0.1.0/24"),
-			Nexthops: []neigh.HardwareRoute{nh("eth1", mac3)},
+	routeFor("10.0.0.1", "0a:00:00:00:00:01", "0a:00:00:00:10:00", "eth1")
+	routeFor("10.0.0.2", "0a:00:00:00:00:02", "0a:00:00:00:20:00", "eth2")
+
+	p1 := netip.MustParseAddr("192.0.2.1")
+	p2 := netip.MustParseAddr("192.0.2.2")
+
+	ribDump := maptrie.NewMapTrie[netip.Prefix, netip.Addr, rib.RoutesList](2)
+	ribDump[24][netip.MustParsePrefix("10.0.0.0/24")] = rib.RoutesList{
+		Routes: []rib.Route{
+			// Globally best bird route (Pref=200) egresses through eth2.
+			{NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: rib.RouteSourceBird, Pref: 200},
+			// Worse bird route (Pref=100) egresses through eth1.
+			{NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: rib.RouteSourceBird, Pref: 100},
 		},
 	}
 
 	tests := []struct {
-		name            string
-		devices         map[string]struct{}
-		wantPrefixes    []string
-		wantNexthopDevs [][]string
+		name       string
+		devices    []string
+		wantDevice string
 	}{
 		{
-			name:            "empty device set returns all entries unchanged",
-			devices:         map[string]struct{}{},
-			wantPrefixes:    []string{"10.0.0.0/24", "10.0.1.0/24"},
-			wantNexthopDevs: [][]string{{"eth0", "eth1"}, {"eth1"}},
+			name:       "no filter selects the global best on eth2",
+			devices:    nil,
+			wantDevice: "eth2",
 		},
 		{
-			name:            "one entry dropped when its nexthops are all on other devices",
-			devices:         map[string]struct{}{"eth0": {}},
-			wantPrefixes:    []string{"10.0.0.0/24"},
-			wantNexthopDevs: [][]string{{"eth0"}},
+			name:       "gateway without eth2 falls back to its eth1 route",
+			devices:    []string{"eth1"},
+			wantDevice: "eth1",
 		},
 		{
-			name:            "all entries dropped when device owns no nexthops",
-			devices:         map[string]struct{}{"eth2": {}},
-			wantPrefixes:    []string{},
-			wantNexthopDevs: [][]string{},
+			name:       "gateway with eth2 keeps the global best",
+			devices:    []string{"eth2"},
+			wantDevice: "eth2",
 		},
-	}
-
-	// Capture nexthop counts before any call to detect mutations of the input.
-	nexthopCounts := make([]int, len(entries))
-	for idx := range entries {
-		nexthopCounts[idx] = len(entries[idx].Nexthops)
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := filterFIBEntries(entries, tc.devices)
-			require.Len(t, got, len(tc.wantPrefixes))
-			for idx, wantPrefix := range tc.wantPrefixes {
-				require.Equal(t, netip.MustParsePrefix(wantPrefix), got[idx].Prefix)
-				devs := make([]string, len(got[idx].Nexthops))
-				for hrIdx, hr := range got[idx].Nexthops {
-					devs[hrIdx] = hr.Device
-				}
-				require.Equal(t, tc.wantNexthopDevs[idx], devs)
-			}
-			// Verify the input entries were not mutated.
-			for idx := range entries {
-				require.Len(t, entries[idx].Nexthops, nexthopCounts[idx])
-			}
+			view := neigh.FilterByDevices(cache.View(), tc.devices)
+			fib, _ := BuildFIB(ribDump, view)
+			require.Len(t, fib.Entries, 1)
+			require.Len(t, fib.Entries[0].Nexthops, 1)
+			require.Equal(t, tc.wantDevice, fib.Entries[0].Nexthops[0].Device)
 		})
 	}
 }
 
+// Test_BuildFIB_DeviceFilterStarvesPrefix verifies that a prefix with no
+// route on any of the gateway's devices is omitted entirely.
+func Test_BuildFIB_DeviceFilterStarvesPrefix(t *testing.T) {
+	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
+	cache.Set(netip.MustParseAddr("10.0.0.1"), neigh.NeighbourEntry{
+		HardwareRoute: neigh.HardwareRoute{
+			SourceMAC:      mustParseMAC(t, "0a:00:00:00:00:01"),
+			DestinationMAC: mustParseMAC(t, "0a:00:00:00:10:00"),
+			Device:         "eth1",
+		},
+	})
+
+	ribDump := maptrie.NewMapTrie[netip.Prefix, netip.Addr, rib.RoutesList](2)
+	ribDump[24][netip.MustParsePrefix("10.0.0.0/24")] = rib.RoutesList{
+		Routes: []rib.Route{
+			{NextHop: netip.MustParseAddr("10.0.0.1"), Peer: netip.MustParseAddr("192.0.2.1"), SourceID: rib.RouteSourceBird},
+		},
+	}
+
+	view := neigh.FilterByDevices(cache.View(), []string{"eth2"})
+	fib, stats := BuildFIB(ribDump, view)
+	require.Empty(t, fib.Entries)
+	require.Equal(t, 1, stats.NeighbourNotFound)
+}
+
+// Test_BuildFIB_FallsBackToLiveRouteWhenBestUnresolvable verifies that an
+// unresolvable best route yields to a worse but resolvable route of the
+// same source.
+//
+// This is the live-best behaviour and fires independently of any device
+// filter, so the device set is left empty here.
+func Test_BuildFIB_FallsBackToLiveRouteWhenBestUnresolvable(t *testing.T) {
+	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
+	// Only the worse route's nexthop is resolvable; the best route's
+	// nexthop has no neighbour entry.
+	cache.Set(netip.MustParseAddr("10.0.0.1"), neigh.NeighbourEntry{
+		HardwareRoute: neigh.HardwareRoute{
+			SourceMAC:      mustParseMAC(t, "0a:00:00:00:00:01"),
+			DestinationMAC: mustParseMAC(t, "0a:00:00:00:10:00"),
+			Device:         "eth1",
+		},
+	})
+
+	p1 := netip.MustParseAddr("192.0.2.1")
+	p2 := netip.MustParseAddr("192.0.2.2")
+
+	ribDump := maptrie.NewMapTrie[netip.Prefix, netip.Addr, rib.RoutesList](2)
+	ribDump[24][netip.MustParsePrefix("10.0.0.0/24")] = rib.RoutesList{
+		Routes: []rib.Route{
+			// Best bird route (Pref=200) — its nexthop is unresolvable.
+			{NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: rib.RouteSourceBird, Pref: 200},
+			// Worse bird route (Pref=100) — resolvable on eth1.
+			{NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: rib.RouteSourceBird, Pref: 100},
+		},
+	}
+
+	fib, stats := BuildFIB(ribDump, cache.View())
+
+	require.Len(t, fib.Entries, 1)
+	require.Len(t, fib.Entries[0].Nexthops, 1)
+	require.Equal(t, "eth1", fib.Entries[0].Nexthops[0].Device)
+	require.Equal(t, 1, stats.NeighbourNotFound)
+	require.Equal(t, 0, stats.FilteredRoutes, "the single live local route is its source's best")
+}
+
+// Test_BuildFIB_MultiSourceWithDeviceFilter verifies that best-per-source
+// selection is scoped to the gateway's devices.
+//
+// A source whose best route is on an excluded device falls back to its
+// route on an owned device, while a different source on an owned device is
+// kept independently.
+func Test_BuildFIB_MultiSourceWithDeviceFilter(t *testing.T) {
+	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
+	routeFor := func(addr, sourceMAC, destinationMAC, device string) {
+		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
+			HardwareRoute: neigh.HardwareRoute{
+				SourceMAC:      mustParseMAC(t, sourceMAC),
+				DestinationMAC: mustParseMAC(t, destinationMAC),
+				Device:         device,
+			},
+		})
+	}
+
+	routeFor("10.0.0.1", "0a:00:00:00:00:01", "0a:00:00:00:10:00", "eth1")
+	routeFor("10.0.0.2", "0a:00:00:00:00:02", "0a:00:00:00:20:00", "eth2")
+	routeFor("10.0.0.3", "0a:00:00:00:00:03", "0a:00:00:00:30:00", "eth1")
+
+	p2 := netip.MustParseAddr("192.0.2.2")
+	p3 := netip.MustParseAddr("192.0.2.3")
+	unspec := netip.IPv6Unspecified()
+
+	ribDump := maptrie.NewMapTrie[netip.Prefix, netip.Addr, rib.RoutesList](2)
+	ribDump[24][netip.MustParsePrefix("10.0.0.0/24")] = rib.RoutesList{
+		Routes: []rib.Route{
+			// Bird best (Pref=200) egresses through the excluded eth2.
+			{NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: rib.RouteSourceBird, Pref: 200},
+			// Bird fallback (Pref=100) egresses through the owned eth1.
+			{NextHop: netip.MustParseAddr("10.0.0.3"), Peer: p3, SourceID: rib.RouteSourceBird, Pref: 100},
+			// Static route egresses through the owned eth1.
+			{NextHop: netip.MustParseAddr("10.0.0.1"), Peer: unspec, SourceID: rib.RouteSourceStatic, Pref: 100},
+		},
+	}
+
+	view := neigh.FilterByDevices(cache.View(), []string{"eth1"})
+	fib, stats := BuildFIB(ribDump, view)
+
+	require.Len(t, fib.Entries, 1)
+	require.Len(t, fib.Entries[0].Nexthops, 2, "bird fallback and static, both on eth1")
+	for _, nh := range fib.Entries[0].Nexthops {
+		require.Equal(t, "eth1", nh.Device)
+	}
+	require.Equal(t, 1, stats.NeighbourNotFound, "the bird route on eth2 is dropped")
+}
+
+// Test_BuildFIB_MultiPrefix verifies that each prefix gets its own
+// nexthops and that the per-pass counters accumulate across prefixes.
+//
+// The two prefixes have different surviving-route counts and live at
+// different prefix lengths, so any cross-prefix bleed would corrupt the
+// smaller prefix's result.
+func Test_BuildFIB_MultiPrefix(t *testing.T) {
+	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
+	routeFor := func(addr, sourceMAC, destinationMAC, device string) {
+		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
+			HardwareRoute: neigh.HardwareRoute{
+				SourceMAC:      mustParseMAC(t, sourceMAC),
+				DestinationMAC: mustParseMAC(t, destinationMAC),
+				Device:         device,
+			},
+		})
+	}
+
+	routeFor("10.0.0.1", "0a:00:00:00:00:01", "0a:00:00:00:10:00", "eth1")
+	routeFor("10.0.0.2", "0a:00:00:00:00:02", "0a:00:00:00:20:00", "eth1")
+	routeFor("10.0.0.3", "0a:00:00:00:00:03", "0a:00:00:00:30:00", "eth2")
+	routeFor("10.1.0.1", "0a:00:00:00:00:04", "0a:00:00:00:40:00", "eth1")
+
+	p1 := netip.MustParseAddr("192.0.2.1")
+	p2 := netip.MustParseAddr("192.0.2.2")
+	p3 := netip.MustParseAddr("192.0.2.3")
+	p4 := netip.MustParseAddr("192.0.2.4")
+
+	ribDump := maptrie.NewMapTrie[netip.Prefix, netip.Addr, rib.RoutesList](2)
+	// Wider prefix: three equal-cost bird routes; one egresses through the
+	// excluded eth2, leaving two ECMP nexthops on eth1.
+	ribDump[24][netip.MustParsePrefix("10.0.0.0/24")] = rib.RoutesList{
+		Routes: []rib.Route{
+			{NextHop: netip.MustParseAddr("10.0.0.1"), Peer: p1, SourceID: rib.RouteSourceBird, Pref: 100},
+			{NextHop: netip.MustParseAddr("10.0.0.2"), Peer: p2, SourceID: rib.RouteSourceBird, Pref: 100},
+			{NextHop: netip.MustParseAddr("10.0.0.3"), Peer: p3, SourceID: rib.RouteSourceBird, Pref: 100},
+		},
+	}
+	// Narrower prefix at a different length: a single live route on eth1.
+	ribDump[16][netip.MustParsePrefix("10.1.0.0/16")] = rib.RoutesList{
+		Routes: []rib.Route{
+			{NextHop: netip.MustParseAddr("10.1.0.1"), Peer: p4, SourceID: rib.RouteSourceBird, Pref: 100},
+		},
+	}
+
+	view := neigh.FilterByDevices(cache.View(), []string{"eth1"})
+	fib, stats := BuildFIB(ribDump, view)
+
+	require.Len(t, fib.Entries, 2)
+	require.Equal(t, 1, stats.NeighbourNotFound, "only the eth2 route of the wider prefix is dropped")
+
+	byPrefix := map[string]FIBEntry{}
+	for _, entry := range fib.Entries {
+		byPrefix[entry.Prefix.String()] = entry
+	}
+
+	wide, ok := byPrefix["10.0.0.0/24"]
+	require.True(t, ok)
+	require.Len(t, wide.Nexthops, 2, "two eth1 ECMP nexthops survive the device filter")
+	for _, nh := range wide.Nexthops {
+		require.Equal(t, "eth1", nh.Device)
+	}
+
+	narrow, ok := byPrefix["10.1.0.0/16"]
+	require.True(t, ok)
+	require.Len(t, narrow.Nexthops, 1, "buffer reuse must not leak the wider prefix's routes")
+	require.Equal(t, "eth1", narrow.Nexthops[0].Device)
+}
+
 func Test_BuildFIB_DedupsNexthops(t *testing.T) {
 	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
-	routeFor := func(addr, sourceMAC, destinationMAC string, device string) {
+	routeFor := func(addr, sourceMAC, destinationMAC, device string) {
 		cache.Set(netip.MustParseAddr(addr), neigh.NeighbourEntry{
 			HardwareRoute: neigh.HardwareRoute{
 				SourceMAC:      mustParseMAC(t, sourceMAC),

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -35,13 +35,13 @@ const (
 
 // Actuator applies a desired set of FIBs to one or more downstream
 // targets (gateways).
-type Actuator = operator.Actuator[[]FIB]
+type Actuator = operator.Actuator[RouteSnapshot]
 
 // Operator is the route operator's thin wrapper around the generic
 // operator framework.
 type Operator struct {
 	cfg          *Config
-	app          *operator.Operator[[]FIB]
+	app          *operator.Operator[RouteSnapshot]
 	routeSvc     *RouteService
 	neighTable   *neigh.NeighTable
 	neighMonitor *neigh.NeighMonitor

--- a/operators/route/internal/operator/route_source.go
+++ b/operators/route/internal/operator/route_source.go
@@ -1,6 +1,9 @@
 package operator
 
 import (
+	"net/netip"
+
+	"github.com/yanet-platform/yanet2/common/go/maptrie"
 	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
 )
@@ -9,13 +12,22 @@ type routeSnapshot interface {
 	Snapshot() map[string]*rib.RIB
 }
 
-// RouteSource is the operator.StateSource[[]FIB] used by the route
+// RouteSnapshot is the desired state for one reconcile pass: the
+// per-module RIB dumps and the neighbour view each gateway needs to build
+// its FIB.
+type RouteSnapshot struct {
+	// RIBs maps each module config name to its route dump.
+	RIBs map[string]maptrie.MapTrie[netip.Prefix, netip.Addr, rib.RoutesList]
+	// Neighbours is the neighbour view used to resolve route nexthops.
+	Neighbours neigh.NexthopCacheView
+}
+
+// RouteSource is the operator.StateSource[RouteSnapshot] used by the route
 // operator.
 //
-// On every Snapshot it pulls a fresh snapshot of the RIBs from the
-// RouteSource reader, joins them with the current neighbour-table view and
-// builds a per-RIB FIB. The resulting slice is the desired state for
-// the next reconcile pass.
+// On every Snapshot it pulls a fresh dump of the RIBs from the route
+// reader and the current neighbour-table view, which each gateway actuator
+// turns into its own FIB.
 //
 // Wake is signalled by the wake callbacks wired into RouteService and
 // NeighbourService whenever their state mutates; it preempts the
@@ -43,36 +55,32 @@ func NewRouteSource(
 	}
 }
 
-// Snapshot builds the current desired FIB set.
+// Snapshot returns the current desired state: the per-module RIB dumps
+// and the neighbour view.
 //
-// The route operator publishes its single network function on every
-// reconcile pass, so an empty FIB set is still a valid state worth
-// applying — Snapshot always returns ok=true. The framework would
-// otherwise skip the apply pass on an empty slice and the function
-// would never be republished while no RIBs exist.
-func (m *RouteSource) Snapshot() ([]FIB, bool) {
+// It always reports ok=true, even with no RIBs: the operator republishes
+// its network function on every reconcile pass, and an empty state would
+// otherwise make the framework skip the pass and never republish.
+func (m *RouteSource) Snapshot() (RouteSnapshot, bool) {
 	select {
 	case <-m.wakeCh:
 	default:
 	}
 
 	ribs := m.routeReader.Snapshot()
-	view := m.neighTable.View()
 
-	fibs := make([]FIB, 0, len(ribs))
+	dumps := make(map[string]maptrie.MapTrie[netip.Prefix, netip.Addr, rib.RoutesList], len(ribs))
 	for name, ribRef := range ribs {
-		fib, _ := BuildFIB(ribRef.DumpRoutes(), view)
-		fib.Name = name
-		fibs = append(fibs, fib)
+		dumps[name] = ribRef.DumpRoutes()
 	}
-	return fibs, true
+	return RouteSnapshot{RIBs: dumps, Neighbours: m.neighTable.View()}, true
 }
 
 func (m *RouteSource) Wake() <-chan struct{} {
 	return m.wakeCh
 }
 
-func (m *RouteSource) Advance(fibs []FIB) {}
+func (m *RouteSource) Advance(snapshot RouteSnapshot) {}
 
 // WakeFunc returns a non-blocking sender suitable for wiring into the
 // RouteService and NeighbourService OnChanged callbacks.

--- a/operators/route/internal/operator/route_source_test.go
+++ b/operators/route/internal/operator/route_source_test.go
@@ -42,9 +42,9 @@ func Test_RouteSource_SnapshotEmptyOK(t *testing.T) {
 		newRIBStore(zap.NewNop()),
 	)
 
-	fibs, ok := source.Snapshot()
+	snapshot, ok := source.Snapshot()
 	require.True(t, ok, "Snapshot must always return ok=true to keep the function publish alive")
-	require.Empty(t, fibs)
+	require.Empty(t, snapshot.RIBs)
 }
 
 func Test_RouteSource_SnapshotDrainsWake(t *testing.T) {
@@ -91,9 +91,13 @@ func Test_RouteSource_SnapshotIncludesRIBs(t *testing.T) {
 		rib.RouteSourceStatic,
 	)
 
-	fibs, ok := source.Snapshot()
+	snapshot, ok := source.Snapshot()
 	require.True(t, ok)
-	require.Len(t, fibs, 1)
+	require.Len(t, snapshot.RIBs, 1)
+	require.Contains(t, snapshot.RIBs, "route0")
+
+	fib, _ := BuildFIB(snapshot.RIBs["route0"], snapshot.Neighbours)
+	fib.Name = "route0"
 
 	expected := FIB{
 		Name: "route0",
@@ -110,5 +114,5 @@ func Test_RouteSource_SnapshotIncludesRIBs(t *testing.T) {
 			},
 		},
 	}
-	require.Equal(t, expected, fibs[0])
+	require.Equal(t, expected, fib)
 }


### PR DESCRIPTION
The route operator pushes a forwarding table to several gateways, but each gateway can forward only through its own devices. Choosing the best route globally could hand a gateway a route whose egress device it lacks, leaving the prefix blackholed there.

- Each gateway selects its best routes only among the routes reachable through its own devices.
- A gateway with no path to the globally best route falls back to the best route it can actually use, instead of dropping the prefix.