### PR TITLE
refactor(lint): exempt same-type parameters from the encapsulation rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,10 @@ Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` 
   `lint/encapsulation/allowlist-private.txt` — do not add new rows.
   Files that `import "C"` are exempt, because C struct fields cannot
   be distinguished from Go private fields without type information.
+  A method may also reach into the private fields or methods of a
+  parameter declared with the same type as its receiver, because an
+  operation on another value of one's own type crosses no
+  encapsulation boundary.
 - **gRPC handlers**: never use `_` for `ctx` / `req` — name them.
 - **No log-only RPC stubs**: when a brief names an RPC, actually invoke
   the client. `m.log.Debug("would call …")` is a bug, not a stub.

--- a/lint/encapsulation/allowlist-private.txt
+++ b/lint/encapsulation/allowlist-private.txt
@@ -21,8 +21,6 @@
 
 common/go/operator/operator.go:NewOperator:opts.GRPCServer.cfg  # legacy: encapsulate behind an exported method or field
 common/go/operator/operator.go:NewOperator:opts.GRPCServer.services  # legacy: encapsulate behind an exported method or field
-common/go/xnetip/uint128.go:uint128.Xor:other.hi  # legacy: encapsulate behind an exported method or field
-common/go/xnetip/uint128.go:uint128.Xor:other.lo  # legacy: encapsulate behind an exported method or field
 controlplane/bundle/bundle.go:buildServices:factory.name  # legacy: encapsulate behind an exported method or field
 controlplane/bundle/bundle.go:buildServices:factory.new  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/gateway.go:Gateway.Run:runner.module  # legacy: encapsulate behind an exported method or field

--- a/lint/encapsulation/cmd/enclint/main.go
+++ b/lint/encapsulation/cmd/enclint/main.go
@@ -5,6 +5,12 @@
 // test package so it cannot reach into private fields or methods at all
 // (rule 2). Known violations are tracked in two allowlists so that paying
 // down the debt is enforced by deleting the corresponding row.
+//
+// A file that imports "C" is exempt from rule 1, since C struct fields are
+// syntactically indistinguishable from Go private fields without type
+// information. A method parameter declared with the same type as its
+// receiver is exempt too, since an operation on another value of one's own
+// type crosses no encapsulation boundary.
 package main
 
 import (
@@ -163,7 +169,7 @@ func checkPrivateAccess(path string, file *ast.File, fset *token.FileSet) []priv
 	for _, decl := range file.Decls {
 		switch d := decl.(type) {
 		case *ast.FuncDecl:
-			violations = append(violations, scanPrivateSelectors(d, path, funcEnclosingName(d), fset)...)
+			violations = append(violations, scanPrivateSelectors(d, path, funcEnclosingName(d), sameTypeParamNames(d), fset)...)
 		case *ast.GenDecl:
 			if d.Tok != token.VAR && d.Tok != token.CONST {
 				continue
@@ -174,7 +180,7 @@ func checkPrivateAccess(path string, file *ast.File, fset *token.FileSet) []priv
 					continue
 				}
 				enclosing := valueSpec.Names[0].Name
-				violations = append(violations, scanPrivateSelectors(valueSpec, path, enclosing, fset)...)
+				violations = append(violations, scanPrivateSelectors(valueSpec, path, enclosing, nil, fset)...)
 			}
 		}
 	}
@@ -183,9 +189,9 @@ func checkPrivateAccess(path string, file *ast.File, fset *token.FileSet) []priv
 }
 
 // scanPrivateSelectors walks node and returns a violation for every
-// *ast.SelectorExpr whose selector is unexported and whose base is not the
-// bare identifier m.
-func scanPrivateSelectors(node ast.Node, path, enclosing string, fset *token.FileSet) []privateViolation {
+// *ast.SelectorExpr whose selector is unexported and whose base is neither
+// the bare identifier m nor a name in exemptParams.
+func scanPrivateSelectors(node ast.Node, path, enclosing string, exemptParams map[string]bool, fset *token.FileSet) []privateViolation {
 	var violations []privateViolation
 
 	ast.Inspect(node, func(n ast.Node) bool {
@@ -196,7 +202,7 @@ func scanPrivateSelectors(node ast.Node, path, enclosing string, fset *token.Fil
 		if ast.IsExported(sel.Sel.Name) {
 			return true
 		}
-		if base, ok := sel.X.(*ast.Ident); ok && base.Name == "m" {
+		if base, ok := sel.X.(*ast.Ident); ok && (base.Name == "m" || exemptParams[base.Name]) {
 			return true
 		}
 
@@ -227,13 +233,23 @@ func funcEnclosingName(decl *ast.FuncDecl) string {
 // receiverTypeName returns the bare receiver type name for recv, stripping
 // any pointer and generic-instantiation wrapping.
 //
-// For example, both "*Foo" and "*Foo[T]" return "Foo".
+// For example, both "*Foo" and "*Foo[T]" return "Foo". It returns "" if
+// recv has no receiver or the receiver's type is not a named type.
 func receiverTypeName(recv *ast.FieldList) string {
 	if recv == nil || len(recv.List) == 0 {
 		return ""
 	}
 
-	expr := recv.List[0].Type
+	return bareTypeName(recv.List[0].Type)
+}
+
+// bareTypeName returns the bare type name denoted by expr, stripping any
+// pointer and generic-instantiation wrapping.
+//
+// For example, "*Foo", "Foo[T]", and "*Foo[T]" all return "Foo". It returns
+// "" for an expression that does not resolve to a named type, such as a
+// qualified identifier or a struct type literal.
+func bareTypeName(expr ast.Expr) string {
 	for {
 		switch t := expr.(type) {
 		case *ast.StarExpr:
@@ -248,6 +264,40 @@ func receiverTypeName(recv *ast.FieldList) string {
 			return ""
 		}
 	}
+}
+
+// sameTypeParamNames returns the set of decl's parameter names whose
+// declared type is the same bare named type as decl's receiver, ignoring
+// pointer and generic-instantiation wrapping.
+//
+// It returns an empty set for a decl with no receiver. This is a
+// name-based approximation, like the rest of this file's AST-only
+// analysis: the exempt set is computed once per FuncDecl and applied to
+// the whole body, so a same-type parameter's name that gets shadowed
+// anywhere inside it — by a local variable, or by a nested closure
+// parameter of a different type — is still treated as exempt.
+func sameTypeParamNames(decl *ast.FuncDecl) map[string]bool {
+	names := map[string]bool{}
+
+	if decl.Recv == nil || len(decl.Recv.List) == 0 || decl.Type.Params == nil {
+		return names
+	}
+
+	receiverType := receiverTypeName(decl.Recv)
+	if receiverType == "" {
+		return names
+	}
+
+	for _, field := range decl.Type.Params.List {
+		if bareTypeName(field.Type) != receiverType {
+			continue
+		}
+		for _, name := range field.Names {
+			names[name.Name] = true
+		}
+	}
+
+	return names
 }
 
 // report prints every unsuppressed violation from both rules, every

--- a/lint/encapsulation/cmd/enclint/main_test.go
+++ b/lint/encapsulation/cmd/enclint/main_test.go
@@ -157,6 +157,162 @@ var handler = a.b
 `,
 			expectedTexts: []string{"a.b"},
 		},
