### PR TITLE
chore(cli): require core over std across the rust workspace

### DIFF
--- a/.claude/conventions/rust.md
+++ b/.claude/conventions/rust.md
@@ -11,7 +11,9 @@ Loaded on demand by the agent writing or reviewing Rust; this is the single sour
 - **Visibility**: avoid `pub(crate)`; items are `pub` or private. Conceptual type API methods are `pub`, even in binaries.
 - **Wire vs domain types**: parse and check invariants in the domain type; wire types get `From<Domain>` and use `TryFrom` only when fallible. Confirm module-specific validation (ACL permits non-contiguous masks, forward/decap do not) before generalising.
 - **`Display`/`Serialize`**: own types implement `Display`; `Serialize` uses `serializer.collect_str(self)`. Never blanket-derive `Serialize` for a proto module with a manual implementation.
-- **`fmt` imports**: `use std::fmt::{self, Display, Formatter};` with explicit `Result<(), fmt::Error>` (not `fmt::Result` alias).
+- **`fmt` imports**: `use core::fmt::{self, Display, Formatter};` with explicit `Result<(), fmt::Error>` (not `fmt::Result` alias).
+- **`clippy::std_instead_of_core`** is deny-level via `[workspace.lints.clippy]` + per-crate `[lints] workspace = true`; prefer `core::` for anything `core` provides (`error::Error`, `fmt`, `net`, `str::FromStr`, `time::Duration`, `mem`, `iter`, `ops`).
+- **Escape hatches** are `#[allow(clippy::std_instead_of_core)]` on an enclosing item (function or module), never the `use` itself — clippy's `useless_attribute` rejects that: tonic's client codegen emits `std::` paths we do not control, and `core_io`-gated items (`io::ErrorKind`, `io::Cursor`) are still unstable in `core`.
 - **No doc comments** on `Display`/`Serialize`/`TryFrom`/`From`/`Debug`/ `Default`/`FromStr` impls — the trait name is the doc.
 - **Doc comments**: `///`/`//!` begin with a one-sentence period-terminated brief and separate detail with a blank `///` line.
 - **No infallible `TryFrom`**: replace with `From`, or remove the impl if the call site is trivially inlinable.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,8 @@ members = [
 
 exclude = ["modules/route/cli"]
 
+[workspace.lints.clippy]
+std_instead_of_core = "deny"
+
 [profile.release]
 panic = "abort"

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.5", features = ["cargo", "derive", "env", "string", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }

--- a/cli/core/src/dispatcher.rs
+++ b/cli/core/src/dispatcher.rs
@@ -1,9 +1,7 @@
+use core::error::Error;
 use std::{
     collections::HashSet,
-    env,
-    error::Error,
-    fs,
-    io::ErrorKind,
+    env, fs,
     os::unix::{fs::PermissionsExt, process::CommandExt},
     path::PathBuf,
     process::{self, Stdio},
@@ -310,6 +308,11 @@ pub fn dispatch(name: &str, prefix: &str, behavior: &impl Dispatch) -> ! {
     exec_sub_binary(&prefix, cmd, collect_args(sub_matches), &modules, behavior);
 }
 
+// `core::io::ErrorKind` is behind the unstable `core_io` feature, so this
+// function keeps `std::io::ErrorKind`; the allow sits here rather than on a
+// `use` because clippy's `useless_attribute` rejects it directly on a `use`
+// item.
+#[allow(clippy::std_instead_of_core)]
 fn exec_sub_binary(
     prefix: &str,
     cmd: &str,
@@ -317,6 +320,8 @@ fn exec_sub_binary(
     modules: &HashSet<String>,
     behavior: &impl Dispatch,
 ) -> ! {
+    use std::io::ErrorKind;
+
     let subcommand = format!("{prefix}{cmd}");
     let Some(path) = locate_sub_binary(prefix, cmd) else {
         behavior.on_sub_binary_not_found(&subcommand, modules);

--- a/cli/core/src/display.rs
+++ b/cli/core/src/display.rs
@@ -88,7 +88,7 @@ pub fn wrap_words(text: &str, width: usize) -> Vec<String> {
             current.push(' ');
             current.push_str(word);
         } else {
-            lines.push(std::mem::take(&mut current));
+            lines.push(core::mem::take(&mut current));
             current.push_str(word);
         }
     }

--- a/cli/modules/common/Cargo.toml
+++ b/cli/modules/common/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}

--- a/cli/modules/counters/Cargo.toml
+++ b/cli/modules/counters/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -1,6 +1,6 @@
 //! CLI for YANET "counters" module.
 
-use std::str::FromStr;
+use core::str::FromStr;
 
 use bytesize::ByteSize;
 use clap::{ArgAction, CommandFactory, Parser};

--- a/cli/modules/device/Cargo.toml
+++ b/cli/modules/device/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}

--- a/cli/modules/function/Cargo.toml
+++ b/cli/modules/function/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 authors = ["YANET Team"]
 description = "CLI for YANET function module"
 
+[lints]
+workspace = true
+
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }

--- a/cli/modules/gateway/Cargo.toml
+++ b/cli/modules/gateway/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "yanet-cli-gateway"
 path = "src/main.rs"

--- a/cli/modules/inspect/Cargo.toml
+++ b/cli/modules/inspect/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 ync = { path = "../../core", version = "0.1", package = "yanet-cli"}

--- a/cli/modules/metrics/Cargo.toml
+++ b/cli/modules/metrics/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "yanet-cli-metrics"
 path = "src/main.rs"

--- a/cli/modules/pipeline/Cargo.toml
+++ b/cli/modules/pipeline/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 authors = ["YANET Team"]
 description = "CLI for YANET pipeline module"
 
+[lints]
+workspace = true
+
 [dependencies]
 ynpb = { path = "../../../common/rust/ynpb", version = "0.1", package = "yanet-ynpb" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }

--- a/cli/modules/ready/Cargo.toml
+++ b/cli/modules/ready/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "yanet-cli-ready"
 path = "src/main.rs"

--- a/cli/modules/ready/src/render/layout.rs
+++ b/cli/modules/ready/src/render/layout.rs
@@ -51,7 +51,7 @@ mod test {
 
     #[test]
     fn name_width_empty_defaults_to_minimum() {
-        assert_eq!(MIN_NAME_WIDTH, name_width(std::iter::empty()));
+        assert_eq!(MIN_NAME_WIDTH, name_width(core::iter::empty()));
     }
 
     #[test]

--- a/common/rust/bitmap/Cargo.toml
+++ b/common/rust/bitmap/Cargo.toml
@@ -3,4 +3,7 @@ name = "bitmap"
 version = "0.1.0"
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]

--- a/common/rust/commonpb/Cargo.toml
+++ b/common/rust/commonpb/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 netip = "0.3"
 prost = "0.13"

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -7,7 +7,7 @@ use core::{
 
 use netip::{Contiguous, IpNetwork, MacAddr, ipv4_range_to_networks, ipv6_range_to_networks};
 
-#[allow(clippy::all, non_snake_case)]
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod pb {
     tonic::include_proto!("common.commonpb.v1");
 }

--- a/common/rust/filterpb/Cargo.toml
+++ b/common/rust/filterpb/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 netip = "0.3"
 prost = "0.13"

--- a/common/rust/filterpb/src/lib.rs
+++ b/common/rust/filterpb/src/lib.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::all, non_snake_case)]
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod pb {
     tonic::include_proto!("common.filterpb.v1");
 }

