### PR TITLE
fix(cli): wrap a long empty-result hint with a hanging indent

### DIFF
--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -43,9 +43,61 @@ pub fn fit_terminal_width(table: &mut Table) {
 /// Returns the current terminal width in columns, detected from stdout.
 ///
 /// Returns `None` when stdout is not a TTY (piped or redirected), matching
-/// the same detection [`fit_terminal_width`] uses.
+/// the same detection [`fit_terminal_width`] uses. See [`stderr_width`] for
+/// the stderr counterpart.
 pub fn terminal_width() -> Option<usize> {
     terminal_size_of(std::io::stdout()).map(|(terminal_size::Width(cols), _)| cols as usize)
+}
+
+/// Returns the current terminal width in columns, detected from stderr.
+///
+/// Counterpart to [`terminal_width`], which reads stdout.
+/// [`crate::output::empty`] and [`crate::output::empty_with_hint`] write their
+/// report to stderr, so their wrapping must be measured against that channel
+/// instead.
+///
+/// Stdout redirected is not a reachable case here: both callers already
+/// return early whenever stdout itself is not a terminal. The case this
+/// function exists for is the opposite one — stderr redirected to a file
+/// while stdout stays a terminal. Measuring stdout there would wrap the
+/// file stderr is writing to against an unrelated terminal's width;
+/// [`crate::output::is_colored`], which already reads stderr for the same
+/// reason, is the existing precedent for measuring this channel instead.
+pub fn stderr_width() -> Option<usize> {
+    terminal_size_of(std::io::stderr()).map(|(terminal_size::Width(cols), _)| cols as usize)
+}
+
+/// Greedily wraps `text` into lines of at most `width` columns, breaking
+/// only at whitespace.
+///
+/// A word longer than `width` is kept whole on its own (overflowing) line
+/// rather than split. Returns `text` unchanged as a single line when
+/// `width` is `0`.
+pub fn wrap_words(text: &str, width: usize) -> Vec<String> {
+    if width == 0 {
+        return vec![text.to_string()];
+    }
+
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current.push_str(word);
+        } else if current.chars().count() + 1 + word.chars().count() <= width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+    }
+
+    if !current.is_empty() || lines.is_empty() {
+        lines.push(current);
+    }
+
+    lines
 }
 
 /// Apply the standard YANET table style to `table`.
@@ -95,7 +147,7 @@ pub fn bar_len(count: u64, max_count: u64) -> usize {
 
 #[cfg(test)]
 mod test {
-    use super::bar_len;
+    use super::{bar_len, wrap_words};
 
     #[test]
     fn bar_len_scaling() {
@@ -108,5 +160,36 @@ mod test {
     fn bar_len_edge_cases() {
         assert_eq!(1, bar_len(1, 1000));
         assert_eq!(0, bar_len(5, 0));
+    }
+
+    #[test]
+    fn wrap_words_fits_within_width() {
+        assert_eq!(vec!["aa bb".to_string(), "cc".to_string()], wrap_words("aa bb cc", 5));
+    }
+
+    #[test]
+    fn wrap_words_keeps_long_word_whole() {
+        assert_eq!(
+            vec!["superlongword".to_string(), "short".to_string()],
+            wrap_words("superlongword short", 5)
+        );
+    }
+
+    #[test]
+    fn wrap_words_zero_width_returns_single_line() {
+        assert_eq!(vec!["one long line".to_string()], wrap_words("one long line", 0));
+    }
+
+    #[test]
+    fn wrap_words_counts_columns_not_bytes() {
+        // Each em dash is 3 UTF-8 bytes but a single display column, so a
+        // width of 5 must fit both of them plus their surrounding letters
+        // on one line — byte-counting would wrap one column early.
+        assert_eq!(vec!["a — b".to_string()], wrap_words("a — b", 5));
+    }
+
+    #[test]
+    fn wrap_words_empty_text_returns_one_empty_line() {
+        assert_eq!(vec![String::new()], wrap_words("", 10));
     }
 }

--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -18,6 +18,7 @@ use erased_serde::Serialize as ErasedSerialize;
 use serde::Serialize;
 
 use crate::{
+    display,
     errors::{Error, ErrorKind},
     logging,
 };
@@ -296,7 +297,7 @@ pub fn empty(message: Arguments) {
         return;
     }
 
-    print_empty_line(&format!("{} {message}", empty_mark()));
+    print_empty_line(mark_prefix(), &message.to_string());
 }
 
 /// Reports an empty result together with the command that would create one.
@@ -311,8 +312,26 @@ pub fn empty_with_hint(message: Arguments, hint: Arguments) {
         return;
     }
 
-    print_empty_line(&format!("{} {message}", empty_mark()));
-    print_empty_line(&format!("    hint: {hint}"));
+    print_empty_line(mark_prefix(), &message.to_string());
+    print_empty_line(HINT_PREFIX, &hint.to_string());
+}
+
+/// Prefix of the hint line: the four-space detail indent and the `hint:`
+/// label.
+const HINT_PREFIX: &str = "    hint: ";
+
+/// Returns the mark prefixing an empty-result line.
+///
+/// The Unicode en dash when colour is enabled, an ASCII hyphen otherwise —
+/// a third mark joining the `[✓]`/`[OK]` and `[✗]`/`[ERR]` fallback pairs
+/// [`HumanOutput`]'s [`success`](Output::success)/[`failure`](Output::failure)
+/// already use.
+fn mark_prefix() -> &'static str {
+    if is_colored() {
+        "[–] "
+    } else {
+        "[-] "
+    }
 }
 
 /// Returns `true` if an empty-result report should be suppressed.
