### PR TITLE
fix(route-operator): answer reads for a configured module before its RIB exists

### DIFF
--- a/operators/route/internal/operator/operator.go
+++ b/operators/route/internal/operator/operator.go
@@ -137,6 +137,7 @@ func NewOperator(cfg *Config, options ...Option) (*Operator, error) {
 		WithRouteServiceRIBTTL(ribTTL(cfg)),
 		WithRouteServiceOnChanged(wake),
 		WithRouteServiceLog(log),
+		WithRouteServiceConfiguredModules(moduleName),
 		WithRouteServiceOnRIBSessionStart(func(name string, sessionID uint64) {
 			ribHelper.OnSessionStart(name, sessionID)
 			metrics.OnRIBSessionStart(name, sessionID)

--- a/operators/route/internal/operator/options.go
+++ b/operators/route/internal/operator/options.go
@@ -48,6 +48,7 @@ type routeServiceOptions struct {
 	OnRIBSessionStart func(name string, sessionID uint64)
 	OnRIBUpdate       func(n int)
 	OnRIBSessionEnd   func(name string, sessionID uint64)
+	ConfiguredModules []string
 	Log               *zap.Logger
 }
 
@@ -124,6 +125,21 @@ func WithRouteServiceOnRIBUpdate(fn func(n int)) RouteServiceOption {
 func WithRouteServiceOnRIBSessionEnd(fn func(name string, sessionID uint64)) RouteServiceOption {
 	return func(o *routeServiceOptions) {
 		o.OnRIBSessionEnd = fn
+	}
+}
+
+// WithRouteServiceConfiguredModules declares the module config names the
+// operator itself manages.
+//
+// A declared name with no RIB yet is the normal state between process
+// start and the first upstream feed, so read RPCs answer it with an empty
+// success instead of NotFound: its data has simply not arrived. A name
+// outside this set stays NotFound, because nothing has created a RIB for
+// it yet — neither the operator's own config nor any write that has
+// arrived.
+func WithRouteServiceConfiguredModules(names ...string) RouteServiceOption {
+	return func(o *routeServiceOptions) {
+		o.ConfiguredModules = names
 	}
 }
 

--- a/operators/route/internal/operator/service_route.go
+++ b/operators/route/internal/operator/service_route.go
@@ -3,7 +3,9 @@ package operator
 import (
 	"context"
 	"io"
+	"maps"
 	"net/netip"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -34,6 +36,13 @@ type RouteService struct {
 	onRIBUpdate       func(n int)
 	onRIBSessionEnd   func(name string, sessionID uint64)
 
+	// configuredModules holds the module config names the operator itself
+	// manages.
+	//
+	// It is built once in NewRouteService and never mutated afterwards, so
+	// reads need no lock.
+	configuredModules map[string]struct{}
+
 	log *zap.Logger
 }
 
@@ -48,6 +57,11 @@ func NewRouteService(
 		o(opts)
 	}
 
+	configuredModules := make(map[string]struct{}, len(opts.ConfiguredModules))
+	for _, name := range opts.ConfiguredModules {
+		configuredModules[name] = struct{}{}
+	}
+
 	return &RouteService{
 		ribs:              opts.RIBs,
 		neighTable:        neighTable,
@@ -57,6 +71,7 @@ func NewRouteService(
 		onRIBSessionStart: opts.OnRIBSessionStart,
 		onRIBUpdate:       opts.OnRIBUpdate,
 		onRIBSessionEnd:   opts.OnRIBSessionEnd,
+		configuredModules: configuredModules,
 		log:               opts.Log,
 	}
 }
@@ -68,13 +83,30 @@ func (m *RouteService) Close() error {
 	return nil
 }
 
-// Configs returns a snapshot of all known RIB config names.
+// Configs returns the config names the operator can answer reads for.
+//
+// The result is the union of RIB-backed config names and configured
+// module names, deduplicated and sorted for a deterministic listing.
 func (m *RouteService) Configs() []string {
-	return m.ribs.Configs()
+	seen := map[string]struct{}{}
+	for _, name := range m.ribs.Configs() {
+		seen[name] = struct{}{}
+	}
+	maps.Copy(seen, m.configuredModules)
+
+	return slices.Sorted(maps.Keys(seen))
 }
 
-// ListConfigs returns the names of all RIB configs known to the
-// operator.
+// isConfigured reports whether name is a module config the operator itself
+// manages, regardless of whether a RIB has been created for it yet.
+func (m *RouteService) isConfigured(name string) bool {
+	_, ok := m.configuredModules[name]
+	return ok
+}
+
+// ListConfigs returns the config names the operator can answer reads for.
+//
+// See Configs for what that set contains.
 func (m *RouteService) ListConfigs(
 	ctx context.Context,
 	req *operatorpb.ListConfigsRequest,
@@ -100,6 +132,9 @@ func (m *RouteService) ShowRoutes(
 
 	holder, ok := m.getRib(name)
 	if !ok {
+		if m.isConfigured(name) {
+			return &operatorpb.ShowRoutesResponse{}, nil
+		}
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 	ribDump := holder.DumpRoutes()
@@ -145,6 +180,9 @@ func (m *RouteService) LookupRoute(
 
 	holder, ok := m.getRib(name)
 	if !ok {
+		if m.isConfigured(name) {
+			return &operatorpb.LookupRouteResponse{}, nil
+		}
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 

--- a/operators/route/internal/operator/service_route_test.go
+++ b/operators/route/internal/operator/service_route_test.go
@@ -160,3 +160,87 @@ func TestInsertRoute_NonStaticMultipleNexthops_InvalidArgument(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, codes.InvalidArgument, st.Code())
 }
+
+// TestShowRoutes_ConfiguredModule_NoRIBYet_Success verifies that ShowRoutes
+// returns an empty success for a module the operator declares as its own
+// even before any RIB exists for it, and that answering the read does not
+// create a RIB or wake the reconcile loop.
+func TestShowRoutes_ConfiguredModule_NoRIBYet_Success(t *testing.T) {
+	var onChangedCount int
+	svc := NewRouteService(
+		neigh.NewNeighTable(),
+		WithRouteServiceConfiguredModules("route0"),
+		WithRouteServiceOnChanged(func() { onChangedCount++ }),
+	)
+
+	resp, err := svc.ShowRoutes(t.Context(), &operatorpb.ShowRoutesRequest{Name: "route0"})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetRoutes())
+
+	_, ok := svc.ribs.Get("route0")
+	require.False(t, ok, "answering a read for a configured module must not create a RIB")
+	require.Zero(t, onChangedCount, "answering a read must not wake the reconcile loop")
+}
+
+// TestLookupRoute_ConfiguredModule_NoRIBYet_Success verifies that
+// LookupRoute returns an empty success for a module the operator declares
+// as its own even before any RIB exists for it, and that answering the
+// read does not create a RIB or wake the reconcile loop.
+func TestLookupRoute_ConfiguredModule_NoRIBYet_Success(t *testing.T) {
+	var onChangedCount int
+	svc := NewRouteService(
+		neigh.NewNeighTable(),
+		WithRouteServiceConfiguredModules("route0"),
+		WithRouteServiceOnChanged(func() { onChangedCount++ }),
+	)
+
+	addr := commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1"))
+	resp, err := svc.LookupRoute(t.Context(), &operatorpb.LookupRouteRequest{Name: "route0", IpAddr: addr})
+	require.NoError(t, err)
+	require.Empty(t, resp.GetRoutes())
+
+	_, ok := svc.ribs.Get("route0")
+	require.False(t, ok, "answering a read for a configured module must not create a RIB")
+	require.Zero(t, onChangedCount, "answering a read must not wake the reconcile loop")
+}
+
+// TestShowRoutesAndLookupRoute_UndeclaredConfig_NotFound verifies that a
+// name outside the configured-modules set stays NotFound even when the
+// set is non-empty, distinguishing it from a declared-but-unpopulated name.
+func TestShowRoutesAndLookupRoute_UndeclaredConfig_NotFound(t *testing.T) {
+	svc := NewRouteService(
+		neigh.NewNeighTable(),
+		WithRouteServiceConfiguredModules("route0"),
+	)
+
+	_, err := svc.ShowRoutes(t.Context(), &operatorpb.ShowRoutesRequest{Name: "other"})
+	require.Equal(t, codes.NotFound, status.Code(err))
+
+	addr := commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1"))
+	_, err = svc.LookupRoute(t.Context(), &operatorpb.LookupRouteRequest{Name: "other", IpAddr: addr})
+	require.Equal(t, codes.NotFound, status.Code(err))
+}
+
+// TestListConfigs_ConfiguredModule_ReportedOnceBeforeAndAfterRIB verifies
+// that a configured module name appears in ListConfigs before its RIB is
+// created, still appears exactly once after the RIB is created, and that
+// the full result is always lexicographically sorted regardless of the
+// order configs and RIBs were added in.
+func TestListConfigs_ConfiguredModule_ReportedOnceBeforeAndAfterRIB(t *testing.T) {
+	svc := NewRouteService(
+		neigh.NewNeighTable(),
+		WithRouteServiceConfiguredModules("route0"),
+	)
+
+	resp, err := svc.ListConfigs(t.Context(), &operatorpb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"route0"}, resp.GetConfigs())
+
+	svc.getOrCreateRib("route0")
+	svc.getOrCreateRib("route2")
+	svc.getOrCreateRib("route1")
+
+	resp, err = svc.ListConfigs(t.Context(), &operatorpb.ListConfigsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, []string{"route0", "route1", "route2"}, resp.GetConfigs())
+}


### PR DESCRIPTION
- The operator creates a routing table lazily, on the first write, so between process start and the first upstream feed a read for its own configured module reported the config as missing — exactly the state someone investigating an upstream outage would be looking at.
- Reads for a module the operator declares as its own now return an empty success, while a name it was never configured with still reports as not found.
- The read path creates no routing table and wakes no reconcile pass, so an empty forwarding table can never reach the dataplane as a side effect of a query.
- The config listing now reports the same set the read path accepts, deduplicated and ordered, keeping the listing, shell completion and the web page consistent with what a read will answer.
