### PR TITLE
refactor(operator): drop the redundant function applier wrapper

### DIFF
--- a/common/go/operator/function.go
+++ b/common/go/operator/function.go
@@ -79,6 +79,11 @@ func NewFunctionApplier(
 	}
 }
 
+// Name returns the function identifier the applier publishes.
+func (m *FunctionApplier) Name() string {
+	return m.spec.Name
+}
+
 // Apply publishes the captured spec to the gateway, or returns true
 // if the gateway is already correctly configured.
 func (m *FunctionApplier) Apply(ctx context.Context) (bool, error) {

--- a/lint/encapsulation/allowlist-private.txt
+++ b/lint/encapsulation/allowlist-private.txt
@@ -109,10 +109,6 @@ modules/route-mpls/controlplane/service.go:RouteMPLSService.UpdateConfig:config.
 modules/route-mpls/controlplane/service.go:RouteMPLSService.UpdateConfig:config.prefixes  # legacy: encapsulate behind an exported method or field
 modules/route-mpls/controlplane/service.go:RouteMPLSService.UpdateConfig:oldConfig.handle  # legacy: encapsulate behind an exported method or field
 modules/route-mpls/controlplane/service.go:RouteMPLSService.UpdateConfig:oldConfig.prefixes  # legacy: encapsulate behind an exported method or field
-operators/decap/internal/operator/actuator_gateway.go:GatewayActuator.Apply:entry.applier  # legacy: encapsulate behind an exported method or field
-operators/decap/internal/operator/actuator_gateway.go:GatewayActuator.Apply:entry.name  # legacy: encapsulate behind an exported method or field
-operators/forward/internal/operator/actuator_gateway.go:GatewayActuator.Apply:entry.applier  # legacy: encapsulate behind an exported method or field
-operators/forward/internal/operator/actuator_gateway.go:GatewayActuator.Apply:entry.name  # legacy: encapsulate behind an exported method or field
 operators/route/internal/operator/metrics.go:GatewayMetrics.collect:g.entries  # legacy: encapsulate behind an exported method or field
 operators/route/internal/operator/metrics.go:GatewayMetrics.collect:g.filteredRoutes  # legacy: encapsulate behind an exported method or field
 operators/route/internal/operator/metrics.go:GatewayMetrics.collect:g.routes  # legacy: encapsulate behind an exported method or field

--- a/operators/decap/internal/operator/actuator_gateway.go
+++ b/operators/decap/internal/operator/actuator_gateway.go
@@ -15,19 +15,12 @@ import (
 	decappb "github.com/yanet-platform/yanet2/modules/decap/controlplane/decappb/v1"
 )
 
-// funcApplierEntry bundles a FunctionApplier with its function name for
-// logging.
-type funcApplierEntry struct {
-	name    string
-	applier *operator.FunctionApplier
-}
-
 // GatewayActuator publishes the desired decap state to a single gateway.
 type GatewayActuator struct {
 	name     string
 	conn     *grpc.ClientConn
 	decap    decappb.DecapServiceClient
-	appliers []funcApplierEntry
+	appliers []*operator.FunctionApplier
 	log      *zap.Logger
 }
 
@@ -54,7 +47,7 @@ func NewGatewayActuator(
 	}
 
 	fnClient := ynpb.NewFunctionServiceClient(conn)
-	appliers := make([]funcApplierEntry, 0, len(functions))
+	appliers := make([]*operator.FunctionApplier, 0, len(functions))
 	for _, fn := range functions {
 		spec := operator.FunctionChainSpec{
 			Name:   fn.Name.Unwrap(),
@@ -65,14 +58,11 @@ func NewGatewayActuator(
 				Name: fn.Module.Unwrap(),
 			}},
 		}
-		appliers = append(appliers, funcApplierEntry{
-			name: fn.Name.Unwrap(),
-			applier: operator.NewFunctionApplier(
-				fnClient,
-				spec,
-				operator.WithIgnorePdump(fn.IgnorePdump),
-			),
-		})
+		appliers = append(appliers, operator.NewFunctionApplier(
+			fnClient,
+			spec,
+			operator.WithIgnorePdump(fn.IgnorePdump),
+		))
 	}
 
 	return &GatewayActuator{
@@ -106,22 +96,22 @@ func (m *GatewayActuator) Apply(ctx context.Context, state State) error {
 		}
 	}
 
