### PR TITLE
fix(web): cap the inspect module strip at eight cards per row

### DIFF
--- a/web/builtin/inspect/ModuleStrip.tsx
+++ b/web/builtin/inspect/ModuleStrip.tsx
@@ -16,7 +16,7 @@ const chrome: ModuleCardsChrome = {
     countClass: 'iv-label__count',
     legendClass: 'iv-module-strip__legend',
     gridClass: 'iv-module-strip__grid',
-    gridTemplateColumns: (n) => `repeat(${n || 1}, minmax(0, 1fr))`,
+    gridTemplateColumns: (n) => `repeat(${Math.min(8, Math.max(1, n))}, minmax(0, 1fr))`,
     cardClass: 'iv-module-card',
     dotClass: 'iv-dot',
     memUsedStyle: (used) => ({


### PR DESCRIPTION
The dataplane module strip on the inspect page laid every module out on a single grid row, so with a dozen active modules the cards became too narrow and their names were ellipsised.

- Cap the strip at eight cards per row and let the remaining modules wrap onto further rows.
- Match the column expression the dashboard module block already uses, so the two renderings of the shared module-card grid stay consistent.
