### PR TITLE
feat(route)!: make the FIB write path range-native

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,6 +3552,7 @@ dependencies = [
  "netip",
  "prost",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tabled",
  "tokio",

--- a/common/lpm.h
+++ b/common/lpm.h
@@ -5,7 +5,8 @@
  * 4-byte unsigned one. The tree organized into variable-length page tree
  * where values marked with the special flag.
  *
- * The tree does not allow to rewrite key-ranges or delete them.
+ * Inserted ranges cannot be deleted. Inserting a range overwrites the values
+ * of every key it covers, so on overlap the last insert wins.
  */
 
 #include <errno.h>

--- a/modules/route/bindings/go/croute/safe.go
+++ b/modules/route/bindings/go/croute/safe.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-
-	"github.com/yanet-platform/yanet2/common/go/xnetip"
 )
 
 const (
@@ -52,19 +50,26 @@ func (m *ModuleConfig) AddRouteList(routeIndices []uint32) (int, error) {
 	return m.addRouteList(routeIndices)
 }
 
-// AddPrefix adds a prefix to the LPM table, pointing at the given route list.
-func (m *ModuleConfig) AddPrefix(prefix netip.Prefix, routeListIdx uint32) error {
-	addrStart := prefix.Addr()
-	addrEnd := xnetip.LastAddr(prefix)
-
-	if addrStart.Is4() {
-		return m.addPrefixV4(addrStart.As4(), addrEnd.As4(), routeListIdx)
+// AddRange adds a contiguous address range to the LPM table, pointing at
+// the given route list.
+//
+// start and end must both be valid, belong to the same address family, and
+// satisfy start <= end. An IPv4-mapped IPv6 address is treated as IPv6,
+// since Is4 returns false for it.
+func (m *ModuleConfig) AddRange(start, end netip.Addr, routeListIdx uint32) error {
+	if !start.IsValid() || !end.IsValid() {
+		return fmt.Errorf("start and end must both be valid addresses")
 	}
-	if addrStart.Is6() {
-		return m.addPrefixV6(addrStart.As16(), addrEnd.As16(), routeListIdx)
+	if start.Is4() != end.Is4() {
+		return fmt.Errorf("address family mismatch: start and end must be the same address family")
 	}
-
-	return fmt.Errorf("unsupported prefix: must be either IPv4 or IPv6")
+	if start.Compare(end) > 0 {
+		return fmt.Errorf("invalid range: start %s is after end %s", start, end)
+	}
+	if start.Is4() {
+		return m.addPrefixV4(start.As4(), end.As4(), routeListIdx)
+	}
+	return m.addPrefixV6(start.As16(), end.As16(), routeListIdx)
 }
 
 // DumpFIB reads the Forwarding Information Base from shared memory using a

--- a/modules/route/cli/route/Cargo.toml
+++ b/modules/route/cli/route/Cargo.toml
@@ -23,5 +23,8 @@ serde = { version = "1", features = ["derive"] }
 netip = "0.3"
 serde_yaml = "0.9.34"
 
+[dev-dependencies]
+serde_json = "1"
+
 [build-dependencies]
 tonic-build = "0.13"

--- a/modules/route/cli/route/src/fib/json.rs
+++ b/modules/route/cli/route/src/fib/json.rs
@@ -1,16 +1,16 @@
 //! JSON payload for `fib show --format json`.
 //!
-//! Each record carries `start`/`end`, or an `invalid` marker for a range
-//! that failed to parse, plus `nexthops` -- always an array mirroring the
-//! wire entry regardless of whether the range parsed, empty rather than
-//! absent for a record with none.
+//! Each entry carries `start`/`end` -- an absent or malformed endpoint
+//! renders as the literal `"invalid"`, matching the human view -- plus
+//! `nexthops`, always an array mirroring the wire entry, empty rather
+//! than absent for an entry with none.
 
 use serde::Serialize;
 
-use super::{format_mac, FibRecord, RangeUnit};
-use crate::routepb::FibNexthop;
+use super::{format_mac, range_endpoints};
+use crate::routepb::{FibEntry, FibNexthop};
 
-/// One nexthop, as serialized in a [`FibRecordJson`].
+/// One nexthop, as serialized in a [`FibEntryJson`].
 #[derive(Debug, Serialize)]
 pub struct FibNexthopJson {
     pub dst_mac: String,
@@ -28,49 +28,54 @@ impl From<&FibNexthop> for FibNexthopJson {
     }
 }
 
-/// JSON range representation for one FIB record.
-///
-/// A well-formed range carries `start`/`end`; an invalid one carries
-/// neither, just an honest `invalid` marker, rather than fabricating
-/// endpoints for a range that failed to parse.
+/// One FIB entry, as serialized for `--format json`.
 #[derive(Debug, Serialize)]
-#[serde(untagged)]
-pub enum FibRangeJson {
-    Range { start: String, end: String },
-    Invalid { invalid: bool },
+pub struct FibEntryJson {
+    pub start: String,
+    pub end: String,
+    pub nexthops: Vec<FibNexthopJson>,
 }
 
-impl From<RangeUnit> for FibRangeJson {
-    fn from(unit: RangeUnit) -> Self {
-        match unit {
-            RangeUnit::Range { start, end } => Self::Range {
-                start: start.to_string(),
-                end: end.to_string(),
-            },
-            RangeUnit::Invalid => Self::Invalid { invalid: true },
+impl From<&FibEntry> for FibEntryJson {
+    fn from(entry: &FibEntry) -> Self {
+        let (start, end) = range_endpoints(entry.range.as_ref());
+        Self {
+            start,
+            end,
+            nexthops: entry.nexthops.iter().map(FibNexthopJson::from).collect(),
         }
     }
 }
 
-/// One FIB record, as serialized for `--format json`.
-///
-/// `nexthops` mirrors the wire entry regardless of whether `range`
-/// serializes as `start`/`end` or as `invalid: true` -- a malformed,
-/// absent, or inverted range still carries whatever nexthops the server
-/// attached to it. A record with no nexthops still serializes with
-/// `nexthops: []` rather than disappearing.
-#[derive(Debug, Serialize)]
-pub struct FibRecordJson {
-    #[serde(flatten)]
-    pub range: FibRangeJson,
-    pub nexthops: Vec<FibNexthopJson>,
-}
+#[cfg(test)]
+mod test {
+    use commonpb::pb::IpRange;
 
-impl From<&FibRecord> for FibRecordJson {
-    fn from(record: &FibRecord) -> Self {
-        Self {
-            range: FibRangeJson::from(record.range),
-            nexthops: record.nexthops.iter().map(FibNexthopJson::from).collect(),
-        }
+    use super::*;
+
+    /// Pins the serialized shape byte-for-byte: `--format json` is a
+    /// contract, and this is what a caller downstream of it parses
+    /// against. Renaming, reordering, or nesting a field would change this
+    /// string and must fail this test.
+    #[test]
+    fn entry_json_matches_expected_shape() {
+        let entry = FibEntry {
+            range: Some(IpRange::from((
+                "10.0.0.0".parse().unwrap(),
+                "10.0.0.255".parse().unwrap(),
+            ))),
+            nexthops: vec![FibNexthop {
+                dst_mac: None,
+                src_mac: None,
+                device: "vlan100".to_owned(),
+            }],
+        };
+
+        let json = serde_json::to_string(&FibEntryJson::from(&entry)).unwrap();
+
+        assert_eq!(
+            r#"{"start":"10.0.0.0","end":"10.0.0.255","nexthops":[{"dst_mac":"00:00:00:00:00:00","src_mac":"00:00:00:00:00:00","device":"vlan100"}]}"#,
+            json
+        );
     }
 }

--- a/modules/route/cli/route/src/fib/mod.rs
+++ b/modules/route/cli/route/src/fib/mod.rs
@@ -1,93 +1,49 @@
-//! Domain model for `fib show`.
+//! Support code for `fib show`.
 //!
-//! The wire carries one [`FibRangeEntry`] per dataplane FIB row: a
-//! contiguous address range plus its (possibly ECMP) nexthops.
-//! [`build_records`] turns each row into a [`FibRecord`] in the order the
-//! server sent it. Both the human view ([`render`]) and the JSON payload
-//! ([`json`]) are built from those same records, so a record dropped or
-//! reshaped here is dropped or reshaped in both.
+//! [`render`] and [`json`] each turn the wire's `FibEntry` rows -- see
+//! [`crate::routepb::FibEntry`] -- straight into their output, in wire
+//! order: [`json`] emits one record per entry, [`render`] emits one row
+//! per entry or one row per nexthop for an ECMP group. The server
+//! validates every range before ShowFIB's response can carry it, and the
+//! data itself comes from an LPM dump that cannot produce a malformed or
+//! inverted pair, so neither view reclassifies or decodes a range here.
+//! This module only holds the two formatting helpers they share:
+//! [`format_mac`] for a nexthop's MAC address, and [`range_endpoints`]
+//! for a range's two endpoints.
 
 pub mod json;
 pub mod render;
 
-use core::net::IpAddr;
-
-use commonpb::pb::{IpRange, MacAddress};
+use commonpb::pb::{IpAddress, IpRange, MacAddress};
 use netip::MacAddr;
 
-use crate::routepb::{FibNexthop, FibRangeEntry};
-
-/// One dataplane FIB row's range, classified as well-formed or invalid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RangeUnit {
-    Range { start: IpAddr, end: IpAddr },
-    Invalid,
-}
-
-/// One FIB record: a range paired with the nexthop(s) attached to it.
+/// The literal rendered for a range endpoint that is absent.
 ///
-/// `nexthops` always mirrors the wire entry regardless of how `range`
-/// classifies -- a [`RangeUnit::Invalid`] record keeps the nexthops the
-/// server sent right alongside it, since that is the data an operator
-/// needs to diagnose a malformed, absent, or inverted range. A row
-/// carrying no nexthops still yields a record, with an empty `nexthops`,
-/// so it can never vanish from the output.
-#[derive(Debug, Clone)]
-pub struct FibRecord {
-    range: RangeUnit,
-    nexthops: Vec<FibNexthop>,
-}
+/// Matches the literal [`commonpb::pb::IpAddress`]'s own `Display` falls
+/// back to for a malformed byte length, so an absent endpoint and a
+/// malformed one render identically instead of the absent one silently
+/// becoming an empty cell.
+const INVALID_ENDPOINT: &str = "invalid";
 
-/// Builds one [`FibRecord`] per row in `entries`, preserving wire order.
-pub fn build_records(entries: &[FibRangeEntry]) -> Vec<FibRecord> {
-    entries.iter().map(build_record).collect()
-}
-
-/// Builds one `FibRangeEntry`'s [`FibRecord`].
+/// Renders a range's two endpoints.
 ///
-/// `nexthops` is cloned from `entry` unconditionally: the classification of
-/// `range` and the fate of the nexthops are independent. `--format json` is
-/// the contract for the wire data and must carry whatever nexthops the
-/// server attached, even to a malformed, absent, or inverted range -- that
-/// is exactly the data an operator needs to diagnose it. The human view is
-/// free to summarise such a record away to a single placeholder row; that
-/// choice belongs to the renderer, not to this constructor.
-fn build_record(entry: &FibRangeEntry) -> FibRecord {
-    let range = range_unit(entry.range.as_ref());
-    let nexthops = entry.nexthops.clone();
-
-    FibRecord { range, nexthops }
+/// An absent `range`, or an absent endpoint within a present one, renders
+/// as [`INVALID_ENDPOINT`] -- the same literal a present-but-malformed
+/// endpoint's `Display` already falls back to.
+pub(crate) fn range_endpoints(range: Option<&IpRange>) -> (String, String) {
+    let start = range.and_then(|range| range.start.as_ref());
+    let end = range.and_then(|range| range.end.as_ref());
+    (format_endpoint(start), format_endpoint(end))
 }
 
-/// Classifies a wire `range` as well-formed or invalid.
-///
-/// A range is invalid when `range` is absent, when converting its two
-/// endpoints to an `IpAddr` pair fails -- a missing endpoint, an address
-/// byte length that is neither 4 nor 16, or an address-family mismatch
-/// between `start` and `end` -- or when it is inverted (`start` after
-/// `end`). `IpAddr`'s `Ord` only orders numerically within a single
-/// family, so the inversion check runs after the conversion has already
-/// established that both endpoints exist and share a family -- checking it
-/// first would compare, for instance, an IPv4 `start` against an IPv6
-/// `end` and report a meaningless verdict.
-fn range_unit(range: Option<&IpRange>) -> RangeUnit {
-    let Some(range) = range else {
-        return RangeUnit::Invalid;
-    };
-
-    let Ok((start, end)) = <(IpAddr, IpAddr)>::try_from(range) else {
-        return RangeUnit::Invalid;
-    };
-
-    if start > end {
-        return RangeUnit::Invalid;
-    }
-
-    RangeUnit::Range { start, end }
+/// Renders one range endpoint, or [`INVALID_ENDPOINT`] if it is absent.
+fn format_endpoint(addr: Option<&IpAddress>) -> String {
+    addr.map(IpAddress::to_string)
+        .unwrap_or_else(|| INVALID_ENDPOINT.to_owned())
 }
 
 /// Renders a nexthop's MAC address, or a fallback for a missing/invalid one.
-fn format_mac(mac: Option<MacAddress>) -> String {
+pub(crate) fn format_mac(mac: Option<MacAddress>) -> String {
     let mac = match mac {
         Some(mac) => match MacAddr::try_from(&mac) {
             Ok(mac) => return mac.to_string(),
@@ -100,106 +56,38 @@ fn format_mac(mac: Option<MacAddress>) -> String {
 
 #[cfg(test)]
 mod test {
-    use commonpb::pb::IpAddress;
+    use core::net::IpAddr;
 
     use super::*;
 
-    fn ip_range(start: &str, end: &str) -> IpRange {
-        IpRange::from((start.parse::<IpAddr>().unwrap(), end.parse::<IpAddr>().unwrap()))
-    }
-
-    fn nexthop(device: &str) -> FibNexthop {
-        FibNexthop {
-            dst_mac: None,
-            src_mac: None,
-            device: device.to_owned(),
-        }
-    }
-
-    fn entry(range: Option<IpRange>, nexthops: Vec<FibNexthop>) -> FibRangeEntry {
-        FibRangeEntry { range, nexthops }
-    }
-
     #[test]
-    fn build_records_yields_one_record_per_entry_in_order() {
-        let entries = vec![
-            entry(Some(ip_range("10.0.0.0", "10.0.0.255")), vec![nexthop("vlan100")]),
-            entry(Some(ip_range("172.16.0.0", "172.16.255.255")), Vec::new()),
-        ];
+    fn range_endpoints_renders_well_formed_addresses() {
+        let range = IpRange {
+            start: Some(IpAddress::from("10.0.0.0".parse::<IpAddr>().unwrap())),
+            end: Some(IpAddress::from("10.0.0.255".parse::<IpAddr>().unwrap())),
+        };
 
-        let records = build_records(&entries);
-
-        assert_eq!(2, records.len());
         assert_eq!(
-            RangeUnit::Range {
-                start: "10.0.0.0".parse().unwrap(),
-                end: "10.0.0.255".parse().unwrap(),
-            },
-            records[0].range
+            ("10.0.0.0".to_owned(), "10.0.0.255".to_owned()),
+            range_endpoints(Some(&range))
         );
-        assert_eq!(1, records[0].nexthops.len());
-        assert!(records[1].nexthops.is_empty());
     }
 
     #[test]
-    fn absent_range_is_invalid() {
-        let records = build_records(&[entry(None, vec![nexthop("vlan100")])]);
-
-        assert_eq!(RangeUnit::Invalid, records[0].range);
+    fn range_endpoints_treats_absent_range_as_invalid() {
+        assert_eq!(("invalid".to_owned(), "invalid".to_owned()), range_endpoints(None));
     }
 
     #[test]
-    fn missing_endpoint_is_invalid() {
+    fn range_endpoints_treats_missing_endpoint_as_invalid() {
         let range = IpRange {
             start: Some(IpAddress::from("10.0.0.1".parse::<IpAddr>().unwrap())),
             end: None,
         };
-        let records = build_records(&[entry(Some(range), Vec::new())]);
 
-        assert_eq!(RangeUnit::Invalid, records[0].range);
-    }
-
-    #[test]
-    fn invalid_address_byte_length_is_invalid() {
-        let range = IpRange {
-            start: Some(IpAddress { addr: vec![0u8; 5] }),
-            end: Some(IpAddress::from("10.0.0.1".parse::<IpAddr>().unwrap())),
-        };
-        let records = build_records(&[entry(Some(range), Vec::new())]);
-
-        assert_eq!(RangeUnit::Invalid, records[0].range);
-    }
-
-    #[test]
-    fn address_family_mismatch_is_invalid() {
-        let range = IpRange {
-            start: Some(IpAddress::from("10.0.0.1".parse::<IpAddr>().unwrap())),
-            end: Some(IpAddress::from("2001:db8::1".parse::<IpAddr>().unwrap())),
-        };
-        let records = build_records(&[entry(Some(range), Vec::new())]);
-
-        assert_eq!(RangeUnit::Invalid, records[0].range);
-    }
-
-    #[test]
-    fn inverted_range_is_invalid() {
-        let records = build_records(&[entry(Some(ip_range("10.0.0.254", "10.0.0.1")), Vec::new())]);
-
-        assert_eq!(RangeUnit::Invalid, records[0].range);
-    }
-
-    #[test]
-    fn well_formed_range_is_not_invalid() {
-        let records = build_records(&[entry(Some(ip_range("10.0.0.1", "10.0.0.1")), Vec::new())]);
-
-        assert_ne!(RangeUnit::Invalid, records[0].range);
-    }
-
-    #[test]
-    fn invalid_range_preserves_nexthops() {
-        let records = build_records(&[entry(None, vec![nexthop("vlan100")])]);
-
-        assert_eq!(RangeUnit::Invalid, records[0].range);
-        assert_eq!(1, records[0].nexthops.len());
+        assert_eq!(
+            ("10.0.0.1".to_owned(), "invalid".to_owned()),
+            range_endpoints(Some(&range))
+        );
     }
 }

--- a/modules/route/cli/route/src/fib/render/mod.rs
+++ b/modules/route/cli/route/src/fib/render/mod.rs
@@ -1,13 +1,11 @@
-//! Human-readable table rendering for `fib show`: one row per record, or one
+//! Human-readable table rendering for `fib show`: one row per entry, or one
 //! row per nexthop for an ECMP group.
 //!
-//! Every record contributes at least one row, so a record with an invalid
-//! range or with no nexthops still shows up rather than vanishing. No
-//! `Width`/`Wrap` setting is ever applied, matching how borderless CLI table
-//! tools conventionally behave: a narrow terminal is left to wrap the output
-//! itself rather than the table pre-wrapping it.
-
-use core::net::IpAddr;
+//! Every entry contributes at least one row, so an entry with no nexthops
+//! still shows up rather than vanishing. No `Width`/`Wrap` setting is ever
+//! applied, matching how borderless CLI table tools conventionally behave:
+//! a narrow terminal is left to wrap the output itself rather than the
+//! table pre-wrapping it.
 
 use tabled::{
     settings::{object::Rows, Color, Padding, Style},
@@ -15,10 +13,10 @@ use tabled::{
 };
 use ync::output;
 
-use super::{format_mac, FibRecord, RangeUnit};
-use crate::routepb::FibNexthop;
+use super::{format_mac, range_endpoints};
+use crate::routepb::{FibEntry, FibNexthop};
 
-/// One table row: either a full record (or its first nexthop), or a
+/// One table row: either a full entry (or its first nexthop), or a
 /// continuation row for a later ECMP nexthop with `from`/`to` left empty.
 #[derive(Debug, Tabled)]
 struct FibRow {
@@ -45,23 +43,11 @@ fn sanitize_wire_text(value: &str) -> String {
     value.chars().map(|ch| if ch.is_control() { '?' } else { ch }).collect()
 }
 
-/// Builds the single-row placeholder for an invalid range.
-fn invalid_row() -> FibRow {
+/// Builds the single-row placeholder for an entry with no nexthops.
+fn no_nexthops_row(from: String, to: String) -> FibRow {
     FibRow {
-        from: "(invalid range)".to_owned(),
-        to: String::new(),
-        device: String::new(),
-        dst_mac: String::new(),
-        src_mac: String::new(),
-    }
-}
-
-/// Builds the single-row placeholder for a well-formed range with no
-/// nexthops.
-fn no_nexthops_row(start: IpAddr, end: IpAddr) -> FibRow {
-    FibRow {
-        from: start.to_string(),
-        to: end.to_string(),
+        from,
+        to,
         device: "(no nexthops)".to_owned(),
         dst_mac: String::new(),
         src_mac: String::new(),
@@ -70,19 +56,16 @@ fn no_nexthops_row(start: IpAddr, end: IpAddr) -> FibRow {
 
 /// Builds one row per nexthop in an ECMP group.
 ///
-/// Only the first row carries the range's `from`/`to` cells; the rest are
+/// Only the first row carries the entry's `from`/`to` cells; the rest are
 /// continuation rows with those cells left empty, which is what tells them
-/// apart from a new record's own row when the table is read back.
-fn nexthop_rows(start: IpAddr, end: IpAddr, nexthops: &[FibNexthop]) -> Vec<FibRow> {
-    let from_text = start.to_string();
-    let to_text = end.to_string();
-
+/// apart from a new entry's own row when the table is read back.
+fn nexthop_rows(from: String, to: String, nexthops: &[FibNexthop]) -> Vec<FibRow> {
     nexthops
         .iter()
         .enumerate()
         .map(|(index, nexthop)| FibRow {
-            from: if index == 0 { from_text.clone() } else { String::new() },
-            to: if index == 0 { to_text.clone() } else { String::new() },
+            from: if index == 0 { from.clone() } else { String::new() },
+            to: if index == 0 { to.clone() } else { String::new() },
             device: sanitize_wire_text(&nexthop.device),
             dst_mac: format_mac(nexthop.dst_mac),
             src_mac: format_mac(nexthop.src_mac),
@@ -90,29 +73,23 @@ fn nexthop_rows(start: IpAddr, end: IpAddr, nexthops: &[FibNexthop]) -> Vec<FibR
         .collect()
 }
 
-/// Builds the row(s) for one [`FibRecord`].
-///
-/// [`RangeUnit::Invalid`] is matched first and unconditionally, ahead of
-/// the nexthop-count check on the `Range` arms: an invalid record may now
-/// carry nexthops cloned from the wire, but the human view still
-/// summarises it down to the single `(invalid range)` placeholder row,
-/// never one row per nexthop.
-fn build_rows(record: &FibRecord) -> Vec<FibRow> {
-    match record.range {
-        RangeUnit::Invalid => vec![invalid_row()],
-        RangeUnit::Range { start, end } if record.nexthops.is_empty() => {
-            vec![no_nexthops_row(start, end)]
-        }
-        RangeUnit::Range { start, end } => nexthop_rows(start, end, &record.nexthops),
+/// Builds the row(s) for one [`FibEntry`].
+fn build_rows(entry: &FibEntry) -> Vec<FibRow> {
+    let (from, to) = range_endpoints(entry.range.as_ref());
+
+    if entry.nexthops.is_empty() {
+        return vec![no_nexthops_row(from, to)];
     }
+
+    nexthop_rows(from, to, &entry.nexthops)
 }
 
-/// Renders `records` as a headered, borderless table.
+/// Renders `entries` as a headered, borderless table.
 ///
 /// `colored` gates only the header row's bold styling: every cell's content
 /// renders identically regardless of colour mode.
-fn render_table(records: &[FibRecord], colored: bool) -> String {
-    let rows: Vec<FibRow> = records.iter().flat_map(build_rows).collect();
+fn render_table(entries: &[FibEntry], colored: bool) -> String {
+    let rows: Vec<FibRow> = entries.iter().flat_map(build_rows).collect();
 
     let mut table = Table::new(&rows);
     table.with(Style::empty()).with(Padding::new(0, 2, 0, 0));
@@ -124,11 +101,38 @@ fn render_table(records: &[FibRecord], colored: bool) -> String {
     table.to_string()
 }
 
-/// Prints `records` as the `fib show` human view.
-pub fn print_fib(records: &[FibRecord]) {
+/// Prints `entries` as the `fib show` human view.
+pub fn print_fib(entries: &[FibEntry]) {
     let colored = output::is_colored();
 
-    for line in render_table(records, colored).lines() {
+    for line in render_table(entries, colored).lines() {
         println!("{}", line.trim_end());
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use core::net::IpAddr;
+
+    use commonpb::pb::IpRange;
+
+    use super::*;
+
+    #[test]
+    fn entry_with_no_nexthops_renders_one_placeholder_row() {
+        let entry = FibEntry {
+            range: Some(IpRange::from((
+                "10.0.0.0".parse::<IpAddr>().unwrap(),
+                "10.0.0.255".parse::<IpAddr>().unwrap(),
+            ))),
+            nexthops: Vec::new(),
+        };
+
+        let rows = build_rows(&entry);
+
+        assert_eq!(1, rows.len());
+        assert_eq!("10.0.0.0", rows[0].from);
+        assert_eq!("10.0.0.255", rows[0].to);
+        assert_eq!("(no nexthops)", rows[0].device);
     }
 }

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -11,12 +11,12 @@ use clap_complete::{
     engine::{ArgValueCandidates, CompletionCandidate},
     CompleteEnv,
 };
-use commonpb::pb::MacAddress;
-use netip::MacAddr;
+use commonpb::pb::{IpRange, MacAddress};
+use netip::{Contiguous, IpNetwork, MacAddr};
 use serde::{Deserialize, Serialize};
 use tonic::codec::CompressionEncoding;
 use yanet_cli_route::{
-    fib,
+    fib::{json::FibEntryJson, render::print_fib},
     routepb::{self, route_service_client::RouteServiceClient, ListConfigsRequest, ShowFibRequest, UpdateFibRequest},
 };
 use ync::{
@@ -32,8 +32,12 @@ struct FibNexthop {
     device: String,
 }
 
+/// A FIB entry as written in the YAML config.
+///
+/// Named `Config` rather than `Entry` to stay visually distinct from the
+/// wire's [`routepb::FibEntry`], which this type converts into.
 #[derive(Debug, Serialize, Deserialize)]
-struct FibEntry {
+struct FibEntryConfig {
     prefix: String,
     #[serde(default)]
     nexthops: Vec<FibNexthop>,
@@ -42,7 +46,7 @@ struct FibEntry {
 #[derive(Debug, Serialize, Deserialize)]
 struct FibConfig {
     #[serde(default)]
-    entries: Vec<FibEntry>,
+    entries: Vec<FibEntryConfig>,
 }
 
 impl FibConfig {
@@ -73,16 +77,21 @@ impl TryFrom<FibNexthop> for routepb::FibNexthop {
     }
 }
 
-impl TryFrom<FibEntry> for routepb::FibEntry {
+impl TryFrom<FibEntryConfig> for routepb::FibEntry {
     type Error = Box<dyn Error>;
 
-    fn try_from(entry: FibEntry) -> Result<Self, Self::Error> {
+    fn try_from(entry: FibEntryConfig) -> Result<Self, Self::Error> {
+        let network = Contiguous::<IpNetwork>::parse(&entry.prefix)?;
+        // `addr()` is this network's base address rather than the address as
+        // typed: `IpNetwork` always normalizes to the mask on construction, so
+        // the range below denotes the whole network the prefix names.
+        let range = IpRange::from((network.addr(), network.last_addr()));
         let nexthops = entry
             .nexthops
             .into_iter()
             .map(routepb::FibNexthop::try_from)
             .collect::<Result<Vec<_>, _>>()?;
-        Ok(Self { prefix: entry.prefix, nexthops })
+        Ok(Self { range: Some(range), nexthops })
     }
 }
 
@@ -255,17 +264,17 @@ impl RouteService {
         };
 
         let response = self.client.show_fib(request).await?.into_inner();
-        let records = fib::build_records(&response.entries);
+        let entries = response.entries;
 
         output::data(
-            || records.iter().map(fib::json::FibRecordJson::from).collect::<Vec<_>>(),
+            || entries.iter().map(FibEntryJson::from).collect::<Vec<_>>(),
             || {
-                if records.is_empty() {
+                if entries.is_empty() {
                     output::empty(format_args!("No FIB entries found for '{}'.", cmd.config_name));
                     return;
                 }
 
-                fib::render::print_fib(&records);
+                print_fib(&entries);
             },
         );
 
@@ -275,10 +284,49 @@ impl RouteService {
 
 #[cfg(test)]
 mod test {
+    use core::net::IpAddr;
+
     use super::*;
 
     #[test]
     fn cmd_is_valid() {
         Cmd::command().debug_assert();
+    }
+
+    fn ip_range(start: &str, end: &str) -> IpRange {
+        IpRange::from((start.parse::<IpAddr>().unwrap(), end.parse::<IpAddr>().unwrap()))
+    }
+
+    fn entry_range(prefix: &str) -> IpRange {
+        let entry = FibEntryConfig {
+            prefix: prefix.to_string(),
+            nexthops: Vec::new(),
+        };
+        routepb::FibEntry::try_from(entry).unwrap().range.unwrap()
+    }
+
+    #[test]
+    fn fib_entry_config_prefix_converts_to_expected_range() {
+        assert_eq!(ip_range("10.0.0.0", "10.0.0.255"), entry_range("10.0.0.0/24"));
+    }
+
+    #[test]
+    fn fib_entry_config_prefix_masks_host_bits_v4() {
+        assert_eq!(ip_range("10.0.0.0", "10.0.0.255"), entry_range("10.0.0.5/24"));
+    }
+
+    #[test]
+    fn fib_entry_config_prefix_masks_host_bits_v6() {
+        assert_eq!(ip_range("2001:db8::", "2001:db8::ff"), entry_range("2001:db8::5/120"));
+    }
+
+    #[test]
+    fn fib_entry_config_prefix_slash_32_is_noop() {
+        assert_eq!(ip_range("10.0.0.5", "10.0.0.5"), entry_range("10.0.0.5/32"));
+    }
+
+    #[test]
+    fn fib_entry_config_prefix_slash_128_is_noop() {
+        assert_eq!(ip_range("2001:db8::5", "2001:db8::5"), entry_range("2001:db8::5/128"));
     }
 }

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -5,7 +5,6 @@ import (
 	"cmp"
 	"fmt"
 	"net"
-	"net/netip"
 
 	"github.com/yanet-platform/yanet2/common/go/bitset"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
@@ -50,7 +49,7 @@ type CounterView struct {
 // module.
 type Backend interface {
 	// UpdateModule builds a fresh ModuleConfig from the supplied FIB
-	// entries and publishes it to the dataplane atomically.
+	// ranges and publishes it to the dataplane atomically.
 	UpdateModule(name string, entries []*routepb.FIBEntry) (ModuleHandle, error)
 	// DeleteModule removes a module config from the dataplane.
 	DeleteModule(name string) error
@@ -77,18 +76,22 @@ func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (Module
 		return nil, fmt.Errorf("failed to create module config: %w", err)
 	}
 
-	// Defensively dedup hardware routes per-prefix using TinyBitset:
+	// Defensively dedup hardware routes per-range using TinyBitset:
 	// the operator already feeds deduplicated entries, but the wire
-	// format encodes a list-of-nexthops per prefix and we keep the
+	// format encodes a list-of-nexthops per range and we keep the
 	// route module robust to mistakes upstream.
 	hardwareIndex := map[HardwareRoute]uint32{}
 	routeListIndex := map[bitset.TinyBitset]uint32{}
 
 	for _, entry := range entries {
-		prefix, err := netip.ParsePrefix(entry.GetPrefix())
+		start, end, err := entry.GetRange().ToRange()
 		if err != nil {
 			module.Free()
-			return nil, fmt.Errorf("failed to parse prefix %q: %w", entry.GetPrefix(), err)
+			return nil, fmt.Errorf("failed to parse range: %w", err)
+		}
+		if start.Compare(end) > 0 {
+			module.Free()
+			return nil, fmt.Errorf("range start %q is greater than end %q", start, end)
 		}
 
 		key := bitset.TinyBitset{}
@@ -127,9 +130,9 @@ func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (Module
 			routeListIndex[key] = listIdx
 		}
 
-		if err := module.AddPrefix(prefix, listIdx); err != nil {
+		if err := module.AddRange(start, end, listIdx); err != nil {
 			module.Free()
-			return nil, fmt.Errorf("failed to add prefix %q: %w", prefix, err)
+			return nil, fmt.Errorf("failed to add range [%s, %s]: %w", start, end, err)
 		}
 	}
 

--- a/modules/route/controlplane/routepb/v1/route.proto
+++ b/modules/route/controlplane/routepb/v1/route.proto
@@ -56,15 +56,7 @@ message ShowFIBRequest {
 // ShowFIBResponse contains the list of FIB entries.
 message ShowFIBResponse {
   // List of FIB rows; each carries one range with its nexthops.
-  repeated FIBRangeEntry entries = 1;
-}
-
-// FIBEntry represents a single prefix in the FIB with its nexthops.
-message FIBEntry {
-  // Network prefix in CIDR notation (e.g. "10.0.0.0/24").
-  string prefix = 1;
-  // Nexthops associated with this prefix (ECMP).
-  repeated FIBNexthop nexthops = 2;
+  repeated FIBEntry entries = 1;
 }
 
 // FIBNexthop represents a hardware-level nexthop in the FIB.
@@ -77,17 +69,22 @@ message FIBNexthop {
   string device = 3;
 }
 
-// FIBRangeEntry represents a single dataplane FIB row.
+// FIBEntry represents a single dataplane FIB row.
 //
 // Carries the contiguous address range covered by one set of nexthops.
-// Used in ShowFIBResponse. UpdateFIBRequest still uses FIBEntry with a
-// CIDR string until a typed common.commonpb.v1.IPPrefix lands.
-message FIBRangeEntry {
+message FIBEntry {
   common.commonpb.v1.IPRange range = 1;
   repeated FIBNexthop nexthops = 2;
 }
 
 // UpdateFIBRequest carries the full FIB to be applied atomically.
+//
+// Entries are applied in list order, and each entry that carries at least
+// one nexthop overwrites every address it covers, so where two such ranges
+// overlap the later one wins regardless of how narrow it is. This is not
+// longest-prefix-match: a client that wants LPM semantics must send
+// narrower ranges last. An entry with no nexthops is skipped entirely and
+// does not displace an earlier overlapping entry.
 message UpdateFIBRequest {
   // ModuleName is the route module config name.
   string module_name = 1;

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -190,7 +190,7 @@ func (m *RouteService) ShowFIB(
 	}
 
 	response := &routepb.ShowFIBResponse{
-		Entries: make([]*routepb.FIBRangeEntry, 0, len(entries)),
+		Entries: make([]*routepb.FIBEntry, 0, len(entries)),
 	}
 	for _, e := range entries {
 		if req.GetIpv4Only() && e.AddressFamily != croute.AddressFamilyIPv4 {
@@ -214,7 +214,7 @@ func (m *RouteService) ShowFIB(
 			return nil, status.Errorf(codes.Internal, "failed to build IP range from FIB entry: %v", err)
 		}
 
-		response.Entries = append(response.Entries, &routepb.FIBRangeEntry{
+		response.Entries = append(response.Entries, &routepb.FIBEntry{
 			Range:    ipRange,
 			Nexthops: nexthops,
 		})
@@ -259,10 +259,21 @@ func (m *RouteService) UpdateFIB(
 		return nil, status.Error(codes.InvalidArgument, "module_name is required")
 	}
 
+	entries := req.GetEntries()
+	for _, entry := range entries {
+		start, end, err := entry.GetRange().ToRange()
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "failed to parse range: %v", err)
+		}
+		if start.Compare(end) > 0 {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid range: start %s is after end %s", start, end)
+		}
+	}
+
 	m.shmLock.Lock()
 	defer m.shmLock.Unlock()
 
-	module, err := m.backend.UpdateModule(name, req.GetEntries())
+	module, err := m.backend.UpdateModule(name, entries)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to apply FIB for %q: %v", name, err)
 	}

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -49,6 +49,9 @@ type fakeBackend struct {
 	counters []route.CounterView
 	// queried records the counter names the service asked for.
 	queried []string
+	// updateCalls records the range entries passed to UpdateModule on
+	// every call, in call order.
+	updateCalls [][]*routepb.FIBEntry
 }
 
 func newFakeBackend() *fakeBackend {
@@ -59,6 +62,7 @@ func (m *fakeBackend) UpdateModule(name string, entries []*routepb.FIBEntry) (ro
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.updateCalls = append(m.updateCalls, entries)
 	return m.handle, nil
 }
 

--- a/modules/route/controlplane/updatefib_test.go
+++ b/modules/route/controlplane/updatefib_test.go
@@ -1,0 +1,117 @@
+package route_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
+	routepb "github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
+)
+
+// mustRange builds a validated IPRange from two address strings.
+func mustRange(t *testing.T, start, end string) *commonpb.IPRange {
+	t.Helper()
+
+	r, err := commonpb.NewIPRange(netip.MustParseAddr(start), netip.MustParseAddr(end))
+	require.NoError(t, err)
+	return r
+}
+
+// rangeEntry builds a FIBEntry with no nexthops.
+func rangeEntry(t *testing.T, start, end string) *routepb.FIBEntry {
+	t.Helper()
+
+	return &routepb.FIBEntry{Range: mustRange(t, start, end)}
+}
+
+// TestUpdateFIBInvalidRangesRejected verifies that a nil range, an inverted
+// range, and a family-mismatched range are all rejected as InvalidArgument
+// before reaching the backend.
+func TestUpdateFIBInvalidRangesRejected(t *testing.T) {
+	v4 := commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.1"))
+	v6 := commonpb.NewIPAddressFromAddr(netip.MustParseAddr("2001:db8::1"))
+
+	tests := []struct {
+		name  string
+		entry *routepb.FIBEntry
+	}{
+		{
+			name:  "nil range",
+			entry: &routepb.FIBEntry{},
+		},
+		{
+			name: "inverted range",
+			entry: &routepb.FIBEntry{
+				Range: &commonpb.IPRange{
+					Start: commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.255")),
+					End:   commonpb.NewIPAddressFromAddr(netip.MustParseAddr("10.0.0.0")),
+				},
+			},
+		},
+		{
+			name: "family mismatch",
+			entry: &routepb.FIBEntry{
+				Range: &commonpb.IPRange{Start: v4, End: v6},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			backend := newFakeBackend()
+			service := route.NewRouteService(backend)
+
+			_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+				ModuleName: "cfg",
+				Entries:    []*routepb.FIBEntry{test.entry},
+			})
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
+			require.Empty(t, backend.updateCalls)
+		})
+	}
+}
+
+// TestUpdateFIBPreservesOrder verifies that UpdateFIB forwards entries to the
+// backend in the exact order the request carried, since order is a
+// documented wire contract a sort or dedup would silently break.
+func TestUpdateFIBPreservesOrder(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	// Start addresses are strictly descending, so a sort of any kind (by
+	// start, by end, or by range) would visibly reorder this input.
+	//
+	// The expected order is captured into independent strings below,
+	// rather than compared against the input slice itself: this call
+	// runs in-process, so req.GetEntries() aliases the same backing
+	// array as entries, and an in-place sort in the service would
+	// silently reorder the "want" side along with the "got" side.
+	entries := []*routepb.FIBEntry{
+		rangeEntry(t, "10.0.2.0", "10.0.2.255"),
+		rangeEntry(t, "10.0.1.0", "10.0.1.255"),
+		rangeEntry(t, "10.0.0.0", "10.0.0.255"),
+	}
+	wantStarts := []string{"10.0.2.0", "10.0.1.0", "10.0.0.0"}
+	wantEnds := []string{"10.0.2.255", "10.0.1.255", "10.0.0.255"}
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    entries,
+	})
+	require.NoError(t, err)
+	require.Len(t, backend.updateCalls, 1)
+
+	got := backend.updateCalls[0]
+	require.Len(t, got, len(wantStarts))
+	for idx := range wantStarts {
+		gotStart, gotEnd, err := got[idx].GetRange().ToRange()
+		require.NoError(t, err)
+		require.Equal(t, wantStarts[idx], gotStart.String(), "entry %d start", idx)
+		require.Equal(t, wantEnds[idx], gotEnd.String(), "entry %d end", idx)
+	}
+}

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -15,6 +15,7 @@ import (
 	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/xerror"
+	"github.com/yanet-platform/yanet2/common/go/xnetip"
 	"github.com/yanet-platform/yanet2/common/go/xpacket"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 	route "github.com/yanet-platform/yanet2/modules/route/controlplane"
@@ -145,8 +146,10 @@ func applyFIB(
 				Device: nh.Device,
 			})
 		}
+		ipRange, err := commonpb.NewIPRange(e.Prefix.Addr(), xnetip.LastAddr(e.Prefix))
+		require.NoError(tb, err)
 		pbEntries = append(pbEntries, &routepb.FIBEntry{
-			Prefix:   e.Prefix.String(),
+			Range:    ipRange,
 			Nexthops: nexthops,
 		})
 	}
@@ -954,4 +957,33 @@ func TestRoute_PerOutcomeCounters(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestUpdateFIB_EmptyNexthopEntryDoesNotDisplaceEarlierEntry verifies the
+// UpdateFIBRequest doc comment's claim that an entry with no nexthops is
+// skipped rather than overwriting an earlier overlapping entry.
+//
+// It exercises the real backend.UpdateModule against shared memory, since
+// the fake backend used by the unit tests in modules/route/controlplane
+// only records the entries handed to it and cannot observe the
+// dataplane-visible skip.
+func TestUpdateFIB_EmptyNexthopEntryDoesNotDisplaceEarlierEntry(t *testing.T) {
+	prefix := netip.MustParsePrefix("10.0.0.0/24")
+
+	_, _, backend := setupRouteHarness(t, "port0")
+
+	handle := applyFIB(t, backend, "cfg", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{routeNextHop}},
+		// Later entry covers the same range but carries no nexthops, so
+		// it must be skipped rather than blackholing or removing the
+		// earlier entry's route.
+		{Prefix: prefix},
+	})
+
+	fib, err := handle.DumpFIB()
+	require.NoError(t, err)
+
+	require.Len(t, fib, 1, "expected the earlier nexthop-bearing entry to survive alone")
+	require.Len(t, fib[0].Nexthops, 1)
+	require.Equal(t, "port0", fib[0].Nexthops[0].Device)
 }

--- a/modules/route/web/useFIBDraft.ts
+++ b/modules/route/web/useFIBDraft.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 import { API, inventoryConfigNames, loadKnownConfigs, unionConfigNames } from '@yanet/core/api';
 import { warnConfigsUnknown } from '@yanet/core/utils';
-import type { FIBEntry, FIBNexthop, FIBRangeEntry } from '@yanet/core/api/routes';
-import { ipRangeToCIDRs } from '@yanet/core/utils/netip';
+import type { FIBEntry, FIBNexthop } from '@yanet/core/api/routes';
+import { cidrToIPRange, ipRangeToCIDRs } from '@yanet/core/utils/netip';
 import type { FIBRowItem } from './types';
 import { fibDraftReducer, initialFIBDraftState } from './fibDraftReducer';
 import { useDraft } from '@yanet/core/components/draft';
@@ -11,8 +11,8 @@ import type { UseDraftResult } from '@yanet/core/components/draft';
 let rowIdCounter = 0;
 const newRowId = (): string => `row-${++rowIdCounter}-${Date.now()}`;
 
-/** Flatten FIBRangeEntry array into flat (prefix, nexthop) row items. */
-export const flattenFIBEntries = (entries: FIBRangeEntry[]): FIBRowItem[] => {
+/** Flatten FIBEntry array into flat (prefix, nexthop) row items. */
+export const flattenFIBEntries = (entries: FIBEntry[]): FIBRowItem[] => {
     const rows: FIBRowItem[] = [];
     for (const entry of entries) {
         const cidrs = ipRangeToCIDRs(entry.range);
@@ -36,20 +36,35 @@ export const flattenFIBEntries = (entries: FIBRangeEntry[]): FIBRowItem[] => {
     return rows;
 };
 
-/** Group flat rows back into FIBEntry list (consecutive rows with same prefix → one entry). */
+/**
+ * Group flat rows back into a FIBEntry list (consecutive rows with the
+ * same prefix collapse into one entry with several ECMP nexthops).
+ *
+ * A row can reach here without having passed validateRow at all, and even a
+ * row that passed it can still fail conversion, since validateRow's
+ * isValidCidrPrefix is a looser check than cidrToIPRange's strict parser.
+ * Throwing here rather than dropping the row is deliberate: a dropped row
+ * would silently delete a route from the FIB, which is worse than failing
+ * the whole commit loudly.
+ */
 export const rowsToFIBEntries = (rows: FIBRowItem[]): FIBEntry[] => {
     const entries: FIBEntry[] = [];
     for (const row of rows) {
+        const range = cidrToIPRange(row.prefix);
+        if (!range) {
+            throw new Error(`Cannot convert FIB row prefix "${row.prefix}" to an IP range`);
+        }
+
         const last = entries[entries.length - 1];
         const nh: FIBNexthop = {
             dst_mac: { addr: row.dst_mac },
             src_mac: { addr: row.src_mac },
             device: row.device,
         };
-        if (last && last.prefix === row.prefix) {
+        if (last && last.range?.start === range.start && last.range?.end === range.end) {
             last.nexthops = [...(last.nexthops || []), nh];
         } else {
-            entries.push({ prefix: row.prefix, nexthops: [nh] });
+            entries.push({ range, nexthops: [nh] });
         }
     }
     return entries;

--- a/operators/route/internal/operator/actuator_gateway.go
+++ b/operators/route/internal/operator/actuator_gateway.go
@@ -11,6 +11,7 @@ import (
 
 	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/common/go/operator"
+	"github.com/yanet-platform/yanet2/common/go/xnetip"
 	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
 	"github.com/yanet-platform/yanet2/modules/route/controlplane/routepb/v1"
 	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
@@ -133,7 +134,11 @@ func (m *GatewayActuator) applyFunction(ctx context.Context) error {
 func (m *GatewayActuator) pushFIB(ctx context.Context, fib FIB) error {
 	entries := make([]*routepb.FIBEntry, len(fib.Entries))
 	for idx, entry := range fib.Entries {
-		entries[idx] = fibEntryToProto(entry)
+		e, err := fibEntryToProto(entry)
+		if err != nil {
+			return fmt.Errorf("failed to convert FIB entry for prefix %q: %w", entry.Prefix, err)
+		}
+		entries[idx] = e
 	}
 
 	req := &routepb.UpdateFIBRequest{
@@ -149,8 +154,8 @@ func (m *GatewayActuator) pushFIB(ctx context.Context, fib FIB) error {
 	return nil
 }
 
-// fibEntryToProto converts an internal FIBEntry to the wire format.
-func fibEntryToProto(entry FIBEntry) *routepb.FIBEntry {
+// fibEntryToProto converts an internal FIBEntry to the wire range format.
+func fibEntryToProto(entry FIBEntry) (*routepb.FIBEntry, error) {
 	nexthops := make([]*routepb.FIBNexthop, len(entry.Nexthops))
 	for idx, nh := range entry.Nexthops {
 		nexthops[idx] = &routepb.FIBNexthop{
@@ -159,8 +164,14 @@ func fibEntryToProto(entry FIBEntry) *routepb.FIBEntry {
 			Device: nh.Device,
 		}
 	}
-	return &routepb.FIBEntry{
-		Prefix:   entry.Prefix.String(),
-		Nexthops: nexthops,
+
+	ipRange, err := commonpb.NewIPRange(entry.Prefix.Addr(), xnetip.LastAddr(entry.Prefix))
+	if err != nil {
+		return nil, err
 	}
+
+	return &routepb.FIBEntry{
+		Range:    ipRange,
+		Nexthops: nexthops,
+	}, nil
 }

--- a/operators/route/internal/operator/fib_build.go
+++ b/operators/route/internal/operator/fib_build.go
@@ -55,6 +55,8 @@ func BuildFIB(
 
 	entries := make([]FIBEntry, 0)
 
+	// The wire applies entries in list order, each overwriting the addresses
+	// it covers, so emitting least-specific first reproduces longest-prefix-match.
 	for prefixLen := range ribDump {
 		for prefix, routesList := range ribDump[prefixLen] {
 			stats.TotalPrefixes++

--- a/web/src/core/api/routes.ts
+++ b/web/src/core/api/routes.ts
@@ -81,18 +81,13 @@ export interface ShowFIBRequest {
     ipv6_only?: boolean;
 }
 
-export interface FIBRangeEntry {
+export interface FIBEntry {
     range?: IPRangeWire;
     nexthops?: FIBNexthop[];
 }
 
 export interface ShowFIBResponse {
-    entries?: FIBRangeEntry[];
-}
-
-export interface FIBEntry {
-    prefix?: string;
-    nexthops?: FIBNexthop[];
+    entries?: FIBEntry[];
 }
 
 export interface FIBNexthop {

--- a/web/src/core/utils/netip.test.ts
+++ b/web/src/core/utils/netip.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest';
-import { ipAddressToString, stringToIPAddress, ipRangeToCIDRs } from './netip';
+import {
+    ipAddressToString,
+    stringToIPAddress,
+    ipRangeToCIDRs,
+    cidrToIPRange,
+    parseCIDRPrefix,
+    parseCidrsToIPNets,
+    parseIPToBytes,
+    IPv4Prefix,
+    CIDRParseError,
+} from './netip';
 
 describe('ipAddressToString', () => {
     it('returns the string directly for IPv4 wire form', () => {
@@ -89,5 +99,246 @@ describe('ipRangeToCIDRs', () => {
 
     it('returns [] when start is greater than end', () => {
         expect(ipRangeToCIDRs({ start: '10.0.0.255', end: '10.0.0.0' })).toEqual([]);
+    });
+});
+
+describe('cidrToIPRange', () => {
+    it('converts an IPv4 /24 to its start/end range', () => {
+        expect(cidrToIPRange('10.0.0.0/24')).toEqual({ start: '10.0.0.0', end: '10.0.0.255' });
+    });
+
+    it('converts an IPv6 /64 to its start/end range', () => {
+        expect(cidrToIPRange('2a02:6b8:2:d::/64'))
+            .toEqual({ start: '2a02:6b8:2:d::', end: '2a02:6b8:2:d:ffff:ffff:ffff:ffff' });
+    });
+
+    it('converts an IPv4 /32 single address to a single-address range', () => {
+        expect(cidrToIPRange('10.0.0.1/32')).toEqual({ start: '10.0.0.1', end: '10.0.0.1' });
+    });
+
+    it('converts an IPv6 /128 single address to a single-address range', () => {
+        expect(cidrToIPRange('2001:db8::1/128')).toEqual({ start: '2001:db8::1', end: '2001:db8::1' });
+    });
+
+    it('masks host bits set in the address to the network base', () => {
+        expect(cidrToIPRange('10.0.0.5/24')).toEqual({ start: '10.0.0.0', end: '10.0.0.255' });
+    });
+
+    it('masks host bits set in an IPv6 address to the network base', () => {
+        expect(cidrToIPRange('2001:db8::1/32')).toEqual({ start: '2001:db8::', end: '2001:db8:ffff:ffff:ffff:ffff:ffff:ffff' });
+    });
+
+    it('returns undefined for an unparseable CIDR', () => {
+        expect(cidrToIPRange('not-a-cidr')).toBeUndefined();
+    });
+
+    it('returns undefined for a missing prefix length', () => {
+        expect(cidrToIPRange('10.0.0.0')).toBeUndefined();
+    });
+
+    it('returns undefined for an out-of-range prefix length', () => {
+        expect(cidrToIPRange('10.0.0.0/33')).toBeUndefined();
+    });
+
+    it('converts a NAT64-style embedded-IPv4 CIDR using the RFC 4291 tail, not hex digits', () => {
+        expect(cidrToIPRange('64:ff9b::10.0.0.0/120'))
+            .toEqual({ start: '64:ff9b::a00:0', end: '64:ff9b::a00:ff' });
+    });
+
+    it('converts an IPv4-mapped embedded-IPv4 CIDR (::ffff: prefix)', () => {
+        expect(cidrToIPRange('::ffff:10.0.0.0/120'))
+            .toEqual({ start: '::ffff:a00:0', end: '::ffff:a00:ff' });
+    });
+
+    it('converts an IPv4-mapped embedded-IPv4 CIDR with a non-trivial dotted quad', () => {
+        expect(cidrToIPRange('::ffff:192.168.1.0/120'))
+            .toEqual({ start: '::ffff:c0a8:100', end: '::ffff:c0a8:1ff' });
+    });
+
+    it('converts an embedded-IPv4 tail written without :: compression', () => {
+        expect(cidrToIPRange('1:2:3:4:5:6:10.0.0.1/128'))
+            .toEqual({ start: '1:2:3:4:5:6:a00:1', end: '1:2:3:4:5:6:a00:1' });
+    });
+
+    it('converts :: compression combined with an embedded-IPv4 tail', () => {
+        expect(cidrToIPRange('1::10.0.0.1/128'))
+            .toEqual({ start: '1::a00:1', end: '1::a00:1' });
+    });
+});
+
+describe('parseIPToBytes octet strictness', () => {
+    it('accepts a plain valid IPv4 address', () => {
+        expect(parseIPToBytes('10.0.0.1')).toEqual([10, 0, 0, 1]);
+    });
+
+    it('rejects an IPv4 octet with trailing junk', () => {
+        expect(parseIPToBytes('10.0.0.1abc')).toBeUndefined();
+    });
+
+    it('accepts a valid embedded-IPv4 tail without :: compression', () => {
+        expect(parseIPToBytes('1:2:3:4:5:6:10.0.0.1'))
+            .toEqual([0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 10, 0, 0, 1]);
+    });
+
+    it('rejects an embedded-IPv4 tail with trailing junk in the last octet', () => {
+        expect(parseIPToBytes('1:2:3:4:5:6:10.0.0.1abc')).toBeUndefined();
+    });
+
+    it('accepts a compressed embedded-IPv4 tail', () => {
+        expect(parseIPToBytes('::10.0.0.1'))
+            .toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 1]);
+    });
+
+    it('rejects a compressed embedded-IPv4 tail with trailing junk', () => {
+        expect(parseIPToBytes('::10.0.0.1abc')).toBeUndefined();
+    });
+
+    it('rejects an out-of-range octet even with junk suppressed', () => {
+        expect(parseIPToBytes('::999.0.0.1')).toBeUndefined();
+    });
+});
+
+describe('parseIPv6ToBytes hex-group strictness', () => {
+    it('rejects a first-position group with trailing junk', () => {
+        expect(parseIPToBytes('1abcg::')).toBeUndefined();
+    });
+
+    it('rejects a non-first-position group with trailing junk', () => {
+        expect(parseIPToBytes('1:2:3:4:5:6:7:8abcg')).toBeUndefined();
+    });
+
+    it('accepts :: alone (positive control)', () => {
+        expect(parseIPToBytes('::')).toEqual(new Array(16).fill(0));
+    });
+
+    it('accepts ::1 (positive control)', () => {
+        expect(parseIPToBytes('::1')).toEqual([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+        ]);
+    });
+
+    it('accepts 1:: (positive control)', () => {
+        expect(parseIPToBytes('1::')).toEqual([
+            0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        ]);
+    });
+
+    it('accepts a full eight-group address (positive control)', () => {
+        expect(parseIPToBytes('1:2:3:4:5:6:7:8')).toEqual([
+            0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 8,
+        ]);
+    });
+
+    it('accepts the already-covered embedded-IPv4 forms (positive control)', () => {
+        expect(parseIPToBytes('::10.0.0.1'))
+            .toEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 1]);
+        expect(parseIPToBytes('1:2:3:4:5:6:10.0.0.1'))
+            .toEqual([0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 10, 0, 0, 1]);
+    });
+});
+
+describe('parseCidrsToIPNets hex-group strictness', () => {
+    it('drops an entry with trailing junk in the first group', () => {
+        expect(parseCidrsToIPNets(['1abcg::/64'])).toEqual([]);
+    });
+
+    it('drops an entry with trailing junk in a non-first group', () => {
+        expect(parseCidrsToIPNets(['1:2:3:4:5:6:7:8abcg/128'])).toEqual([]);
+    });
+
+    it('keeps well-formed entries alongside a dropped junk-group one', () => {
+        expect(parseCidrsToIPNets(['1abcg::/64', '2001:db8::/32']))
+            .toEqual(parseCidrsToIPNets(['2001:db8::/32']));
+        expect(parseCidrsToIPNets(['2001:db8::/32'])).toHaveLength(1);
+    });
+});
+
+describe('IPv4Prefix.parse mask strictness', () => {
+    it('accepts a well-formed mask (positive control)', () => {
+        const result = IPv4Prefix.parse('10.0.0.0/24');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.prefixLength).toBe(24);
+        }
+    });
+
+    it('rejects a mask with trailing alphabetic junk', () => {
+        const result = IPv4Prefix.parse('10.0.0.0/24abc');
+        expect(result).toEqual({ ok: false, error: CIDRParseError.InvalidPrefixLength });
+    });
+
+    it('rejects a mask with a trailing decimal fraction', () => {
+        const result = IPv4Prefix.parse('10.0.0.0/24.5');
+        expect(result).toEqual({ ok: false, error: CIDRParseError.InvalidPrefixLength });
+    });
+
+    it('rejects a mask with embedded whitespace', () => {
+        const result = IPv4Prefix.parse('10.0.0.0/ 24');
+        expect(result).toEqual({ ok: false, error: CIDRParseError.InvalidPrefixLength });
+    });
+
+    it('rejects a mask with an explicit leading plus sign', () => {
+        const result = IPv4Prefix.parse('10.0.0.0/+24');
+        expect(result).toEqual({ ok: false, error: CIDRParseError.InvalidPrefixLength });
+    });
+
+    it('rejects an empty mask', () => {
+        const result = IPv4Prefix.parse('10.0.0.0/');
+        expect(result).toEqual({ ok: false, error: CIDRParseError.InvalidPrefixLength });
+    });
+
+    it('still correctly rejects a negative mask', () => {
+        const result = IPv4Prefix.parse('10.0.0.0/-1');
+        expect(result).toEqual({ ok: false, error: CIDRParseError.InvalidPrefixLength });
+    });
+
+    it('parseCIDRPrefix (the general entry point) rejects the same malformed masks', () => {
+        expect(parseCIDRPrefix('10.0.0.0/24abc').ok).toBe(false);
+        expect(parseCIDRPrefix('10.0.0.0/24.5').ok).toBe(false);
+    });
+
+    it('rejects a malformed mask that also feeds cidrToIPRange, so a typo cannot silently install a route', () => {
+        expect(cidrToIPRange('10.0.0.0/24abc')).toBeUndefined();
+        expect(cidrToIPRange('10.0.0.0/24.5')).toBeUndefined();
+    });
+});
+
+describe('parseCidrsToIPNets mask strictness', () => {
+    it('converts a well-formed CIDR list (positive control)', () => {
+        expect(parseCidrsToIPNets(['10.0.0.0/24'])).toEqual([
+            { addr: 'CgAAAA==', mask: '////AA==' },
+        ]);
+    });
+
+    it('drops an entry with trailing alphabetic junk in the mask', () => {
+        expect(parseCidrsToIPNets(['10.0.0.0/24abc'])).toEqual([]);
+    });
+
+    it('drops an entry with a trailing decimal fraction in the mask', () => {
+        expect(parseCidrsToIPNets(['10.0.0.0/24.5'])).toEqual([]);
+    });
+
+    it('drops an entry with an explicit leading plus sign in the mask', () => {
+        expect(parseCidrsToIPNets(['10.0.0.0/+24'])).toEqual([]);
+    });
+
+    it('drops an entry with an empty mask', () => {
+        expect(parseCidrsToIPNets(['10.0.0.0/'])).toEqual([]);
+    });
+
+    it('keeps well-formed entries alongside dropped malformed ones', () => {
+        expect(parseCidrsToIPNets(['10.0.0.0/24abc', '10.0.0.0/24'])).toEqual([
+            { addr: 'CgAAAA==', mask: '////AA==' },
+        ]);
+    });
+
+    it('drops an entry with trailing junk in an embedded-IPv4 tail octet', () => {
+        expect(parseCidrsToIPNets(['1:2:3:4:5:6:10.0.0.1abc/128'])).toEqual([]);
+    });
+
+    it('keeps a valid embedded-IPv4 CIDR alongside a dropped junk-tail one', () => {
+        expect(parseCidrsToIPNets(['1:2:3:4:5:6:10.0.0.1abc/128', '64:ff9b::10.0.0.0/120']))
+            .toEqual(parseCidrsToIPNets(['64:ff9b::10.0.0.0/120']));
+        expect(parseCidrsToIPNets(['64:ff9b::10.0.0.0/120'])).toHaveLength(1);
     });
 });

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -101,6 +101,28 @@ export function isValidIPv4Address(ip: string): boolean {
 }
 
 /**
+ * Rewrite an RFC 4291 trailing dotted-quad IPv4 tail (the last 32 bits of an
+ * IPv6 address written as e.g. the "10.0.0.0" in "64:ff9b::10.0.0.0" or
+ * "::ffff:192.168.1.1") into two hex groups, so downstream group-counting
+ * and parsing logic only ever has to handle plain hex-group IPv6 syntax.
+ *
+ * Returns the input unchanged when the last colon-separated group has no
+ * dot, and undefined when it has a dot but isn't a valid IPv4 address.
+ */
+const expandIPv6EmbeddedIPv4 = (ip: string): string | undefined => {
+    const lastColon = ip.lastIndexOf(':');
+    const tail = lastColon === -1 ? ip : ip.slice(lastColon + 1);
+    if (!tail.includes('.')) return ip;
+
+    const v4Bytes = parseIPv4ToBytes(tail);
+    if (!v4Bytes) return undefined;
+
+    const hi = ((v4Bytes[0] << 8) | v4Bytes[1]).toString(16);
+    const lo = ((v4Bytes[2] << 8) | v4Bytes[3]).toString(16);
+    return `${ip.slice(0, lastColon + 1)}${hi}:${lo}`;
+};
+
+/**
  * IPv6 Address class with validation
  */
 export class IPv6Address {
@@ -118,8 +140,13 @@ export class IPv6Address {
             // Use URL constructor to validate - it throws for invalid IPs
             new URL(`http://[${ip}]`);
 
-            const parts = ip.split(':');
-            const doubleColonCount = (ip.match(/::/g) || []).length;
+            const normalized = expandIPv6EmbeddedIPv4(ip);
+            if (normalized === undefined) {
+                return err(IPv6ParseError.InvalidFormat);
+            }
+
+            const parts = normalized.split(':');
+            const doubleColonCount = (normalized.match(/::/g) || []).length;
 
             // Can't have more than one ::
             if (doubleColonCount > 1) {
@@ -143,7 +170,7 @@ export class IPv6Address {
             }
 
             // Parse groups (expand :: to zeros)
-            const expanded = ip.replace('::', ':0000'.repeat(9 - parts.length)).split(':');
+            const expanded = normalized.replace('::', ':0000'.repeat(9 - parts.length)).split(':');
             const groups: number[] = [];
             for (const group of expanded) {
                 const num = parseInt(group || '0', 16);
@@ -231,6 +258,58 @@ export function isValidIPv6Address(ip: string): boolean {
     return result.ok;
 }
 
+/**
+ * Parse a string as a strict unsigned integer within [0, maxValue].
+ *
+ * Require the whole string to be pure digits of the given radix (no sign,
+ * no leading/trailing junk): parseInt alone would accept "24abc" or "1abcg"
+ * by stopping at the first character outside the radix's digit set.
+ */
+const parseStrictUint = (str: string, maxValue: number, radix: 10 | 16 = 10): number | undefined => {
+    const pattern = radix === 16 ? /^[0-9a-fA-F]+$/ : /^\d+$/;
+    if (!pattern.test(str)) {
+        return undefined;
+    }
+    const num = parseInt(str, radix);
+    if (isNaN(num) || num < 0 || num > maxValue) {
+        return undefined;
+    }
+    return num;
+};
+
+/** Parse a prefix-length string as a strict base-10 integer within [0, maxMask]. */
+const parseStrictPrefixLength = (maskStr: string, maxMask: number): number | undefined => {
+    return parseStrictUint(maskStr, maxMask);
+};
+
+/**
+ * Parse an IPv4 octet string as a strict base-10 integer within [0, 255].
+ *
+ * Rejects leading zeros (e.g. "010"), matching the strictness IPv4Address.parse
+ * already applies, so a single octet can't be mistaken for octal and different
+ * IPv4 parsers in this file don't disagree on the same input.
+ */
+const parseStrictOctet = (str: string): number | undefined => {
+    if (str.length > 1 && str.startsWith('0')) {
+        return undefined;
+    }
+    return parseStrictUint(str, 255);
+};
+
+/**
+ * Parse an IPv6 hex group string as a strict integer within [0, 0xffff].
+ *
+ * Bounds the group to at most four hex digits, matching RFC 4291: a fifth
+ * digit can't occur in a well-formed group even though parseStrictUint's
+ * decimal counterpart has no analogous width limit.
+ */
+const parseStrictHexGroup = (str: string): number | undefined => {
+    if (str.length > 4) {
+        return undefined;
+    }
+    return parseStrictUint(str, 0xffff, 16);
+};
+
 /** Parse the common fields of a CIDR prefix string before address parsing. */
 const parsePrefixFields = (
     prefix: string,
@@ -246,8 +325,8 @@ const parsePrefixFields = (
     }
 
     const [ip, maskStr] = parts;
-    const mask = parseInt(maskStr, 10);
-    if (isNaN(mask) || mask < 0 || mask > maxMask) {
+    const mask = parseStrictPrefixLength(maskStr, maxMask);
+    if (mask === undefined) {
         return err(CIDRParseError.InvalidPrefixLength);
     }
 
@@ -524,8 +603,8 @@ export const parseIPv4ToBytes = (ipStr: string): number[] | undefined => {
     }
     const bytes: number[] = [];
     for (const part of parts) {
-        const num = parseInt(part, 10);
-        if (isNaN(num) || num < 0 || num > 255) {
+        const num = parseStrictOctet(part);
+        if (num === undefined) {
             return undefined;
         }
         bytes.push(num);
@@ -542,10 +621,14 @@ export const parseIPv6ToBytes = (ipStr: string): number[] | undefined => {
     const trimmed = ipStr.trim();
     if (!trimmed) return undefined;
 
+    const withEmbeddedIPv4Expanded = expandIPv6EmbeddedIPv4(trimmed);
+    if (withEmbeddedIPv4Expanded === undefined) return undefined;
+    const normalized = withEmbeddedIPv4Expanded;
+
     // Handle :: expansion
-    let fullAddr = trimmed;
-    if (trimmed.includes('::')) {
-        const parts = trimmed.split('::');
+    let fullAddr = normalized;
+    if (normalized.includes('::')) {
+        const parts = normalized.split('::');
         const left = parts[0] ? parts[0].split(':') : [];
         const right = parts[1] ? parts[1].split(':') : [];
         const missing = 8 - left.length - right.length;
@@ -559,8 +642,11 @@ export const parseIPv6ToBytes = (ipStr: string): number[] | undefined => {
 
     const bytes: number[] = [];
     for (const part of parts) {
-        const num = parseInt(part || '0', 16);
-        if (isNaN(num) || num < 0 || num > 0xffff) return undefined;
+        // The `::` expansion above always substitutes an explicit '0' for a
+        // compressed group, so an empty part here only comes from that path -
+        // keep it as zero rather than routing it through the strict parser.
+        const num = part === '' ? 0 : parseStrictHexGroup(part);
+        if (num === undefined) return undefined;
         bytes.push((num >> 8) & 0xff);
         bytes.push(num & 0xff);
     }
@@ -804,6 +890,39 @@ export const ipRangeToString = (range: IPRangeWire | undefined): string => {
     return `[${start}, ${end}]`;
 };
 
+// Convert a single CIDR prefix string into a wire IPRange. The address is
+// masked to its network base (e.g. "10.0.0.5/24" yields start "10.0.0.0"),
+// not passed through verbatim, so the emitted range always spans exactly
+// the prefix's address block. Returns undefined for unparseable input.
+export const cidrToIPRange = (cidr: string): IPRangeWire | undefined => {
+    const parsed = parseCIDRPrefix(cidr);
+    if (!parsed.ok) return undefined;
+
+    const prefixLen = getPrefixLength(cidr);
+    if (prefixLen === null) return undefined;
+
+    // Parse bytes from the address substring directly rather than round-tripping
+    // through address.toString(), whose IPv6 :: compression drops the trailing
+    // colon when the compressed run reaches the end of the address.
+    const addrPart = cidr.slice(0, cidr.lastIndexOf('/'));
+    const addrBytes = parseIPToBytes(addrPart);
+    if (!addrBytes) return undefined;
+
+    const totalBytes = addrBytes.length;
+    const totalBits = totalBytes * 8;
+    const hostBits = totalBits - prefixLen;
+
+    const addrBits = bytesToBigInt(addrBytes);
+    const hostMask = hostBits === 0 ? 0n : (1n << BigInt(hostBits)) - 1n;
+    const start = addrBits & ~hostMask;
+    const end = lastAddrOfPrefix(start, prefixLen, totalBits);
+
+    return {
+        start: formatIPFromBytes(bigIntToBytes(start, totalBytes)),
+        end: formatIPFromBytes(bigIntToBytes(end, totalBytes)),
+    };
+};
+
 /** Parse CIDR strings to IPNet array with base64-encoded bytes. */
 export const parseCidrsToIPNets = (cidrs: string[]): Array<{ addr: string; mask: string }> => {
     const results: Array<{ addr: string; mask: string }> = [];
@@ -811,13 +930,12 @@ export const parseCidrsToIPNets = (cidrs: string[]): Array<{ addr: string; mask:
         const parts = cidr.trim().split('/');
         if (parts.length !== 2) continue;
         const [ipPart, maskStr] = parts;
-        const prefixLength = parseInt(maskStr, 10);
-        if (isNaN(prefixLength)) continue;
         const addrBytes = parseIPToBytes(ipPart);
         if (!addrBytes) continue;
         const isIPv4 = addrBytes.length === 4;
         const maxPrefix = isIPv4 ? 32 : 128;
-        if (prefixLength < 0 || prefixLength > maxPrefix) continue;
+        const prefixLength = parseStrictPrefixLength(maskStr, maxPrefix);
+        if (prefixLength === undefined) continue;
         const maskBytes = prefixLengthToMaskBytes(prefixLength, isIPv4 ? 4 : 16);
         results.push({
             addr: bytesToBase64(addrBytes),


### PR DESCRIPTION
- `UpdateFIB` now carries typed address ranges instead of CIDR strings, matching what `ShowFIB` already returned and the range-native lookup layer underneath, which has always stored an inclusive from/to pair. The CIDR on the write path was a lossy encoding of something the dataplane stores as a range, and every range-shaped client had to decompose into several entries on write and rely on the server to recompose them on read.
- The two FIB entry messages collapse into one, so the read and write paths share a single type and a single field name.
- Breaking change to a frozen `.v1` package, authorised by the repository owner: the CIDR-shaped entry message is deleted and field 3 of the update request is retyped. The `buf-breaking` check therefore fails by design and has been un-required for this change. The field number is reused deliberately rather than renumbered: with a new number an old client's payload would decode as zero entries and the server would atomically publish an empty forwarding table, whereas reusing it makes the request fail validation loudly.
- Documents the overlap contract the update RPC has always had but never stated: entries are applied in list order and each repaints exactly the addresses it covers, so where two ranges overlap the later one wins regardless of how narrow it is. This is not longest-prefix-match, and a client that wants those semantics must send narrower ranges last.
- The lookup table's header comment claimed the tree does not allow rewriting key ranges, which was true only of a narrower reading than a reader would take. It now states that an insert overwrites every key it covers. The semantics were confirmed with a dedicated reproduction harness before being documented.
- Records that the route operator's ascending prefix-length walk is what reproduces longest-prefix-match under those semantics. That invariant was previously undocumented and silently load-bearing: a container change there would randomise the order and corrupt the forwarding table.
- The update path now rejects a missing, unparseable, family-mismatched or inverted range as an invalid argument rather than surfacing it as an internal error.
- The CLI rules file keeps its existing shape. Only the conversion changes: a prefix is now turned into a range before it goes on the wire, and host bits are masked to the network base.
- Removes the CLI's invalid-range classification and its placeholder row, which guarded only against the server violating its own validation.
- Fixes an IPv6 parsing defect in the browser address helpers, found while reviewing this change: an address with an embedded IPv4 tail was converted to a different address entirely, and the uncompressed form was wrongly rejected. Both reach the ACL and forward write paths as well as this one.