### PR TITLE
fix(dataplane): read the timestamp counter portably

### DIFF
--- a/lib/dataplane/time/clock.c
+++ b/lib/dataplane/time/clock.c
@@ -3,7 +3,6 @@
 #include <time.h>
 
 #include <rte_cycles.h>
-#include <x86intrin.h>
 
 int
 tsc_clock_init(struct tsc_clock *clock) {
@@ -36,7 +35,7 @@ tsc_clock_adjust(struct tsc_clock *clock) {
 
 uint64_t
 tsc_clock_get_time_ns(struct tsc_clock *clock) {
-	uint64_t tsc = _rdtsc();
+	uint64_t tsc = rte_rdtsc();
 
 	return clock->real_time_ns +
 	       tsc_clock_ticks_to_ns(tsc, clock->tsc_to_ns_mult);


### PR DESCRIPTION
The wall clock read the timestamp counter through an architecture specific compiler intrinsic, while the initialisation a few lines above already used the portable interface. Both reach the same counter on the architecture we run today, so the divergence never showed up, but only one of the two exists anywhere else.

Using the portable interface in both places also lets the file compile for other architectures, which the previous form could not.

Verified to change nothing where we run today: compiling the file before and after with the real build flags produces a byte identical text section, with the same non serialising counter read and no added fence. On a weakly ordered target the portable interface reads the architected timer, and the conversion multiplier this file derives is exact for the counter frequencies such parts report, where it is not exact for a typical current one.

Behaviour, arithmetic, and the header are otherwise untouched. A startup sanity check on the reported counter frequency is worth having, but is deliberately left for its own change.