### PR TITLE
refactor(cli): unify empty-result output across every CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,6 +394,11 @@ Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` 
   too — e.g. if the message declares `nexthop_addrs` (tag 3) before
   `do_flush` (tag 4), the literal must place `nexthop_addrs` before
   `do_flush`, not append it last. `rustfmt`/`clippy` do not catch this.
+- **Empty CLI results**: report through `output::empty`/`empty_with_hint`,
+  never a bare `println!`/`eprintln!`. The primitive owns the `[–]`/`[-]`
+  stderr mark (greyed when colour is on), the `No <subject> found.`
+  (`for <scope>`) register, and suppression on a non-TTY stdout or a
+  serializing format — a call site never adds its own format guard.
 
 ### C
 

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -56,6 +56,18 @@ pub trait Output: Send + Sync {
     /// borrow rather than own — `|| &response.services` and a struct of
     /// borrowed slices are both valid shapes.
     fn data<'a>(&self, payload: &dyn Fn() -> Box<dyn ErasedSerialize + 'a>, render: Box<dyn FnOnce() + 'a>);
+
+    /// Returns `true` if this backend serializes rather than renders.
+    ///
+    /// [`empty`] and [`empty_with_hint`] consult this on the installed
+    /// backend to skip their report on a serializing backend, so a caller
+    /// outside a `data` render closure — a hand-rolled streaming command —
+    /// gets the same suppression a render-closure caller already gets for
+    /// free from [`JsonOutput::data`] never running `render`. Defaults to
+    /// `false`; [`JsonOutput`] overrides it.
+    fn serializes(&self) -> bool {
+        false
+    }
 }
 
 /// Human-readable output backend.
@@ -178,6 +190,10 @@ impl Output for JsonOutput {
 
         println!("{json}");
     }
+
+    fn serializes(&self) -> bool {
+        true
+    }
 }
 
 /// Common format set (`Human` + `Json`) ready to embed in a `clap::Args`.
@@ -238,9 +254,12 @@ pub fn failure(err: &Error) {
 /// runs only if the backend serializes, and `render` runs only if the
 /// backend produces free-form output.
 ///
-/// Call [`empty`] from inside `render` when the result is empty. A
-/// serializing backend never calls `render`, so that check cannot affect
-/// it, and an empty collection still serializes as-is.
+/// [`empty`] and [`empty_with_hint`] report an empty result and are
+/// ordinary functions, callable from anywhere — including a hand-rolled
+/// streaming command with no `render` closure at all. They consult
+/// [`Output::serializes`] on the installed backend themselves before
+/// printing, so a serializing backend never sees their report regardless of
+/// whether the caller sits inside a `data` render closure.
 pub fn data<P, MakePayload, Render>(make_payload: MakePayload, render: Render)
 where
     MakePayload: Fn() -> P,
@@ -254,11 +273,90 @@ where
 
 /// Reports an empty result.
 ///
-/// Writes to stderr rather than stdout, so `<cmd> | wc -l` still reads
-/// zero on an empty result — the message would otherwise show up as a
-/// bogus data line on the same channel the real rows print to.
+/// Suppressed when the installed backend serializes — see
+/// [`Output::serializes`] for why that check lives here rather than at
+/// each call site. Otherwise printed only when stdout is a terminal: a
+/// redirected or piped stdout signals a script rather than a human reading
+/// along, and a script gets nothing on either channel, matching the
+/// precedent set by `gh`.
+///
+/// Writes to stderr rather than stdout, matching the
+/// [`success`](Output::success)/[`failure`](Output::failure) implementations
+/// on [`HumanOutput`] — the only backend `empty` ever prints under: stdout
+/// stays reserved for the run's actual rows, so `cmd 2>/dev/null` silences
+/// this note along with every other status line instead of leaving a
+/// non-data line on stdout.
+///
+/// The whole line — mark and message alike — is greyed via [`dim`], unlike
+/// [`HumanOutput`]'s [`success`](Output::success)/[`failure`](Output::failure),
+/// which colour only the mark or the `hint:` label: here the whole line is
+/// a note about the absence of payload, not the payload itself.
 pub fn empty(message: Arguments) {
-    eprintln!("{message}");
+    if suppress_empty(current().serializes(), stdout_is_terminal()) {
+        return;
+    }
+
+    print_empty_line(&format!("{} {message}", empty_mark()));
+}
+
+/// Reports an empty result together with the command that would create one.
+///
+/// See [`empty`] for the suppression rules and colour rules. The hint line
+/// is indented four spaces and prefixed `hint:`, matching [`HumanOutput`]'s
+/// [`failure`](Output::failure) detail-line indent (`    endpoint:` /
+/// `    service:` / `    hint:`), but stays grey with the rest of the report
+/// rather than picking up its yellow `hint:` label.
+pub fn empty_with_hint(message: Arguments, hint: Arguments) {
+    if suppress_empty(current().serializes(), stdout_is_terminal()) {
+        return;
+    }
+
+    print_empty_line(&format!("{} {message}", empty_mark()));
+    print_empty_line(&format!("    hint: {hint}"));
+}
+
+/// Returns `true` if an empty-result report should be suppressed.
+///
+/// `serializes` is the installed backend's [`Output::serializes`] and
+/// `stdout_is_terminal` is the caller's [`stdout_is_terminal`] reading. Both
+/// are backed by a `OnceLock` — the installed `OUTPUT` and the memoized TTY
+/// check — so each is fixed for the life of a `cargo test` binary and can't
+/// be flipped per test case. Taking them as plain `bool`s instead lifts the
+/// suppression rule out as a pure predicate, letting every combination below
+/// be exercised directly with no real terminal or installed backend needed.
+fn suppress_empty(serializes: bool, stdout_is_terminal: bool) -> bool {
+    serializes || !stdout_is_terminal
+}
+
+/// Returns the mark prefixing an empty-result line.
+///
+/// The Unicode en dash when colour is enabled, an ASCII hyphen otherwise —
+/// a third mark joining the `[✓]`/`[OK]` and `[✗]`/`[ERR]` fallback pairs
+/// [`HumanOutput`]'s [`success`](Output::success)/[`failure`](Output::failure)
+/// already use.
+fn empty_mark() -> &'static str {
+    if is_colored() {
+        "[–]"
+    } else {
+        "[-]"
+    }
+}
+
+/// Writes one line of an empty-result report to stderr, greyed via
+/// [`dim`] when colour is enabled.
+fn print_empty_line(text: &str) {
+    eprintln!("{}", dim(text));
+}
+
+/// Returns `true` if stdout is a terminal, memoized on first call.
+///
+/// This is the print gate for [`empty`] and [`empty_with_hint`], and is
+/// deliberately independent of [`is_colored`], which reads *stderr* and
+/// also folds in `NO_COLOR` — reusing it here would make `NO_COLOR=1`
+/// suppress the message outright instead of just its colour.
+fn stdout_is_terminal() -> bool {
+    static STDOUT_TTY: OnceLock<bool> = OnceLock::new();
+    *STDOUT_TTY.get_or_init(|| std::io::stdout().is_terminal())
 }
 
 /// Returns `true` if ANSI color and Unicode prefixes should be emitted.
@@ -325,4 +423,78 @@ struct ErrorDetailJson<'a> {
     endpoint: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     service: Option<&'a str>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Set on the re-invoked child process to select the direct-call branch
+    /// below, instead of re-spawning itself again.
+    const REEXEC_ENV: &str = "YANET_CLI_OUTPUT_EMPTY_REEXEC";
+
+    /// `empty`/`empty_with_hint` write nothing to either channel when
+    /// stdout is not a terminal.
+    ///
+    /// `cargo test` intercepts `print!`/`eprint!` above the OS file
+    /// descriptor, so a plain in-process call proves nothing about the
+    /// real bytes. This re-invokes the test binary as a child process: with
+    /// `--nocapture` the child's real stdout/stderr reach the pipes
+    /// `Command::output` captures, and those pipes make stdout a non-TTY by
+    /// construction, exercising exactly the gate under test. The child's
+    /// stdout still carries the test harness's own "running 1 test" /
+    /// "test result: …" banner, unrelated to the function under test, so
+    /// stderr — which the harness never writes to on a passing run — is
+    /// the channel that proves the gate; stdout is checked only for the
+    /// absence of the message text itself.
+    ///
+    /// The `--exact` filter is a literal copy of this test's own path, so a
+    /// rename of the function or of `mod test` would make it match nothing
+    /// and the child would exit successfully having run zero tests — every
+    /// assertion below stays green regardless of the gate. The "running 1
+    /// test" check is the positive control that catches that: it fails
+    /// unless the filter actually selected this one test.
+    #[test]
+    fn empty_writes_nothing_when_stdout_is_not_a_tty() {
+        const MESSAGE: &str = "no widgets found";
+        const HINT: &str = "create one with 'widget create'";
+
+        if std::env::var_os(REEXEC_ENV).is_some() {
+            init(0, CommonFormat::Human);
+            empty(format_args!("{MESSAGE}"));
+            empty_with_hint(format_args!("{MESSAGE}"), format_args!("{HINT}"));
+            return;
+        }
+
+        let exe = std::env::current_exe().expect("test binary path");
+        let output = std::process::Command::new(exe)
+            .args([
+                "--exact",
+                "output::test::empty_writes_nothing_when_stdout_is_not_a_tty",
+                "--nocapture",
+            ])
+            .env(REEXEC_ENV, "1")
+            .output()
+            .expect("failed to re-invoke the test binary");
+
+        assert!(output.status.success());
+        assert!(output.stderr.is_empty());
+
+        let stdout = String::from_utf8(output.stdout).expect("child stdout must be UTF-8");
+        assert!(stdout.contains("running 1 test"));
+        assert!(!stdout.contains(MESSAGE));
+        assert!(!stdout.contains(HINT));
+    }
+
+    #[test]
+    fn suppress_empty_is_true_for_a_serializing_backend_even_on_a_terminal() {
+        assert!(suppress_empty(true, true));
+    }
+
+    #[test]
+    fn suppress_empty_is_false_only_for_a_non_serializing_backend_on_a_terminal() {
+        assert!(!suppress_empty(false, true));
+        assert!(suppress_empty(false, false));
+        assert!(suppress_empty(true, false));
+    }
 }

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -486,7 +486,7 @@ impl From<&WorkerCounter> for WorkerRow {
 /// histograms.
 fn format_worker_counters(response: &WorkerCountersResponse) {
     if response.workers.is_empty() {
-        println!("no worker counters");
+        output::empty(format_args!("No worker counters found."));
         return;
     }
 

--- a/cli/modules/device/src/main.rs
+++ b/cli/modules/device/src/main.rs
@@ -89,7 +89,7 @@ impl DeviceService {
 
 fn render(response: &ListDevicesResponse) {
     if response.ids.is_empty() {
-        println!("{}", "No devices configured".yellow());
+        output::empty(format_args!("No devices found."));
         return;
     }
 

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -99,7 +99,7 @@ impl GatewayService {
                 let rows: Vec<ServiceRow> = response.services.iter().map(ServiceRow::from).collect();
 
                 if rows.is_empty() {
-                    output::empty(format_args!("no services registered"));
+                    output::empty(format_args!("No services registered."));
                     return;
                 }
 

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -184,7 +184,7 @@ async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) ->
         || &response.metrics,
         || {
             if response.metrics.is_empty() {
-                output::empty(format_args!("no metrics"));
+                output::empty(format_args!("No metrics found for {name}."));
                 return;
             }
 

--- a/cli/modules/ready/src/main.rs
+++ b/cli/modules/ready/src/main.rs
@@ -223,7 +223,7 @@ async fn run_once(cmd: &Cmd, connection: &Connection, name: &str) -> Result<bool
         || &response.scopes,
         || {
             if response.scopes.is_empty() && missing.is_empty() {
-                output::empty(format_args!("no scopes"));
+                output::empty(format_args!("No scopes found for {name}."));
                 return;
             }
 
@@ -263,7 +263,7 @@ async fn run_watch(cmd: &Cmd, name: &str) -> Result<(), Error> {
                 || &resp.scopes,
                 || {
                     if resp.scopes.is_empty() {
-                        output::empty(format_args!("no scopes"));
+                        output::empty(format_args!("No scopes found for {name}."));
                         return;
                     }
 
@@ -328,7 +328,7 @@ async fn run_aggregate(cmd: Cmd) -> Result<bool, Error> {
         || &reports,
         || {
             if reports.is_empty() {
-                output::empty(format_args!("no readiness services registered"));
+                output::empty(format_args!("No readiness services registered."));
                 return;
             }
 

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -99,7 +99,7 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
         || &snapshot_payload,
         || {
             if reports.is_empty() {
-                output::empty(format_args!("no readiness services registered"));
+                output::empty(format_args!("No readiness services registered."));
             } else {
                 for (idx, report) in reports.iter().enumerate() {
                     if idx > 0 {

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -160,7 +160,10 @@ impl TrafgenService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no configurations"));
+                    output::empty_with_hint(
+                        format_args!("No trafgen configurations found."),
+                        format_args!("create one with 'yanet-cli-device-trafgen update --name <name>'"),
+                    );
                     return;
                 }
 

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -5,7 +5,7 @@ use aclpb::{
     acl_service_client::AclServiceClient, metrics_service_client::MetricsServiceClient,
 };
 use args::{DeleteCmd, MetricsCmd, ModeCmd, ShowCmd, UpdateCmd};
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use serde::{Deserialize, Serialize};
 use tabled::Tabled;
@@ -329,7 +329,10 @@ impl ACLService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no configurations"));
+                    output::empty_with_hint(
+                        format_args!("No ACL configurations found."),
+                        format_args!("create one with 'yanet-cli-acl update --name <name> --rules <path>'"),
+                    );
                     return;
                 }
 
@@ -437,7 +440,10 @@ impl ACLService {
             || &metrics,
             || {
                 if metrics.is_empty() {
-                    output::empty(format_args!("no metrics"));
+                    match cmd.name.as_ref().and_then(ValueEnum::to_possible_value) {
+                        Some(name) => output::empty(format_args!("No ACL metrics found for '{}'.", name.get_name())),
+                        None => output::empty(format_args!("No ACL metrics found.")),
+                    }
                     return;
                 }
 

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -105,7 +105,12 @@ impl Balancer2Service {
             || &response.names,
             || {
                 if response.names.is_empty() {
-                    output::empty(format_args!("no balancer configs"));
+                    output::empty_with_hint(
+                        format_args!("No balancer configurations found."),
+                        format_args!(
+                            "create one with 'yanet-cli-balancer2 update --name <name> --config <path> --sessions <sessions-name>'"
+                        ),
+                    );
                     return;
                 }
 
@@ -168,6 +173,7 @@ impl Balancer2Service {
                 None
             };
 
+        let name = cmd.name.clone();
         let filter = cmd.filter.to_proto();
         let request = GetStateRequest {
             config_name: cmd.name,
@@ -189,7 +195,7 @@ impl Balancer2Service {
             || &response.states,
             || {
                 if response.states.is_empty() {
-                    output::empty(format_args!("no balancer state found"));
+                    output::empty(format_args!("No balancer state found for '{name}'."));
                     return;
                 }
 
@@ -217,7 +223,12 @@ impl Balancer2Service {
             || &response.names,
             || {
                 if response.names.is_empty() {
-                    output::empty(format_args!("no sessions states"));
+                    output::empty_with_hint(
+                        format_args!("No session states found."),
+                        format_args!(
+                            "create one with 'yanet-cli-balancer2 sessions update --name <name> --capacity <n>'"
+                        ),
+                    );
                     return;
                 }
 
@@ -233,6 +244,7 @@ impl Balancer2Service {
     }
 
     async fn sessions_show(&mut self, cmd: SessionsShowCmd, format: CommonFormat) -> Result<(), Error> {
+        let name = cmd.name.clone();
         let request = ListSessionsRequest {
             sessions_state_name: cmd.name,
             filter: cmd.filter.to_proto(),
@@ -247,19 +259,25 @@ impl Balancer2Service {
             .map_err(self.service.status("sessions show"))?
             .into_inner();
 
-        if format == CommonFormat::Human {
-            display::print_sessions_header();
-        }
-
         let now = time::SystemTime::now()
             .duration_since(time::UNIX_EPOCH)
             .expect("system clock before UNIX epoch")
             .as_secs() as i64;
         let mut printed = 0usize;
+        // Deferred until the first session actually arrives, so a zero-session
+        // result does not print a header row over an empty table.
+        let mut header_printed = false;
 
         while let Some(session) = stream.message().await.map_err(self.service.status("sessions show"))? {
             match format {
-                CommonFormat::Human => display::print_session(&session, now),
+                CommonFormat::Human => {
+                    if !header_printed {
+                        display::print_sessions_header();
+                        header_printed = true;
+                    }
+
+                    display::print_session(&session, now);
+                }
                 CommonFormat::Json => println!(
                     "{}",
                     serde_json::to_string(&session).expect("balancer session JSON serialization must not fail")
@@ -268,8 +286,8 @@ impl Balancer2Service {
             printed += 1;
         }
 
-        if printed == 0 && format == CommonFormat::Human {
-            eprintln!("no sessions");
+        if printed == 0 {
+            output::empty(format_args!("No sessions found for '{name}'."));
         }
 
         Ok(())

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -136,7 +136,10 @@ impl BlackholeService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no configurations"));
+                    output::empty_with_hint(
+                        format_args!("No blackhole configurations found."),
+                        format_args!("create one with 'yanet-cli-blackhole update --name <name>'"),
+                    );
                     return;
                 }
 

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -126,7 +126,10 @@ impl DecapService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no decap configs"));
+                    output::empty_with_hint(
+                        format_args!("No decap configurations found."),
+                        format_args!("create one with 'yanet-cli-decap update --name <name> --prefixes <cidr>'"),
+                    );
                     return;
                 }
 

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -156,7 +156,10 @@ impl DscpService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no dscp configs"));
+                    output::empty_with_hint(
+                        format_args!("No DSCP configurations found."),
+                        format_args!("create one with 'yanet-cli-dscp prefix-add --name <name> --prefix <cidr>'"),
+                    );
                     return;
                 }
 

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -219,7 +219,10 @@ impl ForwardService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no forward configs"));
+                    output::empty_with_hint(
+                        format_args!("No forward configurations found."),
+                        format_args!("create one with 'yanet-cli-forward update --name <name> --rules <path>'"),
+                    );
                     return;
                 }
 

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -2,7 +2,7 @@ use core::{fmt, net::Ipv6Addr, time::Duration};
 use std::{collections::HashMap, time::UNIX_EPOCH};
 
 use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
-use clap::{ArgAction, CommandFactory, Parser};
+use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
 use commonpb::pb::{GetMetricsRequest, IpAddress};
 use fwstatepb::{
@@ -104,7 +104,12 @@ impl FWStateService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no fwstate configs"));
+                    output::empty_with_hint(
+                        format_args!("No FWState configurations found."),
+                        format_args!(
+                            "create one with 'yanet-cli-fwstate update --name <name> --src-addr <addr> --dst-ether <mac> --dst-addr-unicast <addr> --port-unicast <port>'"
+                        ),
+                    );
                     return;
                 }
 
@@ -332,13 +337,9 @@ impl FWStateService {
 
         let limit = cmd.count;
         let mut total: u32 = 0;
-
-        if format == CommonFormat::Human {
-            println!(
-                "{:<6} {:<45} {:<45} {:<8} {:<9} {:<7}",
-                "IDX", "SRC", "DST", "PROTO", "FLAGS S|D", "EXPRD"
-            );
-        }
+        // Deferred until the first entry actually arrives, so a zero-entry
+        // result does not print a header row over an empty table.
+        let mut header_printed = false;
 
         while let Some(resp) = response_stream
             .message()
@@ -351,7 +352,17 @@ impl FWStateService {
                 }
 
                 match format {
-                    CommonFormat::Human => print_entry(entry),
+                    CommonFormat::Human => {
+                        if !header_printed {
+                            println!(
+                                "{:<6} {:<45} {:<45} {:<8} {:<9} {:<7}",
+                                "IDX", "SRC", "DST", "PROTO", "FLAGS S|D", "EXPRD"
+                            );
+                            header_printed = true;
+                        }
+
+                        print_entry(entry);
+                    }
                     CommonFormat::Json => {
                         let json_entry = JsonEntry::from_entry(entry);
                         println!(
@@ -380,6 +391,13 @@ impl FWStateService {
             tx.send(next_req)
                 .await
                 .map_err(|err| self.service.status("list entries")(Status::internal(format!("send error: {err}"))))?;
+        }
+
+        if total == 0 {
+            output::empty(format_args!(
+                "No firewall state entries found for '{}'.",
+                cmd.config_name
+            ));
         }
 
         Ok(())
@@ -423,7 +441,12 @@ impl FWStateService {
             || &metrics,
             || {
                 if metrics.is_empty() {
-                    output::empty(format_args!("no metrics"));
+                    match cmd.name.as_ref().and_then(ValueEnum::to_possible_value) {
+                        Some(name) => {
+                            output::empty(format_args!("No FWState metrics found for '{}'.", name.get_name()))
+                        }
+                        None => output::empty(format_args!("No FWState metrics found.")),
+                    }
                     return;
                 }
 

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -219,7 +219,10 @@ impl MirrorService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no mirror configs"));
+                    output::empty_with_hint(
+                        format_args!("No mirror configurations found."),
+                        format_args!("create one with 'yanet-cli-mirror update --name <name> --rules <path>'"),
+                    );
                     return;
                 }
 

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -235,7 +235,10 @@ impl NAT64Service {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no nat64 configs"));
+                    output::empty_with_hint(
+                        format_args!("No NAT64 configurations found."),
+                        format_args!("create one with 'yanet-cli-nat64 prefix add --name <name> --prefix <cidr>'"),
+                    );
                     return;
                 }
 

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -111,7 +111,10 @@ impl PdumpService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no pdump configs"));
+                    output::empty_with_hint(
+                        format_args!("No pdump configurations found."),
+                        format_args!("create one with 'yanet-cli-pdump set --name <name>'"),
+                    );
                     return;
                 }
 

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -226,7 +226,10 @@ impl RouteMplsService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no route-mpls configs"));
+                    output::empty_with_hint(
+                        format_args!("No route-mpls configurations found."),
+                        format_args!("create one with 'yanet-cli-route-mpls create --name <name>'"),
+                    );
                     return;
                 }
 

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -232,7 +232,10 @@ impl RouteService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("No FIB configs found."));
+                    output::empty_with_hint(
+                        format_args!("No FIB configurations found."),
+                        format_args!("create one with 'yanet-cli-route fib update --name <name> --rules <path>'"),
+                    );
                     return;
                 }
 
@@ -258,7 +261,7 @@ impl RouteService {
             || records.iter().map(fib::json::FibRecordJson::from).collect::<Vec<_>>(),
             || {
                 if records.is_empty() {
-                    output::empty(format_args!("No FIB entries found for {}.", cmd.config_name));
+                    output::empty(format_args!("No FIB entries found for '{}'.", cmd.config_name));
                     return;
                 }
 

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -224,11 +224,10 @@ impl NeighbourService {
             || &response.neighbours,
             || {
                 if response.neighbours.is_empty() {
-                    let empty_message = match &cmd.table {
-                        Some(table) => format!("no neighbours in {table}"),
-                        None => "no neighbours".to_owned(),
-                    };
-                    output::empty(format_args!("{empty_message}"));
+                    match &cmd.table {
+                        Some(table) => output::empty(format_args!("No neighbours found for table '{table}'.")),
+                        None => output::empty(format_args!("No neighbours found.")),
+                    }
                     return;
                 }
 
@@ -321,7 +320,12 @@ impl NeighbourService {
             || &response.tables,
             || {
                 if response.tables.is_empty() {
-                    output::empty(format_args!("no neighbour tables"));
+                    output::empty_with_hint(
+                        format_args!("No neighbour tables found."),
+                        format_args!(
+                            "create one with 'yanet-cli-operator-neighbour table create <name> --default-priority <n>'"
+                        ),
+                    );
                     return;
                 }
 

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -243,7 +243,12 @@ impl RouteService {
             || &response.configs,
             || {
                 if response.configs.is_empty() {
-                    output::empty(format_args!("no configurations"));
+                    output::empty_with_hint(
+                        format_args!("No route configurations found."),
+                        format_args!(
+                            "create one with 'yanet-cli-operator-route insert <prefix> --name <name> --via <addr>'"
+                        ),
+                    );
                     return;
                 }
 
@@ -275,7 +280,7 @@ impl RouteService {
             || &response.routes,
             || {
                 if response.routes.is_empty() {
-                    output::empty(format_args!("no routes in {}", cmd.name));
+                    output::empty(format_args!("No routes found for '{}'.", cmd.name));
                     return;
                 }
 
@@ -307,7 +312,7 @@ impl RouteService {
             || &response.routes,
             || {
                 if response.routes.is_empty() {
-                    output::empty(format_args!("no routes for {}", cmd.addr));
+                    output::empty(format_args!("No routes found for {}.", cmd.addr));
                     return;
                 }
 


### PR DESCRIPTION
Every CLI reported an empty result differently: 27 sites used a lowercase fragment, 4 a capitalized sentence, and 4 more hand-rolled a `println!` straight to stdout — one of them coloured yellow, two preceded by a column header that made a zero-row result indistinguishable from a table whose body never arrived.

- All of them now report through `output::empty`/`output::empty_with_hint`, which renders a `[–]`/`[-]` mark on stderr, greyed when colour is on.
- The wording adopts the register the Web UI already uses for the same data — `No decap configurations found.` — copied byte-for-byte wherever a Web string exists, and extended on the same template elsewhere.
- A command given a filter argument now names it, so a typo is visible: `No FIB entries found for 'route0'.` Previously only 4 of 31 sites did this.
- The note is suppressed entirely when stdout is not a terminal, or when the selected format serializes, so a pipe or a redirect gets zero bytes on both channels. That suppression lives in the primitive rather than in a format check each caller has to remember.
- Every list command additionally suggests the command that would create the missing thing; each suggestion was checked to actually succeed in the state that prints it, which is always a first create.
- `CLAUDE.md` records the convention.

The convention was chosen against the behaviour of `ip`, `git`, `podman`, `systemctl`, `kubectl`, `gh` and FRR, none of which colour an empty-result message, and against this project's own success-message and Web UI registers.