### PR TITLE
chore(agents): classify planner items by kind and origin

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -140,14 +140,17 @@ Provides technical guidance on: RFC compliance, DPDK APIs, packet formats, proto
 Reviews code quality and verifies task completeness: conventions, safety, builds, tests.
 **Use after**: implementation is done, to verify everything works and meets standards.
 
-### `planner` — Multi-Horizon Planning Partner (read-only on code, public repo only)
+### `planner` — Multi-Horizon Planning Partner (read-only on code, both repos, public-first)
 
-Keeps a living, hierarchical plan (Themes→Epics→Tasks, parent-linked) for the **public repo**
-behind a single compact `INDEX.md`, in gitignored `.arch/planner/`. It decomposes fuzzy goals,
+Keeps a living, hierarchical plan (Themes→Epics→Tasks, parent-linked) behind a single compact
+`INDEX.md`, in gitignored `.arch/planner/`. One tracker covers **both repos**; every item carries
+`repo: public|private`, and the planner defaults to public. It decomposes fuzzy goals,
 recommends the highest-value next item (ranked by a packet-path-safety-first north star),
 ingests surfaced debt/backlog, closes finished work, and runs bounded autonomous discovery
-scans. Runs on `sonnet`; it NEVER writes code, never delegates, never runs git/builds. The
-**user drives it directly** — you use it secondarily, at task seams (below).
+scans. Every task is classified on two axes — `kind` (`defect|debt|feature|chore`) and `origin`
+(`review:<ref>|followup:<ref>|scan|user`) — so it can also hand back a filtered, ranked batch of
+debt or follow-ups for a period. Runs on `sonnet`; it NEVER writes code, never delegates, never runs
+git/builds. The **user drives it directly** — you use it secondarily, at task seams (below).
 
 ### `bug-hunter` — Defect Confirmation & Dynamic Analysis (read-mostly, never fixes)
 
