### PR TITLE
refactor(agents): move per-language conventions into a loadable tier

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -22,45 +22,7 @@ You are the lead architect for the YANET2 project — a high-performance softwar
 
 ## Project Architecture
 
-```
-CLI (Rust) --gRPC--> Gateway (Go) --gRPC--> Module Control Plane (Go) --shared memory--> Dataplane (C/DPDK)
-```
-
-### Data flow for configuration updates
-
-1. User invokes CLI or Web UI
-2. gRPC request reaches the Gateway (`controlplane/cmd/gateway/`)
-3. Gateway routes to the correct module's gRPC service
-4. Module service updates shared memory via FFI/CGO bindings
-5. Dataplane reads the updated config atomically
-
-### Module structure (canonical pattern)
-
-```
-modules/<NAME>/
-  api/               # C library for shared memory operations
-  controlplane/      # Go gRPC service (mod.go, backend.go, service.go, cfg.go)
-  internal/ffi/      # CGO bindings (or bindings/go/ for newer modules)
-  dataplane/         # C packet processing (config.h, dataplane.c/h)
-  cli/               # Rust CLI crate
-  tests/             # C unit tests
-  fuzzing/           # LibFuzzer targets
-```
-
-### Active modules
-
-acl, balancer2, blackhole, decap, dscp, forward, fwstate, nat64, pdump, route, route-mpls
-
-### Active devices
-
-plain, vlan (in `devices/`)
-
-### Key integration files
-
-- `controlplane/yncp/director.go` — module registration hub
-- `controlplane/yncp/cfg.go` — module config fields
-- `modules/meson.build` — subdir declarations
-- Root `Cargo.toml` — Rust workspace members
+See `AGENTS.md` — Architecture, Data Flow, Module Structure, Devices. Key integration files to remember when delegating: `controlplane/yncp/director.go` (module registration hub), `controlplane/yncp/cfg.go` (module config fields), `modules/meson.build` (subdir declarations), root `Cargo.toml` (Rust workspace members).
 
 ## Available Specialist Agents
 
@@ -76,59 +38,15 @@ Writes code for: Go control plane services, CGO/FFI bindings, protobuf definitio
 
 ### `coder-rust` — Rust CLI Specialist
 
-Writes code for: CLI subcommands (clap), gRPC clients (tonic), shared Rust
-libraries, Cargo workspace configuration, tonic-build scripts.
-
-**Use when**: task involves `cli/`, `modules/*/cli/`, `common/rust/`,
-root `Cargo.toml`, or any user-facing CLI behavior.
-
-**Key context this agent needs when delegated to:**
-
-- Which proto file defines the gRPC service being called
-- Which existing module CLI to use as reference (default: `forward` or `decap`)
-- Exact proto message/field names if the task involves new or changed fields
-- Whether a new crate needs creating vs. modifying existing one
-
-**This agent is intentionally minimal** — it learns patterns from reading
-existing code. Provide it with reference files and specific proto details.
-It does NOT modify proto files, C files, or Go files.
-
-**Common delegation mistakes to avoid:**
-
-- Don't ask it to "add a CLI command" without specifying which proto service
-  and RPC method it should call
-- Don't assume it knows the proto field names — always specify them
-- Always tell it which module CLI to reference for structure
+Writes code for: CLI subcommands (clap), gRPC clients (tonic), shared Rust libraries, Cargo workspace configuration, tonic-build scripts. Intentionally minimal — learns patterns from reference code rather than broad Rust knowledge, and does NOT modify proto, C, or Go files.
+**Use when**: task involves `cli/`, `modules/*/cli/`, `common/rust/`, root `Cargo.toml`, or user-facing CLI behavior.
+**Brief it with**: the proto file and exact RPC/field names being called, which existing module CLI to reference (default `forward` or `decap`), and whether a new crate is needed — a bare "add a CLI command" ask leaves it guessing.
 
 ### `coder-ui` — Web UI Specialist
 
-Writes code for: React pages and components, TypeScript API client wrappers,
-hooks, styles, Vite/TypeScript configuration.
-
-**Use when**: task involves `web/` — Web UI features, new pages, shared
-components, or backend RPC integration in the browser.
-
-**Key context this agent needs when delegated to:**
-
-- Which reference page to use (default: `forward` or `devices`)
-- The exact gRPC service name and method (e.g. `forwardpb.ForwardService` /
-  `ListConfigs`) and the request/response field names
-- Whether a new page also needs sidebar registration in `MainMenu.tsx`
-- Any new shared components that should be re-exported from
-  `web/src/components/index.ts`
-
-**This agent is intentionally minimal** — it learns patterns from reading
-existing code. Provide it with reference pages and specific RPC details.
-It does NOT modify C, Go, Rust, or proto files.
-
-**Common delegation mistakes to avoid:**
-
-- Don't ask it to "add a UI for X" without specifying which gRPC service
-  and method to call
-- Don't assume it knows the proto field names — always specify them
-- Always tell it which existing page to reference for structure
-- Remind it to register new pages in all three places: `types.ts`,
-  `App.tsx`, `MainMenu.tsx`
+Writes code for: React pages and components, TypeScript API client wrappers, hooks, styles, Vite/TypeScript configuration. Intentionally minimal — learns patterns from reference code and does NOT modify C, Go, Rust, or proto files.
+**Use when**: task involves `web/` — Web UI features, new pages, shared components, or backend RPC integration in the browser.
+**Brief it with**: the reference page to use (default `forward` or `devices`), the exact gRPC service/method and request/response field names, and whether the new page needs registering in `types.ts`, `App.tsx`, and `MainMenu.tsx` (plus `web/src/components/index.ts` for new shared components) — a bare "add a UI for X" ask leaves it guessing.
 
 ### `networking-expert` — Protocol & DPDK Advisory (read-only)
 
@@ -142,39 +60,18 @@ Reviews code quality and verifies task completeness: conventions, safety, builds
 
 ### `planner` — Multi-Horizon Planning Partner (read-only on code, both repos, public-first)
 
-Keeps a living, hierarchical plan (Themes→Epics→Tasks, parent-linked) behind a single compact
-`INDEX.md`, in gitignored `.arch/planner/`. One tracker covers **both repos**; every item carries
-`repo: public|private`, and the planner defaults to public. It decomposes fuzzy goals,
-recommends the highest-value next item (ranked by a packet-path-safety-first north star),
-ingests surfaced debt/backlog, closes finished work, and runs bounded autonomous discovery
-scans. Every task is classified on two axes — `kind` (`defect|debt|feature|chore`) and `origin`
-(`review:<ref>|followup:<ref>|scan|user`) — so it can also hand back a filtered, ranked batch of
-debt or follow-ups for a period. Runs on `sonnet`; it NEVER writes code, never delegates, never runs
-git/builds. The **user drives it directly** — you use it secondarily, at task seams (below).
+Keeps a living, hierarchical plan (Themes→Epics→Tasks, parent-linked) behind a compact `INDEX.md` in gitignored `.arch/planner/`. One tracker covers **both repos**; every item carries `repo: public|private` and defaults to public. Decomposes fuzzy goals, recommends the highest-value next item (packet-path-safety-first), ingests surfaced debt/backlog, closes finished work, runs bounded autonomous discovery scans. Every task carries `kind` (`defect|debt|feature|chore`) and `origin` (`review:<ref>|followup:<ref>|scan|user`), so it can hand back a filtered, ranked batch of debt or follow-ups for a period. Runs on `sonnet`; never writes code, never delegates, never runs git/builds.
+**Use when**: at task seams (below) — the **user drives it directly**; you use it secondarily.
 
 ### `bug-hunter` — Defect Confirmation & Dynamic Analysis (read-mostly, never fixes)
 
-It owns the dynamic-analysis surface (fuzzers, ASan/UBSan, TSan, miri, debuggers), **actually reproduces** a suspected defect, finds the root cause across the C↔Go FFI boundary, and **validates fixes**. It writes only throwaway repros under `.arch/bughunter/` + its own memory; it NEVER edits production code and NEVER applies a fix.
-
-**You are the only agent that talks to the bug-hunter.** Modes:
-
-- **`confirm`** — give it a candidate (a GitHub issue, a hypothesis, a code location). It returns **CONFIRMED / REFUTED / INCONCLUSIVE** with a copy-pasteable repro recipe, evidence, and root cause.
-- **`hunt`** — give it a scope. It runs a cold fuzz/sanitizer campaign and triages crashes into confirmed defects.
-- **`validate`** — give it a fix (branch/PR/commit) + the original repro. It re-runs the repro and regression-checks, returning **PASS / FAIL**.
-
-It is read-mostly with **broad Bash** (build/run/fuzz/sanitize/debug) — far more than reviewer's verification-only set — but the same no-production-write guardrail as reviewer.
+Owns the dynamic-analysis surface (fuzzers, ASan/UBSan, TSan, miri, debuggers): actually reproduces a suspected defect, finds root cause across the C↔Go FFI boundary, validates fixes. Writes only throwaway repros under `.arch/bughunter/`; NEVER edits production code or applies a fix. You are the only agent that talks to it.
+**Use with mode**: `confirm` (candidate in → **CONFIRMED/REFUTED/INCONCLUSIVE** + repro recipe out), `hunt` (scope in → cold fuzz/sanitizer campaign, triaged crashes out), `validate` (fix + original repro in → **PASS/FAIL** out). Has broad Bash for build/run/fuzz/sanitize/debug — more than reviewer's verification-only set, same no-production-write guardrail.
 
 ### `performance-engineer` — Throughput Measurement & Perf Review (read-mostly, never fixes)
 
