### PR TITLE
feat(route): track FIB entry count in croute bindings

### DIFF
--- a/modules/route/bindings/go/croute/safe.go
+++ b/modules/route/bindings/go/croute/safe.go
@@ -120,3 +120,20 @@ func (m *ModuleConfig) DumpFIB() ([]FIBEntry, error) {
 
 	return entries, nil
 }
+
+// FIBRangeCount returns the number of FIB ranges, equivalent to
+// len(DumpFIB()) but far cheaper — use it when only the count is needed,
+// e.g. for a metrics gauge.
+func (m *ModuleConfig) FIBRangeCount() (int, error) {
+	iter, err := newFIBIter(m)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create FIB iterator: %w", err)
+	}
+	defer iter.destroy()
+
+	count := 0
+	for iter.next() {
+		count++
+	}
+	return count, nil
+}

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -17,6 +17,9 @@ import (
 // memory.
 type ModuleHandle interface {
 	DumpFIB() ([]croute.FIBEntry, error)
+	// FIBRangeCount returns the number of FIB ranges, equivalent to
+	// len(DumpFIB()) but far cheaper to compute.
+	FIBRangeCount() (int, error)
 	Free()
 }
 


### PR DESCRIPTION
Adds FIBRangeCount() to croute.ModuleConfig, reusing the same FIB iterator DumpFIB walks internally but skipping nexthop resolution and entry allocation.

This gives a count that matches len(DumpFIB()) exactly, without materializing the full FIB. An earlier version of this PR tracked a separately-incremented counter of successful AddPrefix calls, but that diverges from the DumpFIB range count whenever prefixes overlap or share a nexthop set, so it was replaced with this iterator-based approach.

#1379 currently computes its route_fib_entries metric via len(DumpFIB()), which materializes the whole FIB under a read lock on every scrape. Once this merges, that PR will switch to FIBRangeCount() instead.