### PR TITLE
feat(gateway): evict stale external backends from the registry

### DIFF
--- a/controlplane/etc/yanet/controlplane-default.yaml
+++ b/controlplane/etc/yanet/controlplane-default.yaml
@@ -25,6 +25,21 @@ gateway:
   auth:
     disabled: true
     permissions_path: /etc/yanet/auth/permissions.yaml
+  registry:
+    # The gateway drops backends that stopped refreshing their registration,
+    # so a stopped operator disappears from the registry instead of
+    # lingering.
+    #
+    # Set to true to keep every backend registered until the gateway stops,
+    # even after it disappears.
+    preserve_stale_backends: false
+    # How long a backend may go silent before it is evicted.
+    #
+    # Raise this above the registration period of any operator configured to
+    # re-register more slowly than the default.
+    ttl: 5m
+    # How often the eviction check runs.
+    sweep_interval: 30s
 modules:
   route:
     # MemoryPath is the path to the shared-memory file that is used

--- a/controlplane/gateway/cfg.go
+++ b/controlplane/gateway/cfg.go
@@ -1,8 +1,23 @@
 package gateway
 
 import (
+	"fmt"
+	"time"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth"
 )
+
+// defaultRegistryTTL is a generous multiple of the period on which external
+// backends re-register with the gateway.
+//
+// An operator may configure a longer register.interval in its own YAML, in
+// which case the gateway TTL must be raised to match, or that operator will
+// flap in and out of the registry.
+const defaultRegistryTTL = 5 * time.Minute
+
+// defaultRegistrySweepInterval is the default period between eviction sweeps.
+const defaultRegistrySweepInterval = 30 * time.Second
 
 // Config is the configuration for the gateway.
 type Config struct {
@@ -12,6 +27,8 @@ type Config struct {
 	Server ServerConfig `yaml:"server"`
 	// Auth is the configuration for authentication and authorization.
 	Auth auth.Config `yaml:"auth"`
+	// Registry is the configuration for stale backend eviction.
+	Registry RegistryConfig `yaml:"registry"`
 }
 
 // ServerConfig is the configuration for the gateway server.
@@ -26,6 +43,35 @@ type ServerConfig struct {
 	TLS *TLSConfig `yaml:"tls,omitempty"`
 }
 
+// RegistryConfig is the configuration for stale backend eviction.
+type RegistryConfig struct {
+	// PreserveStaleBackends keeps backends that stopped refreshing their
+	// registration instead of evicting them.
+	//
+	// An entry, once registered, stays in the registry until the gateway
+	// stops, even after its backend is gone. Set it when a deployment would
+	// rather serve a request into a backend that may be gone than have it
+	// vanish from the registry.
+	PreserveStaleBackends bool `yaml:"preserve_stale_backends"`
+	// TTL bounds how long an external backend may go without a
+	// registration refresh before it is evicted.
+	TTL xcfg.NonZero[time.Duration] `yaml:"ttl"`
+	// SweepInterval is the period between eviction sweeps.
+	SweepInterval xcfg.NonZero[time.Duration] `yaml:"sweep_interval"`
+}
+
+// Validate validates the registry config.
+func (m *RegistryConfig) Validate() error {
+	if m.TTL.Unwrap() <= 0 {
+		return fmt.Errorf("ttl (%s) must be positive", m.TTL.Unwrap())
+	}
+	if m.SweepInterval.Unwrap() <= 0 {
+		return fmt.Errorf("sweep_interval (%s) must be positive", m.SweepInterval.Unwrap())
+	}
+
+	return nil
+}
+
 // DefaultConfig returns a Config with sensible defaults.
 func DefaultConfig() *Config {
 	return &Config{
@@ -33,5 +79,9 @@ func DefaultConfig() *Config {
 			Endpoint: "[::1]:8080",
 		},
 		Auth: auth.DefaultConfig(),
+		Registry: RegistryConfig{
+			TTL:           xcfg.MustNonZero(defaultRegistryTTL),
+			SweepInterval: xcfg.MustNonZero(defaultRegistrySweepInterval),
+		},
 	}
 }

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -417,6 +417,10 @@ func (m *Gateway) Run(ctx context.Context) error {
 		})
 	}
 
