### PR TITLE
feat(route-operator): collect and expose operator metrics

### DIFF
--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -24,6 +24,7 @@ type GatewayActuator struct {
 	routes      routepb.RouteServiceClient
 	funcApplier *operator.FunctionApplier
 	devices     []string
+	onFIBBuilt  func(module string, stats FIBBuildStats)
 	log         *zap.Logger
 }
 
@@ -71,7 +72,8 @@ func NewGatewayActuator(
 			spec,
 			operator.WithIgnorePdump(fn.IgnorePdump),
 		),
-		devices: opts.Devices,
+		devices:    opts.Devices,
+		onFIBBuilt: opts.OnFIBBuilt,
 		log: opts.Log.With(
 			zap.String("gateway", cfg.Name),
 			zap.String("function", fn.Name.Unwrap()),
@@ -99,8 +101,9 @@ func (m *GatewayActuator) Apply(ctx context.Context, snapshot RouteSnapshot) err
 			continue
 		}
 
-		fib, _ := BuildFIB(dump, neighbours)
+		fib, stats := BuildFIB(dump, neighbours)
 		fib.Name = name
+		m.onFIBBuilt(name, stats)
 		if e := m.pushFIB(ctx, fib); e != nil {
 			err = errors.Join(err, fmt.Errorf("failed to push FIB to gateway %q: %w", m.name, e))
 		}

--- a/operators/route/internal/operator/actuator_metered.go
+++ b/operators/route/internal/operator/actuator_metered.go
@@ -1,0 +1,39 @@
+package operator
+
+import (
+	"context"
+	"time"
+)
+
+// meteredActuator wraps an inner Actuator and records apply duration and
+// outcome per gateway.
+//
+// The inner error is returned unchanged so FanOutActuator error joining
+// and reconcile backoff are preserved.
+type meteredActuator struct {
+	inner   Actuator
+	gateway *GatewayMetrics
+}
+
+// newMeteredActuator wraps inner so every Apply call is timed and
+// reported to gatewayMetrics.
+func newMeteredActuator(inner Actuator, gatewayMetrics *GatewayMetrics) *meteredActuator {
+	return &meteredActuator{
+		inner:   inner,
+		gateway: gatewayMetrics,
+	}
+}
+
+// Apply times the inner actuator's Apply call and reports the outcome
+// via ObserveApply, returning the inner error unchanged.
+func (m *meteredActuator) Apply(ctx context.Context, snapshot RouteSnapshot) error {
+	start := time.Now()
+	err := m.inner.Apply(ctx, snapshot)
+	m.gateway.ObserveApply(time.Since(start), err)
+	return err
+}
+
+// Close delegates to the inner actuator.
+func (m *meteredActuator) Close() error {
+	return m.inner.Close()
+}

--- a/operators/route/internal/operator/metrics.go
+++ b/operators/route/internal/operator/metrics.go
@@ -1,29 +1,357 @@
 package operator
 
 import (
+	"sync"
 	"time"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/common/go/operator"
 )
 
+// applyDurationBounds are the histogram bucket upper bounds, in seconds,
+// used for per-gateway apply latency.
+var applyDurationBounds = []float64{
+	0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+}
+
+var reconcilerStateNames = map[operator.ReconcilerState]string{
+	operator.ReconcilerStateIdle:     "idle",
+	operator.ReconcilerStateApplying: "applying",
+	operator.ReconcilerStateSleeping: "sleeping",
+}
+
 // Metrics is the single observability sink for the route operator.
 //
