### PR TITLE
feat(web): redesign Devices page and live trafgen generator controls

### DIFF
--- a/devices/trafgen/web/TrafgenDetail.tsx
+++ b/devices/trafgen/web/TrafgenDetail.tsx
@@ -1,76 +1,178 @@
 import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { PacketTable, PacketInspector } from '@yanet/core/components/packet';
 import type { PacketRow } from '@yanet/core/components/packet';
-import { parsePacket } from '@yanet/core/utils/packetParser';
+import { parsePacket, base64ToUint8Array } from '@yanet/core/utils/packetParser';
 import { parsePcapFile } from '@yanet/core/utils/pcapFile';
 import { toaster } from '@yanet/core/utils';
 import type { DeviceDetailProps } from '@yanet/core/registry';
+import { trafgen } from './api';
 import { trafgenExt } from './types';
 
-/** Generator controls + Frames + inspector panel for trafgen devices. */
+/** A pcap loaded locally for inspection but not yet uploaded to the device. */
+interface PcapPreview {
+    name: string;
+    bytes: Uint8Array;
+    frames: PacketRow[];
+}
+
+/** Encode a Uint8Array as base64 for the UploadPcap request body. */
+const uint8ToBase64 = (bytes: Uint8Array): string => {
+    let binary = '';
+    for (let idx = 0; idx < bytes.length; idx++) {
+        binary += String.fromCharCode(bytes[idx]);
+    }
+    return btoa(binary);
+};
+
+/** Decode base64 L2 frames from ShowPackets into displayable rows. */
+const framesToPackets = (frames: string[] | undefined): PacketRow[] => {
+    let idx = 0;
+    return (frames ?? []).map(b64 => ({ id: idx++, parsed: parsePacket(base64ToUint8Array(b64)) }));
+};
+
+/** Parse raw .pcap file bytes locally into displayable rows for preview. */
+const pcapToPackets = (bytes: Uint8Array): PacketRow[] => {
+    let idx = 0;
+    return parsePcapFile(bytes).map(frame => ({ id: idx++, parsed: parsePacket(frame) }));
+};
+
+/** Read a picked file as bytes, surfacing read errors as a toast. */
+const readFileBytes = (file: File, onBytes: (bytes: Uint8Array) => void): void => {
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+        const buffer = ev.target?.result;
+        if (buffer instanceof ArrayBuffer) {
+            onBytes(new Uint8Array(buffer));
+        }
+    };
+    reader.onerror = () => toaster.error('trafgen-pcap-read', 'Failed to read file.');
+    reader.readAsArrayBuffer(file);
+};
+
+/** Generator controls + Frames + inspector panel for trafgen devices.
+ *
+ * Rate and pcap are applied live through SetRate / UploadPcap, each behind its
+ * own button and independent of the device Save (which only writes pipelines).
+ */
 const TrafgenDetail = (props: DeviceDetailProps): React.JSX.Element => {
     const { device, onUpdateExt } = props;
 
-    // Read via the helper, which supplies defaults: a server-loaded generator
-    // has no ext slice until loadDeviceExt hydrates it asynchronously.
     const ext = trafgenExt(device);
-
     const deviceName = device.id.name ?? '';
-    const fileInputRef = useRef<HTMLInputElement>(null);
+    const previewInputRef = useRef<HTMLInputElement>(null);
+
+    // Live API calls target a server-created device; a not-yet-saved device
+    // has no backend object to set a rate or upload frames into.
+    const live = !device.isNew;
 
     const [selectedFrameId, setSelectedFrameId] = useState<number | null>(null);
     const [frameDrawerOpen, setFrameDrawerOpen] = useState(false);
     const [frameSearch, setFrameSearch] = useState('');
+    const [framesOpen, setFramesOpen] = useState(true);
+    const [rateInput, setRateInput] = useState(String(ext.ratePps ?? 0));
+    const [applyingRate, setApplyingRate] = useState(false);
+    const [uploading, setUploading] = useState(false);
+    const [preview, setPreview] = useState<PcapPreview | null>(null);
 
-    // Reset the frame inspector whenever the selected generator changes.
+    // Reset the frame inspector and any preview when the generator changes.
     useEffect(() => {
         setSelectedFrameId(null);
         setFrameDrawerOpen(false);
         setFrameSearch('');
+        setPreview(null);
     }, [deviceName]);
 
-    const handleRateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-        const val = parseInt(e.target.value, 10);
-        onUpdateExt({ ratePps: isNaN(val) ? 0 : Math.max(0, val) });
-    }, [onUpdateExt]);
+    // Resync the rate field when the device changes or the server rate loads.
+    useEffect(() => {
+        setRateInput(String(ext.ratePps ?? 0));
+    }, [deviceName, ext.ratePps]);
 
-    const handleChoosePcap = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (!file) { return; }
-        const reader = new FileReader();
-        reader.onload = (ev) => {
-            try {
-                const buffer = ev.target?.result;
-                if (!(buffer instanceof ArrayBuffer)) { return; }
-                const bytes = new Uint8Array(buffer);
-                const frames = parsePcapFile(bytes);
-                let idx = 0;
-                const rows: PacketRow[] = frames.map(frame => ({ id: idx++, parsed: parsePacket(frame) }));
-                onUpdateExt({ stagedPcapBytes: bytes, stagedFramePackets: rows });
-                setSelectedFrameId(null);
-                setFrameDrawerOpen(false);
-            } catch (err) {
-                const msg = err instanceof Error ? err.message : String(err);
-                toaster.error('trafgen-pcap-parse', `Failed to parse pcap: ${msg}`);
-            }
-        };
-        reader.onerror = () => toaster.error('trafgen-pcap-read', 'Failed to read file.');
-        reader.readAsArrayBuffer(file);
-        if (fileInputRef.current) {
-            fileInputRef.current.value = '';
+    const deviceFrames = ext.framePackets ?? [];
+    // While a preview is staged the table shows its local frames; otherwise the
+    // frames currently on the device.
+    const effectiveFrames = preview ? preview.frames : deviceFrames;
+
+    // Accept any keystrokes but only treat a plain natural number (digits, no
+    // sign/decimal/exponent) as a valid rate; anything else blocks Apply.
+    const trimmedRate = rateInput.trim();
+    const rateValid = /^\d+$/.test(trimmedRate);
+    const parsedRate = rateValid ? Number(trimmedRate) : NaN;
+    const rateInvalid = trimmedRate.length > 0 && !rateValid;
+    const rateModified = rateValid && parsedRate !== (ext.ratePps ?? 0);
+    const canApplyRate = live && rateModified && !applyingRate;
+
+    const handleApplyRate = useCallback(async () => {
+        if (!canApplyRate) {
+            return;
         }
-    }, [onUpdateExt]);
+        setApplyingRate(true);
+        try {
+            await trafgen.setRate({ name: deviceName, rate_pps: parsedRate });
+            onUpdateExt({ ratePps: parsedRate });
+            toaster.success(`trafgen-rate-${deviceName}`, `Rate set to ${parsedRate} pps`);
+        } catch (err) {
+            toaster.error(`trafgen-rate-${deviceName}`, 'Failed to set rate', err);
+        } finally {
+            setApplyingRate(false);
+        }
+    }, [canApplyRate, parsedRate, deviceName, onUpdateExt]);
 
