### PR TITLE
feat(counters): add worker drop and pending list counters

### DIFF
--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -416,6 +416,12 @@ struct WorkerRow {
     remote_rx: String,
     #[tabled(rename = "Remote TX")]
     remote_tx: String,
+    #[tabled(rename = "LclTX Drp")]
+    local_tx_drops: String,
+    #[tabled(rename = "RemTX Drp")]
+    remote_tx_drops: String,
+    #[tabled(rename = "Drops")]
+    drops: String,
 }
 
 impl From<&WorkerCounter> for WorkerRow {
@@ -456,6 +462,9 @@ impl From<&WorkerCounter> for WorkerRow {
             avg_burst,
             remote_rx: format_number(w.remote_rx_packets),
             remote_tx: format_number(w.remote_tx_packets),
+            local_tx_drops: format_number(w.local_tx_drops),
+            remote_tx_drops: format_number(w.remote_tx_drops),
+            drops: format_number(w.drops),
         }
     }
 }

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -183,6 +183,9 @@ func (m *Counters) Workers(
 			TxBytes:         worker.TxBytes,
 			RemoteRxPackets: worker.RemoteRxPackets,
 			RemoteTxPackets: worker.RemoteTxPackets,
+			LocalTxDrops:    worker.LocalTxDrops,
+			RemoteTxDrops:   worker.RemoteTxDrops,
+			Drops:           worker.Drops,
 		})
 	}
 

--- a/controlplane/ffi/worker.go
+++ b/controlplane/ffi/worker.go
@@ -26,6 +26,9 @@ type WorkerCounter struct {
 	TxBytes         uint64
 	RemoteRxPackets uint64
 	RemoteTxPackets uint64
+	LocalTxDrops    uint64
+	RemoteTxDrops   uint64
+	Drops           uint64
 }
 
 func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
@@ -50,6 +53,9 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 	txHandle := counterByName["tx"]
 	remoteRxHandle := counterByName["remote_rx"]
 	remoteTxHandle := counterByName["remote_tx"]
+	localTxDropsHandle := counterByName["local_tx_drops"]
+	remoteTxDropsHandle := counterByName["remote_tx_drops"]
+	dropsHandle := counterByName["drops"]
 
 	workerCount := counters.instance_count
 	result := make([]WorkerCounter, workerCount)
@@ -97,6 +103,21 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 			RemoteTxPackets: uint64(C.yanet_get_counter_value(
 				remoteTxHandle.value_handle,
 				workerCounterPacketsValueIdx,
+				idx,
+			)),
+			LocalTxDrops: uint64(C.yanet_get_counter_value(
+				localTxDropsHandle.value_handle,
+				workerCounterSingleValueIdx,
+				idx,
+			)),
+			RemoteTxDrops: uint64(C.yanet_get_counter_value(
+				remoteTxDropsHandle.value_handle,
+				workerCounterSingleValueIdx,
+				idx,
+			)),
+			Drops: uint64(C.yanet_get_counter_value(
+				dropsHandle.value_handle,
+				workerCounterSingleValueIdx,
 				idx,
 			)),
 		}

--- a/controlplane/ynpb/v1/counters.proto
+++ b/controlplane/ynpb/v1/counters.proto
@@ -68,6 +68,12 @@ message WorkerCounter {
   uint64 remote_rx_packets = 12;
   // Total packets sent to remote workers.
   uint64 remote_tx_packets = 13;
+  // Packets dropped because the local NIC TX burst could not accept them.
+  uint64 local_tx_drops = 14;
+  // Packets dropped because the inter-worker data pipe was full or absent.
+  uint64 remote_tx_drops = 15;
+  // Total packets dropped by this worker for any reason.
+  uint64 drops = 16;
 }
 
 // Requests a snapshot of raw cumulative per-port extended stats counters.

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -60,7 +60,9 @@
 #include <rte_ethdev.h>
 
 static void
