### PR TITLE
refactor(cli): defer output payload construction to the active backend

### DIFF
--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -46,22 +46,16 @@ pub trait Output: Send + Sync {
 
     /// Output result data.
     ///
-    /// Backends receive both a structured `payload` (for serialization-
-    /// oriented formats) and a `render` callback (for free-form rendering
-    /// such as tables or trees). Each backend chooses which signal to
-    /// honour and which to ignore.
+    /// An implementation must not call both `payload` and `render`. It may
+    /// call either one, or neither. Passing both sides as closures rather
+    /// than as values, and honouring that exclusivity, is what lets a
+    /// caller hand over two shapes and pay only for the one its backend
+    /// uses.
     ///
-    /// `is_empty` and `empty_message` describe the empty-result case:
-    /// free-form backends may substitute `empty_message` instead of
-    /// invoking `render`; serialization-oriented backends typically
-    /// serialize the empty `payload` as-is.
-    fn data(
-        &self,
-        payload: &dyn ErasedSerialize,
-        is_empty: bool,
-        empty_message: Arguments,
-        render: Box<dyn FnOnce() + '_>,
-    );
+    /// The thunk's return type carries a lifetime, so the payload may
+    /// borrow rather than own — `|| &response.services` and a struct of
+    /// borrowed slices are both valid shapes.
+    fn data<'a>(&self, payload: &dyn Fn() -> Box<dyn ErasedSerialize + 'a>, render: Box<dyn FnOnce() + 'a>);
 }
 
 /// Human-readable output backend.
@@ -130,18 +124,8 @@ impl Output for HumanOutput {
         }
     }
 
-    fn data(
-        &self,
-        _payload: &dyn ErasedSerialize,
-        is_empty: bool,
-        empty_message: Arguments,
-        render: Box<dyn FnOnce() + '_>,
-    ) {
-        if is_empty {
-            eprintln!("{empty_message}");
-        } else {
-            render();
-        }
+    fn data<'a>(&self, _payload: &dyn Fn() -> Box<dyn ErasedSerialize + 'a>, render: Box<dyn FnOnce() + 'a>) {
+        render();
     }
 }
 
@@ -188,14 +172,9 @@ impl Output for JsonOutput {
         println!("{json}");
     }
 
-    fn data(
-        &self,
-        payload: &dyn ErasedSerialize,
-        _is_empty: bool,
-        _empty_message: Arguments,
-        _render: Box<dyn FnOnce() + '_>,
-    ) {
-        let json = serde_json::to_string(payload).expect("payload serialization must not fail");
+    fn data<'a>(&self, payload: &dyn Fn() -> Box<dyn ErasedSerialize + 'a>, _render: Box<dyn FnOnce() + 'a>) {
+        let payload = payload();
+        let json = serde_json::to_string(&payload).expect("payload serialization must not fail");
 
         println!("{json}");
     }
@@ -255,21 +234,31 @@ pub fn failure(err: &Error) {
 
 /// Output result data.
 ///
-/// Delegates to the installed backend's [`Output::data`]. The backend
-/// chooses whether to serialize `payload` or invoke `render`; when the
-/// result is empty (`is_empty == true`), free-form backends may print
-/// `empty_message` in place of `render`.
-pub fn data<P, F>(payload: &P, is_empty: bool, empty_message: Arguments, render: F)
+/// Delegates to the installed backend's [`Output::data`]. `make_payload`
+/// runs only if the backend serializes, and `render` runs only if the
+/// backend produces free-form output.
+///
+/// Call [`empty`] from inside `render` when the result is empty. A
+/// serializing backend never calls `render`, so that check cannot affect
+/// it, and an empty collection still serializes as-is.
+pub fn data<P, MakePayload, Render>(make_payload: MakePayload, render: Render)
 where
+    MakePayload: Fn() -> P,
     P: Serialize,
-    F: FnOnce(),
+    Render: FnOnce(),
 {
-    current().data(
-        payload as &dyn ErasedSerialize,
-        is_empty,
-        empty_message,
-        Box::new(render),
-    );
+    let payload = move || -> Box<dyn ErasedSerialize + '_> { Box::new(make_payload()) };
+
+    current().data(&payload, Box::new(render));
+}
+
+/// Reports an empty result.
+///
+/// Writes to stderr rather than stdout, so `<cmd> | wc -l` still reads
+/// zero on an empty result — the message would otherwise show up as a
+/// bogus data line on the same channel the real rows print to.
+pub fn empty(message: Arguments) {
+    eprintln!("{message}");
 }
 
 /// Returns `true` if ANSI color and Unicode prefixes should be emitted.

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -254,34 +254,46 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                 module_name: perf.module.module_name,
             };
             let response = service.perf(request).await?;
