### PR TITLE
feat(fwstate): metrics service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,6 +3338,7 @@ dependencies = [
  "prost-types",
  "serde",
  "serde_json",
+ "tabled",
  "tokio",
  "tokio-stream",
  "tonic",

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -149,11 +149,11 @@ fn format_gauge_value(name: &str, value: f64) -> String {
         if value < 1024.0 {
             format!("{:.0} B", value)
         } else if value < 1024.0 * 1024.0 {
-            format!("{:.2} KB", value / 1024.0)
+            format!("{:.2} KiB", value / 1024.0)
         } else if value < 1024.0 * 1024.0 * 1024.0 {
-            format!("{:.2} MB", value / (1024.0 * 1024.0))
+            format!("{:.2} MiB", value / (1024.0 * 1024.0))
         } else {
-            format!("{:.2} GB", value / (1024.0 * 1024.0 * 1024.0))
+            format!("{:.2} GiB", value / (1024.0 * 1024.0 * 1024.0))
         }
     } else {
         format_number(value as u64)

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -65,7 +65,7 @@ func NewACLModule(cfg *Config, log *zap.Logger) (*ACLModule, error) {
 		agent,
 		aclAdapter,
 		fwstate.WithLog(log),
-		fwstate.WithMetrics(),
+		fwstate.WithMetrics(fwstate.NewMetricsFactory()),
 	)
 	fwstateMetricsService := fwstate.NewMetricsService(fwstateService)
 

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -14,10 +14,8 @@ import (
 )
 
 const (
-	agentName                 = "acl"
-	serviceName               = "modules.acl.controlplane.aclpb.v1.ACLService"
-	fwstateServiceName        = "modules.fwstate.controlplane.fwstatepb.v1.FWStateService"
-	fwstateMetricsServiceName = "modules.fwstate.controlplane.fwstatepb.v1.MetricsService"
+	agentName   = "acl"
+	serviceName = "modules.acl.controlplane.aclpb.v1.ACLService"
 )
 
 // ACLModule is a control-plane component for ACL (Access Control List) module
@@ -95,8 +93,8 @@ func (m *ACLModule) ServicesNames() []string {
 	return []string{
 		serviceName,
 		aclpb.MetricsService_ServiceDesc.ServiceName,
-		fwstateServiceName,
-		fwstateMetricsServiceName,
+		fwstate.FWStateServiceName,
+		fwstate.FWStateMetricsServiceName,
 	}
 }
 

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -14,21 +14,23 @@ import (
 )
 
 const (
-	agentName          = "acl"
-	serviceName        = "modules.acl.controlplane.aclpb.v1.ACLService"
-	fwstateServiceName = "modules.fwstate.controlplane.fwstatepb.v1.FWStateService"
+	agentName                 = "acl"
+	serviceName               = "modules.acl.controlplane.aclpb.v1.ACLService"
+	fwstateServiceName        = "modules.fwstate.controlplane.fwstatepb.v1.FWStateService"
+	fwstateMetricsServiceName = "modules.fwstate.controlplane.fwstatepb.v1.MetricsService"
 )
 
 // ACLModule is a control-plane component for ACL (Access Control List) module
 // with integrated firewall state management.
 type ACLModule struct {
-	cfg            *Config
-	shm            *ffi.SharedMemory
-	agent          *ffi.Agent
-	aclService     *ACLService
-	metricsService *MetricsService
-	fwstateService *fwstate.FWStateService
-	log            *zap.Logger
+	cfg                   *Config
+	shm                   *ffi.SharedMemory
+	agent                 *ffi.Agent
+	aclService            *ACLService
+	metricsService        *MetricsService
+	fwstateService        *fwstate.FWStateService
+	fwstateMetricsService *fwstate.MetricsService
+	log                   *zap.Logger
 }
 
 // NewACLModule creates a new ACL module instance.
@@ -61,16 +63,23 @@ func NewACLModule(cfg *Config, log *zap.Logger) (*ACLModule, error) {
 	metricsService := NewMetricsService(aclService)
 
 	aclAdapter := NewACLAdapter(aclService)
-	fwstateService := fwstate.NewFWStateService(agent, aclAdapter, log)
+	fwstateService := fwstate.NewFWStateService(
+		agent,
+		aclAdapter,
+		fwstate.WithLog(log),
+		fwstate.WithMetrics(),
+	)
+	fwstateMetricsService := fwstate.NewMetricsService(fwstateService)
 
 	return &ACLModule{
-		cfg:            cfg,
-		shm:            shm,
-		agent:          agent,
-		aclService:     aclService,
-		metricsService: metricsService,
-		fwstateService: fwstateService,
-		log:            log,
+		cfg:                   cfg,
+		shm:                   shm,
+		agent:                 agent,
+		aclService:            aclService,
+		metricsService:        metricsService,
+		fwstateService:        fwstateService,
+		fwstateMetricsService: fwstateMetricsService,
+		log:                   log,
 	}, nil
 }
 
@@ -83,23 +92,31 @@ func (m *ACLModule) Endpoint() string {
 }
 
 func (m *ACLModule) ServicesNames() []string {
-	return []string{serviceName, aclpb.MetricsService_ServiceDesc.ServiceName, fwstateServiceName}
+	return []string{
+		serviceName,
+		aclpb.MetricsService_ServiceDesc.ServiceName,
+		fwstateServiceName,
+		fwstateMetricsServiceName,
+	}
 }
 
 func (m *ACLModule) RegisterService(server *grpc.Server) {
 	aclpb.RegisterACLServiceServer(server, m.aclService)
 	aclpb.RegisterMetricsServiceServer(server, m.metricsService)
 	fwstatepb.RegisterFWStateServiceServer(server, m.fwstateService)
+	fwstatepb.RegisterMetricsServiceServer(server, m.fwstateMetricsService)
 }
 
 // UnaryServerInterceptors returns the gRPC unary interceptors for this module.
 func (m *ACLModule) UnaryServerInterceptors() []grpc.UnaryServerInterceptor {
-	si := m.aclService.UnaryServerInterceptor()
-	if si == nil {
-		return nil
+	var interceptors []grpc.UnaryServerInterceptor
+	if si := m.aclService.UnaryServerInterceptor(); si != nil {
+		interceptors = append(interceptors, si)
 	}
-
-	return []grpc.UnaryServerInterceptor{si}
+	if si := m.fwstateService.UnaryServerInterceptor(); si != nil {
+		interceptors = append(interceptors, si)
+	}
+	return interceptors
 }
 
 // ACLAdapter returns an adapter for fwstate module integration.

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -70,6 +70,56 @@ fwstate_module_config_new(
 		return NULL;
 	}
 	fwstate_config_set_defaults(&config->cfg);
+
+	// Register module-level counters.
+	// size=2 counters hold [packets, bytes]; size=1 counters hold
+	// [packets].
+	struct {
+		const char *name;
+		uint64_t size;
+		uint64_t *dst;
+	} counters[] = {
+		{"fwstate_sync_packets", 2, &config->sync_packets_counter_id},
+		{"fwstate_passthrough", 2, &config->passthrough_counter_id},
+		{"fwstate_sync_v4_inserted",
+		 1,
+		 &config->sync_v4_inserted_counter_id},
+		{"fwstate_sync_v6_inserted",
+		 1,
+		 &config->sync_v6_inserted_counter_id},
+		{"fwstate_sync_v4_insert_failed",
+		 1,
+		 &config->sync_v4_insert_failed_counter_id},
+		{"fwstate_sync_v6_insert_failed",
+		 1,
+		 &config->sync_v6_insert_failed_counter_id},
+		{"fwstate_external_dropped",
+		 2,
+		 &config->external_dropped_counter_id},
+		{"fwstate_internal_forwarded",
+		 2,
+		 &config->internal_forwarded_counter_id},
+	};
+
+	for (size_t i = 0; i < sizeof(counters) / sizeof(counters[0]); ++i) {
+		uint64_t id = counter_registry_register(
+			&config->cp_module.counter_registry,
+			counters[i].name,
+			counters[i].size,
+			err
+		);
+		if (id == (uint64_t)-1) {
+			yanet_error_add(
+				err,
+				"failed to register counter '%s'",
+				counters[i].name
+			);
+			fwstate_module_config_free(&config->cp_module);
+			return NULL;
+		}
+		*counters[i].dst = id;
+	}
+
 	return &config->cp_module;
 }
 

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -79,7 +79,7 @@ fwstate_module_config_new(
 		uint64_t size;
 		uint64_t *dst;
 	} counters[] = {
-		{"fwstate_sync_packets", 2, &config->sync_packets_counter_id},
+		{"fwstate_sync", 2, &config->sync_packets_counter_id},
 		{"fwstate_passthrough", 2, &config->passthrough_counter_id},
 		{"fwstate_sync_v4_inserted",
 		 1,

--- a/modules/fwstate/bindings/go/cfwstate/cgo.go
+++ b/modules/fwstate/bindings/go/cfwstate/cgo.go
@@ -3,6 +3,7 @@ package cfwstate
 //#cgo CFLAGS: -I../../../../../
 //#cgo CFLAGS: -I../../../../../lib
 //#cgo LDFLAGS: -L../../../../../build/modules/fwstate/api -lfwstate_cp
+//#cgo LDFLAGS: -L../../../../../build/lib/counters -lcounters
 //
 //#include "api/agent.h"
 //#include "common/numutils.h"

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 humantime = "2"
 netip = "0.3"
+tabled = { version = "0.18", features = ["ansi"] }
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/modules/fwstate/cli/build.rs
+++ b/modules/fwstate/cli/build.rs
@@ -4,6 +4,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=../controlplane/fwstatepb/v1/fwstate.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/ipaddr.proto");
     println!("cargo:rerun-if-changed=../../../common/commonpb/v1/macaddr.proto");
+    println!("cargo:rerun-if-changed=../../../common/commonpb/v1/metric.proto");
 
     tonic_build::configure()
         .emit_rerun_if_changed(false)

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 use clap::Parser;
 
+use crate::metric::{Kind, Metric};
+
 /// Parse duration from string (e.g., "60s", "5m", "1h")
 fn parse_duration(s: &str) -> Result<Duration, String> {
     humantime::parse_duration(s).map_err(|e| e.to_string())
@@ -24,6 +26,8 @@ pub enum ModeCmd {
     Stats(StatsCmd),
     /// List entries from fwstate map
     Entries(EntriesCmd),
+    /// Show fwstate metrics
+    Metrics(MetricsCmd),
 }
 
 #[derive(Debug, Clone, Parser)]
@@ -160,4 +164,38 @@ pub struct EntriesCmd {
     /// Starting cursor position (0 = beginning)
     #[arg(long, default_value = "0")]
     pub index: u32,
+}
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum MetricName {
+    /// Dataplane packet/byte counters (fwstate_*_packets, fwstate_*_bytes)
+    Counters,
+    /// Map statistics gauges: index_size, total_elements, memory_bytes, etc.
+    MapStats,
+    /// Sync-related counters (fwstate_sync_*)
+    Sync,
+    /// gRPC server metrics: call counts and handling latency histograms
+    Grpc,
+}
+
+impl MetricName {
+    /// Returns true when the metric belongs to this category.
+    pub fn matches(&self, m: &Metric) -> bool {
+        match self {
+            Self::Counters => m.kind == Kind::Counter && m.name.starts_with("fwstate_"),
+            Self::MapStats => m.kind == Kind::Gauge && m.name.starts_with("fwstate_"),
+            Self::Sync => m.kind == Kind::Counter && m.name.starts_with("fwstate_sync_"),
+            Self::Grpc => m.name.starts_with("grpc_"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Parser, Default)]
+pub struct MetricsCmd {
+    /// Label filter, e.g. --label config=my-fwstate --label af=ipv4
+    #[arg(long = "label", short = 'l', value_name = "KEY=VALUE")]
+    pub labels: Vec<String>,
+    /// Show only metrics matching this category
+    #[arg(long, short, value_enum)]
+    pub name: Option<MetricName>,
 }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
-    client::{ConnectionArgs, LayeredChannel, Service},
+    client::{Connection, ConnectionArgs, LayeredChannel, Service},
     display::print_table_from_entries,
     errors::Error,
     output::{self, CommonFormat},
@@ -75,19 +75,17 @@ pub struct FWStateService {
 
 impl FWStateService {
     pub async fn new(connection: &ConnectionArgs) -> Result<Self, Error> {
-        let service = Service::connect(connection, SERVICE_NAME, |channel| {
+        let conn = Connection::connect(connection).await?;
+        let service = Service::new(&conn, SERVICE_NAME, |channel| {
             FwStateServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
-
-        let metrics = Service::connect(connection, METRICS_SERVICE_NAME, |channel| {
+        });
+        let metrics = Service::new(&conn, METRICS_SERVICE_NAME, |channel| {
             MetricsServiceClient::new(channel)
                 .send_compressed(CompressionEncoding::Gzip)
                 .accept_compressed(CompressionEncoding::Gzip)
-        })
-        .await?;
+        });
 
         Ok(Self { service, metrics })
     }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -384,14 +384,17 @@ impl FWStateService {
             .await
             .map_err(self.metrics.status("metrics"))?
             .into_inner();
-        let label_filters: Vec<(&str, &str)> = cmd
-            .labels
-            .iter()
-            .filter_map(|s| {
-                let mut it = s.splitn(2, '=');
-                Some((it.next()?, it.next()?))
-            })
-            .collect();
+        let mut label_filters: Vec<(&str, &str)> = Vec::with_capacity(cmd.labels.len());
+        for s in &cmd.labels {
+            match s.split_once('=') {
+                Some(kv) => label_filters.push(kv),
+                None => {
+                    return Err(self
+                        .metrics
+                        .invalid("metrics", format!("invalid label filter {s:?}, expected KEY=VALUE")));
+                }
+            }
+        }
 
         let metrics: Vec<Metric> = response
             .metrics
@@ -755,62 +758,66 @@ fn print_metrics_table(metrics: &[Metric]) {
         let mut pair_order: Vec<String> = Vec::new();
         let mut pair_map: HashMap<String, CounterPair> = HashMap::new();
 
+        // Generic counters (the default arm of emitCounterMetrics) are all
+        // exported under the shared names fwstate_counter_packets /
+        // fwstate_counter_bytes and distinguished only by the "counter" label.
+        // After stripping the fwstate_ prefix and the _packets/_bytes suffix
+        // they all collapse to the same base "counter", so the pair key must
+        // include the "counter" label value to keep them as separate rows
+        // instead of overwriting each other (last write wins). Dedicated
+        // counters carry no "counter" label, so the suffix is empty and their
+        // base is unaffected.
         for m in counters {
             let val = m.value.unwrap_or(0.0) as u64;
             let stripped = m.name.strip_prefix("fwstate_").unwrap_or(&m.name);
-            if let Some(base) = stripped.strip_suffix("_packets") {
-                let pair = pair_map.entry(base.to_string()).or_insert_with(|| {
-                    pair_order.push(base.to_string());
-                    CounterPair {
-                        display: metric_display_name(base),
-                        packets: None,
-                        bytes: None,
-                        entries: None,
-                    }
-                });
-                pair.packets = Some(val);
-            } else if let Some(base) = stripped.strip_suffix("_bytes") {
-                let pair = pair_map.entry(base.to_string()).or_insert_with(|| {
-                    pair_order.push(base.to_string());
-                    CounterPair {
-                        display: metric_display_name(base),
-                        packets: None,
-                        bytes: None,
-                        entries: None,
-                    }
-                });
-                pair.bytes = Some(val);
-            } else if let Some(base) = stripped.strip_suffix("_entries") {
-                // State-table entry counters (e.g. sync insert counters)
-                // count frames, not packets/bytes; render under Entries.
-                let pair = pair_map.entry(base.to_string()).or_insert_with(|| {
-                    pair_order.push(base.to_string());
-                    CounterPair {
-                        display: metric_display_name(base),
-                        packets: None,
-                        bytes: None,
-                        entries: None,
-                    }
-                });
-                pair.entries = Some(val);
+            let counter_label = m.label_value("counter").unwrap_or("");
+
+            // Determine the semantic suffix and the base name shared by the
+            // packets/bytes series of the same counter. The pair key and the
+            // display name must be built from the base (suffix stripped),
+            // otherwise fwstate_rx_packets and fwstate_rx_bytes get different
+            // keys and end up on two separate rows instead of one.
+            let (base, is_packets, is_bytes) = if let Some(b) = stripped.strip_suffix("_packets") {
+                (b, true, false)
+            } else if let Some(b) = stripped.strip_suffix("_bytes") {
+                (b, false, true)
             } else {
-                let pair = pair_map.entry(stripped.to_string()).or_insert_with(|| {
-                    pair_order.push(stripped.to_string());
-                    CounterPair {
-                        display: metric_display_name(stripped),
-                        packets: None,
-                        bytes: None,
-                        entries: None,
-                    }
-                });
+                (stripped, false, false)
+            };
+
+            let display = if counter_label.is_empty() {
+                metric_display_name(base)
+            } else {
+                metric_display_name(counter_label)
+            };
+            let pair_key = format!("{base}\0{counter_label}");
+
+            let pair = pair_map.entry(pair_key.clone()).or_insert_with(|| {
+                pair_order.push(pair_key.clone());
+                CounterPair {
+                    display,
+                    packets: None,
+                    bytes: None,
+                    entries: None,
+                }
+            });
+
+            if is_packets {
+                pair.packets = Some(val);
+            } else if is_bytes {
+                pair.bytes = Some(val);
+            } else {
+                // State-table entry counters (e.g. sync insert counters) and
+                // any unsuffixed counter count frames/items, not
+                // packets/bytes; render under Entries.
                 pair.entries = Some(val);
             }
         }
 
         let rows: Vec<CounterRow> = pair_order
             .iter()
-            .map(|base| {
-                let p = &pair_map[base];
+            .map(|pair_key| {
+                let p = &pair_map[pair_key];
                 CounterRow {
                     counter: p.display.clone(),
                     packets: p.packets.map(format_number).unwrap_or_else(|| "-".into()),

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -1,26 +1,31 @@
 use core::{fmt, net::Ipv6Addr, time::Duration};
-use std::time::UNIX_EPOCH;
+use std::{collections::HashMap, time::UNIX_EPOCH};
 
-use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
+use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use commonpb::pb::IpAddress;
 use fwstatepb::{
-    DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
-    ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
+    DeleteConfigRequest, Direction, GetMetricsRequest, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest,
+    ListEntriesRequest, ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
+    metrics_service_client::MetricsServiceClient,
 };
+use metric::Metric;
 use netip::MacAddr;
 use serde::Serialize;
+use tabled::Tabled;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    display::print_table_from_entries,
     errors::Error,
     output::{self, CommonFormat},
 };
 
 mod args;
+mod metric;
 
 #[allow(non_snake_case)]
 pub mod fwstatepb {
@@ -31,6 +36,9 @@ pub mod fwstatepb {
 
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.fwstate.controlplane.fwstatepb.v1.FWStateService";
+
+/// The fully-qualified gRPC service name for the metrics service.
+const METRICS_SERVICE_NAME: &str = "modules.fwstate.controlplane.fwstatepb.v1.MetricsService";
 
 /// FWState module CLI.
 #[derive(Debug, Clone, Parser)]
@@ -62,6 +70,7 @@ fn parse_mac(s: &str) -> Result<MacAddr, String> {
 
 pub struct FWStateService {
     service: Service<FwStateServiceClient<LayeredChannel>>,
+    metrics: Service<MetricsServiceClient<LayeredChannel>>,
 }
 
 impl FWStateService {
@@ -73,7 +82,14 @@ impl FWStateService {
         })
         .await?;
 
-        Ok(Self { service })
+        let metrics = Service::connect(connection, METRICS_SERVICE_NAME, |channel| {
+            MetricsServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        })
+        .await?;
+
+        Ok(Self { service, metrics })
     }
 
     pub async fn list_configs(&mut self) -> Result<(), Error> {
@@ -361,6 +377,44 @@ impl FWStateService {
 
         Ok(())
     }
+
+    pub async fn metrics(&mut self, cmd: MetricsCmd) -> Result<(), Error> {
+        let response = self
+            .metrics
+            .client()
+            .get_metrics(GetMetricsRequest {})
+            .await
+            .map_err(self.metrics.status("metrics"))?
+            .into_inner();
+        let label_filters: Vec<(&str, &str)> = cmd
+            .labels
+            .iter()
+            .filter_map(|s| {
+                let mut it = s.splitn(2, '=');
+                Some((it.next()?, it.next()?))
+            })
+            .collect();
+
+        let metrics: Vec<Metric> = response
+            .metrics
+            .into_iter()
+            .map(Metric::from_proto)
+            .filter(|m| {
+                if let Some(ref f) = cmd.name {
+                    if !f.matches(m) {
+                        return false;
+                    }
+                }
+                label_filters.iter().all(|(k, v)| m.label_value(k) == Some(v))
+            })
+            .collect();
+
+        output::data(&metrics, metrics.is_empty(), format_args!("no metrics"), || {
+            print_metrics_table(&metrics)
+        });
+
+        Ok(())
+    }
 }
 
 fn format_addr(addr: Option<&IpAddress>) -> String {
@@ -539,6 +593,315 @@ fn print_entry(entry: &fwstatepb::FwStateEntry) {
     );
 }
 
+#[derive(Tabled)]
+struct CounterRow {
+    #[tabled(rename = "Counter")]
+    counter: String,
+    #[tabled(rename = "Packets")]
+    packets: String,
+    #[tabled(rename = "Bytes")]
+    bytes: String,
+}
+
+#[derive(Tabled)]
+struct GaugeRow {
+    #[tabled(rename = "Metric")]
+    metric: String,
+    #[tabled(rename = "Value")]
+    value: String,
+}
+
+#[derive(Tabled)]
+struct GrpcCallRow {
+    #[tabled(rename = "Method")]
+    method: String,
+    #[tabled(rename = "Code")]
+    code: String,
+    #[tabled(rename = "Handled")]
+    handled: String,
+}
+
+#[derive(Tabled)]
+struct GrpcLatRow {
+    #[tabled(rename = "Method")]
+    method: String,
+    #[tabled(rename = "Total Calls")]
+    total: String,
+    #[tabled(rename = "P50")]
+    p50: String,
+    #[tabled(rename = "P95")]
+    p95: String,
+    #[tabled(rename = "P99")]
+    p99: String,
+}
+
+fn format_number(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, c) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(c);
+    }
+    result.chars().rev().collect()
+}
+
+fn format_gauge_value(name: &str, value: f64) -> String {
+    if name.ends_with("_ns") {
+        if value < 1_000.0 {
+            format!("{:.0}ns", value)
+        } else if value < 1_000_000.0 {
+            format!("{:.2}µs", value / 1_000.0)
+        } else if value < 1_000_000_000.0 {
+            format!("{:.2}ms", value / 1_000_000.0)
+        } else {
+            format!("{:.2}s", value / 1_000_000_000.0)
+        }
+    } else if name.ends_with("_bytes") {
+        if value < 1024.0 {
+            format!("{:.0} B", value)
+        } else if value < 1024.0 * 1024.0 {
+            format!("{:.2} KB", value / 1024.0)
+        } else if value < 1024.0 * 1024.0 * 1024.0 {
+            format!("{:.2} MB", value / (1024.0 * 1024.0))
+        } else {
+            format!("{:.2} GB", value / (1024.0 * 1024.0 * 1024.0))
+        }
+    } else {
+        format_number(value as u64)
+    }
+}
+
+fn metric_display_name(name: &str) -> String {
+    let stripped = name.strip_prefix("fwstate_").unwrap_or(name);
+    stripped
+        .split('_')
+        .map(|word| {
+            let mut c = word.chars();
+            match c.next() {
+                None => String::new(),
+                Some(first) => first.to_uppercase().collect::<String>() + c.as_str(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn print_metrics_table(metrics: &[Metric]) {
+    struct CounterPair {
+        display: String,
+        packets: Option<u64>,
+        bytes: Option<u64>,
+    }
+
+    let mut counter_keys: Vec<String> = Vec::new();
+    let mut counter_map: HashMap<String, Vec<&Metric>> = HashMap::new();
+    let mut gauge_keys: Vec<String> = Vec::new();
+    let mut gauge_map: HashMap<String, Vec<&Metric>> = HashMap::new();
+    let mut grpc_counters: Vec<&Metric> = Vec::new();
+    let mut grpc_histograms: Vec<&Metric> = Vec::new();
+
+    for m in metrics {
+        if m.name.starts_with("grpc_") {
+            match m.kind {
+                metric::Kind::Counter => grpc_counters.push(m),
+                metric::Kind::Histogram => grpc_histograms.push(m),
+                _ => {}
+            }
+            continue;
+        }
+
+        match m.kind {
+            metric::Kind::Gauge => {
+                let cfg = format!(
+                    "{}\0{}",
+                    m.label_value("config").unwrap_or("global"),
+                    m.label_value("af").unwrap_or(""),
+                );
+                if !gauge_map.contains_key(&cfg) {
+                    gauge_keys.push(cfg.clone());
+                }
+                gauge_map.entry(cfg).or_default().push(m);
+            }
+            metric::Kind::Counter => {
+                let key = format!(
+                    "{}\0{}\0{}\0{}\0{}",
+                    m.label_value("config").unwrap_or(""),
+                    m.label_value("device").unwrap_or(""),
+                    m.label_value("pipeline").unwrap_or(""),
+                    m.label_value("function").unwrap_or(""),
+                    m.label_value("chain").unwrap_or(""),
+                );
+                if !counter_map.contains_key(&key) {
+                    counter_keys.push(key.clone());
+                }
+                counter_map.entry(key).or_default().push(m);
+            }
+            _ => {}
+        }
+    }
+
+    for key in &counter_keys {
+        let counters = &counter_map[key];
+        let parts: Vec<&str> = key.split('\0').collect();
+        let (config, device, pipeline, function, chain) = (parts[0], parts[1], parts[2], parts[3], parts[4]);
+        println!(
+            "FWSTATE COUNTERS  config={config} device={device} pipeline={pipeline} function={function} chain={chain}"
+        );
+        println!();
+
+        let mut pair_order: Vec<String> = Vec::new();
+        let mut pair_map: HashMap<String, CounterPair> = HashMap::new();
+
+        for m in counters {
+            let val = m.value.unwrap_or(0.0) as u64;
+            let stripped = m.name.strip_prefix("fwstate_").unwrap_or(&m.name);
+            if let Some(base) = stripped.strip_suffix("_packets") {
+                let pair = pair_map.entry(base.to_string()).or_insert_with(|| {
+                    pair_order.push(base.to_string());
+                    CounterPair {
+                        display: metric_display_name(base),
+                        packets: None,
+                        bytes: None,
+                    }
+                });
+                pair.packets = Some(val);
+            } else if let Some(base) = stripped.strip_suffix("_bytes") {
+                let pair = pair_map.entry(base.to_string()).or_insert_with(|| {
+                    pair_order.push(base.to_string());
+                    CounterPair {
+                        display: metric_display_name(base),
+                        packets: None,
+                        bytes: None,
+                    }
+                });
+                pair.bytes = Some(val);
+            } else {
+                // Counter without a _packets/_bytes suffix (e.g. insert
+                // counters that only track packets).
+                let pair = pair_map.entry(stripped.to_string()).or_insert_with(|| {
+                    pair_order.push(stripped.to_string());
+                    CounterPair {
+                        display: metric_display_name(stripped),
+                        packets: None,
+                        bytes: None,
+                    }
+                });
+                pair.packets = Some(val);
+            }
+        }
+
+        let rows: Vec<CounterRow> = pair_order
+            .iter()
+            .map(|base| {
+                let p = &pair_map[base];
+                CounterRow {
+                    counter: p.display.clone(),
+                    packets: p.packets.map(format_number).unwrap_or_else(|| "-".into()),
+                    bytes: p.bytes.map(format_number).unwrap_or_else(|| "-".into()),
+                }
+            })
+            .collect();
+        print_table_from_entries(rows);
+        println!();
+    }
+
+    for cfg in &gauge_keys {
+        let gauges = &gauge_map[cfg];
+        let parts: Vec<&str> = cfg.split('\0').collect();
+        let (config, af) = (parts[0], parts[1]);
+        println!("FWSTATE MAP STATS  config={config} af={af}");
+        println!();
+        let rows: Vec<GaugeRow> = gauges
+            .iter()
+            .map(|m| GaugeRow {
+                metric: metric_display_name(&m.name),
+                value: format_gauge_value(&m.name, m.value.unwrap_or(0.0)),
+            })
+            .collect();
+        print_table_from_entries(rows);
+        println!();
+    }
+
+    if !grpc_counters.is_empty() {
+        let mut started: HashMap<String, u64> = HashMap::new();
+        let mut handled_keys: Vec<(String, String)> = Vec::new();
+        let mut handled: HashMap<(String, String), u64> = HashMap::new();
+
+        for m in &grpc_counters {
+            let method = m.label_value("grpc_method").unwrap_or("").to_string();
+            if m.name == "grpc_server_started_total" {
+                let count = m.value.unwrap_or(0.0) as u64;
+                *started.entry(method).or_default() += count;
+            } else if m.name == "grpc_server_handled_total" {
+                let code = m.label_value("grpc_code").unwrap_or("").to_string();
+                let key = (method, code);
+                if !handled.contains_key(&key) {
+                    handled_keys.push(key.clone());
+                }
+                *handled.entry(key).or_default() += m.value.unwrap_or(0.0) as u64;
+            }
+        }
+
+        if !handled_keys.is_empty() || !started.is_empty() {
+            println!();
+            println!("GRPC CALLS");
+            println!();
+        }
+
+        if !handled_keys.is_empty() {
+            let rows: Vec<GrpcCallRow> = handled_keys
+                .iter()
+                .map(|(method, code)| GrpcCallRow {
+                    method: method.clone(),
+                    code: code.clone(),
+                    handled: format_number(handled[&(method.clone(), code.clone())]),
+                })
+                .collect();
+            print_table_from_entries(rows);
+        }
+
+        if !started.is_empty() {
+            println!();
+            let mut started_methods: Vec<&String> = started.keys().collect();
+            started_methods.sort();
+            for method in started_methods {
+                println!("  started  {method}: {}", format_number(started[method]));
+            }
+        }
+    }
+
+    if !grpc_histograms.is_empty() {
+        println!();
+        println!("GRPC HANDLING LATENCIES");
+        println!();
+        let rows: Vec<GrpcLatRow> = grpc_histograms
+            .iter()
+            .map(|m| {
+                let method = m.label_value("grpc_method").unwrap_or("unknown").to_string();
+                match &m.histogram {
+                    Some(h) => GrpcLatRow {
+                        method,
+                        total: format_number(h.total_count),
+                        p50: metric::histogram_percentile(&h.buckets, h.total_count, 50.0),
+                        p95: metric::histogram_percentile(&h.buckets, h.total_count, 95.0),
+                        p99: metric::histogram_percentile(&h.buckets, h.total_count, 99.0),
+                    },
+                    None => GrpcLatRow {
+                        method,
+                        total: "-".into(),
+                        p50: "-".into(),
+                        p95: "-".into(),
+                        p99: "-".into(),
+                    },
+                }
+            })
+            .collect();
+        print_table_from_entries(rows);
+    }
+}
+
 async fn run(cmd: Cmd) -> Result<(), Error> {
     let mut service = FWStateService::new(&cmd.connection).await?;
     let format = cmd.format;
@@ -551,6 +914,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ModeCmd::Link(cmd) => service.link_fwstate(cmd).await,
         ModeCmd::Stats(cmd) => service.get_stats(cmd).await,
         ModeCmd::Entries(cmd) => service.list_entries(cmd, format).await,
+        ModeCmd::Metrics(cmd) => service.metrics(cmd).await,
     }
 }
 

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -4,10 +4,10 @@ use std::{collections::HashMap, time::UNIX_EPOCH};
 use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use commonpb::pb::IpAddress;
+use commonpb::pb::{GetMetricsRequest, IpAddress};
 use fwstatepb::{
-    DeleteConfigRequest, Direction, GetMetricsRequest, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest,
-    ListEntriesRequest, ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
+    DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
+    ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
     metrics_service_client::MetricsServiceClient,
 };
 use metric::Metric;

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -662,11 +662,11 @@ fn format_gauge_value(name: &str, value: f64) -> String {
         if value < 1024.0 {
             format!("{:.0} B", value)
         } else if value < 1024.0 * 1024.0 {
-            format!("{:.2} KB", value / 1024.0)
+            format!("{:.2} KiB", value / 1024.0)
         } else if value < 1024.0 * 1024.0 * 1024.0 {
-            format!("{:.2} MB", value / (1024.0 * 1024.0))
+            format!("{:.2} MiB", value / (1024.0 * 1024.0))
         } else {
-            format!("{:.2} GB", value / (1024.0 * 1024.0 * 1024.0))
+            format!("{:.2} GiB", value / (1024.0 * 1024.0 * 1024.0))
         }
     } else {
         format_number(value as u64)

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -601,6 +601,8 @@ struct CounterRow {
     packets: String,
     #[tabled(rename = "Bytes")]
     bytes: String,
+    #[tabled(rename = "Entries")]
+    entries: String,
 }
 
 #[derive(Tabled)]
@@ -693,6 +695,7 @@ fn print_metrics_table(metrics: &[Metric]) {
         display: String,
         packets: Option<u64>,
         bytes: Option<u64>,
+        entries: Option<u64>,
     }
 
     let mut counter_keys: Vec<String> = Vec::new();
@@ -764,6 +767,7 @@ fn print_metrics_table(metrics: &[Metric]) {
                         display: metric_display_name(base),
                         packets: None,
                         bytes: None,
+                        entries: None,
                     }
                 });
                 pair.packets = Some(val);
@@ -774,21 +778,34 @@ fn print_metrics_table(metrics: &[Metric]) {
                         display: metric_display_name(base),
                         packets: None,
                         bytes: None,
+                        entries: None,
                     }
                 });
                 pair.bytes = Some(val);
+            } else if let Some(base) = stripped.strip_suffix("_entries") {
+                // State-table entry counters (e.g. sync insert counters)
+                // count frames, not packets/bytes; render under Entries.
+                let pair = pair_map.entry(base.to_string()).or_insert_with(|| {
+                    pair_order.push(base.to_string());
+                    CounterPair {
+                        display: metric_display_name(base),
+                        packets: None,
+                        bytes: None,
+                        entries: None,
+                    }
+                });
+                pair.entries = Some(val);
             } else {
-                // Counter without a _packets/_bytes suffix (e.g. insert
-                // counters that only track packets).
                 let pair = pair_map.entry(stripped.to_string()).or_insert_with(|| {
                     pair_order.push(stripped.to_string());
                     CounterPair {
                         display: metric_display_name(stripped),
                         packets: None,
                         bytes: None,
+                        entries: None,
                     }
                 });
-                pair.packets = Some(val);
+                pair.entries = Some(val);
             }
         }
 
@@ -800,6 +817,7 @@ fn print_metrics_table(metrics: &[Metric]) {
                     counter: p.display.clone(),
                     packets: p.packets.map(format_number).unwrap_or_else(|| "-".into()),
                     bytes: p.bytes.map(format_number).unwrap_or_else(|| "-".into()),
+                    entries: p.entries.map(format_number).unwrap_or_else(|| "-".into()),
                 }
             })
             .collect();

--- a/modules/fwstate/cli/src/metric.rs
+++ b/modules/fwstate/cli/src/metric.rs
@@ -104,16 +104,60 @@ pub fn histogram_percentile(buckets: &[Bucket], total: u64, p: f64) -> String {
     }
     let target = ((total as f64 * p / 100.0).ceil() as u64).max(1);
     let mut cumulative: u64 = 0;
-    for b in buckets {
+    for (i, b) in buckets.iter().enumerate() {
         cumulative = cumulative.saturating_add(b.count);
         if cumulative >= target {
             return if b.upper_bound.is_infinite() {
-                let prev = buckets[buckets.len().saturating_sub(2)].upper_bound;
-                format!(">{:.3}s", prev)
+                // Report the last finite bound as the lower edge of the
+                // overflow bucket. When the +Inf bucket is the very first one
+                // there is no finite predecessor to reference.
+                match buckets[..i].iter().rev().find(|p| p.upper_bound.is_finite()) {
+                    Some(prev) => format!(">{:.3}s", prev.upper_bound),
+                    None => "+Inf".to_string(),
+                }
             } else {
                 format!("≤{:.3}s", b.upper_bound)
             };
         }
     }
     "-".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bucket(upper_bound: f64, count: u64) -> Bucket {
+        Bucket { upper_bound, count }
+    }
+
+    #[test]
+    fn percentile_empty_or_zero_total() {
+        assert_eq!(histogram_percentile(&[], 0, 50.0), "-");
+        assert_eq!(histogram_percentile(&[bucket(1.0, 0)], 0, 50.0), "-");
+    }
+
+    #[test]
+    fn percentile_finite_bucket() {
+        let buckets = [bucket(0.001, 5), bucket(0.01, 5), bucket(f64::INFINITY, 0)];
+        // total=10, p50 => target=5, cumulative reaches 5 in the first bucket.
+        assert_eq!(histogram_percentile(&buckets, 10, 50.0), "≤0.001s");
+        // p95 => target=ceil(9.5)=10, reached in the second bucket.
+        assert_eq!(histogram_percentile(&buckets, 10, 95.0), "≤0.010s");
+    }
+
+    #[test]
+    fn percentile_overflow_reports_last_finite_bound() {
+        let buckets = [bucket(0.001, 1), bucket(0.01, 1), bucket(f64::INFINITY, 8)];
+        // p99 => target=ceil(9.9)=10, only reached in the +Inf bucket.
+        assert_eq!(histogram_percentile(&buckets, 10, 99.0), ">0.010s");
+    }
+
+    #[test]
+    fn percentile_single_infinite_bucket() {
+        // A histogram with only the +Inf bucket has no finite predecessor;
+        // it must not panic and should fall back to "+Inf".
+        let buckets = [bucket(f64::INFINITY, 4)];
+        assert_eq!(histogram_percentile(&buckets, 4, 50.0), "+Inf");
+    }
 }

--- a/modules/fwstate/cli/src/metric.rs
+++ b/modules/fwstate/cli/src/metric.rs
@@ -1,0 +1,119 @@
+use commonpb::pb;
+use serde::Serialize;
+
+#[derive(Serialize, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum Kind {
+    Counter,
+    Gauge,
+    Histogram,
+    Unknown,
+}
+
+#[derive(Serialize)]
+pub struct Bucket {
+    pub upper_bound: f64,
+    pub count: u64,
+}
+
+#[derive(Serialize)]
+pub struct Histogram {
+    pub total_count: u64,
+    pub buckets: Vec<Bucket>,
+}
+
+#[derive(Serialize)]
+pub struct Label {
+    pub name: String,
+    pub value: String,
+}
+
+#[derive(Serialize)]
+pub struct Metric {
+    pub name: String,
+    pub labels: Vec<Label>,
+    pub kind: Kind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub histogram: Option<Histogram>,
+}
+
+impl Metric {
+    pub fn from_proto(m: pb::Metric) -> Self {
+        use pb::metric::Value;
+
+        let labels = m
+            .labels
+            .into_iter()
+            .map(|l| Label { name: l.name, value: l.value })
+            .collect();
+
+        match m.value {
+            Some(Value::Counter(c)) => Self {
+                name: m.name,
+                labels,
+                kind: Kind::Counter,
+                value: Some(c as f64),
+                histogram: None,
+            },
+            Some(Value::Gauge(g)) => Self {
+                name: m.name,
+                labels,
+                kind: Kind::Gauge,
+                value: Some(g),
+                histogram: None,
+            },
+            Some(Value::Histogram(h)) => Self {
+                name: m.name,
+                labels,
+                kind: Kind::Histogram,
+                value: None,
+                histogram: Some(Histogram {
+                    total_count: h.total_count,
+                    buckets: h
+                        .buckets
+                        .into_iter()
+                        .map(|b| Bucket {
+                            upper_bound: b.upper_bound,
+                            count: b.count,
+                        })
+                        .collect(),
+                }),
+            },
+            None => Self {
+                name: m.name,
+                labels,
+                kind: Kind::Unknown,
+                value: None,
+                histogram: None,
+            },
+        }
+    }
+
+    pub fn label_value(&self, key: &str) -> Option<&str> {
+        self.labels.iter().find(|l| l.name == key).map(|l| l.value.as_str())
+    }
+}
+
+/// Computes the p-th percentile bucket label for a histogram whose upper
+/// bounds are in seconds.
+pub fn histogram_percentile(buckets: &[Bucket], total: u64, p: f64) -> String {
+    if total == 0 || buckets.is_empty() {
+        return "-".to_string();
+    }
+    let target = ((total as f64 * p / 100.0).ceil() as u64).max(1);
+    let mut cumulative: u64 = 0;
+    for b in buckets {
+        cumulative = cumulative.saturating_add(b.count);
+        if cumulative >= target {
+            return if b.upper_bound.is_infinite() {
+                let prev = buckets[buckets.len().saturating_sub(2)].upper_bound;
+                format!(">{:.3}s", prev)
+            } else {
+                format!("≤{:.3}s", b.upper_bound)
+            };
+        }
+    }
+    "-".to_string()
+}

--- a/modules/fwstate/controlplane/ffi.go
+++ b/modules/fwstate/controlplane/ffi.go
@@ -13,6 +13,7 @@ type FwStateConfig struct {
 type CursorEntry = cfwstate.CursorEntry
 type OutdatedLayers = cfwstate.OutdatedLayers
 type mapsStats = cfwstate.MapsStats
+type mapStats = cfwstate.MapStats
 
 func NewFWStateModuleConfig(agent *ffi.Agent, name string) (*FwStateConfig, error) {
 	moduleCfg, err := cfwstate.NewModuleConfig(agent, name)

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -4,6 +4,7 @@ package modules.fwstate.controlplane.fwstatepb.v1;
 
 import "common/commonpb/v1/ipaddr.proto";
 import "common/commonpb/v1/macaddr.proto";
+import "common/commonpb/v1/metric.proto";
 
 option go_package = "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1;fwstatepb";
 
@@ -24,6 +25,16 @@ service FWStateService {
   // Bidirectional stream for listing map entries.
   rpc ListEntries(stream ListEntriesRequest) returns (stream ListEntriesResponse);
 }
+
+// MetricsService exposes FWState module metrics.
+service MetricsService {
+  // GetMetrics returns a snapshot of FWState module metrics.
+  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+}
+
+message GetMetricsRequest {}
+
+message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }
 
 message UpdateConfigRequest {
   string name = 1;

--- a/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
+++ b/modules/fwstate/controlplane/fwstatepb/v1/fwstate.proto
@@ -29,12 +29,8 @@ service FWStateService {
 // MetricsService exposes FWState module metrics.
 service MetricsService {
   // GetMetrics returns a snapshot of FWState module metrics.
-  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+  rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
-
-message GetMetricsRequest {}
-
-message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }
 
 message UpdateConfigRequest {
   string name = 1;

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -162,10 +162,10 @@ func (m *FWStateService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 			}
 
 			switch counter.Name {
-			case "fwstate_sync_packets":
+			case "fwstate_sync":
 				result = append(result,
-					makeCounter("fwstate_sync_packets_packets", packets, baseLabels...),
-					makeCounter("fwstate_sync_packets_bytes", bytes, baseLabels...),
+					makeCounter("fwstate_sync_packets", packets, baseLabels...),
+					makeCounter("fwstate_sync_bytes", bytes, baseLabels...),
 				)
 			case "fwstate_passthrough":
 				result = append(result,

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -1,0 +1,246 @@
+package fwstate
+
+import (
+	"context"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+	fwstatepb "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
+)
+
+// metricsSource provides the module's collected metrics.
+type metricsSource interface {
+	Metrics() ([]*commonpb.Metric, error)
+}
+
+// MetricsService exposes FWState module metrics over its own gRPC service.
+type MetricsService struct {
+	fwstatepb.UnimplementedMetricsServiceServer
+
+	source metricsSource
+}
+
+// NewMetricsService creates a MetricsService backed by source.
+func NewMetricsService(source metricsSource) *MetricsService {
+	return &MetricsService{source: source}
+}
+
+// GetMetrics returns a snapshot of all FWState module metrics.
+func (m *MetricsService) GetMetrics(
+	ctx context.Context,
+	req *fwstatepb.GetMetricsRequest,
+) (*fwstatepb.GetMetricsResponse, error) {
+	all, err := m.source.Metrics()
+	if err != nil {
+		return nil, err
+	}
+
+	return &fwstatepb.GetMetricsResponse{Metrics: all}, nil
+}
+
+func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &commonpb.Metric_Gauge{Gauge: value},
+	}
+}
+
+func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &commonpb.Metric_Counter{Counter: value},
+	}
+}
+
+// Metrics returns all FWState module metrics: per-config map statistics
+// (gauge) and gRPC call metrics.
+//
+// Gauge metrics are emitted per address family (af=ipv4|ipv6) for every
+// loaded fwstate config.
+//
+// Labels:
+//   - config:        fwstate config name (all metrics)
+//   - af:            address family, "ipv4" or "ipv6" (map stats only)
+//   - grpc_type:     always "unary" (gRPC metrics)
+//   - grpc_service:  fully-qualified gRPC service name (gRPC metrics)
+//   - grpc_method:   RPC name (gRPC metrics)
+//   - grpc_code:     gRPC status code string (grpc_server_handled_total only)
+func (m *FWStateService) Metrics() ([]*commonpb.Metric, error) {
+	// Collect map-stat gauges and dataplane counters under a single m.mu lock
+	// so both halves observe the same set of configs. The lock is released
+	// before collecting gRPC metrics: m.metrics.Collect() invokes the retention
+	// callback, which takes m.mu itself.
+	m.mu.Lock()
+	metrics := m.collectMapStats()
+	dpMetrics, err := m.collectDataplaneMetrics()
+	m.mu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	metrics = append(metrics, dpMetrics...)
+	if m.metrics != nil {
+		metrics = append(metrics, m.metrics.Collect()...)
+	}
+	return metrics, nil
+}
+
+// collectMapStats emits gauge metrics derived from the per-config map
+// statistics (GetMapsStats) for both IPv4 and IPv6 address families.
+//
+// The caller must hold m.mu.
+func (m *FWStateService) collectMapStats() []*commonpb.Metric {
+	var result []*commonpb.Metric
+	for name, config := range m.configs {
+		mapsStats := config.GetMapsStats()
+
+		result = append(result, collectMapStatsForAF(name, "ipv4", mapsStats.IPv4)...)
+		result = append(result, collectMapStatsForAF(name, "ipv6", mapsStats.IPv6)...)
+	}
+
+	return result
+}
+
+// collectDataplaneMetrics emits per-config packet/byte counters read from the
+// dataplane counter storage via DPConfig.
+//
+// Counter metrics are omitted when all worker values are zero to reduce
+// output noise.
+//
+// The caller must hold m.mu.
+//
+// Labels:
+//   - config:   fwstate config name
+//   - device:   dataplane device name
+//   - pipeline: pipeline name
+//   - function: pipeline function name
+//   - chain:    pipeline chain name
+func (m *FWStateService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
+	dpConfig := m.agent.DPConfig()
+	if dpConfig == nil {
+		return []*commonpb.Metric{}, nil
+	}
+
+	positions := dpConfig.AllModulePositions("fwstate")
+
+	result := make([]*commonpb.Metric, 0)
+	for pos := range positions {
+		configName := pos.ModuleName
+
+		baseLabels := []*commonpb.Label{
+			{Name: "config", Value: configName},
+			{Name: "device", Value: pos.Device},
+			{Name: "pipeline", Value: pos.Pipeline},
+			{Name: "function", Value: pos.Function},
+			{Name: "chain", Value: pos.Chain},
+		}
+
+		counters := dpConfig.ModuleCounters(
+			pos.Device,
+			pos.Pipeline,
+			pos.Function,
+			pos.Chain,
+			"fwstate",
+			configName,
+			nil,
+		)
+
+		for _, counter := range counters {
+			var packets, bytes uint64
+			for _, workerVals := range counter.Values {
+				if len(workerVals) > 0 {
+					packets += workerVals[0]
+				}
+				if len(workerVals) > 1 {
+					bytes += workerVals[1]
+				}
+			}
+
+			if packets == 0 && bytes == 0 {
+				continue
+			}
+
+			switch counter.Name {
+			case "fwstate_sync_packets":
+				result = append(result,
+					makeCounter("fwstate_sync_packets_packets", packets, baseLabels...),
+					makeCounter("fwstate_sync_packets_bytes", bytes, baseLabels...),
+				)
+			case "fwstate_passthrough":
+				result = append(result,
+					makeCounter("fwstate_passthrough_packets", packets, baseLabels...),
+					makeCounter("fwstate_passthrough_bytes", bytes, baseLabels...),
+				)
+			case "fwstate_sync_v4_inserted":
+				result = append(result,
+					makeCounter("fwstate_sync_v4_inserted_packets", packets, baseLabels...),
+				)
+			case "fwstate_sync_v6_inserted":
+				result = append(result,
+					makeCounter("fwstate_sync_v6_inserted_packets", packets, baseLabels...),
+				)
+			case "fwstate_sync_v4_insert_failed":
+				result = append(result,
+					makeCounter("fwstate_sync_v4_insert_failed_packets", packets, baseLabels...),
+				)
+			case "fwstate_sync_v6_insert_failed":
+				result = append(result,
+					makeCounter("fwstate_sync_v6_insert_failed_packets", packets, baseLabels...),
+				)
+			case "fwstate_external_dropped":
+				result = append(result,
+					makeCounter("fwstate_external_dropped_packets", packets, baseLabels...),
+					makeCounter("fwstate_external_dropped_bytes", bytes, baseLabels...),
+				)
+			case "fwstate_internal_forwarded":
+				result = append(result,
+					makeCounter("fwstate_internal_forwarded_packets", packets, baseLabels...),
+					makeCounter("fwstate_internal_forwarded_bytes", bytes, baseLabels...),
+				)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// collectMapStatsForAF builds the gauge metric set for a single address
+// family of a single fwstate config.
+func collectMapStatsForAF(configName, af string, stats mapStats) []*commonpb.Metric {
+	labels := []*commonpb.Label{
+		{Name: "config", Value: configName},
+		{Name: "af", Value: af},
+	}
+
+	return []*commonpb.Metric{
+		makeGauge("fwstate_index_size", float64(stats.IndexSize), labels...),
+		makeGauge("fwstate_extra_bucket_count", float64(stats.ExtraBucketCount), labels...),
+		makeGauge("fwstate_max_chain_length", float64(stats.MaxChainLength), labels...),
+		makeGauge("fwstate_layer_count", float64(stats.LayerCount), labels...),
+		makeGauge("fwstate_total_elements", float64(stats.TotalElements), labels...),
+		makeGauge("fwstate_max_deadline_ns", float64(stats.MaxDeadline), labels...),
+		makeGauge("fwstate_memory_bytes", float64(stats.MemoryUsed), labels...),
+	}
+}
+
+// retention snapshots the live fwstate config names and returns a predicate
+// that keeps series whose "config" label is still live (or absent).
+func (m *FWStateService) retention() func(metrics.MetricID) bool {
+	m.mu.Lock()
+	configNames := make(map[string]struct{}, len(m.configs))
+	for name := range m.configs {
+		configNames[name] = struct{}{}
+	}
+	m.mu.Unlock()
+
+	return func(id metrics.MetricID) bool {
+		config := id.Labels["config"]
+		if config == "" {
+			return true
+		}
+
+		_, ok := configNames[config]
+		return ok
+	}
+}

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -172,21 +172,26 @@ func (m *FWStateService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 					makeCounter("fwstate_passthrough_packets", packets, baseLabels...),
 					makeCounter("fwstate_passthrough_bytes", bytes, baseLabels...),
 				)
+			// The *_inserted / *_insert_failed counters track state-table
+			// entries (sync frames), not packets: a single sync packet
+			// carries multiple frames and each frame bumps the counter once.
+			// Export them with an _entries suffix so they are not rendered
+			// under a packet/byte column.
 			case "fwstate_sync_v4_inserted":
 				result = append(result,
-					makeCounter("fwstate_sync_v4_inserted_packets", packets, baseLabels...),
+					makeCounter("fwstate_sync_v4_inserted_entries", packets, baseLabels...),
 				)
 			case "fwstate_sync_v6_inserted":
 				result = append(result,
-					makeCounter("fwstate_sync_v6_inserted_packets", packets, baseLabels...),
+					makeCounter("fwstate_sync_v6_inserted_entries", packets, baseLabels...),
 				)
 			case "fwstate_sync_v4_insert_failed":
 				result = append(result,
-					makeCounter("fwstate_sync_v4_insert_failed_packets", packets, baseLabels...),
+					makeCounter("fwstate_sync_v4_insert_failed_entries", packets, baseLabels...),
 				)
 			case "fwstate_sync_v6_insert_failed":
 				result = append(result,
-					makeCounter("fwstate_sync_v6_insert_failed_packets", packets, baseLabels...),
+					makeCounter("fwstate_sync_v6_insert_failed_entries", packets, baseLabels...),
 				)
 			case "fwstate_external_dropped":
 				result = append(result,

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -157,11 +157,15 @@ func (m *FWStateService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 // emitCounterMetrics converts a single dataplane counter into metric series.
 //
 // The dataplane registers a set of well-known fwstate counters (see
-// fwstate_module_config_new) plus the generic per-module rx/tx/rx_bytes/tx_bytes
-// counters registered by cp_module_init. Each known counter is exported under
-// a dedicated metric name with the correct semantic suffix (_packets, _bytes or
-// _entries). Any other counter (one added in the future) is exported through a
-// generic pair labelled with the counter name so it is never silently dropped.
+// fwstate_module_config_new) plus the generic per-module counters registered
+// by cp_module_init: rx, tx, drop, pending_input, pending_output (each a
+// size-2 [packets, bytes] vector) and hist_0..hist_5 (latency histograms, see
+// skipHistCounters). Each known counter is exported under a dedicated metric
+// name with the correct semantic suffix (_packets, _bytes or _entries). The
+// histogram counters are skipped entirely (proper histogram export is a
+// separate task). Any other counter (one added in the future) is exported
+// through a generic pair labelled with the counter name so it is never
+// silently dropped.
 //
 // Counter series are omitted when all worker values are zero to reduce output
 // noise.
@@ -223,25 +227,39 @@ func emitCounterMetrics(counter ffi.CounterInfo, baseLabels []*commonpb.Label) [
 			makeCounter("fwstate_internal_forwarded_bytes", bytes, baseLabels...),
 		}
 	// Generic per-module counters registered by cp_module_init for every
-	// module. They are single-valued: rx/tx hold packet counts, rx_bytes/
-	// tx_bytes hold byte counts. Export each under its own metric name so the
-	// value is not mislabelled as packets.
+	// module.
 	case "rx":
 		return []*commonpb.Metric{
 			makeCounter("fwstate_rx_packets", packets, baseLabels...),
+			makeCounter("fwstate_rx_bytes", bytes, baseLabels...),
 		}
 	case "tx":
 		return []*commonpb.Metric{
 			makeCounter("fwstate_tx_packets", packets, baseLabels...),
+			makeCounter("fwstate_tx_bytes", bytes, baseLabels...),
 		}
-	case "rx_bytes":
+	// drop counts packets the module dropped itself. For fwstate this is
+	// meaningful: external sync packets are dropped when they cannot be
+	// inserted, so it deserves a dedicated pair like the others rather than
+	// falling through to the generic arm.
+	case "drop":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_rx_bytes", packets, baseLabels...),
+			makeCounter("fwstate_drop_packets", packets, baseLabels...),
+			makeCounter("fwstate_drop_bytes", bytes, baseLabels...),
 		}
-	case "tx_bytes":
+	case "pending_input":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_tx_bytes", packets, baseLabels...),
+			makeCounter("fwstate_pending_input_packets", packets, baseLabels...),
+			makeCounter("fwstate_pending_input_bytes", bytes, baseLabels...),
 		}
+	case "pending_output":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_pending_output_packets", packets, baseLabels...),
+			makeCounter("fwstate_pending_output_bytes", bytes, baseLabels...),
+		}
+	case "hist_0", "hist_1", "hist_2", "hist_3", "hist_4", "hist_5":
+		// TODO: handle
+		return nil
 	default:
 		// Any counter not listed above (e.g. one added in the future) is
 		// exported through a generic pair labelled with the counter name so it

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -2,6 +2,7 @@ package fwstate
 
 import (
 	"context"
+	"time"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
@@ -87,12 +88,14 @@ func (m *FWStateService) collectMapStats() []*commonpb.Metric {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	now := time.Now()
+
 	var result []*commonpb.Metric
 	for name, config := range m.configs {
 		mapsStats := config.GetMapsStats()
 
-		result = append(result, collectMapStatsForAF(name, "ipv4", mapsStats.IPv4)...)
-		result = append(result, collectMapStatsForAF(name, "ipv6", mapsStats.IPv6)...)
+		result = append(result, collectMapStatsForAF(name, "ipv4", now, mapsStats.IPv4)...)
+		result = append(result, collectMapStatsForAF(name, "ipv6", now, mapsStats.IPv6)...)
 	}
 
 	return result
@@ -204,12 +207,20 @@ func (m *FWStateService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 	return result, nil
 }
 
-// collectMapStatsForAF builds the gauge metric set for a single address
-// family of a single fwstate config.
-func collectMapStatsForAF(configName, af string, stats mapStats) []*commonpb.Metric {
+// collectMapStatsForAF builds the gauge metric set for a single address family
+// of a single fwstate config.
+func collectMapStatsForAF(configName, af string, now time.Time, stats mapStats) []*commonpb.Metric {
 	labels := []*commonpb.Label{
 		{Name: "config", Value: configName},
 		{Name: "af", Value: af},
+	}
+
+	// MaxDeadline is an absolute timestamp on the dataplane's monotonic clock.
+	// Export the remaining time-to-live (clamped at zero once the deadline has
+	// passed).
+	deadlineTTL := uint64(0)
+	if nowNS := uint64(now.UnixNano()); stats.MaxDeadline > nowNS {
+		deadlineTTL = stats.MaxDeadline - nowNS
 	}
 
 	return []*commonpb.Metric{
@@ -218,7 +229,7 @@ func collectMapStatsForAF(configName, af string, stats mapStats) []*commonpb.Met
 		makeGauge("fwstate_max_chain_length", float64(stats.MaxChainLength), labels...),
 		makeGauge("fwstate_layer_count", float64(stats.LayerCount), labels...),
 		makeGauge("fwstate_total_elements", float64(stats.TotalElements), labels...),
-		makeGauge("fwstate_max_deadline_ns", float64(stats.MaxDeadline), labels...),
+		makeGauge("fwstate_max_deadline_ns", float64(deadlineTTL), labels...),
 		makeGauge("fwstate_memory_bytes", float64(stats.MemoryUsed), labels...),
 	}
 }

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -68,29 +68,25 @@ func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb
 //   - grpc_method:   RPC name (gRPC metrics)
 //   - grpc_code:     gRPC status code string (grpc_server_handled_total only)
 func (m *FWStateService) Metrics() ([]*commonpb.Metric, error) {
-	// Collect map-stat gauges and dataplane counters under a single m.mu lock
-	// so both halves observe the same set of configs. The lock is released
-	// before collecting gRPC metrics: m.metrics.Collect() invokes the retention
-	// callback, which takes m.mu itself.
-	m.mu.Lock()
-	metrics := m.collectMapStats()
+	result := m.collectMapStats()
+
 	dpMetrics, err := m.collectDataplaneMetrics()
-	m.mu.Unlock()
 	if err != nil {
 		return nil, err
 	}
-	metrics = append(metrics, dpMetrics...)
+	result = append(result, dpMetrics...)
 	if m.metrics != nil {
-		metrics = append(metrics, m.metrics.Collect()...)
+		result = append(result, m.metrics.Collect()...)
 	}
-	return metrics, nil
+	return result, nil
 }
 
 // collectMapStats emits gauge metrics derived from the per-config map
 // statistics (GetMapsStats) for both IPv4 and IPv6 address families.
-//
-// The caller must hold m.mu.
 func (m *FWStateService) collectMapStats() []*commonpb.Metric {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	var result []*commonpb.Metric
 	for name, config := range m.configs {
 		mapsStats := config.GetMapsStats()
@@ -107,8 +103,6 @@ func (m *FWStateService) collectMapStats() []*commonpb.Metric {
 //
 // Counter metrics are omitted when all worker values are zero to reduce
 // output noise.
-//
-// The caller must hold m.mu.
 //
 // Labels:
 //   - config:   fwstate config name

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -28,14 +28,14 @@ func NewMetricsService(source metricsSource) *MetricsService {
 // GetMetrics returns a snapshot of all FWState module metrics.
 func (m *MetricsService) GetMetrics(
 	ctx context.Context,
-	req *fwstatepb.GetMetricsRequest,
-) (*fwstatepb.GetMetricsResponse, error) {
+	req *commonpb.GetMetricsRequest,
+) (*commonpb.GetMetricsResponse, error) {
 	all, err := m.source.Metrics()
 	if err != nil {
 		return nil, err
 	}
 
-	return &fwstatepb.GetMetricsResponse{Metrics: all}, nil
+	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
 func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -6,6 +6,7 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	fwstatepb "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
 )
 
@@ -113,6 +114,8 @@ func (m *FWStateService) collectMapStats() []*commonpb.Metric {
 //   - pipeline: pipeline name
 //   - function: pipeline function name
 //   - chain:    pipeline chain name
+//   - counter:  dataplane counter name (fwstate_counter_packets /
+//     fwstate_counter_bytes only)
 func (m *FWStateService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 	dpConfig := m.agent.DPConfig()
 	if dpConfig == nil {
@@ -144,67 +147,114 @@ func (m *FWStateService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 		)
 
 		for _, counter := range counters {
-			var packets, bytes uint64
-			for _, workerVals := range counter.Values {
-				if len(workerVals) > 0 {
-					packets += workerVals[0]
-				}
-				if len(workerVals) > 1 {
-					bytes += workerVals[1]
-				}
-			}
-
-			if packets == 0 && bytes == 0 {
-				continue
-			}
-
-			switch counter.Name {
-			case "fwstate_sync":
-				result = append(result,
-					makeCounter("fwstate_sync_packets", packets, baseLabels...),
-					makeCounter("fwstate_sync_bytes", bytes, baseLabels...),
-				)
-			case "fwstate_passthrough":
-				result = append(result,
-					makeCounter("fwstate_passthrough_packets", packets, baseLabels...),
-					makeCounter("fwstate_passthrough_bytes", bytes, baseLabels...),
-				)
-			// The *_inserted / *_insert_failed counters track state-table
-			// entries (sync frames), not packets: a single sync packet
-			// carries multiple frames and each frame bumps the counter once.
-			// Export them with an _entries suffix so they are not rendered
-			// under a packet/byte column.
-			case "fwstate_sync_v4_inserted":
-				result = append(result,
-					makeCounter("fwstate_sync_v4_inserted_entries", packets, baseLabels...),
-				)
-			case "fwstate_sync_v6_inserted":
-				result = append(result,
-					makeCounter("fwstate_sync_v6_inserted_entries", packets, baseLabels...),
-				)
-			case "fwstate_sync_v4_insert_failed":
-				result = append(result,
-					makeCounter("fwstate_sync_v4_insert_failed_entries", packets, baseLabels...),
-				)
-			case "fwstate_sync_v6_insert_failed":
-				result = append(result,
-					makeCounter("fwstate_sync_v6_insert_failed_entries", packets, baseLabels...),
-				)
-			case "fwstate_external_dropped":
-				result = append(result,
-					makeCounter("fwstate_external_dropped_packets", packets, baseLabels...),
-					makeCounter("fwstate_external_dropped_bytes", bytes, baseLabels...),
-				)
-			case "fwstate_internal_forwarded":
-				result = append(result,
-					makeCounter("fwstate_internal_forwarded_packets", packets, baseLabels...),
-					makeCounter("fwstate_internal_forwarded_bytes", bytes, baseLabels...),
-				)
-			}
+			result = append(result, emitCounterMetrics(counter, baseLabels)...)
 		}
 	}
 
 	return result, nil
+}
+
+// emitCounterMetrics converts a single dataplane counter into metric series.
+//
+// The dataplane registers a set of well-known fwstate counters (see
+// fwstate_module_config_new) plus the generic per-module rx/tx/rx_bytes/tx_bytes
+// counters registered by cp_module_init. Each known counter is exported under
+// a dedicated metric name with the correct semantic suffix (_packets, _bytes or
+// _entries). Any other counter (one added in the future) is exported through a
+// generic pair labelled with the counter name so it is never silently dropped.
+//
+// Counter series are omitted when all worker values are zero to reduce output
+// noise.
+func emitCounterMetrics(counter ffi.CounterInfo, baseLabels []*commonpb.Label) []*commonpb.Metric {
+	var packets, bytes uint64
+	for _, workerVals := range counter.Values {
+		if len(workerVals) > 0 {
+			packets += workerVals[0]
+		}
+		if len(workerVals) > 1 {
+			bytes += workerVals[1]
+		}
+	}
+
+	if packets == 0 && bytes == 0 {
+		return nil
+	}
+
+	switch counter.Name {
+	case "fwstate_sync":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_sync_packets", packets, baseLabels...),
+			makeCounter("fwstate_sync_bytes", bytes, baseLabels...),
+		}
+	case "fwstate_passthrough":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_passthrough_packets", packets, baseLabels...),
+			makeCounter("fwstate_passthrough_bytes", bytes, baseLabels...),
+		}
+	// The *_inserted / *_insert_failed counters track state-table
+	// entries (sync frames), not packets: a single sync packet
+	// carries multiple frames and each frame bumps the counter once.
+	// Export them with an _entries suffix so they are not rendered
+	// under a packet/byte column.
+	case "fwstate_sync_v4_inserted":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_sync_v4_inserted_entries", packets, baseLabels...),
+		}
+	case "fwstate_sync_v6_inserted":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_sync_v6_inserted_entries", packets, baseLabels...),
+		}
+	case "fwstate_sync_v4_insert_failed":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_sync_v4_insert_failed_entries", packets, baseLabels...),
+		}
+	case "fwstate_sync_v6_insert_failed":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_sync_v6_insert_failed_entries", packets, baseLabels...),
+		}
+	case "fwstate_external_dropped":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_external_dropped_packets", packets, baseLabels...),
+			makeCounter("fwstate_external_dropped_bytes", bytes, baseLabels...),
+		}
+	case "fwstate_internal_forwarded":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_internal_forwarded_packets", packets, baseLabels...),
+			makeCounter("fwstate_internal_forwarded_bytes", bytes, baseLabels...),
+		}
+	// Generic per-module counters registered by cp_module_init for every
+	// module. They are single-valued: rx/tx hold packet counts, rx_bytes/
+	// tx_bytes hold byte counts. Export each under its own metric name so the
+	// value is not mislabelled as packets.
+	case "rx":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_rx_packets", packets, baseLabels...),
+		}
+	case "tx":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_tx_packets", packets, baseLabels...),
+		}
+	case "rx_bytes":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_rx_bytes", packets, baseLabels...),
+		}
+	case "tx_bytes":
+		return []*commonpb.Metric{
+			makeCounter("fwstate_tx_bytes", packets, baseLabels...),
+		}
+	default:
+		// Any counter not listed above (e.g. one added in the future) is
+		// exported through a generic pair labelled with the counter name so it
+		// is never silently dropped.
+		counterLabels := append(
+			baseLabels,
+			&commonpb.Label{Name: "counter", Value: counter.Name},
+		)
+		return []*commonpb.Metric{
+			makeCounter("fwstate_counter_packets", packets, counterLabels...),
+			makeCounter("fwstate_counter_bytes", bytes, counterLabels...),
+		}
+	}
 }
 
 // collectMapStatsForAF builds the gauge metric set for a single address family

--- a/modules/fwstate/controlplane/metrics_test.go
+++ b/modules/fwstate/controlplane/metrics_test.go
@@ -138,39 +138,73 @@ func TestEmitCounterMetricsKnownCounters(t *testing.T) {
 }
 
 // TestEmitCounterMetricsGenericModuleCounters checks that the generic
-// per-module rx/tx/rx_bytes/tx_bytes counters registered by cp_module_init are
-// exported under their own dedicated metric names (so a byte counter is not
-// mislabelled as packets) and without a "counter" label.
+// per-module counters registered by cp_module_init (rx, tx, drop,
+// pending_input, pending_output) are exported under their own dedicated metric
+// names as [packets, bytes] pairs and without a "counter" label.
 func TestEmitCounterMetricsGenericModuleCounters(t *testing.T) {
 	cases := []struct {
 		name        string
 		counterName string
-		value       uint64
-		wantName    string
+		packets     uint64
+		bytes       uint64
+		wantNames   []string
 	}{
-		{name: "rx", counterName: "rx", value: 11, wantName: "fwstate_rx_packets"},
-		{name: "tx", counterName: "tx", value: 22, wantName: "fwstate_tx_packets"},
-		{name: "rx_bytes", counterName: "rx_bytes", value: 1100, wantName: "fwstate_rx_bytes"},
-		{name: "tx_bytes", counterName: "tx_bytes", value: 2200, wantName: "fwstate_tx_bytes"},
+		{
+			name:        "rx",
+			counterName: "rx",
+			packets:     11,
+			bytes:       1100,
+			wantNames:   []string{"fwstate_rx_packets", "fwstate_rx_bytes"},
+		},
+		{
+			name:        "tx",
+			counterName: "tx",
+			packets:     22,
+			bytes:       2200,
+			wantNames:   []string{"fwstate_tx_packets", "fwstate_tx_bytes"},
+		},
+		{
+			name:        "drop",
+			counterName: "drop",
+			packets:     4,
+			bytes:       400,
+			wantNames:   []string{"fwstate_drop_packets", "fwstate_drop_bytes"},
+		},
+		{
+			name:        "pending_input",
+			counterName: "pending_input",
+			packets:     5,
+			bytes:       500,
+			wantNames:   []string{"fwstate_pending_input_packets", "fwstate_pending_input_bytes"},
+		},
+		{
+			name:        "pending_output",
+			counterName: "pending_output",
+			packets:     6,
+			bytes:       600,
+			wantNames:   []string{"fwstate_pending_output_packets", "fwstate_pending_output_bytes"},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			counter := ffi.CounterInfo{
 				Name:   tc.counterName,
-				Values: [][]uint64{{tc.value}},
+				Values: [][]uint64{{tc.packets, tc.bytes}},
 			}
 
 			metrics := emitCounterMetrics(counter, baseLabels())
-			require.Len(t, metrics, 1)
+			require.Len(t, metrics, len(tc.wantNames))
 
-			m := findMetric(t, metrics, tc.wantName)
-			require.Equal(t, tc.value, counterValue(t, m))
-			// Dedicated counters must not carry the generic "counter" label.
-			require.Equal(t, "", labelValue(m, "counter"))
-			// Base labels must be preserved.
-			require.Equal(t, "cfg", labelValue(m, "config"))
-			require.Equal(t, "dev0", labelValue(m, "device"))
+			for _, wantName := range tc.wantNames {
+				m := findMetric(t, metrics, wantName)
+				require.NotNil(t, m, "expected metric %q", wantName)
+				// Dedicated counters must not carry the generic "counter" label.
+				require.Equal(t, "", labelValue(m, "counter"))
+				// Base labels must be preserved.
+				require.Equal(t, "cfg", labelValue(m, "config"))
+				require.Equal(t, "dev0", labelValue(m, "device"))
+			}
 		})
 	}
 }
@@ -223,7 +257,8 @@ func TestEmitCounterMetricsZeroSuppression(t *testing.T) {
 	cases := []string{
 		"fwstate_sync",
 		"rx",
-		"rx_bytes",
+		"drop",
+		"pending_input",
 		"fwstate_some_future",
 	}
 

--- a/modules/fwstate/controlplane/metrics_test.go
+++ b/modules/fwstate/controlplane/metrics_test.go
@@ -1,0 +1,256 @@
+package fwstate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+// baseLabels is the shared label set used by collectDataplaneMetrics for every
+// fwstate counter.
+func baseLabels() []*commonpb.Label {
+	return []*commonpb.Label{
+		{Name: "config", Value: "cfg"},
+		{Name: "device", Value: "dev0"},
+		{Name: "pipeline", Value: "pl"},
+		{Name: "function", Value: "fn"},
+		{Name: "chain", Value: "ch"},
+	}
+}
+
+// findMetric returns the first metric with the given name, or nil.
+func findMetric(t *testing.T, metrics []*commonpb.Metric, name string) *commonpb.Metric {
+	t.Helper()
+	for _, m := range metrics {
+		if m.Name == name {
+			return m
+		}
+	}
+	return nil
+}
+
+// labelValue returns the value of the named label, or "" if absent.
+func labelValue(m *commonpb.Metric, name string) string {
+	for _, l := range m.Labels {
+		if l.Name == name {
+			return l.Value
+		}
+	}
+	return ""
+}
+
+// counterValue returns the counter payload of m, failing the test if m is not a
+// counter metric.
+func counterValue(t *testing.T, m *commonpb.Metric) uint64 {
+	t.Helper()
+	require.NotNil(t, m, "metric not found")
+	c, ok := m.Value.(*commonpb.Metric_Counter)
+	require.True(t, ok, "metric %q is not a counter", m.Name)
+	return c.Counter
+}
+
+// TestEmitCounterMetricsKnownCounters checks that the well-known fwstate
+// counters are exported under their dedicated metric names with the base label
+// set and without a "counter" label.
+func TestEmitCounterMetricsKnownCounters(t *testing.T) {
+	cases := []struct {
+		name        string
+		counterName string
+		packets     uint64
+		bytes       uint64
+		wantNames   []string
+	}{
+		{
+			name:        "fwstate_sync two-dimensional",
+			counterName: "fwstate_sync",
+			packets:     10,
+			bytes:       1000,
+			wantNames:   []string{"fwstate_sync_packets", "fwstate_sync_bytes"},
+		},
+		{
+			name:        "fwstate_passthrough two-dimensional",
+			counterName: "fwstate_passthrough",
+			packets:     5,
+			bytes:       500,
+			wantNames:   []string{"fwstate_passthrough_packets", "fwstate_passthrough_bytes"},
+		},
+		{
+			name:        "fwstate_external_dropped two-dimensional",
+			counterName: "fwstate_external_dropped",
+			packets:     3,
+			bytes:       300,
+			wantNames:   []string{"fwstate_external_dropped_packets", "fwstate_external_dropped_bytes"},
+		},
+		{
+			name:        "fwstate_internal_forwarded two-dimensional",
+			counterName: "fwstate_internal_forwarded",
+			packets:     7,
+			bytes:       700,
+			wantNames:   []string{"fwstate_internal_forwarded_packets", "fwstate_internal_forwarded_bytes"},
+		},
+		{
+			name:        "fwstate_sync_v4_inserted one-dimensional entries",
+			counterName: "fwstate_sync_v4_inserted",
+			packets:     42,
+			wantNames:   []string{"fwstate_sync_v4_inserted_entries"},
+		},
+		{
+			name:        "fwstate_sync_v6_inserted one-dimensional entries",
+			counterName: "fwstate_sync_v6_inserted",
+			packets:     43,
+			wantNames:   []string{"fwstate_sync_v6_inserted_entries"},
+		},
+		{
+			name:        "fwstate_sync_v4_insert_failed one-dimensional entries",
+			counterName: "fwstate_sync_v4_insert_failed",
+			packets:     1,
+			wantNames:   []string{"fwstate_sync_v4_insert_failed_entries"},
+		},
+		{
+			name:        "fwstate_sync_v6_insert_failed one-dimensional entries",
+			counterName: "fwstate_sync_v6_insert_failed",
+			packets:     2,
+			wantNames:   []string{"fwstate_sync_v6_insert_failed_entries"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			counter := ffi.CounterInfo{
+				Name:   tc.counterName,
+				Values: [][]uint64{{tc.packets, tc.bytes}},
+			}
+
+			metrics := emitCounterMetrics(counter, baseLabels())
+			require.Len(t, metrics, len(tc.wantNames))
+
+			for _, wantName := range tc.wantNames {
+				m := findMetric(t, metrics, wantName)
+				require.NotNil(t, m, "expected metric %q", wantName)
+				// Known counters must not carry the generic "counter" label.
+				require.Equal(t, "", labelValue(m, "counter"))
+			}
+		})
+	}
+}
+
+// TestEmitCounterMetricsGenericModuleCounters checks that the generic
+// per-module rx/tx/rx_bytes/tx_bytes counters registered by cp_module_init are
+// exported under their own dedicated metric names (so a byte counter is not
+// mislabelled as packets) and without a "counter" label.
+func TestEmitCounterMetricsGenericModuleCounters(t *testing.T) {
+	cases := []struct {
+		name        string
+		counterName string
+		value       uint64
+		wantName    string
+	}{
+		{name: "rx", counterName: "rx", value: 11, wantName: "fwstate_rx_packets"},
+		{name: "tx", counterName: "tx", value: 22, wantName: "fwstate_tx_packets"},
+		{name: "rx_bytes", counterName: "rx_bytes", value: 1100, wantName: "fwstate_rx_bytes"},
+		{name: "tx_bytes", counterName: "tx_bytes", value: 2200, wantName: "fwstate_tx_bytes"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			counter := ffi.CounterInfo{
+				Name:   tc.counterName,
+				Values: [][]uint64{{tc.value}},
+			}
+
+			metrics := emitCounterMetrics(counter, baseLabels())
+			require.Len(t, metrics, 1)
+
+			m := findMetric(t, metrics, tc.wantName)
+			require.Equal(t, tc.value, counterValue(t, m))
+			// Dedicated counters must not carry the generic "counter" label.
+			require.Equal(t, "", labelValue(m, "counter"))
+			// Base labels must be preserved.
+			require.Equal(t, "cfg", labelValue(m, "config"))
+			require.Equal(t, "dev0", labelValue(m, "device"))
+		})
+	}
+}
+
+// TestEmitCounterMetricsGenericCounters checks that counters not in the
+// well-known set are exported through the generic pair labelled with the
+// counter name instead of being silently dropped.
+func TestEmitCounterMetricsGenericCounters(t *testing.T) {
+	cases := []struct {
+		name        string
+		counterName string
+		packets     uint64
+		bytes       uint64
+	}{
+		{name: "future_counter", counterName: "fwstate_some_future", packets: 9, bytes: 90},
+		{name: "unknown", counterName: "something_unexpected", packets: 3, bytes: 30},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			counter := ffi.CounterInfo{
+				Name:   tc.counterName,
+				Values: [][]uint64{{tc.packets, tc.bytes}},
+			}
+
+			metrics := emitCounterMetrics(counter, baseLabels())
+			require.Len(t, metrics, 2)
+
+			pkts := findMetric(t, metrics, "fwstate_counter_packets")
+			byts := findMetric(t, metrics, "fwstate_counter_bytes")
+
+			require.Equal(t, tc.packets, counterValue(t, pkts))
+			require.Equal(t, tc.bytes, counterValue(t, byts))
+
+			// The generic pair must carry the original counter name as a
+			// "counter" label so the series can be distinguished.
+			require.Equal(t, tc.counterName, labelValue(pkts, "counter"))
+			require.Equal(t, tc.counterName, labelValue(byts, "counter"))
+
+			// Base labels must be preserved.
+			require.Equal(t, "cfg", labelValue(pkts, "config"))
+			require.Equal(t, "dev0", labelValue(pkts, "device"))
+		})
+	}
+}
+
+// TestEmitCounterMetricsZeroSuppression checks that a counter whose worker
+// values are all zero is omitted entirely (no series emitted).
+func TestEmitCounterMetricsZeroSuppression(t *testing.T) {
+	cases := []string{
+		"fwstate_sync",
+		"rx",
+		"rx_bytes",
+		"fwstate_some_future",
+	}
+
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			counter := ffi.CounterInfo{
+				Name:   name,
+				Values: [][]uint64{{0, 0}, {0, 0}},
+			}
+			require.Empty(t, emitCounterMetrics(counter, baseLabels()))
+		})
+	}
+}
+
+// TestEmitCounterMetricsAggregatesWorkers checks that values from multiple
+// workers are summed before being exported.
+func TestEmitCounterMetricsAggregatesWorkers(t *testing.T) {
+	counter := ffi.CounterInfo{
+		Name: "fwstate_sync",
+		Values: [][]uint64{
+			{10, 100},
+			{5, 50},
+			{0, 0},
+		},
+	}
+
+	metrics := emitCounterMetrics(counter, baseLabels())
+	require.Equal(t, uint64(15), counterValue(t, findMetric(t, metrics, "fwstate_sync_packets")))
+	require.Equal(t, uint64(150), counterValue(t, findMetric(t, metrics, "fwstate_sync_bytes")))
+}

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -74,6 +74,17 @@ const (
 	maxSyncPort uint32 = 65535
 )
 
+// FWStateServiceName and MetricsServiceName are the fully-qualified gRPC
+// service names exposed by this module, derived from the generated service
+// descriptors so they cannot drift from the proto definitions.
+//
+// They are used to scope the module's [grpcmetrics.ServerMetrics] to its own
+// services when several modules share a single [grpc.Server].
+var (
+	FWStateServiceName        = fwstatepb.FWStateService_ServiceDesc.ServiceName
+	FWStateMetricsServiceName = fwstatepb.MetricsService_ServiceDesc.ServiceName
+)
+
 // clampBatchSize returns a batch size that is within the allowed range:
 // zero is replaced with defaultListEntriesBatchSize, and values above
 // maxListEntriesBatchSize are clamped to maxListEntriesBatchSize.
@@ -150,8 +161,23 @@ func NewFWStateService(
 		log:         opts.Log,
 	}
 	if opts.MetricsOpts != nil {
-		metricsOpts := make([]grpcmetrics.Option, 0, len(opts.MetricsOpts)+2)
+		metricsOpts := make([]grpcmetrics.Option, 0, len(opts.MetricsOpts)+3)
 		metricsOpts = append(metricsOpts, grpcmetrics.WithLabeler(labeler))
+
+		// Scope the collector to this module's own services. This module is
+		// designed to be registered on a [grpc.Server] by a parent module,
+		// which may register other services on the same server and chain this
+		// interceptor onto every unary RPC. Without a service filter the
+		// collector would also record those foreign calls, and the resulting
+		// series would never be pruned: the labeler returns nil for foreign
+		// requests, so they carry no "config" label and the retention predicate
+		// keeps label-less series forever.
+		metricsOpts = append(metricsOpts, grpcmetrics.WithServiceFilter(
+			func(service string) bool {
+				return service == FWStateServiceName ||
+					service == FWStateMetricsServiceName
+			},
+		))
 		metricsOpts = append(metricsOpts, opts.MetricsOpts...)
 		metricsOpts = append(metricsOpts, grpcmetrics.WithRetention(m.retention))
 		m.metrics = grpcmetrics.New(metricsOpts...)

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -11,9 +11,53 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
 )
+
+// Option configures an FWStateService.
+type Option func(*options)
+
+// options holds the optional parameters for FWStateService construction.
+type options struct {
+	// MetricsOpts holds the extra grpcmetrics options (e.g. custom
+	// histogram buckets) to apply when collecting gRPC call metrics.
+	// A non-nil slice enables metrics collection; the labeler and
+	// retention predicate are bound by the service itself.
+	MetricsOpts []grpcmetrics.Option
+	Log         *zap.Logger
+}
+
+func newOptions() *options {
+	return &options{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the service logger.
+func WithLog(log *zap.Logger) Option {
+	return func(o *options) {
+		o.Log = log
+	}
+}
+
+// WithMetrics enables collection of gRPC call metrics and attaches the supplied
+// extra grpcmetrics options (e.g. custom histogram buckets).
+//
+// The [grpcmetrics.Labeler] and [grpcmetrics.Retention] predicate are bound by
+// the service itself, so callers do not need to know about them. When this
+// option is unset, no gRPC call metrics are collected.
+func WithMetrics(opts ...grpcmetrics.Option) Option {
+	return func(o *options) {
+		// Always initialize to a non-nil slice so that a later
+		// MetricsOpts != nil check reliably detects that WithMetrics
+		// was called, even when no extra options were passed.
+		o.MetricsOpts = make([]grpcmetrics.Option, 0, len(opts))
+		o.MetricsOpts = append(o.MetricsOpts, opts...)
+	}
+}
 
 const (
 	// defaultListEntriesBatchSize is the batch size used when the caller
@@ -77,6 +121,7 @@ type FWStateService struct {
 	agent       *ffi.Agent
 	configs     map[string]*FwStateConfig
 	aclProvider ACLServiceProvider
+	metrics     *grpcmetrics.ServerMetrics
 
 	// Pending outdated layers to be freed after successful UpdateModules
 	pendingOutdatedLayers []*OutdatedLayers
@@ -84,13 +129,59 @@ type FWStateService struct {
 	log *zap.Logger
 }
 
-// NewFWStateService creates a new FWState service
-func NewFWStateService(agent *ffi.Agent, aclProvider ACLServiceProvider, log *zap.Logger) *FWStateService {
-	return &FWStateService{
+// NewFWStateService creates a new FWState service.
+//
+// When the WithMetrics option is supplied, gRPC call metrics are collected and
+// exposed through the module's MetricsService.
+func NewFWStateService(
+	agent *ffi.Agent,
+	aclProvider ACLServiceProvider,
+	options ...Option,
+) *FWStateService {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	m := &FWStateService{
 		agent:       agent,
 		configs:     make(map[string]*FwStateConfig),
 		aclProvider: aclProvider,
-		log:         log,
+		log:         opts.Log,
+	}
+	if opts.MetricsOpts != nil {
+		metricsOpts := make([]grpcmetrics.Option, 0, len(opts.MetricsOpts)+2)
+		metricsOpts = append(metricsOpts, grpcmetrics.WithLabeler(labeler))
+		metricsOpts = append(metricsOpts, opts.MetricsOpts...)
+		metricsOpts = append(metricsOpts, grpcmetrics.WithRetention(m.retention))
+		m.metrics = grpcmetrics.New(metricsOpts...)
+	}
+
+	return m
+}
+
+// UnaryServerInterceptor returns the service's gRPC metrics interceptor, or
+// nil when metrics are not configured.
+func (m *FWStateService) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	if m.metrics == nil {
+		return nil
+	}
+
+	return m.metrics.UnaryServerInterceptor()
+}
+
+func labeler(fullMethod string, req any) metrics.Labels {
+	switch r := req.(type) {
+	case *fwstatepb.UpdateConfigRequest:
+		return metrics.Labels{"config": r.GetName()}
+	case *fwstatepb.DeleteConfigRequest:
+		return metrics.Labels{"config": r.GetName()}
+	case *fwstatepb.ShowConfigRequest:
+		return metrics.Labels{"config": r.GetName()}
+	case *fwstatepb.GetStatsRequest:
+		return metrics.Labels{"config": r.GetName()}
+	default:
+		return nil
 	}
 }
 

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -22,12 +22,8 @@ type Option func(*options)
 
 // options holds the optional parameters for FWStateService construction.
 type options struct {
-	// MetricsOpts holds the extra grpcmetrics options (e.g. custom
-	// histogram buckets) to apply when collecting gRPC call metrics.
-	// A non-nil slice enables metrics collection; the labeler and
-	// retention predicate are bound by the service itself.
-	MetricsOpts []grpcmetrics.Option
-	Log         *zap.Logger
+	Metrics grpcmetrics.Factory
+	Log     *zap.Logger
 }
 
 func newOptions() *options {
@@ -43,20 +39,37 @@ func WithLog(log *zap.Logger) Option {
 	}
 }
 
-// WithMetrics enables collection of gRPC call metrics and attaches the supplied
-// extra grpcmetrics options (e.g. custom histogram buckets).
+// WithMetrics enables collection of gRPC call metrics using the supplied
+// factory.
 //
-// The [grpcmetrics.Labeler] and [grpcmetrics.Retention] predicate are bound by
-// the service itself, so callers do not need to know about them. When this
-// option is unset, no gRPC call metrics are collected.
-func WithMetrics(opts ...grpcmetrics.Option) Option {
+// The factory owns label extraction and bucketing; the service injects its own
+// retention provider at construction time. Use [NewMetricsFactory] to build a
+// factory scoped to this module's services.
+func WithMetrics(factory grpcmetrics.Factory) Option {
 	return func(o *options) {
-		// Always initialize to a non-nil slice so that a later
-		// MetricsOpts != nil check reliably detects that WithMetrics
-		// was called, even when no extra options were passed.
-		o.MetricsOpts = make([]grpcmetrics.Option, 0, len(opts))
-		o.MetricsOpts = append(o.MetricsOpts, opts...)
+		o.Metrics = factory
 	}
+}
+
+// NewMetricsFactory returns a [grpcmetrics.Factory] pre-bound to this module's
+// own labeler and service filter, applying any extra options (e.g. custom
+// histogram buckets) supplied by the caller.
+//
+// The [grpcmetrics.Retention] is injected by the service itself at construction
+// time, so it must not be passed here.
+func NewMetricsFactory(extra ...grpcmetrics.Option) grpcmetrics.Factory {
+	opts := make([]grpcmetrics.Option, 0, len(extra)+2)
+	opts = append(opts, grpcmetrics.WithLabeler(labeler))
+
+	// Scope the collector to this module's own services.
+	opts = append(opts, grpcmetrics.WithServiceFilter(
+		func(service string) bool {
+			return service == FWStateServiceName ||
+				service == FWStateMetricsServiceName
+		},
+	))
+	opts = append(opts, extra...)
+	return grpcmetrics.NewFactory(opts...)
 }
 
 const (
@@ -160,27 +173,8 @@ func NewFWStateService(
 		aclProvider: aclProvider,
 		log:         opts.Log,
 	}
-	if opts.MetricsOpts != nil {
-		metricsOpts := make([]grpcmetrics.Option, 0, len(opts.MetricsOpts)+3)
-		metricsOpts = append(metricsOpts, grpcmetrics.WithLabeler(labeler))
-
-		// Scope the collector to this module's own services. This module is
-		// designed to be registered on a [grpc.Server] by a parent module,
-		// which may register other services on the same server and chain this
-		// interceptor onto every unary RPC. Without a service filter the
-		// collector would also record those foreign calls, and the resulting
-		// series would never be pruned: the labeler returns nil for foreign
-		// requests, so they carry no "config" label and the retention predicate
-		// keeps label-less series forever.
-		metricsOpts = append(metricsOpts, grpcmetrics.WithServiceFilter(
-			func(service string) bool {
-				return service == FWStateServiceName ||
-					service == FWStateMetricsServiceName
-			},
-		))
-		metricsOpts = append(metricsOpts, opts.MetricsOpts...)
-		metricsOpts = append(metricsOpts, grpcmetrics.WithRetention(m.retention))
-		m.metrics = grpcmetrics.New(metricsOpts...)
+	if opts.Metrics != nil {
+		m.metrics = opts.Metrics(m.retention)
 	}
 
 	return m

--- a/modules/fwstate/dataplane/config.h
+++ b/modules/fwstate/dataplane/config.h
@@ -10,4 +10,17 @@ struct fwstate_module_config {
 	struct cp_module cp_module;
 
 	struct fwstate_config cfg;
+
+	// Module-level counters, registered by fwstate_module_config_new.
+	// Each counter_id is resolved per-worker via counter_get_address().
+	// size=2 counters hold [packets, bytes]; size=1 counters hold
+	// [packets].
+	uint64_t sync_packets_counter_id;
+	uint64_t passthrough_counter_id;
+	uint64_t sync_v4_inserted_counter_id;
+	uint64_t sync_v6_inserted_counter_id;
+	uint64_t sync_v4_insert_failed_counter_id;
+	uint64_t sync_v6_insert_failed_counter_id;
+	uint64_t external_dropped_counter_id;
+	uint64_t internal_forwarded_counter_id;
 };

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -180,7 +180,9 @@ fwstate_process_sync_v4(
 	struct fw_state_sync_frame *sync_frame,
 	bool is_external,
 	uint64_t now,
-	struct fwstate_timeouts *timeouts
+	struct fwstate_timeouts *timeouts,
+	uint64_t *inserted_cnt,
+	uint64_t *insert_failed_cnt
 ) {
 	struct fw4_state_key key = {
 		.hdr.proto = sync_frame->proto,
@@ -201,9 +203,11 @@ fwstate_process_sync_v4(
 	);
 
 	if (result < 0) {
-		// FIXME: counters
 		// FIXME: ratelimit this errors
 		LOG(ERROR, "failed to insert IPv4 state: %s", strerror(errno));
+		insert_failed_cnt[0] += 1;
+	} else {
+		inserted_cnt[0] += 1;
 	}
 
 	if (lock) {
@@ -219,7 +223,9 @@ fwstate_process_sync_v6(
 	struct fw_state_sync_frame *sync_frame,
 	bool is_external,
 	uint64_t now,
-	struct fwstate_timeouts *timeouts
+	struct fwstate_timeouts *timeouts,
+	uint64_t *inserted_cnt,
+	uint64_t *insert_failed_cnt
 ) {
 	struct fw6_state_key key = {
 		.hdr.proto = sync_frame->proto,
@@ -240,9 +246,11 @@ fwstate_process_sync_v6(
 	);
 
 	if (result < 0) {
-		// FIXME: counters
 		// FIXME: ratelimit this errors
 		LOG(ERROR, "failed to insert IPv6 state: %s", strerror(errno));
+		insert_failed_cnt[0] += 1;
+	} else {
+		inserted_cnt[0] += 1;
 	}
 
 	if (lock) {
@@ -268,6 +276,50 @@ fwstate_handle_packets(
 
 	uint64_t now = dp_worker->current_time;
 
+	// Resolve per-worker counter addresses.
+	// size=2 counters: [0]=packets, [1]=bytes; size=1 counters:
+	// [0]=packets.
+	uint64_t *sync_packets_cnt = counter_get_address(
+		fwstate_module->sync_packets_counter_id,
+		dp_worker->idx,
+		ADDR_OF(&module_ectx->counter_storage)
+	);
+	uint64_t *passthrough_cnt = counter_get_address(
+		fwstate_module->passthrough_counter_id,
+		dp_worker->idx,
+		ADDR_OF(&module_ectx->counter_storage)
+	);
+	uint64_t *sync_v4_inserted_cnt = counter_get_address(
+		fwstate_module->sync_v4_inserted_counter_id,
+		dp_worker->idx,
+		ADDR_OF(&module_ectx->counter_storage)
+	);
+	uint64_t *sync_v6_inserted_cnt = counter_get_address(
+		fwstate_module->sync_v6_inserted_counter_id,
+		dp_worker->idx,
+		ADDR_OF(&module_ectx->counter_storage)
+	);
+	uint64_t *sync_v4_insert_failed_cnt = counter_get_address(
+		fwstate_module->sync_v4_insert_failed_counter_id,
+		dp_worker->idx,
+		ADDR_OF(&module_ectx->counter_storage)
+	);
+	uint64_t *sync_v6_insert_failed_cnt = counter_get_address(
+		fwstate_module->sync_v6_insert_failed_counter_id,
+		dp_worker->idx,
+		ADDR_OF(&module_ectx->counter_storage)
+	);
+	uint64_t *external_dropped_cnt = counter_get_address(
+		fwstate_module->external_dropped_counter_id,
+		dp_worker->idx,
+		ADDR_OF(&module_ectx->counter_storage)
+	);
+	uint64_t *internal_forwarded_cnt = counter_get_address(
+		fwstate_module->internal_forwarded_counter_id,
+		dp_worker->idx,
+		ADDR_OF(&module_ectx->counter_storage)
+	);
+
 	struct packet *packet;
 	while ((packet = packet_list_pop(&packet_front->input)) != NULL) {
 		// FIXME: accumulate multiple internal sync frames into one
@@ -277,12 +329,17 @@ fwstate_handle_packets(
 			    packet, &fwstate_config->sync_config
 		    )) {
 			// Not a sync packet, pass through
+			passthrough_cnt[0] += 1;
+			passthrough_cnt[1] += packet_to_mbuf(packet)->pkt_len;
 			packet_front_output(packet_front, packet);
 			continue;
 		}
 
 		// This is a sync packet - process it
 		struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+
+		sync_packets_cnt[0] += 1;
+		sync_packets_cnt[1] += mbuf->pkt_len;
 
 		// Extract sync frames from UDP payload
 		const uint16_t vlan_offset = sizeof(struct rte_ether_hdr);
@@ -331,7 +388,9 @@ fwstate_handle_packets(
 					sync_frame,
 					is_external,
 					now,
-					&fwstate_config->sync_config.timeouts
+					&fwstate_config->sync_config.timeouts,
+					sync_v4_inserted_cnt,
+					sync_v4_insert_failed_cnt
 				);
 			} else if (sync_frame->addr_type ==
 				   FW_STATE_ADDR_TYPE_IP6) {
@@ -341,7 +400,9 @@ fwstate_handle_packets(
 					sync_frame,
 					is_external,
 					now,
-					&fwstate_config->sync_config.timeouts
+					&fwstate_config->sync_config.timeouts,
+					sync_v6_inserted_cnt,
+					sync_v6_insert_failed_cnt
 				);
 			}
 		}
@@ -350,6 +411,8 @@ fwstate_handle_packets(
 		// processing. Pass through internal packets (from our ACL) to
 		// reach other firewalls.
 		if (is_external) {
+			external_dropped_cnt[0] += 1;
+			external_dropped_cnt[1] += mbuf->pkt_len;
 			packet_front_drop(packet_front, packet);
 		} else {
 			rte_memcpy(
@@ -363,6 +426,8 @@ fwstate_handle_packets(
 			udp_hdr->dgram_cksum = 0;
 			udp_hdr->dgram_cksum =
 				rte_ipv6_udptcp_cksum(ipv6_hdr, udp_hdr);
+			internal_forwarded_cnt[0] += 1;
+			internal_forwarded_cnt[1] += mbuf->pkt_len;
 			packet_front_output(packet_front, packet);
 		}
 	}

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -279,45 +279,34 @@ fwstate_handle_packets(
 	// Resolve per-worker counter addresses.
 	// size=2 counters: [0]=packets, [1]=bytes; size=1 counters:
 	// [0]=packets.
+	struct counter_storage *counter_storage =
+		ADDR_OF_NONNULL(&module_ectx->counter_storage);
+
 	uint64_t *sync_packets_cnt = counter_get_address(
-		fwstate_module->sync_packets_counter_id,
-		dp_worker->idx,
-		ADDR_OF(&module_ectx->counter_storage)
+		fwstate_module->sync_packets_counter_id, counter_storage
 	);
 	uint64_t *passthrough_cnt = counter_get_address(
-		fwstate_module->passthrough_counter_id,
-		dp_worker->idx,
-		ADDR_OF(&module_ectx->counter_storage)
+		fwstate_module->passthrough_counter_id, counter_storage
 	);
 	uint64_t *sync_v4_inserted_cnt = counter_get_address(
-		fwstate_module->sync_v4_inserted_counter_id,
-		dp_worker->idx,
-		ADDR_OF(&module_ectx->counter_storage)
+		fwstate_module->sync_v4_inserted_counter_id, counter_storage
 	);
 	uint64_t *sync_v6_inserted_cnt = counter_get_address(
-		fwstate_module->sync_v6_inserted_counter_id,
-		dp_worker->idx,
-		ADDR_OF(&module_ectx->counter_storage)
+		fwstate_module->sync_v6_inserted_counter_id, counter_storage
 	);
 	uint64_t *sync_v4_insert_failed_cnt = counter_get_address(
 		fwstate_module->sync_v4_insert_failed_counter_id,
-		dp_worker->idx,
-		ADDR_OF(&module_ectx->counter_storage)
+		counter_storage
 	);
 	uint64_t *sync_v6_insert_failed_cnt = counter_get_address(
 		fwstate_module->sync_v6_insert_failed_counter_id,
-		dp_worker->idx,
-		ADDR_OF(&module_ectx->counter_storage)
+		counter_storage
 	);
 	uint64_t *external_dropped_cnt = counter_get_address(
-		fwstate_module->external_dropped_counter_id,
-		dp_worker->idx,
-		ADDR_OF(&module_ectx->counter_storage)
+		fwstate_module->external_dropped_counter_id, counter_storage
 	);
 	uint64_t *internal_forwarded_cnt = counter_get_address(
-		fwstate_module->internal_forwarded_counter_id,
-		dp_worker->idx,
-		ADDR_OF(&module_ectx->counter_storage)
+		fwstate_module->internal_forwarded_counter_id, counter_storage
 	);
 
 	struct packet *packet;

--- a/modules/fwstate/fuzzing/fwstate.c
+++ b/modules/fwstate/fuzzing/fwstate.c
@@ -11,6 +11,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 
+#include "counters/counters.h"
 #include "lib/dataplane/time/clock.h"
 #include "lib/fwstate/config.h"
 #include "lib/fwstate/fwmap.h"
@@ -49,6 +50,84 @@ fwstate_test_config(struct cp_module **cp_module) {
 
 	config->cp_module.dp_module_idx = 0;
 	config->cp_module.agent = NULL;
+
+	// The fwstate handler unconditionally resolves per-worker counter
+	// addresses via counter_get_address(), so a valid counter_registry and
+	// counter_storage must be provided or the handler dereferences NULL.
+	// size=2 counters hold [packets, bytes]; size=1 counters hold
+	// [packets].
+	if (counter_registry_init(
+		    &config->cp_module.counter_registry,
+		    &config->cp_module.memory_context,
+		    0
+	    )) {
+		return -ENOMEM;
+	}
+
+	struct {
+		const char *name;
+		uint64_t size;
+		uint64_t *dst;
+	} counters[] = {
+		{"fwstate_sync_packets", 2, &config->sync_packets_counter_id},
+		{"fwstate_passthrough", 2, &config->passthrough_counter_id},
+		{"fwstate_sync_v4_inserted",
+		 1,
+		 &config->sync_v4_inserted_counter_id},
+		{"fwstate_sync_v6_inserted",
+		 1,
+		 &config->sync_v6_inserted_counter_id},
+		{"fwstate_sync_v4_insert_failed",
+		 1,
+		 &config->sync_v4_insert_failed_counter_id},
+		{"fwstate_sync_v6_insert_failed",
+		 1,
+		 &config->sync_v6_insert_failed_counter_id},
+		{"fwstate_external_dropped",
+		 2,
+		 &config->external_dropped_counter_id},
+		{"fwstate_internal_forwarded",
+		 2,
+		 &config->internal_forwarded_counter_id},
+	};
+
+	for (size_t i = 0; i < sizeof(counters) / sizeof(counters[0]); ++i) {
+		uint64_t id = counter_registry_register(
+			&config->cp_module.counter_registry,
+			counters[i].name,
+			counters[i].size,
+			NULL
+		);
+		if (id == (uint64_t)-1) {
+			return -ENOMEM;
+		}
+		*counters[i].dst = id;
+	}
+
+	if (counter_registry_link(
+		    &config->cp_module.counter_registry, NULL, NULL
+	    )) {
+		return -ENOMEM;
+	}
+
+	struct counter_storage_allocator *alloc = memory_balloc(
+		&fuzz_params.mctx, sizeof(struct counter_storage_allocator)
+	);
+	if (alloc == NULL) {
+		return -ENOMEM;
+	}
+	counter_storage_allocator_init(alloc, &fuzz_params.mctx, 1);
+
+	struct counter_storage *cs = counter_storage_spawn(
+		&fuzz_params.mctx,
+		alloc,
+		NULL,
+		&config->cp_module.counter_registry
+	);
+	if (cs == NULL) {
+		return -ENOMEM;
+	}
+	SET_OFFSET_OF(&fuzz_params.module_ectx.counter_storage, cs);
 
 	// Create fw4state and fw6state maps
 	fwmap_config_t fw4config = {

--- a/modules/fwstate/fuzzing/fwstate.c
+++ b/modules/fwstate/fuzzing/fwstate.c
@@ -69,7 +69,7 @@ fwstate_test_config(struct cp_module **cp_module) {
 		uint64_t size;
 		uint64_t *dst;
 	} counters[] = {
-		{"fwstate_sync_packets", 2, &config->sync_packets_counter_id},
+		{"fwstate_sync", 2, &config->sync_packets_counter_id},
 		{"fwstate_passthrough", 2, &config->passthrough_counter_id},
 		{"fwstate_sync_v4_inserted",
 		 1,

--- a/modules/fwstate/fuzzing/fwstate.c
+++ b/modules/fwstate/fuzzing/fwstate.c
@@ -110,19 +110,8 @@ fwstate_test_config(struct cp_module **cp_module) {
 		return -ENOMEM;
 	}
 
-	struct counter_storage_allocator *alloc = memory_balloc(
-		&fuzz_params.mctx, sizeof(struct counter_storage_allocator)
-	);
-	if (alloc == NULL) {
-		return -ENOMEM;
-	}
-	counter_storage_allocator_init(alloc, &fuzz_params.mctx, 1);
-
 	struct counter_storage *cs = counter_storage_spawn(
-		&fuzz_params.mctx,
-		alloc,
-		NULL,
-		&config->cp_module.counter_registry
+		&fuzz_params.mctx, NULL, &config->cp_module.counter_registry
 	);
 	if (cs == NULL) {
 		return -ENOMEM;

--- a/modules/fwstate/fuzzing/meson.build
+++ b/modules/fwstate/fuzzing/meson.build
@@ -8,6 +8,7 @@ fuzzing_targets += {
       lib_fwstate_dep,
       lib_lib_utils_dep,
       lib_time_dp_dep,
+      lib_counters_dep,
     ],
     'module_dir': '..',
   }

--- a/modules/fwstate/tests/dataplane/cursor_test.go
+++ b/modules/fwstate/tests/dataplane/cursor_test.go
@@ -42,7 +42,8 @@ func ipToUint32(s string) uint32 {
 func TestCursorForwardRead(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("cursor_fwd", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	now := uint64(GetCurrentTime())
 
@@ -76,7 +77,8 @@ func TestCursorForwardRead(t *testing.T) {
 func TestCursorBackwardRead(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("cursor_bwd", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	now := uint64(GetCurrentTime())
 
@@ -109,7 +111,8 @@ func TestCursorBackwardRead(t *testing.T) {
 func TestCursorExpiredFiltering(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("cursor_exp", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	now := uint64(GetCurrentTime())
 
@@ -164,7 +167,8 @@ func TestCursorExpiredFiltering(t *testing.T) {
 func TestCursorKeyDataCorrectness(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("cursor_key", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	now := uint64(GetCurrentTime())
 
@@ -196,7 +200,8 @@ func TestCursorKeyDataCorrectness(t *testing.T) {
 func TestCursorValueDataCorrectness(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("cursor_val", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	now := uint64(GetCurrentTime())
 
@@ -223,7 +228,8 @@ func TestCursorValueDataCorrectness(t *testing.T) {
 func TestCursorInvalidLayer(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("cursor_inv", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	now := uint64(GetCurrentTime())
 
@@ -237,7 +243,8 @@ func TestCursorInvalidLayer(t *testing.T) {
 func TestCursorPaging(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("cursor_page", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	now := uint64(GetCurrentTime())
 

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -32,36 +32,63 @@ fwstate_handle_packets(
 	struct packet_front *packet_front
 );
 
-// Test wrapper for fwstate_handle_packets that constructs module_ectx from cp_module
-void
-test_fwstate_handle_packets(
-	struct dp_worker *dp_worker,
-	struct cp_module *cp_module,
-	struct packet_front *packet_front
-) {
-	struct module_ectx module_ectx = {};
-	SET_OFFSET_OF(&module_ectx.cp_module, cp_module);
-
-	// The dataplane resolves per-worker counter addresses via
-	// counter_get_address(), which dereferences module_ectx.counter_storage.
-	// Reproduce the real dataplane setup: link the registry (assigns counter
-	// offsets) and spawn a per-worker counter storage.
+// Link the module's counter registry and spawn a per-worker counter storage.
+//
+// The dataplane resolves per-worker counter addresses via counter_get_address(),
+// which dereferences module_ectx.counter_storage. Reproduce the real dataplane
+// setup once at config time and reuse the storage across handle calls so that
+// counter values accumulate across invocations.
+//
+// Returns NULL on failure (the error chain is freed internally).
+struct counter_storage *
+fwstate_test_counter_storage_setup(struct cp_module *cp_module) {
 	struct counter_registry *registry = &cp_module->counter_registry;
 
 	yanet_error *err = NULL;
 	if (counter_registry_link(registry, NULL, &err)) {
-		fwstate_handle_packets(dp_worker, &module_ectx, packet_front);
-		return;
+		// Setup failed: do not run the handler with counter_storage still
+		// zero — ADDR_OF_NONNULL on a zero offset yields the address of the
+		// field itself, so counter_get_address would read and write through
+		// a bogus stack pointer. Free the error chain and bail out.
+		yanet_error_free(err);
+		return NULL;
 	}
 
 	struct counter_storage *storage = counter_storage_spawn(
 		&cp_module->memory_context, NULL, registry
 	);
-	SET_OFFSET_OF(&module_ectx.counter_storage, storage);
+	if (storage == NULL) {
+		// Allocation failed: same bogus-pointer hazard as above if the zero
+		// offset were fed to SET_OFFSET_OF. counter_storage_free(NULL) is
+		// safe, but the handler must not run.
+		return NULL;
+	}
+
+	return storage;
+}
+
+// Free a counter storage allocated by fwstate_test_counter_storage_setup.
+// Safe to call with NULL.
+void
+fwstate_test_counter_storage_free(struct counter_storage *storage) {
+	counter_storage_free(storage);
+}
+
+// Test wrapper for fwstate_handle_packets that constructs module_ectx from
+// cp_module and a pre-spawned counter storage. The storage is owned by the
+// caller and reused across calls so counters accumulate.
+void
+test_fwstate_handle_packets(
+	struct dp_worker *dp_worker,
+	struct cp_module *cp_module,
+	struct counter_storage *counter_storage,
+	struct packet_front *packet_front
+) {
+	struct module_ectx module_ectx = {};
+	SET_OFFSET_OF(&module_ectx.cp_module, cp_module);
+	SET_OFFSET_OF(&module_ectx.counter_storage, counter_storage);
 
 	fwstate_handle_packets(dp_worker, &module_ectx, packet_front);
-
-	counter_storage_free(storage);
 }
 
 // Helper to get actual pointer from offset pointer
@@ -142,7 +169,11 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/testutils"
 )
 
-func fwstateModuleConfig(memCtx testutils.MemoryContext) *C.struct_cp_module {
+// fwstateModuleConfig creates a fwstate module config and spawns a per-worker
+// counter storage that is reused across fwstateHandlePackets calls so that
+// counter values accumulate. The returned storage must be freed with
+// [fwstateCounterStorageFree] (the caller owns it).
+func fwstateModuleConfig(memCtx testutils.MemoryContext) (*C.struct_cp_module, *C.struct_counter_storage) {
 	// Allocate agent in the memory context (it needs to be in the same memory space)
 	agent := (*C.struct_agent)(C.memory_balloc(
 		(*C.struct_memory_context)(memCtx.AsRawPtr()),
@@ -202,10 +233,23 @@ func fwstateModuleConfig(memCtx testutils.MemoryContext) *C.struct_cp_module {
 	m.cfg.sync_config.timeouts.udp = C.uint64_t(30e9)
 	m.cfg.sync_config.timeouts.default_ = C.uint64_t(16e9)
 
-	return cpModule
+	// Link the counter registry and spawn a per-worker counter storage once,
+	// so counter values accumulate across fwstateHandlePackets calls.
+	storage := C.fwstate_test_counter_storage_setup(cpModule)
+	if storage == nil {
+		panic("failed to spawn counter storage")
+	}
+
+	return cpModule, storage
 }
 
-func fwstateHandlePackets(cpModule *C.struct_cp_module, packets ...gopacket.Packet) (*dataplane.PacketFrontPayload, error) {
+// fwstateCounterStorageFree frees a counter storage returned by
+// fwstateModuleConfig. Safe to call with nil.
+func fwstateCounterStorageFree(storage *C.struct_counter_storage) {
+	C.fwstate_test_counter_storage_free(storage)
+}
+
+func fwstateHandlePackets(cpModule *C.struct_cp_module, storage *C.struct_counter_storage, packets ...gopacket.Packet) (*dataplane.PacketFrontPayload, error) {
 	pinner := runtime.Pinner{}
 	defer pinner.Unpin()
 
@@ -219,7 +263,7 @@ func fwstateHandlePackets(cpModule *C.struct_cp_module, packets ...gopacket.Pack
 		idx:          0,
 		current_time: C.clock_get_time_ns(nil),
 	}
-	C.test_fwstate_handle_packets(dpWorker, cpModule, (*C.struct_packet_front)(unsafe.Pointer(pf)))
+	C.test_fwstate_handle_packets(dpWorker, cpModule, storage, (*C.struct_packet_front)(unsafe.Pointer(pf)))
 	result := pf.Payload()
 	return &result, nil
 }

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -3,6 +3,7 @@ package fwstate
 //#cgo CFLAGS: -I../../../.. -I../../../../lib -I../../../../common
 //#cgo LDFLAGS: -L../../../../build/modules/fwstate/dataplane -lfwstate_dp
 //#cgo LDFLAGS: -L../../../../build/modules/fwstate/api -lfwstate_cp
+//#cgo LDFLAGS: -L../../../../build/lib/counters -lcounters
 //#cgo LDFLAGS: -L../../../../build/lib/dataplane/packet -lpacket
 //#cgo LDFLAGS: -L../../../../build/lib/fwstate -lfwstate
 //#cgo LDFLAGS: -L../../../../build/lib/logging -llogging
@@ -20,6 +21,7 @@ package fwstate
 #include "lib/fwstate/types.h"
 #include "lib/dataplane/time/clock.h"
 #include "lib/controlplane/agent/agent.h"
+#include "lib/counters/counters.h"
 #include "common/memory.h"
 
 // Forward declaration of fwstate_handle_packets from dataplane module
@@ -39,7 +41,33 @@ test_fwstate_handle_packets(
 ) {
 	struct module_ectx module_ectx = {};
 	SET_OFFSET_OF(&module_ectx.cp_module, cp_module);
+
+	// The dataplane resolves per-worker counter addresses via
+	// counter_get_address(), which dereferences module_ectx.counter_storage.
+	// Reproduce the real dataplane setup: link the registry (assigns counter
+	// offsets) and spawn a per-worker counter storage.
+	struct counter_registry *registry = &cp_module->counter_registry;
+
+	yanet_error *err = NULL;
+	if (counter_registry_link(registry, NULL, &err)) {
+		fwstate_handle_packets(dp_worker, &module_ectx, packet_front);
+		return;
+	}
+
+	struct counter_storage_allocator allocator;
+	counter_storage_allocator_init(
+		&allocator, &cp_module->memory_context, dp_worker->idx + 1
+	);
+
+	struct counter_storage *storage = counter_storage_spawn(
+		&cp_module->memory_context, &allocator, NULL, registry
+	);
+	SET_OFFSET_OF(&module_ectx.counter_storage, storage);
+
 	fwstate_handle_packets(dp_worker, &module_ectx, packet_front);
+
+	counter_storage_free(storage);
+	counter_storage_allocator_fini(&allocator);
 }
 
 // Helper to get actual pointer from offset pointer
@@ -85,12 +113,23 @@ cp_module_init(
 	// Set agent offset
 	SET_OFFSET_OF(&cp_module->agent, agent);
 
+    // Initialize the counter registry. fwstate_module_config_new registers
+    // module-level counters right after cp_module_init, and
+    // counter_registry_register dereferences registry->memory_context (an
+    // offset pointer).
+	if (counter_registry_init(
+		    &cp_module->counter_registry, &cp_module->memory_context, 0
+	    )) {
+		yanet_error_add(err, "failed to init counter registry");
+		return -1;
+	}
+
 	return 0;
 }
 
 void
 cp_module_fini(struct cp_module *cp_module) {
-	(void) cp_module;
+	counter_registry_fini(&cp_module->counter_registry);
 }
 
 */

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -54,20 +54,14 @@ test_fwstate_handle_packets(
 		return;
 	}
 
-	struct counter_storage_allocator allocator;
-	counter_storage_allocator_init(
-		&allocator, &cp_module->memory_context, dp_worker->idx + 1
-	);
-
 	struct counter_storage *storage = counter_storage_spawn(
-		&cp_module->memory_context, &allocator, NULL, registry
+		&cp_module->memory_context, NULL, registry
 	);
 	SET_OFFSET_OF(&module_ectx.counter_storage, storage);
 
 	fwstate_handle_packets(dp_worker, &module_ectx, packet_front);
 
 	counter_storage_free(storage);
-	counter_storage_allocator_fini(&allocator);
 }
 
 // Helper to get actual pointer from offset pointer

--- a/modules/fwstate/tests/dataplane/fwstate.go
+++ b/modules/fwstate/tests/dataplane/fwstate.go
@@ -107,10 +107,10 @@ cp_module_init(
 	// Set agent offset
 	SET_OFFSET_OF(&cp_module->agent, agent);
 
-    // Initialize the counter registry. fwstate_module_config_new registers
-    // module-level counters right after cp_module_init, and
-    // counter_registry_register dereferences registry->memory_context (an
-    // offset pointer).
+	// Initialize the counter registry. fwstate_module_config_new registers
+	// module-level counters right after cp_module_init, and
+	// counter_registry_register dereferences registry->memory_context (an
+	// offset pointer).
 	if (counter_registry_init(
 		    &cp_module->counter_registry, &cp_module->memory_context, 0
 	    )) {

--- a/modules/fwstate/tests/dataplane/fwstate_test.go
+++ b/modules/fwstate/tests/dataplane/fwstate_test.go
@@ -134,8 +134,9 @@ func TestFWStateInternalPacket(t *testing.T) {
 
 	memCtx := testutils.NewMemoryContext("fwstate_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
-	result := xerror.Unwrap(fwstateHandlePackets(cpModule, pkt))
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
+	result := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt))
 
 	// Internal packets should be in output
 	require.NotEmpty(t, result.Output, "Internal packet should be forwarded")
@@ -149,8 +150,9 @@ func TestFWStateExternalPacket(t *testing.T) {
 
 	memCtx := testutils.NewMemoryContext("fwstate_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
-	result := xerror.Unwrap(fwstateHandlePackets(cpModule, pkt))
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
+	result := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt))
 
 	// External packets should be dropped
 	require.Empty(t, result.Output, "External packet should not be forwarded")
@@ -185,8 +187,9 @@ func TestFWStateNonSyncPacket(t *testing.T) {
 
 	memCtx := testutils.NewMemoryContext("fwstate_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
-	result := xerror.Unwrap(fwstateHandlePackets(cpModule, pkt))
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
+	result := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt))
 
 	// Non-sync packets should pass through
 	require.NotEmpty(t, result.Output, "Non-sync packet should pass through")
@@ -201,8 +204,9 @@ func TestFWStateStateCreation(t *testing.T) {
 
 	memCtx := testutils.NewMemoryContext("fwstate_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
-	result := xerror.Unwrap(fwstateHandlePackets(cpModule, pkt))
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
+	result := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt))
 
 	// Verify packet was processed
 	require.NotEmpty(t, result.Output, "Internal packet should be forwarded")
@@ -217,11 +221,12 @@ func TestFWStateStateCreation(t *testing.T) {
 func TestFWStateLayerInsertionOldStateVisible(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("fwstate_layer_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	// Create initial state in the first layer
 	pkt1 := createSyncPacket(t, layers.IPProtocolTCP)
-	result1 := xerror.Unwrap(fwstateHandlePackets(cpModule, pkt1))
+	result1 := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt1))
 	require.NotEmpty(t, result1.Output, "First packet should be forwarded")
 
 	// Verify initial state exists
@@ -240,11 +245,12 @@ func TestFWStateLayerInsertionOldStateVisible(t *testing.T) {
 func TestFWStateLayerInsertionNewStateOverridesOld(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("fwstate_layer_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	// Create initial state with specific deadline
 	pkt1 := createSyncPacket(t, layers.IPProtocolTCP)
-	result1 := xerror.Unwrap(fwstateHandlePackets(cpModule, pkt1))
+	result1 := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt1))
 	require.NotEmpty(t, result1.Output, "First packet should be forwarded")
 
 	// Get initial deadline
@@ -256,7 +262,7 @@ func TestFWStateLayerInsertionNewStateOverridesOld(t *testing.T) {
 
 	// Add same state to new layer (should override old one)
 	pkt2 := createSyncPacket(t, layers.IPProtocolTCP)
-	result2 := xerror.Unwrap(fwstateHandlePackets(cpModule, pkt2))
+	result2 := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt2))
 	require.NotEmpty(t, result2.Output, "Second packet should be forwarded")
 
 	// New deadline should be different (newer)
@@ -268,11 +274,12 @@ func TestFWStateLayerInsertionNewStateOverridesOld(t *testing.T) {
 func TestFWStateTrimStaleLayers(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("fwstate_trim_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	// Create state in first layer with short TTL
 	pkt1 := createSyncPacket(t, layers.IPProtocolTCP)
-	result1 := xerror.Unwrap(fwstateHandlePackets(cpModule, pkt1))
+	result1 := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt1))
 	require.NotEmpty(t, result1.Output)
 
 	// Insert new layer
@@ -280,7 +287,7 @@ func TestFWStateTrimStaleLayers(t *testing.T) {
 
 	// Add different state to new layer
 	pkt2 := createSyncPacket(t, layers.IPProtocolUDP, WithPorts(54321, 8888), WithAddrs("2001:db8::3", "2001:db8::4"))
-	result2 := xerror.Unwrap(fwstateHandlePackets(cpModule, pkt2))
+	result2 := xerror.Unwrap(fwstateHandlePackets(cpModule, storage, pkt2))
 	require.NotEmpty(t, result2.Output)
 
 	// Check layer count before trim
@@ -324,13 +331,14 @@ func TestFWStateTrimStaleLayers(t *testing.T) {
 func TestFWStateUpdateAccumulatesFlags(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("fwstate_acc_flags_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	const synBit = 0x02 // FWSTATE_SYN, src nibble
 	const ackBit = 0x08 // FWSTATE_ACK, src nibble
 
 	pktSyn := createSyncPacket(t, layers.IPProtocolTCP, WithFlags(synBit))
-	_, err := fwstateHandlePackets(cpModule, pktSyn)
+	_, err := fwstateHandlePackets(cpModule, storage, pktSyn)
 	require.NoError(t, err)
 
 	snap1 := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
@@ -338,7 +346,7 @@ func TestFWStateUpdateAccumulatesFlags(t *testing.T) {
 	require.Equal(t, uint8(synBit), snap1.FlagsRaw, "after first sync only SYN must be set")
 
 	pktAck := createSyncPacket(t, layers.IPProtocolTCP, WithFlags(ackBit))
-	_, err = fwstateHandlePackets(cpModule, pktAck)
+	_, err = fwstateHandlePackets(cpModule, storage, pktAck)
 	require.NoError(t, err)
 
 	snap2 := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
@@ -359,19 +367,20 @@ func TestFWStateUpdateAccumulatesFlags(t *testing.T) {
 func TestFWStateUpdateAccumulatesPacketCounters(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("fwstate_acc_counters_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	const forwardCount = 3
 	const backwardCount = 2
 
 	for range forwardCount {
 		pkt := createSyncPacket(t, layers.IPProtocolTCP, WithFib(0))
-		_, err := fwstateHandlePackets(cpModule, pkt)
+		_, err := fwstateHandlePackets(cpModule, storage, pkt)
 		require.NoError(t, err)
 	}
 	for range backwardCount {
 		pkt := createSyncPacket(t, layers.IPProtocolTCP, WithFib(1))
-		_, err := fwstateHandlePackets(cpModule, pkt)
+		_, err := fwstateHandlePackets(cpModule, storage, pkt)
 		require.NoError(t, err)
 	}
 
@@ -393,10 +402,11 @@ func TestFWStateUpdateAccumulatesPacketCounters(t *testing.T) {
 func TestFWStateUpdatePreservesCreatedAt(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("fwstate_created_at_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	pkt1 := createSyncPacket(t, layers.IPProtocolTCP)
-	_, err := fwstateHandlePackets(cpModule, pkt1)
+	_, err := fwstateHandlePackets(cpModule, storage, pkt1)
 	require.NoError(t, err)
 
 	snap1 := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
@@ -409,7 +419,7 @@ func TestFWStateUpdatePreservesCreatedAt(t *testing.T) {
 	// which is monotonic — but we rely on observable difference only for
 	// updated_at, not for the test assertion itself.
 	pkt2 := createSyncPacket(t, layers.IPProtocolTCP)
-	_, err = fwstateHandlePackets(cpModule, pkt2)
+	_, err = fwstateHandlePackets(cpModule, storage, pkt2)
 	require.NoError(t, err)
 
 	snap2 := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")
@@ -427,14 +437,15 @@ func TestFWStateUpdatePreservesCreatedAt(t *testing.T) {
 func TestFWStateMergeFromStaleLayer(t *testing.T) {
 	memCtx := testutils.NewMemoryContext("fwstate_merge_stale_test", datasize.MB*64)
 	defer memCtx.Free()
-	cpModule := fwstateModuleConfig(memCtx)
+	cpModule, storage := fwstateModuleConfig(memCtx)
+	defer fwstateCounterStorageFree(storage)
 
 	const synBit = 0x02
 	const ackBit = 0x08
 
 	// Populate stale layer with SYN + 1 forward packet.
 	pkt1 := createSyncPacket(t, layers.IPProtocolTCP, WithFlags(synBit), WithFib(0))
-	_, err := fwstateHandlePackets(cpModule, pkt1)
+	_, err := fwstateHandlePackets(cpModule, storage, pkt1)
 	require.NoError(t, err)
 
 	// Push that layer down, allocate a new active layer.
@@ -442,7 +453,7 @@ func TestFWStateMergeFromStaleLayer(t *testing.T) {
 
 	// Insert into the fresh active layer with ACK + 1 backward packet.
 	pkt2 := createSyncPacket(t, layers.IPProtocolTCP, WithFlags(ackBit), WithFib(1))
-	_, err = fwstateHandlePackets(cpModule, pkt2)
+	_, err = fwstateHandlePackets(cpModule, storage, pkt2)
 	require.NoError(t, err)
 
 	snap := GetStateValue(cpModule, layers.IPProtocolTCP, 12345, 9999, "2001:db8::1", "2001:db8::2")


### PR DESCRIPTION
Adds a full metrics service for the `fwstate` module: dataplane packet/byte counters, per-config/per-AF map-statistics gauges, and gRPC call metrics. Metrics are exposed through a new `MetricsService` gRPC service and rendered as structured tables by the `yanet-cli-fwstate` CLI.