### PR TITLE
fix(web): show generator transmit rate on the devices list

### DIFF
--- a/devices/trafgen/web/device.ts
+++ b/devices/trafgen/web/device.ts
@@ -69,6 +69,7 @@ export const deviceType: DeviceTypeManifest = {
     kindTag: () => 'GENERATOR',
     typeDescription: 'generator (trafgen)',
     trafficSource: true,
+    generator: true,
     rowSubtitle: () => 'generator · —',
     propertyRows: (device) => {
         const ext = trafgenExt(device);

--- a/web/builtin/devices/DeviceListItem.tsx
+++ b/web/builtin/devices/DeviceListItem.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { MiniSpark } from './components/MiniSpark';
 import { formatPps } from '@yanet/core/utils';
 import { deviceTypeManifest } from '@yanet/core/registry';
+import { displayRates } from './displayRates';
 import type { LocalDevice } from './types';
 import type { CounterHistoryEntry } from '@yanet/core/hooks/useCounterHistory';
 import type { DeviceCounterData } from '@yanet/core/hooks/useDeviceCounters';
@@ -27,10 +28,7 @@ export const DeviceListItem: React.FC<DeviceListItemProps> = ({
     const badge = manifest?.rowBadge?.(device);
     const subtitle = manifest?.rowSubtitle?.(device) ?? '— · —';
     const name = device.id.name || '';
-    const rxPps = counterData?.inputRx.pps ?? 0;
-    const txPps = counterData?.outputTx.pps ?? 0;
-    const rxHistory = history?.inputRx ?? [];
-    const txHistory = history?.outputTx ?? [];
+    const { rxPps, txPps, rxHistory, txHistory } = displayRates(device.type, counterData, history);
 
     return (
         <button

--- a/web/builtin/devices/DeviceRail.tsx
+++ b/web/builtin/devices/DeviceRail.tsx
@@ -3,6 +3,7 @@ import { MiniSpark } from './components/MiniSpark';
 import { IconCaret } from './components/Icons';
 import { formatPps } from '@yanet/core/utils';
 import { deviceTypeManifest } from '@yanet/core/registry';
+import { displayRates } from './displayRates';
 import type { LocalDevice } from './types';
 import type { CounterHistoryEntry } from '@yanet/core/hooks/useCounterHistory';
 import type { DeviceCounterData } from '@yanet/core/hooks/useDeviceCounters';
@@ -44,6 +45,8 @@ const DeviceRailItem = ({
 
     const handleLeave = useCallback(() => setAnchor(null), []);
 
+    const { rxPps, txPps, rxHistory, txHistory } = displayRates(device.type, counterData, history);
+
     return (
         <div
             className={`dv-rail-item${isSelected ? ' rail-sel' : ''}`}
@@ -69,14 +72,14 @@ const DeviceRailItem = ({
                     <div className="dv-rail-pop-type">{typeLabel}</div>
                     <MiniSpark
                         deviceId={`rail-${name}`}
-                        rx={history?.inputRx ?? []}
-                        tx={history?.outputTx ?? []}
+                        rx={rxHistory}
+                        tx={txHistory}
                         width={198}
                         height={34}
                     />
                     <div className="dv-rail-pop-metric">
-                        <span><span className="lbl">RX </span>{formatPps(counterData?.inputRx.pps ?? 0)}</span>
-                        <span><span className="lbl">TX </span>{formatPps(counterData?.outputTx.pps ?? 0)}</span>
+                        <span><span className="lbl">RX </span>{formatPps(rxPps)}</span>
+                        <span><span className="lbl">TX </span>{formatPps(txPps)}</span>
                     </div>
                 </div>
             )}

--- a/web/builtin/devices/displayRates.test.ts
+++ b/web/builtin/devices/displayRates.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { displayRates } from './displayRates';
+import type { DeviceCounterData } from '@yanet/core/hooks/useDeviceCounters';
+import type { CounterHistoryEntry } from '@yanet/core/hooks/useCounterHistory';
+
+const makeCounterData = (overrides: Partial<Record<keyof DeviceCounterData, number>>): DeviceCounterData => {
+    const zero = { pps: 0, bps: 0 };
+    return {
+        inputRx: { ...zero, pps: overrides.inputRx ?? 0 },
+        inputTx: { ...zero, pps: overrides.inputTx ?? 0 },
+        inputEntry: { ...zero, pps: overrides.inputEntry ?? 0 },
+        inputDrop: { ...zero, pps: overrides.inputDrop ?? 0 },
+        outputRx: { ...zero, pps: overrides.outputRx ?? 0 },
+        outputTx: { ...zero, pps: overrides.outputTx ?? 0 },
+        outputDrop: { ...zero, pps: overrides.outputDrop ?? 0 },
+    } as DeviceCounterData;
+};
+
+const makeHistory = (overrides: Partial<CounterHistoryEntry>): CounterHistoryEntry => ({
+    inputRx: [],
+    inputTx: [],
+    inputEntry: [],
+    inputDrop: [],
+    outputRx: [],
+    outputTx: [],
+    outputDrop: [],
+    ...overrides,
+});
+
+describe('displayRates', () => {
+    it('shows inputEntry for a traffic-generator device', () => {
+        const counterData = makeCounterData({ inputEntry: 42, inputTx: 0, outputTx: 7 });
+        const history = makeHistory({ inputEntry: [1, 2, 3], inputTx: [9, 9], outputTx: [7, 7] });
+
+        const result = displayRates('trafgen', counterData, history);
+
+        expect(result.txPps).toBe(42);
+        expect(result.txHistory).toEqual([1, 2, 3]);
+        expect(result.rxPps).toBe(0);
+    });
+
+    it('shows outputTx for a regular device', () => {
+        const counterData = makeCounterData({ inputTx: 0, outputTx: 17 });
+        const history = makeHistory({ inputTx: [], outputTx: [4, 5, 6] });
+
+        const result = displayRates('vlan', counterData, history);
+
+        expect(result.txPps).toBe(17);
+        expect(result.txHistory).toEqual([4, 5, 6]);
+    });
+
+    it('shows outputTx for a plain device (trafficSource but not generator)', () => {
+        const counterData = makeCounterData({ inputTx: 99, outputTx: 11 });
+        const history = makeHistory({ inputTx: [9, 9, 9], outputTx: [1, 1] });
+
+        const result = displayRates('plain', counterData, history);
+
+        expect(result.txPps).toBe(11);
+        expect(result.txHistory).toEqual([1, 1]);
+    });
+
+    it('falls back to outputTx for an unknown or undefined type', () => {
+        const counterData = makeCounterData({ inputTx: 5, outputTx: 9 });
+        const history = makeHistory({ outputTx: [7] });
+
+        expect(displayRates('does-not-exist', counterData, history).txPps).toBe(9);
+        expect(displayRates(undefined, counterData, history).txPps).toBe(9);
+    });
+
+    it('returns zeros when counter data and history are missing', () => {
+        const result = displayRates('trafgen', undefined, undefined);
+
+        expect(result).toEqual({ rxPps: 0, txPps: 0, rxHistory: [], txHistory: [] });
+    });
+});

--- a/web/builtin/devices/displayRates.ts
+++ b/web/builtin/devices/displayRates.ts
@@ -1,0 +1,38 @@
+import { deviceTypeManifest } from '@yanet/core/registry';
+import type { CounterHistoryEntry } from '@yanet/core/hooks/useCounterHistory';
+import type { DeviceCounterData } from '@yanet/core/hooks/useDeviceCounters';
+
+export interface DisplayRates {
+    rxPps: number;
+    txPps: number;
+    rxHistory: number[];
+    txHistory: number[];
+}
+
+/**
+ * Picks the RX/TX pps and sparkline history fields to display for a device.
+ *
+ * Traffic-generator devices (manifest `generator: true`) never transmit on
+ * the wire, so their `outputTx` is legitimately always zero. A generator's
+ * frames also leave the input pipeline via the pending-output list when
+ * routed elsewhere, which zeroes `inputTx` too — so generators display TX
+ * from `inputEntry` instead, which counts every frame the handler emitted
+ * into its input pipelines regardless of how it later left; RX stays
+ * inputRx (an honest zero). All other devices, including plain/vlan
+ * `trafficSource` root interfaces, keep TX from outputTx and are
+ * unaffected.
+ */
+export const displayRates = (
+    deviceType: string | undefined,
+    counterData: DeviceCounterData | undefined,
+    history: CounterHistoryEntry | undefined
+): DisplayRates => {
+    const isGenerator = !!(deviceType && deviceTypeManifest(deviceType)?.generator);
+
+    return {
+        rxPps: counterData?.inputRx.pps ?? 0,
+        txPps: (isGenerator ? counterData?.inputEntry.pps : counterData?.outputTx.pps) ?? 0,
+        rxHistory: history?.inputRx ?? [],
+        txHistory: (isGenerator ? history?.inputEntry : history?.outputTx) ?? [],
+    };
+};

--- a/web/src/core/hooks/useCounterHistory.ts
+++ b/web/src/core/hooks/useCounterHistory.ts
@@ -7,6 +7,7 @@ export const HISTORY_SIZE = 60;
 export interface CounterHistoryEntry {
     inputRx: number[];
     inputTx: number[];
+    inputEntry: number[];
     inputDrop: number[];
     outputRx: number[];
     outputTx: number[];
@@ -48,6 +49,12 @@ export const useCounterHistory = (
         return m;
     }, [counters]);
 
+    const inputEntrySamples = useMemo(() => {
+        const m = new Map<string, number>();
+        counters.forEach((d, name) => m.set(name, d.inputEntry.pps));
+        return m;
+    }, [counters]);
+
     const inputDropSamples = useMemo(() => {
         const m = new Map<string, number>();
         counters.forEach((d, name) => m.set(name, d.inputDrop.pps));
@@ -74,6 +81,7 @@ export const useCounterHistory = (
 
     const inputRxHistory = useRollingWindow(inputRxSamples, HISTORY_SIZE, 1000);
     const inputTxHistory = useRollingWindow(inputTxSamples, HISTORY_SIZE, 1000);
+    const inputEntryHistory = useRollingWindow(inputEntrySamples, HISTORY_SIZE, 1000);
     const inputDropHistory = useRollingWindow(inputDropSamples, HISTORY_SIZE, 1000);
     const outputRxHistory = useRollingWindow(outputRxSamples, HISTORY_SIZE, 1000);
     const outputTxHistory = useRollingWindow(outputTxSamples, HISTORY_SIZE, 1000);
@@ -84,14 +92,24 @@ export const useCounterHistory = (
         counters.forEach((_, name) => {
             const inputRx = inputRxHistory.get(name);
             const inputTx = inputTxHistory.get(name);
+            const inputEntry = inputEntryHistory.get(name);
             const inputDrop = inputDropHistory.get(name);
             const outputRx = outputRxHistory.get(name);
             const outputTx = outputTxHistory.get(name);
             const outputDrop = outputDropHistory.get(name);
-            if (inputRx && inputTx && inputDrop && outputRx && outputTx && outputDrop) {
+            if (
+                inputRx &&
+                inputTx &&
+                inputEntry &&
+                inputDrop &&
+                outputRx &&
+                outputTx &&
+                outputDrop
+            ) {
                 result.set(name, {
                     inputRx,
                     inputTx,
+                    inputEntry,
                     inputDrop,
                     outputRx,
                     outputTx,
@@ -104,6 +122,7 @@ export const useCounterHistory = (
         counters,
         inputRxHistory,
         inputTxHistory,
+        inputEntryHistory,
         inputDropHistory,
         outputRxHistory,
         outputTxHistory,

--- a/web/src/core/hooks/useDeviceCounters.ts
+++ b/web/src/core/hooks/useDeviceCounters.ts
@@ -11,13 +11,19 @@ import {
  * Logical device counter fields.
  *
  * The dataplane exposes 12 device counters organised as rx/tx/drop per
- * input/output direction. Each direction's counter has a packets and a bytes
- * variant; this union names the six logical fields surfaced to the UI
- * (each carries both a rate and an absolute value).
+ * input/output direction, plus `input_entry`. Each direction's counter has a
+ * packets and a bytes variant; this union names the seven logical fields
+ * surfaced to the UI (each carries both a rate and an absolute value).
+ * `inputEntry` counts everything the device handler emitted into its input
+ * pipelines, right after the handler and before dispatch — unlike
+ * `inputTx`, it is not zeroed out when a packet leaves via the pending-output
+ * list (e.g. a routed packet), which makes it the correct transmit-rate
+ * source for generators.
  */
 export type DeviceCounterField =
     | 'inputRx'
     | 'inputTx'
+    | 'inputEntry'
     | 'inputDrop'
     | 'outputRx'
     | 'outputTx'
@@ -28,7 +34,7 @@ export type DeviceCounterField =
  *
  * Each backend counter is a size-2 vector where values[0] = packets and
  * values[1] = bytes. Backend naming convention: `<direction>_<kind>`, where
- * direction is `input`|`output` and kind is `rx`|`tx`|`drop`.
+ * direction is `input`|`output` and kind is `rx`|`tx`|`entry`|`drop`.
  */
 const DEVICE_COUNTER_FIELDS: ReadonlyArray<{
     field: DeviceCounterField;
@@ -36,6 +42,7 @@ const DEVICE_COUNTER_FIELDS: ReadonlyArray<{
 }> = [
     { field: 'inputRx', name: 'input_rx' },
     { field: 'inputTx', name: 'input_tx' },
+    { field: 'inputEntry', name: 'input_entry' },
     { field: 'inputDrop', name: 'input_drop' },
     { field: 'outputRx', name: 'output_rx' },
     { field: 'outputTx', name: 'output_tx' },
@@ -48,6 +55,7 @@ const DEVICE_COUNTER_FIELDS: ReadonlyArray<{
 export interface DeviceCounterData {
     inputRx: InterpolatedCounterData;
     inputTx: InterpolatedCounterData;
+    inputEntry: InterpolatedCounterData;
     inputDrop: InterpolatedCounterData;
     outputRx: InterpolatedCounterData;
     outputTx: InterpolatedCounterData;
@@ -60,6 +68,7 @@ export interface DeviceCounterData {
 export interface DeviceAbsoluteData {
     inputRx: InterpolatedAbsoluteData;
     inputTx: InterpolatedAbsoluteData;
+    inputEntry: InterpolatedAbsoluteData;
     inputDrop: InterpolatedAbsoluteData;
     outputRx: InterpolatedAbsoluteData;
     outputTx: InterpolatedAbsoluteData;

--- a/web/src/core/registry/deviceType.ts
+++ b/web/src/core/registry/deviceType.ts
@@ -80,6 +80,15 @@ export interface DeviceTypeManifest {
      */
     trafficSource?: boolean;
 
+    /** Whether this type is a purely synthetic traffic source with no wire attachment.
+     *
+     * A generator's output entry never transmits, and its generated frames
+     * often leave the input pipeline via the pending-output list (e.g. when
+     * routed elsewhere), which zeroes `inputTx` too. So list/rail displays
+     * show its generated stream from `inputEntry` instead of `outputTx`.
+     */
+    generator?: boolean;
+
     /** One-line subtitle for a list row. */
     rowSubtitle?: (device: BaseDevice) => string;
 


### PR DESCRIPTION
- Generator devices always showed zero rates on the devices list and rail after the device counters were split per direction, because their generated stream is accounted by the input entry rather than the wire counters the list displays.
- Mark generator device types with a dedicated manifest flag and source their transmit rate and sparkline from the input entry counters.
- Physical and logical devices keep the previous fields, covered with unit tests for every device kind.