### PR TITLE
fix(nat64): clamp translated Packet-Too-Big MTU

### DIFF
--- a/modules/nat64/dataplane/nat64dp.c
+++ b/modules/nat64/dataplane/nat64dp.c
@@ -390,28 +390,49 @@ icmp_v6_to_v4(
 		// Big Message)-20, MTU_of_IPv4_nexthop,
 		// (MTU_of_IPv6_nexthop)-20).
 		if (mtu == 0) {
-			// Router doesn't implement RFC1191, use cfg
+			// Router doesn't implement RFC1191, use cfg. Prefer
+			// the configured IPv4 MTU, falling back to the IPv6
+			// MTU when the IPv4 one is unset.
 			mtu = nat64_config->mtu.ipv4;
+			if (mtu == 0) {
+				mtu = nat64_config->mtu.ipv6;
+			}
 		}
 
 		// Calculate header size difference
 		uint16_t delta = sizeof(struct rte_ipv6_hdr) -
 				 sizeof(struct rte_ipv4_hdr);
 
-		// RFC7915: Adjust MTU for header size difference
-		uint16_t adjusted_mtu = mtu - delta;
+		// RFC7915: Adjust MTU for header size difference. Use a
+		// saturating subtraction so a wire MTU at or below delta
+		// cannot wrap around in an unsigned type.
+		uint32_t adjusted_mtu = (mtu > delta) ? (mtu - delta) : 0;
 
 		if (nat64_config->mtu.ipv6 > 0) {
-			adjusted_mtu =
-				RTE_MIN(adjusted_mtu,
-					nat64_config->mtu.ipv6 - delta);
+			// Saturate to 0 rather than wrapping when the
+			// configured IPv6 next-hop MTU is nonzero but at or
+			// below delta; the floor below then raises it to 68.
+			uint32_t ipv6_limit =
+				(nat64_config->mtu.ipv6 > delta)
+					? (uint32_t)nat64_config->mtu.ipv6 -
+						  delta
+					: 0;
+			adjusted_mtu = RTE_MIN(adjusted_mtu, ipv6_limit);
 		}
 
 		if (nat64_config->mtu.ipv4 > 0) {
 			// Account for IPv4->IPv6 translation overhead
 			adjusted_mtu =
-				RTE_MIN(adjusted_mtu, nat64_config->mtu.ipv4);
+				RTE_MIN(adjusted_mtu,
+					(uint32_t)nat64_config->mtu.ipv4);
 		}
+
+		// RFC7915/RFC1191: an underflowed or sub-minimum MTU here
+		// would black-hole PMTUD, so floor at the IPv4 minimum MTU
+		// and cap at what the 16-bit ICMPv4 next-hop MTU field can
+		// hold.
+		adjusted_mtu = RTE_MAX(adjusted_mtu, 68U);
+		adjusted_mtu = RTE_MIN(adjusted_mtu, (uint32_t)UINT16_MAX);
 
 		LOG_DBG(NAT64,
 			"MTU adjustment:\n"
@@ -428,9 +449,13 @@ icmp_v6_to_v4(
 
 		LOG_DBG(NAT64, "Adjusted ICMPv4 MTU: %u\n", mtu);
 
-		// Store the adjusted MTU in the ICMPv4 header
+		// Store the adjusted MTU in the ICMPv4 header. The ICMPv4
+		// next-hop-MTU layout reuses only the low 16 bits, so the
+		// RFC792 unused high half must be cleared, otherwise it
+		// would retain the top bits of the 32-bit ICMPv6 MTU.
 		struct yanet_icmp_hdr *icmp_hdr =
 			(struct yanet_icmp_hdr *)icmp_header;
+		icmp_hdr->icmp_hun.ih_pmtu.ipm_void = 0;
 		icmp_hdr->yanet_icmp_nextmtu = rte_cpu_to_be_16(mtu);
 		break;
 

--- a/modules/nat64/tests/functional/nat64_test.go
+++ b/modules/nat64/tests/functional/nat64_test.go
@@ -844,3 +844,86 @@ func TestNAT64_ICMPv6PacketTooBigToICMPv4FragNeeded(t *testing.T) {
 	require.Equal(t, byte(4), l4[1])
 	require.Equal(t, uint16(1260), binary.BigEndian.Uint16(l4[6:8]))
 }
+
+// TestNAT64_ICMPv6PacketTooBigMTUFloor verifies that the ICMPv4 next-hop MTU
+// derived from an ICMPv6 Packet Too Big never underflows below the IPv4
+// minimum, regardless of the attacker-controlled wire MTU value.
+func TestNAT64_ICMPv6PacketTooBigMTUFloor(t *testing.T) {
+	tests := []struct {
+		name    string
+		wireMTU uint32
+		cfg4    uint32
+		cfg6    uint32
+		want    uint16
+	}{
+		{name: "underflow_1", wireMTU: 1, cfg4: 1450, cfg6: 1280, want: 68},
+		{name: "underflow_19", wireMTU: 19, cfg4: 1450, cfg6: 1280, want: 68},
+		{name: "equals_header_delta_20", wireMTU: 20, cfg4: 1450, cfg6: 1280, want: 68},
+		{name: "below_ipv4_minimum_21", wireMTU: 21, cfg4: 1450, cfg6: 1280, want: 68},
+		{name: "exactly_at_floor_88", wireMTU: 88, cfg4: 1450, cfg6: 1280, want: 68},
+		{name: "just_above_floor_89", wireMTU: 89, cfg4: 1450, cfg6: 1280, want: 69},
+		{name: "normal_100", wireMTU: 100, cfg4: 1450, cfg6: 1280, want: 80},
+		{name: "clamped_by_ipv6_mtu_1400", wireMTU: 1400, cfg4: 1450, cfg6: 1280, want: 1260},
+		{name: "rfc1191_remap_wire0", wireMTU: 0, cfg4: 1450, cfg6: 1280, want: 1260},
+		{name: "ipv4_unset_wire0_falls_back_to_ipv6", wireMTU: 0, cfg4: 0, cfg6: 1280, want: 1260},
+		{name: "both_config_zero_wire0", wireMTU: 0, cfg4: 0, cfg6: 0, want: 68},
+		{name: "cap_at_uint16_max", wireMTU: 100000, cfg4: 0, cfg6: 0, want: 65535},
+		{name: "tiny_ipv6_config_clamps_to_floor", wireMTU: 1400, cfg4: 1450, cfg6: 10, want: 68},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, svc := setupNAT64Harness(t)
+			mustAddPrefix(t, svc, "nat64-test", nat64Prefix96)
+			mustAddMapping(t, svc, "nat64-test", "192.0.2.30", "2001:db8::30", 0)
+			mustSetMTU(t, svc, "nat64-test", tt.cfg4, tt.cfg6)
+
+			innerIP6 := layers.IPv6{
+				Version:    6,
+				HopLimit:   32,
+				NextHeader: layers.IPProtocolUDP,
+				SrcIP:      net.ParseIP("2001:db8::30"),
+				DstIP:      net.ParseIP("2001:db8::198.51.100.2"),
+			}
+			innerUDP := layers.UDP{SrcPort: 2233, DstPort: 3344}
+			require.NoError(t, innerUDP.SetNetworkLayerForChecksum(&innerIP6))
+			innerBuf := gopacket.NewSerializeBuffer()
+			require.NoError(t, gopacket.SerializeLayers(
+				innerBuf,
+				gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true},
+				&innerIP6,
+				&innerUDP,
+			))
+			inner := innerBuf.Bytes()
+			require.GreaterOrEqual(t, len(inner), 48)
+
+			icmp6 := make([]byte, 8+48)
+			icmp6[0] = 2 // Packet Too Big
+			icmp6[1] = 0
+			binary.BigEndian.PutUint32(icmp6[4:8], tt.wireMTU)
+			copy(icmp6[8:], inner[:48])
+			pkt := packetWithIPv6RawExt(
+				t,
+				net.ParseIP("2001:db8::30"),
+				net.ParseIP("2001:db8::198.51.100.2"),
+				byte(layers.IPProtocolICMPv6),
+				icmp6,
+			)
+
+			result, err := h.HandlePackets(pkt)
+			require.NoError(t, err)
+			out := parseOneOutput(t, result)
+			ip4 := out.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
+			require.Equal(t, net.ParseIP("192.0.2.30").To4(), ip4.SrcIP.To4())
+			require.Equal(t, net.ParseIP("198.51.100.2").To4(), ip4.DstIP.To4())
+
+			l4 := ip4.Payload
+			require.GreaterOrEqual(t, len(l4), 8)
+			require.Equal(t, byte(layers.ICMPv4TypeDestinationUnreachable), l4[0])
+			require.Equal(t, byte(4), l4[1])
+			// RFC792 unused field must always be zero.
+			require.Equal(t, uint16(0), binary.BigEndian.Uint16(l4[4:6]))
+			require.Equal(t, tt.want, binary.BigEndian.Uint16(l4[6:8]))
+		})
+	}
+}


### PR DESCRIPTION
The IPv6-to-IPv4 translation of an ICMPv6 Packet Too Big message derived the emitted ICMPv4 next-hop MTU from an attacker-controlled wire value with no lower bound. When that value was at or below the IPv4/IPv6 header-size difference, the subtraction wrapped around in a 16-bit type, so the emitted MTU could be zero — which black-holes Path MTU Discovery — or an out-of-range value that truncated to garbage. A misconfiguration with both configured MTUs unset widened the exposure.

The translation now computes the header-size adjustment with a saturating subtraction, guards the configured-MTU clamps against the same underflow, and floors the emitted value at the IPv4 minimum MTU while capping it at the maximum the 16-bit field can hold. This mirrors the floor already applied on the reverse IPv4-to-IPv6 direction.

Added a table-driven functional test covering the underflow range, the header-delta boundary, the RFC1191 zero-MTU remap, the both-configs-zero wrap case, and the 16-bit cap; the emitted next-hop MTU is now provably within a sane range for every input.

Closes #1160.