-	for _, entry := range m.appliers {
-		skipped, e := entry.applier.Apply(ctx)
+	for _, applier := range m.appliers {
+		skipped, e := applier.Apply(ctx)
 		if e != nil {
 			err = errors.Join(err, fmt.Errorf(
 				"failed to update function %q on gateway %q: %w",
-				entry.name, m.name, e,
+				applier.Name(), m.name, e,
 			))
 			continue
 		}
 		if skipped {
 			m.log.Debug("function already correct, skipped",
-				zap.String("function", entry.name),
+				zap.String("function", applier.Name()),
 			)
 		} else {
 			m.log.Info("updated function",
-				zap.String("function", entry.name),
+				zap.String("function", applier.Name()),
 			)
 		}
 	}

--- a/operators/forward/internal/operator/actuator_gateway.go
+++ b/operators/forward/internal/operator/actuator_gateway.go
@@ -15,19 +15,12 @@ import (
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
-// funcApplierEntry bundles a FunctionApplier with its function name for
-// logging.
-type funcApplierEntry struct {
-	name    string
-	applier *operator.FunctionApplier
-}
-
 // GatewayActuator publishes the desired forward state to a single gateway.
 type GatewayActuator struct {
 	name     string
 	conn     *grpc.ClientConn
 	forward  forwardpb.ForwardServiceClient
-	appliers []funcApplierEntry
+	appliers []*operator.FunctionApplier
 	log      *zap.Logger
 }
 
@@ -54,7 +47,7 @@ func NewGatewayActuator(
 	}
 
 	fnClient := ynpb.NewFunctionServiceClient(conn)
-	appliers := make([]funcApplierEntry, 0, len(functions))
+	appliers := make([]*operator.FunctionApplier, 0, len(functions))
 	for _, fn := range functions {
 		spec := operator.FunctionChainSpec{
 			Name:   fn.Name.Unwrap(),
@@ -65,14 +58,11 @@ func NewGatewayActuator(
 				Name: fn.Module.Unwrap(),
 			}},
 		}
-		appliers = append(appliers, funcApplierEntry{
-			name: fn.Name.Unwrap(),
-			applier: operator.NewFunctionApplier(
-				fnClient,
-				spec,
-				operator.WithIgnorePdump(fn.IgnorePdump),
-			),
-		})
+		appliers = append(appliers, operator.NewFunctionApplier(
+			fnClient,
+			spec,
+			operator.WithIgnorePdump(fn.IgnorePdump),
+		))
 	}
 
 	return &GatewayActuator{
@@ -106,22 +96,22 @@ func (m *GatewayActuator) Apply(ctx context.Context, state State) error {
 		}
 	}
 
-	for _, entry := range m.appliers {
-		skipped, e := entry.applier.Apply(ctx)
+	for _, applier := range m.appliers {
+		skipped, e := applier.Apply(ctx)
 		if e != nil {
 			err = errors.Join(err, fmt.Errorf(
 				"failed to update function %q on gateway %q: %w",
-				entry.name, m.name, e,
+				applier.Name(), m.name, e,
 			))
 			continue
 		}
 		if skipped {
 			m.log.Debug("function already correct, skipped",
-				zap.String("function", entry.name),
+				zap.String("function", applier.Name()),
 			)
 		} else {
 			m.log.Info("updated function",
-				zap.String("function", entry.name),
+				zap.String("function", applier.Name()),
 			)
 		}
 	}


### PR DESCRIPTION
The decap and forward gateway actuators each kept a small private struct pairing a function applier with the function name, purely so the apply loop could name the function in errors and logs. The applier already carries that name in the chain spec it publishes, so the pairing stored the same string twice and existed only because the applier did not expose it.

- Expose the function name from the applier itself.
- Hold the appliers directly in both actuators and delete the wrapper struct.
- Retire the four encapsulation ledger rows that the wrapper's private fields required.

Behaviour is unchanged: identical error text, log messages and levels, branching and iteration order. The two actuators are maintained as near-verbatim copies of each other and stay parallel — their per-file diffs for this change are identical.