+	wg.Go(func() error {
+		return m.runRegistrySweeper(ctx)
+	})
+
 	// Schedule Run for any in-process BackgroundService.
 	for _, service := range m.services {
 		if service.Endpoint() == "" {
@@ -466,6 +470,61 @@ func (m *Gateway) Run(ctx context.Context) error {
 	})
 
 	return wg.Wait()
+}
+
+// runRegistrySweeper periodically evicts stale external backends from the
+// registry until ctx is canceled.
+//
+// Eviction is skipped entirely when PreserveStaleBackends is set.
+func (m *Gateway) runRegistrySweeper(ctx context.Context) error {
+	if m.cfg.Registry.PreserveStaleBackends {
+		m.log.Info("registry eviction disabled, preserving stale backends")
+		return nil
+	}
+
+	// The YAML path is covered by validation: xcfg.NonZero rejects a zero
+	// TTL or sweep interval, and RegistryConfig.Validate rejects a negative
+	// one. gateway.Config is exported, though, so the fallback below still
+	// guards a programmatic literal that sets either field to zero or
+	// below, which would otherwise panic this goroutine (and the director
+	// with it) or evict every live external backend on the first sweep.
+	ttl := m.cfg.Registry.TTL.Unwrap()
+	if ttl <= 0 {
+		m.log.Warn("non-positive registry ttl, falling back to default",
+			zap.Duration("configured", ttl),
+			zap.Duration("default", defaultRegistryTTL),
+		)
+		ttl = defaultRegistryTTL
+	}
+
+	interval := m.cfg.Registry.SweepInterval.Unwrap()
+	if interval <= 0 {
+		m.log.Warn("non-positive registry sweep interval, falling back to default",
+			zap.Duration("configured", interval),
+			zap.Duration("default", defaultRegistrySweepInterval),
+		)
+		interval = defaultRegistrySweepInterval
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			before := time.Now().UTC().Add(-ttl)
+			for _, entry := range m.registry.EvictStale(before) {
+				m.log.Info("evicted stale service from registry",
+					zap.String("service", entry.Service()),
+					zap.String("endpoint", entry.Endpoint()),
+					zap.Time("last_seen_at", entry.LastSeenAt()),
+					zap.Stringer("kind", entry.Kind()),
+				)
+			}
+		}
+	}
 }
 
 // runHTTPServer runs the HTTP server that provides access to gRPC services

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"testing"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
@@ -244,4 +246,180 @@ func TestServiceRunner_Run_ShutsDownWithOpenStream(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("ServiceRunner.Run did not return within the shutdown grace period")
 	}
