### PR TITLE
feat(balancer2): implement dataplane packet processing

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -8,6 +8,7 @@ package dataplaneut
 
 // Library search paths — modules, devices, and support libs.
 #cgo LDFLAGS: -L../../../build/modules/blackhole/dataplane
+#cgo LDFLAGS: -L../../../build/modules/balancer2/dataplane
 #cgo LDFLAGS: -L../../../build/modules/decap/dataplane
 #cgo LDFLAGS: -L../../../build/modules/dscp/dataplane
 #cgo LDFLAGS: -L../../../build/modules/acl/dataplane
@@ -38,7 +39,7 @@ package dataplaneut
 // references between them (fwstate->acl, worker->pipeline, etc.).
 // fwstate depends on acl — acl must come first inside the group.
 #cgo LDFLAGS: -Wl,--start-group
-#cgo LDFLAGS: -lblackhole_dp -ldecap_dp -ldscp_dp -lacl_dp -lfwstate_dp -lforward_dp -lmirror_dp -lroute_dp -lnat64_dp -lpdump_dp
+#cgo LDFLAGS: -lblackhole_dp -lbalancer2_dp -ldecap_dp -ldscp_dp -lacl_dp -lfwstate_dp -lforward_dp -lmirror_dp -lroute_dp -lnat64_dp -lpdump_dp
 #cgo LDFLAGS: -lplain_dp -lvlan_dp
 #cgo LDFLAGS: -ldataplane_ut -lpipeline -lmodule -lworker_dp -lconfig_dp -lpacket
 #cgo LDFLAGS: -llogging -lagent -lconfig_cp -lcounters -lerrors -lfilter_compiler -lfwstate -llib_utils
