### PR TITLE
feat(counters): separate device input/output into rx/tx/drop counters

### DIFF
--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -204,25 +204,103 @@ cp_device_init(
 		goto err_out;
 	}
 
-	self->counter_packet_rx = counter_registry_register(
-		&self->counter_registry, "rx", 2, err
+	input->counter_packet_rx = counter_registry_register(
+		&self->counter_registry, "input_rx", 2, err
 	);
-	if (self->counter_packet_rx == COUNTER_INVALID) {
+	if (input->counter_packet_rx == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
-			"failed to register 'rx' counter for device '%s'",
+			"failed to register 'input_rx' counter for device '%s'",
 			cfg->name
 		);
 		goto err_out;
 	}
 
-	self->counter_packet_tx = counter_registry_register(
-		&self->counter_registry, "tx", 2, err
+	input->counter_packet_entry = counter_registry_register(
+		&self->counter_registry, "input_entry", 2, err
 	);
-	if (self->counter_packet_tx == COUNTER_INVALID) {
+	if (input->counter_packet_entry == COUNTER_INVALID) {
 		yanet_error_add(
 			err,
-			"failed to register 'tx' counter for device '%s'",
+			"failed to register 'input_entry' counter for device "
+			"'%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	input->counter_packet_tx = counter_registry_register(
+		&self->counter_registry, "input_tx", 2, err
+	);
+	if (input->counter_packet_tx == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'input_tx' counter for device '%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	input->counter_packet_drop = counter_registry_register(
+		&self->counter_registry, "input_drop", 2, err
+	);
+	if (input->counter_packet_drop == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'input_drop' counter for device "
+			"'%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	output->counter_packet_rx = counter_registry_register(
+		&self->counter_registry, "output_rx", 2, err
+	);
+	if (output->counter_packet_rx == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'output_rx' counter for device "
+			"'%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	output->counter_packet_entry = counter_registry_register(
+		&self->counter_registry, "output_entry", 2, err
+	);
+	if (output->counter_packet_entry == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'output_entry' counter for device "
+			"'%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	output->counter_packet_tx = counter_registry_register(
+		&self->counter_registry, "output_tx", 2, err
+	);
+	if (output->counter_packet_tx == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'output_tx' counter for device "
+			"'%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	output->counter_packet_drop = counter_registry_register(
+		&self->counter_registry, "output_drop", 2, err
+	);
+	if (output->counter_packet_drop == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'output_drop' counter for device "
+			"'%s'",
 			cfg->name
 		);
 		goto err_out;

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -19,6 +19,10 @@ struct cp_device_pipeline {
 };
 
 struct cp_device_entry {
+	uint64_t counter_packet_rx;
+	uint64_t counter_packet_entry;
+	uint64_t counter_packet_tx;
+	uint64_t counter_packet_drop;
 	uint64_t pipeline_count;
 	struct cp_device_pipeline pipelines[];
 };
@@ -63,9 +67,6 @@ struct cp_device {
 
 	struct cp_device_entry *input_pipelines;
 	struct cp_device_entry *output_pipelines;
-
-	uint64_t counter_packet_rx;
-	uint64_t counter_packet_tx;
 
 	// Link to the previous parked device.
 	struct cp_device *prev;

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -769,6 +769,33 @@ device_entry_ectx_create(
 	memset(device_entry_ectx, 0, ectx_size);
 	device_entry_ectx->handler = handler;
 
+	struct counter_storage *counter_storage =
+		ADDR_OF(&device_ectx->counter_storage);
+	SET_OFFSET_OF(
+		&device_entry_ectx->counter_packet_rx,
+		counter_get_value_handle(
+			cp_device_entry->counter_packet_rx, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&device_entry_ectx->counter_packet_entry,
+		counter_get_value_handle(
+			cp_device_entry->counter_packet_entry, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&device_entry_ectx->counter_packet_tx,
+		counter_get_value_handle(
+			cp_device_entry->counter_packet_tx, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&device_entry_ectx->counter_packet_drop,
+		counter_get_value_handle(
+			cp_device_entry->counter_packet_drop, counter_storage
+		)
+	);
+
 	struct pipeline_ectx **pipelines =
 		(struct pipeline_ectx **)memory_balloc(
 			memory_context,
@@ -931,18 +958,6 @@ device_ectx_create(
 	}
 
 	SET_OFFSET_OF(&device_ectx->counter_storage, counter_storage);
-	SET_OFFSET_OF(
-		&device_ectx->counter_packet_rx,
-		counter_get_value_handle(
-			cp_device->counter_packet_rx, counter_storage
-		)
-	);
-	SET_OFFSET_OF(
-		&device_ectx->counter_packet_tx,
-		counter_get_value_handle(
-			cp_device->counter_packet_tx, counter_storage
-		)
-	);
 
 	struct dp_device *dp_device =
 		ADDR_OF(&dp_config->dp_devices) + cp_device->dp_device_idx;

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -87,6 +87,10 @@ struct pipeline_ectx {
 
 struct device_entry_ectx {
 	device_handler handler;
+	struct counter_value_handle *counter_packet_rx;
+	struct counter_value_handle *counter_packet_entry;
+	struct counter_value_handle *counter_packet_tx;
+	struct counter_value_handle *counter_packet_drop;
 	uint64_t pipeline_count;
 	struct pipeline_ectx **pipelines;
 	uint64_t pipeline_map_size;
@@ -95,8 +99,6 @@ struct device_entry_ectx {
 
 struct device_ectx {
 	struct cp_device *cp_device;
-	struct counter_value_handle *counter_packet_rx;
-	struct counter_value_handle *counter_packet_tx;
 	struct counter_storage *counter_storage;
 	struct device_entry_ectx *input_pipelines;
 	struct device_entry_ectx *output_pipelines;

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -254,18 +254,6 @@ pipeline_ectx_process(
 	);
 }
 
-// Switch the packet front and run the device entry handler.
-static inline void
-device_entry_ectx_process(
-	struct dp_worker *dp_worker,
-	struct device_ectx *device_ectx,
-	struct device_entry_ectx *entry_ectx,
-	struct packet_front *packet_front
-) {
-	packet_front_switch(packet_front);
-	entry_ectx->handler(dp_worker, device_ectx, packet_front);
-}
-
 // Run the entry's only pipeline.
 //
 // With a single pipeline every packet maps to pipeline 0, so the per-packet
@@ -372,6 +360,43 @@ device_entry_ectx_dispatch(
 	}
 }
 
+static inline void
+device_ectx_process_entry(
+	struct dp_worker *dp_worker,
+	struct device_ectx *device_ectx,
+	struct device_entry_ectx *entry_ectx,
+	struct packet_front *packet_front
+) {
+	packet_front_switch(packet_front);
+
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&entry_ectx->counter_packet_rx),
+		packet_front_input_count(packet_front),
+		packet_front_input_bytes(packet_front)
+	);
+
+	entry_ectx->handler(dp_worker, device_ectx, packet_front);
+
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&entry_ectx->counter_packet_entry),
+		packet_front_output_count(packet_front),
+		packet_front_output_bytes(packet_front)
+	);
+
+	device_entry_ectx_dispatch(dp_worker, entry_ectx, packet_front);
+
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&entry_ectx->counter_packet_tx),
+		packet_front_output_count(packet_front),
+		packet_front_output_bytes(packet_front)
+	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&entry_ectx->counter_packet_drop),
+		packet_front_drop_count(packet_front),
+		packet_front_drop_bytes(packet_front)
+	);
+}
+
 void
 device_ectx_process_input(
 	struct dp_worker *dp_worker,
@@ -381,17 +406,9 @@ device_ectx_process_input(
 	struct device_entry_ectx *entry_ectx =
 		ADDR_OF(&device_ectx->input_pipelines);
 
-	device_entry_ectx_process(
+	device_ectx_process_entry(
 		dp_worker, device_ectx, entry_ectx, packet_front
 	);
-
-	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&device_ectx->counter_packet_rx),
-		packet_front_output_count(packet_front),
-		packet_front_output_bytes(packet_front)
-	);
-
-	device_entry_ectx_dispatch(dp_worker, entry_ectx, packet_front);
 }
 
 void
@@ -403,15 +420,7 @@ device_ectx_process_output(
 	struct device_entry_ectx *entry_ectx =
 		ADDR_OF(&device_ectx->output_pipelines);
 
-	device_entry_ectx_process(
+	device_ectx_process_entry(
 		dp_worker, device_ectx, entry_ectx, packet_front
 	);
-
-	counter_add_packets_bytes(
-		ADDR_OF_NONNULL(&device_ectx->counter_packet_tx),
-		packet_front_output_count(packet_front),
-		packet_front_output_bytes(packet_front)
-	);
-
-	device_entry_ectx_dispatch(dp_worker, entry_ectx, packet_front);
 }

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -607,13 +607,24 @@ func TestRoute_Counters(t *testing.T) {
 		require.Equal(t, uint64(0), byName["output"][1], "output_bytes must equal 0 for device-dispatched packet")
 		require.Equal(t, uint64(0), byName["drop"][1], "drop_bytes must equal 0")
 
-		// Device tx counter is the real pass signal: device_ectx_process_output
-		// increments tx when the packet is handed off to the NIC queue.
+		// size-2 vector: [0] = packets, [1] = bytes.
 		byDevName := dataplaneut.ValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
-		require.Equal(t, uint64(1), byDevName["rx"][0], "device rx must equal 1")
-		require.Equal(t, uint64(1), byDevName["tx"][0], "device tx (pass) must equal 1")
-		require.Equal(t, pktSize, byDevName["rx"][1], "device rx_bytes must equal packet size")
-		require.Equal(t, pktSize, byDevName["tx"][1], "device tx_bytes (pass) must equal packet size")
+		require.Equal(t, uint64(1), byDevName["input_rx"][0], "device input_rx must equal 1")
+		require.Equal(t, uint64(1), byDevName["input_entry"][0], "device input_entry (handler output) must equal 1")
+		require.Equal(t, uint64(0), byDevName["input_tx"][0], "device input_tx (survived input handler) must equal 0")
+		require.Equal(t, uint64(0), byDevName["input_drop"][0], "device input_drop must equal 0")
+		require.Equal(t, uint64(1), byDevName["output_rx"][0], "device output_rx must equal 1")
+		require.Equal(t, uint64(1), byDevName["output_entry"][0], "device output_entry (handler output) must equal 1")
+		require.Equal(t, uint64(1), byDevName["output_tx"][0], "device output_tx (pass) must equal 1")
+		require.Equal(t, uint64(0), byDevName["output_drop"][0], "device output_drop must equal 0")
+		require.Equal(t, pktSize, byDevName["input_rx"][1], "device input_rx bytes must equal packet size")
+		require.Equal(t, pktSize, byDevName["input_entry"][1], "device input_entry bytes must equal packet size")
+		require.Equal(t, uint64(0), byDevName["input_tx"][1], "device input_tx bytes must equal 0")
+		require.Equal(t, uint64(0), byDevName["input_drop"][1], "device input_drop bytes must equal 0")
+		require.Equal(t, pktSize, byDevName["output_rx"][1], "device output_rx bytes must equal packet size")
+		require.Equal(t, pktSize, byDevName["output_entry"][1], "device output_entry bytes must equal packet size")
+		require.Equal(t, pktSize, byDevName["output_tx"][1], "device output_tx bytes (pass) must equal packet size")
+		require.Equal(t, uint64(0), byDevName["output_drop"][1], "device output_drop bytes must equal 0")
 	})
 
 	t.Run("drop", func(t *testing.T) {
@@ -642,13 +653,24 @@ func TestRoute_Counters(t *testing.T) {
 		require.Equal(t, uint64(0), byName["output"][1], "output_bytes must equal 0")
 		require.Equal(t, pktSize, byName["drop"][1], "drop_bytes must equal packet size")
 
-		// Device tx stays zero for a dropped packet: device_ectx_process_output
-		// is never reached, so no tx increment occurs.
+		// size-2 vector: [0] = packets, [1] = bytes.
 		byDevName := dataplaneut.ValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
-		require.Equal(t, uint64(1), byDevName["rx"][0], "device rx must equal 1")
-		require.Equal(t, uint64(0), byDevName["tx"][0], "device tx must equal 0 — packet dropped")
-		require.Equal(t, pktSize, byDevName["rx"][1], "device rx_bytes must equal packet size")
-		require.Equal(t, uint64(0), byDevName["tx"][1], "device tx_bytes must equal 0")
+		require.Equal(t, uint64(1), byDevName["input_rx"][0], "device input_rx must equal 1")
+		require.Equal(t, uint64(1), byDevName["input_entry"][0], "device input_entry (handler output) must equal 1")
+		require.Equal(t, uint64(0), byDevName["input_tx"][0], "device input_tx must equal 0")
+		require.Equal(t, uint64(1), byDevName["input_drop"][0], "device input_drop must equal 1")
+		require.Equal(t, uint64(0), byDevName["output_rx"][0], "device output_rx must equal 0 — packet never reached output handler")
+		require.Equal(t, uint64(0), byDevName["output_entry"][0], "device output_entry must equal 0 — packet never reached output handler")
+		require.Equal(t, uint64(0), byDevName["output_tx"][0], "device output_tx must equal 0 — packet dropped")
+		require.Equal(t, uint64(0), byDevName["output_drop"][0], "device output_drop must equal 0")
+		require.Equal(t, pktSize, byDevName["input_rx"][1], "device input_rx bytes must equal packet size")
+		require.Equal(t, pktSize, byDevName["input_entry"][1], "device input_entry bytes must equal packet size")
+		require.Equal(t, uint64(0), byDevName["input_tx"][1], "device input_tx bytes must equal 0")
+		require.Equal(t, pktSize, byDevName["input_drop"][1], "device input_drop bytes must equal packet size")
+		require.Equal(t, uint64(0), byDevName["output_rx"][1], "device output_rx bytes must equal 0")
+		require.Equal(t, uint64(0), byDevName["output_entry"][1], "device output_entry bytes must equal 0")
+		require.Equal(t, uint64(0), byDevName["output_tx"][1], "device output_tx bytes must equal 0")
+		require.Equal(t, uint64(0), byDevName["output_drop"][1], "device output_drop bytes must equal 0")
 	})
 }
 

--- a/web/builtin/dashboard/IsoScene3D.tsx
+++ b/web/builtin/dashboard/IsoScene3D.tsx
@@ -236,8 +236,8 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
         deviceNames.length > 0 && pipelineNames.length > 0 && functionNames.length > 0,
     );
 
-    const trendRxMap = useDeviceTrendSeries(rateCounters, 'rx');
-    const trendTxMap = useDeviceTrendSeries(rateCounters, 'tx');
+    const trendRxMap = useDeviceTrendSeries(rateCounters, 'inputRx');
+    const trendTxMap = useDeviceTrendSeries(rateCounters, 'outputTx');
 
     const liveRef = useRef<LiveSnapshot>({
         devicesById: new Map(),
@@ -257,12 +257,12 @@ export const IsoScene3D: React.FC<IsoScene3DProps> = ({
         structuralDevices.forEach((d) => {
             const counters = rateCounters.get(d.id);
             const abs = absoluteCounters.get(d.id);
-            const rxPps = counters?.rx?.pps ?? 0;
-            const rxBps = counters?.rx?.bps ?? 0;
-            const txPps = counters?.tx?.pps ?? 0;
-            const txBps = counters?.tx?.bps ?? 0;
+            const rxPps = counters?.inputRx?.pps ?? 0;
+            const rxBps = counters?.inputRx?.bps ?? 0;
+            const txPps = counters?.outputTx?.pps ?? 0;
+            const txBps = counters?.outputTx?.bps ?? 0;
             const status: 'ok' | 'idle' =
-                abs && (abs.rx.packets > 0 || abs.tx.packets > 0) ? 'ok' : 'idle';
+                abs && (abs.inputRx.packets > 0 || abs.outputTx.packets > 0) ? 'ok' : 'idle';
             devicesById.set(d.id, {
                 rxPps,
                 rxBps,

--- a/web/builtin/dashboard/hooks.ts
+++ b/web/builtin/dashboard/hooks.ts
@@ -26,7 +26,7 @@ export const useWorkerCount = (deviceNames: string[]): number | null => {
                         { key: 'device', value: firstDevice },
                         { key: 'pipeline', value: '' },
                     ],
-                    query: ['rx'],
+                    query: ['input_rx'],
                 });
                 const counter = resp.groups?.[0]?.counters?.[0];
                 if (!counter?.instances) {

--- a/web/builtin/devices/DeviceDetails.tsx
+++ b/web/builtin/devices/DeviceDetails.tsx
@@ -3,6 +3,7 @@ import {
     IconHdd,
     IconArrowDown,
     IconArrowUp,
+    IconWarning,
     IconSave,
 } from './components/Icons';
 import { DeviceDiffModal } from './components/DeviceDiffModal';
@@ -28,35 +29,37 @@ export interface DeviceDetailsProps {
 }
 
 interface MetricBlockProps {
-    subLabel: string;
-    isRx: boolean;
-    isPps: boolean;
-    value: number;
+    label: string;
+    labelClass: string;
+    pps: number;
+    bps: number;
     deviceId: string;
     series: string;
     color: string;
     history: number[];
+    icon: React.ReactNode;
 }
 
 const MetricBlock = ({
-    subLabel,
-    isRx,
-    isPps,
-    value,
+    label,
+    labelClass,
+    pps,
+    bps,
     deviceId,
     series,
     color,
     history,
+    icon,
 }: MetricBlockProps): React.JSX.Element => (
     <div className="dv-metric">
         <div className="dv-metric-hd">
             <span className="dv-metric-dir">
-                {isRx ? <IconArrowDown /> : <IconArrowUp />}
-                <span style={{ color }}>{isRx ? 'RX' : 'TX'}</span>
+                {icon}
+                <span className={labelClass} style={{ color }}>{label}</span>
             </span>
-            <span className="dv-metric-lbl">{subLabel}</span>
+            <span className="dv-metric-lbl mono">{formatBps(bps)}</span>
         </div>
-        <div className="dv-metric-val mono">{isPps ? formatPps(value) : formatBps(value)}</div>
+        <div className="dv-metric-val mono">{formatPps(pps)}</div>
         <BigSpark
             deviceId={deviceId}
             series={series}
@@ -86,65 +89,101 @@ interface DeviceMetricsProps {
     history: CounterHistoryEntry | undefined;
 }
 
-// Live RX/TX metric grid for the selected device.
+// Live metric grid for the selected device, organised by direction.
+//
+// The dataplane exposes rx/tx/drop counters per input (from NIC) and output
+// (toward NIC) handler. This renders two sections — Input and Output — each
+// with a throughput (RX), forward (TX) and drop (DROP) card.
 //
 // This is the only part of the detail panel that consumes interpolated
 // counters, which refresh on every animation frame. Keeping it in its own
 // component lets the compiler skip re-rendering the heavier config sections
 // (DeviceBody) when only the counters tick.
 const DeviceMetrics = ({ deviceId, counterData, history }: DeviceMetricsProps): React.JSX.Element => {
-    const rxPps = counterData?.rx.pps ?? 0;
-    const rxBps = counterData?.rx.bps ?? 0;
-    const txPps = counterData?.tx.pps ?? 0;
-    const txBps = counterData?.tx.bps ?? 0;
-
-    const rxPpsHistory = history?.rx ?? [];
-    const txPpsHistory = history?.tx ?? [];
-    const rxBpsHistory = history?.rxBytes ?? [];
-    const txBpsHistory = history?.txBytes ?? [];
-
     return (
-        <div className="dv-metric-grid">
-            <MetricBlock
-                subLabel="packets / sec"
-                isRx={true}
-                isPps={true}
-                value={rxPps}
-                deviceId={deviceId}
-                series="rx-pps"
-                color="var(--teal)"
-                history={rxPpsHistory}
-            />
-            <MetricBlock
-                subLabel="bytes / sec"
-                isRx={true}
-                isPps={false}
-                value={rxBps}
-                deviceId={deviceId}
-                series="rx-bps"
-                color="var(--teal)"
-                history={rxBpsHistory}
-            />
-            <MetricBlock
-                subLabel="packets / sec"
-                isRx={false}
-                isPps={true}
-                value={txPps}
-                deviceId={deviceId}
-                series="tx-pps"
-                color="var(--blue)"
-                history={txPpsHistory}
-            />
-            <MetricBlock
-                subLabel="bytes / sec"
-                isRx={false}
-                isPps={false}
-                value={txBps}
-                deviceId={deviceId}
-                series="tx-bps"
-                color="var(--blue)"
-                history={txBpsHistory}
-            />
+        <div className="dv-metrics">
+            <div className="dv-metric-section">
+                <div className="dv-metric-section-hd">
+                    <span>Input</span>
+                    <span className="dv-metric-section-sub">from NIC → pipeline</span>
+                </div>
+                <div className="dv-metric-grid dv-metric-grid--3">
+                    <MetricBlock
+                        label="RX"
+                        labelClass="dv-lbl-rx"
+                        pps={counterData?.inputRx.pps ?? 0}
+                        bps={counterData?.inputRx.bps ?? 0}
+                        deviceId={deviceId}
+                        series="input-rx"
+                        color="var(--teal)"
+                        history={history?.inputRx ?? []}
+                        icon={<IconArrowDown />}
+                    />
+                    <MetricBlock
+                        label="TX"
+                        labelClass="dv-lbl-tx"
+                        pps={counterData?.inputTx.pps ?? 0}
+                        bps={counterData?.inputTx.bps ?? 0}
+                        deviceId={deviceId}
+                        series="input-tx"
+                        color="var(--teal)"
+                        history={history?.inputTx ?? []}
+                        icon={<IconArrowUp />}
+                    />
+                    <MetricBlock
+                        label="DROP"
+                        labelClass="dv-lbl-drop"
+                        pps={counterData?.inputDrop.pps ?? 0}
+                        bps={counterData?.inputDrop.bps ?? 0}
+                        deviceId={deviceId}
+                        series="input-drop"
+                        color="var(--red)"
+                        history={history?.inputDrop ?? []}
+                        icon={<IconWarning />}
+                    />
+                </div>
+            </div>
+            <div className="dv-metric-section">
+                <div className="dv-metric-section-hd">
+                    <span>Output</span>
+                    <span className="dv-metric-section-sub">from pipeline → NIC</span>
+                </div>
+                <div className="dv-metric-grid dv-metric-grid--3">
+                    <MetricBlock
+                        label="RX"
+                        labelClass="dv-lbl-rx"
+                        pps={counterData?.outputRx.pps ?? 0}
+                        bps={counterData?.outputRx.bps ?? 0}
+                        deviceId={deviceId}
+                        series="output-rx"
+                        color="var(--blue)"
+                        history={history?.outputRx ?? []}
+                        icon={<IconArrowDown />}
+                    />
+                    <MetricBlock
+                        label="TX"
+                        labelClass="dv-lbl-tx"
+                        pps={counterData?.outputTx.pps ?? 0}
+                        bps={counterData?.outputTx.bps ?? 0}
+                        deviceId={deviceId}
+                        series="output-tx"
+                        color="var(--blue)"
+                        history={history?.outputTx ?? []}
+                        icon={<IconArrowUp />}
+                    />
+                    <MetricBlock
+                        label="DROP"
+                        labelClass="dv-lbl-drop"
+                        pps={counterData?.outputDrop.pps ?? 0}
+                        bps={counterData?.outputDrop.bps ?? 0}
+                        deviceId={deviceId}
+                        series="output-drop"
+                        color="var(--red)"
+                        history={history?.outputDrop ?? []}
+                        icon={<IconWarning />}
+                    />
+                </div>
+            </div>
         </div>
     );
 };

--- a/web/builtin/devices/DeviceListItem.tsx
+++ b/web/builtin/devices/DeviceListItem.tsx
@@ -27,10 +27,10 @@ export const DeviceListItem: React.FC<DeviceListItemProps> = ({
     const badge = manifest?.rowBadge?.(device);
     const subtitle = manifest?.rowSubtitle?.(device) ?? '— · —';
     const name = device.id.name || '';
-    const rxPps = counterData?.rx.pps ?? 0;
-    const txPps = counterData?.tx.pps ?? 0;
-    const rxHistory = history?.rx ?? [];
-    const txHistory = history?.tx ?? [];
+    const rxPps = counterData?.inputRx.pps ?? 0;
+    const txPps = counterData?.outputTx.pps ?? 0;
+    const rxHistory = history?.inputRx ?? [];
+    const txHistory = history?.outputTx ?? [];
 
     return (
         <button

--- a/web/builtin/devices/DeviceRail.tsx
+++ b/web/builtin/devices/DeviceRail.tsx
@@ -69,14 +69,14 @@ const DeviceRailItem = ({
                     <div className="dv-rail-pop-type">{typeLabel}</div>
                     <MiniSpark
                         deviceId={`rail-${name}`}
-                        rx={history?.rx ?? []}
-                        tx={history?.tx ?? []}
+                        rx={history?.inputRx ?? []}
+                        tx={history?.outputTx ?? []}
                         width={198}
                         height={34}
                     />
                     <div className="dv-rail-pop-metric">
-                        <span><span className="lbl">RX </span>{formatPps(counterData?.rx.pps ?? 0)}</span>
-                        <span><span className="lbl">TX </span>{formatPps(counterData?.tx.pps ?? 0)}</span>
+                        <span><span className="lbl">RX </span>{formatPps(counterData?.inputRx.pps ?? 0)}</span>
+                        <span><span className="lbl">TX </span>{formatPps(counterData?.outputTx.pps ?? 0)}</span>
                     </div>
                 </div>
             )}

--- a/web/builtin/devices/devices.scss
+++ b/web/builtin/devices/devices.scss
@@ -848,6 +848,40 @@
         }
     }
 
+    // Three-column metric grid (rx/tx/drop per direction).
+    .dv-metric-grid--3 {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .dv-metric-section {
+        margin-bottom: 22px;
+    }
+
+    .dv-metric-section-hd {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        font-size: 10.5px;
+        font-weight: 600;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--fg-3);
+        margin-bottom: 10px;
+
+        .dv-metric-section-sub {
+            text-transform: none;
+            letter-spacing: 0;
+            font-weight: 400;
+            color: var(--fg-4, var(--fg-3));
+            font-size: 10px;
+        }
+    }
+
+    .dv-lbl-drop {
+        color: var(--red);
+        opacity: 0.85;
+    }
+
     .dv-metric {
         background: var(--bg-1);
         border: 1px solid var(--border);

--- a/web/builtin/inspect/DeviceTile.tsx
+++ b/web/builtin/inspect/DeviceTile.tsx
@@ -19,7 +19,7 @@ export const DeviceTile: React.FC<DeviceTileProps> = ({ device, name, rateRow, a
 
     const status = useMemo((): 'ok' | 'idle' => {
         if (!absRow) return 'idle';
-        return absRow.rx.packets > 0 || absRow.tx.packets > 0 ? 'ok' : 'idle';
+        return absRow.inputRx.packets > 0 || absRow.outputTx.packets > 0 ? 'ok' : 'idle';
     }, [absRow]);
 
     const accentColor = kind === 'vlan' ? 'var(--iv-link)' : 'var(--iv-accent)';
@@ -41,8 +41,8 @@ export const DeviceTile: React.FC<DeviceTileProps> = ({ device, name, rateRow, a
                 />
             </div>
             <div className="iv-device-tile__rates">
-                <span className="iv-device-tile__pps">{fmtPps(rateRow?.rx?.pps ?? 0)}</span>
-                <span className="iv-device-tile__bps">{fmtBps(rateRow?.rx?.bps ?? 0)}bps</span>
+                <span className="iv-device-tile__pps">{fmtPps(rateRow?.inputRx?.pps ?? 0)}</span>
+                <span className="iv-device-tile__bps">{fmtBps(rateRow?.inputRx?.bps ?? 0)}bps</span>
             </div>
             <Sparkline
                 data={trend}

--- a/web/builtin/inspect/DeviceWall.tsx
+++ b/web/builtin/inspect/DeviceWall.tsx
@@ -18,7 +18,7 @@ export const DeviceWall: React.FC<DeviceWallProps> = ({
 }) => {
     const devices = instance.devices ?? [];
 
-    const rxTrend = useDeviceTrendSeries(rateCounters, 'rx');
+    const rxTrend = useDeviceTrendSeries(rateCounters, 'inputRx');
 
     const phyCount = useMemo(
         () => devices.filter((d) => d.type === 'plain').length,

--- a/web/builtin/inspect/hooks.ts
+++ b/web/builtin/inspect/hooks.ts
@@ -1,13 +1,16 @@
 import { useMemo } from 'react';
 import { API } from '@yanet/core/api';
 import type { CounterTag } from '@yanet/core/api/counters';
-import type { DeviceCounterData } from '@yanet/core/hooks';
+import type { DeviceCounterData, DeviceCounterField } from '@yanet/core/hooks';
 import { useInterpolatedCounters } from '@yanet/core/hooks/useInterpolatedCounters';
 import { useRollingWindow } from '@yanet/core/hooks/useRollingWindow';
 import { groupCounterPacketsAndBytes, makeGroupedCounterKey } from '@yanet/core/utils';
 
 /**
- * Aggregate RX packet-rate and bit-rate across traffic-source devices.
+ * Aggregate ingress packet-rate and bit-rate across traffic-source devices.
+ *
+ * Uses the inputRx counter (packets entering the input handler from the NIC)
+ * as the device-side ingress throughput measure.
  *
  * Filters by sourceDeviceNames to avoid double-counting traffic that also
  * appears on stacked virtual devices (e.g. vlan).
@@ -21,8 +24,8 @@ export const useAggregateThroughput = (
         let bps = 0;
         rateCounters.forEach((d, name) => {
             if (!sourceDeviceNames.has(name)) return;
-            pps += d.rx?.pps ?? 0;
-            bps += d.rx?.bps ?? 0;
+            pps += d.inputRx?.pps ?? 0;
+            bps += d.inputRx?.bps ?? 0;
         });
         return { aggregatePps: pps, aggregateBps: bps };
     }, [rateCounters, sourceDeviceNames]);
@@ -64,24 +67,24 @@ export const useThroughputSeries = (
     let current = 0;
     deviceCounters.forEach((d, name) => {
         if (!sourceDeviceNames.has(name)) return;
-        current += (d.rx?.pps ?? 0) + (d.tx?.pps ?? 0);
+        current += (d.inputRx?.pps ?? 0) + (d.outputTx?.pps ?? 0);
     });
     const series = useRollingSeries(current, maxLen);
     return { current, series };
 };
 
 /**
- * Per-device rolling pps series for a given direction.
+ * Per-device rolling pps series for a given logical counter field.
  */
 export const useDeviceTrendSeries = (
     deviceCounters: Map<string, DeviceCounterData>,
-    kind: 'rx' | 'tx',
+    kind: DeviceCounterField,
     maxLen: number = DEFAULT_MAX_LEN,
 ): Map<string, number[]> => {
     const samples = useMemo(() => {
         const m = new Map<string, number>();
         deviceCounters.forEach((d, name) => {
-            m.set(name, (kind === 'rx' ? d.rx?.pps : d.tx?.pps) ?? 0);
+            m.set(name, d[kind]?.pps ?? 0);
         });
         return m;
     }, [deviceCounters, kind]);

--- a/web/src/core/hooks/index.ts
+++ b/web/src/core/hooks/index.ts
@@ -17,7 +17,12 @@ export type {
 } from './useInterpolatedCounters';
 
 export { useDeviceCounters } from './useDeviceCounters';
-export type { DeviceCounterData, DeviceAbsoluteData, UseDeviceCountersResult } from './useDeviceCounters';
+export type {
+    DeviceCounterData,
+    DeviceAbsoluteData,
+    DeviceCounterField,
+    UseDeviceCountersResult,
+} from './useDeviceCounters';
 
 export { useContainerHeight } from './useContainerHeight';
 

--- a/web/src/core/hooks/useCounterHistory.ts
+++ b/web/src/core/hooks/useCounterHistory.ts
@@ -5,10 +5,12 @@ import { useRollingWindow } from './useRollingWindow';
 export const HISTORY_SIZE = 60;
 
 export interface CounterHistoryEntry {
-    rx: number[];
-    tx: number[];
-    rxBytes: number[];
-    txBytes: number[];
+    inputRx: number[];
+    inputTx: number[];
+    inputDrop: number[];
+    outputRx: number[];
+    outputTx: number[];
+    outputDrop: number[];
 }
 
 /** Returns a new array with v appended, capped at cap elements. */
@@ -33,46 +35,78 @@ export const appendCapped = (arr: number[], v: number, cap: number): number[] =>
 export const useCounterHistory = (
     counters: Map<string, DeviceCounterData>
 ): Map<string, CounterHistoryEntry> => {
-    const rxSamples = useMemo(() => {
+    // One rolling series per logical field; each samples the pps rate.
+    const inputRxSamples = useMemo(() => {
         const m = new Map<string, number>();
-        counters.forEach((d, name) => m.set(name, d.rx.pps));
+        counters.forEach((d, name) => m.set(name, d.inputRx.pps));
         return m;
     }, [counters]);
 
-    const txSamples = useMemo(() => {
+    const inputTxSamples = useMemo(() => {
         const m = new Map<string, number>();
-        counters.forEach((d, name) => m.set(name, d.tx.pps));
+        counters.forEach((d, name) => m.set(name, d.inputTx.pps));
         return m;
     }, [counters]);
 
-    const rxBytesSamples = useMemo(() => {
+    const inputDropSamples = useMemo(() => {
         const m = new Map<string, number>();
-        counters.forEach((d, name) => m.set(name, d.rx.bps));
+        counters.forEach((d, name) => m.set(name, d.inputDrop.pps));
         return m;
     }, [counters]);
 
-    const txBytesSamples = useMemo(() => {
+    const outputRxSamples = useMemo(() => {
         const m = new Map<string, number>();
-        counters.forEach((d, name) => m.set(name, d.tx.bps));
+        counters.forEach((d, name) => m.set(name, d.outputRx.pps));
         return m;
     }, [counters]);
 
-    const rxHistory = useRollingWindow(rxSamples, HISTORY_SIZE, 1000);
-    const txHistory = useRollingWindow(txSamples, HISTORY_SIZE, 1000);
-    const rxBytesHistory = useRollingWindow(rxBytesSamples, HISTORY_SIZE, 1000);
-    const txBytesHistory = useRollingWindow(txBytesSamples, HISTORY_SIZE, 1000);
+    const outputTxSamples = useMemo(() => {
+        const m = new Map<string, number>();
+        counters.forEach((d, name) => m.set(name, d.outputTx.pps));
+        return m;
+    }, [counters]);
+
+    const outputDropSamples = useMemo(() => {
+        const m = new Map<string, number>();
+        counters.forEach((d, name) => m.set(name, d.outputDrop.pps));
+        return m;
+    }, [counters]);
+
+    const inputRxHistory = useRollingWindow(inputRxSamples, HISTORY_SIZE, 1000);
+    const inputTxHistory = useRollingWindow(inputTxSamples, HISTORY_SIZE, 1000);
+    const inputDropHistory = useRollingWindow(inputDropSamples, HISTORY_SIZE, 1000);
+    const outputRxHistory = useRollingWindow(outputRxSamples, HISTORY_SIZE, 1000);
+    const outputTxHistory = useRollingWindow(outputTxSamples, HISTORY_SIZE, 1000);
+    const outputDropHistory = useRollingWindow(outputDropSamples, HISTORY_SIZE, 1000);
 
     return useMemo(() => {
         const result = new Map<string, CounterHistoryEntry>();
         counters.forEach((_, name) => {
-            const rx = rxHistory.get(name);
-            const tx = txHistory.get(name);
-            const rxBytes = rxBytesHistory.get(name);
-            const txBytes = txBytesHistory.get(name);
-            if (rx && tx && rxBytes && txBytes) {
-                result.set(name, { rx, tx, rxBytes, txBytes });
+            const inputRx = inputRxHistory.get(name);
+            const inputTx = inputTxHistory.get(name);
+            const inputDrop = inputDropHistory.get(name);
+            const outputRx = outputRxHistory.get(name);
+            const outputTx = outputTxHistory.get(name);
+            const outputDrop = outputDropHistory.get(name);
+            if (inputRx && inputTx && inputDrop && outputRx && outputTx && outputDrop) {
+                result.set(name, {
+                    inputRx,
+                    inputTx,
+                    inputDrop,
+                    outputRx,
+                    outputTx,
+                    outputDrop,
+                });
             }
         });
         return result;
-    }, [counters, rxHistory, txHistory, rxBytesHistory, txBytesHistory]);
+    }, [
+        counters,
+        inputRxHistory,
+        inputTxHistory,
+        inputDropHistory,
+        outputRxHistory,
+        outputTxHistory,
+        outputDropHistory,
+    ]);
 };

--- a/web/src/core/hooks/useDeviceCounters.ts
+++ b/web/src/core/hooks/useDeviceCounters.ts
@@ -8,30 +8,73 @@ import {
 } from './useInterpolatedCounters';
 
 /**
- * Device counter data with RX and TX rates.
+ * Logical device counter fields.
+ *
+ * The dataplane exposes 12 device counters organised as rx/tx/drop per
+ * input/output direction. Each direction's counter has a packets and a bytes
+ * variant; this union names the six logical fields surfaced to the UI
+ * (each carries both a rate and an absolute value).
+ */
+export type DeviceCounterField =
+    | 'inputRx'
+    | 'inputTx'
+    | 'inputDrop'
+    | 'outputRx'
+    | 'outputTx'
+    | 'outputDrop';
+
+/**
+ * Maps each logical field to its backend size-2 counter name.
+ *
+ * Each backend counter is a size-2 vector where values[0] = packets and
+ * values[1] = bytes. Backend naming convention: `<direction>_<kind>`, where
+ * direction is `input`|`output` and kind is `rx`|`tx`|`drop`.
+ */
+const DEVICE_COUNTER_FIELDS: ReadonlyArray<{
+    field: DeviceCounterField;
+    name: string;
+}> = [
+    { field: 'inputRx', name: 'input_rx' },
+    { field: 'inputTx', name: 'input_tx' },
+    { field: 'inputDrop', name: 'input_drop' },
+    { field: 'outputRx', name: 'output_rx' },
+    { field: 'outputTx', name: 'output_tx' },
+    { field: 'outputDrop', name: 'output_drop' },
+];
+
+/**
+ * Device counter rate data (pps/bps) per logical field.
  */
 export interface DeviceCounterData {
-    rx: InterpolatedCounterData;
-    tx: InterpolatedCounterData;
+    inputRx: InterpolatedCounterData;
+    inputTx: InterpolatedCounterData;
+    inputDrop: InterpolatedCounterData;
+    outputRx: InterpolatedCounterData;
+    outputTx: InterpolatedCounterData;
+    outputDrop: InterpolatedCounterData;
 }
 
 /**
- * Device counter data with RX and TX absolute values.
+ * Device counter absolute data (cumulative packets/bytes) per logical field.
  */
 export interface DeviceAbsoluteData {
-    rx: InterpolatedAbsoluteData;
-    tx: InterpolatedAbsoluteData;
+    inputRx: InterpolatedAbsoluteData;
+    inputTx: InterpolatedAbsoluteData;
+    inputDrop: InterpolatedAbsoluteData;
+    outputRx: InterpolatedAbsoluteData;
+    outputTx: InterpolatedAbsoluteData;
+    outputDrop: InterpolatedAbsoluteData;
 }
 
 export interface UseDeviceCountersResult {
     /**
-     * Map of deviceName -> { rx, tx } rate data (pps/bps).
+     * Map of deviceName -> per-field rate data (pps/bps).
      * Returns undefined for a device if counters are still loading.
      */
     counters: Map<string, DeviceCounterData>;
 
     /**
-     * Map of deviceName -> { rx, tx } absolute data (packets/bytes).
+     * Map of deviceName -> per-field absolute data (packets/bytes).
      * Returns undefined for a device if counters are still loading.
      */
     absoluteCounters: Map<string, DeviceAbsoluteData>;
@@ -42,13 +85,17 @@ export interface UseDeviceCountersResult {
     isLoading: (deviceName: string) => boolean;
 }
 
+/** Build the interpolation key for a device + logical field. */
+const counterKey = (deviceName: string, field: DeviceCounterField): string =>
+    `${deviceName}:${field}`;
+
 /**
- * Hook for fetching and interpolating device counters (RX/TX rates).
+ * Hook for fetching and interpolating device counters.
  *
  * Uses the generic useInterpolatedCounters hook with device-specific fetch logic.
  * - Polls counters every 1 second from backend
  * - Updates visual every 30ms using linear interpolation
- * - Returns both RX (rx) and TX (tx) rates per device
+ * - Returns per-field rates (pps/bps) for input/output rx/tx/drop per device
  * - Also returns interpolated absolute values for cumulative display
  *
  * @param deviceNames - Array of device names to track counters for
@@ -58,23 +105,26 @@ export const useDeviceCounters = (
     deviceNames: string[],
     enabled: boolean = true
 ): UseDeviceCountersResult => {
-    // Create keys for the interpolation hook: each device has rx and tx keys
+    // Create keys for the interpolation hook: each device has one key per field.
     const keys = useMemo(() => {
         const result: string[] = [];
         for (const name of deviceNames) {
-            result.push(`${name}:rx`, `${name}:tx`);
+            for (const { field } of DEVICE_COUNTER_FIELDS) {
+                result.push(counterKey(name, field));
+            }
         }
         return result;
     }, [deviceNames]);
 
-    // Fetch function that gets cumulative counter values for all devices
+    // Fetch function that gets cumulative counter values for all devices.
     const fetchCounters = useCallback(async (): Promise<Map<string, { packets: bigint; bytes: bigint }>> => {
         const newValues = new Map<string, { packets: bigint; bytes: bigint }>();
 
-        // Initialize with zeros
+        // Initialize with zeros.
         for (const name of deviceNames) {
-            newValues.set(`${name}:rx`, { packets: BigInt(0), bytes: BigInt(0) });
-            newValues.set(`${name}:tx`, { packets: BigInt(0), bytes: BigInt(0) });
+            for (const { field } of DEVICE_COUNTER_FIELDS) {
+                newValues.set(counterKey(name, field), { packets: BigInt(0), bytes: BigInt(0) });
+            }
         }
 
         try {
@@ -83,17 +133,20 @@ export const useDeviceCounters = (
                     { key: 'device', value: '*' },
                     { key: 'pipeline', value: '' },
                 ],
-                query: ['rx', 'tx'],
+                query: DEVICE_COUNTER_FIELDS.map(({ name }) => name),
             });
 
             const grouped = groupCounterPacketsAndBytes(response.groups, ['device']);
 
             for (const deviceName of deviceNames) {
-                const rx = grouped.get(makeGroupedCounterKey([deviceName], 'rx')) ?? { packets: BigInt(0), bytes: BigInt(0) };
-                const tx = grouped.get(makeGroupedCounterKey([deviceName], 'tx')) ?? { packets: BigInt(0), bytes: BigInt(0) };
-
-                newValues.set(`${deviceName}:rx`, rx);
-                newValues.set(`${deviceName}:tx`, tx);
+                for (const { field, name } of DEVICE_COUNTER_FIELDS) {
+                    const value =
+                        grouped.get(makeGroupedCounterKey([deviceName], name)) ?? {
+                            packets: BigInt(0),
+                            bytes: BigInt(0),
+                        };
+                    newValues.set(counterKey(deviceName, field), value);
+                }
             }
         } catch {
             // Ignore global counters fetch errors.
@@ -102,7 +155,7 @@ export const useDeviceCounters = (
         return newValues;
     }, [deviceNames]);
 
-    // Use the generic interpolated counters hook
+    // Use the generic interpolated counters hook.
     const { counters: rawCounters, absoluteCounters: rawAbsoluteCounters } = useInterpolatedCounters({
         keys,
         fetchCounters,
@@ -111,33 +164,47 @@ export const useDeviceCounters = (
         interpolationInterval: 30,
     });
 
-    // Transform raw counters into DeviceCounterData map
+    // Transform raw counters into DeviceCounterData map.
     const counters = useMemo(() => {
         const result = new Map<string, DeviceCounterData>();
 
         for (const deviceName of deviceNames) {
-            const rx = rawCounters.get(`${deviceName}:rx`);
-            const tx = rawCounters.get(`${deviceName}:tx`);
-
-            // Only add if both rx and tx are available (not loading)
-            if (rx && tx) {
-                result.set(deviceName, { rx, tx });
+            const partial: Partial<DeviceCounterData> = {};
+            let complete = true;
+            for (const { field } of DEVICE_COUNTER_FIELDS) {
+                const value = rawCounters.get(counterKey(deviceName, field));
+                if (!value) {
+                    complete = false;
+                    break;
+                }
+                partial[field] = value;
+            }
+            // Only add if every field is available (not loading).
+            if (complete) {
+                result.set(deviceName, partial as DeviceCounterData);
             }
         }
 
         return result;
     }, [deviceNames, rawCounters]);
 
-    // Transform raw absolute counters into DeviceAbsoluteData map
+    // Transform raw absolute counters into DeviceAbsoluteData map.
     const absoluteCounters = useMemo(() => {
         const result = new Map<string, DeviceAbsoluteData>();
 
         for (const deviceName of deviceNames) {
-            const rx = rawAbsoluteCounters.get(`${deviceName}:rx`);
-            const tx = rawAbsoluteCounters.get(`${deviceName}:tx`);
-
-            if (rx && tx) {
-                result.set(deviceName, { rx, tx });
+            const partial: Partial<DeviceAbsoluteData> = {};
+            let complete = true;
+            for (const { field } of DEVICE_COUNTER_FIELDS) {
+                const value = rawAbsoluteCounters.get(counterKey(deviceName, field));
+                if (!value) {
+                    complete = false;
+                    break;
+                }
+                partial[field] = value;
+            }
+            if (complete) {
+                result.set(deviceName, partial as DeviceAbsoluteData);
             }
         }
 


### PR DESCRIPTION
Each device direction now tracks received, forwarded, and dropped packets:
- Input handler: input_rx, input_tx, input_drop
- Output handler: output_rx, output_tx, output_drop

Previously the device level only had rx/tx counters (now input_tx/output_tx). The new rx counters track packets entering each handler, and drop counters track packets dropped by the handler.

The web UI device detail page now shows Input and Output sections, each with RX/TX/DROP metric cards including sparklines.