### PR TITLE
fix(controlplane): drain retired devices and modules across agents

### DIFF
--- a/devices/plain/api/controlplane.c
+++ b/devices/plain/api/controlplane.c
@@ -58,6 +58,11 @@ cp_device_plain_free(struct cp_device *cp_device) {
 void
 cp_device_plain_drain_unused(struct agent *agent) {
 	cp_device_agent_drain_unused(agent, cp_device_plain_free);
+	// The drain just freed devices parked on prior agents, dropping their
+	// loaded_device_count; reclaim any prior agent that reached zero so the
+	// count gate does not retain empty predecessors. Runs after the drain,
+	// which releases cp_config_lock.
+	agent_free_unused_agents(agent);
 }
 
 struct cp_device_plain_config *

--- a/devices/trafgen/api/controlplane.c
+++ b/devices/trafgen/api/controlplane.c
@@ -126,6 +126,8 @@ cp_device_trafgen_free(struct cp_device *cp_device) {
 void
 cp_device_trafgen_drain_unused(struct agent *agent) {
 	cp_device_agent_drain_unused(agent, cp_device_trafgen_free);
+	// Reclaim prior agents whose parked devices the drain just freed.
+	agent_free_unused_agents(agent);
 }
 
 struct cp_device_trafgen_config *

--- a/devices/vlan/api/controlplane.c
+++ b/devices/vlan/api/controlplane.c
@@ -60,6 +60,8 @@ cp_device_vlan_free(struct cp_device *cp_device) {
 void
 cp_device_vlan_drain_unused(struct agent *agent) {
 	cp_device_agent_drain_unused(agent, cp_device_vlan_free);
+	// Reclaim prior agents whose parked devices the drain just freed.
+	agent_free_unused_agents(agent);
 }
 
 struct cp_device_vlan_config *

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -271,7 +271,8 @@ agent_attach(
 	while (ADDR_OF(&agent->prev) != NULL) {
 		struct agent *prev_agent = ADDR_OF(&agent->prev);
 
-		if (prev_agent->loaded_module_count == 0) {
+		if (prev_agent->loaded_module_count == 0 &&
+		    prev_agent->loaded_device_count == 0) {
 			SET_OFFSET_OF(&agent->prev, ADDR_OF(&prev_agent->prev));
 			agent_cleanup(prev_agent);
 			continue;
@@ -1939,7 +1940,8 @@ agent_free_unused_agents(struct agent *agent) {
 	while (ADDR_OF(&agent->prev) != NULL) {
 		struct agent *prev_agent = ADDR_OF(&agent->prev);
 
-		if (prev_agent->loaded_module_count == 0) {
+		if (prev_agent->loaded_module_count == 0 &&
+		    prev_agent->loaded_device_count == 0) {
 			SET_OFFSET_OF(&agent->prev, ADDR_OF(&prev_agent->prev));
 			agent_cleanup(prev_agent);
 			continue;

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -36,7 +36,22 @@ struct agent {
 	pid_t pid;
 	uint64_t memory_limit;
 	uint64_t gen;
+	// Count of cp_modules created by this agent and not yet finalized.
+	//
+	// Read at the reclamation gate, but not yet maintained: cp_module_init
+	// and cp_module_fini do not touch it, so it stays zero and module
+	// reclamation is not gated on it yet.
 	uint64_t loaded_module_count;
+	// Count of cp_devices parked on this agent's unused_device list and not
+	// yet drained.
+	//
+	// Incremented when a device is parked by
+	// cp_device_registry_item_free_cb and decremented when the drain frees
+	// it, so it tracks parked devices rather than every initialized device.
+	// agent_attach and agent_free_unused_agents gate reclamation of a
+	// previous agent on this count being zero, since agent_cleanup does not
+	// drain unused_device itself.
+	uint64_t loaded_device_count;
 	uint64_t active_module_count;
 	struct agent *prev;
 	char name[80];

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -449,21 +449,41 @@ cp_device_registry_item_free_cb(struct registry_item *item, void *data) {
 	struct agent *agent = ADDR_OF(&device->agent);
 	EQUATE_OFFSET(&device->prev, &agent->unused_device);
 	SET_OFFSET_OF(&agent->unused_device, device);
+	agent->loaded_device_count++;
 }
 
 void
 cp_device_agent_drain_unused(struct agent *agent, cp_device_free_fn free_fn) {
-	// Detach the whole list first so a device's own free cannot observe a
-	// half-walked list.
-	struct cp_device *device = ADDR_OF(&agent->unused_device);
-	SET_OFFSET_OF(&agent->unused_device, NULL);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
 
-	while (device != NULL) {
-		struct cp_device *prev = ADDR_OF(&device->prev);
-		SET_OFFSET_OF(&device->prev, NULL);
-		free_fn(device);
-		device = prev;
+	// Parking (cp_device_registry_item_free_cb) runs under cp_config_lock
+	// via cp_config_gen_free on every update path, so the detach that
+	// steals the list must take the same lock to avoid racing a concurrent
+	// park. Must not be called with cp_config_lock already held.
+	cp_config_lock(cp_config);
+
+	// Walk the agent and every prior agent in its prev chain so devices
+	// parked by a retired creating agent are reclaimed too. Freeing is
+	// agent-agnostic: free_fn uses each device's own memory_context,
+	// which stays valid as long as the creating agent is alive (the
+	// loaded_device_count gate keeps a prior agent from being cleaned up
+	// while it still holds parked devices).
+	for (; agent != NULL; agent = ADDR_OF(&agent->prev)) {
+		// Detach the whole list first so a device's own free cannot
+		// observe a half-walked list.
+		struct cp_device *device = ADDR_OF(&agent->unused_device);
+		SET_OFFSET_OF(&agent->unused_device, NULL);
+
+		while (device != NULL) {
+			struct cp_device *prev = ADDR_OF(&device->prev);
+			SET_OFFSET_OF(&device->prev, NULL);
+			free_fn(device);
+			agent->loaded_device_count--;
+			device = prev;
+		}
 	}
+
+	cp_config_unlock(cp_config);
 }
 
 void

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -147,10 +147,12 @@ cp_device_fini(struct cp_device *self);
 
 // Reclaim every device parked on the agent's unused_device list.
 //
-// Detaches the list and runs free_fn on each device. Call it from the owning
-// control plane after the retiring generation no longer references the parked
-// devices (i.e. after the device-update wait-for-gen), passing the device
-// type's free function.
+// Detaches the list under cp_config_lock and runs free_fn on each device,
+// walking the agent's prev chain so devices parked by a prior creating agent
+// are reclaimed too. Call it from the owning control plane after the retiring
+// generation no longer references the parked devices (i.e. after the
+// device-update wait-for-gen), passing the device type's free function. Must
+// not be called while cp_config_lock is already held.
 void
 cp_device_agent_drain_unused(struct agent *agent, cp_device_free_fn free_fn);
 

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -189,6 +189,37 @@ cp_module_fini(struct cp_module *cp_module) {
 	memory_context_fini(&cp_module->memory_context);
 }
 
+void
+cp_module_agent_drain_unused(
+	struct agent *agent, cp_module_free_handler free_handler
+) {
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	// Parking (cp_module_registry_item_free_cb) runs under cp_config_lock
+	// via cp_config_gen_free on every update path, so the detach that
+	// steals the list must take the same lock to avoid racing a concurrent
+	// park. Must not be called with cp_config_lock already held.
+	cp_config_lock(cp_config);
+
+	// Walk the agent and every prior agent in its prev chain so modules
+	// parked by a retired creating agent are reclaimed too. Freeing is
+	// agent-agnostic: free_handler uses each module's own memory_context,
+	// which stays valid as long as the creating agent is alive.
+	for (; agent != NULL; agent = ADDR_OF(&agent->prev)) {
+		struct cp_module *module = ADDR_OF(&agent->unused_module);
+		SET_OFFSET_OF(&agent->unused_module, NULL);
+
+		while (module != NULL) {
+			struct cp_module *prev = ADDR_OF(&module->prev);
+			SET_OFFSET_OF(&module->prev, NULL);
+			free_handler(module);
+			module = prev;
+		}
+	}
+
+	cp_config_unlock(cp_config);
+}
+
 int
 cp_module_link_device(
 	struct cp_module *cp_module,

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -132,6 +132,19 @@ cp_module_init(
 void
 cp_module_fini(struct cp_module *cp_module);
 
+// Reclaim every module parked on the agent's unused_module list.
+//
+// Detaches the list under cp_config_lock and runs free_handler on each
+// module, walking the agent's prev chain so modules parked by a prior
+// creating agent are reclaimed too. Call it from the owning control plane
+// after the retiring generation no longer references the parked modules,
+// passing the module type's free handler. Must not be called while
+// cp_config_lock is already held.
+void
+cp_module_agent_drain_unused(
+	struct agent *agent, cp_module_free_handler free_handler
+);
+
 struct cp_module_registry {
 	struct memory_context *memory_context;
 	struct registry registry;

--- a/lib/controlplane/tests/unused_park_test.c
+++ b/lib/controlplane/tests/unused_park_test.c
@@ -41,6 +41,17 @@ counting_device_free(struct cp_device *device) {
 	cp_device_free(device);
 }
 
+// Module twin of counting_device_free: finalizes the base module and returns
+// the struct to the creating agent's arena. Test modules here are raw
+// cp_module allocations, so sizeof(struct cp_module) is the right size.
+static void
+counting_module_free(struct cp_module *module) {
+	struct agent *agent = ADDR_OF(&module->agent);
+	free_call_count += 1;
+	cp_module_fini(module);
+	memory_bfree(&agent->memory_context, module, sizeof(struct cp_module));
+}
+
 // Verifies that parking two devices back-to-back onto an agent's
 // unused_device list, then draining it, reclaims exactly the parked devices
 // without crashing and returns the agent's arena to its pre-park size.
@@ -223,19 +234,111 @@ test_module_park_chain(struct yanet_shm *shm) {
 		ADDR_OF(&second->prev), "first parked module's prev is not NULL"
 	);
 
-	// Nothing drains unused_module today, so reclaim the parked chain by
-	// hand instead of leaving it for agent_detach.
-	struct cp_module *module = head;
-	while (module != NULL) {
-		struct cp_module *prev = ADDR_OF(&module->prev);
-		cp_module_fini(module);
-		memory_bfree(
-			&agent->memory_context, module, sizeof(struct cp_module)
-		);
-		module = prev;
-	}
+	// Drain the parked chain through the module drain helper instead of
+	// leaving it for agent_detach.
+	free_call_count = 0;
+	cp_module_agent_drain_unused(agent, counting_module_free);
+	TEST_ASSERT_EQUAL(
+		free_call_count, 2, "drain did not free exactly two modules"
+	);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent->unused_module),
+		"unused_module is not NULL after drain"
+	);
 
 	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// Regression test for GH#1535: a device parked on a prior (creating) agent
+// must still be drained when the current agent reclaims its unused lists.
+// loaded_device_count keeps the prior agent alive until the parked device is
+// finalized, and the drain walks the prev chain to reach it.
+static int
+test_drain_reaches_prior_agent(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	// agentA creates and parks a device; its loaded_device_count keeps it
+	// alive when agentB attaches with the same name.
+	struct agent *agentA = agent_attach(
+		shm, 0, "xagent", UNUSED_PARK_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agentA, "agentA attach failed");
+
+	struct cp_device_config cfg;
+	TEST_ASSERT_SUCCESS(
+		cp_device_config_init(&cfg, "plain", "xa0", 0, 0, &err),
+		"device config init failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	struct cp_device *device = cp_device_new(&agentA->memory_context);
+	TEST_ASSERT_NOT_NULL(device, "cp_device_new failed");
+	TEST_ASSERT_SUCCESS(
+		cp_device_init(device, agentA, &cfg, &err),
+		"cp_device_init failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_device_config_fini(&cfg);
+	TEST_ASSERT_EQUAL(
+		agentA->loaded_device_count,
+		0,
+		"cp_device_init accounted the device before it was parked"
+	);
+
+	struct cp_device_registry registry;
+	TEST_ASSERT_SUCCESS(
+		cp_device_registry_init(
+			&agentA->memory_context, &registry, &err
+		),
+		"device registry init failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	TEST_ASSERT_SUCCESS(
+		cp_device_registry_upsert(&registry, "xa0", device, &err),
+		"device registry upsert failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	// Releasing the registry parks the device on agentA, which accounts it.
+	cp_device_registry_fini(&registry);
+	TEST_ASSERT(
+		ADDR_OF(&agentA->unused_device) == device,
+		"device is not parked on agentA"
+	);
+	TEST_ASSERT_EQUAL(
+		agentA->loaded_device_count,
+		1,
+		"parking did not account the device on agentA"
+	);
+
+	// agentB attaches with the same name; agentA has a live device so it
+	// must survive as agentB->prev instead of being cleaned up.
+	struct agent *agentB = agent_attach(
+		shm, 0, "xagent", UNUSED_PARK_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agentB, "agentB attach failed");
+	TEST_ASSERT(
+		ADDR_OF(&agentB->prev) == agentA,
+		"agentA was cleaned up instead of staying as agentB->prev"
+	);
+
+	// Draining from agentB must reach agentA's parked device through the
+	// prev chain, finalizing it (which drops agentA's count to zero).
+	free_call_count = 0;
+	cp_device_agent_drain_unused(agentB, counting_device_free);
+	TEST_ASSERT_EQUAL(
+		free_call_count, 1, "drain did not free agentA's parked device"
+	);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agentA->unused_device),
+		"agentA unused_device is not empty after drain"
+	);
+	TEST_ASSERT_EQUAL(
+		agentA->loaded_device_count,
+		0,
+		"agentA loaded_device_count did not drop to zero after drain"
+	);
+
+	agent_detach(agentB);
 	return TEST_SUCCESS;
 }
 
@@ -248,7 +351,7 @@ main(void) {
 	const char *devs_to_load[] = {"plain"};
 
 	struct dataplane_ut_config cfg = {
-		.cp_memory = 1u << 25,
+		.cp_memory = 1u << 27,
 		.dp_memory = 1u << 20,
 		.worker_count = 1,
 		.devices = port_names,
@@ -275,6 +378,9 @@ main(void) {
 	int res = test_device_park_and_drain(shm);
 	if (res == TEST_SUCCESS) {
 		res = test_module_park_chain(shm);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_drain_reaches_prior_agent(shm);
 	}
 
 	dataplane_ut_free(ut);


### PR DESCRIPTION
A device or module replaced by a later same-name agent was parked on the creating agent unused list, but the drain only walked the currently attached agent, so items parked on a prior agent were never reclaimed.

- Walk the agent prev chain in both the device and module drains so prior-agent parking is reached, and take the configuration lock around the drain.
- Add the missing module drain helper mirroring the device path.
- Gate prior-agent reclamation on a live device count so a creating agent is not cleaned up before its parked devices are drained; the device update handler already drains in production, so the count settles.

The module count is intentionally left unmaintained here: modules have no production drain today, so maintaining the count would retain module-creating agents across reattach. That gating lands together with the production module drain wiring in #1526, which also extends all four fixes to `cp_object`.

Closes #1535.