### PR TITLE
fix(gateway): keep a shared backend open while other services still use it

### DIFF
--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -118,12 +118,12 @@ func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, bool) {
 // the registry changed.
 //
 // The displaced backend (the previous one on an endpoint change, or the
-// redundant new one on an unchanged-endpoint re-registration) is closed after
-// the lock is released.
-//
-// This close-on-displace path applies only to 1:1 external module backends.
-// The shared loopback backend is registered once under distinct keys and is
-// never displaced, so it is only closed by Close().
+// redundant new one on an unchanged-endpoint re-registration) is closed
+// after the lock is released, but only once no service name in the registry
+// still resolves to it: displacing one of the names a backend is registered
+// under leaves it open for as long as another name still points at it. This
+// matters because one dialed connection, such as the gateway's own loopback
+// backend, is commonly registered under several service names at once.
 func (m *BackendRegistry) RegisterBackend(service string, b Backend, kind BackendKind) RegistrationStatus {
 	status, evicted := m.registerBackend(service, b, kind)
 	if evicted != nil {
@@ -142,17 +142,30 @@ func (m *BackendRegistry) registerBackend(service string, b Backend, kind Backen
 	existing, ok := m.backends[service]
 	switch {
 	case ok && existing.backend.Endpoint() == b.Endpoint():
-		existing.kind = kind
 		existing.lastSeenAt = now
 		m.backends[service] = existing
-		return RegistrationRenewed, b
+		return RegistrationRenewed, m.unreferencedBackend(b)
 	case ok:
 		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
-		return RegistrationUpdated, existing.backend
+		return RegistrationUpdated, m.unreferencedBackend(existing.backend)
 	default:
 		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
 		return RegistrationRegistered, nil
 	}
+}
+
+// unreferencedBackend returns backend if no entry in the registry points at
+// it, or nil if some entry still does.
+//
+// Must be called with m.mu held.
+func (m *BackendRegistry) unreferencedBackend(backend Backend) Backend {
+	for _, entry := range m.backends {
+		if entry.GetBackend() == backend {
+			return nil
+		}
+	}
+
+	return backend
 }
 
 // Renew refreshes the last-seen timestamp when service is already registered

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -87,7 +87,8 @@ func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
 	original := &fakeBackend{endpoint: "127.0.0.1:9000"}
 	reg.RegisterBackend("svc.Foo", original, BackendKindExternal)
 
-	// Re-register with a different object but the same endpoint and a changed kind.
+	// Re-register with a different object but the same endpoint and a claimed
+	// kind change.
 	second := &fakeBackend{endpoint: "127.0.0.1:9000"}
 
 	status := reg.RegisterBackend("svc.Foo", second, BackendKindInProcess)
@@ -104,10 +105,13 @@ func TestBackendRegistry_SameEndpointRenews(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, original, entry.backend)
 
-	// A changed kind on the same-endpoint path must be reflected.
-	require.Equal(t, BackendKindInProcess, entry.Kind())
+	// The kind claim must have no effect: it is fixed at registration.
+	require.Equal(t, BackendKindExternal, entry.Kind())
 }
 
+// TestBackendRegistry_DifferentEndpointUpdates verifies that a registration
+// at a changed endpoint replaces the entry and closes the now-unreferenced
+// previous backend exactly once.
 func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
 	reg := NewBackendRegistry()
 	prev := &fakeBackend{endpoint: "127.0.0.1:9000"}
@@ -119,8 +123,8 @@ func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
 
 	require.Equal(t, RegistrationUpdated, status)
 
-	// The previous backend must be closed.
-	require.True(t, prev.Closed(), "previous backend should be closed")
+	// The previous backend must be closed exactly once.
+	require.Equal(t, 1, prev.CloseCount(), "previous backend should be closed exactly once")
 
 	// The new backend must be open.
 	require.False(t, next.Closed(), "new backend must remain open")
@@ -129,6 +133,82 @@ func TestBackendRegistry_DifferentEndpointUpdates(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, next, entry.backend)
 	require.Equal(t, "127.0.0.1:9001", entry.Endpoint())
+}
+
+// TestBackendRegistry_FreshNameSucceedsForEveryKind verifies that
+// registering a name with no existing entry succeeds regardless of the
+// backend kind.
+//
+// This guards the invariant that admitting a not-yet-known name never
+// depends on which kind is claimed for it.
+func TestBackendRegistry_FreshNameSucceedsForEveryKind(t *testing.T) {
+	kinds := []BackendKind{BackendKindBuiltin, BackendKindInProcess, BackendKindExternal}
+
+	for _, kind := range kinds {
+		t.Run(kind.String(), func(t *testing.T) {
+			reg := NewBackendRegistry()
+			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+
+			regStatus := reg.RegisterBackend("svc.Foo", b, kind)
+
+			require.Equal(t, RegistrationRegistered, regStatus)
+			require.False(t, b.Closed())
+		})
+	}
+}
+
+// TestBackendRegistry_DisplacingOneOfSeveralSharedNamesKeepsBackendOpen
+// verifies that displacing one of several service names sharing a backend
+// leaves that backend open and every other name still resolving to it.
+//
+// This is the regression guard for the shared loopback hazard: the gateway
+// dials one connection and registers it under many service names, so
+// closing it out from under the names that still use it would take down
+// every one of those services, not just the displaced name.
+func TestBackendRegistry_DisplacingOneOfSeveralSharedNamesKeepsBackendOpen(t *testing.T) {
+	reg := NewBackendRegistry()
+	shared := &fakeBackend{endpoint: "127.0.0.1:8080"}
+	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
+
+	other := &fakeBackend{endpoint: "127.0.0.1:9999"}
+	status := reg.RegisterBackend("svc.A", other, BackendKindExternal)
+
+	require.Equal(t, RegistrationUpdated, status)
+	require.False(t, shared.Closed(), "the shared backend must not be closed")
+
+	entryA, ok := reg.backends["svc.A"]
+	require.True(t, ok)
+	require.Equal(t, other, entryA.backend)
+
+	entryB, ok := reg.backends["svc.B"]
+	require.True(t, ok)
+	require.Equal(t, shared, entryB.backend)
+}
+
+// TestBackendRegistry_DisplacingLastSharedNameClosesBackend verifies that
+// displacing the last service name still referencing a backend does close
+// it, exactly once, so the fix does not simply leak every displaced
+// connection.
+func TestBackendRegistry_DisplacingLastSharedNameClosesBackend(t *testing.T) {
+	reg := NewBackendRegistry()
+	shared := &fakeBackend{endpoint: "127.0.0.1:8080"}
+	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
+
+	otherA := &fakeBackend{endpoint: "127.0.0.1:9998"}
+	reg.RegisterBackend("svc.A", otherA, BackendKindExternal)
+	require.False(t, shared.Closed(), "the shared backend must remain open while svc.B references it")
+
+	otherB := &fakeBackend{endpoint: "127.0.0.1:9999"}
+	status := reg.RegisterBackend("svc.B", otherB, BackendKindExternal)
+
+	require.Equal(t, RegistrationUpdated, status)
+	require.Equal(t, 1, shared.CloseCount(), "the last-referenced backend must be closed exactly once")
+
+	entryB, ok := reg.backends["svc.B"]
+	require.True(t, ok)
+	require.Equal(t, otherB, entryB.backend)
 }
 
 func TestBackendRegistry_Close(t *testing.T) {

--- a/lint/encapsulation/allowlist-private.txt
+++ b/lint/encapsulation/allowlist-private.txt
@@ -30,7 +30,6 @@ controlplane/gateway/metrics_service.go:metricsCollectors:entry.service  # legac
 controlplane/gateway/registry.go:BackendRegistry.GetBackend:entry.backend  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.ListBackends:entry.service  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.backend  # legacy: encapsulate behind an exported method or field
-controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.kind  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.registerBackend:existing.lastSeenAt  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.Renew:entry.backend  # legacy: encapsulate behind an exported method or field
 controlplane/gateway/registry.go:BackendRegistry.Renew:entry.lastSeenAt  # legacy: encapsulate behind an exported method or field


### PR DESCRIPTION
The gateway dials a single connection at startup and registers it under several service names at once — its own registry, auth, readiness and metrics services, plus every service hosted in the gateway process. Replacing any one of those names closed that shared connection, so a registration aimed at a single service silently took down every other service reachable through it, until the process was restarted. A displaced backend is now closed only once no registered name still resolves to it, so losing one name affects only that name.

A registration refresh also no longer changes how an existing service is recorded as being hosted. That mattered once stale backends became evictable: only self-registering backends are eligible for eviction, so accepting the caller-supplied hosting claim on a refresh let a registration mark the gateway's own shared connection as evictable, after which it was reaped on the next sweep with the same consequences. Registrations that genuinely move a self-registering service to a new address are unaffected, and a name lost to a takeover recovers exactly as it did before.

Also retires one row from the encapsulation ledger, which the removed assignment made stale.