### PR TITLE
perf(dataplane): skip counter accounting for zero-packet updates

### DIFF
--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -31,6 +31,10 @@ counter_add_packets_bytes(
 	uint64_t packets,
 	uint64_t bytes
 ) {
+	if (packets == 0) {
+		return;
+	}
+
 	counter_add(packets_id, worker_idx, storage, packets);
 	counter_add(bytes_id, worker_idx, storage, bytes);
 }


### PR DESCRIPTION
- Every polling tick charges packet and byte counters for each pipeline entity even when there is nothing to add; a zero-packet update still resolves counter addresses through several dependent shared-memory dereferences, and such updates are the common case on idle ticks.
- The shared helper now returns early for zero-packet updates; bytes can never be nonzero without packets, so counter values are bit-for-bit unchanged.
- Measured in isolation (benchstat, n=8): drop-heavy traffic gains the most since its downstream counters are all zero — ACL deny path −6.4% ns/op (p=0.035); the empty-pipeline round benchmark gains −2.0% ns/op at batch 8 (p=0.021); ACL allow path and batch 32 rounds show no significant change. The idle-tick savings that motivated the change are outside what these benchmarks exercise: on an idle worker the counter chases are part of the measured ~30% skeleton overhead in live profiles.