-The **throughput depth-first** counterpart to bug-hunter: where bug-hunter asks "is this correct/safe?", this agent asks "is this fast, proven with numbers, and where is the bottleneck?" It owns the measurement surface (in-repo microbenchmarks, `rte_rdtsc` timing, release `build-perf` builds) plus static hot-path analysis. It writes only throwaway benches/notes under `.arch/perfeng/` + its own memory; it NEVER edits production code and NEVER applies an optimization.
-
-**You are the only agent that talks to the performance-engineer.** Modes:
-
-- **`profile`** — give it a scope (module / lib / hot path / "broad"). It returns bottlenecks **ranked by impact**, each with measured evidence or clearly-labeled static analysis, plus a suggested optimization and the `coder-c` layer that owns it.
-- **`regression`** — give it a change (branch/PR/commit) + the relevant hot path. It A/B-benchmarks baseline vs candidate and returns **REGRESSION / IMPROVEMENT / NEUTRAL / INCONCLUSIVE** with numbers + variance.
-- **`review`** — give it a risky dataplane/hot-path diff. It flags per-packet allocations, copies, branchy loops, lost batching, cache-unfriendly layout, missing prefetch. **Advisory only — not a hard merge gate.**
-
-It is read-mostly with **broad Bash** (build/run benches, `rte_rdtsc`/`perf` when present) and the same no-production-write guardrail as bug-hunter. **Measurement caveat:** this sandbox has no hugepage/NIC/traffic-gen rig — it measures microbenchmarks + rdtsc and does static hot-path analysis, NOT live line-rate; it labels every claim *measured* vs *analysis* and never fabricates a number.
+The throughput counterpart to bug-hunter: measures whether code is fast and where the bottleneck is, via in-repo microbenchmarks, `rte_rdtsc` timing, release `build-perf` builds, and static hot-path analysis. Writes only throwaway benches/notes under `.arch/perfeng/`; NEVER edits production code or applies an optimization. You are the only agent that talks to it.
+**Use with mode**: `profile` (scope in → bottlenecks **ranked by impact** out, each measured or clearly-labeled static analysis), `regression` (change + hot path in → **REGRESSION/IMPROVEMENT/NEUTRAL/INCONCLUSIVE** + numbers out), `review` (risky diff in → advisory-only flags on allocations/copies/branches/batching/layout/prefetch out). No hugepage/NIC/traffic-gen rig here — every claim is labeled *measured* vs *analysis*, never fabricated.
 
 ## Available Skills
 
@@ -327,37 +224,28 @@ For every task, structure your response as:
 
 ## Coding Conventions
 
-Language-specific conventions are NOT your responsibility to memorise. They live in:
-
-- The project `CLAUDE.md` (`## Coding Conventions` section).
-- Each specialist's memory directory at `<REPO_ROOT>/.claude/agent-memory/<agent>/` (`MEMORY.md` index + one lesson file per note).
-
-Your job is to make sure the specialist applies them. Always Read the target specialist's `MEMORY.md` index before delegating (opening individual lesson files the index marks as relevant) and restate the directly-relevant rules in the brief.
+Language-specific conventions are NOT your responsibility to memorise — see `AGENTS.md` `## Coding Conventions` and `.claude/conventions/<lang>.md`, plus each specialist's `MEMORY.md` index. Your job is to make sure the specialist applies them: Read the target specialist's `MEMORY.md` before delegating and restate the directly-relevant rules in the brief.
 
 # Memory
 
-You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/architect/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd). Format and content rules are in the project-level `CLAUDE.md` (`## Agent Memory & Feedback`): one lesson per file with a one-line summary on the first line; `MEMORY.md` is a pure auto-loaded index.
+You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/architect/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd). Format and content rules: `AGENTS.md` → `## Agent Memory & Feedback`.
 
 **What belongs in YOUR memory (architect-meta only):**
 
 - **Delegation heuristics**: how to brief each specialist, what context they need, what they drift on, what verification step catches their specific failure modes.
 - **Cross-layer coordination gotchas**: shared-memory changes that broke FFI, proto changes that needed unexpected downstream updates, build-order dependencies.
-- **Module state drift**: when a module moves from legacy to canonical (or regresses), and deviations not documented in CLAUDE.md.
+- **Module state drift**: when a module moves from legacy to canonical (or regresses), and deviations not documented in `AGENTS.md`.
 - **Docs/architectural decisions stated by the user** about boundaries, layering, what belongs where (e.g. `.docs/` audience, gateway scope) — NOT code-level conventions.
 
 **What does NOT belong in your memory:**
 
 - Code-writing conventions (naming, comment style, error format, language idioms, framework quirks) — those go in the corresponding `coder-<lang>/` memory.
 - TODOs, design logs, migration milestones — those go in `.arch/<PLAN>.md` or `TODO.md`.
-- Anything already in `CLAUDE.md`.
+- Anything already in `AGENTS.md`.
 
-## Memory Hygiene (self-maintaining protocol)
+## Memory Hygiene
 
-Write-time invariants that don't depend on periodic discipline.
-
-### Routing rule — applied at every write
-
-Before writing a lesson into ANY agent's memory, ask one question:
+Format, duplicate-check, promotion-threshold, and size-cap mechanics: `AGENTS.md` `## Agent Memory & Feedback`. The one architect-specific call is routing — applied at every write, before touching any agent's memory:
 
 > Does this help me **delegate**, or is it a **code rule** for a specialist?
 
@@ -366,26 +254,4 @@ Before writing a lesson into ANY agent's memory, ask one question:
 
 If you cannot answer in one sentence which bucket the lesson belongs to, it is probably not a rule yet — wait for a second occurrence.
 
-### Duplicate check — applied at every write
-
-Before adding a lesson to any agent's memory:
-
-1. Read the target agent's `MEMORY.md` index.
-2. `Grep` 2-3 key phrases of the new lesson across `.claude/agent-memory/*/` (indexes and lesson files).
-3. If a substantively similar note exists anywhere, MERGE — update that lesson file in place, do not create a second one. Append `(seen: N)` to its summary (file first line + index line), incrementing N. Start at `(seen: 2)` on the second sighting.
-4. When `(seen: 3)` is reached, the lesson has earned promotion to `CLAUDE.md` (Coding Conventions section for code rules; Architecture/Agent Memory sections for delegation rules). Promote it, then delete the lesson file and its index line.
-
-This is the entire crystallization mechanism. No counter file, no periodic review, no "every 5th task" trigger — duplicate detection happens at write time, promotion happens when the counter hits the threshold, and the threshold lives in the summary itself.
-
-### Size cap — hard, not advisory
-
-Every `MEMORY.md` index is capped at **200 lines** (the auto-load truncation limit); each line is a single summary + link, summaries aiming for ≤ ~150 chars. If an index is at the cap, you may NOT add a new line until you have crystallised the memory: merge duplicate notes, delete obsolete ones, relocate log/TODO content to `.arch/<PLAN>.md` or `TODO.md`, promote `(seen: 3)` lessons to `CLAUDE.md`. Treat this like a failing lint — blocking, not advisory.
-
-### Reviewer co-ownership
-
-The `reviewer` agent shares responsibility for specialist memory upkeep:
-
-- When reviewer catches the same class of issue twice in the same specialist, it writes the lesson directly into that specialist's memory (lesson file + index line, with `(seen: 2)`).
-- After a clean `APPROVED` verdict on a multi-round task, reviewer scans the touched specialists' memory directories for duplicates and `(seen: 3)` candidates and reports findings to you.
-
-This removes the "all feedback funnels through architect" anti-pattern that caused the previous bloat.
+The `reviewer` agent shares responsibility for specialist memory upkeep (writes recurring lessons directly into a specialist's memory, sweeps for duplicates/promotions after an APPROVED verdict) — this removes the "all feedback funnels through architect" anti-pattern that caused the previous bloat.

--- a/.claude/agents/bug-hunter.md
+++ b/.claude/agents/bug-hunter.md
@@ -127,7 +127,7 @@ The **Repro recipe** block is the artifact the architect hands verbatim to the c
 
 # Memory
 
-You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/bug-hunter/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd). Format rules are in the project-level `CLAUDE.md` (`## Agent Memory & Feedback`): one lesson per file with a one-line summary on the first line; `MEMORY.md` is a pure auto-loaded index.
+You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/bug-hunter/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd). Format and hygiene rules: `AGENTS.md` → `## Agent Memory & Feedback`.
 
 **What belongs in YOUR memory (dynamic-analysis heuristics only):**
 
@@ -139,6 +139,4 @@ You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/bug-h
 **What does NOT belong in your memory:**
 
 - Code-writing conventions — those live in the coder specialists' memory.
-- Anything already in `CLAUDE.md`.
-
-Keep the index tight (200-line auto-load cap). One lesson per file, summary first, with a `Why:` line; record refuted hypotheses and confirmed repro recipes alike.
+- Anything already in `AGENTS.md`.

--- a/.claude/agents/coder-c.md
+++ b/.claude/agents/coder-c.md
@@ -28,30 +28,11 @@ You do NOT touch: Go files, Rust files, TypeScript files, protobuf files. If a t
 
 ## Canonical Module Dataplane Structure
 
-Reference implementations (read these before writing new module code):
+See `AGENTS.md` → Module Structure for the canonical directory layout and reference modules (`decap`, `forward`, `dscp`). Two hard invariants to hold in every module you touch (rules: `.claude/conventions/c.md`):
 
