### PR TITLE
refactor(gateway): take the logger via constructor options

### DIFF
--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -284,7 +284,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	}
 	server = grpc.NewServer(serverOpts...)
 
-	gatewayService := NewGatewayService(registry, log)
+	gatewayService := NewGatewayService(registry, WithGatewayServiceLog(log))
 	ynpb.RegisterGatewayServer(server, gatewayService)
 
 	ynpb.RegisterAuthServiceServer(server, authService)
@@ -347,7 +347,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 			}
 		} else {
 			// Out-of-process: wrap in a ServiceRunner.
-			runner := NewServiceRunner(entry.service, cfg.Server.Endpoint, cfg.Server.TLS, log)
+			runner := NewServiceRunner(entry.service, cfg.Server.Endpoint, cfg.Server.TLS, WithServiceRunnerLog(log))
 			serviceRunners = append(serviceRunners, runner)
 		}
 

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -191,7 +191,7 @@ func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 	require.NoError(t, err)
 
 	gatewayServer := grpc.NewServer()
-	ynpb.RegisterGatewayServer(gatewayServer, NewGatewayService(NewBackendRegistry(), zap.NewNop()))
+	ynpb.RegisterGatewayServer(gatewayServer, NewGatewayService(NewBackendRegistry()))
 
 	var gatewayGroup errgroup.Group
 	gatewayGroup.Go(func() error {
@@ -211,7 +211,6 @@ func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 		&blockingReadinessService{endpoint: backendAddr},
 		gatewayListener.Addr().String(),
 		nil,
-		zap.NewNop(),
 	)
 
 	ctx, cancel := context.WithCancel(t.Context())

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
@@ -270,7 +269,7 @@ func TestGatewayService_RegisterKindResolution(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := NewBackendRegistry()
-			svc := NewGatewayService(reg, zap.NewNop())
+			svc := NewGatewayService(reg)
 
 			_, err := svc.Register(t.Context(), &ynpb.RegisterRequest{
 				Backend: &ynpb.BackendDesc{

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -35,14 +35,39 @@ type ServiceRunner struct {
 	log             *zap.Logger
 }
 
+// ServiceRunnerOption configures the ServiceRunner constructor.
+type ServiceRunnerOption func(*serviceRunnerOptions)
+
+type serviceRunnerOptions struct {
+	Log *zap.Logger
+}
+
+func newServiceRunnerOptions() *serviceRunnerOptions {
+	return &serviceRunnerOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithServiceRunnerLog sets the logger for the service runner.
+func WithServiceRunnerLog(log *zap.Logger) ServiceRunnerOption {
+	return func(o *serviceRunnerOptions) {
+		o.Log = log
+	}
+}
+
 // NewServiceRunner creates a new ServiceRunner for the given service.
 func NewServiceRunner(
 	module Service,
 	gatewayEndpoint string,
 	gatewayTLS *TLSConfig,
-	log *zap.Logger,
+	options ...ServiceRunnerOption,
 ) *ServiceRunner {
-	log = log.Named(module.Name()).With(zap.String("module", module.Name()))
+	opts := newServiceRunnerOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	log := opts.Log.Named(module.Name()).With(zap.String("module", module.Name()))
 
 	interceptors := []grpc.UnaryServerInterceptor{xgrpc.AccessLogInterceptor(log)}
 	if provider, ok := module.(UnaryInterceptedService); ok {

--- a/controlplane/gateway/runner_test.go
+++ b/controlplane/gateway/runner_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
 	"github.com/stretchr/testify/require"
@@ -103,7 +102,7 @@ func TestServiceRunner_registerClosesGatewayClientConnection(t *testing.T) {
 
 	trackingListener := newConnectionTrackingListener(gatewayListener)
 	backendRegistry := NewBackendRegistry()
-	gatewayService := NewGatewayService(backendRegistry, zap.NewNop())
+	gatewayService := NewGatewayService(backendRegistry)
 
 	gatewayServer := grpc.NewServer()
 	ynpb.RegisterGatewayServer(gatewayServer, gatewayService)
@@ -113,7 +112,7 @@ func TestServiceRunner_registerClosesGatewayClientConnection(t *testing.T) {
 		_ = gatewayServer.Serve(trackingListener)
 	}()
 
-	serviceRunner := NewServiceRunner(&fakeService{}, trackingListener.Addr().String(), nil, zap.NewNop())
+	serviceRunner := NewServiceRunner(&fakeService{}, trackingListener.Addr().String(), nil)
 
 	backendAddrListener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)

--- a/controlplane/gateway/service.go
+++ b/controlplane/gateway/service.go
@@ -45,11 +45,36 @@ type GatewayService struct {
 	log      *zap.Logger
 }
 
+// GatewayServiceOption configures the GatewayService constructor.
+type GatewayServiceOption func(*gatewayServiceOptions)
+
+type gatewayServiceOptions struct {
+	Log *zap.Logger
+}
+
+func newGatewayServiceOptions() *gatewayServiceOptions {
+	return &gatewayServiceOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithGatewayServiceLog sets the logger for the gateway service.
+func WithGatewayServiceLog(log *zap.Logger) GatewayServiceOption {
+	return func(o *gatewayServiceOptions) {
+		o.Log = log
+	}
+}
+
 // NewGatewayService creates a new GatewayService.
-func NewGatewayService(registry *BackendRegistry, log *zap.Logger) *GatewayService {
+func NewGatewayService(registry *BackendRegistry, options ...GatewayServiceOption) *GatewayService {
+	opts := newGatewayServiceOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &GatewayService{
 		registry: registry,
-		log:      log,
+		log:      opts.Log,
 	}
 }
 

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -14,8 +14,6 @@
 # entry is itself a lint failure, so paying down the debt requires deleting
 # the row — the ledger is self-cleaning by construction.
 
-controlplane/gateway/runner.go:NewServiceRunner  # legacy: migrate to the options pattern
-controlplane/gateway/service.go:NewGatewayService  # legacy: migrate to the options pattern
 controlplane/internal/auth/basic/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 controlplane/internal/auth/sshcert/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 controlplane/internal/auth/sshkey/factory.go:NewFromConfig  # legacy: migrate to the options pattern


### PR DESCRIPTION
- Migrates the constructors to the options pattern so the gateway service runner and gateway service constructors no longer take a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the now-paid-down rows from the linter allowlist.