### PR TITLE
feat(blackhole): add gRPC controlplane service and CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "yanet-cli-blackhole"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "colored",
+ "log",
+ "prost",
+ "prost-types",
+ "serde",
+ "tokio",
+ "tonic",
+ "tonic-build",
+ "yanet-cli",
+]
+
+[[package]]
 name = "yanet-cli-common"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "cli/modules/ready",
     "cli/modules/metrics",
     "modules/acl/cli",
+    "modules/blackhole/cli",
     "modules/fwstate/cli",
     "modules/decap/cli",
     "modules/dscp/cli",

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ CLI_CORE_BINARIES := yanet-cli $(addprefix yanet-cli-,$(CLI_CORE_MODULES))
 CLI_MODULES := \
 	acl \
 	balancer2 \
+	blackhole \
 	decap \
 	device-plain \
 	device-vlan \

--- a/controlplane/meson.build
+++ b/controlplane/meson.build
@@ -19,6 +19,7 @@ custom_target(
         # go proto gen deps
         ynpb_gen,
         common_protoc_gen,
+        blackhole_protoc_gen,
         decap_protoc_gen,
         dscp_protoc_gen,
         forward_protoc_gen,
@@ -35,6 +36,8 @@ custom_target(
         # cgo linker deps
         lib_acl_cp,
         lib_acl_dp,
+        lib_blackhole_cp,
+        lib_blackhole_dp,
         lib_decap_cp,
         lib_decap_dp,
         lib_dscp_cp,
@@ -51,8 +54,6 @@ custom_target(
         lib_pdump_dp,
         lib_route_cp,
         lib_route_dp,
-        lib_blackhole_cp,
-        lib_blackhole_dp,
         lib_dev_trafgen_api,
         lib_dev_trafgen_dp,
         lib_filter_compiler,

--- a/debian/yanet2-cli.install
+++ b/debian/yanet2-cli.install
@@ -1,5 +1,6 @@
 usr/bin/yanet-cli
 usr/bin/yanet-cli-acl
+usr/bin/yanet-cli-blackhole
 usr/bin/yanet-cli-fwstate
 usr/bin/yanet-cli-common
 usr/bin/yanet-cli-inspect

--- a/modules/blackhole/cli/Cargo.toml
+++ b/modules/blackhole/cli/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "yanet-cli-blackhole"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+rust-version = "1.85"
+
+[dependencies]
+ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
+log = "0.4"
+clap = { version = "4.5", features = ["derive"] }
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
+tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
+prost = "0.13"
+prost-types = "0.13"
+tonic = { version = "0.13", features = ["gzip"] }
+colored = "3"
+serde = { version = "1", features = ["derive"] }
+
+[build-dependencies]
+tonic-build = "0.13"

--- a/modules/blackhole/cli/build.rs
+++ b/modules/blackhole/cli/build.rs
@@ -1,0 +1,13 @@
+use core::error::Error;
+
+pub fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo:rerun-if-changed=../controlplane/blackholepb/v1/blackhole.proto");
+
+    tonic_build::configure()
+        .emit_rerun_if_changed(false)
+        .build_server(false)
+        .message_attribute(".", "#[derive(Serialize)]")
+        .compile_protos(&["blackholepb/v1/blackhole.proto"], &["../controlplane"])?;
+
+    Ok(())
+}

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -1,0 +1,190 @@
+use blackholepb::{
+    DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
+    blackhole_service_client::BlackholeServiceClient,
+};
+use clap::{ArgAction, CommandFactory, Parser};
+use clap_complete::CompleteEnv;
+use tonic::codec::CompressionEncoding;
+use ync::{
+    client::{ConnectionArgs, LayeredChannel},
+    errors::Error,
+    output::{self, CommonFormat},
+};
+
+#[allow(non_snake_case)]
+pub mod blackholepb {
+    use serde::Serialize;
+
+    tonic::include_proto!("modules.blackhole.controlplane.blackholepb.v1");
+}
+
+/// Blackhole module.
+#[derive(Debug, Clone, Parser)]
+#[command(version, about)]
+#[command(flatten_help = true)]
+pub struct Cmd {
+    #[clap(subcommand)]
+    pub mode: ModeCmd,
+    #[command(flatten)]
+    pub connection: ConnectionArgs,
+    #[arg(long, default_value = "human", global = true)]
+    pub format: CommonFormat,
+    /// Log verbosity level.
+    #[clap(short, action = ArgAction::Count, global = true)]
+    pub verbose: u8,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub enum ModeCmd {
+    List,
+    Show(ShowConfigCmd),
+    Update(UpdateConfigCmd),
+    Delete(DeleteConfigCmd),
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct ShowConfigCmd {
+    /// Blackhole module name to operate on.
+    #[arg(long = "name", short = 'n')]
+    pub config_name: String,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct UpdateConfigCmd {
+    /// Blackhole module name to create or replace.
+    #[arg(long = "name", short = 'n')]
+    pub config_name: String,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct DeleteConfigCmd {
+    /// Blackhole module name to delete.
+    #[arg(long = "name", short = 'n')]
+    pub config_name: String,
+}
+
+/// The fully-qualified gRPC service name used in error messages.
+const SERVICE_NAME: &str = "modules.blackhole.controlplane.blackholepb.v1.BlackholeService";
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() {
+    CompleteEnv::with_factory(Cmd::command).complete();
+    let cmd = Cmd::parse();
+    ync::init(cmd.verbose, cmd.format);
+
+    if let Err(err) = run(cmd).await {
+        output::failure(&err);
+        std::process::exit(err.exit_code());
+    }
+}
+
+async fn run(cmd: Cmd) -> Result<(), Error> {
+    let mut service = BlackholeService::new(&cmd.connection).await?;
+
+    match cmd.mode {
+        ModeCmd::List => service.list_configs().await,
+        ModeCmd::Show(cmd) => service.show_config(cmd).await,
+        ModeCmd::Update(cmd) => service.update_config(cmd).await,
+        ModeCmd::Delete(cmd) => service.delete_config(cmd).await,
+    }
+}
+
+pub struct BlackholeService {
+    client: BlackholeServiceClient<LayeredChannel>,
+    endpoint: String,
+}
+
+impl BlackholeService {
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
+        let channel = ync::client::connect(connection)
+            .await
+            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
+        let client = BlackholeServiceClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip);
+        Ok(Self {
+            client,
+            endpoint: connection.endpoint.clone(),
+        })
+    }
+
+    fn map_err<'a>(&'a self, action: &'a str) -> impl FnOnce(tonic::Status) -> Error + 'a {
+        let endpoint = self.endpoint.clone();
+        move |status| Error::from_status(status, action, endpoint, SERVICE_NAME)
+    }
+
+    pub async fn list_configs(&mut self) -> Result<(), Error> {
+        let request = ListConfigsRequest {};
+        log::trace!("list configs request: {request:?}");
+        let response = self
+            .client
+            .list_configs(request)
+            .await
+            .map_err(self.map_err("list"))?
+            .into_inner();
+        log::debug!("list configs response: {response:?}");
+
+        output::data(
+            &response.configs,
+            response.configs.is_empty(),
+            format_args!("no configurations"),
+            || {
+                for name in &response.configs {
+                    println!("{name}");
+                }
+            },
+        );
+
+        Ok(())
+    }
+
+    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
+        let request = ShowConfigRequest { name: cmd.config_name.clone() };
+        log::trace!("show config request: {request:?}");
+        let response = self
+            .client
+            .show_config(request)
+            .await
+            .map_err(self.map_err("show"))?
+            .into_inner();
+        log::debug!("show config response: {response:?}");
+
+        output::data(&response, false, format_args!(""), || {
+            println!("name: {}", response.name);
+        });
+
+        Ok(())
+    }
+
+    pub async fn update_config(&mut self, cmd: UpdateConfigCmd) -> Result<(), Error> {
+        let request = UpdateConfigRequest { name: cmd.config_name.clone() };
+        log::trace!("update config request: {request:?}");
+        let response = self
+            .client
+            .update_config(request)
+            .await
+            .map_err(self.map_err("update"))?
+            .into_inner();
+        log::debug!("update config response: {response:?}");
+
+        output::success("update", format_args!("Updated {}.", cmd.config_name));
+
+        Ok(())
+    }
+
+    pub async fn delete_config(&mut self, cmd: DeleteConfigCmd) -> Result<(), Error> {
+        let request = DeleteConfigRequest { name: cmd.config_name.clone() };
+        log::trace!("delete config request: {request:?}");
+        let response = self
+            .client
+            .delete_config(request)
+            .await
+            .map_err(self.map_err("delete"))?
+            .into_inner();
+        log::debug!("delete config response: {response:?}");
+
+        output::success("delete", format_args!("Deleted {}.", cmd.config_name));
+
+        Ok(())
+    }
+}

--- a/modules/blackhole/controlplane/backend.go
+++ b/modules/blackhole/controlplane/backend.go
@@ -1,0 +1,40 @@
+package blackhole
+
+import (
+	"fmt"
+
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/blackhole/bindings/go/cblackhole"
+)
+
+// backend is the real Backend implementation backed by shared memory.
+type backend struct {
+	agent *ffi.Agent
+}
+
+// NewBackend creates a Backend that operates on real shared memory.
+func NewBackend(agent *ffi.Agent) Backend {
+	return &backend{
+		agent: agent,
+	}
+}
+
+func (m *backend) UpdateModule(name string) (ModuleHandle, error) {
+	mod, err := cblackhole.NewModuleConfig(m.agent, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create module config: %w", err)
+	}
+
+	if err := m.agent.UpdateModules(
+		[]ffi.ModuleConfig{mod.AsFFIModule()},
+	); err != nil {
+		mod.Free()
+		return nil, fmt.Errorf("failed to update module %q: %w", name, err)
+	}
+
+	return mod, nil
+}
+
+func (m *backend) DeleteModule(name string) error {
+	return m.agent.DeleteModuleConfig(name)
+}

--- a/modules/blackhole/controlplane/blackholepb/meson.build
+++ b/modules/blackhole/controlplane/blackholepb/meson.build
@@ -1,0 +1,19 @@
+proto_dir = join_paths(meson.current_source_dir(), 'v1')
+root_dir = meson.project_source_root()
+proto_files = [join_paths(proto_dir, 'blackhole.proto')]
+
+protoc_gen = custom_target(
+    'blackhole-protoc',
+    output: ['blackhole.pb.go', 'blackhole_grpc.pb.go'],
+    input: proto_files,
+    command: [
+        protoc,
+        '-I', proto_dir,
+        '-I', root_dir,
+        '--go_out=paths=source_relative:' + proto_dir,
+        '--go-grpc_out=paths=source_relative:' + proto_dir,
+        '@INPUT@',
+    ],
+    build_by_default: true,
+)
+blackhole_protoc_gen = protoc_gen

--- a/modules/blackhole/controlplane/blackholepb/v1/blackhole.proto
+++ b/modules/blackhole/controlplane/blackholepb/v1/blackhole.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+package modules.blackhole.controlplane.blackholepb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/modules/blackhole/controlplane/blackholepb/v1;blackholepb";
+
+// BlackholeService is a controlplane service for the blackhole module.
+service BlackholeService {
+  // ListConfigs returns all blackhole module configurations of all
+  // dataplane instances.
+  rpc ListConfigs(ListConfigsRequest) returns (ListConfigsResponse);
+
+  // ShowConfig returns the current configuration for the blackhole module.
+  rpc ShowConfig(ShowConfigRequest) returns (ShowConfigResponse);
+
+  // UpdateConfig creates or replaces the named blackhole config and publishes
+  // it to the dataplane.
+  rpc UpdateConfig(UpdateConfigRequest) returns (UpdateConfigResponse);
+
+  // DeleteConfig removes the named blackhole config when it is no longer
+  // referenced by any pipeline.
+  rpc DeleteConfig(DeleteConfigRequest) returns (DeleteConfigResponse);
+}
+
+message ListConfigsRequest {}
+
+// ListConfigsResponse contains existing configurations.
+message ListConfigsResponse { repeated string configs = 1; }
+
+// ShowConfigRequest retrieves the runtime configuration for the blackhole
+// module.
+message ShowConfigRequest { string name = 1; }
+
+// ShowConfigResponse contains the configuration details of the blackhole
+// module.
+message ShowConfigResponse { string name = 1; }
+
+// UpdateConfigRequest names the config to create or replace.
+//
+// The blackhole config carries no payload, since the module unconditionally
+// drops every packet routed to it.
+message UpdateConfigRequest { string name = 1; }
+
+// UpdateConfigResponse is the response to an UpdateConfig call.
+message UpdateConfigResponse {}
+
+// DeleteConfigRequest names the config to delete.
+message DeleteConfigRequest { string name = 1; }
+
+// DeleteConfigResponse is the response to a DeleteConfig call.
+message DeleteConfigResponse { bool deleted = 1; }

--- a/modules/blackhole/controlplane/cfg.go
+++ b/modules/blackhole/controlplane/cfg.go
@@ -11,8 +11,15 @@ type Config struct {
 	InstanceID uint32 `yaml:"instance_id"`
 	// MemoryPath is the path to the shared memory file.
 	MemoryPath xcfg.NonEmptyString `yaml:"memory_path"`
-	// MemoryRequirements specifies memory requirements for the module
+	// MemoryRequirements is the amount of memory required for a single
+	// transaction.
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
+
+	// Endpoint is the gRPC address the module listens on.
+	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	// GatewayEndpoint is the gRPC address of the gateway the module
+	// registers with.
+	GatewayEndpoint xcfg.NonEmptyString `yaml:"gateway_endpoint"`
 }
 
 // DefaultConfig returns default configuration.
@@ -20,5 +27,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		MemoryPath:         xcfg.MustNonEmptyString("/dev/hugepages/yanet"),
 		MemoryRequirements: xcfg.MustNonZero(4 * datasize.MB),
+		Endpoint:           xcfg.MustNonEmptyString("[::1]:0"),
+		GatewayEndpoint:    xcfg.MustNonEmptyString("[::1]:8080"),
 	}
 }

--- a/modules/blackhole/controlplane/meson.build
+++ b/modules/blackhole/controlplane/meson.build
@@ -1,0 +1,1 @@
+subdir('blackholepb')

--- a/modules/blackhole/controlplane/mod.go
+++ b/modules/blackhole/controlplane/mod.go
@@ -5,15 +5,15 @@ import (
 	"fmt"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
-	"github.com/yanet-platform/yanet2/modules/blackhole/bindings/go/cblackhole"
+	blackholepb "github.com/yanet-platform/yanet2/modules/blackhole/controlplane/blackholepb/v1"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
 const (
-	agentName  = "blackhole"
-	moduleName = "blackhole"
-	configName = "blackhole0"
+	agentName   = "blackhole"
+	moduleName  = "blackhole"
+	serviceName = "modules.blackhole.controlplane.blackholepb.v1.BlackholeService"
 )
 
 // Option configures the BlackholeModule constructor.
@@ -38,10 +38,11 @@ func WithLog(log *zap.Logger) Option {
 
 // BlackholeModule is a controlplane component for blackhole module.
 type BlackholeModule struct {
-	config *cblackhole.ModuleConfig
-	shm    *ffi.SharedMemory
-	agent  *ffi.Agent
-	log    *zap.Logger
+	cfg              *Config
+	shm              *ffi.SharedMemory
+	agent            *ffi.Agent
+	blackholeService *BlackholeService
+	log              *zap.Logger
 }
 
 // NewBlackholeModule creates a new BlackholeModule.
@@ -51,7 +52,7 @@ func NewBlackholeModule(cfg *Config, options ...Option) (*BlackholeModule, error
 		o(opts)
 	}
 
-	log := opts.Log.With(zap.String("module", moduleName))
+	log := opts.Log.With(zap.String("module", serviceName))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {
@@ -68,18 +69,14 @@ func NewBlackholeModule(cfg *Config, options ...Option) (*BlackholeModule, error
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
 
-	config, err := cblackhole.NewModuleConfig(agent, configName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create module config: %w", err)
-	}
-
-	log.Info("created module config", zap.String("name", configName))
+	blackholeService := NewBlackholeService(NewBackend(agent))
 
 	return &BlackholeModule{
-		config: config,
-		shm:    shm,
-		agent:  agent,
-		log:    log,
+		cfg:              cfg,
+		shm:              shm,
+		agent:            agent,
+		blackholeService: blackholeService,
+		log:              log,
 	}, nil
 }
 
@@ -90,16 +87,17 @@ func (m *BlackholeModule) Name() string {
 
 // Endpoint returns the gRPC endpoint for the blackhole module.
 func (m *BlackholeModule) Endpoint() string {
-	return ""
+	return m.cfg.Endpoint.Unwrap()
 }
 
 // ServicesNames returns the gRPC service names exposed by the module.
 func (m *BlackholeModule) ServicesNames() []string {
-	return nil
+	return []string{serviceName}
 }
 
 // RegisterService registers the blackhole module's gRPC service.
 func (m *BlackholeModule) RegisterService(server *grpc.Server) {
+	blackholepb.RegisterBlackholeServiceServer(server, m.blackholeService)
 }
 
 // Close releases shared memory resources held by the module.

--- a/modules/blackhole/controlplane/service.go
+++ b/modules/blackhole/controlplane/service.go
@@ -1,0 +1,162 @@
+package blackhole
+
+import (
+	"context"
+	"sync"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	blackholepb "github.com/yanet-platform/yanet2/modules/blackhole/controlplane/blackholepb/v1"
+)
+
+var errConfigNameRequired = status.Error(codes.InvalidArgument, "config name is required")
+
+// ModuleHandle is a handle to a module configuration.
+type ModuleHandle interface {
+	Free()
+}
+
+// Backend abstracts shared memory operations.
+type Backend interface {
+	// UpdateModule creates a module config and publishes it to the
+	// dataplane.
+	UpdateModule(name string) (ModuleHandle, error)
+	// DeleteModule removes a module config.
+	DeleteModule(name string) error
+}
+
+type config struct {
+	module ModuleHandle
+}
+
+// BlackholeService implements the BlackholeService gRPC server.
+type BlackholeService struct {
+	blackholepb.UnimplementedBlackholeServiceServer
+
+	mu      sync.Mutex
+	backend Backend
+	configs map[string]*config
+}
+
+// NewBlackholeService constructs a BlackholeService backed by the given Backend.
+func NewBlackholeService(backend Backend) *BlackholeService {
+	return &BlackholeService{
+		backend: backend,
+		configs: map[string]*config{},
+	}
+}
+
+// ListConfigs returns all known config names across all dataplane instances.
+func (m *BlackholeService) ListConfigs(
+	ctx context.Context,
+	req *blackholepb.ListConfigsRequest,
+) (*blackholepb.ListConfigsResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	names := make([]string, 0, len(m.configs))
+	for name := range m.configs {
+		names = append(names, name)
+	}
+
+	return &blackholepb.ListConfigsResponse{Configs: names}, nil
+}
+
+// ShowConfig returns the named config when it exists.
+func (m *BlackholeService) ShowConfig(
+	ctx context.Context,
+	req *blackholepb.ShowConfigRequest,
+) (*blackholepb.ShowConfigResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.configs[name]; !ok {
+		return nil, status.Error(codes.NotFound, "no config found")
+	}
+
+	return &blackholepb.ShowConfigResponse{Name: name}, nil
+}
+
+// UpdateConfig creates or replaces the named config and publishes it to the
+// dataplane.
+func (m *BlackholeService) UpdateConfig(
+	ctx context.Context,
+	req *blackholepb.UpdateConfigRequest,
+) (*blackholepb.UpdateConfigResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := m.updateConfig(name); err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to update module config %q: %v", name, err,
+		)
+	}
+
+	return &blackholepb.UpdateConfigResponse{}, nil
+}
+
+// updateConfig publishes a fresh config and, on success, frees the old module
+// handle and stores the new one.
+//
+// The caller must hold m.mu.
+func (m *BlackholeService) updateConfig(name string) error {
+	mod, err := m.backend.UpdateModule(name)
+	if err != nil {
+		return err
+	}
+
+	if old, ok := m.configs[name]; ok && old.module != nil {
+		old.module.Free()
+	}
+
+	m.configs[name] = &config{module: mod}
+
+	return nil
+}
+
+// DeleteConfig removes the named config if it is not referenced by any
+// pipeline.
+func (m *BlackholeService) DeleteConfig(
+	ctx context.Context,
+	req *blackholepb.DeleteConfigRequest,
+) (*blackholepb.DeleteConfigResponse, error) {
+	name := req.GetName()
+	if name == "" {
+		return nil, errConfigNameRequired
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry, ok := m.configs[name]
+	if !ok {
+		return nil, status.Error(codes.NotFound, "no config found")
+	}
+
+	if err := m.backend.DeleteModule(name); err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to delete module config %q: %v", name, err,
+		)
+	}
+
+	if entry.module != nil {
+		entry.module.Free()
+	}
+
+	delete(m.configs, name)
+
+	return &blackholepb.DeleteConfigResponse{Deleted: true}, nil
+}

--- a/modules/blackhole/controlplane/service_test.go
+++ b/modules/blackhole/controlplane/service_test.go
@@ -1,0 +1,194 @@
+package blackhole
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	blackholepb "github.com/yanet-platform/yanet2/modules/blackhole/controlplane/blackholepb/v1"
+)
+
+var errInjectedBackend = errors.New("injected backend failure")
+
+type mockModuleHandle struct{}
+
+func (m *mockModuleHandle) Free() {}
+
+type mockBackend struct{}
+
+func (m *mockBackend) UpdateModule(name string) (ModuleHandle, error) {
+	return &mockModuleHandle{}, nil
+}
+
+func (m *mockBackend) DeleteModule(name string) error {
+	return nil
+}
+
+func newTestService(t *testing.T) *BlackholeService {
+	t.Helper()
+	return NewBlackholeService(&mockBackend{})
+}
+
+// flakyBackend succeeds on the first UpdateModule call and fails thereafter.
+type flakyBackend struct {
+	numCalls atomic.Int64
+}
+
+func (m *flakyBackend) UpdateModule(name string) (ModuleHandle, error) {
+	if m.numCalls.Add(1) >= 2 {
+		return nil, errInjectedBackend
+	}
+	return &mockModuleHandle{}, nil
+}
+
+func (m *flakyBackend) DeleteModule(name string) error {
+	return nil
+}
+
+func Test_BlackholeService_UpdateAndShow(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.UpdateConfig(t.Context(), &blackholepb.UpdateConfigRequest{Name: "blackhole0"})
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+
+	show, err := svc.ShowConfig(t.Context(), &blackholepb.ShowConfigRequest{Name: "blackhole0"})
+	require.NotNil(t, show)
+	require.NoError(t, err)
+	require.Equal(t, "blackhole0", show.Name)
+}
+
+func Test_BlackholeService_ListUpdateList(t *testing.T) {
+	svc := newTestService(t)
+	ctx := t.Context()
+
+	list, err := svc.ListConfigs(ctx, &blackholepb.ListConfigsRequest{})
+	require.NotNil(t, list)
+	require.NoError(t, err)
+	assert.Empty(t, list.Configs)
+
+	_, err = svc.UpdateConfig(ctx, &blackholepb.UpdateConfigRequest{Name: "blackhole0"})
+	require.NoError(t, err)
+
+	list, err = svc.ListConfigs(ctx, &blackholepb.ListConfigsRequest{})
+	require.NotNil(t, list)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"blackhole0"}, list.Configs)
+}
+
+func Test_BlackholeService_DeleteConfig(t *testing.T) {
+	svc := newTestService(t)
+	ctx := t.Context()
+
+	_, err := svc.UpdateConfig(ctx, &blackholepb.UpdateConfigRequest{Name: "blackhole0"})
+	require.NoError(t, err)
+
+	resp, err := svc.DeleteConfig(ctx, &blackholepb.DeleteConfigRequest{Name: "blackhole0"})
+	require.NoError(t, err)
+	require.True(t, resp.Deleted)
+
+	_, err = svc.ShowConfig(ctx, &blackholepb.ShowConfigRequest{Name: "blackhole0"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func Test_BlackholeService_DeleteMissing(t *testing.T) {
+	svc := newTestService(t)
+
+	resp, err := svc.DeleteConfig(t.Context(), &blackholepb.DeleteConfigRequest{Name: "absent"})
+	require.Nil(t, resp)
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func Test_BlackholeService_EmptyConfigName(t *testing.T) {
+	svc := newTestService(t)
+	ctx := t.Context()
+
+	t.Run("UpdateConfig", func(t *testing.T) {
+		resp, err := svc.UpdateConfig(ctx, &blackholepb.UpdateConfigRequest{})
+		require.Nil(t, resp)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("ShowConfig", func(t *testing.T) {
+		resp, err := svc.ShowConfig(ctx, &blackholepb.ShowConfigRequest{})
+		require.Nil(t, resp)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("DeleteConfig", func(t *testing.T) {
+		resp, err := svc.DeleteConfig(ctx, &blackholepb.DeleteConfigRequest{})
+		require.Nil(t, resp)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+}
+
+func Test_BlackholeService_UpdateFailureAtomic(t *testing.T) {
+	svc := NewBlackholeService(&flakyBackend{})
+	ctx := t.Context()
+	name := "blackhole0"
+
+	_, err := svc.UpdateConfig(ctx, &blackholepb.UpdateConfigRequest{Name: name})
+	require.NoError(t, err)
+
+	_, err = svc.UpdateConfig(ctx, &blackholepb.UpdateConfigRequest{Name: name})
+	require.Error(t, err)
+	require.Equal(t, codes.Internal, status.Code(err))
+
+	show, err := svc.ShowConfig(ctx, &blackholepb.ShowConfigRequest{Name: name})
+	require.NotNil(t, show)
+	require.NoError(t, err)
+	require.Equal(t, name, show.Name)
+}
+
+func Test_BlackholeService_ConcurrentAccess(t *testing.T) {
+	svc := newTestService(t)
+
+	const goroutines = 10
+	const iterations = 100
+
+	g, ctx := errgroup.WithContext(t.Context())
+
+	for idx := range goroutines {
+		g.Go(func() error {
+			for jdx := range iterations {
+				name := fmt.Sprintf("config-%d-%d", idx, jdx)
+				_, err := svc.UpdateConfig(ctx, &blackholepb.UpdateConfigRequest{Name: name})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	for range goroutines {
+		g.Go(func() error {
+			for range iterations {
+				_, err := svc.ListConfigs(ctx, &blackholepb.ListConfigsRequest{})
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	for idx := range goroutines {
+		g.Go(func() error {
+			for jdx := range iterations {
+				name := fmt.Sprintf("config-%d-%d", idx, jdx)
+				svc.ShowConfig(ctx, &blackholepb.ShowConfigRequest{Name: name})
+			}
+			return nil
+		})
+	}
+
+	require.NoError(t, g.Wait())
+}

--- a/modules/blackhole/meson.build
+++ b/modules/blackhole/meson.build
@@ -2,4 +2,5 @@ subdir('dataplane')
 
 if not dataplane_only
   subdir('api')
+  subdir('controlplane')
 endif

--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -53,7 +53,7 @@ const (
 var CLIBinaryNames = []string{
 	"yanet-cli",
 	"yanet-cli-route", "yanet-cli-route-mpls",
-	"yanet-cli-nat64", "yanet-cli-acl",
+	"yanet-cli-nat64", "yanet-cli-acl", "yanet-cli-blackhole",
 	"yanet-cli-fwstate", "yanet-cli-pipeline", "yanet-cli-function",
 	"yanet-cli-device-plain", "yanet-cli-device-vlan",
 	"yanet-cli-decap", "yanet-cli-forward",


### PR DESCRIPTION
- Add a gRPC service for the blackhole module exposing list, show, update, and delete operations, by analogy with the forward and decap modules.
- Add a command-line client that lists, shows, updates, and deletes configs by name, registered in the Cargo workspace and the CLI build.
- Keep the blackhole config empty by design, since the module unconditionally drops every packet, so the update path carries only a config name.
- Register the service with the gateway and wire protobuf generation into the build.
