### PR TITLE
fix(forward,mirror): make show output a rule file update accepts

### DIFF
--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -1,3 +1,4 @@
+use core::fmt::{self, Display, Formatter};
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -13,7 +14,7 @@ use forwardpb::{
     forward_service_client::ForwardServiceClient,
 };
 use netip::{Contiguous, IpNetwork};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
@@ -90,11 +91,48 @@ impl From<VlanRange> for filterpb::pb::VlanRange {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl From<filterpb::pb::VlanRange> for VlanRange {
+    fn from(r: filterpb::pb::VlanRange) -> Self {
+        Self { from: r.from, to: r.to }
+    }
+}
+
+/// Forwarding direction for a rule's action.
+///
+/// The uppercase spelling is canonical, matching `ForwardMode`'s proto enum
+/// names. The PascalCase spellings are accepted because the schema used them
+/// previously.
+#[derive(Debug, Deserialize)]
 enum ModeKind {
+    #[serde(rename = "NONE", alias = "None")]
     None,
+    #[serde(rename = "IN", alias = "In")]
     In,
+    #[serde(rename = "OUT", alias = "Out")]
     Out,
+    /// An unrecognised proto enum value.
+    ///
+    /// `show` renders the raw number so one rule from a newer module cannot
+    /// hide the rest of a configuration. `update` rejects it.
+    #[serde(skip)]
+    Unknown(i32),
+}
+
+impl Display for ModeKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Self::None => write!(f, "NONE"),
+            Self::In => write!(f, "IN"),
+            Self::Out => write!(f, "OUT"),
+            Self::Unknown(mode) => write!(f, "{mode}"),
+        }
+    }
+}
+
+impl Serialize for ModeKind {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -112,14 +150,17 @@ impl TryFrom<ForwardRule> for forwardpb::Rule {
     type Error = Box<dyn core::error::Error>;
 
     fn try_from(forward_rule: ForwardRule) -> Result<Self, Self::Error> {
+        let mode: i32 = match forward_rule.mode {
+            ModeKind::None => forwardpb::ForwardMode::None.into(),
+            ModeKind::In => forwardpb::ForwardMode::In.into(),
+            ModeKind::Out => forwardpb::ForwardMode::Out.into(),
+            ModeKind::Unknown(mode) => return Err(format!("unknown forward mode {mode}").into()),
+        };
+
         Ok(Self {
             action: Some(forwardpb::Action {
                 target: forward_rule.target,
-                mode: match forward_rule.mode {
-                    ModeKind::None => forwardpb::ForwardMode::None.into(),
-                    ModeKind::In => forwardpb::ForwardMode::In.into(),
-                    ModeKind::Out => forwardpb::ForwardMode::Out.into(),
-                },
+                mode,
                 counter: forward_rule.counter,
             }),
             devices: forward_rule.devices.into_iter().map(|m| m.into()).collect(),
@@ -138,6 +179,39 @@ impl TryFrom<ForwardRule> for forwardpb::Rule {
     }
 }
 
+impl TryFrom<forwardpb::Rule> for ForwardRule {
+    type Error = Box<dyn core::error::Error>;
+
+    fn try_from(rule: forwardpb::Rule) -> Result<Self, Self::Error> {
+        let action = rule.action.ok_or("forward rule is missing its action")?;
+        let mode = match forwardpb::ForwardMode::try_from(action.mode) {
+            Ok(forwardpb::ForwardMode::None) => ModeKind::None,
+            Ok(forwardpb::ForwardMode::In) => ModeKind::In,
+            Ok(forwardpb::ForwardMode::Out) => ModeKind::Out,
+            Err(_) => ModeKind::Unknown(action.mode),
+        };
+
+        Ok(Self {
+            target: action.target,
+            mode,
+            counter: action.counter,
+            devices: rule.devices.into_iter().map(|d| d.name).collect(),
+            vlan_ranges: rule.vlan_ranges.into_iter().map(VlanRange::from).collect(),
+            srcs: rule.srcs.into_iter().map(|n| n.to_string()).collect(),
+            dsts: rule.dsts.into_iter().map(|n| n.to_string()).collect(),
+        })
+    }
+}
+
+/// A forward module configuration as read from or written to a rule file.
+///
+/// Every rule field is always emitted, including an empty sequence as `[]`
+/// and an empty counter as an empty string, and none of them is optional on
+/// `update` either. A network renders from the address and mask actually
+/// stored, so re-applying shown output normalises an address that carries
+/// host bits outside its mask. A stored IPv6 network's mask may have a hole
+/// at the `/64` boundary. Such a network renders in expanded-mask form, and
+/// `update` rejects it because it requires a contiguous mask.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ForwardConfig {
     rules: Vec<ForwardRule>,
@@ -148,6 +222,19 @@ impl TryFrom<ForwardConfig> for Vec<forwardpb::Rule> {
 
     fn try_from(config: ForwardConfig) -> Result<Self, Self::Error> {
         config.rules.into_iter().map(forwardpb::Rule::try_from).collect()
+    }
+}
+
+impl TryFrom<Vec<forwardpb::Rule>> for ForwardConfig {
+    type Error = Box<dyn core::error::Error>;
+
+    fn try_from(rules: Vec<forwardpb::Rule>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            rules: rules
+                .into_iter()
+                .map(ForwardRule::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
     }
 }
 
@@ -192,15 +279,18 @@ impl ForwardService {
             .map_err(self.service.status("show"))?
             .into_inner();
 
+        let config = ForwardConfig::try_from(response.rules)
+            .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("show", e.to_string()))?;
+
         output::data(
-            || &response,
+            || &config,
             || {
                 print!(
                     "{}",
-                    serde_yaml::to_string(&response).expect("forward config YAML serialization must not fail")
+                    serde_yaml::to_string(&config).expect("forward config YAML serialization must not fail")
                 );
 
-                if response.rules.is_empty() {
+                if config.rules.is_empty() {
                     output::empty_with_hint(
                         format_args!("No forward rules found for '{}'.", cmd.config_name),
                         format_args!("create one with 'yanet-cli-forward update --name <name> --rules <path>'"),
@@ -314,4 +404,151 @@ fn config_candidates() -> Vec<CompletionCandidate> {
         },
         async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
     )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn ip_net(cidr: &str) -> filterpb::pb::IpNet {
+        Contiguous::<IpNetwork>::parse(cidr)
+            .expect("valid cidr in test fixture")
+            .into()
+    }
+
+    fn sample_rules() -> Vec<forwardpb::Rule> {
+        vec![
+            forwardpb::Rule {
+                action: Some(forwardpb::Action {
+                    target: "target-none".to_string(),
+                    mode: forwardpb::ForwardMode::None as i32,
+                    counter: "counter-none".to_string(),
+                }),
+                devices: vec![
+                    filterpb::pb::Device { name: "eth0".to_string() },
+                    filterpb::pb::Device { name: "eth1".to_string() },
+                ],
+                vlan_ranges: vec![
+                    filterpb::pb::VlanRange { from: 0, to: 100 },
+                    filterpb::pb::VlanRange { from: 200, to: 300 },
+                ],
+                srcs: vec![ip_net("192.0.2.0/24"), ip_net("2001:db8::/32")],
+                dsts: vec![ip_net("203.0.113.0/24"), ip_net("2001:db8:1::/48")],
+            },
+            forwardpb::Rule {
+                action: Some(forwardpb::Action {
+                    target: "target-in".to_string(),
+                    mode: forwardpb::ForwardMode::In as i32,
+                    counter: String::new(),
+                }),
+                devices: vec![],
+                vlan_ranges: vec![],
+                srcs: vec![],
+                dsts: vec![],
+            },
+            forwardpb::Rule {
+                action: Some(forwardpb::Action {
+                    target: "target-out".to_string(),
+                    mode: forwardpb::ForwardMode::Out as i32,
+                    counter: "counter-out".to_string(),
+                }),
+                devices: vec![filterpb::pb::Device { name: "eth2".to_string() }],
+                vlan_ranges: vec![filterpb::pb::VlanRange { from: 10, to: 20 }],
+                srcs: vec![ip_net("10.0.0.0/8")],
+                dsts: vec![ip_net("10.1.0.0/16")],
+            },
+        ]
+    }
+
+    #[test]
+    fn a_shown_config_round_trips_through_yaml_back_into_the_original_rules() {
+        let rules = sample_rules();
+
+        let config = ForwardConfig::try_from(rules.clone()).expect("pb rules must convert into a forward config");
+        let yaml = serde_yaml::to_string(&config).expect("forward config must serialize");
+        let parsed: ForwardConfig = serde_yaml::from_str(&yaml).expect("forward config must deserialize");
+        let reconstructed: Vec<forwardpb::Rule> = parsed.try_into().expect("forward config must convert back");
+
+        assert_eq!(rules, reconstructed);
+    }
+
+    #[test]
+    fn a_rule_file_accepts_the_full_mode_vocabulary() {
+        let uppercase = r#"
+rules:
+  - target: "t1"
+    mode: "NONE"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+  - target: "t2"
+    mode: "IN"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+  - target: "t3"
+    mode: "OUT"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+"#;
+        let legacy = r#"
+rules:
+  - target: "t1"
+    mode: "None"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+  - target: "t2"
+    mode: "In"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+  - target: "t3"
+    mode: "Out"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+"#;
+
+        for yaml in [uppercase, legacy] {
+            let config: ForwardConfig = serde_yaml::from_str(yaml).expect("mode spellings must parse");
+            assert!(matches!(config.rules[0].mode, ModeKind::None));
+            assert!(matches!(config.rules[1].mode, ModeKind::In));
+            assert!(matches!(config.rules[2].mode, ModeKind::Out));
+        }
+    }
+
+    #[test]
+    fn an_unrecognised_mode_number_is_shown_but_rejected_by_update() {
+        let rule = forwardpb::Rule {
+            action: Some(forwardpb::Action {
+                target: "t".to_string(),
+                mode: 99,
+                counter: String::new(),
+            }),
+            devices: vec![],
+            vlan_ranges: vec![],
+            srcs: vec![],
+            dsts: vec![],
+        };
+
+        let config = ForwardConfig::try_from(vec![rule]).expect("an unrecognised mode must not blank the show");
+        assert!(serde_yaml::to_string(&config).is_ok());
+
+        let rebuilt: Result<Vec<forwardpb::Rule>, _> = config.try_into();
+        assert!(rebuilt.is_err());
+    }
 }

--- a/modules/forward/web/SaveDiffModal.tsx
+++ b/modules/forward/web/SaveDiffModal.tsx
@@ -1,18 +1,12 @@
 import React, { useMemo } from 'react';
 import type { Rule } from '@yanet/core/api/forward';
-import { ForwardMode } from '@yanet/core/api/forward';
+import { ForwardMode, FORWARD_MODE_LABELS } from '@yanet/core/api/forward';
 import { formatIPNetItem, dumpYamlDoc } from '@yanet/core/utils';
 import { SaveDiffModal as SharedSaveDiffModal } from '@yanet/core/components';
 
 /** Serialize a rules array into the canonical YAML schema for diff display. */
 export const rulesToDiffYaml = (rules: Rule[]): string => {
     const yamlRules = rules.map((r) => {
-        const modeMap: Record<number, string> = {
-            [ForwardMode.NONE]: 'None',
-            [ForwardMode.IN]: 'In',
-            [ForwardMode.OUT]: 'Out',
-        };
-
         const devices = (r.devices ?? []).map(d => d.name ?? '').filter(Boolean);
         const srcs = (r.srcs ?? []).map(formatIPNetItem).filter(Boolean);
         const dsts = (r.dsts ?? []).map(formatIPNetItem).filter(Boolean);
@@ -39,7 +33,7 @@ export const rulesToDiffYaml = (rules: Rule[]): string => {
         if (devices.length > 0) {
             entry['devices'] = devices;
         }
-        entry['mode'] = modeMap[r.action?.mode ?? ForwardMode.NONE] ?? 'None';
+        entry['mode'] = FORWARD_MODE_LABELS[r.action?.mode ?? ForwardMode.NONE] ?? 'NONE';
 
         return entry;
     });

--- a/modules/forward/web/YamlIO.tsx
+++ b/modules/forward/web/YamlIO.tsx
@@ -145,7 +145,7 @@ const YamlIO: React.FC<YamlIOProps> = ({ configName, rules, onImport, disabled }
             exportYaml={() => rulesToDiffYaml(rules)}
             onImport={handleImport}
             toastPrefix="yn-yaml"
-            importPlaceholder={'rules:\n  - target: eth0\n    mode: Out\n    srcs:\n      - 10.0.0.0/8'}
+            importPlaceholder={'rules:\n  - target: eth0\n    mode: OUT\n    srcs:\n      - 10.0.0.0/8'}
             exportFooterHint="Exports current draft rules (unsaved changes included)."
             importFooterHint="Importing replaces all rules in the target config locally. Use Save to push to the server."
             importButtonLabel="Import"

--- a/modules/mirror/cli/src/main.rs
+++ b/modules/mirror/cli/src/main.rs
@@ -1,3 +1,4 @@
+use core::fmt::{self, Display, Formatter};
 use std::{
     fs::File,
     path::{Path, PathBuf},
@@ -13,7 +14,7 @@ use mirrorpb::{
     mirror_service_client::MirrorServiceClient,
 };
 use netip::{Contiguous, IpNetwork};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use tonic::codec::CompressionEncoding;
 use ync::{
     client::{ConnectionArgs, LayeredChannel, Service},
@@ -90,11 +91,48 @@ impl From<VlanRange> for filterpb::pb::VlanRange {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+impl From<filterpb::pb::VlanRange> for VlanRange {
+    fn from(r: filterpb::pb::VlanRange) -> Self {
+        Self { from: r.from, to: r.to }
+    }
+}
+
+/// Mirroring direction for a rule's action.
+///
+/// The uppercase spelling is canonical, matching `MirrorMode`'s proto enum
+/// names. The PascalCase spellings are accepted because the schema used them
+/// previously.
+#[derive(Debug, Deserialize)]
 enum ModeKind {
+    #[serde(rename = "NONE", alias = "None")]
     None,
+    #[serde(rename = "IN", alias = "In")]
     In,
+    #[serde(rename = "OUT", alias = "Out")]
     Out,
+    /// An unrecognised proto enum value.
+    ///
+    /// `show` renders the raw number so one rule from a newer module cannot
+    /// hide the rest of a configuration. `update` rejects it.
+    #[serde(skip)]
+    Unknown(i32),
+}
+
+impl Display for ModeKind {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match self {
+            Self::None => write!(f, "NONE"),
+            Self::In => write!(f, "IN"),
+            Self::Out => write!(f, "OUT"),
+            Self::Unknown(mode) => write!(f, "{mode}"),
+        }
+    }
+}
+
+impl Serialize for ModeKind {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_str(self)
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -112,14 +150,17 @@ impl TryFrom<MirrorRule> for mirrorpb::Rule {
     type Error = Box<dyn core::error::Error>;
 
     fn try_from(mirror_rule: MirrorRule) -> Result<Self, Self::Error> {
+        let mode: i32 = match mirror_rule.mode {
+            ModeKind::None => mirrorpb::MirrorMode::None.into(),
+            ModeKind::In => mirrorpb::MirrorMode::In.into(),
+            ModeKind::Out => mirrorpb::MirrorMode::Out.into(),
+            ModeKind::Unknown(mode) => return Err(format!("unknown mirror mode {mode}").into()),
+        };
+
         Ok(Self {
             action: Some(mirrorpb::Action {
                 target: mirror_rule.target,
-                mode: match mirror_rule.mode {
-                    ModeKind::None => mirrorpb::MirrorMode::None.into(),
-                    ModeKind::In => mirrorpb::MirrorMode::In.into(),
-                    ModeKind::Out => mirrorpb::MirrorMode::Out.into(),
-                },
+                mode,
                 counter: mirror_rule.counter,
             }),
             devices: mirror_rule.devices.into_iter().map(|m| m.into()).collect(),
@@ -138,6 +179,39 @@ impl TryFrom<MirrorRule> for mirrorpb::Rule {
     }
 }
 
+impl TryFrom<mirrorpb::Rule> for MirrorRule {
+    type Error = Box<dyn core::error::Error>;
+
+    fn try_from(rule: mirrorpb::Rule) -> Result<Self, Self::Error> {
+        let action = rule.action.ok_or("mirror rule is missing its action")?;
+        let mode = match mirrorpb::MirrorMode::try_from(action.mode) {
+            Ok(mirrorpb::MirrorMode::None) => ModeKind::None,
+            Ok(mirrorpb::MirrorMode::In) => ModeKind::In,
+            Ok(mirrorpb::MirrorMode::Out) => ModeKind::Out,
+            Err(_) => ModeKind::Unknown(action.mode),
+        };
+
+        Ok(Self {
+            target: action.target,
+            mode,
+            counter: action.counter,
+            devices: rule.devices.into_iter().map(|d| d.name).collect(),
+            vlan_ranges: rule.vlan_ranges.into_iter().map(VlanRange::from).collect(),
+            srcs: rule.srcs.into_iter().map(|n| n.to_string()).collect(),
+            dsts: rule.dsts.into_iter().map(|n| n.to_string()).collect(),
+        })
+    }
+}
+
+/// A mirror module configuration as read from or written to a rule file.
+///
+/// Every rule field is always emitted, including an empty sequence as `[]`
+/// and an empty counter as an empty string, and none of them is optional on
+/// `update` either. A network renders from the address and mask actually
+/// stored, so re-applying shown output normalises an address that carries
+/// host bits outside its mask. A stored IPv6 network's mask may have a hole
+/// at the `/64` boundary. Such a network renders in expanded-mask form, and
+/// `update` rejects it because it requires a contiguous mask.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MirrorConfig {
     rules: Vec<MirrorRule>,
@@ -148,6 +222,19 @@ impl TryFrom<MirrorConfig> for Vec<mirrorpb::Rule> {
 
     fn try_from(config: MirrorConfig) -> Result<Self, Self::Error> {
         config.rules.into_iter().map(mirrorpb::Rule::try_from).collect()
+    }
+}
+
+impl TryFrom<Vec<mirrorpb::Rule>> for MirrorConfig {
+    type Error = Box<dyn core::error::Error>;
+
+    fn try_from(rules: Vec<mirrorpb::Rule>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            rules: rules
+                .into_iter()
+                .map(MirrorRule::try_from)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
     }
 }
 
@@ -192,15 +279,18 @@ impl MirrorService {
             .map_err(self.service.status("show"))?
             .into_inner();
 
+        let config = MirrorConfig::try_from(response.rules)
+            .map_err(|e: Box<dyn core::error::Error>| self.service.invalid("show", e.to_string()))?;
+
         output::data(
-            || &response,
+            || &config,
             || {
                 print!(
                     "{}",
-                    serde_yaml::to_string(&response).expect("mirror config YAML serialization must not fail")
+                    serde_yaml::to_string(&config).expect("mirror config YAML serialization must not fail")
                 );
 
-                if response.rules.is_empty() {
+                if config.rules.is_empty() {
                     output::empty_with_hint(
                         format_args!("No mirror rules found for '{}'.", cmd.config_name),
                         format_args!("create one with 'yanet-cli-mirror update --name <name> --rules <path>'"),
@@ -314,4 +404,151 @@ fn config_candidates() -> Vec<CompletionCandidate> {
         },
         async move |mut client| Ok(client.list_configs(ListConfigsRequest {}).await?.into_inner().configs),
     )
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn ip_net(cidr: &str) -> filterpb::pb::IpNet {
+        Contiguous::<IpNetwork>::parse(cidr)
+            .expect("valid cidr in test fixture")
+            .into()
+    }
+
+    fn sample_rules() -> Vec<mirrorpb::Rule> {
+        vec![
+            mirrorpb::Rule {
+                action: Some(mirrorpb::Action {
+                    target: "target-none".to_string(),
+                    mode: mirrorpb::MirrorMode::None as i32,
+                    counter: "counter-none".to_string(),
+                }),
+                devices: vec![
+                    filterpb::pb::Device { name: "eth0".to_string() },
+                    filterpb::pb::Device { name: "eth1".to_string() },
+                ],
+                vlan_ranges: vec![
+                    filterpb::pb::VlanRange { from: 0, to: 100 },
+                    filterpb::pb::VlanRange { from: 200, to: 300 },
+                ],
+                srcs: vec![ip_net("192.0.2.0/24"), ip_net("2001:db8::/32")],
+                dsts: vec![ip_net("203.0.113.0/24"), ip_net("2001:db8:1::/48")],
+            },
+            mirrorpb::Rule {
+                action: Some(mirrorpb::Action {
+                    target: "target-in".to_string(),
+                    mode: mirrorpb::MirrorMode::In as i32,
+                    counter: String::new(),
+                }),
+                devices: vec![],
+                vlan_ranges: vec![],
+                srcs: vec![],
+                dsts: vec![],
+            },
+            mirrorpb::Rule {
+                action: Some(mirrorpb::Action {
+                    target: "target-out".to_string(),
+                    mode: mirrorpb::MirrorMode::Out as i32,
+                    counter: "counter-out".to_string(),
+                }),
+                devices: vec![filterpb::pb::Device { name: "eth2".to_string() }],
+                vlan_ranges: vec![filterpb::pb::VlanRange { from: 10, to: 20 }],
+                srcs: vec![ip_net("10.0.0.0/8")],
+                dsts: vec![ip_net("10.1.0.0/16")],
+            },
+        ]
+    }
+
+    #[test]
+    fn a_shown_config_round_trips_through_yaml_back_into_the_original_rules() {
+        let rules = sample_rules();
+
+        let config = MirrorConfig::try_from(rules.clone()).expect("pb rules must convert into a mirror config");
+        let yaml = serde_yaml::to_string(&config).expect("mirror config must serialize");
+        let parsed: MirrorConfig = serde_yaml::from_str(&yaml).expect("mirror config must deserialize");
+        let reconstructed: Vec<mirrorpb::Rule> = parsed.try_into().expect("mirror config must convert back");
+
+        assert_eq!(rules, reconstructed);
+    }
+
+    #[test]
+    fn a_rule_file_accepts_the_full_mode_vocabulary() {
+        let uppercase = r#"
+rules:
+  - target: "t1"
+    mode: "NONE"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+  - target: "t2"
+    mode: "IN"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+  - target: "t3"
+    mode: "OUT"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+"#;
+        let legacy = r#"
+rules:
+  - target: "t1"
+    mode: "None"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+  - target: "t2"
+    mode: "In"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+  - target: "t3"
+    mode: "Out"
+    counter: ""
+    devices: []
+    vlan_ranges: []
+    srcs: []
+    dsts: []
+"#;
+
+        for yaml in [uppercase, legacy] {
+            let config: MirrorConfig = serde_yaml::from_str(yaml).expect("mode spellings must parse");
+            assert!(matches!(config.rules[0].mode, ModeKind::None));
+            assert!(matches!(config.rules[1].mode, ModeKind::In));
+            assert!(matches!(config.rules[2].mode, ModeKind::Out));
+        }
+    }
+
+    #[test]
+    fn an_unrecognised_mode_number_is_shown_but_rejected_by_update() {
+        let rule = mirrorpb::Rule {
+            action: Some(mirrorpb::Action {
+                target: "t".to_string(),
+                mode: 99,
+                counter: String::new(),
+            }),
+            devices: vec![],
+            vlan_ranges: vec![],
+            srcs: vec![],
+            dsts: vec![],
+        };
+
+        let config = MirrorConfig::try_from(vec![rule]).expect("an unrecognised mode must not blank the show");
+        assert!(serde_yaml::to_string(&config).is_ok());
+
+        let rebuilt: Result<Vec<mirrorpb::Rule>, _> = config.try_into();
+        assert!(rebuilt.is_err());
+    }
 }

--- a/operators/forward/internal/operator/rules.go
+++ b/operators/forward/internal/operator/rules.go
@@ -22,9 +22,21 @@ type yamlVlanRange struct {
 type yamlModeKind string
 
 const (
-	modeNone yamlModeKind = "None"
-	modeIn   yamlModeKind = "In"
-	modeOut  yamlModeKind = "Out"
+	modeNone yamlModeKind = "NONE"
+	modeIn   yamlModeKind = "IN"
+	modeOut  yamlModeKind = "OUT"
+)
+
+// legacyModeNone, legacyModeIn, and legacyModeOut are the PascalCase
+// spellings of the same three modes.
+//
+// Rule files written before the CLI adopted the proto enum spellings use
+// these forms, and those files must keep loading alongside the canonical
+// uppercase ones.
+const (
+	legacyModeNone yamlModeKind = "None"
+	legacyModeIn   yamlModeKind = "In"
+	legacyModeOut  yamlModeKind = "Out"
 )
 
 // yamlForwardRule mirrors a single rule entry in the YAML forward config.
@@ -110,14 +122,14 @@ func convertRule(r yamlForwardRule) (*forwardpb.Rule, error) {
 // convertMode maps a yamlModeKind to the proto enum value.
 func convertMode(m yamlModeKind) (forwardpb.ForwardMode, error) {
 	switch m {
-	case modeNone:
+	case modeNone, legacyModeNone:
 		return forwardpb.ForwardMode_NONE, nil
-	case modeIn:
+	case modeIn, legacyModeIn:
 		return forwardpb.ForwardMode_IN, nil
-	case modeOut:
+	case modeOut, legacyModeOut:
 		return forwardpb.ForwardMode_OUT, nil
 	default:
-		return 0, fmt.Errorf("unknown mode %q: must be None, In, or Out", m)
+		return 0, fmt.Errorf("unknown mode %q: must be NONE, IN, or OUT", m)
 	}
 }
 

--- a/operators/forward/internal/operator/rules_test.go
+++ b/operators/forward/internal/operator/rules_test.go
@@ -1,0 +1,50 @@
+package operator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
+	"github.com/yanet-platform/yanet2/operators/forward/internal/operator"
+)
+
+// TestLoadForwardRules_Mode verifies that LoadForwardRules accepts both the
+// canonical uppercase mode spellings and the legacy PascalCase spellings,
+// mapping each to the same forwardpb.ForwardMode value, and rejects any
+// other spelling.
+func TestLoadForwardRules_Mode(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		want    forwardpb.ForwardMode
+		wantErr bool
+	}{
+		{name: "canonical NONE", mode: "NONE", want: forwardpb.ForwardMode_NONE},
+		{name: "canonical IN", mode: "IN", want: forwardpb.ForwardMode_IN},
+		{name: "canonical OUT", mode: "OUT", want: forwardpb.ForwardMode_OUT},
+		{name: "legacy None", mode: "None", want: forwardpb.ForwardMode_NONE},
+		{name: "legacy In", mode: "In", want: forwardpb.ForwardMode_IN},
+		{name: "legacy Out", mode: "Out", want: forwardpb.ForwardMode_OUT},
+		{name: "unknown spelling", mode: "out", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "rules.yaml")
+			data := "rules:\n  - target: fn:test\n    mode: " + tt.mode + "\n    counter: cnt\n"
+			require.NoError(t, os.WriteFile(path, []byte(data), 0o644))
+
+			rules, err := operator.LoadForwardRules(path)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, rules, 1)
+			require.Equal(t, tt.want, rules[0].Action.Mode)
+		})
+	}
+}


### PR DESCRIPTION
The `show` command serialized the protobuf response verbatim, so its YAML carried a response-shaped document — a top-level config name, a nested action object, device objects and a numeric mode — that the `update` command could not read back. An operator could not save a shown configuration, edit it, and apply it again.

- Emit the rule-file schema from `show`, so its output is directly accepted by `update`.
- Spell the mode as the proto enum name, making the uppercase form canonical across the CLI, the operator rules loader and the Web UI exporter.
- Keep every parser accepting the PascalCase spelling that existing rule files use, so no deployed configuration has to be migrated.
- Render a mode value the CLI has no name for as its raw number instead of failing the whole command, and keep `update` refusing such a rule.
- Apply the same change to the mirror module CLI, which shares the schema.
- Document the serialization policy for empty fields, host-bit normalization and non-contiguous masks.
