### PR TITLE
fix(cli): wrap CLI help output to the terminal width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 rust-version = "1.85"
 
 [dependencies]
-clap = { version = "4.5", features = ["cargo", "derive", "env", "string"] }
+clap = { version = "4.5", features = ["cargo", "derive", "env", "string", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 simple_logger = { version = "5", features = ["timestamps", "stderr"] }

--- a/cli/modules/common/Cargo.toml
+++ b/cli/modules/common/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.85"
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
 log = "0.4"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/cli/modules/counters/Cargo.toml
+++ b/cli/modules/counters/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/cli/modules/device/Cargo.toml
+++ b/cli/modules/device/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/cli/modules/function/Cargo.toml
+++ b/cli/modules/function/Cargo.toml
@@ -9,7 +9,7 @@ description = "CLI for YANET function module"
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/cli/modules/gateway/Cargo.toml
+++ b/cli/modules/gateway/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost-types = "0.13"
 serde = { version = "1", features = ["derive"] }

--- a/cli/modules/inspect/Cargo.toml
+++ b/cli/modules/inspect/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/cli/modules/metrics/Cargo.toml
+++ b/cli/modules/metrics/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tabled = { version = "0.18", features = ["ansi"] }

--- a/cli/modules/pipeline/Cargo.toml
+++ b/cli/modules/pipeline/Cargo.toml
@@ -10,7 +10,7 @@ ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-y
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}
 serde_yaml = "0.9"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/cli/modules/ready/Cargo.toml
+++ b/cli/modules/ready/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 readinesspb = { path = "../../../common/rust/readinesspb", version = "0.1", package = "yanet-readinesspb" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost-types = "0.13"
 serde = { version = "1", features = ["derive"] }

--- a/devices/plain/cli/Cargo.toml
+++ b/devices/plain/cli/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 serde = { version = "1", features = ["derive"] }

--- a/devices/trafgen/cli/Cargo.toml
+++ b/devices/trafgen/cli/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 prost = "0.13"

--- a/devices/vlan/cli/Cargo.toml
+++ b/devices/vlan/cli/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 serde = { version = "1", features = ["derive"] }

--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -12,7 +12,7 @@ commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = 
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
 netip = "0.3"
 log = "0.4"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 prost = "0.13"

--- a/modules/balancer2/cli/Cargo.toml
+++ b/modules/balancer2/cli/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.85"
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }

--- a/modules/blackhole/cli/Cargo.toml
+++ b/modules/blackhole/cli/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 log = "0.4"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 prost = "0.13"

--- a/modules/decap/cli/Cargo.toml
+++ b/modules/decap/cli/Cargo.toml
@@ -11,7 +11,7 @@ ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 netip = "0.3"
 bitmap = { path = "../../../common/rust/bitmap", version = "0.1" }
 log = "0.4"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 prost = "0.13"

--- a/modules/dscp/cli/Cargo.toml
+++ b/modules/dscp/cli/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 netip = "0.3"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 colored = "3"

--- a/modules/forward/cli/Cargo.toml
+++ b/modules/forward/cli/Cargo.toml
@@ -11,7 +11,7 @@ ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
 netip = "0.3"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 colored = "3"
 prost = "0.13"

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.85"
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 log = "0.4"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tokio-stream = "0.1"

--- a/modules/mirror/cli/Cargo.toml
+++ b/modules/mirror/cli/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.85"
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }
 netip = "0.3"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 colored = "3"
 prost = "0.13"

--- a/modules/nat64/cli/Cargo.toml
+++ b/modules/nat64/cli/Cargo.toml
@@ -11,7 +11,7 @@ ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 netip = "0.3"
 log = "0.4"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 prost = "0.13"

--- a/modules/pdump/cli/Cargo.toml
+++ b/modules/pdump/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.85"
 
 [dependencies]
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 log = "0.4"
 colored = "3"

--- a/modules/route-mpls/cli/Cargo.toml
+++ b/modules/route-mpls/cli/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.85"
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 netip = "0.3"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 prost = "0.13"

--- a/modules/route/cli/route/Cargo.toml
+++ b/modules/route/cli/route/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.85"
 commonpb = { path = "../../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../../cli/core", version = "0.1", package = "yanet-cli" }
 log = "0.4"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 prost = "0.13"

--- a/operators/pipeline/cli/Cargo.toml
+++ b/operators/pipeline/cli/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 log = "0.4"

--- a/operators/route/cli/neighbour/Cargo.toml
+++ b/operators/route/cli/neighbour/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 commonpb = { path = "../../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../../cli/core", version = "0.1", package = "yanet-cli" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 log = "0.4"

--- a/operators/route/cli/route/Cargo.toml
+++ b/operators/route/cli/route/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 [dependencies]
 ync = { path = "../../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost = "0.13"
 log = "0.4"


### PR DESCRIPTION
- Multi-sentence long help printed as one unbroken line at every terminal width, because clap compiles its help wrapping away entirely unless the corresponding feature is enabled — the packet-dump encoding help reached 127 columns before this change, and the paragraphs merged recently made it more visible.
- Enable the feature across every CLI crate, so help text wraps to the detected terminal width. This settles the question repo-wide, in favour of wrapping, rather than as a single-module patch.
- It is not a new dependency and not a new stance: the CLI core already depends on terminal-size detection and already wraps human table output to the terminal. Help text was the one human-facing surface left out.
- The width is deliberately left uncapped on a terminal, matching how the existing table fitting behaves. A run whose output is not a terminal falls back to the environment's column count and then to a fixed default, so redirected help is now wrapped where it previously was not.
- Usage lines are unaffected: clap never wraps those regardless of the feature, so they remain the longest lines in the help corpus.
