### PR TITLE
fix(dataplane_ut): add optional payload reset between benchmark rounds

### DIFF
--- a/bindings/go/dataplane_ut/bench_test.go
+++ b/bindings/go/dataplane_ut/bench_test.go
@@ -84,7 +84,7 @@ func BenchmarkPipelineRound(b *testing.B) {
 				require.NoError(b, err)
 				pkts[idx] = pkt
 			}
-			h.Bench(b, pkts...)
+			h.Bench(b, pkts)
 		})
 	}
 }

--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -406,13 +406,46 @@ func (m *Harness) handlePackets(
 // at most once per process regardless of how many benchmarks call Bench.
 var warnUnoptimizedOnce sync.Once
 
+// benchOptions configures a Bench run.
+type benchOptions struct {
+	resetPayload bool
+}
+
+func newBenchOptions() *benchOptions {
+	return &benchOptions{}
+}
+
+// BenchOption customizes a Bench run.
+type BenchOption func(*benchOptions)
+
+// WithPayloadReset restores every packet payload to its captured state
+// between rounds.
+//
+// Required for modules that rewrite packet contents in place, such as
+// route decrementing TTL; costs one payload copy per packet per round.
+// Only the bytes are restored, so geometry-changing modules stay out of
+// scope.
+func WithPayloadReset() BenchOption {
+	return func(opts *benchOptions) {
+		opts.resetPayload = true
+	}
+}
+
 // Bench runs b.N pipeline rounds over the given packets on worker 0,
 // timing only the C-side loop.
 //
 // Harness, config, and packet-build setup done by the caller before this
-// call is excluded from the measurement.
-func (m *Harness) Bench(b *testing.B, packets ...gopacket.Packet) {
+// call is excluded from the measurement. Packet payloads are reused as
+// is between rounds unless WithPayloadReset is given.
+func (m *Harness) Bench(
+	b *testing.B, packets []gopacket.Packet, options ...BenchOption,
+) {
 	b.Helper()
+
+	opts := newBenchOptions()
+	for _, o := range options {
+		o(opts)
+	}
 
 	warnUnoptimizedOnce.Do(func() {
 		if C.dataplane_ut_build_optimized() == 0 {
@@ -446,12 +479,18 @@ func (m *Harness) Bench(b *testing.B, packets ...gopacket.Packet) {
 	}
 	numPkts := len(payloads)
 
+	reset := C.int(0)
+	if opts.resetPayload {
+		reset = C.int(1)
+	}
+
 	b.ResetTimer()
 	C.dataplane_ut_run_rounds(
 		m.ptr,
 		C.size_t(0),
 		(*C.struct_packet_list)(unsafe.Pointer(packetList)),
 		C.uint64_t(b.N),
+		reset,
 	)
 	b.StopTimer()
 

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -23,6 +23,7 @@
 #include "lib/dataplane/config/topology.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/module/packet_front.h"
+#include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/worker/counters.h"
 #include "lib/dataplane/worker/pipeline_round.h"
 #include "lib/dataplane_ut/mempool.h"
@@ -410,6 +411,10 @@ struct saved_packet {
 	struct packet *pkt;
 	uint16_t tx_device_id;
 	uint16_t rx_device_id;
+	// Payload snapshot (all segments) restored between rounds when
+	// requested, so header-mutating modules see fresh input every round.
+	uint8_t *data;
+	uint32_t data_len;
 };
 
 void
@@ -417,7 +422,8 @@ dataplane_ut_run_rounds(
 	struct dataplane_ut *ut,
 	size_t worker,
 	struct packet_list *input,
-	uint64_t rounds
+	uint64_t rounds,
+	int reset_payload
 ) {
 	if (rounds == 0 || input->count == 0) {
 		return;
@@ -436,6 +442,28 @@ dataplane_ut_run_rounds(
 		saved[idx].pkt = pkt;
 		saved[idx].tx_device_id = pkt->tx_device_id;
 		saved[idx].rx_device_id = pkt->rx_device_id;
+		saved[idx].data = NULL;
+		saved[idx].data_len = 0;
+		if (reset_payload) {
+			struct rte_mbuf *mbuf = packet_to_mbuf(pkt);
+			saved[idx].data_len = rte_pktmbuf_pkt_len(mbuf);
+			saved[idx].data = malloc(saved[idx].data_len);
+			if (saved[idx].data == NULL) {
+				LOG(ERROR,
+				    "run_rounds: no memory for a payload "
+				    "snapshot; packet %zu runs without reset",
+				    idx);
+				continue;
+			}
+			uint32_t offset = 0;
+			for (struct rte_mbuf *seg = mbuf; seg != NULL;
+			     seg = seg->next) {
+				memcpy(saved[idx].data + offset,
+				       rte_pktmbuf_mtod(seg, void *),
+				       seg->data_len);
+				offset += seg->data_len;
+			}
+		}
 	}
 
 	// Assumes a fixed packet set: handlers forward or drop without
@@ -448,6 +476,17 @@ dataplane_ut_run_rounds(
 			pkt->next = NULL;
 			pkt->tx_device_id = saved[idx].tx_device_id;
 			pkt->rx_device_id = saved[idx].rx_device_id;
+			if (saved[idx].data != NULL) {
+				uint32_t offset = 0;
+				for (struct rte_mbuf *seg = packet_to_mbuf(pkt);
+				     seg != NULL;
+				     seg = seg->next) {
+					memcpy(rte_pktmbuf_mtod(seg, void *),
+					       saved[idx].data + offset,
+					       seg->data_len);
+					offset += seg->data_len;
+				}
+			}
 			packet_list_add(input, pkt);
 		}
 
@@ -462,6 +501,7 @@ dataplane_ut_run_rounds(
 		pkt->tx_device_id = saved[idx].tx_device_id;
 		pkt->rx_device_id = saved[idx].rx_device_id;
 		packet_list_add(input, pkt);
+		free(saved[idx].data);
 	}
 
 	free(saved);

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -104,6 +104,14 @@ dataplane_ut_build_optimized(void);
 // holds all packets in a consistent state for freeing. The snapshot array is
 // freed before returning.
 //
+// When reset_payload is nonzero, each packet's payload bytes are also
+// snapshotted at capture and restored before every round, so modules that
+// rewrite headers in place (for example route decrementing TTL) see fresh
+// input each round. Only the bytes are restored: mbuf geometry and parse
+// metadata are not, so modules that grow, shrink, or re-slice packets stay
+// out of scope. A failed per-packet snapshot allocation leaves that packet
+// without payload reset.
+//
 // Returns immediately (leaving input intact) when rounds == 0 or
 // input->count == 0. Returns immediately on malloc failure.
 //
@@ -119,5 +127,6 @@ dataplane_ut_run_rounds(
 	struct dataplane_ut *ut,
 	size_t worker,
 	struct packet_list *input,
-	uint64_t rounds
+	uint64_t rounds,
+	int reset_payload
 );

--- a/modules/acl/tests/functional/acl_bench_dataset_test.go
+++ b/modules/acl/tests/functional/acl_bench_dataset_test.go
@@ -716,7 +716,7 @@ func BenchmarkACLDataset(b *testing.B) {
 			continue
 		}
 		b.Run(fmt.Sprintf("batch=%d", batchSize), func(b *testing.B) {
-			state.harness.Bench(b, state.packets[:batchSize]...)
+			state.harness.Bench(b, state.packets[:batchSize])
 		})
 	}
 }

--- a/modules/acl/tests/functional/acl_bench_test.go
+++ b/modules/acl/tests/functional/acl_bench_test.go
@@ -65,7 +65,7 @@ func BenchmarkACLAllow(b *testing.B) {
 				require.NoError(b, err)
 				pkts[idx] = pkt
 			}
-			h.Bench(b, pkts...)
+			h.Bench(b, pkts)
 		})
 	}
 }
@@ -114,7 +114,7 @@ func BenchmarkACLDeny(b *testing.B) {
 				require.NoError(b, err)
 				pkts[idx] = pkt
 			}
-			h.Bench(b, pkts...)
+			h.Bench(b, pkts)
 		})
 	}
 }
