### PR TITLE
refactor(cli): serialize metrics from the wire message

### DIFF
--- a/cli/core/src/metrics.rs
+++ b/cli/core/src/metrics.rs
@@ -1,10 +1,11 @@
 //! Shared metrics rendering for module CLIs.
 //!
-//! Converts a `GetMetricsResponse` into the domain `Metric` type, formats
-//! gauge/histogram values for human display, and renders the `GRPC CALLS` /
-//! `GRPC HANDLING LATENCIES` sections shared by every module's `metrics`
-//! subcommand. Module-specific grouping (per-module counter tables) stays in
-//! each CLI, since the label sets and grouping keys differ per module.
+//! Free functions read a wire `Metric`'s kind and label values without
+//! converting it, so a caller can filter protobuf messages and keep them on
+//! the machine-readable output path. The domain `Metric` type serves human
+//! display, with helpers that format gauge and histogram values and render
+//! the `GRPC CALLS` / `GRPC HANDLING LATENCIES` sections. Per-module counter
+//! grouping stays in each CLI, since label sets and grouping keys differ.
 
 use std::collections::HashMap;
 
@@ -54,6 +55,7 @@ pub struct Metric {
 
 impl Metric {
     pub fn from_proto(m: commonpb::pb::Metric) -> Self {
+        let kind = proto_kind(&m);
         let labels = m
             .labels
             .into_iter()
@@ -64,21 +66,21 @@ impl Metric {
             Some(Value::Counter(c)) => Self {
                 name: m.name,
                 labels,
-                kind: Kind::Counter,
+                kind,
                 value: Some(c as f64),
                 histogram: None,
             },
             Some(Value::Gauge(g)) => Self {
                 name: m.name,
                 labels,
-                kind: Kind::Gauge,
+                kind,
                 value: Some(g),
                 histogram: None,
             },
             Some(Value::Histogram(h)) => Self {
                 name: m.name,
                 labels,
-                kind: Kind::Histogram,
+                kind,
                 value: None,
                 histogram: Some(Histogram {
                     total_count: h.total_count,
@@ -95,7 +97,7 @@ impl Metric {
             None => Self {
                 name: m.name,
                 labels,
-                kind: Kind::Unknown,
+                kind,
                 value: None,
                 histogram: None,
             },
@@ -105,6 +107,21 @@ impl Metric {
     pub fn label_value(&self, key: &str) -> Option<&str> {
         self.labels.iter().find(|l| l.name == key).map(|l| l.value.as_str())
     }
+}
+
+/// Returns the [`Kind`] of a wire metric from its `value` oneof.
+pub fn proto_kind(m: &commonpb::pb::Metric) -> Kind {
+    match &m.value {
+        Some(Value::Counter(_)) => Kind::Counter,
+        Some(Value::Gauge(_)) => Kind::Gauge,
+        Some(Value::Histogram(_)) => Kind::Histogram,
+        None => Kind::Unknown,
+    }
+}
+
+/// Returns the first label value matching `key` on a wire metric.
+pub fn proto_label_value<'a>(m: &'a commonpb::pb::Metric, key: &str) -> Option<&'a str> {
+    m.labels.iter().find(|l| l.name == key).map(|l| l.value.as_str())
 }
 
 /// Computes the p-th percentile bucket label for a histogram whose upper
@@ -321,6 +338,32 @@ mod test {
 
     fn bucket(upper_bound: f64, count: u64) -> Bucket {
         Bucket { upper_bound, count }
+    }
+
+    #[test]
+    fn proto_kind_matches_from_proto_mapping() {
+        let wire = |value| commonpb::pb::Metric {
+            name: "m".to_string(),
+            labels: Vec::new(),
+            value,
+        };
+        let cases = [
+            (wire(Some(Value::Counter(1))), Kind::Counter),
+            (wire(Some(Value::Gauge(1.0))), Kind::Gauge),
+            (
+                wire(Some(Value::Histogram(commonpb::pb::Histogram {
+                    buckets: Vec::new(),
+                    total_count: 0,
+                }))),
+                Kind::Histogram,
+            ),
+            (wire(None), Kind::Unknown),
+        ];
+
+        for (m, expected) in cases {
+            assert!(proto_kind(&m) == expected);
+            assert!(Metric::from_proto(m).kind == expected);
+        }
     }
 
     #[test]

--- a/modules/acl/cli/src/main.rs
+++ b/modules/acl/cli/src/main.rs
@@ -436,10 +436,9 @@ impl ACLService {
             .map_err(self.metrics.status("metrics"))?
             .into_inner();
 
-        let metrics: Vec<Metric> = response
+        let metrics: Vec<commonpb::Metric> = response
             .metrics
             .into_iter()
-            .map(Metric::from_proto)
             .filter(|m| cmd.name.as_ref().is_none_or(|f| m.name.contains(f.as_filter())))
             .collect();
 
@@ -454,6 +453,7 @@ impl ACLService {
                     return;
                 }
 
+                let metrics: Vec<Metric> = metrics.iter().cloned().map(Metric::from_proto).collect();
                 print_metrics_table(&metrics)
             },
         );

--- a/modules/fwstate/cli/src/args.rs
+++ b/modules/fwstate/cli/src/args.rs
@@ -2,7 +2,8 @@ use core::time::Duration;
 
 use clap::Parser;
 use clap_complete::engine::ArgValueCandidates;
-use ync::metrics::{Kind, Metric};
+use commonpb::pb::Metric;
+use ync::metrics::{self, Kind};
 
 /// Parse duration from string (e.g., "60s", "5m", "1h")
 fn parse_duration(s: &str) -> Result<Duration, String> {
@@ -181,10 +182,11 @@ pub enum MetricName {
 impl MetricName {
     /// Returns true when the metric belongs to this category.
     pub fn matches(&self, m: &Metric) -> bool {
+        let kind = metrics::proto_kind(m);
         match self {
-            Self::Counters => m.kind == Kind::Counter && m.name.starts_with("fwstate_"),
-            Self::MapStats => m.kind == Kind::Gauge && m.name.starts_with("fwstate_"),
-            Self::Sync => m.kind == Kind::Counter && m.name.starts_with("fwstate_sync_"),
+            Self::Counters => kind == Kind::Counter && m.name.starts_with("fwstate_"),
+            Self::MapStats => kind == Kind::Gauge && m.name.starts_with("fwstate_"),
+            Self::Sync => kind == Kind::Counter && m.name.starts_with("fwstate_sync_"),
             Self::Grpc => m.name.starts_with("grpc_"),
         }
     }

--- a/modules/fwstate/cli/src/main.rs
+++ b/modules/fwstate/cli/src/main.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use args::{DeleteCmd, DirectionArg, EntriesCmd, LinkCmd, MetricsCmd, ModeCmd, ShowCmd, StatsCmd, UpdateCmd};
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::{CompleteEnv, engine::CompletionCandidate};
-use commonpb::pb::{GetMetricsRequest, IpAddress, MacAddress};
+use commonpb::pb::{GetMetricsRequest, IpAddress, MacAddress, Metric as ProtoMetric};
 use fwstatepb::{
     DeleteConfigRequest, Direction, GetStatsRequest, LinkFwStateRequest, ListConfigsRequest, ListEntriesRequest,
     ShowConfigRequest, UpdateConfigRequest, fw_state_service_client::FwStateServiceClient,
@@ -417,17 +417,18 @@ impl FWStateService {
             }
         }
 
-        let metrics: Vec<Metric> = response
+        let metrics: Vec<ProtoMetric> = response
             .metrics
             .into_iter()
-            .map(Metric::from_proto)
             .filter(|m| {
                 if let Some(ref f) = cmd.name
                     && !f.matches(m)
                 {
                     return false;
                 }
-                label_filters.iter().all(|(k, v)| m.label_value(k) == Some(v))
+                label_filters
+                    .iter()
+                    .all(|(k, v)| metrics::proto_label_value(m, k) == Some(v))
             })
             .collect();
 
@@ -444,6 +445,7 @@ impl FWStateService {
                     return;
                 }
 
+                let metrics: Vec<Metric> = metrics.iter().cloned().map(Metric::from_proto).collect();
                 print_metrics_table(&metrics)
             },
         );


### PR DESCRIPTION
The shared metrics helper restated the wire message field for field and was what the machine-readable output serialized, so its shape had to be maintained alongside the protocol definition. Filtering now works on the wire messages themselves and hands those straight to the output, leaving one source of truth behind that format.

The helper type stays where it belongs, building the human-readable tables, and is now constructed only when that format is actually being rendered. Its public surface is unchanged, so the tools outside this repository that build on it are unaffected.

The machine-readable shape changes for both affected tools. A metric's value now carries its own kind rather than being flattened alongside a separate kind field, and a counter keeps full integer precision instead of passing through a float. The human-readable tables are untouched.