### PR TITLE
fix(controlplane): gate loaded count on the first registry reference

### DIFF
--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -507,6 +507,11 @@ cp_device_registry_upsert(
 		return -1;
 	}
 
+	// Count the device only on its first registry reference, mirroring the
+	// 1->0 transition at which cp_device_registry_item_free_cb decrements;
+	// a re-upsert of an already-referenced instance must not double-count.
+	uint64_t refcnt_before = new_device->config_item.refcnt;
+
 	if (registry_replace(
 		    &device_registry->registry,
 		    cp_device_registry_item_cmp,
@@ -520,7 +525,7 @@ cp_device_registry_upsert(
 	}
 
 	struct agent *agent = ADDR_OF(&new_device->agent);
-	if (agent != NULL) {
+	if (agent != NULL && refcnt_before == 0) {
 		agent->loaded_device_count += 1;
 	}
 

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -383,6 +383,11 @@ cp_module_registry_upsert(
 		err
 	);
 
+	// Count the module only on its first registry reference, mirroring the
+	// 1->0 transition at which cp_module_registry_item_free_cb decrements;
+	// a re-upsert of an already-referenced instance must not double-count.
+	uint64_t refcnt_before = new_module->config_item.refcnt;
+
 	if (registry_replace(
 		    &module_registry->registry,
 		    cp_module_registry_item_cmp,
@@ -396,7 +401,7 @@ cp_module_registry_upsert(
 	}
 
 	struct agent *agent = ADDR_OF(&new_module->agent);
-	if (agent != NULL) {
+	if (agent != NULL && refcnt_before == 0) {
 		agent->loaded_module_count += 1;
 	}
 

--- a/lib/controlplane/tests/loaded_counts_test.c
+++ b/lib/controlplane/tests/loaded_counts_test.c
@@ -154,6 +154,63 @@ run_loaded_counts_test(struct yanet_shm *shm) {
 	return TEST_SUCCESS;
 }
 
+// Regression test for re-inserting the same device instance: the loaded
+// count must track first-reference (0->1) transitions, so upserting an
+// already-referenced instance a second time must not bump the count again.
+// Before the fix the upsert incremented unconditionally, which over-counted
+// and permanently blocked reclamation of the owning agent.
+static int
+run_reinsert_count_test(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm, 0, "reinsert-count", LOADED_COUNTS_TEST_MEMORY_LIMIT, &err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed for reinsert test");
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	struct cp_device_plain_config *cfg =
+		cp_device_plain_config_new("dev0", 0, 0, &err);
+	TEST_ASSERT_NOT_NULL(
+		cfg,
+		"device config new failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	struct cp_device *dev = cp_device_plain_new(agent, cfg, &err);
+	cp_device_plain_config_free(cfg);
+	TEST_ASSERT_NOT_NULL(dev, "device new failed");
+
+	// First install: the device gains its first reference (count 0->1).
+	struct cp_device *devs[] = {dev};
+	TEST_ASSERT_SUCCESS(
+		cp_config_update_devices(dp_config, cp_config, 1, devs, &err),
+		"first update_devices failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	TEST_ASSERT_EQUAL(
+		agent->loaded_device_count,
+		1,
+		"device count should be one after the first install"
+	);
+
+	// Re-insert the SAME pointer: it is already referenced, so the count
+	// must stay one. Before the fix this bumped it to two.
+	TEST_ASSERT_SUCCESS(
+		cp_config_update_devices(dp_config, cp_config, 1, devs, &err),
+		"second update_devices (same pointer) failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	TEST_ASSERT_EQUAL(
+		agent->loaded_device_count,
+		1,
+		"re-inserting the same device must not double-count"
+	);
+
+	return TEST_SUCCESS;
+}
+
 int
 main(void) {
 	log_enable_name("debug");
@@ -187,6 +244,9 @@ main(void) {
 	}
 
 	int res = run_loaded_counts_test(shm);
+	if (res == TEST_SUCCESS) {
+		res = run_reinsert_count_test(shm);
+	}
 
 	dataplane_ut_free(ut);
 


### PR DESCRIPTION
The module and device registry upserts bumped the owning agent loaded count on every call, but the matching decrement in the registry free callback fires only once per instance (refcount reaching zero). Re-inserting the same instance pointer — within one batch, across generations, same or different name — left the count permanently inflated, defeating the agent reclamation guard and leaking the agent's whole shared-memory arena for the process lifetime.

- Increment only on the instance refcount zero-to-one transition, mirroring the one-to-zero transition the free callback already gates on.
- Adds a reinsert regression case to `loaded_counts_test` (mutation-verified: fails with the unconditional increment, passes with the gate).

Closes #1569.