### PR TITLE
fix(gateway): stop retrying permanent registration rejections

### DIFF
--- a/controlplane/gateway/registrar.go
+++ b/controlplane/gateway/registrar.go
@@ -9,7 +9,9 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/encoding/gzip"
+	"google.golang.org/grpc/status"
 
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 )
@@ -127,6 +129,26 @@ func (m *GatewayRegistrar) Endpoint() string {
 	return m.endpoint
 }
 
+// isPermanentRegisterError reports whether err is a rejection that retrying
+// the same Register call can never turn into success.
+//
+// Every retry resends a byte-identical request with the same (absent)
+// credentials, against a permission set the gateway loads once at startup,
+// so a rejection of the request's content or of the caller's identity
+// repeats forever. Everything else, including framework statuses such as
+// Unimplemented and ambiguous ones such as Unknown and Internal, fails open
+// toward retrying.
+func isPermanentRegisterError(err error) bool {
+	switch status.Code(err) {
+	case codes.InvalidArgument,
+		codes.Unauthenticated,
+		codes.PermissionDenied:
+		return true
+	default:
+		return false
+	}
+}
+
 // RegisterServices registers services with the same backend endpoint.
 func (m *GatewayRegistrar) RegisterServices(
 	ctx context.Context,
@@ -156,6 +178,13 @@ func (m *GatewayRegistrar) RegisterServices(
 			_, err := backoff.Retry(ctx, func() (*ynpb.RegisterResponse, error) {
 				resp, err := m.client.Register(ctx, request)
 				if err != nil {
+					if isPermanentRegisterError(err) {
+						log.Error("gateway rejected registration permanently, abandoning this attempt", zap.Error(err))
+						return nil, backoff.Permanent(fmt.Errorf(
+							"gateway %q permanently rejected registration of service %q: %w",
+							m.endpoint, name, err,
+						))
+					}
 					log.Warn("failed to register in gateway", zap.Error(err))
 					return nil, err
 				}

--- a/controlplane/gateway/registrar_test.go
+++ b/controlplane/gateway/registrar_test.go
@@ -1,0 +1,200 @@
+package gateway_test
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/yanet-platform/yanet2/controlplane/gateway"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// stubGatewayServer is a minimal ynpb.GatewayServer that counts Register
+// calls and rejects a configured number of leading calls with a configured
+// status before succeeding.
+//
+// A negative failures rejects every call, which is what the permanent-error
+// test needs; a non-negative value rejects exactly that many leading calls
+// and then succeeds, letting the transient-error test observe a successful
+// retry without depending on wall-clock timing.
+type stubGatewayServer struct {
+	ynpb.UnimplementedGatewayServer
+
+	code     codes.Code
+	failures int64
+	calls    atomic.Int64
+}
+
+func (m *stubGatewayServer) Register(
+	_ context.Context,
+	_ *ynpb.RegisterRequest,
+) (*ynpb.RegisterResponse, error) {
+	call := m.calls.Add(1)
+	if m.failures < 0 || call <= m.failures {
+		return nil, status.Error(m.code, "stub rejection")
+	}
+	return &ynpb.RegisterResponse{
+		Status: ynpb.RegistrationStatus_REGISTRATION_STATUS_REGISTERED,
+	}, nil
+}
+
+// startGRPCStub starts server on a real 127.0.0.1 listener and returns its
+// endpoint.
+func startGRPCStub(t *testing.T, server ynpb.GatewayServer) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	ynpb.RegisterGatewayServer(grpcServer, server)
+
+	go func() { _ = grpcServer.Serve(listener) }()
+	t.Cleanup(grpcServer.Stop)
+
+	return listener.Addr().String()
+}
+
+// startStubGateway starts a stubGatewayServer on a real 127.0.0.1 listener
+// and returns its endpoint alongside the server for call-count inspection.
+//
+// The stub rejects the first failures calls with code, then succeeds; pass a
+// negative failures to reject every call.
+func startStubGateway(t *testing.T, code codes.Code, failures int64) (string, *stubGatewayServer) {
+	t.Helper()
+
+	stub := &stubGatewayServer{code: code, failures: failures}
+	return startGRPCStub(t, stub), stub
+}
+
+// cancelingStubGatewayServer is a stub whose first Register call cancels the
+// caller-supplied context before returning a transient rejection, isolating
+// the retry loop's own cancellation check from the permanent-error
+// classifier.
+type cancelingStubGatewayServer struct {
+	ynpb.UnimplementedGatewayServer
+
+	cancel context.CancelFunc
+	calls  atomic.Int64
+}
+
+func (m *cancelingStubGatewayServer) Register(
+	_ context.Context,
+	_ *ynpb.RegisterRequest,
+) (*ynpb.RegisterResponse, error) {
+	m.calls.Add(1)
+	m.cancel()
+	return nil, status.Error(codes.Unavailable, "stub rejection")
+}
+
+// constantBackOffFor10ms returns a fresh 10ms constant backoff, matching the
+// factory shape RegisterServices requires per attempt.
+func constantBackOffFor10ms() backoff.BackOff {
+	return backoff.NewConstantBackOff(10 * time.Millisecond)
+}
+
+// TestGatewayRegistrar_PermanentErrorFailsFast verifies that a Register
+// rejection classified as permanent aborts RegisterServices after exactly
+// one attempt, and that the returned error still carries the original gRPC
+// status through the wrap.
+func TestGatewayRegistrar_PermanentErrorFailsFast(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []codes.Code{
+		codes.InvalidArgument,
+		codes.Unauthenticated,
+		codes.PermissionDenied,
+	} {
+		t.Run(code.String(), func(t *testing.T) {
+			t.Parallel()
+
+			endpoint, stub := startStubGateway(t, code, -1)
+
+			registrar, err := gateway.NewGatewayRegistrar(endpoint, nil,
+				gateway.WithBackOff(constantBackOffFor10ms),
+				gateway.WithMaxElapsedTime(5*time.Second),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = registrar.Close() })
+
+			registerErr := registrar.RegisterServices(t.Context(), []string{"test.Service"}, "127.0.0.1:1")
+			require.Error(t, registerErr)
+			assert.Equal(t, int64(1), stub.calls.Load(),
+				"a permanent rejection must not be retried")
+			assert.Equal(t, code, status.Code(registerErr),
+				"wrapping the permanent error must preserve its gRPC status code")
+		})
+	}
+}
+
+// TestGatewayRegistrar_TransientErrorIsRetried is the positive control for
+// TestGatewayRegistrar_PermanentErrorFailsFast: it proves codes outside the
+// permanent set are retried until the underlying RPC succeeds, instead of
+// failing fast, which is what breaks if the classifier is ever widened to
+// treat everything as permanent. The stub fails only the first call, so the
+// assertion holds deterministically without depending on wall-clock timing.
+func TestGatewayRegistrar_TransientErrorIsRetried(t *testing.T) {
+	t.Parallel()
+
+	for _, code := range []codes.Code{
+		codes.Unavailable,
+		codes.DeadlineExceeded,
+		codes.Internal,
+		codes.Unimplemented,
+		codes.FailedPrecondition,
+	} {
+		t.Run(code.String(), func(t *testing.T) {
+			t.Parallel()
+
+			endpoint, stub := startStubGateway(t, code, 1)
+
+			registrar, err := gateway.NewGatewayRegistrar(endpoint, nil,
+				gateway.WithBackOff(constantBackOffFor10ms),
+				gateway.WithMaxElapsedTime(5*time.Second),
+			)
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = registrar.Close() })
+
+			registerErr := registrar.RegisterServices(t.Context(), []string{"test.Service"}, "127.0.0.1:1")
+			require.NoError(t, registerErr)
+			assert.Equal(t, int64(2), stub.calls.Load(),
+				"a transient rejection must be retried exactly once before succeeding")
+		})
+	}
+}
+
+// TestGatewayRegistrar_CanceledContextIsNotPermanent verifies that a Register
+// call cut short by context cancellation surfaces as a plain cancellation
+// error, not as a permanent-rejection error. This guards against two
+// regressions: adding Canceled to the permanent-code set, and moving the
+// permanent-error classification ahead of the retry loop's own cancellation
+// check.
+func TestGatewayRegistrar_CanceledContextIsNotPermanent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	stub := &cancelingStubGatewayServer{cancel: cancel}
+	endpoint := startGRPCStub(t, stub)
+
+	registrar, err := gateway.NewGatewayRegistrar(endpoint, nil,
+		gateway.WithBackOff(constantBackOffFor10ms),
+		gateway.WithMaxElapsedTime(5*time.Second),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = registrar.Close() })
+
+	registerErr := registrar.RegisterServices(ctx, []string{"test.Service"}, "127.0.0.1:1")
+	require.Error(t, registerErr)
+	assert.ErrorIs(t, registerErr, context.Canceled)
+	assert.Equal(t, int64(1), stub.calls.Load(),
+		"the retry loop must stop on cancellation instead of retrying")
+}

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -176,8 +176,5 @@ func (m *ServiceRunner) register(ctx context.Context, addr net.Addr) error {
 	}
 	defer registrar.Close()
 