-            output::data(&response, false, format_args!(""), || {
-                format_perf_counters(&response);
-            });
+            output::data(
+                || &response,
+                || {
+                    format_perf_counters(&response);
+                },
+            );
         }
         Some(ModeCmd::Workers) => {
             let response = service.workers().await?;
-            output::data(&response, false, format_args!(""), || {
-                format_worker_counters(&response);
-            });
+            output::data(
+                || &response,
+                || {
+                    format_worker_counters(&response);
+                },
+            );
         }
         Some(ModeCmd::Ports) => {
             let response = service.ports().await?;
-            output::data(&response, false, format_args!(""), || {
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&response).expect("counters YAML serialization must not fail")
-                );
-            });
+            output::data(
+                || &response,
+                || {
+                    print!(
+                        "{}",
+                        serde_yaml::to_string(&response).expect("counters YAML serialization must not fail")
+                    );
+                },
+            );
         }
         mode => {
             let request = tags_request(mode, cmd.by_tags);
             let response = service.by_tags(request).await?;
-            output::data(&response, false, format_args!(""), || {
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&response).expect("counters YAML serialization must not fail")
-                );
-            });
+            output::data(
+                || &response,
+                || {
+                    print!(
+                        "{}",
+                        serde_yaml::to_string(&response).expect("counters YAML serialization must not fail")
+                    );
+                },
+            );
         }
     }
 

--- a/cli/modules/device/src/main.rs
+++ b/cli/modules/device/src/main.rs
@@ -50,7 +50,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     let mut service = DeviceService::new(&cmd.connection).await?;
     let response = service.list().await?;
 
