### PR TITLE
chore(cargo): discover module CLI crates via a glob workspace member

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,8 @@ members = [
     "cli/modules/ready",
     "cli/modules/metrics",
     "cli/modules/device",
-    "modules/acl/cli",
-    "modules/blackhole/cli",
-    "modules/fwstate/cli",
-    "modules/decap/cli",
-    "modules/dscp/cli",
-    "modules/forward/cli",
-    "modules/mirror/cli",
-    "modules/nat64/cli",
-    "modules/pdump/cli",
-    "modules/balancer2/cli",
+    "modules/*/cli",
     "modules/route/cli/route",
-    "modules/route-mpls/cli",
     "devices/plain/cli",
     "devices/vlan/cli",
     "devices/trafgen/cli",
@@ -38,6 +28,8 @@ members = [
     "operators/route/cli/route",
     "operators/route/cli/neighbour",
 ]
+
+exclude = ["modules/route/cli"]
 
 [profile.release]
 panic = "abort"


### PR DESCRIPTION
Module CLI crates were listed one by one in the workspace, so an optional or out-of-tree module's CLI needed a Cargo.toml edit to be built. Match them with a glob member instead, so a module's CLI crate is picked up by a workspace build automatically — the Cargo counterpart to the meson extra_modules option.

The route CLI crate is nested, so its parent directory is excluded to keep the glob from treating that non-crate directory as a member. The resolved workspace member set and Cargo.lock are unchanged for the public checkout.
