### PR TITLE
fix(build): install and package the mirror CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ CLI_MODULES := \
 	device-trafgen \
 	dscp \
 	fwstate \
+	mirror \
 	route \
 	route-mpls \
 	forward \

--- a/debian/yanet2-cli.install
+++ b/debian/yanet2-cli.install
@@ -13,6 +13,7 @@ usr/bin/yanet-cli-nat64
 usr/bin/yanet-cli-route
 usr/bin/yanet-cli-route-mpls
 usr/bin/yanet-cli-pdump
+usr/bin/yanet-cli-mirror
 usr/bin/yanet-cli-gateway
 usr/bin/yanet-cli-ready
 usr/bin/yanet-cli-metrics


### PR DESCRIPTION
The mirror module ships a CLI crate, and the workspace build already produced its binary, but it was registered in neither the install list nor the Debian package — so the tool was built and then silently dropped on the floor.

- Add mirror to the module CLI list, so the install step picks up its binary.
- Ship the binary in the CLI Debian package alongside the other module CLIs.

Both entries have to land together: once the binary reaches the staging tree, packaging fails unless it is also claimed by the package.