### PR TITLE
refactor(cli): add a shared connection primitive and collapse the service constructors

### DIFF
--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -74,6 +74,30 @@ pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, Connection
     Ok(auth.layer(channel))
 }
 
+/// An established, authenticated channel to one endpoint.
+///
+/// Connect once, then build one [`Service`] per gRPC service over it with
+/// [`Service::new`]. Single-service CLIs skip this and use
+/// [`Service::connect`], which establishes the connection for them.
+pub struct Connection {
+    channel: LayeredChannel,
+    endpoint: String,
+}
+
+impl Connection {
+    /// Establish the authenticated channel to `args.endpoint`.
+    pub async fn connect(args: &ConnectionArgs) -> Result<Self, Error> {
+        let channel = connect(args)
+            .await
+            .map_err(|err| Error::from_connection(err, "connect", &args.endpoint))?;
+
+        Ok(Self {
+            channel,
+            endpoint: args.endpoint.clone(),
+        })
+    }
+}
+
 /// A connected gRPC client bundled with its endpoint and service name.
 ///
 /// Wraps a tonic-generated client together with the endpoint it reached and
@@ -83,8 +107,8 @@ pub async fn connect(args: &ConnectionArgs) -> Result<LayeredChannel, Connection
 /// [`invalid`](Service::invalid) live here once.
 ///
 /// It holds a single client, matching the common one-service CLI. A CLI that
