### PR TITLE
fix(fwstate): validate sync ports before uint16 conversion

### DIFF
--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -24,6 +24,10 @@ const (
 	// ListEntries round-trip to prevent unbounded allocation under the
 	// service mutex.
 	maxListEntriesBatchSize uint32 = 10000
+
+	// maxSyncPort is the highest value accepted for port_multicast and
+	// port_unicast, matching the width of the C-side uint16 port field.
+	maxSyncPort uint32 = 65535
 )
 
 // clampBatchSize returns a batch size that is within the allowed range:
@@ -105,6 +109,9 @@ func (m *FWStateService) UpdateConfig(
 	}
 	if req.MapConfig == nil {
 		return nil, status.Error(codes.InvalidArgument, "map_config is required")
+	}
+	if err := validateSyncPorts(req.SyncConfig); err != nil {
+		return nil, err
 	}
 
 	m.log.Debug("update fwstate config", zap.String("config", name))
@@ -439,6 +446,22 @@ func (m *FWStateService) ListEntries(
 			return err
 		}
 	}
+}
+
+// validateSyncPorts rejects sync config ports that do not fit into the
+// C-side uint16 port field.
+//
+// A zero port means "unset / keep current" and is allowed here. The
+// required-destination-pair check in validateSyncConfig rejects a request
+// that leaves both destinations unset.
+func validateSyncPorts(cfg *fwstatepb.SyncConfig) error {
+	if portMulticast := cfg.GetPortMulticast(); portMulticast > maxSyncPort {
+		return status.Errorf(codes.InvalidArgument, "port_multicast %d exceeds maximum allowed value %d", portMulticast, maxSyncPort)
+	}
+	if portUnicast := cfg.GetPortUnicast(); portUnicast > maxSyncPort {
+		return status.Errorf(codes.InvalidArgument, "port_unicast %d exceeds maximum allowed value %d", portUnicast, maxSyncPort)
+	}
+	return nil
 }
 
 // validateSyncConfig validates that required sync config fields are set

--- a/modules/fwstate/controlplane/service_test.go
+++ b/modules/fwstate/controlplane/service_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
@@ -47,6 +49,66 @@ func TestClampBatchSize(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, clampBatchSize(tc.input))
+		})
+	}
+}
+
+// TestValidateSyncPorts verifies that ports above the uint16 range are
+// rejected with InvalidArgument, while zero and boundary values pass.
+func TestValidateSyncPorts(t *testing.T) {
+	cases := []struct {
+		name          string
+		portMulticast uint32
+		portUnicast   uint32
+		wantErr       bool
+	}{
+		{
+			name:          "both zero",
+			portMulticast: 0,
+			portUnicast:   0,
+			wantErr:       false,
+		},
+		{
+			name:          "boundary value",
+			portMulticast: 65535,
+			portUnicast:   65535,
+			wantErr:       false,
+		},
+		{
+			name:          "multicast port just above boundary",
+			portMulticast: 65536,
+			portUnicast:   0,
+			wantErr:       true,
+		},
+		{
+			name:          "unicast port far above boundary",
+			portMulticast: 0,
+			portUnicast:   70000,
+			wantErr:       true,
+		},
+		{
+			name:          "one valid one out of range",
+			portMulticast: 1,
+			portUnicast:   70000,
+			wantErr:       true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &fwstatepb.SyncConfig{
+				PortMulticast: tc.portMulticast,
+				PortUnicast:   tc.portUnicast,
+			}
+
+			err := validateSyncPorts(cfg)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+
+			require.Error(t, err)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
 		})
 	}
 }


### PR DESCRIPTION
Sync configuration ports are declared as 32-bit values but were silently truncated to 16 bits when converting to the dataplane config, so a caller could set a port such as 70000 and have it accepted as a different wire port.

This adds validation that rejects out-of-range ports with `InvalidArgument` before any conversion, keeping the accepted set aligned with the valid TCP/UDP range.

Closes #899.