### PR TITLE
refactor(dataplane): replace worker-scan helpers with a per-device count

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -741,6 +741,22 @@ dataplane_init(
 			return -1;
 		}
 
+		for (uint64_t device_idx = 0;
+		     device_idx < dataplane->device_count;
+		     ++device_idx) {
+			if (dp_topology_set_device_worker_count(
+				    dp_config,
+				    device_idx,
+				    dataplane->devices[device_idx].worker_count
+			    ) != 0) {
+				LOG(ERROR,
+				    "failed to set dp_topology worker count "
+				    "for device %lu",
+				    device_idx);
+				return -1;
+			}
+		}
+
 		cp_config_unlock(cp_config);
 		dp_config_mark_ready(dp_config);
 	}

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -419,6 +419,13 @@ dataplane_worker_init(
 	}
 	memset(dp_worker, 0, sizeof(struct dp_worker));
 	dp_worker->idx = dp_config->worker_count;
+	// Set before dp_config->worker_count is incremented below: a reader
+	// bounds its walk of dp_config->workers by that count, so these
+	// fields must be live before the count moves, not still zeroed.
+	dp_worker->device_id = worker->device_id;
+	dp_worker->queue_id = queue_id;
+	dp_worker->core_id = config->core_id;
+	dp_worker->rx_burst_size = WORKER_RX_BURST_SIZE;
 
 	// Init worker clock
 	int init_clock_result = tsc_clock_init(&dp_worker->clock);
