### PR TITLE
feat(route): add optional per-nexthop dataplane counters

### DIFF
--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -199,6 +199,7 @@ private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.addre
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.destroy:1  # legacy: encapsulate behind an exported method or field
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.next:1  # legacy: encapsulate behind an exported method or field
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopCount:1  # legacy: encapsulate behind an exported method or field
+private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopCounterName:1  # mirrors the sibling fibIter accessors on the same iterator; encapsulating this one alone would split the pattern without benefit
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopDeviceName:1  # legacy: encapsulate behind an exported method or field
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopDstMAC:1  # legacy: encapsulate behind an exported method or field
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopSrcMAC:1  # legacy: encapsulate behind an exported method or field

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -202,6 +202,7 @@ route_module_config_add_route(
 	struct ether_addr dst_addr,
 	struct ether_addr src_addr,
 	const char *device_name,
+	const char *counter_name,
 	yanet_error **err
 ) {
 	struct route_module_config *config =
@@ -211,6 +212,24 @@ route_module_config_add_route(
 	uint64_t device_index;
 	if (cp_module_link_device(cp_module, device_name, &device_index, err)) {
 		return -1;
+	}
+
+	uint64_t counter_id = COUNTER_INVALID;
+	if (counter_name != NULL && counter_name[0] != '\0') {
+		counter_id = counter_registry_register(
+			&config->cp_module.counter_registry,
+			counter_name,
+			2,
+			err
+		);
+		if (counter_id == COUNTER_INVALID) {
+			yanet_error_add(
+				err,
+				"failed to register counter '%s'",
+				counter_name
+			);
+			return -1;
+		}
 	}
 
 	if (mem_array_expand_exp(
@@ -226,6 +245,7 @@ route_module_config_add_route(
 		.dst_addr = dst_addr,
 		.src_addr = src_addr,
 		.device_id = device_index,
+		.counter_id = counter_id,
 	};
 	SET_OFFSET_OF(&config->routes, routes);
 
@@ -492,6 +512,21 @@ fib_iter_nexthop_device_name(const struct fib_iter *it, uint64_t nexthop_idx) {
 	struct cp_module_device *devices = ADDR_OF(&config->cp_module.devices);
 	if (r->device_id < config->cp_module.device_count) {
 		return devices[r->device_id].name;
+	}
+	return "";
+}
+
+const char *
+fib_iter_nexthop_counter_name(const struct fib_iter *it, uint64_t nexthop_idx) {
+	const struct route *r = fib_iter_resolve_route(it, nexthop_idx);
+	if (r == NULL || r->counter_id == COUNTER_INVALID) {
+		return "";
+	}
+
+	struct route_module_config *config = it->config;
+	struct counter_registry *registry = &config->cp_module.counter_registry;
+	if (r->counter_id < registry->count) {
+		return ADDR_OF(&registry->names)[r->counter_id].name;
 	}
 	return "";
 }

--- a/modules/route/api/controlplane.h
+++ b/modules/route/api/controlplane.h
@@ -46,12 +46,17 @@ route_module_config_register_counters(
 	struct route_module_config *config, yanet_error **err
 );
 
+// Appends a nexthop route to the config.
+//
+// A NULL or empty counter_name leaves the nexthop uncounted — otherwise it
+// names a per-nexthop packet/byte counter to register.
 int
 route_module_config_add_route(
 	struct cp_module *cp_module,
 	struct ether_addr dst_addr,
 	struct ether_addr src_addr,
 	const char *device_name,
+	const char *counter_name,
 	yanet_error **err
 );
 
@@ -141,3 +146,10 @@ fib_iter_nexthop_src_mac(
 // Returns a pointer to the device name of the i-th nexthop.
 const char *
 fib_iter_nexthop_device_name(const struct fib_iter *it, uint64_t nexthop_idx);
+
+// Returns the nexthop's registered counter name.
+//
+// Returns an empty string when no counter name was read for the nexthop,
+// ordinarily because it isn't individually counted.
+const char *
+fib_iter_nexthop_counter_name(const struct fib_iter *it, uint64_t nexthop_idx);

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -4,6 +4,7 @@ package croute
 //#cgo LDFLAGS: -L../../../../../build/modules/route/api -lroute_cp
 //
 //#include "api/agent.h"
+//#include "counters/counters.h"
 //#include "modules/route/api/controlplane.h"
 import "C"
 
@@ -14,6 +15,10 @@ import (
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
 	"github.com/yanet-platform/yanet2/controlplane/ffi"
 )
+
+// CounterNameMaxLen is the longest counter name the shared-memory counter
+// registry accepts.
+const CounterNameMaxLen = C.COUNTER_NAME_LEN - 1
 
 // ModuleConfig is an opaque handle to the route module configuration in shared
 // memory.
@@ -57,9 +62,19 @@ func (m *ModuleConfig) Free() {
 }
 
 // addRoute maps 1:1 to route_module_config_add_route.
-func (m *ModuleConfig) addRoute(dstMAC [6]byte, srcMAC [6]byte, device string) (int, error) {
+//
+// An empty counter reaches C as a nil pointer: route_module_config_add_route
+// treats a NULL counter_name the same as an empty one, and passing nil here
+// avoids allocating a zero-length CString for the common uncounted case.
+func (m *ModuleConfig) addRoute(dstMAC [6]byte, srcMAC [6]byte, device string, counter string) (int, error) {
 	cName := C.CString(device)
 	defer C.free(unsafe.Pointer(cName))
+
+	var cCounter *C.char
+	if counter != "" {
+		cCounter = C.CString(counter)
+		defer C.free(unsafe.Pointer(cCounter))
+	}
 
 	var cErr *C.yanet_error
 	idx := C.route_module_config_add_route(
@@ -67,6 +82,7 @@ func (m *ModuleConfig) addRoute(dstMAC [6]byte, srcMAC [6]byte, device string) (
 		*(*C.struct_ether_addr)(unsafe.Pointer(&dstMAC)),
 		*(*C.struct_ether_addr)(unsafe.Pointer(&srcMAC)),
 		cName,
+		cCounter,
 		&cErr,
 	)
 	if idx < 0 {
@@ -213,4 +229,9 @@ func (m *fibIter) nexthopSrcMAC(idx uint64) [6]byte {
 // nexthopDeviceName maps 1:1 to fib_iter_nexthop_device_name.
 func (m *fibIter) nexthopDeviceName(idx uint64) string {
 	return C.GoString(C.fib_iter_nexthop_device_name(m.ptr, C.uint64_t(idx)))
+}
+
+// nexthopCounterName maps 1:1 to fib_iter_nexthop_counter_name.
+func (m *fibIter) nexthopCounterName(idx uint64) string {
+	return C.GoString(C.fib_iter_nexthop_counter_name(m.ptr, C.uint64_t(idx)))
 }

--- a/modules/route/bindings/go/croute/safe.go
+++ b/modules/route/bindings/go/croute/safe.go
@@ -16,6 +16,12 @@ type FIBNexthop struct {
 	DstMAC net.HardwareAddr
 	SrcMAC net.HardwareAddr
 	Device string
+
+	// Counter is the per-nexthop dataplane counter name.
+	//
+	// Empty means no name was read, ordinarily because the nexthop isn't
+	// individually counted.
+	Counter string
 }
 
 // FIBEntry represents a single FIB prefix with its nexthops.
@@ -26,8 +32,11 @@ type FIBEntry struct {
 	Nexthops      []FIBNexthop
 }
 
-// AddRoute adds a hardware route with MAC addresses and egress device.
-func (m *ModuleConfig) AddRoute(srcAddr net.HardwareAddr, dstAddr net.HardwareAddr, device string) (int, error) {
+// AddRoute adds a hardware route with MAC addresses, egress device, and an
+// optional per-nexthop dataplane counter name.
+//
+// An empty counter leaves the nexthop uncounted.
+func (m *ModuleConfig) AddRoute(srcAddr net.HardwareAddr, dstAddr net.HardwareAddr, device string, counter string) (int, error) {
 	if len(srcAddr) != 6 {
 		return -1, fmt.Errorf("unsupported source MAC address: must be EUI-48")
 	}
@@ -38,7 +47,7 @@ func (m *ModuleConfig) AddRoute(srcAddr net.HardwareAddr, dstAddr net.HardwareAd
 		return -1, fmt.Errorf("device name is required")
 	}
 
-	return m.addRoute([6]byte(dstAddr), [6]byte(srcAddr), device)
+	return m.addRoute([6]byte(dstAddr), [6]byte(srcAddr), device, counter)
 }
 
 // AddRouteList adds a list of route indices as an ECMP group.
@@ -109,9 +118,10 @@ func (m *ModuleConfig) DumpFIB() ([]FIBEntry, error) {
 			srcMAC := iter.nexthopSrcMAC(idx)
 
 			nexthops[idx] = FIBNexthop{
-				DstMAC: net.HardwareAddr(dstMAC[:]),
-				SrcMAC: net.HardwareAddr(srcMAC[:]),
-				Device: iter.nexthopDeviceName(idx),
+				DstMAC:  net.HardwareAddr(dstMAC[:]),
+				SrcMAC:  net.HardwareAddr(srcMAC[:]),
+				Device:  iter.nexthopDeviceName(idx),
+				Counter: iter.nexthopCounterName(idx),
 			}
 		}
 

--- a/modules/route/cli/route/build.rs
+++ b/modules/route/cli/route/build.rs
@@ -31,6 +31,15 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         .field_attribute(
             ".modules.route.controlplane.routepb.v1.FIBEntry.nexthops",
             "#[serde(default)]",
+        )
+        // `counter` is a plain `String`, so prost's derived `Deserialize`
+        // has no `Option` to default on its own. Empty is the normal
+        // uncounted state, so `skip_serializing_if` drops the key on write
+        // and `default` restores it on read, instead of a dead
+        // `"counter":""` on every uncounted row.
+        .field_attribute(
+            ".modules.route.controlplane.routepb.v1.FIBNexthop.counter",
+            "#[serde(default, skip_serializing_if = \"String::is_empty\")]",
         );
     for message in SERDE_MESSAGES {
         config = config

--- a/modules/route/cli/route/src/fib/render/mod.rs
+++ b/modules/route/cli/route/src/fib/render/mod.rs
@@ -30,15 +30,17 @@ struct FibRow {
     dst_mac: String,
     #[tabled(rename = "Src MAC")]
     src_mac: String,
+    #[tabled(rename = "Counter")]
+    counter: String,
 }
 
 /// Strips every `char::is_control` character out of `value`, replacing each
 /// with `?`.
 ///
-/// Applied to a device name before it is pushed into a cell: `device` is
-/// echoed verbatim from the wire with no upstream validation beyond
-/// non-emptiness, so a control character a peer embedded in it -- an ANSI
-/// escape, say -- would otherwise reach the terminal unfiltered.
+/// Applied to a device name or counter name before either is pushed into a
+/// cell: both are echoed verbatim from the wire, and neither is validated
+/// for control characters upstream, so a peer-embedded control character --
+/// an ANSI escape, say -- would otherwise reach the terminal unfiltered.
 fn sanitize_wire_text(value: &str) -> String {
     value.chars().map(|ch| if ch.is_control() { '?' } else { ch }).collect()
 }
@@ -51,6 +53,7 @@ fn no_nexthops_row(from: String, to: String) -> FibRow {
         device: "(no nexthops)".to_owned(),
         dst_mac: String::new(),
         src_mac: String::new(),
+        counter: String::new(),
     }
 }
 
@@ -69,6 +72,7 @@ fn nexthop_rows(from: String, to: String, nexthops: &[FibNexthop]) -> Vec<FibRow
             device: sanitize_wire_text(&nexthop.device),
             dst_mac: nexthop.dst_mac.unwrap_or_default().to_string(),
             src_mac: nexthop.src_mac.unwrap_or_default().to_string(),
+            counter: sanitize_wire_text(&nexthop.counter),
         })
         .collect()
 }

--- a/modules/route/cli/route/src/main.rs
+++ b/modules/route/cli/route/src/main.rs
@@ -312,13 +312,14 @@ mod test {
                 dst_mac: Some(mac("aa:bb:cc:dd:ee:ff")),
                 src_mac: Some(mac("11:22:33:44:55:66")),
                 device: "vlan100".to_owned(),
+                counter: "nexthop_custom-counter".to_owned(),
             }],
         };
 
         let json = serde_json::to_string(&entry).unwrap();
 
         assert_eq!(
-            r#"{"range":{"start":"10.0.0.0","end":"10.0.0.255"},"nexthops":[{"dst_mac":"aa:bb:cc:dd:ee:ff","src_mac":"11:22:33:44:55:66","device":"vlan100"}]}"#,
+            r#"{"range":{"start":"10.0.0.0","end":"10.0.0.255"},"nexthops":[{"dst_mac":"aa:bb:cc:dd:ee:ff","src_mac":"11:22:33:44:55:66","device":"vlan100","counter":"nexthop_custom-counter"}]}"#,
             json
         );
     }
@@ -334,13 +335,15 @@ mod test {
         assert_eq!(r#"{"range":null,"nexthops":[]}"#, json);
     }
 
-    /// An absent MAC serializes as JSON `null`.
+    /// An absent MAC serializes as JSON `null`. `counter` is also empty
+    /// here, so the key is absent entirely.
     #[test]
     fn fib_nexthop_json_absent_mac_is_null() {
         let nexthop = routepb::FibNexthop {
             dst_mac: None,
             src_mac: None,
             device: "vlan100".to_owned(),
+            counter: String::new(),
         };
 
         let json = serde_json::to_string(&nexthop).unwrap();
@@ -358,11 +361,23 @@ mod test {
             dst_mac: Some(MacAddress { addr: 0x1_0000_0000_0000 }),
             src_mac: None,
             device: "vlan100".to_owned(),
+            counter: String::new(),
         };
 
         let json = serde_json::to_string(&nexthop).unwrap();
 
         assert_eq!(r#"{"dst_mac":"invalid","src_mac":null,"device":"vlan100"}"#, json);
+    }
+
+    /// The `counter` key, omitted by `skip_serializing_if` when empty (see
+    /// `fib_nexthop_json_absent_mac_is_null`), still loads back: the paired
+    /// `#[serde(default)]` fills a missing `counter` in as empty.
+    #[test]
+    fn fib_nexthop_json_missing_counter_key_defaults_to_empty() {
+        let nexthop: routepb::FibNexthop =
+            serde_json::from_str(r#"{"dst_mac":null,"src_mac":null,"device":"vlan100"}"#).unwrap();
+
+        assert_eq!("", nexthop.counter);
     }
 
     #[test]
@@ -386,6 +401,7 @@ entries:
                     dst_mac: Some(mac("aa:bb:cc:dd:ee:ff")),
                     src_mac: Some(mac("11:22:33:44:55:66")),
                     device: "eth0".to_owned(),
+                    counter: String::new(),
                 }],
             }],
             config.entries
@@ -419,6 +435,7 @@ entries:
                     dst_mac: Some(mac("aa:bb:cc:dd:ee:ff")),
                     src_mac: Some(mac("11:22:33:44:55:66")),
                     device: "eth0".to_owned(),
+                    counter: String::new(),
                 }],
             }],
             config.entries
