### PR TITLE
docs(lint): document the missing stylelint key forms and per-check rationale

### DIFF
--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -7,15 +7,18 @@
 # where <check> is one of logger, private, testpkg, receiver, loopindex,
 # maplit, grpcdial, sugar, zapmsg, zapkey, testctx, handlerblank, barenew,
 # or loggerlast. <name> is the enclosing function or method
-# ("RecvType.MethodName" or "FuncName"), a struct field
-# ("TypeName.FieldName" for loggerlast), a package-level var/const, or the
-# enclosing name followed by one or more ":"-separated segments identifying
-# the offending site, when several violations of one check can share an
-# enclosing declaration. The private check's key already carries an extra
-# segment of its own ("<path>:<func>:<expr>"), which the leading "private:"
-# prefix does not disturb: parsing only requires a ":" to be present
-# somewhere in the key. <ordinal> is a 1-based count of the violation's
-# position, in source order, among every other violation sharing the same
+# ("RecvType.MethodName" or "FuncName" — an interface method takes the same
+# "TypeName.MethodName" shape with no receiver involved), a struct field
+# ("TypeName.FieldName" for loggerlast), a bare type name when the
+# enclosing declaration is a type, a package-level var/const, a file's own
+# package clause name (testpkg), or the enclosing name followed by one or
+# more ":"-separated segments identifying the offending site, when several
+# violations of one check can share an enclosing declaration. The private
+# check's key already carries an extra segment of its own
+# ("<path>:<func>:<expr>"), which the leading "private:" prefix does not
+# disturb: parsing only requires a ":" to be present somewhere in the key.
+# <ordinal> is a 1-based count of the violation's position, in source
+# order, among every other violation sharing the same
 # "<check>:<path>:<name>" prefix, so that several structurally identical
 # violations inside one function — three "for i := range" loops in the same
 # test, say — each get their own row instead of collapsing onto one.

