### PR TITLE
refactor(cli): extract shared operator readiness reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,6 +3102,7 @@ dependencies = [
  "tonic",
  "tower",
  "uuid",
+ "yanet-readinesspb",
  "yanet-ynpb",
 ]
 
@@ -3440,10 +3441,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "colored",
  "log",
  "prost",
- "tabled",
  "tokio",
  "tonic",
  "tonic-build",
@@ -3457,10 +3456,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "colored",
  "log",
  "prost",
- "tabled",
  "tokio",
  "tonic",
  "tonic-build",
@@ -3492,12 +3489,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "clap_complete",
- "colored",
  "log",
  "prost",
  "serde",
  "serde_json",
- "tabled",
  "tokio",
  "tonic",
  "tonic-build",

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -19,6 +19,7 @@ prost = "0.13"
 prost-types = "0.13"
 tonic = { version = "0.13", features = ["gzip"] }
 ynpb = { path = "../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
+readinesspb = { path = "../../common/rust/readinesspb", version = "0.1", package = "yanet-readinesspb" }
 tower = "0.5"
 http = "1"
 ssh-key = "0.6"

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod errors;
 pub mod humanfmt;
 pub mod logging;
 pub mod output;
+pub mod readiness;
 
 /// Initialise the logger and output backend from a `Format` choice.
 ///

--- a/cli/core/src/readiness.rs
+++ b/cli/core/src/readiness.rs
@@ -1,0 +1,202 @@
+//! Shared readiness reporting for operator CLIs.
+//!
+//! Renders the response of a `ReadinessService::Ready` RPC into a table plus
+//! a one-line summary, so each operator CLI only has to make the RPC call and
+//! hand the result to `report`.
+
+use core::fmt::{self, Display, Formatter};
+use std::{collections::HashSet, time::SystemTime};
+
+use colored::Colorize;
+use tabled::{
+    settings::{
+        object::{Columns, Rows},
+        style::{BorderColor, HorizontalLine},
+        Color, Style,
+    },
+    Table, Tabled,
+};
+
+use crate::{display, humanfmt, output};
+
+/// Renders a `Ready` RPC response and reports whether everything is ready.
+///
+/// Prints a readiness table for `scopes`, a `missing (not registered):` line
+/// for any `requested` scope name absent from `scopes`, and a summary line,
+/// all through `output::data`. Returns `true` only when every scope in
+/// `scopes` is `STATE_READY` and none of the `requested` names is missing.
+pub fn report(scopes: &[readinesspb::pb::Scope], requested: &[String]) -> bool {
+    let missing = missing_scopes(scopes, requested);
+    let all_ready = scopes.iter().all(is_ready) && missing.is_empty();
+
+    let total = scopes.len();
+    let ready_count = scopes.iter().filter(|scope| is_ready(scope)).count();
+
+    output::data(
+        &scopes,
+        scopes.is_empty() && missing.is_empty(),
+        format_args!("no scopes"),
+        || {
+            let mut rows: Vec<ReadinessRow> = scopes.iter().map(ReadinessRow::from).collect();
+            rows.sort_by(|a, b| a.scope.cmp(&b.scope));
+
+            if !rows.is_empty() {
+                print_readiness_table(rows);
+            }
+
+            if !missing.is_empty() {
+                let missing_list = missing.join(", ");
+                let label = "missing (not registered):";
+
+                if output::is_colored() {
+                    println!("{} {}", label.red(), missing_list.red());
+                } else {
+                    println!("{label} {missing_list}");
+                }
+            }
+
+            let missing_count = missing.len();
+
+            if missing_count > 0 {
+                println!("summary: {ready_count}/{total} ready, {missing_count} requested scope missing");
+            } else {
+                println!("summary: {ready_count}/{total} ready");
+            }
+        },
+    );
+
+    all_ready
+}
+
+/// Returns the `requested` scope names absent from `scopes`.
+fn missing_scopes<'a>(scopes: &[readinesspb::pb::Scope], requested: &'a [String]) -> Vec<&'a str> {
+    let returned_names: HashSet<&str> = scopes.iter().map(|scope| scope.name.as_str()).collect();
+
+    requested
+        .iter()
+        .map(String::as_str)
+        .filter(|name| !returned_names.contains(name))
+        .collect()
+}
+
+/// Reports whether `scope` is `STATE_READY`.
+fn is_ready(scope: &readinesspb::pb::Scope) -> bool {
+    scope.state == readinesspb::pb::State::Ready as i32
+}
+
+/// Wraps a readiness state for colored display in the table.
+struct StateCell(readinesspb::pb::State);
+
+impl Display for StateCell {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
+        let StateCell(state) = self;
+        let name = state.as_str_name().strip_prefix("STATE_").unwrap_or_default();
+
+        if output::is_colored() {
+            let colored = match state {
+                readinesspb::pb::State::Ready => name.green().to_string(),
+                readinesspb::pb::State::Degraded => name.yellow().to_string(),
+                readinesspb::pb::State::NotReady => name.red().to_string(),
+                readinesspb::pb::State::Unspecified | readinesspb::pb::State::Unknown => {
+                    name.truecolor(127, 127, 127).to_string()
+                }
+            };
+            write!(f, "{colored}")
+        } else {
+            write!(f, "{name}")
+        }
+    }
+}
+
+#[derive(Debug, Tabled)]
+struct ReadinessRow {
+    #[tabled(rename = "Scope")]
+    scope: String,
+    #[tabled(rename = "State")]
+    state: String,
+    #[tabled(rename = "Last Transition")]
+    last_transition: String,
+    #[tabled(rename = "Observed")]
+    observed: String,
+    #[tabled(rename = "Reasons")]
+    reasons: String,
+}
+
+impl From<&readinesspb::pb::Scope> for ReadinessRow {
+    fn from(scope: &readinesspb::pb::Scope) -> Self {
+        let state = readinesspb::pb::State::try_from(scope.state).unwrap_or_default();
+        let state_cell = StateCell(state);
+
+        let reasons = scope
+            .reasons
+            .iter()
+            .map(|reason| format!("{}: {}", reason.code, reason.message))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        Self {
+            scope: scope.name.clone(),
+            state: state_cell.to_string(),
+            last_transition: humanfmt::format_age(scope.last_transition_time.as_ref(), SystemTime::now())
+                .unwrap_or_else(|| "-".to_string()),
+            observed: humanfmt::format_age(scope.observed_at.as_ref(), SystemTime::now())
+                .unwrap_or_else(|| "-".to_string()),
+            reasons,
+        }
+    }
+}
+
+fn print_readiness_table(rows: Vec<ReadinessRow>) {
+    let mut table = Table::new(&rows);
+    table.with(
+        Style::modern()
+            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
+            .remove_horizontal(),
+    );
+
+    if output::is_colored() {
+        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
+        table.modify(Rows::first(), Color::BOLD);
+    }
+
+    display::fit_terminal_width(&mut table);
+    println!("{table}");
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn scope(name: &str, state: readinesspb::pb::State) -> readinesspb::pb::Scope {
+        readinesspb::pb::Scope {
+            name: name.to_owned(),
+            state: state as i32,
+            reasons: Vec::new(),
+            observed_at: None,
+            last_transition_time: None,
+        }
+    }
+
+    #[test]
+    fn missing_scopes_reports_requested_names_absent_from_scopes() {
+        let scopes = vec![scope("rib", readinesspb::pb::State::Ready)];
+        let requested = vec!["rib".to_owned(), "fib".to_owned()];
+
+        assert_eq!(vec!["fib"], missing_scopes(&scopes, &requested));
+    }
+
+    #[test]
+    fn missing_scopes_is_empty_when_every_requested_name_is_returned() {
+        let scopes = vec![scope("rib", readinesspb::pb::State::Ready)];
+        let requested = vec!["rib".to_owned()];
+
+        assert!(missing_scopes(&scopes, &requested).is_empty());
+    }
+
+    #[test]
+    fn is_ready_true_only_for_state_ready() {
+        assert!(is_ready(&scope("rib", readinesspb::pb::State::Ready)));
+        assert!(!is_ready(&scope("rib", readinesspb::pb::State::Degraded)));
+        assert!(!is_ready(&scope("rib", readinesspb::pb::State::NotReady)));
+    }
+}

