### PR TITLE
fix(dataplane): drop output from input entry point processing

### DIFF
--- a/lib/dataplane/worker/pipeline_round.c
+++ b/lib/dataplane/worker/pipeline_round.c
@@ -81,6 +81,14 @@ worker_pipeline_round(
 				dp_worker, device_ectx, schedule_input + idx
 			);
 
+			/*
+			 * Input entry point processing has no packet
+			 * transmission allowed so drop the whole output.
+			 * The only chance for a packet to be survived is
+			 * being scheduled into pending input/output queues.
+			 */
+			packet_front_drop_output(schedule_input + idx);
+
 			packet_front_merge(packet_front, schedule_input + idx);
 		}
 

--- a/modules/acl/tests/functional/acl_bench_dataset_test.go
+++ b/modules/acl/tests/functional/acl_bench_dataset_test.go
@@ -50,6 +50,8 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
+	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 )
 
 type datasetRange struct {
@@ -672,7 +674,7 @@ func datasetBenchSetup(b *testing.B) *datasetBenchState {
 			DPMemory:      uint64(64 * datasize.MB),
 			WorkerCount:   1,
 			Devices:       []string{device},
-			Modules:       []string{"acl"},
+			Modules:       []string{"acl", "forward"},
 			DevicesToLoad: []string{"plain"},
 		}
 		harness, err := dataplaneut.NewHarness(cfg)
@@ -826,7 +828,7 @@ func datasetTopoBenchSetup(b *testing.B) *datasetBenchState {
 			DPMemory:      uint64(64 * datasize.MB),
 			WorkerCount:   1,
 			Devices:       datasetTopoDevices,
-			Modules:       []string{"acl"},
+			Modules:       []string{"acl", "forward"},
 			DevicesToLoad: []string{"plain"},
 		}
 		harness, err := dataplaneut.NewHarness(cfg)
@@ -867,10 +869,29 @@ func datasetTopoBenchSetup(b *testing.B) *datasetBenchState {
 	return topoBench
 }
 
-// wireACLTopoPipeline binds the ACL pipeline to the ACL-facing topology
-// devices and a pass-through pipeline to the rest.
+// wireACLTopoPipeline binds the ACL pipeline (with a forward sink) to the
+// ACL-facing topology devices and a pass-through pipeline to the rest.
+//
+// The input entry point is not allowed to transmit directly, so a forward
+// sink with per-device ModeOut rules routes allowed packets to their
+// ingress device's output stage via pending_output.
 func wireACLTopoPipeline(tb testing.TB, agent *ffi.Agent, configName string) {
 	tb.Helper()
+
+	sinkName := configName + "-sink"
+	sinkRules := make([]cforward.ForwardRule, 0, len(datasetTopoACLDevices))
+	for _, deviceIdx := range datasetTopoACLDevices {
+		dev := datasetTopoDevices[deviceIdx]
+		sinkRules = append(sinkRules, cforward.ForwardRule{
+			Target:  dev,
+			Mode:    cforward.ModeOut,
+			Counter: "sink_" + dev,
+			Devices: filter.Devices{{Name: dev}},
+		})
+	}
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	require.NoError(tb, err)
+	tb.Cleanup(sinkHandle.Free)
 
 	require.NoError(tb, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: configName,
@@ -880,6 +901,7 @@ func wireACLTopoPipeline(tb testing.TB, agent *ffi.Agent, configName string) {
 				Name: configName + "_chain",
 				Modules: []ffi.ChainModuleConfig{
 					{Type: "acl", Name: configName},
+					{Type: "forward", Name: sinkName},
 				},
 			},
 		}},

--- a/modules/acl/tests/functional/acl_bench_test.go
+++ b/modules/acl/tests/functional/acl_bench_test.go
@@ -178,7 +178,7 @@ func setupACLHarnessLarge(b *testing.B, devices []string) (*dataplaneut.Harness,
 		DPMemory:      uint64(largeDPSize),
 		WorkerCount:   1,
 		Devices:       devices,
-		Modules:       []string{"acl"},
+		Modules:       []string{"acl", "forward"},
 		DevicesToLoad: []string{"plain"},
 	}
 	h, err := dataplaneut.NewHarness(cfg)

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
 	"github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
+	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 )
 
 // Memory sizes for the ACL functional harness.
