### PR TITLE
refactor(plain): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -124,7 +124,7 @@ func buildServices(
 		{
 			name: "plain device",
 			new: func() (gateway.Service, error) {
-				return plain.NewDevicePlainDevice(devicesCfg.Plain, log)
+				return plain.NewDevicePlainDevice(devicesCfg.Plain, plain.WithLog(log))
 			},
 		},
 		{

--- a/devices/plain/controlplane/mod.go
+++ b/devices/plain/controlplane/mod.go
@@ -10,6 +10,26 @@ import (
 	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
 )
 
+// Option configures the DevicePlainDevice constructor.
+type Option func(*deviceOptions)
+
+type deviceOptions struct {
+	Log *zap.Logger
+}
+
+func newDeviceOptions() *deviceOptions {
+	return &deviceOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the plain device.
+func WithLog(log *zap.Logger) Option {
+	return func(o *deviceOptions) {
+		o.Log = log
+	}
+}
+
 // DevicePlainDevice is a control-plane component responsible for plain devices
 type DevicePlainDevice struct {
 	cfg     *Config
@@ -20,8 +40,13 @@ type DevicePlainDevice struct {
 }
 
 // NewDevicePlainDevice creates a new DevicePlain device instance
-func NewDevicePlainDevice(cfg *Config, log *zap.Logger) (*DevicePlainDevice, error) {
-	log = log.With(zap.String("module", "devices.plain.controlplane.plainpb.v1.DevicePlainService"))
+func NewDevicePlainDevice(cfg *Config, options ...Option) (*DevicePlainDevice, error) {
+	opts := newDeviceOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", "devices.plain.controlplane.plainpb.v1.DevicePlainService"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -24,7 +24,6 @@ controlplane/httpproxy/proxy.go:NewHTTPHandler  # legacy: migrate to the options
 controlplane/internal/auth/basic/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 controlplane/internal/auth/sshcert/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 controlplane/internal/auth/sshkey/factory.go:NewFromConfig  # legacy: migrate to the options pattern
-devices/plain/controlplane/mod.go:NewDevicePlainDevice  # legacy: migrate to the options pattern
 modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing  # legacy: migrate to the options pattern
 modules/pdump/controlplane/service.go:NewPdumpService  # legacy: migrate to the options pattern
 operators/bird-adapter/internal/bird/export.go:NewExportReader  # legacy: migrate to the options pattern


### PR DESCRIPTION
- Migrates the plain device constructor to the options pattern so it no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the device's now-paid-down row from the linter allowlist.