### PR TITLE
fix(utils): zero-initialize software-built mbufs to clear stale offload flags

### DIFF
--- a/lib/utils/packet.c
+++ b/lib/utils/packet.c
@@ -264,6 +264,11 @@ alloc_mbuf(uint16_t headroom, uint16_t pkt_len, uint16_t tailroom) {
 
 void
 init_mbuf(struct rte_mbuf *m, struct packet_info *data, uint16_t buf_len) {
+	// Callers hand in a plain malloc'd buffer, so every field this
+	// function does not set below is allocator residue. Some of them are
+	// read further down the pipeline -- an uninitialized ol_flags, for
+	// one, reads as a hardware checksum verdict.
+	memset(m, 0, sizeof(*m));
 	m->priv_size = 0;
 	m->buf_len = buf_len;
 	uint32_t mbuf_size = sizeof(struct rte_mbuf) + m->priv_size;


### PR DESCRIPTION
The test and fuzz harness builds mbufs on plain allocated memory, so any field it does not set explicitly was left as allocator residue.

Downstream code reads the offload-flags field as a hardware checksum verdict, so residual bits could make a valid test packet look corrupt and be dropped, an intermittent, allocation-dependent failure.

Zeroing the mbuf first gives a software-built mbuf the same clean state as one freshly reset from a mempool, matching the sibling segment allocator that already does this. The affected helper is linked only into tests and fuzzers, never the production dataplane.