### PR TITLE
refactor(common): reimplement str_index on top of hash_index

### DIFF
--- a/common/str_index.h
+++ b/common/str_index.h
@@ -3,11 +3,15 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "memory.h"
+#include "common/hash_index.h"
+#include "common/memory.h"
 
-#define STR_INDEX_INVALID 0xffffffff
-#define STR_INDEX_SPARSE_FACTOR 4
+#define STR_INDEX_INVALID HASH_INDEX_INVALID
+#define STR_INDEX_INITIAL_CAPACITY 2
 
+// FNV-1a over the first key_size bytes of key (bounded by its NUL), seeded by
+// seed. Returns a 64-bit hash; str_index truncates to 32 bits for
+// hash_index.
 static inline uint64_t
 str_index_fnv1a(const void *key, size_t key_size, uint32_t seed) {
 	const uint8_t *data = (const uint8_t *)key;
@@ -50,40 +54,60 @@ str_index_fnv1a(const void *key, size_t key_size, uint32_t seed) {
 	return hash;
 }
 
+static inline uint32_t
+str_index_hash(const char *key, uint32_t key_size) {
+	uint32_t length = strnlen(key, key_size);
+	return (uint32_t)str_index_fnv1a(key, length, 0);
+}
+
+// Resolve the key string behind a stored value, for equality checks and
+// rehashing.
+//
+// Returns a NUL-terminated string identifying the entry at index. data is the
+// opaque pointer passed alongside the callback from the lookup or insert call
+// site.
 typedef const char *(*str_index_read_func)(uint32_t index, const void *data);
 
+// Bundle of arguments str_index passes to its hash_index equality adapter.
+struct str_index_eq_context {
+	const char *key;
+	uint32_t key_size;
+	str_index_read_func read_func;
+	const void *read_func_data;
+};
+
+// Equality adapter wrapping str_index's string compare around hash_index's
+// generic eq contract.
+//
+// Returns 0 when the entry at value matches key (via read_func + strncmp), so
+// hash_index_lookup stops probing; non-zero keeps probing.
+static inline int
+str_index_eq(uint32_t value, const void *data) {
+	const struct str_index_eq_context *ctx =
+		(const struct str_index_eq_context *)data;
+	const char *known = ctx->read_func(value, ctx->read_func_data);
+	return strncmp(ctx->key, known, ctx->key_size) ? 1 : 0;
+}
+
+// String-keyed index built on hash_index, with dynamic resizing.
+//
+// The embedded hash_index stores caller-supplied uint32_t values resolved by
+// string keys; str_index contributes FNV-1a hashing, strncmp equality via a
+// read callback, and growth by rehash into a larger fixed-capacity table.
 struct str_index {
-	struct memory_context *memory_context;
-	uint32_t *values;
-	uint32_t size;
-	uint32_t capacity;
+	struct hash_index hash_index;
 };
 
 static inline int
 str_index_init(
 	struct str_index *str_index, struct memory_context *memory_context
 ) {
-	SET_OFFSET_OF(&str_index->memory_context, memory_context);
-
-	SET_OFFSET_OF(&str_index->values, NULL);
-	str_index->capacity = 0;
-	str_index->size = 0;
-
-	return 0;
+	return hash_index_init(&str_index->hash_index, memory_context, 0);
 }
 
 static inline void
 str_index_fini(struct str_index *str_index) {
-	if (str_index->values == NULL)
-		return;
-
-	uint32_t *values = ADDR_OF(&str_index->values);
-	memory_bfree(
-		ADDR_OF(&str_index->memory_context),
-		values,
-		sizeof(uint32_t) * str_index->capacity
-	);
-	SET_OFFSET_OF(&str_index->values, NULL);
+	hash_index_fini(&str_index->hash_index);
 }
 
 static inline uint32_t
@@ -94,43 +118,34 @@ str_index_lookup(
 	str_index_read_func read_func,
 	const void *read_func_data
 ) {
-	if (!str_index->capacity)
-		return STR_INDEX_INVALID;
-
-	uint32_t length = strnlen(key, key_size);
-	uint32_t hash = str_index_fnv1a(key, length, 0);
-	hash = hash % str_index->capacity;
-
-	uint32_t *values = ADDR_OF(&str_index->values);
-
-	while (values[hash] != STR_INDEX_INVALID) {
-		const char *known = read_func(values[hash], read_func_data);
-		if (!strncmp(key, known, key_size)) {
-			break;
-		}
-		hash = (hash + 1) % str_index->capacity;
-	}
-	return values[hash];
+	struct str_index_eq_context ctx = {
+		.key = key,
+		.key_size = key_size,
+		.read_func = read_func,
+		.read_func_data = read_func_data
+	};
+	return hash_index_lookup(
+		&str_index->hash_index,
+		str_index_hash(key, key_size),
+		str_index_eq,
+		&ctx
+	);
 }
 
+// Move a freshly built hash_index into str_index.
+//
+// hash_index holds relative pointers (memory_address.h), so a plain struct
+// copy would rebind them to the wrong base address; EQUATE_OFFSET re-resolves
+// each pointer against the destination field.
 static inline void
-str_index_insert_force(
-	struct str_index *str_index,
-	const char *key,
-	uint32_t key_size,
-	uint32_t value
-) {
-	uint32_t length = strnlen(key, key_size);
-	uint32_t hash = str_index_fnv1a(key, length, 0);
-	hash = hash % str_index->capacity;
-
-	uint32_t *values = ADDR_OF(&str_index->values);
-
-	while (values[hash] != STR_INDEX_INVALID) {
-		hash = (hash + 1) % str_index->capacity;
-	}
-	values[hash] = value;
-	str_index->size += 1;
+str_index_take(struct str_index *str_index, struct hash_index *expanded) {
+	hash_index_fini(&str_index->hash_index);
+	EQUATE_OFFSET(
+		&str_index->hash_index.memory_context, &expanded->memory_context
+	);
+	EQUATE_OFFSET(&str_index->hash_index.entries, &expanded->entries);
+	str_index->hash_index.count = expanded->count;
+	str_index->hash_index.capacity = expanded->capacity;
 }
 
 static inline int
@@ -141,35 +156,28 @@ str_index_expand(
 	str_index_read_func read_func,
 	const void *read_func_data
 ) {
-	uint32_t *new_values = (uint32_t *)memory_balloc(
-		ADDR_OF(&str_index->memory_context),
-		sizeof(uint32_t) * new_capacity
-	);
-	if (new_values == NULL)
+	struct hash_index *index = &str_index->hash_index;
+
+	const uint32_t *old_entries = ADDR_OF(&index->entries);
+	uint32_t old_slots = index->capacity * HASH_INDEX_SPARSE_FACTOR;
+
+	struct hash_index expanded;
+	if (hash_index_init(
+		    &expanded, ADDR_OF(&index->memory_context), new_capacity
+	    ) != 0)
 		return -1;
 
-	memset(new_values, 0xff, sizeof(uint32_t) * new_capacity);
-
-	uint32_t *old_values = ADDR_OF(&str_index->values);
-	uint32_t old_capacity = str_index->capacity;
-
-	SET_OFFSET_OF(&str_index->values, new_values);
-	str_index->capacity = new_capacity;
-
-	for (uint32_t pos = 0; pos < old_capacity; ++pos) {
-		if (old_values[pos] == STR_INDEX_INVALID)
+	for (uint32_t pos = 0; pos < old_slots; ++pos) {
+		uint32_t value = old_entries[pos];
+		if (value == HASH_INDEX_INVALID)
 			continue;
-		const char *key = read_func(old_values[pos], read_func_data);
-		str_index_insert_force(
-			str_index, key, key_size, old_values[pos]
+		const char *key = read_func(value, read_func_data);
+		hash_index_insert(
+			&expanded, str_index_hash(key, key_size), value
 		);
 	}
 
-	memory_bfree(
-		ADDR_OF(&str_index->memory_context),
-		old_values,
-		sizeof(uint32_t) * old_capacity
-	);
+	str_index_take(str_index, &expanded);
 	return 0;
 }
 
@@ -182,20 +190,22 @@ str_index_insert(
 	str_index_read_func read_func,
 	const void *read_func_data
 ) {
-	if (str_index->size >= str_index->capacity / STR_INDEX_SPARSE_FACTOR) {
+	struct hash_index *index = &str_index->hash_index;
+	if (index->count >= index->capacity) {
+		uint32_t new_capacity = index->capacity
+						? index->capacity * 2
+						: STR_INDEX_INITIAL_CAPACITY;
 		if (str_index_expand(
 			    str_index,
 			    key_size,
-			    (str_index->size + !str_index->size) *
-				    STR_INDEX_SPARSE_FACTOR * 2,
+			    new_capacity,
 			    read_func,
 			    read_func_data
-		    )) {
+		    ) != 0)
 			return -1;
-		}
 	}
 
-	str_index_insert_force(str_index, key, key_size, value);
-
-	return 0;
+	return hash_index_insert(
+		&str_index->hash_index, str_index_hash(key, key_size), value
+	);
 }

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -140,6 +140,15 @@ hash_index_test = executable(
 )
 test('hash_index', hash_index_test, suite: ['common'])
 
+str_index_test = executable(
+  'str_index_test',
+  ['str_index_test.c',],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies,
+)
+test('str_index', str_index_test, suite: ['common'])
+
 thread_dep = dependency('threads')
 
 data_pipe_test = executable(

--- a/tests/common/str_index_test.c
+++ b/tests/common/str_index_test.c
@@ -1,0 +1,303 @@
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/str_index.h"
+#include "common/test_assert.h"
+#include "lib/logging/log.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ARENA_SIZE ((size_t)(1u << 22))
+#define KEY_SIZE 32
+#define NAME_COUNT 1024
+
+static char names[NAME_COUNT][KEY_SIZE];
+
+static const char *
+read_name(uint32_t index, const void *data) {
+	(void)data;
+	return names[index];
+}
+
+static void
+set_name(uint32_t index, const char *text) {
+	memset(names[index], 0, KEY_SIZE);
+	strncpy(names[index], text, KEY_SIZE - 1);
+}
+
+struct fixture {
+	void *arena;
+	struct block_allocator allocator;
+	struct memory_context memory_context;
+	struct str_index index;
+};
+
+static int
+fixture_init(struct fixture *fix) {
+	fix->arena = malloc(ARENA_SIZE);
+	TEST_ASSERT(fix->arena != NULL, "arena allocation failed");
+
+	block_allocator_init(&fix->allocator);
+	block_allocator_put_arena(&fix->allocator, fix->arena, ARENA_SIZE);
+
+	TEST_ASSERT(
+		memory_context_init(
+			&fix->memory_context, "test", &fix->allocator
+		) == 0,
+		"memory_context_init failed"
+	);
+
+	TEST_ASSERT(
+		str_index_init(&fix->index, &fix->memory_context) == 0,
+		"str_index_init failed"
+	);
+
+	return 0;
+}
+
+static void
+fixture_fini(struct fixture *fix) {
+	str_index_fini(&fix->index);
+	free(fix->arena);
+}
+
+// Inserts one key and looks it up, then confirms a different key misses.
+static int
+test_single_insert_lookup(void) {
+	struct fixture fix;
+	if (fixture_init(&fix) != 0)
+		return TEST_FAILED;
+
+	set_name(0, "alpha");
+	TEST_ASSERT(
+		str_index_insert(
+			&fix.index, names[0], KEY_SIZE, 0, read_name, NULL
+		) == 0,
+		"insert failed"
+	);
+
+	uint32_t result = str_index_lookup(
+		&fix.index, names[0], KEY_SIZE, read_name, NULL
+	);
+	TEST_ASSERT_EQUAL(0, result, "single insert lookup");
+
+	result = str_index_lookup(
+		&fix.index, "absent", KEY_SIZE, read_name, NULL
+	);
+	TEST_ASSERT_EQUAL(STR_INDEX_INVALID, result, "absent key must miss");
+
+	fixture_fini(&fix);
+	return 0;
+}
+
+// Verifies a lookup on a freshly initialised (empty) index returns
+// STR_INDEX_INVALID without crashing or allocating.
+static int
+test_lookup_empty(void) {
+	struct fixture fix;
+	if (fixture_init(&fix) != 0)
+		return TEST_FAILED;
+
+	TEST_ASSERT(
+		fix.index.hash_index.capacity == 0, "capacity must start at 0"
+	);
+	TEST_ASSERT(fix.index.hash_index.count == 0, "count must start at 0");
+
+	uint32_t result =
+		str_index_lookup(&fix.index, "x", KEY_SIZE, read_name, NULL);
+	TEST_ASSERT_EQUAL(STR_INDEX_INVALID, result, "empty index must miss");
+
+	fixture_fini(&fix);
+	return 0;
+}
+
+// Inserts several distinct keys and looks each one up.
+static int
+test_distinct_keys(void) {
+	struct fixture fix;
+	if (fixture_init(&fix) != 0)
+		return TEST_FAILED;
+
+	for (uint32_t idx = 0; idx < 16; ++idx) {
+		char buf[KEY_SIZE];
+		snprintf(buf, KEY_SIZE, "key-%u", idx * 7 + 3);
+		set_name(idx, buf);
+		TEST_ASSERT(
+			str_index_insert(
+				&fix.index,
+				names[idx],
+				KEY_SIZE,
+				idx,
+				read_name,
+				NULL
+			) == 0,
+			"insert failed at %u",
+			idx
+		);
+	}
+
+	for (uint32_t idx = 0; idx < 16; ++idx) {
+		uint32_t result = str_index_lookup(
+			&fix.index, names[idx], KEY_SIZE, read_name, NULL
+		);
+		TEST_ASSERT_EQUAL(idx, result, "distinct key lookup %u", idx);
+	}
+
+	fixture_fini(&fix);
+	return 0;
+}
+
+// Inserts enough entries to force several expansions, then confirms every
+// stored value is still reachable after the rehashes.
+static int
+test_grow_and_rehash(void) {
+	struct fixture fix;
+	if (fixture_init(&fix) != 0)
+		return TEST_FAILED;
+
+	for (uint32_t idx = 0; idx < NAME_COUNT; ++idx) {
+		char buf[KEY_SIZE];
+		snprintf(buf, KEY_SIZE, "entry-%u", idx);
+		set_name(idx, buf);
+		TEST_ASSERT(
+			str_index_insert(
+				&fix.index,
+				names[idx],
+				KEY_SIZE,
+				idx,
+				read_name,
+				NULL
+			) == 0,
+			"insert failed at %u",
+			idx
+		);
+	}
+	TEST_ASSERT(
+		fix.index.hash_index.count == NAME_COUNT,
+		"count must reach NAME_COUNT"
+	);
+	TEST_ASSERT(
+		fix.index.hash_index.capacity >= NAME_COUNT,
+		"capacity must have grown past NAME_COUNT"
+	);
+
+	for (uint32_t idx = 0; idx < NAME_COUNT; ++idx) {
+		uint32_t result = str_index_lookup(
+			&fix.index, names[idx], KEY_SIZE, read_name, NULL
+		);
+		TEST_ASSERT_EQUAL(idx, result, "post-grow lookup %u", idx);
+	}
+
+	uint32_t miss = str_index_lookup(
+		&fix.index, "entry--1", KEY_SIZE, read_name, NULL
+	);
+	TEST_ASSERT_EQUAL(STR_INDEX_INVALID, miss, "absent key must miss");
+
+	fixture_fini(&fix);
+	return 0;
+}
+
+// A key that is a string prefix of a stored key must not match it: strncmp is
+// bounded by key_size but stops at NUL, so distinct names stay distinct.
+static int
+test_prefix_distinct(void) {
+	struct fixture fix;
+	if (fixture_init(&fix) != 0)
+		return TEST_FAILED;
+
+	set_name(0, "port");
+	set_name(1, "port-in");
+	set_name(2, "port-out");
+
+	for (uint32_t idx = 0; idx < 3; ++idx) {
+		TEST_ASSERT(
+			str_index_insert(
+				&fix.index,
+				names[idx],
+				KEY_SIZE,
+				idx,
+				read_name,
+				NULL
+			) == 0,
+			"insert failed at %u",
+			idx
+		);
+	}
+
+	for (uint32_t idx = 0; idx < 3; ++idx) {
+		uint32_t result = str_index_lookup(
+			&fix.index, names[idx], KEY_SIZE, read_name, NULL
+		);
+		TEST_ASSERT_EQUAL(
+			idx, result, "prefix-distinct lookup %u", idx
+		);
+	}
+
+	fixture_fini(&fix);
+	return 0;
+}
+
+// Confirms that str_index_fini is idempotent and safe to call twice.
+static int
+test_fini_idempotent(void) {
+	struct fixture fix;
+	if (fixture_init(&fix) != 0)
+		return TEST_FAILED;
+
+	set_name(0, "solo");
+	TEST_ASSERT(
+		str_index_insert(
+			&fix.index, names[0], KEY_SIZE, 0, read_name, NULL
+		) == 0,
+		"insert failed"
+	);
+
+	str_index_fini(&fix.index);
+	str_index_fini(&fix.index);
+
+	TEST_ASSERT(
+		fix.index.hash_index.count == 0, "count must be 0 after fini"
+	);
+	TEST_ASSERT(
+		fix.index.hash_index.capacity == 0,
+		"capacity must be 0 after fini"
+	);
+
+	free(fix.arena);
+	return 0;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	if (test_single_insert_lookup() != 0) {
+		LOG(ERROR, "test_single_insert_lookup failed");
+		return -1;
+	}
+	if (test_lookup_empty() != 0) {
+		LOG(ERROR, "test_lookup_empty failed");
+		return -1;
+	}
+	if (test_distinct_keys() != 0) {
+		LOG(ERROR, "test_distinct_keys failed");
+		return -1;
+	}
+	if (test_grow_and_rehash() != 0) {
+		LOG(ERROR, "test_grow_and_rehash failed");
+		return -1;
+	}
+	if (test_prefix_distinct() != 0) {
+		LOG(ERROR, "test_prefix_distinct failed");
+		return -1;
+	}
+	if (test_fini_idempotent() != 0) {
+		LOG(ERROR, "test_fini_idempotent failed");
+		return -1;
+	}
+
+	LOG(INFO, "str_index tests: OK");
+	return 0;
+}


### PR DESCRIPTION
Rebuilds the string-keyed index as a thin layer over the fixed-capacity hash index, replacing the duplicated open-addressing and linear-probing machinery.

- str_index now contributes only FNV-1a hashing, string equality via the read callback, and dynamic resizing through rehash.
- The public API used by the counters library is unchanged.
- Includes a focused unit test suite (tests/common/str_index_test.c).

Stacked on #1593.