### PR TITLE
perf(dataplane): resolve counter value handles at execution context build

### DIFF
--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -70,14 +70,6 @@ module_ectx_create(
 	memset(module_ectx, 0, ectx_size);
 	SET_OFFSET_OF(&module_ectx->cp_module, cp_module);
 
-	module_ectx->rx_counter_id = cp_module->rx_counter_id;
-	module_ectx->tx_counter_id = cp_module->tx_counter_id;
-	module_ectx->rx_bytes_counter_id = cp_module->rx_bytes_counter_id;
-	module_ectx->tx_bytes_counter_id = cp_module->tx_bytes_counter_id;
-	memcpy(module_ectx->perf_counters_indices,
-	       cp_module->perf_counters_indices,
-	       sizeof(cp_module->perf_counters_indices));
-
 	SET_OFFSET_OF(&module_ectx->config_gen_ectx, config_gen_ectx);
 
 	struct dp_module *dp_module =
@@ -118,6 +110,42 @@ module_ectx_create(
 			cp_module->name
 		);
 		goto error;
+	}
+
+	SET_OFFSET_OF(
+		&module_ectx->rx_counter,
+		counter_get_value_handle(
+			cp_module->rx_counter_id, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&module_ectx->rx_bytes_counter,
+		counter_get_value_handle(
+			cp_module->rx_bytes_counter_id, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&module_ectx->tx_counter,
+		counter_get_value_handle(
+			cp_module->tx_counter_id, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&module_ectx->tx_bytes_counter,
+		counter_get_value_handle(
+			cp_module->tx_bytes_counter_id, counter_storage
+		)
+	);
+
+	for (size_t counter_idx = 0; counter_idx < MODULE_ECTX_PERF_COUNTERS;
+	     ++counter_idx) {
+		SET_OFFSET_OF(
+			&module_ectx->perf_counters[counter_idx],
+			counter_get_value_handle(
+				cp_module->perf_counters_indices[counter_idx],
+				counter_storage
+			)
+		);
 	}
 
 	if (cp_config_counter_storage_registry_insert_module(
@@ -313,8 +341,13 @@ chain_ectx_create(
 		SET_OFFSET_OF(
 			&chain_ectx->modules[idx].module_ectx, module_ectx
 		);
-		chain_ectx->modules[idx].tsc_counter_id =
-			cp_chain->modules[idx].tsc_counter_id;
+		SET_OFFSET_OF(
+			&chain_ectx->modules[idx].tsc_counter,
+			counter_get_value_handle(
+				cp_chain->modules[idx].tsc_counter_id,
+				counter_storage
+			)
+		);
 	}
 
 	return chain_ectx;
@@ -461,18 +494,42 @@ function_ectx_create(
 	}
 
 	SET_OFFSET_OF(&function_ectx->counter_storage, counter_storage);
-	function_ectx->counter_packet_in_count =
-		cp_function->counter_packet_in_count;
-	function_ectx->counter_packet_in_bytes =
-		cp_function->counter_packet_in_bytes;
-	function_ectx->counter_packet_out_count =
-		cp_function->counter_packet_out_count;
-	function_ectx->counter_packet_out_bytes =
-		cp_function->counter_packet_out_bytes;
-	function_ectx->counter_packet_drop_count =
-		cp_function->counter_packet_drop_count;
-	function_ectx->counter_packet_drop_bytes =
-		cp_function->counter_packet_drop_bytes;
+	SET_OFFSET_OF(
+		&function_ectx->counter_packet_in_count,
+		counter_get_value_handle(
+			cp_function->counter_packet_in_count, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&function_ectx->counter_packet_in_bytes,
+		counter_get_value_handle(
+			cp_function->counter_packet_in_bytes, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&function_ectx->counter_packet_out_count,
+		counter_get_value_handle(
+			cp_function->counter_packet_out_count, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&function_ectx->counter_packet_out_bytes,
+		counter_get_value_handle(
+			cp_function->counter_packet_out_bytes, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&function_ectx->counter_packet_drop_count,
+		counter_get_value_handle(
+			cp_function->counter_packet_drop_count, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&function_ectx->counter_packet_drop_bytes,
+		counter_get_value_handle(
+			cp_function->counter_packet_drop_bytes, counter_storage
+		)
+	);
 
 	uint64_t pos = 0;
 	for (uint64_t idx = 0; idx < cp_function->chain_count; ++idx) {
@@ -611,18 +668,42 @@ pipeline_ectx_create(
 	}
 
 	SET_OFFSET_OF(&pipeline_ectx->counter_storage, counter_storage);
-	pipeline_ectx->counter_packet_in_count =
-		cp_pipeline->counter_packet_in_count;
-	pipeline_ectx->counter_packet_in_bytes =
-		cp_pipeline->counter_packet_in_bytes;
-	pipeline_ectx->counter_packet_out_count =
-		cp_pipeline->counter_packet_out_count;
-	pipeline_ectx->counter_packet_out_bytes =
-		cp_pipeline->counter_packet_out_bytes;
-	pipeline_ectx->counter_packet_drop_count =
-		cp_pipeline->counter_packet_drop_count;
-	pipeline_ectx->counter_packet_drop_bytes =
-		cp_pipeline->counter_packet_drop_bytes;
+	SET_OFFSET_OF(
+		&pipeline_ectx->counter_packet_in_count,
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_in_count, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&pipeline_ectx->counter_packet_in_bytes,
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_in_bytes, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&pipeline_ectx->counter_packet_out_count,
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_out_count, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&pipeline_ectx->counter_packet_out_bytes,
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_out_bytes, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&pipeline_ectx->counter_packet_drop_count,
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_drop_count, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&pipeline_ectx->counter_packet_drop_bytes,
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_drop_bytes, counter_storage
+		)
+	);
 
 	for (uint64_t idx = 0; idx < cp_pipeline->length; ++idx) {
 		struct cp_function *cp_function = cp_config_gen_lookup_function(
@@ -898,14 +979,30 @@ device_ectx_create(
 	}
 
 	SET_OFFSET_OF(&device_ectx->counter_storage, counter_storage);
-	device_ectx->counter_packet_rx_count =
-		cp_device->counter_packet_rx_count;
-	device_ectx->counter_packet_rx_bytes =
-		cp_device->counter_packet_rx_bytes;
-	device_ectx->counter_packet_tx_count =
-		cp_device->counter_packet_tx_count;
-	device_ectx->counter_packet_tx_bytes =
-		cp_device->counter_packet_tx_bytes;
+	SET_OFFSET_OF(
+		&device_ectx->counter_packet_rx_count,
+		counter_get_value_handle(
+			cp_device->counter_packet_rx_count, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&device_ectx->counter_packet_rx_bytes,
+		counter_get_value_handle(
+			cp_device->counter_packet_rx_bytes, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&device_ectx->counter_packet_tx_count,
+		counter_get_value_handle(
+			cp_device->counter_packet_tx_count, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&device_ectx->counter_packet_tx_bytes,
+		counter_get_value_handle(
+			cp_device->counter_packet_tx_bytes, counter_storage
+		)
+	);
 
 	struct dp_device *dp_device =
 		ADDR_OF(&dp_config->dp_devices) + cp_device->dp_device_idx;

--- a/lib/counters/histogram.h
+++ b/lib/counters/histogram.h
@@ -32,8 +32,7 @@ counter_hist_bucket_exp2(
  * provided key. The key is mapped to a bucket using exponential (log2) scaling,
  * and the corresponding counter is incremented by the specified value.
  *
- * @param counter_id The ID of the counter in the counter registry
- * @param counter_storage Pointer to the counter storage structure
+ * @param counter Precomputed value handle of the counter
  * @param min_bucket The minimum bucket index (log2 scale)
  * @param max_bucket The maximum bucket index (log2 scale)
  * @param key The value to determine which bucket to increment
@@ -41,8 +40,7 @@ counter_hist_bucket_exp2(
  */
 static inline void
 counter_hist_exp2_inc(
-	uint64_t counter_id,
-	struct counter_storage *counter_storage,
+	struct counter_value_handle *counter,
 	uint64_t min_bucket,
 	uint64_t max_bucket,
 	uint64_t key,
@@ -50,7 +48,7 @@ counter_hist_exp2_inc(
 ) {
 	uint64_t bucket = counter_hist_bucket_exp2(key, min_bucket, max_bucket);
 
-	counter_get_address(counter_id, counter_storage)[bucket] += value;
+	counter_handle_get_value(counter)[bucket] += value;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -8,6 +8,7 @@
 
 #include "lib/dataplane/counters/module.h"
 
+struct counter_value_handle;
 struct counter_storage;
 
 struct cp_module;
@@ -23,11 +24,12 @@ struct module_ectx {
 	module_handler handler;
 	struct cp_module *cp_module;
 
-	uint64_t rx_counter_id;
-	uint64_t tx_counter_id;
-	uint64_t rx_bytes_counter_id;
-	uint64_t tx_bytes_counter_id;
-	uint64_t perf_counters_indices[MODULE_ECTX_PERF_COUNTERS];
+	struct counter_value_handle *rx_counter;
+	struct counter_value_handle *tx_counter;
+	struct counter_value_handle *rx_bytes_counter;
+	struct counter_value_handle *tx_bytes_counter;
+
+	struct counter_value_handle *perf_counters[MODULE_ECTX_PERF_COUNTERS];
 
 	struct counter_storage *counter_storage;
 	struct config_gen_ectx *config_gen_ectx;
@@ -53,7 +55,7 @@ module_ectx_decode_device(struct module_ectx *module_ectx, uint64_t index) {
 
 struct chain_module_ectx {
 	struct module_ectx *module_ectx;
-	uint64_t tsc_counter_id;
+	struct counter_value_handle *tsc_counter;
 };
 
 struct chain_ectx {
@@ -65,12 +67,12 @@ struct chain_ectx {
 
 struct function_ectx {
 	struct cp_function *cp_function;
-	uint64_t counter_packet_in_count;
-	uint64_t counter_packet_in_bytes;
-	uint64_t counter_packet_out_count;
-	uint64_t counter_packet_out_bytes;
-	uint64_t counter_packet_drop_count;
-	uint64_t counter_packet_drop_bytes;
+	struct counter_value_handle *counter_packet_in_count;
+	struct counter_value_handle *counter_packet_in_bytes;
+	struct counter_value_handle *counter_packet_out_count;
+	struct counter_value_handle *counter_packet_out_bytes;
+	struct counter_value_handle *counter_packet_drop_count;
+	struct counter_value_handle *counter_packet_drop_bytes;
 	struct counter_storage *counter_storage;
 	uint64_t chain_count;
 	struct chain_ectx **chains;
@@ -80,12 +82,12 @@ struct function_ectx {
 
 struct pipeline_ectx {
 	struct cp_pipeline *cp_pipeline;
-	uint64_t counter_packet_in_count;
-	uint64_t counter_packet_in_bytes;
-	uint64_t counter_packet_out_count;
-	uint64_t counter_packet_out_bytes;
-	uint64_t counter_packet_drop_count;
-	uint64_t counter_packet_drop_bytes;
+	struct counter_value_handle *counter_packet_in_count;
+	struct counter_value_handle *counter_packet_in_bytes;
+	struct counter_value_handle *counter_packet_out_count;
+	struct counter_value_handle *counter_packet_out_bytes;
+	struct counter_value_handle *counter_packet_drop_count;
+	struct counter_value_handle *counter_packet_drop_bytes;
 	struct counter_storage *counter_storage;
 	uint64_t length;
 	struct function_ectx *functions[];
@@ -101,10 +103,10 @@ struct device_entry_ectx {
 
 struct device_ectx {
 	struct cp_device *cp_device;
-	uint64_t counter_packet_rx_count;
-	uint64_t counter_packet_rx_bytes;
-	uint64_t counter_packet_tx_count;
-	uint64_t counter_packet_tx_bytes;
+	struct counter_value_handle *counter_packet_rx_count;
+	struct counter_value_handle *counter_packet_rx_bytes;
+	struct counter_value_handle *counter_packet_tx_count;
+	struct counter_value_handle *counter_packet_tx_bytes;
 	struct counter_storage *counter_storage;
 	struct device_entry_ectx *input_pipelines;
 	struct device_entry_ectx *output_pipelines;

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -13,17 +13,14 @@
 #include <rte_cycles.h>
 
 static inline void
-counter_add(
-	uint64_t counter_id, struct counter_storage *storage, uint64_t count
-) {
-	counter_get_address(counter_id, storage)[0] += count;
+counter_add(struct counter_value_handle *counter, uint64_t count) {
+	counter_handle_get_value(counter)[0] += count;
 }
 
 static inline void
 counter_add_packets_bytes(
-	uint64_t packets_id,
-	uint64_t bytes_id,
-	struct counter_storage *storage,
+	struct counter_value_handle *packets_counter,
+	struct counter_value_handle *bytes_counter,
 	uint64_t packets,
 	uint64_t bytes
 ) {
@@ -31,8 +28,8 @@ counter_add_packets_bytes(
 		return;
 	}
 
-	counter_add(packets_id, storage, packets);
-	counter_add(bytes_id, storage, bytes);
+	counter_add(packets_counter, packets);
+	counter_add(bytes_counter, bytes);
 }
 
 void
@@ -51,14 +48,10 @@ module_ectx_process(
 		);
 	}
 
-	struct counter_storage *storage =
-		ADDR_OF_NONNULL(&module_ectx->counter_storage);
-
 	const uint64_t input_bytes = packet_front_input_bytes(packet_front);
 	counter_add_packets_bytes(
-		module_ectx->rx_counter_id,
-		module_ectx->rx_bytes_counter_id,
-		storage,
+		ADDR_OF_NONNULL(&module_ectx->rx_counter),
+		ADDR_OF_NONNULL(&module_ectx->rx_bytes_counter),
 		packets_count,
 		input_bytes
 	);
@@ -74,14 +67,14 @@ module_ectx_process(
 		size_t batch_idx = idx < MODULE_ECTX_PERF_COUNTERS
 					   ? idx
 					   : MODULE_ECTX_PERF_COUNTERS - 1;
-		size_t counter_idx =
-			module_ectx->perf_counters_indices[batch_idx];
 		size_t hist_idx = counters_hybrid_histogram_batch(
 			&module_ectx_perf_counter, elapsed_ns / packets_count
 		);
 		struct module_ectx_perf_counter_layout *counter =
 			(struct module_ectx_perf_counter_layout *)
-				counter_get_address(counter_idx, storage);
+				counter_handle_get_value(ADDR_OF_NONNULL(
+					&module_ectx->perf_counters[batch_idx]
+				));
 		counter->summary_latency += elapsed_ns;
 		counter->packets += packets_count;
 		counter->bytes += input_bytes;
@@ -89,9 +82,8 @@ module_ectx_process(
 	}
 
 	counter_add_packets_bytes(
-		module_ectx->tx_counter_id,
-		module_ectx->tx_bytes_counter_id,
-		storage,
+		ADDR_OF_NONNULL(&module_ectx->tx_counter),
+		ADDR_OF_NONNULL(&module_ectx->tx_bytes_counter),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -117,8 +109,7 @@ chain_ectx_process(
 
 		uint64_t tsc_stop = rte_rdtsc();
 		counter_hist_exp2_inc(
-			chain_ectx->modules[idx].tsc_counter_id,
-			ADDR_OF_NONNULL(&chain_ectx->counter_storage),
+			ADDR_OF_NONNULL(&chain_ectx->modules[idx].tsc_counter),
 			0,
 			7,
 			input_size,
@@ -210,13 +201,9 @@ function_ectx_process(
 	struct function_ectx *function_ectx,
 	struct packet_front *packet_front
 ) {
-	struct counter_storage *storage =
-		ADDR_OF_NONNULL(&function_ectx->counter_storage);
-
 	counter_add_packets_bytes(
-		function_ectx->counter_packet_in_count,
-		function_ectx->counter_packet_in_bytes,
-		storage,
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_in_count),
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_in_bytes),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -234,16 +221,14 @@ function_ectx_process(
 	}
 
 	counter_add_packets_bytes(
-		function_ectx->counter_packet_out_count,
-		function_ectx->counter_packet_out_bytes,
-		storage,
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_out_count),
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_out_bytes),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		function_ectx->counter_packet_drop_count,
-		function_ectx->counter_packet_drop_bytes,
-		storage,
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_drop_count),
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_drop_bytes),
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
 	);
@@ -255,14 +240,10 @@ pipeline_ectx_process(
 	struct pipeline_ectx *pipeline_ectx,
 	struct packet_front *packet_front
 ) {
-	struct counter_storage *storage =
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_storage);
-
 	// Packets arrive in output list, count them before processing
 	counter_add_packets_bytes(
-		pipeline_ectx->counter_packet_in_count,
-		pipeline_ectx->counter_packet_in_bytes,
-		storage,
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_in_count),
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_in_bytes),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -275,16 +256,14 @@ pipeline_ectx_process(
 	}
 
 	counter_add_packets_bytes(
-		pipeline_ectx->counter_packet_out_count,
-		pipeline_ectx->counter_packet_out_bytes,
-		storage,
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_out_count),
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_out_bytes),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		pipeline_ectx->counter_packet_drop_count,
-		pipeline_ectx->counter_packet_drop_bytes,
-		storage,
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_drop_count),
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_drop_bytes),
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
 	);
@@ -422,9 +401,8 @@ device_ectx_process_input(
 	);
 
 	counter_add_packets_bytes(
-		device_ectx->counter_packet_rx_count,
-		device_ectx->counter_packet_rx_bytes,
-		ADDR_OF_NONNULL(&device_ectx->counter_storage),
+		ADDR_OF_NONNULL(&device_ectx->counter_packet_rx_count),
+		ADDR_OF_NONNULL(&device_ectx->counter_packet_rx_bytes),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -446,9 +424,8 @@ device_ectx_process_output(
 	);
 
 	counter_add_packets_bytes(
-		device_ectx->counter_packet_tx_count,
-		device_ectx->counter_packet_tx_bytes,
-		ADDR_OF_NONNULL(&device_ectx->counter_storage),
+		ADDR_OF_NONNULL(&device_ectx->counter_packet_tx_count),
+		ADDR_OF_NONNULL(&device_ectx->counter_packet_tx_bytes),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);


### PR DESCRIPTION
Store precomputed counter value handles in the execution contexts instead of counter identifiers, so the packet-processing path dereferences a resolved handle directly rather than looking a counter up in its storage on every access.