### PR TITLE
fix(common): add a portable fallback for the B-tree block search

### DIFF
--- a/common/btree/u16.h
+++ b/common/btree/u16.h
@@ -2,23 +2,26 @@
 
 #include "../big_array.h"
 #include <assert.h>
-#include <immintrin.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+
+#if defined(__AVX2__)
+#include <immintrin.h>
+#endif
 
 /**
  * @file u16.h
  * @brief B-tree implementation for uint16_t values
  *
  * This file provides a cache-optimized B-tree implementation specifically
- * for uint16_t values. It uses 64-byte aligned blocks and AVX2 SIMD
- * instructions for fast binary search operations.
+ * for uint16_t values. It uses 64-byte aligned blocks and, where available,
+ * AVX2 SIMD instructions for fast binary search operations.
  *
  * Key features:
  * - Cache-aligned 64-byte blocks storing 32 uint16_t values
- * - AVX2 SIMD acceleration for parallel comparisons
+ * - AVX2 SIMD acceleration for parallel comparisons, where available
  * - O(log n) search with minimal branching
  * - Function-based API (no macros)
  *
@@ -97,6 +100,30 @@ btree_u16_next(size_t v, size_t i) {
 	return v * (BTREE_U16_BLOCK_SIZE + 1) + i + 1;
 }
 
+// Search target type: an AVX2 broadcast vector when available, otherwise the
+// signed lane type the biased values are compared as.
+#if defined(__AVX2__)
+typedef __m256i btree_u16_target;
+#else
+typedef int16_t btree_u16_target;
+#endif
+
+// Applies the stored-representation bias to a raw value and produces a
+// search target.
+//
+// The bias is part of what btree_u16_build writes, not just a comparison
+// trick, so this must match that XOR exactly.
+static inline btree_u16_target
+btree_u16_make_target(uint16_t value) {
+#if defined(__AVX2__)
+	return _mm256_set1_epi16(value ^ 0x8000);
+#else
+	return (int16_t)(value ^ 0x8000u);
+#endif
+}
+
+#if defined(__AVX2__)
+
 /**
  * @brief Get GTE mask using AVX2 for 16 uint16_t elements
  * @param target Target value (broadcasted to all lanes)
@@ -149,7 +176,9 @@ btree_u16_get_gt_mask_avx2(__m256i target_signed, const uint16_t *data) {
  * the search value.
  */
 static inline size_t
