### PR TITLE
feat(ttlmap): add incremental bucket iterator

### DIFF
--- a/common/ttlmap/detail/bucket.h
+++ b/common/ttlmap/detail/bucket.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdalign.h>
+
 #include "key_value.h"
 
 #include "../../container_of.h"
@@ -196,11 +198,14 @@ __ttlmap_bucket_count(size_t kv_entries) { // NOLINT
 		__count;                                                       \
 	})
 
-#define __TTLMAP_BUCKET_ITER(                                                  \
+#define __TTLMAP_BUCKET_SCAN_DELIVERED (0b01)
+#define __TTLMAP_BUCKET_SCAN_STOP (0b10)
+
+#define __TTLMAP_BUCKET_SCAN(                                                  \
 	map_ptr, bucket_id, key_type, value_type, now, cb, data                \
 )                                                                              \
 	__extension__({                                                        \
-		int __result = 0;                                              \
+		int __flags = 0;                                               \
 		void *__addr = __TTLMAP_BUCKET_FIND_WITH_ID(                   \
 			map_ptr, bucket_id, key_type, value_type               \
 		);                                                             \
@@ -214,15 +219,48 @@ __ttlmap_bucket_count(size_t kv_entries) { // NOLINT
 		__ttlmap_unlock(&__bucket->lock);                              \
 		for (size_t __i = 0; __i < __TTLMAP_BUCKET_ENTRIES; ++__i) {   \
 			if (__entries_copy[__i].deadline > (now)) {            \
+				__flags |= __TTLMAP_BUCKET_SCAN_DELIVERED;     \
 				if ((cb)(&__entries_copy[__i].key,             \
 					 &__entries_copy[__i].value,           \
 					 (data))) {                            \
-					__result = 1;                          \
+					__flags |= __TTLMAP_BUCKET_SCAN_STOP;  \
 					break;                                 \
 				}                                              \
 			}                                                      \
 		}                                                              \
-		__result;                                                      \
+		__flags;                                                       \
+	})
+
+#define __TTLMAP_BUCKET_ITER(                                                  \
+	map_ptr, bucket_id, key_type, value_type, now, cb, data                \
+)                                                                              \
+	__extension__({                                                        \
+		(__TTLMAP_BUCKET_SCAN(                                         \
+			 map_ptr,                                              \
+			 bucket_id,                                            \
+			 key_type,                                             \
+			 value_type,                                           \
+			 now,                                                  \
+			 cb,                                                   \
+			 data                                                  \
+		 ) &                                                           \
+		 __TTLMAP_BUCKET_SCAN_STOP) != 0;                              \
+	})
+
+#define __TTLMAP_BUCKET_ITER_NEXT(                                             \
+	map_ptr, bucket_id, key_type, value_type, now, cb, data                \
+)                                                                              \
+	__extension__({                                                        \
+		(__TTLMAP_BUCKET_SCAN(                                         \
+			 map_ptr,                                              \
+			 bucket_id,                                            \
+			 key_type,                                             \
+			 value_type,                                           \
+			 now,                                                  \
+			 cb,                                                   \
+			 data                                                  \
+		 ) &                                                           \
+		 __TTLMAP_BUCKET_SCAN_DELIVERED) != 0;                         \
 	})
 
 #define __TTLMAP_BUCKET_PREFETCH(bucket, entry, bucket_size, ...)              \

--- a/common/ttlmap/detail/iter.h
+++ b/common/ttlmap/detail/iter.h
@@ -31,3 +31,38 @@
 		}                                                              \
 		__ret;                                                         \
 	})
+
+////////////////////////////////////////////////////////////////////////////////
+
+/*
+ * Weakly consistent, bucket-at-a-time iteration.
+ *
+ * Each bucket is copied once under lock; the callback key and value pointers
+ * refer to that copy and must not be retained. A callback early-stop advances
+ * past the current bucket, not the whole map. Each call examines exactly one
+ * bucket, so the return value alone does not indicate whether iteration is
+ * exhausted; the caller must check for completion separately.
+ */
+
+#define __TTLMAP_ITER_NEXT_INTERNAL(                                           \
+	iter_ptr, key_type, value_type, now, cb, data                          \
+)                                                                              \
+	__extension__({                                                        \
+		int __ret = 0;                                                 \
+		struct ttlmap_bucket_iter *__iter = (iter_ptr);                \
+		if (__iter != NULL && __iter->map != NULL &&                   \
+		    __iter->bucket_idx < __iter->bucket_count) {               \
+			size_t __bucket_idx = __iter->bucket_idx;              \
+			++__iter->bucket_idx;                                  \
+			__ret = __TTLMAP_BUCKET_ITER_NEXT(                     \
+				__iter->map,                                   \
+				__bucket_idx,                                  \
+				key_type,                                      \
+				value_type,                                    \
+				(now),                                         \
+				(cb),                                          \
+				(data)                                         \
+			);                                                     \
+		}                                                              \
+		__ret;                                                         \
+	})

