### PR TITLE
feat(dataplane_ut): support per-worker devices in the test harness

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -89,6 +89,27 @@ free_cptr_array(const char **arr) {
 	free(arr);
 }
 
+// alloc_worker_spec_array copies n entries from src (Go-backed) into a
+// fresh C-heap array and returns it. The caller frees with
+// free_worker_spec_array.
+static struct dataplane_ut_worker_spec *
+alloc_worker_spec_array(const struct dataplane_ut_worker_spec *src, size_t n) {
+	struct dataplane_ut_worker_spec *dst =
+		(struct dataplane_ut_worker_spec *)malloc(
+			n * sizeof(struct dataplane_ut_worker_spec)
+		);
+	if (dst == NULL) {
+		return NULL;
+	}
+	memcpy(dst, src, n * sizeof(struct dataplane_ut_worker_spec));
+	return dst;
+}
+
+static void
+free_worker_spec_array(struct dataplane_ut_worker_spec *arr) {
+	free(arr);
+}
+
 void
 keep_refs(void **ptrs) {
 	extern struct module *new_module_blackhole(void);
@@ -141,6 +162,16 @@ import (
 	"github.com/yanet-platform/yanet2/tests/functional/framework"
 )
 
+// WorkerSpec assigns one worker's ingress device and queue, mirroring the
+// per-worker rx/tx port binding the real dataplane sets up before entering
+// its poll loop.
+//
+// DeviceID indexes into Config.Devices.
+type WorkerSpec struct {
+	DeviceID uint16
+	QueueID  uint16
+}
+
 // Config holds parameters for constructing a Harness.
 //
 // WorkerCount must be >= 1.
@@ -155,6 +186,12 @@ type Config struct {
 	// PluginDir is the directory scanned for module .so plugins. An empty
 	// value loads only the statically-linked built-ins.
 	PluginDir string
+	// Workers optionally assigns each worker's device and queue.
+	//
+	// When nil, every worker defaults to device 0 with queue id equal to
+	// its index — the harness's long-standing single-device behavior.
+	// When set, its length must equal WorkerCount.
+	Workers []WorkerSpec
 }
 
 // Result of one pipeline round.
@@ -183,11 +220,41 @@ type Harness struct {
 	// must stay below it. An empty Devices config still exposes the
 	// implicit device slot zero.
 	deviceCount int
+	// Registered worker count; worker indices passed to run calls must
+	// stay below it.
+	workerCount int
 }
 
 // NewHarness constructs a Harness from cfg.
 // Free must be called when the test is done.
 func NewHarness(cfg Config) (*Harness, error) {
+	if cfg.Workers != nil && uint64(len(cfg.Workers)) != cfg.WorkerCount {
+		return nil, fmt.Errorf(
+			"workers length %d does not match worker count %d",
+			len(cfg.Workers),
+			cfg.WorkerCount,
+		)
+	}
+
+	deviceCount := len(cfg.Devices)
+	if deviceCount == 0 {
+		deviceCount = 1
+	}
+
+	// dp_worker->device_id feeds the same per-device scheduling arrays as
+	// packet->tx_device_id in the real dataplane, so an id outside the
+	// registered topology would corrupt memory on the C side.
+	for idx, worker := range cfg.Workers {
+		if int(worker.DeviceID) >= deviceCount {
+			return nil, fmt.Errorf(
+				"worker %d device id %d exceeds topology device count %d",
+				idx,
+				worker.DeviceID,
+				deviceCount,
+			)
+		}
+	}
+
 	// Convert Go string slices to C string arrays. The *C.char values are
 	// C-heap strings; toCStringArray returns Go-backed pointer slices, so
 	// we copy the pointers into C-heap arrays to satisfy the CGO rule that
@@ -232,17 +299,25 @@ func NewHarness(cfg Config) (*Harness, error) {
 		defer C.free(unsafe.Pointer(cPluginDir))
 		cCfg.plugin_dir = cPluginDir
 	}
+	if len(cfg.Workers) > 0 {
+		cWorkers := make([]C.struct_dataplane_ut_worker_spec, len(cfg.Workers))
+		for idx, worker := range cfg.Workers {
+			cWorkers[idx] = C.struct_dataplane_ut_worker_spec{
+				device_id: C.uint16_t(worker.DeviceID),
+				queue_id:  C.uint16_t(worker.QueueID),
+			}
+		}
+		cArr := C.alloc_worker_spec_array(&cWorkers[0], C.size_t(len(cWorkers)))
+		defer C.free_worker_spec_array(cArr)
+		cCfg.workers = cArr
+	}
 
 	ptr := C.dataplane_ut_new(&cCfg)
 	if ptr == nil {
 		return nil, fmt.Errorf("failed to create dataplane harness: dataplane_ut_new returned NULL")
 	}
 
-	deviceCount := len(cfg.Devices)
-	if deviceCount == 0 {
-		deviceCount = 1
-	}
-	return &Harness{ptr: ptr, deviceCount: deviceCount}, nil
+	return &Harness{ptr: ptr, deviceCount: deviceCount, workerCount: int(cfg.WorkerCount)}, nil
 }
 
 // Free tears down the harness. Nil-safe.
@@ -314,12 +389,61 @@ func (m *Harness) HandlePacketsWithHashes(
 // multi-segment mbuf. The result is returned unparsed so callers can inspect
 // packets that gopacket cannot decode.
 func (m *Harness) HandleSegmentedPackets(packets ...[][]byte) (*RawResult, error) {
+	return m.handleSegmentedPackets(0, 0, 0, packets...)
+}
+
+// HandleSegmentedPacketsOnDevice runs one pipeline round on the given worker
+// where each input packet is supplied as an ordered list of byte segments,
+// producing a chained multi-segment mbuf stamped with rxDeviceID as both its
+// ingress and egress device.
+//
+// This mirrors the real dataplane's ingress stamp, where the polling
+// worker's own device becomes both the packet's rx and tx device (see
+// dataplane/worker.c), letting a test exercise device-keyed module behavior
+// instead of the harness default of device 0 on every packet.
+func (m *Harness) HandleSegmentedPacketsOnDevice(
+	worker int,
+	rxDeviceID uint16,
+	packets ...[][]byte,
+) (*RawResult, error) {
+	// The round dispatch indexes per-device scheduling arrays by the
+	// packet device id, so an id outside the registered topology would
+	// corrupt memory on the C side.
+	if int(rxDeviceID) >= m.deviceCount {
+		return nil, fmt.Errorf(
+			"device id %d exceeds topology device count %d",
+			rxDeviceID,
+			m.deviceCount,
+		)
+	}
+
+	return m.handleSegmentedPackets(worker, rxDeviceID, rxDeviceID, packets...)
+}
+
+// handleSegmentedPackets is the shared implementation for the
+// HandleSegmentedPackets* variants.
+func (m *Harness) handleSegmentedPackets(
+	worker int,
+	txDeviceID, rxDeviceID uint16,
+	packets ...[][]byte,
+) (*RawResult, error) {
+	// dataplane_ut_run indexes ut->dp_config->workers[worker] directly, so
+	// a worker index outside the registered topology would corrupt memory
+	// on the C side.
+	if worker < 0 || worker >= m.workerCount {
+		return nil, fmt.Errorf(
+			"worker %d exceeds topology worker count %d",
+			worker,
+			m.workerCount,
+		)
+	}
+
 	pinner := runtime.Pinner{}
 	defer pinner.Unpin()
 
 	builtPackets := make([]*dataplane.Packet, 0, len(packets))
 	for idx := range packets {
-		pkt, err := dataplane.NewPacketFromSegments(packets[idx], 0, 0)
+		pkt, err := dataplane.NewPacketFromSegments(packets[idx], txDeviceID, rxDeviceID)
 		if err != nil {
 			return nil, fmt.Errorf("failed to build segmented packet at index %d: %w", idx, err)
 		}
@@ -334,7 +458,7 @@ func (m *Harness) HandleSegmentedPackets(packets ...[][]byte) (*RawResult, error
 	var result C.struct_dataplane_ut_round_result
 	C.dataplane_ut_run(
 		m.ptr,
-		C.size_t(0),
+		C.size_t(worker),
 		(*C.struct_packet_list)(unsafe.Pointer(packetList)),
 		&result,
 	)
@@ -370,6 +494,17 @@ func (m *Harness) handlePackets(
 	hashes []uint32,
 	packets ...gopacket.Packet,
 ) (*Result, error) {
+	// dataplane_ut_run indexes ut->dp_config->workers[worker] directly, so
+	// a worker index outside the registered topology would corrupt memory
+	// on the C side.
+	if worker < 0 || worker >= m.workerCount {
+		return nil, fmt.Errorf(
+			"worker %d exceeds topology worker count %d",
+			worker,
+			m.workerCount,
+		)
+	}
+
 	pinner := runtime.Pinner{}
 	defer pinner.Unpin()
 

--- a/bindings/go/dataplane_ut/dataplane_ut_test.go
+++ b/bindings/go/dataplane_ut/dataplane_ut_test.go
@@ -1,12 +1,21 @@
 package dataplaneut
 
 import (
+	"net"
 	"testing"
 	"time"
 
 	"github.com/c2h5oh/datasize"
+	"github.com/gopacket/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
+	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 )
 
 // TestHarnessLifecycle exercises construction, shared-memory access, and
@@ -67,4 +76,234 @@ func TestAgentAttach(t *testing.T) {
 	agent, err := shm.AgentAttach("smoke-agent", 0, datasize.MB*2)
 	require.NoError(t, err)
 	require.NotNil(t, agent)
+}
+
+// TestNewHarness_WorkersLengthMismatch verifies that Config.Workers, when
+// set, must have exactly WorkerCount entries — a mismatched length is
+// rejected instead of silently misassigning or truncating workers.
+func TestNewHarness_WorkersLengthMismatch(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: 2,
+		Workers:     []WorkerSpec{{DeviceID: 0, QueueID: 0}},
+	}
+
+	h, err := NewHarness(cfg)
+	require.Error(t, err)
+	require.Nil(t, h)
+}
+
+// Verifies that NewHarness rejects a WorkerSpec.DeviceID at or beyond the
+// configured device count instead of stamping dp_worker->device_id with a
+// value that would later index the C-side per-device scheduling arrays out
+// of bounds.
+func TestNewHarness_WorkerDeviceIDOutOfRange(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: 2,
+		Devices:     []string{"port0", "port1"},
+		Workers: []WorkerSpec{
+			{DeviceID: 0, QueueID: 0},
+			{DeviceID: 5, QueueID: 0},
+		},
+	}
+
+	h, err := NewHarness(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds topology device count")
+	require.Nil(t, h)
+}
+
+// TestHandleSegmentedPacketsOnDevice_InvalidDeviceID verifies that
+// HandleSegmentedPacketsOnDevice rejects an rxDeviceID at or beyond the
+// harness's registered device count instead of stamping a packet that
+// would index the C-side per-device scheduling arrays out of bounds.
+func TestHandleSegmentedPacketsOnDevice_InvalidDeviceID(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: 1,
+	}
+
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	result, err := h.HandleSegmentedPacketsOnDevice(0, 5, [][]byte{{0x00}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds topology device count")
+	require.Nil(t, result)
+}
+
+// TestHandleSegmentedPacketsOnDevice_InvalidWorker verifies that
+// HandleSegmentedPacketsOnDevice rejects a worker index at or beyond the
+// harness's registered worker count instead of indexing the C-side worker
+// array out of bounds.
+func TestHandleSegmentedPacketsOnDevice_InvalidWorker(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: 1,
+	}
+
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	result, err := h.HandleSegmentedPacketsOnDevice(3, 0, [][]byte{{0x00}})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds topology worker count")
+	require.Nil(t, result)
+}
+
+// TestHandlePacketsOnWorker_InvalidWorker verifies that HandlePacketsOnWorker
+// rejects a worker index at or beyond the harness's registered worker count
+// instead of indexing the C-side worker array out of bounds.
+func TestHandlePacketsOnWorker_InvalidWorker(t *testing.T) {
+	cfg := Config{
+		CPMemory:    uint64(datasize.MB * 32),
+		DPMemory:    uint64(datasize.MB * 4),
+		WorkerCount: 1,
+	}
+
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	result, err := h.HandlePacketsOnWorker(3)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds topology worker count")
+	require.Nil(t, result)
+}
+
+// TestHandleSegmentedPacketsOnDevice_ForwardDeviceScopedRule verifies that
+// Config.Workers assigns each worker's own device and that
+// HandleSegmentedPacketsOnDevice stamps the injected packet's ingress
+// device, together letting a forward rule scoped to a non-zero device
+// ("port1") demux the packet to that device's egress.
+//
+// The assertions bracket both knobs: WorkerCounters reads dp_worker's
+// device_id back to prove Config.Workers was honored, and a baseline call
+// through the pre-existing HandleSegmentedPackets (which still pins every
+// packet to device 0) proves the same rule cannot match without the new
+// injection knob.
+func TestHandleSegmentedPacketsOnDevice_ForwardDeviceScopedRule(t *testing.T) {
+	cfg := Config{
+		CPMemory:      uint64(datasize.MB * 64),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   2,
+		Devices:       []string{"port0", "port1"},
+		Modules:       []string{"forward"},
+		DevicesToLoad: []string{"plain"},
+		Workers: []WorkerSpec{
+			{DeviceID: 0, QueueID: 0},
+			{DeviceID: 1, QueueID: 0},
+		},
+	}
+	h, err := NewHarness(cfg)
+	require.NoError(t, err)
+	t.Cleanup(h.Free)
+
+	shm := h.SharedMemory()
+	agent, err := shm.AgentAttach("device-inject-test", 0, datasize.MB*16)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	// Confirm the Workers config threaded through to the C-side dp_worker
+	// fields: without it, both workers would read back device 0.
+	workerCounters, err := shm.DPConfig(0).WorkerCounters()
+	require.NoError(t, err)
+	require.Len(t, workerCounters, 2)
+	assert.Equal(t, uint32(0), workerCounters[0].DeviceID)
+	assert.Equal(t, uint32(1), workerCounters[1].DeviceID)
+
+	backend := forward.NewBackend(agent)
+	rule := cforward.ForwardRule{
+		Target:  "port1",
+		Mode:    cforward.ModeOut,
+		Counter: "port1_rule",
+		Devices: filter.Devices{{Name: "port1"}},
+	}
+	moduleHandle, err := backend.UpdateModule("demux", []cforward.ForwardRule{rule})
+	require.NoError(t, err)
+	t.Cleanup(moduleHandle.Free)
+
+	require.NoError(t, agent.UpdateFunction(ffi.FunctionConfig{
+		Name: "demux",
+		Chains: []ffi.FunctionChainConfig{{
+			Weight: 1,
+			Chain: ffi.ChainConfig{
+				Name:    "demux_chain",
+				Modules: []ffi.ChainModuleConfig{{Type: "forward", Name: "demux"}},
+			},
+		}},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{
+		Name:      "demux",
+		Functions: []string{"demux"},
+	}))
+	require.NoError(t, agent.UpdatePipeline(ffi.PipelineConfig{Name: "dummy_out"}))
+
+	// port0 has no output pipeline: the rule never targets it, so an
+	// unmatched packet has nowhere to go but drop.
+	require.NoError(t, agent.UpdatePlainDevices([]ffi.DeviceConfig{
+		{
+			Name:  "port0",
+			Input: []ffi.DevicePipelineConfig{{Name: "demux", Weight: 1}},
+		},
+		{
+			Name:   "port1",
+			Input:  []ffi.DevicePipelineConfig{{Name: "demux", Weight: 1}},
+			Output: []ffi.DevicePipelineConfig{{Name: "dummy_out", Weight: 1}},
+		},
+	}))
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv4,
+	}
+	ip4 := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    net.ParseIP("1.2.3.4"),
+		DstIP:    net.ParseIP("10.0.0.5"),
+	}
+	icmp := layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(layers.ICMPv4TypeEchoRequest, 0),
+	}
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	payload := pkt.Data()
+
+	// Baseline: the pre-existing entrypoint pins every packet to device 0,
+	// so the port1-scoped rule cannot match. The packet passes through
+	// unmatched and is dropped by the input entry point's no-transmit
+	// policy.
+	baseline, err := h.HandleSegmentedPackets([][]byte{payload})
+	require.NoError(t, err)
+	assert.Empty(t, baseline.Output, "a packet pinned to device 0 must not match the port1-scoped rule")
+	require.Len(t, baseline.Drop, 1)
+
+	// With the packet's ingress device set to port1 and the round run on
+	// the worker that owns port1, the device-scoped rule matches and
+	// redirects the packet out through port1.
+	result, err := h.HandleSegmentedPacketsOnDevice(1, 1, [][]byte{payload})
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "a packet injected on port1 must match the device-scoped rule and reach output")
+	assert.Empty(t, result.Drop)
+
+	// The round ran on worker 1, so the per-rule counter lands in worker
+	// 1's slot rather than worker 0's — RequireModuleCounter always reads
+	// worker 0, so the module counters are read directly here instead.
+	counters := shm.DPConfig(0).ModuleCounters(
+		"port1", "demux", "demux", "demux_chain", "forward", "demux",
+		[]string{"port1_rule"},
+	)
+	require.Len(t, counters, 1)
+	require.GreaterOrEqual(t, len(counters[0].Values), 2)
+	assert.Equal(t, []uint64{0, 0}, counters[0].Values[0], "worker 0 never ran the round")
+	assert.Equal(t, []uint64{1, uint64(len(payload))}, counters[0].Values[1], "worker 1 ran the matching round")
 }

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -284,8 +284,25 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 	ut->dp_config->worker_count = cfg->worker_count;
 	SET_OFFSET_OF(&ut->dp_config->workers, workers_array);
 
+	// Devices are optional: a harness with no explicit device_count still
+	// exposes the implicit device 0, mirroring the Go side's semantics.
+	size_t effective_device_count =
+		cfg->device_count == 0 ? 1 : cfg->device_count;
+
 	struct dp_worker **dp_workers = ADDR_OF(&ut->dp_config->workers);
 	for (size_t idx = 0; idx < cfg->worker_count; ++idx) {
+		if (cfg->workers != NULL &&
+		    cfg->workers[idx].device_id >= effective_device_count) {
+			LOG(ERROR,
+			    "dataplane_ut_new: worker %zu binds out-of-range "
+			    "device_id %u (device_count %zu)",
+			    idx,
+			    cfg->workers[idx].device_id,
+			    effective_device_count);
+			dataplane_ut_free(ut);
+			return NULL;
+		}
+
 		struct dp_worker *dp_worker = (struct dp_worker *)memory_balloc(
 			&ut->dp_config->memory_context, sizeof(struct dp_worker)
 		);
@@ -304,8 +321,13 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		dp_worker->gen = DATAPLANE_UT_HIGH_GEN;
 		dp_worker->rx_mempool = ut->mempool;
 		dp_worker->core_id = (uint32_t)idx;
-		dp_worker->device_id = 0;
-		dp_worker->queue_id = (uint32_t)idx;
+		if (cfg->workers != NULL) {
+			dp_worker->device_id = cfg->workers[idx].device_id;
+			dp_worker->queue_id = cfg->workers[idx].queue_id;
+		} else {
+			dp_worker->device_id = 0;
+			dp_worker->queue_id = (uint32_t)idx;
+		}
 		dp_worker->rx_burst_size = WORKER_RX_BURST_SIZE;
 
 		wire_worker_counters(dp_worker, ut->dp_config);
@@ -375,6 +397,33 @@ dataplane_ut_run(
 	struct packet_list *input,
 	struct dataplane_ut_round_result *result
 ) {
+	if (worker_idx >= ut->dp_config->worker_count) {
+		LOG(ERROR,
+		    "dataplane_ut_run: worker_idx %zu is out of range "
+		    "(worker_count %lu)",
+		    worker_idx,
+		    ut->dp_config->worker_count);
+
+		// Mirror the config_gen_ectx == NULL branch below: a caller
+		// must still get a well-formed result (output/drop initialized)
+		// and input must end up drained, so packets are neither leaked
+		// nor re-added to a non-empty list by dataplane_ut_run_rounds.
+		struct packet_front packet_front;
+		packet_front_init(&packet_front);
+
+		struct packet *packet;
+		while ((packet = packet_list_pop(input)) != NULL) {
+			packet_front_pending_input(&packet_front, packet);
+		}
+
+		packet_list_init(&result->output);
+		packet_list_init(&result->drop);
+
+		packet_front_drop_pending_input(&packet_front);
+		packet_list_concat(&result->drop, &packet_front.drop);
+		return;
+	}
+
 	// The harness only manages one instance, so dp_workers lives in
 	// dp_config->workers as a registry of size worker_count.
 	struct dp_worker **workers = ADDR_OF(&ut->dp_config->workers);

--- a/lib/dataplane_ut/dataplane_ut.h
+++ b/lib/dataplane_ut/dataplane_ut.h
@@ -9,6 +9,13 @@ struct rte_mbuf;
 struct yanet_shm;
 struct dataplane_ut;
 
+// One worker's device and queue assignment, mirroring the per-worker rx/tx
+// port binding the real dataplane sets up before entering its poll loop.
+struct dataplane_ut_worker_spec {
+	uint16_t device_id;
+	uint16_t queue_id;
+};
+
 // Construction parameters for an in-process dataplane harness.
 // worker_count must be >= 1.
 //
@@ -30,6 +37,14 @@ struct dataplane_ut_config {
 
 	const char *const *devices_to_load;
 	size_t devices_to_load_count;
+
+	// Optional per-worker device/queue assignment, one entry per worker.
+	//
+	// NULL reproduces the long-standing default: every worker is assigned
+	// device id 0 with queue id equal to its index. When non-NULL, this
+	// must point to exactly worker_count entries, and entry idx configures
+	// worker idx.
+	const struct dataplane_ut_worker_spec *workers;
 };
 
 // Construct an in-process dataplane harness.

--- a/lib/dataplane_ut/tests/smoke_test.c
+++ b/lib/dataplane_ut/tests/smoke_test.c
@@ -1,4 +1,5 @@
 #include "common/test_assert.h"
+#include "lib/dataplane/packet/data.h"
 #include "lib/dataplane_ut/dataplane_ut.h"
 
 #include <rte_mbuf.h>
@@ -75,6 +76,70 @@ main(void) {
 	// Input validation: NULL cfg must return NULL, not crash.
 	struct dataplane_ut *bad = dataplane_ut_new(NULL);
 	TEST_ASSERT_NULL(bad, "dataplane_ut_new(NULL) should return NULL");
+
+	// Input validation: a worker bound to a device_id outside the
+	// configured topology must return NULL, not crash.
+	{
+		struct dataplane_ut_worker_spec out_of_range_workers[] = {
+			{.device_id = 1, .queue_id = 0},
+		};
+		struct dataplane_ut_config bad_cfg = cfg;
+		bad_cfg.workers = out_of_range_workers;
+
+		struct dataplane_ut *bad_worker = dataplane_ut_new(&bad_cfg);
+		TEST_ASSERT_NULL(
+			bad_worker,
+			"dataplane_ut_new with an out-of-range worker "
+			"device_id should return NULL"
+		);
+	}
+
+	// dataplane_ut_run with an out-of-range worker_idx must still leave
+	// input drained and result well-formed, so a caller can inspect and
+	// free result->output/result->drop exactly as on any other path.
+	{
+		struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+		TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+
+		struct rte_mbuf *mbuf = dataplane_ut_alloc_mbuf(ut);
+		TEST_ASSERT_NOT_NULL(
+			mbuf, "dataplane_ut_alloc_mbuf returned NULL"
+		);
+
+		struct packet *packet = mbuf_to_packet(mbuf);
+		memset(packet, 0, sizeof(*packet));
+		packet->mbuf = mbuf;
+
+		struct packet_list input;
+		packet_list_init(&input);
+		packet_list_add(&input, packet);
+
+		struct dataplane_ut_round_result result;
+		dataplane_ut_run(ut, cfg.worker_count + 1, &input, &result);
+
+		TEST_ASSERT_EQUAL(
+			(long)packet_list_count(&input),
+			0L,
+			"an out-of-range worker_idx must still drain input"
+		);
+		TEST_ASSERT_EQUAL(
+			(long)packet_list_count(&result.output),
+			0L,
+			"an out-of-range worker_idx must yield empty output"
+		);
+		TEST_ASSERT_EQUAL(
+			(long)packet_list_count(&result.drop),
+			1L,
+			"an out-of-range worker_idx must drop the input packet"
+		);
+
+		struct packet *dropped;
+		while ((dropped = packet_list_pop(&result.drop)) != NULL) {
+			rte_pktmbuf_free(packet_to_mbuf(dropped));
+		}
+
+		dataplane_ut_free(ut);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The in-process dataplane test harness pinned every worker to a single device and every injected packet to that same device, so no module could regression-test multi-device origination or any ownership rule that keys on the worker's own port.

This adds two opt-in capabilities to the harness and its Go bindings.

- Per-worker device and queue assignment, so a test can place workers on distinct devices.
- Packet injection with a caller-chosen ingress device, matching how the real dataplane stamps a packet at ingress.

Existing callers are unaffected: when the new options are left unset, the harness behaves exactly as before, and the full set of module test suites that depend on it stays green.

A new acceptance test drives a device-scoped forward rule to prove both capabilities are honoured and fail if either is ignored.