-worker_read(struct dataplane_worker *worker, struct packet_list *packets) {
+worker_read(
+	struct dataplane_worker *worker, struct packet_front *packet_front
+) {
 	struct worker_read_ctx *ctx = &worker->read_ctx;
 	struct rte_mbuf *mbufs[ctx->read_size];
 
@@ -85,9 +87,10 @@ worker_read(struct dataplane_worker *worker, struct packet_list *packets) {
 		if (parse_packet(packet)) {
 			struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 			rte_pktmbuf_free(mbuf);
+			*(worker->dp_worker->drop_count) += 1;
 			continue;
 		}
-		packet_list_add(packets, packet);
+		packet_front_pending_input(packet_front, packet);
 	}
 }
 
@@ -127,6 +130,12 @@ worker_rx_pipe_pop_cb(void **item, size_t count, void *data) {
 		worker->port_id, worker->queue_id, mbufs, count
 	);
 	*(worker->dp_worker->tx_count) += written;
+
+	size_t dropped = count - written;
+	if (dropped > 0) {
+		*(worker->dp_worker->local_tx_drops) += dropped;
+		*(worker->dp_worker->drop_count) += dropped;
+	}
 
 	for (size_t idx = written; idx < count; ++idx) {
 		rte_pktmbuf_free(mbufs[idx]);
@@ -227,13 +236,20 @@ worker_submit_burst(
 
 	*(worker->dp_worker->tx_count) += written;
 
+	uint16_t dropped = count - written;
+	if (dropped > 0) {
+		*(worker->dp_worker->local_tx_drops) += dropped;
+	}
+
 	for (uint16_t idx = written; idx < count; ++idx) {
 		packet_list_add(failed, mbuf_to_packet(mbufs[idx]));
 	}
 }
 
 static void
-worker_write(struct dataplane_worker *worker, struct packet_list *packets) {
+worker_write(
+	struct dataplane_worker *worker, struct packet_front *packet_front
+) {
 	struct dp_config *dp_config = worker->instance->dp_config;
 
 	struct packet_list failed;
@@ -245,10 +261,15 @@ worker_write(struct dataplane_worker *worker, struct packet_list *packets) {
 	// Free all ready mbufs from tx write channels
 	worker_collect_from_port(worker);
 
+	// Drain the output list; transmitted packets are freed and failures
+	// are re-added via packet_front_output, so reset the counters first.
+	packet_front->output_count = 0;
+	packet_front->output_bytes = 0;
+
 	uint16_t to_write = 0;
 
 	struct packet *packet;
-	while ((packet = packet_list_pop(packets)) != NULL) {
+	while ((packet = packet_list_pop(&packet_front->output)) != NULL) {
 		if (to_write == ctx->write_size) {
 			worker_submit_burst(worker, mbufs, to_write, &failed);
 			to_write = 0;
@@ -265,6 +286,7 @@ worker_write(struct dataplane_worker *worker, struct packet_list *packets) {
 			++to_write;
 		} else {
 			if (worker_send_to_port(worker, packet)) {
+				*(worker->dp_worker->remote_tx_drops) += 1;
 				packet_list_add(&failed, packet);
 			} else {
 				*(worker->dp_worker->remote_tx_count) += 1;
@@ -276,7 +298,11 @@ worker_write(struct dataplane_worker *worker, struct packet_list *packets) {
 		worker_submit_burst(worker, mbufs, to_write, &failed);
 	}
 
-	packet_list_concat(packets, &failed);
+	// Move failures back to the output list, restoring counters.
+	struct packet *failed_packet;
+	while ((failed_packet = packet_list_pop(&failed)) != NULL) {
+		packet_front_output(packet_front, failed_packet);
+	}
 
 	// Read incoming mbufs from remote workers and write them to device
 	for (uint32_t pipe_idx = 0; pipe_idx < ctx->rx_pipe_count; ++pipe_idx) {
@@ -311,15 +337,14 @@ worker_loop_round(struct dataplane_worker *worker) {
 	struct packet_front packet_front;
 	packet_front_init(&packet_front);
 
-	worker_read(worker, &packet_front.pending_input);
+	worker_read(worker, &packet_front);
 
 	if (config_gen_ectx == NULL) {
-		worker_write(worker, &packet_front.drop);
+		worker_write(worker, &packet_front);
 
-		packet_list_concat(
-			&packet_front.drop, &packet_front.pending_input
-		);
+		packet_front_drop_pending_input(&packet_front);
 
+		*(worker->dp_worker->drop_count) += packet_front.drop_count;
 		dataplane_drop_packets(worker->dataplane, &packet_front.drop);
 
 		return;
@@ -329,14 +354,15 @@ worker_loop_round(struct dataplane_worker *worker) {
 		worker->dp_worker, cp_config_gen, config_gen_ectx, &packet_front
 	);
 
-	worker_write(worker, &packet_front.output);
+	worker_write(worker, &packet_front);
 
 	/*
-	 * `output_packets` now contains failed-to-transmit packets which
-	 * should be freed.
+	 * `output` now contains failed-to-transmit packets which should be
+	 * freed.
 	 */
-	packet_list_concat(&packet_front.drop, &packet_front.output);
+	packet_front_drop_output(&packet_front);
 
+	*(worker->dp_worker->drop_count) += packet_front.drop_count;
 	dataplane_drop_packets(worker->dataplane, &packet_front.drop);
 }
 
@@ -548,6 +574,12 @@ dataplane_worker_start(struct dataplane_worker *worker) {
 	dp_worker->remote_tx_count =
 		counter_get_address(4, worker_counter_storage) + 0;
 	dp_worker->rx_bursts = counter_get_address(5, worker_counter_storage);
+
+	dp_worker->local_tx_drops =
+		counter_get_address(6, worker_counter_storage);
+	dp_worker->remote_tx_drops =
+		counter_get_address(7, worker_counter_storage);
+	dp_worker->drop_count = counter_get_address(8, worker_counter_storage);
 
 	pthread_attr_t wrk_th_attr;
 	pthread_attr_init(&wrk_th_attr);

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -32,7 +32,7 @@ _Static_assert(
 	"struct packet size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct packet_front) == 128,
+	sizeof(struct packet_front) == 160,
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
@@ -44,6 +44,6 @@ _Static_assert(
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_worker) == 136,
+	sizeof(struct dp_worker) == 160,
 	"struct dp_worker size changed, bump YANET_MODULE_ABI_VERSION"
 );

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -71,6 +71,14 @@ struct dp_worker {
 	uint64_t *remote_rx_count;
 	uint64_t *remote_tx_count;
 
+	// Packets dropped because the local NIC TX burst could not accept them.
+	uint64_t *local_tx_drops;
+	// Packets dropped because the inter-worker data pipe was full or
+	// absent.
+	uint64_t *remote_tx_drops;
+	// Total packets dropped by this worker for any reason.
+	uint64_t *drop_count;
+
 	struct rte_mempool *rx_mempool;
 
 	uint64_t *rx_bursts;

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 3
+#define YANET_MODULE_ABI_VERSION 4
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/module/packet_front.h
+++ b/lib/dataplane/module/packet_front.h
@@ -13,11 +13,11 @@
  * RX and TX are considered as separated stages of packet processing working
  * before and after pipeline processing.
  *
- * The count/byte counters for the input, output and drop lists live here
- * rather than on the packet lists themselves: they reflect the role a list
- * plays in the front. The input counters are a snapshot taken when output is
- * switched into input; output and drop counters accumulate as packets are
- * emitted. The pending lists are not counted.
+ * The count/byte counters for the input, output, drop and pending lists
+ * live here rather than on the packet lists themselves: they reflect the
+ * role a list plays in the front. The input counters are a snapshot taken
+ * when output is switched into input; output, drop and pending counters
+ * accumulate as packets are emitted.
  */
 struct packet_front {
 	struct packet_list pending_input;
@@ -26,6 +26,12 @@ struct packet_front {
 	struct packet_list input;
 	struct packet_list output;
 	struct packet_list drop;
+
+	uint64_t pending_input_count;
+	uint64_t pending_input_bytes;
+
+	uint64_t pending_output_count;
+	uint64_t pending_output_bytes;
 
 	uint64_t input_count;
 	uint64_t input_bytes;
@@ -45,6 +51,10 @@ packet_front_init(struct packet_front *packet_front) {
 	packet_list_init(&packet_front->output);
 	packet_list_init(&packet_front->drop);
 
+	packet_front->pending_input_count = 0;
+	packet_front->pending_input_bytes = 0;
+	packet_front->pending_output_count = 0;
+	packet_front->pending_output_bytes = 0;
 	packet_front->input_count = 0;
 	packet_front->input_bytes = 0;
 	packet_front->output_count = 0;
@@ -60,10 +70,32 @@ packet_front_merge(struct packet_front *dst, struct packet_front *src) {
 	packet_list_concat(&dst->pending_input, &src->pending_input);
 	packet_list_concat(&dst->pending_output, &src->pending_output);
 
+	dst->pending_input_count += src->pending_input_count;
+	dst->pending_input_bytes += src->pending_input_bytes;
+	dst->pending_output_count += src->pending_output_count;
+	dst->pending_output_bytes += src->pending_output_bytes;
 	dst->output_count += src->output_count;
 	dst->output_bytes += src->output_bytes;
 	dst->drop_count += src->drop_count;
 	dst->drop_bytes += src->drop_bytes;
+}
+
+static inline void
+packet_front_pending_input(
+	struct packet_front *packet_front, struct packet *packet
+) {
+	packet_list_add(&packet_front->pending_input, packet);
+	packet_front->pending_input_count += 1;
+	packet_front->pending_input_bytes += packet->data_len;
+}
+
+static inline void
+packet_front_pending_output(
+	struct packet_front *packet_front, struct packet *packet
+) {
+	packet_list_add(&packet_front->pending_output, packet);
+	packet_front->pending_output_count += 1;
+	packet_front->pending_output_bytes += packet->data_len;
 }
 
 static inline void
@@ -127,6 +159,21 @@ packet_front_drop_output(struct packet_front *packet_front) {
 	packet_front->drop_bytes += packet_front->output_bytes;
 	packet_front->output_count = 0;
 	packet_front->output_bytes = 0;
+}
+
+// Move the whole pending_input list into the drop list, transferring the
+// counters.
+//
+// Used by drain paths that discard all pending input (e.g. when no
+// pipeline is configured).
+static inline void
+packet_front_drop_pending_input(struct packet_front *packet_front) {
+	packet_list_concat(&packet_front->drop, &packet_front->pending_input);
+
+	packet_front->drop_count += packet_front->pending_input_count;
+	packet_front->drop_bytes += packet_front->pending_input_bytes;
+	packet_front->pending_input_count = 0;
+	packet_front->pending_input_bytes = 0;
 }
 
 static inline struct packet_list *

--- a/lib/dataplane/worker/counters.c
+++ b/lib/dataplane/worker/counters.c
@@ -42,5 +42,14 @@ worker_counters_register(struct dp_config *dp_config) {
 	if (register_one(dp_config, "rx_bursts", WORKER_RX_BURST_SIZE + 1)) {
 		return -1;
 	}
+	if (register_one(dp_config, "local_tx_drops", 1)) {
+		return -1;
+	}
+	if (register_one(dp_config, "remote_tx_drops", 1)) {
+		return -1;
+	}
+	if (register_one(dp_config, "drops", 1)) {
+		return -1;
+	}
 	return 0;
 }

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -275,8 +275,8 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	);
 	if (workers_array == NULL) {
 		LOG(ERROR,
-		    "dataplane_ut_new: failed to allocate workers pointer array"
-		);
+		    "dataplane_ut_new: failed to allocate workers pointer "
+		    "array");
 		dataplane_ut_free(ut);
 		return NULL;
 	}
@@ -394,14 +394,18 @@ dataplane_ut_run(
 	struct packet_front packet_front;
 	packet_front_init(&packet_front);
 
-	packet_list_concat(&packet_front.pending_input, input);
+	struct packet *packet;
+	while ((packet = packet_list_pop(input)) != NULL) {
+		packet_front_pending_input(&packet_front, packet);
+	}
 
 	packet_list_init(&result->output);
 	packet_list_init(&result->drop);
 
 	if (config_gen_ectx == NULL) {
 		// No active pipeline: drop everything.
-		packet_list_concat(&result->drop, &packet_front.pending_input);
+		packet_front_drop_pending_input(&packet_front);
+		packet_list_concat(&result->drop, &packet_front.drop);
 		return;
 	}
 

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -131,13 +131,13 @@ forward_handle_packets(
 
 			if (target->mode == FORWARD_MODE_IN) {
 				packet->tx_device_id = device_id;
-				packet_list_add(
-					&packet_front->pending_input, packet
+				packet_front_pending_input(
+					packet_front, packet
 				);
 			} else if (target->mode == FORWARD_MODE_OUT) {
 				packet->tx_device_id = device_id;
-				packet_list_add(
-					&packet_front->pending_output, packet
+				packet_front_pending_output(
+					packet_front, packet
 				);
 			} else {
 				packet_front_output(packet_front, packet);

--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -23,7 +23,8 @@ static void
 mirror_clone(
 	struct dp_worker *worker,
 	struct packet *packet,
-	struct packet_list *pending,
+	struct packet_front *packet_front,
+	void (*add)(struct packet_front *, struct packet *),
 	uint16_t device_id
 ) {
 	struct packet *clone = worker_clone_packet(worker, packet);
@@ -32,7 +33,7 @@ mirror_clone(
 	}
 
 	clone->tx_device_id = device_id;
-	packet_list_add(pending, clone);
+	add(packet_front, clone);
 }
 
 static void
@@ -143,14 +144,16 @@ mirror_handle_packets(
 					mirror_clone(
 						dp_worker,
 						packet,
-						&packet_front->pending_input,
+						packet_front,
+						packet_front_pending_input,
 						device_id
 					);
 				} else if (target->mode == MIRROR_MODE_OUT) {
 					mirror_clone(
 						dp_worker,
 						packet,
-						&packet_front->pending_output,
+						packet_front,
+						packet_front_pending_output,
 						device_id
 					);
 				}

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -166,7 +166,7 @@ route_handle_packets(
 
 		route_set_packet_destination(packet, route);
 		packet->tx_device_id = device_id;
-		packet_list_add(&packet_front->pending_output, packet);
+		packet_front_pending_output(packet_front, packet);
 	}
 }
 


### PR DESCRIPTION
Add three per-worker counters exposed through the counters service: local TX drops for NIC burst rejections, remote TX drops for inter-worker pipe failures, and total drops covering all drop reasons including parse errors and pipeline-discarded packets.

Track count and byte counters for the pending_input and pending_output lists in packet_front, alongside the existing input, output and drop counters. All module dataplanes that enqueue packets to pending lists now use counter-maintaining helpers instead of raw list operations.

Replace per-packet drain loops in the worker with bulk drain routines that transfer list counters in a single step. Rework worker_write to operate on packet_front directly so output counters stay accurate after transmission, enabling the existing drop_output drain to work without recounting.

Bump YANET_MODULE_ABI_VERSION to 4 for the packet_front and dp_worker struct layout changes.