### PR TITLE
refactor(cli): route every table through the shared style helper

### DIFF
--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -49,6 +49,11 @@ pub fn terminal_width() -> Option<usize> {
 }
 
 /// Apply the standard YANET table style to `table`.
+///
+/// Border and header color follow [`crate::output::is_colored`], so a
+/// `NO_COLOR` run, a non-UTF-8 locale, or a redirected stderr gets the same
+/// border layout with no ANSI escapes. The border glyph set itself is
+/// unconditional.
 fn apply_style(table: &mut Table) {
     table.with(
         Style::modern()
@@ -56,8 +61,11 @@ fn apply_style(table: &mut Table) {
             .remove_frame()
             .remove_horizontal(),
     );
-    table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-    table.modify(Rows::first(), Color::BOLD);
+
+    if crate::output::is_colored() {
+        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
+        table.modify(Rows::first(), Color::BOLD);
+    }
 }
 
 /// Returns the bar length for a histogram bucket, scaled to `BAR_MAX`.

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -6,14 +6,7 @@ use bytesize::ByteSize;
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
 use colored::Colorize;
-use tabled::{
-    settings::{
-        object::{Columns, Rows},
-        style::{BorderColor, HorizontalLine},
-        Color, Style,
-    },
-    Table, Tabled,
-};
+use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
@@ -499,18 +492,7 @@ fn format_worker_counters(response: &WorkerCountersResponse) {
     }
 
     let rows: Vec<WorkerRow> = response.workers.iter().map(WorkerRow::from).collect();
-    let mut table = Table::new(&rows);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
-    if output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-        table.modify(Rows::first(), Color::BOLD);
-    }
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
+    ync::display::print_table_from_entries(rows);
 
     for worker in &response.workers {
         print_worker_histogram(worker);

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -4,14 +4,7 @@ use std::time::SystemTime;
 
 use clap::{ArgAction, CommandFactory, Parser};
 use clap_complete::CompleteEnv;
-use tabled::{
-    Table, Tabled,
-    settings::{
-        Color, Style,
-        object::{Columns, Rows},
-        style::{BorderColor, HorizontalLine},
-    },
-};
+use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
@@ -103,7 +96,7 @@ impl GatewayService {
                     return;
                 }
 
-                render_table(&rows);
+                ync::display::print_table_from_entries(&rows);
             },
         );
 
@@ -168,23 +161,6 @@ fn last_seen_cell(kind: BackendKind, ts: Option<&prost_types::Timestamp>) -> Str
             humanfmt::format_age(ts, SystemTime::now()).unwrap_or_else(|| "-".to_string())
         }
     }
-}
-
-fn render_table(rows: &[ServiceRow]) {
-    let mut table = Table::new(rows);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
-
-    if output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-        table.modify(Rows::first(), Color::BOLD);
-    }
-
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
 }
 
 #[cfg(test)]

--- a/cli/modules/metrics/src/main.rs
+++ b/cli/modules/metrics/src/main.rs
@@ -6,14 +6,7 @@ use clap_complete::{
     engine::{ArgValueCandidates, CompletionCandidate},
 };
 use commonpb::pb::{GetMetricsRequest, GetMetricsResponse, Histogram, Label, Metric, MetricTag, metric::Value};
-use tabled::{
-    Table, Tabled,
-    settings::{
-        Color, Style,
-        object::{Columns, Rows},
-        style::{BorderColor, HorizontalLine},
-    },
-};
+use tabled::Tabled;
 use ync::{
     client::{Connection, ConnectionArgs},
     completion,
@@ -204,7 +197,7 @@ async fn run_probe(connection: &Connection, name: &str, tags: Vec<MetricTag>) ->
 
             if !scalars.is_empty() {
                 let rows: Vec<MetricRow> = scalars.iter().map(|m| MetricRow::from(*m)).collect();
-                print_metrics_table(rows);
+                ync::display::print_table_from_entries(rows);
             }
 
             if !histograms.is_empty() {
@@ -329,23 +322,6 @@ impl From<&Metric> for MetricRow {
             value,
         }
     }
-}
-
-fn print_metrics_table(rows: Vec<MetricRow>) {
-    let mut table = Table::new(&rows);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
-
-    if output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-        table.modify(Rows::first(), Color::BOLD);
-    }
-
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
 }
 
 /// Returns the `k=v, k=v` join of `labels`, or an empty string when `labels`

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -17,14 +17,7 @@ use clap_complete::{
 };
 use colored::Colorize;
 use netip::{Contiguous, IpNetwork};
-use tabled::{
-    Table, Tabled,
-    settings::{
-        Color, Style,
-        object::{Columns, Rows},
-        style::{BorderColor, HorizontalLine},
-    },
-};
+use tabled::Tabled;
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{Connection, ConnectionArgs, LayeredChannel, Service},
@@ -580,20 +573,7 @@ fn annotate_ecmp_groups(entries: &mut [RouteEntry]) {
 }
 
 fn print_route_table(entries: Vec<RouteEntry>) {
-    let mut table = Table::new(&entries);
-    table.with(
-        Style::modern()
-            .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
-            .remove_horizontal(),
-    );
-
-    if output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
-        table.modify(Rows::first(), Color::BOLD);
-    }
-
-    ync::display::fit_terminal_width(&mut table);
-    println!("{table}");
+    ync::display::print_table_from_entries(entries);
 }
 
 /// Returns the lowercase display name for a `RouteSourceId` discriminant.


### PR DESCRIPTION
Four renderers hand-copied the house table style instead of calling the shared helper, and had drifted from it: they kept an outer box border that no other list command draws, so otherwise identical-looking commands rendered differently. They now call the helper, which removes the last copies of the style chain — the style is declared in exactly one place.

The copies were also right about one thing the helper was wrong about: they gated their colour on terminal capability, while the helper applied it unconditionally. That gate moves into the helper, so every table stops emitting escape sequences when colour is off, not just those four. The border glyph set stays unconditional, as it is elsewhere.

Two renderers became one-line wrappers around the helper call and were inlined at their single call site.