### PR TITLE
fix(acl): exclude fwstate grpc metrics

### DIFF
--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -80,6 +80,10 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 		WithLog(log),
 		WithMetrics(grpcmetrics.NewFactory(
 			grpcmetrics.WithLabeler(labeler),
+			grpcmetrics.WithServiceFilter(func(service string) bool {
+				return service == aclpb.ACLService_ServiceDesc.ServiceName ||
+					service == aclpb.MetricsService_ServiceDesc.ServiceName
+			}),
 		)),
 	)
 


### PR DESCRIPTION
- Restricts ACL gRPC metric collection to ACL-owned services.
- Prevents FWState unary RPC metrics from being exported by both ACL and FWState collectors.