### PR TITLE
refactor(bundle): take the logger via a constructor option

### DIFF
--- a/controlplane/bundle/bundle.go
+++ b/controlplane/bundle/bundle.go
@@ -41,13 +41,38 @@ type Bundle struct {
 	services []gateway.Service
 }
 
+// Option configures the NewBundle constructor.
+type Option func(*bundleOptions)
+
+type bundleOptions struct {
+	Log *zap.Logger
+}
+
+func newBundleOptions() *bundleOptions {
+	return &bundleOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithLog sets the logger for the bundle.
+func WithLog(log *zap.Logger) Option {
+	return func(o *bundleOptions) {
+		o.Log = log
+	}
+}
+
 // NewBundle constructs every bundled module and device from the given config.
 func NewBundle(
 	modulesCfg ModulesConfig,
 	devicesCfg DevicesConfig,
-	log *zap.Logger,
+	options ...Option,
 ) (*Bundle, error) {
-	services, err := buildServices(modulesCfg, devicesCfg, log)
+	opts := newBundleOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
+	services, err := buildServices(modulesCfg, devicesCfg, opts.Log)
 	if err != nil {
 		return nil, err
 	}

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -106,7 +106,7 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 		zap.Uint32("instance_id", cfg.Gateway.InstanceID),
 	)
 
-	bundle, err := bundle.NewBundle(cfg.Modules, cfg.Devices, log)
+	bundle, err := bundle.NewBundle(cfg.Modules, cfg.Devices, bundle.WithLog(log))
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize bundle: %w", err)
 	}

--- a/lint/logger/allowlist.txt
+++ b/lint/logger/allowlist.txt
@@ -14,7 +14,6 @@
 # entry is itself a lint failure, so paying down the debt requires deleting
 # the row — the ledger is self-cleaning by construction.
 
-controlplane/bundle/bundle.go:NewBundle  # legacy: migrate to the options pattern
 controlplane/gateway/runner.go:NewServiceRunner  # legacy: migrate to the options pattern
 controlplane/gateway/service.go:NewGatewayService  # legacy: migrate to the options pattern
 controlplane/httpproxy/proxy.go:NewHTTPHandler  # legacy: migrate to the options pattern


### PR DESCRIPTION
- Migrates the constructors to the options pattern so the bundle constructor no longer takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Removes the now-paid-down row from the linter allowlist.