### PR TITLE
feat(grpcmetrics): add a stream server interceptor

### DIFF
--- a/common/go/grpcmetrics/grpcmetrics.go
+++ b/common/go/grpcmetrics/grpcmetrics.go
@@ -1,5 +1,6 @@
-// Package grpcmetrics provides an opt-in gRPC unary server interceptor that
-// records per-call metrics and renders them to commonpb.Metric.
+// Package grpcmetrics provides opt-in gRPC unary and stream server
+// interceptors that record per-call metrics and render them to
+// commonpb.Metric.
 //
 // Each ServerMetrics instance tracks three metric families:
 //   - grpc_server_started_total    — counter per {grpc_type, grpc_service, grpc_method[, config]}
@@ -7,17 +8,28 @@
 //   - grpc_server_handling_seconds — histogram per {grpc_type, grpc_service, grpc_method[, config]}
 //
 // Label names follow the go-grpc-prometheus (go-grpc-middleware/providers/prometheus)
-// server convention. grpc_type is always "unary"; streaming is a documented
-// future follow-up. The optional "config" label is emitted when the
+// server convention. grpc_type is "unary" for UnaryServerInterceptor calls and
+// one of "client_stream", "server_stream", or "bidi_stream" for
+// StreamServerInterceptor calls, depending on the direction flags on
+// grpc.StreamServerInfo. The optional "config" label is emitted when the
 // Labeler provides it.
 //
