### PR TITLE
fix(fwstate): make stale layer trimming rollback-safe on allocation failure

### DIFF
--- a/lib/fwstate/layermap.h
+++ b/lib/fwstate/layermap.h
@@ -28,16 +28,21 @@ layermap_trim_stale_layers_cp(
 
 	while (layer) {
 		if (layermap_is_layer_outdated(layer, now)) {
-			// Unlink the outdated layer
-			fwmap_t *next_layer = (fwmap_t *)ADDR_OF(&layer->next);
-			ATOMIC_SET_OFFSET_OF(prev_next, next_layer);
-
-			// Add to outdated layers list
+			// Allocate the bookkeeping node before unlinking, so
+			// that a failed allocation leaves the layer in place
+			// to be retried on the next trim instead of being
+			// orphaned.
 			layermap_list_t *node =
 				memory_balloc(ctx, sizeof(layermap_list_t));
 			if (!node) {
 				return -1;
 			}
+
+			// Unlink the outdated layer
+			fwmap_t *next_layer = (fwmap_t *)ADDR_OF(&layer->next);
+			ATOMIC_SET_OFFSET_OF(prev_next, next_layer);
+
+			// Add to outdated layers list
 			SET_OFFSET_OF(&node->layer, layer);
 			SET_OFFSET_OF(&node->next, *outdated_layers);
 			*outdated_layers = node;

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -383,48 +383,70 @@ struct fwstate_outdated_layers {
 	layermap_list_t *v6_layers;
 };
 
-fwstate_outdated_layers_t *
-fwstate_config_trim_stale_layers(struct cp_module *cp_module, uint64_t now) {
+int
+fwstate_config_trim_stale_layers(
+	struct cp_module *cp_module,
+	uint64_t now,
+	fwstate_outdated_layers_t **outdated
+) {
 	struct fwstate_module_config *config = container_of(
 		cp_module, struct fwstate_module_config, cp_module
 	);
 	struct agent *agent = ADDR_OF(&cp_module->agent);
 
 	// Allocate structure to hold outdated layers
-	fwstate_outdated_layers_t *outdated =
-		memory_balloc(&agent->memory_context, sizeof(*outdated));
-	if (!outdated) {
+	fwstate_outdated_layers_t *layers =
+		memory_balloc(&agent->memory_context, sizeof(*layers));
+	if (!layers) {
 		errno = ENOMEM;
-		return NULL;
+		*outdated = NULL;
+		return -1;
 	}
-	outdated->v4_layers = NULL;
-	outdated->v6_layers = NULL;
+	layers->v4_layers = NULL;
+	layers->v6_layers = NULL;
+	*outdated = layers;
 
-	// Trim IPv4 layers if map exists
-	// Always return the structure even if trim fails, to avoid leaking
-	// already collected layers
+	// Attempt both maps unconditionally so each collects independently -
+	// a v4 allocation failure must not skip v6 trimming.
+	bool failed = false;
+
 	if (config->cfg.fw4state) {
-		layermap_trim_stale_layers_cp(
-			&config->cfg.fw4state,
-			&agent->memory_context,
-			now,
-			&outdated->v4_layers
-		);
-		// Ignore errors - we'll return what we collected
+		if (layermap_trim_stale_layers_cp(
+			    &config->cfg.fw4state,
+			    &agent->memory_context,
+			    now,
+			    &layers->v4_layers
+		    )) {
+			failed = true;
+		}
 	}
 
-	// Trim IPv6 layers if map exists
 	if (config->cfg.fw6state) {
-		layermap_trim_stale_layers_cp(
-			&config->cfg.fw6state,
-			&agent->memory_context,
-			now,
-			&outdated->v6_layers
-		);
-		// Ignore errors - we'll return what we collected
+		if (layermap_trim_stale_layers_cp(
+			    &config->cfg.fw6state,
+			    &agent->memory_context,
+			    now,
+			    &layers->v6_layers
+		    )) {
+			failed = true;
+		}
 	}
 
-	return outdated;
+	if (failed) {
+		errno = ENOMEM;
+		if (layers->v4_layers == NULL && layers->v6_layers == NULL) {
+			// Nothing was collected: the reordered layermap trim
+			// fails before mutating the chain, so this is
+			// equivalent to the outer allocation failing.
+			memory_bfree(
+				&agent->memory_context, layers, sizeof(*layers)
+			);
+			*outdated = NULL;
+		}
+		return -1;
+	}
+
+	return 0;
 }
 
 void

--- a/modules/fwstate/api/fwstate_cp.h
+++ b/modules/fwstate/api/fwstate_cp.h
@@ -61,11 +61,24 @@ fwstate_config_get_map_stats(const struct cp_module *cp_module, bool is_ipv6);
 struct fwstate_sync_config
 fwstate_config_get_sync_config(const struct cp_module *cp_module);
 
-// Trim stale layers from both IPv4 and IPv6 maps
-// Returns handle to outdated layers that should be freed after UpdateModules
-// Returns NULL on error (errno is set)
-fwstate_outdated_layers_t *
-fwstate_config_trim_stale_layers(struct cp_module *cp_module, uint64_t now);
+// Trims stale layers from both the IPv4 and IPv6 maps.
+//
+// Returns 0 when both maps were fully trimmed, or -1 with errno set when
+// trimming stopped early because a bookkeeping-node allocation failed. On
+// success *outdated is always non-NULL, though it holds no layers when
+// nothing was stale. On failure it is non-NULL only when at least one layer
+// was collected, which marks a genuine partial trim. It is NULL when the
+// outdated-layers structure itself cannot be allocated, and when trimming
+// failed before collecting anything - in both cases the layer chain is left
+// untouched. Collected layers must still be released with
+// fwstate_outdated_layers_free after the new config is published, regardless
+// of the return value.
+int
+fwstate_config_trim_stale_layers(
+	struct cp_module *cp_module,
+	uint64_t now,
+	fwstate_outdated_layers_t **outdated
+);
 
 // Free outdated layers after successful UpdateModules
 void

--- a/modules/fwstate/bindings/go/cfwstate/safe.go
+++ b/modules/fwstate/bindings/go/cfwstate/safe.go
@@ -371,13 +371,32 @@ func stateValueFromC(value *C.struct_fw_state_value) StateValue {
 }
 
 // TrimStaleLayers trims stale layers from both IPv4 and IPv6 maps.
-func (m *ModuleConfig) TrimStaleLayers(now uint64) *OutdatedLayers {
-	ptr := C.fwstate_config_trim_stale_layers(m.asRawPtr(), C.uint64_t(now))
-	if ptr == nil {
-		return nil
+//
+// On failure, the returned handle is non-nil only when at least one layer
+// was actually collected and unlinked before the failure; that handle must
+// still be freed after the new config is published. A nil handle with an
+// error means nothing was collected and the chain is untouched. Stale
+// layers that were not collected stay linked and are retried on the next
+// trim.
+func (m *ModuleConfig) TrimStaleLayers(now uint64) (*OutdatedLayers, error) {
+	var outdated *C.fwstate_outdated_layers_t
+	rc, cErr := C.fwstate_config_trim_stale_layers(m.asRawPtr(), C.uint64_t(now), &outdated)
+
+	var handle *OutdatedLayers
+	if outdated != nil {
+		// A non-nil handle means layers may have been unlinked on success
+		// and were unlinked on failure, so readers paging by layer_index
+		// must observe a possible topology shift. Over-reporting a shift
+		// is benign, under-reporting is not.
+		handle = &OutdatedLayers{ptr: unsafe.Pointer(outdated)}
+		m.generation++
 	}
-	m.generation++
-	return &OutdatedLayers{ptr: unsafe.Pointer(ptr)}
+
+	if rc != 0 {
+		return handle, fmt.Errorf("failed to trim stale layers: error code=%d, cErr=%v", rc, cErr)
+	}
+
+	return handle, nil
 }
 
 func htons(v uint16) uint16 {

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -243,20 +243,38 @@ func (m *FWStateService) UpdateConfig(
 	if oldConfig != nil {
 		newConfig.PropagateConfig(oldConfig)
 
-		// Trim stale layers from the transferred configuration
-		// Layers with expired deadlines will be collected and added to pending list
-		// They will be freed after successful UpdateModules
+		// Trim stale layers from the transferred configuration.
+		// Layers with expired deadlines are collected and added to the
+		// pending list; they are freed after successful UpdateModules.
 		now := uint64(time.Now().UnixNano())
-		outdatedLayers := newConfig.TrimStaleLayers(now)
-		if outdatedLayers == nil {
-			// Only nil on memory allocation failure
-			newConfig.DetachMaps()
-			newConfig.Free()
-			m.log.Error("failed to allocate memory for outdated layers", zap.String("config", name))
-			return nil, status.Error(codes.Internal, "failed to allocate memory for outdated layer list")
+		outdatedLayers, err := newConfig.TrimStaleLayers(now)
+		if outdatedLayers != nil {
+			m.pendingOutdatedLayers = append(m.pendingOutdatedLayers, outdatedLayers)
 		}
-		// Always add to pending list - will be freed after successful UpdateModules
-		m.pendingOutdatedLayers = append(m.pendingOutdatedLayers, outdatedLayers)
+		if err != nil {
+			if outdatedLayers == nil {
+				// Nothing was collected, so nothing was unlinked: the chain
+				// is untouched and it is safe to abort the update.
+				newConfig.DetachMaps()
+				newConfig.Free()
+				m.log.Error("failed to trim stale fwstate layers",
+					zap.String("config", name),
+					zap.Error(err),
+				)
+				return nil, status.Errorf(codes.Internal, "failed to trim stale fwstate layers: %v", err)
+			}
+
+			// Partial trim: some layers were collected and are already
+			// pending, so continuing lets the upcoming successful publish
+			// free them and relieve the memory pressure that caused the
+			// failure. The layers that were not collected stay linked in
+			// the chain and are retried on the next update. Aborting here
+			// would prevent exactly the publish that frees memory.
+			m.log.Warn("trimmed stale layers only partially",
+				zap.String("config", name),
+				zap.Error(err),
+			)
+		}
 	}
 
 	// Set sync config

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -582,10 +582,18 @@ func GetCurrentTime() uint64 {
 	return uint64(C.clock_get_time_ns(nil))
 }
 
-// TrimStaleLayers trims stale layers using the C API
-func TrimStaleLayers(cpModule *C.struct_cp_module, now uint64) {
-	outdated := C.fwstate_config_trim_stale_layers(cpModule, C.uint64_t(now))
+// TrimStaleLayers trims stale layers using the C API.
+//
+// It immediately frees whatever layers were collected, since the test
+// harness has no publish step to defer the free to.
+func TrimStaleLayers(cpModule *C.struct_cp_module, now uint64) error {
+	var outdated *C.fwstate_outdated_layers_t
+	rc, cErr := C.fwstate_config_trim_stale_layers(cpModule, C.uint64_t(now), &outdated)
 	if outdated != nil {
 		C.fwstate_outdated_layers_free(outdated, cpModule)
 	}
+	if rc != 0 {
+		return fmt.Errorf("failed to trim stale layers: error code=%d, cErr=%v", rc, cErr)
+	}
+	return nil
 }

--- a/modules/fwstate/tests/dataplane/fwstate_test.go
+++ b/modules/fwstate/tests/dataplane/fwstate_test.go
@@ -298,7 +298,7 @@ func TestFWStateTrimStaleLayers(t *testing.T) {
 	futureTime := GetCurrentTime() + 200e9 // 200 seconds in the future
 
 	// Trim stale layers
-	TrimStaleLayers(cpModule, futureTime)
+	require.NoError(t, TrimStaleLayers(cpModule, futureTime))
 
 	// Check layer count after trim
 	_, layerCountAfter := GetLayerCount(cpModule)

--- a/tests/fwstate/layermap_test.c
+++ b/tests/fwstate/layermap_test.c
@@ -176,6 +176,204 @@ test_layermap_basic_operations(void *arena) {
 	fprintf(stderr, "Layermap basic operations test PASSED\n");
 }
 
+#define ALLOC_FAILURE_COARSE_CHUNK_SIZE (64 * 1024)
+#define ALLOC_FAILURE_MAX_COARSE_BLOCKS 4096
+#define ALLOC_FAILURE_MAX_FINE_BLOCKS 65536
+
+// Fills ctx to capacity so that a subsequent allocation of
+// sizeof(layermap_list_t) bytes deterministically fails. A coarse pass of
+// large chunks drains most of the arena quickly, keeping the bookkeeping
+// array small, then a fine pass of layermap_list_t sized blocks exhausts
+// whatever remains.
+static void
+exhaust_memory_context(
+	struct memory_context *ctx,
+	void **coarse_blocks,
+	size_t *coarse_count,
+	void **fine_blocks,
+	size_t *fine_count
+) {
+	*coarse_count = 0;
+	while (*coarse_count < ALLOC_FAILURE_MAX_COARSE_BLOCKS) {
+		void *block =
+			memory_balloc(ctx, ALLOC_FAILURE_COARSE_CHUNK_SIZE);
+		if (block == NULL) {
+			break;
+		}
+		coarse_blocks[(*coarse_count)++] = block;
+	}
+	assert(*coarse_count < ALLOC_FAILURE_MAX_COARSE_BLOCKS);
+
+	*fine_count = 0;
+	while (*fine_count < ALLOC_FAILURE_MAX_FINE_BLOCKS) {
+		void *block = memory_balloc(ctx, sizeof(layermap_list_t));
+		if (block == NULL) {
+			break;
+		}
+		fine_blocks[(*fine_count)++] = block;
+	}
+	assert(*fine_count < ALLOC_FAILURE_MAX_FINE_BLOCKS);
+}
+
+static size_t
+count_chain_layers(fwmap_t *layer) {
+	size_t count = 0;
+	while (layer) {
+		count++;
+		layer = (fwmap_t *)ADDR_OF(&layer->next);
+	}
+	return count;
+}
+
+// Verifies that a bookkeeping-node allocation failure during trim leaves the
+// layer chain and the outdated list fully consistent, with no orphaned
+// layer, and that a retried trim recovers once memory is available again.
+void
+test_layermap_alloc_failure_rollback(void *arena) {
+	fprintf(stderr,
+		"Testing layermap trim allocation-failure rollback...\n");
+
+	struct memory_context *ctx = init_context_from_arena(
+		arena, ARENA_SIZE, "layermap_alloc_failure"
+	);
+
+	fwmap_config_t config = {
+		.key_size = sizeof(int),
+		.value_size = sizeof(int),
+		.hash_seed = 0xdeadbeef,
+		.worker_count = 1,
+		.index_size = 128,
+		.extra_bucket_count = 16,
+	};
+
+	uint64_t now = 0;
+
+	// Allocate the active-layer pointer in the arena (not on the stack)
+	// because layermap functions and ADDR_OF require it to reside in
+	// shared memory.
+	fwmap_t **active_layer_offset = memory_balloc(ctx, sizeof(fwmap_t *));
+	assert(active_layer_offset != NULL);
+
+	fwmap_t *layer1 = fwmap_new(&config, ctx);
+	assert(layer1 != NULL);
+	SET_OFFSET_OF(active_layer_offset, layer1);
+
+	int key1 = 1, value1 = 100;
+	int64_t ret =
+		layermap_put(layer1, 0, now, now + 60, &key1, &value1, NULL);
+	assert(ret >= 0);
+
+	int insert_result =
+		layermap_insert_new_layer_cp(active_layer_offset, &config, ctx);
+	assert(insert_result == 0);
+	fwmap_t *layer2 = ADDR_OF(active_layer_offset);
+
+	int key2 = 2, value2 = 200;
+	ret = layermap_put(layer2, 0, now, now + 60, &key2, &value2, NULL);
+	assert(ret >= 0);
+
+	insert_result =
+		layermap_insert_new_layer_cp(active_layer_offset, &config, ctx);
+	assert(insert_result == 0);
+	fwmap_t *layer3 = ADDR_OF(active_layer_offset);
+
+	// layer3 is active and never examined by trim. layer2 and layer1
+	// both carry a max deadline of now + 60, so trimming at now + 61
+	// makes both of them stale.
+	uint64_t trim_now = now + 61;
+	assert(count_chain_layers(layer3) == 3);
+
+	static void *coarse_blocks[ALLOC_FAILURE_MAX_COARSE_BLOCKS];
+	static void *fine_blocks[ALLOC_FAILURE_MAX_FINE_BLOCKS];
+	size_t coarse_count = 0, fine_count = 0;
+	exhaust_memory_context(
+		ctx, coarse_blocks, &coarse_count, fine_blocks, &fine_count
+	);
+	void *probe = memory_balloc(ctx, sizeof(layermap_list_t));
+	assert(probe == NULL);
+
+	// Total failure: no layermap_list_t node can be allocated at all, so
+	// the very first stale layer must fail to unlink. The chain must be
+	// left fully intact.
+	layermap_list_t *outdated_head = NULL;
+	int trim_ret = layermap_trim_stale_layers_cp(
+		active_layer_offset, ctx, trim_now, &outdated_head
+	);
+	assert(trim_ret == -1);
+	assert(outdated_head == NULL);
+	assert(count_chain_layers(ADDR_OF(active_layer_offset)) == 3);
+
+	// Partial failure: free exactly one layermap_list_t sized block, so
+	// the first stale layer (layer2) can be collected but the second
+	// (layer1) still fails and must stay linked.
+	assert(fine_count > 0);
+	fine_count--;
+	memory_bfree(ctx, fine_blocks[fine_count], sizeof(layermap_list_t));
+
+	trim_ret = layermap_trim_stale_layers_cp(
+		active_layer_offset, ctx, trim_now, &outdated_head
+	);
+	assert(trim_ret == -1);
+	assert(outdated_head != NULL);
+	assert(ADDR_OF(&outdated_head->next) == NULL);
+	assert(ADDR_OF(&outdated_head->layer) == layer2);
+
+	fwmap_t *chain_after_partial = ADDR_OF(active_layer_offset);
+	assert(chain_after_partial == layer3);
+	fwmap_t *remaining_stale =
+		(fwmap_t *)ADDR_OF(&chain_after_partial->next);
+	assert(remaining_stale == layer1);
+	assert(ADDR_OF(&remaining_stale->next) == NULL);
+	assert(count_chain_layers(chain_after_partial) == 2);
+
+	// Recovery: free all remaining blocks and retry. This time both
+	// maps' trim work completes.
+	for (size_t idx = 0; idx < fine_count; idx++) {
+		memory_bfree(ctx, fine_blocks[idx], sizeof(layermap_list_t));
+	}
+	fine_count = 0;
+	for (size_t idx = 0; idx < coarse_count; idx++) {
+		memory_bfree(
+			ctx, coarse_blocks[idx], ALLOC_FAILURE_COARSE_CHUNK_SIZE
+		);
+	}
+	coarse_count = 0;
+
+	trim_ret = layermap_trim_stale_layers_cp(
+		active_layer_offset, ctx, trim_now, &outdated_head
+	);
+	assert(trim_ret == 0);
+	assert(count_chain_layers(ADDR_OF(active_layer_offset)) == 1);
+
+	size_t outdated_count = 0;
+	layermap_list_t *cursor = outdated_head;
+	while (cursor) {
+		outdated_count++;
+		cursor = (layermap_list_t *)ADDR_OF(&cursor->next);
+	}
+	assert(outdated_count == 2);
+
+	// Teardown: free every collected layer and its bookkeeping node,
+	// mirroring fwstate_outdated_layers_free.
+	cursor = outdated_head;
+	while (cursor) {
+		layermap_list_t *next =
+			(layermap_list_t *)ADDR_OF(&cursor->next);
+		fwmap_t *layer = ADDR_OF(&cursor->layer);
+		fwmap_free(layer, ctx);
+		memory_bfree(ctx, cursor, sizeof(layermap_list_t));
+		cursor = next;
+	}
+
+	fwmap_t *active_layer = ADDR_OF(active_layer_offset);
+	fwmap_free(active_layer, ctx);
+	memory_bfree(ctx, active_layer_offset, sizeof(fwmap_t *));
+
+	verify_memory_leaks(ctx, "layermap_alloc_failure_rollback");
+	memory_context_fini(ctx);
+	fprintf(stderr, "Layermap alloc-failure rollback test PASSED\n");
+}
+
 struct rotator_args {
 	fwmap_t **active_layer_offset;
 	fwmap_config_t *config;
@@ -360,6 +558,7 @@ main() {
 	}
 
 	test_layermap_basic_operations(arena);
+	test_layermap_alloc_failure_rollback(arena);
 	test_layermap_multithreaded(arena);
 
 	free_arena(arena, ARENA_SIZE);


### PR DESCRIPTION
- Trim bookkeeping is now allocated before a stale layer is unlinked, so an allocation failure leaves the layer chain intact instead of orphaning the layer in shared memory.
- Partial trim failures are propagated to the control plane, which logs a warning and continues the update so the following publish can free the collected layers and relieve the memory pressure that caused the failure.
- Added a C unit test covering rollback on total allocation failure, partial mid-trim failure, and recovery once memory is available again.

Closes #895.
