### PR TITLE
chore(build): derive the package version from git

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -54,6 +54,12 @@ jobs:
         with:
           submodules: true
 
+      - name: Fetch git history for versioning
+        run: |
+          git fetch --prune --unshallow --tags --filter=blob:none origin \
+            || git fetch --tags --filter=blob:none origin \
+            || true
+
       - uses: hendrikmuhs/ccache-action@v1.2.18
         name: ccache
         with:

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           submodules: true
 
+      - name: Fetch git history for versioning
+        run: |
+          git fetch --prune --unshallow --tags --filter=blob:none origin \
+            || git fetch --tags --filter=blob:none origin \
+            || true
+
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 

--- a/controlplane/meson.build
+++ b/controlplane/meson.build
@@ -1,6 +1,6 @@
 subdir('ynpb')
 
-ld_flags = '-X github.com/yanet-platform/yanet2/controlplane/internal/version.version=' + meson.project_version()
+ld_flags = '-X github.com/yanet-platform/yanet2/controlplane/internal/version.version=' + yanet_version
 
 custom_target(
     'yanet-controlplane',

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+include /usr/share/dpkg/pkg-info.mk
+
 # Enable verbose output for debugging
 export DH_VERBOSE = 1
 export DH_OPTIONS=-v
@@ -22,7 +24,8 @@ override_dh_auto_configure:
 	meson setup $(BUILDDIR) \
 			--default-library=static \
 			-Dfuzzing=disabled \
-			-Dtrace=disabled; \
+			-Dtrace=disabled \
+			-Dversion=$(DEB_VERSION); \
 
 # Handle missing files more gracefully
 override_dh_missing:

--- a/meson.build
+++ b/meson.build
@@ -25,8 +25,10 @@ yanet_conf.set('ENABLE_TRACE_LOG', get_option('trace').enabled())
 yanet_conf.set('MBUF_MAX_SIZE', get_option('mbuf_max_size'))
 
 # Version and build info
+yanet_version = get_option('version') == '' ? meson.project_version() : get_option('version')
+
 cc = meson.get_compiler('c')
-yanet_conf.set_quoted('YANET_VERSION', meson.project_version())
+yanet_conf.set_quoted('YANET_VERSION', yanet_version)
 yanet_conf.set_quoted('YANET_COMPILER_ID', cc.get_id())
 yanet_conf.set_quoted('YANET_COMPILER_VERSION', cc.version())
 yanet_conf.set_quoted('YANET_BUILD_TYPE', get_option('buildtype'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,6 +6,13 @@ option(
 )
 
 option(
+  'version',
+  type: 'string',
+  value: '',
+  description: 'Override the version reported by the binaries; empty uses the project() version.',
+)
+
+option(
   'trace',
   type: 'feature',
   value: 'disabled',

--- a/operators/bird-adapter/meson.build
+++ b/operators/bird-adapter/meson.build
@@ -10,7 +10,7 @@ install_data(
     install_dir: '/etc/yanet2',
 )
 
-bird_adapter_ld_flags = '-X github.com/yanet-platform/yanet2/operators/bird-adapter/internal/version.version=' + meson.project_version()
+bird_adapter_ld_flags = '-X github.com/yanet-platform/yanet2/operators/bird-adapter/internal/version.version=' + yanet_version
 
 # Skip bird-adapter when fuzzing — it does not use CGO but still gets sanitizer
 # flags that interfere with the fuzzing build.

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -2,6 +2,74 @@
 set -euxo pipefail
 env
 
+# Resolve the debian package version from git.
+#
+# A `vX.Y.Z` tag on HEAD becomes `X.Y.Z`, otherwise
+# `<base>+dev<count>.g<sha>` where <base> is the latest reachable tag, or,
+# when no such tag exists yet, the last released version already recorded
+# in debian/changelog (with any leftover `+dev...` suffix stripped, so a
+# base can never compound across runs). <count> is the number of commits
+# reachable from HEAD, and <sha> is the abbreviated commit hash. Falls back
+# to the version already recorded in debian/changelog if git is unavailable
+# or any of the git calls fail, so the build never aborts here.
+resolve_version() {
+    set -e
+
+    if ! git -c safe.directory="$PWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "warning: git version resolution failed, falling back to the changelog version" >&2
+        dpkg-parsechangelog -SVersion
+        return
+    fi
+
+    local tag
+    if tag=$(git -c safe.directory="$PWD" describe --tags --exact-match --match 'v[0-9]*' HEAD 2>/dev/null); then
+        echo "${tag#v}"
+        return
+    fi
+
+    local base
+    if ! base=$(git -c safe.directory="$PWD" describe --tags --abbrev=0 --match 'v[0-9]*' HEAD 2>/dev/null); then
+        if ! base=$(dpkg-parsechangelog -SVersion 2>/dev/null); then
+            base="v0.0.0"
+        fi
+        base="${base%%+dev*}"
+    fi
+
+    local count sha
+    if ! count=$(git -c safe.directory="$PWD" rev-list --count HEAD); then
+        echo "warning: git version resolution failed, falling back to the changelog version" >&2
+        dpkg-parsechangelog -SVersion
+        return
+    fi
+    if ! sha=$(git -c safe.directory="$PWD" rev-parse --short=8 HEAD); then
+        echo "warning: git version resolution failed, falling back to the changelog version" >&2
+        dpkg-parsechangelog -SVersion
+        return
+    fi
+
+    echo "${base#v}+dev${count}.g${sha}"
+}
+
+PKG_VERSION="${PKG_VERSION:-$(resolve_version)}"
+echo "Resolved package version: $PKG_VERSION"
+
+# dch needs a maintainer identity; default it when the environment doesn't
+# already provide one.
+: "${DEBEMAIL:=ci@yanet-platform.dev}"
+: "${DEBFULLNAME:=YANET CI}"
+export DEBEMAIL DEBFULLNAME
+
+changelog_backup=$(mktemp)
+cp debian/changelog "$changelog_backup"
+trap 'cp "$changelog_backup" debian/changelog; rm -f "$changelog_backup"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# The resolved version can sort below the version already tracked in
+# debian/changelog, so force dch to accept it. The entry text is passed as
+# an argument so dch never tries to open an editor.
+dch --newversion "$PKG_VERSION" --distribution unstable --force-bad-version "Automatic CI build."
+
 # Install build deps with verbose output
 apt-get update
 (


### PR DESCRIPTION
Builds that do not come from a release tag reused one hardcoded version, so successive packages were indistinguishable and apt could not upgrade one over another.

* Non-tag builds now carry a monotonically increasing version derived from the commit count, plus the commit hash to identify the exact build.
* Builds from a release tag keep the plain release version.
* The same version now reaches the binaries, not just the package metadata.
* Both workflows that build the packages fetch the history needed to derive the version, so the images and the release artifacts stay in step.

The version resolution lives in the packaging script rather than in the workflows, so a local build produces the same version as CI.