### PR TITLE
feat(dataplane): export module constructors from .so plugins

### DIFF
--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -15,6 +15,13 @@
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.
 #define YANET_MODULE_ABI_VERSION_SYMBOL "yanet_module_abi_version"
 
+// Marks the module constructor symbol for export from the module object.
+//
+// Module dataplane objects are compiled with hidden visibility, so the
+// new_module_<name> constructor would otherwise be unreachable by the
+// plugin loader. Default visibility exports exactly that one symbol.
+#define YANET_MODULE_EXPORT __attribute__((visibility("default")))
+
 struct packet_front;
 struct module_ectx;
 struct dp_worker;


### PR DESCRIPTION
The dataplane loads packet-processing modules as external .so plugins, whose dataplane sources are compiled with hidden visibility. Add the export attribute that marks a module constructor for default visibility so the plugin loader can resolve it from the loaded object.

This completes the export side of the module plugin ABI, following the .so ABI-version guard.
