### PR TITLE
refactor: use correct data size units

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3183,6 +3183,7 @@ dependencies = [
 name = "yanet-cli-counters"
 version = "0.1.0"
 dependencies = [
+ "bytesize",
  "clap",
  "clap_complete",
  "colored",

--- a/cli/modules/counters/Cargo.toml
+++ b/cli/modules/counters/Cargo.toml
@@ -13,6 +13,7 @@ clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
+bytesize = "2.0.1"
 tabled = { version = "0.18", features = ["ansi"] }
 colored = "3"
 serde_yaml = "0.9"

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -2,6 +2,7 @@
 
 use std::str::FromStr;
 
+use bytesize::ByteSize;
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use colored::Colorize;
@@ -449,12 +450,12 @@ impl From<&WorkerCounter> for WorkerRow {
             queue: w.queue_id,
             iterations: format_number(w.iterations),
             rx: if w.rx_bytes > 0 {
-                format!("{} ({})", format_number(w.rx_packets), format_bytes(w.rx_bytes))
+                format!("{} ({})", format_number(w.rx_packets), ByteSize::b(w.rx_bytes))
             } else {
                 format_number(w.rx_packets)
             },
             tx: if w.tx_bytes > 0 {
-                format!("{} ({})", format_number(w.tx_packets), format_bytes(w.tx_bytes))
+                format!("{} ({})", format_number(w.tx_packets), ByteSize::b(w.tx_bytes))
             } else {
                 format_number(w.tx_packets)
             },
@@ -575,12 +576,12 @@ fn format_perf_counters(response: &PerfCountersResponse) {
     let rx_str = format!(
         "RX: {} packets ({})",
         format_number(response.rx),
-        format_bytes(response.rx_bytes)
+        ByteSize::b(response.rx_bytes)
     );
     let tx_str = format!(
         "TX: {} packets ({})",
         format_number(response.tx),
-        format_bytes(response.tx_bytes)
+        ByteSize::b(response.tx_bytes)
     );
 
     // Build the content and pad to exactly 74 chars
@@ -684,7 +685,7 @@ fn format_batch_counter(counter: &PerfCounter, next_min_batch: Option<u32>, widt
         "  Total: {} batches ({} packets, {})",
         format_number(total_batches),
         format_number(total_packets),
-        format_bytes(total_bytes)
+        ByteSize::b(total_bytes)
     );
     let padding1 = TABLE_WIDTH.saturating_sub(display_width(&total_content));
     println!(
@@ -692,7 +693,7 @@ fn format_batch_counter(counter: &PerfCounter, next_min_batch: Option<u32>, widt
         "│".bright_black(),
         format_number(total_batches).bright_white(),
         format_number(total_packets).bright_white(),
-        format_bytes(total_bytes).bright_white(),
+        ByteSize::b(total_bytes).to_string().bright_white(),
         " ".repeat(padding1),
         "│".bright_black()
     );
@@ -1042,28 +1043,6 @@ fn display_width(s: &str) -> usize {
     s.chars().count()
 }
 
-/// Format bytes in appropriate unit (B, KB, MB, GB, TB)
-fn format_bytes(bytes: u64) -> String {
-    const KB: f64 = 1024.0;
-    const MB: f64 = KB * 1024.0;
-    const GB: f64 = MB * 1024.0;
-    const TB: f64 = GB * 1024.0;
-
-    let bytes_f = bytes as f64;
-
-    if bytes_f >= TB {
-        format!("{:.2} TB", bytes_f / TB)
-    } else if bytes_f >= GB {
-        format!("{:.2} GB", bytes_f / GB)
-    } else if bytes_f >= MB {
-        format!("{:.2} MB", bytes_f / MB)
-    } else if bytes_f >= KB {
-        format!("{:.2} KB", bytes_f / KB)
-    } else {
-        format!("{} B", bytes)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -1074,7 +1053,7 @@ mod test {
         let response = PerfCountersResponse {
             tx: 1_234_567,
             rx: 1_234_567,
-            tx_bytes: 1_288_490_188, // ~1.20 GB
+            tx_bytes: 1_288_490_188, // ~1.20 GiB
             rx_bytes: 1_288_490_188,
             counters: vec![
                 // Batch size 1

--- a/tests/fwstate/fwmap_bench_test.c
+++ b/tests/fwstate/fwmap_bench_test.c
@@ -121,7 +121,7 @@ benchmark_performance(void *arena) {
 	printf("    Total elements: %s\n", numfmt(stats.total_elements));
 	printf("    Index size: %u\n", stats.index_size);
 	printf("    Max chain length: %u\n", stats.max_chain_length);
-	printf("    Memory used: %zu KB\n", stats.memory_used / 1024);
+	printf("    Memory used: %zu KiB\n", stats.memory_used / 1024);
 
 	fwmap_free(map, ctx);
 

--- a/web/src/core/components/YamlIOModal.tsx
+++ b/web/src/core/components/YamlIOModal.tsx
@@ -405,7 +405,7 @@ const YamlIOModal: React.FC<YamlIOModalProps> = ({
                             {showModal === 'export' && renderExportFormatToggle()}
                             {isLargeFile ? (
                                 <div className="yn-modal__large-file-notice">
-                                    Large file loaded ({(textContent.current.length / 1_048_576).toFixed(1)} MB) — preview suppressed to avoid browser slowdown.
+                                    Large file loaded ({(textContent.current.length / 1_048_576).toFixed(1)} MiB) — preview suppressed to avoid browser slowdown.
                                 </div>
                             ) : (
                                 <textarea

--- a/web/src/core/utils/bytes.test.ts
+++ b/web/src/core/utils/bytes.test.ts
@@ -89,47 +89,47 @@ describe('formatBytes', () => {
         expect(formatBytes(0n)).toBe('0 B');
     });
 
-    it('formats values below 1 KB', () => {
+    it('formats values below 1 KiB', () => {
         expect(formatBytes(1023n)).toBe('1023 B');
     });
 
-    it('formats exactly 1 KB', () => {
-        expect(formatBytes(1024n)).toBe('1.0 KB');
+    it('formats exactly 1 KiB', () => {
+        expect(formatBytes(1024n)).toBe('1.0 KiB');
     });
 
-    it('formats 1.5 KB', () => {
-        expect(formatBytes(1536n)).toBe('1.5 KB');
+    it('formats 1.5 KiB', () => {
+        expect(formatBytes(1536n)).toBe('1.5 KiB');
     });
 
-    it('formats the last value in the KB range (1 MB - 1 byte)', () => {
-        expect(formatBytes(1024n * 1024n - 1n)).toBe('1.0 MB');
+    it('formats the last value in the KiB range (1 MiB - 1 byte)', () => {
+        expect(formatBytes(1024n * 1024n - 1n)).toBe('1.0 MiB');
     });
 
-    it('formats the last value in the MB range (1 GB - 1 byte)', () => {
-        expect(formatBytes(1024n * 1024n * 1024n - 1n)).toBe('1.00 GB');
+    it('formats the last value in the MiB range (1 GiB - 1 byte)', () => {
+        expect(formatBytes(1024n * 1024n * 1024n - 1n)).toBe('1.00 GiB');
     });
 
-    it('formats the last value in the GB range (1 TB - 1 byte)', () => {
-        expect(formatBytes(1024n ** 4n - 1n)).toBe('1.00 TB');
+    it('formats the last value in the GiB range (1 TiB - 1 byte)', () => {
+        expect(formatBytes(1024n ** 4n - 1n)).toBe('1.00 TiB');
     });
 
-    it('does not overflow past TB (5 exabyte-range value stays in TB)', () => {
-        expect(formatBytes(1024n ** 5n)).toBe('1024.00 TB');
+    it('does not overflow past TiB (5 exabyte-range value stays in TiB)', () => {
+        expect(formatBytes(1024n ** 5n)).toBe('1024.00 TiB');
     });
 
-    it('formats exactly 1 MB', () => {
-        expect(formatBytes(1024n * 1024n)).toBe('1.0 MB');
+    it('formats exactly 1 MiB', () => {
+        expect(formatBytes(1024n * 1024n)).toBe('1.0 MiB');
     });
 
-    it('formats exactly 1 GB', () => {
-        expect(formatBytes(1024n * 1024n * 1024n)).toBe('1.00 GB');
+    it('formats exactly 1 GiB', () => {
+        expect(formatBytes(1024n * 1024n * 1024n)).toBe('1.00 GiB');
     });
 
-    it('formats exactly 1 TB', () => {
-        expect(formatBytes(1024n ** 4n)).toBe('1.00 TB');
+    it('formats exactly 1 TiB', () => {
+        expect(formatBytes(1024n ** 4n)).toBe('1.00 TiB');
     });
 
-    it('formats 5 TB', () => {
-        expect(formatBytes(5n * 1024n ** 4n)).toBe('5.00 TB');
+    it('formats 5 TiB', () => {
+        expect(formatBytes(5n * 1024n ** 4n)).toBe('5.00 TiB');
     });
 });

--- a/web/src/core/utils/bytes.ts
+++ b/web/src/core/utils/bytes.ts
@@ -60,30 +60,30 @@ export const extractBytes = (data: string | Uint8Array | number[] | undefined): 
 };
 
 /**
- * Format a byte count using binary prefixes.
- * Examples: "500 B", "1.2 KB", "3.5 MB", "1.1 GB", "0.50 TB".
+ * Format a byte count using IEC binary prefixes (1024-base).
+ * Examples: "500 B", "1.2 KiB", "3.5 MiB", "1.1 GiB", "0.50 TiB".
  */
 export const formatBytes = (bytes: bigint): string => {
     if (bytes < 1024n) {
         return `${bytes} B`;
     }
     const tiers: { divisor: number; label: string; digits: number }[] = [
-        { divisor: 1024, label: 'KB', digits: 1 },
-        { divisor: 1024 ** 2, label: 'MB', digits: 1 },
-        { divisor: 1024 ** 3, label: 'GB', digits: 2 },
-        { divisor: 1024 ** 4, label: 'TB', digits: 2 },
+        { divisor: 1024, label: 'KiB', digits: 1 },
+        { divisor: 1024 ** 2, label: 'MiB', digits: 1 },
+        { divisor: 1024 ** 3, label: 'GiB', digits: 2 },
+        { divisor: 1024 ** 4, label: 'TiB', digits: 2 },
     ];
     for (let idx = 0; idx < tiers.length; idx++) {
         const tier = tiers[idx];
         const value = Number(bytes) / tier.divisor;
         const formatted = value.toFixed(tier.digits);
-        // Rounding may push the value to the next prefix (e.g. 1023.99 KB → 1024.0 KB);
-        // in that case fall through to the next tier so we report 1.0 MB instead.
+        // Rounding may push the value to the next prefix (e.g. 1023.99 KiB → 1024.0 KiB);
+        // in that case fall through to the next tier so we report 1.0 MiB instead.
         if (parseFloat(formatted) >= 1024 && idx < tiers.length - 1) {
             continue;
         }
         return `${formatted} ${tier.label}`;
     }
     const tb = Number(bytes) / 1024 ** 4;
-    return `${tb.toFixed(2)} TB`;
+    return `${tb.toFixed(2)} TiB`;
 };

--- a/web/src/core/utils/format.test.ts
+++ b/web/src/core/utils/format.test.ts
@@ -25,12 +25,12 @@ describe('formatPps', () => {
 });
 
 describe('formatBps', () => {
-    it('rounds bytes per second below 1 KB', () => {
+    it('rounds bytes per second below 1 KiB', () => {
         expect(formatBps(285.13421819144713)).toBe('285 B/s');
     });
 
-    it('formats rates with binary suffixes above 1 KB', () => {
-        expect(formatBps(1536)).toBe('1.5 KB/s');
-        expect(formatBps(1024 * 1024)).toBe('1.0 MB/s');
+    it('formats rates with binary suffixes above 1 KiB', () => {
+        expect(formatBps(1536)).toBe('1.5 KiB/s');
+        expect(formatBps(1024 * 1024)).toBe('1.0 MiB/s');
     });
 });

--- a/web/src/core/utils/format.ts
+++ b/web/src/core/utils/format.ts
@@ -53,24 +53,24 @@ export const formatSiNumber = (value: number, suffix: string = ''): string => {
 };
 
 /**
- * Format bytes with binary prefixes.
- * Examples: "500 B", "1.2 KB", "3.5 MB", "1.1 GB"
+ * Format bytes with IEC binary prefixes (1024-base).
+ * Examples: "500 B", "1.2 KiB", "3.5 MiB", "1.1 GiB"
  */
 export const formatBytesRate = (bytes: number, suffix: string = '/s'): string => {
     if (bytes < 1024) {
         return `${Math.round(bytes)} B${suffix}`;
     }
     if (bytes < 1024 * 1024) {
-        return `${(bytes / 1024).toFixed(1)} KB${suffix}`;
+        return `${(bytes / 1024).toFixed(1)} KiB${suffix}`;
     }
     if (bytes < 1024 * 1024 * 1024) {
-        return `${(bytes / (1024 * 1024)).toFixed(1)} MB${suffix}`;
+        return `${(bytes / (1024 * 1024)).toFixed(1)} MiB${suffix}`;
     }
-    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB${suffix}`;
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GiB${suffix}`;
 };
 
 /**
  * Format bytes per second value for display.
- * Examples: "500 B/s", "1.2 KB/s", "3.5 MB/s", "1.1 GB/s"
+ * Examples: "500 B/s", "1.2 KiB/s", "3.5 MiB/s", "1.1 GiB/s"
  */
 export const formatBps = (bps: number): string => formatBytesRate(bps);


### PR DESCRIPTION
Use IEC binary prefixes across the project outputs.