### PR TITLE
fix(ci): install deb packaging tools directly instead of caching

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -82,10 +82,10 @@ jobs:
             ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.unbtver }}
             ${{ runner.os }}-cargo-${{ matrix.unbtver }}
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: devscripts equivs
-          version: 1.1
+      - name: Install packaging tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends devscripts equivs
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24.x"

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -32,10 +32,10 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-24.04
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: devscripts equivs
-          version: 1.1
+      - name: Install packaging tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends devscripts equivs
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
- Fixes the recurring deb build failure where a required packaging tool was missing at build time.
- The apt package caching action silently swallows install failures and saves an empty cache under a valid key, poisoning subsequent runs across pull requests.
- The two small packages are now installed directly, so a fetch failure fails the job loudly instead of corrupting the cache.