### PR TITLE
refactor(pdump): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -106,7 +106,7 @@ func buildServices(
 		{
 			name: "pdump module",
 			new: func() (gateway.Service, error) {
-				return pdump.NewPdumpModule(modulesCfg.Pdump, log)
+				return pdump.NewPdumpModule(modulesCfg.Pdump, pdump.WithLog(log))
 			},
 		},
 		{

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -33,7 +33,6 @@ modules/forward/controlplane/mod.go:NewForwardModule  # legacy: migrate to the o
 modules/mirror/controlplane/mod.go:NewMirrorModule  # legacy: migrate to the options pattern
 modules/nat64/controlplane/mod.go:NewNAT64Module  # legacy: migrate to the options pattern
 modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing  # legacy: migrate to the options pattern
-modules/pdump/controlplane/mod.go:NewPdumpModule  # legacy: migrate to the options pattern
 modules/pdump/controlplane/service.go:NewPdumpService  # legacy: migrate to the options pattern
 operators/bird-adapter/internal/bird/export.go:NewExportReader  # legacy: migrate to the options pattern
 operators/bird-adapter/internal/bird/parser.go:NewParser  # legacy: migrate to the options pattern

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -12,6 +12,26 @@ import (
 	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb/v1"
 )
 
+// Option configures the PdumpModule constructor.
+type Option func(*moduleOptions)
+
+type moduleOptions struct {
+	Log *zap.Logger
+}
+
+func newModuleOptions() *moduleOptions {
+	return &moduleOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the pdump module.
+func WithLog(log *zap.Logger) Option {
+	return func(o *moduleOptions) {
+		o.Log = log
+	}
+}
+
 // PdumpModule is a control-plane component of a packet dump module.
 type PdumpModule struct {
 	cfg     *Config
@@ -21,8 +41,13 @@ type PdumpModule struct {
 	log     *zap.Logger
 }
 
-func NewPdumpModule(cfg *Config, log *zap.Logger) (*PdumpModule, error) {
-	log = log.With(zap.String("module", "modules.pdump.controlplane.pdumppb.v1.PdumpService"))
+func NewPdumpModule(cfg *Config, options ...Option) (*PdumpModule, error) {
+	opts := newModuleOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", "modules.pdump.controlplane.pdumppb.v1.PdumpService"))
 
 	// setup CGO export logger
 	logger = log.WithOptions(


### PR DESCRIPTION
- Migrates the pdump module constructor to the options pattern so it no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the module's now-paid-down row from the linter allowlist.