### PR TITLE
refactor(metrics): encapsulate bucket and entry state

### DIFF
--- a/common/go/metrics/histogram.go
+++ b/common/go/metrics/histogram.go
@@ -6,14 +6,40 @@ import (
 	"sync/atomic"
 )
 
+// BucketSnapshot is a point-in-time read of one histogram bucket.
 type BucketSnapshot struct {
 	UpperBound float64
 	Count      uint64
 }
 
+// bucket is one histogram bucket: an upper bound and an observation count.
 type bucket struct {
 	upperBound float64
-	count      atomic.Uint64
+
+	count atomic.Uint64
+}
+
+// newBucket returns a fresh bucket accepting values up to upperBound.
+func newBucket(upperBound float64) bucket {
+	return bucket{upperBound: upperBound}
+}
+
+// Accepts reports whether value falls within this bucket's upper bound.
+func (m *bucket) Accepts(value float64) bool {
+	return m.upperBound >= value
+}
+
+// Record counts one observation in this bucket.
+func (m *bucket) Record() {
+	m.count.Add(1)
+}
+
+// Snapshot returns a point-in-time read of this single bucket.
+func (m *bucket) Snapshot() BucketSnapshot {
+	return BucketSnapshot{
+		UpperBound: m.upperBound,
+		Count:      m.count.Load(),
+	}
 }
 
 type Histogram struct {
@@ -27,10 +53,10 @@ func NewHistogram(bounds []float64) *Histogram {
 	sort.Float64s(sorted)
 
 	buckets := make([]bucket, len(sorted)+1)
-	for i, bound := range sorted {
-		buckets[i].upperBound = bound
+	for idx, bound := range sorted {
+		buckets[idx] = newBucket(bound)
 	}
-	buckets[len(sorted)].upperBound = math.Inf(1)
+	buckets[len(sorted)] = newBucket(math.Inf(1))
 
 	return &Histogram{
 		buckets: buckets,
@@ -41,20 +67,17 @@ func NewHistogram(bounds []float64) *Histogram {
 // Complexity: O(log N) for search + O(1) for atomic write.
 func (m *Histogram) Observe(value float64) {
 	idx := sort.Search(len(m.buckets), func(idx int) bool {
-		return m.buckets[idx].upperBound >= value
+		return m.buckets[idx].Accepts(value)
 	})
 
-	m.buckets[idx].count.Add(1)
+	m.buckets[idx].Record()
 }
 
-// Snapshot returns a snapshot of the histogram buckets.
+// Snapshot returns a snapshot of all histogram buckets.
 func (m *Histogram) Snapshot() []BucketSnapshot {
 	snapshot := make([]BucketSnapshot, len(m.buckets))
-	for i := range m.buckets {
-		snapshot[i] = BucketSnapshot{
-			UpperBound: m.buckets[i].upperBound,
-			Count:      m.buckets[i].count.Load(),
-		}
+	for idx := range m.buckets {
+		snapshot[idx] = m.buckets[idx].Snapshot()
 	}
 	return snapshot
 }

--- a/common/go/metrics/histogram_test.go
+++ b/common/go/metrics/histogram_test.go
@@ -1,4 +1,4 @@
-package metrics
+package metrics_test
 
 import (
 	"fmt"
@@ -9,11 +9,13 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 )
 
 func TestNewHistogram(t *testing.T) {
 	t.Run("SortsBounds", func(t *testing.T) {
-		h := NewHistogram([]float64{100, 10, 50, 1})
+		h := metrics.NewHistogram([]float64{100, 10, 50, 1})
 		snapshot := h.Snapshot()
 		// Verify bounds are sorted (excluding +Inf)
 		bounds := make([]float64, 0, len(snapshot)-1)
@@ -25,13 +27,13 @@ func TestNewHistogram(t *testing.T) {
 	})
 
 	t.Run("BucketCount", func(t *testing.T) {
-		h := NewHistogram([]float64{1, 5, 10})
+		h := metrics.NewHistogram([]float64{1, 5, 10})
 		snapshot := h.Snapshot()
 		assert.Equal(t, 4, len(snapshot), "should have 4 buckets (3 bounds + inf)")
 	})
 
 	t.Run("EmptyBounds", func(t *testing.T) {
-		h := NewHistogram([]float64{})
+		h := metrics.NewHistogram([]float64{})
 		snapshot := h.Snapshot()
 		assert.Len(t, snapshot, 1, "should have 1 inf bucket")
 		assert.True(t, math.IsInf(snapshot[0].UpperBound, 1), "single bucket should be +Inf")
@@ -40,7 +42,7 @@ func TestNewHistogram(t *testing.T) {
 	t.Run("DoesNotModifyInput", func(t *testing.T) {
 		input := []float64{3, 1, 2}
 		original := slices.Clone(input)
-		_ = NewHistogram(input)
+		_ = metrics.NewHistogram(input)
 		assert.Equal(t, original, input, "input should not be modified")
 	})
 }
@@ -48,7 +50,7 @@ func TestNewHistogram(t *testing.T) {
 func TestHistogramObserve(t *testing.T) {
 	// Bounds: [1, 5, 10]
 	// Buckets: [0]: <=1, [1]: (1,5], [2]: (5,10], [3]: >10 (inf)
-	h := NewHistogram([]float64{1, 5, 10})
+	h := metrics.NewHistogram([]float64{1, 5, 10})
 
 	tests := []struct {
 		name   string
@@ -81,7 +83,7 @@ func TestHistogramObserve(t *testing.T) {
 func TestHistogramObserveNegativeBounds(t *testing.T) {
 	// Bounds: [-10, -5, 0, 5] (sorted)
 	// Buckets: [0]: <=-10, [1]: (-10,-5], [2]: (-5,0], [3]: (0,5], [4]: >5
-	h := NewHistogram([]float64{0, -5, 5, -10})
+	h := metrics.NewHistogram([]float64{0, -5, 5, -10})
 
 	tests := []struct {
 		value  float64
@@ -112,7 +114,7 @@ func TestHistogramObserveNegativeBounds(t *testing.T) {
 }
 
 func TestHistogramObserveEmptyBounds(t *testing.T) {
-	h := NewHistogram([]float64{})
+	h := metrics.NewHistogram([]float64{})
 
 	// All values go to the single inf bucket
 	for _, v := range []float64{-100, 0, 100} {
@@ -128,7 +130,7 @@ func TestHistogramObserveEmptyBounds(t *testing.T) {
 }
 
 func TestHistogramConcurrent(t *testing.T) {
-	h := NewHistogram([]float64{10, 50, 100})
+	h := metrics.NewHistogram([]float64{10, 50, 100})
 	var wg sync.WaitGroup
 	n := 1000
 
@@ -151,7 +153,7 @@ func TestHistogramConcurrent(t *testing.T) {
 
 func TestHistogramSnapshot(t *testing.T) {
 	t.Run("EmptyHistogram", func(t *testing.T) {
-		h := NewHistogram([]float64{10, 50, 100})
+		h := metrics.NewHistogram([]float64{10, 50, 100})
 		snapshot := h.Snapshot()
 
 		require.Len(t, snapshot, 4, "should have 4 buckets")
@@ -169,7 +171,7 @@ func TestHistogramSnapshot(t *testing.T) {
 	})
 
 	t.Run("WithObservations", func(t *testing.T) {
-		h := NewHistogram([]float64{10, 50, 100})
+		h := metrics.NewHistogram([]float64{10, 50, 100})
 		h.Observe(5)   // bucket 0
 		h.Observe(25)  // bucket 1
 		h.Observe(75)  // bucket 2
@@ -193,7 +195,7 @@ func TestHistogramSnapshot(t *testing.T) {
 	})
 
 	t.Run("SnapshotIsImmutable", func(t *testing.T) {
-		h := NewHistogram([]float64{10})
+		h := metrics.NewHistogram([]float64{10})
 		h.Observe(5)
 
 		snapshot1 := h.Snapshot()
@@ -212,7 +214,7 @@ func TestHistogramSnapshot(t *testing.T) {
 	})
 
 	t.Run("EmptyBoundsHistogram", func(t *testing.T) {
-		h := NewHistogram([]float64{})
+		h := metrics.NewHistogram([]float64{})
 		h.Observe(100)
 		h.Observe(-100)
 

--- a/common/go/metrics/map.go
+++ b/common/go/metrics/map.go
@@ -18,9 +18,33 @@ type MetricMap[T any] struct {
 	entries map[uint64][]metricEntry[T]
 }
 
+// metricEntry pairs a stored metric with the ID it was registered under.
 type metricEntry[T any] struct {
 	id     MetricID
 	metric T
+}
+
+// MetricFor returns the stored metric when the entry was registered under id.
+func (m metricEntry[T]) MetricFor(id MetricID) (T, bool) {
+	if m.id.Equals(id) {
+		return m.metric, true
+	}
+
+	var zero T
+	return zero, false
+}
+
+// ToMetric converts the entry into a Metric, cloning its ID.
+func (m metricEntry[T]) ToMetric() Metric[T] {
+	return Metric[T]{ID: m.id.Clone(), Value: m.metric}
+}
+
+// Satisfies reports whether pred accepts the entry.
+//
+// The predicate receives a cloned MetricID so it cannot mutate stored map
+// state.
+func (m metricEntry[T]) Satisfies(pred func(MetricID, T) bool) bool {
+	return pred(m.id.Clone(), m.metric)
 }
 
 func NewMetricMap[T any]() *MetricMap[T] {
@@ -33,8 +57,8 @@ func (m *MetricMap[T]) tryGet(id MetricID, h uint64) (T, bool) {
 
 	if bucket, ok := m.entries[h]; ok {
 		for idx := range bucket {
-			if bucket[idx].id.Equals(id) {
-				return bucket[idx].metric, true
+			if metric, ok := bucket[idx].MetricFor(id); ok {
+				return metric, true
 			}
 		}
 	}
@@ -49,13 +73,15 @@ func (m *MetricMap[T]) create(id MetricID, h uint64, create func() T) T {
 
 	if bucket, ok := m.entries[h]; ok {
 		for idx := range bucket {
-			if bucket[idx].id.Equals(id) {
-				return bucket[idx].metric
+			if metric, ok := bucket[idx].MetricFor(id); ok {
+				return metric
 			}
 		}
 	}
-	m.entries[h] = append(m.entries[h], metricEntry[T]{id: id.Clone(), metric: create()})
-	return m.entries[h][len(m.entries[h])-1].metric
+
+	metric := create()
+	m.entries[h] = append(m.entries[h], metricEntry[T]{id: id.Clone(), metric: metric})
+	return metric
 }
 
 // GetOrCreate returns the metric for the given label list, creating it via
@@ -72,11 +98,11 @@ func (m *MetricMap[T]) GetOrCreate(id MetricID, create func() T) T {
 
 // DeleteWhere removes every stored metric whose (ID, metric) satisfies pred.
 //
-// Returns the number of metrics removed.
-//
 // The predicate receives a cloned MetricID so it cannot mutate stored map
-// state. Buckets are compacted in place. Hash buckets that become empty are
-// deleted so the map does not accumulate empty slots.
+// state. Buckets are compacted in place; hash buckets that become empty
+// are deleted so the map does not accumulate empty slots.
+//
+// Returns the number of metrics removed.
 func (m *MetricMap[T]) DeleteWhere(pred func(MetricID, T) bool) int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -84,7 +110,7 @@ func (m *MetricMap[T]) DeleteWhere(pred func(MetricID, T) bool) int {
 	removed := 0
 	for h, bucket := range m.entries {
 		kept := slices.DeleteFunc(bucket, func(entry metricEntry[T]) bool {
-			return pred(entry.id.Clone(), entry.metric)
+			return entry.Satisfies(pred)
 		})
 		removed += len(bucket) - len(kept)
 
@@ -105,11 +131,22 @@ func (m *MetricMap[T]) Metrics() []Metric[T] {
 
 	var out []Metric[T]
 	for _, bucket := range m.entries {
-		for i := range bucket {
-			out = append(out, Metric[T]{ID: bucket[i].id.Clone(), Value: bucket[i].metric})
+		for idx := range bucket {
+			out = append(out, bucket[idx].ToMetric())
 		}
 	}
 	return out
+}
+
+// IsEmpty reports whether the map holds no metrics.
+//
+// It is O(1): emptying the map releases its internal storage, so no scan
+// is needed.
+func (m *MetricMap[T]) IsEmpty() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	return len(m.entries) == 0
 }
 
 // Hashes metric ID deterministically.

--- a/common/go/metrics/map_test.go
+++ b/common/go/metrics/map_test.go
@@ -1,4 +1,4 @@
-package metrics
+package metrics_test
 
 import (
 	"fmt"
@@ -8,29 +8,31 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 )
 
 func TestMetricMapGetOrCreate(t *testing.T) {
 	t.Run("CreatesNew", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
-		id := MetricID{Name: "test", Labels: Labels{"a": "1"}}
+		m := metrics.NewMetricMap[*metrics.Counter]()
+		id := metrics.MetricID{Name: "test", Labels: metrics.Labels{"a": "1"}}
 
 		var calls int
-		c := m.GetOrCreate(id, func() *Counter { calls++; return &Counter{} })
+		c := m.GetOrCreate(id, func() *metrics.Counter { calls++; return &metrics.Counter{} })
 
 		assert.Equal(t, 1, calls, "create should be called once")
 		require.NotNil(t, c, "GetOrCreate should not return nil")
 	})
 
 	t.Run("ReturnsExisting", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
-		id := MetricID{Name: "test"}
+		m := metrics.NewMetricMap[*metrics.Counter]()
+		id := metrics.MetricID{Name: "test"}
 
-		c1 := m.GetOrCreate(id, func() *Counter { return &Counter{} })
+		c1 := m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 		c1.Inc()
 
 		var calls int
-		c2 := m.GetOrCreate(id, func() *Counter { calls++; return &Counter{} })
+		c2 := m.GetOrCreate(id, func() *metrics.Counter { calls++; return &metrics.Counter{} })
 
 		assert.Equal(t, 0, calls, "create should not be called for existing metric")
 		assert.Same(t, c1, c2, "should return same pointer for same ID")
@@ -38,12 +40,12 @@ func TestMetricMapGetOrCreate(t *testing.T) {
 	})
 
 	t.Run("DifferentIDs", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
-		id1 := MetricID{Name: "metric1"}
-		id2 := MetricID{Name: "metric2"}
+		m := metrics.NewMetricMap[*metrics.Counter]()
+		id1 := metrics.MetricID{Name: "metric1"}
+		id2 := metrics.MetricID{Name: "metric2"}
 
-		c1 := m.GetOrCreate(id1, func() *Counter { return &Counter{} })
-		c2 := m.GetOrCreate(id2, func() *Counter { return &Counter{} })
+		c1 := m.GetOrCreate(id1, func() *metrics.Counter { return &metrics.Counter{} })
+		c2 := m.GetOrCreate(id2, func() *metrics.Counter { return &metrics.Counter{} })
 
 		c1.Add(10)
 		c2.Add(20)
@@ -54,13 +56,13 @@ func TestMetricMapGetOrCreate(t *testing.T) {
 }
 
 func TestMetricMapLabelsAreASet(t *testing.T) {
-	m := NewMetricMap[*Counter]()
+	m := metrics.NewMetricMap[*metrics.Counter]()
 
-	id1 := MetricID{Name: "test", Labels: Labels{"a": "1", "b": "2"}}
-	id2 := MetricID{Name: "test", Labels: Labels{"b": "2", "a": "1"}}
+	id1 := metrics.MetricID{Name: "test", Labels: metrics.Labels{"a": "1", "b": "2"}}
+	id2 := metrics.MetricID{Name: "test", Labels: metrics.Labels{"b": "2", "a": "1"}}
 
-	c1 := m.GetOrCreate(id1, func() *Counter { return &Counter{} })
-	c2 := m.GetOrCreate(id2, func() *Counter { return &Counter{} })
+	c1 := m.GetOrCreate(id1, func() *metrics.Counter { return &metrics.Counter{} })
+	c2 := m.GetOrCreate(id2, func() *metrics.Counter { return &metrics.Counter{} })
 
 	assert.Same(t, c1, c2, "same label set should resolve to the same metric")
 
@@ -70,16 +72,16 @@ func TestMetricMapLabelsAreASet(t *testing.T) {
 
 func TestMetricMapMetrics(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
+		m := metrics.NewMetricMap[*metrics.Counter]()
 		refs := m.Metrics()
 		assert.Empty(t, refs, "Metrics() on empty map should return empty slice")
 	})
 
 	t.Run("ReturnsAll", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
+		m := metrics.NewMetricMap[*metrics.Counter]()
 		for i := range 5 {
-			id := MetricID{Name: fmt.Sprintf("metric%d", i)}
-			m.GetOrCreate(id, func() *Counter { return &Counter{} })
+			id := metrics.MetricID{Name: fmt.Sprintf("metric%d", i)}
+			m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 		}
 
 		refs := m.Metrics()
@@ -87,9 +89,9 @@ func TestMetricMapMetrics(t *testing.T) {
 	})
 
 	t.Run("LiveReferences", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
-		id := MetricID{Name: "test"}
-		c := m.GetOrCreate(id, func() *Counter { return &Counter{} })
+		m := metrics.NewMetricMap[*metrics.Counter]()
+		id := metrics.MetricID{Name: "test"}
+		c := m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 
 		refs := m.Metrics()
 		require.Len(t, refs, 1, "should have 1 metric")
@@ -108,9 +110,9 @@ func TestMetricMapMetrics(t *testing.T) {
 	})
 
 	t.Run("IDsPreserved", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
-		id := MetricID{Name: "test", Labels: Labels{"env": "prod"}}
-		m.GetOrCreate(id, func() *Counter { return &Counter{} })
+		m := metrics.NewMetricMap[*metrics.Counter]()
+		id := metrics.MetricID{Name: "test", Labels: metrics.Labels{"env": "prod"}}
+		m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 
 		refs := m.Metrics()
 		assert.True(t, refs[0].ID.Equals(id), "ID should be preserved")
@@ -118,12 +120,12 @@ func TestMetricMapMetrics(t *testing.T) {
 }
 
 func TestMetricMapConcurrent(t *testing.T) {
-	m := NewMetricMap[*Counter]()
+	m := metrics.NewMetricMap[*metrics.Counter]()
 	var wg sync.WaitGroup
 	n := 100
-	ids := make([]MetricID, 10)
+	ids := make([]metrics.MetricID, 10)
 	for i := range ids {
-		ids[i] = MetricID{Name: fmt.Sprintf("metric%d", i)}
+		ids[i] = metrics.MetricID{Name: fmt.Sprintf("metric%d", i)}
 	}
 
 	var createCalls atomic.Int64
@@ -133,9 +135,9 @@ func TestMetricMapConcurrent(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for _, id := range ids {
-				c := m.GetOrCreate(id, func() *Counter {
+				c := m.GetOrCreate(id, func() *metrics.Counter {
 					createCalls.Add(1)
-					return &Counter{}
+					return &metrics.Counter{}
 				})
 				c.Inc()
 			}
@@ -156,9 +158,9 @@ func TestMetricMapConcurrent(t *testing.T) {
 
 func TestMetricMapIntegration(t *testing.T) {
 	t.Run("WithGauge", func(t *testing.T) {
-		m := NewMetricMap[*Gauge]()
-		id := MetricID{Name: "temperature"}
-		g := m.GetOrCreate(id, func() *Gauge { return &Gauge{} })
+		m := metrics.NewMetricMap[*metrics.Gauge]()
+		id := metrics.MetricID{Name: "temperature"}
+		g := m.GetOrCreate(id, func() *metrics.Gauge { return &metrics.Gauge{} })
 		g.Store(36.6)
 
 		refs := m.Metrics()
@@ -166,9 +168,9 @@ func TestMetricMapIntegration(t *testing.T) {
 	})
 
 	t.Run("WithHistogram", func(t *testing.T) {
-		m := NewMetricMap[*Histogram]()
-		id := MetricID{Name: "latency"}
-		h := m.GetOrCreate(id, func() *Histogram { return NewHistogram([]float64{10, 50, 100}) })
+		m := metrics.NewMetricMap[*metrics.Histogram]()
+		id := metrics.MetricID{Name: "latency"}
+		h := m.GetOrCreate(id, func() *metrics.Histogram { return metrics.NewHistogram([]float64{10, 50, 100}) })
 		h.Observe(25)
 
 		refs := m.Metrics()
@@ -185,26 +187,26 @@ func TestMetricMapIntegration(t *testing.T) {
 // matching the predicate and cleans up empty internal buckets.
 func TestMetricMapDeleteWhere(t *testing.T) {
 	t.Run("DeleteNone", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
+		m := metrics.NewMetricMap[*metrics.Counter]()
 		for idx := range 3 {
-			id := MetricID{Name: fmt.Sprintf("metric%d", idx)}
-			m.GetOrCreate(id, func() *Counter { return &Counter{} })
+			id := metrics.MetricID{Name: fmt.Sprintf("metric%d", idx)}
+			m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 		}
 
-		n := m.DeleteWhere(func(MetricID, *Counter) bool { return false })
+		n := m.DeleteWhere(func(metrics.MetricID, *metrics.Counter) bool { return false })
 
 		assert.Equal(t, 0, n, "DeleteWhere(false) should remove nothing")
 		assert.Len(t, m.Metrics(), 3, "all metrics should remain")
 	})
 
 	t.Run("DeleteSome", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
+		m := metrics.NewMetricMap[*metrics.Counter]()
 		for idx := range 4 {
-			id := MetricID{Name: fmt.Sprintf("metric%d", idx)}
-			m.GetOrCreate(id, func() *Counter { return &Counter{} })
+			id := metrics.MetricID{Name: fmt.Sprintf("metric%d", idx)}
+			m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 		}
 
-		n := m.DeleteWhere(func(id MetricID, _ *Counter) bool {
+		n := m.DeleteWhere(func(id metrics.MetricID, _ *metrics.Counter) bool {
 			return id.Name == "metric1" || id.Name == "metric3"
 		})
 
@@ -218,38 +220,33 @@ func TestMetricMapDeleteWhere(t *testing.T) {
 	})
 
 	t.Run("DeleteAll", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
+		m := metrics.NewMetricMap[*metrics.Counter]()
 		for idx := range 3 {
-			id := MetricID{Name: fmt.Sprintf("metric%d", idx)}
-			m.GetOrCreate(id, func() *Counter { return &Counter{} })
+			id := metrics.MetricID{Name: fmt.Sprintf("metric%d", idx)}
+			m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 		}
 
-		n := m.DeleteWhere(func(MetricID, *Counter) bool { return true })
+		n := m.DeleteWhere(func(metrics.MetricID, *metrics.Counter) bool { return true })
 
 		assert.Equal(t, 3, n, "DeleteWhere(true) should remove all metrics")
 		assert.Empty(t, m.Metrics(), "map should be empty after deleting all")
 	})
 
 	t.Run("EmptyBucketCleanup", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
-		id := MetricID{Name: "only"}
-		m.GetOrCreate(id, func() *Counter { return &Counter{} })
+		m := metrics.NewMetricMap[*metrics.Counter]()
+		id := metrics.MetricID{Name: "only"}
+		m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 
-		m.DeleteWhere(func(MetricID, *Counter) bool { return true })
+		m.DeleteWhere(func(metrics.MetricID, *metrics.Counter) bool { return true })
 
-		// The internal bucket map should have no entries after emptying.
-		m.mu.RLock()
-		bucketCount := len(m.entries)
-		m.mu.RUnlock()
-
-		assert.Equal(t, 0, bucketCount, "empty buckets should be removed from the map")
+		assert.True(t, m.IsEmpty(), "empty buckets should be removed from the map")
 	})
 
 	t.Run("DeleteByValue", func(t *testing.T) {
-		m := NewMetricMap[*Counter]()
+		m := metrics.NewMetricMap[*metrics.Counter]()
 		for idx := range 4 {
-			id := MetricID{Name: fmt.Sprintf("metric%d", idx)}
-			c := m.GetOrCreate(id, func() *Counter { return &Counter{} })
+			id := metrics.MetricID{Name: fmt.Sprintf("metric%d", idx)}
+			c := m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 			// Give odd-indexed metrics a non-zero count.
 			if idx%2 != 0 {
 				c.Add(uint64(idx * 10))
@@ -257,7 +254,7 @@ func TestMetricMapDeleteWhere(t *testing.T) {
 		}
 
 		// Delete only metrics whose counter value is zero (keying off the value).
-		n := m.DeleteWhere(func(_ MetricID, c *Counter) bool {
+		n := m.DeleteWhere(func(_ metrics.MetricID, c *metrics.Counter) bool {
 			return c.Load() == 0
 		})
 
@@ -270,42 +267,40 @@ func TestMetricMapDeleteWhere(t *testing.T) {
 	})
 }
 
-// Benchmarks
-
 func BenchmarkGetOrCreate(b *testing.B) {
 	b.Run("New", func(b *testing.B) {
 		for i := range b.N {
-			m := NewMetricMap[*Counter]()
-			id := MetricID{Name: fmt.Sprintf("metric%d", i)}
-			m.GetOrCreate(id, func() *Counter { return &Counter{} })
+			m := metrics.NewMetricMap[*metrics.Counter]()
+			id := metrics.MetricID{Name: fmt.Sprintf("metric%d", i)}
+			m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 		}
 	})
 
 	b.Run("Existing", func(b *testing.B) {
-		m := NewMetricMap[*Counter]()
-		id := MetricID{Name: "metric", Labels: Labels{"a": "1"}}
-		m.GetOrCreate(id, func() *Counter { return &Counter{} })
+		m := metrics.NewMetricMap[*metrics.Counter]()
+		id := metrics.MetricID{Name: "metric", Labels: metrics.Labels{"a": "1"}}
+		m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 
 		b.ResetTimer()
 		for range b.N {
-			m.GetOrCreate(id, func() *Counter { return &Counter{} })
+			m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 		}
 	})
 }
 
 func BenchmarkGetOrCreateParallel(b *testing.B) {
-	m := NewMetricMap[*Counter]()
-	ids := make([]MetricID, 100)
+	m := metrics.NewMetricMap[*metrics.Counter]()
+	ids := make([]metrics.MetricID, 100)
 	for i := range ids {
-		ids[i] = MetricID{Name: fmt.Sprintf("metric%d", i)}
-		m.GetOrCreate(ids[i], func() *Counter { return &Counter{} })
+		ids[i] = metrics.MetricID{Name: fmt.Sprintf("metric%d", i)}
+		m.GetOrCreate(ids[i], func() *metrics.Counter { return &metrics.Counter{} })
 	}
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		i := 0
 		for pb.Next() {
-			m.GetOrCreate(ids[i%len(ids)], func() *Counter { return &Counter{} })
+			m.GetOrCreate(ids[i%len(ids)], func() *metrics.Counter { return &metrics.Counter{} })
 			i++
 		}
 	})
@@ -314,10 +309,10 @@ func BenchmarkGetOrCreateParallel(b *testing.B) {
 func BenchmarkMetrics(b *testing.B) {
 	for _, size := range []int{10, 100, 1000} {
 		b.Run(fmt.Sprintf("Size%d", size), func(b *testing.B) {
-			m := NewMetricMap[*Counter]()
+			m := metrics.NewMetricMap[*metrics.Counter]()
 			for i := range size {
-				id := MetricID{Name: fmt.Sprintf("metric%d", i)}
-				m.GetOrCreate(id, func() *Counter { return &Counter{} })
+				id := metrics.MetricID{Name: fmt.Sprintf("metric%d", i)}
+				m.GetOrCreate(id, func() *metrics.Counter { return &metrics.Counter{} })
 			}
 
 			b.ResetTimer()

--- a/common/go/metrics/metric_test.go
+++ b/common/go/metrics/metric_test.go
@@ -1,53 +1,57 @@
-package metrics
+package metrics_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+)
 
 func TestMetricIDEquals(t *testing.T) {
 	tests := []struct {
 		name string
-		a, b MetricID
+		a, b metrics.MetricID
 		want bool
 	}{
 		{
 			name: "Equal",
-			a:    MetricID{Name: "test", Labels: Labels{"a": "1"}},
-			b:    MetricID{Name: "test", Labels: Labels{"a": "1"}},
+			a:    metrics.MetricID{Name: "test", Labels: metrics.Labels{"a": "1"}},
+			b:    metrics.MetricID{Name: "test", Labels: metrics.Labels{"a": "1"}},
 			want: true,
 		},
 		{
 			name: "DifferentName",
-			a:    MetricID{Name: "test1"},
-			b:    MetricID{Name: "test2"},
+			a:    metrics.MetricID{Name: "test1"},
+			b:    metrics.MetricID{Name: "test2"},
 			want: false,
 		},
 		{
 			name: "DifferentLabelValue",
-			a:    MetricID{Name: "test", Labels: Labels{"a": "1"}},
-			b:    MetricID{Name: "test", Labels: Labels{"a": "2"}},
+			a:    metrics.MetricID{Name: "test", Labels: metrics.Labels{"a": "1"}},
+			b:    metrics.MetricID{Name: "test", Labels: metrics.Labels{"a": "2"}},
 			want: false,
 		},
 		{
 			name: "DifferentLabelKey",
-			a:    MetricID{Name: "test", Labels: Labels{"a": "1"}},
-			b:    MetricID{Name: "test", Labels: Labels{"b": "1"}},
+			a:    metrics.MetricID{Name: "test", Labels: metrics.Labels{"a": "1"}},
+			b:    metrics.MetricID{Name: "test", Labels: metrics.Labels{"b": "1"}},
 			want: false,
 		},
 		{
 			name: "DifferentLabelCount",
-			a:    MetricID{Name: "test", Labels: Labels{"a": "1"}},
-			b:    MetricID{Name: "test", Labels: Labels{"a": "1", "b": "2"}},
+			a:    metrics.MetricID{Name: "test", Labels: metrics.Labels{"a": "1"}},
+			b:    metrics.MetricID{Name: "test", Labels: metrics.Labels{"a": "1", "b": "2"}},
 			want: false,
 		},
 		{
 			name: "BothEmpty",
-			a:    MetricID{Name: "test"},
-			b:    MetricID{Name: "test"},
+			a:    metrics.MetricID{Name: "test"},
+			b:    metrics.MetricID{Name: "test"},
 			want: true,
 		},
 		{
 			name: "NilAndEmptyLabelsEqual",
-			a:    MetricID{Name: "test", Labels: nil},
-			b:    MetricID{Name: "test", Labels: Labels{}},
+			a:    metrics.MetricID{Name: "test", Labels: nil},
+			b:    metrics.MetricID{Name: "test", Labels: metrics.Labels{}},
 			want: true,
 		},
 	}

--- a/lint/encapsulation/allowlist-private.txt
+++ b/lint/encapsulation/allowlist-private.txt
@@ -19,21 +19,6 @@
 # stale. A stale entry is itself a lint failure, so paying down the debt
 # requires deleting the row — the ledger is self-cleaning by construction.
 
-common/go/metrics/histogram.go:Histogram.Observe:m.buckets[idx].count  # legacy: encapsulate behind an exported method or field
-common/go/metrics/histogram.go:Histogram.Observe:m.buckets[idx].upperBound  # legacy: encapsulate behind an exported method or field
-common/go/metrics/histogram.go:Histogram.Snapshot:m.buckets[i].count  # legacy: encapsulate behind an exported method or field
-common/go/metrics/histogram.go:Histogram.Snapshot:m.buckets[i].upperBound  # legacy: encapsulate behind an exported method or field
-common/go/metrics/histogram.go:NewHistogram:buckets[i].upperBound  # legacy: encapsulate behind an exported method or field
-common/go/metrics/histogram.go:NewHistogram:buckets[len(sorted)].upperBound  # legacy: encapsulate behind an exported method or field
-common/go/metrics/map.go:MetricMap.create:bucket[idx].id  # legacy: encapsulate behind an exported method or field
-common/go/metrics/map.go:MetricMap.create:bucket[idx].metric  # legacy: encapsulate behind an exported method or field
-common/go/metrics/map.go:MetricMap.create:m.entries[h][len(m.entries[h]) - 1].metric  # legacy: encapsulate behind an exported method or field
-common/go/metrics/map.go:MetricMap.DeleteWhere:entry.id  # legacy: encapsulate behind an exported method or field
-common/go/metrics/map.go:MetricMap.DeleteWhere:entry.metric  # legacy: encapsulate behind an exported method or field
-common/go/metrics/map.go:MetricMap.Metrics:bucket[i].id  # legacy: encapsulate behind an exported method or field
-common/go/metrics/map.go:MetricMap.Metrics:bucket[i].metric  # legacy: encapsulate behind an exported method or field
-common/go/metrics/map.go:MetricMap.tryGet:bucket[idx].id  # legacy: encapsulate behind an exported method or field
-common/go/metrics/map.go:MetricMap.tryGet:bucket[idx].metric  # legacy: encapsulate behind an exported method or field
 common/go/operator/operator.go:NewOperator:opts.GRPCServer.cfg  # legacy: encapsulate behind an exported method or field
 common/go/operator/operator.go:NewOperator:opts.GRPCServer.services  # legacy: encapsulate behind an exported method or field
 common/go/xbackoff/backoff.go:New:opts.jitter  # legacy: encapsulate behind an exported method or field

--- a/lint/encapsulation/allowlist-testpkg.txt
+++ b/lint/encapsulation/allowlist-testpkg.txt
@@ -27,9 +27,6 @@ common/go/bitset/bitset_test.go:bitset  # legacy: migrate to the external test p
 common/go/dataplane/packet_test.go:dataplane  # legacy: migrate to the external test package
 common/go/grpcmetrics/grpcmetrics_test.go:grpcmetrics  # legacy: migrate to the external test package
 common/go/maptrie/map_trie_test.go:maptrie  # legacy: migrate to the external test package
-common/go/metrics/histogram_test.go:metrics  # legacy: migrate to the external test package
-common/go/metrics/map_test.go:metrics  # legacy: migrate to the external test package
-common/go/metrics/metric_test.go:metrics  # legacy: migrate to the external test package
 common/go/operator/function_test.go:operator  # legacy: migrate to the external test package
 common/go/operator/server_test.go:operator  # legacy: migrate to the external test package
 common/go/xcfg/load_test.go:xcfg  # legacy: migrate to the external test package


### PR DESCRIPTION
Second entry of the encapsulation ledger burn-down. The histogram and the metric map reached directly into the fields of the small element types they own, from their own methods and from a free function. Both element types now expose the behaviour instead, and the 18 ledger entries recording that debt are removed.

The map's create path no longer reads the metric back out of the slice it just appended to, which removes one of those reaches outright rather than hiding it behind an accessor. The lookup predicate and the stored value are now answered by a single call rather than two. The guarantee that a delete predicate sees a cloned identifier now lives on the entry that owns it, and remains stated on the public method as well, since that is where consumers read it.

Tests move to the external test package, so the compiler rather than a linter forbids them from reaching into private state. The one test that verified storage is released when the last metric is deleted has no external observation point, so it now observes that through a new emptiness check. That check is the only public addition, and it is O(1) precisely because the storage is released.

Both element types stay unexported, so no consumer is affected. Behaviour was verified identical against the previous implementation across every bound set, boundary value and hash-collision case, including the construction and lookup paths.