### PR TITLE
refactor(bird-adapter): take the logger via constructor options

### DIFF
--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -34,13 +34,9 @@ barenew:common/go/grpcmetrics/grpcmetrics.go:New:1  # legacy: rename to a descri
 barenew:common/go/xbackoff/backoff.go:New:1  # legacy: rename to a descriptive constructor name
 logger:modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing:1  # legacy: migrate to the options pattern
 logger:modules/pdump/controlplane/service.go:NewPdumpService:1  # legacy: migrate to the options pattern
-logger:operators/bird-adapter/internal/bird/export.go:NewExportReader:1  # legacy: migrate to the options pattern
-logger:operators/bird-adapter/internal/bird/parser.go:NewParser:1  # legacy: migrate to the options pattern
-logger:operators/bird-adapter/internal/bird/update.go:NewUpdateDecoder:1  # legacy: migrate to the options pattern
 logger:operators/bird-adapter/service.go:AdapterService.processBirdImport:1  # legacy: migrate to the options pattern
 logger:operators/bird-adapter/service.go:AdapterService.reconnectStream:1  # legacy: migrate to the options pattern
 logger:operators/bird-adapter/service.go:AdapterService.runBirdImportLoop:1  # legacy: migrate to the options pattern
-logger:operators/bird-adapter/service.go:NewAdapterService:1  # legacy: migrate to the options pattern
 loggerlast:common/go/readiness/readiness.go:options.Log:1  # legacy: move the *zap.Logger field to the end of the struct
 loggerlast:controlplane/gateway/gateway.go:gatewayOptions.Log:1  # legacy: move the *zap.Logger field to the end of the struct
 loggerlast:controlplane/internal/auth/sshkey/authenticator.go:authenticatorOptions.Log:1  # legacy: move the *zap.Logger field to the end of the struct

--- a/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
+++ b/operators/bird-adapter/cmd/yanet-bird-adapter/server.go
@@ -91,7 +91,7 @@ func runServer() error {
 	)
 
 	// Create the adapter service
-	adapterService := birdAdapter.NewAdapterService(cfg.RouteOperatorEndpoint, log)
+	adapterService := birdAdapter.NewAdapterService(cfg.RouteOperatorEndpoint, birdAdapter.WithAdapterServiceLog(log))
 
 	// Create gRPC server
 	grpcServer := grpc.NewServer()

--- a/operators/bird-adapter/internal/bird/export.go
+++ b/operators/bird-adapter/internal/bird/export.go
@@ -29,7 +29,32 @@ type Export struct {
 	log      *zap.Logger
 }
 
