### PR TITLE
test(auth): cover authenticator construction and the enabled-auth path

### DIFF
--- a/controlplane/internal/auth/basic/factory_test.go
+++ b/controlplane/internal/auth/basic/factory_test.go
@@ -1,0 +1,108 @@
+package basic_test
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/basic"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+)
+
+// decodeConfigNode parses text as the "config: ..." wrapper production uses,
+// and returns the inner node exactly as the authenticator entry's nested
+// configuration node in the control-plane auth configuration would.
+func decodeConfigNode(t *testing.T, text string) *yaml.Node {
+	t.Helper()
+
+	var wrapper struct {
+		Config yaml.Node `yaml:"config"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(text), &wrapper))
+
+	return &wrapper.Config
+}
+
+// writeCredentialsFile writes a basic_auth.yaml file with one entry for
+// username, whose password_hash is a bcrypt hash of password.
+func writeCredentialsFile(t *testing.T, username, password string) string {
+	t.Helper()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "basic_auth.yaml")
+	content := "credentials:\n  - username: " + username +
+		"\n    password_hash: " + string(hash) + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// basicToken builds a "Basic <base64(username:password)>" token.
+func basicToken(username, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+}
+
+// TestNewFromConfig verifies that a valid configuration builds an
+// authenticator backed by the configured credentials file, able to
+// authenticate a correct password and reject an incorrect one.
+func TestNewFromConfig(t *testing.T) {
+	credentialsPath := writeCredentialsFile(t, "alice", "s3cret")
+
+	rawConfig := decodeConfigNode(t, "config:\n  credentials_path: "+credentialsPath+"\n")
+
+	authenticator, err := basic.NewFromConfig(rawConfig)
+	require.NoError(t, err)
+	require.Equal(t, "basic", authenticator.Name())
+
+	validToken := basicToken("alice", "s3cret")
+	require.True(t, authenticator.IsTokenSupported(validToken))
+	require.False(t, authenticator.IsTokenSupported("sshkey abc"))
+
+	requestInfo := &core.RequestInfo{FullMethod: "/test.Service/Method"}
+
+	authInfo, err := authenticator.Authenticate(t.Context(), validToken, requestInfo)
+	require.NoError(t, err)
+	require.Equal(t, &core.AuthInfo{Username: "alice", AuthMethod: "basic"}, authInfo)
+
+	wrongToken := basicToken("alice", "wrong-password")
+	_, err = authenticator.Authenticate(t.Context(), wrongToken, requestInfo)
+	require.Error(t, err)
+}
+
+// TestNewFromConfigErrors verifies that malformed or incomplete
+// configurations are rejected before an authenticator is built.
+func TestNewFromConfigErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+	}{
+		{
+			name: "missing credentials_path",
+			text: "config: {}\n",
+		},
+		{
+			name: "nonexistent credentials file",
+			text: "config:\n  credentials_path: /nonexistent/basic_auth.yaml\n",
+		},
+		{
+			name: "scalar config node",
+			text: "config: \"oops\"\n",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			rawConfig := decodeConfigNode(t, testCase.text)
+
+			_, err := basic.NewFromConfig(rawConfig)
+			require.Error(t, err)
+		})
+	}
+}

--- a/controlplane/internal/auth/manager_test.go
+++ b/controlplane/internal/auth/manager_test.go
@@ -1,24 +1,33 @@
-package auth
+package auth_test
 
 import (
-	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gopkg.in/yaml.v3"
 
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth"
 	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
 )
 
 func TestManager_Authenticate(t *testing.T) {
-	cfg := &Config{
+	config := &auth.Config{
 		Disabled: true,
 	}
-	m, err := NewManager(cfg)
+	m, err := auth.NewManager(config)
 	if err != nil {
 		t.Fatalf("NewManager() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name  string
@@ -63,14 +72,14 @@ func TestManager_Authenticate(t *testing.T) {
 
 func TestManager_Authorize(t *testing.T) {
 	log := zap.NewNop()
-	m, err := NewManager(&Config{
+	m, err := auth.NewManager(&auth.Config{
 		Disabled: true,
-	}, WithLog(log))
+	}, auth.WithLog(log))
 	if err != nil {
 		t.Fatalf("NewManager() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a test principal.
 	requestInfo := &core.RequestInfo{FullMethod: "/test.Service/Method"}
@@ -101,6 +110,234 @@ func TestManager_Authorize(t *testing.T) {
 			err := m.Authorize(ctx, principal, tt.fullMethod)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Authorize() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// writeIdentitiesFile writes an identities.yaml file with alice (active,
+// operators group) and mallory (disabled, operators group).
+func writeIdentitiesFile(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "identities.yaml")
+	content := "identities:\n" +
+		"  - username: alice\n" +
+		"    groups: [operators]\n" +
+		"  - username: mallory\n" +
+		"    groups: [operators]\n" +
+		"    disabled: true\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// writePermissionsFile writes a permissions.yaml file granting the
+// operators group access to every method of test.Service.
+func writePermissionsFile(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "permissions.yaml")
+	content := "permissions:\n" +
+		"  groups:\n" +
+		"    - name: operators\n" +
+		"      permissions:\n" +
+		"        - \"/test.Service/*\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// writeBasicCredentialsFile writes a basic_auth.yaml file with bcrypt
+// hashes for alice, mallory, and ghost, all sharing the same password.
+func writeBasicCredentialsFile(t *testing.T) string {
+	t.Helper()
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("s3cret"), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "basic_auth.yaml")
+	content := "credentials:\n" +
+		"  - username: alice\n" +
+		"    password_hash: " + string(hash) + "\n" +
+		"  - username: mallory\n" +
+		"    password_hash: " + string(hash) + "\n" +
+		"  - username: ghost\n" +
+		"    password_hash: " + string(hash) + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// basicToken builds a "Basic <base64(username:password)>" token.
+func basicToken(username, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(username+":"+password))
+}
+
+// buildEnabledConfig unmarshals real YAML into auth.Config, wiring a file
+// identity provider, an RBAC permission store, and a basic authenticator, the
+// same way production configuration is parsed.
+func buildEnabledConfig(t *testing.T) auth.Config {
+	t.Helper()
+
+	identitiesPath := writeIdentitiesFile(t)
+	permissionsPath := writePermissionsFile(t)
+	credentialsPath := writeBasicCredentialsFile(t)
+
+	text := "disabled: false\n" +
+		"identity_providers:\n" +
+		"  - type: file\n" +
+		"    path: " + identitiesPath + "\n" +
+		"permissions_path: " + permissionsPath + "\n" +
+		"authenticators:\n" +
+		"  - type: basic\n" +
+		"    config:\n" +
+		"      credentials_path: " + credentialsPath + "\n"
+
+	var config auth.Config
+	require.NoError(t, yaml.Unmarshal([]byte(text), &config))
+
+	return config
+}
+
+// TestNewManagerEnabled verifies that an enabled Manager, built entirely
+// from YAML configuration, wires the basic authenticator factory and the
+// file identity provider into a working authentication and authorization
+// path.
+func TestNewManagerEnabled(t *testing.T) {
+	config := buildEnabledConfig(t)
+
+	manager, err := auth.NewManager(&config)
+	require.NoError(t, err)
+
+	requestInfo := &core.RequestInfo{FullMethod: "/test.Service/Method"}
+
+	t.Run("known active user authenticates with group and method", func(t *testing.T) {
+		principal, err := manager.Authenticate(t.Context(), basicToken("alice", "s3cret"), requestInfo)
+		require.NoError(t, err)
+		assert.Equal(t, "alice", principal.User)
+		assert.Equal(t, []string{"operators"}, principal.Groups)
+		assert.Equal(t, "basic", principal.AuthMethod)
+		assert.False(t, principal.IsAnonymous)
+
+		require.NoError(t, manager.Authorize(t.Context(), principal, "/test.Service/Method"))
+
+		err = manager.Authorize(t.Context(), principal, "/other.Service/Method")
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+	})
+
+	t.Run("unsupported token falls through to none authenticator", func(t *testing.T) {
+		principal, err := manager.Authenticate(t.Context(), "bearer whatever", requestInfo)
+		require.NoError(t, err)
+		assert.True(t, principal.IsAnonymous)
+		assert.Equal(t, "none", principal.AuthMethod)
+
+		err = manager.Authorize(t.Context(), principal, requestInfo.FullMethod)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+	})
+
+	t.Run("disabled identity fails authentication", func(t *testing.T) {
+		_, err := manager.Authenticate(t.Context(), basicToken("mallory", "s3cret"), requestInfo)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+		assert.Contains(t, st.Message(), `"mallory" is disabled`)
+	})
+
+	t.Run("valid credentials without an identity entry fail authentication", func(t *testing.T) {
+		_, err := manager.Authenticate(t.Context(), basicToken("ghost", "s3cret"), requestInfo)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+		assert.Contains(t, st.Message(), "identity lookup failed")
+	})
+}
+
+// TestNewManagerConfigErrors verifies that NewManager rejects invalid
+// configurations, including binding failures inside the per-type
+// authenticator factories registered in the factory registry.
+func TestNewManagerConfigErrors(t *testing.T) {
+	validConfig := buildEnabledConfig(t)
+
+	tests := []struct {
+		name        string
+		mutate      func(config auth.Config) auth.Config
+		errContains []string
+	}{
+		{
+			name: "unknown authenticator type",
+			mutate: func(config auth.Config) auth.Config {
+				config.Authenticators = []auth.AuthenticatorConfig{
+					{Type: "unknown-method"},
+				}
+				return config
+			},
+			errContains: []string{"unknown-method"},
+		},
+		{
+			name: "unknown identity provider type",
+			mutate: func(config auth.Config) auth.Config {
+				config.IdentityProviders = []auth.IdentityProviderConfig{
+					{Type: "ldap"},
+				}
+				return config
+			},
+			errContains: []string{"ldap"},
+		},
+		{
+			name: "no identity providers configured",
+			mutate: func(config auth.Config) auth.Config {
+				config.IdentityProviders = nil
+				return config
+			},
+			errContains: []string{"no identity providers configured"},
+		},
+		{
+			name: "permissions_path pointing at a nonexistent file",
+			mutate: func(config auth.Config) auth.Config {
+				config.PermissionsPath = "/nonexistent/permissions.yaml"
+				return config
+			},
+			errContains: []string{"permissions"},
+		},
+		{
+			name: "sshkey registry binding surfaces the inner factory error",
+			mutate: func(config auth.Config) auth.Config {
+				var configNode yaml.Node
+				require.NoError(t, yaml.Unmarshal([]byte("{}\n"), &configNode))
+				config.Authenticators = []auth.AuthenticatorConfig{
+					{Type: "sshkey", Config: configNode},
+				}
+				return config
+			},
+			errContains: []string{"sshkey", "keys_path is required"},
+		},
+		{
+			name: "sshcert registry binding surfaces the inner factory error",
+			mutate: func(config auth.Config) auth.Config {
+				var configNode yaml.Node
+				require.NoError(t, yaml.Unmarshal([]byte("{}\n"), &configNode))
+				config.Authenticators = []auth.AuthenticatorConfig{
+					{Type: "sshcert", Config: configNode},
+				}
+				return config
+			},
+			errContains: []string{"sshcert", "ca_sources is required"},
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			config := testCase.mutate(validConfig)
+
+			_, err := auth.NewManager(&config)
+			require.Error(t, err)
+			for _, want := range testCase.errContains {
+				assert.Contains(t, err.Error(), want)
 			}
 		})
 	}

--- a/controlplane/internal/auth/sshcert/factory_test.go
+++ b/controlplane/internal/auth/sshcert/factory_test.go
@@ -1,0 +1,303 @@
+package sshcert_test
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/krl"
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshcert"
+)
+
+// decodeConfigNode parses text as the "config: ..." wrapper production uses,
+// and returns the inner node exactly as the authenticator entry's nested
+// configuration node in the control-plane auth configuration would.
+func decodeConfigNode(t *testing.T, text string) *yaml.Node {
+	t.Helper()
+
+	var wrapper struct {
+		Config yaml.Node `yaml:"config"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(text), &wrapper))
+
+	return &wrapper.Config
+}
+
+// generateECDSASigner creates a new ECDSA P-256 SSH signer, the only key
+// type sshcert supports.
+func generateECDSASigner(t *testing.T) ssh.Signer {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+
+	return signer
+}
+
+// generateUserCert creates a user certificate for username, signed by
+// caSigner, and returns the certificate along with the signer for its
+// subject key.
+func generateUserCert(t *testing.T, caSigner ssh.Signer, username string, serial uint64) (*ssh.Certificate, ssh.Signer) {
+	t.Helper()
+
+	userSigner := generateECDSASigner(t)
+
+	cert := &ssh.Certificate{
+		CertType:        ssh.UserCert,
+		Key:             userSigner.PublicKey(),
+		Serial:          serial,
+		KeyId:           username + "-cert",
+		ValidPrincipals: []string{username},
+		ValidAfter:      uint64(time.Now().Add(-1 * time.Hour).Unix()),
+		ValidBefore:     uint64(time.Now().Add(24 * time.Hour).Unix()),
+		Permissions: ssh.Permissions{
+			Extensions: map[string]string{"permit-pty": ""},
+		},
+	}
+
+	require.NoError(t, cert.SignCert(rand.Reader, caSigner))
+
+	return cert, userSigner
+}
+
+// writeCAFile writes an authorized_keys-format CA file containing the
+// public keys of signers.
+func writeCAFile(t *testing.T, signers ...ssh.Signer) string {
+	t.Helper()
+
+	var content bytes.Buffer
+	for _, signer := range signers {
+		content.Write(ssh.MarshalAuthorizedKey(signer.PublicKey()))
+	}
+
+	path := filepath.Join(t.TempDir(), "ca.pub")
+	require.NoError(t, os.WriteFile(path, content.Bytes(), 0o600))
+
+	return path
+}
+
+// buildKRL creates a KRL binary revoking revokedSerials for the given CA.
+func buildKRL(t *testing.T, caSigner ssh.Signer, revokedSerials []uint64) []byte {
+	t.Helper()
+
+	serialList := krl.KRLCertificateSerialList(revokedSerials)
+
+	k := &krl.KRL{
+		Sections: []krl.KRLSection{
+			&krl.KRLCertificateSection{
+				CA: caSigner.PublicKey(),
+				Sections: []krl.KRLCertificateSubsection{
+					&serialList,
+				},
+			},
+		},
+	}
+
+	data, err := k.Marshal(rand.Reader)
+	require.NoError(t, err)
+
+	return data
+}
+
+// writeKRLFile writes data revoking revokedSerials for caSigner to a temp
+// file and returns its path.
+func writeKRLFile(t *testing.T, caSigner ssh.Signer, revokedSerials []uint64) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "revoked.krl")
+	require.NoError(t, os.WriteFile(path, buildKRL(t, caSigner, revokedSerials), 0o600))
+
+	return path
+}
+
+// signCertToken builds a "sshcert <base64-json>" token binding cert, signed
+// by userSigner (the certificate's subject key).
+func signCertToken(
+	t *testing.T,
+	userSigner ssh.Signer,
+	cert *ssh.Certificate,
+	method string,
+	timestamp int64,
+	nonce string,
+) string {
+	t.Helper()
+
+	token := &sshcert.Token{
+		Version:     1,
+		Certificate: base64.StdEncoding.EncodeToString(cert.Marshal()),
+		Timestamp:   timestamp,
+		Nonce:       nonce,
+		Method:      method,
+	}
+
+	data := fmt.Appendf(nil,
+		"version=%d\ncertificate=%s\ntimestamp=%d\nnonce=%s\nmethod=%s",
+		token.Version, token.Certificate, token.Timestamp, token.Nonce, token.Method,
+	)
+
+	signature, err := userSigner.Sign(rand.Reader, data)
+	require.NoError(t, err)
+	token.Signature = base64.StdEncoding.EncodeToString(ssh.Marshal(signature))
+
+	jsonBytes, err := json.Marshal(token)
+	require.NoError(t, err)
+
+	return "sshcert " + base64.StdEncoding.EncodeToString(jsonBytes)
+}
+
+// newAuthenticator builds an sshcert.Authenticator from rawConfig and
+// registers its Close for cleanup so the background refresh goroutine does
+// not leak past the test.
+func newAuthenticator(t *testing.T, rawConfig *yaml.Node) core.Authenticator {
+	t.Helper()
+
+	authenticator, err := sshcert.NewFromConfig(rawConfig)
+	require.NoError(t, err)
+	t.Cleanup(func() { authenticator.(*sshcert.Authenticator).Close() })
+
+	return authenticator
+}
+
+// TestNewFromConfigCASources verifies that ca_sources is really wired into
+// the composed CA store: a cert signed by either configured CA
+// authenticates, while a cert signed by a third, unconfigured CA is
+// rejected.
+func TestNewFromConfigCASources(t *testing.T) {
+	caOne := generateECDSASigner(t)
+	caTwo := generateECDSASigner(t)
+	caThree := generateECDSASigner(t)
+
+	rawConfig := decodeConfigNode(t, "config:\n  ca_sources:\n    - "+
+		writeCAFile(t, caOne)+"\n    - "+writeCAFile(t, caTwo)+"\n")
+
+	authenticator := newAuthenticator(t, rawConfig)
+
+	method := "/test.Service/Method"
+	requestInfo := &core.RequestInfo{FullMethod: method}
+
+	tests := []struct {
+		name string
+		ca   ssh.Signer
+	}{
+		{name: "caOne", ca: caOne},
+		{name: "caTwo", ca: caTwo},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			cert, userSigner := generateUserCert(t, testCase.ca, "alice", 1)
+			token := signCertToken(t, userSigner, cert, method, time.Now().UnixNano(), "nonce-1")
+
+			authInfo, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+			require.NoError(t, err)
+			require.Equal(t, &core.AuthInfo{Username: "alice", AuthMethod: "sshcert"}, authInfo)
+		})
+	}
+
+	t.Run("unconfigured CA rejected", func(t *testing.T) {
+		cert, userSigner := generateUserCert(t, caThree, "alice", 2)
+		token := signCertToken(t, userSigner, cert, method, time.Now().UnixNano(), "nonce-1")
+
+		_, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "CA verification failed")
+	})
+}
+
+// TestNewFromConfigKRLSource verifies that krl_source is really wired into
+// the revocation checker: the same certificate is rejected once its serial
+// is present in a configured KRL, and accepted when krl_source is omitted.
+func TestNewFromConfigKRLSource(t *testing.T) {
+	ca := generateECDSASigner(t)
+	caPath := writeCAFile(t, ca)
+	cert, userSigner := generateUserCert(t, ca, "alice", 42)
+
+	method := "/test.Service/Method"
+	requestInfo := &core.RequestInfo{FullMethod: method}
+
+	t.Run("krl_source revokes the certificate", func(t *testing.T) {
+		krlPath := writeKRLFile(t, ca, []uint64{42})
+		rawConfig := decodeConfigNode(t, "config:\n  ca_sources:\n    - "+caPath+
+			"\n  krl_source: "+krlPath+"\n")
+
+		authenticator := newAuthenticator(t, rawConfig)
+		token := signCertToken(t, userSigner, cert, method, time.Now().UnixNano(), "nonce-1")
+
+		_, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "certificate revocation check failed")
+	})
+
+	t.Run("omitted krl_source authenticates", func(t *testing.T) {
+		rawConfig := decodeConfigNode(t, "config:\n  ca_sources:\n    - "+caPath+"\n")
+
+		authenticator := newAuthenticator(t, rawConfig)
+		token := signCertToken(t, userSigner, cert, method, time.Now().UnixNano(), "nonce-1")
+
+		authInfo, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+		require.NoError(t, err)
+		require.Equal(t, &core.AuthInfo{Username: "alice", AuthMethod: "sshcert"}, authInfo)
+	})
+}
+
+// TestNewFromConfigErrors verifies that malformed or incomplete
+// configurations are rejected before an authenticator is built.
+func TestNewFromConfigErrors(t *testing.T) {
+	ca := generateECDSASigner(t)
+	caPath := writeCAFile(t, ca)
+
+	emptyCAPath := filepath.Join(t.TempDir(), "empty.pub")
+	require.NoError(t, os.WriteFile(emptyCAPath, []byte("# no keys here\n"), 0o600))
+
+	tests := []struct {
+		name string
+		text string
+	}{
+		{
+			name: "empty ca_sources",
+			text: "config: {}\n",
+		},
+		{
+			name: "nonexistent ca_sources entry",
+			text: "config:\n  ca_sources:\n    - /nonexistent/ca.pub\n",
+		},
+		{
+			name: "CA file with no valid keys",
+			text: "config:\n  ca_sources:\n    - " + emptyCAPath + "\n",
+		},
+		{
+			name: "nonexistent krl_source",
+			text: "config:\n  ca_sources:\n    - " + caPath +
+				"\n  krl_source: /nonexistent/revoked.krl\n",
+		},
+		{
+			name: "scalar config node",
+			text: "config: \"oops\"\n",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			rawConfig := decodeConfigNode(t, testCase.text)
+
+			_, err := sshcert.NewFromConfig(rawConfig)
+			require.Error(t, err)
+		})
+	}
+}

