### PR TITLE
refactor(plain): adopt the shared client wrapper in the device CLI

### DIFF
--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -4,7 +4,7 @@ use code::{UpdateDevicePlainRequest, device_plain_service_client::DevicePlainSer
 use commonpb::pb::Device;
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel},
+    client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -55,37 +55,19 @@ pub struct UpdateCmd {
 const SERVICE_NAME: &str = "devices.plain.controlplane.plainpb.v1.DevicePlainService";
 
 pub struct DevicePlainService {
-    client: DevicePlainServiceClient<LayeredChannel>,
-    endpoint: String,
+    service: Service<DevicePlainServiceClient<LayeredChannel>>,
 }
 
 impl DevicePlainService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
-        let client = DevicePlainServiceClient::new(channel)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip);
-
-        Ok(Self {
-            client,
-            endpoint: connection.endpoint.clone(),
+        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+            DevicePlainServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
         })
-    }
+        .await?;
 
-    fn map_err<'a>(&'a self, action: &'a str) -> impl FnOnce(tonic::Status) -> Error + 'a {
-        let endpoint = self.endpoint.clone();
-        move |status| Error::from_status(status, action, endpoint, SERVICE_NAME)
-    }
-
-    fn invalid_argument(&self, action: &'static str, message: String) -> Error {
-        Error::from_status(
-            tonic::Status::invalid_argument(message),
-            action,
-            self.endpoint.clone(),
-            SERVICE_NAME,
-        )
+        Ok(Self { service })
     }
 
     pub async fn update_config(&mut self, cmd: UpdateCmd) -> Result<(), Error> {
@@ -94,23 +76,24 @@ impl DevicePlainService {
             .into_iter()
             .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.invalid_argument("update", err.to_string()))?;
+            .map_err(|err| self.service.invalid("update", err.to_string()))?;
         let output = cmd
             .output
             .into_iter()
             .map(|s| s.parse::<commonpb::pb::DevicePipeline>())
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| self.invalid_argument("update", err.to_string()))?;
+            .map_err(|err| self.service.invalid("update", err.to_string()))?;
 
         let request = UpdateDevicePlainRequest {
             name: cmd.name.clone(),
             device: Some(Device { input, output }),
         };
 
-        self.client
+        self.service
+            .client()
             .update_device(request)
             .await
-            .map_err(self.map_err("update"))?;
+            .map_err(self.service.status("update"))?;
 
         output::success("update", format_args!("Updated device {}.", cmd.name));
 


### PR DESCRIPTION
- Move the plain device CLI onto the shared client/endpoint wrapper introduced in the CLI core, dropping its own endpoint field and per-command error-mapping helpers.
- Behaviour is unchanged.