@@ -67,7 +69,7 @@ func setupACLHarness(
 		DPMemory:      uint64(aclDPSize),
 		WorkerCount:   1,
 		Devices:       devices,
-		Modules:       []string{"acl"},
+		Modules:       []string{"acl", "forward"},
 		DevicesToLoad: []string{"plain"},
 	}
 	h, err := dataplaneut.NewHarness(cfg)
@@ -102,8 +104,13 @@ func applyACLRules(
 	return handle
 }
 
-// wireACLPipeline wires chain[acl:configName] -> function -> pipeline ->
-// plain-device topology so the harness routes packets through the ACL module.
+// wireACLPipeline wires chain[acl:configName -> forward:sink] -> function ->
+// pipeline -> plain-device topology so the harness routes packets through the
+// ACL module and then forwards allowed packets to the device output stage.
+//
+// The input entry point is not allowed to transmit directly, so a catch-all
+// forward rule with ModeOut routes any packet that survives the ACL (i.e. was
+// allowed) to the output stage via pending_output.
 //
 // Must be called after applyACLRules, because the ACL module config must exist
 // before UpdatePlainDevices resolves chain module references.
@@ -114,6 +121,23 @@ func wireACLPipeline(
 ) {
 	tb.Helper()
 
+	sinkName := configName + "-sink"
+	sinkRules := []cforward.ForwardRule{
+		{
+			Target:  device,
+			Mode:    cforward.ModeOut,
+			Counter: "sink4",
+		},
+		{
+			Target:  device,
+			Mode:    cforward.ModeOut,
+			Counter: "sink6",
+		},
+	}
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	require.NoError(tb, err)
+	tb.Cleanup(sinkHandle.Free)
+
 	require.NoError(tb, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
@@ -122,6 +146,7 @@ func wireACLPipeline(
 				Name: configName + "_chain",
 				Modules: []ffi.ChainModuleConfig{
 					{Type: "acl", Name: configName},
+					{Type: "forward", Name: sinkName},
 				},
 			},
 		}},

--- a/modules/decap/tests/functional/decap_test.go
+++ b/modules/decap/tests/functional/decap_test.go
@@ -14,10 +14,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	decap "github.com/yanet-platform/yanet2/modules/decap/controlplane"
+	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 )
 
 const (
@@ -34,7 +37,7 @@ func setupDecapHarness(t *testing.T) (*dataplaneut.Harness, *ffi.Agent, decap.Ba
 		DPMemory:      uint64(decapDPSize),
 		WorkerCount:   1,
 		Devices:       []string{"port0"},
-		Modules:       []string{"decap"},
+		Modules:       []string{"decap", "forward"},
 		DevicesToLoad: []string{"plain"},
 	})
 	require.NoError(t, err)
