### PR TITLE
build(meson): apply the microarchitecture flag only where it exists

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,10 +14,11 @@ project(
   ],
 )
 
-add_project_arguments(
-  ['-march=' + get_option('cpu_arch'), '-g', '-D_GNU_SOURCE'],
-  language: 'c',
-)
+yanet_project_args = ['-g', '-D_GNU_SOURCE']
+if host_machine.cpu_family() in ['x86', 'x86_64']
+  yanet_project_args += '-march=' + get_option('cpu_arch')
+endif
+add_project_arguments(yanet_project_args, language: 'c')
 
 yanet_conf = configuration_data()
 yanet_conf.set('DEBUG_NAT64', get_option('buildtype') == 'debug')
@@ -119,23 +120,27 @@ yanet_rootdir = include_directories('.')
 # Modules will populate this with their fuzzing targets
 fuzzing_targets = {}
 
+libdpdk_default_options = [
+  'platform=' + get_option('dpdk_platform'),
+  'pkt_mbuf_headroom=@0@'.format(get_option('pkt_mbuf_headroom')),
+  'disable_apps=dumpcap,graph,pdump,proc-info,test-acl,test-bbdev,test-cmdline,test-compress-perf,test-crypto-perf,test-dma-perf,test-eventdev,test-fib,test-flow-perf,test-gpudev,test-mldev,test-pipeline,test-regex,test-sad,test-security-perf',
+  'enable_apps=',
+  'disable_libs=bitratestats,cfgfile,flow_classify,gpudev,gro,gso,kni,jobstats,latencystats,metrics,node,pdump,pipeline,port,power,table,vhost',
+  'enable_driver_sdk=true',
+  'enable_drivers=net/mlx5,common/mlx5,bus/auxiliary,net/virtio,net/e1000,net/iavf,common/iavf,net/i40e,net/ring',
+  'default_library=static',
+  'tests=false',
+  'examples=',
+  'werror=false',
+  'c_args=-Wno-stringop-overflow -Wno-array-bounds -Wno-stringop-overread -Wno-vla-larger-than',
+]
+if host_machine.cpu_family() in ['x86', 'x86_64']
+  libdpdk_default_options += 'cpu_instruction_set=' + get_option('cpu_arch')
+endif
+
 libdpdk = subproject(
   'dpdk',
-  default_options: [
-    'platform=generic',
-    'cpu_instruction_set=' + get_option('cpu_arch'),
-    'pkt_mbuf_headroom=@0@'.format(get_option('pkt_mbuf_headroom')),
-    'disable_apps=dumpcap,graph,pdump,proc-info,test-acl,test-bbdev,test-cmdline,test-compress-perf,test-crypto-perf,test-dma-perf,test-eventdev,test-fib,test-flow-perf,test-gpudev,test-mldev,test-pipeline,test-regex,test-sad,test-security-perf',
-    'enable_apps=',
-    'disable_libs=bitratestats,cfgfile,flow_classify,gpudev,gro,gso,kni,jobstats,latencystats,metrics,node,pdump,pipeline,port,power,table,vhost',
-    'enable_driver_sdk=true',
-    'enable_drivers=net/mlx5,common/mlx5,bus/auxiliary,net/virtio,net/e1000,net/iavf,common/iavf,net/i40e,net/ring',
-    'default_library=static',
-    'tests=false',
-    'examples=',
-    'werror=false',
-    'c_args=-Wno-stringop-overflow -Wno-array-bounds -Wno-stringop-overread -Wno-vla-larger-than',
-  ],
+  default_options: libdpdk_default_options,
 )
 
 libdpdk_dep = libdpdk.get_variable('dpdk_dep')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -38,7 +38,20 @@ option(
   'cpu_arch',
   type: 'string',
   value: 'haswell',
-  description: 'Target CPU architecture for -march flag.',
+  description: 'x86 microarchitecture passed as the -march flag; '
+                + 'ignored on other architectures.',
+)
+
+option(
+  'dpdk_platform',
+  type: 'string',
+  value: 'generic',
+  description: 'DPDK platform for a native build; a cross build takes '
+                + 'the platform from the cross file instead. "generic" '
+                + 'produces a portable build, while an SoC name such as '
+                + '"altra" or "ampereone" produces a tuned, non-portable '
+                + 'one; an unrecognised value is only diagnosed on '
+                + 'architectures that consult it.',
 )
 
 option(


### PR DESCRIPTION
The target microarchitecture option defaults to an x86 value and was applied unconditionally in two places, and both are fatal elsewhere.

- It went onto every compilation unit, and no compiler for another architecture accepts it.
- It was also handed to the dataplane library subproject, which aborts its own configuration on it. That abort happens before the subproject reaches the logic that would have derived the correct flags for the target, so substituting a different value there cannot help. The key is now simply not passed, letting the subproject fall back to its own detection.

The platform given to that subproject, previously fixed to the portable setting, is now an option, so a build tuned for a specific processor can be selected. The default keeps today's behaviour.

**This clears configuration only.** Compilation on another architecture still stops on sources that use architecture specific intrinsics, which are being addressed separately. This is not "the port works now".

Verified unchanged where we build today: the flag still reaches all of our own compilation units, with an identical occurrence count across the whole compilation database before and after, measured against a pristine tree configured separately.

Verified to make progress elsewhere, by cross compiling with a throwaway configuration: before, the build dies immediately with the compiler rejecting the microarchitecture value, on ninety eight targets. After, that error is absent entirely and the build proceeds through nine hundred and seventy one targets before stopping on missing libraries for the target and on the intrinsics noted above. No cross configuration file is added here, since a working cross build is not yet claimed.