### PR TITLE
perf(filter,acl): share the IPv6 half-classification across both ACL filters

### DIFF
--- a/lib/filter/classifiers/net6.h
+++ b/lib/filter/classifiers/net6.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <stdbool.h>
+
 #include "common/lpm.h"
+#include "common/memory_address.h"
 #include "common/value.h"
 
 struct net6_classifier {
@@ -8,3 +11,32 @@ struct net6_classifier {
 	struct lpm lo;
 	struct value_table comb;
 };
+
+// Shared per-direction IPv6 half-address classification.
+//
+// The hi and lo tries are built over the union of the v6 networks of two
+// local classifiers (a and b), so a single double-LPM walk serves both
+// filters. The remap arrays are indexed by a union half-class and hold the
+// corresponding local half-class of each classifier. remap_hi_* arrays
+// have hi_count entries and remap_lo_* arrays have lo_count entries. The
+// array pointers are shared-memory relative pointers.
+struct net6_share_dir {
+	struct lpm hi;
+	struct lpm lo;
+	uint32_t hi_count;
+	uint32_t lo_count;
+	uint32_t *remap_hi_a;
+	uint32_t *remap_lo_a;
+	uint32_t *remap_hi_b;
+	uint32_t *remap_lo_b;
+};
+
+// Whether dir holds a built shared classification.
+//
+// filter_net6_share_init and filter_net6_share_dir_free both leave every
+// field, including remap_hi_a, at zero when there is nothing built, so a
+// NULL remap pointer is a structural "not built" rather than a stored flag.
+static inline bool
+net6_share_dir_is_built(const struct net6_share_dir *dir) {
+	return ADDR_OF(&dir->remap_hi_a) != NULL;
+}

--- a/lib/filter/compiler.h
+++ b/lib/filter/compiler.h
@@ -3,6 +3,7 @@
 #include "lib/filter/compiler/attribute.h"
 #include "lib/filter/compiler/declare.h"
 #include "lib/filter/compiler/helper.h"
+#include "lib/filter/compiler/net6_share.h"
 #include "lib/filter/filter.h"
 
 #include "common/memory.h"

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -8,6 +8,8 @@
 #include "../classifiers/net6.h"
 
 #include "declare.h"
+#include "lib/errors/errors.h"
+#include "net6_share.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -801,4 +803,265 @@ FILTER_ATTR_COMPILER_FREE_FUNC(net6_dst)(
 	void *data, struct memory_context *memory_context
 ) {
 	free_net6(data, memory_context);
+}
+
+// Shared per-direction half-classification.
+struct net6_share_remap_ctx {
+	const struct lpm *local_a;
+	const struct lpm *local_b;
+	uint32_t *remap_a;
+	uint32_t *remap_b;
+	uint32_t class_count;
+};
+
+// Records local half-classes for one walked union range.
+//
+// The union half-partition refines each local one, so the local class is
+// constant across the walked range and looking it up at the range start
+// is enough. A union class may cover several disjoint ranges, and every
+// range must resolve to the same local class — a mismatch means the
+// refinement invariant is broken and filter_net6_share_init reports it as
+// a build failure, which rejects the config apply like any other filter
+// build failure.
+static int
+net6_share_remap_collect(
+	uint8_t key_size,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t value,
+	void *data
+) {
+	(void)to;
+	struct net6_share_remap_ctx *ctx = (struct net6_share_remap_ctx *)data;
+
+	if (value >= ctx->class_count) {
+		return -1;
+	}
+
+	uint32_t class_a = lpm_lookup(ctx->local_a, key_size, from);
+	uint32_t class_b = lpm_lookup(ctx->local_b, key_size, from);
+
+	if (ctx->remap_a[value] != LPM_VALUE_INVALID &&
+	    ctx->remap_a[value] != class_a) {
+		return -1;
+	}
+	if (ctx->remap_b[value] != LPM_VALUE_INVALID &&
+	    ctx->remap_b[value] != class_b) {
+		return -1;
+	}
+
+	ctx->remap_a[value] = class_a;
+	ctx->remap_b[value] = class_b;
+
+	return 0;
+}
+
+// Builds the two remap arrays for one address half.
+//
+// Walks the union trie across the full 8-byte key space and resolves each
+// union half-class into the local half-classes of both classifiers. On
+// success the caller owns the returned arrays, on failure both are freed
+// and err distinguishes an allocation failure from a broken refinement
+// invariant (a local classifier disagreeing with the union classification
+// across a walked range).
+static int
+net6_share_build_remap(
+	struct memory_context *mctx,
+	const struct lpm *uni,
+	uint32_t class_count,
+	const struct lpm *local_a,
+	const struct lpm *local_b,
+	uint32_t **remap_a,
+	uint32_t **remap_b,
+	yanet_error **err
+) {
+	size_t size = sizeof(uint32_t) * class_count;
+
+	uint32_t *a = (uint32_t *)memory_balloc(mctx, size);
+	if (a == NULL) {
+		yanet_error_add(
+			err, "out of memory: failed to allocate remap array"
+		);
+		return -1;
+	}
+	uint32_t *b = (uint32_t *)memory_balloc(mctx, size);
+	if (b == NULL) {
+		memory_bfree(mctx, a, size);
+		yanet_error_add(
+			err, "out of memory: failed to allocate remap array"
+		);
+		return -1;
+	}
+
+	// Mark every slot as not yet written so inconsistent rewrites can
+	// be detected during the walk.
+	memset(a, 0xff, size);
+	memset(b, 0xff, size);
+
+	struct net6_share_remap_ctx ctx = {
+		.local_a = local_a,
+		.local_b = local_b,
+		.remap_a = a,
+		.remap_b = b,
+		.class_count = class_count,
+	};
+
+	uint8_t from[8];
+	uint8_t to[8];
+	memset(from, 0x00, sizeof(from));
+	memset(to, 0xff, sizeof(to));
+
+	if (lpm8_walk(uni, from, to, net6_share_remap_collect, &ctx)) {
+		memory_bfree(mctx, b, size);
+		memory_bfree(mctx, a, size);
+		yanet_error_add(
+			err,
+			"shared net6 remap violates the refinement invariant: "
+			"a local classifier disagrees with the union "
+			"classification"
+		);
+		return -1;
+	}
+
+	*remap_a = a;
+	*remap_b = b;
+
+	return 0;
+}
+
+int
+filter_net6_share_init(
+	struct memory_context *mctx,
+	const struct filter_rule **rules,
+	uint32_t rule_count,
+	int is_src,
+	const struct net6_classifier *local_a,
+	const struct net6_classifier *local_b,
+	struct net6_share_dir *out,
+	yanet_error **err
+) {
+	action_get_net6_func get_net6 =
+		is_src ? action_get_net6_src : action_get_net6_dst;
+
+	// Only the tries are kept. Collector classes are dense, so the
+	// range index maximum value plus one is the class count and the
+	// index itself can be released right away.
+	struct range_index ri;
+	if (collect_net6_range(
+		    mctx,
+		    rules,
+		    rule_count,
+		    get_net6,
+		    net6_get_hi_part,
+		    &out->hi,
+		    &ri
+	    )) {
+		yanet_error_add(
+			err,
+			"out of memory: failed to collect shared net6 hi range"
+		);
+		goto error;
+	}
+	out->hi_count = ri.max_value + 1;
+	range_index_free(&ri);
+
+	if (collect_net6_range(
+		    mctx,
+		    rules,
+		    rule_count,
+		    get_net6,
+		    net6_get_lo_part,
+		    &out->lo,
+		    &ri
+	    )) {
+		yanet_error_add(
+			err,
+			"out of memory: failed to collect shared net6 lo range"
+		);
+		goto error_hi;
+	}
+	out->lo_count = ri.max_value + 1;
+	range_index_free(&ri);
+
+	uint32_t *remap_hi_a;
+	uint32_t *remap_hi_b;
+	if (net6_share_build_remap(
+		    mctx,
+		    &out->hi,
+		    out->hi_count,
+		    &local_a->hi,
+		    &local_b->hi,
+		    &remap_hi_a,
+		    &remap_hi_b,
+		    err
+	    )) {
+		goto error_lo;
+	}
+
+	uint32_t *remap_lo_a;
+	uint32_t *remap_lo_b;
+	if (net6_share_build_remap(
+		    mctx,
+		    &out->lo,
+		    out->lo_count,
+		    &local_a->lo,
+		    &local_b->lo,
+		    &remap_lo_a,
+		    &remap_lo_b,
+		    err
+	    )) {
+		goto error_remap_hi;
+	}
+
+	SET_OFFSET_OF(&out->remap_hi_a, remap_hi_a);
+	SET_OFFSET_OF(&out->remap_hi_b, remap_hi_b);
+	SET_OFFSET_OF(&out->remap_lo_a, remap_lo_a);
+	SET_OFFSET_OF(&out->remap_lo_b, remap_lo_b);
+
+	return 0;
+
+error_remap_hi:
+	memory_bfree(mctx, remap_hi_b, sizeof(uint32_t) * out->hi_count);
+	memory_bfree(mctx, remap_hi_a, sizeof(uint32_t) * out->hi_count);
+
+error_lo:
+	lpm_free(&out->lo);
+
+error_hi:
+	lpm_free(&out->hi);
+
+error:
+	memset(out, 0, sizeof(*out));
+	return -1;
+}
+
+void
+filter_net6_share_dir_free(
+	struct memory_context *mctx, struct net6_share_dir *dir
+) {
+	uint32_t *remap;
+
+	remap = ADDR_OF(&dir->remap_hi_a);
+	if (remap != NULL) {
+		memory_bfree(mctx, remap, sizeof(uint32_t) * dir->hi_count);
+	}
+	remap = ADDR_OF(&dir->remap_hi_b);
+	if (remap != NULL) {
+		memory_bfree(mctx, remap, sizeof(uint32_t) * dir->hi_count);
+	}
+	remap = ADDR_OF(&dir->remap_lo_a);
+	if (remap != NULL) {
+		memory_bfree(mctx, remap, sizeof(uint32_t) * dir->lo_count);
+	}
+	remap = ADDR_OF(&dir->remap_lo_b);
+	if (remap != NULL) {
+		memory_bfree(mctx, remap, sizeof(uint32_t) * dir->lo_count);
+	}
+
+	// lpm_free is safe on a zeroed trie, and zeroing the structure
+	// afterwards keeps the whole free path repeatable.
+	lpm_free(&dir->hi);
+	lpm_free(&dir->lo);
+
+	memset(dir, 0, sizeof(*dir));
 }

