### PR TITLE
perf(filter): route net6 attributes through lpm_hash

### DIFF
--- a/common/lpm_hash.h
+++ b/common/lpm_hash.h
@@ -1,0 +1,484 @@
+#pragma once
+
+/*
+ * Hybrid byte-stride LPM with a hashed top level for 8-byte range maps.
+ *
+ * Lookup probes a hash on the first hops key bytes for the page number of
+ * the trie page those bytes lead to, then walks the remaining bytes from
+ * that page. A miss falls back to the root walk, which is short by
+ * construction. Values are bit-identical to lpm8_lookup on the same trie.
+ *
+ * Correctness of the shortcut: an entry exists for a prefix of hops bytes
+ * exactly when every slot on its path in hops 0..hops-1 holds a page
+ * pointer. The walk of any key sharing that prefix follows those exact
+ * slots, so it cannot terminate before hop hops and lands on precisely
+ * the page stored in the entry; continuing the standard walk there is the
+ * suffix of the full walk. A miss means some slot on the prefix path is
+ * flagged, so the fallback root walk terminates within hops loads. Entry
+ * count equals the trie page count at level hops and is fixed at build
+ * time; nothing is invalidated at run time because the table is built
+ * with the trie and swapped atomically through shared memory with it.
+ *
+ * The hash side is a value_slot_index: a self-contained open-addressing
+ * slot table with fixed 8-byte keys, modelled on common/str_index.h. Keys
+ * are the hops prefix bytes zero-padded to eight; storage, hashing, and
+ * equality operate on those raw bytes. All storage flows through the
+ * memory_context passed to lpm_hash_init (the slot table and the trie via
+ * memory_balloc), so the whole structure is usable from shared memory;
+ * the slot table is a shared-memory relative pointer.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "common/crc32.h"
+#include "common/lpm.h"
+#include "common/memory.h"
+#include "common/range_index.h"
+
+// Slot load factor kept by value_slot_index.
+//
+// Matches str_index: a grow triggers when size reaches capacity /
+// SPARSE_FACTOR (25% load). Each grow doubles capacity, so the table stays at
+// the same load after the insert that triggered the grow.
+#define VALUE_SLOT_INDEX_SPARSE_FACTOR 4
+
+// Capacity of the first table allocation, taken on the first insert.
+//
+// A power of two so that hash & (capacity - 1) is a valid probe index from the
+// very first grow. Zero capacity means the table is unallocated.
+#define VALUE_SLOT_INDEX_INITIAL_CAPACITY 8
+
+// One slot of the value_slot_index table.
+//
+// The slot IS the table: open addressing walks it directly. A slot is empty
+// when value == LPM_VALUE_INVALID, so a freshly memset 0xff table is full of
+// empty slots. Stored values are trie page numbers, which stay far below
+// 0xffffffff for any real table.
+struct lpm_hash_slot {
+	uint8_t key[8];
+	uint32_t value;
+};
+
+// Self-contained open-addressing slot table for fixed 8-byte keys.
+//
+// Mirrors struct str_index: the table is the slot array itself (no external
+// values array, no read callback), capacity starts at zero, and the first
+// insert grows it. All allocation is via memory_balloc through memory_context.
+//
+// capacity is always zero or a power of two, so the probe index is computed as
+// hash & (capacity - 1) instead of hash % capacity.
+struct value_slot_index {
+	struct memory_context *memory_context;
+	struct lpm_hash_slot *slots;
+	uint32_t size;
+	uint32_t capacity;
+};
+
+// Initialise an empty index.
+//
+// Capacity starts at zero; the first insert grows the table to
+// VALUE_SLOT_INDEX_INITIAL_CAPACITY slots. Always returns 0.
+static inline int
+value_slot_index_init(
+	struct value_slot_index *index, struct memory_context *memory_context
+) {
+	SET_OFFSET_OF(&index->memory_context, memory_context);
+	SET_OFFSET_OF(&index->slots, NULL);
+	index->capacity = 0;
+	index->size = 0;
+
+	return 0;
+}
+
+// Release the slot table.
+//
+// NULL-safe: a freshly initialised or already-finalised index has slots == NULL
+// and is left untouched.
+static inline void
+value_slot_index_fini(struct value_slot_index *index) {
+	struct lpm_hash_slot *slots = ADDR_OF(&index->slots);
+	if (slots == NULL) {
+		return;
+	}
+
+	memory_bfree(
+		ADDR_OF(&index->memory_context),
+		slots,
+		sizeof(struct lpm_hash_slot) * index->capacity
+	);
+	SET_OFFSET_OF(&index->slots, NULL);
+	index->capacity = 0;
+	index->size = 0;
+}
+
+// Probe the table for key8.
+//
+// Returns the stored value, or LPM_VALUE_INVALID when no slot holds key8.
+// Hashing is CRC-32C over the full 8 bytes (binary keys may contain NUL, so
+// strnlen must not be used), and equality is memcmp over 8 bytes.
+static inline uint32_t
+value_slot_index_lookup(
+	const struct value_slot_index *index, const uint8_t *key8
+) {
+	if (!index->capacity) {
+		return LPM_VALUE_INVALID;
+	}
+
+	uint32_t mask = index->capacity - 1;
+	uint32_t hash = crc32(key8, 8, 0) & mask;
+
+	const struct lpm_hash_slot *slots = ADDR_OF(&index->slots);
+	while (slots[hash].value != LPM_VALUE_INVALID) {
+		if (memcmp(slots[hash].key, key8, 8) == 0) {
+			return slots[hash].value;
+		}
+		hash = (hash + 1) & mask;
+	}
+	return LPM_VALUE_INVALID;
+}
+
+// Place (key8, value) into the first free slot at or after the hash, without
+// checking load.
+//
+// The caller must have ensured capacity is large enough (the public insert
+// and the expand caller do this). Linear probing matches str_index.
+static inline void
+value_slot_index_insert_force(
+	struct value_slot_index *index, const uint8_t *key8, uint32_t value
+) {
+	uint32_t mask = index->capacity - 1;
+	uint32_t hash = crc32(key8, 8, 0) & mask;
+
+	struct lpm_hash_slot *slots = ADDR_OF(&index->slots);
+	while (slots[hash].value != LPM_VALUE_INVALID) {
+		hash = (hash + 1) & mask;
+	}
+
+	memcpy(slots[hash].key, key8, 8);
+	slots[hash].value = value;
+	index->size += 1;
+}
+
+// Re-house the table at new_capacity and re-insert all live slots by rehashing
+// their 8-byte keys.
+//
+// Mirrors str_index_expand. The new table is memset to 0xff so every slot
+// starts empty (value == LPM_VALUE_INVALID), then each live old slot is
+// re-inserted via value_slot_index_insert_force. The old table is released.
+// Returns 0 on success, -1 on allocation failure (the index is left intact).
+//
+// new_capacity must be a power of two: the probe index is hash & (capacity -
+// 1), so a non-power-of-two capacity would silently corrupt lookups.
+static inline int
+value_slot_index_expand(struct value_slot_index *index, uint32_t new_capacity) {
+	struct lpm_hash_slot *new_slots = (struct lpm_hash_slot *)memory_balloc(
+		ADDR_OF(&index->memory_context),
+		sizeof(struct lpm_hash_slot) * new_capacity
+	);
+	if (new_slots == NULL) {
+		return -1;
+	}
+	memset(new_slots, 0xff, sizeof(struct lpm_hash_slot) * new_capacity);
+
+	struct lpm_hash_slot *old_slots = ADDR_OF(&index->slots);
+	uint32_t old_capacity = index->capacity;
+
+	SET_OFFSET_OF(&index->slots, new_slots);
+	index->capacity = new_capacity;
+
+	for (uint32_t pos = 0; pos < old_capacity; ++pos) {
+		if (old_slots[pos].value == LPM_VALUE_INVALID) {
+			continue;
+		}
+		value_slot_index_insert_force(
+			index, old_slots[pos].key, old_slots[pos].value
+		);
+	}
+
+	if (old_slots != NULL) {
+		memory_bfree(
+			ADDR_OF(&index->memory_context),
+			old_slots,
+			sizeof(struct lpm_hash_slot) * old_capacity
+		);
+	}
+	return 0;
+}
+
+// Insert (key8, value), growing the table on demand.
+//
+// When size reaches capacity / SPARSE_FACTOR the table is doubled, or seeded
+// at VALUE_SLOT_INDEX_INITIAL_CAPACITY on the first insert, keeping capacity a
+// power of two. Returns 0 on success, -1 on allocation failure (the index is
+// left intact).
+static inline int
+value_slot_index_insert(
+	struct value_slot_index *index, const uint8_t *key8, uint32_t value
+) {
+	if (index->size >= index->capacity / VALUE_SLOT_INDEX_SPARSE_FACTOR) {
+		uint32_t new_capacity =
+			index->capacity ? index->capacity * 2
+					: VALUE_SLOT_INDEX_INITIAL_CAPACITY;
+		if (value_slot_index_expand(index, new_capacity)) {
+			return -1;
+		}
+	}
+
+	value_slot_index_insert_force(index, key8, value);
+	return 0;
+}
+
+// Default hashed-top height.
+//
+// Six measured within a few percent of per-trie optimal on the production
+// acl ruleset capture across all four net6 half-tries: hit rates 0.48..0.80
+// with 345..3204 entries, cutting the dependent walk chain by 44..57%.
+#define LPM_HASH_HOPS_DEFAULT 6
+
+struct lpm_hash {
+	struct lpm lpm;
+	struct value_slot_index index;
+	uint8_t hops;
+};
+
+// Allocate an empty hybrid.
+//
+// hops is the hashed top height: the number of leading key bytes resolved by
+// one hash probe on lookup. Values above 7 are clamped to 7, because an
+// 8-byte trie never has pages below level 8. hops 0 disables the shortcut:
+// every lookup falls back to the plain root walk. Returns 0 on success, -1 on
+// LPM allocation failure (the index is finalised before returning).
+static inline int
+lpm_hash_init(
+	struct lpm_hash *lpm_hash,
+	struct memory_context *memory_context,
+	uint8_t hops,
+	const char *name
+) {
+	if (hops > 7) {
+		hops = 7;
+	}
+	if (value_slot_index_init(&lpm_hash->index, memory_context) != 0) {
+		return -1;
+	}
+	lpm_hash->hops = hops;
+
+	if (lpm_init(&lpm_hash->lpm, memory_context, name) != 0) {
+		// lpm_init attached its embedded memory_context as a child
+		// of memory_context before failing, so the trie must be
+		// released through lpm_free to detach it; skipping this leaks
+		// a live child into the caller's context tree and breaks the
+		// tree walk on free. Safe on a trie whose init stopped before
+		// the first page: pages is NULL and the context is empty.
+		lpm_free(&lpm_hash->lpm);
+		value_slot_index_fini(&lpm_hash->index);
+		return -1;
+	}
+
+	return 0;
+}
+
+// Release the index and the LPM trie.
+//
+// Safe on an lpm_hash whose init failed halfway: value_slot_index_fini is
+// NULL-safe and lpm_free is safe on a zeroed trie.
+static inline void
+lpm_hash_fini(struct lpm_hash *lpm_hash) {
+	lpm_free(&lpm_hash->lpm);
+	value_slot_index_fini(&lpm_hash->index);
+}
+
+// Insert [from..to] -> value into the trie.
+//
+// The hash side records trie pages, not values, so inserts are plain trie
+// inserts; the top table is derived once afterwards by lpm_hash_build_top.
+// Returns 0 on success, -1 on trie allocation failure.
+static inline int
+lpm_hash_insert(
+	struct lpm_hash *lpm_hash,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t value
+) {
+	return lpm8_insert(&lpm_hash->lpm, from, to, value);
+}
+
+// Resolve a page pointer to its page number.
+//
+// Pages of one chunk are contiguous in memory and the chunk array is indexed
+// by page number, so the number is recovered by locating the owning chunk.
+// Returns LPM_VALUE_INVALID when the page is not found, which cannot happen
+// for a pointer reached from lpm->pages itself.
+static inline uint32_t
+lpm_page_index(const struct lpm *lpm, const struct lpm_page *page) {
+	struct lpm_page **pages = ADDR_OF(&lpm->pages);
+	uint32_t chunk_count =
+		(lpm->page_count + LPM_CHUNK_SIZE - 1) / LPM_CHUNK_SIZE;
+
+	for (uint32_t chunk_idx = 0; chunk_idx < chunk_count; ++chunk_idx) {
+		struct lpm_page *chunk = ADDR_OF(&pages[chunk_idx]);
+		if (page >= chunk && page < chunk + LPM_CHUNK_SIZE) {
+			return chunk_idx * LPM_CHUNK_SIZE +
+			       (uint32_t)(page - chunk);
+		}
+	}
+	return LPM_VALUE_INVALID;
+}
+
+// Depth-first descent for lpm_hash_build_top.
+//
+// key holds the zero-padded path bytes; page is the page that path leads to.
+// At depth hops the page number is recorded for the path. Between, only
+// pointer slots are followed, which is exactly the entry-existence rule of
+// the shortcut: an entry exists for a path of hops bytes iff every slot along
+// it holds a page pointer. Returns 0 on success, -1 on failure.
+static inline int
+lpm_hash_top_descend(
+	struct lpm_hash *lpm_hash,
+	struct lpm_page *page,
+	uint8_t depth,
+	uint8_t key[8]
+) {
+	if (depth == lpm_hash->hops) {
+		uint32_t page_idx = lpm_page_index(&lpm_hash->lpm, page);
+		if (page_idx == LPM_VALUE_INVALID) {
+			return -1;
+		}
+		return value_slot_index_insert(&lpm_hash->index, key, page_idx);
+	}
+
+	for (uint32_t slot = 0; slot < 256; ++slot) {
+		union lpm_value *stored_value = page->values + slot;
+		if (stored_value->value & LPM_VALUE_FLAG) {
+			continue;
+		}
+		key[depth] = (uint8_t)slot;
+		if (lpm_hash_top_descend(
+			    lpm_hash,
+			    ADDR_OF(&stored_value->page),
+			    depth + 1,
+			    key
+		    )) {
+			return -1;
+		}
+	}
+	return 0;
+}
+
+// Derive the hashed top table from the built trie.
+//
+// Must run after the last lpm_hash_insert: page numbers are assigned at page
+// creation and never reused, so entries recorded now stay valid for the life
+// of the trie. With hops 0 there is nothing to build. Returns 0 on success,
+// -1 on allocation failure (the caller tears the hybrid down).
+static inline int
+lpm_hash_build_top(struct lpm_hash *lpm_hash) {
+	if (!lpm_hash->hops) {
+		return 0;
+	}
+
+	uint8_t key[8];
+	memset(key, 0, sizeof(key));
+	return lpm_hash_top_descend(
+		lpm_hash, lpm_page(&lpm_hash->lpm, 0), 0, key
+	);
+}
+
+// Copy the hops-byte prefix of key into a zero-padded probe key.
+static inline void
+lpm_hash_top_key(
+	const struct lpm_hash *lpm_hash, const uint8_t *key, uint8_t top_key[8]
+) {
+	memcpy(top_key, key, lpm_hash->hops);
+	memset(top_key + lpm_hash->hops, 0, 8 - lpm_hash->hops);
+}
+
+// Probe the top hash, then finish the walk from the hit page or the root.
+//
+// On a hit the answer cannot lie above hop hops (entry-existence rule), so
+// walking hops..7 from the stored page returns the full walk's value. On a
+// miss the root walk terminates within hops loads, so the fallback stays
+// short. Both paths return exactly lpm8_lookup's value.
+static inline uint32_t
+lpm_hash_lookup(const struct lpm_hash *lpm_hash, const uint8_t *key) {
+	uint8_t top_key[8];
+	lpm_hash_top_key(lpm_hash, key, top_key);
+
+	uint32_t page_idx = value_slot_index_lookup(&lpm_hash->index, top_key);
+	if (page_idx == LPM_VALUE_INVALID) {
+		return lpm8_lookup(&lpm_hash->lpm, key);
+	}
+
+	struct lpm_page *page = lpm_page(&lpm_hash->lpm, page_idx);
+	union lpm_value *value = NULL;
+	for (uint8_t hop = lpm_hash->hops; hop < 8; ++hop) {
+		value = page->values + key[hop];
+		if (value->value & LPM_VALUE_FLAG) {
+			break;
+		}
+		// An intermediate node (flag clear) always has a child page,
+		// so the relative pointer is never NULL here — the same
+		// contract as lpm_lookup.
+		page = ADDR_OF_NONNULL(&value->page);
+	}
+
+	return LPM_VALUE_GET(value->value);
+}
+
+struct lpm_hash_insert_ctx {
+	struct lpm_hash *lpm_hash;
+};
+
+// range_index_build callback: forwards each [from..to] -> value range to
+// lpm_hash_insert.
+//
+// key_size is always 8 here (the only lpm_hash interface), so it is ignored.
+static inline int
+lpm_hash_insert_cb(
+	uint8_t key_size,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t value,
+	void *data
+) {
+	(void)key_size;
+	struct lpm_hash_insert_ctx *ctx = (struct lpm_hash_insert_ctx *)data;
+	return lpm_hash_insert(ctx->lpm_hash, from, to, value);
+}
+
+/*
+ * Build an lpm_hash from a range_index.
+ *
+ * Inserts every range into the trie in one pass, then derives the hashed top
+ * table from the finished trie with lpm_hash_build_top. Returns 0 on success,
+ * -1 on failure (the lpm_hash is finalised before returning so the caller
+ * need not clean it up).
+ */
+static inline int
+range_index_build_lpm_hash(
+	const struct range_index *range_index,
+	struct memory_context *memory_context,
+	uint8_t hops,
+	const char *name,
+	struct lpm_hash *lpm_hash
+) {
+	if (lpm_hash_init(lpm_hash, memory_context, hops, name) != 0) {
+		return -1;
+	}
+
+	struct lpm_hash_insert_ctx insert_ctx = {lpm_hash};
+	if (range_index_build(
+		    range_index, 8, lpm_hash_insert_cb, &insert_ctx
+	    )) {
+		lpm_hash_fini(lpm_hash);
+		return -1;
+	}
+
+	if (lpm_hash_build_top(lpm_hash)) {
+		lpm_hash_fini(lpm_hash);
+		return -1;
+	}
+
+	return 0;
+}