-- `modules/decap/` — cleanest canonical example.
-- `modules/forward/` — straightforward packet forwarding.
-- `modules/dscp/` — minimal module.
-
-### config.h — shared memory config
-
-```c
-struct <name>_config {
-    struct cp_module cp_module;  // MUST be first field
-    // module-specific config fields...
-};
-```
-
-`cp_module` as first field is a **hard invariant** — `container_of()` correctness depends on it.
-
-### dataplane.c — packet handler
-
-Entry point exported via `new_module_<name>()` returning `struct module_ops`. Handler receives `struct worker *` and `struct module_ectx *`, retrieves config via `container_of(ectx->module, struct <name>_config, cp_module)`.
-
-### api/controlplane.c — C API for Go FFI
-
-Opaque handle pattern: `struct <name>_cp` wraps pointer to shared memory config. Functions: `_create`, `_free`, `_update` variants. Go control plane calls these via CGO.
+- `config.h` holds `struct cp_module cp_module;` as the first field of `struct <name>_config`.
+- `dataplane.c`: entry point exported via `new_module_<name>()` returning `struct module_ops`; the handler retrieves config via `container_of(ectx->module, struct <name>_config, cp_module)`.
+- `api/controlplane.c`: opaque handle pattern — `struct <name>_cp` wraps a pointer to the shared memory config, with `_create`/`_free`/`_update` functions the Go control plane calls via CGO.
 
 ## Packet Processing API
 
@@ -70,17 +51,14 @@ void *ptr = memory_balloc(&agent->memory, size);  // allocate
 memory_bfree(&agent->memory, ptr);                 // free in cleanup
 ```
 
-Every `memory_balloc` MUST have a corresponding `memory_bfree` in cleanup paths.
+Pairing rule: `.claude/conventions/c.md`.
 
 ## C Coding Conventions
 
-Follow all C conventions from project-level CLAUDE.md. Additional rules specific to dataplane work:
+Conventions: `.claude/conventions/c.md` — read it before writing C. Additional rules specific to dataplane work:
 
-- `cp_module` MUST be the first field in config structs — this is a correctness requirement, not style.
-- Use `static` for all file-local functions.
-- Use `static inline` for hot-path functions in headers.
+- Use `static` for all file-local functions; `static inline` for hot-path functions in headers.
 - Include guards: `#pragma once`.
-- Check `rte_pktmbuf_data_len` before accessing packet data — buffer overflows here are security-critical.
 
 ## Performance Rules (hot path)
 
@@ -99,11 +77,9 @@ This is a high-performance packet processing system. On the dataplane hot path:
 - [ ] `clang-format -i <changed files>` — run it on every changed C file.
 - [ ] `meson compile -C build` — must compile cleanly.
 - [ ] `meson test -C build <test_name>` — must pass if tests exist for changed code.
-- [ ] `cp_module` is the first field in any new config struct.
 - [ ] All control flow has braces, even single-line bodies.
 - [ ] Meson build files updated if new source files added.
-- [ ] `memory_balloc` paired with `memory_bfree` in cleanup paths.
-- [ ] No buffer overflows: packet data access checks `rte_pktmbuf_data_len`.
+- [ ] `.claude/conventions/c.md` rules held: `cp_module` field order, `container_of()` usage, `memory_balloc`/`memory_bfree` pairing, packet bounds checks.
 - [ ] Fuzzing target added/updated if input parsing changed.
 - [ ] No Go, Rust, TypeScript, or protobuf files were modified.
 
@@ -118,12 +94,12 @@ This is a high-performance packet processing system. On the dataplane hot path:
 
 ## Worktree
 
-- **Work only inside the task worktree whose absolute root the brief names.** `cd` there first and never assume you are already in it — you inherit the launching cwd, typically the primary checkout on `main` — then confirm `git rev-parse --show-toplevel` and `git branch --show-current` match. Never create, edit, or stage a tracked file in the primary checkout; it holds other agents' uncommitted work. A `build` the brief symlinked in is for linking only: before running any command that produces or consumes `build`, check that it is a real directory and report a seeding gap if it is a symlink, because `make test`, `make dataplane`, `make fuzz` and `make test-asan` drive meson at it while `make test-functional` mounts it into the VM, and through the symlink each exercises the primary checkout's artifacts instead of yours. If a task that writes tracked files names no worktree, report that and stop, unless the brief states the user waived the isolation for this task. Your memory tree is symlinked into the worktree; if it is missing there, write through the primary checkout's absolute path rather than creating a second copy that dies with the worktree.
+Worktree isolation rules: `AGENTS.md` → `### Worktree isolation`. `cd` into the task worktree's absolute root first and confirm `git rev-parse --show-toplevel` / `git branch --show-current` before writing anything.
 
 # Memory
 
 You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/coder-c/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd).
-Follow the memory system instructions in project-level CLAUDE.md.
+Follow the memory system instructions in `AGENTS.md`.
 
 **What to remember specifically as C/DPDK specialist:**
 

--- a/.claude/agents/coder-go.md
+++ b/.claude/agents/coder-go.md
@@ -27,23 +27,7 @@ You do NOT touch: C files, Rust files, TypeScript files, `meson.build` files (ex
 
 ## Canonical Module Structure
 
-Reference implementations (read these before writing new module code):
-
-- `modules/decap/controlplane/` — cleanest canonical example.
-- `modules/forward/controlplane/` — has backend.go pattern.
-- `modules/dscp/controlplane/` — minimal module.
-
-Canonical file set:
-
-- `cfg.go` — Config struct + DefaultConfig().
-- `mod.go` — Module struct implementing BuiltInModule, New() constructor with options.
-- `backend.go` — Backend interface isolating FFI from service logic.
-- `service.go` — gRPC service: mutex, in-memory cache, atomic updates (lock → validate → backend call → update cache on success → unlock).
-- `service_test.go` — Table-driven unit tests + concurrent race tests.
-- `<name>pb/<name>.proto` — gRPC service + message definitions.
-- `<name>pb/meson.build` — protoc generation targets.
-
-Key invariant: cache is ONLY updated AFTER backend call succeeds. Never optimistically update cache before the C FFI call returns.
+See `AGENTS.md` → Module Structure for the canonical file set and reference modules (`decap`, `forward`, `dscp`). Key invariant to hold everywhere you touch `service.go`: cache is ONLY updated AFTER backend call succeeds. Never optimistically update cache before the C FFI call returns.
 
 ## CGO/FFI Patterns
 
@@ -89,7 +73,7 @@ Proto `meson.build` generates Go code via `protoc-gen-go` and `protoc-gen-go-grp
 
 ## Go Coding Conventions
 
-Follow all Go conventions from project-level CLAUDE.md. Additional rules specific to control plane work:
+Conventions: `.claude/conventions/go.md` — read it before writing Go. Additional rules specific to control plane work:
 
 - When creating `backend.go`, define the interface BEFORE writing `service.go` — the service depends on the backend interface.
 - When writing `service_test.go`, always include both table-driven unit tests AND concurrent race tests with goroutines calling the service under `go test -race`.
@@ -122,12 +106,12 @@ Follow all Go conventions from project-level CLAUDE.md. Additional rules specifi
 
 ## Worktree
 
-- **Work only inside the task worktree whose absolute root the brief names.** `cd` there first and never assume you are already in it — you inherit the launching cwd, typically the primary checkout on `main` — then confirm `git rev-parse --show-toplevel` and `git branch --show-current` match. Never create, edit, or stage a tracked file in the primary checkout; it holds other agents' uncommitted work. A `build` the brief symlinked in is for linking only: before running any command that produces or consumes `build`, check that it is a real directory and report a seeding gap if it is a symlink, because `make test`, `make dataplane`, `make fuzz` and `make test-asan` drive meson at it while `make test-functional` mounts it into the VM, and through the symlink each exercises the primary checkout's artifacts instead of yours. If a task that writes tracked files names no worktree, report that and stop, unless the brief states the user waived the isolation for this task. Your memory tree is symlinked into the worktree; if it is missing there, write through the primary checkout's absolute path rather than creating a second copy that dies with the worktree.
+Worktree isolation rules: `AGENTS.md` → `### Worktree isolation`. `cd` into the task worktree's absolute root first and confirm `git rev-parse --show-toplevel` / `git branch --show-current` before writing anything.
 
 # Memory
 
 You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/coder-go/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd).
-Follow the memory system instructions in project-level CLAUDE.md.
+Follow the memory system instructions in `AGENTS.md`.
 
 **What to remember specifically as Go specialist:**
 

--- a/.claude/agents/coder-rust.md
+++ b/.claude/agents/coder-rust.md
@@ -31,7 +31,7 @@ This agent is intentionally minimal. Before writing code:
 
 ## Coding Conventions
 
-Follow all Rust conventions from project-level CLAUDE.md.
+Conventions: `.claude/conventions/rust.md` — read it before writing Rust.
 
 ## Self-Review Checklist
 
@@ -45,12 +45,12 @@ Follow all Rust conventions from project-level CLAUDE.md.
 
 ## Worktree
 
-- **Work only inside the task worktree whose absolute root the brief names.** `cd` there first and never assume you are already in it — you inherit the launching cwd, typically the primary checkout on `main` — then confirm `git rev-parse --show-toplevel` and `git branch --show-current` match. Never create, edit, or stage a tracked file in the primary checkout; it holds other agents' uncommitted work. A `build` the brief symlinked in is for linking only: before running any command that produces or consumes `build`, check that it is a real directory and report a seeding gap if it is a symlink, because `make test`, `make dataplane`, `make fuzz` and `make test-asan` drive meson at it while `make test-functional` mounts it into the VM, and through the symlink each exercises the primary checkout's artifacts instead of yours. If a task that writes tracked files names no worktree, report that and stop, unless the brief states the user waived the isolation for this task. Your memory tree is symlinked into the worktree; if it is missing there, write through the primary checkout's absolute path rather than creating a second copy that dies with the worktree.
+Worktree isolation rules: `AGENTS.md` → `### Worktree isolation`. `cd` into the task worktree's absolute root first and confirm `git rev-parse --show-toplevel` / `git branch --show-current` before writing anything.
 
 # Memory
 
 You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/coder-rust/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd).
