### PR TITLE
fix(controlplane): relink the agent chain when reclaiming unused generations

### DIFF
--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1983,13 +1983,17 @@ agent_free_unused_agents(struct agent *agent) {
 	if (agent == NULL) {
 		return;
 	}
-	agent = ADDR_OF(&agent->prev);
-	while (agent != NULL) {
+
+	while (ADDR_OF(&agent->prev) != NULL) {
 		struct agent *prev_agent = ADDR_OF(&agent->prev);
-		if (agent->loaded_module_count == 0) {
-			agent_cleanup(agent);
+
+		if (prev_agent->loaded_module_count == 0) {
+			SET_OFFSET_OF(&agent->prev, ADDR_OF(&prev_agent->prev));
+			agent_cleanup(prev_agent);
+			continue;
 		}
-		agent = prev_agent;
+
+		agent = ADDR_OF(&agent->prev);
 	}
 }
 


### PR DESCRIPTION
- Reclaiming an older same-name agent left the retained agent pointing back at the freed node, so the next attachment or traversal dereferenced freed shared memory.
- Relink the chain around each reclaimed generation before cleaning it up, mirroring the reclaim path already used when a new agent is attached.

Closes #1528.