-// TODO: collect metrics.
-type Metrics struct{}
+// It combines three collection styles: reconcile-loop and gateway-apply
+// counters are updated by tee-ing existing callbacks, RIB gauges are
+// pulled from thread-safe snapshots at Collect time, and gateway sinks
+// are created on demand by Gateway.
+type Metrics struct {
+	ribs                *RIBStore
+	neighMonitorEnabled bool
 
-// NewMetrics constructs an empty Metrics sink.
-func NewMetrics() *Metrics {
-	return &Metrics{}
+	reconcileTotal  metrics.Counter
+	reconcileErrors metrics.Counter
+	states          map[operator.ReconcilerState]*metrics.Gauge
+	backoffSeconds  metrics.Gauge
+
+	ribSessionStarts *metrics.MetricMap[*metrics.Counter]
+	ribSessionEnds   *metrics.MetricMap[*metrics.Counter]
+	ribFeedUpdates   metrics.Counter
+
+	neighbourHealthy metrics.Gauge
+	neighbourResyncs metrics.Counter
+	neighbourSyncs   metrics.Counter
+
+	gatewaysMu sync.Mutex
+	gateways   map[string]*GatewayMetrics
+}
+
+// NewMetrics constructs the Metrics sink from the operator-owned
+// dependencies it pulls from at Collect time.
+func NewMetrics(ribs *RIBStore, neighMonitorEnabled bool) *Metrics {
+	states := make(map[operator.ReconcilerState]*metrics.Gauge, len(reconcilerStateNames))
+	for state := range reconcilerStateNames {
+		states[state] = &metrics.Gauge{}
+	}
+
+	return &Metrics{
+		ribs:                ribs,
+		neighMonitorEnabled: neighMonitorEnabled,
+		states:              states,
+		ribSessionStarts:    metrics.NewMetricMap[*metrics.Counter](),
+		ribSessionEnds:      metrics.NewMetricMap[*metrics.Counter](),
+		gateways:            map[string]*GatewayMetrics{},
+	}
+}
+
+// MetricsFactory constructs the operator metrics sink from the
+// operator-owned dependencies.
+//
+// NewOperator invokes the factory once the RIB store exists, so a custom
+// factory can wrap or extend the default sink while still receiving the
+// real pull sources.
+type MetricsFactory func(ribs *RIBStore, neighMonitorEnabled bool) *Metrics
+
+// OnReconcileCompleted records the outcome of one reconcile pass.
+func (m *Metrics) OnReconcileCompleted(err error) {
+	m.reconcileTotal.Inc()
+	if err != nil {
+		m.reconcileErrors.Inc()
+	}
+}
+
+// OnBackoffScheduled records the delay before the next retry.
+func (m *Metrics) OnBackoffScheduled(delay time.Duration) {
+	m.backoffSeconds.Store(delay.Seconds())
+}
+
+// OnBackoffReset clears the backoff gauge after a successful apply.
+func (m *Metrics) OnBackoffReset() {
+	m.backoffSeconds.Store(0)
+}
+
+// OnStateChanged records the reconcile loop's current state.
+func (m *Metrics) OnStateChanged(state operator.ReconcilerState) {
+	for k, g := range m.states {
+		if k == state {
+			g.Store(1)
+		} else {
+			g.Store(0)
+		}
+	}
+}
+
+// OnRIBSessionStart records that a FeedRIB stream session began for the
+// named module config.
+func (m *Metrics) OnRIBSessionStart(name string, sessionID uint64) {
+	m.ribSessionCounter(m.ribSessionStarts, name).Inc()
+}
+
+// OnRIBSessionEnd records that a FeedRIB stream session ended for the
+// named module config.
+func (m *Metrics) OnRIBSessionEnd(name string, sessionID uint64) {
+	m.ribSessionCounter(m.ribSessionEnds, name).Inc()
+}
+
+// OnRIBUpdate records that a batch of n routes was applied to a RIB
+// through a FeedRIB stream session.
+//
+// Unary route mutations (InsertRoute/DeleteRoute) and static-config
+// seeding also change RIB contents but are not counted here; they are
+// visible through the RIB gauges instead.
+func (m *Metrics) OnRIBUpdate(n int) {
+	m.ribFeedUpdates.Add(uint64(n))
+}
+
+// OnNeighbourSynced records the transition to a healthy neighbour table
+// after the initial sync.
+func (m *Metrics) OnNeighbourSynced() {
+	m.neighbourHealthy.Store(1)
+}
+
+// OnNeighbourError records a degradation episode in the neighbour
+// monitor.
+func (m *Metrics) OnNeighbourError(err error) {
+	m.neighbourHealthy.Store(0)
+}
+
+// OnNeighbourResynced records recovery from a degradation episode.
+func (m *Metrics) OnNeighbourResynced() {
+	m.neighbourHealthy.Store(1)
+	m.neighbourResyncs.Inc()
+}
+
+// OnNeighbourHealthy records one successful neighbour table refresh.
+func (m *Metrics) OnNeighbourHealthy() {
+	m.neighbourSyncs.Inc()
+}
+
+// Gateway returns the per-gateway metrics for name, creating them on
+// first use.
+func (m *Metrics) Gateway(name string) *GatewayMetrics {
+	m.gatewaysMu.Lock()
+	defer m.gatewaysMu.Unlock()
+
+	if g, ok := m.gateways[name]; ok {
+		return g
+	}
+
+	g := newGatewayMetrics(name)
+	m.gateways[name] = g
+	return g
+}
+
+// ribSessionCounter returns the per-module counter from the given map,
+// creating it on first use.
+func (m *Metrics) ribSessionCounter(sessions *metrics.MetricMap[*metrics.Counter], module string) *metrics.Counter {
+	id := metrics.MetricID{Labels: metrics.Labels{"module": module}}
+	return sessions.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 }
 
 // Collect renders the current state of every metric as a slice of
-// commonpb.Metric values. Empty for now.
+// commonpb.Metric values.
 func (m *Metrics) Collect() []*commonpb.Metric {
-	return nil
+	out := make([]*commonpb.Metric, 0)
+
+	out = append(out,
+		makeCounter("route_operator_reconcile_total", m.reconcileTotal.Load()),
+		makeCounter("route_operator_reconcile_errors_total", m.reconcileErrors.Load()),
+		makeGauge("route_operator_backoff_seconds", m.backoffSeconds.Load()),
+	)
+	for state, g := range m.states {
+		out = append(out, makeGauge(
+			"route_operator_state",
+			g.Load(),
+			makeLabel("state", reconcilerStateNames[state]),
+		))
+	}
+
+	for name, ribRef := range m.ribs.Snapshot() {
+		stats := ribRef.Stats()
+		module := makeLabel("module", name)
+		out = append(out,
+			makeGauge("route_operator_rib_prefixes", float64(stats.Prefixes), module),
+			makeGauge("route_operator_rib_routes", float64(stats.Routes), module),
+			makeGauge(
+				"route_operator_rib_last_change_timestamp_seconds",
+				float64(stats.ChangedAt.Unix()),
+				module,
+			),
+		)
+	}
+
+	for _, entry := range m.ribSessionStarts.Metrics() {
+		out = append(out, makeCounter(
+			"route_operator_rib_session_starts_total",
+			entry.Value.Load(),
+			makeLabel("module", entry.ID.Labels["module"]),
+		))
+	}
+	for _, entry := range m.ribSessionEnds.Metrics() {
+		out = append(out, makeCounter(
+			"route_operator_rib_session_ends_total",
+			entry.Value.Load(),
+			makeLabel("module", entry.ID.Labels["module"]),
+		))
+	}
+	out = append(out, makeCounter("route_operator_rib_feed_updates_total", m.ribFeedUpdates.Load()))
+
+	if m.neighMonitorEnabled {
+		out = append(out,
+			makeGauge("route_operator_neighbour_monitor_healthy", m.neighbourHealthy.Load()),
+			makeCounter("route_operator_neighbour_resyncs_total", m.neighbourResyncs.Load()),
+			makeCounter("route_operator_neighbour_syncs_total", m.neighbourSyncs.Load()),
+		)
+	}
+
+	m.gatewaysMu.Lock()
+	gateways := make([]*GatewayMetrics, 0, len(m.gateways))
+	for _, g := range m.gateways {
+		gateways = append(gateways, g)
+	}
+	m.gatewaysMu.Unlock()
+
+	for _, g := range gateways {
+		out = append(out, g.collect()...)
+	}
+
+	return out
 }
 
-func (m *Metrics) OnReconcileCompleted(error)              {}
-func (m *Metrics) OnBackoffScheduled(time.Duration)        {}
-func (m *Metrics) OnBackoffReset()                         {}
-func (m *Metrics) OnStateChanged(operator.ReconcilerState) {}
+// fibGauges holds the per-module FIB build gauges reported by a single
+// gateway.
+type fibGauges struct {
+	entries            metrics.Gauge
+	routes             metrics.Gauge
+	unresolvedNexthops metrics.Gauge
+	skippedPrefixes    metrics.Gauge
+	filteredRoutes     metrics.Gauge
+}
+
+// GatewayMetrics is the per-gateway observability sink, fed by
+// meteredActuator (apply outcomes) and GatewayActuator (FIB build
+// stats).
+type GatewayMetrics struct {
+	name string
+
+	apply         metrics.Counter
+	applyErrors   metrics.Counter
+	applyDuration *metrics.Histogram
+
+	fibMu sync.Mutex
+	fib   map[string]*fibGauges
+}
+
+// newGatewayMetrics constructs the metrics sink for a single gateway.
+func newGatewayMetrics(name string) *GatewayMetrics {
+	return &GatewayMetrics{
+		name:          name,
+		applyDuration: metrics.NewHistogram(applyDurationBounds),
+		fib:           map[string]*fibGauges{},
+	}
+}
+
+// ObserveApply records the outcome and duration of one Apply call.
+func (m *GatewayMetrics) ObserveApply(d time.Duration, err error) {
+	m.apply.Inc()
+	if err != nil {
+		m.applyErrors.Inc()
+	}
+	m.applyDuration.Observe(d.Seconds())
+}
+
+// OnFIBBuilt records the outcome of one FIB build for module.
+func (m *GatewayMetrics) OnFIBBuilt(module string, stats FIBBuildStats) {
+	m.fibMu.Lock()
+	g, ok := m.fib[module]
+	if !ok {
+		g = &fibGauges{}
+		m.fib[module] = g
+	}
+	m.fibMu.Unlock()
+
+	g.entries.Store(float64(stats.PrefixesAdded))
+	g.routes.Store(float64(stats.TotalRoutes))
+	g.unresolvedNexthops.Store(float64(stats.NeighbourNotFound))
+	g.skippedPrefixes.Store(float64(stats.SkippedPrefixes))
+	g.filteredRoutes.Store(float64(stats.FilteredRoutes))
+}
+
+// collect renders this gateway's metrics as a slice of commonpb.Metric
+// values.
+func (m *GatewayMetrics) collect() []*commonpb.Metric {
+	gateway := makeLabel("gateway", m.name)
+	out := make([]*commonpb.Metric, 0)
+
+	out = append(out,
+		makeCounter("route_operator_gateway_apply_total", m.apply.Load(), gateway),
+		makeCounter("route_operator_gateway_apply_errors_total", m.applyErrors.Load(), gateway),
+		makeHistogram("route_operator_gateway_apply_duration_seconds", m.applyDuration, gateway),
+	)
+
+	m.fibMu.Lock()
+	defer m.fibMu.Unlock()
+
+	for module, g := range m.fib {
+		labels := []*commonpb.Label{gateway, makeLabel("module", module)}
+		out = append(out,
+			makeGauge("route_operator_fib_entries", g.entries.Load(), labels...),
+			makeGauge("route_operator_fib_routes", g.routes.Load(), labels...),
+			makeGauge("route_operator_fib_unresolved_nexthops", g.unresolvedNexthops.Load(), labels...),
+			makeGauge("route_operator_fib_skipped_prefixes", g.skippedPrefixes.Load(), labels...),
+			makeGauge("route_operator_fib_filtered_routes", g.filteredRoutes.Load(), labels...),
+		)
+	}
+
+	return out
+}
+
+func makeLabel(name, value string) *commonpb.Label {
+	return &commonpb.Label{Name: name, Value: value}
+}
+
+func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &commonpb.Metric_Counter{Counter: value},
+	}
+}
+
+func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &commonpb.Metric_Gauge{Gauge: value},
+	}
+}
+
+func makeHistogram(name string, h *metrics.Histogram, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  commonpb.MetricValueToProto(h),
+	}
+}

