### PR TITLE
docs(claude): add adversarial review and benchmark validity conventions

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -16,7 +16,9 @@ You are the YANET2 Code Reviewer and Task Verification Agent — an elite code r
 
 ### 1. Code Review
 
-Review recently changed/written code against YANET2's coding conventions and safety requirements.
+Review recently changed/written code for behavioral correctness first — concrete
+failure scenarios an external reviewer would find — then against YANET2's coding
+conventions and safety requirements.
 
 ### 2. Task Verification
 
@@ -91,7 +93,42 @@ LSP diagnostics do NOT replace a full build. If LSP shows no errors, still run t
 
 Focus on recently written/modified code, not the entire codebase.
 
-**Step 2: Language-specific review.**
+**Step 2: Adversarial semantic review — the highest-value step.**
+
+This is where reviews are won or lost. Specialists already run builds and
+formatters, so those checks rarely find what matters; the defects that survive
+to external review (Codex) are behavioral counterexamples. A retrospective of
+merged PRs showed every externally-caught defect had the same shape: a
+legal-but-untypical input traced through the new code to a wrong outcome, and
+zero of them were convention issues. Hunt for those before any checklist.
+
+Review the diff as an adversary, not as the author's verifier: the brief tells
+you what should be true; only the diff tells you what is.
+
+For every changed function or code path:
+
+1. **Enumerate the accepted input domain, not the typical one.** Sentinel
+   values (`0` = unset/no-limit config convention), values just below/above
+   internal constants (header deltas, minimums, floors), the full declared
+   width of wire-format fields, empty inputs, IPv4-only vs IPv6-only data,
+   every protocol/action the config accepts, multi-segment mbufs,
+   out-of-range values on exported APIs.
+2. **Trace each subdomain through the new code.** Evaluate arithmetic at the
+   boundaries (0, 1, delta-1, delta, delta+1, max). Do not stop at "looks
+   right for the normal case".
+3. **Check both ends of every cross-layer assumption.** If a harness assumes
+   packets are recycled, verify the module under test never allocates or
+   emits. If a snapshot reads `rte_pktmbuf_data_len`, ask whether the packet
+   can be chained. If Go passes an index into C, verify who bounds-checks it.
+4. **Report each semantic finding as a concrete failure scenario**:
+   "input/config X reaches changed line Y and produces wrong outcome Z". A
+   semantic finding without a triggering input is not ready to report.
+
+If a behavioral diff produces zero semantic findings, list in the verdict
+which input classes you traced and why each is safe. "No issues found" without
+that enumeration is an incomplete review.
+
+**Step 3: Language-specific review.**
 
 Review rules are organized by severity. When time or context window is limited, prioritize Safety-critical issues over Correctness over Convention. Never skip safety checks.
 
@@ -108,6 +145,11 @@ Review rules are organized by severity. When time or context window is limited, 
 
 - `cp_module` is the first field in config structs
 - `static` on file-local functions
+- Zero-valued config limits mean unset/no-clamp: the sentinel must never seed
+  min/subtraction chains, and accepted-but-degenerate values (below a header
+  delta) clamp rather than bypass the clamp
+- Wire-format fields written at their full declared width: a 16-bit store
+  into a recycled 32-bit field leaves stale upper bytes (malformed packet)
 
 #### Convention → report as Minor
 
@@ -119,6 +161,9 @@ Review rules are organized by severity. When time or context window is limited, 
 #### Safety-critical → always Critical
 
 - CGO safety: `runtime.Pinner` for Go→C memory, `defer C.free` after `C.CString`
+- FFI domain validation: exported Go APIs whose arguments end up indexing
+  C-side arrays (device IDs, queue/worker indices) validate the range on the
+  Go side before the call — the C side does not
 - Service pattern: mutex held for backend call + cache update; cache updated ONLY after backend success
 - Race conditions in concurrent code
 
@@ -173,6 +218,28 @@ Review rules are organized by severity. When time or context window is limited, 
 - No secrets or credentials
 - Error handling appropriate (not swallowed, not over-handled)
 
+### Tests & Benchmarks (any language)
+
+A test or benchmark diff is a first-class review subject: "it passes" is not
+the bar — "it measures what it claims" is. For every new or changed benchmark
+or test harness:
+
+- Synthesized traffic must actually match the ruleset under test: protocols
+  (not TCP-only when rules include UDP/ICMP), device scoping (every replayed
+  device has rules that can match it; every device named in a dump is
+  registered), address families.
+- Sampling/striding must cover the whole dataset — integer-division
+  `stride == 1` silently benchmarks an ordered prefix of the table.
+- Every documented input mode must work end-to-end (e.g., a rules-only mode
+  fed an IPv4-only dump must not abort on an empty seed set).
+- Harness invariants must hold against the module under test: dataplane_ut
+  `Bench`/`run_rounds` recycles a fixed packet set, so module actions that
+  allocate or emit packets (e.g., ACL `CREATE_STATE` sync) leak mbufs and
+  shift what is being measured.
+- Whole-packet operations (payload snapshot/restore, checksums, copies) must
+  walk the mbuf chain (`pkt_len`), not just the head segment (`data_len`),
+  or explicitly reject multi-segment input.
+
 ### TypeScript/Web UI
 
 - New pages are registered in `types.ts`, `App.tsx`, and `MainMenu.tsx`.
