### PR TITLE
fix(devices): reclaim retired plain and vlan devices

### DIFF
--- a/devices/plain/api/controlplane.c
+++ b/devices/plain/api/controlplane.c
@@ -55,6 +55,11 @@ cp_device_plain_free(struct cp_device *cp_device) {
 	cp_device_free(cp_device);
 }
 
+void
+cp_device_plain_drain_unused(struct agent *agent) {
+	cp_device_agent_drain_unused(agent, cp_device_plain_free);
+}
+
 struct cp_device_plain_config *
 cp_device_plain_config_new(
 	const char *name,

--- a/devices/plain/api/controlplane.h
+++ b/devices/plain/api/controlplane.h
@@ -22,6 +22,13 @@ cp_device_plain_new(
 void
 cp_device_plain_free(struct cp_device *cp_device);
 
+// Reclaim plain devices parked on the agent's unused_device list.
+//
+// Call after a device update, once the retiring generation no longer
+// references the parked devices.
+void
+cp_device_plain_drain_unused(struct agent *agent);
+
 struct cp_device_plain_config *
 cp_device_plain_config_new(
 	const char *name,

--- a/devices/plain/controlplane/ffi.go
+++ b/devices/plain/controlplane/ffi.go
@@ -89,3 +89,12 @@ func (m *DeviceConfig) asRawPtr() *C.struct_cp_device {
 func (m *DeviceConfig) AsFFIDevice() ffi.ShmDeviceConfig {
 	return m.ptr
 }
+
+// DrainUnusedDevices reclaims plain devices retired from the config
+// generation and parked on the agent's unused list.
+//
+// Call it after UpdateDevices, once the retiring generation no longer
+// references the parked devices.
+func DrainUnusedDevices(agent *ffi.Agent) {
+	C.cp_device_plain_drain_unused((*C.struct_agent)(agent.AsRawPtr()))
+}

--- a/devices/plain/controlplane/service.go
+++ b/devices/plain/controlplane/service.go
@@ -3,6 +3,7 @@ package plain
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -15,6 +16,7 @@ import (
 type DevicePlainService struct {
 	plainpb.UnimplementedDevicePlainServiceServer
 
+	mu    sync.Mutex
 	agent *ffi.Agent
 }
 
@@ -28,6 +30,18 @@ func (m *DevicePlainService) UpdateDevice(
 	ctx context.Context,
 	request *plainpb.UpdateDevicePlainRequest,
 ) (*plainpb.UpdateDevicePlainResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Reclaim devices parked on the agent's unused list, whatever the
+	// outcome of this update.
+	//
+	// The drain is registered before the device config is created on
+	// purpose: once the arena is full, creation fails first, so a drain
+	// registered after that check would never run and the arena could
+	// never recover.
+	defer DrainUnusedDevices(m.agent)
+
 	name := request.GetName()
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")

--- a/devices/plain/controlplane/service_test.go
+++ b/devices/plain/controlplane/service_test.go
@@ -1,0 +1,80 @@
+package plain
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/devices/plain/controlplane/plainpb/v1"
+)
+
+// TestUpdateDevice_DrainsUnusedDevices verifies that repeated UpdateDevice
+// calls do not leak shared-memory arena space.
+//
+// Each update after the first retires the previous generation's device onto
+// the agent's unused list; without draining that list, the arena shrinks by
+// a fixed amount every call and eventually runs out. Free bytes must settle
+// after the first update instead of decreasing indefinitely.
+func TestUpdateDevice_DrainsUnusedDevices(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	agent, err := shm.AgentAttach("plain", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	service := NewDevicePlainService(agent)
+	request := &plainpb.UpdateDevicePlainRequest{
+		Name:   "d0",
+		Device: &commonpb.Device{},
+	}
+
+	const updateCount = 32
+
+	var previousFreeBytes uint64
+	for idx := range updateCount {
+		_, err := service.UpdateDevice(t.Context(), request)
+		require.NoError(t, err)
+
+		freeBytes := freeBytesForAgent(t, shm, "plain")
+		if idx > 0 {
+			require.Equalf(
+				t,
+				previousFreeBytes,
+				freeBytes,
+				"free bytes changed on update %d: %d -> %d",
+				idx,
+				previousFreeBytes,
+				freeBytes,
+			)
+		}
+		previousFreeBytes = freeBytes
+	}
+}
+
+// freeBytesForAgent returns the free byte count reported for the named
+// agent's first instance.
+func freeBytesForAgent(t *testing.T, shm *ffi.SharedMemory, name string) uint64 {
+	t.Helper()
+
+	for _, agentInfo := range shm.DPConfig(0).Agents() {
+		if agentInfo.Name == name {
+			require.NotEmpty(t, agentInfo.Instances)
+			return agentInfo.Instances[0].FreeBytes
+		}
+	}
+
+	t.Fatalf("agent %q not found in dataplane config", name)
+	return 0
+}

--- a/devices/trafgen/controlplane/backend.go
+++ b/devices/trafgen/controlplane/backend.go
@@ -27,6 +27,17 @@ func (m *backend) UpdateDevice(
 	lengths []uint32,
 	ratePps uint64,
 ) error {
+	// Reclaim devices parked on the agent's unused list, whatever the
+	// outcome of this update.
+	//
+	// A device leaving the config generation is parked rather than freed:
+	// both the one replaced by a successful update and the new one rejected
+	// mid-install by a failed update land on the unused list. The drain is
+	// registered before the device config is created on purpose: once the
+	// arena is full, creation fails first, so a drain registered after that
+	// check would never run and the arena could never recover.
+	defer ctrafgen.DrainUnusedDevices(m.agent)
+
 	device, err := ctrafgen.NewDeviceConfig(
 		m.agent,
 		name,
@@ -39,16 +50,6 @@ func (m *backend) UpdateDevice(
 	if err != nil {
 		return fmt.Errorf("failed to create device config: %w", err)
 	}
-
-	// Reclaim devices parked on the agent's unused list once the update
-	// settles, regardless of outcome.
-	//
-	// A device leaving the config generation is parked rather than freed: the
-	// one replaced by a successful update, or the new one rejected mid-install
-	// by a failed update (e.g. an unknown pipeline), both land on the unused
-	// list. Draining on every exit frees them and keeps repeated failed updates
-	// from accumulating dead devices in the agent arena.
-	defer ctrafgen.DrainUnusedDevices(m.agent)
 
 	if err := m.agent.UpdateDevices(
 		[]ffi.ShmDeviceConfig{device.AsFFIDevice()},

--- a/devices/vlan/api/controlplane.c
+++ b/devices/vlan/api/controlplane.c
@@ -57,6 +57,11 @@ cp_device_vlan_free(struct cp_device *cp_device) {
 	cp_device_free(cp_device);
 }
 
+void
+cp_device_vlan_drain_unused(struct agent *agent) {
+	cp_device_agent_drain_unused(agent, cp_device_vlan_free);
+}
+
 struct cp_device_vlan_config *
 cp_device_vlan_config_new(
 	const char *name,

--- a/devices/vlan/api/controlplane.h
+++ b/devices/vlan/api/controlplane.h
@@ -23,6 +23,13 @@ cp_device_vlan_new(
 void
 cp_device_vlan_free(struct cp_device *cp_device);
 
+// Reclaim vlan devices parked on the agent's unused_device list.
+//
+// Call after a device update, once the retiring generation no longer
+// references the parked devices.
+void
+cp_device_vlan_drain_unused(struct agent *agent);
+
 struct cp_device_vlan_config *
 cp_device_vlan_config_new(
 	const char *name,

--- a/devices/vlan/controlplane/ffi.go
+++ b/devices/vlan/controlplane/ffi.go
@@ -90,3 +90,12 @@ func (m *DeviceConfig) asRawPtr() *C.struct_cp_device {
 func (m *DeviceConfig) AsFFIDevice() ffi.ShmDeviceConfig {
 	return m.ptr
 }
+
+// DrainUnusedDevices reclaims vlan devices retired from the config
+// generation and parked on the agent's unused list.
+//
+// Call it after UpdateDevices, once the retiring generation no longer
+// references the parked devices.
+func DrainUnusedDevices(agent *ffi.Agent) {
+	C.cp_device_vlan_drain_unused((*C.struct_agent)(agent.AsRawPtr()))
+}

--- a/devices/vlan/controlplane/service.go
+++ b/devices/vlan/controlplane/service.go
@@ -3,6 +3,7 @@ package vlan
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -15,6 +16,7 @@ import (
 type DeviceVlanService struct {
 	vlanpb.UnimplementedDeviceVlanServiceServer
 
+	mu    sync.Mutex
 	agent *ffi.Agent
 }
 
@@ -28,6 +30,18 @@ func (m *DeviceVlanService) UpdateDevice(
 	ctx context.Context,
 	request *vlanpb.UpdateDeviceVlanRequest,
 ) (*vlanpb.UpdateDeviceVlanResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Reclaim devices parked on the agent's unused list, whatever the
+	// outcome of this update.
+	//
+	// The drain is registered before the device config is created on
+	// purpose: once the arena is full, creation fails first, so a drain
+	// registered after that check would never run and the arena could
+	// never recover.
+	defer DrainUnusedDevices(m.agent)
+
 	name := request.GetName()
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")

--- a/devices/vlan/controlplane/service_test.go
+++ b/devices/vlan/controlplane/service_test.go
@@ -1,0 +1,81 @@
+package vlan
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/devices/vlan/controlplane/vlanpb/v1"
+)
+
+// TestUpdateDevice_DrainsUnusedDevices verifies that repeated UpdateDevice
+// calls do not leak shared-memory arena space.
+//
+// Each update after the first retires the previous generation's device onto
+// the agent's unused list; without draining that list, the arena shrinks by
+// a fixed amount every call and eventually runs out. Free bytes must settle
+// after the first update instead of decreasing indefinitely.
+func TestUpdateDevice_DrainsUnusedDevices(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"vlan"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	agent, err := shm.AgentAttach("vlan", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	service := NewDeviceVlanService(agent)
+	request := &vlanpb.UpdateDeviceVlanRequest{
+		Name:   "d0",
+		Device: &commonpb.Device{},
+		Vlan:   100,
+	}
+
+	const updateCount = 32
+
+	var previousFreeBytes uint64
+	for idx := range updateCount {
+		_, err := service.UpdateDevice(t.Context(), request)
+		require.NoError(t, err)
+
+		freeBytes := freeBytesForAgent(t, shm, "vlan")
+		if idx > 0 {
+			require.Equalf(
+				t,
+				previousFreeBytes,
+				freeBytes,
+				"free bytes changed on update %d: %d -> %d",
+				idx,
+				previousFreeBytes,
+				freeBytes,
+			)
+		}
+		previousFreeBytes = freeBytes
+	}
+}
+
+// freeBytesForAgent returns the free byte count reported for the named
+// agent's first instance.
+func freeBytesForAgent(t *testing.T, shm *ffi.SharedMemory, name string) uint64 {
+	t.Helper()
+
+	for _, agentInfo := range shm.DPConfig(0).Agents() {
+		if agentInfo.Name == name {
+			require.NotEmpty(t, agentInfo.Instances)
+			return agentInfo.Instances[0].FreeBytes
+		}
+	}
+
+	t.Fatalf("agent %q not found in dataplane config", name)
+	return 0
+}


### PR DESCRIPTION
A device leaving the configuration registry is parked on its creating agent's unused list instead of being freed, so the owning control plane can reclaim it once no live generation refers to it. The parking landed in #1303, which wired the mechanism but no consumer; #1306 then drained the list for the traffic generator only. Plain and vlan devices never drained at all, so every update leaked its predecessor into the agent's shared memory arena.

The arena filled after roughly three thousand updates. Since the pipeline operator reapplies configuration every thirty seconds, an affected device instance stopped accepting updates after a few hours and stayed broken until the control plane was restarted, reporting a failure to allocate counter names.

- Drain the unused device list on plain and vlan updates.
- Register the drain before the new configuration is built, so an update that fails because the arena is already full still reclaims and lets the next retry succeed, rather than leaving the instance stuck until a restart.
- Serialise device updates on both types. The reclaim is not safe against concurrent requests, and these were the only devices without that protection.
- Close the same gap in the traffic generator, where a failure to build the configuration skipped the drain.
- Cover the leak with tests that drive the real update path against a shared memory agent and require its free space to settle after the first update. They fail without the fix.
