### PR TITLE
feat(dataplane): guard .so module plugins by ABI version

### DIFF
--- a/lib/dataplane/config/meson.build
+++ b/lib/dataplane/config/meson.build
@@ -30,3 +30,20 @@ lib_config_dp_dep = declare_dependency(
   include_directories: yanet_libdir,
   dependencies: dependencies,
 )
+
+# Source that exports a module .so's compiled-against ABI version, for a
+# future module shared_module() target to pull in. Deliberately kept out
+# of lib_config_dp: linking it into every statically-linked built-in
+# module would make the final dataplane binary define
+# yanet_module_abi_version more than once. A shared_module() target picks
+# this up by adding lib_module_abi_export_sources to its own sources (or
+# lib_module_abi_export_dep to its dependencies) exactly once per .so.
+lib_module_abi_export_sources = files('plugin_abi_export.c')
+
+lib_module_abi_export_dep = declare_dependency(
+  sources: lib_module_abi_export_sources,
+  include_directories: [
+    yanet_libdir,
+    yanet_rootdir,
+  ],
+)

--- a/lib/dataplane/config/module_loader.c
+++ b/lib/dataplane/config/module_loader.c
@@ -7,6 +7,8 @@
 #include "common/exp_array.h"
 #include "common/memory_address.h"
 #include "common/strutils.h"
+// Included purely for its compile-time ABI-size tripwire assertions.
+#include "lib/dataplane/config/plugin_abi_assert.h" // IWYU pragma: keep
 #include "lib/dataplane/config/plugin_loader.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/device/device.h"

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -1,0 +1,49 @@
+#pragma once
+
+// Size tripwires for the structs a module .so exchanges with the dataplane
+// binary across the plugin boundary.
+//
+// Both the dataplane binary and every plugin .so compile these assertions,
+// so a layout change on either side of the boundary fails the build unless
+// YANET_MODULE_ABI_VERSION in module.h is bumped to match.
+//
+// This is a size check only: it catches a struct that grew or shrank, not a
+// same-size field reshuffle, so a reviewer must still bump the version on any
+// layout change that keeps the size constant. When one of these fires, update
+// the literal here and bump YANET_MODULE_ABI_VERSION in the same change.
+
+#include "lib/controlplane/config/cp_module.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/module/module.h"
+#include "lib/dataplane/module/packet_front.h"
+#include "lib/dataplane/packet/packet.h"
+#include "lib/dataplane/pipeline/econtext.h"
+
+_Static_assert(
+	sizeof(struct module) == 88,
+	"struct module size changed, bump YANET_MODULE_ABI_VERSION"
+);
+_Static_assert(
+	sizeof(struct dp_config) == 1432,
+	"struct dp_config size changed, bump YANET_MODULE_ABI_VERSION"
+);
+_Static_assert(
+	sizeof(struct packet) == 48,
+	"struct packet size changed, bump YANET_MODULE_ABI_VERSION"
+);
+_Static_assert(
+	sizeof(struct packet_front) == 160,
+	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
+);
+_Static_assert(
+	sizeof(struct cp_module) == 544,
+	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
+);
+_Static_assert(
+	sizeof(struct module_ectx) == 144,
+	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
+);
+_Static_assert(
+	sizeof(struct dp_worker) == 136,
+	"struct dp_worker size changed, bump YANET_MODULE_ABI_VERSION"
+);

--- a/lib/dataplane/config/plugin_abi_export.c
+++ b/lib/dataplane/config/plugin_abi_export.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+
+#include "lib/dataplane/config/plugin_abi_assert.h" // IWYU pragma: keep
+#include "lib/dataplane/module/module.h"
+
+// Compiled-against ABI version this module .so was built with.
+//
+// The dataplane's plugin loader dlsym's this symbol and refuses to load a
+// plugin whose value does not match YANET_MODULE_ABI_VERSION.
+//
+// This translation unit is compiled ONLY into module shared_module (.so)
+// builds, never into the static built-in modules linked into the main
+// dataplane binary, so multiple statically-linked built-ins never collide
+// by both defining this symbol.
+//
+// Explicit default visibility: a module .so may compile the rest of its
+// sources with -fvisibility=hidden, and this symbol must stay dlsym-able
+// regardless.
+__attribute__((visibility("default"))) uint32_t yanet_module_abi_version =
+	YANET_MODULE_ABI_VERSION;

--- a/lib/dataplane/config/plugin_loader.c
+++ b/lib/dataplane/config/plugin_loader.c
@@ -9,6 +9,7 @@
 #include <sys/stat.h>
 
 #include "common/strutils.h"
+#include "lib/dataplane/module/module.h"
 #include "lib/logging/log.h"
 
 #define PLUGIN_SO_PREFIX "lib"
@@ -38,22 +39,47 @@ plugin_name_from_filename(const char *filename, char *name, size_t name_len) {
 	return 0;
 }
 
