### PR TITLE
feat(filter): reject non-contiguous IPv4 network masks and non-bi-contiguous IPv6 masks

### DIFF
--- a/bindings/go/filter/types.go
+++ b/bindings/go/filter/types.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"encoding/binary"
 	"net"
 	"net/netip"
 )
@@ -46,6 +47,30 @@ func MustParseIPNet(s string) IPNet {
 		Addr: p.Addr(),
 		Mask: makePrefix6(p.Bits()),
 	}
+}
+
+// MaskIsValid reports whether the mask is a contiguous prefix mask.
+//
+// For IPv4 the whole 32-bit mask must be a single contiguous prefix. For
+// IPv6 the mask must be bi-contiguous: each 64-bit half is independently a
+// contiguous prefix, so a hole exactly at the /64 boundary is allowed while
+// a hole within a half is not.
+func (m IPNet) MaskIsValid() bool {
+	if m.Mask.Is4() {
+		bytes := m.Mask.As4()
+		return maskIsPrefix(binary.BigEndian.Uint32(bytes[:]))
+	}
+
+	bytes := m.Mask.As16()
+	return maskIsPrefix(binary.BigEndian.Uint64(bytes[:8])) &&
+		maskIsPrefix(binary.BigEndian.Uint64(bytes[8:]))
+}
+
+// maskIsPrefix reports whether mask is a contiguous run of 1-bits from the
+// most significant bit, with no gaps.
+func maskIsPrefix[T ~uint32 | ~uint64](mask T) bool {
+	inv := ^mask
+	return inv&(inv+1) == 0
 }
 
 type IPNets []IPNet

