### PR TITLE
chore(gitignore): match the agent and scratch trees when they are symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,15 +132,21 @@ deploy/packages/
 ### AI ###
 .ai
 .cursor/
-.claude/agent-memory/
+
+# Worktree symlinks: a worktree may symlink these trees into the main
+# checkout, and a directory-only pattern does not match a symlink.
+.claude/agent-memory
 .claude/settings.*.json
-.claude/skills/loadtest-hw/
-.claude/worktrees/
+.claude/skills/loadtest-hw
+.agents/skills/loadtest-hw
+.claude/worktrees
 /.codex/
-/.agent-state/
+/.agent-state
 
 ### Uncategorized ###
-.arch/
+# Worktree symlinks: a worktree may symlink this tree into the main
+# checkout, and a directory-only pattern does not match a symlink.
+.arch
 .assets/
 .docs/
 .secrets/


### PR DESCRIPTION
A worktree symlinks the agent-memory, worktree and scratch trees into the main checkout, and a pattern ending in a slash matches directories only — so none of them were ignored inside a worktree, leaving them one wildcard stage away from being committed as absolute-path symlinks.

The gap was already diagnosed and worked around in this clone's own per-clone exclude file, which a fresh clone or a second operator does not have. The private sibling repository already took the same fix.

Only entries naming a tree a worktree may symlink lose their slash. Build artefacts keep theirs: they are real directories everywhere, and a symlinked one would fail loudly rather than silently. Verified on a real symlink that the slashed form matches nothing and the slashless one matches, and that no tracked file becomes ignored.

The Codex twin of the locally-installed skill directory was missing from the ignore list as well, and is added beside its counterpart.