### PR TITLE
fix(gateway,cli): mark a registry miss with a structured trailer

### DIFF
--- a/cli/core/src/errors.rs
+++ b/cli/core/src/errors.rs
@@ -105,7 +105,7 @@ impl Error {
         let message = status.message().to_owned();
         let code = status.code();
 
-        let kind = map_code(code, &message);
+        let kind = map_code(&status);
         let hint = default_hint(kind);
 
         Self {
@@ -217,29 +217,50 @@ impl Error {
     }
 }
 
-/// Marker the gateway director opens a `NotFound` `Status` with when the
+/// Trailer metadata key the gateway sets on a `NotFound` `Status` when the
 /// requested gRPC service has no backend registered.
 ///
-/// `controlplane/gateway/gateway.go` produces exactly this message
-/// (`status.Errorf(codes.NotFound, "unknown service")`), with no suffix.
+/// This is a wire contract with the gateway rather than a local constant:
+/// changing it stops registry misses being recognised, silently.
+const ERROR_REASON_METADATA_KEY: &str = "x-yanet-error-reason";
+
+/// Value of [`ERROR_REASON_METADATA_KEY`] that marks a registry miss.
+const SERVICE_UNREGISTERED_REASON: &str = "service-unregistered";
+
+/// Prefix a registry-miss `NotFound` message opens with, on a gateway that
+/// predates [`ERROR_REASON_METADATA_KEY`].
+///
+/// During a rolling upgrade a CLI built after the trailer landed can still
+/// talk to a gateway peer built before it, and that older peer never attaches
+/// the trailer. [`is_unknown_service_status`] falls back to this marker so
+/// the miss is still recognised in that window. Drop the constant and its use
+/// once no supported gateway predates the trailer.
 const UNKNOWN_SERVICE_MARKER: &str = "unknown service";
 
-/// Reports whether `message` is the gateway's unregistered-service `NotFound`.
+/// Reports whether `status` is the gateway's unregistered-service `NotFound`.
 ///
-/// The check is anchored at the start of `message` (`starts_with`) rather
-/// than searched anywhere in it (`contains`): a resource `NotFound` that
-/// merely quotes [`UNKNOWN_SERVICE_MARKER`] inside a config name (e.g.
-/// `config "unknown service" not found`) carries the marker mid-message and
-/// must stay a plain `NotFound`, not be misclassified as an unregistered
-/// service.
-fn is_unknown_service_message(message: &str) -> bool {
-    message.starts_with(UNKNOWN_SERVICE_MARKER)
+/// The trailer set by [`ERROR_REASON_METADATA_KEY`] is the primary signal, so
+/// the gateway's human-readable message stays free to change without
+/// silently reverting the classification client-side. A status without the
+/// trailer is still recognised when its message starts with
+/// [`UNKNOWN_SERVICE_MARKER`] — the compatibility fallback described there.
+/// That check is anchored at the start of the message (`starts_with`, not
+/// `contains`): a resource `NotFound` that merely quotes the marker inside a
+/// config name (e.g. `config "unknown service" not found`) carries it
+/// mid-message and must stay a plain `NotFound`.
+fn is_unknown_service_status(status: &Status) -> bool {
+    let has_trailer = status
+        .metadata()
+        .get(ERROR_REASON_METADATA_KEY)
+        .is_some_and(|value| value == SERVICE_UNREGISTERED_REASON);
+
+    has_trailer || status.message().starts_with(UNKNOWN_SERVICE_MARKER)
 }
 
-/// Map a `tonic::Code` (and optional message text) to a [`ErrorKind`].
-fn map_code(code: Code, message: &str) -> ErrorKind {
-    match code {
-        Code::NotFound if is_unknown_service_message(message) => ErrorKind::ServiceUnregistered,
+/// Map a `tonic::Status` to an [`ErrorKind`].
+fn map_code(status: &Status) -> ErrorKind {
+    match status.code() {
+        Code::NotFound if is_unknown_service_status(status) => ErrorKind::ServiceUnregistered,
         Code::NotFound => ErrorKind::NotFound,
         Code::InvalidArgument => ErrorKind::InvalidArgument,
         Code::Unauthenticated | Code::PermissionDenied => ErrorKind::Auth,
@@ -275,8 +296,8 @@ impl NotFoundMapper {
 
     /// Maps `status` to an [`Error`], rewriting a genuine resource `NotFound`
     /// into a friendly `"<resource> not found"` message and passing everything
-    /// else (including the gateway's "unknown service" `NotFound`) through
-    /// unchanged.
+    /// else (including a registry-miss `NotFound`, whether recognised by
+    /// trailer or by the compatibility fallback) through unchanged.
     pub fn map(
         &self,
         status: Status,
@@ -284,7 +305,7 @@ impl NotFoundMapper {
         endpoint: impl Into<String>,
         resource: Option<&str>,
     ) -> Error {
-        if status.code() == Code::NotFound && !is_unknown_service_message(status.message()) {
+        if status.code() == Code::NotFound && !is_unknown_service_status(&status) {
             let resource = resource.unwrap_or(self.default_resource);
 
             return Error::from_status(
@@ -301,11 +322,21 @@ impl NotFoundMapper {
 
 #[cfg(test)]
 mod test {
-    use tonic::Status;
+    use tonic::{metadata::MetadataMap, Code, Status};
 
     use super::{Error, ErrorKind, NotFoundMapper};
 
     const MAPPER: NotFoundMapper = NotFoundMapper::new("test.Service", "requested item");
+
+    /// Builds a `NotFound` `Status` carrying the gateway's registry-miss
+    /// trailer, pinned to the literal wire values rather than the
+    /// production constants so the test exercises the actual contract.
+    fn unregistered_status(message: &str) -> Status {
+        let mut metadata = MetadataMap::new();
+        metadata.insert("x-yanet-error-reason", "service-unregistered".parse().unwrap());
+
+        Status::with_metadata(Code::NotFound, message, metadata)
+    }
 
     #[test]
     fn new_carries_the_requested_kind() {
@@ -348,16 +379,24 @@ mod test {
 
     #[test]
     fn unknown_service_not_found_passes_through_as_service_unregistered() {
-        let status = Status::not_found("unknown service test.Service");
+        let status = unregistered_status("unknown service test.Service");
         let err = MAPPER.map(status, "show item", "http://localhost:50051", None);
 
         assert_eq!(ErrorKind::ServiceUnregistered, err.kind);
     }
 
     #[test]
-    fn bare_unknown_service_message_is_service_unregistered() {
+    fn unknown_service_message_without_the_trailer_is_the_compatibility_fallback() {
         let status = Status::not_found("unknown service");
         let err = MAPPER.map(status, "show item", "http://localhost:50051", None);
+
+        assert_eq!(ErrorKind::ServiceUnregistered, err.kind);
+    }
+
+    #[test]
+    fn trailer_is_service_unregistered_even_with_a_config_name_message() {
+        let status = unregistered_status(r#"config "unknown service" not found"#);
+        let err = MAPPER.map(status, "show item", "http://localhost:50051", Some("item 'x'"));
 
         assert_eq!(ErrorKind::ServiceUnregistered, err.kind);
     }

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/yanet-platform/yanet2/common/go/grpcmetrics"
@@ -62,6 +63,20 @@ type serviceEntry struct {
 // defaultPerServiceMethodLimit caps the number of distinct grpc_method label
 // values the default metrics factory tracks per grpc_service.
 const defaultPerServiceMethodLimit = 64
+
+// errorReasonMetadataKey is the trailer metadata key that classifies a
+// NotFound status without relying on its message text.
+//
+// It is part of the wire contract with clients that classify on it, so
+// renaming it breaks them.
+const errorReasonMetadataKey = "x-yanet-error-reason"
+
+// errorReasonServiceUnregistered marks a NotFound raised because the
+// requested gRPC service has no backend registered.
+//
+// It is part of the wire contract with clients that classify on it, so
+// renaming it breaks them.
+const errorReasonServiceUnregistered = "service-unregistered"
 
 // MetricsFactory constructs the gateway's gRPC server metrics from the
 // gateway-owned per-call bounds.
@@ -182,6 +197,24 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 
 		backend, ok := registry.GetBackend(service)
 		if !ok {
+			// The HTTP surface answers 503 for this same condition,
+			// because it cannot tell an HTTP client "this service never
+			// existed" from "its control plane is unreachable" and so
+			// separates the two by status code, reserving 404 for a
+			// NotFound a backend itself returns. gRPC keeps both as
+			// NotFound and separates them by trailer instead: Unavailable
+			// is not free to reuse, since clients already give it a
+			// different exit code and a different remedy, retrying the
+			// connection, than a registry miss, which needs the operator
+			// started or registered first.
+			//
+			// The trailer is what lets a client classify this NotFound
+			// structurally. The message text stays unchanged because
+			// clients released before the trailer still match on it, and
+			// stays that way until those are gone. SetTrailer only fails
+			// without a live server stream, which the proxying handler
+			// always supplies; losing it would cost only the marker.
+			_ = grpc.SetTrailer(ctx, metadata.Pairs(errorReasonMetadataKey, errorReasonServiceUnregistered))
 			return proxy.One2One, nil, status.Errorf(codes.NotFound, "unknown service")
 		}
 

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -11,7 +11,11 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 	readinesspb "github.com/yanet-platform/yanet2/common/readinesspb/v1"
@@ -167,6 +171,68 @@ func TestGateway_Run_ShutsDownWithOpenStream(t *testing.T) {
 	// CloseSend or cancels its context, matching the reproduction where an
 	// open readiness watch wedges GracefulStop forever.
 	watchUntilOpen(t, ynpb.NewReadinessServiceClient(conn))
+
+	cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- group.Wait() }()
+
+	select {
+	case err := <-runErr:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Gateway.Run did not return within the shutdown grace period")
+	}
+}
+
+// TestGateway_Director_RegistryMissCarriesReasonTrailer verifies that a
+// NotFound for a service the registry has no backend for keeps the exact
+// "unknown service" message and also carries the errorReasonMetadataKey
+// trailer, so a client can classify the miss without parsing the message.
+// The message assertion is deliberate, not incidental: CLIs released
+// before the trailer existed classify on that exact text, so changing it
+// would break them.
+func TestGateway_Director_RegistryMissCarriesReasonTrailer(t *testing.T) {
+	t.Parallel()
+
+	cfg := DefaultConfig()
+	cfg.Server.Endpoint = freeTCPAddr(t)
+
+	gw, err := NewGateway(cfg, WithLog(zap.NewNop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = gw.Close() })
+
+	ctx, cancel := context.WithCancel(t.Context())
+
+	var group errgroup.Group
+	group.Go(func() error {
+		return gw.Run(ctx)
+	})
+
+	conn, err := grpc.NewClient(cfg.Server.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	var invokeErr error
+	var trailer metadata.MD
+	require.Eventually(t, func() bool {
+		trailer = metadata.MD{}
+		invokeErr = conn.Invoke(t.Context(), "/some.unknown.Service/Method", &emptypb.Empty{}, &emptypb.Empty{}, grpc.Trailer(&trailer))
+		// A fresh gRPC server is not immediately reachable after Run
+		// starts (see watchUntilOpen), so retry past a transient
+		// Unavailable from the listener not being up yet instead of
+		// requiring a fixed sleep.
+		statusErr, ok := status.FromError(invokeErr)
+		return ok && statusErr.Code() != codes.Unavailable
+	}, 5*time.Second, 50*time.Millisecond, "failed to reach the gateway's director")
+
+	require.Error(t, invokeErr)
+	statusErr, ok := status.FromError(invokeErr)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, statusErr.Code())
+	require.Equal(t, "unknown service", statusErr.Message())
+
+	require.Equal(t, []string{"service-unregistered"}, trailer.Get("x-yanet-error-reason"))
 
 	cancel()
 


### PR DESCRIPTION
- The gateway's gRPC director answered a registry miss with a `NotFound` that the CLI could tell apart from a genuine resource `NotFound` only by matching the server's message text. That made a human-readable string part of the wire contract: improving the wording server-side would silently revert the classification, and the CLI would print an unrelated hint instead of the real message.
- The director now attaches a trailer marking the miss, set on that branch only, and the CLI classifies on that marker first.
- The message-prefix check from #1602 is kept as an explicitly transitional fallback for a gateway that predates the trailer, since the two ship as separate packages and a newer CLI can meet an older gateway during a rolling upgrade. Without it that window would silently demote a down operator to a missing config. The fallback stays anchored at the start of the message, so a config whose name quotes the marker is still not misclassified, and it is documented as removable once no supported gateway predates the trailer.
- The status code and the message text are unchanged, so a CLI released before the marker keeps working against a newer gateway.
- Records at the branch why the gRPC path keeps `NotFound` where the HTTP proxy answers 503 for the same condition, and why `Unavailable` is not free to reuse.