@@ -457,10 +464,6 @@ dataplane_worker_init(
 	worker->read_ctx.read_size = WORKER_RX_BURST_SIZE;
 	worker->write_ctx.write_size = 32;
 	worker->write_ctx.rx_pipes = NULL;
-	dp_worker->core_id = config->core_id;
-	dp_worker->device_id = worker->device_id;
-	dp_worker->queue_id = queue_id;
-	dp_worker->rx_burst_size = WORKER_RX_BURST_SIZE;
 
 	uint16_t rx_queue_len =
 		config->rx_queue_len ? config->rx_queue_len : 4096;

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -48,6 +48,6 @@ _Static_assert(
 	"struct dp_worker size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct dp_port) == 112,
+	sizeof(struct dp_port) == 120,
 	"struct dp_port size changed, bump YANET_MODULE_ABI_VERSION"
 );

--- a/lib/dataplane/config/topology.c
+++ b/lib/dataplane/config/topology.c
@@ -6,6 +6,7 @@
 #include "common/memory_address.h"
 
 #include "lib/dataplane/config/zone.h"
+#include "lib/logging/log.h"
 
 struct dp_port *
 dp_topology_alloc_devices(struct dp_config *dp_config, size_t count) {
@@ -45,12 +46,18 @@ dp_topology_set_device_rss(
 		return -1;
 	}
 
+	uint64_t device_count = dp_config->dp_topology.device_count;
+	if (device_id >= device_count) {
+		LOG(ERROR,
+		    "device_id %u out of range (device_count %lu)",
+		    device_id,
+		    device_count);
+		return -1;
+	}
+
 	struct dp_port *devices = ADDR_OF(&dp_config->dp_topology.devices);
 	struct dp_port *device = devices + device_id;
 
-	// Assumes a single call per (instance, device) at device start — a
-	// re-invocation for the same device would leak the previously
-	// allocated key and reta arrays instead of freeing them.
 	uint8_t *key_copy =
 		(uint8_t *)memory_balloc(&dp_config->memory_context, key_len);
 	if (key_copy == NULL) {
@@ -74,6 +81,26 @@ dp_topology_set_device_rss(
 	SET_OFFSET_OF(&device->rss_reta, reta_copy);
 
 	device->rss_valid = true;
+
+	return 0;
+}
+
+int
+dp_topology_set_device_worker_count(
+	struct dp_config *dp_config, uint32_t device_id, uint64_t worker_count
+) {
+	uint64_t device_count = dp_config->dp_topology.device_count;
+
+	if (device_id >= device_count) {
+		LOG(ERROR,
+		    "device_id %u out of range (device_count %lu)",
+		    device_id,
+		    device_count);
+		return -1;
+	}
+
+	struct dp_port *devices = ADDR_OF(&dp_config->dp_topology.devices);
+	devices[device_id].worker_count = worker_count;
 
 	return 0;
 }

--- a/lib/dataplane/config/topology.h
+++ b/lib/dataplane/config/topology.h
@@ -23,12 +23,17 @@ struct dp_port {
 	uint16_t rss_key_len;
 	uint8_t *rss_key;
 
-	// Redirection table: rss_reta[slot] is the rx-queue id the NIC maps
-	// RETA slot to.
+	// Redirection table (RETA): rss_reta[slot] is the rx-queue id the NIC
+	// maps that slot to.
 	//
 	// The table size is queried at runtime and also varies by driver.
 	uint16_t rss_reta_size;
 	uint16_t *rss_reta;
+
+	// Count of workers bound to this device, across every instance -- not
+	// to be confused with dp_config->worker_count, the instance-wide
+	// total across every device.
+	uint64_t worker_count;
 };
 
 struct dp_topology {
@@ -75,7 +80,12 @@ dp_topology_alloc_devices(struct dp_config *dp_config, size_t count);
 // be at least DP_TOPOLOGY_RSS_KEY_LEN_MIN. A call outside that contract is
 // rejected outright — nothing is allocated or stored, and rss_valid stays
 // false — so the device falls back to its non-RSS-aware path instead of an
-// out-of-contract report reaching a consumer.
+// out-of-contract report reaching a consumer. An out-of-range device_id is
+// rejected the same way.
+//
+// Assumes a single call per (instance, device) at device start — a
+// re-invocation for the same device would leak the previously allocated
+// key and reta arrays instead of freeing them.
 //
 // On success the device's rss_valid flag is set. Returns non-zero on
 // rejection or allocation failure, leaving the device's RSS state untouched.
@@ -87,4 +97,18 @@ dp_topology_set_device_rss(
 	uint16_t key_len,
 	const uint16_t *reta,
 	uint16_t reta_size
+);
+
+// Set the count of workers bound to device_id, across every instance, so
+// dp_config_device_worker_count can answer in O(1).
+//
+// Must be the device-wide count, not a single instance's tally: queue ids
+// are handed out per device across every instance, so a device spanning
+// more than one instance would otherwise be undercounted.
+//
+// Returns non-zero if device_id is out of range for dp_topology, leaving
+// the count untouched.
+int
+dp_topology_set_device_worker_count(
+	struct dp_config *dp_config, uint32_t device_id, uint64_t worker_count
 );

--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -104,21 +104,11 @@ dp_config_lookup_device(
 	return -1;
 }
 
-int
-dp_config_worker_idx_by_device_queue(
-	struct dp_config *dp_config,
-	uint32_t device_id,
-	uint16_t queue_id,
-	uint64_t *out_idx
-) {
-	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
-	for (uint64_t idx = 0; idx < dp_config->worker_count; ++idx) {
-		struct dp_worker *worker = ADDR_OF(workers + idx);
-		if (worker->device_id == device_id &&
-		    worker->queue_id == queue_id) {
-			*out_idx = worker->idx;
-			return 0;
-		}
+uint64_t
+dp_config_device_worker_count(struct dp_config *dp_config, uint32_t device_id) {
+	if (device_id >= dp_config->dp_topology.device_count) {
+		return 0;
 	}
-	return -1;
+	struct dp_port *devices = ADDR_OF(&dp_config->dp_topology.devices);
+	return devices[device_id].worker_count;
 }

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -173,21 +173,13 @@ dp_config_lookup_device(
 	struct dp_config *dp_config, const char *name, uint64_t *index
 );
 
-// Find the global dp_worker->idx of the worker owning the given
-// (device_id, rx_queue) pair by scanning dp_config->workers. Writes the
-// found index to *out_idx and returns 0, or returns non-zero if no worker
-// owns that device/queue pair.
+// Count of workers bound to device_id, across every instance.
 //
-// The returned index is the GLOBAL worker index, not the queue id — the two
-// diverge whenever a device's queue ids are not a prefix of the global
-// worker index space.
-int
-dp_config_worker_idx_by_device_queue(
-	struct dp_config *dp_config,
-	uint32_t device_id,
-	uint16_t queue_id,
-	uint64_t *out_idx
-);
+// O(1), reading a count dp_topology_set_device_worker_count publishes per
+// device. Zero for an out-of-range device_id or one whose count was never
+// set.
+uint64_t
+dp_config_device_worker_count(struct dp_config *dp_config, uint32_t device_id);
 
 void
 dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen);

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 7
+#define YANET_MODULE_ABI_VERSION 8
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -335,6 +335,44 @@ dataplane_ut_new(const struct dataplane_ut_config *cfg) {
 		SET_OFFSET_OF(dp_workers + idx, dp_worker);
 	}
 
+	// Skipped when device_count == 0: the implicit device 0 (see above)
+	// has no dp_topology slot, so per-device worker counts stay
+	// unavailable in that mode -- a known, deferred gap.
+	if (cfg->device_count > 0) {
+		uint64_t *device_worker_counts = (uint64_t *)calloc(
+			effective_device_count, sizeof(uint64_t)
+		);
+		if (device_worker_counts == NULL) {
+			LOG(ERROR,
+			    "dataplane_ut_new: failed to allocate device "
+			    "worker counts");
+			dataplane_ut_free(ut);
+			return NULL;
+		}
+		for (size_t idx = 0; idx < cfg->worker_count; ++idx) {
+			struct dp_worker *dp_worker = ADDR_OF(dp_workers + idx);
+			++device_worker_counts[dp_worker->device_id];
+		}
+		for (size_t device_idx = 0; device_idx < effective_device_count;
+		     ++device_idx) {
+			if (dp_topology_set_device_worker_count(
+				    ut->dp_config,
+				    device_idx,
+				    device_worker_counts[device_idx]
+			    ) != 0) {
+				LOG(ERROR,
+				    "dataplane_ut_new: failed to set "
+				    "dp_topology worker count for device "
+				    "%zu",
+				    device_idx);
+				free(device_worker_counts);
+				dataplane_ut_free(ut);
+				return NULL;
+			}
+		}
+		free(device_worker_counts);
+	}
+
 	return ut;
 }
 

--- a/lib/tests/dataplane/fixture.h
+++ b/lib/tests/dataplane/fixture.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/memory.h"
+#include "common/memory_address.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+
+#include "lib/dataplane/config/zone.h"
+
+// Arena size backing every dp_config test fixture in this directory.
+#define DATAPLANE_TEST_ARENA_SIZE (1 << 20)
+
+// A dp_config wired up with an arena-backed memory context and a
+// dp_topology.devices array of device_count slots.
+struct dataplane_test_fixture {
+	void *arena;
+	struct block_allocator block_allocator;
+	struct dp_config dp_config;
+};
+
+static inline int
+dataplane_test_fixture_init(
+	struct dataplane_test_fixture *fixture,
+	const char *name,
+	uint64_t device_count
+) {
+	struct dp_config *cfg = &fixture->dp_config;
+	memset(cfg, 0, sizeof(*cfg));
+
+	fixture->arena = malloc(DATAPLANE_TEST_ARENA_SIZE);
+	TEST_ASSERT_NOT_NULL(fixture->arena, "failed to allocate arena");
+	block_allocator_init(&fixture->block_allocator);
+	block_allocator_put_arena(
+		&fixture->block_allocator,
+		fixture->arena,
+		DATAPLANE_TEST_ARENA_SIZE
+	);
+	memory_context_init(
+		&cfg->memory_context, name, &fixture->block_allocator
+	);
+	TEST_ASSERT_NOT_NULL(
+		dp_topology_alloc_devices(cfg, device_count),
+		"alloc_devices failed"
+	);
+
+	return TEST_SUCCESS;
+}
+
+static inline void
+dataplane_test_fixture_fini(struct dataplane_test_fixture *fixture) {
+	free(fixture->arena);
+}

--- a/lib/tests/dataplane/meson.build
+++ b/lib/tests/dataplane/meson.build
@@ -52,3 +52,16 @@ topology_test = executable(
   include_directories: yanet_rootdir,
 )
 test('topology', topology_test, suite: 'lib_dataplane')
+
+zone_test = executable(
+  'zone_test',
+  'zone_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_config_dp_dep,
+    lib_logging_dep,
+  ],
+  include_directories: yanet_rootdir,
+)
+test('zone', zone_test, suite: 'lib_dataplane')

--- a/lib/tests/dataplane/topology_test.c
+++ b/lib/tests/dataplane/topology_test.c
@@ -1,52 +1,23 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "common/memory.h"
-#include "common/memory_block.h"
 #include "common/test_assert.h"
 
 #include "lib/dataplane/config/topology.h"
 #include "lib/dataplane/config/zone.h"
 #include "lib/logging/log.h"
-
-#define ARENA_SIZE (1 << 20)
+#include "lib/tests/dataplane/fixture.h"
 
 // A single dp_config wired up with a fresh arena-backed memory context and
 // one topology slot, ready for dp_topology_set_device_rss calls.
-struct topology_fixture {
-	void *arena;
-	struct block_allocator block_allocator;
-	struct dp_config dp_config;
-};
-
 static int
-fixture_init(struct topology_fixture *fixture) {
-	memset(&fixture->dp_config, 0, sizeof(fixture->dp_config));
-
-	fixture->arena = malloc(ARENA_SIZE);
-	TEST_ASSERT_NOT_NULL(fixture->arena, "failed to allocate arena");
-
-	block_allocator_init(&fixture->block_allocator);
-	block_allocator_put_arena(
-		&fixture->block_allocator, fixture->arena, ARENA_SIZE
-	);
-	memory_context_init(
-		&fixture->dp_config.memory_context,
-		"topology_test",
-		&fixture->block_allocator
-	);
-
-	TEST_ASSERT_NOT_NULL(
-		dp_topology_alloc_devices(&fixture->dp_config, 1),
-		"dp_topology_alloc_devices failed"
-	);
-
-	return TEST_SUCCESS;
+fixture_init(struct dataplane_test_fixture *fixture) {
+	return dataplane_test_fixture_init(fixture, "topology_test", 1);
 }
 
 static void
-fixture_fini(struct topology_fixture *fixture) {
-	free(fixture->arena);
+fixture_fini(struct dataplane_test_fixture *fixture) {
+	dataplane_test_fixture_fini(fixture);
 }
 
 // Verifies that a reta_size over DP_TOPOLOGY_RSS_RETA_SIZE_MAX is rejected
@@ -55,7 +26,7 @@ fixture_fini(struct topology_fixture *fixture) {
 // exactly 512 slots.
 static int
 test_reject_reta_size_too_large(void) {
-	struct topology_fixture fixture;
+	struct dataplane_test_fixture fixture;
 	TEST_ASSERT_SUCCESS(fixture_init(&fixture), "fixture init failed");
 
 	uint8_t key[40] = {0};
@@ -86,7 +57,7 @@ test_reject_reta_size_too_large(void) {
 // carries no usable RSS state.
 static int
 test_reject_reta_size_zero(void) {
-	struct topology_fixture fixture;
+	struct dataplane_test_fixture fixture;
 	TEST_ASSERT_SUCCESS(fixture_init(&fixture), "fixture init failed");
 
 	uint8_t key[40] = {0};
@@ -112,7 +83,7 @@ test_reject_reta_size_zero(void) {
 // since thash_toeplitz reads its first four bytes unconditionally.
 static int
 test_reject_key_len_too_short(void) {
-	struct topology_fixture fixture;
+	struct dataplane_test_fixture fixture;
 	TEST_ASSERT_SUCCESS(fixture_init(&fixture), "fixture init failed");
 
 	uint8_t key[3] = {0};
@@ -143,7 +114,7 @@ test_reject_key_len_too_short(void) {
 // stored verbatim, with rss_valid set.
 static int
 test_accept_valid_rss_state(void) {
-	struct topology_fixture fixture;
+	struct dataplane_test_fixture fixture;
 	TEST_ASSERT_SUCCESS(fixture_init(&fixture), "fixture init failed");
 
 	uint8_t key[40];

--- a/lib/tests/dataplane/zone_test.c
+++ b/lib/tests/dataplane/zone_test.c
@@ -1,0 +1,125 @@
+#include <stdlib.h>
+
+#include "common/test_assert.h"
+
+#include "lib/dataplane/config/topology.h"
+#include "lib/dataplane/config/zone.h"
+#include "lib/logging/log.h"
+#include "lib/tests/dataplane/fixture.h"
+
+#define ZONE_TEST_DEVICE_COUNT 3
+
+// Verifies that dp_topology_set_device_worker_count writes a distinct count
+// per device, dp_config_device_worker_count reads each back, and a
+// device_id at device_count reads zero.
+static int
+test_worker_counts(void) {
+	struct dataplane_test_fixture fixture;
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(
+			&fixture, "zone_test", ZONE_TEST_DEVICE_COUNT
+		),
+		"fixture init failed"
+	);
+	struct dp_config *cfg = &fixture.dp_config;
+
+	static const uint64_t expected_counts[ZONE_TEST_DEVICE_COUNT] = {
+		3, 2, 1
+	};
+	for (uint32_t device_id = 0; device_id < ZONE_TEST_DEVICE_COUNT;
+	     ++device_id) {
+		TEST_ASSERT_SUCCESS(
+			dp_topology_set_device_worker_count(
+				cfg, device_id, expected_counts[device_id]
+			),
+			"set failed for device %u",
+			device_id
+		);
+	}
+
+	for (uint32_t device_id = 0; device_id < ZONE_TEST_DEVICE_COUNT;
+	     ++device_id) {
+		TEST_ASSERT_EQUAL(
+			dp_config_device_worker_count(cfg, device_id),
+			expected_counts[device_id],
+			"count mismatch for device %u",
+			device_id
+		);
+	}
+
+	TEST_ASSERT_EQUAL(
+		dp_config_device_worker_count(cfg, ZONE_TEST_DEVICE_COUNT),
+		0,
+		"a device_id at device_count must read zero"
+	);
+
+	dataplane_test_fixture_fini(&fixture);
+	return TEST_SUCCESS;
+}
+
+// Verifies that dp_topology_set_device_worker_count rejects a device_id out
+// of range for dp_topology, and that an in-range device whose count was
+// never set reads back zero rather than garbage.
+static int
+test_set_worker_count_out_of_range(void) {
+	struct dataplane_test_fixture fixture;
+	TEST_ASSERT_SUCCESS(
+		dataplane_test_fixture_init(&fixture, "zone_test", 2),
+		"fixture init failed"
+	);
+	struct dp_config *cfg = &fixture.dp_config;
+
+	TEST_ASSERT(
+		dp_topology_set_device_worker_count(cfg, 5, 1) != 0,
+		"set must reject an out-of-range device_id"
+	);
+	TEST_ASSERT_EQUAL(
+		dp_config_device_worker_count(cfg, 1),
+		0,
+		"an in-range device whose count was never set must read zero"
+	);
+
+	dataplane_test_fixture_fini(&fixture);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	LOG(INFO, "=== Starting Zone Test Suite ===");
+
+	struct {
+		const char *name;
+		int (*fn)(void);
+	} tests[] = {
+		{"worker_counts", test_worker_counts},
+		{"set_worker_count_out_of_range",
+		 test_set_worker_count_out_of_range},
+	};
+
+	size_t total = sizeof(tests) / sizeof(tests[0]);
+	size_t failed = 0;
+
+	for (size_t idx = 0; idx < total; ++idx) {
+		LOG(INFO,
+		    "[%zu/%zu] running %s...",
+		    idx + 1,
+		    total,
+		    tests[idx].name);
+		if (tests[idx].fn() != TEST_SUCCESS) {
+			LOG(ERROR, "%s FAILED", tests[idx].name);
+			++failed;
+		} else {
+			LOG(INFO, "%s passed", tests[idx].name);
+		}
+	}
+
+	if (failed == 0) {
+		LOG(INFO, "=== All %zu zone tests passed! ===", total);
+	} else {
+		LOG(ERROR, "=== %zu/%zu zone tests failed ===", failed, total);
+	}
+
+	return failed == 0 ? TEST_SUCCESS : TEST_FAILED;
+}


### PR DESCRIPTION
- Replaces a linear scan over every worker in an instance with a per-device count published once at dataplane startup.
- Removes a topology helper that no longer has any production caller.
- Counts a device's workers across every instance, matching how receive queue ids are assigned and how the consumer scales its work by the number of queues a device spreads over.
- Sets the worker fields the control plane reads directly before the worker is published, so a reader walking the worker list can no longer observe an unclaimed device or queue id.
- Bumps the module ABI version for the shared memory layout change. The loader resolves plugin symbols before it checks that version, so a stale binary paired with a fresh plugin fails as a missing symbol rather than as a version mismatch; the dataplane binary and its plugins must be deployed together.