### PR TITLE
fix(bird-adapter): reject unknown config keys and align the default endpoint

### DIFF
--- a/common/go/xcfg/load.go
+++ b/common/go/xcfg/load.go
@@ -1,7 +1,10 @@
 package xcfg
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"reflect"
 	"strings"
@@ -17,6 +20,36 @@ type validatable interface {
 	Validate() error
 }
 
+// Option configures LoadConfig and Decode.
+type Option func(*options)
+
+type options struct {
+	KnownFields bool
+}
+
+func newOptions() *options {
+	return &options{
+		KnownFields: false,
+	}
+}
+
+// WithKnownFields rejects YAML documents that contain keys not present in
+// the destination type.
+//
+// Without this option an unknown key is silently dropped, which lets typos
+// and renamed fields go unnoticed and leaves the corresponding field at its
+// default value. With this option such a key becomes a decode error, so a
+// stale or misspelled key in a deployed config fails loudly at startup
+// instead of silently keeping a default that may be wrong for the
+// environment. Strictness does not propagate into a field whose type
+// implements a custom UnmarshalYAML that decodes via node.Decode, because
+// yaml.v3 creates a fresh, non-strict decoder for that call.
+func WithKnownFields() Option {
+	return func(o *options) {
+		o.KnownFields = true
+	}
+}
+
 // LoadConfig reads a YAML file from path and returns the parsed Config.
 //
 // Default values are applied before unmarshalling so any absent field retains
