### PR TITLE
refactor(dataplane): drop the unused rx timestamp offload

### DIFF
--- a/dataplane/dpdk.c
+++ b/dataplane/dpdk.c
@@ -196,36 +196,16 @@ dpdk_port_init(
 		port_conf.rxmode.mq_mode = RTE_ETH_MQ_RX_RSS;
 		port_conf.rx_adv_conf.rss_conf.rss_hf = rss_hash;
 	}
-	port_conf.rxmode.offloads |= RTE_ETH_RX_OFFLOAD_TIMESTAMP;
 
 	if ((rc = rte_eth_dev_configure(
 		     *port_id, rx_queue_count, tx_queue_count, &port_conf
 	     ))) {
-		LOG(WARN,
+		LOG(ERROR,
 		    "failed to configure port id %d (%s): %d",
 		    *port_id,
 		    name,
 		    rc);
-		LOG(INFO,
-		    "try to configure port without RX timestamp offload %d "
-		    "(%s)",
-		    *port_id,
-		    name);
-		port_conf.rxmode.offloads &= ~RTE_ETH_RX_OFFLOAD_TIMESTAMP;
-
-		if ((rc = rte_eth_dev_configure(
-			     *port_id,
-			     rx_queue_count,
-			     tx_queue_count,
-			     &port_conf
-		     ))) {
-			LOG(ERROR,
-			    "failed to configure port id %d (%s): %d",
-			    *port_id,
-			    name,
-			    rc);
-			return -1;
-		}
+		return -1;
 	}
 
 	if (mtu && (rc = rte_eth_dev_set_mtu(*port_id, mtu))) {


### PR DESCRIPTION
The dataplane requested the hardware receive timestamp offload on every port and retried port configuration without it whenever the first attempt failed.

No consumer of that timestamp exists anywhere in the tree. Packet capture deliberately stamps its records from the worker clock instead, because hardware timestamps are not portable nanoseconds.

- Drop the offload request and collapse the retry into a single port configuration call, so adapters that reject the offload no longer pay a doomed round-trip.
- Keep the existing error reporting on a genuine configuration failure, now raised to error severity because the failure is terminal.
- Remove an architecture divergence ahead of the aarch64 port, where the vector receive path of some drivers never populates the field.