### PR TITLE
feat(cp): spawn per-worker object ectx with tagged counter storage

### DIFF
--- a/lib/controlplane/config/cp_counter.c
+++ b/lib/controlplane/config/cp_counter.c
@@ -507,3 +507,33 @@ cp_config_counter_storage_registry_insert_module(
 		registry, tags, 6, counter_storage, err
 	);
 }
+
+struct counter_storage *
+cp_config_counter_storage_registry_lookup_object(
+	struct cp_config_counter_storage_registry *registry,
+	const char *object_type,
+	const char *object_name
+) {
+	struct counter_tag tags[] = {
+		{.key = "object_type", .value = object_type},
+		{.key = "object_name", .value = object_name}
+	};
+	return get_one(registry, tags, 2);
+}
+
+int
+cp_config_counter_storage_registry_insert_object(
+	struct cp_config_counter_storage_registry *registry,
+	const char *object_type,
+	const char *object_name,
+	struct counter_storage *counter_storage,
+	yanet_error **err
+) {
+	struct counter_tag tags[] = {
+		{.key = "object_type", .value = object_type},
+		{.key = "object_name", .value = object_name}
+	};
+	return cp_config_counter_storage_registry_insert(
+		registry, tags, 2, counter_storage, err
+	);
+}

--- a/lib/controlplane/config/cp_counter.h
+++ b/lib/controlplane/config/cp_counter.h
@@ -149,3 +149,19 @@ cp_config_counter_storage_registry_insert_module(
 	struct counter_storage *counter_storage,
 	yanet_error **err
 );
+
+struct counter_storage *
+cp_config_counter_storage_registry_lookup_object(
+	struct cp_config_counter_storage_registry *registry,
+	const char *object_type,
+	const char *object_name
+);
+
+int
+cp_config_counter_storage_registry_insert_object(
+	struct cp_config_counter_storage_registry *registry,
+	const char *object_type,
+	const char *object_name,
+	struct counter_storage *counter_storage,
+	yanet_error **err
+);

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -1077,6 +1077,106 @@ error:
 	return NULL;
 }
 
+static void
+object_ectx_free(
+	struct cp_config_gen *cp_config_gen, struct object_ectx *object_ectx
+) {
+	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
+
+	struct counter_storage *counter_storage =
+		ADDR_OF(&object_ectx->counter_storage);
+	if (counter_storage != NULL)
+		counter_storage_free(counter_storage);
+
+	memory_bfree(memory_context, object_ectx, sizeof(struct object_ectx));
+}
+
+// Spawn one object's per-worker counter storage and register it under its
+// object_type/object_name tags so it is reachable through the config
+// generation's counter storage registry.
+//
+// The counter_storage field is set before the registry insert so the error
+// path's object_ectx_free reaches and frees the spawned storage if the insert
+// fails, mirroring device_ectx_create.
+static struct object_ectx *
+object_ectx_create(
+	struct cp_config_gen *cp_config_gen,
+	struct cp_object *cp_object,
+	struct config_gen_ectx *config_gen_ectx,
+	struct cp_config_gen *old_config_gen,
+	uint64_t worker_idx,
+	yanet_error **err
+) {
+	struct cp_config *cp_config = ADDR_OF(&cp_config_gen->cp_config);
+	struct memory_context *memory_context = &cp_config->ectx_memory_context;
+
+	struct object_ectx *object_ectx = (struct object_ectx *)memory_balloc(
+		memory_context, sizeof(struct object_ectx)
+	);
+	if (object_ectx == NULL) {
+		yanet_error_add(
+			err,
+			"failed to allocate memory for object execution context"
+		);
+		return NULL;
+	}
+	memset(object_ectx, 0, sizeof(struct object_ectx));
+	SET_OFFSET_OF(&object_ectx->cp_object, cp_object);
+
+	struct counter_storage *old_counter_storage = NULL;
+	struct config_gen_ectx *old_ectx =
+		cp_config_gen_worker_ectx(old_config_gen, worker_idx);
+	if (old_ectx != NULL) {
+		old_counter_storage =
+			cp_config_counter_storage_registry_lookup_object(
+				ADDR_OF(&old_ectx->counter_storage_registry),
+				cp_object->type,
+				cp_object->name
+			);
+	}
+
+	struct counter_storage *counter_storage = counter_storage_spawn(
+		&cp_config->counter_storage_memory_context,
+		old_counter_storage,
+		&cp_object->counter_registry
+	);
+	if (counter_storage == NULL) {
+		yanet_error_add(
+			err,
+			"failed to spawn counter storage for object '%s:%s'",
+			cp_object->type,
+			cp_object->name
+		);
+		goto error;
+	}
+
+	SET_OFFSET_OF(&object_ectx->counter_storage, counter_storage);
+
+	if (cp_config_counter_storage_registry_insert_object(
+		    ADDR_OF(&config_gen_ectx->counter_storage_registry),
+		    cp_object->type,
+		    cp_object->name,
+		    counter_storage,
+		    err
+	    )) {
+		yanet_error_add(
+			err,
+			"failed to insert counter storage for object '%s:%s'",
+			cp_object->type,
+			cp_object->name
+		);
+		goto error;
+	}
+
+	return object_ectx;
+
+error:
+	object_ectx_free(cp_config_gen, object_ectx);
+
+	return NULL;
+}
+
 void
 config_gen_ectx_free(
 	struct cp_config_gen *cp_config_gen,
@@ -1095,6 +1195,24 @@ config_gen_ectx_free(
 		if (device_ectx != NULL) {
 			device_ectx_free(cp_config_gen, device_ectx);
 		}
+	}
+
+	struct object_ectx **objects = ADDR_OF(&config_gen_ectx->objects);
+	if (objects != NULL) {
+		for (uint64_t object_idx = 0;
+		     object_idx < config_gen_ectx->object_count;
+		     ++object_idx) {
+			struct object_ectx *object_ectx =
+				ADDR_OF(objects + object_idx);
+			if (object_ectx != NULL)
+				object_ectx_free(cp_config_gen, object_ectx);
+		}
+		memory_bfree(
+			memory_context,
+			objects,
+			sizeof(struct object_ectx *) *
+				config_gen_ectx->object_count
+		);
 	}
 
 	struct cp_config_counter_storage_registry *registry =
@@ -1496,6 +1614,55 @@ config_gen_ectx_create(
 			"failed to link config generation execution context"
 		);
 		goto error;
+	}
+
+	config_gen_ectx->object_count =
+		cp_object_registry_capacity(&cp_config_gen->object_registry);
+
+	if (config_gen_ectx->object_count > 0) {
+		struct object_ectx **objects =
+			(struct object_ectx **)memory_balloc(
+				memory_context,
+				sizeof(struct object_ectx *) *
+					config_gen_ectx->object_count
+			);
+		if (objects == NULL) {
+			yanet_error_add(
+				err,
+				"failed to allocate memory for object "
+				"execution contexts"
+			);
+			goto error;
+		}
+		memset(objects,
+		       0,
+		       sizeof(struct object_ectx *) *
+			       config_gen_ectx->object_count);
+		SET_OFFSET_OF(&config_gen_ectx->objects, objects);
+
+		for (uint64_t object_idx = 0;
+		     object_idx < config_gen_ectx->object_count;
+		     ++object_idx) {
+			struct cp_object *cp_object = cp_config_gen_get_object(
+				cp_config_gen, object_idx
+			);
+			if (cp_object == NULL) {
+				continue;
+			}
+
+			struct object_ectx *object_ectx = object_ectx_create(
+				cp_config_gen,
+				cp_object,
+				config_gen_ectx,
+				old_config_gen,
+				worker_idx,
+				err
+			);
+			if (object_ectx == NULL) {
+				goto error;
+			}
+			SET_OFFSET_OF(objects + object_idx, object_ectx);
+		}
 	}
 
 	return config_gen_ectx;

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -13,6 +13,18 @@ config_gen_ectx_get_device(
 	return ADDR_OF(config_gen_ectx->devices + index);
 }
 
