### PR TITLE
feat(cli): colorize ready watch transitions

### DIFF
--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -36,7 +36,7 @@ const REASON_INDENT: usize = 6;
 /// arrow, the header/summary dash, the summary separator, and the
 /// watching-suffix ellipsis.
 ///
-/// Chosen once from the same `colored` flag as [`state_cells`] so every
+/// Chosen once from the same `colored` flag as [`StateStyle`] so every
 /// symbol in the render degrades to plain ASCII together — no glyph can
 /// drift out of sync with the marks in a non-UTF-8 locale or piped run.
 struct Symbols {
@@ -136,6 +136,49 @@ fn print_scope_row(
     print_reason_lines(&scope.reasons, colored, wrap_width);
 }
 
+/// How one `State` renders: its mark glyph and its color.
+///
+/// This is the single place the state → (mark, color) map lives. Both the
+/// snapshot block and the `--watch` transition log build their cells from
+/// here, so a state can never be green in one render and yellow in the
+/// other. `colored` is supplied by the caller — the global color gate is
+/// read once at the top of a render, never here.
+struct StateStyle {
+    mark: &'static str,
+    color: fn(&str) -> String,
+    colored: bool,
+}
+
+impl StateStyle {
+    fn new(state: State, colored: bool) -> Self {
+        let (unicode_mark, ascii_mark, color): (&str, &str, fn(&str) -> String) = match state {
+            State::Ready => ("✓", "[ok]", |s| s.green().to_string()),
+            State::Degraded => ("~", "[!!]", |s| s.yellow().to_string()),
+            State::NotReady => ("✗", "[xx]", |s| s.red().to_string()),
+            State::Unknown | State::Unspecified => ("?", "[??]", |s| s.truecolor(127, 127, 127).to_string()),
+        };
+
+        let mark = if colored { unicode_mark } else { ascii_mark };
+
+        Self { mark, color, colored }
+    }
+
+    /// Returns the mark glyph in the state's color.
+    fn styled_mark(&self) -> String {
+        self.paint(self.mark)
+    }
+
+    /// Paints `text` in the state's color, or returns it as-is when the
+    /// render is not colored.
+    fn paint(&self, text: &str) -> String {
+        if self.colored {
+            (self.color)(text)
+        } else {
+            text.to_string()
+        }
+    }
+}
+
 /// Returns the (mark, label) cell text for `state`, colored when `colored`
 /// is true.
 ///
@@ -143,19 +186,22 @@ fn print_scope_row(
 /// for colored Unicode marks, 4 chars / 9+ chars for the ASCII fallback) so
 /// a double-width glyph can never shift a column.
 fn state_cells(state: State, colored: bool) -> (String, String) {
-    let (unicode_mark, ascii_mark, color): (&str, &str, fn(&str) -> String) = match state {
-        State::Ready => ("✓", "[ok]", |s| s.green().to_string()),
-        State::Degraded => ("~", "[!!]", |s| s.yellow().to_string()),
-        State::NotReady => ("✗", "[xx]", |s| s.red().to_string()),
-        State::Unknown | State::Unspecified => ("?", "[??]", |s| s.truecolor(127, 127, 127).to_string()),
-    };
-
+    let style = StateStyle::new(state, colored);
     let label_cell = format!("{:<width$}", label(state), width = STATE_WIDTH);
 
+    (style.styled_mark(), style.paint(&label_cell))
+}
+
+/// Paints `text` in the grey reserved for secondary text.
+///
+/// Reason text, the `--watch` timestamp, and the transition arrow all share
+/// this one grey, so nothing but the state itself competes for attention on
+/// a transition line.
+fn dim(text: &str, colored: bool) -> String {
     if colored {
-        (color(unicode_mark), color(&label_cell))
+        text.truecolor(127, 127, 127).to_string()
     } else {
-        (ascii_mark.to_string(), label_cell)
+        text.to_string()
     }
 }
 
@@ -206,12 +252,7 @@ fn print_reason_lines(reasons: &[Reason], colored: bool, wrap_width: Option<usiz
         };
 
         for line in lines {
-            let styled = if colored {
-                line.truecolor(127, 127, 127).to_string()
-            } else {
-                line
-            };
-            println!("{indent}{styled}");
+            println!("{indent}{}", dim(&line, colored));
         }
     }
 }

