### PR TITLE
fix(forward): materialise an empty rule counter instead of counting into an unnamed one

### DIFF
--- a/modules/forward/bindings/go/cforward/safe.go
+++ b/modules/forward/bindings/go/cforward/safe.go
@@ -10,6 +10,15 @@ import (
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
 )
 
+// CounterNameMaxLen is the longest counter name the shared-memory counter
+// registry accepts.
+//
+// The C buffer backing a counter name (COUNTER_NAME_LEN) reserves one byte
+// for a trailing NUL terminator. counter_registry_register in
+// lib/counters/counters.c rejects a name whose strnlen reaches the full
+// buffer size, so the longest name it accepts is the buffer size minus one.
+const CounterNameMaxLen = C.COUNTER_NAME_LEN - 1
+
 // ForwardMode defines the forwarding direction.
 type ForwardMode int
 

--- a/modules/forward/cli/src/main.rs
+++ b/modules/forward/cli/src/main.rs
@@ -207,11 +207,20 @@ impl TryFrom<forwardpb::Rule> for ForwardRule {
 ///
 /// Every rule field is always emitted, including an empty sequence as `[]`
 /// and an empty counter as an empty string, and none of them is optional on
-/// `update` either. A network renders from the address and mask actually
-/// stored, so re-applying shown output normalises an address that carries
-/// host bits outside its mask. A stored IPv6 network's mask may have a hole
-/// at the `/64` boundary. Such a network renders in expanded-mask form, and
+/// `update` either.
+///
+/// A network renders from the address and mask actually stored, so
+/// re-applying shown output normalises an address that carries host bits
+/// outside its mask. A stored IPv6 network's mask may have a hole at the
+/// `/64` boundary. Such a network renders in expanded-mask form, and
 /// `update` rejects it because it requires a contiguous mask.
+///
+/// A `counter` left empty on `update` is not stored empty: the server
+/// materialises it to `to_<target>` before storing, bounded to whatever
+/// length the shared-memory counter registry accepts by cutting it back
+/// to the last whole character that still fits, so `show` renders that
+/// name instead of an empty string once the rule has gone through
+/// `update`, and a non-empty `counter` is used verbatim.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ForwardConfig {
     rules: Vec<ForwardRule>,

--- a/modules/forward/controlplane/forwardpb/v1/forward.proto
+++ b/modules/forward/controlplane/forwardpb/v1/forward.proto
@@ -66,6 +66,13 @@ message Rule {
 message Action {
   string target = 1;
   ForwardMode mode = 2;
+
+  // Name of the per-rule dataplane counter.
+  //
+  // May be left empty. UpdateConfig then stores "to_" plus the rule's
+  // target, bounded to the counter-name limit, so a rule applied through it
+  // never carries an empty name. A config the dataplane received directly
+  // through the C API still can, though ShowConfig does not report those.
   string counter = 3;
 }
 

--- a/modules/forward/controlplane/service.go
+++ b/modules/forward/controlplane/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"unicode/utf8"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -100,6 +101,31 @@ func (m *ForwardService) ShowConfig(ctx context.Context, req *forwardpb.ShowConf
 	return response, nil
 }
 
+// materializeCounter builds the default counter name for a rule that left
+// it empty: "to_" plus the target, bounded to the counter-name limit.
+//
+// The cut lands on a rune boundary because a name split mid-rune is not
+// valid UTF-8, and a ShowConfig response carrying it would fail to marshal.
+func materializeCounter(target string) string {
+	name := "to_" + target
+	if len(name) <= cforward.CounterNameMaxLen {
+		return name
+	}
+
+	cut := cforward.CounterNameMaxLen
+	for cut > 0 && !utf8.RuneStart(name[cut]) {
+		cut--
+	}
+	return name[:cut]
+}
+
+// UpdateConfig replaces the rule set for a named forward module config and
+// publishes it to the dataplane.
+//
+// A rule that leaves its counter empty is stored with "to_" plus its
+// target, bounded to the counter-name limit, so ShowConfig never returns an
+// empty name for a rule applied here. A non-empty counter is passed through
+// verbatim.
 func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.UpdateConfigRequest) (*forwardpb.UpdateConfigResponse, error) {
 	name := req.GetName()
 	if name == "" {
@@ -113,6 +139,14 @@ func (m *ForwardService) UpdateConfig(ctx context.Context, req *forwardpb.Update
 		action := reqRule.GetAction()
 		if action == nil {
 			return nil, status.Error(codes.InvalidArgument, "rule action is required")
+		}
+
+		// Assign onto the request's own action message: the ForwardRule
+		// built below and the reqRules stored into m.configs after the
+		// backend call both read this same action, so one assignment here
+		// keeps the shared-memory write and ShowConfig in agreement.
+		if action.Counter == "" {
+			action.Counter = materializeCounter(action.Target)
 		}
 
 		devices, err := filterpb.ToDevices(reqRule.Devices)

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -3,12 +3,15 @@ package forward_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
 	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
@@ -44,6 +47,22 @@ type nilHandleBackend struct {
 
 func (m *nilHandleBackend) UpdateModule(name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
 	return nil, nil
+}
+
+// recordingBackend captures the rules handed to UpdateModule so a test can
+// inspect what the service sends to shared memory.
+//
+// Only single-goroutine tests use it. TestForwardServiceConcurrentAccess
+// uses mockBackend instead, since this field is unguarded under -race.
+type recordingBackend struct {
+	mockBackend
+
+	rules []cforward.ForwardRule
+}
+
+func (m *recordingBackend) UpdateModule(name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
+	m.rules = rules
+	return &mockModuleHandle{}, nil
 }
 
 // TestShowConfigUnknownConfig verifies that ShowConfig reports NotFound for
@@ -101,6 +120,147 @@ func TestUpdateConfigReplacesConfigWithoutHandle(t *testing.T) {
 
 	_, err = svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{Name: "config"})
 	require.NoError(t, err)
+}
+
+// TestUpdateConfigMaterializesEmptyCounter verifies that a rule with an
+// empty counter and a non-empty target is materialised to "to_" + target
+// both in the rules handed to the backend and in what ShowConfig returns
+// afterward.
+func TestUpdateConfigMaterializesEmptyCounter(t *testing.T) {
+	backend := &recordingBackend{}
+	svc := forward.NewForwardService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{
+				Action: &forwardpb.Action{Target: "device0"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.rules, 1)
+	require.Equal(t, "to_device0", backend.rules[0].Counter)
+
+	response, err := svc.ShowConfig(t.Context(), &forwardpb.ShowConfigRequest{Name: "config"})
+	require.NoError(t, err)
+	require.Len(t, response.GetRules(), 1)
+	require.Equal(t, "to_device0", response.GetRules()[0].GetAction().GetCounter())
+}
+
+// TestUpdateConfigKeepsNonEmptyCounter verifies that a rule with a
+// non-empty counter is passed through verbatim, unmaterialised.
+func TestUpdateConfigKeepsNonEmptyCounter(t *testing.T) {
+	backend := &recordingBackend{}
+	svc := forward.NewForwardService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{
+				Action: &forwardpb.Action{Target: "device0", Counter: "custom"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.rules, 1)
+	require.Equal(t, "custom", backend.rules[0].Counter)
+
+	response, err := svc.ShowConfig(t.Context(), &forwardpb.ShowConfigRequest{Name: "config"})
+	require.NoError(t, err)
+	require.Equal(t, "custom", response.GetRules()[0].GetAction().GetCounter())
+}
+
+// TestUpdateConfigEmptyCounterEmptyTarget verifies the degenerate case: a
+// rule with both an empty counter and an empty target materialises to
+// "to_" rather than being rejected.
+func TestUpdateConfigEmptyCounterEmptyTarget(t *testing.T) {
+	backend := &recordingBackend{}
+	svc := forward.NewForwardService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{
+				Action: &forwardpb.Action{},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.rules, 1)
+	require.Equal(t, "to_", backend.rules[0].Counter)
+
+	response, err := svc.ShowConfig(t.Context(), &forwardpb.ShowConfigRequest{Name: "config"})
+	require.NoError(t, err)
+	require.Equal(t, "to_", response.GetRules()[0].GetAction().GetCounter())
+}
+
+// TestUpdateConfigMaterializesEmptyCounterLongTarget verifies that a target
+// long enough to overflow the counter-name limit still applies, with the
+// counter cut to exactly that limit.
+//
+// The expected length (127) is asserted as a literal, not derived from
+// cforward.CounterNameMaxLen, so an off-by-one in that constant would not
+// make this test pass vacuously.
+func TestUpdateConfigMaterializesEmptyCounterLongTarget(t *testing.T) {
+	backend := &recordingBackend{}
+	svc := forward.NewForwardService(backend)
+
+	target := strings.Repeat("a", 300)
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{
+				Action: &forwardpb.Action{Target: target},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.rules, 1)
+	require.Len(t, backend.rules[0].Counter, 127)
+	require.True(t, strings.HasPrefix(backend.rules[0].Counter, "to_aaa"))
+
+	response, err := svc.ShowConfig(t.Context(), &forwardpb.ShowConfigRequest{Name: "config"})
+	require.NoError(t, err)
+	require.Equal(t, backend.rules[0].Counter, response.GetRules()[0].GetAction().GetCounter())
+}
+
+// TestUpdateConfigMaterializesEmptyCounterUTF8Boundary verifies that when
+// the counter-name cut would otherwise split a multi-byte rune, UpdateConfig
+// backs it off to the previous rune boundary instead.
+//
+// The target places a two-byte "é" rune where a byte-wise cut would land on
+// its continuation byte. proto.Marshal is the oracle, not utf8.ValidString
+// alone, because a marshal failure is what a real ShowConfig call would hit.
+func TestUpdateConfigMaterializesEmptyCounterUTF8Boundary(t *testing.T) {
+	backend := &recordingBackend{}
+	svc := forward.NewForwardService(backend)
+
+	target := strings.Repeat("a", 123) + "é" + strings.Repeat("b", 10)
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{
+				Action: &forwardpb.Action{Target: target},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.rules, 1)
+	require.True(t, utf8.ValidString(backend.rules[0].Counter), "counter must be valid UTF-8")
+
+	response, err := svc.ShowConfig(t.Context(), &forwardpb.ShowConfigRequest{Name: "config"})
+	require.NoError(t, err)
+
+	_, err = proto.Marshal(response)
+	require.NoError(t, err, "ShowConfigResponse carrying the materialised counter must marshal")
 }
 
 // Run with: go test -race

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -3,6 +3,7 @@ package forward_test
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 
 	"github.com/c2h5oh/datasize"
@@ -11,11 +12,13 @@ import (
 
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	"github.com/yanet-platform/yanet2/bindings/go/filter"
+	filterpb "github.com/yanet-platform/yanet2/common/filterpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/xerror"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
 	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
+	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
 )
 
 // Memory sizes for the forward functional harness.
@@ -342,6 +345,117 @@ func TestForward_ModeOut_IPv4(t *testing.T) {
 		ModuleName: "test",
 	}
 	dataplaneut.RequireModuleCounter(t, h, path, "rule0", 1, pktSize)
+}
+
+// TestForward_EmptyCounterMaterializesToTarget verifies that a rule applied
+// through the real ForwardService with an empty counter runs the packet
+// path under the materialised "to_"+target counter, and that no counter the
+// module registers is left unnamed.
+//
+// Goes through ForwardService.UpdateConfig rather than backend.UpdateModule
+// directly, so the service's materialisation runs end to end.
+func TestForward_EmptyCounterMaterializesToTarget(t *testing.T) {
+	eth, ip4, _, icmp := fwdEtherLayers()
+	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
+	pktSize := uint64(len(pkt.Data()))
+
+	h, agent, backend := setupForwardHarness(t, []string{"port0", "port1"})
+	svc := forward.NewForwardService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "test",
+		Rules: []*forwardpb.Rule{
+			{
+				Action: &forwardpb.Action{
+					Target: "port1",
+					Mode:   forwardpb.ForwardMode_OUT,
+				},
+				Srcs: []*filterpb.IPNet{
+					{Addr: []byte{0, 0, 0, 0}, Mask: []byte{0, 0, 0, 0}},
+				},
+				Dsts: []*filterpb.IPNet{
+					{Addr: []byte{10, 0, 0, 0}, Mask: []byte{255, 255, 255, 0}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// The config is now applied and owned by the service. Wiring the
+	// pipeline afterward matches applyRules's own ordering requirement.
+	wireForwardPipeline(t, agent, "port0", "test", []string{"port1"})
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "ModeOut packet must reach output after egress pipeline")
+	require.Empty(t, result.Drop, "ModeOut packet with valid device must not be dropped")
+
+	path := dataplaneut.CounterPath{
+		Device:     "port0",
+		Pipeline:   "test",
+		Function:   "test",
+		Chain:      "test_chain",
+		ModuleType: "forward",
+		ModuleName: "test",
+	}
+	dataplaneut.RequireModuleCounter(t, h, path, "to_port1", 1, pktSize)
+
+	// A nil query returns every counter the module registers, including the
+	// generic rx/tx/drop/pending_*/hist_* counters from cp_module_init. None
+	// of those are empty either.
+	registered := h.SharedMemory().DPConfig(0).ModuleCounters(
+		path.Device, path.Pipeline, path.Function, path.Chain, path.ModuleType, path.ModuleName, nil,
+	)
+	require.NotEmpty(t, registered)
+	for _, counter := range registered {
+		require.NotEmpty(t, counter.Name, "module must not register an unnamed counter")
+	}
+}
+
+// TestForward_EmptyCounterLongTargetRegistersInCounterRegistry verifies that
+// the C counter registry accepts and registers a counter name cut to the
+// shared-memory limit — the layer no Go-level test can reach.
+//
+// The target need not name a real device: cp_module_link_device only
+// records it in the module's own device table.
+func TestForward_EmptyCounterLongTargetRegistersInCounterRegistry(t *testing.T) {
+	h, agent, backend := setupForwardHarness(t, []string{"port0"})
+	svc := forward.NewForwardService(backend)
+
+	target := strings.Repeat("a", 300)
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "test",
+		Rules: []*forwardpb.Rule{
+			{
+				Action: &forwardpb.Action{
+					Target: target,
+					Mode:   forwardpb.ForwardMode_NONE,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	response, err := svc.ShowConfig(t.Context(), &forwardpb.ShowConfigRequest{Name: "test"})
+	require.NoError(t, err)
+	require.Len(t, response.GetRules(), 1)
+
+	wantCounter := response.GetRules()[0].GetAction().GetCounter()
+	require.NotEmpty(t, wantCounter)
+	require.Len(t, wantCounter, 127, "materialised counter must be cut to the registry's usable limit")
+
+	wireForwardPipeline(t, agent, "port0", "test", nil)
+
+	registered := h.SharedMemory().DPConfig(0).ModuleCounters(
+		"port0", "test", "test", "test_chain", "forward", "test", nil,
+	)
+
+	names := make([]string, 0, len(registered))
+	for _, counter := range registered {
+		names = append(names, counter.Name)
+	}
+	require.Contains(t, names, wantCounter)
 }
 
 // TestForward_ModeIn_IPv4 verifies that an IPv4 packet matched by a ModeIn

--- a/modules/forward/web/ForwardPage.tsx
+++ b/modules/forward/web/ForwardPage.tsx
@@ -10,7 +10,7 @@ import type { RuleItem, RuleDraft } from './types';
 import { MODE_LABELS } from './types';
 import { ModeFilter } from './ModeFilter';
 import type { ModeFilterValue } from './ModeFilter';
-import { rulesToNgItems, draftToRule, itemToDraft } from './hooks';
+import { rulesToNgItems, draftToRule, itemToDraft, effectiveCounterName } from './hooks';
 import RuleTable from './RuleTable';
 import RuleDrawer from './RuleDrawer';
 import type { RuleDrawerHandle } from './RuleDrawer';
@@ -123,7 +123,7 @@ const ForwardPage: React.FC = () => {
         if (q) {
             res = res.filter((item) =>
                 item.target.toLowerCase().includes(q) ||
-                item.counter.toLowerCase().includes(q) ||
+                effectiveCounterName(item.counter, item.target).toLowerCase().includes(q) ||
                 item.deviceNames.some((d) => d.toLowerCase().includes(q)) ||
                 item.sourceCidrs.some((s) => s.toLowerCase().includes(q)) ||
                 item.dstCidrs.some((s) => s.toLowerCase().includes(q))
@@ -253,12 +253,11 @@ const ForwardPage: React.FC = () => {
         getId: (it) => it.id,
         getLabel: (it) => it.target || '(no target)',
         getSub: (it) => {
-            const parts: string[] = [MODE_LABELS[it.mode]];
-            if (it.counter) parts.push(it.counter);
+            const parts: string[] = [MODE_LABELS[it.mode], effectiveCounterName(it.counter, it.target)];
             if (it.deviceNames.length) parts.push(it.deviceNames.join(', '));
             return parts.join(' · ');
         },
-        searchText: (it) => [it.target, it.counter, ...it.deviceNames, ...it.sourceCidrs, ...it.dstCidrs].join(' '),
+        searchText: (it) => [it.target, effectiveCounterName(it.counter, it.target), ...it.deviceNames, ...it.sourceCidrs, ...it.dstCidrs].join(' '),
         onSelect: (id) => { setModeFilter('all'); handleSearchChange(''); handleJumpToRow(id); },
         icon: '→',
     }), [allItems, handleSearchChange, handleJumpToRow]);

--- a/modules/forward/web/RuleDrawer.tsx
+++ b/modules/forward/web/RuleDrawer.tsx
@@ -168,11 +168,13 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                         </label>
                         <input
                             className="yn-input"
-                            placeholder={draft.target ? `to_${draft.target}` : 'e.g. my_counter'}
+                            placeholder={draft.target ? `to_${draft.target} (default)` : 'e.g. my_counter'}
                             value={draft.counter}
                             onChange={(e) => updateField('counter', e.target.value)}
                         />
-                        <span className="yn-field__hint">Name shown in /stats. Leave empty to skip counting.</span>
+                        <span className="yn-field__hint">
+                            Name shown in /stats. Leave empty to use the auto-assigned default name (to_&lt;target&gt;).
+                        </span>
                     </div>
                 </div>
             </section>

--- a/modules/forward/web/RuleTable.tsx
+++ b/modules/forward/web/RuleTable.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { RuleItem } from './types';
 import type { RuleRate } from './useForwardRuleCounters';
+import { effectiveCounterName } from './hooks';
 import DirectionBadge from './DirectionBadge';
 import AnyBadge from './AnyBadge';
 import Sparkline from '@yanet/core/components/Sparkline';
@@ -80,11 +81,14 @@ const RuleTable: React.FC<RuleTableProps> = ({
             key: 'counter',
             header: 'Counter',
             gridTrack: '140px',
-            renderCell: (item) => (
-                <span className="yn-cell-mono yn-cell-muted" title={item.counter}>
-                    {item.counter || '—'}
-                </span>
-            ),
+            renderCell: (item) => {
+                const name = effectiveCounterName(item.counter, item.target);
+                return (
+                    <span className="yn-cell-mono yn-cell-muted" title={name}>
+                        {name}
+                    </span>
+                );
+            },
         },
         {
             key: 'devices',

--- a/modules/forward/web/SaveDiffModal.tsx
+++ b/modules/forward/web/SaveDiffModal.tsx
@@ -3,9 +3,16 @@ import type { Rule } from '@yanet/core/api/forward';
 import { ForwardMode, FORWARD_MODE_LABELS } from '@yanet/core/api/forward';
 import { formatIPNetItem, dumpYamlDoc } from '@yanet/core/utils';
 import { SaveDiffModal as SharedSaveDiffModal } from '@yanet/core/components';
+import { effectiveCounterName } from './hooks';
 
-/** Serialize a rules array into the canonical YAML schema for diff display. */
-export const rulesToDiffYaml = (rules: Rule[]): string => {
+/**
+ * Serialize a rules array into the canonical YAML schema.
+ *
+ * The `counter` key mirrors the raw stored value by default. Pass
+ * `showEffectiveCounter` to emit the name the server would use instead
+ * (`to_<target>` when unset), as the pre-save diff preview does.
+ */
+export const rulesToDiffYaml = (rules: Rule[], showEffectiveCounter = false): string => {
     const yamlRules = rules.map((r) => {
         const devices = (r.devices ?? []).map(d => d.name ?? '').filter(Boolean);
         const srcs = (r.srcs ?? []).map(formatIPNetItem).filter(Boolean);
@@ -15,10 +22,13 @@ export const rulesToDiffYaml = (rules: Rule[]): string => {
             to: vr.to ?? 0,
         }));
 
+        const target = r.action?.target ?? '';
         const entry: Record<string, unknown> = {
-            target: r.action?.target ?? '',
+            target,
         };
-        if (r.action?.counter) {
+        if (showEffectiveCounter) {
+            entry['counter'] = effectiveCounterName(r.action?.counter ?? '', target);
+        } else if (r.action?.counter) {
             entry['counter'] = r.action.counter;
         }
         if (vlan_ranges.length > 0) {
@@ -60,8 +70,8 @@ export const SaveDiffModal: React.FC<SaveDiffModalProps> = ({
     onClose,
     onApply,
 }) => {
-    const beforeYaml = useMemo(() => rulesToDiffYaml(serverRules), [serverRules]);
-    const afterYaml = useMemo(() => rulesToDiffYaml(draftRules), [draftRules]);
+    const beforeYaml = useMemo(() => rulesToDiffYaml(serverRules, true), [serverRules]);
+    const afterYaml = useMemo(() => rulesToDiffYaml(draftRules, true), [draftRules]);
 
     return (
         <SharedSaveDiffModal

--- a/modules/forward/web/hooks.test.ts
+++ b/modules/forward/web/hooks.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { effectiveCounterName } from './hooks';
+
+describe('effectiveCounterName', () => {
+    it('returns the explicit counter name verbatim when set', () => {
+        expect(effectiveCounterName('my_counter', 'eth0')).toBe('my_counter');
+    });
+
+    it('materialises to_<target> when the counter is empty', () => {
+        expect(effectiveCounterName('', 'eth0')).toBe('to_eth0');
+    });
+
+    it('materialises the literal to_ when both counter and target are empty', () => {
+        expect(effectiveCounterName('', '')).toBe('to_');
+    });
+});

--- a/modules/forward/web/hooks.ts
+++ b/modules/forward/web/hooks.ts
@@ -19,6 +19,16 @@ const computeIsAllVlans = (ranges: VlanRange[] | undefined): boolean => {
     return false;
 };
 
+/**
+ * Counter name to display for a rule.
+ *
+ * An explicit counter wins. Otherwise this mirrors the server's
+ * `to_<target>` default, minus its length truncation, so a long target
+ * reads untruncated until the saved config is refetched.
+ */
+export const effectiveCounterName = (counter: string, target: string): string =>
+    counter || `to_${target}`;
+
 /** Convert a Rule array from the API to RuleItem array for UI display. */
 export const rulesToNgItems = (rules: Rule[]): RuleItem[] => {
     return rules.map((rule, index) => {

--- a/modules/forward/web/useForwardRuleCounters.ts
+++ b/modules/forward/web/useForwardRuleCounters.ts
@@ -1,6 +1,7 @@
 import { useModuleRuleCounters } from '@yanet/core/hooks/useModuleRuleCounters';
 import type { RuleRate } from '@yanet/core/hooks/useModuleRuleCounters';
 import type { RuleItem } from './types';
+import { effectiveCounterName } from './hooks';
 
 export type { RuleRate };
 
@@ -13,17 +14,17 @@ export interface UseForwardRuleCountersResult {
  * Polls CountersService.ByTags once per second for all rules of the given forward config.
  *
  * Maintains a 60-sample pps rolling window per rule and interpolates at ~30 ms for
- * smooth sparkline animation. When enabled=false, polling and history sampling pause;
- * the last known values are preserved so sparklines freeze rather than disappear.
- * Counter names are read from RuleItem.counter; multiple rules sharing the same counter
- * name receive identical sparklines.
+ * smooth sparkline animation. When enabled=false, polling and history sampling pause.
+ * The last known values are preserved so sparklines freeze rather than disappear.
+ * Counter names use each rule's effective counter, so rules sharing a default name
+ * receive identical sparklines.
  */
 export const useForwardRuleCounters = (
     configName: string,
     rules: RuleItem[],
     enabled: boolean,
 ): UseForwardRuleCountersResult => {
-    const counterNames = Array.from(new Set(rules.map(r => r.counter).filter(Boolean)));
+    const counterNames = Array.from(new Set(rules.map(r => effectiveCounterName(r.counter, r.target))));
 
     return useModuleRuleCounters({
         configName,
@@ -31,6 +32,6 @@ export const useForwardRuleCounters = (
         moduleType: 'forward',
         enabled,
         counterNames,
-        getCounterName: (r) => r.counter ?? '',
+        getCounterName: (r) => effectiveCounterName(r.counter, r.target),
     });
 };


### PR DESCRIPTION
A forward rule that left its counter name empty used to register the empty string as a real counter, so every such rule shared one unnamed counter that the dataplane incremented on every match, the metrics service exported under an empty label, and the Web UI hid — while the rule editor's own hint promised that leaving the field empty skipped counting altogether.

The control plane now materialises an empty counter to the rule's target before the config reaches shared memory, so the stored name is what the show command, the metrics service, the CLI and the Web all observe. A non-empty name is still used verbatim. The name is bounded to what the shared-memory counter registry accepts and is cut back on a character boundary, so a long target can neither be rejected for a name the operator never wrote nor produce a name that breaks later responses.

The CLI and Web help now describe that rule, the rule table and search agree on the name they display, and the save preview shows the name that will actually be written.

Three cases make rules share one counter, all resolvable by naming the counter explicitly: rules with no target share a single name; rules whose targets agree up to the length limit share one name; and a rule that leaves its counter empty collides with one that explicitly names the counter after the same target. Where several rules previously fell into the single unnamed counter, each distinct materialised name now registers its own entry, which is the point of the change but does grow the module's counter registry.