### PR TITLE
chore(agents): drop references to skills that do not exist

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -83,10 +83,6 @@ Skills are architect-driven runbooks for recurring, multi-phase workflows
   worktree from confirmed `origin/main`, stage only intended files, open a
   scoped PR, drive CI to green, address every review/Codex finding, and merge
   with the right squash/rebase strategy. Use whenever work is ready to land.
-- **`raii-sweep`** — periodic C lifecycle-symmetry sweep (new/init/fini/free),
-  one prefix family per PR.
-- **`web-dedup`** — de-duplicate `web/` behind a mandatory zero-visual-diff
-  gate, one extraction per PR.
 
 ## Decision Framework
 


### PR DESCRIPTION
- Remove the two entries in the architect's skill list that name runbooks the repository no longer carries, so following the list cannot lead to invoking something that fails to load.
- The skills themselves were removed in #1531, which left the entries describing them behind.
- What remains listed is exactly the skill that is public, matching what a fresh clone actually gets.
