### PR TITLE
feat(device): implement device service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3199,6 +3199,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "yanet-cli-device-list"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "colored",
+ "tokio",
+ "tonic",
+ "yanet-cli",
+ "yanet-ynpb",
+]
+
+[[package]]
 name = "yanet-cli-device-plain"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "cli/modules/gateway",
     "cli/modules/ready",
     "cli/modules/metrics",
+    "cli/modules/device",
     "modules/acl/cli",
     "modules/fwstate/cli",
     "modules/decap/cli",

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ RELEASE_DIR := $(TARGET_DIR)/release
 # Core CLI packages/binaries that live in cli workspace.
 CLI_CORE_MODULES := \
 	common \
+	device-list \
 	inspect \
 	pipeline \
 	function \

--- a/api/info.h
+++ b/api/info.h
@@ -153,6 +153,7 @@ struct cp_device_pipeline_info {
 struct cp_device_info {
 	char type[CP_DEVICE_TYPE_LEN];
 	char name[CP_DEVICE_NAME_LEN];
+	uint64_t index;
 	uint64_t input_count;
 	uint64_t output_count;
 

--- a/cli/modules/device/Cargo.toml
+++ b/cli/modules/device/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "yanet-cli-device-list"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+rust-version = "1.84"
+
+[dependencies]
+ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
+ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
+clap = { version = "4.5", features = ["derive"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
+tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
+tonic = { version = "0.13", features = ["gzip"] }
+colored = "3"

--- a/cli/modules/device/src/main.rs
+++ b/cli/modules/device/src/main.rs
@@ -1,0 +1,100 @@
+//! CLI for YANET "device list" command.
+//!
+//! Lists all configured devices with their registry indices, allowing
+//! consumers to resolve numeric device_id values (e.g. from pdump
+//! RecordMeta.rx_device_id) to human-readable names.
+
+use clap::{ArgAction, CommandFactory, Parser};
+use clap_complete::CompleteEnv;
+use colored::Colorize;
+use tonic::codec::CompressionEncoding;
+use ync::{
+    client::{ConnectionArgs, LayeredChannel},
+    errors::Error,
+    output::{self, CommonFormat},
+};
+use ynpb::pb::{device_service_client::DeviceServiceClient, ListDevicesRequest, ListDevicesResponse};
+
+const DEVICE_SERVICE: &str = "controlplane.ynpb.v1.DeviceService";
+
+/// Device list module - displays all configured devices with their registry
+/// indices.
+#[derive(Debug, Clone, Parser)]
+#[command(version, about)]
+#[command(flatten_help = true)]
+pub struct Cmd {
+    #[command(flatten)]
+    pub connection: ConnectionArgs,
+    /// Output format.
+    #[arg(long, value_enum, default_value = "human", global = true)]
+    pub format: CommonFormat,
+    /// Be verbose in terms of logging.
+    #[clap(short, action = ArgAction::Count, global = true)]
+    pub verbose: u8,
+}
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() {
+    CompleteEnv::with_factory(Cmd::command).complete();
+
+    let cmd = Cmd::parse();
+    ync::init(cmd.verbose, cmd.format);
+
+    if let Err(err) = run(cmd).await {
+        output::failure(&err);
+        std::process::exit(err.exit_code());
+    }
+}
+
+async fn run(cmd: Cmd) -> Result<(), Error> {
+    let mut service = DeviceService::new(&cmd.connection).await?;
+    let response = service.list().await?;
+
+    output::data(&response, false, format_args!(""), || render(&response));
+
+    Ok(())
+}
+
+pub struct DeviceService {
+    client: DeviceServiceClient<LayeredChannel>,
+    endpoint: String,
+}
+
+impl DeviceService {
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
+        let channel = ync::client::connect(connection)
+            .await
+            .map_err(|err| Error::from_connection(err, "device-list", connection.endpoint.clone()))?;
+        let client = DeviceServiceClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip);
+
+        Ok(Self {
+            client,
+            endpoint: connection.endpoint.clone(),
+        })
+    }
+
+    pub async fn list(&mut self) -> Result<ListDevicesResponse, Error> {
+        let response = self
+            .client
+            .list(ListDevicesRequest {})
+            .await
+            .map_err(|status| Error::from_status(status, "device-list", self.endpoint.clone(), DEVICE_SERVICE))?
+            .into_inner();
+
+        Ok(response)
+    }
+}
+
+fn render(response: &ListDevicesResponse) {
+    if response.ids.is_empty() {
+        println!("{}", "No devices configured".yellow());
+        return;
+    }
+
+    println!("{:<8} {:<12} {}", "INDEX".bold(), "TYPE".bold(), "NAME".bold());
+    for device in &response.ids {
+        println!("{:<8} {:<12} {}", device.index, device.r#type, device.name);
+    }
+}

--- a/common/rust/ynpb/build.rs
+++ b/common/rust/ynpb/build.rs
@@ -16,6 +16,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         .compile_protos(
             &[
                 "controlplane/ynpb/v1/logging.proto",
+                "controlplane/ynpb/v1/device.proto",
                 "controlplane/ynpb/v1/function.proto",
                 "controlplane/ynpb/v1/pipeline.proto",
                 "controlplane/ynpb/v1/inspect.proto",

--- a/controlplane/builtin/device.go
+++ b/controlplane/builtin/device.go
@@ -1,0 +1,60 @@
+package builtin
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// Device is an in-process gRPC service for listing dataplane devices.
+type Device struct {
+	ynpb.UnimplementedDeviceServiceServer
+
+	instanceID uint32
+	shm        *ffi.SharedMemory
+}
+
+// NewDevice creates a new Device service.
+func NewDevice(instanceID uint32, shm *ffi.SharedMemory) *Device {
+	return &Device{
+		instanceID: instanceID,
+		shm:        shm,
+	}
+}
+
+// Name returns the service name.
+func (m *Device) Name() string { return "device" }
+
+// Endpoint returns empty string indicating in-process service.
+func (m *Device) Endpoint() string { return "" }
+
+// ServicesNames returns the gRPC service names served by this service.
+func (m *Device) ServicesNames() []string { return []string{"controlplane.ynpb.v1.DeviceService"} }
+
+// RegisterService registers the service on the given gRPC server.
+func (m *Device) RegisterService(server *grpc.Server) {
+	ynpb.RegisterDeviceServiceServer(server, m)
+}
+
+// List returns all configured devices with their registry indices.
+func (m *Device) List(
+	ctx context.Context,
+	request *ynpb.ListDevicesRequest,
+) (*ynpb.ListDevicesResponse, error) {
+	dpConfig := m.shm.DPConfig(m.instanceID)
+	devices := dpConfig.Devices()
+
+	ids := make([]*ynpb.DeviceId, len(devices))
+	for idx, device := range devices {
+		ids[idx] = &ynpb.DeviceId{
+			Type:  device.Type,
+			Name:  device.Name,
+			Index: device.Index,
+		}
+	}
+
+	return &ynpb.ListDevicesResponse{Ids: ids}, nil
+}

--- a/controlplane/builtin/inspect.go
+++ b/controlplane/builtin/inspect.go
@@ -182,6 +182,7 @@ func (m *Inspect) devices(dpConfig *ffi.DPConfig) []*ynpb.DeviceInfo {
 		deviceInfo := &ynpb.DeviceInfo{
 			Type:            device.Type,
 			Name:            device.Name,
+			Index:           device.Index,
 			InputPipelines:  make([]*ynpb.DevicePipelineInfo, len(device.InputPipelines)),
 			OutputPipelines: make([]*ynpb.DevicePipelineInfo, len(device.OutputPipelines)),
 		}

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -358,6 +358,7 @@ type DevicePipelineInfo struct {
 type DeviceInfo struct {
 	Type            string
 	Name            string
+	Index           uint32
 	InputPipelines  []DevicePipelineInfo
 	OutputPipelines []DevicePipelineInfo
 }
@@ -412,6 +413,7 @@ func (m *DPConfig) Devices() []DeviceInfo {
 		out[idx] = DeviceInfo{
 			Type:            C.GoString(&deviceInfo._type[0]),
 			Name:            C.GoString(&deviceInfo.name[0]),
+			Index:           uint32(deviceInfo.index),
 			InputPipelines:  inputPipelines,
 			OutputPipelines: outputPipelines,
 		}

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -127,6 +127,9 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 		gateway.WithBuiltinService(
 			builtin.NewCounters(cfg.Gateway.InstanceID, shm),
 		),
+		gateway.WithBuiltinService(
+			builtin.NewDevice(cfg.Gateway.InstanceID, shm),
+		),
 		gateway.WithLog(log),
 		gateway.WithAtomicLogLevel(opts.LogLevel),
 	}

--- a/controlplane/ynpb/v1/device.proto
+++ b/controlplane/ynpb/v1/device.proto
@@ -4,9 +4,10 @@ package controlplane.ynpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
 
-// TODO: docs
+// DeviceService provides information about network devices configured
+// in the dataplane.
 service DeviceService {
-  // Lists all configured devices
+  // List returns all configured devices.
   rpc List(ListDevicesRequest) returns (ListDevicesResponse);
 }
 
@@ -17,4 +18,6 @@ message ListDevicesResponse { repeated DeviceId ids = 1; }
 message DeviceId {
   string type = 1;
   string name = 2;
+  // Device registry index.
+  uint32 index = 3;
 }

--- a/controlplane/ynpb/v1/inspect.proto
+++ b/controlplane/ynpb/v1/inspect.proto
@@ -224,6 +224,8 @@ message DeviceInfo {
   repeated DevicePipelineInfo input_pipelines = 3;
   // Pipelines which are executed on outgoing traffic from this device.
   repeated DevicePipelineInfo output_pipelines = 4;
+  // Device registry index.
+  uint32 index = 5;
 }
 message DevicePipelineInfo {
   // Name of the pipeline associated with this device.

--- a/debian/yanet2-cli.install
+++ b/debian/yanet2-cli.install
@@ -16,6 +16,7 @@ usr/bin/yanet-cli-gateway
 usr/bin/yanet-cli-ready
 usr/bin/yanet-cli-metrics
 usr/bin/yanet-cli-counters
+usr/bin/yanet-cli-device-list
 usr/bin/yanet-cli-device-plain
 usr/bin/yanet-cli-device-vlan
 usr/bin/yanet-cli-device-trafgen

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1099,7 +1099,7 @@ cp_device_list_info_free(struct cp_device_list_info *device_list_info) {
 }
 
 static struct cp_device_info *
-yanet_build_device_info(struct cp_device *device) {
+yanet_build_device_info(struct cp_device *device, uint64_t index) {
 	struct cp_device_entry *input = ADDR_OF(&device->input_pipelines);
 	struct cp_device_entry *output = ADDR_OF(&device->output_pipelines);
 
@@ -1114,6 +1114,7 @@ yanet_build_device_info(struct cp_device *device) {
 
 	strtcpy(device_info->type, device->type, CP_DEVICE_TYPE_LEN);
 	strtcpy(device_info->name, device->name, CP_DEVICE_NAME_LEN);
+	device_info->index = index;
 
 	device_info->input_count = input->pipeline_count;
 	device_info->output_count = output->pipeline_count;
@@ -1169,7 +1170,7 @@ yanet_get_cp_device_list_info(struct dp_config *dp_config) {
 			continue;
 		}
 		struct cp_device_info *device_info =
-			yanet_build_device_info(cp_device);
+			yanet_build_device_info(cp_device, idx);
 		if (device_info == NULL) {
 			cp_device_list_info_free(device_list_info);
 			device_list_info = NULL;


### PR DESCRIPTION
Implement the previously stub DeviceService gRPC service that provides a lightweight endpoint for resolving numeric device registry indices to human-readable device names.