### PR TITLE
fix(acl): use atomic snapshots for acl metrics collection

### DIFF
--- a/modules/acl/controlplane/acl_adapter.go
+++ b/modules/acl/controlplane/acl_adapter.go
@@ -79,6 +79,7 @@ func (m *ACLAdapter) RelinkConfigs(
 			fwstateName: fwstateConfig.Name(),
 		}
 	}
+	m.service.publishMetricsSnapshotLocked()
 
 	return nil
 }
@@ -124,6 +125,7 @@ func (m *ACLAdapter) LinkConfigs(
 			fwstateName: fwstateConfig.Name(),
 		}
 	}
+	m.service.publishMetricsSnapshotLocked()
 
 	return nil
 }

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -79,8 +79,7 @@ func (m *ACLService) Metrics() ([]*commonpb.Metric, error) {
 }
 
 func (m *ACLService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	snapshot := m.metricsState.load()
 
 	dpConfig := m.backend.DPConfig()
 	if dpConfig == nil {
@@ -192,8 +191,7 @@ func (m *ACLService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 				{Name: "config", Value: configName},
 			}
 
-			if cfg, ok := m.configs[configName]; ok && cfg.acl != nil {
-				info := cfg.acl.GetInfo()
+			if info, ok := snapshot.configInfo(configName); ok {
 				result = append(
 					result,
 					makeGauge(

--- a/modules/acl/controlplane/metrics_snapshot.go
+++ b/modules/acl/controlplane/metrics_snapshot.go
@@ -1,0 +1,41 @@
+package acl
+
+import (
+	"sync/atomic"
+
+	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
+)
+
+// aclMetricsSnapshot is read-only after publication.
+type aclMetricsSnapshot struct {
+	configInfos map[string]cacl.AclConfigInfo
+}
+
+func (m *aclMetricsSnapshot) containsConfig(name string) bool {
+	_, ok := m.configInfos[name]
+	return ok
+}
+
+func (m *aclMetricsSnapshot) configInfo(name string) (cacl.AclConfigInfo, bool) {
+	info, ok := m.configInfos[name]
+	return info, ok
+}
+
+// aclMetricsState owns the atomically published metrics metadata.
+type aclMetricsState struct {
+	snapshot atomic.Pointer[aclMetricsSnapshot]
+}
+
+func newACLMetricsState() *aclMetricsState {
+	m := &aclMetricsState{}
+	m.publish(make(map[string]cacl.AclConfigInfo))
+	return m
+}
+
+func (m *aclMetricsState) load() *aclMetricsSnapshot {
+	return m.snapshot.Load()
+}
+
+func (m *aclMetricsState) publish(configInfos map[string]cacl.AclConfigInfo) {
+	m.snapshot.Store(&aclMetricsSnapshot{configInfos: configInfos})
+}

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -94,6 +94,8 @@ type ACLService struct {
 	configs map[string]aclConfig
 	metrics *grpcmetrics.ServerMetrics
 
+	metricsState *aclMetricsState
+
 	log *zap.Logger
 }
 
@@ -105,9 +107,10 @@ func NewACLService(backend Backend, options ...Option) *ACLService {
 	}
 
 	m := &ACLService{
-		backend: backend,
-		configs: map[string]aclConfig{},
-		log:     opts.Log,
+		backend:      backend,
+		configs:      map[string]aclConfig{},
+		metricsState: newACLMetricsState(),
+		log:          opts.Log,
 	}
 	if opts.Metrics != nil {
 		m.metrics = opts.Metrics(m.retention)
@@ -126,15 +129,9 @@ func (m *ACLService) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return m.metrics.UnaryServerInterceptor()
 }
 
-// retention snapshots the live ACL config names and returns a predicate that
-// keeps series whose "config" label is still live (or absent).
+// retention keeps metrics for active configs.
 func (m *ACLService) retention() func(metrics.MetricID) bool {
-	m.mu.Lock()
-	configNames := make(map[string]struct{}, len(m.configs))
-	for name := range m.configs {
-		configNames[name] = struct{}{}
-	}
-	m.mu.Unlock()
+	snapshot := m.metricsState.load()
 
 	return func(id metrics.MetricID) bool {
 		config := id.Labels["config"]
@@ -142,9 +139,21 @@ func (m *ACLService) retention() func(metrics.MetricID) bool {
 			return true
 		}
 
-		_, ok := configNames[config]
-		return ok
+		return snapshot.containsConfig(config)
 	}
+}
+
+// publishMetricsSnapshotLocked refreshes metric metadata. Caller must hold m.mu.
+func (m *ACLService) publishMetricsSnapshotLocked() {
+	configInfos := make(map[string]cacl.AclConfigInfo, len(m.configs))
+	for name, cfg := range m.configs {
+		if cfg.acl == nil {
+			continue
+		}
+		configInfos[name] = *cfg.acl.GetInfo()
+	}
+
+	m.metricsState.publish(configInfos)
 }
 
 func labeler(fullMethod string, req any) metrics.Labels {
@@ -289,6 +298,7 @@ func (m *ACLService) UpdateConfig(
 		acl:         handle,
 		fwstateName: oldConfigs.fwstateName,
 	}
+	m.publishMetricsSnapshotLocked()
 
 	return &aclpb.UpdateConfigResponse{}, nil
 }
@@ -363,22 +373,9 @@ func (m *ACLService) DeleteConfig(
 	}
 
 	delete(m.configs, name)
+	m.publishMetricsSnapshotLocked()
 
 	response := &aclpb.DeleteConfigResponse{}
 
 	return response, nil
-}
-
-// GetInfo returns the compiled configuration metadata for the named ACL module,
-// or nil if no config with that name is loaded.
-func (m *ACLService) GetInfo(name string) *cacl.AclConfigInfo {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	cfg, ok := m.configs[name]
-	if !ok {
-		return nil
-	}
-
-	return cfg.acl.GetInfo()
 }

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -1,20 +1,26 @@
 package acl
 
 import (
+	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
 	"github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
 )
+
+const metricsConcurrencyTestTimeout = 5 * time.Second
 
 // fakeHandle is an in-memory implementation of ModuleHandle for tests.
 type fakeHandle struct {
@@ -68,6 +74,53 @@ type fakeBackend struct {
 	newModuleErr error
 	deleteErr    error
 	memoryBytes  uint64
+}
+
+type updateBlock struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+// blockingUpdateBackend can pause one UpdateModule call without holding the
+// fake backend mutex, allowing concurrent metrics collection in the test.
+type blockingUpdateBackend struct {
+	*fakeBackend
+
+	blockMu   sync.Mutex
+	nextBlock *updateBlock
+}
+
+func newBlockingUpdateBackend(memoryBytes uint64) *blockingUpdateBackend {
+	return &blockingUpdateBackend{fakeBackend: newFakeBackend(memoryBytes)}
+}
+
+func (m *blockingUpdateBackend) blockNextUpdate() (<-chan struct{}, func()) {
+	m.blockMu.Lock()
+	defer m.blockMu.Unlock()
+
+	block := &updateBlock{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m.nextBlock = block
+
+	return block.entered, sync.OnceFunc(func() {
+		close(block.release)
+	})
+}
+
+func (m *blockingUpdateBackend) UpdateModule(handle ModuleHandle) error {
+	m.blockMu.Lock()
+	block := m.nextBlock
+	m.nextBlock = nil
+	m.blockMu.Unlock()
+
+	if block != nil {
+		close(block.entered)
+		<-block.release
+	}
+
+	return m.fakeBackend.UpdateModule(handle)
 }
 
 func newFakeBackend(memoryBytes uint64) *fakeBackend {
@@ -306,4 +359,102 @@ func TestUpdateConfig_ConcurrentRace(t *testing.T) {
 	}
 
 	require.NoError(t, wg.Wait())
+}
+
+// TestMetrics_DoesNotWaitForUpdateConfig verifies that a config update holding
+// ACLService.mu cannot stall metrics collection.
+func TestMetrics_DoesNotWaitForUpdateConfig(t *testing.T) {
+	backend := newBlockingUpdateBackend(0)
+	svc := NewACLService(backend, WithMetrics(grpcmetrics.NewFactory(
+		grpcmetrics.WithLabeler(labeler),
+	)))
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name: "acl0",
+	})
+	require.NoError(t, err)
+
+	// The fake backend has no dataplane config, so record a gRPC series first
+	// to verify that Metrics returns actual data while the update is blocked.
+	_, err = svc.UnaryServerInterceptor()(
+		t.Context(),
+		&aclpb.ShowConfigRequest{Name: "acl0"},
+		&grpc.UnaryServerInfo{FullMethod: aclpb.ACLService_ShowConfig_FullMethodName},
+		func(context.Context, any) (any, error) {
+			return &aclpb.ShowConfigResponse{}, nil
+		},
+	)
+	require.NoError(t, err)
+
+	updateEntered, releaseUpdate := backend.blockNextUpdate()
+	t.Cleanup(releaseUpdate)
+
+	updateDone := make(chan error, 1)
+	go func() {
+		_, updateErr := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+			Name: "acl0",
+			Rules: []*aclpb.Rule{{
+				Actions: []*aclpb.Action{{
+					Kind: aclpb.ActionKind_ACTION_KIND_DENY,
+				}},
+			}},
+		})
+		updateDone <- updateErr
+	}()
+
+	select {
+	case <-updateEntered:
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("UpdateConfig did not reach the blocked backend update")
+	}
+
+	type metricsResult struct {
+		count int
+		err   error
+	}
+	metricsDone := make(chan metricsResult, 1)
+	go func() {
+		collected, metricsErr := svc.Metrics()
+		metricsDone <- metricsResult{count: len(collected), err: metricsErr}
+	}()
+
+	select {
+	case result := <-metricsDone:
+		require.NoError(t, result.err)
+		assert.Greater(t, result.count, 0)
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("metrics collection waited for UpdateConfig")
+	}
+
+	releaseUpdate()
+	select {
+	case updateErr := <-updateDone:
+		require.NoError(t, updateErr)
+	case <-time.After(metricsConcurrencyTestTimeout):
+		t.Fatal("UpdateConfig did not finish after the backend was released")
+	}
+}
+
+func TestMetricsSnapshotTracksConfigLifecycle(t *testing.T) {
+	svc := newTestService(newFakeBackend(0))
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name: "acl0",
+	})
+	require.NoError(t, err)
+
+	beforeDelete := svc.metricsState.load()
+	info, ok := beforeDelete.configInfo("acl0")
+	require.True(t, ok)
+	assert.Equal(t, uint64(42), info.CompilationTimeNs)
+	assert.Equal(t, uint64(7), info.FilterRuleCountIp4)
+
+	_, err = svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{
+		Name: "acl0",
+	})
+	require.NoError(t, err)
+
+	afterDelete := svc.metricsState.load()
+	assert.False(t, afterDelete.containsConfig("acl0"))
+	assert.True(t, beforeDelete.containsConfig("acl0"), "published snapshots must remain immutable")
 }


### PR DESCRIPTION
As a temporary solution: ACL metadata is now read from an immutable snapshot without acquiring ACLService.mu, preventing long-running config updates from blocking metrics collection. Dynamic counters are still collected directly from the dataplane. A more fundamental lock-scope refactoring will follow separately