### PR TITLE
refactor(route-mpls): own the module handle release in one method

### DIFF
--- a/lint/encapsulation/allowlist-private.txt
+++ b/lint/encapsulation/allowlist-private.txt
@@ -86,17 +86,6 @@ modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopDstMAC
 modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopSrcMAC  # legacy: encapsulate behind an exported method or field
 modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.prefixFrom  # legacy: encapsulate behind an exported method or field
 modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.prefixTo  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:routeMPLSConfig.buildRules:nh.toFFI  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.CreateConfig:config.buildRules  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.CreateConfig:config.handle  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.CreateConfig:old.handle  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.DeleteConfig:config.handle  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.ShowConfig:config.prefixes  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.UpdateConfig:config.buildRules  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.UpdateConfig:config.handle  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.UpdateConfig:config.prefixes  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.UpdateConfig:oldConfig.handle  # legacy: encapsulate behind an exported method or field
-modules/route-mpls/controlplane/service.go:RouteMPLSService.UpdateConfig:oldConfig.prefixes  # legacy: encapsulate behind an exported method or field
 operators/route/internal/operator/metrics.go:GatewayMetrics.collect:g.entries  # legacy: encapsulate behind an exported method or field
 operators/route/internal/operator/metrics.go:GatewayMetrics.collect:g.filteredRoutes  # legacy: encapsulate behind an exported method or field
 operators/route/internal/operator/metrics.go:GatewayMetrics.collect:g.routes  # legacy: encapsulate behind an exported method or field

--- a/modules/route-mpls/controlplane/service.go
+++ b/modules/route-mpls/controlplane/service.go
@@ -102,21 +102,30 @@ func (m *NextHopList) Remove(nextHop NextHop) {
 }
 
 type routeMPLSConfig struct {
-	prefixes maptrie.MapTrie[netip.Prefix, netip.Addr, NextHopList]
-	handle   ModuleHandle
+	Prefixes maptrie.MapTrie[netip.Prefix, netip.Addr, NextHopList]
+	Handle   ModuleHandle
 }
 
-// buildRules iterates the maptrie from longest to shortest prefix and
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *routeMPLSConfig) Free() {
+	if m.Handle != nil {
+		m.Handle.Free()
+	}
+}
+
+// BuildRules iterates the maptrie from longest to shortest prefix and
 // assembles the croutempls.Rule slice, appending default drop rules for both
 // IPv4 and IPv6 at the end.
