### PR TITLE
fix(web): accept RFC 4291 embedded-IPv4 forms in the shared CIDR validators

### DIFF
--- a/web/src/core/utils/netip.test.ts
+++ b/web/src/core/utils/netip.test.ts
@@ -341,4 +341,17 @@ describe('parseCidrsToIPNets mask strictness', () => {
             .toEqual(parseCidrsToIPNets(['64:ff9b::10.0.0.0/120']));
         expect(parseCidrsToIPNets(['64:ff9b::10.0.0.0/120'])).toHaveLength(1);
     });
+
+    it('drops an entry with a zero-padded IPv4 mask', () => {
+        expect(parseCidrsToIPNets(['10.0.0.0/024'])).toEqual([]);
+    });
+
+    it('drops an entry with a zero-padded IPv6 mask', () => {
+        expect(parseCidrsToIPNets(['2001:db8::/0128'])).toEqual([]);
+    });
+
+    it('keeps a mask of exactly "/0" (positive control, guard is not over-broad)', () => {
+        expect(parseCidrsToIPNets(['0.0.0.0/0'])).toHaveLength(1);
+        expect(parseCidrsToIPNets(['::/0'])).toHaveLength(1);
+    });
 });

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -277,8 +277,17 @@ const parseStrictUint = (str: string, maxValue: number, radix: 10 | 16 = 10): nu
     return num;
 };
 
-/** Parse a prefix-length string as a strict base-10 integer within [0, maxMask]. */
+/**
+ * Parse a prefix-length string as a strict base-10 integer within [0, maxMask].
+ *
+ * Rejects leading zeros (e.g. "024") because Go's netip.ParsePrefix rejects
+ * them too, so a padded mask cannot pass validation here and then fail when
+ * the control plane reparses the prefix string.
+ */
 const parseStrictPrefixLength = (maskStr: string, maxMask: number): number | undefined => {
+    if (maskStr.length > 1 && maskStr.startsWith('0')) {
+        return undefined;
+    }
     return parseStrictUint(maskStr, maxMask);
 };
 

--- a/web/src/core/utils/validation.test.ts
+++ b/web/src/core/utils/validation.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { isValidCidr, isValidCidrPrefix } from './validation';
+
+describe('isValidCidr / isValidCidrPrefix — RFC 4291 embedded-IPv4 forms', () => {
+    const embeddedIPv4Prefixes = [
+        '64:ff9b::10.0.0.0/120',
+        '::ffff:192.168.1.1/128',
+        '1:2:3:4:5:6:10.0.0.1/128',
+        '1::10.0.0.1/128',
+    ];
+
+    for (const prefix of embeddedIPv4Prefixes) {
+        it(`accepts "${prefix}" (both functions)`, () => {
+            expect(isValidCidr(prefix)).toBe(true);
+            expect(isValidCidrPrefix(prefix)).toBe(true);
+        });
+    }
+
+    it('accepts mask-less embedded-IPv4 via isValidCidr', () => {
+        expect(isValidCidr('::ffff:192.168.1.1')).toBe(true);
+    });
+
+    it('rejects mask-less embedded-IPv4 via isValidCidrPrefix (mask mandatory)', () => {
+        expect(isValidCidrPrefix('::ffff:192.168.1.1')).toBe(false);
+    });
+});
+
+describe('isValidCidr / isValidCidrPrefix — still accepted', () => {
+    const prefixes = ['10.0.0.0/8', '0.0.0.0/0', '::/0', '2001:db8::/32'];
+
+    for (const prefix of prefixes) {
+        it(`accepts "${prefix}" (both functions)`, () => {
+            expect(isValidCidr(prefix)).toBe(true);
+            expect(isValidCidrPrefix(prefix)).toBe(true);
+        });
+    }
+
+    it('accepts a bare IPv4 host address via isValidCidr', () => {
+        expect(isValidCidr('192.168.1.1')).toBe(true);
+    });
+
+    it('accepts a bare IPv6 host address via isValidCidr', () => {
+        expect(isValidCidr('2001:db8::1')).toBe(true);
+    });
+
+    it('rejects a bare host address via isValidCidrPrefix (mask mandatory)', () => {
+        expect(isValidCidrPrefix('192.168.1.1')).toBe(false);
+    });
+});
+
+describe('isValidCidr / isValidCidrPrefix — rejected', () => {
+    const invalid = [
+        '',
+        '   ',
+        '1.2.3.4/33',
+        '2001:db8::/129',
+        '1:2',
+        '2001:',
+        '999.0.0.0/8',
+        '64:ff9b::10.0.0/120', // three-octet embedded IPv4 tail
+        'fe80::1%eth0',
+    ];
+
+    for (const s of invalid) {
+        it(`rejects ${JSON.stringify(s)} (both functions)`, () => {
+            expect(isValidCidr(s)).toBe(false);
+            expect(isValidCidrPrefix(s)).toBe(false);
+        });
+    }
+
+    // A leading-zero IPv4 octet is rejected, matching IPv4Address.parse.
+    it('rejects a leading-zero IPv4 octet', () => {
+        expect(isValidCidr('010.0.0.1/24')).toBe(false);
+        expect(isValidCidrPrefix('010.0.0.1/24')).toBe(false);
+    });
+
+    // A zero-padded prefix length is rejected. The control plane reparses the
+    // prefix string with Go's netip.ParsePrefix, which refuses the padding.
+    it('rejects a zero-padded prefix length', () => {
+        expect(isValidCidr('10.0.0.0/024')).toBe(false);
+        expect(isValidCidrPrefix('10.0.0.0/024')).toBe(false);
+        expect(isValidCidr('2001:db8::/0128')).toBe(false);
+        expect(isValidCidrPrefix('2001:db8::/0128')).toBe(false);
+    });
+});
+
+describe('isValidCidr / isValidCidrPrefix — whitespace trimming', () => {
+    // Witness for useFIBDraft.ts's rowsToFIBEntries comment, which asserts
+    // isValidCidrPrefix is looser than cidrToIPRange (which does not trim).
+    it('trims surrounding whitespace before validating', () => {
+        expect(isValidCidrPrefix(' 1.2.3.4/24 ')).toBe(true);
+        expect(isValidCidr(' 1.2.3.4/24 ')).toBe(true);
+    });
+});

