### PR TITLE
fix(cli): honour the typed endpoint when completing service names

### DIFF
--- a/cli/core/src/completion.rs
+++ b/cli/core/src/completion.rs
@@ -77,6 +77,17 @@ fn default_connection_args() -> ConnectionArgs {
     ConnectionArgs::from_arg_matches(&matches).expect("ConnectionArgs must parse from its own defaults")
 }
 
+/// Recovers the connection flags a completer's user has typed so far.
+///
+/// A completer probing something other than a config-name list — a service
+/// registry, say — still needs to reach the gateway the user is targeting,
+/// not the default one. It supplies its own `Cmd::command`, and the flags
+/// are parsed out of the real completer argv, falling back to their defaults
+/// (`YANET_ENDPOINT` included) when the mid-typed line cannot be parsed.
+pub fn connection_args(command: impl FnOnce() -> Command) -> ConnectionArgs {
+    recover_connection_args(command, std::env::args_os())
+}
+
 /// Best-effort completion candidates for a config-name argument.
 ///
 /// `command` is the caller's own `Cmd::command`, exactly the factory passed
@@ -116,7 +127,7 @@ where
     B: FnOnce(LayeredChannel) -> C,
     F: AsyncFnOnce(C) -> Result<Vec<String>, Status>,
 {
-    let connection = recover_connection_args(command, std::env::args_os());
+    let connection = connection_args(command);
 
     let Ok(runtime) = tokio::runtime::Builder::new_current_thread().enable_all().build() else {
         return Vec::new();

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -16,6 +16,7 @@ use tabled::{
 };
 use ync::{
     client::{Connection, ConnectionArgs},
+    completion,
     discovery::{self, Resolution},
     errors::{Error, ErrorKind},
     output::{self, CommonFormat},
@@ -248,15 +249,13 @@ async fn suggest_services(connection: &Connection, err: Error) -> Error {
 ///
 /// Strictly best-effort — a tab-completion must never print an error nor hang
 /// — so a gateway that is down, slow or refusing us auth yields no candidates
-/// at all, `discovery::DISCOVERY_TIMEOUT` covering the slow case. The endpoint
-/// comes from the defaults of the command's own flags, `YANET_ENDPOINT`
-/// included, since the completer cannot see what the user has typed so far.
+/// at all, `discovery::DISCOVERY_TIMEOUT` covering the slow case. The
+/// endpoint is recovered from the connection flags the user has actually
+/// typed so far, `YANET_ENDPOINT` included as the fallback.
 fn service_candidates() -> Vec<CompletionCandidate> {
-    let Ok(cmd) = Cmd::try_parse_from([env!("CARGO_BIN_NAME")]) else {
-        return Vec::new();
-    };
+    let connection = completion::connection_args(Cmd::command);
 
-    discovery::candidates(&cmd.connection, METRICS_SERVICE, discovery::DISCOVERY_TIMEOUT)
+    discovery::candidates(&connection, METRICS_SERVICE, discovery::DISCOVERY_TIMEOUT)
         .into_iter()
         .map(CompletionCandidate::new)
         .collect()

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -13,6 +13,7 @@ use readinesspb::pb::{ReadyRequest, ReadyResponse, Scope, State};
 use serde::Serialize;
 use ync::{
     client::{self, Connection, ConnectionArgs},
+    completion,
     discovery::{self, Resolution},
     errors::{Error, ErrorKind},
     output::{self, CommonFormat},
@@ -460,15 +461,13 @@ async fn suggest_services(connection: &Connection, err: Error) -> Error {
 ///
 /// Strictly best-effort — a tab-completion must never print an error nor hang
 /// — so a gateway that is down, slow or refusing us auth yields no candidates
-/// at all, `discovery::DISCOVERY_TIMEOUT` covering the slow case. The endpoint
-/// comes from the defaults of the command's own flags, `YANET_ENDPOINT`
-/// included, since the completer cannot see what the user has typed so far.
+/// at all, `discovery::DISCOVERY_TIMEOUT` covering the slow case. The
+/// endpoint is recovered from the connection flags the user has actually
+/// typed so far, `YANET_ENDPOINT` included as the fallback.
 fn service_candidates() -> Vec<CompletionCandidate> {
-    let Ok(cmd) = Cmd::try_parse_from([env!("CARGO_BIN_NAME")]) else {
-        return Vec::new();
-    };
+    let connection = completion::connection_args(Cmd::command);
 
-    discovery::candidates(&cmd.connection, READINESS_SERVICE, discovery::DISCOVERY_TIMEOUT)
+    discovery::candidates(&connection, READINESS_SERVICE, discovery::DISCOVERY_TIMEOUT)
         .into_iter()
         .map(CompletionCandidate::new)
         .collect()


### PR DESCRIPTION
The readiness and metrics tools complete a service name from the gateway registry. They recovered the connection endpoint from an empty synthetic command line, so an endpoint the user had already typed was ignored — completion always queried the default gateway and could offer services from the wrong host.

They now recover the connection flags from what the user has actually typed, reusing the same recovery the config-name completion already relies on. Completion reaches the gateway being targeted; a gateway that is down or unreachable still yields no candidates, silently.