### PR TITLE
refactor(controlplane): derive cp_device memory context from agent, drop alloc_size

### DIFF
--- a/devices/plain/api/controlplane.c
+++ b/devices/plain/api/controlplane.c
@@ -26,11 +26,6 @@ cp_device_plain_new(
 	}
 
 	memset(cp_device_plain, 0, sizeof(struct cp_device_plain));
-	SET_OFFSET_OF(
-		&cp_device_plain->cp_device.parent_memory_context,
-		&agent->memory_context
-	);
-	cp_device_plain->cp_device.alloc_size = sizeof(struct cp_device_plain);
 
 	if (cp_device_init(
 		    &cp_device_plain->cp_device,
@@ -51,10 +46,13 @@ cp_device_plain_new(
 
 void
 cp_device_plain_free(struct cp_device *cp_device) {
+	struct agent *agent = ADDR_OF(&cp_device->agent);
 	cp_device_fini(cp_device);
-	struct memory_context *mctx =
-		ADDR_OF(&cp_device->parent_memory_context);
-	memory_bfree(mctx, cp_device, cp_device->alloc_size);
+	memory_bfree(
+		&agent->memory_context,
+		cp_device,
+		sizeof(struct cp_device_plain)
+	);
 }
 
 struct cp_device_plain_config *

--- a/devices/trafgen/api/controlplane.c
+++ b/devices/trafgen/api/controlplane.c
@@ -30,12 +30,6 @@ cp_device_trafgen_new(
 	}
 
 	memset(cp_device_trafgen, 0, sizeof(struct cp_device_trafgen));
-	SET_OFFSET_OF(
-		&cp_device_trafgen->cp_device.parent_memory_context,
-		&agent->memory_context
-	);
-	cp_device_trafgen->cp_device.alloc_size =
-		sizeof(struct cp_device_trafgen);
 
 	if (cp_device_init(
 		    &cp_device_trafgen->cp_device,
@@ -119,10 +113,13 @@ cp_device_trafgen_free(struct cp_device *cp_device) {
 		);
 	}
 
+	struct agent *agent = ADDR_OF(&cp_device->agent);
 	cp_device_fini(cp_device);
-	struct memory_context *mctx =
-		ADDR_OF(&cp_device->parent_memory_context);
-	memory_bfree(mctx, cp_device, cp_device->alloc_size);
+	memory_bfree(
+		&agent->memory_context,
+		cp_device,
+		sizeof(struct cp_device_trafgen)
+	);
 }
 
 struct cp_device_trafgen_config *

--- a/devices/vlan/api/controlplane.c
+++ b/devices/vlan/api/controlplane.c
@@ -26,11 +26,6 @@ cp_device_vlan_new(
 	}
 
 	memset(cp_device_vlan, 0, sizeof(struct cp_device_vlan));
-	SET_OFFSET_OF(
-		&cp_device_vlan->cp_device.parent_memory_context,
-		&agent->memory_context
-	);
-	cp_device_vlan->cp_device.alloc_size = sizeof(struct cp_device_vlan);
 
 	if (cp_device_init(
 		    &cp_device_vlan->cp_device,
@@ -53,10 +48,11 @@ cp_device_vlan_new(
 
 void
 cp_device_vlan_free(struct cp_device *cp_device) {
+	struct agent *agent = ADDR_OF(&cp_device->agent);
 	cp_device_fini(cp_device);
-	struct memory_context *mctx =
-		ADDR_OF(&cp_device->parent_memory_context);
-	memory_bfree(mctx, cp_device, cp_device->alloc_size);
+	memory_bfree(
+		&agent->memory_context, cp_device, sizeof(struct cp_device_vlan)
+	);
 }
 
 struct cp_device_vlan_config *

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -124,8 +124,6 @@ cp_device_new(struct memory_context *mctx) {
 	}
 
 	memset(self, 0, sizeof(struct cp_device));
-	SET_OFFSET_OF(&self->parent_memory_context, mctx);
-	self->alloc_size = sizeof(struct cp_device);
 
 	return self;
 }

--- a/lib/controlplane/config/cp_device.h
+++ b/lib/controlplane/config/cp_device.h
@@ -30,30 +30,14 @@ struct cp_device_entry {
 };
 
 struct cp_device {
-	// Offset pointer to the memory_context used to allocate this struct.
-	//
-	// Set by cp_device_new, or by a subclass create function before
-	// cp_device_init.
-	//
-	// Consumed by the device's typed free routine to reclaim the
-	// allocation.
-	struct memory_context *parent_memory_context;
-
-	// Number of bytes to pass to memory_bfree when freeing this struct.
-	//
-	// Set by cp_device_new OR by a subclass create function before
-	// cp_device_init.
-	//
-	// Subclasses MUST store sizeof their wrapper struct here so the typed
-	// free routine reclaims the proper full allocation.
-	uint64_t alloc_size;
-
 	struct registry_item config_item;
 	char type[80];
 	char name[CP_DEVICE_NAME_LEN];
 
 	uint64_t dp_device_idx;
 
+	// Agent that owns this device. Set by cp_device_init; used by the
+	// typed free routine to resolve the memory context for reclamation.
 	struct agent *agent;
 
 	struct memory_context memory_context;

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -742,9 +742,11 @@ cp_config_gen_new(struct agent *agent, yanet_error **err) {
 			goto error;
 		}
 		if (cp_device_init(cp_device, agent, &device_config, err)) {
-			struct memory_context *mctx =
-				ADDR_OF(&cp_device->parent_memory_context);
-			memory_bfree(mctx, cp_device, cp_device->alloc_size);
+			memory_bfree(
+				&agent->memory_context,
+				cp_device,
+				sizeof(struct cp_device)
+			);
 			yanet_error_add(
 				err,
 				"failed to initialize device '%s'",


### PR DESCRIPTION
Removes the redundant parent_memory_context and alloc_size fields from struct cp_device. The owning agent (already stored as cp_device.agent) provides the memory context, and each typed free routine knows its own sizeof, making both fields redundant.

- All three device subclasses (plain, vlan, trafgen) and zone.c are updated to derive the memory context from agent and pass their known struct size to memory_bfree.
- Free routines capture the agent pointer before calling cp_device_fini, since fini clears the agent offset.
- Removes the last remnants of the dead cp_device_free helper from cp_device_new.