--- a/operators/decap/cli/Cargo.toml
+++ b/operators/decap/cli/Cargo.toml
@@ -16,8 +16,6 @@ clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 log = "0.4"
-colored = "3"
-tabled = { version = "0.18", features = ["ansi"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
 

--- a/operators/decap/cli/src/main.rs
+++ b/operators/decap/cli/src/main.rs
@@ -3,26 +3,14 @@
 //! Connects to a gRPC endpoint exposing the operator's `ReadinessService`
 //! and reports per-scope readiness state.
 
-use core::fmt::{self, Display, Formatter};
-use std::time::SystemTime;
-
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use colored::Colorize;
-use tabled::{
-    Table, Tabled,
-    settings::{
-        Color, Style,
-        object::{Columns, Rows},
-        style::{BorderColor, HorizontalLine},
-    },
-};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
-    humanfmt,
     output::{self, CommonFormat},
+    readiness,
 };
 
 use crate::operatorpb::readiness_service_client::ReadinessServiceClient;
@@ -124,142 +112,6 @@ impl DecapOperatorService {
             .map_err(self.service.status("ready"))?
             .into_inner();
 
-        let returned_names: std::collections::HashSet<&str> =
-            response.scopes.iter().map(|scope| scope.name.as_str()).collect();
-
-        let missing: Vec<&str> = cmd
-            .scopes
-            .iter()
-            .map(String::as_str)
-            .filter(|name| !returned_names.contains(name))
-            .collect();
-
-        let all_scopes_ready = response
-            .scopes
-            .iter()
-            .all(|scope| scope.state == readinesspb::pb::State::Ready as i32);
-
-        let all_ready = all_scopes_ready && missing.is_empty();
-
-        let total = response.scopes.len();
-        let ready_count = response
-            .scopes
-            .iter()
-            .filter(|scope| scope.state == readinesspb::pb::State::Ready as i32)
-            .count();
-
-        output::data(
-            &response.scopes,
-            response.scopes.is_empty() && missing.is_empty(),
-            format_args!("no scopes"),
-            || {
-                let mut rows: Vec<ReadinessRow> = response.scopes.iter().map(ReadinessRow::from).collect();
-                rows.sort_by(|a, b| a.scope.cmp(&b.scope));
-
-                if !rows.is_empty() {
-                    print_readiness_table(rows);
-                }
-
-                if !missing.is_empty() {
-                    let missing_list = missing.join(", ");
-                    let label = "missing (not registered):";
-
-                    if output::is_colored() {
-                        println!("{} {}", label.red(), missing_list.red());
-                    } else {
-                        println!("{label} {missing_list}");
-                    }
-                }
-
-                let missing_count = missing.len();
-
-                if missing_count > 0 {
-                    println!("summary: {ready_count}/{total} ready, {missing_count} requested scope missing");
-                } else {
-                    println!("summary: {ready_count}/{total} ready");
-                }
-            },
-        );
-
-        Ok(all_ready)
+        Ok(readiness::report(&response.scopes, &cmd.scopes))
     }
-}
-
-/// Wraps a readiness state for colored display in the table.
-pub struct StateCell(readinesspb::pb::State);
-
-impl Display for StateCell {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let StateCell(state) = self;
-        let name = state.as_str_name().strip_prefix("STATE_").unwrap_or_default();
-
-        if output::is_colored() {
-            let colored = match state {
-                readinesspb::pb::State::Ready => name.green().to_string(),
-                readinesspb::pb::State::Degraded => name.yellow().to_string(),
-                readinesspb::pb::State::NotReady => name.red().to_string(),
-                readinesspb::pb::State::Unspecified | readinesspb::pb::State::Unknown => {
-                    name.truecolor(127, 127, 127).to_string()
-                }
-            };
-            write!(f, "{colored}")
-        } else {
-            write!(f, "{name}")
-        }
-    }
-}
-
-#[derive(Debug, Tabled)]
-pub struct ReadinessRow {
-    #[tabled(rename = "Scope")]
-    pub scope: String,
-    #[tabled(rename = "State")]
-    pub state: String,
-    #[tabled(rename = "Last Transition")]
-    pub last_transition: String,
-    #[tabled(rename = "Observed")]
-    pub observed: String,
-    #[tabled(rename = "Reasons")]
-    pub reasons: String,
-}
-
-impl From<&readinesspb::pb::Scope> for ReadinessRow {
-    fn from(scope: &readinesspb::pb::Scope) -> Self {
-        let state = readinesspb::pb::State::try_from(scope.state).unwrap_or_default();
-        let state_cell = StateCell(state);
-
-        let reasons = scope
-            .reasons
-            .iter()
-            .map(|reason| format!("{}: {}", reason.code, reason.message))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        Self {
-            scope: scope.name.clone(),
-            state: state_cell.to_string(),
-            last_transition: humanfmt::format_age(scope.last_transition_time.as_ref(), SystemTime::now())
-                .unwrap_or_else(|| "-".to_string()),
-            observed: humanfmt::format_age(scope.observed_at.as_ref(), SystemTime::now())
-                .unwrap_or_else(|| "-".to_string()),
-            reasons,
-        }
-    }
-}
-
-fn print_readiness_table(rows: Vec<ReadinessRow>) {
-    let mut table = Table::new(&rows);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
-
-    if output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-        table.modify(Rows::first(), Color::BOLD);
-    }
-
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
 }

