### PR TITLE
docs(agents,c): route the C checklist through the whole conventions file

### DIFF
--- a/.claude/agents/coder-c.md
+++ b/.claude/agents/coder-c.md
@@ -77,9 +77,8 @@ This is a high-performance packet processing system. On the dataplane hot path:
 - [ ] `clang-format -i <changed files>` — run it on every changed C file.
 - [ ] `meson compile -C build` — must compile cleanly.
 - [ ] `meson test -C build <test_name>` — must pass if tests exist for changed code.
-- [ ] All control flow has braces, even single-line bodies.
 - [ ] Meson build files updated if new source files added.
-- [ ] `.claude/conventions/c.md` rules held: `cp_module` field order, `container_of()` usage, `memory_balloc`/`memory_bfree` pairing, packet bounds checks.
+- [ ] Every rule in `.claude/conventions/c.md` held, such as `cp_module` field order, `container_of()` usage, `memory_balloc`/`memory_bfree` pairing, and packet bounds checks.
 - [ ] Fuzzing target added/updated if input parsing changed.
 - [ ] No Go, Rust, TypeScript, or protobuf files were modified.
 

--- a/.claude/conventions/c.md
+++ b/.claude/conventions/c.md
@@ -2,7 +2,7 @@
 
 Loaded on demand by the agent writing or reviewing C; this is the single source for these rules.
 
-- Always use braces for `if`/`else`/`for`/`while`, even single-line bodies. Enforce this rule with `clang-format` (`InsertBraces: true`).
+- Always use braces for `if`/`else`/`for`/`while`, even single-line bodies. `clang-format` (`InsertBraces: true`) inserts them automatically, but it silently skips some cases, among them a body inside a macro definition, a body split from its condition by a preprocessor directive, and an empty `;` body.
 - Format with `clang-format`.
 - **Functions with more than six parameters are a code smell.** Split them or use a designated-initializer config struct; omnibus initialisers are untestable.
 - **Multi-segment mbufs**: `rte_pktmbuf_data_len()` is head-only. Whole-packet work walks `mbuf->next`/uses `rte_pktmbuf_pkt_len()`, or rejects chained packets.


### PR DESCRIPTION
Follow-up to #1695, which turned the brace rule into a formatter option. Two problems surfaced while acting on that. The C specialist's self-review checklist still asked it to verify braces by eye, which the formatter now does on almost every construct. And the row beside it named four of the twelve C conventions as the ones to check, which licensed skipping the other eight — including the brace rule itself, once its own row was gone.

- Drop the redundant brace item from the C specialist's self-review checklist.
- Point the neighbouring row at every rule in the C conventions rather than an enumerated four, so the checklist stops going stale as conventions are added.
- Record in the C conventions which constructs the formatter silently leaves unbraced, so a clean formatting run is not mistaken for proof of compliance.

The formatter's guarantee is not total. It declines to brace a body inside a macro definition, a body split from its condition by a preprocessor directive, an empty statement body, a body whose loop head comes from a macro invocation, and code inside a disabled preprocessor branch or a formatter-off region. Seven such bodies exist in the tree today and the formatting check passes on all of them, which is exactly why the rule has to stay stated in prose and reachable from the checklist.
