### PR TITLE
feat(route): report per-outcome packet counters and config gauges

### DIFF
--- a/lint/encapsulation/allowlist-private.txt
+++ b/lint/encapsulation/allowlist-private.txt
@@ -150,8 +150,6 @@ modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopDstMAC
 modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopSrcMAC  # legacy: encapsulate behind an exported method or field
 modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.prefixFrom  # legacy: encapsulate behind an exported method or field
 modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.prefixTo  # legacy: encapsulate behind an exported method or field
-modules/route/bindings/go/croute/safe.go:ModuleConfig.FIBRangeCount:iter.destroy  # legacy: encapsulate behind an exported method or field
-modules/route/bindings/go/croute/safe.go:ModuleConfig.FIBRangeCount:iter.next  # legacy: encapsulate behind an exported method or field
 modules/route-mpls/controlplane/service.go:routeMPLSConfig.buildRules:nh.toFFI  # legacy: encapsulate behind an exported method or field
 modules/route-mpls/controlplane/service.go:RouteMPLSService.CreateConfig:config.buildRules  # legacy: encapsulate behind an exported method or field
 modules/route-mpls/controlplane/service.go:RouteMPLSService.CreateConfig:config.handle  # legacy: encapsulate behind an exported method or field

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -21,6 +21,63 @@ struct fib_iter {
 	enum fib_iter_phase phase;
 };
 
+int
+route_module_config_register_counters(
+	struct route_module_config *config, yanet_error **err
+) {
+	struct {
+		const char *name;
+		uint64_t size;
+		uint64_t *dst;
+	} counters[] = {
+		{"route_forwarded_v4", 2, &config->counters_v4.forwarded},
+		{"route_forwarded_v6", 2, &config->counters_v6.forwarded},
+		{"route_drop_no_route_v4", 2, &config->counters_v4.drop_no_route
+		},
+		{"route_drop_no_route_v6", 2, &config->counters_v6.drop_no_route
+		},
+		{"route_drop_ttl_expired_v4",
+		 2,
+		 &config->counters_v4.drop_ttl_expired},
+		{"route_drop_ttl_expired_v6",
+		 2,
+		 &config->counters_v6.drop_ttl_expired},
+		{"route_drop_non_ip", 2, &config->drop_non_ip_counter_id},
+		{"route_drop_empty_route_list_v4",
+		 2,
+		 &config->counters_v4.drop_empty_route_list},
+		{"route_drop_empty_route_list_v6",
+		 2,
+		 &config->counters_v6.drop_empty_route_list},
+		{"route_drop_device_unresolved_v4",
+		 2,
+		 &config->counters_v4.drop_device_unresolved},
+		{"route_drop_device_unresolved_v6",
+		 2,
+		 &config->counters_v6.drop_device_unresolved},
+	};
+
+	for (size_t i = 0; i < sizeof(counters) / sizeof(counters[0]); ++i) {
+		uint64_t id = counter_registry_register(
+			&config->cp_module.counter_registry,
+			counters[i].name,
+			counters[i].size,
+			err
+		);
+		if (id == (uint64_t)-1) {
+			yanet_error_add(
+				err,
+				"failed to register counter '%s'",
+				counters[i].name
+			);
+			return -1;
+		}
+		*counters[i].dst = id;
+	}
+
+	return 0;
+}
+
 struct cp_module *
 route_module_config_new(
 	struct agent *agent, const char *name, yanet_error **err
@@ -55,6 +112,11 @@ route_module_config_new(
 			config,
 			sizeof(struct route_module_config)
 		);
+		return NULL;
+	}
+
+	if (route_module_config_register_counters(config, err)) {
+		route_module_config_free(&config->cp_module);
 		return NULL;
 	}
 
@@ -246,6 +308,46 @@ route_module_config_add_prefix_v6(
 	struct route_module_config *config =
 		container_of(cp_module, struct route_module_config, cp_module);
 	return lpm_insert(&config->lpm_v6, 16, from, to, route_list_index);
+}
+
+// Counts the LPM ranges over the whole key space of the given tree.
+static uint64_t
+route_lpm_range_count(const struct lpm *lpm, uint8_t key_size) {
+	uint8_t from[LPM_KEY_SIZE_MAX];
+	uint8_t to[LPM_KEY_SIZE_MAX];
+	memset(from, 0x00, key_size);
+	memset(to, 0xff, key_size);
+
+	struct lpm_iter it;
+	lpm_iter_init(&it, lpm, key_size, from, to);
+
+	uint64_t count = 0;
+	while (lpm_iter_next(&it)) {
+		++count;
+	}
+
+	return count;
+}
+
+uint64_t
+route_module_config_route_count(struct cp_module *cp_module) {
+	struct route_module_config *config =
+		container_of(cp_module, struct route_module_config, cp_module);
+	return config->route_count;
+}
+
+uint64_t
+route_module_config_fib_range_count_v4(struct cp_module *cp_module) {
+	struct route_module_config *config =
+		container_of(cp_module, struct route_module_config, cp_module);
+	return route_lpm_range_count(&config->lpm_v4, 4);
+}
+
+uint64_t
+route_module_config_fib_range_count_v6(struct cp_module *cp_module) {
+	struct route_module_config *config =
+		container_of(cp_module, struct route_module_config, cp_module);
+	return route_lpm_range_count(&config->lpm_v6, 16);
 }
 
 struct fib_iter *

--- a/modules/route/api/controlplane.h
+++ b/modules/route/api/controlplane.h
@@ -36,6 +36,16 @@ route_module_config_data_init(
 	struct memory_context *memory_context
 );
 
