### PR TITLE
fix(web,controlplane): distinguish a missing configuration from a real backend failure

### DIFF
--- a/controlplane/httpproxy/proxy.go
+++ b/controlplane/httpproxy/proxy.go
@@ -96,6 +96,20 @@ func (m *TransparentWebGRPCProxy) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	m.handleUnary(w, r, fullMethodName)
 }
 
+// writeRegistryMissError responds to a registry miss with 503, not 404.
+//
+// The proxy cannot distinguish a service name that never existed from a
+// live module whose control plane is currently unreachable, so reserving
+// 404 for a NotFound the backend itself returns is what preserves that
+// distinction.
+func (m *TransparentWebGRPCProxy) writeRegistryMissError(w http.ResponseWriter, service string) {
+	message := fmt.Sprintf(
+		"service %s is not registered with the gateway, its control plane may be unavailable",
+		service,
+	)
+	http.Error(w, message, http.StatusServiceUnavailable)
+}
+
 // handleUnary handles unary gRPC calls.
 func (m *TransparentWebGRPCProxy) handleUnary(w http.ResponseWriter, r *http.Request, fullMethodName string) {
 	service, method, err := xgrpc.ParseFullMethod(fullMethodName)
@@ -106,7 +120,7 @@ func (m *TransparentWebGRPCProxy) handleUnary(w http.ResponseWriter, r *http.Req
 
 	backend, ok := m.registry.GetBackend(service)
 	if !ok {
-		http.Error(w, fmt.Sprintf("Service not found: %s", service), http.StatusNotFound)
+		m.writeRegistryMissError(w, service)
 		return
 	}
 
@@ -299,7 +313,7 @@ func (m *TransparentWebGRPCProxy) handleServerStreaming(w http.ResponseWriter, r
 
 	backend, ok := m.registry.GetBackend(service)
 	if !ok {
-		http.Error(w, fmt.Sprintf("Service not found: %s", service), http.StatusNotFound)
+		m.writeRegistryMissError(w, service)
 		return
 	}
 

--- a/controlplane/httpproxy/proxy_test.go
+++ b/controlplane/httpproxy/proxy_test.go
@@ -1,0 +1,84 @@
+package httpproxy_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/siderolabs/grpc-proxy/proxy"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	"github.com/yanet-platform/yanet2/controlplane/httpproxy"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// emptyRegistry is a BackendRegistry that never has a matching backend,
+// simulating a service that is missing from the gateway's registry.
+type emptyRegistry struct{}
+
+func (m emptyRegistry) GetBackend(_ string) (proxy.Backend, bool) {
+	return nil, false
+}
+
+// TestServeHTTP_UnknownService verifies that a registry miss is answered
+// with 503, not 404, on both the unary and server-streaming request paths.
+func TestServeHTTP_UnknownService(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		path string
+		// rationale documents why this case exercises the registry-miss
+		// branch rather than a genuine NotFound from a backend.
+		rationale string
+	}{
+		{
+			name:      "unary",
+			path:      "/api/some.unknown.Service/Method",
+			rationale: "the service name matches nothing in the registry or the proto registry",
+		},
+		{
+			name:      "streaming",
+			path:      "/api" + ynpb.ReadinessService_Watch_FullMethodName,
+			rationale: "the method resolves in the proto registry but the backend is still missing",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := httpproxy.NewHTTPHandler(emptyRegistry{})
+
+			req := httptest.NewRequest(http.MethodPost, testCase.path, strings.NewReader("{}"))
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			require.Equal(t, http.StatusServiceUnavailable, recorder.Code, testCase.rationale)
+		})
+	}
+}
+
+// TestReadinessServiceWatch_IsServerStreaming pins the fixture used by the
+// streaming subtest above: ReadinessService.Watch must remain a
+// server-streaming RPC, since that is the only reason a request for it
+// reaches handleServerStreaming instead of handleUnary. If the RPC shape
+// ever changes, this test fails instead of the streaming subtest silently
+// degrading into a duplicate of the unary one.
+func TestReadinessServiceWatch_IsServerStreaming(t *testing.T) {
+	t.Parallel()
+
+	serviceDesc, err := protoregistry.GlobalFiles.FindDescriptorByName("controlplane.ynpb.v1.ReadinessService")
+	require.NoError(t, err)
+
+	svcDesc, ok := serviceDesc.(protoreflect.ServiceDescriptor)
+	require.True(t, ok)
+
+	methodDesc := svcDesc.Methods().ByName("Watch")
+	require.NotNil(t, methodDesc)
+	require.True(t, methodDesc.IsStreamingServer())
+}

--- a/modules/acl/web/AclPage.tsx
+++ b/modules/acl/web/AclPage.tsx
@@ -30,6 +30,7 @@ const AclPage: React.FC = () => {
     const {
         draftConfigs,
         loading,
+        loadFailed,
         draftRules,
         draftRuleIds,
         serverRules,
@@ -41,6 +42,8 @@ const AclPage: React.FC = () => {
         commitDeleteConfig,
         discardConfig,
     } = useAclDraft();
+
+    const canCreate = !loading && !loadFailed;
 
     const { configs: cachedConfigs, counts: cachedCounts } = useConfigListCache('acl');
 
@@ -269,7 +272,7 @@ const AclPage: React.FC = () => {
             addConfigSub: 'Create a new ACL configuration',
             withKeywords: true,
             onAddConfig: () => setAddConfigOpen(true),
-            addConfigDisabled: loading,
+            addConfigDisabled: !canCreate,
             onDeleteConfig: () => handleOpenDeleteConfig(),
             onSwitchConfig: (name) => handleTabSelect(name),
         }));
@@ -301,7 +304,7 @@ const AclPage: React.FC = () => {
         });
         return list;
     }, [
-        loading, currentIsDirty, currentConfig, draftConfigs, dirtySet,
+        canCreate, currentIsDirty, currentConfig, draftConfigs, dirtySet,
         enabledCounterNames, paused, currentFwStateName,
         openAdd, handleSavePress, handleDiscard, closeDrawer,
         handleTabSelect, handleOpenDeleteConfig, handleSearchChange, handleOpenLinkedFwstate,
@@ -378,6 +381,7 @@ const AclPage: React.FC = () => {
                         message="No ACL configurations found."
                         actionLabel="Add Config"
                         onAction={() => setAddConfigOpen(true)}
+                        actionDisabled={!canCreate}
                     />
                 ) : (
                     <>
@@ -388,7 +392,7 @@ const AclPage: React.FC = () => {
                             dirtyConfigs={dirtySet}
                             onSelect={handleTabSelect}
                             onAddConfig={() => setAddConfigOpen(true)}
-                            addConfigDisabled={loading}
+                            addConfigDisabled={!canCreate}
                         />
                         {loading ? (
                             <PageLoader loading size="l" />

--- a/modules/acl/web/useAclDraft.ts
+++ b/modules/acl/web/useAclDraft.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useReducer, useState } from 'react';
-import { API } from '@yanet/core/api';
+import { API, loadKnownConfigs } from '@yanet/core/api';
 import { useConfigListCache } from '@yanet/core/hooks';
-import { toaster, compareNatural } from '@yanet/core/utils';
+import { toaster, compareNatural, warnConfigsUnknown } from '@yanet/core/utils';
 import type { Rule } from '@yanet/core/api/acl';
 import {
     aclDraftReducer,
@@ -23,6 +23,8 @@ const aclDeleteConfig = (name: string): Promise<unknown> =>
 export interface UseAclDraftResult {
     draftConfigs: string[];
     loading: boolean;
+    /** True when the initial load failed and no configs were seeded; cleared on a successful reload. */
+    loadFailed: boolean;
     draftRules: (configName: string) => Rule[];
     draftRuleIds: (configName: string) => string[];
     serverRules: (configName: string) => Rule[];
@@ -45,6 +47,7 @@ export interface UseAclDraftResult {
 export const useAclDraft = (): UseAclDraftResult => {
     const [state, rawDispatch] = useReducer(aclDraftReducer, initialAclDraftState);
     const [loading, setLoading] = useState(true);
+    const [loadFailed, setLoadFailed] = useState(false);
     const { write: writeCache } = useConfigListCache('acl');
 
     const dispatchDraft = useCallback((action: AclDraftAction): void => {
@@ -57,24 +60,24 @@ export const useAclDraft = (): UseAclDraftResult => {
             const listResp = await API.acl.listConfigs();
             const names = listResp.configs ?? [];
 
-            const configs = await Promise.all(
-                names.map(async (name): Promise<{ name: string; rules: Rule[]; fwstateName: string }> => {
-                    try {
-                        const resp = await API.acl.showConfig({ name });
-                        return { name, rules: resp.rules ?? [], fwstateName: resp.fwstate_name ?? '' };
-                    } catch {
-                        return { name, rules: [], fwstateName: '' };
-                    }
-                }),
+            const configs = await loadKnownConfigs(
+                names,
+                async (name): Promise<{ name: string; rules: Rule[]; fwstateName: string }> => {
+                    const resp = await API.acl.showConfig({ name });
+                    return { name, rules: resp.rules ?? [], fwstateName: resp.fwstate_name ?? '' };
+                },
+                { onAllDropped: warnConfigsUnknown('acl-configs-unknown', 'ACL') },
             );
 
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });
             writeCache({
-                configs: [...names].sort((a, b) => compareNatural(a, b)),
+                configs: configs.map(cfg => cfg.name).sort((a, b) => compareNatural(a, b)),
                 counts: Object.fromEntries(configs.map(cfg => [cfg.name, cfg.rules.length])),
             });
+            setLoadFailed(false);
         } catch (err) {
             toaster.error('acl-load', 'Failed to load ACL configurations', err);
+            setLoadFailed(true);
         } finally {
             setLoading(false);
         }
@@ -119,6 +122,7 @@ export const useAclDraft = (): UseAclDraftResult => {
     return {
         draftConfigs,
         loading,
+        loadFailed,
         draftRules: draftRulesFor,
         draftRuleIds: draftRuleIdsFor,
         serverRules: serverRulesFor,

--- a/modules/decap/web/usePrefixDraft.ts
+++ b/modules/decap/web/usePrefixDraft.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
-import { API } from '@yanet/core/api';
+import { API, loadKnownConfigs } from '@yanet/core/api';
+import { warnConfigsUnknown } from '@yanet/core/utils';
 import type { PrefixRowItem } from './types';
 import { prefixDraftReducer, initialPrefixDraftState } from './prefixDraftReducer';
 import { useDraft } from '@yanet/core/components/draft';
@@ -23,13 +24,11 @@ export const usePrefixDraft = (): UsePrefixDraftResult => {
             .filter((c) => c.type === 'decap')
             .map((c) => c.name ?? '')
             .filter(Boolean);
-        return Promise.all(
-            configNames.map(async (name): Promise<{ name: string; rows: PrefixRowItem[] }> => {
-                const resp = await API.decap.showConfig({ name });
-                const rows: PrefixRowItem[] = (resp.prefixes ?? []).map((p) => ({ id: p, prefix: p }));
-                return { name, rows };
-            }),
-        );
+        return loadKnownConfigs(configNames, async (name): Promise<{ name: string; rows: PrefixRowItem[] }> => {
+            const resp = await API.decap.showConfig({ name });
+            const rows: PrefixRowItem[] = (resp.prefixes ?? []).map((p) => ({ id: p, prefix: p }));
+            return { name, rows };
+        }, { onAllDropped: warnConfigsUnknown('decap-configs-unknown', 'decap') });
     }, []);
 
     const commit = useCallback(async (

--- a/modules/forward/web/useForwardDraft.ts
+++ b/modules/forward/web/useForwardDraft.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
-import { API } from '@yanet/core/api';
+import { API, loadKnownConfigs } from '@yanet/core/api';
 import { useConfigListCache } from '@yanet/core/hooks';
-import { toaster } from '@yanet/core/utils';
+import { toaster, warnConfigsUnknown } from '@yanet/core/utils';
 import type { Rule } from '@yanet/core/api/forward';
 import {
     forwardDraftReducer,
@@ -76,11 +76,13 @@ export const useForwardDraft = (): UseForwardDraftResult => {
                 .map(cfg => cfg.name ?? '')
                 .filter(Boolean);
 
-            const configs: Array<{ name: string; rules: Rule[] }> = await Promise.all(
-                forwardNames.map(async (name): Promise<{ name: string; rules: Rule[] }> => {
+            const configs: Array<{ name: string; rules: Rule[] }> = await loadKnownConfigs(
+                forwardNames,
+                async (name): Promise<{ name: string; rules: Rule[] }> => {
                     const resp = await API.forward.showConfig({ name });
                     return { name, rules: resp.rules ?? [] };
-                }),
+                },
+                { onAllDropped: warnConfigsUnknown('forward-configs-unknown', 'forward') },
             );
 
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });

--- a/modules/route/web/useFIBDraft.ts
+++ b/modules/route/web/useFIBDraft.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
-import { API } from '@yanet/core/api';
+import { API, loadKnownConfigs } from '@yanet/core/api';
+import { warnConfigsUnknown } from '@yanet/core/utils';
 import type { FIBEntry, FIBNexthop, FIBRangeEntry } from '@yanet/core/api/routes';
 import { ipRangeToCIDRs } from '@yanet/core/utils/netip';
 import type { FIBRowItem } from './types';
@@ -68,12 +69,10 @@ export const useFIBDraft = (): UseFIBDraftResult => {
     const load = useCallback(async (): Promise<Array<{ name: string; rows: FIBRowItem[] }>> => {
         const configsResp = await API.route.listConfigs();
         const configNames = configsResp.configs ?? [];
-        return Promise.all(
-            configNames.map(async (name): Promise<{ name: string; rows: FIBRowItem[] }> => {
-                const fibResp = await API.route.showFIB({ name });
-                return { name, rows: flattenFIBEntries(fibResp.entries ?? []) };
-            }),
-        );
+        return loadKnownConfigs(configNames, async (name): Promise<{ name: string; rows: FIBRowItem[] }> => {
+            const fibResp = await API.route.showFIB({ name });
+            return { name, rows: flattenFIBEntries(fibResp.entries ?? []) };
+        }, { onAllDropped: warnConfigsUnknown('route-configs-unknown', 'route') });
     }, []);
 
     const commit = useCallback(async (configName: string, draftRows: FIBRowItem[]): Promise<void> => {

--- a/web/src/core/api/client.test.ts
+++ b/web/src/core/api/client.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createService, ApiError, loadKnownConfigs } from './client';
+
+describe('ApiError', () => {
+    beforeEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('carries the numeric status for a 404 response', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+            text: async () => '',
+        }));
+        const service = createService('test.Service');
+        await expect(service.call('Method')).rejects.toMatchObject({ status: 404 });
+    });
+
+    it('carries the numeric status for a 500 response', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: false,
+            status: 500,
+            statusText: 'Internal Server Error',
+            text: async () => '',
+        }));
+        const service = createService('test.Service');
+        await expect(service.call('Method')).rejects.toMatchObject({ status: 500 });
+    });
+
+    it('is an instance of both ApiError and Error', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: false,
+            status: 404,
+            statusText: 'Not Found',
+            text: async () => '',
+        }));
+        const service = createService('test.Service');
+        try {
+            await service.call('Method');
+            expect.unreachable();
+        } catch (err) {
+            expect(err).toBeInstanceOf(ApiError);
+            expect(err).toBeInstanceOf(Error);
+        }
+    });
+});
+
+describe('loadKnownConfigs', () => {
+    it('drops a 404 and keeps the surrounding successes in original order', async () => {
+        const loadOne = async (name: string): Promise<string> => {
+            if (name === 'b') {
+                throw new ApiError(404, 'Not Found', '');
+            }
+            return `loaded-${name}`;
+        };
+        const results = await loadKnownConfigs(['a', 'b', 'c'], loadOne);
+        expect(results).toEqual(['loaded-a', 'loaded-c']);
+    });
+
+    it('rejects with the original error object on a 500', async () => {
+        const serverError = new ApiError(500, 'Internal Server Error', '');
+        const loadOne = async (name: string): Promise<string> => {
+            if (name === 'b') {
+                throw serverError;
+            }
+            return `loaded-${name}`;
+        };
+        await expect(loadKnownConfigs(['a', 'b', 'c'], loadOne)).rejects.toBe(serverError);
+    });
+
+    it('rejects on a rejection that is not an ApiError', async () => {
+        const networkError = new TypeError('network failure');
+        const loadOne = async (name: string): Promise<string> => {
+            if (name === 'a') {
+                throw networkError;
+            }
+            return `loaded-${name}`;
+        };
+        await expect(loadKnownConfigs(['a', 'b'], loadOne)).rejects.toBe(networkError);
+    });
+
+    it('calls onAllDropped with the name count when every name 404s', async () => {
+        const loadOne = async (): Promise<string> => {
+            throw new ApiError(404, 'Not Found', '');
+        };
+        const onAllDropped = vi.fn();
+        const results = await loadKnownConfigs(['a', 'b', 'c'], loadOne, { onAllDropped });
+        expect(results).toEqual([]);
+        expect(onAllDropped).toHaveBeenCalledTimes(1);
+        expect(onAllDropped).toHaveBeenCalledWith(3);
+    });
+
+    it('does not call onAllDropped when at least one name succeeds', async () => {
+        const loadOne = async (name: string): Promise<string> => {
+            if (name === 'b') {
+                throw new ApiError(404, 'Not Found', '');
+            }
+            return `loaded-${name}`;
+        };
+        const onAllDropped = vi.fn();
+        await loadKnownConfigs(['a', 'b'], loadOne, { onAllDropped });
+        expect(onAllDropped).not.toHaveBeenCalled();
+    });
+
+    it('does not call onAllDropped when names is empty', async () => {
+        const loadOne = async (name: string): Promise<string> => `loaded-${name}`;
+        const onAllDropped = vi.fn();
+        await loadKnownConfigs([], loadOne, { onAllDropped });
+        expect(onAllDropped).not.toHaveBeenCalled();
+    });
+
+    it('does not call onAllDropped when a non-404 rejection is rethrown', async () => {
+        const serverError = new ApiError(500, 'Internal Server Error', '');
+        const loadOne = async (name: string): Promise<string> => {
+            if (name === 'a') {
+                throw serverError;
+            }
+            throw new ApiError(404, 'Not Found', '');
+        };
+        const onAllDropped = vi.fn();
+        await expect(loadKnownConfigs(['a', 'b'], loadOne, { onAllDropped })).rejects.toBe(serverError);
+        expect(onAllDropped).not.toHaveBeenCalled();
+    });
+
+    it('rejects as soon as one name fails, without waiting for a sibling that never settles', async () => {
+        const serverError = new ApiError(500, 'Internal Server Error', '');
+        const loadOne = (name: string): Promise<string> => {
+            if (name === 'a') {
+                return new Promise<never>((_resolve, reject) => reject(serverError));
+            }
+            return new Promise<string>(() => {});
+        };
+        await expect(
+            Promise.race([
+                loadKnownConfigs(['a', 'b'], loadOne),
+                new Promise<never>((_resolve, reject) =>
+                    setTimeout(() => reject(new Error('loadKnownConfigs did not settle in time')), 100)
+                ),
+            ])
+        ).rejects.toBe(serverError);
+    });
+});

--- a/web/src/core/api/client.ts
+++ b/web/src/core/api/client.ts
@@ -3,6 +3,27 @@ export interface CallOptions {
     compress?: boolean;
 }
 
+/** Error thrown for a non-2xx HTTP response from a gRPC-over-JSON call.
+ *
+ * Carries the numeric status alongside the formatted message so callers can
+ * branch on it (e.g. treating a 404 as a missing config rather than a real
+ * failure) instead of parsing the message text.
+ */
+export class ApiError extends Error {
+    readonly status: number;
+    readonly statusText: string;
+    readonly detail: string;
+
+    constructor(status: number, statusText: string, detail: string) {
+        const base = `HTTP ${status} ${statusText}`;
+        super(detail ? `${base}: ${detail}` : base);
+        this.name = 'ApiError';
+        this.status = status;
+        this.statusText = statusText;
+        this.detail = detail;
+    }
+}
+
 let apiBase = '';
 
 /** Set the base URL prefix for all API calls. An empty string means same-origin. */
@@ -65,8 +86,7 @@ const callGRPCServiceWithBody = async <T>(
 
     if (!response.ok) {
         const detail = await readErrorDetail(response);
-        const base = `HTTP ${response.status} ${response.statusText}`;
-        throw new Error(detail ? `${base}: ${detail}` : base);
+        throw new ApiError(response.status, response.statusText, detail);
     }
 
     return await response.json() as T;
@@ -77,6 +97,53 @@ const callGRPCService = async <T>(
     options?: CallOptions
 ): Promise<T> => {
     return callGRPCServiceWithBody<T>(servicePath, {}, options);
+};
+
+export interface LoadKnownConfigsOptions {
+    /** Called when the name list was non-empty and every config was dropped. */
+    onAllDropped?: (count: number) => void;
+}
+
+/** Marker substituted for a per-name load whose 404 means the config is gone. */
+const DROPPED = Symbol('dropped');
+
+/** Load one config per name concurrently, dropping names the backend does not know.
+ *
+ * The name list and the per-name loader can come from two different
+ * registries: the dataplane's shared-memory inventory survives a control-plane
+ * restart, while a module service's in-process map is rebuilt empty. Where
+ * both come from the same service, a name can still be deleted between the two
+ * calls. A 404 therefore means the backend has no such config and it is
+ * skipped. Any other failure, including a rejection that is not an ApiError,
+ * rejects the whole load as soon as it happens, so a hung or slow sibling
+ * request never delays surfacing a real error. The rejection is rethrown
+ * unchanged so the caller still sees the original error.
+ *
+ * When every name was dropped and at least one name was requested, every
+ * request was a 404, since any other rejection would already have rejected
+ * the whole load above. `onAllDropped` fires in exactly that case, so a
+ * caller can warn that none of the requested configs came back instead of
+ * rendering a silent empty state.
+ */
+export const loadKnownConfigs = async <T>(
+    names: string[],
+    loadOne: (name: string) => Promise<T>,
+    options?: LoadKnownConfigsOptions,
+): Promise<T[]> => {
+    const results: (T | typeof DROPPED)[] = await Promise.all(names.map((name): Promise<T | typeof DROPPED> =>
+        loadOne(name).catch((reason: unknown) => {
+            if (reason instanceof ApiError && reason.status === 404) {
+                return DROPPED;
+            }
+            throw reason;
+        })
+    ));
+
+    const values = results.filter((result): result is T => result !== DROPPED);
+    if (names.length > 0 && values.length === 0) {
+        options?.onAllDropped?.(names.length);
+    }
+    return values;
 };
 
 export const createService = (serviceName: string) => {
@@ -150,8 +217,7 @@ const streamGRPCService = async <T>(
 
         if (!response.ok) {
             const detail = await readErrorDetail(response);
-            const base = `HTTP ${response.status} ${response.statusText}`;
-            throw new Error(detail ? `${base}: ${detail}` : base);
+            throw new ApiError(response.status, response.statusText, detail);
         }
 
         if (!response.body) {

--- a/web/src/core/api/index.ts
+++ b/web/src/core/api/index.ts
@@ -1,4 +1,4 @@
-export { type CallOptions, setApiBase } from './client';
+export { type CallOptions, ApiError, loadKnownConfigs, setApiBase } from './client';
 export * from './common';
 export * from './routes';
 export * from './neighbours';

--- a/web/src/core/utils/toast.ts
+++ b/web/src/core/utils/toast.ts
@@ -72,3 +72,19 @@ export const toaster = {
         });
     },
 };
+
+/**
+ * Build an `onAllDropped` callback for `loadKnownConfigs` that warns about unknown configs.
+ *
+ * The helper owns the message and the count, so a caller only needs to supply the
+ * toast dedup key and the subject word used in the message. It fires once per page
+ * load when the control plane knows none of the requested configs; a remount fires
+ * it again, and it is the toast dedup key, not the callback, that collapses the repeat.
+ */
+export const warnConfigsUnknown = (toastKey: string, subject: string) => (count: number): void => {
+    const [noun, pronoun] = count === 1 ? ['configuration', 'It is'] : ['configurations', 'They are'];
+    toaster.warning(
+        toastKey,
+        `The control plane does not know ${count} ${subject} ${noun}. ${pronoun} not shown here.`,
+    );
+};


### PR DESCRIPTION
The API client threw a plain error whose only record of the HTTP status was a formatted message, so no caller could tell a missing configuration from a backend fault. It now raises a typed error carrying the numeric status.

Pages that fetch one configuration per name drop the ones the control plane does not know and fail on anything else. Previously they took one of two wrong branches: the decap, forward and route pages failed the entire page on a single missing configuration, which after a control-plane restart left every configuration missing and disabled config creation on a dead page; the access-list page swallowed every error instead, rendering a live rule set as empty and inviting the operator to commit that emptiness back over it.

A page whose configurations are all unknown to the control plane now warns once, so an empty page is not mistaken for an empty instance. A real error also surfaces as soon as it happens, rather than waiting on a slow or hung sibling request.

The gateway answered the same status for a configuration that does not exist and for a service missing from its registry. Since the client now branches on that status, a whole module outage would have rendered as an empty instance, so an unregistered service reports that it is unavailable and the not-found status keeps a single meaning. This is the first test coverage for that package.

The access-list page gains the load-failure gate its sibling pages already had, so a failed load can no longer be committed over a live rule set.