### PR TITLE
feat(acl,controlplane): unlock parallel config compilation

### DIFF
--- a/common/memory.h
+++ b/common/memory.h
@@ -62,20 +62,29 @@ memory_context_init_from(
 	context->balloc_size = 0;
 	context->bfree_size = 0;
 
-	SET_OFFSET_OF(
-		&context->block_allocator, ADDR_OF(&parent->block_allocator)
-	);
+	// No NULL guard here, unlike fini: by contract parent is always a live,
+	// already-initialised context, so its block_allocator is never NULL. A
+	// zeroed (finalised) parent has no valid allocator for us to inherit,
+	// and no caller constructs a child from a finalised parent.
+	struct block_allocator *allocator = ADDR_OF(&parent->block_allocator);
+	SET_OFFSET_OF(&context->block_allocator, allocator);
 	(void)strtcpy(context->name, name, sizeof(context->name));
 
 	// Remember which context contains us, needed to unlink on teardown.
 	SET_OFFSET_OF(&context->parent, parent);
 	SET_OFFSET_OF(&context->first_child, NULL);
 
+	// Parent and child share the same block_allocator by construction, so
+	// its spinlock also guards this splice against concurrent siblings.
+	spinlock_lock(&allocator->lock);
+
 	// Insert at the head of the parent's child list. Capture the current
 	// head into next_sibling before overwriting first_child so the ordering
 	// is correct.
 	EQUATE_OFFSET(&context->next_sibling, &parent->first_child);
 	SET_OFFSET_OF(&parent->first_child, context);
+
+	spinlock_unlock(&allocator->lock);
 
 	return 0;
 }
