### PR TITLE
build(meson): drop the dead 32-bit x86 branch from the host arch checks

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ project(
 )
 
 yanet_project_args = ['-g', '-D_GNU_SOURCE']
-if host_machine.cpu_family() in ['x86', 'x86_64']
+if host_machine.cpu_family() == 'x86_64'
   yanet_project_args += '-march=' + get_option('cpu_arch')
 endif
 # The aarch64 branch appends its own ISA flag to yanet_project_args
@@ -135,7 +135,7 @@ libdpdk_default_options = [
   'werror=false',
   'c_args=-Wno-stringop-overflow -Wno-array-bounds -Wno-stringop-overread -Wno-vla-larger-than',
 ]
-if host_machine.cpu_family() in ['x86', 'x86_64']
+if host_machine.cpu_family() == 'x86_64'
   libdpdk_default_options += 'cpu_instruction_set=' + get_option('cpu_arch')
 endif
 


### PR DESCRIPTION
Both host architecture checks enumerated meson's 32-bit x86 family alongside 64-bit x86, but nothing in the project can build for a 32-bit x86 host — the CRC-32C helpers reject any host that is neither 64-bit x86 nor little-endian aarch64. The entry was an unreachable branch that misstated the supported host set.

Dropping it leaves both checks matching the shape of the aarch64 check below them.

No behavioural change: the generated build graph was diffed against a baseline configured from unmodified main and is byte-identical, across the project and the DPDK and libpcap subprojects alike.