-    output::data(&response, false, format_args!(""), || render(&response));
+    output::data(|| &response, || render(&response));
 
     Ok(())
 }

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -100,21 +100,32 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     match cmd.mode {
         ModeCmd::List => {
             let ids = service.list_functions().await?;
-            output::data(&ids, ids.is_empty(), format_args!("No functions found."), || {
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&ids).expect("function list YAML serialization must not fail")
-                );
-            });
+            output::data(
+                || &ids,
+                || {
+                    if ids.is_empty() {
+                        output::empty(format_args!("No functions found."));
+                        return;
+                    }
+
+                    print!(
+                        "{}",
+                        serde_yaml::to_string(&ids).expect("function list YAML serialization must not fail")
+                    );
+                },
+            );
         }
         ModeCmd::Show(show) => {
             let function = service.get_function(&show.name).await?;
-            output::data(&function, false, format_args!(""), || {
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&function).expect("function YAML serialization must not fail")
-                );
-            });
+            output::data(
+                || &function,
+                || {
+                    print!(
+                        "{}",
+                        serde_yaml::to_string(&function).expect("function YAML serialization must not fail")
+                    );
+                },
+            );
         }
         ModeCmd::Update(update) => {
             let name = update.name.clone();

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -93,13 +93,18 @@ impl GatewayService {
             .map_err(self.service.status("gateway"))?
             .into_inner();
 
-        let rows: Vec<ServiceRow> = response.services.iter().map(ServiceRow::from).collect();
-
         output::data(
-            &response.services,
-            rows.is_empty(),
-            format_args!("no services registered"),
-            || render_table(&rows),
+            || &response.services,
+            || {
+                let rows: Vec<ServiceRow> = response.services.iter().map(ServiceRow::from).collect();
+
+                if rows.is_empty() {
+                    output::empty(format_args!("no services registered"));
+                    return;
+                }
+
+                render_table(&rows);
+            },
         );
 
         Ok(())

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -46,7 +46,7 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     let mut service = InspectService::new(&cmd.connection).await?;
     let response = service.inspect().await?;
 
-    output::data(&response, false, format_args!(""), || render_tree(&response));
+    output::data(|| &response, || render_tree(&response));
 
     Ok(())
 }

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -181,10 +181,13 @@ async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) ->
     let total = response.metrics.len();
 
     output::data(
-        &response.metrics,
-        response.metrics.is_empty(),
-        format_args!("no metrics"),
+        || &response.metrics,
         || {
+            if response.metrics.is_empty() {
+                output::empty(format_args!("no metrics"));
+                return;
+            }
+
             let mut scalars: Vec<&Metric> = response
                 .metrics
                 .iter()

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -112,21 +112,32 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
     match cmd.mode {
         ModeCmd::List => {
             let ids = service.list_pipelines().await?;
-            output::data(&ids, ids.is_empty(), format_args!("No pipelines found."), || {
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&ids).expect("pipeline list YAML serialization must not fail")
-                );
-            });
+            output::data(
+                || &ids,
+                || {
+                    if ids.is_empty() {
+                        output::empty(format_args!("No pipelines found."));
+                        return;
+                    }
+
+                    print!(
+                        "{}",
+                        serde_yaml::to_string(&ids).expect("pipeline list YAML serialization must not fail")
+                    );
+                },
+            );
         }
         ModeCmd::Show(show) => {
             let pipeline = service.get_pipeline(&show.name).await?;
-            output::data(&pipeline, false, format_args!(""), || {
-                print!(
-                    "{}",
-                    serde_yaml::to_string(&pipeline).expect("pipeline YAML serialization must not fail")
-                );
-            });
+            output::data(
+                || &pipeline,
+                || {
+                    print!(
+                        "{}",
+                        serde_yaml::to_string(&pipeline).expect("pipeline YAML serialization must not fail")
+                    );
+                },
+            );
         }
         ModeCmd::Update(update) => {
             let name = update.name.clone();

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -220,10 +220,13 @@ async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool
     let all_ready = all_scopes_ready && missing.is_empty();
 
     output::data(
-        &response.scopes,
-        response.scopes.is_empty() && missing.is_empty(),
-        format_args!("no scopes"),
+        || &response.scopes,
         || {
+            if response.scopes.is_empty() && missing.is_empty() {
+                output::empty(format_args!("no scopes"));
+                return;
+            }
+
             let mut scopes = response.scopes.clone();
             scopes.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -256,32 +259,45 @@ async fn run_watch(cmd: &Cmd, name: &str) -> Result<(), Error> {
         "Watch",
         ReadyRequest { scopes: cmd.scopes.clone() },
         |resp| {
-            output::data(&resp.scopes, resp.scopes.is_empty(), format_args!("no scopes"), || {
-                let mut scopes = resp.scopes.clone();
-                scopes.sort_by(|a, b| a.name.cmp(&b.name));
-
-                match name_width {
-                    None => {
-                        let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
-                        name_width = Some(width);
-
-                        for scope in &scopes {
-                            snapshot.insert((name.to_owned(), scope.name.clone()), scope.clone());
-                        }
-
-                        render::print_status_block(name, &scopes, width, cmd.stale_after, true);
+            output::data(
+                || &resp.scopes,
+                || {
+                    if resp.scopes.is_empty() {
+                        output::empty(format_args!("no scopes"));
+                        return;
                     }
-                    Some(width) => {
-                        for scope in &scopes {
-                            let transition = render::record_transition(&mut snapshot, name, scope);
 
-                            if transition != render::Transition::Unchanged {
-                                render::print_transition_line(render::ServiceColumn::None, scope, width, transition);
+                    let mut scopes = resp.scopes.clone();
+                    scopes.sort_by(|a, b| a.name.cmp(&b.name));
+
+                    match name_width {
+                        None => {
+                            let width = render::name_width(scopes.iter().map(|scope| scope.name.as_str()));
+                            name_width = Some(width);
+
+                            for scope in &scopes {
+                                snapshot.insert((name.to_owned(), scope.name.clone()), scope.clone());
+                            }
+
+                            render::print_status_block(name, &scopes, width, cmd.stale_after, true);
+                        }
+                        Some(width) => {
+                            for scope in &scopes {
+                                let transition = render::record_transition(&mut snapshot, name, scope);
+
+                                if transition != render::Transition::Unchanged {
+                                    render::print_transition_line(
+                                        render::ServiceColumn::None,
+                                        scope,
+                                        width,
+                                        transition,
+                                    );
+                                }
                             }
                         }
                     }
-                }
-            });
+                },
+            );
         },
     )
     .await
@@ -309,10 +325,13 @@ async fn run_aggregate(cmd: Cmd) -> Result<bool, Error> {
     let all_ready = all_ready(&reports);
 
     output::data(
-        &reports,
-        reports.is_empty(),
-        format_args!("no readiness services registered"),
+        || &reports,
         || {
+            if reports.is_empty() {
+                output::empty(format_args!("no readiness services registered"));
+                return;
+            }
+
             let scopes = reports.iter().flat_map(|report| report.scopes.iter());
             let width = render::name_width(scopes.map(|scope| scope.name.as_str()));
 

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -95,25 +95,28 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
 
     let mut aggregate = Aggregate::seed(&reports);
 
-    output::data(&snapshot_payload, false, format_args!(""), || {
-        if reports.is_empty() {
-            eprintln!("no readiness services registered");
-        } else {
-            for (idx, report) in reports.iter().enumerate() {
-                if idx > 0 {
-                    println!();
+    output::data(
+        || &snapshot_payload,
+        || {
+            if reports.is_empty() {
+                output::empty(format_args!("no readiness services registered"));
+            } else {
+                for (idx, report) in reports.iter().enumerate() {
+                    if idx > 0 {
+                        println!();
+                    }
+
+                    print_report(report, scope_width, cmd.stale_after);
                 }
-
-                print_report(report, scope_width, cmd.stale_after);
             }
-        }
 
-        render::print_watching_line();
+            render::print_watching_line();
 
-        if aggregate.all_ready {
-            render::print_all_ready_line();
-        }
-    });
+            if aggregate.all_ready {
+                render::print_all_ready_line();
+            }
+        },
+    );
 
     let (sender, mut receiver) = mpsc::unbounded_channel::<Event>();
 
@@ -294,8 +297,8 @@ struct EventPayload<'a> {
 #[derive(Serialize)]
 struct MembershipPayload<'a> {
     event: EventKind,
-    discovered: &'a [&'a str],
-    departed: &'a [&'a str],
+    discovered: Vec<&'a str>,
+    departed: Vec<&'a str>,
 }
 
 impl Event {
@@ -818,29 +821,32 @@ fn render_event(event: Event, aggregate: &mut Aggregate, scope_width: usize, ali
                     error: None,
                 };
 
-                output::data(&payload, false, format_args!(""), || {
-                    aggregate.mark_reported(&service);
+                output::data(
+                    || &payload,
+                    || {
+                        aggregate.mark_reported(&service);
 
-                    let mut scopes = scopes.clone();
-                    scopes.sort_by(|a, b| a.name.cmp(&b.name));
+                        let mut scopes = scopes.clone();
+                        scopes.sort_by(|a, b| a.name.cmp(&b.name));
 
-                    for scope in &scopes {
-                        let transition = aggregate.observe(&service, scope);
+                        for scope in &scopes {
+                            let transition = aggregate.observe(&service, scope);
 
-                        if transition != Transition::Unchanged {
-                            render::print_transition_line(
-                                ServiceColumn::Named { alias: &alias, width: alias_width },
-                                scope,
-                                scope_width,
-                                transition,
-                            );
+                            if transition != Transition::Unchanged {
+                                render::print_transition_line(
+                                    ServiceColumn::Named { alias: &alias, width: alias_width },
+                                    scope,
+                                    scope_width,
+                                    transition,
+                                );
+                            }
                         }
-                    }
 
-                    if aggregate.refresh() {
-                        render::print_all_ready_line();
-                    }
-                });
+                        if aggregate.refresh() {
+                            render::print_all_ready_line();
+                        }
+                    },
+                );
             }
             EventData::Reattached => {
                 let payload = EventPayload {
@@ -850,9 +856,12 @@ fn render_event(event: Event, aggregate: &mut Aggregate, scope_width: usize, ali
                     error: None,
                 };
 
-                output::data(&payload, false, format_args!(""), || {
-                    render::print_lifecycle_line(&alias, alias_width, "stream reattached");
-                });
+                output::data(
+                    || &payload,
+                    || {
+                        render::print_lifecycle_line(&alias, alias_width, "stream reattached");
+                    },
+                );
             }
             EventData::Lost { cause, retry_after } => {
                 let payload = EventPayload {
@@ -862,37 +871,38 @@ fn render_event(event: Event, aggregate: &mut Aggregate, scope_width: usize, ali
                     error: Some(&cause),
                 };
 
-                output::data(&payload, false, format_args!(""), || {
-                    aggregate.mark_lost(&service);
-                    render::print_lost_line(&alias, alias_width, &cause, retry_after);
-                });
+                output::data(
+                    || &payload,
+                    || {
+                        aggregate.mark_lost(&service);
+                        render::print_lost_line(&alias, alias_width, &cause, retry_after);
+                    },
+                );
             }
         },
         Event::Membership { discovered, departed } => {
-            let discovered_names: Vec<&str> = discovered.iter().map(|(service, _)| service.as_str()).collect();
-            let departed_names: Vec<&str> = departed.iter().map(|(service, _)| service.as_str()).collect();
+            output::data(
+                || MembershipPayload {
+                    event: EventKind::Membership,
+                    discovered: discovered.iter().map(|(service, _)| service.as_str()).collect(),
+                    departed: departed.iter().map(|(service, _)| service.as_str()).collect(),
+                },
+                || {
+                    let crossed = aggregate.apply_membership(&discovered, &departed);
 
-            let payload = MembershipPayload {
-                event: EventKind::Membership,
-                discovered: &discovered_names,
-                departed: &departed_names,
-            };
+                    for (_, alias) in &discovered {
+                        render::print_membership_line(alias, alias_width, render::Membership::Discovered);
+                    }
 
-            output::data(&payload, false, format_args!(""), || {
-                let crossed = aggregate.apply_membership(&discovered, &departed);
+                    for (_, alias) in &departed {
+                        render::print_membership_line(alias, alias_width, render::Membership::Gone);
+                    }
 
-                for (_, alias) in &discovered {
-                    render::print_membership_line(alias, alias_width, render::Membership::Discovered);
-                }
-
-                for (_, alias) in &departed {
-                    render::print_membership_line(alias, alias_width, render::Membership::Gone);
-                }
-
-                if crossed {
-                    render::print_all_ready_line();
-                }
-            });
+                    if crossed {
+                        render::print_all_ready_line();
+                    }
+                },
+            );
         }
     }
 }

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -157,10 +157,13 @@ impl TrafgenService {
             .into_inner();
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no configurations"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no configurations"));
+                    return;
+                }
+
                 for name in &response.configs {
                     println!("{name}");
                 }
@@ -180,11 +183,14 @@ impl TrafgenService {
             .map_err(self.service.status("show"))?
             .into_inner();
 
-        output::data(&response, false, format_args!(""), || {
-            println!("rate (pps):  {}", response.rate_pps);
-            println!("frame count: {}", response.frame_count);
-            println!("total bytes: {}", response.total_bytes);
-        });
+        output::data(
+            || &response,
+            || {
+                println!("rate (pps):  {}", response.rate_pps);
+                println!("frame count: {}", response.frame_count);
+                println!("total bytes: {}", response.total_bytes);
+            },
+        );
 
         Ok(())
     }

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -326,10 +326,13 @@ impl ACLService {
             .into_inner();
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no configurations"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no configurations"));
+                    return;
+                }
+
                 for name in &response.configs {
                     println!("{name}");
                 }
@@ -349,13 +352,16 @@ impl ACLService {
             .map_err(self.service.status("show"))?
             .into_inner();
 
-        output::data(&response, false, format_args!(""), || {
-            let config = ACLConfig { rules: response.rules.clone() };
-            print!(
-                "{}",
-                serde_yaml::to_string(&config).expect("ACL config YAML serialization must not fail")
-            );
-        });
+        output::data(
+            || &response,
+            || {
+                let config = ACLConfig { rules: response.rules.clone() };
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&config).expect("ACL config YAML serialization must not fail")
+                );
+            },
+        );
 
         Ok(())
     }
@@ -427,9 +433,17 @@ impl ACLService {
             .filter(|m| cmd.name.as_ref().is_none_or(|f| m.name.contains(f.as_filter())))
             .collect();
 
-        output::data(&metrics, metrics.is_empty(), format_args!("no metrics"), || {
-            print_metrics_table(&metrics)
-        });
+        output::data(
+            || &metrics,
+            || {
+                if metrics.is_empty() {
+                    output::empty(format_args!("no metrics"));
+                    return;
+                }
+
+                print_metrics_table(&metrics)
+            },
+        );
 
         Ok(())
     }

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -102,10 +102,13 @@ impl Balancer2Service {
         log::debug!("list configs response: {response:?}");
 
         output::data(
-            &response.names,
-            response.names.is_empty(),
-            format_args!("no balancer configs"),
+            || &response.names,
             || {
+                if response.names.is_empty() {
+                    output::empty(format_args!("no balancer configs"));
+                    return;
+                }
+
                 let mut tree = TreeBuilder::new("Balancers".to_owned());
                 for name in &response.names {
                     tree.add_empty_child(name.clone());
@@ -130,13 +133,17 @@ impl Balancer2Service {
             .into_inner();
         log::debug!("get config response: {response:?}");
 
-        output::data(&response, false, format_args!(""), || {
-            let mut json_value =
-                serde_json::to_value(&response).expect("balancer config JSON conversion must not fail");
-            display::prettify_json(&mut json_value);
-            let yaml = serde_yaml::to_string(&json_value).expect("balancer config YAML serialization must not fail");
-            print!("{yaml}");
-        });
+        output::data(
+            || &response,
+            || {
+                let mut json_value =
+                    serde_json::to_value(&response).expect("balancer config JSON conversion must not fail");
+                display::prettify_json(&mut json_value);
+                let yaml =
+                    serde_yaml::to_string(&json_value).expect("balancer config YAML serialization must not fail");
+                print!("{yaml}");
+            },
+        );
 
         Ok(())
     }
@@ -179,10 +186,15 @@ impl Balancer2Service {
         log::debug!("get state response: {response:?}");
 
         output::data(
-            &response.states,
-            response.states.is_empty(),
-            format_args!("no balancer state found"),
-            || display::print_table_view(&response.states, &opts),
+            || &response.states,
+            || {
+                if response.states.is_empty() {
+                    output::empty(format_args!("no balancer state found"));
+                    return;
+                }
+
+                display::print_table_view(&response.states, &opts);
+            },
         );
 
         Ok(())
@@ -202,10 +214,13 @@ impl Balancer2Service {
         log::debug!("list sessions states response: {response:?}");
 
         output::data(
-            &response.names,
-            response.names.is_empty(),
-            format_args!("no sessions states"),
+            || &response.names,
             || {
+                if response.names.is_empty() {
+                    output::empty(format_args!("no sessions states"));
+                    return;
+                }
+
                 let mut tree = TreeBuilder::new("Sessions States".to_owned());
                 for name in &response.names {
                     tree.add_empty_child(name.clone());
@@ -294,13 +309,17 @@ impl Balancer2Service {
             .into_inner();
         log::debug!("get metrics response: {response:?}");
 
-        output::data(&response, false, format_args!(""), || {
-            let mut json_value =
-                serde_json::to_value(&response).expect("balancer metrics JSON conversion must not fail");
-            display::prettify_json(&mut json_value);
-            let json = serde_json::to_string(&json_value).expect("balancer metrics JSON serialization must not fail");
-            println!("{json}");
-        });
+        output::data(
+            || &response,
+            || {
+                let mut json_value =
+                    serde_json::to_value(&response).expect("balancer metrics JSON conversion must not fail");
+                display::prettify_json(&mut json_value);
+                let json =
+                    serde_json::to_string(&json_value).expect("balancer metrics JSON serialization must not fail");
+                println!("{json}");
+            },
+        );
 
         Ok(())
     }

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -133,10 +133,13 @@ impl BlackholeService {
         log::debug!("list configs response: {response:?}");
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no configurations"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no configurations"));
+                    return;
+                }
+
                 for name in &response.configs {
                     println!("{name}");
                 }
@@ -157,9 +160,12 @@ impl BlackholeService {
             .into_inner();
         log::debug!("show config response: {response:?}");
 
-        output::data(&response, false, format_args!(""), || {
-            println!("name: {}", response.name);
-        });
+        output::data(
+            || &response,
+            || {
+                println!("name: {}", response.name);
+            },
+        );
 
         Ok(())
     }

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -123,10 +123,13 @@ impl DecapService {
         log::debug!("list configs response: {response:?}");
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no decap configs"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no decap configs"));
+                    return;
+                }
+
                 let mut tree = TreeBuilder::new("List Decap Configs".to_string());
                 for config in &response.configs {
                     tree.add_empty_child(config.clone());
@@ -150,7 +153,7 @@ impl DecapService {
             .into_inner();
         log::debug!("show config response: {response:?}");
 
-        output::data(&response, false, format_args!(""), || print_tree(&response));
+        output::data(|| &response, || print_tree(&response));
 
         Ok(())
     }

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -153,10 +153,13 @@ impl DscpService {
         log::debug!("list configs response: {response:?}");
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no dscp configs"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no dscp configs"));
+                    return;
+                }
+
                 let mut tree = TreeBuilder::new("List DSCP Configs".to_string());
                 for config in &response.configs {
                     tree.add_empty_child(config.clone());
@@ -180,7 +183,7 @@ impl DscpService {
             .into_inner();
         log::debug!("show config response: {response:?}");
 
-        output::data(&response, false, format_args!(""), || print_tree(&response));
+        output::data(|| &response, || print_tree(&response));
 
         Ok(())
     }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -192,12 +192,15 @@ impl ForwardService {
             .map_err(self.service.status("show"))?
             .into_inner();
 
-        output::data(&response, false, format_args!(""), || {
-            print!(
-                "{}",
-                serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")
-            );
-        });
+        output::data(
+            || &response,
+            || {
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")
+                );
+            },
+        );
 
         Ok(())
     }
@@ -213,10 +216,13 @@ impl ForwardService {
             .into_inner();
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no forward configs"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no forward configs"));
+                    return;
+                }
+
                 for name in &response.configs {
                     println!("{name}");
                 }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -101,10 +101,13 @@ impl FWStateService {
             .into_inner();
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no fwstate configs"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no fwstate configs"));
+                    return;
+                }
+
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&response.configs)
@@ -129,12 +132,15 @@ impl FWStateService {
             .map_err(self.service.status("show"))?
             .into_inner();
 
-        output::data(&response, false, format_args!(""), || {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&response).expect("fwstate config JSON serialization must not fail")
-            );
-        });
+        output::data(
+            || &response,
+            || {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&response).expect("fwstate config JSON serialization must not fail")
+                );
+            },
+        );
 
         Ok(())
     }
