### PR TITLE
feat(lint): enforce the commit subject and PR title convention

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Rejects a commit whose subject does not follow the "<type>(<scope>):
+# <brief>" convention from CLAUDE.md, so the rule is enforced before the
+# commit lands instead of being caught later in review or CI.
+if ! lint/commit/commitlint.sh --file "$1"; then
+	echo "commitlint failed; fix the subject above, or bypass with 'git commit --no-verify'" >&2
+	exit 1
+fi

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,27 @@
+name: Commit Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  commitlint:
+    name: Custom commitlint linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run tests
+        run: lint/commit/commitlint_test.sh
+
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: lint/commit/commitlint.sh --subject "$PR_TITLE"
+
+      - name: Check commit subjects
+        run: |
+          lint/commit/commitlint.sh \
+            --range "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,9 @@ cargo +nightly fmt            # Rust (uses nightly-only options in .rustfmt.toml
 cargo clippy                  # Rust lints
 make proto-lint               # protobuf formatting check
 make lint-go                  # loglint + golangci-lint modernize (lint/logger/, .golangci.yml)
+make lint-commit              # commit-subject convention check (lint/commit/)
 make proto-go                 # generate *.pb.go via protoc (needed before go lint locally)
-make hooks                    # install the pre-commit hook (run once per clone)
+make hooks                    # install the git hooks (run once per clone)
 
 # Fuzzing
 make fuzz                     # build fuzz targets
@@ -348,14 +349,22 @@ Web UI lives in `web/` (`package.json`, `index.html`, `dist/`).
 
 ### Commits & PRs
 
-- Commit format: `feat|fix|perf|chore|refactor(<scope>): brief description`
+- Commit format:
+  `feat|fix|refactor|perf|chore|docs|test|build|ci|style(<scope>): brief description`
   with high-level description (no code-level details, no
   backtick-quoted symbol names).
 - **Do not** add `Co-Authored-By: Claude …` / `Generated with Claude Code`
   footers.
-- PR title: `<feat|fix|refactor|chore|perf|docs>(<scope>): <short description>`
+- PR title:
+  `feat|fix|refactor|perf|chore|docs|test|build|ci|style(<scope>): <short description>`
   — MUST include the scope, exactly like commit subjects. A scopeless
   `feat: …` title is a convention violation.
+- Scope is mandatory (lowercase, comma-separated for multiple scopes); an
+  optional `!` before the colon marks a breaking change (e.g.
+  `feat(route)!: ...`); the brief must not start with an uppercase letter
+  and carries no trailing period. This is enforced mechanically by the
+  `commit-msg` hook (`make hooks`) and the Commit Lint CI job
+  (`lint/commit/`).
 - PR body: bullets start with capital, end with period. Add
   `Closes #<number>.` when applicable. **Do not** include a
   `## Summary` header — content goes directly. **Do not** include a

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,7 @@ CLI_RELEASE_BINARIES := $(addprefix $(RELEASE_DIR)/,$(CLI_BINARIES))
 	proto-breaking \
 	proto-go \
 	lint-go \
+	lint-commit \
 	hooks \
 	test \
 	test-asan \
@@ -173,6 +174,10 @@ lint-go:
 	else \
 		echo "WARN: 'golangci-lint' not found, skipping modernize lint (install: https://golangci-lint.run/welcome/install/)"; \
 	fi
+
+lint-commit:
+	lint/commit/commitlint_test.sh
+	lint/commit/commitlint.sh --range origin/main..HEAD
 
 hooks:
 	git config core.hooksPath .githooks

