### PR TITLE
chore(meson): add a meson lint CI check and fix its findings

### DIFF
--- a/.github/workflows/meson-lint.yml
+++ b/.github/workflows/meson-lint.yml
@@ -1,0 +1,41 @@
+name: Meson Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/meson.build'
+      - '**/meson.options'
+      - 'meson_options.txt'
+      - '.github/workflows/meson-lint.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/meson.build'
+      - '**/meson.options'
+      - 'meson_options.txt'
+      - '.github/workflows/meson-lint.yml'
+
+jobs:
+  mesonlint:
+    name: mesonlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download mesonlint
+        run: |
+          curl -fsSL -o mesonlint.zip https://github.com/JCWasmx86/mesonlsp/releases/download/v5.0.3/mesonlint-x86_64-unknown-linux-musl.zip
+          unzip -q mesonlint.zip
+          chmod +x mesonlint
+
+      - name: Run mesonlint
+        run: |
+          ./mesonlint . 2>&1 | tee mesonlint.out || true
+          findings=$(grep -E '⚠️|🔴' mesonlint.out | grep -v 'subprojects/' || true)
+          if [ -n "$findings" ]; then
+            echo "Meson lint findings (fix these):"
+            echo "$findings"
+            exit 1
+          fi
+          echo "No meson lint findings."

--- a/meson.build
+++ b/meson.build
@@ -59,8 +59,8 @@ if not dataplane_only
   # Define common programs once to avoid duplication
   go = find_program('go', required: true)
   protoc = find_program('protoc', required: true)
-  protoc_gen_go = find_program('protoc-gen-go', required: true, version: '>=1.36.5')
-  protoc_gen_go_grpc = find_program('protoc-gen-go-grpc', required: true, version: '>=1.5.1')
+  find_program('protoc-gen-go', required: true, version: '>=1.36.5')
+  find_program('protoc-gen-go-grpc', required: true, version: '>=1.5.1')
 endif
 
 # Build CGO flags based on b_sanitize option


### PR DESCRIPTION
- Add a CI check that lints meson files with mesonlint, triggered only when meson files change, gating on real lint diagnostics rather than the tool's formatting default.
- Remove two unused program-lookup assignments in the root build definition that the linter flags, keeping the existence and version checks intact.