@@ -237,7 +237,7 @@ func BenchmarkACLAllowRuleScale(b *testing.B) {
 			for idx := range benchRuleScaleBatch {
 				pkts[idx] = benchDiversePacket(b, idx*n/benchRuleScaleBatch)
 			}
-			h.Bench(b, pkts...)
+			h.Bench(b, pkts)
 		})
 	}
 }
@@ -270,7 +270,7 @@ func BenchmarkACLAllowDiverseFlow(b *testing.B) {
 			for idx := range n {
 				pkts[idx] = benchDiversePacket(b, idx)
 			}
-			h.Bench(b, pkts...)
+			h.Bench(b, pkts)
 		})
 	}
 }

--- a/modules/route/tests/functional/route_bench_test.go
+++ b/modules/route/tests/functional/route_bench_test.go
@@ -1,0 +1,74 @@
+package route_test
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+)
+
+// BenchmarkRouteForward measures IPv4 forwarding rounds against a FIB
+// whose default route carries the given number of next hops.
+//
+// The payload-resetting bench runner is required here: the route module
+// decrements TTL in place, so without the reset every round beyond the
+// initial TTL would measure the drop path instead of forwarding.
+func BenchmarkRouteForward(b *testing.B) {
+	for _, nexthopCount := range []int{1, 2} {
+		b.Run(fmt.Sprintf("nexthops=%d", nexthopCount), func(b *testing.B) {
+			h, agent, backend := setupRouteHarness(b, "port0")
+
+			nexthops := make([]FIBNexthop, 0, nexthopCount)
+			for idx := range nexthopCount {
+				nexthops = append(nexthops, FIBNexthop{
+					DstMAC: xerror.Unwrap(net.ParseMAC(
+						fmt.Sprintf("de:ad:be:ef:00:%02x", idx+1),
+					)),
+					SrcMAC: xerror.Unwrap(net.ParseMAC(
+						fmt.Sprintf("ca:fe:ba:be:00:%02x", idx+1),
+					)),
+					Device: "port0",
+				})
+			}
+			applyFIB(b, backend, "bench", []FIBEntry{{
+				Prefix:   netip.MustParsePrefix("0.0.0.0/0"),
+				Nexthops: nexthops,
+			}})
+			wirePipeline(b, agent, "port0", "bench")
+
+			packets := make([]gopacket.Packet, 32)
+			for idx := range packets {
+				eth := layers.Ethernet{
+					SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+					DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+					EthernetType: layers.EthernetTypeIPv4,
+				}
+				ip4 := layers.IPv4{
+					Version:  4,
+					TTL:      64,
+					Protocol: layers.IPProtocolUDP,
+					SrcIP:    net.IP{10, 0, 0, byte(idx + 1)},
+					DstIP:    net.IP{192, 168, byte(idx), 1},
+				}
+				udp := layers.UDP{
+					SrcPort: layers.UDPPort(1024 + idx),
+					DstPort: 443,
+				}
+				require.NoError(b, udp.SetNetworkLayerForChecksum(&ip4))
+				packet, err := xpacket.LayersToPacketChecked(&eth, &ip4, &udp)
+				require.NoError(b, err)
+				packets[idx] = packet
+			}
+
+			h.Bench(b, packets, dataplaneut.WithPayloadReset())
+		})
+	}
+}

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -57,10 +57,10 @@ var routeNextHop = FIBNexthop{
 // applyFIB, because the route module config must exist in shared memory
 // before UpdatePlainDevices resolves chain module references.
 func setupRouteHarness(
-	t *testing.T,
+	tb testing.TB,
 	deviceName string,
 ) (*dataplaneut.Harness, *ffi.Agent, route.Backend) {
-	t.Helper()
+	tb.Helper()
 
 	cfg := dataplaneut.Config{
 		CPMemory:      uint64(routeCPSize),
@@ -71,13 +71,13 @@ func setupRouteHarness(
 		DevicesToLoad: []string{"plain"},
 	}
 	h, err := dataplaneut.NewHarness(cfg)
-	require.NoError(t, err)
-	t.Cleanup(h.Free)
+	require.NoError(tb, err)
+	tb.Cleanup(h.Free)
 
 	shm := h.SharedMemory()
 	agent, err := shm.AgentAttach("r-test", 0, routeMemSize)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = agent.CleanUp() })
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = agent.CleanUp() })
 
 	backend := route.NewBackend(agent)
 	return h, agent, backend
