### PR TITLE
ci(lint): run the encapsulation linter in CI

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - '**/*.go'
       - 'lint/logger/**'
+      - 'lint/encapsulation/**'
       - '.golangci.yml'
       - '.github/workflows/go-lint.yml'
   pull_request:
     paths:
       - '**/*.go'
       - 'lint/logger/**'
+      - 'lint/encapsulation/**'
       - '.golangci.yml'
       - '.github/workflows/go-lint.yml'
 
@@ -30,6 +32,22 @@ jobs:
 
       - name: Run linter
         run: go run ./lint/logger/cmd/loglint/
+
+  enclint:
+    name: Custom enclint linter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test ./lint/encapsulation/cmd/enclint/
+
+      - name: Run linter
+        run: go run ./lint/encapsulation/cmd/enclint/
 
   modernize:
     name: golangci-lint modernize

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ clang-format -i <file>        # C
 cargo +nightly fmt            # Rust (uses nightly-only options in .rustfmt.toml)
 cargo clippy                  # Rust lints
 make proto-lint               # protobuf formatting check
-make lint-go                  # loglint + golangci-lint modernize (lint/logger/, .golangci.yml)
+make lint-go                  # loglint + enclint + golangci-lint modernize (lint/logger/, lint/encapsulation/, .golangci.yml)
 make lint-commit              # commit-subject convention check (lint/commit/)
 make proto-go                 # generate *.pb.go via protoc (needed before go lint locally)
 make hooks                    # install the git hooks (run once per clone)
@@ -265,7 +265,8 @@ Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` 
   reviewable. The check keys on the identifier `m` rather than on
   true receiver identity, so it is a convention aid, not a proof.
   Enforced mechanically by `lint/encapsulation/` (pre-commit hook via
-  `make hooks`, and `make lint-go`); known violations are ledgered in
+  `make hooks`, `make lint-go`, and CI via the `enclint` job in
+  `go-lint.yml`); known violations are ledgered in
   `lint/encapsulation/allowlist-private.txt` — do not add new rows.
   Files that `import "C"` are exempt, because C struct fields cannot
   be distinguished from Go private fields without type information.

--- a/lint/encapsulation/allowlist-private.txt
+++ b/lint/encapsulation/allowlist-private.txt
@@ -51,6 +51,7 @@ controlplane/internal/auth/sshkey/token.go:parseToken:token.validate  # legacy: 
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.configs  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.createLinkedHandlesLocked  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.mu  # legacy: encapsulate behind an exported method or field
+modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.publishMetricsSnapshotLocked  # acl metrics snapshot: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:oldConfig.acl  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:oldConfig.rules  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkedConfigNames:m.service.linkedConfigNamesLocked  # legacy: encapsulate behind an exported method or field
@@ -59,15 +60,20 @@ modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.confi
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.createLinkedHandlesLocked  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.linkedConfigNamesLocked  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.mu  # legacy: encapsulate behind an exported method or field
+modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.publishMetricsSnapshotLocked  # acl metrics snapshot: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:oldConfig.acl  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:oldConfig.rules  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLService.createLinkedHandlesLocked:oldConfig.rules  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/acl_adapter.go:ACLService.linkedConfigNamesLocked:config.fwstateName  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/aclpb/v1/convert.go:FromActions:result[idx].setFromCAclKind  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/aclpb/v1/convert.go:ToActions:action.toCAclKind  # legacy: encapsulate behind an exported method or field
-modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:cfg.acl  # legacy: encapsulate behind an exported method or field
+modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:m.metricsState.load  # acl metrics snapshot: encapsulate behind an exported method or field
+modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:snapshot.configInfo  # acl metrics snapshot: encapsulate behind an exported method or field
 modules/acl/controlplane/service.go:ACLService.DeleteConfig:config.acl  # legacy: encapsulate behind an exported method or field
-modules/acl/controlplane/service.go:ACLService.GetInfo:cfg.acl  # legacy: encapsulate behind an exported method or field
+modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:cfg.acl  # acl metrics snapshot: encapsulate behind an exported method or field
+modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:m.metricsState.publish  # acl metrics snapshot: encapsulate behind an exported method or field
+modules/acl/controlplane/service.go:ACLService.retention:m.metricsState.load  # acl metrics snapshot: encapsulate behind an exported method or field
+modules/acl/controlplane/service.go:ACLService.retention:snapshot.containsConfig  # acl metrics snapshot: encapsulate behind an exported method or field
 modules/acl/controlplane/service.go:ACLService.ShowConfig:config.fwstateName  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/service.go:ACLService.ShowConfig:config.rules  # legacy: encapsulate behind an exported method or field
 modules/acl/controlplane/service.go:ACLService.UpdateConfig:existing.rules  # legacy: encapsulate behind an exported method or field


### PR DESCRIPTION
The encapsulation linter was only ever invoked by the local pre-commit hook and the Go lint make target, never by CI. A contributor without the hooks installed could therefore land violations on the main branch, which is exactly what happened with the recent ACL metrics snapshot work — every unrelated commit made locally now trips the hook on someone else's debt.

- Add a workflow job that runs the encapsulation linter and its tests, mirroring the existing logger linter job.
- Extend the workflow path filters so a change to the linter or its allowlists retriggers the checks.
- Record the ACL controlplane accesses that currently fail the linter in the debt ledger, and drop the two rows that went stale when those accesses moved to another function.

The ledger rows are deliberate, temporary debt with a distinct reason string so the burn-down batch is easy to find. Encapsulating the ACL metrics snapshot state properly is tracked separately.

Note that making this job block merges still requires registering it as a required status check in the branch protection settings.