### PR TITLE
feat(route): add GetMetrics RPC to controlplane

### DIFF
--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -1,0 +1,43 @@
+package route
+
+import (
+	"context"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	routepb "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
+)
+
+// metricsSource provides the module's collected metrics.
+type metricsSource interface {
+	Metrics() ([]*commonpb.Metric, error)
+}
+
+// MetricsService exposes route module metrics over its own gRPC service.
+type MetricsService struct {
+	routepb.UnimplementedMetricsServiceServer
+
+	source metricsSource
+}
+
+// NewMetricsService creates a MetricsService backed by source.
+func NewMetricsService(source metricsSource) *MetricsService {
+	return &MetricsService{source: source}
+}
+
+// GetMetrics returns a snapshot of all route module metrics.
+func (m *MetricsService) GetMetrics(ctx context.Context, req *routepb.GetMetricsRequest) (*routepb.GetMetricsResponse, error) {
+	all, err := m.source.Metrics()
+	if err != nil {
+		return nil, err
+	}
+
+	return &routepb.GetMetricsResponse{Metrics: all}, nil
+}
+
+func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &commonpb.Metric_Gauge{Gauge: value},
+	}
+}

--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -25,13 +25,13 @@ func NewMetricsService(source metricsSource) *MetricsService {
 }
 
 // GetMetrics returns a snapshot of all route module metrics.
