### PR TITLE
refactor(fwstate): render state entries from the proto type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,7 +3339,6 @@ dependencies = [
  "clap_complete",
  "humantime",
  "log",
- "netip",
  "prost",
  "prost-types",
  "serde",

--- a/modules/fwstate/cli/Cargo.toml
+++ b/modules/fwstate/cli/Cargo.toml
@@ -23,7 +23,6 @@ tonic = { version = "0.13", features = ["gzip"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 humantime = "2"
-netip = "0.3"
 tabled = { version = "0.18", features = ["ansi"] }
 
 [build-dependencies]

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -1,17 +1,15 @@
-use core::{fmt, net::Ipv6Addr, time::Duration};
-use std::{collections::HashMap, time::UNIX_EPOCH};
+use core::{fmt, net::Ipv6Addr};
+use std::collections::HashMap;
 
 use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
-use commonpb::pb::{GetMetricsRequest, IpAddress};
+use commonpb::pb::{GetMetricsRequest, IpAddress, MacAddress};
 use fwstatepb::{
     DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
     ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
     metrics_service_client::MetricsServiceClient,
 };
-use netip::MacAddr;
-use serde::Serialize;
 use tabled::Tabled;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -61,11 +59,6 @@ pub struct Cmd {
 fn parse_ipv6(s: &str) -> Result<IpAddress, String> {
     let addr = s.parse::<Ipv6Addr>().map_err(|err| err.to_string())?;
     Ok(IpAddress { addr: addr.octets().to_vec() })
-}
-
-/// Parse a MAC address string.
-fn parse_mac(s: &str) -> Result<MacAddr, String> {
-    s.parse::<MacAddr>().map_err(|err| err.to_string())
 }
 
 pub struct FWStateService {
@@ -193,8 +186,10 @@ impl FWStateService {
         }
 
         if let Some(ref dst_ether) = cmd.dst_ether {
-            let mac = parse_mac(dst_ether).map_err(|err| self.service.invalid("update", err))?;
-            sync_config.dst_ether = Some(mac.into());
+            let mac = dst_ether
+                .parse::<MacAddress>()
+                .map_err(|err| self.service.invalid("update", err.to_string()))?;
+            sync_config.dst_ether = Some(mac);
         }
 
         if let Some(ref dst_addr_multicast) = cmd.dst_addr_multicast {
@@ -364,10 +359,9 @@ impl FWStateService {
                         print_entry(entry);
                     }
                     CommonFormat::Json => {
-                        let json_entry = JsonEntry::from_entry(entry);
                         println!(
                             "{}",
-                            serde_json::to_string(&json_entry).expect("fwstate entry JSON serialization must not fail")
+                            serde_json::to_string(entry).expect("fwstate entry JSON serialization must not fail")
                         );
                     }
                 }
@@ -487,26 +481,11 @@ fn format_proto(proto: u32) -> String {
 ///   - 0x08 = ACK
 struct TcpNibble(u8);
 
-const TCP_FLAG_TABLE: [(u8, char, &str); 4] = [
-    (0x08, 'A', "ACK"),
-    (0x02, 'S', "SYN"),
-    (0x04, 'R', "RST"),
-    (0x01, 'F', "FIN"),
-];
-
-impl TcpNibble {
-    fn names(&self) -> Vec<&'static str> {
-        TCP_FLAG_TABLE
-            .iter()
-            .filter(|(mask, _, _)| self.0 & mask != 0)
-            .map(|(_, _, name)| *name)
-            .collect()
-    }
-}
+const TCP_FLAG_TABLE: [(u8, char); 4] = [(0x08, 'A'), (0x02, 'S'), (0x04, 'R'), (0x01, 'F')];
 
 impl fmt::Display for TcpNibble {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (mask, ch, _) in TCP_FLAG_TABLE {
+        for (mask, ch) in TCP_FLAG_TABLE {
             if self.0 & mask != 0 {
                 write!(f, "{ch}")?;
             } else {
@@ -538,71 +517,6 @@ impl FwStateFlags {
 impl fmt::Display for FwStateFlags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}|{}", self.src(), self.dst())
-    }
-}
-
-/// Flat JSON representation of a firewall state entry.
-#[derive(Serialize)]
-struct JsonEntry {
-    idx: u32,
-    expired: bool,
-    src_port: u32,
-    dst_port: u32,
-    src_addr: String,
-    dst_addr: String,
-    proto: String,
-    origin: &'static str,
-    flags: SrcDstFlags,
-    packets: SrcDstPackets,
-    created_at: String,
-    updated_at: String,
-}
-
-#[derive(Serialize)]
-struct SrcDstFlags {
-    src: Vec<&'static str>,
-    dst: Vec<&'static str>,
-}
-
-#[derive(Serialize)]
-struct SrcDstPackets {
-    src: u64,
-    dst: u64,
-}
-
-impl JsonEntry {
-    fn from_entry(entry: &fwstatepb::FwStateEntry) -> Self {
-        let key = entry.key.as_ref();
-        let val = entry.value.as_ref();
-        let flags = FwStateFlags(val.map(|v| v.flags).unwrap_or(0));
-        let external = val.map(|v| v.external).unwrap_or(false);
-
-        Self {
-            idx: entry.idx,
-            expired: entry.expired,
-            src_port: key.map(|k| k.src_port).unwrap_or(0),
-            dst_port: key.map(|k| k.dst_port).unwrap_or(0),
-            src_addr: format_addr(key.and_then(|k| k.src_addr.as_ref())),
-            dst_addr: format_addr(key.and_then(|k| k.dst_addr.as_ref())),
-            proto: format_proto(key.map(|k| k.proto).unwrap_or(0)),
-            origin: if external { "external" } else { "local" },
-            flags: SrcDstFlags {
-                src: flags.src().names(),
-                dst: flags.dst().names(),
-            },
-            packets: SrcDstPackets {
-                src: val.map(|v| v.packets_forward).unwrap_or(0),
-                dst: val.map(|v| v.packets_backward).unwrap_or(0),
-            },
-            created_at: humantime::format_rfc3339(
-                UNIX_EPOCH + Duration::from_nanos(val.map(|v| v.created_at).unwrap_or(0)),
-            )
-            .to_string(),
-            updated_at: humantime::format_rfc3339(
-                UNIX_EPOCH + Duration::from_nanos(val.map(|v| v.updated_at).unwrap_or(0)),
-            )
-            .to_string(),
-        }
     }
 }
 

--- a/tests/functional/main/fwstate_test.go
+++ b/tests/functional/main/fwstate_test.go
@@ -111,22 +111,28 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 		require.NoError(t, err, "list-entries forward json failed")
 		t.Log("JSON output:\n", output)
 
+		const tcpProto = 6
+		// flags is the raw fw_state_flags_u byte: low nibble tracks the
+		// forward direction, high nibble the backward direction, with bits
+		// 0x01 FIN, 0x02 SYN, 0x04 RST, 0x08 ACK. SYN-only forward is 0x02.
+		const flagsSYNForward = 2
+
+		// The CLI serializes the FwStateEntry proto message as-is.
 		type jsonEntry struct {
-			Idx     int    `json:"idx"`
-			SrcPort int    `json:"src_port"`
-			DstPort int    `json:"dst_port"`
-			SrcAddr string `json:"src_addr"`
-			DstAddr string `json:"dst_addr"`
-			Proto   string `json:"proto"`
-			Origin  string `json:"origin"`
-			Flags   struct {
-				Src []string `json:"src"`
-				Dst []string `json:"dst"`
-			} `json:"flags"`
-			Packets struct {
-				Src int `json:"src"`
-				Dst int `json:"dst"`
-			} `json:"packets"`
+			Idx int `json:"idx"`
+			Key struct {
+				Proto   int    `json:"proto"`
+				SrcPort int    `json:"src_port"`
+				DstPort int    `json:"dst_port"`
+				SrcAddr string `json:"src_addr"`
+				DstAddr string `json:"dst_addr"`
+			} `json:"key"`
+			Value struct {
+				External        bool `json:"external"`
+				Flags           int  `json:"flags"`
+				PacketsForward  int  `json:"packets_forward"`
+				PacketsBackward int  `json:"packets_backward"`
+			} `json:"value"`
 		}
 
 		var entries []jsonEntry
@@ -144,16 +150,15 @@ func testFWStateListEntries(t *testing.T, fw *framework.TestFramework) {
 
 		for i, e := range entries {
 			require.Equal(t, i, e.Idx, "entry %d idx", i)
-			require.Equal(t, "TCP", e.Proto, "entry %d proto should be TCP", i)
-			require.Equal(t, 10000+i, e.SrcPort, "entry %d src_port", i)
-			require.Equal(t, 80, e.DstPort, "entry %d dst_port", i)
-			require.Equal(t, fmt.Sprintf("192.0.2.%d", 10+i), e.SrcAddr, "entry %d src_addr", i)
-			require.Equal(t, "192.0.3.1", e.DstAddr, "entry %d dst_addr", i)
-			require.Equal(t, "local", e.Origin, "entry %d origin should be local", i)
-			require.Equal(t, []string{"SYN"}, e.Flags.Src, "entry %d flags.src should be [SYN]", i)
-			require.Empty(t, e.Flags.Dst, "entry %d flags.dst should be empty", i)
-			require.Equal(t, 1, e.Packets.Src, "entry %d packets.src", i)
-			require.Equal(t, 0, e.Packets.Dst, "entry %d packets.dst", i)
+			require.Equal(t, tcpProto, e.Key.Proto, "entry %d proto should be TCP", i)
+			require.Equal(t, 10000+i, e.Key.SrcPort, "entry %d src_port", i)
+			require.Equal(t, 80, e.Key.DstPort, "entry %d dst_port", i)
+			require.Equal(t, fmt.Sprintf("192.0.2.%d", 10+i), e.Key.SrcAddr, "entry %d src_addr", i)
+			require.Equal(t, "192.0.3.1", e.Key.DstAddr, "entry %d dst_addr", i)
+			require.False(t, e.Value.External, "entry %d should not be external", i)
+			require.Equal(t, flagsSYNForward, e.Value.Flags, "entry %d flags should be SYN forward only", i)
+			require.Equal(t, 1, e.Value.PacketsForward, "entry %d packets_forward", i)
+			require.Equal(t, 0, e.Value.PacketsBackward, "entry %d packets_backward", i)
 		}
 	})
 
@@ -698,13 +703,19 @@ func testFWStateExternalSyncFrame(t *testing.T, fw *framework.TestFramework) {
 		require.NoError(t, err, "list-entries forward json failed")
 		t.Log("JSON entries:\n", output)
 
+		const tcpProto = 6
+
 		type jsonEntry struct {
-			SrcPort int    `json:"src_port"`
-			DstPort int    `json:"dst_port"`
-			SrcAddr string `json:"src_addr"`
-			DstAddr string `json:"dst_addr"`
-			Proto   string `json:"proto"`
-			Origin  string `json:"origin"`
+			Key struct {
+				Proto   int    `json:"proto"`
+				SrcPort int    `json:"src_port"`
+				DstPort int    `json:"dst_port"`
+				SrcAddr string `json:"src_addr"`
+				DstAddr string `json:"dst_addr"`
+			} `json:"key"`
+			Value struct {
+				External bool `json:"external"`
+			} `json:"value"`
 		}
 
 		var entries []jsonEntry
@@ -720,12 +731,12 @@ func testFWStateExternalSyncFrame(t *testing.T, fw *framework.TestFramework) {
 
 		require.Len(t, entries, 1, "should have exactly 1 state entry from external sync")
 		e := entries[0]
-		require.Equal(t, "10.0.0.1", e.SrcAddr, "src_addr should match sync frame")
-		require.Equal(t, "10.0.0.2", e.DstAddr, "dst_addr should match sync frame")
-		require.Equal(t, 5000, e.SrcPort, "src_port should match sync frame")
-		require.Equal(t, 80, e.DstPort, "dst_port should match sync frame")
-		require.Equal(t, "TCP", e.Proto, "proto should be TCP")
-		require.Equal(t, "external", e.Origin, "origin should be external")
+		require.Equal(t, "10.0.0.1", e.Key.SrcAddr, "src_addr should match sync frame")
+		require.Equal(t, "10.0.0.2", e.Key.DstAddr, "dst_addr should match sync frame")
+		require.Equal(t, 5000, e.Key.SrcPort, "src_port should match sync frame")
+		require.Equal(t, 80, e.Key.DstPort, "dst_port should match sync frame")
+		require.Equal(t, tcpProto, e.Key.Proto, "proto should be TCP")
+		require.True(t, e.Value.External, "entry should be marked external")
 	})
 
 	// 7. Verify stats show exactly 1 entry.


### PR DESCRIPTION
The machine-readable entry listing built a hand-written structure mirroring the wire message field for field, so its shape had to be maintained alongside the protocol definition. Serializing the wire message itself leaves one source of truth behind the output, the same change the neighbour listing took in #1684.

Addresses, protocol number, connection flags and timestamps now reach the caller exactly as the control plane reports them, rather than pre-decoded into display strings. This is a deliberate shape change for consumers of the machine-readable listing. The human-readable listing is unchanged and still decodes all of them for the operator.

Hardware address parsing moves to the shared address library, retiring the last local parsing adapter in this tool.

The functional test that reads the machine-readable listing follows the new shape, pinning the same facts through the wire field names.