@@ -328,24 +347,38 @@ fn suppress_empty(serializes: bool, stdout_is_terminal: bool) -> bool {
     serializes || !stdout_is_terminal
 }
 
-/// Returns the mark prefixing an empty-result line.
+/// Writes one line of an empty-result report to stderr, wrapped to the
+/// current stderr width with a hanging indent, and greyed via [`dim`] when
+/// colour is enabled.
 ///
-/// The Unicode en dash when colour is enabled, an ASCII hyphen otherwise —
-/// a third mark joining the `[✓]`/`[OK]` and `[✗]`/`[ERR]` fallback pairs
-/// [`HumanOutput`]'s [`success`](Output::success)/[`failure`](Output::failure)
-/// already use.
-fn empty_mark() -> &'static str {
-    if is_colored() {
-        "[–]"
-    } else {
-        "[-]"
-    }
-}
+/// `prefix` is the literal lead-in before `text` — [`mark_prefix`] for the
+/// mark line, [`HINT_PREFIX`] for the hint line — and its character count
+/// becomes the indent for any wrapped continuation line, so a continuation
+/// lines up under the first line's own text rather than under the prefix.
+///
+/// `text` is wrapped in its plain, undimmed form and each resulting line is
+/// dimmed afterwards: [`dim`] inserts ANSI escape bytes that must never be
+/// counted as display columns.
+///
+/// When the stderr width is unknown, or too narrow to leave room for the
+/// indent, `text` is printed on one unwrapped line, exactly as before this
+/// function wrapped at all.
+fn print_empty_line(prefix: &str, text: &str) {
+    let indent = prefix.chars().count();
 
-/// Writes one line of an empty-result report to stderr, greyed via
-/// [`dim`] when colour is enabled.
-fn print_empty_line(text: &str) {
-    eprintln!("{}", dim(text));
+    let mut lines = match display::stderr_width() {
+        Some(width) if width > indent => display::wrap_words(text, width - indent),
+        _ => vec![text.to_string()],
+    }
+    .into_iter();
+
+    let first = lines.next().expect("wrap_words returns at least one line");
+    eprintln!("{}", dim(&format!("{prefix}{first}")));
+
+    let indent = " ".repeat(indent);
+    for line in lines {
+        eprintln!("{}", dim(&format!("{indent}{line}")));
+    }
 }
 
 /// Returns `true` if stdout is a terminal, memoized on first call.

--- a/cli/modules/ready/src/render/layout.rs
+++ b/cli/modules/ready/src/render/layout.rs
@@ -1,4 +1,6 @@
-//! Text-layout helpers: the scope-name column width and word wrapping.
+//! Text-layout helpers: the scope-name column width and whitespace
+//! normalization. Word wrapping itself lives in `ync::display::wrap_words`,
+//! shared with the core CLI's own output helpers.
 
 const MIN_NAME_WIDTH: usize = 12;
 const MAX_NAME_WIDTH: usize = 40;
@@ -15,39 +17,6 @@ pub fn name_width<'a>(names: impl IntoIterator<Item = &'a str>) -> usize {
         .max()
         .unwrap_or(MIN_NAME_WIDTH)
         .clamp(MIN_NAME_WIDTH, MAX_NAME_WIDTH)
-}
-
-/// Greedily wraps `text` into lines of at most `width` columns, breaking
-/// only at whitespace.
-///
-/// A word longer than `width` is kept whole on its own (overflowing) line
-/// rather than split. Returns `text` unchanged as a single line when
-/// `width` is `0`.
-pub fn wrap_words(text: &str, width: usize) -> Vec<String> {
-    if width == 0 {
-        return vec![text.to_string()];
-    }
-
-    let mut lines = Vec::new();
-    let mut current = String::new();
-
-    for word in text.split_whitespace() {
-        if current.is_empty() {
-            current.push_str(word);
-        } else if current.chars().count() + 1 + word.chars().count() <= width {
-            current.push(' ');
-            current.push_str(word);
-        } else {
-            lines.push(std::mem::take(&mut current));
-            current.push_str(word);
-        }
-    }
-
-    if !current.is_empty() || lines.is_empty() {
-        lines.push(current);
-    }
-
-    lines
 }
 
 /// Collapses every run of whitespace in `text` — including embedded