--- a/lint/commit/commitlint.sh
+++ b/lint/commit/commitlint.sh
@@ -1,0 +1,284 @@
+#!/bin/sh
+
+# commitlint enforces the "<type>(<scope>): <brief>" subject convention on
+# commit messages and PR titles.
+#
+# The convention is documented in CLAUDE.md under "Commits & PRs": type is
+# one of a closed set, scope is mandatory and lowercase, an optional "!"
+# marks a breaking change, and the brief must not start with an uppercase
+# letter and carries no trailing period. Enforcing it mechanically keeps
+# history greppable by scope and type without relying on reviewers to catch
+# drift.
+#
+# The classification below relies on POSIX character ranges ([a-z], [A-Z],
+# [[:space:]]) rather than Unicode properties, so it is forced to the C
+# locale: an accented uppercase letter starting a brief is not caught, which
+# matches the repo's all-ASCII commit history.
+export LC_ALL=C
+
+allowed_types="feat fix refactor perf chore docs test build ci style"
+
+usage() {
+	printf 'usage: %s --file <path> | --subject <text> | --range <a>..<b>\n' "$0" >&2
+}
+
+# validate_header checks the "type(scope)" or "type(scope)!" prefix of a
+# subject, before the ": " separator, printing a diagnostic and returning 1
+# on any violation.
+validate_header() {
+	header=$1
+
+	if ! printf '%s' "$header" | grep -qE '^[a-z]+(\([^)]*\))?!?$'; then
+		printf 'header "%s" must look like "type(scope)", optionally followed by "!"\n' "$header"
+		return 1
+	fi
+
+	commit_type=$(printf '%s' "$header" | sed -E 's/^([a-z]+)(\(([^)]*)\))?!?$/\1/')
+	scope_raw=$(printf '%s' "$header" | sed -E 's/^([a-z]+)(\(([^)]*)\))?!?$/\3/')
+
+	case "$header" in
+	*\(*) has_scope=1 ;;
+	*) has_scope=0 ;;
+	esac
+
+	case " $allowed_types " in
+	*" $commit_type "*) ;;
+	*)
+		printf 'unknown type "%s", must be one of feat, fix, refactor, perf, chore, docs, test, build, ci, style\n' "$commit_type"
+		return 1
+		;;
+	esac
+
+	if [ "$has_scope" -eq 0 ]; then
+		printf 'scope is mandatory, expected "%s" with a scope, e.g. "%s(scope)"\n' "$header" "$commit_type"
+		return 1
+	fi
+
+	if [ -z "$scope_raw" ]; then
+		printf 'scope must not be empty\n'
+		return 1
+	fi
+
+	if ! printf '%s' "$scope_raw" | grep -qE '^[a-z0-9][a-z0-9._/-]*(,[a-z0-9][a-z0-9._/-]*)*$'; then
+		printf 'scope "%s" must match [a-z0-9][a-z0-9._/-]*, comma-separated\n' "$scope_raw"
+		return 1
+	fi
+
+	return 0
+}
+
+# validate checks subject against the "<type>(<scope>): <brief>" convention,
+# printing nothing and returning 0 for a conforming subject, or printing a
+# diagnostic naming the offending subject and the rule it broke and
+# returning 1 otherwise.
+#
+# Merge commits and reverts are skipped without validation, since they carry
+# no type/scope by design. Autosquash markers (fixup!/squash!/amend!) are
+# NOT skipped here: run_file skips them before calling validate, since
+# git commit --fixup is a legitimate local workflow cleaned up later by an
+# interactive rebase, but --subject and --range (the CI callers of validate)
+# must reject a marker that is still present at PR time, since it can only
+# mean the commit either gets squashed away or, on a repo that also allows
+# plain "Rebase and merge", rides onto main unsquashed.
+validate() {
+	subject=$1
+
+	trimmed=$(printf '%s' "$subject" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+	if [ -z "$trimmed" ]; then
+		printf 'subject is empty\n'
+		return 1
+	fi
+
+	case "$subject" in
+	"Merge "* | 'Revert "'*)
+		return 0
+		;;
+	esac
+
+	# Strip a trailing GitHub PR-number suffix before the separator check, so
+	# a squash-merged subject is validated the same as its source commit.
+	subject=$(printf '%s' "$subject" | sed -E 's/[[:space:]]\(#[0-9]+\)$//')
+
+	case "$subject" in
+	*": "*)
+		header=${subject%%: *}
+		brief=${subject#*: }
+		;;
+	*)
+		printf 'subject "%s" must contain a ": " separator after "type(scope)"\n' "$subject"
+		return 1
+		;;
+	esac
+
+	if ! header_error=$(validate_header "$header"); then
+		printf 'subject "%s": %s\n' "$subject" "$header_error"
+		return 1
+	fi
+
+	if [ -z "$brief" ]; then
+		printf 'subject "%s": brief must not be empty\n' "$subject"
+		return 1
+	fi
+
+	case "$brief" in
+	[A-Z]*)
+		printf 'subject "%s": brief "%s" must not start with an uppercase letter\n' "$subject" "$brief"
+		return 1
+		;;
+	esac
+
+	case "$brief" in
+	*.)
+		printf 'subject "%s": brief "%s" must not end with a trailing period\n' "$subject" "$brief"
+		return 1
+		;;
+	esac
+
+	return 0
+}
+
+# first_subject_line prints the first non-empty, non-comment line of a
+# commit message file, or nothing if there is none.
+#
+# The blank check trims both sides, since a whitespace-only line is skipped
+# regardless of indentation. The comment check tests only for a "#" at
+# column 0, matching git's default --cleanup=strip, which does not treat an
+# indented "#" as a comment. The printed line is only trimmed on the
+# trailing side; trimming the leading side here would make the hook accept
+# a subject that CI's --range mode, which reads the raw subject, still
+# rejects.
+first_subject_line() {
+	file=$1
+
+	while IFS= read -r line || [ -n "$line" ]; do
+		trimmed=$(printf '%s' "$line" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+		if [ -z "$trimmed" ]; then
+			continue
+		fi
+		case "$line" in
+		"#"*) continue ;;
+		esac
+
+		printf '%s\n' "$line" | sed -E 's/[[:space:]]+$//'
+		return 0
+	done <"$file"
+}
+
+# run_file validates the subject read from a commit message file, exiting
+# non-zero and printing a diagnostic on failure.
+#
+# An autosquash marker (fixup!/squash!/amend!) is accepted here without
+# validation, since git commit --fixup=<ref> is a legitimate local workflow
+# whose subject is squashed away later by git rebase -i --autosquash.
+run_file() {
+	path=$1
+
+	if [ ! -r "$path" ]; then
+		printf 'failed to read commit message file: %s\n' "$path" >&2
+		exit 1
+	fi
+
+	subject=$(first_subject_line "$path")
+	if [ -z "$subject" ]; then
+		printf 'commit message has no subject line\n' >&2
+		exit 1
+	fi
+
+	case "$subject" in
+	"fixup! "* | "squash! "* | "amend! "*)
+		return 0
+		;;
+	esac
+
+	if ! error_message=$(validate "$subject"); then
+		printf '%s\n' "$error_message" >&2
+		exit 1
+	fi
+}
+
+# run_subject validates a single literal subject, exiting non-zero and
+# printing a diagnostic on failure.
+run_subject() {
+	subject=$1
+
+	if ! error_message=$(validate "$subject"); then
+		printf '%s\n' "$error_message" >&2
+		exit 1
+	fi
+}
+
+# run_range validates every non-merge commit subject in commit_range,
+# reporting every failure rather than stopping at the first one.
+run_range() {
+	commit_range=$1
+
+	subjects_file=$(mktemp)
+	stderr_file=$(mktemp)
+	trap 'rm -f "$subjects_file" "$stderr_file"' EXIT
+
+	if ! git log --no-merges --format=%s "$commit_range" >"$subjects_file" 2>"$stderr_file"; then
+		printf 'failed to run git log: %s\n' "$(cat "$stderr_file")" >&2
+		exit 1
+	fi
+
+	# A blank line here is not noise: git collapses %s to a single line per
+	# commit, so a blank line unambiguously means an empty-subject commit
+	# and must be diagnosed the same as `--subject ''`, not skipped.
+	failed=0
+	while IFS= read -r subject || [ -n "$subject" ]; do
+		if ! error_message=$(validate "$subject"); then
+			printf '%s\n' "$error_message"
+			failed=1
+		fi
+	done <"$subjects_file"
+
+	if [ "$failed" -eq 1 ]; then
+		exit 1
+	fi
+}
+
+file_path=""
+subject_arg=""
+range_arg=""
+has_file=0
+has_subject=0
+has_range=0
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--file)
+		file_path=$2
+		has_file=1
+		shift 2
+		;;
+	--subject)
+		subject_arg=$2
+		has_subject=1
+		shift 2
+		;;
+	--range)
+		range_arg=$2
+		has_range=1
+		shift 2
+		;;
+	*)
+		printf 'unknown argument: %s\n' "$1" >&2
+		usage
+		exit 2
+		;;
+	esac
+done
+
+if [ "$((has_file + has_subject + has_range))" -ne 1 ]; then
+	printf 'exactly one of --file, --subject, --range must be given\n' >&2
+	usage
+	exit 2
+fi
+
+if [ "$has_file" -eq 1 ]; then
+	run_file "$file_path"
+elif [ "$has_subject" -eq 1 ]; then
+	run_subject "$subject_arg"
+else
+	run_range "$range_arg"
+fi