-/// drives several clients over one shared channel keeps them as separate
-/// fields instead.
+/// drives several clients over one shared channel builds each from a shared
+/// [`Connection`] instead.
 pub struct Service<C> {
     client: C,
     endpoint: String,
@@ -92,11 +116,11 @@ pub struct Service<C> {
 }
 
 impl<C> Service<C> {
-    /// Wrap an already-built `client` with its `endpoint` and service `name`.
+    /// Wrap an already-built `client` with a hand-supplied `endpoint` + `name`.
     ///
-    /// Prefer [`Service::connect`], which also establishes the channel. Use
-    /// this only when the channel is built elsewhere.
-    pub fn new(client: C, endpoint: impl Into<String>, name: &'static str) -> Self {
+    /// Internal building block behind [`Service::new`] / [`Service::connect`]
+    /// and the tests; a CLI never wraps a raw client directly.
+    pub(crate) fn from_parts(client: C, endpoint: impl Into<String>, name: &'static str) -> Self {
         Self {
             client,
             endpoint: endpoint.into(),
@@ -104,20 +128,29 @@ impl<C> Service<C> {
         }
     }
 
-    /// Connect to `connection` and build the client via `build`.
+    /// Wrap a `name` service client over an existing [`Connection`].
+    ///
+    /// `build` receives a clone of the connection's channel and returns the
+    /// tonic-generated client (compression and message sizes are configured
+    /// there — they are inherent client methods and cannot be defaulted here).
+    /// A CLI driving several services connects once and calls this per client.
+    pub fn new<F>(connection: &Connection, name: &'static str, build: F) -> Self
+    where
+        F: FnOnce(LayeredChannel) -> C,
+    {
+        Self::from_parts(build(connection.channel.clone()), connection.endpoint.clone(), name)
+    }
+
+    /// Connect to `connection` and wrap a single `name` service.
     ///
     /// `name` is the fully-qualified gRPC service name embedded in error
-    /// messages. `build` receives the layered channel and returns the
-    /// tonic-generated client, configuring compression and message sizes.
+    /// messages. Equivalent to connecting a [`Connection`] and calling
+    /// [`Service::new`]; a CLI driving several services does that itself.
     pub async fn connect<F>(connection: &ConnectionArgs, name: &'static str, build: F) -> Result<Self, Error>
     where
         F: FnOnce(LayeredChannel) -> C,
     {
-        let channel = connect(connection)
-            .await
-            .map_err(|err| Error::from_connection(err, "connect", &connection.endpoint))?;
-
-        Ok(Self::new(build(channel), connection.endpoint.clone(), name))
+        Ok(Self::new(&Connection::connect(connection).await?, name, build))
     }
 
     /// Mutable access to the inner client for issuing RPCs.
@@ -281,7 +314,7 @@ mod test {
 
     #[test]
     fn status_maps_grpc_code() {
-        let service = Service::new((), "grpc://[::1]:8080", "test.Service");
+        let service = Service::from_parts((), "grpc://[::1]:8080", "test.Service");
         let err = (service.status("list"))(Status::not_found("missing"));
 
         assert_eq!(ErrorKind::NotFound, err.kind);
@@ -289,7 +322,7 @@ mod test {
 
     #[test]
     fn invalid_builds_invalid_argument() {
-        let service = Service::new((), "grpc://[::1]:8080", "test.Service");
+        let service = Service::from_parts((), "grpc://[::1]:8080", "test.Service");
         let err = service.invalid("update", "bad input");
 
         assert_eq!(ErrorKind::InvalidArgument, err.kind);
@@ -298,7 +331,7 @@ mod test {
 
     #[test]
     fn endpoint_returns_configured_value() {
-        let service = Service::new((), "grpc://[::1]:8080", "test.Service");
+        let service = Service::from_parts((), "grpc://[::1]:8080", "test.Service");
 
         assert_eq!("grpc://[::1]:8080", service.endpoint());
     }

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -46,17 +46,6 @@ pub enum ModeCmd {
     Delete(DeleteCmd),
 }
 
-impl ModeCmd {
-    pub fn action(&self) -> &'static str {
-        match self {
-            ModeCmd::List => "list functions",
-            ModeCmd::Show(..) => "show function",
-            ModeCmd::Update(..) => "update function",
-            ModeCmd::Delete(..) => "delete function",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Function name.
@@ -99,8 +88,7 @@ pub async fn main() {
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
-    let action = cmd.mode.action();
-    let mut service = FunctionService::new(&cmd.connection, action).await?;
+    let mut service = FunctionService::new(&cmd.connection).await?;
 
     match cmd.mode {
         ModeCmd::List => {
@@ -141,17 +129,15 @@ pub struct FunctionService {
 }
 
 impl FunctionService {
-    pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|err| Error::from_connection(err, action, connection.endpoint.clone()))?;
-        let client = FunctionServiceClient::new(channel)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip);
-
-        Ok(Self {
-            service: Service::new(client, connection.endpoint.clone(), FUNCTION_SERVICE),
+    pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
+        let service = Service::connect(connection, FUNCTION_SERVICE, |channel| {
+            FunctionServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
         })
+        .await?;
+
+        Ok(Self { service })
     }
 
     pub async fn list_functions(&mut self) -> Result<Vec<FunctionId>, Error> {

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -143,17 +143,14 @@ pub struct PipelineService {
 
 impl PipelineService {
     pub async fn new(connection: &ConnectionArgs, action: &'static str) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|err| Error::from_connection(err, action, connection.endpoint.clone()))?;
-        let client = PipelineServiceClient::new(channel)
-            .send_compressed(CompressionEncoding::Gzip)
-            .accept_compressed(CompressionEncoding::Gzip);
-
-        Ok(Self {
-            service: Service::new(client, connection.endpoint.clone(), PIPELINE_SERVICE),
-            action,
+        let service = Service::connect(connection, PIPELINE_SERVICE, |channel| {
+            PipelineServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
         })
+        .await?;
+
+        Ok(Self { service, action })
     }
 
     pub async fn list_pipelines(&mut self) -> Result<Vec<PipelineId>, Error> {

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{Connection, ConnectionArgs, LayeredChannel, Service},
     display::print_table_from_entries,
     errors::Error,
     output::{self, CommonFormat},
@@ -458,27 +458,21 @@ pub struct ACLService {
 
 impl ACLService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
-        let service = Service::new(
-            AclServiceClient::new(channel.clone())
+        let conn = Connection::connect(connection).await?;
+        let service = Service::new(&conn, SERVICE_NAME, |channel| {
+            AclServiceClient::new(channel)
                 .max_decoding_message_size(256 * 1024 * 1024)
                 .max_encoding_message_size(256 * 1024 * 1024)
                 .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip),
-            connection.endpoint.clone(),
-            SERVICE_NAME,
-        );
-        let metrics = Service::new(
+                .accept_compressed(CompressionEncoding::Gzip)
+        });
+        let metrics = Service::new(&conn, SERVICE_NAME, |channel| {
             MetricsServiceClient::new(channel)
                 .max_decoding_message_size(256 * 1024 * 1024)
                 .max_encoding_message_size(256 * 1024 * 1024)
                 .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip),
-            connection.endpoint.clone(),
-            SERVICE_NAME,
-        );
+                .accept_compressed(CompressionEncoding::Gzip)
+        });
 
         Ok(Self { service, metrics })
     }

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -24,7 +24,7 @@ use tabled::{
 };
 use tonic::codec::CompressionEncoding;
 use ync::{
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{Connection, ConnectionArgs, LayeredChannel, Service},
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -215,23 +215,17 @@ pub struct RouteService {
 
 impl RouteService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let channel = ync::client::connect(connection)
-            .await
-            .map_err(|e| Error::from_connection(e, "connect", &connection.endpoint))?;
-        let service = Service::new(
-            RouteServiceClient::new(channel.clone())
+        let conn = Connection::connect(connection).await?;
+        let service = Service::new(&conn, SERVICE_NAME, |channel| {
+            RouteServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip),
-            connection.endpoint.clone(),
-            SERVICE_NAME,
-        );
-        let readiness = Service::new(
+                .accept_compressed(CompressionEncoding::Gzip)
+        });
+        let readiness = Service::new(&conn, READINESS_SERVICE_NAME, |channel| {
             ReadinessServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
-                .accept_compressed(CompressionEncoding::Gzip),
-            connection.endpoint.clone(),
-            READINESS_SERVICE_NAME,
-        );
+                .accept_compressed(CompressionEncoding::Gzip)
+        });
 
         Ok(Self { service, readiness })
     }


### PR DESCRIPTION
- Introduce a shared connection that establishes the channel once and wraps one service per gRPC client, so multi-service CLIs (acl, the route operator) stop hand-rolling the connect boilerplate.
- Make the raw client wrapper internal, leaving one clear entry point per shape: single-service CLIs connect a service directly, multi-service CLIs spawn several from one connection.
- Move the function and pipeline CLIs onto the shared entry point too; request behaviour is unchanged, and their connection-failure errors now report the uniform connect action like every other CLI.
