### PR TITLE
refactor(auth): pass the logger to authenticator factories through options

### DIFF
--- a/controlplane/internal/auth/basic/factory.go
+++ b/controlplane/internal/auth/basic/factory.go
@@ -3,17 +3,13 @@ package basic
 import (
 	"fmt"
 
-	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
 )
 
 // NewFromConfig creates a BasicAuthenticator from a raw YAML config node.
-func NewFromConfig(
-	rawCfg *yaml.Node,
-	log *zap.Logger,
-) (core.Authenticator, error) {
+func NewFromConfig(rawCfg *yaml.Node) (core.Authenticator, error) {
 	var cfg Config
 	if err := rawCfg.Decode(&cfg); err != nil {
 		return nil, fmt.Errorf("decode basic config: %w", err)

--- a/controlplane/internal/auth/manager.go
+++ b/controlplane/internal/auth/manager.go
@@ -21,17 +21,7 @@ import (
 )
 
 // AuthenticatorFactory creates an Authenticator from a raw YAML config node.
-type AuthenticatorFactory func(
-	rawCfg *yaml.Node,
-	log *zap.Logger,
-) (core.Authenticator, error)
-
-// factories maps authenticator type names to their factory functions.
-var factories = map[string]AuthenticatorFactory{
-	"basic":   basic.NewFromConfig,
-	"sshkey":  sshkey.NewFromConfig,
-	"sshcert": sshcert.NewFromConfig,
-}
+type AuthenticatorFactory func(rawCfg *yaml.Node) (core.Authenticator, error)
 
 // Authorizer is the interface for authorization decisions.
 type Authorizer interface {
@@ -150,13 +140,23 @@ func NewManager(cfg *Config, options ...ManagerOption) (*Manager, error) {
 	)
 
 	// Create authenticators from config entries.
+	factories := map[string]AuthenticatorFactory{
+		"basic": basic.NewFromConfig,
+		"sshkey": func(rawCfg *yaml.Node) (core.Authenticator, error) {
+			return sshkey.NewFromConfig(rawCfg, sshkey.WithLog(log))
+		},
+		"sshcert": func(rawCfg *yaml.Node) (core.Authenticator, error) {
+			return sshcert.NewFromConfig(rawCfg, sshcert.WithLog(log))
+		},
+	}
+
 	for _, entry := range cfg.Authenticators {
 		factory, ok := factories[entry.Type]
 		if !ok {
 			return nil, fmt.Errorf("unknown authenticator type: %q", entry.Type)
 		}
 
-		auth, err := factory(&entry.Config, log)
+		auth, err := factory(&entry.Config)
 		if err != nil {
 			return nil, fmt.Errorf("failed to init %q authenticator: %w", entry.Type, err)
 		}

--- a/controlplane/internal/auth/sshcert/factory.go
+++ b/controlplane/internal/auth/sshcert/factory.go
@@ -3,7 +3,6 @@ package sshcert
 import (
 	"fmt"
 
-	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
@@ -12,7 +11,7 @@ import (
 // NewFromConfig creates an SSH certificate Authenticator from a raw YAML.
 func NewFromConfig(
 	rawCfg *yaml.Node,
-	log *zap.Logger,
+	options ...Option,
 ) (core.Authenticator, error) {
 	var cfg Config
 	if err := rawCfg.Decode(&cfg); err != nil {
@@ -49,9 +48,8 @@ func NewFromConfig(
 		}
 	}
 
-	opts := []Option{
-		WithLog(log),
-	}
+	opts := make([]Option, 0, len(options)+2)
+	opts = append(opts, options...)
 	if cfg.TimeWindow > 0 {
 		opts = append(opts, WithTimeWindow(cfg.TimeWindow))
 	}

--- a/controlplane/internal/auth/sshkey/factory.go
+++ b/controlplane/internal/auth/sshkey/factory.go
@@ -3,7 +3,6 @@ package sshkey
 import (
 	"fmt"
 
-	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
@@ -12,7 +11,7 @@ import (
 // NewFromConfig creates an SSH key Authenticator from a raw YAML config node.
 func NewFromConfig(
 	rawCfg *yaml.Node,
-	log *zap.Logger,
+	options ...Option,
 ) (core.Authenticator, error) {
 	var cfg Config
 	if err := rawCfg.Decode(&cfg); err != nil {
@@ -28,9 +27,8 @@ func NewFromConfig(
 		return nil, fmt.Errorf("create SSH key store: %w", err)
 	}
 
-	opts := []Option{
-		WithLog(log),
-	}
+	opts := make([]Option, 0, len(options)+1)
+	opts = append(opts, options...)
 	if cfg.TimeWindow > 0 {
 		opts = append(opts, WithTimeWindow(cfg.TimeWindow))
 	}

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -32,9 +32,6 @@
 
 barenew:common/go/grpcmetrics/grpcmetrics.go:New:1  # legacy: rename to a descriptive constructor name
 barenew:common/go/xbackoff/backoff.go:New:1  # legacy: rename to a descriptive constructor name
-logger:controlplane/internal/auth/basic/factory.go:NewFromConfig:1  # legacy: migrate to the options pattern
-logger:controlplane/internal/auth/sshcert/factory.go:NewFromConfig:1  # legacy: migrate to the options pattern
-logger:controlplane/internal/auth/sshkey/factory.go:NewFromConfig:1  # legacy: migrate to the options pattern
 logger:modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing:1  # legacy: migrate to the options pattern
 logger:modules/pdump/controlplane/service.go:NewPdumpService:1  # legacy: migrate to the options pattern
 logger:operators/bird-adapter/internal/bird/export.go:NewExportReader:1  # legacy: migrate to the options pattern


### PR DESCRIPTION
- Replace the positional logger argument of the three authenticator factories with the options pattern already used across the control plane.
- Drop the argument outright from the basic authenticator factory, which never logged anything.
- Let the two SSH factories accept their package option family, so a caller-supplied logger reaches the authenticator while configuration file settings keep taking precedence.
- Bind the factory registry to the manager logger where it is already in scope, which also removes the logger from the factory contract itself.
- Clear the three corresponding rows from the style ledger.