--- a/bindings/go/filter/types_test.go
+++ b/bindings/go/filter/types_test.go
@@ -1,0 +1,93 @@
+package filter
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIPNet_MaskIsValid verifies that MaskIsValid accepts contiguous prefix
+// masks (bi-contiguous for IPv6) and rejects masks with a hole inside
+// either half.
+func TestIPNet_MaskIsValid(t *testing.T) {
+	tests := []struct {
+		name string
+		net  IPNet
+		want bool
+	}{
+		{
+			name: "ipv4 /24",
+			net:  MustParseIPNet("192.0.2.0/24"),
+			want: true,
+		},
+		{
+			name: "ipv4 /0",
+			net:  MustParseIPNet("0.0.0.0/0"),
+			want: true,
+		},
+		{
+			name: "ipv4 /32",
+			net:  MustParseIPNet("192.0.2.1/32"),
+			want: true,
+		},
+		{
+			name: "ipv4 non-contiguous mask",
+			net: IPNet{
+				Addr: netip.AddrFrom4([4]byte{192, 0, 2, 0}),
+				Mask: netip.AddrFrom4([4]byte{255, 0, 255, 0}),
+			},
+			want: false,
+		},
+		{
+			name: "ipv6 bi-contiguous with hole at /64 boundary",
+			net: IPNet{
+				Addr: netip.IPv6Unspecified(),
+				Mask: netip.AddrFrom16([16]byte{
+					0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00,
+					0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00,
+				}),
+			},
+			want: true,
+		},
+		{
+			name: "ipv6 /0",
+			net:  MustParseIPNet("::/0"),
+			want: true,
+		},
+		{
+			name: "ipv6 /128",
+			net:  MustParseIPNet("2001:db8::1/128"),
+			want: true,
+		},
+		{
+			name: "ipv6 hole within hi half",
+			net: IPNet{
+				Addr: netip.IPv6Unspecified(),
+				Mask: netip.AddrFrom16([16]byte{
+					0xff, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00,
+					0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				}),
+			},
+			want: false,
+		},
+		{
+			name: "ipv6 hole within lo half",
+			net: IPNet{
+				Addr: netip.IPv6Unspecified(),
+				Mask: netip.AddrFrom16([16]byte{
+					0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+					0xff, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00,
+				}),
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.net.MaskIsValid()
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/common/filterpb/v1/convert.go
+++ b/common/filterpb/v1/convert.go
@@ -84,10 +84,24 @@ func ToIPNet(pb *IPNet) (filter.IPNet, error) {
 		)
 	}
 
-	return filter.IPNet{
+	net := filter.IPNet{
 		Addr: addr,
 		Mask: mask,
-	}, nil
+	}
+	if !net.MaskIsValid() {
+		if mask.Is4() {
+			return filter.IPNet{}, status.Error(
+				codes.InvalidArgument,
+				"network mask must be contiguous",
+			)
+		}
+		return filter.IPNet{}, status.Error(
+			codes.InvalidArgument,
+			"network mask must be bi-contiguous",
+		)
+	}
+
+	return net, nil
 }
 
 // ToNet4sFromPrefixes converts protobuf IPPrefix messages to filter

--- a/lib/filter/compiler.h
+++ b/lib/filter/compiler.h
@@ -66,6 +66,26 @@ filter_free(
 	memory_context_fini(&filter->memory_context);
 }
 
+static inline bool
+rule_net4_masks_are_valid(const struct net4 *nets, uint32_t count) {
+	for (uint32_t net_idx = 0; net_idx < count; ++net_idx) {
+		if (!filter_net4_mask_is_valid(nets[net_idx].mask)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+static inline bool
+rule_net6_masks_are_valid(const struct net6 *nets, uint32_t count) {
+	for (uint32_t net_idx = 0; net_idx < count; ++net_idx) {
+		if (!filter_net6_mask_is_valid(nets[net_idx].mask)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 static inline int
 filter_init(
 	struct filter *filter,
@@ -78,6 +98,43 @@ filter_init(
 	if (filter_compiler->lookup_count == 0) {
 		yanet_error_add(err, "filter has no lookups configured");
 		return -1;
+	}
+
+	for (uint32_t rule_idx = 0; rule_idx < rule_count; ++rule_idx) {
+		const struct filter_rule *rule = rules[rule_idx];
+		if (rule == NULL) {
+			continue;
+		}
+
+		if (!rule_net4_masks_are_valid(
+			    rule->net4.srcs, rule->net4.src_count
+		    ) ||
+		    !rule_net4_masks_are_valid(
+			    rule->net4.dsts, rule->net4.dst_count
+		    )) {
+			yanet_error_add(
+				err,
+				"filter rule %u has a non-contiguous IPv4 "
+				"network mask",
+				rule_idx
+			);
+			return -1;
+		}
+
+		if (!rule_net6_masks_are_valid(
+			    rule->net6.srcs, rule->net6.src_count
+		    ) ||
+		    !rule_net6_masks_are_valid(
+			    rule->net6.dsts, rule->net6.dst_count
+		    )) {
+			yanet_error_add(
+				err,
+				"filter rule %u has an IPv6 network mask "
+				"that is not bi-contiguous",
+				rule_idx
+			);
+			return -1;
+		}
 	}
 
 	memset(filter, 0, sizeof(struct filter));

--- a/lib/filter/compiler/helper.c
+++ b/lib/filter/compiler/helper.c
@@ -2,6 +2,35 @@
 #include "common/registry.h"
 #include "lib/filter/filter.h"
 
+#include <endian.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+// A fixed-width mask is a contiguous prefix when its inverse is a run of low
+// bits, so incrementing that inverse carries all the way out and clears it.
+static bool
+mask_is_prefix64(uint64_t mask) {
+	uint64_t inv = ~mask;
+	return (inv & (inv + 1)) == 0;
+}
+
+bool
+filter_net4_mask_is_valid(const uint8_t mask[NET4_LEN]) {
+	uint32_t bits;
+	memcpy(&bits, mask, sizeof(bits));
+	uint32_t inv = ~be32toh(bits);
+	return (inv & (inv + 1)) == 0;
+}
+
+bool
+filter_net6_mask_is_valid(const uint8_t mask[NET6_LEN]) {
+	uint64_t hi, lo;
+	memcpy(&hi, mask, sizeof(hi));
+	memcpy(&lo, mask + 8, sizeof(lo));
+	return mask_is_prefix64(be64toh(hi)) && mask_is_prefix64(be64toh(lo));
+}
+
 int
 init_dummy_registry(
 	struct memory_context *memory_context,

--- a/lib/filter/compiler/helper.h
+++ b/lib/filter/compiler/helper.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <stdbool.h>
+
 #include "common/memory.h"
+#include "common/network.h"
 #include "common/registry.h"
 #include "common/value.h"
 
@@ -35,3 +38,20 @@ lpm_collect_registry_iterator(uint32_t value, void *data) {
 	struct value_registry *registry = (struct value_registry *)data;
 	return value_registry_collect(registry, value);
 }
+
+// Checks that an IPv4 network mask is a contiguous prefix mask.
+//
+// A contiguous prefix mask is a run of set high bits followed only by zero
+// bits, which is the only shape the LPM-derived prefix length classifiers in
+// net4.c can represent correctly.
+bool
+filter_net4_mask_is_valid(const uint8_t mask[NET4_LEN]);
+
+// Checks that an IPv6 network mask is bi-contiguous.
+//
+// Bi-contiguous means each 64-bit half of the mask (bytes[0..7] and
+// bytes[8..15]) is independently a contiguous prefix mask, which matches how
+// net6.c derives a prefix length per half via popcount. A hole exactly at
+// the /64 boundary is therefore still accepted; a hole within a half is not.
+bool
+filter_net6_mask_is_valid(const uint8_t mask[NET6_LEN]);

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
 	"github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
@@ -256,6 +257,31 @@ func TestConvertRules_RejectsUnknownActionKind(t *testing.T) {
 	_, err := convertRules([]*aclpb.Rule{{
 		Actions: []*aclpb.Action{{Kind: aclpb.ActionKind(999)}},
 	}})
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestUpdateConfig_RejectsNonContiguousMask verifies that a rule with a
+// non-contiguous network mask is rejected with codes.InvalidArgument before
+// reaching the backend.
+func TestUpdateConfig_RejectsNonContiguousMask(t *testing.T) {
+	svc := newTestService(newFakeBackend(0))
+
+	req := &aclpb.UpdateConfigRequest{
+		Name: "acl0",
+		Rules: []*aclpb.Rule{
+			{
+				Srcs: []*filterpb.IPNet{
+					{
+						Addr: []byte{192, 0, 2, 0},
+						Mask: []byte{0xff, 0x00, 0xff, 0x00},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := svc.UpdateConfig(t.Context(), req)
 	require.Error(t, err)
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -1717,3 +1717,54 @@ func TestACL_IPv6Fragment_LaterFragment(t *testing.T) {
 	require.Len(t, result.Drop, 1, "non-first fragment must be dropped")
 	requireModuleCounterPackets(t, h, aclCounterPath("port0", "test"), "acl_no_match", 1)
 }
+
+// TestACL_RejectsNonContiguousIPv4Mask verifies that an IPv4 rule whose mask
+// is not a contiguous prefix (a hole between set bits) is rejected at config
+// update time instead of being silently mis-classified.
+func TestACL_RejectsNonContiguousIPv4Mask(t *testing.T) {
+	_, _, backend := setupACLHarness(t, []string{"port0"})
+
+	handle, err := backend.NewModule("reject4")
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	badMask := netip.AddrFrom4([4]byte{0xff, 0x00, 0xff, 0x00})
+	rules := []cacl.AclRule{
+		allow4Rule(
+			filter.IPNets{{Addr: netip.MustParseAddr("192.0.2.0"), Mask: badMask}},
+			filter.IPNets{filter.UnspecifiedIPv4},
+			udpProto,
+		),
+	}
+
+	err = handle.UpdateRules(rules)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "non-contiguous")
+}
+
+// TestACL_RejectsNonBiContiguousIPv6Mask verifies that an IPv6 rule whose
+// mask has a hole within the high 64-bit half is rejected at config update
+// time instead of being silently mis-classified.
+func TestACL_RejectsNonBiContiguousIPv6Mask(t *testing.T) {
+	_, _, backend := setupACLHarness(t, []string{"port0"})
+
+	handle, err := backend.NewModule("reject6")
+	require.NoError(t, err)
+	t.Cleanup(handle.Free)
+
+	badMask := netip.AddrFrom16([16]byte{
+		0xff, 0x00, 0xff, 0x00, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+	})
+	rules := []cacl.AclRule{
+		allow6Rule(
+			filter.IPNets{{Addr: netip.MustParseAddr("2001:db8::"), Mask: badMask}},
+			filter.IPNets{filter.UnspecifiedIPv6},
+			udpProto,
+		),
+	}
+
+	err = handle.UpdateRules(rules)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bi-contiguous")
+}


### PR DESCRIPTION
- Validate that IPv4 network masks are a contiguous prefix and IPv6 masks are bi-contiguous, so malformed masks are rejected instead of being silently mis-classified by the packet filter.
- Reject such masks at the control-plane boundary with an invalid-argument error so clients get a clear response, while the filter engine keeps the same check as a defense-in-depth safety net.
- Cover the behaviour with Go unit tests for the validator and an ACL service test for the rejection path.
