### PR TITLE
refactor(dataplane): reuse a per-worker packet front across loop rounds

### DIFF
--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -345,36 +345,43 @@ worker_loop_round(struct dataplane_worker *worker) {
 	);
 	*worker->dp_worker->iterations += 1;
 
-	struct packet_front packet_front;
-	packet_front_init(&packet_front);
-
-	worker_read(worker, &packet_front);
-
+	// No configuration has been installed yet (startup). Drain the NIC
+	// RX ring into a throwaway stack front so packets that arrived
+	// before the first configuration do not accumulate and get
+	// processed stale once a configuration appears.
 	if (config_gen_ectx == NULL) {
+		struct packet_front packet_front;
+		packet_front_init(&packet_front);
+
+		worker_read(worker, &packet_front);
 		worker_write(worker, &packet_front);
 
 		packet_front_drop_pending_input(&packet_front);
 
 		*(worker->dp_worker->drop_count) += packet_front.drop_count;
 		dataplane_drop_packets(worker->dataplane, &packet_front.drop);
-
 		return;
 	}
 
+	struct packet_front *packet_front = &config_gen_ectx->packet_front;
+
+	worker_read(worker, packet_front);
+
 	worker_pipeline_round(
-		worker->dp_worker, cp_config_gen, config_gen_ectx, &packet_front
+		worker->dp_worker, cp_config_gen, config_gen_ectx, packet_front
 	);
 
-	worker_write(worker, &packet_front);
+	worker_write(worker, packet_front);
 
 	/*
 	 * `output` now contains failed-to-transmit packets which should be
 	 * freed.
 	 */
-	packet_front_drop_output(&packet_front);
+	packet_front_drop_output(packet_front);
 
-	*(worker->dp_worker->drop_count) += packet_front.drop_count;
-	dataplane_drop_packets(worker->dataplane, &packet_front.drop);
+	*(worker->dp_worker->drop_count) += packet_front->drop_count;
+	dataplane_drop_packets(worker->dataplane, &packet_front->drop);
+	packet_front_recycle(packet_front);
 }
 
 static void *

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -1571,6 +1571,7 @@ config_gen_ectx_create(
 		return NULL;
 	}
 	memset(config_gen_ectx, 0, ectx_size);
+	packet_front_init(&config_gen_ectx->packet_front);
 
 	SET_OFFSET_OF(&config_gen_ectx->cp_config_gen, cp_config_gen);
 

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -44,7 +44,7 @@ _Static_assert(
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct config_gen_ectx) == 48,
+	sizeof(struct config_gen_ectx) == 208,
 	"struct config_gen_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 11
+#define YANET_MODULE_ABI_VERSION 12
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/module/packet_front.h
+++ b/lib/dataplane/module/packet_front.h
@@ -63,6 +63,25 @@ packet_front_init(struct packet_front *packet_front) {
 	packet_front->drop_bytes = 0;
 }
 
+// Resets a fully-drained front to a clean reusable state.
+//
+// Only valid on a front whose input, output and pending lists have already
+// been drained to empty by a completed worker round. Resets the spent drop
+// list (its mbufs were already freed by the caller, so only the head needs
+// resetting) and the stale pending/drop accumulator counters, so the front
+// can be handed to the next round without a full packet_front_init.
+static inline void
+packet_front_recycle(struct packet_front *packet_front) {
+	packet_list_init(&packet_front->drop);
+
+	packet_front->drop_count = 0;
+	packet_front->drop_bytes = 0;
+	packet_front->pending_input_count = 0;
+	packet_front->pending_input_bytes = 0;
+	packet_front->pending_output_count = 0;
+	packet_front->pending_output_bytes = 0;
+}
+
 // Move the whole output, drop and pending lists from src into dst, transferring
 // the counters, and leave src empty.
 //

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -110,6 +110,13 @@ struct device_entry_ectx {
 	uint64_t pipeline_count;
 	struct pipeline_ectx **pipelines;
 	uint64_t pipeline_map_size;
+	// Per-entry scratch front the worker round demuxes traffic into.
+	//
+	// The round pops pending input/output for this device's entry point
+	// into this front, runs the entry, then merges the result back and
+	// leaves the front empty, so it is reused in place across rounds
+	// instead of being reinitialized on the stack every iteration.
+	struct packet_front schedule;
 	uint64_t pipeline_map[];
 };
 