--- a/lib/filter/compiler/net6_share.h
+++ b/lib/filter/compiler/net6_share.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "common/memory.h"
+
+#include "lib/errors/errors.h"
+#include "lib/filter/classifiers/net6.h"
+#include "lib/filter/rule.h"
+
+// Builds a shared per-direction IPv6 half-classification.
+//
+// rules is the union projection over the rule sets of the two local
+// classifiers, an array with NULL holes following the filter_init
+// convention. is_src selects the source or destination address attribute.
+// local_a and local_b are the per-filter classifiers whose half-partitions
+// the union partition refines. Everything is allocated from mctx. On
+// failure everything already built is released, out is zeroed, -1 is
+// returned, and err reports the failing step — allocation failure or a
+// broken refinement invariant are distinguished in the message.
+int
+filter_net6_share_init(
+	struct memory_context *mctx,
+	const struct filter_rule **rules,
+	uint32_t rule_count,
+	int is_src,
+	const struct net6_classifier *local_a,
+	const struct net6_classifier *local_b,
+	struct net6_share_dir *out,
+	yanet_error **err
+);
+
+// Releases the union tries and remap arrays of a shared classification.
+//
+// Safe on an all-zero or fully built structure — filter_net6_share_init
+// never leaves a genuinely partial one, since it zeroes out on every
+// failure path. NULL remap pointers are skipped and the whole structure
+// is zeroed afterwards.
+void
+filter_net6_share_dir_free(
+	struct memory_context *mctx, struct net6_share_dir *dir
+);

