### PR TITLE
feat(route): carry BIRD ifindex attribute into the RIB

### DIFF
--- a/operators/bird-adapter/internal/bird/update.go
+++ b/operators/bird-adapter/internal/bird/update.go
@@ -35,28 +35,29 @@ const (
 	//NetMAX     = 11
 
 	// yabird/proto/export/export.c#L94
-	AttrOrigin        AttributeType = 0x01 /* RFC 4271 */ /* WM */
-	AttrLocalPref     AttributeType = 0x05 /* WD */
-	AttrMultiExitDisc AttributeType = 0x04 /* ON */
-	AttrOriginatorID  AttributeType = 0x09 /* RFC 4456 */ /* ON */
+	AttrOrigin        AttributeType = 0x0401 /* RFC 4271 */ /* WM */
+	AttrLocalPref     AttributeType = 0x0405 /* WD */
+	AttrMultiExitDisc AttributeType = 0x0404 /* ON */
+	AttrOriginatorID  AttributeType = 0x0409 /* RFC 4456 */ /* ON */
+	AttrIfindex       AttributeType = 0x1200 /* yanet: egress interface index (u32) */
 
-	AttrASPath         AttributeType = 0x02 /* WM */
-	AttrNextHop        AttributeType = 0x03 /* WM */
-	AttrCommunity      AttributeType = 0x08 /* RFC 1997 */ /* OT */
-	AttrExtCommunity   AttributeType = 0x10 /* RFC 4360 */
-	AttrLargeCommunity AttributeType = 0x20 /* RFC 8092 */
-	AttrMPLSLabelStack AttributeType = 0xfe /* MPLS label stack transfer attribute */
-	AttrClusterList    AttributeType = 0x0a /* RFC 4456 */ /* ON */
+	AttrASPath         AttributeType = 0x0402 /* WM */
+	AttrNextHop        AttributeType = 0x0403 /* WM */
+	AttrCommunity      AttributeType = 0x0408 /* RFC 1997 */ /* OT */
+	AttrExtCommunity   AttributeType = 0x0410 /* RFC 4360 */
+	AttrLargeCommunity AttributeType = 0x0420 /* RFC 8092 */
+	AttrMPLSLabelStack AttributeType = 0x04fe /* MPLS label stack transfer attribute */
+	AttrClusterList    AttributeType = 0x040a /* RFC 4456 */ /* ON */
 
-	AttrMPReachNLRI   AttributeType = 0x0e /* RFC 4760 */
-	AttrMPUnreachNLRI AttributeType = 0x0f /* RFC 4760 */
+	AttrMPReachNLRI   AttributeType = 0x040e /* RFC 4760 */
+	AttrMPUnreachNLRI AttributeType = 0x040f /* RFC 4760 */
 
-	// AtomicAggr     AttributeType = 0x06 /* WD */
-	// Aggregator     AttributeType = 0x07 /* OT */
-	// AS4Path        AttributeType = 0x11 /* RFC 6793 */
-	// AS4Aggregator  AttributeType = 0x12 /* RFC 6793 */
-	// AIGP           AttributeType = 0x1a /* RFC 7311 */
-	// OnlyToCustomer AttributeType = 0x23 /* RFC 9234 */
+	// AtomicAggr     AttributeType = 0x0406 /* WD */
+	// Aggregator     AttributeType = 0x0407 /* OT */
+	// AS4Path        AttributeType = 0x0411 /* RFC 6793 */
+	// AS4Aggregator  AttributeType = 0x0412 /* RFC 6793 */
+	// AIGP           AttributeType = 0x041a /* RFC 7311 */
+	// OnlyToCustomer AttributeType = 0x0423 /* RFC 9234 */
 
 	ASPathSet            = 1 /* Types of path segments */
 	ASPathSequence       = 2
@@ -79,7 +80,7 @@ var (
 	ErrUnsupportedRDType = errors.New("ErrUnsupportedRDType")
 )
 
-type AttributeType uint8
+type AttributeType uint16
 
 func (m AttributeType) String() string {
 	switch m {
@@ -91,6 +92,8 @@ func (m AttributeType) String() string {
 		return "MED"
 	case AttrOriginatorID:
 		return "ORIGINATOR_ID"
+	case AttrIfindex:
+		return "IFINDEX"
 	case AttrASPath:
 		return "AS_PATH"
 	case AttrNextHop:
@@ -110,7 +113,7 @@ func (m AttributeType) String() string {
 	case AttrMPUnreachNLRI:
 		return "MP_UNREACH_NLRI"
 	default:
-		return fmt.Sprintf("UNKNOWN: %x", uint8(m))
+		return fmt.Sprintf("UNKNOWN: %x", uint16(m))
 	}
 }
 
@@ -120,6 +123,7 @@ func (m AttributeType) isU32Attribute() bool {
 	case AttrOriginatorID:
 	case AttrLocalPref:
 	case AttrMultiExitDisc:
+	case AttrIfindex:
 	default:
 		return false
 	}
@@ -294,7 +298,7 @@ func (m *updateDecoder) decodePrefixAndRD(route *rib.Route) error {
 }
 
 func ExtendedAttributeID(attributeID uint32) AttributeType {
-	return AttributeType(attributeID & 0xff)
+	return AttributeType(attributeID & 0xffff)
 }
 
 func (m *updateDecoder) decodeAttributes(route *rib.Route) error {
@@ -331,6 +335,8 @@ func (m *updateDecoder) decodeAttributes(route *rib.Route) error {
 				route.Pref = val
 			case AttrMultiExitDisc:
 				route.Med = val
+			case AttrIfindex:
+				route.Ifindex = val
 			}
 		} else {
 			attrSize = binary.LittleEndian.Uint32(data)

--- a/operators/bird-adapter/internal/bird/update_test.go
+++ b/operators/bird-adapter/internal/bird/update_test.go
@@ -379,6 +379,29 @@ func TestDecodeUpdate(t *testing.T) {
 			},
 		},
 		{
+			name: "OK ifindex attribute",
+			data: []byte{
+				0: 0x1,    // NetIP4
+				1: 0x8,    // prefix len 8
+				2: 0x8, 0, // NetAddrUnion length 8
+				4: 0, 0, 0, 1, // prefix 1.0.0.0 LE u32
+				40: 0x1, 0, 0, 0, // opType insert
+				// peer addr all zero
+				// global_id at 60 (zero)
+				64: 8, 0, 0, 0, // attrsAreaSize = 4 (type) + 4 (value) = 8
+				// AttrIfindex 0x1200: class 0x12 high byte, id 0x00 low byte
+				// (not a BGP attribute). LE u32 -> 0x1200.
+				68: 0x0, 0x12, 0, 0,
+				// ifindex value LE u32 == 10
+				72: 0xa, 0, 0, 0,
+			},
+			expected: rib.Route{
+				Prefix:  netip.MustParsePrefix("1.0.0.0/8"),
+				Peer:    netip.IPv6Unspecified(),
+				Ifindex: 10,
+			},
+		},
+		{
 			name:   "ERR Empty",
 			data:   []byte{},
 			errNew: ErrDataTooSmall,

--- a/operators/bird-adapter/internal/rib/routes.go
+++ b/operators/bird-adapter/internal/rib/routes.go
@@ -65,6 +65,10 @@ type Route struct {
 	ExtCommunities []ExtCommunity
 	// LargeCommunities are used to encode complementary route information
 	LargeCommunities []LargeCommunity
+	// Ifindex is the egress interface index advertised by BIRD.
+	//
+	// BIRD sends it as a u32 attribute (id 0x12) in the route update.
+	Ifindex uint32
 	// Med (MULTI_EXIT_DISC) guides route selection, per RFC 4271 Section 5.1.4.
 	//
 	// This field participates in route cost calculation.
@@ -129,6 +133,7 @@ func ToPBRoute(route *Route) *routepb.Route {
 		Source:           routepb.RouteSourceID(route.SourceID),
 		LargeCommunities: communities,
 		GlobalId:         route.GlobalID,
+		Ifindex:          route.Ifindex,
 	}
 }
 

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -583,6 +583,8 @@ pub struct RouteEntry {
     pub med: u32,
     #[tabled(rename = "Global ID")]
     pub global_id: u32,
+    #[tabled(rename = "Ifindex")]
+    pub ifindex: u32,
     #[tabled(rename = "Communities")]
     pub communities: Communities,
 }
@@ -602,6 +604,7 @@ impl From<operatorpb::Route> for RouteEntry {
             pref: route.pref,
             med: route.med,
             global_id: route.global_id,
+            ifindex: route.ifindex,
             communities: Communities(communities),
         }
     }
@@ -931,6 +934,7 @@ mod test {
             pref: 0,
             med: 0,
             global_id: 1,
+            ifindex: 1,
             communities: Communities(vec![]),
         }
     }

--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -44,6 +44,9 @@ type Route struct {
 	// re-announcing a prefix reuses the same GlobalID, so it drives the BGP
 	// implicit-replace decision.
 	GlobalID uint32
+	// Ifindex is the egress interface index advertised by BIRD as a u32
+	// route attribute.
+	Ifindex uint32
 	// RD stands for Route Distinguisher, as defined in RFC 4364.
 	//
 	// This field is used to distinguish similar routes to different systems.

--- a/operators/route/operatorpb/v1/convert.go
+++ b/operators/route/operatorpb/v1/convert.go
@@ -34,6 +34,7 @@ func FromRIBRoute(route *rib.Route, isBest bool) *Route {
 		LargeCommunities: communities,
 		IsBest:           isBest,
 		GlobalId:         route.GlobalID,
+		Ifindex:          route.Ifindex,
 	}
 }
 
@@ -86,6 +87,7 @@ func ToRIBRoute(route *Route, toRemove bool) (*rib.Route, error) {
 		NextHop:          nexthop,
 		Peer:             peer,
 		GlobalID:         route.GetGlobalId(),
+		Ifindex:          route.GetIfindex(),
 		RD:               route.GetRouteDistinguisher(),
 		LargeCommunities: largeCommunities,
 		UpdatedAt:        time.Now(),

--- a/operators/route/operatorpb/v1/route.proto
+++ b/operators/route/operatorpb/v1/route.proto
@@ -142,6 +142,9 @@ message Route {
   // GlobalID identifies the peer globally, as reported by BIRD on the wire
   // immediately after the peer address.
   uint32 global_id = 13;
+  // Ifindex is the egress interface index advertised by BIRD as a u32
+  // route attribute.
+  uint32 ifindex = 14;
 }
 
 // LargeCommunity represents a BGP Large Community value.


### PR DESCRIPTION
BIRD advertises the egress interface index as a u32 route attribute (id 0x12). The bird-adapter decodes it and forwards it through the route operator protocol into the route operator RIB, where it is retained alongside the other route attributes.

Also widen AttributeType to 16 bits and fold class byte into the attribute constants and the wire decode so the full id is matched rather than only the low byte.