### PR TITLE
refactor(modules): let each config release its own module handle

### DIFF
--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -170,8 +170,6 @@ private:modules/acl/controlplane/aclpb/v1/convert.go:ToActions:action.toCAclKind
 private:modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:m.metricsState.load:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:snapshot.configInfo:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:config.acl:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:config.acl:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:config.acl:3  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:entry.published:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:entry.published:2  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.ListConfigs:entry.published:1  # legacy: encapsulate behind an exported method or field
@@ -183,8 +181,6 @@ private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.publishe
 private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:entry.published:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:entry.published:2  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.acl:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.acl:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.acl:3  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.fwstateName:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.rules:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:entry.published.acl:1  # acl metrics snapshot: encapsulate behind an exported method or field

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -87,6 +87,15 @@ type aclConfig struct {
 	fwstateName string
 }
 
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *aclConfig) Free() {
+	if m.acl != nil {
+		m.acl.Free()
+	}
+}
+
 // configEntry holds the per-name state that lives outside m.mu: the lock
 // serializing mutations of one config name, and the currently published
 // config for that name.
@@ -489,8 +498,8 @@ func (m *ACLService) UpdateConfig(
 		m.publishMetricsSnapshotLocked()
 		m.mu.Unlock()
 
-		if oldConfig != nil && oldConfig.acl != nil {
-			oldConfig.acl.Free()
+		if oldConfig != nil {
+			oldConfig.Free()
 		}
 
 		resp = &aclpb.UpdateConfigResponse{}
@@ -591,9 +600,7 @@ func (m *ACLService) DeleteConfig(
 		m.publishMetricsSnapshotLocked()
 		m.mu.Unlock()
 
-		if config.acl != nil {
-			config.acl.Free()
-		}
+		config.Free()
 
 		return nil
 	})

--- a/modules/blackhole/controlplane/service.go
+++ b/modules/blackhole/controlplane/service.go
@@ -30,6 +30,15 @@ type config struct {
 	Module ModuleHandle
 }
 
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *config) Free() {
+	if m.Module != nil {
+		m.Module.Free()
+	}
+}
+
 // BlackholeService implements the BlackholeService gRPC server.
 type BlackholeService struct {
 	blackholepb.UnimplementedBlackholeServiceServer
@@ -117,8 +126,8 @@ func (m *BlackholeService) updateConfig(name string) error {
 		return err
 	}
 
-	if old, ok := m.configs[name]; ok && old.Module != nil {
-		old.Module.Free()
+	if old, ok := m.configs[name]; ok {
+		old.Free()
 	}
 
 	m.configs[name] = &config{Module: mod}
@@ -152,9 +161,7 @@ func (m *BlackholeService) DeleteConfig(
 		)
 	}
 
-	if entry.Module != nil {
-		entry.Module.Free()
-	}
+	entry.Free()
 
 	delete(m.configs, name)
 

--- a/modules/decap/controlplane/service.go
+++ b/modules/decap/controlplane/service.go
@@ -35,6 +35,15 @@ type config struct {
 	Module   ModuleHandle
 }
 
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *config) Free() {
+	if m.Module != nil {
+		m.Module.Free()
+	}
+}
+
 // DecapService implements the DecapService gRPC server.
 type DecapService struct {
 	decappb.UnimplementedDecapServiceServer
@@ -145,8 +154,8 @@ func (m *DecapService) updateConfig(name string, cfg *config) error {
 		return fmt.Errorf("failed to update module config %q: %w", name, err)
 	}
 
-	if old, ok := m.configs[name]; ok && old.Module != nil {
-		old.Module.Free()
+	if old, ok := m.configs[name]; ok {
+		old.Free()
 	}
 
 	m.configs[name] = &config{

--- a/modules/dscp/controlplane/service.go
+++ b/modules/dscp/controlplane/service.go
@@ -39,6 +39,15 @@ type config struct {
 	Module   ModuleHandle
 }
 
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *config) Free() {
+	if m.Module != nil {
+		m.Module.Free()
+	}
+}
+
 func (m *config) Clone() *config {
 	return &config{
 		Prefixes: slices.Clone(m.Prefixes),
@@ -237,9 +246,7 @@ func (m *DscpService) updateModuleConfig(name string, cfg *config) error {
 		return err
 	}
 
-	if cfg.Module != nil {
-		cfg.Module.Free()
-	}
+	cfg.Free()
 
 	m.configs[name] = &config{
 		Prefixes: cfg.Prefixes,

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -35,6 +35,15 @@ type forwardConfig struct {
 	Module ModuleHandle
 }
 
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *forwardConfig) Free() {
+	if m.Module != nil {
+		m.Module.Free()
+	}
+}
+
 type ForwardService struct {
 	forwardpb.UnimplementedForwardServiceServer
 
@@ -162,7 +171,7 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 	}
 
 	if oldModule, ok := m.configs[name]; ok {
-		oldModule.Module.Free()
+		oldModule.Free()
 	}
 
 	m.configs[name] = forwardConfig{
@@ -191,9 +200,7 @@ func (m *ForwardService) DeleteConfig(ctx context.Context, req *forwardpb.Delete
 		return nil, fmt.Errorf("failed to delete module config %q: %w", name, err)
 	}
 
-	if config.Module != nil {
-		config.Module.Free()
-	}
+	config.Free()
 
 	delete(m.configs, name)
 

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -33,6 +33,19 @@ func (m *mockBackend) ModuleCounters(name string, counterNames []string) []forwa
 	return nil
 }
 
+// nilHandleBackend is a Backend whose UpdateModule publishes a config
+// carrying no module handle.
+//
+// It models a Backend that reports success without producing a handle,
+// which is the case the config's own nil guard exists to survive.
+type nilHandleBackend struct {
+	mockBackend
+}
+
+func (m *nilHandleBackend) UpdateModule(name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
+	return nil, nil
+}
+
 // TestShowConfigUnknownConfig verifies that ShowConfig reports NotFound for
 // a config name that was never applied.
 func TestShowConfigUnknownConfig(t *testing.T) {
@@ -76,6 +89,18 @@ func TestUpdateConfigNilAction(t *testing.T) {
 		},
 	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+// TestUpdateConfigReplacesConfigWithoutHandle verifies that replacing a
+// config that holds no module handle releases it without panicking.
+func TestUpdateConfigReplacesConfigWithoutHandle(t *testing.T) {
+	svc := forward.NewForwardService(&nilHandleBackend{})
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{Name: "config"})
+	require.NoError(t, err)
+
+	_, err = svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{Name: "config"})
+	require.NoError(t, err)
 }
 
 // Run with: go test -race

--- a/modules/mirror/controlplane/service.go
+++ b/modules/mirror/controlplane/service.go
@@ -32,6 +32,15 @@ type mirrorConfig struct {
 	Module ModuleHandle
 }
 
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *mirrorConfig) Free() {
+	if m.Module != nil {
+		m.Module.Free()
+	}
+}
+
 type MirrorService struct {
 	mirrorpb.UnimplementedMirrorServiceServer
 
@@ -165,7 +174,7 @@ func (m *MirrorService) UpdateConfig(
 	}
 
 	if oldModule, ok := m.configs[name]; ok {
-		oldModule.Module.Free()
+		oldModule.Free()
 	}
 
 	m.configs[name] = mirrorConfig{
@@ -197,9 +206,7 @@ func (m *MirrorService) DeleteConfig(
 		return nil, fmt.Errorf("failed to delete module config %q: %w", name, err)
 	}
 
-	if config.Module != nil {
-		config.Module.Free()
-	}
+	config.Free()
 
 	delete(m.configs, name)
 

--- a/modules/mirror/controlplane/service_test.go
+++ b/modules/mirror/controlplane/service_test.go
@@ -32,6 +32,22 @@ func (m *mockBackend) DeleteModule(name string) error {
 	return nil
 }
 
+// nilHandleBackend is a Backend whose UpdateModule publishes a config
+// carrying no module handle.
+//
+// It models a Backend that reports success without producing a handle,
+// which is the case the config's own nil guard exists to survive.
+type nilHandleBackend struct {
+	mockBackend
+}
+
+func (m *nilHandleBackend) UpdateModule(
+	name string,
+	rules []cmirror.MirrorRule,
+) (mirror.ModuleHandle, error) {
+	return nil, nil
+}
+
 // TestShowConfigUnknownConfig verifies that ShowConfig reports NotFound for
 // a config name that was never applied.
 func TestShowConfigUnknownConfig(t *testing.T) {
@@ -61,6 +77,18 @@ func TestShowConfigEmptyRules(t *testing.T) {
 	response, err := svc.ShowConfig(t.Context(), &mirrorpb.ShowConfigRequest{Name: "empty"})
 	require.NoError(t, err)
 	require.Empty(t, response.GetRules())
+}
+
+// TestUpdateConfigReplacesConfigWithoutHandle verifies that replacing a
+// config that holds no module handle releases it without panicking.
+func TestUpdateConfigReplacesConfigWithoutHandle(t *testing.T) {
+	svc := mirror.NewMirrorService(&nilHandleBackend{})
+
+	_, err := svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{Name: "config"})
+	require.NoError(t, err)
+
+	_, err = svc.UpdateConfig(t.Context(), &mirrorpb.UpdateConfigRequest{Name: "config"})
+	require.NoError(t, err)
 }
 
 // Run with: go test -race

--- a/modules/nat64/controlplane/service.go
+++ b/modules/nat64/controlplane/service.go
@@ -52,6 +52,15 @@ type config struct {
 	Module ModuleHandle
 }
 
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *config) Free() {
+	if m.Module != nil {
+		m.Module.Free()
+	}
+}
+
 func (m config) Clone() config {
 	return config{
 		Config: m.Config.Clone(),
@@ -389,9 +398,7 @@ func (m *NAT64Service) updateModuleConfig(name string, inst config) error {
 		return err
 	}
 
-	if inst.Module != nil {
-		inst.Module.Free()
-	}
+	inst.Free()
 	inst.Module = module
 	m.configs[name] = inst
 

--- a/modules/pdump/controlplane/service.go
+++ b/modules/pdump/controlplane/service.go
@@ -49,6 +49,15 @@ type pdumpConfig struct {
 	FFIModule *ModuleConfig // FFI module configuration that needs to be freed when replaced
 }
 
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *pdumpConfig) Free() {
+	if m.FFIModule != nil {
+		m.FFIModule.Free()
+	}
+}
+
 type ringReader struct {
 	Name   string
 	Ring   *ringBuffer
@@ -243,7 +252,7 @@ func (m *PdumpService) DeleteConfig(
 		if err := m.agent.DeleteModuleConfig(name); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
 		}
-		config.FFIModule.Free()
+		config.Free()
 	}
 
 	delete(m.configs, name)
@@ -339,8 +348,8 @@ func (m *PdumpService) updateModuleConfig(
 	}
 
 	// Free old FFI module after successful update
-	if modConfig != nil && modConfig.FFIModule != nil {
-		modConfig.FFIModule.Free()
+	if modConfig != nil {
+		modConfig.Free()
 	}
 
 	// Update the stored FFI module reference

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -58,6 +58,15 @@ type configEntry struct {
 	UpdatedAt time.Time
 }
 
+// Free releases the module handle held by the config.
+//
+// It is safe to call even when no handle is held.
+func (m *configEntry) Free() {
+	if m.Handle != nil {
+		m.Handle.Free()
+	}
+}
+
 // RouteService is the gRPC service implementation backing the slim
 // route-module shim.
 type RouteService struct {
@@ -234,7 +243,7 @@ func (m *RouteService) DeleteConfig(
 	if err := m.backend.DeleteModule(name); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
 	}
-	entry.Handle.Free()
+	entry.Free()
 	delete(m.configs, name)
 
 	return &routepb.DeleteConfigResponse{}, nil
@@ -259,7 +268,7 @@ func (m *RouteService) UpdateFIB(
 	}
 
 	if old, ok := m.configs[name]; ok {
-		old.Handle.Free()
+		old.Free()
 	}
 
 	// The counts are read once, here, off the handle just published: the


### PR DESCRIPTION
- Give every module control-plane config type that owns a dataplane module handle a method that releases the handle behind its own nil guard, and route every call site through it. Nine modules adopt the shape that route-mpls already had.
- Remove a divergence in forward and mirror, where replacing a config released the old handle unconditionally while deleting one guarded the identical release. Under a config that holds no handle the two paths would have behaved differently — one failing loudly, the other silently doing nothing. They now agree.
- Add the same guard to route, whose two release sites both lacked one.
- Retire four encapsulation-allowlist rows in acl, whose release sites reached into a private field.
- Cover the replace-a-handleless-config path with a regression test in forward and mirror, the two modules whose guard is new. Both were confirmed to fail without the change and pass with it.
