### PR TITLE
fix(counters): guard port counter collection against an unpublished array

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -102,7 +102,8 @@ struct port_counter_group_list {
 // Collect counters for every DPDK port, grouped per port.
 //
 // The returned list must be released with yanet_port_counter_group_list_free.
-// Returns NULL on allocation failure.
+// Returns NULL on allocation failure or if the per-port counter array
+// offset is not yet published for a nonzero port count.
 struct port_counter_group_list *
 yanet_get_port_counters(struct dp_config *dp_config);
 

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -2237,6 +2237,12 @@ yanet_get_port_counters(struct dp_config *dp_config) {
 	uint64_t port_count = dp_config->port_count;
 	struct dp_port_counters *port_counters =
 		ADDR_OF(&dp_config->port_counters);
+	// The count and the array offset publish as separate stores, so a
+	// reader can observe a nonzero count before the offset lands and
+	// would otherwise index off a null base.
+	if (port_count != 0 && port_counters == NULL) {
+		return NULL;
+	}
 
 	struct port_counter_group_list *groups =
 		(struct port_counter_group_list *)malloc(

--- a/lib/controlplane/agent/agent_test.c
+++ b/lib/controlplane/agent/agent_test.c
@@ -2,6 +2,7 @@
 #include <string.h>
 
 #include "api/agent.h"
+#include "api/counter.h"
 #include "common/memory_address.h"
 #include "common/test_assert.h"
 #include "controlplane/config/zone.h"
@@ -194,6 +195,76 @@ test_attach_initialised_segment_succeeds() {
 	return TEST_SUCCESS;
 }
 
+// Verify that yanet_get_port_counters returns NULL rather than faulting
+// when the port count is published but the port counters array offset is
+// not, reproducing the two-store publish race.
+static int
+test_get_port_counters_unpublished_array_returns_null() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp_config = NULL;
+	struct cp_config *cp_config = NULL;
+	int rc = dp_storage_init(
+		0,
+		0,
+		storage,
+		TEST_DP_MEMORY,
+		TEST_CP_MEMORY,
+		&dp_config,
+		&cp_config
+	);
+	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+
+	dp_config->port_count = 1;
+
+	struct port_counter_group_list *groups =
+		yanet_get_port_counters(dp_config);
+	TEST_ASSERT_NULL(
+		groups,
+		"yanet_get_port_counters must return NULL when the port "
+		"count is set but the counters array offset is not"
+	);
+
+	free(storage);
+	return TEST_SUCCESS;
+}
+
+// Verify that yanet_get_port_counters returns a non-NULL, zero-length list
+// for a zero port count instead of treating an unset array offset as an
+// error.
+static int
+test_get_port_counters_zero_port_count_returns_empty_list() {
+	void *storage = calloc(1, TEST_STORAGE_SIZE);
+	TEST_ASSERT_NOT_NULL(storage, "calloc failed");
+
+	struct dp_config *dp_config = NULL;
+	struct cp_config *cp_config = NULL;
+	int rc = dp_storage_init(
+		0,
+		0,
+		storage,
+		TEST_DP_MEMORY,
+		TEST_CP_MEMORY,
+		&dp_config,
+		&cp_config
+	);
+	TEST_ASSERT(rc == 0, "dp_storage_init failed");
+
+	struct port_counter_group_list *groups =
+		yanet_get_port_counters(dp_config);
+	TEST_ASSERT_NOT_NULL(
+		groups,
+		"yanet_get_port_counters must return a non-NULL list for a "
+		"zero port count"
+	);
+	TEST_ASSERT_EQUAL(groups->port_count, 0, "port count must be zero");
+
+	yanet_port_counter_group_list_free(groups);
+	free(storage);
+	return TEST_SUCCESS;
+}
+
 int
 main() {
 	log_enable_name("error");
@@ -237,6 +308,24 @@ main() {
 	if (test_attach_initialised_segment_succeeds() != TEST_SUCCESS) {
 		++tests_failed;
 		LOG(ERROR, "test_attach_initialised_segment_succeeds failed");
+	}
+
+	++tests_count;
+	if (test_get_port_counters_unpublished_array_returns_null() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_get_port_counters_unpublished_array_returns_null "
+		    "failed");
+	}
+
+	++tests_count;
+	if (test_get_port_counters_zero_port_count_returns_empty_list() !=
+	    TEST_SUCCESS) {
+		++tests_failed;
+		LOG(ERROR,
+		    "test_get_port_counters_zero_port_count_returns_empty_list "
+		    "failed");
 	}
 
 	if (tests_failed != 0) {


### PR DESCRIPTION
- The control plane resolved the per-port counter array from shared memory without checking that the dataplane had published it, so a reader arriving between the two independent publish stores observed a nonzero port count alongside an unresolved array and dereferenced a null base, faulting the control-plane process instead of reporting a failure.
- Collection now reports a failure in that state, which the caller already degrades into a skipped counter sample.
- A zero port count still returns an empty result rather than an error, and both contracts are now pinned by tests that were verified to fail against a removed and against a weakened guard.
- This supersedes the original approach on this branch, which added a control-plane-side check that could never fire: collection is all-or-nothing, so a successfully returned list never contains an unset counter group.
