### PR TITLE
style(c): wrap every control-statement body in braces

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,6 +13,9 @@ BinPackParameters: false
 AlwaysBreakAfterReturnType: All
 ContinuationIndentWidth: 8
 
+# Always add braces to if/else/for/while bodies, even single-line ones.
+InsertBraces: true
+
 # Special rules for proto files
 ---
 Language: Proto

--- a/.claude/conventions/c.md
+++ b/.claude/conventions/c.md
@@ -2,7 +2,7 @@
 
 Loaded on demand by the agent writing or reviewing C; this is the single source for these rules.
 
-- Always use braces for `if`/`else`/`for`/`while`, even single-line bodies.
+- Always use braces for `if`/`else`/`for`/`while`, even single-line bodies. Enforce this rule with `clang-format` (`InsertBraces: true`).
 - Format with `clang-format`.
 - **Functions with more than six parameters are a code smell.** Split them or use a designated-initializer config struct; omnibus initialisers are untestable.
 - **Multi-segment mbufs**: `rte_pktmbuf_data_len()` is head-only. Whole-packet work walks `mbuf->next`/uses `rte_pktmbuf_pkt_len()`, or rejects chained packets.

--- a/common/crc32.h
+++ b/common/crc32.h
@@ -84,8 +84,9 @@ crc32(const void *data, uint64_t size, uint32_t hash) {
 		data += 2;
 	}
 
-	if (size & 0x1)
+	if (size & 0x1) {
 		hash = crc32_u8(*(const uint8_t *)data, hash);
+	}
 
 	return hash;
 }

--- a/common/exp_array.h
+++ b/common/exp_array.h
@@ -21,8 +21,9 @@ mem_array_expand_exp(
 		void *new_array = memory_brealloc(
 			memory_context, *array, old_size, new_size
 		);
-		if (!new_array)
+		if (!new_array) {
 			return -1;
+		}
 		*array = new_array;
 	}
 
