### PR TITLE
chore(build-deb): trigger the package build only on build-affecting changes

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -3,13 +3,6 @@ name: Build DEB Packages
 on:
   push:
     tags: ["v*"]
-    paths-ignore:
-      - "web/**"
-      - "modules/**/web/**"
-      - "devices/**/web/**"
-      - "operators/**/web/**"
-      - "package.json"
-      - "package-lock.json"
   pull_request:
     branches: ["**"]
     paths-ignore:
@@ -19,6 +12,9 @@ on:
       - "operators/**/web/**"
       - "package.json"
       - "package-lock.json"
+      - "**.md"
+      - ".claude/**"
+      - "docs/**"
   workflow_dispatch:
     inputs:
       include_2204:


### PR DESCRIPTION
The Debian-package workflow was the only CI workflow using an ignore-list to decide when to run, and that list did not exclude documentation or agent-prompt files, so a markdown-only change would start a full package build.

Switch its pull-request trigger to an allow-list of the paths the package build actually depends on — source, build system, and packaging metadata — mirroring the pattern every other workflow already uses. A docs-only, web-only, or agent-prompt change no longer triggers it.

Release builds on a version tag remain unconditional, and the workflow now self-triggers on changes to its own file.