### PR TITLE
feat(cli): watch every readiness service at once

### DIFF
--- a/cli/core/src/client.rs
+++ b/cli/core/src/client.rs
@@ -149,6 +149,63 @@ impl Connection {
             .map(|response| response.into_inner())
             .map_err(|status| Error::from_status(status, action, &self.endpoint, service))
     }
+
+    /// Invoke a server-streaming RPC on an arbitrary gRPC service over this
+    /// connection.
+    ///
+    /// The dispatch is the free [`invoke_server_stream`]'s, minus the
+    /// connect: a CLI watching several services builds one [`Connection`]
+    /// and calls this per service, so they all share a single channel.
+    /// `tonic::Streaming` never leaks to the caller — all stream state is
+    /// contained here.
+    pub async fn invoke_server_stream<Req, Resp, F>(
+        &self,
+        action: &str,
+        service: &str,
+        method: &str,
+        request: Req,
+        mut on_message: F,
+    ) -> Result<(), Error>
+    where
+        Req: Message + Send + Sync + 'static,
+        Resp: Message + Default + Send + Sync + 'static,
+        F: FnMut(Resp),
+    {
+        let mut grpc = Grpc::new(self.channel.clone())
+            .send_compressed(CompressionEncoding::Gzip)
+            .accept_compressed(CompressionEncoding::Gzip);
+
+        let path = PathAndQuery::try_from(format!("/{service}/{method}")).map_err(|err| {
+            Error::from_status(
+                Status::invalid_argument(err.to_string()),
+                action,
+                &self.endpoint,
+                service,
+            )
+        })?;
+
+        grpc.ready()
+            .await
+            .map_err(|err| Error::from_status(Status::unavailable(err.to_string()), action, &self.endpoint, service))?;
+
+        let codec: ProstCodec<Req, Resp> = ProstCodec::default();
+
+        let mut stream = grpc
+            .server_streaming(Request::new(request), path, codec)
+            .await
+            .map_err(|status| Error::from_status(status, action, &self.endpoint, service))?
+            .into_inner();
+
+        while let Some(message) = stream
+            .message()
+            .await
+            .map_err(|status| Error::from_status(status, action, &self.endpoint, service))?
+        {
+            on_message(message);
+        }
+
+        Ok(())
+    }
 }
 
 /// A connected gRPC client bundled with its endpoint and service name.
@@ -284,53 +341,17 @@ pub async fn invoke_server_stream<Req, Resp, F>(
     service: &str,
     method: &str,
     request: Req,
-    mut on_message: F,
+    on_message: F,
 ) -> Result<(), Error>
 where
     Req: Message + Send + Sync + 'static,
     Resp: Message + Default + Send + Sync + 'static,
     F: FnMut(Resp),
 {
-    let endpoint = connection.endpoint.clone();
-
-    let channel = connect(connection)
+    Connection::connect_for(connection, action)
+        .await?
+        .invoke_server_stream(action, service, method, request, on_message)
         .await
-        .map_err(|err| Error::from_connection(err, action, endpoint.clone()))?;
-
-    let mut grpc = Grpc::new(channel)
-        .send_compressed(CompressionEncoding::Gzip)
-        .accept_compressed(CompressionEncoding::Gzip);
-
-    let path = PathAndQuery::try_from(format!("/{service}/{method}")).map_err(|err| {
-        Error::from_status(
-            Status::invalid_argument(err.to_string()),
-            action,
-            endpoint.clone(),
-            service,
-        )
-    })?;
-
-    grpc.ready()
-        .await
-        .map_err(|err| Error::from_status(Status::unavailable(err.to_string()), action, endpoint.clone(), service))?;
-
-    let codec: ProstCodec<Req, Resp> = ProstCodec::default();
-
-    let mut stream = grpc
-        .server_streaming(Request::new(request), path, codec)
-        .await
-        .map_err(|status| Error::from_status(status, action, endpoint.clone(), service))?
-        .into_inner();
-
-    while let Some(message) = stream
-        .message()
-        .await
-        .map_err(|status| Error::from_status(status, action, endpoint.clone(), service))?
-    {
-        on_message(message);
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/cli/core/src/discovery.rs
+++ b/cli/core/src/discovery.rs
@@ -9,6 +9,7 @@
 //! suggests.
 
 use core::time::Duration;
+use std::collections::BTreeMap;
 
 use tonic::codec::CompressionEncoding;
 use ynpb::pb::{gateway_client::GatewayClient, ListServicesRequest};
@@ -108,6 +109,63 @@ pub fn resolve_alias(alias: &str, services: &[String]) -> Resolution {
         1 => Resolution::Resolved(matched.remove(0)),
         _ => Resolution::Ambiguous(matched),
     }
+}
+
+/// Derives a short display alias from a service FQN — the inverse of
+/// [`resolve_alias`].
+///
+/// Drops the trailing segment (the service name itself, e.g.
+/// `ReadinessService`), then discards any remaining segment that is a bare
+/// version marker (`v1`, `v2`, …) or ends in `pb` (`operatorpb`, `ynpb`,
+/// …), and takes the last segment left. `controlplane.ynpb.v1.ReadinessService`
+/// becomes `controlplane`; `operators.route.operatorpb.v1.ReadinessService`
+/// becomes `route`. Falls back to the full `fqn` when nothing remains, e.g.
+/// a bare `ReadinessService` with no package at all.
+pub fn derive_alias(fqn: &str) -> String {
+    let segments: Vec<&str> = fqn.split('.').collect();
+    let package = &segments[..segments.len().saturating_sub(1)];
+
+    package
+        .iter()
+        .rev()
+        .find(|segment| !is_version_segment(segment) && !segment.ends_with("pb"))
+        .map(|segment| (*segment).to_owned())
+        .unwrap_or_else(|| fqn.to_owned())
+}
+
+/// Reports whether `segment` is a bare version marker: `v` followed by one
+/// or more ASCII digits and nothing else.
+fn is_version_segment(segment: &str) -> bool {
+    let Some(digits) = segment.strip_prefix('v') else {
+        return false;
+    };
+
+    !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+/// Derives a display alias for every service in `services`, keyed by the
+/// service's own FQN.
+///
+/// Two services whose derived alias collides both fall back to their full
+/// FQN — a short alias is only useful when it is unambiguous.
+pub fn alias_map(services: &[String]) -> BTreeMap<String, String> {
+    let mut aliases: BTreeMap<String, String> = services
+        .iter()
+        .map(|service| (service.clone(), derive_alias(service)))
+        .collect();
+
+    let mut counts: BTreeMap<String, usize> = BTreeMap::new();
+    for alias in aliases.values() {
+        *counts.entry(alias.clone()).or_insert(0) += 1;
+    }
+
+    for (service, alias) in aliases.iter_mut() {
+        if counts.get(alias.as_str()).copied().unwrap_or(0) > 1 {
+            *alias = service.clone();
+        }
+    }
+
+    aliases
 }
 
 /// Connects to the gateway afresh and lists the services whose last segment
@@ -299,5 +357,48 @@ mod test {
             "no services registered",
             services_hint("available:", "no services registered", &[])
         );
+    }
+
+    #[test]
+    fn derive_alias_drops_version_and_pb_segments() {
+        assert_eq!("controlplane", derive_alias("controlplane.ynpb.v1.ReadinessService"));
+        assert_eq!("route", derive_alias("operators.route.operatorpb.v1.ReadinessService"));
+    }
+
+    #[test]
+    fn derive_alias_handles_double_digit_versions() {
+        assert_eq!("route", derive_alias("operators.route.operatorpb.v12.ReadinessService"));
+    }
+
+    #[test]
+    fn derive_alias_falls_back_to_the_full_name_when_nothing_remains() {
+        assert_eq!("ReadinessService", derive_alias("ReadinessService"));
+        assert_eq!("v1.pb.ReadinessService", derive_alias("v1.pb.ReadinessService"));
+    }
+
+    #[test]
+    fn alias_map_uses_the_derived_alias_when_unique() {
+        let services = vec![
+            "controlplane.ynpb.v1.ReadinessService".to_owned(),
+            "operators.route.operatorpb.v1.ReadinessService".to_owned(),
+        ];
+
+        let aliases = alias_map(&services);
+
+        assert_eq!(Some(&"controlplane".to_owned()), aliases.get(&services[0]));
+        assert_eq!(Some(&"route".to_owned()), aliases.get(&services[1]));
+    }
+
+    #[test]
+    fn alias_map_falls_back_to_the_fqn_on_collision() {
+        let services = vec![
+            "a.route.v1.ReadinessService".to_owned(),
+            "b.route.v2.ReadinessService".to_owned(),
+        ];
+
+        let aliases = alias_map(&services);
+
+        assert_eq!(Some(&services[0]), aliases.get(&services[0]));
+        assert_eq!(Some(&services[1]), aliases.get(&services[1]));
     }
 }

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -19,6 +19,7 @@ use ync::{
 };
 
 mod render;
