### PR TITLE
fix(functional): report why a baseline VM restore failed

### DIFF
--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -1641,13 +1641,13 @@ func (f *TestFramework) RestoreAndReconnect(snapshot string) error {
 
 		f.log.Info("Restarting YANET to reinitialize DPDK device state...")
 		if restartErr := f.RestartYANET(); restartErr != nil {
-			return fmt.Errorf("heartbeat failed, restart also failed: %w", restartErr)
+			return fmt.Errorf("failed to restart YANET after heartbeat failure (pre-restart: %v): %w", err, restartErr)
 		}
 
 		f.ResetConnections()
 
-		if err := f.WaitForDatapathReady(heartbeatTimeout); err != nil {
-			return fmt.Errorf("heartbeat failed after YANET restart: %w", err)
+		if retryErr := f.WaitForDatapathReady(heartbeatTimeout); retryErr != nil {
+			return fmt.Errorf("failed to reach dataplane readiness after YANET restart (pre-restart: %v): %w", err, retryErr)
 		}
 	}
 

--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -411,11 +411,12 @@ func (m *Harness) WithBootedVM(t *testing.T, fn func(fw *TestFramework)) {
 func (m *Harness) RestoreBooted(t *testing.T, fw *TestFramework) {
 	t.Helper()
 
-	if err := fw.RestoreAndReconnect("baseline"); err == nil {
+	err := fw.RestoreAndReconnect("baseline")
+	if err == nil {
 		return
 	}
 
-	t.Logf("baseline restore failed, falling back to preyanet + fresh StartYANET")
+	t.Logf("baseline restore failed, falling back to preyanet + fresh StartYANET: %v", err)
 
 	if err := fw.RestoreClean("preyanet"); err != nil {
 		t.Fatalf("failed to restore VM to preyanet: %v", err)


### PR DESCRIPTION
The functional harness restores a pooled VM to its baseline snapshot and falls back to a slow cold start when that fails, but it threw away the reason on the way out.

The caller tested the restore error inside a condition whose scope then ended, so the log line announcing the fallback carried no cause at all — it named the fallback and nothing else. The restore itself compounds this: when the datapath is still unresponsive right after the snapshot loads, that first readiness failure goes only into a log message and is then left out of both errors the restore can return, so the single most telling fact — whether the datapath was already dead on arrival or only stayed dead through a full restart — never reaches the caller.

The result is a fallback that has been firing unexplained. On the nat44 suite it takes hold for a whole run at a time and roughly triples the suite's wall time, with no recorded reason to work from.

Carry the earlier readiness failure into both returns, and print the error the fallback tripped on. Every stage on that path already wraps its own failures with a stage-identifying message, so propagating and printing the error is enough to name the stage that actually failed, without adding any instrumentation.

This changes diagnostics only: the same code paths run, under the same conditions, with the same control flow.
