### PR TITLE
fix(cp): key the object registry and API by type and name

### DIFF
--- a/api/agent.h
+++ b/api/agent.h
@@ -228,11 +228,16 @@ agent_update_objects(
 	yanet_error **err
 );
 
-// Delete the shared object with the specified name.
+// Delete the shared object with the specified type and name.
 //
 // @return -1 if the object does not exist, 0 on success.
 int
-agent_delete_object(struct agent *agent, const char *name, yanet_error **err);
+agent_delete_object(
+	struct agent *agent,
+	const char *object_type,
+	const char *object_name,
+	yanet_error **err
+);
 
 void *
 agent_storage_read(struct agent *agent, const char *name);

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -723,11 +723,18 @@ agent_update_objects(
 }
 
 int
-agent_delete_object(struct agent *agent, const char *name, yanet_error **err) {
+agent_delete_object(
+	struct agent *agent,
+	const char *object_type,
+	const char *object_name,
+	yanet_error **err
+) {
 	struct dp_config *dp_config = ADDR_OF(&agent->dp_config);
 	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
 
-	int ret = cp_config_delete_object(dp_config, cp_config, name, err);
+	int ret = cp_config_delete_object(
+		dp_config, cp_config, object_type, object_name, err
+	);
 
 	if (ret != 0) {
 		return -1;

--- a/lib/controlplane/agent/agent.h
+++ b/lib/controlplane/agent/agent.h
@@ -182,7 +182,12 @@ agent_update_objects(
 );
 
 int
-agent_delete_object(struct agent *agent, const char *name, yanet_error **err);
+agent_delete_object(
+	struct agent *agent,
+	const char *object_type,
+	const char *object_name,
+	yanet_error **err
+);
 
 struct cp_device_config;
 

--- a/lib/controlplane/config/cp_object.c
+++ b/lib/controlplane/config/cp_object.c
@@ -146,24 +146,46 @@ cp_object_registry_item_cmp(
 	const struct cp_object *object =
 		container_of(item, struct cp_object, config_item);
 
-	return strncmp(object->name, (const char *)data, CP_OBJECT_NAME_LEN);
+	const struct cp_object_cmp_data *cmp_data =
+		(const struct cp_object_cmp_data *)data;
+
+	int cmp = strncmp(object->name, cmp_data->name, sizeof(object->name));
+	if (cmp) {
+		return cmp;
+	}
+
+	return strncmp(object->type, cmp_data->type, sizeof(object->type));
 }
 
 int
 cp_object_registry_lookup_index(
-	struct cp_object_registry *registry, const char *name, uint64_t *index
+	struct cp_object_registry *registry,
+	const char *object_type,
+	const char *object_name,
+	uint64_t *index
 ) {
+	struct cp_object_cmp_data cmp_data;
+	strtcpy(cmp_data.type, object_type, sizeof(cmp_data.type));
+	strtcpy(cmp_data.name, object_name, sizeof(cmp_data.name));
+
 	return registry_lookup(
-		&registry->registry, cp_object_registry_item_cmp, name, index
+		&registry->registry,
+		cp_object_registry_item_cmp,
+		&cmp_data,
+		index
 	);
 }
 
 struct cp_object *
 cp_object_registry_lookup(
-	struct cp_object_registry *registry, const char *name
+	struct cp_object_registry *registry,
+	const char *object_type,
+	const char *object_name
 ) {
 	uint64_t index;
-	if (cp_object_registry_lookup_index(registry, name, &index)) {
+	if (cp_object_registry_lookup_index(
+		    registry, object_type, object_name, &index
+	    )) {
 		return NULL;
 	}
 
@@ -177,12 +199,13 @@ cp_object_registry_lookup(
 int
 cp_object_registry_upsert(
 	struct cp_object_registry *registry,
-	const char *name,
+	const char *object_type,
+	const char *object_name,
 	struct cp_object *new_object,
 	yanet_error **err
 ) {
 	struct cp_object *old_object =
-		cp_object_registry_lookup(registry, name);
+		cp_object_registry_lookup(registry, object_type, object_name);
 
 	if (counter_registry_link(
 		    &new_object->counter_registry,
@@ -191,8 +214,9 @@ cp_object_registry_upsert(
 	    )) {
 		yanet_error_add(
 			err,
-			"failed to link counter registry for object '%s'",
-			name
+			"failed to link counter registry for object '%s:%s'",
+			object_type,
+			object_name
 		);
 		return -1;
 	}
@@ -202,10 +226,14 @@ cp_object_registry_upsert(
 	// a re-upsert of an already-referenced instance must not double-count.
 	uint64_t refcnt_before = new_object->config_item.refcnt;
 
+	struct cp_object_cmp_data cmp_data;
+	strtcpy(cmp_data.type, object_type, sizeof(cmp_data.type));
+	strtcpy(cmp_data.name, object_name, sizeof(cmp_data.name));
+
 	if (registry_replace(
 		    &registry->registry,
 		    cp_object_registry_item_cmp,
-		    name,
+		    &cmp_data,
 		    &new_object->config_item,
 		    cp_object_registry_item_free_cb,
 		    NULL
@@ -224,12 +252,18 @@ cp_object_registry_upsert(
 
 int
 cp_object_registry_delete(
-	struct cp_object_registry *registry, const char *name
+	struct cp_object_registry *registry,
+	const char *object_type,
+	const char *object_name
 ) {
+	struct cp_object_cmp_data cmp_data;
+	strtcpy(cmp_data.type, object_type, sizeof(cmp_data.type));
+	strtcpy(cmp_data.name, object_name, sizeof(cmp_data.name));
+
 	return registry_replace(
 		&registry->registry,
 		cp_object_registry_item_cmp,
-		name,
+		&cmp_data,
 		NULL,
 		cp_object_registry_item_free_cb,
 		NULL

--- a/lib/controlplane/config/cp_object.h
+++ b/lib/controlplane/config/cp_object.h
@@ -64,6 +64,13 @@ struct cp_object_registry {
 	struct registry registry;
 };
 
+// Lookup key for a registry slot: the object identity is the (type, name)
+// pair, mirroring the cp_module (type, name) key.
+struct cp_object_cmp_data {
+	char type[CP_OBJECT_TYPE_LEN];
+	char name[CP_OBJECT_NAME_LEN];
+};
+
 int
 cp_object_registry_init(
 	struct memory_context *memory_context,
@@ -87,25 +94,33 @@ cp_object_registry_get(struct cp_object_registry *registry, uint64_t index);
 
 struct cp_object *
 cp_object_registry_lookup(
-	struct cp_object_registry *registry, const char *name
+	struct cp_object_registry *registry,
+	const char *object_type,
+	const char *object_name
 );
 
 int
 cp_object_registry_lookup_index(
-	struct cp_object_registry *registry, const char *name, uint64_t *index
+	struct cp_object_registry *registry,
+	const char *object_type,
+	const char *object_name,
+	uint64_t *index
 );
 
 int
 cp_object_registry_upsert(
 	struct cp_object_registry *registry,
-	const char *name,
+	const char *object_type,
+	const char *object_name,
 	struct cp_object *new_object,
 	yanet_error **err
 );
 
 int
 cp_object_registry_delete(
-	struct cp_object_registry *registry, const char *name
+	struct cp_object_registry *registry,
+	const char *object_type,
+	const char *object_name
 );
 
 static inline uint64_t

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -615,17 +615,24 @@ cp_config_gen_lookup_pipeline_index(
 
 struct cp_object *
 cp_config_gen_lookup_object(
-	struct cp_config_gen *config_gen, const char *name
+	struct cp_config_gen *config_gen,
+	const char *object_type,
+	const char *object_name
 ) {
-	return cp_object_registry_lookup(&config_gen->object_registry, name);
+	return cp_object_registry_lookup(
+		&config_gen->object_registry, object_type, object_name
+	);
 }
 
 int
 cp_config_gen_lookup_object_index(
-	struct cp_config_gen *config_gen, const char *name, uint64_t *index
+	struct cp_config_gen *config_gen,
+	const char *object_type,
+	const char *object_name,
+	uint64_t *index
 ) {
 	return cp_object_registry_lookup_index(
-		&config_gen->object_registry, name, index
+		&config_gen->object_registry, object_type, object_name, index
 	);
 }
 
@@ -753,13 +760,15 @@ cp_config_update_objects(
 	for (uint64_t idx = 0; idx < object_count; ++idx) {
 		if (cp_object_registry_upsert(
 			    &new_config_gen->object_registry,
+			    objects[idx]->type,
 			    objects[idx]->name,
 			    objects[idx],
 			    err
 		    )) {
 			yanet_error_add(
 				err,
-				"failed to upsert object '%s'",
+				"failed to upsert object '%s:%s'",
+				objects[idx]->type,
 				objects[idx]->name
 			);
 			goto error_free;
@@ -784,7 +793,8 @@ int
 cp_config_delete_object(
 	struct dp_config *dp_config,
 	struct cp_config *cp_config,
-	const char *name,
+	const char *object_type,
+	const char *object_name,
 	yanet_error **err
 ) {
 	cp_config_lock(cp_config);
@@ -793,8 +803,15 @@ cp_config_delete_object(
 		ADDR_OF(&cp_config->cp_config_gen);
 
 	uint64_t index;
-	if (cp_config_gen_lookup_object_index(old_config_gen, name, &index)) {
-		yanet_error_add(err, "object '%s' not found", name);
+	if (cp_config_gen_lookup_object_index(
+		    old_config_gen, object_type, object_name, &index
+	    )) {
+		yanet_error_add(
+			err,
+			"object '%s:%s' not found",
+			object_type,
+			object_name
+		);
 		goto error_unlock;
 	}
 
@@ -804,7 +821,9 @@ cp_config_delete_object(
 		goto error_unlock;
 	}
 
-	if (cp_object_registry_delete(&new_config_gen->object_registry, name)) {
+	if (cp_object_registry_delete(
+		    &new_config_gen->object_registry, object_type, object_name
+	    )) {
 		yanet_error_add(err, "failed to delete object");
 		goto error_free;
 	}

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -221,7 +221,8 @@ int
 cp_config_delete_object(
 	struct dp_config *dp_config,
 	struct cp_config *cp_config,
-	const char *name,
+	const char *object_type,
+	const char *object_name,
 	yanet_error **err
 );
 
@@ -288,11 +289,18 @@ cp_config_gen_lookup_pipeline_index(
 );
 
 struct cp_object *
-cp_config_gen_lookup_object(struct cp_config_gen *config_gen, const char *name);
+cp_config_gen_lookup_object(
+	struct cp_config_gen *config_gen,
+	const char *object_type,
+	const char *object_name
+);
 
 int
 cp_config_gen_lookup_object_index(
-	struct cp_config_gen *config_gen, const char *name, uint64_t *index
+	struct cp_config_gen *config_gen,
+	const char *object_type,
+	const char *object_name,
+	uint64_t *index
 );
 
 /*

--- a/lib/controlplane/tests/cp_object_gen_test.c
+++ b/lib/controlplane/tests/cp_object_gen_test.c
@@ -83,22 +83,26 @@ test_cp_object_gen_update_and_lookup(struct yanet_shm *shm) {
 	struct cp_config_gen *gen = ADDR_OF(&cp_config->cp_config_gen);
 
 	TEST_ASSERT(
-		cp_config_gen_lookup_object(gen, "lookup-1") == obj1,
+		cp_config_gen_lookup_object(gen, "test", "lookup-1") == obj1,
 		"lookup_object(lookup-1) must return obj1"
 	);
 	TEST_ASSERT(
-		cp_config_gen_lookup_object(gen, "lookup-2") == obj2,
+		cp_config_gen_lookup_object(gen, "test", "lookup-2") == obj2,
 		"lookup_object(lookup-2) must return obj2"
 	);
 
 	uint64_t idx1;
 	uint64_t idx2;
 	TEST_ASSERT_SUCCESS(
-		cp_config_gen_lookup_object_index(gen, "lookup-1", &idx1),
+		cp_config_gen_lookup_object_index(
+			gen, "test", "lookup-1", &idx1
+		),
 		"lookup_object_index(lookup-1) failed"
 	);
 	TEST_ASSERT_SUCCESS(
-		cp_config_gen_lookup_object_index(gen, "lookup-2", &idx2),
+		cp_config_gen_lookup_object_index(
+			gen, "test", "lookup-2", &idx2
+		),
 		"lookup_object_index(lookup-2) failed"
 	);
 	TEST_ASSERT(idx1 != idx2, "indices for distinct objects collide");
@@ -113,13 +117,13 @@ test_cp_object_gen_update_and_lookup(struct yanet_shm *shm) {
 	);
 
 	TEST_ASSERT_NULL(
-		cp_config_gen_lookup_object(gen, "no-such-object"),
+		cp_config_gen_lookup_object(gen, "test", "no-such-object"),
 		"lookup of missing object must return NULL"
 	);
 	uint64_t unused_index;
 	TEST_ASSERT(
 		cp_config_gen_lookup_object_index(
-			gen, "no-such-object", &unused_index
+			gen, "test", "no-such-object", &unused_index
 		) != 0,
 		"lookup_index of missing object must fail"
 	);
@@ -128,12 +132,12 @@ test_cp_object_gen_update_and_lookup(struct yanet_shm *shm) {
 	// reference (the prior generation is freed by the install), so the
 	// free callback decrements loaded_object_count for each.
 	TEST_ASSERT_SUCCESS(
-		agent_delete_object(agent, "lookup-1", &err),
+		agent_delete_object(agent, "test", "lookup-1", &err),
 		"delete_object(lookup-1) failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
 	TEST_ASSERT_SUCCESS(
-		agent_delete_object(agent, "lookup-2", &err),
+		agent_delete_object(agent, "test", "lookup-2", &err),
 		"delete_object(lookup-2) failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
@@ -231,7 +235,9 @@ test_cp_object_gen_replace_delete(struct yanet_shm *shm) {
 
 	uint64_t idx1;
 	TEST_ASSERT_SUCCESS(
-		cp_config_gen_lookup_object_index(gen, "replace-me", &idx1),
+		cp_config_gen_lookup_object_index(
+			gen, "test", "replace-me", &idx1
+		),
 		"lookup_object_index(replace-me) failed before replace"
 	);
 
@@ -266,7 +272,9 @@ test_cp_object_gen_replace_delete(struct yanet_shm *shm) {
 	gen = ADDR_OF(&cp_config->cp_config_gen);
 	uint64_t new_idx1;
 	TEST_ASSERT_SUCCESS(
-		cp_config_gen_lookup_object_index(gen, "replace-me", &new_idx1),
+		cp_config_gen_lookup_object_index(
+			gen, "test", "replace-me", &new_idx1
+		),
 		"lookup_object_index(replace-me) failed after replace"
 	);
 	TEST_ASSERT_EQUAL(
@@ -287,7 +295,7 @@ test_cp_object_gen_replace_delete(struct yanet_shm *shm) {
 	// Delete obj2: it leaves the live generation, and its last reference
 	// drops when the prior generation is freed by the install.
 	TEST_ASSERT_SUCCESS(
-		agent_delete_object(agent, "delete-me", &err),
+		agent_delete_object(agent, "test", "delete-me", &err),
 		"delete_object(delete-me) failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
@@ -299,13 +307,13 @@ test_cp_object_gen_replace_delete(struct yanet_shm *shm) {
 
 	gen = ADDR_OF(&cp_config->cp_config_gen);
 	TEST_ASSERT_NULL(
-		cp_config_gen_lookup_object(gen, "delete-me"),
+		cp_config_gen_lookup_object(gen, "test", "delete-me"),
 		"deleted object must not be findable in the live generation"
 	);
 
 	// Delete new_obj1 so every object's last reference has dropped.
 	TEST_ASSERT_SUCCESS(
-		agent_delete_object(agent, "replace-me", &err),
+		agent_delete_object(agent, "test", "replace-me", &err),
 		"delete_object(replace-me) failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);

--- a/lib/controlplane/tests/cp_object_test.c
+++ b/lib/controlplane/tests/cp_object_test.c
@@ -154,7 +154,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 	);
 
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_upsert(&registry, "foo", foo, &err),
+		cp_object_registry_upsert(&registry, "test", "foo", foo, &err),
 		"upsert(foo) failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
@@ -164,7 +164,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 		"loaded_object_count must be 1 after upsert(foo)"
 	);
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_upsert(&registry, "bar", bar, &err),
+		cp_object_registry_upsert(&registry, "test", "bar", bar, &err),
 		"upsert(bar) failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
@@ -177,11 +177,15 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 	uint64_t foo_index;
 	uint64_t bar_index;
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_lookup_index(&registry, "foo", &foo_index),
+		cp_object_registry_lookup_index(
+			&registry, "test", "foo", &foo_index
+		),
 		"lookup(foo) failed"
 	);
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_lookup_index(&registry, "bar", &bar_index),
+		cp_object_registry_lookup_index(
+			&registry, "test", "bar", &bar_index
+		),
 		"lookup(bar) failed"
 	);
 
@@ -204,7 +208,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 
 	uint64_t index;
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_lookup_index(&copied, "foo", &index),
+		cp_object_registry_lookup_index(&copied, "test", "foo", &index),
 		"lookup(foo) in copy failed"
 	);
 	TEST_ASSERT_EQUAL(
@@ -213,7 +217,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 		"foo index must be stable across copy"
 	);
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_lookup_index(&copied, "bar", &index),
+		cp_object_registry_lookup_index(&copied, "test", "bar", &index),
 		"lookup(bar) in copy failed"
 	);
 	TEST_ASSERT_EQUAL(
@@ -238,7 +242,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 		err ? yanet_error_message(err) : "?"
 	);
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_upsert(&copied, "foo", foo2, &err),
+		cp_object_registry_upsert(&copied, "test", "foo", foo2, &err),
 		"upsert-replace(foo) failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
@@ -249,7 +253,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 		"foo in one of two registries"
 	);
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_lookup_index(&copied, "foo", &index),
+		cp_object_registry_lookup_index(&copied, "test", "foo", &index),
 		"lookup(foo) after replace failed"
 	);
 	TEST_ASSERT_EQUAL(
@@ -267,7 +271,8 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 	// the original registry, so the delete drops only the copy's
 	// reference (no free callback). The reinserted bar2 bumps the count.
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_delete(&copied, "bar"), "delete(bar) failed"
+		cp_object_registry_delete(&copied, "test", "bar"),
+		"delete(bar) failed"
 	);
 	TEST_ASSERT_EQUAL(
 		agent->loaded_object_count,
@@ -285,7 +290,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 		err ? yanet_error_message(err) : "?"
 	);
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_upsert(&copied, "bar", bar2, &err),
+		cp_object_registry_upsert(&copied, "test", "bar", bar2, &err),
 		"upsert(bar2) failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);
@@ -295,7 +300,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 		"loaded_object_count must be 4 after upsert(bar2)"
 	);
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_lookup_index(&copied, "bar", &index),
+		cp_object_registry_lookup_index(&copied, "test", "bar", &index),
 		"lookup(bar) after reinsert failed"
 	);
 	TEST_ASSERT_EQUAL(
@@ -313,7 +318,7 @@ test_cp_object_index_stability(struct yanet_shm *shm) {
 		"registry_get(bar) must return the reinserted object"
 	);
 	TEST_ASSERT(
-		cp_object_registry_lookup(&copied, "foo") == foo2,
+		cp_object_registry_lookup(&copied, "test", "foo") == foo2,
 		"registry_lookup(foo) must return the replacement"
 	);
 
@@ -399,7 +404,9 @@ test_cp_object_attach_gate(struct yanet_shm *shm) {
 		err ? yanet_error_message(err) : "?"
 	);
 	TEST_ASSERT_SUCCESS(
-		cp_object_registry_upsert(&registry, "gate", object, &err),
+		cp_object_registry_upsert(
+			&registry, "test", "gate", object, &err
+		),
 		"upsert(gate) failed: %s",
 		err ? yanet_error_message(err) : "?"
 	);


### PR DESCRIPTION
- Keys the control-plane object registry and its lookup, delete, and generation-lookup APIs by both type and name instead of name alone.
- Threads type and name through the config-generation and agent object APIs, matching how the module registry is already keyed.
- Makes a same-name, different-type object a distinct slot, so object identity is consistent end to end.
