### PR TITLE
refactor(commonpb,route): render mac addresses through a display impl

### DIFF
--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -54,20 +54,25 @@ impl TryFrom<&pb::MacAddress> for MacAddr {
     }
 }
 
+impl Display for pb::MacAddress {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match MacAddr::try_from(self) {
+            Ok(mac) => mac.fmt(f),
+            Err(..) => f.write_str("invalid"),
+        }
+    }
+}
+
 impl serde::Serialize for pb::MacAddress {
-    /// Serializes as `aa:bb:cc:dd:ee:ff`, via `MacAddr`'s own `Display`.
+    /// Serializes as the string `Display` renders.
     ///
-    /// A message with the upper 16 bits set is not a valid MAC address --
-    /// `TryFrom<&pb::MacAddress> for MacAddr` rejects it -- and renders as
-    /// the literal `"invalid"` instead.
+    /// A message with the upper 16 bits set renders as the literal
+    /// `"invalid"`, since that is what `Display` already falls back to.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        match MacAddr::try_from(self) {
-            Ok(mac) => serializer.collect_str(&mac),
-            Err(..) => serializer.serialize_str("invalid"),
-        }
+        serializer.collect_str(self)
     }
 }
 
@@ -411,6 +416,23 @@ mod test {
         let json = serde_json::to_string(&malformed).unwrap();
         assert_eq!(r#""invalid""#, json);
         assert!(serde_json::from_str::<pb::IpAddress>(&json).is_err());
+    }
+
+    #[test]
+    fn mac_display() {
+        let mac = pb::MacAddress::from("aa:bb:cc:dd:ee:ff".parse::<MacAddr>().unwrap());
+        assert_eq!("aa:bb:cc:dd:ee:ff", mac.to_string());
+    }
+
+    #[test]
+    fn mac_display_invalid_upper_bits() {
+        let mac = pb::MacAddress { addr: 0x1_0000_0000_0000 };
+        assert_eq!("invalid", mac.to_string());
+    }
+
+    #[test]
+    fn mac_display_default() {
+        assert_eq!("00:00:00:00:00:00", pb::MacAddress::default().to_string());
     }
 
     #[test]

--- a/modules/route/cli/route/Cargo.toml
+++ b/modules/route/cli/route/Cargo.toml
@@ -20,11 +20,11 @@ prost = "0.13"
 tonic = { version = "0.13", features = ["gzip"] }
 tabled = { version = "0.18", features = ["ansi"] }
 serde = { version = "1", features = ["derive"] }
-netip = "0.3"
 serde_yaml = "0.9.34"
 
 [dev-dependencies]
 serde_json = "1"
+netip = "0.3"
 
 [build-dependencies]
 tonic-build = "0.13"

--- a/modules/route/cli/route/src/fib/mod.rs
+++ b/modules/route/cli/route/src/fib/mod.rs
@@ -8,14 +8,12 @@
 //! The server validates every range before ShowFIB's response can carry
 //! it, and the data itself comes from an LPM dump that cannot produce a
 //! malformed or inverted pair, so [`render`] does not reclassify or decode
-//! a range either. This module only holds the two formatting helpers
-//! [`render`] uses: [`format_mac`] for a nexthop's MAC address, and
-//! [`range_endpoints`] for a range's two endpoints.
+//! a range either. This module only holds the formatting helper
+//! [`render`] uses: [`range_endpoints`] for a range's two endpoints.
 
 pub mod render;
 
-use commonpb::pb::{IpAddress, IpRange, MacAddress};
-use netip::MacAddr;
+use commonpb::pb::{IpAddress, IpRange};
 
 /// The literal rendered for a range endpoint that is absent.
 ///
@@ -40,18 +38,6 @@ pub(crate) fn range_endpoints(range: Option<&IpRange>) -> (String, String) {
 fn format_endpoint(addr: Option<&IpAddress>) -> String {
     addr.map(IpAddress::to_string)
         .unwrap_or_else(|| INVALID_ENDPOINT.to_owned())
-}
-
-/// Renders a nexthop's MAC address, or a fallback for a missing/invalid one.
-pub(crate) fn format_mac(mac: Option<MacAddress>) -> String {
-    let mac = match mac {
-        Some(mac) => match MacAddr::try_from(&mac) {
-            Ok(mac) => return mac.to_string(),
-            Err(..) => "invalid",
-        },
-        None => "00:00:00:00:00:00",
-    };
-    mac.to_string()
 }
 
 #[cfg(test)]

--- a/modules/route/cli/route/src/fib/render/mod.rs
+++ b/modules/route/cli/route/src/fib/render/mod.rs
@@ -13,7 +13,7 @@ use tabled::{
 };
 use ync::output;
 
-use super::{format_mac, range_endpoints};
+use super::range_endpoints;
 use crate::routepb::{FibEntry, FibNexthop};
 
 /// One table row: either a full entry (or its first nexthop), or a
@@ -67,8 +67,8 @@ fn nexthop_rows(from: String, to: String, nexthops: &[FibNexthop]) -> Vec<FibRow
             from: if index == 0 { from.clone() } else { String::new() },
             to: if index == 0 { to.clone() } else { String::new() },
             device: sanitize_wire_text(&nexthop.device),
-            dst_mac: format_mac(nexthop.dst_mac),
-            src_mac: format_mac(nexthop.src_mac),
+            dst_mac: nexthop.dst_mac.unwrap_or_default().to_string(),
+            src_mac: nexthop.src_mac.unwrap_or_default().to_string(),
         })
         .collect()
 }


### PR DESCRIPTION
- Give the shared hardware address wire type its own text rendering, matching what the two IP address types already have. It was the only one of the three without one.
- Let the JSON encoder for that type delegate to the new rendering instead of repeating it, so the human and machine surfaces share a single implementation.
- Drop the route CLI's hand-rolled MAC formatter, which existed only to fill that gap, and render the FIB table's address cells straight from the wire value.
- Move the route CLI's networking-primitives dependency to the development section, since deleting that formatter removed its last use outside tests.
- Behaviour is unchanged for every input on both surfaces: an absent address still renders as all zeroes, one with a malformed encoding still renders as invalid, and a well-formed one renders as before.