@@ -441,6 +458,49 @@ entries:
 
         assert_eq!(1, config.entries.len());
         assert!(config.entries[0].nexthops.is_empty());
+    }
+
+    /// A nexthop can omit `counter` entirely -- `FIBNexthop.counter`'s proto
+    /// doc calls that the way to ask the server to generate the name itself
+    /// -- and still load, thanks to `build.rs`'s `#[serde(default)]` on that
+    /// field (the same treatment `FIBEntry.nexthops` gets above, needed here
+    /// too since `counter` is a plain `String` rather than a message field
+    /// that would default on its own).
+    #[test]
+    fn fib_config_yaml_nexthop_without_counter_defaults_to_empty() {
+        let yaml = "
+entries:
+  - range:
+      start: 10.0.0.0
+      end: 10.0.0.255
+    nexthops:
+      - dst_mac: aa:bb:cc:dd:ee:ff
+        src_mac: 11:22:33:44:55:66
+        device: eth0
+";
+        let config: FibConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!(1, config.entries[0].nexthops.len());
+        assert_eq!("", config.entries[0].nexthops[0].counter);
+    }
+
+    /// A nexthop's `counter` key, when present, loads verbatim.
+    #[test]
+    fn fib_config_yaml_nexthop_with_counter_loads_given_name() {
+        let yaml = "
+entries:
+  - range:
+      start: 10.0.0.0
+      end: 10.0.0.255
+    nexthops:
+      - dst_mac: aa:bb:cc:dd:ee:ff
+        src_mac: 11:22:33:44:55:66
+        device: eth0
+        counter: nexthop_my-counter
+";
+        let config: FibConfig = serde_yaml::from_str(yaml).unwrap();
+
+        assert_eq!("nexthop_my-counter", config.entries[0].nexthops[0].counter);
     }
 
     /// A malformed address in the file fails to load rather than silently
