### PR TITLE
fix(dataplane): include the standard library header for string conversion

### DIFF
--- a/dataplane/dpdk.c
+++ b/dataplane/dpdk.c
@@ -2,6 +2,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <rte_dev.h>
 #include <rte_eal.h>


### PR DESCRIPTION
The DPDK setup code parses a socket identifier with a standard library function but never included the header that declares it.

On x86 the platform headers supply the declaration transitively, so the omission was invisible. On aarch64 they do not, and the compiler rejects the call outright.

- Reproduced on unmodified main by configuring an aarch64 cross build and compiling only this object, so the defect predates this change.
- The aarch64 dataplane build surfaced exactly one occurrence of this class; other files that use the same functions were confirmed to receive the declaration transitively, so they are deliberately left alone.
- Verified on x86 with a clean build, and on the aarch64 cross build where this failure is now absent.