### PR TITLE
feat(cli): complete config names for the traffic generator and route operator

### DIFF
--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -1,7 +1,10 @@
 use std::path::PathBuf;
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    CompleteEnv,
+    engine::{ArgValueCandidates, CompletionCandidate},
+};
 use commonpb::pb::Device;
 use tonic::codec::CompressionEncoding;
 use trafgenpb::{
@@ -10,6 +13,7 @@ use trafgenpb::{
 };
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
     errors::Error,
     output::{self, CommonFormat},
 };
@@ -55,7 +59,7 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateCmd {
     /// Generator device name to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Input pipeline assignments in "pipeline:weight" format.
     #[arg(short, long)]
@@ -68,14 +72,14 @@ pub struct UpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct ShowConfigCmd {
     /// Generator device name to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct UploadPcapCmd {
     /// Generator device name to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Path to the pcap file whose packets are replayed.
     #[arg(long, short)]
@@ -85,7 +89,7 @@ pub struct UploadPcapCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct SetRateCmd {
     /// Generator device name to operate on.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// Target aggregate packet rate in packets per second.
     #[arg(long, short = 'r')]
@@ -237,9 +241,13 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -247,4 +255,22 @@ pub async fn main() {
         output::failure(&err);
         std::process::exit(err.exit_code());
     }
+}
+
+/// Completion candidates for a `--name` argument: the generator device
+/// configs the module currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            TrafgenServiceClient::new(channel)
+                .max_decoding_message_size(256 * 1024 * 1024)
+                .max_encoding_message_size(256 * 1024 * 1024)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
+    )
 }

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -11,7 +11,10 @@ use core::{
 use std::collections::HashMap;
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    CompleteEnv,
+    engine::{ArgValueCandidates, CompletionCandidate},
+};
 use colored::Colorize;
 use netip::{Contiguous, IpNetwork};
 use tabled::{
@@ -25,6 +28,7 @@ use tabled::{
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
+    completion,
     errors::Error,
     output::{self, CommonFormat},
     readiness,
@@ -98,7 +102,7 @@ pub struct RouteShowCmd {
     #[arg(long)]
     pub ipv6: bool,
     /// Configuration name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub name: String,
 }
 
@@ -107,7 +111,7 @@ pub struct RouteLookupCmd {
     /// IP address to look up.
     pub addr: IpAddr,
     /// Configuration name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub name: String,
 }
 
@@ -116,7 +120,7 @@ pub struct RouteInsertCmd {
     /// Destination prefix in CIDR notation.
     pub prefix: Contiguous<IpNetwork>,
     /// Configuration name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub name: String,
     /// Next-hop IP address(es); repeat `--via` to specify multiple nexthops for
     /// ECMP.
@@ -132,7 +136,7 @@ pub struct RouteRemoveCmd {
     /// Destination prefix in CIDR notation.
     pub prefix: Contiguous<IpNetwork>,
     /// Configuration name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub name: String,
     /// Next-hop IP address(es); repeat `--via` to specify multiple nexthops for
     /// ECMP.
@@ -146,7 +150,7 @@ pub struct RouteRemoveCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RouteFlushCmd {
     /// Configuration name.
-    #[arg(long = "name", short = 'n')]
+    #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub name: String,
 }
 
@@ -172,10 +176,13 @@ impl RouteSource {
     }
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
 
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
 
     ync::init(cmd.verbose, cmd.format);
@@ -188,6 +195,22 @@ pub async fn main() {
             std::process::exit(err.exit_code());
         }
     }
+}
+
+/// Completion candidates for a `--name` argument: the route operator
+/// configs the operator currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn config_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            RouteServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
+    )
 }
 
 /// Run the requested subcommand.


### PR DESCRIPTION
The traffic generator and the route operator tools now offer tab completion for their config-name arguments, listing what each currently holds. Both share the simple listing shape and reuse the shared helper unchanged.

Fifth of the staged sweep. What remains is the listable names that are not module configs — the neighbour tables and the balancer session states — plus the private tools, which land separately.