@@ -583,6 +643,7 @@ entries:
                     dst_mac: Some(mac("aa:bb:cc:dd:ee:ff")),
                     src_mac: Some(mac("11:22:33:44:55:66")),
                     device: "eth0".to_owned(),
+                    counter: "nexthop_custom-counter".to_owned(),
                 }],
             }],
         };

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -104,7 +104,11 @@ func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (Module
 
 			idx, ok := hardwareIndex[hardwareRoute]
 			if !ok {
-				added, err := module.AddRoute(hardwareRoute.SourceMAC[:], hardwareRoute.DestinationMAC[:], hardwareRoute.Device)
+				// Read from nh, not hardwareRoute: RouteService already
+				// rejects two different counter names for one identity, so
+				// the first nexthop seen carries the name every later one
+				// for this identity would have agreed on.
+				added, err := module.AddRoute(hardwareRoute.SourceMAC[:], hardwareRoute.DestinationMAC[:], hardwareRoute.Device, nh.GetCounter())
 				if err != nil {
 					module.Free()
 					return nil, fmt.Errorf("failed to add hardware route: %w", err)
@@ -182,6 +186,11 @@ func (m *backend) ModuleCounters(name string, counterNames []string) []CounterVi
 }
 
 // HardwareRoute represents a route in the Layer 2 (L2) networking stack.
+//
+// This is the dataplane's forwarding identity: two nexthops agreeing on
+// these three fields share one route slot regardless of what else the
+// request says about them (e.g. counter name). Keying UpdateModule's dedup
+// map on more would split one physical neighbour across slots, skewing ECMP.
 type HardwareRoute struct {
 	// SourceMAC is the MAC address of the local interface that observed
 	// the neighbour.

--- a/modules/route/controlplane/cfg.go
+++ b/modules/route/controlplane/cfg.go
@@ -17,6 +17,12 @@ type Config struct {
 	MemoryRequirements xcfg.NonZero[datasize.ByteSize] `yaml:"memory_requirements"`
 	// Endpoint is the gRPC endpoint of the route module shim.
 	Endpoint xcfg.NonEmptyString `yaml:"endpoint"`
+	// DisableNexthopCounters turns off the per-nexthop dataplane counters.
+	//
+	// Negative polarity so the zero value keeps counters on: an operator
+	// who never sets this field gets the safer, more observable default
+	// without DefaultConfig needing an explicit entry for it.
+	DisableNexthopCounters bool `yaml:"disable_nexthop_counters"`
 }
 
 // DefaultConfig returns a Config populated with sensible defaults.

--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -83,6 +83,83 @@ var counterMappings = map[string]counterMapping{
 // request is stable across scrapes.
 var counterNames = slices.Sorted(maps.Keys(counterMappings))
 
+// intersectSorted returns the elements common to two ascending,
+// deduplicated slices.
+func intersectSorted(a, b []string) []string {
+	result := make([]string, 0, min(len(a), len(b)))
+	for idxA, idxB := 0, 0; idxA < len(a) && idxB < len(b); {
+		switch {
+		case a[idxA] < b[idxB]:
+			idxA++
+		case a[idxA] > b[idxB]:
+			idxB++
+		default:
+			result = append(result, a[idxA])
+			idxA++
+			idxB++
+		}
+	}
+
+	return result
+}
+
+var noNexthopStructuralCounters = []string{}
+
+// collectNexthopMetrics gathers packet and byte counters for every
+// per-nexthop counter registered by any applied config.
+//
+// A "counter" tag is pushed down into the dataplane counter read, so
+// counters excluded by tags are never read from shared memory. An empty
+// name list is never passed to ModuleCounters, which treats it as "all
+// counters", and an exact tag is intersected against the config's own
+// registered names so a module-level or foreign-config counter can never
+// surface under this family.
+func (m *RouteService) collectNexthopMetrics(tags []*commonpb.MetricTag) []*commonpb.Metric {
+	m.shmLock.RLock()
+	defer m.shmLock.RUnlock()
+
+	result := make([]*commonpb.Metric, 0)
+	for configName, entry := range m.configs {
+		names, ok := metrics.Query(tags, entry.NexthopCounterNames, noNexthopStructuralCounters)
+		if !ok {
+			continue
+		}
+
+		names = intersectSorted(names, entry.NexthopCounterNames)
+		if len(names) == 0 {
+			continue
+		}
+
+		for _, counter := range m.backend.ModuleCounters(configName, names) {
+			var packets, bytes uint64
+			for _, instance := range counter.Values {
+				if len(instance) > 0 {
+					packets += instance[0]
+				}
+				if len(instance) > 1 {
+					bytes += instance[1]
+				}
+			}
+
+			labels := []*commonpb.Label{
+				{Name: "config", Value: configName},
+				{Name: "device", Value: counter.Device},
+				{Name: "pipeline", Value: counter.Pipeline},
+				{Name: "function", Value: counter.Function},
+				{Name: "chain", Value: counter.Chain},
+				{Name: "counter", Value: counter.Name},
+			}
+
+			result = append(result,
+				commonpb.NewMetricCounter("route_nexthop_packets", packets, labels...),
+				commonpb.NewMetricCounter("route_nexthop_bytes", bytes, labels...),
+			)
+		}
+	}
+
+	return result
+}
+
 // collectDataplaneMetrics gathers the module-level packet and byte counters
 // of every config, summed across worker instances.
 //

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -74,12 +74,16 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
 
-	service := NewRouteService(
-		NewBackend(agent),
+	serviceOptions := []RouteServiceOption{
 		WithMetrics(grpcmetrics.NewFactory(
 			grpcmetrics.WithLabeler(labeler),
 		)),
-	)
+	}
+	if cfg.DisableNexthopCounters {
+		serviceOptions = append(serviceOptions, WithNexthopCountersDisabled())
+	}
+
+	service := NewRouteService(NewBackend(agent), serviceOptions...)
 
 	metricsService := NewMetricsService(service)
 

--- a/modules/route/controlplane/routepb/v1/route.proto
+++ b/modules/route/controlplane/routepb/v1/route.proto
@@ -67,6 +67,12 @@ message FIBNexthop {
   common.commonpb.v1.MACAddress src_mac = 2;
   // Egress device name.
   string device = 3;
+
+  // Name of the per-nexthop dataplane counter.
+  //
+  // A non-empty name must start with "nexthop_". Left empty, a name may be
+  // generated from the device and destination MAC.
+  string counter = 4;
 }
 
 // FIBEntry represents a single dataplane FIB row.

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -2,7 +2,9 @@ package route
 
 import (
 	"context"
+	"encoding/hex"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,7 +23,8 @@ import (
 type RouteServiceOption func(*routeServiceOptions)
 
 type routeServiceOptions struct {
-	Metrics grpcmetrics.Factory
+	Metrics                grpcmetrics.Factory
+	DisableNexthopCounters bool
 }
 
 func newRouteServiceOptions() *routeServiceOptions {
@@ -34,6 +37,16 @@ func newRouteServiceOptions() *routeServiceOptions {
 func WithMetrics(factory grpcmetrics.Factory) RouteServiceOption {
 	return func(o *routeServiceOptions) {
 		o.Metrics = factory
+	}
+}
+
+// WithNexthopCountersDisabled turns off per-nexthop dataplane counters.
+//
+// UpdateFIB then rejects any nexthop that carries an explicit counter name,
+// and never materializes one for a nexthop that left it empty.
+func WithNexthopCountersDisabled() RouteServiceOption {
+	return func(o *routeServiceOptions) {
+		o.DisableNexthopCounters = true
 	}
 }
 
@@ -53,6 +66,10 @@ type configEntry struct {
 	// NexthopCount is the number of distinct hardware nexthops the config
 	// resolves its prefixes to.
 	NexthopCount uint64
+	// NexthopCounterNames is the deduplicated, sorted set of per-nexthop
+	// counter names this config registered, so the metrics path can query
+	// them without re-walking the FIB.
+	NexthopCounterNames []string
 	// UpdatedAt is when the FIB was applied to the dataplane, and backs
 	// the staleness gauge.
 	UpdatedAt time.Time
@@ -80,6 +97,11 @@ type RouteService struct {
 	configs map[string]configEntry
 
 	metrics *grpcmetrics.ServerMetrics
+
+	// disableNexthopCounters mirrors Config.DisableNexthopCounters: when
+	// set, UpdateFIB rejects an explicit counter and never materializes
+	// one for an empty nexthop.
+	disableNexthopCounters bool
 }
 
 // NewRouteService builds a RouteService bound to the supplied backend.
@@ -90,8 +112,9 @@ func NewRouteService(backend Backend, options ...RouteServiceOption) *RouteServi
 	}
 
 	m := &RouteService{
-		backend: backend,
-		configs: map[string]configEntry{},
+		backend:                backend,
+		configs:                map[string]configEntry{},
+		disableNexthopCounters: opts.DisableNexthopCounters,
 	}
 	if opts.Metrics != nil {
 		m.metrics = opts.Metrics(m.retention)
@@ -203,9 +226,10 @@ func (m *RouteService) ShowFIB(
 		nexthops := make([]*routepb.FIBNexthop, len(e.Nexthops))
 		for idx, nh := range e.Nexthops {
 			nexthops[idx] = &routepb.FIBNexthop{
-				DstMac: commonpb.NewMACAddressEUI48([6]byte(nh.DstMAC)),
-				SrcMac: commonpb.NewMACAddressEUI48([6]byte(nh.SrcMAC)),
-				Device: nh.Device,
+				DstMac:  commonpb.NewMACAddressEUI48([6]byte(nh.DstMAC)),
+				SrcMac:  commonpb.NewMACAddressEUI48([6]byte(nh.SrcMAC)),
+				Device:  nh.Device,
+				Counter: nh.Counter,
 			}
 		}
 
@@ -249,6 +273,113 @@ func (m *RouteService) DeleteConfig(
 	return &routepb.DeleteConfigResponse{}, nil
 }
 
+// nexthopCounterPrefix keeps a nexthop counter name from colliding with a
+// route_* name or a generic per-module one ("rx", "tx", "drop", ...).
+const nexthopCounterPrefix = "nexthop_"
+
+func materializeNexthopCounter(device string, dstMAC [6]byte) string {
+	return nexthopCounterPrefix + device + "_" + hex.EncodeToString(dstMAC[:])
+}
+
+// resolveNexthopCounters validates and materializes nexthop counter names
+// across entries, returning the deduplicated, sorted set of names.
+//
+// A generated name is never truncated on overflow: the trailing MAC is what
+// makes two nexthops distinct, so truncating would merge their counters.
+//
+// The conflict check spans the whole request: backend.UpdateModule keys a
+// nexthop's route by hardware identity alone, so only the first entry for
+// an identity sets its counter, and a per-entry check could miss the clash.
+func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) ([]string, error) {
+	names := map[string]struct{}{}
+	identityCounters := map[HardwareRoute]string{}
+
+	for _, entry := range entries {
+		for _, nh := range entry.GetNexthops() {
+			counter := nh.GetCounter()
+
+			if m.disableNexthopCounters {
+				if counter != "" {
+					return nil, status.Errorf(
+						codes.InvalidArgument,
+						"nexthop for device %q (dst_mac=%x) carries a counter name but nexthop counters are disabled (disable_nexthop_counters)",
+						nh.GetDevice(),
+						nh.GetDstMac().GetAddr(),
+					)
+				}
+				continue
+			}
+
+			generated := counter == ""
+			if generated {
+				counter = materializeNexthopCounter(nh.GetDevice(), nh.GetDstMac().EUI48())
+				nh.Counter = counter
+			} else if !strings.HasPrefix(counter, nexthopCounterPrefix) {
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"nexthop counter %q must start with %q",
+					counter,
+					nexthopCounterPrefix,
+				)
+			}
+
+			// Rejected rather than silently truncated at the C strnlen
+			// boundary, which would diverge from the name in this dedup set.
+			if strings.IndexByte(counter, 0) >= 0 {
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"nexthop counter %q must not contain a NUL byte",
+					counter,
+				)
+			}
+
+			if len(counter) > croute.CounterNameMaxLen {
+				if generated {
+					return nil, status.Errorf(
+						codes.InvalidArgument,
+						"generated nexthop counter %q for device %q exceeds the maximum length of %d",
+						counter,
+						nh.GetDevice(),
+						croute.CounterNameMaxLen,
+					)
+				}
+				return nil, status.Errorf(
+					codes.InvalidArgument,
+					"nexthop counter %q exceeds the maximum length of %d",
+					counter,
+					croute.CounterNameMaxLen,
+				)
+			}
+
+			// Identity-parse failures are left for backend.UpdateModule to
+			// reject — this check only needs the identity, not full validation.
+			if hardwareRoute, err := newHardwareRoute(nh); err == nil {
+				if prior, ok := identityCounters[hardwareRoute]; ok && prior != counter {
+					return nil, status.Errorf(
+						codes.InvalidArgument,
+						"nexthop %s (device %q) carries conflicting counter names %q and %q",
+						hardwareRoute,
+						hardwareRoute.Device,
+						prior,
+						counter,
+					)
+				}
+				identityCounters[hardwareRoute] = counter
+			}
+
+			names[counter] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(names))
+	for name := range names {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+
+	return result, nil
+}
+
 // UpdateFIB applies a freshly-built FIB to the dataplane atomically.
 func (m *RouteService) UpdateFIB(
 	ctx context.Context,
@@ -270,6 +401,14 @@ func (m *RouteService) UpdateFIB(
 		}
 	}
 
+	// Runs before the backend call: a disabled-but-set or over-long name is
+	// rejected before anything is applied, and the generated name written
+	// onto nh.Counter is what the backend and the FIBEntry list agree on.
+	nexthopCounterNames, err := m.resolveNexthopCounters(entries)
+	if err != nil {
+		return nil, err
+	}
+
 	m.shmLock.Lock()
 	defer m.shmLock.Unlock()
 
@@ -286,20 +425,22 @@ func (m *RouteService) UpdateFIB(
 	// FIB never changes again for this generation, and each read walks the
 	// LPM keyspace.
 	m.configs[name] = configEntry{
-		Handle:          module,
-		FIBRangeCountV4: module.FIBRangeCountV4(),
-		FIBRangeCountV6: module.FIBRangeCountV6(),
-		NexthopCount:    module.RouteCount(),
-		UpdatedAt:       time.Now(),
+		Handle:              module,
+		FIBRangeCountV4:     module.FIBRangeCountV4(),
+		FIBRangeCountV6:     module.FIBRangeCountV6(),
+		NexthopCount:        module.RouteCount(),
+		NexthopCounterNames: nexthopCounterNames,
+		UpdatedAt:           time.Now(),
 	}
 
 	return &routepb.UpdateFIBResponse{}, nil
 }
 
 // Metrics returns route module metrics matching tags: per-config FIB
-// gauges, the module-level dataplane counters, plus gRPC call metrics.
+// gauges, the module-level dataplane counters, the per-nexthop dataplane
+// counters, plus gRPC call metrics.
 //
-// A "counter" tag is pushed down into the dataplane counter read, so
+// A "counter" tag is pushed down into both dataplane counter reads, so
 // counters excluded by tags are never read from shared memory.
 //
 // Labels:
@@ -312,6 +453,8 @@ func (m *RouteService) UpdateFIB(
 //   - function:     pipeline function name (all dataplane counter metrics)
 //   - chain:        pipeline chain name (all dataplane counter metrics)
 //   - reason:       drop cause (route_drop_packets / route_drop_bytes only)
+//   - counter:      per-nexthop counter name (route_nexthop_packets /
+//     route_nexthop_bytes only)
 //   - grpc_type:    always "unary" (gRPC metrics)
 //   - grpc_service: fully-qualified gRPC service name (gRPC metrics)
 //   - grpc_method:  RPC name (gRPC metrics)
@@ -319,6 +462,7 @@ func (m *RouteService) UpdateFIB(
 func (m *RouteService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	result := m.collectConfigMetrics()
 	result = append(result, m.collectDataplaneMetrics(tags)...)
+	result = append(result, m.collectNexthopMetrics(tags)...)
 	if m.metrics != nil {
 		result = append(result, m.metrics.Collect()...)
 	}

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -1,6 +1,8 @@
 package route_test
 
 import (
+	"net/netip"
+	"strings"
 	"sync"
 	"testing"
 
@@ -47,8 +49,9 @@ type fakeBackend struct {
 	mu       sync.Mutex
 	handle   *fakeHandle
 	counters []route.CounterView
-	// queried records the counter names the service asked for.
-	queried []string
+	// queries records the counterNames argument of every ModuleCounters
+	// call, in call order.
+	queries [][]string
 	// updateCalls records the range entries passed to UpdateModule on
 	// every call, in call order.
 	updateCalls [][]*routepb.FIBEntry
@@ -74,7 +77,7 @@ func (m *fakeBackend) ModuleCounters(name string, counterNames []string) []route
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	m.queried = counterNames
+	m.queries = append(m.queries, append([]string(nil), counterNames...))
 	return m.counters
 }
 
@@ -219,6 +222,9 @@ func TestDataplaneCounterQueryCoversContract(t *testing.T) {
 	_, err := service.Metrics()
 	require.NoError(t, err)
 
+	// No nexthop counters registered, so this is collectDataplaneMetrics's
+	// query alone.
+	require.Len(t, backend.queries, 1)
 	require.ElementsMatch(t, []string{
 		"route_forwarded_v4",
 		"route_forwarded_v6",
@@ -231,7 +237,7 @@ func TestDataplaneCounterQueryCoversContract(t *testing.T) {
 		"route_drop_empty_route_list_v6",
 		"route_drop_device_unresolved_v4",
 		"route_drop_device_unresolved_v6",
-	}, backend.queried)
+	}, backend.queries[0])
 }
 
 // TestDataplaneMetricsEmitZeroCounters verifies that a counter reading zero is
@@ -411,4 +417,277 @@ func TestShowFIBEmptyConfig(t *testing.T) {
 	response, err := service.ShowFIB(t.Context(), &routepb.ShowFIBRequest{Name: "cfg"})
 	require.NoError(t, err)
 	require.Empty(t, response.GetEntries())
+}
+
+// testDstMAC and testSrcMAC are the fixed EUI-48 addresses used across the
+// nexthop-counter tests below.
+var (
+	testDstMAC = [6]byte{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0x01}
+	testSrcMAC = [6]byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+)
+
+// testNexthop builds a FIBNexthop carrying the fixed test MACs and the
+// given device and counter.
+func testNexthop(device, counter string) *routepb.FIBNexthop {
+	return &routepb.FIBNexthop{
+		DstMac:  commonpb.NewMACAddressEUI48(testDstMAC),
+		SrcMac:  commonpb.NewMACAddressEUI48(testSrcMAC),
+		Device:  device,
+		Counter: counter,
+	}
+}
+
+// testFIBEntry builds a single-address FIBEntry range covering the given
+// prefix's network address, carrying nexthops.
+func testFIBEntry(t *testing.T, prefix string, nexthops ...*routepb.FIBNexthop) *routepb.FIBEntry {
+	t.Helper()
+
+	addr := netip.MustParsePrefix(prefix).Addr()
+	ipRange, err := commonpb.NewIPRange(addr, addr)
+	require.NoError(t, err)
+
+	return &routepb.FIBEntry{Range: ipRange, Nexthops: nexthops}
+}
+
+// TestUpdateFIBMaterializesEmptyCounter verifies that a nexthop which leaves
+// counter empty is materialized to "nexthop_<device>_<dst_mac>" in what the
+// backend receives.
+func TestUpdateFIBMaterializesEmptyCounter(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, backend.updateCalls, 1)
+	got := backend.updateCalls[0][0].Nexthops[0]
+	require.Equal(t, "nexthop_eth0_aabbccddee01", got.GetCounter())
+}
+
+// TestUpdateFIBPassesThroughExplicitCounter verifies that a nexthop's
+// explicit counter reaches the backend verbatim, unmodified.
+func TestUpdateFIBPassesThroughExplicitCounter(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_my_counter"))
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.NoError(t, err)
+
+	got := backend.updateCalls[0][0].Nexthops[0]
+	require.Equal(t, "nexthop_my_counter", got.GetCounter())
+}
+
+// TestUpdateFIBDisabledRejectsExplicitCounter verifies that an explicit
+// counter name is rejected as InvalidArgument when nexthop counters are
+// disabled, and that the config is never applied to the backend.
+func TestUpdateFIBDisabledRejectsExplicitCounter(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend, route.WithNexthopCountersDisabled())
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_my_counter"))
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+}
+
+// TestUpdateFIBDisabledAllowsEmptyCounter verifies that a nexthop leaving
+// counter empty succeeds while nexthop counters are disabled, and stays
+// empty rather than being materialized.
+func TestUpdateFIBDisabledAllowsEmptyCounter(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend, route.WithNexthopCountersDisabled())
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", ""))
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.NoError(t, err)
+
+	got := backend.updateCalls[0][0].Nexthops[0]
+	require.Empty(t, got.GetCounter())
+}
+
+// TestUpdateFIBRejectsOverlongCounter verifies the accepted counter-name
+// length boundary directly against literal byte counts, rather than through
+// croute.CounterNameMaxLen, so an off-by-one in the constant itself cannot
+// hide the regression.
+func TestUpdateFIBRejectsOverlongCounter(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	okEntry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_"+strings.Repeat("a", 127-len("nexthop_"))))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{okEntry},
+	})
+	require.NoError(t, err, "a 127-byte counter name must be accepted")
+
+	tooLongEntry := testFIBEntry(t, "10.0.0.1/32", testNexthop("eth0", "nexthop_"+strings.Repeat("a", 128-len("nexthop_"))))
+	_, err = service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{tooLongEntry},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err), "a 128-byte counter name must be rejected")
+}
+
+// TestUpdateFIBRejectsCounterWithNULByte verifies that a counter name
+// carrying an embedded NUL byte is rejected, rather than silently
+// truncated at the C boundary where it would diverge from the name
+// recorded in the deduplicated counter-name set.
+func TestUpdateFIBRejectsCounterWithNULByte(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_ab\x00cd"))
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+}
+
+// TestUpdateFIBRejectsCounterWithoutPrefix verifies that an explicit
+// counter name not starting with "nexthop_" is rejected, rather than being
+// accepted and risking a future collision with a route-specific or generic
+// module-level counter name.
+func TestUpdateFIBRejectsCounterWithoutPrefix(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "route_forwarded_v4"))
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+}
+
+// TestUpdateFIBRejectsConflictingCounterNamesWithinEntry verifies that
+// listing the same forwarding identity twice in one entry under two
+// different counter names is rejected as InvalidArgument naming both
+// names, and that nothing reaches the backend.
+func TestUpdateFIBRejectsConflictingCounterNamesWithinEntry(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32",
+		testNexthop("eth0", "nexthop_a"),
+		testNexthop("eth0", "nexthop_b"),
+	)
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.ErrorContains(t, err, "nexthop_a")
+	require.ErrorContains(t, err, "nexthop_b")
+	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+}
+
+// TestUpdateFIBRejectsConflictingCounterNamesAcrossEntries verifies that the
+// conflicting-counter check spans the whole request rather than one entry
+// at a time.
+func TestUpdateFIBRejectsConflictingCounterNamesAcrossEntries(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entryA := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_a"))
+	entryB := testFIBEntry(t, "10.0.1.0/32", testNexthop("eth0", "nexthop_b"))
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entryA, entryB},
+	})
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+}
+
+// TestNexthopMetricsSumWorkerInstances verifies that collectNexthopMetrics
+// reaches the dataplane through RouteService.Metrics and sums a registered
+// nexthop counter's worker instances into one series carrying the full
+// label set, rather than only exercising resolveNexthopCounters.
+func TestNexthopMetricsSumWorkerInstances(t *testing.T) {
+	backend := newFakeBackend()
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_my_counter"))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.NoError(t, err)
+
+	backend.counters = []route.CounterView{
+		counterView("nexthop_my_counter", [][]uint64{{1, 100}, {2, 200}}),
+	}
+
+	all, err := service.Metrics()
+	require.NoError(t, err)
+
+	wantLabels := map[string]string{
+		"config":   "cfg",
+		"device":   "dev0",
+		"pipeline": "pipe0",
+		"function": "func0",
+		"chain":    "chain0",
+		"counter":  "nexthop_my_counter",
+	}
+
+	packets := requireMetric(t, all, "route_nexthop_packets", wantLabels)
+	require.Equal(t, uint64(3), packets.GetCounter())
+
+	bytes := requireMetric(t, all, "route_nexthop_bytes", wantLabels)
+	require.Equal(t, uint64(300), bytes.GetCounter())
+}
+
+// TestNexthopMetricsExactTagNeverReadsForeignCounter verifies that an exact
+// "counter" tag naming a module-level counter never reaches
+// collectNexthopMetrics's dataplane read, so the structural counter can
+// never resurface mislabeled under the route_nexthop_* family.
+func TestNexthopMetricsExactTagNeverReadsForeignCounter(t *testing.T) {
+	backend := newFakeBackend()
+	backend.counters = []route.CounterView{
+		counterView("route_forwarded_v4", [][]uint64{{7, 700}}),
+	}
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_my_counter"))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.NoError(t, err)
+
+	tag := &commonpb.MetricTag{Name: "counter", Value: "route_forwarded_v4"}
+	all, err := service.Metrics(tag)
+	require.NoError(t, err)
+
+	require.Empty(t, findMetrics(all, "route_nexthop_packets"))
+	require.Empty(t, findMetrics(all, "route_nexthop_bytes"))
+
+	// Only "nexthop_my_counter" is registered, so the foreign tag leaves
+	// collectNexthopMetrics nothing to query.
+	require.Len(t, backend.queries, 1)
+	require.Equal(t, []string{"route_forwarded_v4"}, backend.queries[0])
 }

