### PR TITLE
feat(counters): track pending lists across the pipeline hierarchy

### DIFF
--- a/lib/controlplane/config/cp_chain.c
+++ b/lib/controlplane/config/cp_chain.c
@@ -65,6 +65,32 @@ cp_chain_init(
 
 	strtcpy(self->name, cp_chain_config->name, sizeof(self->name));
 
+	self->counter_packet_pending_input = counter_registry_register(
+		&self->counter_registry, "pending_input", 2, err
+	);
+	if (self->counter_packet_pending_input == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'pending_input' counter for chain "
+			"'%s'",
+			cp_chain_config->name
+		);
+		goto err_out;
+	}
+
+	self->counter_packet_pending_output = counter_registry_register(
+		&self->counter_registry, "pending_output", 2, err
+	);
+	if (self->counter_packet_pending_output == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'pending_output' counter for chain "
+			"'%s'",
+			cp_chain_config->name
+		);
+		goto err_out;
+	}
+
 	for (uint64_t idx = 0; idx < cp_chain_config->length; ++idx) {
 		strtcpy(self->modules[idx].type,
 			cp_chain_config->modules[idx].type,

--- a/lib/controlplane/config/cp_chain.h
+++ b/lib/controlplane/config/cp_chain.h
@@ -21,6 +21,9 @@ struct cp_chain {
 
 	struct counter_registry counter_registry;
 
+	uint64_t counter_packet_pending_input;
+	uint64_t counter_packet_pending_output;
+
 	uint64_t length;
 	struct cp_chain_module modules[];
 };

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -254,6 +254,32 @@ cp_device_init(
 		goto err_out;
 	}
 
+	input->counter_packet_pending_input = counter_registry_register(
+		&self->counter_registry, "input_pending_input", 2, err
+	);
+	if (input->counter_packet_pending_input == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'input_pending_input' counter for "
+			"device '%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	input->counter_packet_pending_output = counter_registry_register(
+		&self->counter_registry, "input_pending_output", 2, err
+	);
+	if (input->counter_packet_pending_output == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'input_pending_output' counter for "
+			"device '%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
 	output->counter_packet_rx = counter_registry_register(
 		&self->counter_registry, "output_rx", 2, err
 	);
@@ -301,6 +327,33 @@ cp_device_init(
 			err,
 			"failed to register 'output_drop' counter for device "
 			"'%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	output->counter_packet_pending_input = counter_registry_register(
+		&self->counter_registry, "output_pending_input", 2, err
+	);
+	if (output->counter_packet_pending_input == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'output_pending_input' counter for "
+			"device '%s'",
+			cfg->name
+		);
+		goto err_out;
+	}
+
+	output->counter_packet_pending_output = counter_registry_register(
+		&self->counter_registry, "output_pending_output", 2, err
+	);
+	if (output->counter_packet_pending_output == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'output_pending_output' counter "
+			"for "
+			"device '%s'",
 			cfg->name
 		);
 		goto err_out;

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -23,6 +23,8 @@ struct cp_device_entry {
 	uint64_t counter_packet_entry;
 	uint64_t counter_packet_tx;
 	uint64_t counter_packet_drop;
+	uint64_t counter_packet_pending_input;
+	uint64_t counter_packet_pending_output;
 	uint64_t pipeline_count;
 	struct cp_device_pipeline pipelines[];
 };

--- a/lib/controlplane/config/cp_function.c
+++ b/lib/controlplane/config/cp_function.c
@@ -119,6 +119,32 @@ cp_function_init(
 		goto err_out;
 	}
 
+	self->counter_packet_pending_input = counter_registry_register(
+		&self->counter_registry, "pending_input", 2, err
+	);
+	if (self->counter_packet_pending_input == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'pending_input' counter for "
+			"function '%s'",
+			cp_function_config->name
+		);
+		goto err_out;
+	}
+
+	self->counter_packet_pending_output = counter_registry_register(
+		&self->counter_registry, "pending_output", 2, err
+	);
+	if (self->counter_packet_pending_output == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'pending_output' counter for "
+			"function '%s'",
+			cp_function_config->name
+		);
+		goto err_out;
+	}
+
 	for (uint64_t idx = 0; idx < cp_function_config->chain_count; ++idx) {
 		struct cp_chain *new_chain = cp_chain_new(
 			mctx, cp_function_config->chains[idx].chain->length

--- a/lib/controlplane/config/cp_function.h
+++ b/lib/controlplane/config/cp_function.h
@@ -32,6 +32,9 @@ struct cp_function {
 	uint64_t counter_packet_drop;
 	uint64_t counter_packet_in_hist;
 
+	uint64_t counter_packet_pending_input;
+	uint64_t counter_packet_pending_output;
+
 	char name[CP_PIPELINE_NAME_LEN];
 
 	uint64_t chain_count;

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -112,6 +112,33 @@ cp_module_init(
 		);
 		goto fail;
 	}
+	cp_module->pending_input_counter_id = counter_registry_register(
+		&cp_module->counter_registry, "pending_input", 2, err
+	);
+	if (cp_module->pending_input_counter_id == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'pending_input' counter for module "
+			"'%s:%s'",
+			module_type,
+			module_name
+		);
+		goto fail;
+	}
+	cp_module->pending_output_counter_id = counter_registry_register(
+		&cp_module->counter_registry, "pending_output", 2, err
+	);
+	if (cp_module->pending_output_counter_id == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'pending_output' counter for "
+			"module "
+			"'%s:%s'",
+			module_type,
+			module_name
+		);
+		goto fail;
+	}
 
 	if (cp_module_build_perf_counters(cp_module, err)) {
 		goto fail;

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -112,6 +112,18 @@ cp_module_init(
 		);
 		goto fail;
 	}