--- a/web/src/core/utils/validation.ts
+++ b/web/src/core/utils/validation.ts
@@ -1,20 +1,14 @@
-/** Validate CIDR string (IPv4 or IPv6). Returns true if valid. */
+import { isValidCIDRPrefix, isValidIPAddress } from './netip';
+
+/**
+ * Validate CIDR string (IPv4 or IPv6). Returns true if valid.
+ *
+ * The mask is optional — delegates to netip.ts's strict parsers, accepting
+ * either a bare host address or a `/mask` prefix.
+ */
 export const isValidCidr = (s: string): boolean => {
     const trimmed = s.trim();
-    if (!trimmed) return false;
-    const ipv4 = trimmed.match(/^(\d{1,3}(?:\.\d{1,3}){3})(?:\/(\d{1,2}))?$/);
-    if (ipv4) {
-        const parts = ipv4[1].split('.').map(Number);
-        if (parts.some((n) => n > 255)) return false;
-        if (ipv4[2] !== undefined && (Number(ipv4[2]) < 0 || Number(ipv4[2]) > 32)) return false;
-        return true;
-    }
-    const ipv6 = trimmed.match(/^([0-9a-fA-F:]+)(?:\/(\d{1,3}))?$/);
-    if (ipv6 && trimmed.includes(':')) {
-        if (ipv6[2] !== undefined && (Number(ipv6[2]) < 0 || Number(ipv6[2]) > 128)) return false;
-        return true;
-    }
-    return false;
+    return isValidCIDRPrefix(trimmed) || isValidIPAddress(trimmed);
 };
 
 /**
@@ -23,11 +17,7 @@ export const isValidCidr = (s: string): boolean => {
  * Unlike isValidCidr, the mask is mandatory — bare host addresses are
  * rejected.
  */
-export const isValidCidrPrefix = (s: string): boolean => {
-    const trimmed = s.trim();
-    if (!trimmed.includes('/')) return false;
-    return isValidCidr(trimmed);
-};
+export const isValidCidrPrefix = (s: string): boolean => isValidCIDRPrefix(s.trim());
 
 /** Validate device name string. */
 export const isValidDeviceName = (s: string): boolean => /^[a-zA-Z0-9_:.\-]+$/.test(s.trim());


### PR DESCRIPTION
The shared CIDR validators matched addresses with their own regexes, whose IPv6 branch had no dot in its character class. Every RFC 4291 embedded-IPv4 form the address parsers accept was therefore reported invalid, so an operator could not enter, in the route FIB drawer or the ACL, forward and decap prefix forms, a prefix the CLI and the server both accept.

- Validation now delegates to the strict address parsers instead of keeping a second implementation that had drifted away from them.
- Leading-zero IPv4 octets and malformed or partial IPv6 are rejected as a result, which matches what the server accepts.
- Prefix lengths with a leading zero are rejected as well, so a padded mask no longer passes validation in the browser only to fail when the control plane reparses the prefix string.
- The mask-optional and mask-mandatory validators keep their distinct contracts, now pinned by tests.
- A differential run against the server-side parser over every valid address shape found no input the server accepts and the browser now rejects.
