### PR TITLE
fix(dataplane): correct truncating tick-to-nanosecond conversion in worker clock

### DIFF
--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -46,11 +46,12 @@ struct dp_worker {
 
 	// Allows to get current worker time.
 	//
-	// Currently, we init it only once
-	// and dont adjust.
-	// So, we have some drift, which is small but...
-	// (see tsc_clock docs). It is not important
-	// for now and fix should be easy, but need discuss.
+	// Currently, we init it only once and never re-adjust it. The TSC
+	// crystal drifts against real time by a small ppm-scale rate (see
+	// tsc_clock docs), so the longer the worker runs without a fresh
+	// tsc_clock_adjust call, the further current_time strays from real
+	// time. It is not important for now and fix should be easy, but
+	// need discuss.
 	//
 	// TODO: FIXME
 	struct tsc_clock clock;

--- a/lib/dataplane/time/clock.c
+++ b/lib/dataplane/time/clock.c
@@ -11,13 +11,20 @@ tsc_clock_init(struct tsc_clock *clock) {
 	if (clock_gettime(CLOCK_REALTIME, &ts)) {
 		return -1;
 	}
-	clock->real_time_ns = ts.tv_nsec + ts.tv_sec * 1e9;
+
+	uint64_t hz = rte_get_tsc_hz();
+	if (hz == 0) {
+		return -1;
+	}
+
+	clock->real_time_ns = ts.tv_nsec + ts.tv_sec * 1000000000ULL;
 	clock->timestamp_counter = rte_rdtsc();
 
-	clock->tsc_to_ns = 1024e9 / rte_get_tsc_hz();
+	clock->tsc_to_ns_mult = tsc_clock_mult_from_hz(hz);
 
-	clock->real_time_ns -=
-		(clock->timestamp_counter >> 10) * clock->tsc_to_ns;
+	clock->real_time_ns -= tsc_clock_ticks_to_ns(
+		clock->timestamp_counter, clock->tsc_to_ns_mult
+	);
 
 	return 0;
 }
@@ -31,7 +38,8 @@ uint64_t
 tsc_clock_get_time_ns(struct tsc_clock *clock) {
 	uint64_t tsc = _rdtsc();
 
-	return clock->real_time_ns + (tsc >> 10) * clock->tsc_to_ns;
+	return clock->real_time_ns +
+	       tsc_clock_ticks_to_ns(tsc, clock->tsc_to_ns_mult);
 }
 
 dataplane_time_ns_fn_t dataplane_time_ns_fn = tsc_clock_get_time_ns;

--- a/lib/dataplane/time/clock.h
+++ b/lib/dataplane/time/clock.h
@@ -20,7 +20,11 @@
 // clock drift on TSC with 1ppm drift
 // (modern CPUs have drift of 0.1-1 ppm).
 struct tsc_clock {
-	uint64_t tsc_to_ns;
+	// Tick-to-nanosecond multiplier in 32.32 fixed-point.
+	//
+	// Nanoseconds per tick, scaled by 2^32. Convert a tick count with
+	// tsc_clock_ticks_to_ns.
+	uint64_t tsc_to_ns_mult;
 	// Real time when clock was init in nanoseconds.
 	uint64_t real_time_ns;
 
@@ -39,6 +43,34 @@ tsc_clock_adjust(struct tsc_clock *clock);
 // Get current real time in nanoseconds.
 uint64_t
 tsc_clock_get_time_ns(struct tsc_clock *clock);
+
+// Build a 32.32 fixed-point tick-to-nanosecond multiplier from a TSC
+// frequency in Hz.
+//
+// Returns 0 when hz is 0 instead of dividing by it, keeping the helper
+// a total function that never traps — an integer divide by zero would
+// raise SIGFPE — and preserving the old code's frozen-clock behaviour
+// rather than crashing. Callers that must reject an uncalibrated TSC
+// check hz themselves, which is what tsc_clock_init does, because only
+// it has an error channel to report on.
+static inline uint64_t
+tsc_clock_mult_from_hz(uint64_t hz) {
+	if (hz == 0) {
+		return 0;
+	}
+
+	return ((1ULL << 32) * 1000000000ULL) / hz;
+}
+
+// Convert a tick count to nanoseconds using a 32.32 fixed-point
+// tick-to-nanosecond multiplier.
+//
+// The multiplication is carried out in 128 bits so that it does not
+// overflow uint64_t before the final shift.
+static inline uint64_t
+tsc_clock_ticks_to_ns(uint64_t ticks, uint64_t mult) {
+	return (uint64_t)(((__uint128_t)ticks * mult) >> 32);
+}
 
 // Signature of the per-round wall-time read.
 //

--- a/lib/tests/dataplane/clock_test.c
+++ b/lib/tests/dataplane/clock_test.c
@@ -1,0 +1,160 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/test_assert.h"
+
+#include "lib/dataplane/time/clock.h"
+#include "lib/logging/log.h"
+
+// One synthetic TSC frequency to exercise the tick-to-nanosecond
+// conversion at.
+struct tsc_freq_case {
+	const char *name;
+	uint64_t hz;
+};
+
+static const struct tsc_freq_case freq_cases[] = {
+	{"2.0GHz", 2000000000ULL},
+	{"2.2GHz", 2200000000ULL},
+	{"2.5GHz", 2500000000ULL},
+	{"2.9GHz", 2900000000ULL},
+	{"3.6GHz", 3600000000ULL},
+	{"4.0GHz", 4000000000ULL},
+};
+
+#define FREQ_CASE_COUNT (sizeof(freq_cases) / sizeof(freq_cases[0]))
+
+// Verifies that tsc_clock_mult_from_hz returns 0 for a zero frequency,
+// so callers can detect an unusable TSC frequency instead of dividing
+// by zero.
+static int
+test_mult_from_hz_zero(void) {
+	TEST_ASSERT_EQUAL(tsc_clock_mult_from_hz(0), 0, "mult for hz=0");
+
+	return TEST_SUCCESS;
+}
+
+// Verifies that converting exactly one second worth of ticks to
+// nanoseconds stays within the multiplier's provable rounding bound,
+// across a spread of realistic TSC frequencies including 2.5GHz -- the
+// frequency at which the previous 1024-tick pre-shift scheme was off
+// by 0.1465%.
+static int
+test_one_second_within_bound(void) {
+	for (size_t idx = 0; idx < FREQ_CASE_COUNT; ++idx) {
+		uint64_t hz = freq_cases[idx].hz;
+		uint64_t mult = tsc_clock_mult_from_hz(hz);
+		TEST_ASSERT(
+			mult != 0, "mult is zero for %s", freq_cases[idx].name
+		);
+
+		uint64_t ns = tsc_clock_ticks_to_ns(hz, mult);
+		uint64_t bound = hz / (1ULL << 32) + 1;
+		uint64_t diff = ns > 1000000000ULL ? ns - 1000000000ULL
+						   : 1000000000ULL - ns;
+		TEST_ASSERT(
+			diff <= bound,
+			"one-second conversion out of bound for %s: "
+			"ns=%lu diff=%lu bound=%lu",
+			freq_cases[idx].name,
+			(unsigned long)ns,
+			(unsigned long)diff,
+			(unsigned long)bound
+		);
+	}
+
+	return TEST_SUCCESS;
+}
+
+// Verifies that at frequencies where the 32.32 multiplier divides
+// evenly, a full second of ticks converts to exactly one billion
+// nanoseconds with no rounding error at all.
+static int
+test_exact_frequencies(void) {
+	static const uint64_t exact_hz[] = {2000000000ULL, 4000000000ULL};
+
+	for (size_t idx = 0; idx < sizeof(exact_hz) / sizeof(exact_hz[0]);
+	     ++idx) {
+		uint64_t hz = exact_hz[idx];
+		uint64_t mult = tsc_clock_mult_from_hz(hz);
+		uint64_t ns = tsc_clock_ticks_to_ns(hz, mult);
+		TEST_ASSERT_EQUAL(
+			ns,
+			1000000000ULL,
+			"exact one-second conversion for hz=%lu",
+			(unsigned long)hz
+		);
+	}
+
+	return TEST_SUCCESS;
+}
+
+// Verifies that a nine-hour uptime -- the duration of the vla1-4fw15
+// production incident -- converts within a millisecond of the true
+// elapsed time. The previous 1024-tick pre-shift scheme missed this
+// bound by about 47.5 seconds at 2.5GHz.
+static int
+test_nine_hour_uptime_within_bound(void) {
+	const uint64_t seconds = 32400;
+	const uint64_t expected_ns = seconds * 1000000000ULL;
+	const uint64_t bound_ns = 1000000ULL;
+
+	for (size_t idx = 0; idx < FREQ_CASE_COUNT; ++idx) {
+		uint64_t hz = freq_cases[idx].hz;
+		uint64_t mult = tsc_clock_mult_from_hz(hz);
+		uint64_t ticks = hz * seconds;
+		uint64_t ns = tsc_clock_ticks_to_ns(ticks, mult);
+		uint64_t diff =
+			ns > expected_ns ? ns - expected_ns : expected_ns - ns;
+		TEST_ASSERT(
+			diff <= bound_ns,
+			"nine-hour conversion out of bound for %s: "
+			"ns=%lu diff=%lu",
+			freq_cases[idx].name,
+			(unsigned long)ns,
+			(unsigned long)diff
+		);
+	}
+
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	LOG(INFO, "=== Starting Clock Test Suite ===");
+
+	struct {
+		const char *name;
+		int (*fn)(void);
+	} tests[] = {
+		{"mult_from_hz_zero", test_mult_from_hz_zero},
+		{"one_second_within_bound", test_one_second_within_bound},
+		{"exact_frequencies", test_exact_frequencies},
+		{"nine_hour_uptime_within_bound",
+		 test_nine_hour_uptime_within_bound},
+	};
+
+	size_t total = sizeof(tests) / sizeof(tests[0]);
+	size_t failed = 0;
+
+	for (size_t i = 0; i < total; i++) {
+		LOG(INFO, "[%zu/%zu] running %s...", i + 1, total, tests[i].name
+		);
+		if (tests[i].fn() != TEST_SUCCESS) {
+			LOG(ERROR, "%s FAILED", tests[i].name);
+			failed++;
+		} else {
+			LOG(INFO, "%s passed", tests[i].name);
+		}
+	}
+
+	if (failed == 0) {
+		LOG(INFO, "=== All %zu clock tests passed! ===", total);
+	} else {
+		LOG(ERROR, "=== %zu/%zu clock tests failed ===", failed, total);
+	}
+
+	return failed == 0 ? TEST_SUCCESS : TEST_FAILED;
+}

--- a/lib/tests/dataplane/meson.build
+++ b/lib/tests/dataplane/meson.build
@@ -27,3 +27,15 @@ gre_test = executable(
   include_directories: yanet_rootdir,
 )
 test('gre', gre_test, suite: 'lib_packet')
+
+clock_test = executable(
+  'clock_test',
+  'clock_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_logging_dep,
+  ],
+  include_directories: yanet_rootdir,
+)
+test('clock', clock_test, suite: 'lib_dataplane')


### PR DESCRIPTION
The worker clock derived its tick-to-nanosecond multiplier with a floating-point division that was truncated when stored, so the clock ran roughly 0.15 percent slow. The error accumulated from worker start onward and reached a lag of tens of seconds over a long uptime, which was observed on a production rig. Worker time feeds firewall state and ACL timeout arithmetic as well as capture timestamps.

- Replace the truncating multiplier with a fixed-point one evaluated through a wider intermediate, cutting the relative error from roughly 1.5e-3 to 2e-10.
- Drop the tick quantisation that an earlier overflow workaround had to introduce, since the wider intermediate no longer overflows.
- Reject an uncalibrated timestamp counter instead of dividing by zero, which the new integer division would otherwise trap on.
- Add a unit test pinning the scaling across realistic clock frequencies, including ones at which the previous scheme was measurably wrong.
- Refresh the worker clock comment to describe the remaining unadjusted crystal drift.