@@ -51,6 +54,33 @@ func setupDecapHarness(t *testing.T) (*dataplaneut.Harness, *ffi.Agent, decap.Ba
 func wireDecapPipeline(t *testing.T, agent *ffi.Agent, configName string) {
 	t.Helper()
 
+	sinkName := configName + "-sink"
+	sinkRules := []cforward.ForwardRule{
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "sink4",
+			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		},
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "sink6",
+			Src6s:   filter.IPNets{filter.UnspecifiedIPv6},
+			Dst6s:   filter.IPNets{filter.UnspecifiedIPv6},
+		},
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "sink_l2",
+			Devices: filter.Devices{{Name: "port0"}},
+		},
+	}
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	require.NoError(t, err)
+	t.Cleanup(sinkHandle.Free)
+
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
@@ -59,6 +89,7 @@ func wireDecapPipeline(t *testing.T, agent *ffi.Agent, configName string) {
 				Name: configName + "_chain",
 				Modules: []ffi.ChainModuleConfig{
 					{Type: "decap", Name: configName},
+					{Type: "forward", Name: sinkName},
 				},
 			},
 		}},

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -22,7 +22,7 @@ import (
 const (
 	fwdCPSize  = 64 * datasize.MB
 	fwdDPSize  = 4 * datasize.MB
-	fwdMemSize = 8 * datasize.MB
+	fwdMemSize = 16 * datasize.MB
 )
 
 // setupForwardHarness builds a dataplane harness with the forward module
@@ -77,12 +77,43 @@ func applyRules(
 	return handle
 }
 
-// wireForwardPipeline wires a chain[forward:configName] -> function -> pipeline
-// -> plain-device topology.
+// catchAllForwardRules returns forward rules with ModeOut that match every
+// packet type (IPv4, IPv6, and non-IP L2) and route them to the given device's
+// output stage.
 //
-// Each name in extraDevices gets its own dummy input/output pipelines so that
-// ModeIn and ModeOut packet re-routing resolves without looping. Must be
-// called after applyRules.
+// The input entry point is not allowed to transmit directly, so pass-through
+// packets need a catch-all ModeOut rule to reach egress via pending_output.
+func catchAllForwardRules(device string) []cforward.ForwardRule {
+	return []cforward.ForwardRule{
+		{
+			Target:  device,
+			Mode:    cforward.ModeOut,
+			Counter: "sink4",
+			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		},
+		{
+			Target:  device,
+			Mode:    cforward.ModeOut,
+			Counter: "sink6",
+			Src6s:   filter.IPNets{filter.UnspecifiedIPv6},
+			Dst6s:   filter.IPNets{filter.UnspecifiedIPv6},
+		},
+		{
+			Target:  device,
+			Mode:    cforward.ModeOut,
+			Counter: "sink_l2",
+			Devices: filter.Devices{{Name: device}},
+		},
+	}
+}
+
+// wireForwardPipeline wires a chain[forward:configName -> forward:sink] ->
+// function -> pipeline -> plain-device topology.
+//
+// Each name in extraDevices gets its own input pipeline with a forward sink so
+// packets re-routed via ModeIn reach the output stage. Must be called after
+// applyRules.
 func wireForwardPipeline(
 	t *testing.T,
 	agent *ffi.Agent,
@@ -90,6 +121,41 @@ func wireForwardPipeline(
 	extraDevices []string,
 ) {
 	t.Helper()
+
+	fwdBackend := forward.NewBackend(agent)
+
+	// Primary device sink: appended after the test module in the chain so
+	// packets that pass through (ModeNone/NoMatch) reach the output stage.
+	primarySink := configName + "-sink"
+	primarySinkHandle, err := fwdBackend.UpdateModule(primarySink, catchAllForwardRules(primaryDevice))
+	require.NoError(t, err)
+	t.Cleanup(primarySinkHandle.Free)
+
+	// Extra device sinks: each gets its own input pipeline with a forward
+	// sink so packets re-routed via ModeIn reach the output stage.
+	for _, dev := range extraDevices {
+		sinkName := configName + "-sink-" + dev
+		sinkHandle, err := fwdBackend.UpdateModule(sinkName, catchAllForwardRules(dev))
+		require.NoError(t, err)
+		t.Cleanup(sinkHandle.Free)
+
+		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+			Name: sinkName,
+			Chains: []ffi.FunctionChainConfig{{
+				Weight: 1,
+				Chain: ffi.ChainConfig{
+					Name: sinkName + "_chain",
+					Modules: []ffi.ChainModuleConfig{
+						{Type: "forward", Name: sinkName},
+					},
+				},
+			}},
+		}))
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name:      "sink_in_" + dev,
+			Functions: []string{sinkName},
+		}))
+	}
 
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: configName,
@@ -99,6 +165,7 @@ func wireForwardPipeline(
 				Name: configName + "_chain",
 				Modules: []ffi.ChainModuleConfig{
 					{Type: "forward", Name: configName},
+					{Type: "forward", Name: primarySink},
 				},
 			},
 		}},
@@ -113,16 +180,11 @@ func wireForwardPipeline(
 		Name: "dummy",
 	}))
 
-	// Additional dummy pipelines for extra devices — each output must use a
-	// distinct pipeline name to avoid counter-key collisions.
+	// Additional dummy output pipelines for extra devices — each output must
+	// use a distinct pipeline name to avoid counter-key collisions.
 	for _, dev := range extraDevices {
-		pipeName := "dummy_extra_out_" + dev
 		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
-			Name: pipeName,
-		}))
-		pipeName2 := "dummy_extra_in_" + dev
-		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
-			Name: pipeName2,
+			Name: "dummy_extra_out_" + dev,
 		}))
 	}
 
@@ -137,7 +199,7 @@ func wireForwardPipeline(
 	for _, dev := range extraDevices {
 		allDevices = append(allDevices, ffi.DeviceConfig{
 			Name:   dev,
-			Input:  []ffi.DevicePipelineConfig{{Name: "dummy_extra_in_" + dev, Weight: 1}},
+			Input:  []ffi.DevicePipelineConfig{{Name: "sink_in_" + dev, Weight: 1}},
 			Output: []ffi.DevicePipelineConfig{{Name: "dummy_extra_out_" + dev, Weight: 1}},
 		})
 	}

--- a/modules/fwstate/tests/functional/fwstate_test.go
+++ b/modules/fwstate/tests/functional/fwstate_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
 )
 
