### PR TITLE
fix(route-operator): keep ECMP routes when the BGP peer address is unset

### DIFF
--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -71,18 +71,19 @@ type Route struct {
 
 // isSameIdentity reports whether two routes share the same RIB identity.
 //
-// BGP-sourced routes are identified by peer because of BGP implicit replace:
-// a peer re-announcing a prefix with a new nexthop must replace its previous
-// path (RFC 4271), so BGP ECMP arises across peers. Static routes are
-// peerless independent entries, so their identity includes the nexthop,
-// allowing multiple static routes for the same prefix with distinct nexthops
-// to coexist. Static nexthops are compared in normalized (unmapped) form
-// because the API accepts both native IPv4 and IPv4-in-IPv6 encodings.
+// A route learned from a BGP peer is identified by that peer: under BGP
+// implicit replace (RFC 4271) a peer that re-announces a prefix with a new
+// nexthop replaces its own earlier path, so multiple BGP paths for one prefix
+// come from different peers. When no usable peer is present the nexthop is the
+// only discriminator, so routes with distinct nexthops coexist as ECMP instead
+// of replacing each other. This covers static routes and BGP routes whose peer
+// address is unset. Nexthops are compared unmapped because the API accepts both
+// native IPv4 and IPv4-in-IPv6 encodings.
 func (m Route) isSameIdentity(other Route) bool {
 	if m.SourceID != other.SourceID || m.Peer != other.Peer {
 		return false
 	}
-	if m.SourceID == RouteSourceStatic {
+	if !m.Peer.IsValid() || m.Peer.IsUnspecified() {
 		return m.NextHop.Unmap() == other.NextHop.Unmap()
 	}
 	return true

--- a/operators/route/internal/rib/routes_test.go
+++ b/operators/route/internal/rib/routes_test.go
@@ -142,6 +142,24 @@ func TestRoutesListStaticECMP(t *testing.T) {
 	})
 }
 
+// TestRoutesListBirdECMPUnspecifiedPeer verifies that BGP routes advertised for
+// one prefix with an unset peer address keep distinct nexthops as ECMP instead
+// of overwriting each other.
+func TestRoutesListBirdECMPUnspecifiedPeer(t *testing.T) {
+	pfx := netip.MustParsePrefix("2a02:6b8:2:a::/64")
+	nh1 := netip.MustParseAddr("fe80::1c")
+	nh2 := netip.MustParseAddr("fe80::1d")
+	unspec := netip.IPv6Unspecified()
+
+	var list RoutesList
+	r1 := Route{Prefix: pfx, NextHop: nh1, Peer: unspec, SourceID: RouteSourceBird}
+	r2 := Route{Prefix: pfx, NextHop: nh2, Peer: unspec, SourceID: RouteSourceBird}
+
+	require.True(t, list.Insert(r1), "first bird route should be added")
+	require.True(t, list.Insert(r2), "distinct-nexthop bird route with unset peer must coexist")
+	require.Len(t, list.Routes, 2)
+}
+
 // TestBestPerSource verifies that BestPerSource returns the equal-cost group
 // for each source and filters routes that are strictly worse than the source's best.
 func TestBestPerSource(t *testing.T) {


### PR DESCRIPTION
The route operator identified each BGP route only by its peer, ignoring the nexthop. When BIRD advertised a prefix with several ECMP nexthops but no peer address, the paths collapsed onto one identity and only the last nexthop survived, so the dataplane lost the other ECMP routes.

- Fall back to nexthop-based identity when a route has no usable peer address, so distinct nexthops for one prefix coexist as ECMP.
- Keep peer-based identity (BGP implicit replace) for routes from a known peer.
- Add a regression test for a peerless BGP prefix with two nexthops.
