### PR TITLE
fix(gateway): reject requests missing a required message instead of crashing

### DIFF
--- a/controlplane/builtin/function.go
+++ b/controlplane/builtin/function.go
@@ -108,9 +108,12 @@ func (m *Function) Get(
 	ctx context.Context,
 	request *ynpb.GetFunctionRequest,
 ) (*ynpb.GetFunctionResponse, error) {
-	dpConfig := m.shm.DPConfig(m.instanceID)
+	reqId := request.GetId()
+	if reqId == nil {
+		return nil, status.Error(codes.InvalidArgument, "function id is required")
+	}
 
-	reqId := request.Id
+	dpConfig := m.shm.DPConfig(m.instanceID)
 
 	functions := dpConfig.Functions()
 	for _, function := range functions {
@@ -157,19 +160,25 @@ func (m *Function) Update(
 	ctx context.Context,
 	request *ynpb.UpdateFunctionRequest,
 ) (*ynpb.UpdateFunctionResponse, error) {
-	reqFunction := request.Function
-
-	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
-	if err != nil {
-		return nil, fmt.Errorf("failed to attach to agent %q: %w", functionAgentName, err)
+	reqFunction := request.GetFunction()
+	if reqFunction == nil {
+		return nil, status.Error(codes.InvalidArgument, "function is required")
 	}
-	defer agent.Close()
+
+	reqFunctionId := reqFunction.GetId()
+	if reqFunctionId == nil {
+		return nil, status.Error(codes.InvalidArgument, "function id is required")
+	}
 
 	function := ffi.FunctionConfig{
-		Name: reqFunction.Id.Name,
+		Name: reqFunctionId.Name,
 	}
 	for _, reqFunctionChain := range reqFunction.Chains {
-		reqChain := reqFunctionChain.Chain
+		reqChain := reqFunctionChain.GetChain()
+		if reqChain == nil {
+			return nil, status.Error(codes.InvalidArgument, "function chain is required")
+		}
+
 		modules := make([]ffi.ChainModuleConfig, 0, len(reqChain.Modules))
 		for _, reqChainModule := range reqChain.Modules {
 			modules = append(modules, ffi.ChainModuleConfig{
@@ -189,6 +198,12 @@ func (m *Function) Update(
 		function.Chains = append(function.Chains, functionChain)
 	}
 
+	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to attach to agent %q: %w", functionAgentName, err)
+	}
+	defer agent.Close()
+
 	if err := agent.UpdateFunction(function); err != nil {
 		return nil, fmt.Errorf("failed to update function: %w", err)
 	}
@@ -201,7 +216,11 @@ func (m *Function) Delete(
 	ctx context.Context,
 	request *ynpb.DeleteFunctionRequest,
 ) (*ynpb.DeleteFunctionResponse, error) {
-	functionName := request.Id.Name
+	reqId := request.GetId()
+	if reqId == nil {
+		return nil, status.Error(codes.InvalidArgument, "function id is required")
+	}
+	functionName := reqId.Name
 
 	agent, err := m.shm.AgentAttach(functionAgentName, m.instanceID, functionAgentMemory)
 	if err != nil {

--- a/controlplane/builtin/function_test.go
+++ b/controlplane/builtin/function_test.go
@@ -1,0 +1,72 @@
+package builtin_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/builtin"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// TestFunctionUpdateRejectsMissingMessages verifies that Update rejects a
+// request whose optional message fields are absent instead of dereferencing
+// them, and that the rejection happens before any shared memory is touched.
+func TestFunctionUpdateRejectsMissingMessages(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *ynpb.UpdateFunctionRequest
+	}{
+		{
+			name:    "missing function",
+			request: &ynpb.UpdateFunctionRequest{},
+		},
+		{
+			name: "missing function id",
+			request: &ynpb.UpdateFunctionRequest{
+				Function: &ynpb.Function{},
+			},
+		},
+		{
+			name: "missing chain",
+			request: &ynpb.UpdateFunctionRequest{
+				Function: &ynpb.Function{
+					Id: &commonpb.FunctionId{Name: "f"},
+					Chains: []*ynpb.FunctionChain{
+						{Weight: 1},
+					},
+				},
+			},
+		},
+	}
+
+	svc := builtin.NewFunction(0, nil)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := svc.Update(t.Context(), test.request)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// TestFunctionDeleteRejectsMissingID verifies that Delete rejects a request
+// with no id instead of dereferencing it to build the function name.
+func TestFunctionDeleteRejectsMissingID(t *testing.T) {
+	svc := builtin.NewFunction(0, nil)
+
+	_, err := svc.Delete(t.Context(), &ynpb.DeleteFunctionRequest{})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestFunctionGetRejectsMissingID verifies that Get rejects a request with
+// no id instead of dereferencing it.
+func TestFunctionGetRejectsMissingID(t *testing.T) {
+	svc := builtin.NewFunction(0, nil)
+
+	_, err := svc.Get(t.Context(), &ynpb.GetFunctionRequest{})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}

--- a/controlplane/builtin/pipeline.go
+++ b/controlplane/builtin/pipeline.go
@@ -108,9 +108,12 @@ func (m *Pipeline) Get(
 	ctx context.Context,
 	request *ynpb.GetPipelineRequest,
 ) (*ynpb.GetPipelineResponse, error) {
-	dpConfig := m.shm.DPConfig(m.instanceID)
+	reqId := request.GetId()
+	if reqId == nil {
+		return nil, status.Error(codes.InvalidArgument, "pipeline id is required")
+	}
 
-	reqId := request.Id
+	dpConfig := m.shm.DPConfig(m.instanceID)
 
 	pipelines := dpConfig.Pipelines()
 	for _, pipeline := range pipelines {
@@ -143,22 +146,30 @@ func (m *Pipeline) Update(
 	ctx context.Context,
 	request *ynpb.UpdatePipelineRequest,
 ) (*ynpb.UpdatePipelineResponse, error) {
-	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
-	if err != nil {
-		return nil, fmt.Errorf("failed to attach to agent %q: %w", agentName, err)
+	reqPipeline := request.GetPipeline()
+	if reqPipeline == nil {
+		return nil, status.Error(codes.InvalidArgument, "pipeline is required")
 	}
-	defer agent.Close()
 
-	reqPipeline := request.Pipeline
+	reqPipelineId := reqPipeline.GetId()
+	if reqPipelineId == nil {
+		return nil, status.Error(codes.InvalidArgument, "pipeline id is required")
+	}
 
 	pipeline := ffi.PipelineConfig{
-		Name:      reqPipeline.Id.Name,
+		Name:      reqPipelineId.Name,
 		Functions: make([]string, len(reqPipeline.Functions)),
 	}
 
 	for idx, reqFunctionId := range reqPipeline.Functions {
 		pipeline.Functions[idx] = reqFunctionId.Name
 	}
+
+	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
+	if err != nil {
+		return nil, fmt.Errorf("failed to attach to agent %q: %w", agentName, err)
+	}
+	defer agent.Close()
 
 	if err := agent.UpdatePipeline(pipeline); err != nil {
 		return nil, fmt.Errorf("failed to update function: %w", err)
@@ -172,7 +183,11 @@ func (m *Pipeline) Delete(
 	ctx context.Context,
 	request *ynpb.DeletePipelineRequest,
 ) (*ynpb.DeletePipelineResponse, error) {
-	pipelineName := request.GetId().GetName()
+	reqId := request.GetId()
+	if reqId == nil {
+		return nil, status.Error(codes.InvalidArgument, "pipeline id is required")
+	}
+	pipelineName := reqId.Name
 
 	agent, err := m.shm.AgentAttach(agentName, m.instanceID, defaultAgentMemory)
 	if err != nil {

--- a/controlplane/builtin/pipeline_test.go
+++ b/controlplane/builtin/pipeline_test.go
@@ -1,0 +1,60 @@
+package builtin_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/controlplane/builtin"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// TestPipelineUpdateRejectsMissingMessages verifies that Update rejects a
+// request whose optional message fields are absent instead of dereferencing
+// them, and that the rejection happens before any shared memory is touched.
+func TestPipelineUpdateRejectsMissingMessages(t *testing.T) {
+	tests := []struct {
+		name    string
+		request *ynpb.UpdatePipelineRequest
+	}{
+		{
+			name:    "missing pipeline",
+			request: &ynpb.UpdatePipelineRequest{},
+		},
+		{
+			name: "missing pipeline id",
+			request: &ynpb.UpdatePipelineRequest{
+				Pipeline: &ynpb.Pipeline{},
+			},
+		},
+	}
+
+	svc := builtin.NewPipeline(0, nil)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := svc.Update(t.Context(), test.request)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+		})
+	}
+}
+
+// TestPipelineDeleteRejectsMissingID verifies that Delete rejects a request
+// with no id instead of deleting a pipeline named "".
+func TestPipelineDeleteRejectsMissingID(t *testing.T) {
+	svc := builtin.NewPipeline(0, nil)
+
+	_, err := svc.Delete(t.Context(), &ynpb.DeletePipelineRequest{})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestPipelineGetRejectsMissingID verifies that Get rejects a request with
+// no id instead of dereferencing it.
+func TestPipelineGetRejectsMissingID(t *testing.T) {
+	svc := builtin.NewPipeline(0, nil)
+
+	_, err := svc.Get(t.Context(), &ynpb.GetPipelineRequest{})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}


### PR DESCRIPTION
The built-in function and pipeline services read the identifier and nested messages of an incoming request without checking that the request carried them. Those fields are optional on the wire, so a client omitting one dereferenced a nil pointer, and because the server interceptors re-raise a panic after recording it, the gateway process itself went down. This is the same defect class fixed for the forward module in #1650, but here the blast radius is the gateway rather than a single module.

- Reject a request that omits a required message with an invalid-argument status, across every get, update and delete handler of both services.
- Validate the request before touching shared memory, so an invalid update no longer attaches and frees an agent for nothing.
- Align the two delete handlers, which previously disagreed on whether a missing identifier was an error or an empty name.
- Cover each rejection with a regression test, verified to crash against the unguarded handlers.
