### PR TITLE
refactor(metrics): hoist duplicated proto metric constructors into commonpb

### DIFF
--- a/common/commonpb/v1/metrics.go
+++ b/common/commonpb/v1/metrics.go
@@ -81,3 +81,29 @@ func MetricRefsToProto[T metrics.Counter | metrics.Gauge | metrics.Histogram](
 	}
 	return res
 }
+
+// NewMetricCounter builds a Metric carrying a Counter value.
+func NewMetricCounter(name string, value uint64, labels ...*Label) *Metric {
+	return &Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &Metric_Counter{Counter: value},
+	}
+}
+
+// NewMetricGauge builds a Metric carrying a Gauge value.
+func NewMetricGauge(name string, value float64, labels ...*Label) *Metric {
+	return &Metric{
+		Name:   name,
+		Labels: labels,
+		Value:  &Metric_Gauge{Gauge: value},
+	}
+}
+
+// NewLabel builds a Label from a name/value pair.
+func NewLabel(name, value string) *Label {
+	return &Label{
+		Name:  name,
+		Value: value,
+	}
+}

--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -281,7 +281,7 @@ func portMetrics(ports []ffi.PortGroup) []*commonpb.Metric {
 	for _, port := range ports {
 		portID := strconv.FormatUint(uint64(port.PortID), 10)
 		for _, counter := range port.Counters {
-			metrics = append(metrics, makeCounter(
+			metrics = append(metrics, commonpb.NewMetricCounter(
 				"yanet_port_counter_value",
 				counter.Value,
 				&commonpb.Label{Name: "port_id", Value: portID},
@@ -304,16 +304,16 @@ func workerMetrics(workers []ffi.WorkerCounter) []*commonpb.Metric {
 		}
 
 		metrics = append(metrics,
-			makeCounter("yanet_worker_iterations", worker.Iterations, labels...),
-			makeCounter("yanet_worker_rx_packets", worker.RxPackets, labels...),
-			makeCounter("yanet_worker_rx_bytes", worker.RxBytes, labels...),
-			makeCounter("yanet_worker_tx_packets", worker.TxPackets, labels...),
-			makeCounter("yanet_worker_tx_bytes", worker.TxBytes, labels...),
-			makeCounter("yanet_worker_remote_rx_packets", worker.RemoteRxPackets, labels...),
-			makeCounter("yanet_worker_remote_tx_packets", worker.RemoteTxPackets, labels...),
-			makeCounter("yanet_worker_local_tx_drops", worker.LocalTxDrops, labels...),
-			makeCounter("yanet_worker_remote_tx_drops", worker.RemoteTxDrops, labels...),
-			makeCounter("yanet_worker_drops", worker.Drops, labels...),
+			commonpb.NewMetricCounter("yanet_worker_iterations", worker.Iterations, labels...),
+			commonpb.NewMetricCounter("yanet_worker_rx_packets", worker.RxPackets, labels...),
+			commonpb.NewMetricCounter("yanet_worker_rx_bytes", worker.RxBytes, labels...),
+			commonpb.NewMetricCounter("yanet_worker_tx_packets", worker.TxPackets, labels...),
+			commonpb.NewMetricCounter("yanet_worker_tx_bytes", worker.TxBytes, labels...),
+			commonpb.NewMetricCounter("yanet_worker_remote_rx_packets", worker.RemoteRxPackets, labels...),
+			commonpb.NewMetricCounter("yanet_worker_remote_tx_packets", worker.RemoteTxPackets, labels...),
+			commonpb.NewMetricCounter("yanet_worker_local_tx_drops", worker.LocalTxDrops, labels...),
+			commonpb.NewMetricCounter("yanet_worker_remote_tx_drops", worker.RemoteTxDrops, labels...),
+			commonpb.NewMetricCounter("yanet_worker_drops", worker.Drops, labels...),
 		)
 
 		if len(worker.RxBursts) > 0 {
@@ -325,14 +325,6 @@ func workerMetrics(workers []ffi.WorkerCounter) []*commonpb.Metric {
 		}
 	}
 	return metrics
-}
-
-func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Counter{Counter: value},
-	}
 }
 
 // makeHistogram builds a histogram metric from a slice of raw per-bucket

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -37,22 +37,6 @@ func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetric
 	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
-func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Gauge{Gauge: value},
-	}
-}
-
-func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Counter{Counter: value},
-	}
-}
-
 // aclStructuralCounters lists the fixed ACL counters whose metrics carry no
 // "counter" label.
 //