--- a/lib/filter/tests/basic_net6.c
+++ b/lib/filter/tests/basic_net6.c
@@ -576,6 +576,276 @@ test3(void *memory) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Shared per-direction half-classification (filter_net6_share_init).
+
+// Recomputes the leaf slot a plain (non-shared) net6 classifier assigns to
+// addr, the same way FILTER_ATTR_QUERY_FUNC(net6_src/net6_dst) does.
+static uint32_t
+local_net6_slot(struct net6_classifier *c, const uint8_t addr[NET6_LEN]) {
+	uint32_t hi = lpm8_lookup(&c->hi, addr);
+	uint32_t lo = lpm8_lookup(&c->lo, addr + 8);
+	return value_table_get(&c->comb, hi, lo);
+}
+
+// Recomputes the leaf slot the shared union classification assigns to addr
+// for one of its two local classifiers, the way acl_handle_packets does:
+// one union lookup translated through that classifier's remap arrays.
+static uint32_t
+shared_net6_slot(
+	struct net6_share_dir *dir,
+	uint32_t *remap_hi,
+	uint32_t *remap_lo,
+	struct net6_classifier *local,
+	const uint8_t addr[NET6_LEN]
+) {
+	uint32_t hi = lpm8_lookup(&dir->hi, addr);
+	uint32_t lo = lpm8_lookup(&dir->lo, addr + 8);
+	return value_table_get(&local->comb, remap_hi[hi], remap_lo[lo]);
+}
+
+// Verifies that the shared leaf slot for both local classifiers matches
+// their own plain leaf lookup for addr, on both the src and dst share
+// directories built by test_share.
+static void
+assert_share_matches_local(
+	struct net6_share_dir *share_src,
+	struct net6_share_dir *share_dst,
+	struct net6_classifier *local_a_src,
+	struct net6_classifier *local_a_dst,
+	struct net6_classifier *local_b_src,
+	struct net6_classifier *local_b_dst,
+	const uint8_t addr[NET6_LEN]
+) {
+	uint32_t *remap_hi_a = ADDR_OF(&share_src->remap_hi_a);
+	uint32_t *remap_lo_a = ADDR_OF(&share_src->remap_lo_a);
+	uint32_t *remap_hi_b = ADDR_OF(&share_src->remap_hi_b);
+	uint32_t *remap_lo_b = ADDR_OF(&share_src->remap_lo_b);
+
+	assert(local_net6_slot(local_a_src, addr) ==
+	       shared_net6_slot(
+		       share_src, remap_hi_a, remap_lo_a, local_a_src, addr
+	       ));
+	assert(local_net6_slot(local_b_src, addr) ==
+	       shared_net6_slot(
+		       share_src, remap_hi_b, remap_lo_b, local_b_src, addr
+	       ));
+
+	remap_hi_a = ADDR_OF(&share_dst->remap_hi_a);
+	remap_lo_a = ADDR_OF(&share_dst->remap_lo_a);
+	remap_hi_b = ADDR_OF(&share_dst->remap_hi_b);
+	remap_lo_b = ADDR_OF(&share_dst->remap_lo_b);
+
+	assert(local_net6_slot(local_a_dst, addr) ==
+	       shared_net6_slot(
+		       share_dst, remap_hi_a, remap_lo_a, local_a_dst, addr
+	       ));
+	assert(local_net6_slot(local_b_dst, addr) ==
+	       shared_net6_slot(
+		       share_dst, remap_hi_b, remap_lo_b, local_b_dst, addr
+	       ));
+}
+
+// Verifies filter_net6_share_init against two local classifiers (mimicking
+// filter_ip6 and filter_ip6_port) whose partitions genuinely differ: an
+// address landing in one classifier's partition but not the other's is the
+// case a broken remap would smooth over, and netB1 below uses the same
+// non-contiguous-across-128-bit-but-per-64-bit-half-contiguous mask shape
+// as test1's rule (5 hi bytes + 3 lo bytes, with a gap in between).
+static void
+test_share(void *memory) {
+	struct block_allocator allocator;
+	block_allocator_init(&allocator);
+	block_allocator_put_arena(&allocator, memory, 1 << 24);
+
+	struct memory_context mctx;
+	int res = memory_context_init(&mctx, "test", &allocator);
+	assert(res == 0);
+
+	// netA1: broad /8 supernet 0xBB::/8, any lo half.
+	struct net6 net_a1 = {.addr = {}, .mask = {}};
+	net_a1.mask[0] = 0xff;
+	make_addr(net_a1.addr, 0xB, 2, 0, 0);
+
+	// netA2: broad /8 supernet 0xEE::/8, disjoint from B's networks.
+	struct net6 net_a2 = {.addr = {}, .mask = {}};
+	net_a2.mask[0] = 0xff;
+	make_addr(net_a2.addr, 0xE, 2, 0, 0);
+
+	// netB1: nested inside netA1's supernet, narrower than it, with a
+	// bi-contiguous but not whole-address-contiguous mask (5 hi bytes,
+	// then a gap, then 3 lo bytes).
+	struct net6 net_b1 = {
+		.addr = {},
+		.mask =
+			{0xff,
+			 0xff,
+			 0xff,
+			 0xff,
+			 0xff,
+			 0x00,
+			 0x00,
+			 0x00,
+			 0xff,
+			 0xff,
+			 0xff,
+			 0x00,
+			 0x00,
+			 0x00,
+			 0x00,
+			 0x00},
+	};
+	make_addr(net_b1.addr, 0xB, 16, 0xA, 16);
+
+	// netB2: broad /8 supernet 0xCC::/8, disjoint from A's networks.
+	struct net6 net_b2 = {.addr = {}, .mask = {}};
+	net_b2.mask[0] = 0xff;
+	make_addr(net_b2.addr, 0xC, 2, 0, 0);
+
+	struct filter_rule_builder builder_a;
+	builder_init(&builder_a);
+	builder_add_net6_src(&builder_a, net_a1);
+	builder_add_net6_dst(&builder_a, net_a1);
+	struct filter_rule rule_a1 = build_rule(&builder_a);
+
+	struct filter_rule_builder builder_a2;
+	builder_init(&builder_a2);
+	builder_add_net6_src(&builder_a2, net_a2);
+	builder_add_net6_dst(&builder_a2, net_a2);
+	struct filter_rule rule_a2 = build_rule(&builder_a2);
+
+	struct filter_rule_builder builder_b1;
+	builder_init(&builder_b1);
+	builder_add_net6_src(&builder_b1, net_b1);
+	builder_add_net6_dst(&builder_b1, net_b1);
+	struct filter_rule rule_b1 = build_rule(&builder_b1);
+
+	struct filter_rule_builder builder_b2;
+	builder_init(&builder_b2);
+	builder_add_net6_src(&builder_b2, net_b2);
+	builder_add_net6_dst(&builder_b2, net_b2);
+	struct filter_rule rule_b2 = build_rule(&builder_b2);
+
+	const struct filter_rule *rule_ptrs_a[2] = {&rule_a1, &rule_a2};
+	const struct filter_rule *rule_ptrs_b[2] = {&rule_b1, &rule_b2};
+
+	struct filter filter_a;
+	res = filter_init(
+		&filter_a, sign_net6_compile, rule_ptrs_a, 2, &mctx, NULL
+	);
+	assert(res == 0);
+
+	struct filter filter_b;
+	res = filter_init(
+		&filter_b, sign_net6_compile, rule_ptrs_b, 2, &mctx, NULL
+	);
+	assert(res == 0);
+
+	struct net6_classifier *local_a_src =
+		(struct net6_classifier *)ADDR_OF(&filter_a.v[2].data);
+	struct net6_classifier *local_a_dst =
+		(struct net6_classifier *)ADDR_OF(&filter_a.v[3].data);
+	struct net6_classifier *local_b_src =
+		(struct net6_classifier *)ADDR_OF(&filter_b.v[2].data);
+	struct net6_classifier *local_b_dst =
+		(struct net6_classifier *)ADDR_OF(&filter_b.v[3].data);
+
+	// The union projection covers every network of both local
+	// classifiers, mirroring how acl_module_init_net6_share collects
+	// every ip6 rule regardless of which of filter_ip6/filter_ip6_port
+	// it ends up in.
+	const struct filter_rule *rule_ptrs_union[4] = {
+		&rule_a1, &rule_a2, &rule_b1, &rule_b2
+	};
+
+	struct net6_share_dir share_src;
+	res = filter_net6_share_init(
+		&mctx,
+		rule_ptrs_union,
+		4,
+		1,
+		local_a_src,
+		local_b_src,
+		&share_src,
+		NULL
+	);
+	assert(res == 0);
+
+	struct net6_share_dir share_dst;
+	res = filter_net6_share_init(
+		&mctx,
+		rule_ptrs_union,
+		4,
+		0,
+		local_a_dst,
+		local_b_dst,
+		&share_dst,
+		NULL
+	);
+	assert(res == 0);
+
+	// Matches netA1 (0xBB::/8) and, since it is netB1's own address,
+	// netB1 too: a partition both local classifiers agree on.
+	uint8_t addr_both[NET6_LEN];
+	make_addr(addr_both, 0xB, 16, 0xA, 16);
+
+	// Matches netA1's /8 but not netB1's narrower prefix: a partition of
+	// local_a that local_b does not share.
+	uint8_t addr_only_a[NET6_LEN] = {0};
+	addr_only_a[0] = 0xBB;
+
+	// Matches netB2's /8, disjoint from both of local_a's networks: a
+	// partition of local_b that local_a does not share.
+	uint8_t addr_only_b[NET6_LEN] = {0};
+	addr_only_b[0] = 0xCC;
+
+	// Matches neither classifier's networks.
+	uint8_t addr_neither[NET6_LEN] = {0};
+	addr_neither[0] = 0x11;
+
+	assert_share_matches_local(
+		&share_src,
+		&share_dst,
+		local_a_src,
+		local_a_dst,
+		local_b_src,
+		local_b_dst,
+		addr_both
+	);
+	assert_share_matches_local(
+		&share_src,
+		&share_dst,
+		local_a_src,
+		local_a_dst,
+		local_b_src,
+		local_b_dst,
+		addr_only_a
+	);
+	assert_share_matches_local(
+		&share_src,
+		&share_dst,
+		local_a_src,
+		local_a_dst,
+		local_b_src,
+		local_b_dst,
+		addr_only_b
+	);
+	assert_share_matches_local(
+		&share_src,
+		&share_dst,
+		local_a_src,
+		local_a_dst,
+		local_b_src,
+		local_b_dst,
+		addr_neither
+	);
+
+	filter_net6_share_dir_free(&mctx, &share_dst);
+	filter_net6_share_dir_free(&mctx, &share_src);
+	filter_free(&filter_b, sign_net6_compile);
+	filter_free(&filter_a, sign_net6_compile);
+	memory_context_fini(&mctx);
+}
+
 int
 main() {
 	log_enable_name("debug");
@@ -592,6 +862,10 @@ main() {
 	LOG(INFO, "Running test3...");
 	test3(memory);
 	LOG(INFO, "test3 passed");
+
+	LOG(INFO, "Running test_share...");
+	test_share(memory);
+	LOG(INFO, "test_share passed");
 
 	LOG(INFO, "All tests passed");
 

--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <time.h>
 
 #include "controlplane.h"
@@ -7,6 +8,7 @@
 #include "../dataplane/config.h"
 #include "common/memory_address.h"
 #include "lib/errors/errors.h"
+#include "logging/log.h"
 #include "modules/fwstate/api/fwstate_cp.h"
 #include "modules/fwstate/dataplane/config.h"
 
@@ -60,6 +62,14 @@ FILTER_COMPILER_DECLARE(
 	port_dst
 );
 
+// Position of net6_src/net6_dst within the attribute lists declared above:
+// both ACL_FILTER_IP6_TAG and ACL_FILTER_IP6_PROTO_PORT_TAG put them right
+// after device/vlan, at index 2 and 3. Keep these in sync with the two
+// FILTER_COMPILER_DECLARE calls — reordering either list moves the net6
+// leaf vertices that acl_module_init_net6_share reads.
+#define ACL_FILTER_NET6_SRC_POS 2
+#define ACL_FILTER_NET6_DST_POS 3
+
 struct cp_module *
 acl_module_config_init(
 	struct agent *agent, const char *name, yanet_error **err
@@ -93,6 +103,9 @@ acl_module_config_init(
 
 	memset(&config->filter_ip6, 0, sizeof(config->filter_ip6));
 	memset(&config->filter_ip6_port, 0, sizeof(config->filter_ip6_port));
+
+	memset(&config->net6_share_src, 0, sizeof(config->net6_share_src));
+	memset(&config->net6_share_dst, 0, sizeof(config->net6_share_dst));
 
 	// Initialize fwstate_cfg with NULL pointers
 	memset(&config->fwstate_cfg, 0, sizeof(struct fwstate_config));
@@ -159,6 +172,13 @@ acl_module_config_free(struct cp_module *cp_module) {
 	filter_free(&config->filter_ip4_port, ACL_FILTER_IP4_PROTO_PORT_TAG);
 	filter_free(&config->filter_ip6, ACL_FILTER_IP6_TAG);
 	filter_free(&config->filter_ip6_port, ACL_FILTER_IP6_PROTO_PORT_TAG);
+
+	filter_net6_share_dir_free(
+		&cp_module->memory_context, &config->net6_share_src
+	);
+	filter_net6_share_dir_free(
+		&cp_module->memory_context, &config->net6_share_dst
+	);
 
 	// Capture agent before fini zeroes it.
 	struct agent *agent = ADDR_OF(&cp_module->agent);
@@ -475,6 +495,124 @@ acl_module_init_ip6_port(
 	return rc;
 }
 
+// Builds the shared net6 half-classification, the sole production path for
+// classifying v6 addresses once both v6 filters compile non-empty.
+//
+// A build failure is an ordinary config-apply error, exactly like a failure
+// to build filter_ip6 or filter_ip6_port: it is logged and propagated to
+// the caller, and net6_share_src / net6_share_dst are left all-zero.
+static int
+acl_module_init_net6_share(
+	struct cp_module *cp_module,
+	struct acl_rule *acl_rules,
+	uint32_t acl_rule_count,
+	struct filter_rule *filter_rules,
+	const struct filter_rule **filter_rule_ptrs,
+	yanet_error **err
+) {
+	struct acl_module_config *config =
+		container_of(cp_module, struct acl_module_config, cp_module);
+
+	memset(&config->net6_share_src, 0, sizeof(config->net6_share_src));
+	memset(&config->net6_share_dst, 0, sizeof(config->net6_share_dst));
+
+	// Sharing pays off only when both v6 filters are populated.
+	if (config->filter_rule_count_ip6 == 0 ||
+	    config->filter_rule_count_ip6_port == 0) {
+		return 0;
+	}
+
+	// Kill switch, read once per ACL config compile. Flipping it takes a
+	// control-plane process restart plus a full ruleset reapply — it
+	// does nothing to a config already published to shared memory, so
+	// it is not an operational lever an incident responder can pull.
+	// It is one of several ways the dataplane's unshared classification
+	// path gets reached in a running config — the v6-population guard
+	// just above is the far more common one; see the enumeration on the
+	// dataplane side.
+	if (getenv("YANET_ACL_NET6_SHARE_DISABLE") != NULL) {
+		return 0;
+	}
+
+	// The union projection is every v6 rule, which is exactly the two
+	// disjoint per-filter projections taken together.
+	filter_acl_rules(
+		acl_rules,
+		acl_rule_count,
+		filter_rules,
+		filter_rule_ptrs,
+		check_has_ip6
+	);
+
+	// The local half-classifiers live in the leaf vertices of the two
+	// v6 filters, at the slots of their net6 attributes.
+	const size_t ip6_src_leaf =
+		ACL_FILTER_IP6_TAG->lookup_count + ACL_FILTER_NET6_SRC_POS;
+	const size_t ip6_dst_leaf =
+		ACL_FILTER_IP6_TAG->lookup_count + ACL_FILTER_NET6_DST_POS;
+	const size_t ip6_port_src_leaf =
+		ACL_FILTER_IP6_PROTO_PORT_TAG->lookup_count +
+		ACL_FILTER_NET6_SRC_POS;
+	const size_t ip6_port_dst_leaf =
+		ACL_FILTER_IP6_PROTO_PORT_TAG->lookup_count +
+		ACL_FILTER_NET6_DST_POS;
+
+	const struct net6_classifier *ip6_src = (const struct net6_classifier *)
+		ADDR_OF(&config->filter_ip6.v[ip6_src_leaf].data);
+	const struct net6_classifier *ip6_dst = (const struct net6_classifier *)
+		ADDR_OF(&config->filter_ip6.v[ip6_dst_leaf].data);
+	const struct net6_classifier *ip6_port_src =
+		(const struct net6_classifier *)ADDR_OF(
+			&config->filter_ip6_port.v[ip6_port_src_leaf].data
+		);
+	const struct net6_classifier *ip6_port_dst =
+		(const struct net6_classifier *)ADDR_OF(
+			&config->filter_ip6_port.v[ip6_port_dst_leaf].data
+		);
+
+	if (filter_net6_share_init(
+		    &cp_module->memory_context,
+		    filter_rule_ptrs,
+		    acl_rule_count,
+		    1,
+		    ip6_src,
+		    ip6_port_src,
+		    &config->net6_share_src,
+		    err
+	    )) {
+		LOG(ERROR,
+		    "module '%s': failed to init shared net6 src",
+		    cp_module->name);
+		yanet_error_add(err, "failed to init shared net6 src");
+		return -1;
+	}
+
+	if (filter_net6_share_init(
+		    &cp_module->memory_context,
+		    filter_rule_ptrs,
+		    acl_rule_count,
+		    0,
+		    ip6_dst,
+		    ip6_port_dst,
+		    &config->net6_share_dst,
+		    err
+	    )) {
+		filter_net6_share_dir_free(
+			&cp_module->memory_context, &config->net6_share_src
+		);
+		memset(&config->net6_share_src,
+		       0,
+		       sizeof(config->net6_share_src));
+		LOG(ERROR,
+		    "module '%s': failed to init shared net6 dst",
+		    cp_module->name);
+		yanet_error_add(err, "failed to init shared net6 dst");
+		return -1;
+	}
+
+	return 0;
+}
+
 int
 acl_module_config_update(
 	struct cp_module *cp_module,
@@ -637,6 +775,16 @@ acl_module_config_update(
 		goto error_rule_ptrs;
 
 	if (acl_module_init_ip6_port(
+		    cp_module,
+		    acl_rules,
+		    rule_count,
+		    filter_rules,
+		    filter_rule_ptrs,
+		    err
+	    ))
+		goto error_rule_ptrs;
+
+	if (acl_module_init_net6_share(
 		    cp_module,
 		    acl_rules,
 		    rule_count,

--- a/modules/acl/api/meson.build
+++ b/modules/acl/api/meson.build
@@ -2,6 +2,7 @@ cp_dependencies = [
   lib_common_dep,
   lib_errors_dep,
   lib_filter_compiler_dep,
+  lib_logging_dep,
   lib_packet_dp_dep,
   lib_config_cp_dep,
   lib_counters_dep,

--- a/modules/acl/dataplane/config.h
+++ b/modules/acl/dataplane/config.h
@@ -2,6 +2,7 @@
 
 #include "controlplane/config/cp_module.h"
 
+#include "lib/filter/classifiers/net6.h"
 #include "lib/filter/filter.h"
 #include "lib/fwstate/config.h"
 
@@ -53,4 +54,14 @@ struct acl_module_config {
 	uint64_t action_invalid_counter_id;
 	uint64_t action_non_term_counter_id;
 	uint64_t sync_sent_counter_id;
+
+	// Shared v6 half-address classification for the two v6 filters.
+	//
+	// Built only when both filter_ip6 and filter_ip6_port compiled
+	// non-empty, so a single union trie walk classifies the address
+	// halves for both of them. Left all-zero, including a NULL
+	// net6_share_src.remap_hi_a, when there is no shared classification
+	// to use.
+	struct net6_share_dir net6_share_src;
+	struct net6_share_dir net6_share_dst;
 };

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -4,6 +4,8 @@
 #include <rte_ether.h>
 
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "controlplane/config/econtext.h"
 #include "dataplane/module/module.h"
@@ -54,6 +56,74 @@ FILTER_QUERY_DECLARE(
 	port_dst
 );
 
+// Position of net6_src/net6_dst within the attribute lists declared above:
+// both filter_ip6 and filter_ip6_port put them right after device/vlan, at
+// index 2 and 3. Keep these in sync with the two FILTER_QUERY_DECLARE
+// calls — reordering either list moves the net6 leaf vertices the shared
+// classification path reads.
+#define ACL_FILTER_NET6_SRC_POS 2
+#define ACL_FILTER_NET6_DST_POS 3
+
+// Runs the filter_query classification pass with two leaf rows injected.
+//
+// Behaves exactly like filter_query, except that the leaf slot rows of the
+// ext_src_lookup and ext_dst_lookup attributes are copied from the
+// caller-supplied arrays instead of being computed by the per-filter leaf
+// lookups. This intentionally duplicates filter_query's own inner-vertex
+// reduction (lib/filter/query.h) rather than generalizing it to accept
+// injected leaves — that header is shared by every module, and widening it
+// is out of scope here. Keep the two reduction loops in sync by hand.
+static void
+acl_filter_query_ext(
+	struct filter *filter,
+	const struct filter_query *fq,
+	struct packet **packets,
+	uint32_t *results,
+	uint32_t count,
+	size_t ext_src_lookup,
+	const uint32_t *ext_src_slots,
+	size_t ext_dst_lookup,
+	const uint32_t *ext_dst_slots
+) {
+	uint32_t slots[2 * MAX_ATTRIBUTES * count + 1];
+
+	for (size_t ai = 0; ai < fq->lookup_count; ++ai) {
+		size_t vtx = fq->lookup_count + ai;
+		uint32_t *row = slots + vtx * count;
+		if (ai == ext_src_lookup) {
+			memcpy(row, ext_src_slots, sizeof(uint32_t) * count);
+			continue;
+		}
+		if (ai == ext_dst_lookup) {
+			memcpy(row, ext_dst_slots, sizeof(uint32_t) * count);
+			continue;
+		}
+		const struct filter_vertex *v = &filter->v[vtx];
+		fq->lookups[ai](ADDR_OF(&v->data), packets, row, count);
+	}
+
+	for (size_t vtx = fq->lookup_count - 1; vtx >= 2; --vtx) {
+		struct filter_vertex *v = &filter->v[vtx];
+		for (uint32_t idx = 0; idx < count; ++idx) {
+			slots[vtx * count + idx] = value_table_get(
+				&v->table,
+				slots[(vtx << 1) * count + idx],
+				slots[(vtx << 1 | 1) * count + idx]
+			);
+		}
+	}
+
+	const size_t root = fq->lookup_count > 1;
+	struct filter_vertex *r = &filter->v[root];
+	for (uint32_t idx = 0; idx < count; ++idx) {
+		results[idx] = value_table_get(
+			&r->table,
+			root == 0 ? 0 : slots[(root << 1) * count + idx],
+			slots[(root << 1 | 1) * count + idx]
+		);
+	}
+}
+
 static void
 acl_handle_packets(
 	struct dp_worker *dp_worker,
@@ -65,6 +135,24 @@ acl_handle_packets(
 		struct acl_module_config,
 		cp_module
 	);
+
+	// When the compile side built the union tries, both v6 filters are
+	// queried through them: each address half is classified once and the
+	// union classes are translated per filter via the remap arrays.
+	//
+	// net6_share_src is left unbuilt in an ordinary running config
+	// whenever the v6 ruleset does not split across both filter_ip6 and
+	// filter_ip6_port — no v6 rules at all, every v6 rule port-scoped, or
+	// every v6 rule left unscoped by port — and also when the
+	// YANET_ACL_NET6_SHARE_DISABLE kill switch was set at control-plane
+	// startup. A build failure inside acl_module_init_net6_share instead
+	// rejects the whole config apply, exactly like a filter_ip6 or
+	// filter_ip6_port build failure, so it is never one of the reasons a
+	// running config reaches this point unbuilt. The else branch below is
+	// therefore an ordinary production path, not dead code kept only for
+	// the differential test.
+	const bool net6_share =
+		net6_share_dir_is_built(&acl_config->net6_share_src);
 
 	struct fwstate_config *fwstate_config = &acl_config->fwstate_cfg;
 	struct fwstate_sync_config *sync_config = &fwstate_config->sync_config;
@@ -136,6 +224,11 @@ acl_handle_packets(
 	uint32_t ip6_port_result[packet_front_input_count(packet_front)];
 	uint64_t ip6_port_idx = 0;
 
+	// Position of each ip6_port batch packet within the ip6 batch, filled
+	// only on the shared-classification path where every ip6_port packet
+	// is by construction also an ip6 packet.
+	uint32_t ip6_port_pos[packet_front_input_count(packet_front)];
+
 	for (struct packet *packet = packet_list_first(&packet_front->input);
 	     packet != NULL;
 	     packet = packet->next) {
@@ -160,6 +253,10 @@ acl_handle_packets(
 			if (packet->fragment_offset == 0 &&
 			    (packet->transport_header.type == IPPROTO_TCP ||
 			     packet->transport_header.type == IPPROTO_UDP)) {
+				if (net6_share) {
+					ip6_port_pos[ip6_port_idx] =
+						ip6_idx - 1;
+				}
 				ip6_port_packets[ip6_port_idx++] = packet;
 			}
 		}
@@ -189,21 +286,147 @@ acl_handle_packets(
 		ip4_port_idx
 	);
 
-	filter_query(
-		&acl_config->filter_ip6,
-		filter_ip6,
-		ip6_packets,
-		ip6_result,
-		ip6_idx
-	);
+	if (net6_share) {
+		const uint32_t batch_count =
+			packet_front_input_count(packet_front);
 
-	filter_query(
-		&acl_config->filter_ip6_port,
-		filter_ip6_port,
-		ip6_port_packets,
-		ip6_port_result,
-		ip6_port_idx
-	);
+		struct net6_share_dir *share_src = &acl_config->net6_share_src;
+		struct net6_share_dir *share_dst = &acl_config->net6_share_dst;
+
+		// Classify each v6 address half once on the union tries.
+		uint32_t src_hi[batch_count];
+		uint32_t src_lo[batch_count];
+		uint32_t dst_hi[batch_count];
+		uint32_t dst_lo[batch_count];
+
+		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
+			struct rte_mbuf *mbuf =
+				packet_to_mbuf(ip6_packets[idx]);
+			struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
+				mbuf,
+				struct rte_ipv6_hdr *,
+				ip6_packets[idx]->network_header.offset
+			);
+			const uint8_t *saddr =
+				(const uint8_t *)ipv6_hdr->src_addr;
+			const uint8_t *daddr =
+				(const uint8_t *)ipv6_hdr->dst_addr;
+
+			src_hi[idx] = lpm8_lookup(&share_src->hi, saddr);
+			src_lo[idx] = lpm8_lookup(&share_src->lo, saddr + 8);
+			dst_hi[idx] = lpm8_lookup(&share_dst->hi, daddr);
+			dst_lo[idx] = lpm8_lookup(&share_dst->lo, daddr + 8);
+		}
+
+		const uint32_t *src_hi_a = ADDR_OF(&share_src->remap_hi_a);
+		const uint32_t *src_lo_a = ADDR_OF(&share_src->remap_lo_a);
+		const uint32_t *dst_hi_a = ADDR_OF(&share_dst->remap_hi_a);
+		const uint32_t *dst_lo_a = ADDR_OF(&share_dst->remap_lo_a);
+		const uint32_t *src_hi_b = ADDR_OF(&share_src->remap_hi_b);
+		const uint32_t *src_lo_b = ADDR_OF(&share_src->remap_lo_b);
+		const uint32_t *dst_hi_b = ADDR_OF(&share_dst->remap_hi_b);
+		const uint32_t *dst_lo_b = ADDR_OF(&share_dst->remap_lo_b);
+
+		// Translate the union classes into the leaf classes of each
+		// filter and combine them in the filter's own comb table.
+		const size_t ip6_src_leaf =
+			filter_ip6->lookup_count + ACL_FILTER_NET6_SRC_POS;
+		const size_t ip6_dst_leaf =
+			filter_ip6->lookup_count + ACL_FILTER_NET6_DST_POS;
+		struct net6_classifier *ip6_src_cls = (struct net6_classifier *)
+			ADDR_OF(&acl_config->filter_ip6.v[ip6_src_leaf].data);
+		struct net6_classifier *ip6_dst_cls = (struct net6_classifier *)
+			ADDR_OF(&acl_config->filter_ip6.v[ip6_dst_leaf].data);
+
+		uint32_t ip6_src_slots[batch_count];
+		uint32_t ip6_dst_slots[batch_count];
+
+		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
+			ip6_src_slots[idx] = value_table_get(
+				&ip6_src_cls->comb,
+				src_hi_a[src_hi[idx]],
+				src_lo_a[src_lo[idx]]
+			);
+			ip6_dst_slots[idx] = value_table_get(
+				&ip6_dst_cls->comb,
+				dst_hi_a[dst_hi[idx]],
+				dst_lo_a[dst_lo[idx]]
+			);
+		}
+
+		const size_t ip6_port_src_leaf =
+			filter_ip6_port->lookup_count + ACL_FILTER_NET6_SRC_POS;
+		const size_t ip6_port_dst_leaf =
+			filter_ip6_port->lookup_count + ACL_FILTER_NET6_DST_POS;
+		struct net6_classifier *ip6_port_src_cls =
+			(struct net6_classifier *)ADDR_OF(
+				&acl_config->filter_ip6_port
+					 .v[ip6_port_src_leaf]
+					 .data
+			);
+		struct net6_classifier *ip6_port_dst_cls =
+			(struct net6_classifier *)ADDR_OF(
+				&acl_config->filter_ip6_port
+					 .v[ip6_port_dst_leaf]
+					 .data
+			);
+
+		uint32_t ip6_port_src_slots[batch_count];
+		uint32_t ip6_port_dst_slots[batch_count];
+
+		for (uint64_t idx = 0; idx < ip6_port_idx; ++idx) {
+			uint32_t pos = ip6_port_pos[idx];
+			ip6_port_src_slots[idx] = value_table_get(
+				&ip6_port_src_cls->comb,
+				src_hi_b[src_hi[pos]],
+				src_lo_b[src_lo[pos]]
+			);
+			ip6_port_dst_slots[idx] = value_table_get(
+				&ip6_port_dst_cls->comb,
+				dst_hi_b[dst_hi[pos]],
+				dst_lo_b[dst_lo[pos]]
+			);
+		}
+
+		acl_filter_query_ext(
+			&acl_config->filter_ip6,
+			filter_ip6,
+			ip6_packets,
+			ip6_result,
+			ip6_idx,
+			ACL_FILTER_NET6_SRC_POS,
+			ip6_src_slots,
+			ACL_FILTER_NET6_DST_POS,
+			ip6_dst_slots
+		);
+		acl_filter_query_ext(
+			&acl_config->filter_ip6_port,
+			filter_ip6_port,
+			ip6_port_packets,
+			ip6_port_result,
+			ip6_port_idx,
+			ACL_FILTER_NET6_SRC_POS,
+			ip6_port_src_slots,
+			ACL_FILTER_NET6_DST_POS,
+			ip6_port_dst_slots
+		);
+	} else {
+		filter_query(
+			&acl_config->filter_ip6,
+			filter_ip6,
+			ip6_packets,
+			ip6_result,
+			ip6_idx
+		);
+
+		filter_query(
+			&acl_config->filter_ip6_port,
+			filter_ip6_port,
+			ip6_port_packets,
+			ip6_port_result,
+			ip6_port_idx
+		);
+	}
 
 	vlan_idx = 0;
 	ip4_idx = 0;

--- a/modules/acl/tests/functional/acl_bench_dataset_test.go
+++ b/modules/acl/tests/functional/acl_bench_dataset_test.go
@@ -493,7 +493,7 @@ func hostInNet(network filter.IPNet, hostBits int) net.IP {
 // cells the way mixed real traffic does. Uniform sampling over rules is
 // a worst-case-ish cache workload; real traffic is more skewed.
 func synthesizeDatasetPackets(
-	b *testing.B, rules []cacl.AclRule, limit int,
+	tb testing.TB, rules []cacl.AclRule, limit int,
 ) []gopacket.Packet {
 	type flowSeed struct {
 		src filter.IPNet
@@ -527,7 +527,7 @@ func synthesizeDatasetPackets(
 		}
 		seeds = append(seeds, seed)
 	}
-	require.NotEmpty(b, seeds)
+	require.NotEmpty(tb, seeds)
 
 	packets := make([]gopacket.Packet, 0, limit)
 	for idx := 0; len(packets) < limit; idx++ {
@@ -566,7 +566,7 @@ func synthesizeDatasetPackets(
 				DstPort: layers.UDPPort(seed.dstPort),
 			}
 			require.NoError(
-				b, udp.SetNetworkLayerForChecksum(network),
+				tb, udp.SetNetworkLayerForChecksum(network),
 			)
 			transport = udp
 		} else {
@@ -577,7 +577,7 @@ func synthesizeDatasetPackets(
 				Window:  1024,
 			}
 			require.NoError(
-				b, tcp.SetNetworkLayerForChecksum(network),
+				tb, tcp.SetNetworkLayerForChecksum(network),
 			)
 			transport = tcp
 		}
@@ -586,7 +586,7 @@ func synthesizeDatasetPackets(
 			network.(gopacket.SerializableLayer),
 			transport,
 		)
-		require.NoError(b, err)
+		require.NoError(tb, err)
 		packets = append(packets, packet)
 	}
 	return packets

--- a/modules/acl/tests/functional/acl_net6_share_test.go
+++ b/modules/acl/tests/functional/acl_net6_share_test.go
@@ -1,0 +1,464 @@
+package acl_test
+
+// Differential verdict test for the shared net6 half-classification
+// (filter_net6_share_init / acl_module_init_net6_share): the same rules and
+// the same packets must produce identical per-packet actions whether the
+// ACL module classifies filter_ip6 and filter_ip6_port independently or
+// through the shared union tries.
+//
+// The gate compares actions and the full per-rule counter vector, and
+// includes addresses chosen so the two local classifiers' partitions
+// genuinely differ, a pair of destination networks reaching past /64 (so
+// the dst-lo union partition is non-degenerate), a non-contiguous-across-
+// 128-bit (but bi-contiguous) mask, and a later IPv6 fragment that only
+// ever reaches filter_ip6. TestACL_Net6Share_VerdictParity_Scale
+// additionally runs the same comparison at a larger rule count, and
+// TestACL_Net6Share_VerdictParity_ScaleHeavy at a production-ish one,
+// since a degenerate union partition at small scale can leave a remap bug
+// undetectable.
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"os"
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/gopacket/gopacket"
+	"github.com/gopacket/gopacket/layers"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xpacket"
+	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
+	"github.com/yanet-platform/yanet2/tests/functional/framework"
+)
+
+// net6ShareDisableEnv mirrors acl_module_init_net6_share's operational kill
+// switch, checked once at ACL config compile time.
+const net6ShareDisableEnv = "YANET_ACL_NET6_SHARE_DISABLE"
+
+// setNet6ShareDisabled sets the sharing kill switch for the calling test
+// when disabled is true. t.Setenv restores the previous value
+// automatically on cleanup, so there is nothing to do in the false case:
+// the ambient environment (expected unset) is left alone, and whether
+// sharing actually built is verified independently in the "shared" subtest
+// of runNet6ShareVerdictParity via GetInfo rather than by forcing the
+// variable absent here.
+func setNet6ShareDisabled(t *testing.T, disabled bool) {
+	t.Helper()
+
+	if disabled {
+		t.Setenv(net6ShareDisableEnv, "1")
+	}
+}
+
+// net6ShareEdgeCaseRules builds v6 rules chosen to stress the shared
+// classification mechanism rather than the ACL action logic: the specific
+// actions only need to be distinguishable, not meaningful.
+func net6ShareEdgeCaseRules() []cacl.AclRule {
+	// divergeBroad has no port constraint (filter_ip6); divergeNested is
+	// a narrower network scoped to a destination port (filter_ip6_port).
+	// An address inside the nested network lands in a partition that
+	// filter_ip6's own classifier never has to distinguish, exactly the
+	// case a broken remap would smooth over.
+	divergeBroad := filter.MustParseIPNet("2001:db8:1::/48")
+	divergeNested := filter.IPNet{
+		Addr: netip.MustParseAddr("2001:db8:1:1::"),
+		Mask: netip.MustParseAddr("ffff:ffff:ffff:ffff::"),
+	}
+
+	// deepLoA and deepLoB are two disjoint, port-scoped destination
+	// networks that each reach 112 bits deep — 48 bits past the hi/lo
+	// split at byte 8 (see lib/filter/query/net6.h) — so the dst-lo
+	// union partition carries at least three real classes (default,
+	// deepLoA, deepLoB) instead of the degenerate default-plus-one a
+	// small synthetic ruleset otherwise produces. Neither network nor
+	// port range overlaps any other rule here, and both are port-scoped
+	// so they compile into filter_ip6_port only (see check_acl_rule_ip6
+	// / check_acl_rule_ip6_port in modules/acl/api/controlplane.c) —
+	// filter_ip6 has no matching rule to fall back on, so a dst-lo remap
+	// bug affecting either network is not maskable by the other filter's
+	// independently correct answer.
+	deepLoA := filter.IPNet{
+		Addr: netip.MustParseAddr("2001:db8:9::1000:0"),
+		Mask: netip.MustParseAddr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:0000"),
+	}
+	deepLoB := filter.IPNet{
+		Addr: netip.MustParseAddr("2001:db8:9::2000:0"),
+		Mask: netip.MustParseAddr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:0000"),
+	}
+
+	// nonContiguous has a mask that is bi-contiguous (5 hi bytes, then 3
+	// lo bytes) but not contiguous across the full 128 bits: exactly the
+	// shape the net6 compiler accepts and a union partition can obscure.
+	nonContiguous := filter.IPNet{
+		Addr: netip.MustParseAddr("bbbb:bbbb:bb00:0000:aaaa:aa00:0000:0000"),
+		Mask: netip.MustParseAddr("ffff:ffff:ff00:0000:ffff:ff00:0000:0000"),
+	}
+
+	return []cacl.AclRule{
+		{
+			Counter:       "diverge_broad",
+			Actions:       []cacl.AclAction{{Kind: cacl.ActionAllow}},
+			Src6s:         filter.IPNets{divergeBroad},
+			Dst6s:         filter.IPNets{filter.UnspecifiedIPv6},
+			SrcPortRanges: allPorts,
+			DstPortRanges: allPorts,
+			ProtoRanges:   tcpProto,
+		},
+		{
+			Counter:       "diverge_nested",
+			Actions:       []cacl.AclAction{{Kind: cacl.ActionCount}, {Kind: cacl.ActionDeny}},
+			Src6s:         filter.IPNets{divergeNested},
+			Dst6s:         filter.IPNets{filter.UnspecifiedIPv6},
+			SrcPortRanges: allPorts,
+			DstPortRanges: filter.PortRanges{{From: 7000, To: 7000}},
+			ProtoRanges:   tcpProto,
+		},
+		{
+			Counter:       "deep_lo_a",
+			Actions:       []cacl.AclAction{{Kind: cacl.ActionCount}, {Kind: cacl.ActionAllow}},
+			Src6s:         filter.IPNets{filter.UnspecifiedIPv6},
+			Dst6s:         filter.IPNets{deepLoA},
+			SrcPortRanges: allPorts,
+			DstPortRanges: filter.PortRanges{{From: 8000, To: 8000}},
+			ProtoRanges:   tcpProto,
+		},
+		{
+			Counter:       "deep_lo_b",
+			Actions:       []cacl.AclAction{{Kind: cacl.ActionCount}, {Kind: cacl.ActionAllow}},
+			Src6s:         filter.IPNets{filter.UnspecifiedIPv6},
+			Dst6s:         filter.IPNets{deepLoB},
+			SrcPortRanges: allPorts,
+			DstPortRanges: filter.PortRanges{{From: 8001, To: 8001}},
+			ProtoRanges:   tcpProto,
+		},
+		{
+			Counter:       "non_contig_broad",
+			Actions:       []cacl.AclAction{{Kind: cacl.ActionAllow}},
+			Src6s:         filter.IPNets{nonContiguous},
+			Dst6s:         filter.IPNets{filter.UnspecifiedIPv6},
+			SrcPortRanges: allPorts,
+			DstPortRanges: allPorts,
+			ProtoRanges:   udpProto,
+		},
+		{
+			Counter:       "non_contig_port",
+			Actions:       []cacl.AclAction{{Kind: cacl.ActionCount}, {Kind: cacl.ActionAllow}},
+			Src6s:         filter.IPNets{nonContiguous},
+			Dst6s:         filter.IPNets{filter.UnspecifiedIPv6},
+			SrcPortRanges: allPorts,
+			DstPortRanges: filter.PortRanges{{From: 9000, To: 9000}},
+			ProtoRanges:   udpProto,
+		},
+	}
+}
+
+// net6ShareEdgeCasePackets builds packets matching the rules from
+// net6ShareEdgeCaseRules, plus a later IPv6 fragment addressed inside
+// divergeBroad's network: fragments with a non-zero offset skip the port
+// filter entirely (see acl_handle_packets), so this packet only ever
+// reaches filter_ip6, exercising an address whose src half is classified
+// for one signature but never the other.
+func net6ShareEdgeCasePackets(t *testing.T) []gopacket.Packet {
+	t.Helper()
+
+	eth := layers.Ethernet{
+		SrcMAC:       xerror.Unwrap(net.ParseMAC("aa:bb:cc:dd:ee:ff")),
+		DstMAC:       xerror.Unwrap(net.ParseMAC("11:22:33:44:55:66")),
+		EthernetType: layers.EthernetTypeIPv6,
+	}
+
+	packets := make([]gopacket.Packet, 0, 6)
+
+	buildTCP := func(src, dst string, dstPort uint16) {
+		ip6 := layers.IPv6{
+			Version:    6,
+			HopLimit:   64,
+			NextHeader: layers.IPProtocolTCP,
+			SrcIP:      net.ParseIP(src),
+			DstIP:      net.ParseIP(dst),
+		}
+		tcp := layers.TCP{SrcPort: 12345, DstPort: layers.TCPPort(dstPort), SYN: true}
+		require.NoError(t, tcp.SetNetworkLayerForChecksum(&ip6))
+		packets = append(packets, xpacket.LayersToPacket(t, &eth, &ip6, &tcp))
+	}
+
+	buildUDP := func(src, dst string, dstPort uint16) {
+		ip6 := layers.IPv6{
+			Version:    6,
+			HopLimit:   64,
+			NextHeader: layers.IPProtocolUDP,
+			SrcIP:      net.ParseIP(src),
+			DstIP:      net.ParseIP(dst),
+		}
+		udp := layers.UDP{SrcPort: 54321, DstPort: layers.UDPPort(dstPort)}
+		require.NoError(t, udp.SetNetworkLayerForChecksum(&ip6))
+		packets = append(packets, xpacket.LayersToPacket(t, &eth, &ip6, &udp))
+	}
+
+	// Lands in divergeBroad only (filter_ip6), not divergeNested.
+	buildTCP("2001:db8:1:2::1", "2001:db8:aaaa::1", 6000)
+	// Lands in both divergeBroad and divergeNested (nested inside the
+	// broad supernet), the partition-divergence case proper.
+	buildTCP("2001:db8:1:1::5", "2001:db8:aaaa::2", 7000)
+	// Matches deepLoA on its own scoped port: filter_ip6 has no rule
+	// covering this network at all, so this packet's action depends
+	// entirely on filter_ip6_port's dst-lo classification of deepLoA.
+	buildTCP("2001:db8:5::1", "2001:db8:9::1000:1", 8000)
+	// Matches deepLoB the same way, on a disjoint network and port.
+	buildTCP("2001:db8:5::2", "2001:db8:9::2000:1", 8001)
+	// Matches the non-contiguous-mask network via UDP + a scoped port,
+	// reaching filter_ip6_port.
+	buildUDP("bbbb:bbbb:bb00:0000:aaaa:aa00:0000:0001", "2001:db8:bbbb::1", 9000)
+
+	// Later IPv6 fragment (FragmentOffset != 0): skips the port filter
+	// regardless of its inner protocol, so only filter_ip6 ever sees it.
+	fragIP6 := layers.IPv6{
+		Version:    6,
+		HopLimit:   64,
+		NextHeader: layers.IPProtocolIPv6Fragment,
+		SrcIP:      net.ParseIP("2001:db8:1:3::1"),
+		DstIP:      net.ParseIP("2001:db8:cccc::1"),
+	}
+	frag := layers.IPv6Fragment{
+		NextHeader:     layers.IPProtocolTCP,
+		FragmentOffset: 8,
+		MoreFragments:  false,
+		Identification: 0xdeadbeef,
+	}
+	payload := gopacket.Payload([]byte{
+		0x00, 0x00, 0x01, 0xBB, // src-port=0, dst-port=443
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x50, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	})
+	packets = append(packets, serializeFragPacket(t, &eth, &fragIP6, &frag, payload))
+
+	return packets
+}
+
+// net6SharePacketKey identifies a packet by its flow tuple, stable across
+// the baseline and shared-classification runs regardless of output order.
+func net6SharePacketKey(info *framework.PacketInfo) string {
+	proto := info.Protocol
+	if info.IsIPv6 {
+		proto = info.NextHeader
+	}
+	return fmt.Sprintf(
+		"%s|%s|%d|%d|%d",
+		info.SrcIP, info.DstIP, info.SrcPort, info.DstPort, proto,
+	)
+}
+
+// net6ShareResult holds the outcome of one compile-and-classify run: the
+// per-flow verdicts, the resulting per-rule counter vectors, and the
+// compiled configuration metadata used to confirm sharing actually had
+// something to build.
+type net6ShareResult struct {
+	verdicts     map[string]string
+	ruleCounters map[string][]uint64
+	info         *cacl.AclConfigInfo
+}
+
+// collectNet6ShareVerdicts compiles rules once under the given sharing
+// state and returns each surviving/dropped packet's verdict keyed by flow,
+// and the per-rule counter vectors read back from shared memory.
+func collectNet6ShareVerdicts(
+	t *testing.T,
+	rules []cacl.AclRule,
+	packets []gopacket.Packet,
+	shareDisabled bool,
+	cpMemory, agentMemory datasize.ByteSize,
+) net6ShareResult {
+	t.Helper()
+
+	setNet6ShareDisabled(t, shareDisabled)
+
+	h, agent, backend := setupACLHarnessSized(t, []string{"port0"}, cpMemory, agentMemory)
+	handle := applyACLRules(t, backend, "test", rules)
+	wireACLPipeline(t, agent, "port0", "test")
+
+	result, err := h.HandlePackets(packets...)
+	require.NoError(t, err)
+
+	verdicts := make(map[string]string, len(packets))
+	for _, info := range result.Output {
+		verdicts[net6SharePacketKey(info)] = "output"
+	}
+	for _, info := range result.Drop {
+		verdicts[net6SharePacketKey(info)] = "drop"
+	}
+
+	path := aclCounterPath("port0", "test")
+	counters := h.SharedMemory().DPConfig(0).ModuleCounters(
+		path.Device, path.Pipeline, path.Function, path.Chain,
+		path.ModuleType, path.ModuleName, nil,
+	)
+
+	return net6ShareResult{
+		verdicts:     verdicts,
+		ruleCounters: dataplaneut.ValueCounters(counters),
+		info:         handle.GetInfo(),
+	}
+}
+
+// runNet6ShareVerdictParity builds a ruleset of datasetRuleCount dataset
+// rules plus the fixed edge-case family, synthesizes packetCount flow
+// packets, and asserts that the shared and unshared net6 classification
+// paths agree on every packet's verdict and every per-rule counter.
+//
+// acl_module_init_net6_share returns without building the shared trie in
+// three cases: the kill switch, filter_rule_count_ip6 == 0, and
+// filter_rule_count_ip6_port == 0. The kill switch is closed off by the
+// ambient-environment check below; the other two are closed off by
+// asserting both rule counts are non-zero on the shared side, since
+// net6ShareEdgeCaseRules always supplies both port-scoped and
+// non-port-scoped v6 rules. Without that assertion, a ruleset lacking
+// either family would make this subtest compile the unshared path on both
+// sides and compare it against itself.
+func runNet6ShareVerdictParity(
+	t *testing.T,
+	datasetRuleCount, packetCount int,
+	cpMemory, agentMemory datasize.ByteSize,
+) {
+	rules := append(net6ShareEdgeCaseRules(), generateDatasetRules(datasetRuleCount)...)
+
+	packets := net6ShareEdgeCasePackets(t)
+	packets = append(packets, synthesizeDatasetPackets(t, rules, packetCount)...)
+
+	var baseline, shared net6ShareResult
+	t.Run("baseline", func(t *testing.T) {
+		baseline = collectNet6ShareVerdicts(t, rules, packets, true, cpMemory, agentMemory)
+	})
+	t.Run("shared", func(t *testing.T) {
+		_, present := os.LookupEnv(net6ShareDisableEnv)
+		require.False(
+			t, present,
+			"%s is present in the ambient environment (acl_module_init_net6_share "+
+				"keys off getenv() != NULL, not the value); this subtest would "+
+				"compile the unshared path on both sides and compare it "+
+				"against itself, making the differential check vacuous",
+			net6ShareDisableEnv,
+		)
+		shared = collectNet6ShareVerdicts(t, rules, packets, false, cpMemory, agentMemory)
+		require.True(
+			t,
+			shared.info.FilterRuleCountIp6 > 0 && shared.info.FilterRuleCountIp6Port > 0,
+			"ruleset has filter_rule_count_ip6=%d filter_rule_count_ip6_port=%d; "+
+				"acl_module_init_net6_share returns without building the "+
+				"shared trie when either is zero, so this subtest would be "+
+				"comparing the unshared path against itself",
+			shared.info.FilterRuleCountIp6, shared.info.FilterRuleCountIp6Port,
+		)
+	})
+
+	require.NotEmpty(t, baseline.verdicts)
+	require.Equal(
+		t, len(baseline.verdicts), len(shared.verdicts),
+		"shared and baseline runs classified a different number of packets",
+	)
+	for key, wantVerdict := range baseline.verdicts {
+		gotVerdict, ok := shared.verdicts[key]
+		require.True(t, ok, "packet %q missing from the shared-classification result", key)
+		require.Equal(
+			t, wantVerdict, gotVerdict,
+			"packet %q verdict diverges between baseline and shared net6 classification", key,
+		)
+	}
+
+	require.Equal(
+		t, baseline.ruleCounters, shared.ruleCounters,
+		"per-rule counters diverge between baseline and shared net6 classification",
+	)
+}
+
+// TestACL_Net6Share_VerdictParity verifies that enabling the shared net6
+// half-classification never changes an ACL verdict: the same production-
+// shaped ruleset and packet set, compiled once with sharing forced off and
+// once with sharing left on, must agree on every packet's action and every
+// per-rule counter.
+//
+// This uses its own sizes rather than the package-default aclCPSize/
+// aclMemSize: under `-fsanitize=address,undefined` the filter compiler's
+// allocator overhead pushes the default 64/16 MB harness out of memory
+// while compiling filter_ip6_port, even for the unshared baseline subtest,
+// so the failure tracks the sanitizer build, not the sharing change. 128/32
+// MB was the smallest size found to pass under ASan; 192/48 MB adds
+// headroom for allocator-layout and runner-to-runner variance while still
+// measuring well under 512 MiB peak RSS in either build mode.
+func TestACL_Net6Share_VerdictParity(t *testing.T) {
+	const (
+		net6ShareCPMemory  = 192 * datasize.MB
+		net6ShareAgentSize = 48 * datasize.MB
+	)
+	runNet6ShareVerdictParity(t, 384, 512, net6ShareCPMemory, net6ShareAgentSize)
+}
+
+// TestACL_Net6Share_VerdictParity_Scale runs the same differential check at
+// a rule count well past TestACL_Net6Share_VerdictParity's, so union
+// partitions carry more than the tens-to-low-hundreds of classes a small
+// ruleset produces.
+//
+// lib/dataplane_ut/dataplane_ut.c memsets its whole requested CPMemory
+// arena up front, so RSS tracks the requested size directly regardless of
+// how much of it the compiled config actually uses. In a normal build,
+// 12000 dataset rules (plus the fixed edge-case family) measured a
+// repeatable ~1.3-1.4 GiB peak RSS at 1300/975 MB. Under
+// `-fsanitize=address,undefined` the filter compiler's allocator overhead
+// is materially larger: 1300/975 MB no longer even compiles
+// filter_ip6_port, and 1330/998 MB was the smallest size found to pass.
+// 1500/1125 MB adds headroom over that empirical minimum and measured
+// ~1.74 GiB peak RSS under ASan, still comfortably under the 2 GiB a
+// standard CI runner can spare. This tier runs in the default `make test`
+// and `make test-asan` paths, so it must stay well inside that budget in
+// both build modes; TestACL_Net6Share_VerdictParity_ScaleHeavy carries the
+// production-scale rule count instead.
+func TestACL_Net6Share_VerdictParity_Scale(t *testing.T) {
+	const (
+		scaleRuleCount   = 12000
+		scaleCPMemory    = 1500 * datasize.MB
+		scaleAgentMemory = 1125 * datasize.MB
+	)
+	runNet6ShareVerdictParity(t, scaleRuleCount, 4096, scaleCPMemory, scaleAgentMemory)
+}
+
+// net6ShareScaleHeavyEnv gates
+// TestACL_Net6Share_VerdictParity_ScaleHeavy, which compiles two
+// ~40000-rule configs and peaks at roughly 24 GiB RSS: fine for a human to
+// run on demand, far too heavy for the runners `make test` and
+// `make test-asan` share with the rest of CI.
+//
+// Run it directly with:
+//
+//	ACL_NET6_SHARE_SCALE_HEAVY=1 go test -run TestACL_Net6Share_VerdictParity_ScaleHeavy \
+//	    ./modules/acl/tests/functional/
+const net6ShareScaleHeavyEnv = "ACL_NET6_SHARE_SCALE_HEAVY"
+
+// TestACL_Net6Share_VerdictParity_ScaleHeavy runs the same differential
+// check as TestACL_Net6Share_VerdictParity_Scale at a production-ish rule
+// count.
+//
+// At TestACL_Net6Share_VerdictParity_Scale's rule count the union
+// partitions are already non-degenerate, but production rulesets reach
+// tens of thousands of rules, and a remap bug that only manifests once a
+// partition grows past that count would slip through the smaller gates.
+// Gated behind net6ShareScaleHeavyEnv rather than -short: neither
+// `make test` (Makefile:257) nor `make test-asan` (Makefile:267) passes
+// -short, so that alone would not have kept this off CI.
+func TestACL_Net6Share_VerdictParity_ScaleHeavy(t *testing.T) {
+	if os.Getenv(net6ShareScaleHeavyEnv) == "" {
+		t.Skipf("set %s=1 to run the production-scale net6 share differential", net6ShareScaleHeavyEnv)
+	}
+
+	const (
+		scaleCPMemory    = 24 * datasize.GB
+		scaleAgentMemory = 16 * datasize.GB
+	)
+	runNet6ShareVerdictParity(t, 40000, 4096, scaleCPMemory, scaleAgentMemory)
+}

--- a/modules/acl/tests/functional/acl_test.go
+++ b/modules/acl/tests/functional/acl_test.go
@@ -65,9 +65,24 @@ func setupACLHarness(
 	devices []string,
 ) (*dataplaneut.Harness, *ffi.Agent, acl.Backend) {
 	tb.Helper()
+	return setupACLHarnessSized(tb, devices, aclCPSize, aclMemSize)
+}
+
+// setupACLHarnessSized is the parametrized form of setupACLHarness for
+// callers that need non-default CP/agent memory, e.g. a differential test
+// compiling a production-scale ruleset.
+//
+// devices is the set of logical port names to register in the harness topology.
+// Cleanup is wired via tb.Cleanup in LIFO order.
+func setupACLHarnessSized(
+	tb testing.TB,
+	devices []string,
+	cpMemory, agentMemory datasize.ByteSize,
+) (*dataplaneut.Harness, *ffi.Agent, acl.Backend) {
+	tb.Helper()
 
 	cfg := dataplaneut.Config{
-		CPMemory:      uint64(aclCPSize),
+		CPMemory:      uint64(cpMemory),
 		DPMemory:      uint64(aclDPSize),
 		WorkerCount:   1,
 		Devices:       devices,
@@ -79,11 +94,11 @@ func setupACLHarness(
 	tb.Cleanup(h.Free)
 
 	shm := h.SharedMemory()
-	agent, err := shm.AgentAttach("acl-test", 0, aclMemSize)
+	agent, err := shm.AgentAttach("acl-test", 0, agentMemory)
 	require.NoError(tb, err)
 	tb.Cleanup(func() { _ = agent.CleanUp() })
 
-	backend := acl.NewBackend(agent, uint64(aclMemSize))
+	backend := acl.NewBackend(agent, uint64(agentMemory))
 	return h, agent, backend
 }
 


### PR DESCRIPTION
The ACL module issues two filter queries per IPv6 packet class whose signatures both carry the source and destination address attributes, so the same address tries were walked twice per pass and four times per packet across the inbound and outbound configurations. This builds one shared per-direction classification over the union of both signatures' rule sets, with remap arrays translating union classes back to each local classifier, so a single walk answers both.

The implementation is migrated from a stranded WIP branch that had never been measured on real hardware. Only the sharing is taken; the packed union tries bundled in that commit are left for a separate change with its own evidence.

### Measured on the lab firewall stand

- Delivered throughput at saturation rises from 16.43 to 17.83 million packets per second, **+8.5%**, against a noise floor below 1%.
- Baseline was measured three times, once *after* the candidate and across two full binary swaps, and reproduced itself to 0.6% — so stand drift does not explain the gain.
- Inbound ACL falls 223 to 177 ns per packet, outbound 212 to 170 ns.
- Instructions per packet fall 4.8% and instructions per cycle rise 3.3%. Both moving is the signature this latency-bound path requires: only removing dependent trie hops can lift IPC here.
- Both sides were built locally from identical sources with byte-identical build configuration, so the toolchain is not a confound.

### Verdict equivalence is the deliverable

A classification bug on a firewall does not slow anything down, it lets a packet through, so equivalence carries more weight here than the speedup.

- The differential test compiles the same ruleset both ways in one process and asserts identical per-packet verdicts **and** identical per-rule counter vectors — a verdict-only assertion passes when two rules swap outcomes symmetrically.
- It runs at twelve thousand rules by default, sized to about 1.3 GiB so it survives CI, with a forty thousand rule tier behind an environment variable.
- The corpus deliberately includes addresses landing in one local partition but not the other, masks that are non-contiguous across the address yet contiguous within each half, and the fragment path that reaches only one of the two signatures.
- A positive control asserts the kill switch is unset and both filter rule counts are non-zero, because there are three separate ways the shared classification is legitimately not built and any of them would otherwise let the test compare the unshared path against itself.
- Equivalence was additionally confirmed on the stand against the live production ruleset under real traffic, with an oracle that recomputed the local classification per packet: 4.75 million packets classified, zero divergences. That instrument has served its purpose and is not part of this change.

### Deliberate choices worth a reviewer's attention

- A failure to build the shared classification rejects the configuration apply, exactly as a failure of any other filter does. An earlier revision fell back to the unshared path instead; that bought a flag in shared memory, a metric and a second branch in the hot loop for a case a correctly sized arena never reaches.
- The unshared path remains, keyed on the absence of the shared structure rather than on stored state, because it is what the differential test compares against.
- The leaf vertex indices are derived from the signature rather than written as literals; getting them wrong would reinterpret a different attribute's payload with no build error.
- Rule compilation costs about 15% more time and 1% more arena.
