### PR TITLE
feat(balancer2): support optional weight and enabled in real config

### DIFF
--- a/modules/balancer2/cli/src/config.rs
+++ b/modules/balancer2/cli/src/config.rs
@@ -258,7 +258,8 @@ impl From<Real> for balancerpb::RealConfig {
                 ip: ip_to_bytes(real.ip),
                 port: u32::from(real.port),
             }),
-            weight: real.weight,
+            weight: Some(real.weight),
+            enabled: None,
             src: Some(IpNet::from(real.src)),
         }
     }

--- a/modules/balancer2/cli/src/display.rs
+++ b/modules/balancer2/cli/src/display.rs
@@ -204,7 +204,7 @@ fn real_basic_row(real: &balancerpb::RealState) -> Option<RealBasicRow> {
     Some(RealBasicRow {
         real: real_str,
         enabled: real.enabled,
-        weight: rcfg.weight,
+        weight: rcfg.weight.unwrap_or_default(),
         effective_weight: real.effective_weight,
     })
 }
@@ -215,7 +215,7 @@ fn real_stats_row(real: &balancerpb::RealState) -> Option<RealStatsRow> {
     Some(RealStatsRow {
         real: real_str,
         enabled: real.enabled,
-        weight: rcfg.weight,
+        weight: rcfg.weight.unwrap_or_default(),
         effective_weight: real.effective_weight,
         packets: rs.map_or(0, |s| s.packets),
         bytes: rs.map_or(0, |s| s.bytes),

--- a/modules/balancer2/controlplane/balancerpb/v1/config.proto
+++ b/modules/balancer2/controlplane/balancerpb/v1/config.proto
@@ -47,8 +47,8 @@ message VsIdentifier {
 }
 
 // Behavior:
-// - If allowed_srcs list is empty: All sources are denied (no traffic allowed)
-// - If allowed_srcs contains entries: Only matching sources are permitted
+// - If list is empty: All sources are denied (no traffic allowed)
+// - If list contains entries: Only matching sources are permitted
 // - Multiple AllowedSrc entries are evaluated with OR logic (any match allows)
 message AllowedSources {
   repeated common.filterpb.v1.IPNet nets = 1;
@@ -82,8 +82,14 @@ message RealIdentifier {
 
 message RealConfig {
   RelativeRealIdentifier id = 1;
-  uint32 weight = 2;
-  common.filterpb.v1.IPNet src = 3;
+
+  // If not set, inherit from previous config.
+  optional uint32 weight = 2;
+
+  // If not set, inherit from previous config.
+  optional bool enabled = 3;
+
+  common.filterpb.v1.IPNet src = 4;
 }
 
 message VsFlags {

--- a/modules/balancer2/controlplane/balancerpb/v1/state.proto
+++ b/modules/balancer2/controlplane/balancerpb/v1/state.proto
@@ -25,7 +25,7 @@ message BalancerState {
 }
 
 message VsState {
-  // VsConfig.reals and VsConfig.allowed_sources are meaningless here
+  // VsConfig.reals is meaningless here; per-real state is reported in reals.
   VsConfig config = 1;
   VsStats stats = 2;
   uint64 active_sessions = 3;


### PR DESCRIPTION
- Makes RealConfig.weight optional and adds a new optional RealConfig.enabled field, both meaning "inherit from previous config" when unset.
- Lets the full balancer configuration, including which reals are enabled, be specified in a single request.
- Adapts the CLI's real weight handling to the new optional field so the build keeps passing; a full CLI refactor onto the shared output layer follows in a separate PR.