### PR TITLE
refactor(dataplane): build per-worker execution contexts for counters

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -776,7 +776,7 @@ stat_thread_collect_xstat(struct dataplane *dataplane) {
 				uint32_t counter_id =
 					instance->device_xstat_map[device_idx]
 								  [xstat_idx];
-				*counter_get_address(counter_id, 0, storage) =
+				*counter_get_address(counter_id, storage) =
 					xstats[xstat_idx].value;
 			}
 		}

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -299,8 +299,9 @@ worker_loop_round(struct dataplane_worker *worker) {
 	struct cp_config *cp_config = worker->instance->cp_config;
 	struct cp_config_gen *cp_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
-	struct config_gen_ectx *config_gen_ectx =
-		ADDR_OF(&cp_config_gen->config_gen_ectx);
+	struct config_gen_ectx *config_gen_ectx = cp_config_gen_worker_ectx(
+		cp_config_gen, worker->dp_worker->idx
+	);
 
 	__atomic_store_n(
 		&worker->dp_worker->gen, cp_config_gen->gen, __ATOMIC_RELEASE
@@ -526,57 +527,27 @@ dataplane_worker_start(struct dataplane_worker *worker) {
 
 	struct dp_worker *dp_worker = worker->dp_worker;
 	struct dp_config *dp_config = worker->instance->dp_config;
+	struct counter_storage **worker_counter_storages =
+		ADDR_OF(&dp_config->worker_counter_storages);
+	struct counter_storage *worker_counter_storage =
+		ADDR_OF(worker_counter_storages + dp_worker->idx);
 	// FIXME: do not use hard-coded counter identifiers
-	dp_worker->iterations = counter_get_address(
-		0, dp_worker->idx, ADDR_OF(&dp_config->worker_counter_storage)
-	);
+	dp_worker->iterations = counter_get_address(0, worker_counter_storage);
 
 	dp_worker->rx_count =
-		counter_get_address(
-			1,
-			dp_worker->idx,
-			ADDR_OF(&dp_config->worker_counter_storage)
-		) +
-		0;
-	dp_worker->rx_size = counter_get_address(
-				     1,
-				     dp_worker->idx,
-				     ADDR_OF(&dp_config->worker_counter_storage)
-			     ) +
-			     1;
+		counter_get_address(1, worker_counter_storage) + 0;
+	dp_worker->rx_size = counter_get_address(1, worker_counter_storage) + 1;
 
 	dp_worker->tx_count =
-		counter_get_address(
-			2,
-			dp_worker->idx,
-			ADDR_OF(&dp_config->worker_counter_storage)
-		) +
-		0;
-	dp_worker->tx_size = counter_get_address(
-				     2,
-				     dp_worker->idx,
-				     ADDR_OF(&dp_config->worker_counter_storage)
-			     ) +
-			     1;
+		counter_get_address(2, worker_counter_storage) + 0;
+	dp_worker->tx_size = counter_get_address(2, worker_counter_storage) + 1;
 
 	dp_worker->remote_rx_count =
-		counter_get_address(
-			3,
-			dp_worker->idx,
-			ADDR_OF(&dp_config->worker_counter_storage)
-		) +
-		0;
+		counter_get_address(3, worker_counter_storage) + 0;
 
 	dp_worker->remote_tx_count =
-		counter_get_address(
-			4,
-			dp_worker->idx,
-			ADDR_OF(&dp_config->worker_counter_storage)
-		) +
-		0;
-	dp_worker->rx_bursts = counter_get_address(
-		5, dp_worker->idx, ADDR_OF(&dp_config->worker_counter_storage)
-	);
+		counter_get_address(4, worker_counter_storage) + 0;
+	dp_worker->rx_bursts = counter_get_address(5, worker_counter_storage);
 
 	pthread_attr_t wrk_th_attr;
 	pthread_attr_init(&wrk_th_attr);

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -19,6 +19,7 @@
 #include "controlplane/config/zone.h"
 #include "counters/counters.h"
 #include "dataplane/config/zone.h"
+#include "dataplane/pipeline/econtext.h"
 
 #include "lib/errors/errors.h"
 
@@ -1486,22 +1487,46 @@ cp_counter_storage_copy_tags(const struct cp_counter_storage *storage) {
 	return tags;
 }
 
-static void
+// Build a per-worker value-handle array for one counter and stash it behind
+// the opaque counter_handle.value_handle.
+//
+// Each worker has its own single-instance storage. The caller gathers one
+// storage per worker into worker_storages (a plain C-pointer array). The
+// result (worker_count entries) is read back by yanet_get_counter_value(s)
+// and released by yanet_counter_handle_list_free.
+static int
 fill_counter_handle(
 	struct counter_handle *dst,
-	struct counter_storage *counter_storage,
+	struct counter_storage **worker_storages,
+	uint64_t worker_count,
 	uint64_t idx,
 	struct counter_tag *tags,
 	size_t tag_count
 ) {
-	struct counter_registry *reg = ADDR_OF(&counter_storage->registry);
+	struct counter_storage *storage0 = worker_storages[0];
+	struct counter_registry *reg = ADDR_OF(&storage0->registry);
 	struct counter *counters = ADDR_OF(&reg->names);
 	strtcpy(dst->name, counters[idx].name, sizeof(dst->name));
 	dst->size = counters[idx].size;
 	dst->gen = counters[idx].gen;
-	dst->value_handle = counter_get_value_handle(idx, counter_storage);
+
+	// Attach the tags before the fallible allocation so the list free path
+	// reclaims them even when this handle's value array is left NULL.
 	dst->tags = tags;
 	dst->tag_count = tag_count;
+
+	struct counter_value_handle **bases =
+		malloc(worker_count * sizeof(*bases));
+	if (bases == NULL) {
+		return -1;
+	}
+	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+		bases[worker_idx] = counter_get_value_handle(
+			idx, worker_storages[worker_idx]
+		);
+	}
+	dst->value_handle = (struct counter_value_handle *)bases;
+	return 0;
 }
 
 struct counter_handle_list *
@@ -1518,26 +1543,55 @@ yanet_get_counters_by_tags(
 
 	struct cp_config_gen *cp_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
+	uint64_t worker_count = dp_config->worker_count;
 
-	struct cp_counter_storage **storages =
-		cp_config_counter_storage_registry_find(
-			&cp_config_gen->counter_storage_registry,
-			tags,
-			tag_count,
-			err
-		);
-	if (storages == NULL) {
+	// Find matching counter storages in each worker's registry.
+	//
+	// Every worker registry is built by the same ectx traversal, so the
+	// tag-set match order is identical across workers: for match index i,
+	// worker_matches[w][i] holds the same tag-set for every worker w.
+	struct cp_counter_storage ***worker_matches =
+		calloc(worker_count, sizeof(*worker_matches));
+	if (worker_matches == NULL) {
+		yanet_error_add(err, "malloc failed");
 		cp_config_unlock(cp_config);
 		return NULL;
 	}
 
+	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+		struct config_gen_ectx *ectx =
+			cp_config_gen_worker_ectx(cp_config_gen, worker_idx);
+		if (ectx == NULL) {
+			worker_matches[worker_idx] = NULL;
+			continue;
+		}
+		worker_matches[worker_idx] =
+			cp_config_counter_storage_registry_find(
+				ADDR_OF(&ectx->counter_storage_registry),
+				tags,
+				tag_count,
+				err
+			);
+		if (worker_matches[worker_idx] == NULL) {
+			goto err_matches;
+		}
+	}
+
+	// Use worker 0's matches as the reference. When worker 0 has no ectx
+	// (e.g. the initial config gen before any install), return an empty
+	// list.
+	struct cp_counter_storage **matches0 =
+		worker_count > 0 ? worker_matches[0] : NULL;
+
 	size_t match_count = 0;
-	for (size_t i = 0; storages[i] != NULL; ++i) {
-		struct counter_storage *storage =
-			ADDR_OF(&storages[i]->storage);
-		match_count += counter_registry_match_count(
-			ADDR_OF(&storage->registry), query, query_count
-		);
+	if (matches0 != NULL) {
+		for (size_t i = 0; matches0[i] != NULL; ++i) {
+			struct counter_storage *storage =
+				ADDR_OF(&matches0[i]->storage);
+			match_count += counter_registry_match_count(
+				ADDR_OF(&storage->registry), query, query_count
+			);
+		}
 	}
 
 	size_t list_size = sizeof(struct counter_handle_list) +
@@ -1546,15 +1600,15 @@ yanet_get_counters_by_tags(
 		(struct counter_handle_list *)malloc(list_size);
 	if (list == NULL) {
 		yanet_error_add(err, "malloc failed");
-		goto err_find;
+		goto err_matches;
 	}
 	memset(list, 0, list_size);
-	list->instance_count = dp_config->worker_count;
+	list->instance_count = worker_count;
 	list->count = match_count;
 
 	size_t next = 0;
-	for (size_t i = 0; storages[i] != NULL; ++i) {
-		struct cp_counter_storage *cp_storage = storages[i];
+	for (size_t i = 0; matches0 != NULL && matches0[i] != NULL; ++i) {
+		struct cp_counter_storage *cp_storage = matches0[i];
 		struct counter_storage *storage = ADDR_OF(&cp_storage->storage);
 		struct counter_registry *registry = ADDR_OF(&storage->registry);
 		struct counter *counters = ADDR_OF(&registry->names);
@@ -1574,24 +1628,49 @@ yanet_get_counters_by_tags(
 					goto err_list;
 				}
 			}
-			fill_counter_handle(
+			struct counter_storage **worker_storages =
+				malloc(worker_count * sizeof(*worker_storages));
+			if (worker_storages == NULL) {
+				free(worker_storages);
+				yanet_error_add(err, "malloc failed");
+				goto err_list;
+			}
+			for (uint64_t worker_idx = 0; worker_idx < worker_count;
+			     ++worker_idx) {
+				worker_storages[worker_idx] = ADDR_OF(
+					&worker_matches[worker_idx][i]->storage
+				);
+			}
+			int fill_result = fill_counter_handle(
 				&list->counters[next++],
-				storage,
+				worker_storages,
+				worker_count,
 				idx,
 				storage_tags,
 				cp_storage->tag_count
 			);
+			free(worker_storages);
+			if (fill_result) {
+				yanet_error_add(err, "malloc failed");
+				goto err_list;
+			}
 		}
 	}
 
+	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+		free(worker_matches[worker_idx]);
+	}
+	free(worker_matches);
 	cp_config_unlock(cp_config);
-	free(storages);
 	return list;
 
 err_list:
 	yanet_counter_handle_list_free(list);
-err_find:
-	free(storages);
+err_matches:
+	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+		free(worker_matches[worker_idx]);
+	}
+	free(worker_matches);
 	cp_config_unlock(cp_config);
 	return NULL;
 }
@@ -1668,7 +1747,9 @@ yanet_get_counter_value(
 	uint64_t value_idx,
 	uint64_t worker_idx
 ) {
-	return counter_handle_get_value(value_handle, worker_idx)[value_idx];
+	struct counter_value_handle **bases =
+		(struct counter_value_handle **)value_handle;
+	return counter_handle_get_value(bases[worker_idx])[value_idx];
 }
 
 void
@@ -1678,8 +1759,10 @@ yanet_get_counter_values(
 	uint64_t instance_count,
 	uint64_t *values
 ) {
+	struct counter_value_handle **bases =
+		(struct counter_value_handle **)value_handle;
 	for (uint64_t iidx = 0; iidx < instance_count; ++iidx) {
-		uint64_t *src = counter_handle_get_value(value_handle, iidx);
+		uint64_t *src = counter_handle_get_value(bases[iidx]);
 		memcpy(values + iidx * size, src, size * sizeof(uint64_t));
 	}
 }
@@ -1687,10 +1770,10 @@ yanet_get_counter_values(
 static struct counter_handle_list *
 counter_handle_list_build(
 	struct counter_registry *counter_registry,
-	struct counter_storage *storage
+	struct counter_storage **storages,
+	uint64_t worker_count
 ) {
 	uint64_t count = counter_registry->count;
-	struct counter *names = ADDR_OF(&counter_registry->names);
 
 	struct counter_handle_list *list = (struct counter_handle_list *)malloc(
 		sizeof(struct counter_handle_list) +
@@ -1699,20 +1782,45 @@ counter_handle_list_build(
 
 	if (list == NULL)
 		return NULL;
-	list->instance_count = ADDR_OF(&storage->allocator)->instance_count;
+	list->instance_count = worker_count;
 	list->count = count;
 	struct counter_handle *handlers = list->counters;
 
 	for (uint64_t idx = 0; idx < count; ++idx) {
-		strtcpy(handlers[idx].name, names[idx].name, 60);
-		handlers[idx].size = names[idx].size;
-		handlers[idx].gen = names[idx].gen;
-		handlers[idx].value_handle =
-			counter_get_value_handle(idx, storage);
 		handlers[idx].tag_count = 0;
 		handlers[idx].tags = NULL;
+		handlers[idx].value_handle = NULL;
 	}
 
+	// storages holds one offset-pointer cell per worker; materialize a
+	// plain storage pointer per worker before handing them to
+	// fill_counter_handle, which indexes the array directly.
+	struct counter_storage **worker_storages =
+		malloc(worker_count * sizeof(*worker_storages));
+	if (worker_storages == NULL) {
+		yanet_counter_handle_list_free(list);
+		return NULL;
+	}
+	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+		worker_storages[worker_idx] = ADDR_OF(storages + worker_idx);
+	}
+
+	for (uint64_t idx = 0; idx < count; ++idx) {
+		if (fill_counter_handle(
+			    &handlers[idx],
+			    worker_storages,
+			    worker_count,
+			    idx,
+			    NULL,
+			    0
+		    )) {
+			free(worker_storages);
+			yanet_counter_handle_list_free(list);
+			return NULL;
+		}
+	}
+
+	free(worker_storages);
 	return list;
 }
 
@@ -1720,7 +1828,8 @@ struct counter_handle_list *
 yanet_get_worker_counters(struct dp_config *dp_config) {
 	return counter_handle_list_build(
 		&dp_config->worker_counters,
-		ADDR_OF(&dp_config->worker_counter_storage)
+		ADDR_OF(&dp_config->worker_counter_storages),
+		dp_config->worker_counter_storage_count
 	);
 }
 
@@ -1780,7 +1889,7 @@ yanet_get_port_counters(struct dp_config *dp_config) {
 			pc->port_name,
 			sizeof(group->port_name));
 		group->counters = counter_handle_list_build(
-			&pc->registry, ADDR_OF(&pc->storage)
+			&pc->registry, &pc->storage, 1
 		);
 		if (group->counters == NULL) {
 			groups->port_count = idx;
@@ -1823,6 +1932,8 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 		if (i == 0 || handles[i].tags != handles[i - 1].tags) {
 			free(handles[i].tags);
 		}
+		// Each counter owns its own per-worker value-handle array.
+		free(handles[i].value_handle);
 	}
 	free(counters);
 }

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -467,6 +467,10 @@ cp_module_parse_performance_counter(
 	counter->min_batch_size = batch_sizes[counter_idx];
 	counter->latency_ranges_count = hist_buckets;
 
+	// Per-worker value handles are stored behind the opaque handle.
+	struct counter_value_handle **bases =
+		(struct counter_value_handle **)counter_handle->value_handle;
+
 	// Salc summary tx and summary latency
 	counter->summary_latency = 0;
 	counter->packets = 0;
@@ -474,10 +478,7 @@ cp_module_parse_performance_counter(
 	for (size_t instance_idx = 0; instance_idx < workers; ++instance_idx) {
 		struct module_ectx_perf_counter_layout *perf_counter =
 			(struct module_ectx_perf_counter_layout *)
-				counter_handle_get_value(
-					counter_handle->value_handle,
-					instance_idx
-				);
+				counter_handle_get_value(bases[instance_idx]);
 		counter->summary_latency += perf_counter->summary_latency;
 		counter->packets += perf_counter->packets;
 		counter->bytes += perf_counter->bytes;
@@ -501,8 +502,7 @@ cp_module_parse_performance_counter(
 			struct module_ectx_perf_counter_layout *perf_counter =
 				(struct module_ectx_perf_counter_layout *)
 					counter_handle_get_value(
-						counter_handle->value_handle,
-						worker_idx
+						bases[worker_idx]
 					);
 			latency_range->batches +=
 				perf_counter->batch_count[range_idx];
@@ -554,11 +554,12 @@ cp_module_parse_tx_rx(
 	}
 
 	// Aggregate counter values across all workers
+	struct counter_value_handle **bases =
+		(struct counter_value_handle **)counter_handle->value_handle;
 	uint64_t total = 0;
 	for (size_t worker_idx = 0; worker_idx < workers; ++worker_idx) {
-		uint64_t *counter_values = counter_handle_get_value(
-			counter_handle->value_handle, worker_idx
-		);
+		uint64_t *counter_values =
+			counter_handle_get_value(bases[worker_idx]);
 		// Simple counters have size=1, so we access index 0
 		total += counter_values[0];
 	}

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -49,6 +49,7 @@ module_ectx_create(
 	struct pipeline_ectx *pipeline_ectx,
 	struct function_ectx *function_ectx,
 	struct chain_ectx *chain_ectx,
+	uint64_t worker_idx,
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
@@ -88,20 +89,24 @@ module_ectx_create(
 	struct cp_function *cp_function = ADDR_OF(&function_ectx->cp_function);
 	struct cp_chain *cp_chain = ADDR_OF(&chain_ectx->cp_chain);
 
-	struct counter_storage *old_counter_storage =
-		cp_config_counter_storage_registry_lookup_module(
-			&old_config_gen->counter_storage_registry,
-			cp_device->name,
-			cp_pipeline->name,
-			cp_function->name,
-			cp_chain->name,
-			cp_module->type,
-			cp_module->name
-		);
+	struct counter_storage *old_counter_storage = NULL;
+	struct config_gen_ectx *old_ectx =
+		cp_config_gen_worker_ectx(old_config_gen, worker_idx);
+	if (old_ectx != NULL) {
+		old_counter_storage =
+			cp_config_counter_storage_registry_lookup_module(
+				ADDR_OF(&old_ectx->counter_storage_registry),
+				cp_device->name,
+				cp_pipeline->name,
+				cp_function->name,
+				cp_chain->name,
+				cp_module->type,
+				cp_module->name
+			);
+	}
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
 		&cp_config->counter_storage_memory_context,
-		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_module->counter_registry
 	);
@@ -116,7 +121,7 @@ module_ectx_create(
 	}
 
 	if (cp_config_counter_storage_registry_insert_module(
-		    &cp_config_gen->counter_storage_registry,
+		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
 		    cp_device->name,
 		    cp_pipeline->name,
 		    cp_function->name,
@@ -186,6 +191,7 @@ chain_ectx_create(
 	struct device_ectx *device_ectx,
 	struct pipeline_ectx *pipeline_ectx,
 	struct function_ectx *function_ectx,
+	uint64_t worker_idx,
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
@@ -212,18 +218,22 @@ chain_ectx_create(
 	struct cp_pipeline *cp_pipeline = ADDR_OF(&pipeline_ectx->cp_pipeline);
 	struct cp_function *cp_function = ADDR_OF(&function_ectx->cp_function);
 
-	struct counter_storage *old_counter_storage =
-		cp_config_counter_storage_registry_lookup_chain(
-			&old_config_gen->counter_storage_registry,
-			cp_device->name,
-			cp_pipeline->name,
-			cp_function->name,
-			cp_chain->name
-		);
+	struct counter_storage *old_counter_storage = NULL;
+	struct config_gen_ectx *old_ectx =
+		cp_config_gen_worker_ectx(old_config_gen, worker_idx);
+	if (old_ectx != NULL) {
+		old_counter_storage =
+			cp_config_counter_storage_registry_lookup_chain(
+				ADDR_OF(&old_ectx->counter_storage_registry),
+				cp_device->name,
+				cp_pipeline->name,
+				cp_function->name,
+				cp_chain->name
+			);
+	}
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
 		&cp_config->counter_storage_memory_context,
-		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_chain->counter_registry
 	);
@@ -237,7 +247,7 @@ chain_ectx_create(
 	}
 
 	if (cp_config_counter_storage_registry_insert_chain(
-		    &cp_config_gen->counter_storage_registry,
+		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
 		    cp_device->name,
 		    cp_pipeline->name,
 		    cp_function->name,
@@ -285,6 +295,7 @@ chain_ectx_create(
 			pipeline_ectx,
 			function_ectx,
 			chain_ectx,
+			worker_idx,
 			err
 		);
 		if (module_ectx == NULL) {
@@ -356,6 +367,7 @@ function_ectx_create(
 	struct config_gen_ectx *config_gen_ectx,
 	struct device_ectx *device_ectx,
 	struct pipeline_ectx *pipeline_ectx,
+	uint64_t worker_idx,
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
@@ -405,17 +417,21 @@ function_ectx_create(
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
 	struct cp_pipeline *cp_pipeline = ADDR_OF(&pipeline_ectx->cp_pipeline);
 
-	struct counter_storage *old_counter_storage =
-		cp_config_counter_storage_registry_lookup_function(
-			&old_config_gen->counter_storage_registry,
-			cp_device->name,
-			cp_pipeline->name,
-			cp_function->name
-		);
+	struct counter_storage *old_counter_storage = NULL;
+	struct config_gen_ectx *old_ectx =
+		cp_config_gen_worker_ectx(old_config_gen, worker_idx);
+	if (old_ectx != NULL) {
+		old_counter_storage =
+			cp_config_counter_storage_registry_lookup_function(
+				ADDR_OF(&old_ectx->counter_storage_registry),
+				cp_device->name,
+				cp_pipeline->name,
+				cp_function->name
+			);
+	}
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
 		&cp_config->counter_storage_memory_context,
-		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_function->counter_registry
 	);
@@ -429,7 +445,7 @@ function_ectx_create(
 	}
 
 	if (cp_config_counter_storage_registry_insert_function(
-		    &cp_config_gen->counter_storage_registry,
+		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
 		    cp_device->name,
 		    cp_pipeline->name,
 		    cp_function->name,
@@ -470,6 +486,7 @@ function_ectx_create(
 			device_ectx,
 			pipeline_ectx,
 			function_ectx,
+			worker_idx,
 			err
 		);
 		if (chain_ectx == NULL) {
@@ -527,6 +544,7 @@ pipeline_ectx_create(
 	struct cp_config_gen *old_config_gen,
 	struct config_gen_ectx *config_gen_ectx,
 	struct device_ectx *device_ectx,
+	uint64_t worker_idx,
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
@@ -551,16 +569,20 @@ pipeline_ectx_create(
 
 	struct cp_device *cp_device = ADDR_OF(&device_ectx->cp_device);
 
-	struct counter_storage *old_counter_storage =
-		cp_config_counter_storage_registry_lookup_pipeline(
-			&old_config_gen->counter_storage_registry,
-			cp_device->name,
-			cp_pipeline->name
-		);
+	struct counter_storage *old_counter_storage = NULL;
+	struct config_gen_ectx *old_ectx =
+		cp_config_gen_worker_ectx(old_config_gen, worker_idx);
+	if (old_ectx != NULL) {
+		old_counter_storage =
+			cp_config_counter_storage_registry_lookup_pipeline(
+				ADDR_OF(&old_ectx->counter_storage_registry),
+				cp_device->name,
+				cp_pipeline->name
+			);
+	}
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
 		&cp_config->counter_storage_memory_context,
-		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_pipeline->counter_registry
 	);
@@ -574,7 +596,7 @@ pipeline_ectx_create(
 	}
 
 	if (cp_config_counter_storage_registry_insert_pipeline(
-		    &cp_config_gen->counter_storage_registry,
+		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
 		    cp_device->name,
 		    cp_pipeline->name,
 		    counter_storage,
@@ -623,6 +645,7 @@ pipeline_ectx_create(
 			config_gen_ectx,
 			device_ectx,
 			pipeline_ectx,
+			worker_idx,
 			err
 		);
 		if (function_ectx == NULL) {
@@ -683,6 +706,7 @@ device_entry_ectx_create(
 	device_handler handler,
 	struct cp_device_entry *cp_device_entry,
 	struct cp_config_gen *old_config_gen,
+	uint64_t worker_idx,
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&new_config_gen->cp_config);
@@ -757,6 +781,7 @@ device_entry_ectx_create(
 			old_config_gen,
 			config_gen_ectx,
 			device_ectx,
+			worker_idx,
 			err
 		);
 		if (pipeline_ectx == NULL) {
@@ -811,6 +836,7 @@ device_ectx_create(
 	struct cp_device *cp_device,
 	struct config_gen_ectx *config_gen_ectx,
 	struct cp_config_gen *old_config_gen,
+	uint64_t worker_idx,
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
@@ -832,15 +858,19 @@ device_ectx_create(
 	memset(device_ectx, 0, ectx_size);
 	SET_OFFSET_OF(&device_ectx->cp_device, cp_device);
 
-	struct counter_storage *old_counter_storage =
-		cp_config_counter_storage_registry_lookup_device(
-			&old_config_gen->counter_storage_registry,
-			cp_device->name
-		);
+	struct counter_storage *old_counter_storage = NULL;
+	struct config_gen_ectx *old_ectx =
+		cp_config_gen_worker_ectx(old_config_gen, worker_idx);
+	if (old_ectx != NULL) {
+		old_counter_storage =
+			cp_config_counter_storage_registry_lookup_device(
+				ADDR_OF(&old_ectx->counter_storage_registry),
+				cp_device->name
+			);
+	}
 
 	struct counter_storage *counter_storage = counter_storage_spawn(
 		&cp_config->counter_storage_memory_context,
-		&cp_config->counter_storage_allocator,
 		old_counter_storage,
 		&cp_device->counter_registry
 	);
@@ -854,7 +884,7 @@ device_ectx_create(
 	}
 
 	if (cp_config_counter_storage_registry_insert_device(
-		    &cp_config_gen->counter_storage_registry,
+		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
 		    cp_device->name,
 		    counter_storage,
 		    err
@@ -887,6 +917,7 @@ device_ectx_create(
 		dp_device->input_handler,
 		ADDR_OF(&cp_device->input_pipelines),
 		old_config_gen,
+		worker_idx,
 		err
 	);
 	if (input == NULL) {
@@ -901,6 +932,7 @@ device_ectx_create(
 		dp_device->output_handler,
 		ADDR_OF(&cp_device->output_pipelines),
 		old_config_gen,
+		worker_idx,
 		err
 	);
 	if (output == NULL) {
@@ -934,6 +966,17 @@ config_gen_ectx_free(
 		if (device_ectx != NULL) {
 			device_ectx_free(cp_config_gen, device_ectx);
 		}
+	}
+
+	struct cp_config_counter_storage_registry *registry =
+		ADDR_OF(&config_gen_ectx->counter_storage_registry);
+	if (registry != NULL) {
+		cp_config_counter_storage_registry_fini(registry);
+		memory_bfree(
+			&cp_config->memory_context,
+			registry,
+			sizeof(struct cp_config_counter_storage_registry)
+		);
 	}
 
 	size_t ectx_size =
@@ -1232,10 +1275,11 @@ error:
 	return -1;
 }
 
-struct config_gen_ectx *
+static struct config_gen_ectx *
 config_gen_ectx_create(
 	struct cp_config_gen *cp_config_gen,
 	struct cp_config_gen *old_config_gen,
+	uint64_t worker_idx,
 	yanet_error **err
 ) {
 	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
@@ -1261,6 +1305,30 @@ config_gen_ectx_create(
 
 	SET_OFFSET_OF(&config_gen_ectx->cp_config_gen, cp_config_gen);
 
+	struct cp_config_counter_storage_registry *registry =
+		(struct cp_config_counter_storage_registry *)memory_balloc(
+			&cp_config->memory_context,
+			sizeof(struct cp_config_counter_storage_registry)
+		);
+	if (registry == NULL) {
+		yanet_error_add(
+			err, "failed to allocate counter storage registry"
+		);
+		goto error;
+	}
+	if (cp_config_counter_storage_registry_init(
+		    &cp_config->memory_context, registry, err
+	    )) {
+		memory_bfree(
+			&cp_config->memory_context,
+			registry,
+			sizeof(struct cp_config_counter_storage_registry)
+		);
+		yanet_error_add(err, "failed to init counter storage registry");
+		goto error;
+	}
+	SET_OFFSET_OF(&config_gen_ectx->counter_storage_registry, registry);
+
 	config_gen_ectx->device_count =
 		cp_device_registry_capacity(&cp_config_gen->device_registry);
 
@@ -1282,6 +1350,7 @@ config_gen_ectx_create(
 			cp_device,
 			config_gen_ectx,
 			old_config_gen,
+			worker_idx,
 			err
 		);
 		if (device_ectx == NULL) {
@@ -1305,5 +1374,70 @@ config_gen_ectx_create(
 error:
 	config_gen_ectx_free(cp_config_gen, config_gen_ectx);
 
+	return NULL;
+}
+
+struct config_gen_ectx **
+config_gen_ectxs_create(
+	struct cp_config_gen *cp_config_gen,
+	struct cp_config_gen *old_config_gen,
+	uint64_t worker_count,
+	yanet_error **err
+) {
+	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
+
+	if (worker_count == 0) {
+		yanet_error_add(
+			err, "cannot build execution context for zero workers"
+		);
+		return NULL;
+	}
+
+	struct config_gen_ectx **ectxs =
+		(struct config_gen_ectx **)memory_balloc(
+			memory_context,
+			sizeof(struct config_gen_ectx *) * worker_count
+		);
+	if (ectxs == NULL) {
+		yanet_error_add(
+			err,
+			"failed to allocate per-worker execution context array"
+		);
+		return NULL;
+	}
+	memset(ectxs, 0, sizeof(struct config_gen_ectx *) * worker_count);
+
+	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+		struct config_gen_ectx *config_gen_ectx =
+			config_gen_ectx_create(
+				cp_config_gen, old_config_gen, worker_idx, err
+			);
+		if (config_gen_ectx == NULL) {
+			yanet_error_add(
+				err,
+				"failed to build execution context for "
+				"worker %lu",
+				worker_idx
+			);
+			goto error;
+		}
+		SET_OFFSET_OF(ectxs + worker_idx, config_gen_ectx);
+	}
+
+	return ectxs;
+
+error:
+	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+		struct config_gen_ectx *config_gen_ectx =
+			ADDR_OF(ectxs + worker_idx);
+		if (config_gen_ectx != NULL)
+			config_gen_ectx_free(cp_config_gen, config_gen_ectx);
+	}
+	memory_bfree(
+		memory_context,
+		ectxs,
+		sizeof(struct config_gen_ectx *) * worker_count
+	);
 	return NULL;
 }

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -13,10 +13,16 @@ config_gen_ectx_get_device(
 	return ADDR_OF(config_gen_ectx->devices + index);
 }
 
-struct config_gen_ectx *
-config_gen_ectx_create(
+// Build one execution context per worker.
+//
+// Returns an array of worker_count offset pointers, each a config_gen_ectx
+// carrying that worker's own single-instance counter storages. Each entry is
+// released with config_gen_ectx_free; the array itself is freed by the caller.
+struct config_gen_ectx **
+config_gen_ectxs_create(
 	struct cp_config_gen *config_gen,
 	struct cp_config_gen *old_config_gen,
+	uint64_t worker_count,
 	yanet_error **err
 );
 

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -80,7 +80,8 @@ cp_config_gen_new_from(
 	}
 
 	new_config_gen->gen = old_config_gen->gen + 1;
-	new_config_gen->config_gen_ectx = NULL;
+	new_config_gen->config_gen_ectx_count = 0;
+	new_config_gen->config_gen_ectxs = NULL;
 
 	SET_OFFSET_OF(
 		&new_config_gen->dp_config, ADDR_OF(&old_config_gen->dp_config)
@@ -129,15 +130,6 @@ cp_config_gen_new_from(
 		goto error;
 	}
 
-	if (cp_config_counter_storage_registry_init(
-		    &cp_config->memory_context,
-		    &new_config_gen->counter_storage_registry,
-		    err
-	    )) {
-		yanet_error_add(err, "failed to init counter storage registry");
-		goto error;
-	}
-
 	return new_config_gen;
 
 error:
@@ -153,12 +145,27 @@ static inline void
 cp_config_gen_free(
 	struct cp_config *cp_config, struct cp_config_gen *config_gen
 ) {
-	// Free ectx first, as its internals reference
+	// Free per-worker ectx first, as their internals reference
 	// module configs, chains, functions and pipelines
-	struct config_gen_ectx *config_gen_ectx =
-		ADDR_OF(&config_gen->config_gen_ectx);
-	if (config_gen_ectx != NULL)
-		config_gen_ectx_free(config_gen, config_gen_ectx);
+	struct config_gen_ectx **config_gen_ectxs =
+		ADDR_OF(&config_gen->config_gen_ectxs);
+	if (config_gen_ectxs != NULL) {
+		for (uint64_t idx = 0; idx < config_gen->config_gen_ectx_count;
+		     ++idx) {
+			struct config_gen_ectx *config_gen_ectx =
+				ADDR_OF(config_gen_ectxs + idx);
+			if (config_gen_ectx != NULL)
+				config_gen_ectx_free(
+					config_gen, config_gen_ectx
+				);
+		}
+		memory_bfree(
+			&cp_config->ectx_memory_context,
+			config_gen_ectxs,
+			sizeof(struct config_gen_ectx *) *
+				config_gen->config_gen_ectx_count
+		);
+	}
 
 	// Then, free registries of module configs, chains,
 	// functions and pipelines
@@ -166,11 +173,6 @@ cp_config_gen_free(
 	cp_function_registry_fini(&config_gen->function_registry);
 	cp_pipeline_registry_fini(&config_gen->pipeline_registry);
 	cp_device_registry_fini(&config_gen->device_registry);
-
-	// Finally, free counter storage registry
-	cp_config_counter_storage_registry_fini(
-		&config_gen->counter_storage_registry
-	);
 
 	memory_bfree(
 		&cp_config->memory_context,
@@ -189,13 +191,17 @@ cp_config_gen_install(
 	struct cp_config_gen *old_config_gen =
 		ADDR_OF(&cp_config->cp_config_gen);
 
-	struct config_gen_ectx *new_config_gen_ectx =
-		config_gen_ectx_create(new_config_gen, old_config_gen, err);
-	if (new_config_gen_ectx == NULL) {
+	uint64_t worker_count = dp_config->worker_count;
+
+	struct config_gen_ectx **new_config_gen_ectxs = config_gen_ectxs_create(
+		new_config_gen, old_config_gen, worker_count, err
+	);
+	if (new_config_gen_ectxs == NULL) {
 		return -1;
 	}
 
-	SET_OFFSET_OF(&new_config_gen->config_gen_ectx, new_config_gen_ectx);
+	SET_OFFSET_OF(&new_config_gen->config_gen_ectxs, new_config_gen_ectxs);
+	new_config_gen->config_gen_ectx_count = worker_count;
 
 	SET_OFFSET_OF(&cp_config->cp_config_gen, new_config_gen);
 	dp_config_wait_for_gen(dp_config, new_config_gen->gen);
@@ -656,7 +662,8 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 	}
 
 	cp_config_gen->gen = 0;
-	cp_config_gen->config_gen_ectx = NULL;
+	cp_config_gen->config_gen_ectx_count = 0;
+	cp_config_gen->config_gen_ectxs = NULL;
 	SET_OFFSET_OF(
 		&cp_config_gen->dp_config, ADDR_OF(&cp_config->dp_config)
 	);
@@ -695,15 +702,6 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 		    err
 	    )) {
 		yanet_error_add(err, "failed to init device registry");
-		goto error;
-	}
-
-	if (cp_config_counter_storage_registry_init(
-		    &cp_config->memory_context,
-		    &cp_config_gen->counter_storage_registry,
-		    err
-	    )) {
-		yanet_error_add(err, "failed to init counter storage registry");
 		goto error;
 	}
 

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -42,14 +42,19 @@ struct cp_config_gen {
 
 	struct cp_config *cp_config;
 	struct dp_config *dp_config;
-	struct config_gen_ectx *config_gen_ectx;
+
+	// Per-worker execution contexts.
+	//
+	// config_gen_ectxs points to an array of config_gen_ectx_count offset
+	// pointers, one execution context per worker, each with its own
+	// single-instance counter storages.
+	uint64_t config_gen_ectx_count;
+	struct config_gen_ectx **config_gen_ectxs;
 
 	struct cp_module_registry module_registry;
 	struct cp_function_registry function_registry;
 	struct cp_pipeline_registry pipeline_registry;
 	struct cp_device_registry device_registry;
-
-	struct cp_config_counter_storage_registry counter_storage_registry;
 };
 
 /*
@@ -106,10 +111,6 @@ struct cp_config {
 	 * memory zone.
 	 */
 	struct cp_agent_registry *agent_registry;
-	/*
-	 * Allocator for counter backend storage
-	 */
-	struct counter_storage_allocator counter_storage_allocator;
 };
 
 /*
@@ -214,6 +215,20 @@ cp_config_gen_get_pipeline(struct cp_config_gen *config_gen, uint64_t index) {
 static inline struct cp_device *
 cp_config_gen_get_device(struct cp_config_gen *config_gen, uint64_t index) {
 	return cp_device_registry_get(&config_gen->device_registry, index);
+}
+
+// Return the execution context built for the given worker, or NULL when the
+// worker index is out of range or no execution context has been installed yet.
+static inline struct config_gen_ectx *
+cp_config_gen_worker_ectx(
+	struct cp_config_gen *config_gen, uint64_t worker_idx
+) {
+	if (worker_idx >= config_gen->config_gen_ectx_count)
+		return NULL;
+	struct config_gen_ectx **ectxs = ADDR_OF(&config_gen->config_gen_ectxs);
+	if (ectxs == NULL)
+		return NULL;
+	return ADDR_OF(ectxs + worker_idx);
 }
 
 struct cp_module *

--- a/lib/counters/counters.c
+++ b/lib/counters/counters.c
@@ -287,57 +287,20 @@ counter_registry_link(
 	return 0;
 }
 
-void
-counter_storage_allocator_init(
-	struct counter_storage_allocator *counter_storage_allocator,
-	struct memory_context *memory_context,
-	uint64_t instance_count
-) {
-	memory_context_init_from(
-		&counter_storage_allocator->memory_context,
-		memory_context,
-		"counter storage pages"
-	);
-	counter_storage_allocator->instance_count = instance_count;
-}
-
-void
-counter_storage_allocator_fini(struct counter_storage_allocator *self) {
-	if (self == NULL) {
-		return;
-	}
-
-	memory_context_fini(&self->memory_context);
-	self->instance_count = 0;
-}
-
+// Allocate one zeroed counter storage page from the given memory context.
+//
+// Each block now backs a single instance's counters; the per-instance page
+// striding was removed together with the counter storage allocator.
 static struct counter_storage_page *
-counter_storage_allocator_new_pages(struct counter_storage_allocator *allocator
-) {
-	struct counter_storage_page *pages =
+counter_storage_new_page(struct memory_context *memory_context) {
+	struct counter_storage_page *page =
 		(struct counter_storage_page *)memory_balloc(
-			&allocator->memory_context,
-			sizeof(struct counter_storage_page) *
-				allocator->instance_count
+			memory_context, sizeof(struct counter_storage_page)
 		);
-	if (pages == NULL)
+	if (page == NULL)
 		return NULL;
-	memset(pages,
-	       0,
-	       sizeof(struct counter_storage_page) * allocator->instance_count);
-	return pages;
-}
-
-static void
-counter_storage_allocator_free_pages(
-	struct counter_storage_allocator *allocator,
-	struct counter_storage_page *pages
-) {
-	memory_bfree(
-		&allocator->memory_context,
-		pages,
-		sizeof(struct counter_storage_page) * allocator->instance_count
-	);
+	memset(page, 0, sizeof(struct counter_storage_page));
+	return page;
 }
 
 // Initialize a counter_storage_pool to the zero-init state.
@@ -353,11 +316,9 @@ static void
 counter_storage_init(
 	struct memory_context *memory_context,
 	struct counter_storage *storage,
-	struct counter_storage_allocator *allocator,
 	struct counter_registry *registry
 ) {
 	SET_OFFSET_OF(&storage->memory_context, memory_context);
-	SET_OFFSET_OF(&storage->allocator, allocator);
 	SET_OFFSET_OF(&storage->registry, registry);
 	for (uint64_t idx = 0; idx < COUNTER_POOL_SIZE; ++idx) {
 		counter_storage_pool_init(storage->pools + idx);
@@ -367,21 +328,16 @@ counter_storage_init(
 struct counter_storage *
 counter_storage_spawn(
 	struct memory_context *memory_context,
-	struct counter_storage_allocator *allocator,
 	struct counter_storage *old_counter_storage,
 	struct counter_registry *counter_registry
 ) {
-	if (old_counter_storage != NULL &&
-	    ADDR_OF(&old_counter_storage->allocator) != allocator)
-		return NULL;
-
 	struct counter_storage *new_counter_storage = (struct counter_storage *)
 		memory_balloc(memory_context, sizeof(struct counter_storage));
 	if (new_counter_storage == NULL)
 		return NULL;
 
 	counter_storage_init(
-		memory_context, new_counter_storage, allocator, counter_registry
+		memory_context, new_counter_storage, counter_registry
 	);
 
 	for (uint64_t pool_idx = 0; pool_idx < COUNTER_POOL_SIZE; ++pool_idx) {
@@ -445,7 +401,7 @@ counter_storage_spawn(
 				);
 			block->refcnt = 1;
 			struct counter_storage_page *pages =
-				counter_storage_allocator_new_pages(allocator);
+				counter_storage_new_page(memory_context);
 			if (pages == NULL) {
 				goto error;
 			}
@@ -517,9 +473,10 @@ counter_storage_pool_fini(
 			continue;
 
 		if (--block->refcnt == 0) {
-			counter_storage_allocator_free_pages(
-				ADDR_OF(&storage->allocator),
-				ADDR_OF(&block->pages)
+			memory_bfree(
+				memory_context,
+				ADDR_OF(&block->pages),
+				sizeof(struct counter_storage_page)
 			);
 			memory_bfree(
 				memory_context,
@@ -566,18 +523,12 @@ counter_storage_free(struct counter_storage *storage) {
 void
 counter_handle_accum(
 	uint64_t *accum,
-	size_t instances,
 	size_t counter_size,
 	struct counter_value_handle *handle
 ) {
 	// counter_size is the number of uint64_t elements, not bytes
-	memset(accum, 0, counter_size * sizeof(uint64_t));
-	for (size_t instance_idx = 0; instance_idx < instances;
-	     ++instance_idx) {
-		uint64_t *value =
-			counter_handle_get_value(handle, instance_idx);
-		for (size_t idx = 0; idx < counter_size; ++idx) {
-			accum[idx] += value[idx];
-		}
+	uint64_t *value = counter_handle_get_value(handle);
+	for (size_t idx = 0; idx < counter_size; ++idx) {
+		accum[idx] = value[idx];
 	}
 }

--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -75,35 +75,18 @@ struct counter_storage_pool {
 	struct counter_storage_block **blocks;
 };
 
-struct counter_storage_allocator {
-	struct memory_context memory_context;
-	uint64_t instance_count;
-};
-
-void
-counter_storage_allocator_init(
-	struct counter_storage_allocator *counter_storage_allocator,
-	struct memory_context *memory_context,
-	uint64_t instance_count
-);
-
-void
-counter_storage_allocator_fini(struct counter_storage_allocator *self);
-
 struct counter_value_handle;
 
 struct counter_storage {
 	struct memory_context *memory_context;
 	struct counter_value_handle **counter_value_handles;
 	struct counter_registry *registry;
-	struct counter_storage_allocator *allocator;
 	struct counter_storage_pool pools[COUNTER_POOL_SIZE];
 };
 
 struct counter_storage *
 counter_storage_spawn(
 	struct memory_context *memory_context,
-	struct counter_storage_allocator *allocator,
 	struct counter_storage *old_counter_storage,
 	struct counter_registry *registry
 );
@@ -121,39 +104,29 @@ counter_get_value_handle(
 }
 
 static inline uint64_t *
-counter_handle_get_value(
-	struct counter_value_handle *value_handle, uint64_t instance_id
-) {
-	return (uint64_t *)((uintptr_t)value_handle +
-			    COUNTER_STORAGE_PAGE_SIZE * instance_id);
+counter_handle_get_value(struct counter_value_handle *value_handle) {
+	return (uint64_t *)value_handle;
 }
 
 static inline uint64_t *
-counter_get_address(
-	uint64_t counter_id,
-	uint64_t instance_id,
-	struct counter_storage *storage
-) {
+counter_get_address(uint64_t counter_id, struct counter_storage *storage) {
 	struct counter_value_handle *value_handle =
 		counter_get_value_handle(counter_id, storage);
 
 #ifdef COUNTERS_CHECK
 	if (value_handle == NULL)
 		return NULL;
-	if (instance_id >= instances)
-		return NULL;
 #endif
 
-	return counter_handle_get_value(value_handle, instance_id);
+	return counter_handle_get_value(value_handle);
 }
 
 struct counter_handle;
 
-// Accumulates `instances` counters into one `accum` counter.
+// Copies a single counter's values into `accum`.
 void
 counter_handle_accum(
 	uint64_t *accum,
-	size_t instances,
 	size_t counter_size,
 	struct counter_value_handle *handle
 );

--- a/lib/counters/histogram.h
+++ b/lib/counters/histogram.h
@@ -33,7 +33,6 @@ counter_hist_bucket_exp2(
  * and the corresponding counter is incremented by the specified value.
  *
  * @param counter_id The ID of the counter in the counter registry
- * @param instance_id The instance ID for multi-instance counters
  * @param counter_storage Pointer to the counter storage structure
  * @param min_bucket The minimum bucket index (log2 scale)
  * @param max_bucket The maximum bucket index (log2 scale)
@@ -43,7 +42,6 @@ counter_hist_bucket_exp2(
 static inline void
 counter_hist_exp2_inc(
 	uint64_t counter_id,
-	uint64_t instance_id,
 	struct counter_storage *counter_storage,
 	uint64_t min_bucket,
 	uint64_t max_bucket,
@@ -52,8 +50,7 @@ counter_hist_exp2_inc(
 ) {
 	uint64_t bucket = counter_hist_bucket_exp2(key, min_bucket, max_bucket);
 
-	counter_get_address(counter_id, instance_id, counter_storage)[bucket] +=
-		value;
+	counter_get_address(counter_id, counter_storage)[bucket] += value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/dataplane/config/counter_storage.c
+++ b/lib/dataplane/config/counter_storage.c
@@ -1,5 +1,7 @@
 #include "counter_storage.h"
 
+#include <string.h>
+
 #include "common/memory_address.h"
 #include "lib/controlplane/config/zone.h"
 #include "lib/counters/counters.h"
@@ -13,16 +15,7 @@ dp_counter_storage_init(
 	struct cp_config *cp_config,
 	uint64_t worker_count
 ) {
-	counter_storage_allocator_init(
-		&dp_config->counter_storage_allocator,
-		&dp_config->memory_context,
-		worker_count
-	);
-	counter_storage_allocator_init(
-		&cp_config->counter_storage_allocator,
-		&cp_config->memory_context,
-		worker_count
-	);
+	(void)cp_config;
 
 	yanet_error *err = NULL;
 	if (counter_registry_link(&dp_config->worker_counters, NULL, &err)) {
@@ -33,26 +26,43 @@ dp_counter_storage_init(
 		return -1;
 	}
 
-	struct counter_storage *worker_counter_storage = counter_storage_spawn(
-		&dp_config->memory_context,
-		&dp_config->counter_storage_allocator,
-		NULL,
-		&dp_config->worker_counters
-	);
-	if (worker_counter_storage == NULL) {
-		LOG(ERROR, "failed to allocate worker counter storage");
+	struct counter_storage **storages =
+		(struct counter_storage **)memory_balloc(
+			&dp_config->memory_context,
+			sizeof(struct counter_storage *) * worker_count
+		);
+	if (storages == NULL && worker_count > 0) {
+		LOG(ERROR, "failed to allocate worker counter storage array");
 		return -1;
 	}
+	memset(storages, 0, sizeof(struct counter_storage *) * worker_count);
 
-	SET_OFFSET_OF(
-		&dp_config->worker_counter_storage, worker_counter_storage
-	);
+	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
+		struct counter_storage *storage = counter_storage_spawn(
+			&dp_config->memory_context,
+			NULL,
+			&dp_config->worker_counters
+		);
+		if (storage == NULL) {
+			LOG(ERROR,
+			    "failed to spawn worker counter storage for worker "
+			    "%lu",
+			    worker_idx);
+			for (uint64_t idx = 0; idx < worker_idx; ++idx) {
+				counter_storage_free(ADDR_OF(storages + idx));
+			}
+			memory_bfree(
+				&dp_config->memory_context,
+				storages,
+				sizeof(struct counter_storage *) * worker_count
+			);
+			return -1;
+		}
+		SET_OFFSET_OF(storages + worker_idx, storage);
+	}
 
-	counter_storage_allocator_init(
-		&dp_config->port_counter_storage_allocator,
-		&dp_config->memory_context,
-		1
-	);
+	SET_OFFSET_OF(&dp_config->worker_counter_storages, storages);
+	dp_config->worker_counter_storage_count = worker_count;
 
 	struct dp_port_counters *port_counters =
 		ADDR_OF(&dp_config->port_counters);
@@ -70,10 +80,7 @@ dp_counter_storage_init(
 
 		struct counter_storage *port_counter_storage =
 			counter_storage_spawn(
-				&dp_config->memory_context,
-				&dp_config->port_counter_storage_allocator,
-				NULL,
-				&pc->registry
+				&dp_config->memory_context, NULL, &pc->registry
 			);
 		if (port_counter_storage == NULL) {
 			LOG(ERROR, "failed to allocate port counter storage");

--- a/lib/dataplane/config/counter_storage.h
+++ b/lib/dataplane/config/counter_storage.h
@@ -5,10 +5,10 @@
 struct cp_config;
 struct dp_config;
 
-// Initialise per-zone counter storage and link the worker counter registry.
+// Link the worker counter registry and spawn its per-worker storages.
 //
-// Allocates counter_storage_allocator instances for both zones, links the
-// worker counter registry, and spawns its backing storage. Caller must have
+// Links the worker counter registry and spawns one single-instance backing
+// storage per worker into dp_config->worker_counter_storages. Caller must have
 // registered the worker counters into dp_config->worker_counters before
 // invoking.
 //

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -24,7 +24,7 @@ _Static_assert(
 	"struct module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_config) == 1432,
+	sizeof(struct dp_config) == 1168,
 	"struct dp_config size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -31,7 +31,7 @@ struct dp_device {
 //
 // Each physical port owns a distinct registry (xstat schema) and storage
 // (values), so a port's counter lifecycle is independent of the others. All
-// port storages are spawned from the single shared allocator on dp_config.
+// port storages are spawned directly from the dp_config memory context.
 struct dp_port_counters {
 	uint16_t port_id;
 	char port_name[80];
@@ -117,11 +117,16 @@ struct dp_config {
 	uint64_t worker_count;
 	struct dp_worker **workers;
 
-	struct counter_storage_allocator counter_storage_allocator;
 	struct counter_registry worker_counters;
-	struct counter_storage *worker_counter_storage;
 
-	struct counter_storage_allocator port_counter_storage_allocator;
+	// Per-worker worker-counter storages.
+	//
+	// worker_counter_storages points to an array of
+	// worker_counter_storage_count offset pointers, one single-instance
+	// storage per worker.
+	uint64_t worker_counter_storage_count;
+	struct counter_storage **worker_counter_storages;
+
 	uint64_t port_count;
 	struct dp_port_counters *port_counters;
 

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 2
+#define YANET_MODULE_ABI_VERSION 3
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -17,6 +17,7 @@ struct cp_pipeline;
 struct cp_device;
 
 struct cp_config_gen;
+struct cp_config_counter_storage_registry;
 
 struct module_ectx {
 	module_handler handler;
@@ -112,6 +113,8 @@ struct device_ectx {
 struct config_gen_ectx {
 	struct cp_config_gen *cp_config_gen;
 	struct phy_device_map *phy_device_maps;
+
+	struct cp_config_counter_storage_registry *counter_storage_registry;
 
 	uint64_t device_count;
 	struct device_ectx *devices[];

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -14,19 +14,15 @@
 
 static inline void
 counter_add(
-	uint64_t counter_id,
-	uint64_t worker_idx,
-	struct counter_storage *storage,
-	uint64_t count
+	uint64_t counter_id, struct counter_storage *storage, uint64_t count
 ) {
-	counter_get_address(counter_id, worker_idx, storage)[0] += count;
+	counter_get_address(counter_id, storage)[0] += count;
 }
 
 static inline void
 counter_add_packets_bytes(
 	uint64_t packets_id,
 	uint64_t bytes_id,
-	uint64_t worker_idx,
 	struct counter_storage *storage,
 	uint64_t packets,
 	uint64_t bytes
@@ -35,8 +31,8 @@ counter_add_packets_bytes(
 		return;
 	}
 
-	counter_add(packets_id, worker_idx, storage, packets);
-	counter_add(bytes_id, worker_idx, storage, bytes);
+	counter_add(packets_id, storage, packets);
+	counter_add(bytes_id, storage, bytes);
 }
 
 void
@@ -62,7 +58,6 @@ module_ectx_process(
 	counter_add_packets_bytes(
 		module_ectx->rx_counter_id,
 		module_ectx->rx_bytes_counter_id,
-		dp_worker->idx,
 		storage,
 		packets_count,
 		input_bytes
@@ -86,9 +81,7 @@ module_ectx_process(
 		);
 		struct module_ectx_perf_counter_layout *counter =
 			(struct module_ectx_perf_counter_layout *)
-				counter_get_address(
-					counter_idx, dp_worker->idx, storage
-				);
+				counter_get_address(counter_idx, storage);
 		counter->summary_latency += elapsed_ns;
 		counter->packets += packets_count;
 		counter->bytes += input_bytes;
@@ -98,7 +91,6 @@ module_ectx_process(
 	counter_add_packets_bytes(
 		module_ectx->tx_counter_id,
 		module_ectx->tx_bytes_counter_id,
-		dp_worker->idx,
 		storage,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
@@ -126,7 +118,6 @@ chain_ectx_process(
 		uint64_t tsc_stop = rte_rdtsc();
 		counter_hist_exp2_inc(
 			chain_ectx->modules[idx].tsc_counter_id,
-			dp_worker->idx,
 			ADDR_OF(&chain_ectx->counter_storage),
 			0,
 			7,
@@ -225,7 +216,6 @@ function_ectx_process(
 	counter_add_packets_bytes(
 		function_ectx->counter_packet_in_count,
 		function_ectx->counter_packet_in_bytes,
-		dp_worker->idx,
 		storage,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
@@ -246,7 +236,6 @@ function_ectx_process(
 	counter_add_packets_bytes(
 		function_ectx->counter_packet_out_count,
 		function_ectx->counter_packet_out_bytes,
-		dp_worker->idx,
 		storage,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
@@ -254,7 +243,6 @@ function_ectx_process(
 	counter_add_packets_bytes(
 		function_ectx->counter_packet_drop_count,
 		function_ectx->counter_packet_drop_bytes,
-		dp_worker->idx,
 		storage,
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
@@ -274,7 +262,6 @@ pipeline_ectx_process(
 	counter_add_packets_bytes(
 		pipeline_ectx->counter_packet_in_count,
 		pipeline_ectx->counter_packet_in_bytes,
-		dp_worker->idx,
 		storage,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
@@ -290,7 +277,6 @@ pipeline_ectx_process(
 	counter_add_packets_bytes(
 		pipeline_ectx->counter_packet_out_count,
 		pipeline_ectx->counter_packet_out_bytes,
-		dp_worker->idx,
 		storage,
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
@@ -298,7 +284,6 @@ pipeline_ectx_process(
 	counter_add_packets_bytes(
 		pipeline_ectx->counter_packet_drop_count,
 		pipeline_ectx->counter_packet_drop_bytes,
-		dp_worker->idx,
 		storage,
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
@@ -439,7 +424,6 @@ device_ectx_process_input(
 	counter_add_packets_bytes(
 		device_ectx->counter_packet_rx_count,
 		device_ectx->counter_packet_rx_bytes,
-		dp_worker->idx,
 		ADDR_OF(&device_ectx->counter_storage),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
@@ -464,7 +448,6 @@ device_ectx_process_output(
 	counter_add_packets_bytes(
 		device_ectx->counter_packet_tx_count,
 		device_ectx->counter_packet_tx_bytes,
-		dp_worker->idx,
 		ADDR_OF(&device_ectx->counter_storage),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -55,34 +55,30 @@ enum {
 
 // Wire counter address pointers for a single dp_worker.
 //
-// The worker_counter_storage must already be spawned and wired into
+// The worker's counter storage must already be spawned and wired into
 // dp_config before calling this.
 static void
 wire_worker_counters(struct dp_worker *dp_worker, struct dp_config *dp_config) {
 	struct counter_storage *storage =
-		ADDR_OF(&dp_config->worker_counter_storage);
-	uint64_t idx = dp_worker->idx;
+		ADDR_OF(ADDR_OF(&dp_config->worker_counter_storages) +
+			dp_worker->idx);
 
 	dp_worker->iterations =
-		counter_get_address(WORKER_CTR_ITERATIONS, idx, storage);
+		counter_get_address(WORKER_CTR_ITERATIONS, storage);
 
-	dp_worker->rx_count =
-		counter_get_address(WORKER_CTR_RX, idx, storage) + 0;
-	dp_worker->rx_size =
-		counter_get_address(WORKER_CTR_RX, idx, storage) + 1;
+	dp_worker->rx_count = counter_get_address(WORKER_CTR_RX, storage) + 0;
+	dp_worker->rx_size = counter_get_address(WORKER_CTR_RX, storage) + 1;
 
-	dp_worker->tx_count =
-		counter_get_address(WORKER_CTR_TX, idx, storage) + 0;
-	dp_worker->tx_size =
-		counter_get_address(WORKER_CTR_TX, idx, storage) + 1;
+	dp_worker->tx_count = counter_get_address(WORKER_CTR_TX, storage) + 0;
+	dp_worker->tx_size = counter_get_address(WORKER_CTR_TX, storage) + 1;
 
 	dp_worker->remote_rx_count =
-		counter_get_address(WORKER_CTR_REMOTE_RX, idx, storage) + 0;
+		counter_get_address(WORKER_CTR_REMOTE_RX, storage) + 0;
 
 	dp_worker->remote_tx_count =
-		counter_get_address(WORKER_CTR_REMOTE_TX, idx, storage) + 0;
+		counter_get_address(WORKER_CTR_REMOTE_TX, storage) + 0;
 	dp_worker->rx_bursts =
-		counter_get_address(WORKER_CTR_RX_BURSTS, idx, storage);
+		counter_get_address(WORKER_CTR_RX_BURSTS, storage);
 }
 
 struct dataplane_ut *
@@ -333,16 +329,10 @@ dataplane_ut_free(struct dataplane_ut *ut) {
 	}
 
 	if (ut->cp_config != NULL) {
-		counter_storage_allocator_fini(
-			&ut->cp_config->counter_storage_allocator
-		);
 		memory_context_fini(&ut->cp_config->memory_context);
 	}
 
 	if (ut->dp_config != NULL) {
-		counter_storage_allocator_fini(
-			&ut->dp_config->counter_storage_allocator
-		);
 		memory_context_fini(&ut->dp_config->memory_context);
 	}
 
@@ -395,7 +385,7 @@ dataplane_ut_run(
 	struct cp_config_gen *cp_config_gen =
 		ADDR_OF(&ut->cp_config->cp_config_gen);
 	struct config_gen_ectx *config_gen_ectx =
-		ADDR_OF(&cp_config_gen->config_gen_ectx);
+		cp_config_gen_worker_ectx(cp_config_gen, worker_idx);
 
 	__atomic_store_n(&dp_worker->gen, cp_config_gen->gen, __ATOMIC_RELEASE);
 	*dp_worker->iterations += 1;

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -74,49 +74,41 @@ acl_handle_packets(
 
 	uint64_t *pass_cnt = counter_get_address(
 		acl_config->action_allow_counter_id,
-		dp_worker->idx,
 		ADDR_OF(&module_ectx->counter_storage)
 	);
 
 	uint64_t *deny_cnt = counter_get_address(
 		acl_config->action_deny_counter_id,
-		dp_worker->idx,
 		ADDR_OF(&module_ectx->counter_storage)
 	);
 
 	uint64_t *create_cnt = counter_get_address(
 		acl_config->action_create_state_counter_id,
-		dp_worker->idx,
 		ADDR_OF(&module_ectx->counter_storage)
 	);
 
 	uint64_t *check_pass_cnt = counter_get_address(
 		acl_config->action_check_pass_counter_id,
-		dp_worker->idx,
 		ADDR_OF(&module_ectx->counter_storage)
 	);
 
 	uint64_t *check_miss_cnt = counter_get_address(
 		acl_config->action_check_miss_counter_id,
-		dp_worker->idx,
 		ADDR_OF(&module_ectx->counter_storage)
 	);
 
 	uint64_t *sync_cnt = counter_get_address(
 		acl_config->sync_sent_counter_id,
-		dp_worker->idx,
 		ADDR_OF(&module_ectx->counter_storage)
 	);
 
 	uint64_t *invalid_cnt = counter_get_address(
 		acl_config->action_invalid_counter_id,
-		dp_worker->idx,
 		ADDR_OF(&module_ectx->counter_storage)
 	);
 
 	uint64_t *non_term_cnt = counter_get_address(
 		acl_config->action_non_term_counter_id,
-		dp_worker->idx,
 		ADDR_OF(&module_ectx->counter_storage)
 	);
 
@@ -294,7 +286,6 @@ acl_handle_packets(
 				case ACTION_COUNT: {
 					uint64_t *counters = counter_get_address(
 						target->counter_id,
-						dp_worker->idx,
 						ADDR_OF(&module_ectx
 								 ->counter_storage
 						)
@@ -388,7 +379,6 @@ acl_handle_packets(
 		} else {
 			uint64_t *c = counter_get_address(
 				acl_config->no_match_counter_id,
-				dp_worker->idx,
 				ADDR_OF(&module_ectx->counter_storage)
 			);
 			c[0] += 1;

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -25,6 +25,8 @@ forward_handle_packets(
 	struct module_ectx *module_ectx,
 	struct packet_front *packet_front
 ) {
+	(void)dp_worker;
+
 	struct forward_module_config *forward_config = container_of(
 		ADDR_OF(&module_ectx->cp_module),
 		struct forward_module_config,
@@ -113,7 +115,6 @@ forward_handle_packets(
 		if (target != NULL) {
 			uint64_t *counters = counter_get_address(
 				target->counter_id,
-				dp_worker->idx,
 				ADDR_OF(&module_ectx->counter_storage)
 			);
 			counters[0] += 1;

--- a/modules/forward/fuzzing/forward.c
+++ b/modules/forward/fuzzing/forward.c
@@ -144,19 +144,8 @@ forward_test_config(struct cp_module **cp_module, yanet_error **err) {
 		goto fail;
 	}
 
-	struct counter_storage_allocator *alloc = memory_balloc(
-		&fuzz_params.mctx, sizeof(struct counter_storage_allocator)
-	);
-	if (alloc == NULL) {
-		goto fail;
-	}
-	counter_storage_allocator_init(alloc, &fuzz_params.mctx, 1);
-
 	struct counter_storage *cs = counter_storage_spawn(
-		&fuzz_params.mctx,
-		alloc,
-		NULL,
-		&config->cp_module.counter_registry
+		&fuzz_params.mctx, NULL, &config->cp_module.counter_registry
 	);
 	if (cs == NULL) {
 		goto fail;

--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -129,7 +129,6 @@ mirror_handle_packets(
 		if (target != NULL) {
 			uint64_t *counters = counter_get_address(
 				target->counter_id,
-				dp_worker->idx,
 				ADDR_OF(&module_ectx->counter_storage)
 			);
 			counters[0] += 1;

--- a/modules/mirror/fuzzing/mirror.c
+++ b/modules/mirror/fuzzing/mirror.c
@@ -143,19 +143,8 @@ mirror_test_config(struct cp_module **cp_module, yanet_error **err) {
 		goto fail;
 	}
 
-	struct counter_storage_allocator *alloc = memory_balloc(
-		&fuzz_params.mctx, sizeof(struct counter_storage_allocator)
-	);
-	if (alloc == NULL) {
-		goto fail;
-	}
-	counter_storage_allocator_init(alloc, &fuzz_params.mctx, 1);
-
 	struct counter_storage *cs = counter_storage_spawn(
-		&fuzz_params.mctx,
-		alloc,
-		NULL,
-		&config->cp_module.counter_registry
+		&fuzz_params.mctx, NULL, &config->cp_module.counter_registry
 	);
 	if (cs == NULL) {
 		goto fail;

--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -131,7 +131,6 @@ route_mpls_handle_packets(
 			ADDR_OF(&target->nexthops) + nexthop_idx;
 		uint64_t *counters = counter_get_address(
 			nexthop->counter_id,
-			dp_worker->idx,
 			ADDR_OF(&module_ectx->counter_storage)
 		);
 		counters[0] += 1;

--- a/tests/controlplane/config_gen_test.c
+++ b/tests/controlplane/config_gen_test.c
@@ -75,12 +75,13 @@ main(void) {
 	TEST_ASSERT_NOT_NULL(gen, "cp_config_gen_new failed");
 
 	// Reproduce the worker's code path:
-	//   config_gen_ectx = ADDR_OF(&cp_config_gen->config_gen_ectx);
+	//   config_gen_ectx = cp_config_gen_worker_ectx(cp_config_gen, idx);
 	//
 	// Without the fix, this resolves the stale offset into a wild
 	// pointer. Accessing it triggers ASAN use-after-poison / SIGSEGV.
-	// With the fix, ADDR_OF returns NULL and the access is skipped.
-	struct config_gen_ectx *ectx = ADDR_OF(&gen->config_gen_ectx);
+	// With the fix, the fresh gen reports zero worker ectx and the
+	// accessor returns NULL.
+	struct config_gen_ectx *ectx = cp_config_gen_worker_ectx(gen, 0);
 	if (ectx != NULL) {
 		volatile uint64_t x = ectx->device_count;
 		(void)x;


### PR DESCRIPTION
Each worker now gets its own execution context tree carrying its own single-instance counter storages, instead of one shared context whose counters were strided by worker index. Counter addressing no longer takes a worker index, and the counter storage allocator is removed. Per-worker counter values still survive configuration reloads through per-worker storage migration, and worker-level counters move to per-worker storage as well. The control-plane read path keeps its public API by resolving a counter to a per-worker array of value handles.