--- a/common/ttlmap/detail/ttlmap.h
+++ b/common/ttlmap/detail/ttlmap.h
@@ -313,3 +313,5 @@ static inline size_t
 ttlmap_memory_usage(struct ttlmap *map) {
 	return map->mctx.balloc_size - map->mctx.bfree_size;
 }
+
+#define TTLMAP_BUCKET_SIZE __TTLMAP_BUCKET_ENTRIES

--- a/common/ttlmap/ttlmap.h
+++ b/common/ttlmap/ttlmap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 
 #include "common/memory.h"
@@ -11,6 +12,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef struct ttlmap ttlmap_t;
+
+struct ttlmap_bucket_iter {
+	ttlmap_t *map;
+	size_t bucket_idx;
+	size_t bucket_count;
+};
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -40,6 +47,11 @@ typedef struct ttlmap ttlmap_t;
 #define TTLMAP_ITER(map_ptr, key_type, value_type, now, cb, data)              \
 	__TTLMAP_ITER_INTERNAL(map_ptr, key_type, value_type, now, cb, data)
 
+#define TTLMAP_ITER_NEXT(iter_ptr, key_type, value_type, now, cb, data)        \
+	__TTLMAP_ITER_NEXT_INTERNAL(                                           \
+		iter_ptr, key_type, value_type, now, cb, data                  \
+	)
+
 #define TTLMAP_PREFETCH(map_ptr, key_ptr, value_type, ...)                     \
 	__TTLMAP_PREFETCH(map_ptr, key_ptr, value_type, ##__VA_ARGS__)
 
@@ -54,6 +66,30 @@ static inline void
 ttlmap_init_empty(ttlmap_t *map) {
 	memset(map, 0, sizeof(*map));
 	map->buckets_exp = -1;
+}
+
+static inline void
+ttlmap_bucket_iter_init(struct ttlmap_bucket_iter *iter, ttlmap_t *map) {
+	if (iter == NULL) {
+		return;
+	}
+
+	iter->map = map;
+	iter->bucket_idx = 0;
+	iter->bucket_count = 0;
+	if (map == NULL || map->buckets_exp == (size_t)-1) {
+		return;
+	}
+
+	iter->bucket_count = 1ull << map->buckets_exp;
+}
+
+static inline bool
+ttlmap_bucket_iter_done(const struct ttlmap_bucket_iter *iter) {
+	if (iter == NULL) {
+		return true;
+	}
+	return iter->bucket_idx >= iter->bucket_count;
 }
 
 static inline uint64_t

--- a/tests/common/ttlmap_test.c
+++ b/tests/common/ttlmap_test.c
@@ -10,6 +10,8 @@
 #include <assert.h>
 #include <pthread.h>
 #include <stdalign.h>
+#include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
@@ -511,6 +513,336 @@ ttlmap_iter(void *memory, size_t memory_size) {
 	memory_context_fini(&mctx);
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+struct bucket_iter_ctx {
+	ttlmap_t *map;
+	size_t lookup_bucket_id;
+	size_t count;
+	size_t stop_after;
+	bool mutate_copies;
+	bool lookup_same_bucket;
+};
+
+static test_key_t
+bucket_iter_key(size_t key_id) {
+	return (test_key_t){.ip_dst = key_id + 0x01010,
+			    .ip_src = key_id + 0x10101,
+			    .port_dst = 10,
+			    .port_src = 20,
+			    .proto = 55,
+			    .tcp_flags = key_id,
+			    .pad = {0, 0, 0}};
+}
+
+static void
+ttlmap_test_insert_bucket(
+	ttlmap_t *map,
+	size_t bucket_id,
+	size_t key_id,
+	size_t counter1,
+	uint32_t now,
+	uint32_t timeout
+) {
+	void *bucket = __TTLMAP_BUCKET_FIND_WITH_ID(
+		map, bucket_id, test_key_t, test_value_t
+	);
+	test_key_t key = bucket_iter_key(key_id);
+	test_value_t *value;
+	ttlmap_lock_t *lock;
+	int res = __TTLMAP_BUCKET_GET(
+		bucket, &key, &value, &lock, now, timeout, 0
+	);
+	assert(TTLMAP_STATUS(res) == TTLMAP_INSERTED);
+	assert(value != NULL);
+	assert(lock != NULL);
+	*value = (test_value_t
+	){.counter1 = counter1, .counter2 = counter1 + 1, .session_id = 0};
+	ttlmap_release_lock(lock);
+}
+
+static int
+bucket_iter_callback(test_key_t *key, test_value_t *value, void *data) {
+	struct bucket_iter_ctx *ctx = data;
+	assert(key->proto == 55);
+	assert(key->port_dst == 10);
+	assert(key->port_src == 20);
+	assert(value->session_id == 0);
+	assert(value->counter2 - value->counter1 == 1);
+
+	if (ctx->lookup_same_bucket) {
+		void *bucket = __TTLMAP_BUCKET_FIND_WITH_ID(
+			ctx->map,
+			ctx->lookup_bucket_id,
+			test_key_t,
+			test_value_t
+		);
+		test_value_t *lookup_value;
+		ttlmap_lock_t *lock;
+		int res = __TTLMAP_BUCKET_GET(
+			bucket, key, &lookup_value, &lock, (uint32_t)9, 10, 0
+		);
+		assert(TTLMAP_STATUS(res) == TTLMAP_FOUND);
+		assert(lookup_value->counter2 - lookup_value->counter1 == 1);
+		ttlmap_release_lock(lock);
+	}
+
+	++ctx->count;
+	if (ctx->mutate_copies) {
+		key->proto = 0;
+		value->counter1 = 1000;
+		value->counter2 = 1000;
+	}
+	if (ctx->stop_after != 0 && ctx->count >= ctx->stop_after) {
+		return 1;
+	}
+	return 0;
+}
+
+void
+ttlmap_bucket_iter(void *memory, size_t memory_size) {
+	int res;
+	const uint32_t live_now = 9;
+	const uint32_t expired_now = 10;
+
+	struct block_allocator alloc;
+	res = block_allocator_init(&alloc);
+	assert(res == 0);
+	block_allocator_put_arena(&alloc, memory, memory_size);
+
+	struct memory_context mctx;
+	res = memory_context_init(&mctx, "test", &alloc);
+	assert(res == 0);
+
+	ttlmap_t empty_map;
+	ttlmap_init_empty(&empty_map);
+	struct ttlmap_bucket_iter iter;
+	ttlmap_bucket_iter_init(NULL, &empty_map);
+	ttlmap_bucket_iter_init(&iter, &empty_map);
+	assert(ttlmap_bucket_iter_done(&iter));
+	assert(ttlmap_bucket_iter_done(NULL));
+	struct bucket_iter_ctx ctx = {0};
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 0);
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 0);
+	ttlmap_bucket_iter_init(&iter, NULL);
+	assert(ttlmap_bucket_iter_done(&iter));
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 0);
+	assert(TTLMAP_ITER_NEXT(
+		       NULL,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 0);
+
+	ttlmap_t map;
+	res = TTLMAP_INIT(&map, &mctx, test_key_t, test_value_t, 64);
+	assert(res == 0);
+	assert((1ull << map.buckets_exp) == 4);
+
+	ttlmap_test_insert_bucket(&map, 0, 10, 10, 0, 10);
+	ttlmap_test_insert_bucket(&map, 2, 20, 20, 0, 10);
+	ttlmap_test_insert_bucket(&map, 2, 21, 21, 0, 10);
+
+	// Full drain via the done predicate; each call handles one bucket.
+	ctx = (struct bucket_iter_ctx){0};
+	ttlmap_bucket_iter_init(&iter, &map);
+	while (!ttlmap_bucket_iter_done(&iter)) {
+		TTLMAP_ITER_NEXT(
+			&iter,
+			test_key_t,
+			test_value_t,
+			live_now,
+			bucket_iter_callback,
+			&ctx
+		);
+	}
+	assert(ctx.count == 3);
+	assert(iter.bucket_idx == iter.bucket_count);
+	assert(ttlmap_bucket_iter_done(&iter));
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 0);
+	assert(iter.bucket_idx == iter.bucket_count);
+
+	// Everything expired: a single call still touches exactly one bucket
+	// and never walks the whole map looking for something live.
+	ctx = (struct bucket_iter_ctx){0};
+	ttlmap_bucket_iter_init(&iter, &map);
+	size_t prev_idx = iter.bucket_idx;
+	while (!ttlmap_bucket_iter_done(&iter)) {
+		res = TTLMAP_ITER_NEXT(
+			&iter,
+			test_key_t,
+			test_value_t,
+			expired_now,
+			bucket_iter_callback,
+			&ctx
+		);
+		assert(res == 0);
+		assert(iter.bucket_idx == prev_idx + 1);
+		prev_idx = iter.bucket_idx;
+	}
+	assert(ctx.count == 0);
+	assert(iter.bucket_idx == iter.bucket_count);
+
+	// Empty buckets are no longer silently skipped within a call: empty
+	// bucket 1 returns 0 and advances by exactly one bucket.
+	ctx = (struct bucket_iter_ctx){0};
+	ttlmap_bucket_iter_init(&iter, &map);
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 1);
+	assert(ctx.count == 1);
+	assert(iter.bucket_idx == 1);
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 0);
+	assert(ctx.count == 1);
+	assert(iter.bucket_idx == 2);
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 1);
+	assert(ctx.count == 3);
+	assert(iter.bucket_idx == 3);
+
+	// Callback pointers reference a per-bucket copy; mutating them and
+	// doing a same-bucket lookup from inside the callback leaves storage
+	// intact.
+	ctx = (struct bucket_iter_ctx){.map = &map,
+				       .lookup_bucket_id = 2,
+				       .mutate_copies = true,
+				       .lookup_same_bucket = true};
+	ttlmap_bucket_iter_init(&iter, &map);
+	iter.bucket_idx = 2;
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 1);
+	assert(iter.bucket_idx == 3);
+	void *bucket =
+		__TTLMAP_BUCKET_FIND_WITH_ID(&map, 2, test_key_t, test_value_t);
+	test_key_t lookup_key = bucket_iter_key(20);
+	test_value_t *stored_value;
+	ttlmap_lock_t *stored_lock;
+	res = __TTLMAP_BUCKET_GET(
+		bucket,
+		&lookup_key,
+		&stored_value,
+		&stored_lock,
+		live_now,
+		10,
+		0
+	);
+	assert(TTLMAP_STATUS(res) == TTLMAP_FOUND);
+	assert(stored_value->counter1 == 20);
+	assert(stored_value->counter2 == 21);
+	ttlmap_release_lock(stored_lock);
+
+	TTLMAP_FREE(&map);
+
+	// Early stop inside a bucket skips the rest of that bucket, still
+	// reports delivered, and advances by exactly one bucket.
+	res = TTLMAP_INIT(&map, &mctx, test_key_t, test_value_t, 64);
+	assert(res == 0);
+	ttlmap_test_insert_bucket(&map, 1, 100, 100, 0, 10);
+	ttlmap_test_insert_bucket(&map, 1, 101, 101, 0, 10);
+	ttlmap_test_insert_bucket(&map, 3, 300, 300, 0, 10);
+	ctx = (struct bucket_iter_ctx){.stop_after = 1};
+	ttlmap_bucket_iter_init(&iter, &map);
+	iter.bucket_idx = 1;
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 1);
+	assert(ctx.count == 1);
+	assert(iter.bucket_idx == 2);
+	ctx.stop_after = 0;
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 0);
+	assert(ctx.count == 1);
+	assert(iter.bucket_idx == 3);
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 1);
+	assert(ctx.count == 2);
+	assert(iter.bucket_idx == 4);
+	assert(ttlmap_bucket_iter_done(&iter));
+	assert(TTLMAP_ITER_NEXT(
+		       &iter,
+		       test_key_t,
+		       test_value_t,
+		       live_now,
+		       bucket_iter_callback,
+		       &ctx
+	       ) == 0);
+	assert(iter.bucket_idx == 4);
+
+	TTLMAP_FREE(&map);
+	memory_context_fini(&mctx);
+}
+
 int
 main() {
 	log_enable_name("debug");
@@ -557,6 +889,9 @@ main() {
 
 	LOG(INFO, "test ttlmap_iter...");
 	ttlmap_iter(memory, memory_size);
+
+	LOG(INFO, "test ttlmap_bucket_iter...");
+	ttlmap_bucket_iter(memory, memory_size);
 
 	LOG(INFO, "free memory");
 	free(memory);


### PR DESCRIPTION
- Adds a bucket-at-a-time iterator (ttlmap_bucket_iter / TTLMAP_ITER_NEXT) that copies one bucket under lock per call, for callers that need to stream a map's contents across multiple steps instead of holding one long lock over the whole pass.
- Exposes the bucket entry count as a public constant (TTLMAP_BUCKET_SIZE) for callers sizing per-call buffers.