### PR TITLE
feat(build): add extra_modules option to build optional module dirs

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -40,3 +40,11 @@ option(
   value: false,
   description: 'Build only the dataplane binary, skip Go/protobuf targets.',
 )
+
+option(
+  'extra_modules',
+  type: 'array',
+  value: [],
+  description: 'Additional module directories under modules/ to build, '
+                + 'beyond the built-in set (for optional or vendored modules).',
+)

--- a/modules/meson.build
+++ b/modules/meson.build
@@ -10,3 +10,7 @@ subdir('nat64')
 subdir('pdump')
 subdir('balancer2')
 subdir('blackhole')
+
+foreach extra_module : get_option('extra_modules')
+  subdir(extra_module)
+endforeach


### PR DESCRIPTION
The build hardcoded every module as a subdir, so an optional or out-of-tree module could only be built by editing the tracked module list. Add an extra_modules meson option whose directories are built in addition to the built-in set — the build-time counterpart to the runtime module plugin loader.

With the default empty value the built-in module set and the resulting build are unchanged. An optional module is built by passing its directory name through the option at configure time.
