### PR TITLE
fix(acl): create one module handle per distinct linked config name

### DIFF
--- a/modules/acl/controlplane/acl_adapter.go
+++ b/modules/acl/controlplane/acl_adapter.go
@@ -63,9 +63,9 @@ func (m *ACLAdapter) RelinkConfigs(
 			return err
 		}
 
-		ffiCfgs := make([]ffi.ModuleConfig, 0, len(linked))
-		for _, name := range linked {
-			ffiCfgs = append(ffiCfgs, newHandles[name].AsFFIModule())
+		ffiCfgs := make([]ffi.ModuleConfig, 0, len(newHandles))
+		for _, h := range newHandles {
+			ffiCfgs = append(ffiCfgs, h.AsFFIModule())
 		}
 
 		if err := publish(ffiCfgs); err != nil {
@@ -101,9 +101,9 @@ func (m *ACLAdapter) LinkConfigs(
 			return err
 		}
 
-		ffiCfgs := make([]ffi.ModuleConfig, 0, len(names))
-		for _, name := range names {
-			ffiCfgs = append(ffiCfgs, newHandles[name].AsFFIModule())
+		ffiCfgs := make([]ffi.ModuleConfig, 0, len(newHandles))
+		for _, h := range newHandles {
+			ffiCfgs = append(ffiCfgs, h.AsFFIModule())
 		}
 
 		if err := publish(ffiCfgs); err != nil {
@@ -214,9 +214,12 @@ func (m *ACLService) swapLinkedHandles(newHandles map[string]ModuleHandle, entri
 	}
 }
 
-// createLinkedHandles creates new ACL module handles for every name in
-// names, linked to fwstateConfig. On any failure every handle created so far
-// is freed before returning the error.
+// createLinkedHandles creates one new ACL module handle per distinct name in
+// names, linked to fwstateConfig.
+//
+// names may repeat a name, in which case the returned map still holds one
+// handle for it. On any failure every handle created so far is freed before
+// returning the error.
 //
 // Caller must hold the name lock for every name in names, and entries must
 // carry that name's entry.
@@ -228,6 +231,10 @@ func (m *ACLService) createLinkedHandles(
 	newHandles := map[string]ModuleHandle{}
 
 	for _, name := range names {
+		if _, ok := newHandles[name]; ok {
+			continue
+		}
+
 		entry, ok := entries[name]
 		if !ok || entry.published == nil {
 			for _, h := range newHandles {

--- a/modules/acl/controlplane/service_test.go
+++ b/modules/acl/controlplane/service_test.go
@@ -1189,3 +1189,47 @@ func TestACLAdapterLinkConfigs_TombstonedName(t *testing.T) {
 	err = adapter.LinkConfigs([]string{"a"}, fwstateConfig, publish)
 	require.ErrorContains(t, err, "not found")
 }
+
+// TestACLAdapterLinkConfigs_DuplicateName verifies that a name repeated in
+// the LinkConfigs list creates and publishes exactly one handle for it,
+// instead of leaking the handle a naive per-occurrence loop would create
+// and then drop.
+func TestACLAdapterLinkConfigs_DuplicateName(t *testing.T) {
+	backend := newFakeBackend(0)
+	svc := newTestService(backend)
+	adapter := NewACLAdapter(svc)
+
+	_, err := svc.UpdateConfig(t.Context(), &aclpb.UpdateConfigRequest{
+		Name:  "a",
+		Rules: []*aclpb.Rule{{Actions: []*aclpb.Action{{Kind: aclpb.ActionKind_ACTION_KIND_PASS}}}},
+	})
+	require.NoError(t, err)
+
+	createdBefore := len(backend.CreatedHandles())
+
+	fwstateConfig := &fwstate.FwStateConfig{ModuleConfig: &cfwstate.ModuleConfig{}}
+
+	var publishedCount int
+	publish := func(linkedFFI []ffi.ModuleConfig) error {
+		publishedCount = len(linkedFFI)
+		return nil
+	}
+
+	err = adapter.LinkConfigs([]string{"a", "a"}, fwstateConfig, publish)
+	require.NoError(t, err)
+
+	assert.Equal(t, createdBefore+1, len(backend.CreatedHandles()), "a duplicated name must create exactly one handle")
+	assert.Equal(t, 1, publishedCount, "a duplicated name must publish exactly one module config")
+
+	svc.mu.RLock()
+	liveHandle := svc.configs["a"].published.acl
+	svc.mu.RUnlock()
+
+	for _, h := range backend.CreatedHandles() {
+		if h == liveHandle {
+			assert.Equal(t, 0, h.FreeCount(), "the live handle must not have been freed")
+			continue
+		}
+		assert.Equal(t, 1, h.FreeCount(), "every superseded handle must be freed exactly once")
+	}
+}


### PR DESCRIPTION
- Create one ACL module handle per distinct config name when linking a fwstate config to a list of names, instead of one per list position.
- A name repeated in that list previously allocated two handles in shared memory, tracked only the second, and leaked the first; the same repeat also published the same module configuration twice in a single dataplane update.
- Keep the invariant with the function that depends on it rather than only with today's single caller, which rejects a repeated name before it reaches this path — so no live path is affected today, and the next caller cannot reintroduce the leak by forgetting that guard.
- Add a regression test asserting that a repeated name creates exactly one handle, publishes exactly one module configuration, and leaves no handle unfreed.