@@ -92,6 +93,7 @@ free_cptr_array(const char **arr) {
 void
 keep_refs(void **ptrs) {
 	extern struct module *new_module_blackhole(void);
+	extern struct module *new_module_balancer2(void);
 	extern struct module *new_module_decap(void);
 	extern struct module *new_module_dscp(void);
 	extern struct module *new_module_acl(void);
@@ -107,6 +109,7 @@ keep_refs(void **ptrs) {
 
 	static void *funcs[] = {
 		new_module_blackhole,
+		new_module_balancer2,
 		new_module_decap,
 		new_module_dscp,
 		new_module_acl,

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -531,6 +531,7 @@ dataplane_init(
 			"route_mpls",
 			"blackhole",
 			"mirror",
+			"balancer2",
 		};
 
 		for (size_t i = 0;

--- a/dataplane/meson.build
+++ b/dataplane/meson.build
@@ -51,6 +51,7 @@ dependencies = lib_dependencies + [
   lib_pdump_dp_dep,
   lib_fwstate_dp_dep,
   lib_blackhole_dp_dep,
+  lib_balancer2_dp_dep,
 
   #devices
   lib_dev_plain_dp_dep,

--- a/modules/balancer2/dataplane/config.h
+++ b/modules/balancer2/dataplane/config.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "filter/filter.h"
+
+#include "lib/controlplane/config/cp_module.h"
+
+#include "types/session.h"
+
+#include "common/rcu.h"
+
+struct balancer_session_table_chain;
+struct virtual_service;
+
+struct balancer_module_config {
+	struct cp_module cp_module;
+
+	uint64_t common_counter_id;
+	uint64_t l4_counter_id;
+
+	struct filter vs_matcher_ip4;
+	struct filter vs_matcher_ip6;
+
+	struct virtual_service *vs;
+	uint32_t vs_count;
+
+	struct balancer_session_timeouts session_timeouts;
+
+	struct balancer_session_table_chain *st_chain;
+
+	/*
+	 * RCU guard for the inner atomic changes on the config,
+	 * including changes on reals ring of virtual services.
+	 */
+	rcu_t rcu;
+};

--- a/modules/balancer2/dataplane/context.h
+++ b/modules/balancer2/dataplane/context.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stdint.h>
+
+struct packet_front;
+struct counter_storage;
+
+struct worker_context {
+	struct packet_front *packet_front;
+	struct balancer_module_config *config;
+	struct counter_storage *counter_storage;
+
+	struct balancer_common_stats *common_stats;
+	struct balancer_l4_stats *l4_stats;
+
+	uint32_t worker_idx;
+
+	/* Current time in seconds. */
+	uint32_t now;
+};

--- a/modules/balancer2/dataplane/dataplane.c
+++ b/modules/balancer2/dataplane/dataplane.c
@@ -1,0 +1,209 @@
+#include <assert.h>
+#include <netinet/in.h>
+#include <rte_ether.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "common/memory_address.h"
+
+#include "lib/counters/counters.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/dataplane/module/packet_front.h"
+#include "lib/dataplane/packet/data.h"
+#include "lib/dataplane/pipeline/econtext.h"
+
+#include "types/stats.h"
+
+#include "config.h"
+#include "context.h"
+#include "dataplane.h"
+
+#include "icmp/handle.h"
+#include "l4/handle.h"
+
+#define MAX_BATCH_SIZE 64
+static_assert(
+	MAX_BATCH_SIZE <= 256, "MAX_BATCH_SIZE must fit in a uint8_t index"
+);
+
+typedef void (*batch_handler)(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count
+);
+
+struct packet_batcher {
+	struct packet *packets[MAX_BATCH_SIZE];
+	size_t count;
+	batch_handler handler;
+};
+
+static void
+batcher_add(
+	struct packet_batcher *batcher,
+	struct worker_context *context,
+	struct packet *packet
+) {
+	batcher->packets[batcher->count++] = packet;
+	if (batcher->count == MAX_BATCH_SIZE) {
+		batcher->handler(context, batcher->packets, batcher->count);
+		batcher->count = 0;
+	}
+}
+
+static void
+batcher_flush(struct packet_batcher *batcher, struct worker_context *context) {
+	if (batcher->count > 0) {
+		batcher->handler(context, batcher->packets, batcher->count);
+		batcher->count = 0;
+	}
+}
+
+static uint64_t *
+context_get_counter(struct worker_context *context, uint64_t counter_id) {
+	return counter_get_address(counter_id, context->counter_storage);
+}
+
+static void
+build_context(
+	struct worker_context *ctx,
+	struct dp_worker *dp_worker,
+	struct module_ectx *module_ectx,
+	struct packet_front *packet_front
+) {
+	struct balancer_module_config *config = container_of(
+		ADDR_OF(&module_ectx->cp_module),
+		struct balancer_module_config,
+		cp_module
+	);
+	ctx->config = config;
+	ctx->packet_front = packet_front;
+	ctx->counter_storage = ADDR_OF(&module_ectx->counter_storage);
+	ctx->worker_idx = dp_worker->idx;
+	ctx->now = dp_worker->current_time / (1000 * 1000 * 1000); /* ns -> s */
+
+	ctx->common_stats = (struct balancer_common_stats *)context_get_counter(
+		ctx, config->common_counter_id
+	);
+	ctx->l4_stats = (struct balancer_l4_stats *)context_get_counter(
+		ctx, config->l4_counter_id
+	);
+}
+
+static inline bool
+valid_packet_network(uint16_t network_type) {
+	return network_type == rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4) ||
+	       network_type == rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6);
+}
+
+static inline bool
+valid_packet_transport(uint16_t transport_type) {
+	/*
+	 * Connection-bearing protocols are forwarded to reals; ICMP is
+	 * accepted separately for echo/error handling rather than
+	 * load-balancing.
+	 */
+	return transport_type == IPPROTO_TCP || transport_type == IPPROTO_UDP ||
+	       transport_type == IPPROTO_ICMP ||
+	       transport_type == IPPROTO_ICMPV6;
+}
+
+void
+balancer2_handle_packets(
+	struct dp_worker *dp_worker,
+	struct module_ectx *module_ectx,
+	struct packet_front *packet_front
+) {
+	struct worker_context context;
+	build_context(&context, dp_worker, module_ectx, packet_front);
+
+	/*
+	 * Classify incoming packets by protocol (L4/ICMP) and IP version
+	 * (IPv4/IPv6), accumulating them into per-category batches.
+	 *
+	 * Batched processing allows the filter engine to evaluate multiple
+	 * packets at once, which is significantly faster than one-at-a-time
+	 * lookups due to memory prefetching and reduced per-packet overhead.
+	 *
+	 * Batches are flushed when they reach MAX_BATCH_SIZE or when all
+	 * input packets have been classified.
+	 */
+	enum { l4_ip4, l4_ip6, icmp_ip4, icmp_ip6, batcher_count };
+	struct packet_batcher batchers[batcher_count] = {
+		[l4_ip4] = {.handler = balancer_handle_l4_ip4},
+		[l4_ip6] = {.handler = balancer_handle_l4_ip6},
+		/* For the future ICMP support. */
+		[icmp_ip4] = {.handler = balancer_handle_icmp_ip4},
+		[icmp_ip6] = {.handler = balancer_handle_icmp_ip6},
+	};
+
+	context.common_stats->incoming_packets +=
+		packet_front_input_count(packet_front);
+
+	struct packet *packet;
+	while ((packet = packet_list_pop(&packet_front->input)) != NULL) {
+		context.common_stats->incoming_bytes += packet_data_len(packet);
+
+		uint16_t network_type = packet->network_header.type;
+		if (!valid_packet_network(network_type)) {
+			context.common_stats->unexpected_network_proto += 1;
+			packet_front_output(packet_front, packet);
+			continue;
+		}
+
+		uint16_t transport_type = packet->transport_header.type;
+		if (!valid_packet_transport(transport_type)) {
+			context.common_stats->unexpected_transport_proto += 1;
+			packet_front_output(packet_front, packet);
+			continue;
+		}
+
+		int is_ip6 =
+			network_type == rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6);
+		int is_icmp = transport_type == IPPROTO_ICMP ||
+			      transport_type == IPPROTO_ICMPV6;
+
+		/*
+		 * Only the initial fragment of a TCP/UDP datagram carries a
+		 * port header; later fragments would have their fragment
+		 * payload misread as ports.
+		 */
+		if (!is_icmp && packet->fragment_offset != 0) {
+			context.common_stats->non_initial_l4_fragments += 1;
+			packet_front_output(packet_front, packet);
+			continue;
+		}
+
+		int idx = is_icmp * 2 + is_ip6;
+		batcher_add(&batchers[idx], &context, packet);
+	}
+
+	for (int i = 0; i < batcher_count; ++i) {
+		batcher_flush(&batchers[i], &context);
+	}
+}
+
+struct balancer_module {
+	struct module module;
+};
+
+struct module *
+new_module_balancer2() {
+	struct balancer_module *module =
+		(struct balancer_module *)malloc(sizeof(struct balancer_module)
+		);
+
+	if (module == NULL) {
+		return NULL;
+	}
+
+	snprintf(
+		module->module.name,
+		sizeof(module->module.name),
+		"%s",
+		"balancer2"
+	);
+	module->module.handler = balancer2_handle_packets;
+
+	return &module->module;
+}

--- a/modules/balancer2/dataplane/dataplane.h
+++ b/modules/balancer2/dataplane/dataplane.h
@@ -1,0 +1,4 @@
+#pragma once
+
+struct module *
+new_module_balancer2();

--- a/modules/balancer2/dataplane/icmp/handle.c
+++ b/modules/balancer2/dataplane/icmp/handle.c
@@ -1,0 +1,27 @@
+#include "handle.h"
+
+#include "lib/dataplane/module/packet_front.h"
+
+#include "context.h"
+
+void
+balancer_handle_icmp_ip4(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count
+) {
+	for (size_t i = 0; i < packets_count; i++) {
+		packet_front_drop(context->packet_front, packets[i]);
+	}
+}
+
+void
+balancer_handle_icmp_ip6(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count
+) {
+	for (size_t i = 0; i < packets_count; i++) {
+		packet_front_drop(context->packet_front, packets[i]);
+	}
+}

--- a/modules/balancer2/dataplane/icmp/handle.h
+++ b/modules/balancer2/dataplane/icmp/handle.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stddef.h>
+
+struct packet;
+struct worker_context;
+
+void
+balancer_handle_icmp_ip4(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count
+);
+
+void
+balancer_handle_icmp_ip6(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count
+);

--- a/modules/balancer2/dataplane/l4/group.c
+++ b/modules/balancer2/dataplane/l4/group.c
@@ -1,0 +1,60 @@
+#include "common/likely.h"
+#include <string.h>
+
+#include "group.h"
+
+/*
+ * Maximum number of distinct VS IDs we track per batch.
+ * Practically 1-5 in normal traffic; 16 covers even degenerate cases.
+ * If exceeded, grouping is skipped (packets still processed correctly,
+ * just not batched per-VS for ACL queries).
+ */
+#define MAX_GROUPS 16
+
+void
+group_by_id(uint32_t *vs_ids, uint8_t *order, size_t count) {
+	/* Pass 1: collect unique VS IDs and count per group. */
+	uint32_t unique_vs[MAX_GROUPS];
+	size_t counts[MAX_GROUPS];
+	size_t ngroups = 0;
+
+	for (size_t i = 0; i < count; ++i) {
+		for (size_t g = 0; g < ngroups; ++g) {
+			if (unique_vs[g] == vs_ids[i]) {
+				counts[g]++;
+				goto next;
+			}
+		}
+		if (unlikely(ngroups == MAX_GROUPS)) {
+			return;
+		}
+		unique_vs[ngroups] = vs_ids[i];
+		counts[ngroups] = 1;
+		ngroups++;
+	next:;
+	}
+
+	/* Compute scatter offsets from prefix sums. */
+	size_t offsets[MAX_GROUPS];
+	offsets[0] = 0;
+	for (size_t g = 1; g < ngroups; ++g) {
+		offsets[g] = offsets[g - 1] + counts[g - 1];
+	}
+
+	/* Pass 2: scatter into temporary arrays. */
+	uint32_t tmp_ids[count];
+	uint8_t tmp_order[count];
+	for (size_t i = 0; i < count; ++i) {
+		for (size_t g = 0; g < ngroups; ++g) {
+			if (unique_vs[g] == vs_ids[i]) {
+				size_t pos = offsets[g]++;
+				tmp_ids[pos] = vs_ids[i];
+				tmp_order[pos] = order[i];
+				break;
+			}
+		}
+	}
+
+	memcpy(vs_ids, tmp_ids, count * sizeof(uint32_t));
+	memcpy(order, tmp_order, count * sizeof(uint8_t));
+}

--- a/modules/balancer2/dataplane/l4/group.h
+++ b/modules/balancer2/dataplane/l4/group.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Rearrange vs_ids[] and order[] so that entries with the same vs_id
+ * are contiguous. Uses a two-pass counting sort with a small group
+ * table, giving O(n * k) time for k distinct VS IDs.
+ *
+ * If there is too many distinct VS, the grouping is skipped.
+ */
+void
+group_by_id(uint32_t *ids, uint8_t *order, size_t count);

--- a/modules/balancer2/dataplane/l4/handle.c
+++ b/modules/balancer2/dataplane/l4/handle.c
@@ -1,0 +1,372 @@
+#include <string.h>
+
+#include "common/likely.h"
+#include "common/memory_address.h"
+
+#include "lib/dataplane/module/packet_front.h"
+#include "lib/dataplane/packet/data.h"
+
+#include "filter/query.h"
+
+#include "config.h"
+#include "context.h"
+#include "group.h"
+#include "packet.h"
+#include "select.h"
+#include "session.h"
+#include "tunnel.h"
+#include "vs.h"
+
+#include "../session.h"
+
+#include "types/stats.h"
+
+FILTER_QUERY_DECLARE(
+	ipv4_vs_matcher, net4_fast_dst, port_fast_dst, proto_range_fast
+);
+FILTER_QUERY_DECLARE(ipv4_vs_acl, net4_fast_src, port_fast_src);
+
+FILTER_QUERY_DECLARE(
+	ipv6_vs_matcher, net6_fast_dst, port_fast_dst, proto_range_fast
+);
+FILTER_QUERY_DECLARE(ipv6_vs_acl, net6_fast_src, port_fast_src);
+
+/*
+ * Batch ACL query for a group of packets sharing the same VS.
+ * Updates incoming and ACL stats, drops packets that fail.
+ * Appends passing packets to pkt_ctxs.
+ * Returns the number of packets that passed.
+ */
+static size_t
+filter_vs_group(
+	struct worker_context *context,
+	struct virtual_service *vs,
+	struct packet **group_pkts,
+	size_t group_size,
+	struct packet_context *pkt_ctxs,
+	bool is_ipv6
+) {
+	struct balancer_vs_stats *vs_stats =
+		vs_fetch_stats(vs, context->counter_storage);
+
+	uint32_t acl_results[group_size];
+	if (is_ipv6) {
+		filter_query(
+			&vs->acl,
+			ipv6_vs_acl,
+			group_pkts,
+			acl_results,
+			group_size
+		);
+	} else {
+		filter_query(
+			&vs->acl,
+			ipv4_vs_acl,
+			group_pkts,
+			acl_results,
+			group_size
+		);
+	}
+
+	size_t passed = 0;
+	for (size_t i = 0; i < group_size; ++i) {
+		uint32_t rule_idx = acl_results[i];
+		if (rule_idx == FILTER_RULE_INVALID) {
+			vs_stats->packet_src_not_allowed += 1;
+			packet_front_drop(context->packet_front, group_pkts[i]);
+			continue;
+		}
+
+		vs_stats->incoming_packets += 1;
+		vs_stats->incoming_bytes += packet_data_len(group_pkts[i]);
+
+		uint64_t *rule_counter = vs_fetch_acl_stats(
+			vs, context->counter_storage, rule_idx
+		);
+
+		/* Dont track stats for rules with empty tag. */
+		if (rule_counter != NULL) {
+			*rule_counter += 1;
+		}
+
+		pkt_ctxs[passed++] = (struct packet_context){
+			.packet = group_pkts[i],
+			.matched_vs = vs,
+			.matched_vs_stats = vs_stats,
+		};
+	}
+
+	return passed;
+}
+
+/*
+ * Match packets to virtual services, then filter by ACL.
+ *
+ * 1. Batch VS lookup — classify all packets at once.
+ * 2. Group matched packets by VS.
+ * 3. Batch ACL per group — drop packets that fail.
+ *
+ * Returns the number of packets that passed both checks.
+ * The boolean parameter is constant at each call site, so the
+ * compiler can eliminate the unreachable branch after inlining.
+ */
+static size_t
+service_lookup(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count,
+	struct packet_context *pkt_ctxs,
+	bool is_ipv6
+) {
+	/* Batch VS lookup. */
+	uint32_t vs_results[packets_count];
+	if (is_ipv6) {
+		filter_query(
+			&context->config->vs_matcher_ip6,
+			ipv6_vs_matcher,
+			packets,
+			vs_results,
+			packets_count
+		);
+	} else {
+		filter_query(
+			&context->config->vs_matcher_ip4,
+			ipv4_vs_matcher,
+			packets,
+			vs_results,
+			packets_count
+		);
+	}
+
+	/* Drop unmatched, record indices and vs_ids of the rest. */
+	uint8_t order[packets_count];
+	uint32_t vs_ids[packets_count];
+	size_t matched_count = 0;
+
+	for (size_t i = 0; i < packets_count; ++i) {
+		uint32_t vs_id = vs_results[i];
+		if (vs_id == FILTER_RULE_INVALID) {
+			context->l4_stats->select_vs_failed += 1;
+			packet_front_drop(context->packet_front, packets[i]);
+			continue;
+		}
+
+		order[matched_count] = i;
+		vs_ids[matched_count] = vs_id;
+		matched_count++;
+	}
+
+	if (unlikely(matched_count == 0)) {
+		return 0;
+	}
+
+	/*
+	 * Group by VS for batched ACL queries. If grouping fails
+	 * (too many distinct VSes), the loop below still works
+	 * correctly with ungrouped packets — just smaller batches.
+	 */
+	group_by_id(vs_ids, order, matched_count);
+
+	struct virtual_service *virtual_services =
+		ADDR_OF(&context->config->vs);
+
+	/* Run ACL per VS group. */
+	size_t total_passed = 0;
+	size_t pkt_idx = 0;
+	struct packet *group_pkts[matched_count];
+	while (pkt_idx < matched_count) {
+		uint32_t cur_vs_id = vs_ids[pkt_idx];
+
+		/* Collect contiguous packets for this VS. */
+		size_t group_size = 0;
+		while (pkt_idx < matched_count && vs_ids[pkt_idx] == cur_vs_id
+		) {
+			group_pkts[group_size++] = packets[order[pkt_idx]];
+			pkt_idx++;
+		}
+
+		total_passed += filter_vs_group(
+			context,
+			virtual_services + cur_vs_id,
+			group_pkts,
+			group_size,
+			pkt_ctxs + total_passed,
+			is_ipv6
+		);
+	}
+
+	return total_passed;
+}
+
+static size_t
+select_reals(
+	struct worker_context *context,
+	struct packet_context *pkt_ctxs,
+	struct session *sessions,
+	size_t packet_count,
+	struct balancer_session_table_chain *st_chain,
+	uint64_t st_chain_gen
+) {
+	const size_t prefetch_distance = 4;
+
+	size_t kept = 0;
+	for (size_t pkt_idx = 0; pkt_idx < packet_count; ++pkt_idx) {
+		if (pkt_idx + prefetch_distance < packet_count) {
+			st_chain_prefetch_session(
+				st_chain,
+				st_chain_gen,
+				&sessions[pkt_idx + prefetch_distance].id
+			);
+		}
+
+		struct real *real = select_real(
+			context,
+			&pkt_ctxs[pkt_idx],
+			&sessions[pkt_idx],
+			st_chain,
+			st_chain_gen
+		);
+
+		if (unlikely(real == NULL)) {
+			context->l4_stats->select_real_failed += 1;
+			packet_front_drop(
+				context->packet_front, pkt_ctxs[pkt_idx].packet
+			);
+			continue;
+		}
+
+		if (kept != pkt_idx) {
+			pkt_ctxs[kept] = pkt_ctxs[pkt_idx];
+		}
+		pkt_ctxs[kept].selected_real = real;
+		pkt_ctxs[kept].selected_real_stats =
+			real_fetch_stats(real, context->counter_storage);
+		kept++;
+	}
+
+	return kept;
+}
+
+static void
+tunnel_packets(
+	struct worker_context *context,
+	struct packet_context *pkt_ctxs,
+	size_t packet_count,
+	bool is_ipv6
+) {
+	struct packet_front *packet_front = context->packet_front;
+	for (size_t pkt_idx = 0; pkt_idx < packet_count; ++pkt_idx) {
+		struct packet_context *pkt_ctx = &pkt_ctxs[pkt_idx];
+
+		int res;
+		if (is_ipv6) {
+			res = tunnel_ip6_packet(pkt_ctx);
+		} else {
+			res = tunnel_ip4_packet(pkt_ctx);
+		}
+
+		if (unlikely(res != 0)) {
+			context->l4_stats->tunnel_failed += 1;
+			packet_front_drop(packet_front, pkt_ctx->packet);
+			continue;
+		}
+
+		packet_front_output(packet_front, pkt_ctx->packet);
+
+		uint64_t pkt_len = packet_data_len(pkt_ctx->packet);
+
+		context->common_stats->outgoing_packets += 1;
+		context->common_stats->outgoing_bytes += pkt_len;
+
+		context->l4_stats->outgoing_packets += 1;
+
+		pkt_ctx->matched_vs_stats->outgoing_packets += 1;
+		pkt_ctx->matched_vs_stats->outgoing_bytes += pkt_len;
+
+		pkt_ctx->selected_real_stats->packets += 1;
+		pkt_ctx->selected_real_stats->bytes += pkt_len;
+	}
+}
+
+/*
+ * L4 packet processing pipeline.
+ *
+ * 1. match_and_filter:       VS lookup + ACL check (batched).
+ *                            Drops packets with no VS or failing ACL.
+ *
+ * 2. fill_sessions:          parse IP/transport headers into
+ *                            session_id, timeout, and reschedule flag.
+ *
+ * 3. select_reals:           look up or create a session, pick a
+ *                            real server. Runs inside two critical
+ *                            sections:
+ *   - reals_selector_guard:  RCU guard for real selector rings,
+ *                            held across both select and tunnel
+ *                            so the ring isn't freed mid-use.
+ *   - session table CS:      pins the current session map generation,
+ *                            released after all lookups are done.
+ *
+ * 4. tunnel_packets:         encapsulate and forward to the chosen real.
+ */
+static void
+balancer_handle_l4_packets(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count,
+	bool is_ipv6
+) {
+	context->l4_stats->incoming_packets += packets_count;
+
+	struct packet_context pkt_ctxs[packets_count];
+	struct session sessions[packets_count];
+
+	size_t count = service_lookup(
+		context, packets, packets_count, pkt_ctxs, is_ipv6
+	);
+
+	fill_sessions(
+		sessions,
+		pkt_ctxs,
+		count,
+		&context->config->session_timeouts,
+		is_ipv6
+	);
+
+	struct balancer_session_table_chain *st_chain =
+		ADDR_OF(&context->config->st_chain);
+
+	rcu_t *reals_selector_guard = &context->config->rcu;
+	rcu_read_begin(reals_selector_guard, context->worker_idx);
+	uint64_t st_chain_gen =
+		st_chain_begin_cs(st_chain, context->worker_idx);
+
+	count = select_reals(
+		context, pkt_ctxs, sessions, count, st_chain, st_chain_gen
+	);
+
+	st_chain_end_cs(st_chain, context->worker_idx);
+
+	rcu_read_end(reals_selector_guard, context->worker_idx);
+
+	tunnel_packets(context, pkt_ctxs, count, is_ipv6);
+}
+
+void
+balancer_handle_l4_ip4(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count
+) {
+	const bool is_ipv6 = false;
+	balancer_handle_l4_packets(context, packets, packets_count, is_ipv6);
+}
+
+void
+balancer_handle_l4_ip6(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count
+) {
+	const bool is_ipv6 = true;
+	balancer_handle_l4_packets(context, packets, packets_count, is_ipv6);
+}

--- a/modules/balancer2/dataplane/l4/handle.h
+++ b/modules/balancer2/dataplane/l4/handle.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct packet;
+struct worker_context;
+
+void
+balancer_handle_l4_ip4(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count
+);
+
+void
+balancer_handle_l4_ip6(
+	struct worker_context *context,
+	struct packet **packets,
+	size_t packets_count
+);

--- a/modules/balancer2/dataplane/l4/packet.h
+++ b/modules/balancer2/dataplane/l4/packet.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "real.h"
+#include "vs.h"
+
+struct packet_context {
+	struct packet *packet;
+
+	struct virtual_service *matched_vs;
+	struct balancer_vs_stats *matched_vs_stats;
+
+	struct real *selected_real;
+	struct balancer_real_stats *selected_real_stats;
+};

--- a/modules/balancer2/dataplane/l4/select.c
+++ b/modules/balancer2/dataplane/l4/select.c
@@ -1,0 +1,298 @@
+#include <netinet/in.h>
+#include <stdatomic.h>
+#include <string.h>
+
+#include <rte_mbuf.h>
+#include <rte_tcp.h>
+
+#include "common/big_array.h"
+#include "common/flatmap.h"
+#include "common/memory_address.h"
+#include "common/network.h"
+#include "common/ttlmap/detail/lock.h"
+
+#include "lib/dataplane/packet/packet.h"
+
+#include "../session.h"
+#include "context.h"
+#include "packet.h"
+#include "real.h"
+#include "selector.h"
+#include "session.h"
+#include "vs.h"
+
+#include "types/stats.h"
+
+#define INVALID_REAL_IDX ((uint32_t)-1)
+
+static uint32_t
+ring_get(struct ring *ring, uint64_t index) {
+	if (ring->real_ids.size > 0) {
+		uint32_t pos = index % (ring->real_ids.size / sizeof(uint32_t));
+		uint32_t val;
+		memcpy(&val,
+		       big_array_get(&ring->real_ids, pos * sizeof(uint32_t)),
+		       sizeof(val));
+		return val;
+	} else {
+		return INVALID_REAL_IDX;
+	}
+}
+
+static uint32_t
+selector_select(
+	struct real_selector *selector, uint32_t worker, uint32_t hash
+) {
+	size_t ring_id =
+		atomic_load_explicit(&selector->ring_id, memory_order_acquire);
+
+	struct ring *ring = &selector->rings[ring_id];
+
+	uint64_t idx = (selector->workers_rr_counter[worker].value++ &
+			~selector->packet_hash_mask) |
+		       (hash & selector->packet_hash_mask);
+	return ring_get(ring, idx);
+}
+
+static void
+update_session_state(
+	struct balancer_session_state *session_state,
+	uint32_t now,
+	uint32_t session_timeout
+) {
+	session_state->last_packet_timestamp = now;
+	session_state->timeout = session_timeout;
+}
+
+static void
+create_session_state(
+	struct balancer_session_state *session_state,
+	struct real *real,
+	uint32_t now,
+	uint32_t session_timeout
+) {
+	session_state->create_timestamp = now;
+	session_state->last_packet_timestamp = now;
+	session_state->real_ip.addr = real->addr;
+	session_state->real_ip.family =
+		(real_flags(real) & real_ip6 ? ip_family_ip6 : ip_family_ip4);
+	session_state->timeout = session_timeout;
+}
+
+static struct real *
+vs_lookup_real(struct virtual_service *vs, struct real_ip *real_ip) {
+	void *id = flatmap_lookup(
+		&vs->reals_map, real_ip, sizeof(*real_ip), sizeof(uint32_t)
+	);
+	return id == NULL ? NULL : ADDR_OF(&vs->reals) + *(uint32_t *)id;
+}
+
+/*
+ * Checks whether a real is currently enabled, accounting the packet
+ * against it if not.
+ *
+ * A real selected from the ring can still be disabled: ring rebuilds
+ * and the real's enabled flag are updated as separate steps by the
+ * control plane, so a worker can briefly observe a stale ring entry
+ * for a real that was just disabled.
+ */
+static bool
+real_is_usable(
+	struct worker_context *context,
+	struct real *real,
+	struct balancer_vs_stats *vs_stats
+) {
+	if (likely(real_flags(real) & real_enabled)) {
+		return true;
+	}
+	struct balancer_real_stats *stats =
+		real_fetch_stats(real, context->counter_storage);
+	stats->packets_real_disabled += 1;
+	vs_stats->real_is_disabled += 1;
+	return false;
+}
+
+/*
+ * Try to reuse the real from an existing session.
+ * Returns the real if still exists and enabled, NULL otherwise.
+ */
+static struct real *
+try_reuse_session_real(
+	struct worker_context *context,
+	struct packet_context *pkt_ctx,
+	struct balancer_session_state *session_state
+) {
+	struct virtual_service *vs = pkt_ctx->matched_vs;
+	struct balancer_vs_stats *vs_stats = pkt_ctx->matched_vs_stats;
+
+	struct real *real = vs_lookup_real(vs, &session_state->real_ip);
+	if (unlikely(real == NULL)) {
+		return NULL;
+	}
+
+	if (unlikely(!real_is_usable(context, real, vs_stats))) {
+		return NULL;
+	}
+
+	return real;
+}
+
+static struct real *
+select_real_ops(
+	struct worker_context *context,
+	struct packet_context *pkt_ctx,
+	struct virtual_service *vs
+) {
+	uint32_t real_idx = selector_select(
+		ADDR_OF(&vs->selector),
+		context->worker_idx,
+		pkt_ctx->packet->hash
+	);
+	if (unlikely(real_idx == INVALID_REAL_IDX)) {
+		pkt_ctx->matched_vs_stats->no_reals += 1;
+		return NULL;
+	}
+	struct real *real = ADDR_OF(&vs->reals) + real_idx;
+	if (unlikely(!real_is_usable(context, real, pkt_ctx->matched_vs_stats)
+	    )) {
+		return NULL;
+	}
+	return real;
+}
+
+/*
+ * Select a new real from the ring and write it into the session slot.
+ * Returns the real, or NULL if the ring is empty or the selected real
+ * is disabled.
+ */
+static struct real *
+schedule_new_real(
+	struct worker_context *context,
+	struct packet_context *pkt_ctx,
+	struct session *session,
+	struct virtual_service *vs,
+	struct balancer_session_state *session_state
+) {
+	uint32_t real_id = selector_select(
+		ADDR_OF(&vs->selector),
+		context->worker_idx,
+		pkt_ctx->packet->hash
+	);
+	if (unlikely(real_id == INVALID_REAL_IDX)) {
+		pkt_ctx->matched_vs_stats->no_reals += 1;
+		return NULL;
+	}
+
+	struct real *real = ADDR_OF(&vs->reals) + real_id;
+	if (unlikely(!real_is_usable(context, real, pkt_ctx->matched_vs_stats)
+	    )) {
+		return NULL;
+	}
+	create_session_state(
+		session_state, real, context->now, session->timeout
+	);
+
+	struct balancer_real_stats *real_stats =
+		real_fetch_stats(real, context->counter_storage);
+	real_stats->created_sessions += 1;
+	pkt_ctx->matched_vs_stats->created_sessions += 1;
+
+	return real;
+}
+
+struct real *
+select_real(
+	struct worker_context *context,
+	struct packet_context *pkt_ctx,
+	struct session *session,
+	struct balancer_session_table_chain *st_chain,
+	uint64_t current_table_gen
+) {
+	struct virtual_service *vs = pkt_ctx->matched_vs;
+	struct balancer_vs_stats *vs_stats = pkt_ctx->matched_vs_stats;
+
+	/* OPS: stateless selection, no session involved. */
+	if (vs->flags & vs_ops) {
+		return select_real_ops(context, pkt_ctx, vs);
+	}
+
+	/*
+	 * Acquire a session slot from the session table. The slot is either
+	 * an existing entry or a freshly allocated one, returned under a lock
+	 * that must be released before this function returns.
+	 *
+	 * Possible results:
+	 * - SESSION_FOUND:    existing entry, session_state is populated.
+	 * - SESSION_CREATED:  new (or recycled) entry, session_state is blank.
+	 * - SESSION_TABLE_OVERFLOW: table is full, no slot acquired, no lock
+	 * held.
+	 */
+	struct balancer_session_state *session_state = NULL;
+	ttlmap_lock_t *session_lock;
+	int result = st_chain_get_or_create_session(
+		st_chain,
+		current_table_gen,
+		context->now,
+		session->timeout,
+		&session->id,
+		&session_state,
+		&session_lock
+	);
+
+	if (unlikely(result == SESSION_TABLE_OVERFLOW)) {
+		vs_stats->session_table_overflow += 1;
+		return NULL;
+	}
+
+	/*
+	 * From here on, session_lock is held and must be released
+	 * before returning. session_state points to the locked slot.
+	 */
+
+	/* Try to reuse the real from an existing session. */
+	if (result == SESSION_FOUND) {
+		struct real *real =
+			try_reuse_session_real(context, pkt_ctx, session_state);
+		if (real != NULL) {
+			/* Real is still valid -- prolong the session. */
+			update_session_state(
+				session_state, context->now, session->timeout
+			);
+			st_chain_unlock_session(session_lock);
+			return real;
+		}
+		/*
+		 * Real is gone (disabled or removed). The session slot
+		 * is still allocated and locked -- fall through to
+		 * reschedule, which will overwrite it with a new real.
+		 */
+	}
+
+	/*
+	 * At this point we need to assign a new real to the session slot.
+	 * This happens when:
+	 * - SESSION_CREATED: no prior session existed (new flow).
+	 * - SESSION_FOUND but real is stale (disabled/removed).
+	 *
+	 * Only connection-initiating packets may create or overwrite
+	 * sessions. Non-initiating packets (TCP non-SYN) are dropped
+	 * and the session slot is freed.
+	 */
+	if (unlikely(!session->can_reschedule)) {
+		vs_stats->not_rescheduled_packets += 1;
+		st_chain_remove_session(session_state);
+		st_chain_unlock_session(session_lock);
+		return NULL;
+	}
+
+	/* Select a new real and write it into the session slot. */
+	struct real *real =
+		schedule_new_real(context, pkt_ctx, session, vs, session_state);
+	if (unlikely(real == NULL)) {
+		st_chain_remove_session(session_state);
+	}
+
+	st_chain_unlock_session(session_lock);
+
+	return real;
+}

--- a/modules/balancer2/dataplane/l4/select.h
+++ b/modules/balancer2/dataplane/l4/select.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <stdint.h>
+
+struct worker_context;
+struct session;
+struct packet_context;
+struct balancer_session_table_chain;
+
+/*
+ * Select the real server that should handle this packet.
+ *
+ * In OPS (one-packet-scheduling) mode, each packet is independently
+ * assigned to a real via the selector ring. No session is created
+ * or consulted.
+ *
+ * Otherwise, a session slot is acquired from the session table. The
+ * slot is either an existing entry or a freshly allocated one, and
+ * it is returned under a lock. The slot is used as follows:
+ *
+ * - Session found, real is valid and enabled:
+ *   The session is prolonged (timestamps and timeout updated)
+ *   and the same real is returned.
+ *
+ * - Session found, but the real was disabled or removed:
+ *   The session is stale. If the packet is reschedulable
+ *   (TCP SYN or any UDP), a new real is selected from the ring
+ *   and the session slot is overwritten with the new real.
+ *   Non-reschedulable packets (TCP non-SYN) are dropped and
+ *   the session slot is freed.
+ *
+ * - No session found (new flow):
+ *   A blank slot is allocated. If the packet is reschedulable,
+ *   a new real is selected and written into the slot.
+ *   Non-reschedulable packets are dropped and the slot is
+ *   freed -- this handles stray TCP ACKs arriving after
+ *   session timeout.
+ *
+ * The session lock is always released before returning.
+ *
+ * Returns the selected real, or NULL if the packet should be
+ * dropped. The caller is responsible for dropping NULL-result
+ * packets.
+ */
+struct real *
+select_real(
+	struct worker_context *context,
+	struct packet_context *pkt_ctx,
+	struct session *session,
+	struct balancer_session_table_chain *st_chain,
+	uint64_t st_chain_gen
+);

--- a/modules/balancer2/dataplane/l4/session.c
+++ b/modules/balancer2/dataplane/l4/session.c
@@ -1,0 +1,143 @@
+#include <rte_ip.h>
+#include <rte_mbuf.h>
+#include <rte_tcp.h>
+#include <rte_udp.h>
+#include <string.h>
+
+#include "common/network.h"
+
+#include "lib/dataplane/packet/data.h"
+
+#include "packet.h"
+#include "session.h"
+#include "types/session.h"
+
+static void
+extract_ipv4(struct packet *packet, struct session *session) {
+	struct rte_ipv4_hdr *hdr = rte_pktmbuf_mtod_offset(
+		packet->mbuf,
+		struct rte_ipv4_hdr *,
+		packet->network_header.offset
+	);
+	rte_memcpy(&session->id.client_ip, (uint8_t *)&hdr->src_addr, NET4_LEN);
+	rte_memcpy(&session->id.vip, (uint8_t *)&hdr->dst_addr, NET4_LEN);
+}
+
+static void
+extract_ipv6(struct packet *packet, struct session *session) {
+	struct rte_ipv6_hdr *hdr = rte_pktmbuf_mtod_offset(
+		packet->mbuf,
+		struct rte_ipv6_hdr *,
+		packet->network_header.offset
+	);
+	rte_memcpy(&session->id.client_ip, hdr->src_addr, NET6_LEN);
+	rte_memcpy(&session->id.vip, hdr->dst_addr, NET6_LEN);
+}
+
+static void
+extract_network(struct packet *packet, struct session *session, bool is_ipv6) {
+	if (is_ipv6) {
+		extract_ipv6(packet, session);
+	} else {
+		extract_ipv4(packet, session);
+	}
+}
+
+static uint32_t
+tcp_timeout(struct balancer_session_timeouts *timeouts, uint16_t tcp_flags) {
+	if ((tcp_flags & RTE_TCP_SYN_FLAG) == RTE_TCP_SYN_FLAG) {
+		if ((tcp_flags & RTE_TCP_ACK_FLAG) == RTE_TCP_ACK_FLAG) {
+			return timeouts->tcp_syn_ack;
+		}
+		return timeouts->tcp_syn;
+	}
+	if (tcp_flags & RTE_TCP_FIN_FLAG) {
+		return timeouts->tcp_fin;
+	}
+	return timeouts->tcp;
+}
+
+static void
+extract_tcp(
+	struct packet *packet,
+	struct session *session,
+	struct balancer_session_timeouts *timeouts
+) {
+	struct rte_tcp_hdr *hdr = rte_pktmbuf_mtod_offset(
+		packet->mbuf,
+		struct rte_tcp_hdr *,
+		packet->transport_header.offset
+	);
+
+	uint8_t flags = hdr->tcp_flags;
+
+	session->id.client_port = hdr->src_port;
+	session->id.vs_port = hdr->dst_port;
+	session->id.transport = transport_proto_tcp;
+
+	session->timeout = tcp_timeout(timeouts, flags);
+	session->can_reschedule = (flags & (RTE_TCP_SYN_FLAG | RTE_TCP_RST_FLAG)
+				  ) == RTE_TCP_SYN_FLAG;
+}
+
+static void
+extract_udp(
+	struct packet *packet,
+	struct session *session,
+	struct balancer_session_timeouts *timeouts
+) {
+	struct rte_udp_hdr *hdr = rte_pktmbuf_mtod_offset(
+		packet->mbuf,
+		struct rte_udp_hdr *,
+		packet->transport_header.offset
+	);
+
+	session->id.client_port = hdr->src_port;
+	session->id.vs_port = hdr->dst_port;
+	session->id.transport = transport_proto_udp;
+
+	session->timeout = timeouts->udp;
+	session->can_reschedule = true;
+}
+
+static void
+extract_transport(
+	struct packet *packet,
+	struct session *session,
+	struct balancer_session_timeouts *timeouts
+) {
+	if (packet->transport_header.type == IPPROTO_TCP) {
+		extract_tcp(packet, session, timeouts);
+	} else {
+		extract_udp(packet, session, timeouts);
+	}
+}
+
+void
+fill_sessions(
+	struct session *sessions,
+	struct packet_context *pkt_ctxs,
+	size_t count,
+	struct balancer_session_timeouts *timeouts,
+	bool is_ipv6
+) {
+	const size_t prefetch_distance = 2;
+
+	for (size_t pkt_idx = 0; pkt_idx < count; ++pkt_idx) {
+		if (pkt_idx + prefetch_distance < count) {
+			struct rte_mbuf *mbuf = packet_to_mbuf(
+				pkt_ctxs[pkt_idx + prefetch_distance].packet
+			);
+			rte_prefetch0(mbuf);
+		}
+
+		struct packet *packet = pkt_ctxs[pkt_idx].packet;
+		struct session *session = &sessions[pkt_idx];
+
+		memset(&session->id, 0, sizeof(struct balancer_session_id));
+		session->id.ip_family = is_ipv6 ? ip_family_ip6 : ip_family_ip4;
+
+		extract_network(packet, session, is_ipv6);
+		extract_transport(packet, session, timeouts);
+	}
+}

--- a/modules/balancer2/dataplane/l4/session.h
+++ b/modules/balancer2/dataplane/l4/session.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "types/session.h"
+
+struct session {
+	struct balancer_session_id id;
+	uint32_t timeout;
+	bool can_reschedule;
+};
+
+struct packet_context;
+
+/*
+ * Parse packet headers into session state for a batch of packets.
+ *
+ * For each packet, the session identity captures the client and
+ * virtual-service endpoints (addresses and ports) together with the
+ * transport protocol and IP family. Each entry also receives the
+ * timeout derived from the transport protocol and a flag indicating
+ * whether the packet may trigger session creation or rescheduling.
+ *
+ * The two arrays are parallel and must each have at least count
+ * elements.
+ */
+void
+fill_sessions(
+	struct session *sessions,
+	struct packet_context *pkt_ctxs,
+	size_t count,
+	struct balancer_session_timeouts *timeouts,
+	bool is_ipv6
+);

--- a/modules/balancer2/dataplane/l4/tunnel.c
+++ b/modules/balancer2/dataplane/l4/tunnel.c
@@ -1,0 +1,156 @@
+#include <netinet/in.h>
+
+#include <rte_ether.h>
+#include <rte_ip.h>
+#include <rte_mbuf.h>
+
+#include "common/network.h"
+
+#include "dataplane/packet/mss.h"
+#include "lib/dataplane/packet/data.h"
+#include "lib/dataplane/packet/encap.h"
+
+#include "packet.h"
+#include "real.h"
+#include "tunnel.h"
+#include "types/stats.h"
+#include "vs.h"
+
+#define CLAMP_MSS 1220
+#define INSERT_MSS 576
+
+/*
+ * Builds the outer IPv4 tunnel source address by embedding client source
+ * bits into the unmasked positions of the configured source network.
+ */
+static inline void
+build_outer_src4(
+	uint8_t *out, const uint8_t *client_src, const struct net4 *src_net
+) {
+	memcpy(out, src_net->addr, NET4_LEN);
+	for (size_t i = 0; i < NET4_LEN; ++i) {
+		out[i] |= client_src[i] & ~src_net->mask[i];
+	}
+}
+
+static inline void
+build_outer_src6(
+	uint8_t *out,
+	const uint8_t *client_src,
+	uint8_t client_len,
+	const struct net6 *src_net
+) {
+	memcpy(out, src_net->addr, NET6_LEN);
+	uint8_t offset = NET6_LEN - client_len;
+	for (uint8_t i = 0; i < client_len; ++i) {
+		out[offset + i] |= client_src[i] & ~src_net->mask[offset + i];
+	}
+}
+
+/*
+ * Shared encapsulation logic for both inner-IPv4 and inner-IPv6 packets.
+ * client_src points to the client source address in the inner header;
+ * client_src_len is its byte length (4 for IPv4, 16 for IPv6).
+ */
+static inline int
+encapsulate(
+	struct packet *packet,
+	struct real *real,
+	bool gre,
+	const uint8_t *client_src,
+	uint8_t client_src_len
+) {
+	bool is_outer_ipv6 = real_flags(real) & real_ip6;
+
+	if (is_outer_ipv6) {
+		uint8_t outer_src[NET6_LEN];
+		build_outer_src6(
+			outer_src, client_src, client_src_len, &real->src.v6
+		);
+		if (!gre) {
+			return packet_ip6_encap(
+				packet, real->addr.v6.bytes, outer_src
+			);
+		} else {
+			return packet_ip6_encap_gre(
+				packet, real->addr.v6.bytes, outer_src
+			);
+		}
+	} else {
+		uint8_t outer_src[NET4_LEN];
+		build_outer_src4(outer_src, client_src, &real->src.v4);
+		if (!gre) {
+			return packet_ip4_encap(
+				packet, real->addr.v4.bytes, outer_src
+			);
+		} else {
+			return packet_ip4_encap_gre(
+				packet, real->addr.v4.bytes, outer_src
+			);
+		}
+	}
+}
+
+static int
+encapsulate_ipv4(struct packet *packet, struct real *real, bool gre) {
+	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+	struct rte_ipv4_hdr *inner = rte_pktmbuf_mtod_offset(
+		mbuf, struct rte_ipv4_hdr *, packet->network_header.offset
+	);
+	return encapsulate(
+		packet, real, gre, (const uint8_t *)&inner->src_addr, NET4_LEN
+	);
+}
+
+static int
+encapsulate_ipv6(struct packet *packet, struct real *real, bool gre) {
+	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
+	struct rte_ipv6_hdr *inner = rte_pktmbuf_mtod_offset(
+		mbuf, struct rte_ipv6_hdr *, packet->network_header.offset
+	);
+	return encapsulate(
+		packet, real, gre, (const uint8_t *)inner->src_addr, NET6_LEN
+	);
+}
+
+/*
+ * Tunnel a packet whose inner layer is IPv4.
+ */
+int
+tunnel_ip4_packet(struct packet_context *pkt_ctx) {
+	struct packet *packet = pkt_ctx->packet;
+	struct real *real = pkt_ctx->selected_real;
+	struct virtual_service *vs = pkt_ctx->matched_vs;
+
+	/* No MSS clamping for inner IPv4. */
+
+	return encapsulate_ipv4(packet, real, vs->flags & vs_gre);
+}
+
+/*
+ * Tunnel a packet whose inner layer is IPv6.
+ *
+ * MSS clamping is applied when the VS has fix mss flag set.
+ */
+int
+tunnel_ip6_packet(struct packet_context *pkt_ctx) {
+	struct packet *packet = pkt_ctx->packet;
+	struct real *real = pkt_ctx->selected_real;
+	struct virtual_service *vs = pkt_ctx->matched_vs;
+	struct balancer_vs_stats *vs_stats = pkt_ctx->matched_vs_stats;
+
+	if (vs->flags & vs_fix_mss) {
+		switch (packet_set_mss(packet, CLAMP_MSS, INSERT_MSS)) {
+		case packet_set_mss_ok:
+			break;
+		case packet_set_mss_malformed:
+			vs_stats->mss_malformed_packet += 1;
+			break;
+		case packet_set_mss_no_headroom:
+			vs_stats->mss_no_headroom += 1;
+			break;
+		}
+	}
+
+	return encapsulate_ipv6(packet, real, vs->flags & vs_gre);
+}

--- a/modules/balancer2/dataplane/l4/tunnel.h
+++ b/modules/balancer2/dataplane/l4/tunnel.h
@@ -1,0 +1,28 @@
+#pragma once
+
+struct packet_context;
+
+/*
+ * Tunnel a packet whose inner layer is IPv4.
+ *
+ * Encapsulates the packet in an IP-in-IP tunnel towards the resolved
+ * real server, embeds the client source IP into the outer header,
+ * and optionally wraps in GRE.
+ *
+ * MSS clamping is not performed — it only applies to inner IPv6.
+ */
+int
+tunnel_ip4_packet(struct packet_context *pkt_ctx);
+
+/*
+ * Tunnel a packet whose inner layer is IPv6.
+ *
+ * Encapsulates the packet in an IP-in-IP tunnel towards the resolved
+ * real server, embeds the client source IP into the outer header,
+ * and optionally wraps in GRE.
+ *
+ * MSS clamping is applied when the virtual service is configured
+ * to enforce a maximum segment size.
+ */
+int
+tunnel_ip6_packet(struct packet_context *pkt_ctx);

--- a/modules/balancer2/dataplane/meson.build
+++ b/modules/balancer2/dataplane/meson.build
@@ -1,0 +1,38 @@
+dp_dependencies = [
+  lib_common_dep,
+  lib_packet_dp_dep,
+  lib_module_dp_dep,
+  lib_worker_dp_dep,
+  lib_filter_query_dep,
+]
+
+includes = include_directories('.', '../../../')
+
+dp_sources = files(
+  'dataplane.c',
+  'l4/handle.c',
+  'l4/select.c',
+  'l4/tunnel.c',
+  'l4/group.c',
+  'l4/session.c',
+  'icmp/handle.c',
+)
+
+lib_balancer2_dp = static_library(
+  'balancer2_dp',
+  dp_sources,
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: dp_dependencies,
+  include_directories: includes,
+  install: false,
+)
+
+lib_balancer2_dp_dep = declare_dependency(
+  link_with: lib_balancer2_dp,
+  link_args: [
+    '-Wl,--defsym',
+    '-Wl,new_module_balancer2=new_module_balancer2',
+    '-Wl,--export-dynamic-symbol=new_module_balancer2',
+  ],
+)

--- a/modules/balancer2/dataplane/real.h
+++ b/modules/balancer2/dataplane/real.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <stdatomic.h>
+#include <stdbool.h>
+
+#include "common/network.h"
+
+#include "lib/counters/counters.h"
+
+enum real_flags {
+	real_enabled = 1u << 0,
+	real_ip6 = 1u << 1,
+};
+
+/* A real (backend) server within a virtual service. */
+struct real {
+	/* Destination IP address of the real server (IPv4 or IPv6). */
+	struct net_addr addr;
+
+	/*
+	 * Source network for the outer tunnel header.
+	 *
+	 * The control plane guarantees the host bits are already cleared,
+	 * so the tunnel code can embed client source bits into the unmasked
+	 * positions with a single bitwise-OR, without an extra mask step.
+	 */
+	struct net src;
+
+	uint64_t counter_id;
+
+	_Atomic uint8_t flags;
+};
+
+static inline struct balancer_real_stats *
+real_fetch_stats(struct real *real, struct counter_storage *counter_storage) {
+	return (struct balancer_real_stats *)counter_get_address(
+		real->counter_id, counter_storage
+	);
+}
+
+static inline uint8_t
+real_flags(struct real *real) {
+	return atomic_load_explicit(&real->flags, memory_order_relaxed);
+}

--- a/modules/balancer2/dataplane/selector.h
+++ b/modules/balancer2/dataplane/selector.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/big_array.h"
+
+/*
+ * Ring containing real indices.
+ *
+ * Each backend appears multiple times according to its weight.
+ * The ring is shuffled to distribute selections evenly.
+ */
+struct ring {
+	/*
+	 * Indices of backend servers.
+	 *
+	 * Stored in a big array because the weighted list can exceed
+	 * the allocator's maximum block size.
+	 */
+	struct big_array real_ids;
+};
+
+/* Padded to a cache line to prevent false sharing across workers. */
+struct rr_counter {
+	uint64_t value;
+} __attribute__((aligned(64)));
+
+/*
+ * Real backend selector.
+ *
+ * Maintains two rings for RCU-swapped updates and per-worker RR counters.
+ * Uses either round-robin or hash-based selection,
+ * depending on the virtual server scheduler.
+ */
+struct real_selector {
+	/* Double-buffered rings. */
+	struct ring rings[2];
+
+	/* Active ring index. */
+	_Atomic uint64_t ring_id;
+
+	/*
+	 * Bitmask applied to the ring index: bits covered by the mask come
+	 * from the packet hash, the remaining bits from the per-worker
+	 * counter. This blends hash-based affinity with round-robin
+	 * distribution.
+	 */
+	uint64_t packet_hash_mask;
+
+	/* Per-worker round-robin counters. */
+	struct rr_counter workers_rr_counter[];
+};

--- a/modules/balancer2/dataplane/session.h
+++ b/modules/balancer2/dataplane/session.h
@@ -1,0 +1,188 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "common/memory_address.h"
+#include "common/rcu.h"
+#include "common/ttlmap/ttlmap.h"
+
+#include "types/session.h"
+
+struct balancer_session_table {
+	struct ttlmap map;
+};
+
+/* Mark a session slot as empty. Must be called while the lock is held. */
+static inline void
+st_chain_remove_session(struct balancer_session_state *session_state) {
+	TTLMAP_REMOVE(struct balancer_session_id, session_state);
+}
+
+/* Release the session lock. */
+static inline void
+st_chain_unlock_session(ttlmap_lock_t *lock) {
+	ttlmap_release_lock(lock);
+}
+
+/*
+ * All access to session table chain must happen within a critical
+ * section (st_begin_cs / st_end_cs). The critical section pins the
+ * current generation, ensuring the controlplane does not
+ * free a map while workers are still reading it.
+ */
+struct balancer_session_table_chain {
+	_Atomic uint64_t gen;
+	struct balancer_session_table *tables[2];
+	rcu_t rcu;
+};
+
+/*
+ * Enter a session table chain critical section.
+ * Returns the current generation, which must be passed to
+ * all subsequent st_* calls within this critical section.
+ */
+static inline uint64_t
+st_chain_begin_cs(
+	struct balancer_session_table_chain *st_chain, uint32_t worker
+) {
+	return RCU_READ_BEGIN(&st_chain->rcu, worker, &st_chain->gen);
+}
+
+/*
+ * Leave a session table chain critical section.
+ * After this call, the controlplane may update the chain.
+ */
+static inline void
+st_chain_end_cs(
+	struct balancer_session_table_chain *st_chain, uint32_t worker
+) {
+	RCU_READ_END(&st_chain->rcu, worker);
+}
+
+/*
+ * Even generations are steady state; during odd generations (transitions),
+ * both maps must be consulted as sessions may not yet have migrated to the
+ * front table. The front-table index therefore advances only every second
+ * generation.
+ */
+static inline uint32_t
+st_chain_current_session_table_index(uint64_t gen) {
+	return ((gen + 1) & 0b11) >> 1;
+}
+
+static inline void
+st_chain_read_front_back(
+	struct balancer_session_table_chain *st_chain,
+	uint64_t gen,
+	struct balancer_session_table **front,
+	struct balancer_session_table **back
+) {
+	uint32_t cur = st_chain_current_session_table_index(gen);
+	*front = ADDR_OF(&st_chain->tables[cur]);
+	*back = ADDR_OF(&st_chain->tables[cur ^ 1]);
+}
+
+/*
+ * Whether the previous map should be consulted.
+ * True during transition generations (odd), when sessions may
+ * still reside in the session table pending migration.
+ */
+static inline int
+st_chain_prev_table_used(uint64_t table_gen) {
+	return table_gen & 1;
+}
+
+#define SESSION_TABLE_OVERFLOW 0
+#define SESSION_FOUND 1
+#define SESSION_CREATED 2
+
+/*
+ * Look up or create a session entry.
+ *
+ * First tries the current map. If the session is found, returns
+ * SESSION_FOUND with session_state pointing to the existing entry.
+ *
+ * If the session is not found, a new slot is allocated in the
+ * current map. During transition generations (odd), the previous
+ * map is also checked -- if the session exists there, its state
+ * is copied into the new slot and SESSION_FOUND is returned.
+ * This handles sessions that have not yet been migrated.
+ *
+ * If neither map has the session, returns SESSION_CREATED with
+ * a blank slot allocated in the current map.
+ *
+ * Returns SESSION_TABLE_OVERFLOW if the current map is full and
+ * no slot could be allocated. In this case no lock is held.
+ *
+ * On SESSION_FOUND or SESSION_CREATED, the returned session_state is
+ * locked via *lock. The caller must release the lock after modifying
+ * the state.
+ */
+static inline int
+st_chain_get_or_create_session(
+	struct balancer_session_table_chain *st_chain,
+	uint64_t gen,
+	uint32_t now,
+	uint32_t timeout,
+	struct balancer_session_id *session_id,
+	struct balancer_session_state **session_state,
+	ttlmap_lock_t **lock
+) {
+	struct balancer_session_table *front;
+	struct balancer_session_table *back;
+	st_chain_read_front_back(st_chain, gen, &front, &back);
+
+	int res = TTLMAP_GET(
+		&front->map, session_id, session_state, lock, now, timeout
+	);
+	int status = TTLMAP_STATUS(res);
+
+	int result_status;
+	if (status == TTLMAP_FOUND) {
+		result_status = SESSION_FOUND;
+	} else if (status == TTLMAP_INSERTED || status == TTLMAP_REPLACED) {
+		if (!st_chain_prev_table_used(gen)) {
+			result_status = SESSION_CREATED;
+		} else {
+			/*
+			 * New slot allocated in front map. During transition
+			 * (odd gen), check the back map for a session that
+			 * has not been migrated yet.
+			 */
+			int lookup_res = TTLMAP_LOOKUP(
+				&back->map, session_id, *session_state, now
+			);
+			if (TTLMAP_STATUS(lookup_res) == TTLMAP_FAILED) {
+				result_status = SESSION_CREATED;
+			} else {
+				result_status = SESSION_FOUND;
+			}
+		}
+	} else { // status == TTLMAP_FAILED
+		/*
+		 * Front bucket is saturated, so the back map isn't consulted
+		 * here: a session resident only in back that hashes to this
+		 * bucket is reported as overflow instead of found. Deemed
+		 * rare enough to accept for now.
+		 */
+		result_status = SESSION_TABLE_OVERFLOW;
+	}
+
+	return result_status;
+}
+
+static inline void
+st_chain_prefetch_session(
+	struct balancer_session_table_chain *st_chain,
+	uint64_t gen,
+	struct balancer_session_id *session_id
+) {
+	struct balancer_session_table *front;
+	struct balancer_session_table *back;
+
+	st_chain_read_front_back(st_chain, gen, &front, &back);
+
+	TTLMAP_PREFETCH(
+		&front->map, session_id, struct balancer_session_state, 1, 0
+	);
+}

--- a/modules/balancer2/dataplane/types/real.h
+++ b/modules/balancer2/dataplane/types/real.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "common/network.h"
+
+struct real_ip {
+	struct net_addr addr;
+	enum ip_family family;
+};

--- a/modules/balancer2/dataplane/types/session.h
+++ b/modules/balancer2/dataplane/types/session.h
@@ -1,6 +1,32 @@
 #pragma once
 
+#include "common/network.h"
+#include "real.h"
+
+#include <stdbool.h>
 #include <stdint.h>
+
+/*
+ * Key identifying a tracked session.
+ *
+ * The whole struct is used as a TTL map key, so zero it before
+ * filling. IP addresses and ports are stored in network byte order.
+ */
+struct balancer_session_id {
+	uint16_t client_port;
+	uint16_t vs_port;
+	struct net_addr vip;
+	struct net_addr client_ip;
+	enum transport_proto transport;
+	enum ip_family ip_family;
+};
+
+struct balancer_session_state {
+	uint32_t last_packet_timestamp;
+	uint32_t create_timestamp;
+	uint32_t timeout;
+	struct real_ip real_ip;
+};
 
 struct balancer_session_timeouts {
 	uint32_t tcp_syn_ack;

--- a/modules/balancer2/dataplane/types/stats.h
+++ b/modules/balancer2/dataplane/types/stats.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <stdint.h>
+
+struct balancer_common_stats {
+	uint64_t incoming_packets;
+	uint64_t incoming_bytes;
+	uint64_t unexpected_network_proto;
+	uint64_t unexpected_transport_proto;
+	/* Non-initial fragment of a TCP/UDP datagram; has no port header. */
+	uint64_t non_initial_l4_fragments;
+	uint64_t decap_successful;
+	uint64_t decap_failed;
+	uint64_t outgoing_packets;
+	uint64_t outgoing_bytes;
+};
+
+struct balancer_l4_stats {
+	uint64_t incoming_packets;
+	uint64_t select_vs_failed;
+	uint64_t tunnel_failed;
+	uint64_t select_real_failed;
+	uint64_t outgoing_packets;
+};
+
+/* Per-virtual-service runtime counters. */
+struct balancer_vs_stats {
+	uint64_t incoming_packets;
+	uint64_t incoming_bytes;
+	/* Dropped: source address not in the configured allowlist. */
+	uint64_t packet_src_not_allowed;
+	/* No eligible real server was available. */
+	uint64_t no_reals;
+	/* Session slot could not be allocated; the table was full. */
+	uint64_t session_table_overflow;
+	uint64_t echo_icmp_packets;
+	uint64_t error_icmp_packets;
+	/* Packets whose assigned real was disabled at lookup time. */
+	uint64_t real_is_disabled;
+	/* Reserved; not yet incremented. */
+	uint64_t real_is_removed;
+	/* Non-reschedulable packets (TCP non-SYN) with no valid session. */
+	uint64_t not_rescheduled_packets;
+	/* ICMP error packets replicated to peer balancers. */
+	uint64_t broadcasted_icmp_packets;
+	uint64_t created_sessions;
+	uint64_t outgoing_packets;
+	/* MSS clamping rejected a malformed TCP options field. */
+	uint64_t mss_malformed_packet;
+	/* MSS clamping failed because prepend headroom was exhausted. */
+	uint64_t mss_no_headroom;
+	uint64_t outgoing_bytes;
+};
+
+/* Per-real-server runtime counters. */
+struct balancer_real_stats {
+	/* Packets whose session points to this real while it was disabled. */
+	uint64_t packets_real_disabled;
+	uint64_t error_icmp_packets;
+	uint64_t created_sessions;
+	uint64_t packets;
+	uint64_t bytes;
+};

--- a/modules/balancer2/dataplane/vs.h
+++ b/modules/balancer2/dataplane/vs.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/flatmap.h"
+#include "filter/filter.h"
+
+#include "selector.h"
+
+#include "lib/counters/counters.h"
+
+enum vs_flags {
+	vs_fix_mss = 1u << 0,
+	vs_ops = 1u << 1,
+	vs_gre = 1u << 2,
+	vs_ip6 = 1u << 3
+};
+
+struct virtual_service {
+	struct real *reals;
+	uint32_t reals_count;
+
+	struct flatmap reals_map;
+
+	uint64_t counter_id;
+
+	struct filter acl;
+
+	uint64_t *rule_counter_ids;
+	size_t rule_count;
+
+	uint8_t flags;
+
+	struct real_selector *selector;
+};
+
+static inline struct balancer_vs_stats *
+vs_fetch_stats(
+	struct virtual_service *vs, struct counter_storage *counter_storage
+) {
+	return (struct balancer_vs_stats *)counter_get_address(
+		vs->counter_id, counter_storage
+	);
+}
+
+static inline uint64_t *
+vs_fetch_acl_stats(
+	struct virtual_service *vs,
+	struct counter_storage *counter_storage,
+	uint32_t rule_idx
+) {
+	// Rule counter is undefined if tag is empty
+	uint64_t id = ADDR_OF(&vs->rule_counter_ids)[rule_idx];
+	return id != (uint64_t)-1 ? counter_get_address(id, counter_storage)
+				  : NULL;
+}

--- a/modules/balancer2/meson.build
+++ b/modules/balancer2/meson.build
@@ -1,3 +1,5 @@
+subdir('dataplane')
+
 if not dataplane_only
   subdir('controlplane')
 endif


### PR DESCRIPTION
- Adds the dataplane packet-processing path for the balancer2 module: L4 (TCP/UDP) load balancing with per-VS schedulers, session tracking, and IP-in-IP/GRE tunnel encapsulation to reals.
- Wires the module into the main dataplane binary and the Go dataplane_ut test harness.