### PR TITLE
perf(pipeline): execution-context process helpers internal linkage

### DIFF
--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -25,7 +25,7 @@ counter_add_packets_bytes(
 	values[1] += bytes;
 }
 
-void
+static inline void
 module_ectx_process(
 	struct dp_worker *dp_worker,
 	struct module_ectx *module_ectx,
@@ -112,7 +112,7 @@ module_ectx_process(
 	);
 }
 
-void
+static inline void
 chain_ectx_process(
 	struct dp_worker *dp_worker,
 	struct chain_ectx *chain_ectx,
@@ -230,7 +230,7 @@ function_ectx_drain(
 	function_ectx_run_chains(dp_worker, function_ectx, packet_front);
 }
 
-void
+static inline void
 function_ectx_process(
 	struct dp_worker *dp_worker,
 	struct function_ectx *function_ectx,
@@ -293,7 +293,7 @@ function_ectx_process(
 	);
 }
 
-void
+static inline void
 pipeline_ectx_process(
 	struct dp_worker *dp_worker,
 	struct pipeline_ectx *pipeline_ectx,

--- a/lib/dataplane/pipeline/pipeline.h
+++ b/lib/dataplane/pipeline/pipeline.h
@@ -6,15 +6,7 @@ struct dp_config;
 struct dp_worker;
 struct packet_front;
 
-struct pipeline_ectx;
 struct device_ectx;
-
-void
-pipeline_ectx_process(
-	struct dp_worker *dp_worker,
-	struct pipeline_ectx *pipeline_ectx,
-	struct packet_front *packet_front
-);
 
 void
 device_ectx_process_input(


### PR DESCRIPTION
- Give the per-level execution-context process helpers internal linkage so
the device-entry dispatch path folds into a single inlinable region,
removing four consecutive external call boundaries.
- Drop the now-unused pipeline-level prototype and its forward declaration
from the public header, leaving the device input and output entry points as
the only external surface.