+// Read a plugin's exported YANET_MODULE_ABI_VERSION_SYMBOL value.
+//
+// Returns 0 and sets *out to the exported version on success, -1 if the
+// plugin does not export the symbol.
+static int
+dp_plugin_abi_version(void *dl_handle, uint32_t *out) {
+	dlerror();
+	uint32_t *version =
+		(uint32_t *)dlsym(dl_handle, YANET_MODULE_ABI_VERSION_SYMBOL);
+	if (version == NULL || dlerror() != NULL) {
+		return -1;
+	}
+
+	*out = *version;
+	return 0;
+}
+
 int
 dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry) {
 	registry->plugins = NULL;
 	registry->count = 0;
 
-	if (plugin_dir == NULL || plugin_dir[0] == '\0')
+	// An empty plugin_dir means the plugin feature is unused: a clean
+	// no-op, not an error.
+	if (plugin_dir == NULL || plugin_dir[0] == '\0') {
 		return 0;
+	}
 
 	DIR *dir = opendir(plugin_dir);
 	if (dir == NULL) {
-		LOG(WARN,
-		    "cannot open plugin directory %s: %s",
+		// A non-empty plugin_dir was explicitly configured, so failing
+		// to open it is a misconfiguration and must abort startup
+		// rather than silently run without the configured plugins.
+		LOG(ERROR,
+		    "cannot open configured plugin directory %s: %s",
 		    plugin_dir,
 		    strerror(errno));
-		return 0;
+		return -1;
 	}
+
+	void *dl = NULL;
 
 	struct dirent *entry;
 	while ((entry = readdir(dir)) != NULL) {
@@ -76,10 +102,35 @@ dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry) {
 		if (stat(so_path, &st) != 0 || !S_ISREG(st.st_mode))
 			continue;
 
-		void *dl = dlopen(so_path, RTLD_NOW | RTLD_GLOBAL);
+		// A file matching the plugin filename pattern is an explicitly
+		// configured plugin. If it is present but broken, abort startup
+		// instead of running without the module.
+		dl = dlopen(so_path, RTLD_NOW | RTLD_GLOBAL);
 		if (dl == NULL) {
 			LOG(ERROR, "dlopen(%s) failed: %s", so_path, dlerror());
-			continue;
+			goto fail;
+		}
+
+		uint32_t found_version = 0;
+		if (dp_plugin_abi_version(dl, &found_version) != 0) {
+			LOG(ERROR,
+			    "plugin %s (%s) does not export the %s symbol; "
+			    "refusing to load a plugin with unknown "
+			    "dataplane ABI version",
+			    name,
+			    so_path,
+			    YANET_MODULE_ABI_VERSION_SYMBOL);
+			goto fail;
+		}
+		if (found_version != YANET_MODULE_ABI_VERSION) {
+			LOG(ERROR,
+			    "plugin %s (%s) ABI version mismatch: dataplane "
+			    "expects %u, plugin was built for %u",
+			    name,
+			    so_path,
+			    (unsigned)YANET_MODULE_ABI_VERSION,
+			    (unsigned)found_version);
+			goto fail;
 		}
 
 		struct plugin_handle *new_plugins =
@@ -88,8 +139,7 @@ dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry) {
 					(registry->count + 1));
 		if (new_plugins == NULL) {
 			LOG(ERROR, "out of memory for plugin %s", name);
-			dlclose(dl);
-			continue;
+			goto fail;
 		}
 		registry->plugins = new_plugins;
 
@@ -98,6 +148,9 @@ dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry) {
 		strtcpy(handle->name, name, sizeof(handle->name));
 		handle->dl_handle = dl;
 		registry->count++;
+
+		// Ownership of the handle now belongs to the registry.
+		dl = NULL;
 
 		LOG(INFO, "loaded plugin %s from %s", name, so_path);
 	}
@@ -109,6 +162,16 @@ dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry) {
 	    (unsigned long)registry->count,
 	    plugin_dir);
 	return 0;
+
+fail:
+	// Close the handle that failed before it was registered, then unload
+	// every plugin already registered so the registry is left empty.
+	if (dl != NULL) {
+		dlclose(dl);
+	}
+	closedir(dir);
+	dp_unload_plugins(registry);
+	return -1;
 }
 
 void

--- a/lib/dataplane/config/plugin_loader.h
+++ b/lib/dataplane/config/plugin_loader.h
@@ -16,8 +16,13 @@ struct plugin_registry {
 
 // Scan plugin_dir for lib*_dp.so files and dlopen each one.
 // Returns 0 on success, -1 on fatal error.
-// Individual plugin failures are logged but do not prevent other
-// plugins from loading.
+//
+// An empty plugin_dir is a clean no-op. Any other failure is fatal and
+// returns -1 with the registry left empty: a plugin_dir that cannot be
+// opened, a dlopen failure, an out-of-memory condition, a plugin missing
+// the ABI version symbol, or an exported ABI version that does not match
+// YANET_MODULE_ABI_VERSION. A present-but-broken plugin aborts startup
+// rather than silently running without the configured module.
 int
 dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry);
 

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -2,6 +2,19 @@
 
 #define MODULE_TYPE_LEN 80
 
+// Dataplane <-> module .so ABI version.
+//
+// Bump this monotonically whenever the layout of a struct or function
+// signature shared between the dataplane binary and a module .so changes.
+//
+// The dataplane's plugin loader rejects a .so whose exported version does
+// not match this constant.
+#define YANET_MODULE_ABI_VERSION 1
+
+// Symbol name a module .so exports carrying its compiled-against
+// YANET_MODULE_ABI_VERSION, as a uint32_t global.
+#define YANET_MODULE_ABI_VERSION_SYMBOL "yanet_module_abi_version"
+
 struct packet_front;
 struct module_ectx;
 struct dp_worker;


### PR DESCRIPTION
The dataplane loads packet-processing modules as external .so plugins from a configured directory, but the loader performed no version check — a plugin built against a different dataplane layout could silently corrupt shared memory.

Each plugin now embeds an ABI-version symbol that the loader verifies on load, refusing any plugin with a missing or mismatched version.

A compile-time assertion over the shared dataplane structures fails the build whenever that ABI changes without a version bump, so the version cannot silently fall out of date.

Plugin load errors now fail dataplane startup instead of being silently skipped.
