### PR TITLE
refactor(decap): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -76,7 +76,7 @@ func buildServices(
 		{
 			name: "decap module",
 			new: func() (gateway.Service, error) {
-				return decap.NewDecapModule(modulesCfg.Decap, log)
+				return decap.NewDecapModule(modulesCfg.Decap, decap.WithLog(log))
 			},
 		},
 		{

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -27,7 +27,6 @@ controlplane/internal/auth/sshkey/factory.go:NewFromConfig  # legacy: migrate to
 devices/plain/controlplane/mod.go:NewDevicePlainDevice  # legacy: migrate to the options pattern
 devices/vlan/controlplane/mod.go:NewDeviceVlanDevice  # legacy: migrate to the options pattern
 modules/acl/controlplane/mod.go:NewACLModule  # legacy: migrate to the options pattern
-modules/decap/controlplane/mod.go:NewDecapModule  # legacy: migrate to the options pattern
 modules/dscp/controlplane/mod.go:NewDSCPModule  # legacy: migrate to the options pattern
 modules/forward/controlplane/mod.go:NewForwardModule  # legacy: migrate to the options pattern
 modules/mirror/controlplane/mod.go:NewMirrorModule  # legacy: migrate to the options pattern

--- a/modules/decap/controlplane/mod.go
+++ b/modules/decap/controlplane/mod.go
@@ -10,6 +10,26 @@ import (
 	"github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
 
+// Option configures the DecapModule constructor.
+type Option func(*moduleOptions)
+
+type moduleOptions struct {
+	Log *zap.Logger
+}
+
+func newModuleOptions() *moduleOptions {
+	return &moduleOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the decap module.
+func WithLog(log *zap.Logger) Option {
+	return func(o *moduleOptions) {
+		o.Log = log
+	}
+}
+
 // DecapModule is a control-plane component of a module that is responsible for
 // decapsulating various kinds of tunnels.
 type DecapModule struct {
@@ -20,8 +40,13 @@ type DecapModule struct {
 	log          *zap.Logger
 }
 
-func NewDecapModule(cfg *Config, log *zap.Logger) (*DecapModule, error) {
-	log = log.With(zap.String("module", "modules.decap.controlplane.decappb.v1.DecapService"))
+func NewDecapModule(cfg *Config, options ...Option) (*DecapModule, error) {
+	opts := newModuleOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", "modules.decap.controlplane.decappb.v1.DecapService"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {


### PR DESCRIPTION
- Migrates the decap module constructor to the options pattern so it no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the module's now-paid-down row from the linter allowlist.