### PR TITLE
refactor(cli): bundle client, endpoint and error mapping into one wrapper

### DIFF
--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -74,6 +74,82 @@ pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, Connection
     Ok(auth.layer(channel))
 }
 
+/// A connected gRPC client bundled with its endpoint and service name.
+///
+/// Wraps a tonic-generated client together with the endpoint it reached and
+/// its fully-qualified service name. This lets a CLI stop threading
+/// `endpoint` through its own service struct and stop re-declaring the
+/// per-command error-mapping helpers: [`status`](Service::status) and
+/// [`invalid`](Service::invalid) live here once.
+///
+/// It holds a single client, matching the common one-service CLI. A CLI that
+/// drives several clients over one shared channel keeps them as separate
+/// fields instead.
+pub struct Service<C> {
+    client: C,
+    endpoint: String,
+    name: &'static str,
+}
+
+impl<C> Service<C> {
+    /// Wrap an already-built `client` with its `endpoint` and service `name`.
+    ///
+    /// Prefer [`Service::connect`], which also establishes the channel. Use
+    /// this only when the channel is built elsewhere.
+    pub fn new(client: C, endpoint: impl Into<String>, name: &'static str) -> Self {
+        Self {
+            client,
+            endpoint: endpoint.into(),
+            name,
+        }
+    }
+
+    /// Connect to `connection` and build the client via `build`.
+    ///
+    /// `name` is the fully-qualified gRPC service name embedded in error
+    /// messages. `build` receives the layered channel and returns the
+    /// tonic-generated client, configuring compression and message sizes.
+    pub async fn connect<F>(connection: &ConnectionArgs, name: &'static str, build: F) -> Result<Self, Error>
+    where
+        F: FnOnce(LayeredChannel) -> C,
+    {
+        let channel = connect(connection)
+            .await
+            .map_err(|err| Error::from_connection(err, "connect", &connection.endpoint))?;
+
+        Ok(Self::new(build(channel), connection.endpoint.clone(), name))
+    }
+
+    /// Mutable access to the inner client for issuing RPCs.
+    pub fn client(&mut self) -> &mut C {
+        &mut self.client
+    }
+
+    /// A closure mapping a gRPC [`Status`] to a structured [`Error`].
+    ///
+    /// `action` is the user-facing verb (e.g. `"list"`); pass the returned
+    /// closure to `Result::map_err` on an RPC result. The closure owns its
+    /// captures, so it never borrows `self`.
+    pub fn status(&self, action: &'static str) -> impl FnOnce(Status) -> Error {
+        let endpoint = self.endpoint.clone();
+        let name = self.name;
+
+        move |status| Error::from_status(status, action, endpoint, name)
+    }
+
+    /// Build an invalid-argument [`Error`] for input rejected locally.
+    ///
+    /// Use when the CLI detects a bad argument before issuing the RPC.
+    pub fn invalid(&self, action: &'static str, message: impl Into<String>) -> Error {
+        Error::from_status(
+            Status::invalid_argument(message.into()),
+            action,
+            self.endpoint.clone(),
+            self.name,
+        )
+    }
+}
+
 /// Invoke a unary RPC on an arbitrary gRPC service by its fully-qualified
 /// name, without a generated client.
 ///
@@ -185,4 +261,29 @@ where
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use tonic::Status;
+
+    use super::Service;
+    use crate::errors::ErrorKind;
+
+    #[test]
+    fn status_maps_grpc_code() {
+        let service = Service::new((), "grpc://[::1]:8080", "test.Service");
+        let err = (service.status("list"))(Status::not_found("missing"));
+
+        assert_eq!(ErrorKind::NotFound, err.kind);
+    }
+
+    #[test]
+    fn invalid_builds_invalid_argument() {
+        let service = Service::new((), "grpc://[::1]:8080", "test.Service");
+        let err = service.invalid("update", "bad input");
+
+        assert_eq!(ErrorKind::InvalidArgument, err.kind);
+        assert_eq!("bad input", err.message);
+    }
 }

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -9,7 +9,7 @@ use trafgenpb::{
     trafgen_service_client::TrafgenServiceClient,
 };
 use ync::{
-    client::{ConnectionArgs, LayeredChannel},
+    client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -96,39 +96,21 @@ pub struct SetRateCmd {
 const SERVICE_NAME: &str = "devices.trafgen.controlplane.trafgenpb.v1.TrafgenService";
 
 pub struct TrafgenService {
-    client: TrafgenServiceClient<LayeredChannel>,
-    endpoint: String,
+    service: Service<TrafgenServiceClient<LayeredChannel>>,
 }
 
 impl TrafgenService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
-        let client = TrafgenServiceClient::new(channel)
-            .max_decoding_message_size(256 * 1024 * 1024)
-            .max_encoding_message_size(256 * 1024 * 1024)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip);
-
-        Ok(Self {
-            client,
-            endpoint: connection.endpoint.clone(),
+        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+            TrafgenServiceClient::new(channel)
+                .max_decoding_message_size(256 * 1024 * 1024)
+                .max_encoding_message_size(256 * 1024 * 1024)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
         })
-    }
+        .await?;
 