--- a/cli/modules/ready/src/render/watch.rs
+++ b/cli/modules/ready/src/render/watch.rs
@@ -4,11 +4,17 @@
 use std::collections::BTreeMap;
 
 use chrono::Local;
-use colored::Colorize;
 use readinesspb::pb::{Scope, State};
 use ync::{display, output};
 
-use super::layout::{normalize_whitespace, wrap_words};
+use super::{
+    StateStyle, Symbols, dim,
+    layout::{normalize_whitespace, wrap_words},
+};
+
+/// Gap between the transition line's prefix and the reason text that follows
+/// it on the same line.
+const REASON_GAP: usize = 3;
 
 /// The kind of change observed for one scope in a `--watch` delta message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -38,6 +44,57 @@ pub fn record_transition(snapshot: &mut BTreeMap<String, Scope>, scope: &Scope) 
     }
 }
 
+/// The transition line's prefix in both of its forms.
+///
+/// `plain` carries no ANSI escapes and is the only form ever measured;
+/// `styled` is the only form ever printed. Measuring `styled` would count
+/// the escape bytes as columns and blow up the hanging indent.
+struct Prefix {
+    plain: String,
+    styled: String,
+}
+
+/// Builds the `HH:MM:SS  ✗ name  PREV → NEXT` prefix of a transition line.
+///
+/// `name` must already be padded to the scope-name column width. Every part
+/// is rendered twice from the same text: once bare for [`Prefix::plain`] and
+/// once through [`StateStyle`] for [`Prefix::styled`], so the two can never
+/// disagree on the visible width. The mark and both state labels are colored
+/// by their own state — the previous label keeps its old state's color — and
+/// the timestamp and arrow stay grey.
+fn transition_prefix(timestamp: &str, name: &str, state: State, transition: Transition, colored: bool) -> Prefix {
+    let symbols = Symbols::new(colored);
+    let style = StateStyle::new(state, colored);
+    let label = super::label(state);
+
+    let (change, styled_change) = match transition {
+        Transition::StateChanged { previous } => {
+            let previous_style = StateStyle::new(previous, colored);
+            let previous_label = super::label(previous);
+
+            (
+                format!("{previous_label} {} {label}", symbols.arrow),
+                format!(
+                    "{} {} {}",
+                    previous_style.paint(previous_label),
+                    dim(symbols.arrow, colored),
+                    style.paint(label)
+                ),
+            )
+        }
+        Transition::ReasonChanged => (label.to_string(), style.paint(label)),
+    };
+
+    Prefix {
+        plain: format!("{timestamp}  {} {name} {change}", style.mark),
+        styled: format!(
+            "{}  {} {name} {styled_change}",
+            dim(timestamp, colored),
+            style.styled_mark()
+        ),
+    }
+}
+
 /// Prints one append-only log line for a `--watch` change.
 ///
 /// A state change shows `PREV → NEXT` on the transition line; a reason-only