@@ -83,37 +52,6 @@ mod test {
     #[test]
     fn name_width_empty_defaults_to_minimum() {
         assert_eq!(MIN_NAME_WIDTH, name_width(std::iter::empty()));
-    }
-
-    #[test]
-    fn wrap_words_fits_within_width() {
-        assert_eq!(vec!["aa bb".to_string(), "cc".to_string()], wrap_words("aa bb cc", 5));
-    }
-
-    #[test]
-    fn wrap_words_keeps_long_word_whole() {
-        assert_eq!(
-            vec!["superlongword".to_string(), "short".to_string()],
-            wrap_words("superlongword short", 5)
-        );
-    }
-
-    #[test]
-    fn wrap_words_zero_width_returns_single_line() {
-        assert_eq!(vec!["one long line".to_string()], wrap_words("one long line", 0));
-    }
-
-    #[test]
-    fn wrap_words_counts_columns_not_bytes() {
-        // Each em dash is 3 UTF-8 bytes but a single display column, so a
-        // width of 5 must fit both of them plus their surrounding letters
-        // on one line — byte-counting would wrap one column early.
-        assert_eq!(vec!["a — b".to_string()], wrap_words("a — b", 5));
-    }
-
-    #[test]
-    fn wrap_words_empty_text_returns_one_empty_line() {
-        assert_eq!(vec![String::new()], wrap_words("", 10));
     }
 
     #[test]

--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -16,10 +16,7 @@ use colored::Colorize;
 use readinesspb::pb::{Reason, Scope, State};
 use ync::{display, humanfmt, output};
 
-use self::{
-    age::is_stale,
-    layout::{normalize_whitespace, wrap_words},
-};
+use self::{age::is_stale, layout::normalize_whitespace};
 pub use self::{
     layout::name_width,
     watch::{
@@ -310,7 +307,7 @@ fn print_reason_lines(reasons: &[Reason], colored: bool, wrap_width: Option<usiz
         let text = format_reason(reason);
 
         let lines = match wrap_width {
-            Some(width) if width > reason_indent => wrap_words(&text, width - reason_indent),
+            Some(width) if width > reason_indent => display::wrap_words(&text, width - reason_indent),
             _ => vec![normalize_whitespace(&text)],
         };
 

--- a/cli/modules/ready/src/render/watch.rs
+++ b/cli/modules/ready/src/render/watch.rs
@@ -11,10 +11,7 @@ use colored::Colorize;
 use readinesspb::pb::{Scope, State};
 use ync::{display, output};
 
-use super::{
-    StateStyle, Symbols, dim,
-    layout::{normalize_whitespace, wrap_words},
-};
+use super::{StateStyle, Symbols, dim, layout::normalize_whitespace};
 
 /// Gap between the transition line's prefix and the reason text that follows
 /// it on the same line.
@@ -220,7 +217,7 @@ pub fn print_transition_line(service: ServiceColumn, scope: &Scope, name_width: 
         let reason_text = super::format_reason(reason);
 
         let lines = match wrap_width {
-            Some(width) if width > indent => wrap_words(&reason_text, width - indent),
+            Some(width) if width > indent => display::wrap_words(&reason_text, width - indent),
             _ => vec![normalize_whitespace(&reason_text)],
         };
 
@@ -263,7 +260,7 @@ pub fn print_lifecycle_line(alias: &str, alias_width: usize, message: &str) {
     print!("{}", dim(&prefix, colored));
 
     let lines = match wrap_width {
-        Some(width) if width > indent => wrap_words(message, width - indent),
+        Some(width) if width > indent => display::wrap_words(message, width - indent),
         _ => vec![normalize_whitespace(message)],
     };
 
@@ -382,7 +379,7 @@ pub fn print_membership_line(alias: &str, alias_width: usize, membership: Member
     print!("{}  {} {name} ", dim(&timestamp, colored), style.styled_mark());
 
     let lines = match wrap_width {
-        Some(width) if width > indent => wrap_words(message, width - indent),
+        Some(width) if width > indent => display::wrap_words(message, width - indent),
         _ => vec![normalize_whitespace(message)],
     };
 


### PR DESCRIPTION
A hint longer than the terminal hard-wrapped at the edge and its continuation flushed to column zero, undoing the four-space indent that subordinates the hint to its message. The longest hint in the CLI is around 150 characters, so it broke on any terminal narrower than that.

- Both lines of an empty-result report now wrap, with continuation lines aligned under the first line's own text rather than under its prefix.
- The width is measured on the channel the report is written to, which is stderr, not stdout.
- When the width is unknown or too narrow to leave room for the indent, the line prints unwrapped exactly as before.

The word wrapper the readiness renderer already used moves into the core CLI library, with its tests, so both callers share one implementation instead of the report growing a second one.