### PR TITLE
fix(forward,mirror,acl): report a missing config as not found

### DIFF
--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -367,7 +367,7 @@ func (m *ACLService) DeleteConfig(
 
 	config, ok := m.configs[name]
 	if !ok {
-		return nil, status.Error(codes.InvalidArgument, "not found")
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	if config.acl != nil {

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -369,6 +369,15 @@ func TestUpdateConfig_RejectsNonContiguousMask(t *testing.T) {
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 }
 
+// TestDeleteConfig_UnknownConfig verifies that DeleteConfig reports
+// codes.NotFound for a config name that was never applied.
+func TestDeleteConfig_UnknownConfig(t *testing.T) {
+	svc := newTestService(newFakeBackend(0))
+
+	_, err := svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
 // TestUpdateConfig_ConcurrentRace exercises UpdateConfig and ShowConfig under
 // concurrent access to surface data races under go test -race.
 func TestUpdateConfig_ConcurrentRace(t *testing.T) {

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -80,7 +80,7 @@ func (m *ForwardService) ShowConfig(ctx context.Context, req *forwardpb.ShowConf
 	config, ok := m.configs[req.Name]
 
 	if !ok {
-		return nil, status.Error(codes.InvalidArgument, "not found")
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	response := &forwardpb.ShowConfigResponse{
@@ -179,7 +179,7 @@ func (m *ForwardService) DeleteConfig(ctx context.Context, req *forwardpb.Delete
 
 	config, ok := m.configs[name]
 	if !ok {
-		return nil, status.Error(codes.InvalidArgument, "not found")
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	if err := m.backend.DeleteModule(name); err != nil {

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
 	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
@@ -29,6 +31,37 @@ func (m *mockBackend) DeleteModule(name string) error {
 
 func (m *mockBackend) ModuleCounters(name string, counterNames []string) []forward.CounterView {
 	return nil
+}
+
+// TestShowConfigUnknownConfig verifies that ShowConfig reports NotFound for
+// a config name that was never applied.
+func TestShowConfigUnknownConfig(t *testing.T) {
+	svc := forward.NewForwardService(&mockBackend{})
+
+	_, err := svc.ShowConfig(t.Context(), &forwardpb.ShowConfigRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestDeleteConfigUnknownConfig verifies that DeleteConfig reports NotFound
+// for a config name that was never applied.
+func TestDeleteConfigUnknownConfig(t *testing.T) {
+	svc := forward.NewForwardService(&mockBackend{})
+
+	_, err := svc.DeleteConfig(t.Context(), &forwardpb.DeleteConfigRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestShowConfigEmptyRules verifies that ShowConfig succeeds with an empty
+// rule list for a config that was applied without rules.
+func TestShowConfigEmptyRules(t *testing.T) {
+	svc := forward.NewForwardService(&mockBackend{})
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{Name: "empty"})
+	require.NoError(t, err)
+
+	response, err := svc.ShowConfig(t.Context(), &forwardpb.ShowConfigRequest{Name: "empty"})
+	require.NoError(t, err)
+	require.Empty(t, response.GetRules())
 }
 
 // Run with: go test -race

--- a/modules/mirror/controlplane/service.go
+++ b/modules/mirror/controlplane/service.go
@@ -80,7 +80,7 @@ func (m *MirrorService) ShowConfig(
 	config, ok := m.configs[req.Name]
 
 	if !ok {
-		return nil, status.Error(codes.InvalidArgument, "not found")
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	response := &mirrorpb.ShowConfigResponse{
@@ -190,7 +190,7 @@ func (m *MirrorService) DeleteConfig(
 
 	config, ok := m.configs[name]
 	if !ok {
-		return nil, status.Error(codes.InvalidArgument, "not found")
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	if err := m.backend.DeleteModule(name); err != nil {

--- a/modules/mirror/controlplane/service_test.go
+++ b/modules/mirror/controlplane/service_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/modules/mirror/bindings/go/cmirror"
 	mirror "github.com/yanet-platform/yanet2/modules/mirror/controlplane"
@@ -28,6 +30,37 @@ func (m *mockBackend) UpdateModule(
 
 func (m *mockBackend) DeleteModule(name string) error {
 	return nil
+}
+
+// TestShowConfigUnknownConfig verifies that ShowConfig reports NotFound for
+// a config name that was never applied.
+func TestShowConfigUnknownConfig(t *testing.T) {
+	svc := mirror.NewMirrorService(&mockBackend{})
+
+	_, err := svc.ShowConfig(t.Context(), &mirrorpb.ShowConfigRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestDeleteConfigUnknownConfig verifies that DeleteConfig reports NotFound
+// for a config name that was never applied.
+func TestDeleteConfigUnknownConfig(t *testing.T) {
+	svc := mirror.NewMirrorService(&mockBackend{})
+
+	_, err := svc.DeleteConfig(t.Context(), &mirrorpb.DeleteConfigRequest{Name: "missing"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestShowConfigEmptyRules verifies that ShowConfig succeeds with an empty
+// rule list for a config that was applied without rules.
+func TestShowConfigEmptyRules(t *testing.T) {
+	svc := mirror.NewMirrorService(&mockBackend{})
+
+	_, err := svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{Name: "empty"})
+	require.NoError(t, err)
+
+	response, err := svc.ShowConfig(t.Context(), &mirrorpb.ShowConfigRequest{Name: "empty"})
+	require.NoError(t, err)
+	require.Empty(t, response.GetRules())
 }
 
 // Run with: go test -race


### PR DESCRIPTION
Showing or deleting a configuration that does not exist reported an invalid argument — the same class of error a malformed flag produces — so a script branching on the exit code could not distinguish "no such config" from "you typed the flag wrong". These handlers now answer with a not-found error, which is what every sibling module already does and what the previous change in this series established for pdump and route.

- `forward show` and `mirror show` report a missing configuration as not found.
- The delete handlers of forward, mirror and acl carried the same defect and are fixed with them, since they are one class rather than three sites.
- A missing or empty name argument is still an invalid argument, which is the correct code for it.

Completes the gRPC-code half of the CLI empty-output series.