### PR TITLE
feat(route): print FIB entries as address ranges

### DIFF
--- a/modules/route/cli/route/src/fib/json.rs
+++ b/modules/route/cli/route/src/fib/json.rs
@@ -1,0 +1,76 @@
+//! JSON payload for `fib show --format json`.
+//!
+//! Each record carries `start`/`end`, or an `invalid` marker for a range
+//! that failed to parse, plus `nexthops` -- always an array mirroring the
+//! wire entry regardless of whether the range parsed, empty rather than
+//! absent for a record with none.
+
+use serde::Serialize;
+
+use super::{format_mac, FibRecord, RangeUnit};
+use crate::routepb::FibNexthop;
+
+/// One nexthop, as serialized in a [`FibRecordJson`].
+#[derive(Debug, Serialize)]
+pub struct FibNexthopJson {
+    pub dst_mac: String,
+    pub src_mac: String,
+    pub device: String,
+}
+
+impl From<&FibNexthop> for FibNexthopJson {
+    fn from(nexthop: &FibNexthop) -> Self {
+        Self {
+            dst_mac: format_mac(nexthop.dst_mac),
+            src_mac: format_mac(nexthop.src_mac),
+            device: nexthop.device.clone(),
+        }
+    }
+}
+
+/// JSON range representation for one FIB record.
+///
+/// A well-formed range carries `start`/`end`; an invalid one carries
+/// neither, just an honest `invalid` marker, rather than fabricating
+/// endpoints for a range that failed to parse.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum FibRangeJson {
+    Range { start: String, end: String },
+    Invalid { invalid: bool },
+}
+
+impl From<RangeUnit> for FibRangeJson {
+    fn from(unit: RangeUnit) -> Self {
+        match unit {
+            RangeUnit::Range { start, end } => Self::Range {
+                start: start.to_string(),
+                end: end.to_string(),
+            },
+            RangeUnit::Invalid => Self::Invalid { invalid: true },
+        }
+    }
+}
+
+/// One FIB record, as serialized for `--format json`.
+///
+/// `nexthops` mirrors the wire entry regardless of whether `range`
+/// serializes as `start`/`end` or as `invalid: true` -- a malformed,
+/// absent, or inverted range still carries whatever nexthops the server
+/// attached to it. A record with no nexthops still serializes with
+/// `nexthops: []` rather than disappearing.
+#[derive(Debug, Serialize)]
+pub struct FibRecordJson {
+    #[serde(flatten)]
+    pub range: FibRangeJson,
+    pub nexthops: Vec<FibNexthopJson>,
+}
+
+impl From<&FibRecord> for FibRecordJson {
+    fn from(record: &FibRecord) -> Self {
+        Self {
+            range: FibRangeJson::from(record.range),
+            nexthops: record.nexthops.iter().map(FibNexthopJson::from).collect(),
+        }
+    }
+}

