### PR TITLE
feat(route-operator): add neighbour table metrics

### DIFF
--- a/operators/route/internal/operator/metrics.go
+++ b/operators/route/internal/operator/metrics.go
@@ -7,6 +7,7 @@ import (
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 )
 
 // applyDurationBounds are the histogram bucket upper bounds, in seconds,
@@ -28,8 +29,9 @@ var reconcilerStateNames = map[operator.ReconcilerState]string{
 // pulled from thread-safe snapshots at Collect time, and gateway sinks
 // are created on demand by Gateway.
 type Metrics struct {
-	ribs                *RIBStore
-	neighMonitorEnabled bool
+	ribs                  *RIBStore
+	neighTable            *neigh.NeighTable
+	netlinkMonitorEnabled bool
 
 	reconcileTotal  metrics.Counter
 	reconcileErrors metrics.Counter
@@ -50,29 +52,61 @@ type Metrics struct {
 
 // NewMetrics constructs the Metrics sink from the operator-owned
 // dependencies it pulls from at Collect time.
-func NewMetrics(ribs *RIBStore, neighMonitorEnabled bool) *Metrics {
+func NewMetrics(ribs *RIBStore, neighTable *neigh.NeighTable, options ...MetricsOption) *Metrics {
+	opts := newMetricsOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	states := make(map[operator.ReconcilerState]*metrics.Gauge, len(reconcilerStateNames))
 	for state := range reconcilerStateNames {
 		states[state] = &metrics.Gauge{}
 	}
 
 	return &Metrics{
-		ribs:                ribs,
-		neighMonitorEnabled: neighMonitorEnabled,
-		states:              states,
-		ribSessionStarts:    metrics.NewMetricMap[*metrics.Counter](),
-		ribSessionEnds:      metrics.NewMetricMap[*metrics.Counter](),
-		gateways:            map[string]*GatewayMetrics{},
+		ribs:                  ribs,
+		neighTable:            neighTable,
+		netlinkMonitorEnabled: opts.NetlinkMonitorEnabled,
+		states:                states,
+		ribSessionStarts:      metrics.NewMetricMap[*metrics.Counter](),
+		ribSessionEnds:        metrics.NewMetricMap[*metrics.Counter](),
+		gateways:              map[string]*GatewayMetrics{},
 	}
 }
 
 // MetricsFactory constructs the operator metrics sink from the
 // operator-owned dependencies.
 //
-// NewOperator invokes the factory once the RIB store exists, so a custom
-// factory can wrap or extend the default sink while still receiving the
-// real pull sources.
-type MetricsFactory func(ribs *RIBStore, neighMonitorEnabled bool) *Metrics
+// NewOperator invokes the factory once the RIB store and neighbour table
+// exist, so a custom factory can wrap or extend the default sink while
+// still receiving the real pull sources.
+type MetricsFactory func(ribs *RIBStore, neighTable *neigh.NeighTable, options ...MetricsOption) *Metrics
+
+// metricsOptions holds the configurable toggles for NewMetrics.
+type metricsOptions struct {
+	NetlinkMonitorEnabled bool
+}
+
+func newMetricsOptions() *metricsOptions {
+	return &metricsOptions{}
+}
+
+// MetricsOption configures NewMetrics.
+type MetricsOption func(*metricsOptions)
+
+// WithNetlinkMonitorMetrics enables the netlink-monitor health metric
+// family.
+//
+// This covers route_operator_neighbour_monitor_healthy,
+// route_operator_neighbour_resyncs_total, and
+// route_operator_neighbour_syncs_total. Pass this option only when the
+// netlink monitor actually runs, so a deliberately disabled monitor does
+// not read as unhealthy.
+func WithNetlinkMonitorMetrics() MetricsOption {
+	return func(o *metricsOptions) {
+		o.NetlinkMonitorEnabled = true
+	}
+}
 
 // OnReconcileCompleted records the outcome of one reconcile pass.
 func (m *Metrics) OnReconcileCompleted(err error) {
@@ -202,6 +236,16 @@ func (m *Metrics) Collect() []*commonpb.Metric {
 		)
 	}
 
+	for _, src := range m.neighTable.ListSources() {
+		out = append(out, makeGauge(
+			"route_operator_neighbour_entries",
+			float64(src.EntryCount),
+			makeLabel("table", src.Name),
+		))
+	}
+	_, nexthops := m.neighTable.View().Entries()
+	out = append(out, makeGauge("route_operator_neighbour_nexthops", float64(nexthops)))
+
 	for _, entry := range m.ribSessionStarts.Metrics() {
 		out = append(out, makeCounter(
 			"route_operator_rib_session_starts_total",
@@ -218,7 +262,7 @@ func (m *Metrics) Collect() []*commonpb.Metric {
 	}
 	out = append(out, makeCounter("route_operator_rib_feed_updates_total", m.ribFeedUpdates.Load()))
 
-	if m.neighMonitorEnabled {
+	if m.netlinkMonitorEnabled {
 		out = append(out,
 			makeGauge("route_operator_neighbour_monitor_healthy", m.neighbourHealthy.Load()),
 			makeCounter("route_operator_neighbour_resyncs_total", m.neighbourResyncs.Load()),

--- a/operators/route/internal/operator/metrics_test.go
+++ b/operators/route/internal/operator/metrics_test.go
@@ -12,6 +12,7 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 	"github.com/yanet-platform/yanet2/operators/route/internal/rib"
 )
 
@@ -64,7 +65,7 @@ func (m *fakeActuator) Close() error {
 // TestMetrics_ReconcileEvents verifies that reconcile-loop observer methods
 // update the corresponding counters and gauges rendered by Collect.
 func TestMetrics_ReconcileEvents(t *testing.T) {
-	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+	m := NewMetrics(newRIBStore(zap.NewNop()), neigh.NewNeighTable())
 
 	m.OnReconcileCompleted(nil)
 	m.OnReconcileCompleted(errors.New("boom"))
@@ -102,7 +103,7 @@ func TestMetrics_ReconcileEvents(t *testing.T) {
 // TestMetrics_RIBFeedEvents verifies that RIB session and update callbacks
 // are rendered per module, without leaking into other modules' counters.
 func TestMetrics_RIBFeedEvents(t *testing.T) {
-	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+	m := NewMetrics(newRIBStore(zap.NewNop()), neigh.NewNeighTable())
 
 	m.OnRIBSessionStart("route0", 1)
 	m.OnRIBSessionStart("route0", 2)
@@ -135,7 +136,7 @@ func TestMetrics_RIBFeedEvents(t *testing.T) {
 // neighbour metrics are absent when the monitor is disabled.
 func TestMetrics_NeighbourEvents(t *testing.T) {
 	t.Run("MonitorEnabled", func(t *testing.T) {
-		m := NewMetrics(newRIBStore(zap.NewNop()), true)
+		m := NewMetrics(newRIBStore(zap.NewNop()), neigh.NewNeighTable(), WithNetlinkMonitorMetrics())
 
 		m.OnNeighbourSynced()
 		m.OnNeighbourHealthy()
@@ -159,7 +160,7 @@ func TestMetrics_NeighbourEvents(t *testing.T) {
 	})
 
 	t.Run("MonitorDisabled", func(t *testing.T) {
-		m := NewMetrics(newRIBStore(zap.NewNop()), false)
+		m := NewMetrics(newRIBStore(zap.NewNop()), neigh.NewNeighTable())
 
 		m.OnNeighbourSynced()
 		m.OnNeighbourHealthy()
@@ -182,7 +183,7 @@ func TestMetrics_PullRIBStats(t *testing.T) {
 		rib.RouteSourceStatic,
 	))
 
-	m := NewMetrics(store, false)
+	m := NewMetrics(store, neigh.NewNeighTable())
 
 	metricList := m.Collect()
 
@@ -201,10 +202,55 @@ func TestMetrics_PullRIBStats(t *testing.T) {
 	))
 }
 
+// TestMetrics_PullNeighbourStats verifies that neighbour gauges are pulled
+// from the live NeighTable's sources and merged view at Collect time.
+func TestMetrics_PullNeighbourStats(t *testing.T) {
+	table := neigh.NewNeighTable()
+	_, err := table.CreateSource("kernel", 100, false)
+	require.NoError(t, err)
+
+	require.NoError(t, table.Add("kernel", []neigh.NeighbourEntry{
+		{
+			NextHop: netip.MustParseAddr("10.0.0.1"),
+			HardwareRoute: neigh.HardwareRoute{
+				SourceMAC:      [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+				DestinationMAC: [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x02},
+				Device:         "eth0",
+			},
+			UpdatedAt: time.Now(),
+			State:     neigh.NeighbourStatePermanent,
+			Priority:  100,
+		},
+		{
+			NextHop: netip.MustParseAddr("10.0.0.2"),
+			HardwareRoute: neigh.HardwareRoute{
+				SourceMAC:      [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x03},
+				DestinationMAC: [6]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x04},
+				Device:         "eth0",
+			},
+			UpdatedAt: time.Now(),
+			State:     neigh.NeighbourStatePermanent,
+			Priority:  100,
+		},
+	}))
+
+	m := NewMetrics(newRIBStore(zap.NewNop()), table)
+
+	metricList := m.Collect()
+
+	entries := findMetric(metricList, "route_operator_neighbour_entries", map[string]string{"table": "kernel"})
+	require.NotNil(t, entries)
+	require.Equal(t, 2.0, entries.GetGauge())
+
+	nexthops := findMetric(metricList, "route_operator_neighbour_nexthops", map[string]string{})
+	require.NotNil(t, nexthops)
+	require.Equal(t, 2.0, nexthops.GetGauge())
+}
+
 // TestGatewayMetrics_FIBBuilt verifies that OnFIBBuilt renders the five FIB
 // gauges from FIBBuildStats, keyed by gateway and module.
 func TestGatewayMetrics_FIBBuilt(t *testing.T) {
-	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+	m := NewMetrics(newRIBStore(zap.NewNop()), neigh.NewNeighTable())
 
 	gateway := m.Gateway("gw0")
 	gateway.OnFIBBuilt("route0", FIBBuildStats{
@@ -242,7 +288,7 @@ func TestGatewayMetrics_FIBBuilt(t *testing.T) {
 // TestGatewayMetrics_ObserveApply verifies that ObserveApply updates the
 // apply counters and renders a non-empty duration histogram.
 func TestGatewayMetrics_ObserveApply(t *testing.T) {
-	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+	m := NewMetrics(newRIBStore(zap.NewNop()), neigh.NewNeighTable())
 	gateway := m.Gateway("gw0")
 
 	gateway.ObserveApply(10*time.Millisecond, nil)
@@ -275,7 +321,7 @@ func TestGatewayMetrics_ObserveApply(t *testing.T) {
 // Apply call, returns the inner error unchanged, and delegates Close.
 func TestMeteredActuator(t *testing.T) {
 	inner := &fakeActuator{applyErr: errors.New("gateway unreachable")}
-	m := NewMetrics(newRIBStore(zap.NewNop()), false)
+	m := NewMetrics(newRIBStore(zap.NewNop()), neigh.NewNeighTable())
 	gateway := m.Gateway("gw0")
 
 	actuator := newMeteredActuator(inner, gateway)

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -60,7 +60,6 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	moduleName := cfg.Function.Module.Unwrap()
 
 	routeRIBStore := newRIBStore(log)
-	metrics := opts.Metrics(routeRIBStore, !cfg.NetlinkMonitor.Disabled)
 
 	// Build the readiness tracker scope list: one fib:<gateway>:<module> scope per
 	// gateway, plus a neighbours scope, a rib scope, and optionally a bird-session scope.
@@ -80,6 +79,12 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 	if _, err := neighTable.CreateSource("static", staticTablePriority, true); err != nil {
 		return nil, fmt.Errorf("failed to create static neighbour source: %w", err)
 	}
+
+	metricsOptions := []MetricsOption{}
+	if !cfg.NetlinkMonitor.Disabled {
+		metricsOptions = append(metricsOptions, WithNetlinkMonitorMetrics())
+	}
+	metrics := opts.Metrics(routeRIBStore, neighTable, metricsOptions...)
 
 	// Propagate the neighbours scope based on netlink monitor config, and
 	// construct the monitor itself only when it is enabled.


### PR DESCRIPTION
- Adds neighbour-table state gauges to the route operator metrics: per-source entry counts and the merged nexthop view size, pulled from the live table at collection time.
- Replaces the boolean monitor flag in the metrics constructor with functional options, so the netlink monitor health family is enabled by an explicit option and the constructor stays readable at the call site.