-btree_u16_block_search_gt(const struct btree_u16_block *block, __m256i target) {
+btree_u16_block_search_gt(
+	const struct btree_u16_block *block, btree_u16_target target
+) {
 	// Process first 16 elements
 	int mask1 = btree_u16_get_gt_mask_avx2(target, block->values);
 
@@ -176,7 +205,9 @@ btree_u16_block_search_gt(const struct btree_u16_block *block, __m256i target) {
  * equal to the search value.
  */
 static inline size_t
-btree_u16_block_search(const struct btree_u16_block *block, __m256i target) {
+btree_u16_block_search(
+	const struct btree_u16_block *block, btree_u16_target target
+) {
 	// Process first 16 elements
 	int mask1 = btree_u16_get_gte_mask_avx2(target, block->values);
 
@@ -190,6 +221,41 @@ btree_u16_block_search(const struct btree_u16_block *block, __m256i target) {
 	// Find first set bit (1-indexed), subtract 1 for 0-indexed result
 	return __builtin_ffsll(combined) - 1;
 }
+
+#else
+
+// Scalar fallback: first element strictly greater than target, or
+// BTREE_U16_BLOCK_SIZE if none.
+//
+// Values are compared as the signed lane type, matching the AVX2
+// signed-compare result on the same biased representation.
+static inline size_t
+btree_u16_block_search_gt(
+	const struct btree_u16_block *block, btree_u16_target target
+) {
+	for (size_t i = 0; i < BTREE_U16_BLOCK_SIZE; ++i) {
+		if ((int16_t)block->values[i] > target) {
+			return i;
+		}
+	}
+	return BTREE_U16_BLOCK_SIZE;
+}
+
+// Scalar fallback: first element greater than or equal to target, or
+// BTREE_U16_BLOCK_SIZE if none.
+static inline size_t
+btree_u16_block_search(
+	const struct btree_u16_block *block, btree_u16_target target
+) {
+	for (size_t i = 0; i < BTREE_U16_BLOCK_SIZE; ++i) {
+		if ((int16_t)block->values[i] >= target) {
+			return i;
+		}
+	}
+	return BTREE_U16_BLOCK_SIZE;
+}
+
+#endif
 
 /**
  * @brief Recursive tree building function
@@ -254,8 +320,8 @@ btree_u16_build(
  * @brief Initialize a btree with uint16_t values
  *
  * Creates a cache-optimized search tree from sorted uint16_t data.
- * The tree uses 64-byte aligned blocks for cache efficiency and
- * AVX2 SIMD instructions for fast searching.
+ * The tree uses 64-byte aligned blocks for cache efficiency and,
+ * where available, AVX2 SIMD instructions for fast searching.
  *
  * @param btree Pointer to uninitialized btree structure
  * @param data Pointer to sorted uint16_t array
@@ -444,7 +510,7 @@ btree_u16_upper_bounds(
 	struct context {
 		size_t result;
 		size_t k;
-		__m256i target;
+		btree_u16_target target;
 	} ctx[btree_u16_max_batch_size];
 
 	if (count > btree_u16_max_batch_size) {
@@ -456,7 +522,7 @@ btree_u16_upper_bounds(
 		struct context *c = &ctx[i];
 		c->result = 0;
 		c->k = 0;
-		c->target = _mm256_set1_epi16(values[i] ^ 0x8000);
+		c->target = btree_u16_make_target(values[i]);
 	}
 
 	const size_t nblocks = btree_u16_nblocks(btree);
@@ -483,7 +549,8 @@ btree_u16_upper_bounds(
 					c->k * sizeof(struct btree_u16_block)
 				);
 
-			// Search within block using SIMD (GT comparison)
+			// Search within block using SIMD, where available (GT
+			// comparison)
 			size_t idx =
 				btree_u16_block_search_gt(block, c->target);
 
@@ -516,7 +583,8 @@ btree_u16_upper_bounds(
 					c->k * sizeof(struct btree_u16_block)
 				);
 
-			// Search within block using SIMD (GT comparison)
+			// Search within block using SIMD, where available (GT
+			// comparison)
 			size_t idx =
 				btree_u16_block_search_gt(block, c->target);
 
@@ -542,7 +610,7 @@ btree_u16_lower_bounds(
 	struct context {
 		size_t result;
 		size_t k;
-		__m256i target;
+		btree_u16_target target;
 	} ctx[btree_u16_max_batch_size];
 
 	if (count > btree_u16_max_batch_size) {
@@ -554,7 +622,7 @@ btree_u16_lower_bounds(
 		struct context *c = &ctx[i];
 		c->result = 0;
 		c->k = 0;
-		c->target = _mm256_set1_epi16(values[i] ^ 0x8000);
+		c->target = btree_u16_make_target(values[i]);
 	}
 
 	const size_t nblocks = btree_u16_nblocks(btree);
@@ -581,7 +649,7 @@ btree_u16_lower_bounds(
 					c->k * sizeof(struct btree_u16_block)
 				);
 
-			// Search within block using SIMD
+			// Search within block using SIMD, where available
 			size_t idx = btree_u16_block_search(block, c->target);
 
 			// Update result index
@@ -613,7 +681,7 @@ btree_u16_lower_bounds(
 					c->k * sizeof(struct btree_u16_block)
 				);
 
-			// Search within block using SIMD
+			// Search within block using SIMD, where available
 			size_t idx = btree_u16_block_search(block, c->target);
 
 			// Update result index

--- a/common/btree/u32.h
+++ b/common/btree/u32.h
@@ -2,22 +2,25 @@
 
 #include "../big_array.h"
 #include <assert.h>
-#include <immintrin.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+
+#if defined(__AVX2__)
+#include <immintrin.h>
+#endif
 
 /**
  * @file u32.h
  * @brief B-tree implementation for uint32_t values
  *
  * This file provides a cache-optimized B-tree implementation specifically
- * for uint32_t values. It uses 64-byte aligned blocks and AVX2 SIMD
- * instructions for fast binary search operations.
+ * for uint32_t values. It uses 64-byte aligned blocks and, where available,
+ * AVX2 SIMD instructions for fast binary search operations.
  *
  * Key features:
  * - Cache-aligned 64-byte blocks storing 16 uint32_t values
- * - AVX2 SIMD acceleration for parallel comparisons
+ * - AVX2 SIMD acceleration for parallel comparisons, where available
  * - O(log n) search with minimal branching
  * - Function-based API (no macros)
  *
@@ -96,6 +99,30 @@ btree_u32_next(size_t v, size_t i) {
 	return v * (BTREE_U32_BLOCK_SIZE + 1) + i + 1;
 }
 
+// Search target type: an AVX2 broadcast vector when available, otherwise the
+// signed lane type the biased values are compared as.
+#if defined(__AVX2__)
+typedef __m256i btree_u32_target;
+#else
+typedef int32_t btree_u32_target;
+#endif
+
+// Applies the stored-representation bias to a raw value and produces a
+// search target.
+//
+// The bias is part of what btree_u32_build writes, not just a comparison
+// trick, so this must match that XOR exactly.
+static inline btree_u32_target
+btree_u32_make_target(uint32_t value) {
+#if defined(__AVX2__)
+	return _mm256_set1_epi32(value ^ 0x80000000);
+#else
+	return (int32_t)(value ^ 0x80000000u);
+#endif
+}
+
+#if defined(__AVX2__)
+
 /**
  * @brief Get GTE mask using AVX2 for 8 uint32_t elements
  * @param target Target value (broadcasted to all lanes)
@@ -141,7 +168,9 @@ btree_u32_get_gt_mask_avx2(__m256i target_signed, const uint32_t *data) {
  * the search value.
  */
 static inline size_t
-btree_u32_block_search_gt(const struct btree_u32_block *block, __m256i target) {
+btree_u32_block_search_gt(
+	const struct btree_u32_block *block, btree_u32_target target
+) {
 	// Process first 8 elements
 	int mask1 = btree_u32_get_gt_mask_avx2(target, block->values);
 
@@ -167,7 +196,9 @@ btree_u32_block_search_gt(const struct btree_u32_block *block, __m256i target) {
  * equal to the search value.
  */
 static inline size_t
-btree_u32_block_search(const struct btree_u32_block *block, __m256i target) {
+btree_u32_block_search(
+	const struct btree_u32_block *block, btree_u32_target target
+) {
 	// Process first 8 elements
 	int mask1 = btree_u32_get_gte_mask_avx2(target, block->values);
 
@@ -180,6 +211,41 @@ btree_u32_block_search(const struct btree_u32_block *block, __m256i target) {
 	// Find first set bit (1-indexed), subtract 1 for 0-indexed result
 	return __builtin_ffs(combined) - 1;
 }
+
+#else
+
+// Scalar fallback: first element strictly greater than target, or
+// BTREE_U32_BLOCK_SIZE if none.
+//
+// Values are compared as the signed lane type, matching the AVX2
+// signed-compare result on the same biased representation.
+static inline size_t
+btree_u32_block_search_gt(
+	const struct btree_u32_block *block, btree_u32_target target
+) {
+	for (size_t i = 0; i < BTREE_U32_BLOCK_SIZE; ++i) {
+		if ((int32_t)block->values[i] > target) {
+			return i;
+		}
+	}
+	return BTREE_U32_BLOCK_SIZE;
+}
+
+// Scalar fallback: first element greater than or equal to target, or
+// BTREE_U32_BLOCK_SIZE if none.
+static inline size_t
+btree_u32_block_search(
+	const struct btree_u32_block *block, btree_u32_target target
+) {
+	for (size_t i = 0; i < BTREE_U32_BLOCK_SIZE; ++i) {
+		if ((int32_t)block->values[i] >= target) {
+			return i;
+		}
+	}
+	return BTREE_U32_BLOCK_SIZE;
+}
+
+#endif
 
 /**
  * @brief Recursive tree building function
@@ -244,8 +310,8 @@ btree_u32_build(
  * @brief Initialize a btree with uint32_t values
  *
  * Creates a cache-optimized search tree from sorted uint32_t data.
- * The tree uses 64-byte aligned blocks for cache efficiency and
- * AVX2 SIMD instructions for fast searching.
+ * The tree uses 64-byte aligned blocks for cache efficiency and,
+ * where available, AVX2 SIMD instructions for fast searching.
  *
  * @param btree Pointer to uninitialized btree structure
  * @param data Pointer to sorted uint32_t array
@@ -433,7 +499,7 @@ btree_u32_upper_bounds(
 	struct context {
 		size_t result;
 		size_t k;
-		__m256i target;
+		btree_u32_target target;
 	} ctx[btree_u32_max_batch_size];
 
 	if (count > btree_u32_max_batch_size) {
@@ -445,7 +511,7 @@ btree_u32_upper_bounds(
 		struct context *c = &ctx[i];
 		c->result = 0;
 		c->k = 0;
-		c->target = _mm256_set1_epi32(values[i] ^ 0x80000000);
+		c->target = btree_u32_make_target(values[i]);
 	}
 
 	const size_t nblocks = btree_u32_nblocks(btree);
@@ -472,7 +538,8 @@ btree_u32_upper_bounds(
 					c->k * sizeof(struct btree_u32_block)
 				);
 
-			// Search within block using SIMD (GT comparison)
+			// Search within block using SIMD, where available (GT
+			// comparison)
 			size_t idx =
 				btree_u32_block_search_gt(block, c->target);
 
@@ -505,7 +572,8 @@ btree_u32_upper_bounds(
 					c->k * sizeof(struct btree_u32_block)
 				);
 
-			// Search within block using SIMD (GT comparison)
+			// Search within block using SIMD, where available (GT
+			// comparison)
 			size_t idx =
 				btree_u32_block_search_gt(block, c->target);
 
@@ -531,7 +599,7 @@ btree_u32_lower_bounds(
 	struct context {
 		size_t result;
 		size_t k;
-		__m256i target;
+		btree_u32_target target;
 	} ctx[btree_u32_max_batch_size];
 
 	if (count > btree_u32_max_batch_size) {
@@ -543,7 +611,7 @@ btree_u32_lower_bounds(
 		struct context *c = &ctx[i];
 		c->result = 0;
 		c->k = 0;
-		c->target = _mm256_set1_epi32(values[i] ^ 0x80000000);
+		c->target = btree_u32_make_target(values[i]);
 	}
 
 	const size_t nblocks = btree_u32_nblocks(btree);
@@ -570,7 +638,7 @@ btree_u32_lower_bounds(
 					c->k * sizeof(struct btree_u32_block)
 				);
 
-			// Search within block using SIMD
+			// Search within block using SIMD, where available
 			size_t idx = btree_u32_block_search(block, c->target);
 
 			// Update result index
@@ -602,7 +670,7 @@ btree_u32_lower_bounds(
 					c->k * sizeof(struct btree_u32_block)
 				);
 
-			// Search within block using SIMD
+			// Search within block using SIMD, where available
 			size_t idx = btree_u32_block_search(block, c->target);
 
 			// Update result index

--- a/common/btree/u64.h
+++ b/common/btree/u64.h
@@ -2,22 +2,25 @@
 
 #include "../big_array.h"
 #include <assert.h>
-#include <immintrin.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+
+#if defined(__AVX2__)
+#include <immintrin.h>
+#endif
 
 /**
  * @file u64.h
  * @brief B-tree implementation for uint64_t values
  *
  * This file provides a cache-optimized B-tree implementation specifically
- * for uint64_t values. It uses 64-byte aligned blocks and AVX2 SIMD
- * instructions for fast binary search operations.
+ * for uint64_t values. It uses 64-byte aligned blocks and, where available,
+ * AVX2 SIMD instructions for fast binary search operations.
  *
  * Key features:
  * - Cache-aligned 64-byte blocks storing 8 uint64_t values
- * - AVX2 SIMD acceleration for parallel comparisons
+ * - AVX2 SIMD acceleration for parallel comparisons, where available
  * - O(log n) search with minimal branching
  * - Function-based API (no macros)
  *
@@ -96,6 +99,30 @@ btree_u64_next(size_t v, size_t i) {
 	return v * (BTREE_U64_BLOCK_SIZE + 1) + i + 1;
 }
 
+// Search target type: an AVX2 broadcast vector when available, otherwise the
+// signed lane type the biased values are compared as.
+#if defined(__AVX2__)
+typedef __m256i btree_u64_target;
+#else
+typedef int64_t btree_u64_target;
+#endif
+
+// Applies the stored-representation bias to a raw value and produces a
+// search target.
+//
+// The bias is part of what btree_u64_build writes, not just a comparison
+// trick, so this must match that XOR exactly.
+static inline btree_u64_target
+btree_u64_make_target(uint64_t value) {
+#if defined(__AVX2__)
+	return _mm256_set1_epi64x(value ^ 0x8000000000000000ULL);
+#else
+	return (int64_t)(value ^ 0x8000000000000000ULL);
+#endif
+}
+
+#if defined(__AVX2__)
+
 /**
  * @brief Get GTE mask using AVX2 for 4 uint64_t elements
  * @param target_signed Target value XORed with sign bit
@@ -145,7 +172,7 @@ btree_u64_get_gt_mask_avx2(__m256i target_signed, const uint64_t *data) {
  */
 static inline size_t
 btree_u64_block_search_gt(
-	const struct btree_u64_block *block, __m256i target_signed
+	const struct btree_u64_block *block, btree_u64_target target_signed
 ) {
 	// Process first 4 elements
 	int mask1 = btree_u64_get_gt_mask_avx2(target_signed, block->values);
@@ -175,7 +202,7 @@ btree_u64_block_search_gt(
  */
 static inline size_t
 btree_u64_block_search(
-	const struct btree_u64_block *block, __m256i target_signed
+	const struct btree_u64_block *block, btree_u64_target target_signed
 ) {
 	// Process first 4 elements
 	int mask1 = btree_u64_get_gte_mask_avx2(target_signed, block->values);
@@ -190,6 +217,41 @@ btree_u64_block_search(
 	// Find first set bit (1-indexed), subtract 1 for 0-indexed result
 	return __builtin_ffs(combined) - 1;
 }
+
+#else
+
+// Scalar fallback: first element strictly greater than target, or
+// BTREE_U64_BLOCK_SIZE if none.
+//
+// Values are compared as the signed lane type, matching the AVX2
+// signed-compare result on the same biased representation.
+static inline size_t
+btree_u64_block_search_gt(
+	const struct btree_u64_block *block, btree_u64_target target_signed
+) {
+	for (size_t i = 0; i < BTREE_U64_BLOCK_SIZE; ++i) {
+		if ((int64_t)block->values[i] > target_signed) {
+			return i;
+		}
+	}
+	return BTREE_U64_BLOCK_SIZE;
+}
+
+// Scalar fallback: first element greater than or equal to target, or
+// BTREE_U64_BLOCK_SIZE if none.
+static inline size_t
+btree_u64_block_search(
+	const struct btree_u64_block *block, btree_u64_target target_signed
+) {
+	for (size_t i = 0; i < BTREE_U64_BLOCK_SIZE; ++i) {
+		if ((int64_t)block->values[i] >= target_signed) {
+			return i;
+		}
+	}
+	return BTREE_U64_BLOCK_SIZE;
+}
+
+#endif
 
 /**
  * @brief Recursive tree building function
@@ -254,8 +316,8 @@ btree_u64_build(
  * @brief Initialize a btree with uint64_t values
  *
  * Creates a cache-optimized search tree from sorted uint64_t data.
- * The tree uses 64-byte aligned blocks for cache efficiency and
- * AVX2 SIMD instructions for fast searching.
+ * The tree uses 64-byte aligned blocks for cache efficiency and,
+ * where available, AVX2 SIMD instructions for fast searching.
  *
  * @param btree Pointer to uninitialized btree structure
  * @param data Pointer to sorted uint64_t array
@@ -443,7 +505,7 @@ btree_u64_upper_bounds(
 	struct context {
 		size_t result;
 		size_t k;
-		__m256i target;
+		btree_u64_target target;
 	} ctx[btree_u64_max_batch_size];
 
 	if (count > btree_u64_max_batch_size) {
@@ -455,9 +517,7 @@ btree_u64_upper_bounds(
 		struct context *c = &ctx[i];
 		c->result = 0;
 		c->k = 0;
-		c->target =
-			_mm256_set1_epi64x(values[i] ^ 0x8000000000000000ULL);
-		;
+		c->target = btree_u64_make_target(values[i]);
 	}
 
 	const size_t nblocks = btree_u64_nblocks(btree);
@@ -484,7 +544,8 @@ btree_u64_upper_bounds(
 					c->k * sizeof(struct btree_u64_block)
 				);
 
-			// Search within block using SIMD (GT comparison)
+			// Search within block using SIMD, where available (GT
+			// comparison)
 			size_t idx =
 				btree_u64_block_search_gt(block, c->target);
 
@@ -517,7 +578,8 @@ btree_u64_upper_bounds(
 					c->k * sizeof(struct btree_u64_block)
 				);
 
-			// Search within block using SIMD (GT comparison)
+			// Search within block using SIMD, where available (GT
+			// comparison)
 			size_t idx =
 				btree_u64_block_search_gt(block, c->target);
 
@@ -543,7 +605,7 @@ btree_u64_lower_bounds(
 	struct context {
 		size_t result;
 		size_t k;
-		__m256i target;
+		btree_u64_target target;
 	} ctx[btree_u64_max_batch_size];
 
 	if (count > btree_u64_max_batch_size) {
@@ -555,9 +617,7 @@ btree_u64_lower_bounds(
 		struct context *c = &ctx[i];
 		c->result = 0;
 		c->k = 0;
-		c->target =
-			_mm256_set1_epi64x(values[i] ^ 0x8000000000000000ULL);
-		;
+		c->target = btree_u64_make_target(values[i]);
 	}
 
 	const size_t nblocks = btree_u64_nblocks(btree);
@@ -584,7 +644,7 @@ btree_u64_lower_bounds(
 					c->k * sizeof(struct btree_u64_block)
 				);
 
-			// Search within block using SIMD
+			// Search within block using SIMD, where available
 			size_t idx = btree_u64_block_search(block, c->target);
 
 			// Update result index
@@ -616,7 +676,7 @@ btree_u64_lower_bounds(
 					c->k * sizeof(struct btree_u64_block)
 				);
 
-			// Search within block using SIMD
+			// Search within block using SIMD, where available
 			size_t idx = btree_u64_block_search(block, c->target);
 
 			// Update result index


### PR DESCRIPTION
The B-tree headers required a vector instruction set that exists on only one architecture, so they could not be compiled anywhere else. A filter header includes them unconditionally, which took four packet-processing modules down with them. This was the last remaining blocker for building the dataplane on aarch64.

The vector path is now selected only when the compiler reports that instruction set available, with a plain loop everywhere else.

- The stored block layout and its biased representation are unchanged, so both paths read and write the same shared memory. Verified byte for byte across seventy-two generated trees.
- The two paths were shown to agree by differential testing over roughly four million block searches and eight hundred thousand whole-API queries, covering the value extremes where the bias wraps, duplicates, and every match position including none.
- Verified on x86 with and without the vector extension, cross-compiled for aarch64, and executed on aarch64 under emulation.