### PR TITLE
ci(deb): keep only packages and debug symbols in build artifacts

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -121,7 +121,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: debs-${{ matrix.unbtver }}
-          path: outdeb/*
+          path: |
+            outdeb/*.deb
+            outdeb/*.ddeb
 
   release:
     needs: build-deb

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -78,7 +78,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: debs-24.04
-          path: outdeb/*
+          path: |
+            outdeb/*.deb
+            outdeb/*.ddeb
 
   build-images:
     needs: build-deb


### PR DESCRIPTION
- The package upload globbed the whole build output directory, so every artifact also carried the native source tarball, the changes file and the buildinfo.
- Nothing downstream reads any of those: the release job filters to packages, and the image build copies packages by name.
- The tarball embeds the vendored DPDK tree and was the single largest component of each artifact.
- Debug symbol packages are deliberately kept, so post-mortem analysis of a dataplane core dump is unaffected.
- Retention itself is governed by the repository setting, which has been lowered from ninety days to seven separately.