@@ -151,48 +135,48 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 			switch counter.Name {
 			case "acl_no_match":
 				result = append(result,
-					makeCounter("acl_no_match_packets", packets, baseLabels...),
-					makeCounter("acl_no_match_bytes", bytes, baseLabels...),
+					commonpb.NewMetricCounter("acl_no_match_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_no_match_bytes", bytes, baseLabels...),
 				)
 			case "acl_action_allow":
 				result = append(result,
-					makeCounter("acl_action_allow_packets", packets, baseLabels...),
-					makeCounter("acl_action_allow_bytes", bytes, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_allow_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_allow_bytes", bytes, baseLabels...),
 				)
 			case "acl_action_deny":
 				result = append(result,
-					makeCounter("acl_action_deny_packets", packets, baseLabels...),
-					makeCounter("acl_action_deny_bytes", bytes, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_deny_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_deny_bytes", bytes, baseLabels...),
 				)
 			case "acl_action_count":
 				result = append(result,
-					makeCounter("acl_action_count_packets", packets, baseLabels...),
-					makeCounter("acl_action_count_bytes", bytes, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_count_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_count_bytes", bytes, baseLabels...),
 				)
 			case "acl_action_check_state":
 				result = append(result,
-					makeCounter("acl_action_check_state_packets", packets, baseLabels...),
-					makeCounter("acl_action_check_state_bytes", bytes, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_check_state_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_check_state_bytes", bytes, baseLabels...),
 				)
 			case "acl_action_create_state":
 				result = append(result,
-					makeCounter("acl_action_create_state_packets", packets, baseLabels...),
-					makeCounter("acl_action_create_state_bytes", bytes, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_create_state_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_create_state_bytes", bytes, baseLabels...),
 				)
 			case "acl_action_unknown":
 				result = append(result,
-					makeCounter("acl_action_unknown_packets", packets, baseLabels...),
-					makeCounter("acl_action_unknown_bytes", bytes, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_unknown_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_action_unknown_bytes", bytes, baseLabels...),
 				)
 			case "acl_state_miss":
 				result = append(result,
-					makeCounter("acl_state_miss_packets", packets, baseLabels...),
-					makeCounter("acl_state_miss_bytes", bytes, baseLabels...),
+					commonpb.NewMetricCounter("acl_state_miss_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_state_miss_bytes", bytes, baseLabels...),
 				)
 			case "acl_sync_sent":
 				result = append(result,
-					makeCounter("acl_sync_sent_packets", packets, baseLabels...),
-					makeCounter("acl_sync_sent_bytes", bytes, baseLabels...),
+					commonpb.NewMetricCounter("acl_sync_sent_packets", packets, baseLabels...),
+					commonpb.NewMetricCounter("acl_sync_sent_bytes", bytes, baseLabels...),
 				)
 			default:
 				ruleLabels := append(
@@ -200,8 +184,8 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 					&commonpb.Label{Name: "counter", Value: counter.Name},
 				)
 				result = append(result,
-					makeCounter("acl_rule_packets", packets, ruleLabels...),
-					makeCounter("acl_rule_bytes", bytes, ruleLabels...),
+					commonpb.NewMetricCounter("acl_rule_packets", packets, ruleLabels...),
+					commonpb.NewMetricCounter("acl_rule_bytes", bytes, ruleLabels...),
 				)
 			}
 		}
@@ -216,31 +200,31 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 			if info, ok := snapshot.configInfo(configName); ok {
 				result = append(
 					result,
-					makeGauge(
+					commonpb.NewMetricGauge(
 						"acl_compilation_time_ns",
 						float64(info.CompilationTimeNs),
 						configLabels...),
-					makeGauge(
+					commonpb.NewMetricGauge(
 						"acl_filter_rule_count_vlan",
 						float64(info.FilterRuleCountVlan),
 						configLabels...),
-					makeGauge(
+					commonpb.NewMetricGauge(
 						"acl_filter_rule_count_ip4",
 						float64(info.FilterRuleCountIp4),
 						configLabels...),
-					makeGauge(
+					commonpb.NewMetricGauge(
 						"acl_filter_rule_count_ip4_port",
 						float64(info.FilterRuleCountIp4Port),
 						configLabels...),
-					makeGauge(
+					commonpb.NewMetricGauge(
 						"acl_filter_rule_count_ip6",
 						float64(info.FilterRuleCountIp6),
 						configLabels...),
-					makeGauge(
+					commonpb.NewMetricGauge(
 						"acl_filter_rule_count_ip6_port",
 						float64(info.FilterRuleCountIp6Port),
 						configLabels...),
-					makeGauge("acl_memory_bytes", float64(m.backend.MemoryBytes()), configLabels...),
+					commonpb.NewMetricGauge("acl_memory_bytes", float64(m.backend.MemoryBytes()), configLabels...),
 				)
 			}
 		}

--- a/modules/forward/controlplane/metrics.go
+++ b/modules/forward/controlplane/metrics.go
@@ -36,15 +36,6 @@ func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetric
 	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
-// makeCounter builds a counter metric with the provided name, value, and labels.
-func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Counter{Counter: value},
-	}
-}
-
 // Metrics returns Forward per-rule metrics matching tags, collected from the
 // dataplane.
 func (m *ForwardService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
@@ -97,8 +88,8 @@ func (m *ForwardService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]
 			}
 
 			result = append(result,
-				makeCounter("forward_rule_packets", packets, labels...),
-				makeCounter("forward_rule_bytes", bytes, labels...),
+				commonpb.NewMetricCounter("forward_rule_packets", packets, labels...),
+				commonpb.NewMetricCounter("forward_rule_bytes", bytes, labels...),
 			)
 		}
 	}

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -41,22 +41,6 @@ func (m *MetricsService) GetMetrics(
 	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
-func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Gauge{Gauge: value},
-	}
-}
-
-func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Counter{Counter: value},
-	}
-}
-
 // fwstateStructuralCounters lists the fixed fwstate counters whose metrics
 // carry no "counter" label.
 //
@@ -210,13 +194,13 @@ func emitCounterMetrics(counter ffi.CounterInfo, baseLabels []*commonpb.Label) [
 	switch counter.Name {
 	case "fwstate_sync":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_sync_packets", packets, baseLabels...),
-			makeCounter("fwstate_sync_bytes", bytes, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_sync_packets", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_sync_bytes", bytes, baseLabels...),
 		}
 	case "fwstate_passthrough":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_passthrough_packets", packets, baseLabels...),
-			makeCounter("fwstate_passthrough_bytes", bytes, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_passthrough_packets", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_passthrough_bytes", bytes, baseLabels...),
 		}
 	// The *_inserted / *_insert_failed counters track state-table
 	// entries (sync frames), not packets: a single sync packet
@@ -225,41 +209,41 @@ func emitCounterMetrics(counter ffi.CounterInfo, baseLabels []*commonpb.Label) [
 	// under a packet/byte column.
 	case "fwstate_sync_v4_inserted":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_sync_v4_inserted_entries", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_sync_v4_inserted_entries", packets, baseLabels...),
 		}
 	case "fwstate_sync_v6_inserted":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_sync_v6_inserted_entries", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_sync_v6_inserted_entries", packets, baseLabels...),
 		}
 	case "fwstate_sync_v4_insert_failed":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_sync_v4_insert_failed_entries", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_sync_v4_insert_failed_entries", packets, baseLabels...),
 		}
 	case "fwstate_sync_v6_insert_failed":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_sync_v6_insert_failed_entries", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_sync_v6_insert_failed_entries", packets, baseLabels...),
 		}
 	case "fwstate_external_dropped":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_external_dropped_packets", packets, baseLabels...),
