### PR TITLE
feat(cli): complete config names for fwstate, pdump, route, route-mpls and balancer2

### DIFF
--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -11,10 +11,15 @@ use std::{
 };
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    CompleteEnv,
+    engine::{ArgValueCandidates, CompletionCandidate},
+};
+use tonic::codec::CompressionEncoding;
 use yanet_cli_balancer2::balancerpb;
 use ync::{
     client::ConnectionArgs,
+    completion,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -59,7 +64,7 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// Balancer configuration name.
-    #[arg(long, short = 'n')]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub name: String,
     /// Path to YAML configuration file.
     #[arg(long, short = 'c')]
@@ -73,14 +78,14 @@ pub struct UpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ConfigCmd {
     /// Balancer configuration name.
-    #[arg(long, short = 'n')]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// Balancer configuration name.
-    #[arg(long, short = 'n')]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub name: String,
 
     /// Show all counters, active sessions and last packet timestamps.
@@ -303,9 +308,13 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     service.handle(cmd.mode, cmd.format).await
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -313,4 +322,26 @@ pub async fn main() {
         output::failure(&err);
         std::process::exit(err.exit_code());
     }
+}
+
+/// Completion candidates for a `--name` argument: the balancer configs the
+/// module currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            balancerpb::balancer_client::BalancerClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| {
+            Ok(client
+                .list_configs(balancerpb::ListConfigsRequest {})
+                .await?
+                .into_inner()
+                .names)
+        },
+    )
 }

--- a/modules/balancer2/cli/src/reals.rs
+++ b/modules/balancer2/cli/src/reals.rs
@@ -1,6 +1,7 @@
 use std::net::IpAddr;
 
 use clap::Parser;
+use clap_complete::engine::ArgValueCandidates;
 
 use crate::VsId;
 
