### PR TITLE
fix(forward): describe mode as target queue selection in web drawer

### DIFF
--- a/modules/forward/web/DirectionBadge.tsx
+++ b/modules/forward/web/DirectionBadge.tsx
@@ -8,7 +8,7 @@ interface DirectionBadgeProps {
     mode: ForwardMode;
 }
 
-/** Colored pill badge showing direction mode (IN / OUT / NONE) with equal width. */
+/** Colored pill badge showing forwarding mode (IN / OUT / NONE) with equal width. */
 const DirectionBadge: React.FC<DirectionBadgeProps> = ({ mode }) => {
     let cls = 'yn-badge-dir';
     if (mode === ForwardMode.IN) cls += ' yn-badge-dir--in';

--- a/modules/forward/web/RuleDrawer.tsx
+++ b/modules/forward/web/RuleDrawer.tsx
@@ -137,11 +137,11 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                 value={draft.target}
                                 onChange={(e) => updateField('target', e.target.value)}
                             />
-                            <span className="yn-field__hint">Output target device matched traffic is forwarded to.</span>
+                            <span className="yn-field__hint">Target device of the rule. Matched packets are dropped if no device with this name exists.</span>
                         </div>
                         <div className="yn-field">
                             <label className="yn-field__label">Mode</label>
-                            <div className="yn-segmented" role="radiogroup" aria-label="Direction mode">
+                            <div className="yn-segmented" role="radiogroup" aria-label="Forwarding mode">
                                 {modeOptions.map((opt) => (
                                     <button
                                         key={opt.value}
@@ -156,9 +156,9 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                                 ))}
                             </div>
                             <span className="yn-field__hint">
-                                {draft.mode === ForwardMode.IN && 'Match traffic entering the device.'}
-                                {draft.mode === ForwardMode.OUT && 'Match traffic exiting the device.'}
-                                {draft.mode === ForwardMode.NONE && 'Match without direction binding.'}
+                                {draft.mode === ForwardMode.IN && 'Matched packets are scheduled to the input path of the target device.'}
+                                {draft.mode === ForwardMode.OUT && 'Matched packets are scheduled to the output path of the target device.'}
+                                {draft.mode === ForwardMode.NONE && 'Matched packets stay on the chain and go to the next module. The target is still resolved.'}
                             </span>
                         </div>
                     </div>


### PR DESCRIPTION
- Reword the rule drawer mode hints so they describe what happens after a rule matches: the packet is scheduled to the input or output path of the target device, or stays on the chain for the next module.
- Drop the direction-as-match-criterion wording, which taught operators the wrong mental model of both the filter and the resulting pipeline traversal.
- Restate the target field hint around the condition the packet path actually checks, since a matched packet is dropped when no device with that name exists rather than when the device is outside the current pipeline.
- Rename the segmented control accessible label from direction to forwarding mode to match the visible field.