-			makeCounter("fwstate_external_dropped_bytes", bytes, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_external_dropped_packets", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_external_dropped_bytes", bytes, baseLabels...),
 		}
 	case "fwstate_internal_forwarded":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_internal_forwarded_packets", packets, baseLabels...),
-			makeCounter("fwstate_internal_forwarded_bytes", bytes, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_internal_forwarded_packets", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_internal_forwarded_bytes", bytes, baseLabels...),
 		}
 	// Generic per-module counters registered by cp_module_init for every
 	// module.
 	case "rx":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_rx_packets", packets, baseLabels...),
-			makeCounter("fwstate_rx_bytes", bytes, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_rx_packets", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_rx_bytes", bytes, baseLabels...),
 		}
 	case "tx":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_tx_packets", packets, baseLabels...),
-			makeCounter("fwstate_tx_bytes", bytes, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_tx_packets", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_tx_bytes", bytes, baseLabels...),
 		}
 	// drop counts packets the module dropped itself. For fwstate this is
 	// meaningful: external sync packets are dropped when they cannot be
@@ -267,18 +251,18 @@ func emitCounterMetrics(counter ffi.CounterInfo, baseLabels []*commonpb.Label) [
 	// falling through to the generic arm.
 	case "drop":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_drop_packets", packets, baseLabels...),
-			makeCounter("fwstate_drop_bytes", bytes, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_drop_packets", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_drop_bytes", bytes, baseLabels...),
 		}
 	case "pending_input":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_pending_input_packets", packets, baseLabels...),
