### PR TITLE
fix(controlplane): log counter collection failures instead of dropping them silently

### DIFF
--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strconv"
 
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
 	"github.com/yanet-platform/yanet2/common/commonpb/v1"
@@ -18,13 +19,40 @@ type Counters struct {
 
 	instanceID uint32
 	shm        *ffi.SharedMemory
+	log        *zap.Logger
+}
+
+// CountersOption configures the Counters constructor.
+type CountersOption func(*countersOptions)
+
+type countersOptions struct {
+	Log *zap.Logger
+}
+
+func newCountersOptions() *countersOptions {
+	return &countersOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithCountersLog sets the logger for the counters service.
+func WithCountersLog(log *zap.Logger) CountersOption {
+	return func(o *countersOptions) {
+		o.Log = log
+	}
 }
 
 // NewCounters creates a new Counters service.
-func NewCounters(instanceID uint32, shm *ffi.SharedMemory) *Counters {
+func NewCounters(instanceID uint32, shm *ffi.SharedMemory, options ...CountersOption) *Counters {
+	opts := newCountersOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &Counters{
 		instanceID: instanceID,
 		shm:        shm,
+		log:        opts.Log,
 	}
 }
 
@@ -225,6 +253,9 @@ func (m *Counters) Ports(
 }
 
 // Collect returns a generic metrics snapshot for port and worker counters.
+//
+// A family that fails to collect is omitted from the snapshot, so a
+// consumer sees a gap for that scrape rather than stale values.
 func (m *Counters) Collect() []*commonpb.Metric {
 	dpConfig := m.shm.DPConfig(m.instanceID)
 
@@ -232,10 +263,14 @@ func (m *Counters) Collect() []*commonpb.Metric {
 
 	if ports, err := dpConfig.PortCounters(); err == nil {
 		metrics = append(metrics, portMetrics(ports)...)
+	} else {
+		m.log.Warn("failed to collect port counters", zap.Error(err))
 	}
 
 	if workers, err := dpConfig.WorkerCounters(); err == nil {
 		metrics = append(metrics, workerMetrics(workers)...)
+	} else {
+		m.log.Warn("failed to collect worker counters", zap.Error(err))
 	}
 
 	return metrics

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -125,7 +125,7 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 			builtin.NewFunction(cfg.Gateway.InstanceID, shm, builtin.WithFunctionLog(log)),
 		),
 		gateway.WithBuiltinService(
-			builtin.NewCounters(cfg.Gateway.InstanceID, shm),
+			builtin.NewCounters(cfg.Gateway.InstanceID, shm, builtin.WithCountersLog(log)),
 		),
 		gateway.WithBuiltinService(
 			builtin.NewDevice(cfg.Gateway.InstanceID, shm),


### PR DESCRIPTION
- The counters service discarded an entire metric family from its snapshot whenever collection failed, with no log line, no error to the caller and no counter of failures. A family disappearing from a scrape left nothing anywhere to explain it.
- The two families were also covered by a single guard each, so a failure in one was indistinguishable from a failure in the other.
- Both failures are now reported and the families stay independent, so one of them failing no longer hides the other.
- A failure still omits that family from the snapshot rather than serving stale values, which is the behaviour a consumer should see.