### PR TITLE
refactor(fwstate): typed fwmap4/fwmap6 handles to enforce key/value sizes

### DIFF
--- a/lib/fwstate/fwmap_typed.h
+++ b/lib/fwstate/fwmap_typed.h
@@ -1,0 +1,379 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "fwmap.h"
+#include "fwstate_cursor.h"
+#include "layermap.h"
+#include "types.h"
+
+/*
+ * Typed fwmap handles — bind the generic fwmap_t to a specific key family so
+ * that a key/map family mismatch (e.g. feeding a struct fw6_state_key to an
+ * fw4state map) becomes a compile-time error instead of silent truncation UB.
+ *
+ * Each handle is a thin stack-local wrapper around the resolved fwmap_t
+ * pointer. It carries no extra state and is NOT stored in shared memory:
+ * the shared-memory layout (fwmap_t, fwstate_config) is unchanged. Callers
+ * resolve the offset to a raw fwmap_t * and wrap it at the point of use.
+ *
+ * Sizes are baked into the typed constructors, so production callers can no
+ * longer influence key_size/value_size — the field becomes an internal
+ * invariant of fwmap4_new/fwmap6_new rather than a contract every caller
+ * has to remember.
+ */
+
+typedef struct fwmap4 {
+	fwmap_t *raw;
+} fwmap4_t;
+typedef struct fwmap6 {
+	fwmap_t *raw;
+} fwmap6_t;
+
+static inline fwmap4_t
+fwmap4_from_raw(fwmap_t *raw) {
+	return (fwmap4_t){.raw = raw};
+}
+
+static inline fwmap6_t
+fwmap6_from_raw(fwmap_t *raw) {
+	return (fwmap6_t){.raw = raw};
+}
+
+static inline fwmap_t *
+fwmap4_raw(fwmap4_t m) {
+	return m.raw;
+}
+
+static inline fwmap_t *
+fwmap6_raw(fwmap6_t m) {
+	return m.raw;
+}
+
+/* ====================================================================
+ * Construction / destruction
+ * ==================================================================== */
+
+#define FWMAP4_DEFAULT_INDEX_SIZE (1024u * 1024u)
+#define FWMAP6_DEFAULT_INDEX_SIZE (1024u * 1024u)
+#define FWMAP_DEFAULT_EXTRA_BUCKETS 1024u
+
+static inline fwmap4_t
+fwmap4_new(
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count,
+	struct memory_context *ctx
+) {
+	if (index_size == 0) {
+		index_size = FWMAP4_DEFAULT_INDEX_SIZE;
+	}
+	if (extra_bucket_count == 0) {
+		extra_bucket_count = FWMAP_DEFAULT_EXTRA_BUCKETS;
+	}
+
+	fwmap_config_t cfg = {
+		.key_size = sizeof(struct fw4_state_key),
+		.value_size = sizeof(struct fw_state_value),
+		.hash_seed = 0,
+		.worker_count = worker_count,
+		.index_size = index_size,
+		.extra_bucket_count = extra_bucket_count,
+		.hash_fn_id = FWMAP_HASH_FNV1A,
+		.key_equal_fn_id = FWMAP_KEY_EQUAL_FW4,
+		.rand_fn_id = FWMAP_RAND_DEFAULT,
+		.copy_key_fn_id = FWMAP_COPY_KEY_FW4,
+		.update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE,
+		.promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE,
+	};
+
+	return fwmap4_from_raw(fwmap_new(&cfg, ctx));
+}
+
+static inline fwmap6_t
+fwmap6_new(
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count,
+	struct memory_context *ctx
+) {
+	if (index_size == 0) {
+		index_size = FWMAP6_DEFAULT_INDEX_SIZE;
+	}
+	if (extra_bucket_count == 0) {
+		extra_bucket_count = FWMAP_DEFAULT_EXTRA_BUCKETS;
+	}
+
+	fwmap_config_t cfg = {
+		.key_size = sizeof(struct fw6_state_key),
+		.value_size = sizeof(struct fw_state_value),
+		.hash_seed = 0,
+		.worker_count = worker_count,
+		.index_size = index_size,
+		.extra_bucket_count = extra_bucket_count,
+		.hash_fn_id = FWMAP_HASH_FNV1A,
+		.key_equal_fn_id = FWMAP_KEY_EQUAL_FW6,
+		.rand_fn_id = FWMAP_RAND_DEFAULT,
+		.copy_key_fn_id = FWMAP_COPY_KEY_FW6,
+		.update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE,
+		.promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE,
+	};
+
+	return fwmap6_from_raw(fwmap_new(&cfg, ctx));
+}
+
+static inline void
+fwmap4_free(fwmap4_t m, struct memory_context *ctx) {
+	fwmap_free(m.raw, ctx);
+}
+
+static inline void
+fwmap6_free(fwmap6_t m, struct memory_context *ctx) {
+	fwmap_free(m.raw, ctx);
+}
+
+/* ====================================================================
+ * Typed lookup / insert (hot path)
+ *
+ * These are the correctness-critical operations: the key and value
+ * parameters are typed, so a caller cannot pair a struct fw6_state_key
+ * with an fw4 map (or vice versa) — the mismatch is caught at compile
+ * time. Each wrapper asserts that the underlying map's stored sizes
+ * match the baked-in compile-time sizes, guarding against a wrong raw
+ * pointer being wrapped.
+ * ==================================================================== */
+
+static inline int64_t
+fwmap4_get_value_and_deadline(
+	fwmap4_t m,
+	uint64_t now,
+	const struct fw4_state_key *key,
+	struct fw_state_value **value,
+	rwlock_t **lock,
+	uint64_t *deadline,
+	bool *value_from_stale_layer
+) {
+	assert(m.raw->key_size == sizeof(struct fw4_state_key));
+	assert(m.raw->value_size == sizeof(struct fw_state_value));
+	return layermap_get_value_and_deadline(
+		m.raw,
+		now,
+		key,
+		(void **)value,
+		lock,
+		deadline,
+		value_from_stale_layer
+	);
+}
+
+static inline int64_t
+fwmap6_get_value_and_deadline(
+	fwmap6_t m,
+	uint64_t now,
+	const struct fw6_state_key *key,
+	struct fw_state_value **value,
+	rwlock_t **lock,
+	uint64_t *deadline,
+	bool *value_from_stale_layer
+) {
+	assert(m.raw->key_size == sizeof(struct fw6_state_key));
+	assert(m.raw->value_size == sizeof(struct fw_state_value));
+	return layermap_get_value_and_deadline(
+		m.raw,
+		now,
+		key,
+		(void **)value,
+		lock,
+		deadline,
+		value_from_stale_layer
+	);
+}
+
+static inline int64_t
+fwmap4_put(
+	fwmap4_t m,
+	uint16_t worker_idx,
+	uint64_t now,
+	uint64_t ttl,
+	const struct fw4_state_key *key,
+	const struct fw_state_value *value,
+	rwlock_t **lock
+) {
+	assert(m.raw->key_size == sizeof(struct fw4_state_key));
+	assert(m.raw->value_size == sizeof(struct fw_state_value));
+	return layermap_put(m.raw, worker_idx, now, ttl, key, value, lock);
+}
+
+static inline int64_t
+fwmap6_put(
+	fwmap6_t m,
+	uint16_t worker_idx,
+	uint64_t now,
+	uint64_t ttl,
+	const struct fw6_state_key *key,
+	const struct fw_state_value *value,
+	rwlock_t **lock
+) {
+	assert(m.raw->key_size == sizeof(struct fw6_state_key));
+	assert(m.raw->value_size == sizeof(struct fw_state_value));
+	return layermap_put(m.raw, worker_idx, now, ttl, key, value, lock);
+}
+
+/* ====================================================================
+ * Layer management (control plane)
+ *
+ * layermap_insert_new_layer_cp and layermap_trim_stale_layers_cp operate
+ * on the shared-memory offset field (fwmap_t **) and need a config only
+ * for layer creation. The typed insert wrappers bake in the config; trim
+ * is family-agnostic (it only inspects deadlines) and is exposed as a
+ * thin pass-through for symmetry.
+ * ==================================================================== */
+
+static inline int
+fwmap4_insert_new_layer_cp(
+	fwmap_t **active_layer_offset,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count,
+	struct memory_context *ctx
+) {
+	if (index_size == 0) {
+		index_size = FWMAP4_DEFAULT_INDEX_SIZE;
+	}
+	if (extra_bucket_count == 0) {
+		extra_bucket_count = FWMAP_DEFAULT_EXTRA_BUCKETS;
+	}
+
+	fwmap_config_t cfg = {
+		.key_size = sizeof(struct fw4_state_key),
+		.value_size = sizeof(struct fw_state_value),
+		.hash_seed = 0,
+		.worker_count = worker_count,
+		.index_size = index_size,
+		.extra_bucket_count = extra_bucket_count,
+		.hash_fn_id = FWMAP_HASH_FNV1A,
+		.key_equal_fn_id = FWMAP_KEY_EQUAL_FW4,
+		.rand_fn_id = FWMAP_RAND_DEFAULT,
+		.copy_key_fn_id = FWMAP_COPY_KEY_FW4,
+		.update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE,
+		.promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE,
+	};
+
+	return layermap_insert_new_layer_cp(active_layer_offset, &cfg, ctx);
+}
+
+static inline int
+fwmap6_insert_new_layer_cp(
+	fwmap_t **active_layer_offset,
+	uint32_t index_size,
+	uint32_t extra_bucket_count,
+	uint16_t worker_count,
+	struct memory_context *ctx
+) {
+	if (index_size == 0) {
+		index_size = FWMAP6_DEFAULT_INDEX_SIZE;
+	}
+	if (extra_bucket_count == 0) {
+		extra_bucket_count = FWMAP_DEFAULT_EXTRA_BUCKETS;
+	}
+
+	fwmap_config_t cfg = {
+		.key_size = sizeof(struct fw6_state_key),
+		.value_size = sizeof(struct fw_state_value),
+		.hash_seed = 0,
+		.worker_count = worker_count,
+		.index_size = index_size,
+		.extra_bucket_count = extra_bucket_count,
+		.hash_fn_id = FWMAP_HASH_FNV1A,
+		.key_equal_fn_id = FWMAP_KEY_EQUAL_FW6,
+		.rand_fn_id = FWMAP_RAND_DEFAULT,
+		.copy_key_fn_id = FWMAP_COPY_KEY_FW6,
+		.update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE,
+		.promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE,
+	};
+
+	return layermap_insert_new_layer_cp(active_layer_offset, &cfg, ctx);
+}
+
+/* ====================================================================
+ * Stats / counters (family-agnostic; typed for API symmetry)
+ * ==================================================================== */
+
+static inline fwmap_stats_t
+fwmap4_get_stats(fwmap4_t m) {
+	return fwmap_get_stats(m.raw);
+}
+
+static inline fwmap_stats_t
+fwmap6_get_stats(fwmap6_t m) {
+	return fwmap_get_stats(m.raw);
+}
+
+static inline uint32_t
+fwmap4_layer_count(fwmap4_t m) {
+	return fwmap_layer_count(m.raw);
+}
+
+static inline uint32_t
+fwmap6_layer_count(fwmap6_t m) {
+	return fwmap_layer_count(m.raw);
+}
+
+static inline uint64_t
+fwmap4_max_deadline(fwmap4_t m) {
+	return fwmap_max_deadline(m.raw);
+}
+
+static inline uint64_t
+fwmap6_max_deadline(fwmap6_t m) {
+	return fwmap_max_deadline(m.raw);
+}
+
+/* ====================================================================
+ * Cursor helpers (index-based; typed for API symmetry)
+ * ==================================================================== */
+
+static inline uint32_t
+fwmap4_cursor_read_forward(
+	fwmap4_t m,
+	fwstate_cursor_t *cursor,
+	uint64_t now,
+	fwstate_cursor_entry_t *out,
+	uint32_t count
+) {
+	return fwstate_cursor_read_forward(m.raw, cursor, now, out, count);
+}
+
+static inline uint32_t
+fwmap6_cursor_read_forward(
+	fwmap6_t m,
+	fwstate_cursor_t *cursor,
+	uint64_t now,
+	fwstate_cursor_entry_t *out,
+	uint32_t count
+) {
+	return fwstate_cursor_read_forward(m.raw, cursor, now, out, count);
+}
+
+static inline uint32_t
+fwmap4_cursor_read_backward(
+	fwmap4_t m,
+	fwstate_cursor_t *cursor,
+	uint64_t now,
+	fwstate_cursor_entry_t *out,
+	uint32_t count
+) {
+	return fwstate_cursor_read_backward(m.raw, cursor, now, out, count);
+}
+
+static inline uint32_t
+fwmap6_cursor_read_backward(
+	fwmap6_t m,
+	fwstate_cursor_t *cursor,
+	uint64_t now,
+	fwstate_cursor_entry_t *out,
+	uint32_t count
+) {
+	return fwstate_cursor_read_backward(m.raw, cursor, now, out, count);
+}

