### PR TITLE
feat(metrics): filter metrics by label tags

### DIFF
--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -5,7 +5,7 @@ use clap_complete::{
     CompleteEnv,
     engine::{ArgValueCandidates, CompletionCandidate},
 };
-use commonpb::pb::{GetMetricsRequest, GetMetricsResponse, Histogram, Label, Metric, metric::Value};
+use commonpb::pb::{GetMetricsRequest, GetMetricsResponse, Histogram, Label, Metric, MetricTag, metric::Value};
 use tabled::{
     Table, Tabled,
     settings::{
@@ -52,6 +52,15 @@ pub struct Cmd {
     pub name: Option<String>,
     #[command(flatten)]
     pub connection: ConnectionArgs,
+    /// Server-side tag filter: `NAME=VALUE`, repeatable — a metric is
+    /// returned only if it satisfies every tag (logical AND).
+    ///
+    /// An empty `VALUE` requires the label to be absent, `*` requires it to
+    /// be present with any value, and any other string requires an exact
+    /// value match. Shells typically expand `*`, so quote it, e.g.
+    /// `--tag 'config=*'`.
+    #[arg(long = "tag", short = 't', value_name = "NAME=VALUE", global = true)]
+    pub tags: Vec<String>,
     /// Output format.
     #[arg(long, value_enum, default_value = "human", global = true)]
     pub format: CommonFormat,
@@ -95,6 +104,13 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         ));
     }
 
+    let tags = cmd
+        .tags
+        .iter()
+        .map(|entry| parse_tag(entry))
+        .collect::<Result<Vec<_>, String>>()
+        .map_err(|message| Error::invalid_argument("metrics", &cmd.connection.endpoint, message))?;
+
     let connection = Connection::connect_for(&cmd.connection, "metrics").await?;
 
     let name = if name.contains('.') {
@@ -103,7 +119,22 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
         resolve_alias(&cmd, &connection, &name).await?
     };
 
-    run_probe(&connection, &name).await
+    run_probe(&connection, &name, tags).await
+}
+
+/// Parses a `NAME=VALUE` tag entry into a [`MetricTag`].
+///
+/// An entry without `=` is bad input — the message is turned into an
+/// invalid-argument [`Error`] once at the call site.
+fn parse_tag(entry: &str) -> Result<MetricTag, String> {
+    let Some((name, value)) = entry.split_once('=') else {
+        return Err(format!("invalid --tag \"{entry}\": expected NAME=VALUE"));
+    };
+
+    Ok(MetricTag {
+        name: name.to_string(),
+        value: value.to_string(),
+    })
 }
 
 /// Whether a service name is empty or whitespace only.