+// Registers the module-level counters and records their ids in the config.
+//
+// The counter registry must already be initialized. Callers that build a
+// config without route_module_config_new have to invoke this themselves,
+// otherwise the handler reads unregistered counter ids.
+int
+route_module_config_register_counters(
+	struct route_module_config *config, yanet_error **err
+);
+
 int
 route_module_config_add_route(
 	struct cp_module *cp_module,
@@ -65,6 +75,24 @@ route_module_config_add_prefix_v6(
 	const uint8_t *to,
 	uint32_t route_list_index
 );
+
+// Returns the number of distinct hardware routes held by the config.
+uint64_t
+route_module_config_route_count(struct cp_module *cp_module);
+
+// Returns the number of IPv4 FIB ranges.
+//
+// Counts the same ranges a FIB iterator would yield for the IPv4 LPM, without
+// materializing any of them.
+uint64_t
+route_module_config_fib_range_count_v4(struct cp_module *cp_module);
+
+// Returns the number of IPv6 FIB ranges.
+//
+// Counts the same ranges a FIB iterator would yield for the IPv6 LPM, without
+// materializing any of them.
+uint64_t
+route_module_config_fib_range_count_v6(struct cp_module *cp_module);
 
 // Create a FIB iterator for the given module config.
 //

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -124,6 +124,32 @@ func (m *ModuleConfig) addPrefixV6(from [16]byte, to [16]byte, routeListIndex ui
 	return nil
 }
 
+// RouteCount returns the number of distinct hardware nexthops held by the
+// config.
+//
+// Despite the name, which mirrors the C symbol, this is not a route count
+// in the routing sense: it counts the resolved forwarding targets, each a
+// distinct (dst MAC, src MAC, device) triple, that prefixes point at.
+func (m *ModuleConfig) RouteCount() uint64 {
+	return uint64(C.route_module_config_route_count(m.asRawPtr()))
+}
+
+// FIBRangeCountV4 returns the number of IPv4 FIB ranges.
+//
+// The count is computed inside the C API without materializing any range,
+// which makes it cheap enough for a metrics scrape.
+func (m *ModuleConfig) FIBRangeCountV4() uint64 {
+	return uint64(C.route_module_config_fib_range_count_v4(m.asRawPtr()))
+}
+
+// FIBRangeCountV6 returns the number of IPv6 FIB ranges.
+//
+// The count is computed inside the C API without materializing any range,
+// which makes it cheap enough for a metrics scrape.
+func (m *ModuleConfig) FIBRangeCountV6() uint64 {
+	return uint64(C.route_module_config_fib_range_count_v6(m.asRawPtr()))
+}
+
 // fibIter wraps the C fib_iter handle.
 type fibIter struct {
 	ptr *C.struct_fib_iter

--- a/modules/route/bindings/go/croute/safe.go
+++ b/modules/route/bindings/go/croute/safe.go
@@ -120,20 +120,3 @@ func (m *ModuleConfig) DumpFIB() ([]FIBEntry, error) {
 
 	return entries, nil
 }
-
-// FIBRangeCount returns the number of FIB ranges, equivalent to
-// len(DumpFIB()) but far cheaper — use it when only the count is needed,
-// e.g. for a metrics gauge.
-func (m *ModuleConfig) FIBRangeCount() (int, error) {
-	iter, err := newFIBIter(m)
-	if err != nil {
-		return 0, fmt.Errorf("failed to create FIB iterator: %w", err)
-	}
-	defer iter.destroy()
-
-	count := 0
-	for iter.next() {
-		count++
-	}
-	return count, nil
-}

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -17,15 +17,34 @@ import (
 // memory.
 type ModuleHandle interface {
 	DumpFIB() ([]croute.FIBEntry, error)
-	// FIBRangeCount returns the number of FIB ranges, equivalent to
-	// len(DumpFIB()) but far cheaper to compute.
-	FIBRangeCount() (int, error)
+	// RouteCount returns the number of distinct hardware nexthops the
+	// config resolves prefixes to.
+	RouteCount() uint64
+	// FIBRangeCountV4 returns the number of IPv4 FIB ranges, equivalent
+	// to counting the IPv4 entries of DumpFIB but far cheaper.
+	FIBRangeCountV4() uint64
+	// FIBRangeCountV6 returns the number of IPv6 FIB ranges, equivalent
+	// to counting the IPv6 entries of DumpFIB but far cheaper.
+	FIBRangeCountV6() uint64
 	Free()
 }
 
 // Compile-time assertion that *croute.ModuleConfig satisfies the
 // ModuleHandle interface; catches drift in the bindings layer.
 var _ ModuleHandle = (*croute.ModuleConfig)(nil)
+
+// CounterView is a single dataplane counter read back from one position at
+// which a route config is installed.
+type CounterView struct {
+	Device   string
+	Pipeline string
+	Function string
+	Chain    string
+	Name     string
+	// Values holds the counter slots per worker instance, indexed as
+	// [instance][slot].
+	Values [][]uint64
+}
 
 // Backend abstracts shared memory write-path operations for the route
 // module.
@@ -35,6 +54,9 @@ type Backend interface {
 	UpdateModule(name string, entries []*routepb.FIBEntry) (ModuleHandle, error)
 	// DeleteModule removes a module config from the dataplane.
 	DeleteModule(name string) error
+	// ModuleCounters reads the named counters back from every position
+	// at which the named config is installed.
+	ModuleCounters(name string, counterNames []string) []CounterView
 }
 
 // backend is the real Backend implementation backed by shared memory.
@@ -121,6 +143,39 @@ func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (Module
 
 func (m *backend) DeleteModule(name string) error {
 	return m.agent.DeleteModuleConfig(name)
+}
+
+func (m *backend) ModuleCounters(name string, counterNames []string) []CounterView {
+	dpConfig := m.agent.DPConfig()
+
+	var views []CounterView
+	for pos := range dpConfig.AllModulePositions(agentName) {
+		if pos.ModuleName != name {
+			continue
+		}
+
+		infos := dpConfig.ModuleCounters(
+			pos.Device,
+			pos.Pipeline,
+			pos.Function,
+			pos.Chain,
+			agentName,
+			name,
+			counterNames,
+		)
+		for _, info := range infos {
+			views = append(views, CounterView{
+				Device:   pos.Device,
+				Pipeline: pos.Pipeline,
+				Function: pos.Function,
+				Chain:    pos.Chain,
+				Name:     info.Name,
+				Values:   info.Values,
+			})
+		}
+	}
+
+	return views
 }
 
 // HardwareRoute represents a route in the Layer 2 (L2) networking stack.

--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -2,6 +2,8 @@ package route
 
 import (
 	"context"
+	"maps"
+	"slices"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	routepb "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
@@ -40,4 +42,109 @@ func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.
 		Labels: labels,
 		Value:  &commonpb.Metric_Gauge{Gauge: value},
 	}
+}
+
+// makeCounter builds a counter metric with the provided name, value, and labels.
+func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &commonpb.Metric_Counter{Counter: value},
+	}
+}
+
+// counterMapping projects one route dataplane counter onto the metric family
+// that carries it.
+type counterMapping struct {
+	// Metric is the emitted metric family, without the _packets or
+	// _bytes suffix.
+	Metric string
+	// Reason names the drop cause behind the counter.
+	//
+	// Empty for families that carry no reason label.
+	Reason string
+	// Family is the address family the counter observes.
+	Family string
+}
+
+// counterMappings is the control plane's half of the counter contract with
+// the route dataplane.
+//
+// Every counter the dataplane registers is spelled out here exactly once,
+// so the table doubles as the documentation of what each series means. A
+// counter missing from the table is never requested and never exported.
+var counterMappings = map[string]counterMapping{
+	"route_forwarded_v4": {Metric: "route_forwarded", Family: "v4"},
+	"route_forwarded_v6": {Metric: "route_forwarded", Family: "v6"},
+
+	"route_drop_no_route_v4": {Metric: "route_drop", Reason: "no_route", Family: "v4"},
+	"route_drop_no_route_v6": {Metric: "route_drop", Reason: "no_route", Family: "v6"},
+
+	"route_drop_ttl_expired_v4": {Metric: "route_drop", Reason: "ttl_expired", Family: "v4"},
+	"route_drop_ttl_expired_v6": {Metric: "route_drop", Reason: "ttl_expired", Family: "v6"},
+
+	// The ethertype is not IP, so the drop has no address family to
+	// report.
+	"route_drop_non_ip": {Metric: "route_drop", Reason: "non_ip", Family: "unknown"},
+
+	"route_drop_empty_route_list_v4": {Metric: "route_drop", Reason: "empty_route_list", Family: "v4"},
+	"route_drop_empty_route_list_v6": {Metric: "route_drop", Reason: "empty_route_list", Family: "v6"},
+
+	"route_drop_device_unresolved_v4": {Metric: "route_drop", Reason: "device_unresolved", Family: "v4"},
+	"route_drop_device_unresolved_v6": {Metric: "route_drop", Reason: "device_unresolved", Family: "v6"},
+}
+
+// counterNames is the counter query sent to the dataplane, sorted so the
+// request is stable across scrapes.
+var counterNames = slices.Sorted(maps.Keys(counterMappings))
+
+// collectDataplaneMetrics gathers the module-level packet and byte counters
+// of every config, summed across worker instances.
+//
+// Every known counter is emitted even when it reads zero. A series that
+// disappears and reappears breaks rate() in Prometheus, and the empty route
+// list counters are invariant canaries expected to read zero forever, which
+// only works if they are visible.
+func (m *RouteService) collectDataplaneMetrics() []*commonpb.Metric {
+	m.shmLock.RLock()
+	defer m.shmLock.RUnlock()
+
+	result := make([]*commonpb.Metric, 0)
+	for configName := range m.configs {
+		for _, counter := range m.backend.ModuleCounters(configName, counterNames) {
+			mapping, ok := counterMappings[counter.Name]
+			if !ok {
+				continue
+			}
+
+			var packets, bytes uint64
+			for _, instance := range counter.Values {
+				if len(instance) > 0 {
+					packets += instance[0]
+				}
+				if len(instance) > 1 {
+					bytes += instance[1]
+				}
+			}
+
+			labels := []*commonpb.Label{
+				{Name: "config", Value: configName},
+				{Name: "device", Value: counter.Device},
+				{Name: "pipeline", Value: counter.Pipeline},
+				{Name: "function", Value: counter.Function},
+				{Name: "chain", Value: counter.Chain},
+				{Name: "family", Value: mapping.Family},
+			}
+			if mapping.Reason != "" {
+				labels = append(labels, &commonpb.Label{Name: "reason", Value: mapping.Reason})
+			}
+
+			result = append(result,
+				makeCounter(mapping.Metric+"_packets", packets, labels...),
+				makeCounter(mapping.Metric+"_bytes", bytes, labels...),
+			)
+		}
+	}
+
+	return result
 }

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -76,7 +76,6 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 
 	service := NewRouteService(
 		NewBackend(agent),
-		WithRouteServiceLog(log),
 		WithMetrics(grpcmetrics.NewFactory(
 			grpcmetrics.WithLabeler(labeler),
 		)),

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"sort"
 	"sync"
+	"time"
 
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -22,20 +22,10 @@ type RouteServiceOption func(*routeServiceOptions)
 
 type routeServiceOptions struct {
 	Metrics grpcmetrics.Factory
-	Log     *zap.Logger
 }
 
 func newRouteServiceOptions() *routeServiceOptions {
-	return &routeServiceOptions{
-		Log: zap.NewNop(),
-	}
-}
-
-// WithRouteServiceLog sets the logger for the RouteService.
-func WithRouteServiceLog(log *zap.Logger) RouteServiceOption {
-	return func(o *routeServiceOptions) {
-		o.Log = log
-	}
+	return &routeServiceOptions{}
 }
 
 // WithMetrics sets the gRPC metrics factory.
@@ -45,6 +35,27 @@ func WithMetrics(factory grpcmetrics.Factory) RouteServiceOption {
 	return func(o *routeServiceOptions) {
 		o.Metrics = factory
 	}
+}
+
+// configEntry is one route config applied to shared memory, together with
+// the facts measured at the moment it was applied.
+//
+// A config's FIB is immutable once published: every update builds a fresh
+// handle and retires the previous one. The sizes are therefore measured
+// once here rather than walked out of the LPM keyspace on every scrape.
+type configEntry struct {
+	// Handle owns the published shared-memory config generation.
+	Handle ModuleHandle
+	// FIBRangeCountV4 is the number of IPv4 FIB ranges the config holds.
+	FIBRangeCountV4 uint64
+	// FIBRangeCountV6 is the number of IPv6 FIB ranges the config holds.
+	FIBRangeCountV6 uint64
+	// NexthopCount is the number of distinct hardware nexthops the config
+	// resolves its prefixes to.
+	NexthopCount uint64
+	// UpdatedAt is when the FIB was applied to the dataplane, and backs
+	// the staleness gauge.
+	UpdatedAt time.Time
 }
 
 // RouteService is the gRPC service implementation backing the slim
@@ -57,11 +68,9 @@ type RouteService struct {
 	// shmLock serializes shared-memory mutations and protects the
 	// configs map.
 	shmLock sync.RWMutex
-	configs map[string]ModuleHandle
+	configs map[string]configEntry
 
 	metrics *grpcmetrics.ServerMetrics
-
-	log *zap.Logger
 }
 
 // NewRouteService builds a RouteService bound to the supplied backend.
@@ -73,8 +82,7 @@ func NewRouteService(backend Backend, options ...RouteServiceOption) *RouteServi
 
 	m := &RouteService{
 		backend: backend,
-		configs: map[string]ModuleHandle{},
-		log:     opts.Log,
+		configs: map[string]configEntry{},
 	}
 	if opts.Metrics != nil {
 		m.metrics = opts.Metrics(m.retention)
@@ -162,12 +170,12 @@ func (m *RouteService) ShowFIB(
 	m.shmLock.RLock()
 	defer m.shmLock.RUnlock()
 
-	module, ok := m.configs[name]
+	entry, ok := m.configs[name]
 	if !ok {
 		return &routepb.ShowFIBResponse{}, nil
 	}
 
-	entries, err := module.DumpFIB()
+	entries, err := entry.Handle.DumpFIB()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to dump FIB: %v", err)
 	}
@@ -218,7 +226,7 @@ func (m *RouteService) DeleteConfig(
 	m.shmLock.Lock()
 	defer m.shmLock.Unlock()
 
-	module, ok := m.configs[name]
+	entry, ok := m.configs[name]
 	if !ok {
 		return &routepb.DeleteConfigResponse{}, nil
 	}
@@ -226,7 +234,7 @@ func (m *RouteService) DeleteConfig(
 	if err := m.backend.DeleteModule(name); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
 	}
-	module.Free()
+	entry.Handle.Free()
 	delete(m.configs, name)
 
 	return &routepb.DeleteConfigResponse{}, nil
@@ -251,51 +259,83 @@ func (m *RouteService) UpdateFIB(
 	}
 
 	if old, ok := m.configs[name]; ok {
-		old.Free()
+		old.Handle.Free()
 	}
-	m.configs[name] = module
+
+	// The counts are read once, here, off the handle just published: the
+	// FIB never changes again for this generation, and each read walks the
+	// LPM keyspace.
+	m.configs[name] = configEntry{
+		Handle:          module,
+		FIBRangeCountV4: module.FIBRangeCountV4(),
+		FIBRangeCountV6: module.FIBRangeCountV6(),
+		NexthopCount:    module.RouteCount(),
+		UpdatedAt:       time.Now(),
+	}
 
 	return &routepb.UpdateFIBResponse{}, nil
 }
 
-// Metrics returns all route module metrics: per-config FIB size gauges, plus
-// gRPC call metrics.
+// Metrics returns all route module metrics: per-config FIB gauges, the
+// module-level dataplane counters, plus gRPC call metrics.
 //
 // Labels:
-//   - config:       route config name (all gauge metrics)
+//   - config:       route config name (all gauge and counter metrics)
+//   - family:       address family, "v4", "v6", or "unknown" when the
+//     ethertype was not IP (route_fib_entries, route_forwarded_*,
+//     route_drop_*)
+//   - device:       dataplane device name (all dataplane counter metrics)
+//   - pipeline:     pipeline name (all dataplane counter metrics)
+//   - function:     pipeline function name (all dataplane counter metrics)
+//   - chain:        pipeline chain name (all dataplane counter metrics)
+//   - reason:       drop cause (route_drop_packets / route_drop_bytes only)
 //   - grpc_type:    always "unary" (gRPC metrics)
 //   - grpc_service: fully-qualified gRPC service name (gRPC metrics)
 //   - grpc_method:  RPC name (gRPC metrics)
 //   - grpc_code:    gRPC status code string (grpc_server_handled_total only)
 func (m *RouteService) Metrics() ([]*commonpb.Metric, error) {
 	result := m.collectConfigMetrics()
+	result = append(result, m.collectDataplaneMetrics()...)
 	if m.metrics != nil {
 		result = append(result, m.metrics.Collect()...)
 	}
 	return result, nil
 }
 
-// collectConfigMetrics gathers per-config gauges on a best-effort basis: a
-// dump failure for one config is logged and skipped so the remaining configs
-// still contribute their series.
+// collectConfigMetrics gathers the gauges describing what each config
+// currently holds in shared memory, and when it was last applied.
+//
+// The FIB size is reported per address family, so the combined total stays
+// derivable as a sum over the family label. Every value was measured when
+// the config was applied, so a scrape costs no shared-memory traversal.
 func (m *RouteService) collectConfigMetrics() []*commonpb.Metric {
 	m.shmLock.RLock()
 	defer m.shmLock.RUnlock()
 
-	result := make([]*commonpb.Metric, 0, len(m.configs))
-	for name, module := range m.configs {
-		labels := []*commonpb.Label{{Name: "config", Value: name}}
-
-		count, err := module.FIBRangeCount()
-		if err != nil {
-			m.log.Warn("failed to collect fib metrics for config",
-				zap.String("config", name),
-				zap.Error(err),
-			)
-			continue
+	result := make([]*commonpb.Metric, 0, 4*len(m.configs))
+	for name, entry := range m.configs {
+		configLabels := []*commonpb.Label{
+			{Name: "config", Value: name},
+		}
+		v4Labels := []*commonpb.Label{
+			{Name: "config", Value: name},
+			{Name: "family", Value: "v4"},
+		}
+		v6Labels := []*commonpb.Label{
+			{Name: "config", Value: name},
+			{Name: "family", Value: "v6"},
 		}
 
-		result = append(result, makeGauge("route_fib_entries", float64(count), labels...))
+		result = append(result,
+			makeGauge("route_fib_entries", float64(entry.FIBRangeCountV4), v4Labels...),
+			makeGauge("route_fib_entries", float64(entry.FIBRangeCountV6), v6Labels...),
+			makeGauge("route_nexthops", float64(entry.NexthopCount), configLabels...),
+			makeGauge(
+				"route_config_updated_timestamp_seconds",
+				float64(entry.UpdatedAt.Unix()),
+				configLabels...,
+			),
+		)
 	}
 
 	return result

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -1,0 +1,386 @@
+package route_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
+	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
+	routepb "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
+)
+
+// fakeHandle is an in-memory implementation of route.ModuleHandle.
+type fakeHandle struct {
+	routeCount uint64
+	rangesV4   uint64
+	rangesV6   uint64
+	freed      bool
+}
+
+func (m *fakeHandle) DumpFIB() ([]croute.FIBEntry, error) {
+	return nil, nil
+}
+
+func (m *fakeHandle) RouteCount() uint64 {
+	return m.routeCount
+}
+
+func (m *fakeHandle) FIBRangeCountV4() uint64 {
+	return m.rangesV4
+}
+
+func (m *fakeHandle) FIBRangeCountV6() uint64 {
+	return m.rangesV6
+}
+
+func (m *fakeHandle) Free() {
+	m.freed = true
+}
+
+// fakeBackend is an in-memory implementation of route.Backend.
+type fakeBackend struct {
+	mu       sync.Mutex
+	handle   *fakeHandle
+	counters []route.CounterView
+	// queried records the counter names the service asked for.
+	queried []string
+}
+
+func newFakeBackend() *fakeBackend {
+	return &fakeBackend{handle: &fakeHandle{}}
+}
+
+func (m *fakeBackend) UpdateModule(name string, entries []*routepb.FIBEntry) (route.ModuleHandle, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.handle, nil
+}
+
+func (m *fakeBackend) DeleteModule(name string) error {
+	return nil
+}
+
+func (m *fakeBackend) ModuleCounters(name string, counterNames []string) []route.CounterView {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.queried = counterNames
+	return m.counters
+}
+
+// newServiceWithConfig returns a service holding a single applied config
+// named "cfg", backed by the supplied backend.
+func newServiceWithConfig(t *testing.T, backend route.Backend) *route.RouteService {
+	t.Helper()
+
+	service := route.NewRouteService(backend)
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{ModuleName: "cfg"})
+	require.NoError(t, err)
+
+	return service
+}
+
+// counterView builds a dataplane counter reading for the fixed position used
+// throughout these tests.
+func counterView(name string, values [][]uint64) route.CounterView {
+	return route.CounterView{
+		Device:   "dev0",
+		Pipeline: "pipe0",
+		Function: "func0",
+		Chain:    "chain0",
+		Name:     name,
+		Values:   values,
+	}
+}
+
+// labelsOf returns the metric's labels as a name-to-value map.
+func labelsOf(metric *commonpb.Metric) map[string]string {
+	result := map[string]string{}
+	for _, label := range metric.GetLabels() {
+		result[label.GetName()] = label.GetValue()
+	}
+
+	return result
+}
+
+// findMetrics returns every emitted series carrying the given metric name.
+func findMetrics(all []*commonpb.Metric, name string) []*commonpb.Metric {
+	var result []*commonpb.Metric
+	for _, metric := range all {
+		if metric.GetName() == name {
+			result = append(result, metric)
+		}
+	}
+
+	return result
+}
+
+// requireMetric returns the single series with the given name whose labels
+// contain every entry of want.
+func requireMetric(t *testing.T, all []*commonpb.Metric, name string, want map[string]string) *commonpb.Metric {
+	t.Helper()
+
+	var matches []*commonpb.Metric
+	for _, metric := range findMetrics(all, name) {
+		labels := labelsOf(metric)
+		matched := true
+		for key, value := range want {
+			if labels[key] != value {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			matches = append(matches, metric)
+		}
+	}
+
+	require.Len(t, matches, 1, "expected exactly one %q series with labels %v", name, want)
+	return matches[0]
+}
+
+// TestDataplaneCounterMapping verifies that each counter the route dataplane
+// registers lands on the agreed metric family, reason, and address family.
+func TestDataplaneCounterMapping(t *testing.T) {
+	tests := []struct {
+		counterName string
+		metricName  string
+		reason      string
+		family      string
+	}{
+		{"route_forwarded_v4", "route_forwarded", "", "v4"},
+		{"route_forwarded_v6", "route_forwarded", "", "v6"},
+		{"route_drop_no_route_v4", "route_drop", "no_route", "v4"},
+		{"route_drop_no_route_v6", "route_drop", "no_route", "v6"},
+		{"route_drop_ttl_expired_v4", "route_drop", "ttl_expired", "v4"},
+		{"route_drop_ttl_expired_v6", "route_drop", "ttl_expired", "v6"},
+		{"route_drop_non_ip", "route_drop", "non_ip", "unknown"},
+		{"route_drop_empty_route_list_v4", "route_drop", "empty_route_list", "v4"},
+		{"route_drop_empty_route_list_v6", "route_drop", "empty_route_list", "v6"},
+		{"route_drop_device_unresolved_v4", "route_drop", "device_unresolved", "v4"},
+		{"route_drop_device_unresolved_v6", "route_drop", "device_unresolved", "v6"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.counterName, func(t *testing.T) {
+			backend := newFakeBackend()
+			backend.counters = []route.CounterView{
+				counterView(test.counterName, [][]uint64{{7, 700}}),
+			}
+
+			service := newServiceWithConfig(t, backend)
+
+			all, err := service.Metrics()
+			require.NoError(t, err)
+
+			wantLabels := map[string]string{
+				"config":   "cfg",
+				"device":   "dev0",
+				"pipeline": "pipe0",
+				"function": "func0",
+				"chain":    "chain0",
+				"family":   test.family,
+			}
+			if test.reason != "" {
+				wantLabels["reason"] = test.reason
+			}
+
+			packets := requireMetric(t, all, test.metricName+"_packets", wantLabels)
+			require.Equal(t, uint64(7), packets.GetCounter())
+
+			bytes := requireMetric(t, all, test.metricName+"_bytes", wantLabels)
+			require.Equal(t, uint64(700), bytes.GetCounter())
+
+			// A forwarded counter carries no drop reason at all,
+			// rather than an empty one.
+			if test.reason == "" {
+				require.NotContains(t, labelsOf(packets), "reason")
+			}
+		})
+	}
+}
+
+// TestDataplaneCounterQueryCoversContract verifies that the service asks the
+// dataplane for every counter it knows how to map.
+func TestDataplaneCounterQueryCoversContract(t *testing.T) {
+	backend := newFakeBackend()
+	service := newServiceWithConfig(t, backend)
+
+	_, err := service.Metrics()
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{
+		"route_forwarded_v4",
+		"route_forwarded_v6",
+		"route_drop_no_route_v4",
+		"route_drop_no_route_v6",
+		"route_drop_ttl_expired_v4",
+		"route_drop_ttl_expired_v6",
+		"route_drop_non_ip",
+		"route_drop_empty_route_list_v4",
+		"route_drop_empty_route_list_v6",
+		"route_drop_device_unresolved_v4",
+		"route_drop_device_unresolved_v6",
+	}, backend.queried)
+}
+
+// TestDataplaneMetricsEmitZeroCounters verifies that a counter reading zero is
+// still exported, so a canary that is meant to stay at zero remains visible
+// and rate() never sees the series vanish.
+func TestDataplaneMetricsEmitZeroCounters(t *testing.T) {
+	backend := newFakeBackend()
+	backend.counters = []route.CounterView{
+		counterView("route_drop_empty_route_list_v4", [][]uint64{{0, 0}}),
+		counterView("route_forwarded_v6", [][]uint64{{0, 0}, {0, 0}}),
+	}
+
+	service := newServiceWithConfig(t, backend)
+
+	all, err := service.Metrics()
+	require.NoError(t, err)
+
+	drop := requireMetric(t, all, "route_drop_packets", map[string]string{
+		"reason": "empty_route_list",
+		"family": "v4",
+	})
+	require.Equal(t, uint64(0), drop.GetCounter())
+
+	forwarded := requireMetric(t, all, "route_forwarded_bytes", map[string]string{
+		"family": "v6",
+	})
+	require.Equal(t, uint64(0), forwarded.GetCounter())
+}
+
+// TestDataplaneMetricsSumWorkerInstances verifies that the per-worker slots of
+// a counter are added up into a single series.
+func TestDataplaneMetricsSumWorkerInstances(t *testing.T) {
+	backend := newFakeBackend()
+	backend.counters = []route.CounterView{
+		counterView("route_forwarded_v4", [][]uint64{{1, 100}, {2, 200}, {3, 300}}),
+	}
+
+	service := newServiceWithConfig(t, backend)
+
+	all, err := service.Metrics()
+	require.NoError(t, err)
+
+	packets := requireMetric(t, all, "route_forwarded_packets", map[string]string{"family": "v4"})
+	require.Equal(t, uint64(6), packets.GetCounter())
+
+	bytes := requireMetric(t, all, "route_forwarded_bytes", map[string]string{"family": "v4"})
+	require.Equal(t, uint64(600), bytes.GetCounter())
+}
+
+// requireConfigGauges asserts the three per-config gauges of "cfg" read back
+// the supplied IPv4 range, IPv6 range, and nexthop counts.
+func requireConfigGauges(t *testing.T, service *route.RouteService, rangesV4, rangesV6, nexthopCount float64) {
+	t.Helper()
+
+	all, err := service.Metrics()
+	require.NoError(t, err)
+
+	v4 := requireMetric(t, all, "route_fib_entries", map[string]string{"config": "cfg", "family": "v4"})
+	require.Equal(t, rangesV4, v4.GetGauge())
+
+	v6 := requireMetric(t, all, "route_fib_entries", map[string]string{"config": "cfg", "family": "v6"})
+	require.Equal(t, rangesV6, v6.GetGauge())
+
+	nexthops := requireMetric(t, all, "route_nexthops", map[string]string{"config": "cfg"})
+	require.Equal(t, nexthopCount, nexthops.GetGauge())
+}
+
+// TestConfigGauges verifies that the FIB size is reported per address family
+// and that the hardware nexthop count is reported once per config.
+func TestConfigGauges(t *testing.T) {
+	backend := newFakeBackend()
+	backend.handle = &fakeHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
+
+	service := newServiceWithConfig(t, backend)
+
+	requireConfigGauges(t, service, 11, 23, 5)
+
+	all, err := service.Metrics()
+	require.NoError(t, err)
+	nexthops := requireMetric(t, all, "route_nexthops", map[string]string{"config": "cfg"})
+	require.NotContains(t, labelsOf(nexthops), "family")
+}
+
+// TestConfigGaugesMeasuredAtApply verifies that the gauges are measured once
+// when the config is applied, rather than read off the handle on every
+// scrape.
+func TestConfigGaugesMeasuredAtApply(t *testing.T) {
+	backend := newFakeBackend()
+	handle := &fakeHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
+	backend.handle = handle
+
+	service := newServiceWithConfig(t, backend)
+	requireConfigGauges(t, service, 11, 23, 5)
+
+	// A published FIB never changes, so a scrape must not consult the
+	// handle again. Moving the counts underneath the service is the only
+	// way to observe whether it does.
+	handle.routeCount = 6
+	handle.rangesV4 = 12
+	handle.rangesV6 = 24
+
+	requireConfigGauges(t, service, 11, 23, 5)
+}
+
+// TestConfigGaugesFollowLatestApply verifies that re-applying a FIB retires
+// the previous handle and republishes the gauges from the new one.
+func TestConfigGaugesFollowLatestApply(t *testing.T) {
+	backend := newFakeBackend()
+	first := &fakeHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
+	backend.handle = first
+
+	service := newServiceWithConfig(t, backend)
+	requireConfigGauges(t, service, 11, 23, 5)
+
+	backend.handle = &fakeHandle{routeCount: 1, rangesV4: 2, rangesV6: 3}
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{ModuleName: "cfg"})
+	require.NoError(t, err)
+
+	requireConfigGauges(t, service, 2, 3, 1)
+	require.True(t, first.freed, "the retired handle must be freed")
+}
+
+// TestConfigGaugesFollowConfigLifetime verifies that the per-config gauges
+// appear once a FIB is applied, do not outlive their config, and carry
+// nothing over from a deleted config of the same name.
+func TestConfigGaugesFollowConfigLifetime(t *testing.T) {
+	backend := newFakeBackend()
+	backend.handle = &fakeHandle{routeCount: 5, rangesV4: 11, rangesV6: 23}
+	service := route.NewRouteService(backend)
+
+	all, err := service.Metrics()
+	require.NoError(t, err)
+	require.Empty(t, findMetrics(all, "route_config_updated_timestamp_seconds"))
+	require.Empty(t, findMetrics(all, "route_fib_entries"))
+
+	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{ModuleName: "cfg"})
+	require.NoError(t, err)
+
+	all, err = service.Metrics()
+	require.NoError(t, err)
+	updated := requireMetric(t, all, "route_config_updated_timestamp_seconds", map[string]string{"config": "cfg"})
+	require.Positive(t, updated.GetGauge())
+
+	_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
+	require.NoError(t, err)
+
+	all, err = service.Metrics()
+	require.NoError(t, err)
+	require.Empty(t, findMetrics(all, "route_config_updated_timestamp_seconds"))
+	require.Empty(t, findMetrics(all, "route_fib_entries"))
+	require.Empty(t, findMetrics(all, "route_nexthops"))
+
+	backend.handle = &fakeHandle{routeCount: 1, rangesV4: 2, rangesV6: 3}
+	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{ModuleName: "cfg"})
+	require.NoError(t, err)
+
+	requireConfigGauges(t, service, 2, 3, 1)
+}

--- a/modules/route/dataplane/config.h
+++ b/modules/route/dataplane/config.h
@@ -20,6 +20,20 @@ struct route_list {
 	uint64_t count;
 };
 
+// Counter ids of a single address family.
+//
+// The ethertype test already selects a family per packet, so the handler
+// points at the matching set there and the shared tail stays family agnostic.
+// The sets live in the config so that selecting one costs a pointer and the
+// handler builds nothing per invocation.
+struct route_family_counter_ids {
+	uint64_t forwarded;
+	uint64_t drop_no_route;
+	uint64_t drop_ttl_expired;
+	uint64_t drop_empty_route_list;
+	uint64_t drop_device_unresolved;
+};
+
 /*
  * Route module configuration. Handler lookups route list index using
  * corresponding lpm and retrieves start position and count of applicable
@@ -43,4 +57,12 @@ struct route_module_config {
 	// Route indexes storage
 	uint64_t route_index_count;
 	uint64_t *route_indexes;
+
+	// Module-level counters, registered by route_module_config_new
+	struct route_family_counter_ids counters_v4;
+	struct route_family_counter_ids counters_v6;
+
+	// A non-IP packet has no address family, so its drop counter is
+	// shared rather than kept in a per-family set.
+	uint64_t drop_non_ip_counter_id;
 };

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -20,14 +20,42 @@ struct route_module {
 	struct module module;
 };
 
+// Why a packet could not be routed.
+//
+// Meaningful only when route_handle_v4 or route_handle_v6 return
+// LPM_VALUE_INVALID. The two are worth telling apart: an expired TTL is
+// ordinary traceroute traffic, while a lookup miss is a blackhole.
+enum route_drop_reason {
+	ROUTE_DROP_TTL_EXPIRED,
+	ROUTE_DROP_NO_ROUTE,
+};
+
+static inline void
+route_count_packet(
+	struct module_ectx *module_ectx,
+	uint64_t counter_id,
+	struct packet *packet
+) {
+	uint64_t *counters = counter_get_address(
+		counter_id, ADDR_OF_NONNULL(&module_ectx->counter_storage)
+	);
+	counters[0] += 1;
+	counters[1] += packet_data_len(packet);
+}
+
 static uint32_t
-route_handle_v4(struct route_module_config *config, struct packet *packet) {
+route_handle_v4(
+	struct route_module_config *config,
+	struct packet *packet,
+	enum route_drop_reason *drop_reason
+) {
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
 	struct rte_ipv4_hdr *header = rte_pktmbuf_mtod_offset(
 		mbuf, struct rte_ipv4_hdr *, packet->network_header.offset
 	);
 	if (header->time_to_live <= 1) {
+		*drop_reason = ROUTE_DROP_TTL_EXPIRED;
 		return LPM_VALUE_INVALID;
 	}
 	header->time_to_live -= 1;
@@ -42,21 +70,30 @@ route_handle_v4(struct route_module_config *config, struct packet *packet) {
 		((~rte_be_to_cpu_16(header->hdr_checksum)) & 0xFFFF) + 0xFEFF;
 	header->hdr_checksum = ~rte_cpu_to_be_16(sum + (sum >> 16));
 
+	// Past the TTL check a miss is the only remaining way to fail.
+	*drop_reason = ROUTE_DROP_NO_ROUTE;
 	return lpm_lookup(&config->lpm_v4, 4, (uint8_t *)&header->dst_addr);
 }
 
 static uint32_t
-route_handle_v6(struct route_module_config *config, struct packet *packet) {
+route_handle_v6(
+	struct route_module_config *config,
+	struct packet *packet,
+	enum route_drop_reason *drop_reason
+) {
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
 	struct rte_ipv6_hdr *header = rte_pktmbuf_mtod_offset(
 		mbuf, struct rte_ipv6_hdr *, packet->network_header.offset
 	);
 	if (header->hop_limits <= 1) {
+		*drop_reason = ROUTE_DROP_TTL_EXPIRED;
 		return LPM_VALUE_INVALID;
 	}
 	header->hop_limits -= 1;
 
+	// Past the hop limit check a miss is the only remaining way to fail.
+	*drop_reason = ROUTE_DROP_NO_ROUTE;
 	return lpm_lookup(&config->lpm_v6, 16, header->dst_addr);
 }
 
@@ -124,18 +161,41 @@ route_handle_packets(
 	struct packet *packet;
 	while ((packet = packet_list_pop(&packet_front->input)) != NULL) {
 		uint32_t route_list_id = 0;
+		// Nothing makes the helpers assign a reason, so keep the
+		// historical one by default rather than misattribute a drop.
+		enum route_drop_reason drop_reason = ROUTE_DROP_NO_ROUTE;
+		const struct route_family_counter_ids *counters;
 
 		if (packet->network_header.type ==
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
-			route_list_id = route_handle_v4(route_config, packet);
+			route_list_id = route_handle_v4(
+				route_config, packet, &drop_reason
+			);
+			counters = &route_config->counters_v4;
 		} else if (packet->network_header.type ==
 			   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
-			route_list_id = route_handle_v6(route_config, packet);
+			route_list_id = route_handle_v6(
+				route_config, packet, &drop_reason
+			);
+			counters = &route_config->counters_v6;
 		} else {
-			route_list_id = LPM_VALUE_INVALID;
+			route_count_packet(
+				module_ectx,
+				route_config->drop_non_ip_counter_id,
+				packet
+			);
+			packet_front_drop(packet_front, packet);
+			continue;
 		}
 
 		if (route_list_id == LPM_VALUE_INVALID) {
+			route_count_packet(
+				module_ectx,
+				drop_reason == ROUTE_DROP_TTL_EXPIRED
+					? counters->drop_ttl_expired
+					: counters->drop_no_route,
+				packet
+			);
 			packet_front_drop(packet_front, packet);
 			continue;
 		}
@@ -143,6 +203,11 @@ route_handle_packets(
 		struct route_list *route_list =
 			ADDR_OF(&route_config->route_lists) + route_list_id;
 		if (route_list->count == 0) {
+			route_count_packet(
+				module_ectx,
+				counters->drop_empty_route_list,
+				packet
+			);
 			packet_front_drop(packet_front, packet);
 			continue;
 		}
@@ -160,12 +225,18 @@ route_handle_packets(
 		);
 
 		if (device_id == (uint16_t)-1) {
+			route_count_packet(
+				module_ectx,
+				counters->drop_device_unresolved,
+				packet
+			);
 			packet_front_drop(packet_front, packet);
 			continue;
 		}
 
 		route_set_packet_destination(packet, route);
 		packet->tx_device_id = device_id;
+		route_count_packet(module_ectx, counters->forwarded, packet);
 		packet_front_pending_output(packet_front, packet);
 	}
 }

--- a/modules/route/fuzzing/route.c
+++ b/modules/route/fuzzing/route.c
@@ -37,6 +37,15 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 	config->cp_module.device_count = 0;
 	SET_OFFSET_OF(&config->cp_module.devices, NULL);
 
+	// Needed by route_module_config_register_counters.
+	if (counter_registry_init(
+		    &config->cp_module.counter_registry,
+		    &config->cp_module.memory_context,
+		    0
+	    )) {
+		goto error_lpm_v4;
+	}
+
 	struct memory_context *memory_context =
 		&config->cp_module.memory_context;
 	if (lpm_init(&config->lpm_v4, memory_context)) {
@@ -100,6 +109,26 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 	if (rc != 0) {
 		goto error_lpm_v6;
 	}
+
+	// Set up counter storage, because route_handle_packets accesses
+	// counters on every outcome.
+	if (route_module_config_register_counters(config, err)) {
+		goto error_lpm_v6;
+	}
+
+	if (counter_registry_link(
+		    &config->cp_module.counter_registry, NULL, err
+	    )) {
+		goto error_lpm_v6;
+	}
+
+	struct counter_storage *cs = counter_storage_spawn(
+		&fuzz_params.mctx, NULL, &config->cp_module.counter_registry
+	);
+	if (cs == NULL) {
+		goto error_lpm_v6;
+	}
+	SET_OFFSET_OF(&fuzz_params.module_ectx.counter_storage, cs);
 
 	*cp_module = (struct cp_module *)config;
 	return 0;


### PR DESCRIPTION
Route previously exposed no dataplane counters at all, and its five drop reasons collapsed into one worker-global counter shared with every other module — a route drop could not be attributed even to the module, let alone to a cause.

Adds `route_drop_packets`/`_bytes` labelled by reason (no_route, ttl_expired, non_ip, empty_route_list, device_unresolved) and by address family, plus `route_forwarded_packets`/`_bytes` as the denominator.

Adds `route_nexthops` and `route_config_updated_timestamp_seconds`, and splits `route_fib_entries` by address family.

FIB size gauges are now measured once per apply instead of walking the LPM keyspace on every scrape.

Note for consumers: `route_fib_entries` now emits one series per family per config; use `sum by (config) (route_fib_entries)` for the previous single value.