### PR TITLE
feat(cli): report empty results at the remaining silent sites

### DIFF
--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -279,6 +279,10 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                         "{}",
                         serde_yaml::to_string(&response).expect("counters YAML serialization must not fail")
                     );
+
+                    if response.ports.is_empty() {
+                        output::empty(format_args!("No port counters found."));
+                    }
                 },
             );
         }
@@ -292,6 +296,10 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                         "{}",
                         serde_yaml::to_string(&response).expect("counters YAML serialization must not fail")
                     );
+
+                    if response.groups.is_empty() {
+                        output::empty(format_args!("No counters found."));
+                    }
                 },
             );
         }

--- a/cli/modules/function/src/main.rs
+++ b/cli/modules/function/src/main.rs
@@ -124,6 +124,13 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                         "{}",
                         serde_yaml::to_string(&function).expect("function YAML serialization must not fail")
                     );
+
+                    if function.chains.is_empty() {
+                        output::empty_with_hint(
+                            format_args!("No chains found for '{}'.", show.name),
+                            format_args!("create one with 'yanet-cli function update --name <name> --chains <chain>'"),
+                        );
+                    }
                 },
             );
         }

--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -81,92 +81,138 @@ impl InspectService {
 }
 
 fn render_tree(response: &InspectResponse) {
+    let Some(info) = &response.instance_info else {
+        output::empty(format_args!("No instance information found."));
+        return;
+    };
+
     let mut tree = TreeBuilder::new("YANET System".to_string());
 
-    if let Some(info) = &response.instance_info {
-        tree.begin_child(format!("Instance {}", info.instance_idx));
+    tree.begin_child(format!("Instance {}", info.instance_idx));
 
-        tree.begin_child(format!("Attached to NUMA {}", info.numa_idx));
+    tree.begin_child(format!("Attached to NUMA {}", info.numa_idx));
+    tree.end_child();
+
+    tree.begin_child("Dataplane Modules".to_string());
+    if info.dp_modules.is_empty() {
+        tree.add_empty_child("(none)".to_owned());
+    }
+
+    for (idx, module) in info.dp_modules.iter().enumerate() {
+        tree.add_empty_child(format!("{}: {}", idx, module.name));
+    }
+    tree.end_child();
+
+    tree.begin_child("Controlplane Configurations".to_string());
+    if info.cp_configs.is_empty() {
+        tree.add_empty_child("(none)".to_owned());
+    }
+
+    for cfg in &info.cp_configs {
+        tree.add_empty_child(format!("{}:{} (gen: {})", cfg.r#type, cfg.name, cfg.generation));
+    }
+    tree.end_child();
+
+    tree.begin_child("Agents".to_string());
+    if info.agents.is_empty() {
+        tree.add_empty_child("(none)".to_owned());
+    }
+
+    for agent in &info.agents {
+        tree.begin_child(agent.name.to_string());
+        if agent.instances.is_empty() {
+            tree.add_empty_child("(none)".to_owned());
+        }
+
+        for instance in &agent.instances {
+            let used = instance.memory_limit.saturating_sub(instance.free_bytes);
+            tree.begin_child(format!("Instance (PID: {})", instance.pid));
+            tree.add_empty_child(format!("Memory limit: {}", ByteSize::b(instance.memory_limit)));
+            tree.add_empty_child(format!("Used:         {}", ByteSize::b(used)));
+            tree.add_empty_child(format!("Free:         {}", ByteSize::b(instance.free_bytes)));
+            tree.add_empty_child(format!("Generation: {}", instance.generation));
+            tree.end_child();
+        }
+
         tree.end_child();
+    }
+    tree.end_child();
 
-        tree.begin_child("Dataplane Modules".to_string());
-        for (idx, module) in info.dp_modules.iter().enumerate() {
-            tree.add_empty_child(format!("{}: {}", idx, module.name));
+    tree.begin_child("Functions".to_string());
+    if info.functions.is_empty() {
+        tree.add_empty_child("(none)".to_owned());
+    }
+
+    for function in &info.functions {
+        tree.begin_child(format!("Function {}", function.name));
+        if function.chains.is_empty() {
+            tree.add_empty_child("(none)".to_owned());
+        }
+
+        for chain in &function.chains {
+            tree.begin_child(format!("Chain {} (weight {})", chain.name, chain.weight));
+            if chain.modules.is_empty() {
+                tree.add_empty_child("(none)".to_owned());
+            }
+
+            for module in &chain.modules {
+                tree.add_empty_child(format!("Module {}:{}", module.r#type, module.name));
+            }
+            tree.end_child();
+        }
+        tree.end_child();
+    }
+    tree.end_child();
+
+    tree.begin_child("Pipelines".to_string());
+    if info.pipelines.is_empty() {
+        tree.add_empty_child("(none)".to_owned());
+    }
+
+    for pipeline in &info.pipelines {
+        tree.begin_child(format!("Pipeline {}", pipeline.name));
+        tree.add_empty_child("rx".to_string());
+        for function in &pipeline.functions {
+            tree.add_empty_child(function.to_string());
+        }
+        tree.add_empty_child("tx".to_string());
+        tree.end_child();
+    }
+    tree.end_child();
+
+    tree.begin_child("Devices".to_string());
+    if info.devices.is_empty() {
+        tree.add_empty_child("(none)".to_owned());
+    }
+
+    for device in &info.devices {
+        tree.begin_child(format!("Device {}:{}", device.r#type, device.name));
+
+        tree.begin_child("input".to_string());
+        if device.input_pipelines.is_empty() {
+            tree.add_empty_child("(none)".to_owned());
+        }
+
+        for pipeline in &device.input_pipelines {
+            tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
         }
         tree.end_child();
 
-        tree.begin_child("Controlplane Configurations".to_string());
-        for cfg in &info.cp_configs {
-            tree.add_empty_child(format!("{}:{} (gen: {})", cfg.r#type, cfg.name, cfg.generation));
+        tree.begin_child("output".to_string());
+        if device.output_pipelines.is_empty() {
+            tree.add_empty_child("(none)".to_owned());
         }
-        tree.end_child();
 
-        tree.begin_child("Agents".to_string());
-        for agent in &info.agents {
-            tree.begin_child(agent.name.to_string());
-
-            for instance in &agent.instances {
-                let used = instance.memory_limit.saturating_sub(instance.free_bytes);
-                tree.begin_child(format!("Instance (PID: {})", instance.pid));
-                tree.add_empty_child(format!("Memory limit: {}", ByteSize::b(instance.memory_limit)));
-                tree.add_empty_child(format!("Used:         {}", ByteSize::b(used)));
-                tree.add_empty_child(format!("Free:         {}", ByteSize::b(instance.free_bytes)));
-                tree.add_empty_child(format!("Generation: {}", instance.generation));
-                tree.end_child();
-            }
-
-            tree.end_child();
-        }
-        tree.end_child();
-
-        tree.begin_child("Functions".to_string());
-        for function in &info.functions {
-            tree.begin_child(format!("Function {}", function.name));
-            for chain in &function.chains {
-                tree.begin_child(format!("Chain {} (weight {})", chain.name, chain.weight));
-                for module in &chain.modules {
-                    tree.add_empty_child(format!("Module {}:{}", module.r#type, module.name));
-                }
-                tree.end_child();
-            }
-            tree.end_child();
-        }
-        tree.end_child();
-
-        tree.begin_child("Pipelines".to_string());
-        for pipeline in &info.pipelines {
-            tree.begin_child(format!("Pipeline {}", pipeline.name));
-            tree.add_empty_child("rx".to_string());
-            for function in &pipeline.functions {
-                tree.add_empty_child(function.to_string());
-            }
-            tree.add_empty_child("tx".to_string());
-            tree.end_child();
-        }
-        tree.end_child();
-
-        tree.begin_child("Devices".to_string());
-        for device in &info.devices {
-            tree.begin_child(format!("Device {}:{}", device.r#type, device.name));
-
-            tree.begin_child("input".to_string());
-            for pipeline in &device.input_pipelines {
-                tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
-            }
-            tree.end_child();
-
-            tree.begin_child("output".to_string());
-            for pipeline in &device.output_pipelines {
-                tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
-            }
-            tree.end_child();
-
-            tree.end_child();
+        for pipeline in &device.output_pipelines {
+            tree.add_empty_child(format!("Pipeline {} (weight: {})", pipeline.name, pipeline.weight));
         }
         tree.end_child();
 
         tree.end_child();
     }
+    tree.end_child();
+
+    tree.end_child();
 
     let tree = tree.build();
     let _ = ptree::print_tree(&tree);

--- a/cli/modules/pipeline/src/main.rs
+++ b/cli/modules/pipeline/src/main.rs
@@ -136,6 +136,15 @@ async fn run(cmd: Cmd) -> Result<(), Error> {
                         "{}",
                         serde_yaml::to_string(&pipeline).expect("pipeline YAML serialization must not fail")
                     );
+
+                    if pipeline.functions.is_empty() {
+                        output::empty_with_hint(
+                            format_args!("No functions found for '{}'.", show.name),
+                            format_args!(
+                                "create one with 'yanet-cli pipeline update --name <name> --functions <function>'"
+                            ),
+                        );
+                    }
                 },
             );
         }

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -363,6 +363,13 @@ impl ACLService {
                     "{}",
                     serde_yaml::to_string(&config).expect("ACL config YAML serialization must not fail")
                 );
+
+                if response.rules.is_empty() {
+                    output::empty_with_hint(
+                        format_args!("No ACL rules found for '{}'.", cmd.config_name),
+                        format_args!("create one with 'yanet-cli-acl update --name <name> --rules <path>'"),
+                    );
+                }
             },
         );
 

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -336,6 +336,10 @@ impl Balancer2Service {
                 let json =
                     serde_json::to_string(&json_value).expect("balancer metrics JSON serialization must not fail");
                 println!("{json}");
+
+                if response.metrics.is_empty() {
+                    output::empty(format_args!("No balancer metrics found."));
+                }
             },
         );
 

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -156,7 +156,20 @@ impl DecapService {
             .into_inner();
         log::debug!("show config response: {response:?}");
 
-        output::data(|| &response, || print_tree(&response));
+        output::data(
+            || &response,
+            || {
+                if response.prefixes.is_empty() {
+                    output::empty_with_hint(
+                        format_args!("No decap prefixes found for '{}'.", cmd.config_name),
+                        format_args!("create one with 'yanet-cli-decap update --name <name> --prefixes <cidr>'"),
+                    );
+                    return;
+                }
+
+                print_tree(&response);
+            },
+        );
 
         Ok(())
     }

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -186,7 +186,20 @@ impl DscpService {
             .into_inner();
         log::debug!("show config response: {response:?}");
 
-        output::data(|| &response, || print_tree(&response));
+        output::data(
+            || &response,
+            || {
+                if response.config.is_none() {
+                    output::empty_with_hint(
+                        format_args!("No DSCP configuration found for '{}'.", cmd.config_name),
+                        format_args!("create one with 'yanet-cli-dscp prefix-add --name <name> --prefix <cidr>'"),
+                    );
+                    return;
+                }
+
+                print_tree(&response);
+            },
+        );
 
         Ok(())
     }
@@ -282,6 +295,10 @@ fn print_tree(response: &ShowConfigResponse) {
         }
 
         tree.begin_child("Prefixes".to_string());
+        if config.prefixes.is_empty() {
+            tree.add_empty_child("(none)".to_owned());
+        }
+
         for (idx, prefix) in config.prefixes.iter().enumerate() {
             tree.add_empty_child(format!("{idx}: {prefix}"));
         }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -199,6 +199,13 @@ impl ForwardService {
                     "{}",
                     serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")
                 );
+
+                if response.rules.is_empty() {
+                    output::empty_with_hint(
+                        format_args!("No forward rules found for '{}'.", cmd.config_name),
+                        format_args!("create one with 'yanet-cli-forward update --name <name> --rules <path>'"),
+                    );
+                }
             },
         );
 

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -199,6 +199,13 @@ impl MirrorService {
                     "{}",
                     serde_yaml::to_string(&response).expect("mirror config YAML serialization must not fail")
                 );
+
+                if response.rules.is_empty() {
+                    output::empty_with_hint(
+                        format_args!("No mirror rules found for '{}'.", cmd.config_name),
+                        format_args!("create one with 'yanet-cli-mirror update --name <name> --rules <path>'"),
+                    );
+                }
             },
         );
 

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -272,7 +272,20 @@ impl NAT64Service {
             .into_inner();
         log::debug!("show config response: {response:?}");
 
-        output::data(|| &response, || print_tree(&response));
+        output::data(
+            || &response,
+            || {
+                if response.config.is_none() {
+                    output::empty_with_hint(
+                        format_args!("No NAT64 configuration found for '{}'.", cmd.config_name),
+                        format_args!("create one with 'yanet-cli-nat64 prefix add --name <name> --prefix <cidr>'"),
+                    );
+                    return;
+                }
+
+                print_tree(&response);
+            },
+        );
 
         Ok(())
     }
@@ -418,12 +431,20 @@ fn print_tree(resp: &ShowConfigResponse) {
 
     if let Some(config) = &resp.config {
         tree.begin_child("Prefixes".to_owned());
+        if config.prefixes.is_empty() {
+            tree.add_empty_child("(none)".to_owned());
+        }
+
         for (idx, prefix) in config.prefixes.iter().enumerate() {
             tree.add_empty_child(format!("{}: {:?}", idx, prefix.prefix));
         }
         tree.end_child();
 
         tree.begin_child("Mappings".to_owned());
+        if config.mappings.is_empty() {
+            tree.add_empty_child("(none)".to_owned());
+        }
+
         for mapping in &config.mappings {
             let ipv4 = mapping.ipv4.as_ref().map(|a| a.to_string()).unwrap_or_default();
             let ipv6 = mapping.ipv6.as_ref().map(|a| a.to_string()).unwrap_or_default();

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -132,7 +132,20 @@ impl PdumpService {
     pub async fn show_config(&mut self, cmd: ShowConfigCmd) -> Result<(), Error> {
         let response = self.get_config(&cmd.config_name).await?;
 
-        output::data(|| &response, || print_tree(&response));
+        output::data(
+            || &response,
+            || {
+                if response.config.is_none() {
+                    output::empty_with_hint(
+                        format_args!("No pdump configuration found for '{}'.", cmd.config_name),
+                        format_args!("create one with 'yanet-cli-pdump set --name <name>'"),
+                    );
+                    return;
+                }
+
+                print_tree(&response);
+            },
+        );
 
         Ok(())
     }

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -258,7 +258,16 @@ impl RouteMplsService {
                 print!(
                     "{}",
                     serde_yaml::to_string(&response).expect("route-mpls config YAML serialization must not fail")
-                )
+                );
+
+                if response.rules.is_empty() {
+                    output::empty_with_hint(
+                        format_args!("No route-mpls rules found for '{}'.", cmd.config_name),
+                        format_args!(
+                            "create one with 'yanet-cli-route-mpls update --name <name> --prefix <cidr> --dst <addr> --label <n> --src <addr> --weight <n> --counter <counter-name>'"
+                        ),
+                    );
+                }
             },
         );
 


### PR DESCRIPTION
Follow-up to #1571, which unified how the CLI reports an empty result but only covered the sites that already said something. This one closes the sites that said nothing at all.

- Thirteen commands whose human render was content-free when the data was empty — a bare tree root, an echoed config name with an empty list, or an empty collection — now report through the shared helper instead, naming the filter argument they were given and suggesting the command that would create the missing thing.
- `balancer2 metrics` gains the emptiness check every sibling `metrics` subcommand already had.
- Inside a tree that still carries real content, a section with nothing in it is marked in place, so a branch header no longer dangles with nothing under it.
- Machine output is untouched: no payload changed, so `--format json` is byte-identical to before.

Sections that are one of several siblings in an otherwise useful render were audited and deliberately left silent: a readiness heartbeat carrying no changed scopes, the latency histograms, the gRPC call tables, the balancer detail sections, and the two commands that stream JSON Lines, where zero bytes is already the well-formed empty document.

A later change makes the pdump service answer an unknown config name with a not-found error rather than an empty success, at which point that one guard becomes defensive rather than load-bearing.