### PR TITLE
test(acl): use non-empty rulesets in metrics tests

### DIFF
--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -400,7 +400,8 @@ func TestMetrics_DoesNotWaitForUpdateConfig(t *testing.T) {
 	)))
 
 	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
-		Name: "acl0",
+		Name:  "acl0",
+		Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}},
 	})
 	require.NoError(t, err)
 
@@ -469,7 +470,8 @@ func TestMetricsSnapshotTracksConfigLifecycle(t *testing.T) {
 	svc := newTestService(newFakeBackend(0))
 
 	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
-		Name: "acl0",
+		Name:  "acl0",
+		Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_DENY}}}},
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
The empty-ruleset validation added in #1487 rejects configuration updates that carry no rules. Two metrics tests still submitted empty rulesets, so once both changes were on main they began failing and turned the build workflow red, blocking every pull request's full test suite.

Give those two tests a minimal valid ruleset so they exercise the metrics paths as intended. The non-idempotent-update test uses a distinct rule so its second, deliberately blocked update is not collapsed by the idempotency short-circuit.