+}
+
+// TestGateway_RunRegistrySweeper_PreserveModeShortCircuits verifies that
+// PreserveStaleBackends returns immediately without touching a long-stale
+// external entry.
+func TestGateway_RunRegistrySweeper_PreserveModeShortCircuits(t *testing.T) {
+	t.Parallel()
+
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+
+	entry := reg.backends["svc.Foo"]
+	entry.lastSeenAt = time.Now().UTC().Add(-24 * time.Hour)
+	reg.backends["svc.Foo"] = entry
+
+	gw := &Gateway{
+		cfg: &Config{
+			Registry: RegistryConfig{
+				PreserveStaleBackends: true,
+				TTL:                   xcfg.MustNonZero(time.Minute),
+				SweepInterval:         xcfg.MustNonZero(time.Second),
+			},
+		},
+		registry: reg,
+		log:      zap.NewNop(),
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- gw.runRegistrySweeper(t.Context()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("runRegistrySweeper did not return promptly in preserve mode")
+	}
+
+	require.False(t, b.Closed(), "preserved backend must not be closed")
+
+	_, ok := reg.backends["svc.Foo"]
+	require.True(t, ok, "preserved entry must remain registered")
+}
+
+// TestGateway_RunRegistrySweeper_EvictsStaleExternal verifies that a stale
+// external entry is evicted and its backend closed once the sweeper's
+// ticker fires.
+func TestGateway_RunRegistrySweeper_EvictsStaleExternal(t *testing.T) {
+	t.Parallel()
+
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+
+	entry := reg.backends["svc.Foo"]
+	entry.lastSeenAt = time.Now().UTC().Add(-time.Hour)
+	reg.backends["svc.Foo"] = entry
+
+	gw := &Gateway{
+		cfg: &Config{
+			Registry: RegistryConfig{
+				TTL:           xcfg.MustNonZero(time.Millisecond),
+				SweepInterval: xcfg.MustNonZero(5 * time.Millisecond),
+			},
+		},
+		registry: reg,
+		log:      zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- gw.runRegistrySweeper(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return b.Closed()
+	}, time.Second, 5*time.Millisecond, "stale external backend must be evicted and closed")
+
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("runRegistrySweeper did not return after cancel")
+	}
+
+	_, ok := reg.backends["svc.Foo"]
+	require.False(t, ok, "evicted entry must be removed from the registry")
+}
+
+// TestGateway_RunRegistrySweeper_ZeroSweepIntervalFallsBack verifies that a
+// programmatic RegistryConfig with a zero SweepInterval falls back to the
+// default instead of panicking.
+//
+// A zero interval reaches time.NewTicker directly, which panics; the
+// fallback is the guard against that.
+func TestGateway_RunRegistrySweeper_ZeroSweepIntervalFallsBack(t *testing.T) {
+	t.Parallel()
+
+	reg := NewBackendRegistry()
+
+	gw := &Gateway{
+		cfg: &Config{
+			Registry: RegistryConfig{
+				TTL: xcfg.MustNonZero(time.Minute),
+			},
+		},
+		registry: reg,
+		log:      zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				done <- fmt.Errorf("runRegistrySweeper panicked: %v", r)
+			}
+		}()
+		done <- gw.runRegistrySweeper(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("runRegistrySweeper did not return after context timeout")
+	}
+}
+
+// TestGateway_RunRegistrySweeper_ZeroTTLFallsBack verifies that a
+// programmatic RegistryConfig with a zero TTL falls back to the default
+// instead of evicting a live entry on the first sweep.
+//
+// The sweep interval is small and positive so a sweep genuinely runs before
+// the test's deadline; the fallback TTL must still land far enough in the
+// past to spare an entry seen moments ago, or the cutoff would land at or
+// after time.Now and wipe every live backend on the first sweep.
+func TestGateway_RunRegistrySweeper_ZeroTTLFallsBack(t *testing.T) {
+	t.Parallel()
+
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+
+	gw := &Gateway{
+		cfg: &Config{
+			Registry: RegistryConfig{
+				SweepInterval: xcfg.MustNonZero(5 * time.Millisecond),
+			},
+		},
+		registry: reg,
+		log:      zap.NewNop(),
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- gw.runRegistrySweeper(ctx) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("runRegistrySweeper did not return after context timeout")
+	}
+
+	require.False(t, b.Closed(), "live entry must survive the fallback ttl")
+
+	_, ok := reg.backends["svc.Foo"]
+	require.True(t, ok, "live entry must remain registered")
 }

--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -82,6 +82,14 @@ func (m *BackendEntry) GetBackend() proxy.Backend {
 	return m.backend
 }
 
+// Close closes the entry's underlying backend.
+//
+// Only the owning registry closes an entry. An entry handed out by
+// ListBackends must not be closed by its receiver.
+func (m *BackendEntry) Close() error {
+	return m.backend.Close()
+}
+
 // BackendRegistry is a registry of backends for Gateway API.
 type BackendRegistry struct {
 	mu       sync.RWMutex
@@ -147,18 +155,24 @@ func (m *BackendRegistry) registerBackend(service string, b Backend, kind Backen
 	}
 }
 
