### PR TITLE
perf(route): skip the next-hop selection modulo for single-route lists

### DIFF
--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -149,8 +149,16 @@ route_handle_packets(
 
 		// TODO: Route selection should be based on hash/NUMA/dp
 		// instance/etc
-		uint64_t route_index = ADDR_OF(&route_config->route_indexes
-		)[route_list->start + packet->hash % route_list->count];
+		//
+		// Single-route lists skip the per-packet modulo: the hash
+		// demux divide is pure overhead when there is nothing to
+		// balance between.
+		uint64_t route_offset = route_list->start;
+		if (route_list->count > 1) {
+			route_offset += packet->hash % route_list->count;
+		}
+		uint64_t route_index =
+			ADDR_OF(&route_config->route_indexes)[route_offset];
 
 		struct route *route =
 			ADDR_OF(&route_config->routes) + route_index;


### PR DESCRIPTION
- Route selection ran a 64-bit modulo on every packet to pick a next hop, even when the route list holds a single entry and the result is always zero; single-next-hop prefixes dominate real FIBs.
- Skips the modulo behind a well-predicted branch for single-entry lists; ECMP selection for multi-next-hop lists is unchanged, including the hash distribution.
- Measured on a dedicated route forwarding micro-benchmark (single-next-hop FIB, batch 32, benchstat n=8): no statistically significant change (p=0.33) — out-of-order execution hides the divide latency across independent packets in a batch. The value of this change is therefore hygiene and consistency with the same skip already applied to the function chain (#1312) and device dispatch (#1316) paths, not a measured throughput win.