@@ -24,7 +57,7 @@ type validatable interface {
 //
 // Validation is driven by Decode, which calls Validate() on every field whose
 // type implements it.
-func LoadConfig[T any](path string) (*T, error) {
+func LoadConfig[T any](path string, options ...Option) (*T, error) {
 	buf, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
@@ -34,7 +67,7 @@ func LoadConfig[T any](path string) (*T, error) {
 	if def, ok := any(cfg).(defaultable); ok {
 		def.Default()
 	}
-	if err := Decode(buf, cfg); err != nil {
+	if err := Decode(buf, cfg, options...); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
 
@@ -43,9 +76,22 @@ func LoadConfig[T any](path string) (*T, error) {
 
 // Decode deserializes YAML data into dst and then recursively validates all
 // fields that implement "validatable".
-func Decode(buf []byte, dst any) error {
-	if err := yaml.Unmarshal(buf, dst); err != nil {
-		return err
+func Decode(buf []byte, dst any, options ...Option) error {
+	opts := newOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	if opts.KnownFields {
+		dec := yaml.NewDecoder(bytes.NewReader(buf))
+		dec.KnownFields(true)
+		if err := dec.Decode(dst); err != nil && !errors.Is(err, io.EOF) {
+			return err
+		}
+	} else {
+		if err := yaml.Unmarshal(buf, dst); err != nil {
+			return err
+		}
 	}
 
 	return validate(reflect.ValueOf(dst), "")

--- a/common/go/xcfg/load_test.go
+++ b/common/go/xcfg/load_test.go
@@ -194,6 +194,87 @@ func Test_Load_SliceElement_SecondElementMissingField(t *testing.T) {
 	require.Equal(t, "items[1].value", pathErr.Path)
 }
 
+func Test_Decode_UnknownField_IgnoredByDefault(t *testing.T) {
+	// By default an unknown key is silently dropped, leaving the rest of the
+	// document to decode normally. This documents the current lenient
+	// behaviour that WithKnownFields is meant to opt out of.
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+	}
+
+	var cfg Config
+	err := Decode([]byte("name: foo\nunknown_key: bar"), &cfg)
+	require.NoError(t, err)
+	require.Equal(t, "foo", cfg.Name.Unwrap())
+}
+
+func Test_Decode_UnknownField_RejectedWithKnownFields(t *testing.T) {
+	// With WithKnownFields, an unknown key must fail loudly instead of being
+	// silently dropped, and the error must name the offending key.
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+	}
+
+	var cfg Config
+	err := Decode([]byte("name: foo\nunknown_key: bar"), &cfg, WithKnownFields())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unknown_key")
+}
+
+func Test_Decode_EmptyDocument_NoErrorInEitherMode(t *testing.T) {
+	// yaml.Decoder.Decode returns io.EOF on an empty document, unlike
+	// yaml.Unmarshal which treats it as a no-op. Both modes must preserve
+	// the lenient behaviour: no error, and defaults left untouched.
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+	}
+
+	testCases := []struct {
+		name    string
+		options []Option
+	}{
+		{
+			name:    "lenient",
+			options: nil,
+		},
+		{
+			name:    "known fields",
+			options: []Option{WithKnownFields()},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cfg := Config{Name: MustNonEmptyString("default-name")}
+			err := Decode([]byte(""), &cfg, testCase.options...)
+			require.NoError(t, err)
+			require.Equal(t, "default-name", cfg.Name.Unwrap())
+		})
+	}
+}
+
+func Test_Decode_KnownFields_StillValidates(t *testing.T) {
+	// Default()/Validate() behaviour must hold unchanged under
+	// WithKnownFields: valid input decodes cleanly, invalid input is still
+	// rejected by the field's Validate().
+	type Config struct {
+		Name NonEmptyString `yaml:"name"`
+		Path NonEmptyString `yaml:"path"`
+	}
+
+	var validConfig Config
+	require.NoError(t, Decode([]byte("name: foo\npath: /tmp"), &validConfig, WithKnownFields()))
+	require.Equal(t, "foo", validConfig.Name.Unwrap())
+	require.Equal(t, "/tmp", validConfig.Path.Unwrap())
+
+	var invalidConfig Config
+	err := Decode([]byte("name: foo"), &invalidConfig, WithKnownFields())
+
+	var pathErr *PathError
+	require.ErrorAs(t, err, &pathErr)
+	require.Equal(t, "path", pathErr.Path)
+}
+
 func Test_Load_LineErrorUnwrapsFromPathError(t *testing.T) {
 	// Verify that LineError from UnmarshalYAML is accessible via
 	// errors.As through the error chain, even when Decode doesn't

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/README.md
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/README.md
@@ -45,7 +45,7 @@ yanet-bird-adapter server -c config.yaml
 logging:
   level: info
 listen_addr: "localhost:50051"
-route_operator_endpoint: "localhost:8080"
+route_operator_endpoint: "[::1]:8080"
 ```
 
 ### Configure Import

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/client.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/client.go
@@ -92,7 +92,7 @@ func runClient() error {
 	}
 
 	// Load server config to get the adapter address
-	serverCfg, err := xcfg.LoadConfig[ServerConfig](clientCmdArgs.ServerConfigPath)
+	serverCfg, err := xcfg.LoadConfig[ServerConfig](clientCmdArgs.ServerConfigPath, xcfg.WithKnownFields())
 	if err != nil {
 		return fmt.Errorf("failed to load server config: %w", err)
 	}
@@ -164,7 +164,7 @@ func init() {
 
 func runListSessions() error {
 	// Load server config to get the adapter address
-	serverCfg, err := xcfg.LoadConfig[ServerConfig](listSessionsCmdArgs.ServerConfigPath)
+	serverCfg, err := xcfg.LoadConfig[ServerConfig](listSessionsCmdArgs.ServerConfigPath, xcfg.WithKnownFields())
 	if err != nil {
 		return fmt.Errorf("failed to load server config: %w", err)
 	}

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
@@ -68,12 +68,12 @@ func DefaultServerConfig() *ServerConfig {
 			Level: zapcore.InfoLevel,
 		},
 		ListenAddr:            "localhost:50051",
-		RouteOperatorEndpoint: "localhost:50052",
+		RouteOperatorEndpoint: "[::1]:8080",
 	}
 }
 
 func runServer() error {
-	cfg, err := xcfg.LoadConfig[ServerConfig](serverCmdArgs.ConfigPath)
+	cfg, err := xcfg.LoadConfig[ServerConfig](serverCmdArgs.ConfigPath, xcfg.WithKnownFields())
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/server_test.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/server_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+// Test_ShippedDefaultConfig_MatchesServerConfig guards against drift between
+// the shipped default config file and the ServerConfig struct.
+//
+// With strict parsing enabled a stale or renamed key in the shipped YAML
+// would break every fresh install, so this test loads the conffile through
+// xcfg.WithKnownFields() and requires it to decode to exactly
+// DefaultServerConfig(). That also catches the Go defaults silently
+// drifting away from the shipped conffile.
+func Test_ShippedDefaultConfig_MatchesServerConfig(t *testing.T) {
+	cfg, err := xcfg.LoadConfig[ServerConfig]("../../etc/yanet/bird-adapter-default.yaml", xcfg.WithKnownFields())
+	require.NoError(t, err)
+	require.Equal(t, DefaultServerConfig(), cfg)
+}

--- a/operators/bird-adapter/etc/yanet/bird-adapter-default.yaml
+++ b/operators/bird-adapter/etc/yanet/bird-adapter-default.yaml
@@ -10,4 +10,4 @@ listen_addr: "localhost:50051"
 
 # gRPC endpoint serving the route operator's RouteService for RIB updates.
 # Connect directly to the route operator or to the gateway that proxies it.
-route_operator_endpoint: "localhost:8080"
+route_operator_endpoint: "[::1]:8080"


### PR DESCRIPTION
A renamed configuration key (`gateway_endpoint` → `route_operator_endpoint`) was silently dropped on load, because config parsing ignored unknown YAML keys. The endpoint therefore kept its built-in default, which disagreed with the shipped configuration file and happened to match the adapter's own listen address on a deployed host. The adapter opened its RIB stream to itself, and BIRD route updates never reached the route operator — with no error at startup.

- Add opt-in strict YAML decoding to the shared config loader, so an unknown or renamed key becomes a startup error instead of a silent fallback to a default.
- Enable strict decoding for the BIRD adapter only, leaving every other component on the existing lenient behaviour so that hosts carrying older configuration files keep starting.
- Align the built-in defaults with the shipped configuration file and point both at the gateway address the other operators already use. The previous default targeted a port nothing listens on.
- Pin the shipped configuration file to the built-in defaults with a test, so the two can no longer drift apart unnoticed.