### PR TITLE
fix(controlplane,dataplane): order the config generation publication

### DIFF
--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -323,8 +323,10 @@ worker_loop_round(struct dataplane_worker *worker) {
 	}
 
 	struct cp_config *cp_config = worker->instance->cp_config;
+	// Acquire the generation pointer, paired with the release-publish
+	// in cp_config_gen_install.
 	struct cp_config_gen *cp_config_gen =
-		ADDR_OF(&cp_config->cp_config_gen);
+		ATOMIC_ADDR_OF(&cp_config->cp_config_gen);
 	struct config_gen_ectx *config_gen_ectx = cp_config_gen_worker_ectx(
 		cp_config_gen, worker->dp_worker->idx
 	);

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -203,7 +203,9 @@ cp_config_gen_install(
 	SET_OFFSET_OF(&new_config_gen->config_gen_ectxs, new_config_gen_ectxs);
 	new_config_gen->config_gen_ectx_count = worker_count;
 
-	SET_OFFSET_OF(&cp_config->cp_config_gen, new_config_gen);
+	// Release-publish the new generation so workers never observe this
+	// pointer before its contents are fully written.
+	ATOMIC_SET_OFFSET_OF(&cp_config->cp_config_gen, new_config_gen);
 	dp_config_wait_for_gen(dp_config, new_config_gen->gen);
 	cp_config_gen_free(cp_config, old_config_gen);
 


### PR DESCRIPTION
The control plane published a freshly built configuration generation to the running dataplane with a plain store, and each worker picked it up with a plain load. On a strongly ordered processor the writes that fill the generation cannot become visible after the pointer that publishes it, so the handover was safe. That guarantee came from the processor, not from the code.

On a weakly ordered processor the two stores may be reordered, letting a worker follow a valid looking pointer into a structure whose contents are not there yet, in the middle of the packet path. Publishing with release semantics and consuming with acquire semantics states the ordering instead of inheriting it. The macros used already existed and were previously almost unused.

Verified by cross compiling the affected translation unit for a weakly ordered target. Before the change the file emits no ordering instruction at all and the publication is a plain store:

```
str  x19, [x20, 1176]
```

After the change the same site becomes a store release, and the file's total count of ordering instructions goes from zero to seven, all of them at this one publication point, which appears seven times because the enclosing function is inlined into each of its callers:

```
stlr x0, [x23]
```

The compiler chose a store release rather than a full barrier, and on the strongly ordered target both variants still compile to the same plain move plus a compiler barrier, so there is no cost there. Instruction counts on the two affected files are unchanged or marginally lower.

The consuming side is one load per worker round, not per packet.