-func NewExportReader(cfg *Config, onUpdate Updater, onFlush Notifier, log *zap.Logger) *Export {
+// ExportReaderOption configures the Export constructor.
+type ExportReaderOption func(*exportReaderOptions)
+
+type exportReaderOptions struct {
+	Log *zap.Logger
+}
+
+func newExportReaderOptions() *exportReaderOptions {
+	return &exportReaderOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithExportReaderLog sets the logger for the export reader.
+func WithExportReaderLog(log *zap.Logger) ExportReaderOption {
+	return func(o *exportReaderOptions) {
+		o.Log = log
+	}
+}
+
+func NewExportReader(cfg *Config, onUpdate Updater, onFlush Notifier, options ...ExportReaderOption) *Export {
+	opts := newExportReaderOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	sockets := make([]exportSocket, 0, len(cfg.Sockets))
 	for _, s := range cfg.Sockets {
 		sockets = append(sockets, exportSocket{
@@ -42,7 +67,7 @@ func NewExportReader(cfg *Config, onUpdate Updater, onFlush Notifier, log *zap.L
 		cfg:      cfg,
 		updater:  onUpdate,
 		notifier: onFlush,
-		log:      log,
+		log:      opts.Log,
 	}
 }
 
@@ -81,7 +106,7 @@ func (m *Export) Run(ctx context.Context) error {
 				}
 			}()
 			reader := bufio.NewReader(c)
-			parser := NewParser(reader, socket.BufSize, m.log)
+			parser := NewParser(reader, socket.BufSize, WithParserLog(m.log))
 			for {
 				update, err := parser.Next()
 				if err != nil {

--- a/operators/bird-adapter/internal/bird/parser.go
+++ b/operators/bird-adapter/internal/bird/parser.go
@@ -22,11 +22,36 @@ type Parser struct {
 	log    *zap.Logger
 }
 
-func NewParser(r io.Reader, bufSize int, log *zap.Logger) *Parser {
+// ParserOption configures the Parser constructor.
+type ParserOption func(*parserOptions)
+
+type parserOptions struct {
+	Log *zap.Logger
+}
+
+func newParserOptions() *parserOptions {
+	return &parserOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithParserLog sets the logger for the parser.
+func WithParserLog(log *zap.Logger) ParserOption {
+	return func(o *parserOptions) {
+		o.Log = log
+	}
+}
+
+func NewParser(r io.Reader, bufSize int, options ...ParserOption) *Parser {
+	opts := newParserOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &Parser{
 		reader: r,
 		buf:    make([]byte, bufSize),
-		log:    log,
+		log:    opts.Log,
 	}
 }
 
@@ -65,5 +90,5 @@ func (m *Parser) Next() (*updateDecoder, error) {
 		return nil, fmt.Errorf("m.readChunk(%d): %w", readSize, err)
 	}
 
-	return NewUpdateDecoder(m.buf[:int(readSize)], m.log)
+	return NewUpdateDecoder(m.buf[:int(readSize)], WithUpdateDecoderLog(m.log))
 }

--- a/operators/bird-adapter/internal/bird/parser_test.go
+++ b/operators/bird-adapter/internal/bird/parser_test.go
@@ -45,7 +45,7 @@ func TestParserNext(t *testing.T) {
 	buf.Write(updateData)
 
 	reader := bytes.NewReader(buf.Bytes())
-	parser := bird.NewParser(reader, 4096, zaptest.NewLogger(t))
+	parser := bird.NewParser(reader, 4096, bird.WithParserLog(zaptest.NewLogger(t)))
 
 	// With the fix, this should work correctly
 	decoder, err := parser.Next()

--- a/operators/bird-adapter/internal/bird/update.go
+++ b/operators/bird-adapter/internal/bird/update.go
@@ -222,21 +222,49 @@ func newUpdate(data []byte) (*update, error) {
 	return u, nil
 }
 
-// NewUpdateDecoder creates a new updateDecoder from raw data with the provided logger.
-// If logger is nil, a nop logger will be used.
-func NewUpdateDecoder(data []byte, log *zap.Logger) (*updateDecoder, error) {
+// UpdateDecoderOption configures the updateDecoder constructor.
+type UpdateDecoderOption func(*updateDecoderOptions)
+
+type updateDecoderOptions struct {
+	Log *zap.Logger
+}
+
+// nopLog is the default logger for the update decoder.
+//
+// The decoder is constructed once per route update, so building a fresh
+// no-op logger on every call would allocate a logger that is discarded as
+// soon as the caller supplies its own logger. A shared instance is safe
+// because zap loggers are immutable.
+var nopLog = zap.NewNop()
+
+func newUpdateDecoderOptions() *updateDecoderOptions {
+	return &updateDecoderOptions{
+		Log: nopLog,
+	}
+}
+
+// WithUpdateDecoderLog sets the logger for the update decoder.
+func WithUpdateDecoderLog(log *zap.Logger) UpdateDecoderOption {
+	return func(o *updateDecoderOptions) {
+		o.Log = log
+	}
+}
+
+// NewUpdateDecoder creates a new updateDecoder from raw data.
+func NewUpdateDecoder(data []byte, options ...UpdateDecoderOption) (*updateDecoder, error) {
+	opts := newUpdateDecoderOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	u, err := newUpdate(data)
 	if err != nil {
 		return nil, err
 	}
 
-	if log == nil {
-		log = zap.NewNop()
-	}
-
 	return &updateDecoder{
 		update: u,
-		log:    log,
+		log:    opts.Log,
 	}, nil
 }
 

--- a/operators/bird-adapter/internal/bird/update_test.go
+++ b/operators/bird-adapter/internal/bird/update_test.go
@@ -499,7 +499,7 @@ func TestDecodeUpdate(t *testing.T) {
 
 	for idx, c := range cases {
 		t.Run(fmt.Sprintf("case #%d %s", idx, c.name), func(t *testing.T) {
-			decoder, err := bird.NewUpdateDecoder(c.data, nil)
+			decoder, err := bird.NewUpdateDecoder(c.data)
 			if c.errNew != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, c.errNew, "err from NewUpdateDecoder")
@@ -527,7 +527,7 @@ func Benchmark_update_Decode(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		decoder, err := bird.NewUpdateDecoder(dataIPv6WithLargeCommunities, nil)
+		decoder, err := bird.NewUpdateDecoder(dataIPv6WithLargeCommunities)
 		if err != nil {
 			b.Logf("unexpected error: %v", err)
 			b.FailNow()
@@ -567,7 +567,7 @@ func Fuzz_update_Decode(f *testing.F) {
 	f.Add(([]byte)(nil))
 
 	f.Fuzz(func(t *testing.T, data []byte) {
-		decoder, err := bird.NewUpdateDecoder(data, nil)
+		decoder, err := bird.NewUpdateDecoder(data)
 		if decoder != nil {
 			route := &rib.Route{}
 			err = decoder.Decode(route)

--- a/operators/bird-adapter/service.go
+++ b/operators/bird-adapter/service.go
@@ -54,15 +54,40 @@ type AdapterService struct {
 	log                   *zap.Logger
 }
 
+// AdapterServiceOption configures the AdapterService constructor.
+type AdapterServiceOption func(*adapterServiceOptions)
+
+type adapterServiceOptions struct {
+	Log *zap.Logger
+}
+
+func newAdapterServiceOptions() *adapterServiceOptions {
+	return &adapterServiceOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithAdapterServiceLog sets the logger for the adapter service.
+func WithAdapterServiceLog(log *zap.Logger) AdapterServiceOption {
+	return func(o *adapterServiceOptions) {
+		o.Log = log
+	}
+}
+
 func NewAdapterService(
 	routeOperatorEndpoint string,
-	log *zap.Logger,
+	options ...AdapterServiceOption,
 ) *AdapterService {
+	opts := newAdapterServiceOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &AdapterService{
 		imports:               make(map[string]*importHolder),
 		routeOperatorEndpoint: routeOperatorEndpoint,
 		quitCh:                make(chan bool),
-		log:                   log,
+		log:                   opts.Log,
 	}
 }
 
@@ -388,7 +413,7 @@ func (m *AdapterService) processBirdImport(
 		return nil
 	}
 
-	export := bird.NewExportReader(cfg, onUpdate, onFlush, clientLog)
+	export := bird.NewExportReader(cfg, onUpdate, onFlush, bird.WithExportReaderLog(clientLog))
 
 	holder := newImportHolder(export, cancel, conn, currentStream, cfg.Sockets)
 


### PR DESCRIPTION
- Migrates the BIRD adapter service and its export reader, parser and update decoder to the options pattern so none of them takes a zap logger as a parameter, matching the convention enforced by the logger linter.
- Each constructor gets its own option family, since three of them share a package and a bare option name would collide.
- Drops the hand-rolled nil-logger fallback in the update decoder, now that the no-op logger is the option default.
- Removes the four now-paid-down rows from the linter allowlist. The logger-taking methods on the adapter service stay allowlisted; they need a design decision rather than a mechanical migration.