### PR TITLE
fix(web): keep a mask-less address when saving ACL and forward rules

### DIFF
--- a/web/src/core/utils/netip.test.ts
+++ b/web/src/core/utils/netip.test.ts
@@ -7,6 +7,7 @@ import {
     parseCIDRPrefix,
     parseCidrsToIPNets,
     parseIPToBytes,
+    parseIPv6ToBytes,
     IPv4Prefix,
     IPv6Address,
     CIDRParseError,
@@ -238,6 +239,49 @@ describe('parseIPv6ToBytes hex-group strictness', () => {
     });
 });
 
+describe('parseIPv6ToBytes malformed :: and empty-group rejection', () => {
+    it('rejects more than one :: in the address', () => {
+        expect(parseIPv6ToBytes('1::2::3')).toBeUndefined();
+    });
+
+    it('rejects a stray empty group produced by :: colliding with an adjacent colon', () => {
+        expect(parseIPv6ToBytes('2001:db8:::1')).toBeUndefined();
+    });
+
+    it('rejects a bare ::: with no other groups', () => {
+        expect(parseIPv6ToBytes(':::')).toBeUndefined();
+    });
+
+    it('rejects a leading single colon with no :: compression', () => {
+        expect(parseIPv6ToBytes(':1:2:3:4:5:6:7')).toBeUndefined();
+    });
+
+    it('rejects a trailing :: that compresses zero groups', () => {
+        expect(parseIPv6ToBytes('1:2:3:4:5:6:7:8::')).toBeUndefined();
+    });
+
+    it('accepts a :: compressing exactly one group and expands it in place', () => {
+        expect(parseIPv6ToBytes('1:2:3:4:5:6:7::')).toEqual([
+            0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 7, 0, 0,
+        ]);
+        expect(parseIPv6ToBytes('1:2:3:4:5:6::8')).toEqual([
+            0, 1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0, 0, 0, 8,
+        ]);
+    });
+});
+
+describe('parseCidrsToIPNets rejects malformed :: forms in both spellings', () => {
+    it('drops ::: bare and with /128', () => {
+        expect(parseCidrsToIPNets([':::'])).toEqual([]);
+        expect(parseCidrsToIPNets([':::/128'])).toEqual([]);
+    });
+
+    it('drops 1::2::3 bare and with /128', () => {
+        expect(parseCidrsToIPNets(['1::2::3'])).toEqual([]);
+        expect(parseCidrsToIPNets(['1::2::3/128'])).toEqual([]);
+    });
+});
+
 describe('parseCidrsToIPNets hex-group strictness', () => {
     it('drops an entry with trailing junk in the first group', () => {
         expect(parseCidrsToIPNets(['1abcg::/64'])).toEqual([]);
@@ -354,6 +398,39 @@ describe('parseCidrsToIPNets mask strictness', () => {
     it('keeps a mask of exactly "/0" (positive control, guard is not over-broad)', () => {
         expect(parseCidrsToIPNets(['0.0.0.0/0'])).toHaveLength(1);
         expect(parseCidrsToIPNets(['::/0'])).toHaveLength(1);
+    });
+});
+
+describe('parseCidrsToIPNets mask-less host addresses', () => {
+    it('converts a mask-less IPv4 address identically to the same address written /32', () => {
+        expect(parseCidrsToIPNets(['192.168.1.1'])).toEqual(
+            parseCidrsToIPNets(['192.168.1.1/32']),
+        );
+        expect(parseCidrsToIPNets(['192.168.1.1'])).toHaveLength(1);
+    });
+
+    it('encodes a mask-less IPv6 address as a full-width /128 host prefix', () => {
+        expect(parseCidrsToIPNets(['2001:db8::1'])).toEqual([
+            { addr: 'IAENuAAAAAAAAAAAAAAAAQ==', mask: '/////////////////////w==' },
+        ]);
+    });
+
+    it('converts a mask-less embedded-IPv4 address identically to the same address written /128', () => {
+        expect(parseCidrsToIPNets(['::ffff:192.168.1.1'])).toEqual(
+            parseCidrsToIPNets(['::ffff:192.168.1.1/128']),
+        );
+        expect(parseCidrsToIPNets(['::ffff:192.168.1.1'])).toHaveLength(1);
+    });
+
+    it('still drops an entry with an empty mask rather than treating it as mask-less', () => {
+        expect(parseCidrsToIPNets(['10.0.0.0/'])).toEqual([]);
+    });
+
+    it('keeps a mask-less entry alongside a well-formed masked one, in order', () => {
+        expect(parseCidrsToIPNets(['192.168.1.1', '10.0.0.0/24'])).toEqual([
+            ...parseCidrsToIPNets(['192.168.1.1/32']),
+            ...parseCidrsToIPNets(['10.0.0.0/24']),
+        ]);
     });
 });
 

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -607,11 +607,12 @@ export const parseIPv6ToBytes = (ipStr: string): number[] | undefined => {
     // Handle :: expansion
     let fullAddr = normalized;
     if (normalized.includes('::')) {
-        const parts = normalized.split('::');
-        const left = parts[0] ? parts[0].split(':') : [];
-        const right = parts[1] ? parts[1].split(':') : [];
+        const doubleColonParts = normalized.split('::');
+        if (doubleColonParts.length !== 2) return undefined;
+        const left = doubleColonParts[0] ? doubleColonParts[0].split(':') : [];
+        const right = doubleColonParts[1] ? doubleColonParts[1].split(':') : [];
         const missing = 8 - left.length - right.length;
-        if (missing < 0) return undefined;
+        if (missing < 1) return undefined;
         const middle = Array(missing).fill('0');
         fullAddr = [...left, ...middle, ...right].join(':');
     }
@@ -621,10 +622,7 @@ export const parseIPv6ToBytes = (ipStr: string): number[] | undefined => {
 
     const bytes: number[] = [];
     for (const part of parts) {
-        // The `::` expansion above always substitutes an explicit '0' for a
-        // compressed group, so an empty part here only comes from that path -
-        // keep it as zero rather than routing it through the strict parser.
-        const num = part === '' ? 0 : parseStrictHexGroup(part);
+        const num = parseStrictHexGroup(part);
         if (num === undefined) return undefined;
         bytes.push((num >> 8) & 0xff);
         bytes.push(num & 0xff);
@@ -899,18 +897,24 @@ export const cidrToIPRange = (cidr: string): IPRangeWire | undefined => {
     };
 };
 
-/** Parse CIDR strings to IPNet array with base64-encoded bytes. */
+/**
+ * Parse CIDR strings to IPNet array with base64-encoded bytes.
+ *
+ * A token with no `/mask` is a bare host address and is encoded at full
+ * width for its family (/32 for IPv4, /128 for IPv6). A token with an
+ * empty or malformed mask is dropped.
+ */
 export const parseCidrsToIPNets = (cidrs: string[]): Array<{ addr: string; mask: string }> => {
     const results: Array<{ addr: string; mask: string }> = [];
     for (const cidr of cidrs) {
         const parts = cidr.trim().split('/');
-        if (parts.length !== 2) continue;
+        if (parts.length > 2) continue;
         const [ipPart, maskStr] = parts;
         const addrBytes = parseIPToBytes(ipPart);
         if (!addrBytes) continue;
         const isIPv4 = addrBytes.length === 4;
         const maxPrefix = isIPv4 ? 32 : 128;
-        const prefixLength = parseStrictPrefixLength(maskStr, maxPrefix);
+        const prefixLength = parts.length === 1 ? maxPrefix : parseStrictPrefixLength(maskStr, maxPrefix);
         if (prefixLength === undefined) continue;
         const maskBytes = prefixLengthToMaskBytes(prefixLength, isIPv4 ? 4 : 16);
         results.push({


### PR DESCRIPTION
The CIDR helper behind the ACL and forward source and destination fields discarded any entry written without a mask, although the validator guarding those fields accepts a bare host address on purpose — the mask is mandatory only for the route and decap prefix rows. An operator could enter one, see it accepted, save, and lose it before the rule reached the control plane. For ACL that is not a narrower rule but a different one, since a rule with no source networks is matched differently.

- A bare address is now saved as a host prefix at full width for its family, which is the narrowest mask it could be given and cannot widen a rule.
- An empty or otherwise malformed mask is still dropped, as is a token with more than one separator, and every well-formed entry keeps its exact bytes.
- The address parser behind the same path accepted a few malformed spellings and silently turned them into a valid-looking different address. It now rejects them, so the save path agrees with the validator guarding the field, and so does every other caller of that parser.
- Checked in both directions against the browser's own parser over a large generated corpus and against the control plane's parser over every canonical spelling: no legal address is newly rejected, none newly accepted, and no accepted address changes bytes.
- The two rule importers share the same helper, so a hand-written bare host in an imported document is now kept as well, and an exported document still round-trips unchanged.
- Follows up on the review of #1670, which raised the silent drop.
