### PR TITLE
feat(cli): discover readiness services in yanet-cli ready

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3571,9 +3571,12 @@ dependencies = [
  "colored",
  "humantime",
  "prost-types",
+ "serde",
  "tokio",
+ "tonic",
  "yanet-cli",
  "yanet-readinesspb",
+ "yanet-ynpb",
 ]
 
 [[package]]

--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -87,14 +87,67 @@ pub struct Connection {
 impl Connection {
     /// Establish the authenticated channel to `args.endpoint`.
     pub async fn connect(args: &ConnectionArgs) -> Result<Self, Error> {
+        Self::connect_for(args, "connect").await
+    }
+
+    /// Establish the channel, blaming a failure on `action` rather than the
+    /// connect step.
+    ///
+    /// The dynamic-dispatch helpers report the verb the user asked for (e.g.
+    /// `ready`) all the way through, so they name their own action here. So
+    /// does a CLI that connects once and then dispatches several RPCs over
+    /// that one connection: a connect failure must read the same as an RPC
+    /// failure of the same command.
+    pub async fn connect_for(args: &ConnectionArgs, action: &str) -> Result<Self, Error> {
         let channel = connect(args)
             .await
-            .map_err(|err| Error::from_connection(err, "connect", &args.endpoint))?;
+            .map_err(|err| Error::from_connection(err, action, &args.endpoint))?;
 
         Ok(Self {
             channel,
             endpoint: args.endpoint.clone(),
         })
+    }
+
+    /// Invoke a unary RPC on an arbitrary gRPC service over this connection.
+    ///
+    /// The dispatch is the free [`invoke_unary`]'s, minus the connect: a CLI
+    /// probing several services builds one [`Connection`] and calls this per
+    /// service, so they all share a single channel.
+    pub async fn invoke_unary<Req, Resp>(
+        &self,
+        action: &str,
+        service: &str,
+        method: &str,
+        request: Req,
+    ) -> Result<Resp, Error>
+    where
+        Req: Message + 'static,
+        Resp: Message + Default + 'static,
+    {
+        let mut grpc = Grpc::new(self.channel.clone())
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip);
+
+        let path = PathAndQuery::try_from(format!("/{service}/{method}")).map_err(|err| {
+            Error::from_status(
+                Status::invalid_argument(err.to_string()),
+                action,
+                &self.endpoint,
+                service,
+            )
+        })?;
+
+        grpc.ready()
+            .await
+            .map_err(|err| Error::from_status(Status::unavailable(err.to_string()), action, &self.endpoint, service))?;
+
+        let codec: ProstCodec<Req, Resp> = ProstCodec::default();
+
+        grpc.unary(Request::new(request), path, codec)
+            .await
+            .map(|response| response.into_inner())
+            .map_err(|status| Error::from_status(status, action, &self.endpoint, service))
     }
 }
 
@@ -210,35 +263,10 @@ where
     Req: Message + 'static,
     Resp: Message + Default + 'static,
 {
-    let endpoint = connection.endpoint.clone();
-
-    let channel = connect(connection)
+    Connection::connect_for(connection, action)
+        .await?
+        .invoke_unary(action, service, method, request)
         .await
-        .map_err(|err| Error::from_connection(err, action, endpoint.clone()))?;
-
-    let mut grpc = Grpc::new(channel)
-        .send_compressed(CompressionEncoding::Gzip)
-        .accept_compressed(CompressionEncoding::Gzip);
-
-    let path = PathAndQuery::try_from(format!("/{service}/{method}")).map_err(|err| {
-        Error::from_status(
-            Status::invalid_argument(err.to_string()),
-            action,
-            endpoint.clone(),
-            service,
-        )
-    })?;
-
-    grpc.ready()
-        .await
-        .map_err(|err| Error::from_status(Status::unavailable(err.to_string()), action, endpoint.clone(), service))?;
-
-    let codec: ProstCodec<Req, Resp> = ProstCodec::default();
-
-    grpc.unary(Request::new(request), path, codec)
-        .await
-        .map(|response| response.into_inner())
-        .map_err(|status| Error::from_status(status, action, endpoint, service))
 }
 
 /// Invoke a server-streaming RPC on an arbitrary gRPC service by its

--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -150,6 +150,67 @@ impl Error {
         }
     }
 
