### PR TITLE
fix(route): reject neighbours whose link has no usable source address

### DIFF
--- a/operators/route/internal/discovery/neigh/neigh.go
+++ b/operators/route/internal/discovery/neigh/neigh.go
@@ -125,6 +125,16 @@ func WithOnHealthy(fn func()) Option {
 	}
 }
 
+// WithKernelTable configures the neighbour monitor with the source of the
+// kernel's link and neighbour tables.
+//
+// The default reads them from a live netlink socket.
+func WithKernelTable(kernelTable KernelTable) Option {
+	return func(o *options) {
+		o.KernelTable = kernelTable
+	}
+}
+
 type options struct {
 	UpdateInterval time.Duration
 	LinkMap        map[string]string
@@ -132,6 +142,7 @@ type options struct {
 	OnError        func(error)
 	OnResynced     func()
 	OnHealthy      func()
+	KernelTable    KernelTable
 	Log            *zap.Logger
 }
 
@@ -143,8 +154,31 @@ func newOptions() *options {
 		OnError:        func(error) {},
 		OnResynced:     func() {},
 		OnHealthy:      func() {},
+		KernelTable:    netlinkKernelTable{},
 		Log:            zap.NewNop(),
 	}
+}
+
+// KernelTable supplies the kernel's link and neighbour tables.
+//
+// The default implementation reads them from a live netlink socket.
+type KernelTable interface {
+	LinkList() ([]netlink.Link, error)
+	NeighList() ([]netlink.Neigh, error)
+}
+
+// netlinkKernelTable is the default KernelTable backed by the live netlink
+// socket.
+type netlinkKernelTable struct{}
+
+// LinkList lists the links known to the kernel.
+func (m netlinkKernelTable) LinkList() ([]netlink.Link, error) {
+	return netlink.LinkList()
+}
+
+// NeighList lists the neighbour entries known to the kernel.
+func (m netlinkKernelTable) NeighList() ([]netlink.Neigh, error) {
+	return netlink.NeighList(0, 0)
 }
 
 // NeighMonitor is a monitor of neighbour events.
