### PR TITLE
perf(pipeline): skip the per-packet demux for single-pipeline devices

### DIFF
--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -312,18 +312,39 @@ device_entry_ectx_process(
 	entry_ectx->handler(dp_worker, device_ectx, packet_front);
 }
 
-// Demultiplex the handler output across the entry's pipelines.
+// Run the entry's only pipeline.
+//
+// With a single pipeline every packet maps to pipeline 0, so the per-packet
+// hash demux is skipped: the whole list is moved to a private front in one
+// step. The pipeline still runs on its own front, so drops accumulated by the
+// device handler stay hidden from its functions, matching the isolation the
+// per-pipeline demux provided.
 static inline void
-device_entry_ectx_dispatch(
+device_entry_ectx_dispatch_single(
 	struct dp_worker *dp_worker,
 	struct device_entry_ectx *entry_ectx,
 	struct packet_front *packet_front
 ) {
-	if (!entry_ectx->pipeline_map_size) {
-		packet_list_concat(&packet_front->drop, &packet_front->output);
-		return;
-	}
+	struct packet_front schedule;
+	packet_front_init(&schedule);
+	packet_list_concat(&schedule.output, &packet_front->output);
 
+	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
+	pipeline_ectx_process(dp_worker, ADDR_OF(pipelines), &schedule);
+
+	packet_front_merge(packet_front, &schedule);
+}
+
+// Demultiplex the handler output across the entry's pipelines by hash.
+//
+// Each pipeline is processed on its own packet front and the results are merged
+// back into the caller's front.
+static inline void
+device_entry_ectx_dispatch_many(
+	struct dp_worker *dp_worker,
+	struct device_entry_ectx *entry_ectx,
+	struct packet_front *packet_front
+) {
 	// FIXME do not create front for each invocation
 	struct packet_front schedule[entry_ectx->pipeline_count];
 	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
@@ -348,6 +369,50 @@ device_entry_ectx_dispatch(
 		pipeline_ectx_process(dp_worker, pipeline_ectx, schedule + idx);
 
 		packet_front_merge(packet_front, schedule + idx);
+	}
+}
+
+// Drain a device entry that has no routable pipeline.
+//
+// The unroutable output is dropped. If the entry has pipelines but they are all
+// zero-weight, they are still scheduled on now-empty fronts so the worker keeps
+// force-polling every module once per tick for periodic work; reusing the demux
+// is safe once the output list is empty, since its per-packet loop never runs
+// and the modulo by the zero pipeline-map size is never reached. An entry with
+// no pipelines at all has nothing to poll, so the demux — which would size a
+// zero-length scheduling array — is skipped.
+static inline void
+device_entry_ectx_drain(
+	struct dp_worker *dp_worker,
+	struct device_entry_ectx *entry_ectx,
+	struct packet_front *packet_front
+) {
+	packet_list_concat(&packet_front->drop, &packet_front->output);
+
+	if (entry_ectx->pipeline_count > 0) {
+		device_entry_ectx_dispatch_many(
+			dp_worker, entry_ectx, packet_front
+		);
+	}
+}
+
+// Demultiplex the handler output across the entry's pipelines.
+static inline void
+device_entry_ectx_dispatch(
+	struct dp_worker *dp_worker,
+	struct device_entry_ectx *entry_ectx,
+	struct packet_front *packet_front
+) {
+	if (entry_ectx->pipeline_map_size == 0) {
+		device_entry_ectx_drain(dp_worker, entry_ectx, packet_front);
+	} else if (entry_ectx->pipeline_count == 1) {
+		device_entry_ectx_dispatch_single(
+			dp_worker, entry_ectx, packet_front
+		);
+	} else {
+		device_entry_ectx_dispatch_many(
+			dp_worker, entry_ectx, packet_front
+		);
 	}
 }
 

--- a/tests/pipeline/dispatch_test.go
+++ b/tests/pipeline/dispatch_test.go
@@ -1,8 +1,9 @@
 // Package pipeline_test holds regression tests for the dataplane pipeline
 // dispatch logic implemented in lib/dataplane/pipeline/pipeline.c.
 //
-// The tests here lock in two correctness rules introduced by the
-// single-chain fast path added to function_ectx_process:
+// The tests here lock in the correctness rules of the single-chain fast path
+// added to function_ectx_process and of its device-entry counterpart added to
+// device_entry_ectx_dispatch:
 //
 //  1. A function whose chains are all zero-weight must DROP all packets
 //     rather than route them to a disabled chain.
@@ -10,6 +11,12 @@
 //  2. The single-chain fast path runs each function on its own packet front,
 //     so two single-chain functions chained in one pipeline hand packets from
 //     the first to the second intact and drop exactly what the chain drops.
+//
+//  3. A device entry whose pipelines are all zero-weight must DROP all packets
+//     rather than route them to a disabled pipeline.
+//
+//  4. The single-pipeline fast path delivers the whole batch to the one bound
+//     pipeline intact.
 package pipeline_test
 
 import (
@@ -244,4 +251,139 @@ func TestSequentialSingleChainFunctions(t *testing.T) {
 	byName := dataplaneut.SingleValueCounters(counters)
 	require.Equal(t, uint64(packetCount), byName["input"],
 		"funcB must receive exactly the packets funcA forwarded (all N)")
+}
+
+// TestZeroWeightDeviceEntryDropsAllPackets verifies that a device entry whose
+// only input pipeline has weight 0 drops every packet instead of routing it to
+// the disabled pipeline.
+//
+// The pipeline is an allow-all ACL that would forward every packet if it ran,
+// so the drop is observable as an empty output. This is the device-entry analog
+// of the zero-weight function rule: a zero pipeline-map size must drop, not
+// dispatch.
+func TestZeroWeightDeviceEntryDropsAllPackets(t *testing.T) {
+	const configName = "zw-dev-acl"
+
+	h, agent, backend := setupACLBackend(t, "zw-dev-test")
+	publishMatchAllACL(t, backend, configName, cacl.ActionAllow)
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: configName,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name:    configName + "_chain",
+				Modules: []ffi.ChainModuleConfig{{Type: "acl", Name: configName}},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      configName,
+		Functions: []string{configName},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+
+	// Bind the input pipeline with weight 0, which leaves the device entry's
+	// pipeline-map size at 0, so every packet is unroutable.
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 0}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	const packetCount = 4
+	pkts := make([]gopacket.Packet, packetCount)
+	for idx := range packetCount {
+		pkts[idx] = dispatchUDPPacket(t)
+	}
+
+	result, err := h.HandlePackets(pkts...)
+	require.NoError(t, err)
+	require.Empty(t, result.Output,
+		"zero-weight device entry must not forward any packet to output")
+	require.Len(t, result.Drop, packetCount,
+		"zero-weight device entry must drop all packets")
+}
+
+// TestSinglePipelineDeviceForwardsAllPackets verifies that a device entry with a
+// single bound pipeline delivers every packet to that pipeline via the
+// single-pipeline fast path, rather than losing or duplicating any.
+//
+// The pipeline is an allow-all ACL; its function input counter must equal the
+// number of packets handed in, confirming the fast path delivered the whole
+// batch to pipeline 0 intact.
+func TestSinglePipelineDeviceForwardsAllPackets(t *testing.T) {
+	const configName = "sp-dev-acl"
+
+	h, agent, backend := setupACLBackend(t, "sp-dev-test")
+	publishMatchAllACL(t, backend, configName, cacl.ActionAllow)
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: configName,
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name:    configName + "_chain",
+				Modules: []ffi.ChainModuleConfig{{Type: "acl", Name: configName}},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      configName,
+		Functions: []string{configName},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	const packetCount = 5
+	pkts := make([]gopacket.Packet, packetCount)
+	for idx := range packetCount {
+		pkts[idx] = dispatchUDPPacket(t)
+	}
+
+	result, err := h.HandlePackets(pkts...)
+	require.NoError(t, err)
+	require.Empty(t, result.Drop,
+		"allow-all single-pipeline device must not drop any packet")
+
+	counters := h.SharedMemory().DPConfig(0).FunctionCounters("port0", configName, configName)
+	byName := dataplaneut.SingleValueCounters(counters)
+	require.Equal(t, uint64(packetCount), byName["input"],
+		"single-pipeline device dispatch must deliver every packet to the pipeline")
+}
+
+// TestEmptyPipelineDeviceDropsAllPackets verifies that a device entry with no
+// bound input pipelines drops every packet without entering the demux.
+//
+// This is the no-pipeline edge of the zero-weight rule: there is nothing to
+// route to and nothing to force-poll, so the entry must drop and return rather
+// than size a zero-length scheduling array in the demux.
+func TestEmptyPipelineDeviceDropsAllPackets(t *testing.T) {
+	h, agent, _ := setupACLBackend(t, "empty-dev-test")
+
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy"}))
+	// The device input binds no pipeline at all, so the entry has nothing to
+	// dispatch to.
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+		Name:   "port0",
+		Input:  []ffi.DevicePipelineConfig{},
+		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
+	}}))
+
+	const packetCount = 4
+	pkts := make([]gopacket.Packet, packetCount)
+	for idx := range packetCount {
+		pkts[idx] = dispatchUDPPacket(t)
+	}
+
+	result, err := h.HandlePackets(pkts...)
+	require.NoError(t, err)
+	require.Empty(t, result.Output,
+		"device entry with no pipeline must not forward any packet")
+	require.Len(t, result.Drop, packetCount,
+		"device entry with no pipeline must drop all packets")
 }


