### PR TITLE
fix(build): restore the DPDK configuration include for header-only consumers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -151,7 +151,14 @@ libdpdk = subproject(
 )
 
 libdpdk_dep = libdpdk.get_variable('dpdk_dep')
-libdpdk_inc_dep = libdpdk_dep.partial_dependency(includes: true)
+
+# partial_dependency(includes: true) strips the compile args carried by
+# dpdk_dep, including -include rte_config.h, so it has to be re-added here.
+# DPDK's machine args are deliberately left out.
+libdpdk_inc_dep = declare_dependency(
+  dependencies: libdpdk_dep.partial_dependency(includes: true),
+  compile_args: ['-include', 'rte_config.h'],
+)
 
 subdir('common')
 subdir('lib')


### PR DESCRIPTION
Targets that take only the include directories from the DPDK dependency lost the compiler flags that make DPDK's generated configuration visible, so they compiled DPDK headers with none of that configuration in effect.

On x86 the affected headers tolerate the omission, which is why this went unnoticed. On aarch64 the equivalent headers reject it outright and the build fails before any project code is reached.

- Restores the configuration include for those targets, so it now travels on the same dependency object as the include directories and cannot drift from them.
- Leaves DPDK's machine-specific tuning flags deliberately unrestored, keeping the project's own instruction-set baseline authoritative for these targets.
- Verified on x86 with a clean build and the full test suite, and on an aarch64 cross build where the failure class this causes is now absent.