### PR TITLE
refactor(function): adopt the shared client wrapper in the function CLI

### DIFF
--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -125,6 +125,15 @@ impl<C> Service<C> {
         &mut self.client
     }
 
+    /// The endpoint this client reached.
+    ///
+    /// Exposed for the few call sites that build errors through a helper
+    /// other than [`status`](Service::status) / [`invalid`](Service::invalid)
+    /// (for example a [`NotFoundMapper`](crate::errors::NotFoundMapper)).
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
     /// A closure mapping a gRPC [`Status`] to a structured [`Error`].
     ///
     /// `action` is the user-facing verb (e.g. `"list"`); pass the returned
@@ -285,5 +294,12 @@ mod test {
 
         assert_eq!(ErrorKind::InvalidArgument, err.kind);
         assert_eq!("bad input", err.message);
+    }
+
+    #[test]
+    fn endpoint_returns_configured_value() {
+        let service = Service::new((), "grpc://[::1]:8080", "test.Service");
+
+        assert_eq!("grpc://[::1]:8080", service.endpoint());
     }
 }

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -5,7 +5,7 @@ use clap_complete::CompleteEnv;
 use commonpb::pb::FunctionId;
 use tonic::{codec::CompressionEncoding, Status};
 use ync::{
-    client::{ConnectionArgs, LayeredChannel},
+    client::{ConnectionArgs, LayeredChannel, Service},
     errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
@@ -137,8 +137,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
 }
 
 pub struct FunctionService {
-    client: FunctionServiceClient<LayeredChannel>,
-    endpoint: String,
+    service: Service<FunctionServiceClient<LayeredChannel>>,
 }
 
 impl FunctionService {
@@ -151,17 +150,17 @@ impl FunctionService {
             .accept_compressed(CompressionEncoding::Gzip);
 
         Ok(Self {
-            client,
-            endpoint: connection.endpoint.clone(),
+            service: Service::new(client, connection.endpoint.clone(), FUNCTION_SERVICE),
         })
     }
 
     pub async fn list_functions(&mut self) -> Result<Vec<FunctionId>, Error> {
         let response = self
-            .client
+            .service
+            .client()
             .list(ListFunctionsRequest {})
             .await
-            .map_err(|status| NOT_FOUND.map(status, "list functions", &self.endpoint, None))?
+            .map_err(|status| NOT_FOUND.map(status, "list functions", self.service.endpoint(), None))?
             .into_inner();
 
         Ok(response.ids)
@@ -173,14 +172,15 @@ impl FunctionService {
         };
 
         let response = self
-            .client
+            .service
+            .client()
             .get(request)
             .await
             .map_err(|status| {
                 NOT_FOUND.map(
                     status,
                     "show function",
-                    &self.endpoint,
+                    self.service.endpoint(),
                     Some(&format!("function '{name}'")),
                 )
             })?
@@ -190,7 +190,7 @@ impl FunctionService {
             Error::from_status(
                 Status::not_found(format!("function '{name}' not found")),
                 "show function",
-                self.endpoint.clone(),
+                self.service.endpoint(),
                 FUNCTION_SERVICE,
             )
         })?;
@@ -206,11 +206,11 @@ impl FunctionService {
             }),
         };
 
-        self.client.update(request).await.map_err(|status| {
+        self.service.client().update(request).await.map_err(|status| {
             NOT_FOUND.map(
                 status,
                 "update function",
-                &self.endpoint,
+                self.service.endpoint(),
                 Some(&format!("function '{name}'", name = cmd.name)),
             )
         })?;
@@ -221,7 +221,8 @@ impl FunctionService {
     pub async fn delete_function(&mut self, cmd: DeleteCmd) -> Result<(), Error> {
         let name = cmd.name;
 
-        self.client
+        self.service
+            .client()
             .delete(DeleteFunctionRequest {
                 id: Some(FunctionId { name: name.clone() }),
             })
@@ -230,7 +231,7 @@ impl FunctionService {
                 NOT_FOUND.map(
                     status,
                     "delete function",
-                    &self.endpoint,
+                    self.service.endpoint(),
                     Some(&format!("function '{name}'")),
                 )
             })?;


### PR DESCRIPTION
- Move the function CLI onto the shared client wrapper, dropping its own endpoint field.
- Expose the wrapper's endpoint so the CLI's friendly not-found rewriting keeps working unchanged.
- Behaviour is unchanged.
