### PR TITLE
feat(route): use global_id to identify BGP routes

### DIFF
--- a/operators/bird-adapter/internal/bird/parser_test.go
+++ b/operators/bird-adapter/internal/bird/parser_test.go
@@ -16,7 +16,7 @@ import (
 // but the old parser code was incorrectly subtracting 4 from it again.
 func TestParserNext(t *testing.T) {
 	// Use existing test data from update_test.go
-	// This data is 64 bytes (update struct without the chunk size prefix)
+	// This data is 68 bytes (update struct without the chunk size prefix)
 	updateData := []byte{
 		// NetAddrUnion 40 bytes
 		0: 0x2,     // NetAddr type NetIP6
@@ -30,8 +30,10 @@ func TestParserNext(t *testing.T) {
 		40: 0x1, 0, 0, 0,
 		// peer addr
 		44: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		// global_id LE u32 == 0
+		60: 0, 0, 0, 0,
 		// attrsAreaSize EXCLUDING sizeof(attrsAreaSize) - 0x0 => no attributes
-		60: 0x0, 0, 0, 0x0,
+		64: 0x0, 0, 0, 0x0,
 	}
 
 	// BIRD protocol: chunk size EXCLUDES the 4-byte size field itself

--- a/operators/bird-adapter/internal/bird/update.go
+++ b/operators/bird-adapter/internal/bird/update.go
@@ -188,6 +188,7 @@ type update struct {
 	baseTail      [sizeOfBaseTypeTail]byte // NetAddrUnion data
 	opType        Operation
 	peerAddr      IP6Addr
+	globalID      uint32
 	attrsAreaSize uint32
 }
 
@@ -241,6 +242,7 @@ func (m *updateDecoder) Decode(route *rib.Route) error {
 			m.update.base.String(), m.update.base.length, sizeOfNetAddrUnion, ErrUnknownAddrUnion)
 	}
 	route.Peer = netipAddrFrom4U32(m.update.peerAddr)
+	route.GlobalID = m.update.globalID
 	route.ToRemove = m.update.opType.isRemove()
 
 	if err := m.decodePrefixAndRD(route); err != nil {

--- a/operators/bird-adapter/internal/bird/update.go
+++ b/operators/bird-adapter/internal/bird/update.go
@@ -39,6 +39,7 @@ const (
 	AttrLocalPref     AttributeType = 0x05 /* WD */
 	AttrMultiExitDisc AttributeType = 0x04 /* ON */
 	AttrOriginatorID  AttributeType = 0x09 /* RFC 4456 */ /* ON */
+	AttrIfindex       AttributeType = 0x12 /* yanet: egress interface index (u32) */
 
 	AttrASPath         AttributeType = 0x02 /* WM */
 	AttrNextHop        AttributeType = 0x03 /* WM */
@@ -54,7 +55,7 @@ const (
 	// AtomicAggr     AttributeType = 0x06 /* WD */
 	// Aggregator     AttributeType = 0x07 /* OT */
 	// AS4Path        AttributeType = 0x11 /* RFC 6793 */
-	// AS4Aggregator  AttributeType = 0x12 /* RFC 6793 */
+	// 0x12 was AS4Aggregator (RFC 6793); reused by AttrIfindex above.
 	// AIGP           AttributeType = 0x1a /* RFC 7311 */
 	// OnlyToCustomer AttributeType = 0x23 /* RFC 9234 */
 
@@ -91,6 +92,8 @@ func (m AttributeType) String() string {
 		return "MED"
 	case AttrOriginatorID:
 		return "ORIGINATOR_ID"
+	case AttrIfindex:
+		return "IFINDEX"
 	case AttrASPath:
 		return "AS_PATH"
 	case AttrNextHop:
@@ -120,6 +123,7 @@ func (m AttributeType) isU32Attribute() bool {
 	case AttrOriginatorID:
 	case AttrLocalPref:
 	case AttrMultiExitDisc:
+	case AttrIfindex:
 	default:
 		return false
 	}
@@ -331,6 +335,8 @@ func (m *updateDecoder) decodeAttributes(route *rib.Route) error {
 				route.Pref = val
 			case AttrMultiExitDisc:
 				route.Med = val
+			case AttrIfindex:
+				route.Ifindex = val
 			}
 		} else {
 			attrSize = binary.LittleEndian.Uint32(data)

--- a/operators/bird-adapter/internal/bird/update.go
+++ b/operators/bird-adapter/internal/bird/update.go
@@ -35,22 +35,22 @@ const (
 	//NetMAX     = 11
 
 	// yabird/proto/export/export.c#L94
-	AttrOrigin        AttributeType = 0x01 /* RFC 4271 */ /* WM */
-	AttrLocalPref     AttributeType = 0x05 /* WD */
-	AttrMultiExitDisc AttributeType = 0x04 /* ON */
-	AttrOriginatorID  AttributeType = 0x09 /* RFC 4456 */ /* ON */
-	AttrIfindex       AttributeType = 0x12 /* yanet: egress interface index (u32) */
+	AttrOrigin        AttributeType = 0x0401 /* RFC 4271 */ /* WM */
+	AttrLocalPref     AttributeType = 0x0405 /* WD */
+	AttrMultiExitDisc AttributeType = 0x0404 /* ON */
+	AttrOriginatorID  AttributeType = 0x0409 /* RFC 4456 */ /* ON */
+	AttrIfindex       AttributeType = 0x1200 /* yanet: egress interface index (u32) */
 
-	AttrASPath         AttributeType = 0x02 /* WM */
-	AttrNextHop        AttributeType = 0x03 /* WM */
-	AttrCommunity      AttributeType = 0x08 /* RFC 1997 */ /* OT */
-	AttrExtCommunity   AttributeType = 0x10 /* RFC 4360 */
-	AttrLargeCommunity AttributeType = 0x20 /* RFC 8092 */
-	AttrMPLSLabelStack AttributeType = 0xfe /* MPLS label stack transfer attribute */
-	AttrClusterList    AttributeType = 0x0a /* RFC 4456 */ /* ON */
+	AttrASPath         AttributeType = 0x0402 /* WM */
+	AttrNextHop        AttributeType = 0x0403 /* WM */
+	AttrCommunity      AttributeType = 0x0408 /* RFC 1997 */ /* OT */
+	AttrExtCommunity   AttributeType = 0x0410 /* RFC 4360 */
+	AttrLargeCommunity AttributeType = 0x0420 /* RFC 8092 */
+	AttrMPLSLabelStack AttributeType = 0x04fe /* MPLS label stack transfer attribute */
+	AttrClusterList    AttributeType = 0x040a /* RFC 4456 */ /* ON */
 
-	AttrMPReachNLRI   AttributeType = 0x0e /* RFC 4760 */
-	AttrMPUnreachNLRI AttributeType = 0x0f /* RFC 4760 */
+	AttrMPReachNLRI   AttributeType = 0x040e /* RFC 4760 */
+	AttrMPUnreachNLRI AttributeType = 0x040f /* RFC 4760 */
 
 	// AtomicAggr     AttributeType = 0x06 /* WD */
 	// Aggregator     AttributeType = 0x07 /* OT */
@@ -80,7 +80,7 @@ var (
 	ErrUnsupportedRDType = errors.New("ErrUnsupportedRDType")
 )
 
-type AttributeType uint8
+type AttributeType uint16
 
 func (m AttributeType) String() string {
 	switch m {
@@ -113,7 +113,7 @@ func (m AttributeType) String() string {
 	case AttrMPUnreachNLRI:
 		return "MP_UNREACH_NLRI"
 	default:
-		return fmt.Sprintf("UNKNOWN: %x", uint8(m))
+		return fmt.Sprintf("UNKNOWN: %x", uint16(m))
 	}
 }
 
@@ -298,7 +298,7 @@ func (m *updateDecoder) decodePrefixAndRD(route *rib.Route) error {
 }
 
 func ExtendedAttributeID(attributeID uint32) AttributeType {
-	return AttributeType(attributeID & 0xff)
+	return AttributeType(attributeID & 0xffff)
 }
 
 func (m *updateDecoder) decodeAttributes(route *rib.Route) error {

--- a/operators/bird-adapter/internal/bird/update_test.go
+++ b/operators/bird-adapter/internal/bird/update_test.go
@@ -44,56 +44,58 @@ var dataIPv6WithLargeCommunities = []byte{
 	40: 0x1, 0, 0, 0,
 	//  peer addr 16 bytes as 4 LE u32
 	44: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x1, 0, 0, 0,
+	// global_id 4 bytes LE u32 == 0x2a == 42
+	60: 0x2a, 0, 0, 0,
 	// attrsAreaSize 4 bytes LE u32 - 0x76 == 118 (EXCLUDING the 4-byte size field itself)
-	60: 0x76, 0, 0, 0,
+	64: 0x76, 0, 0, 0,
 
 	// attributes
-	// AttrOrigin 0x01 - first byte;  65: PROTOCOL_BGP = 0x4, 0, 0 - packed LE int
-	64: 0x1, 65: 0x4, 0, 0,
+	// AttrOrigin 0x01 - first byte;  69: PROTOCOL_BGP = 0x4, 0, 0 - packed LE int
+	68: 0x1, 69: 0x4, 0, 0,
 	// value of the AttrOrigin - LE u32
-	68: 0x2, 0, 0, 0,
+	72: 0x2, 0, 0, 0,
 
 	//  AttrASPath = 0x2 : PROTOCOL_BGP = 0x4, 0, 0
-	72: 0x2, 0x4, 0, 0,
+	76: 0x2, 0x4, 0, 0,
 	//  Complex attribute length LE u32 0xe == 14
-	76: 0xe, 0, 0, 0,
-	// Segment Type 0x2 = ASPathSequence; 81: Segment Size 0x3 = 3 AS
-	80: 0x2, 81: 0x3,
+	80: 0xe, 0, 0, 0,
+	// Segment Type 0x2 = ASPathSequence; 85: Segment Size 0x3 = 3 AS
+	84: 0x2, 85: 0x3,
 	// AS#3 - PeerAS LE u32 - 0x0000c7fa = 51194 - nearest to us
-	82: 0, 0, 0xc7, 0xf1,
+	86: 0, 0, 0xc7, 0xf1,
 	// AS#2 - next after origin AS = 0x00001d4c = 7500
-	86: 0, 0, 0x1d, 0x4c,
+	90: 0, 0, 0x1d, 0x4c,
 	// AS#1 - OriginAS = 0x00005c52 = 23634
-	90: 0, 0, 0x5c, 0x52,
+	94: 0, 0, 0x5c, 0x52,
 
 	// AttrNextHop 0x3; PROTOCOL_BGP
-	94: 0x3, 0x4, 0, 0,
+	98: 0x3, 0x4, 0, 0,
 	// Complex attribute length LE u32 0x10 == 16 - one ipv6 addr
-	98: 0x10, 0, 0, 0,
+	102: 0x10, 0, 0, 0,
 	//  NextHop addr 16 bytes as 4 LE u32 == "2a02:2891:9:200::13"
-	102: 0x91, 0x28, 0x2, 0x2a, 0, 0x2, 0x9, 0, 0, 0, 0, 0, 0x13, 0, 0, 0,
+	106: 0x91, 0x28, 0x2, 0x2a, 0, 0x2, 0x9, 0, 0, 0, 0, 0, 0x13, 0, 0, 0,
 
 	// AttrLocalPref 0x5; PROTOCOL_BGP - simple u32 attributes
-	118: 0x5, 0x4, 0, 0,
+	122: 0x5, 0x4, 0, 0,
 	// LocalPref 0x64 == 100
-	122: 0x64, 0, 0, 0,
+	126: 0x64, 0, 0, 0,
 	// AttrCommunity 0x8; PROTOCOL_BGP
-	126: 0x8, 0x4, 0, 0,
+	130: 0x8, 0x4, 0, 0,
 	// AttrCommunity length - 16
-	130: 0x10, 0, 0, 0,
-	134: 0x2, 0, 0xf1, 0xc7, 0xf6, 0x1, 0xf1, 0xc7, 0x9a, 0x2, 0xf1, 0xc7, 0x12, 0x8, 0xf1, 0xc7,
+	134: 0x10, 0, 0, 0,
+	138: 0x2, 0, 0xf1, 0xc7, 0xf6, 0x1, 0xf1, 0xc7, 0x9a, 0x2, 0xf1, 0xc7, 0x12, 0x8, 0xf1, 0xc7,
 
 	// AttrLargeCommunity 0x20; PROTOCOL_BGP
-	150: 0x20, 0x4, 0, 0,
+	154: 0x20, 0x4, 0, 0,
 	// Complex attribute length 0x18 = 24
-	154: 0x18, 0, 0, 0,
+	158: 0x18, 0, 0, 0,
 	// 12 bytes
-	158: 0xfa, 0xc9, 0, 0, 0xe8, 0x3, 0, 0, 0x1, 0, 0, 0,
+	162: 0xfa, 0xc9, 0, 0, 0xe8, 0x3, 0, 0, 0x1, 0, 0, 0,
 	// 11 bytes
-	170: 0xfa, 0xc9, 0, 0, 0xe9, 0x3, 0, 0, 0x1, 0, 0,
+	174: 0xfa, 0xc9, 0, 0, 0xe9, 0x3, 0, 0, 0x1, 0, 0,
 	// last byte
 	// attributes data len respects the value of attrsAreaSize
-	64 - /* - sizeOf(attrsAreaSize)*/ 4 + ( /*len - 1*/ 122 - 1): 0,
+	attrAreaSizeOffset + ( /*len - 1*/ 122 - 1): 0,
 }
 
 func TestDecodeUpdate(t *testing.T) {
@@ -111,6 +113,7 @@ func TestDecodeUpdate(t *testing.T) {
 				Prefix:    netip.MustParsePrefix("2001:200:c000::/35"),
 				NextHop:   netip.MustParseAddr("2a02:2891:9:200::13"),
 				Peer:      netip.MustParseAddr("::1"),
+				GlobalID:  42,
 				ASPath:    []uint32{51185, 7500, 23634},
 				ASPathLen: 3,
 				Med:       0,
@@ -163,8 +166,10 @@ func TestDecodeUpdate(t *testing.T) {
 				40: 0x1, 0, 0, 0,
 				// peer addr
 				44: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+				// global_id LE u32 == 0
+				60: 0, 0, 0, 0,
 				// attrsAreaSize EXCLUDING sizeof(attrsAreaSize) - 0x0 => no attributes
-				60: 0x0, 0, 0, 0x0,
+				64: 0x0, 0, 0, 0x0,
 			},
 			expected: rib.Route{
 				Prefix: netip.MustParsePrefix("2307:db8:4::/48"),
@@ -187,17 +192,19 @@ func TestDecodeUpdate(t *testing.T) {
 				40: 0x1, 0, 0, 0,
 				// peer addr 16 byte as 4 LE u32 = ::1
 				44: 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x1, 0, 0, 0,
+				// global_id LE u32 == 0
+				60: 0, 0, 0, 0,
 
 				// attributes
 				// attrsAreaSize 0x6e == 110 bytes (EXCLUDING the 4-byte size field itself)
-				60: 0x6e, 0, 0, 0,
+				64: 0x6e, 0, 0, 0,
 				// attributes data
 				// ORIGIN
-				64: 0x1, 0x4, 0, 0 /* origin value */, 0, 0, 0, 0,
+				68: 0x1, 0x4, 0, 0 /* origin value */, 0, 0, 0, 0,
 				// ASPath
-				72: 0x2, 0x4, 0, 0,
-				76: 0x1e, 0, 0, 0, // ASPath area size = 30 bytes
-				80: 0x2, 81: 0x7, // 80: ASPathSequence; 81: ASPathLen == 0x7
+				76: 0x2, 0x4, 0, 0,
+				80: 0x1e, 0, 0, 0, // ASPath area size = 30 bytes
+				84: 0x2, 85: 0x7, // 84: ASPathSequence; 85: ASPathLen == 0x7
 				0, 0, 0xbb, 0xc6, // 1
 				0, 0, 0x5, 0x13, // 2
 				0, 0, 0x1d, 0x79, // 3
@@ -205,13 +212,13 @@ func TestDecodeUpdate(t *testing.T) {
 				0, 0, 0x97, 0x93, // 5
 				0, 0, 0x97, 0x93, // 6
 				0, 0, 0x97, 0x93, // 7
-				110: 0x3, 0x4, 0, 0, // 0x3 = AttrNextHop; PROTOCOL_BGP
-				114: 0x10, 0, 0, 0, // NextHop size LE u32 = 16 bytes
+				114: 0x3, 0x4, 0, 0, // 0x3 = AttrNextHop; PROTOCOL_BGP
+				118: 0x10, 0, 0, 0, // NextHop size LE u32 = 16 bytes
 				// nextHop ::ffff:c342:e2fe == ::ffff:195.66.226.254
-				118: 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0xfe, 0xe2, 0x42, 0xc3,
-				134: 0x5, 0x4, 0, 0, // AttrLocalPref = 0x5; PROTOCOL_BGP
-				138: 0x64, 0, 0, 0, // LE u32 == 100
-				142: 0x8, 0x4, 0, 0, // AttrCommunity; PROTOCOL_BGP
+				122: 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0xfe, 0xe2, 0x42, 0xc3,
+				138: 0x5, 0x4, 0, 0, // AttrLocalPref = 0x5; PROTOCOL_BGP
+				142: 0x64, 0, 0, 0, // LE u32 == 100
+				146: 0x8, 0x4, 0, 0, // AttrCommunity; PROTOCOL_BGP
 				0x4, 0, 0, 0, // 4 bytes
 				0x64, 0, 0xc6, 0xbb,
 				0x20, 0x4, 0, 0, // AttrLargeCommunity; PROTOCOL_BGP
@@ -246,10 +253,12 @@ func TestDecodeUpdate(t *testing.T) {
 			name: "OK ToRemove",
 			data: []byte{
 				1, 0x18, 8, 5: 7, 7: 1, 24: 0x10, 0x92, 0x53, 9, 0x1c, 0x5b, 32: 1,
-				0x11, 8, 0, 0, 0x80, 0, 1, 2, 56: 1, 60: 0x4e, 0, 0, 0, 1, 4, // attrsAreaSize=0x4e=78
-				72: 2, 4, 0, 0, 0x12, 0, 0, 0, 2, 4, 0, 6, 0x14, 0x81, 0, 0, 5,
-				89: 0x13, 0, 0, 0x1d, 0x79, 0, 0, 0x97, 0x93, 3, 4, 0, 0, 0x10,
-				114: 0xff, 0xff, 0, 0, 0xb9, 0x68, 0x52, 0xce, 5, 4, 0, 0, 0x64,
+				0x11, 8, 0, 0, 0x80, 0, 1, 2, 56: 1,
+				// global_id at 60 (zero); attrsAreaSize=0x4e=78 at 64
+				64: 0x4e, 0, 0, 0, 1, 4,
+				76: 2, 4, 0, 0, 0x12, 0, 0, 0, 2, 4, 0, 6, 0x14, 0x81, 0, 0, 5,
+				93: 0x13, 0, 0, 0x1d, 0x79, 0, 0, 0x97, 0x93, 3, 4, 0, 0, 0x10,
+				118: 0xff, 0xff, 0, 0, 0xb9, 0x68, 0x52, 0xce, 5, 4, 0, 0, 0x64,
 				0, 0, 0, 8, 4, 0, 0, 4, 0, 0, 0, 0xb8, 0x88, 0x13, 0x5,
 			},
 			expected: rib.Route{
@@ -278,19 +287,20 @@ func TestDecodeUpdate(t *testing.T) {
 				4: 0, 0, 0, 1, // prefix 1.0.0.0 LE u32
 				40: 0x1, 0, 0, 0, // opType insert
 				// peer addr all zero
-				60: 22, 0, 0, 0, // attrsAreaSize = 4+4+14 = 22
+				// global_id at 60 (zero)
+				64: 22, 0, 0, 0, // attrsAreaSize = 4+4+14 = 22
 				// AS_PATH attr: type + PROTOCOL_BGP
-				64: 0x2, 0x4, 0, 0,
+				68: 0x2, 0x4, 0, 0,
 				// attr data size = 14 bytes
-				68: 14, 0, 0, 0,
+				72: 14, 0, 0, 0,
 				// AS_SEQUENCE, 3 ASNs
-				72: 2, 3,
+				76: 2, 3,
 				// ASN 1 (BE u32)
-				74: 0, 0, 0, 1,
+				78: 0, 0, 0, 1,
 				// ASN 2 (BE u32)
-				78: 0, 0, 0, 2,
+				82: 0, 0, 0, 2,
 				// ASN 3 (BE u32)
-				82: 0, 0, 0, 3,
+				86: 0, 0, 0, 3,
 			},
 			expected: rib.Route{
 				Prefix:    netip.MustParsePrefix("1.0.0.0/8"),
@@ -310,25 +320,26 @@ func TestDecodeUpdate(t *testing.T) {
 				4: 0, 0, 0, 1, // prefix 1.0.0.0 LE u32
 				40: 0x1, 0, 0, 0, // opType insert
 				// peer addr all zero
-				60: 32, 0, 0, 0, // attrsAreaSize = 4+4+24 = 32
+				// global_id at 60 (zero)
+				64: 32, 0, 0, 0, // attrsAreaSize = 4+4+24 = 32
 				// AS_PATH attr: type + PROTOCOL_BGP
-				64: 0x2, 0x4, 0, 0,
+				68: 0x2, 0x4, 0, 0,
 				// attr data size = 24 bytes (2+8 + 2+12)
-				68: 24, 0, 0, 0,
+				72: 24, 0, 0, 0,
 				// AS_CONFED_SEQUENCE, 2 ASNs
-				72: 3, 2,
+				76: 3, 2,
 				// ASN 10 (BE u32)
-				74: 0, 0, 0, 10,
+				78: 0, 0, 0, 10,
 				// ASN 20 (BE u32)
-				78: 0, 0, 0, 20,
+				82: 0, 0, 0, 20,
 				// AS_SEQUENCE, 3 ASNs
-				82: 2, 3,
+				86: 2, 3,
 				// ASN 100 (BE u32)
-				84: 0, 0, 0, 100,
+				88: 0, 0, 0, 100,
 				// ASN 200 (BE u32)
-				88: 0, 0, 0, 200,
+				92: 0, 0, 0, 200,
 				// ASN 300 (BE u32)
-				92: 0, 0, 1, 44,
+				96: 0, 0, 1, 44,
 			},
 			expected: rib.Route{
 				Prefix:    netip.MustParsePrefix("1.0.0.0/8"),
@@ -348,17 +359,18 @@ func TestDecodeUpdate(t *testing.T) {
 				4: 0, 0, 0, 1, // prefix 1.0.0.0 LE u32
 				40: 0x1, 0, 0, 0, // opType insert
 				// peer addr all zero
-				60: 18, 0, 0, 0, // attrsAreaSize = 4+4+10 = 18
+				// global_id at 60 (zero)
+				64: 18, 0, 0, 0, // attrsAreaSize = 4+4+10 = 18
 				// AS_PATH attr: type + PROTOCOL_BGP
-				64: 0x2, 0x4, 0, 0,
+				68: 0x2, 0x4, 0, 0,
 				// attr data size = 10 bytes (2+8)
-				68: 10, 0, 0, 0,
+				72: 10, 0, 0, 0,
 				// AS_SET, 2 ASNs
-				72: 1, 2,
+				76: 1, 2,
 				// ASN 1 (BE u32)
-				74: 0, 0, 0, 1,
+				78: 0, 0, 0, 1,
 				// ASN 2 (BE u32)
-				78: 0, 0, 0, 2,
+				82: 0, 0, 0, 2,
 			},
 			expected: rib.Route{
 				Prefix:    netip.MustParsePrefix("1.0.0.0/8"),
@@ -382,8 +394,9 @@ func TestDecodeUpdate(t *testing.T) {
 				// RD LE u64 (bytes in the reverse order as described in the RFC)
 				24: 0, 0, 0, 0, 0, 0, 0x1, 0,
 				40: 0x1, 0, 0, 0, // update type LE u32
-				44: 0,            // ... peer addr all zero
-				60: 0x0, 0, 0, 0, // attrsAreaSize=0 (no attrs)
+				44: 0, // ... peer addr all zero
+				// global_id at 60 (zero)
+				64: 0x0, 0, 0, 0, // attrsAreaSize=0 (no attrs)
 			},
 			errDecode: ErrBadPrefix,
 		},
@@ -403,7 +416,8 @@ func TestDecodeUpdate(t *testing.T) {
 				0: 0xa,     // ERROR: NetMAX unsupported prefix
 				1: 0x8,     // prefix len
 				2: 0x14, 0, // NetAddr struct size
-				60: 0, 0, 0, 0, // attrsAreaSize=0
+				// global_id at 60 (zero)
+				64: 0, 0, 0, 0, // attrsAreaSize=0
 			},
 			errDecode: ErrUnsupportedPrefix,
 		},
@@ -415,9 +429,9 @@ func TestDecodeUpdate(t *testing.T) {
 				1: 0x8,     // prefix len
 				2: 0x14, 0, // NetAddr struct size
 				8: 0, 0, 0, 0, 0, 0, 0x1, 0, // RD LE u64
-				// attrsAreaSize expected at idx == 60
-				60: 2,    // ERROR attrsAreaSize=2 but only 2 bytes available (need at least 4 for attr type)
-				64: 0, 0, // truncated attrs data
+				// global_id at 60 (zero); attrsAreaSize at 64
+				64: 2,    // ERROR attrsAreaSize=2 but only 2 bytes available (need at least 4 for attr type)
+				68: 0, 0, // truncated attrs data
 			},
 			errDecode: ErrAttrsUnexpectedEOD,
 		},
@@ -429,9 +443,10 @@ func TestDecodeUpdate(t *testing.T) {
 				1: 0x8,     // prefix len
 				2: 0x14, 0, // NetAddr struct size
 				8: 0, 0, 0, 0, 0, 0, 0x1, 0, // RD LE u64
-				60: 4 + /* ERROR: not enough storage for U32 attribute */ 2,
-				64: 0x1 /* < ORIGIN: PROTOCOL_BGP > */, 0x4, 0, 0,
-				68: 0, 0, // ... truncated
+				// global_id at 60 (zero)
+				64: 4 + /* ERROR: not enough storage for U32 attribute */ 2,
+				68: 0x1 /* < ORIGIN: PROTOCOL_BGP > */, 0x4, 0, 0,
+				72: 0, 0, // ... truncated
 			},
 			errDecode: ErrAttributesTruncated,
 		},
@@ -443,10 +458,11 @@ func TestDecodeUpdate(t *testing.T) {
 				1: 0x8,     // prefix len
 				2: 0x14, 0, // NetAddr struct size
 				8: 0, 0, 0, 0, 0, 0, 0x1, 0, // RD LE u64
-				60: 4 + 4 + 4,
-				64: 0x2 /* < AS_PATH: PROTOCOL_BGP > */, 0x4, 0, 0,
-				68: 100, 5, 0, 0, // ERROR: size of complex attribute too big
-				72: 0, 0, 0, 0,
+				// global_id at 60 (zero)
+				64: 4 + 4 + 4,
+				68: 0x2 /* < AS_PATH: PROTOCOL_BGP > */, 0x4, 0, 0,
+				72: 100, 5, 0, 0, // ERROR: size of complex attribute too big
+				76: 0, 0, 0, 0,
 			},
 			errDecode: ErrAttributesTruncated,
 		},
@@ -457,10 +473,11 @@ func TestDecodeUpdate(t *testing.T) {
 				0: 0x3,     // NetVPN4
 				1: 0x8,     // prefix len
 				2: 0x14, 0, // NetAddr struct size
-				60: 4 + 4 + 4,
-				64: 0x2 /* < AS_PATH: PROTOCOL_BGP > */, 0x4, 0, 0,
-				68: 2, 0, 0, 0, // size of ASPath attribute
-				72: 2, 100, // ERROR: 100 segments but not enough data
+				// global_id at 60 (zero)
+				64: 4 + 4 + 4,
+				68: 0x2 /* < AS_PATH: PROTOCOL_BGP > */, 0x4, 0, 0,
+				72: 2, 0, 0, 0, // size of ASPath attribute
+				76: 2, 100, // ERROR: 100 segments but not enough data
 			},
 			errNew: ErrAttributesTruncated,
 		},

--- a/operators/bird-adapter/internal/bird/update_test.go
+++ b/operators/bird-adapter/internal/bird/update_test.go
@@ -379,6 +379,28 @@ func TestDecodeUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "OK ifindex attribute",
+			data: []byte{
+				0: 0x1,    // NetIP4
+				1: 0x8,    // prefix len 8
+				2: 0x8, 0, // NetAddrUnion length 8
+				4: 0, 0, 0, 1, // prefix 1.0.0.0 LE u32
+				40: 0x1, 0, 0, 0, // opType insert
+				// peer addr all zero
+				// global_id at 60 (zero)
+				64: 8, 0, 0, 0, // attrsAreaSize = 4 (type) + 4 (value) = 8
+				// AttrIfindex 0x12; PROTOCOL_BGP
+				68: 0x12, 0x4, 0, 0,
+				// ifindex value LE u32 == 10
+				72: 0xa, 0, 0, 0,
+			},
+			expected: rib.Route{
+				Prefix:  netip.MustParsePrefix("1.0.0.0/8"),
+				Peer:    netip.IPv6Unspecified(),
+				Ifindex: 10,
+			},
+		},
+		{
 			name:   "ERR Empty",
 			data:   []byte{},
 			errNew: ErrDataTooSmall,

--- a/operators/bird-adapter/internal/rib/routes.go
+++ b/operators/bird-adapter/internal/rib/routes.go
@@ -65,6 +65,10 @@ type Route struct {
 	ExtCommunities []ExtCommunity
 	// LargeCommunities are used to encode complementary route information
 	LargeCommunities []LargeCommunity
+	// Ifindex is the egress interface index advertised by BIRD.
+	//
+	// BIRD sends it as a u32 attribute (id 0x12) in the route update.
+	Ifindex uint32
 	// Med (MULTI_EXIT_DISC) guides route selection, per RFC 4271 Section 5.1.4.
 	//
 	// This field participates in route cost calculation.
@@ -129,6 +133,7 @@ func ToPBRoute(route *Route) *routepb.Route {
 		Source:           routepb.RouteSourceID(route.SourceID),
 		LargeCommunities: communities,
 		GlobalId:         route.GlobalID,
+		Ifindex:          route.Ifindex,
 	}
 }
 

--- a/operators/bird-adapter/internal/rib/routes.go
+++ b/operators/bird-adapter/internal/rib/routes.go
@@ -52,6 +52,9 @@ type Route struct {
 	// This field is used to distinguish similar routes from different peers.
 	// The same routes can have different costs.
 	Peer netip.Addr
+	// GlobalID identifies the peer globally, as reported by BIRD on the wire
+	// immediately after the peer address.
+	GlobalID uint32
 	// RD stands for Route Distinguisher, as defined in RFC 4364.
 	//
 	// This field is used to distinguish similar routes to different systems.
@@ -125,6 +128,7 @@ func ToPBRoute(route *Route) *routepb.Route {
 		AsPathLen:        route.ASPathLen,
 		Source:           routepb.RouteSourceID(route.SourceID),
 		LargeCommunities: communities,
+		GlobalId:         route.GlobalID,
 	}
 }
 

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -581,6 +581,10 @@ pub struct RouteEntry {
     pub pref: u32,
     #[tabled(rename = "MED")]
     pub med: u32,
+    #[tabled(rename = "Global ID")]
+    pub global_id: u32,
+    #[tabled(rename = "Ifindex")]
+    pub ifindex: u32,
     #[tabled(rename = "Communities")]
     pub communities: Communities,
 }
@@ -599,6 +603,8 @@ impl From<operatorpb::Route> for RouteEntry {
             origin_as: route.origin_as,
             pref: route.pref,
             med: route.med,
+            global_id: route.global_id,
+            ifindex: route.ifindex,
             communities: Communities(communities),
         }
     }

--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -44,6 +44,9 @@ type Route struct {
 	// re-announcing a prefix reuses the same GlobalID, so it drives the BGP
 	// implicit-replace decision.
 	GlobalID uint32
+	// Ifindex is the egress interface index advertised by BIRD as a u32
+	// route attribute.
+	Ifindex uint32
 	// RD stands for Route Distinguisher, as defined in RFC 4364.
 	//
 	// This field is used to distinguish similar routes to different systems.

--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -37,6 +37,13 @@ type Route struct {
 	// This field is used to distinguish similar routes from different peers.
 	// The same routes can have different costs.
 	Peer netip.Addr
+	// GlobalID is the route identifier reported by BIRD, used together with
+	// the peer to identify a BGP path within a prefix.
+	//
+	// BIRD emits it on the wire immediately after the peer address; a peer
+	// re-announcing a prefix reuses the same GlobalID, so it drives the BGP
+	// implicit-replace decision.
+	GlobalID uint32
 	// RD stands for Route Distinguisher, as defined in RFC 4364.
 	//
 	// This field is used to distinguish similar routes to different systems.
@@ -71,13 +78,14 @@ type Route struct {
 
 // isSameIdentity reports whether two routes share the same RIB identity.
 //
-// BGP-sourced routes are identified by peer because of BGP implicit replace:
-// a peer re-announcing a prefix with a new nexthop must replace its previous
-// path (RFC 4271), so BGP ECMP arises across peers. Static routes are
-// peerless independent entries, so their identity includes the nexthop,
-// allowing multiple static routes for the same prefix with distinct nexthops
-// to coexist. Static nexthops are compared in normalized (unmapped) form
-// because the API accepts both native IPv4 and IPv4-in-IPv6 encodings.
+// BGP-sourced routes are identified by peer and GlobalID because of BGP
+// implicit replace: a peer re-announcing a prefix reuses its GlobalID and must
+// replace its previous path (RFC 4271), so BGP ECMP arises across distinct
+// (peer, GlobalID) paths. Static routes are peerless independent entries, so
+// their identity includes the nexthop, allowing multiple static routes for the
+// same prefix with distinct nexthops to coexist. Static nexthops are compared
+// in normalized (unmapped) form because the API accepts both native IPv4 and
+// IPv4-in-IPv6 encodings.
 func (m Route) isSameIdentity(other Route) bool {
 	if m.SourceID != other.SourceID || m.Peer != other.Peer {
 		return false
@@ -85,7 +93,7 @@ func (m Route) isSameIdentity(other Route) bool {
 	if m.SourceID == RouteSourceStatic {
 		return m.NextHop.Unmap() == other.NextHop.Unmap()
 	}
-	return true
+	return m.GlobalID == other.GlobalID
 }
 
 func routeCompare(a Route, b Route) int {

--- a/operators/route/internal/rib/routes_test.go
+++ b/operators/route/internal/rib/routes_test.go
@@ -142,6 +142,56 @@ func TestRoutesListStaticECMP(t *testing.T) {
 	})
 }
 
+// TestRoutesListBGPGlobalID verifies that BGP paths from the same peer are
+// distinguished by GlobalID: distinct GlobalIDs coexist as ECMP, while a
+// re-announced GlobalID replaces its previous path in place.
+func TestRoutesListBGPGlobalID(t *testing.T) {
+	pfx := netip.MustParsePrefix("10.0.0.0/24")
+	nh1 := netip.MustParseAddr("10.0.0.1")
+	nh2 := netip.MustParseAddr("10.0.0.2")
+	peer := netip.MustParseAddr("192.0.2.1")
+
+	t.Run("same peer different global_id both present", func(t *testing.T) {
+		var list RoutesList
+		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: peer, GlobalID: 1, SourceID: RouteSourceBird}
+		r2 := Route{Prefix: pfx, NextHop: nh2, Peer: peer, GlobalID: 2, SourceID: RouteSourceBird}
+
+		added1 := list.Insert(r1)
+		added2 := list.Insert(r2)
+
+		require.True(t, added1, "first bird route should be added")
+		require.True(t, added2, "bird route with different global_id should be added")
+		require.Len(t, list.Routes, 2)
+	})
+
+	t.Run("re-announce same global_id replaces in place", func(t *testing.T) {
+		var list RoutesList
+		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: peer, GlobalID: 7, SourceID: RouteSourceBird}
+		r1Updated := Route{Prefix: pfx, NextHop: nh2, Peer: peer, GlobalID: 7, SourceID: RouteSourceBird}
+
+		list.Insert(r1)
+		added := list.Insert(r1Updated)
+
+		require.False(t, added, "re-announce of same global_id should replace, not append")
+		require.Len(t, list.Routes, 1)
+		require.Equal(t, nh2, list.Routes[0].NextHop)
+	})
+
+	t.Run("remove by global_id leaves the other path", func(t *testing.T) {
+		var list RoutesList
+		r1 := Route{Prefix: pfx, NextHop: nh1, Peer: peer, GlobalID: 1, SourceID: RouteSourceBird}
+		r2 := Route{Prefix: pfx, NextHop: nh2, Peer: peer, GlobalID: 2, SourceID: RouteSourceBird}
+		list.Insert(r1)
+		list.Insert(r2)
+
+		removed := list.Remove(Route{Prefix: pfx, Peer: peer, GlobalID: 1, SourceID: RouteSourceBird})
+
+		require.True(t, removed)
+		require.Len(t, list.Routes, 1)
+		require.Equal(t, uint32(2), list.Routes[0].GlobalID)
+	})
+}
+
 // TestBestPerSource verifies that BestPerSource returns the equal-cost group
 // for each source and filters routes that are strictly worse than the source's best.
 func TestBestPerSource(t *testing.T) {

--- a/operators/route/operatorpb/v1/convert.go
+++ b/operators/route/operatorpb/v1/convert.go
@@ -84,6 +84,7 @@ func ToRIBRoute(route *Route, toRemove bool) (*rib.Route, error) {
 		Prefix:           prefix,
 		NextHop:          nexthop,
 		Peer:             peer,
+		GlobalID:         route.GetGlobalId(),
 		RD:               route.GetRouteDistinguisher(),
 		LargeCommunities: largeCommunities,
 		UpdatedAt:        time.Now(),

--- a/operators/route/operatorpb/v1/convert.go
+++ b/operators/route/operatorpb/v1/convert.go
@@ -85,6 +85,7 @@ func ToRIBRoute(route *Route, toRemove bool) (*rib.Route, error) {
 		NextHop:          nexthop,
 		Peer:             peer,
 		GlobalID:         route.GetGlobalId(),
+		Ifindex:          route.GetIfindex(),
 		RD:               route.GetRouteDistinguisher(),
 		LargeCommunities: largeCommunities,
 		UpdatedAt:        time.Now(),

--- a/operators/route/operatorpb/v1/convert.go
+++ b/operators/route/operatorpb/v1/convert.go
@@ -33,6 +33,8 @@ func FromRIBRoute(route *rib.Route, isBest bool) *Route {
 		Source:           RouteSourceID(route.SourceID),
 		LargeCommunities: communities,
 		IsBest:           isBest,
+		GlobalId:         route.GlobalID,
+		Ifindex:          route.Ifindex,
 	}
 }
 

--- a/operators/route/operatorpb/v1/route.proto
+++ b/operators/route/operatorpb/v1/route.proto
@@ -139,6 +139,9 @@ message Route {
   // All equal-cost members of the per-source best group carry this flag,
   // including every static ECMP nexthop and every equal-cost BIRD path.
   bool is_best = 12;
+  // GlobalID identifies the peer globally, as reported by BIRD on the wire
+  // immediately after the peer address.
+  uint32 global_id = 13;
 }
 
 // LargeCommunity represents a BGP Large Community value.

--- a/operators/route/operatorpb/v1/route.proto
+++ b/operators/route/operatorpb/v1/route.proto
@@ -142,6 +142,9 @@ message Route {
   // GlobalID identifies the peer globally, as reported by BIRD on the wire
   // immediately after the peer address.
   uint32 global_id = 13;
+  // Ifindex is the egress interface index advertised by BIRD as a u32
+  // route attribute.
+  uint32 ifindex = 14;
 }
 
 // LargeCommunity represents a BGP Large Community value.


### PR DESCRIPTION
BIRD now emits a per-route global identifier on the wire immediately after the peer address. The bird-adapter decodes it and forwards it through the route operator protocol, and the route operator RIB uses it together with the peer to identify BGP paths within a prefix, driving the implicit-replace decision.