### PR TITLE
fix(web): cross-check the shared-memory inventory on the fwstate page

### DIFF
--- a/modules/fwstate/web/FWStatePage.tsx
+++ b/modules/fwstate/web/FWStatePage.tsx
@@ -15,7 +15,7 @@ import {
 import { CircleInfo, Plus } from '@gravity-ui/icons';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useConfigListCache, useSearchParamHelpers, usePageContribution, useContainerHeight, useTabCycle, useUnsavedChangesBlocker } from '@yanet/core/hooks';
-import { API, ApiError, loadKnownConfigs } from '@yanet/core/api';
+import { API, ApiError, inventoryConfigNames, loadKnownConfigs, unionConfigNames } from '@yanet/core/api';
 import { Direction, type FwStateEntry, type ListEntriesRequest, type MapStats } from '@yanet/core/api/fwstate';
 import { ConfirmDialog, ConfigTabStrip, PageLayout, PageLoader, EmptyPagePlaceholder } from '@yanet/core/components';
 import { ipAddressToString, isValidIPAddress, parseIPToBytes, stringToIPAddress, type IPAddressWire } from '@yanet/core/utils/netip';
@@ -1150,8 +1150,11 @@ const FWStatePage: React.FC = () => {
     const loadAll = useCallback(async (options?: { preserveDirty?: boolean; skipDirtyNames?: Set<string> }): Promise<void> => {
         setLoading(true);
         try {
-            const fwConfigsResp = await API.fwstate.listConfigs();
-            const fwNames = fwConfigsResp.configs ?? [];
+            const [fwConfigsResp, inventoryNames] = await Promise.all([
+                API.fwstate.listConfigs(),
+                inventoryConfigNames('fwstate'),
+            ]);
+            const fwNames = unionConfigNames(fwConfigsResp.configs ?? [], inventoryNames);
             const fwFull = await loadKnownConfigs(
                 fwNames,
                 async (name) => ({ name, config: await API.fwstate.showConfig({ name }) }),


### PR DESCRIPTION
A module control plane rebuilds its configuration map empty on startup, while the dataplane keeps its configurations in shared memory across that restart. The firewall-state page listed configurations only from the control plane, so after a restart it showed a plain empty page and offered to create a first configuration while the dataplane was still holding a live one.

The page now combines the control plane's own list with the shared-memory inventory the inspect API exposes, the same cross-check the acl and route pages already do. A configuration the control plane no longer knows is still dropped from the view, but the page now warns instead of pretending the instance is empty. Creating a configuration stays available, since re-applying one is how an operator recovers.

Verified in a browser against a stubbed backend: with an empty control-plane list and a non-empty inventory the page warns that the control plane does not know the configuration, and with both empty it still shows the plain empty placeholder and no warning.