@@ -37,8 +38,9 @@ mem_array_free_exp(
 	size_t item_size,
 	uint64_t count
 ) {
-	if (!count)
+	if (!count) {
 		return;
+	}
 
 	uint64_t capacity = 1 << uint64_log_up(count);
 	memory_bfree(memory_context, array, capacity * item_size);

--- a/common/hash_index.h
+++ b/common/hash_index.h
@@ -65,8 +65,9 @@ hash_index_init(
 static inline void
 hash_index_fini(struct hash_index *hash_index) {
 	uint32_t *entries = ADDR_OF(&hash_index->entries);
-	if (entries == NULL)
+	if (entries == NULL) {
 		return;
+	}
 
 	memory_bfree(
 		ADDR_OF(&hash_index->memory_context),
@@ -86,16 +87,18 @@ hash_index_lookup(
 	hash_index_eq_func eq_func,
 	const void *eq_func_data
 ) {
-	if (!hash_index->capacity)
+	if (!hash_index->capacity) {
 		return HASH_INDEX_INVALID;
+	}
 
 	uint32_t bucket =
 		hash % (hash_index->capacity * HASH_INDEX_SPARSE_FACTOR);
 	const uint32_t *entries = ADDR_OF(&hash_index->entries);
 
 	while (entries[bucket] != HASH_INDEX_INVALID) {
-		if (eq_func(entries[bucket], eq_func_data) == 0)
+		if (eq_func(entries[bucket], eq_func_data) == 0) {
 			return entries[bucket];
+		}
 		bucket = (bucket + 1) %
 			 (hash_index->capacity * HASH_INDEX_SPARSE_FACTOR);
 	}
@@ -110,16 +113,18 @@ static inline int
 hash_index_insert(
 	struct hash_index *hash_index, uint32_t hash, uint32_t value
 ) {
-	if (hash_index->count >= hash_index->capacity)
+	if (hash_index->count >= hash_index->capacity) {
 		return -1;
+	}
 
 	uint32_t bucket =
 		hash % (hash_index->capacity * HASH_INDEX_SPARSE_FACTOR);
 	uint32_t *entries = ADDR_OF(&hash_index->entries);
 
-	while (entries[bucket] != HASH_INDEX_INVALID)
+	while (entries[bucket] != HASH_INDEX_INVALID) {
 		bucket = (bucket + 1) %
 			 (hash_index->capacity * HASH_INDEX_SPARSE_FACTOR);
+	}
 
 	entries[bucket] = value;
 	hash_index->count += 1;

--- a/common/key.h
+++ b/common/key.h
@@ -7,16 +7,18 @@
 static inline void
 filter_key_inc(uint8_t key_size, uint8_t *key) {
 	for (int16_t idx = key_size - 1; idx >= 0; --idx) {
-		if (key[idx]++ != 0xff)
+		if (key[idx]++ != 0xff) {
 			break;
+		}
 	}
 }
 
 static inline void
 filter_key_dec(uint8_t key_size, uint8_t *key) {
 	for (int16_t idx = key_size - 1; idx >= 0; --idx) {
-		if (key[idx]-- != 0x00)
+		if (key[idx]-- != 0x00) {
 			break;
+		}
 	}
 }
 
@@ -25,19 +27,23 @@ filter_key_apply_prefix(
 	uint8_t key_size, const uint8_t *from, uint8_t *to, uint8_t prefix
 ) {
 	memcpy(to, from, key_size);
-	if (prefix % 8)
+	if (prefix % 8) {
 		to[prefix / 8] |= ((uint16_t)1 << (8 - prefix % 8)) - 1;
-	for (uint8_t idx = (prefix + 7) / 8; idx < key_size; ++idx)
+	}
+	for (uint8_t idx = (prefix + 7) / 8; idx < key_size; ++idx) {
 		to[idx] |= 0xff;
+	}
 }
 
 static inline int
 filter_key_cmp(uint8_t key_size, const uint8_t *l, const uint8_t *r) {
 	for (size_t i = 0; i < key_size; ++i) {
-		if (l[i] < r[i])
+		if (l[i] < r[i]) {
 			return -1;
-		if (l[i] > r[i])
+		}
+		if (l[i] > r[i]) {
 			return 1;
+		}
 	}
 	return 0;
 }

--- a/common/lpm.h
+++ b/common/lpm.h
@@ -163,10 +163,12 @@ lpm_check_range_lo(
 	uint8_t check[key_size];
 	memcpy(check, key, hop + 1);
 
-	if (hop + 1 < key_size)
+	if (hop + 1 < key_size) {
 		memset(check + hop + 1, 0x00, key_size - hop - 1);
-	if (filter_key_cmp(key_size, check, from) < 0)
+	}
+	if (filter_key_cmp(key_size, check, from) < 0) {
 		return -1;
+	}
 
 	return 0;
 }
@@ -178,10 +180,12 @@ lpm_check_range_hi(
 	uint8_t check[key_size];
 	memcpy(check, key, key_size);
 
-	if (hop + 1 < key_size)
+	if (hop + 1 < key_size) {
 		memset(check + hop + 1, 0xff, key_size - hop - 1);
-	if (filter_key_cmp(key_size, check, to) > 0)
+	}
+	if (filter_key_cmp(key_size, check, to) > 0) {
 		return -1;
+	}
 
 	return 0;
 }
@@ -223,8 +227,9 @@ lpm_insert(
 			if (hop < key_size - 1 &&
 			    (lpm_check_range_lo(key_size, key, from, hop) ||
 			     lpm_check_range_hi(key_size, key, to, hop))) {
-				if (lpm_new_page(lpm, stored_value))
+				if (lpm_new_page(lpm, stored_value)) {
 					return -1;
+				}
 				++hop;
 				if (hop > max_hop) {
 					key[hop] = from[hop];
@@ -252,14 +257,17 @@ lpm_insert(
 		do {
 			key[hop]++;
 			uint8_t upper_bound = 0xff;
-			if (lpm_check_range_hi(key_size, key, to, hop))
+			if (lpm_check_range_hi(key_size, key, to, hop)) {
 				upper_bound = to[hop];
+			}
 			if (key[hop] == (uint8_t)(upper_bound + 1)) {
-				if (hop == 0)
+				if (hop == 0) {
 					return 0;
+				}
 				--hop;
-			} else
+			} else {
 				break;
+			}
 		} while (1);
 	}
 
@@ -273,8 +281,9 @@ lpm_lookup(const struct lpm *lpm, uint8_t key_size, const uint8_t *key) {
 
 	for (uint8_t hop = 0; hop < key_size; ++hop) {
 		value = page->values + key[hop];
-		if (value->value & LPM_VALUE_FLAG)
+		if (value->value & LPM_VALUE_FLAG) {
 			break;
+		}
 		// An intermediate node (flag clear) always has a child page, so
 		// the relative pointer is never NULL here — skip the NULL test.
 		page = ADDR_OF_NONNULL(&value->page);
@@ -496,8 +505,9 @@ lpm_walk(
 			memcpy(prev_to, key, key_size);
 			memset(prev_to + hop + 1, 0xff, key_size - hop - 1);
 		} else {
-			if (key[hop] == to[hop] && hop == hi_limit)
+			if (key[hop] == to[hop] && hop == hi_limit) {
 				++hi_limit;
+			}
 
 			++hop;
 			if (hop > max_hop) {
@@ -513,15 +523,17 @@ lpm_walk(
 		do {
 			key[hop]++;
 			uint8_t upper_bound = 0xff;
-			if (hop == hi_limit)
+			if (hop == hi_limit) {
 				upper_bound = to[hop];
+			}
 			if (key[hop] == (uint8_t)(upper_bound + 1)) {
 				if (hop == hi_limit) {
 					goto out;
 				}
 				--hop;
-			} else
+			} else {
 				break;
+			}
 		} while (1);
 	}
 
@@ -583,8 +595,9 @@ lpm_collect_values(
 				}
 			}
 		} else {
-			if (key[hop] == to[hop] && hop == hi_limit)
+			if (key[hop] == to[hop] && hop == hi_limit) {
 				++hi_limit;
+			}
 
 			++hop;
 			if (hop > max_hop) {
@@ -601,15 +614,17 @@ lpm_collect_values(
 			key[hop]++;
 
 			uint8_t upper_bound = 0xff;
-			if (hop == hi_limit)
+			if (hop == hi_limit) {
 				upper_bound = to[hop];
+			}
 			if (key[hop] == (uint8_t)(upper_bound + 1)) {
 				if (hop == hi_limit) {
 					goto out;
 				}
 				--hop;
-			} else
+			} else {
 				break;
+			}
 
 		} while (1);
 	}
@@ -650,11 +665,13 @@ lpm_remap(struct lpm *lpm, uint8_t key_size, struct value_table *table) {
 		do {
 			key[hop]++;
 			if (key[hop] == 0) {
-				if (hop == 0)
+				if (hop == 0) {
 					goto out;
+				}
 				--hop;
-			} else
+			} else {
 				break;
+			}
 		} while (1);
 	}
 
@@ -683,18 +700,20 @@ lpm_compact(struct lpm *lpm, uint8_t key_size) {
 		do {
 			key[hop]++;
 			if (key[hop] == 0) {
-				if (hop == 0)
+				if (hop == 0) {
 					goto out;
+				}
 
 				uint64_t first_value =
 					pages[hop]->values[0].value;
 				bool is_monolite = first_value & LPM_VALUE_FLAG;
 
 				for (uint8_t idx = 255; is_monolite && idx > 0;
-				     --idx)
+				     --idx) {
 					is_monolite &=
 						first_value ==
 						pages[hop]->values[idx].value;
+				}
 
 				--hop;
 				if (is_monolite) {

--- a/common/lpm_wide.h
+++ b/common/lpm_wide.h
@@ -182,10 +182,12 @@ lpm_wide_key_to_be(uint8_t word_size, const uint16_t *words, uint8_t *key) {
 static inline int
 lpm_wide_key_cmp(uint8_t word_size, const uint16_t *l, const uint16_t *r) {
 	for (size_t i = 0; i < word_size; ++i) {
-		if (l[i] < r[i])
+		if (l[i] < r[i]) {
 			return -1;
-		if (l[i] > r[i])
+		}
+		if (l[i] > r[i]) {
 			return 1;
+		}
 	}
 	return 0;
 }
@@ -200,12 +202,14 @@ lpm_wide_check_range_lo(
 	uint16_t check[word_size];
 	memcpy(check, key, (hop + 1) * sizeof(uint16_t));
 
-	if (hop + 1 < word_size)
+	if (hop + 1 < word_size) {
 		memset(check + hop + 1,
 		       0x00,
 		       (word_size - hop - 1) * sizeof(uint16_t));
-	if (lpm_wide_key_cmp(word_size, check, from) < 0)
+	}
+	if (lpm_wide_key_cmp(word_size, check, from) < 0) {
 		return -1;
+	}
 
 	return 0;
 }
@@ -223,8 +227,9 @@ lpm_wide_check_range_hi(
 			check[word_idx] = 0xffff;
 		}
 	}
-	if (lpm_wide_key_cmp(word_size, check, to) > 0)
+	if (lpm_wide_key_cmp(word_size, check, to) > 0) {
 		return -1;
+	}
 
 	return 0;
 }
@@ -237,8 +242,9 @@ lpm_wide_insert(
 	const uint8_t *to,
 	uint32_t value
 ) {
-	if (lpm_wide_check_key_size(key_size))
+	if (lpm_wide_check_key_size(key_size)) {
 		return -1;
+	}
 
 	uint8_t word_size = key_size / 2;
 
@@ -267,8 +273,9 @@ lpm_wide_insert(
 			     lpm_wide_check_range_hi(
 				     word_size, key, to_words, hop
 			     ))) {
-				if (lpm_wide_new_page(lpm, stored_value))
+				if (lpm_wide_new_page(lpm, stored_value)) {
 					return -1;
+				}
 				++hop;
 				if (hop > max_hop) {
 					key[hop] = from_words[hop];
@@ -305,11 +312,13 @@ lpm_wide_insert(
 				}
 			}
 			if (next > upper_bound) {
-				if (hop == 0)
+				if (hop == 0) {
 					return 0;
+				}
 				--hop;
-			} else
+			} else {
 				break;
+			}
 		} while (1);
 	}
 
@@ -320,8 +329,9 @@ static inline uint32_t
 lpm_wide_lookup(
 	const struct lpm_wide *lpm, uint8_t key_size, const uint8_t *key
 ) {
-	if (lpm_wide_check_key_size(key_size))
+	if (lpm_wide_check_key_size(key_size)) {
 		return LPM_WIDE_VALUE_INVALID;
+	}
 
 	uint8_t word_size = key_size / 2;
 	uint16_t key_words[word_size];
@@ -332,8 +342,9 @@ lpm_wide_lookup(
 
 	for (uint8_t hop = 0; hop < word_size; ++hop) {
 		value = page->values + key_words[hop];
-		if (value->value & LPM_WIDE_VALUE_FLAG)
+		if (value->value & LPM_WIDE_VALUE_FLAG) {
 			break;
+		}
 		page = ADDR_OF(&value->page);
 	}
 
@@ -362,8 +373,9 @@ lpm_wide_walk(
 	lpm_wide_walk_func walk_func,
 	void *walk_func_data
 ) {
-	if (lpm_wide_check_key_size(key_size))
+	if (lpm_wide_check_key_size(key_size)) {
 		return -1;
+	}
 
 	uint8_t word_size = key_size / 2;
 
@@ -433,8 +445,9 @@ lpm_wide_walk(
 				prev_to[word_idx] = 0xffff;
 			}
 		} else {
-			if (key[hop] == to_words[hop] && hop == hi_limit)
+			if (key[hop] == to_words[hop] && hop == hi_limit) {
 				++hi_limit;
+			}
 
 			++hop;
 			if (hop > max_hop) {
@@ -450,8 +463,9 @@ lpm_wide_walk(
 		do {
 			uint32_t next = (uint32_t)key[hop] + 1;
 			uint16_t upper_bound = 0xffff;
-			if (hop == hi_limit)
+			if (hop == hi_limit) {
 				upper_bound = to_words[hop];
+			}
 			if (next > upper_bound) {
 				if (hop == hi_limit) {
 					goto out;
@@ -498,8 +512,9 @@ lpm_wide_collect_values(
 	lpm_wide_collect_values_func collect_func,
 	void *collect_func_data
 ) {
-	if (lpm_wide_check_key_size(key_size))
+	if (lpm_wide_check_key_size(key_size)) {
 		return -1;
+	}
 
 	uint8_t word_size = key_size / 2;
 
@@ -533,8 +548,9 @@ lpm_wide_collect_values(
 				}
 			}
 		} else {
-			if (key[hop] == to_words[hop] && hop == hi_limit)
+			if (key[hop] == to_words[hop] && hop == hi_limit) {
 				++hi_limit;
+			}
 
 			++hop;
 			if (hop > max_hop) {
@@ -551,8 +567,9 @@ lpm_wide_collect_values(
 			uint32_t next = (uint32_t)key[hop] + 1;
 
 			uint16_t upper_bound = 0xffff;
-			if (hop == hi_limit)
+			if (hop == hi_limit) {
 				upper_bound = to_words[hop];
+			}
 			if (next > upper_bound) {
 				if (hop == hi_limit) {
 					goto out;
@@ -575,8 +592,9 @@ static inline void
 lpm_wide_remap(
 	struct lpm_wide *lpm, uint8_t key_size, struct value_table *table
 ) {
-	if (lpm_wide_check_key_size(key_size))
+	if (lpm_wide_check_key_size(key_size)) {
 		return;
+	}
 
 	uint8_t word_size = key_size / 2;
 	uint16_t key[word_size];
@@ -602,8 +620,9 @@ lpm_wide_remap(
 		do {
 			uint32_t next = (uint32_t)key[hop] + 1;
 			if (next > 0xffff) {
-				if (hop == 0)
+				if (hop == 0) {
 					goto out;
+				}
 				--hop;
 			} else {
 				key[hop] = next;
@@ -618,8 +637,9 @@ out:
 
 static inline void
 lpm_wide_compact(struct lpm_wide *lpm, uint8_t key_size) {
-	if (lpm_wide_check_key_size(key_size))
+	if (lpm_wide_check_key_size(key_size)) {
 		return;
+	}
 
 	uint8_t word_size = key_size / 2;
 	uint16_t key[word_size];
@@ -641,8 +661,9 @@ lpm_wide_compact(struct lpm_wide *lpm, uint8_t key_size) {
 		do {
 			uint32_t next = (uint32_t)key[hop] + 1;
 			if (next > 0xffff) {
-				if (hop == 0)
+				if (hop == 0) {
 					goto out;
+				}
 
 				uint64_t first_value =
 					pages[hop]->values[0].value;

--- a/common/memory.h
+++ b/common/memory.h
@@ -146,8 +146,9 @@ memory_balloc(struct memory_context *context, size_t size) {
 	void *result = block_allocator_balloc(
 		ADDR_OF(&context->block_allocator), size
 	);
-	if (result == NULL)
+	if (result == NULL) {
 		return NULL;
+	}
 	// A single memory_context (e.g. an agent's own context) can now be
 	// ballocked from by several controlplane threads at once.
 	__atomic_fetch_add(&context->balloc_count, 1, __ATOMIC_RELAXED);
@@ -157,8 +158,9 @@ memory_balloc(struct memory_context *context, size_t size) {
 
 static inline void
 memory_bfree(struct memory_context *context, void *block, size_t size) {
-	if (block == NULL || !size)
+	if (block == NULL || !size) {
 		return;
+	}
 // Verified reproducing: gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0, release
 // build flags (-O2 -g -Wall -Wextra -Werror -march=haswell -fPIC), e.g.
 // modules/acl/api/controlplane.c inlining memory_bfree into
@@ -190,8 +192,9 @@ memory_brealloc(
 	size_t old_size,
 	size_t new_size
 ) {
-	if (!new_size && !old_size)
+	if (!new_size && !old_size) {
 		return NULL;
+	}
 
 	if (!new_size) {
 		memory_bfree(context, data, old_size);
@@ -199,16 +202,19 @@ memory_brealloc(
 	}
 
 	void *new_data = memory_balloc(context, new_size);
-	if (new_data == NULL)
+	if (new_data == NULL) {
 		return NULL;
+	}
 	if (old_size < new_size) {
-		if (old_size)
+		if (old_size) {
 			memcpy(new_data, data, old_size);
+		}
 	} else {
 		memcpy(new_data, data, new_size);
 	}
 
-	if (old_size)
+	if (old_size) {
 		memory_bfree(context, data, old_size);
+	}
 	return new_data;
 }

--- a/common/memory_block.h
+++ b/common/memory_block.h
@@ -98,8 +98,9 @@ static inline size_t
 block_allocator_pool_index(struct block_allocator *allocator, size_t size) {
 	(void)allocator;
 
-	if (size < MEMORY_BLOCK_ALLOCATOR_MIN_SIZE)
+	if (size < MEMORY_BLOCK_ALLOCATOR_MIN_SIZE) {
 		return 0;
+	}
 
 	// Make 'size' the upper end of its power-of-2 range
 	size = (size << 1) - 1;
@@ -164,11 +165,13 @@ block_allocator_pool_borrow(
 
 static inline void *
 block_allocator_balloc(struct block_allocator *allocator, size_t size) {
-	if (!size)
+	if (!size) {
 		return NULL;
+	}
 
-	if (size > MEMORY_BLOCK_ALLOCATOR_MAX_SIZE)
+	if (size > MEMORY_BLOCK_ALLOCATOR_MAX_SIZE) {
 		return NULL;
+	}
 
 	size += 2 * ASAN_RED_ZONE;
 
@@ -202,8 +205,9 @@ static inline void
 block_allocator_bfree_internal(
 	struct block_allocator *allocator, void *block, size_t size
 ) {
-	if (!size)
+	if (!size) {
 		return;
+	}
 
 	size_t pool_index = block_allocator_pool_index(allocator, size);
 	struct block_allocator_pool *pool = allocator->pools + pool_index;
@@ -221,8 +225,9 @@ static inline void
 block_allocator_bfree(
 	struct block_allocator *allocator, void *block, size_t size
 ) {
-	if (!size)
+	if (!size) {
 		return;
+	}
 
 	size += 2 * ASAN_RED_ZONE;
 	block -= ASAN_RED_ZONE;
@@ -257,11 +262,13 @@ block_allocator_put_arena(
 		 * The loop bellow could be replaced with some bit magic but
 		 * let us do it in the future
 		 */
-		while (pos + block_size > end)
+		while (pos + block_size > end) {
 			block_size >>= 1;
+		}
 
-		if (block_size > MEMORY_BLOCK_ALLOCATOR_MAX_SIZE_INTERNAL)
+		if (block_size > MEMORY_BLOCK_ALLOCATOR_MAX_SIZE_INTERNAL) {
 			block_size = MEMORY_BLOCK_ALLOCATOR_MAX_SIZE_INTERNAL;
+		}
 
 		block_allocator_bfree_internal(
 			allocator, (void *)pos, block_size

--- a/common/numutils.h
+++ b/common/numutils.h
@@ -6,8 +6,9 @@
 /// TODO: docs
 static inline uint64_t
 uint64_log_up(uint64_t value) {
-	if (unlikely(value == 0))
+	if (unlikely(value == 0)) {
 		return 0;
+	}
 
 	return sizeof(long long) * 8 - __builtin_clzll(value) -
 	       !(value & (value - 1));

--- a/common/radix.h
+++ b/common/radix.h
@@ -47,8 +47,9 @@ radix_new_page(struct radix *radix, uint32_t *page_idx) {
 			memory_context, sizeof(radix_page_t) * RADIX_CHUNK_SIZE
 		);
 
-		if (new_chunk == NULL)
+		if (new_chunk == NULL) {
 			return -1;
+		}
 
 		radix_page_t **old_pages = ADDR_OF(&radix->pages);
 		uint64_t old_chunk_count = radix->page_count / RADIX_CHUNK_SIZE;
@@ -79,8 +80,9 @@ radix_new_page(struct radix *radix, uint32_t *page_idx) {
 			old_chunk_count * sizeof(radix_page_t *)
 		);
 	}
-	if (page_idx != NULL)
+	if (page_idx != NULL) {
 		*page_idx = radix->page_count;
+	}
 	radix_page_t *page = radix_page(radix, radix->page_count);
 	memset(page, 0xff, sizeof(radix_page_t));
 	radix->page_count += 1;
@@ -103,8 +105,9 @@ radix_free(struct radix *radix) {
 		(radix->page_count + RADIX_CHUNK_SIZE - 1) / RADIX_CHUNK_SIZE;
 	for (uint32_t chunk_idx = 0; chunk_idx < chunk_count; ++chunk_idx) {
 		radix_page_t *chunk = ADDR_OF(&pages[chunk_idx]);
-		if (chunk == NULL)
+		if (chunk == NULL) {
 			continue;
+		}
 
 		memory_bfree(
 			memory_context,
@@ -131,8 +134,9 @@ radix_insert(
 	for (uint8_t iter = 0; iter < key_size - 1; ++iter) {
 		uint32_t *stored_value = (*page) + key[iter];
 		if ((*stored_value == RADIX_VALUE_INVALID) &&
-		    radix_new_page(radix, stored_value))
+		    radix_new_page(radix, stored_value)) {
 			return -1;
+		}
 		page = radix_page(radix, *stored_value);
 	}
 
@@ -147,8 +151,9 @@ radix_lookup(const struct radix *radix, uint8_t key_size, const uint8_t *key) {
 	radix_page_t *page = radix_page(radix, 0);
 	for (uint8_t iter = 0; iter < key_size - 1; ++iter) {
 		value = (*page)[key[iter]];
-		if (value == RADIX_VALUE_INVALID)
+		if (value == RADIX_VALUE_INVALID) {
 			return RADIX_VALUE_INVALID;
+		}
 
 		page = radix_page(radix, value);
 	}
@@ -189,11 +194,13 @@ radix_walk_rec(
 				    depth + 1,
 				    cb,
 				    cb_data
-			    ))
+			    )) {
 				return -1;
+			}
 		} else {
-			if (cb(key_size, key, value, cb_data))
+			if (cb(key_size, key, value, cb_data)) {
 				return -1;
+			}
 		}
 	}
 	return 0;

--- a/common/range_collector.h
+++ b/common/range_collector.h
@@ -24,8 +24,9 @@ range_collector_init(
 ) {
 	collector->memory_context = memory_context;
 
-	if (radix_init(&collector->radix, collector->memory_context))
+	if (radix_init(&collector->radix, collector->memory_context)) {
 		return -1;
+	}
 	collector->masks = NULL;
 	collector->mask_count = 0;
 
@@ -89,8 +90,9 @@ range_collector_add(
 	const uint8_t *value,
 	const uint8_t prefix
 ) {
-	if (!prefix)
+	if (!prefix) {
 		return 0;
+	}
 
 	uint32_t mask_index = radix_lookup(&collector->radix, key_size, value);
 	if (mask_index == RADIX_VALUE_INVALID) {
@@ -169,13 +171,15 @@ range_collector_stack_emit(
 	struct range_collector_stack_item item =
 		range_collector_stack_last(ctx, key_size);
 
-	if (*item.value == LPM_VALUE_INVALID)
+	if (*item.value == LPM_VALUE_INVALID) {
 		*item.value = ctx->max_value++;
+	}
 
 	if (range_index_insert(
 		    ctx->range_index, key_size, ctx->pos, *item.value
-	    ))
+	    )) {
 		return -1;
+	}
 
 	memcpy(ctx->pos, to, key_size);
 	filter_key_inc(key_size, ctx->pos);
@@ -191,8 +195,11 @@ range_collector_stack_emit_until(
 		struct range_collector_stack_item item =
 			range_collector_stack_last(ctx, key_size);
 		if (filter_key_cmp(key_size, item.to, to) < 0) {
-			if (range_collector_stack_emit(ctx, key_size, item.to))
+			if (range_collector_stack_emit(
+				    ctx, key_size, item.to
+			    )) {
 				return -1;
+			}
 			--ctx->stack_depth;
 		} else if (filter_key_cmp(key_size, ctx->pos, to) < 0) {
 			uint8_t emit_to[key_size];
@@ -216,8 +223,9 @@ range_collector_add_network(
 	const uint8_t *to,
 	struct range_collector_ctx *ctx
 ) {
-	if (range_collector_stack_emit_until(ctx, key_size, from))
+	if (range_collector_stack_emit_until(ctx, key_size, from)) {
 		return -1;
+	}
 	range_collector_stack_push(ctx, key_size, to);
 
 	return 0;
@@ -242,8 +250,9 @@ range_collector_iterate(
 			mask_item ^= 0x01 << (7 - (prefix - 1) % 8);
 			if (range_collector_add_network(
 				    key_size, from, to, ctx
-			    ))
+			    )) {
 				return -1;
+			}
 		}
 	}
 
@@ -279,14 +288,16 @@ range_collector_collect(
 
 	if (radix_walk(
 		    &collector->radix, key_size, range_collector_iterate, &ctx
-	    ))
+	    )) {
 		goto error;
+	}
 
 	while (ctx.stack_depth > 0) {
 		struct range_collector_stack_item item =
 			range_collector_stack_last(&ctx, key_size);
-		if (range_collector_stack_emit(&ctx, key_size, item.to))
+		if (range_collector_stack_emit(&ctx, key_size, item.to)) {
 			goto error;
+		}
 		--ctx.stack_depth;
 	}
 

--- a/common/range_index.h
+++ b/common/range_index.h
@@ -54,14 +54,16 @@ range_index_insert(
 	if (!((range_index->count - 1) & range_index->count)) {
 		old_count = range_index->count;
 		new_count = old_count * 2;
-		if (!new_count)
+		if (!new_count) {
 			new_count = 1;
+		}
 		new_values = (uint32_t *)memory_balloc(
 			memory_context, new_count * sizeof(uint32_t)
 		);
 
-		if (new_values == NULL)
+		if (new_values == NULL) {
 			return -1;
+		}
 		if (old_count > 0) {
 			memcpy(new_values,
 			       old_values,
@@ -91,8 +93,9 @@ range_index_insert(
 		);
 	}
 
-	if (value > range_index->max_value)
+	if (value > range_index->max_value) {
 		range_index->max_value = value;
+	}
 
 	return 0;
 }
@@ -158,8 +161,9 @@ range_index_lpm_cb(
 			    ctx->prev_from,
 			    to,
 			    ctx->prev_value
-		    ))
+		    )) {
 			return -1;
+		}
 	}
 
 	memcpy(ctx->prev_from, from, key_size);
@@ -176,16 +180,20 @@ range_index_build_lpm(
 	ctx.values = ADDR_OF(&range_index->values);
 	ctx.prev_value = LPM_VALUE_INVALID;
 
-	if (radix_walk(&range_index->radix, key_size, range_index_lpm_cb, &ctx))
+	if (radix_walk(
+		    &range_index->radix, key_size, range_index_lpm_cb, &ctx
+	    )) {
 		return -1;
+	}
 
 	if (ctx.prev_value != LPM_VALUE_INVALID) {
 		uint8_t to[key_size];
 		memset(to, 0xff, key_size);
 		if (lpm_insert(
 			    lpm, key_size, ctx.prev_from, to, ctx.prev_value
-		    ))
+		    )) {
 			return -1;
+		}
 	}
 
 	return 0;

--- a/common/rcu.h
+++ b/common/rcu.h
@@ -334,8 +334,9 @@ wait_epoch_flush(rcu_t *rcu, unsigned e) {
 				}
 			}
 		}
-		if (!any)
+		if (!any) {
 			break;
+		}
 		cpu_pause();
 	}
 }

--- a/common/registry.h
+++ b/common/registry.h
@@ -91,8 +91,9 @@ value_collector_check(struct value_collector *collector, uint32_t value) {
 			new_chunk_count * sizeof(uint32_t *)
 		);
 
-		if (new_use_map == NULL)
+		if (new_use_map == NULL) {
 			return -1;
+		}
 
 		// Set correct relative addresses
 		for (uint32_t idx = 0; idx < collector->chunk_count; ++idx) {
@@ -102,8 +103,9 @@ value_collector_check(struct value_collector *collector, uint32_t value) {
 
 		for (uint32_t idx = collector->chunk_count;
 		     idx < new_chunk_count;
-		     ++idx)
+		     ++idx) {
 			new_use_map[idx] = NULL;
+		}
 
 		memory_bfree(
 			collector->memory_context,
@@ -123,8 +125,9 @@ value_collector_check(struct value_collector *collector, uint32_t value) {
 			VALUE_COLLECTOR_CHUNK_SIZE * sizeof(uint32_t)
 		);
 
-		if (chunk == NULL)
+		if (chunk == NULL) {
 			return -1;
+		}
 
 		memset(chunk,
 		       0xff,
@@ -146,8 +149,9 @@ value_collector_check(struct value_collector *collector, uint32_t value) {
 static inline int
 value_collector_collect(struct value_collector *collector, uint32_t value) {
 	int check = value_collector_check(collector, value);
-	if (check != 1)
+	if (check != 1) {
 		return check;
+	}
 
 	uint32_t **use_map = ADDR_OF(&collector->use_map);
 	uint32_t chunk_idx = value / VALUE_COLLECTOR_CHUNK_SIZE;
@@ -179,8 +183,9 @@ static inline int
 value_registry_init(
 	struct value_registry *registry, struct memory_context *memory_context
 ) {
-	if (value_collector_init(&registry->collector, memory_context))
+	if (value_collector_init(&registry->collector, memory_context)) {
 		return -1;
+	}
 
 	registry->memory_context = memory_context;
 
@@ -210,8 +215,9 @@ value_registry_start(struct value_registry *registry) {
 				new_capacity * sizeof(struct value_range)
 			);
 
-		if (new_ranges == NULL)
+		if (new_ranges == NULL) {
 			return -1;
+		}
 
 		for (uint64_t idx = 0; idx < old_capacity; ++idx) {
 			SET_OFFSET_OF(
@@ -273,11 +279,15 @@ value_registry_collect(struct value_registry *registry, uint32_t value) {
 	if (rc == 1) {
 		struct value_range *range =
 			ADDR_OF(&registry->ranges) + registry->range_count - 1;
-		if (value_range_append(registry->memory_context, range, value))
+		if (value_range_append(
+			    registry->memory_context, range, value
+		    )) {
 			return -1;
+		}
 
-		if (value > registry->max_value)
+		if (value > registry->max_value) {
 			registry->max_value = value;
+		}
 	}
 
 	return 0;

--- a/common/remap.h
+++ b/common/remap.h
@@ -70,8 +70,9 @@ remap_table_init(
 		table->memory_context, sizeof(struct remap_item *)
 	);
 
-	if (keys == NULL)
+	if (keys == NULL) {
 		return -1;
+	}
 
 	struct remap_item *chunk = (struct remap_item *)memory_balloc(
 		table->memory_context,
@@ -97,8 +98,9 @@ static inline void
 remap_table_free(struct remap_table *table) {
 	struct remap_item **keys = ADDR_OF(&table->keys);
 
-	if (keys == NULL)
+	if (keys == NULL) {
 		return;
+	}
 
 	uint32_t chunk_count = (table->count + REMAP_TABLE_CHUNK_SIZE - 1) /
 			       REMAP_TABLE_CHUNK_SIZE;
@@ -159,8 +161,9 @@ remap_table_new_key(struct remap_table *table, uint32_t *key) {
 					REMAP_TABLE_CHUNK_SIZE
 			);
 
-		if (new_chunk == NULL)
+		if (new_chunk == NULL) {
 			return -1;
+		}
 
 		uint32_t old_chunk_count =
 			table->count / REMAP_TABLE_CHUNK_SIZE;
@@ -214,8 +217,9 @@ remap_table_touch(struct remap_table *table, uint32_t key, uint32_t *value) {
 	if (item->gen != table->gen) {
 		// Allocate new key and update generation
 		uint32_t new_key;
-		if (remap_table_new_key(table, &new_key))
+		if (remap_table_new_key(table, &new_key)) {
 			return -1;
+		}
 		item->gen = table->gen;
 		item->value = new_key;
 		res = 1;

--- a/common/rwlock.h
+++ b/common/rwlock.h
@@ -130,17 +130,19 @@ rwlock_write_lock(rwlock_t *rwl) {
 				    YANET_RWLOCK_WRITE,
 				    memory_order_acquire,
 				    memory_order_relaxed
-			    ))
+			    )) {
 				return;
+			}
 		}
 
 		/* Turn on writer wait bit */
-		if (!(x & YANET_RWLOCK_WAIT))
+		if (!(x & YANET_RWLOCK_WAIT)) {
 			atomic_fetch_or_explicit(
 				&rwl->cnt,
 				YANET_RWLOCK_WAIT,
 				memory_order_relaxed
 			);
+		}
 	}
 }
 

--- a/common/str_index.h
+++ b/common/str_index.h
@@ -74,8 +74,9 @@ str_index_init(
 
 static inline void
 str_index_fini(struct str_index *str_index) {
-	if (str_index->values == NULL)
+	if (str_index->values == NULL) {
 		return;
+	}
 
 	uint32_t *values = ADDR_OF(&str_index->values);
 	memory_bfree(
@@ -94,8 +95,9 @@ str_index_lookup(
 	str_index_read_func read_func,
 	const void *read_func_data
 ) {
-	if (!str_index->capacity)
+	if (!str_index->capacity) {
 		return STR_INDEX_INVALID;
+	}
 
 	uint32_t length = strnlen(key, key_size);
 	uint32_t hash = str_index_fnv1a(key, length, 0);
@@ -145,8 +147,9 @@ str_index_expand(
 		ADDR_OF(&str_index->memory_context),
 		sizeof(uint32_t) * new_capacity
 	);
-	if (new_values == NULL)
+	if (new_values == NULL) {
 		return -1;
+	}
 
 	memset(new_values, 0xff, sizeof(uint32_t) * new_capacity);
 
@@ -157,8 +160,9 @@ str_index_expand(
 	str_index->capacity = new_capacity;
 
 	for (uint32_t pos = 0; pos < old_capacity; ++pos) {
-		if (old_values[pos] == STR_INDEX_INVALID)
+		if (old_values[pos] == STR_INDEX_INVALID) {
 			continue;
+		}
 		const char *key = read_func(old_values[pos], read_func_data);
 		str_index_insert_force(
 			str_index, key, key_size, old_values[pos]

--- a/common/strutils.h
+++ b/common/strutils.h
@@ -24,7 +24,8 @@ strtcpy(char *restrict dst, const char *restrict src, size_t dsize) {
 	memcpy(dst, src, dlen);
 	dst[dlen] = '\0';
 
-	if (trunc)
+	if (trunc) {
 		errno = E2BIG;
+	}
 	return trunc ? -1 : (ssize_t)slen;
 }

--- a/common/value.h
+++ b/common/value.h
@@ -25,8 +25,9 @@ value_table_free(struct value_table *value_table) {
 		ADDR_OF(&value_table->memory_context);
 
 	uint32_t **values = ADDR_OF(&value_table->values);
-	if (values == NULL)
+	if (values == NULL) {
 		return;
+	}
 
 	uint64_t value_count = value_table->v_dim;
 	value_count *= value_table->h_dim;
@@ -35,8 +36,9 @@ value_table_free(struct value_table *value_table) {
 
 	for (uint32_t chunk_idx = 0; chunk_idx < chunk_count; ++chunk_idx) {
 		uint32_t *chunk = ADDR_OF(values + chunk_idx);
-		if (chunk == NULL)
+		if (chunk == NULL) {
 			continue;
+		}
 		memory_bfree(
 			memory_context,
 			chunk,
@@ -70,8 +72,9 @@ value_table_init(
 	uint32_t **values = (uint32_t **)memory_balloc(
 		memory_context, chunk_count * sizeof(uint32_t *)
 	);
-	if (values == NULL)
+	if (values == NULL) {
 		return -1;
+	}
 
 	memset(values, 0, chunk_count * sizeof(uint32_t *));
 	SET_OFFSET_OF(&value_table->values, values);

--- a/dataplane/config.c
+++ b/dataplane/config.c
@@ -91,16 +91,18 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 
 	yaml_parser_t parser;
 	yaml_event_t event;
-	if (!yaml_parser_initialize(&parser))
+	if (!yaml_parser_initialize(&parser)) {
 		return -1;
+	}
 
 	yaml_parser_set_input_file(&parser, file);
 
 	struct dataplane_config *dataplane =
 		(struct dataplane_config *)malloc(sizeof(struct dataplane_config
 		));
-	if (dataplane == NULL)
+	if (dataplane == NULL) {
 		goto err_alloc_config;
+	}
 
 	memset(dataplane, 0, sizeof(*dataplane));
 
@@ -144,8 +146,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 			case state_dataplane_dpdk_memory:
 				dataplane->dpdk_memory =
 					strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 				state = state_dataplane;
 				break;
 			case state_dataplane_iova_mode:
@@ -168,8 +171,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				break;
 			case state_modules:
 				if (dataplane->module_count >=
-				    DATAPLANE_MAX_MODULES)
+				    DATAPLANE_MAX_MODULES) {
 					goto error;
+				}
 				strtcpy(dataplane->module_names
 						[dataplane->module_count],
 					start,
@@ -180,20 +184,23 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 			// handle new instance
 			case state_instance_numa_id:
 				instance->numa_idx = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 				state = state_instance;
 				break;
 			case state_instance_dp_memory:
 				instance->dp_memory = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 				state = state_instance;
 				break;
 			case state_instance_cp_memory:
 				instance->cp_memory = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 				state = state_instance;
 				break;
 			case state_device_name:
@@ -217,58 +224,66 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 				break;
 			case state_device_mtu:
 				device->mtu = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 				state = state_device;
 				break;
 			case state_device_max_lro_packet_size:
 				device->max_lro_packet_size =
 					strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 
 				state = state_device;
 				break;
 			case state_device_rss_hash:
 				device->rss_hash = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 
 				state = state_device;
 				break;
 
 			case state_worker_core_id:
 				worker->core_id = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 
 				state = state_worker;
 				break;
 			case state_worker_instance_id:
 				worker->instance_id = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 
 				state = state_worker;
 				break;
 			case state_worker_rx_queue_len:
 				worker->rx_queue_len = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 
 				state = state_worker;
 				break;
 			case state_worker_tx_queue_len:
 				worker->tx_queue_len = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 
 				state = state_worker;
 				break;
 			case state_worker_num_mbufs:
 				worker->num_mbufs = strtol(start, &end, 10);
-				if (*end != '\0')
+				if (*end != '\0') {
 					goto error;
+				}
 
 				state = state_worker;
 				break;
@@ -550,8 +565,9 @@ dataplane_config_init(FILE *file, struct dataplane_config **config) {
 	}
 	yaml_event_delete(&event);
 
-	if (resolve_connections(dataplane) != 0)
+	if (resolve_connections(dataplane) != 0) {
 		goto error;
+	}
 
 	yaml_parser_delete(&parser);
 

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -62,8 +62,9 @@ dataplane_worker_connect(
 			tx_conn->pipes,
 			sizeof(struct worker_tx_pipe) * 2 * (tx_conn->count + 1)
 		);
-		if (pipes == NULL)
+		if (pipes == NULL) {
 			return -1;
+		}
 		tx_conn->pipes = pipes;
 	}
 
@@ -74,14 +75,16 @@ dataplane_worker_connect(
 			sizeof(struct data_pipe) * 2 *
 				(wrk_rx->write_ctx.rx_pipe_count + 1)
 		);
-		if (pipes == NULL)
+		if (pipes == NULL) {
 			return -1;
+		}
 		wrk_rx->write_ctx.rx_pipes = pipes;
 	}
 
 	struct worker_tx_pipe *tx_pipe = tx_conn->pipes + tx_conn->count;
-	if (data_pipe_init(&tx_pipe->pipe, WORKER_TX_PIPE_SIZE))
+	if (data_pipe_init(&tx_pipe->pipe, WORKER_TX_PIPE_SIZE)) {
 		return -1;
+	}
 
 	uint32_t pending_capacity =
 		1u << (WORKER_TX_PIPE_SIZE + WORKER_TX_PIPE_PENDING_SHIFT);
@@ -117,8 +120,9 @@ dataplane_connect_device(
 	 * device worker.
 	 */
 	size_t pipe_count = from_device->worker_count;
-	if (to_device->worker_count > pipe_count)
+	if (to_device->worker_count > pipe_count) {
 		pipe_count = to_device->worker_count;
+	}
 
 	for (size_t pipe_idx = 0; pipe_idx < pipe_count; ++pipe_idx) {
 		// Select source and destination workers

--- a/dataplane/drivers/sock_dev.c
+++ b/dataplane/drivers/sock_dev.c
@@ -360,8 +360,9 @@ sock_dev_create(const char *path, const char *name, int numa_node) {
 		(struct sock_internals *)rte_zmalloc_socket(
 			path, sizeof(struct sock_internals), 0, numa_node
 		);
-	if (internals == NULL)
+	if (internals == NULL) {
 		return ENOSPC;
+	}
 
 	internals->pci_id.device_id = 0xBEEF;
 

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -481,8 +481,9 @@ cp_chain_config_create(
 		calloc(1,
 		       sizeof(struct cp_chain_config) +
 			       sizeof(struct cp_chain_module_config) * length);
-	if (cp_chain_config == NULL)
+	if (cp_chain_config == NULL) {
 		return NULL;
+	}
 
 	strtcpy(cp_chain_config->name, name, CP_CHAIN_NAME_LEN);
 	cp_chain_config->length = length;
@@ -510,8 +511,9 @@ cp_function_config_create(const char *name, uint64_t chain_count) {
 		sizeof(struct cp_function_config) +
 			sizeof(struct cp_function_chain_config) * chain_count
 	);
-	if (config == NULL)
+	if (config == NULL) {
 		return NULL;
+	}
 	strtcpy(config->name, name, CP_FUNCTION_NAME_LEN);
 	config->chain_count = chain_count;
 
@@ -521,8 +523,9 @@ cp_function_config_create(const char *name, uint64_t chain_count) {
 void
 cp_function_config_free(struct cp_function_config *config) {
 	for (uint64_t idx = 0; idx < config->chain_count; ++idx) {
-		if (config->chains[idx].chain != NULL)
+		if (config->chains[idx].chain != NULL) {
 			cp_chain_config_free(config->chains[idx].chain);
+		}
 	}
 	free(config);
 }
@@ -534,11 +537,13 @@ cp_function_config_set_chain(
 	struct cp_chain_config *cp_chain_config,
 	uint64_t weight
 ) {
-	if (index >= cp_function_config->chain_count)
+	if (index >= cp_function_config->chain_count) {
 		return -1;
+	}
 
-	if (cp_function_config->chains[index].chain != NULL)
+	if (cp_function_config->chains[index].chain != NULL) {
 		return -1;
+	}
 
 	cp_function_config->chains[index] = (struct cp_function_chain_config){
 		.chain = cp_chain_config,
@@ -653,8 +658,9 @@ int
 cp_pipeline_config_set_function(
 	struct cp_pipeline_config *config, uint64_t index, const char *name
 ) {
-	if (index >= config->length)
+	if (index >= config->length) {
 		return -1;
+	}
 	strtcpy(config->functions[index], name, sizeof(config->functions[index])
 	);
 	return 0;
@@ -756,8 +762,9 @@ yanet_get_dp_module_info(
 	uint64_t index,
 	struct dp_module_info *module_info
 ) {
-	if (index >= module_list->module_count)
+	if (index >= module_list->module_count) {
 		return -1;
+	}
 	*module_info = module_list->modules[index];
 	return 0;
 }
@@ -776,8 +783,9 @@ yanet_get_dp_module_list_info(struct dp_config *dp_config) {
 			sizeof(struct dp_module_list_info) +
 			dp_config->module_count * sizeof(struct dp_module_info)
 		);
-	if (module_list_info == NULL)
+	if (module_list_info == NULL) {
 		goto unlock;
+	}
 
 	struct dp_module *modules = ADDR_OF(&dp_config->dp_modules);
 
@@ -817,8 +825,9 @@ yanet_get_cp_module_list_info(struct dp_config *dp_config) {
 			sizeof(struct cp_module_info) *
 				module_registry->registry.capacity
 		);
-	if (module_list_info == NULL)
+	if (module_list_info == NULL) {
 		goto unlock;
+	}
 
 	module_list_info->module_count = 0;
 
@@ -850,8 +859,9 @@ struct cp_module_info *
 yanet_get_cp_module_info(
 	struct cp_module_list_info *module_list, uint64_t index
 ) {
-	if (index >= module_list->module_count)
+	if (index >= module_list->module_count) {
 		return NULL;
+	}
 	return module_list->modules + index;
 }
 
@@ -893,8 +903,9 @@ yanet_get_cp_function_list_info(struct dp_config *dp_config) {
 			sizeof(struct cp_function_info *) *
 				function_registry->registry.capacity
 		);
-	if (function_list_info == NULL)
+	if (function_list_info == NULL) {
 		goto unlock;
+	}
 
 	function_list_info->function_count = 0;
 
@@ -987,8 +998,9 @@ struct cp_function_info *
 yanet_get_cp_function_info(
 	struct cp_function_list_info *function_list, uint64_t index
 ) {
-	if (index >= function_list->function_count)
+	if (index >= function_list->function_count) {
 		return NULL;
+	}
 
 	return function_list->functions[index];
 }
@@ -997,8 +1009,9 @@ struct cp_chain_info *
 yanet_get_cp_function_chain_info(
 	struct cp_function_info *function_info, uint64_t index
 ) {
-	if (index >= function_info->chain_count)
+	if (index >= function_info->chain_count) {
 		return NULL;
+	}
 
 	return function_info->chains[index];
 }
@@ -1007,8 +1020,9 @@ struct cp_module_info_id *
 yanet_get_cp_function_chain_module_info(
 	struct cp_chain_info *chain_info, uint64_t index
 ) {
-	if (index >= chain_info->length)
+	if (index >= chain_info->length) {
 		return NULL;
+	}
 
 	return chain_info->modules + index;
 }
@@ -1017,8 +1031,9 @@ yanet_get_cp_function_chain_module_info(
 
 void
 cp_pipeline_list_info_free(struct cp_pipeline_list_info *pipeline_list_info) {
-	for (uint64_t idx = 0; idx < pipeline_list_info->count; ++idx)
+	for (uint64_t idx = 0; idx < pipeline_list_info->count; ++idx) {
 		free(pipeline_list_info->pipelines[idx]);
+	}
 	free(pipeline_list_info);
 }
 
@@ -1037,8 +1052,9 @@ yanet_get_cp_pipeline_list_info(struct dp_config *dp_config) {
 			sizeof(struct cp_pipeline_info *) *
 				pipeline_registry->capacity
 		);
-	if (pipeline_list_info == NULL)
+	if (pipeline_list_info == NULL) {
 		goto unlock;
+	}
 
 	memset(pipeline_list_info,
 	       0,
@@ -1087,8 +1103,9 @@ struct cp_pipeline_info *
 yanet_get_cp_pipeline_info(
 	struct cp_pipeline_list_info *pipeline_list_info, uint64_t index
 ) {
-	if (index >= pipeline_list_info->count)
+	if (index >= pipeline_list_info->count) {
 		return NULL;
+	}
 
 	return pipeline_list_info->pipelines[index];
 }
@@ -1097,8 +1114,9 @@ struct cp_function_info_id *
 yanet_get_cp_pipeline_function_info_id(
 	struct cp_pipeline_info *pipeline_info, uint64_t index
 ) {
-	if (index >= pipeline_info->length)
+	if (index >= pipeline_info->length) {
 		return NULL;
+	}
 
 	return pipeline_info->functions + index;
 }
@@ -1173,8 +1191,9 @@ yanet_get_cp_device_list_info(struct dp_config *dp_config) {
 			device_registry->registry.capacity;
 	struct cp_device_list_info *device_list_info =
 		(struct cp_device_list_info *)malloc(device_list_info_size);
-	if (device_list_info == NULL)
+	if (device_list_info == NULL) {
 		goto unlock;
+	}
 
 	memset(device_list_info, 0, device_list_info_size);
 	device_list_info->device_count = 0;
@@ -1208,8 +1227,9 @@ struct cp_device_info *
 yanet_get_cp_device_info(
 	struct cp_device_list_info *device_list_info, uint64_t idx
 ) {
-	if (idx >= device_list_info->device_count)
+	if (idx >= device_list_info->device_count) {
 		return NULL;
+	}
 
 	return device_list_info->devices[idx];
 }
@@ -1218,8 +1238,9 @@ struct cp_device_pipeline_info *
 yanet_get_cp_device_input_pipeline_info(
 	struct cp_device_info *device_info, uint64_t idx
 ) {
-	if (idx >= device_info->input_count)
+	if (idx >= device_info->input_count) {
 		return NULL;
+	}
 
 	return device_info->pipelines + idx;
 }
@@ -1228,8 +1249,9 @@ struct cp_device_pipeline_info *
 yanet_get_cp_device_output_pipeline_info(
 	struct cp_device_info *device_info, uint64_t idx
 ) {
-	if (idx >= device_info->output_count)
+	if (idx >= device_info->output_count) {
 		return NULL;
+	}
 
 	return device_info->pipelines + device_info->input_count + idx;
 }
@@ -1348,8 +1370,9 @@ cp_device_config_create(
 		(struct cp_device_config *)malloc(sizeof(struct cp_device_config
 		));
 
-	if (config == NULL)
+	if (config == NULL) {
 		return NULL;
+	}
 
 	memset(config, 0, sizeof(struct cp_device_config));
 	strtcpy(config->name, name, CP_DEVICE_NAME_LEN);
@@ -1399,8 +1422,9 @@ cp_device_config_set_input_pipeline(
 	const char *name,
 	uint64_t weight
 ) {
-	if (index >= device->input_pipelines->count)
+	if (index >= device->input_pipelines->count) {
 		return -1;
+	}
 	strtcpy(device->input_pipelines->pipelines[index].name,
 		name,
 		CP_PIPELINE_NAME_LEN);
@@ -1416,8 +1440,9 @@ cp_device_config_set_output_pipeline(
 	const char *name,
 	uint64_t weight
 ) {
-	if (index >= device->output_pipelines->count)
+	if (index >= device->output_pipelines->count) {
 		return -1;
+	}
 	strtcpy(device->output_pipelines->pipelines[index].name,
 		name,
 		CP_PIPELINE_NAME_LEN);
@@ -1787,8 +1812,9 @@ yanet_get_device_counters(
 
 struct counter_handle *
 yanet_get_counter(struct counter_handle_list *counters, uint64_t idx) {
-	if (idx >= counters->count)
+	if (idx >= counters->count) {
 		return NULL;
+	}
 	return counters->counters + idx;
 }
 
@@ -1829,8 +1855,9 @@ counter_handle_list_build(
 		sizeof(struct counter_handle) * count
 	);
 
-	if (list == NULL)
+	if (list == NULL) {
 		return NULL;
+	}
 	list->instance_count = worker_count;
 	list->count = count;
 	struct counter_handle *handlers = list->counters;
@@ -1925,8 +1952,9 @@ yanet_get_port_counters(struct dp_config *dp_config) {
 			sizeof(struct port_counter_group_list) +
 			sizeof(struct port_counter_group) * port_count
 		);
-	if (groups == NULL)
+	if (groups == NULL) {
 		return NULL;
+	}
 	groups->port_count = port_count;
 
 	for (uint64_t idx = 0; idx < port_count; ++idx) {

--- a/lib/controlplane/config/cp_device.c
+++ b/lib/controlplane/config/cp_device.c
@@ -359,8 +359,9 @@ cp_device_entry_free(
 	struct memory_context *memory_context,
 	struct cp_device_entry *cp_device_entry
 ) {
-	if (cp_device_entry == NULL)
+	if (cp_device_entry == NULL) {
 		return;
+	}
 	memory_bfree(
 		memory_context,
 		cp_device_entry,

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -292,8 +292,9 @@ cp_module_registry_get(
 ) {
 	struct registry_item *item =
 		registry_get(&module_registry->registry, index);
-	if (item == NULL)
+	if (item == NULL) {
 		return NULL;
+	}
 	return container_of(item, struct cp_module, config_item);
 }
 
@@ -314,8 +315,9 @@ cp_module_registry_item_cmp(
 
 	int cmp = strncmp(module->name, cmp_data->name, sizeof(module->name));
 
-	if (cmp)
+	if (cmp) {
 		return cmp;
+	}
 
 	return strncmp(module->type, cmp_data->type, sizeof(module->type));
 }

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -15,8 +15,9 @@ module_ectx_free(
 
 	struct counter_storage *counter_storage =
 		ADDR_OF(&module_ectx->counter_storage);
-	if (counter_storage != NULL)
+	if (counter_storage != NULL) {
 		counter_storage_free(counter_storage);
+	}
 
 	uint64_t *cm_index = ADDR_OF(&module_ectx->cm_index);
 	if (cm_index != NULL) {
@@ -197,16 +198,18 @@ chain_ectx_free(
 	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
 		struct module_ectx *module_ectx =
 			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
-		if (module_ectx == NULL)
+		if (module_ectx == NULL) {
 			continue;
+		}
 
 		module_ectx_free(cp_config_gen, module_ectx);
 	}
 
 	struct counter_storage *counter_storage =
 		ADDR_OF(&chain_ectx->counter_storage);
-	if (counter_storage != NULL)
+	if (counter_storage != NULL) {
 		counter_storage_free(counter_storage);
+	}
 
 	memory_bfree(
 		memory_context,
@@ -388,8 +391,9 @@ function_ectx_free(
 		for (uint64_t idx = 0; idx < function_ectx->chain_count;
 		     ++idx) {
 			struct chain_ectx *chain_ectx = ADDR_OF(chains + idx);
-			if (chain_ectx == NULL)
+			if (chain_ectx == NULL) {
 				continue;
+			}
 
 			chain_ectx_free(cp_config_gen, chain_ectx);
 		}
@@ -402,8 +406,9 @@ function_ectx_free(
 
 	struct counter_storage *counter_storage =
 		ADDR_OF(&function_ectx->counter_storage);
-	if (counter_storage != NULL)
+	if (counter_storage != NULL) {
 		counter_storage_free(counter_storage);
+	}
 
 	size_t ectx_size =
 		sizeof(struct function_ectx) +
@@ -595,16 +600,18 @@ pipeline_ectx_free(
 	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
 		struct function_ectx *function_ectx =
 			ADDR_OF(pipeline_ectx->functions + idx);
-		if (function_ectx == NULL)
+		if (function_ectx == NULL) {
 			continue;
+		}
 
 		function_ectx_free(cp_config_gen, function_ectx);
 	}
 
 	struct counter_storage *counter_storage =
 		ADDR_OF(&pipeline_ectx->counter_storage);
-	if (counter_storage != NULL)
+	if (counter_storage != NULL) {
 		counter_storage_free(counter_storage);
+	}
 
 	size_t ectx_size =
 		sizeof(struct pipeline_ectx) +
@@ -774,8 +781,9 @@ device_entry_ectx_free(
 		     ++idx) {
 			struct pipeline_ectx *pipeline_ectx =
 				ADDR_OF(pipelines + idx);
-			if (pipeline_ectx == NULL)
+			if (pipeline_ectx == NULL) {
 				continue;
+			}
 			pipeline_ectx_free(cp_config_gen, pipeline_ectx);
 		}
 
@@ -889,8 +897,9 @@ device_entry_ectx_create(
 	}
 	device_entry_ectx->pipeline_count = cp_device_entry->pipeline_count;
 
-	if (!device_entry_ectx->pipeline_count)
+	if (!device_entry_ectx->pipeline_count) {
 		return device_entry_ectx;
+	}
 
 	memset(pipelines,
 	       0,
@@ -951,17 +960,20 @@ device_ectx_free(
 
 	struct device_entry_ectx *input =
 		ADDR_OF(&device_ectx->input_pipelines);
-	if (input)
+	if (input) {
 		device_entry_ectx_free(cp_config_gen, input);
+	}
 	struct device_entry_ectx *output =
 		ADDR_OF(&device_ectx->output_pipelines);
-	if (output)
+	if (output) {
 		device_entry_ectx_free(cp_config_gen, output);
+	}
 
 	struct counter_storage *counter_storage =
 		ADDR_OF(&device_ectx->counter_storage);
-	if (counter_storage != NULL)
+	if (counter_storage != NULL) {
 		counter_storage_free(counter_storage);
+	}
 
 	size_t ectx_size = sizeof(struct device_ectx);
 	memory_bfree(memory_context, device_ectx, ectx_size);
@@ -1152,8 +1164,9 @@ link_module_ectx(
 		);
 		goto error;
 	}
-	for (uint64_t idx = 0; idx < config_gen_ectx->device_count; ++idx)
+	for (uint64_t idx = 0; idx < config_gen_ectx->device_count; ++idx) {
 		cm_index[idx] = 0;
+	}
 	SET_OFFSET_OF(&module_ectx->cm_index, cm_index);
 	module_ectx->cm_index_size = config_gen_ectx->device_count;
 
@@ -1170,8 +1183,9 @@ link_module_ectx(
 		);
 		goto error;
 	}
-	for (uint64_t idx = 0; idx < cp_module->device_count; ++idx)
+	for (uint64_t idx = 0; idx < cp_module->device_count; ++idx) {
 		mc_index[idx] = -1;
+	}
 	SET_OFFSET_OF(&module_ectx->mc_index, mc_index);
 	module_ectx->mc_index_size = cp_module->device_count;
 
@@ -1182,8 +1196,9 @@ link_module_ectx(
 		     ++c_idx) {
 			struct device_ectx *device_ectx =
 				ADDR_OF(config_gen_ectx->devices + c_idx);
-			if (device_ectx == NULL)
+			if (device_ectx == NULL) {
 				continue;
+			}
 			struct cp_device *cp_device =
 				ADDR_OF(&device_ectx->cp_device);
 			if (!strncmp(
@@ -1216,8 +1231,9 @@ link_chain_ectx(
 	for (uint64_t idx = 0; idx < chain_ectx->length; ++idx) {
 		struct module_ectx *module_ectx =
 			ADDR_OF(&chain_ectx->modules[idx].module_ectx);
-		if (module_ectx == NULL)
+		if (module_ectx == NULL) {
 			continue;
+		}
 		if (link_module_ectx(
 			    config_gen_ectx,
 			    device_ectx,
@@ -1253,8 +1269,9 @@ link_function_ectx(
 	struct chain_ectx **chains = ADDR_OF(&function_ectx->chains);
 	for (uint64_t idx = 0; idx < function_ectx->chain_count; ++idx) {
 		struct chain_ectx *chain_ectx = ADDR_OF(chains + idx);
-		if (chain_ectx == NULL)
+		if (chain_ectx == NULL) {
 			continue;
+		}
 		if (link_chain_ectx(
 			    config_gen_ectx,
 			    device_ectx,
@@ -1288,8 +1305,9 @@ link_pipeline_ectx(
 	for (uint64_t idx = 0; idx < pipeline_ectx->length; ++idx) {
 		struct function_ectx *function_ectx =
 			ADDR_OF(pipeline_ectx->functions + idx);
-		if (function_ectx == NULL)
+		if (function_ectx == NULL) {
 			continue;
+		}
 		if (link_function_ectx(
 			    config_gen_ectx,
 			    device_ectx,
@@ -1322,8 +1340,9 @@ link_device_entry_ectx(
 		ADDR_OF(&device_entry_ectx->pipelines);
 	for (uint64_t idx = 0; idx < device_entry_ectx->pipeline_count; ++idx) {
 		struct pipeline_ectx *pipeline_ectx = ADDR_OF(pipelines + idx);
-		if (pipeline_ectx == NULL)
+		if (pipeline_ectx == NULL) {
 			continue;
+		}
 		if (link_pipeline_ectx(
 			    config_gen_ectx,
 			    device_ectx,
@@ -1388,8 +1407,9 @@ link_config_gen_ectx(
 	for (uint64_t idx = 0; idx < config_gen_ectx->device_count; ++idx) {
 		struct device_ectx *device_ectx =
 			ADDR_OF(config_gen_ectx->devices + idx);
-		if (device_ectx == NULL)
+		if (device_ectx == NULL) {
 			continue;
+		}
 		if (link_device_ectx(config_gen_ectx, device_ectx, err)) {
 			yanet_error_add(
 				err, "failed to link device execution context"
@@ -1560,8 +1580,9 @@ error:
 	for (uint64_t worker_idx = 0; worker_idx < worker_count; ++worker_idx) {
 		struct config_gen_ectx *config_gen_ectx =
 			ADDR_OF(ectxs + worker_idx);
-		if (config_gen_ectx != NULL)
+		if (config_gen_ectx != NULL) {
 			config_gen_ectx_free(cp_config_gen, config_gen_ectx);
+		}
 	}
 	memory_bfree(
 		memory_context,

--- a/lib/controlplane/config/econtext.h
+++ b/lib/controlplane/config/econtext.h
@@ -8,8 +8,9 @@ static inline struct device_ectx *
 config_gen_ectx_get_device(
 	struct config_gen_ectx *config_gen_ectx, uint64_t index
 ) {
-	if (index >= config_gen_ectx->device_count)
+	if (index >= config_gen_ectx->device_count) {
 		return NULL;
+	}
 	return ADDR_OF(config_gen_ectx->devices + index);
 }
 

--- a/lib/controlplane/config/registry.h
+++ b/lib/controlplane/config/registry.h
@@ -25,8 +25,9 @@ registry_item_unref(
 	void *free_func_data
 ) {
 	item->refcnt -= 1;
-	if (!item->refcnt)
+	if (!item->refcnt) {
 		free_func(item, free_func_data);
+	}
 }
 
 struct registry {
@@ -38,8 +39,9 @@ struct registry {
 static inline struct registry_item *
 registry_get(struct registry *registry, uint64_t idx) {
 #ifdef REGISTRY_SANITIZE
-	if (idx >= registry->capacity)
+	if (idx >= registry->capacity) {
 		return NULL;
+	}
 #endif
 	return ADDR_OF(ADDR_OF(&registry->items) + idx);
 }
@@ -49,8 +51,9 @@ registry_set(
 	struct registry *registry, uint64_t idx, struct registry_item *item
 ) {
 #ifdef REGISTRY_SANITIZE
-	if (idx >= registry->capacity)
+	if (idx >= registry->capacity) {
 		return;
+	}
 #endif
 	SET_OFFSET_OF(ADDR_OF(&registry->items) + idx, item);
 }
@@ -191,8 +194,9 @@ registry_lookup(
 ) {
 	for (uint64_t idx = 0; idx < registry->capacity; ++idx) {
 		struct registry_item *item = registry_get(registry, idx);
-		if (item == NULL)
+		if (item == NULL) {
 			continue;
+		}
 		if (!cmp_func(item, cmp_data)) {
 			*index = idx;
 			return 0;

--- a/lib/controlplane/config/zone.c
+++ b/lib/controlplane/config/zone.c
@@ -168,10 +168,11 @@ cp_config_gen_free(
 		     ++idx) {
 			struct config_gen_ectx *config_gen_ectx =
 				ADDR_OF(config_gen_ectxs + idx);
-			if (config_gen_ectx != NULL)
+			if (config_gen_ectx != NULL) {
 				config_gen_ectx_free(
 					config_gen, config_gen_ectx
 				);
+			}
 		}
 		memory_bfree(
 			&cp_config->ectx_memory_context,

--- a/lib/controlplane/config/zone.h
+++ b/lib/controlplane/config/zone.h
@@ -260,11 +260,13 @@ static inline struct config_gen_ectx *
 cp_config_gen_worker_ectx(
 	struct cp_config_gen *config_gen, uint64_t worker_idx
 ) {
-	if (worker_idx >= config_gen->config_gen_ectx_count)
+	if (worker_idx >= config_gen->config_gen_ectx_count) {
 		return NULL;
+	}
 	struct config_gen_ectx **ectxs = ADDR_OF(&config_gen->config_gen_ectxs);
-	if (ectxs == NULL)
+	if (ectxs == NULL) {
 		return NULL;
+	}
 	return ADDR_OF(ectxs + worker_idx);
 }
 

--- a/lib/counters/counters.c
+++ b/lib/counters/counters.c
@@ -14,8 +14,9 @@ counter_registry_init(
 	SET_OFFSET_OF(&registry->memory_context, memory_context);
 
 	registry->count = 0;
-	for (uint64_t idx = 0; idx < COUNTER_POOL_SIZE; ++idx)
+	for (uint64_t idx = 0; idx < COUNTER_POOL_SIZE; ++idx) {
 		registry->counts[idx] = 0;
+	}
 
 	registry->capacity = 0;
 	registry->gen = gen;
@@ -69,8 +70,9 @@ counter_registry_lookup_index(
 		registry
 	);
 
-	if (index != STR_INDEX_INVALID)
+	if (index != STR_INDEX_INVALID) {
 		return index;
+	}
 
 	return (uint64_t)-1;
 }
@@ -92,8 +94,9 @@ counter_registry_expand(
 		);
 		return -1;
 	}
-	if (new_capacity == registry->capacity)
+	if (new_capacity == registry->capacity) {
 		return 0;
+	}
 
 	struct memory_context *memory_context =
 		ADDR_OF(&registry->memory_context);
@@ -134,13 +137,15 @@ counter_registry_insert(
 	uint64_t gen,
 	yanet_error **err
 ) {
-	if (!size)
+	if (!size) {
 		return -1;
+	}
 
 	if (registry->count >= registry->capacity) {
 		uint64_t new_capacity = registry->capacity * 2;
-		if (new_capacity == 0)
+		if (new_capacity == 0) {
 			new_capacity = 8;
+		}
 		if (counter_registry_expand(registry, new_capacity, err)) {
 			yanet_error_add(
 				err, "failed to expand counter registry"
@@ -237,8 +242,9 @@ counter_registry_link(
 				ADDR_OF(&src->names) + src_idx;
 
 			// Skip outdated counters
-			if (src_name->gen != src->gen)
+			if (src_name->gen != src->gen) {
 				continue;
+			}
 
 			uint64_t dst_idx = counter_registry_lookup_index(
 				dst, src_name->name
@@ -297,8 +303,9 @@ counter_storage_new_page(struct memory_context *memory_context) {
 		(struct counter_storage_page *)memory_balloc(
 			memory_context, sizeof(struct counter_storage_page)
 		);
-	if (page == NULL)
+	if (page == NULL) {
 		return NULL;
+	}
 	memset(page, 0, sizeof(struct counter_storage_page));
 	return page;
 }
@@ -344,8 +351,9 @@ counter_storage_spawn(
 
 	struct counter_storage *new_counter_storage = (struct counter_storage *)
 		memory_balloc(memory_context, sizeof(struct counter_storage));
-	if (new_counter_storage == NULL)
+	if (new_counter_storage == NULL) {
 		return NULL;
+	}
 
 	counter_storage_init(
 		memory_context, new_counter_storage, counter_registry
@@ -474,16 +482,18 @@ static void
 counter_storage_pool_fini(
 	struct counter_storage *storage, struct counter_storage_pool *pool
 ) {
-	if (ADDR_OF(&pool->blocks) == NULL)
+	if (ADDR_OF(&pool->blocks) == NULL) {
 		return;
+	}
 
 	struct memory_context *memory_context =
 		ADDR_OF(&storage->memory_context);
 	for (uint64_t idx = 0; idx < pool->block_count; ++idx) {
 		struct counter_storage_block *block =
 			ADDR_OF(ADDR_OF(&pool->blocks) + idx);
-		if (block == NULL)
+		if (block == NULL) {
 			continue;
+		}
 
 		if (--block->refcnt == 0) {
 			memory_bfree(
@@ -508,11 +518,13 @@ counter_storage_pool_fini(
 
 void
 counter_storage_free(struct counter_storage *storage) {
-	if (storage == NULL)
+	if (storage == NULL) {
 		return;
+	}
 
-	if (--storage->refcnt > 0)
+	if (--storage->refcnt > 0) {
 		return;
+	}
 
 	struct memory_context *memory_context =
 		ADDR_OF(&storage->memory_context);

--- a/lib/counters/counters.h
+++ b/lib/counters/counters.h
@@ -121,8 +121,9 @@ counter_get_address(uint64_t counter_id, struct counter_storage *storage) {
 		counter_get_value_handle(counter_id, storage);
 
 #ifdef COUNTERS_CHECK
-	if (value_handle == NULL)
+	if (value_handle == NULL) {
 		return NULL;
+	}
 #endif
 
 	return counter_handle_get_value(value_handle);

--- a/lib/counters/histogram.h
+++ b/lib/counters/histogram.h
@@ -14,11 +14,13 @@ counter_hist_bucket_exp2(
 	uint64_t value, uint64_t min_bucket, uint64_t max_bucket
 ) {
 	uint64_t bucket = uint64_log_up(value);
-	if (bucket < min_bucket)
+	if (bucket < min_bucket) {
 		bucket = min_bucket;
+	}
 	bucket -= min_bucket;
-	if (bucket > max_bucket - 1)
+	if (bucket > max_bucket - 1) {
 		bucket = max_bucket - 1;
+	}
 
 	return bucket;
 }

--- a/lib/dataplane/config/plugin_loader.c
+++ b/lib/dataplane/config/plugin_loader.c
@@ -23,16 +23,20 @@ plugin_name_from_filename(const char *filename, char *name, size_t name_len) {
 	size_t suffix_len = strlen(PLUGIN_SO_SUFFIX);
 	size_t fn_len = strlen(filename);
 
-	if (fn_len <= prefix_len + suffix_len)
+	if (fn_len <= prefix_len + suffix_len) {
 		return -1;
-	if (strncmp(filename, PLUGIN_SO_PREFIX, prefix_len) != 0)
+	}
+	if (strncmp(filename, PLUGIN_SO_PREFIX, prefix_len) != 0) {
 		return -1;
-	if (strcmp(filename + fn_len - suffix_len, PLUGIN_SO_SUFFIX) != 0)
+	}
+	if (strcmp(filename + fn_len - suffix_len, PLUGIN_SO_SUFFIX) != 0) {
 		return -1;
+	}
 
 	size_t mod_len = fn_len - prefix_len - suffix_len;
-	if (mod_len >= name_len)
+	if (mod_len >= name_len) {
 		return -1;
+	}
 
 	memcpy(name, filename + prefix_len, mod_len);
 	name[mod_len] = '\0';
@@ -86,8 +90,9 @@ dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry) {
 		char name[PLUGIN_NAME_LEN];
 		if (plugin_name_from_filename(
 			    entry->d_name, name, sizeof(name)
-		    ) != 0)
+		    ) != 0) {
 			continue;
+		}
 
 		char so_path[512];
 		snprintf(
@@ -99,8 +104,9 @@ dp_load_plugins(const char *plugin_dir, struct plugin_registry *registry) {
 		);
 
 		struct stat st;
-		if (stat(so_path, &st) != 0 || !S_ISREG(st.st_mode))
+		if (stat(so_path, &st) != 0 || !S_ISREG(st.st_mode)) {
 			continue;
+		}
 
 		// A file matching the plugin filename pattern is an explicitly
 		// configured plugin. If it is present but broken, abort startup
@@ -176,8 +182,9 @@ fail:
 
 void
 dp_unload_plugins(struct plugin_registry *registry) {
-	if (registry->plugins == NULL)
+	if (registry->plugins == NULL) {
 		return;
+	}
 
 	for (uint64_t i = 0; i < registry->count; i++) {
 		struct plugin_handle *p = &registry->plugins[i];

--- a/lib/dataplane/packet/encap.c
+++ b/lib/dataplane/packet/encap.c
@@ -16,8 +16,9 @@ int
 packet_prepend(struct packet *packet, const void *header, const size_t size) {
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
-	if (rte_pktmbuf_prepend(mbuf, size) == NULL)
+	if (rte_pktmbuf_prepend(mbuf, size) == NULL) {
 		return -1;
+	}
 	memcpy(rte_pktmbuf_mtod(mbuf, char *), header, size);
 
 	packet->network_header.offset += size;
@@ -36,8 +37,9 @@ packet_network_prepend(
 ) {
 	struct rte_mbuf *mbuf = packet_to_mbuf(packet);
 
-	if (rte_pktmbuf_prepend(mbuf, size) == NULL)
+	if (rte_pktmbuf_prepend(mbuf, size) == NULL) {
 		return -1;
+	}
 	memmove(rte_pktmbuf_mtod(mbuf, char *),
 		rte_pktmbuf_mtod_offset(mbuf, char *, size),
 		packet->network_header.offset);
@@ -232,8 +234,9 @@ packet_mpls_encap(
 
 	if (packet_network_prepend(
 		    packet, rte_cpu_to_be_16(RTE_ETHER_TYPE_MPLS), &label, 4
-	    ))
+	    )) {
 		return -1;
+	}
 
 	return 0;
 }
@@ -290,16 +293,18 @@ packet_ip4_encap_udp(
 
 	if (packet_network_prepend(
 		    packet, 0, &udp_header, sizeof(struct rte_udp_hdr)
-	    ))
+	    )) {
 		return -1;
+	}
 
 	if (packet_network_prepend(
 		    packet,
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4),
 		    &ip_header,
 		    sizeof(struct rte_ipv4_hdr)
-	    ))
+	    )) {
 		return -1;
+	}
 
 	return 0;
 }
@@ -349,16 +354,18 @@ packet_ip6_encap_udp(
 
 	if (packet_network_prepend(
 		    packet, 0, &udp_header, sizeof(struct rte_udp_hdr)
-	    ))
+	    )) {
 		return -1;
+	}
 
 	if (packet_network_prepend(
 		    packet,
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6),
 		    &ip_header,
 		    sizeof(struct rte_ipv6_hdr)
-	    ))
+	    )) {
 		return -1;
+	}
 
 	return 0;
 }

--- a/lib/dataplane/packet/packet.h
+++ b/lib/dataplane/packet/packet.h
@@ -84,8 +84,9 @@ packet_list_first(struct packet_list *list) {
 static inline void
 packet_list_concat(struct packet_list *dst, struct packet_list *src) {
 	// Nothing to do if src is empty
-	if (src->first == NULL)
+	if (src->first == NULL) {
 		return;
+	}
 
 	// Replace dst with src if dst is empty
 	if (dst->first == NULL) {
@@ -103,12 +104,14 @@ packet_list_concat(struct packet_list *dst, struct packet_list *src) {
 static inline struct packet *
 packet_list_pop(struct packet_list *packets) {
 	struct packet *res = packets->first;
-	if (res == NULL)
+	if (res == NULL) {
 		return res;
+	}
 
 	packets->first = res->next;
-	if (packets->first == NULL)
+	if (packets->first == NULL) {
 		packets->last = NULL;
+	}
 
 	return res;
 }

--- a/lib/filter/compiler/device.c
+++ b/lib/filter/compiler/device.c
@@ -19,8 +19,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 	for (const struct filter_rule **r_ptr = rules;
 	     r_ptr < rules + rule_count;
 	     ++r_ptr) {
-		if (*r_ptr == NULL)
+		if (*r_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *r = *r_ptr;
 
 		for (uint16_t idx = 0; idx < r->device_count; ++idx) {
@@ -49,8 +50,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 	for (const struct filter_rule **r_ptr = rules;
 	     r_ptr < rules + rule_count;
 	     ++r_ptr) {
-		if (*r_ptr == NULL)
+		if (*r_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *r = *r_ptr;
 
 		if (r->device_count == 0) {
@@ -78,8 +80,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 			goto error_collect;
 		}
 
-		if (*r_ptr == NULL)
+		if (*r_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *r = *r_ptr;
 
 		if (r->device_count == 0) {
@@ -124,8 +127,9 @@ FILTER_ATTR_COMPILER_FREE_FUNC(device)(
 	void *data, struct memory_context *memory_context
 ) {
 	struct value_table *t = (struct value_table *)data;
-	if (t == NULL)
+	if (t == NULL) {
 		return;
+	}
 	value_table_free(t);
 	memory_bfree(memory_context, t, sizeof(struct value_table));
 }

--- a/lib/filter/compiler/helper.c
+++ b/lib/filter/compiler/helper.c
@@ -64,8 +64,9 @@ static int
 value_table_set_action(uint32_t v1, uint32_t v2, uint32_t idx, void *data) {
 	struct value_set_ctx *set_ctx = (struct value_set_ctx *)data;
 	uint32_t *value = value_table_get_ptr(set_ctx->table, v1, v2);
-	if (*value != FILTER_RULE_INVALID)
+	if (*value != FILTER_RULE_INVALID) {
 		return 0;
+	}
 	*value = idx;
 
 	return 0;
@@ -108,8 +109,9 @@ merge_and_set_registry_values(
 			    range_idx,
 			    value_table_set_action,
 			    &set_ctx
-		    ))
+		    )) {
 			goto error_join;
+		}
 	}
 
 	return 0;

--- a/lib/filter/compiler/ipfrag.c
+++ b/lib/filter/compiler/ipfrag.c
@@ -33,8 +33,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(ip_frag)(
 	for (const struct filter_rule **r_ptr = rules;
 	     r_ptr < rules + rule_count;
 	     ++r_ptr) {
-		if (*r_ptr == NULL)
+		if (*r_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *r = *r_ptr;
 
 		if (r->fragment == FILTER_IP_FRAG_ANY) {
@@ -42,10 +43,11 @@ FILTER_ATTR_COMPILER_INIT_FUNC(ip_frag)(
 		}
 		remap_table_new_gen(&remap_table);
 		uint32_t id;
-		if (r->fragment == FILTER_IP_FRAG_NONE)
+		if (r->fragment == FILTER_IP_FRAG_NONE) {
 			id = 0;
-		else
+		} else {
 			id = 1;
+		}
 		uint32_t *value = value_table_get_ptr(t, 0, id);
 		if (remap_table_touch(&remap_table, *value, value) < 0) {
 			goto error_touch;
@@ -63,8 +65,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(ip_frag)(
 		if (value_registry_start(registry)) {
 			goto error_collect;
 		}
-		if (*r_ptr == NULL)
+		if (*r_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *r = *r_ptr;
 
 		if (r->fragment == FILTER_IP_FRAG_ANY) {
@@ -73,8 +76,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(ip_frag)(
 			    ) ||
 			    value_registry_collect(
 				    registry, value_table_get(t, 0, 1)
-			    ))
+			    )) {
 				goto error_collect;
+			}
 		} else {
 			if (value_registry_collect(
 				    registry,
@@ -85,8 +89,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(ip_frag)(
 						    ? 0
 						    : 1
 				    )
-			    ))
+			    )) {
 				goto error_collect;
+			}
 		}
 	}
 	return 0;
@@ -110,8 +115,9 @@ FILTER_ATTR_COMPILER_FREE_FUNC(ip_frag)(
 	void *data, struct memory_context *memory_context
 ) {
 	struct value_table *t = (struct value_table *)data;
-	if (t == NULL)
+	if (t == NULL) {
 		return;
+	}
 	value_table_free(t);
 	memory_bfree(memory_context, t, sizeof(struct value_table));
 }

--- a/lib/filter/compiler/net4.c
+++ b/lib/filter/compiler/net4.c
@@ -38,8 +38,9 @@ net4_collect_values(
 	uint32_t *values = ADDR_OF(&range_index->values);
 
 	for (struct net4 *net4 = start; net4 < start + count; ++net4) {
-		if (*(uint32_t *)net4->mask == 0x00000000)
+		if (*(uint32_t *)net4->mask == 0x00000000) {
 			continue;
+		}
 		uint32_t to =
 			*(uint32_t *)net4->addr | ~*(uint32_t *)net4->mask;
 		filter_key_inc(4, (uint8_t *)&to);
@@ -47,10 +48,11 @@ net4_collect_values(
 		uint32_t start =
 			radix_lookup(&range_index->radix, 4, net4->addr);
 		uint32_t stop = range_index->count;
-		if (to != 0)
+		if (to != 0) {
 			stop = radix_lookup(
 				&range_index->radix, 4, (uint8_t *)&to
 			);
+		}
 
 		for (uint32_t idx = start; idx < stop; ++idx) {
 			uint32_t *value =
@@ -99,14 +101,16 @@ collect_net4_values(
 	struct value_registry *registry
 ) {
 	struct range_collector collector;
-	if (range_collector_init(&collector, memory_context))
+	if (range_collector_init(&collector, memory_context)) {
 		goto error;
+	}
 
 	for (const struct filter_rule **action_ptr = actions;
 	     action_ptr < actions + count;
 	     ++action_ptr) {
-		if (*action_ptr == NULL)
+		if (*action_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *action = *action_ptr;
 
 		if (action->net4.src_count == 0 &&
@@ -125,8 +129,9 @@ collect_net4_values(
 				    net4->addr,
 				    __builtin_popcountll(*(uint32_t *)net4->mask
 				    )
-			    ))
+			    )) {
 				goto error_collector;
+			}
 		}
 	}
 	if (lpm_init(lpm, memory_context)) {
@@ -146,12 +151,14 @@ collect_net4_values(
 	}
 
 	struct value_table table;
-	if (value_table_init(&table, memory_context, 1, collector.count))
+	if (value_table_init(&table, memory_context, 1, collector.count)) {
 		goto error_table;
+	}
 
 	struct remap_table remap_table;
-	if (remap_table_init(&remap_table, memory_context, collector.count))
+	if (remap_table_init(&remap_table, memory_context, collector.count)) {
 		goto error_remap;
+	}
 
 	for (const struct filter_rule **action_ptr = actions;
 	     action_ptr < actions + count;
@@ -159,8 +166,9 @@ collect_net4_values(
 
 		remap_table_new_gen(&remap_table);
 
-		if (*action_ptr == NULL)
+		if (*action_ptr == NULL) {
 			continue;
+		}
 
 		const struct filter_rule *action = *action_ptr;
 
@@ -187,8 +195,9 @@ collect_net4_values(
 			goto error_net_collect;
 		}
 
-		if (*action_ptr == NULL)
+		if (*action_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *action = *action_ptr;
 
 		struct net4 *nets;
@@ -289,8 +298,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(net4_dst)(
 static void
 free_net4(void *data, struct memory_context *memory_context) {
 	struct lpm *lpm = (struct lpm *)data;
-	if (lpm == NULL)
+	if (lpm == NULL) {
 		return;
+	}
 	lpm_free(lpm);
 	memory_bfree(memory_context, lpm, sizeof(struct lpm));
 }

--- a/lib/filter/compiler/net4_fast.c
+++ b/lib/filter/compiler/net4_fast.c
@@ -52,8 +52,9 @@ validate_and_count(
 ) {
 	int cnt = 0;
 	for (size_t i = 0; i < rules_count; ++i) {
-		if (rules[i] == NULL)
+		if (rules[i] == NULL) {
 			continue;
+		}
 		struct net4_count n4_count = getter(rules[i]);
 		for (size_t j = 0; j < n4_count.count; ++j) {
 			if (!validate_net4(n4_count.net4 + j)) {
@@ -94,8 +95,9 @@ classifier_init(
 
 	size_t segment_idx = 0;
 	for (size_t rule_idx = 0; rule_idx < rules_count; ++rule_idx) {
-		if (rules[rule_idx] == NULL)
+		if (rules[rule_idx] == NULL) {
 			continue;
+		}
 		struct net4_count cur = getter(rules[rule_idx]);
 		for (size_t j = 0; j < cur.count; ++j) {
 			uint32_t from, to;

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -51,8 +51,9 @@ static inline void
 net6_normalize(struct net6 *src, struct net6 *dst) {
 	memcpy(dst->addr, src->addr, 16);
 	memcpy(dst->mask, src->mask, 16);
-	for (uint8_t idx = 0; idx < 16; ++idx)
+	for (uint8_t idx = 0; idx < 16; ++idx) {
 		dst->addr[idx] &= src->mask[idx];
+	}
 }
 
 static inline int
@@ -66,15 +67,17 @@ collect_net6_range(
 	struct range_index *ri
 ) {
 	struct range_collector collector;
-	if (range_collector_init(&collector, memory_context))
+	if (range_collector_init(&collector, memory_context)) {
 		goto error;
+	}
 
 	for (const struct filter_rule **action_ptr = actions;
 	     action_ptr < actions + count;
 	     ++action_ptr) {
 
-		if (*action_ptr == NULL)
+		if (*action_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *action = *action_ptr;
 
 		struct net6 *nets;
@@ -94,8 +97,9 @@ collect_net6_range(
 				    &collector,
 				    addr,
 				    __builtin_popcountll(*(uint64_t *)mask)
-			    ))
+			    )) {
 				goto error_collector;
+			}
 		}
 	}
 	if (lpm_init(lpm, memory_context)) {
@@ -155,8 +159,9 @@ net6_part_range_index_bound(
 	filter_key_inc(8, next);
 	*start = radix_lookup(&range_index->radix, 8, addr);
 	*stop = range_index->count;
-	if (*(uint64_t *)next != 0)
+	if (*(uint64_t *)next != 0) {
 		*stop = radix_lookup(&range_index->radix, 8, next);
+	}
 }
 
 /*
@@ -225,8 +230,9 @@ touch_network_ranges(
 
 			// Skip `any` network
 			if (*(uint64_t *)net6.mask == 0 &&
-			    *(uint64_t *)(net6.mask + 8) == 0)
+			    *(uint64_t *)(net6.mask + 8) == 0) {
 				continue;
+			}
 
 			uint32_t start_hi;
 			uint32_t stop_hi;
@@ -362,8 +368,9 @@ build_net6_info(
 	     action_ptr < actions + action_count;
 	     ++action_ptr) {
 
-		if (*action_ptr == NULL)
+		if (*action_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *action = *action_ptr;
 
 		struct net6 *rule_nets;
@@ -377,8 +384,9 @@ build_net6_info(
 			net6_normalize(rule_net, &net6);
 
 			if (radix_lookup(net_radix, 32, net6.addr) !=
-			    RADIX_VALUE_INVALID)
+			    RADIX_VALUE_INVALID) {
 				continue;
+			}
 
 			if (radix_insert(
 				    net_radix, 32, net6.addr, *net_count
@@ -415,8 +423,9 @@ build_net6_info(
 	     action_ptr < actions + action_count;
 	     ++action_ptr) {
 
-		if (*action_ptr == NULL)
+		if (*action_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *action = *action_ptr;
 
 		remap_table_new_gen(&net_remap);
@@ -445,15 +454,18 @@ build_net6_info(
 	value_table_compact(&net_table, &net_remap);
 	remap_table_free(&net_remap);
 
-	for (uint32_t idx = 0; idx < *net_count; ++idx)
-		if (value_table_get(&net_table, 0, idx) >= *net_range_count)
+	for (uint32_t idx = 0; idx < *net_count; ++idx) {
+		if (value_table_get(&net_table, 0, idx) >= *net_range_count) {
 			*net_range_count =
 				value_table_get(&net_table, 0, idx) + 1;
+		}
+	}
 	*net_ranges = (struct value_range *)memory_balloc(
 		memory_context, sizeof(struct value_range) * *net_range_count
 	);
-	if (*net_ranges == NULL)
+	if (*net_ranges == NULL) {
 		goto error_table;
+	}
 
 	memset(*net_ranges, 0, sizeof(struct value_range) * *net_range_count);
 	for (uint32_t net_idx = 0; net_idx < *net_count; ++net_idx) {
@@ -581,11 +593,13 @@ merge_net6_range(
 	     action_ptr < actions + count;
 	     ++action_ptr) {
 		// A value range should be created even for empty rules
-		if (value_registry_start(registry))
+		if (value_registry_start(registry)) {
 			goto error_registry;
+		}
 
-		if (*action_ptr == NULL)
+		if (*action_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *action = *action_ptr;
 
 		struct net6 *nets;
@@ -680,8 +694,9 @@ init_net6(
 ) {
 	struct net6_classifier *net6 =
 		memory_balloc(memory_context, sizeof(struct net6_classifier));
-	if (net6 == NULL)
+	if (net6 == NULL) {
 		return -1;
+	}
 	SET_OFFSET_OF(data, net6);
 
 	struct range_index ri_hi;
@@ -786,11 +801,13 @@ FILTER_ATTR_COMPILER_INIT_FUNC(net6_dst)(
 // Allows to free data for IPv6 classification.
 static inline void
 free_net6(void *data, struct memory_context *memory_context) {
-	if (data == NULL)
+	if (data == NULL) {
 		return;
+	}
 	struct net6_classifier *c = (struct net6_classifier *)data;
-	if (c == NULL)
+	if (c == NULL) {
 		return;
+	}
 	lpm_free(&c->lo);
 	lpm_free(&c->hi);
 	value_table_free(&c->comb);

--- a/lib/filter/compiler/net6_fast.c
+++ b/lib/filter/compiler/net6_fast.c
@@ -57,8 +57,9 @@ validate_and_count(
 ) {
 	int cnt = 0;
 	for (size_t i = 0; i < rules_count; ++i) {
-		if (rules[i] == NULL)
+		if (rules[i] == NULL) {
 			continue;
+		}
 		struct net6_count n6_count = getter(rules[i]);
 		for (size_t j = 0; j < n6_count.count; ++j) {
 			if (!validate_net6(n6_count.nets + j)) {
@@ -89,8 +90,9 @@ init_classifier_part(
 
 	size_t segment_idx = 0;
 	for (size_t rule_idx = 0; rule_idx < rules_count; ++rule_idx) {
-		if (rules[rule_idx] == NULL)
+		if (rules[rule_idx] == NULL) {
 			continue;
+		}
 		struct net6_count cur = getter(rules[rule_idx]);
 		for (size_t j = 0; j < cur.count; ++j) {
 			uint64_t from, to;

--- a/lib/filter/compiler/port.c
+++ b/lib/filter/compiler/port.c
@@ -21,8 +21,9 @@ collect_port_values(
 	struct value_table *table,
 	struct value_registry *registry
 ) {
-	if (value_table_init(table, memory_context, 1, 65536))
+	if (value_table_init(table, memory_context, 1, 65536)) {
 		return -1;
+	}
 
 	struct remap_table remap_table;
 	if (remap_table_init(&remap_table, memory_context, 65536)) {
@@ -35,8 +36,9 @@ collect_port_values(
 
 		remap_table_new_gen(&remap_table);
 
-		if (*action_ptr == NULL)
+		if (*action_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *action = *action_ptr;
 
 		struct filter_port_range *port_ranges;
@@ -45,8 +47,9 @@ collect_port_values(
 		for (struct filter_port_range *ports = port_ranges;
 		     ports < port_ranges + port_range_count;
 		     ++ports) {
-			if (ports->to - ports->from == 65535)
+			if (ports->to - ports->from == 65535) {
 				continue;
+			}
 			for (uint32_t port = ports->from; port <= ports->to;
 			     ++port) {
 				uint32_t *value =
@@ -71,8 +74,9 @@ collect_port_values(
 		if (value_registry_start(registry)) {
 			goto error_collect;
 		}
-		if (*action_ptr == NULL)
+		if (*action_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *action = *action_ptr;
 
 		struct filter_port_range *port_ranges;
@@ -200,8 +204,9 @@ FILTER_ATTR_COMPILER_FREE_FUNC(port_src)(
 	void *data, struct memory_context *memory_context
 ) {
 	struct value_table *table = (struct value_table *)data;
-	if (table == NULL)
+	if (table == NULL) {
 		return;
+	}
 
 	value_table_free(table);
 	memory_bfree(memory_context, table, sizeof(struct value_table));
@@ -212,8 +217,9 @@ FILTER_ATTR_COMPILER_FREE_FUNC(port_dst)(
 	void *data, struct memory_context *memory_context
 ) {
 	struct value_table *table = (struct value_table *)data;
-	if (table == NULL)
+	if (table == NULL) {
 		return;
+	}
 
 	value_table_free(table);
 	memory_bfree(memory_context, table, sizeof(struct value_table));

--- a/lib/filter/compiler/port_fast.c
+++ b/lib/filter/compiler/port_fast.c
@@ -32,8 +32,9 @@ validate_and_count(
 ) {
 	int cnt = 0;
 	for (size_t i = 0; i < rules_count; ++i) {
-		if (rules[i] == NULL)
+		if (rules[i] == NULL) {
 			continue;
+		}
 		struct filter_port_ranges ranges = getter(rules[i]);
 		if (!validate_port_ranges(ranges)) {
 			return -1;
@@ -66,8 +67,9 @@ classifier_init(
 		malloc(sizeof(struct segment_u16) * count);
 	size_t segment_idx = 0;
 	for (size_t rule_idx = 0; rule_idx < rules_count; ++rule_idx) {
-		if (rules[rule_idx] == NULL)
+		if (rules[rule_idx] == NULL) {
 			continue;
+		}
 		struct filter_port_ranges ranges = getter(rules[rule_idx]);
 		for (size_t range_idx = 0; range_idx < ranges.count;
 		     ++range_idx) {

--- a/lib/filter/compiler/proto.c
+++ b/lib/filter/compiler/proto.c
@@ -30,8 +30,9 @@ proto_classifier_init_internal(
 	for (const struct filter_rule **r_ptr = rules;
 	     r_ptr < rules + rule_count;
 	     ++r_ptr) {
-		if (*r_ptr == NULL)
+		if (*r_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *r = *r_ptr;
 
 		const struct filter_proto *proto = &r->transport.proto;
@@ -78,8 +79,9 @@ proto_classifier_init_internal(
 	     ++r_ptr) {
 		// A value range should be created even for empty rules
 		value_registry_start(registry);
-		if (*r_ptr == NULL)
+		if (*r_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *r = *r_ptr;
 		const struct filter_proto *proto = &r->transport.proto;
 		switch (proto->proto) {

--- a/lib/filter/compiler/proto_range.c
+++ b/lib/filter/compiler/proto_range.c
@@ -19,8 +19,9 @@ collect_proto_values(
 ) {
 	if (value_table_init(
 		    table, memory_context, 1, PROTO_RANGE_CLASSIFIER_MAX_VALUE
-	    ))
+	    )) {
 		return -1;
+	}
 
 	struct remap_table remap_table;
 	if (remap_table_init(
@@ -34,8 +35,9 @@ collect_proto_values(
 	for (const struct filter_rule **rule_ptr = rules;
 	     rule_ptr < rules + count;
 	     ++rule_ptr) {
-		if (*rule_ptr == NULL)
+		if (*rule_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *rule = *rule_ptr;
 
 		remap_table_new_gen(&remap_table);
@@ -72,8 +74,9 @@ collect_proto_values(
 		if (value_registry_start(registry)) {
 			goto error_collect;
 		}
-		if (*rule_ptr == NULL)
+		if (*rule_ptr == NULL) {
 			continue;
+		}
 
 		const struct filter_rule *rule = *rule_ptr;
 
@@ -138,8 +141,9 @@ void
 FILTER_ATTR_COMPILER_FREE_FUNC(proto_range)(
 	void *data, struct memory_context *memory_context
 ) {
-	if (data == NULL)
+	if (data == NULL) {
 		return;
+	}
 	struct proto_range_classifier *c =
 		(struct proto_range_classifier *)data;
 	value_table_free(&c->table);

--- a/lib/filter/compiler/proto_range_fast.c
+++ b/lib/filter/compiler/proto_range_fast.c
@@ -24,8 +24,9 @@ static int
 validate_and_count(const struct filter_rule **rules, size_t rules_count) {
 	int cnt = 0;
 	for (size_t i = 0; i < rules_count; ++i) {
-		if (rules[i] == NULL)
+		if (rules[i] == NULL) {
 			continue;
+		}
 		struct filter_proto_ranges ranges;
 		ranges.count = rules[i]->transport.proto_count;
 		ranges.items = rules[i]->transport.protos;
@@ -66,8 +67,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(proto_range_fast)(
 	size_t segment_idx = 0;
 	for (size_t rule_idx = 0; rule_idx < rule_count; ++rule_idx) {
 		const struct filter_rule *rule = rules[rule_idx];
-		if (rule == NULL)
+		if (rule == NULL) {
 			continue;
+		}
 		struct filter_proto_range *proto_ranges =
 			rule->transport.protos;
 		size_t proto_count = rule->transport.proto_count;
@@ -94,8 +96,9 @@ void
 FILTER_ATTR_COMPILER_FREE_FUNC(proto_range_fast)(
 	void *data, struct memory_context *memory_context
 ) {
-	if (data == NULL)
+	if (data == NULL) {
 		return;
+	}
 	struct proto_range_fast_classifier *c =
 		(struct proto_range_fast_classifier *)data;
 	segments_classifier_u16_fini(&c->classifier, memory_context);

--- a/lib/filter/compiler/segments.c
+++ b/lib/filter/compiler/segments.c
@@ -153,8 +153,9 @@ fill_registry_from_segments_u16(
 	for (size_t segment_idx = 0; segment_idx < segment_count;
 	     ++segment_idx) {
 		while (segments[segment_idx].label >= registry->range_count) {
-			if (value_registry_start(registry))
+			if (value_registry_start(registry)) {
 				return -1;
+			}
 		}
 
 		struct segment_u16 *segment = &segments[segment_idx];
@@ -349,8 +350,9 @@ fill_registry_from_segments_u32(
 	for (size_t segment_idx = 0; segment_idx < segment_count;
 	     ++segment_idx) {
 		while (segments[segment_idx].label >= registry->range_count) {
-			if (value_registry_start(registry))
+			if (value_registry_start(registry)) {
 				return -1;
+			}
 		}
 
 		struct segment_u32 *segment = &segments[segment_idx];
@@ -546,8 +548,9 @@ fill_registry_from_segments_u64(
 	for (size_t segment_idx = 0; segment_idx < segment_count;
 	     ++segment_idx) {
 		while (segments[segment_idx].label >= registry->range_count) {
-			if (value_registry_start(registry))
+			if (value_registry_start(registry)) {
 				return -1;
+			}
 		}
 
 		struct segment_u64 *segment = &segments[segment_idx];

--- a/lib/filter/compiler/vlan.c
+++ b/lib/filter/compiler/vlan.c
@@ -33,8 +33,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 	for (const struct filter_rule **r_ptr = rules;
 	     r_ptr < rules + rule_count;
 	     ++r_ptr) {
-		if (*r_ptr == NULL)
+		if (*r_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *r = *r_ptr;
 
 		if (r->vlan_range_count == 0) {
@@ -67,8 +68,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 		if (value_registry_start(registry)) {
 			goto error_collect;
 		}
-		if (*r_ptr == NULL)
+		if (*r_ptr == NULL) {
 			continue;
+		}
 		const struct filter_rule *r = *r_ptr;
 
 		if (r->vlan_range_count == 0) {
@@ -115,8 +117,9 @@ FILTER_ATTR_COMPILER_FREE_FUNC(vlan)(
 	void *data, struct memory_context *memory_context
 ) {
 	struct value_table *t = (struct value_table *)data;
-	if (t == NULL)
+	if (t == NULL) {
 		return;
+	}
 	value_table_free(t);
 	memory_bfree(memory_context, t, sizeof(struct value_table));
 }

--- a/lib/filter/query/device.h
+++ b/lib/filter/query/device.h
@@ -13,8 +13,9 @@ FILTER_ATTR_QUERY_FUNC(device)(
 	struct value_table *t = (struct value_table *)data;
 	for (uint32_t idx = 0; idx < count; ++idx) {
 		uint64_t device_id = packets[idx]->module_device_id;
-		if (device_id >= t->h_dim)
+		if (device_id >= t->h_dim) {
 			device_id = 0;
+		}
 		result[idx] = value_table_get(t, 0, device_id);
 	}
 }

--- a/lib/filter/query/net6.h
+++ b/lib/filter/query/net6.h
@@ -14,8 +14,9 @@ static inline void
 FILTER_ATTR_QUERY_FUNC(net6_dst)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	if (!count)
+	if (!count) {
 		return;
+	}
 
 	struct net6_classifier *c = (struct net6_classifier *)data;
 
@@ -59,8 +60,9 @@ static inline void
 FILTER_ATTR_QUERY_FUNC(net6_src)(
 	void *data, struct packet **packets, uint32_t *result, uint32_t count
 ) {
-	if (!count)
+	if (!count) {
 		return;
+	}
 
 	struct net6_classifier *c = (struct net6_classifier *)data;
 

--- a/lib/filter/tests/basic_net4_fast.c
+++ b/lib/filter/tests/basic_net4_fast.c
@@ -199,8 +199,9 @@ test_basic(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t i = 0; i < nets_count; i++)
+	for (size_t i = 0; i < nets_count; i++) {
 		rule_ptrs[i] = &rules[i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -396,8 +397,9 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[num_rules];
-	for (size_t i = 0; i < num_rules; i++)
+	for (size_t i = 0; i < num_rules; i++) {
 		rule_ptrs[i] = &rules[i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -521,8 +523,9 @@ stress(void *arena,
 	// Initialize both filters
 	const struct filter_rule **rule_ptrs =
 		malloc(sizeof(const struct filter_rule *) * num_rules);
-	for (size_t i = 0; i < num_rules; i++)
+	for (size_t i = 0; i < num_rules; i++) {
 		rule_ptrs[i] = &rules[i];
+	}
 
 	struct filter filter;
 	switch (sign) {
@@ -726,8 +729,9 @@ test_no_match(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t i = 0; i < nets_count; i++)
+	for (size_t i = 0; i < nets_count; i++) {
 		rule_ptrs[i] = &rules[i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -856,8 +860,9 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t i = 0; i < nets_count; i++)
+	for (size_t i = 0; i < nets_count; i++) {
 		rule_ptrs[i] = &rules[i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -979,8 +984,9 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t i = 0; i < nets_count; i++)
+	for (size_t i = 0; i < nets_count; i++) {
 		rule_ptrs[i] = &rules[i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -1109,8 +1115,9 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t i = 0; i < nets_count; i++)
+	for (size_t i = 0; i < nets_count; i++) {
 		rule_ptrs[i] = &rules[i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -1240,8 +1247,9 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t i = 0; i < nets_count; i++)
+	for (size_t i = 0; i < nets_count; i++) {
 		rule_ptrs[i] = &rules[i];
+	}
 
 	struct filter filter;
 	if (sign == src) {

--- a/lib/filter/tests/basic_net6_fast.c
+++ b/lib/filter/tests/basic_net6_fast.c
@@ -214,8 +214,9 @@ test_basic(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -526,8 +527,9 @@ test_multiple_nets_per_rule(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[num_rules];
-	for (size_t rp_i = 0; rp_i < num_rules; rp_i++)
+	for (size_t rp_i = 0; rp_i < num_rules; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -661,8 +663,9 @@ stress(void *arena,
 	// Initialize filter
 	const struct filter_rule **rule_ptrs =
 		malloc(sizeof(const struct filter_rule *) * num_rules);
-	for (size_t rp_i = 0; rp_i < num_rules; rp_i++)
+	for (size_t rp_i = 0; rp_i < num_rules; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	switch (sign) {
@@ -885,8 +888,9 @@ test_no_match(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -1117,8 +1121,9 @@ test_overlapping_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -1301,8 +1306,9 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -1454,8 +1460,9 @@ test_single_host_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -1648,8 +1655,9 @@ test_adjacent_networks(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[nets_count];
-	for (size_t rp_i = 0; rp_i < nets_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < nets_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {

--- a/lib/filter/tests/basic_port_fast.c
+++ b/lib/filter/tests/basic_port_fast.c
@@ -196,8 +196,9 @@ test_basic(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[ranges_count];
-	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -344,8 +345,9 @@ test_multiple_ranges_per_rule(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[num_rules];
-	for (size_t rp_i = 0; rp_i < num_rules; rp_i++)
+	for (size_t rp_i = 0; rp_i < num_rules; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -459,8 +461,9 @@ stress(void *arena,
 	// Initialize filter
 	const struct filter_rule **rule_ptrs =
 		malloc(sizeof(const struct filter_rule *) * num_rules);
-	for (size_t rp_i = 0; rp_i < num_rules; rp_i++)
+	for (size_t rp_i = 0; rp_i < num_rules; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	switch (sign) {
@@ -538,8 +541,9 @@ stress(void *arena,
 						break;
 					}
 				}
-				if (!src_match)
+				if (!src_match) {
 					ok = 0;
+				}
 			}
 
 			if (check_dst) {
@@ -555,8 +559,9 @@ stress(void *arena,
 						break;
 					}
 				}
-				if (!dst_match)
+				if (!dst_match) {
 					ok = 0;
+				}
 			}
 
 			if (ok && expected_ranges[packet_idx] ==
@@ -705,8 +710,9 @@ test_no_match(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[ranges_count];
-	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -843,8 +849,9 @@ test_overlapping_ranges(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[ranges_count];
-	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -974,8 +981,9 @@ test_boundary_conditions(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[ranges_count];
-	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -1117,8 +1125,9 @@ test_single_port_ranges(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[ranges_count];
-	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -1255,8 +1264,9 @@ test_adjacent_ranges(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[ranges_count];
-	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {
@@ -1397,8 +1407,9 @@ test_extreme_ports(void *arena, enum filter_sign sign) {
 	TEST_ASSERT_EQUAL(res, 0, "failed to initialize memory context");
 
 	const struct filter_rule *rule_ptrs[ranges_count];
-	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++)
+	for (size_t rp_i = 0; rp_i < ranges_count; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	if (sign == src) {

--- a/lib/filter/tests/basic_proto_range_fast.c
+++ b/lib/filter/tests/basic_proto_range_fast.c
@@ -72,8 +72,9 @@ test_basic_tcp_udp(void *memory) {
 	struct filter_rule rules[2] = {r1, r2};
 
 	const struct filter_rule *rule_ptrs[2];
-	for (size_t rp_i = 0; rp_i < 2; rp_i++)
+	for (size_t rp_i = 0; rp_i < 2; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 
@@ -139,8 +140,9 @@ test_tcp_flags(void *memory) {
 	struct filter_rule rules[3] = {r1, r2, r3};
 
 	const struct filter_rule *rule_ptrs[3];
-	for (size_t rp_i = 0; rp_i < 3; rp_i++)
+	for (size_t rp_i = 0; rp_i < 3; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	res = filter_init(
@@ -194,8 +196,9 @@ test_multiple_ranges_per_rule(void *memory) {
 	struct filter_rule rules[1] = {r1};
 
 	const struct filter_rule *rule_ptrs[1];
-	for (size_t rp_i = 0; rp_i < 1; rp_i++)
+	for (size_t rp_i = 0; rp_i < 1; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	res = filter_init(
@@ -247,8 +250,9 @@ test_boundary_values(void *memory) {
 	struct filter_rule rules[2] = {r1, r2};
 
 	const struct filter_rule *rule_ptrs[2];
-	for (size_t rp_i = 0; rp_i < 2; rp_i++)
+	for (size_t rp_i = 0; rp_i < 2; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	res = filter_init(

--- a/lib/filter/tests/bench_net4.c
+++ b/lib/filter/tests/bench_net4.c
@@ -541,8 +541,9 @@ main(int argc, char **argv) {
 	printf("Initializing filter...\n");
 	const struct filter_rule **rule_ptrs =
 		malloc(sizeof(const struct filter_rule *) * config.num_rules);
-	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++)
+	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	switch (config.sig_type) {

--- a/lib/filter/tests/bench_net4_fast.c
+++ b/lib/filter/tests/bench_net4_fast.c
@@ -556,8 +556,9 @@ main(int argc, char **argv) {
 	printf("Initializing filter...\n");
 	const struct filter_rule **rule_ptrs =
 		malloc(sizeof(const struct filter_rule *) * config.num_rules);
-	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++)
+	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	switch (config.sig_type) {

--- a/lib/filter/tests/bench_net6.c
+++ b/lib/filter/tests/bench_net6.c
@@ -587,8 +587,9 @@ main(int argc, char **argv) {
 	printf("Initializing filter...\n");
 	const struct filter_rule **rule_ptrs =
 		malloc(sizeof(const struct filter_rule *) * config.num_rules);
-	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++)
+	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	switch (config.sig_type) {

--- a/lib/filter/tests/bench_net6_fast.c
+++ b/lib/filter/tests/bench_net6_fast.c
@@ -590,8 +590,9 @@ main(int argc, char **argv) {
 	printf("Initializing filter...\n");
 	const struct filter_rule **rule_ptrs =
 		malloc(sizeof(const struct filter_rule *) * config.num_rules);
-	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++)
+	for (size_t rp_i = 0; rp_i < config.num_rules; rp_i++) {
 		rule_ptrs[rp_i] = &rules[rp_i];
+	}
 
 	struct filter filter;
 	switch (config.sig_type) {

--- a/lib/utils/packet.c
+++ b/lib/utils/packet.c
@@ -40,10 +40,11 @@ make_mbuf4(
 
 	uint16_t total_len =
 		sizeof(struct rte_ether_hdr) + sizeof(struct rte_ipv4_hdr);
-	if (proto == IPPROTO_UDP)
+	if (proto == IPPROTO_UDP) {
 		total_len += sizeof(struct rte_udp_hdr);
-	else
+	} else {
 		total_len += sizeof(struct rte_tcp_hdr);
+	}
 
 	mbuf->buf_addr = ((char *)mbuf) + sizeof(struct rte_mbuf);
 	mbuf->data_len = MBUF_MAX_SIZE;

--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -741,8 +741,9 @@ acl_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (acl_module_init_ip4(
 		    cp_module,
@@ -751,8 +752,9 @@ acl_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (acl_module_init_ip4_port(
 		    cp_module,
@@ -761,8 +763,9 @@ acl_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (acl_module_init_ip6(
 		    cp_module,
@@ -771,8 +774,9 @@ acl_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (acl_module_init_ip6_port(
 		    cp_module,
@@ -781,8 +785,9 @@ acl_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (acl_module_init_net6_share(
 		    cp_module,
@@ -791,8 +796,9 @@ acl_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	clock_gettime(CLOCK_MONOTONIC, &ts_end);
 	config->compilation_time_ns =

--- a/modules/acl/dataplane/dataplane.c
+++ b/modules/acl/dataplane/dataplane.c
@@ -476,8 +476,9 @@ acl_handle_packets(
 			}
 		}
 
-		if (action != FILTER_RULE_INVALID)
+		if (action != FILTER_RULE_INVALID) {
 			target = ADDR_OF(&acl_config->targets) + action;
+		}
 
 		const uint64_t pkt_len = packet_data_len(packet);
 

--- a/modules/decap/api/controlplane.c
+++ b/modules/decap/api/controlplane.c
@@ -76,10 +76,12 @@ decap_module_config_data_init(
 	struct decap_module_config *config,
 	struct memory_context *memory_context
 ) {
-	if (lpm_init(&config->prefixes4, memory_context))
+	if (lpm_init(&config->prefixes4, memory_context)) {
 		return -1;
-	if (lpm_init(&config->prefixes6, memory_context))
+	}
+	if (lpm_init(&config->prefixes6, memory_context)) {
 		goto error_lpm_v6;
+	}
 
 	return 0;
 

--- a/modules/dscp/api/controlplane.c
+++ b/modules/dscp/api/controlplane.c
@@ -76,8 +76,9 @@ int
 dscp_module_config_data_init(
 	struct dscp_module_config *config, struct memory_context *memory_context
 ) {
-	if (lpm_init(&config->lpm_v4, memory_context))
+	if (lpm_init(&config->lpm_v4, memory_context)) {
 		return -1;
+	}
 	if (lpm_init(&config->lpm_v6, memory_context)) {
 		lpm_free(&config->lpm_v4);
 		return -1;

--- a/modules/forward/api/controlplane.c
+++ b/modules/forward/api/controlplane.c
@@ -355,8 +355,9 @@ forward_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (forward_module_init_ip4(
 		    cp_module,
@@ -365,8 +366,9 @@ forward_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (forward_module_init_ip6(
 		    cp_module,
@@ -375,8 +377,9 @@ forward_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	free(filter_rule_ptrs);
 	free(filter_rules);

--- a/modules/forward/dataplane/dataplane.c
+++ b/modules/forward/dataplane/dataplane.c
@@ -99,18 +99,21 @@ forward_handle_packets(
 
 		if (packet->network_header.type ==
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
-			if (ip4_result[ip4_idx] < action)
+			if (ip4_result[ip4_idx] < action) {
 				action = ip4_result[ip4_idx];
+			}
 			++ip4_idx;
 		} else if (packet->network_header.type ==
 			   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
-			if (ip6_result[ip6_idx] < action)
+			if (ip6_result[ip6_idx] < action) {
 				action = ip6_result[ip6_idx];
+			}
 			++ip6_idx;
 		}
 
-		if (action != FILTER_RULE_INVALID)
+		if (action != FILTER_RULE_INVALID) {
 			target = ADDR_OF(&forward_config->targets) + action;
+		}
 
 		if (target != NULL) {
 			uint64_t *counters = counter_get_address(

--- a/modules/mirror/api/controlplane.c
+++ b/modules/mirror/api/controlplane.c
@@ -347,8 +347,9 @@ mirror_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (mirror_module_init_ip4(
 		    cp_module,
@@ -357,8 +358,9 @@ mirror_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (mirror_module_init_ip6(
 		    cp_module,
@@ -367,8 +369,9 @@ mirror_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	free(filter_rule_ptrs);
 	free(filter_rules);

--- a/modules/mirror/dataplane/dataplane.c
+++ b/modules/mirror/dataplane/dataplane.c
@@ -114,18 +114,21 @@ mirror_handle_packets(
 
 		if (packet->network_header.type ==
 		    rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV4)) {
-			if (ip4_result[ip4_idx] < action)
+			if (ip4_result[ip4_idx] < action) {
 				action = ip4_result[ip4_idx];
+			}
 			++ip4_idx;
 		} else if (packet->network_header.type ==
 			   rte_cpu_to_be_16(RTE_ETHER_TYPE_IPV6)) {
-			if (ip6_result[ip6_idx] < action)
+			if (ip6_result[ip6_idx] < action) {
 				action = ip6_result[ip6_idx];
+			}
 			++ip6_idx;
 		}
 
-		if (action != FILTER_RULE_INVALID)
+		if (action != FILTER_RULE_INVALID) {
 			target = ADDR_OF(&mirror_config->targets) + action;
+		}
 
 		if (target != NULL) {
 			uint64_t *counters = counter_get_address(

--- a/modules/nat64/fuzzing/nat64w.c
+++ b/modules/nat64/fuzzing/nat64w.c
@@ -99,18 +99,20 @@ nat64_test_config(struct cp_module **cp_module) {
 	return 0;
 
 error_mappings:
-	if (config->mappings.list)
+	if (config->mappings.list) {
 		memory_bfree(
 			&config->cp_module.memory_context,
 			config->mappings.list,
 			sizeof(struct ip4to6) * config->mappings.count
 		);
-	if (config->prefixes.prefixes)
+	}
+	if (config->prefixes.prefixes) {
 		memory_bfree(
 			&config->cp_module.memory_context,
 			config->prefixes.prefixes,
 			sizeof(struct nat64_prefix) * config->prefixes.count
 		);
+	}
 
 error_lpm_prefixes:
 	lpm_free(&config->prefixes.v6_prefixes);

--- a/modules/nat64/tests/dataplane/commands.c
+++ b/modules/nat64/tests/dataplane/commands.c
@@ -62,17 +62,19 @@ cmd_autotest_parsed(
 	int ret = 0;
 
 	TAILQ_FOREACH(t, &commands_list, next) {
-		if (!strcmp(res->autotest, t->command))
+		if (!strcmp(res->autotest, t->command)) {
 			ret = t->callback();
+		}
 	}
 
 	last_test_result = ret;
-	if (ret == 0)
+	if (ret == 0) {
 		printf("Test OK\n");
-	else if (ret == TEST_SKIPPED)
+	} else if (ret == TEST_SKIPPED) {
 		printf("Test Skipped\n");
-	else
+	} else {
 		printf("Test Failed\n");
+	}
 	fflush(stdout);
 }
 
@@ -113,24 +115,25 @@ cmd_dump_parsed(
 ) {
 	struct cmd_dump_result *res = parsed_result;
 
-	if (!strcmp(res->dump, "dump_physmem"))
+	if (!strcmp(res->dump, "dump_physmem")) {
 		rte_dump_physmem_layout(stdout);
-	else if (!strcmp(res->dump, "dump_memzone"))
+	} else if (!strcmp(res->dump, "dump_memzone")) {
 		rte_memzone_dump(stdout);
-	else if (!strcmp(res->dump, "dump_struct_sizes"))
+	} else if (!strcmp(res->dump, "dump_struct_sizes")) {
 		dump_struct_sizes();
-	else if (!strcmp(res->dump, "dump_ring"))
+	} else if (!strcmp(res->dump, "dump_ring")) {
 		rte_ring_list_dump(stdout);
-	else if (!strcmp(res->dump, "dump_mempool"))
+	} else if (!strcmp(res->dump, "dump_mempool")) {
 		rte_mempool_list_dump(stdout);
-	else if (!strcmp(res->dump, "dump_devargs"))
+	} else if (!strcmp(res->dump, "dump_devargs")) {
 		rte_devargs_dump(stdout);
-	else if (!strcmp(res->dump, "dump_log_types"))
+	} else if (!strcmp(res->dump, "dump_log_types")) {
 		rte_log_dump(stdout);
-	else if (!strcmp(res->dump, "dump_malloc_stats"))
+	} else if (!strcmp(res->dump, "dump_malloc_stats")) {
 		rte_malloc_dump_stats(stdout, NULL);
-	else if (!strcmp(res->dump, "dump_malloc_heaps"))
+	} else if (!strcmp(res->dump, "dump_malloc_heaps")) {
 		rte_malloc_dump_heaps(stdout);
+	}
 }
 
 cmdline_parse_token_string_t cmd_dump_dump = TOKEN_STRING_INITIALIZER(
@@ -257,13 +260,15 @@ commands_init(void) {
 	}
 
 	commands = (char *)calloc(commands_len, sizeof(char));
-	if (!commands)
+	if (!commands) {
 		return -1;
+	}
 
 	TAILQ_FOREACH(t, &commands_list, next) {
 		strlcat(commands, t->command, commands_len);
-		if (TAILQ_NEXT(t, next) != NULL)
+		if (TAILQ_NEXT(t, next) != NULL) {
 			strlcat(commands, "#", commands_len);
+		}
 	}
 
 	cmd_autotest_autotest.string_data.str = commands;

--- a/modules/nat64/tests/dataplane/main.c
+++ b/modules/nat64/tests/dataplane/main.c
@@ -99,17 +99,20 @@ main(int argc, char **argv) {
 			goto out;
 		}
 
-		for (i = 0; i < argc; i++)
+		for (i = 0; i < argc; i++) {
 			all_argv[i] = argv[i];
-		for (i = 0; i < eargc; i++)
+		}
+		for (i = 0; i < eargc; i++) {
 			all_argv[argc + i] = eargv[i];
+		}
 		all_argv[all_argc] = NULL;
 
 		/* call eal_init with combined args */
 		ret = rte_eal_init(all_argc, all_argv);
 		free(all_argv);
-	} else
+	} else {
 		ret = rte_eal_init(argc, argv);
+	}
 	if (ret < 0) {
 		ret = -1;
 		goto out;
@@ -142,10 +145,12 @@ main(int argc, char **argv) {
 
 	char *dpdk_test = getenv("YANET_TEST");
 
-	if (dpdk_test && strlen(dpdk_test) > 0)
+	if (dpdk_test && strlen(dpdk_test) > 0) {
 		tests[test_count++] = dpdk_test;
-	for (i = 1; i < argc; i++)
+	}
+	for (i = 1; i < argc; i++) {
 		tests[test_count++] = argv[i];
+	}
 
 	if (test_count > 0) {
 		char buf[1024];
@@ -168,10 +173,11 @@ main(int argc, char **argv) {
 				RTE_DIM(skip_tests),
 				','
 			);
-			if (split_ret > 0)
+			if (split_ret > 0) {
 				n_skip_tests = split_ret;
-			else
+			} else {
 				free(dpdk_test_skip);
+			}
 		}
 
 		cl = cmdline_new(main_ctx, "YANET>>", 0, 1);
@@ -201,15 +207,18 @@ main(int argc, char **argv) {
 			} else if (cmdline_in(cl, buf, strlen(buf)) < 0) {
 				printf("error on cmdline input\n");
 				ret = -1;
-			} else
+			} else {
 				ret = last_test_result;
+			}
 
 		end_of_cmd:
-			if (ret != 0 && ret != TEST_SKIPPED)
+			if (ret != 0 && ret != TEST_SKIPPED) {
 				break;
+			}
 		}
-		if (n_skip_tests > 0)
+		if (n_skip_tests > 0) {
 			free(dpdk_test_skip);
+		}
 
 		cmdline_free(cl);
 		goto out;
@@ -257,18 +266,20 @@ unit_test_suite_count_tcs_on_setup_fail(
 		suite->total += ts->total;
 		suite->failed += ts->failed;
 		suite->skipped += ts->skipped;
-		if (ts->failed)
+		if (ts->failed) {
 			(*sub_ts_failed)++;
-		else
+		} else {
 			(*sub_ts_skipped)++;
+		}
 		(*sub_ts_total)++;
 	}
 	FOR_EACH_SUITE_TESTCASE(i, suite, tc) {
 		suite->total++;
-		if (!tc.enabled || test_success == TEST_SKIPPED)
+		if (!tc.enabled || test_success == TEST_SKIPPED) {
 			suite->skipped++;
-		else
+		} else {
 			suite->failed++;
+		}
 	}
 }
 
@@ -335,30 +346,33 @@ unit_test_suite_runner(struct unit_test_suite *suite) {
 		}
 
 		/* run test case setup */
-		if (tc.setup)
+		if (tc.setup) {
 			test_success = tc.setup();
-		else
+		} else {
 			test_success = TEST_SUCCESS;
+		}
 
 		if (test_success == TEST_SUCCESS) {
 			/* run the test case */
-			if (tc.testcase)
+			if (tc.testcase) {
 				test_success = tc.testcase();
-			else if (tc.testcase_with_data)
+			} else if (tc.testcase_with_data) {
 				test_success = tc.testcase_with_data(tc.data);
-			else
+			} else {
 				test_success = -ENOTSUP;
+			}
 
-			if (test_success == TEST_SUCCESS)
+			if (test_success == TEST_SUCCESS) {
 				suite->succeeded++;
-			else if (test_success == TEST_SKIPPED) {
+			} else if (test_success == TEST_SKIPPED) {
 				suite->skipped++;
 				suite->executed--;
 			} else if (test_success == -ENOTSUP) {
 				suite->unsupported++;
 				suite->executed--;
-			} else
+			} else {
 				suite->failed++;
+			}
 		} else if (test_success == -ENOTSUP) {
 			suite->unsupported++;
 		} else if (test_success == TEST_SKIPPED) {
@@ -368,17 +382,19 @@ unit_test_suite_runner(struct unit_test_suite *suite) {
 		}
 
 		/* run the test case teardown */
-		if (tc.teardown)
+		if (tc.teardown) {
 			tc.teardown();
+		}
 
-		if (test_success == TEST_SUCCESS)
+		if (test_success == TEST_SUCCESS) {
 			status = "succeeded";
-		else if (test_success == TEST_SKIPPED)
+		} else if (test_success == TEST_SKIPPED) {
 			status = "skipped";
-		else if (test_success == -ENOTSUP)
+		} else if (test_success == -ENOTSUP) {
 			status = "unsupported";
-		else
+		} else {
 			status = "failed";
+		}
 
 		printf(" + TestCase [%2d] : %s %s\n",
 		       suite->total,
@@ -387,12 +403,13 @@ unit_test_suite_runner(struct unit_test_suite *suite) {
 	}
 	FOR_EACH_SUITE_TESTSUITE(i, suite, ts) {
 		ret = unit_test_suite_runner(ts);
-		if (ret == TEST_SUCCESS)
+		if (ret == TEST_SUCCESS) {
 			sub_ts_succeeded++;
-		else if (ret == TEST_SKIPPED)
+		} else if (ret == TEST_SKIPPED) {
 			sub_ts_skipped++;
-		else
+		} else {
 			sub_ts_failed++;
+		}
 		sub_ts_total++;
 
 		suite->total += ts->total;
@@ -404,8 +421,9 @@ unit_test_suite_runner(struct unit_test_suite *suite) {
 	}
 
 	/* Run test suite teardown */
-	if (suite->teardown)
+	if (suite->teardown) {
 		suite->teardown();
+	}
 
 	goto suite_summary;
 
@@ -453,9 +471,11 @@ suite_summary:
 
 	last_test_result = suite->failed;
 
-	if (suite->failed)
+	if (suite->failed) {
 		return TEST_FAILED;
-	if (suite->total == suite->skipped)
+	}
+	if (suite->total == suite->skipped) {
 		return TEST_SKIPPED;
+	}
 	return TEST_SUCCESS;
 }

--- a/modules/nat64/tests/dataplane/nat64_test.c
+++ b/modules/nat64/tests/dataplane/nat64_test.c
@@ -3751,10 +3751,12 @@ append_test_cases_from_mappings_icmp_more(struct test_case **test_case) {
 		);
 
 		if (!pkt_v4 || !pkt_v6) {
-			if (pkt_v4)
+			if (pkt_v4) {
 				rte_free(pkt_v4);
-			if (pkt_v6)
+			}
+			if (pkt_v6) {
 				rte_free(pkt_v6);
+			}
 			return -1;
 		}
 
@@ -5231,8 +5233,9 @@ static uint8_t *
 build_embedded_icmp_echo(uint16_t embedded_total_len, uint16_t *out_len) {
 	*out_len = sizeof(struct rte_ipv4_hdr) + sizeof(struct icmphdr);
 	uint8_t *buf = rte_malloc(NULL, *out_len, 0);
-	if (!buf)
+	if (!buf) {
 		return NULL;
+	}
 
 	struct rte_ipv4_hdr *ip4 = (struct rte_ipv4_hdr *)buf;
 	ip4->version_ihl = RTE_IPV4_VHL_DEF;

--- a/modules/nat64/tests/dataplane/test.h
+++ b/modules/nat64/tests/dataplane/test.h
@@ -167,8 +167,9 @@ struct unit_test_case {
 
 static inline void
 debug_hexdump(FILE *file, const char *title, const void *buf, size_t len) {
-	if (rte_log_get_global_level() == RTE_LOG_DEBUG)
+	if (rte_log_get_global_level() == RTE_LOG_DEBUG) {
 		rte_hexdump(file, title, buf, len);
+	}
 }
 
 struct unit_test_suite {

--- a/modules/route-mpls/api/controlplane.c
+++ b/modules/route-mpls/api/controlplane.c
@@ -63,8 +63,9 @@ route_mpls_module_config_fini(struct module_config *config) {
 	struct target **targets = ADDR_OF(&config->targets);
 	for (uint64_t idx = 0; idx < config->target_count; ++idx) {
 		struct target *target = ADDR_OF(targets + idx);
-		if (target == NULL)
+		if (target == NULL) {
 			continue;
+		}
 
 		if (ADDR_OF(&target->nexthops) != NULL) {
 			memory_bfree(
@@ -260,8 +261,9 @@ route_mpls_rule_target_new(
 	struct target *target = (struct target *)memory_balloc(
 		memory_context, target_memory_size(map_size)
 	);
-	if (target == NULL)
+	if (target == NULL) {
 		return NULL;
+	}
 
 	memset(target, 0, target_memory_size(map_size));
 	target->nexthop_map_size = map_size;
@@ -270,8 +272,9 @@ route_mpls_rule_target_new(
 		memory_context,
 		sizeof(struct nexthop) * route_mpls_rule->nexthop_count
 	);
-	if (nexthops == NULL)
+	if (nexthops == NULL) {
 		goto error_target;
+	}
 
 	memset(nexthops,
 	       0,
@@ -365,8 +368,9 @@ route_mpls_module_config_update(
 			cp_module, route_mpls_rules + idx, err
 		);
 
-		if (target == NULL)
+		if (target == NULL) {
 			goto error;
+		}
 
 		SET_OFFSET_OF(targets + idx, target);
 	}
@@ -398,8 +402,9 @@ route_mpls_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	if (route_mpls_module_init_ip6(
 		    cp_module,
@@ -408,8 +413,9 @@ route_mpls_module_config_update(
 		    filter_rules,
 		    filter_rule_ptrs,
 		    err
-	    ))
+	    )) {
 		goto error_rule_ptrs;
+	}
 
 	free(filter_rule_ptrs);
 	free(filter_rules);

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -128,8 +128,9 @@ route_module_config_data_init(
 	struct route_module_config *config,
 	struct memory_context *memory_context
 ) {
-	if (lpm_init(&config->lpm_v4, memory_context))
+	if (lpm_init(&config->lpm_v4, memory_context)) {
 		return -1;
+	}
 	if (lpm_init(&config->lpm_v6, memory_context)) {
 		lpm_free(&config->lpm_v4);
 		return -1;
@@ -353,8 +354,9 @@ route_module_config_fib_range_count_v6(struct cp_module *cp_module) {
 struct fib_iter *
 fib_iter_new(struct cp_module *cp_module) {
 	struct fib_iter *it = calloc(1, sizeof(*it));
-	if (it == NULL)
+	if (it == NULL) {
 		return NULL;
+	}
 	it->config =
 		container_of(cp_module, struct route_module_config, cp_module);
 	return it;
@@ -423,8 +425,9 @@ uint64_t
 fib_iter_nexthop_count(const struct fib_iter *it) {
 	uint32_t rli = it->lpm_it.cur_value;
 	struct route_module_config *config = it->config;
-	if (rli >= config->route_list_count)
+	if (rli >= config->route_list_count) {
 		return 0;
+	}
 	struct route_list *rls = ADDR_OF(&config->route_lists);
 	return rls[rli].count;
 }
@@ -434,18 +437,21 @@ static const struct route *
 fib_iter_resolve_route(const struct fib_iter *it, uint64_t nexthop_idx) {
 	uint32_t rli = it->lpm_it.cur_value;
 	struct route_module_config *config = it->config;
-	if (rli >= config->route_list_count)
+	if (rli >= config->route_list_count) {
 		return NULL;
+	}
 
 	struct route_list *rls = ADDR_OF(&config->route_lists);
 	struct route_list *rl = &rls[rli];
-	if (nexthop_idx >= rl->count)
+	if (nexthop_idx >= rl->count) {
 		return NULL;
+	}
 
 	uint64_t *route_indexes = ADDR_OF(&config->route_indexes);
 	uint64_t route_idx = route_indexes[rl->start + nexthop_idx];
-	if (route_idx >= config->route_count)
+	if (route_idx >= config->route_count) {
 		return NULL;
+	}
 
 	struct route *routes = ADDR_OF(&config->routes);
 	return &routes[route_idx];
@@ -456,10 +462,11 @@ fib_iter_nexthop_dst_mac(
 	const struct fib_iter *it, uint64_t nexthop_idx, struct ether_addr *dst
 ) {
 	const struct route *r = fib_iter_resolve_route(it, nexthop_idx);
-	if (r != NULL)
+	if (r != NULL) {
 		*dst = r->dst_addr;
-	else
+	} else {
 		memset(dst, 0, sizeof(*dst));
+	}
 }
 
 void
@@ -467,21 +474,24 @@ fib_iter_nexthop_src_mac(
 	const struct fib_iter *it, uint64_t nexthop_idx, struct ether_addr *dst
 ) {
 	const struct route *r = fib_iter_resolve_route(it, nexthop_idx);
-	if (r != NULL)
+	if (r != NULL) {
 		*dst = r->src_addr;
-	else
+	} else {
 		memset(dst, 0, sizeof(*dst));
+	}
 }
 
 const char *
 fib_iter_nexthop_device_name(const struct fib_iter *it, uint64_t nexthop_idx) {
 	const struct route *r = fib_iter_resolve_route(it, nexthop_idx);
-	if (r == NULL)
+	if (r == NULL) {
 		return "";
+	}
 
 	struct route_module_config *config = it->config;
 	struct cp_module_device *devices = ADDR_OF(&config->cp_module.devices);
-	if (r->device_id < config->cp_module.device_count)
+	if (r->device_id < config->cp_module.device_count) {
 		return devices[r->device_id].name;
+	}
 	return "";
 }

--- a/tests/common/balloc_bench.c
+++ b/tests/common/balloc_bench.c
@@ -27,8 +27,9 @@ get_time_us(void) {
 static inline uint64_t
 rng_next_bounded(uint64_t *r, uint64_t bound_inclusive) {
 	/* returns [0..bound_inclusive] */
-	if (bound_inclusive == 0)
+	if (bound_inclusive == 0) {
 		return 0;
+	}
 	return rng_next(r) % (bound_inclusive + 1);
 }
 
@@ -81,14 +82,18 @@ print_help(const char *argv0) {
 
 static void
 clamp_config(struct bench_config *cfg) {
-	if (cfg->max_pool >= MEMORY_BLOCK_ALLOCATOR_EXP)
+	if (cfg->max_pool >= MEMORY_BLOCK_ALLOCATOR_EXP) {
 		cfg->max_pool = MEMORY_BLOCK_ALLOCATOR_EXP - 1;
-	if (cfg->min_pool > cfg->max_pool)
+	}
+	if (cfg->min_pool > cfg->max_pool) {
 		cfg->min_pool = cfg->max_pool;
-	if (cfg->working_set == 0)
+	}
+	if (cfg->working_set == 0) {
 		cfg->working_set = 1;
-	if (cfg->arena_mb == 0)
+	}
+	if (cfg->arena_mb == 0) {
 		cfg->arena_mb = 1;
+	}
 }
 
 static int
@@ -219,10 +224,12 @@ main(int argc, char **argv) {
 		     ++attempt) {
 			req = pool_req_size(&ba, pool_idx);
 			p = memory_balloc(&mctx, req);
-			if (p != NULL)
+			if (p != NULL) {
 				break;
-			if (pool_idx == cfg.min_pool)
+			}
+			if (pool_idx == cfg.min_pool) {
 				break;
+			}
 			pool_idx--;
 		}
 		if (p == NULL) {
@@ -270,10 +277,12 @@ main(int argc, char **argv) {
 		     ++attempt) {
 			req = pool_req_size(&ba, pool_idx);
 			p = memory_balloc(&mctx, req);
-			if (p != NULL)
+			if (p != NULL) {
 				break;
-			if (pool_idx == cfg.min_pool)
+			}
+			if (pool_idx == cfg.min_pool) {
 				break;
+			}
 			pool_idx--;
 		}
 
@@ -317,8 +326,9 @@ main(int argc, char **argv) {
 
 	/* 7) Cleanup: free live blocks, teardown */
 	for (size_t i = 0; i < cfg.working_set; ++i) {
-		if (slots[i] != NULL)
+		if (slots[i] != NULL) {
 			memory_bfree(&mctx, slots[i], sizes[i]);
+		}
 	}
 
 	free(slots);

--- a/tests/common/btree_bench_u16.c
+++ b/tests/common/btree_bench_u16.c
@@ -241,10 +241,12 @@ benchmark_btree_u16(size_t num_elements) {
 		uint64_t iter_time = iter_end - iter_start;
 
 		total_time_ns += iter_time;
-		if (iter_time < min_time_ns)
+		if (iter_time < min_time_ns) {
 			min_time_ns = iter_time;
-		if (iter_time > max_time_ns)
+		}
+		if (iter_time > max_time_ns) {
 			max_time_ns = iter_time;
+		}
 
 		double iter_time_ms = iter_time / 1000000.0;
 		double searches_per_sec =
@@ -410,10 +412,12 @@ benchmark_btree_u16_upper_bounds(size_t num_elements) {
 		uint64_t iter_time = iter_end - iter_start;
 
 		total_time_ns += iter_time;
-		if (iter_time < min_time_ns)
+		if (iter_time < min_time_ns) {
 			min_time_ns = iter_time;
-		if (iter_time > max_time_ns)
+		}
+		if (iter_time > max_time_ns) {
 			max_time_ns = iter_time;
+		}
 
 		double iter_time_ms = iter_time / 1000000.0;
 		double searches_per_sec =

--- a/tests/common/btree_bench_u32.c
+++ b/tests/common/btree_bench_u32.c
@@ -241,10 +241,12 @@ benchmark_btree_u32(size_t num_elements) {
 		uint64_t iter_time = iter_end - iter_start;
 
 		total_time_ns += iter_time;
-		if (iter_time < min_time_ns)
+		if (iter_time < min_time_ns) {
 			min_time_ns = iter_time;
-		if (iter_time > max_time_ns)
+		}
+		if (iter_time > max_time_ns) {
 			max_time_ns = iter_time;
+		}
 
 		double iter_time_ms = iter_time / 1000000.0;
 		double searches_per_sec =
@@ -410,10 +412,12 @@ benchmark_btree_u32_upper_bounds(size_t num_elements) {
 		uint64_t iter_time = iter_end - iter_start;
 
 		total_time_ns += iter_time;
-		if (iter_time < min_time_ns)
+		if (iter_time < min_time_ns) {
 			min_time_ns = iter_time;
-		if (iter_time > max_time_ns)
+		}
+		if (iter_time > max_time_ns) {
 			max_time_ns = iter_time;
+		}
 
 		double iter_time_ms = iter_time / 1000000.0;
 		double searches_per_sec =

--- a/tests/common/btree_bench_u64.c
+++ b/tests/common/btree_bench_u64.c
@@ -240,10 +240,12 @@ benchmark_btree_u64(size_t num_elements) {
 		uint64_t iter_time = iter_end - iter_start;
 
 		total_time_ns += iter_time;
-		if (iter_time < min_time_ns)
+		if (iter_time < min_time_ns) {
 			min_time_ns = iter_time;
-		if (iter_time > max_time_ns)
+		}
+		if (iter_time > max_time_ns) {
 			max_time_ns = iter_time;
+		}
 
 		double iter_time_ms = iter_time / 1000000.0;
 		double searches_per_sec =
@@ -408,10 +410,12 @@ benchmark_btree_u64_upper_bounds(size_t num_elements) {
 		uint64_t iter_time = iter_end - iter_start;
 
 		total_time_ns += iter_time;
-		if (iter_time < min_time_ns)
+		if (iter_time < min_time_ns) {
 			min_time_ns = iter_time;
-		if (iter_time > max_time_ns)
+		}
+		if (iter_time > max_time_ns) {
 			max_time_ns = iter_time;
+		}
 
 		double iter_time_ms = iter_time / 1000000.0;
 		double searches_per_sec =

--- a/tests/common/btree_test.c
+++ b/tests/common/btree_test.c
@@ -2322,90 +2322,130 @@ main() {
 	int failed = 0;
 
 	// Run uint16_t tests
-	if (test_btree_u16_init_free() != TEST_SUCCESS)
+	if (test_btree_u16_init_free() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_empty() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_empty() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_single_element() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_single_element() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_lower_bound() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_lower_bound() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_upper_bound() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_upper_bound() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_large_dataset() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_large_dataset() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_duplicates() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_duplicates() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_sequential_searches() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_sequential_searches() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_boundary_values() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_boundary_values() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_power_of_2_sizes() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_power_of_2_sizes() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_upper_bounds_batch() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_upper_bounds_batch() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_upper_bounds_large_batch() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_upper_bounds_large_batch() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u16_sentinel_high_bit() != TEST_SUCCESS)
+	}
+	if (test_btree_u16_sentinel_high_bit() != TEST_SUCCESS) {
 		failed++;
+	}
 
 	// Run uint32_t tests
-	if (test_btree_u32_init_free() != TEST_SUCCESS)
+	if (test_btree_u32_init_free() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_empty() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_empty() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_single_element() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_single_element() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_lower_bound() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_lower_bound() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_upper_bound() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_upper_bound() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_large_dataset() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_large_dataset() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_duplicates() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_duplicates() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_sequential_searches() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_sequential_searches() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_boundary_values() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_boundary_values() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_power_of_2_sizes() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_power_of_2_sizes() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_upper_bounds_batch() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_upper_bounds_batch() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_upper_bounds_large_batch() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_upper_bounds_large_batch() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u32_sentinel_high_bit() != TEST_SUCCESS)
+	}
+	if (test_btree_u32_sentinel_high_bit() != TEST_SUCCESS) {
 		failed++;
+	}
 
 	// Run uint64_t tests
-	if (test_btree_u64_init_free() != TEST_SUCCESS)
+	if (test_btree_u64_init_free() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_empty() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_empty() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_single_element() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_single_element() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_lower_bound() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_lower_bound() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_upper_bound() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_upper_bound() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_basic() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_basic() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_large_dataset() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_large_dataset() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_duplicates() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_duplicates() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_sequential_searches() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_sequential_searches() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_boundary_values() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_boundary_values() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_power_of_2_sizes() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_power_of_2_sizes() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_upper_bounds_batch() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_upper_bounds_batch() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_upper_bounds_large_batch() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_upper_bounds_large_batch() != TEST_SUCCESS) {
 		failed++;
-	if (test_btree_u64_sentinel_high_bit() != TEST_SUCCESS)
+	}
+	if (test_btree_u64_sentinel_high_bit() != TEST_SUCCESS) {
 		failed++;
+	}
 
 	// Run various size tests
 	size_t ns[] = {
@@ -2425,12 +2465,15 @@ main() {
 		(1 << 14) - 1
 	};
 	for (size_t i = 0; i < sizeof(ns) / sizeof(size_t); i++) {
-		if (test_btree_u16_various_n(ns[i]) != TEST_SUCCESS)
+		if (test_btree_u16_various_n(ns[i]) != TEST_SUCCESS) {
 			failed++;
-		if (test_btree_u32_various_n(ns[i]) != TEST_SUCCESS)
+		}
+		if (test_btree_u32_various_n(ns[i]) != TEST_SUCCESS) {
 			failed++;
-		if (test_btree_u64_various_n(ns[i]) != TEST_SUCCESS)
+		}
+		if (test_btree_u64_various_n(ns[i]) != TEST_SUCCESS) {
 			failed++;
+		}
 	}
 
 	if (failed == 0) {

--- a/tests/common/hash_index_test.c
+++ b/tests/common/hash_index_test.c
@@ -28,8 +28,9 @@ static int
 match_item(uint32_t value, const void *data) {
 	const struct eq_context *ctx = (const struct eq_context *)data;
 	if (items[value].key == ctx->want_key &&
-	    items[value].tag == ctx->want_tag)
+	    items[value].tag == ctx->want_tag) {
 		return 0;
+	}
 	return 1;
 }
 
@@ -80,8 +81,9 @@ fixture_fini(struct fixture *fix) {
 static int
 test_single_insert_lookup(void) {
 	struct fixture fix;
-	if (fixture_init(&fix, ITEM_COUNT) != 0)
+	if (fixture_init(&fix, ITEM_COUNT) != 0) {
 		return TEST_FAILED;
+	}
 
 	items[0] = (struct test_item){.key = 42, .tag = 100};
 	TEST_ASSERT(
@@ -108,8 +110,9 @@ test_single_insert_lookup(void) {
 static int
 test_lookup_empty(void) {
 	struct fixture fix;
-	if (fixture_init(&fix, ITEM_COUNT) != 0)
+	if (fixture_init(&fix, ITEM_COUNT) != 0) {
 		return TEST_FAILED;
+	}
 
 	struct eq_context ctx = {.want_key = 1, .want_tag = 1};
 	uint32_t result =
@@ -127,8 +130,9 @@ test_lookup_empty(void) {
 static int
 test_zero_capacity(void) {
 	struct fixture fix;
-	if (fixture_init(&fix, 0) != 0)
+	if (fixture_init(&fix, 0) != 0) {
 		return TEST_FAILED;
+	}
 
 	TEST_ASSERT(fix.index.capacity == 0, "capacity must be 0");
 	TEST_ASSERT(fix.index.count == 0, "count must be 0");
@@ -156,8 +160,9 @@ test_zero_capacity(void) {
 static int
 test_distinct_keys(void) {
 	struct fixture fix;
-	if (fixture_init(&fix, ITEM_COUNT) != 0)
+	if (fixture_init(&fix, ITEM_COUNT) != 0) {
 		return TEST_FAILED;
+	}
 
 	for (uint32_t idx = 0; idx < 16; ++idx) {
 		items[idx] = (struct test_item){.key = idx * 7 + 3,
@@ -194,8 +199,9 @@ test_distinct_keys(void) {
 static int
 test_fill_capacity(void) {
 	struct fixture fix;
-	if (fixture_init(&fix, ITEM_COUNT) != 0)
+	if (fixture_init(&fix, ITEM_COUNT) != 0) {
 		return TEST_FAILED;
+	}
 
 	for (uint32_t idx = 0; idx < ITEM_COUNT; ++idx) {
 		items[idx] = (struct test_item){.key = idx * 7 + 1,
@@ -238,8 +244,9 @@ test_fill_capacity(void) {
 static int
 test_same_hash_multiple_values(void) {
 	struct fixture fix;
-	if (fixture_init(&fix, ITEM_COUNT) != 0)
+	if (fixture_init(&fix, ITEM_COUNT) != 0) {
 		return TEST_FAILED;
+	}
 
 	items[0] = (struct test_item){.key = 7, .tag = 10};
 	items[1] = (struct test_item){.key = 7, .tag = 20};
@@ -277,8 +284,9 @@ test_same_hash_multiple_values(void) {
 static int
 test_fini_idempotent(void) {
 	struct fixture fix;
-	if (fixture_init(&fix, ITEM_COUNT) != 0)
+	if (fixture_init(&fix, ITEM_COUNT) != 0) {
 		return TEST_FAILED;
+	}
 
 	items[0] = (struct test_item){.key = 1, .tag = 1};
 	TEST_ASSERT(

--- a/tests/common/lpm_test.c
+++ b/tests/common/lpm_test.c
@@ -35,17 +35,20 @@ walk_func(
 	if (read_u32(from + 8) != htobe32(value * 256)) {
 		return -1;
 	}
-	if (from[15] != 4)
+	if (from[15] != 4) {
 		return -1;
+	}
 
 	if (read_u32(to + 8) != htobe32(value * 256)) {
 		return -1;
 	}
-	if (to[15] != 8)
+	if (to[15] != 8) {
 		return -1;
+	}
 
-	if (value != *(uint32_t *)check)
+	if (value != *(uint32_t *)check) {
 		return -1;
+	}
 
 	++(*(uint32_t *)check);
 	return 0;
@@ -56,8 +59,9 @@ walk_func(
 static int
 test_overlapping_prefixes(void) {
 	void *arena = malloc(ARENA_SIZE);
-	if (arena == NULL)
+	if (arena == NULL) {
 		return -1;
+	}
 
 	struct block_allocator ba;
 	block_allocator_init(&ba);
@@ -140,8 +144,9 @@ main(int argc, char **argv) {
 		from[15] = 4;
 		write_u32(to + 8, htobe32(idx * 256));
 		to[15] = 8;
-		if (lpm_insert(&lpm, 16, from, to, idx))
+		if (lpm_insert(&lpm, 16, from, to, idx)) {
 			break;
+		}
 		++idx;
 	} while (1);
 	uint32_t fail_idx = idx;
@@ -166,8 +171,9 @@ main(int argc, char **argv) {
 		from[15] = 4;
 		write_u32(to + 8, htobe32(idx * 256));
 		to[15] = 8;
-		if (lpm_insert(&lpm, 16, from, to, idx))
+		if (lpm_insert(&lpm, 16, from, to, idx)) {
 			break;
+		}
 		++idx;
 	} while (1);
 

--- a/tests/common/lpm_wide_test.c
+++ b/tests/common/lpm_wide_test.c
@@ -35,17 +35,20 @@ walk_func(
 	if (read_u32(from + 8) != htobe32(value * 256)) {
 		return -1;
 	}
-	if (from[15] != 4)
+	if (from[15] != 4) {
 		return -1;
+	}
 
 	if (read_u32(to + 8) != htobe32(value * 256)) {
 		return -1;
 	}
-	if (to[15] != 8)
+	if (to[15] != 8) {
 		return -1;
+	}
 
-	if (value != *(uint32_t *)check)
+	if (value != *(uint32_t *)check) {
 		return -1;
+	}
 
 	++(*(uint32_t *)check);
 	return 0;
@@ -56,8 +59,9 @@ walk_func(
 static int
 test_overlapping_prefixes(void) {
 	void *arena = malloc(ARENA_SIZE);
-	if (arena == NULL)
+	if (arena == NULL) {
 		return -1;
+	}
 
 	struct block_allocator ba;
 	block_allocator_init(&ba);
@@ -140,8 +144,9 @@ main(int argc, char **argv) {
 		from[15] = 4;
 		write_u32(to + 8, htobe32(idx * 256));
 		to[15] = 8;
-		if (lpm_wide_insert(&lpm, 16, from, to, idx))
+		if (lpm_wide_insert(&lpm, 16, from, to, idx)) {
 			break;
+		}
 		++idx;
 	} while (1);
 	uint32_t fail_idx = idx;
@@ -166,8 +171,9 @@ main(int argc, char **argv) {
 		from[15] = 4;
 		write_u32(to + 8, htobe32(idx * 256));
 		to[15] = 8;
-		if (lpm_wide_insert(&lpm, 16, from, to, idx))
+		if (lpm_wide_insert(&lpm, 16, from, to, idx)) {
 			break;
+		}
 		++idx;
 	} while (1);
 

--- a/tests/common/rcu_bench.c
+++ b/tests/common/rcu_bench.c
@@ -237,10 +237,12 @@ benchmark_contention(void) {
 	uint64_t sum_time = 0;
 
 	for (size_t i = 0; i < BENCH_WORKERS; i++) {
-		if (worker_times[i] < min_time)
+		if (worker_times[i] < min_time) {
 			min_time = worker_times[i];
-		if (worker_times[i] > max_time)
+		}
+		if (worker_times[i] > max_time) {
 			max_time = worker_times[i];
+		}
 		sum_time += worker_times[i];
 	}
 
@@ -295,10 +297,12 @@ benchmark_latency_distribution(void) {
 	uint64_t sum_lat = 0;
 
 	for (size_t i = 0; i < num_samples; i++) {
-		if (latencies[i] < min_lat)
+		if (latencies[i] < min_lat) {
 			min_lat = latencies[i];
-		if (latencies[i] > max_lat)
+		}
+		if (latencies[i] > max_lat) {
 			max_lat = latencies[i];
+		}
 		sum_lat += latencies[i];
 	}
 
@@ -488,10 +492,12 @@ benchmark_reader_writer_interaction(size_t num_readers) {
 		(updates < max_latencies) ? updates : max_latencies;
 
 	for (size_t i = 0; i < num_latencies; i++) {
-		if (update_latencies[i] < min_update_lat)
+		if (update_latencies[i] < min_update_lat) {
 			min_update_lat = update_latencies[i];
-		if (update_latencies[i] > max_update_lat)
+		}
+		if (update_latencies[i] > max_update_lat) {
 			max_update_lat = update_latencies[i];
+		}
 		sum_update_lat += update_latencies[i];
 	}
 

--- a/tests/fwstate/fwmap_basic_test.c
+++ b/tests/fwstate/fwmap_basic_test.c
@@ -407,8 +407,9 @@ test_capacity_limits(void *arena) {
 		);
 		if (ret >= 0) {
 			inserted++;
-			if (inserted >= target)
+			if (inserted >= target) {
 				break;
+			}
 		} else {
 			failed++;
 		}


### PR DESCRIPTION
The C conventions have always required braces around every `if`, `else`, `for` and `while` body, even a single-line one, but the rule was prose only and drifted: 86 files carried braceless bodies. Enabling the corresponding clang-format option turns the rule into a mechanical gate, so the existing formatting check now enforces it and review no longer has to.

- Enable brace insertion in the default clang-format profile, leaving the protobuf profile's behaviour unchanged.
- Reformat every C source and header outside the vendored subprojects into conformance.
- Record in the C conventions that the rule is now enforced by the formatter.

The reformat is entirely machine-generated. Stripping whitespace and braces leaves each of the 86 files byte-identical to its previous content, and no retained line changed its indentation, so every inserted pair encloses exactly the statements that were already at that nesting depth. The formatter declines to insert braces inside macro definitions or where a body spans a preprocessor branch, which is why no directive or line-continuation was touched. A build, the full unit-test suite and a fuzz-target build were all verified green, and the reformat was reproduced byte-for-byte inside the pinned formatter image CI uses.
