### PR TITLE
feat(cp): spawn per-worker counter storage for cp_object in the generation ectx

### DIFF
--- a/lib/controlplane/config/cp_counter.c
+++ b/lib/controlplane/config/cp_counter.c
@@ -346,6 +346,28 @@ cp_config_counter_storage_registry_insert_device(
 }
 
 struct counter_storage *
+cp_config_counter_storage_registry_lookup_object(
+	struct cp_config_counter_storage_registry *registry,
+	const char *object_name
+) {
+	struct counter_tag tags[] = {{.key = "object", .value = object_name}};
+	return get_one(registry, tags, 1);
+}
+
+int
+cp_config_counter_storage_registry_insert_object(
+	struct cp_config_counter_storage_registry *registry,
+	const char *object_name,
+	struct counter_storage *counter_storage,
+	yanet_error **err
+) {
+	struct counter_tag tag = {.key = "object", .value = object_name};
+	return cp_config_counter_storage_registry_insert(
+		registry, &tag, 1, counter_storage, err
+	);
+}
+
+struct counter_storage *
 cp_config_counter_storage_registry_lookup_pipeline(
 	struct cp_config_counter_storage_registry *registry,
 	const char *device_name,

--- a/lib/controlplane/config/cp_counter.h
+++ b/lib/controlplane/config/cp_counter.h
@@ -73,6 +73,20 @@ cp_config_counter_storage_registry_insert_device(
 );
 
 struct counter_storage *
+cp_config_counter_storage_registry_lookup_object(
+	struct cp_config_counter_storage_registry *registry,
+	const char *object_name
+);
+
+int
+cp_config_counter_storage_registry_insert_object(
+	struct cp_config_counter_storage_registry *registry,
+	const char *object_name,
+	struct counter_storage *counter_storage,
+	yanet_error **err
+);
+
+struct counter_storage *
 cp_config_counter_storage_registry_lookup_pipeline(
 	struct cp_config_counter_storage_registry *registry,
 	const char *device_name,

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -1077,6 +1077,98 @@ error:
 	return NULL;
 }
 
+static void
+object_ectx_free(
+	struct cp_config_gen *cp_config_gen, struct object_ectx *object_ectx
+) {
+	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
+
+	struct counter_storage *counter_storage =
+		ADDR_OF(&object_ectx->counter_storage);
+	if (counter_storage != NULL)
+		counter_storage_free(counter_storage);
+
+	size_t ectx_size = sizeof(struct object_ectx);
+	memory_bfree(memory_context, object_ectx, ectx_size);
+}
+
+static struct object_ectx *
+object_ectx_create(
+	struct cp_config_gen *cp_config_gen,
+	struct cp_object *cp_object,
+	struct config_gen_ectx *config_gen_ectx,
+	struct cp_config_gen *old_config_gen,
+	uint64_t worker_idx,
+	yanet_error **err
+) {
+	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
+
+	size_t ectx_size = sizeof(struct object_ectx);
+
+	struct object_ectx *object_ectx =
+		(struct object_ectx *)memory_balloc(memory_context, ectx_size);
+	if (object_ectx == NULL) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for object execution context"
+		);
+		return NULL;
+	}
+
+	memset(object_ectx, 0, ectx_size);
+	SET_OFFSET_OF(&object_ectx->cp_object, cp_object);
+
+	struct counter_storage *old_counter_storage = NULL;
+	struct config_gen_ectx *old_ectx =
+		cp_config_gen_worker_ectx(old_config_gen, worker_idx);
+	if (old_ectx != NULL) {
+		old_counter_storage =
+			cp_config_counter_storage_registry_lookup_object(
+				ADDR_OF(&old_ectx->counter_storage_registry),
+				cp_object->name
+			);
+	}
+
+	struct counter_storage *counter_storage = counter_storage_spawn(
+		&cp_config->counter_storage_memory_context,
+		old_counter_storage,
+		&cp_object->counter_registry
+	);
+	if (counter_storage == NULL) {
+		yanet_error_add(
+			err,
+		"failed to spawn counter storage for object '%s'",
+		cp_object->name
+	);
+		goto error;
+	}
+
+	SET_OFFSET_OF(&object_ectx->counter_storage, counter_storage);
+
+	if (cp_config_counter_storage_registry_insert_object(
+		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
+		    cp_object->name,
+		    counter_storage,
+		    err
+	    )) {
+		yanet_error_add(
+			err,
+			"failed to insert counter storage for object '%s'",
+			cp_object->name
+		);
+		goto error;
+	}
+
+	return object_ectx;
+
+error:
+	object_ectx_free(cp_config_gen, object_ectx);
+
+	return NULL;
+}
+
 void
 config_gen_ectx_free(
 	struct cp_config_gen *cp_config_gen,
@@ -1095,6 +1187,28 @@ config_gen_ectx_free(
 		if (device_ectx != NULL) {
 			device_ectx_free(cp_config_gen, device_ectx);
 		}
+	}
+
+	struct object_ectx **objects = ADDR_OF(&config_gen_ectx->objects);
+	if (objects != NULL) {
+		for (uint64_t object_idx = 0;
+		     object_idx < config_gen_ectx->object_count;
+		     ++object_idx) {
+
+			struct object_ectx *object_ectx =
+				ADDR_OF(objects + object_idx);
+
+			if (object_ectx != NULL) {
+				object_ectx_free(cp_config_gen, object_ectx);
+			}
+		}
+
+		memory_bfree(
+			memory_context,
+			objects,
+			sizeof(struct object_ectx *) *
+				config_gen_ectx->object_count
+		);
 	}
 
 	struct cp_config_counter_storage_registry *registry =
@@ -1488,6 +1602,51 @@ config_gen_ectx_create(
 		SET_OFFSET_OF(
 			config_gen_ectx->devices + device_idx, device_ectx
 		);
+	}
+
+	config_gen_ectx->object_count =
+		cp_object_registry_capacity(&cp_config_gen->object_registry);
+
+	struct object_ectx **objects = (struct object_ectx **)memory_balloc(
+		memory_context,
+		sizeof(struct object_ectx *) * config_gen_ectx->object_count
+	);
+	if (config_gen_ectx->object_count && objects == NULL) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for object execution "
+			"contexts"
+		);
+		goto error;
+	}
+	memset(objects,
+	       0,
+	       sizeof(struct object_ectx *) * config_gen_ectx->object_count);
+	SET_OFFSET_OF(&config_gen_ectx->objects, objects);
+
+	for (uint64_t object_idx = 0;
+	     object_idx < config_gen_ectx->object_count;
+	     ++object_idx) {
+
+		struct cp_object *cp_object =
+			cp_config_gen_get_object(cp_config_gen, object_idx);
+		if (cp_object == NULL) {
+			objects[object_idx] = NULL;
+			continue;
+		}
+
+		struct object_ectx *object_ectx = object_ectx_create(
+			cp_config_gen,
+			cp_object,
+			config_gen_ectx,
+			old_config_gen,
+			worker_idx,
+			err
+		);
+		if (object_ectx == NULL) {
+			goto error;
+		}
+		SET_OFFSET_OF(objects + object_idx, object_ectx);
 	}
 
 	if (link_config_gen_ectx(config_gen_ectx, err)) {

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -17,6 +17,7 @@ struct cp_chain;
 struct cp_function;
 struct cp_pipeline;
 struct cp_device;
+struct cp_object;
 
 struct cp_config_gen;
 struct cp_config_counter_storage_registry;
@@ -119,6 +120,22 @@ struct device_ectx {
 	struct device_entry_ectx *output_pipelines;
 };
 
+// Per-worker execution context for a cp_object.
+//
+// Mirrors device_ectx minus the input/output pipeline entries: objects own a
+// counter registry but have no dataplane handler and no device binding, so an
+// object_ectx only carries the spawned per-worker counter storage.
+struct object_ectx {
+	struct cp_object *cp_object;
+	struct counter_storage *counter_storage;
+};
+
+// Per-worker execution context for one config generation.
+//
+// devices[] is the inline flexible-array tail of the single allocation sized
+// in config_gen_ectx_create. objects cannot also be a flexible array (a struct
+// may have only one), so it is a separately allocated array of offset slots
+// reached through the objects pointer, mirroring function_ectx.chains.
 struct config_gen_ectx {
 	struct cp_config_gen *cp_config_gen;
 	struct phy_device_map *phy_device_maps;
@@ -126,6 +143,8 @@ struct config_gen_ectx {
 	struct cp_config_counter_storage_registry *counter_storage_registry;
 
 	uint64_t device_count;
+	uint64_t object_count;
+	struct object_ectx **objects;
 	struct device_ectx *devices[];
 };
 


### PR DESCRIPTION
- Give each cp_object a per-worker execution context (object_ectx) bound in config_gen_ectx, mirroring device_ectx.
- A counter_storage is spawned from the object's counter_registry for each worker and registered in the worker's counter storage registry, realizing the deferred expansion of object counters into per-worker storages.
- Add counter-storage-registry lookup and insert for objects, and build and free the objects ectx array alongside devices.
- Objects are inert (no packet handler), so object_ectx carries only the cp_object reference and its counter storage.