--- a/operators/forward/cli/Cargo.toml
+++ b/operators/forward/cli/Cargo.toml
@@ -16,8 +16,6 @@ clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 log = "0.4"
-colored = "3"
-tabled = { version = "0.18", features = ["ansi"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
 

--- a/operators/forward/cli/src/main.rs
+++ b/operators/forward/cli/src/main.rs
@@ -3,26 +3,14 @@
 //! Connects to a gRPC endpoint exposing the operator's `ReadinessService`
 //! and reports per-scope readiness state.
 
-use core::fmt::{self, Display, Formatter};
-use std::time::SystemTime;
-
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use colored::Colorize;
-use tabled::{
-    Table, Tabled,
-    settings::{
-        Color, Style,
-        object::{Columns, Rows},
-        style::{BorderColor, HorizontalLine},
-    },
-};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
-    humanfmt,
     output::{self, CommonFormat},
+    readiness,
 };
 
 use crate::operatorpb::readiness_service_client::ReadinessServiceClient;
@@ -124,142 +112,6 @@ impl ForwardOperatorService {
             .map_err(self.service.status("ready"))?
             .into_inner();
 
-        let returned_names: std::collections::HashSet<&str> =
-            response.scopes.iter().map(|scope| scope.name.as_str()).collect();
-
-        let missing: Vec<&str> = cmd
-            .scopes
-            .iter()
-            .map(String::as_str)
-            .filter(|name| !returned_names.contains(name))
-            .collect();
-
-        let all_scopes_ready = response
-            .scopes
-            .iter()
-            .all(|scope| scope.state == readinesspb::pb::State::Ready as i32);
-
-        let all_ready = all_scopes_ready && missing.is_empty();
-
-        let total = response.scopes.len();
-        let ready_count = response
-            .scopes
-            .iter()
-            .filter(|scope| scope.state == readinesspb::pb::State::Ready as i32)
-            .count();
-
-        output::data(
-            &response.scopes,
-            response.scopes.is_empty() && missing.is_empty(),
-            format_args!("no scopes"),
-            || {
-                let mut rows: Vec<ReadinessRow> = response.scopes.iter().map(ReadinessRow::from).collect();
-                rows.sort_by(|a, b| a.scope.cmp(&b.scope));
-
-                if !rows.is_empty() {
-                    print_readiness_table(rows);
-                }
-
-                if !missing.is_empty() {
-                    let missing_list = missing.join(", ");
-                    let label = "missing (not registered):";
-
-                    if output::is_colored() {
-                        println!("{} {}", label.red(), missing_list.red());
-                    } else {
-                        println!("{label} {missing_list}");
-                    }
-                }
-
-                let missing_count = missing.len();
-
-                if missing_count > 0 {
-                    println!("summary: {ready_count}/{total} ready, {missing_count} requested scope missing");
-                } else {
-                    println!("summary: {ready_count}/{total} ready");
-                }
-            },
-        );
-
-        Ok(all_ready)
+        Ok(readiness::report(&response.scopes, &cmd.scopes))
     }
-}
-
-/// Wraps a readiness state for colored display in the table.
-pub struct StateCell(readinesspb::pb::State);
-
-impl Display for StateCell {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let StateCell(state) = self;
-        let name = state.as_str_name().strip_prefix("STATE_").unwrap_or_default();
-
-        if output::is_colored() {
-            let colored = match state {
-                readinesspb::pb::State::Ready => name.green().to_string(),
-                readinesspb::pb::State::Degraded => name.yellow().to_string(),
-                readinesspb::pb::State::NotReady => name.red().to_string(),
-                readinesspb::pb::State::Unspecified | readinesspb::pb::State::Unknown => {
-                    name.truecolor(127, 127, 127).to_string()
-                }
-            };
-            write!(f, "{colored}")
-        } else {
-            write!(f, "{name}")
-        }
-    }
-}
-
-#[derive(Debug, Tabled)]
-pub struct ReadinessRow {
-    #[tabled(rename = "Scope")]
-    pub scope: String,
-    #[tabled(rename = "State")]
-    pub state: String,
-    #[tabled(rename = "Last Transition")]
-    pub last_transition: String,
-    #[tabled(rename = "Observed")]
-    pub observed: String,
-    #[tabled(rename = "Reasons")]
-    pub reasons: String,
-}
-
-impl From<&readinesspb::pb::Scope> for ReadinessRow {
-    fn from(scope: &readinesspb::pb::Scope) -> Self {
-        let state = readinesspb::pb::State::try_from(scope.state).unwrap_or_default();
-        let state_cell = StateCell(state);
-
-        let reasons = scope
-            .reasons
-            .iter()
-            .map(|reason| format!("{}: {}", reason.code, reason.message))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        Self {
-            scope: scope.name.clone(),
-            state: state_cell.to_string(),
-            last_transition: humanfmt::format_age(scope.last_transition_time.as_ref(), SystemTime::now())
-                .unwrap_or_else(|| "-".to_string()),
-            observed: humanfmt::format_age(scope.observed_at.as_ref(), SystemTime::now())
-                .unwrap_or_else(|| "-".to_string()),
-            reasons,
-        }
-    }
-}
-
-fn print_readiness_table(rows: Vec<ReadinessRow>) {
-    let mut table = Table::new(&rows);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
-
-    if output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-        table.modify(Rows::first(), Color::BOLD);
-    }
-
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
 }

