### PR TITLE
feat(acl): reject loading an empty ruleset

### DIFF
--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -246,6 +246,12 @@ func (m *ACLService) UpdateConfig(
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
+	// Rejecting an empty ruleset is enforced here in the Go control plane by
+	// design, not in the C shared-memory load path. A matching C-side guard
+	// can be added later if a non-Go caller ever needs the same protection.
+	if len(req.GetRules()) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "at least one rule is required, an empty ruleset would drop all traffic")
+	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -200,7 +200,7 @@ func TestUpdateConfig_Idempotency(t *testing.T) {
 
 	req := &aclpb.UpdateConfigRequest{
 		Name:  "acl0",
-		Rules: []*aclpb.Rule{},
+		Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_DENY}}}},
 	}
 
 	_, err := svc.UpdateConfig(t.Context(), req)
@@ -223,9 +223,10 @@ func TestUpdateConfig_ErrorPropagation(t *testing.T) {
 	svc := newTestService(b)
 
 	// Pre-populate a config so we can verify it is unchanged after the error.
+	initialRules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}}
 	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
 		Name:  "acl0",
-		Rules: []*aclpb.Rule{},
+		Rules: initialRules,
 	})
 	require.NoError(t, err)
 
@@ -248,7 +249,36 @@ func TestUpdateConfig_ErrorPropagation(t *testing.T) {
 	// The original config must still be present and unchanged.
 	resp, err := svc.ShowConfig(t.Context(), &aclpb.ShowConfigRequest{Name: "acl0"})
 	require.NoError(t, err)
-	assert.Empty(t, resp.Rules, "config rules must not have changed after failed update")
+	assert.True(t, rulesEqual(initialRules, resp.Rules), "config rules must not have changed after failed update")
+}
+
+// TestUpdateConfig_RejectsEmptyRuleset verifies that an empty ruleset is
+// rejected with codes.InvalidArgument before reaching the backend, for both
+// a nil and an explicitly empty rule slice.
+func TestUpdateConfig_RejectsEmptyRuleset(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules []*aclpb.Rule
+	}{
+		{name: "nil rules", rules: nil},
+		{name: "empty rules", rules: []*aclpb.Rule{}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newFakeBackend(0)
+			svc := newTestService(b)
+
+			_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+				Name:  "acl0",
+				Rules: tc.rules,
+			})
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Equal(t, 0, b.PublishCalls(), "backend must not be asked to publish")
+			assert.Empty(t, b.modules, "no module must be created")
+		})
+	}
 }
 
 // TestConvertRules_RejectsUnknownActionKind ensures unrecognized action kinds
@@ -297,7 +327,7 @@ func TestUpdateConfig_ConcurrentRace(t *testing.T) {
 			name := "acl0"
 			_, _ = svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
 				Name:  name,
-				Rules: []*aclpb.Rule{},
+				Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_DENY}}}},
 			})
 			_, _ = svc.ShowConfig(t.Context(), &aclpb.ShowConfigRequest{Name: name})
 			_, _ = svc.ListConfigs(t.Context(), &aclpb.ListConfigsRequest{})

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gopacket/gopacket/layers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
@@ -285,40 +287,19 @@ func TestACL_NoMatch_Drop(t *testing.T) {
 	requireModuleCounterPackets(t, h, aclCounterPath("port0", "test"), "acl_no_match", 1)
 }
 
-// TestACL_EmptyRules_Drop verifies that an empty ACL config is valid and
-// behaves as match-nothing with acl_no_match increments.
-func TestACL_EmptyRules_Drop(t *testing.T) {
-	eth := layers.Ethernet{
-		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
-		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
-		EthernetType: layers.EthernetTypeIPv4,
-	}
-	ip4 := layers.IPv4{
-		Version:  4,
-		TTL:      64,
-		Protocol: layers.IPProtocolUDP,
-		SrcIP:    net.ParseIP("192.0.2.1"),
-		DstIP:    net.ParseIP("10.0.0.1"),
-	}
-	udp := layers.UDP{SrcPort: 12345, DstPort: 80}
-	udp.SetNetworkLayerForChecksum(&ip4)
-	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &udp)
-
-	h, agent, backend := setupACLHarness(t, []string{"port0"})
+// TestACL_EmptyRules_Rejected verifies that UpdateConfig rejects an empty
+// ruleset with codes.InvalidArgument and never publishes a module config,
+// since an empty ACL would silently drop all traffic.
+func TestACL_EmptyRules_Rejected(t *testing.T) {
+	_, _, backend := setupACLHarness(t, []string{"port0"})
 	svc := acl.NewACLService(backend)
+
 	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
 		Name:  "test",
 		Rules: nil,
 	})
-	require.NoError(t, err)
-
-	wireACLPipeline(t, agent, "port0", "test")
-
-	result, err := h.HandlePackets(pkt)
-	require.NoError(t, err)
-	require.Empty(t, result.Output, "empty rules config must not match and must not reach output")
-	require.Len(t, result.Drop, 1, "empty rules config must drop packet via no-match")
-	requireModuleCounterPackets(t, h, aclCounterPath("port0", "test"), "acl_no_match", 1)
+	require.Error(t, err)
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
 // TestACL_TCP_SYNFlag verifies the proto subtype byte selects on TCP flags.


### PR DESCRIPTION
An empty ACL ruleset previously compiled successfully but caused the dataplane to drop all traffic, because every packet fell through to the no-match path. That let an easy misconfiguration silently blackhole a device.

- Reject an ACL config update that carries no rules with an invalid-argument error explaining that an empty ruleset would drop all traffic.
- Enforce the check in the control plane by design; a matching guard can be added to the shared-memory load path later if a non-Go caller ever needs it.
- Update the ACL service and functional tests that previously treated an empty ruleset as valid to assert the rejection instead.