@@ -156,6 +190,7 @@ func newOptions() *options {
 type NeighMonitor struct {
 	neighTable     *NeighTable
 	source         *NeighSource
+	kernelTable    KernelTable
 	updateInterval time.Duration
 	linkMap        map[string]string
 	onSynced       sync.Once
@@ -185,6 +220,7 @@ func NewNeighMonitor(neighTable *NeighTable, source *NeighSource, options ...Opt
 	m := &NeighMonitor{
 		neighTable:     neighTable,
 		source:         source,
+		kernelTable:    opts.KernelTable,
 		linkMap:        opts.LinkMap,
 		updateInterval: opts.UpdateInterval,
 		onSyncedFn:     opts.OnSynced,
@@ -316,13 +352,35 @@ func (m *NeighMonitor) notifyResynced() {
 	m.onResyncedFn()
 }
 
+// isUsableSourceMAC reports whether a link's hardware address can serve as
+// the source MAC of a forwarded frame.
+//
+// An all-zero source MAC is not learnable and is dropped by many switches,
+// so it must be rejected rather than emitted. Links without an Ethernet
+// address of their own — tunnels and other point-to-point devices — report
+// a nil or short HardwareAddr, and the loopback device reports six genuine
+// zero bytes; both fail this check. A true result also guarantees exactly
+// six bytes, which the caller relies on: its [6]byte(hardwareAddr) array
+// conversion panics on any other length.
+func isUsableSourceMAC(hardwareAddr net.HardwareAddr) bool {
+	if len(hardwareAddr) != 6 {
+		return false
+	}
+	for _, octet := range hardwareAddr {
+		if octet != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *NeighMonitor) updateNeighbours() error {
-	neighs, err := netlink.NeighList(0, 0)
+	neighs, err := m.kernelTable.NeighList()
 	if err != nil {
 		return fmt.Errorf("failed to list neighbours: %w", err)
 	}
 
-	links, err := netlink.LinkList()
+	links, err := m.kernelTable.LinkList()
 	if err != nil {
 		return fmt.Errorf("failed to list links: %w", err)
 	}
@@ -336,12 +394,7 @@ func (m *NeighMonitor) updateNeighbours() error {
 
 		// TODO: should we filter out loopback links?
 
-		hardwareAddr := attrs.HardwareAddr
-		if hardwareAddr == nil {
-			hardwareAddr = make(net.HardwareAddr, 6)
-		}
-
-		linkIndexToHardwareAddr[attrs.Index] = hardwareAddr
+		linkIndexToHardwareAddr[attrs.Index] = attrs.HardwareAddr
 		linkIndexToName[attrs.Index] = attrs.Name
 	}
 
@@ -369,14 +422,17 @@ func (m *NeighMonitor) updateNeighbours() error {
 		// Get the hardware address of the interface.
 		hardwareAddr, ok := linkIndexToHardwareAddr[neigh.LinkIndex]
 		if !ok {
-			m.log.Warn("no hardware address for link index",
+			m.log.Warn("link index not found in link table",
 				zap.Int("link_index", neigh.LinkIndex),
 			)
 			continue
 		}
-		if len(hardwareAddr) != 6 {
-			m.log.Warn("skipping entry with unsupported interface MAC address: must be EUI-48",
-				zap.Stringer("mac", hardwareAddr),
+		if !isUsableSourceMAC(hardwareAddr) {
+			m.log.Warn("skipping entry with unusable source MAC address",
+				zap.String("link_name", linkIndexToName[neigh.LinkIndex]),
+				zap.Int("link_index", neigh.LinkIndex),
+				zap.Stringer("source_mac", hardwareAddr),
+				zap.Stringer("nexthop_addr", nexthopAddr),
 			)
 			continue
 		}

--- a/operators/route/internal/discovery/neigh/neigh_test.go
+++ b/operators/route/internal/discovery/neigh/neigh_test.go
@@ -1,0 +1,105 @@
+package neigh_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"go.uber.org/zap"
+
+	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
+)
+
+// fakeKernelTable is a neigh.KernelTable backed by fixed link and neighbour
+// lists instead of a live netlink socket.
+type fakeKernelTable struct {
+	links  []netlink.Link
+	neighs []netlink.Neigh
+}
+
+// LinkList returns the fixed link list.
+func (m fakeKernelTable) LinkList() ([]netlink.Link, error) {
+	return m.links, nil
+}
+
+// NeighList returns the fixed neighbour list.
+func (m fakeKernelTable) NeighList() ([]netlink.Neigh, error) {
+	return m.neighs, nil
+}
+
+// TestNeighMonitorRejectsUnusableSourceMAC verifies that a neighbour whose
+// link cannot provide a usable source MAC — a nil, all-zero, or non-EUI-48
+// hardware address — is left out of the resolved nexthop cache instead of
+// being admitted with a fabricated or unusable address.
+func TestNeighMonitorRejectsUnusableSourceMAC(t *testing.T) {
+	nexthop := netip.MustParseAddr("10.0.0.1")
+	neighbourMAC := net.HardwareAddr{0x02, 0x00, 0x00, 0x00, 0x00, 0x01}
+
+	tests := []struct {
+		name             string
+		linkHardwareAddr net.HardwareAddr
+		wantPresent      bool
+	}{
+		{
+			name:             "nil hardware address",
+			linkHardwareAddr: nil,
+			wantPresent:      false,
+		},
+		{
+			name:             "all-zero hardware address",
+			linkHardwareAddr: net.HardwareAddr{0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+			wantPresent:      false,
+		},
+		{
+			name:             "short tunnel-style hardware address",
+			linkHardwareAddr: net.HardwareAddr{0x0a, 0x00, 0x00, 0x01},
+			wantPresent:      false,
+		},
+		{
+			name:             "normal EUI-48 hardware address",
+			linkHardwareAddr: net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},
+			wantPresent:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := neigh.NewNeighTable()
+			source, err := table.CreateSource("kernel", 100, true)
+			require.NoError(t, err)
+
+			link := &netlink.Device{
+				LinkAttrs: netlink.LinkAttrs{
+					Index:        1,
+					Name:         "eth0",
+					HardwareAddr: tt.linkHardwareAddr,
+				},
+			}
+			kernelNeigh := netlink.Neigh{
+				LinkIndex:    1,
+				IP:           nexthop.AsSlice(),
+				HardwareAddr: neighbourMAC,
+				State:        netlink.NUD_REACHABLE,
+			}
+
+			fake := fakeKernelTable{
+				links:  []netlink.Link{link},
+				neighs: []netlink.Neigh{kernelNeigh},
+			}
+
+			neigh.NewNeighMonitor(table, source,
+				neigh.WithKernelTable(fake),
+				neigh.WithLog(zap.NewNop()),
+			)
+
+			entry, ok := table.View().Lookup(nexthop)
+			require.Equal(t, tt.wantPresent, ok)
+			if tt.wantPresent {
+				require.Equal(t, [6]byte(tt.linkHardwareAddr), entry.HardwareRoute.SourceMAC)
+				require.Equal(t, [6]byte(neighbourMAC), entry.HardwareRoute.DestinationMAC)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- A link without an Ethernet address of its own was given a fabricated all-zero hardware address, which then became the source MAC of every frame forwarded over it.
- Such a frame is not learnable and many switches drop it outright, so traffic left the box and disappeared with nothing logged and no counter moved.
- Neighbours discovered over a link that cannot supply a usable source address are now rejected and reported instead, leaving the nexthop unresolved where the existing metric already makes it visible.
- The loopback device reports six genuine zero bytes and falls into the same class, so it is rejected on the same grounds.
- The kernel table is now read through an injected source, so the resolution path is covered by a regression test.