### PR TITLE
perf(vlan): concatenate transit input packets instead of per-packet moves

### DIFF
--- a/devices/vlan/dataplane/dataplane.c
+++ b/devices/vlan/dataplane/dataplane.c
@@ -24,13 +24,7 @@ vlan_input_handle(
 	(void)dp_worker;
 	(void)device_ectx;
 
-	struct packet *packet = packet_list_pop(&packet_front->input);
-
-	while (packet != NULL) {
-		packet_front_output(packet_front, packet);
-
-		packet = packet_list_pop(&packet_front->input);
-	}
+	packet_list_concat(&packet_front->output, &packet_front->input);
 }
 
 static void


### PR DESCRIPTION
- The vlan input handler is a pure transit stage: all tag manipulation lives on the output side, so the input side only moves packets from the input list to the output list.
- Replaces the per-packet pop and append loop with the constant-time list concatenation the plain device already uses; packet order, counts, and byte accounting are preserved exactly.
- Removes list surgery proportional to the batch size from the vlan input path.