### PR TITLE
refactor(dataplane): embed scheduling packet front into chain and pipeline contexts

### DIFF
--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -568,7 +568,9 @@ function_ectx_create(
 		for (uint64_t weight_idx = 0;
 		     weight_idx < cp_function->chains[idx].weight;
 		     ++weight_idx) {
-			function_ectx->chain_map[pos] = idx;
+			SET_OFFSET_OF(
+				function_ectx->chain_map + pos, chain_ectx
+			);
 			++pos;
 		}
 	}

--- a/lib/dataplane/module/packet_front.h
+++ b/lib/dataplane/module/packet_front.h
@@ -63,6 +63,12 @@ packet_front_init(struct packet_front *packet_front) {
 	packet_front->drop_bytes = 0;
 }
 
+// Move the whole output, drop and pending lists from src into dst, transferring
+// the counters, and leave src empty.
+//
+// Zeroing src lets a scratch front be reused across rounds without a separate
+// per-round reset: merge moves every packet and counter out, so nothing stale
+// survives into the next round.
 static inline void
 packet_front_merge(struct packet_front *dst, struct packet_front *src) {
 	packet_list_concat(&dst->output, &src->output);
@@ -78,6 +84,8 @@ packet_front_merge(struct packet_front *dst, struct packet_front *src) {
 	dst->output_bytes += src->output_bytes;
 	dst->drop_count += src->drop_count;
 	dst->drop_bytes += src->drop_bytes;
+
+	packet_front_init(src);
 }
 
 static inline void

--- a/lib/dataplane/packet/packet.h
+++ b/lib/dataplane/packet/packet.h
@@ -62,13 +62,16 @@ struct packet_list {
 static inline void
 packet_list_init(struct packet_list *list) {
 	list->first = NULL;
-	list->last = &list->first;
+	list->last = NULL;
 }
 
 static inline void
 packet_list_add(struct packet_list *list, struct packet *packet) {
-	*list->last = packet;
 	packet->next = NULL;
+	if (list->last == NULL) {
+		list->last = &list->first;
+	}
+	*list->last = packet;
 	list->last = &packet->next;
 }
 
@@ -105,7 +108,7 @@ packet_list_pop(struct packet_list *packets) {
 
 	packets->first = res->next;
 	if (packets->first == NULL)
-		packets->last = &packets->first;
+		packets->last = NULL;
 
 	return res;
 }

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -5,6 +5,7 @@
 #include "common/memory_address.h"
 #include "lib/dataplane/device/device.h"
 #include "lib/dataplane/module/module.h"
+#include "lib/dataplane/module/packet_front.h"
 
 #include "lib/dataplane/counters/module.h"
 
@@ -65,6 +66,7 @@ struct chain_ectx {
 	struct counter_value_handle *counter_packet_pending_input;
 	struct counter_value_handle *counter_packet_pending_output;
 	uint64_t length;
+	struct packet_front schedule;
 	struct chain_module_ectx modules[];
 };
 
@@ -79,7 +81,7 @@ struct function_ectx {
 	uint64_t chain_count;
 	struct chain_ectx **chains;
 	uint64_t chain_map_size;
-	uint64_t chain_map[];
+	struct chain_ectx *chain_map[];
 };
 
 struct pipeline_ectx {
@@ -91,6 +93,7 @@ struct pipeline_ectx {
 	struct counter_value_handle *counter_packet_pending_output;
 	struct counter_storage *counter_storage;
 	uint64_t length;
+	struct packet_front schedule;
 	struct function_ectx *functions[];
 };
 

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -166,14 +166,15 @@ function_ectx_run_single_chain(
 	struct function_ectx *function_ectx,
 	struct packet_front *packet_front
 ) {
-	struct packet_front schedule;
-	packet_front_init(&schedule);
-	packet_front_take_output(&schedule, packet_front);
-
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
-	chain_ectx_process(dp_worker, ADDR_OF(chains), &schedule);
+	struct chain_ectx *chain_ectx = ADDR_OF(chains);
 
-	packet_front_merge(packet_front, &schedule);
+	struct packet_front *schedule = &chain_ectx->schedule;
+	packet_front_take_output(schedule, packet_front);
+
+	chain_ectx_process(dp_worker, chain_ectx, schedule);
+
+	packet_front_merge(packet_front, schedule);
 }
 
 // Demultiplex packets across the function's chains by hash.
@@ -186,29 +187,29 @@ function_ectx_run_chains(
 	struct function_ectx *function_ectx,
 	struct packet_front *packet_front
 ) {
-	// FIXME: do not create schedule for each invocation
-	struct packet_front schedule[function_ectx->chain_count];
-	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx)
-		packet_front_init(schedule + idx);
-
 	struct packet *packet = packet_list_pop(&packet_front->output);
 	while (packet != NULL) {
-		uint64_t chain_idx =
-			function_ectx->chain_map
-				[packet->hash % function_ectx->chain_map_size];
-		packet_front_output(schedule + chain_idx, packet);
+		uint64_t map_idx = packet->hash % function_ectx->chain_map_size;
+
+		struct chain_ectx *chain_ectx =
+			ADDR_OF(function_ectx->chain_map + map_idx);
+		packet_front_output(&chain_ectx->schedule, packet);
+
 		packet = packet_list_pop(&packet_front->output);
 	}
 	packet_front->output_count = 0;
 	packet_front->output_bytes = 0;
 
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
+
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
 		struct chain_ectx *chain_ectx = ADDR_OF(chains + idx);
 
-		chain_ectx_process(dp_worker, chain_ectx, schedule + idx);
+		chain_ectx_process(
+			dp_worker, chain_ectx, &chain_ectx->schedule
+		);
 
-		packet_front_merge(packet_front, schedule + idx);
+		packet_front_merge(packet_front, &chain_ectx->schedule);
 	}
 }
 
@@ -347,14 +348,15 @@ device_entry_ectx_dispatch_single(
 	struct device_entry_ectx *entry_ectx,
 	struct packet_front *packet_front
 ) {
-	struct packet_front schedule;
-	packet_front_init(&schedule);
-	packet_front_take_output(&schedule, packet_front);
-
 	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
-	pipeline_ectx_process(dp_worker, ADDR_OF(pipelines), &schedule);
+	struct pipeline_ectx *pipeline_ectx = ADDR_OF(pipelines);
 
-	packet_front_merge(packet_front, &schedule);
+	struct packet_front *schedule = &pipeline_ectx->schedule;
+	packet_front_take_output(schedule, packet_front);
+
+	pipeline_ectx_process(dp_worker, pipeline_ectx, schedule);
+
+	packet_front_merge(packet_front, schedule);
 }
 
 // Demultiplex the handler output across the entry's pipelines by hash.
@@ -367,11 +369,7 @@ device_entry_ectx_dispatch_many(
 	struct device_entry_ectx *entry_ectx,
 	struct packet_front *packet_front
 ) {
-	// FIXME do not create front for each invocation
-	struct packet_front schedule[entry_ectx->pipeline_count];
-	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
-		packet_front_init(schedule + idx);
-	}
+	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
 
 	struct packet *packet = packet_list_pop(&packet_front->output);
 	while (packet != NULL) {
@@ -379,20 +377,23 @@ device_entry_ectx_dispatch_many(
 			entry_ectx->pipeline_map
 				[packet->hash % entry_ectx->pipeline_map_size];
 
-		packet_front_output(schedule + pipeline_idx, packet);
+		struct pipeline_ectx *pipeline_ectx =
+			ADDR_OF(pipelines + pipeline_idx);
+		packet_front_output(&pipeline_ectx->schedule, packet);
 
 		packet = packet_list_pop(&packet_front->output);
 	}
 	packet_front->output_count = 0;
 	packet_front->output_bytes = 0;
 
-	struct pipeline_ectx **pipelines = ADDR_OF(&entry_ectx->pipelines);
 	for (uint64_t idx = 0; idx < entry_ectx->pipeline_count; ++idx) {
 		struct pipeline_ectx *pipeline_ectx = ADDR_OF(pipelines + idx);
 
-		pipeline_ectx_process(dp_worker, pipeline_ectx, schedule + idx);
+		pipeline_ectx_process(
+			dp_worker, pipeline_ectx, &pipeline_ectx->schedule
+		);
 
-		packet_front_merge(packet_front, schedule + idx);
+		packet_front_merge(packet_front, &pipeline_ectx->schedule);
 	}
 }
 


### PR DESCRIPTION
The dispatch scratch front used to fan packets out across the chains of a
function and the pipelines of a device entry lived in a parallel array on
the parent context, indexed by child position, and was reallocated on
every pipeline round. Move it into each chain and pipeline execution
context as an embedded field so every context owns the front it runs on
and it is reused across rounds.

This drops the separate allocation and free for those arrays and lets the
front be reached directly from the child context in the single-chain and
single-pipeline fast paths.

Now that merging a front moves every packet and counter out and leaves the
source empty, the per-round reset in the device-entry dispatch paths no
longer has anything to clear, and the create-time initialization of the
chain schedule front is already covered by the zeroing allocation. Remove
both so every dispatch path relies on the same create-time zero plus
merge-cleanup contract.