--- a/common/range_index.h
+++ b/common/range_index.h
@@ -130,71 +130,130 @@ range_index_free(struct range_index *range_index) {
 }
 
 /*
- * Build an LPM from a range_index.
+ * Build callback invoked once per contiguous range of the partition stored in
+ * a range_index.
  *
- * The range_index stores a contiguous, ascending, non-overlapping partition
- * of the full keyspace: radix maps each range-start key -> an index into the
- * values[] array.  This function walks the radix in ascending order, derives
- * each range's upper bound from the next key, and inserts [from..to] -> value
- * into the LPM.  The LPM must already be initialised by the caller.
+ * from and to bound the range inclusively (big-endian keys), value is the
+ * payload the range_index assigned to it, and ctx is the opaque pointer passed
+ * alongside the callback from the build call site. Return 0 to keep walking,
+ * non-zero to abort the build (range_index_build then returns -1).
  */
-struct range_index_lpm_ctx {
-	struct lpm *lpm;
+typedef int (*range_index_build_fn)(
+	uint8_t key_size,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t value,
+	void *ctx
+);
+
+// Walk state shared between range_index_build and its radix callback.
+//
+// prev_value starts at LPM_VALUE_INVALID and is replaced by each walked range's
+// value; the previous range is emitted when the next range starts, and the
+// final range is emitted by range_index_build once the walk completes.
+struct range_index_build_state {
 	const uint32_t *values;
 	uint8_t prev_from[LPM_KEY_SIZE_MAX];
 	uint32_t prev_value;
+	range_index_build_fn fn;
+	void *fn_ctx;
 };
 
 static inline int
-range_index_lpm_cb(
+range_index_build_cb(
 	uint8_t key_size, const uint8_t *from, uint32_t index, void *data
 ) {
-	struct range_index_lpm_ctx *ctx = (struct range_index_lpm_ctx *)data;
+	struct range_index_build_state *state =
+		(struct range_index_build_state *)data;
 
-	if (ctx->prev_value != LPM_VALUE_INVALID) {
+	if (state->prev_value != LPM_VALUE_INVALID) {
 		uint8_t to[key_size];
 		memcpy(to, from, key_size);
 		filter_key_dec(key_size, to);
-		if (lpm_insert(
-			    ctx->lpm,
+		if (state->fn(
 			    key_size,
-			    ctx->prev_from,
+			    state->prev_from,
 			    to,
-			    ctx->prev_value
+			    state->prev_value,
+			    state->fn_ctx
 		    )) {
 			return -1;
 		}
 	}
 
-	memcpy(ctx->prev_from, from, key_size);
-	ctx->prev_value = ctx->values[index];
+	memcpy(state->prev_from, from, key_size);
+	state->prev_value = state->values[index];
 	return 0;
 }
 
+/*
+ * Drive a build callback across every range of a range_index.
+ *
+ * The range_index stores a contiguous, ascending, non-overlapping partition of
+ * the full keyspace: radix maps each range-start key -> an index into the
+ * values[] array. This walks the radix in ascending order, derives each range's
+ * upper bound from the next key, and invokes fn with [from..to] -> value per
+ * range, plus the final [prev_from..0xff..0xff] -> value after the walk.
+ */
 static inline int
-range_index_build_lpm(
-	const struct range_index *range_index, uint8_t key_size, struct lpm *lpm
+range_index_build(
+	const struct range_index *range_index,
+	uint8_t key_size,
+	range_index_build_fn fn,
+	void *ctx
 ) {
-	struct range_index_lpm_ctx ctx;
-	ctx.lpm = lpm;
-	ctx.values = ADDR_OF(&range_index->values);
-	ctx.prev_value = LPM_VALUE_INVALID;
+	struct range_index_build_state state;
+	state.values = ADDR_OF(&range_index->values);
+	state.prev_value = LPM_VALUE_INVALID;
+	state.fn = fn;
+	state.fn_ctx = ctx;
 
 	if (radix_walk(
-		    &range_index->radix, key_size, range_index_lpm_cb, &ctx
+		    &range_index->radix, key_size, range_index_build_cb, &state
 	    )) {
 		return -1;
 	}
 
-	if (ctx.prev_value != LPM_VALUE_INVALID) {
+	if (state.prev_value != LPM_VALUE_INVALID) {
 		uint8_t to[key_size];
 		memset(to, 0xff, key_size);
-		if (lpm_insert(
-			    lpm, key_size, ctx.prev_from, to, ctx.prev_value
-		    )) {
+		if (fn(key_size, state.prev_from, to, state.prev_value, ctx)) {
 			return -1;
 		}
 	}
 
 	return 0;
+}
+
+struct range_index_lpm_ctx {
+	struct lpm *lpm;
+};
+
+static inline int
+range_index_lpm_insert_cb(
+	uint8_t key_size,
+	const uint8_t *from,
+	const uint8_t *to,
+	uint32_t value,
+	void *ctx
+) {
+	struct range_index_lpm_ctx *lpm_ctx = (struct range_index_lpm_ctx *)ctx;
+	return lpm_insert(lpm_ctx->lpm, key_size, from, to, value);
+}
+
+/*
+ * Build an LPM from a range_index.
+ *
+ * Thin wrapper over range_index_build whose callback forwards each range to
+ * lpm_insert. The LPM must already be initialised by the caller. Behaviour is
+ * identical to walking the radix and inserting [from..to] -> value per range.
+ */
+static inline int
+range_index_build_lpm(
+	const struct range_index *range_index, uint8_t key_size, struct lpm *lpm
+) {
+	struct range_index_lpm_ctx ctx = {lpm};
+	return range_index_build(
+		range_index, key_size, range_index_lpm_insert_cb, &ctx
+	);
 }

--- a/lib/filter/classifiers/net6.h
+++ b/lib/filter/classifiers/net6.h
@@ -2,13 +2,13 @@
 
 #include <stdbool.h>
 
-#include "common/lpm.h"
+#include "common/lpm_hash.h"
 #include "common/memory_address.h"
 #include "common/value.h"
 
 struct net6_classifier {
-	struct lpm hi;
-	struct lpm lo;
+	struct lpm_hash hi;
+	struct lpm_hash lo;
 	struct value_table comb;
 };
 
@@ -21,8 +21,8 @@ struct net6_classifier {
 // have hi_count entries and remap_lo_* arrays have lo_count entries. The
 // array pointers are shared-memory relative pointers.
 struct net6_share_dir {
-	struct lpm hi;
-	struct lpm lo;
+	struct lpm_hash hi;
+	struct lpm_hash lo;
 	uint32_t hi_count;
 	uint32_t lo_count;
 	uint32_t *remap_hi_a;

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -1,6 +1,7 @@
 #include "../rule.h"
 
 #include "common/lpm.h"
+#include "common/lpm_hash.h"
 #include "common/range_collector.h"
 
 #include "common/registry.h"
@@ -10,6 +11,16 @@
 #include "declare.h"
 #include "lib/errors/errors.h"
 #include "net6_share.h"
+
+/*
+ * Hashed-top height for the net6 classifier halves.
+ *
+ * The top hash resolves the leading bytes of a half to the trie page they
+ * lead to, so its value is a walk-skip depth, not a prefix property. Six is
+ * within a few percent of per-trie optimal on the production ruleset capture
+ * for all four half-tries.
+ */
+#define NET6_LPM_HASH_HOPS LPM_HASH_HOPS_DEFAULT
 
 typedef void (*action_get_net6_func)(
 	const struct filter_rule *rule, struct net6 **net, uint32_t *count
@@ -63,8 +74,6 @@ collect_net6_range(
 	uint32_t count,
 	action_get_net6_func get_net6,
 	net6_get_part_func get_part,
-	struct lpm *lpm,
-	const char *lpm_name,
 	struct range_index *ri
 ) {
 	struct range_collector collector;
@@ -103,39 +112,21 @@ collect_net6_range(
 			}
 		}
 	}
-	if (lpm_init(lpm, memory_context, lpm_name)) {
-		goto error_lpm;
-	}
 
 	if (range_index_init(ri, memory_context)) {
-		goto error_ri_init;
+		goto error_collector;
 	}
 
 	if (range_collector_collect(&collector, 8, ri)) {
-		goto error_collect;
-	}
-
-	if (range_index_build_lpm(ri, 8, lpm)) {
-		goto error_collect;
+		goto error_ri;
 	}
 
 	range_collector_free(&collector, 8);
 
 	return 0;
 
-error_collect:
+error_ri:
 	range_index_free(ri);
-	lpm_free(lpm);
-	range_collector_free(&collector, 8);
-	return -1;
-
-error_ri_init:
-	lpm_free(lpm);
-	range_collector_free(&collector, 8);
-	return -1;
-
-error_lpm:
-	lpm_free(lpm);
 
 error_collector:
 	range_collector_free(&collector, 8);
@@ -710,10 +701,18 @@ init_net6(
 		    count,
 		    get_net6,
 		    net6_get_hi_part,
-		    &net6->hi,
-		    "lpm_hi",
 		    &ri_hi
 	    )) {
+		goto error_hi;
+	}
+	if (range_index_build_lpm_hash(
+		    &ri_hi,
+		    memory_context,
+		    NET6_LPM_HASH_HOPS,
+		    "lpm_hi",
+		    &net6->hi
+	    )) {
+		range_index_free(&ri_hi);
 		goto error_hi;
 	}
 
@@ -724,11 +723,23 @@ init_net6(
 		    count,
 		    get_net6,
 		    net6_get_lo_part,
-		    &net6->lo,
-		    "lpm_lo",
 		    &ri_lo
 	    )) {
-		goto error_lo;
+		range_index_free(&ri_hi);
+		lpm_hash_fini(&net6->hi);
+		goto error_hi;
+	}
+	if (range_index_build_lpm_hash(
+		    &ri_lo,
+		    memory_context,
+		    NET6_LPM_HASH_HOPS,
+		    "lpm_lo",
+		    &net6->lo
+	    )) {
+		range_index_free(&ri_lo);
+		range_index_free(&ri_hi);
+		lpm_hash_fini(&net6->hi);
+		goto error_hi;
 	}
 
 	if (merge_net6_range(
@@ -741,21 +752,17 @@ init_net6(
 		    &net6->comb,
 		    registry
 	    )) {
-		goto error_merge;
+		range_index_free(&ri_lo);
+		lpm_hash_fini(&net6->lo);
+		range_index_free(&ri_hi);
+		lpm_hash_fini(&net6->hi);
+		goto error_hi;
 	}
 
 	range_index_free(&ri_hi);
 	range_index_free(&ri_lo);
 
 	return 0;
-
-error_merge:
-	range_index_free(&ri_lo);
-	lpm_free(&net6->lo);
-
-error_lo:
-	range_index_free(&ri_hi);
-	lpm_free(&net6->hi);
 
 error_hi:
 	SET_OFFSET_OF(data, NULL);
@@ -814,8 +821,8 @@ free_net6(void *data, struct memory_context *memory_context) {
 	if (c == NULL) {
 		return;
 	}
-	lpm_free(&c->lo);
-	lpm_free(&c->hi);
+	lpm_hash_fini(&c->lo);
+	lpm_hash_fini(&c->hi);
 	value_table_free(&c->comb);
 	memory_bfree(memory_context, c, sizeof(struct net6_classifier));
 }
@@ -836,8 +843,8 @@ FILTER_ATTR_COMPILER_FREE_FUNC(net6_dst)(
 
 // Shared per-direction half-classification.
 struct net6_share_remap_ctx {
-	const struct lpm *local_a;
-	const struct lpm *local_b;
+	const struct lpm_hash *local_a;
+	const struct lpm_hash *local_b;
 	uint32_t *remap_a;
 	uint32_t *remap_b;
 	uint32_t class_count;
@@ -860,6 +867,7 @@ net6_share_remap_collect(
 	uint32_t value,
 	void *data
 ) {
+	(void)key_size;
 	(void)to;
 	struct net6_share_remap_ctx *ctx = (struct net6_share_remap_ctx *)data;
 
@@ -867,8 +875,8 @@ net6_share_remap_collect(
 		return -1;
 	}
 
-	uint32_t class_a = lpm_lookup(ctx->local_a, key_size, from);
-	uint32_t class_b = lpm_lookup(ctx->local_b, key_size, from);
+	uint32_t class_a = lpm_hash_lookup(ctx->local_a, from);
+	uint32_t class_b = lpm_hash_lookup(ctx->local_b, from);
 
 	if (ctx->remap_a[value] != LPM_VALUE_INVALID &&
 	    ctx->remap_a[value] != class_a) {
@@ -887,19 +895,22 @@ net6_share_remap_collect(
 
 // Builds the two remap arrays for one address half.
 //
-// Walks the union trie across the full 8-byte key space and resolves each
-// union half-class into the local half-classes of both classifiers. On
-// success the caller owns the returned arrays, on failure both are freed
-// and err distinguishes an allocation failure from a broken refinement
-// invariant (a local classifier disagreeing with the union classification
-// across a walked range).
+// Walks the union range_index across the full 8-byte key space and
+// resolves each union half-class into the local half-classes of both
+// classifiers. The range_index partitions the full key space, so the
+// walked ranges are the same ones the trie walk used to cover; the
+// callback already matches range_index_build_fn. On success the caller
+// owns the returned arrays, on failure both are freed and err
+// distinguishes an allocation failure from a broken refinement
+// invariant (a local classifier disagreeing with the union
+// classification across a walked range).
 static int
 net6_share_build_remap(
 	struct memory_context *mctx,
-	const struct lpm *uni,
+	const struct range_index *uni_ri,
 	uint32_t class_count,
-	const struct lpm *local_a,
-	const struct lpm *local_b,
+	const struct lpm_hash *local_a,
+	const struct lpm_hash *local_b,
 	uint32_t **remap_a,
 	uint32_t **remap_b,
 	yanet_error **err
@@ -935,12 +946,7 @@ net6_share_build_remap(
 		.class_count = class_count,
 	};
 
-	uint8_t from[8];
-	uint8_t to[8];
-	memset(from, 0x00, sizeof(from));
-	memset(to, 0xff, sizeof(to));
-
-	if (lpm8_walk(uni, from, to, net6_share_remap_collect, &ctx)) {
+	if (range_index_build(uni_ri, 8, net6_share_remap_collect, &ctx)) {
 		memory_bfree(mctx, b, size);
 		memory_bfree(mctx, a, size);
 		yanet_error_add(
@@ -973,18 +979,13 @@ filter_net6_share_init(
 		is_src ? action_get_net6_src : action_get_net6_dst;
 
 	// Only the tries are kept. Collector classes are dense, so the
-	// range index maximum value plus one is the class count and the
-	// index itself can be released right away.
-	struct range_index ri;
+	// range index maximum value plus one is the class count. The range
+	// index must outlive the remap walk, since lpm_hash has no walk and
+	// net6_share_build_remap walks the union range_index directly, so
+	// each ri is freed only after its remap succeeds.
+	struct range_index ri_hi;
 	if (collect_net6_range(
-		    mctx,
-		    rules,
-		    rule_count,
-		    get_net6,
-		    net6_get_hi_part,
-		    &out->hi,
-		    is_src ? "net6_share_src_hi" : "net6_share_dst_hi",
-		    &ri
+		    mctx, rules, rule_count, get_net6, net6_get_hi_part, &ri_hi
 	    )) {
 		yanet_error_add(
 			err,
@@ -992,18 +993,24 @@ filter_net6_share_init(
 		);
 		goto error;
 	}
-	out->hi_count = ri.max_value + 1;
-	range_index_free(&ri);
-
-	if (collect_net6_range(
+	if (range_index_build_lpm_hash(
+		    &ri_hi,
 		    mctx,
-		    rules,
-		    rule_count,
-		    get_net6,
-		    net6_get_lo_part,
-		    &out->lo,
-		    is_src ? "net6_share_src_lo" : "net6_share_dst_lo",
-		    &ri
+		    NET6_LPM_HASH_HOPS,
+		    is_src ? "net6_share_src_hi" : "net6_share_dst_hi",
+		    &out->hi
+	    )) {
+		yanet_error_add(
+			err, "out of memory: failed to build shared net6 hi lpm"
+		);
+		range_index_free(&ri_hi);
+		goto error;
+	}
+	out->hi_count = ri_hi.max_value + 1;
+
+	struct range_index ri_lo;
+	if (collect_net6_range(
+		    mctx, rules, rule_count, get_net6, net6_get_lo_part, &ri_lo
 	    )) {
 		yanet_error_add(
 			err,
@@ -1011,14 +1018,26 @@ filter_net6_share_init(
 		);
 		goto error_hi;
 	}
-	out->lo_count = ri.max_value + 1;
-	range_index_free(&ri);
+	if (range_index_build_lpm_hash(
+		    &ri_lo,
+		    mctx,
+		    NET6_LPM_HASH_HOPS,
+		    is_src ? "net6_share_src_lo" : "net6_share_dst_lo",
+		    &out->lo
+	    )) {
+		yanet_error_add(
+			err, "out of memory: failed to build shared net6 lo lpm"
+		);
+		range_index_free(&ri_lo);
+		goto error_hi;
+	}
+	out->lo_count = ri_lo.max_value + 1;
 
 	uint32_t *remap_hi_a;
 	uint32_t *remap_hi_b;
 	if (net6_share_build_remap(
 		    mctx,
-		    &out->hi,
+		    &ri_hi,
 		    out->hi_count,
 		    &local_a->hi,
 		    &local_b->hi,
@@ -1033,7 +1052,7 @@ filter_net6_share_init(
 	uint32_t *remap_lo_b;
 	if (net6_share_build_remap(
 		    mctx,
-		    &out->lo,
+		    &ri_lo,
 		    out->lo_count,
 		    &local_a->lo,
 		    &local_b->lo,
@@ -1049,6 +1068,9 @@ filter_net6_share_init(
 	SET_OFFSET_OF(&out->remap_lo_a, remap_lo_a);
 	SET_OFFSET_OF(&out->remap_lo_b, remap_lo_b);
 
+	range_index_free(&ri_lo);
+	range_index_free(&ri_hi);
+
 	return 0;
 
 error_remap_hi:
@@ -1056,10 +1078,12 @@ error_remap_hi:
 	memory_bfree(mctx, remap_hi_a, sizeof(uint32_t) * out->hi_count);
 
 error_lo:
-	lpm_free(&out->lo);
+	lpm_hash_fini(&out->lo);
+	range_index_free(&ri_lo);
 
 error_hi:
-	lpm_free(&out->hi);
+	lpm_hash_fini(&out->hi);
+	range_index_free(&ri_hi);
 
 error:
 	memset(out, 0, sizeof(*out));
@@ -1089,10 +1113,11 @@ filter_net6_share_dir_free(
 		memory_bfree(mctx, remap, sizeof(uint32_t) * dir->lo_count);
 	}
 
-	// lpm_free is safe on a zeroed trie, and zeroing the structure
-	// afterwards keeps the whole free path repeatable.
-	lpm_free(&dir->hi);
-	lpm_free(&dir->lo);
+	// lpm_hash_fini is safe on a zeroed trie (lpm_free handles a zeroed
+	// lpm and value_slot_index_fini is NULL-safe), and zeroing the
+	// structure afterwards keeps the whole free path repeatable.
+	lpm_hash_fini(&dir->hi);
+	lpm_hash_fini(&dir->lo);
 
 	memset(dir, 0, sizeof(*dir));
 }

--- a/lib/filter/query/net6.h
+++ b/lib/filter/query/net6.h
@@ -9,7 +9,6 @@
 #include <rte_mbuf.h>
 
 #include <stdint.h>
-#include <string.h>
 
 static inline void
 FILTER_ATTR_QUERY_FUNC(net6_dst)(
@@ -21,11 +20,6 @@ FILTER_ATTR_QUERY_FUNC(net6_dst)(
 
 	struct net6_classifier *c = (struct net6_classifier *)data;
 
-	uint8_t hi_keys[count][8];
-	uint8_t lo_keys[count][8];
-	uint32_t hi_values[count];
-	uint32_t lo_values[count];
-
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
 		struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
@@ -34,17 +28,9 @@ FILTER_ATTR_QUERY_FUNC(net6_dst)(
 			packets[idx]->network_header.offset
 		);
 
-		memcpy(hi_keys[idx], ipv6_hdr->dst_addr, 8);
-		memcpy(lo_keys[idx], ipv6_hdr->dst_addr + 8, 8);
-	}
-
-	lpm8_lookup_batch(&c->hi, hi_keys[0], hi_values, count);
-	lpm8_lookup_batch(&c->lo, lo_keys[0], lo_values, count);
-
-	for (uint32_t idx = 0; idx < count; ++idx) {
-		result[idx] = value_table_get(
-			&c->comb, hi_values[idx], lo_values[idx]
-		);
+		uint32_t hi = lpm_hash_lookup(&c->hi, ipv6_hdr->dst_addr);
+		uint32_t lo = lpm_hash_lookup(&c->lo, ipv6_hdr->dst_addr + 8);
+		result[idx] = value_table_get(&c->comb, hi, lo);
 	}
 }
 
@@ -58,11 +44,6 @@ FILTER_ATTR_QUERY_FUNC(net6_src)(
 
 	struct net6_classifier *c = (struct net6_classifier *)data;
 
-	uint8_t hi_keys[count][8];
-	uint8_t lo_keys[count][8];
-	uint32_t hi_values[count];
-	uint32_t lo_values[count];
-
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		struct rte_mbuf *mbuf = packet_to_mbuf(packets[idx]);
 		struct rte_ipv6_hdr *ipv6_hdr = rte_pktmbuf_mtod_offset(
@@ -71,16 +52,8 @@ FILTER_ATTR_QUERY_FUNC(net6_src)(
 			packets[idx]->network_header.offset
 		);
 
-		memcpy(hi_keys[idx], ipv6_hdr->src_addr, 8);
-		memcpy(lo_keys[idx], ipv6_hdr->src_addr + 8, 8);
-	}
-
-	lpm8_lookup_batch(&c->hi, hi_keys[0], hi_values, count);
-	lpm8_lookup_batch(&c->lo, lo_keys[0], lo_values, count);
-
-	for (uint32_t idx = 0; idx < count; ++idx) {
-		result[idx] = value_table_get(
-			&c->comb, hi_values[idx], lo_values[idx]
-		);
+		uint32_t hi = lpm_hash_lookup(&c->hi, ipv6_hdr->src_addr);
+		uint32_t lo = lpm_hash_lookup(&c->lo, ipv6_hdr->src_addr + 8);
+		result[idx] = value_table_get(&c->comb, hi, lo);
 	}
 }

--- a/lib/filter/tests/basic_net6.c
+++ b/lib/filter/tests/basic_net6.c
@@ -582,8 +582,8 @@ test3(void *memory) {
 // addr, the same way FILTER_ATTR_QUERY_FUNC(net6_src/net6_dst) does.
 static uint32_t
 local_net6_slot(struct net6_classifier *c, const uint8_t addr[NET6_LEN]) {
-	uint32_t hi = lpm8_lookup(&c->hi, addr);
-	uint32_t lo = lpm8_lookup(&c->lo, addr + 8);
+	uint32_t hi = lpm_hash_lookup(&c->hi, addr);
+	uint32_t lo = lpm_hash_lookup(&c->lo, addr + 8);
 	return value_table_get(&c->comb, hi, lo);
 }
 
@@ -598,8 +598,8 @@ shared_net6_slot(
 	struct net6_classifier *local,
 	const uint8_t addr[NET6_LEN]
 ) {
-	uint32_t hi = lpm8_lookup(&dir->hi, addr);
-	uint32_t lo = lpm8_lookup(&dir->lo, addr + 8);
+	uint32_t hi = lpm_hash_lookup(&dir->hi, addr);
+	uint32_t lo = lpm_hash_lookup(&dir->lo, addr + 8);
 	return value_table_get(&local->comb, remap_hi[hi], remap_lo[lo]);
 }
 

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -338,14 +338,11 @@ acl_handle_packets(
 		struct net6_share_dir *share_src = &acl_config->net6_share_src;
 		struct net6_share_dir *share_dst = &acl_config->net6_share_dst;
 
-		// Classify each v6 address half once on the union tries. The
-		// keys are packed per half so the batched walk can interleave
-		// each trie's dependent page chains across the batch instead of
-		// stalling on every hop of every packet.
-		uint8_t src_hi_keys[count][8];
-		uint8_t src_lo_keys[count][8];
-		uint8_t dst_hi_keys[count][8];
-		uint8_t dst_lo_keys[count][8];
+		// Classify each v6 address half once on the union tries.
+		uint32_t src_hi[ip6_idx];
+		uint32_t src_lo[ip6_idx];
+		uint32_t dst_hi[ip6_idx];
+		uint32_t dst_lo[ip6_idx];
 
 		for (uint64_t idx = 0; idx < ip6_idx; ++idx) {
 			struct rte_mbuf *mbuf =
@@ -360,29 +357,13 @@ acl_handle_packets(
 			const uint8_t *daddr =
 				(const uint8_t *)ipv6_hdr->dst_addr;
 
-			memcpy(src_hi_keys[idx], saddr, 8);
-			memcpy(src_lo_keys[idx], saddr + 8, 8);
-			memcpy(dst_hi_keys[idx], daddr, 8);
-			memcpy(dst_lo_keys[idx], daddr + 8, 8);
+			src_hi[idx] = lpm_hash_lookup(&share_src->hi, saddr);
+			src_lo[idx] =
+				lpm_hash_lookup(&share_src->lo, saddr + 8);
+			dst_hi[idx] = lpm_hash_lookup(&share_dst->hi, daddr);
+			dst_lo[idx] =
+				lpm_hash_lookup(&share_dst->lo, daddr + 8);
 		}
-
-		uint32_t src_hi[count];
-		uint32_t src_lo[count];
-		uint32_t dst_hi[count];
-		uint32_t dst_lo[count];
-
-		lpm8_lookup_batch(
-			&share_src->hi, src_hi_keys[0], src_hi, ip6_idx
-		);
-		lpm8_lookup_batch(
-			&share_src->lo, src_lo_keys[0], src_lo, ip6_idx
-		);
-		lpm8_lookup_batch(
-			&share_dst->hi, dst_hi_keys[0], dst_hi, ip6_idx
-		);
-		lpm8_lookup_batch(
-			&share_dst->lo, dst_lo_keys[0], dst_lo, ip6_idx
-		);
 
 		const uint32_t *src_hi_a = ADDR_OF(&share_src->remap_hi_a);
 		const uint32_t *src_lo_a = ADDR_OF(&share_src->remap_lo_a);

--- a/tests/common/lpm_hash_hybrid_bench.c
+++ b/tests/common/lpm_hash_hybrid_bench.c
@@ -1,0 +1,748 @@
+/*
+ * Proof-of-concept benchmark for a byte-stride LPM with a hashed top level.
+ *
+ * The container is `struct lpm_hash` from common/lpm_hash.h: an 8-byte
+ * lpm trie plus a hash that maps the leading hops key bytes to the trie
+ * page number they lead to. A hit skips the first hops dependent page
+ * loads and walks the rest from the stored page; a miss falls back to the
+ * root walk, which terminates within hops loads because the miss itself
+ * proves a flagged slot sits on the prefix path.
+ *
+ * Motivation: common/lpm.h walks one dependent pointer chase per key byte,
+ * so an 8-byte lookup (lpm8_lookup) costs up to 8 dependent cache-line
+ * accesses. The net6 classifier (lib/filter/classifiers/net6.h) runs two
+ * such lookups per IPv6 address, one per 64-bit half, and the production
+ * acl capture averages 5.4..7.0 loads per half. Offloading the first hops
+ * bytes to one hash probe cuts the dependent chain by 44..57% at hops 6
+ * with 345..3204 entries per trie.
+ *
+ * This is a POC harness only. It is not wired into the filter pipeline. It
+ * builds a plain full LPM (control, holds every prefix) alongside the
+ * hybrid, asserts lpm_hash == full for a large key sample, then A/B-times
+ * both scalar lookup paths over a recycled probe set.
+ *
+ * Timing uses __rdtsc (the instruction rte_rdtsc wraps on x86) plus
+ * clock_gettime(CLOCK_MONOTONIC); both run the same recycled loop.
+ * cycles/lookup is frequency-independent; ns/lookup is the human-readable
+ * headline.
+ */
+
+#include "common/lpm.h"
+#include "common/lpm_hash.h"
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/rng.h"
+#include "lib/logging/log.h"
+
+#include <x86intrin.h>
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#define BENCH_KEY_SIZE 8
+#define BENCH_HOPS_DEFAULT LPM_HASH_HOPS_DEFAULT
+
+// Compile-time corruption toggle for the sanity check. When defined to 1,
+// the page numbers of adjacent occupied hash slots are swapped after the
+// build, so lookups for those prefixes start the walk on a foreign page and
+// the correctness loop MUST report divergence. Proves the assertion can
+// actually fail. The production lpm_hash (common/lpm_hash.h) has no corrupt
+// path of its own; the bench injects the fault by editing slots directly.
+#ifndef HYBRID_BENCH_CORRUPT
+#define HYBRID_BENCH_CORRUPT 0
+#endif
+
+struct prefix_spec {
+	uint8_t from[BENCH_KEY_SIZE];
+	uint8_t to[BENCH_KEY_SIZE];
+	uint32_t value;
+	uint8_t prefix_len;
+	bool is_long;
+};
+
+// Read 8 big-endian bytes into a uint64 and the reverse.
+//
+// These are bench-local helpers for probe generation; they are NOT used by
+// the lpm_hash storage path. lpm_hash_insert and lpm_hash_lookup take raw
+// 8-byte keys, hash and compare them in place, and never convert to or from
+// uint64 (see common/lpm_hash.h).
+static inline uint64_t
+be_read(const uint8_t *p) {
+	uint64_t value = 0;
+	for (uint8_t idx = 0; idx < 8; ++idx) {
+		value = (value << 8) | p[idx];
+	}
+	return value;
+}
+
+static inline void
+be_write(uint64_t value, uint8_t *p) {
+	for (uint8_t idx = 0; idx < 8; ++idx) {
+		p[7 - idx] = (uint8_t)(value >> (8 * idx));
+	}
+}
+
+static inline uint64_t
+rdtsc_read(void) {
+	unsigned int aux;
+	return __rdtscp(&aux);
+}
+
+static uint64_t
+calibrate_tsc_hz(void) {
+	struct timespec ts_start;
+	struct timespec ts_end;
+	clock_gettime(CLOCK_MONOTONIC, &ts_start);
+	uint64_t tsc_start = rdtsc_read();
+
+	// ~50 ms gate, enough for clock_gettime resolution yet short.
+	struct timespec sleep_ts = {.tv_sec = 0, .tv_nsec = 50 * 1000 * 1000};
+	nanosleep(&sleep_ts, NULL);
+
+	uint64_t tsc_end = rdtsc_read();
+	clock_gettime(CLOCK_MONOTONIC, &ts_end);
+
+	uint64_t ns =
+		(uint64_t)(ts_end.tv_sec - ts_start.tv_sec) * 1000000000ULL +
+		(uint64_t)(ts_end.tv_nsec - ts_start.tv_nsec);
+	if (ns == 0) {
+		return 0;
+	}
+	return tsc_end * 1000000000ULL / ns - tsc_start * 1000000000ULL / ns;
+}
+
+static void
+prefix_range_from_len(
+	const uint8_t *base, uint8_t prefix_len, uint8_t *from, uint8_t *to
+) {
+	uint8_t whole = prefix_len / 8;
+	uint8_t frac = prefix_len % 8;
+
+	memcpy(from, base, BENCH_KEY_SIZE);
+	memset(from + whole, 0x00, BENCH_KEY_SIZE - whole);
+	if (frac) {
+		uint8_t mask = (uint8_t)(0xff << (8 - frac));
+		from[whole] &= mask;
+	}
+
+	memcpy(to, from, BENCH_KEY_SIZE);
+	for (uint8_t idx = whole; idx < BENCH_KEY_SIZE; ++idx) {
+		if (idx == whole && frac) {
+			to[idx] |= (uint8_t)~(0xff << (8 - frac));
+		} else {
+			to[idx] = 0xff;
+		}
+	}
+}
+
+// Builds a prefix set with a controllable long/short split.
+//
+// Long prefixes are /56../64 of the half; they push pointer paths deep and
+// populate the hashed top. Each gets a disjoint top-byte region. Short
+// prefixes are /0../16 defaults; they terminate the walk early, so probes
+// under them miss the top hash and take the (short) root fallback.
+static void
+generate_prefixes(
+	struct prefix_spec *prefixes,
+	size_t count,
+	double long_fraction,
+	uint64_t *rng
+) {
+	size_t long_count = (size_t)((double)count * long_fraction);
+	if (long_count > count) {
+		long_count = count;
+	}
+
+	size_t long_idx = 0;
+	for (size_t i = 0; i < count; ++i) {
+		struct prefix_spec *spec = &prefixes[i];
+		spec->value = (uint32_t)(i + 1);
+
+		if (long_idx < long_count) {
+			// Disjoint region: carve a /56 slice out of byte 0.
+			// 256 slices available, so wrap and shift down for
+			// larger long_count.
+			uint64_t slice = long_idx % 256ULL;
+			uint8_t base[BENCH_KEY_SIZE];
+			memset(base, 0, BENCH_KEY_SIZE);
+			base[0] = (uint8_t)slice;
+			base[1] = (uint8_t)(long_idx / 256ULL);
+
+			// Bias toward /64-of-half (one covered address), the
+			// realistic exact-match-heavy workload that makes a
+			// plain LPM walk all 8 bytes. A small minority sits at
+			// /56../63 so deeper pointer paths exist too.
+			uint8_t len;
+			uint32_t shape = (uint32_t)(rng_next(rng) % 100);
+			if (shape < 85) {
+				len = 64;
+			} else {
+				len = 56 + (uint8_t)(rng_next(rng) % 9);
+			}
+			prefix_range_from_len(base, len, spec->from, spec->to);
+			spec->prefix_len = len;
+			spec->is_long = true;
+			++long_idx;
+		} else {
+			// Default-range prefix: /0, /8, or /16.
+			uint8_t base[BENCH_KEY_SIZE];
+			memset(base, 0, BENCH_KEY_SIZE);
+			uint32_t pick = (uint32_t)(rng_next(rng) % 3);
+			uint8_t len = (pick == 0) ? 0 : (pick == 1 ? 8 : 16);
+			if (len) {
+				base[0] = (uint8_t)(rng_next(rng) % 256);
+			}
+			prefix_range_from_len(base, len, spec->from, spec->to);
+			spec->prefix_len = len;
+			spec->is_long = false;
+		}
+	}
+}
+
+// Builds a recycled probe set biased so that roughly long_fraction of probes
+// hit a long (deep) prefix and the rest hit only a short default.
+static void
+generate_probes(
+	uint8_t (*probes)[BENCH_KEY_SIZE],
+	size_t count,
+	const struct prefix_spec *prefixes,
+	size_t prefix_count,
+	double long_fraction,
+	uint64_t *rng
+) {
+	size_t long_count = 0;
+	for (size_t i = 0; i < prefix_count; ++i) {
+		if (prefixes[i].is_long) {
+			++long_count;
+		}
+	}
+
+	for (size_t i = 0; i < count; ++i) {
+		double roll =
+			(double)(rng_next(rng) >> 11) / (double)(1ULL << 53);
+		const struct prefix_spec *spec = NULL;
+		if (roll < long_fraction && long_count) {
+			size_t idx = (size_t)(rng_next(rng) % prefix_count);
+			while (!prefixes[idx].is_long) {
+				idx = (idx + 1) % prefix_count;
+			}
+			spec = &prefixes[idx];
+		} else {
+			size_t idx = (size_t)(rng_next(rng) % prefix_count);
+			while (prefixes[idx].is_long) {
+				idx = (idx + 1) % prefix_count;
+			}
+			spec = &prefixes[idx];
+		}
+
+		uint64_t base = be_read(spec->from);
+		uint64_t last = be_read(spec->to);
+		uint64_t addr;
+		if (base == 0 && last == UINT64_MAX) {
+			// Full 64-bit range (a /0 default): any value is valid
+			// and span+1 would overflow to 0, so pick directly.
+			addr = rng_next(rng);
+		} else {
+			uint64_t span = last - base;
+			uint64_t off =
+				(span == 0) ? 0 : (rng_next(rng) % (span + 1));
+			addr = base + off;
+		}
+		be_write(addr, probes[i]);
+	}
+}
+
+// Asserts lpm_hash == full for every key in [keys]. Returns the number of
+// mismatches. A mismatch is a real bug, not a benchmark artifact.
+static uint64_t
+verify_against_full(
+	const struct lpm_hash *lpm_hash,
+	const struct lpm *full,
+	const uint8_t (*keys)[BENCH_KEY_SIZE],
+	size_t count
+) {
+	uint64_t mismatches = 0;
+	for (size_t i = 0; i < count; ++i) {
+		uint32_t full_value = lpm8_lookup(full, keys[i]);
+		uint32_t lpm_hash_value = lpm_hash_lookup(lpm_hash, keys[i]);
+		if (full_value != lpm_hash_value) {
+			if (mismatches < 8) {
+				fprintf(stderr,
+					"mismatch at %zu: full=%u "
+					"lpm_hash=%u\n",
+					i,
+					full_value,
+					lpm_hash_value);
+			}
+			++mismatches;
+		}
+	}
+	return mismatches;
+}
+
+struct bench_args {
+	size_t num_prefixes;
+	double long_fraction;
+	uint32_t hops;
+	size_t num_probes;
+	uint32_t rounds;
+	uint64_t seed;
+};
+
+static void
+print_help(const char *argv0) {
+	fprintf(stderr,
+		"Usage: %s [options]\n"
+		"\n"
+		"  --prefixes N       total prefix count (default 10000)\n"
+		"  --long-fraction F  fraction of prefixes that are long /\n"
+		"                     deep, 0..1 (default 0.8)\n"
+		"  --hops N           hashed top height, 0..7 (default %u)\n"
+		"  --probes N         recycled probe set size (default "
+		"1048576)\n"
+		"  --rounds N         timed rounds, median reported (default "
+		"11)\n"
+		"  --seed S           PRNG seed, hex (default time-based)\n",
+		argv0,
+		BENCH_HOPS_DEFAULT);
+}
+
+static int
+parse_args(int argc, char **argv, struct bench_args *args) {
+	*args = (struct bench_args){
+		.num_prefixes = 10000,
+		.long_fraction = 0.8,
+		.hops = BENCH_HOPS_DEFAULT,
+		.num_probes = 1u << 20,
+		.rounds = 11,
+		.seed = 0,
+	};
+
+	for (int i = 1; i < argc; ++i) {
+		const char *a = argv[i];
+		if (strcmp(a, "-h") == 0 || strcmp(a, "--help") == 0) {
+			print_help(argv[0]);
+			return 1;
+		} else if (strcmp(a, "--prefixes") == 0 && i + 1 < argc) {
+			args->num_prefixes =
+				(size_t)strtoull(argv[++i], NULL, 10);
+		} else if (strcmp(a, "--long-fraction") == 0 && i + 1 < argc) {
+			args->long_fraction = strtod(argv[++i], NULL);
+		} else if (strcmp(a, "--hops") == 0 && i + 1 < argc) {
+			args->hops = (uint32_t)strtoul(argv[++i], NULL, 10);
+		} else if (strcmp(a, "--probes") == 0 && i + 1 < argc) {
+			args->num_probes =
+				(size_t)strtoull(argv[++i], NULL, 10);
+		} else if (strcmp(a, "--rounds") == 0 && i + 1 < argc) {
+			args->rounds = (uint32_t)strtoul(argv[++i], NULL, 10);
+		} else if (strcmp(a, "--seed") == 0 && i + 1 < argc) {
+			args->seed = strtoull(argv[++i], NULL, 16);
+		} else {
+			fprintf(stderr, "unknown arg: %s\n", a);
+			print_help(argv[0]);
+			return -1;
+		}
+	}
+
+	if (args->num_prefixes == 0 || args->num_probes == 0 ||
+	    args->rounds == 0) {
+		fprintf(stderr, "counts must be > 0\n");
+		return -1;
+	}
+	if (args->hops > 7) {
+		fprintf(stderr, "hops must be 0..7\n");
+		return -1;
+	}
+	if (args->long_fraction < 0.0) {
+		args->long_fraction = 0.0;
+	}
+	if (args->long_fraction > 1.0) {
+		args->long_fraction = 1.0;
+	}
+	return 0;
+}
+
+static int
+cmp_u64(const void *a, const void *b) {
+	uint64_t ua = *(const uint64_t *)a;
+	uint64_t ub = *(const uint64_t *)b;
+	return (ua > ub) - (ua < ub);
+}
+
+// Broadest prefix first. lpm.h resolves overlapping inserts last-writer-wins
+// at each covered leaf, so inserting least-specific first makes the more
+// specific prefix survive and the lookup behave as real longest-prefix-match.
+static int
+cmp_prefix_broad_first(const void *a, const void *b) {
+	const struct prefix_spec *pa = a;
+	const struct prefix_spec *pb = b;
+	return (int)pa->prefix_len - (int)pb->prefix_len;
+}
+
+static uint64_t
+median_u64(uint64_t *values, uint32_t count) {
+	qsort(values, count, sizeof(*values), cmp_u64);
+	return values[count / 2];
+}
+
+int
+main(int argc, char **argv) {
+	struct bench_args args;
+	int parsed = parse_args(argc, argv, &args);
+	if (parsed != 0) {
+		return (parsed > 0) ? 0 : 1;
+	}
+
+	log_enable_name("info");
+
+	if (args.seed == 0) {
+		struct timespec ts;
+		clock_gettime(CLOCK_MONOTONIC, &ts);
+		args.seed = ((uint64_t)ts.tv_sec << 20) ^ (uint64_t)ts.tv_nsec ^
+			    0x9e3779b97f4a7c15ULL;
+	}
+	uint64_t rng = args.seed;
+
+	LOG(INFO,
+	    "lpm_hash_hybrid_bench: prefixes=%zu long_fraction=%.2f "
+	    "hops=%u probes=%zu rounds=%u seed=0x%016" PRIx64,
+	    args.num_prefixes,
+	    args.long_fraction,
+	    args.hops,
+	    args.num_probes,
+	    args.rounds,
+	    args.seed);
+
+	uint64_t tsc_hz = calibrate_tsc_hz();
+	LOG(INFO,
+	    "lpm_hash_hybrid_bench: tsc_hz ~= %" PRIu64
+	    " (%.2f GHz, self-calibrated)",
+	    tsc_hz,
+	    (double)tsc_hz / 1e9);
+
+	size_t arena_size =
+		args.num_prefixes * 32ULL * 1024ULL + 64ULL * 1024ULL * 1024ULL;
+	if (arena_size < 128ULL * 1024ULL * 1024ULL) {
+		arena_size = 128ULL * 1024ULL * 1024ULL;
+	}
+	void *arena = malloc(arena_size);
+	if (arena == NULL) {
+		fprintf(stderr, "arena malloc failed (%zu bytes)\n", arena_size
+		);
+		return 1;
+	}
+
+	struct block_allocator allocator;
+	block_allocator_init(&allocator);
+	block_allocator_put_arena(&allocator, arena, arena_size);
+
+	struct memory_context bench_ctx;
+	if (memory_context_init(&bench_ctx, "lpm_hash_bench", &allocator) !=
+	    0) {
+		fprintf(stderr, "memory_context_init failed\n");
+		free(arena);
+		return 1;
+	}
+
+	struct prefix_spec *prefixes = (struct prefix_spec *)calloc(
+		args.num_prefixes, sizeof(struct prefix_spec)
+	);
+	if (prefixes == NULL) {
+		fprintf(stderr, "prefixes calloc failed\n");
+		return 1;
+	}
+	generate_prefixes(
+		prefixes, args.num_prefixes, args.long_fraction, &rng
+	);
+
+	// Reorder so broadest prefixes are inserted first (see comparator).
+	qsort(prefixes,
+	      args.num_prefixes,
+	      sizeof(*prefixes),
+	      cmp_prefix_broad_first);
+
+	size_t long_count = 0;
+	size_t short_count = 0;
+	for (size_t i = 0; i < args.num_prefixes; ++i) {
+		if (prefixes[i].is_long) {
+			++long_count;
+		} else {
+			++short_count;
+		}
+	}
+
+	// Full control LPM: every prefix.
+	struct lpm full;
+	if (lpm_init(&full, &bench_ctx, "bench_full") != 0) {
+		fprintf(stderr, "full lpm_init failed\n");
+		return 1;
+	}
+	for (size_t i = 0; i < args.num_prefixes; ++i) {
+		if (lpm8_insert(
+			    &full,
+			    prefixes[i].from,
+			    prefixes[i].to,
+			    prefixes[i].value
+		    ) != 0) {
+			fprintf(stderr,
+				"full lpm8_insert failed at %zu (arena "
+				"full?)\n",
+				i);
+			return 1;
+		}
+	}
+
+	// lpm_hash: same prefixes into its trie, then the top table is
+	// derived from the finished trie.
+	struct lpm_hash lh;
+	if (lpm_hash_init(
+		    &lh, &bench_ctx, (uint8_t)args.hops, "lpm_hash_bench"
+	    ) != 0) {
+		fprintf(stderr, "lpm_hash_init failed\n");
+		return 1;
+	}
+	for (size_t i = 0; i < args.num_prefixes; ++i) {
+		if (lpm_hash_insert(
+			    &lh,
+			    prefixes[i].from,
+			    prefixes[i].to,
+			    prefixes[i].value
+		    ) != 0) {
+			fprintf(stderr, "lpm_hash_insert failed at %zu\n", i);
+			return 1;
+		}
+	}
+	if (lpm_hash_build_top(&lh) != 0) {
+		fprintf(stderr, "lpm_hash_build_top failed\n");
+		return 1;
+	}
+	LOG(INFO,
+	    "lpm_hash_hybrid_bench: long_prefixes=%zu short_prefixes=%zu "
+	    "top_entries=%u lpm_pages=%zu",
+	    long_count,
+	    short_count,
+	    lh.index.size,
+	    lh.lpm.page_count);
+
+#if HYBRID_BENCH_CORRUPT
+	// Inject a deliberate fault so the correctness check has something to
+	// catch. The production lpm_hash has no corrupt path, so swap the page
+	// numbers of adjacent occupied slots directly: lookups for the swapped
+	// prefixes start the walk on a foreign page and disagree with the full
+	// LPM. Swaps keep every page number valid, so no out-of-range page is
+	// dereferenced.
+	{
+		struct lpm_hash_slot *slots = ADDR_OF(&lh.index.slots);
+		for (uint32_t pos = 0; pos + 1 < lh.index.capacity; ++pos) {
+			if (slots[pos].value == LPM_VALUE_INVALID ||
+			    slots[pos + 1].value == LPM_VALUE_INVALID) {
+				continue;
+			}
+			uint32_t tmp = slots[pos].value;
+			slots[pos].value = slots[pos + 1].value;
+			slots[pos + 1].value = tmp;
+			++pos;
+		}
+	}
+#endif
+
+	uint8_t(*probes)[BENCH_KEY_SIZE] = (uint8_t(*)[BENCH_KEY_SIZE]
+	)malloc(args.num_probes * BENCH_KEY_SIZE);
+	if (probes == NULL) {
+		fprintf(stderr, "probes malloc failed\n");
+		return 1;
+	}
+	generate_probes(
+		probes,
+		args.num_probes,
+		prefixes,
+		args.num_prefixes,
+		args.long_fraction,
+		&rng
+	);
+
+	// Correctness: the biased probes and a deterministic whole-space grid.
+	uint64_t probe_mismatch =
+		verify_against_full(&lh, &full, probes, args.num_probes);
+
+	size_t grid_count = 1u << 16;
+	uint8_t(*grid)[BENCH_KEY_SIZE] =
+		(uint8_t(*)[BENCH_KEY_SIZE])malloc(grid_count * BENCH_KEY_SIZE);
+	if (grid == NULL) {
+		fprintf(stderr, "grid malloc failed\n");
+		return 1;
+	}
+	for (size_t i = 0; i < grid_count; ++i) {
+		uint64_t addr = (i * 0x9e3779b97f4a7c15ULL);
+		be_write(addr, grid[i]);
+	}
+	uint64_t grid_mismatch =
+		verify_against_full(&lh, &full, grid, grid_count);
+	free(grid);
+
+#if HYBRID_BENCH_CORRUPT
+	if (probe_mismatch == 0 && grid_mismatch == 0) {
+		fprintf(stderr,
+			"CORRUPT MODE: correctness check did NOT detect the "
+			"injected fault (assertion is vacuous)\n");
+		return 2;
+	}
+	LOG(INFO,
+	    "lpm_hash_hybrid_bench: CORRUPT mode detected %llu injected "
+	    "mismatches (assertion is live), skipping timing.",
+	    (unsigned long long)(probe_mismatch + grid_mismatch));
+	lpm_hash_fini(&lh);
+	lpm_free(&full);
+	free(probes);
+	free(prefixes);
+	memory_context_fini(&bench_ctx);
+	free(arena);
+	return 0;
+#else
+	if (probe_mismatch || grid_mismatch) {
+		fprintf(stderr,
+			"correctness FAILED: probe mismatches=%llu "
+			"grid mismatches=%llu\n",
+			(unsigned long long)probe_mismatch,
+			(unsigned long long)grid_mismatch);
+		return 2;
+	}
+#endif
+
+	// Measure top-hit rate over the probe set for interpretation.
+	//
+	// A hit is a successful value_slot_index probe on the zero-padded
+	// leading-hops bytes (no root fallback), reported by
+	// value_slot_index_lookup as a value other than LPM_VALUE_INVALID.
+	uint64_t hash_hits = 0;
+	volatile uint32_t sink = 0;
+	for (size_t i = 0; i < args.num_probes; ++i) {
+		uint8_t top_key[8];
+		lpm_hash_top_key(&lh, probes[i], top_key);
+		uint32_t hit = value_slot_index_lookup(&lh.index, top_key);
+		if (hit != LPM_VALUE_INVALID) {
+			++hash_hits;
+		}
+		sink ^= hit;
+	}
+	double hash_hit_rate = (double)hash_hits / (double)args.num_probes;
+
+	uint64_t *plain_ns = (uint64_t *)calloc(args.rounds, sizeof(uint64_t));
+	uint64_t *plain_cyc = (uint64_t *)calloc(args.rounds, sizeof(uint64_t));
+	uint64_t *lpm_hash_ns =
+		(uint64_t *)calloc(args.rounds, sizeof(uint64_t));
+	uint64_t *lpm_hash_cyc =
+		(uint64_t *)calloc(args.rounds, sizeof(uint64_t));
+	if (!plain_ns || !plain_cyc || !lpm_hash_ns || !lpm_hash_cyc) {
+		fprintf(stderr, "timing arrays alloc failed\n");
+		return 1;
+	}
+
+	for (uint32_t round = 0; round < args.rounds; ++round) {
+		struct timespec ts_start;
+		struct timespec ts_end;
+		uint32_t acc = 0;
+
+		clock_gettime(CLOCK_MONOTONIC, &ts_start);
+		uint64_t tsc_start = rdtsc_read();
+		for (size_t i = 0; i < args.num_probes; ++i) {
+			acc ^= lpm8_lookup(&full, probes[i]);
+		}
+		uint64_t tsc_end = rdtsc_read();
+		clock_gettime(CLOCK_MONOTONIC, &ts_end);
+		sink ^= acc;
+
+		plain_ns[round] = (uint64_t)(ts_end.tv_sec - ts_start.tv_sec) *
+					  1000000000ULL +
+				  (uint64_t)(ts_end.tv_nsec - ts_start.tv_nsec);
+		plain_cyc[round] = tsc_end - tsc_start;
+	}
+
+	for (uint32_t round = 0; round < args.rounds; ++round) {
+		struct timespec ts_start;
+		struct timespec ts_end;
+		uint32_t acc = 0;
+
+		clock_gettime(CLOCK_MONOTONIC, &ts_start);
+		uint64_t tsc_start = rdtsc_read();
+		for (size_t i = 0; i < args.num_probes; ++i) {
+			acc ^= lpm_hash_lookup(&lh, probes[i]);
+		}
+		uint64_t tsc_end = rdtsc_read();
+		clock_gettime(CLOCK_MONOTONIC, &ts_end);
+		sink ^= acc;
+
+		lpm_hash_ns[round] =
+			(uint64_t)(ts_end.tv_sec - ts_start.tv_sec) *
+				1000000000ULL +
+			(uint64_t)(ts_end.tv_nsec - ts_start.tv_nsec);
+		lpm_hash_cyc[round] = tsc_end - tsc_start;
+	}
+
+	(void)sink;
+
+	uint64_t plain_ns_med = median_u64(plain_ns, args.rounds);
+	uint64_t lpm_hash_ns_med = median_u64(lpm_hash_ns, args.rounds);
+	uint64_t plain_cyc_med = median_u64(plain_cyc, args.rounds);
+	uint64_t lpm_hash_cyc_med = median_u64(lpm_hash_cyc, args.rounds);
+
+	double plain_ns_per = (double)plain_ns_med / (double)args.num_probes;
+	double lpm_hash_ns_per =
+		(double)lpm_hash_ns_med / (double)args.num_probes;
+	double plain_cyc_per = (double)plain_cyc_med / (double)args.num_probes;
+	double lpm_hash_cyc_per =
+		(double)lpm_hash_cyc_med / (double)args.num_probes;
+
+	double speedup = 0.0;
+	if (lpm_hash_ns_per > 0.0) {
+		speedup =
+			(plain_ns_per - lpm_hash_ns_per) / plain_ns_per * 100.0;
+	}
+
+	printf("\n");
+	printf("=== lpm_hash (hashed top, hops=%u) vs plain 8-byte LPM ===\n",
+	       args.hops);
+	printf("prefixes=%zu  long_fraction=%.2f  rounds=%u\n",
+	       args.num_prefixes,
+	       args.long_fraction,
+	       args.rounds);
+	printf("long=%zu short=%zu top_entries=%u top_hit_rate=%.3f\n",
+	       long_count,
+	       short_count,
+	       lh.index.size,
+	       hash_hit_rate);
+	printf("hash_table_bytes=%" PRIu64 " full_lpm_bytes=%lu "
+	       "lpm_hash_lpm_bytes=%lu\n",
+	       (uint64_t)lh.index.capacity * sizeof(struct lpm_hash_slot),
+	       lpm_memory_usage(&full),
+	       lpm_memory_usage(&lh.lpm));
+	printf("\n");
+	printf("                    ns/lookup   cycles/lookup\n");
+	printf("plain  scalar       %8.2f      %8.1f\n",
+	       plain_ns_per,
+	       plain_cyc_per);
+	printf("hash   scalar       %8.2f      %8.1f\n",
+	       lpm_hash_ns_per,
+	       lpm_hash_cyc_per);
+	printf("\n");
+	printf("speedup scalar vs plain (ns/lookup): %+.1f%%\n", speedup);
+
+	free(plain_ns);
+	free(plain_cyc);
+	free(lpm_hash_ns);
+	free(lpm_hash_cyc);
+	lpm_hash_fini(&lh);
+	lpm_free(&full);
+	free(probes);
+	free(prefixes);
+	memory_context_fini(&bench_ctx);
+	free(arena);
+
+	return 0;
+}

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -117,6 +117,14 @@ executable(
   dependencies: dependencies
 )
 
+executable(
+  'lpm_hash_hybrid_bench',
+  ['lpm_hash_hybrid_bench.c'],
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies
+)
+
 big_array_test = executable(
   'big_array_test',
   ['big_array_test.c'],


### PR DESCRIPTION
Route the net6 half-classification through a byte-stride trie with a hashed top level. An open-addressing hash maps the leading hops bytes of an 8-byte half to the trie page those bytes lead to, so a hit walks only the remaining bytes and a miss falls back to the root walk, which by construction terminates within hops loads. The container is built once from the range partition the compiler already produces, entries are derived from the finished trie (one per page at the cut level), and lookup results are bit-identical to the plain walk.

- Generalize range_index_build_lpm into a range_index_build driving a per-range callback; the lpm and lpm_hash builders are thin wrappers over it.
- The hash side is a value_slot_index modelled on str_index: a self-contained open-addressing slot table with auto-grow, with all storage flowing through the memory_context so the structure is usable from shared memory.
- A hit skips the first hops dependent page loads; hops six cuts the dependent chain per packet roughly in half on the production acl ruleset across all four half-tries (a few hundred to a few thousand entries per trie).
- The shared net6 classification takes the same fast path: its remap arrays are built by walking the union range_index directly, since the container exposes no trie walk.
- Lookups are plain scalar lpm_hash_lookup calls in the net6 attribute queries and the acl dataplane: a hop-major batched walk measured 1.9..2.3x slower than the scalar loop on production traffic at -O2, so batching is not used.
- A self-contained benchmark under tests/common asserts equality with a full LPM control over biased and whole-space probe sets, then A/B-times the scalar lookup paths.

All filter suites, the full meson test set, and the acl Go suites pass, including the shared-classification functional tests.