--- a/modules/route/cli/route/src/fib/mod.rs
+++ b/modules/route/cli/route/src/fib/mod.rs
@@ -1,0 +1,205 @@
+//! Domain model for `fib show`.
+//!
+//! The wire carries one [`FibRangeEntry`] per dataplane FIB row: a
+//! contiguous address range plus its (possibly ECMP) nexthops.
+//! [`build_records`] turns each row into a [`FibRecord`] in the order the
+//! server sent it. Both the human view ([`render`]) and the JSON payload
+//! ([`json`]) are built from those same records, so a record dropped or
+//! reshaped here is dropped or reshaped in both.
+
+pub mod json;
+pub mod render;
+
+use core::net::IpAddr;
+
+use commonpb::pb::{IpRange, MacAddress};
+use netip::MacAddr;
+
+use crate::routepb::{FibNexthop, FibRangeEntry};
+
+/// One dataplane FIB row's range, classified as well-formed or invalid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RangeUnit {
+    Range { start: IpAddr, end: IpAddr },
+    Invalid,
+}
+
+/// One FIB record: a range paired with the nexthop(s) attached to it.
+///
+/// `nexthops` always mirrors the wire entry regardless of how `range`
+/// classifies -- a [`RangeUnit::Invalid`] record keeps the nexthops the
+/// server sent right alongside it, since that is the data an operator
+/// needs to diagnose a malformed, absent, or inverted range. A row
+/// carrying no nexthops still yields a record, with an empty `nexthops`,
+/// so it can never vanish from the output.
+#[derive(Debug, Clone)]
+pub struct FibRecord {
+    range: RangeUnit,
+    nexthops: Vec<FibNexthop>,
+}
+
+/// Builds one [`FibRecord`] per row in `entries`, preserving wire order.
+pub fn build_records(entries: &[FibRangeEntry]) -> Vec<FibRecord> {
+    entries.iter().map(build_record).collect()
+}
+
+/// Builds one `FibRangeEntry`'s [`FibRecord`].
+///
+/// `nexthops` is cloned from `entry` unconditionally: the classification of
+/// `range` and the fate of the nexthops are independent. `--format json` is
+/// the contract for the wire data and must carry whatever nexthops the
+/// server attached, even to a malformed, absent, or inverted range -- that
+/// is exactly the data an operator needs to diagnose it. The human view is
+/// free to summarise such a record away to a single placeholder row; that
+/// choice belongs to the renderer, not to this constructor.
+fn build_record(entry: &FibRangeEntry) -> FibRecord {
+    let range = range_unit(entry.range.as_ref());
+    let nexthops = entry.nexthops.clone();
+
+    FibRecord { range, nexthops }
+}
+
+/// Classifies a wire `range` as well-formed or invalid.
+///
+/// A range is invalid when `range` is absent, when converting its two
+/// endpoints to an `IpAddr` pair fails -- a missing endpoint, an address
+/// byte length that is neither 4 nor 16, or an address-family mismatch
+/// between `start` and `end` -- or when it is inverted (`start` after
+/// `end`). `IpAddr`'s `Ord` only orders numerically within a single
+/// family, so the inversion check runs after the conversion has already
+/// established that both endpoints exist and share a family -- checking it
+/// first would compare, for instance, an IPv4 `start` against an IPv6
+/// `end` and report a meaningless verdict.
+fn range_unit(range: Option<&IpRange>) -> RangeUnit {
+    let Some(range) = range else {
+        return RangeUnit::Invalid;
+    };
+
+    let Ok((start, end)) = <(IpAddr, IpAddr)>::try_from(range) else {
+        return RangeUnit::Invalid;
+    };
+
+    if start > end {
+        return RangeUnit::Invalid;
+    }
+
+    RangeUnit::Range { start, end }
+}
+
+/// Renders a nexthop's MAC address, or a fallback for a missing/invalid one.
+fn format_mac(mac: Option<MacAddress>) -> String {
+    let mac = match mac {
+        Some(mac) => match MacAddr::try_from(&mac) {
+            Ok(mac) => return mac.to_string(),
+            Err(..) => "invalid",
+        },
+        None => "00:00:00:00:00:00",
+    };
+    mac.to_string()
+}
+
+#[cfg(test)]
+mod test {
+    use commonpb::pb::IpAddress;
+
+    use super::*;
+
+    fn ip_range(start: &str, end: &str) -> IpRange {
+        IpRange::from((start.parse::<IpAddr>().unwrap(), end.parse::<IpAddr>().unwrap()))
+    }
+
+    fn nexthop(device: &str) -> FibNexthop {
+        FibNexthop {
+            dst_mac: None,
+            src_mac: None,
+            device: device.to_owned(),
+        }
+    }
+
+    fn entry(range: Option<IpRange>, nexthops: Vec<FibNexthop>) -> FibRangeEntry {
+        FibRangeEntry { range, nexthops }
+    }
+
+    #[test]
+    fn build_records_yields_one_record_per_entry_in_order() {
+        let entries = vec![
+            entry(Some(ip_range("10.0.0.0", "10.0.0.255")), vec![nexthop("vlan100")]),
+            entry(Some(ip_range("172.16.0.0", "172.16.255.255")), Vec::new()),
+        ];
+
+        let records = build_records(&entries);
+
+        assert_eq!(2, records.len());
+        assert_eq!(
+            RangeUnit::Range {
+                start: "10.0.0.0".parse().unwrap(),
+                end: "10.0.0.255".parse().unwrap(),
+            },
+            records[0].range
+        );
+        assert_eq!(1, records[0].nexthops.len());
+        assert!(records[1].nexthops.is_empty());
+    }
+
+    #[test]
+    fn absent_range_is_invalid() {
+        let records = build_records(&[entry(None, vec![nexthop("vlan100")])]);
+
+        assert_eq!(RangeUnit::Invalid, records[0].range);
+    }
+
+    #[test]
+    fn missing_endpoint_is_invalid() {
+        let range = IpRange {
+            start: Some(IpAddress::from("10.0.0.1".parse::<IpAddr>().unwrap())),
+            end: None,
+        };
+        let records = build_records(&[entry(Some(range), Vec::new())]);
+
+        assert_eq!(RangeUnit::Invalid, records[0].range);
+    }
+
+    #[test]
+    fn invalid_address_byte_length_is_invalid() {
+        let range = IpRange {
+            start: Some(IpAddress { addr: vec![0u8; 5] }),
+            end: Some(IpAddress::from("10.0.0.1".parse::<IpAddr>().unwrap())),
+        };
+        let records = build_records(&[entry(Some(range), Vec::new())]);
+
+        assert_eq!(RangeUnit::Invalid, records[0].range);
+    }
+
+    #[test]
+    fn address_family_mismatch_is_invalid() {
+        let range = IpRange {
+            start: Some(IpAddress::from("10.0.0.1".parse::<IpAddr>().unwrap())),
+            end: Some(IpAddress::from("2001:db8::1".parse::<IpAddr>().unwrap())),
+        };
+        let records = build_records(&[entry(Some(range), Vec::new())]);
+
+        assert_eq!(RangeUnit::Invalid, records[0].range);
+    }
+
+    #[test]
+    fn inverted_range_is_invalid() {
+        let records = build_records(&[entry(Some(ip_range("10.0.0.254", "10.0.0.1")), Vec::new())]);
+
+        assert_eq!(RangeUnit::Invalid, records[0].range);
+    }
+
+    #[test]
+    fn well_formed_range_is_not_invalid() {
+        let records = build_records(&[entry(Some(ip_range("10.0.0.1", "10.0.0.1")), Vec::new())]);
+
+        assert_ne!(RangeUnit::Invalid, records[0].range);
+    }
+
+    #[test]
+    fn invalid_range_preserves_nexthops() {
+        let records = build_records(&[entry(None, vec![nexthop("vlan100")])]);
+
+        assert_eq!(RangeUnit::Invalid, records[0].range);
+        assert_eq!(1, records[0].nexthops.len());
+    }
+}