+		{
+			name: "same-type value parameter clean",
+			source: `package foo
+
+type uint128 struct {
+	hi uint64
+	lo uint64
+}
+
+func (m uint128) Xor(other uint128) uint128 {
+	return uint128{
+		hi: m.hi ^ other.hi,
+		lo: m.lo ^ other.lo,
+	}
+}
+`,
+		},
+		{
+			name: "same-type pointer parameter with pointer receiver clean",
+			source: `package foo
+
+type Service struct {
+	log int
+}
+
+func (m *Service) Merge(other *Service) {
+	m.log = other.log
+}
+`,
+		},
+		{
+			name: "same-type generic parameter clean",
+			source: `package foo
+
+type Set[T any] struct {
+	items int
+}
+
+func (m *Set[T]) Add(other *Set[T]) {
+	m.items = other.items
+}
+`,
+		},
+		{
+			name: "multi-name same-type parameter field clean",
+			source: `package foo
+
+type Point struct {
+	x int
+}
+
+func (m Point) Pick(a, b Point) int {
+	return a.x + b.x
+}
+`,
+		},
+		{
+			name: "different-type parameter still flagged",
+			source: `package foo
+
+type Service struct {
+	log int
+}
+
+type Other struct {
+	log int
+}
+
+func (m *Service) Merge(other *Other) {
+	_ = other.log
+}
+`,
+			expectedTexts: []string{"other.log"},
+		},
+		{
+			name: "same-named local variable in plain function still flagged",
+			source: `package foo
+
+func Run() {
+	other := getOther()
+	_ = other.log
+}
+`,
+			expectedTexts: []string{"other.log"},
+		},
+		{
+			name: "chained base through same-type parameter still flagged",
+			source: `package foo
+
+type Service struct {
+	service int
+}
+
+func (m *Service) Merge(other *Service) {
+	_ = other.service.configs
+}
+`,
+			expectedTexts: []string{"other.service.configs"},
+		},
+		{
+			name: "qualified same-named type parameter still flagged",
+			source: `package foo
+
+type Service struct {
+	log int
+}
+
+func (m *Service) Merge(other pkg.Service) {
+	_ = other.log
+}
+`,
+			expectedTexts: []string{"other.log"},
+		},
+		{
+			name: "qualified same-named pointer type parameter still flagged",
+			source: `package foo
+
+type Service struct {
+	log int
+}
+
+func (m *Service) Merge(other *pkg.Service) {
+	_ = other.log
+}
+`,
+			expectedTexts: []string{"other.log"},
+		},
+		{
+			name: "receiverless function with same-typed parameter still flagged",
+			source: `package foo
+
+type Service struct {
+	log int
+}
+
+func Run(other Service) {
+	_ = other.log
+}
+`,
+			expectedTexts: []string{"other.log"},
+		},
+		{
+			name: "named result of receiver type still flagged",
+			source: `package foo
+
+type Service struct {
+	log int
+}
+
+func (m *Service) Clone() (result *Service) {
+	_ = result.log
+	return result
+}
+`,
+			expectedTexts: []string{"result.log"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The encapsulation rule requires a private field or method to be reached through the receiver. It misfires on a method that operates on another value of its own type, such as a bitwise operation on a 128-bit integer helper: there is no other spelling available, no encapsulation boundary is crossed, and no exported surface would make the code more reviewable. That is a rule wrong on a whole class rather than inconvenient on one instance, so the fix belongs in the linter rather than in the debt ledger.

- Accept a selector whose base names a method parameter declared with the same type as the receiver, ignoring pointer and generic wrapping.
- Keep everything else flagged: local variables, results, receiverless functions, parameters of a different or qualified type, and chained bases.
- Retire the two ledger rows that only existed because of the misfire.
- Document the exemption alongside the existing carve-out for files that use cgo.

The exemption stays a name-based approximation, like the rest of this linter's syntax-only analysis, and the doc comments say so. Its blast radius was measured against the previous ledger: exactly the two retired rows and nothing else. The boundary tests were checked by mutation — changing the type-name helper to accept qualified identifiers turns the two new tests red and no others.