### PR TITLE
fix(gateway): keep an evicted backend open until its in-flight calls finish

### DIFF
--- a/controlplane/gateway/gateway.go
+++ b/controlplane/gateway/gateway.go
@@ -164,7 +164,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 			return proxy.One2One, nil, status.Errorf(codes.NotFound, "malformed gRPC method name: %v", err)
 		}
 
-		backend, ok := registry.GetBackend(service)
+		backend, release, ok := registry.GetBackend(service)
 		if !ok {
 			// The HTTP surface answers 503 for this same condition,
 			// because it cannot tell an HTTP client "this service never
@@ -186,6 +186,14 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 			_ = grpc.SetTrailer(ctx, metadata.Pairs(errorReasonMetadataKey, errorReasonServiceUnregistered))
 			return proxy.One2One, nil, status.Errorf(codes.NotFound, "unknown service")
 		}
+
+		// The proxy library hands backend to its own machinery for the
+		// whole call rather than returning it to this closure, so there is
+		// no return-site here to release the lease at. ctx is the RPC's
+		// own server-side stream context, which the proxy library cancels
+		// once this call finishes, so tying the release to it releases the
+		// lease exactly when the call is done, however it ends.
+		context.AfterFunc(ctx, release)
 
 		log.Debug("proxying request",
 			zap.String("method", fullMethodName),
@@ -225,7 +233,7 @@ func NewGateway(cfg *Config, options ...GatewayOption) (*Gateway, error) {
 	// A registry backend lookup is mutex-guarded and cheap. The gateway's
 	// own registered services are read from the cached serviceKnown snapshot.
 	serviceFilter := func(service string) bool {
-		if _, ok := registry.GetBackend(service); ok {
+		if registry.HasBackend(service) {
 			return true
 		}
 		_, ok := serviceKnown()[service]

--- a/controlplane/gateway/registry.go
+++ b/controlplane/gateway/registry.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/siderolabs/grpc-proxy/proxy"
@@ -77,8 +78,8 @@ func (m *BackendEntry) Kind() BackendKind {
 	return m.kind
 }
 
-// GetBackend returns the proxy.Backend for this entry.
-func (m *BackendEntry) GetBackend() proxy.Backend {
+// GetBackend returns the Backend for this entry.
+func (m *BackendEntry) GetBackend() Backend {
 	return m.backend
 }
 
@@ -90,28 +91,113 @@ func (m *BackendEntry) Close() error {
 	return m.backend.Close()
 }
 
+// backendRef is the shared, atomically-updated refcount for one distinct
+// backend connection.
+//
+// Its count is the number of registry entries currently resolving to
+// backend plus the number of leases handed out for it by GetBackend. The
+// backend is closed the instant the count reaches zero, by whichever
+// decrement gets it there.
+type backendRef struct {
+	backend Backend
+	count   atomic.Int64
+}
+
+// GetBackend returns the backend this ref counts references to.
+func (m *backendRef) GetBackend() Backend {
+	return m.backend
+}
+
+// Retain records one more reference to the backend.
+func (m *backendRef) Retain() {
+	m.count.Add(1)
+}
+
+// Release drops one reference to the backend and reports whether that was
+// the last one.
+func (m *backendRef) Release() bool {
+	return m.count.Add(-1) == 0
+}
+
 // BackendRegistry is a registry of backends for Gateway API.
 type BackendRegistry struct {
 	mu       sync.RWMutex
 	backends map[string]BackendEntry
+	refs     map[Backend]*backendRef
 }
 
 // NewBackendRegistry creates a new BackendRegistry.
 func NewBackendRegistry() *BackendRegistry {
 	return &BackendRegistry{
 		backends: map[string]BackendEntry{},
+		refs:     map[Backend]*backendRef{},
 	}
 }
 
-// GetBackend returns a backend for the given service.
+// GetBackend returns a leased backend for the given service, plus a release
+// function the caller must call exactly once when it is done using the
+// backend.
 //
 // Service parameter must be in gRPC format, such as "routepb.RouteService".
-func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, bool) {
+// The lease keeps the backend's connection open even if EvictStale or a
+// displacing RegisterBackend removes it from the registry while the lease
+// is outstanding: the connection is only closed once every lease on it has
+// been released and no registry entry resolves to it any more. Release is
+// idempotent and safe to call after the entry backing the lease has been
+// evicted or displaced.
+func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, func(), bool) {
+	m.mu.RLock()
+	entry, ok := m.backends[service]
+	if !ok {
+		m.mu.RUnlock()
+		return nil, func() {}, false
+	}
+
+	ref := m.refs[entry.backend]
+	ref.Retain()
+	m.mu.RUnlock()
+
+	return entry.GetBackend(), m.lease(ref), true
+}
+
+// HasBackend reports whether a backend is currently registered for service,
+// without leasing it.
+//
+// Service parameter must be in gRPC format, such as "routepb.RouteService".
+func (m *BackendRegistry) HasBackend(service string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	entry, ok := m.backends[service]
-	return entry.backend, ok
+	_, ok := m.backends[service]
+	return ok
+}
+
+// lease returns an idempotent release function for ref.
+//
+// Wrapping the decrement in sync.Once means a caller that releases more
+// than once, deliberately or by accident, still drops the refcount by
+// exactly one.
+func (m *BackendRegistry) lease(ref *backendRef) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() { m.releaseRef(ref) })
+	}
+}
+
+// releaseRef drops one reference from ref and closes its backend, outside
+// the registry lock, if that was the last reference of any kind.
+func (m *BackendRegistry) releaseRef(ref *backendRef) {
+	if !ref.Release() {
+		return
+	}
+
+	m.mu.Lock()
+	if m.refs[ref.GetBackend()] == ref {
+		delete(m.refs, ref.GetBackend())
+	}
+	m.mu.Unlock()
+
+	_ = ref.GetBackend().Close()
 }
 
 // RegisterBackend stores or replaces the backend for service and reports how
@@ -120,9 +206,11 @@ func (m *BackendRegistry) GetBackend(service string) (proxy.Backend, bool) {
 // The displaced backend (the previous one on an endpoint change, or the
 // redundant new one on an unchanged-endpoint re-registration) is closed
 // after the lock is released, but only once no service name in the registry
-// still resolves to it: displacing one of the names a backend is registered
-// under leaves it open for as long as another name still points at it. This
-// matters because one dialed connection, such as the gateway's own loopback
+// still resolves to it and no outstanding GetBackend lease still holds it:
+// displacing one of the names a backend is registered under leaves it open
+// for as long as another name still points at it, and a call already
+// proxying through it leaves it open until that call finishes. This matters
+// because one dialed connection, such as the gateway's own loopback
 // backend, is commonly registered under several service names at once.
 func (m *BackendRegistry) RegisterBackend(service string, b Backend, kind BackendKind) RegistrationStatus {
 	status, evicted := m.registerBackend(service, b, kind)
@@ -133,6 +221,16 @@ func (m *BackendRegistry) RegisterBackend(service string, b Backend, kind Backen
 	return status
 }
 
+// registerBackend performs the registration under the write lock and
+// reports the backend the caller must close afterwards, if any.
+//
+// The renewed branch's displaced value is b itself when the registry holds
+// no reference to it yet, since such a b is a freshly dialed connection
+// discarded before ever being stored in m.backends. When m.refs already
+// tracks b, such as a backend shared across several service names, the
+// displaced value is nil instead: b is a connection this registration never
+// retained, so closing it would tear down every other entry still
+// resolving to it.
 func (m *BackendRegistry) registerBackend(service string, b Backend, kind BackendKind) (RegistrationStatus, Backend) {
 	now := time.Now().UTC()
 
@@ -144,28 +242,55 @@ func (m *BackendRegistry) registerBackend(service string, b Backend, kind Backen
 	case ok && existing.backend.Endpoint() == b.Endpoint():
 		existing.lastSeenAt = now
 		m.backends[service] = existing
-		return RegistrationRenewed, m.unreferencedBackend(b)
+		if _, tracked := m.refs[b]; tracked {
+			return RegistrationRenewed, nil
+		}
+		return RegistrationRenewed, b
 	case ok:
 		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
-		return RegistrationUpdated, m.unreferencedBackend(existing.backend)
+		m.retainLocked(b)
+		return RegistrationUpdated, m.releaseLocked(existing.backend)
 	default:
 		m.backends[service] = BackendEntry{service: service, backend: b, kind: kind, lastSeenAt: now}
+		m.retainLocked(b)
 		return RegistrationRegistered, nil
 	}
 }
 
-// unreferencedBackend returns backend if no entry in the registry points at
-// it, or nil if some entry still does.
+// retainLocked records a new registry-entry reference to b, creating its
+// refcount if no entry or lease points at it yet.
 //
-// Must be called with m.mu held.
-func (m *BackendRegistry) unreferencedBackend(backend Backend) Backend {
-	for _, entry := range m.backends {
-		if entry.GetBackend() == backend {
-			return nil
-		}
+// Must be called with m.mu held for writing.
+func (m *BackendRegistry) retainLocked(b Backend) {
+	ref, ok := m.refs[b]
+	if !ok {
+		ref = &backendRef{backend: b}
+		m.refs[b] = ref
+	}
+	ref.Retain()
+}
+
+// releaseLocked drops one registry-entry reference from b and returns b if
+// that was its last reference of any kind, or nil if a lease or another
+// entry still holds it.
+//
+// Must be called with m.mu held for writing. A non-nil result must be
+// closed by the caller after the lock is released.
+func (m *BackendRegistry) releaseLocked(b Backend) Backend {
+	ref, ok := m.refs[b]
+	if !ok {
+		// Every backend stored in m.backends was retained via
+		// retainLocked, so a missing ref here is a bookkeeping bug
+		// rather than a state this registry can reach.
+		return nil
 	}
 
-	return backend
+	if !ref.Release() {
+		return nil
+	}
+
+	delete(m.refs, b)
+	return b
 }
 
 // Renew refreshes the last-seen timestamp when service is already registered
@@ -219,38 +344,48 @@ func (m *BackendRegistry) Close() error {
 // in-process entries share one loopback backend across several service keys,
 // and closing it here would tear down every other service hosted on that
 // backend along with the one that looked stale.
+//
+// An evicted backend is closed outside the registry lock, and only once
+// nothing else still holds it: a GetBackend lease taken before eviction
+// keeps the connection open until that call releases it, so a concurrent
+// caller already proxying through the backend never sees it close under it.
 func (m *BackendRegistry) EvictStale(before time.Time) []BackendEntry {
-	evicted := m.evictStale(before)
-	for _, entry := range evicted {
-		_ = entry.Close()
+	evicted, closable := m.evictStale(before)
+	for _, b := range closable {
+		_ = b.Close()
 	}
 
 	return evicted
 }
 
-func (m *BackendRegistry) evictStale(before time.Time) []BackendEntry {
+func (m *BackendRegistry) evictStale(before time.Time) ([]BackendEntry, []Backend) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	var evicted []BackendEntry
+	var closable []Backend
 	for service, entry := range m.backends {
 		if entry.Kind() == BackendKindExternal && entry.LastSeenAt().Before(before) {
 			evicted = append(evicted, entry)
 			delete(m.backends, service)
+			if b := m.releaseLocked(entry.GetBackend()); b != nil {
+				closable = append(closable, b)
+			}
 		}
 	}
 
-	return evicted
+	return evicted, closable
 }
 
 // takeBackends atomically returns the registered backends and clears the
-// registry.
+// registry, including its refcount bookkeeping.
 func (m *BackendRegistry) takeBackends() map[string]BackendEntry {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	backends := m.backends
 	m.backends = map[string]BackendEntry{}
+	m.refs = map[Backend]*backendRef{}
 	return backends
 }
 

--- a/controlplane/gateway/registry_test.go
+++ b/controlplane/gateway/registry_test.go
@@ -211,6 +211,35 @@ func TestBackendRegistry_DisplacingLastSharedNameClosesBackend(t *testing.T) {
 	require.Equal(t, otherB, entryB.backend)
 }
 
+// TestBackendRegistry_RenewingWithASharedBackendKeepsItOpen verifies that
+// renewing a service name with a backend object the registry already tracks
+// under another service name leaves that backend open.
+//
+// This is the regression guard for the shared loopback hazard on the
+// renewal path: renewing svc.A with the very backend object already
+// registered under both svc.A and svc.B must not close it out from under
+// svc.B, even though the renewal branch treats the passed-in backend as
+// redundant.
+func TestBackendRegistry_RenewingWithASharedBackendKeepsItOpen(t *testing.T) {
+	reg := NewBackendRegistry()
+	shared := &fakeBackend{endpoint: "127.0.0.1:8080"}
+	reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
+	reg.RegisterBackend("svc.B", shared, BackendKindBuiltin)
+
+	status := reg.RegisterBackend("svc.A", shared, BackendKindBuiltin)
+
+	require.Equal(t, RegistrationRenewed, status)
+	require.False(t, shared.Closed(), "the shared backend must not be closed")
+
+	entryA, ok := reg.backends["svc.A"]
+	require.True(t, ok)
+	require.Equal(t, shared, entryA.backend)
+
+	entryB, ok := reg.backends["svc.B"]
+	require.True(t, ok)
+	require.Equal(t, shared, entryB.backend)
+}
+
 func TestBackendRegistry_Close(t *testing.T) {
 	reg := NewBackendRegistry()
 	bA := &fakeBackend{endpoint: "127.0.0.1:9000"}
@@ -292,7 +321,9 @@ func TestBackendRegistry_ConcurrentRace(t *testing.T) {
 			b := &fakeBackend{endpoint: "127.0.0.1:9000"}
 			reg.RegisterBackend("svc.Race", b, BackendKindExternal)
 			reg.Renew("svc.Race", "127.0.0.1:9000")
-			reg.GetBackend("svc.Race")
+			if _, release, ok := reg.GetBackend("svc.Race"); ok {
+				release()
+			}
 			reg.ListBackends()
 		}()
 	}
@@ -437,6 +468,101 @@ func TestBackendRegistry_EvictStaleSparesSharedBackend(t *testing.T) {
 	require.True(t, ok, "svc.A must remain registered")
 	_, ok = reg.backends["svc.B"]
 	require.True(t, ok, "svc.B must remain registered")
+}
+
+// TestBackendRegistry_LeaseSurvivesConcurrentEviction verifies that a
+// backend obtained via GetBackend is not closed by a concurrent EvictStale
+// while the lease is still held, and is closed once that lease is the last
+// one released.
+//
+// This is the direct regression guard for the eviction race: GetBackend
+// used to hand out a raw backend with no ownership guarantee, so a sweep
+// that ran between lookup and use could close the connection out from
+// under an in-flight call.
+func TestBackendRegistry_LeaseSurvivesConcurrentEviction(t *testing.T) {
+	t.Parallel()
+
+	reg := NewBackendRegistry()
+	b := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", b, BackendKindExternal)
+
+	backend, release, ok := reg.GetBackend("svc.Foo")
+	require.True(t, ok)
+	require.NotNil(t, backend)
+
+	// Make the entry stale so a sweep evicts it while the lease above is
+	// still outstanding.
+	entry := reg.backends["svc.Foo"]
+	entry.lastSeenAt = time.Now().UTC().Add(-time.Hour)
+	reg.backends["svc.Foo"] = entry
+
+	evictedCh := make(chan []BackendEntry, 1)
+	go func() {
+		evictedCh <- reg.EvictStale(time.Now().UTC())
+	}()
+
+	var evicted []BackendEntry
+	select {
+	case evicted = <-evictedCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("EvictStale did not return")
+	}
+	require.Len(t, evicted, 1)
+
+	require.False(t, b.Closed(), "backend must stay open while the lease obtained before eviction is still held")
+
+	release()
+
+	require.True(t, b.Closed(), "backend must be closed once its last outstanding lease is released")
+}
+
+// TestBackendRegistry_ReRegisterAfterEvictionLeavesNewBackendUsable verifies
+// that releasing a lease held on a backend evicted and superseded by a
+// fresh registration under the same service name closes only the old
+// backend, never the new one.
+//
+// This guards the evict-then-re-register cycle: a lease taken before
+// eviction outlives the entry it was obtained from, so its eventual
+// release must not reach past that entry into whatever now occupies the
+// same service name.
+func TestBackendRegistry_ReRegisterAfterEvictionLeavesNewBackendUsable(t *testing.T) {
+	t.Parallel()
+
+	reg := NewBackendRegistry()
+	old := &fakeBackend{endpoint: "127.0.0.1:9000"}
+	reg.RegisterBackend("svc.Foo", old, BackendKindExternal)
+
+	// Simulate a call that obtained the backend just before the sweeper
+	// runs.
+	_, release, ok := reg.GetBackend("svc.Foo")
+	require.True(t, ok)
+
+	entry := reg.backends["svc.Foo"]
+	entry.lastSeenAt = time.Now().UTC().Add(-time.Hour)
+	reg.backends["svc.Foo"] = entry
+
+	evicted := reg.EvictStale(time.Now().UTC())
+	require.Len(t, evicted, 1)
+	require.False(t, old.Closed(), "old backend must stay open while its lease is outstanding")
+
+	// A fresh registration under the same service name, using a distinct
+	// connection, lands before the old lease is released.
+	next := &fakeBackend{endpoint: "127.0.0.1:9001"}
+	status := reg.RegisterBackend("svc.Foo", next, BackendKindExternal)
+	require.Equal(t, RegistrationRegistered, status)
+
+	nextBackend, nextRelease, ok := reg.GetBackend("svc.Foo")
+	require.True(t, ok)
+	require.Same(t, next, nextBackend)
+
+	// Releasing the stale lease must close only the now-unreferenced old
+	// backend, never the newly registered one sharing its service name.
+	release()
+	require.True(t, old.Closed(), "old backend must close once its last lease is released")
+	require.False(t, next.Closed(), "re-registered backend must not be closed by the old lease's release")
+
+	nextRelease()
+	require.False(t, next.Closed(), "releasing the only lease on a still-registered backend must not close it")
 }
 
 // TestBackendRegistry_RenewSavesFromEviction verifies that a Renew after

--- a/controlplane/httpproxy/proxy.go
+++ b/controlplane/httpproxy/proxy.go
@@ -22,8 +22,16 @@ import (
 )
 
 // BackendRegistry is the subset of backend lookup API required by the HTTP proxy.
+//
+// GetBackend leases the returned backend: the caller must call the release
+// function exactly once when it is done using the backend, or the
+// connection may be kept open past the point it should have closed.
+// HasBackend performs the same lookup without leasing, so a handler can
+// reject an unregistered service before it pays for reading the request
+// body.
 type BackendRegistry interface {
-	GetBackend(service string) (proxy.Backend, bool)
+	GetBackend(service string) (proxy.Backend, func(), bool)
+	HasBackend(service string) bool
 }
 
 // TransparentWebGRPCProxy is an HTTP handler that translates HTTP requests
@@ -137,8 +145,7 @@ func (m *TransparentWebGRPCProxy) handleUnary(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	backend, ok := m.registry.GetBackend(service)
-	if !ok {
+	if !m.registry.HasBackend(service) {
 		m.writeRegistryMissError(w, service)
 		return
 	}
@@ -148,6 +155,13 @@ func (m *TransparentWebGRPCProxy) handleUnary(w http.ResponseWriter, r *http.Req
 		http.Error(w, fmt.Sprintf("Failed to read request body: %v", err), http.StatusBadRequest)
 		return
 	}
+
+	backend, release, ok := m.registry.GetBackend(service)
+	if !ok {
+		m.writeRegistryMissError(w, service)
+		return
+	}
+	defer release()
 
 	requestMsg, err := m.jsonToProtobuf(fullMethodName, body, true)
 	if err != nil {
@@ -325,8 +339,7 @@ func (m *TransparentWebGRPCProxy) handleServerStreaming(w http.ResponseWriter, r
 		return
 	}
 
-	backend, ok := m.registry.GetBackend(service)
-	if !ok {
+	if !m.registry.HasBackend(service) {
 		m.writeRegistryMissError(w, service)
 		return
 	}
@@ -336,6 +349,13 @@ func (m *TransparentWebGRPCProxy) handleServerStreaming(w http.ResponseWriter, r
 		http.Error(w, fmt.Sprintf("Failed to read request body: %v", err), http.StatusBadRequest)
 		return
 	}
+
+	backend, release, ok := m.registry.GetBackend(service)
+	if !ok {
+		m.writeRegistryMissError(w, service)
+		return
+	}
+	defer release()
 
 	requestMsg, err := m.jsonToProtobuf(fullMethodName, body, true)
 	if err != nil {

--- a/controlplane/httpproxy/proxy_test.go
+++ b/controlplane/httpproxy/proxy_test.go
@@ -22,8 +22,12 @@ import (
 // simulating a service that is missing from the gateway's registry.
 type emptyRegistry struct{}
 
-func (m emptyRegistry) GetBackend(_ string) (proxy.Backend, bool) {
-	return nil, false
+func (m emptyRegistry) GetBackend(_ string) (proxy.Backend, func(), bool) {
+	return nil, func() {}, false
+}
+
+func (m emptyRegistry) HasBackend(_ string) bool {
+	return false
 }
 
 // TestServeHTTP_UnknownService verifies that a registry miss is answered
@@ -66,6 +70,55 @@ func TestServeHTTP_UnknownService(t *testing.T) {
 	}
 }
 
+// explodingBody is an io.Reader that fails the test if it is ever read.
+//
+// It stands in for a request body in the unregistered-service tests, where
+// the handler must reject the request before reading it.
+type explodingBody struct {
+	t *testing.T
+}
+
+func (m explodingBody) Read(_ []byte) (int, error) {
+	m.t.Fatal("request body was read for an unregistered service")
+	return 0, nil
+}
+
+// TestServeHTTP_UnknownService_DoesNotReadBody verifies that a registry miss
+// is answered without the handler ever consuming the request body, on both
+// the unary and server-streaming request paths.
+func TestServeHTTP_UnknownService_DoesNotReadBody(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "unary",
+			path: "/api/some.unknown.Service/Method",
+		},
+		{
+			name: "streaming",
+			path: "/api" + ynpb.ReadinessService_Watch_FullMethodName,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := httpproxy.NewHTTPHandler(emptyRegistry{})
+
+			req := httptest.NewRequest(http.MethodPost, testCase.path, explodingBody{t: t})
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, req)
+
+			require.Equal(t, http.StatusServiceUnavailable, recorder.Code)
+		})
+	}
+}
+
 // unreachableBackend is a proxy.Backend whose GetConnection always fails,
 // simulating a registered service whose upstream connection cannot be
 // established.
@@ -101,8 +154,12 @@ type unreachableRegistry struct {
 	backend unreachableBackend
 }
 
-func (m unreachableRegistry) GetBackend(_ string) (proxy.Backend, bool) {
-	return m.backend, true
+func (m unreachableRegistry) GetBackend(_ string) (proxy.Backend, func(), bool) {
+	return m.backend, func() {}, true
+}
+
+func (m unreachableRegistry) HasBackend(_ string) bool {
+	return true
 }
 
 // TestServeHTTP_BackendUnreachable verifies that a GetConnection failure is


### PR DESCRIPTION
- Close a backend connection only once no registry entry resolves to it and no in-flight call still holds it. The staleness sweeper previously closed the connection as soon as it dropped the entry, so a call that had already looked the backend up but not yet sent its request had the connection closed underneath it and surfaced as unavailable to the client.
- Hand callers a lease alongside the backend, counted per distinct connection, and release it when the call ends. The reference is taken while the lookup still holds the registry read lock, so an eviction cannot close a connection in the window between a caller finding it and starting to use it. The proxying director has no return site to release at, because the backend outlives the lookup closure, so its release is tied to the call's own context ending.
- Serve the service filter from a lookup that takes no lease, since it only tests membership and never uses the connection.
- Cover the race, the evict-then-register cycle, and the existing rule that a connection shared by several service names survives losing one of them.

This was found while diagnosing a private module's functional suite, which failed intermittently right after a virtual-machine snapshot restore. The clock step there makes the sweeper treat a live backend as stale, and the eviction that follows cut the next call. The window is small but not test-only: any registration that briefly lapses and recovers can hand a client one spurious failure per flap.
