### PR TITLE
fix(controlplane): bound the gRPC graceful stop on shutdown

### DIFF
--- a/common/go/operator/server.go
+++ b/common/go/operator/server.go
@@ -7,6 +7,8 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+
+	"github.com/yanet-platform/yanet2/common/go/xgrpc"
 )
 
 type grpcServerOptions struct {
@@ -78,7 +80,11 @@ func (m *GRPCServer) Run(ctx context.Context, listener net.Listener) error {
 		m.log.Info("stopping gRPC server", zap.Stringer("addr", listener.Addr()))
 		defer m.log.Info("stopped gRPC server", zap.Stringer("addr", listener.Addr()))
 
-		m.server.GracefulStop()
+		xgrpc.StopGracefully(m.server, xgrpc.GracefulStopTimeout, func() {
+			m.log.Warn("graceful stop timed out, forcing shutdown",
+				zap.Duration("grace_period", xgrpc.GracefulStopTimeout),
+			)
+		})
 		// Drain Serve's return value.
 		if err := <-serveErr; err != nil {
 			return fmt.Errorf("failed to serve gRPC: %w", err)

--- a/common/go/operator/server_test.go
+++ b/common/go/operator/server_test.go
@@ -1,0 +1,96 @@
+package operator
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// blockingReadinessServer is a fake ReadinessServiceServer whose Watch
+// handler blocks on the stream context instead of returning, reproducing a
+// server-streaming RPC that only ends once the client disconnects.
+type blockingReadinessServer struct {
+	ynpb.UnimplementedReadinessServiceServer
+}
+
+func (m *blockingReadinessServer) Watch(
+	req *readinesspb.ReadyRequest,
+	stream ynpb.ReadinessService_WatchServer,
+) error {
+	if err := stream.Send(&readinesspb.ReadyResponse{}); err != nil {
+		return err
+	}
+
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+// TestGRPCServer_Run_ShutsDownWithOpenStream verifies that GRPCServer.Run
+// returns within a bounded time after its context is canceled, even while a
+// client keeps a server-streaming ReadinessService.Watch call open,
+// reproducing the hang a bare GracefulStop causes for an operator whose
+// readiness stream is proxied through the gateway.
+func TestGRPCServer_Run_ShutsDownWithOpenStream(t *testing.T) {
+	t.Parallel()
+
+	registrar := func(server *grpc.Server) string {
+		ynpb.RegisterReadinessServiceServer(server, &blockingReadinessServer{})
+		return ynpb.ReadinessService_ServiceDesc.ServiceName
+	}
+
+	server, serviceNames := NewGRPCServer(&GRPCServerConfig{}, []ServiceRegistrar{registrar}, WithGRPCLog(zap.NewNop()))
+	require.Equal(t, []string{ynpb.ReadinessService_ServiceDesc.ServiceName}, serviceNames)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var group errgroup.Group
+	group.Go(func() error {
+		return server.Run(ctx, listener)
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := ynpb.NewReadinessServiceClient(conn)
+
+	// The stream is deliberately left open: the client never calls
+	// CloseSend or cancels its context, matching the reproduction where an
+	// open readiness watch wedges GracefulStop forever.
+	var stream ynpb.ReadinessService_WatchClient
+	require.Eventually(t, func() bool {
+		var watchErr error
+		stream, watchErr = client.Watch(t.Context(), &readinesspb.ReadyRequest{})
+		if watchErr != nil {
+			return false
+		}
+
+		_, watchErr = stream.Recv()
+		return watchErr == nil
+	}, 5*time.Second, 50*time.Millisecond, "failed to open readiness watch stream")
+
+	cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- group.Wait() }()
+
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("GRPCServer.Run did not return within the shutdown grace period")
+	}
+}

--- a/common/go/xgrpc/graceful.go
+++ b/common/go/xgrpc/graceful.go
@@ -1,0 +1,61 @@
+// Package xgrpc provides generic gRPC helpers shared across the gateway,
+// operators, and modules.
+package xgrpc
+
+import (
+	"time"
+
+	"google.golang.org/grpc"
+)
+
+// GracefulStopTimeout bounds how long StopGracefully's callers wait for
+// grpc.Server.GracefulStop to drain in-flight RPCs before forcing the
+// shutdown.
+//
+// GracefulStop blocks until every active RPC completes, and a
+// server-streaming call is active for as long as its client keeps it open —
+// an unattended readiness watch, or one merely proxied for an operator,
+// would otherwise wedge shutdown forever and turn a SIGTERM into a hung
+// process. Cutting the grace window short trades a clean drain for a bounded
+// exit: forcing the stop only closes connections, it never aborts a handler
+// goroutine mid-execution, so a config write already in flight still runs to
+// completion and only the client's connection is lost.
+const GracefulStopTimeout = 5 * time.Second
+
+// StopGracefully stops server, giving in-flight RPCs up to timeout to finish
+// before forcing the shutdown with Stop.
+//
+// timeout bounds only the grace window before the stop is forced, not the
+// total time this call takes. Once forced, StopGracefully still waits for
+// every in-flight handler goroutine to return, deliberately: Stop only
+// closes connections and cancels RPC contexts, it cannot abort a handler
+// that is part-way through a shared-memory config write, and returning out
+// from under one would let the process exit while that write is torn. So
+// the effective wait is the longer of timeout and the slowest in-flight
+// handler. The backstop against a handler that never returns is not this
+// function's timeout but the service unit's own stop timeout, which is
+// expected to SIGKILL the process if shutdown overruns it.
+//
+// onForceStop is called exactly when timeout elapses and the stop must be
+// forced, immediately before server.Stop(). It is nil-safe: a caller that
+// does not care about the event may pass nil.
+func StopGracefully(server *grpc.Server, timeout time.Duration, onForceStop func()) {
+	done := make(chan struct{})
+	go func() {
+		server.GracefulStop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		if onForceStop != nil {
+			onForceStop()
+		}
+		server.Stop()
+		// Deliberately unbounded: Stop() cancels RPC contexts but cannot
+		// abort a handler mid-shared-memory-write, and exiting underneath
+		// one would tear that write.
+		<-done
+	}
+}

--- a/common/go/xgrpc/graceful_test.go
+++ b/common/go/xgrpc/graceful_test.go
@@ -1,0 +1,138 @@
+package xgrpc
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+// blockingHealthServer is a fake Health server whose Watch handler blocks on
+// the stream context instead of returning, reproducing a server-streaming
+// RPC that only ends once the client disconnects.
+type blockingHealthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+}
+
+func (m *blockingHealthServer) Watch(
+	req *grpc_health_v1.HealthCheckRequest,
+	stream grpc_health_v1.Health_WatchServer,
+) error {
+	if err := stream.Send(&grpc_health_v1.HealthCheckResponse{}); err != nil {
+		return err
+	}
+
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+// TestStopGracefully_ReturnsWithinTimeout verifies that StopGracefully
+// returns close to the given timeout, and not before it elapses, while a
+// client keeps a server-streaming RPC open — reproducing the hang a bare
+// GracefulStop causes when a handler goroutine never observes cancellation.
+func TestStopGracefully_ReturnsWithinTimeout(t *testing.T) {
+	t.Parallel()
+
+	server := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(server, &blockingHealthServer{})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	var group errgroup.Group
+	group.Go(func() error {
+		return server.Serve(listener)
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := grpc_health_v1.NewHealthClient(conn)
+
+	// The stream is deliberately left open: the client never calls
+	// CloseSend or cancels its context, matching the reproduction where an
+	// open watch stream wedges GracefulStop forever.
+	var stream grpc.ServerStreamingClient[grpc_health_v1.HealthCheckResponse]
+	require.Eventually(t, func() bool {
+		var watchErr error
+		stream, watchErr = client.Watch(t.Context(), &grpc_health_v1.HealthCheckRequest{})
+		if watchErr != nil {
+			return false
+		}
+
+		_, watchErr = stream.Recv()
+		return watchErr == nil
+	}, 5*time.Second, 50*time.Millisecond, "failed to open health watch stream")
+
+	const timeout = 200 * time.Millisecond
+
+	var forceStopCount atomic.Int32
+
+	started := time.Now()
+	stopped := make(chan struct{})
+	go func() {
+		StopGracefully(server, timeout, func() { forceStopCount.Add(1) })
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("StopGracefully did not return within the shutdown grace period")
+	}
+	elapsed := time.Since(started)
+
+	require.GreaterOrEqual(t, elapsed, timeout, "StopGracefully returned before the grace period elapsed")
+	require.Less(t, elapsed, timeout+5*time.Second, "StopGracefully took far longer than the grace period")
+	require.EqualValues(t, 1, forceStopCount.Load(), "onForceStop must fire exactly once on the forced path")
+
+	require.NoError(t, group.Wait())
+}
+
+// TestStopGracefully_NoForceStopWithinTimeout verifies that onForceStop is
+// not called when GracefulStop completes within the grace period.
+func TestStopGracefully_NoForceStopWithinTimeout(t *testing.T) {
+	t.Parallel()
+
+	server := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(server, &grpc_health_v1.UnimplementedHealthServer{})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	var group errgroup.Group
+	group.Go(func() error {
+		return server.Serve(listener)
+	})
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client := grpc_health_v1.NewHealthClient(conn)
+
+	// Wait for the server to actually be serving before stopping it:
+	// calling StopGracefully before Serve's listener loop has started makes
+	// Serve return grpc.ErrServerStopped instead of nil.
+	require.Eventually(t, func() bool {
+		_, checkErr := client.Check(t.Context(), &grpc_health_v1.HealthCheckRequest{})
+		return status.Code(checkErr) == codes.Unimplemented
+	}, 5*time.Second, 50*time.Millisecond, "failed to observe the server serving")
+
+	var forceStopCount atomic.Int32
+
+	StopGracefully(server, GracefulStopTimeout, func() { forceStopCount.Add(1) })
+
+	require.EqualValues(t, 0, forceStopCount.Load(), "onForceStop must not fire when the server stops within the grace period")
+
+	require.NoError(t, group.Wait())
+}

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -18,6 +18,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/common/go/readiness"
+	commonxgrpc "github.com/yanet-platform/yanet2/common/go/xgrpc"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/httpproxy"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth"
@@ -470,7 +471,11 @@ func (m *Gateway) Run(ctx context.Context) error {
 	m.log.Info("stopping gRPC gateway", zap.Stringer("addr", listener.Addr()))
 	defer m.log.Info("stopped gRPC gateway", zap.Stringer("addr", listener.Addr()))
 
-	m.server.GracefulStop()
+	commonxgrpc.StopGracefully(m.server, commonxgrpc.GracefulStopTimeout, func() {
+		m.log.Warn("graceful stop timed out, forcing shutdown",
+			zap.Duration("grace_period", commonxgrpc.GracefulStopTimeout),
+		)
+	})
 
 	return wg.Wait()
 }

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -1,10 +1,19 @@
 package gateway
 
 import (
+	"context"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
 // sharedServerService is a test Service whose Endpoint returns "" so it is
@@ -56,4 +65,184 @@ func TestNewGateway_DeclaredKindsWired(t *testing.T) {
 
 	// Module/device services registered with WithService must be in-process.
 	require.Equal(t, BackendKindInProcess, kinds["test.InProcessService"], "WithService must yield in-process kind")
+}
+
+// freeTCPAddr reserves and immediately releases an ephemeral TCP port so a
+// server that binds it later gets a concrete, otherwise-unused endpoint.
+func freeTCPAddr(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := listener.Addr().String()
+	require.NoError(t, listener.Close())
+
+	return addr
+}
+
+// blockingReadinessService is a fake Service whose Watch handler blocks on
+// the stream context instead of returning, reproducing a server-streaming
+// RPC that only ends once the client disconnects.
+type blockingReadinessService struct {
+	ynpb.UnimplementedReadinessServiceServer
+
+	endpoint string
+}
+
+func (m *blockingReadinessService) Name() string     { return "blocking-readiness" }
+func (m *blockingReadinessService) Endpoint() string { return m.endpoint }
+
+func (m *blockingReadinessService) ServicesNames() []string {
+	return []string{ynpb.ReadinessService_ServiceDesc.ServiceName}
+}
+
+func (m *blockingReadinessService) RegisterService(server *grpc.Server) {
+	ynpb.RegisterReadinessServiceServer(server, m)
+}
+
+func (m *blockingReadinessService) Watch(
+	req *readinesspb.ReadyRequest,
+	stream ynpb.ReadinessService_WatchServer,
+) error {
+	if err := stream.Send(&readinesspb.ReadyResponse{}); err != nil {
+		return err
+	}
+
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+// watchUntilOpen retries opening a ReadinessService.Watch stream and
+// receiving its first message until both succeed, returning the live
+// stream.
+//
+// A fresh gRPC server is not immediately reachable after Run starts, since
+// the listener and the client registration both happen asynchronously, so
+// the retry absorbs that startup race instead of requiring a fixed sleep.
+func watchUntilOpen(t *testing.T, client ynpb.ReadinessServiceClient) {
+	t.Helper()
+
+	var stream ynpb.ReadinessService_WatchClient
+	require.Eventually(t, func() bool {
+		var watchErr error
+		stream, watchErr = client.Watch(t.Context(), &readinesspb.ReadyRequest{})
+		if watchErr != nil {
+			return false
+		}
+
+		_, watchErr = stream.Recv()
+		return watchErr == nil
+	}, 5*time.Second, 50*time.Millisecond, "failed to open readiness watch stream")
+}
+
+// TestGateway_Run_ShutsDownWithOpenStream verifies that Gateway.Run returns
+// within a bounded time after its context is canceled, even while a client
+// keeps a server-streaming ReadinessService.Watch call open, reproducing the
+// dpkg-upgrade hang a bare GracefulStop causes on the gateway's own server.
+func TestGateway_Run_ShutsDownWithOpenStream(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.Server.Endpoint = freeTCPAddr(t)
+
+	gw, err := NewGateway(cfg, WithLog(zap.NewNop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var group errgroup.Group
+	group.Go(func() error {
+		return gw.Run(ctx)
+	})
+
+	conn, err := grpc.NewClient(cfg.Server.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	// The stream is deliberately left open: the client never calls
+	// CloseSend or cancels its context, matching the reproduction where an
+	// open readiness watch wedges GracefulStop forever.
+	watchUntilOpen(t, ynpb.NewReadinessServiceClient(conn))
+
+	cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- group.Wait() }()
+
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Gateway.Run did not return within the shutdown grace period")
+	}
+}
+
+// TestServiceRunner_Run_ShutsDownWithOpenStream verifies that
+// ServiceRunner.Run returns within a bounded time after its context is
+// canceled, even while a client keeps a server-streaming RPC open on the
+// runner's own out-of-process gRPC server, reproducing the same hang for an
+// operator's readiness stream proxied through the gateway.
+func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
+	t.Parallel()
+
+	gatewayListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	gatewayServer := grpc.NewServer()
+	ynpb.RegisterGatewayServer(gatewayServer, NewGatewayService(NewBackendRegistry(), zap.NewNop()))
+
+	var gatewayGroup errgroup.Group
+	gatewayGroup.Go(func() error {
+		return gatewayServer.Serve(gatewayListener)
+	})
+	// Stop before waiting: Serve only returns once the server is stopped, and
+	// t.Cleanup runs in LIFO order, so registering both steps in a single
+	// cleanup keeps the ordering correct regardless of what else is
+	// registered around it.
+	t.Cleanup(func() {
+		gatewayServer.Stop()
+		_ = gatewayGroup.Wait()
+	})
+
+	backendAddr := freeTCPAddr(t)
+	runner := NewServiceRunner(
+		&blockingReadinessService{endpoint: backendAddr},
+		gatewayListener.Addr().String(),
+		nil,
+		zap.NewNop(),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var runnerGroup errgroup.Group
+	runnerGroup.Go(func() error {
+		return runner.Run(ctx)
+	})
+
+	select {
+	case <-runner.Ready():
+	case <-time.After(5 * time.Second):
+		t.Fatal("service runner did not become ready")
+	}
+
+	conn, err := grpc.NewClient(backendAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	// As above, the stream is deliberately left open across shutdown.
+	watchUntilOpen(t, ynpb.NewReadinessServiceClient(conn))
+
+	cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- runnerGroup.Wait() }()
+
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("ServiceRunner.Run did not return within the shutdown grace period")
+	}
 }

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
+	commonxgrpc "github.com/yanet-platform/yanet2/common/go/xgrpc"
 	"github.com/yanet-platform/yanet2/controlplane/internal/xgrpc"
 )
 
@@ -109,7 +110,11 @@ func (m *ServiceRunner) Run(ctx context.Context) error {
 	m.log.Info("stopping gRPC API", zap.Stringer("addr", listener.Addr()))
 	defer m.log.Info("stopped gRPC API", zap.Stringer("addr", listener.Addr()))
 
-	m.server.GracefulStop()
+	commonxgrpc.StopGracefully(m.server, commonxgrpc.GracefulStopTimeout, func() {
+		m.log.Warn("graceful stop timed out, forcing shutdown",
+			zap.Duration("grace_period", commonxgrpc.GracefulStopTimeout),
+		)
+	})
 
 	return wg.Wait()
 }

--- a/debian/yanet2-bird-adapter.service
+++ b/debian/yanet2-bird-adapter.service
@@ -10,6 +10,7 @@ User=root
 Group=yanet
 ExecStart=/usr/bin/yanet-bird-adapter server -c /etc/yanet2/bird-adapter.yaml
 TimeoutSec=1200
+TimeoutStopSec=30
 Restart=always
 RestartSec=1
 LimitCORE=infinity

--- a/debian/yanet2-controlplane.service
+++ b/debian/yanet2-controlplane.service
@@ -12,6 +12,7 @@ Group=yanet
 
 ExecStart=/usr/bin/yanet-controlplane -c /etc/yanet2/controlplane.yaml
 TimeoutSec=1200
+TimeoutStopSec=30
 Restart=always
 RestartSec=1
 LimitCORE=infinity

--- a/debian/yanet2-decap-operator.service
+++ b/debian/yanet2-decap-operator.service
@@ -11,6 +11,7 @@ Group=yanet
 
 ExecStart=/usr/bin/yanet-decap-operator -c /etc/yanet2/yanet-decap-operator.yaml
 TimeoutSec=1200
+TimeoutStopSec=30
 Restart=always
 RestartSec=1
 LimitCORE=infinity

--- a/debian/yanet2-forward-operator.service
+++ b/debian/yanet2-forward-operator.service
@@ -11,6 +11,7 @@ Group=yanet
 
 ExecStart=/usr/bin/yanet-forward-operator -c /etc/yanet2/yanet-forward-operator.yaml
 TimeoutSec=1200
+TimeoutStopSec=30
 Restart=always
 RestartSec=1
 LimitCORE=infinity

--- a/debian/yanet2-pipeline-operator.service
+++ b/debian/yanet2-pipeline-operator.service
@@ -11,6 +11,7 @@ Group=yanet
 
 ExecStart=/usr/bin/yanet-pipeline-operator -c /etc/yanet2/yanet-pipeline-operator.yaml
 TimeoutSec=1200
+TimeoutStopSec=30
 Restart=always
 RestartSec=1
 LimitCORE=infinity

--- a/debian/yanet2-route-operator.service
+++ b/debian/yanet2-route-operator.service
@@ -11,6 +11,7 @@ Group=yanet
 
 ExecStart=/usr/bin/yanet-route-operator -c /etc/yanet2/yanet-route-operator.yaml
 TimeoutSec=1200
+TimeoutStopSec=30
 Restart=always
 RestartSec=1
 LimitCORE=infinity

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/logging"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	"github.com/yanet-platform/yanet2/common/go/xcmd"
+	"github.com/yanet-platform/yanet2/common/go/xgrpc"
 	birdAdapter "github.com/yanet-platform/yanet2/operators/bird-adapter"
 	adapterpb "github.com/yanet-platform/yanet2/operators/bird-adapter/adapterpb/v1"
 )
@@ -118,7 +119,13 @@ func runServer() error {
 		err := xcmd.WaitInterrupted(ctx)
 		log.Info("caught signal", zap.Error(err))
 		log.Info("shutting down gRPC server")
-		grpcServer.GracefulStop()
+
+		xgrpc.StopGracefully(grpcServer, xgrpc.GracefulStopTimeout, func() {
+			log.Warn("graceful stop timed out, forcing shutdown",
+				zap.Duration("grace_period", xgrpc.GracefulStopTimeout),
+			)
+		})
+
 		return err
 	})
 


### PR DESCRIPTION
The control plane never exited on SIGTERM while any client held a long-lived stream open: the graceful stop waits for every active call to complete, and an open server stream stays active until its client hangs up. Package upgrades therefore hung at the control plane's restart until systemd's twenty-minute stop timeout expired.

Shutdown now gives in-flight calls a bounded grace period and then forces the server down. Forcing it only closes connections — a handler already writing shared memory still runs to completion, so a configuration update in flight cannot be torn.

The bounded stop lives in a single shared helper used by the gateway, the per-module servers, the operators and the BIRD adapter, replacing the copies that had grown in each of them.

The stop timeout of every non-dataplane unit is lowered as defence in depth, so a future shutdown defect degrades into a quick kill rather than a hung upgrade.