--- a/lib/fwstate/layermap.h
+++ b/lib/fwstate/layermap.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common/memory.h"
 #include "fwmap.h"
 

--- a/lib/fwstate/lookup.c
+++ b/lib/fwstate/lookup.c
@@ -7,6 +7,7 @@
 #include "dataplane/packet/packet.h"
 #include "lib/dataplane/packet/data.h"
 
+#include "fwmap_typed.h"
 #include "layermap.h"
 #include "lookup.h"
 #include "types.h"
@@ -99,12 +100,13 @@ fwstate_build_state_key_v6(
 }
 
 /**
- * Common state lookup logic.
+ * Typed IPv4 state lookup. The fwmap4_t handle and the fw4_state_key are
+ * bound by the type system — a mismatch is a compile error.
  */
 static inline bool
-fwstate_lookup_state(
-	fwmap_t *fwstate,
-	void *key,
+fwstate_lookup_state_v4(
+	fwmap4_t map,
+	const struct fw4_state_key *key,
 	uint64_t now,
 	uint64_t *deadline,
 	bool *value_from_stale_layer
@@ -112,14 +114,8 @@ fwstate_lookup_state(
 	struct fw_state_value *value = NULL;
 	rwlock_t *lock = NULL;
 
-	int64_t result = layermap_get_value_and_deadline(
-		fwstate,
-		now,
-		key,
-		(void **)&value,
-		&lock,
-		deadline,
-		value_from_stale_layer
+	int64_t result = fwmap4_get_value_and_deadline(
+		map, now, key, &value, &lock, deadline, value_from_stale_layer
 	);
 
 	bool found = result >= 0;
@@ -138,18 +134,46 @@ fwstate_lookup_state(
 	return found;
 }
 
+/**
+ * Typed IPv6 state lookup.
+ */
+static inline bool
+fwstate_lookup_state_v6(
+	fwmap6_t map,
+	const struct fw6_state_key *key,
+	uint64_t now,
+	uint64_t *deadline,
+	bool *value_from_stale_layer
+) {
+	struct fw_state_value *value = NULL;
+	rwlock_t *lock = NULL;
+
+	int64_t result = fwmap6_get_value_and_deadline(
+		map, now, key, &value, &lock, deadline, value_from_stale_layer
+	);
+
+	bool found = result >= 0;
+	if (found && value) {
+		__atomic_fetch_add(
+			&value->packets_backward, 1, __ATOMIC_RELAXED
+		);
+	}
+
+	if (lock) {
+		rwlock_read_unlock(lock);
+	}
+
+	return found;
+}
+
 bool
 fwstate_check_state(
-	fwmap_t *fwstate,
+	fwmap_t *fw4state,
+	fwmap_t *fw6state,
 	struct packet *packet,
 	uint64_t now,
 	enum sync_packet_direction *sync_required
 ) {
-	if (fwstate == NULL) {
-		*sync_required = SYNC_NONE;
-		return false;
-	}
-
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
 	uint64_t deadline = now;
@@ -158,17 +182,38 @@ fwstate_check_state(
 
 	if (packet->network_header.type ==
 	    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
+		if (fw4state == NULL) {
+			*sync_required = SYNC_NONE;
+			return false;
+		}
 		struct fw4_state_key key;
 		fwstate_build_state_key_v4(mbuf, packet, &key);
-		found = fwstate_lookup_state(
-			fwstate, &key, now, &deadline, &value_from_stale_layer
+		found = fwstate_lookup_state_v4(
+			fwmap4_from_raw(fw4state),
+			&key,
+			now,
+			&deadline,
+			&value_from_stale_layer
 		);
-	} else {
+	} else if (packet->network_header.type ==
+		   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
+		if (fw6state == NULL) {
+			*sync_required = SYNC_NONE;
+			return false;
+		}
 		struct fw6_state_key key;
 		fwstate_build_state_key_v6(mbuf, packet, &key);
-		found = fwstate_lookup_state(
-			fwstate, &key, now, &deadline, &value_from_stale_layer
+		found = fwstate_lookup_state_v6(
+			fwmap6_from_raw(fw6state),
+			&key,
+			now,
+			&deadline,
+			&value_from_stale_layer
 		);
+	} else {
+		// Non-IP packet — no firewall state to check.
+		*sync_required = SYNC_NONE;
+		return false;
 	}
 
 	if (found) {

--- a/lib/fwstate/lookup.h
+++ b/lib/fwstate/lookup.h
@@ -11,9 +11,15 @@ typedef struct fwmap fwmap_t;
 
 /**
  * Check if a state exists for the given packet.
- * Builds the appropriate key based on packet IP version and performs lookup.
+ * Builds the appropriate key based on packet IP version and performs lookup
+ * in the matching map (fw4state for IPv4, fw6state for IPv6).
  *
- * @param fwstate The firewall state map
+ * Both maps are passed explicitly so that the key family and the map family
+ * are decided by the same packet-type branch inside this function — a
+ * key/map mismatch is impossible by construction.
+ *
+ * @param fw4state The IPv4 firewall state map (may be NULL)
+ * @param fw6state The IPv6 firewall state map (may be NULL)
  * @param packet The packet to check state for
  * @param now Current time in nanoseconds
  * @param sync_required Output parameter indicating if sync is required
@@ -21,7 +27,8 @@ typedef struct fwmap fwmap_t;
  */
 bool
 fwstate_check_state(
-	fwmap_t *fwstate,
+	fwmap_t *fw4state,
+	fwmap_t *fw6state,
 	struct packet *packet,
 	uint64_t now,
 	enum sync_packet_direction *sync_required

--- a/lib/fwstate/ops.h
+++ b/lib/fwstate/ops.h
@@ -1,16 +1,24 @@
 #pragma once
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include "types.h"
 
+/*
+ * NOTE: the `size` argument of every callback below is currently ignored
+ * (the hard-cast makes it redundant). A temporary assert is kept as a
+ * correctness net until Phase 2 removes the `size` parameter entirely.
+ * See https://github.com/yanet-platform/yanet2/issues/1534.
+ */
+
 // === Custom copy functions for fwmap keys and values.
 
 static inline void
 fwmap_copy_key_fw4(void *dst, const void *src, size_t size) {
-	(void)size;
+	assert(size == sizeof(struct fw4_state_key));
 	const struct fw4_state_key *s = (const struct fw4_state_key *)src;
 	struct fw4_state_key *d = (struct fw4_state_key *)dst;
 
@@ -19,7 +27,7 @@ fwmap_copy_key_fw4(void *dst, const void *src, size_t size) {
 
 static inline void
 fwmap_copy_key_fw6(void *dst, const void *src, size_t size) {
-	(void)size;
+	assert(size == sizeof(struct fw6_state_key));
 	const struct fw6_state_key *s = (const struct fw6_state_key *)src;
 	struct fw6_state_key *d = (struct fw6_state_key *)dst;
 
@@ -36,7 +44,7 @@ static inline void
 fwmap_update_value_fwstate(
 	void *dst, const void *src, bool dst_empty, size_t size
 ) {
-	(void)size;
+	assert(size == sizeof(struct fw_state_value));
 	const struct fw_state_value *s = (const struct fw_state_value *)src;
 	struct fw_state_value *d = (struct fw_state_value *)dst;
 
@@ -77,7 +85,7 @@ static inline void
 fwmap_promote_value_fwstate(
 	void *dst, const void *new_value, const void *old_value, size_t size
 ) {
-	(void)size;
+	assert(size == sizeof(struct fw_state_value));
 
 	struct fw_state_value *d = (struct fw_state_value *)dst;
 	const struct fw_state_value *new_v =
@@ -104,7 +112,7 @@ fwmap_promote_value_fwstate(
 
 static inline bool
 fwmap_fw4_key_equal(const void *a, const void *b, size_t size) {
-	(void)size;
+	assert(size == sizeof(struct fw4_state_key));
 	const struct fw4_state_key *k1 = (const struct fw4_state_key *)a;
 	const struct fw4_state_key *k2 = (const struct fw4_state_key *)b;
 
@@ -116,7 +124,7 @@ fwmap_fw4_key_equal(const void *a, const void *b, size_t size) {
 
 static inline bool
 fwmap_fw6_key_equal(const void *a, const void *b, size_t size) {
-	(void)size;
+	assert(size == sizeof(struct fw6_state_key));
 	const struct fw6_state_key *k1 = (const struct fw6_state_key *)a;
 	const struct fw6_state_key *k2 = (const struct fw6_state_key *)b;
 

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -70,7 +70,6 @@ acl_handle_packets(
 	struct fwstate_sync_config *sync_config = &fwstate_config->sync_config;
 	fwmap_t *fw4state = ADDR_OF(&fwstate_config->fw4state);
 	fwmap_t *fw6state = ADDR_OF(&fwstate_config->fw6state);
-	fwmap_t *state_table = NULL;
 
 	struct counter_storage *counter_storage =
 		ADDR_OF_NONNULL(&module_ectx->counter_storage);
@@ -222,8 +221,6 @@ acl_handle_packets(
 
 		if (packet->network_header.type ==
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
-			state_table = fw4state;
-
 			if (ip4_result[ip4_idx] < action) {
 				action = ip4_result[ip4_idx];
 			}
@@ -240,8 +237,6 @@ acl_handle_packets(
 			}
 		} else if (packet->network_header.type ==
 			   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
-			state_table = fw6state;
-
 			if (ip6_result[ip6_idx] < action) {
 				action = ip6_result[ip6_idx];
 			}
@@ -295,7 +290,8 @@ acl_handle_packets(
 				}
 				case ACTION_CHECK_STATE: {
 					if (fwstate_check_state(
-						    state_table,
+						    fw4state,
+						    fw6state,
 						    packet,
 						    now,
 						    &push_sync_packet

--- a/modules/fwstate/api/fwstate_cp.c
+++ b/modules/fwstate/api/fwstate_cp.c
@@ -7,6 +7,7 @@
 #include "controlplane/agent/agent.h"
 #include "lib/errors/errors.h"
 #include "lib/fwstate/config.h"
+#include "lib/fwstate/fwmap_typed.h"
 #include "lib/fwstate/layermap.h"
 #include "modules/fwstate/dataplane/config.h"
 
@@ -16,7 +17,9 @@ fwstate_config_fini(struct fwstate_config *config, struct agent *agent) {
 		fwmap_t *node = ADDR_OF(&config->fw4state);
 		while (node != NULL) {
 			fwmap_t *next = (fwmap_t *)ADDR_OF(&node->next);
-			fwmap_free(node, &agent->memory_context);
+			fwmap4_free(
+				fwmap4_from_raw(node), &agent->memory_context
+			);
 			node = next;
 		}
 		config->fw4state = NULL;
@@ -25,7 +28,9 @@ fwstate_config_fini(struct fwstate_config *config, struct agent *agent) {
 		fwmap_t *node = ADDR_OF(&config->fw6state);
 		while (node != NULL) {
 			fwmap_t *next = (fwmap_t *)ADDR_OF(&node->next);
-			fwmap_free(node, &agent->memory_context);
+			fwmap6_free(
+				fwmap6_from_raw(node), &agent->memory_context
+			);
 			node = next;
 		}
 		config->fw6state = NULL;
@@ -170,42 +175,6 @@ fwstate_module_config_detach_maps(struct cp_module *cp_module) {
 	config->cfg.fw6state = NULL;
 }
 
-// Helper function to initialize fwmap config
-static inline void
-fwstate_init_config(
-	fwmap_config_t *config,
-	uint16_t key_size,
-	fwmap_func_id_t key_equal_fn_id,
-	fwmap_func_id_t copy_key_fn_id,
-	uint32_t index_size,
-	uint32_t extra_bucket_count,
-	uint16_t worker_count
-
-) {
-	if (index_size == 0) {
-		index_size = 1024 * 1024; // Default: 1M entries
-	}
-	if (extra_bucket_count == 0) {
-		extra_bucket_count = 1024; // Default: 1024 extra buckets
-	}
-
-	config->key_size = key_size;
-	config->key_equal_fn_id = key_equal_fn_id;
-	config->copy_key_fn_id = copy_key_fn_id;
-
-	config->value_size = sizeof(struct fw_state_value);
-	config->update_value_fn_id = FWMAP_UPDATE_VALUE_FWSTATE;
-	config->promote_value_fn_id = FWMAP_PROMOTE_VALUE_FWSTATE;
-
-	config->hash_seed = 0;
-	config->hash_fn_id = FWMAP_HASH_FNV1A;
-
-	config->worker_count = worker_count;
-	config->index_size = index_size;
-	config->extra_bucket_count = extra_bucket_count;
-	config->rand_fn_id = FWMAP_RAND_DEFAULT;
-}
-
 int
 fwstate_config_create_maps(
 	struct cp_module *cp_module,
@@ -229,43 +198,31 @@ fwstate_config_create_maps(
 	}
 
 	// Configure and create IPv4 firewall state map
-	fwmap_config_t fw4_config;
-	fwstate_init_config(
-		&fw4_config,
-		sizeof(struct fw4_state_key),
-		FWMAP_KEY_EQUAL_FW4,
-		FWMAP_COPY_KEY_FW4,
+	fwmap4_t fw4state = fwmap4_new(
 		index_size,
 		extra_bucket_count,
-		worker_count
+		worker_count,
+		&agent->memory_context
 	);
-
-	fwmap_t *fw4state = fwmap_new(&fw4_config, &agent->memory_context);
-	if (fw4state == NULL) {
+	if (fw4state.raw == NULL) {
 		return -1;
 	}
-	SET_OFFSET_OF(&config->cfg.fw4state, fw4state);
+	SET_OFFSET_OF(&config->cfg.fw4state, fw4state.raw);
 
 	// Configure and create IPv6 firewall state map
-	fwmap_config_t fw6_config;
-	fwstate_init_config(
-		&fw6_config,
-		sizeof(struct fw6_state_key),
-		FWMAP_KEY_EQUAL_FW6,
-		FWMAP_COPY_KEY_FW6,
+	fwmap6_t fw6state = fwmap6_new(
 		index_size,
 		extra_bucket_count,
-		worker_count
+		worker_count,
+		&agent->memory_context
 	);
-
-	fwmap_t *fw6state = fwmap_new(&fw6_config, &agent->memory_context);
-	if (fw6state == NULL) {
+	if (fw6state.raw == NULL) {
 		fwmap_t *fw4 = ADDR_OF(&config->cfg.fw4state);
-		fwmap_free(fw4, &agent->memory_context);
+		fwmap4_free(fwmap4_from_raw(fw4), &agent->memory_context);
 		config->cfg.fw4state = NULL;
 		return -1;
 	}
-	SET_OFFSET_OF(&config->cfg.fw6state, fw6state);
+	SET_OFFSET_OF(&config->cfg.fw6state, fw6state.raw);
 
 	return 0;
 }
@@ -293,43 +250,31 @@ fwstate_config_insert_new_layer(
 	}
 
 	// Configure and insert new layer for IPv4
-	fwmap_config_t fw4_config;
-	fwstate_init_config(
-		&fw4_config,
-		sizeof(struct fw4_state_key),
-		FWMAP_KEY_EQUAL_FW4,
-		FWMAP_COPY_KEY_FW4,
-		index_size,
-		extra_bucket_count,
-		worker_count
-	);
-
-	if (layermap_insert_new_layer_cp(
-		    &config->cfg.fw4state, &fw4_config, &agent->memory_context
+	if (fwmap4_insert_new_layer_cp(
+		    &config->cfg.fw4state,
+		    index_size,
+		    extra_bucket_count,
+		    worker_count,
+		    &agent->memory_context
 	    )) {
 		return -1;
 	}
 
 	// Configure and insert new layer for IPv6
-	fwmap_config_t fw6_config;
-	fwstate_init_config(
-		&fw6_config,
-		sizeof(struct fw6_state_key),
-		FWMAP_KEY_EQUAL_FW6,
-		FWMAP_COPY_KEY_FW6,
-		index_size,
-		extra_bucket_count,
-		worker_count
-	);
-
-	if (layermap_insert_new_layer_cp(
-		    &config->cfg.fw6state, &fw6_config, &agent->memory_context
+	if (fwmap6_insert_new_layer_cp(
+		    &config->cfg.fw6state,
+		    index_size,
+		    extra_bucket_count,
+		    worker_count,
+		    &agent->memory_context
 	    )) {
 		// Rollback: remove the IPv4 layer we just added
 		fwmap_t *fw4_active = ADDR_OF(&config->cfg.fw4state);
 		fwmap_t *fw4_old = ADDR_OF(&fw4_active->next);
 		SET_OFFSET_OF(&config->cfg.fw4state, fw4_old);
-		fwmap_free(fw4_active, &agent->memory_context);
+		fwmap4_free(
+			fwmap4_from_raw(fw4_active), &agent->memory_context
+		);
 		return -1;
 	}
 
@@ -352,20 +297,19 @@ fwstate_config_get_map_stats(const struct cp_module *cp_module, bool is_ipv6) {
 		cp_module, struct fwstate_module_config, cp_module
 	);
 
-	fwmap_t *map;
 	if (is_ipv6) {
 		if (config->cfg.fw6state == NULL) {
 			return (fwmap_stats_t){0};
 		}
-		map = ADDR_OF(&config->cfg.fw6state);
-	} else {
-		if (config->cfg.fw4state == NULL) {
-			return (fwmap_stats_t){0};
-		}
-		map = ADDR_OF(&config->cfg.fw4state);
+		fwmap_t *map = ADDR_OF(&config->cfg.fw6state);
+		return fwmap6_get_stats(fwmap6_from_raw(map));
 	}
 
-	return fwmap_get_stats(map);
+	if (config->cfg.fw4state == NULL) {
+		return (fwmap_stats_t){0};
+	}
+	fwmap_t *map = ADDR_OF(&config->cfg.fw4state);
+	return fwmap4_get_stats(fwmap4_from_raw(map));
 }
 
 struct fwstate_sync_config
@@ -445,7 +389,7 @@ fwstate_outdated_layers_free(
 			(layermap_list_t *)ADDR_OF(&v4_node->next);
 
 		// Free the layer
-		fwmap_free(layer, &agent->memory_context);
+		fwmap4_free(fwmap4_from_raw(layer), &agent->memory_context);
 
 		// Free the list node
 		memory_bfree(&agent->memory_context, v4_node, sizeof(*v4_node));
@@ -461,7 +405,7 @@ fwstate_outdated_layers_free(
 			(layermap_list_t *)ADDR_OF(&v6_node->next);
 
 		// Free the layer
-		fwmap_free(layer, &agent->memory_context);
+		fwmap6_free(fwmap6_from_raw(layer), &agent->memory_context);
 
 		// Free the list node
 		memory_bfree(&agent->memory_context, v6_node, sizeof(*v6_node));

--- a/modules/fwstate/dataplane/dataplane.c
+++ b/modules/fwstate/dataplane/dataplane.c
@@ -9,6 +9,7 @@
 
 #include "common/memory_address.h"
 #include "dataplane/module/module.h"
+#include "fwstate/fwmap_typed.h"
 #include "fwstate/layermap.h"
 #include "fwstate/types.h"
 #include "lib/dataplane/module/packet_front.h"
@@ -175,7 +176,7 @@ fwstate_build_value(
 // Process IPv4 state sync frame
 static void
 fwstate_process_sync_v4(
-	fwmap_t *fw4state,
+	fwmap4_t fw4state,
 	uint16_t worker_idx,
 	struct fw_state_sync_frame *sync_frame,
 	bool is_external,
@@ -198,7 +199,7 @@ fwstate_process_sync_v4(
 
 	// Insert or update the state
 	rwlock_t *lock = NULL;
-	int64_t result = layermap_put(
+	int64_t result = fwmap4_put(
 		fw4state, worker_idx, now, state.ttl, &key, &state.value, &lock
 	);
 
@@ -218,7 +219,7 @@ fwstate_process_sync_v4(
 // Process IPv6 state sync frame
 static void
 fwstate_process_sync_v6(
-	fwmap_t *fw6state,
+	fwmap6_t fw6state,
 	uint16_t worker_idx,
 	struct fw_state_sync_frame *sync_frame,
 	bool is_external,
@@ -241,7 +242,7 @@ fwstate_process_sync_v6(
 
 	// Insert or update the state
 	rwlock_t *lock = NULL;
-	int64_t result = layermap_put(
+	int64_t result = fwmap6_put(
 		fw6state, worker_idx, now, state.ttl, &key, &state.value, &lock
 	);
 
@@ -372,7 +373,7 @@ fwstate_handle_packets(
 
 			if (sync_frame->addr_type == FW_STATE_ADDR_TYPE_IP4) {
 				fwstate_process_sync_v4(
-					fw4state,
+					fwmap4_from_raw(fw4state),
 					(uint16_t)dp_worker->idx,
 					sync_frame,
 					is_external,
@@ -384,7 +385,7 @@ fwstate_handle_packets(
 			} else if (sync_frame->addr_type ==
 				   FW_STATE_ADDR_TYPE_IP6) {
 				fwstate_process_sync_v6(
-					fw6state,
+					fwmap6_from_raw(fw6state),
 					(uint16_t)dp_worker->idx,
 					sync_frame,
 					is_external,


### PR DESCRIPTION
Phase 1 of #1534: typed per-family wrapper handles (fwmap4_t/fwmap6_t) around the generic fwmap_t so that key/map family mismatch becomes a compile-time error instead of silent truncation UB.

- Typed constructors bake in sizeof(struct fw4/fw6_state_key) and sizeof(struct fw_state_value); callers can no longer influence the sizes.
- fwstate_check_state now takes both maps and picks the matching one internally, eliminating the generic void *key lookup path.
- The six fwstate callbacks in ops.h assert(size == sizeof(...)) as a debug net until Phase 2 removes the size parameter.
- The generic fwmap.h and fwmap_func_registry are untouched, so the test corpus and fuzzers keep working unchanged.
- Adds the missing #pragma once to layermap.h (exposed by the new include chain).

Closes #1534.