### PR TITLE
chore(cli): update netip to 0.3.8 and raise the rust msrv to 1.88

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,6 +286,6 @@ These rules bind the delegating agent, not the implementer.
 
 - **DPDK**: v23+ (submodule)
 - **Go**: 1.24.13+
-- **Rust**: 1.84+ (nightly for formatting)
+- **Rust**: 1.88+ (nightly for formatting)
 - **Meson**: 0.61+
 - **Protobuf**: 3.0+ (protoc-gen-go >=1.36.5, protoc-gen-go-grpc >=1.5.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,9 +1233,9 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "netip"
-version = "0.3.2"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff1fcab1e3a897063665edc7c11f1de7591aa92179994ca049b422db94a3001"
+checksum = "513b83d6285ebc6b4519a89263bb0bd789e4d2d279f1f99e59034d3138b6f74f"
 
 [[package]]
 name = "no-std-net"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ YANET employs a multi-language approach to leverage the strengths of different p
 ### Dependencies
 
 - Go 1.21+.
-- Rust 1.84+.
+- Rust 1.88+.
 - Protobuf compiler 3.0+.
 - Meson 0.61+.
 - Ninja build system.

--- a/cli/core/Cargo.toml
+++ b/cli/core/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/cli/modules/common/Cargo.toml
+++ b/cli/modules/common/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/cli/modules/counters/Cargo.toml
+++ b/cli/modules/counters/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/cli/modules/device/Cargo.toml
+++ b/cli/modules/device/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/cli/modules/gateway/Cargo.toml
+++ b/cli/modules/gateway/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/cli/modules/inspect/Cargo.toml
+++ b/cli/modules/inspect/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/cli/modules/metrics/Cargo.toml
+++ b/cli/modules/metrics/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/cli/modules/ready/Cargo.toml
+++ b/cli/modules/ready/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/common/rust/commonpb/Cargo.toml
+++ b/common/rust/commonpb/Cargo.toml
@@ -3,7 +3,7 @@ name = "yanet-commonpb"
 version = "0.1.0"
 edition = "2024"
 publish = false
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/common/rust/filterpb/Cargo.toml
+++ b/common/rust/filterpb/Cargo.toml
@@ -3,7 +3,7 @@ name = "yanet-filterpb"
 version = "0.1.0"
 edition = "2024"
 publish = false
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/common/rust/readinesspb/Cargo.toml
+++ b/common/rust/readinesspb/Cargo.toml
@@ -3,7 +3,7 @@ name = "yanet-readinesspb"
 version = "0.1.0"
 edition = "2024"
 publish = false
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/common/rust/ynpb/Cargo.toml
+++ b/common/rust/ynpb/Cargo.toml
@@ -3,7 +3,7 @@ name = "yanet-ynpb"
 version = "0.1.0"
 edition = "2024"
 publish = false
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/devices/plain/cli/Cargo.toml
+++ b/devices/plain/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/devices/trafgen/cli/Cargo.toml
+++ b/devices/trafgen/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/devices/vlan/cli/Cargo.toml
+++ b/devices/vlan/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/acl/cli/Cargo.toml
+++ b/modules/acl/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/balancer2/cli/Cargo.toml
+++ b/modules/balancer2/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/balancer2/cli/src/display.rs
+++ b/modules/balancer2/cli/src/display.rs
@@ -299,15 +299,15 @@ fn print_decap(state: &balancerpb::BalancerState) {
     let Some(addr) = &state.addr else {
         return;
     };
-    if !addr.source_ip4.is_empty() {
-        if let Ok(ip) = bytes_to_ip(&addr.source_ip4) {
-            println!("Source IPv4: {}", ip);
-        }
+    if !addr.source_ip4.is_empty()
+        && let Ok(ip) = bytes_to_ip(&addr.source_ip4)
+    {
+        println!("Source IPv4: {}", ip);
     }
-    if !addr.source_ip6.is_empty() {
-        if let Ok(ip) = bytes_to_ip(&addr.source_ip6) {
-            println!("Source IPv6: {}", ip);
-        }
+    if !addr.source_ip6.is_empty()
+        && let Ok(ip) = bytes_to_ip(&addr.source_ip6)
+    {
+        println!("Source IPv6: {}", ip);
     }
     if !addr.decaps.is_empty() {
         println!("Decap Addresses:");

--- a/modules/blackhole/cli/Cargo.toml
+++ b/modules/blackhole/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/decap/cli/Cargo.toml
+++ b/modules/decap/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/forward/cli/Cargo.toml
+++ b/modules/forward/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -428,10 +428,10 @@ impl FWStateService {
             .into_iter()
             .map(Metric::from_proto)
             .filter(|m| {
-                if let Some(ref f) = cmd.name {
-                    if !f.matches(m) {
-                        return false;
-                    }
+                if let Some(ref f) = cmd.name
+                    && !f.matches(m)
+                {
+                    return false;
                 }
                 label_filters.iter().all(|(k, v)| m.label_value(k) == Some(v))
             })

--- a/modules/mirror/cli/Cargo.toml
+++ b/modules/mirror/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/nat64/cli/Cargo.toml
+++ b/modules/nat64/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/pdump/cli/Cargo.toml
+++ b/modules/pdump/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "yanet-cli-pdump"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/route-mpls/cli/Cargo.toml
+++ b/modules/route-mpls/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/modules/route/cli/route/Cargo.toml
+++ b/modules/route/cli/route/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/operators/pipeline/cli/Cargo.toml
+++ b/operators/pipeline/cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/operators/route/cli/neighbour/Cargo.toml
+++ b/operators/route/cli/neighbour/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true

--- a/operators/route/cli/route/Cargo.toml
+++ b/operators/route/cli/route/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
-rust-version = "1.85"
+rust-version = "1.88"
 
 [lints]
 workspace = true


### PR DESCRIPTION
- Update the netip dependency from 0.3.2 to the latest 0.3.8 release. Every version in the intervening range is documented as additive-only, and the workspace uses none of the changed surface, so no call site needed adapting.
- Raise the declared minimum supported Rust version to 1.88 across the workspace, which is what the new netip release requires. The requirement string stays loose, matching how every other dependency here is written, so the lockfile remains the single place the version is pinned.
- Collapse three nested conditionals into let chains. The linter only proposes this once the declared minimum reaches the release that stabilised the feature, so the raised minimum turns it into a hard failure under the warnings-as-errors gate.
- Update the documented Rust version in the contributor guide and the readme dependency list. Both still named a version below what the manifests already declared.