-// Stale series are pruned via a retention predicate.
+// A transparent gRPC proxy (such as the gateway's unknown-service handler)
+// registers every proxied method, including originally unary ones, as a
+// bidirectional stream at the transport level. Calls recorded through such a
+// proxy therefore carry grpc_type="bidi_stream" even when the underlying RPC
+// is unary — this reflects transport-level truth, not a labeling bug.
+//
+// A service filter rejects calls for unknown services before any series or
+// per-service method bookkeeping is allocated, and stale series are pruned
+// via a retention predicate.
 package grpcmetrics
 
 import (
 	"context"
 	"maps"
 	"strings"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -29,13 +41,28 @@ import (
 )
 
 const (
-	labelType    = "grpc_type"
-	labelService = "grpc_service"
-	labelMethod  = "grpc_method"
-	labelCode    = "grpc_code"
+	labelType   = "grpc_type"
+	labelMethod = "grpc_method"
+	labelCode   = "grpc_code"
 )
 
-const grpcTypeUnary = "unary"
+// methodOverflow is the grpc_method label value recorded once a service's
+// distinct method count has reached the WithPerServiceMethodLimit cap.
+const methodOverflow = "other"
+
+// ServiceLabel is the label key holding the fully-qualified gRPC service name
+// on every recorded series.
+//
+// Retention predicates that key off the proxied service name, rather than a
+// Labeler-supplied label, read id.Labels[ServiceLabel].
+const ServiceLabel = "grpc_service"
+
+const (
+	grpcTypeUnary        = "unary"
+	grpcTypeClientStream = "client_stream"
+	grpcTypeServerStream = "server_stream"
+	grpcTypeBidiStream   = "bidi_stream"
+)
 
 // DefaultBuckets is the default histogram bucket boundary set in seconds.
 //
@@ -49,7 +76,10 @@ var DefaultBuckets = []float64{
 // Labeler derives extra per-call labels from a unary request.
 //
 // It is called once per RPC before the handler runs. A nil return means no
-// extra labels are attached.
+// extra labels are attached. Stream calls have no single request message, so
+// StreamServerInterceptor invokes the Labeler with a nil req; a Labeler that
+// only type-switches on req (the common case) naturally yields no extra
+// labels for streams.
 type Labeler func(fullMethod string, req any) metrics.Labels
 
 // Retention reports which series to keep when pruning stale metrics.
@@ -118,13 +148,18 @@ func (m *codeSeries) Record() {
 
 // ServerMetrics records unary gRPC server call metrics.
 type ServerMetrics struct {
-	buckets   []float64
-	labeler   Labeler
-	retention Retention
-	clock     func() time.Time
+	buckets               []float64
+	labeler               Labeler
+	retention             Retention
+	clock                 func() time.Time
+	perServiceMethodLimit int
+	serviceFilter         func(service string) bool
 
 	calls   *metrics.MetricMap[*callSeries]
 	handled *metrics.MetricMap[*codeSeries]
+
+	methodsMu sync.Mutex
+	methods   map[string]map[string]struct{}
 }
 
 // Factory builds a ServerMetrics bound to a caller-supplied retention
@@ -156,13 +191,49 @@ func New(options ...Option) *ServerMetrics {
 		o(opts)
 	}
 	return &ServerMetrics{
-		buckets:   opts.Buckets,
-		labeler:   opts.Labeler,
-		retention: opts.Retention,
-		clock:     opts.Clock,
-		calls:     metrics.NewMetricMap[*callSeries](),
-		handled:   metrics.NewMetricMap[*codeSeries](),
+		buckets:               opts.Buckets,
+		labeler:               opts.Labeler,
+		retention:             opts.Retention,
+		clock:                 opts.Clock,
+		perServiceMethodLimit: opts.PerServiceMethodLimit,
+		serviceFilter:         opts.ServiceFilter,
+		calls:                 metrics.NewMetricMap[*callSeries](),
+		handled:               metrics.NewMetricMap[*codeSeries](),
+		methods:               map[string]map[string]struct{}{},
 	}
+}
+
+// resolveMethod applies the per-service method cardinality cap and returns
+// the label value to record under grpc_method.
+//
+// The decision is made once per call and reused for the started, handled,
+// and handling series alike. A method already tracked for the service keeps
+// its own name. A new method is admitted while the service is under the
+// limit; once the limit is reached, further new methods are folded into the
+// methodOverflow label instead. A limit of 0 disables the cap.
+func (m *ServerMetrics) resolveMethod(service, method string) string {
+	if m.perServiceMethodLimit <= 0 {
+		return method
+	}
+
+	m.methodsMu.Lock()
+	defer m.methodsMu.Unlock()
+
+	seen := m.methods[service]
+	if _, ok := seen[method]; ok {
+		return method
+	}
+	if len(seen) >= m.perServiceMethodLimit {
+		return methodOverflow
+	}
+
+	if seen == nil {
+		seen = map[string]struct{}{}
+		m.methods[service] = seen
+	}
+	seen[method] = struct{}{}
+
+	return method
 }
 
 // UnaryServerInterceptor returns a gRPC unary server interceptor that records
@@ -174,12 +245,17 @@ func (m *ServerMetrics) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp any, err error) {
+		service, method := splitFullMethod(info.FullMethod)
+		if !m.serviceFilter(service) {
+			return handler(ctx, req)
+		}
+
 		start := m.clock()
 
 		extra := m.labeler(info.FullMethod, req)
 
-		service, method := splitFullMethod(info.FullMethod)
-		callID := m.callID(service, method, extra)
+		method = m.resolveMethod(service, method)
+		callID := m.callID(grpcTypeUnary, service, method, extra)
 		call := m.calls.GetOrCreate(callID, func() *callSeries {
 			return newCallSeries(m.buckets)
 		})
@@ -193,7 +269,7 @@ func (m *ServerMetrics) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 			} else {
 				code = status.Code(err)
 			}
-			m.recordExit(call, service, method, extra, code, start)
+			m.recordExit(grpcTypeUnary, call, service, method, extra, code, start)
 			if r != nil {
 				panic(r)
 			}
@@ -204,7 +280,73 @@ func (m *ServerMetrics) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
+// StreamServerInterceptor returns a gRPC stream server interceptor that
+// records started, handled, and handling-latency metrics for every call.
+//
+// The grpc_type label is derived from the direction flags on
+// grpc.StreamServerInfo; see the package doc for the transparent-proxy
+// caveat.
+func (m *ServerMetrics) StreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv any,
+		stream grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) (err error) {
+		service, method := splitFullMethod(info.FullMethod)
+		if !m.serviceFilter(service) {
+			return handler(srv, stream)
+		}
+
+		start := m.clock()
+
+		grpcType := streamGRPCType(info)
+		extra := m.labeler(info.FullMethod, nil)
+
+		method = m.resolveMethod(service, method)
+		callID := m.callID(grpcType, service, method, extra)
+		call := m.calls.GetOrCreate(callID, func() *callSeries {
+			return newCallSeries(m.buckets)
+		})
+		call.RecordStart()
+
+		defer func() {
+			r := recover()
+			var code codes.Code
+			if r != nil {
+				code = codes.Unknown
+			} else {
+				code = status.Code(err)
+			}
+			m.recordExit(grpcType, call, service, method, extra, code, start)
+			if r != nil {
+				panic(r)
+			}
+		}()
+
+		err = handler(srv, stream)
+		return err
+	}
+}
+
+// streamGRPCType classifies a stream call per the go-grpc-prometheus
+// convention: bidirectional when both direction flags are set, otherwise the
+// single direction that is set.
+func streamGRPCType(info *grpc.StreamServerInfo) string {
+	switch {
+	case info.IsClientStream && info.IsServerStream:
+		return grpcTypeBidiStream
+	case info.IsClientStream:
+		return grpcTypeClientStream
+	case info.IsServerStream:
+		return grpcTypeServerStream
+	default:
+		return grpcTypeBidiStream
+	}
+}
+
 func (m *ServerMetrics) recordExit(
+	grpcType string,
 	call *callSeries,
 	service string,
 	method string,
@@ -215,7 +357,7 @@ func (m *ServerMetrics) recordExit(
 	durationSeconds := m.clock().Sub(start).Seconds()
 	call.RecordFinish(durationSeconds)
 
-	handledID := m.handledID(service, method, code.String(), extra)
+	handledID := m.handledID(grpcType, service, method, code.String(), extra)
 	handled := m.handled.GetOrCreate(handledID, func() *codeSeries {
 		return &codeSeries{}
 	})
@@ -249,20 +391,20 @@ func (m *ServerMetrics) reconcile() {
 	})
 }
 
