### PR TITLE
fix(filter): propagate allocator failures during rule compilation

### DIFF
--- a/common/registry.h
+++ b/common/registry.h
@@ -265,7 +265,12 @@ value_range_append(
 
 static inline int
 value_registry_collect(struct value_registry *registry, uint32_t value) {
-	if (value_collector_collect(&registry->collector, value) == 1) {
+	int rc = value_collector_collect(&registry->collector, value);
+	if (rc < 0) {
+		return -1;
+	}
+
+	if (rc == 1) {
 		struct value_range *range =
 			ADDR_OF(&registry->ranges) + registry->range_count - 1;
 		if (value_range_append(registry->memory_context, range, value))
@@ -317,6 +322,8 @@ value_registry_capacity(struct value_registry *registry) {
 /*
  * Registry join callback called for each value pair combined from
  * two registry values.
+ *
+ * Returns 0 on success, negative on error.
  */
 typedef int (*value_registry_join_func)(
 	uint32_t first, uint32_t second, uint32_t idx, void *data
@@ -345,7 +352,9 @@ value_registry_join_range(
 			uint32_t v1 = values1[idx1];
 			uint32_t v2 = values2[idx2];
 
-			join_func(v1, v2, range_idx, join_func_data);
+			if (join_func(v1, v2, range_idx, join_func_data) < 0) {
+				return -1;
+			}
 		}
 	}
 	return 0;

--- a/lib/filter/compiler/device.c
+++ b/lib/filter/compiler/device.c
@@ -74,7 +74,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 	for (const struct filter_rule **r_ptr = rules;
 	     r_ptr < rules + rule_count;
 	     ++r_ptr) {
-		value_registry_start(registry);
+		if (value_registry_start(registry)) {
+			goto error_collect;
+		}
 
 		if (*r_ptr == NULL)
 			continue;

--- a/lib/filter/compiler/helper.c
+++ b/lib/filter/compiler/helper.c
@@ -131,8 +131,9 @@ value_table_touch_action(uint32_t v1, uint32_t v2, uint32_t idx, void *data) {
 	struct collect_ctx *collect_ctx = (struct collect_ctx *)data;
 
 	uint32_t *value = value_table_get_ptr(collect_ctx->value_table, v1, v2);
-	if (remap_table_touch(&collect_ctx->remap_table, *value, value))
+	if (remap_table_touch(&collect_ctx->remap_table, *value, value) < 0) {
 		return -1;
+	}
 	return 0;
 }
 
@@ -166,13 +167,15 @@ merge_registry_values(
 	for (uint32_t range_idx = 0; range_idx < registry1->range_count;
 	     ++range_idx) {
 		remap_table_new_gen(&collect_ctx.remap_table);
-		value_registry_join_range(
-			registry1,
-			registry2,
-			range_idx,
-			value_table_touch_action,
-			&collect_ctx
-		);
+		if (value_registry_join_range(
+			    registry1,
+			    registry2,
+			    range_idx,
+			    value_table_touch_action,
+			    &collect_ctx
+		    )) {
+			goto error_join;
+		}
 	}
 
 	remap_table_compact(&collect_ctx.remap_table);
@@ -180,6 +183,9 @@ merge_registry_values(
 	remap_table_free(&collect_ctx.remap_table);
 
 	return 0;
+
+error_join:
+	remap_table_free(&collect_ctx.remap_table);
 
 error_remap_table:
 	value_table_free(table);
@@ -223,17 +229,26 @@ collect_registry_values(
 
 	for (uint32_t range_idx = 0; range_idx < registry1->range_count;
 	     ++range_idx) {
-		value_registry_start(registry);
-		value_registry_join_range(
-			registry1,
-			registry2,
-			range_idx,
-			value_table_collect_action,
-			&collect_ctx
-		);
+		if (value_registry_start(registry)) {
+			goto error_registry;
+		}
+		if (value_registry_join_range(
+			    registry1,
+			    registry2,
+			    range_idx,
+			    value_table_collect_action,
+			    &collect_ctx
+		    )) {
+			goto error_registry;
+		}
 	}
 
 	return 0;
+
+error_registry:
+	value_registry_fini(registry);
+
+	return -1;
 }
 
 int

--- a/lib/filter/compiler/ipfrag.c
+++ b/lib/filter/compiler/ipfrag.c
@@ -60,7 +60,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(ip_frag)(
 	     r_ptr < rules + rule_count;
 	     ++r_ptr) {
 		// A value range should be created even for empty rules
-		value_registry_start(registry);
+		if (value_registry_start(registry)) {
+			goto error_collect;
+		}
 		if (*r_ptr == NULL)
 			continue;
 		const struct filter_rule *r = *r_ptr;

--- a/lib/filter/compiler/net4.c
+++ b/lib/filter/compiler/net4.c
@@ -64,7 +64,7 @@ net4_collect_values(
 	return 0;
 }
 
-static inline void
+static inline int
 net4_collect_registry(
 	struct net4 *start,
 	uint32_t count,
@@ -75,14 +75,18 @@ net4_collect_registry(
 		uint32_t addr = *(uint32_t *)net4->addr;
 		uint32_t mask = *(uint32_t *)net4->mask;
 		uint32_t to = addr | ~mask;
-		lpm4_collect_values(
-			lpm,
-			(uint8_t *)&addr,
-			(uint8_t *)&to,
-			lpm_collect_registry_iterator,
-			registry
-		);
+		if (lpm4_collect_values(
+			    lpm,
+			    (uint8_t *)&addr,
+			    (uint8_t *)&to,
+			    lpm_collect_registry_iterator,
+			    registry
+		    )) {
+			return -1;
+		}
 	}
+
+	return 0;
 }
 
 static inline int
@@ -179,7 +183,9 @@ collect_net4_values(
 	     action_ptr < actions + count;
 	     ++action_ptr) {
 		// A value range should be created even for empty rules
-		value_registry_start(registry);
+		if (value_registry_start(registry)) {
+			goto error_net_collect;
+		}
 
 		if (*action_ptr == NULL)
 			continue;
@@ -189,7 +195,9 @@ collect_net4_values(
 		uint32_t net_count;
 		get_net4(action, &nets, &net_count);
 
-		net4_collect_registry(nets, net_count, lpm, registry);
+		if (net4_collect_registry(nets, net_count, lpm, registry)) {
+			goto error_net_collect;
+		}
 	}
 
 	remap_table_free(&remap_table);

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -289,7 +289,9 @@ collect_network_values(
 	for (uint32_t net_idx = 0; net_idx < all_net_count; ++net_idx) {
 		struct net6 net6 = all_nets[net_idx];
 
-		value_registry_start(registry);
+		if (value_registry_start(registry)) {
+			return -1;
+		}
 
 		uint32_t start_hi;
 		uint32_t stop_hi;
@@ -352,7 +354,9 @@ build_net6_info(
 	*net_ranges = NULL;
 	*net_range_count = 0;
 
-	radix_init(net_radix, memory_context);
+	if (radix_init(net_radix, memory_context)) {
+		return -1;
+	}
 
 	for (const struct filter_rule **action_ptr = actions;
 	     action_ptr < actions + action_count;
@@ -376,7 +380,11 @@ build_net6_info(
 			    RADIX_VALUE_INVALID)
 				continue;
 
-			radix_insert(net_radix, 32, net6.addr, *net_count);
+			if (radix_insert(
+				    net_radix, 32, net6.addr, *net_count
+			    )) {
+				goto error_nets;
+			}
 			if (mem_array_expand_exp(
 				    memory_context,
 				    (void **)nets,
@@ -555,7 +563,9 @@ merge_net6_range(
 	}
 
 	struct value_registry net_registry;
-	value_registry_init(&net_registry, memory_context);
+	if (value_registry_init(&net_registry, memory_context)) {
+		goto error_table;
+	}
 
 	if (collect_network_values(
 		    nets, net_cnt, ri_hi, ri_lo, table, &net_registry
@@ -563,7 +573,9 @@ merge_net6_range(
 		goto error_net_registry;
 	}
 
-	value_registry_init(registry, memory_context);
+	if (value_registry_init(registry, memory_context)) {
+		goto error_net_registry;
+	}
 
 	for (const struct filter_rule **action_ptr = actions;
 	     action_ptr < actions + count;

--- a/lib/filter/compiler/port.c
+++ b/lib/filter/compiler/port.c
@@ -68,7 +68,9 @@ collect_port_values(
 	     action_ptr < actions + count;
 	     ++action_ptr) {
 		// A value range should be created even for empty rules
-		value_registry_start(registry);
+		if (value_registry_start(registry)) {
+			goto error_collect;
+		}
 		if (*action_ptr == NULL)
 			continue;
 		const struct filter_rule *action = *action_ptr;

--- a/lib/filter/compiler/proto_range.c
+++ b/lib/filter/compiler/proto_range.c
@@ -69,7 +69,9 @@ collect_proto_values(
 	     rule_ptr < rules + count;
 	     ++rule_ptr) {
 		// A value range should be created even for empty rules
-		value_registry_start(registry);
+		if (value_registry_start(registry)) {
+			goto error_collect;
+		}
 		if (*rule_ptr == NULL)
 			continue;
 

--- a/lib/filter/compiler/vlan.c
+++ b/lib/filter/compiler/vlan.c
@@ -64,16 +64,21 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 	     r_ptr < rules + rule_count;
 	     ++r_ptr) {
 		// A value range should be created even for empty rules
-		value_registry_start(registry);
+		if (value_registry_start(registry)) {
+			goto error_collect;
+		}
 		if (*r_ptr == NULL)
 			continue;
 		const struct filter_rule *r = *r_ptr;
 
 		if (r->vlan_range_count == 0) {
 			for (uint16_t vlan = 0; vlan <= 4095; ++vlan) {
-				value_registry_collect(
-					registry, value_table_get(t, 0, vlan)
-				);
+				if (value_registry_collect(
+					    registry,
+					    value_table_get(t, 0, vlan)
+				    )) {
+					goto error_collect;
+				}
 			}
 		}
 		for (uint32_t idx = 0; idx < r->vlan_range_count; ++idx) {

--- a/lib/filter/tests/meson.build
+++ b/lib/filter/tests/meson.build
@@ -226,3 +226,47 @@ executable('bench_net6_fast',
   dependencies: test_deps,
   link_language: 'c'
 )
+
+# Allocation-failure injection sweep. The compiler sources are recompiled
+# with oom_shim.h force-included so every memory_balloc call on the compile
+# path can be forced to fail one at a time.
+oom_shim_c_args = yanet_test_c_args + [
+  '-include', meson.current_source_dir() / 'oom_shim.h',
+]
+
+filter_compiler_oom_shim = static_library(
+  'filter_compiler_oom_shim',
+  compiler_sources,
+  c_args: oom_shim_c_args,
+  link_args: yanet_link_args,
+  include_directories: include_directories('..'),
+  dependencies: [lib_common_dep, lib_errors_dep],
+  install: false,
+)
+
+filter_compiler_oom_shim_dep = declare_dependency(
+  link_with: filter_compiler_oom_shim,
+  include_directories: include_directories('..'),
+  dependencies: [lib_errors_dep],
+)
+
+oom_sweep_deps = [
+  lib_common_dep,
+  lib_packet_dp_dep,
+  filter_compiler_oom_shim_dep,
+  lib_filter_query_dep,
+  lib_lib_utils_dep,
+  libdpdk_inc_dep,
+  libdpdk_dep,
+]
+
+# The sweep test itself inlines part of the compile path (filter_init is a
+# static inline in compiler.h), so it needs the same shim.
+test_filter_oom_sweep = executable('oom_sweep',
+  ['oom_sweep.c'],
+  c_args: oom_shim_c_args,
+  link_args: yanet_link_args,
+  dependencies: oom_sweep_deps,
+  link_language: 'c'
+)
+test('oom_sweep', test_filter_oom_sweep, suite: ['filter'])

--- a/lib/filter/tests/oom_shim.h
+++ b/lib/filter/tests/oom_shim.h
@@ -1,0 +1,64 @@
+#pragma once
+
+// Allocation-failure injector for the filter-compiler OOM sweep test.
+//
+// Force-included ahead of every shimmed translation unit (see the
+// filter_compiler_oom_shim library and the oom_sweep executable in
+// meson.build) so every memory_balloc call on the compile path routes
+// through a counter that can be made to fail at an exact, armed call
+// index.
+//
+// The real header is included first, so its static inline memory_balloc
+// definition is fully parsed before the macro below exists. Dropping this
+// include would let the force-included macro rewrite that real definition
+// itself into a syntax error, which is why the redefinition stays scoped
+// to call sites rather than the definition itself.
+#include "common/memory.h"
+
+// Armed by the sweep driver around one filter_init call at a time, so a
+// fixture's own setup allocations are never subject to injection.
+extern int filter_test_oom_armed;
+
+// -1 disables injection while still counting, which is how the sweep
+// driver learns how many memory_balloc calls a clean compile makes.
+extern long filter_test_oom_fail_at;
+extern long filter_test_oom_calls;
+
+static inline void *
+filter_test_balloc(struct memory_context *context, size_t size) {
+	if (!filter_test_oom_armed) {
+		return (memory_balloc)(context, size);
+	}
+
+	if (filter_test_oom_calls++ == filter_test_oom_fail_at) {
+		return NULL;
+	}
+
+	return (memory_balloc)(context, size);
+}
+
+#define memory_balloc(context, size) filter_test_balloc((context), (size))
+
+// The real memory_brealloc body was parsed before this header existed, so it
+// still calls the real memory_balloc directly and stays outside the counter
+// above. Shimming it here too keeps a growing realloc injectable and counted,
+// which is how mem_array_expand_exp reaches the compile path.
+static inline void *
+filter_test_brealloc(
+	struct memory_context *context,
+	void *data,
+	size_t old_size,
+	size_t new_size
+) {
+	// A zero new_size only frees or no-ops, so it never allocates and is
+	// not an injection point.
+	if (new_size != 0 && filter_test_oom_armed &&
+	    filter_test_oom_calls++ == filter_test_oom_fail_at) {
+		return NULL;
+	}
+
+	return (memory_brealloc)(context, data, old_size, new_size);
+}
+
+#define memory_brealloc(context, data, old_size, new_size)                     \
+	filter_test_brealloc((context), (data), (old_size), (new_size))

--- a/lib/filter/tests/oom_sweep.c
+++ b/lib/filter/tests/oom_sweep.c
@@ -1,0 +1,374 @@
+// Allocation-failure injection sweep over the production filter compiler.
+//
+// A plain undersized-arena test does not reach the bug class this guards
+// against: the block allocator is a buddy allocator, so failure is monotone
+// in arena size and every unchecked memory_balloc site in the compiler
+// happens to be followed by a checked, larger one. The bug needs a
+// non-monotone failure, which is what a concurrent compile produces in
+// production and what single-point fault injection models here: force
+// exactly one memory_balloc call to fail, for every call the compile
+// makes, and require a clean -1 every time.
+#include "common/asan.h"
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/network.h"
+#include "common/test_assert.h"
+
+#include "lib/filter/compiler.h"
+#include "lib/filter/filter.h"
+
+#include "lib/filter/tests/helpers.h"
+
+#include "logging/log.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+FILTER_COMPILER_DECLARE(sign_net6_src_compile, net6_src);
+FILTER_COMPILER_DECLARE(sign_net4_src_compile, net4_src);
+FILTER_COMPILER_DECLARE(sign_ports_compile, port_src, port_dst);
+FILTER_COMPILER_DECLARE(sign_net4_ports_compile, net4_src, port_src, port_dst);
+
+// Storage for the extern injector state declared in oom_shim.h.
+int filter_test_oom_armed;
+long filter_test_oom_fail_at = -1;
+long filter_test_oom_calls;
+
+#define SWEEP_RULE_COUNT 16
+#define SWEEP_ARENA_SIZE (1 << 24)
+
+static struct net6
+sweep_mk_net6(uint32_t idx, uint8_t prefix_len) {
+	struct net6 net = {0};
+	// Spreads the significant bits across both 64-bit halves so both
+	// the hi and lo range indices grow with idx.
+	net.addr[0] = 0x20;
+	net.addr[1] = 0x01;
+	net.addr[2] = (uint8_t)(idx >> 8);
+	net.addr[3] = (uint8_t)idx;
+	net.addr[8] = (uint8_t)(idx >> 4);
+	net.addr[9] = (uint8_t)(idx << 3);
+	for (uint8_t byte_idx = 0; byte_idx < 16; ++byte_idx) {
+		uint8_t bits = prefix_len > byte_idx * 8
+				       ? prefix_len - byte_idx * 8
+				       : 0;
+		if (bits > 8) {
+			bits = 8;
+		}
+		net.mask[byte_idx] = (uint8_t)(bits ? (0xff << (8 - bits)) : 0);
+	}
+	return net;
+}
+
+static void
+build_net6_src_rules(
+	struct filter_rule_builder *builders,
+	struct filter_rule *rules,
+	const struct filter_rule **rule_ptrs,
+	uint32_t rule_count
+) {
+	for (uint32_t idx = 0; idx < rule_count; ++idx) {
+		builder_init(&builders[idx]);
+		builder_add_net6_src(
+			&builders[idx], sweep_mk_net6(idx, 64 + (idx % 8))
+		);
+		builder_add_net6_src(
+			&builders[idx],
+			sweep_mk_net6(idx + 1000, 48 + (idx % 16))
+		);
+		rules[idx] = build_rule(&builders[idx]);
+		rule_ptrs[idx] = &rules[idx];
+	}
+}
+
+static void
+build_net4_src_rules(
+	struct filter_rule_builder *builders,
+	struct filter_rule *rules,
+	const struct filter_rule **rule_ptrs,
+	uint32_t rule_count
+) {
+	for (uint32_t idx = 0; idx < rule_count; ++idx) {
+		builder_init(&builders[idx]);
+		uint8_t addr[NET4_LEN] = {
+			10, (uint8_t)(idx >> 8), (uint8_t)idx, 0
+		};
+		uint8_t mask[NET4_LEN] = {0xff, 0xff, 0xff, 0x00};
+		builder_add_net4_src(&builders[idx], addr, mask);
+		rules[idx] = build_rule(&builders[idx]);
+		rule_ptrs[idx] = &rules[idx];
+	}
+}
+
+static void
+build_ports_rules(
+	struct filter_rule_builder *builders,
+	struct filter_rule *rules,
+	const struct filter_rule **rule_ptrs,
+	uint32_t rule_count
+) {
+	for (uint32_t idx = 0; idx < rule_count; ++idx) {
+		builder_init(&builders[idx]);
+		builder_add_port_src_range(
+			&builders[idx],
+			(uint16_t)(idx * 3),
+			(uint16_t)(idx * 3 + 100)
+		);
+		builder_add_port_dst_range(
+			&builders[idx],
+			(uint16_t)(idx * 7),
+			(uint16_t)(idx * 7 + 50)
+		);
+		rules[idx] = build_rule(&builders[idx]);
+		rule_ptrs[idx] = &rules[idx];
+	}
+}
+
+// Three lookups are the threshold that puts filter_init's merge loop on
+// merge_and_collect_registry, so this is the sweep's only shape reaching
+// merge_registry_values and collect_registry_values in helper.c.
+// Its collect_registry_values unwind is swept, but merge_registry_values'
+// error_join is not: reaching it needs remap_table_touch to fail, which
+// first allocates only past 4096 remap keys, where 16 rules reach 101.
+static void
+build_net4_ports_rules(
+	struct filter_rule_builder *builders,
+	struct filter_rule *rules,
+	const struct filter_rule **rule_ptrs,
+	uint32_t rule_count
+) {
+	for (uint32_t idx = 0; idx < rule_count; ++idx) {
+		builder_init(&builders[idx]);
+		uint8_t addr[NET4_LEN] = {
+			10, (uint8_t)(idx >> 8), (uint8_t)idx, 0
+		};
+		uint8_t mask[NET4_LEN] = {0xff, 0xff, 0xff, 0x00};
+		builder_add_net4_src(&builders[idx], addr, mask);
+		builder_add_port_src_range(
+			&builders[idx],
+			(uint16_t)(idx * 3),
+			(uint16_t)(idx * 3 + 100)
+		);
+		builder_add_port_dst_range(
+			&builders[idx],
+			(uint16_t)(idx * 7),
+			(uint16_t)(idx * 7 + 50)
+		);
+		rules[idx] = build_rule(&builders[idx]);
+		rule_ptrs[idx] = &rules[idx];
+	}
+}
+
+// Rebuilds the arena, block allocator and memory context from scratch so
+// every sweep iteration starts from the same state a fresh config apply
+// would see.
+static int
+sweep_reset_fixture(
+	uint8_t *arena,
+	size_t arena_size,
+	struct block_allocator *allocator,
+	struct memory_context *mctx
+) {
+	// The block allocator leaves parts of the arena ASan-poisoned from
+	// the previous iteration's compile, so the region has to be
+	// reclaimed before the fill below can touch it.
+	asan_unpoison_memory_region(arena, arena_size);
+
+	// A production agent arena is recycled, not freshly zeroed on every
+	// config apply. Poisoning it before every iteration reproduces the
+	// stale bytes a use that skips a check would actually read, instead
+	// of the misleadingly benign zero fill malloc happens to give.
+	memset(arena, 0x5a, arena_size);
+
+	block_allocator_init(allocator);
+	block_allocator_put_arena(allocator, arena, arena_size);
+
+	int res = memory_context_init(mctx, "oom_sweep", allocator);
+	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
+
+	return TEST_SUCCESS;
+}
+
+// Compiles one filter with the injector armed at fail_at (-1 disables
+// failure and just counts) and returns filter_init's return code.
+static int
+sweep_compile(
+	const struct filter_compiler *compiler,
+	const struct filter_rule **rule_ptrs,
+	uint32_t rule_count,
+	struct memory_context *mctx,
+	long fail_at,
+	struct filter *filter
+) {
+	filter_test_oom_calls = 0;
+	filter_test_oom_fail_at = fail_at;
+	filter_test_oom_armed = 1;
+
+	int rc = filter_init(
+		filter, compiler, rule_ptrs, rule_count, mctx, NULL
+	);
+
+	filter_test_oom_armed = 0;
+	filter_test_oom_fail_at = -1;
+
+	return rc;
+}
+
+typedef void (*sweep_build_func)(
+	struct filter_rule_builder *builders,
+	struct filter_rule *rules,
+	const struct filter_rule **rule_ptrs,
+	uint32_t rule_count
+);
+
+// Same checks as TEST_ASSERT_SUCCESS/TEST_ASSERT_EQUAL, but jump to the
+// sweep's single cleanup exit instead of returning directly, so the arena
+// allocated further up in sweep_signature is always freed.
+#define SWEEP_ASSERT_SUCCESS(value, msg, ...)                                  \
+	do {                                                                   \
+		if ((value) != TEST_SUCCESS) {                                 \
+			LOG(ERROR, "ASSERT FAILED: " msg, ##__VA_ARGS__);      \
+			goto out;                                              \
+		}                                                              \
+	} while (0)
+
+#define SWEEP_ASSERT_EQUAL(a, b, msg, ...)                                     \
+	do {                                                                   \
+		if ((a) != (b)) {                                              \
+			LOG(ERROR,                                             \
+			    "ASSERT FAILED: " msg                              \
+			    " (expected: %ld, got: %ld)",                      \
+			    ##__VA_ARGS__,                                     \
+			    (long)(b),                                         \
+			    (long)(a));                                        \
+			goto out;                                              \
+		}                                                              \
+	} while (0)
+
+// Verifies that injecting a single allocation failure at every call the
+// compiler makes, for one attribute signature, always leaves filter_init
+// reporting a clean -1 and never crashes.
+static int
+sweep_signature(
+	const char *name,
+	const struct filter_compiler *compiler,
+	sweep_build_func build
+) {
+	static struct filter_rule_builder builders[SWEEP_RULE_COUNT];
+	static struct filter_rule rules[SWEEP_RULE_COUNT];
+	static const struct filter_rule *rule_ptrs[SWEEP_RULE_COUNT];
+	build(builders, rules, rule_ptrs, SWEEP_RULE_COUNT);
+
+	uint8_t *arena = malloc(SWEEP_ARENA_SIZE);
+	TEST_ASSERT_NOT_NULL(
+		arena, "%s: failed to allocate the sweep arena", name
+	);
+
+	int result = TEST_FAILED;
+
+	struct block_allocator allocator;
+	struct memory_context mctx;
+	SWEEP_ASSERT_SUCCESS(
+		sweep_reset_fixture(arena, SWEEP_ARENA_SIZE, &allocator, &mctx),
+		"%s: failed to reset the sweep fixture",
+		name
+	);
+
+	struct filter filter;
+	int rc = sweep_compile(
+		compiler, rule_ptrs, SWEEP_RULE_COUNT, &mctx, -1, &filter
+	);
+	SWEEP_ASSERT_EQUAL(rc, 0, "%s: clean compile failed", name);
+	long total_calls = filter_test_oom_calls;
+	filter_free(&filter, compiler);
+
+	LOG(INFO, "%s: sweeping %ld allocation points", name, total_calls);
+
+	for (long fail_at = 0; fail_at < total_calls; ++fail_at) {
+		SWEEP_ASSERT_SUCCESS(
+			sweep_reset_fixture(
+				arena, SWEEP_ARENA_SIZE, &allocator, &mctx
+			),
+			"%s: failed to reset the sweep fixture for call %ld",
+			name,
+			fail_at
+		);
+
+		struct filter failed_filter;
+		int frc = sweep_compile(
+			compiler,
+			rule_ptrs,
+			SWEEP_RULE_COUNT,
+			&mctx,
+			fail_at,
+			&failed_filter
+		);
+		SWEEP_ASSERT_EQUAL(
+			frc,
+			-1,
+			"%s: injecting a failure at call %ld did not produce "
+			"a clean OOM",
+			name,
+			fail_at
+		);
+	}
+
+	result = TEST_SUCCESS;
+
+out:
+	// The last iteration leaves the arena ASan-poisoned; the allocator
+	// requires manually poisoned memory to be unpoisoned before free.
+	asan_unpoison_memory_region(arena, SWEEP_ARENA_SIZE);
+	free(arena);
+
+	return result;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	size_t tests = 0;
+	size_t failed = 0;
+
+	++tests;
+	if (sweep_signature(
+		    "net6-src", sign_net6_src_compile, build_net6_src_rules
+	    )) {
+		LOG(ERROR, "net6-src sweep failed");
+		++failed;
+	}
+
+	++tests;
+	if (sweep_signature(
+		    "net4-src", sign_net4_src_compile, build_net4_src_rules
+	    )) {
+		LOG(ERROR, "net4-src sweep failed");
+		++failed;
+	}
+
+	++tests;
+	if (sweep_signature("ports", sign_ports_compile, build_ports_rules)) {
+		LOG(ERROR, "ports sweep failed");
+		++failed;
+	}
+
+	++tests;
+	if (sweep_signature(
+		    "net4-ports",
+		    sign_net4_ports_compile,
+		    build_net4_ports_rules
+	    )) {
+		LOG(ERROR, "net4-ports sweep failed");
+		++failed;
+	}
+
+	if (failed == 0) {
+		LOG(INFO, "All %zu OOM sweeps passed", tests);
+	} else {
+		LOG(ERROR, "%zu/%zu OOM sweeps failed", failed, tests);
+	}
+
+	return failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The filter compiler dropped the failure return of several allocating helpers. A failed allocation mid-compile then either dereferenced a wild pointer or, worse, let the compile report success while producing a filter that classifies traffic differently. On an ACL that is a silent policy change under memory pressure.

Injecting a single allocation failure at each of the 295 allocations three representative compiles make produced 131 segmentation faults and 18 successful compiles whose filter answered differently from a clean build. This change propagates every dropped return through the existing unwind paths, so an exhausted arena always ends in a clean error instead.

The compiler also treated a legitimate remap-table result as a failure while merging registries. That was dormant only because the enclosing join discarded its callback's return, and had to be corrected alongside it.

Adds a regression test that recompiles a fixed rule set once per allocation the compiler makes, forcing that one allocation to fail, and requires a clean error every time. It runs over four attribute signatures and poisons the arena between iterations, since a recycled arena is what makes the wild reads fatal in production. A plain undersized-arena test is not enough here: the block allocator fails monotonically in request size, so arena starvation alone never reaches these paths.
