### PR TITLE
perf(filter): speed up net6 classifier compilation and lookup

### DIFF
--- a/lib/filter/compiler/helper.c
+++ b/lib/filter/compiler/helper.c
@@ -64,12 +64,14 @@ registry_pair_representatives(
 			struct value_range *o2 = &ranges2[other];
 			if (slot_hash[pos] == hash && o1->count == r1->count &&
 			    o2->count == r2->count &&
-			    memcmp(ADDR_OF(&o1->values),
-				   v1,
-				   r1->count * sizeof(uint32_t)) == 0 &&
-			    memcmp(ADDR_OF(&o2->values),
-				   v2,
-				   r2->count * sizeof(uint32_t)) == 0) {
+			    (r1->count == 0 ||
+			     memcmp(ADDR_OF(&o1->values),
+				    v1,
+				    r1->count * sizeof(uint32_t)) == 0) &&
+			    (r2->count == 0 ||
+			     memcmp(ADDR_OF(&o2->values),
+				    v2,
+				    r2->count * sizeof(uint32_t)) == 0)) {
 				found = other;
 				break;
 			}

--- a/lib/filter/compiler/helper.c
+++ b/lib/filter/compiler/helper.c
@@ -2,6 +2,95 @@
 #include "common/registry.h"
 #include "lib/filter/filter.h"
 
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// For each range, finds the earliest range built from the same value sets.
+//
+// Ranges built from identical value sets produce identical results, so later
+// passes can handle the first one and reuse it for the duplicates. The result
+// maps each range to its earliest match; a range that matches only itself is a
+// first occurrence. A null result means scratch memory ran out and every range
+// must be processed.
+static uint32_t *
+registry_pair_representatives(
+	struct value_registry *registry1, struct value_registry *registry2
+) {
+	uint64_t count = registry1->range_count;
+	uint32_t *rep = (uint32_t *)malloc(count * sizeof(uint32_t));
+	if (rep == NULL)
+		return NULL;
+
+	uint64_t need = (uint64_t)count * 2;
+	uint64_t cap = 8;
+	while (cap < need)
+		cap <<= 1;
+
+	uint32_t *slot = (uint32_t *)malloc(cap * sizeof(uint32_t));
+	uint64_t *slot_hash = (uint64_t *)malloc(cap * sizeof(uint64_t));
+	if (slot == NULL || slot_hash == NULL) {
+		free(rep);
+		free(slot);
+		free(slot_hash);
+		return NULL;
+	}
+	for (uint32_t idx = 0; idx < cap; ++idx)
+		slot[idx] = UINT32_MAX;
+
+	struct value_range *ranges1 = ADDR_OF(&registry1->ranges);
+	struct value_range *ranges2 = ADDR_OF(&registry2->ranges);
+
+	for (uint64_t idx = 0; idx < count; ++idx) {
+		struct value_range *r1 = &ranges1[idx];
+		struct value_range *r2 = &ranges2[idx];
+		uint32_t *v1 = ADDR_OF(&r1->values);
+		uint32_t *v2 = ADDR_OF(&r2->values);
+
+		uint64_t hash = 1469598103934665603ULL;
+		hash = (hash ^ r1->count) * 1099511628211ULL;
+		for (uint64_t k = 0; k < r1->count; ++k)
+			hash = (hash ^ v1[k]) * 1099511628211ULL;
+		hash = (hash ^ r2->count) * 1099511628211ULL;
+		for (uint64_t k = 0; k < r2->count; ++k)
+			hash = (hash ^ v2[k]) * 1099511628211ULL;
+
+		uint32_t pos = (uint32_t)(hash & (cap - 1));
+		uint32_t found = UINT32_MAX;
+		while (slot[pos] != UINT32_MAX) {
+			uint32_t other = slot[pos];
+			struct value_range *o1 = &ranges1[other];
+			struct value_range *o2 = &ranges2[other];
+			if (slot_hash[pos] == hash && o1->count == r1->count &&
+			    o2->count == r2->count &&
+			    memcmp(ADDR_OF(&o1->values),
+				   v1,
+				   r1->count * sizeof(uint32_t)) == 0 &&
+			    memcmp(ADDR_OF(&o2->values),
+				   v2,
+				   r2->count * sizeof(uint32_t)) == 0) {
+				found = other;
+				break;
+			}
+			pos = (pos + 1) & (cap - 1);
+		}
+
+		if (found != UINT32_MAX) {
+			rep[idx] = found;
+		} else {
+			slot[pos] = (uint32_t)idx;
+			slot_hash[pos] = hash;
+			rep[idx] = (uint32_t)idx;
+		}
+	}
+
+	free(slot);
+	free(slot_hash);
+
+	return rep;
+}
+
 int
 init_dummy_registry(
 	struct memory_context *memory_context,
@@ -73,8 +162,15 @@ merge_and_set_registry_values(
 	struct value_set_ctx set_ctx;
 	set_ctx.table = table;
 
+	// A repeated value set only revisits cells an earlier range already
+	// claimed with a smaller index, so it cannot change the result and is
+	// skipped.
+	uint32_t *rep = registry_pair_representatives(registry1, registry2);
+
 	for (uint32_t range_idx = 0; range_idx < registry1->range_count;
 	     ++range_idx) {
+		if (rep != NULL && rep[range_idx] != range_idx)
+			continue;
 		if (value_registry_join_range(
 			    registry1,
 			    registry2,
@@ -85,9 +181,12 @@ merge_and_set_registry_values(
 			goto error_join;
 	}
 
+	free(rep);
+
 	return 0;
 
 error_join:
+	free(rep);
 	value_table_free(table);
 
 	return -1;
@@ -114,7 +213,8 @@ merge_registry_values(
 	struct memory_context *memory_context,
 	struct value_registry *registry1,
 	struct value_registry *registry2,
-	struct value_table *table
+	struct value_table *table,
+	const uint32_t *rep
 ) {
 	if (value_table_init(
 		    table,
@@ -136,8 +236,12 @@ merge_registry_values(
 		goto error_remap_table;
 	}
 
+	// A repeated value set refines the same cells the same way, so only the
+	// first occurrence needs its own generation.
 	for (uint32_t range_idx = 0; range_idx < registry1->range_count;
 	     ++range_idx) {
+		if (rep != NULL && rep[range_idx] != range_idx)
+			continue;
 		remap_table_new_gen(&collect_ctx.remap_table);
 		value_registry_join_range(
 			registry1,
@@ -184,7 +288,8 @@ collect_registry_values(
 	struct value_registry *registry1,
 	struct value_registry *registry2,
 	struct value_table *table,
-	struct value_registry *registry
+	struct value_registry *registry,
+	const uint32_t *rep
 ) {
 	if (value_registry_init(registry, memory_context)) {
 		return -1;
@@ -196,7 +301,25 @@ collect_registry_values(
 
 	for (uint32_t range_idx = 0; range_idx < registry1->range_count;
 	     ++range_idx) {
-		value_registry_start(registry);
+		if (value_registry_start(registry))
+			return -1;
+
+		// A repeated value set collects the same values, so copy the
+		// first occurrence's result instead of walking the join again.
+		if (rep != NULL && rep[range_idx] != range_idx) {
+			struct value_range *src =
+				ADDR_OF(&registry->ranges) + rep[range_idx];
+			uint32_t *src_values = ADDR_OF(&src->values);
+			uint64_t src_count = src->count;
+			for (uint64_t k = 0; k < src_count; ++k) {
+				if (value_registry_collect(
+					    registry, src_values[k]
+				    ))
+					return -1;
+			}
+			continue;
+		}
+
 		value_registry_join_range(
 			registry1,
 			registry2,
@@ -217,18 +340,24 @@ merge_and_collect_registry(
 	struct value_table *table,
 	struct value_registry *registry
 ) {
+	uint32_t *rep = registry_pair_representatives(registry1, registry2);
+
 	if (merge_registry_values(
-		    memory_context, registry1, registry2, table
+		    memory_context, registry1, registry2, table, rep
 	    )) {
+		free(rep);
 		return -1;
 	}
 
 	if (collect_registry_values(
-		    memory_context, registry1, registry2, table, registry
+		    memory_context, registry1, registry2, table, registry, rep
 	    )) {
+		free(rep);
 		value_table_free(table);
 		return -1;
 	}
+
+	free(rep);
 
 	return 0;
 }

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -207,7 +207,8 @@ net6_first_occurrence_mask(
 					actions[slot[pos]], &other, &other_count
 				);
 				if (other_count == net_count &&
-				    memcmp(nets, other, byte_count) == 0) {
+				    (net_count == 0 ||
+				     memcmp(nets, other, byte_count) == 0)) {
 					duplicate = true;
 					break;
 				}

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -9,6 +9,10 @@
 
 #include "declare.h"
 
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef void (*action_get_net6_func)(
@@ -139,6 +143,92 @@ error:
 	return -1;
 }
 
+// Marks each action that is the first to use its network set.
+//
+// Actions that repeat an earlier action's network set refine the value table
+// the same way, so only the first one needs a generation. A null result means
+// scratch memory ran out and every action must be processed.
+static bool *
+net6_first_occurrence_mask(
+	const struct filter_rule **actions,
+	uint32_t count,
+	action_get_net6_func get_net6
+) {
+	bool *first = (bool *)malloc(count * sizeof(bool));
+	if (first == NULL)
+		return NULL;
+
+	// Size the scratch table to keep the load factor at one half. Fall back
+	// to processing every action if the count is too large to size for.
+	uint64_t need = (uint64_t)count * 2;
+	if (need > ((uint64_t)1 << 31)) {
+		free(first);
+		return NULL;
+	}
+	uint32_t cap = 8;
+	while (cap < need)
+		cap <<= 1;
+
+	uint32_t *slot = (uint32_t *)malloc(cap * sizeof(uint32_t));
+	uint64_t *slot_hash = (uint64_t *)malloc(cap * sizeof(uint64_t));
+	if (slot == NULL || slot_hash == NULL) {
+		free(first);
+		free(slot);
+		free(slot_hash);
+		return NULL;
+	}
+	for (uint32_t idx = 0; idx < cap; ++idx)
+		slot[idx] = UINT32_MAX;
+
+	for (uint32_t idx = 0; idx < count; ++idx) {
+		first[idx] = false;
+		if (actions[idx] == NULL)
+			continue;
+
+		struct net6 *nets;
+		uint32_t net_count;
+		get_net6(actions[idx], &nets, &net_count);
+
+		uint32_t byte_count = net_count * (uint32_t)sizeof(struct net6);
+		uint64_t hash = 1469598103934665603ULL;
+		const uint8_t *bytes = (const uint8_t *)nets;
+		for (uint32_t b = 0; b < byte_count; ++b) {
+			hash ^= bytes[b];
+			hash *= 1099511628211ULL;
+		}
+
+		uint32_t pos = (uint32_t)(hash & (cap - 1));
+		bool duplicate = false;
+		while (slot[pos] != UINT32_MAX) {
+			if (slot_hash[pos] == hash) {
+				struct net6 *other;
+				uint32_t other_count;
+				get_net6(
+					actions[slot[pos]], &other, &other_count
+				);
+				if (other_count == net_count &&
+				    memcmp(nets, other, byte_count) == 0) {
+					duplicate = true;
+					break;
+				}
+			}
+			pos = (pos + 1) & (cap - 1);
+		}
+
+		if (duplicate)
+			continue;
+
+		slot[pos] = idx;
+		slot_hash[pos] = hash;
+		first[idx] = true;
+	}
+
+	free(slot);
+	free(slot_hash);
+
+	return first;
+}
+
 static inline int
 merge_net6_range(
 	struct memory_context *memory_context,
@@ -168,6 +258,10 @@ merge_net6_range(
 		goto error_remap_table;
 	}
 
+	// Actions that share a network set refine the table the same way, so
+	// the loop below runs a generation only for the first of each set.
+	bool *first_set = net6_first_occurrence_mask(actions, count, get_net6);
+
 	uint32_t net_cnt = 0;
 
 	struct radix rdx;
@@ -178,6 +272,8 @@ merge_net6_range(
 	     ++action_ptr) {
 
 		if (*action_ptr == NULL)
+			continue;
+		if (first_set != NULL && !first_set[action_ptr - actions])
 			continue;
 		const struct filter_rule *action = *action_ptr;
 
@@ -258,6 +354,13 @@ merge_net6_range(
 			}
 		}
 	}
+
+	free(first_set);
+
+	// Pack the combined values into a dense range before building the
+	// registry, so the value tables stacked on top stay small.
+	remap_table_compact(&remap_table);
+	value_table_compact(table, &remap_table);
 	remap_table_free(&remap_table);
 
 	uint32_t *values_hi = ADDR_OF(&ri_hi->values);
@@ -383,6 +486,7 @@ error_late:
 	return -1;
 
 error_touch:
+	free(first_set);
 	radix_free(&rdx);
 	remap_table_free(&remap_table);
 

--- a/lib/filter/query/net6.h
+++ b/lib/filter/query/net6.h
@@ -30,22 +30,9 @@ FILTER_ATTR_QUERY_FUNC(net6_dst)(
 			packets[idx]->network_header.offset
 		);
 
-		hi_values[idx] = lpm8_lookup(
-			&c->hi, (const uint8_t *)ipv6_hdr->dst_addr
-		);
-	}
-
-	for (uint32_t idx = 0; idx < count; ++idx) {
-		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
-		struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
-			mbuf,
-			struct rte_ipv6_hdr *,
-			packets[idx]->network_header.offset
-		);
-
-		lo_values[idx] = lpm8_lookup(
-			&c->lo, (const uint8_t *)ipv6_hdr->dst_addr + 8
-		);
+		const uint8_t *addr = (const uint8_t *)ipv6_hdr->dst_addr;
+		hi_values[idx] = lpm8_lookup(&c->hi, addr);
+		lo_values[idx] = lpm8_lookup(&c->lo, addr + 8);
 	}
 
 	for (uint32_t idx = 0; idx < count; ++idx) {
@@ -75,22 +62,9 @@ FILTER_ATTR_QUERY_FUNC(net6_src)(
 			packets[idx]->network_header.offset
 		);
 
-		hi_values[idx] = lpm8_lookup(
-			&c->hi, (const uint8_t *)ipv6_hdr->src_addr
-		);
-	}
-
-	for (uint32_t idx = 0; idx < count; ++idx) {
-		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
-		struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
-			mbuf,
-			struct rte_ipv6_hdr *,
-			packets[idx]->network_header.offset
-		);
-
-		lo_values[idx] = lpm8_lookup(
-			&c->lo, (const uint8_t *)ipv6_hdr->src_addr + 8
-		);
+		const uint8_t *addr = (const uint8_t *)ipv6_hdr->src_addr;
+		hi_values[idx] = lpm8_lookup(&c->hi, addr);
+		lo_values[idx] = lpm8_lookup(&c->lo, addr + 8);
 	}
 
 	for (uint32_t idx = 0; idx < count; ++idx) {


### PR DESCRIPTION
Three small optimizations for the net6 (IPv6) filter and the shared compiler
helper it builds on. Classification results are unchanged.

- net6: skip repeated networks. When several rules use the same set of networks, the combined value table is built once and reused for the rest, instead of redoing the same work for every rule.
- helper: skip repeated value pairs. The shared merge step (also used by other attribute combinations) now spots repeated value sets and processes each one only once.
- net6 compact: after the combined table is built, its values are packed into a dense range, so the value tables built on top of it stay smaller.

The net6 query path also reads each packet's address once and does both lookups in a single pass, instead of reading the header twice.

Result: filter compilation is faster on rulesets where many rules share the same networks, memory use is a little lower, and the dataplane does slightly less work per packet.