### PR TITLE
fix(commonpb): render IPv4-mapped IPv6 addresses as IPv4

### DIFF
--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -75,6 +75,10 @@ impl TryFrom<&pb::IpAddress> for IpAddr {
 impl Display for pb::IpAddress {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match IpAddr::try_from(self) {
+            Ok(IpAddr::V6(v6)) => match v6.to_ipv4_mapped() {
+                Some(v4) => v4.fmt(f),
+                None => v6.fmt(f),
+            },
             Ok(addr) => addr.fmt(f),
             Err(..) => f.write_str("invalid"),
         }
@@ -212,6 +216,18 @@ mod test {
     fn display_invalid_length() {
         let ip = pb::IpAddress { addr: vec![0u8; 5] };
         assert_eq!("invalid", ip.to_string());
+    }
+
+    #[test]
+    fn ip_address_display_unwraps_ipv4_mapped() {
+        let ip = pb::IpAddress::from(IpAddr::V6(Ipv4Addr::new(141, 8, 128, 254).to_ipv6_mapped()));
+        assert_eq!("141.8.128.254", ip.to_string());
+    }
+
+    #[test]
+    fn display_v6_unspecified() {
+        let ip = pb::IpAddress::from(IpAddr::V6(Ipv6Addr::UNSPECIFIED));
+        assert_eq!("::", ip.to_string());
     }
 
     #[test]


### PR DESCRIPTION
IPv4 next-hops stored as 16-byte IPv4-mapped IPv6 rendered in their mapped form with a `::ffff:` prefix, which looks wrong next to an IPv4 prefix in CLI output such as route listings.

Canonicalize the shared address display so an IPv4-mapped IPv6 address renders as plain IPv4, benefiting every consumer of the shared address type uniformly. Genuine IPv6, unspecified, link-local, and NAT64 addresses are left unchanged.