-	if err = registrar.RegisterServices(ctx, m.module.ServicesNames(), addr.String()); err != nil {
-		return fmt.Errorf("failed to register services: %w", err)
-	}
-	return nil
+	return registrar.RegisterServices(ctx, m.module.ServicesNames(), addr.String())
 }

--- a/controlplane/ynpb/v1/gateway.proto
+++ b/controlplane/ynpb/v1/gateway.proto
@@ -11,6 +11,18 @@ service Gateway {
   // ListServices returns all registered backends.
   rpc ListServices(ListServicesRequest) returns (ListServicesResponse);
   // Register registers a new backend.
+  //
+  // Terminal statuses the gateway itself produces, which a registrant must
+  // not retry:
+  //
+  // - INVALID_ARGUMENT: the request is malformed (no backend, or an empty
+  //   name or endpoint), so resending it unchanged cannot succeed.
+  // - UNAUTHENTICATED, PERMISSION_DENIED: with authentication enabled, a
+  //   registrant that presents the same credentials on every attempt is
+  //   refused on every attempt.
+  //
+  // A status from the transport or the framework, such as a peer that does
+  // not serve this RPC, is outside this contract.
   rpc Register(RegisterRequest) returns (RegisterResponse);
 }
 


### PR DESCRIPTION
The gateway registration client treated every failed registration call as transient and kept retrying it for the whole backoff window. A rejection that can never succeed therefore stalled the caller for up to fifteen minutes before surfacing as an opaque process-level failure, instead of being diagnosed at the point of rejection.

Two such rejections are reachable today: the gateway refuses a malformed registration request, and, with authentication enabled, its interceptor refuses a registrant it cannot authenticate or authorize. Neither can change while the caller resends the same request with the same credentials.

- Terminal rejections now fail fast with a diagnostic naming the service and the gateway that refused it, while every other failure keeps retrying as before.
- The registration heartbeat loop is deliberately unchanged, so a terminal rejection there still only ends the current round rather than stopping the loop and taking an operator process down with it.
- The registration RPC now documents which statuses are terminal for a registrant, so a client implementing retry from the wire contract reaches the same conclusion.
- A duplicated wrapping of the same failure message in the out-of-process service runner is removed.