--- a/modules/route/cli/route/src/fib/render/mod.rs
+++ b/modules/route/cli/route/src/fib/render/mod.rs
@@ -1,0 +1,134 @@
+//! Human-readable table rendering for `fib show`: one row per record, or one
+//! row per nexthop for an ECMP group.
+//!
+//! Every record contributes at least one row, so a record with an invalid
+//! range or with no nexthops still shows up rather than vanishing. No
+//! `Width`/`Wrap` setting is ever applied, matching how borderless CLI table
+//! tools conventionally behave: a narrow terminal is left to wrap the output
+//! itself rather than the table pre-wrapping it.
+
+use core::net::IpAddr;
+
+use tabled::{
+    settings::{object::Rows, Color, Padding, Style},
+    Table, Tabled,
+};
+use ync::output;
+
+use super::{format_mac, FibRecord, RangeUnit};
+use crate::routepb::FibNexthop;
+
+/// One table row: either a full record (or its first nexthop), or a
+/// continuation row for a later ECMP nexthop with `from`/`to` left empty.
+#[derive(Debug, Tabled)]
+struct FibRow {
+    #[tabled(rename = "From")]
+    from: String,
+    #[tabled(rename = "To")]
+    to: String,
+    #[tabled(rename = "Device")]
+    device: String,
+    #[tabled(rename = "Dst MAC")]
+    dst_mac: String,
+    #[tabled(rename = "Src MAC")]
+    src_mac: String,
+}
+
+/// Strips every `char::is_control` character out of `value`, replacing each
+/// with `?`.
+///
+/// Applied to a device name before it is pushed into a cell: `device` is
+/// echoed verbatim from the wire with no upstream validation beyond
+/// non-emptiness, so a control character a peer embedded in it -- an ANSI
+/// escape, say -- would otherwise reach the terminal unfiltered.
+fn sanitize_wire_text(value: &str) -> String {
+    value.chars().map(|ch| if ch.is_control() { '?' } else { ch }).collect()
+}
+
+/// Builds the single-row placeholder for an invalid range.
+fn invalid_row() -> FibRow {
+    FibRow {
+        from: "(invalid range)".to_owned(),
+        to: String::new(),
+        device: String::new(),
+        dst_mac: String::new(),
+        src_mac: String::new(),
+    }
+}
+
+/// Builds the single-row placeholder for a well-formed range with no
+/// nexthops.
+fn no_nexthops_row(start: IpAddr, end: IpAddr) -> FibRow {
+    FibRow {
+        from: start.to_string(),
+        to: end.to_string(),
+        device: "(no nexthops)".to_owned(),
+        dst_mac: String::new(),
+        src_mac: String::new(),
+    }
+}
+
+/// Builds one row per nexthop in an ECMP group.
+///
+/// Only the first row carries the range's `from`/`to` cells; the rest are
+/// continuation rows with those cells left empty, which is what tells them
+/// apart from a new record's own row when the table is read back.
+fn nexthop_rows(start: IpAddr, end: IpAddr, nexthops: &[FibNexthop]) -> Vec<FibRow> {
+    let from_text = start.to_string();
+    let to_text = end.to_string();
+
+    nexthops
+        .iter()
+        .enumerate()
+        .map(|(index, nexthop)| FibRow {
+            from: if index == 0 { from_text.clone() } else { String::new() },
+            to: if index == 0 { to_text.clone() } else { String::new() },
+            device: sanitize_wire_text(&nexthop.device),
+            dst_mac: format_mac(nexthop.dst_mac),
+            src_mac: format_mac(nexthop.src_mac),
+        })
+        .collect()
+}
+
+/// Builds the row(s) for one [`FibRecord`].
+///
+/// [`RangeUnit::Invalid`] is matched first and unconditionally, ahead of
+/// the nexthop-count check on the `Range` arms: an invalid record may now
+/// carry nexthops cloned from the wire, but the human view still
+/// summarises it down to the single `(invalid range)` placeholder row,
+/// never one row per nexthop.
+fn build_rows(record: &FibRecord) -> Vec<FibRow> {
+    match record.range {
+        RangeUnit::Invalid => vec![invalid_row()],
+        RangeUnit::Range { start, end } if record.nexthops.is_empty() => {
+            vec![no_nexthops_row(start, end)]
+        }
+        RangeUnit::Range { start, end } => nexthop_rows(start, end, &record.nexthops),
+    }
+}
+
+/// Renders `records` as a headered, borderless table.
+///
+/// `colored` gates only the header row's bold styling: every cell's content
+/// renders identically regardless of colour mode.
+fn render_table(records: &[FibRecord], colored: bool) -> String {
+    let rows: Vec<FibRow> = records.iter().flat_map(build_rows).collect();
+
+    let mut table = Table::new(&rows);
+    table.with(Style::empty()).with(Padding::new(0, 2, 0, 0));
+
+    if colored {
+        table.modify(Rows::first(), Color::BOLD);
+    }
+
+    table.to_string()
+}
+
+/// Prints `records` as the `fib show` human view.
+pub fn print_fib(records: &[FibRecord]) {
+    let colored = output::is_colored();
+
+    for line in render_table(records, colored).lines() {
+        println!("{}", line.trim_end());
+    }
+}