@@ -87,6 +96,19 @@ memory_context_init_from(
 // leave a child pointing at freed memory. Idempotent and order-independent.
 static inline void
 memory_context_fini(struct memory_context *self) {
+	// A zeroed offset reads back as NULL through ADDR_OF. A context that
+	// was already fini'd has no tree links left to touch. Return before
+	// taking a lock on a garbage allocator.
+	struct block_allocator *allocator = ADDR_OF(&self->block_allocator);
+	if (allocator == NULL) {
+		return;
+	}
+
+	// Parent and child share the same block_allocator by construction, so
+	// its spinlock also guards the unlink and child-detach below against
+	// concurrent siblings.
+	spinlock_lock(&allocator->lock);
+
 	struct memory_context *parent = ADDR_OF(&self->parent);
 	if (parent != NULL) {
 		// Walk the sibling chain and bridge over ourselves.
@@ -114,6 +136,8 @@ memory_context_fini(struct memory_context *self) {
 		child = next;
 	}
 
+	spinlock_unlock(&allocator->lock);
+
 	memset(self, 0, sizeof(*self));
 }
 
@@ -124,8 +148,10 @@ memory_balloc(struct memory_context *context, size_t size) {
 	);
 	if (result == NULL)
 		return NULL;
-	++context->balloc_count;
-	context->balloc_size += size;
+	// A single memory_context (e.g. an agent's own context) can now be
+	// ballocked from by several controlplane threads at once.
+	__atomic_fetch_add(&context->balloc_count, 1, __ATOMIC_RELAXED);
+	__atomic_fetch_add(&context->balloc_size, size, __ATOMIC_RELAXED);
 	return result;
 }
 
@@ -133,8 +159,25 @@ static inline void
 memory_bfree(struct memory_context *context, void *block, size_t size) {
 	if (block == NULL || !size)
 		return;
-	++context->bfree_count;
-	context->bfree_size += size;
+// Verified reproducing: gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, release
+// build flags (-O2 -g -Wall -Wextra -Werror -march=haswell -fPIC), e.g.
+// modules/acl/api/controlplane.c inlining memory_bfree into
+// acl_module_config_free. context is derived from a relative offset
+// pointer (ADDR_OF) at every caller. GCC compiles the theoretical,
+// architecturally-unreachable branch where the stored offset is exactly 0
+// (ADDR_OF's own NULL case), folds it into a literal near-null address,
+// and then misreports the atomic RMW below as an overflowing write to a
+// size-0 object at that address. Clang does not know -Wstringop-overflow,
+// so the pragma is gcc-only.
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+	__atomic_fetch_add(&context->bfree_count, 1, __ATOMIC_RELAXED);
+	__atomic_fetch_add(&context->bfree_size, size, __ATOMIC_RELAXED);
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 	return block_allocator_bfree(
 		ADDR_OF(&context->block_allocator), block, size
 	);

--- a/common/memory_block.h
+++ b/common/memory_block.h
@@ -6,6 +6,7 @@
 
 #include "asan.h"
 #include "likely.h"
+#include "spinlock.h"
 
 #include "memory_address.h"
 
@@ -52,6 +53,11 @@ struct block_allocator {
 
 	// bitwise mask of not empty pools
 	uint32_t not_empty_mask;
+
+	// Guards the free lists above and, since every memory_context in a
+	// tree shares its root's block_allocator, the context tree splices in
+	// memory_context_init_from / memory_context_fini as well.
+	struct spinlock lock;
 };
 
 // FIXME: the routine must accept block sizes
@@ -66,6 +72,8 @@ block_allocator_init(struct block_allocator *allocator) {
 	}
 
 	allocator->not_empty_mask = 0;
+
+	spinlock_init(&allocator->lock);
 
 	return 0;
 }
@@ -165,10 +173,13 @@ block_allocator_balloc(struct block_allocator *allocator, size_t size) {
 	size += 2 * ASAN_RED_ZONE;
 
 	size_t pool_index = block_allocator_pool_index(allocator, size);
-
 	struct block_allocator_pool *pool = allocator->pools + pool_index;
+
+	spinlock_lock(&allocator->lock);
+
 	uint32_t mask = allocator->not_empty_mask >> pool_index;
 	if (unlikely(mask == 0)) {
+		spinlock_unlock(&allocator->lock);
 		return NULL;
 	}
 	size_t parent_pool_index = pool_index + __builtin_ctz(mask);
@@ -181,6 +192,8 @@ block_allocator_balloc(struct block_allocator *allocator, size_t size) {
 	asan_unpoison_memory_region(
 		memory + ASAN_RED_ZONE, size - 2 * ASAN_RED_ZONE
 	);
+
+	spinlock_unlock(&allocator->lock);
 
 	return memory + ASAN_RED_ZONE;
 }
@@ -214,7 +227,9 @@ block_allocator_bfree(
 	size += 2 * ASAN_RED_ZONE;
 	block -= ASAN_RED_ZONE;
 
+	spinlock_lock(&allocator->lock);
 	block_allocator_bfree_internal(allocator, block, size);
+	spinlock_unlock(&allocator->lock);
 }
 
 static inline void
@@ -225,6 +240,8 @@ block_allocator_put_arena(
 	pos = (pos + 7) & ~(uintptr_t)0x07; // round up to 8 byte boundary
 	uintptr_t end = (uintptr_t)arena + size;
 	end = end & ~(uintptr_t)0x07; // round down to 8 byte boundary
+
+	spinlock_lock(&allocator->lock);
 
 	while (pos < end) {
 		size_t align = (size_t)1 << __builtin_ctzll(pos);
@@ -251,14 +268,18 @@ block_allocator_put_arena(
 		);
 		pos += block_size;
 	}
+
+	spinlock_unlock(&allocator->lock);
 }
 
 static inline size_t
 block_allocator_free_size(struct block_allocator *alloc) {
 	size_t size = 0;
+	spinlock_lock(&alloc->lock);
 	for (size_t i = 0; i < MEMORY_BLOCK_ALLOCATOR_EXP; ++i) {
 		struct block_allocator_pool *pool = &alloc->pools[i];
 		size += pool->free * block_allocator_pool_size(alloc, i);
 	}
+	spinlock_unlock(&alloc->lock);
 	return size;
 }

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -103,6 +103,11 @@ dataplane_instance_worker_count(struct dp_config *dp_config) {
 	return (uint32_t)dp_config->worker_count;
 }
 
+// Body of agent_free_unused_agents for a caller that already holds
+// cp_config_lock. See the definition further down for details.
+static void
+agent_free_unused_agents_locked(struct agent *agent);
+
 struct agent *
 agent_attach(
 	struct yanet_shm *shm,
@@ -268,7 +273,7 @@ agent_attach(
 		SET_OFFSET_OF(&cp_config->agent_registry, new_registry);
 	}
 
-	agent_free_unused_agents(new_agent);
+	agent_free_unused_agents_locked(new_agent);
 
 unlock:
 	cp_config_unlock(cp_config);
@@ -1981,8 +1986,10 @@ yanet_counter_handle_list_free(struct counter_handle_list *counters) {
 	free(counters);
 }
 
-void
-agent_free_unused_agents(struct agent *agent) {
+// Unlocked body shared by agent_free_unused_agents and the agent_attach call
+// site, which already holds cp_config_lock itself.
+static void
+agent_free_unused_agents_locked(struct agent *agent) {
 	if (agent == NULL) {
 		return;
 	}
@@ -2000,6 +2007,22 @@ agent_free_unused_agents(struct agent *agent) {
 
 		agent = ADDR_OF(&agent->prev);
 	}
+}
+
+void
+agent_free_unused_agents(struct agent *agent) {
+	if (agent == NULL) {
+		return;
+	}
+
+	// This walks and splices the agent->prev chain and calls agent_cleanup,
+	// which frees the superseded agent into cp_config->memory_context. It
+	// must run under cp_config_lock now that Go-side callers are no longer
+	// serialized by a global mutex.
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+	cp_config_lock(cp_config);
+	agent_free_unused_agents_locked(agent);
+	cp_config_unlock(cp_config);
 }
 
 struct dp_config *

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 9
+#define YANET_MODULE_ABI_VERSION 10
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -101,7 +101,6 @@ loopindex:modules/pdump/controlplane/ring_test.go:createTestRingBuffer:i:1  # le
 loopindex:modules/route/bindings/go/croute/cgo.go:ModuleConfig.addRouteList:i:1  # legacy: rename to idx
 maplit:controlplane/ffi/shm.go:DPConfig.AllModulePositions:map[string][]Chain:1  # legacy: use T{} instead of make(map...)
 maplit:controlplane/ffi/shm.go:DPConfig.AllModulePositions:map[string][]string:1  # legacy: use T{} instead of make(map...)
-maplit:modules/acl/controlplane/acl_adapter.go:ACLService.createLinkedHandlesLocked:map[string]ModuleHandle:1  # legacy: use T{} instead of make(map...)
 maplit:modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:map[string]struct{}:1  # legacy: use T{} instead of make(map...)
 maplit:modules/acl/controlplane/metrics_snapshot.go:newACLMetricsState:map[string]cacl.AclConfigInfo:1  # legacy: use T{} instead of make(map...)
 maplit:modules/fwstate/controlplane/service.go:FWStateService.LinkFWState:map[string]bool:1  # legacy: use T{} instead of make(map...)
@@ -141,49 +140,65 @@ private:controlplane/internal/auth/sshcert/token.go:parseToken:token.validate:1 
 private:controlplane/internal/auth/sshkey/authenticator.go:Authenticator.Authenticate:token.canonicalSignedData:1  # legacy: encapsulate behind an exported method or field
 private:controlplane/internal/auth/sshkey/authenticator.go:Authenticator.Authenticate:token.checkTimestamp:1  # legacy: encapsulate behind an exported method or field
 private:controlplane/internal/auth/sshkey/token.go:parseToken:token.validate:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.configs:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.configs:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.createLinkedHandlesLocked:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.mu:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.mu:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.publishMetricsSnapshotLocked:1  # acl metrics snapshot: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:oldConfig.acl:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:oldConfig.acl:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:oldConfig.rules:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkedConfigNames:m.service.linkedConfigNamesLocked:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkedConfigNames:m.service.mu:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkedConfigNames:m.service.mu:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.configs:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.configs:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.createLinkedHandlesLocked:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.linkedConfigNamesLocked:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.mu:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.mu:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.publishMetricsSnapshotLocked:1  # acl metrics snapshot: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:oldConfig.acl:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:oldConfig.acl:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:oldConfig.rules:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLService.createLinkedHandlesLocked:oldConfig.rules:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/acl_adapter.go:ACLService.linkedConfigNamesLocked:config.fwstateName:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.checkLinkable:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.createLinkedHandles:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.swapLinkedHandles:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkConfigs:m.service.withEntries:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.LinkedConfigNames:m.service.linkedConfigNames:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.createLinkedHandles:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.linkedConfigNames:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.stillLinked:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.swapLinkedHandles:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLAdapter.RelinkConfigs:m.service.withEntries:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.createLinkedHandles:entry.published.rules:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.createLinkedHandles:entry.published:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.createLinkedHandles:entry.published:2  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.linkedConfigNames:entry.published.fwstateName:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.linkedConfigNames:entry.published:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.linkedConfigNames:entry.published:2  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.stillLinked:entry.published.fwstateName:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.stillLinked:entry.published:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.stillLinked:entry.published:2  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:entry.published.acl:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:entry.published.rules:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:entry.published:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:entry.published:2  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:entry.published:3  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:entry.published:4  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/aclpb/v1/convert.go:FromActions:result[idx].setFromCAclKind:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/aclpb/v1/convert.go:ToActions:action.toCAclKind:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:m.metricsState.load:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:snapshot.configInfo:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:config.acl:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:config.acl:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.ShowConfig:config.fwstateName:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.ShowConfig:config.rules:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:existing.rules:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfigs.acl:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfigs.acl:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfigs.acl:3  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfigs.fwstateName:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfigs.fwstateName:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:cfg.acl:1  # acl metrics snapshot: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:cfg.acl:2  # acl metrics snapshot: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:config.acl:3  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:entry.published:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:entry.published:2  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.ListConfigs:entry.published:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published.fwstateName:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published.rules:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published:2  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published:3  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:entry.published:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:entry.published:2  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.acl:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.acl:2  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.acl:3  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.fwstateName:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.rules:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:entry.published.acl:1  # acl metrics snapshot: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:entry.published.acl:2  # acl metrics snapshot: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:entry.published:1  # acl metrics snapshot: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:entry.published:2  # acl metrics snapshot: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:entry.published:3  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:m.metricsState.publish:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.retention:m.metricsState.load:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.retention:snapshot.containsConfig:1  # acl metrics snapshot: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.withEntries:e.updateMu:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.withEntries:e.updateMu:2  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.withEntry:entry.updateMu:1  # legacy: encapsulate behind an exported method or field
+private:modules/acl/controlplane/service.go:ACLService.withEntry:entry.updateMu:2  # legacy: encapsulate behind an exported method or field
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.addressFamily:1  # legacy: encapsulate behind an exported method or field
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.destroy:1  # legacy: encapsulate behind an exported method or field
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.next:1  # legacy: encapsulate behind an exported method or field

--- a/modules/acl/controlplane/acl_adapter.go
+++ b/modules/acl/controlplane/acl_adapter.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	aclpb "github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
 	fwstate "github.com/yanet-platform/yanet2/modules/fwstate/controlplane"
 )
 
@@ -27,116 +28,106 @@ func NewACLAdapter(service *ACLService) *ACLAdapter {
 // LinkedConfigNames returns ACL config names linked to the given fwstate
 // config name.
 func (m *ACLAdapter) LinkedConfigNames(fwstateConfigName string) []string {
-	m.service.mu.Lock()
-	defer m.service.mu.Unlock()
-
-	return m.service.linkedConfigNamesLocked(fwstateConfigName)
+	return m.service.linkedConfigNames(fwstateConfigName)
 }
 
 // RelinkConfigs creates new ACL module configs for every name currently
 // linked to fwstateConfig.
 //
-// Calls publish to push the combined dataplane update.
+// Calls publish to push the combined dataplane update. Every linked name's
+// lock is held for the whole rebuild (including the compile), so a read on
+// one of those names still returns instantly under mu.RLock, and an
+// UpdateConfig/DeleteConfig on one of those names waits behind this call
+// instead of racing it.
 func (m *ACLAdapter) RelinkConfigs(
 	fwstateConfig *fwstate.FwStateConfig,
 	publish func(linkedFFI []ffi.ModuleConfig) error,
 ) error {
-	m.service.mu.Lock()
-	defer m.service.mu.Unlock()
-
-	names := m.service.linkedConfigNamesLocked(fwstateConfig.Name())
+	names := m.service.linkedConfigNames(fwstateConfig.Name())
 	if len(names) == 0 {
 		return publish(nil)
 	}
 
-	newHandles, err := m.service.createLinkedHandlesLocked(names, fwstateConfig)
-	if err != nil {
-		return err
-	}
-
-	ffiCfgs := make([]ffi.ModuleConfig, 0, len(names))
-	for _, name := range names {
-		ffiCfgs = append(ffiCfgs, newHandles[name].AsFFIModule())
-	}
-
-	if err := publish(ffiCfgs); err != nil {
-		for _, h := range newHandles {
-			h.Free()
+	return m.service.withEntries(names, func(entries map[string]*configEntry) error {
+		// A Delete or an UpdateConfig that lost the race for one of these
+		// name locks may have run to completion before we got them, so the
+		// snapshot above can no longer be trusted. Keep only names still
+		// linked.
+		linked := m.service.stillLinked(names, entries, fwstateConfig.Name())
+		if len(linked) == 0 {
+			return publish(nil)
 		}
 
-		return err
-	}
-
-	for name, newHandle := range newHandles {
-		oldConfig := m.service.configs[name]
-		if oldConfig.acl != nil {
-			oldConfig.acl.Free()
+		newHandles, err := m.service.createLinkedHandles(linked, entries, fwstateConfig)
+		if err != nil {
+			return err
 		}
 
-		m.service.configs[name] = aclConfig{
-			rules:       oldConfig.rules,
-			acl:         newHandle,
-			fwstateName: fwstateConfig.Name(),
+		ffiCfgs := make([]ffi.ModuleConfig, 0, len(linked))
+		for _, name := range linked {
+			ffiCfgs = append(ffiCfgs, newHandles[name].AsFFIModule())
 		}
-	}
-	m.service.publishMetricsSnapshotLocked()
 
-	return nil
+		if err := publish(ffiCfgs); err != nil {
+			for _, h := range newHandles {
+				h.Free()
+			}
+
+			return err
+		}
+
+		m.service.swapLinkedHandles(newHandles, entries, fwstateConfig.Name())
+
+		return nil
+	})
 }
 
 // LinkConfigs creates new ACL module configs for the given explicit list of
 // names, linking them to fwstateConfig, then calls publish so the caller can
-// push the combined dataplane update atomically.
+// push the combined dataplane update atomically. A name absent from configs
+// is an error, as today.
 func (m *ACLAdapter) LinkConfigs(
 	names []string,
 	fwstateConfig *fwstate.FwStateConfig,
 	publish func(linkedFFI []ffi.ModuleConfig) error,
 ) error {
-	m.service.mu.Lock()
-	defer m.service.mu.Unlock()
-
-	newHandles, err := m.service.createLinkedHandlesLocked(names, fwstateConfig)
-	if err != nil {
+	if err := m.service.checkLinkable(names); err != nil {
 		return err
 	}
 
-	ffiCfgs := make([]ffi.ModuleConfig, 0, len(names))
-	for _, name := range names {
-		ffiCfgs = append(ffiCfgs, newHandles[name].AsFFIModule())
-	}
-
-	if err := publish(ffiCfgs); err != nil {
-		for _, h := range newHandles {
-			h.Free()
+	return m.service.withEntries(names, func(entries map[string]*configEntry) error {
+		newHandles, err := m.service.createLinkedHandles(names, entries, fwstateConfig)
+		if err != nil {
+			return err
 		}
 
-		return err
-	}
-
-	for name, newHandle := range newHandles {
-		oldConfig := m.service.configs[name]
-		if oldConfig.acl != nil {
-			oldConfig.acl.Free()
+		ffiCfgs := make([]ffi.ModuleConfig, 0, len(names))
+		for _, name := range names {
+			ffiCfgs = append(ffiCfgs, newHandles[name].AsFFIModule())
 		}
 
-		m.service.configs[name] = aclConfig{
-			rules:       oldConfig.rules,
-			acl:         newHandle,
-			fwstateName: fwstateConfig.Name(),
-		}
-	}
-	m.service.publishMetricsSnapshotLocked()
+		if err := publish(ffiCfgs); err != nil {
+			for _, h := range newHandles {
+				h.Free()
+			}
 
-	return nil
+			return err
+		}
+
+		m.service.swapLinkedHandles(newHandles, entries, fwstateConfig.Name())
+
+		return nil
+	})
 }
 
-// linkedConfigNamesLocked returns linked names without taking the mutex.
-//
-// Caller must hold m.mu.
-func (m *ACLService) linkedConfigNamesLocked(fwstateConfigName string) []string {
+// linkedConfigNames returns the names currently linked to fwstateConfigName.
+func (m *ACLService) linkedConfigNames(fwstateConfigName string) []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	names := make([]string, 0)
-	for name, config := range m.configs {
-		if config.fwstateName == fwstateConfigName {
+	for name, entry := range m.configs {
+		if entry.published != nil && entry.published.fwstateName == fwstateConfigName {
 			names = append(names, name)
 		}
 	}
@@ -144,20 +135,101 @@ func (m *ACLService) linkedConfigNamesLocked(fwstateConfigName string) []string 
 	return names
 }
 
-// createLinkedHandlesLocked creates new ACL module handles for every name in
+// checkLinkable verifies that every name in names already has an entry,
+// returning the same not-found error createLinkedHandles would produce for
+// the first missing name.
+//
+// LinkConfigs uses this as a read-only pre-check, before withEntries
+// interns an entry for every requested name regardless of whether one
+// already exists. Existence is the correct test here: an entry is created
+// only by UpdateConfig, so one already being present means the name was
+// created at some point, or is being created right now by an UpdateConfig
+// whose compile has not finished, and either way the name belongs on the
+// locked path below rather than being rejected up front. A name confirmed
+// to have an entry here is not guaranteed to still have a live published
+// config once withEntries locks it: a concurrent delete could run in
+// between, or an in-flight create could still be compiling. Neither race is
+// this check's job: the authoritative re-check under the name's own lock in
+// createLinkedHandles, which runs only after any in-flight compile for the
+// name has finished, catches both.
+func (m *ACLService) checkLinkable(names []string) error {
+	for _, name := range names {
+		if !m.hasEntry(name) {
+			return fmt.Errorf("ACL config %q not found", name)
+		}
+	}
+
+	return nil
+}
+
+// stillLinked filters names to those still linked to fwstateConfigName,
+// preserving names' order.
+//
+// The caller holds updateMu for every entry in entries, which is what
+// makes reading published without m.mu safe and authoritative: nothing
+// else can mutate one of these entries while its lock is held.
+func (m *ACLService) stillLinked(names []string, entries map[string]*configEntry, fwstateConfigName string) []string {
+	kept := make([]string, 0, len(names))
+	for _, name := range names {
+		entry := entries[name]
+		if entry.published != nil && entry.published.fwstateName == fwstateConfigName {
+			kept = append(kept, name)
+		}
+	}
+
+	return kept
+}
+
+// swapLinkedHandles publishes newHandles into entries and the metrics
+// snapshot under a single mu.Lock section, then frees the handles they
+// replaced.
+//
+// Caller must hold the name lock for every name in newHandles, and entries
+// must carry that name's entry.
+func (m *ACLService) swapLinkedHandles(newHandles map[string]ModuleHandle, entries map[string]*configEntry, fwstateConfigName string) {
+	m.mu.Lock()
+	oldHandles := make(map[string]ModuleHandle, len(newHandles))
+	for name, newHandle := range newHandles {
+		entry := entries[name]
+
+		var rules []*aclpb.Rule
+		if entry.published != nil {
+			oldHandles[name] = entry.published.acl
+			rules = entry.published.rules
+		}
+
+		entry.published = &aclConfig{
+			rules:       rules,
+			acl:         newHandle,
+			fwstateName: fwstateConfigName,
+		}
+	}
+	m.publishMetricsSnapshotLocked()
+	m.mu.Unlock()
+
+	for _, h := range oldHandles {
+		if h != nil {
+			h.Free()
+		}
+	}
+}
+
+// createLinkedHandles creates new ACL module handles for every name in
 // names, linked to fwstateConfig. On any failure every handle created so far
 // is freed before returning the error.
 //
-// Caller must hold m.mu.
-func (m *ACLService) createLinkedHandlesLocked(
+// Caller must hold the name lock for every name in names, and entries must
+// carry that name's entry.
+func (m *ACLService) createLinkedHandles(
 	names []string,
+	entries map[string]*configEntry,
 	fwstateConfig *fwstate.FwStateConfig,
 ) (map[string]ModuleHandle, error) {
-	newHandles := make(map[string]ModuleHandle)
+	newHandles := map[string]ModuleHandle{}
 
 	for _, name := range names {
-		oldConfig, ok := m.configs[name]
-		if !ok {
+		entry, ok := entries[name]
+		if !ok || entry.published == nil {
 			for _, h := range newHandles {
 				h.Free()
 			}
@@ -176,7 +248,7 @@ func (m *ACLService) createLinkedHandlesLocked(
 
 		handle.SetFwStateConfig(fwstateConfig.AsFFIModule())
 
-		rules, err := convertRules(oldConfig.rules)
+		rules, err := convertRules(entry.published.rules)
 		if err != nil {
 			handle.Free()
 			for _, h := range newHandles {

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -2,6 +2,8 @@ package acl
 
 import (
 	"context"
+	"slices"
+	"sort"
 	"sync"
 
 	"go.uber.org/zap"
@@ -85,13 +87,76 @@ type aclConfig struct {
 	fwstateName string
 }
 
+// configEntry holds the per-name state that lives outside m.mu: the lock
+// serializing mutations of one config name, and the currently published
+// config for that name.
+//
+// UpdateConfig is the only mutation that can create an entry: it is the
+// only one of the four with*-calling RPCs that ever reaches withEntry or
+// withEntries for a name with no existing entry. DeleteConfig and
+// checkLinkable (LinkConfigs' pre-check) reject an unknown name before
+// either gets there, and RelinkConfigs takes its names from
+// linkedConfigNames, which only lists names already in the map, so none of
+// the other three mutation paths ever interns one. Once created, an
+// entry is never removed: DeleteConfig sets published to nil instead of
+// dropping the map entry, keeping it as the lock anchor. Every mutation
+// RPC is operator-driven, so the key set stays low-cardinality, and an
+// entry costs one idle mutex.
+//
+// Acquiring a name's lock is a two-step operation: a caller fetches the
+// entry pointer while holding m.mu, releases m.mu, and only then locks the
+// entry's updateMu. Between those two steps a goroutine holds a bare entry
+// pointer that no lock protects yet. If entries could be removed from the
+// map, another goroutine could delete that entry and insert a fresh one for
+// the same name during exactly that window. The first goroutine would then
+// go on to lock the orphaned entry while the second locks its replacement,
+// and both would believe they had serialized the same name when in fact
+// they had not. Keeping entries append-only removes that class of race by
+// construction, since the entry for a name stays the same object for the
+// whole life of the process.
+type configEntry struct {
+	// updateMu serializes mutations of this name for the entry's whole
+	// life, across the whole operation including a C compile: UpdateConfig,
+	// DeleteConfig, and the fwstate adapter's link/relink of this name all
+	// hold it for their duration.
+	updateMu sync.Mutex
+	// published is the currently active config for this name, or nil when
+	// the name is absent (a tombstone left by DeleteConfig or a name that
+	// was only ever touched by a failed mutation).
+	//
+	// It is written only while holding both updateMu and m.mu.Lock.
+	//
+	// An updateMu holder may read its own entry's published field without
+	// m.mu, since it is the only possible writer while updateMu is held.
+	published *aclConfig
+}
+
 // ACLService implements the gRPC ACL service.
 type ACLService struct {
 	aclpb.UnimplementedACLServiceServer
 
-	mu      sync.Mutex
+	// mu guards configs (including insertion of a fresh entry) and the
+	// metrics snapshot's ordering relative to it.
+	//
+	// A read-only critical section under mu.RLock is always a short map
+	// read: of configs itself, or of an entry's published field. A
+	// mutating critical section under mu.Lock is a map insert, a swap of
+	// an entry's published field, or both, followed by rebuilding and
+	// publishing the metrics snapshot from the state just installed —
+	// every mutation site does both under the same lock acquisition so
+	// snapshot publishes stay totally ordered with map mutations. The
+	// snapshot rebuild calls GetInfo, a cgo accessor that copies a handful
+	// of integers out of an already-compiled C module, so it is cheap to
+	// run under mu.Lock. The long-running work (backend.NewModule,
+	// handle.UpdateRules, backend.UpdateModule, and the C compile they
+	// trigger) runs under the target entry's updateMu instead, outside any
+	// mu section, so a compile for one config never blocks a read or a
+	// compile for another.
+	mu      sync.RWMutex
 	backend Backend
-	configs map[string]aclConfig
+	// configs maps a name to its entry. See configEntry for the entry
+	// lifecycle and locking rules.
+	configs map[string]*configEntry
 	metrics *grpcmetrics.ServerMetrics
 
 	metricsState *aclMetricsState
@@ -108,7 +173,7 @@ func NewACLService(backend Backend, options ...Option) *ACLService {
 
 	m := &ACLService{
 		backend:      backend,
-		configs:      map[string]aclConfig{},
+		configs:      map[string]*configEntry{},
 		metricsState: newACLMetricsState(),
 		log:          opts.Log,
 	}
@@ -117,6 +182,111 @@ func NewACLService(backend Backend, options ...Option) *ACLService {
 	}
 
 	return m
+}
+
+// entry returns the configEntry for name, creating it under a brief write
+// lock the first time name is touched.
+//
+// The returned pointer is stable for the entry's whole life, so a caller
+// may keep it after releasing m.mu and use it to acquire updateMu.
+func (m *ACLService) entry(name string) *configEntry {
+	m.mu.RLock()
+	e, ok := m.configs[name]
+	m.mu.RUnlock()
+	if ok {
+		return e
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if e, ok := m.configs[name]; ok {
+		return e
+	}
+	e = &configEntry{}
+	m.configs[name] = e
+	return e
+}
+
+// hasEntry reports whether name already has an entry in configs, regardless
+// of whether that entry's published config is live or tombstoned.
+//
+// It takes m.mu.RLock for the lookup. DeleteConfig and checkLinkable use it
+// as a read-only pre-check before a mutation reaches withEntry or
+// withEntries, which would otherwise intern an entry for a name regardless
+// of whether one already exists. Existence alone is the correct test for
+// that pre-check: an entry is created only by UpdateConfig, so one already
+// being present means the name was created at some point, or is being
+// created right now by an UpdateConfig whose compile has not finished. In
+// either case falling through to the locked path below is the right
+// outcome, since it interns nothing for a name that already has an entry
+// and its check of published runs under the name's own lock, after any
+// in-flight compile for the name has finished. A name with no entry at all
+// can never reach that state through any other path, so rejecting it here
+// is exact, not an approximation refined later.
+func (m *ACLService) hasEntry(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	_, ok := m.configs[name]
+	return ok
+}
+
+// withEntry fetches or creates the entry for name, holds its updateMu for
+// the duration of fn, then returns fn's error.
+//
+// updateMu is locked and unlocked only here and in withEntries, nowhere
+// else in the package. That is what makes mutation serialization for a
+// name exhaustive: grep the package for updateMu.Lock( and
+// updateMu.Unlock( and every match resolves to one of these two helpers.
+func (m *ACLService) withEntry(name string, fn func(*configEntry) error) error {
+	entry := m.entry(name)
+	entry.updateMu.Lock()
+	defer entry.updateMu.Unlock()
+
+	return fn(entry)
+}
+
+// withEntries dedups and sorts names, fetches or creates the entry for
+// each, locks their updateMu in sorted order, then runs fn with the
+// entries keyed by name before unlocking in reverse order and returning
+// fn's error.
+//
+// A consistent lock order across every multi-name caller avoids
+// deadlocks between two calls that share some names but list them in a
+// different order.
+//
+// updateMu is locked and unlocked only here and in withEntry, nowhere else
+// in the package. That is what makes mutation serialization for a name
+// exhaustive: grep the package for updateMu.Lock( and updateMu.Unlock( and
+// every match resolves to one of these two helpers.
+func (m *ACLService) withEntries(names []string, fn func(map[string]*configEntry) error) error {
+	seen := make(map[string]struct{}, len(names))
+	sorted := make([]string, 0, len(names))
+	for _, name := range names {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		sorted = append(sorted, name)
+	}
+	sort.Strings(sorted)
+
+	entries := make(map[string]*configEntry, len(sorted))
+	locked := make([]*configEntry, len(sorted))
+	for idx, name := range sorted {
+		e := m.entry(name)
+		e.updateMu.Lock()
+		locked[idx] = e
+		entries[name] = e
+	}
+	defer func() {
+		for _, e := range slices.Backward(locked) {
+			e.updateMu.Unlock()
+		}
+	}()
+
+	return fn(entries)
 }
 
 // UnaryServerInterceptor returns the service's gRPC metrics interceptor, or nil
@@ -143,14 +313,23 @@ func (m *ACLService) retention() func(metrics.MetricID) bool {
 	}
 }
 
-// publishMetricsSnapshotLocked refreshes metric metadata. Caller must hold m.mu.
+// publishMetricsSnapshotLocked rebuilds metric metadata from configs and
+// publishes it.
+//
+// The caller must already hold m.mu.Lock and must call this before
+// unlocking, in the same critical section that just installed the map state
+// being snapshotted. That ordering is what keeps snapshot publishes totally
+// ordered with map mutations: a publish computed from an older map state can
+// never run after, and so can never overwrite, a publish computed from a
+// newer one. Calling it while holding only m.mu.RLock is a bug, since two
+// readers could then publish concurrently and race each other.
 func (m *ACLService) publishMetricsSnapshotLocked() {
 	configInfos := make(map[string]cacl.AclConfigInfo, len(m.configs))
-	for name, cfg := range m.configs {
-		if cfg.acl == nil {
+	for name, entry := range m.configs {
+		if entry.published == nil || entry.published.acl == nil {
 			continue
 		}
-		configInfos[name] = *cfg.acl.GetInfo()
+		configInfos[name] = *entry.published.acl.GetInfo()
 	}
 
 	m.metricsState.publish(configInfos)
@@ -262,74 +441,89 @@ func (m *ACLService) UpdateConfig(
 		return nil, status.Error(codes.InvalidArgument, "at least one rule is required, an empty ruleset would drop all traffic")
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	var resp *aclpb.UpdateConfigResponse
+	err := m.withEntry(name, func(entry *configEntry) error {
+		oldConfig := entry.published
 
-	if existing, ok := m.configs[name]; ok && rulesEqual(existing.rules, req.Rules) {
-		return &aclpb.UpdateConfigResponse{}, nil
-	}
+		if oldConfig != nil && rulesEqual(oldConfig.rules, req.Rules) {
+			resp = &aclpb.UpdateConfigResponse{}
+			return nil
+		}
 
-	rules, err := convertRules(req.Rules)
+		rules, err := convertRules(req.Rules)
+		if err != nil {
+			return err
+		}
+
+		handle, err := m.backend.NewModule(name)
+		if err != nil {
+			return status.Errorf(codes.Internal, "failed to create module config: %v", err)
+		}
+
+		if err := handle.UpdateRules(rules); err != nil {
+			handle.Free()
+			return status.Errorf(codes.Internal, "failed to update module config: %v", err)
+		}
+
+		fwstateName := ""
+		if oldConfig != nil {
+			fwstateName = oldConfig.fwstateName
+		}
+
+		if fwstateName != "" {
+			handle.TransferFwStateConfig(oldConfig.acl.AsFFIModule())
+			m.log.Info("transferred fwstate config for ACL module", zap.String("config", name))
+		}
+
+		if err := m.backend.UpdateModule(handle); err != nil {
+			handle.Free()
+			return status.Errorf(codes.Internal, "failed to update module: %v", err)
+		}
+
+		m.mu.Lock()
+		entry.published = &aclConfig{
+			rules:       req.Rules,
+			acl:         handle,
+			fwstateName: fwstateName,
+		}
+		m.publishMetricsSnapshotLocked()
+		m.mu.Unlock()
+
+		if oldConfig != nil && oldConfig.acl != nil {
+			oldConfig.acl.Free()
+		}
+
+		resp = &aclpb.UpdateConfigResponse{}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	handle, err := m.backend.NewModule(name)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to create module config: %v", err)
-	}
-
-	if err := handle.UpdateRules(rules); err != nil {
-		handle.Free()
-		return nil, status.Errorf(codes.Internal, "failed to update module config: %v", err)
-	}
-
-	oldConfigs, ok := m.configs[name]
-	if ok && oldConfigs.fwstateName != "" {
-		handle.TransferFwStateConfig(oldConfigs.acl.AsFFIModule())
-		m.log.Info("transferred fwstate config for ACL module", zap.String("config", name))
-	}
-
-	if err := m.backend.UpdateModule(handle); err != nil {
-		handle.Free()
-		return nil, status.Errorf(codes.Internal, "failed to update module: %v", err)
-	}
-
-	if oldConfigs.acl != nil {
-		oldConfigs.acl.Free()
-	}
-
-	m.configs[name] = aclConfig{
-		rules:       req.Rules,
-		acl:         handle,
-		fwstateName: oldConfigs.fwstateName,
-	}
-	m.publishMetricsSnapshotLocked()
-
-	return &aclpb.UpdateConfigResponse{}, nil
+	return resp, nil
 }
 
 func (m *ACLService) ShowConfig(
 	ctx context.Context,
 	req *aclpb.ShowConfigRequest,
 ) (*aclpb.ShowConfigResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	name := req.GetName()
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	config, ok := m.configs[name]
-	if !ok {
+	entry, ok := m.configs[name]
+	if !ok || entry.published == nil {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	response := &aclpb.ShowConfigResponse{
 		Name:        name,
-		Rules:       config.rules,
-		FwstateName: config.fwstateName,
+		Rules:       entry.published.rules,
+		FwstateName: entry.published.fwstateName,
 	}
 
 	return response, nil
@@ -339,14 +533,17 @@ func (m *ACLService) ListConfigs(
 	ctx context.Context,
 	req *aclpb.ListConfigsRequest,
 ) (*aclpb.ListConfigsResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 
 	response := &aclpb.ListConfigsResponse{
 		Configs: make([]string, 0, len(m.configs)),
 	}
 
-	for name := range m.configs {
+	for name, entry := range m.configs {
+		if entry.published == nil {
+			continue
+		}
 		response.Configs = append(response.Configs, name)
 	}
 
@@ -357,31 +554,52 @@ func (m *ACLService) DeleteConfig(
 	ctx context.Context,
 	req *aclpb.DeleteConfigRequest,
 ) (*aclpb.DeleteConfigResponse, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	name := req.GetName()
 	if name == "" {
 		return nil, status.Error(codes.InvalidArgument, "module config name is required")
 	}
 
-	config, ok := m.configs[name]
-	if !ok {
+	// A read-only pre-check rejects a name with no entry at all before
+	// withEntry would create one for it. A name whose entry already exists,
+	// live or tombstoned or still being created by an in-flight
+	// UpdateConfig, falls through to the locked path below, whose
+	// authoritative re-check of published under the name's own lock decides
+	// the outcome once any in-flight compile for the name has finished.
+	// Skipping this pre-check entirely would still be correct, since that
+	// locked re-check catches every case on its own. But skipping it would
+	// also intern an entry for a name that never existed, and never remove
+	// it.
+	if !m.hasEntry(name) {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
-	if config.acl != nil {
-		if err := m.backend.DeleteModule(name); err != nil {
-			return nil, status.Errorf(codes.Internal, "could not delete acl module config '%s': %v", name, err)
+	err := m.withEntry(name, func(entry *configEntry) error {
+		config := entry.published
+		if config == nil {
+			return status.Errorf(codes.NotFound, "config %q not found", name)
 		}
-		m.log.Info("successfully deleted ACL module config", zap.String("name", name))
-		config.acl.Free()
+
+		if config.acl != nil {
+			if err := m.backend.DeleteModule(name); err != nil {
+				return status.Errorf(codes.Internal, "could not delete acl module config '%s': %v", name, err)
+			}
+			m.log.Info("successfully deleted ACL module config", zap.String("name", name))
+		}
+
+		m.mu.Lock()
+		entry.published = nil
+		m.publishMetricsSnapshotLocked()
+		m.mu.Unlock()
+
+		if config.acl != nil {
+			config.acl.Free()
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	delete(m.configs, name)
-	m.publishMetricsSnapshotLocked()
-
-	response := &aclpb.DeleteConfigResponse{}
-
-	return response, nil
+	return &aclpb.DeleteConfigResponse{}, nil
 }

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -18,16 +18,35 @@ import (
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
 	"github.com/yanet-platform/yanet2/modules/acl/controlplane/aclpb/v1"
+	"github.com/yanet-platform/yanet2/modules/fwstate/bindings/go/cfwstate"
+	fwstate "github.com/yanet-platform/yanet2/modules/fwstate/controlplane"
 )
 
 const metricsConcurrencyTestTimeout = 5 * time.Second
+
+// concurrencyWaitTimeout bounds the wait for a channel signal in a
+// concurrency test. Reaching it means the operation under test stalled
+// where it must not, so the test fails instead of hanging forever.
+const concurrencyWaitTimeout = 5 * time.Second
+
+// waitOnChan waits for ch to fire, failing the test if concurrencyWaitTimeout
+// elapses first.
+func waitOnChan(t *testing.T, ch <-chan struct{}, msg string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal(msg)
+	}
+}
 
 // fakeHandle is an in-memory implementation of ModuleHandle for tests.
 type fakeHandle struct {
 	mu          sync.Mutex
 	name        string
 	rules       []cacl.AclRule
-	freed       bool
+	freeCount   int
 	transferred bool
 }
 
@@ -35,7 +54,16 @@ func (m *fakeHandle) Free() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.freed = true
+	m.freeCount++
+}
+
+// FreeCount returns how many times Free has been called, so a test can
+// assert a handle was freed exactly once and never left dangling.
+func (m *fakeHandle) FreeCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.freeCount
 }
 
 func (m *fakeHandle) AsFFIModule() ffi.ModuleConfig {
@@ -70,6 +98,7 @@ func (m *fakeHandle) GetInfo() *cacl.AclConfigInfo {
 type fakeBackend struct {
 	mu           sync.Mutex
 	modules      map[string]*fakeHandle
+	created      []*fakeHandle
 	publishCalls int
 	newModuleErr error
 	deleteErr    error
@@ -140,7 +169,17 @@ func (m *fakeBackend) NewModule(name string) (ModuleHandle, error) {
 
 	h := &fakeHandle{name: name}
 	m.modules[name] = h
+	m.created = append(m.created, h)
 	return h, nil
+}
+
+// CreatedHandles returns every handle NewModule has ever produced, in
+// creation order, so a test can audit that each was freed exactly once.
+func (m *fakeBackend) CreatedHandles() []*fakeHandle {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]*fakeHandle(nil), m.created...)
 }
 
 func (m *fakeBackend) UpdateModule(_ ModuleHandle) error {
@@ -185,6 +224,100 @@ func (m *fakeBackend) SetNewModuleErr(err error) {
 	defer m.mu.Unlock()
 
 	m.newModuleErr = err
+}
+
+// compileBlock synchronizes one blocked compile with the test: entered
+// signals that UpdateRules has started, release lets it return.
+type compileBlock struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+// compileBlockingBackend wraps fakeBackend so a test can arm a specific
+// config name's next UpdateRules call to block until released, proving
+// overlap or ordering between compiles via channel synchronization instead
+// of timing. Every UpdateRules call, blocked or not, is recorded in
+// entryOrder for tests that only need to assert relative ordering.
+type compileBlockingBackend struct {
+	*fakeBackend
+
+	mu      sync.Mutex
+	entries []string
+	blocks  map[string]*compileBlock
+}
+
+func newCompileBlockingBackend(memoryBytes uint64) *compileBlockingBackend {
+	return &compileBlockingBackend{
+		fakeBackend: newFakeBackend(memoryBytes),
+		blocks:      map[string]*compileBlock{},
+	}
+}
+
+// blockCompile arms the next UpdateRules call for name to block until the
+// returned release function is called. The returned channel closes once
+// that call has entered UpdateRules.
+func (m *compileBlockingBackend) blockCompile(name string) (<-chan struct{}, func()) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	block := &compileBlock{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m.blocks[name] = block
+
+	return block.entered, sync.OnceFunc(func() {
+		close(block.release)
+	})
+}
+
+// recordEntry logs that UpdateRules for name has started and returns and
+// consumes any block armed for name.
+func (m *compileBlockingBackend) recordEntry(name string) *compileBlock {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.entries = append(m.entries, name)
+	block := m.blocks[name]
+	delete(m.blocks, name)
+
+	return block
+}
+
+// entryOrder returns the config names in the order their UpdateRules calls
+// started.
+func (m *compileBlockingBackend) entryOrder() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return append([]string(nil), m.entries...)
+}
+
+func (m *compileBlockingBackend) NewModule(name string) (ModuleHandle, error) {
+	handle, err := m.fakeBackend.NewModule(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &compileBlockingHandle{ModuleHandle: handle, backend: m, name: name}, nil
+}
+
+// compileBlockingHandle records and optionally blocks its UpdateRules call
+// before delegating to the wrapped fakeHandle.
+type compileBlockingHandle struct {
+	ModuleHandle
+	backend *compileBlockingBackend
+	name    string
+}
+
+func (m *compileBlockingHandle) UpdateRules(rules []cacl.AclRule) error {
+	block := m.backend.recordEntry(m.name)
+	if block != nil {
+		close(block.entered)
+		<-block.release
+	}
+
+	return m.ModuleHandle.UpdateRules(rules)
 }
 
 func newTestService(b Backend) *ACLService {
@@ -370,12 +503,169 @@ func TestUpdateConfig_RejectsNonContiguousMask(t *testing.T) {
 }
 
 // TestDeleteConfig_UnknownConfig verifies that DeleteConfig reports
-// codes.NotFound for a config name that was never applied.
+// codes.NotFound for a config name that was never applied, and that the
+// rejected name is not interned into svc.configs: a client that misspells a
+// delete repeatedly must not grow the map.
 func TestDeleteConfig_UnknownConfig(t *testing.T) {
 	svc := newTestService(newFakeBackend(0))
 
 	_, err := svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{Name: "missing"})
 	require.Equal(t, codes.NotFound, status.Code(err))
+
+	svc.mu.RLock()
+	_, ok := svc.configs["missing"]
+	svc.mu.RUnlock()
+	assert.False(t, ok, "an unknown delete target must not create an entry")
+}
+
+// TestDeleteConfig_LiveNameTombstones verifies that deleting a name with a
+// live published config still succeeds and leaves the entry in svc.configs
+// with published set to nil, rather than removing the entry outright. That
+// tombstone is what lets a later UpdateConfig of the same name reuse the
+// entry instead of racing a fresh one into existence. It also verifies that
+// a second delete of the now-tombstoned name reports codes.NotFound: the
+// existence-only fast-path pre-check lets the tombstoned name through since
+// its entry is still present, and the locked path's own check of published
+// is what actually rejects it.
+func TestDeleteConfig_LiveNameTombstones(t *testing.T) {
+	svc := newTestService(newFakeBackend(0))
+
+	name := "acl0"
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:  name,
+		Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{Name: name})
+	require.NoError(t, err)
+
+	svc.mu.RLock()
+	entry, ok := svc.configs[name]
+	svc.mu.RUnlock()
+	require.True(t, ok, "the entry for a deleted live name must be retained as a tombstone")
+	assert.Nil(t, entry.published, "a tombstoned entry must have published set to nil")
+
+	_, err = svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{Name: name})
+	require.Equal(t, codes.NotFound, status.Code(err), "deleting an already-tombstoned name must report NotFound")
+}
+
+// TestDeleteConfig_WaitsBehindInFlightCreate verifies that a DeleteConfig
+// racing an UpdateConfig that is creating a brand-new name waits behind the
+// name's lock instead of returning NotFound while the create's compile is
+// still in flight. In that window the entry already exists but published is
+// still nil, so a pre-check keyed on liveness rather than existence would
+// return NotFound immediately instead of serializing behind the create and
+// then acting on its result. This test forces exactly that window with
+// compileBlockingBackend and asserts the delete only resolves after the
+// create publishes, then removes the config the create just published.
+func TestDeleteConfig_WaitsBehindInFlightCreate(t *testing.T) {
+	backend := newCompileBlockingBackend(0)
+	svc := newTestService(backend)
+
+	name := "new-config"
+	rules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}}
+
+	entered, release := backend.blockCompile(name)
+	t.Cleanup(release)
+
+	updateDone := make(chan error, 1)
+	go func() {
+		_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: name, Rules: rules})
+		updateDone <- err
+	}()
+
+	waitOnChan(t, entered, "create did not reach UpdateRules")
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		_, err := svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{Name: name})
+		deleteDone <- err
+	}()
+
+	// deleteDone firing here would mean DeleteConfig resolved without
+	// waiting for the create's compile to release the name's lock, which is
+	// only possible through the liveness-keyed pre-check this test guards
+	// against.
+	select {
+	case err := <-deleteDone:
+		t.Fatalf("DeleteConfig returned (err=%v) before the racing create released its compile", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	release()
+
+	select {
+	case err := <-updateDone:
+		require.NoError(t, err)
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("UpdateConfig did not finish after release")
+	}
+
+	select {
+	case err := <-deleteDone:
+		require.NoError(t, err, "the delete must succeed once it can see the create's published config")
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("DeleteConfig did not finish after the racing create released its compile")
+	}
+
+	svc.mu.RLock()
+	entry, ok := svc.configs[name]
+	svc.mu.RUnlock()
+	require.True(t, ok, "the entry created by the racing update must survive the delete as a tombstone")
+	assert.Nil(t, entry.published, "the delete must have tombstoned the config the racing create just published")
+
+	assert.Equal(t, 1, backend.PublishCalls(), "the create must have published its module before the delete could act on it")
+
+	created := backend.CreatedHandles()
+	require.Len(t, created, 1, "the racing create must have produced exactly one handle")
+	assert.Equal(t, 1, created[0].FreeCount(), "the delete must free the just-published handle exactly once")
+}
+
+// TestUpdateConfig_ResurrectsThroughTombstone verifies that Update, Delete,
+// then Update of the same name reuses the entry DeleteConfig tombstoned
+// instead of racing a fresh one into existence: Show returns the
+// resurrected rules, List reports the name exactly once, and every handle
+// the fakeBackend produced along the way is freed exactly once, except the
+// one still live at the end.
+func TestUpdateConfig_ResurrectsThroughTombstone(t *testing.T) {
+	backend := newFakeBackend(0)
+	svc := newTestService(backend)
+
+	name := "acl0"
+	firstRules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}}
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: name, Rules: firstRules})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{Name: name})
+	require.NoError(t, err)
+
+	_, err = svc.ShowConfig(t.Context(), &aclpb.ShowConfigRequest{Name: name})
+	require.Equal(t, codes.NotFound, status.Code(err), "a deleted name must read back as not found")
+
+	newRules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_DENY}}}}
+	_, err = svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: name, Rules: newRules})
+	require.NoError(t, err)
+
+	resp, err := svc.ShowConfig(t.Context(), &aclpb.ShowConfigRequest{Name: name})
+	require.NoError(t, err)
+	assert.True(t, rulesEqual(newRules, resp.Rules), "Show must return the resurrected config's rules")
+
+	listResp, err := svc.ListConfigs(t.Context(), &aclpb.ListConfigsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, []string{name}, listResp.Configs, "List must report the resurrected name exactly once")
+
+	svc.mu.RLock()
+	liveHandle := svc.configs[name].published.acl
+	svc.mu.RUnlock()
+
+	for _, h := range backend.CreatedHandles() {
+		if h == liveHandle {
+			assert.Equal(t, 0, h.FreeCount(), "the live handle must not have been freed")
+			continue
+		}
+		assert.Equal(t, 1, h.FreeCount(), "every superseded or deleted handle must be freed exactly once")
+	}
 }
 
 // TestUpdateConfig_ConcurrentRace exercises UpdateConfig and ShowConfig under
@@ -498,4 +788,404 @@ func TestMetricsSnapshotTracksConfigLifecycle(t *testing.T) {
 	afterDelete := svc.metricsState.load()
 	assert.False(t, afterDelete.containsConfig("acl0"))
 	assert.True(t, beforeDelete.containsConfig("acl0"), "published snapshots must remain immutable")
+}
+
+// TestMetricsSnapshotOrderingSurvivesConcurrentBarrage verifies that once a
+// concurrent barrage of UpdateConfig and DeleteConfig calls across several
+// config names has fully joined, the metrics snapshot's config-name set
+// equals the configs map's key set exactly. Because publishMetricsSnapshotLocked
+// only ever runs inside the same mu.Lock section that installs the map
+// mutation it reflects, every publish is totally ordered with the mutations:
+// the snapshot published by the last critical section to run is necessarily
+// the last one published, so it must match the final map state. Before that
+// fix, a snapshot computed from an earlier map state (for example a delete
+// of one name) could publish after a snapshot computed from a later state
+// (an update of a different name), overwriting the newer one and leaving
+// the equality checked here false — the exact interleaving this test guards
+// against, without pinning any particular schedule.
+func TestMetricsSnapshotOrderingSurvivesConcurrentBarrage(t *testing.T) {
+	backend := newFakeBackend(0)
+	svc := newTestService(backend)
+
+	names := []string{"a", "b", "c", "d"}
+	rules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}}
+
+	var wg errgroup.Group
+	for round := range 60 {
+		name := names[round%len(names)]
+		wg.Go(func() error {
+			if round%3 == 0 {
+				_, _ = svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{Name: name})
+			} else {
+				_, _ = svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: name, Rules: rules})
+			}
+			return nil
+		})
+	}
+	require.NoError(t, wg.Wait())
+
+	svc.mu.RLock()
+	wantNames := make(map[string]struct{}, len(svc.configs))
+	for name, entry := range svc.configs {
+		if entry.published == nil {
+			continue
+		}
+		wantNames[name] = struct{}{}
+	}
+	svc.mu.RUnlock()
+
+	snapshot := svc.metricsState.load()
+	gotNames := make(map[string]struct{}, len(snapshot.configInfos))
+	for name := range snapshot.configInfos {
+		gotNames[name] = struct{}{}
+	}
+
+	assert.Equal(t, wantNames, gotNames,
+		"metrics snapshot config set must match the configs map exactly after the barrage settles")
+}
+
+// TestUpdateConfig_CompilesInParallel verifies that UpdateConfig calls for
+// different names compile concurrently: both are proven to be inside
+// UpdateRules at the same time via channel synchronization, not timing.
+func TestUpdateConfig_CompilesInParallel(t *testing.T) {
+	backend := newCompileBlockingBackend(0)
+	svc := newTestService(backend)
+
+	rules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}}
+
+	enteredA, releaseA := backend.blockCompile("a")
+	enteredB, releaseB := backend.blockCompile("b")
+	t.Cleanup(releaseA)
+	t.Cleanup(releaseB)
+
+	doneA := make(chan error, 1)
+	doneB := make(chan error, 1)
+	go func() {
+		_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: "a", Rules: rules})
+		doneA <- err
+	}()
+	go func() {
+		_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: "b", Rules: rules})
+		doneB <- err
+	}()
+
+	// Neither release fires until both signal that they are inside
+	// UpdateRules, so a pass here proves the two compiles overlapped.
+	waitOnChan(t, enteredA, "config \"a\" did not reach UpdateRules")
+	waitOnChan(t, enteredB, "config \"b\" did not reach UpdateRules")
+
+	releaseA()
+	releaseB()
+
+	select {
+	case err := <-doneA:
+		require.NoError(t, err)
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("UpdateConfig for \"a\" did not finish after release")
+	}
+	select {
+	case err := <-doneB:
+		require.NoError(t, err)
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("UpdateConfig for \"b\" did not finish after release")
+	}
+}
+
+// TestShowAndListConfigs_DoNotWaitForCompile verifies that ShowConfig
+// returns the old published state, and ListConfigs completes, while another
+// UpdateConfig call is parked inside a compile. Under a single global mutex
+// both would hang until the compile released it.
+func TestShowAndListConfigs_DoNotWaitForCompile(t *testing.T) {
+	backend := newCompileBlockingBackend(0)
+	svc := newTestService(backend)
+
+	initialRules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}}
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: "a", Rules: initialRules})
+	require.NoError(t, err)
+
+	newRules := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_DENY}}}}
+	entered, release := backend.blockCompile("a")
+	t.Cleanup(release)
+
+	updateDone := make(chan error, 1)
+	go func() {
+		_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: "a", Rules: newRules})
+		updateDone <- err
+	}()
+
+	waitOnChan(t, entered, "update did not reach UpdateRules")
+
+	type showResult struct {
+		resp *aclpb.ShowConfigResponse
+		err  error
+	}
+	showDone := make(chan showResult, 1)
+	go func() {
+		resp, err := svc.ShowConfig(t.Context(), &aclpb.ShowConfigRequest{Name: "a"})
+		showDone <- showResult{resp, err}
+	}()
+
+	select {
+	case result := <-showDone:
+		require.NoError(t, result.err)
+		assert.True(t, rulesEqual(initialRules, result.resp.Rules),
+			"ShowConfig must return the old published state while a compile is in flight")
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("ShowConfig waited for the in-flight compile")
+	}
+
+	listDone := make(chan error, 1)
+	go func() {
+		_, err := svc.ListConfigs(t.Context(), &aclpb.ListConfigsRequest{})
+		listDone <- err
+	}()
+
+	select {
+	case err := <-listDone:
+		require.NoError(t, err)
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("ListConfigs waited for the in-flight compile")
+	}
+
+	release()
+
+	select {
+	case err := <-updateDone:
+		require.NoError(t, err)
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("UpdateConfig did not finish after release")
+	}
+}
+
+// TestUpdateConfig_SameNameSerializes verifies that two UpdateConfig calls
+// for the same name serialize: the second cannot reach UpdateRules until the
+// first has released the per-name lock, which is proven by lock acquisition
+// order rather than a sleep-based race check.
+func TestUpdateConfig_SameNameSerializes(t *testing.T) {
+	backend := newCompileBlockingBackend(0)
+	svc := newTestService(backend)
+
+	rulesA := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}}
+	rulesB := []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_DENY}}}}
+
+	enteredFirst, releaseFirst := backend.blockCompile("a")
+
+	doneFirst := make(chan error, 1)
+	go func() {
+		_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: "a", Rules: rulesA})
+		doneFirst <- err
+	}()
+
+	waitOnChan(t, enteredFirst, "first update did not reach UpdateRules")
+
+	// Arm a second block before starting the second call: since the first
+	// block was already consumed, this block will only fire once the second
+	// call reaches UpdateRules on its own turn.
+	enteredSecond, releaseSecond := backend.blockCompile("a")
+	t.Cleanup(releaseSecond)
+
+	doneSecond := make(chan error, 1)
+	go func() {
+		_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{Name: "a", Rules: rulesB})
+		doneSecond <- err
+	}()
+
+	releaseFirst()
+
+	select {
+	case err := <-doneFirst:
+		require.NoError(t, err)
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("first UpdateConfig did not finish after release")
+	}
+
+	// The second call can only reach UpdateRules by acquiring the per-name
+	// lock, which the first call releases only when it returns above — so
+	// this signal firing at all proves the ordering, not merely its timing.
+	waitOnChan(t, enteredSecond, "second update did not reach UpdateRules after the first finished")
+
+	releaseSecond()
+
+	select {
+	case err := <-doneSecond:
+		require.NoError(t, err)
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("second UpdateConfig did not finish after release")
+	}
+
+	assert.Equal(t, []string{"a", "a"}, backend.entryOrder())
+
+	resp, err := svc.ShowConfig(t.Context(), &aclpb.ShowConfigRequest{Name: "a"})
+	require.NoError(t, err)
+	assert.True(t, rulesEqual(rulesB, resp.Rules))
+}
+
+// TestUpdateAndDeleteConfig_NoDoubleFree verifies that concurrent
+// UpdateConfig and DeleteConfig calls racing on the same name never free a
+// handle twice and never leave a handle still referenced from configs freed.
+func TestUpdateAndDeleteConfig_NoDoubleFree(t *testing.T) {
+	backend := newFakeBackend(0)
+	svc := newTestService(backend)
+
+	name := "a"
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:  name,
+		Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}},
+	})
+	require.NoError(t, err)
+
+	var wg errgroup.Group
+	for idx := range 20 {
+		wg.Go(func() error {
+			if idx%2 == 0 {
+				_, _ = svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+					Name:  name,
+					Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_DENY}}}},
+				})
+			} else {
+				_, _ = svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{Name: name})
+			}
+			return nil
+		})
+	}
+	require.NoError(t, wg.Wait())
+
+	svc.mu.RLock()
+	entry := svc.configs[name]
+	svc.mu.RUnlock()
+
+	hasLive := entry.published != nil
+	var liveHandle ModuleHandle
+	if hasLive {
+		liveHandle = entry.published.acl
+	}
+
+	for _, h := range backend.CreatedHandles() {
+		if hasLive && h == liveHandle {
+			assert.Equal(t, 0, h.FreeCount(), "the live handle must not have been freed")
+			continue
+		}
+		assert.Equal(t, 1, h.FreeCount(), "every replaced or deleted handle must be freed exactly once")
+	}
+}
+
+// TestRelinkConfigs_ConcurrentWithUpdateOfSharedName verifies that
+// ACLAdapter.RelinkConfigs racing an UpdateConfig call on one of its linked
+// names completes without deadlock and leaves both configs present with a
+// handle from one of the two racing operations, never a freed-but-still-
+// referenced handle.
+func TestRelinkConfigs_ConcurrentWithUpdateOfSharedName(t *testing.T) {
+	backend := newFakeBackend(0)
+	svc := newTestService(backend)
+	adapter := NewACLAdapter(svc)
+
+	fwstateConfig := &fwstate.FwStateConfig{ModuleConfig: &cfwstate.ModuleConfig{}}
+	publish := func(_ []ffi.ModuleConfig) error { return nil }
+
+	for _, name := range []string{"a", "b"} {
+		_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+			Name:  name,
+			Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}},
+		})
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, adapter.LinkConfigs([]string{"a", "b"}, fwstateConfig, publish))
+
+	svc.mu.RLock()
+	handleB0 := svc.configs["b"].published.acl
+	svc.mu.RUnlock()
+
+	var wg errgroup.Group
+	wg.Go(func() error {
+		return adapter.RelinkConfigs(fwstateConfig, publish)
+	})
+	wg.Go(func() error {
+		_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+			Name:  "a",
+			Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_DENY}}}},
+		})
+		return err
+	})
+
+	raceDone := make(chan error, 1)
+	go func() { raceDone <- wg.Wait() }()
+
+	select {
+	case err := <-raceDone:
+		require.NoError(t, err)
+	case <-time.After(concurrencyWaitTimeout):
+		t.Fatal("RelinkConfigs racing an UpdateConfig on a shared name deadlocked")
+	}
+
+	svc.mu.RLock()
+	entryA := svc.configs["a"]
+	entryB := svc.configs["b"]
+	svc.mu.RUnlock()
+
+	require.NotNil(t, entryA.published, "config \"a\" must survive the race")
+	require.NotNil(t, entryB.published, "config \"b\" must survive the race")
+	assert.NotNil(t, entryA.published.acl)
+	assert.True(t, entryB.published.acl != handleB0, "RelinkConfigs must have installed a fresh handle for \"b\"")
+
+	for _, h := range backend.CreatedHandles() {
+		if h == entryA.published.acl || h == entryB.published.acl {
+			assert.Equal(t, 0, h.FreeCount(), "a still-referenced handle must not be freed")
+			continue
+		}
+		assert.Equal(t, 1, h.FreeCount(), "every replaced handle must be freed exactly once")
+	}
+}
+
+// TestACLAdapterLinkConfigs_UnknownName verifies that LinkConfigs with an
+// unknown name in the list fails without interning an entry for it, and
+// without disturbing an already-live name also present in the list.
+func TestACLAdapterLinkConfigs_UnknownName(t *testing.T) {
+	backend := newFakeBackend(0)
+	svc := newTestService(backend)
+	adapter := NewACLAdapter(svc)
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:  "a",
+		Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}},
+	})
+	require.NoError(t, err)
+
+	fwstateConfig := &fwstate.FwStateConfig{ModuleConfig: &cfwstate.ModuleConfig{}}
+	publish := func(_ []ffi.ModuleConfig) error { return nil }
+
+	err = adapter.LinkConfigs([]string{"a", "missing"}, fwstateConfig, publish)
+	require.Error(t, err)
+
+	svc.mu.RLock()
+	_, ok := svc.configs["missing"]
+	svc.mu.RUnlock()
+	assert.False(t, ok, "an unknown name in a LinkConfigs request must not create an entry")
+}
+
+// TestACLAdapterLinkConfigs_TombstonedName verifies that LinkConfigs with a
+// tombstoned name in the list — one whose entry exists but whose published
+// config was deleted — reports a not-found error. checkLinkable's
+// existence-only pre-check lets the tombstoned name through since its entry
+// is still present, and createLinkedHandles' own check of published, under
+// the name's lock, is what actually rejects it.
+func TestACLAdapterLinkConfigs_TombstonedName(t *testing.T) {
+	backend := newFakeBackend(0)
+	svc := newTestService(backend)
+	adapter := NewACLAdapter(svc)
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:  "a",
+		Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}},
+	})
+	require.NoError(t, err)
+
+	_, err = svc.DeleteConfig(t.Context(), &aclpb.DeleteConfigRequest{Name: "a"})
+	require.NoError(t, err)
+
+	fwstateConfig := &fwstate.FwStateConfig{ModuleConfig: &cfwstate.ModuleConfig{}}
+	publish := func(_ []ffi.ModuleConfig) error { return nil }
+
+	err = adapter.LinkConfigs([]string{"a"}, fwstateConfig, publish)
+	require.ErrorContains(t, err, "not found")
 }

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -285,7 +285,8 @@ func (m *FWStateService) UpdateConfig(
 	// Rebuild all linked ACL configs against the new fwstate config and publish
 	// both atomically.
 	//
-	// RelinkConfigs holds the ACL lock for the entire window.
+	// RelinkConfigs holds each linked ACL config name's lock for the entire
+	// window, so it never blocks a read or a compile on an unrelated name.
 	if err := m.aclProvider.RelinkConfigs(newConfig, func(linkedFFI []ffi.ModuleConfig) error {
 		return m.agent.UpdateModules(append(linkedFFI, newConfig.AsFFIModule()))
 	}); err != nil {
@@ -347,7 +348,8 @@ func (m *FWStateService) LinkFWState(
 	}
 
 	// Link the given ACL configs to this fwstate and publish both atomically.
-	// LinkConfigs holds the ACL lock for the entire window.
+	// LinkConfigs holds each named ACL config's lock for the entire window,
+	// so it never blocks a read or a compile on an unrelated name.
 	if err := m.aclProvider.LinkConfigs(aclConfigNames, fwstateConfig, func(linkedFFI []ffi.ModuleConfig) error {
 		return m.agent.UpdateModules(append(linkedFFI, fwstateConfig.AsFFIModule()))
 	}); err != nil {
@@ -382,7 +384,8 @@ func (m *FWStateService) ShowConfig(
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
-	// LinkedConfigNames is self-locking.
+	// LinkedConfigNames is self-locking: a brief RLock, never blocked behind
+	// an in-flight ACL compile.
 	linkedACLs := m.aclProvider.LinkedConfigNames(name)
 
 	response := &fwstatepb.ShowConfigResponse{

--- a/tests/common/balloc_thread_stress_test.c
+++ b/tests/common/balloc_thread_stress_test.c
@@ -1,0 +1,296 @@
+// Threaded stress test for the block_allocator spinlock and the
+// memory_context tree splice locking added alongside it.
+//
+// Several pthreads hammer one shared block_allocator with balloc/bfree churn
+// spanning multiple pool sizes (forcing the borrow/split path), while also
+// churning memory_context_init_from/memory_context_fini of child contexts
+// against one shared parent context, and periodically calling
+// block_allocator_free_size as a locked reader racing that churn. This is
+// only safe concurrently because block_allocator_balloc/bfree/free_size and
+// the context tree splices all take the allocator's own spinlock.
+// block_allocator_put_arena is exercised only single-threaded, before the
+// threads start.
+
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+#include "lib/logging/log.h"
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define ARENA_ALIGN                                                            \
+	(1u << 21) // 2 MiB, a MEMORY_BLOCK_ALLOCATOR_MAX_ALIGN chunk.
+#define RAW_ALLOC_SZ ((size_t)(1u << 22))
+
+#define THREAD_COUNT 8
+#define ITERATIONS_PER_THREAD 20000
+#define SLOTS_PER_THREAD 16
+#define CHILD_CHURN_PERIOD 23
+#define FREE_SIZE_CHURN_PERIOD 17
+
+// Request sizes spanning several pools, so a borrow/split chain is exercised
+// on nearly every allocation.
+static const size_t kSizes[] = {8, 24, 40, 96, 200, 480, 1000, 2040};
+#define NUM_SIZES (sizeof(kSizes) / sizeof(kSizes[0]))
+
+static struct memory_context g_root;
+static atomic_int g_failures = 0;
+
+// Records a worker-thread invariant violation without unwinding the thread:
+// TEST_ASSERT returning TEST_FAILED does not fit a pthread start routine.
+#define THREAD_CHECK(cond, msg, ...)                                           \
+	do {                                                                   \
+		if (!(cond)) {                                                 \
+			LOG(ERROR, "THREAD ASSERT FAILED: " msg, ##__VA_ARGS__ \
+			);                                                     \
+			atomic_fetch_add(&g_failures, 1);                      \
+		}                                                              \
+	} while (0)
+
+struct thread_args {
+	unsigned seed;
+	struct block_allocator *ba;
+};
+
+// Drives balloc/bfree churn against the shared root context through a small
+// fixed set of slots, interleaved with memory_context_init_from/fini churn
+// of transient child contexts on the same root.
+static void *
+stress_worker(void *arg) {
+	struct thread_args *args = (struct thread_args *)arg;
+	unsigned seed = args->seed;
+	struct block_allocator *ba = args->ba;
+
+	void *slots[SLOTS_PER_THREAD];
+	size_t slot_sizes[SLOTS_PER_THREAD];
+	memset(slots, 0, sizeof(slots));
+	memset(slot_sizes, 0, sizeof(slot_sizes));
+
+	for (int iter = 0; iter < ITERATIONS_PER_THREAD; ++iter) {
+		int idx = (int)(rand_r(&seed) % SLOTS_PER_THREAD);
+		if (slots[idx] != NULL) {
+			memory_bfree(&g_root, slots[idx], slot_sizes[idx]);
+			slots[idx] = NULL;
+		} else {
+			size_t size = kSizes[rand_r(&seed) % NUM_SIZES];
+			void *ptr = memory_balloc(&g_root, size);
+			if (ptr != NULL) {
+				slots[idx] = ptr;
+				slot_sizes[idx] = size;
+			}
+		}
+
+		if (iter % CHILD_CHURN_PERIOD == 0) {
+			struct memory_context child;
+			THREAD_CHECK(
+				memory_context_init_from(
+					&child, &g_root, "stress-child"
+				) == 0,
+				"memory_context_init_from failed"
+			);
+
+			void *cp = memory_balloc(&child, 32);
+			if (cp != NULL) {
+				memory_bfree(&child, cp, 32);
+			}
+
+			THREAD_CHECK(
+				child.balloc_count == child.bfree_count,
+				"child balloc_count/bfree_count mismatch: "
+				"%zu != %zu",
+				child.balloc_count,
+				child.bfree_count
+			);
+			THREAD_CHECK(
+				child.balloc_size == child.bfree_size,
+				"child balloc_size/bfree_size mismatch: %zu "
+				"!= %zu",
+				child.balloc_size,
+				child.bfree_size
+			);
+
+			memory_context_fini(&child);
+		}
+
+		if (iter % FREE_SIZE_CHURN_PERIOD == 0) {
+			// A locked reader racing balloc/bfree on the same
+			// allocator. Only the lock itself is under test, since
+			// the exact value is transient under concurrent churn.
+			size_t free_size = block_allocator_free_size(ba);
+			THREAD_CHECK(
+				free_size <= ARENA_ALIGN,
+				"free_size %zu exceeds arena size %u",
+				free_size,
+				ARENA_ALIGN
+			);
+		}
+	}
+
+	for (int idx = 0; idx < SLOTS_PER_THREAD; ++idx) {
+		if (slots[idx] != NULL) {
+			memory_bfree(&g_root, slots[idx], slot_sizes[idx]);
+			slots[idx] = NULL;
+		}
+	}
+
+	return NULL;
+}
+
+static int
+cmp_ptr(const void *a, const void *b) {
+	void *const *pa = (void *const *)a;
+	void *const *pb = (void *const *)b;
+	if (*pa < *pb) {
+		return -1;
+	}
+	if (*pa > *pb) {
+		return 1;
+	}
+	return 0;
+}
+
+// Verifies that concurrent balloc/bfree churn and memory_context
+// init_from/fini churn against one shared block_allocator and parent context
+// never corrupt the free lists or the context tree: the allocator returns to
+// its baseline free size, the parent ends up with no children, per-context
+// counters balance, and an exhaustive alloc-until-NULL sweep recovers every
+// byte exactly once.
+static int
+test_concurrent_balloc_and_context_churn(void) {
+	struct block_allocator ba;
+	TEST_ASSERT(
+		block_allocator_init(&ba) == 0, "block_allocator_init failed"
+	);
+
+	void *raw = malloc(RAW_ALLOC_SZ + ARENA_ALIGN);
+	TEST_ASSERT(raw != NULL, "failed to allocate raw arena buffer");
+	uintptr_t aligned = ((uintptr_t)raw + ARENA_ALIGN - 1) &
+			    ~(uintptr_t)(ARENA_ALIGN - 1);
+	void *arena = (void *)aligned;
+	size_t arena_size = ARENA_ALIGN;
+
+	block_allocator_put_arena(&ba, arena, arena_size);
+
+	TEST_ASSERT(
+		memory_context_init(&g_root, "stress-root", &ba) == 0,
+		"root context init failed"
+	);
+
+	size_t baseline_free = block_allocator_free_size(&ba);
+	TEST_ASSERT(
+		baseline_free > 0, "arena ingestion produced no free bytes"
+	);
+
+	pthread_t threads[THREAD_COUNT];
+	struct thread_args args[THREAD_COUNT];
+	for (int idx = 0; idx < THREAD_COUNT; ++idx) {
+		args[idx].seed = (unsigned)(0xc0ffeeu + (unsigned)idx * 7919u);
+		args[idx].ba = &ba;
+		TEST_ASSERT(
+			pthread_create(
+				&threads[idx], NULL, stress_worker, &args[idx]
+			) == 0,
+			"pthread_create failed for thread %d",
+			idx
+		);
+	}
+	for (int idx = 0; idx < THREAD_COUNT; ++idx) {
+		pthread_join(threads[idx], NULL);
+	}
+
+	TEST_ASSERT(
+		atomic_load(&g_failures) == 0,
+		"one or more worker threads observed a broken invariant"
+	);
+
+	TEST_ASSERT(
+		g_root.balloc_count == g_root.bfree_count,
+		"root balloc_count/bfree_count mismatch after churn: %zu != "
+		"%zu",
+		g_root.balloc_count,
+		g_root.bfree_count
+	);
+	TEST_ASSERT(
+		g_root.balloc_size == g_root.bfree_size,
+		"root balloc_size/bfree_size mismatch after churn: %zu != %zu",
+		g_root.balloc_size,
+		g_root.bfree_size
+	);
+	TEST_ASSERT(
+		ADDR_OF(&g_root.first_child) == NULL,
+		"root must have no children left after churn"
+	);
+
+	size_t drained_free = block_allocator_free_size(&ba);
+	TEST_ASSERT(
+		drained_free == baseline_free,
+		"allocator free size did not return to baseline: got %zu, "
+		"want %zu",
+		drained_free,
+		baseline_free
+	);
+
+	// Exhaustive sweep: repeatedly take the smallest block until the
+	// allocator is empty. This walks the real free lists (unlike
+	// block_allocator_free_size, which only sums pool counters), so a
+	// free list corrupted by an unlocked race shows up here as a
+	// duplicate pointer, a wrong leftover free size, or a runaway
+	// iteration count.
+	size_t sweep_cap = baseline_free / MEMORY_BLOCK_ALLOCATOR_MIN_SIZE + 16;
+	void **swept = malloc(sweep_cap * sizeof(void *));
+	TEST_ASSERT(
+		swept != NULL, "failed to allocate sweep bookkeeping array"
+	);
+
+	size_t swept_count = 0;
+	for (;;) {
+		void *p =
+			memory_balloc(&g_root, MEMORY_BLOCK_ALLOCATOR_MIN_SIZE);
+		if (p == NULL) {
+			break;
+		}
+		TEST_ASSERT(
+			swept_count < sweep_cap,
+			"sweep exceeded expected iteration cap %zu; free list "
+			"is likely corrupted",
+			sweep_cap
+		);
+		swept[swept_count++] = p;
+	}
+
+	TEST_ASSERT(
+		block_allocator_free_size(&ba) == 0,
+		"allocator still reports free bytes after an exhaustive sweep"
+	);
+
+	qsort(swept, swept_count, sizeof(void *), cmp_ptr);
+	for (size_t idx = 1; idx < swept_count; ++idx) {
+		TEST_ASSERT(
+			swept[idx] != swept[idx - 1],
+			"sweep returned the same block twice: %p",
+			swept[idx]
+		);
+	}
+
+	free(swept);
+	memory_context_fini(&g_root);
+	free(raw);
+	return 0;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	if (test_concurrent_balloc_and_context_churn() != 0) {
+		LOG(ERROR, "test_concurrent_balloc_and_context_churn failed");
+		return -1;
+	}
+
+	LOG(INFO, "balloc thread stress tests: OK");
+	return 0;
+}

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -1,4 +1,5 @@
 dependencies = [lib_common_dep, lib_logging_dep]
+thread_dep = dependency('threads')
 
 lpm_test = executable(
   'lpm_test',
@@ -81,6 +82,15 @@ memory_context_tree_test = executable(
 )
 test('memory_context_tree', memory_context_tree_test, suite: ['common'])
 
+balloc_thread_stress_test = executable(
+  'balloc_thread_stress_test',
+  ['balloc_thread_stress_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies + [thread_dep],
+)
+test('balloc_thread_stress', balloc_thread_stress_test, suite: ['common'])
+
 executable(
   'balloc_bench',
   ['balloc_bench.c'],
@@ -139,8 +149,6 @@ hash_index_test = executable(
   dependencies: dependencies,
 )
 test('hash_index', hash_index_test, suite: ['common'])
-
-thread_dep = dependency('threads')
 
 data_pipe_test = executable(
   'data_pipe_test',


### PR DESCRIPTION
- Serialize shared-memory block-allocator operations with an internal lock so concurrent module-config builds no longer corrupt the free lists.
- Guard the memory-context tree bookkeeping and the unused-agent sweep, which previously relied on control-plane callers being serialized by a global mutex.
- Replace the ACL service's global mutex with per-name locking behind a scoped callback API, so compilations of different configs run in parallel and reads never wait for an in-flight compile.
- Keep metrics-snapshot publication totally ordered with config-map mutations.
- Bump the module ABI version because the allocator layout changed while keeping its size, so a stale plugin refuses to load instead of corrupting shared memory.
- Add a threaded allocator stress test and concurrent ACL service tests.
- A deployment needs rebuilt plugins and a fresh shared-memory segment because of the ABI bump.