--- a/lint/commit/commitlint_test.sh
+++ b/lint/commit/commitlint_test.sh
@@ -1,0 +1,217 @@
+#!/bin/sh
+
+# commitlint_test.sh runs commitlint.sh against a table of subjects with
+# known verdicts and fails if any of them gets the wrong one.
+#
+# Each case here mirrors one of the rules documented in CLAUDE.md under
+# "Commits & PRs": every accepted type, the mandatory scope, comma-separated
+# multi-scope, the breaking-change marker, the GitHub PR-number suffix, and
+# every rejection rule down to the exact diagnostic it must report.
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+commitlint="$script_dir/commitlint.sh"
+
+failures=0
+
+expect_pass() {
+	subject=$1
+	if ! "$commitlint" --subject "$subject" >/dev/null 2>&1; then
+		printf 'FAIL (want pass): %s\n' "$subject"
+		failures=$((failures + 1))
+	fi
+}
+
+expect_fail() {
+	subject=$1
+	if "$commitlint" --subject "$subject" >/dev/null 2>&1; then
+		printf 'FAIL (want fail): %s\n' "$subject"
+		failures=$((failures + 1))
+	fi
+}
+
+# expect_fail_message additionally checks that the diagnostic names the
+# rule that was broken, so a case can't pass for the wrong reason.
+expect_fail_message() {
+	subject=$1
+	needle=$2
+
+	output=$("$commitlint" --subject "$subject" 2>&1)
+	status=$?
+	if [ "$status" -eq 0 ]; then
+		printf 'FAIL (want fail): %s\n' "$subject"
+		failures=$((failures + 1))
+		return
+	fi
+
+	case "$output" in
+	*"$needle"*) ;;
+	*)
+		printf 'FAIL (want message containing %s): %s -> %s\n' "$needle" "$subject" "$output"
+		failures=$((failures + 1))
+		;;
+	esac
+}
+
+expect_pass "feat(route): add support for foo"
+expect_pass "fix(acl): correct the icmpv6 target slice"
+expect_pass "refactor(pdump): collapse duplicated printer bodies"
+expect_pass "perf(dataplane): skip demux on a single chain"
+expect_pass "chore(cli): bump the release version"
+expect_pass "docs(gateway): describe the registration flow"
+expect_pass "test(functest): add unfiltered socket capture for unsolicited traffic"
+expect_pass "build(cli): pin the protoc-gen-go version"
+expect_pass "ci(github): cache the cargo registry"
+expect_pass "style(acl): reflow the comment block"
+
+expect_pass "refactor(acl,fwstate): share the chain lookup"
+
+expect_pass "fix(dataplane_ut): stabilize the bench harness"
+expect_pass "fix(cli/acl): correct the mask parser"
+expect_pass "feat(operators/decap): add the readiness probe"
+expect_pass "fix(bird-adapter): reconnect on stream drop"
+expect_pass "fix(route-mpls): correct the label pop"
+expect_pass "refactor(acl,fwstate): share the chain lookup"
+expect_pass "chore(web): 8 columns for modules cards"
+
+expect_pass "feat(route)!: change the wire format"
+expect_pass "feat(acl,fwstate)!: x"
+
+expect_pass "fix(functional): stabilize VM snapshot fallback in CI (#1400)"
+expect_pass "refactor(acl): simplify (again)"
+expect_pass "fix(acl): handle the (#) marker"
+expect_pass "refactor(pdump): collapse printers (#1461)"
+
+expect_fail_message "feature(route): add support for foo" "unknown type"
+expect_fail_message "ai(x): y" "unknown type"
+expect_fail_message "feat: add thing" "scope is mandatory"
+expect_fail_message "fix(Route): correct the label pop" "scope"
+expect_fail_message "fix(route): Correct the label pop" "uppercase letter"
+expect_fail_message "feat(bench): Go-driven dataplane benchmarks" "uppercase letter"
+expect_fail_message "fix(route): correct the label pop." "trailing period"
+expect_fail_message "fix(route): " "brief must not be empty"
+expect_fail_message "fix(route):correct the label pop" ': " separator'
+
+expect_pass "Merge pull request #1234 from user/branch"
+expect_pass 'Revert "fix(route): correct the label pop"'
+
+# Autosquash markers are only exempted for the commit-msg hook (--file); CI
+# (--subject, --range) must reject them so a fixup commit cannot ride onto
+# main unsquashed via a plain "Rebase and merge".
+expect_fail "fixup! fix(route): correct the label pop"
+expect_fail "squash! fix(route): correct the label pop"
+expect_fail "amend! fix(route): correct the label pop"
+
+expect_fail "xfeat(a): b"
+expect_fail "prefix feat(a): b"
+expect_fail "feat(): x"
+expect_fail "feat(a, b): x"
+expect_fail "feat!(a): x"
+expect_fail "feat(a)!!: x"
+expect_fail "no separator here"
+
+expect_fail "feat(,a): x"
+expect_fail "feat(a,,b): x"
+expect_fail "feat(a,): x"
+expect_fail "refactor(acl,fwstate,): x"
+
+lead_file=$(mktemp)
+printf '\n# Please enter the commit message for your changes.\n' >"$lead_file"
+printf 'feat(route): add support for foo\n\n' >>"$lead_file"
+printf '# On branch main\n# Changes to be committed:\n' >>"$lead_file"
+if ! "$commitlint" --file "$lead_file" >/dev/null 2>&1; then
+	printf 'FAIL (want pass, comments/blank lines should be skipped): --file %s\n' "$lead_file"
+	failures=$((failures + 1))
+fi
+rm -f "$lead_file"
+
+# The commit-msg hook must still accept an autosquash marker, since
+# git commit --fixup=<ref> is a legitimate local workflow.
+fixup_file=$(mktemp)
+printf 'fixup! fix(route): correct the label pop\n' >"$fixup_file"
+if ! "$commitlint" --file "$fixup_file" >/dev/null 2>&1; then
+	printf 'FAIL (want pass, hook must accept fixup!): --file %s\n' "$fixup_file"
+	failures=$((failures + 1))
+fi
+rm -f "$fixup_file"
+
+empty_file=$(mktemp)
+printf '\n# only comments\n\n' >"$empty_file"
+if "$commitlint" --file "$empty_file" >/dev/null 2>&1; then
+	printf 'FAIL (want fail, no subject line found): --file %s\n' "$empty_file"
+	failures=$((failures + 1))
+fi
+rm -f "$empty_file"
+
+# Leading whitespace on a subject must survive into validate() and be
+# rejected there, matching git's own trailing-only --cleanup=strip.
+leading_file=$(mktemp)
+printf '  fix(route): leading spaces\n' >"$leading_file"
+if "$commitlint" --file "$leading_file" >/dev/null 2>&1; then
+	printf 'FAIL (want fail, leading whitespace must not be stripped): --file %s\n' "$leading_file"
+	failures=$((failures + 1))
+fi
+rm -f "$leading_file"
+
+# Trailing whitespace on a subject must be stripped, matching git's
+# --cleanup=strip.
+trailing_file=$(mktemp)
+printf 'fix(route): trailing spaces   \n' >"$trailing_file"
+if ! "$commitlint" --file "$trailing_file" >/dev/null 2>&1; then
+	printf 'FAIL (want pass, trailing whitespace must be stripped): --file %s\n' "$trailing_file"
+	failures=$((failures + 1))
+fi
+rm -f "$trailing_file"
+
+# Only a "#" at column 0 is a git comment; an indented "#" is the subject
+# and must be rejected, matching git's --cleanup=strip.
+indented_comment_file=$(mktemp)
+printf '  # indented\n' >"$indented_comment_file"
+if "$commitlint" --file "$indented_comment_file" >/dev/null 2>&1; then
+	printf 'FAIL (want fail, indented "#" line is the subject): --file %s\n' "$indented_comment_file"
+	failures=$((failures + 1))
+fi
+rm -f "$indented_comment_file"
+
+# run_range must not let git log's blank line for an empty-subject commit
+# slip through as nothing to validate.
+#
+# A hermetic scratch repo pins one conforming commit as the lower bound of
+# a known-good range (must pass) and appends an empty-subject commit after
+# it, so a range that reaches the tip must fail with an "empty" diagnostic
+# while the range excluding it still passes.
+range_repo=$(mktemp -d)
+trap 'rm -rf "$range_repo"' EXIT
+
+git -C "$range_repo" init -q
+git -C "$range_repo" config user.email test@example.com
+git -C "$range_repo" config user.name test
+git -C "$range_repo" commit -q --allow-empty -m 'feat(range): add the base commit'
+base=$(git -C "$range_repo" rev-parse HEAD)
+git -C "$range_repo" commit -q --allow-empty -m 'fix(range): add a conforming commit'
+good_head=$(git -C "$range_repo" rev-parse HEAD)
+git -C "$range_repo" commit -q --allow-empty --allow-empty-message -m ''
+
+if ! (cd "$range_repo" && "$commitlint" --range "$base..$good_head") >/dev/null 2>&1; then
+	printf 'FAIL (want pass, range of conforming commits): %s..%s\n' "$base" "$good_head"
+	failures=$((failures + 1))
+fi
+
+if range_output=$(cd "$range_repo" && "$commitlint" --range "$base..HEAD" 2>&1); then
+	printf 'FAIL (want fail, range hides an empty-subject commit)\n'
+	failures=$((failures + 1))
+else
+	case "$range_output" in
+	*"subject is empty"*) ;;
+	*)
+		printf 'FAIL (want message containing subject is empty): %s\n' "$range_output"
+		failures=$((failures + 1))
+		;;
+	esac
+fi
+
+if [ "$failures" -ne 0 ]; then
+	printf '%d case(s) failed\n' "$failures"
+	exit 1
+fi
+
+printf 'all commitlint cases passed\n'


### PR DESCRIPTION
Commit subjects and PR titles have drifted because the convention was documented but never enforced. Non-conforming subjects reach main through both merge strategies in use here: squash, where the pull request title becomes the subject, and rebase, where every commit lands as written.

- Add a linter for the documented subject format, checking the type against a closed set, a mandatory lowercase scope, an optional breaking-change marker, and a brief that is neither sentence-cased nor period-terminated.
- Install it as a commit-msg hook, so a bad subject is rejected before the commit lands rather than in review. The existing pre-commit hook is untouched, and `make hooks` already points git at the whole hook directory.
- Add a CI job checking the pull request title and every commit in the branch, so neither merge strategy can carry a bad subject onto main.
- Reconcile the documented convention itself, which listed one set of types for commits and a different one for pull request titles.

The linter is plain POSIX shell, so a simple text check needs no toolchain fetch and no build step before a commit hook can run.

Merge commits, autosquash markers and reverts are skipped. Existing history is never scanned: only new commits and the pull request title are checked, so the non-conforming subjects already on main are left alone.