--- a/operators/pipeline/cli/Cargo.toml
+++ b/operators/pipeline/cli/Cargo.toml
@@ -14,10 +14,8 @@ clap = { version = "4.5", features = ["derive"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 log = "0.4"
-colored = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tabled = { version = "0.18", features = ["ansi"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
 

--- a/operators/pipeline/cli/src/main.rs
+++ b/operators/pipeline/cli/src/main.rs
@@ -1,26 +1,14 @@
 //! CLI for YANET pipeline operator.
 
-use core::fmt::{self, Display, Formatter};
-use std::time::SystemTime;
-
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use colored::Colorize;
 use commonpb::pb::GetMetricsRequest;
-use tabled::{
-    Table, Tabled,
-    settings::{
-        Color, Style,
-        object::{Columns, Rows},
-        style::{BorderColor, HorizontalLine},
-    },
-};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
     errors::Error,
-    humanfmt,
     output::{self, CommonFormat},
+    readiness,
 };
 
 use crate::operatorpb::{
@@ -151,142 +139,6 @@ impl PipelineReadinessService {
             .map_err(self.service.status("ready"))?
             .into_inner();
 
-        let returned_names: std::collections::HashSet<&str> =
-            response.scopes.iter().map(|scope| scope.name.as_str()).collect();
-
-        let missing: Vec<&str> = cmd
-            .scopes
-            .iter()
-            .map(String::as_str)
-            .filter(|name| !returned_names.contains(name))
-            .collect();
-
-        let all_scopes_ready = response
-            .scopes
-            .iter()
-            .all(|scope| scope.state == readinesspb::pb::State::Ready as i32);
-
-        let all_ready = all_scopes_ready && missing.is_empty();
-
-        let total = response.scopes.len();
-        let ready_count = response
-            .scopes
-            .iter()
-            .filter(|scope| scope.state == readinesspb::pb::State::Ready as i32)
-            .count();
-
-        output::data(
-            &response.scopes,
-            response.scopes.is_empty() && missing.is_empty(),
-            format_args!("no scopes"),
-            || {
-                let mut rows: Vec<ReadinessRow> = response.scopes.iter().map(ReadinessRow::from).collect();
-                rows.sort_by(|a, b| a.scope.cmp(&b.scope));
-
-                if !rows.is_empty() {
-                    print_readiness_table(rows);
-                }
-
-                if !missing.is_empty() {
-                    let missing_list = missing.join(", ");
-                    let label = "missing (not registered):";
-
-                    if output::is_colored() {
-                        println!("{} {}", label.red(), missing_list.red());
-                    } else {
-                        println!("{label} {missing_list}");
-                    }
-                }
-
-                let missing_count = missing.len();
-
-                if missing_count > 0 {
-                    println!("summary: {ready_count}/{total} ready, {missing_count} requested scope missing");
-                } else {
-                    println!("summary: {ready_count}/{total} ready");
-                }
-            },
-        );
-
-        Ok(all_ready)
+        Ok(readiness::report(&response.scopes, &cmd.scopes))
     }
-}
-
-/// Wraps a readiness state for colored display in the table.
-pub struct StateCell(readinesspb::pb::State);
-
-impl Display for StateCell {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let StateCell(state) = self;
-        let name = state.as_str_name().strip_prefix("STATE_").unwrap_or_default();
-
-        if output::is_colored() {
-            let colored = match state {
-                readinesspb::pb::State::Ready => name.green().to_string(),
-                readinesspb::pb::State::Degraded => name.yellow().to_string(),
-                readinesspb::pb::State::NotReady => name.red().to_string(),
-                readinesspb::pb::State::Unspecified | readinesspb::pb::State::Unknown => {
-                    name.truecolor(127, 127, 127).to_string()
-                }
-            };
-            write!(f, "{colored}")
-        } else {
-            write!(f, "{name}")
-        }
-    }
-}
-
-#[derive(Debug, Tabled)]
-pub struct ReadinessRow {
-    #[tabled(rename = "Scope")]
-    pub scope: String,
-    #[tabled(rename = "State")]
-    pub state: String,
-    #[tabled(rename = "Last Transition")]
-    pub last_transition: String,
-    #[tabled(rename = "Observed")]
-    pub observed: String,
-    #[tabled(rename = "Reasons")]
-    pub reasons: String,
-}
-
-impl From<&readinesspb::pb::Scope> for ReadinessRow {
-    fn from(scope: &readinesspb::pb::Scope) -> Self {
-        let state = readinesspb::pb::State::try_from(scope.state).unwrap_or_default();
-        let state_cell = StateCell(state);
-
-        let reasons = scope
-            .reasons
-            .iter()
-            .map(|reason| format!("{}: {}", reason.code, reason.message))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        Self {
-            scope: scope.name.clone(),
-            state: state_cell.to_string(),
-            last_transition: humanfmt::format_age(scope.last_transition_time.as_ref(), SystemTime::now())
-                .unwrap_or_else(|| "-".to_string()),
-            observed: humanfmt::format_age(scope.observed_at.as_ref(), SystemTime::now())
-                .unwrap_or_else(|| "-".to_string()),
-            reasons,
-        }
-    }
-}
-
-fn print_readiness_table(rows: Vec<ReadinessRow>) {
-    let mut table = Table::new(&rows);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
-
-    if output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-        table.modify(Rows::first(), Color::BOLD);
-    }
-
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
 }

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -8,7 +8,7 @@ use core::{
     fmt::{self, Display, Formatter},
     net::IpAddr,
 };
-use std::{collections::HashMap, time::SystemTime};
+use std::collections::HashMap;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
@@ -26,8 +26,8 @@ use tonic::codec::CompressionEncoding;
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
     errors::Error,
-    humanfmt,
     output::{self, CommonFormat},
+    readiness,
 };
 
 use crate::operatorpb::{
@@ -413,64 +413,7 @@ impl RouteService {
             .map_err(self.readiness.status("ready"))?
             .into_inner();
 
-        let returned_names: std::collections::HashSet<&str> =
-            response.scopes.iter().map(|scope| scope.name.as_str()).collect();
-
-        let missing: Vec<&str> = cmd
-            .scopes
-            .iter()
-            .map(String::as_str)
-            .filter(|name| !returned_names.contains(name))
-            .collect();
-
-        let all_scopes_ready = response
-            .scopes
-            .iter()
-            .all(|scope| scope.state == readinesspb::pb::State::Ready as i32);
-
-        let all_ready = all_scopes_ready && missing.is_empty();
-
-        let total = response.scopes.len();
-        let ready_count = response
-            .scopes
-            .iter()
-            .filter(|scope| scope.state == readinesspb::pb::State::Ready as i32)
-            .count();
-
-        output::data(
-            &response.scopes,
-            response.scopes.is_empty() && missing.is_empty(),
-            format_args!("no scopes"),
-            || {
-                let mut rows: Vec<ReadinessRow> = response.scopes.iter().map(ReadinessRow::from).collect();
-                rows.sort_by(|a, b| a.scope.cmp(&b.scope));
-
-                if !rows.is_empty() {
-                    print_readiness_table(rows);
-                }
-
-                if !missing.is_empty() {
-                    let missing_list = missing.join(", ");
-                    let label = "missing (not registered):";
-
-                    if output::is_colored() {
-                        println!("{} {}", label.red(), missing_list.red());
-                    } else {
-                        println!("{label} {missing_list}");
-                    }
-                }
-
-                let missing_count = missing.len();
-
-                if missing_count > 0 {
-                    println!("summary: {ready_count}/{total} ready, {missing_count} requested scope missing");
-                } else {
-                    println!("summary: {ready_count}/{total} ready");
-                }
-            },
-        );
-
-        Ok(all_ready)
+        Ok(readiness::report(&response.scopes, &cmd.scopes))
     }
 }
 
