### PR TITLE
fix(controlplane): correct stale keys in the default config

### DIFF
--- a/controlplane/etc/yanet/controlplane-default.yaml
+++ b/controlplane/etc/yanet/controlplane-default.yaml
@@ -6,7 +6,7 @@ logging:
   #
   # Possible values: "debug", "info", "warning", "error".
   level: debug
-# MemoryPathPrefix is the path to the shared-memory file that is used to
+# MemoryPath is the path to the shared-memory file that is used to
 # communicate with dataplane.
 memory_path: &memory_path /dev/hugepages/yanet
 gateway:
@@ -48,14 +48,13 @@ modules:
     # Memory requirements for a single FIB-push transaction.
     memory_requirements: 16MB
     endpoint: "[::1]:0"
-    gateway_endpoint: *gateway_endpoint
   decap:
-    memory_path_prefix: /dev/hugepages/yanet
+    memory_path: *memory_path
     memory_requirements: 16MB
     endpoint: "[::1]:0"
     gateway_endpoint: *gateway_endpoint
   acl:
-    memory_path_prefix: /dev/hugepages/yanet
+    memory_path: *memory_path
     memory_requirements: 8GB
     endpoint: "[::1]:0"
     gateway_endpoint: *gateway_endpoint


### PR DESCRIPTION
The packaged control-plane template is installed as the operator-facing example, but it carried entries that no longer match the configuration they decode into. The loader accepts unknown keys silently, so those entries were discarded and the affected settings kept their built-in defaults instead.

Nothing was visibly broken on a stock install, because each discarded value happened to equal the default it fell back to. The defect surfaces the moment an operator edits the template: relocating the shared-memory file produced no effect and no error, with the control plane attached at the new path while two modules kept writing to the old one.

The module entries now name the keys the configuration actually declares, reusing the anchor already defined at the top of the file so the path is stated once rather than repeated. The entry naming a setting the route module does not have is removed, since that module is one of the two in the bundle that legitimately has no such setting. A comment still referring to a field under its former name is corrected alongside, as the last residue of the same rename.

Every remaining key in the file was audited against the structures it decodes into, including the commented-out block, so no silently discarded key is left behind. Values on a stock install are unchanged.
