### PR TITLE
fix(cli): keep the watch status notice off a piped stdout

### DIFF
--- a/cli/core/src/output.rs
+++ b/cli/core/src/output.rs
@@ -383,11 +383,18 @@ fn print_empty_line(prefix: &str, text: &str) {
 
 /// Returns `true` if stdout is a terminal, memoized on first call.
 ///
-/// This is the print gate for [`empty`] and [`empty_with_hint`], and is
-/// deliberately independent of [`is_colored`], which reads *stderr* and
-/// also folds in `NO_COLOR` — reusing it here would make `NO_COLOR=1`
-/// suppress the message outright instead of just its colour.
-fn stdout_is_terminal() -> bool {
+/// This is the "may I print a line that is not data?" gate for a
+/// human-format renderer — the print gate for [`empty`] and
+/// [`empty_with_hint`], and for any other renderer deciding whether a
+/// reassurance line belongs alongside its data. A caller outside a
+/// [`data`] render closure must also consult [`Output::serializes`], as
+/// [`empty`] does. It is deliberately independent of [`is_colored`], which
+/// reads *stderr* and also folds in `NO_COLOR` — reusing it here would make
+/// `NO_COLOR=1` suppress the message outright instead of just its colour.
+/// It also answers a different question than
+/// [`display::terminal_width`]/[`display::stderr_width`], which assume
+/// output is wanted and only report how wide it may be.
+pub fn stdout_is_terminal() -> bool {
     static STDOUT_TTY: OnceLock<bool> = OnceLock::new();
     *STDOUT_TTY.get_or_init(|| std::io::stdout().is_terminal())
 }

--- a/cli/modules/ready/src/render/mod.rs
+++ b/cli/modules/ready/src/render/mod.rs
@@ -124,7 +124,14 @@ pub fn print_status_block(name: &str, scopes: &[Scope], name_width: usize, stale
 /// one blank line on each side. Single-service watch does not use this —
 /// it appends its `watching` suffix straight onto the block's own summary
 /// line via [`print_status_block`]'s `watching` flag instead.
+///
+/// This line is not data, it is a reassurance that the process is alive and
+/// waiting, so it prints only when stdout is a terminal.
 pub fn print_watching_line() {
+    if !output::stdout_is_terminal() {
+        return;
+    }
+
     let colored = output::is_colored();
     let symbols = Symbols::new(colored);
     let text = format!("watching{}", symbols.ellipsis);
@@ -148,9 +155,10 @@ fn all_ready_line(colored: bool) -> String {
 /// Prints the distinct banner aggregate `--watch` shows each time the whole
 /// set of watched subsystems crosses into fully ready.
 ///
-/// No surrounding blank lines: at startup [`print_watching_line`] already
-/// leaves a trailing blank above it, and mid-stream it sits flush under the
-/// transition lines that caused the crossing.
+/// No surrounding blank lines: at startup [`print_watching_line`] leaves a
+/// trailing blank above it whenever it prints at all, and when it does not
+/// print, a pipe wants no separator anyway. Mid-stream it sits flush under
+/// the transition lines that caused the crossing.
 pub fn print_all_ready_line() {
     let colored = output::is_colored();
     println!("{}", all_ready_line(colored));

--- a/cli/modules/ready/src/watch.rs
+++ b/cli/modules/ready/src/watch.rs
@@ -57,10 +57,10 @@ const PROBE_TIMEOUT: Duration = Duration::from_secs(5);
 /// Runs aggregate `--watch`.
 ///
 /// Probes every discovered service once — rendering the same blocks the
-/// one-shot aggregate command does, plus a standalone `watching…` line —
-/// then hands off to one supervisor task per service and a re-discovery
-/// task, rendering every event they produce until the process is
-/// interrupted.
+/// one-shot aggregate command does, plus a standalone `watching…` line
+/// when stdout is a terminal — then hands off to one supervisor task per
+/// service and a re-discovery task, rendering every event they produce
+/// until the process is interrupted.
 ///
 /// Only ends on interruption: every supervisor loops forever and the
 /// re-discovery task never exits, so the `Ok(true)` below is unreachable
@@ -87,7 +87,10 @@ pub async fn run(cmd: &Cmd) -> Result<bool, Error> {
 
     // Always renders, even with no services discovered: the re-discovery
     // sweep below will pick services up as they register, so the wait
-    // must stay visible instead of leaving a silent hang.
+    // must stay visible to a human at a terminal instead of leaving a
+    // silent hang. `print_watching_line` is what gates that notice to a
+    // terminal, since a piped or redirected stdout was never the reader
+    // it was for.
     let snapshot_payload = SnapshotPayload {
         event: EventKind::Snapshot,
         services: &reports,


### PR DESCRIPTION
The readiness watch printed its standalone waiting notice to stdout unconditionally, while the empty-registry note sitting directly beside it was suppressed whenever stdout was not a terminal. A piped watch against an empty registry therefore received the decoration and not the note.

- The notice is a reassurance for someone reading a terminal rather than a row of data, so it now follows the same gate the note does, and a pipe receives only the events.
- The gate is the one already memoised for that question, promoted to shared use rather than duplicated.
- Transition lines, status blocks and the all-ready banner are unchanged: those are the data.
- Machine output was never affected, since the notice only ever printed on the human render path.