### PR TITLE
fix(commonpb): tag a metric value by its protocol field name

### DIFF
--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -38,8 +38,14 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         // Covers `Metric`'s `value` oneof, generated as its own enum --
         // `Metric` cannot derive `Serialize`/`Deserialize` unless that enum
         // does too. No message here excludes an enum, so this stays a
-        // blanket path unlike `SERDE_MESSAGES` above.
-        .enum_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]");
+        // blanket path unlike `SERDE_MESSAGES` above. The rename is needed
+        // because prost upper-camel-cases the oneof member names, and
+        // without it the default tag would emit a Rust identifier rather
+        // than the proto field name.
+        .enum_attribute(
+            ".",
+            "#[derive(serde::Serialize, serde::Deserialize)]#[serde(rename_all = \"snake_case\")]",
+        );
     for message in SERDE_MESSAGES {
         config = config.message_attribute(message, "#[derive(serde::Serialize, serde::Deserialize)]");
     }

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -509,6 +509,23 @@ mod test {
         assert_eq!("192.168.1.1/32", cidrs[0]);
     }
 
+    /// The `value` oneof's wire name (`counter`), not the Rust variant
+    /// identifier (`Counter`) prost generates for it, is what must appear
+    /// in the tag.
+    #[test]
+    fn serde_metric_value_oneof_uses_snake_case_tag() {
+        let metric = pb::Metric {
+            name: "fwstate_sync_packets".to_string(),
+            labels: vec![],
+            value: Some(pb::metric::Value::Counter(42)),
+        };
+        let json = serde_json::to_string(&metric).unwrap();
+        assert_eq!(
+            r#"{"name":"fwstate_sync_packets","labels":[],"value":{"counter":42}}"#,
+            json
+        );
+    }
+
     #[test]
     fn iprange_cidrs_invalid_family() {
         let start = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));


### PR DESCRIPTION
A metric's value is a choice between a counter, a gauge and a histogram. The machine-readable output tagged that choice with the generated Rust identifier rather than the name the protocol definition gives it, so the key arrived capitalised. Renaming through the serializer restores the protocol spelling.

This is a regression from the change that moved metrics output onto the wire message: the key was lowercase before it, so this restores a contract rather than inventing one.

The rename is on the whole family rather than at one call site, so every tool emitting metrics picks it up. It is also symmetric, so reading the format back stays consistent. Spelling was chosen so that a member whose name is several words keeps the protocol spelling exactly, which the simpler lowercasing would have run together.

A test pins the encoding, since it is the only mechanical guard against the attribute being dropped later and the identifier silently returning.