+// Return the object execution context installed at the given object index, or
+// NULL when the index is out of range or no context was created for that slot.
+static inline struct object_ectx *
+config_gen_ectx_get_object(
+	struct config_gen_ectx *config_gen_ectx, uint64_t index
+) {
+	if (index >= config_gen_ectx->object_count)
+		return NULL;
+	struct object_ectx **objects = ADDR_OF(&config_gen_ectx->objects);
+	return ADDR_OF(objects + index);
+}
+
 // Build one execution context per worker.
 //
 // Returns an array of worker_count offset pointers, each a config_gen_ectx

--- a/lib/controlplane/tests/cp_object_gen_test.c
+++ b/lib/controlplane/tests/cp_object_gen_test.c
@@ -13,6 +13,7 @@
 
 #include "controlplane/agent/agent.h"
 #include "controlplane/config/cp_object.h"
+#include "controlplane/config/econtext.h"
 #include "controlplane/config/zone.h"
 
 #include "counters/counters.h"
@@ -23,6 +24,7 @@
 #include "logging/log.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define CP_OBJECT_GEN_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
@@ -346,6 +348,125 @@ test_cp_object_gen_replace_delete(struct yanet_shm *shm) {
 	return TEST_SUCCESS;
 }
 
+// After install, the object's per-worker execution context owns a spawned
+// counter storage carrying the object's registered counters, and that storage
+// is reachable through the config generation's tag-indexed counter storage
+// registry under the object_type and object_name tags.
+static int
+test_cp_object_gen_ectx_counter_storage(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"cp-object-gen-ectx",
+		CP_OBJECT_GEN_TEST_MEMORY_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	size_t baseline = block_allocator_free_size(&agent->block_allocator);
+
+	struct cp_object *obj = (struct cp_object *)memory_balloc(
+		&agent->memory_context, sizeof(struct cp_object)
+	);
+	TEST_ASSERT_NOT_NULL(obj, "object allocation failed");
+	TEST_ASSERT_SUCCESS(
+		cp_object_init(obj, agent, "test", "with-counters", &err),
+		"cp_object_init failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	TEST_ASSERT(
+		counter_registry_register(
+			&obj->counter_registry, "bytes", 2, &err
+		) != COUNTER_INVALID,
+		"failed to register counter on object"
+	);
+
+	struct cp_object *objects[] = {obj};
+	TEST_ASSERT_SUCCESS(
+		agent_update_objects(agent, 1, objects, &err),
+		"agent_update_objects failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+	struct cp_config_gen *gen = ADDR_OF(&cp_config->cp_config_gen);
+
+	uint64_t idx;
+	TEST_ASSERT_SUCCESS(
+		cp_config_gen_lookup_object_index(
+			gen, "test", "with-counters", &idx
+		),
+		"lookup_object_index(with-counters) failed"
+	);
+
+	struct config_gen_ectx *ectx = cp_config_gen_worker_ectx(gen, 0);
+	TEST_ASSERT_NOT_NULL(ectx, "worker 0 execution context must exist");
+
+	struct object_ectx *object_ectx = config_gen_ectx_get_object(ectx, idx);
+	TEST_ASSERT_NOT_NULL(
+		object_ectx,
+		"object execution context must exist for the installed object"
+	);
+
+	struct counter_storage *storage =
+		ADDR_OF(&object_ectx->counter_storage);
+	TEST_ASSERT_NOT_NULL(
+		storage,
+		"object execution context must own a spawned counter storage"
+	);
+
+	struct counter_registry *storage_registry = ADDR_OF(&storage->registry);
+	TEST_ASSERT_EQUAL(
+		(long)storage_registry->count,
+		1L,
+		"spawned storage must carry the object's registered counter"
+	);
+
+	// The same storage is reachable through the tag-indexed registry, so
+	// the object's counters are queryable by object_type and object_name.
+	struct counter_tag tags[] = {
+		{.key = "object_type", .value = "test"},
+		{.key = "object_name", .value = "with-counters"}
+	};
+	struct cp_counter_storage **found =
+		cp_config_counter_storage_registry_find(
+			ADDR_OF(&ectx->counter_storage_registry), tags, 2, NULL
+		);
+	TEST_ASSERT_NOT_NULL(found, "tag find must not fail");
+	TEST_ASSERT(
+		found[0] != NULL && found[1] == NULL,
+		"tag find must match exactly the one object storage"
+	);
+	TEST_ASSERT(
+		ADDR_OF(&found[0]->storage) == storage,
+		"tag find must return the object execution context's storage"
+	);
+	free(found);
+
+	TEST_ASSERT_SUCCESS(
+		agent_delete_object(agent, "test", "with-counters", &err),
+		"delete_object(with-counters) failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	cp_object_fini(obj);
+	memory_bfree(&agent->memory_context, obj, sizeof(*obj));
+
+	size_t after = block_allocator_free_size(&agent->block_allocator);
+	TEST_ASSERT_EQUAL(
+		(long)after,
+		(long)baseline,
+		"arena did not return to baseline: baseline=%zu after=%zu",
+		baseline,
+		after
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
 int
 main(void) {
 	log_enable_name("debug");
@@ -384,6 +505,9 @@ main(void) {
 	int res = test_cp_object_gen_update_and_lookup(shm);
 	if (res == TEST_SUCCESS) {
 		res = test_cp_object_gen_replace_delete(shm);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_cp_object_gen_ectx_counter_storage(shm);
 	}
 
 	dataplane_ut_free(ut);

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -17,6 +17,7 @@ struct cp_chain;
 struct cp_function;
 struct cp_pipeline;
 struct cp_device;
+struct cp_object;
 
 struct cp_config_gen;
 struct cp_config_counter_storage_registry;
@@ -119,11 +120,29 @@ struct device_ectx {
 	struct device_entry_ectx *output_pipelines;
 };
 
+// Per-worker execution context for a cp_object.
+//
+// Owns the counter_storage spawned from the object's counter_registry for this
+// worker. Counters are read by name through the storage, and the storage is
+// reachable through the config generation's tag-indexed counter storage
+// registry under the object_type and object_name tags.
+struct object_ectx {
+	struct cp_object *cp_object;
+	struct counter_storage *counter_storage;
+};
+
 struct config_gen_ectx {
 	struct cp_config_gen *cp_config_gen;
 	struct phy_device_map *phy_device_maps;
 
 	struct cp_config_counter_storage_registry *counter_storage_registry;
+
+	// Offset pointer to a separately allocated array of object_ectx offset
+	// pointers, one per object index, parallel to devices below. Lives in
+	// its own allocation because devices[] is the trailing flexible array
+	// member.
+	uint64_t object_count;
+	struct object_ectx **objects;
 
 	uint64_t device_count;
 	struct device_ectx *devices[];


### PR DESCRIPTION
- Each cp_object gets a per-worker object execution context nested in the config generation execution context, owning a counter storage spawned from the object's counter registry.
- The storage is registered under the object's type and name tags, so object counters are reachable through the same tag-indexed counter storage registry used by devices, pipelines, and modules.
- Mirrors the existing device execution context, including the leak-free insert-failure error path.
- Adds a regression test covering the spawned storage, its registered counter, and tag-based lookup.

Stacked on #1595; rebase to main after that merges.