@@ -281,12 +287,15 @@ impl FWStateService {
             .map_err(self.service.status("stats"))?
             .into_inner();
 
-        output::data(&response, false, format_args!(""), || {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&response).expect("fwstate stats JSON serialization must not fail")
-            );
-        });
+        output::data(
+            || &response,
+            || {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&response).expect("fwstate stats JSON serialization must not fail")
+                );
+            },
+        );
 
         Ok(())
     }
@@ -410,9 +419,17 @@ impl FWStateService {
             })
             .collect();
 
-        output::data(&metrics, metrics.is_empty(), format_args!("no metrics"), || {
-            print_metrics_table(&metrics)
-        });
+        output::data(
+            || &metrics,
+            || {
+                if metrics.is_empty() {
+                    output::empty(format_args!("no metrics"));
+                    return;
+                }
+
+                print_metrics_table(&metrics)
+            },
+        );
 
         Ok(())
     }

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -192,12 +192,15 @@ impl MirrorService {
             .map_err(self.service.status("show"))?
             .into_inner();
 
-        output::data(&response, false, format_args!(""), || {
-            print!(
-                "{}",
-                serde_yaml::to_string(&response).expect("mirror config YAML serialization must not fail")
-            );
-        });
+        output::data(
+            || &response,
+            || {
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&response).expect("mirror config YAML serialization must not fail")
+                );
+            },
+        );
 
         Ok(())
     }
