### PR TITLE
fix(web): correct IPv6 address group expansion and zero-run compression

### DIFF
--- a/web/src/core/utils/netip.test.ts
+++ b/web/src/core/utils/netip.test.ts
@@ -8,6 +8,7 @@ import {
     parseCidrsToIPNets,
     parseIPToBytes,
     IPv4Prefix,
+    IPv6Address,
     CIDRParseError,
 } from './netip';
 
@@ -340,5 +341,129 @@ describe('parseCidrsToIPNets mask strictness', () => {
         expect(parseCidrsToIPNets(['1:2:3:4:5:6:10.0.0.1abc/128', '64:ff9b::10.0.0.0/120']))
             .toEqual(parseCidrsToIPNets(['64:ff9b::10.0.0.0/120']));
         expect(parseCidrsToIPNets(['64:ff9b::10.0.0.0/120'])).toHaveLength(1);
+    });
+});
+
+describe('IPv6Address.parse groups', () => {
+    it('expands a leading :: into 8 groups', () => {
+        const result = IPv6Address.parse('::1');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.groups).toEqual([0, 0, 0, 0, 0, 0, 0, 1]);
+        }
+    });
+
+    it('converts a leading-:: address to the correct BigInt value', () => {
+        const result = IPv6Address.parse('::1');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.toBigInt()).toBe(1n);
+        }
+    });
+
+    it('expands a mid-string :: into 8 groups', () => {
+        const result = IPv6Address.parse('2001:db8::1');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.groups).toEqual([0x2001, 0x0db8, 0, 0, 0, 0, 0, 1]);
+        }
+    });
+
+    it('expands the unspecified address :: into 8 zero groups', () => {
+        const result = IPv6Address.parse('::');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.groups).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+        }
+    });
+
+    it('parses an uncompressed 8-group address without change', () => {
+        const result = IPv6Address.parse('1:2:3:4:5:6:7:8');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.groups).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+        }
+    });
+
+    it('expands an embedded-IPv4 tail after a leading ::', () => {
+        const result = IPv6Address.parse('::ffff:192.168.1.1');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.groups).toEqual([0, 0, 0, 0, 0, 0xffff, 0xc0a8, 0x0101]);
+        }
+    });
+
+    it('expands an embedded-IPv4 tail after a mid-string ::', () => {
+        const result = IPv6Address.parse('64:ff9b::10.0.0.0');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.groups).toEqual([0x0064, 0xff9b, 0, 0, 0, 0, 0x0a00, 0]);
+        }
+    });
+
+    it('rejects a group with trailing non-hex junk', () => {
+        expect(IPv6Address.parse('1abcg::').ok).toBe(false);
+    });
+
+    it('rejects a group with trailing non-hex junk in an uncompressed address', () => {
+        expect(IPv6Address.parse('1:2:3:4:5:6:7:8abcg').ok).toBe(false);
+    });
+
+    it('rejects a group with more than 4 hex digits', () => {
+        expect(IPv6Address.parse('12345::1').ok).toBe(false);
+    });
+
+    it('rejects 9 uncompressed groups', () => {
+        expect(IPv6Address.parse('1:2:3:4:5:6:7:8:9').ok).toBe(false);
+    });
+
+    it('rejects the empty string', () => {
+        expect(IPv6Address.parse('').ok).toBe(false);
+    });
+
+    it('rejects a leading tab, which the URL parser would otherwise strip', () => {
+        expect(IPv6Address.parse('\t::1').ok).toBe(false);
+    });
+
+    it('rejects a leading newline, which the URL parser would otherwise strip', () => {
+        expect(IPv6Address.parse('\n::1').ok).toBe(false);
+    });
+
+    it('rejects a leading carriage return, which the URL parser would otherwise strip', () => {
+        expect(IPv6Address.parse('\r::1').ok).toBe(false);
+    });
+
+    it('rejects a trailing tab, which the URL parser would otherwise strip', () => {
+        expect(IPv6Address.parse('::1\t').ok).toBe(false);
+    });
+
+    it('still accepts the plain form with no surrounding whitespace', () => {
+        expect(IPv6Address.parse('::1').ok).toBe(true);
+    });
+});
+
+describe('IPv6Address.toString round-trip', () => {
+    it('round-trips the unspecified address ::', () => {
+        const result = IPv6Address.parse('::');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.toString()).toBe('::');
+        }
+    });
+
+    it('round-trips a trailing-:: address whose compressed run reaches the last group', () => {
+        const result = IPv6Address.parse('2a02:6b8:2:d::');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.toString()).toBe('2a02:6b8:2:d::');
+        }
+    });
+
+    it('does not compress a single zero group, per RFC 5952 4.2.2', () => {
+        const result = IPv6Address.parse('1:0:2:3:4:5:6:7');
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.toString()).toBe('1:0:2:3:4:5:6:7');
+        }
     });
 });

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -136,6 +136,12 @@ export class IPv6Address {
             return err(IPv6ParseError.EmptyString);
         }
 
