### PR TITLE
feat(cli): align and dim the ready --watch readiness log

### DIFF
--- a/cli/modules/ready/src/render/watch.rs
+++ b/cli/modules/ready/src/render/watch.rs
@@ -88,8 +88,9 @@ pub fn record_transition(snapshot: &mut BTreeMap<(String, String), Scope>, servi
 ///
 /// [`ServiceColumn::None`] is single-service watch, where every line names
 /// the same service and repeating it would be noise. [`ServiceColumn::Named`]
-/// is aggregate watch: `alias` is padded to `width`, which must be measured
-/// once (via [`super::name_width`]) and held for the whole session.
+/// is aggregate watch: `alias` is padded to `width`, which is measured at
+/// startup and only ever widened as new services or scopes appear, never
+/// shrunk.
 #[derive(Debug, Clone, Copy)]
 pub enum ServiceColumn<'a> {
     None,
@@ -158,7 +159,13 @@ fn transition_prefix(
             )
         }
         Transition::ReasonChanged | Transition::Unchanged | Transition::FirstSeen => {
-            (label.to_string(), style.paint(label))
+            // Padded to `STATE_WIDTH` so the trailing `first seen` tag and
+            // any inline reason line up at a fixed column across every
+            // single-label line — a `StateChanged`'s `PREV -> NEXT` shape
+            // cannot share that column anyway, so it is left unpadded.
+            let label = format!("{label:<width$}", width = super::STATE_WIDTH);
+
+            (label.clone(), style.paint(&label))
         }
     };
 
