### PR TITLE
fix(common): compute the flow hash portably

### DIFF
--- a/common/crc32.h
+++ b/common/crc32.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#if defined(__x86_64__) || defined(__i386__)
+
 static inline uint32_t
 crc32_u8(uint8_t v, uint32_t hash) {
 	return __builtin_ia32_crc32qi(hash, v);
@@ -22,6 +24,42 @@ static inline uint32_t
 crc32_u64(uint64_t v, uint32_t hash) {
 	return __builtin_ia32_crc32di(hash, v);
 }
+
+#elif defined(__aarch64__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+
+#include <arm_acle.h>
+
+// The c variants compute CRC-32C (Castagnoli), matching the x86
+// crc32 instruction bit for bit.
+//
+// The plain (non-c) intrinsics compute the Ethernet polynomial
+// instead and must never be used here.
+
+static inline uint32_t
+crc32_u8(uint8_t v, uint32_t hash) {
+	return __crc32cb(hash, v);
+}
+
+static inline uint32_t
+crc32_u16(uint16_t v, uint32_t hash) {
+	return __crc32ch(hash, v);
+}
+
+static inline uint32_t
+crc32_u32(uint32_t v, uint32_t hash) {
+	return __crc32cw(hash, v);
+}
+
+static inline uint32_t
+crc32_u64(uint64_t v, uint32_t hash) {
+	return __crc32cd(hash, v);
+}
+
+#else
+
+#error "crc32: no CRC-32C implementation for this architecture"
+
+#endif
 
 static inline uint32_t
 crc32(const void *data, uint64_t size, uint32_t hash) {

--- a/meson.build
+++ b/meson.build
@@ -17,6 +17,13 @@ project(
 yanet_project_args = ['-g', '-D_GNU_SOURCE']
 if host_machine.cpu_family() in ['x86', 'x86_64']
   yanet_project_args += '-march=' + get_option('cpu_arch')
+elif host_machine.cpu_family() == 'aarch64'
+  # The CRC32C intrinsics used by common/crc32.h are not part of the
+  # aarch64 baseline instruction set, so the CRC extension must be
+  # requested explicitly.
+  #
+  # Both Ampere Altra and AmpereOne implement it.
+  yanet_project_args += '-march=armv8-a+crc'
 endif
 add_project_arguments(yanet_project_args, language: 'c')
 

--- a/tests/common/crc32_test.c
+++ b/tests/common/crc32_test.c
@@ -1,0 +1,119 @@
+#include "common/crc32.h"
+#include "common/test_assert.h"
+
+#include "lib/logging/log.h"
+
+#include <stdint.h>
+
+struct crc32_vector {
+	const char *name;
+	const uint8_t *data;
+	uint64_t size;
+	uint32_t seed;
+	uint32_t expected;
+};
+
+// These values were captured by running crc32() on the x86 build, which
+// defines the wire-visible behaviour: packet->hash is computed from them
+// and steers ECMP, MPLS entropy, pipeline and chain demux, and TX queue
+// selection, so any architecture must reproduce these constants exactly.
+
+static const uint8_t vec_len1[] = {0xab};
+static const uint8_t vec_len2[] = {0x01, 0x02};
+static const uint8_t vec_len3[] = {0x01, 0x02, 0x03};
+static const uint8_t vec_len4[] = {0x01, 0x02, 0x03, 0x04};
+static const uint8_t vec_len5[] = {0x01, 0x02, 0x03, 0x04, 0x05};
+static const uint8_t vec_len6[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+static const uint8_t vec_len7[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+static const uint8_t vec_len8[] = {
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+};
+static const uint8_t vec_len13[] = {
+	0x11,
+	0x22,
+	0x33,
+	0x44,
+	0x55,
+	0x66,
+	0x77,
+	0x88,
+	0x99,
+	0xaa,
+	0xbb,
+	0xcc,
+	0xdd,
+};
+static const uint8_t vec_len17[] = {
+	0x01,
+	0x02,
+	0x03,
+	0x04,
+	0x05,
+	0x06,
+	0x07,
+	0x08,
+	0x09,
+	0x0a,
+	0x0b,
+	0x0c,
+	0x0d,
+	0x0e,
+	0x0f,
+	0x10,
+	0x11,
+};
+
+static const struct crc32_vector vectors[] = {
+	{"empty, zero seed", NULL, 0, 0x00000000u, 0x00000000u},
+	{"empty, non-zero seed", NULL, 0, 0xffffffffu, 0xffffffffu},
+	{"1 byte", vec_len1, sizeof(vec_len1), 0x00000000u, 0x3bc21e9du},
+	{"2 bytes", vec_len2, sizeof(vec_len2), 0x00000000u, 0xf299e880u},
+	{"3 bytes", vec_len3, sizeof(vec_len3), 0x00000000u, 0x91545164u},
+	{"4 bytes", vec_len4, sizeof(vec_len4), 0x00000000u, 0x6157c733u},
+	{"5 bytes", vec_len5, sizeof(vec_len5), 0x00000000u, 0x1623f99eu},
+	{"6 bytes", vec_len6, sizeof(vec_len6), 0x00000000u, 0x18678721u},
+	{"7 bytes", vec_len7, sizeof(vec_len7), 0x00000000u, 0x06040eb1u},
+	{"8 bytes", vec_len8, sizeof(vec_len8), 0x00000000u, 0xcaa1ad0bu},
+	{"13 bytes, non-zero seed",
+	 vec_len13,
+	 sizeof(vec_len13),
+	 0xdeadbeefu,
+	 0xd103d910u},
+	{"17 bytes", vec_len17, sizeof(vec_len17), 0x00000000u, 0xbdc13ac3u},
+};
+
+// Verifies that crc32() reproduces the golden values captured from the
+// x86 build across an empty input, every tail length from 1 to 8 bytes
+// (so the 8/4/2/1-byte branches each fire), an input past 8 bytes so the
+// 8-byte loop iterates, an input past 16 bytes so the loop runs two full
+// laps before the tail, and a non-zero seed.
+static int
+test_golden_vectors(void) {
+	LOG(INFO, "Test golden vectors...");
+
+	for (size_t idx = 0; idx < sizeof(vectors) / sizeof(vectors[0]);
+	     ++idx) {
+		const struct crc32_vector *vector = vectors + idx;
+		uint32_t hash = crc32(vector->data, vector->size, vector->seed);
+		TEST_ASSERT_EQUAL(
+			hash,
+			vector->expected,
+			"crc32 mismatch for %s",
+			vector->name
+		);
+	}
+
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	if (test_golden_vectors() != TEST_SUCCESS) {
+		return -1;
+	}
+
+	LOG(INFO, "All crc32 tests passed");
+	return 0;
+}

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -163,3 +163,13 @@ thash_test = executable(
 )
 test('thash', thash_test, suite: ['common'])
 
+crc32_test = executable(
+  'crc32_test',
+  ['crc32_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies,
+  include_directories: yanet_rootdir,
+)
+test('crc32', crc32_test, suite: ['common'])
+


### PR DESCRIPTION
The flow hash was built from an architecture specific instruction. It is not an internal detail: the value selects the next hop for equal cost routing, the label switched next hop and its entropy value, the pipeline and chain selection, and the transmit queue. Two machines that disagree on it disagree about where a flow goes, which is why this is the part of the port worth being most careful with.

- Add an implementation for the other target architecture, using the instructions that compute the same polynomial. The neighbouring instructions on that architecture compute a different one, and confusing them is a single character mistake, so the choice is called out in a comment.
- Refuse to build anywhere else. A portable software fallback would risk a fleet quietly disagreeing the moment one node built without the instruction path, which is worse than a build failure.
- Request the extension providing those instructions, since it is not part of that architecture's baseline. Measured to be a strict superset of the previous default, adding one feature and removing nothing.
- Pin the result with a table of expected values taken from the original implementation, covering the empty input, each tail length, and an input long enough to loop twice.

Verified by execution rather than by argument. The generated code on the architecture we run today is unchanged, proven by an identical text section. The new implementation reproduces the pinned values when cross built and run under emulation. Swapping in the wrong instructions makes the test fail, and reverting makes it pass again, so the table has real discriminating power rather than passing regardless. Branch coverage over the hash function is complete in both directions.

One gap worth stating: no runner builds the new path, so it currently has no continuous coverage. A compile only smoke job would be cheap and is worth adding separately.