@@ -137,9 +168,9 @@ async fn require_service(cmd: &Cmd) -> Error {
 /// Probes one metrics service's `GetMetrics` over the shared connection, and
 /// suggests the services that do exist when the probe finds none under that
 /// name.
-async fn run_probe(connection: &Connection, name: &str) -> Result<(), Error> {
+async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) -> Result<(), Error> {
     let result = connection
-        .invoke_unary::<_, GetMetricsResponse>("metrics", name, "GetMetrics", GetMetricsRequest {})
+        .invoke_unary::<_, GetMetricsResponse>("metrics", name, "GetMetrics", GetMetricsRequest { tags })
         .await;
 
     let response = match result {
@@ -417,5 +448,28 @@ mod test {
         let cmd = Cmd::try_parse_from(["yanet-cli-metrics", "route"]).expect("a service name must parse");
 
         assert_eq!(Some("route".to_owned()), cmd.name);
+    }
+
+    #[test]
+    fn a_tag_entry_splits_on_the_first_equals() {
+        let tag = parse_tag("config=my-acl").expect("a well-formed tag must parse");
+
+        assert_eq!("config", tag.name);
+        assert_eq!("my-acl", tag.value);
+    }
+
+    #[test]
+    fn an_empty_tag_value_requires_the_label_absent() {
+        let tag = parse_tag("config=").expect("an empty value must parse");
+
+        assert_eq!("config", tag.name);
+        assert_eq!("", tag.value);
+    }
+
+    #[test]
+    fn a_tag_entry_without_equals_is_rejected() {
+        let err = parse_tag("config").expect_err("a bare tag name must be rejected");
+
+        assert!(err.contains("NAME=VALUE"));
     }
 }

--- a/common/commonpb/v1/metric.proto
+++ b/common/commonpb/v1/metric.proto
@@ -4,7 +4,25 @@ package common.commonpb.v1;
 
 option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
 
-message GetMetricsRequest {}
+message GetMetricsRequest {
+  // Predicates a returned metric's labels must all satisfy.
+  //
+  // A metric is included only if it satisfies every tag in the list
+  // (logical AND). An empty list imposes no filter, preserving the
+  // current behavior of returning all metrics.
+  repeated MetricTag tags = 1;
+}
+
+// A predicate against a metric's labels.
+//
+// The check is encoded in value: an empty string requires the label to
+// be absent, "*" requires the label to be present with any value, and
+// any other string requires the label to be present with exactly that
+// value. This mirrors controlplane.ynpb.v1.CounterTag.
+message MetricTag {
+  string name = 1;
+  string value = 2;
+}
 
 message GetMetricsResponse { repeated Metric metrics = 1; }
 

--- a/common/go/metrics/filter.go
+++ b/common/go/metrics/filter.go
@@ -1,0 +1,152 @@
+package metrics
+
+// NameValue is satisfied by any tag or label that reports a name and a
+// value.
+type NameValue interface {
+	GetName() string
+	GetValue() string
+}
+
+// Labeled is satisfied by any metric that reports its labels as a slice
+// of L.
+type Labeled[L NameValue] interface {
+	GetLabels() []L
+}
+
+// counterLabel is the metric label whose value identifies the individual
+// dataplane counter behind a per-entry metric (e.g. one ACL rule).
+const counterLabel = "counter"
+
+// Matches reports whether labels satisfies every tag.
+//
+// A tag without a corresponding label passes only if its value is
+// empty. A tag with a corresponding label passes if its value is "*",
+// or is non-empty and equals the label's value. Tags are combined with
+// logical AND, and a nil or empty tags list always matches.
+func Matches[L NameValue, T NameValue](labels []L, tags []T) bool {
+	for _, tag := range tags {
+		if !matchesOne(labels, tag) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchesOne[L NameValue, T NameValue](labels []L, tag T) bool {
+	for _, label := range labels {
+		if label.GetName() != tag.GetName() {
+			continue
+		}
+
+		if tag.GetValue() == "" {
+			return false
+		}
+
+		return tag.GetValue() == "*" || label.GetValue() == tag.GetValue()
+	}
+
+	return tag.GetValue() == ""
+}
+
+// Filter returns the subset of metrics whose labels satisfy every tag,
+// preserving their relative order.
+//
+// A nil or empty tags list returns metrics unchanged. The result is
+// always non-nil, even when nothing matches, so callers can embed it
+// directly in a response.
+func Filter[M Labeled[L], L NameValue, T NameValue](metrics []M, tags []T) []M {
+	if len(tags) == 0 {
+		return metrics
+	}
+
+	selected := make([]M, 0, len(metrics))
+	for _, metric := range metrics {
+		if Matches(metric.GetLabels(), tags) {
+			selected = append(selected, metric)
+		}
+	}
+
+	return selected
+}
+
+// Query derives the counter-name include-list a collector should pass to
+// the dataplane counter read, from the tags attached to a metrics request.
+//
+// It reduces every tag named counterLabel with logical AND into a
+// single effective predicate. An absent value ("") means only the
+// fixed, structural counters that carry no counter label. A
+// present-any value ("*") means every per-entry counter. Any other
+// value names an exact counter. No counter tag at all falls back to
+// defaultNames, read unconditionally.
+// An absent predicate resolves to fixedNames, with the second return
+// reporting whether there are any to read at all. A present-any
+// predicate resolves to defaultNames read in full, since Matches still
+// drops the structural metrics that lack the label at emission time.
+// Two counter tags that can never both hold (e.g. two different exact
+// values) make the request unsatisfiable: the second return is false
+// and the caller must skip the counter read and emit no per-entry
+// metrics. Query only decides what to read, while Matches remains the
+// correctness gate applied to each emitted metric.
+func Query[T NameValue](tags []T, defaultNames, fixedNames []string) ([]string, bool) {
+	var values []string
+	for _, tag := range tags {
+		if tag.GetName() == counterLabel {
+			values = append(values, tag.GetValue())
+		}
+	}
+
+	if len(values) == 0 {
+		return defaultNames, true
+	}
+
+	value, ok := reduceValues(values)
+	if !ok {
+		return nil, false
+	}
+
+	switch value {
+	case "":
+		return fixedNames, len(fixedNames) > 0
+	case "*":
+		return defaultNames, true
+	default:
+		return []string{value}, true
+	}
+}
+
+// reduceValues combines counter-tag values with logical AND, returning the
+// single effective predicate they imply.
+//
+// Absent ("") is incompatible with any other value, and two different
+// exact values can never both hold. Either case reports the second
+// return as false. Otherwise present-any ("*") yields to any exact
+// value it is paired with, since matching a specific name also
+// satisfies "present".
+func reduceValues(values []string) (string, bool) {
+	distinct := map[string]struct{}{}
+	for _, v := range values {
+		distinct[v] = struct{}{}
+	}
+
+	if len(distinct) == 1 {
+		for v := range distinct {
+			return v, true
+		}
+	}
+
+	if _, hasAbsent := distinct[""]; hasAbsent {
+		return "", false
+	}
+
+	delete(distinct, "*")
+	if len(distinct) != 1 {
+		return "", false
+	}
+
+	for v := range distinct {
+		return v, true
+	}
+
+	return "", false
+}

--- a/common/go/metrics/filter_test.go
+++ b/common/go/metrics/filter_test.go
@@ -1,0 +1,266 @@
+package metrics_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+)
+
+// nameValue is a minimal stand-in for a caller's tag or label type, used
+// to exercise the package's generic constraints without depending on any
+// concrete wire type.
+type nameValue struct {
+	name  string
+	value string
+}
+
+func (m nameValue) GetName() string  { return m.name }
+func (m nameValue) GetValue() string { return m.value }
+
+// labeled is a minimal stand-in for a caller's metric type, used to
+// exercise Filter without depending on any concrete wire type.
+type labeled struct {
+	name   string
+	labels []nameValue
+}
+
+func (m labeled) GetLabels() []nameValue { return m.labels }
+
+// TestMatches verifies the predicate semantics of a single tag and
+// their combination with logical AND across several tags.
+func TestMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		labels   []nameValue
+		tags     []nameValue
+		expected bool
+	}{
+		{
+			name:     "no tags passes any metric",
+			labels:   []nameValue{{name: "device", value: "eth0"}},
+			tags:     nil,
+			expected: true,
+		},
+		{
+			name:     "exact value match passes",
+			labels:   []nameValue{{name: "device", value: "eth0"}},
+			tags:     []nameValue{{name: "device", value: "eth0"}},
+			expected: true,
+		},
+		{
+			name:     "exact value mismatch fails",
+			labels:   []nameValue{{name: "device", value: "eth0"}},
+			tags:     []nameValue{{name: "device", value: "eth1"}},
+			expected: false,
+		},
+		{
+			name:     "wildcard passes when label is present",
+			labels:   []nameValue{{name: "device", value: "eth0"}},
+			tags:     []nameValue{{name: "device", value: "*"}},
+			expected: true,
+		},
+		{
+			name:     "wildcard fails when label is absent",
+			labels:   nil,
+			tags:     []nameValue{{name: "device", value: "*"}},
+			expected: false,
+		},
+		{
+			name:     "empty value passes when label is absent",
+			labels:   nil,
+			tags:     []nameValue{{name: "device", value: ""}},
+			expected: true,
+		},
+		{
+			name:     "empty value fails when label is present",
+			labels:   []nameValue{{name: "device", value: "eth0"}},
+			tags:     []nameValue{{name: "device", value: ""}},
+			expected: false,
+		},
+		{
+			name:     "empty value fails when label is present with an empty value",
+			labels:   []nameValue{{name: "device", value: ""}},
+			tags:     []nameValue{{name: "device", value: ""}},
+			expected: false,
+		},
+		{
+			name:     "wildcard passes when label is present with an empty value",
+			labels:   []nameValue{{name: "device", value: ""}},
+			tags:     []nameValue{{name: "device", value: "*"}},
+			expected: true,
+		},
+		{
+			name: "all tags must pass",
+			labels: []nameValue{
+				{name: "device", value: "eth0"},
+				{name: "pipeline", value: "main"},
+			},
+			tags: []nameValue{
+				{name: "device", value: "eth0"},
+				{name: "pipeline", value: "main"},
+			},
+			expected: true,
+		},
+		{
+			name: "a single failing tag rejects the metric",
+			labels: []nameValue{
+				{name: "device", value: "eth0"},
+				{name: "pipeline", value: "main"},
+			},
+			tags: []nameValue{
+				{name: "device", value: "eth0"},
+				{name: "pipeline", value: "backup"},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, metrics.Matches(test.labels, test.tags))
+		})
+	}
+}
+
+// TestFilter verifies that Filter selects the matching subset of metrics
+// while preserving their relative order.
+func TestFilter(t *testing.T) {
+	eth0 := labeled{name: "packets", labels: []nameValue{{name: "device", value: "eth0"}}}
+	eth1 := labeled{name: "packets", labels: []nameValue{{name: "device", value: "eth1"}}}
+	noDevice := labeled{name: "packets"}
+
+	metricsList := []labeled{eth0, eth1, noDevice}
+
+	tests := []struct {
+		name     string
+		tags     []nameValue
+		expected []labeled
+	}{
+		{
+			name:     "no tags returns everything",
+			tags:     nil,
+			expected: metricsList,
+		},
+		{
+			name:     "exact match returns only the matching subset in order",
+			tags:     []nameValue{{name: "device", value: "eth1"}},
+			expected: []labeled{eth1},
+		},
+		{
+			name:     "no match returns a non-nil empty slice",
+			tags:     []nameValue{{name: "device", value: "eth2"}},
+			expected: []labeled{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := metrics.Filter(metricsList, test.tags)
+
+			require.NotNil(t, result)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}
+
+// TestQuery verifies the counter-name include-list derivation from the
+// counter tags attached to a metrics request.
+func TestQuery(t *testing.T) {
+	defaultNames := []string{"rx", "tx", "acl_rule"}
+	fixedNames := []string{"rx", "tx"}
+
+	tests := []struct {
+		name          string
+		tags          []nameValue
+		fixedNames    []string
+		expectedNames []string
+		expectedRead  bool
+	}{
+		{
+			name:          "no counter tag reads the default set",
+			tags:          nil,
+			fixedNames:    fixedNames,
+			expectedNames: defaultNames,
+			expectedRead:  true,
+		},
+		{
+			name:          "absent counter reads the fixed set",
+			tags:          []nameValue{{name: "counter", value: ""}},
+			fixedNames:    fixedNames,
+			expectedNames: fixedNames,
+			expectedRead:  true,
+		},
+		{
+			name:          "absent counter with no fixed names skips the read",
+			tags:          []nameValue{{name: "counter", value: ""}},
+			fixedNames:    nil,
+			expectedNames: nil,
+			expectedRead:  false,
+		},
+		{
+			name:          "wildcard counter reads the default set in full",
+			tags:          []nameValue{{name: "counter", value: "*"}},
+			fixedNames:    fixedNames,
+			expectedNames: defaultNames,
+			expectedRead:  true,
+		},
+		{
+			name:          "exact counter reads only that name",
+			tags:          []nameValue{{name: "counter", value: "acl_rule"}},
+			fixedNames:    fixedNames,
+			expectedNames: []string{"acl_rule"},
+			expectedRead:  true,
+		},
+		{
+			name: "conflicting exact counters are unsatisfiable",
+			tags: []nameValue{
+				{name: "counter", value: "acl_rule"},
+				{name: "counter", value: "acl_rule2"},
+			},
+			fixedNames:    fixedNames,
+			expectedNames: nil,
+			expectedRead:  false,
+		},
+		{
+			name: "duplicate exact counters reduce to that name",
+			tags: []nameValue{
+				{name: "counter", value: "acl_rule"},
+				{name: "counter", value: "acl_rule"},
+			},
+			fixedNames:    fixedNames,
+			expectedNames: []string{"acl_rule"},
+			expectedRead:  true,
+		},
+		{
+			name: "wildcard combined with an exact value reduces to that value",
+			tags: []nameValue{
+				{name: "counter", value: "*"},
+				{name: "counter", value: "acl_rule"},
+			},
+			fixedNames:    fixedNames,
+			expectedNames: []string{"acl_rule"},
+			expectedRead:  true,
+		},
+		{
+			name: "absent combined with an exact value is unsatisfiable",
+			tags: []nameValue{
+				{name: "counter", value: ""},
+				{name: "counter", value: "acl_rule"},
+			},
+			fixedNames:    fixedNames,
+			expectedNames: nil,
+			expectedRead:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			names, read := metrics.Query(test.tags, defaultNames, test.fixedNames)
+
+			require.Equal(t, test.expectedRead, read)
+			require.Equal(t, test.expectedNames, names)
+		})
+	}
+}

--- a/controlplane/gateway/metrics_service.go
+++ b/controlplane/gateway/metrics_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
 
@@ -31,12 +32,12 @@ func (m *MetricsService) GetMetrics(
 	ctx context.Context,
 	req *commonpb.GetMetricsRequest,
 ) (*commonpb.GetMetricsResponse, error) {
-	metrics := make([]*commonpb.Metric, 0)
+	all := make([]*commonpb.Metric, 0)
 	for _, collector := range m.collectors {
-		metrics = append(metrics, collector.Collect()...)
+		all = append(all, collector.Collect()...)
 	}
 
-	return &commonpb.GetMetricsResponse{Metrics: metrics}, nil
+	return &commonpb.GetMetricsResponse{Metrics: metrics.Filter(all, req.GetTags())}, nil
 }
 
 func metricsCollectors(server metricsCollector, entries []serviceEntry) []metricsCollector {

--- a/modules/acl/cli/src/args.rs
+++ b/modules/acl/cli/src/args.rs
@@ -80,9 +80,13 @@ impl MetricName {
 
 #[derive(Debug, Clone, Parser, Default)]
 pub struct MetricsCmd {
-    /// Label filter, e.g. --label config=my-acl --label device=eth0
-    #[arg(long = "label", short = 'l', value_name = "KEY=VALUE")]
-    pub labels: Vec<String>,
+    /// Server-side tag filter, e.g. --tag config=my-acl --tag device=eth0.
+    ///
+    /// An empty value requires the label to be absent, `*` requires it to be
+    /// present with any value, and any other value requires an exact match.
+    /// Mirrors the counters `CounterTag` semantics.
+    #[arg(long = "tag", short = 't', value_name = "NAME=VALUE")]
+    pub tags: Vec<String>,
     /// Show only metrics matching this category
     #[arg(long, short, value_enum)]
     pub name: Option<MetricName>,

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -22,7 +22,7 @@ use ync::{
 mod args;
 
 use ::commonpb::pb as commonpb;
-use commonpb::GetMetricsRequest;
+use commonpb::{GetMetricsRequest, MetricTag};
 
 #[allow(non_snake_case)]
 pub mod aclpb {
@@ -405,34 +405,26 @@ impl ACLService {
     }
 
     pub async fn metrics(&mut self, cmd: MetricsCmd) -> Result<(), Error> {
+        let tags = cmd
+            .tags
+            .iter()
+            .map(|entry| parse_tag(entry))
+            .collect::<Result<Vec<_>, String>>()
+            .map_err(|message| Error::invalid_argument("metrics", self.metrics.endpoint(), message))?;
+
         let response = self
             .metrics
             .client()
-            .get_metrics(GetMetricsRequest {})
+            .get_metrics(GetMetricsRequest { tags })
             .await
             .map_err(self.metrics.status("metrics"))?
             .into_inner();
-        let label_filters: Vec<(&str, &str)> = cmd
-            .labels
-            .iter()
-            .filter_map(|s| {
-                let mut it = s.splitn(2, '=');
-                Some((it.next()?, it.next()?))
-            })
-            .collect();
 
         let metrics: Vec<Metric> = response
             .metrics
             .into_iter()
             .map(Metric::from_proto)
-            .filter(|m| {
-                if let Some(ref f) = cmd.name {
-                    if !m.name.contains(f.as_filter()) {
-                        return false;
-                    }
-                }
-                label_filters.iter().all(|(k, v)| m.label_value(k) == Some(v))
-            })
+            .filter(|m| cmd.name.as_ref().is_none_or(|f| m.name.contains(f.as_filter())))
             .collect();
 
         output::data(&metrics, metrics.is_empty(), format_args!("no metrics"), || {
@@ -441,6 +433,21 @@ impl ACLService {
 
         Ok(())
     }
+}
+
+/// Parses a `NAME=VALUE` tag entry into a [`MetricTag`].
+///
+/// An entry without `=` is bad input — the message is turned into an
+/// invalid-argument [`Error`] once at the call site.
+fn parse_tag(entry: &str) -> Result<MetricTag, String> {
+    let Some((name, value)) = entry.split_once('=') else {
+        return Err(format!("invalid --tag \"{entry}\": expected NAME=VALUE"));
+    };
+
+    Ok(MetricTag {
+        name: name.to_string(),
+        value: value.to_string(),
+    })
 }
 
 async fn run(cmd: Cmd) -> Result<(), Error> {
@@ -504,5 +511,28 @@ mod test {
         let content = include_str!("../../../../tests/functional/testdata/acl+fwstate.yaml");
         let config: ACLConfig = serde_yaml::from_str(content).expect("acl+fwstate.yaml fixture must deserialize");
         assert!(!config.rules.is_empty());
+    }
+
+    #[test]
+    fn a_tag_entry_splits_on_the_first_equals() {
+        let tag = parse_tag("config=my-acl").expect("a well-formed tag must parse");
+
+        assert_eq!("config", tag.name);
+        assert_eq!("my-acl", tag.value);
+    }
+
+    #[test]
+    fn an_empty_tag_value_requires_the_label_absent() {
+        let tag = parse_tag("config=").expect("an empty value must parse");
+
+        assert_eq!("config", tag.name);
+        assert_eq!("", tag.value);
+    }
+
+    #[test]
+    fn a_tag_entry_without_equals_is_rejected() {
+        let err = parse_tag("config").expect_err("a bare tag name must be rejected");
+
+        assert!(err.contains("NAME=VALUE"));
     }
 }

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -4,12 +4,14 @@ import (
 	"context"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
 )
 
-// metricsSource provides the module's collected metrics.
+// metricsSource provides the module's metrics, filtered by tags.
 type metricsSource interface {
-	Metrics() ([]*commonpb.Metric, error)
+	Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
 }
 
 // MetricsService exposes ACL module metrics over its own gRPC service.
@@ -24,9 +26,10 @@ func NewMetricsService(source metricsSource) *MetricsService {
 	return &MetricsService{source: source}
 }
 
-// GetMetrics returns a snapshot of all ACL module metrics.
+// GetMetrics returns a snapshot of ACL module metrics matching the
+// request's tags.
 func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetricsRequest) (*commonpb.GetMetricsResponse, error) {
-	all, err := m.source.Metrics()
+	all, err := m.source.Metrics(req.GetTags()...)
 	if err != nil {
 		return nil, err
 	}
@@ -50,11 +53,25 @@ func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb
 	}
 }
 
-// Metrics returns all ACL module metrics: per-pipeline packet counters,
-// per-rule counters, ACL compilation info, and gRPC call metrics.
+// aclStructuralCounters lists the fixed ACL counters whose metrics carry no
+// "counter" label.
+//
+// It MUST mirror the named cases of the switch in collectDataplaneMetrics.
+// A per-rule ("counter"-labelled) metric is anything not in this set. Used
+// to derive the counter-name query so per-rule counters are not read from
+// shm when they are filtered out.
+var aclStructuralCounters = []string{
+	"acl_no_match", "acl_action_allow", "acl_action_deny", "acl_action_count",
+	"acl_action_check_state", "acl_action_create_state", "acl_action_unknown",
+	"acl_state_miss", "acl_sync_sent",
+}
+
+// Metrics returns ACL module metrics matching tags: per-pipeline packet
+// counters, per-rule counters, ACL compilation info, and gRPC call metrics.
 //
 // Counter metrics are omitted when all worker values are zero to reduce output
-// noise.
+// noise. A "counter" tag is pushed down into the dataplane counter read, so
+// per-rule counters excluded by tags are never read from shared memory.
 //
 // Labels:
 //   - config:        ACL config name (all counter metrics)
@@ -67,18 +84,18 @@ func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb
 //   - grpc_service:  fully-qualified gRPC service name (gRPC metrics)
 //   - grpc_method:   RPC name (gRPC metrics)
 //   - grpc_code:     gRPC status code string (grpc_server_handled_total only)
-func (m *ACLService) Metrics() ([]*commonpb.Metric, error) {
-	metrics, err := m.collectDataplaneMetrics()
+func (m *ACLService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
+	all, err := m.collectDataplaneMetrics(tags)
 	if err != nil {
 		return nil, err
 	}
 	if m.metrics != nil {
-		metrics = append(metrics, m.metrics.Collect()...)
+		all = append(all, m.metrics.Collect()...)
 	}
-	return metrics, nil
+	return metrics.Filter(all, tags), nil
 }
 
-func (m *ACLService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
+func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	snapshot := m.metricsState.load()
 
 	dpConfig := m.backend.DPConfig()
@@ -87,6 +104,8 @@ func (m *ACLService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 	}
 
 	positions := dpConfig.AllModulePositions("acl")
+
+	names, read := metrics.Query(tags, nil, aclStructuralCounters)
 
 	result := make([]*commonpb.Metric, 0)
 	gaugesEmitted := make(map[string]struct{})
@@ -101,15 +120,18 @@ func (m *ACLService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 			{Name: "chain", Value: pos.Chain},
 		}
 
-		counters := dpConfig.ModuleCounters(
-			pos.Device,
-			pos.Pipeline,
-			pos.Function,
-			pos.Chain,
-			"acl",
-			configName,
-			nil,
-		)
+		var counters []ffi.CounterInfo
+		if read {
+			counters = dpConfig.ModuleCounters(
+				pos.Device,
+				pos.Pipeline,
+				pos.Function,
+				pos.Chain,
+				"acl",
+				configName,
+				names,
+			)
+		}
 
 		for _, counter := range counters {
 			var packets, bytes uint64

--- a/modules/acl/controlplane/metrics_test.go
+++ b/modules/acl/controlplane/metrics_test.go
@@ -1,0 +1,62 @@
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	acl "github.com/yanet-platform/yanet2/modules/acl/controlplane"
+)
+
+// spyMetricsSource records the tags it receives and returns a fixed slice
+// of metrics for MetricsService wiring tests.
+type spyMetricsSource struct {
+	metrics []*commonpb.Metric
+
+	receivedTags []*commonpb.MetricTag
+}
+
+func (m *spyMetricsSource) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
+	m.receivedTags = tags
+	return m.metrics, nil
+}
+
+// TestMetricsServiceGetMetricsForwardsTags verifies that GetMetrics forwards
+// the request's tags into the source unchanged and returns exactly what the
+// source produces, since filtering now lives inside Metrics.
+func TestMetricsServiceGetMetricsForwardsTags(t *testing.T) {
+	metrics := []*commonpb.Metric{
+		{
+			Name:  "acl_action_allow_packets",
+			Value: &commonpb.Metric_Counter{Counter: 42},
+		},
+	}
+
+	tests := []struct {
+		name string
+		tags []*commonpb.MetricTag
+	}{
+		{
+			name: "no tags",
+			tags: nil,
+		},
+		{
+			name: "counter tag",
+			tags: []*commonpb.MetricTag{{Name: "counter", Value: ""}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			source := &spyMetricsSource{metrics: metrics}
+			service := acl.NewMetricsService(source)
+
+			response, err := service.GetMetrics(t.Context(), &commonpb.GetMetricsRequest{Tags: test.tags})
+
+			require.NoError(t, err)
+			require.Equal(t, test.tags, source.receivedTags)
+			require.Equal(t, metrics, response.GetMetrics())
+		})
+	}
+}

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -282,7 +282,7 @@ impl Balancer2Service {
     }
 
     async fn metrics(&mut self, _cmd: MetricsCmd) -> Result<(), Error> {
-        let request = GetMetricsRequest {};
+        let request = GetMetricsRequest::default();
         log::trace!("get metrics request: {request:?}");
 
         let response = self

--- a/modules/forward/controlplane/metrics.go
+++ b/modules/forward/controlplane/metrics.go
@@ -4,12 +4,13 @@ import (
 	"context"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
-// metricsSource provides the module's collected metrics.
+// metricsSource provides the module's metrics, filtered by tags.
 type metricsSource interface {
-	Metrics() ([]*commonpb.Metric, error)
+	Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
 }
 
 // MetricsService exposes Forward module per-rule metrics over its own gRPC service.
@@ -24,9 +25,10 @@ func NewMetricsService(source metricsSource) *MetricsService {
 	return &MetricsService{source: source}
 }
 
-// GetMetrics returns a snapshot of Forward per-rule metrics.
+// GetMetrics returns a snapshot of Forward per-rule metrics matching the
+// request's tags.
 func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetricsRequest) (*commonpb.GetMetricsResponse, error) {
-	all, err := m.source.Metrics()
+	all, err := m.source.Metrics(req.GetTags()...)
 	if err != nil {
 		return nil, err
 	}
@@ -43,20 +45,38 @@ func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb
 	}
 }
 
-// Metrics returns Forward per-rule metrics collected from the dataplane.
-func (m *ForwardService) Metrics() ([]*commonpb.Metric, error) {
-	return m.collectDataplaneMetrics()
+// Metrics returns Forward per-rule metrics matching tags, collected from the
+// dataplane.
+func (m *ForwardService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
+	all, err := m.collectDataplaneMetrics(tags)
+	if err != nil {
+		return nil, err
+	}
+	return metrics.Filter(all, tags), nil
 }
 
-// collectDataplaneMetrics gathers packet and byte counters for all configured Forward dataplane rules.
-func (m *ForwardService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
+// collectDataplaneMetrics gathers packet and byte counters for all configured
+// Forward dataplane rules.
+//
+// A "counter" tag is pushed down into the dataplane counter read, so
+// per-rule counters excluded by tags are never read from shared memory.
+// Forward has no structural (non-per-rule) counters, so its full name list
+// is exactly the rule set. An empty derived name list therefore means there
+// is nothing to read, never "read everything", so the read is skipped
+// rather than passed on to ModuleCounters, which treats an empty list as
+// "all counters".
+func (m *ForwardService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	result := make([]*commonpb.Metric, 0)
 	for configName, config := range m.configs {
-		counterNames := ruleCounterNames(config.rules)
-		for _, counter := range m.backend.ModuleCounters(configName, counterNames) {
+		names, read := metrics.Query(tags, ruleCounterNames(config.rules), nil)
+		if !read || len(names) == 0 {
+			continue
+		}
+
+		for _, counter := range m.backend.ModuleCounters(configName, names) {
 			var packets, bytes uint64
 			for _, instance := range counter.Values {
 				if len(instance) > 0 {

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -380,7 +380,7 @@ impl FWStateService {
         let response = self
             .metrics
             .client()
-            .get_metrics(GetMetricsRequest {})
+            .get_metrics(GetMetricsRequest::default())
             .await
             .map_err(self.metrics.status("metrics"))?
             .into_inner();

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -10,9 +10,9 @@ import (
 	fwstatepb "github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
 )
 
-// metricsSource provides the module's collected metrics.
+// metricsSource provides the module's metrics, filtered by tags.
 type metricsSource interface {
-	Metrics() ([]*commonpb.Metric, error)
+	Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
 }
 
 // MetricsService exposes FWState module metrics over its own gRPC service.
@@ -27,12 +27,13 @@ func NewMetricsService(source metricsSource) *MetricsService {
 	return &MetricsService{source: source}
 }
 
-// GetMetrics returns a snapshot of all FWState module metrics.
+// GetMetrics returns a snapshot of FWState module metrics matching the
+// request's tags.
 func (m *MetricsService) GetMetrics(
 	ctx context.Context,
 	req *commonpb.GetMetricsRequest,
 ) (*commonpb.GetMetricsResponse, error) {
-	all, err := m.source.Metrics()
+	all, err := m.source.Metrics(req.GetTags()...)
 	if err != nil {
 		return nil, err
 	}
@@ -56,8 +57,23 @@ func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb
 	}
 }
 
-// Metrics returns all FWState module metrics: per-config map statistics
-// (gauge) and gRPC call metrics.
+// fwstateStructuralCounters lists the fixed fwstate counters whose metrics
+// carry no "counter" label.
+//
+// It MUST mirror the named cases of the switch in emitCounterMetrics.
+// Anything else is exported per-entry with a "counter" label. Used to
+// derive the counter-name query so per-entry counters are not read from
+// shm when filtered out.
+var fwstateStructuralCounters = []string{
+	"fwstate_sync", "fwstate_passthrough",
+	"fwstate_sync_v4_inserted", "fwstate_sync_v6_inserted",
+	"fwstate_sync_v4_insert_failed", "fwstate_sync_v6_insert_failed",
+	"fwstate_external_dropped", "fwstate_internal_forwarded",
+	"rx", "tx", "drop", "pending_input", "pending_output",
+}
+
+// Metrics returns FWState module metrics matching tags: per-config map
+// statistics (gauge), dataplane counters, and gRPC call metrics.
 //
 // Gauge metrics are emitted per address family (af=ipv4|ipv6) for every
 // loaded fwstate config.
@@ -69,10 +85,10 @@ func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb
 //   - grpc_service:  fully-qualified gRPC service name (gRPC metrics)
 //   - grpc_method:   RPC name (gRPC metrics)
 //   - grpc_code:     gRPC status code string (grpc_server_handled_total only)
-func (m *FWStateService) Metrics() ([]*commonpb.Metric, error) {
+func (m *FWStateService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	result := m.collectMapStats()
 
-	dpMetrics, err := m.collectDataplaneMetrics()
+	dpMetrics, err := m.collectDataplaneMetrics(tags)
 	if err != nil {
 		return nil, err
 	}
@@ -80,7 +96,7 @@ func (m *FWStateService) Metrics() ([]*commonpb.Metric, error) {
 	if m.metrics != nil {
 		result = append(result, m.metrics.Collect()...)
 	}
-	return result, nil
+	return metrics.Filter(result, tags), nil
 }
 
 // collectMapStats emits gauge metrics derived from the per-config map
@@ -105,6 +121,8 @@ func (m *FWStateService) collectMapStats() []*commonpb.Metric {
 // collectDataplaneMetrics emits per-config packet/byte counters read from the
 // dataplane counter storage via DPConfig.
 //
+// A "counter" tag is pushed down into the dataplane counter read, so
+// per-entry counters excluded by tags are never read from shared memory.
 // Counter metrics are omitted when all worker values are zero to reduce
 // output noise.
 //
@@ -116,13 +134,15 @@ func (m *FWStateService) collectMapStats() []*commonpb.Metric {
 //   - chain:    pipeline chain name
 //   - counter:  dataplane counter name (fwstate_counter_packets /
 //     fwstate_counter_bytes only)
-func (m *FWStateService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
+func (m *FWStateService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	dpConfig := m.agent.DPConfig()
 	if dpConfig == nil {
 		return []*commonpb.Metric{}, nil
 	}
 
 	positions := dpConfig.AllModulePositions("fwstate")
+
+	names, read := metrics.Query(tags, nil, fwstateStructuralCounters)
 
 	result := make([]*commonpb.Metric, 0)
 	for pos := range positions {
@@ -136,15 +156,18 @@ func (m *FWStateService) collectDataplaneMetrics() ([]*commonpb.Metric, error) {
 			{Name: "chain", Value: pos.Chain},
 		}
 
-		counters := dpConfig.ModuleCounters(
-			pos.Device,
-			pos.Pipeline,
-			pos.Function,
-			pos.Chain,
-			"fwstate",
-			configName,
-			nil,
-		)
+		var counters []ffi.CounterInfo
+		if read {
+			counters = dpConfig.ModuleCounters(
+				pos.Device,
+				pos.Pipeline,
+				pos.Function,
+				pos.Chain,
+				"fwstate",
+				configName,
+				names,
+			)
+		}
 
 		for _, counter := range counters {
 			result = append(result, emitCounterMetrics(counter, baseLabels)...)

--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -6,12 +6,13 @@ import (
 	"slices"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 	routepb "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 )
 
-// metricsSource provides the module's collected metrics.
+// metricsSource provides the module's metrics, filtered by tags.
 type metricsSource interface {
-	Metrics() ([]*commonpb.Metric, error)
+	Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error)
 }
 
 // MetricsService exposes route module metrics over its own gRPC service.
@@ -26,9 +27,10 @@ func NewMetricsService(source metricsSource) *MetricsService {
 	return &MetricsService{source: source}
 }
 
-// GetMetrics returns a snapshot of all route module metrics.
+// GetMetrics returns a snapshot of route module metrics matching the
+// request's tags.
 func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetricsRequest) (*commonpb.GetMetricsResponse, error) {
-	all, err := m.source.Metrics()
+	all, err := m.source.Metrics(req.GetTags()...)
 	if err != nil {
 		return nil, err
 	}
@@ -101,17 +103,24 @@ var counterNames = slices.Sorted(maps.Keys(counterMappings))
 // collectDataplaneMetrics gathers the module-level packet and byte counters
 // of every config, summed across worker instances.
 //
-// Every known counter is emitted even when it reads zero. A series that
-// disappears and reappears breaks rate() in Prometheus, and the empty route
-// list counters are invariant canaries expected to read zero forever, which
-// only works if they are visible.
-func (m *RouteService) collectDataplaneMetrics() []*commonpb.Metric {
+// A "counter" tag is pushed down into the dataplane counter read, so
+// counters excluded by tags are never read from shared memory. Every known
+// counter is emitted even when it reads zero. A series that disappears and
+// reappears breaks rate() in Prometheus, and the empty route list counters
+// are invariant canaries expected to read zero forever, which only works if
+// they are visible.
+func (m *RouteService) collectDataplaneMetrics(tags []*commonpb.MetricTag) []*commonpb.Metric {
 	m.shmLock.RLock()
 	defer m.shmLock.RUnlock()
 
+	names, read := metrics.Query(tags, counterNames, counterNames)
+	if !read {
+		return []*commonpb.Metric{}
+	}
+
 	result := make([]*commonpb.Metric, 0)
 	for configName := range m.configs {
-		for _, counter := range m.backend.ModuleCounters(configName, counterNames) {
+		for _, counter := range m.backend.ModuleCounters(configName, names) {
 			mapping, ok := counterMappings[counter.Name]
 			if !ok {
 				continue

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -276,8 +276,11 @@ func (m *RouteService) UpdateFIB(
 	return &routepb.UpdateFIBResponse{}, nil
 }
 
-// Metrics returns all route module metrics: per-config FIB gauges, the
-// module-level dataplane counters, plus gRPC call metrics.
+// Metrics returns route module metrics matching tags: per-config FIB
+// gauges, the module-level dataplane counters, plus gRPC call metrics.
+//
+// A "counter" tag is pushed down into the dataplane counter read, so
+// counters excluded by tags are never read from shared memory.
 //
 // Labels:
 //   - config:       route config name (all gauge and counter metrics)
@@ -293,13 +296,13 @@ func (m *RouteService) UpdateFIB(
 //   - grpc_service: fully-qualified gRPC service name (gRPC metrics)
 //   - grpc_method:  RPC name (gRPC metrics)
 //   - grpc_code:    gRPC status code string (grpc_server_handled_total only)
-func (m *RouteService) Metrics() ([]*commonpb.Metric, error) {
+func (m *RouteService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	result := m.collectConfigMetrics()
-	result = append(result, m.collectDataplaneMetrics()...)
+	result = append(result, m.collectDataplaneMetrics(tags)...)
 	if m.metrics != nil {
 		result = append(result, m.metrics.Collect()...)
 	}
-	return result, nil
+	return metrics.Filter(result, tags), nil
 }
 
 // collectConfigMetrics gathers the gauges describing what each config

--- a/operators/pipeline/cli/src/main.rs
+++ b/operators/pipeline/cli/src/main.rs
@@ -95,7 +95,7 @@ async fn run(cmd: Cmd) -> Result<bool, Error> {
 
             let response = service
                 .client()
-                .get_metrics(GetMetricsRequest {})
+                .get_metrics(GetMetricsRequest::default())
                 .await
                 .map_err(service.status("get_metrics"))?
                 .into_inner();

--- a/operators/pipeline/internal/operator/service.go
+++ b/operators/pipeline/internal/operator/service.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/operators/pipeline/operatorpb/v1"
 )
 
@@ -44,9 +45,9 @@ func (m *Service) GetMetrics(
 	ctx context.Context,
 	req *commonpb.GetMetricsRequest,
 ) (*commonpb.GetMetricsResponse, error) {
-	metrics := m.metrics.Collect()
+	all := m.metrics.Collect()
 
 	return &commonpb.GetMetricsResponse{
-		Metrics: metrics,
+		Metrics: metrics.Filter(all, req.GetTags()),
 	}, nil
 }

--- a/operators/route/internal/operator/service_metrics.go
+++ b/operators/route/internal/operator/service_metrics.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/common/go/metrics"
 	"github.com/yanet-platform/yanet2/operators/route/operatorpb/v1"
 )
 
@@ -42,6 +43,6 @@ func (m *MetricsService) GetMetrics(
 	req *commonpb.GetMetricsRequest,
 ) (*commonpb.GetMetricsResponse, error) {
 	return &commonpb.GetMetricsResponse{
-		Metrics: m.metrics.Collect(),
+		Metrics: metrics.Filter(m.metrics.Collect(), req.GetTags()),
 	}, nil
 }


### PR DESCRIPTION
Add a tag filter to the metrics request so a caller can select which metrics to receive by label, mirroring the tag filter already used by counters.

Push the counter-label filter down into the dataplane counter read, so per-rule counters are never fetched from shared memory when the filter excludes them.

Expose the filter as a repeatable tag flag on the generic metrics probe and on the ACL metrics command.