### PR TITLE
feat(dataplane): add RSS introspection and worker-affinity plumbing

### DIFF
--- a/common/thash.h
+++ b/common/thash.h
@@ -1,0 +1,58 @@
+#pragma once
+
+// Toeplitz hash, the RSS hash function used by NIC drivers (mlx5, i40e, and
+// most other RSS-capable devices) to steer incoming packets to a receive
+// queue. This header is DPDK-free by design so it can be shared by code
+// that must not depend on rte_* headers, so do not include rte_thash.h or
+// call rte_softrss here.
+//
+// The implementation below is the classic MSB-first bit-walking Toeplitz
+// hash: a 32-bit window is initialised from the first four key bytes, then
+// shifted left one bit per input bit, pulling in one new key bit at a time —
+// whenever an input bit is set the current window is XORed into the
+// running hash. It is bit-identical to DPDK's rte_softrss_be given the
+// same raw key bytes and the same input bytes.
+//
+// The caller is responsible for assembling the input tuple bytes in
+// whatever order the NIC hashes them (typically source address,
+// destination address, source port, destination port, but the exact
+// byte/field order is driver- and configuration-dependent). This header
+// does not attempt to guess that order — it must be verified empirically
+// against a live capture by the caller.
+//
+// The caller must pass key_len >= 4, since the initial 32-bit window is
+// seeded from the first four key bytes. Real RSS keys are at least 40
+// bytes, so this always holds in practice.
+
+#include <stdint.h>
+
+static inline uint32_t
+thash_toeplitz(
+	const uint8_t *key,
+	uint32_t key_len,
+	const uint8_t *input,
+	uint32_t input_len
+) {
+	uint32_t hash = 0;
+	uint32_t window = ((uint32_t)key[0] << 24) | ((uint32_t)key[1] << 16) |
+			  ((uint32_t)key[2] << 8) | (uint32_t)key[3];
+
+	uint32_t input_bits = input_len * 8;
+	uint32_t key_bits = key_len * 8;
+
+	for (uint32_t bit = 0; bit < input_bits; ++bit) {
+		if (input[bit / 8] & (0x80 >> (bit % 8))) {
+			hash ^= window;
+		}
+
+		window <<= 1;
+
+		uint32_t key_bit = bit + 32;
+		if (key_bit < key_bits &&
+		    (key[key_bit / 8] & (0x80 >> (key_bit % 8)))) {
+			window |= 1;
+		}
+	}
+
+	return hash;
+}

--- a/dataplane/device.c
+++ b/dataplane/device.c
@@ -5,19 +5,77 @@
 
 #include "common/strutils.h"
 #include "dpdk.h"
+#include "lib/dataplane/config/topology.h"
 #include "logging/log.h"