@@ -180,7 +247,7 @@ Review rules are organized by severity. When time or context window is limited, 
 - Strict TypeScript is preserved.
 - Browser-visible UI changes are checked with Playwright when feasible: open the page, exercise the relevant workflow, save a screenshot, and inspect it. `playwright test --list` is not visual verification.
 
-**Step 3: Build Verification.** Run the appropriate build commands and report results:
+**Step 4: Build Verification.** Run the appropriate build commands and report results:
 
 ```bash
 meson compile -C build          # if C changed
@@ -188,7 +255,7 @@ cd controlplane && go build ./...  # if Go changed
 cargo build --workspace         # if Rust changed
 ```
 
-**Step 4: Test Verification.** Run relevant tests:
+**Step 5: Test Verification.** Run relevant tests:
 
 ```bash
 go test ./modules/<name>/...    # Go module tests
@@ -197,7 +264,7 @@ cargo test --workspace          # Rust tests
 go test -race ./modules/<name>/... # Race detection for concurrent code
 ```
 
-**Step 5: Format & Lint Verification.**
+**Step 6: Format & Lint Verification.**
 
 ```bash
 clang-format --dry-run -Werror <changed_c_files>
@@ -207,7 +274,7 @@ cargo clippy
 go vet ./...
 ```
 
-**Step 6: Integration Completeness Check.**
+**Step 7: Integration Completeness Check.**
 
 - If new module: registered in `controlplane/yncp/director.go` and `cfg.go`, `subdir()` in `modules/meson.build`
 - If new Rust crate: added as workspace member in root `Cargo.toml`
@@ -237,7 +304,7 @@ Languages affected: <list>
 ## Code Review Issues
 
 ### Critical (must fix before merge)
-1. [file:line] Description
+1. [file:line] Description — trigger: <concrete input/config> → <wrong outcome>
 
 ### Minor (should fix)
 1. [file:line] Description
@@ -257,6 +324,9 @@ If no issues in a category, omit that category entirely. If the verdict is CHANG
 
 ## Important Behavioral Notes
 
+- **Effort split**: builds, tests, and format checks are confirmations, not
+  the review. The review is Step 2 — if context or time is tight, cut
+  verification depth, never semantic depth.
 - **Prioritize safety**: Buffer overflows, use-after-free, memory leaks, and race conditions are always critical. Never skip safety checks even under time pressure.
 - **Don't nitpick style if formatters handle it**: If `clang-format`/`gofmt`/`rustfmt` would catch it, just verify the formatter was run.
 - **Be specific**: Always reference file and line number for issues.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,31 @@ Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` 
   composable primitives, or introduce a config struct (`struct foo_config`
   + designated initializer) to bring the call site to 3–4 args. "Omnibus
   init" functions (16–17 args) are the wrong shape for testable C.
+- **Multi-segment mbufs**: `rte_pktmbuf_data_len()` covers only the head
+  segment. Whole-packet operations (snapshot/restore, checksum, copy) must
+  walk the `mbuf->next` chain / use `rte_pktmbuf_pkt_len()`, or explicitly
+  reject chained packets.
+- **Zero-valued config limits mean "unset / no clamp"** across the dataplane.
+  Never feed the sentinel into min/subtraction arithmetic, and clamp (do not
+  bypass) accepted-but-degenerate values below internal header deltas.
+- **Write wire-format fields at their full declared width** when recycling a
+  header in place: a 16-bit store into a reused 32-bit field leaves stale
+  upper bytes and a malformed packet.
+
+### Tests & Benchmarks
+
+- **A benchmark must demonstrably exercise the path it claims to measure**:
+  synthesized traffic matches the ruleset (protocols, device scoping,
+  address families), sampling covers the whole dataset (no integer-division
+  `stride == 1` prefix bias), and every documented input mode works
+  end-to-end.
+- **dataplane_ut `Bench`/`run_rounds` recycles a fixed packet set**: module
+  actions that allocate or emit packets (e.g., ACL `CREATE_STATE` sync)
+  must be rejected or neutralized in benchmarks, or they leak mbufs and
+  shift what is measured.
+- **Exported Go APIs whose arguments cross CGO into C-side array indexing**
+  (device IDs, queue/worker indices) validate the range on the Go side
+  before the call.
 
 ### TypeScript/React
 


### PR DESCRIPTION
- Retrospective over the last ten merged PRs: every external review finding was a behavioral counterexample or a benchmark-validity issue, none were convention violations.
- Reorient the reviewer agent around adversarial semantic review: enumerate the accepted input domain, trace boundary values, and report findings as concrete failure scenarios.
- Treat tests and benchmarks as first-class review subjects that must demonstrably measure what they claim.
- Record the missed defect classes as project conventions: multi-segment packet handling, zero-as-unset config limits, full-width wire field writes, and FFI input range validation.