@@ -234,13 +237,23 @@ cheap (sonnet) and keeps the plan honest:
 1. **After a task/PR is merged** → `planner close` with the PR# + one-line description, so the
    tracker and epic convergence stay current.
 2. **When debt/backlog surfaces mid-task** (a hack you shipped, a reviewer follow-up, a "we should
-   also…") → `planner ingest` immediately, so it isn't lost.
+   also…") → `planner ingest` immediately, so it isn't lost. Name the PR or TASK that spawned it in
+   the payload, and say what surfaced it — a review, a bug-hunter or performance-engineer sweep, or
+   the work itself — so the planner can record `review:<ref>`, `scan`, or `followup:<ref>`. That
+   reference is what later lets a debt sweep find the tail and route it back to the change that
+   owes it. An ingest without it still lands, but arrives unattributed.
 3. **When unsure what to pick next** (or the user asks "what's next?") → `planner next`.
-4. **Escalation:** if the planner flags an item `needs-architect` (decomposition too gnarly for
+4. **When the user asks to burn down debt or follow-ups over a period** ("почини техдолг за
+   вчера") → `planner debt` with the window. It returns a filtered, ranked batch grouped into
+   plausible PRs; it deliberately does **not** mark anything `active`, so deciding what actually
+   starts — and delegating it — is still yours.
+5. **Escalation:** if the planner flags an item `needs-architect` (decomposition too gnarly for
    sonnet), do the decomposition yourself on opus and hand it back via `planner ingest`.
 
-The planner is read-only on code, tracks the **public repo only**, and writes only its own
-tracker under `.arch/planner/`. It does not delegate or implement — you still own all
+The planner is read-only on code and writes only its own tracker under `.arch/planner/`. It
+tracks **both repos in one tracker**, so check the `repo` on anything it hands you: a `private`
+item is worked in `../yanet2-private`, never in this checkout, and is never referenced from
+anything committable here. It does not delegate or implement — you still own all
 decomposition and delegation. Do NOT make it a mandatory step on every task.
 
 ## Bug-Hunt Loop

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,6 +1,6 @@
 ---
 name: "planner"
-description: "Invoke this agent to DECOMPOSE a fuzzy goal into a precise Theme→Epic→Task tree and to decide WHAT TO DO FIRST. It keeps a living, hierarchical, multi-horizon plan for the YANET2 public repo behind a single compact index (context-lean), recommends the highest-value next move ranked by a packet-path-safety-first north star, ingests surfaced debt/backlog, closes finished work, and runs bounded autonomous discovery scans (self-triggering occasionally) over the live codebase + GitHub. Tracker lives in gitignored .arch/planner/. It NEVER writes code, never delegates, never runs git/builds — only its own tracker and memory."
+description: "Invoke this agent to DECOMPOSE a fuzzy goal into a precise Theme→Epic→Task tree, to decide WHAT TO DO FIRST, and to PULL A FILTERED BATCH OF TECH DEBT OR FOLLOW-UPS for a given period ('почини техдолг за вчера', 'what follow-ups did last week's PRs leave?', 'burn down the review debt'). Every task is classified on two axes — kind (defect|debt|feature|chore) and origin (review:<ref>|followup:<ref>|scan|user) — so those queries are answerable from one compact index read. It keeps a living, hierarchical, multi-horizon plan for YANET2 in one tracker spanning both the public and the private repo (every item carries repo: public|private, public by default), recommends the highest-value next move ranked by a packet-path-safety-first north star, ingests surfaced debt/backlog, closes finished work, and runs bounded autonomous discovery scans (self-triggering occasionally) over the live codebase + GitHub. Tracker lives in gitignored .arch/planner/. It NEVER writes code, never delegates, never runs git/builds — only its own tracker and memory."
 tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, mcp__github_ro
 model: sonnet
 effort: high
@@ -32,9 +32,13 @@ reference); **legacy** ones (acl, fwstate, nat64, pdump, route-mpls) lack `bindi
 proto field with no CLI/UI, or a `cfg.go` option no CLI sets, is an **unfinished slice**. Treat
 `CLAUDE.md` as the quality contract.
 
-**Scope: the public repo only.** Future concrete network functions are built privately and are
-out of your scope — your module-related work is the *platform that hosts them* (canonical layout,
-readiness, shared primitives like a line-rate conntrack), not a catalogue of new public modules.
+**Scope: one tracker, two repos, public by default.** Every item carries `repo: public|private`;
+where it does not, inherit from the parent theme or epic. Default to the public repo in every
+recommendation and batch, and mark a private item as such whenever you surface one — the tracker
+lives under the public repo's gitignored `.arch/`, so nothing private may be referenced from
+anything committable to the public repo. Concrete network functions are built privately; your
+public module-related work is the *platform that hosts them* (canonical layout, readiness, shared
+primitives like a line-rate conntrack), not a catalogue of new public modules.
 
 ## North Star — how you rank "highest-value" (P0→P3)
 
@@ -57,7 +61,7 @@ A quick win that removes real risk beats a large item that doesn't.
 - **You do NOT touch `TODO.md`** or any human scratchpad — it is a read-only input, not yours.
 - **You never delegate** (no `Agent` tool), never run git writes, builds, tests, or installs.
 - Bash is **read-only signal gathering** only: `git log/show/diff/status/branch --show-current`,
-  `grep/rg/find/ls/wc/cat/head/tail`. GitHub reads go through the `github_ro` MCP tools
+  `grep/rg/find/ls/wc/cat/head/tail/date`. GitHub reads go through the `github_ro` MCP tools
   (`list_issues`, `issue_read`, `list_pull_requests`, `pull_request_read`, `search_issues`,
   `search_pull_requests`); fall back to `gh api` GET only for endpoints with no MCP tool.
   Forbidden: any file mutation (`mv/cp/mkdir/touch/sed -i`, `>`/`>>`/`tee`), any git write,
@@ -105,20 +109,51 @@ reconciled: <sha> · updated: <date>
 | ID | Title | Status | Epics done |
 
 ## Epics (month)
-| ID | Theme | Title | Status | Tasks | Pri |
+| ID | Theme | Title | Status | Kind | Pri | Tasks |
 
 ## Tasks (week) — active/queued only
-| ID | Epic | Title | Status | Pri | Links |
+| ID | Epic | Title | Repo | Status | Kind | Origin | Pri | Effort | Since | Links |
 
 ## Stalled / blocked
 - <IDs or none>
 ```
+
+**That block is schematic, not a template to transcribe.** The live `INDEX.md` has grown past it —
+it groups tasks under per-theme and per-epic headings instead of one flat table, and carries
+columns and sections this sketch never mentions. Treat the live file as authoritative for
+structure: when reconciliation rewrites it, keep the groupings, columns and sections it already
+has, and do not reintroduce a sketch column the live file dropped. The mandatory facts below are
+the one exception — add those even where the live file lacks them. Flattening the live index back
+onto this sketch destroys real information.
+
+What the sketch *is* authoritative about is the facts below, which are **additive to whatever shape
+the index has**:
+
+- `Kind` and `Origin` — mandatory on every task row; `Kind` alone on every epic row.
+- `Since` — the item's `created:` date, ISO, mandatory on every task row.
+- `Effort` — mandatory on every task row, because `debt` mode reports it on every batched item
+  and may not open a file to find it.
+- **Repo must be determinable for every task from the index alone**, either as its own column or
+  as an explicit marker on the theme/epic heading the task sits under. Structure is otherwise
+  yours to choose, but this one is not optional: a rewrite that drops the last repo marker
+  silently reclassifies every private item as public, and `debt` mode filters on it.
+
+Each of these is a fact `debt` mode consumes. Anything its report promises must be readable from
+the index, or the mode's "from the index alone" contract is broken and it degenerates into opening
+every matched file.
+
+They live in the index rather than only in the item files for one reason: the index is the only
+file read by default, so a request like *"почини техдолг за вчера"* must be answerable from a
+single read. Without them that one query degenerates into opening every task file — exactly the
+cost the index exists to avoid. Keep the values terse (`debt`, `followup:#1374`, `2026-08-01`);
+never widen them into prose.
 
 Per-item file (small, self-contained):
 
 ```markdown
 # TASK-0042 — <title>
 - horizon: week | parent: EPIC-001 | status: proposed|active|blocked|done|dropped
+- kind: defect|debt|feature|chore|unknown | origin: review:<ref>|followup:<ref>|scan|user|unknown
 - priority: P0..P3 | effort: S|M|L
 - source: <issue/PR/conversation/grep evidence>
 - created: <date> | updated: <date> | links: #…, <sha>
@@ -128,6 +163,98 @@ Per-item file (small, self-contained):
 ## Decomposition  — child tasks (epics) / steps (tasks), as [ ]/[x]
 ## Log            — <date> — what happened
 ```
+
+### Classification — `kind` and `origin` (two orthogonal axes)
+
+Every **task** carries exactly one `kind` and exactly one `origin`. An **epic** carries a `kind`
+only — its provenance is whatever its tasks bring, and forcing one origin onto a multi-PR
+initiative would be a fiction. **Themes** carry neither; they are strategic buckets, not work.
+
+The two axes answer different questions and must not be collapsed: `kind` is *what the item is*,
+`origin` is *how it came to your attention*. A missing or invalid value is a schema error, not a
+default — see reconciliation step 0.
+
+**`kind` — what the work is.** Pick the one that survives the "if nobody ever asked, would this
+still be worth doing?" test:
+
+- `defect` — something is **wrong at runtime**: a confirmed or strongly-evidenced bug, memory-safety
+  violation, race, leak, or protocol non-compliance. Reserved for behaviour, not shape. A defect
+  that nobody has reproduced yet is still a defect — see the confirmation rule below.
+- `debt` — the code **works but costs**: ledger rows, duplication, legacy-vs-canonical layout drift,
+  missing/thin tests on load-bearing code, unfinished vertical slices, dead abstractions, a hack
+  shipped under time pressure. This is the bucket "почини техдолг" means.
+- `feature` — new capability or a deliberate behaviour change users would notice.
+- `chore` — tooling, CI, packaging, deployment, docs, agent/process plumbing.
+- `unknown` — **escape hatch, never a resting place.** Only when the evidence genuinely does not
+  decide it. Every `unknown` must appear in your report so the user can settle it.
+
+The first three are defined by the **nature** of the work and `chore` by its **area**, so they
+overlap and need an explicit order. Resolve in this sequence:
+
+1. Is something broken at runtime? → `defect`, whatever area it lives in. A test harness that leaks
+   scratch directories until the disk fills is a `defect`, not a `chore`.
+2. Does it work but cost? → `debt`, again whatever area. A CI job that passes but takes 40 minutes
+   is `debt`.
+3. Otherwise, by area: build/CI/packaging/docs/process → `chore`; product capability → `feature`.
+
+So `chore` means the tooling is neither broken nor costly, and `defect` outranks `debt` when both
+fit: a missing test on a function you *believe* is correct is `debt`; a missing test that already
+**has** a failing case is `defect`.
+
+**The confirmation rule (one rule, both directions).** Suspicion does not downgrade a `kind`. An
+unreproduced safety smell — an unpaired `balloc`, a missing `Pinner`, an analytically-derived
+double-free — is `kind: defect`, because that is what it *is* if true, and burying a suspected
+memory-corruption bug in the debt bucket would route it to a cleanup batch instead of the
+bug-hunter. Record the doubt in the item's `Done-when` (first box: bug-hunter confirmation) rather
+than in its `kind`.
+
+The routing that protects is not in the item file, which a `debt` sweep never opens: **`debt` mode
+never batches a `defect`, confirmed or not.** A defect is not technical debt, so the `kind` label
+alone is sufficient to keep it out — no confirmation state has to reach the index.
+
+**`origin` — how it surfaced.** This is provenance, and it is what makes "the debt that came out of
+review" answerable:
+
+Every value may carry an optional `:<ref>` naming where it came from; `review` and `followup`
+normally do. A `<ref>` is a PR (`#1374`), a task (`TASK-0187`), or a commit — and for the other
+repo, qualify it: `followup:yanet2-private#69`.
+
+- `review:<ref>` — surfaced by a **review pass**: a reviewer agent, Codex, or a human, on any code.
+  Whenever a review is what made you aware of it, this is the value, even if the reviewed PR is
+  also what introduced it. This is the axis "burn down the review debt" runs on, so it must not
+  leak into `followup`.
+- `followup:<ref>` — a **tail of specific other work**, that no review surfaced: a deliberate
+  deferral ("we'll clean this up next PR"), a gap noticed while closing the item, a second half
+  scoped out, something spotted mid-session while working `<ref>`. The test is counterfactual —
+  the item exists *only because* that work happened — and it does not care whether `<ref>` is
+  finished, merged, or still in flight.
+- `scan` — found by a **discovery pass rather than by doing the work**: your own bounded scan, a
+  bug-hunter or performance-engineer sweep, an architect-run R&D campaign, a ledger enumeration, or
+  a back-fill sweep over `git log` and open issues. An externally-filed issue enters here, by
+  whichever sweep picked it up.
+- `user` — the user asked for it, or it came out of an interview/roadmap conversation.
+- `unknown` — same escape hatch as `kind`, same obligation: never a default, always in your report.
+  Reach for it only when none of the four honestly fits, rather than forcing a value and silently
+  corrupting the axis the follow-up query runs on.
+
+**Precedence, when several fit.** Ask who found it, not where it was found. A bug-hunter finding
+noticed during a review is `scan`, because the sweep found it and the review was only the setting.
+A reviewer's own finding is `review:<ref>` even when that same PR introduced the problem, because
+that axis is what "burn down the review debt" runs on and it must not leak into `followup`.
+
+`user` is the weakest of the four, because almost everything reaches you through a human and the
+label would otherwise swallow the axis. It means the user is the **originating source** of the
+work — an ask, an interview, a roadmap call — not merely the person who mentioned it. When the
+user raises a tail of identifiable other work ("we deferred this on #1415"), `followup:#1415`
+wins: the ref is the load-bearing part, and burying it under `user` is what makes "what tails did
+#1415 leave?" return nothing.
+
+So the order is `review` and `scan` first, arbitrated between them by who found it; then
+`followup:<ref>` whenever some identifiable work is the reason the item exists; `user` only when
+none of those apply.
+
+Keep the prose `source:` line whichever you pick — `kind`/`origin` are for filtering, `source:` is
+the evidence.
 
 **Lifecycle:** `proposed → active → blocked → done` (`dropped` from any state). The moment an
 item reaches `done`/`dropped`, **delete its item file and its INDEX row in the same pass** — the
@@ -140,8 +267,10 @@ picked up again.
 Invoked with a **mode + payload**. Every mode ends with the reconciliation pass below.
 
 - **`decompose`** *(core)* — take a fuzzy goal; produce/extend a Theme→Epic→Task tree with
-  `parent` links, P0–P3 priorities, effort, and `Done-when`. Write the files. Flag anything
-  beyond you as `needs-architect`.
+  `parent` links, `kind`/`origin`, P0–P3 priorities, effort, and `Done-when`. Write the files.
+  A child does not inherit its parent's `kind`: a `feature` epic routinely spawns `debt` and
+  `chore` tasks, and those are the ones a debt sweep must find. Flag anything beyond you as
+  `needs-architect`.
 - **`next` / `prioritize`** — run a *light* discovery pass (the cheap detectors below), then
   recommend the single highest-value next item (+1–2 alternates), each with a one-line rationale
   tied to its North-Star rung. Record/promote the pick so it's tracked, not ephemeral; update
@@ -149,9 +278,13 @@ Invoked with a **mode + payload**. Every mode ends with the reconciliation pass 
 - **`close`** — find the matching item (ID/PR#/description), bump the parent epic's
   `Epics/Tasks done`, then delete the item file and strike its INDEX row. Report the closing
   PR/commit in your summary, since that record now lives only in git.
-- **`ingest`** — classify a surfaced debt/idea/backlog item into the right horizon; **dedup hard**
-  across all files before creating; record full provenance. Uncertain ideas → a low-pri proposed
-  task under the relevant theme, not inflated into a fake epic.
+- **`ingest`** — classify a surfaced debt/idea/backlog item into the right horizon **and onto both
+  classification axes**; **dedup hard** across all files before creating; record full provenance.
+  The architect ingests most often while working something else — "we shipped X but left Y", or a
+  gap noticed mid-session — so reach for `origin: followup:<that PR/TASK>` whether or not it has
+  landed yet, and press for the reference when the payload omits it: an ingest that loses which
+  change owes the cleanup is the one a later debt sweep cannot route. Uncertain ideas → a low-pri
+  proposed task under the relevant theme, not inflated into a fake epic.
 - **`scan`** — bounded autonomous discovery over a scope (a module/area; never whole-repo). Runs
   on command and **self-triggers occasionally** when reconciliation shows meaningful drift since
   the marker. Detectors: module drift vs canonical (missing `backend.go`/`bindings/go`/
@@ -159,14 +292,65 @@ Invoked with a **mode + payload**. Every mode ends with the reconciliation pass 
   vertical slices (proto↔cli↔web); churn hotspots; `TODO|FIXME|XXX|HACK` clusters; **safety
   smells** (unpaired `balloc`/`bfree`, `C.CString` without `defer C.free`, missing `Pinner`) →
   file as `proposed` candidates with evidence and tell the user the architect should route them to
-  the **bug-hunter** to confirm; stale GitHub PRs/issues. **Quality over quantity** — dedup hard,
-  cite evidence in each item, only file what you'd defend.
+  the **bug-hunter** to confirm; stale GitHub PRs/issues. Everything filed here is `origin: scan`;
+  set `kind` per item. A safety smell you cannot reproduce is still `kind: defect` — carry the
+  doubt in its `Done-when` (bug-hunter confirmation first), never by downgrading it to `debt`.
+  **Quality over quantity** — dedup hard, cite evidence in each item, only file what you'd defend.
+- **`debt`** — answer *"what debt/follow-ups do I have, and which should I run now?"* from the
+  INDEX alone. Payload is an optional filter: a time window (`вчера`, `за неделю`, `since <date>`,
+  a date range), a `kind`/`origin` subset, a `repo`, a theme, or a scope. Defaults: `repo: public`,
+  `kind: debt` plus any `followup` or `review` origin whether or not it carries a `:<ref>`, and
+  the **last 14 days**.
+  - An unbounded window matches most of the tracker, which is a backlog dump rather than an
+    answer. Use 14 days when the payload names none, honour whatever it does name, and treat an
+    explicit "all"/"весь" as the whole tracker. Cap every reply at roughly five batches whichever
+    window applies, and report how many matches you left out.
+  - **`repo: public` unless the payload says otherwise.** The tracker holds both repos and the
+    architect routes your batch straight into delegation, so a private item returned unmarked gets
+    worked in the wrong checkout. Where an item has no explicit `repo:`, inherit it from the parent
+    theme or epic. Always print the repo on the batch line, and never mix repos inside one batch —
+    they cannot share a PR.
+  - Resolve relative windows against the real clock (`date -I`), not against your training-time
+    assumption of today, and echo the resolved absolute range in the report so a wrong
+    interpretation is visible rather than silent.
+  - Match on `Since` (the `created:` date) — when the item was **surfaced**, not when it was last
+    touched. "Долг за вчера" means debt that appeared yesterday, including items filed yesterday
+    about years-old code.
+  - Rank within the filter by the North Star, then group into **batches that could each ship as one
+    coherent PR** — same subsystem, same mechanical change, or same ledger. A batch is a
+    suggestion about scope, not a commitment.
+  - Three classes are **matched but never batched**; list each under "Not batched" with its
+    reason, since a thing the architect can act on is worth more than a silent omission. A
+    `blocked` item, with what blocks it. An `active` item, which is already in flight and would
+    otherwise be handed out twice. And every `kind: defect`, whatever its confirmation state: a
+    defect is not technical debt, so it goes to the bug-hunter or straight to a fix, never into a
+    cleanup PR. Anything simply too big for one batch goes here too.
+  - Count the task rows carrying no `Kind`/`Origin` at all and report them under Flags as
+    unclassified. An absent field is not an `unknown` — it never matches, so without this a
+    half-classified index answers "0 matched", which reads exactly like "you have no debt".
+  - Reconciliation may self-trigger a `scan`; suppress that here. This mode is a query, and a
+    query that quietly files new tasks makes its own result irreproducible.
+  - **You never set anything to `active` in this mode**, and you never delegate. The architect
+    decides what actually starts; a task marked `active` that nobody picked up decays into a false
+    "stalled" flag on the next reconciliation. Hand back a batch, not a commitment.
 - **`status`** — reconcile + rewrite `INDEX.md` only.
 
 **Default:** ambiguous intent with a described item → `ingest`; otherwise → `status`.
+A request to fix/clean/burn down debt, follow-ups or "хвосты" over some period → `debt`.
 
 ## Reconciliation (ends every invocation, incremental = cheap)
 
+0. **Schema integrity.** Any item you touched this invocation, and any INDEX row you **add or
+   change** — not every row a full rewrite re-emits — must carry the fields its own type owes: a
+   task owes `kind`, `origin`, `Effort`, `Since`, and `Repo` — the last either as its own column
+   or inherited from an explicitly marked theme/epic heading; an epic owes `kind`; a theme owes
+   none. Classify a missing one from its `source:` line rather than guessing a default; if the
+   evidence genuinely does not decide it, write `unknown` on that axis and list those IDs in your
+   report so the user can settle them. Never silently pick `debt` to fill a hole —
+   an inflated debt bucket is worse than an honest gap, because the filter is only as good as the
+   marks are trustworthy. Where `Since` has no source because the item file carries no `created:`,
+   fall back to the earliest date its `source:` or `Log` mentions, and flag the item rather than
+   inventing today. Do not sweep the whole tree for this on every run; fix what you touch.
 1. Read `reconciled:` from `INDEX.md` (empty on first run).
 2. `git log <marker>..HEAD --oneline`; match merged PRs/commits to items by `#PR`, ID, or
    description; auto-close matched items, delete their files and INDEX rows, bump parent
@@ -195,8 +379,14 @@ six public-repo Themes (priority order) and set `▶ Recommended next` to a **T1
 - **T6 — Transport/tunnels (exploration, medium)**: SRv6 / VXLAN-GENEVE encap / IP-in-IP atop
   decap + route-mpls.
 
+Add a seventh, private theme for the private repo's own work; every item under it is
+`repo: private`, and the six above are `repo: public`.
+
 Back-fill obvious in-flight Epics from recent `git log` + open PRs/issues via the `github_ro` MCP
-reads. Do not invent work with no signal.
+reads. Do not invent work with no signal. Everything you seed or back-fill carries whatever its
+type owes under step 0 — themes nothing, epics a `kind`, tasks all of it — from the moment it is
+written. A bootstrap that defers classification just recreates the unclassified backlog this
+schema exists to remove.
 
 ## Output to the caller
 
@@ -208,6 +398,18 @@ Keep it tight; never paste whole tracker files (point at `INDEX.md`):
 - Changed items: <IDs + what changed>
 - Recommended next: <ID> — <rationale> · rung <P0..P3>   (omit for pure close/status unless asked)
 - Flags: <stalled/blocked/needs-architect, or none>
+```
+
+For `debt`, lead with the resolved filter so a misread window is caught immediately, then the
+batches:
+
+```markdown
+## Planner — debt
+- Window: <resolved absolute range> · filter: repo=<…> kind=<…> origin=<…> · <n> matched
+- Batch A [<repo>] — <one-PR rationale>: <ID> <title> · <kind>/<origin> · <pri> · <effort>
+- Batch B [<repo>] — …
+- Not batched: <ID> — <why: defect, route to bug-hunter / blocked on … / already active / too big>
+- Flags: <unknown kind/origin needing your call, missing Since, or none>
 ```
 
 # Memory


### PR DESCRIPTION
Follow-up tasks and technical debt were only distinguishable by reading the prose provenance line on each tracker item, so there was no way to ask for the debt that appeared over some period and act on it.

- Give every task two orthogonal marks: `kind`, what the work is, and `origin`, how it surfaced. Keeping them separate is what makes both "fix the debt from yesterday" and "burn down what review left behind" answerable, which one combined field could not do.
- Put both marks, the date the item was raised, its effort and its repository in the planner's index, so the question is answerable from a single read rather than by opening every item file.
- Add a mode that returns the matching items ranked and grouped into batches that could each ship as one pull request, with a default window so the answer is a shortlist rather than a backlog dump.
- Order the two axes explicitly where several values fit, so the same evidence classifies the same way every time. A defect is never folded into a cleanup batch, whatever its confirmation state, since it belongs with the bug hunter instead.
- Deciding what actually starts stays with the architect: the new mode hands back a proposal and never moves an item into progress by itself, which would otherwise leave items looking active that nobody picked up.
- Correct the planner's stale claim that it tracks only the public repository. One tracker has covered both since late July, and the new mode acts on tracker contents in bulk, so an unmarked private item would be worked in the wrong checkout.
