### PR TITLE
fix(route-operator): use the provided logger in the RIB store

### DIFF
--- a/operators/route/internal/operator/rib.go
+++ b/operators/route/internal/operator/rib.go
@@ -18,7 +18,7 @@ type RIBStore struct {
 func newRIBStore(log *zap.Logger) *RIBStore {
 	return &RIBStore{
 		ribs: map[string]*rib.RIB{},
-		log:  zap.NewNop(),
+		log:  log,
 	}
 }
 


### PR DESCRIPTION
- The RIB store constructor silently discarded the logger passed by its caller and installed a no-op logger instead, muting the store's log output.
- The store now uses the supplied logger, as the call site always intended.