### PR TITLE
fix(dataplane): recover the physical to virtio relay after tx overload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -584,6 +584,10 @@ jobs:
           tail -n 100 main/test.log 2>/dev/null || echo "main/test.log not found"
 
           echo ""
+          echo "=== virtio_stall/test.log (last 100 lines) ==="
+          tail -n 100 virtio_stall/test.log 2>/dev/null || echo "virtio_stall/test.log not found"
+
+          echo ""
           echo "=== converted/test.log (last 100 lines) ==="
           tail -n 100 converted/test.log 2>/dev/null || echo "converted/test.log not found"
 
@@ -597,4 +601,5 @@ jobs:
           name: functional-test-logs
           path: |
             tests/functional/main/test.log
+            tests/functional/virtio_stall/test.log
             tests/functional/converted/test.log

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -187,6 +187,7 @@ func (m *Counters) Workers(
 			LocalTxDrops:    worker.LocalTxDrops,
 			RemoteTxDrops:   worker.RemoteTxDrops,
 			Drops:           worker.Drops,
+			RemoteTxPending: worker.RemoteTxPending,
 		})
 	}
 
@@ -279,6 +280,7 @@ func workerMetrics(workers []ffi.WorkerCounter) []*commonpb.Metric {
 			makeCounter("yanet_worker_local_tx_drops", worker.LocalTxDrops, labels...),
 			makeCounter("yanet_worker_remote_tx_drops", worker.RemoteTxDrops, labels...),
 			makeCounter("yanet_worker_drops", worker.Drops, labels...),
+			makeGauge("yanet_worker_remote_tx_pending", float64(worker.RemoteTxPending), labels...),
 		)
 
 		if len(worker.RxBursts) > 0 {
@@ -297,6 +299,14 @@ func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb
 		Name:   name,
 		Labels: labels,
 		Value:  &commonpb.Metric_Counter{Counter: value},
+	}
+}
+
+func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
+	return &commonpb.Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &commonpb.Metric_Gauge{Gauge: value},
 	}
 }
 

--- a/controlplane/ffi/worker.go
+++ b/controlplane/ffi/worker.go
@@ -29,6 +29,7 @@ type WorkerCounter struct {
 	LocalTxDrops    uint64
 	RemoteTxDrops   uint64
 	Drops           uint64
+	RemoteTxPending uint64
 }
 
 func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
@@ -56,6 +57,9 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 	localTxDropsHandle := counterByName["local_tx_drops"]
 	remoteTxDropsHandle := counterByName["remote_tx_drops"]
 	dropsHandle := counterByName["drops"]
+	// This counter is absent in an older, version-skewed dataplane, so its
+	// handle may be nil and must be guarded before use.
+	remoteTxPendingHandle := counterByName["remote_tx_pending"]
 
 	workerCount := counters.instance_count
 	result := make([]WorkerCounter, workerCount)
@@ -122,6 +126,13 @@ func (m *DPConfig) WorkerCounters() ([]WorkerCounter, error) {
 			)),
 		}
 