-			makeCounter("fwstate_pending_input_bytes", bytes, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_pending_input_packets", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_pending_input_bytes", bytes, baseLabels...),
 		}
 	case "pending_output":
 		return []*commonpb.Metric{
-			makeCounter("fwstate_pending_output_packets", packets, baseLabels...),
-			makeCounter("fwstate_pending_output_bytes", bytes, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_pending_output_packets", packets, baseLabels...),
+			commonpb.NewMetricCounter("fwstate_pending_output_bytes", bytes, baseLabels...),
 		}
 	case "hist_0", "hist_1", "hist_2", "hist_3", "hist_4", "hist_5":
 		// TODO: handle
@@ -292,8 +276,8 @@ func emitCounterMetrics(counter ffi.CounterInfo, baseLabels []*commonpb.Label) [
 			&commonpb.Label{Name: "counter", Value: counter.Name},
 		)
 		return []*commonpb.Metric{
-			makeCounter("fwstate_counter_packets", packets, counterLabels...),
-			makeCounter("fwstate_counter_bytes", bytes, counterLabels...),
+			commonpb.NewMetricCounter("fwstate_counter_packets", packets, counterLabels...),
+			commonpb.NewMetricCounter("fwstate_counter_bytes", bytes, counterLabels...),
 		}
 	}
 }
