### PR TITLE
fix(dataplane): reclaim virtio TX completions at quiescence

### DIFF
--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -310,6 +310,15 @@ worker_write(
 			ctx->rx_pipes + pipe_idx, worker_rx_pipe_pop_cb, worker
 		);
 	}
+
+	// Give the PMD a chance to reclaim completed TX descriptors even
+	// when no packet was transmitted this round. On virtio this is the
+	// only way to drain the accepted-but-unreclaimed tail of the last
+	// burst at quiescence (the driver does not reclaim outside a nonzero
+	// tx_burst without this op). For PMDs that already reclaim inside
+	// tx_burst it is a cheap no-op; for those without the op (e.g. ring)
+	// it returns -ENOTSUP, which we ignore.
+	rte_eth_tx_done_cleanup(worker->port_id, worker->queue_id, 0);
 }
 
 static void


### PR DESCRIPTION
The virtio PMD only reclaims completed TX descriptors inside a nonzero rte_eth_tx_burst() call and did not implement the tx_done_cleanup ethdev op, so rte_eth_tx_done_cleanup() returned -ENOTSUP. PR #1509 worked around this at the worker level by retrying rejected packets to keep bursts flowing, but left a quiescent residual: the accepted-but-unreclaimed tail of the last burst stayed pinned in the producer's pending FIFO until the next nonzero burst arrived.

Implement the tx_done_cleanup device operation in the virtio PMD (DPDK fork), dispatching to the existing per-ring-variant cleanup helpers. Unlike the teardown-only virtio_tx_completed_cleanup, num is computed per ring type: virtqueue_nused() for split (carries the acquire barrier the split cleanup trusts) and vq_nentries for packed (virtqueue_nused reads the split used->idx which is meaningless for packed; packed helpers self-guard via desc_is_used()).

The worker now calls rte_eth_tx_done_cleanup() unconditionally each round, draining the quiescent residual to zero. PR #1509's retry logic remains as defense-in-depth — it prevents the wedge under overload, while this probe completes the cure at idle.