+    /// Build an [`Error`] the CLI decided on itself, carrying an explicit
+    /// `kind`.
+    ///
+    /// No RPC was issued, so there is no `tonic::Status` to map from and no
+    /// service to name. Pass the `kind` the gateway would have reported for
+    /// the same condition — an alias resolved against the live registry that
+    /// matches nothing means exactly what the gateway's `unknown service`
+    /// means — so that both spellings of a condition exit with one code.
+    /// [`Error::invalid_argument`] is the shorthand for the common case.
+    pub fn new(
+        kind: ErrorKind,
+        action: impl Into<String>,
+        endpoint: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            action: action.into(),
+            kind,
+            message: message.into(),
+            endpoint: Some(endpoint.into()),
+            service: None,
+            hint: default_hint(kind),
+            raw_code: None,
+            raw_message: None,
+        }
+    }
+
+    /// Build an [`Error`] for input the CLI rejected before issuing any RPC.
+    ///
+    /// Unlike [`Error::from_status`] no service is named: the input was wrong
+    /// on its own terms — a malformed value, an impossible flag combination —
+    /// so the endpoint is the only context worth carrying.
+    pub fn invalid_argument(
+        action: impl Into<String>,
+        endpoint: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(ErrorKind::InvalidArgument, action, endpoint, message)
+    }
+
+    /// Attach `hint`, replacing the default hint for this error kind.
+    ///
+    /// For the call sites that know more than the generic status mapping can
+    /// — the readiness CLI, say, which can name the services the gateway
+    /// actually has. A multi-line hint renders as aligned continuation lines.
+    pub fn with_hint(mut self, hint: impl Into<String>) -> Self {
+        self.hint = Some(hint.into());
+
+        self
+    }
+
+    /// The category this error was mapped to.
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// The human-readable message from the RPC or transport layer.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
     /// Process exit code for this error.
     pub fn exit_code(&self) -> i32 {
         self.kind.exit_code()
@@ -223,9 +284,30 @@ impl NotFoundMapper {
 mod test {
     use tonic::Status;
 
-    use super::{ErrorKind, NotFoundMapper};
+    use super::{Error, ErrorKind, NotFoundMapper};
 
     const MAPPER: NotFoundMapper = NotFoundMapper::new("test.Service", "requested item");
+
+    #[test]
+    fn new_carries_the_requested_kind() {
+        let err = Error::new(
+            ErrorKind::ServiceUnregistered,
+            "ready",
+            "grpc://[::1]:8080",
+            "unknown readiness service",
+        );
+
+        assert_eq!(ErrorKind::ServiceUnregistered, err.kind());
+        assert_eq!(3, err.exit_code());
+    }
+
+    #[test]
+    fn invalid_argument_is_an_invalid_argument() {
+        let err = Error::invalid_argument("ready", "grpc://[::1]:8080", "bad input");
+
+        assert_eq!(ErrorKind::InvalidArgument, err.kind());
+        assert_eq!(1, err.exit_code());
+    }
 
     #[test]
     fn not_found_resource_is_rewritten() {

--- a/cli/modules/ready/Cargo.toml
+++ b/cli/modules/ready/Cargo.toml
@@ -12,11 +12,14 @@ path = "src/main.rs"
 
 [dependencies]
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
+ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 readinesspb = { path = "../../../common/rust/readinesspb", version = "0.1", package = "yanet-readinesspb" }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost-types = "0.13"
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
+tonic = { version = "0.13", features = ["gzip"] }
 colored = "3"
 chrono = "0.4"
 humantime = "2"

--- a/cli/modules/ready/src/discovery.rs
+++ b/cli/modules/ready/src/discovery.rs
@@ -1,0 +1,178 @@
+//! Gateway-driven discovery of readiness services.
+//!
+//! The gateway registry holds one entry per registered gRPC service name, so
+//! the readiness services are simply the entries whose name ends in
+//! `ReadinessService`: the built-in one plus one per running operator. That
+//! list is what the CLI probes when no service is named, what a short alias
+//! resolves against, and what an error hint suggests.
+
+use tonic::codec::CompressionEncoding;
+use ync::{
+    client::{Connection, LayeredChannel, Service},
+    errors::Error,
+};
+use ynpb::pb::{ListServicesRequest, gateway_client::GatewayClient};
+
+/// Fully-qualified name of the gateway registry service.
+///
+/// Taken from the `Gateway` service declaration in
+/// `controlplane/ynpb/v1/gateway.proto`, the wire contract — not from the
+/// generated tonic module name, which is a Rust-side artefact.
+const GATEWAY_SERVICE: &str = "controlplane.ynpb.v1.Gateway";
+
+/// Trailing segment of every readiness service's fully-qualified name.
+const READINESS_SERVICE: &str = "ReadinessService";
+
+/// Outcome of resolving a short alias against the discovered services.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// Exactly one service matched the alias.
+    Resolved(String),
+    /// Several services matched; these are the candidates.
+    Ambiguous(Vec<String>),
+    /// No service matched.
+    Unknown,
+}
+
+/// Lists the fully-qualified names of the readiness services registered with
+/// the gateway, sorted.
+///
+/// The sort makes the aggregate probe order — and hence the rendered blocks —
+/// stable across runs, since the registry itself is unordered.
+pub async fn list_readiness_services(connection: &Connection) -> Result<Vec<String>, Error> {
+    let mut service = Service::new(connection, GATEWAY_SERVICE, |channel: LayeredChannel| {
+        GatewayClient::new(channel)
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip)
+    });
+
+    let response = service
+        .client()
+        .list_services(ListServicesRequest {})
+        .await
+        .map_err(service.status("discover"))?
+        .into_inner();
+
+    let mut services: Vec<String> = response
+        .services
+        .iter()
+        .filter_map(|registered| registered.backend.as_ref())
+        .map(|backend| backend.name.as_str())
+        .filter(|name| is_readiness_service(name))
+        .map(str::to_owned)
+        .collect();
+
+    services.sort();
+    services.dedup();
+
+    Ok(services)
+}
+
+/// Reports whether `name` is a readiness service's fully-qualified name.
+///
+/// The last dot-separated segment must be exactly `ReadinessService`, so a
+/// service that merely mentions readiness elsewhere in its name is not
+/// mistaken for one.
+fn is_readiness_service(name: &str) -> bool {
+    name.rsplit('.').next() == Some(READINESS_SERVICE)
+}
+
+/// Resolves a short alias (e.g. `route`) against the discovered `services`.
+///
+/// A service matches when its name contains the alias as a case-insensitive
+/// substring, which lets both an operator name (`forward`) and a package
+/// segment (`controlplane`) select their service without spelling out the
+/// whole FQN.
+pub fn resolve_alias(alias: &str, services: &[String]) -> Resolution {
+    let alias = alias.to_lowercase();
+
+    let mut matched: Vec<String> = services
+        .iter()
+        .filter(|service| service.to_lowercase().contains(&alias))
+        .cloned()
+        .collect();
+
+    match matched.len() {
+        0 => Resolution::Unknown,
+        1 => Resolution::Resolved(matched.remove(0)),
+        _ => Resolution::Ambiguous(matched),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn services() -> Vec<String> {
+        vec![
+            "controlplane.ynpb.v1.ReadinessService".to_owned(),
+            "operators.decap.operatorpb.v1.ReadinessService".to_owned(),
+            "operators.forward.operatorpb.v1.ReadinessService".to_owned(),
+            "operators.pipeline.operatorpb.v1.ReadinessService".to_owned(),
+            "operators.route.operatorpb.v1.ReadinessService".to_owned(),
+        ]
+    }
+
+    #[test]
+    fn readiness_service_is_recognised_by_its_last_segment() {
+        assert!(is_readiness_service("controlplane.ynpb.v1.ReadinessService"));
+        assert!(is_readiness_service("operators.route.operatorpb.v1.ReadinessService"));
+    }
+
+    #[test]
+    fn other_services_are_not_readiness_services() {
+        assert!(!is_readiness_service("controlplane.ynpb.v1.Gateway"));
+        assert!(!is_readiness_service("operators.route.operatorpb.v1.MetricsService"));
+        assert!(!is_readiness_service(
+            "operators.route.operatorpb.v1.ReadinessServiceV2"
+        ));
+        assert!(!is_readiness_service("ReadinessService.operators.route"));
+    }
+
+    #[test]
+    fn alias_resolves_to_the_only_match() {
+        assert_eq!(
+            Resolution::Resolved("operators.route.operatorpb.v1.ReadinessService".to_owned()),
+            resolve_alias("route", &services())
+        );
+    }
+
+    #[test]
+    fn alias_resolution_ignores_case() {
+        assert_eq!(
+            Resolution::Resolved("operators.decap.operatorpb.v1.ReadinessService".to_owned()),
+            resolve_alias("DeCap", &services())
+        );
+    }
+
+    #[test]
+    fn package_segment_resolves_the_built_in_service() {
+        assert_eq!(
+            Resolution::Resolved("controlplane.ynpb.v1.ReadinessService".to_owned()),
+            resolve_alias("controlplane", &services())
+        );
+    }
+
+    #[test]
+    fn alias_matching_several_services_is_ambiguous() {
+        assert_eq!(
+            Resolution::Ambiguous(vec![
+                "operators.decap.operatorpb.v1.ReadinessService".to_owned(),
+                "operators.forward.operatorpb.v1.ReadinessService".to_owned(),
+                "operators.pipeline.operatorpb.v1.ReadinessService".to_owned(),
+                "operators.route.operatorpb.v1.ReadinessService".to_owned(),
+            ]),
+            resolve_alias("operatorpb", &services())
+        );
+    }
+
+    #[test]
+    fn unmatched_alias_is_unknown() {
+        assert_eq!(Resolution::Unknown, resolve_alias("balancer", &services()));
+    }
+
+    #[test]
+    fn any_alias_is_unknown_without_discovered_services() {
+        assert_eq!(Resolution::Unknown, resolve_alias("route", &[]));
+    }
+}

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -4,34 +4,69 @@ use core::time::Duration;
 use std::collections::BTreeMap;
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    CompleteEnv,
+    engine::{ArgValueCandidates, CompletionCandidate},
+};
 use colored::Colorize;
 use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope, State};
+use serde::Serialize;
 use ync::{
-    client::ConnectionArgs,
-    errors::Error,
+    client::{self, Connection, ConnectionArgs},
+    errors::{Error, ErrorKind},
     output::{self, CommonFormat},
 };
 
+use self::discovery::Resolution;
+
+mod discovery;
 mod render;
 
 /// Exit code used when the RPC succeeds but not all scopes are `STATE_READY`.
 const EXIT_NOT_READY: i32 = 2;
 
+/// Caption of the hint that lists every discovered readiness service.
+const AVAILABLE_SERVICES: &str = "available readiness services:";
+
+/// Budget for a best-effort gateway lookup: an error hint, a shell completion.
+///
+/// Such a lookup only enriches something the CLI can do without, so it must
+/// never be the thing that hangs: a flag-validation error or a tab press would
+/// otherwise stall against a slow or blackholed endpoint until the transport
+/// gives up. Exceeding the budget is simply a failed lookup — the hint or the
+/// candidate list is dropped and the caller carries on. A probe the user did
+/// ask for gets no such budget: there a slow gateway must surface as the error
+/// it is.
+const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(1);
+
 /// Generic readiness probe — calls `Ready` on any `ReadinessService`.
 ///
 /// Connects to the gateway and invokes `/<FQN>/Ready` using tonic's low-level
 /// dynamic dispatcher with the shared `readinesspb` message types. No
-/// per-service generated client is needed.
+/// per-service generated client is needed. The services to probe are
+/// discovered from the gateway registry, so neither the user nor the CLI has
+/// to keep a list of them.
 #[derive(Debug, Clone, Parser)]
 #[command(version, about)]
 #[command(flatten_help = true)]
 pub struct Cmd {
-    /// Fully-qualified gRPC service name, e.g.
-    /// `operators.forward.operatorpb.v1.ReadinessService`.
-    pub name: String,
+    /// Readiness service to probe: either a fully-qualified gRPC service name
+    /// (e.g. `operators.forward.operatorpb.v1.ReadinessService`) or a short
+    /// alias matched against the discovered services (e.g. `forward`).
+    ///
+    /// Omit it to probe every discovered readiness service.
+    #[arg(value_name = "SERVICE", add = ArgValueCandidates::new(service_candidates))]
+    pub name: Option<String>,
     /// Restrict output to these scope names; empty means all.
+    ///
+    /// Only meaningful together with an explicit service.
     pub scopes: Vec<String>,
+    /// Probe every readiness service registered with the gateway.
+    ///
+    /// This is what happens anyway when no service is named; the flag only
+    /// says so out loud.
+    #[arg(long, default_value_t = false, conflicts_with = "name")]
+    pub all: bool,
     #[command(flatten)]
     pub connection: ConnectionArgs,
     /// Output format.
@@ -42,6 +77,9 @@ pub struct Cmd {
     pub verbose: u8,
     /// Stream readiness changes until interrupted instead of exiting after one
     /// snapshot.
+    ///
+    /// Requires a single service: several interleaved transition logs would be
+    /// unreadable.
     #[arg(long, default_value_t = false)]
     pub watch: bool,
     /// Minimum time since a scope was last observed before flagging it
@@ -56,6 +94,28 @@ pub struct Cmd {
     /// disables the tag.
     #[arg(long, default_value = "15m", value_parser = parse_duration)]
     pub stale_after: Duration,
+}
+
+impl Cmd {
+    /// Whether every discovered service is to be probed.
+    ///
+    /// Naming no service means the same thing as `--all`, which is why the two
+    /// are mutually exclusive rather than one requiring the other.
+    fn is_aggregate(&self) -> bool {
+        self.all || self.name.is_none()
+    }
+}
+
+/// One service's outcome in the aggregate probe.
+///
+/// `error` is set instead of `scopes` when that one service could not be
+/// probed; the run itself still succeeds, so a single dead operator cannot
+/// hide the state of the others.
+#[derive(Debug, Serialize)]
+struct ServiceReport {
+    service: String,
+    scopes: Vec<Scope>,
+    error: Option<String>,
 }
 
 /// Parses a CLI duration flag via `humantime`.
@@ -81,25 +141,70 @@ pub async fn main() {
     }
 }
 
-/// Run the readiness probe, dispatching to one-shot or streaming mode.
+/// Run the readiness probe, dispatching to aggregate or single-service mode.
+///
+/// The single-service mode establishes one connection and drives everything it
+/// needs over it: resolving the alias, probing the service and enriching the
+/// error hint. A failure to establish it is reported as a failure of the verb
+/// the user asked for, `ready`, exactly like a failing probe.
 async fn run(cmd: Cmd) -> Result<bool, Error> {
-    if cmd.watch {
-        run_watch(cmd).await.map(|()| true)
+    if cmd.is_aggregate() {
+        return run_aggregate(cmd).await;
+    }
+
+    let name = cmd.name.clone().expect("a non-aggregate command names a service");
+
+    if is_blank(&name) {
+        return Err(Error::invalid_argument(
+            "ready",
+            &cmd.connection.endpoint,
+            "service name must not be empty",
+        ));
+    }
+
+    let connection = Connection::connect_for(&cmd.connection, "ready").await?;
+
+    let name = if name.contains('.') {
+        name
     } else {
-        run_once(cmd).await
+        resolve_alias(&cmd, &connection, &name).await?
+    };
+
+    run_service(&cmd, &connection, &name).await
+}
+
+/// Whether a service name is empty or whitespace only.
+///
+/// An empty name is a substring of every service, so as an alias it matches
+/// them all — and with a single readiness service registered it would resolve
+/// to that one and hand its readiness to the caller as the exit code of a probe
+/// they never asked for. `yanet-cli ready "$SERVICE"` on an unset variable is
+/// bad input rather than a registry condition, so it is rejected as such, and
+/// before anything is discovered.
+fn is_blank(name: &str) -> bool {
+    name.trim().is_empty()
+}
+
+/// Probes one service, one-shot or streaming, and suggests the services that
+/// do exist when the probe finds none under that name.
+async fn run_service(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool, Error> {
+    let result = if cmd.watch {
+        run_watch(cmd, name).await.map(|()| true)
+    } else {
+        run_once(cmd, connection, name).await
+    };
+
+    match result {
+        Ok(ready) => Ok(ready),
+        Err(err) => Err(suggest_services(connection, err).await),
     }
 }
 
 /// Run a single unary `Ready` call and return whether all scopes are ready.
-async fn run_once(cmd: Cmd) -> Result<bool, Error> {
-    let response: ReadyResponse = ync::client::invoke_unary(
-        &cmd.connection,
-        "ready",
-        &cmd.name,
-        "Ready",
-        ReadyRequest { scopes: cmd.scopes.clone() },
-    )
-    .await?;
+async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool, Error> {
+    let response: ReadyResponse = connection
+        .invoke_unary("ready", name, "Ready", ReadyRequest { scopes: cmd.scopes.clone() })
+        .await?;
 
     let returned_names: std::collections::HashSet<&str> =
         response.scopes.iter().map(|scope| scope.name.as_str()).collect();
@@ -111,7 +216,7 @@ async fn run_once(cmd: Cmd) -> Result<bool, Error> {
         .filter(|name| !returned_names.contains(name))
         .collect();
 
-    let all_scopes_ready = response.scopes.iter().all(|scope| scope.state == State::Ready as i32);
+    let all_scopes_ready = response.scopes.iter().all(is_ready);
 
     let all_ready = all_scopes_ready && missing.is_empty();
 
@@ -125,7 +230,7 @@ async fn run_once(cmd: Cmd) -> Result<bool, Error> {
 
             if !scopes.is_empty() {
                 let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
-                render::print_status_block(&cmd.name, &scopes, width, cmd.stale_after, false);
+                render::print_status_block(name, &scopes, width, cmd.stale_after, false);
             }
 
             print_missing(&missing);
@@ -141,14 +246,14 @@ async fn run_once(cmd: Cmd) -> Result<bool, Error> {
 /// the status block; each subsequent message carries only the scopes that
 /// changed and renders one append-only log line per scope. Returns `Ok(())`
 /// on clean stream close.
-async fn run_watch(cmd: Cmd) -> Result<(), Error> {
+async fn run_watch(cmd: &Cmd, name: &str) -> Result<(), Error> {
     let mut snapshot: BTreeMap<String, Scope> = BTreeMap::new();
     let mut name_width: Option<usize> = None;
 
-    ync::client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
+    client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
         &cmd.connection,
         "ready",
-        &cmd.name,
+        name,
         "Watch",
         ReadyRequest { scopes: cmd.scopes.clone() },
         |resp| {
@@ -165,7 +270,7 @@ async fn run_watch(cmd: Cmd) -> Result<(), Error> {
                             snapshot.insert(scope.name.clone(), scope.clone());
                         }
 
-                        render::print_status_block(&cmd.name, &scopes, width, cmd.stale_after, true);
+                        render::print_status_block(name, &scopes, width, cmd.stale_after, true);
                     }
                     Some(width) => {
                         for scope in &scopes {
@@ -178,6 +283,106 @@ async fn run_watch(cmd: Cmd) -> Result<(), Error> {
         },
     )
     .await
+}
+
+/// Probes every discovered readiness service over one shared connection.
+///
+/// The services are probed sequentially, in the sorted order discovery
+/// returns them in, and one failing probe does not abort the rest. The
+/// scope-name column is measured across every service at once so it cannot
+/// jitter from block to block.
+async fn run_aggregate(cmd: Cmd) -> Result<bool, Error> {
+    if cmd.watch {
+        return Err(watch_requires_service(&cmd).await);
+    }
+
+    let connection = Connection::connect_for(&cmd.connection, "ready").await?;
+    let services = discovery::list_readiness_services(&connection).await?;
+
+    let mut reports = Vec::with_capacity(services.len());
+    for service in services {
+        reports.push(probe(&connection, service).await);
+    }
+
+    let all_ready = all_ready(&reports);
+
+    output::data(
+        &reports,
+        reports.is_empty(),
+        format_args!("no readiness services registered"),
+        || {
+            let scopes = reports.iter().flat_map(|report| report.scopes.iter());
+            let width = render::name_width(scopes.map(|scope| scope.name.as_str()));
+
+            for (idx, report) in reports.iter().enumerate() {
+                if idx > 0 {
+                    println!();
+                }
+
+                print_report(report, width, cmd.stale_after);
+            }
+        },
+    );
+
+    Ok(all_ready)
+}
+
+/// Probes one service's `Ready` over the shared connection.
+async fn probe(connection: &Connection, service: String) -> ServiceReport {
+    let request = ReadyRequest { scopes: Vec::new() };
+
+    match connection
+        .invoke_unary::<_, ReadyResponse>("ready", &service, "Ready", request)
+        .await
+    {
+        Ok(response) => {
+            let mut scopes = response.scopes;
+            scopes.sort_by(|a, b| a.name.cmp(&b.name));
+
+            ServiceReport { service, scopes, error: None }
+        }
+        Err(err) => ServiceReport {
+            service,
+            scopes: Vec::new(),
+            error: Some(err.message().to_owned()),
+        },
+    }
+}
+
+/// Reports whether every scope of every probed service is ready.
+///
+/// A failed probe is never ready — its scopes are unknown, not absent — and
+/// neither is an empty set of services: `yanet-cli ready` exiting `0` must
+/// mean something was checked and found ready.
+fn all_ready(reports: &[ServiceReport]) -> bool {
+    !reports.is_empty()
+        && reports
+            .iter()
+            .all(|report| report.error.is_none() && report.scopes.iter().all(is_ready))
+}
+
+/// Reports whether `scope` is in `STATE_READY`.
+fn is_ready(scope: &Scope) -> bool {
+    scope.state == State::Ready as i32
+}
+
+/// Renders one service's block of the aggregate probe.
+fn print_report(report: &ServiceReport, name_width: usize, stale_after: Duration) {
+    match &report.error {
+        Some(message) => print_service_error(&report.service, message),
+        None => render::print_status_block(&report.service, &report.scopes, name_width, stale_after, false),
+    }
+}
+
+/// Prints the one-line stand-in for a service whose probe failed.
+fn print_service_error(service: &str, message: &str) {
+    let line = format!("{service}: {message}");
+
+    if output::is_colored() {
+        println!("{}", line.red());
+    } else {
+        println!("{line}");
+    }
 }
 
 /// Prints the red `missing (not registered): …` line for requested scopes
@@ -194,5 +399,267 @@ fn print_missing(missing: &[&str]) {
         println!("{} {}", label.red(), missing_list.red());
     } else {
         println!("{label} {missing_list}");
+    }
+}
+
+/// Resolves a short alias against the services the gateway knows.
+///
+/// An alias that matches nothing describes the same operational condition as a
+/// fully-qualified name the gateway does not know — that readiness service is
+/// not registered, its operator down or not yet up — because the alias is
+/// resolved against the live registry. It therefore carries the same kind the
+/// gateway's own answer would map to, so that a monitoring script gets one exit
+/// code for both spellings of the condition. An ambiguous alias, in contrast,
+/// really is bad input.
+async fn resolve_alias(cmd: &Cmd, connection: &Connection, alias: &str) -> Result<String, Error> {
+    let services = discovery::list_readiness_services(connection).await?;
+    let endpoint = &cmd.connection.endpoint;
+
+    match discovery::resolve_alias(alias, &services) {
+        Resolution::Resolved(name) => Ok(name),
+        Resolution::Ambiguous(candidates) => {
+            let message = format!("service name \"{alias}\" is ambiguous");
+
+            Err(Error::invalid_argument("ready", endpoint, message)
+                .with_hint(services_hint("matching readiness services:", &candidates)))
+        }
+        Resolution::Unknown => {
+            let message = format!("unknown readiness service \"{alias}\"");
+
+            Err(Error::new(ErrorKind::ServiceUnregistered, "ready", endpoint, message)
+                .with_hint(services_hint(AVAILABLE_SERVICES, &services)))
+        }
+    }
+}
+
+/// Builds the error for `--watch` without a single service to watch.
+///
+/// Discovery is best-effort here: the services it finds become the hint, and a
+/// gateway that cannot be reached — or does not answer within the budget
+/// `discover` gives it — simply leaves the error hintless. The flag
+/// combination is wrong either way, and reporting so must not wait on the
+/// network.
+async fn watch_requires_service(cmd: &Cmd) -> Error {
+    let err = Error::invalid_argument("ready", &cmd.connection.endpoint, "--watch requires a single service");
+
+    match discover(&cmd.connection).await {
+        Ok(services) => err.with_hint(services_hint(AVAILABLE_SERVICES, &services)),
+        Err(..) => err,
+    }
+}
+
+/// Adds the discovered services to `err`'s hint when it reads like the named
+/// service is simply not registered.
+///
+/// Best-effort: a failed discovery leaves `err` exactly as it was, so a
+/// gateway that is down still surfaces the original probe error rather than a
+/// second, more confusing one.
+async fn suggest_services(connection: &Connection, err: Error) -> Error {
+    if !matches!(err.kind(), ErrorKind::ServiceUnregistered | ErrorKind::NotFound) {
+        return err;
+    }
+
+    match discovery::list_readiness_services(connection).await {
+        Ok(services) => err.with_hint(services_hint(AVAILABLE_SERVICES, &services)),
+        Err(..) => err,
+    }
+}
+
+/// Connects to the gateway afresh and lists the readiness services it knows,
+/// within `DISCOVERY_TIMEOUT`.
+///
+/// This is the best-effort half of discovery, and the only half that has to
+/// establish its own connection: every caller reaches an endpoint nothing has
+/// spoken to yet, purely to enrich something — a hint, a completion — which is
+/// why the budget lives here rather than at the call sites. Discovery the user
+/// asked for runs over the `Connection` the probe already established and is
+/// deliberately unbounded.
+async fn discover(connection: &ConnectionArgs) -> Result<Vec<String>, Error> {
+    let lookup = async {
+        let connection = Connection::connect(connection).await?;
+
+        discovery::list_readiness_services(&connection).await
+    };
+
+    match tokio::time::timeout(DISCOVERY_TIMEOUT, lookup).await {
+        Ok(services) => services,
+        Err(..) => {
+            let budget = humantime::format_duration(DISCOVERY_TIMEOUT);
+            let message = format!("gateway did not answer within {budget}");
+
+            Err(Error::new(
+                ErrorKind::Unavailable,
+                "discover",
+                &connection.endpoint,
+                message,
+            ))
+        }
+    }
+}
+
+/// Formats a hint listing `services` one per line under `caption`.
+///
+/// `output::failure` aligns every hint line after the first under the first,
+/// so the names come out as a column.
+fn services_hint(caption: &str, services: &[String]) -> String {
+    if services.is_empty() {
+        return "no readiness services are registered with the gateway".to_owned();
+    }
+
+    let mut hint = String::from(caption);
+
+    for service in services {
+        hint.push('\n');
+        hint.push_str(service);
+    }
+
+    hint
+}
+
+/// Completion candidates for the service positional: the readiness services
+/// the gateway currently knows.
+///
+/// Strictly best-effort — a tab-completion must never print an error nor hang
+/// — so a gateway that is down, slow or refusing us auth yields no candidates
+/// at all, `discover`'s time budget covering the slow case. The endpoint comes
+/// from the defaults of the command's own flags, `YANET_ENDPOINT` included,
+/// since the completer cannot see what the user has typed so far.
+fn service_candidates() -> Vec<CompletionCandidate> {
+    let Ok(cmd) = Cmd::try_parse_from([env!("CARGO_BIN_NAME")]) else {
+        return Vec::new();
+    };
+
+    // The completer is called from within this binary's `#[tokio::main]`
+    // runtime, which forbids a nested `block_on`, so the lookup gets a thread
+    // and a runtime of its own. A panic in it joins as an error and, like
+    // every other failure here, yields no candidates.
+    let services = std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .ok()?;
+
+        runtime.block_on(discover(&cmd.connection)).ok()
+    })
+    .join()
+    .ok()
+    .flatten()
+    .unwrap_or_default();
+
+    services.into_iter().map(CompletionCandidate::new).collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn scope(name: &str, state: State) -> Scope {
+        Scope {
+            name: name.to_owned(),
+            state: state as i32,
+            reasons: Vec::new(),
+            observed_at: None,
+            last_transition_time: None,
+        }
+    }
+
+    fn report(service: &str, scopes: Vec<Scope>) -> ServiceReport {
+        ServiceReport {
+            service: service.to_owned(),
+            scopes,
+            error: None,
+        }
+    }
+
+    fn failed_report(service: &str) -> ServiceReport {
+        ServiceReport {
+            service: service.to_owned(),
+            scopes: Vec::new(),
+            error: Some("unknown service".to_owned()),
+        }
+    }
+
+    #[test]
+    fn all_ready_when_every_scope_of_every_service_is_ready() {
+        let reports = vec![
+            report("a", vec![scope("rib", State::Ready)]),
+            report("b", vec![scope("fib", State::Ready), scope("neighbours", State::Ready)]),
+        ];
+
+        assert!(all_ready(&reports));
+    }
+
+    #[test]
+    fn not_ready_when_one_scope_of_one_service_is_not_ready() {
+        let reports = vec![
+            report("a", vec![scope("rib", State::Ready)]),
+            report("b", vec![scope("fib", State::Degraded)]),
+        ];
+
+        assert!(!all_ready(&reports));
+    }
+
+    #[test]
+    fn not_ready_when_one_service_failed_to_be_probed() {
+        let reports = vec![report("a", vec![scope("rib", State::Ready)]), failed_report("b")];
+
+        assert!(!all_ready(&reports));
+    }
+
+    #[test]
+    fn not_ready_without_any_discovered_service() {
+        assert!(!all_ready(&[]));
+    }
+
+    #[test]
+    fn an_empty_service_name_is_blank() {
+        assert!(is_blank(""));
+    }
+
+    #[test]
+    fn a_whitespace_only_service_name_is_blank() {
+        assert!(is_blank("  \t "));
+    }
+
+    #[test]
+    fn a_named_service_is_not_blank() {
+        assert!(!is_blank("route"));
+    }
+
+    #[test]
+    fn services_hint_lists_one_service_per_line() {
+        let services = vec!["a.ReadinessService".to_owned(), "b.ReadinessService".to_owned()];
+
+        assert_eq!(
+            "available:\na.ReadinessService\nb.ReadinessService",
+            services_hint("available:", &services)
+        );
+    }
+
+    #[test]
+    fn services_hint_states_the_registry_is_empty() {
+        assert_eq!(
+            "no readiness services are registered with the gateway",
+            services_hint("available:", &[])
+        );
+    }
+
+    #[test]
+    fn aggregate_mode_is_the_default() {
+        let cmd = Cmd::try_parse_from(["yanet-cli-ready"]).expect("no arguments must parse");
+
+        assert!(cmd.is_aggregate());
+    }
+
+    #[test]
+    fn naming_a_service_leaves_aggregate_mode() {
+        let cmd = Cmd::try_parse_from(["yanet-cli-ready", "route"]).expect("a service name must parse");
+
+        assert!(!cmd.is_aggregate());
+    }
+
+    #[test]
+    fn all_flag_conflicts_with_a_named_service() {
+        assert!(Cmd::try_parse_from(["yanet-cli-ready", "--all", "route"]).is_err());
     }
 }


### PR DESCRIPTION
Probe every readiness service registered with the gateway when none is named, so checking the whole control plane no longer means spelling out each fully-qualified service name by hand. The registry is the source of truth, so a newly added operator shows up without a CLI change.

A service may still be named explicitly, either by its fully-qualified name or by a short alias resolved against the registry; an ambiguous alias reports its candidates.

The services that do exist are offered in two places: shell completion for the service argument, and the hint of an unknown-service error.

Exit codes are unchanged in spirit: success means something was checked and found ready, a probe that reached the gateway but found a scope not ready still exits with the not-ready code, and an unregistered service reports the same code whether it was named in full or by alias.

Streaming with the watch flag still requires a single service — several interleaved transition logs would be unreadable — and says so with the available services in the hint.