### PR TITLE
fix(httpproxy): answer 503 for an unreachable backend

### DIFF
--- a/controlplane/httpproxy/proxy.go
+++ b/controlplane/httpproxy/proxy.go
@@ -110,6 +110,25 @@ func (m *TransparentWebGRPCProxy) writeRegistryMissError(w http.ResponseWriter, 
 	http.Error(w, message, http.StatusServiceUnavailable)
 }
 
+// writeBackendUnreachableError responds to a GetConnection failure with 503,
+// not 500.
+//
+// The only proxy.Backend the gateway builds (controlplane/gateway/backend.go)
+// returns a nil error unconditionally, so this branch is unreachable in
+// production. 503 is what keeps it consistent with the outage that does
+// happen: that backend's grpc.NewClient dials lazily, so a down control
+// plane surfaces later at conn.Invoke as codes.Unavailable, which
+// grpcCodeToHTTPStatus turns into 503 on the unary path.
+func (m *TransparentWebGRPCProxy) writeBackendUnreachableError(w http.ResponseWriter, service, method string, err error) {
+	m.log.Error("failed to get connection to backend",
+		zap.String("service", service),
+		zap.String("method", method),
+		zap.Error(err),
+	)
+	message := fmt.Sprintf("service %s is unreachable: %v", service, err)
+	http.Error(w, message, http.StatusServiceUnavailable)
+}
+
 // handleUnary handles unary gRPC calls.
 func (m *TransparentWebGRPCProxy) handleUnary(w http.ResponseWriter, r *http.Request, fullMethodName string) {
 	service, method, err := xgrpc.ParseFullMethod(fullMethodName)
@@ -153,12 +172,7 @@ func (m *TransparentWebGRPCProxy) handleUnary(w http.ResponseWriter, r *http.Req
 
 	outCtx, conn, err := backend.GetConnection(ctx, fullMethodName)
 	if err != nil {
-		m.log.Error("failed to get connection to backend",
-			zap.String("service", service),
-			zap.String("method", method),
-			zap.Error(err),
-		)
-		http.Error(w, fmt.Sprintf("Failed to connect to backend: %v", err), http.StatusInternalServerError)
+		m.writeBackendUnreachableError(w, service, method, err)
 		return
 	}
 
@@ -346,12 +360,7 @@ func (m *TransparentWebGRPCProxy) handleServerStreaming(w http.ResponseWriter, r
 
 	outCtx, conn, err := backend.GetConnection(ctx, fullMethodName)
 	if err != nil {
-		m.log.Error("failed to get connection to backend",
-			zap.String("service", service),
-			zap.String("method", method),
-			zap.Error(err),
-		)
-		http.Error(w, fmt.Sprintf("Failed to connect to backend: %v", err), http.StatusInternalServerError)
+		m.writeBackendUnreachableError(w, service, method, err)
 		return
 	}
 

--- a/controlplane/httpproxy/proxy_test.go
+++ b/controlplane/httpproxy/proxy_test.go
@@ -1,6 +1,8 @@
 package httpproxy_test
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/siderolabs/grpc-proxy/proxy"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
@@ -59,6 +62,84 @@ func TestServeHTTP_UnknownService(t *testing.T) {
 			handler.ServeHTTP(recorder, req)
 
 			require.Equal(t, http.StatusServiceUnavailable, recorder.Code, testCase.rationale)
+		})
+	}
+}
+
+// unreachableBackend is a proxy.Backend whose GetConnection always fails,
+// simulating a registered service whose upstream connection cannot be
+// established.
+type unreachableBackend struct {
+	err error
+	// called records whether GetConnection was actually invoked, so the
+	// test can distinguish this branch from the registry-miss branch,
+	// which also answers 503 without ever calling GetConnection.
+	called *bool
+}
+
+func (m unreachableBackend) String() string {
+	return "unreachable-backend"
+}
+
+func (m unreachableBackend) GetConnection(_ context.Context, _ string) (context.Context, *grpc.ClientConn, error) {
+	*m.called = true
+	return nil, nil, m.err
+}
+
+func (m unreachableBackend) AppendInfo(_ bool, resp []byte) ([]byte, error) {
+	return resp, nil
+}
+
+func (m unreachableBackend) BuildError(_ bool, _ error) ([]byte, error) {
+	return nil, nil
+}
+
+// unreachableRegistry is a BackendRegistry that always resolves to an
+// unreachableBackend, simulating a service that is registered but whose
+// control plane connection is currently down.
+type unreachableRegistry struct {
+	backend unreachableBackend
+}
+
+func (m unreachableRegistry) GetBackend(_ string) (proxy.Backend, bool) {
+	return m.backend, true
+}
+
+// TestServeHTTP_BackendUnreachable verifies that a GetConnection failure is
+// answered with 503, not 500, on both the unary and server-streaming
+// request paths, and that the failing backend was actually reached.
+func TestServeHTTP_BackendUnreachable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "unary",
+			path: "/api" + ynpb.ReadinessService_Ready_FullMethodName,
+		},
+		{
+			name: "streaming",
+			path: "/api" + ynpb.ReadinessService_Watch_FullMethodName,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			called := false
+			backend := unreachableBackend{err: errors.New("connection refused"), called: &called}
+			handler := httpproxy.NewHTTPHandler(unreachableRegistry{backend: backend})
+
+			req := httptest.NewRequest(http.MethodPost, testCase.path, strings.NewReader("{}"))
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+			require.True(t, called, "GetConnection was never invoked")
 		})
 	}
 }


### PR DESCRIPTION
- The HTTP proxy answered `500 Internal Server Error` when it could not obtain a connection to a module control plane, while the neighbouring registry miss already answered `503 Service Unavailable` for what is the same failure from the caller's point of view.
- Both reachability failures now answer 503 through one shared response path, which records what actually earns that status: the connection the gateway hands out dials lazily, so a control plane that is genuinely down surfaces later as `Unavailable` and already mapped to 503.
- Adds coverage for both the unary and the server-streaming path against a backend whose connection cannot be established, asserting the backend was actually reached so the case cannot pass through the registry-miss branch.
- No consumer distinguishes the two statuses today: the Web UI special-cases 404 only, and there is no retry or health logic keyed on 5xx.