-func (m *ServerMetrics) callID(service, method string, extra metrics.Labels) metrics.MetricID {
+func (m *ServerMetrics) callID(grpcType, service, method string, extra metrics.Labels) metrics.MetricID {
 	labels := metrics.Labels{
-		labelType:    grpcTypeUnary,
-		labelService: service,
+		labelType:    grpcType,
+		ServiceLabel: service,
 		labelMethod:  method,
 	}
 	maps.Copy(labels, extra)
 	return metrics.MetricID{Labels: labels}
 }
 
-func (m *ServerMetrics) handledID(service, method, code string, extra metrics.Labels) metrics.MetricID {
+func (m *ServerMetrics) handledID(grpcType, service, method, code string, extra metrics.Labels) metrics.MetricID {
 	labels := metrics.Labels{
-		labelType:    grpcTypeUnary,
-		labelService: service,
+		labelType:    grpcType,
+		ServiceLabel: service,
 		labelMethod:  method,
 		labelCode:    code,
 	}

--- a/common/go/grpcmetrics/grpcmetrics_test.go
+++ b/common/go/grpcmetrics/grpcmetrics_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
@@ -18,6 +19,31 @@ import (
 // fakeInfo builds a grpc.UnaryServerInfo for tests.
 func fakeInfo(method string) *grpc.UnaryServerInfo {
 	return &grpc.UnaryServerInfo{FullMethod: method}
+}
+
+// fakeServerStream is a minimal grpc.ServerStream for tests that never sends
+// or receives messages.
+type fakeServerStream struct {
+	ctx context.Context
+}
+
+func (m *fakeServerStream) Context() context.Context     { return m.ctx }
+func (m *fakeServerStream) SetHeader(metadata.MD) error  { return nil }
+func (m *fakeServerStream) SendHeader(metadata.MD) error { return nil }
+func (m *fakeServerStream) SetTrailer(metadata.MD)       {}
+func (m *fakeServerStream) SendMsg(any) error            { return nil }
+func (m *fakeServerStream) RecvMsg(any) error            { return nil }
+
+// okStreamHandler is a gRPC stream handler that succeeds.
+func okStreamHandler(_ any, _ grpc.ServerStream) error {
+	return nil
+}
+
+// errStreamHandler returns a gRPC status error with the given code.
+func errStreamHandler(code codes.Code) grpc.StreamHandler {
+	return func(_ any, _ grpc.ServerStream) error {
+		return status.Errorf(code, "test stream error")
+	}
 }
 
 // okHandler is a gRPC handler that succeeds.
@@ -381,4 +407,415 @@ func TestParallelCallsRace(t *testing.T) {
 
 	out := serverMetrics.Collect()
 	assert.NotEmpty(t, out)
+}
+
+// TestStreamInterceptorOK verifies that a successful stream call records
+// started, the handling-seconds observation, and handled with grpc_code=OK,
+// labeled with the grpc_type matching the stream's direction flags.
+func TestStreamInterceptorOK(t *testing.T) {
+	tests := []struct {
+		name           string
+		isClientStream bool
+		isServerStream bool
+		wantType       string
+	}{
+		{
+			name:           "bidi stream",
+			isClientStream: true,
+			isServerStream: true,
+			wantType:       "bidi_stream",
+		},
+		{
+			name:           "client stream",
+			isClientStream: true,
+			isServerStream: false,
+			wantType:       "client_stream",
+		},
+		{
+			name:           "server stream",
+			isClientStream: false,
+			isServerStream: true,
+			wantType:       "server_stream",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			serverMetrics := New()
+			interceptor := serverMetrics.StreamServerInterceptor()
+
+			info := &grpc.StreamServerInfo{
+				FullMethod:     "/svc/Method",
+				IsClientStream: test.isClientStream,
+				IsServerStream: test.isServerStream,
+			}
+			err := interceptor(nil, &fakeServerStream{ctx: t.Context()}, info, okStreamHandler)
+			require.NoError(t, err)
+
+			out := serverMetrics.Collect()
+			baseLabels := map[string]string{
+				"grpc_type":    test.wantType,
+				"grpc_service": "svc",
+				"grpc_method":  "Method",
+			}
+
+			started := findMetric(out, "grpc_server_started_total", baseLabels)
+			require.NotNil(t, started, "grpc_server_started_total should be present")
+			assert.Equal(t, uint64(1), counterValue(started))
+
+			handling := findMetric(out, "grpc_server_handling_seconds", baseLabels)
+			require.NotNil(t, handling, "grpc_server_handling_seconds should be present")
+			assert.Equal(t, uint64(1), histogramTotal(handling))
+
+			handledLabels := map[string]string{
+				"grpc_type":    test.wantType,
+				"grpc_service": "svc",
+				"grpc_method":  "Method",
+				"grpc_code":    codes.OK.String(),
+			}
+			handled := findMetric(out, "grpc_server_handled_total", handledLabels)
+			require.NotNil(t, handled, "grpc_server_handled_total should be present")
+			assert.Equal(t, uint64(1), counterValue(handled))
+		})
+	}
+}
+
+// TestStreamInterceptorErrorCode verifies that a stream handler returning a
+// gRPC status error records handled with the matching grpc_code and no OK
+// series.
+func TestStreamInterceptorErrorCode(t *testing.T) {
+	serverMetrics := New()
+	interceptor := serverMetrics.StreamServerInterceptor()
+
+	info := &grpc.StreamServerInfo{
+		FullMethod:     "/svc/Method",
+		IsClientStream: true,
+		IsServerStream: true,
+	}
+	err := interceptor(nil, &fakeServerStream{ctx: t.Context()}, info, errStreamHandler(codes.NotFound))
+	require.Error(t, err)
+
+	out := serverMetrics.Collect()
+
+	handledLabels := map[string]string{
+		"grpc_type":    "bidi_stream",
+		"grpc_service": "svc",
+		"grpc_method":  "Method",
+		"grpc_code":    codes.NotFound.String(),
+	}
+	handled := findMetric(out, "grpc_server_handled_total", handledLabels)
+	require.NotNil(t, handled, "grpc_server_handled_total[NotFound] should be present")
+	assert.Equal(t, uint64(1), counterValue(handled))
+
+	okLabels := map[string]string{
+		"grpc_type":    "bidi_stream",
+		"grpc_service": "svc",
+		"grpc_method":  "Method",
+		"grpc_code":    codes.OK.String(),
+	}
+	assert.Nil(t, findMetric(out, "grpc_server_handled_total", okLabels), "OK series should not exist")
+}
+
+// TestStreamInterceptorLabelerReceivesNilReq verifies that the Labeler is
+// invoked with a nil req for stream calls.
+func TestStreamInterceptorLabelerReceivesNilReq(t *testing.T) {
+	var gotReq any
+	sawReq := false
+
+	serverMetrics := New(
+		WithLabeler(func(_ string, req any) metrics.Labels {
+			gotReq = req
+			sawReq = true
+			return nil
+		}),
+	)
+	interceptor := serverMetrics.StreamServerInterceptor()
+
+	info := &grpc.StreamServerInfo{
+		FullMethod:     "/svc/Method",
+		IsClientStream: true,
+		IsServerStream: true,
+	}
+	err := interceptor(nil, &fakeServerStream{ctx: t.Context()}, info, okStreamHandler)
+	require.NoError(t, err)
+
+	require.True(t, sawReq, "labeler should have been invoked")
+	assert.Nil(t, gotReq, "labeler should receive a nil req for stream calls")
+}
+
+// TestPerServiceMethodLimitUnary verifies that WithPerServiceMethodLimit caps
+// the distinct grpc_method values recorded per service on the unary path:
+// methods admitted before the cap keep their own name, methods past the cap
+// fold into the overflow label, and repeat calls to an already-tracked
+// method are unaffected.
+func TestPerServiceMethodLimitUnary(t *testing.T) {
+	serverMetrics := New(WithPerServiceMethodLimit(2))
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	call := func(method string) {
+		_, err := interceptor(t.Context(), nil, fakeInfo(method), okHandler)
+		require.NoError(t, err)
+	}
+
+	call("/svc/One")
+	call("/svc/Two")
+	call("/svc/Three")
+	call("/svc/One")
+
+	out := serverMetrics.Collect()
+
+	for _, method := range []string{"One", "Two"} {
+		started := findMetric(out, "grpc_server_started_total", map[string]string{
+			"grpc_type":    "unary",
+			"grpc_service": "svc",
+			"grpc_method":  method,
+		})
+		require.NotNil(t, started, "method %s below the limit should keep its own name", method)
+	}
+
+	one := findMetric(out, "grpc_server_started_total", map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "One",
+	})
+	require.NotNil(t, one)
+	assert.Equal(t, uint64(2), counterValue(one),
+		"repeat call to a known method should still record under its own name")
+
+	three := findMetric(out, "grpc_server_started_total", map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "Three",
+	})
+	assert.Nil(t, three, "a method past the limit must not appear under its own name")
+
+	overflowLabels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "other",
+	}
+	overflowStarted := findMetric(out, "grpc_server_started_total", overflowLabels)
+	require.NotNil(t, overflowStarted, "a method past the limit should be recorded under the overflow label")
+	assert.Equal(t, uint64(1), counterValue(overflowStarted))
+
+	overflowHandling := findMetric(out, "grpc_server_handling_seconds", overflowLabels)
+	require.NotNil(t, overflowHandling, "handling-seconds should also use the overflow label")
+	assert.Equal(t, uint64(1), histogramTotal(overflowHandling))
+
+	overflowHandledLabels := map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "other",
+		"grpc_code":    codes.OK.String(),
+	}
+	overflowHandled := findMetric(out, "grpc_server_handled_total", overflowHandledLabels)
+	require.NotNil(t, overflowHandled, "handled should also use the overflow label")
+	assert.Equal(t, uint64(1), counterValue(overflowHandled))
+}
+
+// TestPerServiceMethodLimitStream verifies that the overflow label applies
+// consistently on the stream path too, across all three metric families.
+func TestPerServiceMethodLimitStream(t *testing.T) {
+	serverMetrics := New(WithPerServiceMethodLimit(1))
+	interceptor := serverMetrics.StreamServerInterceptor()
+
+	info := func(method string) *grpc.StreamServerInfo {
+		return &grpc.StreamServerInfo{FullMethod: method, IsClientStream: true, IsServerStream: true}
+	}
+
+	require.NoError(t, interceptor(nil, &fakeServerStream{ctx: t.Context()}, info("/svc/One"), okStreamHandler))
+	require.NoError(t, interceptor(nil, &fakeServerStream{ctx: t.Context()}, info("/svc/Two"), okStreamHandler))
+
+	out := serverMetrics.Collect()
+
+	overflowLabels := map[string]string{
+		"grpc_type":    "bidi_stream",
+		"grpc_service": "svc",
+		"grpc_method":  "other",
+	}
+	assert.NotNil(t, findMetric(out, "grpc_server_started_total", overflowLabels),
+		"started should use the overflow label")
+	assert.NotNil(t, findMetric(out, "grpc_server_handling_seconds", overflowLabels),
+		"handling-seconds should use the overflow label")
+
+	overflowHandledLabels := map[string]string{
+		"grpc_type":    "bidi_stream",
+		"grpc_service": "svc",
+		"grpc_method":  "other",
+		"grpc_code":    codes.OK.String(),
+	}
+	assert.NotNil(t, findMetric(out, "grpc_server_handled_total", overflowHandledLabels),
+		"handled should use the overflow label")
+
+	assert.Nil(t, findMetric(out, "grpc_server_started_total", map[string]string{
+		"grpc_type":    "bidi_stream",
+		"grpc_service": "svc",
+		"grpc_method":  "Two",
+	}), "the method past the limit must not appear under its own name")
+}
+
+// TestPerServiceMethodLimitUnlimitedByDefault verifies that a ServerMetrics
+// with no WithPerServiceMethodLimit option never folds methods into the
+// overflow label, regardless of how many distinct methods a service sees.
+func TestPerServiceMethodLimitUnlimitedByDefault(t *testing.T) {
+	serverMetrics := New()
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	for _, method := range []string{"/svc/One", "/svc/Two", "/svc/Three", "/svc/Four"} {
+		_, err := interceptor(t.Context(), nil, fakeInfo(method), okHandler)
+		require.NoError(t, err)
+	}
+
+	out := serverMetrics.Collect()
+
+	overflow := findMetric(out, "grpc_server_started_total", map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "svc",
+		"grpc_method":  "other",
+	})
+	assert.Nil(t, overflow, "no method should be folded into the overflow label without a limit")
+
+	for _, method := range []string{"One", "Two", "Three", "Four"} {
+		started := findMetric(out, "grpc_server_started_total", map[string]string{
+			"grpc_type":    "unary",
+			"grpc_service": "svc",
+			"grpc_method":  method,
+		})
+		assert.NotNil(t, started, "method %s should keep its own name", method)
+	}
+}
+
+// TestPerServiceMethodLimitPerService verifies that the cap is tracked
+// independently per grpc_service: exhausting one service's method slots does
+// not affect another service's cap.
+func TestPerServiceMethodLimitPerService(t *testing.T) {
+	serverMetrics := New(WithPerServiceMethodLimit(1))
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	call := func(method string) {
+		_, err := interceptor(t.Context(), nil, fakeInfo(method), okHandler)
+		require.NoError(t, err)
+	}
+
+	call("/svcA/One")
+	call("/svcB/One")
+
+	out := serverMetrics.Collect()
+
+	for _, service := range []string{"svcA", "svcB"} {
+		started := findMetric(out, "grpc_server_started_total", map[string]string{
+			"grpc_type":    "unary",
+			"grpc_service": service,
+			"grpc_method":  "One",
+		})
+		require.NotNil(t, started, "service %s should admit its first method under its own name", service)
+	}
+}
+
+// TestServiceFilterRejectsUnary verifies that a rejected service records no
+// series and calls the handler directly, while an accepted service is
+// unaffected.
+func TestServiceFilterRejectsUnary(t *testing.T) {
+	serverMetrics := New(WithServiceFilter(func(service string) bool {
+		return service == "allowed"
+	}))
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	resp, err := interceptor(t.Context(), "req", fakeInfo("/rejected/Method"), okHandler)
+	require.NoError(t, err)
+	assert.Equal(t, "req", resp, "handler should still run for a rejected service")
+
+	resp, err = interceptor(t.Context(), "req", fakeInfo("/allowed/Method"), okHandler)
+	require.NoError(t, err)
+	assert.Equal(t, "req", resp)
+
+	out := serverMetrics.Collect()
+
+	rejected := findMetric(out, "grpc_server_started_total", map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "rejected",
+		"grpc_method":  "Method",
+	})
+	assert.Nil(t, rejected, "a rejected service must not record a series")
+
+	allowed := findMetric(out, "grpc_server_started_total", map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "allowed",
+		"grpc_method":  "Method",
+	})
+	require.NotNil(t, allowed, "an accepted service should record normally")
+	assert.Equal(t, uint64(1), counterValue(allowed))
+}
+
+// TestServiceFilterRejectsStream verifies that a rejected service records no
+// series on the stream path either, while an accepted service is unaffected.
+func TestServiceFilterRejectsStream(t *testing.T) {
+	serverMetrics := New(WithServiceFilter(func(service string) bool {
+		return service == "allowed"
+	}))
+	interceptor := serverMetrics.StreamServerInterceptor()
+
+	info := func(method string) *grpc.StreamServerInfo {
+		return &grpc.StreamServerInfo{FullMethod: method, IsClientStream: true, IsServerStream: true}
+	}
+
+	require.NoError(t, interceptor(nil, &fakeServerStream{ctx: t.Context()}, info("/rejected/Method"), okStreamHandler))
+	require.NoError(t, interceptor(nil, &fakeServerStream{ctx: t.Context()}, info("/allowed/Method"), okStreamHandler))
+
+	out := serverMetrics.Collect()
+
+	rejected := findMetric(out, "grpc_server_started_total", map[string]string{
+		"grpc_type":    "bidi_stream",
+		"grpc_service": "rejected",
+		"grpc_method":  "Method",
+	})
+	assert.Nil(t, rejected, "a rejected service must not record a series")
+
+	allowed := findMetric(out, "grpc_server_started_total", map[string]string{
+		"grpc_type":    "bidi_stream",
+		"grpc_service": "allowed",
+		"grpc_method":  "Method",
+	})
+	require.NotNil(t, allowed, "an accepted service should record normally")
+	assert.Equal(t, uint64(1), counterValue(allowed))
+}
+
+// TestServiceFilterRejectsMethodBookkeeping verifies that a rejected service
+// never populates the per-service method map, even under a method limit.
+func TestServiceFilterRejectsMethodBookkeeping(t *testing.T) {
+	serverMetrics := New(
+		WithServiceFilter(func(service string) bool {
+			return service == "allowed"
+		}),
+		WithPerServiceMethodLimit(64),
+	)
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	for _, method := range []string{"/rejected/One", "/rejected/Two", "/rejected/Three"} {
+		_, err := interceptor(t.Context(), nil, fakeInfo(method), okHandler)
+		require.NoError(t, err)
+	}
+
+	serverMetrics.methodsMu.Lock()
+	_, ok := serverMetrics.methods["rejected"]
+	serverMetrics.methodsMu.Unlock()
+	assert.False(t, ok, "a rejected service must not allocate a method bookkeeping entry")
+}
+
+// TestServiceFilterDefaultAcceptsAll verifies that a ServerMetrics built
+// without WithServiceFilter records every service unchanged.
+func TestServiceFilterDefaultAcceptsAll(t *testing.T) {
+	serverMetrics := New()
+	interceptor := serverMetrics.UnaryServerInterceptor()
+
+	_, err := interceptor(t.Context(), nil, fakeInfo("/anything/Method"), okHandler)
+	require.NoError(t, err)
+
+	out := serverMetrics.Collect()
+	started := findMetric(out, "grpc_server_started_total", map[string]string{
+		"grpc_type":    "unary",
+		"grpc_service": "anything",
+		"grpc_method":  "Method",
+	})
+	require.NotNil(t, started, "the default filter should accept every service")
 }