@@ -315,13 +299,13 @@ func collectMapStatsForAF(configName, af string, now time.Time, stats mapStats) 
 	}
 
 	return []*commonpb.Metric{
-		makeGauge("fwstate_index_size", float64(stats.IndexSize), labels...),
-		makeGauge("fwstate_extra_bucket_count", float64(stats.ExtraBucketCount), labels...),
-		makeGauge("fwstate_max_chain_length", float64(stats.MaxChainLength), labels...),
-		makeGauge("fwstate_layer_count", float64(stats.LayerCount), labels...),
-		makeGauge("fwstate_total_elements", float64(stats.TotalElements), labels...),
-		makeGauge("fwstate_max_deadline_ns", float64(deadlineTTL), labels...),
-		makeGauge("fwstate_memory_bytes", float64(stats.MemoryUsed), labels...),
+		commonpb.NewMetricGauge("fwstate_index_size", float64(stats.IndexSize), labels...),
+		commonpb.NewMetricGauge("fwstate_extra_bucket_count", float64(stats.ExtraBucketCount), labels...),
+		commonpb.NewMetricGauge("fwstate_max_chain_length", float64(stats.MaxChainLength), labels...),
+		commonpb.NewMetricGauge("fwstate_layer_count", float64(stats.LayerCount), labels...),
+		commonpb.NewMetricGauge("fwstate_total_elements", float64(stats.TotalElements), labels...),
+		commonpb.NewMetricGauge("fwstate_max_deadline_ns", float64(deadlineTTL), labels...),
+		commonpb.NewMetricGauge("fwstate_memory_bytes", float64(stats.MemoryUsed), labels...),
 	}
 }
 

--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -38,23 +38,6 @@ func (m *MetricsService) GetMetrics(ctx context.Context, req *commonpb.GetMetric
 	return &commonpb.GetMetricsResponse{Metrics: all}, nil
 }
 
