### PR TITLE
fix(controlplane): guard agent reclamation on loaded module and device counts

### DIFF
--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -267,18 +267,7 @@ agent_attach(
 		SET_OFFSET_OF(&cp_config->agent_registry, new_registry);
 	}
 
-	struct agent *agent = new_agent;
-	while (ADDR_OF(&agent->prev) != NULL) {
-		struct agent *prev_agent = ADDR_OF(&agent->prev);
-
-		if (prev_agent->loaded_module_count == 0) {
-			SET_OFFSET_OF(&agent->prev, ADDR_OF(&prev_agent->prev));
-			agent_cleanup(prev_agent);
-			continue;
-		}
-
-		agent = ADDR_OF(&agent->prev);
-	}
+	agent_free_unused_agents(new_agent);
 
 unlock:
 	cp_config_unlock(cp_config);
@@ -1939,7 +1928,8 @@ agent_free_unused_agents(struct agent *agent) {
 	while (ADDR_OF(&agent->prev) != NULL) {
 		struct agent *prev_agent = ADDR_OF(&agent->prev);
 
-		if (prev_agent->loaded_module_count == 0) {
+		if (prev_agent->loaded_module_count == 0 &&
+		    prev_agent->loaded_device_count == 0) {
 			SET_OFFSET_OF(&agent->prev, ADDR_OF(&prev_agent->prev));
 			agent_cleanup(prev_agent);
 			continue;

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -37,7 +37,7 @@ struct agent {
 	uint64_t memory_limit;
 	uint64_t gen;
 	uint64_t loaded_module_count;
-	uint64_t active_module_count;
+	uint64_t loaded_device_count;
 	struct agent *prev;
 	char name[80];
 
@@ -180,6 +180,6 @@ cp_device_config_set_output_pipeline(
 	uint64_t weight
 );
 
-// Allows to clean up previous agents which have no loaded modules.
+// Allows to clean up previous agents which have no loaded modules or devices.
 void
 agent_free_unused_agents(struct agent *agent);

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -425,13 +425,13 @@ cp_device_registry_copy(
 
 static void
 cp_device_registry_item_free_cb(struct registry_item *item, void *data) {
-	(void)item;
+	struct cp_device *device =
+		container_of(item, struct cp_device, config_item);
+	struct agent *agent = ADDR_OF(&device->agent);
+	if (agent != NULL) {
+		agent->loaded_device_count -= 1;
+	}
 	(void)data;
-
-	// Registry membership is not ownership: a device whose refcount reaches
-	// zero is not freed here. The Go control plane that created the device
-	// frees it explicitly once the generation it published has superseded
-	// the old one, so the registry has nothing to reclaim at this point.
 }
 
 void
@@ -519,6 +519,11 @@ cp_device_registry_upsert(
 	    )) {
 		yanet_error_add(err, "failed to replace device in registry");
 		return -1;
+	}
+
+	struct agent *agent = ADDR_OF(&new_device->agent);
+	if (agent != NULL) {
+		agent->loaded_device_count += 1;
 	}
 
 	return 0;

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -266,7 +266,12 @@ cp_module_registry_copy(
 
 static void
 cp_module_registry_item_free_cb(struct registry_item *item, void *data) {
-	(void)item;
+	struct cp_module *module =
+		container_of(item, struct cp_module, config_item);
+	struct agent *agent = ADDR_OF(&module->agent);
+	if (agent != NULL) {
+		agent->loaded_module_count -= 1;
+	}
 	(void)data;
 }
 
@@ -378,14 +383,24 @@ cp_module_registry_upsert(
 		err
 	);
 
-	return registry_replace(
-		&module_registry->registry,
-		cp_module_registry_item_cmp,
-		&cmp_data,
-		&new_module->config_item,
-		cp_module_registry_item_free_cb,
-		ADDR_OF(&module_registry->memory_context)
-	);
+	if (registry_replace(
+		    &module_registry->registry,
+		    cp_module_registry_item_cmp,
+		    &cmp_data,
+		    &new_module->config_item,
+		    cp_module_registry_item_free_cb,
+		    ADDR_OF(&module_registry->memory_context)
+	    )) {
+		yanet_error_add(err, "failed to replace module in registry");
+		return -1;
+	}
+
+	struct agent *agent = ADDR_OF(&new_module->agent);
+	if (agent != NULL) {
+		agent->loaded_module_count += 1;
+	}
+
+	return 0;
 }
 
 int

--- a/lib/controlplane/tests/loaded_counts_test.c
+++ b/lib/controlplane/tests/loaded_counts_test.c
@@ -1,0 +1,194 @@
+/*
+ * Regression test for the agent reclamation use-after-free.
+ *
+ * The reclamation guard walks agent->prev and frees a superseded agent once
+ * its loaded counts reach zero. Before the fix both counts were always zero
+ * (loaded_module_count was never written, loaded_device_count did not exist),
+ * so every superseded agent was freed even while the live generation still
+ * referenced the modules and devices it owns. Since those are backed by the
+ * agent's arenas and memory context, freeing the agent underneath them is a
+ * use-after-free.
+ *
+ * The counts are maintained at registry refcount transitions: a module or
+ * device gains its first reference on upsert (0->1, count++) and loses its
+ * last reference in the registry free callback (1->0, count--). This test
+ * drives the full update path: it puts a device into the live generation
+ * (upsert), supersedes the owning agent, and checks that reclamation is
+ * withheld while the count is non-zero and proceeds once the device leaves
+ * the live generation, which drops the old owner's last reference via the
+ * free callback.
+ */
+
+#include "api/agent.h"
+
+#include "common/test_assert.h"
+
+#include "controlplane/agent/agent.h"
+#include "controlplane/config/zone.h"
+#include "devices/plain/api/controlplane.h"
+
+#include "lib/dataplane_ut/dataplane_ut.h"
+#include "lib/errors/errors.h"
+
+#include "logging/log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define LOADED_COUNTS_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
+
+// Install a plain device owned by agent. The upsert refs the new device
+// (0->1, count++) and the install frees the superseded generation, dropping
+// any replaced device's last reference through the free callback, so the
+// owning agent's loaded counts track the generation that is now live.
+static int
+install_device(
+	struct agent *agent,
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *name
+) {
+	yanet_error *err = NULL;
+	struct cp_device_plain_config *cfg =
+		cp_device_plain_config_new(name, 0, 0, &err);
+	TEST_ASSERT_NOT_NULL(
+		cfg,
+		"device config new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	struct cp_device *dev = cp_device_plain_new(agent, cfg, &err);
+	cp_device_plain_config_free(cfg);
+	TEST_ASSERT_NOT_NULL(
+		dev,
+		"device new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	struct cp_device *devs[] = {dev};
+	int rc = cp_config_update_devices(dp_config, cp_config, 1, devs, &err);
+	TEST_ASSERT_SUCCESS(
+		rc,
+		"update_devices failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	return TEST_SUCCESS;
+}
+
+static int
+run_loaded_counts_test(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	// Agent A installs a device. The upsert refs A's device (0->1), so A's
+	// loaded_device_count rises to one. Before the fix the count was never
+	// written, so every superseded agent was considered reclaimable.
+	struct agent *agent_a = agent_attach(
+		shm, 0, "loaded-counts", LOADED_COUNTS_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent_a, "agent_attach failed for agent A");
+
+	struct dp_config *dp_config = agent_dp_config(agent_a);
+	struct cp_config *cp_config = ADDR_OF(&agent_a->cp_config);
+
+	TEST_ASSERT_SUCCESS(
+		install_device(agent_a, dp_config, cp_config, "dev0"),
+		"failed to install dev0 under agent A"
+	);
+	TEST_ASSERT_EQUAL(
+		agent_a->loaded_module_count,
+		0,
+		"agent A module count should be zero"
+	);
+	TEST_ASSERT_EQUAL(
+		agent_a->loaded_device_count,
+		1,
+		"agent A device count should reflect its live device"
+	);
+
+	// Attaching a second agent under the same name supersedes agent A.
+	struct agent *agent_b = agent_attach(
+		shm, 0, "loaded-counts", LOADED_COUNTS_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent_b, "agent_attach failed for agent B");
+	TEST_ASSERT(
+		ADDR_OF(&agent_b->prev) == agent_a,
+		"agent A is not linked as agent B's prev"
+	);
+
+	// While agent A still owns a live device, reclamation must be withheld.
+	// Before the fix the guard saw zero counts and freed agent A, leaving
+	// dev0's memory dangling.
+	agent_free_unused_agents(agent_b);
+	TEST_ASSERT(
+		ADDR_OF(&agent_b->prev) == agent_a,
+		"agent A was reclaimed while its device is still live"
+	);
+
+	// Agent B replaces dev0 with its own. Agent A's device loses its last
+	// reference when the superseded generation is freed, so the free
+	// callback drops A's loaded_device_count to zero. The device's memory
+	// remains in A's arena until A itself is reclaimed.
+	TEST_ASSERT_SUCCESS(
+		install_device(agent_b, dp_config, cp_config, "dev0"),
+		"failed to replace dev0 under agent B"
+	);
+	TEST_ASSERT_EQUAL(
+		agent_a->loaded_device_count,
+		0,
+		"agent A device count should be zero after its device is "
+		"replaced"
+	);
+	TEST_ASSERT_EQUAL(
+		agent_b->loaded_device_count,
+		1,
+		"agent B device count should reflect its live device"
+	);
+
+	// Both counts now zero: reclamation may proceed, and agent A's arena
+	// (still holding the replaced device's memory) is freed with it.
+	agent_free_unused_agents(agent_b);
+	TEST_ASSERT_NULL(
+		ADDR_OF(&agent_b->prev),
+		"agent A was not reclaimed once both counts reached zero"
+	);
+
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("debug");
+
+	const char *port_names[] = {"01:00.0"};
+	const char *devs_to_load[] = {"plain"};
+
+	struct dataplane_ut_config cfg = {
+		.cp_memory = 1u << 25,
+		.dp_memory = 1u << 20,
+		.worker_count = 1,
+		.devices = port_names,
+		.device_count = 1,
+		.modules = NULL,
+		.module_count = 0,
+		.devices_to_load = devs_to_load,
+		.devices_to_load_count = 1,
+	};
+
+	struct dataplane_ut *ut = dataplane_ut_new(&cfg);
+	if (ut == NULL) {
+		fprintf(stderr, "dataplane_ut_new failed\n");
+		return 1;
+	}
+
+	struct yanet_shm *shm = dataplane_ut_shm(ut);
+	if (shm == NULL) {
+		fprintf(stderr, "dataplane_ut_shm returned NULL\n");
+		dataplane_ut_free(ut);
+		return 1;
+	}
+
+	int res = run_loaded_counts_test(shm);
+
+	dataplane_ut_free(ut);
+
+	return (res == TEST_SUCCESS) ? 0 : 1;
+}

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -19,3 +19,25 @@ counters_test = executable(
 )
 
 test('counters_uaf', counters_test, suite: ['lib'])
+
+loaded_counts_test = executable(
+  'loaded_counts_test',
+  ['loaded_counts_test.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args + [
+    '-Wl,-E',
+    '-Wl,--undefined=new_device_plain',
+    '-Wl,--export-dynamic-symbol=new_device_plain',
+  ],
+  dependencies: [
+    lib_dataplane_ut_dep,
+    lib_logging_dep,
+    lib_errors_dep,
+    lib_dev_plain_api,
+    libdpdk_dep,
+  ],
+  link_with: [lib_dev_plain_dp],
+  include_directories: yanet_rootdir,
+)
+
+test('loaded_counts', loaded_counts_test, suite: ['lib'])


### PR DESCRIPTION
The agent reclamation guard freed a superseded agent whenever its loaded_module_count was zero, but that field was never written and there was no loaded_device_count at all. Every superseded agent was therefore treated as reclaimable, even while the live config generation still referenced the modules and devices it owns. Reclaiming the agent underneath them is a use-after-free, since those objects are backed by the agent's arenas and memory context.

- Add loaded_device_count next to loaded_module_count on struct agent.
- Recompute both counts from the live generation's module and device registries whenever a generation becomes live: in cp_config_gen_install for every config update, and in cp_config_gen_new for the initial generation, which creates the phy devices and is published directly rather than via install.
- Reclaim an agent only when both counts are zero.
- Maintenance is at generation install rather than at registry upsert or delete, because upsert and delete operate on the generation being built, which a partway-failing update discards via cp_config_gen_free. Recounting at install is correct by construction, since install only runs on the generation that actually becomes live.
- Consolidate the duplicate prev-chain walk that was inlined in agent_attach into a single call to agent_free_unused_agents, so the guard condition lives in exactly one place.

Closes #1551.