### PR TITLE
refactor(xbackoff): drop dead write-only configuration fields

### DIFF
--- a/common/go/xbackoff/backoff.go
+++ b/common/go/xbackoff/backoff.go
@@ -70,13 +70,9 @@ func WithOnReset(f func()) Option {
 // Backoff is a retry helper with exponential delay and a pluggable
 // wait strategy.
 type Backoff struct {
-	initial    time.Duration
-	max        time.Duration
-	multiplier float64
-	jitter     float64
-	sleeper    Sleeper
-	onRetry    func(attempt int, delay time.Duration, err error)
-	onReset    func()
+	sleeper Sleeper
+	onRetry func(attempt int, delay time.Duration, err error)
+	onReset func()
 
 	inner   backoff.ExponentialBackOff
 	attempt int
@@ -90,13 +86,9 @@ func New(initial time.Duration, options ...Option) *Backoff {
 	}
 
 	m := &Backoff{
-		initial:    initial,
-		max:        opts.Max,
-		multiplier: opts.Multiplier,
-		jitter:     opts.Jitter,
-		sleeper:    opts.Sleeper,
-		onRetry:    opts.OnRetry,
-		onReset:    opts.OnReset,
+		sleeper: opts.Sleeper,
+		onRetry: opts.OnRetry,
+		onReset: opts.OnReset,
 		inner: backoff.ExponentialBackOff{
 			InitialInterval:     initial,
 			RandomizationFactor: opts.Jitter,


### PR DESCRIPTION
- Removed the four private interval, cap, multiplier and jitter fields from the retry helper: each was assigned once at construction and never read afterwards.
- The embedded exponential backoff already holds these values and is the only thing the retry timing consults, so the deletion is behaviorally inert and leaves a single place where the configuration is set.
- Motivation is readability rather than a bug: the duplicated state invited a future reader to trust one of the copies, or to "fix" it with no effect on the actual retry schedule.
