### PR TITLE
Port counters implementation

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -73,6 +73,37 @@ yanet_get_module_counters(
 struct counter_handle_list *
 yanet_get_worker_counters(struct dp_config *dp_config);
 
+// Counters of a single DPDK port.
+//
+// port_id/port_name identify the port; counters holds that port's xstats as a
+// standard counter_handle_list.
+struct port_counter_group {
+	uint16_t port_id;
+	char port_name[80];
+	struct counter_handle_list *counters;
+};
+
+// Per-port counter groups for every DPDK port of an instance.
+struct port_counter_group_list {
+	uint64_t port_count;
+	struct port_counter_group ports[];
+};
+
+// Collect counters for every DPDK port, grouped per port.
+//
+// The returned list must be released with yanet_port_counter_group_list_free.
+// Returns NULL on allocation failure.
+struct port_counter_group_list *
+yanet_get_port_counters(struct dp_config *dp_config);
+
+struct port_counter_group *
+yanet_get_port_counter_group(
+	struct port_counter_group_list *groups, uint64_t idx
+);
+
+void
+yanet_port_counter_group_list_free(struct port_counter_group_list *groups);
+
 struct worker_counter_metadata {
 	uint32_t core_id;
 	uint32_t device_id;

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -21,8 +21,8 @@ use ync::{
 };
 use ynpb::pb::{
     counters_service_client::CountersServiceClient, CounterTag, CountersByTagsRequest, CountersByTagsResponse,
-    LatencyRangeCounter, PerfCounter, PerfCountersRequest, PerfCountersResponse, WorkerCounter, WorkerCountersRequest,
-    WorkerCountersResponse,
+    LatencyRangeCounter, PerfCounter, PerfCountersRequest, PerfCountersResponse, PortCountersRequest,
+    PortCountersResponse, WorkerCounter, WorkerCountersRequest, WorkerCountersResponse,
 };
 
 const COUNTERS_SERVICE: &str = "controlplane.ynpb.v1.CountersService";
@@ -113,6 +113,8 @@ pub enum ModeCmd {
     Perf(PerfCmd),
     /// Show worker counters.
     Workers,
+    /// Show port counters.
+    Ports,
 }
 
 impl ModeCmd {
@@ -125,6 +127,7 @@ impl ModeCmd {
             ModeCmd::Module(..) => "show module counters",
             ModeCmd::Perf(..) => "show perf counters",
             ModeCmd::Workers => "show worker counters",
+            ModeCmd::Ports => "show port counters",
         }
     }
 }
@@ -260,6 +263,15 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                 format_worker_counters(&response);
             });
         }
+        Some(ModeCmd::Ports) => {
+            let response = service.ports().await?;
+            output::data(&response, false, format_args!(""), || {
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&response).expect("counters YAML serialization must not fail")
+                );
+            });
+        }
         mode => {
             let request = tags_request(mode, cmd.by_tags);
             let response = service.by_tags(request).await?;
@@ -315,7 +327,7 @@ fn tags_request(mode: Option<ModeCmd>, by_tags: ByTagsCmd) -> CountersByTagsRequ
             ("module_type", cmd.module_type),
             ("module_name", cmd.module_name),
         ]),
-        Some(ModeCmd::Perf(..)) | Some(ModeCmd::Workers) => unreachable!(),
+        Some(ModeCmd::Perf(..)) | Some(ModeCmd::Workers) | Some(ModeCmd::Ports) => unreachable!(),
     }
 }
 
