### PR TITLE
fix(forward): reject a rule without an action instead of crashing

### DIFF
--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -101,6 +101,11 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 
 	rules := make([]cforward.ForwardRule, 0, len(reqRules))
 	for _, reqRule := range reqRules {
+		action := reqRule.GetAction()
+		if action == nil {
+			return nil, status.Error(codes.InvalidArgument, "rule action is required")
+		}
+
 		devices, err := filterpb.ToDevices(reqRule.Devices)
 		if err != nil {
 			return nil, err
@@ -127,9 +132,9 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 		}
 
 		rule := cforward.ForwardRule{
-			Target:     reqRule.Action.Target,
+			Target:     action.Target,
 			Mode:       cforward.ModeNone,
-			Counter:    reqRule.Action.Counter,
+			Counter:    action.Counter,
 			Devices:    devices,
 			VlanRanges: vlanRanges,
 			Src4s:      src4s,
@@ -138,10 +143,10 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 			Dst6s:      dst6s,
 		}
 
-		if reqRule.Action.Mode == forwardpb.ForwardMode_IN {
+		if action.Mode == forwardpb.ForwardMode_IN {
 			rule.Mode = cforward.ModeIn
 		}
-		if reqRule.Action.Mode == forwardpb.ForwardMode_OUT {
+		if action.Mode == forwardpb.ForwardMode_OUT {
 			rule.Mode = cforward.ModeOut
 		}
 

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -64,6 +64,20 @@ func TestShowConfigEmptyRules(t *testing.T) {
 	require.Empty(t, response.GetRules())
 }
 
+// TestUpdateConfigNilAction verifies that UpdateConfig rejects a rule with a
+// nil action instead of dereferencing it.
+func TestUpdateConfigNilAction(t *testing.T) {
+	svc := forward.NewForwardService(&mockBackend{})
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{},
+		},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
 // Run with: go test -race
 func TestForwardServiceConcurrentAccess(t *testing.T) {
 	svc := forward.NewForwardService(&mockBackend{})


### PR DESCRIPTION
The forward update handler read the action fields of every incoming rule without checking that the rule carried one. Because the action is an optional message on the wire, a request omitting it dereferenced a nil pointer, and the server interceptors re-raise a panic after recording it, so any client could take the control plane down.

- Reject a rule that carries no action with an invalid-argument status, matching the guard the mirror module already has.
- Read the action fields from the checked value rather than dereferencing the request rule again.
- Cover the rejection with a regression test, verified to crash against the unguarded handler.
