### PR TITLE
Fix net6 compilation

### DIFF
--- a/common/registry.h
+++ b/common/registry.h
@@ -240,27 +240,39 @@ value_registry_start(struct value_registry *registry) {
 }
 
 static inline int
+value_range_append(
+	struct memory_context *memory_context,
+	struct value_range *value_range,
+	uint32_t value
+) {
+	uint32_t *values = ADDR_OF(&value_range->values);
+
+	if (mem_array_expand_exp(
+		    memory_context,
+		    (void **)&values,
+		    sizeof(*values),
+		    &value_range->count
+	    )) {
+		return -1;
+	}
+
+	values[value_range->count - 1] = value;
+
+	SET_OFFSET_OF(&value_range->values, values);
+
+	return 0;
+}
+
+static inline int
 value_registry_collect(struct value_registry *registry, uint32_t value) {
 	if (value_collector_collect(&registry->collector, value) == 1) {
 		struct value_range *range =
 			ADDR_OF(&registry->ranges) + registry->range_count - 1;
-		uint32_t *values = ADDR_OF(&range->values);
-
-		if (mem_array_expand_exp(
-			    registry->memory_context,
-			    (void **)&values,
-			    sizeof(*values),
-			    &range->count
-		    )) {
+		if (value_range_append(registry->memory_context, range, value))
 			return -1;
-		}
-
-		values[range->count - 1] = value;
 
 		if (value > registry->max_value)
 			registry->max_value = value;
-
-		SET_OFFSET_OF(&range->values, values);
 	}
 
 	return 0;

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -139,6 +139,368 @@ error:
 	return -1;
 }
 
