### PR TITLE
refactor(acl): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -112,7 +112,7 @@ func buildServices(
 		{
 			name: "acl module",
 			new: func() (gateway.Service, error) {
-				return acl.NewACLModule(modulesCfg.ACL, log)
+				return acl.NewACLModule(modulesCfg.ACL, acl.WithModuleLog(log))
 			},
 		},
 		{

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -26,7 +26,6 @@ controlplane/internal/auth/sshcert/factory.go:NewFromConfig  # legacy: migrate t
 controlplane/internal/auth/sshkey/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 devices/plain/controlplane/mod.go:NewDevicePlainDevice  # legacy: migrate to the options pattern
 devices/vlan/controlplane/mod.go:NewDeviceVlanDevice  # legacy: migrate to the options pattern
-modules/acl/controlplane/mod.go:NewACLModule  # legacy: migrate to the options pattern
 modules/dscp/controlplane/mod.go:NewDSCPModule  # legacy: migrate to the options pattern
 modules/forward/controlplane/mod.go:NewForwardModule  # legacy: migrate to the options pattern
 modules/mirror/controlplane/mod.go:NewMirrorModule  # legacy: migrate to the options pattern

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -18,6 +18,26 @@ const (
 	serviceName = "modules.acl.controlplane.aclpb.v1.ACLService"
 )
 
+// ModuleOption configures the ACLModule constructor.
+type ModuleOption func(*moduleOptions)
+
+type moduleOptions struct {
+	Log *zap.Logger
+}
+
+func newModuleOptions() *moduleOptions {
+	return &moduleOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithModuleLog sets the logger for the ACL module.
+func WithModuleLog(log *zap.Logger) ModuleOption {
+	return func(o *moduleOptions) {
+		o.Log = log
+	}
+}
+
 // ACLModule is a control-plane component for ACL (Access Control List) module
 // with integrated firewall state management.
 type ACLModule struct {
@@ -32,8 +52,13 @@ type ACLModule struct {
 }
 
 // NewACLModule creates a new ACL module instance.
-func NewACLModule(cfg *Config, log *zap.Logger) (*ACLModule, error) {
-	log = log.With(zap.String("module", serviceName))
+func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
+	opts := newModuleOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", serviceName))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {


### PR DESCRIPTION
- Migrates the ACL module constructor to the options pattern so it no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the module's now-paid-down row from the linter allowlist.