+mod watch;
 
 /// Exit code used when the RPC succeeds but not all scopes are `STATE_READY`.
 const EXIT_NOT_READY: i32 = 2;
@@ -71,8 +72,12 @@ pub struct Cmd {
     /// Stream readiness changes until interrupted instead of exiting after one
     /// snapshot.
     ///
-    /// Requires a single service: several interleaved transition logs would be
-    /// unreadable.
+    /// With a single service named, streams that one service's transition
+    /// log. Otherwise (the default with no service named, or with `--all`)
+    /// watches every discovered service at once over one shared connection:
+    /// each service gets its own supervisor that reconnects with backoff on
+    /// its own, and every transition lands in one interleaved log, each line
+    /// naming the service it belongs to.
     #[arg(long, default_value_t = false)]
     pub watch: bool,
     /// Minimum time since a scope was last observed before flagging it
@@ -240,7 +245,7 @@ async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool
 /// changed and renders one append-only log line per scope. Returns `Ok(())`
 /// on clean stream close.
 async fn run_watch(cmd: &Cmd, name: &str) -> Result<(), Error> {
-    let mut snapshot: BTreeMap<String, Scope> = BTreeMap::new();
+    let mut snapshot: BTreeMap<(String, String), Scope> = BTreeMap::new();
     let mut name_width: Option<usize> = None;
 
     client::invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
@@ -260,15 +265,18 @@ async fn run_watch(cmd: &Cmd, name: &str) -> Result<(), Error> {
                         name_width = Some(width);
 
                         for scope in &scopes {
-                            snapshot.insert(scope.name.clone(), scope.clone());
+                            snapshot.insert((name.to_owned(), scope.name.clone()), scope.clone());
                         }
 
                         render::print_status_block(name, &scopes, width, cmd.stale_after, true);
                     }
                     Some(width) => {
                         for scope in &scopes {
-                            let transition = render::record_transition(&mut snapshot, scope);
-                            render::print_transition_line(scope, width, transition);
+                            let transition = render::record_transition(&mut snapshot, name, scope);
+
+                            if transition != render::Transition::Unchanged {
+                                render::print_transition_line(render::ServiceColumn::None, scope, width, transition);
+                            }
                         }
                     }
                 }
@@ -286,7 +294,7 @@ async fn run_watch(cmd: &Cmd, name: &str) -> Result<(), Error> {
 /// jitter from block to block.
 async fn run_aggregate(cmd: Cmd) -> Result<bool, Error> {
     if cmd.watch {
-        return Err(watch_requires_service(&cmd).await);
+        return watch::run(&cmd).await;
     }
 
     let connection = Connection::connect_for(&cmd.connection, "ready").await?;
@@ -427,22 +435,6 @@ async fn resolve_alias(cmd: &Cmd, connection: &Connection, alias: &str) -> Resul
             Err(Error::new(ErrorKind::ServiceUnregistered, "ready", endpoint, message)
                 .with_hint(discovery::services_hint(AVAILABLE_SERVICES, NO_SERVICES, &services)))
         }
-    }
-}
-
-/// Builds the error for `--watch` without a single service to watch.
-///
-/// Discovery is best-effort here: the services it finds become the hint, and a
-/// gateway that cannot be reached — or does not answer within
-/// `discovery::discover_within`'s budget — simply leaves the error hintless.
-/// The flag combination is wrong either way, and reporting so must not wait
-/// on the network.
-async fn watch_requires_service(cmd: &Cmd) -> Error {
-    let err = Error::invalid_argument("ready", &cmd.connection.endpoint, "--watch requires a single service");
-
-    match discovery::discover_within(&cmd.connection, READINESS_SERVICE, discovery::DISCOVERY_TIMEOUT).await {
-        Ok(services) => err.with_hint(discovery::services_hint(AVAILABLE_SERVICES, NO_SERVICES, &services)),
-        Err(..) => err,
     }
 }
 

