### PR TITLE
fix(web): bound the growth of the inspect module strip

### DIFF
--- a/web/builtin/inspect/ModuleStrip.tsx
+++ b/web/builtin/inspect/ModuleStrip.tsx
@@ -15,7 +15,7 @@ const chrome: ModuleCardsChrome = {
     labelClass: 'iv-label',
     countClass: 'iv-label__count',
     legendClass: 'iv-module-strip__legend',
-    gridClass: 'iv-module-strip__grid',
+    gridClass: 'iv-module-strip__grid iv-scroll',
     cardClass: 'iv-module-card',
     dotClass: 'iv-dot',
     memUsedStyle: (used) => ({

--- a/web/builtin/inspect/inspect.scss
+++ b/web/builtin/inspect/inspect.scss
@@ -320,6 +320,9 @@
         .iv-module-strip__grid {
             display: grid;
             gap: 8px;
+            max-height: 373px;
+            overflow-y: auto;
+            padding-right: 4px;
         }
     }
 


### PR DESCRIPTION
The dataplane module strip grew without limit as modules were added, pushing the rest of the inspect view further down the page. The device wall on the same view already bounds itself the same way.

- Bound the module strip to three card rows and let it scroll past that.
- Give it the thin scrollbar the other scrolling sections on the view use.
- Leave today's module count unaffected, since it occupies two rows.
