### PR TITLE
fix(pdump): stamp captures from the worker clock

### DIFF
--- a/lib/dataplane/time/tsc.h
+++ b/lib/dataplane/time/tsc.h
@@ -5,39 +5,6 @@
 
 #define TSC_SHIFT 32
 
-////////////////////////////////////////////////////////////////////////////////
-
-static inline uint64_t
-tsc_timestamp_ns() {
-	static uint64_t tsc_mult = ~0ULL;
-
-	// One-time initialization
-	if (unlikely(tsc_mult == ~0ULL)) {
-		uint64_t hz = rte_get_tsc_hz();
-		if (unlikely(hz == 0)) {
-			return 0;
-		}
-
-		// Verify we won't overflow during multiplication
-		// Max safe TSC value: ~18 years at 5GHz, which should be fine
-		tsc_mult = ((1ULL << TSC_SHIFT) * 1000000000ULL) / hz;
-	}
-
-	uint64_t current_tsc = rte_rdtsc();
-
-// Check if your compiler/platform supports __uint128_t
-#ifdef __SIZEOF_INT128__
-	uint64_t timestamp_ns =
-		((__uint128_t)current_tsc * tsc_mult) >> TSC_SHIFT;
-#else
-	// Fallback for platforms without 128-bit support
-	uint64_t high = (current_tsc >> 32) * tsc_mult;
-	uint64_t low = (current_tsc & 0xFFFFFFFF) * tsc_mult;
-	uint64_t timestamp_ns = (high >> (TSC_SHIFT - 32)) + (low >> TSC_SHIFT);
-#endif
-	return timestamp_ns;
-}
-
 static inline uint64_t
 tsc_elapsed_ns(uint64_t elapsed_tsc) {
 	static uint64_t tsc_mult = ~0ULL;

--- a/modules/pdump/cli/src/writer.rs
+++ b/modules/pdump/cli/src/writer.rs
@@ -149,8 +149,10 @@ impl PdumpWriter {
                 writer.base_ts = Some(meta.timestamp);
                 0
             }
-            // Align timestamps relative to the first packet.
-            Some(v) => meta.timestamp - *v,
+            // Align timestamps relative to the first packet. Records arrive in
+            // per-worker arrival order rather than timestamp order, so a record
+            // can predate the baseline -- clamp instead of wrapping.
+            Some(v) => meta.timestamp.saturating_sub(*v),
         };
         meta.timestamp = ts;
 

--- a/modules/pdump/dataplane/dataplane.c
+++ b/modules/pdump/dataplane/dataplane.c
@@ -2,7 +2,6 @@
 
 #include <bpf_impl.h>
 #include <rte_bpf.h>
-#include <rte_mbuf_dyn.h>
 
 #include "dataplane/config/zone.h"
 #include "dataplane/module/module.h"
@@ -12,79 +11,22 @@
 
 #include "controlplane/config/econtext.h"
 
-#include "dataplane/time/tsc.h"
 #include "ring.h"
