### PR TITLE
fix(common): drop the dead 32-bit x86 arm from the crc32 arch guard

### DIFF
--- a/common/crc32.h
+++ b/common/crc32.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <string.h>
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__)
 
 static inline uint32_t
 crc32_u8(uint8_t v, uint32_t hash) {


### PR DESCRIPTION
The x86 branch of the CRC-32C selection relies on a 64-bit-only intrinsic, so a 32-bit x86 build entered that branch and died on an implicit declaration plus an undefined symbol at link time, instead of the clear unsupported-architecture error the fallback branch was written to give.

Nothing in this project builds for 32-bit x86, so this is a correctness-of-intent fix rather than a live bug.

Verified as a no-op on both supported architectures: the emitted text section is byte-identical before and after on x86-64 and on aarch64, and the golden-vector test passes on both. A 32-bit compile now stops at the intended unsupported-architecture error.