### PR TITLE
docs(claude): sync the module structure map with the tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,24 +124,30 @@ modules/<name>/
   internal/          # Optional: module-private Go packages (route only — discovery, rib).
 ```
 
-**Legacy** (acl, fwstate, nat64, pdump, route-mpls): no `bindings/`,
-CGO calls live directly in `controlplane/ffi.go`, no `backend.go`.
+`acl`, `blackhole`, `mirror`, `nat64`, and `route-mpls` have migrated to
+this layout too; of those, `acl` and `blackhole` have no `fuzzing/` yet,
+and `route-mpls` has neither `tests/` nor `fuzzing/`.
 
-**Early-stage**: `balancer2` has only `api/` and `dataplane/`. `blackhole` has
-the canonical skeleton (`api/`, `bindings/go/`, `controlplane/`, `dataplane/`,
-`tests/`) but its `controlplane/` is only `cfg.go` + `mod.go` so far — no
-`service.go`/`backend.go`/`cli/`/`fuzzing/` yet.
+**Legacy** (pdump): no `bindings/`, CGO calls live directly in
+`controlplane/ffi.go`, no `backend.go`. `fwstate` is partially
+migrated: it has `bindings/go/` but still routes CGO through
+`controlplane/ffi.go` and has no `backend.go`.
+
+**Early-stage** (balancer2): has `api/`, `bindings/go/`, `dataplane/`,
+and `cli/`, but its `controlplane/` holds only `balancerpb/` — no
+`mod.go`/`cfg.go`/`service.go`/`backend.go` — and it has no `tests/`
+or `fuzzing/`.
 
 Module dataplane symbols are exported via meson linker defsym: `new_module_<name>`.
 
 Active modules: `route, acl, balancer2, blackhole, forward, decap, nat64,
-fwstate, dscp, pdump, route-mpls`.
+fwstate, dscp, pdump, route-mpls, mirror`.
 
 ### Devices
 
 `devices/` mirrors `modules/` layout (`api/`, `controlplane/`, `dataplane/`,
 `cli/`) but for device adapters rather than packet-processing modules.
-Active devices: `plain`, `vlan`.
+Active devices: `plain`, `vlan`, `trafgen`.
 
 ### Operators
 


### PR DESCRIPTION
The module structure map had drifted on nine counts. It is a routing input for every contributor and agent, so a wrong line there produces confidently wrong work rather than an obvious error — a planning task was recently built on one of these stale claims.

Three modules listed as legacy have finished migrating, one sits between the two layouts and now says so, and only one still matches the legacy definition. Both early-stage descriptions were stale. One public module and one device were missing from the active lists entirely.

Every claim was checked against the tree using the criteria the document itself defines.

The reference list is left alone: which modules to imitate is an editorial choice, not a mechanical property of their layout.