--- a/common/rust/filterpb/src/network.rs
+++ b/common/rust/filterpb/src/network.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Display, Formatter};
+use core::fmt::{self, Display, Formatter};
 
 use netip::{Contiguous, IpNetwork, Ipv4Network, Ipv6Network};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};

--- a/common/rust/readinesspb/Cargo.toml
+++ b/common/rust/readinesspb/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 prost = "0.13"
 prost-types = "0.13"

--- a/common/rust/readinesspb/src/lib.rs
+++ b/common/rust/readinesspb/src/lib.rs
@@ -4,7 +4,7 @@
 //! `pb::State`, and `pb::Reason` generated from
 //! `common/readinesspb/v1/readiness.proto`.
 
-#[allow(clippy::all, non_snake_case)]
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod pb {
     tonic::include_proto!("common.readinesspb.v1");
 }

--- a/common/rust/ynpb/Cargo.toml
+++ b/common/rust/ynpb/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2024"
 publish = false
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 prost = "0.13"
 prost-types = "0.13"

--- a/common/rust/ynpb/src/lib.rs
+++ b/common/rust/ynpb/src/lib.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::all, non_snake_case)]
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod pb {
     tonic::include_proto!("controlplane.ynpb.v1");
 }

--- a/devices/plain/cli/Cargo.toml
+++ b/devices/plain/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}

