### PR TITLE
fix(common): make the spin-wait hint portable

### DIFF
--- a/common/cpu_pause.h
+++ b/common/cpu_pause.h
@@ -1,0 +1,22 @@
+#pragma once
+
+// Portable CPU pause hint for busy-wait spin loops.
+//
+// Emits the architecture's spin-wait hint instruction where one exists, and
+// falls back to a plain compiler barrier everywhere else. Every branch
+// carries a "memory" clobber so the compiler cannot hoist a spin loop's
+// loads out across the call, which matters on the fallback path just as
+// much as on the instruction paths.
+//
+// This header must stay free of DPDK headers: it sits on the cgo boundary
+// through common/rwlock.h and lib/fwstate/fwmap.h.
+static inline void
+cpu_pause(void) {
+#if defined(__x86_64__) || defined(__i386__)
+	__asm__ __volatile__("pause" ::: "memory");
+#elif defined(__aarch64__)
+	__asm__ __volatile__("yield" ::: "memory");
+#else
+	__asm__ __volatile__("" ::: "memory");
+#endif
+}

--- a/common/rcu.h
+++ b/common/rcu.h
@@ -150,6 +150,7 @@
  * writers. The RCU mechanism does not serialize writers.
  */
 
+#include "cpu_pause.h"
 #include "memory.h"
 #include "memory_address.h"
 
@@ -301,23 +302,6 @@ rcu_read_end(rcu_t *rcu, size_t w) {
 ////////////////////////////////////////////////////////////////////////////////
 
 /**
- * @brief CPU relaxation hint for busy-wait loops
- *
- * This function provides a hint to the CPU that we're in a busy-wait loop,
- * allowing it to optimize power consumption and potentially improve
- * performance of hyper-threaded cores.
- *
- * @note On x86/x86_64, this emits a PAUSE instruction. On other architectures,
- *       it's a no-op but the compiler barrier still prevents optimization.
- */
-static inline void
-cpu_relax(void) {
-#if defined(__x86_64__) || defined(__i386__)
-	__asm__ __volatile__("pause");
-#endif
-}
-
-/**
  * @brief Wait for all workers to finish reading from a specific epoch
  *
  * This function implements the grace period mechanism by busy-waiting until
@@ -356,7 +340,7 @@ wait_epoch_flush(rcu_t *rcu, unsigned e) {
 		}
 		if (!any)
 			break;
-		cpu_relax();
+		cpu_pause();
 	}
 }
 

--- a/common/rwlock.h
+++ b/common/rwlock.h
@@ -7,6 +7,7 @@
 #include "cpu_pause.h"
 
 #include <stdatomic.h>
+#include <stdint.h>
 
 #ifndef likely
 #define likely(x) __builtin_expect(!!(x), 1)

--- a/common/rwlock.h
+++ b/common/rwlock.h
@@ -4,7 +4,8 @@
 
 #pragma once
 
-#include <emmintrin.h>
+#include "cpu_pause.h"
+
 #include <stdatomic.h>
 
 #ifndef likely
@@ -63,7 +64,7 @@ rwlock_read_lock(rwlock_t *rwl) {
 		    // really help
 			// Wait while writer is present or pending
 			while (atomic_load_explicit(&rwl->cnt,
-		   memory_order_relaxed) & YANET_RWLOCK_MASK) { _mm_pause();
+		   memory_order_relaxed) & YANET_RWLOCK_MASK) { cpu_pause();
 			}
 		*/
 
@@ -115,7 +116,7 @@ rwlock_write_lock(rwlock_t *rwl) {
 		while ((x = atomic_load_explicit(
 				&rwl->cnt, memory_order_relaxed
 			)) > YANET_RWLOCK_WAIT) {
-			_mm_pause();
+			cpu_pause();
 		}
 
 		/* No readers or writers? */

--- a/common/spinlock.h
+++ b/common/spinlock.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "cpu_pause.h"
+
 #include <sched.h>
 #include <stdatomic.h>
 #include <stdbool.h>
@@ -12,13 +14,6 @@ struct spinlock {
 static inline void
 spinlock_init(struct spinlock *lock) {
 	atomic_init(&lock->locked, false);
-}
-
-static inline void
-spinlock_cpu_relax(void) {
-#if defined(__x86_64__) || defined(__i386__)
-	__asm__ __volatile__("pause");
-#endif
 }
 
 /* Acquire the lock (blocking) */
@@ -50,7 +45,7 @@ spinlock_lock(struct spinlock *lock) {
 
 		while (atomic_load_explicit(&lock->locked, memory_order_relaxed)
 		) {
-			spinlock_cpu_relax();
+			cpu_pause();
 			if (++spins >= 1024) {
 				sched_yield();
 				spins = 0;


### PR DESCRIPTION
Three headers each hand-rolled the same busy-wait hint, and all three were wrong away from the architecture we run today.

- The read-write lock reached for an architecture specific compiler header. That alone kept the firewall state code from compiling elsewhere, since it includes that lock.
- The read-copy-update and spinlock headers guarded the body on that architecture with no alternative branch, so the function was empty everywhere else. Not merely a missing hint: there was no compiler barrier either, which its own documentation claimed was still there. A spin loop was free to have its loads hoisted out.

All three now call one shared primitive that emits the architecture's hint instruction where one exists and always keeps the barrier, including on the fallback path where the barrier is the only thing left. The two local wrappers, each with a single caller, are gone rather than kept as aliases.

The primitive is deliberately free of any dataplane library header, because it is reachable from the control plane bindings through the read-write lock, and pulling that dependency in would grow it into the bindings.

Verified: the expected hint instruction is emitted for both targets from the real header, the header that blocked the firewall state build now compiles for the other target, and the added barrier costs nothing. Compiling the three real spin loops with and without it yields byte identical code, so the strengthening is free. No lock or reclamation algorithm is touched, and no memory ordering changed.