--- a/operators/route/internal/operator/metrics_test.go
+++ b/operators/route/internal/operator/metrics_test.go
@@ -1,0 +1,302 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
+)
+
+// findMetric returns the metric named name whose label set matches labels
+// exactly (order-independent), or nil if none matches.
+func findMetric(metricList []*commonpb.Metric, name string, labels map[string]string) *commonpb.Metric {
+	for _, metric := range metricList {
+		if metric.GetName() != name {
+			continue
+		}
+
+		if len(metric.GetLabels()) != len(labels) {
+			continue
+		}
+
+		matched := true
+		for _, label := range metric.GetLabels() {
+			if labels[label.GetName()] != label.GetValue() {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return metric
+		}
+	}
+
+	return nil
+}
+
+// fakeActuator is a minimal Actuator used to drive meteredActuator in
+// isolation from the real gateway RPC client.
+type fakeActuator struct {
+	applyErr   error
+	applyCalls int
+	closeErr   error
+	closeCalls int
+}
+
+func (m *fakeActuator) Apply(ctx context.Context, snapshot RouteSnapshot) error {
+	m.applyCalls++
+	return m.applyErr
+}
+
+func (m *fakeActuator) Close() error {
+	m.closeCalls++
+	return m.closeErr
+}
+
+// TestMetrics_ReconcileEvents verifies that reconcile-loop observer methods
+// update the corresponding counters and gauges rendered by Collect.
+func TestMetrics_ReconcileEvents(t *testing.T) {
+	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+
+	m.OnReconcileCompleted(nil)
+	m.OnReconcileCompleted(errors.New("boom"))
+	m.OnBackoffScheduled(2 * time.Second)
+	m.OnStateChanged(operator.ReconcilerStateApplying)
+
+	metricList := m.Collect()
+
+	total := findMetric(metricList, "route_operator_reconcile_total", map[string]string{})
+	require.NotNil(t, total)
+	require.Equal(t, uint64(2), total.GetCounter())
+
+	errs := findMetric(metricList, "route_operator_reconcile_errors_total", map[string]string{})
+	require.NotNil(t, errs)
+	require.Equal(t, uint64(1), errs.GetCounter())
+
+	backoff := findMetric(metricList, "route_operator_backoff_seconds", map[string]string{})
+	require.NotNil(t, backoff)
+	require.Equal(t, 2.0, backoff.GetGauge())
+
+	applying := findMetric(metricList, "route_operator_state", map[string]string{"state": "applying"})
+	require.NotNil(t, applying)
+	require.Equal(t, 1.0, applying.GetGauge())
+
+	idle := findMetric(metricList, "route_operator_state", map[string]string{"state": "idle"})
+	require.NotNil(t, idle)
+	require.Equal(t, 0.0, idle.GetGauge())
+
+	m.OnBackoffReset()
+	backoff = findMetric(m.Collect(), "route_operator_backoff_seconds", map[string]string{})
+	require.NotNil(t, backoff)
+	require.Equal(t, 0.0, backoff.GetGauge())
+}
+
+// TestMetrics_RIBFeedEvents verifies that RIB session and update callbacks
+// are rendered per module, without leaking into other modules' counters.
+func TestMetrics_RIBFeedEvents(t *testing.T) {
+	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+
+	m.OnRIBSessionStart("route0", 1)
+	m.OnRIBSessionStart("route0", 2)
+	m.OnRIBSessionEnd("route0", 1)
+	m.OnRIBSessionStart("route1", 1)
+	m.OnRIBUpdate(3)
+	m.OnRIBUpdate(2)
+
+	metricList := m.Collect()
+
+	starts0 := findMetric(metricList, "route_operator_rib_session_starts_total", map[string]string{"module": "route0"})
+	require.NotNil(t, starts0)
+	require.Equal(t, uint64(2), starts0.GetCounter())
+
+	ends0 := findMetric(metricList, "route_operator_rib_session_ends_total", map[string]string{"module": "route0"})
+	require.NotNil(t, ends0)
+	require.Equal(t, uint64(1), ends0.GetCounter())
+
+	starts1 := findMetric(metricList, "route_operator_rib_session_starts_total", map[string]string{"module": "route1"})
+	require.NotNil(t, starts1)
+	require.Equal(t, uint64(1), starts1.GetCounter())
+
+	updates := findMetric(metricList, "route_operator_rib_feed_updates_total", map[string]string{})
+	require.NotNil(t, updates)
+	require.Equal(t, uint64(5), updates.GetCounter())
+}
+
+// TestMetrics_NeighbourEvents verifies that the neighbour health gauge and
+// resync/sync counters track the monitor's callback sequence, and that
+// neighbour metrics are absent when the monitor is disabled.
+func TestMetrics_NeighbourEvents(t *testing.T) {
+	t.Run("MonitorEnabled", func(t *testing.T) {
+		m := NewMetrics(newRIBStore(zap.NewNop()), true)
+
+		m.OnNeighbourSynced()
+		m.OnNeighbourHealthy()
+		m.OnNeighbourError(errors.New("degraded"))
+		m.OnNeighbourResynced()
+		m.OnNeighbourHealthy()
+
+		metricList := m.Collect()
+
+		healthy := findMetric(metricList, "route_operator_neighbour_monitor_healthy", map[string]string{})
+		require.NotNil(t, healthy)
+		require.Equal(t, 1.0, healthy.GetGauge())
+
+		resyncs := findMetric(metricList, "route_operator_neighbour_resyncs_total", map[string]string{})
+		require.NotNil(t, resyncs)
+		require.Equal(t, uint64(1), resyncs.GetCounter())
+
+		syncs := findMetric(metricList, "route_operator_neighbour_syncs_total", map[string]string{})
+		require.NotNil(t, syncs)
+		require.Equal(t, uint64(2), syncs.GetCounter())
+	})
+
+	t.Run("MonitorDisabled", func(t *testing.T) {
+		m := NewMetrics(newRIBStore(zap.NewNop()), false)
+
+		m.OnNeighbourSynced()
+		m.OnNeighbourHealthy()
+
+		metricList := m.Collect()
+
+		require.Nil(t, findMetric(metricList, "route_operator_neighbour_monitor_healthy", map[string]string{}))
+		require.Nil(t, findMetric(metricList, "route_operator_neighbour_syncs_total", map[string]string{}))
+	})
+}
+
+// TestMetrics_PullRIBStats verifies that RIB gauges are pulled from the
+// RIBStore's live snapshot at Collect time.
+func TestMetrics_PullRIBStats(t *testing.T) {
+	store := newRIBStore(zap.NewNop())
+	ribRef := store.GetOrCreate("route0")
+	require.NoError(t, ribRef.AddUnicastRoute(
+		netip.MustParsePrefix("10.0.0.0/24"),
+		netip.MustParseAddr("192.168.1.1"),
+		rib.RouteSourceStatic,
+	))
+
+	m := NewMetrics(store, false)
+
+	metricList := m.Collect()
+
+	prefixes := findMetric(metricList, "route_operator_rib_prefixes", map[string]string{"module": "route0"})
+	require.NotNil(t, prefixes)
+	require.Equal(t, 1.0, prefixes.GetGauge())
+
+	routes := findMetric(metricList, "route_operator_rib_routes", map[string]string{"module": "route0"})
+	require.NotNil(t, routes)
+	require.Equal(t, 1.0, routes.GetGauge())
+
+	require.NotNil(t, findMetric(
+		metricList,
+		"route_operator_rib_last_change_timestamp_seconds",
+		map[string]string{"module": "route0"},
+	))
+}
+
+// TestGatewayMetrics_FIBBuilt verifies that OnFIBBuilt renders the five FIB
+// gauges from FIBBuildStats, keyed by gateway and module.
+func TestGatewayMetrics_FIBBuilt(t *testing.T) {
+	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+
+	gateway := m.Gateway("gw0")
+	gateway.OnFIBBuilt("route0", FIBBuildStats{
+		TotalRoutes:       4,
+		SkippedPrefixes:   1,
+		NeighbourNotFound: 2,
+		PrefixesAdded:     3,
+		FilteredRoutes:    5,
+	})
+
+	metricList := m.Collect()
+	labels := map[string]string{"gateway": "gw0", "module": "route0"}
+
+	entries := findMetric(metricList, "route_operator_fib_entries", labels)
+	require.NotNil(t, entries)
+	require.Equal(t, 3.0, entries.GetGauge())
+
+	routes := findMetric(metricList, "route_operator_fib_routes", labels)
+	require.NotNil(t, routes)
+	require.Equal(t, 4.0, routes.GetGauge())
+
+	unresolved := findMetric(metricList, "route_operator_fib_unresolved_nexthops", labels)
+	require.NotNil(t, unresolved)
+	require.Equal(t, 2.0, unresolved.GetGauge())
+
+	skipped := findMetric(metricList, "route_operator_fib_skipped_prefixes", labels)
+	require.NotNil(t, skipped)
+	require.Equal(t, 1.0, skipped.GetGauge())
+
+	filtered := findMetric(metricList, "route_operator_fib_filtered_routes", labels)
+	require.NotNil(t, filtered)
+	require.Equal(t, 5.0, filtered.GetGauge())
+}
+
+// TestGatewayMetrics_ObserveApply verifies that ObserveApply updates the
+// apply counters and renders a non-empty duration histogram.
+func TestGatewayMetrics_ObserveApply(t *testing.T) {
+	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+	gateway := m.Gateway("gw0")
+
+	gateway.ObserveApply(10*time.Millisecond, nil)
+	gateway.ObserveApply(20*time.Millisecond, errors.New("failed"))
+
+	metricList := m.Collect()
+
+	apply := findMetric(metricList, "route_operator_gateway_apply_total", map[string]string{"gateway": "gw0"})
+	require.NotNil(t, apply)
+	require.Equal(t, uint64(2), apply.GetCounter())
+
+	applyErrors := findMetric(
+		metricList,
+		"route_operator_gateway_apply_errors_total",
+		map[string]string{"gateway": "gw0"},
+	)
+	require.NotNil(t, applyErrors)
+	require.Equal(t, uint64(1), applyErrors.GetCounter())
+
+	duration := findMetric(
+		metricList,
+		"route_operator_gateway_apply_duration_seconds",
+		map[string]string{"gateway": "gw0"},
+	)
+	require.NotNil(t, duration)
+	require.Equal(t, uint64(2), duration.GetHistogram().GetTotalCount())
+}
+
+// TestMeteredActuator verifies that meteredActuator times and reports every
+// Apply call, returns the inner error unchanged, and delegates Close.
+func TestMeteredActuator(t *testing.T) {
+	inner := &fakeActuator{applyErr: errors.New("gateway unreachable")}
+	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+	gateway := m.Gateway("gw0")
+
+	actuator := newMeteredActuator(inner, gateway)
+
+	err := actuator.Apply(t.Context(), RouteSnapshot{})
+	require.ErrorIs(t, err, inner.applyErr)
+	require.Equal(t, 1, inner.applyCalls)
+
+	metricList := m.Collect()
+	apply := findMetric(metricList, "route_operator_gateway_apply_total", map[string]string{"gateway": "gw0"})
+	require.NotNil(t, apply)
+	require.Equal(t, uint64(1), apply.GetCounter())
+
+	applyErrors := findMetric(
+		metricList,
+		"route_operator_gateway_apply_errors_total",
+		map[string]string{"gateway": "gw0"},
+	)
+	require.NotNil(t, applyErrors)
+	require.Equal(t, uint64(1), applyErrors.GetCounter())
+
+	require.NoError(t, actuator.Close())
+	require.Equal(t, 1, inner.closeCalls)
+}

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -56,9 +56,11 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	}
 
 	log := opts.Log
