### PR TITLE
feat(route-operator): collect installed FIB metrics from the route module

### DIFF
--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -19,13 +19,14 @@ import (
 // GatewayActuator applies route-operator state to a single Gateway via
 // the route module's UpdateFIB unary RPC.
 type GatewayActuator struct {
-	name        string
-	conn        *grpc.ClientConn
-	routes      routepb.RouteServiceClient
-	funcApplier *operator.FunctionApplier
-	devices     []string
-	onFIBBuilt  func(module string, stats FIBBuildStats)
-	log         *zap.Logger
+	name          string
+	conn          *grpc.ClientConn
+	routes        routepb.RouteServiceClient
+	moduleMetrics routepb.MetricsServiceClient
+	funcApplier   *operator.FunctionApplier
+	devices       []string
+	onFIBBuilt    func(module string, stats FIBBuildStats)
+	log           *zap.Logger
 }
 
 // NewGatewayActuator dials the Gateway endpoint and returns a
@@ -64,9 +65,10 @@ func NewGatewayActuator(
 	}
 
 	return &GatewayActuator{
-		name:   cfg.Name,
-		conn:   conn,
-		routes: routepb.NewRouteServiceClient(conn),
+		name:          cfg.Name,
+		conn:          conn,
+		routes:        routepb.NewRouteServiceClient(conn),
+		moduleMetrics: routepb.NewMetricsServiceClient(conn),
 		funcApplier: operator.NewFunctionApplier(
 			ynpb.NewFunctionServiceClient(conn),
 			spec,
@@ -84,6 +86,17 @@ func NewGatewayActuator(
 // Close releases the underlying gRPC connection.
 func (m *GatewayActuator) Close() error {
 	return m.conn.Close()
+}
+
+// ModuleMetrics fetches the route module's metrics snapshot through the
+// gateway connection.
+func (m *GatewayActuator) ModuleMetrics(ctx context.Context) ([]*commonpb.Metric, error) {
+	resp, err := m.moduleMetrics.GetMetrics(ctx, &commonpb.GetMetricsRequest{})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.GetMetrics(), nil
 }
 
 // Apply builds and pushes the FIB for each module config to the gateway,

--- a/operators/route/internal/operator/metrics.go
+++ b/operators/route/internal/operator/metrics.go
@@ -1,14 +1,22 @@
 package operator
 
 import (
+	"context"
 	"sync"
 	"time"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 )
+
+// moduleMetricsTimeout bounds the route-module metrics scrape performed
+// during Collect.
+const moduleMetricsTimeout = 5 * time.Second
 
 // applyDurationBounds are the histogram bucket upper bounds, in seconds,
 // used for per-gateway apply latency.
@@ -48,6 +56,8 @@ type Metrics struct {
 
 	gatewaysMu sync.Mutex
 	gateways   map[string]*GatewayMetrics
+
+	log *zap.Logger
 }
 
 // NewMetrics constructs the Metrics sink from the operator-owned
@@ -71,6 +81,7 @@ func NewMetrics(ribs *RIBStore, neighTable *neigh.NeighTable, options ...Metrics
 		ribSessionStarts:      metrics.NewMetricMap[*metrics.Counter](),
 		ribSessionEnds:        metrics.NewMetricMap[*metrics.Counter](),
 		gateways:              map[string]*GatewayMetrics{},
+		log:                   opts.Log,
 	}
 }
 
@@ -85,14 +96,25 @@ type MetricsFactory func(ribs *RIBStore, neighTable *neigh.NeighTable, options .
 // metricsOptions holds the configurable toggles for NewMetrics.
 type metricsOptions struct {
 	NetlinkMonitorEnabled bool
+	Log                   *zap.Logger
 }
 
 func newMetricsOptions() *metricsOptions {
-	return &metricsOptions{}
+	return &metricsOptions{
+		Log: zap.NewNop(),
+	}
 }
 
 // MetricsOption configures NewMetrics.
 type MetricsOption func(*metricsOptions)
+
+// WithMetricsLog sets the logger used to report best-effort collection
+// failures, such as an unreachable route module during a metrics scrape.
+func WithMetricsLog(log *zap.Logger) MetricsOption {
+	return func(o *metricsOptions) {
+		o.Log = log
+	}
+}
 
 // WithNetlinkMonitorMetrics enables the netlink-monitor health metric
 // family.
@@ -192,7 +214,7 @@ func (m *Metrics) Gateway(name string) *GatewayMetrics {
 		return g
 	}
 
-	g := newGatewayMetrics(name)
+	g := newGatewayMetrics(name, m.log)
 	m.gateways[name] = g
 	return g
 }
@@ -277,8 +299,24 @@ func (m *Metrics) Collect() []*commonpb.Metric {
 	}
 	m.gatewaysMu.Unlock()
 
-	for _, g := range gateways {
+	// Scrape every gateway's route module concurrently under one shared
+	// deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), moduleMetricsTimeout)
+	defer cancel()
+
+	moduleMetrics := make([][]*commonpb.Metric, len(gateways))
+	var group errgroup.Group
+	for idx, g := range gateways {
+		group.Go(func() error {
+			moduleMetrics[idx] = g.collectModuleMetrics(ctx)
+			return nil
+		})
+	}
+	_ = group.Wait()
+
+	for idx, g := range gateways {
 		out = append(out, g.collect()...)
+		out = append(out, moduleMetrics[idx]...)
 	}
 
 	return out
@@ -306,15 +344,29 @@ type GatewayMetrics struct {
 
 	fibMu sync.Mutex
 	fib   map[string]*fibGauges
+
+	moduleMetrics func(ctx context.Context) ([]*commonpb.Metric, error)
+
+	log *zap.Logger
 }
 
 // newGatewayMetrics constructs the metrics sink for a single gateway.
-func newGatewayMetrics(name string) *GatewayMetrics {
+func newGatewayMetrics(name string, log *zap.Logger) *GatewayMetrics {
 	return &GatewayMetrics{
 		name:          name,
 		applyDuration: metrics.NewHistogram(applyDurationBounds),
 		fib:           map[string]*fibGauges{},
+		log:           log,
 	}
+}
+
+// SetModuleMetricsSource wires the route-module metrics scrape reached
+// through this gateway.
+//
+// The source is fetched synchronously during Collect; a nil source (the
+// default) leaves the route-module metrics out of the operator's output.
+func (m *GatewayMetrics) SetModuleMetricsSource(fn func(ctx context.Context) ([]*commonpb.Metric, error)) {
+	m.moduleMetrics = fn
 }
 
 // ObserveApply records the outcome and duration of one Apply call.
@@ -370,6 +422,33 @@ func (m *GatewayMetrics) collect() []*commonpb.Metric {
 	}
 
 	return out
+}
+
+// collectModuleMetrics scrapes the route module reached through this
+// gateway and returns its metrics tagged with the gateway label.
+//
+// The scrape is best-effort: a failure is logged and yields no metrics so
+// the operator's own metrics still render.
+func (m *GatewayMetrics) collectModuleMetrics(ctx context.Context) []*commonpb.Metric {
+	if m.moduleMetrics == nil {
+		return nil
+	}
+
+	moduleMetrics, err := m.moduleMetrics(ctx)
+	if err != nil {
+		m.log.Warn("failed to collect route module metrics",
+			zap.String("gateway", m.name),
+			zap.Error(err),
+		)
+		return nil
+	}
+
+	gateway := makeLabel("gateway", m.name)
+	for _, metric := range moduleMetrics {
+		metric.Labels = append(metric.Labels, gateway)
+	}
+
+	return moduleMetrics
 }
 
 func makeLabel(name, value string) *commonpb.Label {

--- a/operators/route/internal/operator/metrics_test.go
+++ b/operators/route/internal/operator/metrics_test.go
@@ -285,6 +285,52 @@ func TestGatewayMetrics_FIBBuilt(t *testing.T) {
 	require.Equal(t, 5.0, filtered.GetGauge())
 }
 
+// TestGatewayMetrics_ModuleMetrics verifies that the route-module scrape is
+// merged into Collect output tagged with the gateway label, and that a
+// failed scrape is skipped without dropping the operator's own metrics.
+func TestGatewayMetrics_ModuleMetrics(t *testing.T) {
+	t.Run("Merged", func(t *testing.T) {
+		m := NewMetrics(newRIBStore(zap.NewNop()), neigh.NewNeighTable())
+		for _, name := range []string{"gw0", "gw1"} {
+			gateway := m.Gateway(name)
+			gateway.SetModuleMetricsSource(func(ctx context.Context) ([]*commonpb.Metric, error) {
+				return []*commonpb.Metric{
+					makeGauge("route_fib_entries", 42, makeLabel("config", "route0")),
+				}, nil
+			})
+		}
+
+		metricList := m.Collect()
+		for _, name := range []string{"gw0", "gw1"} {
+			entries := findMetric(metricList, "route_fib_entries", map[string]string{
+				"gateway": name,
+				"config":  "route0",
+			})
+			require.NotNil(t, entries)
+			require.Equal(t, 42.0, entries.GetGauge())
+		}
+	})
+
+	t.Run("ScrapeError", func(t *testing.T) {
+		m := NewMetrics(newRIBStore(zap.NewNop()), neigh.NewNeighTable())
+		gateway := m.Gateway("gw0")
+		gateway.SetModuleMetricsSource(func(ctx context.Context) ([]*commonpb.Metric, error) {
+			return nil, errors.New("gateway unreachable")
+		})
+
+		metricList := m.Collect()
+		require.Nil(t, findMetric(metricList, "route_fib_entries", map[string]string{
+			"gateway": "gw0",
+			"config":  "route0",
+		}))
+		require.NotNil(t, findMetric(
+			metricList,
+			"route_operator_gateway_apply_total",
+			map[string]string{"gateway": "gw0"},
+		))
+	})
+}
+
 // TestGatewayMetrics_ObserveApply verifies that ObserveApply updates the
 // apply counters and renders a non-empty duration histogram.
 func TestGatewayMetrics_ObserveApply(t *testing.T) {

--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -80,7 +80,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		return nil, fmt.Errorf("failed to create static neighbour source: %w", err)
 	}
 
-	metricsOptions := []MetricsOption{}
+	metricsOptions := []MetricsOption{WithMetricsLog(log)}
 	if !cfg.NetlinkMonitor.Disabled {
 		metricsOptions = append(metricsOptions, WithNetlinkMonitorMetrics())
 	}
@@ -176,6 +176,10 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 			}
 			return nil, fmt.Errorf("failed to construct gateway actuator %q: %w", gw.Name, err)
 		}
+
+		// Surface the route module's own metrics (installed FIB size, gRPC
+		// stats) through the gateway this actuator already dials.
+		gatewayMetrics.SetModuleMetricsSource(actuator.ModuleMetrics)
 
 		// Wrap each actuator so that apply outcomes drive the per-gateway apply
 		// metrics, then so that they drive the per-gateway fib readiness scope.


### PR DESCRIPTION
- The operator now scrapes the route module's metrics service over the gateway connection each actuator already dials, and merges the module's metrics into its own snapshot tagged with the gateway label.
- This surfaces the FIB actually installed in the dataplane alongside the operator's existing build-side FIB gauges, so a divergence between what was built and what was installed becomes observable.
- The scrape runs during metric collection, is bounded by a timeout, and is best-effort: a failure is logged and skipped without dropping the operator's own metrics.