### PR TITLE
test(functional): make the qemu vm-ready timeout configurable

### DIFF
--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -372,7 +372,7 @@ func SetupHarness(config HarnessConfig) (_ *Harness, cleanup func(), err error) 
 	if err = pool.StartAll(); err != nil {
 		return nil, nil, fmt.Errorf("failed to start VM pool: %w", err)
 	}
-	if err = pool.WaitAllReady(120 * time.Second); err != nil {
+	if err = pool.WaitAllReady(VMReadyTimeout()); err != nil {
 		return nil, nil, fmt.Errorf("failed to wait for VM pool readiness: %w", err)
 	}
 
@@ -476,7 +476,7 @@ func (m *baselineSetup) ensureTemplate(qemuImage, bootedTemplate, baselineTempla
 	if err := prepPool.StartAll(); err != nil {
 		return fmt.Errorf("failed to start baseline prep pool: %w", err)
 	}
-	if err := prepPool.WaitAllReady(120 * time.Second); err != nil {
+	if err := prepPool.WaitAllReady(VMReadyTimeout()); err != nil {
 		return fmt.Errorf("baseline prep pool not ready: %w", err)
 	}
 

--- a/tests/functional/framework/pool.go
+++ b/tests/functional/framework/pool.go
@@ -209,7 +209,7 @@ func (p *VMPool) validateBootedTemplate() error {
 	}
 	defer valFW.Stop() //nolint:errcheck
 
-	if err := valMgr.WaitForReady(60 * time.Second); err != nil {
+	if err := valMgr.WaitForReady(VMReadyTimeout()); err != nil {
 		return fmt.Errorf("validation VM not ready after start: %w", err)
 	}
 
@@ -277,7 +277,7 @@ func (p *VMPool) bootstrapTemplate() error {
 	if _, err := vm0.fw.Start(); err != nil {
 		return fmt.Errorf("failed to start VM0 for bootstrap: %w", err)
 	}
-	if err := vm0.manager.WaitForReady(120 * time.Second); err != nil {
+	if err := vm0.manager.WaitForReady(VMReadyTimeout()); err != nil {
 		_ = vm0.fw.Stop()
 		return fmt.Errorf("VM0 not ready during bootstrap: %w", err)
 	}

--- a/tests/functional/framework/qemu.go
+++ b/tests/functional/framework/qemu.go
@@ -984,7 +984,7 @@ func (q *QEMUManager) RestoreBooted() error {
 	go q.readSerial()
 
 	// Wait for shell readiness.
-	if err := q.WaitForReady(120 * time.Second); err != nil {
+	if err := q.WaitForReady(VMReadyTimeout()); err != nil {
 		return fmt.Errorf("wait for ready after booted restore: %w", err)
 	}
 

--- a/tests/functional/framework/utils.go
+++ b/tests/functional/framework/utils.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // findProjectRoot locates the YANET project root directory by traversing up the
@@ -90,4 +91,23 @@ func IsDebugEnabled() bool {
 func ShouldKeepVMAlive() bool {
 	_, ok := os.LookupEnv("YANET_KEEP_VM_ALIVE")
 	return ok
+}
+
+// VMReadyTimeout returns how long to wait for a VM to reach the shell prompt.
+//
+// It defaults to 120 seconds and is overridable via YANET_VM_READY_TIMEOUT, a
+// Go duration string such as "5m" or "300s". An unset, empty, unparseable, or
+// non-positive value falls back to the default, which slow TCG (no-KVM) runners
+// routinely need to raise.
+func VMReadyTimeout() time.Duration {
+	const defaultTimeout = 120 * time.Second
+	raw, ok := os.LookupEnv("YANET_VM_READY_TIMEOUT")
+	if !ok {
+		return defaultTimeout
+	}
+	timeout, err := time.ParseDuration(raw)
+	if err != nil || timeout <= 0 {
+		return defaultTimeout
+	}
+	return timeout
 }

--- a/tests/functional/framework/utils_test.go
+++ b/tests/functional/framework/utils_test.go
@@ -1,0 +1,56 @@
+package framework_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/tests/functional/framework"
+)
+
+// TestVMReadyTimeout verifies that VMReadyTimeout parses a valid override and
+// falls back to the default for an empty, unparseable, or non-positive value.
+func TestVMReadyTimeout(t *testing.T) {
+	testCases := []struct {
+		name     string
+		value    string
+		expected time.Duration
+	}{
+		{
+			name:     "valid override",
+			value:    "90s",
+			expected: 90 * time.Second,
+		},
+		{
+			name:     "empty falls back to default",
+			value:    "",
+			expected: 120 * time.Second,
+		},
+		{
+			name:     "unparseable falls back to default",
+			value:    "garbage",
+			expected: 120 * time.Second,
+		},
+		{
+			name:     "zero falls back to default",
+			value:    "0s",
+			expected: 120 * time.Second,
+		},
+		{
+			name:     "negative falls back to default",
+			value:    "-5s",
+			expected: 120 * time.Second,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Setenv("YANET_VM_READY_TIMEOUT", testCase.value)
+
+			timeout := framework.VMReadyTimeout()
+
+			require.Equal(t, testCase.expected, timeout)
+		})
+	}
+}


### PR DESCRIPTION
- Adds an environment override (YANET_VM_READY_TIMEOUT) for how long the functional-test harness waits for a VM to reach the shell prompt, defaulting to the previous 120 seconds.
- Lets slow emulated (no-KVM/TCG) runners raise the boot budget without a code change, which is what the self-hosted QEMU tier needs.