@@ -21,7 +22,7 @@ pub enum RealsMode {
 #[derive(Debug, Clone, Parser)]
 pub struct EnableRealCmd {
     /// Balancer configuration name.
-    #[arg(long, short = 'n')]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub name: String,
     /// Virtual service identifier: "ip:port/proto" or "[ipv6]:port/proto".
     #[arg(long)]
@@ -38,7 +39,7 @@ pub struct EnableRealCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DisableRealCmd {
     /// Balancer configuration name.
-    #[arg(long, short = 'n')]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub name: String,
     /// Virtual service identifier: "ip:port/proto" or "[ipv6]:port/proto".
     #[arg(long)]

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use clap::Parser;
+use clap_complete::engine::ArgValueCandidates;
 use ync::metrics::{Kind, Metric};
 
 /// Parse duration from string (e.g., "60s", "5m", "1h")
@@ -32,21 +33,21 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// The name of the fwstate config to delete
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ShowCmd {
     /// FWState config name to show
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct LinkCmd {
     /// FWState config name to link
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
     /// ACL config names to link (can be specified multiple times)
@@ -57,14 +58,14 @@ pub struct LinkCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct StatsCmd {
     /// FWState config name to get statistics for
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// FWState config name to operate on
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
     /// Size of the hash table index for firewall state maps
@@ -133,7 +134,7 @@ pub enum DirectionArg {
 #[derive(Debug, Clone, Parser)]
 pub struct EntriesCmd {
     /// FWState config name
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
     /// Use IPv6 map instead of IPv4

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, time::UNIX_EPOCH};
 
 use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use commonpb::pb::{GetMetricsRequest, IpAddress};
 use fwstatepb::{
     DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
@@ -18,6 +18,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
+    completion,
     display::print_table_from_entries,
     errors::Error,
     metrics::{self, GaugeRow, Kind, Metric},
@@ -780,9 +781,13 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -790,4 +795,20 @@ pub async fn main() {
         output::failure(&err);
         std::process::exit(err.exit_code());
     }
+}
+
+/// Completion candidates for a `--name` argument: the fwstate configs the
+/// module currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            FwStateServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
+    )
 }

--- a/modules/pdump/cli/Cargo.toml
+++ b/modules/pdump/cli/Cargo.toml
@@ -2,10 +2,11 @@
 name = "yanet-cli-pdump"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
-clap_complete = "4.5"
+clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 colored = "3"
 serde = { version = "1.0", features = ["derive"] }

--- a/modules/pdump/cli/src/args.rs
+++ b/modules/pdump/cli/src/args.rs
@@ -2,6 +2,7 @@ use core::str::FromStr;
 
 use bytesize::ByteSize;
 use clap::{Parser, ValueEnum};
+use clap_complete::engine::ArgValueCandidates;
 
 #[derive(Debug, Clone, Parser)]
 pub enum ModeCmd {
@@ -15,21 +16,21 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct DeleteCmd {
     /// Pdump config name to delete.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// Pdump config name to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct SetConfigCmd {
     /// Pdump config name to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
     /// Filter represents a pcap-style filter expression
@@ -52,7 +53,7 @@ pub struct SetConfigCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ReadCmd {
     /// Pdump config name to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(crate::config_candidates))]
     pub config_name: String,
 
     /// Packet-dump encoding for the captured stream.

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -1,6 +1,6 @@
 use args::{DeleteCmd, ModeCmd, ReadCmd, SetConfigCmd, ShowConfigCmd};
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use pdumppb::{
     DeleteConfigRequest, ListConfigsRequest, ReadDumpRequest, ShowConfigRequest, ShowConfigResponse,
     pdump_service_client::PdumpServiceClient,
@@ -14,6 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tonic::{Status, codec::CompressionEncoding};
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -269,9 +270,13 @@ fn print_tree(resp: &ShowConfigResponse) {
     let _ = ptree::print_tree(&tree.build());
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -279,4 +284,20 @@ pub async fn main() {
         output::failure(&err);
         std::process::exit(err.exit_code());
     }
+}
+
+/// Completion candidates for a `--name` argument: the pdump configs the
+/// module currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            PdumpServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
+    )
 }

--- a/modules/route-mpls/cli/Cargo.toml
+++ b/modules/route-mpls/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.84"
+rust-version = "1.85"
 
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -17,7 +17,10 @@ pub mod routemplspb {
 }
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    engine::{ArgValueCandidates, CompletionCandidate},
+    CompleteEnv,
+};
 use netip::{Contiguous, IpNetwork};
 use routemplspb::{
     route_mpls_service_client::RouteMplsServiceClient, update_event::Event, CreateConfigRequest, DeleteConfigRequest,
@@ -26,6 +29,7 @@ use routemplspb::{
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -66,28 +70,28 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RouteShowCmd {
     /// Route config name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct RouteCreateCmd {
     /// Route config name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct RouteDeleteCmd {
     /// Route config name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct RouteUpdateCmd {
     /// Route config name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Route prefix
     #[arg(long = "prefix", short)]
@@ -112,7 +116,7 @@ pub struct RouteUpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RouteWithdrawCmd {
     /// Route config name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Route prefix
     #[arg(long = "prefix", short)]
@@ -147,10 +151,13 @@ impl TryFrom<Contiguous<IpNetwork>> for filterpb::IpPrefix {
 /// The fully-qualified gRPC service name used in error messages.
 const SERVICE_NAME: &str = "modules.route_mpls.controlplane.routemplspb.v1.RouteMPLSService";
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
 
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -158,6 +165,22 @@ pub async fn main() {
         output::failure(&err);
         std::process::exit(err.exit_code());
     }
+}
+
+/// Completion candidates for a `--name` argument: the route-mpls configs
+/// the module currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            RouteMplsServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
+    )
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {

--- a/modules/route/cli/route/Cargo.toml
+++ b/modules/route/cli/route/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.84"
+rust-version = "1.85"
 
 [dependencies]
 commonpb = { path = "../../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    engine::{ArgValueCandidates, CompletionCandidate},
+    CompleteEnv,
+};
 use commonpb::pb::MacAddress;
 use netip::MacAddr;
 use serde::{Deserialize, Serialize};
@@ -26,6 +29,7 @@ use yanet_cli_route::{
 };
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
+    completion,
     output::{self, CommonFormat},
 };
 
@@ -131,7 +135,7 @@ pub enum FibAction {
 #[derive(Debug, Clone, Parser)]
 pub struct FibUpdateCmd {
     /// Route module config name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Path to the FIB YAML file.
     #[arg(required = true, long = "rules", value_name = "PATH")]
@@ -147,14 +151,17 @@ pub struct FibShowCmd {
     #[arg(long)]
     pub ipv6: bool,
     /// Route config name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
 
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -162,6 +169,22 @@ pub async fn main() {
         log::error!("ERROR: {err}");
         std::process::exit(1);
     }
+}
+
+/// Completion candidates for a `--name` argument: the route configs the
+/// module currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            RouteServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
+    )
 }
 
 async fn run(cmd: Cmd) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
The remaining config-holding module tools now offer tab completion for their config-name arguments, listing what each module currently holds. One of them reports its names under a differently-named field, absorbed by the shared helper with only a different accessor at the call site.

A few manifests are tidied to match the others: two tools gain the minimum compiler version the completion helper requires, and one now declares the completion feature it had been relying on only because a neighbouring crate enabled it.

Fourth of the staged sweep. What remains is the non-config listable names — the traffic generator, the route operator tables, and balancer session states — plus the private tools, which land separately.