-	metrics := NewMetrics()
 
 	moduleName := cfg.Function.Module.Unwrap()
+
+	routeRIBStore := newRIBStore(log)
+	metrics := opts.Metrics(routeRIBStore, !cfg.NetlinkMonitor.Disabled)
 
 	// Build the readiness tracker scope list: one fib:<gateway>:<module> scope per
 	// gateway, plus a neighbours scope, a rib scope, and optionally a bird-session scope.
@@ -93,18 +95,22 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		neighOpts := []neigh.Option{
 			neigh.WithOnSynced(func() {
 				tracker.Set("neighbours", readinesspb.State_STATE_READY)
+				metrics.OnNeighbourSynced()
 			}),
 			neigh.WithOnError(func(err error) {
 				tracker.SetWithReason("neighbours",
 					readinesspb.State_STATE_DEGRADED,
 					&readinesspb.Reason{Code: "RESYNC", Message: err.Error()},
 				)
+				metrics.OnNeighbourError(err)
 			}),
 			neigh.WithOnResynced(func() {
 				tracker.Set("neighbours", readinesspb.State_STATE_READY)
+				metrics.OnNeighbourResynced()
 			}),
 			neigh.WithOnHealthy(func() {
 				tracker.Touch("neighbours")
+				metrics.OnNeighbourHealthy()
 			}),
 		}
 
