### PR TITLE
fix(build): skip dot-directories when collecting protos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ proto-go:
 	@command -v protoc-gen-go >/dev/null 2>&1 || { echo "ERROR: protoc-gen-go not found (go install google.golang.org/protobuf/cmd/protoc-gen-go@latest)"; exit 1; }
 	@command -v protoc-gen-go-grpc >/dev/null 2>&1 || { echo "ERROR: protoc-gen-go-grpc not found (go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest)"; exit 1; }
 	@set -e; protos=$$(find . \
-		\( -path './subprojects' -o -path './build*' -o -path './.git' \) -prune \
+		\( -path './subprojects' -o -path './build*' -o -type d -name '.?*' \) -prune \
 		-o -name '*.proto' -print \
 		| sort); \
 		test -n "$$protos"; \

--- a/buf.yaml
+++ b/buf.yaml
@@ -4,6 +4,7 @@ modules:
     excludes:
       - subprojects
       - .claude
+      - .assets
 lint:
   use:
     - STANDARD

--- a/lint/protobuf/cmd/protolint/main.go
+++ b/lint/protobuf/cmd/protolint/main.go
@@ -72,7 +72,11 @@ func isExcluded(path string, excludes []string) bool {
 }
 
 // collectProtoFiles walks the directory tree rooted at root and returns a
-// parsed protoFile for every .proto file found, skipping excluded directories.
+// parsed protoFile for every .proto file found.
+//
+// It skips excluded directories and any dot-prefixed directory other than
+// root itself, since dot-directories in this repository host full worktree
+// copies of the repository.
 func collectProtoFiles(root string, excludes []string) ([]protoFile, error) {
 	var files []protoFile
 
@@ -82,6 +86,9 @@ func collectProtoFiles(root string, excludes []string) ([]protoFile, error) {
 		}
 
 		if info.IsDir() {
+			if path != root && strings.HasPrefix(info.Name(), ".") {
+				return filepath.SkipDir
+			}
 			if isExcluded(path, excludes) {
 				return filepath.SkipDir
 			}

--- a/lint/protobuf/cmd/protolint/main_test.go
+++ b/lint/protobuf/cmd/protolint/main_test.go
@@ -85,6 +85,65 @@ func TestCollectProtoFilesExclude(t *testing.T) {
 	}
 }
 
+// TestCollectProtoFilesSkipsDotDirectories verifies that a .proto file
+// nested under a dot-prefixed directory is not collected, while a .proto
+// file directly under a dot-prefixed root still is.
+func TestCollectProtoFilesSkipsDotDirectories(t *testing.T) {
+	t.Run("dot directory below root is skipped", func(t *testing.T) {
+		root := t.TempDir()
+
+		includedDir := filepath.Join(root, "goodpb")
+		dotDir := filepath.Join(root, ".assets", "cache", "src", "goodpb")
+		for _, d := range []string{includedDir, dotDir} {
+			if err := os.MkdirAll(d, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+		}
+
+		writeFile := func(path, content string) {
+			t.Helper()
+			if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+		}
+
+		writeFile(filepath.Join(includedDir, "good.proto"), "syntax = \"proto3\";\npackage goodpb;\n")
+		writeFile(filepath.Join(dotDir, "stale.proto"), "syntax = \"proto3\";\npackage goodpb;\n")
+
+		files, err := collectProtoFiles(root, nil)
+		if err != nil {
+			t.Fatalf("collectProtoFiles: %v", err)
+		}
+
+		if len(files) != 1 {
+			t.Fatalf("got %d files, want 1: %v", len(files), files)
+		}
+		if files[0].Path != filepath.Join(includedDir, "good.proto") {
+			t.Errorf("collected file = %q, want %q", files[0].Path, filepath.Join(includedDir, "good.proto"))
+		}
+	})
+
+	t.Run("dot-prefixed root is still scanned", func(t *testing.T) {
+		parent := t.TempDir()
+		root := filepath.Join(parent, ".hidden")
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "good.proto"), []byte("syntax = \"proto3\";\npackage goodpb;\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+
+		files, err := collectProtoFiles(root, nil)
+		if err != nil {
+			t.Fatalf("collectProtoFiles: %v", err)
+		}
+
+		if len(files) != 1 {
+			t.Fatalf("got %d files, want 1: %v", len(files), files)
+		}
+	})
+}
+
 // writeProto creates a temporary .proto file with the given content inside a
 // subdirectory named dirName under a root temp dir. It returns the file path
 // and the root directory.


### PR DESCRIPTION
Dot-directories in this repository hold full copies of the tree: a cached source worktree and the per-agent worktrees. Every tool that walked the tree therefore saw each proto several times over.

Proto generation failed outright on duplicate definitions, the buf lint run reported the same duplicates, and the custom proto linter silently checked the stale copies instead of only the working tree.

Proto collection now skips dot-directories. The buf configuration cannot express that as a pattern, so it keeps an explicit list, which previously covered only one of the two offenders.

Protos belonging to private, git-ignored modules are still collected, so their generated code is unaffected.