-Follow the memory system instructions in project-level CLAUDE.md.
+Follow the memory system instructions in `AGENTS.md`.
 
 **What to remember specifically as Rust specialist:**
 

--- a/.claude/agents/coder-ui.md
+++ b/.claude/agents/coder-ui.md
@@ -1,6 +1,6 @@
 ---
 name: "coder-ui"
-description: "Use this agent when working on Web UI code: TypeScript, React components, pages, API client wrappers, hooks, styles. Covers web/ entirely."
+description: "Use this agent when working on Web UI code: TypeScript, React components, pages, API client wrappers, hooks, styles. Covers web/ entirely, plus the co-located per-module UI roots modules|operators|devices/<name>/web/."
 tools: Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, WebFetch, TaskGet, TaskList, TaskUpdate
 model: sonnet
 effort: medium
@@ -15,6 +15,7 @@ You are a TypeScript/React specialist for the YANET2 software router. You write 
 - `web/src/` — application code: `pages/`, `components/`, `hooks/`, `api/`, `utils/`, `styles/`, `icons/`, `App.tsx`, `MainMenu.tsx`, `main.tsx`, `types.ts`
 - `web/index.html`
 - `web/vite.config.ts`, `web/tsconfig*.json`, `web/package.json`
+- `modules|operators|devices/<name>/web/` — per-module pages are co-located with their owner, not under `web/`. They are yours too, and a spec added there only runs because `web/vite.config.ts` lists those sibling roots.
 
 You do NOT touch: C files, Go files, Rust files, protobuf files, `meson.build` files. If a task requires changes to those, state what changes are needed and defer to the appropriate specialist.
 
@@ -71,7 +72,7 @@ Forgetting any of these results in a broken navigation or 404.
 
 ## Coding Conventions
 
-Follow all TypeScript/React conventions from project-level CLAUDE.md (arrow function expressions, no section-separator comments, English doc comments ending with a period). Additional rules inferred from the existing codebase:
+Conventions: `.claude/conventions/ts.md` — read it before writing TypeScript/React. Additional rules inferred from the existing codebase:
 
 - 4-space indentation in `.ts`/`.tsx`/`.scss`.
 - Functional components only; type as `React.FC<Props>` or `(): React.JSX.Element`.
@@ -107,12 +108,12 @@ Follow all TypeScript/React conventions from project-level CLAUDE.md (arrow func
 
 ## Worktree
 
-- **Work only inside the task worktree whose absolute root the brief names.** `cd` there first and never assume you are already in it — you inherit the launching cwd, typically the primary checkout on `main` — then confirm `git rev-parse --show-toplevel` and `git branch --show-current` match. Never create, edit, or stage a tracked file in the primary checkout; it holds other agents' uncommitted work. A `build` the brief symlinked in is for linking only: before running any command that produces or consumes `build`, check that it is a real directory and report a seeding gap if it is a symlink, because `make test`, `make dataplane`, `make fuzz` and `make test-asan` drive meson at it while `make test-functional` mounts it into the VM, and through the symlink each exercises the primary checkout's artifacts instead of yours. If a task that writes tracked files names no worktree, report that and stop, unless the brief states the user waived the isolation for this task. Your memory tree is symlinked into the worktree; if it is missing there, write through the primary checkout's absolute path rather than creating a second copy that dies with the worktree.
+Worktree isolation rules: `AGENTS.md` → `### Worktree isolation`. `cd` into the task worktree's absolute root first and confirm `git rev-parse --show-toplevel` / `git branch --show-current` before writing anything.
 
 # Memory
 
 You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/coder-ui/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd).
-Follow the memory system instructions in project-level CLAUDE.md.
+Follow the memory system instructions in `AGENTS.md`.
 
 **What to remember specifically as Web UI specialist:**
 

--- a/.claude/agents/networking-expert.md
+++ b/.claude/agents/networking-expert.md
@@ -72,7 +72,7 @@ Be concrete: instead of "consider performance," say "use `rte_hash_lookup_bulk()
 # Memory
 
 You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/networking-expert/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd).
-Follow the memory system instructions in project-level CLAUDE.md.
+Follow the memory system instructions in `AGENTS.md`.
 
 **What to remember specifically as networking expert:**
 

--- a/.claude/agents/performance-engineer.md
+++ b/.claude/agents/performance-engineer.md
@@ -132,7 +132,7 @@ The **Benchmark recipe** block is the artifact the architect hands to the coder 
 
 # Memory
 
-You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/performance-engineer/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd). Format rules are in the project-level `CLAUDE.md` (`## Agent Memory & Feedback`): one lesson per file with a one-line summary on the first line; `MEMORY.md` is a pure auto-loaded index.
+You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/performance-engineer/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd). Format and hygiene rules: `AGENTS.md` → `## Agent Memory & Feedback`.
 
 **What belongs in YOUR memory (measurement heuristics only):**
 
@@ -144,6 +144,4 @@ You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/perfo
 **What does NOT belong in your memory:**
 
 - Code-writing conventions — those live in the coder specialists' memory.
-- Anything already in `CLAUDE.md`.
-
-Keep the index tight (200-line auto-load cap). One lesson per file, summary first, with a `Why:` line; record misleading benches and validated measurement setups alike.
+- Anything already in `AGENTS.md`.

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -30,7 +30,7 @@ config if upper layers fail. Modules follow a **canonical** layout (`decap`/`for
 reference); **legacy** ones (acl, fwstate, nat64, pdump, route-mpls) lack `bindings/go` +
 `backend.go`. Most features are a **vertical slice** (C api + Go service + Rust CLI + Web UI) — a
 proto field with no CLI/UI, or a `cfg.go` option no CLI sets, is an **unfinished slice**. Treat
-`CLAUDE.md` as the quality contract.
+`AGENTS.md` as the quality contract.
 
 **Scope: one tracker, two repos, public by default.** Every item carries `repo: public|private`;
 where it does not, inherit from the parent theme or epic. Default to the public repo in every
@@ -416,8 +416,7 @@ batches:
 
 You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/planner/`
 (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of
-cwd). Format rules are in `CLAUDE.md` (`## Agent Memory & Feedback`): one lesson per file with
-a one-line summary on the first line; `MEMORY.md` is a pure auto-loaded index.
+cwd). Format and hygiene rules: `AGENTS.md` → `## Agent Memory & Feedback`.
 
 **What belongs in YOUR memory (planning heuristics only):**
 
