### PR TITLE
fix(functional): give the snapshot restore a working recovery

### DIFF
--- a/tests/functional/framework/framework.go
+++ b/tests/functional/framework/framework.go
@@ -236,8 +236,8 @@ type TestFramework struct {
 
 	socketClients *socketClientsCache
 
-	lastDataplaneConfig    string // Last dataplane config used by StartYANET (for RestartYANET)
-	lastControlplaneConfig string // Last controlplane config used by StartYANET (for RestartYANET)
+	lastDataplaneConfig    string // Last dataplane config recorded by StartYANET or AdoptRunningConfig (for RestartYANET)
+	lastControlplaneConfig string // Last controlplane config recorded by StartYANET or AdoptRunningConfig (for RestartYANET)
 
 	testName string
 	t        *testing.T
@@ -523,13 +523,15 @@ func (f *TestFramework) withTestName(testName string) *TestFramework {
 	}
 
 	fWithName := &TestFramework{
-		qemu:          f.qemu,
-		cli:           f.cli.WithLog(namedLog),
-		PacketParser:  f.PacketParser,
-		log:           namedLog,
-		Paths:         f.Paths,
-		socketClients: f.socketClients, // shared cache with mutex
-		testName:      testName,
+		qemu:                   f.qemu,
+		cli:                    f.cli.WithLog(namedLog),
+		PacketParser:           f.PacketParser,
+		log:                    namedLog,
+		Paths:                  f.Paths,
+		socketClients:          f.socketClients, // shared cache with mutex
+		lastDataplaneConfig:    f.lastDataplaneConfig,
+		lastControlplaneConfig: f.lastControlplaneConfig,
+		testName:               testName,
 	}
 
 	if testName == globalName {
@@ -1073,6 +1075,10 @@ func (f *TestFramework) StartYANET(dataplaneConfig string, controlplaneConfig st
 }
 
 func (f *TestFramework) RestartYANET() error {
+	if f.lastDataplaneConfig == "" {
+		return fmt.Errorf("no recorded configuration to restart from: neither StartYANET nor AdoptRunningConfig recorded one")
+	}
+
 	f.log.Info("Restarting YANET (kill + fresh start)...")
 
 	killCmd := "kill $(pidof yanet-dataplane) $(pidof yanet-controlplane) 2>/dev/null; sleep 1; kill -9 $(pidof yanet-dataplane) $(pidof yanet-controlplane) 2>/dev/null; true"
@@ -1094,6 +1100,19 @@ func (f *TestFramework) RestartYANET() error {
 
 	f.log.Info("YANET restarted and reconfigured successfully")
 	return nil
+}
+
+// AdoptRunningConfig records the configuration to restart the guest with.
+//
+// It starts nothing. A VM restored from a baseline snapshot boots with
+// YANET already running, so the framework driving it never called
+// StartYANET and therefore holds no configuration for RestartYANET to
+// restart from. Call this once the caller knows what configuration the
+// running guest was baked with, so a later in-place restart has something
+// to fall back to.
+func (f *TestFramework) AdoptRunningConfig(dataplaneConfig string, controlplaneConfig string) {
+	f.lastDataplaneConfig = dataplaneConfig
+	f.lastControlplaneConfig = controlplaneConfig
 }
 
 // WaitOutputPresent repeatedly executes a command until the output satisfies the

--- a/tests/functional/framework/framework_test.go
+++ b/tests/functional/framework/framework_test.go
@@ -1,0 +1,63 @@
+package framework
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRestartYANETGuardsMissingConfig verifies that RestartYANET rejects a
+// framework with no recorded dataplane configuration.
+//
+// The guard must return before touching anything that requires a live
+// guest, so the call returns an error instead of panicking on a nil logger.
+// It covers both a framework that never recorded anything and one that
+// recorded a controlplane config but not a dataplane one, so the guard is
+// pinned to the dataplane field rather than to either field being
+// non-empty.
+func TestRestartYANETGuardsMissingConfig(t *testing.T) {
+	testCases := []struct {
+		name string
+		fw   *TestFramework
+	}{
+		{
+			name: "nothing recorded",
+			fw:   &TestFramework{},
+		},
+		{
+			name: "controlplane config recorded but dataplane config still empty",
+			fw:   &TestFramework{lastControlplaneConfig: "logging:\n  level: info\n"},
+		},
+	}
+
+	for idx, testCase := range testCases {
+		err := testCase.fw.RestartYANET()
+		if err == nil {
+			t.Fatalf("case %d (%s): RestartYANET() error = nil, want non-nil", idx, testCase.name)
+		}
+
+		if !strings.Contains(err.Error(), "no recorded configuration") {
+			t.Errorf("case %d (%s): RestartYANET() error = %q, want it to describe the no-recorded-configuration case", idx, testCase.name, err.Error())
+		}
+	}
+}
+
+// TestAdoptRunningConfigRecordsConfig verifies that AdoptRunningConfig
+// records both configuration YAML documents.
+//
+// Recording both is what lets a later RestartYANET call get past its
+// no-recorded-configuration guard.
+func TestAdoptRunningConfigRecordsConfig(t *testing.T) {
+	dataplaneConfig := "dataplane:\n  storage: /dev/hugepages/yanet\n"
+	controlplaneConfig := "logging:\n  level: info\n"
+
+	fw := &TestFramework{}
+
+	fw.AdoptRunningConfig(dataplaneConfig, controlplaneConfig)
+
+	if fw.lastDataplaneConfig != dataplaneConfig {
+		t.Errorf("lastDataplaneConfig = %q, want %q", fw.lastDataplaneConfig, dataplaneConfig)
+	}
+	if fw.lastControlplaneConfig != controlplaneConfig {
+		t.Errorf("lastControlplaneConfig = %q, want %q", fw.lastControlplaneConfig, controlplaneConfig)
+	}
+}

--- a/tests/functional/framework/harness.go
+++ b/tests/functional/framework/harness.go
@@ -411,6 +411,8 @@ func (m *Harness) WithBootedVM(t *testing.T, fn func(fw *TestFramework)) {
 func (m *Harness) RestoreBooted(t *testing.T, fw *TestFramework) {
 	t.Helper()
 
+	fw.AdoptRunningConfig(m.dataplane, m.controlplane)
+
 	err := fw.RestoreAndReconnect("baseline")
 	if err == nil {
 		return


### PR DESCRIPTION
When the datapath fails its readiness check right after a baseline snapshot loads, the harness tries an in-place restart of the guest before falling back to a full cold start. That restart could never succeed.

It restarts the guest from the configuration this process last started YANET with, but a VM restored from a snapshot comes up with YANET already running, so this process never started it and never recorded anything. The restart therefore always failed for want of a configuration. It also killed the running processes and removed the guest interface *before* reaching that check, so it tore the system down and only then reported it had nothing to restart from. And because each test works on its own copy of the framework, nothing carried over from an earlier cold-start fallback either. The net effect is that this recovery has never once succeeded on the snapshot path, for any test, in any run.

The diagnostics merged earlier are what exposed it, on their first run: the previously blank fallback line now reads `heartbeat failed, restart also failed: YANET restart failed: dataplane configurations are required`.

Refuse the restart before tearing anything down when no configuration was recorded, and let the harness record the configuration its snapshot was baked with, so the cheap recovery gets a real chance before the expensive one runs.

The safety net is unchanged. If the restart now runs and still fails to bring the datapath back, the caller falls back to the cold path exactly as before, and that path opens by rolling the whole guest back to a snapshot, which discards everything the restart touched.

The guard's value is its ordering, so a test pins it: on a bare framework the guard must return before the first call that needs a live guest. Moving the guard below the teardown makes that test fail rather than regress silently.
