### PR TITLE
perf(counters): elide the null test on hot counter pointer chases

### DIFF
--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -528,9 +528,9 @@ dataplane_worker_start(struct dataplane_worker *worker) {
 	struct dp_worker *dp_worker = worker->dp_worker;
 	struct dp_config *dp_config = worker->instance->dp_config;
 	struct counter_storage **worker_counter_storages =
-		ADDR_OF(&dp_config->worker_counter_storages);
+		ADDR_OF_NONNULL(&dp_config->worker_counter_storages);
 	struct counter_storage *worker_counter_storage =
-		ADDR_OF(worker_counter_storages + dp_worker->idx);
+		ADDR_OF_NONNULL(worker_counter_storages + dp_worker->idx);
 	// FIXME: do not use hard-coded counter identifiers
 	dp_worker->iterations = counter_get_address(0, worker_counter_storage);
 

--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -99,8 +99,8 @@ counter_get_value_handle(
 	uint64_t counter_id, struct counter_storage *counter_storage
 ) {
 	struct counter_value_handle **handles =
-		ADDR_OF(&counter_storage->counter_value_handles);
-	return ADDR_OF(handles + counter_id);
+		ADDR_OF_NONNULL(&counter_storage->counter_value_handles);
+	return ADDR_OF_NONNULL(handles + counter_id);
 }
 
 static inline uint64_t *

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -52,7 +52,7 @@ module_ectx_process(
 	}
 
 	struct counter_storage *storage =
-		ADDR_OF(&module_ectx->counter_storage);
+		ADDR_OF_NONNULL(&module_ectx->counter_storage);
 
 	const uint64_t input_bytes = packet_front_input_bytes(packet_front);
 	counter_add_packets_bytes(
@@ -118,7 +118,7 @@ chain_ectx_process(
 		uint64_t tsc_stop = rte_rdtsc();
 		counter_hist_exp2_inc(
 			chain_ectx->modules[idx].tsc_counter_id,
-			ADDR_OF(&chain_ectx->counter_storage),
+			ADDR_OF_NONNULL(&chain_ectx->counter_storage),
 			0,
 			7,
 			input_size,
@@ -211,7 +211,7 @@ function_ectx_process(
 	struct packet_front *packet_front
 ) {
 	struct counter_storage *storage =
-		ADDR_OF(&function_ectx->counter_storage);
+		ADDR_OF_NONNULL(&function_ectx->counter_storage);
 
 	counter_add_packets_bytes(
 		function_ectx->counter_packet_in_count,
@@ -256,7 +256,7 @@ pipeline_ectx_process(
 	struct packet_front *packet_front
 ) {
 	struct counter_storage *storage =
-		ADDR_OF(&pipeline_ectx->counter_storage);
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_storage);
 
 	// Packets arrive in output list, count them before processing
 	counter_add_packets_bytes(
@@ -424,7 +424,7 @@ device_ectx_process_input(
 	counter_add_packets_bytes(
 		device_ectx->counter_packet_rx_count,
 		device_ectx->counter_packet_rx_bytes,
-		ADDR_OF(&device_ectx->counter_storage),
+		ADDR_OF_NONNULL(&device_ectx->counter_storage),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -448,7 +448,7 @@ device_ectx_process_output(
 	counter_add_packets_bytes(
 		device_ectx->counter_packet_tx_count,
 		device_ectx->counter_packet_tx_bytes,
-		ADDR_OF(&device_ectx->counter_storage),
+		ADDR_OF_NONNULL(&device_ectx->counter_storage),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -59,9 +59,10 @@ enum {
 // dp_config before calling this.
 static void
 wire_worker_counters(struct dp_worker *dp_worker, struct dp_config *dp_config) {
-	struct counter_storage *storage =
-		ADDR_OF(ADDR_OF(&dp_config->worker_counter_storages) +
-			dp_worker->idx);
+	struct counter_storage *storage = ADDR_OF_NONNULL(
+		ADDR_OF_NONNULL(&dp_config->worker_counter_storages) +
+		dp_worker->idx
+	);
 
 	dp_worker->iterations =
 		counter_get_address(WORKER_CTR_ITERATIONS, storage);

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -72,44 +72,39 @@ acl_handle_packets(
 	fwmap_t *fw6state = ADDR_OF(&fwstate_config->fw6state);
 	fwmap_t *state_table = NULL;
 
+	struct counter_storage *counter_storage =
+		ADDR_OF_NONNULL(&module_ectx->counter_storage);
+
 	uint64_t *pass_cnt = counter_get_address(
-		acl_config->action_allow_counter_id,
-		ADDR_OF(&module_ectx->counter_storage)
+		acl_config->action_allow_counter_id, counter_storage
 	);
 
 	uint64_t *deny_cnt = counter_get_address(
-		acl_config->action_deny_counter_id,
-		ADDR_OF(&module_ectx->counter_storage)
+		acl_config->action_deny_counter_id, counter_storage
 	);
 
 	uint64_t *create_cnt = counter_get_address(
-		acl_config->action_create_state_counter_id,
-		ADDR_OF(&module_ectx->counter_storage)
+		acl_config->action_create_state_counter_id, counter_storage
 	);
 
 	uint64_t *check_pass_cnt = counter_get_address(
-		acl_config->action_check_pass_counter_id,
-		ADDR_OF(&module_ectx->counter_storage)
+		acl_config->action_check_pass_counter_id, counter_storage
 	);
 
 	uint64_t *check_miss_cnt = counter_get_address(
-		acl_config->action_check_miss_counter_id,
-		ADDR_OF(&module_ectx->counter_storage)
+		acl_config->action_check_miss_counter_id, counter_storage
 	);
 
 	uint64_t *sync_cnt = counter_get_address(
-		acl_config->sync_sent_counter_id,
-		ADDR_OF(&module_ectx->counter_storage)
+		acl_config->sync_sent_counter_id, counter_storage
 	);
 
 	uint64_t *invalid_cnt = counter_get_address(
-		acl_config->action_invalid_counter_id,
-		ADDR_OF(&module_ectx->counter_storage)
+		acl_config->action_invalid_counter_id, counter_storage
 	);
 
 	uint64_t *non_term_cnt = counter_get_address(
-		acl_config->action_non_term_counter_id,
-		ADDR_OF(&module_ectx->counter_storage)
+		acl_config->action_non_term_counter_id, counter_storage
 	);
 
 	// Time in nanoseconds is sufficient for keeping state up to 500 years
@@ -284,12 +279,11 @@ acl_handle_packets(
 					goto apply;
 				}
 				case ACTION_COUNT: {
-					uint64_t *counters = counter_get_address(
-						target->counter_id,
-						ADDR_OF(&module_ectx
-								 ->counter_storage
-						)
-					);
+					uint64_t *counters =
+						counter_get_address(
+							target->counter_id,
+							counter_storage
+						);
 					counters[0] += 1;
 					counters[1] += pkt_len;
 
@@ -378,8 +372,7 @@ acl_handle_packets(
 			}
 		} else {
 			uint64_t *c = counter_get_address(
-				acl_config->no_match_counter_id,
-				ADDR_OF(&module_ectx->counter_storage)
+				acl_config->no_match_counter_id, counter_storage
 			);
 			c[0] += 1;
 

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -115,7 +115,7 @@ forward_handle_packets(
 		if (target != NULL) {
 			uint64_t *counters = counter_get_address(
 				target->counter_id,
-				ADDR_OF(&module_ectx->counter_storage)
+				ADDR_OF_NONNULL(&module_ectx->counter_storage)
 			);
 			counters[0] += 1;
 			counters[1] += packet_data_len(packet);

--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -129,7 +129,7 @@ mirror_handle_packets(
 		if (target != NULL) {
 			uint64_t *counters = counter_get_address(
 				target->counter_id,
-				ADDR_OF(&module_ectx->counter_storage)
+				ADDR_OF_NONNULL(&module_ectx->counter_storage)
 			);
 			counters[0] += 1;
 			counters[1] += packet_data_len(packet);

--- a/modules/route-mpls/dataplane/dataplane.c
+++ b/modules/route-mpls/dataplane/dataplane.c
@@ -131,7 +131,7 @@ route_mpls_handle_packets(
 			ADDR_OF(&target->nexthops) + nexthop_idx;
 		uint64_t *counters = counter_get_address(
 			nexthop->counter_id,
-			ADDR_OF(&module_ectx->counter_storage)
+			ADDR_OF_NONNULL(&module_ectx->counter_storage)
 		);
 		counters[0] += 1;
 		counters[1] += packet_data_len(packet);


### PR DESCRIPTION
Use ADDR_OF_NONNULL for the counter storage and value-handle relative pointers on the packet-processing path, where a live execution context always carries its counter storage and every registered counter has a value handle. This drops the per-access branch the null-tolerant ADDR_OF must emit. The acl handler resolves its counter storage once into a local reused across all counter lookups.