### PR TITLE
refactor(dataplane): empty the source list on packet-list concat

### DIFF
--- a/lib/dataplane/module/packet_front.h
+++ b/lib/dataplane/module/packet_front.h
@@ -52,11 +52,9 @@ packet_front_drop(struct packet_front *packet_front, struct packet *packet) {
 static inline void
 packet_front_switch(struct packet_front *packet_front) {
 	packet_list_concat(&packet_front->input, &packet_front->output);
-	packet_list_init(&packet_front->output);
 }
 
 static inline void
 packet_front_pass(struct packet_front *packet_front) {
 	packet_list_concat(&packet_front->output, &packet_front->input);
-	packet_list_init(&packet_front->input);
 }

--- a/lib/dataplane/packet/packet.h
+++ b/lib/dataplane/packet/packet.h
@@ -83,6 +83,7 @@ packet_list_first(struct packet_list *list) {
 	return list->first;
 }
 
+// Move every packet from src into dst, leaving src empty.
 static inline void
 packet_list_concat(struct packet_list *dst, struct packet_list *src) {
 	// Nothing to do if src is empty
@@ -92,6 +93,7 @@ packet_list_concat(struct packet_list *dst, struct packet_list *src) {
 	// Replace dst with src if dst is empty
 	if (dst->first == NULL) {
 		*dst = *src;
+		packet_list_init(src);
 		return;
 	}
 
@@ -99,6 +101,8 @@ packet_list_concat(struct packet_list *dst, struct packet_list *src) {
 	dst->last = src->last;
 	dst->count += src->count;
 	dst->bytes += src->bytes;
+
+	packet_list_init(src);
 }
 
 static inline struct packet *

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -150,7 +150,6 @@ function_ectx_run_single_chain(
 	struct packet_front schedule;
 	packet_front_init(&schedule);
 	packet_list_concat(&schedule.output, &packet_front->output);
-	packet_list_init(&packet_front->output);
 
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
 	chain_ectx_process(dp_worker, ADDR_OF(chains), &schedule);
@@ -205,7 +204,6 @@ function_ectx_drain(
 	struct packet_front *packet_front
 ) {
 	packet_list_concat(&packet_front->drop, &packet_front->output);
-	packet_list_init(&packet_front->output);
 
 	function_ectx_run_chains(dp_worker, function_ectx, packet_front);
 }
@@ -323,7 +321,6 @@ device_entry_ectx_dispatch(
 ) {
 	if (!entry_ectx->pipeline_map_size) {
 		packet_list_concat(&packet_front->drop, &packet_front->output);
-		packet_list_init(&packet_front->output);
 		return;
 	}
 

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -386,7 +386,6 @@ dataplane_ut_run(
 	packet_front_init(&packet_front);
 
 	packet_list_concat(&packet_front.pending_input, input);
-	packet_list_init(input);
 
 	packet_list_init(&result->output);
 	packet_list_init(&result->drop);


### PR DESCRIPTION
Concatenating two packet lists now leaves the source list empty: the move resets the source after splicing its packets onto the destination. Every moved packet therefore has a single owner, which removes a class of latent stale-alias bugs where a drained source kept pointing at packets it no longer owned.

This folds a reset that callers previously performed by hand into the move itself, dropping the redundant per-call-site cleanup across the pipeline, the packet-front helpers, and the dataplane test harness.

The change is zero-cost on the per-packet hot path, validated at the assembly level. Where the source is a dead local — the inlined fast paths — the compiler eliminates the added reset entirely: the generated code is byte-for-byte identical to before at -O1, -O2, and -O3 (gcc 13.3, -march=haswell, matching the project's optimization level). As a negative control, when the source outlives the call the reset stores survive exactly as they must, and at those escaping sites the stores were already emitted by the old hand-written reset — so nothing is added there either.

The dataplane build and the single-chain dispatch regression tests pass.