--- a/devices/plain/cli/src/main.rs
+++ b/devices/plain/cli/src/main.rs
@@ -9,7 +9,7 @@ use ync::{
     output::{self, CommonFormat},
 };
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod code {
     use serde::Serialize;
 

--- a/devices/trafgen/cli/Cargo.toml
+++ b/devices/trafgen/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }

--- a/devices/trafgen/cli/src/main.rs
+++ b/devices/trafgen/cli/src/main.rs
@@ -18,7 +18,7 @@ use ync::{
     output::{self, CommonFormat},
 };
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod trafgenpb {
     use serde::Serialize;
 

--- a/devices/vlan/cli/Cargo.toml
+++ b/devices/vlan/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}

--- a/devices/vlan/cli/src/main.rs
+++ b/devices/vlan/cli/src/main.rs
@@ -9,7 +9,7 @@ use ync::{
     output::{self, CommonFormat},
 };
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod code {
     use serde::Serialize;
 

--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -24,7 +24,7 @@ mod args;
 use ::commonpb::pb as commonpb;
 use commonpb::{GetMetricsRequest, MetricTag};
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod aclpb {
     tonic::include_proto!("modules.acl.controlplane.aclpb.v1");
 }

--- a/modules/balancer2/cli/Cargo.toml
+++ b/modules/balancer2/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }

--- a/modules/balancer2/cli/src/config.rs
+++ b/modules/balancer2/cli/src/config.rs
@@ -1,10 +1,10 @@
-use std::{
+use core::{
     error::Error,
     fmt::Display,
-    fs::File,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     str::FromStr,
 };
+use std::fs::File;
 
 use filterpb::pb::{IpNet, PortRange};
 use netip::IpNetwork;

--- a/modules/balancer2/cli/src/lib.rs
+++ b/modules/balancer2/cli/src/lib.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::all, non_snake_case)]
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod balancerpb {
     tonic::include_proto!("modules.balancer2.controlplane.balancerpb.v1");
 }

--- a/modules/balancer2/cli/src/main.rs
+++ b/modules/balancer2/cli/src/main.rs
@@ -4,7 +4,7 @@ mod reals;
 mod service;
 mod sessions;
 
