### PR TITLE
build(deb): narrow the binary package architectures to the supported hosts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Build-Depends: debhelper (>= 12)
  , python3-pyelftools
 
 Package: yanet2-dataplane
-Architecture: any
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}
  , ${misc:Depends}
  , libnuma1
@@ -33,7 +33,7 @@ Description: Yanet2 dataplane component
  packet processing, routing, NAT64, and other network functions.
 
 Package: yanet2-controlplane
-Architecture: any
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}
  , ${misc:Depends}
  , libyaml-0-2
@@ -44,7 +44,7 @@ Description: Yanet2 controlplane component
  dataplane configuration, routing tables, and network policies.
 
 Package: yanet2-cli
-Architecture: any
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}
  , ${misc:Depends}
 Recommends: bash-completion
@@ -59,7 +59,7 @@ Description: Yanet2 CLI utilities
 
 
 Package: yanet2
-Architecture: all
+Architecture: amd64 arm64
 Depends: yanet2-dataplane (= ${binary:Version}),
  yanet2-controlplane (= ${binary:Version}),
  yanet2-cli (= ${binary:Version})
@@ -70,7 +70,7 @@ Description: Yanet2 meta-package
  including dataplane, controlplane and CLI utilities.
 
 Package: yanet2-bird-adapter
-Architecture: any
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}
  , ${misc:Depends}
  , libyaml-0-2
@@ -80,7 +80,7 @@ Description: Yanet2 BIRD adapter component
  This package contains the control-plane services that manage the BIRD import configurations that enable the BIRD import feed to push routes into route-instance configurations.
 
 Package: yanet2-pipeline-operator
-Architecture: any
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}
  , ${misc:Depends}
 Description: YANET2 pipeline operator
@@ -90,7 +90,7 @@ Description: YANET2 pipeline operator
  and device-to-pipeline bindings.
 
 Package: yanet2-route-operator
-Architecture: any
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}
  , ${misc:Depends}
 Description: YANET2 route operator
@@ -100,7 +100,7 @@ Description: YANET2 route operator
  and neighbour discovery.
 
 Package: yanet2-forward-operator
-Architecture: any
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}
  , ${misc:Depends}
 Description: YANET2 forward operator
@@ -108,7 +108,7 @@ Description: YANET2 forward operator
  more YANET2 gateways via FunctionService.
 
 Package: yanet2-decap-operator
-Architecture: any
+Architecture: amd64 arm64
 Depends: ${shlibs:Depends}
  , ${misc:Depends}
 Description: YANET2 decap operator


### PR DESCRIPTION
- Nine binary packages declared an architecture wildcard that claimed support for every architecture Debian knows about, or, for the meta-package, for none in particular.
- The project in fact builds only on 64-bit x86 and little-endian ARM: the CRC-32C helper stops the compile with an explicit error on anything else, and the build system only knows how to derive ISA flags for those two families.
- Narrow every package to amd64 and arm64 so a build daemon no longer attempts an architecture the source cannot compile on, and so the meta-package is not advertised on hosts where the components it pulls in are never built.
- Of the twenty valid dpkg architectures whose CPU is x86-64 or aarch64, only these two are glibc/Linux; the rest are non-Linux ports, alternative libc ports, or the 32-bit-pointer x86-64 ABI, none of which can satisfy the build dependencies.