### PR TITLE
chore(lint): resolve staticcheck findings in production code

### DIFF
--- a/controlplane/builtin/inspect.go
+++ b/controlplane/builtin/inspect.go
@@ -136,9 +136,7 @@ func (m *Inspect) pipelines(dpConfig *ffi.DPConfig) []*ynpb.PipelineInfo {
 			Name: pipeline.Name,
 		}
 
-		for _, function := range pipeline.Functions {
-			pipelineInfo.Functions = append(pipelineInfo.Functions, function)
-		}
+		pipelineInfo.Functions = append(pipelineInfo.Functions, pipeline.Functions...)
 
 		out[idx] = pipelineInfo
 	}

--- a/modules/dscp/controlplane/service.go
+++ b/modules/dscp/controlplane/service.go
@@ -13,13 +13,6 @@ import (
 	"github.com/yanet-platform/yanet2/modules/dscp/controlplane/dscppb/v1"
 )
 
-var (
-	errConfigNameRequired = status.Error(
-		codes.InvalidArgument,
-		"module config name is required",
-	)
-)
-
 // ModuleHandle is a handle to a module configuration.
 type ModuleHandle interface {
 	Free()

--- a/modules/fwstate/controlplane/ffi.go
+++ b/modules/fwstate/controlplane/ffi.go
@@ -12,7 +12,6 @@ type FwStateConfig struct {
 
 type CursorEntry = cfwstate.CursorEntry
 type OutdatedLayers = cfwstate.OutdatedLayers
-type mapsStats = cfwstate.MapsStats
 type mapStats = cfwstate.MapStats
 
 func NewFWStateModuleConfig(agent *ffi.Agent, name string) (*FwStateConfig, error) {

--- a/operators/bird-adapter/internal/bird/export.go
+++ b/operators/bird-adapter/internal/bird/export.go
@@ -23,7 +23,6 @@ type exportSocket struct {
 
 type Export struct {
 	sockets  []exportSocket
-	ch       chan []rib.Route
 	cfg      *Config
 	updater  Updater
 	notifier Notifier

--- a/operators/bird-adapter/internal/mpls/routes.go
+++ b/operators/bird-adapter/internal/mpls/routes.go
@@ -128,7 +128,7 @@ func routeListBest(
 	routes []rib.Route,
 ) []rib.Route {
 	if len(routes) < 2 {
-		return routes[:len(routes)]
+		return routes[:]
 	}
 
 	count := 1


### PR DESCRIPTION
- Drop unused declarations and apply two minor simplifications flagged by staticcheck across the control plane, the dscp and fwstate modules, and the bird adapter.
- These are cleanups with no behavior change.