### PR TITLE
perf(pipeline): skip per-packet demux for single-chain functions

### DIFF
--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -192,6 +192,24 @@ function_ectx_run_chains(
 	}
 }
 
+// Drain a function whose chains are all zero-weight (chain_map_size == 0).
+//
+// There is no chain to route packets to, so the output is dropped. The chains
+// are still scheduled on now-empty fronts so the worker keeps force-polling
+// every module once per tick for periodic work, exactly as the demux path did
+// for a function with no packets to route.
+static void
+function_ectx_drain(
+	struct dp_worker *dp_worker,
+	struct function_ectx *function_ectx,
+	struct packet_front *packet_front
+) {
+	packet_list_concat(&packet_front->drop, &packet_front->output);
+	packet_list_init(&packet_front->output);
+
+	function_ectx_run_chains(dp_worker, function_ectx, packet_front);
+}
+
 void
 function_ectx_process(
 	struct dp_worker *dp_worker,
@@ -211,10 +229,7 @@ function_ectx_process(
 	);
 
 	if (function_ectx->chain_map_size == 0) {
-		// Every chain is zero-weight (disabled): there is no chain to
-		// route to, so drop, mirroring the empty device dispatch map.
-		packet_list_concat(&packet_front->drop, &packet_front->output);
-		packet_list_init(&packet_front->output);
+		function_ectx_drain(dp_worker, function_ectx, packet_front);
 	} else if (function_ectx->chain_count == 1) {
 		function_ectx_run_single_chain(
 			dp_worker, function_ectx, packet_front

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -134,24 +134,40 @@ chain_ectx_process(
 	}
 }
 
-void
-function_ectx_process(
+// Run the function's only chain.
+//
+// With a single chain every packet maps to chain 0, so the per-packet hash
+// demux is skipped: the whole list is moved to a private front in one step.
+// The chain still runs on its own front, so drops accumulated by earlier
+// functions stay hidden from this chain's modules, matching the isolation the
+// per-chain demux provided.
+static void
+function_ectx_run_single_chain(
 	struct dp_worker *dp_worker,
 	struct function_ectx *function_ectx,
 	struct packet_front *packet_front
 ) {
-	struct counter_storage *storage =
-		ADDR_OF(&function_ectx->counter_storage);
+	struct packet_front schedule;
+	packet_front_init(&schedule);
+	packet_list_concat(&schedule.output, &packet_front->output);
+	packet_list_init(&packet_front->output);
 
-	counter_add_packets_bytes(
-		function_ectx->counter_packet_in_count,
-		function_ectx->counter_packet_in_bytes,
-		dp_worker->idx,
-		storage,
-		packet_front->output.count,
-		packet_list_bytes_sum(&packet_front->output)
-	);
+	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
+	chain_ectx_process(dp_worker, ADDR_OF(chains), &schedule);
 
+	packet_front_merge(packet_front, &schedule);
+}
+
+// Demultiplex packets across the function's chains by hash.
+//
+// Each chain is processed on its own packet front and the results are merged
+// back into the caller's front.
+static void
+function_ectx_run_chains(
+	struct dp_worker *dp_worker,
+	struct function_ectx *function_ectx,
+	struct packet_front *packet_front
+) {
 	// FIXME: do not create schedule for each invocation
 	struct packet_front schedule[function_ectx->chain_count];
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx)
@@ -173,6 +189,40 @@ function_ectx_process(
 		chain_ectx_process(dp_worker, chain_ectx, schedule + idx);
 
 		packet_front_merge(packet_front, schedule + idx);
+	}
+}
+
+void
+function_ectx_process(
+	struct dp_worker *dp_worker,
+	struct function_ectx *function_ectx,
+	struct packet_front *packet_front
+) {
+	struct counter_storage *storage =
+		ADDR_OF(&function_ectx->counter_storage);
+
+	counter_add_packets_bytes(
+		function_ectx->counter_packet_in_count,
+		function_ectx->counter_packet_in_bytes,
+		dp_worker->idx,
+		storage,
+		packet_front->output.count,
+		packet_list_bytes_sum(&packet_front->output)
+	);
+
+	if (function_ectx->chain_map_size == 0) {
+		// Every chain is zero-weight (disabled): there is no chain to
+		// route to, so drop, mirroring the empty device dispatch map.
+		packet_list_concat(&packet_front->drop, &packet_front->output);
+		packet_list_init(&packet_front->output);
+	} else if (function_ectx->chain_count == 1) {
+		function_ectx_run_single_chain(
+			dp_worker, function_ectx, packet_front
+		);
+	} else {
+		function_ectx_run_chains(
+			dp_worker, function_ectx, packet_front
+		);
 	}
 
 	counter_add_packets_bytes(

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -192,7 +192,7 @@ function_ectx_run_chains(
 	}
 }
 
-// Drain a function whose chains are all zero-weight (chain_map_size == 0).
+// Drain a function whose chains are all zero-weight (fully disabled).
 //
 // There is no chain to route packets to, so the output is dropped. The chains
 // are still scheduled on now-empty fronts so the worker keeps force-polling

--- a/tests/pipeline/dispatch_test.go
+++ b/tests/pipeline/dispatch_test.go
@@ -4,8 +4,8 @@
 // The tests here lock in two correctness rules introduced by the
 // single-chain fast path added to function_ectx_process:
 //
-//  1. A function whose chains are all zero-weight (chain_map_size == 0)
-//     must DROP all packets rather than route them to a disabled chain.
+//  1. A function whose chains are all zero-weight must DROP all packets
+//     rather than route them to a disabled chain.
 //
 //  2. The single-chain fast path runs each function on its own packet front,
 //     so two single-chain functions chained in one pipeline hand packets from
@@ -123,21 +123,19 @@ func publishMatchAllACL(t *testing.T, backend acl.Backend, name string, action u
 }
 
 // TestZeroWeightFunctionDropsAllPackets verifies that a function whose only
-// chain has weight 0 (chain_map_size == 0) drops every packet instead of
-// running its disabled chain.
+// chain has weight 0 drops every packet instead of running its disabled chain.
 //
 // The chain is an allow-all ACL that would forward every packet if it ran, so
-// the drop is observable as an empty output. Without the guard in
-// function_ectx_process the zero-weight chain would run (forwarding the
-// packets) or divide by zero in the chain-map modulo.
+// the drop is observable as an empty output. Without the dispatch guard a
+// zero-weight chain would instead process traffic.
 func TestZeroWeightFunctionDropsAllPackets(t *testing.T) {
 	const configName = "zw-acl"
 
 	h, agent, backend := setupACLBackend(t, "zw-test")
 	publishMatchAllACL(t, backend, configName, cacl.ActionAllow)
 
-	// Register an ACL function whose single chain has Weight 0.  The
-	// dataplane builds chain_map_size = 0 for this function.
+	// Register an ACL function whose single chain has weight 0, which the
+	// dataplane treats as fully disabled.
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{

--- a/tests/pipeline/dispatch_test.go
+++ b/tests/pipeline/dispatch_test.go
@@ -31,10 +31,14 @@ import (
 )
 
 // Memory sizes for the dispatch regression harness.
+//
+// They are generous because a single test compiles two ACL modules in one
+// agent arena, and the ACL filter compilation must still fit under sanitizer
+// (ASan redzone) builds.
 const (
-	dispatchCPSize  = 64 * datasize.MB
-	dispatchDPSize  = 4 * datasize.MB
-	dispatchMemSize = 16 * datasize.MB
+	dispatchCPSize  = 256 * datasize.MB
+	dispatchDPSize  = 16 * datasize.MB
+	dispatchMemSize = 128 * datasize.MB
 )
 
 // dispatchUDPPacket builds a single Ethernet/IPv4/UDP packet whose source and

--- a/tests/pipeline/dispatch_test.go
+++ b/tests/pipeline/dispatch_test.go
@@ -1,0 +1,245 @@
+// Package pipeline_test holds regression tests for the dataplane pipeline
+// dispatch logic implemented in lib/dataplane/pipeline/pipeline.c.
+//
+// The tests here lock in two correctness rules introduced by the
+// single-chain fast path added to function_ectx_process:
+//
+//  1. A function whose chains are all zero-weight (chain_map_size == 0)
+//     must DROP all packets rather than route them to a disabled chain.
+//
+//  2. The single-chain fast path runs each function on its own packet front,
+//     so two single-chain functions chained in one pipeline hand packets from
+//     the first to the second intact and drop exactly what the chain drops.
+package pipeline_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
+	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
+)
+
+// Memory sizes for the dispatch regression harness.
+const (
+	dispatchCPSize  = 64 * datasize.MB
+	dispatchDPSize  = 4 * datasize.MB
+	dispatchMemSize = 16 * datasize.MB
+)
+
+// dispatchUDPPacket builds a single Ethernet/IPv4/UDP packet whose source and
+// destination addresses fall in the ranges used by the test rules.
+func dispatchUDPPacket(t *testing.T) gopacket.Packet {
+	t.Helper()
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    net.ParseIP("192.0.2.1"),
+		DstIP:    net.ParseIP("10.0.0.1"),
+	}
+	udp := layers.UDP{SrcPort: 12345, DstPort: 80}
+	require.NoError(t, udp.SetNetworkLayerForChecksum(&ip4))
+	return xpacket.LayersToPacket(t, &eth, &ip4, &udp)
+}
+
+// setupACLBackend creates a single-device harness with the acl module loaded
+// and returns it together with an attached agent and ACL backend.
+func setupACLBackend(
+	t *testing.T,
+	agentName string,
+	extraModules ...string,
+) (*dataplaneut.Harness, *ffi.Agent, acl.Backend) {
+	t.Helper()
+
+	modules := append([]string{"acl"}, extraModules...)
+	cfg := dataplaneut.Config{
+		CPMemory:      uint64(dispatchCPSize),
+		DPMemory:      uint64(dispatchDPSize),
+		WorkerCount:   1,
+		Devices:       []string{"port0"},
+		Modules:       modules,
+		DevicesToLoad: []string{"plain"},
+	}
+	h, err := dataplaneut.NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	agent, err := h.SharedMemory().AgentAttach(agentName, 0, dispatchMemSize)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	backend := acl.NewBackend(agent, uint64(dispatchMemSize))
+	return h, agent, backend
+}
+
+// publishMatchAllACL creates an ACL module whose single rule matches every
+// IPv4 UDP packet with the given action and publishes it to shared memory.
+//
+// The created handle is freed via t.Cleanup.
+func publishMatchAllACL(t *testing.T, backend acl.Backend, name string, action uint32) {
+	t.Helper()
+
+	handle, err := backend.NewModule(name)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	rule := cacl.AclRule{
+		Actions:       []cacl.AclAction{{Kind: action}},
+		Devices:       filter.Devices{{Name: "port0"}},
+		Src4s:         filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:         filter.IPNets{filter.UnspecifiedIPv4},
+		Src6s:         filter.IPNets{},
+		Dst6s:         filter.IPNets{},
+		SrcPortRanges: filter.PortRanges{{From: 0, To: 65535}},
+		DstPortRanges: filter.PortRanges{{From: 0, To: 65535}},
+		ProtoRanges: filter.ProtoRanges{
+			filter.NewProtoRange(uint8(layers.IPProtocolUDP), filter.AnySubtype()),
+		},
+		Fragment: filter.FragmentAny,
+	}
+	require.NoError(t, handle.UpdateRules([]cacl.AclRule{rule}))
+	require.NoError(t, backend.UpdateModule(handle))
+}
+
+// TestZeroWeightFunctionDropsAllPackets verifies that a function whose only
+// chain has weight 0 (chain_map_size == 0) drops every packet instead of
+// running its disabled chain.
+//
+// The chain is an allow-all ACL that would forward every packet if it ran, so
+// the drop is observable as an empty output. Without the guard in
+// function_ectx_process the zero-weight chain would run (forwarding the
+// packets) or divide by zero in the chain-map modulo.
+func TestZeroWeightFunctionDropsAllPackets(t *testing.T) {
+	const configName = "zw-acl"
+
+	h, agent, backend := setupACLBackend(t, "zw-test")
+	publishMatchAllACL(t, backend, configName, cacl.ActionAllow)
+
+	// Register an ACL function whose single chain has Weight 0.  The
+	// dataplane builds chain_map_size = 0 for this function.
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: configName,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 0,
+			Chain: ffi.ChainConfig{
+				Name:    configName + "_chain",
+				Modules: []ffi.ChainModuleConfig{{Type: "acl", Name: configName}},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      configName,
+		Functions: []string{configName},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	const packetCount = 4
+	pkts := make([]gopacket.Packet, packetCount)
+	for idx := range packetCount {
+		pkts[idx] = dispatchUDPPacket(t)
+	}
+
+	result, err := h.HandlePackets(pkts...)
+	require.NoError(t, err)
+	require.Empty(t, result.Output,
+		"zero-weight function must not forward any packet to output")
+	require.Len(t, result.Drop, packetCount,
+		"zero-weight function must drop all packets")
+}
+
+// TestSequentialSingleChainFunctions verifies that two single-chain functions
+// chained in one pipeline route packets correctly through the single-chain
+// fast path.
+//
+// The pipeline runs funcA (ACL allow-all) followed by funcB (ACL deny-all),
+// both single-chain functions. funcA forwards all N packets to funcB, which
+// drops every one, so the egress output is empty. funcB's input counter must
+// equal N, confirming the fast path handed funcA's output to funcB intact
+// rather than losing or smuggling packets.
+func TestSequentialSingleChainFunctions(t *testing.T) {
+	const (
+		aclA       = "allow-all"
+		aclB       = "deny-all"
+		pipelineAB = "pipe-ab"
+	)
+
+	h, agent, backend := setupACLBackend(t, "pf-test")
+
+	// funcA allows every matching UDP IPv4 packet; funcB then drops them all.
+	publishMatchAllACL(t, backend, aclA, cacl.ActionAllow)
+	publishMatchAllACL(t, backend, aclB, cacl.ActionDeny)
+
+	// Wire both single-chain functions into one pipeline in order.
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: aclA,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name:    aclA + "_chain",
+				Modules: []ffi.ChainModuleConfig{{Type: "acl", Name: aclA}},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: aclB,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name:    aclB + "_chain",
+				Modules: []ffi.ChainModuleConfig{{Type: "acl", Name: aclB}},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      pipelineAB,
+		Functions: []string{aclA, aclB},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: pipelineAB, Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	const packetCount = 5
+	pkts := make([]gopacket.Packet, packetCount)
+	for idx := range packetCount {
+		pkts[idx] = dispatchUDPPacket(t)
+	}
+
+	result, err := h.HandlePackets(pkts...)
+	require.NoError(t, err)
+	require.Empty(t, result.Output,
+		"allow-then-deny pipeline must not forward any packet to egress")
+	require.Len(t, result.Drop, packetCount,
+		"allow-then-deny pipeline must drop all packets")
+
+	// funcB's input counter must equal N: the single-chain fast path handed
+	// funcA's forwarded packets to funcB intact.
+	counters := h.SharedMemory().DPConfig(0).FunctionCounters("port0", pipelineAB, aclB)
+	byName := dataplaneut.SingleValueCounters(counters)
+	require.Equal(t, uint64(packetCount), byName["input"],
+		"funcB must receive exactly the packets funcA forwarded (all N)")
+}


### PR DESCRIPTION
A pipeline function demultiplexes packets across its chains on every invocation — allocating a per-call scheduling buffer, computing a per-packet hash modulo, and tearing the packet list apart and rebuilding it — even when the function has a single chain, which is the common case. With one chain that demultiplex is a no-op.

This adds a fast path for the single-chain case: the whole packet list is moved to a private front in one step (no per-packet hash modulo) and the chain runs there, so earlier functions' drops stay isolated from the chain's modules exactly as the demux path guaranteed. A function whose chains are all zero-weight is dropped explicitly instead of routed to a disabled chain. The dispatch cost drops from ~4.7% of worker cycles to ~0.05% in the profile.

Re-benchmarked with the corrected build on the production ACL ruleset (78803 rules), two workers, saturated by the in-band traffic generator, median of 15 samples per config in one session (the host adds ~±0.4 Mpps of jitter):

| Configuration | Throughput | vs baseline |
|---|---|---|
| Baseline | 7.08 Mpps | — |
| Single-chain fast path (this PR) | 7.91 Mpps | +12% |
| + single-pipeline fast path (follow-up, not in this PR) | 7.84 Mpps | +11% |

The single-chain fast path is the win (+12%, removing the per-packet divide that runs once per function — three times per packet on this chain). The follow-up applies the same idea one level up at device dispatch; its increment over the single-chain path is within the host's jitter here (the device runs one dispatch per packet versus three for the functions), so it is kept as a separate, independently-validated change rather than folded in.