@@ -90,13 +90,13 @@ func setupRouteHarness(
 // configName is already present in shared memory when the pipeline resolves
 // its chain module references.
 func wirePipeline(
-	t *testing.T,
+	tb testing.TB,
 	agent *ffi.Agent,
 	deviceName, configName string,
 ) {
-	t.Helper()
+	tb.Helper()
 
-	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+	require.NoError(tb, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
@@ -108,14 +108,14 @@ func wirePipeline(
 			},
 		}},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
 		Name:      configName,
 		Functions: []string{configName},
 	}))
-	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+	require.NoError(tb, agent.UpdatePipeline(ffi.PipelineConfig{
 		Name: "dummy",
 	}))
-	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
+	require.NoError(tb, agent.UpdatePlainDevices([]ffi.DeviceConfig{{
 		Name:   deviceName,
 		Input:  []ffi.DevicePipelineConfig{{Name: configName, Weight: 1}},
 		Output: []ffi.DevicePipelineConfig{{Name: "dummy", Weight: 1}},
@@ -125,14 +125,14 @@ func wirePipeline(
 // applyFIB pushes entries via backend.UpdateModule and registers cleanup.
 //
 // Returns the route.ModuleHandle; the caller may inspect it. The handle is
-// freed via t.Cleanup.
+// freed via tb.Cleanup.
 func applyFIB(
-	t *testing.T,
+	tb testing.TB,
 	backend route.Backend,
 	name string,
 	entries []FIBEntry,
 ) route.ModuleHandle {
-	t.Helper()
+	tb.Helper()
 
 	pbEntries := make([]*routepb.FIBEntry, 0, len(entries))
 	for _, e := range entries {
@@ -151,8 +151,8 @@ func applyFIB(
 	}
 
 	handle, err := backend.UpdateModule(name, pbEntries)
-	require.NoError(t, err)
-	t.Cleanup(handle.Free)
+	require.NoError(tb, err)
+	tb.Cleanup(handle.Free)
 	return handle
 }
 

--- a/tests/pipeline/scheduler_bench_test.go
+++ b/tests/pipeline/scheduler_bench_test.go
@@ -207,7 +207,7 @@ func BenchmarkScheduler(b *testing.B) {
 		for _, batch := range schedBatchSizes {
 			b.Run(fmt.Sprintf("devices=%d/batch=%d", devices, batch), func(b *testing.B) {
 				h, pkts := buildBench(b, devices, batch)
-				h.Bench(b, pkts...)
+				h.Bench(b, pkts)
 			})
 		}
 	}


### PR DESCRIPTION
- The benchmark runner recycles one packet set across all rounds and restored only the routing fields, so modules that rewrite packet contents in place drifted off the measured path: with the route module, packets exhausted their TTL after the first 63 rounds and the benchmark silently measured the early-drop path instead of forwarding (58.6 Mpps reported versus 31.1 Mpps of actual forwarding on the same setup).
- Bench now takes the packet slice plus functional options; the new WithPayloadReset option snapshots every payload at capture time and restores it between rounds. Benchmarks without the option keep byte-identical behavior and timing. Only payload bytes are restored, so in-place header rewrites are covered while geometry-changing modules stay out of scope, as documented.
- Adds a route forwarding benchmark using the new option — the first benchmark for the route module; it was built to measure a proposed route optimization and correctly refuted it (#1363).
- The shared route test helpers now accept any test type, following the ACL test package precedent.