### PR TITLE
refactor(builtin): take the logger via constructor options

### DIFF
--- a/controlplane/builtin/function.go
+++ b/controlplane/builtin/function.go
@@ -34,12 +34,37 @@ type Function struct {
 	log        *zap.Logger
 }
 
+// FunctionOption configures the Function constructor.
+type FunctionOption func(*functionOptions)
+
+type functionOptions struct {
+	Log *zap.Logger
+}
+
+func newFunctionOptions() *functionOptions {
+	return &functionOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithFunctionLog sets the logger for the function service.
+func WithFunctionLog(log *zap.Logger) FunctionOption {
+	return func(o *functionOptions) {
+		o.Log = log
+	}
+}
+
 // NewFunction creates a new Function service.
-func NewFunction(instanceID uint32, shm *ffi.SharedMemory, log *zap.Logger) *Function {
+func NewFunction(instanceID uint32, shm *ffi.SharedMemory, options ...FunctionOption) *Function {
+	opts := newFunctionOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &Function{
 		instanceID: instanceID,
 		shm:        shm,
-		log:        log,
+		log:        opts.Log,
 	}
 }
 

--- a/controlplane/builtin/logging.go
+++ b/controlplane/builtin/logging.go
@@ -22,11 +22,36 @@ type Logging struct {
 	log  *zap.Logger
 }
 
+// LoggingOption configures the Logging constructor.
+type LoggingOption func(*loggingOptions)
+
+type loggingOptions struct {
+	Log *zap.Logger
+}
+
+func newLoggingOptions() *loggingOptions {
+	return &loggingOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLoggingLog sets the logger for the logging service.
+func WithLoggingLog(log *zap.Logger) LoggingOption {
+	return func(o *loggingOptions) {
+		o.Log = log
+	}
+}
+
 // NewLogging creates a new Logging service.
-func NewLogging(level *zap.AtomicLevel, log *zap.Logger) *Logging {
+func NewLogging(level *zap.AtomicLevel, options ...LoggingOption) *Logging {
+	opts := newLoggingOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &Logging{
 		atom: level,
-		log:  log,
+		log:  opts.Log,
 	}
 }
 

--- a/controlplane/builtin/pipeline.go
+++ b/controlplane/builtin/pipeline.go
@@ -34,12 +34,37 @@ type Pipeline struct {
 	log        *zap.Logger
 }
 
+// PipelineOption configures the Pipeline constructor.
+type PipelineOption func(*pipelineOptions)
+
+type pipelineOptions struct {
+	Log *zap.Logger
+}
+
+func newPipelineOptions() *pipelineOptions {
+	return &pipelineOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithPipelineLog sets the logger for the pipeline service.
+func WithPipelineLog(log *zap.Logger) PipelineOption {
+	return func(o *pipelineOptions) {
+		o.Log = log
+	}
+}
+
 // NewPipeline creates a new Pipeline service.
-func NewPipeline(instanceID uint32, shm *ffi.SharedMemory, log *zap.Logger) *Pipeline {
+func NewPipeline(instanceID uint32, shm *ffi.SharedMemory, options ...PipelineOption) *Pipeline {
+	opts := newPipelineOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &Pipeline{
 		instanceID: instanceID,
 		shm:        shm,
-		log:        log,
+		log:        opts.Log,
 	}
 }
 

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -113,16 +113,16 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 
 	gatewayOptions := []gateway.GatewayOption{
 		gateway.WithBuiltinService(
-			builtin.NewLogging(opts.LogLevel, log),
+			builtin.NewLogging(opts.LogLevel, builtin.WithLoggingLog(log)),
 		),
 		gateway.WithBuiltinService(
 			builtin.NewInspect(cfg.Gateway.InstanceID, shm),
 		),
 		gateway.WithBuiltinService(
-			builtin.NewPipeline(cfg.Gateway.InstanceID, shm, log),
+			builtin.NewPipeline(cfg.Gateway.InstanceID, shm, builtin.WithPipelineLog(log)),
 		),
 		gateway.WithBuiltinService(
-			builtin.NewFunction(cfg.Gateway.InstanceID, shm, log),
+			builtin.NewFunction(cfg.Gateway.InstanceID, shm, builtin.WithFunctionLog(log)),
 		),
 		gateway.WithBuiltinService(
 			builtin.NewCounters(cfg.Gateway.InstanceID, shm),

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -14,9 +14,6 @@
 # entry is itself a lint failure, so paying down the debt requires deleting
 # the row — the ledger is self-cleaning by construction.
 
-controlplane/builtin/function.go:NewFunction  # legacy: migrate to the options pattern
-controlplane/builtin/logging.go:NewLogging  # legacy: migrate to the options pattern
-controlplane/builtin/pipeline.go:NewPipeline  # legacy: migrate to the options pattern
 controlplane/bundle/bundle.go:NewBundle  # legacy: migrate to the options pattern
 controlplane/gateway/runner.go:NewServiceRunner  # legacy: migrate to the options pattern
 controlplane/gateway/service.go:NewGatewayService  # legacy: migrate to the options pattern


### PR DESCRIPTION
- Migrates the constructors to the options pattern so the built-in function, logging and pipeline services no longer take a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the now-paid-down rows from the linter allowlist.