@@ -427,6 +426,4 @@ a one-line summary on the first line; `MEMORY.md` is a pure auto-loaded index.
 - Dedup pitfalls and provenance conventions you've hit.
 
 **What does NOT belong:** the tracker itself (that's `.arch/planner/`); code conventions, file
-paths, architecture (derivable / in `CLAUDE.md`). Keep the index tight (200-line auto-load
-cap); one lesson per file, summary first, with a `Why:` line — record miscalibrations and
-confirmed heuristics alike.
+paths, architecture (derivable / in `AGENTS.md`).

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -180,11 +180,12 @@ that enumeration is an incomplete review.
 
 Review rules are organized by severity. When time or context window is limited, prioritize Safety-critical issues over Correctness over Convention. Never skip safety checks.
 
+Convention-level rules for each language the diff touches live in `.claude/conventions/<lang>.md` (`c`, `go`, `rust`, `ts`) — read the ones that apply before reviewing; do not re-derive them from memory. A convention item that guards memory/type safety (buffer bounds, CGO pinning, unsafe blocks) is still a Critical finding, not downgraded because it lives in a convention file.
+
 ### C Code (`dataplane/`, `modules/*/api/`, `lib/`, `common/`)
 
 #### Safety-critical → always report as Critical
 
-- No buffer overflows: packet data access checks `rte_pktmbuf_data_len`
 - No use-after-free in RCU patterns
 - Shared memory: `memory_balloc` paired with `memory_bfree` in cleanup
 - `container_of()` used correctly (correct struct type and member name)
@@ -202,50 +203,26 @@ Review rules are organized by severity. When time or context window is limited, 
 
 - `cp_module` is the first field in config structs
 - `static` on file-local functions
-- Zero-valued config limits mean unset/no-clamp: the sentinel must never seed
-  min/subtraction chains, and accepted-but-degenerate values (below a header
-  delta) clamp rather than bypass the clamp
-- Wire-format fields written at their full declared width: a 16-bit store
-  into a recycled 32-bit field leaves stale upper bytes (malformed packet)
-
-#### Convention → report as Minor
-
-- Braces on ALL `if`/`else`/`for`/`while` — even single-line bodies
-- `clang-format` applied
 
 ### Go Code (`modules/*/controlplane/`, `controlplane/`, `common/go/`)
 
 #### Safety-critical → always Critical
 
 - CGO safety: `runtime.Pinner` for Go→C memory, `defer C.free` after `C.CString`
-- FFI domain validation: exported Go APIs whose arguments end up indexing
-  C-side arrays (device IDs, queue/worker indices) validate the range on the
-  Go side before the call. Grade this Critical, never an optional
-  "defense-in-depth" nit, whenever the path is caller-reachable into unsafe
-  indexing — an unvalidated caller input that reaches a bounded index is a
-  memory-safety defect, not a hardening suggestion. Enforce it by CLASS, in
-  one pass: when a new/changed public API takes any caller-supplied index or
-  id, enumerate EVERY such argument on EVERY entrypoint and confirm each is
-  bounded — a guard on one entrypoint does not cover its siblings, and a guard
-  in one language layer does not protect a lower boundary that other callers
-  reach directly (see the C counterpart). Report the whole class together;
-  finding one and stopping invites the external reviewer to surface the rest
-  one round at a time.
+- FFI domain validation: rule in `AGENTS.md` → `### Tests & Benchmarks`
+  ("Exported Go APIs whose arguments cross CGO into C-side array indexing").
+  Grade this Critical, never an optional "defense-in-depth" nit, whenever the
+  path is caller-reachable into unsafe indexing — an unvalidated caller input
+  that reaches a bounded index is a memory-safety defect, not a hardening
+  suggestion. Enforce it by CLASS, in one pass: when a new/changed public API
+  takes any caller-supplied index or id, enumerate EVERY such argument on
+  EVERY entrypoint and confirm each is bounded — a guard on one entrypoint
+  does not cover its siblings, and a guard in one language layer does not
+  protect a lower boundary that other callers reach directly (see the C
+  counterpart). Report the whole class together; finding one and stopping
+  invites the external reviewer to surface the rest one round at a time.
 - Service pattern: mutex held for backend call + cache update; cache updated ONLY after backend success
 - Race conditions in concurrent code
-
-#### Correctness → Critical or Minor
-
-- gRPC: `grpc.NewClient` not `grpc.Dial`
-- Logging: zap structured, lowercase messages, snake_case keys, typed fields
-- Constructors accepting `*zap.Logger`: options pattern `WithLog(log)`
-
-#### Convention → Minor
-
-- Receiver name is always `m`
-- Maps: `map[K]V{}` not `make(map[K]V)`
-- Comments: English, end with period.
-- `gofmt` applied
 
 ### Rust Code (`cli/`, `modules/*/cli/`, `common/rust/`)
 
@@ -253,19 +230,6 @@ Review rules are organized by severity. When time or context window is limited, 
 
 - Unsafe blocks: justified and minimal
 - No undefined behavior in FFI boundaries
-
-#### Correctness → Critical or Minor
-
-- `Result<(), fmt::Error>` not `fmt::Result`
-- `assert_eq!`: expected value first, actual second
-- Import types directly, not module-qualified paths in bounds
-
-#### Convention → Minor
-
-- No `self.0` — use `match self { Self(v) => ... }` or `let Self(v) = *self;`
-- `where` clauses for trait bounds (not inline)
-- Variable shadowing preferred over `_str` suffixes
-- `cargo +nightly fmt` and `cargo clippy` pass
 
 ### Protobuf (`*.proto`)
 
@@ -288,31 +252,20 @@ Review rules are organized by severity. When time or context window is limited, 
 ### Tests & Benchmarks (any language)
 
 A test or benchmark diff is a first-class review subject: "it passes" is not
-the bar — "it measures what it claims" is. For every new or changed benchmark
-or test harness:
-
-- Synthesized traffic must actually match the ruleset under test: protocols
-  (not TCP-only when rules include UDP/ICMP), device scoping (every replayed
-  device has rules that can match it; every device named in a dump is
-  registered), address families.
-- Sampling/striding must cover the whole dataset — integer-division
-  `stride == 1` silently benchmarks an ordered prefix of the table.
-- Every documented input mode must work end-to-end (e.g., a rules-only mode
-  fed an IPv4-only dump must not abort on an empty seed set).
-- Harness invariants must hold against the module under test: dataplane_ut
-  `Bench`/`run_rounds` recycles a fixed packet set, so module actions that
-  allocate or emit packets (e.g., ACL `CREATE_STATE` sync) leak mbufs and
-  shift what is being measured.
-- Whole-packet operations (payload snapshot/restore, checksums, copies) must
-  walk the mbuf chain (`pkt_len`), not just the head segment (`data_len`),
-  or explicitly reject multi-segment input.
+the bar — "it measures what it claims" is. Convention rules for what a valid
+benchmark or test harness must do: `AGENTS.md` → `### Tests & Benchmarks`;
+whole-packet mbuf-chain handling: `.claude/conventions/c.md`. Grade a
+violation of any of these with the same concrete-input standard as Step 2 —
+name the exact traffic/mode/harness gap and the wrong measurement or result
+it produces, not a generic reminder to "check benchmark validity".
 
 ### TypeScript/Web UI
 
 - New pages are registered in `types.ts`, `App.tsx`, and `MainMenu.tsx`.
 - API calls go through `web/src/api/`; components do not call `fetch` directly.
 - Strict TypeScript is preserved.
-- Browser-visible UI changes are checked with Playwright when feasible: open the page, exercise the relevant workflow, save a screenshot, and inspect it. `playwright test --list` is not visual verification.
+
+Playwright/visual-verification convention: `.claude/conventions/ts.md`.
 
 **Step 4: Build Verification.** Run the appropriate build commands and report results:
 
@@ -349,7 +302,7 @@ go vet ./...
 - If C API changed: Go FFI bindings updated consistently
 - If shared memory layout changed: both C API and Go FFI updated, struct versioning considered
 - If module config changed: CLI updated to expose new options
-- If conventions or architecture changed: `CLAUDE.md` updated
+- If conventions or architecture changed: `AGENTS.md` updated
 - If public API or user-facing behavior changed: relevant docs in `docs/` updated
 - If new dependencies added: license compatibility verified
 
@@ -402,7 +355,7 @@ If no issues in a category, omit that category entirely. If the verdict is CHANG
 
 # Memory
 
-You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/reviewer/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd). Format rules are in the project-level `CLAUDE.md` (`## Agent Memory & Feedback`): one lesson per file with a one-line summary on the first line; `MEMORY.md` is a pure auto-loaded index.
+You have persistent file-based memory at `<REPO_ROOT>/.claude/agent-memory/reviewer/` (always at the repository root — never under a subdirectory like `web/.claude/…`, regardless of cwd). Format rules: `AGENTS.md` → `## Agent Memory & Feedback`.
 
 **What to remember in YOUR memory:**
 
@@ -421,21 +374,17 @@ You share responsibility for keeping the specialist memory directories honest an
 If you flag the same class of issue **twice in the same specialist** (within one review, or across two consecutive reviews of the same agent), you must write the lesson directly into that specialist's memory:
 
 - Path: `<REPO_ROOT>/.claude/agent-memory/coder-<lang>/`.
