### PR TITLE
feat(dscp): unify CLI output via the shared output layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,7 +3284,6 @@ dependencies = [
  "prost",
  "ptree",
  "serde",
- "serde_json",
  "tokio",
  "tonic",
  "tonic-build",

--- a/modules/dscp/cli/Cargo.toml
+++ b/modules/dscp/cli/Cargo.toml
@@ -11,7 +11,6 @@ clap_complete = "4.5"
 log = "0.4"
 colored = "3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 tokio = { version = "1", features = ["rt", "macros"] }
 tonic = { version = "0.13", features = ["gzip"] }
 prost = "0.13"

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -1,6 +1,4 @@
-use core::error::Error;
-
-use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
+use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use dscppb::{
     AddPrefixesRequest, DscpConfig, RemovePrefixesRequest, SetDscpMarkingRequest, ShowConfigRequest,
@@ -10,8 +8,9 @@ use netip::{Contiguous, IpNetwork};
 use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel},
-    logging,
+    client::{ConnectionArgs, LayeredChannel, Service},
+    errors::Error,
+    output::{self, CommonFormat},
 };
 
 use crate::dscppb::ListConfigsRequest;
@@ -32,6 +31,9 @@ pub struct Cmd {
     pub mode: ModeCmd,
     #[command(flatten)]
     pub connection: ConnectionArgs,
+    /// Output format.
+    #[arg(long, default_value = "human", global = true)]
+    pub format: CommonFormat,
     /// Log verbosity level.
     #[clap(short, action = ArgAction::Count, global = true)]
     pub verbose: u8,
@@ -51,9 +53,6 @@ pub struct ShowConfigCmd {
     /// DSCP module name to operate on.
     #[arg(long = "name", short = 'n')]
     pub config_name: String,
-    /// Output format.
-    #[clap(long, value_enum, default_value_t = OutputFormat::Tree)]
-    pub format: OutputFormat,
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -90,28 +89,22 @@ pub struct SetDscpMarkingCmd {
     pub mark: u32,
 }
 
-/// Output format options.
-#[derive(Debug, Clone, ValueEnum)]
-pub enum OutputFormat {
-    /// Tree structure with colored output (default).
-    Tree,
-    /// JSON format.
-    Json,
-}
+/// The fully-qualified gRPC service name used in error messages.
+const SERVICE_NAME: &str = "modules.dscp.controlplane.dscppb.v1.DscpService";
 
 #[tokio::main(flavor = "current_thread")]
 pub async fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
     let cmd = Cmd::parse();
-    logging::init(cmd.verbose as usize).expect("initialize logging");
+    ync::init(cmd.verbose, cmd.format);
 
     if let Err(err) = run(cmd).await {
-        log::error!("ERROR: {err}");
-        std::process::exit(1);
+        output::failure(&err);
+        std::process::exit(err.exit_code());
     }
 }
 
-async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
+async fn run(cmd: Cmd) -> Result<(), Error> {
     let mut service = DscpService::new(&cmd.connection).await?;
 
     match cmd.mode {
@@ -124,78 +117,123 @@ async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {
 }
 
 pub struct DscpService {
-    client: DscpServiceClient<LayeredChannel>,
+    service: Service<DscpServiceClient<LayeredChannel>>,
 }
 
 impl DscpService {
-    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Box<dyn Error>> {
-        let channel = ync::client::connect(connection).await?;
-        let client = DscpServiceClient::new(channel)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip);
-        Ok(Self { client })
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
+        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+            DscpServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        })
+        .await?;
+
+        Ok(Self { service })
     }
 
-    pub async fn list_configs(&mut self) -> Result<(), Box<dyn Error>> {
+    pub async fn list_configs(&mut self) -> Result<(), Error> {
         let request = ListConfigsRequest {};
         log::trace!("list configs request: {request:?}");
-        let response = self.client.list_configs(request).await?.into_inner();
+        let response = self
+            .service
+            .client()
+            .list_configs(request)
+            .await
+            .map_err(self.service.status("list"))?
+            .into_inner();
         log::debug!("list configs response: {response:?}");
 
-        let mut tree = TreeBuilder::new("List DSCP Configs".to_string());
-        for config in response.configs {
-            tree.add_empty_child(config);
-        }
-        let tree = tree.build();
-        ptree::print_tree(&tree)?;
+        output::data(
+            &response.configs,
+            response.configs.is_empty(),
+            format_args!("no dscp configs"),
+            || {
+                let mut tree = TreeBuilder::new("List DSCP Configs".to_string());
+                for config in &response.configs {
+                    tree.add_empty_child(config.clone());
+                }
+                let _ = ptree::print_tree(&tree.build());
+            },
+        );
+
         Ok(())
     }
 
-    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Box<dyn Error>> {
+    pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
         let request = ShowConfigRequest { name: cmd.config_name.to_owned() };
         log::trace!("show config request: {request:?}");
-        let response = self.client.show_config(request).await?.into_inner();
+        let response = self
+            .service
+            .client()
+            .show_config(request)
+            .await
+            .map_err(self.service.status("show"))?
+            .into_inner();
         log::debug!("show config response: {response:?}");
 
-        match cmd.format {
-            OutputFormat::Json => print_json(&response)?,
-            OutputFormat::Tree => print_tree(&response)?,
-        }
+        output::data(&response, false, format_args!(""), || print_tree(&response));
 
         Ok(())
     }
 
-    pub async fn add_prefixes(&mut self, cmd: AddPrefixesCmd) -> Result<(), Box<dyn Error>> {
+    pub async fn add_prefixes(&mut self, cmd: AddPrefixesCmd) -> Result<(), Error> {
         let request = AddPrefixesRequest {
             name: cmd.config_name.clone(),
             prefixes: cmd.prefix.iter().map(|p| p.to_string()).collect(),
         };
         log::trace!("AddPrefixesRequest: {request:?}");
-        let response = self.client.add_prefixes(request).await?.into_inner();
+        let response = self
+            .service
+            .client()
+            .add_prefixes(request)
+            .await
+            .map_err(self.service.status("prefix-add"))?
+            .into_inner();
         log::debug!("AddPrefixesResponse: {response:?}");
+
+        output::success(
+            "prefix-add",
+            format_args!("Added {} prefix(es) to {}.", cmd.prefix.len(), cmd.config_name),
+        );
+
         Ok(())
     }
 
-    pub async fn remove_prefixes(&mut self, cmd: RemovePrefixesCmd) -> Result<(), Box<dyn Error>> {
+    pub async fn remove_prefixes(&mut self, cmd: RemovePrefixesCmd) -> Result<(), Error> {
         let request = RemovePrefixesRequest {
             name: cmd.config_name.clone(),
             prefixes: cmd.prefix.iter().map(|p| p.to_string()).collect(),
         };
         log::trace!("RemovePrefixesRequest: {request:?}");
-        let response = self.client.remove_prefixes(request).await?.into_inner();
+        let response = self
+            .service
+            .client()
+            .remove_prefixes(request)
+            .await
+            .map_err(self.service.status("prefix-remove"))?
+            .into_inner();
         log::debug!("RemovePrefixesResponse: {response:?}");
+
+        output::success(
+            "prefix-remove",
+            format_args!("Removed {} prefix(es) from {}.", cmd.prefix.len(), cmd.config_name),
+        );
+
         Ok(())
     }
 
-    pub async fn set_dscp_marking(&mut self, cmd: SetDscpMarkingCmd) -> Result<(), Box<dyn Error>> {
+    pub async fn set_dscp_marking(&mut self, cmd: SetDscpMarkingCmd) -> Result<(), Error> {
         // Validate flag value
         if cmd.flag > 2 {
-            return Err("Invalid flag value (must be 0, 1, or 2)".into());
+            return Err(self
+                .service
+                .invalid("set-marking", "Invalid flag value (must be 0, 1, or 2)"));
         }
 
         // Validate mark value (6-bit field)
         if cmd.mark > 63 {
-            return Err("Invalid mark value (must be 0-63)".into());
+            return Err(self.service.invalid("set-marking", "Invalid mark value (must be 0-63)"));
         }
 
         let request = SetDscpMarkingRequest {
@@ -203,18 +241,22 @@ impl DscpService {
             dscp_config: Some(DscpConfig { flag: cmd.flag, mark: cmd.mark }),
         };
         log::trace!("SetDscpMarkingRequest: {request:?}");
-        let response = self.client.set_dscp_marking(request).await?.into_inner();
+        let response = self
+            .service
+            .client()
+            .set_dscp_marking(request)
+            .await
+            .map_err(self.service.status("set-marking"))?
+            .into_inner();
         log::debug!("SetDscpMarkingResponse: {response:?}");
+
+        output::success("set-marking", format_args!("Set DSCP marking on {}.", cmd.config_name));
+
         Ok(())
     }
 }
 
-pub fn print_json(config: &ShowConfigResponse) -> Result<(), Box<dyn Error>> {
-    println!("{}", serde_json::to_string(&config)?);
-    Ok(())
-}
-
-pub fn print_tree(response: &ShowConfigResponse) -> Result<(), Box<dyn Error>> {
+fn print_tree(response: &ShowConfigResponse) {
     let mut tree = TreeBuilder::new("View DSCP Config".to_string());
 
     if let Some(config) = &response.config {
@@ -232,10 +274,7 @@ pub fn print_tree(response: &ShowConfigResponse) -> Result<(), Box<dyn Error>> {
         tree.end_child();
     }
 
-    let tree = tree.build();
-    ptree::print_tree(&tree)?;
-
-    Ok(())
+    let _ = ptree::print_tree(&tree.build());
 }
 
 fn flag_to_string(flag: u32) -> String {


### PR DESCRIPTION
- Adopt the shared output stack and client wrapper in the dscp module CLI, so it gains a machine-readable JSON mode alongside consistent human and error rendering.
- Replace the per-command output-format switch with the global format flag, and drop the now-unused direct JSON dependency.
- Request behaviour is unchanged.