--- a/modules/route/dataplane/config.h
+++ b/modules/route/dataplane/config.h
@@ -13,6 +13,10 @@ struct route {
 	struct ether_addr dst_addr;
 	struct ether_addr src_addr;
 	uint64_t device_id;
+
+	// Per-nexthop packet/byte counter, or COUNTER_INVALID if this
+	// nexthop is not individually counted.
+	uint64_t counter_id;
 };
 
 struct route_list {

--- a/modules/route/dataplane/dataplane.c
+++ b/modules/route/dataplane/dataplane.c
@@ -237,6 +237,11 @@ route_handle_packets(
 		route_set_packet_destination(packet, route);
 		packet->tx_device_id = device_id;
 		route_count_packet(module_ectx, counters->forwarded, packet);
+		if (route->counter_id != COUNTER_INVALID) {
+			route_count_packet(
+				module_ectx, route->counter_id, packet
+			);
+		}
 		packet_front_pending_output(packet_front, packet);
 	}
 }

--- a/modules/route/fuzzing/route.c
+++ b/modules/route/fuzzing/route.c
@@ -74,6 +74,7 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 			.addr = {0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c},
 		},
 		"dev0",
+		NULL,
 		err
 	);
 	if (route_idx == -1) {

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -33,6 +33,12 @@ type FIBNexthop struct {
 	DstMAC net.HardwareAddr
 	SrcMAC net.HardwareAddr
 	Device string
+	// Counter is the per-nexthop dataplane counter name.
+	//
+	// applyFIB passes this straight to backend.UpdateModule, bypassing
+	// RouteService.UpdateFIB, so nothing on this path auto-fills an empty
+	// value.
+	Counter string
 }
 
 // FIBEntry is a test-domain FIB prefix with associated nexthops.
@@ -141,9 +147,10 @@ func applyFIB(
 		nexthops := make([]*routepb.FIBNexthop, 0, len(e.Nexthops))
 		for _, nh := range e.Nexthops {
 			nexthops = append(nexthops, &routepb.FIBNexthop{
-				DstMac: commonpb.NewMACAddressEUI48([6]byte(nh.DstMAC)),
-				SrcMac: commonpb.NewMACAddressEUI48([6]byte(nh.SrcMAC)),
-				Device: nh.Device,
+				DstMac:  commonpb.NewMACAddressEUI48([6]byte(nh.DstMAC)),
+				SrcMac:  commonpb.NewMACAddressEUI48([6]byte(nh.SrcMAC)),
+				Device:  nh.Device,
+				Counter: nh.Counter,
 			})
 		}
 		ipRange, err := commonpb.NewIPRange(e.Prefix.Addr(), xnetip.LastAddr(e.Prefix))
@@ -959,6 +966,109 @@ func TestRoute_PerOutcomeCounters(t *testing.T) {
 	}
 }
 
+// TestRoute_NexthopCounter verifies that a nexthop carrying an explicit
+// counter name reaches the real C counter registry: a matching packet
+// increments the named counter by exactly one packet and its own byte
+// length.
+func TestRoute_NexthopCounter(t *testing.T) {
+	const counterName = "nexthop_port0_deadbeef0001"
+
+	countedHop := FIBNexthop{
+		DstMAC:  xerror.Unwrap(net.ParseMAC("de:ad:be:ef:00:01")),
+		SrcMAC:  xerror.Unwrap(net.ParseMAC("ca:fe:ba:be:00:01")),
+		Device:  "port0",
+		Counter: counterName,
+	}
+
+	h, agent, backend := setupRouteHarness(t, "port0")
+	handle := applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: netip.MustParsePrefix("10.0.0.0/24"), Nexthops: []FIBNexthop{countedHop}},
+	})
+	wirePipeline(t, agent, "port0", "test")
+
+	pkt := buildRouteIPv4Packet(t, "10.0.0.5", 64)
+	pktSize := uint64(len(pkt.Data()))
+
+	result, err := h.HandlePackets(pkt)
+	require.NoError(t, err)
+	require.Len(t, result.Output, 1, "expected one forwarded packet")
+	require.Empty(t, result.Drop, "expected no dropped packets")
+
+	path := dataplaneut.CounterPath{
+		Device: "port0", Pipeline: "test", Function: "test",
+		Chain: "test_chain", ModuleType: "route", ModuleName: "test",
+	}
+	dataplaneut.RequireModuleCounter(t, h, path, counterName, 1, pktSize)
+
+	// Close the round trip: ShowFIB's DumpFIB path must resolve the same
+	// name back out of the real C counter registry, not just accept it on
+	// write.
+	fib, err := handle.DumpFIB()
+	require.NoError(t, err)
+	require.Len(t, fib, 1)
+	require.Len(t, fib[0].Nexthops, 1)
+	require.Equal(t, counterName, fib[0].Nexthops[0].Counter)
+}
+
+// TestRoute_ECMPSameIdentitySameCounterDedupesToOneMember verifies that
+// listing the same (src_mac, dst_mac, device) nexthop twice under the same
+// counter name resolves to a single route-list member, not two.
+//
+// A duplicated member takes 2/N of the ECMP hash space instead of 1/N: this
+// exercises the real backend.UpdateModule dedup against shared memory and
+// inspects the resulting nexthop set via DumpFIB, since a fake backend
+// cannot observe route-list membership at all.
+func TestRoute_ECMPSameIdentitySameCounterDedupesToOneMember(t *testing.T) {
+	prefix := netip.MustParsePrefix("192.168.4.0/24")
+	hop := FIBNexthop{
+		DstMAC:  xerror.Unwrap(net.ParseMAC("de:ad:be:ef:00:04")),
+		SrcMAC:  xerror.Unwrap(net.ParseMAC("ca:fe:ba:be:00:04")),
+		Device:  "port0",
+		Counter: "nexthop_dup",
+	}
+
+	_, _, backend := setupRouteHarness(t, "port0")
+	handle := applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{hop, hop}},
+	})
+
+	fib, err := handle.DumpFIB()
+	require.NoError(t, err)
+	require.Len(t, fib, 1)
+	require.Len(t, fib[0].Nexthops, 1, "a duplicated hardware route must collapse to one route-list member")
+}
+
+// TestRoute_ECMPDistinctSourceMACRemainsSeparate verifies that two nexthops
+// sharing a destination MAC and device but differing in source MAC remain
+// distinct route-list members, since source MAC is part of the forwarding
+// identity.
+func TestRoute_ECMPDistinctSourceMACRemainsSeparate(t *testing.T) {
+	prefix := netip.MustParsePrefix("192.168.5.0/24")
+	dstMAC := xerror.Unwrap(net.ParseMAC("de:ad:be:ef:00:05"))
+	hopA := FIBNexthop{
+		DstMAC:  dstMAC,
+		SrcMAC:  xerror.Unwrap(net.ParseMAC("ca:fe:ba:be:00:05")),
+		Device:  "port0",
+		Counter: "nexthop_a",
+	}
+	hopB := FIBNexthop{
+		DstMAC:  dstMAC,
+		SrcMAC:  xerror.Unwrap(net.ParseMAC("ca:fe:ba:be:00:06")),
+		Device:  "port0",
+		Counter: "nexthop_b",
+	}
+
+	_, _, backend := setupRouteHarness(t, "port0")
+	handle := applyFIB(t, backend, "test", []FIBEntry{
+		{Prefix: prefix, Nexthops: []FIBNexthop{hopA, hopB}},
+	})
+
+	fib, err := handle.DumpFIB()
+	require.NoError(t, err)
+	require.Len(t, fib, 1)
+	require.Len(t, fib[0].Nexthops, 2, "nexthops differing only in src_mac must remain distinct routes")
+}
+
 // TestUpdateFIB_EmptyNexthopEntryDoesNotDisplaceEarlierEntry verifies the
 // UpdateFIBRequest doc comment's claim that an entry with no nexthops is
 // skipped rather than overwriting an earlier overlapping entry.