@@ -49,23 +106,15 @@ pub fn record_transition(snapshot: &mut BTreeMap<String, Scope>, scope: &Scope) 
 /// prints just the transition line.
 pub fn print_transition_line(scope: &Scope, name_width: usize, transition: Transition) {
     let colored = output::is_colored();
-    let symbols = super::Symbols::new(colored);
     let wrap_width = display::terminal_width();
-    let timestamp = Local::now().format("%H:%M:%S");
+    let timestamp = Local::now().format("%H:%M:%S").to_string();
     let state = State::try_from(scope.state).unwrap_or_default();
     let name = format!("{:<width$}", scope.name, width = name_width);
 
-    let change = match transition {
-        Transition::StateChanged { previous } => {
-            format!("{} {} {}", super::label(previous), symbols.arrow, super::label(state))
-        }
-        Transition::ReasonChanged => super::label(state).to_string(),
-    };
+    let prefix = transition_prefix(&timestamp, &name, state, transition, colored);
+    let indent = prefix.plain.chars().count() + REASON_GAP;
 
-    let prefix = format!("{timestamp}  {name}  {change}");
-    let indent = prefix.chars().count() + 3;
-
-    print!("{prefix}");
+    print!("{}", prefix.styled);
 
     let mut is_first_line = true;
     for reason in &scope.reasons {
@@ -77,14 +126,10 @@ pub fn print_transition_line(scope: &Scope, name_width: usize, transition: Trans
         };
 
         for line in &lines {
-            let styled = if colored {
-                line.truecolor(127, 127, 127).to_string()
-            } else {
-                line.clone()
-            };
+            let styled = dim(line, colored);
 
             if is_first_line {
-                print!("   {styled}");
+                print!("{:width$}{styled}", "", width = REASON_GAP);
                 is_first_line = false;
             } else {
                 print!("\n{:indent$}{styled}", "");
@@ -107,6 +152,79 @@ mod test {
             observed_at: None,
             last_transition_time: None,
         }
+    }
+
+    /// Drops every ANSI SGR escape (`ESC [ … m`) from `text`, leaving the
+    /// characters a terminal would actually show.
+    fn strip_ansi(text: &str) -> String {
+        let mut visible = String::new();
+        let mut chars = text.chars();
+
+        while let Some(c) = chars.next() {
+            if c != '\x1b' {
+                visible.push(c);
+                continue;
+            }
+
+            for escaped in chars.by_ref() {
+                if escaped == 'm' {
+                    break;
+                }
+            }
+        }
+
+        visible
+    }
+
+    #[test]
+    fn transition_prefix_colors_do_not_change_the_measured_width() {
+        colored::control::set_override(true);
+
+        let prefix = transition_prefix(
+            "14:32:11",
+            "rib         ",
+            State::NotReady,
+            Transition::StateChanged { previous: State::Ready },
+            true,
+        );
+
+        assert_eq!(prefix.plain, strip_ansi(&prefix.styled));
+        assert!(!prefix.plain.contains('\x1b'));
+        assert!(prefix.styled.contains('\x1b'));
+    }
+
+    #[test]
+    fn transition_prefix_uncolored_is_ascii_and_escape_free() {
+        let prefix = transition_prefix(
+            "14:32:11",
+            "rib         ",
+            State::NotReady,
+            Transition::StateChanged { previous: State::Ready },
+            false,
+        );
+
+        assert_eq!(prefix.plain, prefix.styled);
+        assert!(prefix.plain.is_ascii());
+        assert!(prefix.plain.contains("[xx]"));
+        assert!(prefix.plain.contains("->"));
+    }
+
+    #[test]
+    fn transition_prefix_reason_only_change_keeps_one_label() {
+        colored::control::set_override(true);
+
+        let prefix = transition_prefix(
+            "14:32:11",
+            "rib         ",
+            State::Degraded,
+            Transition::ReasonChanged,
+            true,
+        );
+
+        assert_eq!(prefix.plain, strip_ansi(&prefix.styled));
+        assert!(prefix.plain.contains(StateStyle::new(State::Degraded, true).mark));
+        assert!(prefix.plain.contains("rib"));
+        assert!(!prefix.plain.contains(Symbols::new(true).arrow));
     }
 
     #[test]


### PR DESCRIPTION
The streaming readiness log printed every transition in plain text, so the one thing worth spotting in a stream — a scope leaving or entering the ready state — carried no visual signal, even though the snapshot block above it was already colored.

Each transition line now opens with the state mark and paints the old and the new state in their own colors, keeping the timestamp, the arrow and the reason text muted.

The state-to-color mapping moves to a single place, so the streaming log and the snapshot block can no longer disagree on how a state looks.

Colors and glyphs still degrade together to plain ASCII when the output is not a terminal, and the reason text still wraps against the visible width of the line rather than its escape-laden length.