-use std::{
+use core::{
     fmt::{self, Display, Formatter},
     net::{AddrParseError, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     str::FromStr,
@@ -180,8 +180,8 @@ impl Display for VsIdParseError {
     }
 }
 
-impl std::error::Error for VsIdParseError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for VsIdParseError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::InvalidSocket(e) => Some(e),
             _ => None,
@@ -253,7 +253,7 @@ impl Display for BytesToIpError {
     }
 }
 
-impl std::error::Error for BytesToIpError {}
+impl core::error::Error for BytesToIpError {}
 
 pub fn bytes_to_ip(bytes: &[u8]) -> Result<IpAddr, BytesToIpError> {
     match bytes.len() {

--- a/modules/balancer2/cli/src/reals.rs
+++ b/modules/balancer2/cli/src/reals.rs
@@ -1,4 +1,4 @@
-use std::net::IpAddr;
+use core::net::IpAddr;
 
 use clap::Parser;
 use clap_complete::engine::ArgValueCandidates;

--- a/modules/balancer2/cli/src/service.rs
+++ b/modules/balancer2/cli/src/service.rs
@@ -1,4 +1,5 @@
-use std::{net::IpAddr, time};
+use core::net::IpAddr;
+use std::time;
 
 use commonpb::pb::GetMetricsRequest;
 use ptree::TreeBuilder;
@@ -65,7 +66,7 @@ impl Balancer2Service {
             .map_err(|err| self.service.invalid("update", err.to_string()))?;
         let parts: ConfigParts = yaml_config
             .try_into()
-            .map_err(|err: Box<dyn std::error::Error>| self.service.invalid("update", err.to_string()))?;
+            .map_err(|err: Box<dyn core::error::Error>| self.service.invalid("update", err.to_string()))?;
 
         let request = UpdateConfigRequest {
             config_name: cmd.name.clone(),

--- a/modules/blackhole/cli/Cargo.toml
+++ b/modules/blackhole/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 log = "0.4"

--- a/modules/blackhole/cli/src/main.rs
+++ b/modules/blackhole/cli/src/main.rs
@@ -15,7 +15,7 @@ use ync::{
     output::{self, CommonFormat},
 };
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod blackholepb {
     use serde::Serialize;
 

--- a/modules/decap/cli/Cargo.toml
+++ b/modules/decap/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 netip = "0.3"

--- a/modules/decap/cli/src/main.rs
+++ b/modules/decap/cli/src/main.rs
@@ -17,7 +17,7 @@ use ync::{
     output::{self, CommonFormat},
 };
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod decappb {
     use serde::Serialize;
 

--- a/modules/dscp/cli/Cargo.toml
+++ b/modules/dscp/cli/Cargo.toml
@@ -3,6 +3,9 @@ name = "yanet-cli-dscp"
 version = "0.1.0"
 edition = "2024"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 netip = "0.3"

--- a/modules/dscp/cli/src/main.rs
+++ b/modules/dscp/cli/src/main.rs
@@ -19,7 +19,7 @@ use ync::{
 
 use crate::dscppb::ListConfigsRequest;
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod dscppb {
     use serde::Serialize;
 

--- a/modules/forward/cli/Cargo.toml
+++ b/modules/forward/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -22,7 +22,7 @@ use ync::{
     output::{self, CommonFormat},
 };
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod forwardpb {
     use serde::Serialize;
 
@@ -109,7 +109,7 @@ struct ForwardRule {
 }
 
 impl TryFrom<ForwardRule> for forwardpb::Rule {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn core::error::Error>;
 
     fn try_from(forward_rule: ForwardRule) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -144,7 +144,7 @@ pub struct ForwardConfig {
 }
 
 impl TryFrom<ForwardConfig> for Vec<forwardpb::Rule> {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn core::error::Error>;
 
     fn try_from(config: ForwardConfig) -> Result<Self, Self::Error> {
         config.rules.into_iter().map(forwardpb::Rule::try_from).collect()
@@ -152,7 +152,7 @@ impl TryFrom<ForwardConfig> for Vec<forwardpb::Rule> {
 }
 
 impl ForwardConfig {
-    pub fn load<P>(path: P) -> Result<Self, Box<dyn std::error::Error>>
+    pub fn load<P>(path: P) -> Result<Self, Box<dyn core::error::Error>>
     where
         P: AsRef<Path>,
     {
@@ -259,7 +259,7 @@ impl ForwardService {
         let config = ForwardConfig::load(&cmd.rules).map_err(|e| self.service.invalid("update", e.to_string()))?;
         let rules: Vec<forwardpb::Rule> = config
             .try_into()
-            .map_err(|e: Box<dyn std::error::Error>| self.service.invalid("update", e.to_string()))?;
+            .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("update", e.to_string()))?;
         let request = UpdateConfigRequest { name: cmd.config.clone(), rules };
         self.service
             .client()

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use core::time::Duration;
 
 use clap::Parser;
 use clap_complete::engine::ArgValueCandidates;

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -27,7 +27,7 @@ use ync::{
 
 mod args;
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod fwstatepb {
     use serde::Serialize;
 

--- a/modules/mirror/cli/Cargo.toml
+++ b/modules/mirror/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli"}
 filterpb = { path = "../../../common/rust/filterpb", version = "0.1", package = "yanet-filterpb" }

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -22,7 +22,7 @@ use ync::{
     output::{self, CommonFormat},
 };
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod mirrorpb {
     use serde::Serialize;
 
@@ -109,7 +109,7 @@ struct MirrorRule {
 }
 
 impl TryFrom<MirrorRule> for mirrorpb::Rule {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn core::error::Error>;
 
     fn try_from(mirror_rule: MirrorRule) -> Result<Self, Self::Error> {
         Ok(Self {
@@ -144,7 +144,7 @@ pub struct MirrorConfig {
 }
 
 impl TryFrom<MirrorConfig> for Vec<mirrorpb::Rule> {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn core::error::Error>;
 
     fn try_from(config: MirrorConfig) -> Result<Self, Self::Error> {
         config.rules.into_iter().map(mirrorpb::Rule::try_from).collect()
@@ -152,7 +152,7 @@ impl TryFrom<MirrorConfig> for Vec<mirrorpb::Rule> {
 }
 
 impl MirrorConfig {
-    pub fn load<P>(path: P) -> Result<Self, Box<dyn std::error::Error>>
+    pub fn load<P>(path: P) -> Result<Self, Box<dyn core::error::Error>>
     where
         P: AsRef<Path>,
     {
@@ -259,7 +259,7 @@ impl MirrorService {
         let config = MirrorConfig::load(&cmd.rules).map_err(|e| self.service.invalid("update", e.to_string()))?;
         let rules: Vec<mirrorpb::Rule> = config
             .try_into()
-            .map_err(|e: Box<dyn std::error::Error>| self.service.invalid("update", e.to_string()))?;
+            .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("update", e.to_string()))?;
         let request = UpdateConfigRequest { name: cmd.config.clone(), rules };
         self.service
             .client()

--- a/modules/nat64/cli/Cargo.toml
+++ b/modules/nat64/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }

--- a/modules/nat64/cli/src/main.rs
+++ b/modules/nat64/cli/src/main.rs
@@ -21,7 +21,7 @@ use ync::{
     output::{self, CommonFormat},
 };
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod nat64pb {
     use serde::Serialize;
     tonic::include_proto!("modules.nat64.controlplane.nat64pb.v1");

--- a/modules/pdump/cli/Cargo.toml
+++ b/modules/pdump/cli/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }

--- a/modules/pdump/cli/src/dump_mode.rs
+++ b/modules/pdump/cli/src/dump_mode.rs
@@ -3,7 +3,7 @@
 //! This module provides types and functions for configuring packet capture
 //! modes, including input packets and dropped packets
 
-use std::ops::BitOrAssign;
+use core::ops::BitOrAssign;
 
 use clap::Args;
 

--- a/modules/pdump/cli/src/main.rs
+++ b/modules/pdump/cli/src/main.rs
@@ -26,7 +26,7 @@ mod dump_mode;
 mod printer;
 mod writer;
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod pdumppb {
     use serde::Serialize;
 

--- a/modules/pdump/cli/src/printer.rs
+++ b/modules/pdump/cli/src/printer.rs
@@ -1,7 +1,5 @@
-use std::{
-    io::{self, Write},
-    net::{Ipv4Addr, Ipv6Addr},
-};
+use core::net::{Ipv4Addr, Ipv6Addr};
+use std::io::{self, Write};
 
 use pnet_packet::{
     Packet,
@@ -874,7 +872,11 @@ fn format_duration_ns(ts: u64) -> String {
     format!("{hours:02}:{minutes:02}:{seconds:02}.{millis:03}.{micro:03}")
 }
 
+// `core::io::Cursor` is behind the unstable `core_io` feature, so this module
+// keeps `std::io::Cursor`; the allow sits on the module rather than the `use`
+// because clippy's `useless_attribute` rejects it directly on a `use` item.
 #[cfg(test)]
+#[allow(clippy::std_instead_of_core)]
 mod tests {
     use std::io::Cursor;
 

--- a/modules/pdump/cli/src/writer.rs
+++ b/modules/pdump/cli/src/writer.rs
@@ -1,8 +1,7 @@
+use core::{error::Error, time::Duration};
 use std::{
-    error::Error,
     fs,
     io::{self, Write},
-    time::Duration,
 };
 
 use pcap_file::{

--- a/modules/route-mpls/cli/Cargo.toml
+++ b/modules/route-mpls/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }

--- a/modules/route-mpls/cli/src/main.rs
+++ b/modules/route-mpls/cli/src/main.rs
@@ -2,14 +2,14 @@
 
 use core::{net::IpAddr, ops::Deref};
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod filterpb {
     use serde::Serialize;
 
     tonic::include_proto!("common.filterpb.v1");
 }
 
-#[allow(non_snake_case)]
+#[allow(clippy::std_instead_of_core, non_snake_case)]
 pub mod routemplspb {
     use serde::Serialize;
 
@@ -130,7 +130,7 @@ pub struct RouteWithdrawCmd {
 }
 
 impl TryFrom<Contiguous<IpNetwork>> for filterpb::IpPrefix {
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn core::error::Error>;
 
     fn try_from(net: Contiguous<IpNetwork>) -> Result<Self, Self::Error> {
         let length = net.prefix() as u32;

--- a/modules/route/cli/route/Cargo.toml
+++ b/modules/route/cli/route/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 commonpb = { path = "../../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../../cli/core", version = "0.1", package = "yanet-cli" }

--- a/modules/route/cli/route/src/lib.rs
+++ b/modules/route/cli/route/src/lib.rs
@@ -1,4 +1,4 @@
-#[allow(clippy::all, non_snake_case)]
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod routepb {
     tonic::include_proto!("modules.route.controlplane.routepb.v1");
 }

--- a/operators/pipeline/cli/Cargo.toml
+++ b/operators/pipeline/cli/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [dependencies]
 commonpb = { path = "../../../common/rust/commonpb", version = "0.1", package = "yanet-commonpb" }
 ync = { path = "../../../cli/core", version = "0.1", package = "yanet-cli" }

--- a/operators/pipeline/cli/src/main.rs
+++ b/operators/pipeline/cli/src/main.rs
@@ -12,7 +12,7 @@ use ync::{
 
 use crate::operatorpb::metrics_service_client::MetricsServiceClient;
 
-#[allow(clippy::all, non_snake_case)]
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod operatorpb {
     tonic::include_proto!("operators.pipeline.operatorpb.v1");
 }

--- a/operators/route/cli/neighbour/Cargo.toml
+++ b/operators/route/cli/neighbour/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "yanet-cli-operator-neighbour"
 path = "src/main.rs"

--- a/operators/route/cli/neighbour/src/main.rs
+++ b/operators/route/cli/neighbour/src/main.rs
@@ -34,7 +34,7 @@ use crate::operatorpb::{
     UpdateNeighbourTableRequest, UpdateNeighboursRequest, neighbour_service_client::NeighbourServiceClient,
 };
 
-#[allow(clippy::all, non_snake_case)]
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod operatorpb {
     tonic::include_proto!("operators.route.operatorpb.v1");
 }

--- a/operators/route/cli/route/Cargo.toml
+++ b/operators/route/cli/route/Cargo.toml
@@ -6,6 +6,9 @@ publish = false
 
 rust-version = "1.85"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "yanet-cli-operator-route"
 path = "src/main.rs"

--- a/operators/route/cli/route/src/main.rs
+++ b/operators/route/cli/route/src/main.rs
@@ -31,7 +31,7 @@ use crate::operatorpb::{
     ShowRoutesRequest, route_service_client::RouteServiceClient,
 };
 
-#[allow(clippy::all, non_snake_case)]
+#[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod operatorpb {
     tonic::include_proto!("operators.route.operatorpb.v1");
 }


### PR DESCRIPTION
Enable the `std_instead_of_core` clippy lint at deny level for the whole Rust workspace, so anything `core` provides is imported from `core` rather than `std`. The lint is declared once in the root manifest and inherited by every member through a `[lints]` table, which is the mechanism Cargo offers for workspace-wide lint policy.

The lint belongs to the restriction group, which `clippy::all` does not cover. Several generated protobuf wrappers already carried a blanket allow for `clippy::all` and were still emitting hits, so the suppression had to be named explicitly.

Every generated protobuf wrapper now carries that explicit allow, because the gRPC client codegen emits `std` paths that are not ours to change. All remaining occurrences are hand-written and were converted, covering error, formatting, networking, string-parsing, duration, memory, iterator and operator imports.

One case intentionally keeps `std`: a caller that reads the system clock, since the wall-clock types have no `core` equivalent while the address type alongside them does.

The Rust conventions document previously prescribed the exact `std` import the lint now rejects, so it is corrected and the new rule recorded alongside it.