@@ -639,85 +582,6 @@ fn annotate_ecmp_groups(entries: &mut [RouteEntry]) {
 
 fn print_route_table(entries: Vec<RouteEntry>) {
     let mut table = Table::new(&entries);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
-
-    if output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-        table.modify(Rows::first(), Color::BOLD);
-    }
-
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
-}
-
-/// Wraps a readiness state for colored display in the table.
-pub struct StateCell(readinesspb::pb::State);
-
-impl Display for StateCell {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        let StateCell(state) = self;
-        let name = state.as_str_name().strip_prefix("STATE_").unwrap_or_default();
-
-        if output::is_colored() {
-            let colored = match state {
-                readinesspb::pb::State::Ready => name.green().to_string(),
-                readinesspb::pb::State::Degraded => name.yellow().to_string(),
-                readinesspb::pb::State::NotReady => name.red().to_string(),
-                readinesspb::pb::State::Unspecified | readinesspb::pb::State::Unknown => {
-                    name.truecolor(127, 127, 127).to_string()
-                }
-            };
-            write!(f, "{colored}")
-        } else {
-            write!(f, "{name}")
-        }
-    }
-}
-
-#[derive(Debug, Tabled)]
-pub struct ReadinessRow {
-    #[tabled(rename = "Scope")]
-    pub scope: String,
-    #[tabled(rename = "State")]
-    pub state: String,
-    #[tabled(rename = "Last Transition")]
-    pub last_transition: String,
-    #[tabled(rename = "Observed")]
-    pub observed: String,
-    #[tabled(rename = "Reasons")]
-    pub reasons: String,
-}
-
-impl From<&readinesspb::pb::Scope> for ReadinessRow {
-    fn from(scope: &readinesspb::pb::Scope) -> Self {
-        let state = readinesspb::pb::State::try_from(scope.state).unwrap_or_default();
-        let state_cell = StateCell(state);
-
-        let reasons = scope
-            .reasons
-            .iter()
-            .map(|reason| format!("{}: {}", reason.code, reason.message))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        Self {
-            scope: scope.name.clone(),
-            state: state_cell.to_string(),
-            last_transition: humanfmt::format_age(scope.last_transition_time.as_ref(), SystemTime::now())
-                .unwrap_or_else(|| "-".to_string()),
-            observed: humanfmt::format_age(scope.observed_at.as_ref(), SystemTime::now())
-                .unwrap_or_else(|| "-".to_string()),
-            reasons,
-        }
-    }
-}
-
-fn print_readiness_table(rows: Vec<ReadinessRow>) {
-    let mut table = Table::new(&rows);
     table.with(
         Style::modern()
             .horizontals([(1, HorizontalLine::inherit(Style::modern()))])


### PR DESCRIPTION
The decap, forward, pipeline and route operator CLIs each carried a nearly identical copy of the readiness table rendering and summary logic. In the three smaller operator CLIs roughly 97 percent of the file was duplicated code, differing only in the operator name, the proto path and the service constant.

- Moved the shared readiness reporting into the CLI core library, so each operator CLI now keeps only its own command definitions and RPC wiring.
- Reduced the decap and forward CLIs from 265 to 117 lines each, and pipeline from 292 to 144.
- Carved the readiness parts out of the route CLI without touching its route specific commands or tests.
- Dropped dependencies that became unused in the three operator crates.

No behavior change: the rendered output, the exit code semantics and the JSON payload are all unchanged.