--- a/lint/style/cmd/stylelint/encapsulation.go
+++ b/lint/style/cmd/stylelint/encapsulation.go
@@ -11,10 +11,12 @@ import (
 // _test.go file whose declared package is neither an external test package
 // nor "main".
 //
-// Scope: _test.go files only, gated by its caller lintGoFile. A package
-// main is clean: a main package is unimportable, so an external test
-// package for it could never reach anything, making "package main" the
-// only possible clause for a command's test.
+// An internal test package can reach a type's private fields and methods
+// directly, defeating the guarantee that outside code only crosses a
+// type's exported surface. Scope: _test.go files only, gated by its caller
+// lintParsedFile. A package main is clean: a main package is unimportable,
+// so an external test package for it could never reach anything, making
+// "package main" the only possible clause for a command's test.
 func checkTestPackage(file *ast.File, fileCtx *fileContext) []violation {
 	pkg := file.Name.Name
 	if strings.HasSuffix(pkg, "_test") || pkg == "main" {
@@ -34,10 +36,13 @@ func checkTestPackage(file *ast.File, fileCtx *fileContext) []violation {
 // *ast.SelectorExpr whose selector is unexported and whose base is neither
 // the bare identifier m nor a name in exemptParams.
 //
-// Scope: production, non-cgo, non-test code, gated by its callers
-// lintFuncDecl and lintGenDecl. A file that imports "C" is exempt, since C
-// struct fields are syntactically indistinguishable from Go private fields
-// without type information. A _test.go file is exempt too: it is checked by
+// Reaching a private field or method through anything but the receiver m
+// lets code elsewhere in the package bypass whatever invariant or mutex
+// the owning type's own methods maintain over it. Scope: production,
+// non-cgo, non-test code, gated by its callers lintFuncDecl and
+// lintGenDecl. A file that imports "C" is exempt, since C struct fields
+// are syntactically indistinguishable from Go private fields without type
+// information. A _test.go file is exempt too: it is checked by
 // checkTestPackage instead, which enforces the external-test-package rule
 // that keeps a test file from reaching into private fields at all.
 func scanPrivateSelectors(node ast.Node, enclosing string, exemptParams map[string]bool, fileCtx *fileContext) []violation {

--- a/lint/style/cmd/stylelint/logger.go
+++ b/lint/style/cmd/stylelint/logger.go
@@ -14,11 +14,14 @@ var constructorNameRe = regexp.MustCompile(`^[Nn]ew([A-Z_]|$)`)
 // checkLoggerParam reports a violation when decl is a constructor or a
 // method and one of its parameters carries a zap logger.
 //
-// Scope: production code only. A _test.go file is skipped entirely by its
-// caller, lintFuncDecl, since the options pattern this check enforces has
-// no test-code exemption to preserve — the check simply never fires there
-// in practice, so scoping it out keeps a hand-rolled test double from
-// needing an allowlist row.
+// A logger accepted positionally ties every call site to that exact
+// parameter list; the options pattern (WithLog) lets a constructor or
+// method gain further optional dependencies later without breaking
+// existing callers. Scope: production code only. A _test.go file is
+// skipped entirely by its caller, lintFuncDecl, since the options pattern
+// this check enforces has no test-code exemption to preserve — the check
+// simply never fires there in practice, so scoping it out keeps a
+// hand-rolled test double from needing an allowlist row.
 func checkLoggerParam(decl *ast.FuncDecl, name string, fileCtx *fileContext) []violation {
 	if !fileCtx.HasZap {
 		return nil
@@ -46,9 +49,13 @@ func checkLoggerParam(decl *ast.FuncDecl, name string, fileCtx *fileContext) []v
 // checkLoggerInterface reports a violation for every interface method
 // declaration in typeSpec whose parameter list carries a zap logger.
 //
+// It flags the same anti-pattern as checkLoggerParam, for the reason given
+// there.
+//
 // Scope: production code only, gated by its caller lintGenDecl on
-// !fileCtx.IsTest, for the same reason as checkLoggerParam. Non-interface type
-// declarations produce no violations.
+// !fileCtx.IsTest, on the same scoping grounds as checkLoggerParam's own
+// test-file exemption. Non-interface type declarations produce no
+// violations.
 func checkLoggerInterface(typeSpec *ast.TypeSpec, fileCtx *fileContext) []violation {
 	if !fileCtx.HasZap {
 		return nil

--- a/lint/style/cmd/stylelint/main.go
+++ b/lint/style/cmd/stylelint/main.go
@@ -14,13 +14,16 @@
 //     what each one enforces.
 //
 // <name> is the enclosing function or method ("RecvType.MethodName" or
-// "FuncName"), a struct field ("TypeName.FieldName"), a package-level
-// var/const, or the enclosing name followed by additional ":"-separated
-// segments identifying the offending site, when several violations of one
-// check can share an enclosing declaration. The private check's key already
-// carries an extra segment of its own ("<path>:<func>:<expr>"), which the
-// leading "private:" prefix does not disturb: the allowlist only requires a
-// ":" to be present somewhere in the key.
+// "FuncName" — an interface method takes the same "TypeName.MethodName"
+// shape with no receiver involved), a struct field ("TypeName.FieldName"),
+// a bare type name when the enclosing declaration is a type, a
+// package-level var/const, a file's own package clause name, or the
+// enclosing name followed by additional ":"-separated segments identifying
+// the offending site, when several violations of one check can share an
+// enclosing declaration. The private check's key already carries an extra
+// segment of its own ("<path>:<func>:<expr>"), which the leading "private:"
+// prefix does not disturb: the allowlist only requires a ":" to be present
+// somewhere in the key.
 //
 // <ordinal> is a 1-based count of the violation's position, in source
 // order, among every other violation sharing the same

--- a/lint/style/cmd/stylelint/naming.go
+++ b/lint/style/cmd/stylelint/naming.go
@@ -9,10 +9,12 @@ import (
 // checkReceiver reports a violation when decl's method receiver has an
 // explicit name other than m, including the blank identifier.
 //
-// Scope: every method, in production and test code alike. An unnamed
-// receiver, such as the stateless "noop" observer pattern
-// (func (noopObserver) OnEvent()), is not flagged: it deliberately has no
-// identifier to rename, unlike a receiver given some other name.
+// A fixed receiver name lets the private check treat the bare identifier m
+// as a method's own access path without per-type configuration. Scope:
+// every method, in production and test code alike. An unnamed receiver,
+// such as the stateless "noop" observer pattern (func (noopObserver)
+// OnEvent()), is not flagged: it deliberately has no identifier to
+// rename, unlike a receiver given some other name.
 func checkReceiver(decl *ast.FuncDecl, fileCtx *fileContext) []violation {
 	if len(decl.Recv.List[0].Names) == 0 {
 		return nil
@@ -36,9 +38,11 @@ func checkReceiver(decl *ast.FuncDecl, fileCtx *fileContext) []violation {
 // checkBareNew reports a violation when decl is a top-level function
 // literally named New.
 //
-// Scope: package-level functions only, in production and test code alike. A
-// method literally named New is not a package's discoverable constructor,
-// so it is out of scope.
+// A constructor literally named New stops naming the type it builds once
+// a package needs a second constructible type. Scope: package-level
+// functions only, in production and test code alike. A method literally
+// named New is not a package's discoverable constructor, so it is out of
+// scope.
 func checkBareNew(decl *ast.FuncDecl, fileCtx *fileContext) []violation {
 	if decl.Recv != nil || decl.Name.Name != "New" {
 		return nil
@@ -57,8 +61,10 @@ func checkBareNew(decl *ast.FuncDecl, fileCtx *fileContext) []violation {
 // typeSpec that is not the last field in its struct, whether named or
 // anonymously embedded.
 //
-// Scope: every struct type declaration, in production and test code alike,
-// in any file whose package (not necessarily that file itself) imports zap.
+// This is house style: keeping the logger last groups a struct's domain
+// fields together ahead of its infrastructure plumbing. Scope: every
+// struct type declaration, in production and test code alike, in any file
+// whose package (not necessarily that file itself) imports zap.
 func checkLoggerLast(typeSpec *ast.TypeSpec, fileCtx *fileContext) []violation {
 	if !fileCtx.ZapEligible {
 		return nil
@@ -119,7 +125,10 @@ func isZapLoggerType(expr ast.Expr, zapAlias string) bool {
 // checkLoopIndexFor reports a violation when stmt's Init clause declares or
 // assigns a loop variable named i.
 //
-// Scope: every for-loop, in production and test code alike. Both a
+// The repository's no-abbreviated-identifiers rule carves out idx, not i,
+// as its one allowed loop-counter abbreviation, so a lone i reads as an
+// unexplained shorthand next to every other spelled-out name. Scope:
+// every for-loop, in production and test code alike. Both a
 // short-variable-declaration Init clause (for i := 0; ...) and a plain
 // assignment to a variable declared earlier (var i int; for i = 0; ...) are
 // in scope, since the loop reads as an "i" index either way.
@@ -138,6 +147,9 @@ func checkLoopIndexFor(stmt *ast.ForStmt, enclosing string, fileCtx *fileContext
 }
 
 // checkLoopIndexRange reports a violation when stmt's range key is named i.
+//
+// It flags the same abbreviated-identifier smell as checkLoopIndexFor, for
+// the reason given there.
 //
 // Scope: every range loop, in production and test code alike.
 func checkLoopIndexRange(stmt *ast.RangeStmt, enclosing string, fileCtx *fileContext) []violation {

--- a/lint/style/cmd/stylelint/style.go
+++ b/lint/style/cmd/stylelint/style.go
@@ -29,7 +29,10 @@ var snakeCaseRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
 // checkMapLiteral reports a violation when call is a single-argument
 // make(map[K]V), which a capacity-hinted two-argument make is not.
 //
-// Scope: every call expression, in production and test code alike.
+// This is house style: map[K]V{} reads the same as a struct or slice
+// composite literal, instead of reaching for make when no capacity hint is
+// being given. Scope: every call expression, in production and test code
+// alike.
 func checkMapLiteral(call *ast.CallExpr, enclosing string, fileCtx *fileContext) []violation {
 	ident, ok := call.Fun.(*ast.Ident)
 	if !ok || ident.Name != "make" || len(call.Args) != 1 {
@@ -54,7 +57,9 @@ func checkMapLiteral(call *ast.CallExpr, enclosing string, fileCtx *fileContext)
 // checkGRPCDial reports a violation when call is grpc.Dial or
 // grpc.DialContext.
 //
-// Scope: every call expression, in production and test code alike.
+// grpc.Dial and grpc.DialContext are deprecated upstream in favor of
+// grpc.NewClient. Scope: every call expression, in production and test
+// code alike.
 func checkGRPCDial(call *ast.CallExpr, enclosing string, fileCtx *fileContext) []violation {
 	if !fileCtx.HasGRPC {
 		return nil
@@ -84,8 +89,11 @@ func checkGRPCDial(call *ast.CallExpr, enclosing string, fileCtx *fileContext) [
 // checkSugarType reports a violation when sel denotes the zap.SugaredLogger
 // type.
 //
-// Scope: every selector expression, in production and test code alike, in
-// any file whose package (not necessarily that file itself) imports zap. In
+// zap.SugaredLogger accepts untyped key-value pairs checked only at
+// runtime; *zap.Logger's typed field constructors (zap.String, zap.Int,
+// ...) catch a mismatched argument at compile time instead. Scope: every
+// selector expression, in production and test code alike, in any file
+// whose package (not necessarily that file itself) imports zap. In
 // practice this only ever fires in a file that itself imports zap, since
 // the zap.SugaredLogger reference this check matches requires that file's
 // own zap import to compile.
@@ -106,6 +114,9 @@ func checkSugarType(sel *ast.SelectorExpr, enclosing string, fileCtx *fileContex
 }
 
 // checkSugarCall reports a violation when call is a niladic .Sugar() call.
+//
+// It flags the same anti-pattern as checkSugarType, for the reason given
+// there.
 //
 // Scope: every call expression, in production and test code alike, in any
 // file whose package (not necessarily that file itself) imports zap.
@@ -128,12 +139,14 @@ func checkSugarCall(call *ast.CallExpr, enclosing string, fileCtx *fileContext) 
 // checkZapMsg reports a violation when call is a logger call whose first
 // argument is a string literal starting with an uppercase letter.
 //
-// Scope: every call expression, in production and test code alike, in any
-// file whose package (not necessarily that file itself) imports zap. A call
-// on the bare identifier t or b is skipped: testing.T and testing.B expose
-// Error and Fatal under the same names as the zap logger API, and their
-// arguments are failure messages read by a human running the test, not
-// structured log messages.
+// A lowercase message follows the same convention as a Go error string, so
+// it composes predictably when embedded inside a larger line. Scope: every
+// call expression, in production and test code alike, in any file whose
+// package (not necessarily that file itself) imports zap. A call on the
+// bare identifier t or b is skipped: testing.T and testing.B expose Error
+// and Fatal under the same names as the zap logger API, and their arguments
+// are failure messages read by a human running the test, not structured log
+// messages.
 func checkZapMsg(call *ast.CallExpr, enclosing string, fileCtx *fileContext) []violation {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok || !loggerMethodNames[sel.Sel.Name] || len(call.Args) == 0 {
@@ -169,11 +182,14 @@ func checkZapMsg(call *ast.CallExpr, enclosing string, fileCtx *fileContext) []v
 // constructor whose first argument is a string literal that is not
 // snake_case.
 //
-// Scope: every call expression, in production and test code alike, in any
-// file whose package (not necessarily that file itself) imports zap. In
-// practice this only ever fires in a file that itself imports zap, since
-// the zap.<Type>(...) syntax this check matches requires that file's own
-// zap import to compile.
+// This is house style: a uniform snake_case key vocabulary keeps every
+// structured log field queryable the same way, instead of mixing
+// camelCase and snake_case across call sites. Scope: every call
+// expression, in production and test code alike, in any file whose
+// package (not necessarily that file itself) imports zap. In practice
+// this only ever fires in a file that itself imports zap, since the
+// zap.<Type>(...) syntax this check matches requires that file's own zap
+// import to compile.
 func checkZapKey(call *ast.CallExpr, enclosing string, fileCtx *fileContext) []violation {
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {

--- a/lint/style/cmd/stylelint/testscope.go
+++ b/lint/style/cmd/stylelint/testscope.go
@@ -8,6 +8,9 @@ import (
 // checkTestContext reports a violation when call is context.Background()
 // or context.TODO(), inside a _test.go file.
 //
+// t.Context() is canceled automatically when the test finishes, whereas
+// context.Background() and context.TODO() never cancel, so a value built
+// from either can leak a goroutine or resource past its owning test.
 // Scope: _test.go files only, gated by its caller inspectBody, since
 // t.Context() — the replacement this check demands — does not exist
 // outside of test code.
@@ -38,10 +41,14 @@ func checkTestContext(call *ast.CallExpr, enclosing string, fileCtx *fileContext
 // name, whose type is context.Context or a "pb"-suffixed package type and
 // whose name is the blank identifier.
 //
-// Scope: production methods only, gated by its caller lintFuncDecl on
-// decl.Recv != nil and !fileCtx.IsTest — a free function is never checked.
-// A test double implementing an interface routinely blanks out every
-// parameter it does not need, so this check does not apply to test code.
+// A named ctx or request parameter documents the handler's signature and
+// stays available for a later change to start reading it. The blank
+// identifier discards that name and forces a signature edit before the
+// value can be used. Scope: production methods only, gated by its caller
+// lintFuncDecl on decl.Recv != nil and !fileCtx.IsTest — a free function is
+// never checked. A test double implementing an interface routinely blanks
+// out every parameter it does not need, so this check does not apply to
+// test code.
 func checkHandlerBlank(decl *ast.FuncDecl, name string, fileCtx *fileContext) []violation {
 	if decl.Type.Params == nil {
 		return nil


### PR DESCRIPTION
The allowlist key format described in the style linter's package comment, and paraphrased in the allowlist header, enumerated four forms the name segment can take. Two real ones were missing.

- A file's own package clause name, which the internal test-package check emits. This is not hypothetical: dozens of live ledger rows are already in that shape, and a reader could not match any of them to the documented forms.
- A bare type name, emitted when a violation is found while walking a type declaration. No live rows today, so latent rather than urgent, but reachable.

Both are now documented in the package comment and in the allowlist header, which remain paraphrases of each other. The enumeration also glossed an interface method as a receiver-and-method pair, which it is not.

The package comment further claimed to carry each check's rationale, inlining it for a few and deferring the rest to their declarations, where several carried only a note on scope. Every one of the fourteen checks now states why the convention it enforces exists, so that deferral is honest. Where one check has two implementing functions, the rationale lives on one and the sibling points at it.

One check's scope note named a caller that only reaches it transitively; corrected to the real one.

No behaviour change: no check logic was touched and no allowlist row was added, removed, or reordered.