### PR TITLE
feat(dataplane_ut): load modules from .so plugins at runtime

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -152,6 +152,9 @@ type Config struct {
 	Devices       []string
 	Modules       []string
 	DevicesToLoad []string
+	// PluginDir is the directory scanned for module .so plugins. An empty
+	// value loads only the statically-linked built-ins.
+	PluginDir string
 }
 
 // Result of one pipeline round.
@@ -223,6 +226,11 @@ func NewHarness(cfg Config) (*Harness, error) {
 		cArr := C.alloc_cptr_array(&cDevicesToLoad[0], C.size_t(len(cDevicesToLoad)))
 		defer C.free_cptr_array(cArr)
 		cCfg.devices_to_load = cArr
+	}
+	if cfg.PluginDir != "" {
+		cPluginDir := C.CString(cfg.PluginDir)
+		defer C.free(unsafe.Pointer(cPluginDir))
+		cCfg.plugin_dir = cPluginDir
 	}
 
 	ptr := C.dataplane_ut_new(&cCfg)

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -20,6 +20,7 @@
 #include "lib/dataplane/config/bootstrap.h"
 #include "lib/dataplane/config/counter_storage.h"
 #include "lib/dataplane/config/module_loader.h"
+#include "lib/dataplane/config/plugin_loader.h"
 #include "lib/dataplane/config/topology.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/module/packet_front.h"
@@ -38,6 +39,7 @@ struct dataplane_ut {
 	struct agent *agent;
 	struct rte_mempool *mempool;
 	uint64_t mock_time_ns;
+	struct plugin_registry plugins;
 };
 
 // Counter indices used by wire_worker_counters to address the
@@ -146,10 +148,23 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		return NULL;
 	}
 
+	// Load module .so plugins so their symbols take priority over the
+	// statically-linked built-ins when resolving new_module_<name>.
+	if (dp_load_plugins(cfg->plugin_dir, &ut->plugins) == -1) {
+		LOG(ERROR,
+		    "dataplane_ut_new: failed to load plugins from %s",
+		    cfg->plugin_dir);
+		dataplane_ut_free(ut);
+		return NULL;
+	}
+
 	// Load requested packet-processing modules.
 	for (size_t idx = 0; idx < cfg->module_count; ++idx) {
 		if (dp_load_module(
-			    ut->dp_config, bin_hndl, NULL, cfg->modules[idx]
+			    ut->dp_config,
+			    bin_hndl,
+			    &ut->plugins,
+			    cfg->modules[idx]
 		    ) == -1) {
 			LOG(ERROR,
 			    "dataplane_ut_new: failed to load module %s",
@@ -335,6 +350,8 @@ dataplane_ut_free(struct dataplane_ut *ut) {
 		free(ut->arena);
 		ut->arena = NULL;
 	}
+
+	dp_unload_plugins(&ut->plugins);
 
 	free(ut);
 }

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -24,6 +24,10 @@ struct dataplane_ut_config {
 	const char *const *modules;
 	size_t module_count;
 
+	// Directory scanned for module .so plugins. NULL or empty loads
+	// only statically-linked built-ins.
+	const char *plugin_dir;
+
 	const char *const *devices_to_load;
 	size_t devices_to_load_count;
 };


### PR DESCRIPTION
The in-process dataplane test harness could only run statically-linked modules. Thread the shared-memory plugin loader through the harness so a test can point it at a directory of module .so plugins and have them resolved at runtime, taking priority over the statically-linked built-ins.

An empty plugin directory keeps the previous behaviour: only the statically-linked built-in modules are resolved, so existing harness tests are unaffected.
