### PR TITLE
docs(pdump): document capture timestamp origin and resolution in the CLI help

### DIFF
--- a/modules/pdump/cli/src/args.rs
+++ b/modules/pdump/cli/src/args.rs
@@ -60,6 +60,17 @@ pub struct ReadCmd {
     ///
     /// Distinct from the global `--format`, which controls how CLI messages
     /// (errors, success, structured data) are rendered.
+    ///
+    /// Timestamp origin differs by encoding. `text` and `pretty` render an
+    /// offset from the first record received, so that record itself reads
+    /// zero, and the offset is displayed in a clock-shaped form despite
+    /// being relative. `pcap` and `pcap-ng` carry the absolute dataplane
+    /// clock value instead.
+    ///
+    /// Timestamps resolve to a worker's polling round rather than to an
+    /// individual packet, so every record captured in one round shares a
+    /// single value. Repeated identical timestamps, including several
+    /// leading zeros in the relative forms, are expected.
     #[clap(long, short = 'f', value_enum, default_value_t = DumpOutputFormat::Text)]
     pub dump_format: DumpOutputFormat,
 


### PR DESCRIPTION
The read command's output encodings disagree on what a timestamp means, and nothing said so.

- The human-readable encodings render an offset from the first record received, so that record itself reads zero, while the capture-file encodings carry the absolute dataplane clock value. The same packet therefore shows different numbers depending on how the capture is read.
- The relative form is displayed in a clock-shaped layout, which invites reading it as a wall-clock time.
- Capture timestamps resolve to a worker's polling round rather than to an individual packet, so every record taken in one round shares a single value. Runs of identical timestamps are expected in every encoding, including the capture files, and are not a defect.

Documentation only. No behavioral change, and the note was confirmed to render in the long help of the real binary.