### PR TITLE
fix(web): warn when only some configurations are missing from the control plane

### DIFF
--- a/modules/acl/web/useAclDraft.ts
+++ b/modules/acl/web/useAclDraft.ts
@@ -70,7 +70,7 @@ export const useAclDraft = (): UseAclDraftResult => {
                     const resp = await API.acl.showConfig({ name });
                     return { name, rules: resp.rules ?? [], fwstateName: resp.fwstate_name ?? '' };
                 },
-                { onAllDropped: warnConfigsUnknown('acl-configs-unknown', 'ACL') },
+                { onDropped: warnConfigsUnknown('acl-configs-unknown', 'ACL') },
             );
 
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });

--- a/modules/decap/web/usePrefixDraft.ts
+++ b/modules/decap/web/usePrefixDraft.ts
@@ -23,7 +23,7 @@ export const usePrefixDraft = (): UsePrefixDraftResult => {
             const resp = await API.decap.showConfig({ name });
             const rows: PrefixRowItem[] = (resp.prefixes ?? []).map((p) => ({ id: p, prefix: p }));
             return { name, rows };
-        }, { onAllDropped: warnConfigsUnknown('decap-configs-unknown', 'decap') });
+        }, { onDropped: warnConfigsUnknown('decap-configs-unknown', 'decap') });
     }, []);
 
     const commit = useCallback(async (

--- a/modules/forward/web/useForwardDraft.ts
+++ b/modules/forward/web/useForwardDraft.ts
@@ -77,7 +77,7 @@ export const useForwardDraft = (): UseForwardDraftResult => {
                     const resp = await API.forward.showConfig({ name });
                     return { name, rules: resp.rules ?? [] };
                 },
-                { onAllDropped: warnConfigsUnknown('forward-configs-unknown', 'forward') },
+                { onDropped: warnConfigsUnknown('forward-configs-unknown', 'forward') },
             );
 
             rawDispatch({ type: 'LOAD_ALL_CONFIGS', configs });

--- a/modules/fwstate/web/FWStatePage.tsx
+++ b/modules/fwstate/web/FWStatePage.tsx
@@ -1158,7 +1158,7 @@ const FWStatePage: React.FC = () => {
             const fwFull = await loadKnownConfigs(
                 fwNames,
                 async (name) => ({ name, config: await API.fwstate.showConfig({ name }) }),
-                { onAllDropped: warnConfigsUnknown('fwstate-configs-unknown', 'fwstate') },
+                { onDropped: warnConfigsUnknown('fwstate-configs-unknown', 'fwstate') },
             );
             const nextConfigs: Record<string, DraftConfig> = {};
             fwFull.forEach(({ name, config }) => {

--- a/modules/route/web/useFIBDraft.ts
+++ b/modules/route/web/useFIBDraft.ts
@@ -75,7 +75,7 @@ export const useFIBDraft = (): UseFIBDraftResult => {
         return loadKnownConfigs(configNames, async (name): Promise<{ name: string; rows: FIBRowItem[] }> => {
             const fibResp = await API.route.showFIB({ name });
             return { name, rows: flattenFIBEntries(fibResp.entries ?? []) };
-        }, { onAllDropped: warnConfigsUnknown('route-configs-unknown', 'route') });
+        }, { onDropped: warnConfigsUnknown('route-configs-unknown', 'route') });
     }, []);
 
     const commit = useCallback(async (configName: string, draftRows: FIBRowItem[]): Promise<void> => {

--- a/web/src/core/api/client.test.ts
+++ b/web/src/core/api/client.test.ts
@@ -80,37 +80,46 @@ describe('loadKnownConfigs', () => {
         await expect(loadKnownConfigs(['a', 'b'], loadOne)).rejects.toBe(networkError);
     });
 
-    it('calls onAllDropped with the name count when every name 404s', async () => {
+    it('calls onDropped with all names when every name 404s', async () => {
         const loadOne = async (): Promise<string> => {
             throw new ApiError(404, 'Not Found', '');
         };
-        const onAllDropped = vi.fn();
-        const results = await loadKnownConfigs(['a', 'b', 'c'], loadOne, { onAllDropped });
+        const onDropped = vi.fn();
+        const results = await loadKnownConfigs(['a', 'b', 'c'], loadOne, { onDropped });
         expect(results).toEqual([]);
-        expect(onAllDropped).toHaveBeenCalledTimes(1);
-        expect(onAllDropped).toHaveBeenCalledWith(3);
+        expect(onDropped).toHaveBeenCalledTimes(1);
+        expect(onDropped).toHaveBeenCalledWith(['a', 'b', 'c']);
     });
 
-    it('does not call onAllDropped when at least one name succeeds', async () => {
+    it('calls onDropped with exactly the dropped name when at least one name succeeds', async () => {
         const loadOne = async (name: string): Promise<string> => {
             if (name === 'b') {
                 throw new ApiError(404, 'Not Found', '');
             }
             return `loaded-${name}`;
         };
-        const onAllDropped = vi.fn();
-        await loadKnownConfigs(['a', 'b'], loadOne, { onAllDropped });
-        expect(onAllDropped).not.toHaveBeenCalled();
+        const onDropped = vi.fn();
+        await loadKnownConfigs(['a', 'b'], loadOne, { onDropped });
+        expect(onDropped).toHaveBeenCalledTimes(1);
+        expect(onDropped).toHaveBeenCalledWith(['b']);
     });
 
-    it('does not call onAllDropped when names is empty', async () => {
+    it('does not call onDropped when names is empty', async () => {
         const loadOne = async (name: string): Promise<string> => `loaded-${name}`;
-        const onAllDropped = vi.fn();
-        await loadKnownConfigs([], loadOne, { onAllDropped });
-        expect(onAllDropped).not.toHaveBeenCalled();
+        const onDropped = vi.fn();
+        await loadKnownConfigs([], loadOne, { onDropped });
+        expect(onDropped).not.toHaveBeenCalled();
     });
 
-    it('does not call onAllDropped when a non-404 rejection is rethrown', async () => {
+    it('does not call onDropped when every name loads successfully', async () => {
+        const loadOne = async (name: string): Promise<string> => `loaded-${name}`;
+        const onDropped = vi.fn();
+        const results = await loadKnownConfigs(['a', 'b', 'c'], loadOne, { onDropped });
+        expect(results).toEqual(['loaded-a', 'loaded-b', 'loaded-c']);
+        expect(onDropped).not.toHaveBeenCalled();
+    });
+
+    it('does not call onDropped when a non-404 rejection is rethrown', async () => {
         const serverError = new ApiError(500, 'Internal Server Error', '');
         const loadOne = async (name: string): Promise<string> => {
             if (name === 'a') {
@@ -118,9 +127,28 @@ describe('loadKnownConfigs', () => {
             }
             throw new ApiError(404, 'Not Found', '');
         };
-        const onAllDropped = vi.fn();
-        await expect(loadKnownConfigs(['a', 'b'], loadOne, { onAllDropped })).rejects.toBe(serverError);
-        expect(onAllDropped).not.toHaveBeenCalled();
+        const onDropped = vi.fn();
+        await expect(loadKnownConfigs(['a', 'b'], loadOne, { onDropped })).rejects.toBe(serverError);
+        expect(onDropped).not.toHaveBeenCalled();
+    });
+
+    it('preserves original name order even when a later name settles before an earlier one', async () => {
+        const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+        const loadOne = async (name: string): Promise<string> => {
+            if (name === 'a') {
+                throw new ApiError(404, 'Not Found', '');
+            }
+            if (name === 'b') {
+                await delay(20);
+                return `loaded-${name}`;
+            }
+            await delay(10);
+            return `loaded-${name}`;
+        };
+        const onDropped = vi.fn();
+        const results = await loadKnownConfigs(['a', 'b', 'c'], loadOne, { onDropped });
+        expect(results).toEqual(['loaded-b', 'loaded-c']);
+        expect(onDropped).toHaveBeenCalledWith(['a']);
     });
 
     it('rejects as soon as one name fails, without waiting for a sibling that never settles', async () => {

--- a/web/src/core/api/client.ts
+++ b/web/src/core/api/client.ts
@@ -100,8 +100,8 @@ const callGRPCService = async <T>(
 };
 
 export interface LoadKnownConfigsOptions {
-    /** Called when the name list was non-empty and every config was dropped. */
-    onAllDropped?: (count: number) => void;
+    /** Called with the dropped names whenever at least one name was dropped. */
+    onDropped?: (names: string[]) => void;
 }
 
 /** Marker substituted for a per-name load whose 404 means the config is gone. */
@@ -119,11 +119,11 @@ const DROPPED = Symbol('dropped');
  * request never delays surfacing a real error. The rejection is rethrown
  * unchanged so the caller still sees the original error.
  *
- * When every name was dropped and at least one name was requested, every
- * request was a 404, since any other rejection would already have rejected
- * the whole load above. `onAllDropped` fires in exactly that case, so a
- * caller can warn that none of the requested configs came back instead of
- * rendering a silent empty state.
+ * A dropped name means its request was a 404, since any other rejection
+ * would already have rejected the whole load above. `onDropped` fires
+ * whenever at least one name was dropped, passing the dropped names, so a
+ * caller can warn about a partial or total loss instead of rendering a
+ * silently incomplete or empty state.
  */
 export const loadKnownConfigs = async <T>(
     names: string[],
@@ -139,9 +139,17 @@ export const loadKnownConfigs = async <T>(
         })
     ));
 
-    const values = results.filter((result): result is T => result !== DROPPED);
-    if (names.length > 0 && values.length === 0) {
-        options?.onAllDropped?.(names.length);
+    const values: T[] = [];
+    const dropped: string[] = [];
+    results.forEach((result, idx) => {
+        if (result === DROPPED) {
+            dropped.push(names[idx]);
+        } else {
+            values.push(result);
+        }
+    });
+    if (dropped.length > 0) {
+        options?.onDropped?.(dropped);
     }
     return values;
 };

--- a/web/src/core/api/inspect.test.ts
+++ b/web/src/core/api/inspect.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { inventoryConfigNames, unionConfigNames } from './inspect';
 
 describe('unionConfigNames', () => {
-    it('regression: an empty service list plus a non-empty inventory yields the inventory names, so onAllDropped can fire after a restart', () => {
+    it('regression: an empty service list plus a non-empty inventory yields the inventory names, so onDropped can fire after a restart', () => {
         expect(unionConfigNames([], ['acl0'])).toEqual(['acl0']);
     });
 

--- a/web/src/core/utils/toast.test.ts
+++ b/web/src/core/utils/toast.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const addMock = vi.fn();
+
+vi.mock('@gravity-ui/uikit/toaster-singleton', () => ({
+    toaster: {
+        add: (options: { content: string }) => addMock(options),
+    },
+}));
+
+import { warnConfigsUnknown } from './toast';
+
+const namesOfLength = (count: number): string[] =>
+    Array.from({ length: count }, (_unused, idx) => `cfg-${String.fromCharCode(97 + idx)}`);
+
+describe('warnConfigsUnknown', () => {
+    beforeEach(() => {
+        addMock.mockClear();
+    });
+
+    it('lists a bounded prefix and mentions the total and remainder counts when over the cap', () => {
+        const names = namesOfLength(9);
+        warnConfigsUnknown('key', 'route')(names);
+
+        const content = addMock.mock.calls[0][0].content as string;
+        const listedCount = names.filter((name) => content.includes(name)).length;
+
+        expect(listedCount).toBeLessThan(names.length);
+        expect(content).toContain(String(names.length));
+        expect(content).toContain(String(names.length - listedCount));
+    });
+
+    it('lists the same number of names regardless of how far over the cap the list is', () => {
+        const shortOverflow = namesOfLength(6);
+        const longOverflow = namesOfLength(9);
+
+        warnConfigsUnknown('key', 'route')(shortOverflow);
+        const shortContent = addMock.mock.calls[0][0].content as string;
+        const shortListed = shortOverflow.filter((name) => shortContent.includes(name)).length;
+
+        addMock.mockClear();
+
+        warnConfigsUnknown('key', 'route')(longOverflow);
+        const longContent = addMock.mock.calls[0][0].content as string;
+        const longListed = longOverflow.filter((name) => longContent.includes(name)).length;
+
+        expect(longListed).toBe(shortListed);
+    });
+
+    it('lists all names and mentions no remainder count when the list is exactly at the cap', () => {
+        const names = namesOfLength(5);
+        warnConfigsUnknown('key', 'route')(names);
+
+        const content = addMock.mock.calls[0][0].content as string;
+
+        for (const name of names) {
+            expect(content).toContain(name);
+        }
+
+        const numbers = content.match(/\d+/g) ?? [];
+        for (const number of numbers) {
+            expect(Number(number)).toBe(names.length);
+        }
+    });
+});

--- a/web/src/core/utils/toast.ts
+++ b/web/src/core/utils/toast.ts
@@ -73,18 +73,28 @@ export const toaster = {
     },
 };
 
-/**
- * Build an `onAllDropped` callback for `loadKnownConfigs` that warns about unknown configs.
- *
- * The helper owns the message and the count, so a caller only needs to supply the
- * toast dedup key and the subject word used in the message. It fires once per page
- * load when the control plane knows none of the requested configs; a remount fires
- * it again, and it is the toast dedup key, not the callback, that collapses the repeat.
+/** Names beyond this count are summarised instead of listed, so a control plane
+ * that lost a dozen configurations cannot produce an unbounded toast string.
  */
-export const warnConfigsUnknown = (toastKey: string, subject: string) => (count: number): void => {
-    const [noun, pronoun] = count === 1 ? ['configuration', 'It is'] : ['configurations', 'They are'];
+const MAX_LISTED_NAMES = 5;
+
+/**
+ * Build an `onDropped` callback for `loadKnownConfigs` that warns about unknown configs.
+ *
+ * The helper owns the message and the name list, so a caller only needs to supply the
+ * toast dedup key and the subject word used in the message. It fires when the control
+ * plane does not know at least one of the requested configs; a remount fires it again,
+ * and it is the toast dedup key, not the callback, that collapses the repeat.
+ */
+export const warnConfigsUnknown = (toastKey: string, subject: string) => (names: string[]): void => {
+    const [noun, pronoun] = names.length === 1 ? ['configuration', 'It is'] : ['configurations', 'They are'];
+    const listed = names.slice(0, MAX_LISTED_NAMES);
+    const rest = names.length - listed.length;
+    const list = rest > 0
+        ? `${listed.join(', ')}, and ${rest} more`
+        : listed.join(', ');
     toaster.warning(
         toastKey,
-        `The control plane does not know ${count} ${subject} ${noun}. ${pronoun} not shown here.`,
+        `The control plane does not know ${names.length} ${subject} ${noun} (${list}). ${pronoun} not shown here.`,
     );
 };


### PR DESCRIPTION
The shared configuration loader warned only when the control plane knew none of the requested configurations. Once at least one survived, the pages silently dropped the rest, so an operator who had re-applied part of a lost set saw the remainder vanish with no indication at all. That is the realistic case after a control-plane restart, since the dataplane keeps its configurations in shared memory across one and the pages cross-check that inventory.

The warning now fires whenever any configuration is missing, and it names the ones that are gone so an operator can tell which to re-apply. A long list is summarised so the message stays bounded. All five pages that combine a configuration list with a per-name read share the loader and gain this at once.

Addresses the review finding left on #1635, which was deliberately deferred there because the fix belongs in the shared loader rather than in one page.

The new coverage pins the bound and the remainder as invariants rather than pinning the wording, and pins that the reported names follow the requested order even when the reads settle out of order.
