### PR TITLE
refactor(functest): extract the VM harness into a reusable framework library

### DIFF
--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -68,6 +68,7 @@ var CLIBinaryNames = []string{
 type GuestPaths struct {
 	CLIBase        string // directory with yanet-cli-* binaries
 	BuildDir       string // directory with yanet-dataplane, yanet-controlplane
+	PluginDir      string // directory with dataplane module .so plugins
 	ConfigDir      string // directory for config files
 	LogDir         string // directory for log files
 	DPDKDevbindDir string // directory containing dpdk-devbind.py
@@ -80,6 +81,7 @@ func DefaultGuestPaths() GuestPaths {
 	return GuestPaths{
 		CLIBase:        "/mnt/target/release",
 		BuildDir:       "/mnt/build",
+		PluginDir:      "/mnt/build/plugins",
 		ConfigDir:      "/mnt/config",
 		LogDir:         "/mnt/logs",
 		DPDKDevbindDir: "/mnt/yanet2/subprojects/dpdk/usertools",
@@ -95,6 +97,7 @@ func LocalGuestPaths() GuestPaths {
 	return GuestPaths{
 		CLIBase:        "/tmp/yanet/cli",
 		BuildDir:       "/tmp/yanet/build",
+		PluginDir:      "/tmp/yanet/build/plugins",
 		ConfigDir:      "/tmp/yanet/config",
 		LogDir:         "/tmp/yanet/logs",
 		DPDKDevbindDir: "/tmp/yanet/tools",
@@ -1403,11 +1406,22 @@ func (f *TestFramework) PrepareLocalStorage() error {
 
 	// Copy files step by step to avoid serial terminal line-length limits.
 	// Each command is kept short enough for reliable serial transmission.
+	//
+	// Dataplane module .so plugins are copied onto local tmpfs too: a
+	// dataplane that loads a plugin keeps its .so mmap'd, which would block
+	// unmounting the 9P share before savevm, so the plugin must not live on
+	// 9P once YANET is running.
+	//
+	// The build's plugin directory holds host symlinks that dangle inside
+	// the guest, so copy the real plugin objects from their module build
+	// directories, renaming each from lib<name>_dp_plugin.so to the
+	// lib<name>_dp.so form the dataplane's plugin loader recognizes.
 	copyCommands := []string{
-		"mkdir -p /tmp/yanet/build/dataplane /tmp/yanet/build/controlplane /tmp/yanet/cli /tmp/yanet/config /tmp/yanet/logs /tmp/yanet/tools",
+		"mkdir -p /tmp/yanet/build/dataplane /tmp/yanet/build/controlplane /tmp/yanet/build/plugins /tmp/yanet/cli /tmp/yanet/config /tmp/yanet/logs /tmp/yanet/tools",
 		"cp /mnt/build/dataplane/yanet-dataplane /tmp/yanet/build/dataplane/",
 		"cp /mnt/build/controlplane/yanet-controlplane /tmp/yanet/build/controlplane/",
 		"cp /mnt/yanet2/subprojects/dpdk/usertools/dpdk-devbind.py /tmp/yanet/tools/",
+		"for f in /mnt/build/modules/*/dataplane/*_dp_plugin.so; do [ -e \"$f\" ] || continue; b=$(basename \"$f\"); cp \"$f\" /tmp/yanet/build/plugins/${b%_plugin.so}.so; done",
 	}
 
 	// Copy CLI binaries individually -- serial terminals truncate long lines.

--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -1,0 +1,553 @@
+package framework
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// DataplaneOptions customizes the baseline dataplane configuration a Harness
+// boots with.
+//
+// PluginDir and Modules drive the dataplane's runtime plugin loader: when
+// PluginDir is set the dataplane scans it for module .so plugins and loads
+// each name listed in Modules. Leaving both empty produces a configuration
+// that relies solely on the modules statically linked into the dataplane
+// binary.
+type DataplaneOptions struct {
+	PluginDir string
+	Modules   []string
+}
+
+// DataplaneConfig returns the baseline dataplane YAML used by functional
+// tests, optionally requesting runtime module plugins via opts.
+func DataplaneConfig(opts DataplaneOptions) string {
+	plugins := ""
+	cpMemory := "134217728"
+	if opts.PluginDir != "" {
+		plugins = "  plugin_dir: " + opts.PluginDir + "\n"
+		if len(opts.Modules) > 0 {
+			plugins += "  modules:\n"
+			for _, module := range opts.Modules {
+				plugins += "    - " + module + "\n"
+			}
+		}
+		cpMemory = "167772160"
+	}
+
+	// cp_memory defaults to 128 MiB, matching the built-in main pool used
+	// before this configuration was extracted into a builder.
+	//
+	// The plugin-loading configuration bumps it to 160 MiB to carry headroom
+	// for a standalone module control plane's agent, alongside the ephemeral
+	// per-update agents the gateway's builtin function and pipeline services
+	// attach.
+	return `
+dataplane:
+  storage: /dev/hugepages/yanet
+  dpdk_memory: 128
+  loglevel: trace
+` + plugins + `  instances:
+    - dp_memory: 100663296
+      cp_memory: ` + cpMemory + `
+      numa_id: 0
+  devices:
+    - port_name: 01:00.0
+      mac_addr: 52:54:00:6b:ff:a5
+      mtu: 7000
+      max_lro_packet_size: 7200
+      rss_hash: 0
+      workers:
+        - core_id: 0
+          instance_id: 0
+          rx_queue_len: 1024
+          tx_queue_len: 1024
+          num_mbufs: 2048
+    - port_name: virtio_user_kni0
+      mac_addr: 52:54:00:6b:ff:a5
+      mtu: 7000
+      max_lro_packet_size: 7200
+      rss_hash: 0
+      workers:
+        - core_id: 0
+          instance_id: 0
+          rx_queue_len: 1024
+          tx_queue_len: 1024
+          num_mbufs: 2048
+  connections:
+    - src_device: 01:00.0
+      dst_device: virtio_user_kni0
+    - src_device: virtio_user_kni0
+      dst_device: 01:00.0
+`
+}
+
+// DefaultControlplaneConfig returns the baseline controlplane YAML used by
+// functional tests.
+func DefaultControlplaneConfig() string {
+	return `
+logging:
+  level: debug
+
+gateway:
+  server:
+    endpoint: "0.0.0.0:8080"
+  auth:
+    disabled: true
+
+modules:
+  route:
+    link_map:
+      kni0: 01:00.0
+    memory_requirements: 8MB
+  route-mpls:
+    memory_requirements: 8MB
+  decap:
+    memory_requirements: 8MB
+  dscp:
+    memory_requirements: 8MB
+  forward:
+    memory_requirements: 8MB
+  nat64:
+    memory_requirements: 8MB
+  pdump:
+    memory_requirements: 8MB
+  acl:
+    memory_requirements: 16MB
+
+devices:
+  plain:
+    memory_requirements: 8MB
+  vlan:
+    memory_requirements: 8MB
+`
+}
+
+// DefaultForwardConfig returns the baseline forward.yaml used by functional
+// tests.
+func DefaultForwardConfig() string {
+	return `
+rules:
+  - target: virtio_user_kni0
+    counter: to_virtio_user_kni0
+    vlan_ranges:
+      - from: 0
+        to: 4095
+    srcs:
+      - "0.0.0.0/0"
+      - "::/0"
+    dsts:
+      - ` + VMIPv4Host + `/32
+      - ` + VMIPv6Host + `/64
+      - "ff02::0/16"
+    mode: Out
+    devices:
+      - 01:00.0
+  - target: 01:00.0
+    counter: to_pass
+    vlan_ranges:
+      - from: 0
+        to: 4095
+    srcs:
+      - "0.0.0.0/0"
+      - "::/0"
+    dsts:
+      - "0.0.0.0/0"
+      - "::/0"
+    mode: None
+    devices:
+      - 01:00.0
+  - target: virtio_user_kni0
+    counter: to_virtio_user_kni0
+    vlan_ranges:
+      - from: 0
+        to: 4095
+    srcs:
+    dsts:
+    mode: Out
+    devices:
+      - 01:00.0
+  - target: 01:00.0
+    counter: to_01:00.0
+    vlan_ranges:
+      - from: 0
+        to: 4095
+    srcs:
+    dsts:
+    mode: Out
+    devices:
+      - virtio_user_kni0
+`
+}
+
+// DefaultRouteConfig returns the baseline route0.yaml used by functional
+// tests.
+func DefaultRouteConfig() string {
+	return `
+entries:
+  - prefix: "0.0.0.0/0"
+    nexthops:
+      - dst_mac: "` + SrcMAC + `"
+        src_mac: "` + DstMAC + `"
+        device: "01:00.0"
+  - prefix: "::/0"
+    nexthops:
+      - dst_mac: "` + SrcMAC + `"
+        src_mac: "` + DstMAC + `"
+        device: "01:00.0"
+`
+}
+
+// HarnessConfig describes the VM pool a functional-test package boots.
+//
+// PoolName names the pool's VM instances and logging scope. BaselineTag
+// scopes the cached baseline template overlay so pools that boot different
+// YANET configurations never collide on one cached snapshot file. QEMUImage,
+// when empty, defaults to the shared functional-test image resolved from the
+// project root. The YAML fields default to the Default*/DataplaneConfig
+// builders when left empty.
+type HarnessConfig struct {
+	PoolName     string
+	BaselineTag  string
+	QEMUImage    string
+	Dataplane    string
+	Controlplane string
+	Forward      string
+	Route        string
+}
+
+// Harness owns a booted, baseline-configured VM pool shared by the tests of
+// one functional-test package, together with the YANET configuration used to
+// restore a VM to that baseline.
+type Harness struct {
+	pool         *VMPool
+	dataplane    string
+	controlplane string
+}
+
+// Pool returns the underlying VM pool.
+func (m *Harness) Pool() *VMPool {
+	return m.pool
+}
+
+// Shutdown stops every VM in the pool.
+func (m *Harness) Shutdown() error {
+	return m.pool.Shutdown()
+}
+
+// resolveQEMUImage returns the configured QEMU image, or the shared
+// functional-test image resolved from the project root when unset.
+func resolveQEMUImage(configured string) (string, error) {
+	if configured != "" {
+		return configured, nil
+	}
+	if env := os.Getenv("YANET_QEMU_IMAGE"); env != "" {
+		return env, nil
+	}
+	root, err := findProjectRoot()
+	if err != nil {
+		return "", fmt.Errorf("failed to locate project root for QEMU image: %w", err)
+	}
+	return filepath.Join(root, "tests", "functional", "yanet-test.qcow2"), nil
+}
+
+// newHarnessLogger builds the logger a harness runs with, mirroring the
+// verbosity split the functional tests rely on: quiet by default, verbose to
+// test.log when debugging is enabled.
+func newHarnessLogger() (*zap.SugaredLogger, func(), error) {
+	config := zap.NewDevelopmentConfig()
+	if !IsDebugEnabled() {
+		config.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	} else {
+		config.OutputPaths = []string{"test.log"}
+		config.ErrorOutputPaths = []string{"stderr", "test.log"}
+	}
+	logger, err := config.Build()
+	if err != nil {
+		return nil, nil, err
+	}
+	return logger.Sugar(), func() { _ = logger.Sync() }, nil
+}
+
+// SetupHarness prepares a baseline VM pool for a functional-test package.
+//
+// It ensures the baseline template overlay exists (bootstrapping it from the
+// booted template when missing), starts the pool, waits for readiness, and
+// pauses idle VM CPUs. The returned cleanup releases the harness logger; the
+// caller owns Shutdown of the returned Harness.
+func SetupHarness(config HarnessConfig) (_ *Harness, cleanup func(), err error) {
+	logger, syncLog, err := newHarnessLogger()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to build harness logger: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			syncLog()
+		}
+	}()
+
+	qemuImage, err := resolveQEMUImage(config.QEMUImage)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// A custom YAML must not reuse the shared "baseline" cache silently.
+	customConfig := config.Dataplane != "" || config.Controlplane != "" ||
+		config.Forward != "" || config.Route != ""
+	if config.BaselineTag == "" && customConfig {
+		return nil, nil, fmt.Errorf("failed to set up harness: a custom YAML configuration requires a non-empty BaselineTag so it does not reuse the shared baseline cache")
+	}
+
+	dataplane := config.Dataplane
+	if dataplane == "" {
+		dataplane = DataplaneConfig(DataplaneOptions{})
+	}
+	controlplane := config.Controlplane
+	if controlplane == "" {
+		controlplane = DefaultControlplaneConfig()
+	}
+	forward := config.Forward
+	if forward == "" {
+		forward = DefaultForwardConfig()
+	}
+	route := config.Route
+	if route == "" {
+		route = DefaultRouteConfig()
+	}
+
+	baselineTag := config.BaselineTag
+	if baselineTag == "" {
+		baselineTag = "baseline"
+	}
+
+	bootedTemplate := BootedImagePath(qemuImage)
+	baselineTemplate := SnapshotImagePath(qemuImage, baselineTag)
+
+	baseline := &baselineSetup{
+		dataplane:    dataplane,
+		controlplane: controlplane,
+		forward:      forward,
+		route:        route,
+		poolName:     config.PoolName,
+		log:          logger,
+	}
+	if err = baseline.ensureTemplate(qemuImage, bootedTemplate, baselineTemplate); err != nil {
+		return nil, nil, fmt.Errorf("failed to prepare baseline template: %w", err)
+	}
+	MarkBaselineSaved()
+
+	logger.Infof("Starting VM pool %q with size %d (baseline template: %s)",
+		config.PoolName, PoolSize(), baselineTemplate)
+
+	pool, err := NewVMPool(
+		PoolSize(), config.PoolName, qemuImage,
+		bootedTemplate, baselineTemplate, "baseline", logger,
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create VM pool: %w", err)
+	}
+
+	defer func() {
+		if err != nil {
+			_ = pool.Shutdown()
+		}
+	}()
+
+	if err = pool.StartAll(); err != nil {
+		return nil, nil, fmt.Errorf("failed to start VM pool: %w", err)
+	}
+	if err = pool.WaitAllReady(120 * time.Second); err != nil {
+		return nil, nil, fmt.Errorf("failed to wait for VM pool readiness: %w", err)
+	}
+
+	// Pause all VM CPUs now that baseline snapshots are saved. Idle VMs would
+	// otherwise keep DPDK's busy-poll loop running and consume host CPU,
+	// starving the active VM's packet processing. Each VM resumes when
+	// RestoreSnapshot calls loadvm+cont.
+	pool.StopAllCPU()
+
+	harness := &Harness{
+		pool:         pool,
+		dataplane:    dataplane,
+		controlplane: controlplane,
+	}
+	return harness, syncLog, nil
+}
+
+// WithBootedVM acquires a pooled VM, restores it to a working YANET baseline,
+// runs fn, then returns the VM to the pool.
+func (m *Harness) WithBootedVM(t *testing.T, fn func(fw *TestFramework)) {
+	t.Helper()
+	base := m.pool.Acquire()
+	t.Cleanup(func() {
+		m.pool.Release(base)
+	})
+	fw := base.ForTest(t)
+	m.RestoreBooted(t, fw)
+	fn(fw)
+}
+
+// RestoreBooted restores fw to a working YANET state.
+//
+// It tries the fast path (baseline snapshot with YANET already running)
+// first, and falls back to the slow path (preyanet snapshot plus a fresh
+// StartYANET) only when the baseline restore fails.
+func (m *Harness) RestoreBooted(t *testing.T, fw *TestFramework) {
+	t.Helper()
+
+	if err := fw.RestoreAndReconnect("baseline"); err == nil {
+		return
+	}
+
+	t.Logf("baseline restore failed, falling back to preyanet + fresh StartYANET")
+
+	if err := fw.RestoreClean("preyanet"); err != nil {
+		t.Fatalf("failed to restore VM to preyanet: %v", err)
+	}
+	if err := fw.StartYANET(m.dataplane, m.controlplane); err != nil {
+		t.Fatalf("failed to start YANET: %v", err)
+	}
+	if _, err := fw.ExecuteCommands(fw.CommonConfigCommands()...); err != nil {
+		t.Fatalf("failed to configure YANET: %v", err)
+	}
+
+	fw.ResetConnections()
+
+	const dpTimeout = 15 * time.Second
+	if err := fw.WaitForDatapathReady(dpTimeout); err != nil {
+		t.Logf("dataplane not ready after %v, restarting YANET...", dpTimeout)
+		if restartErr := fw.RestartYANET(); restartErr != nil {
+			t.Fatalf("YANET restart failed: %v", restartErr)
+		}
+		fw.ResetConnections()
+		if err := fw.WaitForDatapathReady(dpTimeout); err != nil {
+			t.Fatalf("dataplane not ready after preyanet restore + restart: %v", err)
+		}
+	}
+}
+
+// baselineSetup captures the YANET configuration used while baking a baseline
+// template overlay.
+type baselineSetup struct {
+	dataplane    string
+	controlplane string
+	forward      string
+	route        string
+	poolName     string
+	log          *zap.SugaredLogger
+}
+
+// ensureTemplate makes sure baselineTemplate holds a "baseline" snapshot,
+// bootstrapping it from the booted template when the cache is cold.
+func (m *baselineSetup) ensureTemplate(qemuImage, bootedTemplate, baselineTemplate string) error {
+	if OverlayHasSnapshot(baselineTemplate, "baseline") {
+		m.log.Infof("Using cached baseline template: %s", baselineTemplate)
+		return nil
+	}
+
+	m.log.Infof("Baseline template %s not found; bootstrapping from booted template", baselineTemplate)
+
+	prepPool, err := NewVMPool(1, "baseline-prep-"+m.poolName, qemuImage, bootedTemplate, "", "", m.log)
+	if err != nil {
+		return fmt.Errorf("failed to create baseline prep pool: %w", err)
+	}
+	defer func() {
+		if err := prepPool.Shutdown(); err != nil {
+			m.log.Errorf("Failed to shut down baseline prep pool: %v", err)
+		}
+	}()
+
+	if err := prepPool.StartAll(); err != nil {
+		return fmt.Errorf("failed to start baseline prep pool: %w", err)
+	}
+	if err := prepPool.WaitAllReady(120 * time.Second); err != nil {
+		return fmt.Errorf("baseline prep pool not ready: %w", err)
+	}
+
+	prepFW := prepPool.Acquire()
+	defer prepPool.Release(prepFW)
+
+	if err := prepFW.PrepareLocalStorage(); err != nil {
+		return fmt.Errorf("failed to prepare local storage: %w", err)
+	}
+	if err := m.configure(prepFW); err != nil {
+		return fmt.Errorf("failed to configure baseline: %w", err)
+	}
+	if err := prepFW.SaveSnapshotKeepUnmounted("baseline"); err != nil {
+		return fmt.Errorf("failed to save baseline snapshot: %w", err)
+	}
+	m.log.Info("Baseline snapshot saved successfully")
+
+	if err := prepFW.ExportCurrentOverlay(baselineTemplate); err != nil {
+		return fmt.Errorf("failed to export baseline template: %w", err)
+	}
+	if !OverlayHasSnapshot(baselineTemplate, "baseline") {
+		return fmt.Errorf("exported baseline template %s is missing snapshot %q", baselineTemplate, "baseline")
+	}
+
+	m.log.Infof("Baseline template cached at %s", baselineTemplate)
+	return nil
+}
+
+// configure writes the baseline config files, captures a "preyanet" fallback
+// snapshot, then starts YANET and applies the common runtime configuration.
+func (m *baselineSetup) configure(fw *TestFramework) error {
+	// Write config files BEFORE starting YANET so the "preyanet" snapshot
+	// captures them on disk without a running dataplane.
+	if err := fw.CreateForwardConfig(m.forward); err != nil {
+		return err
+	}
+	if err := fw.CreateConfigFile("route0.yaml", m.route); err != nil {
+		return err
+	}
+
+	// Save "preyanet" snapshot: OS booted, binaries copied to /tmp/yanet,
+	// config files written, 9P unmounted, no YANET running. Used as the
+	// fallback source when baseline restore fails.
+	if err := fw.SaveSnapshotKeepUnmounted("preyanet"); err != nil {
+		return err
+	}
+	m.log.Info("Pre-yanet snapshot saved")
+
+	// Remount 9P: CommonConfigCommands needs /mnt/config/route0.yaml.
+	if err := fw.Mount9P(); err != nil {
+		return err
+	}
+
+	if err := fw.StartYANET(m.dataplane, m.controlplane); err != nil {
+		return err
+	}
+
+	m.dumpMemoryDiagnostics(fw)
+
+	if _, err := fw.ExecuteCommands(fw.CommonConfigCommands()...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// dumpMemoryDiagnostics logs guest memory and YANET process state, aiding
+// diagnosis of allocation failures during baseline setup.
+func (m *baselineSetup) dumpMemoryDiagnostics(fw *TestFramework) {
+	diagCmds := []string{
+		"echo '=== HUGEPAGES ===' && cat /proc/meminfo | grep -i huge",
+		"echo '=== FREE ===' && free -h",
+		"echo '=== PROCESS MEMORY ===' && ps aux | grep yanet",
+		"echo '=== HUGEPAGE FILE ===' && ls -lh /dev/hugepages/yanet",
+		"echo '=== DATAPLANE LOG ===' && cat /tmp/yanet/logs/yanet-dataplane.log",
+		"echo '=== CONTROLPLANE LOG ===' && cat /tmp/yanet/logs/yanet-controlplane.log",
+	}
+	outputs, err := fw.ExecuteCommands(diagCmds...)
+	if err != nil {
+		m.log.Errorf("MEMORY DIAG: error collecting diagnostics: %v", err)
+		return
+	}
+	for idx, cmd := range diagCmds {
+		m.log.Infof("MEMORY DIAG: %s\n%s\n---", cmd, outputs[idx])
+	}
+}

--- a/tests/functional/main/framework_test.go
+++ b/tests/functional/main/framework_test.go
@@ -5,301 +5,26 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/yanet-platform/yanet2/tests/functional/framework"
-	"go.uber.org/zap"
 )
 
-// Global VM pool used for test isolation. Works for any pool size >= 1.
+// harness owns the baseline VM pool shared by every test in this package.
+var harness *framework.Harness
+
+// globalPool is the baseline VM pool. It is a convenience alias for
+// harness.Pool() used by the per-test isolation helpers below.
 var globalPool *framework.VMPool
-
-func dataplaneConfig() string {
-	return `
-dataplane:
-  storage: /dev/hugepages/yanet
-  dpdk_memory: 128
-  loglevel: trace
-  instances:
-    - dp_memory: 100663296
-      cp_memory: 134217728
-      numa_id: 0
-  devices:
-    - port_name: 01:00.0
-      mac_addr: 52:54:00:6b:ff:a5
-      mtu: 7000
-      max_lro_packet_size: 7200
-      rss_hash: 0
-      workers:
-        - core_id: 0
-          instance_id: 0
-          rx_queue_len: 1024
-          tx_queue_len: 1024
-          num_mbufs: 2048
-    - port_name: virtio_user_kni0
-      mac_addr: 52:54:00:6b:ff:a5
-      mtu: 7000
-      max_lro_packet_size: 7200
-      rss_hash: 0
-      workers:
-        - core_id: 0
-          instance_id: 0
-          rx_queue_len: 1024
-          tx_queue_len: 1024
-          num_mbufs: 2048
-  connections:
-    - src_device: 01:00.0
-      dst_device: virtio_user_kni0
-    - src_device: virtio_user_kni0
-      dst_device: 01:00.0
-`
-}
-
-func controlplaneConfig() string {
-	return `
-logging:
-  level: debug
-
-gateway:
-  server:
-    endpoint: "0.0.0.0:8080"
-  auth:
-    disabled: true
-
-modules:
-  route:
-    link_map:
-      kni0: 01:00.0
-    memory_requirements: 8MB
-  route-mpls:
-    memory_requirements: 8MB
-  decap:
-    memory_requirements: 8MB
-  dscp:
-    memory_requirements: 8MB
-  forward:
-    memory_requirements: 8MB
-  nat64:
-    memory_requirements: 8MB
-  pdump:
-    memory_requirements: 8MB
-  acl:
-    memory_requirements: 16MB
-
-devices:
-  plain:
-    memory_requirements: 8MB
-  vlan:
-    memory_requirements: 8MB
-`
-}
-
-func forwardConfig() string {
-	return `
-rules:
-  - target: virtio_user_kni0
-    counter: to_virtio_user_kni0
-    vlan_ranges:
-      - from: 0
-        to: 4095
-    srcs:
-      - "0.0.0.0/0"
-      - "::/0"
-    dsts:
-      - ` + framework.VMIPv4Host + `/32
-      - ` + framework.VMIPv6Host + `/64
-      - "ff02::0/16"
-    mode: Out
-    devices:
-      - 01:00.0
-  - target: 01:00.0
-    counter: to_pass
-    vlan_ranges:
-      - from: 0
-        to: 4095
-    srcs:
-      - "0.0.0.0/0"
-      - "::/0"
-    dsts:
-      - "0.0.0.0/0"
-      - "::/0"
-    mode: None
-    devices:
-      - 01:00.0
-  - target: virtio_user_kni0
-    counter: to_virtio_user_kni0
-    vlan_ranges:
-      - from: 0
-        to: 4095
-    srcs:
-    dsts:
-    mode: Out
-    devices:
-      - 01:00.0
-  - target: 01:00.0
-    counter: to_01:00.0
-    vlan_ranges:
-      - from: 0
-        to: 4095
-    srcs:
-    dsts:
-    mode: Out
-    devices:
-      - virtio_user_kni0
-`
-}
-
-func route0Config() string {
-	return `
-entries:
-  - prefix: "0.0.0.0/0"
-    nexthops:
-      - dst_mac: "` + framework.SrcMAC + `"
-        src_mac: "` + framework.DstMAC + `"
-        device: "01:00.0"
-  - prefix: "::/0"
-    nexthops:
-      - dst_mac: "` + framework.SrcMAC + `"
-        src_mac: "` + framework.DstMAC + `"
-        device: "01:00.0"
-`
-}
-
-func dumpMemoryDiagnostics(fw *framework.TestFramework, log *zap.SugaredLogger) {
-	diagCmds := []string{
-		"echo '=== HUGEPAGES ===' && cat /proc/meminfo | grep -i huge",
-		"echo '=== FREE ===' && free -h",
-		"echo '=== PROCESS MEMORY ===' && ps aux | grep yanet",
-		"echo '=== HUGEPAGE FILE ===' && ls -lh /dev/hugepages/yanet",
-		"echo '=== DATAPLANE LOG ===' && cat /tmp/yanet/logs/yanet-dataplane.log",
-		"echo '=== CONTROLPLANE LOG ===' && cat /tmp/yanet/logs/yanet-controlplane.log",
-	}
-	outputs, err := fw.ExecuteCommands(diagCmds...)
-	if err != nil {
-		log.Errorf("MEMORY DIAG: error collecting diagnostics: %v", err)
-		return
-	}
-	for i, cmd := range diagCmds {
-		log.Infof("MEMORY DIAG: %s\n%s\n---", cmd, outputs[i])
-	}
-}
-
-// Baseline configs stored at package level so RestartYANET and the
-// preyanet fallback in restoreBooted can access them.
-var (
-	baselineDP = dataplaneConfig()
-	baselineCP = controlplaneConfig()
-)
-
-func configureBaseline(fw *framework.TestFramework, log *zap.SugaredLogger) error {
-	// Write config files BEFORE starting YANET so the "preyanet"
-	// snapshot captures them on disk without a running dataplane.
-	if err := fw.CreateForwardConfig(forwardConfig()); err != nil {
-		return err
-	}
-	if err := fw.CreateConfigFile("route0.yaml", route0Config()); err != nil {
-		return err
-	}
-
-	// Save "preyanet" snapshot -- OS booted, binaries copied to
-	// /tmp/yanet/, config files written, 9P unmounted, no YANET running.
-	// Used as fallback when baseline restore fails.
-	if err := fw.SaveSnapshotKeepUnmounted("preyanet"); err != nil {
-		return err
-	}
-	log.Info("Pre-yanet snapshot saved")
-
-	// Remount 9P -- CommonConfigCommands needs /mnt/config/route0.yaml.
-	if err := fw.Mount9P(); err != nil {
-		return err
-	}
-
-	// Start YANET and apply runtime configurations
-	if err := fw.StartYANET(baselineDP, baselineCP); err != nil {
-		return err
-	}
-
-	dumpMemoryDiagnostics(fw, log)
-
-	if _, err := fw.ExecuteCommands(fw.CommonConfigCommands()...); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func saveBaselineSnapshot(fw *framework.TestFramework, log *zap.SugaredLogger) error {
-	if err := fw.SaveSnapshotKeepUnmounted("baseline"); err != nil {
-		return err
-	}
-
-	log.Info("Baseline snapshot saved successfully")
-	return nil
-}
-
-func ensureBaselineTemplate(qemuImage string, bootedTemplate string, baselineTemplate string, log *zap.SugaredLogger) error {
-	if framework.OverlayHasSnapshot(baselineTemplate, "baseline") {
-		log.Infof("Using cached baseline template: %s", baselineTemplate)
-		return nil
-	}
-
-	log.Infof("Baseline template %s not found; bootstrapping from booted template", baselineTemplate)
-
-	prepPool, err := framework.NewVMPool(1, "baseline-prep", qemuImage, bootedTemplate, "", "", log)
-	if err != nil {
-		return fmt.Errorf("create baseline prep pool: %w", err)
-	}
-	defer func() {
-		if err := prepPool.Shutdown(); err != nil {
-			log.Errorf("Failed to shut down baseline prep pool: %v", err)
-		}
-	}()
-
-	if err := prepPool.StartAll(); err != nil {
-		return fmt.Errorf("start baseline prep pool: %w", err)
-	}
-	if err := prepPool.WaitAllReady(120 * time.Second); err != nil {
-		return fmt.Errorf("baseline prep pool not ready: %w", err)
-	}
-
-	prepFW := prepPool.Acquire()
-	defer prepPool.Release(prepFW)
-
-	if err := prepFW.PrepareLocalStorage(); err != nil {
-		return fmt.Errorf("prepare local storage: %w", err)
-	}
-	if err := configureBaseline(prepFW, log); err != nil {
-		return fmt.Errorf("configure baseline: %w", err)
-	}
-	if err := saveBaselineSnapshot(prepFW, log); err != nil {
-		return fmt.Errorf("save baseline snapshot: %w", err)
-	}
-	if err := prepFW.ExportCurrentOverlay(baselineTemplate); err != nil {
-		return fmt.Errorf("export baseline template: %w", err)
-	}
-	if !framework.OverlayHasSnapshot(baselineTemplate, "baseline") {
-		return fmt.Errorf("exported baseline template %s is missing snapshot %q", baselineTemplate, "baseline")
-	}
-
-	log.Infof("Baseline template cached at %s", baselineTemplate)
-	return nil
-}
 
 // withBootedVM acquires a VM from the pool and restores it to a working
 // YANET state. See restoreBooted for the restore strategy.
 func withBootedVM(t *testing.T, fn func(fw *framework.TestFramework)) {
 	t.Helper()
-	if globalPool == nil {
+	if harness == nil {
 		t.Fatal("VM pool is not initialized")
 	}
-	base := globalPool.Acquire()
-	t.Cleanup(func() {
-		globalPool.Release(base)
-	})
-	fw := base.ForTest(t)
-	restoreBooted(t, fw)
-	fn(fw)
+	harness.WithBootedVM(t, fn)
 }
 
 // bootedRunner runs subtests each in their own isolated booted restore.
@@ -349,51 +74,14 @@ func testFramework(t *testing.T) *framework.TestFramework {
 	return fw
 }
 
-// restoreBooted restores the VM to a working YANET state. It tries the
-// fast path (baseline snapshot with YANET already running) first, and
-// falls back to the slow path (preyanet snapshot + fresh StartYANET)
-// only when baseline restore fails.
+// restoreBooted restores the VM to a working YANET state.
 //
-// Fast path (~3-5s): loadvm to "baseline" (YANET running, configured).
-//
-//	Requires connection reset to clear stale host-side sockets.
-//
-// Slow path (~20-50s): loadvm to "preyanet" (no YANET), StartYANET from
-//
-//	scratch, configure. Used when DPDK device state is genuinely broken
-//	after loadvm and the heartbeat cannot succeed.
+// It tries the fast path (baseline snapshot with YANET already running)
+// first, and falls back to the slow path (preyanet snapshot + fresh
+// StartYANET) only when baseline restore fails.
 func restoreBooted(t *testing.T, fw *framework.TestFramework) {
 	t.Helper()
-
-	if err := fw.RestoreAndReconnect("baseline"); err == nil {
-		return
-	}
-
-	t.Logf("baseline restore failed, falling back to preyanet + fresh StartYANET")
-
-	if err := fw.RestoreClean("preyanet"); err != nil {
-		t.Fatalf("failed to restore VM to preyanet: %v", err)
-	}
-	if err := fw.StartYANET(baselineDP, baselineCP); err != nil {
-		t.Fatalf("failed to start YANET: %v", err)
-	}
-	if _, err := fw.ExecuteCommands(fw.CommonConfigCommands()...); err != nil {
-		t.Fatalf("failed to configure YANET: %v", err)
-	}
-
-	fw.ResetConnections()
-
-	const dpTimeout = 15 * time.Second
-	if err := fw.WaitForDatapathReady(dpTimeout); err != nil {
-		t.Logf("dataplane not ready after %v, restarting YANET...", dpTimeout)
-		if restartErr := fw.RestartYANET(); restartErr != nil {
-			t.Fatalf("YANET restart failed: %v", restartErr)
-		}
-		fw.ResetConnections()
-		if err := fw.WaitForDatapathReady(dpTimeout); err != nil {
-			t.Fatalf("dataplane not ready after preyanet restore + restart: %v", err)
-		}
-	}
+	harness.RestoreBooted(t, fw)
 }
 
 // TestMain is the entry point for running tests in this package.
@@ -403,24 +91,8 @@ func TestMain(m *testing.M) {
 	os.Exit(testMainWrapper(m))
 }
 
-// testMainWrapper is a test framework wrapper function that:
-// 1. Initializes logging based on YANET_TEST_DEBUG environment variable
-// 2. Creates and configures test framework with QEMU image
-// 3. Starts YANET with predefined dataplane and controlplane configurations
-// 4. Executes common configuration commands
-// 5. Runs all tests via testing.M.Run()
-//
-// The function handles framework lifecycle:
-// - Starts framework and QEMU VM
-// - Waits for VM readiness
-// - Ensures proper cleanup on exit
-// - Returns test execution status code
-//
-// Parameters:
-//   - m: testing.M instance for running tests
-//
-// Returns:
-//   - int: Test execution result code
+// testMainWrapper builds the baseline VM pool via the framework harness, runs
+// the package's tests, and tears the pool down on exit.
 func testMainWrapper(m *testing.M) (code int) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -429,77 +101,28 @@ func testMainWrapper(m *testing.M) (code int) {
 		}
 	}()
 
-	// Create logger for detailed logging
-	lg := zap.NewDevelopmentConfig()
-	if !framework.IsDebugEnabled() {
-		// no env - set error level
-		lg.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
-	} else {
-		// save debug log to test.log
-		lg.OutputPaths = []string{"test.log"}
-		lg.ErrorOutputPaths = []string{"stderr", "test.log"}
-	}
-	logger, err := lg.Build()
+	h, cleanup, err := framework.SetupHarness(framework.HarnessConfig{
+		PoolName: "main",
+	})
 	if err != nil {
-		panic(err)
-	}
-	defer logger.Sync()
-	sugar := logger.Sugar()
-
-	// Get QEMU image path (relative to parent functional directory)
-	qemuImage := os.Getenv("YANET_QEMU_IMAGE")
-	if qemuImage == "" {
-		qemuImage = "../yanet-test.qcow2"
-	}
-	// Booted template is stored alongside the base image.
-	// It is created by 'make prepare-vm'; if missing it is bootstrapped at runtime.
-	bootedTemplate := framework.BootedImagePath(qemuImage)
-	baselineTemplate := framework.BaselineImagePath(qemuImage)
-
-	if err := ensureBaselineTemplate(qemuImage, bootedTemplate, baselineTemplate, sugar); err != nil {
-		sugar.Errorf("Failed to prepare baseline template: %v", err)
+		fmt.Fprintf(os.Stderr, "failed to set up functional-test harness: %v\n", err)
 		return 1
 	}
-	framework.MarkBaselineSaved()
+	defer cleanup()
 
-	sugar.Infof("Starting VM pool with size %d (baseline template: %s)", framework.PoolSize(), baselineTemplate)
-
-	pool, err := framework.NewVMPool(framework.PoolSize(), "main", qemuImage, bootedTemplate, baselineTemplate, "baseline", sugar)
-	if err != nil {
-		sugar.Errorf("Failed to create VM pool: %v", err)
-		return 1
-	}
-	globalPool = pool
+	harness = h
+	globalPool = h.Pool()
 
 	defer func() {
-		if globalPool != nil {
-			if err := globalPool.Shutdown(); err != nil {
-				sugar.Errorf("Failed to shut down VM pool: %v", err)
-				code = 12
-			}
-			globalPool = nil
+		if err := h.Shutdown(); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to shut down VM pool: %v\n", err)
+			code = 12
 		}
+		harness = nil
+		globalPool = nil
 	}()
 
-	if err := pool.StartAll(); err != nil {
-		sugar.Errorf("Failed to start VM pool: %v", err)
-		return 1
-	}
-
-	if err := pool.WaitAllReady(120 * time.Second); err != nil {
-		sugar.Errorf("Failed to wait for VM pool readiness: %v", err)
-		return 1
-	}
-
-	// Pause all VM CPUs now that baseline snapshots are saved.
-	// Idle VMs would otherwise keep DPDK's busy-poll loop running and
-	// consume host CPU, starving the active VM's packet processing.
-	// Each VM resumes automatically when RestoreSnapshot calls loadvm+cont.
-	pool.StopAllCPU()
-
-	// Run tests
-	code = m.Run()
-	return code
+	return m.Run()
 }
 
 // TestFramework - comprehensive test for checking all yanet functionality


### PR DESCRIPTION
The functional-test VM-pool baseline setup lived inline in the main test package, so no other module's test package could reuse it. Extract it into the framework library as a reusable harness with its config builders, and refactor the main test package to consume it.

The framework also gains optional module .so plugin loading (a plugin directory passthrough plus copying the plugin objects to local tmpfs), so a module test package can boot a VM that loads its plugin. The existing main pool keeps its previous configuration; the extra shared-memory headroom applies only to plugin-loading configurations.