+        // The URL parser strips leading/trailing tab, LF and CR before parsing,
+        // so the `new URL` guard below cannot be relied on to reject them.
+        if (ip !== ip.trim()) {
+            return err(IPv6ParseError.InvalidFormat);
+        }
+
         try {
             // Use URL constructor to validate - it throws for invalid IPs
             new URL(`http://[${ip}]`);
@@ -169,15 +175,17 @@ export class IPv6Address {
                 }
             }
 
-            // Parse groups (expand :: to zeros)
-            const expanded = normalized.replace('::', ':0000'.repeat(9 - parts.length)).split(':');
+            // Running the embedded-IPv4 expansion again here on an already-expanded
+            // string is idempotent: the rebuilt tail is hex digits from
+            // Number.prototype.toString(16), which never contains a dot, so the
+            // second pass takes the early return and leaves it untouched.
+            const bytes = parseIPv6ToBytes(normalized);
+            if (bytes === undefined) {
+                return err(IPv6ParseError.InvalidFormat);
+            }
             const groups: number[] = [];
-            for (const group of expanded) {
-                const num = parseInt(group || '0', 16);
-                if (isNaN(num) || num < 0 || num > 0xFFFF) {
-                    return err(IPv6ParseError.InvalidFormat);
-                }
-                groups.push(num);
+            for (let i = 0; i < 8; i++) {
+                groups.push((bytes[2 * i] << 8) | bytes[2 * i + 1]);
             }
 
             return ok(new IPv6Address(groups));
@@ -190,49 +198,11 @@ export class IPv6Address {
      * Convert to string representation (compressed format)
      */
     toString(): string {
-        // Find longest sequence of zeros for compression
-        let bestStart = -1;
-        let bestLength = 0;
-        let currentStart = -1;
-        let currentLength = 0;
-
-        for (let i = 0; i < this.groups.length; i++) {
-            if (this.groups[i] === 0) {
-                if (currentStart === -1) {
-                    currentStart = i;
-                    currentLength = 1;
-                } else {
-                    currentLength++;
-                }
-            } else {
-                if (currentLength > bestLength) {
-                    bestStart = currentStart;
-                    bestLength = currentLength;
-                }
-                currentStart = -1;
-                currentLength = 0;
-            }
+        const bytes: number[] = [];
+        for (const group of this.groups) {
+            bytes.push((group >> 8) & 0xff, group & 0xff);
         }
-
-        // Check the last sequence
-        if (currentLength > bestLength) {
-            bestStart = currentStart;
-            bestLength = currentLength;
-        }
-
-        // Build the string
-        const parts: string[] = [];
-        for (let i = 0; i < this.groups.length; i++) {
-            if (bestStart !== -1 && i >= bestStart && i < bestStart + bestLength) {
-                if (i === bestStart) {
-                    parts.push('');
-                }
-                continue;
-            }
-            parts.push(this.groups[i].toString(16));
-        }
-
-        return parts.join(':');
+        return formatIPv6FromBytes(bytes);
     }
 
     /**
@@ -901,9 +871,6 @@ export const cidrToIPRange = (cidr: string): IPRangeWire | undefined => {
     const prefixLen = getPrefixLength(cidr);
     if (prefixLen === null) return undefined;
 
-    // Parse bytes from the address substring directly rather than round-tripping
-    // through address.toString(), whose IPv6 :: compression drops the trailing
-    // colon when the compressed run reaches the end of the address.
     const addrPart = cidr.slice(0, cidr.lastIndexOf('/'));
     const addrBytes = parseIPToBytes(addrPart);
     if (!addrBytes) return undefined;

--- a/web/src/core/utils/packetParser.test.ts
+++ b/web/src/core/utils/packetParser.test.ts
@@ -10,6 +10,24 @@ const fromHex = (hex: string): Uint8Array => {
     return Uint8Array.from(bytes);
 };
 
+// Builds an Ethernet + bare IPv6 header packet with the given src/dst
+// 16-bit groups, for exercising IPv6 address rendering through parsePacket.
+const buildIPv6Packet = (srcGroups: number[], dstGroups: number[]): Uint8Array => {
+    const bytes: number[] = [
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // dst mac
+        0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, // src mac
+        0x86, 0xdd, // etherType IPv6
+        0x60, 0x00, 0x00, 0x00, // version 6, traffic class 0, flow label 0
+        0x00, 0x00, // payload length
+        0x3b, // next header (59, no next header)
+        0x40, // hop limit
+    ];
+    for (const group of [...srcGroups, ...dstGroups]) {
+        bytes.push((group >> 8) & 0xff, group & 0xff);
+    }
+    return Uint8Array.from(bytes);
+};
+
 describe('parsePacket VLAN parsing', () => {
     it('parses a single VLAN-tagged IPv4 packet and keeps IPv4 offsets correct', () => {
         const packet = fromHex(`
@@ -66,5 +84,74 @@ describe('parsePacket VLAN parsing', () => {
         expect(parsed.ipv4?.srcAddr).toBe('10.0.0.1');
         expect(parsed.ipv4?.dstAddr).toBe('10.0.0.2');
         expect(parsed.payloadOffset).toBe(42);
+    });
+});
+
+describe('parsePacket IPv6 address compression', () => {
+    it('compresses the longest zero run over an earlier shorter one', () => {
+        const packet = buildIPv6Packet(
+            [1, 0, 0, 2, 0, 0, 0, 3],
+            [0, 0, 1, 0, 0, 0, 0, 2],
+        );
+
+        const parsed = parsePacket(packet);
+
+        expect(parsed.ipv6?.srcAddr).toBe('1:0:0:2::3');
+        expect(parsed.ipv6?.dstAddr).toBe('0:0:1::2');
+    });
+
+    it('compresses a zero run that reaches the last group', () => {
+        const packet = buildIPv6Packet(
+            [1, 2, 3, 4, 5, 0, 0, 0],
+            [1, 2, 3, 4, 5, 0, 0, 0],
+        );
+
+        const parsed = parsePacket(packet);
+
+        expect(parsed.ipv6?.srcAddr).toBe('1:2:3:4:5::');
+    });
+
+    it('compresses the all-zero address to ::', () => {
+        const packet = buildIPv6Packet(
+            [0, 0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        );
+
+        const parsed = parsePacket(packet);
+
+        expect(parsed.ipv6?.srcAddr).toBe('::');
+    });
+
+    it('leaves a single zero group uncompressed', () => {
+        const packet = buildIPv6Packet(
+            [1, 0, 2, 3, 4, 5, 6, 7],
+            [1, 0, 2, 3, 4, 5, 6, 7],
+        );
+
+        const parsed = parsePacket(packet);
+
+        expect(parsed.ipv6?.srcAddr).toBe('1:0:2:3:4:5:6:7');
+    });
+
+    it('breaks an equal-length zero-run tie in favor of the first run', () => {
+        const packet = buildIPv6Packet(
+            [1, 0, 0, 2, 0, 0, 3, 4],
+            [1, 0, 0, 2, 0, 0, 3, 4],
+        );
+
+        const parsed = parsePacket(packet);
+
+        expect(parsed.ipv6?.srcAddr).toBe('1::2:0:0:3:4');
+    });
+
+    it('leaves an address with no zero group untouched', () => {
+        const packet = buildIPv6Packet(
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            [1, 2, 3, 4, 5, 6, 7, 8],
+        );
+
+        const parsed = parsePacket(packet);
+
+        expect(parsed.ipv6?.srcAddr).toBe('1:2:3:4:5:6:7:8');
     });
 });

--- a/web/src/core/utils/packetParser.ts
+++ b/web/src/core/utils/packetParser.ts
@@ -1,5 +1,7 @@
 // Packet parser for Ethernet/IPv4/IPv6/TCP/UDP/ICMP
 
+import { formatIPv6FromBytes } from './netip';
+
 export interface EthernetHeader {
     dstMac: string;
     srcMac: string;
@@ -151,16 +153,7 @@ const formatIPv4 = (bytes: Uint8Array, offset: number): string => {
 };
 
 const formatIPv6 = (bytes: Uint8Array, offset: number): string => {
-    const parts: string[] = [];
-    for (let i = 0; i < 8; i++) {
-        const val = (bytes[offset + i * 2] << 8) | bytes[offset + i * 2 + 1];
-        parts.push(val.toString(16));
-    }
-    // Simple compression: find longest run of zeros
-    let result = parts.join(':');
-    // Replace longest run of :0:0:... with ::
-    result = result.replace(/(?:^|:)0(?::0)+(?::|$)/, '::');
-    return result;
+    return formatIPv6FromBytes(Array.from(bytes.subarray(offset, offset + 16)));
 };
 
 const getEtherTypeName = (etherType: number): string => {


### PR DESCRIPTION
The IPv6 address class in the web networking utilities maintained its own copies of the double-colon expansion and the zero-run compression that the same module already provided, and both copies had drifted into defects.

- Expanding a compressed address produced seven groups instead of eight, because the expansion spliced a string and merged the last inserted zero group into the token that followed it. Every compressed address therefore carried a wrong numeric value.
- Rendering an address whose zero run reached the last group dropped a colon, so a prefix base and the unspecified address both serialized to something that no longer parses back.
- The packet parser carried a third copy of the compression, a regular expression that shortened the first zero run rather than the longest one, so a packet dump could render an address in a non-canonical form. Filtering a dump by address text is affected, since the canonical form now matches where it previously did not.

All three now reuse the module's existing array-based expansion and byte-based renderer, which are already exercised by the surrounding tests and conform to RFC 5952. As a consequence a lone zero group is no longer compressed, matching the canonical text representation.

Parsing also gains an explicit rejection of surrounding whitespace. The URL validation the parser relies on silently strips tab, newline and carriage return, so those characters previously reached the backend inside an address that the form had already accepted.

The change is confined to the shared web utilities. No consumer reads the corrected group values or rendered form today, so the only user-visible effect is stricter address validation in the route, firewall-state and neighbour forms, and canonical addresses in packet dumps.