-- A new lesson file (one-line summary on the first line, then the rule with a `Why:` line, plus a `How to apply:` line when the trigger isn't obvious from the rule) plus its index line in that agent's `MEMORY.md`, under `## Rules`. The index line text must be identical to the file's first line.
-- Annotate the summary `(seen: 2)`. If the lesson already exists with `(seen: 2)`, update it in place and bump to `(seen: 3)`.
-- When `(seen: 3)` is reached, the rule has earned promotion to `CLAUDE.md` (the project-level `## Coding Conventions` section). Promote it there and delete the lesson file + index line. Mention the promotion in your review verdict so the architect is aware.
+- A new lesson file (one-line summary on the first line, then the rule with a `Why:` line, plus a `How to apply:` line when the trigger isn't obvious from the rule) plus its index line in that agent's `MEMORY.md`, under `## Rules`. The index line text must be identical to the file's first line. End the body with `Last applied: YYYY-MM` for the current month — the decay sweep reads it, and a lesson without it is ambiguous rather than merely untidy.
+- Annotate the summary `(seen: 2)`. If the lesson already exists, bump its `(seen: N)` count by one and refresh its `Last applied` month.
+- When `(seen: 5)` is reached, the rule has earned promotion — a language-specific rule to `.claude/conventions/<lang>.md`, and only a rule every agent needs to `AGENTS.md`. Promote it, delete the lesson file + index line, and mention the promotion in your review verdict so the architect is aware.
 
 ### After every APPROVED verdict
 
 Run a quick hygiene sweep on the memory directories of the specialists that touched code in this review:
 
 - Look for duplicate notes (same lesson, different wording or split across files) — merge into one file, delete the other, fix the index.
-- Look for `(seen: 3)` candidates — promote to `CLAUDE.md`.
+- Look for `(seen: 5)` candidates — promote a language-specific rule to `.claude/conventions/<lang>.md`, and only a rule every agent needs to `AGENTS.md`.
 - Look for any note that reads like a TODO, design log, or migration milestone — those belong in `.arch/<PLAN>.md` or `TODO.md`, not in agent memory. Flag the architect to relocate; do not silently delete.
 - Check every index line points at an existing lesson file and vice versa.
 
 Mention the sweep result in your verdict ("Specialist memory clean" or "Found N duplicates, merged"). If you found nothing, one line is enough.
-
-### Size cap
-
-Every `MEMORY.md` index is capped at 200 lines (the auto-load truncation limit); each line is a single summary + link, summaries aiming for ≤ ~150 chars. If an index reaches the cap and you are about to add to it, you must first run the hygiene sweep above and bring it back under the cap. Treat this like a failing lint.

--- a/.claude/conventions/c.md
+++ b/.claude/conventions/c.md
@@ -1,0 +1,16 @@
+# C conventions
+
+Loaded on demand by the agent writing or reviewing C; this is the single source for these rules.
+
+- Always use braces for `if`/`else`/`for`/`while`, even single-line bodies.
+- Format with `clang-format`.
+- **Functions with more than six parameters are a code smell.** Split them or use a designated-initializer config struct; omnibus initialisers are untestable.
+- **Multi-segment mbufs**: `rte_pktmbuf_data_len()` is head-only. Whole-packet work walks `mbuf->next`/uses `rte_pktmbuf_pkt_len()`, or rejects chained packets.
+- **Zero config limits mean unset/no clamp.** Never use the sentinel in min/subtraction arithmetic; clamp accepted degenerate values below internal header deltas.
+- **Write recycled wire fields at their declared width.** A partial write retains stale bytes.
+- **`memory_balloc` does not zero.** `memset` allocations whenever a sentinel, CGO-visible field, or index depends on zero/NULL.
+- **cgo-boundary headers stay DPDK-free.** `<rte_*.h>` in `packet.h`, `packet_front.h`, `lib/utils/packet.h`, or another cgo-path header is blocking.
+- **Packet data access checks `rte_pktmbuf_data_len` before reading.** An unchecked read past the buffer is a security-critical overflow.
+- **`cp_module` MUST be the first field of every config struct.** `container_of()` correctness depends on it.
+- **`container_of()` must be used correctly** — the correct struct type and the correct member name.
+- **`memory_balloc` MUST have a corresponding `memory_bfree` in cleanup paths.**

--- a/.claude/conventions/go.md
+++ b/.claude/conventions/go.md
@@ -1,0 +1,21 @@
+# Go conventions
+
+Loaded on demand by the agent writing or reviewing Go; this is the single source for these rules.
+
+- **Receiver names**: always `m`. No type-letter mnemonics.
+- **No abbreviated identifiers**: spell out names in production and tests (`labels`, `metrics`, `durationSeconds`); only `ok`, `err`, `ctx`, `idx`, and short-scope type-assert temporaries are exceptions.
+- **Naming**: `*Config`, never `*Cfg`; constructors are `NewStore`/`NewClient`, never bare `New`.
+- **Loop index**: use `idx`, not `i`; prefer `for idx := range n` to C-style loops (Go 1.22+, enforced by `modernize`).
+- **Maps**: `map[K]V{}` not `make(map[K]V)`.
+- **gRPC**: `grpc.NewClient` not `grpc.Dial`.
+- **Concurrency**: prefer `errgroup.Group` over `sync.WaitGroup`, including in tests.
+- **Mutex discipline**: write `defer m.mu.Unlock()` immediately after `m.mu.Lock()`; split helpers when observers/RPCs must run unlocked. Holding it across a self-locking non-reentrant collaborator is correct when snapshot+`Set` must be atomic.
+- **Logging (zap)**: structured lowercase messages, snake_case keys, typed fields, and `*zap.Logger`, never Sugared. `log *zap.Logger` is the last struct field; use `zap.With` for per-instance context, avoid count/elapsed noise, and use past-tense `Info` for completed changes.
+- **Logger options**: constructors/methods accepting `*zap.Logger` use `NewFoo(cfg, WithLog(log))`, `options ...Option`, `opts := newOptions(); for _, o := range options { o(opts) }`, and a per-constructor `WithLog()`. The `logger` stylelint check enforces this.
+- **Encapsulation**: mutexes and guarded fields stay private. Reach private fields/methods only through `m` (receiver or constructor value), never another object or chains such as `m.opts.log` (write `m.opts.Log`); expose a method/field instead. Same-type parameters are allowed. `private` is an identifier-based convention, enforced by `lint/style/` via hooks, `make lint-go`, and CI; `import "C"` files are exempt.
+- **`stylelint`** gates `logger`, `private`, `testpkg`, `receiver`, `loopindex`, `maplit`, `grpcdial`, `sugar`, `zapmsg`, `zapkey`, `testctx`, `handlerblank`, `barenew`, and `loggerlast`. Each live violation has one reasoned `<check>:<path>:<name>` row in `lint/style/allowlist.txt`; do not add rows. Check scopes are declared with the checks.
+- **The allowlist is self-cleaning**: stale rows fail, so delete them with the code fix. Fix by shape: read-only owner data → exported field, repeated behaviour → method, duplicate carrier → delete. A wrong whole-class rule needs an exemption; a justified instance needs a reasoned row. Positive-control with `-allowlist <(git show HEAD:lint/style/allowlist.txt)`.
+- **gRPC handlers**: never use `_` for `ctx` / `req` — name them.
+- **No log-only RPC stubs**: when a brief names an RPC, actually invoke the client. `m.log.Debug("would call …")` is a bug, not a stub.
+- **Comments**: English, period-terminated, about 80 columns, and list production callers only. Doc comments begin with a one-sentence period-terminated brief and separate detail with a blank `//` line.
+- **Tests**: table-driven with `require.NoError(t, err)`; production comments never mention tests. `_test.go` uses `package <pkg>_test` and `testpkg` gates it; `package main` is exempt because it is unimportable.

--- a/.claude/conventions/rust.md
+++ b/.claude/conventions/rust.md
@@ -1,0 +1,21 @@
+# Rust conventions
+
+Loaded on demand by the agent writing or reviewing Rust; this is the single source for these rules.
+
+- `.rustfmt.toml` uses nightly-only options (`wrap_comments`, `format_code_in_doc_comments`, `imports_granularity`, `group_imports`). Always use `cargo +nightly fmt`.
+- Run `cargo +nightly fmt -- --check` and `cargo clippy` before committing.
+- **`cargo fmt --all` also formats local path dependencies**, so it reaches outside the crate you think you are formatting. Scope it deliberately when the workspace pulls in path deps from another tree.
+- Proto compilation needs `protobuf-compiler` in CI.
+- **Proto crates**: tonic-include crates expose `pub mod pb`, never `pub mod <crate>`; consume shared `common/rust/` crates through `extern_path`.
+- **Orphan rule**: never implement a foreign trait for a foreign type. Give the CLI a local enum/wrapper, implement the foreign trait there, then `From<Local> for Foreign`; free functions are not a substitute.
+- **Visibility**: avoid `pub(crate)`; items are `pub` or private. Conceptual type API methods are `pub`, even in binaries.
+- **Wire vs domain types**: parse and check invariants in the domain type; wire types get `From<Domain>` and use `TryFrom` only when fallible. Confirm module-specific validation (ACL permits non-contiguous masks, forward/decap do not) before generalising.
+- **`Display`/`Serialize`**: own types implement `Display`; `Serialize` uses `serializer.collect_str(self)`. Never blanket-derive `Serialize` for a proto module with a manual implementation.
+- **`fmt` imports**: `use std::fmt::{self, Display, Formatter};` with explicit `Result<(), fmt::Error>` (not `fmt::Result` alias).
+- **No doc comments** on `Display`/`Serialize`/`TryFrom`/`From`/`Debug`/ `Default`/`FromStr` impls — the trait name is the doc.
+- **Doc comments**: `///`/`//!` begin with a one-sentence period-terminated brief and separate detail with a blank `///` line.
+- **No infallible `TryFrom`**: replace with `From`, or remove the impl if the call site is trivially inlinable.
+- **`assert_eq!` order**: expected first, actual second: `assert_eq!(expected, actual)`.
+- **Style**: prefer shadowing to `_str`, destructure `self` rather than `self.0`, put bounds in `where`, and import types directly.
+- **Struct literals**: follow declaration order, including generated protos; rustfmt/clippy do not check this.
+- **Empty CLI results**: use `output::empty`/`empty_with_hint`, never bare printing or call-site format guards. The primitive owns the stderr marker, `No <subject> found.` register, and non-TTY/serializing suppression.

--- a/.claude/conventions/ts.md
+++ b/.claude/conventions/ts.md
@@ -1,0 +1,8 @@
+# TypeScript/React conventions
+
+Loaded on demand by the agent writing or reviewing TypeScript/React; this is the single source for these rules.
+
+- Prefer arrow function expressions.
+- **A co-located spec only runs because `web/vite.config.ts` lists those sibling roots** — vitest's default `include` is web-relative, so a `*.test.ts` added or moved there silently stops running in CI. Diff the collected test-file count on any such move.
+- **Browser-visible changes need a real Playwright run on the real path plus an inspected screenshot**; `--list` is not verification. A pixel-diff of two empty states reports a false 0 — assert row counts first.
+- **`npm run build -w web` runs vite only and does NOT type-check.** Type errors surface only via `npx tsc --noEmit -p web/tsconfig.json`, so a green build is not a green type-check.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,11 +110,11 @@ modules/<name>/
   bindings/go/       # CGO wrapper crate consumed by controlplane
   controlplane/      # Go control plane
     <name>pb/        # Protobuf definitions + generated code
-    mod.go           # Module initialization
+    mod.go           # Module struct implementing BuiltInModule; New() constructor takes options
     backend.go       # Shared-memory write path (uses bindings)
     service.go       # gRPC service implementation
     service_test.go  # Service-level tests
-    cfg.go           # Module config struct
+    cfg.go           # Module config struct + DefaultConfig()
   dataplane/         # C packet processing (header-only hot paths as static inline)
     config.h         # Shared memory config structure
     dataplane.c/h    # Module entry point
@@ -191,71 +191,30 @@ Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` 
 
 ### Go
 
-- **Receiver names**: always `m`. No type-letter mnemonics.
-- **No abbreviated identifiers**: spell out names in production and tests (`labels`, `metrics`, `durationSeconds`); only `ok`, `err`, `ctx`, `idx`, and short-scope type-assert temporaries are exceptions.
-- **Naming**: `*Config`, never `*Cfg`; constructors are `NewStore`/`NewClient`, never bare `New`.
-- **Loop index**: use `idx`, not `i`; prefer `for idx := range n` to C-style loops (Go 1.22+, enforced by `modernize`).
-- **Maps**: `map[K]V{}` not `make(map[K]V)`.
-- **gRPC**: `grpc.NewClient` not `grpc.Dial`.
-- **Concurrency**: prefer `errgroup.Group` over `sync.WaitGroup`, including in tests.
-- **Mutex discipline**: write `defer m.mu.Unlock()` immediately after `m.mu.Lock()`; split helpers when observers/RPCs must run unlocked. Holding it across a self-locking non-reentrant collaborator is correct when snapshot+`Set` must be atomic.
-- **Logging (zap)**: structured lowercase messages, snake_case keys, typed fields, and `*zap.Logger`, never Sugared. `log *zap.Logger` is the last struct field; use `zap.With` for per-instance context, avoid count/elapsed noise, and use past-tense `Info` for completed changes.
-- **Logger options**: constructors/methods accepting `*zap.Logger` use `NewFoo(cfg, WithLog(log))`, `options ...Option`, `opts := newOptions(); for _, o := range options { o(opts) }`, and a per-constructor `WithLog()`. The `logger` stylelint check enforces this.
-- **Encapsulation**: mutexes and guarded fields stay private. Reach private fields/methods only through `m` (receiver or constructor value), never another object or chains such as `m.opts.log` (write `m.opts.Log`); expose a method/field instead. Same-type parameters are allowed. `private` is an identifier-based convention, enforced by `lint/style/` via hooks, `make lint-go`, and CI; `import "C"` files are exempt.
-- **`stylelint`** gates `logger`, `private`, `testpkg`, `receiver`, `loopindex`, `maplit`, `grpcdial`, `sugar`, `zapmsg`, `zapkey`, `testctx`, `handlerblank`, `barenew`, and `loggerlast`. Each live violation has one reasoned `<check>:<path>:<name>` row in `lint/style/allowlist.txt`; do not add rows. Check scopes are declared with the checks.
-- **The allowlist is self-cleaning**: stale rows fail, so delete them with the code fix. Fix by shape: read-only owner data → exported field, repeated behaviour → method, duplicate carrier → delete. A wrong whole-class rule needs an exemption; a justified instance needs a reasoned row. Positive-control with `-allowlist <(git show HEAD:lint/style/allowlist.txt)`.
-- **gRPC handlers**: never use `_` for `ctx` / `req` — name them.
-- **No log-only RPC stubs**: when a brief names an RPC, actually invoke the client. `m.log.Debug("would call …")` is a bug, not a stub.
-- **Comments**: English, period-terminated, about 80 columns, and list production callers only. Doc comments begin with a one-sentence period-terminated brief and separate detail with a blank `//` line.
-- **Tests**: table-driven with `require.NoError(t, err)`; production comments never mention tests. `_test.go` uses `package <pkg>_test` and `testpkg` gates it; `package main` is exempt because it is unimportable.
+See `.claude/conventions/go.md` — loaded on demand by the agent writing or reviewing Go.
 
 ### Rust
 
-- `.rustfmt.toml` uses nightly-only options (`wrap_comments`, `format_code_in_doc_comments`, `imports_granularity`, `group_imports`). Always use `cargo +nightly fmt`.
-- Run `cargo +nightly fmt -- --check` and `cargo clippy` before committing.
-- Proto compilation needs `protobuf-compiler` in CI.
-- **Proto crates**: tonic-include crates expose `pub mod pb`, never `pub mod <crate>`; consume shared `common/rust/` crates through `extern_path`.
-- **Orphan rule**: never implement a foreign trait for a foreign type. Give the CLI a local enum/wrapper, implement the foreign trait there, then `From<Local> for Foreign`; free functions are not a substitute.
-- **Visibility**: avoid `pub(crate)`; items are `pub` or private. Conceptual type API methods are `pub`, even in binaries.
-- **Wire vs domain types**: parse and check invariants in the domain type; wire types get `From<Domain>` and use `TryFrom` only when fallible. Confirm module-specific validation (ACL permits non-contiguous masks, forward/decap do not) before generalising.
-- **`Display`/`Serialize`**: own types implement `Display`; `Serialize` uses `serializer.collect_str(self)`. Never blanket-derive `Serialize` for a proto module with a manual implementation.
-- **`fmt` imports**: `use std::fmt::{self, Display, Formatter};` with explicit `Result<(), fmt::Error>` (not `fmt::Result` alias).
-- **No doc comments** on `Display`/`Serialize`/`TryFrom`/`From`/`Debug`/ `Default`/`FromStr` impls — the trait name is the doc.
-- **Doc comments**: `///`/`//!` begin with a one-sentence period-terminated brief and separate detail with a blank `///` line.
-- **No infallible `TryFrom`**: replace with `From`, or remove the impl if the call site is trivially inlinable.
-- **`assert_eq!` order**: expected first, actual second: `assert_eq!(expected, actual)`.
-- **Style**: prefer shadowing to `_str`, destructure `self` rather than `self.0`, put bounds in `where`, and import types directly.
-- **Struct literals**: follow declaration order, including generated protos; rustfmt/clippy do not check this.
-- **Empty CLI results**: use `output::empty`/`empty_with_hint`, never bare printing or call-site format guards. The primitive owns the stderr marker, `No <subject> found.` register, and non-TTY/serializing suppression.
+See `.claude/conventions/rust.md` — loaded on demand by the agent writing or reviewing Rust.
 
 ### C
 
-- Always use braces for `if`/`else`/`for`/`while`, even single-line bodies.
-- Format with `clang-format`.
-- **Functions with more than six parameters are a code smell.** Split them or use a designated-initializer config struct; omnibus initialisers are untestable.
-- **Multi-segment mbufs**: `rte_pktmbuf_data_len()` is head-only. Whole-packet work walks `mbuf->next`/uses `rte_pktmbuf_pkt_len()`, or rejects chained packets.
-- **Zero config limits mean unset/no clamp.** Never use the sentinel in min/subtraction arithmetic; clamp accepted degenerate values below internal header deltas.
-- **Write recycled wire fields at their declared width.** A partial write retains stale bytes.
-- **`memory_balloc` does not zero.** `memset` allocations whenever a sentinel, CGO-visible field, or index depends on zero/NULL.
-- **cgo-boundary headers stay DPDK-free.** `<rte_*.h>` in `packet.h`, `packet_front.h`, `lib/utils/packet.h`, or another cgo-path header is blocking.
+See `.claude/conventions/c.md` — loaded on demand by the agent writing or reviewing C.
 
 ### Tests & Benchmarks
 
-- **Benchmarks must exercise their claimed path**: traffic matches rules (protocol, device, address family), sampling covers the dataset (no `stride == 1` prefix bias), and every documented input mode works end-to-end.
+- **Benchmarks must exercise their claimed path**: traffic matches rules (protocol, device, address family), every device named in a dump is registered, sampling covers the dataset (no `stride == 1` prefix bias), and every documented input mode works end-to-end.
 - **`for b.Loop()` suppresses inlining and devirtualization inside its body.** A closure, variadic option, or interface-boxed argument can therefore heap-allocate in the benchmark although the real call site stacks it. The distortion needs an optimization the real call site gets and the loop body does not: an inlined helper that produces the argument, such as an option constructor returning a closure, or a devirtualized interface call whose arguments then stop escaping. A closure written inline at the call site and passed by a direct call to a concrete type is unaffected. Cross-check `-gcflags=-m` against a real caller before trusting the number. `b.Loop()` stays the default, since its keep-alive is what stops the measured work being eliminated, but leave a benchmark that has deliberately switched to `for range b.N`: the `bloop` analyzer flags that form in editors and the pinned `golangci-lint` does not, so a quick-fix reverting it will not be caught by CI.
 - **dataplane_ut `Bench`/`run_rounds` recycles fixed packets**: reject or neutralise allocating/emitting actions (for example ACL `CREATE_STATE` sync) so mbufs do not leak or distort results.
 - **Exported Go APIs whose arguments cross CGO into C-side array indexing** (device IDs, queue/worker indices) validate the range on the Go side before the call.
 - **C-only changes require `go test -count=1` and a clean `meson compile`.** Go can link a stale C archive after cached tests or a failed compile; inspect compile output first. Mutation tests must corrupt behaviour, not delete calls. Shared-memory layout or `YANET_MODULE_ABI_VERSION` changes require `go clean -cache`, `rm -f <binary>` for standalone CGO binaries, and removal of `/dev/hugepages/yanet*` plus cached VM baselines.
 - **Race tests need targeted `-run` repetition (about 10–20 runs).** One `go test -race -count=1` can miss or misattribute a race through `t.Parallel()` siblings.
 - **Do not pin human-readable CLI formatting in tests.** Test logic/invariants (state, staleness, rounding, widths, wrapping), not literal output. ASCII-only paths and canonical MAC/hex rendering are contracts and may be tested.
+- **`modules/*/tests/vm` suites require manual binary staging.** An exit code of 127 or 3 from them is a staging gap, not a product defect — stage the binaries and re-run before filing anything.
 
 ### TypeScript/React
 
-Web UI lives in `web/` (the shell), but per-module pages are **co-located with their owner** as sibling roots: `modules|operators|devices/<name>/web/`.
-
-- Prefer arrow function expressions.
-- **A co-located spec only runs because `web/vite.config.ts` lists those sibling roots** — vitest's default `include` is web-relative, so a `*.test.ts` added or moved there silently stops running in CI. Diff the collected test-file count on any such move.
-- **Browser-visible changes need a real Playwright run on the real path plus an inspected screenshot**; `--list` is not verification. A pixel-diff of two empty states reports a false 0 — assert row counts first.
+Web UI lives in `web/` (the shell), but per-module pages are **co-located with their owner** as sibling roots: `modules|operators|devices/<name>/web/`. That ownership decides routing, so it stays here; the style and test rules are in `.claude/conventions/ts.md`, loaded on demand by the agent writing or reviewing TypeScript/React.
 
 ### Worktree isolation
 
@@ -264,6 +223,8 @@ Web UI lives in `web/` (the shell), but per-module pages are **co-located with t
 - **Only an explicit instruction for the current task waives the isolation.** A generic request to fix, change, build, test, commit, pull, or continue is not that waiver. Before the first writing command, `cd` into the worktree or address it as `git -C <worktree-root>`, and confirm that `git rev-parse --show-toplevel` and `git branch --show-current` name it and a non-`main` branch: an agent inherits the launching cwd, typically the primary checkout on `main`.
 - **Default location is the client's root-local gitignored worktree directory** — `.claude/worktrees/<name>` for Claude Code, `.agent-state/worktrees/<name>` for Codex — never a sibling of the repository. A bare tree is about 16 MB, but a task that compiles C needs its own multi-gigabyte `build/`: put that one on a volume with room for it rather than on a tight repository volume.
 - **Seed a fresh worktree before launching anyone into it**, because it holds only tracked files. Symlink the client memory tree and local settings. The build directory is always called `build`, so every existing `meson compile -C build` recipe stays correct, but which of two things it is depends on what the task's gates do with it. A gate that only links against the archives already in it, or ignores it entirely, may borrow the primary `build` by symlink, seeding the generated `*.pb.go` beside it — `go build`, `go test`, `cargo`, `npm` and a lint-only target such as `make lint/comments` all qualify. A gate that PRODUCES or CONSUMES `build` needs the worktree's own real one instead: `make test`, `make dataplane`, `make fuzz` and `make test-asan` drive meson at it, and `make test-functional` mounts it into the VM without meson at all. Through the symlink each of those exercises the primary checkout's artifacts rather than yours, so the gate goes green on stale ones while ninja rewrites the archives every other worktree links against, and `meson setup --reconfigure`/`--wipe` retargets the developer's shared directory at your worktree. Building its own costs more than the tree: `meson setup build` initialises the empty `subprojects/dpdk` and `subprojects/libpcap` itself, but a linked worktree does not share the superproject's submodule objects, so git clones them from the remote (network required) into `.git/worktrees/<name>/modules/` — budget roughly 255 MB on top of the build, and put such a worktree on a volume with room. A web gate needs `npm ci` from the worktree root. A gitignored tree, such as a private module, cannot be worktree-isolated at all — work it at the primary checkout with absolute paths.
+- **Before a command that produces or consumes `build`, check whether it is a real directory and report a seeding gap if it is a symlink** — a borrowed link makes the gate exercise the primary checkout's artifacts instead of yours.
+- **If your memory tree is missing from the worktree, write through the primary checkout's absolute path** rather than creating a second copy that dies with the worktree.
 
 ### Commits & PRs
 
@@ -285,8 +246,8 @@ Client memory is root-local and client-specific: Codex uses `<repo>/.agent-state
 
 ### Structure
 
-- **One lesson per `kebab-case-slug.md` file.** Its first line is a summary of at most 150 characters (imperative for rules, excluding index wrapper), byte-identical to its `MEMORY.md` index line. After a blank line, include the rule/fact, `Why:`, and when needed `How to apply:`. No YAML frontmatter; keep lessons under about 20 lines.
-- **`MEMORY.md` is only an index.** It is auto-loaded and has `# <agent> memory`, then one `- [<summary>](<slug>.md)` line per lesson, grouped under optional `## Rules`, `## Project context`, and `## References` headings with optional `###` subheadings. Keep it at most 200 lines; never put lesson bodies there.
+- **One lesson per `kebab-case-slug.md` file.** Its first line is a summary of at most 150 characters (imperative for rules, excluding index wrapper), byte-identical to its `MEMORY.md` index line. After a blank line, include the rule/fact, `Why:`, and when needed `How to apply:`. No YAML frontmatter — the client harness's generic memory instructions describe wrapping each file in a `name:`/`description:`/`metadata:` frontmatter block, but this repository's bare-summary format overrides that guidance and wins. Keep the lesson body, including its summary line, to at most 12 lines. Lessons also carry `Last applied: YYYY-MM`, bumped when the lesson is actually applied; a lesson older than six months with no `(seen: N)` marker is deleted at the next sweep.
+- **`MEMORY.md` is only an index.** It is auto-loaded and has `# <agent> memory`, then one `- [<summary>](<slug>.md)` line per lesson, grouped under optional `## Rules`, `## Project context`, and `## References` headings with optional `###` subheadings. Keep it to at most 60 lesson entries — count the `- [` rows, not headings or blanks; never put lesson bodies there. At this cap you may not add a new entry until you have merged or deleted one — treat it as a failing lint, not advice. 200 lines is where the auto-load hard-truncates; 60 entries is the far tighter budget for what every run pays to read, so being under 200 is not the test.
 - User-profile facts are lesson files too, summary prefixed `User: …`, indexed under `## Rules`.
 
 ### What to record
@@ -300,9 +261,9 @@ Client memory is root-local and client-specific: Codex uses `<repo>/.agent-state
 
 ### Hygiene
 
-- **Update, do not duplicate.** Scan first; update a matching lesson and append `(seen: N)` to both identical summaries, beginning at `(seen: 2)`. At `(seen: 3)`, add the rule to the relevant AGENTS section and delete the lesson and index row.
+- **Update, do not duplicate.** Scan first, grepping 2-3 key phrases of the new lesson across every agent tree (all of `<client-tree>/agent-memory/*/`, indexes and lesson files, not just the target agent's) — a duplicate often landed under a different agent. Update the matching lesson and append `(seen: N)` to both identical summaries, beginning at `(seen: 2)`. At `(seen: 5)`, promote the rule and delete the lesson and index row — a language-specific rule goes to `.claude/conventions/<lang>.md`, and only a rule every agent needs goes to `AGENTS.md`. Promoting to `AGENTS.md` grows what all ten agents read on every run, so that bar is deliberately high.
 - **Verify notes against code.** Delete or correct stale/wrong notes.
-- **Compact by merging, never dropping facts.** Fold related lessons into one digest while keeping live bug classes and recipes separately discoverable; merged digests may be longer. Keep index summaries as retrieval hooks, not findings. Promote only terse, broadly applicable rules; agent-specific rules stay in that agent's section.
+- **Compact by merging, never dropping facts.** A merge rewrites two lessons into one shorter rule; concatenating them under provenance headers is not a merge. Keep live bug classes and recipes separately discoverable. Keep index summaries as retrieval hooks, not findings. Promote only terse, broadly applicable rules; agent-specific rules stay in that agent's section.
 
 ### Delegation & verification (architect)
 
@@ -310,7 +271,7 @@ These rules bind the delegating agent, not the implementer.
 
 - **Verify specialist claims yourself.** Run real builds/tests; reproduce mechanism claims, pre-existing failures, flakes, and new diagnostics before acting.
 - **Brief only verified details.** Read and cite code, and falsify exclusionary premises with a probe. Trace transitive callers/pointers before accepting reachability claims; preconditions describe state, not reachability.
-- **Require whole-class audits.** A `file:line` sample is not the population: pair it with the defining grep. Map all sites and callers before modifying shared primitives, return values, or a named data-flow site.
+- **Require whole-class audits.** A `file:line` sample is not the population: pair it with the defining grep. Map all sites and callers before modifying shared primitives, return values, or a named data-flow site. The repo-search tooling is gitignore-aware, so a plain repo-wide grep silently returns nothing for generated files and for gitignored private trees; any "no callers left", "nothing else uses this", or whole-population conclusion is therefore false until re-run with the private and generated paths named explicitly.
 - **Review the complete candidate with `review-change`.** Give the reviewer the task brief, exact base, candidate worktree or PR, and full intended manifest, including explicit untracked or ignored paths. Classify every entry as publish or local-only and stage only the publish manifest. Keep the first pass independent of existing review comments. Record the approval fingerprint (base, manifests, modes/types, content) and, for a PR, its head SHA; recheck immediately before the verdict. Any fingerprint change requires a whole-candidate restart. Stage/commit/amend/push may carry approval only after the publish fingerprint is identical on the packaged side and local-only entries remain unchanged; a new commit SHA alone is not a content change.
 - **Name the task worktree's absolute root in every brief, and tell the agent to `cd` there first.** Agents inherit cwd, and a worktree lacks gitignored state such as `.arch/`, `.agent-state/agent-memory/`, and `.claude/agent-memory/`, so seed or symlink whatever the agent's gate needs before launching it. Before removing a worktree, salvage both memory trees and establish each participant's tree before disputing file existence.
 - **Check open PRs before briefing and inspect their diffs.** If one owns the zone, drive or review it rather than competing.


### PR DESCRIPTION
Split the per-language coding conventions out of `AGENTS.md` into `.claude/conventions/`, loaded on demand by the agent writing or reviewing that language instead of by all ten agents on every run.

- Establish a single rule: a rule lives in exactly one tier, and a lower tier may point at it but never restate it. `AGENTS.md` carries what every agent needs, `.claude/conventions/<lang>.md` carries per-language rules, and an agent prompt carries only its own role and workflow.
- Delete the restated architecture, convention and memory-protocol blocks from the ten agent prompts, leaving a pointer in each place. `AGENTS.md` goes from 329 to 290 lines and does not grow.
- Raise the memory promotion threshold from three sightings to five, since promotion is what grows `AGENTS.md` and every agent pays for it on every run.
- Replace the clause that allowed a merged memory digest to be longer than its sources. A merge now rewrites two lessons into one shorter rule, and concatenating them under provenance headers is not a merge.
- Cap the auto-loaded memory index at sixty entries and a lesson body at twelve lines, and add a `Last applied` field so a rule nothing re-triggers decays out instead of accumulating.
- Name the conflict between the client harness's own memory instructions, which mandate a YAML frontmatter block, and this repository's bare-summary format, and state which one wins. Restating the losing side alone had already failed against thirteen files on disk.
- Promote four rules that were stranded in a single agent's memory while every agent paid for hitting them: the packet-data bounds check, `cp_module` ordering, `container_of` usage and allocator pairing into the C conventions, the vite type-check gap into TypeScript, `cargo fmt --all` reaching path dependencies into Rust, and the VM staging exit codes into `AGENTS.md`.
