### PR TITLE
fix(web): cross-check the shared-memory inventory on the acl and route pages

### DIFF
--- a/modules/acl/web/useAclDraft.ts
+++ b/modules/acl/web/useAclDraft.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useReducer, useState } from 'react';
-import { API, loadKnownConfigs } from '@yanet/core/api';
+import { API, inventoryConfigNames, loadKnownConfigs, unionConfigNames } from '@yanet/core/api';
 import { useConfigListCache } from '@yanet/core/hooks';
 import { toaster, compareNatural, warnConfigsUnknown } from '@yanet/core/utils';
 import type { Rule } from '@yanet/core/api/acl';
@@ -40,7 +40,8 @@ export interface UseAclDraftResult {
 /**
  * Wraps ACL config data with a local-draft layer.
  *
- * Server state is fetched once on mount via listConfigs + showConfig per name.
+ * Server state is fetched once on mount via listConfigs and the shared-memory
+ * inventory, then showConfig per name.
  * All UI mutations go through dispatchDraft and update only local state until
  * the user explicitly calls saveConfig.
  */
@@ -57,8 +58,11 @@ export const useAclDraft = (): UseAclDraftResult => {
     const load = useCallback(async (): Promise<void> => {
         setLoading(true);
         try {
-            const listResp = await API.acl.listConfigs();
-            const names = listResp.configs ?? [];
+            const [listResp, inventoryNames] = await Promise.all([
+                API.acl.listConfigs(),
+                inventoryConfigNames('acl'),
+            ]);
+            const names = unionConfigNames(listResp.configs ?? [], inventoryNames);
 
             const configs = await loadKnownConfigs(
                 names,

--- a/modules/decap/web/usePrefixDraft.ts
+++ b/modules/decap/web/usePrefixDraft.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { API, loadKnownConfigs } from '@yanet/core/api';
+import { API, inventoryConfigNames, loadKnownConfigs } from '@yanet/core/api';
 import { warnConfigsUnknown } from '@yanet/core/utils';
 import type { PrefixRowItem } from './types';
 import { prefixDraftReducer, initialPrefixDraftState } from './prefixDraftReducer';
@@ -18,12 +18,7 @@ export type UsePrefixDraftResult = UseDraftResult<PrefixRowItem>;
  */
 export const usePrefixDraft = (): UsePrefixDraftResult => {
     const load = useCallback(async (): Promise<Array<{ name: string; rows: PrefixRowItem[] }>> => {
-        const inspectResp = await API.inspect.inspect();
-        const cpConfigs = inspectResp.instance_info?.cp_configs ?? [];
-        const configNames = cpConfigs
-            .filter((c) => c.type === 'decap')
-            .map((c) => c.name ?? '')
-            .filter(Boolean);
+        const configNames = await inventoryConfigNames('decap');
         return loadKnownConfigs(configNames, async (name): Promise<{ name: string; rows: PrefixRowItem[] }> => {
             const resp = await API.decap.showConfig({ name });
             const rows: PrefixRowItem[] = (resp.prefixes ?? []).map((p) => ({ id: p, prefix: p }));

--- a/modules/forward/web/useForwardDraft.ts
+++ b/modules/forward/web/useForwardDraft.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
-import { API, loadKnownConfigs } from '@yanet/core/api';
+import { API, inventoryConfigNames, loadKnownConfigs } from '@yanet/core/api';
 import { useConfigListCache } from '@yanet/core/hooks';
 import { toaster, warnConfigsUnknown } from '@yanet/core/utils';
 import type { Rule } from '@yanet/core/api/forward';
@@ -69,12 +69,7 @@ export const useForwardDraft = (): UseForwardDraftResult => {
     const load = useCallback(async (): Promise<void> => {
         setLoading(true);
         try {
-            const inspectResp = await API.inspect.inspect();
-            const cpConfigs = inspectResp.instance_info?.cp_configs ?? [];
-            const forwardNames = cpConfigs
-                .filter(cfg => cfg.type === 'forward')
-                .map(cfg => cfg.name ?? '')
-                .filter(Boolean);
+            const forwardNames = await inventoryConfigNames('forward');
 
             const configs: Array<{ name: string; rules: Rule[] }> = await loadKnownConfigs(
                 forwardNames,

--- a/modules/route/web/useFIBDraft.ts
+++ b/modules/route/web/useFIBDraft.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { API, loadKnownConfigs } from '@yanet/core/api';
+import { API, inventoryConfigNames, loadKnownConfigs, unionConfigNames } from '@yanet/core/api';
 import { warnConfigsUnknown } from '@yanet/core/utils';
 import type { FIBEntry, FIBNexthop, FIBRangeEntry } from '@yanet/core/api/routes';
 import { ipRangeToCIDRs } from '@yanet/core/utils/netip';
@@ -60,15 +60,18 @@ export type UseFIBDraftResult = UseDraftResult<FIBRowItem>;
 /**
  * Wraps FIB config data with a local-draft layer.
  *
- * Server state is fetched once on mount via the route.showFIB and route.listConfigs APIs.
+ * Server state is fetched once on mount via the route.listConfigs, inspect and route.showFIB APIs.
  * All UI mutations go through dispatchDraft and update only local state until the user
  * explicitly calls commitConfig. On commit the full draft rows are sent via API.route.updateFIB
  * and the local server snapshot is updated so dirty clears.
  */
 export const useFIBDraft = (): UseFIBDraftResult => {
     const load = useCallback(async (): Promise<Array<{ name: string; rows: FIBRowItem[] }>> => {
-        const configsResp = await API.route.listConfigs();
-        const configNames = configsResp.configs ?? [];
+        const [configsResp, inventoryNames] = await Promise.all([
+            API.route.listConfigs(),
+            inventoryConfigNames('route'),
+        ]);
+        const configNames = unionConfigNames(configsResp.configs ?? [], inventoryNames);
         return loadKnownConfigs(configNames, async (name): Promise<{ name: string; rows: FIBRowItem[] }> => {
             const fibResp = await API.route.showFIB({ name });
             return { name, rows: flattenFIBEntries(fibResp.entries ?? []) };

--- a/web/src/core/api/inspect.test.ts
+++ b/web/src/core/api/inspect.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { inventoryConfigNames, unionConfigNames } from './inspect';
+
+describe('unionConfigNames', () => {
+    it('regression: an empty service list plus a non-empty inventory yields the inventory names, so onAllDropped can fire after a restart', () => {
+        expect(unionConfigNames([], ['acl0'])).toEqual(['acl0']);
+    });
+
+    it('keeps service names first, in their original order', () => {
+        expect(unionConfigNames(['b', 'a'], [])).toEqual(['b', 'a']);
+    });
+
+    it('keeps service names before inventory-only names', () => {
+        expect(unionConfigNames(['b'], ['a'])).toEqual(['b', 'a']);
+    });
+
+    it('lists a name present in both sources exactly once', () => {
+        expect(unionConfigNames(['a', 'b'], ['a', 'b'])).toEqual(['a', 'b']);
+    });
+
+    it('returns the service list unchanged when the inventory is empty', () => {
+        expect(unionConfigNames(['a', 'b'], [])).toEqual(['a', 'b']);
+    });
+});
+
+describe('inventoryConfigNames', () => {
+    beforeEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    const stubInspectResponse = (body: unknown): void => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            json: async () => body,
+        }));
+    };
+
+    it('filters cp_configs by the requested module type', async () => {
+        stubInspectResponse({
+            instance_info: {
+                cp_configs: [
+                    { type: 'acl', name: 'acl0' },
+                    { type: 'route', name: 'route0' },
+                ],
+            },
+        });
+        await expect(inventoryConfigNames('acl')).resolves.toEqual(['acl0']);
+    });
+
+    it('drops entries with a missing or empty name', async () => {
+        stubInspectResponse({
+            instance_info: {
+                cp_configs: [
+                    { type: 'acl', name: '' },
+                    { type: 'acl' },
+                    { type: 'acl', name: 'acl0' },
+                ],
+            },
+        });
+        await expect(inventoryConfigNames('acl')).resolves.toEqual(['acl0']);
+    });
+
+    it('returns an empty list when instance_info is absent', async () => {
+        stubInspectResponse({});
+        await expect(inventoryConfigNames('acl')).resolves.toEqual([]);
+    });
+
+    it('returns an empty list when cp_configs is absent', async () => {
+        stubInspectResponse({ instance_info: {} });
+        await expect(inventoryConfigNames('acl')).resolves.toEqual([]);
+    });
+});
+

--- a/web/src/core/api/inspect.ts
+++ b/web/src/core/api/inspect.ts
@@ -78,3 +78,28 @@ export const inspect = {
         return inspectService.call<InspectResponse>('Inspect', options);
     },
 };
+
+/** Config names of the given module type held in the dataplane's shared-memory inventory.
+ *
+ * The inventory outlives a module control-plane restart, so it is the only source
+ * that still knows a config the service's in-process map lost.
+ */
+export const inventoryConfigNames = async (moduleType: string): Promise<string[]> => {
+    const resp = await inspect.inspect();
+    const cpConfigs = resp.instance_info?.cp_configs ?? [];
+    return cpConfigs
+        .filter((config) => config.type === moduleType)
+        .map((config) => config.name ?? '')
+        .filter(Boolean);
+};
+
+/** Union of a module service's own config names with the shared-memory inventory.
+ *
+ * Service names come first, in their original order. Inventory-only names are
+ * appended in inventory order. Every name appears exactly once, even when
+ * `serviceNames` itself contains a duplicate. This ordering guarantees that a
+ * config already rendered from the service list never moves or disappears —
+ * the inventory can only add names, never reorder or drop existing ones.
+ */
+export const unionConfigNames = (serviceNames: string[], inventoryNames: string[]): string[] =>
+    [...new Set([...serviceNames, ...inventoryNames])];


### PR DESCRIPTION
A module control plane rebuilds its configuration map empty on startup, while the dataplane keeps its configurations in shared memory across that restart. The acl and route pages listed configurations only from the control plane, so after a restart they rendered a plain empty page and offered to create a first configuration while the dataplane was still forwarding under the old one.

- Combine the control plane's own configuration list with the shared-memory inventory the inspect API exposes, which is the source the decap and forward pages already trusted.
- Warn when the control plane knows none of the configurations that shared memory still holds, instead of rendering an empty page indistinguishable from a genuinely empty instance.
- Move the inventory lookup the decap and forward pages carried inline into a shared helper, so all four pages read it the same way.

A configuration the control plane no longer knows is still dropped from the view, and a module outage still fails the load outright rather than being misread as an empty instance. Creating a configuration stays available in the warned state, since re-applying one is how an operator recovers.