### PR TITLE
refactor(cli): declare each interface colour in one place

### DIFF
--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -55,6 +55,9 @@ pub fn terminal_width() -> Option<usize> {
 /// border layout with no ANSI escapes. The border glyph set itself is
 /// unconditional.
 fn apply_style(table: &mut Table) {
+    /// Colour of a table's cell borders.
+    const TABLE_BORDER_COLOR: (u8, u8, u8) = (0x4e, 0x4e, 0x4e);
+
     table.with(
         Style::modern()
             .horizontals([(1, HorizontalLine::inherit(Style::modern()))])
@@ -63,7 +66,8 @@ fn apply_style(table: &mut Table) {
     );
 
     if crate::output::is_colored() {
-        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(0x4e, 0x4e, 0x4e)));
+        let (r, g, b) = TABLE_BORDER_COLOR;
+        table.modify(Columns::new(..), BorderColor::filled(Color::rgb_fg(r, g, b)));
         table.modify(Rows::first(), Color::BOLD);
     }
 }

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -379,10 +379,20 @@ pub fn is_colored() -> bool {
 /// carries no escape codes.
 pub fn dim(text: &str) -> String {
     if is_colored() {
-        text.truecolor(127, 127, 127).to_string()
+        paint_dim(text)
     } else {
         text.to_string()
     }
+}
+
+/// Paints `text` in the secondary grey, without consulting [`is_colored`].
+///
+/// Call this from a site that has already made its own colour decision,
+/// either from an explicit `colored` flag or from an enclosing
+/// [`is_colored`] branch. Everyone else should call [`dim`], which makes
+/// that decision itself.
+pub fn paint_dim(text: &str) -> String {
+    text.truecolor(127, 127, 127).to_string()
 }
 
 /// Returns `true` if the current locale advertises UTF-8 encoding.

--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -34,6 +34,8 @@ const STATE_WIDTH: usize = 9;
 const REASON_INDENT_COLORED: usize = 3 + 1;
 /// Display width of an ASCII mark (e.g. `[ok]`) plus its separating space.
 const REASON_INDENT_ASCII: usize = 4 + 1;
+/// Colour marking a stale readiness observation's age tag.
+const STALE_TAG_COLOR: (u8, u8, u8) = (180, 140, 0);
 
 /// Leading indent for reason continuation lines.
 ///
@@ -183,7 +185,8 @@ fn print_scope_row(
         let stale_age = humanfmt::format_age(scope.observed_at.as_ref(), now).unwrap_or_default();
         let tag = format!("stale {stale_age}");
         let tag = if colored {
-            tag.truecolor(180, 140, 0).to_string()
+            let (r, g, b) = STALE_TAG_COLOR;
+            tag.truecolor(r, g, b).to_string()
         } else {
             tag
         };
@@ -214,7 +217,7 @@ impl StateStyle {
             State::Ready => ("[✓]", "[ok]", |s| s.green().to_string()),
             State::Degraded => ("[~]", "[!!]", |s| s.yellow().to_string()),
             State::NotReady => ("[✗]", "[xx]", |s| s.red().to_string()),
-            State::Unknown | State::Unspecified => ("[?]", "[??]", |s| s.truecolor(127, 127, 127).to_string()),
+            State::Unknown | State::Unspecified => ("[?]", "[??]", output::paint_dim),
         };
 
         let mark = if colored { unicode_mark } else { ascii_mark };
@@ -258,7 +261,7 @@ fn state_cells(state: State, colored: bool) -> (String, String) {
 /// a transition line.
 fn dim(text: &str, colored: bool) -> String {
     if colored {
-        text.truecolor(127, 127, 127).to_string()
+        output::paint_dim(text)
     } else {
         text.to_string()
     }

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -469,7 +469,7 @@ impl Display for Prefix {
                     write!(f, "{s}")
                 }
             } else {
-                write!(f, "{}", s.truecolor(127, 127, 127))
+                write!(f, "{}", output::paint_dim(&s))
             }
         } else if *is_best && *ecmp_size > 1 {
             write!(f, "{s} ⇉")


### PR DESCRIPTION
The grey reserved for secondary text was spelled out as a raw colour triple at four call sites, so nothing tied them together and a change to one would have silently drifted from the rest. It now has a single painter in the core CLI library that every site calls.

- Each caller keeps its own decision about whether to colour at all, because they differ: one reads the global terminal capability, one receives the decision as an argument so a render can be driven either way, and two already sit inside such a branch.
- The table border grey and the stale-observation amber are separate visual tiers rather than the same colour, so they stay distinct and are simply named for what they mark.
- No output changes in any colour mode; this only moves where the values are declared.