+		if remoteTxPendingHandle != nil {
+			worker.RemoteTxPending = uint64(C.yanet_get_counter_value(
+				remoteTxPendingHandle.values,
+				workerCounterSingleValueIdx,
+				idx,
+			))
+		}
 		rxBurstSize := uint32(metadata.rx_burst_size) + 1
 		worker.RxBursts = make([]uint64, rxBurstSize)
 		for burstIdx := C.uint64_t(0); burstIdx < rxBurstsHandle.size; burstIdx++ {

--- a/controlplane/ynpb/v1/counters.proto
+++ b/controlplane/ynpb/v1/counters.proto
@@ -74,6 +74,9 @@ message WorkerCounter {
   uint64 remote_tx_drops = 15;
   // Total packets dropped by this worker for any reason.
   uint64 drops = 16;
+  // Packets currently held in this worker's remote-tx pending FIFOs
+  // awaiting NIC completion.
+  uint64 remote_tx_pending = 17;
 }
 
 // Requests a snapshot of raw cumulative per-port extended stats counters.

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -69,9 +69,9 @@ dataplane_worker_connect(
 
 	if (!(wrk_rx->write_ctx.rx_pipe_count &
 	      (wrk_rx->write_ctx.rx_pipe_count + 1))) {
-		struct data_pipe *pipes = (struct data_pipe *)realloc(
+		struct worker_rx_pipe *pipes = (struct worker_rx_pipe *)realloc(
 			wrk_rx->write_ctx.rx_pipes,
-			sizeof(struct data_pipe) * 2 *
+			sizeof(struct worker_rx_pipe) * 2 *
 				(wrk_rx->write_ctx.rx_pipe_count + 1)
 		);
 		if (pipes == NULL)
@@ -83,8 +83,22 @@ dataplane_worker_connect(
 	if (data_pipe_init(&tx_pipe->pipe, WORKER_TX_PIPE_SIZE))
 		return -1;
 
+	// Size the deferred-free ring so the pipe can never wedge waiting for
+	// space.
+	//
+	// Pending occupancy is bounded by packets still in the pipe (at most
+	// the pipe capacity) plus accepted-but-unreclaimed packets (at most
+	// the consumer's tx queue depth, since completions are reclaimed in
+	// order). So the pending ring can never fill while the pipe is empty.
+	// A producer always makes progress into the pipe, and un-accepted
+	// packets left in the pipe guarantee the consumer keeps issuing the
+	// nonzero tx bursts that let the PMD reclaim completions.
+	uint16_t consumer_tx_queue_len = wrk_rx->config.tx_queue_len
+						 ? wrk_rx->config.tx_queue_len
+						 : 4096;
+	uint32_t pipe_capacity = 1u << WORKER_TX_PIPE_SIZE;
 	uint32_t pending_capacity =
-		1u << (WORKER_TX_PIPE_SIZE + WORKER_TX_PIPE_PENDING_SHIFT);
+		rte_align32pow2(pipe_capacity + consumer_tx_queue_len + 1);
 	tx_pipe->pending_mbufs = (struct worker_pending_mbuf *)malloc(
 		sizeof(struct worker_pending_mbuf) * pending_capacity
 	);
@@ -98,8 +112,11 @@ dataplane_worker_connect(
 
 	++tx_conn->count;
 
-	*(wrk_rx->write_ctx.rx_pipes + wrk_rx->write_ctx.rx_pipe_count++) =
-		tx_pipe->pipe;
+	struct worker_rx_pipe *rx_pipe =
+		wrk_rx->write_ctx.rx_pipes + wrk_rx->write_ctx.rx_pipe_count++;
+	rx_pipe->pipe = tx_pipe->pipe;
+	rx_pipe->stall_head = NULL;
+	rx_pipe->stall_rounds = 0;
 
 	return 0;
 }

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -119,29 +119,191 @@ worker_connection_push_cb(void **item, size_t count, void *data) {
 	return 0;
 }
 
+// Carries the per-pipe retry state into worker_rx_pipe_pop_cb, which the
+// data_pipe callback signature has no room for.
+struct worker_rx_pop_ctx {
+	struct dataplane_worker *worker;
+	struct worker_rx_pipe *rx_pipe;
+};
+
+// Tracks how many consecutive rounds the same head has been rejected,
+// reporting when the retry budget is spent.
+static bool
+worker_rx_pipe_note_rejected_head(
+	struct worker_rx_pipe *rx_pipe, struct rte_mbuf *head
+) {
+	if (rx_pipe->stall_head == head) {
+		++rx_pipe->stall_rounds;
+	} else {
+		rx_pipe->stall_head = head;
+		rx_pipe->stall_rounds = 1;
+	}
+
+	if (rx_pipe->stall_rounds > WORKER_TX_RETRY_ROUND_LIMIT) {
+		// Saturate so a very long stall cannot wrap the counter.
+		rx_pipe->stall_rounds = WORKER_TX_RETRY_ROUND_LIMIT + 1;
+		return true;
+	}
+
+	return false;
+}
+
+// Drops a rejected head and folds its accounting into the shared
+// counters, then clears stall tracking so the next round starts fresh.
+static void
+worker_rx_pipe_drop_head(
+	struct dataplane_worker *worker,
+	struct worker_rx_pipe *rx_pipe,
+	struct rte_mbuf *head
+) {
+	rte_pktmbuf_free(head);
+	*(worker->dp_worker->local_tx_drops) += 1;
+	*(worker->dp_worker->drop_count) += 1;
+	(*worker->dp_worker->remote_rx_count) += 1;
+
+	rx_pipe->stall_head = NULL;
+	rx_pipe->stall_rounds = 0;
+}
+
+// Handles a rejected head whose retry budget is spent.
+//
+// Probes ahead of it to tell a truly stuck head apart from one merely
+// stalled behind a full ring, and returns how many mbufs were consumed
+// from the front of the batch.
+static size_t
+worker_rx_pipe_resolve_stalled_head(
+	struct dataplane_worker *worker,
+	struct worker_rx_pipe *rx_pipe,
+	struct rte_mbuf **mbufs,
+	size_t count
+) {
+	// The budget alone cannot tell a head the NIC will never
+	// accept apart from a head merely caught behind a fully
+	// stalled ring: dropping in the latter case only frees a
+	// pipe slot that the producer immediately refills, so the
+	// pending ring fills up around a consumer that never moves.
+	//
+	// Discriminate by probing the next packet in the batch alone:
+	// if the NIC accepts it, the ring is making progress and the
+	// head itself is at fault, so drop it.
+	//
+	// If the probe is rejected too, every packet is being rejected
+	// right now, so dropping would only feed more packets into the
+	// same trap. Keep retrying instead and the pending occupancy
+	// never grows.
+	if (count >= 2) {
+		uint16_t probe = rte_eth_tx_burst(
+			worker->port_id, worker->queue_id, &mbufs[1], 1
+		);
+
+		if (probe == 1) {
+			*(worker->dp_worker->tx_count) += 1;
+			(*worker->dp_worker->remote_rx_count) += 1;
+
+			// The probe is transmitted ahead of the head
+			// we are about to drop, reordering the two
+			// relative to each other. That is acceptable
+			// here: the alternative is dropping the head
+			// regardless, and the rest of the pipe still
+			// drains in order behind this pair.
+			worker_rx_pipe_drop_head(worker, rx_pipe, mbufs[0]);
+			// Consumes a contiguous prefix: the dropped
+			// head and the transmitted probe.
+			return 2;
+		}
+	} else if (count == 1) {
+		// The window handed to the callback is clipped at the
+		// ring boundary: a head parked in the ring's last
+		// masked slot always sees count == 1, even with a
+		// large backlog wrapped behind it. Tell that case
+		// apart from a genuinely lone head by testing the
+		// head's own slot index against the ring's last slot,
+		// rather than inferring it from count: item points
+		// into pipe->data at the read side's masked_from, so
+		// the head is at the boundary iff that offset is the
+		// ring's last slot. Read the true backlog directly off
+		// the pipe's positions to know whether anything is
+		// queued behind a boundary head worth waiting for.
+		// This mirrors the ordering data_pipe_ring_handle
+		// itself uses for a pop: r_pos is ours (relaxed),
+		// w_pos is the producer's (acquire).
+		struct data_pipe *pipe = &rx_pipe->pipe;
+		size_t backlog =
+			atomic_load_explicit(
+				pipe->w_pos, memory_order_acquire
+			) -
+			atomic_load_explicit(pipe->r_pos, memory_order_relaxed);
+		bool head_at_last_slot = (size_t)((void **)mbufs - pipe->data
+					 ) == (1u << pipe->size) - 1;
+
+		if (head_at_last_slot && backlog >= 2) {
+			// The head sits in the ring's last slot
+			// before the wrap, guaranteed by the
+			// positional check above rather than inferred
+			// from count: the window handed to us is
+			// clipped at the boundary, not because the
+			// head is genuinely alone. There is no second
+			// packet in this batch to probe with, and the
+			// probe above could not reach across the wrap
+			// anyway: the callback may only consume a
+			// contiguous prefix bounded by count, so an
+			// accepted cross-boundary probe could not be
+			// consumed. Fall back to a plain timeout drop
+			// of the head instead, but only once
+			// backlog >= 2 confirms something is actually
+			// queued behind it: a lone boundary head with
+			// nothing behind it must keep waiting, not
+			// drop. During a total stall this costs at
+			// most one drop per stall episode, because
+			// dropping moves the head to the ring's first
+			// slot, where the discriminating probe above
+			// is active again and the pending-occupancy
+			// invariant keeps its slack.
+			worker_rx_pipe_drop_head(worker, rx_pipe, mbufs[0]);
+			return 1;
+		}
+	}
+
+	// Either there was nobody to probe with and nothing queued
+	// behind the head in the ring, so the lone head blocks
+	// nobody, or the probe was rejected too and the ring is
+	// genuinely stalled. Either way, keep waiting instead of
+	// dropping.
+	return 0;
+}
+
 static size_t
 worker_rx_pipe_pop_cb(void **item, size_t count, void *data) {
-	struct dataplane_worker *worker = (struct dataplane_worker *)data;
+	struct worker_rx_pop_ctx *pop_ctx = (struct worker_rx_pop_ctx *)data;
+	struct dataplane_worker *worker = pop_ctx->worker;
+	struct worker_rx_pipe *rx_pipe = pop_ctx->rx_pipe;
 	struct rte_mbuf **mbufs = (struct rte_mbuf **)item;
-
-	(*worker->dp_worker->remote_rx_count) += count;
 
 	size_t written = rte_eth_tx_burst(
 		worker->port_id, worker->queue_id, mbufs, count
 	);
 	*(worker->dp_worker->tx_count) += written;
+	// Count each relayed packet once, at acceptance, not on every retry
+	// of a rejected tail.
+	(*worker->dp_worker->remote_rx_count) += written;
 
-	size_t dropped = count - written;
-	if (dropped > 0) {
-		*(worker->dp_worker->local_tx_drops) += dropped;
-		*(worker->dp_worker->drop_count) += dropped;
+	if (written > 0) {
+		rx_pipe->stall_head = NULL;
+		rx_pipe->stall_rounds = 0;
+		return written;
 	}
 
-	for (size_t idx = written; idx < count; ++idx) {
-		rte_pktmbuf_free(mbufs[idx]);
+	// Nothing was accepted this round: leave the whole batch in the pipe
+	// instead of freeing it, so the next round issues another nonzero
+	// tx_burst and, on virtio, gives the PMD another chance to reclaim
+	// completed descriptors inside that call.
+	if (!worker_rx_pipe_note_rejected_head(rx_pipe, mbufs[0])) {
+		return 0;
 	}
 
-	return count;
+	return worker_rx_pipe_resolve_stalled_head(
+		worker, rx_pipe, mbufs, count
+	);
 }
 
 static size_t
@@ -212,15 +374,23 @@ worker_tx_pipe_reclaim(struct worker_tx_pipe *tx_pipe) {
 
 static void
 worker_collect_from_port(struct dataplane_worker *worker) {
+	uint64_t pending = 0;
+
 	for (uint32_t conn_idx = 0; conn_idx < worker->dataplane->device_count;
 	     ++conn_idx) {
 		struct worker_tx_connection *tx_conn =
 			worker->write_ctx.tx_connections + conn_idx;
 		for (uint32_t pipe_idx = 0; pipe_idx < tx_conn->count;
 		     ++pipe_idx) {
-			worker_tx_pipe_reclaim(tx_conn->pipes + pipe_idx);
+			struct worker_tx_pipe *tx_pipe =
+				tx_conn->pipes + pipe_idx;
+			worker_tx_pipe_reclaim(tx_pipe);
+			pending +=
+				tx_pipe->pending_stop - tx_pipe->pending_start;
 		}
 	}
+
+	*(worker->dp_worker->remote_tx_pending) = pending;
 }
 
 static void
@@ -306,8 +476,12 @@ worker_write(
 
 	// Read incoming mbufs from remote workers and write them to device
 	for (uint32_t pipe_idx = 0; pipe_idx < ctx->rx_pipe_count; ++pipe_idx) {
+		struct worker_rx_pop_ctx pop_ctx = {
+			.worker = worker,
+			.rx_pipe = ctx->rx_pipes + pipe_idx,
+		};
 		data_pipe_item_pop(
-			ctx->rx_pipes + pipe_idx, worker_rx_pipe_pop_cb, worker
+			&pop_ctx.rx_pipe->pipe, worker_rx_pipe_pop_cb, &pop_ctx
 		);
 	}
 }
@@ -580,6 +754,9 @@ dataplane_worker_start(struct dataplane_worker *worker) {
 	dp_worker->remote_tx_drops =
 		counter_get_address(7, worker_counter_storage);
 	dp_worker->drop_count = counter_get_address(8, worker_counter_storage);
+
+	dp_worker->remote_tx_pending =
+		counter_get_address(9, worker_counter_storage);
 
 	pthread_attr_t wrk_th_attr;
 	pthread_attr_init(&wrk_th_attr);

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -16,10 +16,23 @@ struct dp_worker;
 
 // log2 of the per-connection SPSC data pipe capacity.
 #define WORKER_TX_PIPE_SIZE 10
-// The per-pipe deferred-free ring holds 2^(WORKER_TX_PIPE_SIZE + this)
-// mbufs, sized above the pipe capacity to absorb consumer-side NIC tx
-// backlog before backpressure drops further packets.
-#define WORKER_TX_PIPE_PENDING_SHIFT 2
+
+// Bounds head-of-line blocking by a persistently rejected packet.
+//
+// A worker_rx_pipe retries a rejected head instead of dropping it, so a
+// packet that can never be transmitted (for example a chain exceeding the
+// destination NIC's segment limit) would otherwise block the rest of the
+// pipe forever. This is not a flat "drop after N rounds" budget: once the
+// same head has been rejected for this many consecutive rounds, the
+// consumer probes whether the NIC still accepts a different packet from
+// the same batch. Only a head that keeps being rejected while other
+// packets get through is dropped to let the pipe proceed. A ring that is
+// stalled end to end keeps failing the probe too, so it keeps retrying
+// indefinitely and never drops — except when the head sits in the ring's
+// last slot before the wrap, where no probe is possible and the budget
+// falls back to an unconditional drop, bounded to at most one per stall
+// episode.
+#define WORKER_TX_RETRY_ROUND_LIMIT 4096
 
 struct worker_read_ctx {
 	uint16_t read_size;
@@ -36,6 +49,11 @@ struct worker_pending_mbuf {
 // and records it in `pending_mbufs`; the reference is released once the
 // consumer's NIC tx completes. Per-pipe completion is FIFO, so the ring
 // is drained head-first.
+//
+// The deferred-free ring is sized by the consumer's tx queue depth rather
+// than a fixed multiple of the pipe capacity: see the pending_capacity
+// computation in dataplane_worker_connect for the liveness invariant this
+// depends on.
 struct worker_tx_pipe {
 	struct data_pipe pipe;
 	struct worker_pending_mbuf *pending_mbufs;
@@ -49,6 +67,20 @@ struct worker_tx_connection {
 	struct worker_tx_pipe *pipes;
 };
 
+// A consumer-side rx pipe paired with retry-budget tracking for its head.
+//
+// A rejected batch is left in the pipe rather than freed, so the next
+// nonzero tx_burst gets another chance to drain it and, on virtio, lets
+// the PMD reclaim completed descriptors in the process. stall_head and
+// stall_rounds bound how long a single persistently untransmittable
+// packet may block the rest of the pipe behind it, per
+// WORKER_TX_RETRY_ROUND_LIMIT.
+struct worker_rx_pipe {
+	struct data_pipe pipe;
+	struct rte_mbuf *stall_head;
+	uint32_t stall_rounds;
+};
+
 struct worker_write_ctx {
 
 	uint16_t write_size;
@@ -58,7 +90,7 @@ struct worker_write_ctx {
 
 	// pipes to read from another workers
 	uint32_t rx_pipe_count;
-	struct data_pipe *rx_pipes;
+	struct worker_rx_pipe *rx_pipes;
 };
 
 struct dataplane_worker {

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -44,7 +44,7 @@ _Static_assert(
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_worker) == 160,
+	sizeof(struct dp_worker) == 168,
 	"struct dp_worker size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -87,6 +87,12 @@ struct dp_worker {
 	uint32_t device_id;
 	uint32_t queue_id;
 	uint32_t rx_burst_size;
+
+	// Packets currently held in this worker's remote tx pending FIFOs,
+	// awaiting NIC tx completion.
+	//
+	// A gauge, overwritten each round rather than accumulated.
+	uint64_t *remote_tx_pending;
 };
 
 // Value written to dp_config.ready_magic by dp_config_mark_ready once the

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 7
+#define YANET_MODULE_ABI_VERSION 8
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/worker/counters.c
+++ b/lib/dataplane/worker/counters.c
@@ -51,5 +51,8 @@ worker_counters_register(struct dp_config *dp_config) {
 	if (register_one(dp_config, "drops", 1)) {
 		return -1;
 	}
+	if (register_one(dp_config, "remote_tx_pending", 1)) {
+		return -1;
+	}
 	return 0;
 }

--- a/tests/common/data_pipe_tsan.c
+++ b/tests/common/data_pipe_tsan.c
@@ -48,6 +48,101 @@ free_handler(void **items, size_t count, void *ctx) {
 	return 0;
 }
 
+#define PARTIAL_PIPE_SIZE_LOG2 6
+#define PARTIAL_NUM_ITERATIONS 200000
+#define PARTIAL_PUSH_BURST 8
+
+struct data_pipe partial_pipe;
+
+// Producer callback: offers up to PARTIAL_PUSH_BURST sequential values in
+// a single push, mirroring a worker that hands a whole tx_burst-sized
+// batch to a pipe rather than one packet at a time.
+static size_t
+partial_push_handler(void **items, size_t count, void *ctx) {
+	uintptr_t *next = (uintptr_t *)ctx;
+	size_t remaining = PARTIAL_NUM_ITERATIONS - (*next - 1);
+
+	size_t offer = count;
+	if (offer > PARTIAL_PUSH_BURST) {
+		offer = PARTIAL_PUSH_BURST;
+	}
+	if (offer > remaining) {
+		offer = remaining;
+	}
+
+	for (size_t idx = 0; idx < offer; idx++) {
+		items[idx] = (void *)(*next + idx);
+	}
+	*next += offer;
+
+	return offer;
+}
+
+// Consumer callback: deliberately accepts only half of what is offered
+// (rounded down, at least one), leaving a tail in the pipe for the next
+// pop call. This mirrors retry semantics where a rejected mbuf tail stays
+// in the pipe rather than being freed, so the r_pos protocol must stay
+// correct across many consecutive rounds where pop returns less than
+// count.
+static size_t
+partial_pop_handler(void **items, size_t count, void *ctx) {
+	uintptr_t *expected = (uintptr_t *)ctx;
+
+	size_t accept = count / 2;
+	if (accept == 0) {
+		accept = 1;
+	}
+
+	for (size_t idx = 0; idx < accept; idx++) {
+		uintptr_t val = (uintptr_t)items[idx];
+		if (val != *expected) {
+			fprintf(stderr,
+				"PARTIAL CORRUPTION: expected %lu, got %lu\n",
+				(unsigned long)*expected,
+				(unsigned long)val);
+			return 0;
+		}
+		*expected += 1;
+	}
+
+	return accept;
+}
+
+static void *
+partial_producer_thread(void *arg) {
+	(void)arg;
+	uintptr_t next = 1;
+
+	while (next <= PARTIAL_NUM_ITERATIONS) {
+		while (data_pipe_item_push(
+			       &partial_pipe, partial_push_handler, &next
+		       ) == 0) {
+			// If push failed, try to free some items to make space.
+			data_pipe_item_free(&partial_pipe, free_handler, NULL);
+		}
+	}
+
+	printf("Partial producer pushed %lu items\n",
+	       (unsigned long)PARTIAL_NUM_ITERATIONS);
+	return NULL;
+}
+
+static void *
+partial_consumer_thread(void *arg) {
+	(void)arg;
+	uintptr_t expected = 1;
+
+	while (expected <= PARTIAL_NUM_ITERATIONS) {
+		data_pipe_item_pop(
+			&partial_pipe, partial_pop_handler, &expected
+		);
+	}
+
+	printf("Partial consumer processed %lu items\n",
+	       (unsigned long)expected - 1);
+	return NULL;
+}
+
 static void *
 producer_thread(void *arg) {
 	(void)arg;
@@ -93,6 +188,22 @@ main(void) {
 	pthread_join(cons, NULL);
 
 	data_pipe_fini(&shared_pipe);
+
+	printf("Done.\n");
+
+	printf("=== TSAN test: partial-consume (retry) scenario ===\n");
+
+	ret = data_pipe_init(&partial_pipe, PARTIAL_PIPE_SIZE_LOG2);
+	assert(ret == 0);
+
+	pthread_t partial_prod, partial_cons;
+	pthread_create(&partial_prod, NULL, partial_producer_thread, NULL);
+	pthread_create(&partial_cons, NULL, partial_consumer_thread, NULL);
+
+	pthread_join(partial_prod, NULL);
+	pthread_join(partial_cons, NULL);
+
+	data_pipe_fini(&partial_pipe);
 
 	printf("Done.\n");
 	return 0;

--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -53,7 +53,7 @@ endif
 # falling back to the preyanet snapshot only when baseline fails.
 test: prepare-vm
 	@echo "Running all functional tests..."
-	go test -count=1 -v ./main/...
+	go test -count=1 -v -p 1 ./main/... ./virtio_stall/...
 
 # Run main functional tests
 test-main: prepare-vm

--- a/tests/functional/virtio_stall/virtio_tx_stall_test.go
+++ b/tests/functional/virtio_stall/virtio_tx_stall_test.go
@@ -1,0 +1,259 @@
+package virtiostall
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+	"github.com/yanet-platform/yanet2/tests/functional/framework"
+)
+
+const floodPacketCount = 65536
+
+// virtioTXQueueLen must match the tx_queue_len (and rx_queue_len) baked into
+// the virtio worker config by the surgery in TestMain below.
+const virtioTXQueueLen = 32
+
+var testHarness *framework.Harness
+
+func TestMain(m *testing.M) {
+	dataplane := framework.DataplaneConfig(framework.DataplaneOptions{})
+	// The phy worker's mempool must cover its rx ring plus the bounded
+	// pending occupancy of the phy->virtio relay: packets still in the pipe
+	// and the small accepted-but-unreclaimed tail. Keep enough headroom for
+	// that plus the post-flood marker packet.
+	dataplane = strings.Replace(dataplane, "num_mbufs: 2048", "num_mbufs: 4608", 1)
+	if !strings.Contains(dataplane, "num_mbufs: 4608") {
+		fmt.Fprintf(os.Stderr, "failed to set up virtio stall harness: num_mbufs replacement did not take effect, dataplane config template drifted\n")
+		os.Exit(1)
+	}
+	dataplane = strings.Replace(
+		dataplane,
+		"port_name: virtio_user_kni0\n      mac_addr: 52:54:00:6b:ff:a5\n      mtu: 7000\n      max_lro_packet_size: 7200\n      rss_hash: 0\n      workers:\n        - core_id: 0\n          instance_id: 0\n          rx_queue_len: 1024\n          tx_queue_len: 1024",
+		"port_name: virtio_user_kni0\n      mac_addr: 52:54:00:6b:ff:a5\n      mtu: 7000\n      max_lro_packet_size: 7200\n      rss_hash: 0\n      workers:\n        - core_id: 0\n          instance_id: 0\n          rx_queue_len: 32\n          tx_queue_len: 32",
+		1,
+	)
+	if !strings.Contains(dataplane, "rx_queue_len: 32\n          tx_queue_len: 32") {
+		fmt.Fprintf(os.Stderr, "failed to set up virtio stall harness: virtio worker queue length replacement did not take effect, dataplane config template drifted\n")
+		os.Exit(1)
+	}
+
+	harness, cleanup, err := framework.SetupHarness(framework.HarnessConfig{
+		PoolName: "virtio-stall",
+		// Bump this tag whenever the dataplane/CLI binaries or the config
+		// surgery above change: a cached baseline snapshot bakes in the
+		// binaries copied at bake time and is otherwise reused stale.
+		BaselineTag: "virtio-stall-v3",
+		Dataplane:   dataplane,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set up virtio stall harness: %v\n", err)
+		os.Exit(1)
+	}
+	testHarness = harness
+
+	code := m.Run()
+	if err := harness.Shutdown(); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to shut down virtio stall harness: %v\n", err)
+		code = 1
+	}
+	cleanup()
+	os.Exit(code)
+}
+
+type workerCounter struct {
+	WorkerIdx       uint32 `json:"worker_idx"`
+	DeviceID        uint32 `json:"device_id"`
+	RXPackets       uint64 `json:"rx_packets"`
+	TXPackets       uint64 `json:"tx_packets"`
+	RemoteRXPackets uint64 `json:"remote_rx_packets"`
+	RemoteTXPackets uint64 `json:"remote_tx_packets"`
+	LocalTXDrops    uint64 `json:"local_tx_drops"`
+	RemoteTXDrops   uint64 `json:"remote_tx_drops"`
+	Drops           uint64 `json:"drops"`
+	RemoteTXPending uint64 `json:"remote_tx_pending"`
+}
+
+type workerCountersResponse struct {
+	Workers []workerCounter `json:"workers"`
+}
+
+// tryReadWorkerCounters fetches the current worker counter snapshot without
+// failing the test on error, so it is safe to poll from inside
+// require.Eventually.
+func tryReadWorkerCounters(fw *framework.TestFramework) (workerCountersResponse, error) {
+	output, err := fw.ExecuteCommand(
+		fw.Paths.CLI("yanet-cli-counters") + " workers --format json",
+	)
+	if err != nil {
+		return workerCountersResponse{}, err
+	}
+
+	var response workerCountersResponse
+	if err := json.Unmarshal([]byte(output), &response); err != nil {
+		return workerCountersResponse{}, err
+	}
+	if len(response.Workers) != 2 {
+		return workerCountersResponse{}, fmt.Errorf(
+			"unexpected worker count: %d", len(response.Workers),
+		)
+	}
+	return response, nil
+}
+
+// readWorkerCounters polls tryReadWorkerCounters until it succeeds. The
+// serial-console capture can interleave terminal control sequences with the
+// JSON payload, so a single read may fail to parse transiently.
+func readWorkerCounters(t *testing.T, fw *framework.TestFramework) workerCountersResponse {
+	t.Helper()
+
+	var response workerCountersResponse
+	require.Eventually(t, func() bool {
+		var err error
+		response, err = tryReadWorkerCounters(fw)
+		return err == nil
+	}, 5*time.Second, 250*time.Millisecond, "failed to read worker counters")
+
+	return response
+}
+
+func createTaggedSilentUDPv6Packet() []byte {
+	eth := layers.Ethernet{
+		SrcMAC:       framework.MustParseMAC(framework.SrcMAC),
+		DstMAC:       framework.MustParseMAC(framework.DstMAC),
+		EthernetType: layers.EthernetTypeDot1Q,
+	}
+	vlan := layers.Dot1Q{
+		VLANIdentifier: 411,
+		Type:           layers.EthernetTypeIPv6,
+	}
+	ipv6 := layers.IPv6{
+		Version:    6,
+		NextHeader: layers.IPProtocolUDP,
+		HopLimit:   64,
+		SrcIP:      net.ParseIP("2001:db8::1"),
+		// The default forward rule sends fe80::/64 to kni0. This address is
+		// deliberately not local, so Linux silently discards the packet.
+		DstIP: net.ParseIP("fe80::dead:beef"),
+	}
+	udp := layers.UDP{SrcPort: 12345, DstPort: 80}
+	if err := udp.SetNetworkLayerForChecksum(&ipv6); err != nil {
+		panic(err)
+	}
+
+	buf := gopacket.NewSerializeBuffer()
+	if err := gopacket.SerializeLayers(
+		buf,
+		gopacket.SerializeOptions{FixLengths: true, ComputeChecksums: true},
+		&eth,
+		&vlan,
+		&ipv6,
+		&udp,
+		gopacket.Payload(make([]byte, 64)),
+	); err != nil {
+		panic(err)
+	}
+	return buf.Bytes()
+}
+
+func createMarkerPacket(seq uint16) []byte {
+	return framework.CreateICMPv4EchoPacket(
+		net.ParseIP(framework.VMIPv4Gateway),
+		net.ParseIP(framework.VMIPv4Host),
+		1,
+		seq,
+		[]byte("virtio tx recovery marker"),
+	)
+}
+
+func requireMarkerReply(t *testing.T, fw *framework.TestFramework, seq uint16) {
+	t.Helper()
+	_, reply, err := fw.SendPacketAndParse(0, 0, createMarkerPacket(seq), time.Second)
+	require.NoError(t, err, "physical -> virtio -> kernel did not recover")
+	require.NotNil(t, reply)
+	require.Equal(t, framework.VMIPv4Host, reply.SrcIP.String())
+	require.Equal(t, framework.VMIPv4Gateway, reply.DstIP.String())
+}
+
+func TestVirtioTXRecoversAfterOverload(t *testing.T) {
+	testHarness.WithBootedVM(t, func(fw *framework.TestFramework) {
+		activeConfig, err := fw.ExecuteCommand("sed -n '/port_name: virtio_user_kni0/,+12p' /tmp/yanet/config/dataplane.yaml")
+		require.NoError(t, err)
+		t.Logf("active virtio config:\n%s", activeConfig)
+		requireMarkerReply(t, fw, 1)
+		before := readWorkerCounters(t, fw)
+
+		// Keep the DPDK workers running while temporarily starving the
+		// vhost-net completion thread. This deterministically fills the virtio
+		// TX ring and makes rte_eth_tx_burst() return a partial write.
+		hogStatus, err := fw.ExecuteCommand(`vhost_tid=$(ps -eLo tid,comm | awk '$2 ~ /^vhost-/ {print $1; exit}'); test -n "$vhost_tid"; taskset -pc 1 "$vhost_tid"; nohup taskset -c 1 chrt -f 90 sh -c 'while :; do :; done' >/dev/null 2>&1 & echo $! >/tmp/yanet-vhost-hog.pid; sleep 0.2; ps -o cls=,rtprio=,psr=,comm= -p $(cat /tmp/yanet-vhost-hog.pid); taskset -pc "$vhost_tid"`)
+		require.NoError(t, err)
+		t.Logf("vhost starvation setup:\n%s", hogStatus)
+		require.Contains(t, hogStatus, "FF")
+		defer func() {
+			_, _ = fw.ExecuteCommand("kill -9 $(cat /tmp/yanet-vhost-hog.pid) 2>/dev/null; rm -f /tmp/yanet-vhost-hog.pid")
+		}()
+
+		client, err := fw.GetSocketClient(0)
+		require.NoError(t, err)
+		require.NoError(t, framework.WithTimeout(30*time.Second)(client))
+		require.NoError(t, client.Connect())
+
+		packet := createTaggedSilentUDPv6Packet()
+		packets := make([][]byte, floodPacketCount)
+		for idx := range packets {
+			packets[idx] = packet
+		}
+		require.NoError(t, client.SendPackets(packets, ""))
+
+		// Read the counters while the hog still starves the vhost-net
+		// completion thread, so the pending FIFOs and drop counters reflect
+		// the backpressure the flood created.
+		afterFlood := readWorkerCounters(t, fw)
+		t.Logf("workers before: %+v", before.Workers)
+		t.Logf("workers after flood: %+v", afterFlood.Workers)
+		require.Greater(t, afterFlood.Workers[0].RemoteTXPending, uint64(0),
+			"phy worker did not accumulate pending remote-tx packets under backpressure")
+		require.Greater(t, afterFlood.Workers[0].RemoteTXDrops, before.Workers[0].RemoteTXDrops,
+			"test did not create inter-worker backpressure")
+
+		_, err = fw.ExecuteCommand("kill -9 $(cat /tmp/yanet-vhost-hog.pid) 2>/dev/null; rm -f /tmp/yanet-vhost-hog.pid")
+		require.NoError(t, err)
+
+		// Give vhost-net time to complete accepted descriptors. The dataplane
+		// must then make forward progress without another flood or a restart.
+		time.Sleep(500 * time.Millisecond)
+
+		require.Eventually(t, func() bool {
+			_, reply, markerErr := fw.SendPacketAndParse(
+				0, 0, createMarkerPacket(2), 200*time.Millisecond,
+			)
+			return markerErr == nil && reply != nil
+		}, 3*time.Second, 250*time.Millisecond, "virtio TX remained stalled after overload")
+
+		afterRecovery := readWorkerCounters(t, fw)
+		t.Logf("workers after recovery: %+v", afterRecovery.Workers)
+		require.Greater(t, afterRecovery.Workers[1].TXPackets, afterFlood.Workers[1].TXPackets,
+			"virtio worker did not transmit any further packets once the hog was gone")
+
+		// Without a virtio tx_done_cleanup op, the accepted-but-uncleaned tail
+		// of the last tx burst stays pinned in the producer's pending FIFO
+		// until the next nonzero burst frees it. At quiescence that leaves a
+		// small residual bounded by the consumer's TX ring depth, never a
+		// wedge, so the FIFO drains down to virtioTXQueueLen, not to zero.
+		require.Eventually(t, func() bool {
+			response, drainErr := tryReadWorkerCounters(fw)
+			if drainErr != nil {
+				return false
+			}
+			return response.Workers[0].RemoteTXPending <= virtioTXQueueLen
+		}, 3*time.Second, 250*time.Millisecond, "phy worker's remote-tx pending FIFO did not drain to the bounded residual")
+	})
+}


### PR DESCRIPTION
Overloading the physical → virtio_user (to-kernel) direction left it permanently wedged even after the load stopped: BFD/ND stopped passing, BIRD dropped BGP sessions, neighbours decayed into PROBE/INCOMPLETE, and only a full restart healed the router. This change makes the relay path recover on its own, adds observability for it, and ships a functional regression test that reproduces the outage end to end.

## Anatomy of the relay path

A packet that a worker must send out through another worker's device travels through an SPSC ring (data_pipe) with a three-phase push → pop → free protocol. On top of it sits a per-pipe pending FIFO: worker mempools are single-producer-put, so the final mbuf free must happen on the producing worker. The producer takes an extra reference on every relayed mbuf and records it in the FIFO; the reference drops back to baseline once the consumer side releases the packet, and the producer then reclaims FIFO entries strictly head-first, stopping at the first mbuf still held.

Before this change the consumer's pop callback transmitted what it could, freed the rejected tail, and reported the whole batch consumed — the pipe drained regardless of how much the NIC actually accepted.

## The deadlock

The virtio PMD frees mbufs of completed TX descriptors only inside a subsequent transmit burst with one or more packets: every transmit variant returns before any cleanup when called with an empty batch, and the driver does not implement the tx done cleanup device operation, so `rte_eth_tx_done_cleanup()` returns `-ENOTSUP`. If bursts stop, previously accepted mbufs stay held forever — even after the backend (vhost-net) has long transmitted them and filled the used ring.

```mermaid
sequenceDiagram
    participant P as producer worker (phy)
    participant F as pending FIFO (4096)
    participant D as data_pipe (1024)
    participant C as consumer worker (kni)
    participant V as virtio TX ring (4096)
    participant K as vhost-net (kernel)

    Note over P,K: PHASE 1 — flood, the kernel side cannot keep up
    loop flood
        P->>F: push, extra ref recorded
        P->>D: packet enters the pipe
        C->>V: tx_burst, ring accepts while slots remain
        Note over V: ring fills up with 4096 mbufs at refcnt 2
        C->>C: the rest rejected, freed + counted as drops
        C-->>D: whole batch reported consumed, pipe drained
    end
    Note over F: reclaim stops at held heads (refcnt 2)<br/>behind them sit already-released entries
    Note over F: all 16 pending FIFOs full (16 x 4096 = 65536)
    P--xD: backpressure, NO new packet enters the pipe

    Note over P,K: PHASE 2 — flood stops, but it is already too late
    K->>V: vhost drains the ring, publishes used descriptors
    Note over V: completions are ready but nobody services them
    C->>C: pipe is empty, tx_burst is never called again
    Note over V: cleanup runs only inside a nonzero burst
    Note over F: heads stay at refcnt 2 forever, reclaim stuck,<br/>FIFOs full forever, backpressure forever
    P--xD: BFD/ND/probe packets dropped at the entrance
```

The cycle is perfectly closed: freeing the pending FIFO needs a cleanup, a cleanup needs a nonzero burst, a burst needs a packet in the pipe, and a packet can enter the pipe only after the FIFO frees up.

The production incident arithmetic confirms it: 16 physical workers × 4096 pending slots = 65536, of which exactly 4096 were mbufs accepted into the virtio TX ring (depth 4096, one indirect descriptor per packet) and never reclaimed, and 61440 were rejected packets already released but trapped behind the held heads. The regression test reproduces the same fingerprint on the baseline code in a single-worker geometry.

## Why the simple ways out do not work

| Idea | Why not |
|---|---|
| Zero-length burst on idle | The virtio transmit path returns before any cleanup on an empty batch |
| `rte_eth_tx_done_cleanup()` | `-ENOTSUP`: the op is not implemented by the virtio PMD |
| Free the held heads by force | The mbufs belong to the PMD's TX ring — that is a use-after-free on the wire, and it breaks the single-producer mempool contract |
| Device stop/start (which does clean up) | A link flap on the kernel port: queues reset, in-flight lost, reverse path disrupted |
| Bigger pending rings / mempools | Postpones, does not cure: after the load stops nothing will ever clean up |

An alternative that does cure it — implementing the tx done cleanup operation in the virtio PMD plus an idle-round cleanup probe in the worker — was prototyped and fully validated (including an in-process virtio-user/vhost harness across split, in-order and packed rings), but it requires patching the bundled DPDK and is deferred to a follow-up. This change is deliberately worker-only.

## The fix

Three cooperating mechanisms, all in the worker relay path.

**Retry instead of drop.** The pop callback now reports only the accepted prefix as consumed; the rejected tail stays in the pipe. The next round therefore issues another nonzero burst, and inside that call the virtio driver reclaims completed descriptors on its own. Packets are counted once, at acceptance; overload drops move to the producer side (pipe-full backpressure).

**Pending ring sized by an invariant.** The deferred-free ring is now sized strictly above the pipe capacity plus the consumer's TX queue depth (8192 for the defaults). Pending occupancy is bounded by packets still in the pipe (≤ pipe capacity) plus accepted-but-unreclaimed packets (≤ the consumer's ring depth, completions are reclaimed in order), so the pending ring can never fill while the pipe is empty — a producer can always make progress into the pipe, and un-accepted packets in the pipe guarantee the bursts keep coming. This closes the corner where a single producer fills the TX ring with all-accepted packets, leaving no reject in the pipe to force the next burst.

**A retry budget with a discriminating probe.** Blind infinite retry would let one genuinely untransmittable packet (for example a chain exceeding a physical NIC's segment limit on the reverse relay) wedge its pipe head-of-line forever. Blind timeout-drop is just as bad in the opposite direction: during a total backend stall every dropped head frees a pipe slot that the producer immediately refills, so the pending ring slowly fills around a consumer that never moves. The two cases are indistinguishable by the head alone, so after 4096 fruitless rounds the consumer probes the next packet of the window on its own:

```mermaid
sequenceDiagram
    participant C as consumer
    participant N as NIC (tx_burst)

    Note over C: the same head has been rejected for > 4096 rounds<br/>(the counter saturates against wrap-around)
    alt the window has a second packet (count >= 2)
        C->>N: probe: tx_burst(&mbufs[1], 1)
        alt probe ACCEPTED
            Note over C: the ring is alive yet the head keeps being rejected —<br/>the head is poisoned: drop it, count the probe as accepted,<br/>consume both (return 2)
        else probe REJECTED
            Note over C: total ring stall — dropping would only feed the trap,<br/>keep waiting (return 0)
        end
    else count == 1 but true backlog (w_pos - r_pos) >= 2
        Note over C: the head sits in the ring's last slot —<br/>the window is clipped by the wrap and no probe is possible<br/>(a callback may only consume a contiguous prefix) —<br/>plain timeout drop (return 1),<br/>the next head lands in slot 0 where the probe works again
    else genuinely lone head (backlog <= 1)
        Note over C: it blocks nobody behind it —<br/>discrimination resumes once traffic queues up
    end
```

A subtlety caught in review: the window size handed to the pop callback is clipped at the ring boundary, so "the head is alone" must not be inferred from it — a head parked in the last slot always sees a window of one, whatever is queued behind the wrap. The boundary is detected positionally (the head's slot index), and the true backlog is read from the pipe positions with the same memory ordering the pop protocol itself uses. The boundary geometry falls back to a plain timeout drop, which costs at most one drop per stall episode, keeping the invariant's slack intact.

One structural residual is documented: two consecutive permanently untransmittable heads are indistinguishable from a total stall (the probe target is itself poisoned, and the probe cannot rotate across the window under the contiguous-prefix contract). It is unreachable today — virtio negotiates indirect descriptors, and a physical-relay reproduction would need adjacent chains beyond the frame sizes the MTU allows — and is tracked as a follow-up, together with re-introducing the idle cleanup probe once the PMD grows the missing operation.

## Recovery picture

```mermaid
sequenceDiagram
    participant P as producer (phy)
    participant F as pending FIFO
    participant D as pipe
    participant C as consumer (kni)
    participant V as virtio ring
    participant K as vhost-net

    Note over P,K: flood stopped — un-accepted packets remain in the pipe
    loop every consumer round
        C->>V: tx_burst(retried head packets)
        V->>V: internal cleanup reclaims used descriptors
        V-->>F: held heads drop back to baseline refcnt
        K->>V: vhost keeps draining
    end
    P->>F: reclaim advances, FIFO drains
    Note over F: pending gauge returns to a small residual<br/>(the tail of the final burst, bounded by the ring depth)
    P->>D: BFD/ND/probe packets pass again — no restart
```

The only quiescent residual of the worker-only approach: the accepted-but-unreclaimed tail of the very last burst (bounded by the consumer's ring depth) stays in the pending FIFO until the next burst arrives. It never blocks producers.

## Observability

A new per-worker gauge, remote_tx_pending, exposes the pending-FIFO occupancy (summed over the worker's pipes, overwritten every round) through the counter registry, the counters API, the gateway metrics and the CLI JSON output. The regression test asserts on it directly: it rises under backpressure and drains to the bounded residual after recovery.

## Validation

- Baseline RED: on the unfixed code the functional scenario (an RT hog starving the vhost-net thread inside the VM, then a 65536-packet flood into the kernel-bound fallback) wedges permanently — the probe packet never recovers and the counters freeze with the production fingerprint.
- Fix GREEN: the same scenario passes repeatedly (including three consecutive runs with byte-identical pre-run snapshots and exact packet balance producer drops + delivered = flood). With the discriminator in place a truly total stall produces zero consumer-side drops, the pending gauge peaks exactly at the invariant bound (pipe + ring) and drains to the residual, and every retried packet is delivered once the backend recovers.
- The partial-consume pop protocol is exercised by a new ThreadSanitizer scenario for the SPSC pipe, green in both regular and TSan builds.
- The functional suite is wired into the make target and CI (serialized with the main suite so the two QEMU pools never run concurrently, with logs collected in the workflow).

## Follow-ups

- Implement the tx done cleanup operation for the virtio PMD upstream and re-introduce the worker's idle cleanup probe on top of it: that removes the quiescent residual and gives virtio a completion path independent of new traffic.
- A pre-existing latent hazard in the pending-FIFO reference scheme for multi-segment packets (the extra reference pins only the head segment) was found during the analysis; this change narrows its exposure but the class needs its own reproduction and fix.
