### PR TITLE
refactor(metrics): unify GetMetrics messages on the shared commonpb pair

### DIFF
--- a/controlplane/gateway/metrics_service.go
+++ b/controlplane/gateway/metrics_service.go
@@ -28,7 +28,7 @@ func NewMetricsService(collector metricsCollector) *MetricsService {
 // GetMetrics returns a snapshot of all gateway gRPC server metrics.
 func (m *MetricsService) GetMetrics(
 	ctx context.Context,
-	req *ynpb.GetMetricsRequest,
-) (*ynpb.GetMetricsResponse, error) {
-	return &ynpb.GetMetricsResponse{Metrics: m.collector.Collect()}, nil
+	req *commonpb.GetMetricsRequest,
+) (*commonpb.GetMetricsResponse, error) {
+	return &commonpb.GetMetricsResponse{Metrics: m.collector.Collect()}, nil
 }

--- a/controlplane/ynpb/v1/metrics.proto
+++ b/controlplane/ynpb/v1/metrics.proto
@@ -9,9 +9,5 @@ import "common/commonpb/v1/metric.proto";
 // MetricsService exposes gateway runtime metrics.
 service MetricsService {
   // GetMetrics returns a snapshot of gateway runtime metrics.
-  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+  rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
-
-message GetMetricsRequest {}
-
-message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fs::File, path::Path};
 
 use aclpb::{
-    DeleteConfigRequest, GetMetricsRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
+    DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     acl_service_client::AclServiceClient, metrics_service_client::MetricsServiceClient,
 };
 use args::{DeleteCmd, MetricsCmd, ModeCmd, ShowCmd, UpdateCmd};
@@ -22,6 +22,7 @@ mod args;
 mod metric;
 
 use ::commonpb::pb as commonpb;
+use commonpb::GetMetricsRequest;
 
 #[allow(non_snake_case)]
 pub mod aclpb {

--- a/modules/acl/controlplane/aclpb/v1/acl.proto
+++ b/modules/acl/controlplane/aclpb/v1/acl.proto
@@ -23,7 +23,7 @@ service ACLService {
 // MetricsService exposes ACL module metrics.
 service MetricsService {
   // GetMetrics returns a snapshot of ACL module metrics.
-  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+  rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
 
 message UpdateConfigRequest {
@@ -79,7 +79,3 @@ message DeleteConfigResponse { bool deleted = 1; }
 message ListConfigsRequest {}
 
 message ListConfigsResponse { repeated string configs = 1; }
-
-message GetMetricsRequest {}
-
-message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -25,13 +25,13 @@ func NewMetricsService(source metricsSource) *MetricsService {
 }
 
 // GetMetrics returns a snapshot of all ACL module metrics.
-func (m *MetricsService) GetMetrics(ctx context.Context, req *aclpb.GetMetricsRequest) (*aclpb.GetMetricsResponse, error) {
+func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetricsRequest) (*commonpb.GetMetricsResponse, error) {
 	all, err := m.source.Metrics()
 	if err != nil {
 		return nil, err
 	}
 
-	return &aclpb.GetMetricsResponse{Metrics: all}, nil
+	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
 func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -1,11 +1,12 @@
 use std::{net::IpAddr, time};
 
+use commonpb::pb::GetMetricsRequest;
 use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use yanet_cli_balancer2::balancerpb::{
-    self, GetConfigRequest, GetMetricsRequest, GetStateRequest, ListConfigsRequest, ListSessionsRequest,
-    ListSessionsStatesRequest, PacketHandlerRef, RealUpdate, UpdateConfigRequest, UpdateRealsRequest,
-    UpdateSessionsStateRequest, balancer_client::BalancerClient,
+    self, GetConfigRequest, GetStateRequest, ListConfigsRequest, ListSessionsRequest, ListSessionsStatesRequest,
+    PacketHandlerRef, RealUpdate, UpdateConfigRequest, UpdateRealsRequest, UpdateSessionsStateRequest,
+    balancer_client::BalancerClient,
 };
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},

--- a/modules/balancer2/controlplane/balancerpb/v1/balancer.proto
+++ b/modules/balancer2/controlplane/balancerpb/v1/balancer.proto
@@ -35,7 +35,7 @@ service Balancer {
 
   rpc ListSessions(ListSessionsRequest) returns (stream Session);
 
-  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+  rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
 
 // On create (first update), all fields are required.
@@ -122,7 +122,3 @@ message UpdateSessionsStateRequest {
 }
 
 message UpdateSessionsStateResponse {}
-
-message GetMetricsRequest {}
-
-message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }

--- a/modules/forward/controlplane/forwardpb/v1/forward.proto
+++ b/modules/forward/controlplane/forwardpb/v1/forward.proto
@@ -26,7 +26,7 @@ service ForwardService {
 // MetricsService exposes Forward module per-rule metrics.
 service MetricsService {
   // GetMetrics returns a snapshot of Forward per-rule metrics.
-  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+  rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
 
 message Config {
@@ -84,7 +84,3 @@ message DeleteConfigRequest {
 }
 
 message DeleteConfigResponse { bool deleted = 1; }
-
-message GetMetricsRequest {}
-
-message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }

--- a/modules/forward/controlplane/metrics.go
+++ b/modules/forward/controlplane/metrics.go
@@ -25,13 +25,13 @@ func NewMetricsService(source metricsSource) *MetricsService {
 }
 
 // GetMetrics returns a snapshot of Forward per-rule metrics.
-func (m *MetricsService) GetMetrics(ctx context.Context, req *forwardpb.GetMetricsRequest) (*forwardpb.GetMetricsResponse, error) {
+func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetricsRequest) (*commonpb.GetMetricsResponse, error) {
 	all, err := m.source.Metrics()
 	if err != nil {
 		return nil, err
 	}
 
-	return &forwardpb.GetMetricsResponse{Metrics: all}, nil
+	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
 // makeCounter builds a counter metric with the provided name, value, and labels.

--- a/operators/pipeline/cli/src/main.rs
+++ b/operators/pipeline/cli/src/main.rs
@@ -5,6 +5,7 @@ use core::fmt::{self, Display, Formatter};
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use colored::Colorize;
+use commonpb::pb::GetMetricsRequest;
 use tabled::{
     Table, Tabled,
     settings::{
@@ -21,7 +22,7 @@ use ync::{
 };
 
 use crate::operatorpb::{
-    GetMetricsRequest, metrics_service_client::MetricsServiceClient, readiness_service_client::ReadinessServiceClient,
+    metrics_service_client::MetricsServiceClient, readiness_service_client::ReadinessServiceClient,
 };
 
 #[allow(clippy::all, non_snake_case)]

--- a/operators/pipeline/internal/operator/service.go
+++ b/operators/pipeline/internal/operator/service.go
@@ -42,11 +42,11 @@ func NewService(options ...ServiceOption) *Service {
 // error.
 func (m *Service) GetMetrics(
 	ctx context.Context,
-	req *operatorpb.GetMetricsRequest,
-) (*operatorpb.GetMetricsResponse, error) {
+	req *commonpb.GetMetricsRequest,
+) (*commonpb.GetMetricsResponse, error) {
 	metrics := m.metrics.Collect()
 
-	return &operatorpb.GetMetricsResponse{
+	return &commonpb.GetMetricsResponse{
 		Metrics: metrics,
 	}, nil
 }

--- a/operators/pipeline/operatorpb/v1/operator.proto
+++ b/operators/pipeline/operatorpb/v1/operator.proto
@@ -15,9 +15,5 @@ service PipelineOperatorService {}
 
 service MetricsService {
   // GetMetrics returns a snapshot of operator runtime metrics.
-  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+  rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
-
-message GetMetricsRequest {}
-
-message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }

--- a/operators/route/internal/operator/service_metrics.go
+++ b/operators/route/internal/operator/service_metrics.go
@@ -39,9 +39,9 @@ func NewMetricsService(options ...MetricsServiceOption) *MetricsService {
 // an error.
 func (m *MetricsService) GetMetrics(
 	ctx context.Context,
-	req *operatorpb.GetMetricsRequest,
-) (*operatorpb.GetMetricsResponse, error) {
-	return &operatorpb.GetMetricsResponse{
+	req *commonpb.GetMetricsRequest,
+) (*commonpb.GetMetricsResponse, error) {
+	return &commonpb.GetMetricsResponse{
 		Metrics: m.metrics.Collect(),
 	}, nil
 }

--- a/operators/route/operatorpb/v1/operator.proto
+++ b/operators/route/operatorpb/v1/operator.proto
@@ -26,7 +26,7 @@ service RouteOperatorService {
 // MetricsService exposes operator runtime metrics.
 service MetricsService {
   // GetMetrics returns a snapshot of operator runtime metrics.
-  rpc GetMetrics(GetMetricsRequest) returns (GetMetricsResponse);
+  rpc GetMetrics(common.commonpb.v1.GetMetricsRequest) returns (common.commonpb.v1.GetMetricsResponse);
 }
 
 message SwitchRequest {}
@@ -36,7 +36,3 @@ message SwitchResponse {}
 message StatusRequest {}
 
 message StatusResponse {}
-
-message GetMetricsRequest {}
-
-message GetMetricsResponse { repeated common.commonpb.v1.Metric metrics = 1; }


### PR DESCRIPTION
Every module and operator that exposes a metrics RPC used to redefine its own identical `GetMetricsRequest`/`GetMetricsResponse` pair, while an identical canonical pair sat unused in commonpb. This points all of them at the shared commonpb messages and deletes the per-package copies.

The metrics service itself stays defined per package, because the gateway routes by fully-qualified service name to each backend — only the message types are unified. The generic metrics probe already spoke the commonpb types, so its contract is unchanged.

The change is wire-compatible: the request stays empty and the response still carries the same repeated metric list. Because the referenced message type names change, the Buf breaking check reports the nominal rename for the affected packages even though no bytes on the wire change.