--- a/cli/modules/ready/src/render/layout.rs
+++ b/cli/modules/ready/src/render/layout.rs
@@ -34,7 +34,7 @@ pub fn wrap_words(text: &str, width: usize) -> Vec<String> {
     for word in text.split_whitespace() {
         if current.is_empty() {
             current.push_str(word);
-        } else if current.len() + 1 + word.len() <= width {
+        } else if current.chars().count() + 1 + word.chars().count() <= width {
             current.push(' ');
             current.push_str(word);
         } else {
@@ -101,6 +101,14 @@ mod test {
     #[test]
     fn wrap_words_zero_width_returns_single_line() {
         assert_eq!(vec!["one long line".to_string()], wrap_words("one long line", 0));
+    }
+
+    #[test]
+    fn wrap_words_counts_columns_not_bytes() {
+        // Each em dash is 3 UTF-8 bytes but a single display column, so a
+        // width of 5 must fit both of them plus their surrounding letters
+        // on one line — byte-counting would wrap one column early.
+        assert_eq!(vec!["a — b".to_string()], wrap_words("a — b", 5));
     }
 
     #[test]

--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -22,7 +22,9 @@ use self::{
 };
 pub use self::{
     layout::name_width,
-    watch::{print_transition_line, record_transition},
+    watch::{
+        ServiceColumn, Transition, print_lifecycle_line, print_lost_line, print_transition_line, record_transition,
+    },
 };
 
 /// Fixed width of the state label cell (`len("NOT_READY")`).
@@ -113,6 +115,23 @@ pub fn print_status_block(name: &str, scopes: &[Scope], name_width: usize, stale
     if watching {
         println!();
     }
+}
+
+/// Prints the standalone `watching…` line aggregate `--watch` shows once,
+/// after every service's status block.
+///
+/// Separated from the blocks above it and the transition log below it by
+/// one blank line on each side. Single-service watch does not use this —
+/// it appends its `watching` suffix straight onto the block's own summary
+/// line via [`print_status_block`]'s `watching` flag instead.
+pub fn print_watching_line() {
+    let colored = output::is_colored();
+    let symbols = Symbols::new(colored);
+    let text = format!("watching{}", symbols.ellipsis);
+
+    println!();
+    println!("{}", dim(&text, colored));
+    println!();
 }
 
 /// Prints one scope's row plus any reason continuation lines.

--- a/cli/modules/ready/src/render/watch.rs
+++ b/cli/modules/ready/src/render/watch.rs
@@ -1,6 +1,8 @@
-//! `--watch` transition tracking: the merged snapshot diff and the
-//! append-only log line renderer.
+//! `--watch` transition tracking: the merged snapshot diff, the append-only
+//! transition log line renderer, and the transport-lifecycle line renderer
+//! used by aggregate watch's reconnect-with-backoff supervisors.
 
+use core::time::Duration;
 use std::collections::BTreeMap;
 
 use chrono::Local;
@@ -16,31 +18,90 @@ use super::{
 /// it on the same line.
 const REASON_GAP: usize = 3;
 
+/// Trailing tag appended to a [`Transition::FirstSeen`] line, in the same
+/// [`dim`] grey as reason text rather than the `stale` tag's amber — a first
+/// sighting is informational, not a warning about aging data.
+const FIRST_SEEN_TAG: &str = "first seen";
+
 /// The kind of change observed for one scope in a `--watch` delta message.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Transition {
+    /// No entry existed for this scope in the snapshot map — its very first
+    /// observation, whatever its state.
+    ///
+    /// Deliberately distinct from `StateChanged { previous: State::Unknown
+    /// }`: that would claim the scope was once actually seen as `UNKNOWN`,
+    /// which never happened. A service picked up by the re-discovery sweep,
+    /// or one whose initial probe failed, both surface here.
+    FirstSeen,
     /// The scope's state changed away from `previous`.
     StateChanged { previous: State },
     /// The state is unchanged; only the reason changed.
     ReasonChanged,
+    /// Neither the state nor the reason changed — only a heartbeat field
+    /// (e.g. `observed_at`) advanced.
+    Unchanged,
 }
 
 /// Records `scope`'s new data in `snapshot` and classifies the change.
 ///
-/// A scope absent from `snapshot` is treated as having previously been
-/// `STATE_UNKNOWN`. `snapshot` is updated with `scope`'s full data so later
-/// calls can diff against it.
-pub fn record_transition(snapshot: &mut BTreeMap<String, Scope>, scope: &Scope) -> Transition {
-    let next = State::try_from(scope.state).unwrap_or_default();
-    let previous = snapshot
-        .insert(scope.name.clone(), scope.clone())
-        .map(|prev| State::try_from(prev.state).unwrap_or_default())
-        .unwrap_or(State::Unknown);
+/// `snapshot` is keyed by `(service, scope name)`, not scope name alone —
+/// scope names collide across services (several operators share a
+/// `reconcile` scope). A scope absent from `snapshot` returns
+/// [`Transition::FirstSeen`] rather than being diffed against a synthesized
+/// `STATE_UNKNOWN` entry — doing the latter would silently swallow a
+/// genuinely first-seen `UNKNOWN`, reason-less scope, since it would then
+/// compare equal to its own fabricated "previous" and render as nothing at
+/// all. `snapshot` is updated with `scope`'s full data so later calls can
+/// diff against it.
+///
+/// Only `state` and `reasons` are compared: `observed_at` and
+/// `last_transition_time` advance on every heartbeat and must never by
+/// themselves classify a message as changed — this mirrors the server's
+/// own change predicate, which never emits a `Watch` message for a pure
+/// heartbeat in the first place.
+pub fn record_transition(snapshot: &mut BTreeMap<(String, String), Scope>, service: &str, scope: &Scope) -> Transition {
+    let key = (service.to_owned(), scope.name.clone());
+    let previous = snapshot.insert(key, scope.clone());
 
-    if previous == next {
+    let Some(previous) = previous else {
+        return Transition::FirstSeen;
+    };
+
+    let previous_state = State::try_from(previous.state).unwrap_or_default();
+    let next_state = State::try_from(scope.state).unwrap_or_default();
+
+    if previous_state != next_state {
+        return Transition::StateChanged { previous: previous_state };
+    }
+
+    if previous.reasons.as_slice() != scope.reasons.as_slice() {
         Transition::ReasonChanged
     } else {
-        Transition::StateChanged { previous }
+        Transition::Unchanged
+    }
+}
+
+/// The optional service cell prefixing a `--watch` transition line.
+///
+/// [`ServiceColumn::None`] is single-service watch, where every line names
+/// the same service and repeating it would be noise. [`ServiceColumn::Named`]
+/// is aggregate watch: `alias` is padded to `width`, which must be measured
+/// once (via [`super::name_width`]) and held for the whole session.
+#[derive(Debug, Clone, Copy)]
+pub enum ServiceColumn<'a> {
+    None,
+    Named { alias: &'a str, width: usize },
+}
+
+impl ServiceColumn<'_> {
+    /// Renders the cell text: the padded alias plus its separating space,
+    /// or an empty string for [`ServiceColumn::None`].
+    fn cell(self) -> String {
+        match self {
+            Self::None => String::new(),
+            Self::Named { alias, width } => format!("{alias:<width$} "),
+        }
     }
 }
 
@@ -54,18 +115,30 @@ struct Prefix {
     styled: String,
 }
 
-/// Builds the `HH:MM:SS  ✗ name  PREV → NEXT` prefix of a transition line.
+/// Builds the `HH:MM:SS  ✗ [service] name  PREV → NEXT` prefix of a
+/// transition line.
 ///
 /// `name` must already be padded to the scope-name column width. Every part
 /// is rendered twice from the same text: once bare for [`Prefix::plain`] and
 /// once through [`StateStyle`] for [`Prefix::styled`], so the two can never
 /// disagree on the visible width. The mark and both state labels are colored
 /// by their own state — the previous label keeps its old state's color — and
-/// the timestamp and arrow stay grey.
-fn transition_prefix(timestamp: &str, name: &str, state: State, transition: Transition, colored: bool) -> Prefix {
+/// the timestamp, service cell, and arrow stay grey or uncolored.
+/// [`Transition::FirstSeen`] renders the same single-label shape as a
+/// reason-only change; [`print_transition_line`] appends the tag that tells
+/// the two apart.
+fn transition_prefix(
+    timestamp: &str,
+    service: ServiceColumn,
+    name: &str,
+    state: State,
+    transition: Transition,
+    colored: bool,
+) -> Prefix {
     let symbols = Symbols::new(colored);
     let style = StateStyle::new(state, colored);
     let label = super::label(state);
+    let service = service.cell();
 
     let (change, styled_change) = match transition {
         Transition::StateChanged { previous } => {
@@ -82,13 +155,15 @@ fn transition_prefix(timestamp: &str, name: &str, state: State, transition: Tran
                 ),
             )
         }
-        Transition::ReasonChanged => (label.to_string(), style.paint(label)),
+        Transition::ReasonChanged | Transition::Unchanged | Transition::FirstSeen => {
+            (label.to_string(), style.paint(label))
+        }
     };
 
     Prefix {
-        plain: format!("{timestamp}  {} {name} {change}", style.mark),
+        plain: format!("{timestamp}  {} {service}{name} {change}", style.mark),
         styled: format!(
-            "{}  {} {name} {styled_change}",
+            "{}  {} {service}{name} {styled_change}",
             dim(timestamp, colored),
             style.styled_mark()
         ),
@@ -98,23 +173,38 @@ fn transition_prefix(timestamp: &str, name: &str, state: State, transition: Tran
 /// Prints one append-only log line for a `--watch` change.
 ///
 /// A state change shows `PREV → NEXT` on the transition line; a reason-only
-/// change shows the unchanged state instead. Both kinds then render every
-/// `CODE: message` reason (if any) on a wrapped, dim continuation line — the
-/// server never resends an unchanged reason, so a persistent failure's
-/// message would otherwise only ever be shown once. Long reason text wraps
-/// with a hanging indent when stdout is a TTY; a scope with no reasons
-/// prints just the transition line.
-pub fn print_transition_line(scope: &Scope, name_width: usize, transition: Transition) {
+/// change shows the unchanged state instead. [`Transition::FirstSeen`] shows
+/// the unchanged-looking state too, but follows it with a trailing dim
+/// `first seen` tag — otherwise a scope's very first sighting would be
+/// indistinguishable from a reason-only change that happens to land on the
+/// same state. Every kind then renders every `CODE: message` reason (if
+/// any) on a wrapped, dim continuation line — the server never resends an
+/// unchanged reason, so a persistent failure's message would otherwise
+/// only ever be shown once. Long reason text wraps with a hanging indent
+/// when stdout is a TTY; a scope with no reasons prints just the
+/// transition line. `service` names the service the change belongs to in
+/// aggregate watch, and is omitted in single-service watch — see
+/// [`ServiceColumn`]. A caller must not pass [`Transition::Unchanged`]: the
+/// whole point of that variant is that nothing is worth printing.
+pub fn print_transition_line(service: ServiceColumn, scope: &Scope, name_width: usize, transition: Transition) {
     let colored = output::is_colored();
     let wrap_width = display::terminal_width();
     let timestamp = Local::now().format("%H:%M:%S").to_string();
     let state = State::try_from(scope.state).unwrap_or_default();
     let name = format!("{:<width$}", scope.name, width = name_width);
 
-    let prefix = transition_prefix(&timestamp, &name, state, transition, colored);
-    let indent = prefix.plain.chars().count() + REASON_GAP;
+    let prefix = transition_prefix(&timestamp, service, &name, state, transition, colored);
+    let first_seen_tag = matches!(transition, Transition::FirstSeen).then(|| dim(FIRST_SEEN_TAG, colored));
+    let tag_width = first_seen_tag
+        .as_ref()
+        .map_or(0, |_| REASON_GAP + FIRST_SEEN_TAG.chars().count());
+    let indent = prefix.plain.chars().count() + tag_width + REASON_GAP;
 
     print!("{}", prefix.styled);
+
+    if let Some(tag) = &first_seen_tag {
+        print!("{:width$}{tag}", "", width = REASON_GAP);
+    }
 
     let mut is_first_line = true;
     for reason in &scope.reasons {
@@ -140,8 +230,63 @@ pub fn print_transition_line(scope: &Scope, name_width: usize, transition: Trans
     println!();
 }
 
+/// Prints one lifecycle line for a `--watch` supervisor event that is not a
+/// readiness change, given an already-composed `message`: a stream
+/// reattaching, or — via [`print_lost_line`] — one being lost.
+///
+/// `HH:MM:SS  [!] alias  message`, the whole line dim — this is transport
+/// chatter, not a readiness state, and must never borrow a [`StateStyle`]
+/// colour. Long messages wrap with a hanging indent, the same way a
+/// transition line's reason text does.
+pub fn print_lifecycle_line(alias: &str, alias_width: usize, message: &str) {
+    let colored = output::is_colored();
+    let wrap_width = display::terminal_width();
+    let timestamp = Local::now().format("%H:%M:%S").to_string();
+    let mark = if colored { "[!]" } else { "[--]" };
+    let name = format!("{alias:<alias_width$}");
+
+    let prefix = format!("{timestamp}  {mark} {name}  ");
+    let indent = prefix.chars().count();
+
+    print!("{}", dim(&prefix, colored));
+
+    let lines = match wrap_width {
+        Some(width) if width > indent => wrap_words(message, width - indent),
+        _ => vec![normalize_whitespace(message)],
+    };
+
+    for (idx, line) in lines.iter().enumerate() {
+        if idx > 0 {
+            print!("\n{:indent$}", "");
+        }
+        print!("{}", dim(line, colored));
+    }
+
+    println!();
+}
+
+/// Prints one lifecycle line for a `--watch` supervisor losing its stream,
+/// composing the raw disconnect `cause` and the backoff `retry_after` into
+/// one human line.
+///
+/// `stream lost: {cause}{dash}reconnecting in {delay}`, `dash` taken from
+/// [`Symbols`] so it degrades to ASCII off [`output::is_colored`] exactly
+/// like every other glyph in this render. The composition happens here, at
+/// render time, rather than where the event is built, so the
+/// machine-readable payload's `error` field carries `cause` alone.
+pub fn print_lost_line(alias: &str, alias_width: usize, cause: &str, retry_after: Duration) {
+    let colored = output::is_colored();
+    let symbols = Symbols::new(colored);
+    let delay = humantime::format_duration(retry_after);
+    let message = format!("stream lost: {cause}{}reconnecting in {delay}", symbols.dash);
+
+    print_lifecycle_line(alias, alias_width, &message);
+}
+
 #[cfg(test)]
 mod test {
+    use readinesspb::pb::Reason;
+
     use super::*;
 
     fn scope(name: &str, state: State) -> Scope {
@@ -151,6 +296,16 @@ mod test {
             reasons: Vec::new(),
             observed_at: None,
             last_transition_time: None,
+        }
+    }
+
+    fn scope_with_reason(name: &str, state: State, code: &str) -> Scope {
+        Scope {
+            reasons: vec![Reason {
+                code: code.to_owned(),
+                message: String::new(),
+            }],
+            ..scope(name, state)
         }
     }
 
@@ -182,6 +337,7 @@ mod test {
 
         let prefix = transition_prefix(
             "14:32:11",
+            ServiceColumn::None,
             "rib         ",
             State::NotReady,
             Transition::StateChanged { previous: State::Ready },
@@ -197,6 +353,7 @@ mod test {
     fn transition_prefix_uncolored_is_ascii_and_escape_free() {
         let prefix = transition_prefix(
             "14:32:11",
+            ServiceColumn::None,
             "rib         ",
             State::NotReady,
             Transition::StateChanged { previous: State::Ready },
@@ -215,6 +372,7 @@ mod test {
 
         let prefix = transition_prefix(
             "14:32:11",
+            ServiceColumn::None,
             "rib         ",
             State::Degraded,
             Transition::ReasonChanged,
@@ -228,11 +386,37 @@ mod test {
     }
 
     #[test]
+    fn transition_prefix_named_service_adds_a_padded_cell() {
+        let with_service = transition_prefix(
+            "14:32:11",
+            ServiceColumn::Named { alias: "route", width: 10 },
+            "rib         ",
+            State::Ready,
+            Transition::ReasonChanged,
+            false,
+        );
+        let without_service = transition_prefix(
+            "14:32:11",
+            ServiceColumn::None,
+            "rib         ",
+            State::Ready,
+            Transition::ReasonChanged,
+            false,
+        );
+
+        assert!(with_service.plain.contains("route"));
+        assert_eq!(
+            without_service.plain.chars().count() + 11,
+            with_service.plain.chars().count()
+        );
+    }
+
+    #[test]
     fn record_transition_detects_state_change() {
         let mut snapshot = BTreeMap::new();
-        snapshot.insert("rib".to_string(), scope("rib", State::Ready));
+        snapshot.insert(("route".to_owned(), "rib".to_owned()), scope("rib", State::Ready));
 
-        let transition = record_transition(&mut snapshot, &scope("rib", State::Degraded));
+        let transition = record_transition(&mut snapshot, "route", &scope("rib", State::Degraded));
 
         assert_eq!(Transition::StateChanged { previous: State::Ready }, transition);
     }
@@ -240,30 +424,87 @@ mod test {
     #[test]
     fn record_transition_detects_reason_only_change() {
         let mut snapshot = BTreeMap::new();
-        snapshot.insert("rib".to_string(), scope("rib", State::Degraded));
+        snapshot.insert(
+            ("route".to_owned(), "rib".to_owned()),
+            scope_with_reason("rib", State::Degraded, "BIRD_DOWN"),
+        );
 
-        let transition = record_transition(&mut snapshot, &scope("rib", State::Degraded));
+        let transition = record_transition(
+            &mut snapshot,
+            "route",
+            &scope_with_reason("rib", State::Degraded, "TIMEOUT"),
+        );
 
         assert_eq!(Transition::ReasonChanged, transition);
     }
 
     #[test]
-    fn record_transition_treats_unknown_scope_as_previously_unknown() {
+    fn record_transition_is_unchanged_when_state_and_reasons_match() {
+        let mut snapshot = BTreeMap::new();
+        let mut previous = scope_with_reason("rib", State::Degraded, "BIRD_DOWN");
+        previous.observed_at = Some(prost_types::Timestamp { seconds: 1, nanos: 0 });
+        snapshot.insert(("route".to_owned(), "rib".to_owned()), previous);
+
+        // Same state and reason, but `observed_at` advanced — a pure
+        // heartbeat must not be classified as a change.
+        let mut next = scope_with_reason("rib", State::Degraded, "BIRD_DOWN");
+        next.observed_at = Some(prost_types::Timestamp { seconds: 2, nanos: 0 });
+
+        let transition = record_transition(&mut snapshot, "route", &next);
+
+        assert_eq!(Transition::Unchanged, transition);
+    }
+
+    #[test]
+    fn record_transition_first_sighting_is_first_seen_regardless_of_state() {
         let mut snapshot = BTreeMap::new();
 
-        let transition = record_transition(&mut snapshot, &scope("neighbours", State::NotReady));
+        let transition = record_transition(&mut snapshot, "route", &scope("neighbours", State::NotReady));
 
-        assert_eq!(Transition::StateChanged { previous: State::Unknown }, transition);
-        assert!(snapshot.contains_key("neighbours"));
+        assert_eq!(Transition::FirstSeen, transition);
+        assert!(snapshot.contains_key(&("route".to_owned(), "neighbours".to_owned())));
+    }
+
+    #[test]
+    fn record_transition_first_sighting_of_unknown_reasonless_scope_is_not_unchanged() {
+        // This is the exact bug: synthesizing a fake `STATE_UNKNOWN`,
+        // reason-less "previous" for an absent snapshot entry made a
+        // genuinely first-seen `UNKNOWN` scope compare equal to it and
+        // vanish as `Unchanged`.
+        let mut snapshot = BTreeMap::new();
+
+        let transition = record_transition(&mut snapshot, "route", &scope("neighbours", State::Unknown));
+
+        assert_eq!(Transition::FirstSeen, transition);
+        assert_ne!(Transition::Unchanged, transition);
+    }
+
+    #[test]
+    fn record_transition_keys_by_service_and_scope_name() {
+        let mut snapshot = BTreeMap::new();
+        snapshot.insert(
+            ("route".to_owned(), "reconcile".to_owned()),
+            scope("reconcile", State::Ready),
+        );
+
+        // A same-named scope from a different service must not be diffed
+        // against `route`'s entry — it must be a first sighting, not a
+        // comparison against `route`'s `Ready` entry.
+        let transition = record_transition(&mut snapshot, "decap", &scope("reconcile", State::NotReady));
+
+        assert_eq!(Transition::FirstSeen, transition);
     }
 
     #[test]
     fn record_transition_updates_snapshot() {
         let mut snapshot = BTreeMap::new();
-        snapshot.insert("rib".to_string(), scope("rib", State::Ready));
+        snapshot.insert(("route".to_owned(), "rib".to_owned()), scope("rib", State::Ready));
 
-        record_transition(&mut snapshot, &scope("rib", State::NotReady));
+        record_transition(&mut snapshot, "route", &scope("rib", State::NotReady));
 
-        assert_eq!(State::NotReady as i32, snapshot["rib"].state);
+        assert_eq!(
+            State::NotReady as i32,
+            snapshot[&("route".to_owned(), "rib".to_owned())].state
+        );
     }
 }

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -1,0 +1,658 @@
+//! Aggregate `--watch`: one reconnect-with-backoff supervisor per
+//! discovered service, a periodic re-discovery sweep for services that
+//! register later, and the single render loop that serializes their
+//! output.
+//!
+//! The initial probe (shared with the one-shot aggregate command) seeds the
+//! merged transition snapshot before any supervisor's `Watch` stream opens,
+//! so its first message — always a full snapshot, per the server's own
+//! contract — diffs to nothing instead of reporting every scope as newly
+//! discovered.
+
+use core::time::Duration;
+use std::{
+    collections::{BTreeMap, HashSet},
+    sync::Arc,
+};
+
+use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope};
+use serde::Serialize;
+use tokio::sync::mpsc;
+use ync::{client::Connection, discovery, errors::Error, output};
+
+use crate::{
+    Cmd, READINESS_SERVICE, ServiceReport, print_report, probe,
+    render::{self, ServiceColumn, Transition},
+};
+
+/// Initial delay before a supervisor's first reconnect attempt, doubling on
+/// each further failure up to [`MAX_BACKOFF`].
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Ceiling every supervisor's reconnect backoff is clamped to.
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// How often the re-discovery sweep re-lists the gateway's registered
+/// readiness services, to pick up ones not yet registered at startup.
+///
+/// Also doubles as that sweep's own per-attempt timeout budget: a
+/// `list_services` call that has not answered by the time the next sweep is
+/// due is stalled by definition, so the cadence is its own natural bound and
+/// needs no separate magic number. The worst case is simply that the
+/// effective sweep period doubles.
+const REDISCOVER_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Budget for one service's initial `Ready` probe in aggregate `--watch`.
+///
+/// The probe only seeds the first rendered snapshot; a service that misses
+/// this budget still gets its supervisor spawned on schedule, whose `Watch`
+/// stream opens independently and always starts with a full snapshot (per
+/// the server's own contract) that repopulates it as first sightings. So
+/// this deliberately favours starting the watch promptly over a prettier
+/// first screen, which is why it is its own constant rather than a reuse of
+/// [`discovery::DISCOVERY_TIMEOUT`] — that one scopes only best-effort
+/// enrichment such as hints and shell completions.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Runs aggregate `--watch`.
+///
+/// Probes every discovered service once — rendering the same blocks the
+/// one-shot aggregate command does, plus a standalone `watching…` line —
+/// then hands off to one supervisor task per service and a re-discovery
+/// task, rendering every event they produce until the process is
+/// interrupted.
+///
+/// Only ends on interruption: every supervisor loops forever and the
+/// re-discovery task never exits, so the `Ok(true)` below is unreachable
+/// in practice — it mirrors single-service `--watch`, whose clean stream
+/// close likewise maps to `Ok(true)` rather than reporting the readiness
+/// observed at startup.
+pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
+    let connection = Arc::new(Connection::connect_for(&cmd.connection, "ready").await?);
+    let services = discovery::list_services(&connection, READINESS_SERVICE).await?;
+
+    let mut reports = Vec::with_capacity(services.len());
+    for service in &services {
+        reports.push(probe_bounded(&connection, service.clone()).await);
+    }
+
+    let aliases = discovery::alias_map(&services);
+    let alias_width = render::name_width(aliases.values().map(String::as_str));
+    let scope_width = render::name_width(
+        reports
+            .iter()
+            .flat_map(|report| report.scopes.iter())
+            .map(|scope| scope.name.as_str()),
+    );
+
+    // Always renders, even with no services discovered: the re-discovery
+    // sweep below will pick services up as they register, so the wait
+    // must stay visible instead of leaving a silent hang.
+    let snapshot_payload = SnapshotPayload {
+        event: EventKind::Snapshot,
+        services: &reports,
+    };
+
+    output::data(&snapshot_payload, false, format_args!(""), || {
+        if reports.is_empty() {
+            eprintln!("no readiness services registered");
+        } else {
+            for (idx, report) in reports.iter().enumerate() {
+                if idx > 0 {
+                    println!();
+                }
+
+                print_report(report, scope_width, cmd.stale_after);
+            }
+        }
+
+        render::print_watching_line();
+    });
+
+    let mut snapshot: BTreeMap<(String, String), Scope> = BTreeMap::new();
+    for report in &reports {
+        for scope in &report.scopes {
+            snapshot.insert((report.service.clone(), scope.name.clone()), scope.clone());
+        }
+    }
+
+    let (sender, mut receiver) = mpsc::unbounded_channel::<Event>();
+
+    for service in &services {
+        let alias = aliases.get(service).cloned().unwrap_or_else(|| service.clone());
+
+        tokio::spawn(supervise(connection.clone(), service.clone(), alias, sender.clone()));
+    }
+
+    let known: HashSet<String> = services.into_iter().collect();
+    tokio::spawn(rediscover(connection.clone(), known, aliases, sender.clone()));
+
+    drop(sender);
+
+    while let Some(event) = receiver.recv().await {
+        render_event(event, &mut snapshot, scope_width, alias_width);
+    }
+
+    Ok(true)
+}
+
+/// Probes one service for the initial snapshot, bounded by [`PROBE_TIMEOUT`].
+///
+/// A service that is registered but never answers `Ready` — a wedged
+/// component, a half-open socket — must not stall every other service's
+/// probe, nor the supervisors and rediscovery task spawned once probing
+/// finishes. A timeout is reported the same way [`probe`] already reports a
+/// failed one: an empty `scopes` and a populated `error`, so it renders as
+/// that service's error block and its supervisor still starts normally.
+async fn probe_bounded(connection: &Connection, service: String) -> ServiceReport {
+    match tokio::time::timeout(PROBE_TIMEOUT, probe(connection, service.clone())).await {
+        Ok(report) => report,
+        Err(..) => ServiceReport {
+            service,
+            scopes: Vec::new(),
+            error: Some(format!("probe timed out after {PROBE_TIMEOUT:?}")),
+        },
+    }
+}
+
+/// One update delivered by a supervisor to the render loop.
+///
+/// `service` and `data` are the serialized payload's source (via
+/// [`EventPayload`]); `alias` steers human rendering only and is never
+/// serialized.
+struct Event {
+    service: String,
+    alias: String,
+    data: EventData,
+}
+
+/// The event-specific data carried by an [`Event`].
+///
+/// A [`Lost`](Self::Lost) event keeps its disconnect `cause` and its
+/// `retry_after` backoff separate rather than pre-composed into one
+/// string: the human renderer composes them into one line at render time,
+/// and the serialized payload's `error` is `cause` alone.
+enum EventData {
+    /// A `Watch` message arrived, carrying the scopes it changed (or, for
+    /// the first message after a stream opens, the full snapshot).
+    Message(Vec<Scope>),
+    /// The stream (re)established after a previous disconnect.
+    Reattached,
+    /// The stream ended or errored; the supervisor is retrying after
+    /// `retry_after`.
+    Lost { cause: String, retry_after: Duration },
+}
+
+/// The wire discriminator shared by [`SnapshotPayload`]'s and
+/// [`EventPayload`]'s `event` field.
+///
+/// `Snapshot` is the stream's first line ([`SnapshotPayload`]); the other
+/// three each describe one [`EventPayload`] line that follows it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum EventKind {
+    Snapshot,
+    Message,
+    Reattached,
+    Lost,
+}
+
+impl EventData {
+    fn kind(&self) -> EventKind {
+        match self {
+            Self::Message(..) => EventKind::Message,
+            Self::Reattached => EventKind::Reattached,
+            Self::Lost { .. } => EventKind::Lost,
+        }
+    }
+}
+
+/// The wire shape of the snapshot line an aggregate `--watch` JSON stream
+/// opens with.
+///
+/// Every later line is an [`EventPayload`], which always names one
+/// `service`; this envelope instead lists every service probed before any
+/// supervisor's stream opened, so it needs its own struct rather than
+/// reusing that shape. Wrapping `services` behind the same `event`
+/// discriminator means line 1 is a JSON object like every other line, not
+/// a bare array a `jq -c 'select(.event == …)'` pipeline would choke on.
+#[derive(Serialize)]
+struct SnapshotPayload<'a> {
+    event: EventKind,
+    services: &'a [ServiceReport],
+}
+
+/// The self-describing JSON Lines wire shape of one aggregate `--watch`
+/// per-service event: every line after the stream's first (see
+/// [`SnapshotPayload`]).
+///
+/// `event` is the discriminator a monitoring script switches on; `error`
+/// means an error and nothing else — it is set only when `event` is
+/// `"lost"`, and holds the raw disconnect cause alone, never the composed
+/// "reconnecting in …" wording that the human renderer adds. A successful
+/// reconnect (`"reattached"`) therefore always serializes with
+/// `error: null`, never mistakeable for a failure.
+#[derive(Serialize)]
+struct EventPayload<'a> {
+    service: &'a str,
+    event: EventKind,
+    scopes: &'a [Scope],
+    error: Option<&'a str>,
+}
+
+impl Event {
+    fn message(service: &str, alias: &str, scopes: Vec<Scope>) -> Self {
+        Self {
+            service: service.to_owned(),
+            alias: alias.to_owned(),
+            data: EventData::Message(scopes),
+        }
+    }
+
+    fn reattached(service: &str, alias: &str) -> Self {
+        Self {
+            service: service.to_owned(),
+            alias: alias.to_owned(),
+            data: EventData::Reattached,
+        }
+    }
+
+    fn lost(service: &str, alias: &str, cause: &str, retry_after: Duration) -> Self {
+        Self {
+            service: service.to_owned(),
+            alias: alias.to_owned(),
+            data: EventData::Lost { cause: cause.to_owned(), retry_after },
+        }
+    }
+}
+
+/// The reconnect-lifecycle state one `supervise` loop threads across
+/// attempts.
+///
+/// Kept as its own type, independent of the live stream, so the rules
+/// around when a `Lost` is due and when it is closed out by a `Reattached`
+/// are testable without a server to drive `supervise`'s stream.
+/// `last_unopened_message` dedupes repeated `Lost` events across
+/// consecutive attempts that never open, all reporting the same error;
+/// `lost_outstanding` is the single fact both event kinds key off — a
+/// `Lost` has been emitted since the last successful open and not yet
+/// closed out by one.
+#[derive(Debug, Default)]
+struct SuperviseState {
+    lost_outstanding: bool,
+    last_unopened_message: Option<String>,
+}
+
+impl SuperviseState {
+    /// Records that this attempt's stream opened successfully.
+    ///
+    /// Returns whether a `Reattached` event is due — exactly when a `Lost`
+    /// was outstanding from a previous attempt — and always clears the
+    /// outstanding flag and the failure-dedupe key, since a live stream
+    /// closes both out.
+    fn opened(&mut self) -> bool {
+        let reattached = self.lost_outstanding;
+        self.lost_outstanding = false;
+        self.last_unopened_message = None;
+
+        reattached
+    }
+
+    /// Records that this attempt's stream opened at least once and then
+    /// ended.
+    ///
+    /// Always due: a stream that was open and is now gone is always worth
+    /// reporting, unlike a repeat of the same never-opened failure.
+    fn lost_after_open(&mut self) -> bool {
+        self.lost_outstanding = true;
+
+        true
+    }
+
+    /// Records that this attempt ended without the stream ever opening,
+    /// with the given error `message`.
+    ///
+    /// Returns whether a `Lost` event is due: a repeat of the same message
+    /// across consecutive never-opened attempts is deduped, but the first
+    /// is always reported.
+    fn failed_before_open(&mut self, message: &str) -> bool {
+        let should_emit = self.last_unopened_message.as_deref() != Some(message);
+        self.last_unopened_message = Some(message.to_owned());
+
+        if should_emit {
+            self.lost_outstanding = true;
+        }
+
+        should_emit
+    }
+}
+
+/// Watches one service forever, reconnecting with backoff on every
+/// disconnect and forwarding every message and lifecycle event to `sender`.
+///
+/// Never returns on its own: a service that disappears from the registry,
+/// or never answers at all, just keeps retrying and reporting `Lost`
+/// events rather than being torn down — re-registration then works with no
+/// special handling.
+async fn supervise(connection: Arc<Connection>, service: String, alias: String, sender: mpsc::UnboundedSender<Event>) {
+    let mut backoff = INITIAL_BACKOFF;
+    let mut state = SuperviseState::default();
+
+    loop {
+        let mut opened_this_attempt = false;
+
+        let result = connection
+            .invoke_server_stream::<ReadyRequest, ReadyResponse, _>(
+                "ready",
+                &service,
+                "Watch",
+                ReadyRequest { scopes: Vec::new() },
+                |resp: ReadyResponse| {
+                    if !opened_this_attempt {
+                        opened_this_attempt = true;
+                        backoff = INITIAL_BACKOFF;
+
+                        if state.opened() {
+                            let _ = sender.send(Event::reattached(&service, &alias));
+                        }
+                    }
+
+                    let _ = sender.send(Event::message(&service, &alias, resp.scopes));
+                },
+            )
+            .await;
+
+        let message = stream_error_message(&result);
+        let should_emit = if opened_this_attempt {
+            state.lost_after_open()
+        } else {
+            state.failed_before_open(&message)
+        };
+
+        if should_emit {
+            let _ = sender.send(Event::lost(&service, &alias, &message, backoff));
+        }
+
+        tokio::time::sleep(backoff).await;
+        backoff = next_backoff(backoff);
+    }
+}
+
+/// Renders the outcome of one `Watch` attempt as a `Lost` event's message
+/// text: the RPC error's own message, or a fixed wording when the server
+/// simply closed the stream.
+fn stream_error_message(result: &Result<(), Error>) -> String {
+    match result {
+        Ok(()) => "stream closed by server".to_owned(),
+        Err(err) => err.message().to_owned(),
+    }
+}
+
+/// Doubles `backoff`, clamped to [`MAX_BACKOFF`].
+fn next_backoff(backoff: Duration) -> Duration {
+    (backoff * 2).min(MAX_BACKOFF)
+}
+
+/// Periodically re-lists the gateway's registered readiness services and
+/// spawns a supervisor for each one not already known.
+///
+/// A failed or stalled sweep is silent: the next tick retries, and a service
+/// that really is unreachable already has its own supervisor saying so via
+/// `Lost` events. The `list_services` call is bounded by
+/// [`REDISCOVER_INTERVAL`] rather than left to hang indefinitely — a stuck
+/// gateway connection must not park this task forever, since it is the only
+/// path that picks up services registering after startup. `known` and
+/// `aliases` are owned exclusively by this task from the moment it is
+/// spawned, so assigning a newly discovered service's alias needs no shared
+/// or locked state, and never rewrites an alias a running supervisor has
+/// already been handed.
+async fn rediscover(
+    connection: Arc<Connection>,
+    mut known: HashSet<String>,
+    mut aliases: BTreeMap<String, String>,
+    sender: mpsc::UnboundedSender<Event>,
+) {
+    loop {
+        tokio::time::sleep(REDISCOVER_INTERVAL).await;
+
+        let sweep = discovery::list_services(&connection, READINESS_SERVICE);
+        let Ok(Ok(services)) = tokio::time::timeout(REDISCOVER_INTERVAL, sweep).await else {
+            continue;
+        };
+
+        for service in services {
+            if !known.insert(service.clone()) {
+                continue;
+            }
+
+            let alias = assign_alias(&service, &aliases);
+            aliases.insert(service.clone(), alias.clone());
+
+            tokio::spawn(supervise(connection.clone(), service, alias, sender.clone()));
+        }
+    }
+}
+
+/// Assigns a display alias for a newly discovered `service`, falling back
+/// to its full name when the derived alias collides with one already
+/// assigned.
+///
+/// Compares against every known service's own *derived* alias
+/// (`discovery::derive_alias`), not against `aliases`' assigned values: a
+/// pair of services that already collided has had both of its values
+/// rewritten to their FQNs, so comparing against values alone would miss a
+/// third service later deriving that same alias.
+fn assign_alias(service: &str, aliases: &BTreeMap<String, String>) -> String {
+    let candidate = discovery::derive_alias(service);
+
+    let collides = aliases.keys().any(|known| discovery::derive_alias(known) == candidate);
+
+    if collides { service.to_owned() } else { candidate }
+}
+
+/// Renders one event from a supervisor.
+///
+/// A `Message` diffs its scopes against the merged `snapshot` and prints
+/// one transition line per scope that actually changed; `Reattached`
+/// prints one dim [`render::print_lifecycle_line`]; `Lost` composes its
+/// cause and retry delay via [`render::print_lost_line`]. Always calls
+/// `output::data` so JSON mode sees every event exactly as received, even
+/// when nothing is worth printing in human mode.
+fn render_event(
+    event: Event,
+    snapshot: &mut BTreeMap<(String, String), Scope>,
+    scope_width: usize,
+    alias_width: usize,
+) {
+    let Event { service, alias, data } = event;
+    let kind = data.kind();
+
+    match data {
+        EventData::Message(scopes) => {
+            let payload = EventPayload {
+                service: &service,
+                event: kind,
+                scopes: &scopes,
+                error: None,
+            };
+
+            output::data(&payload, false, format_args!(""), || {
+                let mut scopes = scopes.clone();
+                scopes.sort_by(|a, b| a.name.cmp(&b.name));
+
+                for scope in &scopes {
+                    let transition = render::record_transition(snapshot, &service, scope);
+
+                    if transition != Transition::Unchanged {
+                        render::print_transition_line(
+                            ServiceColumn::Named { alias: &alias, width: alias_width },
+                            scope,
+                            scope_width,
+                            transition,
+                        );
+                    }
+                }
+            });
+        }
+        EventData::Reattached => {
+            let payload = EventPayload {
+                service: &service,
+                event: kind,
+                scopes: &[],
+                error: None,
+            };
+
+            output::data(&payload, false, format_args!(""), || {
+                render::print_lifecycle_line(&alias, alias_width, "stream reattached");
+            });
+        }
+        EventData::Lost { cause, retry_after } => {
+            let payload = EventPayload {
+                service: &service,
+                event: kind,
+                scopes: &[],
+                error: Some(&cause),
+            };
+
+            output::data(&payload, false, format_args!(""), || {
+                render::print_lost_line(&alias, alias_width, &cause, retry_after);
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn backoff_doubles_up_to_the_ceiling() {
+        let mut backoff = INITIAL_BACKOFF;
+        let mut steps = Vec::new();
+
+        for _ in 0..7 {
+            steps.push(backoff);
+            backoff = next_backoff(backoff);
+        }
+
+        assert_eq!(
+            vec![
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+                Duration::from_secs(4),
+                Duration::from_secs(8),
+                Duration::from_secs(16),
+                Duration::from_secs(30),
+                Duration::from_secs(30),
+            ],
+            steps
+        );
+    }
+
+    #[test]
+    fn supervise_state_first_attempt_opens_without_a_reattached() {
+        let mut state = SuperviseState::default();
+
+        assert!(!state.opened());
+    }
+
+    #[test]
+    fn supervise_state_opens_dies_reopens_emits_lost_then_reattached() {
+        let mut state = SuperviseState::default();
+
+        assert!(!state.opened());
+        assert!(state.lost_after_open());
+        assert!(state.opened());
+    }
+
+    #[test]
+    fn supervise_state_failed_before_first_open_still_reattaches() {
+        // The bug case: a first attempt that never opens must not leave
+        // the eventual successful open silent.
+        let mut state = SuperviseState::default();
+
+        assert!(state.failed_before_open("boom"));
+        assert!(state.opened());
+    }
+
+    #[test]
+    fn supervise_state_dedupes_a_repeated_failure_but_keeps_the_lost_outstanding() {
+        let mut state = SuperviseState::default();
+
+        assert!(state.failed_before_open("boom"));
+        assert!(!state.failed_before_open("boom"));
+        assert!(state.opened());
+    }
+
+    #[test]
+    fn assign_alias_uses_the_derived_alias_when_no_collision() {
+        let aliases = BTreeMap::new();
+
+        let alias = assign_alias("operators.forward.operatorpb.v1.ReadinessService", &aliases);
+
+        assert_eq!("forward", alias);
+    }
+
+    #[test]
+    fn assign_alias_falls_back_to_the_fqn_on_collision() {
+        let mut aliases = BTreeMap::new();
+        aliases.insert(
+            "operators.route.operatorpb.v1.ReadinessService".to_owned(),
+            "route".to_owned(),
+        );
+
+        let alias = assign_alias("operators.route.operatorpb.v2.ReadinessService", &aliases);
+
+        assert_eq!("operators.route.operatorpb.v2.ReadinessService", alias);
+    }
+
+    #[test]
+    fn assign_alias_detects_a_collision_even_after_earlier_ones_were_rewritten_to_fqns() {
+        // Both entries already collided with each other, so their values
+        // are FQNs rather than "route" — a third service deriving "route"
+        // must still be caught by comparing against derived aliases, not
+        // against these already-rewritten values.
+        let mut aliases = BTreeMap::new();
+        aliases.insert(
+            "operators.route.operatorpb.v1.ReadinessService".to_owned(),
+            "operators.route.operatorpb.v1.ReadinessService".to_owned(),
+        );
+        aliases.insert(
+            "operators.route.operatorpb.v2.ReadinessService".to_owned(),
+            "operators.route.operatorpb.v2.ReadinessService".to_owned(),
+        );
+
+        let alias = assign_alias("operators.route.operatorpb.v3.ReadinessService", &aliases);
+
+        assert_eq!("operators.route.operatorpb.v3.ReadinessService", alias);
+    }
+
+    #[test]
+    fn event_data_kind_matches_its_variant() {
+        assert_eq!(EventKind::Message, EventData::Message(Vec::new()).kind());
+        assert_eq!(EventKind::Reattached, EventData::Reattached.kind());
+        assert_eq!(
+            EventKind::Lost,
+            EventData::Lost {
+                cause: "boom".to_owned(),
+                retry_after: Duration::from_secs(1)
+            }
+            .kind()
+        );
+    }
+
+    #[test]
+    fn lost_event_keeps_the_raw_cause_with_no_composed_wording() {
+        let event = Event::lost("svc", "alias", "boom", Duration::from_secs(5));
+
+        let EventData::Lost { cause, retry_after } = event.data else {
+            panic!("expected a Lost event");
+        };
+
+        // The cause must stay exactly what the RPC reported: no
+        // `reconnecting in …` suffix baked in, since that composition is
+        // the human renderer's job, done only at render time.
+        assert_eq!("boom", cause);
+        assert_eq!(Duration::from_secs(5), retry_after);
+    }
+}


### PR DESCRIPTION
Watching readiness previously required naming a single service, so observing a bring-up or a rolling restart meant one terminal per operator. Running the probe with no service named now streams every discovered readiness service at once, tagging each log line with a short service alias so the merged transition log stays readable. Naming a service keeps the existing single-service behaviour unchanged.

The watch is built to outlive the components it observes:

- A lost stream reconnects with exponential backoff, and repeated identical failures are collapsed so a long outage does not spam the log.
- The gateway registry is re-scanned periodically, so operators that register after the watch started are picked up automatically.
- An initial probe seeds the observed state, so a reconnect's full snapshot reports only what genuinely changed rather than replaying every scope.

Machine-readable output gained an explicit event discriminator, so a successful reconnect can never be mistaken for a failure by a monitoring consumer, and every line of the stream can be switched on uniformly.