--- a/common/go/grpcmetrics/options.go
+++ b/common/go/grpcmetrics/options.go
@@ -10,10 +10,12 @@ import (
 type Option func(*options)
 
 type options struct {
-	Buckets   []float64
-	Labeler   Labeler
-	Retention Retention
-	Clock     func() time.Time
+	Buckets               []float64
+	Labeler               Labeler
+	Retention             Retention
+	Clock                 func() time.Time
+	PerServiceMethodLimit int
+	ServiceFilter         func(service string) bool
 }
 
 func newOptions() *options {
@@ -27,7 +29,11 @@ func newOptions() *options {
 				return true
 			}
 		},
-		Clock: time.Now,
+		Clock:                 time.Now,
+		PerServiceMethodLimit: 0,
+		ServiceFilter: func(string) bool {
+			return true
+		},
 	}
 }
 
@@ -62,5 +68,37 @@ func WithClock(fn func() time.Time) Option {
 		if fn != nil {
 			o.Clock = fn
 		}
+	}
+}
+
+// WithPerServiceMethodLimit caps the number of distinct grpc_method label
+// values tracked per grpc_service.
+//
+// Once a service reaches the limit, calls for a method not already seen are
+// recorded under the overflow label grpc_method="other" instead of the
+// client-supplied name; methods already tracked keep recording under their
+// own name. A server that only exposes registered services rejects unknown
+// methods before any interceptor runs, so the cap is chiefly useful for
+// transparent proxies, which forward any client-supplied method name under a
+// registered service straight to the backend. The default, 0, is unlimited.
+func WithPerServiceMethodLimit(limit int) Option {
+	return func(o *options) {
+		o.PerServiceMethodLimit = limit
+	}
+}
+
+// WithServiceFilter sets a predicate that gates which fully-qualified gRPC
+// services get recorded at all.
+//
+// It runs first, before any series or per-service method bookkeeping is
+// allocated for a call. This is essential for transparent proxies whose
+// interceptors run ahead of routing and auth: an unauthenticated caller
+// probing random service names would otherwise create a permanent metric
+// series and a permanent methods-map entry for each one, since Retention
+// only prunes series for services the server once knew but later removed.
+// The default accepts every service.
+func WithServiceFilter(filter func(service string) bool) Option {
+	return func(o *options) {
+		o.ServiceFilter = filter
 	}
 }


### PR DESCRIPTION
- Adds a stream server interceptor recording the same started, handled and handling-duration metric families as the unary one, with the stream kind derived from the handler flags.
- Generalizes the internal series machinery over the call type and exports the service label name for consumers that build retention predicates.
- For streams the extra-label hook is invoked without a request message, which is now documented.