--- a/modules/route/cli/route/src/lib.rs
+++ b/modules/route/cli/route/src/lib.rs
@@ -1,58 +1,6 @@
-use commonpb::pb::MacAddress;
-use netip::MacAddr;
-use serde::Serialize;
-use tabled::Tabled;
-
 #[allow(clippy::all, non_snake_case)]
 pub mod routepb {
     tonic::include_proto!("modules.route.controlplane.routepb.v1");
 }
 
-fn format_mac(mac: Option<MacAddress>) -> String {
-    let mac = match mac {
-        Some(mac) => match MacAddr::try_from(&mac) {
-            Ok(mac) => return mac.to_string(),
-            Err(..) => "invalid",
-        },
-        None => "00:00:00:00:00:00",
-    };
-    mac.to_string()
-}
-
-/// FIB entry for display in the CLI table.
-#[derive(Clone, Debug, Serialize, Tabled)]
-pub struct FibDisplayEntry {
-    #[tabled(rename = "Prefix")]
-    pub prefix: String,
-    #[tabled(rename = "Dst MAC")]
-    pub dst_mac: String,
-    #[tabled(rename = "Src MAC")]
-    pub src_mac: String,
-    #[tabled(rename = "Device")]
-    pub device: String,
-}
-
-impl FibDisplayEntry {
-    /// Convert a `FibRangeEntry` proto message into display rows.
-    ///
-    /// Emits one row per (CIDR, nexthop) pair. The CIDR list is produced by
-    /// decomposing the `range` field into the minimum set of covering
-    /// networks. Returns an empty `Vec` when `range` is absent or invalid.
-    pub fn from_range_entry(entry: routepb::FibRangeEntry) -> Vec<Self> {
-        let Some(range) = entry.range else {
-            return Vec::new();
-        };
-        let prefixes: Vec<String> = range.cidrs().map(|net| net.to_string()).collect();
-        prefixes
-            .into_iter()
-            .flat_map(|prefix| {
-                entry.nexthops.iter().map(move |nh| FibDisplayEntry {
-                    prefix: prefix.clone(),
-                    dst_mac: format_mac(nh.dst_mac),
-                    src_mac: format_mac(nh.src_mac),
-                    device: nh.device.clone(),
-                })
-            })
-            .collect()
-    }
-}
+pub mod fib;

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -14,18 +14,10 @@ use clap_complete::{
 use commonpb::pb::MacAddress;
 use netip::MacAddr;
 use serde::{Deserialize, Serialize};
-use tabled::{
-    settings::{
-        object::{Columns, Rows},
-        style::{BorderColor, HorizontalLine},
-        Color, Style,
-    },
-    Table, Tabled,
-};
 use tonic::codec::CompressionEncoding;
 use yanet_cli_route::{
+    fib,
     routepb::{self, route_service_client::RouteServiceClient, ListConfigsRequest, ShowFibRequest, UpdateFibRequest},
-    FibDisplayEntry,
 };
 use ync::{
     client::{ConnectionArgs, LayeredChannel},
@@ -260,43 +252,20 @@ impl RouteService {
         };
 
         let response = self.client.show_fib(request).await?.into_inner();
-
-        let entries: Vec<FibDisplayEntry> = response
-            .entries
-            .into_iter()
-            .flat_map(FibDisplayEntry::from_range_entry)
-            .collect();
+        let records = fib::build_records(&response.entries);
 
         output::data(
-            || &entries,
+            || records.iter().map(fib::json::FibRecordJson::from).collect::<Vec<_>>(),
             || {
-                if entries.is_empty() {
+                if records.is_empty() {
                     output::empty(format_args!("No FIB entries found for {}.", cmd.config_name));
                     return;
                 }
 
-                print_table(entries.clone());
+                fib::render::print_fib(&records);
             },
         );
 
         Ok(())
     }
-}
-
-fn print_table<I, T>(entries: I)
-where
-    I: IntoIterator<Item = T>,
-    T: Tabled,
-{
-    let mut table = Table::new(entries);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
-    table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-    table.modify(Rows::first(), Color::BOLD);
-
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
 }


### PR DESCRIPTION
The dataplane stores each forwarding entry as one contiguous address range, already coalesced by the lookup structure, and the wire has carried it that way for a while. The CLI nevertheless decomposed every entry back into covering networks and emitted one line per network per nexthop, so a three-entry table printed as nine lines and an IPv6 range whose boundary falls inside a prefix could expand into hundreds.

Entries are now shown the way shared memory holds them, as a range with its nexthops beneath it, in a borderless table with a bold header row. The number of blocks printed therefore matches the entry-count metric, which was previously impossible to reconcile against the listing.

An entry whose range is unusable, or which carries no nexthops at all, used to disappear from the listing entirely, because the decomposition had nothing to iterate over and silently produced no rows. Such an entry now always occupies one visible row and survives into the machine-readable output as well. An inverted range is recognised as unusable too, which the previous decomposition only caught by accident.

A device name arrives from the wire unvalidated, so control characters in it are replaced before rendering rather than reaching the operator's terminal.

The machine-readable payload is built only when that format is selected, using the deferral introduced in the preceding output-facade change.