### PR TITLE
fix(pdump): resolve duplicate short flag in the read command

### DIFF
--- a/modules/pdump/cli/src/args.rs
+++ b/modules/pdump/cli/src/args.rs
@@ -67,7 +67,7 @@ pub struct ReadCmd {
     pub output: Option<String>,
 
     /// The number of packets to capture before exiting.
-    #[arg(long, short)]
+    #[arg(long)]
     pub num: Option<u64>,
 }
 


### PR DESCRIPTION
- Fixes a startup panic in the pdump read command caused by two options sharing the same short flag.
- The packet count option is now long-only, keeping the short flag for the config name consistent with the other subcommands.