@@ -213,10 +216,13 @@ impl MirrorService {
             .into_inner();
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no mirror configs"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no mirror configs"));
+                    return;
+                }
+
                 for name in &response.configs {
                     println!("{name}");
                 }

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -232,10 +232,13 @@ impl NAT64Service {
         log::debug!("list configs response: {response:?}");
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no nat64 configs"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no nat64 configs"));
+                    return;
+                }
+
                 let mut tree = TreeBuilder::new("List NAT64 Configs".to_owned());
                 for config in &response.configs {
                     tree.add_empty_child(config.clone());
@@ -266,7 +269,7 @@ impl NAT64Service {
             .into_inner();
         log::debug!("show config response: {response:?}");
 
-        output::data(&response, false, format_args!(""), || print_tree(&response));
+        output::data(|| &response, || print_tree(&response));
 
         Ok(())
     }

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -108,10 +108,13 @@ impl PdumpService {
         log::debug!("list configs response: {response:?}");
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no pdump configs"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no pdump configs"));
+                    return;
+                }
+
                 let mut tree = TreeBuilder::new("List Pdump Configs".to_owned());
                 for config in &response.configs {
                     tree.add_empty_child(config.clone());
@@ -126,7 +129,7 @@ impl PdumpService {
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
         let response = self.get_config(&cmd.config_name).await?;
 
-        output::data(&response, false, format_args!(""), || print_tree(&response));
+        output::data(|| &response, || print_tree(&response));
 
         Ok(())
     }

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -223,10 +223,13 @@ impl RouteMplsService {
             .into_inner();
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no route-mpls configs"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no route-mpls configs"));
+                    return;
+                }
+
                 for name in &response.configs {
                     println!("{name}");
                 }