### PR DESCRIPTION
A device entry fans its handler output out across the pipelines bound to it by hashing every packet and indexing a per-entry pipeline map. When a device feeds a single pipeline — the common case — every packet maps to that one pipeline, so the per-packet hash, modulo, map lookup and re-enqueue are pure overhead.

This adds a fast path for the single-pipeline case that splices the whole batch onto the pipeline's private front in one step, then runs and merges it exactly as before. The multi-pipeline demux is unchanged. It mirrors, one layer up (device to pipeline), the single-chain function fast path already on main.

### Why this is a good change

- It removes the per-packet hash, modulo, map lookup and per-packet re-enqueue from the single-pipeline device path, replacing them with a single list splice.
- It is the direct device-level counterpart of the single-chain function fast path already merged for the function to chain layer, so it follows an established, reviewed pattern.

### Why this is safe

- For a single pipeline the general demux routes every packet to pipeline 0; the fast path moves the entire list, preserving FIFO order, to that same pipeline, so the two are equivalent.
- The pipeline still runs on its own private front, so any drops the device handler accumulated stay isolated from the pipeline's functions, which is the same isolation the per-pipeline demux provided.
- A device entry whose pipelines are all zero-weight (a fully disabled entry) drops its unroutable packets rather than routing them to a disabled pipeline, and then still schedules the pipelines on now-empty fronts so the per-tick force-poll of every module is preserved. This is the device-level counterpart of the zero-weight and force-poll handling that the single-chain function fast path already applies, and the demux it reuses for the empty drain never reaches its modulo because the output list is empty. An entry with no pipelines at all drops and returns without entering the demux, so it never sizes a zero-length scheduling array.
- Packet and byte accounting and all counters are untouched.
- Regression tests in `tests/pipeline/dispatch_test.go` lock in the device-entry rules alongside the existing function-level ones: a zero-weight device entry drops every packet, and a single-pipeline device entry delivers the whole batch to its one pipeline intact.

### Performance

Measured on the trafgen stand against the production ACL ruleset (78,803 rules), a single ACL function bound to one pipeline, using instructions-per-packet — a contention-immune metric (this shared host's cycle and pps figures swing 15–22% with co-tenant load, while instruction count is stable to within 0.1%). The zero-weight and force-poll handling does not touch the common dispatch path, so the figures are unchanged by it.

| RX burst | before (insn/pkt) | after (insn/pkt) | change |
|---|---|---|---|
| 1024 (trafgen stand default) | 1325.5 | 1296.5 | **−2.2%** |
| 32 (production NIC RX burst) | 1645.7 | 1615.6 | **−1.8%** |

The saving is a flat ~30 instructions per packet — the eliminated per-packet demux work. It composes with the classifier change in the companion null-test PR for a combined ~−11% at the stand default and ~−9% at the production NIC burst.
