### PR TITLE
refactor(web): compute the module grid columns in the shared renderer

### DIFF
--- a/web/builtin/dashboard/DataplaneModules.tsx
+++ b/web/builtin/dashboard/DataplaneModules.tsx
@@ -12,7 +12,6 @@ const chrome: ModuleCardsChrome = {
     rootClass: 'dash-modules',
     headClass: 'dash-modules__head',
     gridClass: 'dash-modules__grid',
-    gridTemplateColumns: (n) => `repeat(${Math.min(8, Math.max(1, n))}, minmax(0, 1fr))`,
     cardClass: 'dash-module-card',
     dotClass: 'dash-dot',
     countStyle: { color: 'var(--iv-text-dim)' },

--- a/web/builtin/inspect/ModuleCardsGrid.tsx
+++ b/web/builtin/inspect/ModuleCardsGrid.tsx
@@ -17,7 +17,6 @@ export interface ModuleCardsChrome {
     countStyle?: React.CSSProperties;
     legendClass?: string;
     gridClass: string;
-    gridTemplateColumns: (moduleCount: number) => string;
     cardClass: string;
     dotClass: string;
     memUsedStyle: (used: number) => React.CSSProperties;
@@ -30,6 +29,16 @@ export interface ModuleCardsGridProps {
     usage: Map<string, AgentUsage>;
     chrome: ModuleCardsChrome;
 }
+
+/**
+ * One equal-width grid column per module, capped at eight.
+ *
+ * The count is also floored at one because `repeat(0, ...)` is invalid CSS;
+ * the browser drops the whole declaration and the grid silently collapses
+ * to a single implicit column.
+ */
+const gridTemplateColumns = (moduleCount: number): string =>
+    `repeat(${Math.min(8, Math.max(1, moduleCount))}, minmax(0, 1fr))`;
 
 /** Shared module-card grid renderer used by ModuleStrip and DataplaneModules. */
 export const ModuleCardsGrid: React.FC<ModuleCardsGridProps> = ({ instance, usage, chrome }) => {
@@ -55,7 +64,7 @@ export const ModuleCardsGrid: React.FC<ModuleCardsGridProps> = ({ instance, usag
             </div>
             <div
                 className={chrome.gridClass}
-                style={{ gridTemplateColumns: chrome.gridTemplateColumns(modules.length) }}
+                style={{ gridTemplateColumns: gridTemplateColumns(modules.length) }}
             >
                 {moduleData.map((m) => {
                     const href = getModuleRoute(m.name);

--- a/web/builtin/inspect/ModuleStrip.tsx
+++ b/web/builtin/inspect/ModuleStrip.tsx
@@ -16,7 +16,6 @@ const chrome: ModuleCardsChrome = {
     countClass: 'iv-label__count',
     legendClass: 'iv-module-strip__legend',
     gridClass: 'iv-module-strip__grid',
-    gridTemplateColumns: (n) => `repeat(${Math.min(8, Math.max(1, n))}, minmax(0, 1fr))`,
     cardClass: 'iv-module-card',
     dotClass: 'iv-dot',
     memUsedStyle: (used) => ({


### PR DESCRIPTION
Both callers of the shared module-card grid passed a byte-identical column template, so the chrome knob had a single possible value and an edit to one copy would have silently diverged the inspect strip from the dashboard block.

- Compute the column template once inside the shared renderer and drop the knob from the chrome interface.
- Document why the column count is floored at one, since the clamp guards against emitting invalid CSS.
- Leave the rendered output unchanged on both surfaces.
