### PR TITLE
feat(cli): complete config names from the module's own list rpc

### DIFF
--- a/cli/core/src/completion.rs
+++ b/cli/core/src/completion.rs
@@ -1,0 +1,237 @@
+//! Best-effort shell completion for config-name arguments.
+//!
+//! A module CLI's config-name argument (`--name`, `--config`, …) is
+//! completed from the module's own `list` RPC. The caller supplies its own
+//! generated client and its own generated method through two closures, so a
+//! proto rename breaks the build instead of silently degrading completion
+//! into a no-op — this is the whole point of [`candidates`]'s shape.
+
+use std::ffi::OsString;
+
+use clap::{Args, Command, FromArgMatches};
+use clap_complete::engine::CompletionCandidate;
+use tonic::Status;
+
+use crate::{
+    client::{self, ConnectionArgs, LayeredChannel},
+    discovery::DISCOVERY_TIMEOUT,
+};
+
+/// Extracts the words the user has typed so far from the completer's raw
+/// argv.
+///
+/// `clap_complete` invokes the completer as `<completer> -- <bin>
+/// <word>...`; this mirrors `clap_complete::CompleteEnv::try_complete`'s own
+/// extraction verbatim. Drops `argv[0]` — the completer's own path — then
+/// drops everything through the FIRST `--`. What remains is `[bin_name,
+/// ...user words...]`, exactly the argv clap itself parses. Returns an
+/// empty vector if `args` is empty or contains no `--`, since neither shape
+/// carries any words to recover.
+fn user_words<I>(args: I) -> Vec<OsString>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut args: Vec<OsString> = args.into_iter().collect();
+    if args.is_empty() {
+        return args;
+    }
+
+    args.remove(0);
+    let escape_index = args
+        .iter()
+        .position(|a| *a == "--")
+        .map(|i| i + 1)
+        .unwrap_or(args.len());
+    args.drain(0..escape_index);
+
+    args
+}
+
+/// Recovers the connection flags from the given completer argv.
+///
+/// Parses `user_words(args)` against the caller's own `command`, with parse
+/// errors ignored — the line is mid-typing and usually not yet valid.
+/// Falls back to [`default_connection_args`] whenever recovery is
+/// impossible: no `--` in `args`, an unparsable line, or a `Cmd` that does
+/// not flatten [`ConnectionArgs`] at all.
+fn recover_connection_args<I>(command: impl FnOnce() -> Command, args: I) -> ConnectionArgs
+where
+    I: IntoIterator<Item = OsString>,
+{
+    command()
+        .ignore_errors(true)
+        .try_get_matches_from(user_words(args))
+        .ok()
+        .and_then(|matches| ConnectionArgs::from_arg_matches(&matches).ok())
+        .unwrap_or_else(default_connection_args)
+}
+
+/// [`ConnectionArgs`]' own defaults, independent of any `Cmd` — the
+/// fallback when recovery from the caller's command tree is impossible.
+///
+/// `YANET_ENDPOINT` is still honored, since it is the `endpoint` field's
+/// `env` attribute rather than anything specific to the caller's `Cmd`.
+fn default_connection_args() -> ConnectionArgs {
+    let matches = ConnectionArgs::augment_args(Command::new("connection")).get_matches_from(Vec::<OsString>::new());
+
+    ConnectionArgs::from_arg_matches(&matches).expect("ConnectionArgs must parse from its own defaults")
+}
+
+/// Best-effort completion candidates for a config-name argument.
+///
+/// `command` is the caller's own `Cmd::command`, exactly the factory passed
+/// to `CompleteEnv::with_factory` in `main` — it recovers the connection
+/// flags (`--endpoint`, `--auth`, …) the user has actually typed so far, so
+/// completion talks to the gateway the user is targeting rather than
+/// silently falling back to the default one. `build` receives the layered
+/// channel and returns the caller's tonic-generated client, exactly like
+/// the `build` parameter of [`Service::new`](crate::client::Service::new) —
+/// compression is configured there, since it is an inherent client method.
+/// `lookup` issues the RPC on that client and returns the config names.
+///
+/// Strictly best-effort: a gateway that is down, slow, or refusing auth
+/// yields an empty list, never an error or a hang. Connect and lookup share
+/// one [`DISCOVERY_TIMEOUT`] budget, and the whole call runs on its own
+/// single-threaded runtime built and torn down here — nothing may reach
+/// stdout, since `clap_complete` owns it.
+///
+/// The caller must invoke `CompleteEnv::complete` from a sync `main`, before
+/// any runtime is entered, because the runtime built here is blocked on
+/// directly, which panics if it is reached from inside another runtime's
+/// context.
+///
+/// `lookup` must be a genuine async closure, `async move |client| …`, not a
+/// plain closure returning an `async move` block — the latter cannot infer
+/// `client`'s type and fails to compile.
+pub fn candidates<C, B, F>(command: impl FnOnce() -> Command, build: B, lookup: F) -> Vec<CompletionCandidate>
+where
+    B: FnOnce(LayeredChannel) -> C,
+    F: AsyncFnOnce(C) -> Result<Vec<String>, Status>,
+{
+    let connection = recover_connection_args(command, std::env::args_os());
+
+    let Ok(runtime) = tokio::runtime::Builder::new_current_thread().enable_all().build() else {
+        return Vec::new();
+    };
+
+    let attempt = async move {
+        let channel = client::connect(&connection).await.ok()?;
+
+        lookup(build(channel)).await.ok()
+    };
+
+    // `tokio::time::timeout` captures the current runtime's timer handle as
+    // soon as it is constructed, not once polled, so it must be built inside
+    // the `async` block handed to `block_on` rather than before it.
+    runtime
+        .block_on(async move { tokio::time::timeout(DISCOVERY_TIMEOUT, attempt).await })
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use clap::{CommandFactory, Parser};
+
+    use super::*;
+
+    fn words(raw: &[&str]) -> Vec<OsString> {
+        raw.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn user_words_is_empty_for_empty_argv() {
+        assert!(user_words(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn user_words_is_empty_without_a_separator() {
+        let argv = words(&["completer", "show", "--name", ""]);
+
+        assert!(user_words(argv).is_empty());
+    }
+
+    #[test]
+    fn user_words_strips_through_the_first_separator() {
+        let argv = words(&["completer", "--", "bin", "show", "--name", ""]);
+
+        assert_eq!(words(&["bin", "show", "--name", ""]), user_words(argv));
+    }
+
+    #[test]
+    fn user_words_uses_the_first_separator_when_user_words_also_contain_one() {
+        let argv = words(&["completer", "--", "bin", "run", "--", "--name", ""]);
+
+        assert_eq!(words(&["bin", "run", "--", "--name", ""]), user_words(argv));
+    }
+
+    /// A faithful replica of a module CLI's `Cmd`: a required subcommand
+    /// plus globally flattened [`ConnectionArgs`], the exact shape that
+    /// made a `ConnectionArgs`-only wrapper miss a global flag typed after
+    /// the subcommand.
+    #[derive(Parser)]
+    struct TestCmd {
+        #[command(subcommand)]
+        mode: TestModeCmd,
+        #[command(flatten)]
+        connection: ConnectionArgs,
+    }
+
+    #[derive(Parser)]
+    enum TestModeCmd {
+        Show(TestShowCmd),
+    }
+
+    #[derive(Parser)]
+    struct TestShowCmd {
+        #[arg(long = "name", short = 'n')]
+        name: String,
+    }
+
+    fn recovered_endpoint(argv: &[&str]) -> String {
+        recover_connection_args(TestCmd::command, words(argv)).endpoint
+    }
+
+    #[test]
+    fn recovers_endpoint_given_before_the_subcommand() {
+        let endpoint = recovered_endpoint(&[
+            "completer",
+            "--",
+            "bin",
+            "--endpoint",
+            "grpc://example:1",
+            "show",
+            "--name",
+            "",
+        ]);
+
+        assert_eq!("grpc://example:1", endpoint);
+    }
+
+    #[test]
+    fn recovers_endpoint_given_after_the_subcommand() {
+        let endpoint = recovered_endpoint(&[
+            "completer",
+            "--",
+            "bin",
+            "show",
+            "--endpoint",
+            "grpc://example:1",
+            "--name",
+            "",
+        ]);
+
+        assert_eq!("grpc://example:1", endpoint);
+    }
+
+    #[test]
+    fn falls_back_to_defaults_without_a_separator() {
+        let fallback = default_connection_args().endpoint;
+
+        assert_eq!(fallback, recovered_endpoint(&["completer", "show", "--name", ""]));
+    }
+}

--- a/cli/core/src/lib.rs
+++ b/cli/core/src/lib.rs
@@ -2,6 +2,7 @@ use crate::output::Format;
 
 pub mod auth;
 pub mod client;
+pub mod completion;
 pub mod discovery;
 pub mod dispatcher;
 pub mod display;

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -1,5 +1,8 @@
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    CompleteEnv,
+    engine::{ArgValueCandidates, CompletionCandidate},
+};
 use decappb::{
     ListConfigsRequest, ShowConfigRequest, ShowConfigResponse, UpdateConfigRequest,
     decap_service_client::DecapServiceClient,
@@ -9,6 +12,7 @@ use ptree::TreeBuilder;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -47,14 +51,14 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// Decap module name to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateConfigCmd {
     /// Decap module name to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Prefixes in the full desired set, replacing the current one entirely.
     #[arg(long, short)]
@@ -64,9 +68,13 @@ pub struct UpdateConfigCmd {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.decap.controlplane.decappb.v1.DecapService";
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -176,4 +184,20 @@ fn print_tree(resp: &ShowConfigResponse) {
     }
 
     let _ = ptree::print_tree(&tree.build());
+}
+
+/// Completion candidates for a `--name` argument: the decap configs the
+/// module currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            DecapServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
+    )
 }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    CompleteEnv,
+    engine::{ArgValueCandidates, CompletionCandidate},
+};
 use forwardpb::{
     DeleteConfigRequest, ListConfigsRequest, ShowConfigRequest, UpdateConfigRequest,
     forward_service_client::ForwardServiceClient,
@@ -14,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -53,21 +57,21 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// The name of the module config to show.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// The name of the module config to delete.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// The name of the module config to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config: String,
     /// Ruleset file path.
     #[arg(required = true, long = "rules", value_name = "PATH")]
@@ -264,9 +268,13 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -274,4 +282,20 @@ pub async fn main() {
         output::failure(&err);
         std::process::exit(err.exit_code());
     }
+}
+
+/// Completion candidates for a `--name` argument: the forward configs the
+/// module currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            ForwardServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
+    )
 }


### PR DESCRIPTION
Config-name arguments across the module command line tools now offer shell completion, sourced from each module's own list RPC. An existing config can be picked with a tab instead of being recalled by hand.

The shared primitive is deliberately shaped so that each tool passes its own generated client and issues its own generated call. A proto rename therefore breaks the build, rather than quietly degrading completion into a no-op — which is what a name-based lookup would have done.

Completion is strictly best-effort. A gateway that is down, slow, or refusing authentication yields no candidates at all: never an error, never a hang. Connect and lookup share a single one-second budget.

Completion setup now runs ahead of the async runtime, which lets the completer own the runtime it needs and drops the worker thread the previous approach would have required.

This is the first of a staged sweep. Decap and forward are the first adopters; the remaining command line tools follow in later changes.