-    const handleCancelStagedPcap = useCallback(() => {
-        onUpdateExt({ stagedPcapBytes: null, stagedFramePackets: undefined });
+    // Pushes pcap bytes to the device, then refreshes the on-device frame set
+    // and clears any preview.
+    const doUploadBytes = useCallback(async (bytes: Uint8Array, name: string) => {
+        setUploading(true);
+        try {
+            await trafgen.uploadPcap({ name: deviceName, pcap: uint8ToBase64(bytes) });
+            const pkts = await trafgen.showPackets(deviceName);
+            onUpdateExt({
+                framePackets: framesToPackets(pkts.packets),
+                truncated: pkts.truncated ?? false,
+            });
+            setPreview(null);
+            setSelectedFrameId(null);
+            setFrameDrawerOpen(false);
+            toaster.success(`trafgen-pcap-${deviceName}`, `Uploaded ${name}`);
+        } catch (err) {
+            toaster.error(`trafgen-pcap-${deviceName}`, 'Failed to upload pcap', err);
+        } finally {
+            setUploading(false);
+        }
+    }, [deviceName, onUpdateExt]);
+
+    // Loads a pcap locally into a preview without touching the device.
+    const handlePreviewPick = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (file) {
+            readFileBytes(file, (bytes) => {
+                try {
+                    setPreview({ name: file.name, bytes, frames: pcapToPackets(bytes) });
+                    setSelectedFrameId(null);
+                    setFrameDrawerOpen(false);
+                    setFramesOpen(true);
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    toaster.error('trafgen-pcap-parse', `Failed to parse pcap: ${msg}`);
+                }
+            });
+        }
+        if (previewInputRef.current) {
+            previewInputRef.current.value = '';
+        }
+    }, []);
+
+    // Uploads the staged preview to the device. Loading a file is done via the
+    // clickable frame-count box; this button only commits.
+    const handleUpload = useCallback(() => {
+        if (preview) {
+            doUploadBytes(preview.bytes, preview.name);
+        }
+    }, [preview, doUploadBytes]);
+
+    const handleDiscardPreview = useCallback(() => {
+        setPreview(null);
         setSelectedFrameId(null);
         setFrameDrawerOpen(false);
-    }, [onUpdateExt]);
-
-    const effectiveFrames = useMemo(
-        () => ext.stagedFramePackets ?? ext.framePackets ?? [],
-        [ext.stagedFramePackets, ext.framePackets],
-    );
+    }, []);
 
     const handleSelectFrame = useCallback((packet: PacketRow | null) => {
         if (packet) {
@@ -91,73 +193,149 @@ const TrafgenDetail = (props: DeviceDetailProps): React.JSX.Element => {
         ? effectiveFrames.find(p => p.id === selectedFrameId) ?? null
         : null;
 
-    const stagedFrameCount = ext.stagedFramePackets?.length ?? 0;
-    const pcapStaged = ext.stagedPcapBytes != null;
+    const sourceLabel = preview
+        ? `${preview.name} · preview`
+        : deviceFrames.length > 0
+            ? `${deviceFrames.length} frames loaded`
+            : 'No pcap loaded';
+    const frameMeta = preview
+        ? `${preview.frames.length} frames · preview`
+        : `${deviceFrames.length} frames`;
 
     return (
         <>
             <div className="dv-section">
                 <div className="dv-section-hd"><span>Generator</span></div>
-                <div className="dv-gen-controls">
-                    <div className="dv-gen-group">
-                        <label className="dv-gen-lbl" htmlFor="dv-gen-rate">Rate</label>
-                        <input
-                            id="dv-gen-rate"
-                            className="dv-gen-rate mono"
-                            type="number"
-                            min={0}
-                            step={1}
-                            value={String(ext.ratePps ?? 0)}
-                            onChange={handleRateChange}
-                        />
-                        <span className="dv-gen-unit">pps</span>
+                {!live && (
+                    <div className="dv-gen-note">Save the device to enable live rate and pcap.</div>
+                )}
+                <div className="dv-gen-cards">
+                    <div className="dv-gen-card">
+                        <div className="dv-gen-card-hd">
+                            <label className="dv-gen-card-title" htmlFor="dv-gen-rate">Transmit rate</label>
+                            <span
+                                className={"dv-gen-card-flag" + (rateInvalid ? ' dv-gen-card-flag--err' : '')}
+                                style={{ visibility: rateModified || rateInvalid ? 'visible' : 'hidden' }}
+                            >
+                                {rateInvalid ? 'natural number only' : '● modified'}
+                            </span>
+                        </div>
+                        <div className="dv-gen-card-row">
+                            <input
+                                id="dv-gen-rate"
+                                className={"dv-gen-rate mono" + (rateInvalid ? ' dv-gen-rate--invalid' : '')}
+                                type="text"
+                                inputMode="numeric"
+                                value={rateInput}
+                                disabled={!live}
+                                onChange={e => setRateInput(e.target.value)}
+                                onKeyDown={e => { if (e.key === 'Enter') { handleApplyRate(); } }}
+                            />
+                            <span className="dv-gen-unit">pps</span>
+                            <button
+                                className={"btn-primary dv-gen-apply" + (canApplyRate ? '' : ' btn-primary-dim')}
+                                onClick={handleApplyRate}
+                                disabled={!canApplyRate}
+                            >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+                                    <polyline points="20,6 9,17 4,12" />
+                                </svg>
+                                {applyingRate ? 'Applying…' : 'Apply rate'}
+                            </button>
+                        </div>
+                        <div className="dv-gen-card-note">
+                            Target packets-per-second the generator emits. Apply rate pushes it to
+                            the running device immediately — the Save button is only for pipelines.
+                        </div>
                     </div>
-                    <div className="dv-gen-group">
-                        <input
-                            ref={fileInputRef}
-                            type="file"
-                            accept=".pcap,.pcapng"
-                            style={{ display: 'none' }}
-                            onChange={handleChoosePcap}
-                        />
-                        <button className="btn-secondary" onClick={() => fileInputRef.current?.click()}>
-                            Choose pcap…
-                        </button>
-                        {pcapStaged && (
-                            <>
-                                <span className="dv-gen-hint">
-                                    {stagedFrameCount} frame{stagedFrameCount !== 1 ? 's' : ''} staged · saves on Save
-                                </span>
-                                <button className="btn-secondary" onClick={handleCancelStagedPcap}>
-                                    Cancel
-                                </button>
-                            </>
+
+                    <div className="dv-gen-card">
+                        <div className="dv-gen-card-hd">
+                            <span className="dv-gen-card-title">Packet source</span>
+                            <span className="dv-gen-card-meta mono">{frameMeta}</span>
+                        </div>
+                        <div className="dv-gen-card-row">
+                            <button
+                                type="button"
+                                className={"dv-gen-file" + (preview ? ' dv-gen-file--preview' : '')}
+                                onClick={() => previewInputRef.current?.click()}
+                                title="Load a pcap to preview its frames"
+                            >
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8">
+                                    <path d="M6 3h8l4 4v14H6Z" /><polyline points="14,3 14,7 18,7" />
+                                </svg>
+                                <span className="dv-gen-file-name mono">{sourceLabel}</span>
+                            </button>
+                            <input
+                                ref={previewInputRef}
+                                type="file"
+                                accept=".pcap,.pcapng"
+                                style={{ display: 'none' }}
+                                onChange={handlePreviewPick}
+                            />
+                            <button
+                                className="btn-secondary"
+                                onClick={handleUpload}
+                                disabled={!live || uploading || !preview}
+                            >
+                                {uploading ? 'Uploading…' : 'Upload to device'}
+                            </button>
+                        </div>
+                        {preview ? (
+                            <div className="dv-gen-preview-note">
+                                <span>Previewing <span className="mono">{preview.name}</span> — not uploaded.</span>
+                                <button className="dv-gen-link" onClick={handleDiscardPreview}>Discard</button>
+                            </div>
+                        ) : (
+                            <div className="dv-gen-card-note">
+                                Click the frame count to load and preview a pcap, then “Upload to
+                                device” to apply it live — no Save required.
+                            </div>
                         )}
                     </div>
                 </div>
-                {ext.truncated && !pcapStaged && (
-                    <div className="dv-gen-note">The preview shows a capped subset of the uploaded frames.</div>
+                {!preview && ext.truncated && (
+                    <div className="dv-gen-note">The frame list shows a capped subset of the uploaded frames.</div>
                 )}
             </div>
 
             <div className="dv-section">
-                <div className="dv-section-hd"><span>Frames</span></div>
-                <div className="dv-gen-frames">
-                    <PacketTable
-                        key={deviceName || 'empty'}
-                        packets={effectiveFrames}
-                        selectedPacketId={selectedFrameId}
-                        onSelectPacket={handleSelectFrame}
-                        searchQuery={frameSearch}
-                        onSearchQueryChange={setFrameSearch}
-                        isLive={false}
-                        emptyMessage="No frames loaded. Choose a pcap file to stage one."
-                        emptyFilterMessage="No frames match the filter."
-                        showTimeColumn={false}
-                        showToolbarActions={false}
-                        footerNote={<span>{effectiveFrames.length > 0 ? 'Click to inspect' : ''}</span>}
-                    />
-                </div>
+                <button
+                    className="dv-frames-toggle"
+                    onClick={() => setFramesOpen(v => !v)}
+                    aria-expanded={framesOpen}
+                >
+                    <svg
+                        className={"dv-frames-chevron" + (framesOpen ? ' open' : '')}
+                        width="14" height="14" viewBox="0 0 24 24"
+                        fill="none" stroke="currentColor" strokeWidth="2.2"
+                    >
+                        <polyline points="9,6 15,12 9,18" />
+                    </svg>
+                    <span className="dv-frames-toggle-lbl">Frames</span>
+                    <span className="dv-frames-toggle-count mono">
+                        {effectiveFrames.length} packet{effectiveFrames.length !== 1 ? 's' : ''}
+                    </span>
+                    <span className="dv-frames-toggle-hint">{framesOpen ? 'Hide' : 'Show'}</span>
+                </button>
+                {framesOpen && (
+                    <div className="dv-gen-frames">
+                        <PacketTable
+                            key={(deviceName || 'empty') + (preview ? ':preview' : '')}
+                            packets={effectiveFrames}
+                            selectedPacketId={selectedFrameId}
+                            onSelectPacket={handleSelectFrame}
+                            searchQuery={frameSearch}
+                            onSearchQueryChange={setFrameSearch}
+                            isLive={false}
+                            emptyMessage="No frames loaded. Load a pcap file to populate them."
+                            emptyFilterMessage="No frames match the filter."
+                            showTimeColumn={false}
+                            showToolbarActions={false}
+                            footerNote={<span>{effectiveFrames.length > 0 ? 'Click to inspect' : ''}</span>}
+                        />
+                    </div>
+                )}
             </div>
 
             <PacketInspector

--- a/devices/trafgen/web/device.ts
+++ b/devices/trafgen/web/device.ts
@@ -7,15 +7,6 @@ import { trafgen } from './api';
 import { trafgenExt } from './types';
 import { IconGenerator } from './icon';
 
-/** Encode a Uint8Array as base64. */
-const uint8ArrayToBase64 = (bytes: Uint8Array): string => {
-    let binary = '';
-    for (let idx = 0; idx < bytes.length; idx++) {
-        binary += String.fromCharCode(bytes[idx]);
-    }
-    return btoa(binary);
-};
-
 /** Decode base64 L2 frames into displayable packet rows. */
 const framesToPackets = (frames: string[] | undefined): PacketRow[] => {
     let idx = 0;
@@ -38,23 +29,21 @@ const loadData = async (device: BaseDevice): Promise<Record<string, unknown>> =>
     } catch {
         // No server-side config yet; fall through with the empty defaults.
     }
-    return { ratePps, framePackets, truncated, stagedPcapBytes: null };
+    return { ratePps, framePackets, truncated };
 };
 
+// Persists only the pipeline assignments. Rate and pcap are applied live from
+// the detail panel through their own API calls, independent of Save.
 const save = async (
     device: BaseDevice,
     snapshot: BaseDevice | undefined,
 ): Promise<Record<string, unknown>> => {
     const name = device.id.name ?? '';
     const ext = trafgenExt(device);
-    const snapExt = snapshot ? trafgenExt(snapshot) : undefined;
 
     const pipelinesDirty = device.isNew || !snapshot
         || JSON.stringify(device.inputPipelines) !== JSON.stringify(snapshot.inputPipelines)
         || JSON.stringify(device.outputPipelines) !== JSON.stringify(snapshot.outputPipelines);
-    const rateDirty = device.isNew
-        || (snapExt != null && ext.ratePps !== snapExt.ratePps);
-    const pcapStaged = ext.stagedPcapBytes != null;
 
     if (pipelinesDirty) {
         await trafgen.updateDevice({
@@ -62,25 +51,11 @@ const save = async (
             device: toDevicePayload(device.inputPipelines, device.outputPipelines),
         });
     }
-    if (rateDirty) {
-        await trafgen.setRate({ name, rate_pps: ext.ratePps });
-    }
-
-    let framePackets = ext.framePackets;
-    let truncated = ext.truncated;
-    if (pcapStaged && ext.stagedPcapBytes) {
-        await trafgen.uploadPcap({ name, pcap: uint8ArrayToBase64(ext.stagedPcapBytes) });
-        const pkts = await trafgen.showPackets(name);
-        framePackets = framesToPackets(pkts.packets);
-        truncated = pkts.truncated ?? false;
-    }
 
     return {
         ratePps: ext.ratePps,
-        framePackets,
-        truncated,
-        stagedPcapBytes: null,
-        stagedFramePackets: undefined,
+        framePackets: ext.framePackets,
+        truncated: ext.truncated,
     };
 };
 
@@ -106,17 +81,9 @@ export const deviceType: DeviceTypeManifest = {
         ratePps: 0,
         framePackets: [],
         truncated: false,
-        stagedPcapBytes: null,
     }),
     loadData,
     save,
-    extDirty: (device, snapshot) => {
-        const ext = trafgenExt(device);
-        const snapExt = snapshot ? trafgenExt(snapshot) : undefined;
-        return device.isNew
-            || (snapExt != null && ext.ratePps !== snapExt.ratePps)
-            || ext.stagedPcapBytes != null;
-    },
     confirmViaDiff: false,
     loadDetail: () => import('./TrafgenDetail'),
 };

--- a/devices/trafgen/web/trafgen.scss
+++ b/devices/trafgen/web/trafgen.scss
@@ -5,19 +5,132 @@
         border: 1px solid rgba(232, 161, 60, 0.22);
     }
 
-    .dv-gen-controls {
-        display: flex;
-        align-items: center;
-        gap: 16px;
-        flex-wrap: wrap;
+    .dv-gen-cards {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+
+        @media (max-width: 1100px) {
+            grid-template-columns: 1fr;
+        }
     }
 
-    .dv-gen-group {
+    .dv-gen-card {
+        background: var(--bg-1);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 14px 15px;
+        display: flex;
+        flex-direction: column;
+        gap: 11px;
+    }
+
+    .dv-gen-card-hd {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+    }
+
+    .dv-gen-card-title {
+        font-size: 12.5px;
+        font-weight: 500;
+        color: var(--fg-1);
+    }
+
+    .dv-gen-card-meta {
+        font-size: 11px;
+        color: var(--fg-3);
+    }
+
+    .dv-gen-card-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .dv-gen-card-note {
+        font-size: 11.5px;
+        color: var(--fg-3);
+    }
+
+    // Clickable file box — opens a local pcap preview without uploading.
+    .dv-gen-file {
+        flex: 1;
+        min-width: 0;
         display: flex;
         align-items: center;
         gap: 8px;
+        background: var(--bg-2);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 7px 11px;
+        color: var(--fg-3);
+        font: inherit;
+        text-align: left;
+        cursor: pointer;
+        transition: border-color 0.12s ease, background 0.12s ease;
+
+        &:hover {
+            border-color: var(--accent-mid);
+            background: var(--bg-3);
+        }
+
+        &--preview {
+            border-color: var(--accent-mid);
+            background: var(--accent-soft);
+        }
     }
 
+    .dv-gen-file-name {
+        font-size: 12px;
+        color: var(--fg-1);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .dv-gen-preview-note {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 11.5px;
+        color: var(--accent);
+    }
+
+    .dv-gen-link {
+        background: transparent;
+        border: 0;
+        padding: 0;
+        color: var(--fg-2);
+        font-family: var(--sans);
+        font-size: 11.5px;
+        text-decoration: underline;
+        cursor: pointer;
+
+        &:hover {
+            color: var(--red);
+        }
+    }
+
+    .dv-gen-card-flag {
+        font-size: 11px;
+        color: var(--accent);
+
+        &--err {
+            color: var(--red);
+        }
+    }
+
+    .dv-gen-apply {
+        margin-left: auto;
+        flex: none;
+        min-width: 116px;
+        justify-content: center;
+    }
+
+    // Actionable secondary button — accent-highlighted while enabled, clearly
+    // muted (grey, not-allowed) once disabled.
     .btn-secondary {
         display: inline-flex;
         align-items: center;
@@ -25,9 +138,9 @@
         height: 30px;
         box-sizing: border-box;
         padding: 0 12px;
-        background: var(--bg-2);
-        color: var(--fg-1);
-        border: 1px solid var(--border-strong);
+        background: var(--accent-soft);
+        color: var(--accent);
+        border: 1px solid var(--accent-mid);
         border-radius: 5px;
         font-family: var(--sans);
         font-size: 13px;
@@ -35,24 +148,22 @@
         cursor: pointer;
         transition: background 0.12s ease, border-color 0.12s ease, color 0.12s ease;
 
-        &:hover {
-            background: var(--bg-3);
+        &:not(:disabled):hover {
+            background: var(--accent-mid);
             border-color: var(--accent);
-            color: var(--fg);
         }
 
-        &:active {
+        &:disabled {
             background: var(--bg-3);
+            color: var(--fg-3);
+            border-color: var(--border);
+            opacity: 0.55;
+            cursor: not-allowed;
         }
-    }
-
-    .dv-gen-lbl {
-        font-size: 12px;
-        color: var(--fg-2);
     }
 
     .dv-gen-rate {
-        width: 130px;
+        width: 120px;
         height: 30px;
         box-sizing: border-box;
         background: var(--bg-2);
@@ -67,15 +178,20 @@
         &:focus {
             border-color: var(--accent);
         }
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        &--invalid,
+        &--invalid:focus {
+            border-color: var(--red);
+        }
     }
 
     .dv-gen-unit {
         font-size: 12px;
-        color: var(--fg-3);
-    }
-
-    .dv-gen-hint {
-        font-size: 11px;
         color: var(--fg-3);
     }
 
@@ -85,11 +201,57 @@
         margin-top: 8px;
     }
 
+    .dv-frames-toggle {
+        width: 100%;
+        display: flex;
+        align-items: center;
+        gap: 11px;
+        background: var(--bg-1);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 12px 14px;
+        margin-bottom: 12px;
+        color: var(--fg);
+        cursor: pointer;
+        font-family: var(--sans);
+
+        &:hover {
+            background: var(--bg-3);
+        }
+    }
+
+    .dv-frames-chevron {
+        color: var(--fg-2);
+        transition: transform 0.18s ease;
+
+        &.open {
+            transform: rotate(90deg);
+        }
+    }
+
+    .dv-frames-toggle-lbl {
+        font-size: 10.5px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-3);
+    }
+
+    .dv-frames-toggle-count {
+        font-size: 12px;
+        color: var(--fg-2);
+    }
+
+    .dv-frames-toggle-hint {
+        margin-left: auto;
+        font-size: 12px;
+        color: var(--fg-3);
+    }
+
     .dv-gen-frames {
-        // Full-bleed past the scroll padding so the shared packet table
-        // (min-width 800px) fits without clipping or horizontal scroll.
-        // The table sizes its own height and carries its own border.
-        margin: 0 -16px;
+        // Aligned with the Frames toggle and the rest of the detail content:
+        // the table sizes to the section width (it carries its own border and
+        // scrolls horizontally only when narrower than its min content width).
         min-height: 300px;
         display: flex;
         flex-direction: column;

--- a/devices/trafgen/web/types.ts
+++ b/devices/trafgen/web/types.ts
@@ -3,13 +3,15 @@ import type { BaseDevice } from '@yanet/core/registry';
 
 export type { PacketRow };
 
-/** Per-device editable state for trafgen generators. */
+/** Per-device editable state for trafgen generators.
+ *
+ * Rate and pcap are applied live through their own API calls, so the ext only
+ * mirrors the last server-confirmed values — it carries no pending/staged edits.
+ */
 export interface TrafgenExt {
     ratePps: number;
     framePackets: PacketRow[];
     truncated: boolean;
-    stagedPcapBytes: Uint8Array | null;
-    stagedFramePackets?: PacketRow[];
 }
 
 /** Read the trafgen ext slice from a BaseDevice with safe defaults. */
@@ -19,6 +21,5 @@ export const trafgenExt = (device: BaseDevice): TrafgenExt => {
         ratePps: 0,
         framePackets: [],
         truncated: false,
-        stagedPcapBytes: null,
     };
 };

--- a/web/builtin/devices/DeviceDetails.tsx
+++ b/web/builtin/devices/DeviceDetails.tsx
@@ -62,7 +62,7 @@ const MetricBlock = ({
             series={series}
             values={history}
             color={color}
-            height={48}
+            height={56}
         />
     </div>
 );
@@ -190,24 +190,6 @@ const DeviceBody = ({
 
     return (
         <>
-            <div className="dv-section">
-                <div className="dv-section-hd"><span>Counters</span></div>
-                <div className="dv-err-strip">
-                    <div className="dv-err-chip">
-                        <span className="dv-err-chip-lbl">Errors</span>
-                        <span className="dv-err-chip-val mono">0</span>
-                    </div>
-                    <div className="dv-err-chip">
-                        <span className="dv-err-chip-lbl">Drops</span>
-                        <span className="dv-err-chip-val mono">0</span>
-                    </div>
-                    <div className="dv-err-chip">
-                        <span className="dv-err-chip-lbl">Discards</span>
-                        <span className="dv-err-chip-val mono">0</span>
-                    </div>
-                </div>
-            </div>
-
             <div className="dv-section">
                 <div className="dv-section-hd"><span>Properties</span></div>
                 <div className="dv-prop-grid">
@@ -348,29 +330,39 @@ export const DeviceDetails: React.FC<DeviceDetailsProps> = ({
         <div className="dv-detail">
             <div className="dv-detail-hd">
                 <div className="dv-detail-hd-left">
-                    <span className="dv-detail-icon" style={{ color: iconColor }}>
-                        {Icon && <Icon size={20} />}
-                    </span>
-                    <div className="dv-detail-title-wrap">
-                        <div className="dv-detail-title">
-                            <span className="dv-detail-name">{name}</span>
-                            <span className={"dv-kind-tag kind-" + device.type}>
-                                {kindTag}
-                            </span>
-                            {(device.isDirty || device.isNew) && (
-                                <span className="dv-unsaved">unsaved changes</span>
-                            )}
-                        </div>
-                        <div className="dv-detail-sub">
-                            <span className="dv-link-pill link-unknown">
-                                <span className="dv-link-pill-dot" />
-                                Link unknown
-                            </span>
-                            <span className="dv-meta-sep">·</span>
-                            <span>— · —</span>
-                            <span className="dv-meta-sep">·</span>
-                            <span>NUMA —</span>
-                        </div>
+                    <div className="dv-detail-title">
+                        <span className="dv-detail-icon" style={{ color: iconColor }}>
+                            {Icon && <Icon size={18} />}
+                        </span>
+                        <span className="dv-detail-name">{name}</span>
+                        <span className={"dv-kind-tag kind-" + device.type}>
+                            {kindTag}
+                        </span>
+                        {(device.isDirty || device.isNew) && (
+                            <span className="dv-unsaved">unsaved changes</span>
+                        )}
+                    </div>
+                    <div className="dv-detail-sub">
+                        <span className="dv-link-pill link-unknown">
+                            <span className="dv-link-pill-dot" />
+                            Link unknown
+                        </span>
+                        <span className="dv-meta-item">Speed <span className="mono">—</span></span>
+                        <span className="dv-meta-item">Duplex <span className="mono">—</span></span>
+                        <span className="dv-meta-item">NUMA <span className="mono">—</span></span>
+                        <span className="dv-meta-divider" />
+                        <span className="dv-counter-pill">
+                            <span className="dv-counter-dot dot-err" />
+                            Errors <span className="dv-counter-val mono">0</span>
+                        </span>
+                        <span className="dv-counter-pill">
+                            <span className="dv-counter-dot dot-drop" />
+                            Drops <span className="dv-counter-val mono">0</span>
+                        </span>
+                        <span className="dv-counter-pill">
+                            <span className="dv-counter-dot dot-discard" />
+                            Discards <span className="dv-counter-val mono">0</span>
+                        </span>
                     </div>
                 </div>
                 <div className="dv-detail-hd-actions">

--- a/web/builtin/devices/DeviceListItem.tsx
+++ b/web/builtin/devices/DeviceListItem.tsx
@@ -64,12 +64,12 @@ export const DeviceListItem: React.FC<DeviceListItemProps> = ({
 
             <span className="dv-row-metric">
                 <span className="dv-row-pps-entry">
-                    <span className="dv-row-pps-lbl dv-lbl-rx">RX</span>
                     <span className="dv-row-pps mono">{formatPps(rxPps)}</span>
+                    <span className="dv-row-pps-lbl dv-lbl-rx">RX</span>
                 </span>
                 <span className="dv-row-pps-entry">
-                    <span className="dv-row-pps-lbl dv-lbl-tx">TX</span>
                     <span className="dv-row-pps mono">{formatPps(txPps)}</span>
+                    <span className="dv-row-pps-lbl dv-lbl-tx">TX</span>
                 </span>
             </span>
 

--- a/web/builtin/devices/DeviceRail.tsx
+++ b/web/builtin/devices/DeviceRail.tsx
@@ -1,0 +1,123 @@
+import React, { useState, useCallback } from 'react';
+import { MiniSpark } from './components/MiniSpark';
+import { IconCaret } from './components/Icons';
+import { formatPps } from '@yanet/core/utils';
+import { deviceTypeManifest } from '@yanet/core/registry';
+import type { LocalDevice } from './types';
+import type { CounterHistoryEntry } from '@yanet/core/hooks/useCounterHistory';
+import type { DeviceCounterData } from '@yanet/core/hooks/useDeviceCounters';
+
+interface PopAnchor {
+    left: number;
+    top: number;
+}
+
+interface DeviceRailItemProps {
+    device: LocalDevice;
+    isSelected: boolean;
+    counterData: DeviceCounterData | undefined;
+    history: CounterHistoryEntry | undefined;
+    onClick: () => void;
+}
+
+const DeviceRailItem = ({
+    device,
+    isSelected,
+    counterData,
+    history,
+    onClick,
+}: DeviceRailItemProps): React.JSX.Element => {
+    const manifest = deviceTypeManifest(device.type);
+    const Icon = manifest?.icon;
+    const iconColor = manifest?.accentColor ?? 'var(--teal)';
+    const name = device.id.name || '';
+    const typeLabel = manifest?.typeDescription ?? device.type;
+
+    // Fixed-position anchor for the hover popover so it escapes the rail's
+    // own scroll clipping; null while not hovered.
+    const [anchor, setAnchor] = useState<PopAnchor | null>(null);
+
+    const handleEnter = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        setAnchor({ left: rect.right + 12, top: rect.top + rect.height / 2 });
+    }, []);
+
+    const handleLeave = useCallback(() => setAnchor(null), []);
+
+    return (
+        <div
+            className={`dv-rail-item${isSelected ? ' rail-sel' : ''}`}
+            onMouseEnter={handleEnter}
+            onMouseLeave={handleLeave}
+        >
+            <button
+                id={`dv-row-${name}`}
+                className="dv-rail-btn"
+                onClick={onClick}
+                style={{ color: iconColor }}
+            >
+                <span className="dv-rail-icon">{Icon && <Icon />}</span>
+                <span className="dv-rail-short">{name}</span>
+            </button>
+
+            {anchor && (
+                <div className="dv-rail-pop" style={{ left: anchor.left, top: anchor.top }}>
+                    <div className="dv-rail-pop-hd">
+                        <span className="dv-rail-pop-dot" style={{ background: iconColor }} />
+                        <span className="dv-rail-pop-name">{name}</span>
+                    </div>
+                    <div className="dv-rail-pop-type">{typeLabel}</div>
+                    <MiniSpark
+                        deviceId={`rail-${name}`}
+                        rx={history?.rx ?? []}
+                        tx={history?.tx ?? []}
+                        width={198}
+                        height={34}
+                    />
+                    <div className="dv-rail-pop-metric">
+                        <span><span className="lbl">RX </span>{formatPps(counterData?.rx.pps ?? 0)}</span>
+                        <span><span className="lbl">TX </span>{formatPps(counterData?.tx.pps ?? 0)}</span>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export interface DeviceRailProps {
+    devices: LocalDevice[];
+    selectedDeviceName: string | null;
+    onSelectDevice: (deviceName: string) => void;
+    onExpand: () => void;
+    counters: Map<string, DeviceCounterData>;
+    history: Map<string, CounterHistoryEntry>;
+}
+
+/** Collapsed list variant: a narrow icon rail with hover detail popovers. */
+export const DeviceRail: React.FC<DeviceRailProps> = ({
+    devices,
+    selectedDeviceName,
+    onSelectDevice,
+    onExpand,
+    counters,
+    history,
+}) => (
+    <div className="dv-rail">
+        <button className="dv-icon-btn" onClick={onExpand} title="Expand list">
+            <IconCaret dir="right" />
+        </button>
+        <div className="dv-rail-divider" />
+        <div className="dv-rail-scroll">
+            {devices.map(d => (
+                <DeviceRailItem
+                    key={d.id.name}
+                    device={d}
+                    isSelected={d.id.name === selectedDeviceName}
+                    counterData={counters.get(d.id.name || '')}
+                    history={history.get(d.id.name || '')}
+                    onClick={() => onSelectDevice(d.id.name || '')}
+                />
+            ))}
+        </div>
+    </div>
+);

--- a/web/builtin/devices/DevicesList.tsx
+++ b/web/builtin/devices/DevicesList.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { DeviceListItem } from './DeviceListItem';
-import { IconStack } from './components/Icons';
+import { DeviceRail } from './DeviceRail';
+import { IconStack, IconCaret } from './components/Icons';
 import { deviceTypes } from '@yanet/core/registry';
 import type { LocalDevice } from './types';
 import type { CounterHistoryEntry } from '@yanet/core/hooks/useCounterHistory';
@@ -20,6 +21,8 @@ export interface DevicesListProps {
     history: Map<string, CounterHistoryEntry>;
     filter: FilterKind;
     onFilterChange: (filter: FilterKind) => void;
+    collapsed: boolean;
+    onToggleCollapse: () => void;
 }
 
 interface DeviceGroup {
@@ -73,6 +76,8 @@ export const DevicesList: React.FC<DevicesListProps> = ({
     history,
     filter,
     onFilterChange,
+    collapsed,
+    onToggleCollapse,
 }) => {
 
     const counts = useMemo(() => {
@@ -92,6 +97,8 @@ export const DevicesList: React.FC<DevicesListProps> = ({
 
     const groups = useMemo(() => buildGroups(filtered, grouping), [filtered, grouping]);
 
+    const flatVisible = useMemo(() => groups.flatMap(g => g.items), [groups]);
+
     const chipDefs: [FilterKind, string, number][] = [
         ['all', 'All', counts.all],
         ...deviceTypes.map(m => [m.type, m.pluralLabel, counts.byType[m.type] ?? 0] as [FilterKind, string, number]),
@@ -101,31 +108,52 @@ export const DevicesList: React.FC<DevicesListProps> = ({
         .map(m => `${counts.byType[m.type] ?? 0} ${m.pluralLabel.toLowerCase()}`)
         .join(' · ');
 
+    if (collapsed) {
+        return (
+            <DeviceRail
+                devices={flatVisible}
+                selectedDeviceName={selectedDeviceName}
+                onSelectDevice={onSelectDevice}
+                onExpand={onToggleCollapse}
+                counters={counters}
+                history={history}
+            />
+        );
+    }
+
     return (
         <div className="dv-list">
             <div className="dv-list-hd">
-                <div className="dv-list-counts">
-                    {summary}
-                </div>
-                <div className="dv-filter-row">
-                    <div className="dv-chips">
-                        {chipDefs.map(([k, label, n]) => (
-                            <button
-                                key={k}
-                                className={"dv-chip" + (filter === k ? ' chip-on' : '')}
-                                onClick={() => onFilterChange(k)}
-                            >
-                                {label} <span className="dv-chip-n">{n}</span>
-                            </button>
-                        ))}
+                <div className="dv-list-hd-top">
+                    <span className="dv-list-counts">{summary}</span>
+                    <div className="dv-list-actions">
+                        <button
+                            className="dv-icon-btn dv-icon-btn-wide"
+                            onClick={() => onGroupingChange(nextGrouping(grouping))}
+                            title="Toggle grouping"
+                        >
+                            <IconStack /> {grouping}
+                        </button>
+                        <button
+                            className="dv-icon-btn"
+                            onClick={onToggleCollapse}
+                            title="Collapse list"
+                        >
+                            <IconCaret dir="left" />
+                        </button>
                     </div>
-                    <button
-                        className="dv-group-btn"
-                        onClick={() => onGroupingChange(nextGrouping(grouping))}
-                        title="Toggle grouping"
-                    >
-                        <IconStack /> {grouping}
-                    </button>
+                </div>
+                <div className="dv-filter">
+                    {chipDefs.map(([k, label, n]) => (
+                        <button
+                            key={k}
+                            className={"dv-filter-seg" + (filter === k ? ' seg-on' : '')}
+                            onClick={() => onFilterChange(k)}
+                        >
+                            <span className="dv-filter-seg-lbl">{label}</span>
+                            <span className="dv-filter-seg-n">{n}</span>
+                        </button>
+                    ))}
                 </div>
             </div>
 

--- a/web/builtin/devices/DevicesPage.tsx
+++ b/web/builtin/devices/DevicesPage.tsx
@@ -42,6 +42,9 @@ const DevicesPage: React.FC = () => {
     const [createDialogOpen, setCreateDialogOpen] = useState(false);
     const [grouping, setGrouping] = useState<GroupingMode>('type');
     const [deviceFilter, setDeviceFilter] = useState<FilterKind>('all');
+    const [listCollapsed, setListCollapsed] = useState(false);
+
+    const toggleListCollapsed = useCallback(() => setListCollapsed(v => !v), []);
 
     const deviceNames = useMemo(() => devices.map(d => d.id.name || ''), [devices]);
 
@@ -167,8 +170,15 @@ const DevicesPage: React.FC = () => {
             keywords: 'group parent hierarchy',
             onSelect: () => setGrouping('parent'),
         });
+        list.push({
+            id: '__toggle_list',
+            icon: '⇔',
+            label: listCollapsed ? 'Expand device list' : 'Collapse device list',
+            keywords: 'collapse expand list rail sidebar',
+            onSelect: () => toggleListCollapsed(),
+        });
         return list;
-    }, [canCreate, selectedDevice, handleCreateDevice, handleSaveDevice]);
+    }, [canCreate, selectedDevice, handleCreateDevice, handleSaveDevice, listCollapsed, toggleListCollapsed]);
 
     const rowAdapter = useMemo((): RowAdapter<LocalDevice> => ({
         rows: devices,
@@ -222,7 +232,7 @@ const DevicesPage: React.FC = () => {
                 <EmptyState message={error} />
             ) : (
                 <div className="devices-page-v2">
-                    <div className="dv-workspace">
+                    <div className={"dv-workspace" + (listCollapsed ? " dv-workspace--rail" : "")}>
                         <DevicesList
                             devices={devices}
                             selectedDeviceName={selectedDeviceName}
@@ -233,6 +243,8 @@ const DevicesPage: React.FC = () => {
                             history={history}
                             filter={deviceFilter}
                             onFilterChange={setDeviceFilter}
+                            collapsed={listCollapsed}
+                            onToggleCollapse={toggleListCollapsed}
                         />
                         <DeviceDetails
                             device={selectedDevice}

--- a/web/builtin/devices/devices.scss
+++ b/web/builtin/devices/devices.scss
@@ -85,7 +85,9 @@
         gap: 6px;
         background: var(--accent);
         color: #221a0c;
-        border: 0;
+        // Transparent 1px border keeps the box footprint identical to the
+        // `-dim` variant, so toggling enabled/disabled never shifts content.
+        border: 1px solid transparent;
         border-radius: 6px;
         padding: 7px 12px;
         font-size: 13px;
@@ -100,14 +102,19 @@
 
         &.btn-primary-dim {
             background: var(--bg-3);
-            color: var(--fg-2);
-            border: 1px solid var(--border-strong);
+            color: var(--fg-3);
+            border: 1px solid var(--border);
             box-shadow: none;
 
             &:hover {
                 background: var(--bg-3);
-                color: var(--fg-1);
+                color: var(--fg-3);
             }
+        }
+
+        &:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
         }
     }
 
@@ -155,6 +162,158 @@
         @media (max-width: 1100px) {
             grid-template-columns: 340px 1fr;
         }
+
+        // Collapsed list reduces the first column to an icon rail.
+        &--rail {
+            grid-template-columns: 64px 1fr;
+
+            @media (max-width: 1100px) {
+                grid-template-columns: 64px 1fr;
+            }
+        }
+    }
+
+    // Collapsed icon rail
+    .dv-rail {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        border-right: 1px solid var(--border);
+        background: var(--bg);
+        min-height: 0;
+        padding: 12px 0;
+    }
+
+    .dv-rail-scroll {
+        flex: 1;
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 8px;
+        margin-top: 10px;
+        padding: 2px 0;
+        overflow-y: auto;
+        min-height: 0;
+        @include dv-thin-scrollbar;
+    }
+
+    .dv-rail-divider {
+        width: 24px;
+        height: 1px;
+        background: var(--border);
+    }
+
+    .dv-rail-item {
+        position: relative;
+    }
+
+    .dv-rail-btn {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        width: 56px;
+        padding: 0;
+        background: transparent;
+        border: 0;
+        cursor: pointer;
+    }
+
+    .dv-rail-icon {
+        width: 38px;
+        height: 38px;
+        border-radius: 10px;
+        background: var(--bg-2);
+        border: 1px solid var(--border);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: background 0.1s, box-shadow 0.1s;
+    }
+
+    .dv-rail-btn:hover .dv-rail-icon {
+        background: var(--bg-3);
+    }
+
+    .dv-rail-short {
+        font-family: var(--mono);
+        font-size: 9.5px;
+        line-height: 1;
+        color: var(--fg-2);
+        max-width: 52px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .dv-rail-item.rail-sel {
+        .dv-rail-icon {
+            box-shadow: inset 0 0 0 1.5px currentColor;
+            background: var(--accent-soft);
+        }
+
+        .dv-rail-short {
+            color: var(--fg);
+        }
+    }
+
+    // Rail hover popover — positioned via fixed coords to escape rail clipping.
+    .dv-rail-pop {
+        position: fixed;
+        z-index: 40;
+        width: 224px;
+        transform: translateY(-50%);
+        display: flex;
+        flex-direction: column;
+        gap: 9px;
+        background: var(--bg-3);
+        border: 1px solid var(--border-strong);
+        border-radius: 11px;
+        padding: 12px 13px;
+        box-shadow: 0 18px 44px rgba(0, 0, 0, 0.5);
+        pointer-events: none;
+    }
+
+    .dv-rail-pop-hd {
+        display: flex;
+        align-items: center;
+        gap: 9px;
+        min-width: 0;
+    }
+
+    .dv-rail-pop-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 3px;
+        flex: none;
+    }
+
+    .dv-rail-pop-name {
+        font-family: var(--mono);
+        font-size: 13px;
+        color: var(--fg);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    .dv-rail-pop-type {
+        font-size: 11px;
+        letter-spacing: 0.04em;
+        color: var(--fg-2);
+    }
+
+    .dv-rail-pop-metric {
+        display: flex;
+        justify-content: space-between;
+        font-family: var(--mono);
+        font-size: 11px;
+    }
+
+    .dv-rail-pop-metric .lbl {
+        color: var(--fg-3);
+        letter-spacing: 0.05em;
     }
 
     // List column
@@ -182,79 +341,103 @@
         font-variant-numeric: tabular-nums;
     }
 
-    .dv-filter-row {
+    .dv-list-hd-top {
         display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: 8px;
     }
 
-    .dv-chips {
+    .dv-list-actions {
         display: flex;
-        flex-wrap: wrap;
-        gap: 4px;
-        flex: 1;
-    }
-
-    .dv-chip {
-        display: inline-flex;
         align-items: center;
         gap: 5px;
-        background: transparent;
-        border: 1px solid var(--border);
+        flex: none;
+    }
+
+    // Square icon button shared by grouping toggle + collapse / expand.
+    .dv-icon-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 4px;
+        width: 26px;
+        height: 26px;
+        background: var(--bg-1);
         color: var(--fg-2);
-        border-radius: 5px;
-        padding: 3px 8px;
-        font-size: 11.5px;
-        font-family: var(--sans);
+        border: 1px solid var(--border);
+        border-radius: 6px;
         cursor: pointer;
-        transition: all 0.1s;
+        font-family: var(--sans);
 
         &:hover {
-            color: var(--fg-1);
+            color: var(--fg);
+            background: var(--bg-3);
             border-color: var(--border-strong);
         }
 
-        &.chip-on {
+        // Variant carrying a short text label (grouping mode).
+        &.dv-icon-btn-wide {
+            width: auto;
+            padding: 0 8px;
+            font-size: 11px;
+            text-transform: lowercase;
+        }
+    }
+
+    // Segmented one-row filter control.
+    .dv-filter {
+        display: flex;
+        gap: 4px;
+        background: var(--bg-1);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 3px;
+    }
+
+    .dv-filter-seg {
+        flex: 1;
+        min-width: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 5px;
+        padding: 5px 4px;
+        background: transparent;
+        border: 0;
+        border-radius: 6px;
+        color: var(--fg-2);
+        font-size: 11.5px;
+        font-weight: 500;
+        font-family: var(--sans);
+        cursor: pointer;
+        white-space: nowrap;
+        transition: background 0.1s, color 0.1s;
+
+        &:hover {
+            color: var(--fg-1);
+        }
+
+        &.seg-on {
             background: var(--accent-soft);
-            border-color: var(--accent-mid);
             color: var(--accent);
 
-            .dv-chip-n {
-                color: var(--accent-strong);
-                background: rgba(255, 192, 97, 0.08);
+            .dv-filter-seg-n {
+                color: var(--accent);
             }
         }
     }
 
-    .dv-chip-n {
-        font-variant-numeric: tabular-nums;
-        font-size: 10.5px;
-        color: var(--fg-3);
-        background: var(--bg-2);
-        padding: 1px 5px;
-        border-radius: 3px;
-        min-width: 16px;
-        text-align: center;
+    .dv-filter-seg-lbl {
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
-    .dv-group-btn {
-        display: inline-flex;
-        align-items: center;
-        gap: 5px;
-        background: transparent;
-        color: var(--fg-2);
-        border: 1px solid var(--border);
-        border-radius: 5px;
-        padding: 3px 8px;
-        font-size: 11.5px;
-        cursor: pointer;
-        text-transform: lowercase;
-        font-family: var(--sans);
-
-        &:hover {
-            color: var(--fg-1);
-            border-color: var(--border-strong);
-        }
+    .dv-filter-seg-n {
+        font-family: var(--mono);
+        font-size: 10.5px;
+        color: var(--fg-3);
+        font-variant-numeric: tabular-nums;
     }
 
     .dv-list-scroll {
@@ -502,27 +685,28 @@
 
     .dv-detail-hd-left {
         display: flex;
+        flex-direction: column;
         gap: 12px;
-        align-items: flex-start;
         min-width: 0;
     }
 
     .dv-detail-icon {
+        width: 34px;
+        height: 34px;
+        border-radius: 9px;
         display: inline-flex;
-        padding-top: 2px;
-    }
-
-    .dv-detail-title-wrap {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        min-width: 0;
+        align-items: center;
+        justify-content: center;
+        flex: none;
+        // Faint tint of the device's own accent (set via inline `color`).
+        background: var(--bg-2);
+        background: color-mix(in srgb, currentColor 16%, transparent);
     }
 
     .dv-detail-title {
         display: flex;
         align-items: center;
-        gap: 8px;
+        gap: 10px;
         flex-wrap: wrap;
     }
 
@@ -535,11 +719,11 @@
     }
 
     .dv-kind-tag {
-        font-size: 10px;
-        font-weight: 600;
-        letter-spacing: 0.08em;
-        padding: 2px 7px;
-        border-radius: 3px;
+        font-size: 9.5px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        padding: 2px 8px;
+        border-radius: 999px;
         font-family: var(--mono);
 
         &.kind-plain {
@@ -570,8 +754,49 @@
         color: var(--fg-2);
     }
 
-    .dv-meta-sep {
+    .dv-meta-item {
         color: var(--fg-3);
+
+        .mono {
+            color: var(--fg-1);
+        }
+    }
+
+    .dv-meta-divider {
+        width: 1px;
+        height: 14px;
+        background: var(--border-strong);
+    }
+
+    .dv-counter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        color: var(--fg-2);
+    }
+
+    .dv-counter-dot {
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        flex: none;
+
+        &.dot-err {
+            background: var(--red);
+        }
+
+        &.dot-drop {
+            background: var(--amber-warn);
+        }
+
+        &.dot-discard {
+            background: var(--fg-3);
+        }
+    }
+
+    .dv-counter-val {
+        font-weight: 600;
+        color: var(--fg-1);
     }
 
     .dv-link-pill {
@@ -606,7 +831,7 @@
     .dv-detail-scroll {
         flex: 1;
         overflow-y: auto;
-        padding: 18px 24px 32px;
+        padding: 18px 24px;
         min-height: 0;
         @include dv-thin-scrollbar;
     }
@@ -626,14 +851,15 @@
     .dv-metric {
         background: var(--bg-1);
         border: 1px solid var(--border);
-        border-radius: 8px;
-        padding: 12px 14px 6px;
+        border-radius: 10px;
+        padding: 13px 15px 0;
         display: flex;
         flex-direction: column;
-        gap: 4px;
+        gap: 10px;
         min-width: 0;
         position: relative;
         overflow: hidden;
+        height: 128px;
     }
 
     .dv-metric-hd {
@@ -659,14 +885,13 @@
     }
 
     .dv-metric-val {
-        font-size: 22px;
+        font-size: 26px;
         color: var(--fg);
         font-weight: 400;
         letter-spacing: -0.01em;
         display: flex;
         align-items: baseline;
         gap: 5px;
-        margin-top: -2px;
         font-family: var(--mono);
     }
 
@@ -677,8 +902,11 @@
     }
 
     .dv-big-spark {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
         display: block;
-        margin-top: 2px;
     }
 
     // Sections
@@ -700,41 +928,10 @@
         border-bottom: 1px solid var(--border);
     }
 
-    // Error/Counter chips
-    .dv-err-strip {
-        display: flex;
-        gap: 8px;
-        flex-wrap: wrap;
-    }
-
-    .dv-err-chip {
-        display: inline-flex;
-        align-items: center;
-        gap: 8px;
-        background: var(--bg-1);
-        border: 1px solid var(--border);
-        border-radius: 6px;
-        padding: 7px 12px;
-        min-width: 110px;
-    }
-
-    .dv-err-chip-lbl {
-        font-size: 11px;
-        color: var(--fg-2);
-        letter-spacing: 0.04em;
-    }
-
-    .dv-err-chip-val {
-        font-size: 14px;
-        color: var(--fg);
-        font-feature-settings: 'tnum' 1;
-        font-family: var(--mono);
-    }
-
     // Properties grid
     .dv-prop-grid {
         display: grid;
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(3, 1fr);
         gap: 1px;
         background: var(--border);
         border: 1px solid var(--border);


### PR DESCRIPTION
Redesigns the Devices page to match the new design. The device list collapses to an icon rail with hover previews, the type filter becomes a segmented control, metric cards are taller with bottom-anchored sparklines, and per-device counters move into the detail header next to a tinted device icon and rounded kind badges.

Adds live generator controls for trafgen devices. The transmit rate and the pcap frame set are now applied to the running device through their own actions, independent of Save, which now persists only pipeline assignments. The transmit rate field is validated and Apply is enabled only for natural numbers.

Lets a pcap be loaded and previewed locally before it is uploaded to the device.

Makes the frames table collapsible and aligned with its toggle, and keeps the RX and TX labels fixed in the device list so they no longer shift with value width.
