### PR TITLE
feat(web): support multiple UI instances with different backends

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -17,7 +17,23 @@ Run the development server (from the repo root, or `cd web` and drop the flag):
 npm run dev -w web
 ```
 
-The development server will run on `http://localhost:3000` and proxy API requests to the backend.
+The development server runs on `http://localhost:3000` by default and proxies
+`/api` requests to the gateway's HTTP endpoint.
+
+### Dev server configuration
+
+| Env var              | Default                  | Description                                      |
+| -------------------- | ------------------------ | ------------------------------------------------ |
+| `VITE_BACKEND_URL`   | `http://localhost:8081`  | Full URL of the gateway HTTP endpoint (proxy target). |
+| `VITE_DEV_PORT`      | `3000`                   | Dev server listen port.                          |
+
+```bash
+# Point the dev proxy at a remote gateway
+VITE_BACKEND_URL=http://10.0.0.5:8081 npm run dev -w web
+
+# Run a second dev instance on a different port
+VITE_BACKEND_URL=http://localhost:8082 VITE_DEV_PORT=3001 npm run dev -w web
+```
 
 ## Build
 
@@ -28,3 +44,68 @@ npm run build -w web
 ```
 
 The built files will be in the `web/dist/` directory and will be served by the HTTP gateway.
+
+## Multiple instances with different backends
+
+The web UI supports talking to multiple gateway backends — either from a
+single UI instance (via the Gateway drawer) or by deploying separate UI
+instances each pre-configured for a different backend.
+
+### Runtime config (`config.json`)
+
+On startup the SPA fetches `/config.json` (served from `web/public/`).
+Override this file per deployment to pre-configure the default backend and
+seed additional gateways:
+
+```json
+{
+  "defaultBackendUrl": "http://gateway-01:8081",
+  "gateways": [
+    { "host": "gateway-01", "numa": 0, "addr": "gateway-01:8081" },
+    { "host": "gateway-02", "numa": 0, "addr": "gateway-02:8081" }
+  ]
+}
+```
+
+- `defaultBackendUrl` — the builtin (non-deletable) gateway's base URL. An
+  empty string means same-origin (the gateway serves the SPA itself).
+- `gateways` — extra gateway entries that appear in the Gateway drawer on
+  first load. Users can switch between them or add more.
+
+If `/config.json` is missing or returns a non-200 response, the SPA falls
+back to same-origin defaults.
+
+### Dev mode
+
+Run multiple dev servers, each proxying to a different backend:
+
+```bash
+# Instance 1
+VITE_BACKEND_URL=http://localhost:8081 VITE_DEV_PORT=3000 npm run dev -w web
+
+# Instance 2
+VITE_BACKEND_URL=http://localhost:8082 VITE_DEV_PORT=3001 npm run dev -w web
+```
+
+### Production (gateway-served)
+
+When the gateway serves the SPA, each gateway automatically serves a UI
+pointing at itself (same-origin). No `config.json` override is needed.
+
+### Production (standalone)
+
+Deploy the built `web/dist/` on a separate static server and place a
+custom `config.json` at the root:
+
+```bash
+npm run build -w web
+# Copy dist/ to your static server
+# Place a custom config.json at the server root
+```
+
+### CORS
+
+The gateway's HTTP proxy sets `Access-Control-Allow-Origin: *`
+(`controlplane/httpproxy/proxy.go`), so cross-origin UI deployments work
+without additional configuration. The web client automatically skips gzip
+compression for cross-origin requests to avoid CORS preflight issues.

--- a/web/public/config.json
+++ b/web/public/config.json
@@ -1,0 +1,4 @@
+{
+  "defaultBackendUrl": "",
+  "gateways": []
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { PAGE_IDS, SidebarContext } from './types';
 import { PaletteProvider, usePalette, CommandPalette, navigationCommands, ShortcutsHelp } from '@yanet/core/components/command-palette';
 import type { RowAdapter, Command } from '@yanet/core/components/command-palette';
 import { GatewayProvider, GatewayDrawer, useGateways, gatewayCommands } from '@yanet/core/gateways';
+import type { RuntimeConfig } from '@yanet/core/gateways';
 import { setApiBase } from '@yanet/core/api';
 import { routes, prefetchers, defaultRoute, navItems } from './registry';
 
@@ -224,16 +225,16 @@ const AppContentInner = (): React.JSX.Element => {
     );
 };
 
-const AppContent = (): React.JSX.Element => (
-    <GatewayProvider>
+const AppContent = ({ runtimeConfig }: { runtimeConfig?: RuntimeConfig }): React.JSX.Element => (
+    <GatewayProvider runtimeConfig={runtimeConfig}>
         <AppContentInner />
     </GatewayProvider>
 );
 
-const App = (): React.JSX.Element => {
+const App = ({ runtimeConfig }: { runtimeConfig?: RuntimeConfig }): React.JSX.Element => {
     return (
         <BrowserRouter>
-            <AppContent />
+            <AppContent runtimeConfig={runtimeConfig} />
         </BrowserRouter>
     );
 };

--- a/web/src/core/gateways/GatewayContext.tsx
+++ b/web/src/core/gateways/GatewayContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 import type { Gateway } from './types';
 import { loadFromStorage, saveToStorage } from './storage';
+import type { RuntimeConfig } from './runtimeConfig';
 
 export interface GatewayContextValue {
     gateways: Gateway[];
@@ -20,9 +21,15 @@ export const GatewayContext = createContext<GatewayContextValue>({
     setActive: () => {},
 });
 
+export interface GatewayProviderProps {
+    children: React.ReactNode;
+    /** Runtime config from `/config.json` — overrides the default seed. */
+    runtimeConfig?: RuntimeConfig;
+}
+
 /** Provides gateway list and active-selection state to the entire app. */
-export const GatewayProvider = ({ children }: { children: React.ReactNode }): React.JSX.Element => {
-    const initial = useMemo(() => loadFromStorage(), []);
+export const GatewayProvider = ({ children, runtimeConfig }: GatewayProviderProps): React.JSX.Element => {
+    const initial = useMemo(() => loadFromStorage(runtimeConfig), [runtimeConfig]);
     const [gateways, setGateways] = useState<Gateway[]>(initial.gateways);
     const [activeId, setActiveId] = useState<string>(initial.activeId);
 

--- a/web/src/core/gateways/GatewayDrawer.tsx
+++ b/web/src/core/gateways/GatewayDrawer.tsx
@@ -1,19 +1,8 @@
 import React, { useState, useCallback, useEffect } from 'react';
 import { useGateways } from './GatewayContext';
 import type { Gateway, GatewayStatus } from './types';
+import { deriveBaseUrl } from './deriveBaseUrl';
 import './GatewayDrawer.scss';
-
-/** Derives a base URL from a raw address string entered by the user. */
-export const deriveBaseUrl = (addr: string): string => {
-    const trimmed = addr.trim();
-    if (!trimmed) {
-        return '';
-    }
-    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
-        return trimmed;
-    }
-    return `http://${trimmed}`;
-};
 
 const statusColor = (status: GatewayStatus): string => {
     switch (status) {

--- a/web/src/core/gateways/deriveBaseUrl.test.ts
+++ b/web/src/core/gateways/deriveBaseUrl.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveBaseUrl } from './GatewayDrawer';
+import { deriveBaseUrl } from './deriveBaseUrl';
 
 describe('deriveBaseUrl', () => {
     it('returns empty string for an empty input', () => {

--- a/web/src/core/gateways/deriveBaseUrl.ts
+++ b/web/src/core/gateways/deriveBaseUrl.ts
@@ -1,0 +1,11 @@
+/** Derives a base URL from a raw address string entered by the user. */
+export const deriveBaseUrl = (addr: string): string => {
+    const trimmed = addr.trim();
+    if (!trimmed) {
+        return '';
+    }
+    if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+        return trimmed;
+    }
+    return `http://${trimmed}`;
+};

--- a/web/src/core/gateways/index.ts
+++ b/web/src/core/gateways/index.ts
@@ -1,5 +1,8 @@
 export type { Gateway, GatewayStatus } from './types';
 export { GatewayProvider, useGateways } from './GatewayContext';
-export type { GatewayContextValue } from './GatewayContext';
+export type { GatewayContextValue, GatewayProviderProps } from './GatewayContext';
 export { GatewayDrawer } from './GatewayDrawer';
 export { gatewayCommands } from './gatewayCommands';
+export { deriveBaseUrl } from './deriveBaseUrl';
+export { loadRuntimeConfig, builtinFromConfig, seedGatewaysFromConfig } from './runtimeConfig';
+export type { RuntimeConfig, ConfigGateway } from './runtimeConfig';

--- a/web/src/core/gateways/index.ts
+++ b/web/src/core/gateways/index.ts
@@ -4,5 +4,5 @@ export type { GatewayContextValue, GatewayProviderProps } from './GatewayContext
 export { GatewayDrawer } from './GatewayDrawer';
 export { gatewayCommands } from './gatewayCommands';
 export { deriveBaseUrl } from './deriveBaseUrl';
-export { loadRuntimeConfig, builtinFromConfig, seedGatewaysFromConfig } from './runtimeConfig';
+export { loadRuntimeConfig, builtinFromConfig, seedGatewaysFromConfig, extraGatewaysFromConfig } from './runtimeConfig';
 export type { RuntimeConfig, ConfigGateway } from './runtimeConfig';

--- a/web/src/core/gateways/runtimeConfig.test.ts
+++ b/web/src/core/gateways/runtimeConfig.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { builtinFromConfig, seedGatewaysFromConfig, loadRuntimeConfig } from './runtimeConfig';
+import type { RuntimeConfig } from './runtimeConfig';
+
+const EMPTY_CONFIG: RuntimeConfig = { defaultBackendUrl: '', gateways: [] };
+
+describe('builtinFromConfig', () => {
+    it('returns a same-origin builtin when defaultBackendUrl is empty', () => {
+        const gw = builtinFromConfig(EMPTY_CONFIG);
+        expect(gw.id).toBe('localhost');
+        expect(gw.baseUrl).toBe('');
+        expect(gw.addr).toBe('same-origin');
+        expect(gw.builtin).toBe(true);
+    });
+
+    it('returns a configured builtin when defaultBackendUrl is set', () => {
+        const gw = builtinFromConfig({ ...EMPTY_CONFIG, defaultBackendUrl: 'http://10.0.0.5:8081' });
+        expect(gw.id).toBe('localhost');
+        expect(gw.baseUrl).toBe('http://10.0.0.5:8081');
+        expect(gw.addr).toBe('http://10.0.0.5:8081');
+        expect(gw.host).toBe('10.0.0.5');
+        expect(gw.builtin).toBe(true);
+    });
+
+    it('falls back to "default" host for malformed URLs', () => {
+        const gw = builtinFromConfig({ ...EMPTY_CONFIG, defaultBackendUrl: 'not-a-url' });
+        expect(gw.host).toBe('default');
+        expect(gw.baseUrl).toBe('not-a-url');
+    });
+});
+
+describe('seedGatewaysFromConfig', () => {
+    it('returns only the builtin gateway when config has no extra gateways', () => {
+        const seed = seedGatewaysFromConfig(EMPTY_CONFIG);
+        expect(seed).toHaveLength(1);
+        expect(seed[0].builtin).toBe(true);
+    });
+
+    it('appends extra gateways from config', () => {
+        const config: RuntimeConfig = {
+            defaultBackendUrl: 'http://gw1:8081',
+            gateways: [
+                { host: 'gw2', numa: 0, addr: 'gw2:8081' },
+                { host: 'gw3', numa: 1, addr: 'https://gw3:8081' },
+            ],
+        };
+        const seed = seedGatewaysFromConfig(config);
+        expect(seed).toHaveLength(3);
+        expect(seed[0].builtin).toBe(true);
+        expect(seed[0].baseUrl).toBe('http://gw1:8081');
+        expect(seed[1].host).toBe('gw2');
+        expect(seed[1].baseUrl).toBe('http://gw2:8081');
+        expect(seed[2].host).toBe('gw3');
+        expect(seed[2].baseUrl).toBe('https://gw3:8081');
+    });
+
+    it('derives baseUrl from addr for extra gateways', () => {
+        const config: RuntimeConfig = {
+            defaultBackendUrl: '',
+            gateways: [{ host: 'gw', numa: 0, addr: '10.0.0.10:8080' }],
+        };
+        const seed = seedGatewaysFromConfig(config);
+        expect(seed[1].baseUrl).toBe('http://10.0.0.10:8080');
+    });
+});
+
+describe('loadRuntimeConfig', () => {
+    beforeEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('returns empty config when fetch returns 404', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+        const config = await loadRuntimeConfig();
+        expect(config).toEqual(EMPTY_CONFIG);
+    });
+
+    it('returns parsed config on success', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                defaultBackendUrl: 'http://gw1:8081',
+                gateways: [{ host: 'gw2', numa: 0, addr: 'gw2:8081' }],
+            }),
+        }));
+        const config = await loadRuntimeConfig();
+        expect(config.defaultBackendUrl).toBe('http://gw1:8081');
+        expect(config.gateways).toHaveLength(1);
+        expect(config.gateways[0].host).toBe('gw2');
+    });
+
+    it('returns empty config on fetch error', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+        const config = await loadRuntimeConfig();
+        expect(config).toEqual(EMPTY_CONFIG);
+    });
+
+    it('returns empty config when response is not valid JSON', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => { throw new Error('parse error'); },
+        }));
+        const config = await loadRuntimeConfig();
+        expect(config).toEqual(EMPTY_CONFIG);
+    });
+
+    it('filters out gateway entries with empty addr', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                gateways: [
+                    { host: 'gw1', numa: 0, addr: 'gw1:8081' },
+                    { host: 'gw2', numa: 0, addr: '' },
+                ],
+            }),
+        }));
+        const config = await loadRuntimeConfig();
+        expect(config.gateways).toHaveLength(1);
+        expect(config.gateways[0].host).toBe('gw1');
+    });
+
+    it('defaults numa to 0 when missing', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                gateways: [{ host: 'gw', addr: 'gw:8081' }],
+            }),
+        }));
+        const config = await loadRuntimeConfig();
+        expect(config.gateways[0].numa).toBe(0);
+    });
+});