@@ -40,7 +43,7 @@ func setupFWStateHarness(t *testing.T) (*dataplaneut.Harness, *ffi.Agent) {
 		DPMemory:      uint64(fwsDPSize),
 		WorkerCount:   1,
 		Devices:       []string{"port0"},
-		Modules:       []string{"fwstate"},
+		Modules:       []string{"fwstate", "forward"},
 		DevicesToLoad: []string{"plain"},
 	}
 	h, err := dataplaneut.NewHarness(cfg)
@@ -85,9 +88,35 @@ func configureFWState(t *testing.T, agent *ffi.Agent, name string) {
 	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{modCfg.AsFFIModule()}))
 }
 
-// wireFWSPipeline wires chain[fwstate:name] into a pipeline bound to port0.
+// wireFWSPipeline wires chain[fwstate:name -> forward:sink] into a pipeline
+// bound to port0.
+//
+// The input entry point is not allowed to transmit directly, so a catch-all
+// forward rule with ModeOut routes packets that pass through fwstate to the
+// device output stage via pending_output.
 func wireFWSPipeline(t *testing.T, agent *ffi.Agent, name string) {
 	t.Helper()
+
+	sinkName := name + "-sink"
+	sinkRules := []cforward.ForwardRule{
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "sink4",
+			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		},
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "sink6",
+			Src6s:   filter.IPNets{filter.UnspecifiedIPv6},
+			Dst6s:   filter.IPNets{filter.UnspecifiedIPv6},
+		},
+	}
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	require.NoError(t, err)
+	t.Cleanup(sinkHandle.Free)
 
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: name,
@@ -97,6 +126,7 @@ func wireFWSPipeline(t *testing.T, agent *ffi.Agent, name string) {
 				Name: name + "_chain",
 				Modules: []ffi.ChainModuleConfig{
 					{Type: "fwstate", Name: name},
+					{Type: "forward", Name: sinkName},
 				},
 			},
 		}},

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 	"github.com/yanet-platform/yanet2/modules/mirror/bindings/go/cmirror"
 	mirror "github.com/yanet-platform/yanet2/modules/mirror/controlplane"
 )
