### PR TITLE
refactor(dataplane): move packet counters from packet_list to packet_front

### DIFF
--- a/common/go/dataplane/packet.go
+++ b/common/go/dataplane/packet.go
@@ -161,7 +161,11 @@ func (packetList *PacketList) First() *Packet {
 }
 
 func (packetList *PacketList) Count() int {
-	return int((*C.struct_packet_list)(packetList).count)
+	count := 0
+	for packet := packetList.First(); packet != nil; packet = packet.Next() {
+		count++
+	}
+	return count
 }
 
 func (packetList *PacketList) Add(packet *Packet) {
@@ -255,14 +259,20 @@ func NewPacketFront(
 
 	if input != nil {
 		packetFront.input = *(*C.struct_packet_list)(input)
+		packetFront.input_count = C.packet_list_count(&packetFront.input)
+		packetFront.input_bytes = C.packet_list_bytes(&packetFront.input)
 	}
 
 	if output != nil {
 		packetFront.output = *(*C.struct_packet_list)(output)
+		packetFront.output_count = C.packet_list_count(&packetFront.output)
+		packetFront.output_bytes = C.packet_list_bytes(&packetFront.output)
 	}
 
 	if drop != nil {
 		packetFront.drop = *(*C.struct_packet_list)(drop)
+		packetFront.drop_count = C.packet_list_count(&packetFront.drop)
+		packetFront.drop_bytes = C.packet_list_bytes(&packetFront.drop)
 	}
 
 	return (*PacketFront)(&packetFront)

--- a/devices/plain/dataplane/dataplane.c
+++ b/devices/plain/dataplane/dataplane.c
@@ -20,7 +20,7 @@ plain_input_handle(
 	(void)dp_worker;
 	(void)device_ectx;
 
-	packet_list_concat(&packet_front->output, &packet_front->input);
+	packet_front_pass(packet_front);
 }
 
 static void
@@ -32,7 +32,7 @@ plain_output_handle(
 	(void)dp_worker;
 	(void)device_ectx;
 
-	packet_list_concat(&packet_front->output, &packet_front->input);
+	packet_front_pass(packet_front);
 }
 
 struct device_plain {

--- a/devices/trafgen/dataplane/dataplane.c
+++ b/devices/trafgen/dataplane/dataplane.c
@@ -101,7 +101,7 @@ trafgen_input_handle(
 
 	// Forward anything that arrived on this device unchanged; a generator
 	// has no real RX, so this is normally empty.
-	packet_list_concat(&packet_front->output, &packet_front->input);
+	packet_front_pass(packet_front);
 
 	if (config->frame_count == 0 || config->rate_pps == 0 ||
 	    config->worker_count == 0) {
@@ -165,7 +165,7 @@ trafgen_output_handle(
 	(void)dp_worker;
 	(void)device_ectx;
 
-	packet_list_concat(&packet_front->output, &packet_front->input);
+	packet_front_pass(packet_front);
 }
 
 struct device *

--- a/devices/vlan/dataplane/dataplane.c
+++ b/devices/vlan/dataplane/dataplane.c
@@ -24,7 +24,7 @@ vlan_input_handle(
 	(void)dp_worker;
 	(void)device_ectx;
 
-	packet_list_concat(&packet_front->output, &packet_front->input);
+	packet_front_pass(packet_front);
 }
 
 static void

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -32,7 +32,7 @@ _Static_assert(
 	"struct packet size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct packet_front) == 160,
+	sizeof(struct packet_front) == 128,
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 1
+#define YANET_MODULE_ABI_VERSION 2
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/module/packet_front.h
+++ b/lib/dataplane/module/packet_front.h
@@ -12,6 +12,12 @@
  *
  * RX and TX are considered as separated stages of packet processing working
  * before and after pipeline processing.
+ *
+ * The count/byte counters for the input, output and drop lists live here
+ * rather than on the packet lists themselves: they reflect the role a list
+ * plays in the front. The input counters are a snapshot taken when output is
+ * switched into input; output and drop counters accumulate as packets are
+ * emitted. The pending lists are not counted.
  */
 struct packet_front {
 	struct packet_list pending_input;
@@ -20,6 +26,15 @@ struct packet_front {
 	struct packet_list input;
 	struct packet_list output;
 	struct packet_list drop;
+
+	uint64_t input_count;
+	uint64_t input_bytes;
+
+	uint64_t output_count;
+	uint64_t output_bytes;
+
+	uint64_t drop_count;
+	uint64_t drop_bytes;
 };
 
 static inline void
@@ -29,6 +44,13 @@ packet_front_init(struct packet_front *packet_front) {
 	packet_list_init(&packet_front->input);
 	packet_list_init(&packet_front->output);
 	packet_list_init(&packet_front->drop);
+
+	packet_front->input_count = 0;
+	packet_front->input_bytes = 0;
+	packet_front->output_count = 0;
+	packet_front->output_bytes = 0;
+	packet_front->drop_count = 0;
+	packet_front->drop_bytes = 0;
 }
 
 static inline void
@@ -37,24 +59,107 @@ packet_front_merge(struct packet_front *dst, struct packet_front *src) {
 	packet_list_concat(&dst->drop, &src->drop);
 	packet_list_concat(&dst->pending_input, &src->pending_input);
 	packet_list_concat(&dst->pending_output, &src->pending_output);
+
+	dst->output_count += src->output_count;
+	dst->output_bytes += src->output_bytes;
+	dst->drop_count += src->drop_count;
+	dst->drop_bytes += src->drop_bytes;
 }
 
 static inline void
 packet_front_output(struct packet_front *packet_front, struct packet *packet) {
 	packet_list_add(&packet_front->output, packet);
+	packet_front->output_count += 1;
+	packet_front->output_bytes += packet->data_len;
 }
 
 static inline void
 packet_front_drop(struct packet_front *packet_front, struct packet *packet) {
 	packet_list_add(&packet_front->drop, packet);
+	packet_front->drop_count += 1;
+	packet_front->drop_bytes += packet->data_len;
 }
 
 static inline void
 packet_front_switch(struct packet_front *packet_front) {
 	packet_list_concat(&packet_front->input, &packet_front->output);
+
+	packet_front->input_count = packet_front->output_count;
+	packet_front->input_bytes = packet_front->output_bytes;
+	packet_front->output_count = 0;
+	packet_front->output_bytes = 0;
 }
 
 static inline void
 packet_front_pass(struct packet_front *packet_front) {
 	packet_list_concat(&packet_front->output, &packet_front->input);
+
+	packet_front->output_count += packet_front->input_count;
+	packet_front->output_bytes += packet_front->input_bytes;
+	packet_front->input_count = 0;
+	packet_front->input_bytes = 0;
+}
+
+// Move the whole output list of src into dst, transferring the output
+// counters.
+//
+// Used by the single-chain and single-pipeline fast paths that schedule a
+// front on a fresh packet_front; dst->output is empty on entry, so its first
+// packet_front_switch reads the transferred counters.
+static inline void
+packet_front_take_output(struct packet_front *dst, struct packet_front *src) {
+	packet_list_concat(&dst->output, &src->output);
+
+	dst->output_count = src->output_count;
+	dst->output_bytes = src->output_bytes;
+	src->output_count = 0;
+	src->output_bytes = 0;
+}
+
+// Move the whole output list into the drop list, transferring the counters.
+//
+// Used by drain paths that discard unroutable output.
+static inline void
+packet_front_drop_output(struct packet_front *packet_front) {
+	packet_list_concat(&packet_front->drop, &packet_front->output);
+
+	packet_front->drop_count += packet_front->output_count;
+	packet_front->drop_bytes += packet_front->output_bytes;
+	packet_front->output_count = 0;
+	packet_front->output_bytes = 0;
+}
+
+static inline struct packet_list *
+packet_front_input(struct packet_front *packet_front) {
+	return &packet_front->input;
+}
+
+static inline uint64_t
+packet_front_input_count(struct packet_front *packet_front) {
+	return packet_front->input_count;
+}
+
+static inline uint64_t
+packet_front_input_bytes(struct packet_front *packet_front) {
+	return packet_front->input_bytes;
+}
+
+static inline uint64_t
+packet_front_output_count(struct packet_front *packet_front) {
+	return packet_front->output_count;
+}
+
+static inline uint64_t
+packet_front_output_bytes(struct packet_front *packet_front) {
+	return packet_front->output_bytes;
+}
+
+static inline uint64_t
+packet_front_drop_count(struct packet_front *packet_front) {
+	return packet_front->drop_count;
+}
+
+static inline uint64_t
+packet_front_drop_bytes(struct packet_front *packet_front) {
+	return packet_front->drop_bytes;
 }

--- a/lib/dataplane/packet/data.h
+++ b/lib/dataplane/packet/data.h
@@ -35,10 +35,10 @@ packet_data_offset(struct packet *packet) {
 
 // Refresh the cached first-segment length after the mbuf was resized.
 //
-// Call this only while the packet is not linked in a metered packet_list
-// (between a pop and the next add): packet_list.bytes is kept in sync
-// incrementally from data_len, so refreshing it in place inside a list
-// would desync that list's cached byte sum.
+// Call this only while the packet is not linked in a counted packet_front
+// list (between a pop and the next counted add): packet_front byte sums are
+// kept in sync incrementally from data_len, so refreshing it in place after
+// the packet has been counted would desync that front's cached byte sum.
 static inline void
 packet_refresh_data_len(struct packet *packet) {
 	packet->data_len = rte_pktmbuf_data_len(packet_to_mbuf(packet));

--- a/lib/dataplane/packet/packet.h
+++ b/lib/dataplane/packet/packet.h
@@ -46,7 +46,7 @@ struct packet {
 
 	uint16_t fragment_offset;
 
-	// Cached first-segment byte length; mirrors the mbuf so packet_list
+	// Cached first-segment byte length; mirrors the mbuf so packet_front
 	// can sum bytes without touching DPDK.
 	uint16_t data_len;
 
@@ -57,16 +57,12 @@ struct packet {
 struct packet_list {
 	struct packet *first;
 	struct packet **last;
-	uint64_t count;
-	uint64_t bytes;
 };
 
 static inline void
 packet_list_init(struct packet_list *list) {
 	list->first = NULL;
 	list->last = &list->first;
-	list->count = 0;
-	list->bytes = 0;
 }
 
 static inline void
@@ -74,8 +70,6 @@ packet_list_add(struct packet_list *list, struct packet *packet) {
 	*list->last = packet;
 	packet->next = NULL;
 	list->last = &packet->next;
-	list->count += 1;
-	list->bytes += packet->data_len;
 }
 
 static inline struct packet *
@@ -99,8 +93,6 @@ packet_list_concat(struct packet_list *dst, struct packet_list *src) {
 
 	*dst->last = packet_list_first(src);
 	dst->last = src->last;
-	dst->count += src->count;
-	dst->bytes += src->bytes;
 
 	packet_list_init(src);
 }
@@ -114,22 +106,31 @@ packet_list_pop(struct packet_list *packets) {
 	packets->first = res->next;
 	if (packets->first == NULL)
 		packets->last = &packets->first;
-	packets->count -= 1;
-	packets->bytes -= res->data_len;
 
 	return res;
 }
 
 static inline uint64_t
 packet_list_count(struct packet_list *packets) {
-	return packets->count;
+	uint64_t count = 0;
+	for (struct packet *pkt = packets->first; pkt != NULL;
+	     pkt = pkt->next) {
+		count += 1;
+	}
+	return count;
 }
 
 static inline uint64_t
-packet_list_bytes_sum(struct packet_list *list) {
-	return list->bytes;
-}
+packet_list_bytes(struct packet_list *packets) {
+	uint64_t bytes = 0;
 
+	for (struct packet *pkt = packets->first; pkt != NULL;
+	     pkt = pkt->next) {
+		bytes += pkt->data_len;
+	}
+
+	return bytes;
+}
 int
 parse_ipv4_header(struct packet *packet, uint16_t *type, uint16_t *offset);
 

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -46,7 +46,7 @@ module_ectx_process(
 	struct packet_front *packet_front
 
 ) {
-	const size_t packets_count = packet_front->input.count;
+	const size_t packets_count = packet_front_input_count(packet_front);
 
 	for (struct packet *packet = packet_front->input.first; packet != NULL;
 	     packet = packet->next) {
@@ -58,8 +58,7 @@ module_ectx_process(
 	struct counter_storage *storage =
 		ADDR_OF(&module_ectx->counter_storage);
 
-	const uint64_t input_bytes =
-		packet_list_bytes_sum(&packet_front->input);
+	const uint64_t input_bytes = packet_front_input_bytes(packet_front);
 	counter_add_packets_bytes(
 		module_ectx->rx_counter_id,
 		module_ectx->rx_bytes_counter_id,
@@ -101,8 +100,8 @@ module_ectx_process(
 		module_ectx->tx_bytes_counter_id,
 		dp_worker->idx,
 		storage,
-		packet_front->output.count,
-		packet_list_bytes_sum(&packet_front->output)
+		packet_front_output_count(packet_front),
+		packet_front_output_bytes(packet_front)
 	);
 }
 
@@ -112,7 +111,7 @@ chain_ectx_process(
 	struct chain_ectx *chain_ectx,
 	struct packet_front *packet_front
 ) {
-	uint64_t input_size = packet_list_count(&packet_front->input);
+	uint64_t input_size = packet_front_input_count(packet_front);
 
 	uint64_t tsc_start = rte_rdtsc();
 
@@ -153,7 +152,7 @@ function_ectx_run_single_chain(
 ) {
 	struct packet_front schedule;
 	packet_front_init(&schedule);
-	packet_list_concat(&schedule.output, &packet_front->output);
+	packet_front_take_output(&schedule, packet_front);
 
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
 	chain_ectx_process(dp_worker, ADDR_OF(chains), &schedule);
@@ -184,6 +183,8 @@ function_ectx_run_chains(
 		packet_front_output(schedule + chain_idx, packet);
 		packet = packet_list_pop(&packet_front->output);
 	}
+	packet_front->output_count = 0;
+	packet_front->output_bytes = 0;
 
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
@@ -207,7 +208,7 @@ function_ectx_drain(
 	struct function_ectx *function_ectx,
 	struct packet_front *packet_front
 ) {
-	packet_list_concat(&packet_front->drop, &packet_front->output);
+	packet_front_drop_output(packet_front);
 
 	function_ectx_run_chains(dp_worker, function_ectx, packet_front);
 }
@@ -226,8 +227,8 @@ function_ectx_process(
 		function_ectx->counter_packet_in_bytes,
 		dp_worker->idx,
 		storage,
-		packet_front->output.count,
-		packet_list_bytes_sum(&packet_front->output)
+		packet_front_output_count(packet_front),
+		packet_front_output_bytes(packet_front)
 	);
 
 	if (function_ectx->chain_map_size == 0) {
@@ -247,16 +248,16 @@ function_ectx_process(
 		function_ectx->counter_packet_out_bytes,
 		dp_worker->idx,
 		storage,
-		packet_front->output.count,
-		packet_list_bytes_sum(&packet_front->output)
+		packet_front_output_count(packet_front),
+		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
 		function_ectx->counter_packet_drop_count,
 		function_ectx->counter_packet_drop_bytes,
 		dp_worker->idx,
 		storage,
-		packet_front->drop.count,
-		packet_list_bytes_sum(&packet_front->drop)
+		packet_front_drop_count(packet_front),
+		packet_front_drop_bytes(packet_front)
 	);
 }
 
@@ -275,8 +276,8 @@ pipeline_ectx_process(
 		pipeline_ectx->counter_packet_in_bytes,
 		dp_worker->idx,
 		storage,
-		packet_front->output.count,
-		packet_list_bytes_sum(&packet_front->output)
+		packet_front_output_count(packet_front),
+		packet_front_output_bytes(packet_front)
 	);
 
 	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
@@ -291,16 +292,16 @@ pipeline_ectx_process(
 		pipeline_ectx->counter_packet_out_bytes,
 		dp_worker->idx,
 		storage,
-		packet_front->output.count,
-		packet_list_bytes_sum(&packet_front->output)
+		packet_front_output_count(packet_front),
+		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
 		pipeline_ectx->counter_packet_drop_count,
 		pipeline_ectx->counter_packet_drop_bytes,
 		dp_worker->idx,
 		storage,
-		packet_front->drop.count,
-		packet_list_bytes_sum(&packet_front->drop)
+		packet_front_drop_count(packet_front),
+		packet_front_drop_bytes(packet_front)
 	);
 }
 
@@ -331,7 +332,7 @@ device_entry_ectx_dispatch_single(
 ) {
 	struct packet_front schedule;
 	packet_front_init(&schedule);
-	packet_list_concat(&schedule.output, &packet_front->output);
+	packet_front_take_output(&schedule, packet_front);
 
 	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
 	pipeline_ectx_process(dp_worker, ADDR_OF(pipelines), &schedule);
@@ -365,6 +366,8 @@ device_entry_ectx_dispatch_many(
 
 		packet = packet_list_pop(&packet_front->output);
 	}
+	packet_front->output_count = 0;
+	packet_front->output_bytes = 0;
 
 	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
 	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
@@ -391,7 +394,7 @@ device_entry_ectx_drain(
 	struct device_entry_ectx *entry_ectx,
 	struct packet_front *packet_front
 ) {
-	packet_list_concat(&packet_front->drop, &packet_front->output);
+	packet_front_drop_output(packet_front);
 
 	if (entry_ectx->pipeline_count > 0) {
 		device_entry_ectx_dispatch_many(
@@ -438,8 +441,8 @@ device_ectx_process_input(
 		device_ectx->counter_packet_rx_bytes,
 		dp_worker->idx,
 		ADDR_OF(&device_ectx->counter_storage),
-		packet_list_count(&packet_front->output),
-		packet_list_bytes_sum(&packet_front->output)
+		packet_front_output_count(packet_front),
+		packet_front_output_bytes(packet_front)
 	);
 
 	device_entry_ectx_dispatch(dp_worker, entry_ectx, packet_front);
@@ -463,8 +466,8 @@ device_ectx_process_output(
 		device_ectx->counter_packet_tx_bytes,
 		dp_worker->idx,
 		ADDR_OF(&device_ectx->counter_storage),
-		packet_list_count(&packet_front->output),
-		packet_list_bytes_sum(&packet_front->output)
+		packet_front_output_count(packet_front),
+		packet_front_output_bytes(packet_front)
 	);
 
 	device_entry_ectx_dispatch(dp_worker, entry_ectx, packet_front);

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -442,11 +442,11 @@ dataplane_ut_run_rounds(
 	uint64_t rounds,
 	int reset_payload
 ) {
-	if (rounds == 0 || input->count == 0) {
+	size_t count = (size_t)packet_list_count(input);
+	if (rounds == 0 || count == 0) {
 		return;
 	}
 
-	size_t count = (size_t)input->count;
 	struct saved_packet *saved =
 		malloc(count * sizeof(struct saved_packet));
 	if (saved == NULL) {

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -117,7 +117,7 @@ dataplane_ut_build_optimized(void);
 // without payload reset.
 //
 // Returns immediately (leaving input intact) when rounds == 0 or
-// input->count == 0. Returns immediately on malloc failure.
+// input is empty. Returns immediately on malloc failure.
 //
 // Caveat: this primitive assumes each round's handlers only forward or drop the
 // fixed packet set. A handler that allocates, frees, or replicates packets per

--- a/lib/fuzzing/fuzzing.h
+++ b/lib/fuzzing/fuzzing.h
@@ -155,10 +155,14 @@ fuzzing_process_packet(
 	memset(packet, 0, sizeof(struct packet));
 	packet->mbuf = mbuf;
 
-	// Create packet front and add packet to input list
+	// Create packet front and hand the packet to input the way the
+	// pipeline does: emit to output, then switch it into input so the
+	// input counters modules read for VLA sizing are populated.
 	struct packet_front pf;
 	packet_front_init(&pf);
-	packet_list_add(&pf.input, packet);
+	packet->data_len = packet_data_len(packet);
+	packet_front_output(&pf, packet);
+	packet_front_switch(&pf);
 
 	// Parse packet
 	if (parse_packet(packet)) {

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -130,26 +130,24 @@ acl_handle_packets(
 	 * For the second option we have to split v4 and v6 processing.
 	 */
 
-	struct packet *vlan_packets[packet_list_count(&packet_front->input)];
-	uint32_t vlan_result[packet_list_count(&packet_front->input)];
+	struct packet *vlan_packets[packet_front_input_count(packet_front)];
+	uint32_t vlan_result[packet_front_input_count(packet_front)];
 	uint64_t vlan_idx = 0;
 
-	struct packet *ip4_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip4_result[packet_list_count(&packet_front->input)];
+	struct packet *ip4_packets[packet_front_input_count(packet_front)];
+	uint32_t ip4_result[packet_front_input_count(packet_front)];
 	uint64_t ip4_idx = 0;
 
-	struct packet
-		*ip4_port_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip4_port_result[packet_list_count(&packet_front->input)];
+	struct packet *ip4_port_packets[packet_front_input_count(packet_front)];
+	uint32_t ip4_port_result[packet_front_input_count(packet_front)];
 	uint64_t ip4_port_idx = 0;
 
-	struct packet *ip6_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip6_result[packet_list_count(&packet_front->input)];
+	struct packet *ip6_packets[packet_front_input_count(packet_front)];
+	uint32_t ip6_result[packet_front_input_count(packet_front)];
 	uint64_t ip6_idx = 0;
 
-	struct packet
-		*ip6_port_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip6_port_result[packet_list_count(&packet_front->input)];
+	struct packet *ip6_port_packets[packet_front_input_count(packet_front)];
+	uint32_t ip6_port_result[packet_front_input_count(packet_front)];
 	uint64_t ip6_port_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);

--- a/modules/dscp/dataplane/dataplane.c
+++ b/modules/dscp/dataplane/dataplane.c
@@ -74,7 +74,7 @@ dscp_handle_packets(
 		while ((packet = packet_list_pop(&packet_front->input)) != NULL
 		) {
 			dscp_handle(dscp_config, packet);
-			packet_list_add(&packet_front->output, packet);
+			packet_front_output(packet_front, packet);
 		}
 	} else {
 		packet_front_pass(packet_front);

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -31,16 +31,16 @@ forward_handle_packets(
 		cp_module
 	);
 
-	struct packet *vlan_packets[packet_list_count(&packet_front->input)];
-	uint32_t vlan_result[packet_list_count(&packet_front->input)];
+	struct packet *vlan_packets[packet_front_input_count(packet_front)];
+	uint32_t vlan_result[packet_front_input_count(packet_front)];
 	uint64_t vlan_idx = 0;
 
-	struct packet *ip4_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip4_result[packet_list_count(&packet_front->input)];
+	struct packet *ip4_packets[packet_front_input_count(packet_front)];
+	uint32_t ip4_result[packet_front_input_count(packet_front)];
 	uint64_t ip4_idx = 0;
 
-	struct packet *ip6_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip6_result[packet_list_count(&packet_front->input)];
+	struct packet *ip6_packets[packet_front_input_count(packet_front)];
+	uint32_t ip6_result[packet_front_input_count(packet_front)];
 	uint64_t ip6_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);

--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -47,16 +47,16 @@ mirror_handle_packets(
 		cp_module
 	);
 
-	struct packet *vlan_packets[packet_list_count(&packet_front->input)];
-	uint32_t vlan_result[packet_list_count(&packet_front->input)];
+	struct packet *vlan_packets[packet_front_input_count(packet_front)];
+	uint32_t vlan_result[packet_front_input_count(packet_front)];
 	uint64_t vlan_idx = 0;
 
-	struct packet *ip4_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip4_result[packet_list_count(&packet_front->input)];
+	struct packet *ip4_packets[packet_front_input_count(packet_front)];
+	uint32_t ip4_result[packet_front_input_count(packet_front)];
 	uint64_t ip4_idx = 0;
 
-	struct packet *ip6_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip6_result[packet_list_count(&packet_front->input)];
+	struct packet *ip6_packets[packet_front_input_count(packet_front)];
+	uint32_t ip6_result[packet_front_input_count(packet_front)];
 	uint64_t ip6_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);

--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -42,12 +42,12 @@ route_mpls_handle_packets(
 		cp_module
 	);
 
-	struct packet *ip4_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip4_result[packet_list_count(&packet_front->input)];
+	struct packet *ip4_packets[packet_front_input_count(packet_front)];
+	uint32_t ip4_result[packet_front_input_count(packet_front)];
 	uint64_t ip4_idx = 0;
 
-	struct packet *ip6_packets[packet_list_count(&packet_front->input)];
-	uint32_t ip6_result[packet_list_count(&packet_front->input)];
+	struct packet *ip6_packets[packet_front_input_count(packet_front)];
+	uint32_t ip6_result[packet_front_input_count(packet_front)];
 	uint64_t ip6_idx = 0;
 
 	for (struct packet *packet = packet_list_first(&packet_front->input);


### PR DESCRIPTION
The count and byte accounting is a property of the role a list plays in a packet front rather than of the intrusive list itself. Make packet_list a bare list and let packet_front own the input, output and drop counters: input counters are a snapshot taken on switch, output and drop counters accumulate as packets are emitted, and wholesale list moves transfer them as one step. The demux and drain hot loops no longer do per-packet accounting.