### PR TITLE
fix(metrics): ignore invalid NaN observations instead of panicking

### DIFF
--- a/common/go/metrics/histogram.go
+++ b/common/go/metrics/histogram.go
@@ -64,8 +64,19 @@ func NewHistogram(bounds []float64) *Histogram {
 }
 
 // Observe records a new value.
+//
+// NaN is treated as invalid input and dropped. No bucket accepts NaN, so an
+// unguarded search would return len(m.buckets) and the following index
+// expression would panic. NaN is deliberately not folded into the +Inf
+// catch-all bucket either, because that bucket feeds percentile estimation,
+// and a NaN counted there would inflate the reported p99.
+//
 // Complexity: O(log N) for search + O(1) for atomic write.
 func (m *Histogram) Observe(value float64) {
+	if math.IsNaN(value) {
+		return
+	}
+
 	idx := sort.Search(len(m.buckets), func(idx int) bool {
 		return m.buckets[idx].Accepts(value)
 	})

--- a/common/go/metrics/histogram_test.go
+++ b/common/go/metrics/histogram_test.go
@@ -129,6 +129,29 @@ func TestHistogramObserveEmptyBounds(t *testing.T) {
 	}
 }
 
+// TestHistogramObserveNaN verifies that a NaN observation is dropped
+// without panicking.
+//
+// The +Inf and -Inf assertions are a regression fence against a future
+// over-broad guard that rejects the infinities along with NaN.
+func TestHistogramObserveNaN(t *testing.T) {
+	h := metrics.NewHistogram([]float64{1, 5, 10})
+
+	before := h.Snapshot()
+	require.NotPanics(t, func() { h.Observe(math.NaN()) }, "observing NaN should not panic")
+	after := h.Snapshot()
+	assert.Equal(t, before, after, "NaN observation should not change any bucket count")
+
+	h.Observe(math.Inf(1))
+	snapshot := h.Snapshot()
+	assert.Equal(t, after[len(after)-1].Count+1, snapshot[len(snapshot)-1].Count, "+Inf should be recorded in the last bucket")
+
+	beforeNegativeInf := h.Snapshot()
+	h.Observe(math.Inf(-1))
+	snapshot = h.Snapshot()
+	assert.Equal(t, beforeNegativeInf[0].Count+1, snapshot[0].Count, "-Inf should be recorded in the first bucket")
+}
+
 func TestHistogramConcurrent(t *testing.T) {
 	h := metrics.NewHistogram([]float64{10, 50, 100})
 	var wg sync.WaitGroup


### PR DESCRIPTION
Observing a NaN value panicked the control plane with an out-of-range index. Every ordered comparison against NaN is false, so no bucket accepts it and the bucket search runs past the end of the slice.

A NaN is now treated as invalid input and dropped. It is deliberately not folded into the catch-all bucket instead: that bucket feeds percentile estimation, so a NaN parked there would inflate the reported tail latency.

The defect was latent rather than live. Both call sites observe a duration in seconds, which can never be NaN, so no production path could reach the panic — this closes the gap for future callers of a shared library.

Adds a regression test covering the dropped NaN, plus assertions that positive and negative infinity are still recorded, which fence against a future guard that over-rejects.