+
+// Maximum RSS key / RETA sizes we are willing to stage on the stack while
+// querying the NIC. RTE_ETH_RSS_RETA_SIZE_512 (the largest table any driver
+// reports today) and 64 bytes (generous even for wide symmetric keys) both
+// comfortably cover mlx5 and i40e.
+#define DATAPLANE_RSS_KEY_BUF_LEN 64
+#define DATAPLANE_RSS_RETA_BUF_LEN 512
+
+static void
+dataplane_device_start_query_rss(
+	struct dataplane *dataplane, struct dataplane_device *device
+) {
+	uint8_t key_buf[DATAPLANE_RSS_KEY_BUF_LEN];
+	uint16_t key_len;
+	uint16_t reta_buf[DATAPLANE_RSS_RETA_BUF_LEN];
+	uint16_t reta_size;
+
+	if (dpdk_port_get_rss_key(
+		    device->port_id, key_buf, sizeof(key_buf), &key_len
+	    )) {
+		return;
+	}
+	if (dpdk_port_get_rss_reta(
+		    device->port_id,
+		    reta_buf,
+		    DATAPLANE_RSS_RETA_BUF_LEN,
+		    &reta_size
+	    )) {
+		return;
+	}
+
+	for (uint32_t instance_idx = 0;
+	     instance_idx < dataplane->instance_count;
+	     ++instance_idx) {
+		struct dataplane_instance *instance =
+			dataplane->instances + instance_idx;
+		if (dp_topology_set_device_rss(
+			    instance->dp_config,
+			    device->device_id,
+			    key_buf,
+			    key_len,
+			    reta_buf,
+			    reta_size
+		    )) {
+			LOG(WARN,
+			    "failed to store RSS state for device id=%u "
+			    "instance=%u",
+			    device->device_id,
+			    instance_idx);
+		}
+	}
+}
 
 int
 dataplane_device_start(
 	struct dataplane *dataplane, struct dataplane_device *device
 ) {
-	(void)dataplane;
-
 	LOG(INFO,
 	    "start dataplane device id=%u with %d workers",
 	    device->device_id,
 	    device->worker_count);
 	dpdk_port_start(device->port_id);
+
+	// Query the NIC's RSS hash key and redirection table for later use by
+	// RSS-aware worker-affinity lookups. This is a best-effort query: no
+	// RSS state (unsupported driver, RSS disabled, un-negotiated virtio
+	// feature bits) leaves the device's rss_valid flag clear and callers
+	// fall back to their non-RSS-aware path.
+	dataplane_device_start_query_rss(dataplane, device);
 
 	for (uint32_t wrk_idx = 0; wrk_idx < device->worker_count; ++wrk_idx) {
 		struct dataplane_worker *worker = device->workers + wrk_idx;

--- a/dataplane/dpdk.c
+++ b/dataplane/dpdk.c
@@ -258,3 +258,91 @@ int
 dpdk_port_get_mac(uint16_t port_id, struct rte_ether_addr *ether_addr) {
 	return rte_eth_macaddr_get(port_id, ether_addr);
 }
+
+int
+dpdk_port_get_rss_key(
+	uint16_t port_id,
+	uint8_t *key_buf,
+	uint16_t key_buf_len,
+	uint16_t *key_len
+) {
+	struct rte_eth_dev_info dev_info;
+	memset(&dev_info, 0, sizeof(dev_info));
+	if (rte_eth_dev_info_get(port_id, &dev_info)) {
+		return -1;
+	}
+	if (dev_info.hash_key_size == 0 ||
+	    dev_info.hash_key_size > key_buf_len) {
+		return -1;
+	}
+
+	struct rte_eth_rss_conf rss_conf;
+	memset(&rss_conf, 0, sizeof(rss_conf));
+	rss_conf.rss_key = key_buf;
+	rss_conf.rss_key_len = dev_info.hash_key_size;
+
+	if (rte_eth_dev_rss_hash_conf_get(port_id, &rss_conf)) {
+		return -1;
+	}
+
+	// A driver can answer the hash-config query even when RSS is not
+	// active on the port (RSS disabled at configuration time, an
+	// un-negotiated virtio feature, a ring device). An all-zero rss_hf
+	// means the NIC is not steering traffic by RSS, so the key and RETA
+	// it would report describe no usable RSS state.
+	if (rss_conf.rss_hf == 0) {
+		return -1;
+	}
+
+	*key_len = dev_info.hash_key_size;
+	return 0;
+}
+
+int
+dpdk_port_get_rss_reta(
+	uint16_t port_id,
+	uint16_t *reta_buf,
+	uint16_t reta_buf_len,
+	uint16_t *reta_size
+) {
+	struct rte_eth_dev_info dev_info;
+	memset(&dev_info, 0, sizeof(dev_info));
+	if (rte_eth_dev_info_get(port_id, &dev_info)) {
+		return -1;
+	}
+	if (dev_info.reta_size == 0 || dev_info.reta_size > reta_buf_len ||
+	    dev_info.reta_size > RTE_ETH_RSS_RETA_SIZE_512) {
+		return -1;
+	}
+
+	// RETA entries are queried in fixed-size groups of
+	// RTE_ETH_RETA_GROUP_SIZE. RTE_ETH_RSS_RETA_SIZE_512 is the largest
+	// table size any driver reports today, so a group array sized for it
+	// covers every real device without a dynamic allocation.
+	uint16_t group_count =
+		(dev_info.reta_size + RTE_ETH_RETA_GROUP_SIZE - 1) /
+		RTE_ETH_RETA_GROUP_SIZE;
+	struct rte_eth_rss_reta_entry64
+		reta_conf[RTE_ETH_RSS_RETA_SIZE_512 / RTE_ETH_RETA_GROUP_SIZE];
+	memset(reta_conf,
+	       0,
+	       sizeof(struct rte_eth_rss_reta_entry64) * group_count);
+	for (uint16_t group = 0; group < group_count; ++group) {
+		reta_conf[group].mask = UINT64_MAX;
+	}
+
+	if (rte_eth_dev_rss_reta_query(
+		    port_id, reta_conf, dev_info.reta_size
+	    )) {
+		return -1;
+	}
+
+	for (uint16_t idx = 0; idx < dev_info.reta_size; ++idx) {
+		uint16_t group = idx / RTE_ETH_RETA_GROUP_SIZE;
+		uint16_t slot = idx % RTE_ETH_RETA_GROUP_SIZE;
+		reta_buf[idx] = reta_conf[group].reta[slot];
+	}
+
+	*reta_size = dev_info.reta_size;
+	return 0;
+}

--- a/dataplane/dpdk.h
+++ b/dataplane/dpdk.h
@@ -45,3 +45,32 @@ dpdk_port_stop(uint16_t port_id);
 
 int
 dpdk_port_get_mac(uint16_t port_id, struct rte_ether_addr *ether_addr);
+
+// Query the port's RSS hash key into caller-owned key_buf (of size
+// key_buf_len).
+//
+// On success writes the actual key length to *key_len. Returns non-zero if
+// the driver does not report RSS state (unsupported, disabled, or the
+// buffer is too small).
+int
+dpdk_port_get_rss_key(
+	uint16_t port_id,
+	uint8_t *key_buf,
+	uint16_t key_buf_len,
+	uint16_t *key_len
+);
+
+// Query the port's redirection table into caller-owned reta_buf (of
+// reta_buf_len entries), decoding each populated RETA slot to its target
+// rx-queue id.
+//
+// On success writes the actual table size to *reta_size. Returns non-zero
+// if the driver does not report RETA state (unsupported, disabled, or the
+// buffer is too small).
+int
+dpdk_port_get_rss_reta(
+	uint16_t port_id,
+	uint16_t *reta_buf,
+	uint16_t reta_buf_len,
+	uint16_t *reta_size
+);

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -47,3 +47,7 @@ _Static_assert(
 	sizeof(struct dp_worker) == 160,
 	"struct dp_worker size changed, bump YANET_MODULE_ABI_VERSION"
 );
+_Static_assert(
+	sizeof(struct dp_port) == 112,
+	"struct dp_port size changed, bump YANET_MODULE_ABI_VERSION"
+);

--- a/lib/dataplane/config/topology.c
+++ b/lib/dataplane/config/topology.c
@@ -1,5 +1,7 @@
 #include "topology.h"
 
+#include <string.h>
+
 #include "common/memory.h"
 #include "common/memory_address.h"
 
@@ -13,9 +15,52 @@ dp_topology_alloc_devices(struct dp_config *dp_config, size_t count) {
 	if (ports == NULL) {
 		return NULL;
 	}
+	memset(ports, 0, sizeof(struct dp_port) * count);
 
 	dp_config->dp_topology.device_count = count;
 	SET_OFFSET_OF(&dp_config->dp_topology.devices, ports);
 
 	return ports;
+}
+
+int
+dp_topology_set_device_rss(
+	struct dp_config *dp_config,
+	uint32_t device_id,
+	const uint8_t *key,
+	uint16_t key_len,
+	const uint16_t *reta,
+	uint16_t reta_size
+) {
+	struct dp_port *devices = ADDR_OF(&dp_config->dp_topology.devices);
+	struct dp_port *device = devices + device_id;
+
+	// Assumes a single call per (instance, device) at device start — a
+	// re-invocation for the same device would leak the previously
+	// allocated key and reta arrays instead of freeing them.
+	uint8_t *key_copy =
+		(uint8_t *)memory_balloc(&dp_config->memory_context, key_len);
+	if (key_copy == NULL) {
+		return -1;
+	}
+	memcpy(key_copy, key, key_len);
+
+	uint16_t *reta_copy = (uint16_t *)memory_balloc(
+		&dp_config->memory_context, sizeof(uint16_t) * reta_size
+	);
+	if (reta_copy == NULL) {
+		memory_bfree(&dp_config->memory_context, key_copy, key_len);
+		return -1;
+	}
+	memcpy(reta_copy, reta, sizeof(uint16_t) * reta_size);
+
+	device->rss_key_len = key_len;
+	SET_OFFSET_OF(&device->rss_key, key_copy);
+
+	device->rss_reta_size = reta_size;
+	SET_OFFSET_OF(&device->rss_reta, reta_copy);
+
+	device->rss_valid = true;
+
+	return 0;
 }

--- a/lib/dataplane/config/topology.h
+++ b/lib/dataplane/config/topology.h
@@ -1,11 +1,34 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 struct dp_port {
 	uint16_t port_id;
 	char device_name[80];
+
+	// RSS introspection state for this device, queried once at device
+	// start.
+	//
+	// False means the device has no usable RSS state (query failed, RSS
+	// disabled, or the driver does not support it) — callers must fall
+	// back to a non-RSS-aware path in that case.
+	bool rss_valid;
+
+	// Raw RSS hash key, exactly as reported by the NIC driver.
+	//
+	// Length and layout are driver-specific (mlx5 and i40e differ), so
+	// callers must not assume a fixed size.
+	uint16_t rss_key_len;
+	uint8_t *rss_key;
+
+	// Redirection table: rss_reta[slot] is the rx-queue id the NIC maps
+	// RETA slot to.
+	//
+	// The table size is queried at runtime and also varies by driver.
+	uint16_t rss_reta_size;
+	uint16_t *rss_reta;
 };
 
 struct dp_topology {
@@ -16,7 +39,27 @@ struct dp_topology {
 struct dp_config;
 
 // Allocate the dp_topology.devices array of count slots and wire it into
-// dp_config. The slots are left uninitialised — the caller fills each
-// entry's fields. Returns NULL on out-of-memory.
+// dp_config. Returns NULL on out-of-memory.
+//
+// The slots are zero-initialised, so a device whose RSS state is never
+// filled reads back as the not-valid sentinel: rss_valid false and the
+// key and reta offset pointers NULL. The caller only needs to fill the
+// entries it has RSS state for.
 struct dp_port *
 dp_topology_alloc_devices(struct dp_config *dp_config, size_t count);
+
+// Store the RSS hash key and redirection table for device_id in dp_topology,
+// copying key and reta into fresh shared-memory blocks owned by
+// dp_config->memory_context.
+//
+// On success the device's rss_valid flag is set. Returns non-zero on
+// allocation failure, leaving the device's RSS state untouched.
+int
+dp_topology_set_device_rss(
+	struct dp_config *dp_config,
+	uint32_t device_id,
+	const uint8_t *key,
+	uint16_t key_len,
+	const uint16_t *reta,
+	uint16_t reta_size
+);

--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -103,3 +103,22 @@ dp_config_lookup_device(
 	}
 	return -1;
 }
+
+int
+dp_config_worker_idx_by_device_queue(
+	struct dp_config *dp_config,
+	uint32_t device_id,
+	uint16_t queue_id,
+	uint64_t *out_idx
+) {
+	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
+	for (uint64_t idx = 0; idx < dp_config->worker_count; ++idx) {
+		struct dp_worker *worker = ADDR_OF(workers + idx);
+		if (worker->device_id == device_id &&
+		    worker->queue_id == queue_id) {
+			*out_idx = worker->idx;
+			return 0;
+		}
+	}
+	return -1;
+}

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -173,5 +173,21 @@ dp_config_lookup_device(
 	struct dp_config *dp_config, const char *name, uint64_t *index
 );
 
+// Find the global dp_worker->idx of the worker owning the given
+// (device_id, rx_queue) pair by scanning dp_config->workers. Writes the
+// found index to *out_idx and returns 0, or returns non-zero if no worker
+// owns that device/queue pair.
+//
+// The returned index is the GLOBAL worker index, not the queue id — the two
+// diverge whenever a device's queue ids are not a prefix of the global
+// worker index space.
+int
+dp_config_worker_idx_by_device_queue(
+	struct dp_config *dp_config,
+	uint32_t device_id,
+	uint16_t queue_id,
+	uint64_t *out_idx
+);
+
 void
 dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen);

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 6
+#define YANET_MODULE_ABI_VERSION 7
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -20,6 +20,7 @@ struct cp_device;
 
 struct cp_config_gen;
 struct cp_config_counter_storage_registry;
+struct dp_config;
 
 struct module_ectx {
 	module_handler handler;
@@ -127,3 +128,13 @@ struct config_gen_ectx {
 	uint64_t device_count;
 	struct device_ectx *devices[];
 };
+
+// Returns the dp_config that the worker's active config generation
+// belongs to, reached through the module_ectx -> config_gen_ectx ->
+// cp_config_gen offset-pointer chain.
+//
+// Returns NULL if any hop of the chain is not wired, so callers must treat
+// a NULL result as "unavailable" and fall back accordingly rather than
+// dereferencing it.
+struct dp_config *
+module_ectx_dp_config(struct module_ectx *module_ectx);

--- a/lib/dataplane/pipeline/pipeline.c
+++ b/lib/dataplane/pipeline/pipeline.c
@@ -8,6 +8,7 @@
 #include "dataplane/config/zone.h"
 #include "dataplane/packet/packet.h"
 #include "dataplane/time/tsc.h"
+#include "lib/controlplane/config/zone.h"
 #include "lib/dataplane/module/packet_front.h"
 
 #include <rte_cycles.h>
@@ -110,6 +111,23 @@ module_ectx_process(
 		packet_front_pending_output_bytes(packet_front) -
 			pending_output_bytes
 	);
+}
+
+struct dp_config *
+module_ectx_dp_config(struct module_ectx *module_ectx) {
+	struct config_gen_ectx *config_gen_ectx =
+		ADDR_OF(&module_ectx->config_gen_ectx);
+	if (config_gen_ectx == NULL) {
+		return NULL;
+	}
+
+	struct cp_config_gen *cp_config_gen =
+		ADDR_OF(&config_gen_ectx->cp_config_gen);
+	if (cp_config_gen == NULL) {
+		return NULL;
+	}
+
+	return ADDR_OF(&cp_config_gen->dp_config);
 }
 
 static inline void

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -153,3 +153,13 @@ flatmap_test = executable(
 )
 test('flatmap', flatmap_test, suite: ['common'])
 
+thash_test = executable(
+  'thash_test',
+  ['thash_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies,
+  include_directories: yanet_rootdir,
+)
+test('thash', thash_test, suite: ['common'])
+

--- a/tests/common/thash_test.c
+++ b/tests/common/thash_test.c
@@ -1,0 +1,126 @@
+#include "common/test_assert.h"
+#include "common/thash.h"
+
+#include "lib/logging/log.h"
+
+#include <stdint.h>
+#include <string.h>
+
+// The 40-byte default RSS key and the IPv4-tuple RSS verification vectors
+// from the Intel 82599 datasheet section 7.1.2.8.3, also used as the
+// reference vectors in DPDK's own test_thash.c.
+static const uint8_t default_rss_key[] = {
+	0x6d, 0x5a, 0x56, 0xda, 0x25, 0x5b, 0x0e, 0xc2, 0x41, 0x67,
+	0x25, 0x3d, 0x43, 0xa3, 0x8f, 0xb0, 0xd0, 0xca, 0x2b, 0xcb,
+	0xae, 0x7b, 0x30, 0xb4, 0x77, 0xcb, 0x2d, 0xa3, 0x80, 0x30,
+	0xf2, 0x0c, 0x6a, 0x42, 0xb7, 0x3b, 0xbe, 0xac, 0x01, 0xfa,
+};
+
+struct thash_v4_vector {
+	uint8_t dst_ip[4];
+	uint8_t src_ip[4];
+	uint16_t dst_port;
+	uint16_t src_port;
+	uint32_t hash_l3;
+	uint32_t hash_l3l4;
+};
+
+static const struct thash_v4_vector v4_vectors[] = {
+	{{161, 142, 100, 80},
+	 {66, 9, 149, 187},
+	 1766,
+	 2794,
+	 0x323e8fc2,
+	 0x51ccc178},
+	{{65, 69, 140, 83},
+	 {199, 92, 111, 2},
+	 4739,
+	 14230,
+	 0xd718262a,
+	 0xc626b0ea},
+	{{12, 22, 207, 184},
+	 {24, 19, 198, 95},
+	 38024,
+	 12898,
+	 0xd2d0a5de,
+	 0x5c2b394a},
+	{{209, 142, 163, 6},
+	 {38, 27, 205, 30},
+	 2217,
+	 48228,
+	 0x82989176,
+	 0xafc7327f},
+	{{202, 188, 127, 2},
+	 {153, 39, 163, 191},
+	 1303,
+	 44251,
+	 0x5d1809c5,
+	 0x10e828a2},
+};
+
+static void
+put_u16_be(uint8_t *dst, uint16_t value) {
+	dst[0] = (uint8_t)(value >> 8);
+	dst[1] = (uint8_t)value;
+}
+
+// Verifies that thash_toeplitz reproduces the well-known RSS verification
+// suite vectors, for both the L3-only tuple (source and destination
+// address) and the L3+L4 tuple (address pair plus source and destination
+// port). This is the empirical anchor that the algorithm matches the
+// hardware Toeplitz hash bit-for-bit.
+static int
+test_v4_reference_vectors(void) {
+	LOG(INFO, "Test IPv4 reference vectors...");
+
+	for (size_t idx = 0; idx < sizeof(v4_vectors) / sizeof(v4_vectors[0]);
+	     ++idx) {
+		const struct thash_v4_vector *vector = v4_vectors + idx;
+
+		uint8_t input_l3[8];
+		memcpy(input_l3, vector->src_ip, 4);
+		memcpy(input_l3 + 4, vector->dst_ip, 4);
+
+		uint32_t hash_l3 = thash_toeplitz(
+			default_rss_key,
+			sizeof(default_rss_key),
+			input_l3,
+			sizeof(input_l3)
+		);
+		TEST_ASSERT_EQUAL(
+			hash_l3, vector->hash_l3, "L3 hash mismatch at %zu", idx
+		);
+
+		uint8_t input_l3l4[12];
+		memcpy(input_l3l4, input_l3, sizeof(input_l3));
+		put_u16_be(input_l3l4 + 8, vector->src_port);
+		put_u16_be(input_l3l4 + 10, vector->dst_port);
+
+		uint32_t hash_l3l4 = thash_toeplitz(
+			default_rss_key,
+			sizeof(default_rss_key),
+			input_l3l4,
+			sizeof(input_l3l4)
+		);
+		TEST_ASSERT_EQUAL(
+			hash_l3l4,
+			vector->hash_l3l4,
+			"L3+L4 hash mismatch at %zu",
+			idx
+		);
+	}
+
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	if (test_v4_reference_vectors() != TEST_SUCCESS) {
+		return -1;
+	}
+
+	LOG(INFO, "All thash tests passed");
+	return 0;
+}


### PR DESCRIPTION
Foundational public-core plumbing for RSS-aware worker affinity of the origin leg.

- Query the NIC RSS hash key and redirection table after port start and cache them per device in shared memory, with a clean no-RSS fallback for devices that do not report RSS support.
- Add a reverse mapping from a device receive queue to its owning worker, and a DPDK-free Toeplitz hash helper.
- Expose the dataplane configuration to module handlers through the existing execution-context chain, without changing any shared ABI structure.
- This change is behaviour-neutral: nothing on the packet path consumes the new state yet. The consumer that selects an RSS-aware source port lands separately.
