### PR TITLE
perf(counters): refcount counter_storage to skip rebuild for unchanged modules

### DIFF
--- a/lib/counters/counters.c
+++ b/lib/counters/counters.c
@@ -331,6 +331,17 @@ counter_storage_spawn(
 	struct counter_storage *old_counter_storage,
 	struct counter_registry *counter_registry
 ) {
+	// Fast path: if the old generation's storage was built for the same
+	// counter_registry (same pointer — the registry item was shared by
+	// refcounting across generations), the counter layout is identical.
+	// Bump the refcount and return the old storage directly, skipping the
+	// wrapper rebuild, pool copy, and handle resolution.
+	if (old_counter_storage != NULL &&
+	    ADDR_OF(&old_counter_storage->registry) == counter_registry) {
+		old_counter_storage->refcnt += 1;
+		return old_counter_storage;
+	}
+
 	struct counter_storage *new_counter_storage = (struct counter_storage *)
 		memory_balloc(memory_context, sizeof(struct counter_storage));
 	if (new_counter_storage == NULL)
@@ -339,6 +350,8 @@ counter_storage_spawn(
 	counter_storage_init(
 		memory_context, new_counter_storage, counter_registry
 	);
+
+	new_counter_storage->refcnt = 1;
 
 	for (uint64_t pool_idx = 0; pool_idx < COUNTER_POOL_SIZE; ++pool_idx) {
 
@@ -496,6 +509,9 @@ counter_storage_pool_fini(
 void
 counter_storage_free(struct counter_storage *storage) {
 	if (storage == NULL)
+		return;
+
+	if (--storage->refcnt > 0)
 		return;
 
 	struct memory_context *memory_context =

--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -82,6 +82,13 @@ struct counter_storage {
 	struct counter_value_handle **counter_value_handles;
 	struct counter_registry *registry;
 	struct counter_storage_pool pools[COUNTER_POOL_SIZE];
+
+	// Reference count for cross-generation sharing.
+	//
+	// When a config update does not change a module's counter layout, the
+	// old generation's counter_storage is reused by bumping this count
+	// instead of rebuilding the wrapper, handle array, and pool blocks.
+	uint64_t refcnt;
 };
 
 struct counter_storage *


### PR DESCRIPTION
Every config generation install rebuilds the entire ectx tree, including spawning fresh counter_storage wrappers for every node — even though counter value pages are already COW-shared.

For a typical single-module config update, 99%+ of modules are unchanged (same cp_module pointer shared via registry refcounting). Their counter_registry pointer is identical, so the counter layout is also identical. The wrapper rebuild is pure waste.

- Adds a refcnt field to counter_storage.
- In counter_storage_spawn, if the old storage registry pointer matches, bumps refcnt and returns the old storage directly.
- counter_storage_free decrements refcnt and skips reclamation until zero.
- Eliminates the majority of per-node allocation and handle-resolution work during config updates.
- No dataplane or ABI impact — counter data pages were already shared.

Closes #1631.