### PR TITLE
ci(workflows): install apt packages directly instead of caching them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,14 +37,10 @@ jobs:
       cache_name: build-asan-test
 
     steps:
-      - name: update apt (act hack)
-        if: ${{ env.ACT }}
-        run: apt-get update
-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
-          version: 1.1
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
 
       - uses: actions/checkout@v4
         with:
@@ -105,14 +101,10 @@ jobs:
       cache_name: build-tsan-test
 
     steps:
-      - name: update apt (act hack)
-        if: ${{ env.ACT }}
-        run: apt-get update
-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
-          version: 1.1
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
 
       - uses: actions/checkout@v4
         with:
@@ -165,14 +157,10 @@ jobs:
       cache_name: build-release-artifacts
 
     steps:
-      - name: update apt (act hack)
-        if: ${{ env.ACT }}
-        run: apt-get update
-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
-          version: 1.1
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
 
       - uses: actions/checkout@v4
         with:
@@ -295,14 +283,10 @@ jobs:
       cache_name: clang-tidy
 
     steps:
-      - name: update apt (act hack)
-        if: ${{ env.ACT }}
-        run: apt-get update
-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
-          version: 1.1
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
 
       - name: Install LLVM 19 toolchain
         id: llvm
@@ -438,13 +422,10 @@ jobs:
           go-version: "1.24.x"
           cache: true
 
-      - name: update apt (act hack)
-        if: ${{ env.ACT }}
-        run: apt-get update
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: qemu-system-x86 qemu-utils genisoimage cloud-image-utils wget curl jq libpcap-dev
-          version: 1.1
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-x86 qemu-utils genisoimage cloud-image-utils wget curl jq libpcap-dev
 
       - name: Configure system for QEMU
         run: |

--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -1,6 +1,14 @@
 name: Fuzz test
 
 on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/fuzz-test.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/fuzz-test.yml"
   schedule:
     - cron: "0 4 * * *"
   workflow_dispatch:
@@ -22,10 +30,10 @@ jobs:
           sudo apt-get clean
           docker rmi $(docker images -q) 2>/dev/null || true
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
-          version: 1.1
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -61,10 +61,10 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: protobuf-compiler libpcap-dev
-          version: 1.0
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libpcap-dev
 
       - name: Install Go protobuf plugins
         run: |

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -46,10 +46,10 @@ jobs:
           key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-check-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: protobuf-compiler
-          version: 1.0
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - run: cargo check --workspace
 
   test:
@@ -70,10 +70,10 @@ jobs:
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-test-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: protobuf-compiler
-          version: 1.0
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - run: cargo test --workspace
 
   clippy:
@@ -95,8 +95,8 @@ jobs:
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-clippy-
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: protobuf-compiler
-          version: 1.0
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
       - run: cargo clippy --workspace -- -D warnings


### PR DESCRIPTION
The functional tests, and intermittently other jobs, have been failing with a missing command. The cause is a self-sustaining loop in the package caching action.

- The action never refreshes the package index, so once a mirror retires a pinned version the install fails with a not-found error. This is what broke the QEMU tier, through a transitive dependency of the emulator package.
- Its post step still saves a cache entry describing an empty package set. Because the cache key is derived from the package list, every later run restores that empty entry, installs nothing, and fails reporting a missing command.
- Purging the entry only exposes the original install failure, and the run that then fails immediately recreates the empty entry. The jobs cannot recover on their own, and the failure reproduces identically on the default branch.

Installing the packages directly removes both halves of the loop: the index is refreshed before every install, and no cache remains that can be poisoned. The package list of each job is unchanged.

Also give the fuzz workflow triggers scoped to its own file. It previously ran only on a schedule, so a change to it could not be verified by the pull request making that change, which is how this defect survived unnoticed. The scoping is a single literal path, so ordinary code changes do not start it.