### PR TITLE
refactor(forward): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -88,7 +88,7 @@ func buildServices(
 		{
 			name: "forward module",
 			new: func() (gateway.Service, error) {
-				return forward.NewForwardModule(modulesCfg.Forward, log)
+				return forward.NewForwardModule(modulesCfg.Forward, forward.WithLog(log))
 			},
 		},
 		{

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -29,7 +29,6 @@ devices/vlan/controlplane/mod.go:NewDeviceVlanDevice  # legacy: migrate to the o
 modules/acl/controlplane/mod.go:NewACLModule  # legacy: migrate to the options pattern
 modules/decap/controlplane/mod.go:NewDecapModule  # legacy: migrate to the options pattern
 modules/dscp/controlplane/mod.go:NewDSCPModule  # legacy: migrate to the options pattern
-modules/forward/controlplane/mod.go:NewForwardModule  # legacy: migrate to the options pattern
 modules/mirror/controlplane/mod.go:NewMirrorModule  # legacy: migrate to the options pattern
 modules/nat64/controlplane/mod.go:NewNAT64Module  # legacy: migrate to the options pattern
 modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing  # legacy: migrate to the options pattern

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -15,6 +15,26 @@ const (
 	serviceName = "modules.forward.controlplane.forwardpb.v1.ForwardService"
 )
 
+// Option configures the ForwardModule constructor.
+type Option func(*moduleOptions)
+
+type moduleOptions struct {
+	Log *zap.Logger
+}
+
+func newModuleOptions() *moduleOptions {
+	return &moduleOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the forward module.
+func WithLog(log *zap.Logger) Option {
+	return func(o *moduleOptions) {
+		o.Log = log
+	}
+}
+
 // ForwardModule is a control-plane component of a module that is responsible for
 // forwarding traffic between devices.
 type ForwardModule struct {
@@ -26,8 +46,13 @@ type ForwardModule struct {
 	log            *zap.Logger
 }
 
-func NewForwardModule(cfg *Config, log *zap.Logger) (*ForwardModule, error) {
-	log = log.With(zap.String("module", serviceName))
+func NewForwardModule(cfg *Config, options ...Option) (*ForwardModule, error) {
+	opts := newModuleOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", serviceName))
 
 	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {


### PR DESCRIPTION
- Migrates the forward module constructor to the options pattern so it no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the module's now-paid-down row from the linter allowlist.