@@ -363,6 +375,16 @@ impl CountersService {
             .service
             .client()
             .workers(WorkerCountersRequest {})
+            .await
+            .map_err(self.service.status(self.action))?
+            .into_inner())
+    }
+
+    pub async fn ports(&mut self) -> Result<PortCountersResponse, Error> {
+        Ok(self
+            .service
+            .client()
+            .ports(PortCountersRequest {})
             .await
             .map_err(self.service.status(self.action))?
             .into_inner())

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -186,3 +186,34 @@ func (m *Counters) Workers(
 
 	return response, nil
 }
+
+func (m *Counters) Ports(
+	ctx context.Context,
+	request *ynpb.PortCountersRequest,
+) (*ynpb.PortCountersResponse, error) {
+	dpConfig := m.shm.DPConfig(m.instanceID)
+	counters, err := dpConfig.PortCounters()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ynpb.PortCountersResponse{
+		Ports: make([]*ynpb.PortCountersGroup, 0, len(counters)),
+	}
+	for _, group := range counters {
+		counterValues := make([]*ynpb.PortCounter, 0, len(group.Counters))
+		for _, counter := range group.Counters {
+			counterValues = append(counterValues, &ynpb.PortCounter{
+				Name:  counter.Name,
+				Value: counter.Value,
+			})
+		}
+		response.Ports = append(response.Ports, &ynpb.PortCountersGroup{
+			PortId:   uint32(group.PortID),
+			PortName: group.PortName,
+			Counters: counterValues,
+		})
+	}
+
+	return response, nil
+}

--- a/controlplane/ffi/port.go
+++ b/controlplane/ffi/port.go
@@ -1,0 +1,62 @@
+package ffi
+
+//#cgo CFLAGS: -I../../
+//#include "api/counter.h"
+import "C"
+
+import "fmt"
+
+type PortCounter struct {
+	Name  string
+	Value uint64
+}
+
+type PortGroup struct {
+	PortID   uint16
+	PortName string
+	Counters []PortCounter
+}
+
+func (m *DPConfig) PortCounters() ([]PortGroup, error) {
+	groups := C.yanet_get_port_counters(m.ptr)
+	if groups == nil {
+		return nil, fmt.Errorf("failed to get port counters")
+	}
+	defer C.yanet_port_counter_group_list_free(groups)
+
+	result := make([]PortGroup, 0, groups.port_count)
+	for groupIdx := range groups.port_count {
+		group := C.yanet_get_port_counter_group(groups, groupIdx)
+		if group == nil {
+			continue
+		}
+
+		counters := group.counters
+		portGroup := PortGroup{
+			PortID:   uint16(group.port_id),
+			PortName: C.GoString(&group.port_name[0]),
+			Counters: make([]PortCounter, 0, counters.count),
+		}
+		for idx := range counters.count {
+			handle := C.yanet_get_counter(counters, idx)
+			if handle == nil {
+				continue
+			}
+			portGroup.Counters = append(
+				portGroup.Counters,
+				PortCounter{
+					Name: C.GoString(&handle.name[0]),
+					Value: uint64(C.yanet_get_counter_value(
+						handle.value_handle,
+						0,
+						0,
+					)),
+				},
+			)
+		}
+
+		result = append(result, portGroup)
+	}
+
+	return result, nil
+}

--- a/controlplane/ynpb/v1/counters.proto
+++ b/controlplane/ynpb/v1/counters.proto
@@ -8,6 +8,7 @@ service CountersService {
   rpc Perf(PerfCountersRequest) returns (PerfCountersResponse);
   rpc ByTags(CountersByTagsRequest) returns (CountersByTagsResponse);
   rpc Workers(WorkerCountersRequest) returns (WorkerCountersResponse);
+  rpc Ports(PortCountersRequest) returns (PortCountersResponse);
 }
 
 message CounterTag {
@@ -67,6 +68,24 @@ message WorkerCounter {
   uint64 remote_rx_packets = 12;
   // Total packets sent to remote workers.
   uint64 remote_tx_packets = 13;
+}
+
+// Requests a snapshot of raw cumulative per-port extended stats counters.
+message PortCountersRequest {}
+
+// Returns the counters of every DPDK port, grouped per port.
+message PortCountersResponse { repeated PortCountersGroup ports = 1; }
+
+// Counters of a single DPDK port.
+message PortCountersGroup {
+  uint32 port_id = 1;
+  string port_name = 2;
+  repeated PortCounter counters = 3;
+}
+
+message PortCounter {
+  string name = 1;
+  uint64 value = 2;
 }
 
 // Request message for retrieving module performance counters.

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -633,6 +633,85 @@ dataplane_init(
 		dataplane, config->connection_count, config->connections
 	);
 
+	// init dataplane port counter
+	for (uint32_t instance_idx = 0;
+	     instance_idx < dataplane->instance_count;
+	     ++instance_idx) {
+		struct dataplane_instance *instance =
+			dataplane->instances + instance_idx;
+		struct dp_config *dp_config = instance->dp_config;
+
+		instance->device_xstat_map = (uint32_t **)memory_balloc(
+			&dp_config->memory_context,
+			sizeof(uint32_t *) * dataplane->device_count
+		);
+		if (instance->device_xstat_map == NULL) {
+			LOG(ERROR, "failed allocate device xstat map");
+			return -1;
+		}
+
+		struct dp_port_counters *port_counters =
+			(struct dp_port_counters *)memory_balloc(
+				&dp_config->memory_context,
+				sizeof(struct dp_port_counters) *
+					dataplane->device_count
+			);
+		if (port_counters == NULL) {
+			LOG(ERROR, "failed allocate port counters");
+			return -1;
+		}
+		dp_config->port_count = dataplane->device_count;
+		SET_OFFSET_OF(&dp_config->port_counters, port_counters);
+
+		for (uint32_t device_idx = 0;
+		     device_idx < dataplane->device_count;
+		     ++device_idx) {
+			struct dataplane_device *device =
+				dataplane->devices + device_idx;
+			struct dp_port_counters *pc =
+				port_counters + device_idx;
+
+			device->xstat_count = rte_eth_xstats_get_names(
+				device->port_id, NULL, 0
+			);
+
+			pc->port_id = device->port_id;
+			strtcpy(pc->port_name,
+				device->port_name,
+				sizeof(pc->port_name));
+			counter_registry_init(
+				&pc->registry, &dp_config->memory_context, 0
+			);
+
+			instance->device_xstat_map[device_idx] =
+				(uint32_t *)memory_balloc(
+					&dp_config->memory_context,
+					sizeof(uint32_t) * device->xstat_count
+				);
+			if (instance->device_xstat_map[device_idx] == NULL) {
+				LOG(ERROR, "failed allocate device xstat map");
+				return -1;
+			}
+
+			struct rte_eth_xstat_name names[device->xstat_count];
+			rte_eth_xstats_get_names(
+				device->port_id, names, device->xstat_count
+			);
+			for (uint32_t xstat_idx = 0;
+			     xstat_idx < device->xstat_count;
+			     ++xstat_idx) {
+				instance->device_xstat_map[device_idx]
+							  [xstat_idx] =
+					counter_registry_register(
+						&pc->registry,
+						names[xstat_idx].name,
+						1,
+						NULL
+					);
+			}
+		}
+	}
+
 	// init dataplane instances
 	for (uint32_t instance_idx = 0;
 	     instance_idx < dataplane->instance_count;
@@ -658,72 +737,48 @@ dataplane_init(
 	return 0;
 }
 
+static void
+stat_thread_collect_xstat(struct dataplane *dataplane) {
+	for (uint16_t device_idx = 0; device_idx < dataplane->device_count;
+	     ++device_idx) {
+		struct dataplane_device *device =
+			dataplane->devices + device_idx;
+
+		struct rte_eth_xstat xstats[device->xstat_count];
+		rte_eth_xstats_get(
+			device->port_id, xstats, device->xstat_count
+		);
+
+		for (uint32_t instance_idx = 0;
+		     instance_idx < dataplane->instance_count;
+		     ++instance_idx) {
+			struct dataplane_instance *instance =
+				dataplane->instances + instance_idx;
+			struct dp_config *dp_config = instance->dp_config;
+			struct dp_port_counters *pc =
+				ADDR_OF(&dp_config->port_counters) + device_idx;
+			struct counter_storage *storage = ADDR_OF(&pc->storage);
+
+			for (uint32_t xstat_idx = 0;
+			     xstat_idx < device->xstat_count;
+			     ++xstat_idx) {
+				uint32_t counter_id =
+					instance->device_xstat_map[device_idx]
+								  [xstat_idx];
+				*counter_get_address(counter_id, 0, storage) =
+					xstats[xstat_idx].value;
+			}
+		}
+	}
+}
+
 static void *
 stat_thread(void *arg) {
 	struct dataplane *dataplane = (struct dataplane *)arg;
 
-	FILE *log = fopen("stat.log", "w");
-
-	struct rte_eth_xstat_name names[4096];
-	struct rte_eth_xstat xstats0[dataplane->device_count][4096];
-
-	struct rte_eth_stats stats0[dataplane->device_count];
-	for (uint16_t idx = 0; idx < dataplane->device_count; ++idx) {
-		rte_eth_stats_get(
-			dataplane->devices[idx].port_id, &stats0[idx]
-		);
-		rte_eth_xstats_get(
-			dataplane->devices[idx].port_id, xstats0[idx], 4096
-		);
-	}
-
 	while (1) {
-		sleep(1);
-
-		for (uint16_t idx = 0; idx < dataplane->device_count; ++idx) {
-			struct rte_eth_stats stats1;
-			rte_eth_stats_get(
-				dataplane->devices[idx].port_id, &stats1
-			);
-			fprintf(log,
-				"dev %u ib %li ob %li ip %li op %li ie %li oe "
-				"%li\n",
-				idx,
-				(int64_t)(stats1.ibytes - stats0[idx].ibytes),
-				(int64_t)(stats1.obytes - stats0[idx].obytes),
-				(int64_t)(stats1.ipackets - stats0[idx].ipackets
-				),
-				(int64_t)(stats1.opackets - stats0[idx].opackets
-				),
-				(int64_t)(stats1.ierrors - stats0[idx].ierrors),
-				(int64_t)(stats1.oerrors - stats0[idx].oerrors)
-			);
-
-			memcpy(&stats0[idx], &stats1, sizeof(stats1));
-
-			struct rte_eth_xstat xstats1[4096];
-			rte_eth_xstats_get_names(
-				dataplane->devices[idx].port_id, names, 4096
-			);
-			int cnt = rte_eth_xstats_get(
-				dataplane->devices[idx].port_id, xstats1, 4096
-			);
-
-			for (int pth = 0; pth < cnt; ++pth) {
-				fprintf(log,
-					"xstat %u %s %lu\n",
-					idx,
-					names[xstats1[pth].id].name,
-					xstats1[pth].value -
-						xstats0[idx][pth].value);
-			}
-
-			memcpy(&xstats0[idx],
-			       xstats1,
-			       sizeof(struct rte_eth_xstat) * cnt);
-		}
-
-		fflush(log);
+		usleep(1e4);
+		stat_thread_collect_xstat(dataplane);
 	}
 
 	return NULL;

--- a/dataplane/dataplane.h
+++ b/dataplane/dataplane.h
@@ -11,6 +11,7 @@ struct dataplane_device;
 struct dataplane_instance {
 	struct dp_config *dp_config;
 	struct cp_config *cp_config;
+	uint32_t **device_xstat_map;
 };
 
 #define DATAPLANE_MAX_INSTANCES 8

--- a/dataplane/device.h
+++ b/dataplane/device.h
@@ -18,6 +18,7 @@ struct dataplane_device {
 	char port_name[80];
 
 	uint16_t port_id;
+	uint32_t xstat_count;
 };
 
 int

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1684,12 +1684,11 @@ yanet_get_counter_values(
 	}
 }
 
-struct counter_handle_list *
-yanet_get_worker_counters(struct dp_config *dp_config) {
-	struct counter_registry *counter_registry = &dp_config->worker_counters;
-	struct counter_storage *storage =
-		ADDR_OF(&dp_config->worker_counter_storage);
-
+static struct counter_handle_list *
+counter_handle_list_build(
+	struct counter_registry *counter_registry,
+	struct counter_storage *storage
+) {
 	uint64_t count = counter_registry->count;
 	struct counter *names = ADDR_OF(&counter_registry->names);
 
@@ -1715,6 +1714,14 @@ yanet_get_worker_counters(struct dp_config *dp_config) {
 	}
 
 	return list;
+}
+
+struct counter_handle_list *
+yanet_get_worker_counters(struct dp_config *dp_config) {
+	return counter_handle_list_build(
+		&dp_config->worker_counters,
+		ADDR_OF(&dp_config->worker_counter_storage)
+	);
 }
 
 int
@@ -1747,6 +1754,63 @@ yanet_get_worker_counter_metadata(
 	metadata->rx_burst_size = worker->rx_burst_size;
 
 	return 0;
+}
+
+struct port_counter_group_list *
+yanet_get_port_counters(struct dp_config *dp_config) {
+	uint64_t port_count = dp_config->port_count;
+	struct dp_port_counters *port_counters =
+		ADDR_OF(&dp_config->port_counters);
+
+	struct port_counter_group_list *groups =
+		(struct port_counter_group_list *)malloc(
+			sizeof(struct port_counter_group_list) +
+			sizeof(struct port_counter_group) * port_count
+		);
+	if (groups == NULL)
+		return NULL;
+	groups->port_count = port_count;
+
+	for (uint64_t idx = 0; idx < port_count; ++idx) {
+		struct dp_port_counters *pc = port_counters + idx;
+		struct port_counter_group *group = groups->ports + idx;
+
+		group->port_id = pc->port_id;
+		strtcpy(group->port_name,
+			pc->port_name,
+			sizeof(group->port_name));
+		group->counters = counter_handle_list_build(
+			&pc->registry, ADDR_OF(&pc->storage)
+		);
+		if (group->counters == NULL) {
+			groups->port_count = idx;
+			yanet_port_counter_group_list_free(groups);
+			return NULL;
+		}
+	}
+
+	return groups;
+}
+
+struct port_counter_group *
+yanet_get_port_counter_group(
+	struct port_counter_group_list *groups, uint64_t idx
+) {
+	if (groups == NULL || idx >= groups->port_count) {
+		return NULL;
+	}
+	return groups->ports + idx;
+}
+
+void
+yanet_port_counter_group_list_free(struct port_counter_group_list *groups) {
+	if (groups == NULL) {
+		return;
+	}
+	for (uint64_t idx = 0; idx < groups->port_count; ++idx) {
+		yanet_counter_handle_list_free(groups->ports[idx].counters);
+	}
+	free(groups);
 }
 
 void

--- a/lib/dataplane/config/counter_storage.c
+++ b/lib/dataplane/config/counter_storage.c
@@ -33,15 +33,55 @@ dp_counter_storage_init(
 		return -1;
 	}
 
-	SET_OFFSET_OF(
-		&dp_config->worker_counter_storage,
-		counter_storage_spawn(
-			&dp_config->memory_context,
-			&dp_config->counter_storage_allocator,
-			NULL,
-			&dp_config->worker_counters
-		)
+	struct counter_storage *worker_counter_storage = counter_storage_spawn(
+		&dp_config->memory_context,
+		&dp_config->counter_storage_allocator,
+		NULL,
+		&dp_config->worker_counters
 	);
+	if (worker_counter_storage == NULL) {
+		LOG(ERROR, "failed to allocate worker counter storage");
+		return -1;
+	}
+
+	SET_OFFSET_OF(
+		&dp_config->worker_counter_storage, worker_counter_storage
+	);
+
+	counter_storage_allocator_init(
+		&dp_config->port_counter_storage_allocator,
+		&dp_config->memory_context,
+		1
+	);
+
+	struct dp_port_counters *port_counters =
+		ADDR_OF(&dp_config->port_counters);
+	for (uint64_t port_idx = 0; port_idx < dp_config->port_count;
+	     ++port_idx) {
+		struct dp_port_counters *pc = port_counters + port_idx;
+
+		if (counter_registry_link(&pc->registry, NULL, &err)) {
+			LOG(ERROR,
+			    "failed to link port counter registry: %s",
+			    yanet_error_message(err));
+			yanet_error_free(err);
+			return -1;
+		}
+
+		struct counter_storage *port_counter_storage =
+			counter_storage_spawn(
+				&dp_config->memory_context,
+				&dp_config->port_counter_storage_allocator,
+				NULL,
+				&pc->registry
+			);
+		if (port_counter_storage == NULL) {
+			LOG(ERROR, "failed to allocate port counter storage");
+			return -1;
+		}
+
+		SET_OFFSET_OF(&pc->storage, port_counter_storage);
+	}
 
 	return 0;
 }

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -27,6 +27,18 @@ struct dp_device {
 	device_handler output_handler;
 };
 
+// Per-DPDK-port counter registry and storage.
+//
+// Each physical port owns a distinct registry (xstat schema) and storage
+// (values), so a port's counter lifecycle is independent of the others. All
+// port storages are spawned from the single shared allocator on dp_config.
+struct dp_port_counters {
+	uint16_t port_id;
+	char port_name[80];
+	struct counter_registry registry;
+	struct counter_storage *storage;
+};
+
 struct dp_worker {
 	uint64_t idx;
 
@@ -108,6 +120,10 @@ struct dp_config {
 	struct counter_storage_allocator counter_storage_allocator;
 	struct counter_registry worker_counters;
 	struct counter_storage *worker_counter_storage;
+
+	struct counter_storage_allocator port_counter_storage_allocator;
+	uint64_t port_count;
+	struct dp_port_counters *port_counters;
 
 	// Written by dp_config_mark_ready with release ordering after the
 	// dataplane releases cp_config and finishes initialising the instance.


### PR DESCRIPTION
Dataplane has a separate thread aimed to pull DPDK port statistics and store then into shared memory.
The statistics is driver-dependent and copied between instances.