### PR TITLE
feat(cli): complete pipeline and function names

### DIFF
--- a/cli/core/src/completion.rs
+++ b/cli/core/src/completion.rs
@@ -103,6 +103,14 @@ fn default_connection_args() -> ConnectionArgs {
 /// `lookup` must be a genuine async closure, `async move |client| …`, not a
 /// plain closure returning an `async move` block — the latter cannot infer
 /// `client`'s type and fails to compile.
+///
+/// Do not attach these candidates to an argument that uses clap's
+/// `value_delimiter`, such as a comma-separated list like pipeline's
+/// `--functions acl,route`. `ArgValueCandidates` completes the whole raw
+/// token before delimiter splitting, so a candidate would try to replace the
+/// entire typed token rather than just its trailing element, producing a
+/// wrong insertion — completing a delimited list needs delimiter-aware
+/// candidates, which this helper does not provide.
 pub fn candidates<C, B, F>(command: impl FnOnce() -> Command, build: B, lookup: F) -> Vec<CompletionCandidate>
 where
     B: FnOnce(LayeredChannel) -> C,

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -1,11 +1,15 @@
 //! CLI for YANET "function" module.
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    engine::{ArgValueCandidates, CompletionCandidate},
+    CompleteEnv,
+};
 use commonpb::pb::FunctionId;
 use tonic::{codec::CompressionEncoding, Status};
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
     errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
@@ -49,7 +53,7 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Function name.
-    #[arg(short, long)]
+    #[arg(short, long, add = ArgValueCandidates::new(function_candidates))]
     pub name: String,
 }
 
@@ -60,7 +64,7 @@ pub struct ShowCmd {
 )]
 pub struct UpdateCmd {
     /// Function name.
-    #[arg(short, long)]
+    #[arg(short, long, add = ArgValueCandidates::new(function_candidates))]
     pub name: String,
     /// Chains in format `name:weight=type:name,type:name`.
     #[arg(long, required = true)]
@@ -70,14 +74,17 @@ pub struct UpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// Function name.
-    #[arg(short, long)]
+    #[arg(short, long, add = ArgValueCandidates::new(function_candidates))]
     pub name: String,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
 
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -224,4 +231,29 @@ impl FunctionService {
 
         Ok(())
     }
+}
+
+/// Completion candidates for a `--name` argument: the functions the module
+/// currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn function_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            FunctionServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| {
+            Ok(client
+                .list(ListFunctionsRequest {})
+                .await?
+                .into_inner()
+                .ids
+                .into_iter()
+                .map(|id| id.name)
+                .collect())
+        },
+    )
 }

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -1,11 +1,15 @@
 //! CLI for YANET "pipeline" module.
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    engine::{ArgValueCandidates, CompletionCandidate},
+    CompleteEnv,
+};
 use commonpb::pb::{FunctionId, PipelineId};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
     errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
 };
@@ -60,7 +64,7 @@ impl ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Pipeline name.
-    #[arg(short, long)]
+    #[arg(short, long, add = ArgValueCandidates::new(pipeline_candidates))]
     pub name: String,
 }
 
@@ -71,7 +75,7 @@ pub struct ShowCmd {
 )]
 pub struct UpdateCmd {
     /// Pipeline name.
-    #[arg(short, long)]
+    #[arg(short, long, add = ArgValueCandidates::new(pipeline_candidates))]
     pub name: String,
     /// Pipeline functions.
     #[arg(long, value_delimiter = ',')]
@@ -81,14 +85,17 @@ pub struct UpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// Pipeline name.
-    #[arg(short, long)]
+    #[arg(short, long, add = ArgValueCandidates::new(pipeline_candidates))]
     pub name: String,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
 
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -238,4 +245,29 @@ impl PipelineService {
 
         Ok(())
     }
+}
+
+/// Completion candidates for a `--name` argument: the pipelines the module
+/// currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn pipeline_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            PipelineServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| {
+            Ok(client
+                .list(ListPipelinesRequest {})
+                .await?
+                .into_inner()
+                .ids
+                .into_iter()
+                .map(|id| id.name)
+                .collect())
+        },
+    )
 }


### PR DESCRIPTION
Pipeline and function name arguments now offer the same tab completion the module configs received, listing what the gateway currently knows.

These are the first tools whose listing call is shaped differently from the module ones: it is named differently, and it answers with identifiers rather than plain strings. Absorbing that took no change to the shared helper — only a different accessor at the call site, which is precisely what the helper was shaped for.

Names are offered exactly as the gateway reports them, so a completed value is always one the command accepts. This matters for functions, whose names carry a prefix that is tedious to type by hand and easy to get wrong.

Second of the staged sweep; the remaining command line tools follow.