### PR TITLE
feat(nat64,fwstate,route): add -4/-6 short aliases for address-family flags

### DIFF
--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -138,7 +138,7 @@ pub struct EntriesCmd {
     pub config_name: String,
 
     /// Use IPv6 map instead of IPv4
-    #[arg(long)]
+    #[arg(long, short = '6')]
     pub ipv6: bool,
 
     /// Layer index to iterate (0 = active layer)

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -829,3 +829,13 @@ fn config_candidates() -> Vec<CompletionCandidate> {
         async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
     )
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cmd_is_valid() {
+        Cmd::command().debug_assert();
+    }
+}

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -121,10 +121,10 @@ pub struct AddMappingCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// IPv4 address (4 bytes).
-    #[arg(long)]
+    #[arg(long, short = '4')]
     pub ipv4: Ipv4Addr,
     /// IPv6 address (16 bytes).
-    #[arg(long)]
+    #[arg(long, short = '6')]
     pub ipv6: Ipv6Addr,
     /// Index of the prefix to use.
     #[arg(long)]
@@ -137,7 +137,7 @@ pub struct RemoveMappingCmd {
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
     pub config_name: String,
     /// IPv4 address (4 bytes).
-    #[arg(long)]
+    #[arg(long, short = '4')]
     pub ipv4: Ipv4Addr,
 }
 
@@ -460,4 +460,14 @@ fn config_candidates() -> Vec<CompletionCandidate> {
         },
         async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
     )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cmd_is_valid() {
+        Cmd::command().debug_assert();
+    }
 }

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -137,10 +137,10 @@ pub struct FibUpdateCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct FibShowCmd {
     /// Show only IPv4 FIB entries.
-    #[arg(long)]
+    #[arg(long, short = '4')]
     pub ipv4: bool,
     /// Show only IPv6 FIB entries.
-    #[arg(long)]
+    #[arg(long, short = '6')]
     pub ipv6: bool,
     /// Route config name.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
@@ -267,5 +267,15 @@ impl RouteService {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn cmd_is_valid() {
+        Cmd::command().debug_assert();
     }
 }

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -81,10 +81,10 @@ pub enum ModeCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RouteShowCmd {
     /// Show only IPv4 routes.
-    #[arg(long)]
+    #[arg(long, short = '4')]
     pub ipv4: bool,
     /// Show only IPv6 routes.
-    #[arg(long)]
+    #[arg(long, short = '6')]
     pub ipv6: bool,
     /// Configuration name.
     #[arg(long = "name", short = 'n', add = ArgValueCandidates::new(config_candidates))]
@@ -771,5 +771,10 @@ mod test {
 
         assert_eq!(2, entries[0].prefix.2);
         assert_eq!(2, entries[1].prefix.2);
+    }
+
+    #[test]
+    fn cmd_is_valid() {
+        Cmd::command().debug_assert();
     }
 }


### PR DESCRIPTION
Every address-family option across the module and operator CLIs now accepts a single-character alias alongside its long form, matching what users expect from common networking tools.

The long forms are untouched, so existing scripts, functional tests and documentation stay valid. This is a strict widening of accepted input: the digit shorts were previously a hard parse error, so no command line that worked before changes meaning.

Each affected CLI also gains a parser-validity test. A short-flag collision is reported only under debug assertions and is silent in a release binary, so until now nothing guarded against one. The tests were confirmed to fail when a real collision is injected.

The MTU options in the address-translation CLI keep long forms only, since they are distinct options rather than address-family selectors.