### PR TITLE
fix(dataplane): apply wire-format masks in the correct byte order

### DIFF
--- a/lib/dataplane/packet/decap.c
+++ b/lib/dataplane/packet/decap.c
@@ -34,7 +34,7 @@ packet_skip_gre(struct packet *packet, uint16_t *type, uint16_t *offset) {
 
 	uint32_t gre_hdr_u32;
 	rte_memcpy(&gre_hdr_u32, gre_hdr, sizeof(uint32_t));
-	if ((gre_hdr_u32 & 0x0000FF4F) != 0x00000000) {
+	if ((gre_hdr_u32 & RTE_BE32(0x4FFF0000)) != 0x00000000) {
 		// If any reserved bits or a version is set
 		return -1;
 	}

--- a/lib/dataplane/packet/packet.c
+++ b/lib/dataplane/packet/packet.c
@@ -92,11 +92,13 @@ parse_ipv4_header(struct packet *packet, uint16_t *type, uint16_t *offset) {
 	packet->hash = crc32(&ipv4_hdr->src_addr, 4, packet->hash);
 	packet->hash = crc32(&ipv4_hdr->dst_addr, 4, packet->hash);
 
-	if ((ipv4_hdr->fragment_offset & 0xFF3F) != 0) {
+	if ((ipv4_hdr->fragment_offset &
+	     RTE_BE16(RTE_IPV4_HDR_MF_FLAG | RTE_IPV4_HDR_OFFSET_MASK)) != 0) {
 		packet->flags |= 1 << PACKET_FLAG_FRAGMENTED;
 
 		packet->fragment_offset =
-			rte_be_to_cpu_16(ipv4_hdr->fragment_offset & 0xFF1F);
+			rte_be_to_cpu_16(ipv4_hdr->fragment_offset) &
+			RTE_IPV4_HDR_OFFSET_MASK;
 	}
 
 	// FIXME: process extensions
@@ -177,11 +179,12 @@ parse_ipv6_header(struct packet *packet, uint16_t *type, uint16_t *offset) {
 					*offset
 				);
 
-			if ((ext->offset_flag & 0xF9FF) != 0x0000) {
+			if ((ext->offset_flag &
+			     RTE_BE16(RTE_IPV6_FRAG_USED_MASK)) != 0x0000) {
 				packet->flags |= 1 << PACKET_FLAG_FRAGMENTED;
-				packet->fragment_offset = rte_be_to_cpu_16(
-					ext->offset_flag & 0xF8FF
-				);
+				packet->fragment_offset =
+					rte_be_to_cpu_16(ext->offset_flag) &
+					RTE_IPV6_EHDR_FO_MASK;
 			}
 
 			ext_type = ext->next_header;

--- a/lib/tests/dataplane/meson.build
+++ b/lib/tests/dataplane/meson.build
@@ -28,6 +28,21 @@ gre_test = executable(
 )
 test('gre', gre_test, suite: 'lib_packet')
 
+parse_frag_test = executable(
+  'parse_frag_test',
+  'parse_frag_test.c',
+  c_args: yanet_c_args,
+  link_args: yanet_link_args,
+  dependencies: [
+    lib_packet_dp_dep,
+    lib_lib_utils_dep,
+    lib_logging_dep,
+    libdpdk_dep,
+  ],
+  include_directories: yanet_rootdir,
+)
+test('parse_frag', parse_frag_test, suite: 'lib_packet')
+
 encap_dscp_test = executable(
   'encap_dscp_test',
   'encap_dscp_test.c',

--- a/lib/tests/dataplane/parse_frag_test.c
+++ b/lib/tests/dataplane/parse_frag_test.c
@@ -1,0 +1,362 @@
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <rte_byteorder.h>
+#include <rte_ether.h>
+#include <rte_gre.h>
+#include <rte_ip.h>
+#include <rte_mbuf.h>
+#include <rte_udp.h>
+
+#include "common/network.h"
+#include "common/test_assert.h"
+
+#include "lib/dataplane/packet/decap.h"
+#include "lib/dataplane/packet/encap.h"
+#include "lib/dataplane/packet/packet.h"
+#include "lib/logging/log.h"
+#include "lib/utils/packet.h"
+
+#define DEFAULT_HEADROOM 128
+#define DEFAULT_TAILROOM 256
+
+// Room for a UDP header plus a few bytes, so parse_packet reaches the
+// transport layer instead of bailing out on a truncated header.
+#define PAYLOAD_LEN (sizeof(struct rte_udp_hdr) + 8)
+
+#define TTL 64
+
+static const uint8_t src4[NET4_LEN] = {192, 168, 1, 1};
+static const uint8_t dst4[NET4_LEN] = {192, 168, 1, 2};
+
+static const uint8_t outer_src4[NET4_LEN] = {10, 0, 0, 1};
+static const uint8_t outer_dst4[NET4_LEN] = {10, 0, 0, 2};
+
+static const uint8_t src6[NET6_LEN] = {
+	0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+};
+static const uint8_t dst6[NET6_LEN] = {
+	0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2
+};
+
+// Builds eth + IPv4 + UDP-sized payload carrying the given raw fragment field
+// and runs parse_packet on it.
+static int
+build_ip4(struct packet *p, uint16_t fragment_offset_host) {
+	uint16_t pkt_len = sizeof(struct rte_ether_hdr) +
+			   sizeof(struct rte_ipv4_hdr) + PAYLOAD_LEN;
+	memset(p, 0, sizeof(*p));
+	p->mbuf = alloc_mbuf(DEFAULT_HEADROOM, pkt_len, DEFAULT_TAILROOM);
+	if (p->mbuf == NULL) {
+		return -1;
+	}
+
+	struct rte_ether_hdr *eth =
+		rte_pktmbuf_mtod(p->mbuf, struct rte_ether_hdr *);
+	eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4);
+
+	struct rte_ipv4_hdr *ip4 = (struct rte_ipv4_hdr *)(eth + 1);
+	ip4->version_ihl = 0x45;
+	ip4->total_length = rte_cpu_to_be_16(sizeof(*ip4) + PAYLOAD_LEN);
+	ip4->fragment_offset = rte_cpu_to_be_16(fragment_offset_host);
+	ip4->time_to_live = TTL;
+	ip4->next_proto_id = IPPROTO_UDP;
+	memcpy(&ip4->src_addr, src4, NET4_LEN);
+	memcpy(&ip4->dst_addr, dst4, NET4_LEN);
+	ip4->hdr_checksum = 0;
+	ip4->hdr_checksum = rte_ipv4_cksum(ip4);
+
+	return parse_packet(p);
+}
+
+// Builds eth + IPv6 + optional fragment extension + UDP-sized payload and runs
+// parse_packet on it.
+static int
+build_ip6(struct packet *p, bool with_fragment, uint16_t offset_flag_host) {
+	uint16_t ext_len =
+		with_fragment ? sizeof(struct yanet_ipv6_ext_fragment) : 0;
+	uint16_t payload_len = ext_len + PAYLOAD_LEN;
+	uint16_t pkt_len = sizeof(struct rte_ether_hdr) +
+			   sizeof(struct rte_ipv6_hdr) + payload_len;
+	memset(p, 0, sizeof(*p));
+	p->mbuf = alloc_mbuf(DEFAULT_HEADROOM, pkt_len, DEFAULT_TAILROOM);
+	if (p->mbuf == NULL) {
+		return -1;
+	}
+
+	struct rte_ether_hdr *eth =
+		rte_pktmbuf_mtod(p->mbuf, struct rte_ether_hdr *);
+	eth->ether_type = rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6);
+
+	struct rte_ipv6_hdr *ip6 = (struct rte_ipv6_hdr *)(eth + 1);
+	ip6->vtc_flow = rte_cpu_to_be_32(0x6u << 28);
+	ip6->payload_len = rte_cpu_to_be_16(payload_len);
+	ip6->proto = with_fragment ? IPPROTO_FRAGMENT : IPPROTO_UDP;
+	ip6->hop_limits = TTL;
+	memcpy(ip6->src_addr, src6, NET6_LEN);
+	memcpy(ip6->dst_addr, dst6, NET6_LEN);
+
+	if (with_fragment) {
+		struct yanet_ipv6_ext_fragment *ext =
+			(struct yanet_ipv6_ext_fragment *)(ip6 + 1);
+		ext->next_header = IPPROTO_UDP;
+		ext->reserved = 0;
+		ext->offset_flag = rte_cpu_to_be_16(offset_flag_host);
+		ext->identification = rte_cpu_to_be_32(0xdeadbeef);
+	}
+
+	return parse_packet(p);
+}
+
+// Builds an IPv4-in-GRE-in-IPv4 packet parsed down to its outer headers.
+//
+// Prepending the tunnel leaves transport_header describing the inner UDP
+// header, so the frame is parsed again to make transport_header name the outer
+// GRE header, which is what packet_decap and pkt_gre read.
+static int
+build_gre_encapped(struct packet *p) {
+	if (build_ip4(p, 0) != 0) {
+		return -1;
+	}
+	if (packet_ip4_encap_gre(p, outer_dst4, outer_src4) != 0) {
+		return -1;
+	}
+	return parse_packet(p);
+}
+
+static struct rte_gre_hdr *
+pkt_gre(struct packet *p) {
+	return rte_pktmbuf_mtod_offset(
+		p->mbuf, struct rte_gre_hdr *, p->transport_header.offset
+	);
+}
+
+static int
+assert_fragment_state(
+	const struct packet *p, int expect_fragmented, uint16_t expect_offset
+) {
+	TEST_ASSERT_EQUAL(
+		(p->flags >> PACKET_FLAG_FRAGMENTED) & 1,
+		expect_fragmented,
+		"PACKET_FLAG_FRAGMENTED"
+	);
+	TEST_ASSERT_EQUAL(p->fragment_offset, expect_offset, "fragment_offset");
+	return TEST_SUCCESS;
+}
+
+static int
+run_ip4_case(
+	uint16_t fragment_offset_host,
+	int expect_fragmented,
+	uint16_t expect_offset
+) {
+	struct packet p;
+	TEST_ASSERT_SUCCESS(build_ip4(&p, fragment_offset_host), "build");
+	TEST_ASSERT_SUCCESS(
+		assert_fragment_state(&p, expect_fragmented, expect_offset),
+		"fragment state"
+	);
+	free_packet(&p);
+	return TEST_SUCCESS;
+}
+
+static int
+run_ip6_case(
+	bool with_fragment,
+	uint16_t offset_flag_host,
+	int expect_fragmented,
+	uint16_t expect_offset
+) {
+	struct packet p;
+	TEST_ASSERT_SUCCESS(
+		build_ip6(&p, with_fragment, offset_flag_host), "build"
+	);
+	TEST_ASSERT_SUCCESS(
+		assert_fragment_state(&p, expect_fragmented, expect_offset),
+		"fragment state"
+	);
+	free_packet(&p);
+	return TEST_SUCCESS;
+}
+
+// Verifies that an IPv4 packet with an empty fragment field is not fragmented.
+static int
+test_ip4_plain(void) {
+	return run_ip4_case(0x0000, 0, 0);
+}
+
+// Verifies that the IPv4 Don't Fragment bit alone does not mark a packet as
+// fragmented, which is the ordinary case for most traffic.
+static int
+test_ip4_df_only(void) {
+	return run_ip4_case(RTE_IPV4_HDR_DF_FLAG, 0, 0);
+}
+
+// Verifies that the IPv4 More Fragments bit alone marks a packet as fragmented
+// at offset zero.
+static int
+test_ip4_mf_only(void) {
+	return run_ip4_case(RTE_IPV4_HDR_MF_FLAG, 1, 0);
+}
+
+// Verifies that a nonzero IPv4 fragment offset marks a packet as fragmented and
+// is reported in the header's own eight-byte units.
+static int
+test_ip4_offset_only(void) {
+	return run_ip4_case(185, 1, 185);
+}
+
+// Verifies that the IPv4 Don't Fragment bit is excluded from the reported
+// fragment offset.
+static int
+test_ip4_df_and_offset(void) {
+	return run_ip4_case(RTE_IPV4_HDR_DF_FLAG | 185, 1, 185);
+}
+
+// Verifies that an IPv6 packet without a fragment extension is not fragmented.
+static int
+test_ip6_no_extension(void) {
+	return run_ip6_case(false, 0x0000, 0, 0);
+}
+
+// Verifies that the IPv6 More Fragments bit alone marks a packet as fragmented
+// at offset zero.
+static int
+test_ip6_mf_only(void) {
+	return run_ip6_case(true, RTE_IPV6_EHDR_MF_MASK, 1, 0);
+}
+
+// Verifies that a nonzero IPv6 fragment offset marks a packet as fragmented and
+// is reported shifted in place, as a byte offset.
+static int
+test_ip6_offset_only(void) {
+	return run_ip6_case(true, 0x0BD0, 1, 0x0BD0);
+}
+
+// Verifies that the IPv6 fragment extension reserved bits are masked out, so a
+// packet carrying only those is not fragmented.
+static int
+test_ip6_reserved_only(void) {
+	return run_ip6_case(true, 0x0006, 0, 0);
+}
+
+// Verifies that a GRE header with cleared reserved bits and version is
+// accepted, and that the encapsulated packet is unwrapped.
+static int
+test_gre_accepted(void) {
+	struct packet p;
+	TEST_ASSERT_SUCCESS(build_gre_encapped(&p), "build");
+	TEST_ASSERT_EQUAL(
+		p.transport_header.type, IPPROTO_GRE, "outer transport is GRE"
+	);
+
+	TEST_ASSERT_EQUAL(packet_decap(&p), 0, "rc");
+	TEST_ASSERT_EQUAL(
+		p.network_header.type,
+		rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4),
+		"inner network type after decap"
+	);
+
+	free_packet(&p);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a GRE header carrying a nonzero version is rejected.
+static int
+test_gre_reject_ver(void) {
+	struct packet p;
+	TEST_ASSERT_SUCCESS(build_gre_encapped(&p), "build");
+	pkt_gre(&p)->ver = 1;
+	TEST_ASSERT_EQUAL(packet_decap(&p), -1, "rc");
+	free_packet(&p);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a GRE header carrying a nonzero res1 reserved bit is rejected.
+static int
+test_gre_reject_res1(void) {
+	struct packet p;
+	TEST_ASSERT_SUCCESS(build_gre_encapped(&p), "build");
+	pkt_gre(&p)->res1 = 1;
+	TEST_ASSERT_EQUAL(packet_decap(&p), -1, "rc");
+	free_packet(&p);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a GRE header carrying nonzero res2 reserved bits is rejected.
+static int
+test_gre_reject_res2(void) {
+	struct packet p;
+	TEST_ASSERT_SUCCESS(build_gre_encapped(&p), "build");
+	pkt_gre(&p)->res2 = 1;
+	TEST_ASSERT_EQUAL(packet_decap(&p), -1, "rc");
+	free_packet(&p);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a GRE header carrying nonzero res3 reserved bits is rejected.
+static int
+test_gre_reject_res3(void) {
+	struct packet p;
+	TEST_ASSERT_SUCCESS(build_gre_encapped(&p), "build");
+	pkt_gre(&p)->res3 = 1;
+	TEST_ASSERT_EQUAL(packet_decap(&p), -1, "rc");
+	free_packet(&p);
+	return TEST_SUCCESS;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	LOG(INFO, "=== Starting fragment and GRE mask test suite ===");
+
+	struct {
+		const char *name;
+		int (*fn)(void);
+	} tests[] = {
+		{"ip4_plain", test_ip4_plain},
+		{"ip4_df_only", test_ip4_df_only},
+		{"ip4_mf_only", test_ip4_mf_only},
+		{"ip4_offset_only", test_ip4_offset_only},
+		{"ip4_df_and_offset", test_ip4_df_and_offset},
+		{"ip6_no_extension", test_ip6_no_extension},
+		{"ip6_mf_only", test_ip6_mf_only},
+		{"ip6_offset_only", test_ip6_offset_only},
+		{"ip6_reserved_only", test_ip6_reserved_only},
+		{"gre_accepted", test_gre_accepted},
+		{"gre_reject_ver", test_gre_reject_ver},
+		{"gre_reject_res1", test_gre_reject_res1},
+		{"gre_reject_res2", test_gre_reject_res2},
+		{"gre_reject_res3", test_gre_reject_res3},
+	};
+
+	size_t total = sizeof(tests) / sizeof(tests[0]);
+	size_t failed = 0;
+
+	for (size_t i = 0; i < total; i++) {
+		LOG(INFO, "[%zu/%zu] running %s...", i + 1, total, tests[i].name
+		);
+		if (tests[i].fn() != TEST_SUCCESS) {
+			LOG(ERROR, "%s FAILED", tests[i].name);
+			failed++;
+		} else {
+			LOG(INFO, "%s passed", tests[i].name);
+		}
+	}
+
+	if (failed == 0) {
+		LOG(INFO,
+		    "=== All %zu fragment and GRE tests passed! ===",
+		    total);
+	} else {
+		LOG(ERROR,
+		    "=== %zu/%zu fragment and GRE tests failed ===",
+		    failed,
+		    total);
+	}
+
+	return failed == 0 ? TEST_SUCCESS : TEST_FAILED;
+}

--- a/modules/nat64/tests/dataplane/nat64_test.c
+++ b/modules/nat64/tests/dataplane/nat64_test.c
@@ -449,7 +449,8 @@ print_upkt(struct upkt *pkt) {
 		RTE_LOG(INFO,
 			NAT64_TEST,
 			"  Flags: 0x%01X\n",
-			(pkt->ip.ipv4.fragment_offset & 0x00E0) >> 5);
+			rte_be_to_cpu_16(pkt->ip.ipv4.fragment_offset) >>
+				RTE_IPV4_HDR_MF_SHIFT);
 		RTE_LOG(INFO,
 			NAT64_TEST,
 			"  Fragment Offset: %d\n",
@@ -764,7 +765,8 @@ print_rte_mbuf(struct rte_mbuf *mbuf) {
 		RTE_LOG(INFO,
 			NAT64_TEST,
 			"  Flags: 0x%01X\n",
-			(ipv4_hdr->fragment_offset & 0x00E0) >> 5);
+			rte_be_to_cpu_16(ipv4_hdr->fragment_offset) >>
+				RTE_IPV4_HDR_MF_SHIFT);
 		RTE_LOG(INFO,
 			NAT64_TEST,
 			"  Fragment Offset: %d\n",


### PR DESCRIPTION
Fragment classification for IPv4 and IPv6, and the GRE header validation on the decapsulation path, masked raw big-endian header fields with host-order constants. That selects the intended bits only on a little-endian host, where the literals happen to be the pre-swapped byte images.

On a big-endian host the same masks land on the wrong bits: an ordinary Don't-Fragment packet would be classified as a fragment, stripping two low bits off the fragment offset in the process, and every GRE packet would be rejected because the mask would fall on the protocol-type field instead of the reserved and version bits.

The mask constants are now byte-swapped at compile time from the names the vendored DPDK headers already define, so the same bits are selected on either byte order. Every one of them expands to the exact literal it replaces, which makes this change a provable no-op on the little-endian architectures currently targeted; the generated code is unchanged apart from one offset extraction moving to the far side of the byte swap.

A new unit test pins the classification behaviour so a future portability change cannot silently invert it: Don't-Fragment alone is not a fragment, More-Fragments alone is a fragment at offset zero, a non-zero offset is a fragment, the Don't-Fragment bit is excluded from the reported offset, the IPv6 fragment-extension reserved bits are ignored, and a GRE header is accepted only when its reserved bits and version are clear. Each case was confirmed to fail under a deliberate mutation of the constant it covers.

Two debug log lines in the nat64 dataplane test carried the last instances of the same pattern repo-wide and are corrected in the same change, leaving no header field anywhere in the dataplane that is masked before its byte swap.

Pre-existing and dormant on every architecture the project currently ships on.