### PR TITLE
fix(pdump,web): preserve sub-millisecond precision in the web pcap export

### DIFF
--- a/modules/pdump/web/PdumpPage.tsx
+++ b/modules/pdump/web/PdumpPage.tsx
@@ -16,6 +16,7 @@ import FilterRow from './FilterRow';
 import ConfigStrip from './ConfigStrip';
 import PacketDrawer from './PacketDrawer';
 import DeleteConfigDialog from './DeleteConfigDialog';
+import { createPcapBuffer } from './pcap';
 import type { PdumpConfigInfo, CapturedPacket } from './types';
 import type { Command, PagePaletteContribution } from '@yanet/core/components/command-palette';
 import '@yanet/core/styles/chrome.scss';
@@ -26,53 +27,10 @@ const EMPTY_DIRTY_SET = new Set<string>();
 const QP_CONFIG = 'config';
 const QP_SEARCH = 'search';
 const EMPTY_PPS_HISTORY: number[] = [];
-const PCAP_GLOBAL_HEADER_BYTES = 24;
-const PCAP_PACKET_HEADER_BYTES = 16;
-const PCAP_LINKTYPE_ETHERNET = 1;
 
 const sanitizeFilenamePart = (value: string): string => {
     const sanitized = value.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
     return sanitized || 'capture';
-};
-
-const createPcapBuffer = (records: CapturedPacket[]): ArrayBuffer => {
-    let totalSize = PCAP_GLOBAL_HEADER_BYTES;
-    for (const packet of records) {
-        totalSize += PCAP_PACKET_HEADER_BYTES + packet.parsed.raw.length;
-    }
-
-    const buffer = new ArrayBuffer(totalSize);
-    const view = new DataView(buffer);
-    const bytes = new Uint8Array(buffer);
-
-    view.setUint32(0, 0xa1b2c3d4, true);
-    view.setUint16(4, 2, true);
-    view.setUint16(6, 4, true);
-    view.setInt32(8, 0, true);
-    view.setUint32(12, 0, true);
-    view.setUint32(16, 65535, true);
-    view.setUint32(20, PCAP_LINKTYPE_ETHERNET, true);
-
-    let offset = PCAP_GLOBAL_HEADER_BYTES;
-    for (const packet of records) {
-        const payload = packet.parsed.raw;
-        const capturedLength = payload.length;
-        const originalLength = packet.record.meta?.packet_len ?? capturedLength;
-        const timestampMs = packet.timestamp.getTime();
-        const tsSec = Math.floor(timestampMs / 1000);
-        const tsUsec = Math.floor((timestampMs % 1000) * 1000);
-
-        view.setUint32(offset, tsSec, true);
-        view.setUint32(offset + 4, tsUsec, true);
-        view.setUint32(offset + 8, capturedLength, true);
-        view.setUint32(offset + 12, originalLength, true);
-        offset += PCAP_PACKET_HEADER_BYTES;
-
-        bytes.set(payload, offset);
-        offset += capturedLength;
-    }
-
-    return buffer;
 };
 
 const PdumpPage: React.FC = () => {

--- a/modules/pdump/web/hooks.ts
+++ b/modules/pdump/web/hooks.ts
@@ -243,6 +243,14 @@ export const usePdumpCapture = (paused: boolean) => {
                         ? { ...record, data: undefined }
                         : record;
 
+                    // record.meta.timestamp is typed number | string, like the other
+                    // 64-bit wire fields in web/src/core/api/; the current gateway sends
+                    // a bare JSON number, and Number() normalises either branch. new Date
+                    // truncates the result to whole milliseconds, which is all this
+                    // Date's consumers need (e.g. PacketDrawer renders
+                    // fractionalSecondDigits: 3, PacketTable sorts by time). Code that
+                    // needs the sub-millisecond digits reads meta.timestamp directly, as
+                    // pcap.ts does.
                     const capturedPacket: CapturedPacket = {
                         id: packetIdRef.current++,
                         timestamp: record.meta?.timestamp

--- a/modules/pdump/web/pcap.test.ts
+++ b/modules/pdump/web/pcap.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import { createPcapBuffer } from './pcap';
+import type { CapturedPacket } from './types';
+
+const makePacket = (options: {
+    raw: Uint8Array;
+    timestamp: Date;
+    metaTimestamp?: number;
+    packetLen?: number;
+}): CapturedPacket => ({
+    id: 0,
+    timestamp: options.timestamp,
+    record: {
+        meta: {
+            timestamp: options.metaTimestamp,
+            packet_len: options.packetLen,
+        },
+    },
+    parsed: {
+        payloadOffset: 0,
+        payloadLength: options.raw.length,
+        raw: options.raw,
+    },
+});
+
+const readGlobalHeader = (buffer: ArrayBuffer) => {
+    const view = new DataView(buffer);
+    return {
+        magic: view.getUint32(0, true),
+        versionMajor: view.getUint16(4, true),
+        versionMinor: view.getUint16(6, true),
+        snaplen: view.getUint32(16, true),
+        linktype: view.getUint32(20, true),
+    };
+};
+
+const readPacketHeader = (buffer: ArrayBuffer, offset: number) => {
+    const view = new DataView(buffer);
+    return {
+        tsSec: view.getUint32(offset, true),
+        tsFrac: view.getUint32(offset + 4, true),
+        inclLen: view.getUint32(offset + 8, true),
+        origLen: view.getUint32(offset + 12, true),
+    };
+};
+
+// meta.timestamp is typed number | string (RecordMeta in web/src/core/api/pdump.ts).
+// The current gateway sends it as a bare JSON number: encoding/json marshals the
+// wire uint64 as a plain number, and JSON.parse rounds it to the nearest
+// representable double (~128 ns at epoch-nanosecond magnitude). The numeric
+// literals below are exact doubles chosen so the fixtures reflect what
+// production actually delivers, with no silent rounding hidden in the test
+// source.
+describe('createPcapBuffer', () => {
+    it('keeps sub-millisecond resolution the arrival Date would truncate', () => {
+        const packet = makePacket({
+            raw: new Uint8Array([1, 2, 3]),
+            timestamp: new Date(1754049600123),
+            metaTimestamp: 1754049600123456768,
+        });
+
+        const buffer = createPcapBuffer([packet]);
+        const header = readPacketHeader(buffer, 24);
+
+        expect(header.tsSec).toBe(1754049600);
+        expect(header.tsFrac).toBe(123456768);
+    });
+
+    it('handles a zero nanosecond remainder', () => {
+        const packet = makePacket({
+            raw: new Uint8Array([1]),
+            timestamp: new Date(1754049600000),
+            metaTimestamp: 1754049600000000000,
+        });
+
+        const buffer = createPcapBuffer([packet]);
+        const header = readPacketHeader(buffer, 24);
+
+        expect(header.tsSec).toBe(1754049600);
+        expect(header.tsFrac).toBe(0);
+    });
+
+    it('handles a remainder just below the second boundary', () => {
+        const packet = makePacket({
+            raw: new Uint8Array([1]),
+            timestamp: new Date(1754049600999),
+            metaTimestamp: 1754049600999998976,
+        });
+
+        const buffer = createPcapBuffer([packet]);
+        const header = readPacketHeader(buffer, 24);
+
+        expect(header.tsSec).toBe(1754049600);
+        expect(header.tsFrac).toBe(999998976);
+    });
+
+    it('writes a nanosecond-resolution pcap global header', () => {
+        const packet = makePacket({
+            raw: new Uint8Array([1, 2]),
+            timestamp: new Date(1754049600123),
+            metaTimestamp: 1754049600123456768,
+        });
+
+        const buffer = createPcapBuffer([packet]);
+        const header = readGlobalHeader(buffer);
+
+        expect(header.magic).toBe(0xa1b23c4d);
+        expect(header.versionMajor).toBe(2);
+        expect(header.versionMinor).toBe(4);
+        expect(header.snaplen).toBe(65535);
+        expect(header.linktype).toBe(1);
+    });
+
+    it('falls back to the arrival Date when the dataplane timestamp is absent', () => {
+        const packet = makePacket({
+            raw: new Uint8Array([1]),
+            timestamp: new Date(1754049600123),
+        });
+
+        const buffer = createPcapBuffer([packet]);
+        const header = readPacketHeader(buffer, 24);
+
+        expect(header.tsSec).toBe(1754049600);
+        expect(header.tsFrac).toBe(123000000);
+    });
+
+    it('writes payload and lengths correctly across multiple records', () => {
+        const rawA = new Uint8Array([1, 2, 3]);
+        const rawB = new Uint8Array([4, 5]);
+        const packetA = makePacket({
+            raw: rawA,
+            timestamp: new Date(1754049600000),
+            metaTimestamp: 1754049600000000000,
+            packetLen: 10,
+        });
+        const packetB = makePacket({
+            raw: rawB,
+            timestamp: new Date(1754049601000),
+            metaTimestamp: 1754049601000000000,
+        });
+
+        const buffer = createPcapBuffer([packetA, packetB]);
+
+        expect(buffer.byteLength).toBe(24 + (16 + rawA.length) + (16 + rawB.length));
+
+        const headerA = readPacketHeader(buffer, 24);
+        expect(headerA.inclLen).toBe(rawA.length);
+        expect(headerA.origLen).toBe(10);
+
+        const bytes = new Uint8Array(buffer);
+        expect(Array.from(bytes.slice(24 + 16, 24 + 16 + rawA.length))).toEqual(Array.from(rawA));
+
+        const offsetB = 24 + 16 + rawA.length;
+        const headerB = readPacketHeader(buffer, offsetB);
+        expect(headerB.inclLen).toBe(rawB.length);
+        expect(headerB.origLen).toBe(rawB.length);
+
+        expect(
+            Array.from(bytes.slice(offsetB + 16, offsetB + 16 + rawB.length))
+        ).toEqual(Array.from(rawB));
+    });
+});

--- a/modules/pdump/web/pcap.ts
+++ b/modules/pdump/web/pcap.ts
@@ -1,0 +1,87 @@
+import type { CapturedPacket } from './types';
+
+const PCAP_GLOBAL_HEADER_BYTES = 24;
+const PCAP_PACKET_HEADER_BYTES = 16;
+const PCAP_LINKTYPE_ETHERNET = 1;
+
+// Standard nanosecond-resolution pcap magic (libpcap's NSEC_TCPDUMP_MAGIC).
+//
+// The microsecond magic 0xa1b2c3d4 carries a microsecond fractional field, so
+// the magic and the fractional units below must change together.
+//
+// Matches the Rust CLI's pcap_file::TsResolution::NanoSecond writer so both
+// exports carry the same pcap variant. The CLI reads the dataplane's
+// protobuf record directly and is exact to 1 ns; this writer's precision is
+// bounded by the JSON transport (see the doc comment below).
+const PCAP_MAGIC_NANOSECOND = 0xa1b23c4d;
+
+const NANOS_PER_SECOND = 1000000000n;
+const NANOS_PER_MILLISECOND = 1000000;
+
+/**
+ * Builds a pcap file buffer from captured packets.
+ *
+ * Per-packet timestamps use the transport-delivered epoch-nanosecond value
+ * when available, falling back to the packet's arrival Date when it is
+ * absent. Reading meta.timestamp instead of the Date avoids the Date's
+ * truncation to whole milliseconds.
+ *
+ * The value is split into seconds and nanoseconds via BigInt rather than
+ * double arithmetic. This keeps the split exact by construction, independent
+ * of whether the input's magnitude happens to fall in a range where double
+ * division and modulo are exact; it does not recover precision that a double
+ * split would lose at typical epoch-nanosecond magnitudes.
+ *
+ * The gateway's JSON transport already rounds the value to the nearest
+ * representable double before it reaches this code, so the resolution here
+ * is bounded to roughly ±128 ns rather than exact.
+ */
+export const createPcapBuffer = (records: CapturedPacket[]): ArrayBuffer => {
+    let totalSize = PCAP_GLOBAL_HEADER_BYTES;
+    for (const packet of records) {
+        totalSize += PCAP_PACKET_HEADER_BYTES + packet.parsed.raw.length;
+    }
+
+    const buffer = new ArrayBuffer(totalSize);
+    const view = new DataView(buffer);
+    const bytes = new Uint8Array(buffer);
+
+    view.setUint32(0, PCAP_MAGIC_NANOSECOND, true);
+    view.setUint16(4, 2, true);
+    view.setUint16(6, 4, true);
+    view.setInt32(8, 0, true);
+    view.setUint32(12, 0, true);
+    view.setUint32(16, 65535, true);
+    view.setUint32(20, PCAP_LINKTYPE_ETHERNET, true);
+
+    let offset = PCAP_GLOBAL_HEADER_BYTES;
+    for (const packet of records) {
+        const payload = packet.parsed.raw;
+        const capturedLength = payload.length;
+        const originalLength = packet.record.meta?.packet_len ?? capturedLength;
+
+        let tsSec: number;
+        let tsNsec: number;
+        const rawTimestamp = packet.record.meta?.timestamp;
+        if (rawTimestamp) {
+            const ns = BigInt(rawTimestamp);
+            tsSec = Number(ns / NANOS_PER_SECOND);
+            tsNsec = Number(ns % NANOS_PER_SECOND);
+        } else {
+            const timestampMs = packet.timestamp.getTime();
+            tsSec = Math.floor(timestampMs / 1000);
+            tsNsec = (timestampMs % 1000) * NANOS_PER_MILLISECOND;
+        }
+
+        view.setUint32(offset, tsSec, true);
+        view.setUint32(offset + 4, tsNsec, true);
+        view.setUint32(offset + 8, capturedLength, true);
+        view.setUint32(offset + 12, originalLength, true);
+        offset += PCAP_PACKET_HEADER_BYTES;
+
+        bytes.set(payload, offset);
+        offset += capturedLength;
+    }
+
+    return buffer;
+};

--- a/web/src/core/api/pdump.ts
+++ b/web/src/core/api/pdump.ts
@@ -22,7 +22,7 @@ export interface ShowConfigResponse {
 }
 
 export interface RecordMeta {
-    timestamp?: string;
+    timestamp?: number | string;
     data_size?: number;
     packet_len?: number;
     worker_idx?: number;


### PR DESCRIPTION
The browser built its exported pcap timestamps from the JavaScript date it renders in the packet list. That date carries whole milliseconds, so the export discarded everything below a millisecond and its fractional field was always a round number — the same capture exported from the command-line tool disagreed by up to a millisecond per packet.

The export now reads the dataplane timestamp directly instead of going through that date, and writes the nanosecond-resolution pcap variant the command-line tool already writes, so both exports of one capture carry the same format and agree.

The declared type of the timestamp field claimed a shape the gateway does not send; it now matches the other 64-bit wire fields in the API layer. The date shown in the packet list is unchanged and remains at millisecond resolution, which is what the interface renders.

The pcap encoding moved out of the page component into its own module so it could be covered by a unit test, which pins the timestamp arithmetic, the file header, the fallback for records without a dataplane timestamp, and the payload layout.
