### PR TITLE
build(deb): ship bash and zsh completions for yanet-cli

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,6 +47,7 @@ Package: yanet2-cli
 Architecture: any
 Depends: ${shlibs:Depends}
  , ${misc:Depends}
+Recommends: bash-completion
 Description: Yanet2 CLI utilities
  Command-line tools for Yanet2: yanet-cli-nat64, yanet-cli-route,
  yanet-cli-decap, yanet-cli-dscp, yanet-cli-forward,

--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,11 @@ override_dh_auto_configure:
 			-Dtrace=disabled \
 			-Dversion=$(DEB_VERSION); \
 
+execute_after_dh_auto_install:
+	./scripts/gen-shell-completions.sh debian/yanet2-cli.install \
+		debian/tmp/usr/share/bash-completion/completions \
+		debian/tmp/usr/share/zsh/vendor-completions
+
 # Handle missing files more gracefully
 override_dh_missing:
 	dh_missing --fail-missing

--- a/debian/yanet2-cli.install
+++ b/debian/yanet2-cli.install
@@ -28,3 +28,5 @@ usr/bin/yanet-cli-operator-neighbour
 usr/bin/yanet-cli-operator-route
 usr/bin/yanet-cli-operator-decap
 usr/bin/yanet-cli-operator-forward
+usr/share/bash-completion/completions/*
+usr/share/zsh/vendor-completions/*

--- a/scripts/gen-shell-completions.sh
+++ b/scripts/gen-shell-completions.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+install_list="$1"
+bash_dir="$2"
+zsh_dir="$3"
+
+mkdir -p "$bash_dir" "$zsh_dir"
+
+while IFS= read -r line || [ -n "$line" ]; do
+	case "$line" in
+	usr/bin/yanet-cli*)
+		bin=$(basename "$line")
+		fn=_clap_dynamic_completer_$(printf '%s' "$bin" | tr -c '[:alnum:]' '_')
+		printf 'source <(COMPLETE=bash %s)\n' "$bin" >"$bash_dir/$bin"
+		# Tail-call the sourced completer so the autoloaded #compdef file answers the first Tab.
+		printf '#compdef %s\nsource <(COMPLETE=zsh %s)\n%s "$@"\n' "$bin" "$bin" "$fn" >"$zsh_dir/_$bin"
+		;;
+	esac
+done <"$install_list"


### PR DESCRIPTION
- Ships clap dynamic shell completions for all yanet-cli binaries in the yanet2-cli package, so tab-completion works right after install without editing shell startup files.
- Generates the bash and zsh completion loaders from the shipped binary list during the package build, and installs them into the standard bash and zsh completion directories.
- Recommends bash-completion so the completion directory is active out of the box.