### PR TITLE
feat(controlplane): add agent_delete_device

### DIFF
--- a/api/agent.h
+++ b/api/agent.h
@@ -204,6 +204,15 @@ agent_update_devices(
 	yanet_error **err
 );
 
+// Delete device with specified name.
+//
+// @return -1 if device does not exist or is a predefined topology
+// device, 0 on success.
+int
+agent_delete_device(
+	struct agent *agent, const char *device_name, yanet_error **err
+);
+
 // Update shared objects in the active configuration generation.
 //
 // Each object in objects is upserted by name into the new generation; an

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -680,6 +680,25 @@ agent_update_devices(
 }
 
 int
+agent_delete_device(
+	struct agent *agent, const char *device_name, yanet_error **err
+) {
+	struct dp_config *dp_config = ADDR_OF(&agent->dp_config);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	int ret =
+		cp_config_delete_device(dp_config, cp_config, device_name, err);
+
+	if (ret != 0) {
+		return -1;
+	}
+
+	agent_free_unused_agents(agent);
+
+	return 0;
+}
+
+int
 agent_update_objects(
 	struct agent *agent,
 	uint64_t object_count,

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -164,6 +164,15 @@ agent_update_devices(
 	yanet_error **err
 );
 
+// Delete device with specified name.
+//
+// @return -1 if device does not exist or is a predefined topology
+// device, 0 on success.
+int
+agent_delete_device(
+	struct agent *agent, const char *device_name, yanet_error **err
+);
+
 int
 agent_update_objects(
 	struct agent *agent,

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -1,5 +1,6 @@
 #include "zone.h"
 
+#include <errno.h>
 #include <unistd.h>
 
 #include "controlplane/config/econtext.h"
@@ -661,6 +662,60 @@ cp_config_update_devices(
 			);
 			goto error_free;
 		}
+	}
+
+	if (cp_config_gen_install(dp_config, cp_config, new_config_gen, err)) {
+		goto error_free;
+	}
+	cp_config_unlock(cp_config);
+
+	return 0;
+
+error_free:
+	cp_config_gen_free(cp_config, new_config_gen);
+error_unlock:
+	cp_config_unlock(cp_config);
+	return -1;
+}
+
+int
+cp_config_delete_device(
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *name,
+	yanet_error **err
+) {
+	// Reject deletion of predefined topology devices.
+	for (uint64_t idx = 0; idx < dp_config->dp_topology.device_count;
+	     ++idx) {
+		struct dp_port *port =
+			&ADDR_OF(&dp_config->dp_topology.devices)[idx];
+		if (strncmp(port->device_name, name, CP_DEVICE_NAME_LEN) == 0) {
+			errno = EBUSY;
+			yanet_error_add(
+				err,
+				"device '%s' is a predefined topology device "
+				"and cannot be deleted",
+				name
+			);
+			return -1;
+		}
+	}
+
+	cp_config_lock(cp_config);
+
+	struct cp_config_gen *old_config_gen =
+		ADDR_OF(&cp_config->cp_config_gen);
+
+	struct cp_config_gen *new_config_gen =
+		cp_config_gen_new_from(cp_config, old_config_gen, err);
+	if (new_config_gen == NULL) {
+		goto error_unlock;
+	}
+
+	if (cp_device_registry_delete(&new_config_gen->device_registry, name)) {
+		yanet_error_add(err, "device '%s' not found", name);
+		goto error_free;
 	}
 
 	if (cp_config_gen_install(dp_config, cp_config, new_config_gen, err)) {

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -196,6 +196,18 @@ cp_config_update_devices(
 	yanet_error **err
 );
 
+// Delete device with specified name.
+//
+// Returns -1 if the device does not exist or is a predefined topology
+// device (created automatically for each dataplane port), 0 on success.
+int
+cp_config_delete_device(
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *name,
+	yanet_error **err
+);
+
 int
 cp_config_update_objects(
 	struct dp_config *dp_config,


### PR DESCRIPTION
Adds a single-device delete entry point matching the existing agent_delete_module, agent_delete_function, and agent_delete_pipeline patterns.

- Previously, removing one device required rebuilding and resubmitting the entire device list via agent_update_devices.
- The implementation calls cp_device_registry_delete inside a new configuration generation, following the same lock-copy-install flow used by the other delete operations.
- Predefined topology devices (one per dataplane port, created automatically during config generation init) are protected: if the requested name matches a dp_topology.devices entry, EBUSY is returned.

Closes #1568.