### PR TITLE
feat(dataplane): configurable numa-local worker thread stack

### DIFF
--- a/dataplane/config.c
+++ b/dataplane/config.c
@@ -73,6 +73,7 @@ enum state {
 	state_worker_rx_queue_len,
 	state_worker_tx_queue_len,
 	state_worker_num_mbufs,
+	state_worker_stack_size,
 
 	state_connections,
 	state_connection,
@@ -272,6 +273,13 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 
 				state = state_worker;
 				break;
+			case state_worker_stack_size:
+				worker->stack_size = strtoull(start, &end, 10);
+				if (*end != '\0')
+					goto error;
+
+				state = state_worker;
+				break;
 
 			case state_connection_src:
 				strtcpy(connection->src_device,
@@ -361,6 +369,8 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 					state = state_worker_tx_queue_len;
 				} else if (!strcmp("num_mbufs", start)) {
 					state = state_worker_num_mbufs;
+				} else if (!strcmp("stack_size", start)) {
+					state = state_worker_stack_size;
 				} else {
 					goto error;
 				}

--- a/dataplane/config.h
+++ b/dataplane/config.h
@@ -19,6 +19,12 @@ struct dataplane_device_worker_config {
 	uint16_t rx_queue_len;
 	uint16_t tx_queue_len;
 	uint32_t num_mbufs;
+
+	// Per-worker thread stack size in bytes, or 0 for the OS default.
+	//
+	// When non-zero, the stack is allocated from the worker instance's
+	// NUMA-local dataplane memory zone instead of an anonymous mapping.
+	uint64_t stack_size;
 };
 
 struct dataplane_device_config {

--- a/dataplane/unittest/config/dataplane.yaml
+++ b/dataplane/unittest/config/dataplane.yaml
@@ -21,6 +21,7 @@ dataplane:
           instance_id: 0
           rx_queue_len: 1024
           tx_queue_len: 512
+          stack_size: 2097152
     - port_name: virtio_user_kni0
       mac_addr: 52:54:00:6b:ff:a5
       mtu: 7000

--- a/dataplane/unittest/config/main.c
+++ b/dataplane/unittest/config/main.c
@@ -91,6 +91,19 @@ test_valid_config(void) {
 	check_instance(config->instances + 1, 1, 512, 128);
 	check_instance(config->instances + 2, 0, 123, 124);
 
+	assert(config->device_count == 2);
+	assert(config->devices[0].worker_count == 1);
+	struct dataplane_device_worker_config *worker =
+		config->devices[0].workers;
+	assert(worker->core_id == 4);
+	assert(worker->instance_id == 0);
+	assert(worker->rx_queue_len == 1024);
+	assert(worker->tx_queue_len == 512);
+	assert(worker->stack_size == 2097152);
+
+	// The second worker omits stack_size, so it stays the unset default.
+	assert(config->devices[1].workers[0].stack_size == 0);
+
 	assert(config->connection_count == 2);
 	assert(config->connections[0].src_device_id == 0);
 	assert(config->connections[0].dst_device_id == 1);

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -57,6 +57,8 @@
 #include "common/data_pipe.h"
 #include "logging/log.h"
 
+#include <limits.h>
+
 #include <rte_ethdev.h>
 
 static void
@@ -410,6 +412,12 @@ dataplane_worker_init(
 	worker->queue_id = queue_id;
 	worker->config = *config;
 
+	// The worker struct comes from an unzeroed malloc, so a NULL stack must
+	// be set here to mark the default-stack case that dataplane_worker_stop
+	// must not free.
+	worker->stack = NULL;
+	worker->stack_size = 0;
+
 	struct dp_config *dp_config = worker->instance->dp_config;
 	struct dp_worker *dp_worker = (struct dp_worker *)memory_balloc(
 		&dp_config->memory_context, sizeof(struct dp_worker)
@@ -562,6 +570,92 @@ error_mempool:
 	return -1;
 }
 
+// Smallest power of two not less than value.
+//
+// Values above 2^63 have no representable power-of-two result, so they clamp
+// to 2^63, which every caller then rejects as oversized. Zero and one return 1.
+static inline uint64_t
+round_up_pow2(uint64_t value) {
+	if (value <= 1) {
+		return 1;
+	}
+	if (value > (1ull << 63)) {
+		return 1ull << 63;
+	}
+	return 1ull << (64 - __builtin_clzll(value - 1));
+}
+
+// Allocate the worker thread stack from the instance's NUMA-local dp zone.
+//
+// A zero configured size keeps the OS default stack and leaves the attribute
+// untouched. Otherwise the size is clamped to PTHREAD_STACK_MIN, rounded up to
+// a power of two so the buddy allocator returns a block aligned to its own size
+// (page/hugepage aligned, as pthread_attr_setstack requires), and pinned to the
+// worker instance dp memory. The allocation is recorded on the worker so
+// dataplane_worker_stop can free the exact block after the join.
+//
+// Under sanitizer builds the allocator's red zones offset the block off its
+// page boundary, so pthread_attr_setstack rejects it and the worker fails to
+// start gracefully; a custom stack therefore requires a non-sanitized build.
+static int
+dataplane_worker_setup_stack(
+	struct dataplane_worker *worker, pthread_attr_t *attr
+) {
+	if (worker->config.stack_size == 0) {
+		return 0;
+	}
+
+	struct dp_config *dp_config = worker->instance->dp_config;
+
+	size_t stack_size = worker->config.stack_size;
+	if (stack_size < (size_t)PTHREAD_STACK_MIN) {
+		stack_size = (size_t)PTHREAD_STACK_MIN;
+	}
+	stack_size = round_up_pow2(stack_size);
+
+	if (stack_size > MEMORY_BLOCK_ALLOCATOR_MAX_SIZE) {
+		LOG(ERROR,
+		    "worker core=%u stack size %zu exceeds maximum %zu",
+		    worker->config.core_id,
+		    stack_size,
+		    (size_t)MEMORY_BLOCK_ALLOCATOR_MAX_SIZE);
+		return -1;
+	}
+
+	void *stack = memory_balloc(&dp_config->memory_context, stack_size);
+	if (stack == NULL) {
+		LOG(ERROR,
+		    "failed to allocate %zu-byte stack for worker core=%u from "
+		    "instance %u dp zone",
+		    stack_size,
+		    worker->config.core_id,
+		    worker->config.instance_id);
+		return -1;
+	}
+
+	int rc = pthread_attr_setstack(attr, stack, stack_size);
+	if (rc != 0) {
+		LOG(ERROR,
+		    "failed to set stack for worker core=%u: %s",
+		    worker->config.core_id,
+		    strerror(rc));
+		memory_bfree(&dp_config->memory_context, stack, stack_size);
+		return -1;
+	}
+
+	worker->stack = stack;
+	worker->stack_size = stack_size;
+
+	LOG(INFO,
+	    "worker core=%u uses a %zu-byte numa-local stack from instance %u "
+	    "dp zone",
+	    worker->config.core_id,
+	    stack_size,
+	    worker->config.instance_id);
+
+	return 0;
+}
+
 int
 dataplane_worker_start(struct dataplane_worker *worker) {
 
@@ -598,6 +692,11 @@ dataplane_worker_start(struct dataplane_worker *worker) {
 	pthread_attr_t wrk_th_attr;
 	pthread_attr_init(&wrk_th_attr);
 
+	if (dataplane_worker_setup_stack(worker, &wrk_th_attr) != 0) {
+		pthread_attr_destroy(&wrk_th_attr);
+		return -1;
+	}
+
 	cpu_set_t mask;
 	CPU_ZERO(&mask);
 	CPU_SET(worker->config.core_id, &mask);
@@ -616,4 +715,17 @@ dataplane_worker_start(struct dataplane_worker *worker) {
 void
 dataplane_worker_stop(struct dataplane_worker *worker) {
 	pthread_join(worker->thread_id, NULL);
+
+	// The join guarantees the thread no longer touches its stack, so the
+	// NUMA-local block can be returned to the instance dp zone.
+	if (worker->stack != NULL) {
+		struct dp_config *dp_config = worker->instance->dp_config;
+		memory_bfree(
+			&dp_config->memory_context,
+			worker->stack,
+			worker->stack_size
+		);
+		worker->stack = NULL;
+		worker->stack_size = 0;
+	}
 }

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -70,6 +70,14 @@ struct dataplane_worker {
 
 	pthread_t thread_id;
 
+	// NUMA-local thread stack from the instance dp zone, or NULL.
+	//
+	// Set only when the worker config requests a custom stack size. The
+	// matching size passed to memory_balloc is kept in stack_size so
+	// dataplane_worker_stop can free the exact block after the join.
+	void *stack;
+	size_t stack_size;
+
 	// FIXME port_id and device_id could be inherited from device
 	uint16_t port_id;
 	uint16_t queue_id;


### PR DESCRIPTION
Add a per-worker stack size option to the dataplane configuration. When set, the worker thread stack is allocated from the worker instance's NUMA-local dataplane memory zone and backed by hugepages, keeping stack accesses on the same node as the pinned core. Leaving the size unset preserves the existing operating-system default stack.