@@ -238,9 +245,9 @@ pub fn print_transition_line(service: ServiceColumn, scope: &Scope, name_width: 
 ///
 /// Callers compose `message` themselves — [`print_lost_line`] shows how a
 /// lost stream's cause and retry delay become one such message.
-/// `HH:MM:SS  [!] alias  message`, the whole line dim — this is transport
+/// `HH:MM:SS  [!] alias message`, the whole line dim — this is transport
 /// chatter, not a readiness state, and must never borrow a [`StateStyle`]
-/// colour or [`print_membership_line`]'s full weight. Long messages wrap
+/// colour or [`print_membership_line`]'s colored mark. Long messages wrap
 /// with a hanging indent, the same way a transition line's reason text
 /// does.
 pub fn print_lifecycle_line(alias: &str, alias_width: usize, message: &str) {
@@ -250,7 +257,7 @@ pub fn print_lifecycle_line(alias: &str, alias_width: usize, message: &str) {
     let mark = if colored { "[!]" } else { "[--]" };
     let name = format!("{alias:<alias_width$}");
 
-    let prefix = format!("{timestamp}  {mark} {name}  ");
+    let prefix = format!("{timestamp}  {mark} {name} ");
     let indent = prefix.chars().count();
 
     print!("{}", dim(&prefix, colored));
@@ -348,16 +355,19 @@ impl MembershipStyle {
     }
 }
 
-/// Prints one full-weight line for a `--watch` registry membership change:
-/// a service joining or leaving the gateway's registry.
+/// Prints one `--watch` registry membership change line: a service joining
+/// or leaving the gateway's registry.
 ///
 /// Structured like [`print_lifecycle_line`] — timestamp, bracketed mark,
 /// alias padded to `alias_width`, wrapped message with a hanging indent —
-/// but printed at full weight rather than dim: a backend joining or
-/// leaving the registry is a state-level event, not transport chatter.
-/// `membership` alone selects the mark, its color, and the message text,
-/// so the joined and departed lines can never drift apart from one
-/// another.
+/// but the mark keeps `membership`'s own color instead of [`dim`]'s grey: a
+/// backend joining or leaving the registry is a state-level event, not
+/// transport chatter, so the mark stays as prominent as a readiness
+/// [`StateStyle`] mark. The alias prints at full weight and only the
+/// descriptive message is dimmed, the same split a transition line makes
+/// between its state labels and its dim reason text. `membership` alone
+/// selects the mark, its color, and the message text, so the joined and
+/// departed lines can never drift apart from one another.
 pub fn print_membership_line(alias: &str, alias_width: usize, membership: Membership) {
     let colored = output::is_colored();
     let wrap_width = display::terminal_width();
@@ -366,10 +376,10 @@ pub fn print_membership_line(alias: &str, alias_width: usize, membership: Member
     let message = membership.message();
     let name = format!("{alias:<alias_width$}");
 
-    let plain_prefix = format!("{timestamp}  {} {name}  ", style.mark);
+    let plain_prefix = format!("{timestamp}  {} {name} ", style.mark);
     let indent = plain_prefix.chars().count();
 
-    print!("{}  {} {name}  ", dim(&timestamp, colored), style.styled_mark());
+    print!("{}  {} {name} ", dim(&timestamp, colored), style.styled_mark());
 
     let lines = match wrap_width {
         Some(width) if width > indent => wrap_words(message, width - indent),
@@ -380,7 +390,7 @@ pub fn print_membership_line(alias: &str, alias_width: usize, membership: Member
         if idx > 0 {
             print!("\n{:indent$}", "");
         }
-        print!("{line}");
+        print!("{}", dim(line, colored));
     }
 
     println!();

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -77,8 +77,8 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
     }
 
     let aliases = discovery::alias_map(&services);
-    let alias_width = render::name_width(aliases.values().map(String::as_str));
-    let scope_width = render::name_width(
+    let mut alias_width = render::name_width(aliases.values().map(String::as_str));
+    let mut scope_width = render::name_width(
         reports
             .iter()
             .flat_map(|report| report.scopes.iter())
@@ -131,10 +131,40 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
     drop(sender);
 
     while let Some(event) = receiver.recv().await {
+        grow_widths(&event, &mut scope_width, &mut alias_width);
         render_event(event, &mut aggregate, scope_width, alias_width);
     }
 
     Ok(true)
+}
+
+/// Grows `scope_width` and `alias_width` to fit every name `event` carries,
+/// reusing [`render::name_width`]'s own `[MIN, MAX]` clamp for each name
+/// rather than a hardcoded bound.
+///
+/// Only ever widens: a name shorter than the running width leaves it
+/// unchanged, since a line already printed against the wider column must
+/// not go stale. `service` is registered gateway-side before its
+/// supervisor's `Watch` stream can carry a scope, so an `Event::Service`
+/// widens `alias_width` off its own `alias` unconditionally, but only
+/// widens `scope_width` when `data` is a `Message` — `Reattached` and
+/// `Lost` carry no scopes. `Event::Membership` widens `alias_width` off
+/// every alias on either side of the sweep's delta.
+fn grow_widths(event: &Event, scope_width: &mut usize, alias_width: &mut usize) {
+    match event {
+        Event::Service { alias, data, .. } => {
+            *alias_width = render::name_width([alias.as_str()]).max(*alias_width);
+
+            if let EventData::Message(scopes) = data {
+                let names = scopes.iter().map(|scope| scope.name.as_str());
+                *scope_width = render::name_width(names).max(*scope_width);
+            }
+        }
+        Event::Membership { discovered, departed } => {
+            let aliases = discovered.iter().chain(departed).map(|(_, alias)| alias.as_str());
+            *alias_width = render::name_width(aliases).max(*alias_width);
+        }
+    }
 }
 
 /// Probes one service for the initial snapshot, bounded by [`PROBE_TIMEOUT`].
@@ -897,6 +927,92 @@ mod test {
             scopes: Vec::new(),
             error: Some("unknown service".to_owned()),
         }
+    }
+
+    #[test]
+    fn grow_widths_widens_alias_width_from_a_service_event_and_never_shrinks_it() {
+        let mut scope_width = 12;
+        let mut alias_width = 12;
+
+        let event = Event::Service {
+            service: "svc".to_owned(),
+            alias: "x".repeat(16),
+            data: EventData::Message(Vec::new()),
+        };
+        grow_widths(&event, &mut scope_width, &mut alias_width);
+
+        assert_eq!(16, alias_width);
+        assert_eq!(12, scope_width);
+
+        let shorter = Event::Service {
+            service: "svc2".to_owned(),
+            alias: "a".to_owned(),
+            data: EventData::Message(Vec::new()),
+        };
+        grow_widths(&shorter, &mut scope_width, &mut alias_width);
+
+        assert_eq!(16, alias_width);
+    }
+
+    #[test]
+    fn grow_widths_clamps_alias_width_to_the_maximum_name_width() {
+        let mut scope_width = 12;
+        let mut alias_width = 12;
+
+        let event = Event::Service {
+            service: "svc".to_owned(),
+            alias: "x".repeat(100),
+            data: EventData::Message(Vec::new()),
+        };
+        grow_widths(&event, &mut scope_width, &mut alias_width);
+
+        assert_eq!(40, alias_width);
+    }
+
+    #[test]
+    fn grow_widths_widens_scope_width_from_a_message_events_scopes() {
+        let mut scope_width = 12;
+        let mut alias_width = 12;
+
+        let event = Event::Service {
+            service: "svc".to_owned(),
+            alias: "svc".to_owned(),
+            data: EventData::Message(vec![scope(&"x".repeat(20), State::Ready)]),
+        };
+        grow_widths(&event, &mut scope_width, &mut alias_width);
+
+        assert_eq!(20, scope_width);
+    }
+
+    #[test]
+    fn grow_widths_leaves_scope_width_untouched_for_lifecycle_events() {
+        let mut scope_width = 12;
+        let mut alias_width = 12;
+
+        let event = Event::Service {
+            service: "svc".to_owned(),
+            alias: "x".repeat(20),
+            data: EventData::Reattached,
+        };
+        grow_widths(&event, &mut scope_width, &mut alias_width);
+
+        assert_eq!(20, alias_width);
+        assert_eq!(12, scope_width);
+    }
+
+    #[test]
+    fn grow_widths_widens_alias_width_from_both_sides_of_a_membership_event() {
+        let mut scope_width = 12;
+        let mut alias_width = 12;
+
+        let event = Event::Membership {
+            discovered: vec![("svc".to_owned(), "x".repeat(15))],
+            departed: vec![("svc2".to_owned(), "y".repeat(18))],
+        };
+        grow_widths(&event, &mut scope_width, &mut alias_width);
+
+        assert_eq!(18, alias_width);
+        assert_eq!(12, scope_width);
     }
 
     #[test]


### PR DESCRIPTION
- Grow the watch log column widths from the services and scopes actually seen, so state labels line up when backends register after startup instead of staying frozen at the width measured before any of them were known.
- Dim the registry membership message and remove an extra leading space so it aligns with the scope-name column, while keeping the join and leave markers colored.
- Pad single-state transition labels so a first-seen tag and an inline reason share a fixed column, and apply the same one-space alignment to the reconnect lifecycle lines.