@@ -115,7 +121,6 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		neighMonitor = monitor
 	}
 
-	routeRIBStore := newRIBStore(log)
 	source := NewRouteSource(neighTable, routeRIBStore)
 	wake := source.WakeFunc()
 	ribHelper := newRIBReadiness(cfg.Readiness, routeRIBStore, moduleName, tracker, log)
@@ -126,9 +131,18 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		WithRouteServiceRIBTTL(ribTTL(cfg)),
 		WithRouteServiceOnChanged(wake),
 		WithRouteServiceLog(log),
-		WithRouteServiceOnRIBSessionStart(ribHelper.OnSessionStart),
-		WithRouteServiceOnRIBUpdate(ribHelper.OnUpdate),
-		WithRouteServiceOnRIBSessionEnd(ribHelper.OnSessionEnd),
+		WithRouteServiceOnRIBSessionStart(func(name string, sessionID uint64) {
+			ribHelper.OnSessionStart(name, sessionID)
+			metrics.OnRIBSessionStart(name, sessionID)
+		}),
+		WithRouteServiceOnRIBUpdate(func(n int) {
+			ribHelper.OnUpdate(n)
+			metrics.OnRIBUpdate(n)
+		}),
+		WithRouteServiceOnRIBSessionEnd(func(name string, sessionID uint64) {
+			ribHelper.OnSessionEnd(name, sessionID)
+			metrics.OnRIBSessionEnd(name, sessionID)
+		}),
 	)
 
 	neighbourSvc := NewNeighbourService(
@@ -142,11 +156,14 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 
 	actuators := make([]Actuator, 0, len(cfg.Gateways))
 	for _, gw := range cfg.Gateways {
+		gatewayMetrics := metrics.Gateway(gw.Name)
+
 		actuator, err := NewGatewayActuator(
 			gw,
 			WithGatewayActuatorLog(log),
 			WithGatewayActuatorFunction(cfg.Function),
 			WithGatewayActuatorDevices(cfg.GatewayDevices[gw.Name]),
+			WithGatewayActuatorOnFIBBuilt(gatewayMetrics.OnFIBBuilt),
 		)
 		if err != nil {
 			for _, a := range actuators {
@@ -155,8 +172,10 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			return nil, fmt.Errorf("failed to construct gateway actuator %q: %w", gw.Name, err)
 		}
 
-		// Wrap each actuator so that apply outcomes drive the per-gateway fib scope.
-		observed := operator.NewObservedActuator(actuator, fmt.Sprintf("fib:%s:%s", gw.Name, moduleName), tracker.Observe)
+		// Wrap each actuator so that apply outcomes drive the per-gateway apply
+		// metrics, then so that they drive the per-gateway fib readiness scope.
+		metered := newMeteredActuator(actuator, gatewayMetrics)
+		observed := operator.NewObservedActuator(metered, fmt.Sprintf("fib:%s:%s", gw.Name, moduleName), tracker.Observe)
 		actuators = append(actuators, observed)
 	}
 

--- a/operators/route/internal/operator/options.go
+++ b/operators/route/internal/operator/options.go
@@ -9,12 +9,14 @@ import (
 )
 
 type options struct {
-	Log *zap.Logger
+	Log     *zap.Logger
+	Metrics MetricsFactory
 }
 
 func newOptions() *options {
 	return &options{
-		Log: zap.NewNop(),
+		Log:     zap.NewNop(),
+		Metrics: NewMetrics,
 	}
 }
 
@@ -25,6 +27,17 @@ type Option func(*options)
 func WithLog(log *zap.Logger) Option {
 	return func(o *options) {
 		o.Log = log
+	}
+}
+
+// WithMetrics overrides the factory used to construct the metrics sink.
+//
+// The default factory is NewMetrics; use this to wrap or extend the
+// default sink, for example to share it with an externally owned
+// metrics-service registration.
+func WithMetrics(factory MetricsFactory) Option {
+	return func(o *options) {
+		o.Metrics = factory
 	}
 }
 
@@ -175,14 +188,16 @@ func newOperatorServiceOptions() *operatorServiceOptions {
 type OperatorServiceOption func(*operatorServiceOptions)
 
 type gatewayActuatorOptions struct {
-	Function FunctionConfig
-	Devices  []string
-	Log      *zap.Logger
+	Function   FunctionConfig
+	Devices    []string
+	OnFIBBuilt func(module string, stats FIBBuildStats)
+	Log        *zap.Logger
 }
 
 func newGatewayActuatorOptions() *gatewayActuatorOptions {
 	return &gatewayActuatorOptions{
-		Log: zap.NewNop(),
+		OnFIBBuilt: func(string, FIBBuildStats) {},
+		Log:        zap.NewNop(),
 	}
 }
 
@@ -212,5 +227,13 @@ func WithGatewayActuatorFunction(fn FunctionConfig) GatewayActuatorOption {
 func WithGatewayActuatorDevices(devices []string) GatewayActuatorOption {
 	return func(o *gatewayActuatorOptions) {
 		o.Devices = devices
+	}
+}
+
+// WithGatewayActuatorOnFIBBuilt registers a callback invoked with the build
+// statistics of every FIB built during Apply.
+func WithGatewayActuatorOnFIBBuilt(fn func(module string, stats FIBBuildStats)) GatewayActuatorOption {
+	return func(o *gatewayActuatorOptions) {
+		o.OnFIBBuilt = fn
 	}
 }


### PR DESCRIPTION
- Adds a metrics sink for the route operator covering four domains: the reconcile loop, per-gateway actuation, RIB state and feed sessions, and the neighbour monitor.
- State gauges are pulled from existing thread-safe snapshots at collection time, event counters piggyback on the callbacks already wired into the operator, and per-gateway apply outcome and duration are observed by a decorator at the actuator boundary.
- FIB build statistics, previously discarded, are now reported per gateway and module, including the count of routes whose nexthops did not resolve.
- The sink is constructed by a factory supplied through operator options, with the default factory wired in automatically, and is served over the existing metrics gRPC service.