@@ -22,7 +24,7 @@ import (
 const (
 	mirCPSize  = 64 * datasize.MB
 	mirDPSize  = 4 * datasize.MB
-	mirMemSize = 8 * datasize.MB
+	mirMemSize = 16 * datasize.MB
 )
 
 // setupMirrorHarness builds a dataplane harness with the mirror module
@@ -42,7 +44,7 @@ func setupMirrorHarness(
 		DPMemory:      uint64(mirDPSize),
 		WorkerCount:   1,
 		Devices:       devices,
-		Modules:       []string{"mirror"},
+		Modules:       []string{"mirror", "forward"},
 		DevicesToLoad: []string{"plain"},
 	}
 	h, err := dataplaneut.NewHarness(cfg)
@@ -77,12 +79,43 @@ func applyRules(
 	return handle
 }
 
-// wireMirrorPipeline wires a chain[mirror:configName] -> function -> pipeline
-// -> plain-device topology.
+// catchAllForwardRules returns forward rules with ModeOut that match every
+// packet type (IPv4, IPv6, and non-IP L2) and route them to the given device's
+// output stage.
 //
-// Each name in extraDevices gets its own dummy input/output pipelines so that
-// ModeIn and ModeOut packet re-routing resolves without looping. Must be
-// called after applyRules.
+// The input entry point is not allowed to transmit directly, so pass-through
+// packets need a catch-all ModeOut rule to reach egress via pending_output.
+func catchAllForwardRules(device string) []cforward.ForwardRule {
+	return []cforward.ForwardRule{
+		{
+			Target:  device,
+			Mode:    cforward.ModeOut,
+			Counter: "sink4",
+			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		},
+		{
+			Target:  device,
+			Mode:    cforward.ModeOut,
+			Counter: "sink6",
+			Src6s:   filter.IPNets{filter.UnspecifiedIPv6},
+			Dst6s:   filter.IPNets{filter.UnspecifiedIPv6},
+		},
+		{
+			Target:  device,
+			Mode:    cforward.ModeOut,
+			Counter: "sink_l2",
+			Devices: filter.Devices{{Name: device}},
+		},
+	}
+}
+
+// wireMirrorPipeline wires a chain[mirror:configName -> forward:sink] ->
+// function -> pipeline -> plain-device topology.
+//
+// Each name in extraDevices gets its own input pipeline with a forward sink so
+// mirrored packets re-routed via ModeIn reach the output stage. Must be called
+// after applyRules.
 func wireMirrorPipeline(
 	t *testing.T,
 	agent *ffi.Agent,
@@ -90,6 +123,42 @@ func wireMirrorPipeline(
 	extraDevices []string,
 ) {
 	t.Helper()
+
+	fwdBackend := forward.NewBackend(agent)
+
+	// Primary device sink: appended after the test module in the chain so
+	// packets that pass through (originals and ModeNone mirrors) reach the
+	// output stage.
+	primarySink := configName + "-sink"
+	primarySinkHandle, err := fwdBackend.UpdateModule(primarySink, catchAllForwardRules(primaryDevice))
+	require.NoError(t, err)
+	t.Cleanup(primarySinkHandle.Free)
+
+	// Extra device sinks: each gets its own input pipeline with a forward
+	// sink so mirrored packets re-routed via ModeIn reach the output stage.
+	for _, dev := range extraDevices {
+		sinkName := configName + "-sink-" + dev
+		sinkHandle, err := fwdBackend.UpdateModule(sinkName, catchAllForwardRules(dev))
+		require.NoError(t, err)
+		t.Cleanup(sinkHandle.Free)
+
+		require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+			Name: sinkName,
+			Chains: []ffi.FunctionChainConfig{{
+				Weight: 1,
+				Chain: ffi.ChainConfig{
+					Name: sinkName + "_chain",
+					Modules: []ffi.ChainModuleConfig{
+						{Type: "forward", Name: sinkName},
+					},
+				},
+			}},
+		}))
+		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+			Name:      "sink_in_" + dev,
+			Functions: []string{sinkName},
+		}))
+	}
 
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: configName,
@@ -99,6 +168,7 @@ func wireMirrorPipeline(
 				Name: configName + "_chain",
 				Modules: []ffi.ChainModuleConfig{
 					{Type: "mirror", Name: configName},
+					{Type: "forward", Name: primarySink},
 				},
 			},
 		}},
@@ -113,16 +183,11 @@ func wireMirrorPipeline(
 		Name: "dummy",
 	}))
 
-	// Additional dummy pipelines for extra devices — each output must use a
-	// distinct pipeline name to avoid counter-key collisions.
+	// Additional dummy output pipelines for extra devices — each output must
+	// use a distinct pipeline name to avoid counter-key collisions.
 	for _, dev := range extraDevices {
-		pipeName := "dummy_extra_out_" + dev
 		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
-			Name: pipeName,
-		}))
-		pipeName2 := "dummy_extra_in_" + dev
-		require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
-			Name: pipeName2,
+			Name: "dummy_extra_out_" + dev,
 		}))
 	}
 
@@ -137,7 +202,7 @@ func wireMirrorPipeline(
 	for _, dev := range extraDevices {
 		allDevices = append(allDevices, ffi.DeviceConfig{
 			Name:   dev,
-			Input:  []ffi.DevicePipelineConfig{{Name: "dummy_extra_in_" + dev, Weight: 1}},
+			Input:  []ffi.DevicePipelineConfig{{Name: "sink_in_" + dev, Weight: 1}},
 			Output: []ffi.DevicePipelineConfig{{Name: "dummy_extra_out_" + dev, Weight: 1}},
 		})
 	}

--- a/modules/nat64/tests/functional/nat64_test.go
+++ b/modules/nat64/tests/functional/nat64_test.go
@@ -12,10 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 	nat64 "github.com/yanet-platform/yanet2/modules/nat64/controlplane"
 	nat64pb "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1"
 )
@@ -36,7 +39,7 @@ func setupNAT64Harness(t *testing.T) (*dataplaneut.Harness, *nat64.NAT64Service)
 		DPMemory:      uint64(nat64DPSize),
 		WorkerCount:   1,
 		Devices:       []string{"port0"},
-		Modules:       []string{"nat64"},
+		Modules:       []string{"nat64", "forward"},
 		DevicesToLoad: []string{"plain"},
 	})
 	require.NoError(t, err)