-
-#define TSC_SHIFT 32
-
-static inline bool
-mbuf_is_timestamp_enabled(const struct rte_mbuf *mbuf) {
-	// Returns true when the mbuf carries a hardware RX timestamp.
-	//
-	// -2 means the dynflag offset has not been resolved yet; negative
-	// values other than -2 mean the flag is absent (ENOENT from the
-	// registry). The offset is cached with a relaxed atomic store so
-	// the lookup runs at most once per worker thread without taking any
-	// registry lock on the hot path.
-	static int timestamp_rx_dynflag_offset = -2;
-
-	int offset =
-		__atomic_load_n(&timestamp_rx_dynflag_offset, __ATOMIC_RELAXED);
-	if (offset == -2) {
-		offset = rte_mbuf_dynflag_lookup(
-			RTE_MBUF_DYNFLAG_RX_TIMESTAMP_NAME, NULL
-		);
-		__atomic_store_n(
-			&timestamp_rx_dynflag_offset, offset, __ATOMIC_RELAXED
-		);
-	}
-
-	if (offset < 0) {
-		return false;
-	}
-
-	return (mbuf->ol_flags & RTE_BIT64(offset)) != 0;
-}
-
-static inline rte_mbuf_timestamp_t
-mbuf_get_timestamp(const struct rte_mbuf *mbuf) {
-	// Returns the hardware RX timestamp stored in a dynamic field.
-	//
-	// -2 means the dynfield offset has not been resolved yet; negative
-	// values other than -2 mean the field is absent (ENOENT from the
-	// registry). The offset is cached with a relaxed atomic store so
-	// the lookup runs at most once per worker thread without taking any
-	// registry lock on the hot path.
-	static int timestamp_dynfield_offset = -2;
-
-	int offset =
-		__atomic_load_n(&timestamp_dynfield_offset, __ATOMIC_RELAXED);
-	if (offset == -2) {
-		offset = rte_mbuf_dynfield_lookup(
-			RTE_MBUF_DYNFIELD_TIMESTAMP_NAME, NULL
-		);
-		__atomic_store_n(
-			&timestamp_dynfield_offset, offset, __ATOMIC_RELAXED
-		);
-	}
-
-	if (offset < 0) {
-		return 0;
-	}
-
-	return *RTE_MBUF_DYNFIELD(mbuf, offset, rte_mbuf_timestamp_t *);
-}
 
 static inline void
 process_queue(
 	struct packet *first_pkt,
 	struct rte_bpf *bpf,
 	struct ring_buffer *ring,
-	uint32_t worker_idx,
+	const struct dp_worker *dp_worker,
 	uint32_t snaplen,
 	enum pdump_mode queue
 ) {
-	uint64_t tsc_timestamp = ~0ULL;
+	// Stamp every record from the worker clock, which is the same time
+	// base the rest of the dataplane uses. Hardware RX timestamps are not
+	// portable nanoseconds: mlx5 hands over a raw device counter unless
+	// the NIC runs in real-time mode, so they cannot share this field.
+	uint64_t timestamp = dp_worker->current_time;
 
 	uint8_t *ring_data = ADDR_OF(&ring->data);
 
@@ -93,18 +35,6 @@ process_queue(
 
 		int rc = rte_bpf_exec(bpf, (void *)mbuf);
 		if (rc) {
-			uint64_t timestamp;
-			if (mbuf_is_timestamp_enabled(mbuf)) {
-				timestamp = mbuf_get_timestamp(mbuf);
-			} else {
-				// Fallback to the TSC timestamp for the entire
-				// packet list.
-				if (tsc_timestamp == ~0ULL) {
-					tsc_timestamp = tsc_timestamp_ns();
-				}
-				timestamp = tsc_timestamp;
-			}
-
 			// NOTE: We do not support multi-segment mbuf;
 			// therefore, data_len must equal pkt_len.
 			uint16_t packet_len = rte_pktmbuf_data_len(mbuf);
@@ -115,7 +45,7 @@ process_queue(
 				.magic = RING_MSG_MAGIC,
 				.packet_len = packet_len,
 				.timestamp = timestamp,
-				.worker_idx = worker_idx,
+				.worker_idx = dp_worker->idx,
 				// FIXME
 				// .pipeline_idx = pkt->pipeline_idx,
 				.rx_device_id = pkt->rx_device_id,
@@ -156,7 +86,7 @@ pdump_handle_packets(
 			packet_front->drop.first,
 			&bpf,
 			ring,
-			dp_worker->idx,
+			dp_worker,
 			config->snaplen,
 			PDUMP_DROPS
 		);
@@ -168,7 +98,7 @@ pdump_handle_packets(
 			packet_front->input.first,
 			&bpf,
 			ring,
-			dp_worker->idx,
+			dp_worker,
 			config->snaplen,
 			PDUMP_INPUT
 		);


### PR DESCRIPTION
- Capture timestamps were taken from the NIC hardware RX timestamp when the driver offered one. Mellanox adapters fill that field with a raw device counter rather than nanoseconds unless the adapter runs in real-time mode, and on ConnectX-4/5 a single tick is 12.8 ns, so pdump rendered a timeline compressed by that factor. A one-second-periodic event displayed as roughly 78 ms apart, which actively misled a live debugging session.
- Records are now stamped from the worker clock, the same time base the rest of the dataplane already uses. This drops both the hardware timestamp path and the parallel fallback clock beside it, and is also cheaper on the packet path than the per-packet dynamic-field lookup it replaces.
- The pcap and pcapng writers previously treated the dataplane value as an absolute epoch. The worker clock is anchored to the host clock once at start-up and never re-calibrated, so only the differences between its stamps are trustworthy. Both writers now pin the local wall clock at the first record and apply dataplane offsets on top of it, which keeps intervals accurate and sources absolute time from a calibrated clock.
- Text output remains relative to the first packet, and no longer underflows when records arrive out of order across per-worker readers.
- Removes the timestamp helper left without callers once pdump stopped using it.