+/*
+ * Resolve range index boundaries for 64-bit address and mask
+ */
+static inline void
+net6_part_range_index_bound(
+	const struct range_index *range_index,
+	const uint8_t *addr,
+	const uint8_t *mask,
+	uint32_t *start,
+	uint32_t *stop
+) {
+	uint8_t next[8];
+	*(uint64_t *)next = *(uint64_t *)addr | ~*(uint64_t *)mask;
+	filter_key_inc(8, next);
+	*start = radix_lookup(&range_index->radix, 8, addr);
+	*stop = range_index->count;
+	if (*(uint64_t *)next != 0)
+		*stop = radix_lookup(&range_index->radix, 8, next);
+}
+
+/*
+ * Resolve hi and lo network partitions range index boundaries
+ */
+static inline void
+net6_range_index_bounds(
+	const struct range_index *range_index_hi,
+	const struct range_index *range_index_lo,
+	struct net6 *net6,
+	uint32_t *start_hi,
+	uint32_t *stop_hi,
+	uint32_t *start_lo,
+	uint32_t *stop_lo
+) {
+	uint8_t *from;
+	uint8_t *mask;
+	net6_get_hi_part(net6, &from, &mask);
+	net6_part_range_index_bound(
+		range_index_hi, from, mask, start_hi, stop_hi
+	);
+	net6_get_lo_part(net6, &from, &mask);
+	net6_part_range_index_bound(
+		range_index_lo, from, mask, start_lo, stop_lo
+	);
+}
+
+/*
+ * Touch each network group set.
+ * Networks are distributed by groups where any network in a group has
+ * exact the same set of rules the network contains in. The routine makes
+ * new remap_table generation for each group and then touches all subitems
+ * of networks containing in the group.
+ */
+static inline int
+touch_network_ranges(
+	struct memory_context *memory_context,
+	struct net6 *all_nets,
+	struct value_range *net_ranges,
+	uint32_t net_range_count,
+	const struct range_index *ri_hi,
+	const struct range_index *ri_lo,
+	struct value_table *value_table
+) {
+
+	struct remap_table remap_table;
+	if (remap_table_init(
+		    &remap_table,
+		    memory_context,
+		    (ri_hi->max_value + 1) * (ri_lo->max_value + 1)
+	    )) {
+		return -1;
+	}
+
+	uint32_t *values_hi = ADDR_OF(&ri_hi->values);
+	uint32_t *values_lo = ADDR_OF(&ri_lo->values);
+
+	for (uint32_t net_range_idx = 0; net_range_idx < net_range_count;
+	     ++net_range_idx) {
+		remap_table_new_gen(&remap_table);
+
+		uint32_t *values = ADDR_OF(&net_ranges[net_range_idx].values);
+		for (uint32_t idx = 0; idx < net_ranges[net_range_idx].count;
+		     ++idx) {
+			struct net6 net6 = all_nets[values[idx]];
+
+			// Skip `any` network
+			if (*(uint64_t *)net6.mask == 0 &&
+			    *(uint64_t *)(net6.mask + 8) == 0)
+				continue;
+
+			uint32_t start_hi;
+			uint32_t stop_hi;
+			uint32_t start_lo;
+			uint32_t stop_lo;
+
+			net6_range_index_bounds(
+				ri_hi,
+				ri_lo,
+				&net6,
+				&start_hi,
+				&stop_hi,
+				&start_lo,
+				&stop_lo
+			);
+
+			for (uint32_t idx_hi = start_hi; idx_hi < stop_hi;
+			     ++idx_hi) {
+				for (uint32_t idx_lo = start_lo;
+				     idx_lo < stop_lo;
+				     ++idx_lo) {
+					uint32_t *value = value_table_get_ptr(
+						value_table,
+						values_hi[idx_hi],
+						values_lo[idx_lo]
+					);
+					if (remap_table_touch(
+						    &remap_table, *value, value
+					    ) < 0) {
+						goto error;
+					}
+				}
+			}
+		}
+	}
+
+	remap_table_compact(&remap_table);
+	value_table_compact(value_table, &remap_table);
+	remap_table_free(&remap_table);
+
+	return 0;
+
+error:
+	remap_table_free(&remap_table);
+	return -1;
+}
+
+static inline int
+collect_network_values(
+	struct net6 *all_nets,
+	uint32_t all_net_count,
+	const struct range_index *ri_hi,
+	const struct range_index *ri_lo,
+	struct value_table *value_table,
+	struct value_registry *registry
+) {
+	uint32_t *values_hi = ADDR_OF(&ri_hi->values);
+	uint32_t *values_lo = ADDR_OF(&ri_lo->values);
+
+	for (uint32_t net_idx = 0; net_idx < all_net_count; ++net_idx) {
+		struct net6 net6 = all_nets[net_idx];
+
+		value_registry_start(registry);
+
+		uint32_t start_hi;
+		uint32_t stop_hi;
+		uint32_t start_lo;
+		uint32_t stop_lo;
+
+		net6_range_index_bounds(
+			ri_hi,
+			ri_lo,
+			&net6,
+			&start_hi,
+			&stop_hi,
+			&start_lo,
+			&stop_lo
+		);
+
+		for (uint32_t idx_hi = start_hi; idx_hi < stop_hi; ++idx_hi) {
+			for (uint32_t idx_lo = start_lo; idx_lo < stop_lo;
+			     ++idx_lo) {
+				if (value_registry_collect(
+					    registry,
+					    value_table_get(
+						    value_table,
+						    values_hi[idx_hi],
+						    values_lo[idx_lo]
+					    )
+				    )) {
+					return -1;
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
+/*
+ * Collect all networks in a radix and distribute them into groups where
+ * each groups contains networks with the same set of rules the networks
+ * contains in.
+ */
+static inline int
+build_net6_info(
+	struct memory_context *memory_context,
+	const struct filter_rule **actions,
+	uint32_t action_count,
+	action_get_net6_func get_net6,
+
+	struct radix *net_radix,
+
+	struct net6 **nets,
+	uint64_t *net_count,
+
+	struct value_range **net_ranges,
+	uint32_t *net_range_count
+) {
+	*nets = NULL;
+	*net_count = 0;
+
+	*net_ranges = NULL;
+	*net_range_count = 0;
+
+	radix_init(net_radix, memory_context);
+
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + action_count;
+	     ++action_ptr) {
+
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
+
+		struct net6 *rule_nets;
+		uint32_t rule_net_count;
+		get_net6(action, &rule_nets, &rule_net_count);
+
+		for (struct net6 *rule_net = rule_nets;
+		     rule_net < rule_nets + rule_net_count;
+		     ++rule_net) {
+			struct net6 net6;
+			net6_normalize(rule_net, &net6);
+
+			if (radix_lookup(net_radix, 32, net6.addr) !=
+			    RADIX_VALUE_INVALID)
+				continue;
+
+			radix_insert(net_radix, 32, net6.addr, *net_count);
+			if (mem_array_expand_exp(
+				    memory_context,
+				    (void **)nets,
+				    sizeof(**nets),
+				    net_count
+			    )) {
+				goto error_nets;
+			}
+			(*nets)[*net_count - 1] = net6;
+		}
+	}
+
+	if (*net_count == 0) {
+		return 0;
+	}
+
+	struct value_table net_table;
+	if (value_table_init(&net_table, memory_context, 1, *net_count)) {
+		goto error_nets;
+	}
+
+	struct remap_table net_remap;
+	if (remap_table_init(&net_remap, memory_context, *net_count)) {
+		goto error_table;
+	}
+
+	for (const struct filter_rule **action_ptr = actions;
+	     action_ptr < actions + action_count;
+	     ++action_ptr) {
+
+		if (*action_ptr == NULL)
+			continue;
+		const struct filter_rule *action = *action_ptr;
+
+		remap_table_new_gen(&net_remap);
+
+		struct net6 *rule_nets;
+		uint32_t rule_net_count;
+		get_net6(action, &rule_nets, &rule_net_count);
+
+		for (struct net6 *rule_net = rule_nets;
+		     rule_net < rule_nets + rule_net_count;
+		     ++rule_net) {
+			struct net6 net6;
+			net6_normalize(rule_net, &net6);
+
+			uint32_t net_idx =
+				radix_lookup(net_radix, 32, net6.addr);
+			uint32_t *v =
+				value_table_get_ptr(&net_table, 0, net_idx);
+			if (remap_table_touch(&net_remap, *v, v) < 0) {
+				goto error_touch;
+			}
+		}
+	}
+
+	remap_table_compact(&net_remap);
+	value_table_compact(&net_table, &net_remap);
+	remap_table_free(&net_remap);
+
+	for (uint32_t idx = 0; idx < *net_count; ++idx)
+		if (value_table_get(&net_table, 0, idx) >= *net_range_count)
+			*net_range_count =
+				value_table_get(&net_table, 0, idx) + 1;
+	*net_ranges = (struct value_range *)memory_balloc(
+		memory_context, sizeof(struct value_range) * *net_range_count
+	);
+	if (*net_ranges == NULL)
+		goto error_table;
+
+	memset(*net_ranges, 0, sizeof(struct value_range) * *net_range_count);
+	for (uint32_t net_idx = 0; net_idx < *net_count; ++net_idx) {
+		if (value_range_append(
+			    memory_context,
+			    *net_ranges +
+				    value_table_get(&net_table, 0, net_idx),
+			    net_idx
+		    )) {
+			goto error_append;
+		}
+	}
+
+	value_table_free(&net_table);
+
+	return 0;
+
+error_append:
+	for (uint32_t idx = 0; idx < *net_range_count; ++idx) {
+		struct value_range *range = *net_ranges + idx;
+		mem_array_free_exp(
+			memory_context,
+			ADDR_OF(&range->values),
+			sizeof(uint32_t),
+			range->count
+		);
+	}
+
+	memory_bfree(
+		memory_context,
+		*net_ranges,
+		sizeof(struct value_range) * *net_range_count
+	);
+
+	*net_ranges = NULL;
+	*net_range_count = 0;
+
+	goto error_table;
+
+error_touch:
+	remap_table_free(&net_remap);
+
+error_table:
+	value_table_free(&net_table);
+
+error_nets:
+	mem_array_free_exp(memory_context, *nets, sizeof(**nets), *net_count);
+	*nets = NULL;
+	*net_count = 0;
+
+	radix_free(net_radix);
+
+	return -1;
+}
+
 static inline int
 merge_net6_range(
 	struct memory_context *memory_context,
@@ -150,189 +512,55 @@ merge_net6_range(
 	struct value_table *table,
 	struct value_registry *registry
 ) {
+	struct net6 *nets;
+	uint64_t net_cnt = 0;
+	struct radix net_radix;
+
+	struct value_range *net_ranges;
+	uint32_t net_range_count = 0;
+
+	if (build_net6_info(
+		    memory_context,
+		    actions,
+		    count,
+		    get_net6,
+		    &net_radix,
+		    &nets,
+		    &net_cnt,
+		    &net_ranges,
+		    &net_range_count
+	    )) {
+		return -1;
+	}
+
 	if (value_table_init(
 		    table,
 		    memory_context,
 		    ri_hi->max_value + 1,
 		    ri_lo->max_value + 1
 	    )) {
-		return -1;
+		goto error_info;
 	}
 
-	struct remap_table remap_table;
-	if (remap_table_init(
-		    &remap_table,
+	if (touch_network_ranges(
 		    memory_context,
-		    (ri_hi->max_value + 1) * (ri_lo->max_value + 1)
+		    nets,
+		    net_ranges,
+		    net_range_count,
+		    ri_hi,
+		    ri_lo,
+		    table
 	    )) {
-		goto error_remap_table;
+		goto error_table;
 	}
-
-	uint32_t net_cnt = 0;
-
-	struct radix rdx;
-	radix_init(&rdx, memory_context);
-
-	for (const struct filter_rule **action_ptr = actions;
-	     action_ptr < actions + count;
-	     ++action_ptr) {
-
-		if (*action_ptr == NULL)
-			continue;
-		const struct filter_rule *action = *action_ptr;
-
-		remap_table_new_gen(&remap_table);
-
-		uint32_t *values_hi = ADDR_OF(&ri_hi->values);
-		uint32_t *values_lo = ADDR_OF(&ri_lo->values);
-
-		struct net6 *nets;
-		uint32_t net_count;
-		get_net6(action, &nets, &net_count);
-
-		for (struct net6 *rule_net = nets; rule_net < nets + net_count;
-		     ++rule_net) {
-			struct net6 net6;
-			net6_normalize(rule_net, &net6);
-
-			if (radix_lookup(&rdx, 32, net6.addr) !=
-			    RADIX_VALUE_INVALID)
-				continue;
-
-			radix_insert(&rdx, 32, net6.addr, net_cnt++);
-
-			uint8_t *from_hi;
-			uint8_t *mask_hi;
-			net6_get_hi_part(&net6, &from_hi, &mask_hi);
-			uint8_t to_hi[8];
-			*(uint64_t *)to_hi =
-				*(uint64_t *)from_hi | ~*(uint64_t *)mask_hi;
-			filter_key_inc(8, to_hi);
-			uint32_t start_hi =
-				radix_lookup(&ri_hi->radix, 8, from_hi);
-			uint32_t stop_hi = ri_hi->count;
-			if (*(uint64_t *)to_hi != 0)
-				stop_hi = radix_lookup(&ri_hi->radix, 8, to_hi);
-
-			uint8_t *from_lo;
-			uint8_t *mask_lo;
-			net6_get_lo_part(&net6, &from_lo, &mask_lo);
-			uint8_t to_lo[8];
-			*(uint64_t *)to_lo =
-				*(uint64_t *)from_lo | ~*(uint64_t *)mask_lo;
-			filter_key_inc(8, to_lo);
-			uint32_t start_lo =
-				radix_lookup(&ri_lo->radix, 8, from_lo);
-			uint32_t stop_lo = ri_lo->count;
-			if (*(uint64_t *)to_lo != 0)
-				stop_lo = radix_lookup(&ri_lo->radix, 8, to_lo);
-
-			if (!(*(uint64_t *)from_hi == 0 &&
-			      *(uint64_t *)to_hi == 0 &&
-			      *(uint64_t *)from_lo == 0 &&
-			      *(uint64_t *)to_lo == 0)) {
-
-				for (uint32_t idx_hi = start_hi;
-				     idx_hi < stop_hi;
-				     ++idx_hi) {
-					for (uint32_t idx_lo = start_lo;
-					     idx_lo < stop_lo;
-					     ++idx_lo) {
-						uint32_t *value =
-							value_table_get_ptr(
-								table,
-								values_hi
-									[idx_hi],
-								values_lo
-									[idx_lo]
-							);
-						if (remap_table_touch(
-							    &remap_table,
-							    *value,
-							    value
-						    ) < 0) {
-							goto error_touch;
-						}
-					}
-				}
-			}
-		}
-	}
-	remap_table_free(&remap_table);
-
-	uint32_t *values_hi = ADDR_OF(&ri_hi->values);
-	uint32_t *values_lo = ADDR_OF(&ri_lo->values);
 
 	struct value_registry net_registry;
 	value_registry_init(&net_registry, memory_context);
 
-	for (const struct filter_rule **action_ptr = actions;
-	     action_ptr < actions + count;
-	     ++action_ptr) {
-
-		if (*action_ptr == NULL)
-			continue;
-		const struct filter_rule *action = *action_ptr;
-
-		struct net6 *nets;
-		uint32_t net_count;
-		get_net6(action, &nets, &net_count);
-
-		for (struct net6 *rule_net = nets; rule_net < nets + net_count;
-		     ++rule_net) {
-			struct net6 net6;
-			net6_normalize(rule_net, &net6);
-
-			uint32_t net_idx = radix_lookup(&rdx, 32, net6.addr);
-			if (net_idx < net_registry.range_count)
-				continue;
-
-			value_registry_start(&net_registry);
-
-			uint8_t *from_hi;
-			uint8_t *mask_hi;
-			net6_get_hi_part(&net6, &from_hi, &mask_hi);
-			uint8_t to_hi[8];
-			*(uint64_t *)to_hi =
-				*(uint64_t *)from_hi | ~*(uint64_t *)mask_hi;
-			filter_key_inc(8, to_hi);
-			uint32_t start_hi =
-				radix_lookup(&ri_hi->radix, 8, from_hi);
-			uint32_t stop_hi = ri_hi->count;
-			if (*(uint64_t *)to_hi != 0)
-				stop_hi = radix_lookup(&ri_hi->radix, 8, to_hi);
-
-			uint8_t *from_lo;
-			uint8_t *mask_lo;
-			net6_get_lo_part(&net6, &from_lo, &mask_lo);
-			uint8_t to_lo[8];
-			*(uint64_t *)to_lo =
-				*(uint64_t *)from_lo | ~*(uint64_t *)mask_lo;
-			filter_key_inc(8, to_lo);
-			uint32_t start_lo =
-				radix_lookup(&ri_lo->radix, 8, from_lo);
-			uint32_t stop_lo = ri_lo->count;
-			if (*(uint64_t *)to_lo != 0)
-				stop_lo = radix_lookup(&ri_lo->radix, 8, to_lo);
-
-			for (uint32_t idx_hi = start_hi; idx_hi < stop_hi;
-			     ++idx_hi) {
-				for (uint32_t idx_lo = start_lo;
-				     idx_lo < stop_lo;
-				     ++idx_lo) {
-					if (value_registry_collect(
-						    &net_registry,
-						    value_table_get(
-							    table,
-							    values_hi[idx_hi],
-							    values_lo[idx_lo]
-						    )
-					    )) {
-						goto error_late;
-					}
-				}
-			}
-		}
+	if (collect_network_values(
+		    nets, net_cnt, ri_hi, ri_lo, table, &net_registry
+	    )) {
+		goto error_net_registry;
 	}
 
 	value_registry_init(registry, memory_context);
@@ -342,7 +570,7 @@ merge_net6_range(
 	     ++action_ptr) {
 		// A value range should be created even for empty rules
 		if (value_registry_start(registry))
-			goto error_late;
+			goto error_registry;
 
 		if (*action_ptr == NULL)
 			continue;
@@ -356,7 +584,8 @@ merge_net6_range(
 			struct net6 net6;
 			net6_normalize(rule_net, &net6);
 
-			uint32_t net_idx = radix_lookup(&rdx, 32, net6.addr);
+			uint32_t net_idx =
+				radix_lookup(&net_radix, 32, net6.addr);
 
 			struct value_range *rng =
 				ADDR_OF(&net_registry.ranges) + net_idx;
@@ -365,29 +594,63 @@ merge_net6_range(
 				if (value_registry_collect(
 					    registry, vls[idx]
 				    )) {
-					goto error_late;
+					goto error_registry;
 				}
 			}
 		}
 	}
 
-	radix_free(&rdx);
+	radix_free(&net_radix);
 	value_registry_fini(&net_registry);
+	for (uint32_t idx = 0; idx < net_range_count; ++idx) {
+		struct value_range *range = net_ranges + idx;
+		mem_array_free_exp(
+			memory_context,
+			ADDR_OF(&range->values),
+			sizeof(uint32_t),
+			range->count
+		);
+	}
+
+	memory_bfree(
+		memory_context,
+		net_ranges,
+		sizeof(struct value_range) * net_range_count
+	);
+
+	mem_array_free_exp(memory_context, nets, sizeof(*nets), net_cnt);
 
 	return 0;
 
-error_late:
-	radix_free(&rdx);
+error_registry:
+	value_registry_fini(registry);
+
+error_net_registry:
 	value_registry_fini(&net_registry);
-	value_table_free(table);
-	return -1;
 
-error_touch:
-	radix_free(&rdx);
-	remap_table_free(&remap_table);
-
-error_remap_table:
+error_table:
 	value_table_free(table);
+
+error_info:
+	for (uint32_t idx = 0; idx < net_range_count; ++idx) {
+		struct value_range *range = net_ranges + idx;
+		mem_array_free_exp(
+			memory_context,
+			ADDR_OF(&range->values),
+			sizeof(uint32_t),
+			range->count
+		);
+	}
+
+	memory_bfree(
+		memory_context,
+		net_ranges,
+		sizeof(struct value_range) * net_range_count
+	);
+
+	mem_array_free_exp(memory_context, nets, sizeof(*nets), net_cnt);
+
+	radix_free(&net_radix);
 
 	return -1;
 }

--- a/lib/filter/tests/meson.build
+++ b/lib/filter/tests/meson.build
@@ -82,6 +82,15 @@ test_filter_net4_ports = executable(
 )
 test('net4_ports', test_filter_net4_ports, suite: ['filter'])
 
+test_filter_net6_overlap = executable('net6_overlap',
+  ['net6_overlap.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: test_deps,
+  link_language: 'c'
+)
+test('net6_overlap', test_filter_net6_overlap, suite: ['filter'])
+
 # test memory reuse
 test_filter_memory = executable('memory',
   ['memory.c'],

--- a/lib/filter/tests/net6_overlap.c
+++ b/lib/filter/tests/net6_overlap.c
@@ -1,0 +1,128 @@
+#include "lib/filter/compiler.h"
+#include "lib/filter/filter.h"
+#include "lib/filter/query.h"
+
+#include "lib/filter/tests/helpers.h"
+#include "lib/utils/packet.h"
+
+#include "logging/log.h"
+#include <assert.h>
+#include <netinet/in.h>
+#include <string.h>
+
+FILTER_COMPILER_DECLARE(sign_net6_compile, net6_src, net6_dst);
+FILTER_QUERY_DECLARE(sign_net6, net6_src, net6_dst);
+
+// The IPv6 classifier could match a packet to the wrong rule
+// when a wide prefix and a single address inside it appear across several
+// rules. The bug needs a source match too, so every rule has a dst and a src.
+//
+// Rules in priority order (lower number wins):
+//   rule 0 - dst: fe80::/64 and fe80::f15;  src: 2a02:6b8::/32
+//   rule 1 - dst: fe80::f15;                src: any
+//   rule 2 - dst: fe80::/64;                src: any
+//
+// The probe's source is not in rule 0, and its destination is in fe80::/64
+// but not fe80::f15. Only rule 2 matches it, so the filter must return 2;
+// the bug returns 1.
+
+static struct net6
+net6_cidr(const uint8_t addr[NET6_LEN], int prefix_len) {
+	struct net6 net;
+	memcpy(net.addr, addr, NET6_LEN);
+	memset(net.mask, 0, NET6_LEN);
+	for (int idx = 0; idx < prefix_len; ++idx) {
+		net.mask[idx / 8] |= 0x80 >> (idx % 8);
+	}
+	return net;
+}
+
+static uint32_t
+query_one(
+	struct filter *filter,
+	const uint8_t src[NET6_LEN],
+	const uint8_t dst[NET6_LEN]
+) {
+	struct packet packet = {0};
+	int res = fill_packet_net6(&packet, src, dst, 100, 200, IPPROTO_UDP, 0);
+	assert(res == 0);
+
+	struct packet *packet_ptr = &packet;
+	uint32_t action;
+	filter_query(filter, sign_net6, &packet_ptr, &action, 1);
+	free_packet(&packet);
+
+	return action;
+}
+
+int
+main() {
+	log_enable_name("info");
+	void *memory = malloc(1 << 24);
+
+	struct block_allocator allocator;
+	block_allocator_init(&allocator);
+	block_allocator_put_arena(&allocator, memory, 1 << 24);
+
+	struct memory_context mctx;
+	int res = memory_context_init(&mctx, "test", &allocator);
+	assert(res == 0);
+
+	const uint8_t any[NET6_LEN] = {0};
+	const uint8_t wide_prefix[NET6_LEN] = {0xfe, 0x80};
+	uint8_t single_address[NET6_LEN] = {0xfe, 0x80};
+	single_address[14] = 0x0f;
+	single_address[15] = 0x15;
+	const uint8_t src_prefix[NET6_LEN] = {0x2a, 0x02, 0x06, 0xb8};
+
+	// rule 0: wide prefix + the address, fixed source
+	struct filter_rule_builder b0;
+	builder_init(&b0);
+	builder_add_net6_dst(&b0, net6_cidr(wide_prefix, 64));
+	builder_add_net6_dst(&b0, net6_cidr(single_address, 128));
+	builder_add_net6_src(&b0, net6_cidr(src_prefix, 32));
+	struct filter_rule rule0 = build_rule(&b0);
+
+	// rule 1: the address only, any source
+	struct filter_rule_builder b1;
+	builder_init(&b1);
+	builder_add_net6_dst(&b1, net6_cidr(single_address, 128));
+	builder_add_net6_src(&b1, net6_cidr(any, 0));
+	struct filter_rule rule1 = build_rule(&b1);
+
+	// rule 2: the wide prefix only, any source
+	struct filter_rule_builder b2;
+	builder_init(&b2);
+	builder_add_net6_dst(&b2, net6_cidr(wide_prefix, 64));
+	builder_add_net6_src(&b2, net6_cidr(any, 0));
+	struct filter_rule rule2 = build_rule(&b2);
+
+	const struct filter_rule *rule_ptrs[3] = {&rule0, &rule1, &rule2};
+
+	struct filter filter;
+	res = filter_init(
+		&filter, sign_net6_compile, rule_ptrs, 3, &mctx, NULL
+	);
+	assert(res == 0);
+
+	// packet: src outside rule 0, dst in the wide prefix but not the
+	// address — matches only rule 2.
+	const uint8_t src[NET6_LEN] = {
+		0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+	};
+	uint8_t dst[NET6_LEN] = {0xfe, 0x80};
+	dst[14] = 0x12;
+	dst[15] = 0x34;
+
+	uint32_t action = query_one(&filter, src, dst);
+	LOG(INFO, "dst fe80::1234 -> rule %u (expected 2)", action);
+	assert(action == 2);
+
+	LOG(INFO, "net6 overlap test passed");
+
+	filter_free(&filter, sign_net6_compile);
+	memory_context_fini(&mctx);
+	free(memory);
+
+	return 0;
+}


### PR DESCRIPTION
Split all networks to groups where each network has exact the same rule set the rule containing in. The evaluate distinct identifiers for each network group intersection and account them to rules.