--- a/web/src/core/gateways/runtimeConfig.ts
+++ b/web/src/core/gateways/runtimeConfig.ts
@@ -100,10 +100,9 @@ export const builtinFromConfig = (config: RuntimeConfig): Gateway => {
     };
 };
 
-/** Builds the full seed gateway list from a runtime config. */
-export const seedGatewaysFromConfig = (config: RuntimeConfig): Gateway[] => {
-    const builtin = builtinFromConfig(config);
-    const extras: Gateway[] = config.gateways.map((g, i) => ({
+/** Builds the extra (non-builtin) gateway list from a runtime config. */
+export const extraGatewaysFromConfig = (config: RuntimeConfig): Gateway[] => {
+    return config.gateways.map((g, i) => ({
         id: `seed-${i}-${g.host}-${g.numa}`,
         host: g.host,
         numa: g.numa,
@@ -111,5 +110,9 @@ export const seedGatewaysFromConfig = (config: RuntimeConfig): Gateway[] => {
         baseUrl: deriveBaseUrl(g.addr),
         status: 'online',
     }));
-    return [builtin, ...extras];
+};
+
+/** Builds the full seed gateway list from a runtime config. */
+export const seedGatewaysFromConfig = (config: RuntimeConfig): Gateway[] => {
+    return [builtinFromConfig(config), ...extraGatewaysFromConfig(config)];
 };

--- a/web/src/core/gateways/runtimeConfig.ts
+++ b/web/src/core/gateways/runtimeConfig.ts
@@ -1,0 +1,115 @@
+import { deriveBaseUrl } from './deriveBaseUrl';
+import type { Gateway } from './types';
+
+/** A gateway entry in the runtime config file. */
+export interface ConfigGateway {
+    host: string;
+    numa: number;
+    addr: string;
+}
+
+/** Shape of the `/config.json` file served alongside the SPA. */
+export interface RuntimeConfig {
+    /**
+     * Base URL of the default (builtin) backend.
+     *
+     * An empty string means same-origin — the SPA is served by the gateway
+     * itself and API calls go to `/api/...` on the current origin.
+     *
+     * Set to a full URL (e.g. `http://10.0.0.10:8081`) when the SPA is
+     * deployed separately from the gateway.
+     */
+    defaultBackendUrl: string;
+    /** Additional gateways to seed so users can switch between them. */
+    gateways: ConfigGateway[];
+}
+
+const EMPTY_CONFIG: RuntimeConfig = {
+    defaultBackendUrl: '',
+    gateways: [],
+};
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+    typeof v === 'object' && v !== null;
+
+const parseConfig = (raw: unknown): RuntimeConfig => {
+    if (!isRecord(raw)) {
+        return EMPTY_CONFIG;
+    }
+    const defaultBackendUrl =
+        typeof raw.defaultBackendUrl === 'string' ? raw.defaultBackendUrl.trim() : '';
+    const gateways = Array.isArray(raw.gateways)
+        ? raw.gateways
+              .filter(isRecord)
+              .map((g) => ({
+                  host: typeof g.host === 'string' ? g.host : 'unnamed',
+                  numa: typeof g.numa === 'number' ? g.numa : 0,
+                  addr: typeof g.addr === 'string' ? g.addr : '',
+              }))
+              .filter((g) => g.addr.length > 0)
+        : [];
+    return { defaultBackendUrl, gateways };
+};
+
+/**
+ * Fetches `/config.json` and returns the parsed runtime configuration.
+ *
+ * The file is optional — if it does not exist (404) or fails to parse, an
+ * empty config is returned and the SPA falls back to same-origin defaults.
+ */
+export const loadRuntimeConfig = async (): Promise<RuntimeConfig> => {
+    try {
+        const res = await fetch('/config.json', { cache: 'no-cache' });
+        if (!res.ok) {
+            return EMPTY_CONFIG;
+        }
+        return parseConfig(await res.json());
+    } catch {
+        return EMPTY_CONFIG;
+    }
+};
+
+/** Builds the builtin gateway from a runtime config. */
+export const builtinFromConfig = (config: RuntimeConfig): Gateway => {
+    const url = config.defaultBackendUrl;
+    if (!url) {
+        return {
+            id: 'localhost',
+            host: 'localhost',
+            numa: 0,
+            addr: 'same-origin',
+            baseUrl: '',
+            status: 'online',
+            builtin: true,
+        };
+    }
+    let host = 'default';
+    try {
+        host = new URL(url).hostname || 'default';
+    } catch {
+        // keep 'default'
+    }
+    return {
+        id: 'localhost',
+        host,
+        numa: 0,
+        addr: url,
+        baseUrl: url,
+        status: 'online',
+        builtin: true,
+    };
+};
+
+/** Builds the full seed gateway list from a runtime config. */
+export const seedGatewaysFromConfig = (config: RuntimeConfig): Gateway[] => {
+    const builtin = builtinFromConfig(config);
+    const extras: Gateway[] = config.gateways.map((g, i) => ({
+        id: `seed-${i}-${g.host}-${g.numa}`,
+        host: g.host,
+        numa: g.numa,
+        addr: g.addr,
+        baseUrl: deriveBaseUrl(g.addr),
+        status: 'online',
+    }));
+    return [builtin, ...extras];
+};

--- a/web/src/core/gateways/seed.ts
+++ b/web/src/core/gateways/seed.ts
@@ -1,25 +1,23 @@
 import type { Gateway } from './types';
+import { builtinFromConfig, seedGatewaysFromConfig } from './runtimeConfig';
+import type { RuntimeConfig } from './runtimeConfig';
+
+const EMPTY_CONFIG: RuntimeConfig = { defaultBackendUrl: '', gateways: [] };
 
 /**
- * Default gateway inventory seeded on first load.
+ * Default gateway inventory seeded on first load when no `/config.json` is
+ * present.
  *
  * The builtin localhost entry is always first and carries an empty baseUrl
  * so same-origin API calls work out of the box against the dev server or
  * production host. It is non-deletable and non-editable.
  */
-export const SEED_GATEWAYS: Gateway[] = [
-    {
-        id: 'localhost',
-        host: 'localhost',
-        numa: 0,
-        addr: 'same-origin',
-        baseUrl: '',
-        status: 'online',
-        builtin: true,
-    }
-];
+export const SEED_GATEWAYS: Gateway[] = seedGatewaysFromConfig(EMPTY_CONFIG);
 
 /** The builtin localhost entry that is always present. */
-export const BUILTIN_GATEWAY: Gateway = SEED_GATEWAYS[0];
+export const BUILTIN_GATEWAY: Gateway = builtinFromConfig(EMPTY_CONFIG);
 
 export const SEED_ACTIVE_ID = 'localhost';
+
+export { builtinFromConfig, seedGatewaysFromConfig };
+export type { RuntimeConfig, ConfigGateway } from './runtimeConfig';

--- a/web/src/core/gateways/seed.ts
+++ b/web/src/core/gateways/seed.ts
@@ -1,5 +1,5 @@
 import type { Gateway } from './types';
-import { builtinFromConfig, seedGatewaysFromConfig } from './runtimeConfig';
+import { builtinFromConfig, seedGatewaysFromConfig, extraGatewaysFromConfig } from './runtimeConfig';
 import type { RuntimeConfig } from './runtimeConfig';
 
 const EMPTY_CONFIG: RuntimeConfig = { defaultBackendUrl: '', gateways: [] };
@@ -19,5 +19,5 @@ export const BUILTIN_GATEWAY: Gateway = builtinFromConfig(EMPTY_CONFIG);
 
 export const SEED_ACTIVE_ID = 'localhost';
 
-export { builtinFromConfig, seedGatewaysFromConfig };
+export { builtinFromConfig, seedGatewaysFromConfig, extraGatewaysFromConfig };
 export type { RuntimeConfig, ConfigGateway } from './runtimeConfig';

--- a/web/src/core/gateways/storage.test.ts
+++ b/web/src/core/gateways/storage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { loadFromStorage, saveToStorage } from './storage';
 import { SEED_GATEWAYS, SEED_ACTIVE_ID, BUILTIN_GATEWAY } from './seed';
+import type { RuntimeConfig } from './runtimeConfig';
 
 const STORAGE_KEY = 'yanet_gateways_v1';
 
@@ -89,5 +90,47 @@ describe('saveToStorage + loadFromStorage round-trip', () => {
         const builtin = result.gateways.find((g) => g.builtin === true);
         expect(builtin).toBeDefined();
         expect(builtin).toEqual(BUILTIN_GATEWAY);
+    });
+});
+
+describe('loadFromStorage with runtime config', () => {
+    let mockStorage: Storage;
+
+    beforeEach(() => {
+        mockStorage = makeMockStorage();
+        vi.stubGlobal('localStorage', mockStorage);
+    });
+
+    it('returns config-derived seed when localStorage is empty', () => {
+        const config: RuntimeConfig = {
+            defaultBackendUrl: 'http://gw1:8081',
+            gateways: [{ host: 'gw2', numa: 0, addr: 'gw2:8081' }],
+        };
+        const result = loadFromStorage(config);
+        expect(result.gateways).toHaveLength(2);
+        expect(result.gateways[0].baseUrl).toBe('http://gw1:8081');
+        expect(result.gateways[0].builtin).toBe(true);
+        expect(result.gateways[1].host).toBe('gw2');
+        expect(result.activeId).toBe('localhost');
+    });
+
+    it('re-injects config-derived builtin when stored list lacks one', () => {
+        const config: RuntimeConfig = {
+            defaultBackendUrl: 'http://gw1:8081',
+            gateways: [],
+        };
+        const stored = {
+            gateways: [{ id: 'x', host: 'other', numa: 0, addr: '1.2.3.4:80', baseUrl: 'http://1.2.3.4:80', status: 'online' as const }],
+            activeId: 'x',
+        };
+        mockStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+        const result = loadFromStorage(config);
+        expect(result.gateways[0].builtin).toBe(true);
+        expect(result.gateways[0].baseUrl).toBe('http://gw1:8081');
+    });
+
+    it('returns same-origin seed when config is empty', () => {
+        const result = loadFromStorage({ defaultBackendUrl: '', gateways: [] });
+        expect(result.gateways).toEqual(SEED_GATEWAYS);
     });
 });

--- a/web/src/core/gateways/storage.test.ts
+++ b/web/src/core/gateways/storage.test.ts
@@ -155,4 +155,49 @@ describe('loadFromStorage with runtime config', () => {
         const nonBuiltin = result.gateways.find((g) => !g.builtin);
         expect(nonBuiltin!.host).toBe('other');
     });
+
+    it('merges config extras into stored list for returning users', () => {
+        const config: RuntimeConfig = {
+            defaultBackendUrl: 'http://gw1:8081',
+            gateways: [
+                { host: 'gw2', numa: 0, addr: 'gw2:8081' },
+                { host: 'gw3', numa: 0, addr: 'gw3:8081' },
+            ],
+        };
+        const stored = {
+            gateways: [
+                { id: 'localhost', host: 'localhost', numa: 0, addr: 'same-origin', baseUrl: '', status: 'online' as const, builtin: true },
+                { id: 'gw-01', host: 'other', numa: 0, addr: '10.0.0.10:8080', baseUrl: 'http://10.0.0.10:8080', status: 'online' as const },
+            ],
+            activeId: 'localhost',
+        };
+        mockStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+        const result = loadFromStorage(config);
+        // builtin + stored non-builtin + 2 config extras
+        expect(result.gateways).toHaveLength(4);
+        expect(result.gateways[0].builtin).toBe(true);
+        expect(result.gateways[0].baseUrl).toBe('http://gw1:8081');
+        expect(result.gateways[1].host).toBe('other');
+        expect(result.gateways[2].host).toBe('gw2');
+        expect(result.gateways[3].host).toBe('gw3');
+    });
+
+    it('dedupes config extras by addr when stored list has matching entry', () => {
+        const config: RuntimeConfig = {
+            defaultBackendUrl: '',
+            gateways: [{ host: 'gw2', numa: 0, addr: 'gw2:8081' }],
+        };
+        const stored = {
+            gateways: [
+                { id: 'localhost', host: 'localhost', numa: 0, addr: 'same-origin', baseUrl: '', status: 'online' as const, builtin: true },
+                { id: 'gw-01', host: 'gw2', numa: 0, addr: 'gw2:8081', baseUrl: 'http://gw2:8081', status: 'online' as const },
+            ],
+            activeId: 'localhost',
+        };
+        mockStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+        const result = loadFromStorage(config);
+        // builtin + stored gw2 (config gw2 is deduped)
+        expect(result.gateways).toHaveLength(2);
+        expect(result.gateways[1].addr).toBe('gw2:8081');
+    });
 });

--- a/web/src/core/gateways/storage.test.ts
+++ b/web/src/core/gateways/storage.test.ts
@@ -133,4 +133,26 @@ describe('loadFromStorage with runtime config', () => {
         const result = loadFromStorage({ defaultBackendUrl: '', gateways: [] });
         expect(result.gateways).toEqual(SEED_GATEWAYS);
     });
+
+    it('replaces stored same-origin builtin with config-derived one', () => {
+        const config: RuntimeConfig = {
+            defaultBackendUrl: 'http://gw1:8081',
+            gateways: [],
+        };
+        const stored = {
+            gateways: [
+                { id: 'localhost', host: 'localhost', numa: 0, addr: 'same-origin', baseUrl: '', status: 'online' as const, builtin: true },
+                { id: 'gw-01', host: 'other', numa: 0, addr: '10.0.0.10:8080', baseUrl: 'http://10.0.0.10:8080', status: 'online' as const },
+            ],
+            activeId: 'localhost',
+        };
+        mockStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
+        const result = loadFromStorage(config);
+        const builtin = result.gateways.find((g) => g.builtin === true);
+        expect(builtin).toBeDefined();
+        expect(builtin!.baseUrl).toBe('http://gw1:8081');
+        expect(result.gateways).toHaveLength(2);
+        const nonBuiltin = result.gateways.find((g) => !g.builtin);
+        expect(nonBuiltin!.host).toBe('other');
+    });
 });