@@ -143,6 +150,13 @@ struct config_gen_ectx {
 	// member.
 	uint64_t object_count;
 	struct object_ectx **objects;
+
+	// Per-worker scratch front reused across worker rounds.
+	//
+	// Initialized once when the ectx is created and left clean at the
+	// end of every worker round, so the worker loop reuses it in place
+	// instead of reinitializing a fresh front on each iteration.
+	struct packet_front packet_front;
 
 	uint64_t device_count;
 	struct device_ectx *devices[];

--- a/lib/dataplane/worker/pipeline_round.c
+++ b/lib/dataplane/worker/pipeline_round.c
@@ -28,33 +28,47 @@ worker_pipeline_round(
 	int force_poll = 1;
 
 	while (1) {
-		struct packet_front schedule_input[device_count];
-		for (uint64_t idx = 0; idx < device_count; ++idx) {
-			packet_front_init(schedule_input + idx);
-		}
-
-		struct packet_front schedule_output[device_count];
-		for (uint64_t idx = 0; idx < device_count; ++idx) {
-			packet_front_init(schedule_output + idx);
-		}
-
 		struct packet *packet;
 
 		int empty = 1;
 
+		// Demux pending traffic into each target device's per-entry
+		// schedule front. A packet whose target device is absent from
+		// this generation (out of range or not configured) cannot be
+		// delivered, so it is dropped rather than stranded.
 		while ((packet = packet_list_pop(&packet_front->pending_input)
 		       ) != NULL) {
 			empty = 0;
+			struct device_ectx *device_ectx =
+				config_gen_ectx_get_device(
+					config_gen_ectx, packet->tx_device_id
+				);
+			if (device_ectx == NULL) {
+				packet_front_drop(packet_front, packet);
+				continue;
+			}
 			packet_front_output(
-				schedule_input + packet->tx_device_id, packet
+				&ADDR_OF(&device_ectx->input_pipelines)
+					 ->schedule,
+				packet
 			);
 		}
 
 		while ((packet = packet_list_pop(&packet_front->pending_output)
 		       ) != NULL) {
 			empty = 0;
+			struct device_ectx *device_ectx =
+				config_gen_ectx_get_device(
+					config_gen_ectx, packet->tx_device_id
+				);
+			if (device_ectx == NULL) {
+				packet_front_drop(packet_front, packet);
+				continue;
+			}
 			packet_front_output(
-				schedule_output + packet->tx_device_id, packet
+				&ADDR_OF(&device_ectx->output_pipelines)
+					 ->schedule,
+				packet
 			);
 		}
 
@@ -71,14 +85,17 @@ worker_pipeline_round(
 				continue;
 			}
 
+			struct packet_front *schedule =
+				&ADDR_OF(&device_ectx->input_pipelines)
+					 ->schedule;
+
 			if (!force_poll &&
-			    packet_list_first(&schedule_input[idx].output) ==
-				    NULL) {
+			    packet_list_first(&schedule->output) == NULL) {
 				continue;
 			}
 
 			device_ectx_process_input(
-				dp_worker, device_ectx, schedule_input + idx
+				dp_worker, device_ectx, schedule
 			);
 
 			/*
@@ -87,9 +104,9 @@ worker_pipeline_round(
 			 * The only chance for a packet to be survived is
 			 * being scheduled into pending input/output queues.
 			 */
-			packet_front_drop_output(schedule_input + idx);
+			packet_front_drop_output(schedule);
 
-			packet_front_merge(packet_front, schedule_input + idx);
+			packet_front_merge(packet_front, schedule);
 		}
 
 		for (uint64_t idx = 0; idx < device_count; ++idx) {
@@ -101,17 +118,20 @@ worker_pipeline_round(
 				continue;
 			}
 
+			struct packet_front *schedule =
+				&ADDR_OF(&device_ectx->output_pipelines)
+					 ->schedule;
+
 			if (!force_poll &&
-			    packet_list_first(&schedule_output[idx].output) ==
-				    NULL) {
+			    packet_list_first(&schedule->output) == NULL) {
 				continue;
 			}
 
 			device_ectx_process_output(
-				dp_worker, device_ectx, schedule_output + idx
+				dp_worker, device_ectx, schedule
 			);
 
-			packet_front_merge(packet_front, schedule_output + idx);
+			packet_front_merge(packet_front, schedule);
 		}
 
 		force_poll = 0;


### PR DESCRIPTION
- The per-worker execution context now owns a packet front that is initialized once and reused, so the worker loop no longer builds and initializes a fresh front on every iteration.
- A worker with no installed configuration now skips the round entirely instead of receiving and dropping packets, so it does not read from the device until a configuration is set.