### PR TITLE
refactor(vlan): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -130,7 +130,7 @@ func buildServices(
 		{
 			name: "vlan device",
 			new: func() (gateway.Service, error) {
-				return vlan.NewDeviceVlanDevice(devicesCfg.Vlan, log)
+				return vlan.NewDeviceVlanDevice(devicesCfg.Vlan, vlan.WithLog(log))
 			},
 		},
 		{

--- a/devices/vlan/controlplane/mod.go
+++ b/devices/vlan/controlplane/mod.go
@@ -10,6 +10,26 @@ import (
 	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
 )
 
+// Option configures the DeviceVlanDevice constructor.
+type Option func(*deviceOptions)
+
+type deviceOptions struct {
+	Log *zap.Logger
+}
+
+func newDeviceOptions() *deviceOptions {
+	return &deviceOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the vlan device.
+func WithLog(log *zap.Logger) Option {
+	return func(o *deviceOptions) {
+		o.Log = log
+	}
+}
+
 // DeviceVlanDevice is a control-plane component responsible for vlan devices
 type DeviceVlanDevice struct {
 	cfg     *Config
@@ -20,8 +40,13 @@ type DeviceVlanDevice struct {
 }
 
 // NewDeviceVlanDevice creates a new DeviceVlan device instance
-func NewDeviceVlanDevice(cfg *Config, log *zap.Logger) (*DeviceVlanDevice, error) {
-	log = log.With(zap.String("module", "devices.vlan.controlplane.vlanpb.v1.DeviceVlanService"))
+func NewDeviceVlanDevice(cfg *Config, options ...Option) (*DeviceVlanDevice, error) {
+	opts := newDeviceOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.With(zap.String("module", "devices.vlan.controlplane.vlanpb.v1.DeviceVlanService"))
 
 	shm, err := ffi.AttachSharedMemory(cfg.MemoryPath.Unwrap())
 	if err != nil {

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -25,7 +25,6 @@ controlplane/internal/auth/basic/factory.go:NewFromConfig  # legacy: migrate to 
 controlplane/internal/auth/sshcert/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 controlplane/internal/auth/sshkey/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 devices/plain/controlplane/mod.go:NewDevicePlainDevice  # legacy: migrate to the options pattern
-devices/vlan/controlplane/mod.go:NewDeviceVlanDevice  # legacy: migrate to the options pattern
 modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing  # legacy: migrate to the options pattern
 modules/pdump/controlplane/service.go:NewPdumpService  # legacy: migrate to the options pattern
 operators/bird-adapter/internal/bird/export.go:NewExportReader  # legacy: migrate to the options pattern


### PR DESCRIPTION
- Migrates the vlan device constructor to the options pattern so it no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the device's now-paid-down row from the linter allowlist.