### PR TITLE
refactor(cli): table-free ready output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3566,11 +3566,12 @@ dependencies = [
 name = "yanet-cli-ready"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "clap",
  "clap_complete",
  "colored",
+ "humantime",
  "prost-types",
- "tabled",
  "tokio",
  "yanet-cli",
  "yanet-readinesspb",

--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -40,6 +40,14 @@ pub fn fit_terminal_width(table: &mut Table) {
     }
 }
 
+/// Returns the current terminal width in columns, detected from stdout.
+///
+/// Returns `None` when stdout is not a TTY (piped or redirected), matching
+/// the same detection [`fit_terminal_width`] uses.
+pub fn terminal_width() -> Option<usize> {
+    terminal_size_of(std::io::stdout()).map(|(terminal_size::Width(cols), _)| cols as usize)
+}
+
 /// Apply the standard YANET table style to `table`.
 fn apply_style(table: &mut Table) {
     table.with(

--- a/cli/modules/ready/Cargo.toml
+++ b/cli/modules/ready/Cargo.toml
@@ -18,4 +18,5 @@ clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost-types = "0.13"
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 colored = "3"
-tabled = { version = "0.18", features = ["ansi"] }
+chrono = "0.4"
+humantime = "2"

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -1,25 +1,19 @@
 //! Generic readiness probe CLI.
 
-use core::fmt::{self, Display, Formatter};
+use core::time::Duration;
+use std::collections::BTreeMap;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use colored::Colorize;
-use prost_types::Timestamp;
 use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope, State};
-use tabled::{
-    Table, Tabled,
-    settings::{
-        Color, Style,
-        object::{Columns, Rows},
-        style::{BorderColor, HorizontalLine},
-    },
-};
 use ync::{
     client::ConnectionArgs,
     errors::Error,
     output::{self, CommonFormat},
 };
+
+mod render;
 
 /// Exit code used when the RPC succeeds but not all scopes are `STATE_READY`.
 const EXIT_NOT_READY: i32 = 2;
@@ -50,6 +44,23 @@ pub struct Cmd {
     /// snapshot.
     #[arg(long, default_value_t = false)]
     pub watch: bool,
+    /// Minimum time since a scope was last observed before flagging it
+    /// `stale` in human output.
+    ///
+    /// Readiness sources heartbeat on their own, differing cadences — e.g.
+    /// reconcile actuators every 30s, the bird RIB sampler every 1s, and the
+    /// slowest in-tree one, the route operator's neighbour monitor, every
+    /// 5m. Since the CLI cannot know a given scope's expected interval, the
+    /// default is deliberately generous, roughly 3x the slowest known
+    /// heartbeat. Accepts humantime durations (e.g. `30s`, `5m`). `0`
+    /// disables the tag.
+    #[arg(long, default_value = "15m", value_parser = parse_duration)]
+    pub stale_after: Duration,
+}
+
+/// Parses a CLI duration flag via `humantime`.
+fn parse_duration(value: &str) -> Result<Duration, String> {
+    humantime::parse_duration(value).map_err(|err| err.to_string())
 }
 
 #[tokio::main(flavor = "current_thread")]
@@ -104,43 +115,20 @@ async fn run_once(cmd: Cmd) -> Result<bool, Error> {
 
     let all_ready = all_scopes_ready && missing.is_empty();
 
-    let total = response.scopes.len();
-    let ready_count = response
-        .scopes
-        .iter()
-        .filter(|scope| scope.state == State::Ready as i32)
-        .count();
-
     output::data(
         &response.scopes,
         response.scopes.is_empty() && missing.is_empty(),
         format_args!("no scopes"),
         || {
-            let mut rows: Vec<ReadinessRow> = response.scopes.iter().map(ReadinessRow::from).collect();
-            rows.sort_by(|a, b| a.scope.cmp(&b.scope));
+            let mut scopes = response.scopes.clone();
+            scopes.sort_by(|a, b| a.name.cmp(&b.name));
 
-            if !rows.is_empty() {
-                print_readiness_table(rows);
+            if !scopes.is_empty() {
+                let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
+                render::print_status_block(&cmd.name, &scopes, width, cmd.stale_after, false);
             }
 
-            if !missing.is_empty() {
-                let missing_list = missing.join(", ");
-                let label = "missing (not registered):";
-
-                if output::is_colored() {
-                    println!("{} {}", label.red(), missing_list.red());
-                } else {
-                    println!("{label} {missing_list}");
-                }
-            }
-
-            let missing_count = missing.len();
-
-            if missing_count > 0 {
-                println!("summary: {ready_count}/{total} ready, {missing_count} requested scope missing");
-            } else {
-                println!("summary: {ready_count}/{total} ready");
-            }
+            print_missing(&missing);
         },
     );
 
@@ -149,10 +137,14 @@ async fn run_once(cmd: Cmd) -> Result<bool, Error> {
 
 /// Stream readiness updates via `Watch` until the server closes the connection.
 ///
-/// The first message is a full snapshot of all selected scopes; each
-/// subsequent message carries only the scopes that changed. Returns `Ok(())`
+/// The first message is a full snapshot of all selected scopes and renders
+/// the status block; each subsequent message carries only the scopes that
+/// changed and renders one append-only log line per scope. Returns `Ok(())`
 /// on clean stream close.
 async fn run_watch(cmd: Cmd) -> Result<(), Error> {
+    let mut snapshot: BTreeMap<String, Scope> = BTreeMap::new();
+    let mut name_width: Option<usize> = None;
+
     ync::client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
         &cmd.connection,
         "ready",
@@ -160,12 +152,27 @@ async fn run_watch(cmd: Cmd) -> Result<(), Error> {
         "Watch",
         ReadyRequest { scopes: cmd.scopes.clone() },
         |resp| {
-            let mut rows: Vec<ReadinessRow> = resp.scopes.iter().map(ReadinessRow::from).collect();
-            rows.sort_by(|a, b| a.scope.cmp(&b.scope));
-
             output::data(&resp.scopes, resp.scopes.is_empty(), format_args!("no scopes"), || {
-                if !rows.is_empty() {
-                    print_readiness_table(rows);
+                let mut scopes = resp.scopes.clone();
+                scopes.sort_by(|a, b| a.name.cmp(&b.name));
+
+                match name_width {
+                    None => {
+                        let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
+                        name_width = Some(width);
+
+                        for scope in &scopes {
+                            snapshot.insert(scope.name.clone(), scope.clone());
+                        }
+
+                        render::print_status_block(&cmd.name, &scopes, width, cmd.stale_after, true);
+                    }
+                    Some(width) => {
+                        for scope in &scopes {
+                            let transition = render::record_transition(&mut snapshot, scope);
+                            render::print_transition_line(scope, width, transition);
+                        }
+                    }
                 }
             });
         },
@@ -173,163 +180,19 @@ async fn run_watch(cmd: Cmd) -> Result<(), Error> {
     .await
 }
 
-/// Wraps a readiness state for colored display in the table.
-pub struct StateCell(State);
-
-impl Display for StateCell {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let StateCell(state) = self;
-        let name = state.as_str_name().strip_prefix("STATE_").unwrap_or_default();
-
-        if output::is_colored() {
-            let colored = match state {
-                State::Ready => name.green().to_string(),
-                State::Degraded => name.yellow().to_string(),
-                State::NotReady => name.red().to_string(),
-                State::Unspecified | State::Unknown => name.truecolor(127, 127, 127).to_string(),
-            };
-            write!(f, "{colored}")
-        } else {
-            write!(f, "{name}")
-        }
+/// Prints the red `missing (not registered): …` line for requested scopes
+/// the server did not return at all.
+fn print_missing(missing: &[&str]) {
+    if missing.is_empty() {
+        return;
     }
-}
 
-/// A displayable row for the readiness table.
-#[derive(Debug, Tabled)]
-pub struct ReadinessRow {
-    #[tabled(rename = "Scope")]
-    pub scope: String,
-    #[tabled(rename = "State")]
-    pub state: String,
-    #[tabled(rename = "Last Transition")]
-    pub last_transition: String,
-    #[tabled(rename = "Observed")]
-    pub observed: String,
-    #[tabled(rename = "Reasons")]
-    pub reasons: String,
-}
-
-impl From<&Scope> for ReadinessRow {
-    fn from(scope: &Scope) -> Self {
-        let state = State::try_from(scope.state).unwrap_or_default();
-        let state_cell = StateCell(state);
-
-        let reasons = scope
-            .reasons
-            .iter()
-            .map(|reason| format!("{}: {}", reason.code, reason.message))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        Self {
-            scope: scope.name.clone(),
-            state: state_cell.to_string(),
-            last_transition: format_age(scope.last_transition_time.as_ref()),
-            observed: format_age(scope.observed_at.as_ref()),
-            reasons,
-        }
-    }
-}
-
-fn print_readiness_table(rows: Vec<ReadinessRow>) {
-    let mut table = Table::new(&rows);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
+    let missing_list = missing.join(", ");
+    let label = "missing (not registered):";
 
     if output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-        table.modify(Rows::first(), Color::BOLD);
-    }
-
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
-}
-
-/// Formats a `Timestamp` as a human-readable relative age.
-///
-/// Returns `"-"` when `ts` is `None` or the zero sentinel
-/// (`seconds == 0 && nanos == 0`). Otherwise formats as `Xs ago`,
-/// `XmYs ago`, or `XhYm ago` depending on magnitude.
-pub fn format_age(ts: Option<&Timestamp>) -> String {
-    let ts = match ts {
-        Some(ts) if ts.seconds != 0 || ts.nanos != 0 => ts,
-        _ => return "-".to_string(),
-    };
-
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-
-    let ts_secs = ts.seconds.max(0) as u64;
-    let now_secs = now.as_secs();
-
-    let secs = now_secs.saturating_sub(ts_secs);
-
-    if secs < 60 {
-        format!("{secs}s ago")
-    } else if secs < 3600 {
-        let minutes = secs / 60;
-        let remainder = secs % 60;
-        format!("{minutes}m{remainder}s ago")
+        println!("{} {}", label.red(), missing_list.red());
     } else {
-        let hours = secs / 3600;
-        let minutes = (secs % 3600) / 60;
-        format!("{hours}h{minutes}m ago")
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn format_age_none_returns_dash() {
-        assert_eq!("-", format_age(None));
-    }
-
-    #[test]
-    fn format_age_zero_sentinel_returns_dash() {
-        let ts = Timestamp { seconds: 0, nanos: 0 };
-        assert_eq!("-", format_age(Some(&ts)));
-    }
-
-    #[test]
-    fn format_age_seconds() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap();
-        let ts = Timestamp {
-            seconds: now.as_secs() as i64 - 30,
-            nanos: 0,
-        };
-        assert_eq!("30s ago", format_age(Some(&ts)));
-    }
-
-    #[test]
-    fn format_age_minutes() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap();
-        let ts = Timestamp {
-            seconds: now.as_secs() as i64 - 64,
-            nanos: 0,
-        };
-        assert_eq!("1m4s ago", format_age(Some(&ts)));
-    }
-
-    #[test]
-    fn format_age_hours() {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap();
-        let ts = Timestamp {
-            seconds: now.as_secs() as i64 - (2 * 3600 + 3 * 60),
-            nanos: 0,
-        };
-        assert_eq!("2h3m ago", format_age(Some(&ts)));
+        println!("{label} {missing_list}");
     }
 }

--- a/cli/modules/ready/src/render/age.rs
+++ b/cli/modules/ready/src/render/age.rs
@@ -1,0 +1,196 @@
+//! Age formatting and the staleness predicate.
+
+use core::time::Duration;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use prost_types::Timestamp;
+
+const SECONDS_PER_MINUTE: u64 = 60;
+const SECONDS_PER_HOUR: u64 = 60 * SECONDS_PER_MINUTE;
+const SECONDS_PER_DAY: u64 = 24 * SECONDS_PER_HOUR;
+
+/// Formats a `Timestamp` as an age string relative to `now`.
+///
+/// Returns `None` when `ts` is absent or the zero sentinel, signalling the
+/// caller should render the literal `never` instead. The output is capped
+/// at two units because humantime's year/month decomposition would
+/// otherwise leave a minute/second tail.
+pub fn format_age(ts: Option<&Timestamp>, now: SystemTime) -> Option<String> {
+    let ts = match ts {
+        Some(ts) if ts.seconds != 0 || ts.nanos != 0 => ts,
+        _ => return None,
+    };
+
+    let now_secs = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    let ts_secs = ts.seconds.max(0) as u64;
+    let age = now_secs.saturating_sub(ts_secs);
+
+    let rendered = humantime::format_duration(Duration::from_secs(round_age(age))).to_string();
+    Some(rendered.split_whitespace().take(2).collect::<Vec<_>>().join(" "))
+}
+
+/// Rounds an age in seconds down, dropping precision finer than the
+/// displayed units.
+///
+/// Second-level precision is noise in a readiness view: seconds are kept
+/// under a minute, dropped under a day, and minutes are dropped too beyond
+/// a day.
+fn round_age(seconds: u64) -> u64 {
+    if seconds < SECONDS_PER_MINUTE {
+        seconds
+    } else if seconds < SECONDS_PER_DAY {
+        seconds - seconds % SECONDS_PER_MINUTE
+    } else {
+        seconds - seconds % SECONDS_PER_HOUR
+    }
+}
+
+/// Returns whether a scope's staleness tag should be shown.
+///
+/// True only when the scope has been re-observed since its last transition
+/// and that observation is older than `stale_after`. A scope set once and
+/// never re-observed is never stale; `stale_after == Duration::ZERO`
+/// disables the tag unconditionally.
+pub fn is_stale(
+    observed_at: Option<&Timestamp>,
+    last_transition_time: Option<&Timestamp>,
+    now: SystemTime,
+    stale_after: Duration,
+) -> bool {
+    if stale_after.is_zero() {
+        return false;
+    }
+
+    let (Some(observed_at), Some(last_transition_time)) = (observed_at, last_transition_time) else {
+        return false;
+    };
+
+    if (observed_at.seconds, observed_at.nanos) <= (last_transition_time.seconds, last_transition_time.nanos) {
+        return false;
+    }
+
+    let now_secs = now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs();
+    let observed_secs = observed_at.seconds.max(0) as u64;
+    let age = Duration::from_secs(now_secs.saturating_sub(observed_secs));
+
+    age > stale_after
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn round_age_sub_minute_keeps_seconds() {
+        assert_eq!(0, round_age(0));
+        assert_eq!(45, round_age(45));
+        assert_eq!(59, round_age(59));
+    }
+
+    #[test]
+    fn round_age_minute_band_drops_seconds() {
+        assert_eq!(60, round_age(60));
+        assert_eq!(12 * SECONDS_PER_MINUTE, round_age(12 * SECONDS_PER_MINUTE + 34));
+        assert_eq!(
+            23 * SECONDS_PER_HOUR + 59 * SECONDS_PER_MINUTE,
+            round_age(SECONDS_PER_DAY - 1)
+        );
+    }
+
+    #[test]
+    fn round_age_day_band_rounds_to_hours() {
+        assert_eq!(
+            3 * SECONDS_PER_DAY + 5 * SECONDS_PER_HOUR,
+            round_age(3 * SECONDS_PER_DAY + 5 * SECONDS_PER_HOUR + 40 * SECONDS_PER_MINUTE)
+        );
+        assert_eq!(SECONDS_PER_DAY, round_age(SECONDS_PER_DAY));
+    }
+
+    #[test]
+    fn format_age_none_returns_none() {
+        assert_eq!(None, format_age(None, SystemTime::now()));
+    }
+
+    #[test]
+    fn format_age_zero_sentinel_returns_none() {
+        let ts = Timestamp { seconds: 0, nanos: 0 };
+        assert_eq!(None, format_age(Some(&ts), SystemTime::now()));
+    }
+
+    #[test]
+    fn format_age_future_timestamp_saturates_to_zero() {
+        let now = SystemTime::now();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let ts = Timestamp { seconds: now_secs + 60, nanos: 0 };
+
+        assert_eq!(Some("0s".to_string()), format_age(Some(&ts), now));
+    }
+
+    #[test]
+    fn format_age_large_age_caps_at_two_units() {
+        let now = SystemTime::now();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let ts = Timestamp {
+            seconds: now_secs - 400 * SECONDS_PER_DAY as i64,
+            nanos: 0,
+        };
+
+        let rendered = format_age(Some(&ts), now).unwrap();
+
+        assert!(rendered.split_whitespace().count() <= 2);
+    }
+
+    #[test]
+    fn is_stale_disabled_when_stale_after_zero() {
+        let now = SystemTime::now();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let old = Timestamp { seconds: now_secs - 10_000, nanos: 0 };
+        let recent = Timestamp { seconds: now_secs, nanos: 0 };
+
+        assert!(!is_stale(Some(&old), Some(&recent), now, Duration::ZERO));
+    }
+
+    #[test]
+    fn is_stale_never_for_set_once_scope() {
+        let now = SystemTime::now();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let ts = Timestamp { seconds: now_secs - 10_000, nanos: 0 };
+
+        assert!(!is_stale(Some(&ts), Some(&ts), now, Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn is_stale_true_past_threshold() {
+        let now = SystemTime::now();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let transition = Timestamp { seconds: now_secs - 10_000, nanos: 0 };
+        let observed = Timestamp { seconds: now_secs - 120, nanos: 0 };
+
+        assert!(is_stale(
+            Some(&observed),
+            Some(&transition),
+            now,
+            Duration::from_secs(60)
+        ));
+    }
+
+    #[test]
+    fn is_stale_false_within_threshold() {
+        let now = SystemTime::now();
+        let now_secs = now.duration_since(UNIX_EPOCH).unwrap().as_secs() as i64;
+        let transition = Timestamp { seconds: now_secs - 10_000, nanos: 0 };
+        let observed = Timestamp { seconds: now_secs - 10, nanos: 0 };
+
+        assert!(!is_stale(
+            Some(&observed),
+            Some(&transition),
+            now,
+            Duration::from_secs(60)
+        ));
+    }
+
+    #[test]
+    fn is_stale_false_when_timestamps_missing() {
+        assert!(!is_stale(None, None, SystemTime::now(), Duration::from_secs(60)));
+    }
+}

--- a/cli/modules/ready/src/render/layout.rs
+++ b/cli/modules/ready/src/render/layout.rs
@@ -1,0 +1,128 @@
+//! Text-layout helpers: the scope-name column width and word wrapping.
+
+const MIN_NAME_WIDTH: usize = 12;
+const MAX_NAME_WIDTH: usize = 40;
+
+/// Computes the scope-name column width for a rendered set of scopes.
+///
+/// The longest name wins, clamped to `[MIN_NAME_WIDTH, MAX_NAME_WIDTH]`.
+/// Compute this once per render (or once per watch session) and hold it —
+/// recomputing per row would make the column width jitter.
+pub fn name_width<'a>(names: impl IntoIterator<Item = &'a str>) -> usize {
+    names
+        .into_iter()
+        .map(str::len)
+        .max()
+        .unwrap_or(MIN_NAME_WIDTH)
+        .clamp(MIN_NAME_WIDTH, MAX_NAME_WIDTH)
+}
+
+/// Greedily wraps `text` into lines of at most `width` columns, breaking
+/// only at whitespace.
+///
+/// A word longer than `width` is kept whole on its own (overflowing) line
+/// rather than split. Returns `text` unchanged as a single line when
+/// `width` is `0`.
+pub fn wrap_words(text: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return vec![text.to_string()];
+    }
+
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.len() + 1 + word.len() <= width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+    }
+
+    if !current.is_empty() || lines.is_empty() {
+        lines.push(current);
+    }
+
+    lines
+}
+
+/// Collapses every run of whitespace in `text` — including embedded
+/// newlines — into a single ASCII space.
+///
+/// Used on the non-wrapping (non-TTY) render path, where reason text is
+/// printed as one grep-friendly line; the source message (a Go
+/// `err.Error()`) may otherwise carry embedded newlines.
+pub fn normalize_whitespace(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn name_width_clamps_to_minimum() {
+        assert_eq!(MIN_NAME_WIDTH, name_width(["rib"]));
+    }
+
+    #[test]
+    fn name_width_clamps_to_maximum() {
+        let long_name = "a".repeat(100);
+        assert_eq!(MAX_NAME_WIDTH, name_width([long_name.as_str()]));
+    }
+
+    #[test]
+    fn name_width_uses_longest_name() {
+        assert_eq!(16, name_width(["bird-session", "fib:gw-01:route0", "rib"]));
+    }
+
+    #[test]
+    fn name_width_empty_defaults_to_minimum() {
+        assert_eq!(MIN_NAME_WIDTH, name_width(std::iter::empty()));
+    }
+
+    #[test]
+    fn wrap_words_fits_within_width() {
+        assert_eq!(vec!["aa bb".to_string(), "cc".to_string()], wrap_words("aa bb cc", 5));
+    }
+
+    #[test]
+    fn wrap_words_keeps_long_word_whole() {
+        assert_eq!(
+            vec!["superlongword".to_string(), "short".to_string()],
+            wrap_words("superlongword short", 5)
+        );
+    }
+
+    #[test]
+    fn wrap_words_zero_width_returns_single_line() {
+        assert_eq!(vec!["one long line".to_string()], wrap_words("one long line", 0));
+    }
+
+    #[test]
+    fn wrap_words_empty_text_returns_one_empty_line() {
+        assert_eq!(vec![String::new()], wrap_words("", 10));
+    }
+
+    #[test]
+    fn normalize_whitespace_collapses_embedded_newlines() {
+        assert_eq!(
+            "rpc error: connection refused extra detail",
+            normalize_whitespace("rpc error: connection refused\nextra detail")
+        );
+    }
+
+    #[test]
+    fn normalize_whitespace_collapses_runs_of_spaces() {
+        assert_eq!("a b", normalize_whitespace("a    b"));
+    }
+
+    #[test]
+    fn normalize_whitespace_empty_text_returns_empty() {
+        assert_eq!("", normalize_whitespace(""));
+    }
+}

--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -1,0 +1,268 @@
+//! Table-free readiness rendering.
+//!
+//! The mark and state label are fixed-width compile-time constants; the
+//! age and the reason text are not columns, so their variable width never
+//! shifts anything to their left. The reason text moves to an indented
+//! continuation line instead of sharing a row.
+
+mod age;
+mod layout;
+mod watch;
+
+use core::time::Duration;
+use std::time::SystemTime;
+
+use colored::Colorize;
+use readinesspb::pb::{Reason, Scope, State};
+use ync::{display, output};
+
+use self::{
+    age::{format_age, is_stale},
+    layout::{normalize_whitespace, wrap_words},
+};
+pub use self::{
+    layout::name_width,
+    watch::{print_transition_line, record_transition},
+};
+
+/// Fixed width of the state label cell (`len("NOT_READY")`).
+const STATE_WIDTH: usize = 9;
+/// Leading indent for each scope row.
+const ROW_INDENT: usize = 2;
+/// Leading indent for reason continuation lines.
+const REASON_INDENT: usize = 6;
+
+/// ASCII/Unicode form for the glyphs that aren't state marks: the watch
+/// arrow, the header/summary dash, the summary separator, and the
+/// watching-suffix ellipsis.
+///
+/// Chosen once from the same `colored` flag as [`state_cells`] so every
+/// symbol in the render degrades to plain ASCII together — no glyph can
+/// drift out of sync with the marks in a non-UTF-8 locale or piped run.
+struct Symbols {
+    arrow: &'static str,
+    dash: &'static str,
+    separator: &'static str,
+    ellipsis: &'static str,
+}
+
+impl Symbols {
+    fn new(colored: bool) -> Self {
+        if colored {
+            Self {
+                arrow: "→",
+                dash: " — ",
+                separator: " · ",
+                ellipsis: "…",
+            }
+        } else {
+            Self {
+                arrow: "->",
+                dash: " - ",
+                separator: ", ",
+                ellipsis: "...",
+            }
+        }
+    }
+}
+
+/// Renders the full one-shot status block for `scopes` to stdout.
+///
+/// `name_width` must be computed once via [`name_width`] and held constant
+/// across the render — recomputing it per row would make the column jitter.
+/// The header line is `{name}{dash}{summary}`; `watching` appends a
+/// `watching` suffix to that summary and, once the block is printed, adds
+/// one trailing blank line to separate it from the `--watch` transition log
+/// that follows.
+pub fn print_status_block(name: &str, scopes: &[Scope], name_width: usize, stale_after: Duration, watching: bool) {
+    let now = SystemTime::now();
+    let colored = output::is_colored();
+    let symbols = Symbols::new(colored);
+    let wrap_width = display::terminal_width();
+
+    let mut summary = summary_line(scopes, symbols.separator);
+    if watching {
+        summary.push_str(symbols.separator);
+        summary.push_str("watching");
+        summary.push_str(symbols.ellipsis);
+    }
+
+    println!("{name}{}{summary}", symbols.dash);
+
+    for scope in scopes {
+        print_scope_row(scope, name_width, stale_after, now, colored, wrap_width);
+    }
+
+    if watching {
+        println!();
+    }
+}
+
+/// Prints one scope's row plus any reason continuation lines.
+fn print_scope_row(
+    scope: &Scope,
+    name_width: usize,
+    stale_after: Duration,
+    now: SystemTime,
+    colored: bool,
+    wrap_width: Option<usize>,
+) {
+    let state = State::try_from(scope.state).unwrap_or_default();
+    let (mark, label_cell) = state_cells(state, colored);
+    let name = format!("{:<width$}", scope.name, width = name_width);
+    let age = format_age(scope.last_transition_time.as_ref(), now);
+    let time = time_cell(age.as_deref());
+
+    let mut line = format!("{:width$}{mark} {name} {label_cell} {time}", "", width = ROW_INDENT);
+
+    if is_stale(
+        scope.observed_at.as_ref(),
+        scope.last_transition_time.as_ref(),
+        now,
+        stale_after,
+    ) {
+        let stale_age = format_age(scope.observed_at.as_ref(), now).unwrap_or_default();
+        let tag = format!("stale {stale_age}");
+        let tag = if colored {
+            tag.truecolor(180, 140, 0).to_string()
+        } else {
+            tag
+        };
+        line.push_str("   ");
+        line.push_str(&tag);
+    }
+
+    println!("{line}");
+    print_reason_lines(&scope.reasons, colored, wrap_width);
+}
+
+/// Returns the (mark, label) cell text for `state`, colored when `colored`
+/// is true.
+///
+/// Both cells are fixed-width within a given color mode (1 char / 9+ chars
+/// for colored Unicode marks, 4 chars / 9+ chars for the ASCII fallback) so
+/// a double-width glyph can never shift a column.
+fn state_cells(state: State, colored: bool) -> (String, String) {
+    let (unicode_mark, ascii_mark, color): (&str, &str, fn(&str) -> String) = match state {
+        State::Ready => ("✓", "[ok]", |s| s.green().to_string()),
+        State::Degraded => ("~", "[!!]", |s| s.yellow().to_string()),
+        State::NotReady => ("✗", "[xx]", |s| s.red().to_string()),
+        State::Unknown | State::Unspecified => ("?", "[??]", |s| s.truecolor(127, 127, 127).to_string()),
+    };
+
+    let label_cell = format!("{:<width$}", label(state), width = STATE_WIDTH);
+
+    if colored {
+        (color(unicode_mark), color(&label_cell))
+    } else {
+        (ascii_mark.to_string(), label_cell)
+    }
+}
+
+/// Maps a `State` to its label text, stripped of the `STATE_` prefix.
+fn label(state: State) -> &'static str {
+    match state {
+        State::Ready => "READY",
+        State::Degraded => "DEGRADED",
+        State::NotReady => "NOT_READY",
+        State::Unknown => "UNKNOWN",
+        State::Unspecified => "UNSPECIFIED",
+    }
+}
+
+/// Renders the `for <age>` time cell, or `for never` when `age` is `None`.
+fn time_cell(age: Option<&str>) -> String {
+    format!("for {}", age.unwrap_or("never"))
+}
+
+/// Renders a reason's display text.
+///
+/// Returns the bare `code` when `message` is empty, otherwise `code:
+/// message`. Shared by the snapshot block and the `--watch` transition log
+/// so a state change and a reason-only change never disagree on how a
+/// reason reads.
+fn format_reason(reason: &Reason) -> String {
+    if reason.message.is_empty() {
+        reason.code.clone()
+    } else {
+        format!("{}: {}", reason.code, reason.message)
+    }
+}
+
+/// Prints each reason as one or more indented continuation lines.
+///
+/// A reason with no message prints its bare code. Long text wraps with a
+/// hanging indent when `wrap_width` is `Some` (stdout is a TTY); otherwise
+/// it prints as one long, grep-friendly line.
+fn print_reason_lines(reasons: &[Reason], colored: bool, wrap_width: Option<usize>) {
+    let indent = " ".repeat(REASON_INDENT);
+
+    for reason in reasons {
+        let text = format_reason(reason);
+
+        let lines = match wrap_width {
+            Some(width) if width > REASON_INDENT => wrap_words(&text, width - REASON_INDENT),
+            _ => vec![normalize_whitespace(&text)],
+        };
+
+        for line in lines {
+            let styled = if colored {
+                line.truecolor(127, 127, 127).to_string()
+            } else {
+                line
+            };
+            println!("{indent}{styled}");
+        }
+    }
+}
+
+/// Builds the `N/M ready · 1 degraded · 1 not ready` summary line.
+///
+/// Only non-zero categories beyond `ready` are included. `separator` joins
+/// the parts and is chosen by the caller from [`Symbols`], so the whole line
+/// degrades to ASCII together with the rest of the render.
+fn summary_line(scopes: &[Scope], separator: &str) -> String {
+    let total = scopes.len();
+    let mut ready = 0usize;
+    let mut degraded = 0usize;
+    let mut not_ready = 0usize;
+    let mut unknown = 0usize;
+
+    for scope in scopes {
+        match State::try_from(scope.state).unwrap_or_default() {
+            State::Ready => ready += 1,
+            State::Degraded => degraded += 1,
+            State::NotReady => not_ready += 1,
+            State::Unknown | State::Unspecified => unknown += 1,
+        }
+    }
+
+    let mut parts = vec![format!("{ready}/{total} ready")];
+
+    if degraded > 0 {
+        parts.push(format!("{degraded} degraded"));
+    }
+    if not_ready > 0 {
+        parts.push(format!("{not_ready} not ready"));
+    }
+    if unknown > 0 {
+        parts.push(format!("{unknown} unknown"));
+    }
+
+    parts.join(separator)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn symbols_ascii_fallback_has_no_unicode() {
+        let symbols = Symbols::new(false);
+
+        assert!(symbols.arrow.is_ascii());
+        assert!(symbols.dash.is_ascii());
+        assert!(symbols.separator.is_ascii());
+        assert!(symbols.ellipsis.is_ascii());
+    }
+}

--- a/cli/modules/ready/src/render/watch.rs
+++ b/cli/modules/ready/src/render/watch.rs
@@ -1,0 +1,151 @@
+//! `--watch` transition tracking: the merged snapshot diff and the
+//! append-only log line renderer.
+
+use std::collections::BTreeMap;
+
+use chrono::Local;
+use colored::Colorize;
+use readinesspb::pb::{Scope, State};
+use ync::{display, output};
+
+use super::layout::{normalize_whitespace, wrap_words};
+
+/// The kind of change observed for one scope in a `--watch` delta message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transition {
+    /// The scope's state changed away from `previous`.
+    StateChanged { previous: State },
+    /// The state is unchanged; only the reason changed.
+    ReasonChanged,
+}
+
+/// Records `scope`'s new data in `snapshot` and classifies the change.
+///
+/// A scope absent from `snapshot` is treated as having previously been
+/// `STATE_UNKNOWN`. `snapshot` is updated with `scope`'s full data so later
+/// calls can diff against it.
+pub fn record_transition(snapshot: &mut BTreeMap<String, Scope>, scope: &Scope) -> Transition {
+    let next = State::try_from(scope.state).unwrap_or_default();
+    let previous = snapshot
+        .insert(scope.name.clone(), scope.clone())
+        .map(|prev| State::try_from(prev.state).unwrap_or_default())
+        .unwrap_or(State::Unknown);
+
+    if previous == next {
+        Transition::ReasonChanged
+    } else {
+        Transition::StateChanged { previous }
+    }
+}
+
+/// Prints one append-only log line for a `--watch` change.
+///
+/// A state change shows `PREV → NEXT` on the transition line; a reason-only
+/// change shows the unchanged state instead. Both kinds then render every
+/// `CODE: message` reason (if any) on a wrapped, dim continuation line — the
+/// server never resends an unchanged reason, so a persistent failure's
+/// message would otherwise only ever be shown once. Long reason text wraps
+/// with a hanging indent when stdout is a TTY; a scope with no reasons
+/// prints just the transition line.
+pub fn print_transition_line(scope: &Scope, name_width: usize, transition: Transition) {
+    let colored = output::is_colored();
+    let symbols = super::Symbols::new(colored);
+    let wrap_width = display::terminal_width();
+    let timestamp = Local::now().format("%H:%M:%S");
+    let state = State::try_from(scope.state).unwrap_or_default();
+    let name = format!("{:<width$}", scope.name, width = name_width);
+
+    let change = match transition {
+        Transition::StateChanged { previous } => {
+            format!("{} {} {}", super::label(previous), symbols.arrow, super::label(state))
+        }
+        Transition::ReasonChanged => super::label(state).to_string(),
+    };
+
+    let prefix = format!("{timestamp}  {name}  {change}");
+    let indent = prefix.chars().count() + 3;
+
+    print!("{prefix}");
+
+    let mut is_first_line = true;
+    for reason in &scope.reasons {
+        let reason_text = super::format_reason(reason);
+
+        let lines = match wrap_width {
+            Some(width) if width > indent => wrap_words(&reason_text, width - indent),
+            _ => vec![normalize_whitespace(&reason_text)],
+        };
+
+        for line in &lines {
+            let styled = if colored {
+                line.truecolor(127, 127, 127).to_string()
+            } else {
+                line.clone()
+            };
+
+            if is_first_line {
+                print!("   {styled}");
+                is_first_line = false;
+            } else {
+                print!("\n{:indent$}{styled}", "");
+            }
+        }
+    }
+
+    println!();
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn scope(name: &str, state: State) -> Scope {
+        Scope {
+            name: name.to_string(),
+            state: state as i32,
+            reasons: Vec::new(),
+            observed_at: None,
+            last_transition_time: None,
+        }
+    }
+
+    #[test]
+    fn record_transition_detects_state_change() {
+        let mut snapshot = BTreeMap::new();
+        snapshot.insert("rib".to_string(), scope("rib", State::Ready));
+
+        let transition = record_transition(&mut snapshot, &scope("rib", State::Degraded));
+
+        assert_eq!(Transition::StateChanged { previous: State::Ready }, transition);
+    }
+
+    #[test]
+    fn record_transition_detects_reason_only_change() {
+        let mut snapshot = BTreeMap::new();
+        snapshot.insert("rib".to_string(), scope("rib", State::Degraded));
+
+        let transition = record_transition(&mut snapshot, &scope("rib", State::Degraded));
+
+        assert_eq!(Transition::ReasonChanged, transition);
+    }
+
+    #[test]
+    fn record_transition_treats_unknown_scope_as_previously_unknown() {
+        let mut snapshot = BTreeMap::new();
+
+        let transition = record_transition(&mut snapshot, &scope("neighbours", State::NotReady));
+
+        assert_eq!(Transition::StateChanged { previous: State::Unknown }, transition);
+        assert!(snapshot.contains_key("neighbours"));
+    }
+
+    #[test]
+    fn record_transition_updates_snapshot() {
+        let mut snapshot = BTreeMap::new();
+        snapshot.insert("rib".to_string(), scope("rib", State::Ready));
+
+        record_transition(&mut snapshot, &scope("rib", State::NotReady));
+
+        assert_eq!(State::NotReady as i32, snapshot["rib"].state);
+    }
+}


### PR DESCRIPTION
The readiness table jumped in width between runs and refreshes, which made it unusable for eyeballing readiness or watching a rollout.

Column widths were derived from content, and the reason column held unbounded free text — a single long apply error forced every other column to reflow. The streaming mode re-rendered a whole table for each stream message, even though the server sends only the scopes that changed after the first snapshot, so every frame had a different shape.

The table is replaced with a status list. The fields that precede the age are fixed-width, the reason text moves onto indented continuation lines instead of being a column, and the only content-derived width is computed once and held. The streaming mode now prints one snapshot followed by an append-only transition log.

Ages are rendered through the duration formatter the crate already depends on, rather than a hand-rolled one.

A scope is reported as stale only when it is demonstrably heartbeated, so a scope that is set once and never re-observed is never flagged. Readiness sources heartbeat on their own differing cadences, so the threshold is deliberately generous and can be tuned or disabled.

Machine-readable output is unchanged, as are the exit codes.