### PR TITLE
test(route-operator): cover the configured-module wiring end to end

### DIFF
--- a/operators/route/internal/operator/service_route_test.go
+++ b/operators/route/internal/operator/service_route_test.go
@@ -221,6 +221,35 @@ func TestShowRoutesAndLookupRoute_UndeclaredConfig_NotFound(t *testing.T) {
 	require.Equal(t, codes.NotFound, status.Code(err))
 }
 
+// TestNewOperator_ConfiguredModuleNoRIBYet_ReadsSucceedWithoutCreatingRIB
+// verifies that an Operator built by NewOperator answers ShowRoutes and
+// LookupRoute for its configured module with an empty success before any
+// RIB exists for it, and that neither read creates one.
+func TestNewOperator_ConfiguredModuleNoRIBYet_ReadsSucceedWithoutCreatingRIB(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.NetlinkMonitor.Disabled = true
+
+	op, err := NewOperator(cfg)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, op.Close())
+	}()
+
+	moduleName := cfg.Function.Module.Unwrap()
+
+	showResp, err := op.routeSvc.ShowRoutes(t.Context(), &operatorpb.ShowRoutesRequest{Name: moduleName})
+	require.NoError(t, err)
+	require.Empty(t, showResp.GetRoutes())
+
+	addr := commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1"))
+	lookupResp, err := op.routeSvc.LookupRoute(t.Context(), &operatorpb.LookupRouteRequest{Name: moduleName, IpAddr: addr})
+	require.NoError(t, err)
+	require.Empty(t, lookupResp.GetRoutes())
+
+	_, ok := op.routeSvc.ribs.Get(moduleName)
+	require.False(t, ok, "answering reads for the configured module must not create a RIB")
+}
+
 // TestListConfigs_ConfiguredModule_ReportedOnceBeforeAndAfterRIB verifies
 // that a configured module name appears in ListConfigs before its RIB is
 // created, still appears exactly once after the RIB is created, and that


### PR DESCRIPTION
- The reads that answer for the operator's own configured module were covered only by tests that construct the service with that module already declared, so removing the line that declares it in production left every test in the repository green.
- The new test builds the operator the way the process does, with no static routes and no upstream feed, and asserts both reads succeed for the configured module.
- It also asserts no routing table is created by answering them, which fences the eager pre-creation shape that would push an empty forwarding table to the dataplane.
- Mutation-checked in review: deleting the production wiring makes this test, and only this test, fail — and it fails on its own assertion rather than on a construction error.
