### PR TITLE
fix(common): make value table destructor safe on failed init

### DIFF
--- a/common/value.h
+++ b/common/value.h
@@ -24,12 +24,15 @@ value_table_free(struct value_table *value_table) {
 	struct memory_context *memory_context =
 		ADDR_OF(&value_table->memory_context);
 
+	uint32_t **values = ADDR_OF(&value_table->values);
+	if (values == NULL)
+		return;
+
 	uint64_t value_count = value_table->v_dim;
 	value_count *= value_table->h_dim;
 	uint32_t chunk_count = (value_count + VALUE_TABLE_CHUNK_SIZE - 1) /
 			       VALUE_TABLE_CHUNK_SIZE;
 
-	uint32_t **values = ADDR_OF(&value_table->values);
 	for (uint32_t chunk_idx = 0; chunk_idx < chunk_count; ++chunk_idx) {
 		uint32_t *chunk = ADDR_OF(values + chunk_idx);
 		if (chunk == NULL)
@@ -56,6 +59,7 @@ value_table_init(
 
 	value_table->v_dim = v_dim;
 	value_table->h_dim = h_dim;
+	SET_OFFSET_OF(&value_table->values, NULL);
 
 	uint64_t value_count = v_dim;
 	value_count *= h_dim;

--- a/tests/common/value_table.c
+++ b/tests/common/value_table.c
@@ -3,8 +3,32 @@
 #include <assert.h>
 #include <stdio.h>
 
+// value_table_free must be a no-op on an object whose value_table_init
+// failed, e.g. when the backing allocator cannot satisfy the values array.
+// Before the fix the values field was left uninitialized and the subsequent
+// free dereferenced it.
+static void
+test_free_after_failed_init(void) {
+	struct block_allocator alloc;
+	block_allocator_init(&alloc);
+
+	struct memory_context mem_ctx;
+	int res = memory_context_init(&mem_ctx, "fail", &alloc);
+	assert(res == 0);
+
+	struct value_table table;
+	memset(&table, 0xa5, sizeof(table));
+
+	res = value_table_init(&table, &mem_ctx, 1, 10);
+	assert(res == -1);
+
+	value_table_free(&table);
+}
+
 int
 main() {
+	test_free_after_failed_init();
+
 	void *arena0 = malloc(1 << 24); // 16MB
 	if (arena0 == NULL) {
 		return 1;


### PR DESCRIPTION
Initialising a value table could leave its backing pointer unset when the first allocation failed, so cleaning up the partially-constructed object dereferenced garbage and crashed. Initialise the pointer before any allocation and make the destructor a no-op on an unconstructed object. Adds a regression test that forces the allocation-failure path.