### PR TITLE
fix(controlplane): link parked devices and modules correctly on the unused list

### DIFF
--- a/devices/plain/controlplane/service_test.go
+++ b/devices/plain/controlplane/service_test.go
@@ -63,6 +63,59 @@ func TestUpdateDevice_DrainsUnusedDevices(t *testing.T) {
 	}
 }
 
+// TestUpdateDevices_ParksTwoPredecessorsBackToBack verifies that a single
+// UpdateDevices call replacing two live devices at once drains cleanly.
+//
+// Replacing two devices in one call parks both predecessors onto the
+// agent's unused list back-to-back, before either is drained. That is the
+// only way to link a second entry onto a non-empty unused list, so it is
+// the case a single-device update (one park per drain) can never exercise.
+func TestUpdateDevices_ParksTwoPredecessorsBackToBack(t *testing.T) {
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(datasize.MB * 32),
+		DPMemory:      uint64(datasize.MB * 4),
+		WorkerCount:   1,
+		DevicesToLoad: []string{"plain"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(harness.Free)
+
+	shm := harness.SharedMemory()
+	agent, err := shm.AgentAttach("plain", 0, datasize.MB*2)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = agent.CleanUp() })
+
+	service := NewDevicePlainService(agent)
+
+	for _, name := range []string{"d0", "d1"} {
+		_, err := service.UpdateDevice(t.Context(), &plainpb.UpdateDevicePlainRequest{
+			Name:   name,
+			Device: &commonpb.Device{},
+		})
+		require.NoError(t, err)
+	}
+
+	freeBytesBeforeReplace := freeBytesForAgent(t, shm, "plain")
+
+	deviceConfig0, err := NewDeviceConfig(agent, "d0", &commonpb.Device{})
+	require.NoError(t, err)
+	deviceConfig1, err := NewDeviceConfig(agent, "d1", &commonpb.Device{})
+	require.NoError(t, err)
+
+	err = agent.UpdateDevices([]ffi.ShmDeviceConfig{
+		deviceConfig0.AsFFIDevice(),
+		deviceConfig1.AsFFIDevice(),
+	})
+	require.NoError(t, err)
+
+	DrainUnusedDevices(agent)
+
+	// Both predecessors retired by this replace and both fresh configs
+	// built above are reclaimed, so the arena settles back to the size
+	// it had right before the replace.
+	require.Equal(t, freeBytesBeforeReplace, freeBytesForAgent(t, shm, "plain"))
+}
+
 // freeBytesForAgent returns the free byte count reported for the named
 // agent's first instance.
 func freeBytesForAgent(t *testing.T, shm *ffi.SharedMemory, name string) uint64 {

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -447,7 +447,7 @@ cp_device_registry_item_free_cb(struct registry_item *item, void *data) {
 	// Park the device on its creating agent's unused_device list instead;
 	// the agent reclaims it once no live generation references it.
 	struct agent *agent = ADDR_OF(&device->agent);
-	SET_OFFSET_OF(&device->prev, agent->unused_device);
+	EQUATE_OFFSET(&device->prev, &agent->unused_device);
 	SET_OFFSET_OF(&agent->unused_device, device);
 }
 

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -272,7 +272,7 @@ cp_module_registry_item_free_cb(struct registry_item *item, void *data) {
 		container_of(item, struct cp_module, config_item);
 
 	struct agent *agent = ADDR_OF(&module->agent);
-	SET_OFFSET_OF(&module->prev, agent->unused_module);
+	EQUATE_OFFSET(&module->prev, &agent->unused_module);
 	SET_OFFSET_OF(&agent->unused_module, module);
 }
 

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -19,3 +19,28 @@ counters_test = executable(
 )
 
 test('counters_uaf', counters_test, suite: ['lib'])
+
+unused_park_test = executable(
+  'unused_park_test',
+  ['unused_park_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+    '-Wl,--undefined=new_module_route',
+    '-Wl,--export-dynamic-symbol=new_module_route',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_dev_plain_api,
+    lib_route_cp_dep,
+    libdpdk_dep,
+  ],
+  link_with: [lib_dev_plain_dp, lib_route_dp],
+  include_directories: yanet_rootdir,
+)
+
+test('unused_park', unused_park_test, suite: ['lib'])

--- a/lib/controlplane/tests/unused_park_test.c
+++ b/lib/controlplane/tests/unused_park_test.c
@@ -1,0 +1,283 @@
+/*
+ * Regression test for the "park on unused list" corruption: parking a
+ * device or module on its agent's unused list used SET_OFFSET_OF with a raw
+ * relative-pointer value read straight from the list head field instead of
+ * resolving it to a virtual address first.
+ *
+ * The first park onto an empty list happened to work because the raw value
+ * was zero, but every following park stored garbage into the parked
+ * entry's prev field. Walking that link later (cp_device_agent_drain_unused)
+ * dereferences the garbage and crashes or invokes an arbitrary free_fn.
+ */
+
+#include "api/agent.h"
+
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/cp_device.h"
+#include "controlplane/config/cp_module.h"
+
+#include "devices/plain/api/controlplane.h"
+
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/errors/errors.h"
+
+#include "logging/log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define UNUSED_PARK_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
+
+static uint64_t free_call_count;
+
+static void
+counting_device_free(struct cp_device *device) {
+	free_call_count += 1;
+	cp_device_fini(device);
+	cp_device_free(device);
+}
+
+// Verifies that parking two devices back-to-back onto an agent's
+// unused_device list, then draining it, reclaims exactly the parked devices
+// without crashing and returns the agent's arena to its pre-park size.
+static int
+test_device_park_and_drain(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm, 0, "unused-park-dev", UNUSED_PARK_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	size_t baseline = block_allocator_free_size(&agent->block_allocator);
+
+	struct cp_device_registry registry;
+	TEST_ASSERT_SUCCESS(
+		cp_device_registry_init(
+			&agent->memory_context, &registry, &err
+		),
+		"device registry init failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct cp_device_config cfg0;
+	TEST_ASSERT_SUCCESS(
+		cp_device_config_init(&cfg0, "plain", "dev0", 0, 0, &err),
+		"device config init failed for dev0: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	struct cp_device *device0 = cp_device_new(&agent->memory_context);
+	TEST_ASSERT_NOT_NULL(device0, "cp_device_new failed for dev0");
+	TEST_ASSERT_SUCCESS(
+		cp_device_init(device0, agent, &cfg0, &err),
+		"cp_device_init failed for dev0: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_device_config_fini(&cfg0);
+	TEST_ASSERT_SUCCESS(
+		cp_device_registry_upsert(&registry, "dev0", device0, &err),
+		"device registry upsert failed for dev0: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct cp_device_config cfg1;
+	TEST_ASSERT_SUCCESS(
+		cp_device_config_init(&cfg1, "plain", "dev1", 0, 0, &err),
+		"device config init failed for dev1: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	struct cp_device *device1 = cp_device_new(&agent->memory_context);
+	TEST_ASSERT_NOT_NULL(device1, "cp_device_new failed for dev1");
+	TEST_ASSERT_SUCCESS(
+		cp_device_init(device1, agent, &cfg1, &err),
+		"cp_device_init failed for dev1: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_device_config_fini(&cfg1);
+	TEST_ASSERT_SUCCESS(
+		cp_device_registry_upsert(&registry, "dev1", device1, &err),
+		"device registry upsert failed for dev1: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	// Releasing the registry parks both devices onto agent->unused_device
+	// back-to-back: this is the exact corruption trigger, since the
+	// second park reads the first park's raw relative-pointer value
+	// straight out of unused_device instead of resolving it first.
+	cp_device_registry_fini(&registry);
+
+	struct cp_device *head = ADDR_OF(&agent->unused_device);
+	TEST_ASSERT(
+		head == device1,
+		"unused_device head is not the last parked device"
+	);
+	struct cp_device *second = ADDR_OF(&head->prev);
+	TEST_ASSERT(
+		second == device0,
+		"second parked device's prev does not resolve to the first "
+		"parked device"
+	);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&second->prev), "first parked device's prev is not NULL"
+	);
+
+	free_call_count = 0;
+	cp_device_agent_drain_unused(agent, counting_device_free);
+	TEST_ASSERT_EQUAL(
+		free_call_count, 2, "drain did not free exactly two devices"
+	);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->unused_device),
+		"unused_device is not NULL after drain"
+	);
+
+	size_t after = block_allocator_free_size(&agent->block_allocator);
+	TEST_ASSERT_EQUAL(
+		(long)after,
+		(long)baseline,
+		"agent arena did not return to its pre-park size: "
+		"baseline=%zu after=%zu",
+		baseline,
+		after
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// Verifies that the module twin of the same park-on-unused-list path links
+// parked modules correctly: the second parked module's prev resolves to the
+// first, and the walk terminates at NULL.
+static int
+test_module_park_chain(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm, 0, "unused-park-mod", UNUSED_PARK_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct cp_module_registry registry;
+	TEST_ASSERT_SUCCESS(
+		cp_module_registry_init(
+			&agent->memory_context, &registry, &err
+		),
+		"module registry init failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct cp_module *module0 = (struct cp_module *)memory_balloc(
+		&agent->memory_context, sizeof(struct cp_module)
+	);
+	TEST_ASSERT_NOT_NULL(module0, "failed to allocate module0");
+	TEST_ASSERT_SUCCESS(
+		cp_module_init(module0, agent, "route", "mod0", &err),
+		"cp_module_init failed for mod0: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_module_registry_upsert(
+			&registry, "route", "mod0", module0, &err
+		),
+		"module registry upsert failed for mod0: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct cp_module *module1 = (struct cp_module *)memory_balloc(
+		&agent->memory_context, sizeof(struct cp_module)
+	);
+	TEST_ASSERT_NOT_NULL(module1, "failed to allocate module1");
+	TEST_ASSERT_SUCCESS(
+		cp_module_init(module1, agent, "route", "mod1", &err),
+		"cp_module_init failed for mod1: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_module_registry_upsert(
+			&registry, "route", "mod1", module1, &err
+		),
+		"module registry upsert failed for mod1: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	// Releasing the registry parks both modules onto agent->unused_module
+	// back-to-back, the same corruption trigger as the device path above.
+	cp_module_registry_fini(&registry);
+
+	struct cp_module *head = ADDR_OF(&agent->unused_module);
+	TEST_ASSERT(
+		head == module1,
+		"unused_module head is not the last parked module"
+	);
+	struct cp_module *second = ADDR_OF(&head->prev);
+	TEST_ASSERT(
+		second == module0,
+		"second parked module's prev does not resolve to the first "
+		"parked module"
+	);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&second->prev), "first parked module's prev is not NULL"
+	);
+
+	// Nothing drains unused_module today, so reclaim the parked chain by
+	// hand instead of leaving it for agent_detach.
+	struct cp_module *module = head;
+	while (module != NULL) {
+		struct cp_module *prev = ADDR_OF(&module->prev);
+		cp_module_fini(module);
+		memory_bfree(
+			&agent->memory_context, module, sizeof(struct cp_module)
+		);
+		module = prev;
+	}
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	const char *port_names[] = {"01:00.0"};
+	const char *modules[] = {"route"};
+	const char *devs_to_load[] = {"plain"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = modules,
+		.module_count = 1,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	if (ut == NULL) {
+		fprintf(stderr, "dataplane_ut_new failed\n");
+		return 1;
+	}
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	if (shm == NULL) {
+		fprintf(stderr, "dataplane_ut_shm returned NULL\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+
+	int res = test_device_park_and_drain(shm);
+	if (res == TEST_SUCCESS) {
+		res = test_module_park_chain(shm);
+	}
+
+	dataplane_ut_free(ut);
+
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}


### PR DESCRIPTION
- Parking a retired device or module onto its agent's unused list wrote a broken link whenever the list already had an entry, so draining the list crashed the control plane.
- Any device update retiring two or more devices at once triggered the crash after the reclaim path started draining on every update.
- Store the link as a proper relative pointer and cover the double-park scenario with C and Go regression tests.