-func (m *MetricsService) GetMetrics(ctx context.Context, req *routepb.GetMetricsRequest) (*routepb.GetMetricsResponse, error) {
+func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetricsRequest) (*commonpb.GetMetricsResponse, error) {
 	all, err := m.source.Metrics()
 	if err != nil {
 		return nil, err
 	}
 
-	return &routepb.GetMetricsResponse{Metrics: all}, nil
+	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
 func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	cpffi "github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
@@ -41,11 +42,12 @@ func WithLog(log *zap.Logger) Option {
 // yanet-route-operator agent rebuilds the FIB and pushes it via
 // UpdateFIB.
 type RouteModule struct {
-	cfg     *Config
-	shm     *cpffi.SharedMemory
-	agent   *cpffi.Agent
-	service *RouteService
-	log     *zap.Logger
+	cfg            *Config
+	shm            *cpffi.SharedMemory
+	agent          *cpffi.Agent
+	service        *RouteService
+	metricsService *MetricsService
+	log            *zap.Logger
 }
 
 // NewRouteModule creates a new RouteModule.
@@ -72,14 +74,23 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
 
-	service := NewRouteService(NewBackend(agent), WithRouteServiceLog(log))
+	service := NewRouteService(
+		NewBackend(agent),
+		WithRouteServiceLog(log),
+		WithMetrics(grpcmetrics.NewFactory(
+			grpcmetrics.WithLabeler(labeler),
+		)),
+	)
+
+	metricsService := NewMetricsService(service)
 
 	return &RouteModule{
-		cfg:     cfg,
-		shm:     shm,
-		agent:   agent,
-		service: service,
-		log:     log,
+		cfg:            cfg,
+		shm:            shm,
+		agent:          agent,
+		service:        service,
+		metricsService: metricsService,
+		log:            log,
 	}, nil
 }
 
@@ -97,12 +108,25 @@ func (m *RouteModule) Endpoint() string {
 func (m *RouteModule) ServicesNames() []string {
 	return []string{
 		"modules.route.controlplane.routepb.v1.RouteService",
+		routepb.MetricsService_ServiceDesc.ServiceName,
 	}
 }
 
 // RegisterService registers the route module's gRPC service.
 func (m *RouteModule) RegisterService(server *grpc.Server) {
 	routepb.RegisterRouteServiceServer(server, m.service)
+	routepb.RegisterMetricsServiceServer(server, m.metricsService)
+}
+
+// UnaryServerInterceptors returns the gRPC unary interceptors for this
+// module.
+func (m *RouteModule) UnaryServerInterceptors() []grpc.UnaryServerInterceptor {
+	si := m.service.UnaryServerInterceptor()
+	if si == nil {
+		return nil
+	}
+
+	return []grpc.UnaryServerInterceptor{si}
 }
 
 // Close closes the module.

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -121,12 +121,12 @@ func (m *RouteModule) RegisterService(server *grpc.Server) {
 // UnaryServerInterceptors returns the gRPC unary interceptors for this
 // module.
 func (m *RouteModule) UnaryServerInterceptors() []grpc.UnaryServerInterceptor {
-	si := m.service.UnaryServerInterceptor()
-	if si == nil {
+	interceptor := m.service.UnaryServerInterceptor()
+	if interceptor == nil {
 		return nil
 	}
 
-	return []grpc.UnaryServerInterceptor{si}
+	return []grpc.UnaryServerInterceptor{interceptor}
 }
 
 // Close closes the module.

--- a/modules/route/controlplane/routepb/v1/route.proto
+++ b/modules/route/controlplane/routepb/v1/route.proto
@@ -6,6 +6,7 @@ option go_package = "github.com/yanet-platform/yanet2/modules/route/controlplane
 
 import "common/commonpb/v1/iprange.proto";
 import "common/commonpb/v1/macaddr.proto";
+import "common/commonpb/v1/metric.proto";
 
 service RouteService {
   // ListConfigs returns all route module configurations known to the
@@ -22,6 +23,12 @@ service RouteService {
   // UpdateFIB pushes a freshly-built FIB to the route module and
   // applies it atomically.
   rpc UpdateFIB(UpdateFIBRequest) returns (UpdateFIBResponse);
+}
+
+// MetricsService exposes route module metrics.
+service MetricsService {
+  // GetMetrics returns a snapshot of route module metrics.
+  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
 }
 
 // ListConfigsRequest is the request to list configurations.
@@ -90,3 +97,9 @@ message UpdateFIBRequest {
 
 // UpdateFIBResponse is the empty ack for UpdateFIB.
 message UpdateFIBResponse {}
+
+// GetMetricsRequest is the empty request for GetMetrics.
+message GetMetricsRequest {}
+
+// GetMetricsResponse contains a snapshot of route module metrics.
+message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }

--- a/modules/route/controlplane/routepb/v1/route.proto
+++ b/modules/route/controlplane/routepb/v1/route.proto
@@ -28,7 +28,7 @@ service RouteService {
 // MetricsService exposes route module metrics.
 service MetricsService {
   // GetMetrics returns a snapshot of route module metrics.
-  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+  rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
 
 // ListConfigsRequest is the request to list configurations.
@@ -97,9 +97,3 @@ message UpdateFIBRequest {
 
 // UpdateFIBResponse is the empty ack for UpdateFIB.
 message UpdateFIBResponse {}
-
-// GetMetricsRequest is the empty request for GetMetrics.
-message GetMetricsRequest {}
-
-// GetMetricsResponse contains a snapshot of route module metrics.
-message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -286,7 +286,7 @@ func (m *RouteService) collectConfigMetrics() []*commonpb.Metric {
 	for name, module := range m.configs {
 		labels := []*commonpb.Label{{Name: "config", Value: name}}
 
-		entries, err := module.DumpFIB()
+		count, err := module.FIBRangeCount()
 		if err != nil {
 			m.log.Warn("failed to collect fib metrics for config",
 				zap.String("config", name),
@@ -295,7 +295,7 @@ func (m *RouteService) collectConfigMetrics() []*commonpb.Metric {
 			continue
 		}
 
-		result = append(result, makeGauge("route_fib_entries", float64(len(entries)), labels...))
+		result = append(result, makeGauge("route_fib_entries", float64(count), labels...))
 	}
 
 	return result

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -6,10 +6,13 @@ import (
 	"sync"
 
 	"go.uber.org/zap"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
 	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
@@ -18,7 +21,8 @@ import (
 type RouteServiceOption func(*routeServiceOptions)
 
 type routeServiceOptions struct {
-	Log *zap.Logger
+	Metrics grpcmetrics.Factory
+	Log     *zap.Logger
 }
 
 func newRouteServiceOptions() *routeServiceOptions {
@@ -34,6 +38,15 @@ func WithRouteServiceLog(log *zap.Logger) RouteServiceOption {
 	}
 }
 
+// WithMetrics sets the gRPC metrics factory.
+//
+// When unset, no metrics are collected.
+func WithMetrics(factory grpcmetrics.Factory) RouteServiceOption {
+	return func(o *routeServiceOptions) {
+		o.Metrics = factory
+	}
+}
+
 // RouteService is the gRPC service implementation backing the slim
 // route-module shim.
 type RouteService struct {
@@ -46,6 +59,8 @@ type RouteService struct {
 	shmLock sync.RWMutex
 	configs map[string]ModuleHandle
 
+	metrics *grpcmetrics.ServerMetrics
+
 	log *zap.Logger
 }
 
@@ -56,10 +71,59 @@ func NewRouteService(backend Backend, options ...RouteServiceOption) *RouteServi
 		o(opts)
 	}
 
-	return &RouteService{
+	m := &RouteService{
 		backend: backend,
 		configs: map[string]ModuleHandle{},
 		log:     opts.Log,
+	}
+	if opts.Metrics != nil {
+		m.metrics = opts.Metrics(m.retention)
+	}
+
+	return m
+}
+
+// UnaryServerInterceptor returns the service's gRPC metrics interceptor, or
+// nil when metrics are not configured.
+func (m *RouteService) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	if m.metrics == nil {
+		return nil
+	}
+
+	return m.metrics.UnaryServerInterceptor()
+}
+
+// retention snapshots the live route config names and returns a predicate
+// that keeps series whose "config" label is still live (or absent).
+func (m *RouteService) retention() func(metrics.MetricID) bool {
+	m.shmLock.RLock()
+	configNames := make(map[string]struct{}, len(m.configs))
+	for name := range m.configs {
+		configNames[name] = struct{}{}
+	}
+	m.shmLock.RUnlock()
+
+	return func(id metrics.MetricID) bool {
+		config := id.Labels["config"]
+		if config == "" {
+			return true
+		}
+
+		_, ok := configNames[config]
+		return ok
+	}
+}
+
+func labeler(fullMethod string, req any) metrics.Labels {
+	switch r := req.(type) {
+	case *routepb.DeleteConfigRequest:
+		return metrics.Labels{"config": r.GetName()}
+	case *routepb.ShowFIBRequest:
+		return metrics.Labels{"config": r.GetName()}
+	case *routepb.UpdateFIBRequest:
+		return metrics.Labels{"config": r.GetModuleName()}
+	default:
+		return nil
 	}
 }
 
@@ -192,4 +256,47 @@ func (m *RouteService) UpdateFIB(
 	m.configs[name] = module
 
 	return &routepb.UpdateFIBResponse{}, nil
+}
+
+// Metrics returns all route module metrics: per-config FIB size gauges, plus
+// gRPC call metrics.
+//
+// Labels:
+//   - config:       route config name (all gauge metrics)
+//   - grpc_type:    always "unary" (gRPC metrics)
+//   - grpc_service: fully-qualified gRPC service name (gRPC metrics)
+//   - grpc_method:  RPC name (gRPC metrics)
+//   - grpc_code:    gRPC status code string (grpc_server_handled_total only)
+func (m *RouteService) Metrics() ([]*commonpb.Metric, error) {
+	metrics := m.collectConfigMetrics()
+	if m.metrics != nil {
+		metrics = append(metrics, m.metrics.Collect()...)
+	}
+	return metrics, nil
+}
+
+// collectConfigMetrics gathers per-config gauges on a best-effort basis: a
+// dump failure for one config is logged and skipped so the remaining configs
+// still contribute their series.
+func (m *RouteService) collectConfigMetrics() []*commonpb.Metric {
+	m.shmLock.RLock()
+	defer m.shmLock.RUnlock()
+
+	result := make([]*commonpb.Metric, 0, len(m.configs))
+	for name, module := range m.configs {
+		labels := []*commonpb.Label{{Name: "config", Value: name}}
+
+		entries, err := module.DumpFIB()
+		if err != nil {
+			m.log.Warn("failed to collect fib metrics for config",
+				zap.String("config", name),
+				zap.Error(err),
+			)
+			continue
+		}
+
+		result = append(result, makeGauge("route_fib_entries", float64(len(entries)), labels...))
+	}
+
+	return result
 }

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -268,11 +268,11 @@ func (m *RouteService) UpdateFIB(
 //   - grpc_method:  RPC name (gRPC metrics)
 //   - grpc_code:    gRPC status code string (grpc_server_handled_total only)
 func (m *RouteService) Metrics() ([]*commonpb.Metric, error) {
-	metrics := m.collectConfigMetrics()
+	result := m.collectConfigMetrics()
 	if m.metrics != nil {
-		metrics = append(metrics, m.metrics.Collect()...)
+		result = append(result, m.metrics.Collect()...)
 	}
-	return metrics, nil
+	return result, nil
 }
 
 // collectConfigMetrics gathers per-config gauges on a best-effort basis: a


### PR DESCRIPTION
- Adds a MetricsService.GetMetrics RPC to the route module controlplane, mirroring the pattern already used by ACL.
- Exposes a route_fib_entries gauge per live config plus automatic per-RPC gRPC call metrics (started/handled/latency) for RouteService.