-    fn map_err<'a>(&'a self, action: &'a str) -> impl FnOnce(tonic::Status) -> Error + 'a {
-        let endpoint = self.endpoint.clone();
-        move |status| Error::from_status(status, action, endpoint, SERVICE_NAME)
-    }
-
-    fn invalid_argument(&self, action: &'static str, message: String) -> Error {
-        Error::from_status(
-            tonic::Status::invalid_argument(message),
-            action,
-            self.endpoint.clone(),
-            SERVICE_NAME,
-        )
+        Ok(Self { service })
     }
 
     pub async fn update_device(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
@@ -137,22 +119,23 @@ impl TrafgenService {
             .into_iter()
             .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.invalid_argument("update", err.to_string()))?;
+            .map_err(|err| self.service.invalid("update", err.to_string()))?;
         let output = cmd
             .output
             .into_iter()
             .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.invalid_argument("update", err.to_string()))?;
+            .map_err(|err| self.service.invalid("update", err.to_string()))?;
 
         let request = UpdateDeviceRequest {
             name: cmd.config_name.clone(),
             device: Some(Device { input, output }),
         };
-        self.client
+        self.service
+            .client()
             .update_device(request)
             .await
-            .map_err(self.map_err("update"))?
+            .map_err(self.service.status("update"))?
             .into_inner();
 
         output::success("update", format_args!("Updated device {}.", cmd.config_name));
@@ -162,10 +145,11 @@ impl TrafgenService {
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
         let response = self
-            .client
+            .service
+            .client()
             .list_configs(ListConfigsRequest {})
             .await
-            .map_err(self.map_err("list"))?
+            .map_err(self.service.status("list"))?
             .into_inner();
 
         output::data(
@@ -185,10 +169,11 @@ impl TrafgenService {
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
         let request = ShowConfigRequest { name: cmd.config_name.clone() };
         let response = self
-            .client
+            .service
+            .client()
             .show_config(request)
             .await
-            .map_err(self.map_err("show"))?
+            .map_err(self.service.status("show"))?
             .into_inner();
 
         output::data(&response, false, format_args!(""), || {
@@ -202,14 +187,16 @@ impl TrafgenService {
 
     pub async fn upload_pcap(&mut self, cmd: UploadPcapCmd) -> Result<(), Error> {
         let pcap = std::fs::read(&cmd.pcap).map_err(|err| {
-            self.invalid_argument("upload", format!("failed to read pcap {}: {err}", cmd.pcap.display()))
+            self.service
+                .invalid("upload", format!("failed to read pcap {}: {err}", cmd.pcap.display()))
         })?;
 
         let request = UploadPcapRequest { name: cmd.config_name.clone(), pcap };
-        self.client
+        self.service
+            .client()
             .upload_pcap(request)
             .await
-            .map_err(self.map_err("upload"))?
+            .map_err(self.service.status("upload"))?
             .into_inner();
 
         output::success("upload", format_args!("Uploaded pcap to {}.", cmd.config_name));
@@ -222,10 +209,11 @@ impl TrafgenService {
             name: cmd.config_name.clone(),
             rate_pps: cmd.rate,
         };
-        self.client
+        self.service
+            .client()
             .set_rate(request)
             .await
-            .map_err(self.map_err("rate"))?
+            .map_err(self.service.status("rate"))?
             .into_inner();
 
         output::success(

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -8,7 +8,7 @@ use netip::{Contiguous, IpNetwork};
 use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel},
+    client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -87,38 +87,30 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 pub struct DecapService {
-    client: DecapServiceClient<LayeredChannel>,
-    endpoint: String,
+    service: Service<DecapServiceClient<LayeredChannel>>,
 }
 
 impl DecapService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
-        let client = DecapServiceClient::new(channel)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip);
-
-        Ok(Self {
-            client,
-            endpoint: connection.endpoint.clone(),
+        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+            DecapServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
         })
-    }
+        .await?;
 
-    fn map_err<'a>(&'a self, action: &'a str) -> impl FnOnce(tonic::Status) -> Error + 'a {
-        let endpoint = self.endpoint.clone();
-        move |status| Error::from_status(status, action, endpoint, SERVICE_NAME)
+        Ok(Self { service })
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
         let request = ListConfigsRequest {};
         log::trace!("list configs request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .list_configs(request)
             .await
-            .map_err(self.map_err("list"))?
+            .map_err(self.service.status("list"))?
             .into_inner();
         log::debug!("list configs response: {response:?}");
 
@@ -142,10 +134,11 @@ impl DecapService {
         let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
         log::trace!("show config request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .show_config(request)
             .await
-            .map_err(self.map_err("show"))?
+            .map_err(self.service.status("show"))?
             .into_inner();
         log::debug!("show config response: {response:?}");
 
@@ -161,10 +154,11 @@ impl DecapService {
         };
         log::trace!("update config request: {request:?}");
         let response = self
-            .client
+            .service
+            .client()
             .update_config(request)
             .await
-            .map_err(self.map_err("update"))?
+            .map_err(self.service.status("update"))?
             .into_inner();
         log::debug!("update config response: {response:?}");
 


### PR DESCRIPTION
- Introduce a shared wrapper in the CLI core that pairs a gRPC client with its endpoint and service name, so a CLI no longer threads the endpoint through its own struct or re-declares the per-command error-mapping helpers.
- Convert the decap and trafgen CLIs to the wrapper as the reference; behaviour is unchanged.
- Leave the remaining single-client CLIs and the two-client CLIs (which share one channel across clients) for a follow-up consistency pass.
