### PR TITLE
chore(gitignore): keep skills private by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,11 +137,19 @@ deploy/packages/
 # checkout, and a directory-only pattern does not match a symlink.
 .claude/agent-memory
 .claude/settings.*.json
-.claude/skills/loadtest-hw
-.agents/skills/loadtest-hw
 .claude/worktrees
 /.codex/
 /.agent-state
+
+# Ignore skills by default.
+#
+# Public skills are whitelisted below, so adding a new private skill needs
+# no change here.
+.agents/skills/*
+!.agents/skills/review-change
+!.agents/skills/ship-pr
+.claude/skills/*
+!.claude/skills/ship-pr
 
 ### Uncategorized ###
 # Worktree symlinks: a worktree may symlink this tree into the main


### PR DESCRIPTION
- Switch the skill directories from a blacklist of individually named private skills to a default-deny allowlist, so a new private skill is excluded automatically instead of needing a matching entry.
- Mirror the shape the repository already uses for out-of-tree modules, keeping the two policies expressed the same way.
- Invert which mistake is possible: forgetting an entry previously left a private skill committable, and now it makes adding a public skill fail loudly instead.
