### PR TITLE
refactor(mirror): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -94,7 +94,7 @@ func buildServices(
 		{
 			name: "mirror module",
 			new: func() (gateway.Service, error) {
-				return mirror.NewMirrorModule(modulesCfg.Mirror, log)
+				return mirror.NewMirrorModule(modulesCfg.Mirror, mirror.WithLog(log))
 			},
 		},
 		{

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -28,7 +28,6 @@ devices/plain/controlplane/mod.go:NewDevicePlainDevice  # legacy: migrate to the
 devices/vlan/controlplane/mod.go:NewDeviceVlanDevice  # legacy: migrate to the options pattern
 modules/acl/controlplane/mod.go:NewACLModule  # legacy: migrate to the options pattern
 modules/dscp/controlplane/mod.go:NewDSCPModule  # legacy: migrate to the options pattern
-modules/mirror/controlplane/mod.go:NewMirrorModule  # legacy: migrate to the options pattern
 modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing  # legacy: migrate to the options pattern
 modules/pdump/controlplane/service.go:NewPdumpService  # legacy: migrate to the options pattern
 operators/bird-adapter/internal/bird/export.go:NewExportReader  # legacy: migrate to the options pattern

--- a/modules/mirror/controlplane/mod.go
+++ b/modules/mirror/controlplane/mod.go
@@ -12,6 +12,26 @@ import (
 
 const agentName = "mirror"
 
+// Option configures the MirrorModule constructor.
+type Option func(*moduleOptions)
+
+type moduleOptions struct {
+	Log *zap.Logger
+}
+
+func newModuleOptions() *moduleOptions {
+	return &moduleOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the mirror module.
+func WithLog(log *zap.Logger) Option {
+	return func(o *moduleOptions) {
+		o.Log = log
+	}
+}
+
 // MirrorModule is a control-plane component of a module that is responsible for
 // mirroring traffic between devices.
 type MirrorModule struct {
@@ -22,8 +42,13 @@ type MirrorModule struct {
 	log           *zap.Logger
 }
 
-func NewMirrorModule(cfg *Config, log *zap.Logger) (*MirrorModule, error) {
-	log = log.With(zap.String("module", "modules.mirror.controlplane.mirrorpb.v1.MirrorService"))
+func NewMirrorModule(cfg *Config, options ...Option) (*MirrorModule, error) {
+	opts := newModuleOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", "modules.mirror.controlplane.mirrorpb.v1.MirrorService"))
 
 	shm, err := cpffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {


### PR DESCRIPTION
- Migrates the mirror module constructor to the options pattern so it no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the module's now-paid-down row from the linter allowlist.