### PR TITLE
refactor(dscp): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -82,7 +82,7 @@ func buildServices(
 		{
 			name: "dscp module",
 			new: func() (gateway.Service, error) {
-				return dscp.NewDSCPModule(modulesCfg.DSCP, log)
+				return dscp.NewDSCPModule(modulesCfg.DSCP, dscp.WithLog(log))
 			},
 		},
 		{

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -26,7 +26,6 @@ controlplane/internal/auth/sshcert/factory.go:NewFromConfig  # legacy: migrate t
 controlplane/internal/auth/sshkey/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 devices/plain/controlplane/mod.go:NewDevicePlainDevice  # legacy: migrate to the options pattern
 devices/vlan/controlplane/mod.go:NewDeviceVlanDevice  # legacy: migrate to the options pattern
-modules/dscp/controlplane/mod.go:NewDSCPModule  # legacy: migrate to the options pattern
 modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing  # legacy: migrate to the options pattern
 modules/pdump/controlplane/service.go:NewPdumpService  # legacy: migrate to the options pattern
 operators/bird-adapter/internal/bird/export.go:NewExportReader  # legacy: migrate to the options pattern

--- a/modules/dscp/controlplane/mod.go
+++ b/modules/dscp/controlplane/mod.go
@@ -10,6 +10,26 @@ import (
 	"github.com/yanet-platform/yanet2/modules/dscp/controlplane/dscppb/v1"
 )
 
+// Option configures the DscpModule constructor.
+type Option func(*moduleOptions)
+
+type moduleOptions struct {
+	Log *zap.Logger
+}
+
+func newModuleOptions() *moduleOptions {
+	return &moduleOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the dscp module.
+func WithLog(log *zap.Logger) Option {
+	return func(o *moduleOptions) {
+		o.Log = log
+	}
+}
+
 // DscpModule is a control-plane component of a module that is responsible for
 // DSCP marking of packets.
 type DscpModule struct {
@@ -20,8 +40,13 @@ type DscpModule struct {
 	log         *zap.Logger
 }
 
-func NewDSCPModule(cfg *Config, log *zap.Logger) (*DscpModule, error) {
-	log = log.With(zap.String("module", "dscp"))
+func NewDSCPModule(cfg *Config, options ...Option) (*DscpModule, error) {
+	opts := newModuleOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", "dscp"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {


### PR DESCRIPTION
- Migrates the DSCP module constructor to the options pattern so it no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the module's now-paid-down row from the linter allowlist.