### PR TITLE
perf(common): elide the null test on hot relative-pointer chases

### DIFF
--- a/common/lpm.h
+++ b/common/lpm.h
@@ -274,7 +274,9 @@ lpm_lookup(const struct lpm *lpm, uint8_t key_size, const uint8_t *key) {
 		value = page->values + key[hop];
 		if (value->value & LPM_VALUE_FLAG)
 			break;
-		page = ADDR_OF(&value->page);
+		// An intermediate node (flag clear) always has a child page, so
+		// the relative pointer is never NULL here — skip the NULL test.
+		page = ADDR_OF_NONNULL(&value->page);
 	}
 
 	return LPM_VALUE_GET(value->value);

--- a/common/memory_address.h
+++ b/common/memory_address.h
@@ -20,6 +20,23 @@
 	})
 
 /**
+ * @brief Convert a known-non-NULL relative pointer to a virtual address.
+ *
+ * Same as ADDR_OF but skips the NULL test. The compiler cannot prove the
+ * stored offset is non-zero (it is data), so ADDR_OF always emits a branch /
+ * cmov. On hot pointer-chases where the relative pointer is structurally never
+ * NULL — e.g. an intermediate LPM trie node always has a child page — this
+ * drops that per-hop cmov. If the offset is in fact 0 the result is the slot
+ * address itself, a wrong value but never a crash.
+ */
+#define ADDR_OF_NONNULL(OFFSET)                                                \
+	__extension__({                                                        \
+		typeof(*(OFFSET)) offset_val = *(OFFSET);                      \
+		(typeof(offset_val))((uintptr_t)offset_val +                   \
+				     (uintptr_t)(OFFSET));                     \
+	})
+
+/**
  * @brief Set a relative pointer to point to a virtual address
  *
  * This macro sets a relative pointer to point to a specified virtual address.

--- a/common/value.h
+++ b/common/value.h
@@ -92,12 +92,16 @@ static inline uint32_t *
 value_table_get_ptr(
 	struct value_table *value_table, uint32_t v_idx, uint32_t h_idx
 ) {
-	uint32_t **values = ADDR_OF(&value_table->values);
+	// values and the chunk pointers are set at init and cleared only by
+	// value_table_free, which never races a lookup — so on the query path
+	// they are never NULL and the NULL test in ADDR_OF is pure per-lookup
+	// overhead.
+	uint32_t **values = ADDR_OF_NONNULL(&value_table->values);
 	uint64_t idx = v_idx;
 	idx *= value_table->h_dim;
 	idx += h_idx;
 
-	return ADDR_OF(values + idx / VALUE_TABLE_CHUNK_SIZE) +
+	return ADDR_OF_NONNULL(values + idx / VALUE_TABLE_CHUNK_SIZE) +
 	       idx % VALUE_TABLE_CHUNK_SIZE;
 }
 


### PR DESCRIPTION
Shared-memory relative pointers are resolved through a helper that always tests the stored offset for the null encoding before adding it to the slot address. The compiler cannot prove the offset is non-zero — it is data read from shared memory — so it emits that test plus a conditional move on every dereference. On the ACL classifier hot path this helper runs on every longest-prefix-match trie hop and on every cross-producting value-table access, so the redundant test is paid for on every packet.

This adds a non-null variant of the helper and uses it at exactly two sites where the stored offset is structurally never null: the per-hop child-page pointer in the trie walk, and the row/chunk pointers of the value table.

### Why this is a good change

- It removes one test and one conditional move per trie hop and per value-table access on the busiest, always-taken classifier path, with no new branch and no data-structure change.
- The hot path here is instruction-throughput bound, not memory bound (backend stalls stay under 0.25% even at 30%+ cache-miss rate), so cutting instructions is the lever that actually moves throughput.

### Why this is safe

- The non-null variant is bit-for-bit identical to the original for every non-zero offset; the two diverge only when the stored offset is exactly zero, which is precisely the null encoding. So correctness reduces to showing neither site ever reads a null relative pointer.
- The trie site is reached only after the leaf check has broken out of the walk, i.e. only for intermediate nodes, which by construction always carry a child page (the offset is set to a freshly allocated page, never zero).
- The value-table pointers are populated when the table is built and cleared only when it is freed. A half-built or freed table is never published to the dataplane — an init failure unwinds and propagates an error — and the dataplane only ever reads an immutable, fully-built config.
- The address arithmetic is identical to the original's non-null branch, so it is unaffected by the control-plane to dataplane memory remap.

### Performance

Measured on the trafgen stand against the production ACL ruleset (78,803 rules), a single ACL function bound to one pipeline, using instructions-per-packet — a contention-immune metric (this shared host's cycle and pps figures swing 15–22% with co-tenant load, while instruction count is stable to within 0.1%).

| RX burst | before (insn/pkt) | after (insn/pkt) | change |
|---|---|---|---|
| 1024 (trafgen stand default) | 1325.5 | 1204.6 | **−9.1%** |
| 32 (production NIC RX burst) | 1645.7 | 1526.7 | **−7.2%** |

The saving is a flat ~120 instructions per packet regardless of burst size, since it is purely per-packet classifier work; the percentage is larger at the larger burst only because the fixed per-batch plumbing is amortized over more packets there.