@@ -986,4 +1096,5 @@ func TestUpdateFIB_EmptyNexthopEntryDoesNotDisplaceEarlierEntry(t *testing.T) {
 	require.Len(t, fib, 1, "expected the earlier nexthop-bearing entry to survive alone")
 	require.Len(t, fib[0].Nexthops, 1)
 	require.Equal(t, "port0", fib[0].Nexthops[0].Device)
+	require.Empty(t, fib[0].Nexthops[0].Counter, "uncounted nexthop must round-trip as empty, not a stale or garbage name")
 }


### PR DESCRIPTION
Give the route module per-nexthop packet and byte counters, mirroring the per-rule counters the forward module already carries. Traffic can now be attributed to the neighbour it left through, which is what an ECMP balance check needs.

- Add an optional counter name to a FIB nexthop. When it is left empty, the name is generated from the egress device and destination MAC, so a nexthop applied through the service always has an addressable counter.
- Require a reserved prefix on every such name. The shared-memory registry is keyed by name and returns the existing slot for a name already taken, at the same slot size the module's own counters use, so without the prefix a nexthop could quietly share a slot with a structural counter and corrupt it. A prefix makes that unreachable by construction, where a reserved-name list would have to track two separate C sources and rot as either grows.
- Keep the counter name out of a route's identity, so it cannot influence how traffic is spread. Naming the same nexthop twice with different counters is refused across the whole request rather than resolved, because either resolution would silently reweight an ECMP group or reintroduce per-prefix accounting through the back door.
- Gate the whole feature on a module-level setting that is enabled by default. With it disabled nothing is registered and nothing is counted, and naming a counter explicitly is rejected with a clear error rather than silently ignored.
- Report the resolved name back from the FIB read path, so the field round-trips instead of being write-only, and show it in the CLI table and JSON output.
- Export the counters as a new per-nexthop metric family, scoped so that an exact counter tag cannot pull the module-level counters into it.

The module-level counters keep working unchanged in every configuration.

The route web page is deliberately left out of this change and still drops the field when saving an edited FIB, so an explicit name set through the API is not safe against a later save from that page. Carrying it through the page's draft layer needs a refactor of its own and is being done separately.

The per-nexthop increment sits on the forwarded path only. Measured cost is 8 instructions per forwarded packet when a counter is attached, about 0.4% of a full firewall packet, and 3 instructions when the feature is disabled. The nexthop record grows from 24 to 32 bytes, which removes the cache-line straddle that the previous stride produced on a quarter of all records.
