### PR TITLE
test(bird-adapter): benchmark the update decoder's production call shape

### DIFF
--- a/operators/bird-adapter/internal/bird/update_test.go
+++ b/operators/bird-adapter/internal/bird/update_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/yanet-platform/yanet2/operators/bird-adapter/internal/bird"
 	"github.com/yanet-platform/yanet2/operators/bird-adapter/internal/rib"
@@ -519,15 +520,17 @@ func TestDecodeUpdate(t *testing.T) {
 
 }
 
-// cpu: 13th Gen Intel(R) Core(TM) i7-13700H
-// Benchmark_update_Decode-20      30660841                39.61 ns/op            0 B/op          0 allocs/op
 func Benchmark_update_Decode(b *testing.B) {
 	route := &rib.Route{} // memset(0)
 	result := 0
 
+	// The production caller always supplies a logger option, so a bare call
+	// here would benchmark a path nothing runs.
+	log := zap.NewNop()
+
 	b.ResetTimer()
-	for b.Loop() {
-		decoder, err := bird.NewUpdateDecoder(dataIPv6WithLargeCommunities)
+	for range b.N {
+		decoder, err := bird.NewUpdateDecoder(dataIPv6WithLargeCommunities, bird.WithUpdateDecoderLog(log))
 		if err != nil {
 			b.Logf("unexpected error: %v", err)
 			b.FailNow()


### PR DESCRIPTION
- Constructs the decoder the way the export parser does, so the benchmark exercises the option path that actually runs rather than a call shape used only by tests. The previous form could not observe a regression on that path, and nearly failed to: a change costing 184 ns, 152 bytes and 3 allocations per route update moved this benchmark by 8 bytes and one allocation.
- Switches the loop to a plain iteration count. The benchmark helper suppresses inlining inside its loop body, which made the option closure heap-allocate even though the real call site provably stacks it, so the harness distorted the exact quantity the benchmark exists to protect. Measured side by side, the helper reports 128 B and 9 allocations per operation against 112 B and 8 for the real shape.
- Drops a pinned result recorded on another machine. It had drifted by two orders of magnitude, and its stale claim of zero allocations was quoted back as evidence during review.