### PR TITLE
fix(build): add missing proto-gen dependencies to the Go build targets

### DIFF
--- a/common/readinesspb/meson.build
+++ b/common/readinesspb/meson.build
@@ -5,7 +5,7 @@ readiness_proto_files = [
     join_paths(readiness_proto_dir, 'v1', 'readiness.proto'),
 ]
 
-readiness_protoc_gen = custom_target(
+common_readiness_protoc_gen = custom_target(
     'readiness-protoc',
     output: [
         'readiness.pb.go',

--- a/controlplane/meson.build
+++ b/controlplane/meson.build
@@ -32,6 +32,11 @@ custom_target(
         trafgen_protoc_gen,
         plain_protoc_gen,
         vlan_protoc_gen,
+        filter_protoc_gen,
+        fwstate_protoc_gen,
+        common_readiness_protoc_gen,
+        route_operator_protoc_gen,
+        route_operator_readiness_protoc_gen,
 
         # cgo linker deps
         lib_acl_cp,

--- a/meson.build
+++ b/meson.build
@@ -150,6 +150,16 @@ subdir('lib/dataplane_ut/tests')
 subdir('dataplane')
 
 if not dataplane_only
+  # Operator proto targets must exist before their consumers are declared.
+  #
+  # Meson resolves variables in subdir traversal order, so the control-plane
+  # and operator binaries below can only depend on these targets if the
+  # directories that define them are entered first.
+  subdir('operators/bird-adapter/adapterpb')
+  subdir('operators/pipeline/operatorpb')
+  subdir('operators/route/operatorpb')
+  subdir('operators/forward/operatorpb')
+  subdir('operators/decap/operatorpb')
   subdir('controlplane')
   subdir('operators')
   foreach dir : module_test_dirs

--- a/operators/bird-adapter/meson.build
+++ b/operators/bird-adapter/meson.build
@@ -1,5 +1,3 @@
-subdir('adapterpb')
-
 install_data(
     'etc/yanet/yanet2-bird-adapter-bootstrap.service',
     install_dir: '/usr/lib/systemd/system',
@@ -30,10 +28,13 @@ if not get_option('fuzzing').enabled()
       build_by_default: true,
       build_always_stale: true,
       depends: [
-          ynpb_gen,
           bird_adapter_protoc_gen,
-          route_protoc_gen,
           common_protoc_gen,
+          filter_protoc_gen,
+          route_mpls_protoc_gen,
+          common_readiness_protoc_gen,
+          route_operator_protoc_gen,
+          route_operator_readiness_protoc_gen,
       ],
       install: true,
       install_dir: get_option('bindir'),

--- a/operators/decap/meson.build
+++ b/operators/decap/meson.build
@@ -1,5 +1,3 @@
-subdir('operatorpb')
-
 install_data(
     'etc/yanet/decap.d/default.yaml',
     install_dir: '/etc/yanet2/decap.d',
@@ -29,7 +27,7 @@ if not get_option('fuzzing').enabled()
           common_protoc_gen,
           decap_protoc_gen,
           decap_operator_protoc_gen,
-          readiness_protoc_gen,
+          common_readiness_protoc_gen,
       ],
       install: true,
       install_dir: get_option('bindir'),

--- a/operators/forward/meson.build
+++ b/operators/forward/meson.build
@@ -1,5 +1,3 @@
-subdir('operatorpb')
-
 install_data(
     'etc/yanet/forward.d/vlan-phy-default.yaml',
     'etc/yanet/forward.d/phy-vlan-default.yaml',
@@ -30,7 +28,8 @@ if not get_option('fuzzing').enabled()
           common_protoc_gen,
           forward_protoc_gen,
           forward_operator_protoc_gen,
-          readiness_protoc_gen,
+          common_readiness_protoc_gen,
+          filter_protoc_gen,
       ],
       install: true,
       install_dir: get_option('bindir'),

--- a/operators/pipeline/meson.build
+++ b/operators/pipeline/meson.build
@@ -1,5 +1,3 @@
-subdir('operatorpb')
-
 # Skip pipeline-operator when fuzzing — no CGO but still gets sanitizer flags
 # that interfere with the fuzzing build.
 if not get_option('fuzzing').enabled()
@@ -20,7 +18,7 @@ if not get_option('fuzzing').enabled()
       depends: [
           pipeline_operator_protoc_gen,
           pipeline_operator_readiness_protoc_gen,
-          readiness_protoc_gen,
+          common_readiness_protoc_gen,
           ynpb_gen,
           common_protoc_gen,
           plain_protoc_gen,

--- a/operators/pipeline/operatorpb/meson.build
+++ b/operators/pipeline/operatorpb/meson.build
@@ -22,7 +22,7 @@ readiness_proto_files = [
     join_paths(proto_dir, 'readiness.proto'),
 ]
 
-readiness_protoc_gen = custom_target(
+pipeline_operator_readiness_protoc_gen = custom_target(
     'pipeline-operator-readiness-protoc',
     output: [
         'readiness.pb.go',
@@ -38,4 +38,3 @@ readiness_protoc_gen = custom_target(
     ],
     build_by_default: true,
 )
-pipeline_operator_readiness_protoc_gen = readiness_protoc_gen

--- a/operators/route/meson.build
+++ b/operators/route/meson.build
@@ -1,5 +1,3 @@
-subdir('operatorpb')
-
 # Skip route-operator when fuzzing — no CGO but still gets sanitizer flags
 # that interfere with the fuzzing build.
 if not get_option('fuzzing').enabled()
@@ -22,6 +20,8 @@ if not get_option('fuzzing').enabled()
           ynpb_gen,
           common_protoc_gen,
           route_protoc_gen,
+          common_readiness_protoc_gen,
+          route_operator_readiness_protoc_gen,
       ],
       install: true,
       install_dir: get_option('bindir'),

--- a/operators/route/operatorpb/meson.build
+++ b/operators/route/operatorpb/meson.build
@@ -38,7 +38,7 @@ readiness_proto_files = [
     join_paths(proto_dir, 'readiness.proto'),
 ]
 
-readiness_protoc_gen = custom_target(
+route_operator_readiness_protoc_gen = custom_target(
     'route-operator-readiness-protoc',
     output: [
         'readiness.pb.go',
@@ -54,4 +54,3 @@ readiness_protoc_gen = custom_target(
     ],
     build_by_default: true,
 )
-route_operator_readiness_protoc_gen = readiness_protoc_gen


### PR DESCRIPTION
Meson evaluates every subdir in one flat variable namespace, so the readiness proto-gen target name was silently rebound by each operator that declared a readiness proto of its own. Depending on the traversal order, the forward and decap operators ended up wired to the route operator's readiness target, while the route and pipeline operators depended on their own twice — in every case the dependency on the shared readiness definitions was missing.

Give each readiness proto-gen target a unique name so the dependency edges mean what they say, and declare the proto dependencies every control-plane and operator binary actually imports. Without them a parallel build can start compiling Go code before protobuf generation finishes.