@@ -246,12 +249,15 @@ impl RouteMplsService {
             .map_err(self.service.status("show"))?
             .into_inner();
 
-        output::data(&response, false, format_args!(""), || {
-            print!(
-                "{}",
-                serde_yaml::to_string(&response).expect("route-mpls config YAML serialization must not fail")
-            )
-        });
+        output::data(
+            || &response,
+            || {
+                print!(
+                    "{}",
+                    serde_yaml::to_string(&response).expect("route-mpls config YAML serialization must not fail")
+                )
+            },
+        );
 
         Ok(())
     }

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -237,10 +237,13 @@ impl RouteService {
         let response = self.client.list_configs(ListConfigsRequest {}).await?.into_inner();
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("No FIB configs found."),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("No FIB configs found."));
+                    return;
+                }
+
                 for name in &response.configs {
                     println!("{name}");
                 }
@@ -265,10 +268,15 @@ impl RouteService {
             .collect();
 
         output::data(
-            &entries,
-            entries.is_empty(),
-            format_args!("No FIB entries found for {}.", cmd.config_name),
-            || print_table(entries.clone()),
+            || &entries,
+            || {
+                if entries.is_empty() {
+                    output::empty(format_args!("No FIB entries found for {}.", cmd.config_name));
+                    return;
+                }
+
+                print_table(entries.clone());
+            },
         );
 
         Ok(())

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -220,16 +220,18 @@ impl NeighbourService {
             .map_err(|status| NOT_FOUND.map(status, "show", self.service.endpoint(), resource.as_deref()))?
             .into_inner();
 
-        let empty_message = match &cmd.table {
-            Some(table) => format!("no neighbours in {table}"),
-            None => "no neighbours".to_owned(),
-        };
-
         output::data(
-            &response.neighbours,
-            response.neighbours.is_empty(),
-            format_args!("{empty_message}"),
+            || &response.neighbours,
             || {
+                if response.neighbours.is_empty() {
+                    let empty_message = match &cmd.table {
+                        Some(table) => format!("no neighbours in {table}"),
+                        None => "no neighbours".to_owned(),
+                    };
+                    output::empty(format_args!("{empty_message}"));
+                    return;
+                }
+
                 let mut entries: Vec<NeighbourEntry> =
                     response.neighbours.iter().cloned().map(NeighbourEntry::from).collect();
                 entries.sort_by(|a, b| (a.state, &a.next_hop).cmp(&(b.state, &b.next_hop)));
@@ -316,10 +318,13 @@ impl NeighbourService {
             .into_inner();
 
         output::data(
-            &response.tables,
-            response.tables.is_empty(),
-            format_args!("no neighbour tables"),
+            || &response.tables,
             || {
+                if response.tables.is_empty() {
+                    output::empty(format_args!("no neighbour tables"));
+                    return;
+                }
+
                 let entries: Vec<TableEntry> = response.tables.iter().cloned().map(TableEntry::from).collect();
                 print_table_from_entries(entries);
             },

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -240,10 +240,13 @@ impl RouteService {
             .into_inner();
 
         output::data(
-            &response.configs,
-            response.configs.is_empty(),
-            format_args!("no configurations"),
+            || &response.configs,
             || {
+                if response.configs.is_empty() {
+                    output::empty(format_args!("no configurations"));
+                    return;
+                }
+
                 for config in &response.configs {
                     println!("{config}");
                 }
@@ -269,10 +272,13 @@ impl RouteService {
             .into_inner();
 
         output::data(
-            &response.routes,
-            response.routes.is_empty(),
-            format_args!("no routes in {}", cmd.name),
+            || &response.routes,
             || {
+                if response.routes.is_empty() {
+                    output::empty(format_args!("no routes in {}", cmd.name));
+                    return;
+                }
+
                 let mut entries: Vec<RouteEntry> = response.routes.iter().cloned().map(RouteEntry::from).collect();
                 entries.sort_by_key(|entry| entry.prefix.0);
                 annotate_ecmp_groups(&mut entries);
@@ -298,10 +304,13 @@ impl RouteService {
             .into_inner();
 
         output::data(
-            &response.routes,
-            response.routes.is_empty(),
-            format_args!("no routes for {}", cmd.addr),
+            || &response.routes,
             || {
+                if response.routes.is_empty() {
+                    output::empty(format_args!("no routes for {}", cmd.addr));
+                    return;
+                }
+
                 let mut entries: Vec<RouteEntry> = response.routes.iter().cloned().map(RouteEntry::from).collect();
                 annotate_ecmp_groups(&mut entries);
                 print_route_table(entries);


### PR DESCRIPTION
The CLI output facade took a fully built serializable payload alongside a human render callback, but only one of the two is ever used: a serializing format ignores the callback, a human format ignores the payload. Every read subcommand therefore built a structure that its selected format immediately discarded.

The payload now crosses the backend boundary as a closure, so a serializing backend builds it and a rendering one never does. The trait documents the exclusivity as an obligation on implementations, since that is what the saving rests on.

The empty-result flag and its message leave the facade as well. The render callback already knows whether its own data is empty, so the flag was a second source of truth; a dedicated helper now reports the empty case and keeps it on the error stream, so a piped run still reads as no rows.

All call sites are converted, and three of them now build their display or payload structures inside the callback that needs them, which is where the deferral actually pays off. Observable output is unchanged in both formats.