### PR TITLE
feat(cli): complete neighbour table and balancer session-state names

### DIFF
--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -71,7 +71,7 @@ pub struct UpdateCmd {
     pub config: String,
     /// Sessions state name to bind this configuration to (required on first
     /// create; optional on subsequent updates of an existing config).
-    #[arg(long, short = 's')]
+    #[arg(long, short = 's', add = ArgValueCandidates::new(sessions_candidates))]
     pub sessions: Option<String>,
 }
 
@@ -339,6 +339,28 @@ fn config_candidates() -> Vec<CompletionCandidate> {
         async move |mut client| {
             Ok(client
                 .list_configs(balancerpb::ListConfigsRequest {})
+                .await?
+                .into_inner()
+                .names)
+        },
+    )
+}
+
+/// Completion candidates for a sessions-state name argument: the sessions
+/// states the module currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn sessions_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            balancerpb::balancer_client::BalancerClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| {
+            Ok(client
+                .list_sessions_states(balancerpb::ListSessionsStatesRequest {})
                 .await?
                 .into_inner()
                 .names)

--- a/modules/balancer2/cli/src/sessions.rs
+++ b/modules/balancer2/cli/src/sessions.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use clap_complete::engine::ArgValueCandidates;
 
 use crate::FilterFlags;
 
@@ -21,7 +22,7 @@ pub enum SessionsMode {
 #[derive(Debug, Clone, Parser)]
 pub struct SessionsShowCmd {
     /// Sessions state name.
-    #[arg(long, short = 'n')]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(crate::sessions_candidates))]
     pub name: String,
 
     #[command(flatten)]
@@ -31,7 +32,7 @@ pub struct SessionsShowCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct SessionsUpdateCmd {
     /// Sessions state name.
-    #[arg(long, short = 'n')]
+    #[arg(long, short = 'n', add = ArgValueCandidates::new(crate::sessions_candidates))]
     pub name: String,
     /// Capacity (number of session entries).
     #[arg(long, short = 'c')]

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -12,13 +12,17 @@ use core::{
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use clap::{ArgAction, CommandFactory, Parser};
-use clap_complete::CompleteEnv;
+use clap_complete::{
+    CompleteEnv,
+    engine::{ArgValueCandidates, CompletionCandidate},
+};
 use commonpb::pb::{IpAddress, MacAddress};
 use netip::MacAddr;
 use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
+    completion,
     display::print_table_from_entries,
     errors::{Error, NotFoundMapper},
     output::{self, CommonFormat},
@@ -92,7 +96,7 @@ pub enum TableAction {
 pub struct ShowCmd {
     /// Show entries from a specific table only. If omitted, shows the
     /// merged view.
-    #[arg(long)]
+    #[arg(long, add = ArgValueCandidates::new(table_candidates))]
     pub table: Option<String>,
 }
 
@@ -110,7 +114,7 @@ pub struct AddCmd {
     #[arg(long)]
     pub device: Option<String>,
     /// Neighbour table name. Defaults to "static".
-    #[arg(long)]
+    #[arg(long, add = ArgValueCandidates::new(table_candidates))]
     pub table: Option<String>,
     /// Priority for this entry (lower wins). Defaults to the table's
     /// default priority.
@@ -123,13 +127,14 @@ pub struct RemoveCmd {
     /// Next-hop IP address(es) to remove.
     pub next_hops: Vec<String>,
     /// Neighbour table name. Defaults to "static".
-    #[arg(long)]
+    #[arg(long, add = ArgValueCandidates::new(table_candidates))]
     pub table: Option<String>,
 }
 
 #[derive(Debug, Clone, Parser)]
 pub struct CreateTableCmd {
     /// Neighbour table name.
+    #[arg(add = ArgValueCandidates::new(table_candidates))]
     pub name: String,
     /// Default priority for entries in this table.
     #[arg(long)]
@@ -139,6 +144,7 @@ pub struct CreateTableCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct UpdateTableCmd {
     /// Neighbour table name.
+    #[arg(add = ArgValueCandidates::new(table_candidates))]
     pub name: String,
     /// New default priority for entries in this table.
     #[arg(long)]
@@ -148,13 +154,17 @@ pub struct UpdateTableCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RemoveTableCmd {
     /// Table name.
+    #[arg(add = ArgValueCandidates::new(table_candidates))]
     pub name: String,
 }
 
-#[tokio::main(flavor = "current_thread")]
-pub async fn main() {
+fn main() {
     CompleteEnv::with_factory(Cmd::command).complete();
+    start();
+}
 
+#[tokio::main(flavor = "current_thread")]
+async fn start() {
     let cmd = Cmd::parse();
     ync::init(cmd.verbose, cmd.format);
 
@@ -481,4 +491,29 @@ impl From<NeighbourTableInfo> for TableEntry {
             built_in: table.built_in,
         }
     }
+}
+
+/// Completion candidates for a table-name argument: the neighbour tables
+/// the operator currently knows.
+///
+/// Strictly best-effort — see [`completion::candidates`].
+fn table_candidates() -> Vec<CompletionCandidate> {
+    completion::candidates(
+        Cmd::command,
+        |channel| {
+            NeighbourServiceClient::new(channel)
+                .send_compressed(CompressionEncoding::Gzip)
+                .accept_compressed(CompressionEncoding::Gzip)
+        },
+        async move |mut client| {
+            Ok(client
+                .list_tables(ListNeighbourTablesRequest {})
+                .await?
+                .into_inner()
+                .tables
+                .into_iter()
+                .map(|table| table.name)
+                .collect())
+        },
+    )
 }


### PR DESCRIPTION
Two more listable-name arguments now offer tab completion. The neighbour operator completes its table names from the table listing, and the balancer completes its session-state names from their own listing — distinct from the config names it already completes.

The neighbour listing answers with structured table entries rather than plain strings, so the shared helper takes a different accessor at the call site to read each table's name — the same way the pipeline and function tools already do.

Final public tool in the staged sweep.