+	cp_module->drop_counter_id = counter_registry_register(
+		&cp_module->counter_registry, "drop", 2, err
+	);
+	if (cp_module->drop_counter_id == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'drop' counter for module '%s:%s'",
+			module_type,
+			module_name
+		);
+		goto fail;
+	}
 	cp_module->pending_input_counter_id = counter_registry_register(
 		&cp_module->counter_registry, "pending_input", 2, err
 	);

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -55,6 +55,8 @@ struct cp_module {
 	uint64_t rx_counter_id;
 	// Tx packet/byte counter (size 2: [packets, bytes])
 	uint64_t tx_counter_id;
+	// Drop packet/byte counter (size 2: [packets, bytes])
+	uint64_t drop_counter_id;
 
 	// Pending-input packet/byte counter (size 2: [packets, bytes])
 	uint64_t pending_input_counter_id;

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -56,6 +56,11 @@ struct cp_module {
 	// Tx packet/byte counter (size 2: [packets, bytes])
 	uint64_t tx_counter_id;
 
+	// Pending-input packet/byte counter (size 2: [packets, bytes])
+	uint64_t pending_input_counter_id;
+	// Pending-output packet/byte counter (size 2: [packets, bytes])
+	uint64_t pending_output_counter_id;
+
 	// Runtime indices for the performance histogram counters.
 	// These indices map to the actual counter storage locations for
 	// the performance counters defined in cp_module->perf_counters_indices.

--- a/lib/controlplane/config/cp_pipeline.c
+++ b/lib/controlplane/config/cp_pipeline.c
@@ -121,6 +121,32 @@ cp_pipeline_init(
 		goto err_out;
 	}
 
+	self->counter_packet_pending_input = counter_registry_register(
+		&self->counter_registry, "pending_input", 2, err
+	);
+	if (self->counter_packet_pending_input == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'pending_input' counter for "
+			"pipeline '%s'",
+			cp_pipeline_config->name
+		);
+		goto err_out;
+	}
+
+	self->counter_packet_pending_output = counter_registry_register(
+		&self->counter_registry, "pending_output", 2, err
+	);
+	if (self->counter_packet_pending_output == COUNTER_INVALID) {
+		yanet_error_add(
+			err,
+			"failed to register 'pending_output' counter for "
+			"pipeline '%s'",
+			cp_pipeline_config->name
+		);
+		goto err_out;
+	}
+
 	for (uint64_t idx = 0; idx < cp_pipeline_config->length; ++idx) {
 		strtcpy(self->functions[idx].name,
 			cp_pipeline_config->functions[idx],

--- a/lib/controlplane/config/cp_pipeline.h
+++ b/lib/controlplane/config/cp_pipeline.h
@@ -31,6 +31,9 @@ struct cp_pipeline {
 	uint64_t counter_packet_drop;
 	uint64_t counter_packet_in_hist;
 
+	uint64_t counter_packet_pending_input;
+	uint64_t counter_packet_pending_output;
+
 	char name[CP_PIPELINE_NAME_LEN];
 
 	uint64_t length;

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -124,6 +124,18 @@ module_ectx_create(
 			cp_module->tx_counter_id, counter_storage
 		)
 	);
+	SET_OFFSET_OF(
+		&module_ectx->pending_input_counter,
+		counter_get_value_handle(
+			cp_module->pending_input_counter_id, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&module_ectx->pending_output_counter,
+		counter_get_value_handle(
+			cp_module->pending_output_counter_id, counter_storage
+		)
+	);
 
 	for (size_t counter_idx = 0; counter_idx < MODULE_ECTX_PERF_COUNTERS;
 	     ++counter_idx) {
@@ -280,6 +292,18 @@ chain_ectx_create(
 	}
 
 	SET_OFFSET_OF(&chain_ectx->counter_storage, counter_storage);
+	SET_OFFSET_OF(
+		&chain_ectx->counter_packet_pending_input,
+		counter_get_value_handle(
+			cp_chain->counter_packet_pending_input, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&chain_ectx->counter_packet_pending_output,
+		counter_get_value_handle(
+			cp_chain->counter_packet_pending_output, counter_storage
+		)
+	);
 
 	for (uint64_t idx = 0; idx < cp_chain->length; ++idx) {
 		struct cp_module *cp_module = cp_config_gen_lookup_module(
@@ -500,6 +524,20 @@ function_ectx_create(
 			cp_function->counter_packet_drop, counter_storage
 		)
 	);
+	SET_OFFSET_OF(
+		&function_ectx->counter_packet_pending_input,
+		counter_get_value_handle(
+			cp_function->counter_packet_pending_input,
+			counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&function_ectx->counter_packet_pending_output,
+		counter_get_value_handle(
+			cp_function->counter_packet_pending_output,
+			counter_storage
+		)
+	);
 
 	uint64_t pos = 0;
 	for (uint64_t idx = 0; idx < cp_function->chain_count; ++idx) {
@@ -656,6 +694,20 @@ pipeline_ectx_create(
 			cp_pipeline->counter_packet_drop, counter_storage
 		)
 	);
+	SET_OFFSET_OF(
+		&pipeline_ectx->counter_packet_pending_input,
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_pending_input,
+			counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&pipeline_ectx->counter_packet_pending_output,
+		counter_get_value_handle(
+			cp_pipeline->counter_packet_pending_output,
+			counter_storage
+		)
+	);
 
 	for (uint64_t idx = 0; idx < cp_pipeline->length; ++idx) {
 		struct cp_function *cp_function = cp_config_gen_lookup_function(
@@ -793,6 +845,20 @@ device_entry_ectx_create(
 		&device_entry_ectx->counter_packet_drop,
 		counter_get_value_handle(
 			cp_device_entry->counter_packet_drop, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&device_entry_ectx->counter_packet_pending_input,
+		counter_get_value_handle(
+			cp_device_entry->counter_packet_pending_input,
+			counter_storage
+		)
+	);
+	SET_OFFSET_OF(
+		&device_entry_ectx->counter_packet_pending_output,
+		counter_get_value_handle(
+			cp_device_entry->counter_packet_pending_output,
+			counter_storage
 		)
 	);
 

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -125,6 +125,12 @@ module_ectx_create(
 		)
 	);
 	SET_OFFSET_OF(
+		&module_ectx->drop_counter,
+		counter_get_value_handle(
+			cp_module->drop_counter_id, counter_storage
+		)
+	);
+	SET_OFFSET_OF(
 		&module_ectx->pending_input_counter,
 		counter_get_value_handle(
 			cp_module->pending_input_counter_id, counter_storage

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -36,11 +36,11 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 544,
+	sizeof(struct cp_module) == 552,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 144,
+	sizeof(struct module_ectx) == 152,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -36,11 +36,11 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 528,
+	sizeof(struct cp_module) == 544,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 128,
+	sizeof(struct module_ectx) == 144,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 4
+#define YANET_MODULE_ABI_VERSION 5
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 5
+#define YANET_MODULE_ABI_VERSION 6
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/module/packet_front.h
+++ b/lib/dataplane/module/packet_front.h
@@ -210,3 +210,23 @@ static inline uint64_t
 packet_front_drop_bytes(struct packet_front *packet_front) {
 	return packet_front->drop_bytes;
 }
+
+static inline uint64_t
+packet_front_pending_input_count(struct packet_front *packet_front) {
+	return packet_front->pending_input_count;
+}
+
+static inline uint64_t
+packet_front_pending_input_bytes(struct packet_front *packet_front) {
+	return packet_front->pending_input_bytes;
+}
+
+static inline uint64_t
+packet_front_pending_output_count(struct packet_front *packet_front) {
+	return packet_front->pending_output_count;
+}
+
+static inline uint64_t
+packet_front_pending_output_bytes(struct packet_front *packet_front) {
+	return packet_front->pending_output_bytes;
+}

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -26,6 +26,7 @@ struct module_ectx {
 
 	struct counter_value_handle *rx_counter;
 	struct counter_value_handle *tx_counter;
+	struct counter_value_handle *drop_counter;
 	struct counter_value_handle *pending_input_counter;
 	struct counter_value_handle *pending_output_counter;
 

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -26,6 +26,8 @@ struct module_ectx {
 
 	struct counter_value_handle *rx_counter;
 	struct counter_value_handle *tx_counter;
+	struct counter_value_handle *pending_input_counter;
+	struct counter_value_handle *pending_output_counter;
 
 	struct counter_value_handle *perf_counters[MODULE_ECTX_PERF_COUNTERS];
 
@@ -59,6 +61,8 @@ struct chain_module_ectx {
 struct chain_ectx {
 	struct cp_chain *cp_chain;
 	struct counter_storage *counter_storage;
+	struct counter_value_handle *counter_packet_pending_input;
+	struct counter_value_handle *counter_packet_pending_output;
 	uint64_t length;
 	struct chain_module_ectx modules[];
 };
@@ -68,6 +72,8 @@ struct function_ectx {
 	struct counter_value_handle *counter_packet_in;
 	struct counter_value_handle *counter_packet_out;
 	struct counter_value_handle *counter_packet_drop;
+	struct counter_value_handle *counter_packet_pending_input;
+	struct counter_value_handle *counter_packet_pending_output;
 	struct counter_storage *counter_storage;
 	uint64_t chain_count;
 	struct chain_ectx **chains;
@@ -80,6 +86,8 @@ struct pipeline_ectx {
 	struct counter_value_handle *counter_packet_in;
 	struct counter_value_handle *counter_packet_out;
 	struct counter_value_handle *counter_packet_drop;
+	struct counter_value_handle *counter_packet_pending_input;
+	struct counter_value_handle *counter_packet_pending_output;
 	struct counter_storage *counter_storage;
 	uint64_t length;
 	struct function_ectx *functions[];
@@ -91,6 +99,8 @@ struct device_entry_ectx {
 	struct counter_value_handle *counter_packet_entry;
 	struct counter_value_handle *counter_packet_tx;
 	struct counter_value_handle *counter_packet_drop;
+	struct counter_value_handle *counter_packet_pending_input;
+	struct counter_value_handle *counter_packet_pending_output;
 	uint64_t pipeline_count;
 	struct pipeline_ectx **pipelines;
 	uint64_t pipeline_map_size;

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -32,6 +32,19 @@ module_ectx_process(
 	struct packet_front *packet_front
 
 ) {
+	uint64_t pending_input_count =
+		packet_front_pending_input_count(packet_front);
+	uint64_t pending_input_bytes =
+		packet_front_pending_input_bytes(packet_front);
+
+	uint64_t pending_output_count =
+		packet_front_pending_output_count(packet_front);
+	uint64_t pending_output_bytes =
+		packet_front_pending_output_bytes(packet_front);
+
+	uint64_t drop_count = packet_front_drop_count(packet_front);
+	uint64_t drop_bytes = packet_front_drop_bytes(packet_front);
+
 	const size_t packets_count = packet_front_input_count(packet_front);
 
 	for (struct packet *packet = packet_front->input.first; packet != NULL;
@@ -79,14 +92,23 @@ module_ectx_process(
 		packet_front_output_bytes(packet_front)
 	);
 	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&module_ectx->drop_counter),
+		packet_front_drop_count(packet_front) - drop_count,
+		packet_front_drop_bytes(packet_front) - drop_bytes
+	);
+	counter_add_packets_bytes(
 		ADDR_OF_NONNULL(&module_ectx->pending_input_counter),
-		packet_front_pending_input_count(packet_front),
-		packet_front_pending_input_bytes(packet_front)
+		packet_front_pending_input_count(packet_front) -
+			pending_input_count,
+		packet_front_pending_input_bytes(packet_front) -
+			pending_input_bytes
 	);
 	counter_add_packets_bytes(
 		ADDR_OF_NONNULL(&module_ectx->pending_output_counter),
-		packet_front_pending_output_count(packet_front),
-		packet_front_pending_output_bytes(packet_front)
+		packet_front_pending_output_count(packet_front) -
+			pending_output_count,
+		packet_front_pending_output_bytes(packet_front) -
+			pending_output_bytes
 	);
 }
 
@@ -213,6 +235,19 @@ function_ectx_process(
 	struct function_ectx *function_ectx,
 	struct packet_front *packet_front
 ) {
+	uint64_t drop_count = packet_front_drop_count(packet_front);
+	uint64_t drop_bytes = packet_front_drop_bytes(packet_front);
+
+	uint64_t pending_input_count =
+		packet_front_pending_input_count(packet_front);
+	uint64_t pending_input_bytes =
+		packet_front_pending_input_bytes(packet_front);
+
+	uint64_t pending_output_count =
+		packet_front_pending_output_count(packet_front);
+	uint64_t pending_output_bytes =
+		packet_front_pending_output_bytes(packet_front);
+
 	counter_add_packets_bytes(
 		ADDR_OF_NONNULL(&function_ectx->counter_packet_in),
 		packet_front_output_count(packet_front),
@@ -238,18 +273,22 @@ function_ectx_process(
 	);
 	counter_add_packets_bytes(
 		ADDR_OF_NONNULL(&function_ectx->counter_packet_drop),
-		packet_front_drop_count(packet_front),
-		packet_front_drop_bytes(packet_front)
+		packet_front_drop_count(packet_front) - drop_count,
+		packet_front_drop_bytes(packet_front) - drop_bytes
 	);
 	counter_add_packets_bytes(
 		ADDR_OF_NONNULL(&function_ectx->counter_packet_pending_input),
-		packet_front_pending_input_count(packet_front),
-		packet_front_pending_input_bytes(packet_front)
+		packet_front_pending_input_count(packet_front) -
+			pending_input_count,
+		packet_front_pending_input_bytes(packet_front) -
+			pending_input_bytes
 	);
 	counter_add_packets_bytes(
 		ADDR_OF_NONNULL(&function_ectx->counter_packet_pending_output),
-		packet_front_pending_output_count(packet_front),
-		packet_front_pending_output_bytes(packet_front)
+		packet_front_pending_output_count(packet_front) -
+			pending_output_count,
+		packet_front_pending_output_bytes(packet_front) -
+			pending_output_bytes
 	);
 }
 

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -78,6 +78,16 @@ module_ectx_process(
 		packet_front_output_count(packet_front),
 		packet_front_output_bytes(packet_front)
 	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&module_ectx->pending_input_counter),
+		packet_front_pending_input_count(packet_front),
+		packet_front_pending_input_bytes(packet_front)
+	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&module_ectx->pending_output_counter),
+		packet_front_pending_output_count(packet_front),
+		packet_front_pending_output_bytes(packet_front)
+	);
 }
 
 void
@@ -108,6 +118,17 @@ chain_ectx_process(
 		);
 		tsc_start = tsc_stop;
 	}
+
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&chain_ectx->counter_packet_pending_input),
+		packet_front_pending_input_count(packet_front),
+		packet_front_pending_input_bytes(packet_front)
+	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&chain_ectx->counter_packet_pending_output),
+		packet_front_pending_output_count(packet_front),
+		packet_front_pending_output_bytes(packet_front)
+	);
 }
 
 // Run the function's only chain.
@@ -220,6 +241,16 @@ function_ectx_process(
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
 	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_pending_input),
+		packet_front_pending_input_count(packet_front),
+		packet_front_pending_input_bytes(packet_front)
+	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&function_ectx->counter_packet_pending_output),
+		packet_front_pending_output_count(packet_front),
+		packet_front_pending_output_bytes(packet_front)
+	);
 }
 
 void
@@ -251,6 +282,16 @@ pipeline_ectx_process(
 		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_drop),
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
+	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_pending_input),
+		packet_front_pending_input_count(packet_front),
+		packet_front_pending_input_bytes(packet_front)
+	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&pipeline_ectx->counter_packet_pending_output),
+		packet_front_pending_output_count(packet_front),
+		packet_front_pending_output_bytes(packet_front)
 	);
 }
 
@@ -394,6 +435,16 @@ device_ectx_process_entry(
 		ADDR_OF_NONNULL(&entry_ectx->counter_packet_drop),
 		packet_front_drop_count(packet_front),
 		packet_front_drop_bytes(packet_front)
+	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&entry_ectx->counter_packet_pending_input),
+		packet_front_pending_input_count(packet_front),
+		packet_front_pending_input_bytes(packet_front)
+	);
+	counter_add_packets_bytes(
+		ADDR_OF_NONNULL(&entry_ectx->counter_packet_pending_output),
+		packet_front_pending_output_count(packet_front),
+		packet_front_pending_output_bytes(packet_front)
 	);
 }
 

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -606,6 +606,10 @@ func TestRoute_Counters(t *testing.T) {
 		require.Equal(t, pktSize, byName["input"][1], "input_bytes must equal packet size")
 		require.Equal(t, uint64(0), byName["output"][1], "output_bytes must equal 0 for device-dispatched packet")
 		require.Equal(t, uint64(0), byName["drop"][1], "drop_bytes must equal 0")
+		require.Equal(t, uint64(0), byName["pending_input"][0], "pipeline pending_input must equal 0")
+		require.Equal(t, uint64(1), byName["pending_output"][0], "pipeline pending_output must equal 1 — route defers packet to output path")
+		require.Equal(t, uint64(0), byName["pending_input"][1], "pipeline pending_input bytes must equal 0")
+		require.Equal(t, pktSize, byName["pending_output"][1], "pipeline pending_output bytes must equal packet size")
 
 		// size-2 vector: [0] = packets, [1] = bytes.
 		byDevName := dataplaneut.ValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
@@ -625,6 +629,10 @@ func TestRoute_Counters(t *testing.T) {
 		require.Equal(t, pktSize, byDevName["output_entry"][1], "device output_entry bytes must equal packet size")
 		require.Equal(t, pktSize, byDevName["output_tx"][1], "device output_tx bytes (pass) must equal packet size")
 		require.Equal(t, uint64(0), byDevName["output_drop"][1], "device output_drop bytes must equal 0")
+		require.Equal(t, uint64(0), byDevName["input_pending_input"][0], "device input_pending_input must equal 0")
+		require.Equal(t, uint64(1), byDevName["input_pending_output"][0], "device input_pending_output must equal 1 — route defers packet to output path")
+		require.Equal(t, uint64(0), byDevName["output_pending_input"][0], "device output_pending_input must equal 0")
+		require.Equal(t, uint64(0), byDevName["output_pending_output"][0], "device output_pending_output must equal 0")
 	})
 
 	t.Run("drop", func(t *testing.T) {
@@ -652,6 +660,8 @@ func TestRoute_Counters(t *testing.T) {
 		require.Equal(t, pktSize, byName["input"][1], "input_bytes must equal packet size")
 		require.Equal(t, uint64(0), byName["output"][1], "output_bytes must equal 0")
 		require.Equal(t, pktSize, byName["drop"][1], "drop_bytes must equal packet size")
+		require.Equal(t, uint64(0), byName["pending_input"][0], "pipeline pending_input must equal 0")
+		require.Equal(t, uint64(0), byName["pending_output"][0], "pipeline pending_output must equal 0")
 
 		// size-2 vector: [0] = packets, [1] = bytes.
 		byDevName := dataplaneut.ValueCounters(h.SharedMemory().DPConfig(0).DeviceCounters("port0"))
@@ -671,6 +681,10 @@ func TestRoute_Counters(t *testing.T) {
 		require.Equal(t, uint64(0), byDevName["output_entry"][1], "device output_entry bytes must equal 0")
 		require.Equal(t, uint64(0), byDevName["output_tx"][1], "device output_tx bytes must equal 0")
 		require.Equal(t, uint64(0), byDevName["output_drop"][1], "device output_drop bytes must equal 0")
+		require.Equal(t, uint64(0), byDevName["input_pending_input"][0], "device input_pending_input must equal 0")
+		require.Equal(t, uint64(0), byDevName["input_pending_output"][0], "device input_pending_output must equal 0")
+		require.Equal(t, uint64(0), byDevName["output_pending_input"][0], "device output_pending_input must equal 0")
+		require.Equal(t, uint64(0), byDevName["output_pending_output"][0], "device output_pending_output must equal 0")
 	})
 }
 

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -633,6 +633,17 @@ func TestRoute_Counters(t *testing.T) {
 		require.Equal(t, uint64(1), byDevName["input_pending_output"][0], "device input_pending_output must equal 1 — route defers packet to output path")
 		require.Equal(t, uint64(0), byDevName["output_pending_input"][0], "device output_pending_input must equal 0")
 		require.Equal(t, uint64(0), byDevName["output_pending_output"][0], "device output_pending_output must equal 0")
+
+		// The route module forwards a matched packet, so its own drop
+		// counter stays zero (the module-level drop uses a per-module
+		// delta, so it reflects only what this module dropped).
+		routeModulePath := dataplaneut.CounterPath{
+			Device: "port0", Pipeline: "test", Function: "test",
+			Chain: "test_chain", ModuleType: "route", ModuleName: "test",
+		}
+		dataplaneut.RequireModuleCounter(t, h, routeModulePath, "rx", 1, pktSize)
+		dataplaneut.RequireModuleCounter(t, h, routeModulePath, "tx", 0, 0)
+		dataplaneut.RequireModuleCounter(t, h, routeModulePath, "drop", 0, 0)
 	})
 
 	t.Run("drop", func(t *testing.T) {
@@ -685,6 +696,16 @@ func TestRoute_Counters(t *testing.T) {
 		require.Equal(t, uint64(0), byDevName["input_pending_output"][0], "device input_pending_output must equal 0")
 		require.Equal(t, uint64(0), byDevName["output_pending_input"][0], "device output_pending_input must equal 0")
 		require.Equal(t, uint64(0), byDevName["output_pending_output"][0], "device output_pending_output must equal 0")
+
+		// The route module drops an unmatched packet itself, so its own
+		// drop counter records it (rx in, drop out; tx stays zero).
+		routeModulePath := dataplaneut.CounterPath{
+			Device: "port0", Pipeline: "test", Function: "test",
+			Chain: "test_chain", ModuleType: "route", ModuleName: "test",
+		}
+		dataplaneut.RequireModuleCounter(t, h, routeModulePath, "rx", 1, pktSize)
+		dataplaneut.RequireModuleCounter(t, h, routeModulePath, "tx", 0, 0)
+		dataplaneut.RequireModuleCounter(t, h, routeModulePath, "drop", 1, pktSize)
 	})
 }
 


### PR DESCRIPTION
Each pipeline stage now observes its pending input and output lists after processing, complementing the existing received/transmitted/drop counters so the packet books balance at every level: in roughly equals out plus drop plus pending.

Adds pending input/output counters at the device entry, pipeline, function, chain, and module stages. Each stage is an independent observation point, so a deferred packet is visible all the way up the tree, matching how the received and transmitted counters already work across levels.

Bumps the module ABI version for the control-plane module and execution-context struct layout changes.