### PR TITLE
fix(commonpb): encode infinite histogram bucket bounds as JSON null

### DIFF
--- a/common/commonpb/v1/json.go
+++ b/common/commonpb/v1/json.go
@@ -1,0 +1,29 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"math"
+)
+
+// MarshalJSON renders histogram buckets for the gateway's HTTP translation
+// layer, which encodes gRPC responses with plain encoding/json.
+//
+// That encoder rejects non-finite floats, and the final bucket of every
+// histogram carries an upper bound of +Inf (see common/go/metrics). The
+// binary protobuf wire format keeps non-finite bounds untouched, since
+// Prometheus export depends on it, but the JSON rendering maps them to
+// null, mirroring the Rust CLI's serde output for --format json.
+func (m *Bucket) MarshalJSON() ([]byte, error) {
+	type shadow struct {
+		Count      uint64   `json:"count"`
+		UpperBound *float64 `json:"upper_bound"`
+	}
+
+	s := shadow{Count: m.Count}
+	if !math.IsInf(m.UpperBound, 0) && !math.IsNaN(m.UpperBound) {
+		upperBound := m.UpperBound
+		s.UpperBound = &upperBound
+	}
+
+	return json.Marshal(s)
+}

--- a/common/commonpb/v1/json_test.go
+++ b/common/commonpb/v1/json_test.go
@@ -1,0 +1,66 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBucket_MarshalJSON verifies that a bucket with a finite upper bound
+// serializes both fields in the order count, upper_bound.
+func TestBucket_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		bucket   *Bucket
+		expected string
+	}{
+		{
+			name:     "finite upper bound",
+			bucket:   &Bucket{Count: 7, UpperBound: 100},
+			expected: `{"count":7,"upper_bound":100}`,
+		},
+		{
+			name:     "infinite upper bound",
+			bucket:   &Bucket{Count: 3, UpperBound: math.Inf(1)},
+			expected: `{"count":3,"upper_bound":null}`,
+		},
+		{
+			name:     "NaN upper bound",
+			bucket:   &Bucket{Count: 9, UpperBound: math.NaN()},
+			expected: `{"count":9,"upper_bound":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.bucket)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, string(data))
+		})
+	}
+}
+
+// TestMetric_MarshalJSON_HistogramWithInfBucket is the regression test for
+// the gateway HTTP proxy path: encoding/json must traverse through the
+// Metric_Histogram oneof wrapper into Bucket.MarshalJSON without error.
+func TestMetric_MarshalJSON_HistogramWithInfBucket(t *testing.T) {
+	metric := &Metric{
+		Name: "latency",
+		Value: &Metric_Histogram{
+			Histogram: &Histogram{
+				Buckets: []*Bucket{
+					{Count: 5, UpperBound: 10},
+					{Count: 2, UpperBound: math.Inf(1)},
+				},
+				TotalCount: 7,
+			},
+		},
+	}
+
+	data, err := json.Marshal(metric)
+	require.NoError(t, err)
+	require.Contains(t, string(data), `{"count":5,"upper_bound":10}`)
+	require.Contains(t, string(data), `{"count":2,"upper_bound":null}`)
+}


### PR DESCRIPTION
- Histograms always carry a final bucket with an infinite upper bound, which the gateway HTTP translation layer could not encode: the standard JSON encoder rejects non-finite floats, so any metrics snapshot containing a histogram produced an empty response body with an encode error in the log.
- The bucket type now provides a custom JSON marshaller that renders an infinite bound as null, matching what the CLI JSON output already produces, while the binary wire format and the Prometheus export path stay untouched.
- Verified live against the gateway HTTP endpoint: the metrics snapshot now returns valid JSON with null bounds on the overflow buckets.