@@ -55,16 +58,37 @@ func setupNAT64Harness(t *testing.T) (*dataplaneut.Harness, *nat64.NAT64Service)
 func wireNAT64Pipeline(t *testing.T, agent *ffi.Agent, name string) {
 	t.Helper()
 
+	sinkName := name + "-sink"
+	sinkRules := []cforward.ForwardRule{
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "sink4",
+			Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+			Dst4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		},
+		{
+			Target:  "port0",
+			Mode:    cforward.ModeOut,
+			Counter: "sink6",
+			Src6s:   filter.IPNets{filter.UnspecifiedIPv6},
+			Dst6s:   filter.IPNets{filter.UnspecifiedIPv6},
+		},
+	}
+	sinkHandle, err := forward.NewBackend(agent).UpdateModule(sinkName, sinkRules)
+	require.NoError(t, err)
+	t.Cleanup(sinkHandle.Free)
+
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: name,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
 			Chain: ffi.ChainConfig{
 				Name: name + "_chain",
-				Modules: []ffi.ChainModuleConfig{{
-					Type: "nat64",
-					Name: name,
-				}},
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "nat64", Name: name},
+					{Type: "forward", Name: sinkName},
+				},
 			},
 		}},
 	}))

--- a/tests/pipeline/dispatch_test.go
+++ b/tests/pipeline/dispatch_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
 	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
+	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 )
 
 // Memory sizes for the dispatch regression harness.
@@ -309,22 +311,43 @@ func TestZeroWeightDeviceEntryDropsAllPackets(t *testing.T) {
 // single bound pipeline delivers every packet to that pipeline via the
 // single-pipeline fast path, rather than losing or duplicating any.
 //
-// The pipeline is an allow-all ACL; its function input counter must equal the
-// number of packets handed in, confirming the fast path delivered the whole
-// batch to pipeline 0 intact.
+// The pipeline chain allows every packet through an ACL and then forwards it to
+// the device's output stage via a forward rule, so reaching egress proves the
+// fast path delivered the whole batch intact. The input entry point is not
+// allowed to transmit directly: only packets routed to the output stage survive.
+// Accordingly the function input counter must equal the number of packets handed
+// in.
 func TestSinglePipelineDeviceForwardsAllPackets(t *testing.T) {
 	const configName = "sp-dev-acl"
+	const forwardName = configName + "-fwd"
 
-	h, agent, backend := setupACLBackend(t, "sp-dev-test")
+	h, agent, backend := setupACLBackend(t, "sp-dev-test", "forward")
 	publishMatchAllACL(t, backend, configName, cacl.ActionAllow)
+
+	forwardBackend := forward.NewBackend(agent)
+	rule := cforward.ForwardRule{
+		Target:  "port0",
+		Mode:    cforward.ModeOut,
+		Counter: forwardName,
+		Src4s:   filter.IPNets{filter.UnspecifiedIPv4},
+		Dst4s:   filter.IPNets{filter.MustParseIPNet("10.0.0.0/8")},
+	}
+	handle, err := forwardBackend.UpdateModule(
+		forwardName, []cforward.ForwardRule{rule},
+	)
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
 
 	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
 		Name: configName,
 		Chains: []ffi.FunctionChainConfig{{
 			Weight: 1,
 			Chain: ffi.ChainConfig{
-				Name:    configName + "_chain",
-				Modules: []ffi.ChainModuleConfig{{Type: "acl", Name: configName}},
+				Name: configName + "_chain",
+				Modules: []ffi.ChainModuleConfig{
+					{Type: "acl", Name: configName},
+					{Type: "forward", Name: forwardName},
+				},
 			},
 		}},
 	}))
@@ -347,8 +370,10 @@ func TestSinglePipelineDeviceForwardsAllPackets(t *testing.T) {
 
 	result, err := h.HandlePackets(pkts...)
 	require.NoError(t, err)
+	require.Len(t, result.Output, packetCount,
+		"single-pipeline device must forward every packet to egress")
 	require.Empty(t, result.Drop,
-		"allow-all single-pipeline device must not drop any packet")
+		"single-pipeline device must not drop any packet")
 
 	counters := h.SharedMemory().DPConfig(0).FunctionCounters("port0", configName, configName)
 	byName := dataplaneut.SingleValueCounters(counters)


### PR DESCRIPTION
The input entry point must not transmit packets directly — it may only classify and re-route them via pending queues. Enforce this by dropping the output list after device_ectx_process_input, leaving pending_input and pending_output as the only paths to survival.

Update all functional test harnesses to append a catch-all forward sink with ModeOut to each chain, so pass-through packets reach the output stage via pending_output.