### PR TITLE
fix(pdump,route): report a missing config as not found

### DIFF
--- a/modules/pdump/controlplane/service.go
+++ b/modules/pdump/controlplane/service.go
@@ -102,23 +102,23 @@ func (m *PdumpService) ShowConfig(
 		return nil, status.Error(codes.InvalidArgument, errMsgConfigNameRequired)
 	}
 
-	response := &pdumppb.ShowConfigResponse{}
-
 	// Lock configs store and module updates
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if config, ok := m.configs[name]; ok {
-		response.Config = &pdumppb.Config{
+	config, ok := m.configs[name]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
+	}
+
+	return &pdumppb.ShowConfigResponse{
+		Config: &pdumppb.Config{
 			Filter:   config.Filter,
 			Mode:     config.DumpMode,
 			Snaplen:  config.Snaplen,
 			RingSize: config.Ring.PerWorkerSize,
-		}
-
-	}
-
-	return response, nil
+		},
+	}, nil
 }
 
 // SetConfig updates or creates packet capture configuration.

--- a/modules/pdump/controlplane/service_test.go
+++ b/modules/pdump/controlplane/service_test.go
@@ -1,0 +1,22 @@
+package pdump_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pdump "github.com/yanet-platform/yanet2/modules/pdump/controlplane"
+	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb/v1"
+)
+
+// TestShowConfigUnknownConfig verifies that ShowConfig reports NotFound for
+// a config name that was never set.
+func TestShowConfigUnknownConfig(t *testing.T) {
+	service := pdump.NewPdumpService(nil, zap.NewNop())
+
+	_, err := service.ShowConfig(t.Context(), &pdumppb.ShowConfigRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -172,7 +172,7 @@ func (m *RouteService) ShowFIB(
 
 	entry, ok := m.configs[name]
 	if !ok {
-		return &routepb.ShowFIBResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	entries, err := entry.Handle.DumpFIB()

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/modules/route/bindings/go/croute"
@@ -383,4 +385,26 @@ func TestConfigGaugesFollowConfigLifetime(t *testing.T) {
 	require.NoError(t, err)
 
 	requireConfigGauges(t, service, 2, 3, 1)
+}
+
+// TestShowFIBUnknownConfig verifies that ShowFIB reports NotFound for a
+// config name that was never applied, distinguishing it from a registered
+// config that genuinely holds no FIB entries.
+func TestShowFIBUnknownConfig(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	_, err := service.ShowFIB(t.Context(), &routepb.ShowFIBRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestShowFIBEmptyConfig verifies that a registered config with no FIB
+// entries still returns a normal empty success.
+func TestShowFIBEmptyConfig(t *testing.T) {
+	backend := newFakeBackend()
+	service := newServiceWithConfig(t, backend)
+
+	response, err := service.ShowFIB(t.Context(), &routepb.ShowFIBRequest{Name: "cfg"})
+	require.NoError(t, err)
+	require.Empty(t, response.GetEntries())
 }

--- a/operators/route/internal/operator/service_route.go
+++ b/operators/route/internal/operator/service_route.go
@@ -100,7 +100,7 @@ func (m *RouteService) ShowRoutes(
 
 	holder, ok := m.getRib(name)
 	if !ok {
-		return &operatorpb.ShowRoutesResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 	ribDump := holder.DumpRoutes()
 
@@ -145,7 +145,7 @@ func (m *RouteService) LookupRoute(
 
 	holder, ok := m.getRib(name)
 	if !ok {
-		return &operatorpb.LookupRouteResponse{}, nil
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	prefix, routes, ok := holder.LongestMatch(addr)

--- a/operators/route/internal/operator/service_route_test.go
+++ b/operators/route/internal/operator/service_route_test.go
@@ -83,6 +83,64 @@ func TestShowRoutes_BirdDifferentPref_OnlyBetterIsBest(t *testing.T) {
 	require.True(t, bestByNexthop["10.0.0.2"], "static route must be best within its source")
 }
 
+// TestShowRoutes_UnknownConfig_NotFound verifies that ShowRoutes reports
+// NotFound for a config name that was never registered, distinguishing it
+// from a registered config that genuinely holds no routes.
+func TestShowRoutes_UnknownConfig_NotFound(t *testing.T) {
+	svc := NewRouteService(neigh.NewNeighTable())
+
+	_, err := svc.ShowRoutes(t.Context(), &operatorpb.ShowRoutesRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestShowRoutes_EmptyConfig_Success verifies that a registered config with
+// no routes still returns a normal empty success.
+func TestShowRoutes_EmptyConfig_Success(t *testing.T) {
+	svc := NewRouteService(neigh.NewNeighTable())
+	svc.getOrCreateRib("route0")
+
+	resp, err := svc.ShowRoutes(t.Context(), &operatorpb.ShowRoutesRequest{Name: "route0"})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetRoutes())
+}
+
+// TestLookupRoute_ThreeWay verifies that LookupRoute distinguishes an
+// unknown config (NotFound) from a registered config with no matching route
+// (empty success) and from a registered config with a match (the route).
+func TestLookupRoute_ThreeWay(t *testing.T) {
+	svc := NewRouteService(neigh.NewNeighTable())
+
+	addr := commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1"))
+
+	t.Run("unknown config", func(t *testing.T) {
+		_, err := svc.LookupRoute(t.Context(), &operatorpb.LookupRouteRequest{Name: "missing", IpAddr: addr})
+		require.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("no matching route", func(t *testing.T) {
+		svc.getOrCreateRib("route0")
+
+		resp, err := svc.LookupRoute(t.Context(), &operatorpb.LookupRouteRequest{Name: "route0", IpAddr: addr})
+		require.NoError(t, err)
+		require.Empty(t, resp.GetRoutes())
+	})
+
+	t.Run("matching route", func(t *testing.T) {
+		_, err := svc.InsertRoute(t.Context(), &operatorpb.InsertRouteRequest{
+			Name:         "route0",
+			Prefix:       "10.0.0.0/24",
+			NexthopAddrs: []*commonpb.IPAddress{commonpb.NewIPAddressFromAddr(netip.MustParseAddr("192.168.1.1"))},
+			SourceId:     operatorpb.RouteSourceID_ROUTE_SOURCE_ID_STATIC,
+		})
+		require.NoError(t, err)
+
+		resp, err := svc.LookupRoute(t.Context(), &operatorpb.LookupRouteRequest{Name: "route0", IpAddr: addr})
+		require.NoError(t, err)
+		require.Equal(t, "10.0.0.0/24", resp.GetPrefix())
+		require.Len(t, resp.GetRoutes(), 1)
+	})
+}
+
 func TestInsertRoute_NonStaticMultipleNexthops_InvalidArgument(t *testing.T) {
 	svc := NewRouteService(neigh.NewNeighTable())
 


### PR DESCRIPTION
Four control-plane handlers answered an unknown configuration name with an empty success response, so a typo produced output byte-identical to a correctly named but genuinely empty result — the wrong signal to hand someone debugging under pressure. They now return a not-found error, which is what every sibling service already does.

- `pdump show`, `route fib show`, and the route operator's `show routes` and `lookup` all report a missing configuration as an error instead of an empty answer.
- A lookup that matches no route on a configuration that does exist is unchanged: still an ordinary empty answer, since that is the genuinely intended miss.
- A configuration that exists and is genuinely empty is likewise unchanged.
- The route page in the web UI reports a per-configuration load failure instead of failing the whole page, because a configuration deleted while the page is loading can now answer with an error.

Closes the first of the two remaining steps of the CLI empty-output series; the second covers forward and mirror, which return the wrong code for the same condition.