### PR TITLE
refactor(cli): drop the dead serialization derive from the gateway row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3359,7 +3359,6 @@ dependencies = [
  "clap_complete",
  "colored",
  "prost-types",
- "serde",
  "tabled",
  "tokio",
  "tonic",

--- a/cli/modules/gateway/Cargo.toml
+++ b/cli/modules/gateway/Cargo.toml
@@ -19,7 +19,6 @@ ync = { path = "../../core", version = "0.1", package = "yanet-cli" }
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_complete = { version = "4.5", features = ["unstable-dynamic"] }
 prost-types = "0.13"
-serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["rt", "net", "time", "macros", "sync"] }
 tonic = { version = "0.13", features = ["gzip"] }
 colored = "3"

--- a/cli/modules/gateway/src/main.rs
+++ b/cli/modules/gateway/src/main.rs
@@ -105,7 +105,7 @@ impl GatewayService {
 }
 
 /// A displayable row for the gateway services table.
-#[derive(Debug, Tabled, serde::Serialize)]
+#[derive(Debug, Tabled)]
 pub struct ServiceRow {
     #[tabled(rename = "Name")]
     pub name: String,


### PR DESCRIPTION
The gateway service listing renders its machine-readable output from the wire message already, so the table row type carried a serialization derive that nothing ever reached. Leaving it in place made the two output paths read as though they shared a shape, which is how a mirror structure finds its way back onto the machine-readable path.

The serialization dependency goes with it, since that derive was its only use in this tool. It stays available transitively through the shared CLI core, so no other crate is affected.

The row type itself, its conversion and the human table are untouched.