### PR TITLE
refactor(httpproxy): take the logger via a constructor option

### DIFF
--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -476,7 +476,7 @@ func (m *Gateway) runHTTPServer(ctx context.Context) error {
 		Handler: httpproxy.GzipMiddleware(
 			httpproxy.NewHTTPHandler(
 				m.registry,
-				m.log,
+				httpproxy.WithLog(m.log),
 			),
 		),
 	}

--- a/controlplane/httpproxy/proxy.go
+++ b/controlplane/httpproxy/proxy.go
@@ -33,11 +33,36 @@ type TransparentWebGRPCProxy struct {
 	log      *zap.Logger
 }
 
+// Option configures the HTTPHandler constructor.
+type Option func(*handlerOptions)
+
+type handlerOptions struct {
+	Log *zap.Logger
+}
+
+func newHandlerOptions() *handlerOptions {
+	return &handlerOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the HTTP handler.
+func WithLog(log *zap.Logger) Option {
+	return func(o *handlerOptions) {
+		o.Log = log
+	}
+}
+
 // NewHTTPHandler creates a new HTTPHandler.
-func NewHTTPHandler(registry BackendRegistry, log *zap.Logger) *TransparentWebGRPCProxy {
+func NewHTTPHandler(registry BackendRegistry, options ...Option) *TransparentWebGRPCProxy {
+	opts := newHandlerOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &TransparentWebGRPCProxy{
 		registry: registry,
-		log:      log,
+		log:      opts.Log,
 	}
 }
 

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -20,7 +20,6 @@ controlplane/builtin/pipeline.go:NewPipeline  # legacy: migrate to the options p
 controlplane/bundle/bundle.go:NewBundle  # legacy: migrate to the options pattern
 controlplane/gateway/runner.go:NewServiceRunner  # legacy: migrate to the options pattern
 controlplane/gateway/service.go:NewGatewayService  # legacy: migrate to the options pattern
-controlplane/httpproxy/proxy.go:NewHTTPHandler  # legacy: migrate to the options pattern
 controlplane/internal/auth/basic/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 controlplane/internal/auth/sshcert/factory.go:NewFromConfig  # legacy: migrate to the options pattern
 controlplane/internal/auth/sshkey/factory.go:NewFromConfig  # legacy: migrate to the options pattern


### PR DESCRIPTION
- Migrates the constructors to the options pattern so the HTTP handler constructor no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the now-paid-down row from the linter allowlist.