-// Renew refreshes the last-seen timestamp and hosting kind when service is
-// already registered at endpoint, and reports whether it did.
+// Renew refreshes the last-seen timestamp when service is already registered
+// at endpoint, and reports whether it did.
+//
+// An entry's kind is fixed at registration and never changes here. The
+// sweeper acts only on BackendKindExternal, so letting a caller relabel an
+// existing entry would let it either arm eviction against a backend the
+// gateway shares across its own services, or exempt itself from eviction
+// entirely. A same-name registration at a different endpoint falls through
+// to registerBackend's same-name branch instead, which is out of scope here.
 //
 // A false result means the caller must dial a new backend and call
 // RegisterBackend (new service or changed endpoint).
-func (m *BackendRegistry) Renew(service, endpoint string, kind BackendKind) bool {
+func (m *BackendRegistry) Renew(service, endpoint string) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	entry, ok := m.backends[service]
 	if ok && entry.backend.Endpoint() == endpoint {
-		entry.kind = kind
 		entry.lastSeenAt = time.Now().UTC()
 		m.backends[service] = entry
 		return true
@@ -176,10 +190,44 @@ func (m *BackendRegistry) Renew(service, endpoint string, kind BackendKind) bool
 func (m *BackendRegistry) Close() error {
 	var err error
 	for _, entry := range m.takeBackends() {
-		err = errors.Join(err, entry.backend.Close())
+		err = errors.Join(err, entry.Close())
 	}
 
 	return err
+}
+
+// EvictStale removes external backends not refreshed since before and
+// returns the entries it removed.
+//
+// Only BackendKindExternal entries are eligible. That is the sole kind that
+// heartbeats — builtin and in-process entries are registered once and never
+// renewed, so a stale lastSeenAt on them reflects gateway startup, not a dead
+// process. It is also the sole kind with a 1:1 connection: builtin and
+// in-process entries share one loopback backend across several service keys,
+// and closing it here would tear down every other service hosted on that
+// backend along with the one that looked stale.
+func (m *BackendRegistry) EvictStale(before time.Time) []BackendEntry {
+	evicted := m.evictStale(before)
+	for _, entry := range evicted {
+		_ = entry.Close()
+	}
+
+	return evicted
+}
+
+func (m *BackendRegistry) evictStale(before time.Time) []BackendEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var evicted []BackendEntry
+	for service, entry := range m.backends {
+		if entry.Kind() == BackendKindExternal && entry.LastSeenAt().Before(before) {
+			evicted = append(evicted, entry)
+			delete(m.backends, service)
+		}
+	}
+
+	return evicted
 }
 
 // takeBackends atomically returns the registered backends and clears the

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -17,10 +17,14 @@ import (
 
 // fakeBackend is a test double for the Backend interface.
 //
-// Close is idempotent via sync.Once, mirroring the real backend, so tests that
-// close it more than once still see closeCount == 1.
+// Close is idempotent via sync.Once, mirroring the real backend, so tests
+// that close it more than once still see CloseCount() == 1. closed and
+// closeCount are guarded by mu, since Closed and CloseCount are polled from
+// a goroutine other than the one that calls Close (require.Eventually runs
+// its condition on its own goroutine).
 type fakeBackend struct {
 	endpoint   string
+	mu         sync.Mutex
 	closed     bool
 	closeCount int
 	closeOnce  sync.Once
@@ -38,10 +42,26 @@ func (m *fakeBackend) BuildError(bool, error) ([]byte, error)         { return n
 
 func (m *fakeBackend) Close() error {
 	m.closeOnce.Do(func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
 		m.closed = true
 		m.closeCount++
 	})
 	return nil
+}
+
+// Closed reports whether Close has run.
+func (m *fakeBackend) Closed() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closed
+}
+
+// CloseCount returns how many times the underlying close work has run.
+func (m *fakeBackend) CloseCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closeCount
 }
 
 // Ensure fakeBackend satisfies both interfaces at compile time.
@@ -55,7 +75,7 @@ func TestBackendRegistry_FirstRegistration(t *testing.T) {
 	status := reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
 
 	require.Equal(t, RegistrationRegistered, status)
-	require.False(t, b.closed)
+	require.False(t, b.Closed())
 
 	entry, ok := reg.backends["svc.Foo"]
 	require.True(t, ok)
@@ -75,10 +95,10 @@ func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
 	require.Equal(t, RegistrationRenewed, status)
 
 	// The redundant new backend must be closed.
-	require.True(t, second.closed, "redundant backend should be closed")
+	require.True(t, second.Closed(), "redundant backend should be closed")
 
 	// The original backend must still be open and retained.
-	require.False(t, original.closed, "original backend must remain open")
+	require.False(t, original.Closed(), "original backend must remain open")
 
 	entry, ok := reg.backends["svc.Foo"]
 	require.True(t, ok)
@@ -100,10 +120,10 @@ func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
 	require.Equal(t, RegistrationUpdated, status)
 
 	// The previous backend must be closed.
-	require.True(t, prev.closed, "previous backend should be closed")
+	require.True(t, prev.Closed(), "previous backend should be closed")
 
 	// The new backend must be open.
-	require.False(t, next.closed, "new backend must remain open")
+	require.False(t, next.Closed(), "new backend must remain open")
 
 	entry, ok := reg.backends["svc.Foo"]
 	require.True(t, ok)
@@ -122,8 +142,8 @@ func TestBackendRegistry_Close(t *testing.T) {
 	err := reg.Close()
 	require.NoError(t, err)
 
-	require.True(t, bA.closed, "bA should be closed")
-	require.True(t, bB.closed, "bB should be closed")
+	require.True(t, bA.Closed(), "bA should be closed")
+	require.True(t, bB.Closed(), "bB should be closed")
 
 	// Registry must be empty after Close.
 	require.Empty(t, reg.backends)
@@ -143,7 +163,7 @@ func TestBackendRegistry_CloseSharedBackendOnce(t *testing.T) {
 
 	// Close is called once per registry entry (two), but the backend's own
 	// idempotency (sync.Once) ensures the underlying work runs exactly once.
-	require.Equal(t, 1, shared.closeCount, "shared backend must be closed exactly once")
+	require.Equal(t, 1, shared.CloseCount(), "shared backend must be closed exactly once")
 
 	// Registry must be empty after Close.
 	require.Empty(t, reg.backends)
@@ -159,16 +179,16 @@ func TestBackendRegistry_Renew(t *testing.T) {
 	// Sleep briefly so lastSeenAt can advance.
 	time.Sleep(time.Millisecond)
 
-	ok := reg.Renew("svc.Foo", "127.0.0.1:9000", BackendKindExternal)
+	ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
 	require.True(t, ok, "Renew should return true for matching endpoint")
 	require.True(t, reg.backends["svc.Foo"].lastSeenAt.After(before), "lastSeenAt should advance")
 
 	// Wrong endpoint: Renew must return false.
-	ok = reg.Renew("svc.Foo", "127.0.0.1:9999", BackendKindExternal)
+	ok = reg.Renew("svc.Foo", "127.0.0.1:9999")
 	require.False(t, ok, "Renew should return false for different endpoint")
 
 	// Absent service: Renew must return false.
-	ok = reg.Renew("svc.Missing", "127.0.0.1:9000", BackendKindExternal)
+	ok = reg.Renew("svc.Missing", "127.0.0.1:9000")
 	require.False(t, ok, "Renew should return false for absent service")
 }
 
@@ -191,7 +211,7 @@ func TestBackendRegistry_ConcurrentRace(t *testing.T) {
 			defer func() { done <- struct{}{} }()
 			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
 			reg.RegisterBackend("svc.Race", b, BackendKindExternal)
-			reg.Renew("svc.Race", "127.0.0.1:9000", BackendKindExternal)
+			reg.Renew("svc.Race", "127.0.0.1:9000")
 			reg.GetBackend("svc.Race")
 			reg.ListBackends()
 		}()
@@ -225,16 +245,18 @@ func TestBackendRegistry_KindIsPreserved(t *testing.T) {
 	require.Equal(t, BackendKindExternal, kinds["svc.External"])
 }
 
-func TestBackendRegistry_RenewUpdatesKind(t *testing.T) {
+// TestBackendRegistry_RenewKindIsImmutable verifies that Renew never changes
+// an entry's kind, regardless of what a caller claims, while always
+// reporting success.
+func TestBackendRegistry_RenewKindIsImmutable(t *testing.T) {
 	cases := []struct {
-		name     string
-		initial  BackendKind
-		renewed  BackendKind
-		wantKind BackendKind
+		name    string
+		initial BackendKind
+		claimed BackendKind
 	}{
-		{"same kind preserved", BackendKindExternal, BackendKindExternal, BackendKindExternal},
-		{"external to in-process", BackendKindExternal, BackendKindInProcess, BackendKindInProcess},
-		{"in-process to external", BackendKindInProcess, BackendKindExternal, BackendKindExternal},
+		{"same kind claimed", BackendKindExternal, BackendKindExternal},
+		{"external claims in-process", BackendKindExternal, BackendKindInProcess},
+		{"in-process claims external", BackendKindInProcess, BackendKindExternal},
 	}
 
 	for _, tc := range cases {
@@ -243,14 +265,192 @@ func TestBackendRegistry_RenewUpdatesKind(t *testing.T) {
 			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
 			reg.RegisterBackend("svc.Foo", b, tc.initial)
 
-			ok := reg.Renew("svc.Foo", "127.0.0.1:9000", tc.renewed)
-			require.True(t, ok)
+			ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
+			require.True(t, ok, "Renew must report success even though the kind claim has no effect")
 
 			entries := reg.ListBackends()
 			require.Len(t, entries, 1)
-			require.Equal(t, tc.wantKind, entries[0].Kind())
+			require.Equal(t, tc.initial, entries[0].Kind(), "kind must stay as it was at registration")
 		})
 	}
+}
+
+// TestBackendRegistry_EvictStaleRemovesExternal verifies that a stale
+// external backend is removed from the registry and closed exactly once.
+func TestBackendRegistry_EvictStaleRemovesExternal(t *testing.T) {
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+
+	past := time.Now().UTC().Add(-time.Hour)
+	entry := reg.backends["svc.Foo"]
+	entry.lastSeenAt = past
+	reg.backends["svc.Foo"] = entry
+
+	evicted := reg.EvictStale(time.Now().UTC())
+
+	require.Len(t, evicted, 1)
+	require.Equal(t, "svc.Foo", evicted[0].Service())
+	require.Equal(t, 1, b.CloseCount(), "evicted backend must be closed exactly once")
+
+	_, ok := reg.backends["svc.Foo"]
+	require.False(t, ok, "evicted entry must be removed from the registry")
+}
+
+// TestBackendRegistry_EvictStaleSparesNonExternal verifies that stale
+// builtin and in-process entries are never evicted or closed.
+//
+// This is the regression guard for the constraint that only
+// BackendKindExternal entries heartbeat: builtin and in-process entries may
+// share the gateway's loopback backend with other live services.
+func TestBackendRegistry_EvictStaleSparesNonExternal(t *testing.T) {
+	reg := NewBackendRegistry()
+	builtin := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	inProc := &fakeBackend{endpoint: "127.0.0.1:9001"}
+	reg.RegisterBackend("svc.Builtin", builtin, BackendKindBuiltin)
+	reg.RegisterBackend("svc.InProcess", inProc, BackendKindInProcess)
+
+	past := time.Now().UTC().Add(-24 * time.Hour)
+	for _, service := range []string{"svc.Builtin", "svc.InProcess"} {
+		entry := reg.backends[service]
+		entry.lastSeenAt = past
+		reg.backends[service] = entry
+	}
+
+	evicted := reg.EvictStale(time.Now().UTC())
+
+	require.Empty(t, evicted)
+	require.False(t, builtin.Closed(), "builtin backend must not be closed")
+	require.False(t, inProc.Closed(), "in-process backend must not be closed")
+
+	_, ok := reg.backends["svc.Builtin"]
+	require.True(t, ok, "builtin entry must remain registered")
+	_, ok = reg.backends["svc.InProcess"]
+	require.True(t, ok, "in-process entry must remain registered")
+}
+
+// TestBackendRegistry_EvictStaleSparesSharedBackend verifies that evicting a
+// stale external entry leaves a shared builtin backend, registered under
+// several service keys, open and its keys intact.
+func TestBackendRegistry_EvictStaleSparesSharedBackend(t *testing.T) {
+	reg := NewBackendRegistry()
+	shared := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
+
+	ext := &fakeBackend{endpoint: "127.0.0.1:9001"}
+	reg.RegisterBackend("svc.External", ext, BackendKindExternal)
+
+	past := time.Now().UTC().Add(-time.Hour)
+	entry := reg.backends["svc.External"]
+	entry.lastSeenAt = past
+	reg.backends["svc.External"] = entry
+
+	evicted := reg.EvictStale(time.Now().UTC())
+
+	require.Len(t, evicted, 1)
+	require.Equal(t, "svc.External", evicted[0].Service())
+	require.True(t, ext.Closed(), "external backend must be closed")
+	require.Equal(t, 0, shared.CloseCount(), "shared backend must remain open")
+
+	_, ok := reg.backends["svc.A"]
+	require.True(t, ok, "svc.A must remain registered")
+	_, ok = reg.backends["svc.B"]
+	require.True(t, ok, "svc.B must remain registered")
+}
+
+// TestBackendRegistry_RenewSavesFromEviction verifies that a Renew after
+// registration refreshes lastSeenAt so the entry survives a sweep whose
+// cutoff would otherwise have evicted it.
+func TestBackendRegistry_RenewSavesFromEviction(t *testing.T) {
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+
+	past := time.Now().UTC().Add(-time.Hour)
+	entry := reg.backends["svc.Foo"]
+	entry.lastSeenAt = past
+	reg.backends["svc.Foo"] = entry
+
+	ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
+	require.True(t, ok)
+
+	evicted := reg.EvictStale(time.Now().UTC().Add(-time.Minute))
+
+	require.Empty(t, evicted)
+	require.False(t, b.Closed(), "renewed backend must not be closed")
+
+	_, ok = reg.backends["svc.Foo"]
+	require.True(t, ok, "renewed entry must remain registered")
+}
+
+// TestBackendRegistry_EvictStaleCutoffOlderThanAllEntriesRemovesNothing
+// verifies that a cutoff older than every entry's lastSeenAt evicts nothing.
+func TestBackendRegistry_EvictStaleCutoffOlderThanAllEntriesRemovesNothing(t *testing.T) {
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+
+	evicted := reg.EvictStale(time.Now().UTC().Add(-time.Hour))
+
+	require.Empty(t, evicted)
+	require.False(t, b.Closed())
+
+	_, ok := reg.backends["svc.Foo"]
+	require.True(t, ok, "entry must remain registered")
+}
+
+// TestBackendRegistry_RenewCannotArmSweeperAgainstSharedBackend verifies
+// that renewing a builtin entry cannot relabel it as external.
+//
+// This is the regression guard for the loopback hazard: a Register RPC that
+// names a builtin service's own endpoint must not relabel that entry, or
+// the sweeper would later evict and close a backend shared with every other
+// in-process service.
+func TestBackendRegistry_RenewCannotArmSweeperAgainstSharedBackend(t *testing.T) {
+	reg := NewBackendRegistry()
+	shared := &fakeBackend{endpoint: "127.0.0.1:8080"}
+	reg.RegisterBackend("controlplane.ynpb.v1.Gateway", shared, BackendKindBuiltin)
+
+	ok := reg.Renew("controlplane.ynpb.v1.Gateway", "127.0.0.1:8080")
+	require.True(t, ok)
+
+	after := time.Now().UTC()
+	evicted := reg.EvictStale(after)
+
+	require.Empty(t, evicted, "a builtin entry must never be evicted, even after a spoofed renewal")
+	require.False(t, shared.Closed(), "shared backend must not be closed")
+
+	entry, ok := reg.backends["controlplane.ynpb.v1.Gateway"]
+	require.True(t, ok, "entry must remain registered")
+	require.Equal(t, BackendKindBuiltin, entry.Kind(), "entry must keep its original kind")
+}
+
+// TestBackendRegistry_RenewCannotExemptExternalFromEviction verifies that
+// renewing an external entry cannot relabel it out of the sweeper's reach.
+//
+// This is the regression guard for the reverse hazard: if a renewal could
+// demote an external entry, a separate-process backend would become
+// permanently non-evictable the moment it stopped heartbeating.
+func TestBackendRegistry_RenewCannotExemptExternalFromEviction(t *testing.T) {
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+
+	ok := reg.Renew("svc.Foo", "127.0.0.1:9000")
+	require.True(t, ok)
+
+	cutoff := time.Now().UTC()
+
+	entry := reg.backends["svc.Foo"]
+	entry.lastSeenAt = cutoff.Add(-time.Hour)
+	reg.backends["svc.Foo"] = entry
+
+	evicted := reg.EvictStale(cutoff)
+
+	require.Len(t, evicted, 1)
+	require.Equal(t, "svc.Foo", evicted[0].Service())
+	require.True(t, b.Closed(), "entry must not have become immortal after a renewal")
 }
 
 // TestGatewayService_RegisterKindResolution verifies that the Register RPC

--- a/controlplane/gateway/service.go
+++ b/controlplane/gateway/service.go
@@ -140,7 +140,7 @@ func (m *GatewayService) Register(
 	// A registration that races in between this check and RegisterBackend
 	// below is resolved there authoritatively (the redundant connection is
 	// closed), so this check need not be the linearization point.
-	if m.registry.Renew(backendDesc.GetName(), backendDesc.GetEndpoint(), kind) {
+	if m.registry.Renew(backendDesc.GetName(), backendDesc.GetEndpoint()) {
 		log.Debug("renewed service registration in registry")
 		return &ynpb.RegisterResponse{Status: registrationStatusToProto(RegistrationRenewed)}, nil
 	}

--- a/lint/encapsulation/allowlist-private.txt
+++ b/lint/encapsulation/allowlist-private.txt
@@ -27,14 +27,12 @@ controlplane/gateway/gateway.go:Gateway.Run:runner.module  # legacy: encapsulate
 controlplane/gateway/gateway.go:NewGateway:entry.kind  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/gateway.go:NewGateway:entry.service  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/metrics_service.go:metricsCollectors:entry.service  # legacy: encapsulate behind an exported method or field
-controlplane/gateway/registry.go:BackendRegistry.Close:entry.backend  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.GetBackend:entry.backend  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.ListBackends:entry.service  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.backend  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.kind  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.lastSeenAt  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.Renew:entry.backend  # legacy: encapsulate behind an exported method or field
-controlplane/gateway/registry.go:BackendRegistry.Renew:entry.kind  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.Renew:entry.lastSeenAt  # legacy: encapsulate behind an exported method or field
 controlplane/internal/auth/sshcert/authenticator.go:Authenticator.Authenticate:token.canonicalSignedData  # legacy: encapsulate behind an exported method or field
 controlplane/internal/auth/sshcert/authenticator.go:Authenticator.Authenticate:token.checkTimestamp  # legacy: encapsulate behind an exported method or field


### PR DESCRIPTION
The gateway backend registry had no removal path at all: an entry, once registered, stayed until the process stopped. An operator that was shut down or crashed therefore remained listed indefinitely, and the gateway kept proxying requests into a backend that was gone. Backends that stop refreshing their registration are now dropped after a configurable timeout.

Only self-registering external backends are eligible for eviction. They are the only ones that heartbeat, and the only ones that own their connection instead of sharing the one the gateway hosts its own services on, so built-in and in-process services are never evicted no matter how long ago they registered. A registration refresh may no longer relabel an existing entry as external either, which would otherwise let a caller aim eviction at a connection the gateway shares between services.

The behaviour can be switched off with an explicit setting that keeps every backend for the lifetime of the gateway, and the timeout and sweep period are configurable alongside it. Invalid values are rejected at config load with the offending key named.

On upgrade, an already-installed default config that predates this change has no registry section, so eviction is enabled with a five-minute timeout and a thirty-second sweep. A deployment running an operator configured to re-register less often than that must raise the timeout to match, or that operator will flap in and out of the registry.

Also retires one row from the encapsulation ledger, which the new entry-owned close method makes obsolete.