### PR TITLE
refactor(filter): build LPM from range_index instead of dual-writing in collector

### DIFF
--- a/common/range_collector.h
+++ b/common/range_collector.h
@@ -6,7 +6,6 @@
 #include "memory.h"
 
 #include "key.h"
-#include "lpm.h"
 #include "radix.h"
 #include "range_index.h"
 
@@ -120,7 +119,6 @@ range_collector_add(
 
 struct range_collector_ctx {
 	struct range_collector *collector;
-	struct lpm *lpm;
 	struct range_index *range_index;
 
 	uint32_t max_value;
@@ -173,9 +171,6 @@ range_collector_stack_emit(
 
 	if (*item.value == LPM_VALUE_INVALID)
 		*item.value = ctx->max_value++;
-
-	if (lpm_insert(ctx->lpm, key_size, ctx->pos, to, *item.value))
-		return -1;
 
 	if (range_index_insert(
 		    ctx->range_index, key_size, ctx->pos, *item.value
@@ -259,14 +254,12 @@ static inline int
 range_collector_collect(
 	struct range_collector *collector,
 	uint8_t key_size,
-	struct lpm *lpm64,
 	struct range_index *range_index
 ) {
 	struct range_collector_ctx ctx;
 	ctx.collector = collector;
 	ctx.max_value = 0;
 
-	ctx.lpm = lpm64;
 	ctx.range_index = range_index;
 
 	uint32_t stack_size = key_size * 8 + 1;

--- a/common/range_index.h
+++ b/common/range_index.h
@@ -5,6 +5,9 @@
 #include "radix.h"
 #include "value.h"
 
+#include "key.h"
+#include "lpm.h"
+
 #include <strings.h>
 
 struct range_index {
@@ -121,4 +124,69 @@ range_index_free(struct range_index *range_index) {
 	SET_OFFSET_OF(&range_index->values, NULL);
 
 	radix_free(&range_index->radix);
+}
+
+/*
+ * Build an LPM from a range_index.
+ *
+ * The range_index stores a contiguous, ascending, non-overlapping partition
+ * of the full keyspace: radix maps each range-start key -> an index into the
+ * values[] array.  This function walks the radix in ascending order, derives
+ * each range's upper bound from the next key, and inserts [from..to] -> value
+ * into the LPM.  The LPM must already be initialised by the caller.
+ */
+struct range_index_lpm_ctx {
+	struct lpm *lpm;
+	const uint32_t *values;
+	uint8_t prev_from[LPM_KEY_SIZE_MAX];
+	uint32_t prev_value;
+};
+
+static inline int
+range_index_lpm_cb(
+	uint8_t key_size, const uint8_t *from, uint32_t index, void *data
+) {
+	struct range_index_lpm_ctx *ctx = (struct range_index_lpm_ctx *)data;
+
+	if (ctx->prev_value != LPM_VALUE_INVALID) {
+		uint8_t to[key_size];
+		memcpy(to, from, key_size);
+		filter_key_dec(key_size, to);
+		if (lpm_insert(
+			    ctx->lpm,
+			    key_size,
+			    ctx->prev_from,
+			    to,
+			    ctx->prev_value
+		    ))
+			return -1;
+	}
+
+	memcpy(ctx->prev_from, from, key_size);
+	ctx->prev_value = ctx->values[index];
+	return 0;
+}
+
+static inline int
+range_index_build_lpm(
+	const struct range_index *range_index, uint8_t key_size, struct lpm *lpm
+) {
+	struct range_index_lpm_ctx ctx;
+	ctx.lpm = lpm;
+	ctx.values = ADDR_OF(&range_index->values);
+	ctx.prev_value = LPM_VALUE_INVALID;
+
+	if (radix_walk(&range_index->radix, key_size, range_index_lpm_cb, &ctx))
+		return -1;
+
+	if (ctx.prev_value != LPM_VALUE_INVALID) {
+		uint8_t to[key_size];
+		memset(to, 0xff, key_size);
+		if (lpm_insert(
+			    lpm, key_size, ctx.prev_from, to, ctx.prev_value
+		    ))
+			return -1;
+	}
+
+	return 0;
 }

--- a/lib/filter/compiler/net4.c
+++ b/lib/filter/compiler/net4.c
@@ -135,7 +135,11 @@ collect_net4_values(
 		goto error_lpm;
 	}
 
-	if (range_collector_collect(&collector, 4, lpm, &range_index)) {
+	if (range_collector_collect(&collector, 4, &range_index)) {
+		goto error_range_collect;
+	}
+
+	if (range_index_build_lpm(&range_index, 4, lpm)) {
 		goto error_range_collect;
 	}
 

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -112,7 +112,11 @@ collect_net6_range(
 		goto error_ri_init;
 	}
 
-	if (range_collector_collect(&collector, 8, lpm, ri)) {
+	if (range_collector_collect(&collector, 8, ri)) {
+		goto error_collect;
+	}
+
+	if (range_index_build_lpm(ri, 8, lpm)) {
 		goto error_collect;
 	}
 


### PR DESCRIPTION
The range collector previously inserted every range into both the LPM and the range_index simultaneously. This coupled the collector to lpm.h and created a latent consistency hazard: the two structures stayed in sync only because the emit loop was a single chokepoint.

Now the collector produces only a range_index. A new range_index_build_lpm() derives the LPM from the range_index in a dedicated pass — walking the radix in ascending order and inserting [from..next_from-1] -> value. The collector no longer includes lpm.h.

- Runtime query path (lpm4_lookup / lpm8_lookup) and in-memory LPM layout are unchanged.
- Zero dataplane/ABI impact — purely a compile-time construction-ordering refactor.
- Only the classic net4 and net6 filter compilers are affected; the _fast variants are untouched.