--- a/controlplane/internal/auth/sshkey/factory_test.go
+++ b/controlplane/internal/auth/sshkey/factory_test.go
@@ -1,0 +1,192 @@
+package sshkey_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/core"
+	"github.com/yanet-platform/yanet2/controlplane/internal/auth/sshkey"
+)
+
+// decodeConfigNode parses text as the "config: ..." wrapper production uses,
+// and returns the inner node exactly as the authenticator entry's nested
+// configuration node in the control-plane auth configuration would.
+func decodeConfigNode(t *testing.T, text string) *yaml.Node {
+	t.Helper()
+
+	var wrapper struct {
+		Config yaml.Node `yaml:"config"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(text), &wrapper))
+
+	return &wrapper.Config
+}
+
+// generateEd25519Signer creates a new Ed25519 SSH signer.
+func generateEd25519Signer(t *testing.T) ssh.Signer {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	require.NoError(t, err)
+
+	return signer
+}
+
+// writeKeysFile writes a keys.yaml file with one entry for username, whose
+// public_key is the authorized_keys line for signer.
+func writeKeysFile(t *testing.T, username string, signer ssh.Signer) string {
+	t.Helper()
+
+	line := strings.TrimSpace(string(ssh.MarshalAuthorizedKey(signer.PublicKey())))
+
+	path := filepath.Join(t.TempDir(), "keys.yaml")
+	content := "keys:\n  - username: " + username +
+		"\n    public_key: \"" + line + "\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}
+
+// signToken builds a "sshkey <base64-json>" token signed by signer.
+func signToken(
+	t *testing.T,
+	signer ssh.Signer,
+	username, method string,
+	timestamp int64,
+	nonce string,
+) string {
+	t.Helper()
+
+	token := &sshkey.Token{
+		Version:   1,
+		Username:  username,
+		Timestamp: timestamp,
+		Nonce:     nonce,
+		Method:    method,
+	}
+
+	data := fmt.Appendf(nil,
+		"version=%d\nusername=%s\ntimestamp=%d\nnonce=%s\nmethod=%s",
+		token.Version, token.Username, token.Timestamp, token.Nonce, token.Method,
+	)
+
+	signature, err := signer.Sign(rand.Reader, data)
+	require.NoError(t, err)
+	token.Signature = base64.StdEncoding.EncodeToString(ssh.Marshal(signature))
+
+	jsonBytes, err := json.Marshal(token)
+	require.NoError(t, err)
+
+	return "sshkey " + base64.StdEncoding.EncodeToString(jsonBytes)
+}
+
+// TestNewFromConfig verifies that a valid configuration builds an
+// authenticator backed by the configured keys file, able to authenticate a
+// token signed by a registered key.
+func TestNewFromConfig(t *testing.T) {
+	signer := generateEd25519Signer(t)
+	keysPath := writeKeysFile(t, "alice", signer)
+
+	rawConfig := decodeConfigNode(t, "config:\n  keys_path: "+keysPath+"\n")
+
+	authenticator, err := sshkey.NewFromConfig(rawConfig)
+	require.NoError(t, err)
+
+	method := "/test.Service/Method"
+	requestInfo := &core.RequestInfo{FullMethod: method}
+	token := signToken(t, signer, "alice", method, time.Now().UnixNano(), "nonce-1")
+
+	authInfo, err := authenticator.Authenticate(t.Context(), token, requestInfo)
+	require.NoError(t, err)
+	require.Equal(t, &core.AuthInfo{Username: "alice", AuthMethod: "sshkey"}, authInfo)
+}
+
+// TestNewFromConfigTimeWindow verifies that time_window from the config is
+// actually wired into the authenticator: an explicit wide window accepts a
+// stale token, while the default (narrow) window rejects the same token.
+func TestNewFromConfigTimeWindow(t *testing.T) {
+	signer := generateEd25519Signer(t)
+	keysPath := writeKeysFile(t, "alice", signer)
+
+	method := "/test.Service/Method"
+	requestInfo := &core.RequestInfo{FullMethod: method}
+	staleTimestamp := time.Now().Add(-10 * time.Minute).UnixNano()
+	token := signToken(t, signer, "alice", method, staleTimestamp, "nonce-1")
+
+	t.Run("wide time_window accepts a stale token", func(t *testing.T) {
+		rawConfig := decodeConfigNode(t,
+			"config:\n  keys_path: "+keysPath+"\n  time_window: 1h\n")
+
+		authenticator, err := sshkey.NewFromConfig(rawConfig)
+		require.NoError(t, err)
+
+		_, err = authenticator.Authenticate(t.Context(), token, requestInfo)
+		require.NoError(t, err)
+	})
+
+	t.Run("default time_window rejects the same stale token", func(t *testing.T) {
+		rawConfig := decodeConfigNode(t, "config:\n  keys_path: "+keysPath+"\n")
+
+		authenticator, err := sshkey.NewFromConfig(rawConfig)
+		require.NoError(t, err)
+
+		_, err = authenticator.Authenticate(t.Context(), token, requestInfo)
+		require.Error(t, err)
+	})
+}
+
+// TestNewFromConfigErrors verifies that malformed or incomplete
+// configurations are rejected before an authenticator is built.
+func TestNewFromConfigErrors(t *testing.T) {
+	unparseableKeysPath := filepath.Join(t.TempDir(), "keys.yaml")
+	require.NoError(t, os.WriteFile(unparseableKeysPath,
+		[]byte("keys:\n  - username: alice\n    public_key: \"not a key\"\n"),
+		0o600,
+	))
+
+	tests := []struct {
+		name string
+		text string
+	}{
+		{
+			name: "missing keys_path",
+			text: "config: {}\n",
+		},
+		{
+			name: "nonexistent keys file",
+			text: "config:\n  keys_path: /nonexistent/keys.yaml\n",
+		},
+		{
+			name: "unparseable public_key",
+			text: "config:\n  keys_path: " + unparseableKeysPath + "\n",
+		},
+		{
+			name: "scalar config node",
+			text: "config: \"oops\"\n",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			rawConfig := decodeConfigNode(t, testCase.text)
+
+			_, err := sshkey.NewFromConfig(rawConfig)
+			require.Error(t, err)
+		})
+	}
+}

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -238,8 +238,6 @@ testctx:controlplane/internal/auth/interceptor_test.go:TestExtractToken:Backgrou
 testctx:controlplane/internal/auth/interceptor_test.go:TestExtractToken:Background:2  # legacy: migrate to t.Context()
 testctx:controlplane/internal/auth/interceptor_test.go:TestStreamServerInterceptor:Background:1  # legacy: migrate to t.Context()
 testctx:controlplane/internal/auth/interceptor_test.go:TestUnaryServerInterceptor:Background:1  # legacy: migrate to t.Context()
-testctx:controlplane/internal/auth/manager_test.go:TestManager_Authenticate:Background:1  # legacy: migrate to t.Context()
-testctx:controlplane/internal/auth/manager_test.go:TestManager_Authorize:Background:1  # legacy: migrate to t.Context()
 testctx:controlplane/internal/auth/none/authenticator_test.go:TestNoneAuthenticator_Authenticate:Background:1  # legacy: migrate to t.Context()
 testctx:controlplane/internal/auth/sshcert/authenticator_test.go:TestAuthenticator_ExpiredCertificate:Background:1  # legacy: migrate to t.Context()
 testctx:controlplane/internal/auth/sshcert/authenticator_test.go:TestAuthenticator_ExpiredTimestamp:Background:1  # legacy: migrate to t.Context()
@@ -298,7 +296,6 @@ testpkg:controlplane/gateway/readiness_test.go:gateway:1  # legacy: migrate to t
 testpkg:controlplane/gateway/registry_test.go:gateway:1  # legacy: migrate to the external test package
 testpkg:controlplane/gateway/runner_test.go:gateway:1  # legacy: migrate to the external test package
 testpkg:controlplane/internal/auth/interceptor_test.go:auth:1  # legacy: migrate to the external test package
-testpkg:controlplane/internal/auth/manager_test.go:auth:1  # legacy: migrate to the external test package
 testpkg:controlplane/internal/auth/none/authenticator_test.go:none:1  # legacy: migrate to the external test package
 testpkg:controlplane/internal/auth/sshcert/authenticator_test.go:sshcert:1  # legacy: migrate to the external test package
 testpkg:controlplane/internal/auth/sshcert/ca_store_test.go:sshcert:1  # legacy: migrate to the external test package


### PR DESCRIPTION
Both existing manager tests built the manager with authentication disabled, which returns before the factory registry is ever consulted, so nothing populated the authenticators list or reached any of the three authenticator factories. The whole package family was unguarded against exactly the class of change a recent options refactor made to it.

- Adds a construction test per factory package that decodes the real configuration node and then authenticates a freshly issued credential end to end.
- Pins the wiring each test names in both directions: the credential, key and certificate-authority sources, the timestamp tolerance window, and the revocation source each have a case that fails if the configured value stops reaching the authenticator.
- Adds an enabled-auth manager test built from real configuration, covering the factory registry, the file identity provider and role-based authorization, including the disabled-account, unknown-account and anonymous-fallback paths.
- Asserts the message each factory raises for an incomplete configuration, which also pins which factory the registry binds to each type name.
- Retires three style-allowlist rows, since migrating the manager tests to the external test package resolves them.