-func (m *routeMPLSConfig) buildRules() []croutempls.Rule {
+func (m *routeMPLSConfig) BuildRules() []croutempls.Rule {
 	rules := make([]croutempls.Rule, 0)
 
 	for prefixLen := 128; prefixLen >= 0; prefixLen-- {
-		for prefix, nextHopList := range m.prefixes[prefixLen] {
+		for prefix, nextHopList := range m.Prefixes[prefixLen] {
 			nexthops := make([]croutempls.Nexthop, 0, len(nextHopList.NextHops))
 			for _, nh := range nextHopList.NextHops {
-				nexthops = append(nexthops, nh.toFFI())
+				nexthops = append(nexthops, nh.ToFFI())
 			}
 
 			dst4s, _ := filter.Net4sFromPrefixes([]netip.Prefix{prefix})
@@ -159,7 +168,9 @@ func (m *routeMPLSConfig) buildRules() []croutempls.Rule {
 	return rules
 }
 
-func (m *NextHop) toFFI() croutempls.Nexthop {
+// ToFFI converts the nexthop into its bindings representation for the
+// route-mpls dataplane.
+func (m *NextHop) ToFFI() croutempls.Nexthop {
 	return croutempls.Nexthop{
 		Kind:        croutempls.KindTun,
 		Source:      m.Source,
@@ -222,7 +233,7 @@ func (m *RouteMPLSService) ShowConfig(
 	}
 
 	rules := make([]*routemplspb.Rule, 0)
-	for _, prefixes := range config.prefixes {
+	for _, prefixes := range config.Prefixes {
 		for prefix, nexthops := range prefixes {
 			for _, nexthop := range nexthops.NextHops {
 				rules = append(rules, &routemplspb.Rule{
@@ -271,9 +282,7 @@ func (m *RouteMPLSService) DeleteConfig(
 		return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
 	}
 
-	if config.handle != nil {
-		config.handle.Free()
-	}
+	config.Free()
 	delete(m.configs, name)
 
 	return &routemplspb.DeleteConfigResponse{}, nil
@@ -318,22 +327,22 @@ func (m *RouteMPLSService) CreateConfig(
 	}
 
 	config := routeMPLSConfig{
-		prefixes: prefixes,
+		Prefixes: prefixes,
 	}
 
 	m.shmLock.Lock()
 	defer m.shmLock.Unlock()
 
-	handle, err := m.backend.UpdateModule(name, config.buildRules())
+	handle, err := m.backend.UpdateModule(name, config.BuildRules())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
 
-	if old, ok := m.configs[name]; ok && old.handle != nil {
-		old.handle.Free()
+	if old, ok := m.configs[name]; ok {
+		old.Free()
 	}
 
-	config.handle = handle
+	config.Handle = handle
 	m.configs[name] = config
 
 	return &routemplspb.CreateConfigResponse{}, nil
@@ -356,12 +365,12 @@ func (m *RouteMPLSService) UpdateConfig(
 	oldConfig, ok := m.configs[name]
 	if !ok {
 		oldConfig = routeMPLSConfig{
-			prefixes: maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0),
+			Prefixes: maptrie.NewMapTrie[netip.Prefix, netip.Addr, NextHopList](0),
 		}
 	}
 
 	config := routeMPLSConfig{
-		prefixes: oldConfig.prefixes.Clone(),
+		Prefixes: oldConfig.Prefixes.Clone(),
 	}
 
 	for _, update := range req.Updates {
@@ -376,7 +385,7 @@ func (m *RouteMPLSService) UpdateConfig(
 				return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
 			}
 
-			config.prefixes.InsertOrUpdate(
+			config.Prefixes.InsertOrUpdate(
 				prefix,
 				func() NextHopList {
 					return NextHopList{
@@ -401,7 +410,7 @@ func (m *RouteMPLSService) UpdateConfig(
 				return nil, status.Errorf(codes.InvalidArgument, "failed to parse nexthop: %v", err)
 			}
 
-			config.prefixes.UpdateOrDelete(
+			config.Prefixes.UpdateOrDelete(
 				prefix,
 				func(list NextHopList) (NextHopList, bool) {
 					list.Remove(nextHop)
@@ -411,16 +420,14 @@ func (m *RouteMPLSService) UpdateConfig(
 		}
 	}
 
-	handle, err := m.backend.UpdateModule(name, config.buildRules())
+	handle, err := m.backend.UpdateModule(name, config.BuildRules())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
 	}
 
-	if oldConfig.handle != nil {
-		oldConfig.handle.Free()
-	}
+	oldConfig.Free()
 
-	config.handle = handle
+	config.Handle = handle
 	m.configs[name] = config
 
 	return &routemplspb.UpdateConfigResponse{}, nil


### PR DESCRIPTION
Eleven ledger rows in one file. The cached per-config record kept its state private while every request handler reached inside it, and three separate places hand-rolled the same nil check before releasing the module handle.

- Export the record's prefix trie and module handle, its rule builder, and the nexthop conversion helper.
- Give the record a method that owns the handle release, and call it from all three sites.
- Retire the eleven corresponding ledger rows.

The method rather than a bare exported field is deliberate here: three copies of one guard is where a fourth eventually forgets the nil check, and two sibling modules already show that drift, guarding on one path and not the other. Behaviour is unchanged on every path — same ordering relative to the backend call, same error paths, same lock scope, no handle freed twice and none left reachable after release.