### PR TITLE
fix(dataplane): handle ring device creation errors

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -289,6 +289,17 @@ dataplane_create_devices(
 			    "net_ring_:",
 			    strlen("net_ring_:")
 		    )) {
+			// The rings are single-producer/single-consumer and
+			// the device exposes exactly one rx/tx queue pair,
+			// so only one worker may poll it.
+			if (device_config->worker_count != 1) {
+				LOG(ERROR,
+				    "ring device %s requires exactly one "
+				    "worker, got %u",
+				    device_config->port_name,
+				    device_config->worker_count);
+				return -1;
+			}
 			if (dpdk_add_ring_port(device_config->port_name)) {
 				LOG(ERROR,
 				    "failed to add yanet ring port %s",

--- a/dataplane/dpdk.c
+++ b/dataplane/dpdk.c
@@ -5,6 +5,7 @@
 
 #include <rte_dev.h>
 #include <rte_eal.h>
+#include <rte_errno.h>
 #include <rte_ether.h>
 
 #include <rte_eth_ring.h>
@@ -153,14 +154,20 @@ dpdk_add_ring_port(const char *port_name) {
 		return -1;
 	}
 
-	rte_eth_from_rings(
-		port_name + strlen("net_ring_"),
-		&rx_ring,
-		1,
-		&tx_ring,
-		1,
-		socket_id
-	);
+	if (rte_eth_from_rings(
+		    port_name + strlen("net_ring_"),
+		    &rx_ring,
+		    1,
+		    &tx_ring,
+		    1,
+		    socket_id
+	    ) < 0) {
+		LOG(ERROR,
+		    "failed to create eth device from rings for %s: %s",
+		    port_name,
+		    rte_strerror(rte_errno));
+		return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
- Check the result of creating an eth device from rings instead of silently reporting success; a failure now surfaces immediately with the underlying DPDK error instead of a confusing port lookup failure later during device initialization.
- Reject ring device configurations with more than one worker: the underlying rings are single-producer/single-consumer and the device exposes a single rx/tx queue pair, so a multi-worker setup previously failed later with a misleading configure warning.