### PR TITLE
refactor(counters): merge packet/byte counter pairs into size-2 vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3307,6 +3307,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "yanet-cli",
+ "yanet-commonpb",
  "yanet-filterpb",
 ]
 

--- a/bindings/go/dataplane_ut/testing.go
+++ b/bindings/go/dataplane_ut/testing.go
@@ -71,3 +71,15 @@ func SingleValueCounters(counters []ffi.CounterInfo) map[string]uint64 {
 	}
 	return byName
 }
+
+// ValueCounters flattens a CounterInfo slice into a map of
+// counter name -> first worker's values.
+func ValueCounters(counters []ffi.CounterInfo) map[string][]uint64 {
+	byName := map[string][]uint64{}
+	for _, c := range counters {
+		if len(c.Values) > 0 && len(c.Values[0]) > 0 {
+			byName[c.Name] = c.Values[0]
+		}
+	}
+	return byName
+}

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -204,10 +204,10 @@ cp_device_init(
 		goto err_out;
 	}
 
-	self->counter_packet_rx_count = counter_registry_register(
-		&self->counter_registry, "rx", 1, err
+	self->counter_packet_rx = counter_registry_register(
+		&self->counter_registry, "rx", 2, err
 	);
-	if (self->counter_packet_rx_count == COUNTER_INVALID) {
+	if (self->counter_packet_rx == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
 			"failed to register 'rx' counter for device '%s'",
@@ -216,37 +216,13 @@ cp_device_init(
 		goto err_out;
 	}
 
-	self->counter_packet_tx_count = counter_registry_register(
-		&self->counter_registry, "tx", 1, err
+	self->counter_packet_tx = counter_registry_register(
+		&self->counter_registry, "tx", 2, err
 	);
-	if (self->counter_packet_tx_count == COUNTER_INVALID) {
+	if (self->counter_packet_tx == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
 			"failed to register 'tx' counter for device '%s'",
-			cfg->name
-		);
-		goto err_out;
-	}
-
-	self->counter_packet_rx_bytes = counter_registry_register(
-		&self->counter_registry, "rx_bytes", 1, err
-	);
-	if (self->counter_packet_rx_bytes == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'rx_bytes' counter for device '%s'",
-			cfg->name
-		);
-		goto err_out;
-	}
-
-	self->counter_packet_tx_bytes = counter_registry_register(
-		&self->counter_registry, "tx_bytes", 1, err
-	);
-	if (self->counter_packet_tx_bytes == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'tx_bytes' counter for device '%s'",
 			cfg->name
 		);
 		goto err_out;

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -64,10 +64,8 @@ struct cp_device {
 	struct cp_device_entry *input_pipelines;
 	struct cp_device_entry *output_pipelines;
 
-	uint64_t counter_packet_rx_count;
-	uint64_t counter_packet_tx_count;
-	uint64_t counter_packet_rx_bytes;
-	uint64_t counter_packet_tx_bytes;
+	uint64_t counter_packet_rx;
+	uint64_t counter_packet_tx;
 
 	// Link to the previous parked device.
 	struct cp_device *prev;

--- a/lib/controlplane/config/cp_function.c
+++ b/lib/controlplane/config/cp_function.c
@@ -70,10 +70,10 @@ cp_function_init(
 
 	strtcpy(self->name, cp_function_config->name, CP_PIPELINE_NAME_LEN);
 
-	self->counter_packet_in_count = counter_registry_register(
-		&self->counter_registry, "input", 1, err
+	self->counter_packet_in = counter_registry_register(
+		&self->counter_registry, "input", 2, err
 	);
-	if (self->counter_packet_in_count == COUNTER_INVALID) {
+	if (self->counter_packet_in == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
 			"failed to register 'input' counter for function '%s'",
@@ -82,10 +82,10 @@ cp_function_init(
 		goto err_out;
 	}
 
-	self->counter_packet_out_count = counter_registry_register(
-		&self->counter_registry, "output", 1, err
+	self->counter_packet_out = counter_registry_register(
+		&self->counter_registry, "output", 2, err
 	);
-	if (self->counter_packet_out_count == COUNTER_INVALID) {
+	if (self->counter_packet_out == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
 			"failed to register 'output' counter for function '%s'",
@@ -94,52 +94,13 @@ cp_function_init(
 		goto err_out;
 	}
 
-	self->counter_packet_drop_count = counter_registry_register(
-		&self->counter_registry, "drop", 1, err
+	self->counter_packet_drop = counter_registry_register(
+		&self->counter_registry, "drop", 2, err
 	);
-	if (self->counter_packet_drop_count == COUNTER_INVALID) {
+	if (self->counter_packet_drop == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
 			"failed to register 'drop' counter for function '%s'",
-			cp_function_config->name
-		);
-		goto err_out;
-	}
-
-	self->counter_packet_in_bytes = counter_registry_register(
-		&self->counter_registry, "input_bytes", 1, err
-	);
-	if (self->counter_packet_in_bytes == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'input_bytes' counter for function "
-			"'%s'",
-			cp_function_config->name
-		);
-		goto err_out;
-	}
-
-	self->counter_packet_out_bytes = counter_registry_register(
-		&self->counter_registry, "output_bytes", 1, err
-	);
-	if (self->counter_packet_out_bytes == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'output_bytes' counter for "
-			"function '%s'",
-			cp_function_config->name
-		);
-		goto err_out;
-	}
-
-	self->counter_packet_drop_bytes = counter_registry_register(
-		&self->counter_registry, "drop_bytes", 1, err
-	);
-	if (self->counter_packet_drop_bytes == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'drop_bytes' counter for function "
-			"'%s'",
 			cp_function_config->name
 		);
 		goto err_out;

--- a/lib/controlplane/config/cp_function.h
+++ b/lib/controlplane/config/cp_function.h
@@ -27,12 +27,9 @@ struct cp_function {
 
 	struct counter_registry counter_registry;
 
-	uint64_t counter_packet_in_count;
-	uint64_t counter_packet_out_count;
-	uint64_t counter_packet_drop_count;
-	uint64_t counter_packet_in_bytes;
-	uint64_t counter_packet_out_bytes;
-	uint64_t counter_packet_drop_bytes;
+	uint64_t counter_packet_in;
+	uint64_t counter_packet_out;
+	uint64_t counter_packet_drop;
 	uint64_t counter_packet_in_hist;
 
 	char name[CP_PIPELINE_NAME_LEN];

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -89,7 +89,7 @@ cp_module_init(
 	}
 
 	cp_module->rx_counter_id = counter_registry_register(
-		&cp_module->counter_registry, "rx", 1, err
+		&cp_module->counter_registry, "rx", 2, err
 	);
 	if (cp_module->rx_counter_id == COUNTER_INVALID) {
 		yanet_error_add(
@@ -101,38 +101,12 @@ cp_module_init(
 		goto fail;
 	}
 	cp_module->tx_counter_id = counter_registry_register(
-		&cp_module->counter_registry, "tx", 1, err
+		&cp_module->counter_registry, "tx", 2, err
 	);
 	if (cp_module->tx_counter_id == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
 			"failed to register 'tx' counter for module '%s:%s'",
-			module_type,
-			module_name
-		);
-		goto fail;
-	}
-	cp_module->rx_bytes_counter_id = counter_registry_register(
-		&cp_module->counter_registry, "rx_bytes", 1, err
-	);
-	if (cp_module->rx_bytes_counter_id == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'rx_bytes' counter for module "
-			"'%s:%s'",
-			module_type,
-			module_name
-		);
-		goto fail;
-	}
-	cp_module->tx_bytes_counter_id = counter_registry_register(
-		&cp_module->counter_registry, "tx_bytes", 1, err
-	);
-	if (cp_module->tx_bytes_counter_id == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'tx_bytes' counter for module "
-			"'%s:%s'",
 			module_type,
 			module_name
 		);
@@ -524,46 +498,44 @@ cp_module_parse_tx_rx(
 	uint64_t *tx_bytes,
 	uint64_t *rx_bytes
 ) {
-	// Validate inputs
 	if (counter_handle == NULL || workers == 0) {
 		errno = EINVAL;
 		return -1;
 	}
 
-	// Determine which counter this is by checking the name
 	const char *name = counter_handle->name;
-	uint64_t *target = NULL;
+
+	uint64_t *packets_target = NULL;
+	uint64_t *bytes_target = NULL;
 
 	if (strcmp(name, "tx") == 0) {
-		target = tx;
+		packets_target = tx;
+		bytes_target = tx_bytes;
 	} else if (strcmp(name, "rx") == 0) {
-		target = rx;
-	} else if (strcmp(name, "tx_bytes") == 0) {
-		target = tx_bytes;
-	} else if (strcmp(name, "rx_bytes") == 0) {
-		target = rx_bytes;
+		packets_target = rx;
+		bytes_target = rx_bytes;
 	} else {
-		// Not a tx/rx counter, return 1 to indicate no match
 		return 1;
 	}
 
-	// Validate target pointer
-	if (target == NULL) {
+	if (packets_target == NULL || bytes_target == NULL) {
 		errno = EINVAL;
 		return -1;
 	}
 
-	// Aggregate counter values across all workers
 	struct counter_value_handle **bases =
 		(struct counter_value_handle **)counter_handle->value_handle;
-	uint64_t total = 0;
+	uint64_t total_packets = 0;
+	uint64_t total_bytes = 0;
 	for (size_t worker_idx = 0; worker_idx < workers; ++worker_idx) {
 		uint64_t *counter_values =
 			counter_handle_get_value(bases[worker_idx]);
-		// Simple counters have size=1, so we access index 0
-		total += counter_values[0];
+		// size-2 counter: [0] = packets, [1] = bytes
+		total_packets += counter_values[0];
+		total_bytes += counter_values[1];
 	}
 
-	*target = total;
+	*packets_target = total_packets;
+	*bytes_target = total_bytes;
 	return 0;
 }

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -51,14 +51,10 @@ struct cp_module {
 	// Counters declared inside module data
 	struct counter_registry counter_registry;
 
-	// Rx packet counter
+	// Rx packet/byte counter (size 2: [packets, bytes])
 	uint64_t rx_counter_id;
-	// Tx packet counter
+	// Tx packet/byte counter (size 2: [packets, bytes])
 	uint64_t tx_counter_id;
-	// Rx bytes counter
-	uint64_t rx_bytes_counter_id;
-	// Tx bytes counter
-	uint64_t tx_bytes_counter_id;
 
 	// Runtime indices for the performance histogram counters.
 	// These indices map to the actual counter storage locations for

--- a/lib/controlplane/config/cp_pipeline.c
+++ b/lib/controlplane/config/cp_pipeline.c
@@ -72,10 +72,10 @@ cp_pipeline_init(
 		goto err_out;
 	}
 
-	self->counter_packet_in_count = counter_registry_register(
-		&self->counter_registry, "input", 1, err
+	self->counter_packet_in = counter_registry_register(
+		&self->counter_registry, "input", 2, err
 	);
-	if (self->counter_packet_in_count == COUNTER_INVALID) {
+	if (self->counter_packet_in == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
 			"failed to register 'input' counter for pipeline '%s'",
@@ -84,10 +84,10 @@ cp_pipeline_init(
 		goto err_out;
 	}
 
-	self->counter_packet_out_count = counter_registry_register(
-		&self->counter_registry, "output", 1, err
+	self->counter_packet_out = counter_registry_register(
+		&self->counter_registry, "output", 2, err
 	);
-	if (self->counter_packet_out_count == COUNTER_INVALID) {
+	if (self->counter_packet_out == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
 			"failed to register 'output' counter for pipeline '%s'",
@@ -96,52 +96,13 @@ cp_pipeline_init(
 		goto err_out;
 	}
 
-	self->counter_packet_drop_count = counter_registry_register(
-		&self->counter_registry, "drop", 1, err
+	self->counter_packet_drop = counter_registry_register(
+		&self->counter_registry, "drop", 2, err
 	);
-	if (self->counter_packet_drop_count == COUNTER_INVALID) {
+	if (self->counter_packet_drop == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
 			"failed to register 'drop' counter for pipeline '%s'",
-			cp_pipeline_config->name
-		);
-		goto err_out;
-	}
-
-	self->counter_packet_in_bytes = counter_registry_register(
-		&self->counter_registry, "input_bytes", 1, err
-	);
-	if (self->counter_packet_in_bytes == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'input_bytes' counter for pipeline "
-			"'%s'",
-			cp_pipeline_config->name
-		);
-		goto err_out;
-	}
-
-	self->counter_packet_out_bytes = counter_registry_register(
-		&self->counter_registry, "output_bytes", 1, err
-	);
-	if (self->counter_packet_out_bytes == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'output_bytes' counter for "
-			"pipeline '%s'",
-			cp_pipeline_config->name
-		);
-		goto err_out;
-	}
-
-	self->counter_packet_drop_bytes = counter_registry_register(
-		&self->counter_registry, "drop_bytes", 1, err
-	);
-	if (self->counter_packet_drop_bytes == COUNTER_INVALID) {
-		yanet_error_add(
-			err,
-			"failed to register 'drop_bytes' counter for pipeline "
-			"'%s'",
 			cp_pipeline_config->name
 		);
 		goto err_out;

--- a/lib/controlplane/config/cp_pipeline.h
+++ b/lib/controlplane/config/cp_pipeline.h
@@ -26,12 +26,9 @@ struct cp_pipeline {
 
 	struct counter_registry counter_registry;
 
-	uint64_t counter_packet_in_count;
-	uint64_t counter_packet_out_count;
-	uint64_t counter_packet_drop_count;
-	uint64_t counter_packet_in_bytes;
-	uint64_t counter_packet_out_bytes;
-	uint64_t counter_packet_drop_bytes;
+	uint64_t counter_packet_in;
+	uint64_t counter_packet_out;
+	uint64_t counter_packet_drop;
 	uint64_t counter_packet_in_hist;
 
 	char name[CP_PIPELINE_NAME_LEN];

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -119,21 +119,9 @@ module_ectx_create(
 		)
 	);
 	SET_OFFSET_OF(
-		&module_ectx->rx_bytes_counter,
-		counter_get_value_handle(
-			cp_module->rx_bytes_counter_id, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
 		&module_ectx->tx_counter,
 		counter_get_value_handle(
 			cp_module->tx_counter_id, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&module_ectx->tx_bytes_counter,
-		counter_get_value_handle(
-			cp_module->tx_bytes_counter_id, counter_storage
 		)
 	);
 
@@ -495,39 +483,21 @@ function_ectx_create(
 
 	SET_OFFSET_OF(&function_ectx->counter_storage, counter_storage);
 	SET_OFFSET_OF(
-		&function_ectx->counter_packet_in_count,
+		&function_ectx->counter_packet_in,
 		counter_get_value_handle(
-			cp_function->counter_packet_in_count, counter_storage
+			cp_function->counter_packet_in, counter_storage
 		)
 	);
 	SET_OFFSET_OF(
-		&function_ectx->counter_packet_in_bytes,
+		&function_ectx->counter_packet_out,
 		counter_get_value_handle(
-			cp_function->counter_packet_in_bytes, counter_storage
+			cp_function->counter_packet_out, counter_storage
 		)
 	);
 	SET_OFFSET_OF(
-		&function_ectx->counter_packet_out_count,
+		&function_ectx->counter_packet_drop,
 		counter_get_value_handle(
-			cp_function->counter_packet_out_count, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_out_bytes,
-		counter_get_value_handle(
-			cp_function->counter_packet_out_bytes, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_drop_count,
-		counter_get_value_handle(
-			cp_function->counter_packet_drop_count, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&function_ectx->counter_packet_drop_bytes,
-		counter_get_value_handle(
-			cp_function->counter_packet_drop_bytes, counter_storage
+			cp_function->counter_packet_drop, counter_storage
 		)
 	);
 
@@ -669,39 +639,21 @@ pipeline_ectx_create(
 
 	SET_OFFSET_OF(&pipeline_ectx->counter_storage, counter_storage);
 	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_in_count,
+		&pipeline_ectx->counter_packet_in,
 		counter_get_value_handle(
-			cp_pipeline->counter_packet_in_count, counter_storage
+			cp_pipeline->counter_packet_in, counter_storage
 		)
 	);
 	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_in_bytes,
+		&pipeline_ectx->counter_packet_out,
 		counter_get_value_handle(
-			cp_pipeline->counter_packet_in_bytes, counter_storage
+			cp_pipeline->counter_packet_out, counter_storage
 		)
 	);
 	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_out_count,
+		&pipeline_ectx->counter_packet_drop,
 		counter_get_value_handle(
-			cp_pipeline->counter_packet_out_count, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_out_bytes,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_out_bytes, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_drop_count,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_drop_count, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&pipeline_ectx->counter_packet_drop_bytes,
-		counter_get_value_handle(
-			cp_pipeline->counter_packet_drop_bytes, counter_storage
+			cp_pipeline->counter_packet_drop, counter_storage
 		)
 	);
 
@@ -980,27 +932,15 @@ device_ectx_create(
 
 	SET_OFFSET_OF(&device_ectx->counter_storage, counter_storage);
 	SET_OFFSET_OF(
-		&device_ectx->counter_packet_rx_count,
+		&device_ectx->counter_packet_rx,
 		counter_get_value_handle(
-			cp_device->counter_packet_rx_count, counter_storage
+			cp_device->counter_packet_rx, counter_storage
 		)
 	);
 	SET_OFFSET_OF(
-		&device_ectx->counter_packet_rx_bytes,
+		&device_ectx->counter_packet_tx,
 		counter_get_value_handle(
-			cp_device->counter_packet_rx_bytes, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_ectx->counter_packet_tx_count,
-		counter_get_value_handle(
-			cp_device->counter_packet_tx_count, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_ectx->counter_packet_tx_bytes,
-		counter_get_value_handle(
-			cp_device->counter_packet_tx_bytes, counter_storage
+			cp_device->counter_packet_tx, counter_storage
 		)
 	);
 

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -36,11 +36,11 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 544,
+	sizeof(struct cp_module) == 528,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 144,
+	sizeof(struct module_ectx) == 128,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 3
+#define YANET_MODULE_ABI_VERSION 4
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -26,8 +26,6 @@ struct module_ectx {
 
 	struct counter_value_handle *rx_counter;
 	struct counter_value_handle *tx_counter;
-	struct counter_value_handle *rx_bytes_counter;
-	struct counter_value_handle *tx_bytes_counter;
 
 	struct counter_value_handle *perf_counters[MODULE_ECTX_PERF_COUNTERS];
 
@@ -67,12 +65,9 @@ struct chain_ectx {
 
 struct function_ectx {
 	struct cp_function *cp_function;
-	struct counter_value_handle *counter_packet_in_count;
-	struct counter_value_handle *counter_packet_in_bytes;
-	struct counter_value_handle *counter_packet_out_count;
-	struct counter_value_handle *counter_packet_out_bytes;
-	struct counter_value_handle *counter_packet_drop_count;
-	struct counter_value_handle *counter_packet_drop_bytes;
+	struct counter_value_handle *counter_packet_in;
+	struct counter_value_handle *counter_packet_out;
+	struct counter_value_handle *counter_packet_drop;
 	struct counter_storage *counter_storage;
 	uint64_t chain_count;
 	struct chain_ectx **chains;
@@ -82,12 +77,9 @@ struct function_ectx {
 
 struct pipeline_ectx {
 	struct cp_pipeline *cp_pipeline;
-	struct counter_value_handle *counter_packet_in_count;
-	struct counter_value_handle *counter_packet_in_bytes;
-	struct counter_value_handle *counter_packet_out_count;
-	struct counter_value_handle *counter_packet_out_bytes;
-	struct counter_value_handle *counter_packet_drop_count;
-	struct counter_value_handle *counter_packet_drop_bytes;
+	struct counter_value_handle *counter_packet_in;
+	struct counter_value_handle *counter_packet_out;
+	struct counter_value_handle *counter_packet_drop;
 	struct counter_storage *counter_storage;
 	uint64_t length;
 	struct function_ectx *functions[];
@@ -103,10 +95,8 @@ struct device_entry_ectx {
 
 struct device_ectx {
 	struct cp_device *cp_device;
-	struct counter_value_handle *counter_packet_rx_count;
-	struct counter_value_handle *counter_packet_rx_bytes;
-	struct counter_value_handle *counter_packet_tx_count;
-	struct counter_value_handle *counter_packet_tx_bytes;
+	struct counter_value_handle *counter_packet_rx;
+	struct counter_value_handle *counter_packet_tx;
 	struct counter_storage *counter_storage;
 	struct device_entry_ectx *input_pipelines;
 	struct device_entry_ectx *output_pipelines;

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -13,23 +13,16 @@
 #include <rte_cycles.h>
 
 static inline void
-counter_add(struct counter_value_handle *counter, uint64_t count) {
-	counter_handle_get_value(counter)[0] += count;
-}
-
-static inline void
 counter_add_packets_bytes(
-	struct counter_value_handle *packets_counter,
-	struct counter_value_handle *bytes_counter,
-	uint64_t packets,
-	uint64_t bytes
+	struct counter_value_handle *counter, uint64_t packets, uint64_t bytes
 ) {
 	if (packets == 0) {
 		return;
 	}
 
-	counter_add(packets_counter, packets);
-	counter_add(bytes_counter, bytes);
+	uint64_t *values = counter_handle_get_value(counter);
+	values[0] += packets;
+	values[1] += bytes;
 }
 
 void
@@ -51,7 +44,6 @@ module_ectx_process(
 	const uint64_t input_bytes = packet_front_input_bytes(packet_front);
 	counter_add_packets_bytes(
 		ADDR_OF_NONNULL(&module_ectx->rx_counter),
-		ADDR_OF_NONNULL(&module_ectx->rx_bytes_counter),
 		packets_count,
 		input_bytes
 	);
@@ -83,7 +75,6 @@ module_ectx_process(
 
 	counter_add_packets_bytes(
 		ADDR_OF_NONNULL(&module_ectx->tx_counter),
-		ADDR_OF_NONNULL(&module_ectx->tx_bytes_counter),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -202,8 +193,7 @@ function_ectx_process(
 	struct packet_front *packet_front
 ) {
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_in_count),
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_in_bytes),
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_in),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -221,14 +211,12 @@ function_ectx_process(
 	}
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_out_count),
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_out_bytes),
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_out),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_drop_count),
-		ADDR_OF_NONNULL(&function_ectx->counter_packet_drop_bytes),
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_drop),
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
 	);
@@ -242,8 +230,7 @@ pipeline_ectx_process(
 ) {
 	// Packets arrive in output list, count them before processing
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_in_count),
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_in_bytes),
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_in),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -256,14 +243,12 @@ pipeline_ectx_process(
 	}
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_out_count),
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_out_bytes),
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_out),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_drop_count),
-		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_drop_bytes),
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_drop),
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
 	);
@@ -401,8 +386,7 @@ device_ectx_process_input(
 	);
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&device_ectx->counter_packet_rx_count),
-		ADDR_OF_NONNULL(&device_ectx->counter_packet_rx_bytes),
+		ADDR_OF_NONNULL(&device_ectx->counter_packet_rx),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
@@ -424,8 +408,7 @@ device_ectx_process_output(
 	);
 
 	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&device_ectx->counter_packet_tx_count),
-		ADDR_OF_NONNULL(&device_ectx->counter_packet_tx_bytes),
+		ADDR_OF_NONNULL(&device_ectx->counter_packet_tx),
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -589,7 +589,7 @@ func TestRoute_Counters(t *testing.T) {
 		require.Len(t, result.Output, 1, "expected one forwarded packet")
 		require.Empty(t, result.Drop, "expected no dropped packets")
 
-		byName := dataplaneut.SingleValueCounters(h.SharedMemory().DPConfig(0).PipelineCounters("port0", "test"))
+		byName := dataplaneut.ValueCounters(h.SharedMemory().DPConfig(0).PipelineCounters("port0", "test"))
 
 		// The route module dispatches forwarded packets to the device output
 		// queue inside the pipeline, so packet_front->output is empty at the
@@ -600,20 +600,20 @@ func TestRoute_Counters(t *testing.T) {
 		//
 		// The distinguishing property of a forwarded packet is that
 		// drop == 0 while input == 1.
-		require.Equal(t, uint64(1), byName["input"], "input counter must equal 1")
-		require.Equal(t, uint64(0), byName["output"], "routed packet leaves via device queue, not pipeline output list")
-		require.Equal(t, uint64(0), byName["drop"], "drop counter must equal 0")
-		require.Equal(t, pktSize, byName["input_bytes"], "input_bytes must equal packet size")
-		require.Equal(t, uint64(0), byName["output_bytes"], "output_bytes must equal 0 for device-dispatched packet")
-		require.Equal(t, uint64(0), byName["drop_bytes"], "drop_bytes must equal 0")
+		require.Equal(t, uint64(1), byName["input"][0], "input counter must equal 1")
+		require.Equal(t, uint64(0), byName["output"][0], "routed packet leaves via device queue, not pipeline output list")
+		require.Equal(t, uint64(0), byName["drop"][0], "drop counter must equal 0")
+		require.Equal(t, pktSize, byName["input"][1], "input_bytes must equal packet size")
+		require.Equal(t, uint64(0), byName["output"][1], "output_bytes must equal 0 for device-dispatched packet")
+		require.Equal(t, uint64(0), byName["drop"][1], "drop_bytes must equal 0")
 
 		// Device tx counter is the real pass signal: device_ectx_process_output
 		// increments tx when the packet is handed off to the NIC queue.
-		byDevName := dataplaneut.SingleValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
-		require.Equal(t, uint64(1), byDevName["rx"], "device rx must equal 1")
-		require.Equal(t, uint64(1), byDevName["tx"], "device tx (pass) must equal 1")
-		require.Equal(t, pktSize, byDevName["rx_bytes"], "device rx_bytes must equal packet size")
-		require.Equal(t, pktSize, byDevName["tx_bytes"], "device tx_bytes (pass) must equal packet size")
+		byDevName := dataplaneut.ValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
+		require.Equal(t, uint64(1), byDevName["rx"][0], "device rx must equal 1")
+		require.Equal(t, uint64(1), byDevName["tx"][0], "device tx (pass) must equal 1")
+		require.Equal(t, pktSize, byDevName["rx"][1], "device rx_bytes must equal packet size")
+		require.Equal(t, pktSize, byDevName["tx"][1], "device tx_bytes (pass) must equal packet size")
 	})
 
 	t.Run("drop", func(t *testing.T) {
@@ -634,21 +634,21 @@ func TestRoute_Counters(t *testing.T) {
 		require.Empty(t, result.Output, "expected no forwarded packets")
 		require.Len(t, result.Drop, 1, "expected one dropped packet")
 
-		byName := dataplaneut.SingleValueCounters(h.SharedMemory().DPConfig(0).PipelineCounters("port0", "test"))
-		require.Equal(t, uint64(1), byName["input"], "input counter must equal 1")
-		require.Equal(t, uint64(0), byName["output"], "output counter must equal 0")
-		require.Equal(t, uint64(1), byName["drop"], "drop counter must equal 1")
-		require.Equal(t, pktSize, byName["input_bytes"], "input_bytes must equal packet size")
-		require.Equal(t, uint64(0), byName["output_bytes"], "output_bytes must equal 0")
-		require.Equal(t, pktSize, byName["drop_bytes"], "drop_bytes must equal packet size")
+		byName := dataplaneut.ValueCounters(h.SharedMemory().DPConfig(0).PipelineCounters("port0", "test"))
+		require.Equal(t, uint64(1), byName["input"][0], "input counter must equal 1")
+		require.Equal(t, uint64(0), byName["output"][0], "output counter must equal 0")
+		require.Equal(t, uint64(1), byName["drop"][0], "drop counter must equal 1")
+		require.Equal(t, pktSize, byName["input"][1], "input_bytes must equal packet size")
+		require.Equal(t, uint64(0), byName["output"][1], "output_bytes must equal 0")
+		require.Equal(t, pktSize, byName["drop"][1], "drop_bytes must equal packet size")
 
 		// Device tx stays zero for a dropped packet: device_ectx_process_output
 		// is never reached, so no tx increment occurs.
-		byDevName := dataplaneut.SingleValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
-		require.Equal(t, uint64(1), byDevName["rx"], "device rx must equal 1")
-		require.Equal(t, uint64(0), byDevName["tx"], "device tx must equal 0 — packet dropped")
-		require.Equal(t, pktSize, byDevName["rx_bytes"], "device rx_bytes must equal packet size")
-		require.Equal(t, uint64(0), byDevName["tx_bytes"], "device tx_bytes must equal 0")
+		byDevName := dataplaneut.ValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
+		require.Equal(t, uint64(1), byDevName["rx"][0], "device rx must equal 1")
+		require.Equal(t, uint64(0), byDevName["tx"][0], "device tx must equal 0 — packet dropped")
+		require.Equal(t, pktSize, byDevName["rx"][1], "device rx_bytes must equal packet size")
+		require.Equal(t, uint64(0), byDevName["tx"][1], "device tx_bytes must equal 0")
 	})
 }
 

--- a/web/builtin/dashboard/hooks.ts
+++ b/web/builtin/dashboard/hooks.ts
@@ -3,9 +3,8 @@ import { API } from '@yanet/core/api';
 
 /**
  * Infer total worker count from a device counter response. Each counter
- * instance corresponds to one dataplane (NUMA) instance, and each value
- * slot in `values[]` corresponds to one worker on that instance. Polling
- * a single device is enough — every counter is sized the same way.
+ * instance corresponds to one dataplane worker. Polling a single device
+ * is enough — every counter is sized the same way.
  *
  * Returns null while the first fetch is in flight, or if no device names
  * are available, or on error.
@@ -34,10 +33,7 @@ export const useWorkerCount = (deviceNames: string[]): number | null => {
                     if (!cancelled) setCount(null);
                     return;
                 }
-                let total = 0;
-                for (const inst of counter.instances) {
-                    total += inst.values?.length ?? 0;
-                }
+                let total = counter.instances.length;
                 if (!cancelled) setCount(total > 0 ? total : null);
             } catch {
                 if (!cancelled) setCount(null);

--- a/web/builtin/functions/hooks/useModuleCounters.ts
+++ b/web/builtin/functions/hooks/useModuleCounters.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { API } from '@yanet/core/api';
 import { useInterpolatedCounters } from '@yanet/core/hooks';
 import type { InterpolatedCounterData } from '@yanet/core/hooks';
-import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '@yanet/core/utils';
+import { groupCounterPacketsAndBytes, makeGroupedCounterKey } from '@yanet/core/utils';
 
 export interface ModuleInfo {
     nodeId: string;
@@ -41,12 +41,11 @@ export const useModuleCounters = (
         try {
             const response = await API.counters.byTags({
                 tags: [{ key: 'module_type', value: '*' }],
-                query: ['rx', 'rx_bytes'],
+                query: ['rx'],
             });
-            const grouped = groupCounterGroupsByTagsAndName(
+            const grouped = groupCounterPacketsAndBytes(
                 response.groups,
                 ['function', 'chain', 'module_type', 'module_name'],
-                0
             );
 
             for (const moduleInfo of moduleInfoList) {
@@ -56,13 +55,9 @@ export const useModuleCounters = (
                     moduleInfo.moduleType,
                     moduleInfo.moduleName,
                 ];
-                const rxPackets = grouped.get(makeGroupedCounterKey(keyPrefix, 'rx'))?.value ?? BigInt(0);
-                const rxBytes = grouped.get(makeGroupedCounterKey(keyPrefix, 'rx_bytes'))?.value ?? BigInt(0);
+                const rx = grouped.get(makeGroupedCounterKey(keyPrefix, 'rx')) ?? { packets: BigInt(0), bytes: BigInt(0) };
 
-                newValues.set(moduleInfo.nodeId, {
-                    packets: rxPackets,
-                    bytes: rxBytes,
-                });
+                newValues.set(moduleInfo.nodeId, rx);
             }
         } catch {
             // tolerate fetch failures.

--- a/web/builtin/inspect/hooks.ts
+++ b/web/builtin/inspect/hooks.ts
@@ -4,7 +4,7 @@ import type { CounterTag } from '@yanet/core/api/counters';
 import type { DeviceCounterData } from '@yanet/core/hooks';
 import { useInterpolatedCounters } from '@yanet/core/hooks/useInterpolatedCounters';
 import { useRollingWindow } from '@yanet/core/hooks/useRollingWindow';
-import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '@yanet/core/utils';
+import { groupCounterPacketsAndBytes, makeGroupedCounterKey } from '@yanet/core/utils';
 
 /**
  * Aggregate RX packet-rate and bit-rate across traffic-source devices.
@@ -93,7 +93,7 @@ interface RatesAndSeries {
     series: Map<string, number[]>;
 }
 
-const COUNTER_QUERY = ['input', 'input_bytes'];
+const COUNTER_QUERY = ['input'];
 
 /**
  * Poll counters selected by tag filter and produce per-key rate and
@@ -118,12 +118,11 @@ const useTagCounterSeries = (
                 tags: filterTags,
                 query: COUNTER_QUERY,
             });
-            const grouped = groupCounterGroupsByTagsAndName(response.groups, groupTagKeys, 0);
+            const grouped = groupCounterPacketsAndBytes(response.groups, groupTagKeys);
             for (const k of keys) {
-                totals.set(k, {
-                    packets: grouped.get(makeGroupedCounterKey([k], 'input'))?.value ?? BigInt(0),
-                    bytes: grouped.get(makeGroupedCounterKey([k], 'input_bytes'))?.value ?? BigInt(0),
-                });
+                totals.set(k,
+                    grouped.get(makeGroupedCounterKey([k], 'input')) ?? { packets: BigInt(0), bytes: BigInt(0) }
+                );
             }
         } catch {
             // tolerate fetch failures.

--- a/web/builtin/pipelines/hooks/useFunctionRefCounters.ts
+++ b/web/builtin/pipelines/hooks/useFunctionRefCounters.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { API } from '@yanet/core/api';
 import { useInterpolatedCounters } from '@yanet/core/hooks';
 import type { InterpolatedCounterData } from '@yanet/core/hooks';
-import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '@yanet/core/utils';
+import { groupCounterPacketsAndBytes, makeGroupedCounterKey } from '@yanet/core/utils';
 
 /** Well-known key for pipeline-level fallthrough counters. */
 export const PIPELINE_COUNTER_KEY = '__pipeline__';
@@ -52,16 +52,15 @@ export const useFunctionRefCounters = (
                         { key: 'function', value: '*' },
                         { key: 'chain', value: '' },
                     ],
-                    query: ['input', 'input_bytes'],
+                    query: ['input'],
                 });
-                const grouped = groupCounterGroupsByTagsAndName(response.groups, ['pipeline', 'function'], 0);
+                const grouped = groupCounterPacketsAndBytes(response.groups, ['pipeline', 'function']);
 
                 for (const ref of refs) {
                     const tagValues = [pipelineName, ref.functionName];
-                    const packets = grouped.get(makeGroupedCounterKey(tagValues, 'input'))?.value ?? BigInt(0);
-                    const bytes = grouped.get(makeGroupedCounterKey(tagValues, 'input_bytes'))?.value ?? BigInt(0);
+                    const val = grouped.get(makeGroupedCounterKey(tagValues, 'input')) ?? { packets: BigInt(0), bytes: BigInt(0) };
 
-                    newValues.set(ref.nodeId, { packets, bytes });
+                    newValues.set(ref.nodeId, val);
                 }
             } catch {
                 // tolerate fetch failures.
@@ -75,13 +74,12 @@ export const useFunctionRefCounters = (
                         { key: 'pipeline', value: pipelineName },
                         { key: 'function', value: '' },
                     ],
-                    query: ['input', 'input_bytes'],
+                    query: ['input'],
                 });
-                const grouped = groupCounterGroupsByTagsAndName(response.groups, ['pipeline'], 0);
-                newValues.set(PIPELINE_COUNTER_KEY, {
-                    packets: grouped.get(makeGroupedCounterKey([pipelineName], 'input'))?.value ?? BigInt(0),
-                    bytes: grouped.get(makeGroupedCounterKey([pipelineName], 'input_bytes'))?.value ?? BigInt(0),
-                });
+                const grouped = groupCounterPacketsAndBytes(response.groups, ['pipeline']);
+                newValues.set(PIPELINE_COUNTER_KEY,
+                    grouped.get(makeGroupedCounterKey([pipelineName], 'input')) ?? { packets: BigInt(0), bytes: BigInt(0) }
+                );
             } catch {
                 // tolerate fetch failures.
             }

--- a/web/src/core/hooks/useDeviceCounters.ts
+++ b/web/src/core/hooks/useDeviceCounters.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { API } from '../api';
-import { groupCounterGroupsByTagsAndName, makeGroupedCounterKey } from '../utils';
+import { groupCounterPacketsAndBytes, makeGroupedCounterKey } from '../utils';
 import {
     useInterpolatedCounters,
     type InterpolatedCounterData,
@@ -48,7 +48,7 @@ export interface UseDeviceCountersResult {
  * Uses the generic useInterpolatedCounters hook with device-specific fetch logic.
  * - Polls counters every 1 second from backend
  * - Updates visual every 30ms using linear interpolation
- * - Returns both RX (rx, rx_bytes) and TX (tx, tx_bytes) rates per device
+ * - Returns both RX (rx) and TX (tx) rates per device
  * - Also returns interpolated absolute values for cumulative display
  *
  * @param deviceNames - Array of device names to track counters for
@@ -83,19 +83,17 @@ export const useDeviceCounters = (
                     { key: 'device', value: '*' },
                     { key: 'pipeline', value: '' },
                 ],
-                query: ['rx', 'rx_bytes', 'tx', 'tx_bytes'],
+                query: ['rx', 'tx'],
             });
 
-            const grouped = groupCounterGroupsByTagsAndName(response.groups, ['device'], 0);
+            const grouped = groupCounterPacketsAndBytes(response.groups, ['device']);
 
             for (const deviceName of deviceNames) {
-                const rxPackets = grouped.get(makeGroupedCounterKey([deviceName], 'rx'))?.value ?? BigInt(0);
-                const rxBytes = grouped.get(makeGroupedCounterKey([deviceName], 'rx_bytes'))?.value ?? BigInt(0);
-                const txPackets = grouped.get(makeGroupedCounterKey([deviceName], 'tx'))?.value ?? BigInt(0);
-                const txBytes = grouped.get(makeGroupedCounterKey([deviceName], 'tx_bytes'))?.value ?? BigInt(0);
+                const rx = grouped.get(makeGroupedCounterKey([deviceName], 'rx')) ?? { packets: BigInt(0), bytes: BigInt(0) };
+                const tx = grouped.get(makeGroupedCounterKey([deviceName], 'tx')) ?? { packets: BigInt(0), bytes: BigInt(0) };
 
-                newValues.set(`${deviceName}:rx`, { packets: rxPackets, bytes: rxBytes });
-                newValues.set(`${deviceName}:tx`, { packets: txPackets, bytes: txBytes });
+                newValues.set(`${deviceName}:rx`, rx);
+                newValues.set(`${deviceName}:tx`, tx);
             }
         } catch {
             // Ignore global counters fetch errors.

--- a/web/src/core/utils/counterGroups.test.ts
+++ b/web/src/core/utils/counterGroups.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     getCounterGroupTagValue,
     groupCounterGroupsByTagsAndName,
+    groupCounterPacketsAndBytes,
     makeGroupedCounterKey,
     sumCounterInfoValuesAtIndex,
 } from './counterGroups';
@@ -60,5 +61,56 @@ describe('groupCounterGroupsByTagsAndName', () => {
         const grouped = groupCounterGroupsByTagsAndName(groups, ['pipeline'], 0);
         expect(grouped.get(makeGroupedCounterKey(['p1'], 'input'))?.value).toBe(BigInt(22));
         expect(grouped.get(makeGroupedCounterKey(['p2'], 'input'))?.value).toBe(BigInt(100));
+    });
+});
+
+describe('groupCounterPacketsAndBytes', () => {
+    it('groups size-2 counters into {packets, bytes} per tag+name key', () => {
+        const groups: CounterGroup[] = [
+            {
+                tags: [{ key: 'device', value: 'eth0' }],
+                counters: [
+                    {
+                        name: 'rx',
+                        instances: [
+                            { values: [10, 1000] },
+                            { values: [5, 500] },
+                        ],
+                    },
+                ],
+            },
+            {
+                tags: [{ key: 'device', value: 'eth0' }],
+                counters: [
+                    {
+                        name: 'tx',
+                        instances: [{ values: [3, 300] }],
+                    },
+                ],
+            },
+            {
+                tags: [{ key: 'device', value: 'eth1' }],
+                counters: [
+                    {
+                        name: 'rx',
+                        instances: [{ values: [7, 700] }],
+                    },
+                ],
+            },
+        ];
+
+        const grouped = groupCounterPacketsAndBytes(groups, ['device']);
+        expect(grouped.get(makeGroupedCounterKey(['eth0'], 'rx'))).toEqual({
+            packets: BigInt(15),
+            bytes: BigInt(1500),
+        });
+        expect(grouped.get(makeGroupedCounterKey(['eth0'], 'tx'))).toEqual({
+            packets: BigInt(3),
+            bytes: BigInt(300),
+        });
+        expect(grouped.get(makeGroupedCounterKey(['eth1'], 'rx'))).toEqual({
+            packets: BigInt(7),
+            bytes: BigInt(700),
+        });
     });
 });

--- a/web/src/core/utils/counterGroups.ts
+++ b/web/src/core/utils/counterGroups.ts
@@ -24,6 +24,49 @@ export const makeGroupedCounterKey = (tagValues: string[], counterName: string):
     return JSON.stringify([...tagValues, counterName]);
 };
 
+export interface GroupedPacketsAndBytes {
+    packets: bigint;
+    bytes: bigint;
+}
+
+/**
+ * Group counter groups by tag values + counter name and sum both the
+ * packets (values[0]) and bytes (values[1]) dimensions.
+ *
+ * For size-2 counters where values[0] = packets and values[1] = bytes.
+ */
+export const groupCounterPacketsAndBytes = (
+    groups: CounterGroup[] | undefined,
+    tagKeys: string[],
+): Map<string, GroupedPacketsAndBytes> => {
+    const result = new Map<string, GroupedPacketsAndBytes>();
+
+    for (const group of groups ?? []) {
+        const tagValues = tagKeys.map((tagKey) => getCounterGroupTagValue(group, tagKey) ?? '');
+        for (const counter of group.counters ?? []) {
+            const counterName = counter.name ?? '';
+            if (!counterName) {
+                continue;
+            }
+
+            const key = makeGroupedCounterKey(tagValues, counterName);
+            const packets = sumCounterInfoValuesAtIndex(counter, 0);
+            const bytes = sumCounterInfoValuesAtIndex(counter, 1);
+            const existing = result.get(key);
+            if (!existing) {
+                result.set(key, { packets, bytes });
+            } else {
+                result.set(key, {
+                    packets: existing.packets + packets,
+                    bytes: existing.bytes + bytes,
+                });
+            }
+        }
+    }
+
+    return result;
+};
+
 export const groupCounterGroupsByTagsAndName = (
     groups: CounterGroup[] | undefined,
     tagKeys: string[],


### PR DESCRIPTION
Replace separate count and bytes counters with single size-2 counters ([0]=packets, [1]=bytes) across all pipeline layers:

- pipeline/function: input, output, drop (was 6 counters, now 3)
- device: rx, tx (was 4 counters, now 2)
- module: rx, tx (was 4 counters, now 2)

This halves the number of counter registrations and value-handle resolutions per pipeline stage, reducing counter-storage overhead and simplifying the dataplane hot path (one handle write instead of two).

Bumps YANET_MODULE_ABI_VERSION 3 -> 4 due to cp_module and module_ectx struct layout changes.