### PR TITLE
refactor(nat64): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -100,7 +100,7 @@ func buildServices(
 		{
 			name: "nat64 module",
 			new: func() (gateway.Service, error) {
-				return nat64.NewNAT64Module(modulesCfg.NAT64, log)
+				return nat64.NewNAT64Module(modulesCfg.NAT64, nat64.WithLog(log))
 			},
 		},
 		{

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -31,7 +31,6 @@ modules/decap/controlplane/mod.go:NewDecapModule  # legacy: migrate to the optio
 modules/dscp/controlplane/mod.go:NewDSCPModule  # legacy: migrate to the options pattern
 modules/forward/controlplane/mod.go:NewForwardModule  # legacy: migrate to the options pattern
 modules/mirror/controlplane/mod.go:NewMirrorModule  # legacy: migrate to the options pattern
-modules/nat64/controlplane/mod.go:NewNAT64Module  # legacy: migrate to the options pattern
 modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing  # legacy: migrate to the options pattern
 modules/pdump/controlplane/mod.go:NewPdumpModule  # legacy: migrate to the options pattern
 modules/pdump/controlplane/service.go:NewPdumpService  # legacy: migrate to the options pattern

--- a/modules/nat64/controlplane/mod.go
+++ b/modules/nat64/controlplane/mod.go
@@ -10,6 +10,26 @@ import (
 	nat64pb "github.com/yanet-platform/yanet2/modules/nat64/controlplane/nat64pb/v1"
 )
 
+// Option configures the NAT64Module constructor.
+type Option func(*moduleOptions)
+
+type moduleOptions struct {
+	Log *zap.Logger
+}
+
+func newModuleOptions() *moduleOptions {
+	return &moduleOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the nat64 module.
+func WithLog(log *zap.Logger) Option {
+	return func(o *moduleOptions) {
+		o.Log = log
+	}
+}
+
 // NAT64Module is a control-plane component responsible for NAT64 translation
 type NAT64Module struct {
 	cfg          *Config
@@ -20,8 +40,13 @@ type NAT64Module struct {
 }
 
 // NewNAT64Module creates a new NAT64 module instance
-func NewNAT64Module(cfg *Config, log *zap.Logger) (*NAT64Module, error) {
-	log = log.With(zap.String("module", "modules.nat64.controlplane.nat64pb.v1.NAT64Service"))
+func NewNAT64Module(cfg *Config, options ...Option) (*NAT64Module, error) {
+	opts := newModuleOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", "modules.nat64.controlplane.nat64pb.v1.NAT64Service"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {


### PR DESCRIPTION
- Migrates the NAT64 module constructor to the options pattern so it no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the module's now-paid-down row from the linter allowlist.