--- a/web/src/core/gateways/storage.ts
+++ b/web/src/core/gateways/storage.ts
@@ -21,14 +21,19 @@ interface StoredState {
  * If the stored list has no builtin entry (e.g. saved before this feature was
  * added), the builtin is prepended so the invariant holds after every load.
  *
- * When a runtime config is provided, the builtin reflects the configured
- * `defaultBackendUrl` rather than the plain same-origin default.
+ * When a runtime config is provided, any stored builtin is replaced with the
+ * config-derived one so `defaultBackendUrl` changes take effect even for
+ * users who previously saved a same-origin builtin.
  */
 const ensureBuiltin = (gateways: Gateway[], config?: RuntimeConfig): Gateway[] => {
+    const builtin = config ? builtinFromConfig(config) : BUILTIN_GATEWAY;
+    if (config) {
+        const rest = gateways.filter((g) => !g.builtin);
+        return [builtin, ...rest];
+    }
     if (gateways.some((g) => g.builtin === true)) {
         return gateways;
     }
-    const builtin = config ? builtinFromConfig(config) : BUILTIN_GATEWAY;
     return [builtin, ...gateways];
 };
 

--- a/web/src/core/gateways/storage.ts
+++ b/web/src/core/gateways/storage.ts
@@ -1,5 +1,12 @@
 import type { Gateway } from './types';
-import { SEED_GATEWAYS, SEED_ACTIVE_ID, BUILTIN_GATEWAY } from './seed';
+import {
+    SEED_GATEWAYS,
+    SEED_ACTIVE_ID,
+    BUILTIN_GATEWAY,
+    builtinFromConfig,
+    seedGatewaysFromConfig,
+} from './seed';
+import type { RuntimeConfig } from './runtimeConfig';
 
 const STORAGE_KEY = 'yanet_gateways_v1';
 
@@ -9,24 +16,29 @@ interface StoredState {
 }
 
 /**
- * Ensures the builtin localhost gateway is always the first entry.
+ * Ensures the builtin gateway is always the first entry.
  *
  * If the stored list has no builtin entry (e.g. saved before this feature was
  * added), the builtin is prepended so the invariant holds after every load.
+ *
+ * When a runtime config is provided, the builtin reflects the configured
+ * `defaultBackendUrl` rather than the plain same-origin default.
  */
-const ensureBuiltin = (gateways: Gateway[]): Gateway[] => {
+const ensureBuiltin = (gateways: Gateway[], config?: RuntimeConfig): Gateway[] => {
     if (gateways.some((g) => g.builtin === true)) {
         return gateways;
     }
-    return [BUILTIN_GATEWAY, ...gateways];
+    const builtin = config ? builtinFromConfig(config) : BUILTIN_GATEWAY;
+    return [builtin, ...gateways];
 };
 
 /** Load gateways and active id from localStorage, falling back to the seed on any error. */
-export const loadFromStorage = (): StoredState => {
+export const loadFromStorage = (config?: RuntimeConfig): StoredState => {
+    const seed = config ? seedGatewaysFromConfig(config) : SEED_GATEWAYS;
     try {
         const raw = localStorage.getItem(STORAGE_KEY);
         if (!raw) {
-            return { gateways: SEED_GATEWAYS, activeId: SEED_ACTIVE_ID };
+            return { gateways: seed, activeId: SEED_ACTIVE_ID };
         }
         const parsed = JSON.parse(raw) as unknown;
         if (
@@ -35,12 +47,12 @@ export const loadFromStorage = (): StoredState => {
             !Array.isArray((parsed as StoredState).gateways) ||
             typeof (parsed as StoredState).activeId !== 'string'
         ) {
-            return { gateways: SEED_GATEWAYS, activeId: SEED_ACTIVE_ID };
+            return { gateways: seed, activeId: SEED_ACTIVE_ID };
         }
         const state = parsed as StoredState;
-        return { gateways: ensureBuiltin(state.gateways), activeId: state.activeId };
+        return { gateways: ensureBuiltin(state.gateways, config), activeId: state.activeId };
     } catch {
-        return { gateways: SEED_GATEWAYS, activeId: SEED_ACTIVE_ID };
+        return { gateways: seed, activeId: SEED_ACTIVE_ID };
     }
 };
 

--- a/web/src/core/gateways/storage.ts
+++ b/web/src/core/gateways/storage.ts
@@ -5,6 +5,7 @@ import {
     BUILTIN_GATEWAY,
     builtinFromConfig,
     seedGatewaysFromConfig,
+    extraGatewaysFromConfig,
 } from './seed';
 import type { RuntimeConfig } from './runtimeConfig';
 
@@ -16,25 +17,32 @@ interface StoredState {
 }
 
 /**
- * Ensures the builtin gateway is always the first entry.
+ * Merges stored gateways with the runtime config.
  *
- * If the stored list has no builtin entry (e.g. saved before this feature was
- * added), the builtin is prepended so the invariant holds after every load.
+ * When a config is provided:
+ * - The stored builtin is replaced with the config-derived one so
+ *   `defaultBackendUrl` changes take effect for returning users.
+ * - Config-defined extra gateways are appended, deduped by `addr` so
+ *   users who already added the same backend don't get a duplicate.
  *
- * When a runtime config is provided, any stored builtin is replaced with the
- * config-derived one so `defaultBackendUrl` changes take effect even for
- * users who previously saved a same-origin builtin.
+ * Without a config, the stored builtin is kept as-is (or the default
+ * same-origin one is prepended if missing).
  */
-const ensureBuiltin = (gateways: Gateway[], config?: RuntimeConfig): Gateway[] => {
+const mergeWithConfig = (gateways: Gateway[], config?: RuntimeConfig): Gateway[] => {
     const builtin = config ? builtinFromConfig(config) : BUILTIN_GATEWAY;
-    if (config) {
-        const rest = gateways.filter((g) => !g.builtin);
-        return [builtin, ...rest];
+
+    if (!config) {
+        if (gateways.some((g) => g.builtin === true)) {
+            return gateways;
+        }
+        return [builtin, ...gateways];
     }
-    if (gateways.some((g) => g.builtin === true)) {
-        return gateways;
-    }
-    return [builtin, ...gateways];
+
+    const rest = gateways.filter((g) => !g.builtin);
+    const existingAddrs = new Set(rest.map((g) => g.addr));
+    const extras = extraGatewaysFromConfig(config).filter((g) => !existingAddrs.has(g.addr));
+
+    return [builtin, ...rest, ...extras];
 };
 
 /** Load gateways and active id from localStorage, falling back to the seed on any error. */
@@ -55,7 +63,7 @@ export const loadFromStorage = (config?: RuntimeConfig): StoredState => {
             return { gateways: seed, activeId: SEED_ACTIVE_ID };
         }
         const state = parsed as StoredState;
-        return { gateways: ensureBuiltin(state.gateways, config), activeId: state.activeId };
+        return { gateways: mergeWithConfig(state.gateways, config), activeId: state.activeId };
     } catch {
         return { gateways: seed, activeId: SEED_ACTIVE_ID };
     }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,18 +4,20 @@ import { ThemeProvider } from '@gravity-ui/uikit';
 import { ToasterProvider, ToasterComponent } from '@gravity-ui/uikit';
 import { toaster } from '@gravity-ui/uikit/toaster-singleton';
 import App from './App';
+import { loadRuntimeConfig } from '@yanet/core/gateways/runtimeConfig';
 import '@gravity-ui/uikit/styles/fonts.css';
 import '@gravity-ui/uikit/styles/styles.css';
 import '@yanet/core/styles/tokens.scss';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-    <React.StrictMode>
-        <ThemeProvider theme="dark">
-            <ToasterProvider toaster={toaster}>
-                <App />
-                <ToasterComponent />
-            </ToasterProvider>
-        </ThemeProvider>
-    </React.StrictMode>
-);
-
+loadRuntimeConfig().then((runtimeConfig) => {
+    ReactDOM.createRoot(document.getElementById('root')!).render(
+        <React.StrictMode>
+            <ThemeProvider theme="dark">
+                <ToasterProvider toaster={toaster}>
+                    <App runtimeConfig={runtimeConfig} />
+                    <ToasterComponent />
+                </ToasterProvider>
+            </ThemeProvider>
+        </React.StrictMode>
+    );
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -7,6 +7,19 @@ const ReactCompilerConfig = {};
 
 const rootDir = fileURLToPath(new URL('.', import.meta.url));
 
+// Backend gateway HTTP URL for the dev proxy. Supports a full URL so the
+// dev server can target a gateway on any host:port, enabling multiple dev
+// instances each talking to a different backend.
+//
+//   VITE_BACKEND_URL=http://10.0.0.5:8081 npm run dev -w web
+//
+// Falls back to http://localhost:8081 when unset.
+const backendUrl = process.env.VITE_BACKEND_URL || 'http://localhost:8081';
+
+// Dev server port. Override to run multiple dev instances side by side.
+//   VITE_DEV_PORT=3001 npm run dev -w web
+const devPort = parseInt(process.env.VITE_DEV_PORT || '3000', 10);
+
 // Serve the SPA shell for HTML navigations whose path collides with a
 // co-located source directory.
 //
@@ -83,7 +96,7 @@ export default defineConfig({
     },
     server: {
         host: '::',
-        port: 3000,
+        port: devPort,
         allowedHosts: ['yanet-dev-esafronov.vla.yp-c.yandex.net'],
         // Allow the dev server to read co-located module web sources above
         // web/ (phase 4+). Keep searchForWorkspaceRoot or auto workspace
@@ -96,7 +109,7 @@ export default defineConfig({
         },
         proxy: {
             '/api': {
-                target: 'http://localhost:8081',
+                target: backendUrl,
                 changeOrigin: true,
             },
         },


### PR DESCRIPTION
Add runtime config.json mechanism so each deployment can pre-configure its default backend URL and seed additional gateways. The SPA fetches /config.json on startup; if missing it falls back to same-origin.

Replace VITE_BACKEND_PORT with VITE_BACKEND_URL (full URL) and add VITE_DEV_PORT so multiple dev servers can run side by side, each proxying to a different backend.

Extract deriveBaseUrl from GatewayDrawer into its own module so runtimeConfig and the drawer share one implementation. Wire GatewayProvider to accept a runtimeConfig prop that overrides the seed gateways and builtin gateway base URL.