-func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Gauge{Gauge: value},
-	}
-}
-
-// makeCounter builds a counter metric with the provided name, value, and labels.
-func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Counter{Counter: value},
-	}
-}
-
 // counterMapping projects one route dataplane counter onto the metric family
 // that carries it.
 type counterMapping struct {
@@ -149,8 +132,8 @@ func (m *RouteService) collectDataplaneMetrics(tags []*commonpb.MetricTag) []*co
 			}
 
 			result = append(result,
-				makeCounter(mapping.Metric+"_packets", packets, labels...),
-				makeCounter(mapping.Metric+"_bytes", bytes, labels...),
+				commonpb.NewMetricCounter(mapping.Metric+"_packets", packets, labels...),
+				commonpb.NewMetricCounter(mapping.Metric+"_bytes", bytes, labels...),
 			)
 		}
 	}

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -330,10 +330,10 @@ func (m *RouteService) collectConfigMetrics() []*commonpb.Metric {
 		}
 
 		result = append(result,
-			makeGauge("route_fib_entries", float64(entry.FIBRangeCountV4), v4Labels...),
-			makeGauge("route_fib_entries", float64(entry.FIBRangeCountV6), v6Labels...),
-			makeGauge("route_nexthops", float64(entry.NexthopCount), configLabels...),
-			makeGauge(
+			commonpb.NewMetricGauge("route_fib_entries", float64(entry.FIBRangeCountV4), v4Labels...),
+			commonpb.NewMetricGauge("route_fib_entries", float64(entry.FIBRangeCountV6), v6Labels...),
+			commonpb.NewMetricGauge("route_nexthops", float64(entry.NexthopCount), configLabels...),
+			commonpb.NewMetricGauge(
 				"route_config_updated_timestamp_seconds",
 				float64(entry.UpdatedAt.Unix()),
 				configLabels...,

--- a/operators/pipeline/internal/operator/metrics.go
+++ b/operators/pipeline/internal/operator/metrics.go
@@ -83,31 +83,31 @@ func (m *Metrics) OnStateChanged(state operator.ReconcilerState) {
 func (m *Metrics) Collect() []*commonpb.Metric {
 	out := make([]*commonpb.Metric, 0)
 
-	out = append(out, makeCounter(
+	out = append(out, commonpb.NewMetricCounter(
 		"pipeline_operator_reconcile_total",
 		m.reconcileTotal.Load(),
 	))
-	out = append(out, makeCounter(
+	out = append(out, commonpb.NewMetricCounter(
 		"pipeline_operator_reconcile_errors_total",
 		m.reconcileErrors.Load(),
 	))
-	out = append(out, makeCounter(
+	out = append(out, commonpb.NewMetricCounter(
 		"pipeline_operator_stage_advance_total",
 		m.stageAdvance.Load(),
 	))
 
 	for state, g := range m.states {
-		out = append(out, makeGauge(
+		out = append(out, commonpb.NewMetricGauge(
 			"pipeline_operator_state",
 			g.Load(),
-			makeLabel("state", reconcilerStateNames[state]),
+			commonpb.NewLabel("state", reconcilerStateNames[state]),
 		))
 	}
-	out = append(out, makeGauge(
+	out = append(out, commonpb.NewMetricGauge(
 		"pipeline_operator_queue_depth",
 		m.queueDepth.Load(),
 	))
-	out = append(out, makeGauge(
+	out = append(out, commonpb.NewMetricGauge(
 		"pipeline_operator_backoff_seconds",
 		m.backoffSeconds.Load(),
 	))
@@ -189,68 +189,48 @@ func (m *GatewayMetrics) OnGC(deleted, failed int, err error) {
 // Collect renders the current state of this gateway's metrics as a
 // []*commonpb.Metric.
 func (m *GatewayMetrics) Collect() []*commonpb.Metric {
-	gw := makeLabel("gateway", m.name)
+	gw := commonpb.NewLabel("gateway", m.name)
 	out := make([]*commonpb.Metric, 0)
 
-	out = append(out, makeCounter(
+	out = append(out, commonpb.NewMetricCounter(
 		"pipeline_operator_gateway_apply_total",
 		m.apply.Load(),
 		gw,
 	))
-	out = append(out, makeCounter(
+	out = append(out, commonpb.NewMetricCounter(
 		"pipeline_operator_gateway_apply_errors_total",
 		m.applyErrors.Load(),
 		gw,
 	))
 
 	for kind, c := range m.resourceUpdate {
-		out = append(out, makeCounter(
+		out = append(out, commonpb.NewMetricCounter(
 			"pipeline_operator_resource_update_total",
 			c.Load(),
-			gw, makeLabel("kind", kind),
+			gw, commonpb.NewLabel("kind", kind),
 		))
 	}
 	for kind, c := range m.resourceUpdateErrors {
-		out = append(out, makeCounter(
+		out = append(out, commonpb.NewMetricCounter(
 			"pipeline_operator_resource_update_errors_total",
 			c.Load(),
-			gw, makeLabel("kind", kind),
+			gw, commonpb.NewLabel("kind", kind),
 		))
 	}
 
 	out = append(out,
-		makeCounter("pipeline_operator_gc_runs_total", m.gcRuns.Load(), gw),
-		makeCounter("pipeline_operator_gc_errors_total", m.gcErrors.Load(), gw),
-		makeCounter(
+		commonpb.NewMetricCounter("pipeline_operator_gc_runs_total", m.gcRuns.Load(), gw),
+		commonpb.NewMetricCounter("pipeline_operator_gc_errors_total", m.gcErrors.Load(), gw),
+		commonpb.NewMetricCounter(
 			"pipeline_operator_gc_pipelines_deleted_total",
 			m.gcDeleted.Load(),
 			gw,
 		),
-		makeCounter(
+		commonpb.NewMetricCounter(
 			"pipeline_operator_gc_pipelines_delete_errors_total",
 			m.gcDeleteErrors.Load(),
 			gw,
 		),
 	)
 	return out
-}
-
-func makeLabel(name, value string) *commonpb.Label {
-	return &commonpb.Label{Name: name, Value: value}
-}
-
-func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Counter{Counter: value},
-	}
-}
-
-func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Gauge{Gauge: value},
-	}
 }

--- a/operators/route/internal/operator/metrics.go
+++ b/operators/route/internal/operator/metrics.go
@@ -210,25 +210,25 @@ func (m *Metrics) Collect() []*commonpb.Metric {
 	out := make([]*commonpb.Metric, 0)
 
 	out = append(out,
-		makeCounter("route_operator_reconcile_total", m.reconcileTotal.Load()),
-		makeCounter("route_operator_reconcile_errors_total", m.reconcileErrors.Load()),
-		makeGauge("route_operator_backoff_seconds", m.backoffSeconds.Load()),
+		commonpb.NewMetricCounter("route_operator_reconcile_total", m.reconcileTotal.Load()),
+		commonpb.NewMetricCounter("route_operator_reconcile_errors_total", m.reconcileErrors.Load()),
+		commonpb.NewMetricGauge("route_operator_backoff_seconds", m.backoffSeconds.Load()),
 	)
 	for state, g := range m.states {
-		out = append(out, makeGauge(
+		out = append(out, commonpb.NewMetricGauge(
 			"route_operator_state",
 			g.Load(),
-			makeLabel("state", reconcilerStateNames[state]),
+			commonpb.NewLabel("state", reconcilerStateNames[state]),
 		))
 	}
 
 	for name, ribRef := range m.ribs.Snapshot() {
 		stats := ribRef.Stats()
-		module := makeLabel("module", name)
+		module := commonpb.NewLabel("module", name)
 		out = append(out,
-			makeGauge("route_operator_rib_prefixes", float64(stats.Prefixes), module),
-			makeGauge("route_operator_rib_routes", float64(stats.Routes), module),
-			makeGauge(
+			commonpb.NewMetricGauge("route_operator_rib_prefixes", float64(stats.Prefixes), module),
+			commonpb.NewMetricGauge("route_operator_rib_routes", float64(stats.Routes), module),
+			commonpb.NewMetricGauge(
 				"route_operator_rib_last_change_timestamp_seconds",
 				float64(stats.ChangedAt.Unix()),
 				module,
@@ -237,36 +237,36 @@ func (m *Metrics) Collect() []*commonpb.Metric {
 	}
 
 	for _, src := range m.neighTable.ListSources() {
-		out = append(out, makeGauge(
+		out = append(out, commonpb.NewMetricGauge(
 			"route_operator_neighbour_entries",
 			float64(src.EntryCount),
-			makeLabel("table", src.Name),
+			commonpb.NewLabel("table", src.Name),
 		))
 	}
 	_, nexthops := m.neighTable.View().Entries()
-	out = append(out, makeGauge("route_operator_neighbour_nexthops", float64(nexthops)))
+	out = append(out, commonpb.NewMetricGauge("route_operator_neighbour_nexthops", float64(nexthops)))
 
 	for _, entry := range m.ribSessionStarts.Metrics() {
-		out = append(out, makeCounter(
+		out = append(out, commonpb.NewMetricCounter(
 			"route_operator_rib_session_starts_total",
 			entry.Value.Load(),
-			makeLabel("module", entry.ID.Labels["module"]),
+			commonpb.NewLabel("module", entry.ID.Labels["module"]),
 		))
 	}
 	for _, entry := range m.ribSessionEnds.Metrics() {
-		out = append(out, makeCounter(
+		out = append(out, commonpb.NewMetricCounter(
 			"route_operator_rib_session_ends_total",
 			entry.Value.Load(),
-			makeLabel("module", entry.ID.Labels["module"]),
+			commonpb.NewLabel("module", entry.ID.Labels["module"]),
 		))
 	}
-	out = append(out, makeCounter("route_operator_rib_feed_updates_total", m.ribFeedUpdates.Load()))
+	out = append(out, commonpb.NewMetricCounter("route_operator_rib_feed_updates_total", m.ribFeedUpdates.Load()))
 
 	if m.netlinkMonitorEnabled {
 		out = append(out,
-			makeGauge("route_operator_neighbour_monitor_healthy", m.neighbourHealthy.Load()),
-			makeCounter("route_operator_neighbour_resyncs_total", m.neighbourResyncs.Load()),
-			makeCounter("route_operator_neighbour_syncs_total", m.neighbourSyncs.Load()),
+			commonpb.NewMetricGauge("route_operator_neighbour_monitor_healthy", m.neighbourHealthy.Load()),
+			commonpb.NewMetricCounter("route_operator_neighbour_resyncs_total", m.neighbourResyncs.Load()),
+			commonpb.NewMetricCounter("route_operator_neighbour_syncs_total", m.neighbourSyncs.Load()),
 		)
 	}
 
@@ -359,12 +359,12 @@ func (m *GatewayMetrics) OnFIBBuilt(module string, stats FIBBuildStats) {
 // Collect renders this gateway's metrics as a slice of commonpb.Metric
 // values.
 func (m *GatewayMetrics) Collect() []*commonpb.Metric {
-	gateway := makeLabel("gateway", m.name)
+	gateway := commonpb.NewLabel("gateway", m.name)
 	out := make([]*commonpb.Metric, 0)
 
 	out = append(out,
-		makeCounter("route_operator_gateway_apply_total", m.apply.Load(), gateway),
-		makeCounter("route_operator_gateway_apply_errors_total", m.applyErrors.Load(), gateway),
+		commonpb.NewMetricCounter("route_operator_gateway_apply_total", m.apply.Load(), gateway),
+		commonpb.NewMetricCounter("route_operator_gateway_apply_errors_total", m.applyErrors.Load(), gateway),
 		makeHistogram("route_operator_gateway_apply_duration_seconds", m.applyDuration, gateway),
 	)
 
@@ -372,37 +372,17 @@ func (m *GatewayMetrics) Collect() []*commonpb.Metric {
 	defer m.fibMu.Unlock()
 
 	for module, g := range m.fib {
-		labels := []*commonpb.Label{gateway, makeLabel("module", module)}
+		labels := []*commonpb.Label{gateway, commonpb.NewLabel("module", module)}
 		out = append(out,
-			makeGauge("route_operator_fib_entries", g.Entries.Load(), labels...),
-			makeGauge("route_operator_fib_routes", g.Routes.Load(), labels...),
-			makeGauge("route_operator_fib_unresolved_nexthops", g.UnresolvedNexthops.Load(), labels...),
-			makeGauge("route_operator_fib_skipped_prefixes", g.SkippedPrefixes.Load(), labels...),
-			makeGauge("route_operator_fib_filtered_routes", g.FilteredRoutes.Load(), labels...),
+			commonpb.NewMetricGauge("route_operator_fib_entries", g.Entries.Load(), labels...),
+			commonpb.NewMetricGauge("route_operator_fib_routes", g.Routes.Load(), labels...),
+			commonpb.NewMetricGauge("route_operator_fib_unresolved_nexthops", g.UnresolvedNexthops.Load(), labels...),
+			commonpb.NewMetricGauge("route_operator_fib_skipped_prefixes", g.SkippedPrefixes.Load(), labels...),
+			commonpb.NewMetricGauge("route_operator_fib_filtered_routes", g.FilteredRoutes.Load(), labels...),
 		)
 	}
 
 	return out
-}
-
-func makeLabel(name, value string) *commonpb.Label {
-	return &commonpb.Label{Name: name, Value: value}
-}
-
-func makeCounter(name string, value uint64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Counter{Counter: value},
-	}
-}
-
-func makeGauge(name string, value float64, labels ...*commonpb.Label) *commonpb.Metric {
-	return &commonpb.Metric{
-		Name:   name,
-		Labels: labels,
-		Value:  &commonpb.Metric_Gauge{Gauge: value},
-	}
 }
 
 func makeHistogram(name string, h *metrics.Histogram, labels ...*commonpb.Label) *commonpb.Metric {


### PR DESCRIPTION
Seven control-plane and operator packages each carried a byte-identical unexported constructor for a protobuf metric or label. The helpers now live once in the shared commonpb package, alongside the existing metric conversion helpers, and every call site uses them.

- Adds three constructors to the shared protobuf package, following its established naming pattern for message constructors.
- Removes the fourteen local copies across the ACL, forward, fwstate and route modules, the pipeline and route operators, and the built-in counters service.
- Migrates all one hundred twenty four call sites.

The change is purely mechanical: emitted metric names, values and labels are unchanged. The two remaining histogram helpers are deliberately left in place, since their signatures genuinely differ.