### PR TITLE
fix(counters): widen counter_handle name buffer to match the registry

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -3,6 +3,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "lib/counters/counters.h"
 #include "lib/errors/errors.h"
 
 struct dp_config;
@@ -15,7 +16,7 @@ struct counter_tag {
 };
 
 struct counter_handle {
-	char name[60];
+	char name[COUNTER_NAME_LEN];
 	uint64_t size;
 	uint64_t gen;
 	struct counter_tag *tags;


### PR DESCRIPTION
- Widens counter_handle's name buffer from a hardcoded 60 bytes to COUNTER_NAME_LEN (128), matching the internal counter registry it copies from.
- A 60-byte buffer is too short for load-balancer counter names, which risked silent truncation and name collisions.