### PR TITLE
docs(comments): drop clause-joining semicolons from comment prose

### DIFF
--- a/bindings/go/dataplane_ut/dataplane_ut.go
+++ b/bindings/go/dataplane_ut/dataplane_ut.go
@@ -216,11 +216,11 @@ type RawResult struct {
 // struct holds self-referential pointers.
 type Harness struct {
 	ptr *C.struct_dataplane_ut
-	// Registered topology device count; device ids passed to bench runs
+	// Registered topology device count. Device ids passed to bench runs
 	// must stay below it. An empty Devices config still exposes the
 	// implicit device slot zero.
 	deviceCount int
-	// Registered worker count; worker indices passed to run calls must
+	// Registered worker count. Worker indices passed to run calls must
 	// stay below it.
 	workerCount int
 }
@@ -256,7 +256,7 @@ func NewHarness(cfg Config) (*Harness, error) {
 	}
 
 	// Convert Go string slices to C string arrays. The *C.char values are
-	// C-heap strings; toCStringArray returns Go-backed pointer slices, so
+	// C-heap strings. toCStringArray returns Go-backed pointer slices, so
 	// we copy the pointers into C-heap arrays to satisfy the CGO rule that
 	// no Go pointer may appear inside a value passed to C.
 	cDevices, freeDevices := toCStringArray(cfg.Devices)
@@ -367,7 +367,7 @@ func (m *Harness) HandlePacketsOnWorker(worker int, packets ...gopacket.Packet) 
 //
 // hashes[i] is written into packets[i].hash before the round, giving
 // modules that select outputs via hash (e.g. route ECMP) deterministic
-// test-controlled values. hashes may be shorter than packets; entries
+// test-controlled values. hashes may be shorter than packets — entries
 // past len(hashes) keep their original hash. Returns an error if
 // len(hashes) > len(packets).
 func (m *Harness) HandlePacketsWithHashes(
@@ -574,7 +574,7 @@ type BenchOption func(*benchOptions)
 // between rounds.
 //
 // Required for modules that rewrite packet contents in place, such as
-// route decrementing TTL; costs one payload copy per packet per round.
+// route decrementing TTL — costs one payload copy per packet per round.
 // Only the bytes are restored, so geometry-changing modules stay out of
 // scope.
 func WithPayloadReset() BenchOption {
@@ -585,7 +585,7 @@ func WithPayloadReset() BenchOption {
 
 // WithDeviceIDs assigns per-packet rx/tx device ids before the run.
 //
-// ids[i] is written into packets[i]; packets past len(ids) keep device 0.
+// ids[i] is written into packets[i]. Packets past len(ids) keep device 0.
 // The round dispatch then splits the burst into per-device fronts the way
 // a real multi-device worker round does. Ids persist across bench rounds
 // via the harness packet snapshot.

--- a/bindings/go/filter/types.go
+++ b/bindings/go/filter/types.go
@@ -32,7 +32,7 @@ var UnspecifiedIPv6 = IPNet{
 // MustParseIPNet parses a CIDR prefix string into an IPNet.
 //
 // The IPv4/IPv6 family is inferred from the parsed address. Panics on
-// malformed input; intended for static test data and other contexts
+// malformed input — intended for static test data and other contexts
 // where a parse failure is a programmer error.
 func MustParseIPNet(s string) IPNet {
 	p := netip.MustParsePrefix(s)

--- a/common/go/grpcmetrics/grpcmetrics.go
+++ b/common/go/grpcmetrics/grpcmetrics.go
@@ -77,7 +77,7 @@ var DefaultBuckets = []float64{
 //
 // It is called once per RPC before the handler runs. A nil return means no
 // extra labels are attached. Stream calls have no single request message, so
-// StreamServerInterceptor invokes the Labeler with a nil req; a Labeler that
+// StreamServerInterceptor invokes the Labeler with a nil req. A Labeler that
 // only type-switches on req (the common case) naturally yields no extra
 // labels for streams.
 type Labeler func(fullMethod string, req any) metrics.Labels
@@ -209,7 +209,7 @@ func New(options ...Option) *ServerMetrics {
 // The decision is made once per call and reused for the started, handled,
 // and handling series alike. A method already tracked for the service keeps
 // its own name. A new method is admitted while the service is under the
-// limit; once the limit is reached, further new methods are folded into the
+// limit. Once the limit is reached, further new methods are folded into the
 // methodOverflow label instead. A limit of 0 disables the cap.
 func (m *ServerMetrics) resolveMethod(service, method string) string {
 	if m.perServiceMethodLimit <= 0 {
@@ -284,7 +284,7 @@ func (m *ServerMetrics) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
 // records started, handled, and handling-latency metrics for every call.
 //
 // The grpc_type label is derived from the direction flags on
-// grpc.StreamServerInfo; see the package doc for the transparent-proxy
+// grpc.StreamServerInfo. See the package doc for the transparent-proxy
 // caveat.
 func (m *ServerMetrics) StreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(

--- a/common/go/grpcmetrics/options.go
+++ b/common/go/grpcmetrics/options.go
@@ -76,7 +76,7 @@ func WithClock(fn func() time.Time) Option {
 //
 // Once a service reaches the limit, calls for a method not already seen are
 // recorded under the overflow label grpc_method="other" instead of the
-// client-supplied name; methods already tracked keep recording under their
+// client-supplied name. Methods already tracked keep recording under their
 // own name. A server that only exposes registered services rejects unknown
 // methods before any interceptor runs, so the cap is chiefly useful for
 // transparent proxies, which forward any client-supplied method name under a

--- a/common/go/metrics/map.go
+++ b/common/go/metrics/map.go
@@ -99,8 +99,8 @@ func (m *MetricMap[T]) GetOrCreate(id MetricID, create func() T) T {
 // DeleteWhere removes every stored metric whose (ID, metric) satisfies pred.
 //
 // The predicate receives a cloned MetricID so it cannot mutate stored map
-// state. Buckets are compacted in place; hash buckets that become empty
-// are deleted so the map does not accumulate empty slots.
+// state. Buckets are compacted in place. Hash buckets that become empty are
+// deleted so the map does not accumulate empty slots.
 //
 // Returns the number of metrics removed.
 func (m *MetricMap[T]) DeleteWhere(pred func(MetricID, T) bool) int {

--- a/common/go/operator/cfg.go
+++ b/common/go/operator/cfg.go
@@ -38,7 +38,7 @@ type ReconcileConfig struct {
 	// Interval is the steady-state period between successful reconcile
 	// passes.
 	Interval xcfg.NonZero[time.Duration] `yaml:"interval"`
-	// InitialBackoff is the first sleep after a failed pass; grows
+	// InitialBackoff is the first sleep after a failed pass. It grows
 	// exponentially.
 	InitialBackoff xcfg.NonZero[time.Duration] `yaml:"initial_backoff"`
 	// MaxBackoff caps the exponential backoff sleep.

--- a/common/go/operator/options.go
+++ b/common/go/operator/options.go
@@ -82,7 +82,7 @@ func WithGateways(register RegisterConfig, gateways ...GatewayConfig) Option {
 // WithGRPCServer enables an embedded gRPC server bound to cfg.Endpoint
 // that exposes the supplied service set.
 //
-// Gateway registration via WithGateways is optional; use gRPC alone for
+// Gateway registration via WithGateways is optional. Use gRPC alone for
 // metrics or operator APIs without director registration.
 //
 // When this option is not supplied, the operator does not bind a listener.

--- a/common/go/operator/reconciler.go
+++ b/common/go/operator/reconciler.go
@@ -74,9 +74,9 @@ type ReconcilerMetricsObserver interface {
 //
 // The loop has three states observable through ReconcilerMetricsObserver:
 //   - Idle (source returned ok=false: block on ctx and Wake).
-//   - Applying (Apply runs to completion; retried with backoff on
+//   - Applying (Apply runs to completion — retried with backoff on
 //     failure, preemptable by Wake between retries).
-//   - Sleeping (interval after success, backoff delay after failure;
+//   - Sleeping (interval after success, backoff delay after failure —
 //     preemptable by Wake or ctx).
 //
 // Apply is never cancelled mid-flight by a concurrent Wake —

--- a/common/go/readiness/readiness.go
+++ b/common/go/readiness/readiness.go
@@ -86,7 +86,7 @@ func (m *scopeState) Apply(
 
 // subscriber holds state for one active Watch call.
 type subscriber struct {
-	// filter is the set of scope names this subscriber wants; empty means all.
+	// filter is the set of scope names this subscriber wants. Empty means all.
 	filter  map[string]struct{}
 	ch      chan *readinesspb.ReadyResponse
 	dropped chan struct{}
@@ -105,7 +105,7 @@ func (m *subscriber) Matches(name string) bool {
 
 // Send delivers resp to the subscriber without blocking.
 //
-// It reports false when the subscriber's buffer is full; the caller is
+// It reports false when the subscriber's buffer is full. The caller is
 // responsible for dropping the subscriber in that case.
 func (m *subscriber) Send(resp *readinesspb.ReadyResponse) bool {
 	select {
@@ -344,7 +344,7 @@ func observeOutcome(current readinesspb.State, err error) (readinesspb.State, *r
 //
 // A failed apply holds the scope at DEGRADED when it was previously applied,
 // and drops to NOT_READY only when it was never applied. observed_at always
-// advances; last_transition_time changes only on a state transition.
+// advances. last_transition_time changes only on a state transition.
 func (m *Tracker) Observe(gatewayID string, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/common/go/readiness/readiness_test.go
+++ b/common/go/readiness/readiness_test.go
@@ -183,7 +183,7 @@ func TestTracker_LastTransitionTime_OnlyChangesOnStateChange(t *testing.T) {
 	obs2 := resp2.Scopes[0].ObservedAt.AsTime()
 
 	assert.Equal(t, ltt1, ltt2, "last_transition_time must not change when state stays READY")
-	// observed_at may or may not advance depending on clock resolution; just
+	// observed_at may or may not advance depending on clock resolution. Just
 	// ensure it is not before the first observation.
 	assert.False(t, obs2.Before(obs1))
 
@@ -469,7 +469,7 @@ func TestTracker_Log_DrainLogsPerChangedScope(t *testing.T) {
 	// Leave gw-b at UNKNOWN (no transition yet).
 	countBeforeDrain := logs.Len()
 
-	// Drain: gw-a transitions READY -> NOT_READY (logs); gw-b transitions
+	// Drain: gw-a transitions READY -> NOT_READY (logs). gw-b transitions
 	// UNKNOWN -> NOT_READY (logs). gw-b was never in NOT_READY, so it logs too.
 	r.Drain()
 	assert.Equal(t, countBeforeDrain+2, logs.Len(),

--- a/common/go/testutils/memory.go
+++ b/common/go/testutils/memory.go
@@ -64,7 +64,7 @@ func (m *MemoryContext) AsRawPtr() unsafe.Pointer {
 //
 // The overhead consists of:
 // - Block allocator alignment overhead: 2MB (may be smaller but never larger in some cases)
-// - Sanitizer RED ZONES overhead: ~4MB (if sanitizers are enabled; empirical value that depends on allocation count)
+// - Sanitizer RED ZONES overhead: ~4MB (if sanitizers are enabled — empirical value that depends on allocation count)
 func CPAlignmentOverhead() datasize.ByteSize {
 	// Block allocator alignment overhead on max block size
 	// This value can be smaller but not bigger in some circumstances.

--- a/common/go/xcfg/load_test.go
+++ b/common/go/xcfg/load_test.go
@@ -152,7 +152,7 @@ func Test_Load_SliceElement_ExplicitEmptyField(t *testing.T) {
 		Items []Item `yaml:"items"`
 	}
 
-	// An explicit empty string is rejected at UnmarshalYAML; Decode must still
+	// An explicit empty string is rejected at UnmarshalYAML. Decode must still
 	// surface an error.
 	yaml := "items:\n  - name: \"\"\n"
 	var cfg Config

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -636,7 +636,7 @@ type CounterGroup struct {
 
 // CountersByTags returns counters matching every predicate in tags and at
 // least one name in query. A nil or empty tags slice imposes no per-tag
-// constraint; a nil or empty query matches any counter name.
+// constraint. A nil or empty query matches any counter name.
 func (m *DPConfig) CountersByTags(
 	tags []CounterTag,
 	query []string,

--- a/controlplane/gateway/backend.go
+++ b/controlplane/gateway/backend.go
@@ -72,7 +72,8 @@ func (m *backend) AppendInfo(_ bool, resp []byte) ([]byte, error) {
 	return resp, nil
 }
 
-// BuildError satisfies proxy.Backend; the gateway never synthesises error frames.
+// BuildError satisfies proxy.Backend. The gateway never synthesises error
+// frames.
 func (m *backend) BuildError(bool, error) ([]byte, error) {
 	return nil, nil
 }

--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -182,7 +182,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 			// clients released before the trailer still match on it, and
 			// stays that way until those are gone. SetTrailer only fails
 			// without a live server stream, which the proxying handler
-			// always supplies; losing it would cost only the marker.
+			// always supplies. Losing it would cost only the marker.
 			_ = grpc.SetTrailer(ctx, metadata.Pairs(errorReasonMetadataKey, errorReasonServiceUnregistered))
 			return proxy.One2One, nil, status.Errorf(codes.NotFound, "unknown service")
 		}
@@ -222,7 +222,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	// serviceFilter rejects any service the gateway does not know about,
 	// stopping metric series and per-service method bookkeeping allocation
 	// at the source for unauthenticated scans against random service names.
-	// A registry backend lookup is mutex-guarded and cheap; the gateway's
+	// A registry backend lookup is mutex-guarded and cheap. The gateway's
 	// own registered services are read from the cached serviceKnown snapshot.
 	serviceFilter := func(service string) bool {
 		if _, ok := registry.GetBackend(service); ok {

--- a/controlplane/gateway/gateway_test.go
+++ b/controlplane/gateway/gateway_test.go
@@ -501,7 +501,7 @@ func TestGateway_RunRegistrySweeper_EvictsStaleExternal(t *testing.T) {
 // programmatic RegistryConfig with a zero SweepInterval falls back to the
 // default instead of panicking.
 //
-// A zero interval reaches time.NewTicker directly, which panics; the
+// A zero interval reaches time.NewTicker directly, which panics. The
 // fallback is the guard against that.
 func TestGateway_RunRegistrySweeper_ZeroSweepIntervalFallsBack(t *testing.T) {
 	t.Parallel()
@@ -544,7 +544,7 @@ func TestGateway_RunRegistrySweeper_ZeroSweepIntervalFallsBack(t *testing.T) {
 // instead of evicting a live entry on the first sweep.
 //
 // The sweep interval is small and positive so a sweep genuinely runs before
-// the test's deadline; the fallback TTL must still land far enough in the
+// the test's deadline. The fallback TTL must still land far enough in the
 // past to spare an entry seen moments ago, or the cutoff would land at or
 // after time.Now and wipe every live backend on the first sweep.
 func TestGateway_RunRegistrySweeper_ZeroTTLFallsBack(t *testing.T) {

--- a/controlplane/gateway/registrar_test.go
+++ b/controlplane/gateway/registrar_test.go
@@ -23,7 +23,7 @@ import (
 // status before succeeding.
 //
 // A negative failures rejects every call, which is what the permanent-error
-// test needs; a non-negative value rejects exactly that many leading calls
+// test needs. A non-negative value rejects exactly that many leading calls
 // and then succeeds, letting the transient-error test observe a successful
 // retry without depending on wall-clock timing.
 type stubGatewayServer struct {
@@ -67,7 +67,7 @@ func startGRPCStub(t *testing.T, server ynpb.GatewayServer) string {
 // startStubGateway starts a stubGatewayServer on a real 127.0.0.1 listener
 // and returns its endpoint alongside the server for call-count inspection.
 //
-// The stub rejects the first failures calls with code, then succeeds; pass a
+// The stub rejects the first failures calls with code, then succeeds. Pass a
 // negative failures to reject every call.
 func startStubGateway(t *testing.T, code codes.Code, failures int64) (string, *stubGatewayServer) {
 	t.Helper()

--- a/controlplane/gateway/runner.go
+++ b/controlplane/gateway/runner.go
@@ -87,10 +87,10 @@ func NewServiceRunner(
 	}
 }
 
-// Ready returns a channel that is closed when the runner has finished
-// the initial service registration phase against the gateway. The
-// channel is closed exactly once; consumers can use it to detect that
-// the module is reachable through the gateway.
+// Ready returns a channel that is closed when the runner has finished the
+// initial service registration phase against the gateway. The channel is
+// closed exactly once. Consumers can use it to detect that the module is
+// reachable through the gateway.
 func (m *ServiceRunner) Ready() <-chan struct{} {
 	return m.ready
 }

--- a/devices/trafgen/controlplane/service.go
+++ b/devices/trafgen/controlplane/service.go
@@ -23,7 +23,7 @@ var errConfigNameRequired = status.Error(codes.InvalidArgument, "config name is 
 // maxFrameLen is the largest replay frame the dataplane can emit.
 //
 // The dataplane reserves mbuf tailroom with a 16-bit length, so a frame above
-// this bound would wrap and corrupt the mbuf; reject such frames at upload.
+// this bound would wrap and corrupt the mbuf. Reject such frames at upload.
 const maxFrameLen = 65535
 
 // Pipeline is a weighted input/output pipeline assignment for the generator.
@@ -71,7 +71,7 @@ func NewTrafgenService(backend Backend) *TrafgenService {
 
 // UpdateDevice binds the input/output pipelines of the named generator.
 //
-// The loaded frames and the target rate are preserved; generated traffic is
+// The loaded frames and the target rate are preserved. Generated traffic is
 // demultiplexed into the configured input pipelines by the dataplane.
 func (m *TrafgenService) UpdateDevice(
 	ctx context.Context,

--- a/devices/vlan/controlplane/service_test.go
+++ b/devices/vlan/controlplane/service_test.go
@@ -16,7 +16,7 @@ import (
 // calls do not leak shared-memory arena space.
 //
 // Each update after the first retires the previous generation's device onto
-// the agent's unused list; without draining that list, the arena shrinks by
+// the agent's unused list. Without draining that list, the arena shrinks by
 // a fixed amount every call and eventually runs out. Free bytes must settle
 // after the first update instead of decreasing indefinitely.
 func TestUpdateDevice_DrainsUnusedDevices(t *testing.T) {

--- a/lint/internal/gosrc/gosrc.go
+++ b/lint/internal/gosrc/gosrc.go
@@ -29,7 +29,7 @@ const nodeModulesName = "node_modules"
 // "tests" is the top-level QEMU functional-test harness, out of scope for
 // this repository's Go linters per an explicit project decision.
 // "subprojects" holds the DPDK meson subproject. The "build*" entries are
-// the meson build directories created by "meson setup"; they are matched
+// the meson build directories created by "meson setup". They are matched
 // exactly, not by prefix, so that a future Go package such as "builder/" or
 // "buildinfo/" is not silently exempted.
 var rootRelativeExcludes = map[string]bool{
@@ -139,8 +139,8 @@ func Walk(root string, excludes ExcludeList, visit func(path string) error) erro
 // the subset that git ignores.
 //
 // It reports an error only when git is unavailable or the invocation
-// genuinely fails; callers should treat that as "nothing is ignored"
-// rather than failing the whole scan.
+// genuinely fails. Callers should treat that as "nothing is ignored" rather
+// than failing the whole scan.
 func gitIgnored(paths []string) (map[string]bool, error) {
 	if len(paths) == 0 {
 		return nil, nil

--- a/lint/protobuf/cmd/protolint/main.go
+++ b/lint/protobuf/cmd/protolint/main.go
@@ -181,7 +181,7 @@ func lintFile(pf protoFile) bool {
 	ok := true
 	line := pf.GoPkgLine
 
-	// Rule 1: go_package must be on a single line ending with ";".
+	// Rule 1: go_package must appear on one line and end with a semicolon.
 	if !strings.HasSuffix(line, ";") {
 		fmt.Printf("%s: option go_package must be written on a single line ending with \";\"\n", pf.Path)
 		return false
@@ -198,8 +198,9 @@ func lintFile(pf protoFile) bool {
 		fmt.Printf("%s: option go_package must contain an alias (e.g. \"path;alias\")\n", pf.Path)
 		ok = false
 	} else {
-		// Rule 3: alias must equal the penultimate directory in the import
-		// path. For "github.com/.../aclpb/v1;aclpb", penultimate is "aclpb".
+		// Rule 3: alias must equal the penultimate directory in the import path.
+		// In "github.com/org/repo/aclpb/v1" with alias "aclpb" the penultimate
+		// segment is "aclpb", so the two match.
 		penult := penultimateSegment(importPath)
 		if penult != "" && alias != penult {
 			fmt.Printf("%s: option go_package alias %q does not match penultimate path segment %q\n", pf.Path, alias, penult)

--- a/lint/style/cmd/stylelint/logger.go
+++ b/lint/style/cmd/stylelint/logger.go
@@ -15,13 +15,13 @@ var constructorNameRe = regexp.MustCompile(`^[Nn]ew([A-Z_]|$)`)
 // method and one of its parameters carries a zap logger.
 //
 // A logger accepted positionally ties every call site to that exact
-// parameter list; the options pattern (WithLog) lets a constructor or
-// method gain further optional dependencies later without breaking
-// existing callers. Scope: production code only. A _test.go file is
-// skipped entirely by its caller, lintFuncDecl, since the options pattern
-// this check enforces has no test-code exemption to preserve — the check
-// simply never fires there in practice, so scoping it out keeps a
-// hand-rolled test double from needing an allowlist row.
+// parameter list. The options pattern (WithLog) lets a constructor or method
+// gain further optional dependencies later without breaking existing
+// callers. Scope: production code only. A _test.go file is skipped entirely
+// by its caller, lintFuncDecl, since the options pattern this check enforces
+// has no test-code exemption to preserve — the check simply never fires
+// there in practice, so scoping it out keeps a hand-rolled test double from
+// needing an allowlist row.
 func checkLoggerParam(decl *ast.FuncDecl, name string, fileCtx *fileContext) []violation {
 	if !fileCtx.HasZap {
 		return nil

--- a/lint/style/cmd/stylelint/naming.go
+++ b/lint/style/cmd/stylelint/naming.go
@@ -125,13 +125,13 @@ func isZapLoggerType(expr ast.Expr, zapAlias string) bool {
 // checkLoopIndexFor reports a violation when stmt's Init clause declares or
 // assigns a loop variable named i.
 //
-// The repository's no-abbreviated-identifiers rule carves out idx, not i,
-// as its one allowed loop-counter abbreviation, so a lone i reads as an
-// unexplained shorthand next to every other spelled-out name. Scope:
-// every for-loop, in production and test code alike. Both a
-// short-variable-declaration Init clause (for i := 0; ...) and a plain
-// assignment to a variable declared earlier (var i int; for i = 0; ...) are
-// in scope, since the loop reads as an "i" index either way.
+// The repository's no-abbreviated-identifiers rule carves out idx, not i, as
+// its one allowed loop-counter abbreviation, so a lone i reads as an
+// unexplained shorthand next to every other spelled-out name. Scope: every
+// for-loop, in production and test code alike. Both a
+// short-variable-declaration Init clause (i := 0) and a plain assignment
+// to a variable declared earlier (i = 0) are in scope, since the loop
+// reads as an "i" index either way.
 func checkLoopIndexFor(stmt *ast.ForStmt, enclosing string, fileCtx *fileContext) []violation {
 	assign, ok := stmt.Init.(*ast.AssignStmt)
 	if !ok || (assign.Tok != token.DEFINE && assign.Tok != token.ASSIGN) {

--- a/lint/style/cmd/stylelint/style.go
+++ b/lint/style/cmd/stylelint/style.go
@@ -89,14 +89,14 @@ func checkGRPCDial(call *ast.CallExpr, enclosing string, fileCtx *fileContext) [
 // checkSugarType reports a violation when sel denotes the zap.SugaredLogger
 // type.
 //
-// zap.SugaredLogger accepts untyped key-value pairs checked only at
-// runtime; *zap.Logger's typed field constructors (zap.String, zap.Int,
-// ...) catch a mismatched argument at compile time instead. Scope: every
-// selector expression, in production and test code alike, in any file
-// whose package (not necessarily that file itself) imports zap. In
-// practice this only ever fires in a file that itself imports zap, since
-// the zap.SugaredLogger reference this check matches requires that file's
-// own zap import to compile.
+// zap.SugaredLogger accepts untyped key-value pairs checked only at runtime.
+// *zap.Logger's typed field constructors (zap.String, zap.Int, ...) catch a
+// mismatched argument at compile time instead. Scope: every selector
+// expression, in production and test code alike, in any file whose package
+// (not necessarily that file itself) imports zap. In practice this only ever
+// fires in a file that itself imports zap, since the zap.SugaredLogger
+// reference this check matches requires that file's own zap import to
+// compile.
 func checkSugarType(sel *ast.SelectorExpr, enclosing string, fileCtx *fileContext) []violation {
 	ident, ok := sel.X.(*ast.Ident)
 	if !ok || ident.Name != fileCtx.ZapAlias || sel.Sel.Name != "SugaredLogger" {

--- a/modules/acl/controlplane/aclpb/v1/convert.go
+++ b/modules/acl/controlplane/aclpb/v1/convert.go
@@ -113,7 +113,7 @@ func FromRules(rules []cacl.AclRule) []*Rule {
 // to the given cacl action kind.
 //
 // Unrecognized cacl kinds map to ActionKind_ACTION_KIND_PASS (the proto
-// zero value); FromActions does not surface an error in this direction
+// zero value). FromActions does not surface an error in this direction
 // because input comes from a typed Go value, not the wire.
 func (m *Action) setFromCAclKind(kind uint32) {
 	switch kind {

--- a/modules/acl/tests/functional/acl_bench_dataset_test.go
+++ b/modules/acl/tests/functional/acl_bench_dataset_test.go
@@ -491,7 +491,7 @@ func hostInNet(network filter.IPNet, hostBits int) net.IP {
 //
 // This way a batch lands in many distinct classifier classes and table
 // cells the way mixed real traffic does. Uniform sampling over rules is
-// a worst-case-ish cache workload; real traffic is more skewed.
+// a worst-case-ish cache workload — real traffic is more skewed.
 func synthesizeDatasetPackets(
 	tb testing.TB, rules []cacl.AclRule, limit int,
 ) []gopacket.Packet {
@@ -752,7 +752,7 @@ var datasetTopoDevices = []string{
 }
 
 // datasetTopoACLDevices lists positions in datasetTopoDevices whose
-// input pipeline runs ACL; the .2000 device carries the fwstate path in
+// input pipeline runs ACL. The .2000 device carries the fwstate path in
 // production and bypasses ACL.
 var datasetTopoACLDevices = []uint16{0, 1, 2, 3, 5, 6}
 
@@ -768,7 +768,7 @@ var (
 // Production dumps scope every rule explicitly, so real rulesets pass
 // through untouched. Synthesized rules carry no device scopes, which
 // would collapse the device classifier column to a single class and
-// reduce the topology benchmark to batch splitting; the catch-all rule
+// reduce the topology benchmark to batch splitting. The catch-all rule
 // spans every rule-bearing device the way per-device catch-alls do in
 // production. The remaining replayed devices deliberately stay
 // rule-free: in the production dump they carry traffic but no rules,

--- a/modules/acl/tests/functional/acl_bench_test.go
+++ b/modules/acl/tests/functional/acl_bench_test.go
@@ -162,7 +162,7 @@ func benchDiversePacket(b *testing.B, idx int) gopacket.Packet {
 // regions for benchmarks that compile a large number of rules.
 //
 // The shared package constants (aclCPSize/aclDPSize/aclMemSize) are sized for
-// functional tests; 10 000 compiled ACL rules require a significantly larger
+// functional tests. 10 000 compiled ACL rules require a significantly larger
 // agent arena and CP region.
 func setupACLHarnessLarge(b *testing.B, devices []string) (*dataplaneut.Harness, *ffi.Agent, acl.Backend) {
 	b.Helper()

--- a/modules/acl/tests/functional/acl_net6_share_test.go
+++ b/modules/acl/tests/functional/acl_net6_share_test.go
@@ -60,7 +60,7 @@ func setNet6ShareDisabled(t *testing.T, disabled bool) {
 // classification mechanism rather than the ACL action logic: the specific
 // actions only need to be distinguishable, not meaningful.
 func net6ShareEdgeCaseRules() []cacl.AclRule {
-	// divergeBroad has no port constraint (filter_ip6); divergeNested is
+	// divergeBroad has no port constraint (filter_ip6). divergeNested is
 	// a narrower network scoped to a destination port (filter_ip6_port).
 	// An address inside the nested network lands in a partition that
 	// filter_ip6's own classifier never has to distinguish, exactly the
@@ -316,7 +316,7 @@ func collectNet6ShareVerdicts(
 // acl_module_init_net6_share returns without building the shared trie in
 // three cases: the kill switch, filter_rule_count_ip6 == 0, and
 // filter_rule_count_ip6_port == 0. The kill switch is closed off by the
-// ambient-environment check below; the other two are closed off by
+// ambient-environment check below. The other two are closed off by
 // asserting both rule counts are non-zero on the shared side, since
 // net6ShareEdgeCaseRules always supplies both port-scoped and
 // non-port-scoped v6 rules. Without that assertion, a ruleset lacking
@@ -389,7 +389,7 @@ func runNet6ShareVerdictParity(
 // allocator overhead pushes the default 64/16 MB harness out of memory
 // while compiling filter_ip6_port, even for the unshared baseline subtest,
 // so the failure tracks the sanitizer build, not the sharing change. 128/32
-// MB was the smallest size found to pass under ASan; 192/48 MB adds
+// MB was the smallest size found to pass under ASan. 192/48 MB adds
 // headroom for allocator-layout and runner-to-runner variance while still
 // measuring well under 512 MiB peak RSS in either build mode.
 func TestACL_Net6Share_VerdictParity(t *testing.T) {
@@ -417,7 +417,7 @@ func TestACL_Net6Share_VerdictParity(t *testing.T) {
 // ~1.74 GiB peak RSS under ASan, still comfortably under the 2 GiB a
 // standard CI runner can spare. This tier runs in the default `make test`
 // and `make test-asan` paths, so it must stay well inside that budget in
-// both build modes; TestACL_Net6Share_VerdictParity_ScaleHeavy carries the
+// both build modes. TestACL_Net6Share_VerdictParity_ScaleHeavy carries the
 // production-scale rule count instead.
 func TestACL_Net6Share_VerdictParity_Scale(t *testing.T) {
 	const (

--- a/modules/balancer2/bindings/go/cbalancer2/cgo.go
+++ b/modules/balancer2/bindings/go/cbalancer2/cgo.go
@@ -62,7 +62,7 @@ type SessionTable struct {
 }
 
 // SessionTableChain is an opaque handle to a session table chain in shared
-// memory. A chain references session tables but does not own them; the
+// memory. A chain references session tables but does not own them. The
 // referenced tables must outlive the chain.
 type SessionTableChain struct {
 	ptr *C.struct_balancer_session_table_chain
@@ -70,7 +70,7 @@ type SessionTableChain struct {
 
 // Install installs the balancer handle in the dataplane. If a balancer with
 // the same name is already installed, it is replaced and the previous handle
-// becomes unused; the caller is responsible for freeing it.
+// becomes unused. The caller is responsible for freeing it.
 func (m *Balancer) Install(agent *ffi.Agent) error {
 	var cErr *C.yanet_error
 	if rc := C.balancer_install((*C.struct_agent)(agent.AsRawPtr()), m.ptr, &cErr); rc != 0 {
@@ -161,7 +161,7 @@ func (m *SessionTableChain) Free(agent *ffi.Agent) {
 
 // PushFront pushes the given table as the new front (primary) session table.
 // Workers look up sessions in the front table first and fall back to the
-// previous (back) table; new sessions are always created in the front table.
+// previous (back) table. New sessions are always created in the front table.
 // Returns an error if two tables are already attached.
 func (m *SessionTableChain) PushFront(table *SessionTable) error {
 	var cErr *C.yanet_error

--- a/modules/balancer2/bindings/go/cbalancer2/safe.go
+++ b/modules/balancer2/bindings/go/cbalancer2/safe.go
@@ -24,7 +24,7 @@ type SessionTimeouts struct {
 // traffic to.
 //
 // Dst is the real's destination address. Src is the source network used as
-// the encapsulation source (for the IPIP/GRE tunnel); its mask may be any
+// the encapsulation source (for the IPIP/GRE tunnel). Its mask may be any
 // (possibly non-contiguous) bitmask, and its address family must match Dst.
 type RealConfig struct {
 	Dst         netip.Addr
@@ -35,7 +35,7 @@ type RealConfig struct {
 // AllowedSources describes one entry in a virtual service's source allow
 // list. A packet is admitted only if its source address matches one of the
 // listed networks AND its source port matches one of the listed ranges. An
-// empty set of networks disallows all networks; an empty set of ports allows
+// empty set of networks disallows all networks. An empty set of ports allows
 // all ports.
 type AllowedSources struct {
 	Net4s       filter.IPNets

--- a/modules/forward/tests/functional/forward_test.go
+++ b/modules/forward/tests/functional/forward_test.go
@@ -513,7 +513,7 @@ func TestForward_UnmappedDevice(t *testing.T) {
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
 
-	// "phantom" is never registered via UpdatePlainDevices; its mc_index
+	// "phantom" is never registered via UpdatePlainDevices. Its mc_index
 	// entry stays at the initial sentinel value of -1.
 	rule := cforward.ForwardRule{
 		Target:  "phantom",
@@ -525,7 +525,7 @@ func TestForward_UnmappedDevice(t *testing.T) {
 
 	h, agent, backend := setupForwardHarness(t, []string{"port0"})
 	applyRules(t, backend, "test", []cforward.ForwardRule{rule})
-	// Only port0 is wired; "phantom" has no cp_device entry.
+	// Only port0 is wired. "phantom" has no cp_device entry.
 	wireForwardPipeline(t, agent, "port0", "test", nil)
 
 	result, err := h.HandlePackets(pkt)
@@ -694,7 +694,7 @@ func TestForward_MinAction(t *testing.T) {
 	require.Len(t, result.Output, 1, "packet must pass through via rule 0 (ModeNone)")
 	require.Empty(t, result.Drop, "packet must not be dropped")
 
-	// Rule 0 counter must be 1; rule 1 counter must be 0 (never selected).
+	// Rule 0 counter must be 1 — rule 1 counter must be 0 (never selected).
 	path := dataplaneut.CounterPath{
 		Device:     "port0",
 		Pipeline:   "test",

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -42,7 +42,7 @@ func WithLog(log *zap.Logger) Option {
 // WithMetrics enables collection of gRPC call metrics using the supplied
 // factory.
 //
-// The factory owns label extraction and bucketing; the service injects its own
+// The factory owns label extraction and bucketing. The service injects its own
 // retention provider at construction time. Use [NewMetricsFactory] to build a
 // factory scoped to this module's services.
 func WithMetrics(factory grpcmetrics.Factory) Option {

--- a/modules/fwstate/tests/functional/fwstate_test.go
+++ b/modules/fwstate/tests/functional/fwstate_test.go
@@ -149,7 +149,7 @@ func wireFWSPipeline(t *testing.T, agent *ffi.Agent, name string) {
 // Ethernet (VLAN) -> 802.1Q (IPv6) -> IPv6 (UDP) -> UDP -> syncFrame payload.
 //
 // srcIP6 is the IPv6 source address. An all-zero source marks an internal
-// originator; any non-zero source is external.
+// originator. Any non-zero source is external.
 func buildSyncPacketLayers(srcIP6 net.IP, syncFrame []byte) []gopacket.SerializableLayer {
 	eth := &layers.Ethernet{
 		SrcMAC:       net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff},

--- a/modules/mirror/tests/functional/mirror_test.go
+++ b/modules/mirror/tests/functional/mirror_test.go
@@ -404,7 +404,7 @@ func TestMirror_UnmappedDevice(t *testing.T) {
 	pkt := xpacket.LayersToPacket(t, &eth, &ip4, &icmp)
 	pktSize := uint64(len(pkt.Data()))
 
-	// "phantom" is never registered via UpdatePlainDevices; its mc_index
+	// "phantom" is never registered via UpdatePlainDevices. Its mc_index
 	// entry stays at the initial sentinel value of -1.
 	rule := cmirror.MirrorRule{
 		Target:  "phantom",
@@ -416,7 +416,7 @@ func TestMirror_UnmappedDevice(t *testing.T) {
 
 	h, agent, backend := setupMirrorHarness(t, []string{"port0"})
 	applyRules(t, backend, "test", []cmirror.MirrorRule{rule})
-	// Only port0 is wired; "phantom" has no cp_device entry.
+	// Only port0 is wired. "phantom" has no cp_device entry.
 	wireMirrorPipeline(t, agent, "port0", "test", nil)
 
 	result, err := h.HandlePackets(pkt)
@@ -585,7 +585,7 @@ func TestMirror_MinAction(t *testing.T) {
 	require.Len(t, result.Output, 1, "passthrough packet has no mirror copy")
 	require.Empty(t, result.Drop, "packet must not be dropped")
 
-	// Rule 0 counter must be 1; rule 1 counter must be 0 (never selected).
+	// Rule 0 counter must be 1 — rule 1 counter must be 0 (never selected).
 	path := dataplaneut.CounterPath{
 		Device:     "port0",
 		Pipeline:   "test",

--- a/modules/route-mpls/controlplane/backend.go
+++ b/modules/route-mpls/controlplane/backend.go
@@ -14,7 +14,7 @@ type ModuleHandle interface {
 }
 
 // Compile-time assertion that *croutempls.ModuleConfig satisfies the
-// ModuleHandle interface; catches drift in the bindings layer.
+// ModuleHandle interface. Catches drift in the bindings layer.
 var _ ModuleHandle = (*croutempls.ModuleConfig)(nil)
 
 // Backend abstracts shared memory write-path operations for the route-mpls

--- a/modules/route-mpls/controlplane/service_test.go
+++ b/modules/route-mpls/controlplane/service_test.go
@@ -217,7 +217,7 @@ func Test_RouteMPLSService_CreateConfig_BackendFailure(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Second call fails; old config must be preserved.
+	// Second call fails. Old config must be preserved.
 	_, err = svc.CreateConfig(ctx, &routemplspb.CreateConfigRequest{
 		Name:  "mpls0",
 		Rules: []*routemplspb.Rule{makeRule(t, "10.0.1.0/24", "203.0.113.2", 200)},

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -30,7 +30,7 @@ type ModuleHandle interface {
 }
 
 // Compile-time assertion that *croute.ModuleConfig satisfies the
-// ModuleHandle interface; catches drift in the bindings layer.
+// ModuleHandle interface. Catches drift in the bindings layer.
 var _ ModuleHandle = (*croute.ModuleConfig)(nil)
 
 // CounterView is a single dataplane counter read back from one position at

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -38,7 +38,7 @@ func WithLog(log *zap.Logger) Option {
 // RouteModule is the slim route-module shim that owns shared memory and
 // exposes the routepb.RouteService gRPC surface.
 //
-// The module no longer owns a RIB or a neighbour table; the
+// The module no longer owns a RIB or a neighbour table. The
 // yanet-route-operator agent rebuilds the FIB and pushes it via
 // UpdateFIB.
 type RouteModule struct {

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -125,7 +125,7 @@ func wirePipeline(
 
 // applyFIB pushes entries via backend.UpdateModule and registers cleanup.
 //
-// Returns the route.ModuleHandle; the caller may inspect it. The handle is
+// Returns the route.ModuleHandle. The caller may inspect it. The handle is
 // freed via tb.Cleanup.
 func applyFIB(
 	tb testing.TB,
@@ -699,7 +699,7 @@ func TestRoute_Counters(t *testing.T) {
 		require.Equal(t, uint64(0), byDevName["output_pending_output"][0], "device output_pending_output must equal 0")
 
 		// The route module drops an unmatched packet itself, so its own
-		// drop counter records it (rx in, drop out; tx stays zero).
+		// drop counter records it (rx in, drop out, tx stays zero).
 		routeModulePath := dataplaneut.CounterPath{
 			Device: "port0", Pipeline: "test", Function: "test",
 			Chain: "test_chain", ModuleType: "route", ModuleName: "test",
@@ -850,7 +850,7 @@ func TestRoute_PerOutcomeCounters(t *testing.T) {
 		Device: "phantom",
 	}
 
-	// FIB installed so matching packets reach a nexthop; a TTL check fires
+	// FIB installed so matching packets reach a nexthop. A TTL check fires
 	// before the lookup, so ttl-expired cases still target a real prefix.
 	fib := []FIBEntry{
 		{Prefix: netip.MustParsePrefix("10.0.0.0/24"), Nexthops: []FIBNexthop{routeNextHop}},

--- a/operators/bird-adapter/internal/bird/update_test.go
+++ b/operators/bird-adapter/internal/bird/update_test.go
@@ -42,7 +42,7 @@ var dataIPv6WithLargeCommunities = []byte{
 	64: 0x76, 0, 0, 0,
 
 	// attributes
-	// AttrOrigin 0x01 - first byte;  69: PROTOCOL_BGP = 0x4, 0, 0 - packed LE int
+	// AttrOrigin 0x01 - first byte, 69: PROTOCOL_BGP = 0x4, 0, 0 - packed LE int
 	68: 0x1, 69: 0x4, 0, 0,
 	// value of the AttrOrigin - LE u32
 	72: 0x2, 0, 0, 0,
@@ -51,7 +51,7 @@ var dataIPv6WithLargeCommunities = []byte{
 	76: 0x2, 0x4, 0, 0,
 	//  Complex attribute length LE u32 0xe == 14
 	80: 0xe, 0, 0, 0,
-	// Segment Type 0x2 = ASPathSequence; 85: Segment Size 0x3 = 3 AS
+	// Segment Type 0x2 = ASPathSequence, 85: Segment Size 0x3 = 3 AS
 	84: 0x2, 85: 0x3,
 	// AS#3 - PeerAS LE u32 - 0x0000c7fa = 51194 - nearest to us
 	86: 0, 0, 0xc7, 0xf1,
@@ -60,24 +60,24 @@ var dataIPv6WithLargeCommunities = []byte{
 	// AS#1 - OriginAS = 0x00005c52 = 23634
 	94: 0, 0, 0x5c, 0x52,
 
-	// AttrNextHop 0x3; PROTOCOL_BGP
+	// AttrNextHop 0x3, PROTOCOL_BGP
 	98: 0x3, 0x4, 0, 0,
 	// Complex attribute length LE u32 0x10 == 16 - one ipv6 addr
 	102: 0x10, 0, 0, 0,
 	//  NextHop addr 16 bytes as 4 LE u32 == "2a02:2891:9:200::13"
 	106: 0x91, 0x28, 0x2, 0x2a, 0, 0x2, 0x9, 0, 0, 0, 0, 0, 0x13, 0, 0, 0,
 
-	// AttrLocalPref 0x5; PROTOCOL_BGP - simple u32 attributes
+	// AttrLocalPref 0x5, PROTOCOL_BGP - simple u32 attributes
 	122: 0x5, 0x4, 0, 0,
 	// LocalPref 0x64 == 100
 	126: 0x64, 0, 0, 0,
-	// AttrCommunity 0x8; PROTOCOL_BGP
+	// AttrCommunity 0x8, PROTOCOL_BGP
 	130: 0x8, 0x4, 0, 0,
 	// AttrCommunity length - 16
 	134: 0x10, 0, 0, 0,
 	138: 0x2, 0, 0xf1, 0xc7, 0xf6, 0x1, 0xf1, 0xc7, 0x9a, 0x2, 0xf1, 0xc7, 0x12, 0x8, 0xf1, 0xc7,
 
-	// AttrLargeCommunity 0x20; PROTOCOL_BGP
+	// AttrLargeCommunity 0x20, PROTOCOL_BGP
 	154: 0x20, 0x4, 0, 0,
 	// Complex attribute length 0x18 = 24
 	158: 0x18, 0, 0, 0,
@@ -196,7 +196,7 @@ func TestDecodeUpdate(t *testing.T) {
 				// ASPath
 				76: 0x2, 0x4, 0, 0,
 				80: 0x1e, 0, 0, 0, // ASPath area size = 30 bytes
-				84: 0x2, 85: 0x7, // 84: ASPathSequence; 85: ASPathLen == 0x7
+				84: 0x2, 85: 0x7, // 84: ASPathSequence, 85: ASPathLen == 0x7
 				0, 0, 0xbb, 0xc6, // 1
 				0, 0, 0x5, 0x13, // 2
 				0, 0, 0x1d, 0x79, // 3
@@ -204,16 +204,16 @@ func TestDecodeUpdate(t *testing.T) {
 				0, 0, 0x97, 0x93, // 5
 				0, 0, 0x97, 0x93, // 6
 				0, 0, 0x97, 0x93, // 7
-				114: 0x3, 0x4, 0, 0, // 0x3 = AttrNextHop; PROTOCOL_BGP
+				114: 0x3, 0x4, 0, 0, // 0x3 = AttrNextHop, PROTOCOL_BGP
 				118: 0x10, 0, 0, 0, // NextHop size LE u32 = 16 bytes
 				// nextHop ::ffff:c342:e2fe == ::ffff:195.66.226.254
 				122: 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0xfe, 0xe2, 0x42, 0xc3,
-				138: 0x5, 0x4, 0, 0, // AttrLocalPref = 0x5; PROTOCOL_BGP
+				138: 0x5, 0x4, 0, 0, // AttrLocalPref = 0x5, PROTOCOL_BGP
 				142: 0x64, 0, 0, 0, // LE u32 == 100
-				146: 0x8, 0x4, 0, 0, // AttrCommunity; PROTOCOL_BGP
+				146: 0x8, 0x4, 0, 0, // AttrCommunity, PROTOCOL_BGP
 				0x4, 0, 0, 0, // 4 bytes
 				0x64, 0, 0xc6, 0xbb,
-				0x20, 0x4, 0, 0, // AttrLargeCommunity; PROTOCOL_BGP
+				0x20, 0x4, 0, 0, // AttrLargeCommunity, PROTOCOL_BGP
 				0xc, 0, 0, 0, // 12 bytes == 3 u32
 				0xc6, 0xbb, 0, 0,
 				0x64, 0, 0, 0,
@@ -246,7 +246,7 @@ func TestDecodeUpdate(t *testing.T) {
 			data: []byte{
 				1, 0x18, 8, 5: 7, 7: 1, 24: 0x10, 0x92, 0x53, 9, 0x1c, 0x5b, 32: 1,
 				0x11, 8, 0, 0, 0x80, 0, 1, 2, 56: 1,
-				// global_id at 60 (zero); attrsAreaSize=0x4e=78 at 64
+				// global_id at 60 (zero), attrsAreaSize=0x4e=78 at 64
 				64: 0x4e, 0, 0, 0, 1, 4,
 				76: 2, 4, 0, 0, 0x12, 0, 0, 0, 2, 4, 0, 6, 0x14, 0x81, 0, 0, 5,
 				93: 0x13, 0, 0, 0x1d, 0x79, 0, 0, 0x97, 0x93, 3, 4, 0, 0, 0x10,
@@ -444,7 +444,7 @@ func TestDecodeUpdate(t *testing.T) {
 				1: 0x8,     // prefix len
 				2: 0x14, 0, // NetAddr struct size
 				8: 0, 0, 0, 0, 0, 0, 0x1, 0, // RD LE u64
-				// global_id at 60 (zero); attrsAreaSize at 64
+				// global_id at 60 (zero), attrsAreaSize at 64
 				64: 2,    // ERROR attrsAreaSize=2 but only 2 bytes available (need at least 4 for attr type)
 				68: 0, 0, // truncated attrs data
 			},

--- a/operators/bird-adapter/service.go
+++ b/operators/bird-adapter/service.go
@@ -197,7 +197,7 @@ type importHolder struct {
 	export        *bird.Export                                                       // Reads/parses routes from BIRD
 	cancel        context.CancelFunc                                                 // Stops this import's goroutines (runBirdImportLoop, RunExport)
 	conn          *grpc.ClientConn                                                   // gRPC connection to the route operator's RouteService
-	currentStream *grpc.ClientStreamingClient[routepb.Update, routepb.UpdateSummary] // Active gRPC stream for RIB updates; replaced on reconnect
+	currentStream *grpc.ClientStreamingClient[routepb.Update, routepb.UpdateSummary] // Active gRPC stream for RIB updates, replaced on reconnect
 	sockets       []string                                                           // Unix socket paths being read from
 	createdAt     time.Time                                                          // Timestamp when the session was created
 }
@@ -249,7 +249,7 @@ func (m *importHolder) RunExport(ctx context.Context) error {
 
 // CloseStream closes the active gRPC stream to the route operator.
 //
-// The summary the route operator returns on close is discarded; callers
+// The summary the route operator returns on close is discarded — callers
 // only care whether the close itself failed.
 func (m *importHolder) CloseStream() error {
 	_, err := (*m.currentStream).CloseAndRecv()

--- a/operators/decap/internal/operator/actuator_gateway.go
+++ b/operators/decap/internal/operator/actuator_gateway.go
@@ -26,7 +26,7 @@ type GatewayActuator struct {
 
 // NewGatewayActuator dials the gateway endpoint and returns a
 // ready-to-use actuator for all configured functions. The connection is
-// kept open for the lifetime of the actuator; call Close to release it.
+// kept open for the lifetime of the actuator — call Close to release it.
 func NewGatewayActuator(
 	cfg operator.GatewayConfig,
 	functions []FunctionConfig,
@@ -77,7 +77,7 @@ func NewGatewayActuator(
 // Apply pushes every module config and then ensures all function
 // definitions are correct on the gateway.
 //
-// Errors from individual modules or functions are joined; the reconcile
+// Errors from individual modules or functions are joined — the reconcile
 // loop applies backoff, so each Apply pass tries everything regardless
 // of partial failures.
 func (m *GatewayActuator) Apply(ctx context.Context, state State) error {

--- a/operators/decap/internal/operator/source.go
+++ b/operators/decap/internal/operator/source.go
@@ -28,7 +28,7 @@ type staticSource struct {
 }
 
 // NewStaticSource constructs a staticSource holding the supplied module
-// configs. The slice is not copied; callers must not modify it after
+// configs. The slice is not copied — callers must not modify it after
 // passing it in.
 func NewStaticSource(modules []ModuleConfig, options ...StaticSourceOption) operator.StateSource[State] {
 	opts := newStaticSourceOptions()
@@ -49,7 +49,7 @@ func (m *staticSource) Snapshot() (State, bool) {
 
 // Wake returns the channel the Reconciler monitors for eager wakeups.
 //
-// staticSource never signals it; the reconcile interval is the sole
+// staticSource never signals it — the reconcile interval is the sole
 // pacing mechanism.
 func (m *staticSource) Wake() <-chan struct{} { return m.wake }
 

--- a/operators/forward/internal/operator/actuator_gateway.go
+++ b/operators/forward/internal/operator/actuator_gateway.go
@@ -26,7 +26,7 @@ type GatewayActuator struct {
 
 // NewGatewayActuator dials the gateway endpoint and returns a
 // ready-to-use actuator for all configured functions. The connection is
-// kept open for the lifetime of the actuator; call Close to release it.
+// kept open for the lifetime of the actuator — call Close to release it.
 func NewGatewayActuator(
 	cfg operator.GatewayConfig,
 	functions []FunctionConfig,
@@ -77,7 +77,7 @@ func NewGatewayActuator(
 // Apply pushes every module config and then ensures all function
 // definitions are correct on the gateway.
 //
-// Errors from individual modules or functions are joined; the reconcile
+// Errors from individual modules or functions are joined — the reconcile
 // loop applies backoff, so each Apply pass tries everything regardless
 // of partial failures.
 func (m *GatewayActuator) Apply(ctx context.Context, state State) error {

--- a/operators/forward/internal/operator/source.go
+++ b/operators/forward/internal/operator/source.go
@@ -29,7 +29,7 @@ type staticSource struct {
 }
 
 // NewStaticSource constructs a staticSource holding the supplied module
-// configs. The slice is not copied; callers must not modify it after
+// configs. The slice is not copied — callers must not modify it after
 // passing it in.
 func NewStaticSource(modules []ModuleConfig, options ...StaticSourceOption) operator.StateSource[State] {
 	opts := newStaticSourceOptions()
@@ -49,7 +49,7 @@ func (m *staticSource) Snapshot() (State, bool) {
 }
 
 // Wake returns the channel the Reconciler monitors for eager wakeups.
-// staticSource never signals it; the reconcile interval is the sole
+// staticSource never signals it — the reconcile interval is the sole
 // pacing mechanism.
 func (m *staticSource) Wake() <-chan struct{} { return m.wake }
 

--- a/operators/route/internal/discovery/neigh/neigh.go
+++ b/operators/route/internal/discovery/neigh/neigh.go
@@ -359,7 +359,7 @@ func (m *NeighMonitor) notifyResynced() {
 // so it must be rejected rather than emitted. Links without an Ethernet
 // address of their own — tunnels and other point-to-point devices — report
 // a nil or short HardwareAddr, and the loopback device reports six genuine
-// zero bytes; both fail this check. A true result also guarantees exactly
+// zero bytes. Both fail this check. A true result also guarantees exactly
 // six bytes, which the caller relies on: its [6]byte(hardwareAddr) array
 // conversion panics on any other length.
 func isUsableSourceMAC(hardwareAddr net.HardwareAddr) bool {

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -90,7 +90,7 @@ func (m *GatewayActuator) Close() error {
 // then republishes the operator's network function.
 //
 // Every FIB is attempted and the function is published even on a partial
-// failure; the joined errors let the reconcile loop retry under backoff.
+// failure — the joined errors let the reconcile loop retry under backoff.
 func (m *GatewayActuator) Apply(ctx context.Context, snapshot RouteSnapshot) error {
 	neighbours := neigh.FilterByDevices(snapshot.Neighbours, m.devices)
 

--- a/operators/route/internal/operator/cfg.go
+++ b/operators/route/internal/operator/cfg.go
@@ -42,7 +42,7 @@ type Config struct {
 	Reconcile operator.ReconcileConfig   `yaml:"reconcile"`
 	Static    StaticConfig               `yaml:"static"`
 	// Function is the single gateway-side network function published by
-	// this operator. Re-applied every reconcile pass; idempotent updates.
+	// this operator. Re-applied every reconcile pass — idempotent updates.
 	Function       FunctionConfig       `yaml:"function"`
 	LinkMap        map[string]string    `yaml:"link_map"`
 	RIBTTL         time.Duration        `yaml:"rib_ttl"`

--- a/operators/route/internal/operator/fib_build_test.go
+++ b/operators/route/internal/operator/fib_build_test.go
@@ -236,7 +236,7 @@ func Test_BuildFIB_DeviceFilterStarvesPrefix(t *testing.T) {
 // filter, so the device set is left empty here.
 func Test_BuildFIB_FallsBackToLiveRouteWhenBestUnresolvable(t *testing.T) {
 	cache := rcucache.NewEmptyCache[netip.Addr, neigh.NeighbourEntry]()
-	// Only the worse route's nexthop is resolvable; the best route's
+	// Only the worse route's nexthop is resolvable — the best route's
 	// nexthop has no neighbour entry.
 	cache.Set(netip.MustParseAddr("10.0.0.1"), neigh.NeighbourEntry{
 		HardwareRoute: neigh.HardwareRoute{
@@ -346,7 +346,7 @@ func Test_BuildFIB_MultiPrefix(t *testing.T) {
 	p4 := netip.MustParseAddr("192.0.2.4")
 
 	ribDump := maptrie.NewMapTrie[netip.Prefix, netip.Addr, rib.RoutesList](2)
-	// Wider prefix: three equal-cost bird routes; one egresses through the
+	// Wider prefix: three equal-cost bird routes — one egresses through the
 	// excluded eth2, leaving two ECMP nexthops on eth1.
 	ribDump[24][netip.MustParsePrefix("10.0.0.0/24")] = rib.RoutesList{
 		Routes: []rib.Route{

--- a/operators/route/internal/operator/metrics.go
+++ b/operators/route/internal/operator/metrics.go
@@ -153,7 +153,7 @@ func (m *Metrics) OnRIBSessionEnd(name string, sessionID uint64) {
 // through a FeedRIB stream session.
 //
 // Unary route mutations (InsertRoute/DeleteRoute) and static-config
-// seeding also change RIB contents but are not counted here; they are
+// seeding also change RIB contents but are not counted here — they are
 // visible through the RIB gauges instead.
 func (m *Metrics) OnRIBUpdate(n int) {
 	m.ribFeedUpdates.Add(uint64(n))

--- a/operators/route/internal/operator/options.go
+++ b/operators/route/internal/operator/options.go
@@ -32,7 +32,7 @@ func WithLog(log *zap.Logger) Option {
 
 // WithMetrics overrides the factory used to construct the metrics sink.
 //
-// The default factory is NewMetrics; use this to wrap or extend the
+// The default factory is NewMetrics. Use this to wrap or extend the
 // default sink, for example to share it with an externally owned
 // metrics-service registration.
 func WithMetrics(factory MetricsFactory) Option {

--- a/operators/route/internal/operator/readiness_test.go
+++ b/operators/route/internal/operator/readiness_test.go
@@ -924,7 +924,7 @@ func TestStaticRIBReadiness_PostPreRunReady(t *testing.T) {
 		return helper.Run(ctx)
 	})
 
-	// 50ms is far shorter than the 500ms sample_interval; any readiness change
+	// 50ms is far shorter than the 500ms sample_interval — any readiness change
 	// here can only come from the entry evaluate, not a ticker tick.
 	require.Eventually(t, func() bool {
 		s := requireScope(t, tracker, "rib")

--- a/operators/route/internal/operator/rib_readiness.go
+++ b/operators/route/internal/operator/rib_readiness.go
@@ -66,7 +66,7 @@ type birdRIBReadiness struct {
 	tracker    *readiness.Tracker
 
 	// counter is the total number of route updates applied in the current
-	// session. Written by OnUpdate on the FeedRIB hot path; read by Run.
+	// session. Written by OnUpdate on the FeedRIB hot path, read by Run.
 	counter atomic.Int64
 
 	// mu guards session/settle fields and the consistency of rib/bird-session
@@ -172,7 +172,7 @@ func (m *birdRIBReadiness) ribSyncingState() readinesspb.State {
 //
 // sessionID is the id returned by ribRef.NewSession and is stored so that a
 // stale OnSessionEnd from a superseded stream can be ignored. The bird-session
-// scope transitions to READY; the rib scope resets the bulk-settle gate and
+// scope transitions to READY. The rib scope resets the bulk-settle gate and
 // enters the syncing state.
 func (m *birdRIBReadiness) OnSessionStart(name string, sessionID uint64) {
 	if name != m.configName {
@@ -204,7 +204,7 @@ func (m *birdRIBReadiness) OnUpdate(n int) {
 // OnSessionEnd is called by FeedRIB when the stream ends for the given config.
 //
 // sessionID must match the id passed to the most recent OnSessionStart for
-// name; if it does not, the call is from a superseded stream and is silently
+// name. If it does not, the call is from a superseded stream and is silently
 // ignored to prevent a stale end from clobbering the active session state.
 // When the session id matches, bird-session transitions to
 // DEGRADED(RECONNECTING) and rib to DEGRADED(SESSION_ENDED) — routes remain
@@ -265,7 +265,8 @@ func (m *birdRIBReadiness) tick(now time.Time, rate float64) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Re-stamp bird-session freshness each tick; tick re-confirms session liveness.
+	// Re-stamp bird-session freshness each tick — the tick re-confirms
+	// session liveness.
 	m.tracker.Touch("bird-session")
 
 	if !m.bulkSettled {
@@ -276,7 +277,7 @@ func (m *birdRIBReadiness) tick(now time.Time, rate float64) {
 				m.bulkSettled = true
 			}
 		} else {
-			// Rate spiked above threshold; reset the continuous window.
+			// Rate spiked above threshold — reset the continuous window.
 			m.belowSince = time.Time{}
 		}
 	}

--- a/operators/route/internal/operator/route_source.go
+++ b/operators/route/internal/operator/route_source.go
@@ -30,7 +30,7 @@ type RouteSnapshot struct {
 // turns into its own FIB.
 //
 // Wake is signalled by the wake callbacks wired into RouteService and
-// NeighbourService whenever their state mutates; it preempts the
+// NeighbourService whenever their state mutates — it preempts the
 // reconcile loop's sleep so the next pass picks up the change without
 // waiting for the steady-state interval.
 type RouteSource struct {

--- a/operators/route/internal/operator/service_route.go
+++ b/operators/route/internal/operator/service_route.go
@@ -251,7 +251,7 @@ func (m *RouteService) InsertRoute(
 	}
 
 	// Wake the reconcile loop only when the caller explicitly asks for a
-	// flush; otherwise the RIB mutation is buffered until a later flush.
+	// flush — otherwise the RIB mutation is buffered until a later flush.
 	if req.GetDoFlush() {
 		m.onChanged()
 	}
@@ -300,7 +300,7 @@ func (m *RouteService) DeleteRoute(
 	}
 
 	// Wake the reconcile loop only when the caller explicitly asks for a
-	// flush; otherwise the RIB mutation is buffered until a later flush.
+	// flush — otherwise the RIB mutation is buffered until a later flush.
 	if req.GetDoFlush() {
 		m.onChanged()
 	}

--- a/operators/route/internal/rib/rib_test.go
+++ b/operators/route/internal/rib/rib_test.go
@@ -32,7 +32,7 @@ func routesForPrefix(t *testing.T, r *RIB, prefix netip.Prefix) []Route {
 // with a Bird source does not remove BGP routes from distinct peers even when
 // the nexthop matches.
 //
-// BGP route identity is peer-scoped; the unary API carries no peer, so the
+// BGP route identity is peer-scoped. The unary API carries no peer, so the
 // candidate Peer is IPv6Unspecified. A real BGP route has a non-unspecified
 // Peer, so IsSameIdentity must return false and neither route may be removed.
 func TestRemoveUnicastRoute_BGPPeerIsolation(t *testing.T) {

--- a/operators/route/internal/rib/routes.go
+++ b/operators/route/internal/rib/routes.go
@@ -40,7 +40,7 @@ type Route struct {
 	// GlobalID is the route identifier reported by BIRD, used together with
 	// the peer to identify a BGP path within a prefix.
 	//
-	// BIRD emits it on the wire immediately after the peer address; a peer
+	// BIRD emits it on the wire immediately after the peer address. A peer
 	// re-announcing a prefix reuses the same GlobalID, so it drives the BGP
 	// implicit-replace decision.
 	GlobalID uint32
@@ -149,7 +149,7 @@ func (m *RoutesList) Insert(route Route) bool {
 // source's best-cost group.
 //
 // The list is assumed to be sorted best-first by routeCompareRev. For each
-// source, the first route seen establishes the best cost; every subsequent
+// source, the first route seen establishes the best cost. Every subsequent
 // route of the same source with equal cost is also marked true. Routes
 // strictly worse than their source's best are false.
 func (m *RoutesList) BestPerSourceMask() []bool {

--- a/operators/route/internal/rib/routes_test.go
+++ b/operators/route/internal/rib/routes_test.go
@@ -38,7 +38,7 @@ func TestRouteComparator(t *testing.T) {
 
 	b.ASPathLen = 2
 	a.Med = 1
-	// a has Med=1, b has Med=0; lower MED is better, so b beats a
+	// a has Med=1, b has Med=0 — lower MED is better, so b beats a
 	require.True(t, routeCompare(a, b) < 0)
 	// c has ASPathLen=0 which beats both a and b (ASPathLen=2)
 	require.True(t, routeCompare(c, a) > 0)
@@ -46,7 +46,7 @@ func TestRouteComparator(t *testing.T) {
 
 	routes := []Route{a, b, c}
 	slices.SortFunc(routes, routeCompareRev)
-	// c has ASPathLen=0 so it is the best; among equal ASPathLen, b (Med=0) beats a (Med=1)
+	// c has ASPathLen=0 so it is the best — among equal ASPathLen, b (Med=0) beats a (Med=1)
 	require.Equal(t, s(c, b, a), s(routes...))
 
 	b.Pref = 100

--- a/operators/route/operatorpb/v1/convert.go
+++ b/operators/route/operatorpb/v1/convert.go
@@ -95,7 +95,7 @@ func ToRIBRoute(route *Route, toRemove bool) (*rib.Route, error) {
 		OriginAS:         route.GetOriginAs(),
 		Med:              route.GetMed(),
 		Pref:             route.GetPref(),
-		// Wire field is uint32; saturate so absurdly long paths stay worst
+		// Wire field is uint32 — saturate so absurdly long paths stay worst
 		// instead of wrapping to best.
 		ASPathLen: uint8(min(route.GetAsPathLen(), uint32(math.MaxUint8))),
 		SourceID:  sourceID,


### PR DESCRIPTION
The comment prose convention now forbids joining two independent clauses with a semicolon, so this pays off the existing debt across the Go tree.

- Every rewrite either ends the sentence or uses a dash, whichever reads naturally at the site.
- The change is comment text only. The token stream of each touched file is byte-identical to before, and no compiler directive is affected.
- Seven sites in the style linter's own source are deliberately left alone. They travel with the follow-up change that adds the check enforcing this rule, which cannot be split from them cleanly.
