### PR TITLE
feat(cp): link modules to objects with per-worker link ectx

### DIFF
--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -184,6 +184,18 @@ cp_module_fini(struct cp_module *cp_module) {
 	SET_OFFSET_OF(&cp_module->devices, NULL);
 	cp_module->device_count = 0;
 
+	struct cp_module_object *objects = ADDR_OF(&cp_module->objects);
+	if (objects != NULL) {
+		memory_bfree(
+			&cp_module->memory_context,
+			objects,
+			sizeof(struct cp_module_object) *
+				cp_module->object_count
+		);
+	}
+	SET_OFFSET_OF(&cp_module->objects, NULL);
+	cp_module->object_count = 0;
+
 	SET_OFFSET_OF(&cp_module->agent, NULL);
 
 	memory_context_fini(&cp_module->memory_context);
@@ -225,6 +237,56 @@ cp_module_link_device(
 	SET_OFFSET_OF(&cp_module->devices, devices);
 	*index = cp_module->device_count;
 	++cp_module->device_count;
+
+	return 0;
+}
+
+int
+cp_module_link_object(
+	struct cp_module *cp_module,
+	const char *object_type,
+	const char *object_name,
+	uint64_t *index,
+	yanet_error **err
+) {
+	struct cp_module_object *objects = ADDR_OF(&cp_module->objects);
+	for (uint64_t idx = 0; idx < cp_module->object_count; ++idx) {
+		if (!strncmp(
+			    objects[idx].type, object_type, CP_OBJECT_TYPE_LEN
+		    ) &&
+		    !strncmp(
+			    objects[idx].name, object_name, CP_OBJECT_NAME_LEN
+		    )) {
+			*index = idx;
+			return 0;
+		}
+	}
+
+	objects = (struct cp_module_object *)memory_brealloc(
+		&cp_module->memory_context,
+		objects,
+		sizeof(struct cp_module_object) * cp_module->object_count,
+		sizeof(struct cp_module_object) * (cp_module->object_count + 1)
+	);
+	if (objects == NULL) {
+		yanet_error_add(
+			err,
+			"failed to reallocate objects array for module '%s:%s'",
+			cp_module->type,
+			cp_module->name
+		);
+		return -1;
+	}
+
+	strtcpy(objects[cp_module->object_count].type,
+		object_type,
+		CP_OBJECT_TYPE_LEN);
+	strtcpy(objects[cp_module->object_count].name,
+		object_name,
+		CP_OBJECT_NAME_LEN);
+	SET_OFFSET_OF(&cp_module->objects, objects);
+	*index = cp_module->object_count;
+	++cp_module->object_count;
 
 	return 0;
 }
@@ -480,7 +542,8 @@ cp_module_parse_performance_counter(
 	// Allocate memory for latency ranges
 	counter->latency_ranges =
 		(struct module_performance_counter_latency_range *)malloc(
-			sizeof(struct module_performance_counter_latency_range
+			sizeof(
+				struct module_performance_counter_latency_range
 			) *
 			hist_buckets
 		);

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -32,6 +32,14 @@ struct cp_module_device {
 	char name[CP_DEVICE_NAME_LEN];
 };
 
+// A module's declared link to a cp_object, identified by the object's
+// (type, name) pair. Resolved to a per-worker object_ectx at execution-context
+// build time, mirroring cp_module_device's name-based device linkage.
+struct cp_module_object {
+	char type[CP_OBJECT_TYPE_LEN];
+	char name[CP_OBJECT_NAME_LEN];
+};
+
 struct cp_module {
 	struct registry_item config_item;
 
@@ -79,6 +87,11 @@ struct cp_module {
 
 	uint64_t device_count;
 	struct cp_module_device *devices;
+
+	// Objects this module links to, declared via cp_module_link_object and
+	// resolved to per-worker object execution contexts at build time.
+	uint64_t object_count;
+	struct cp_module_object *objects;
 };
 
 /**
@@ -96,6 +109,29 @@ int
 cp_module_link_device(
 	struct cp_module *cp_module,
 	const char *name,
+	uint64_t *index,
+	yanet_error **err
+);
+
+/**
+ * Link an object to a module configuration.
+ *
+ * Associates a cp_object with the module by the object's type and name. If an
+ * entry for the same (type, name) already exists, its index is returned
+ * unchanged; otherwise a new entry is appended.
+ *
+ * @param cp_module Pointer to the module configuration
+ * @param object_type Type identifier of the object to link
+ * @param object_name Name identifier of the object to link
+ * @param index Output parameter for the link index
+ * @param err Error output parameter
+ * @return 0 on success, negative error code on failure
+ */
+int
+cp_module_link_object(
+	struct cp_module *cp_module,
+	const char *object_type,
+	const char *object_name,
 	uint64_t *index,
 	yanet_error **err
 );

--- a/lib/controlplane/config/cp_object.c
+++ b/lib/controlplane/config/cp_object.c
@@ -52,6 +52,18 @@ cp_object_init(
 		goto err_out;
 	}
 
+	if (counter_registry_init(
+		    &self->link_counter_registry, &self->memory_context, 0
+	    )) {
+		yanet_error_add(
+			err,
+			"failed to initialize link counter registry for object "
+			"'%s'",
+			name
+		);
+		goto err_out;
+	}
+
 	return 0;
 
 err_out:
@@ -61,6 +73,7 @@ err_out:
 
 void
 cp_object_fini(struct cp_object *self) {
+	counter_registry_fini(&self->link_counter_registry);
 	counter_registry_fini(&self->counter_registry);
 
 	SET_OFFSET_OF(&self->agent, NULL);
@@ -215,6 +228,22 @@ cp_object_registry_upsert(
 		yanet_error_add(
 			err,
 			"failed to link counter registry for object '%s:%s'",
+			object_type,
+			object_name
+		);
+		return -1;
+	}
+
+	if (counter_registry_link(
+		    &new_object->link_counter_registry,
+		    (old_object != NULL) ? &old_object->link_counter_registry
+					 : NULL,
+		    err
+	    )) {
+		yanet_error_add(
+			err,
+			"failed to link link counter registry for object "
+			"'%s:%s'",
 			object_type,
 			object_name
 		);

--- a/lib/controlplane/config/cp_object.h
+++ b/lib/controlplane/config/cp_object.h
@@ -30,6 +30,12 @@ struct cp_object {
 
 	struct counter_registry counter_registry;
 
+	// Counters describing the relation between this object and the modules
+	// that link it. Each module's per-worker link execution context spawns
+	// its own counter storage from this registry, keeping the counter
+	// definitions on the object and the per-link values independent.
+	struct counter_registry link_counter_registry;
+
 	// Controlplane agent the configuration belongs to.
 	struct agent *agent;
 

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -37,6 +37,24 @@ module_ectx_free(
 		);
 	}
 
+	struct module_object_link_ectx *object_links =
+		ADDR_OF(&module_ectx->object_links);
+	if (object_links != NULL) {
+		for (uint64_t idx = 0; idx < module_ectx->object_link_count;
+		     ++idx) {
+			struct counter_storage *link_storage =
+				ADDR_OF(&object_links[idx].counter_storage);
+			if (link_storage != NULL)
+				counter_storage_free(link_storage);
+		}
+		memory_bfree(
+			memory_context,
+			object_links,
+			sizeof(struct module_object_link_ectx) *
+				module_ectx->object_link_count
+		);
+	}
+
 	memory_bfree(memory_context, module_ectx, sizeof(struct module_ectx));
 }
 
@@ -177,13 +195,95 @@ module_ectx_create(
 
 	SET_OFFSET_OF(&module_ectx->counter_storage, counter_storage);
 
+	if (cp_module->object_count > 0) {
+		struct memory_context *counter_storage_memory_context =
+			&cp_config->counter_storage_memory_context;
+
+		struct module_object_link_ectx *object_links =
+			(struct module_object_link_ectx *)memory_balloc(
+				memory_context,
+				sizeof(struct module_object_link_ectx) *
+					cp_module->object_count
+			);
+		if (object_links == NULL) {
+			yanet_error_add(
+				err,
+				"failed to allocate memory for module object "
+				"link execution contexts"
+			);
+			goto error;
+		}
+		memset(object_links,
+		       0,
+		       sizeof(struct module_object_link_ectx) *
+			       cp_module->object_count);
+		module_ectx->object_link_count = cp_module->object_count;
+		SET_OFFSET_OF(&module_ectx->object_links, object_links);
+
+		struct cp_module_object *linked_objects =
+			ADDR_OF(&cp_module->objects);
+		for (uint64_t link_idx = 0; link_idx < cp_module->object_count;
+		     ++link_idx) {
+			uint64_t object_idx;
+			if (cp_config_gen_lookup_object_index(
+				    cp_config_gen,
+				    linked_objects[link_idx].type,
+				    linked_objects[link_idx].name,
+				    &object_idx
+			    )) {
+				yanet_error_add(
+					err,
+					"linked object '%s:%s' not found for "
+					"module '%s:%s'",
+					linked_objects[link_idx].type,
+					linked_objects[link_idx].name,
+					cp_module->type,
+					cp_module->name
+				);
+				goto error;
+			}
+
+			struct cp_object *cp_object = cp_config_gen_get_object(
+				cp_config_gen, object_idx
+			);
+			struct object_ectx *object_ectx =
+				config_gen_ectx_get_object(
+					config_gen_ectx, object_idx
+				);
+
+			struct counter_storage *link_storage =
+				counter_storage_spawn(
+					counter_storage_memory_context,
+					NULL,
+					&cp_object->link_counter_registry
+				);
+			if (link_storage == NULL) {
+				yanet_error_add(
+					err,
+					"failed to spawn link counter storage "
+					"for object '%s:%s'",
+					cp_object->type,
+					cp_object->name
+				);
+				goto error;
+			}
+			SET_OFFSET_OF(
+				&object_links[link_idx].counter_storage,
+				link_storage
+			);
+			SET_OFFSET_OF(
+				&object_links[link_idx].object_ectx, object_ectx
+			);
+		}
+	}
+
 	return module_ectx;
 
 error_storage:
 	counter_storage_free(counter_storage);
 
 error:
-	memory_bfree(memory_context, module_ectx, ectx_size);
+	module_ectx_free(cp_config_gen, module_ectx);
 
 	return NULL;
 }

--- a/lib/controlplane/tests/cp_object_gen_test.c
+++ b/lib/controlplane/tests/cp_object_gen_test.c
@@ -28,6 +28,10 @@
 #include <string.h>
 
 #define CP_OBJECT_GEN_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
+// A link-object unit test allocates only a base cp_module and a small objects
+// array, so a small arena is plenty and avoids cumulative cp-pool pressure
+// from the other tests' no-op agent_detach cycles.
+#define CP_MODULE_LINK_TEST_MEMORY_LIMIT (256u * 1024u)
 
 // Update installs objects into the live generation; lookup, lookup_index,
 // and get_object all agree on identity and index, and a missing name
@@ -382,6 +386,12 @@ test_cp_object_gen_ectx_counter_storage(struct yanet_shm *shm) {
 		) != COUNTER_INVALID,
 		"failed to register counter on object"
 	);
+	TEST_ASSERT(
+		counter_registry_register(
+			&obj->link_counter_registry, "lookups", 1, &err
+		) != COUNTER_INVALID,
+		"failed to register counter on object link counter registry"
+	);
 
 	struct cp_object *objects[] = {obj};
 	TEST_ASSERT_SUCCESS(
@@ -424,6 +434,20 @@ test_cp_object_gen_ectx_counter_storage(struct yanet_shm *shm) {
 		"spawned storage must carry the object's registered counter"
 	);
 
+	// The dedicated link counter registry is independent of the object's
+	// own registry: it carries the relation counter registered above, and
+	// the object's spawned storage does not include it.
+	TEST_ASSERT_EQUAL(
+		(long)obj->link_counter_registry.count,
+		1L,
+		"link counter registry must hold its registered counter"
+	);
+	TEST_ASSERT(
+		storage_registry != &obj->link_counter_registry,
+		"object storage must spawn from the object's own registry, not "
+		"the link registry"
+	);
+
 	// The same storage is reachable through the tag-indexed registry, so
 	// the object's counters are queryable by object_type and object_name.
 	struct counter_tag tags[] = {
@@ -453,6 +477,113 @@ test_cp_object_gen_ectx_counter_storage(struct yanet_shm *shm) {
 
 	cp_object_fini(obj);
 	memory_bfree(&agent->memory_context, obj, sizeof(*obj));
+
+	size_t after = block_allocator_free_size(&agent->block_allocator);
+	TEST_ASSERT_EQUAL(
+		(long)after,
+		(long)baseline,
+		"arena did not return to baseline: baseline=%zu after=%zu",
+		baseline,
+		after
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// cp_module_link_object keys links by the object's (type, name): a repeat link
+// returns the existing index, a same-name different-type object is a distinct
+// link, and cp_module_fini reclaims the array. Uses a base cp_module whose
+// memory context is initialized directly, avoiding module-type loading.
+static int
+test_cp_module_link_object(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"cp-module-link-object",
+		CP_MODULE_LINK_TEST_MEMORY_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	size_t baseline = block_allocator_free_size(&agent->block_allocator);
+
+	struct cp_module *module = (struct cp_module *)memory_balloc(
+		&agent->memory_context, sizeof(struct cp_module)
+	);
+	TEST_ASSERT_NOT_NULL(module, "module allocation failed");
+	memset(module, 0, sizeof(struct cp_module));
+	memory_context_init_from(
+		&module->memory_context, &agent->memory_context, "test-module"
+	);
+
+	uint64_t idx1;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(module, "test", "obj-a", &idx1, &err),
+		"link_object(test:obj-a) failed"
+	);
+	TEST_ASSERT_EQUAL((long)idx1, 0L, "first link must be at index 0");
+
+	uint64_t idx1_again;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(
+			module, "test", "obj-a", &idx1_again, &err
+		),
+		"link_object(test:obj-a) repeat failed"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)idx1_again,
+		0L,
+		"repeat link must return the existing index"
+	);
+
+	uint64_t idx2;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(module, "other", "obj-a", &idx2, &err),
+		"link_object(other:obj-a) failed"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)idx2,
+		1L,
+		"same name, different type must append at index 1"
+	);
+
+	uint64_t idx3;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(module, "test", "obj-b", &idx3, &err),
+		"link_object(test:obj-b) failed"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)idx3, 2L, "third distinct link must append at index 2"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)module->object_count, 3L, "object_count must be 3"
+	);
+
+	struct cp_module_object *objects = ADDR_OF(&module->objects);
+	TEST_ASSERT(
+		!strncmp(objects[0].type, "test", CP_OBJECT_TYPE_LEN) &&
+			!strncmp(objects[0].name, "obj-a", CP_OBJECT_NAME_LEN),
+		"link 0 must keep the (test, obj-a) identity"
+	);
+	TEST_ASSERT(
+		!strncmp(objects[1].type, "other", CP_OBJECT_TYPE_LEN) &&
+			!strncmp(objects[1].name, "obj-a", CP_OBJECT_NAME_LEN),
+		"link 1 must keep the (other, obj-a) identity"
+	);
+	TEST_ASSERT(
+		!strncmp(objects[2].type, "test", CP_OBJECT_TYPE_LEN) &&
+			!strncmp(objects[2].name, "obj-b", CP_OBJECT_NAME_LEN),
+		"link 2 must keep the (test, obj-b) identity"
+	);
+
+	// cp_module_fini frees the objects array (and the base allocations),
+	// verifying the new cleanup path; the struct itself is then returned to
+	// the agent arena.
+	cp_module_fini(module);
+	memory_bfree(&agent->memory_context, module, sizeof(*module));
 
 	size_t after = block_allocator_free_size(&agent->block_allocator);
 	TEST_ASSERT_EQUAL(
@@ -508,6 +639,9 @@ main(void) {
 	}
 	if (res == TEST_SUCCESS) {
 		res = test_cp_object_gen_ectx_counter_storage(shm);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_cp_module_link_object(shm);
 	}
 
 	dataplane_ut_free(ut);

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -36,11 +36,11 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 552,
+	sizeof(struct cp_module) == 568,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 152,
+	sizeof(struct module_ectx) == 168,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -43,7 +43,34 @@ struct module_ectx {
 
 	uint64_t cm_index_size;
 	uint64_t *cm_index;
+
+	// One entry per object this module links to. Each entry owns a counter
+	// storage spawned from the linked object's link counter registry and
+	// references that object's per-worker execution context.
+	uint64_t object_link_count;
+	struct module_object_link_ectx *object_links;
 };
+
+// Per-worker, per-link state for a module's link to a cp_object.
+//
+// counter_storage holds the values for the counters declared in the linked
+// object's link counter registry, private to this module link on this worker.
+// object_ectx references the linked object's per-worker execution context.
+struct module_object_link_ectx {
+	struct counter_storage *counter_storage;
+	struct object_ectx *object_ectx;
+};
+
+// Return the object link execution context at the given link index, or NULL
+// when the index is out of range (the module has no object link at that slot).
+static inline struct module_object_link_ectx *
+object_link_get_address(struct module_ectx *module_ectx, uint64_t index) {
+	if (index >= module_ectx->object_link_count)
+		return NULL;
+	struct module_object_link_ectx *links =
+		ADDR_OF(&module_ectx->object_links);
+	return links + index;
+}
 
 static inline uint64_t
 module_ectx_encode_device(struct module_ectx *module_ectx, uint64_t index) {


### PR DESCRIPTION
- A cp_module declares links to cp_objects by (type, name) via cp_module_link_object, mirroring the device linkage.
- At execution-context build time each link resolves to a module_object_link_ectx inside the module_ectx, owning a counter storage spawned from the linked object's dedicated relation counter registry and referencing that object's per-worker execution context.
- Links are reached at runtime through object_link_get_address, which returns NULL when the module has no link at that index.
- cp_object gains the dedicated relation counter registry alongside its own, with init, fini, and cross-generation linking.
- Bumps YANET_MODULE_ABI_VERSION for the cp_module and module_ectx layout changes.

Stacked on #1692; rebase to main after the chain (#1595 -> #1692) merges.

Note: link counter storages spawn without old-storage reuse for now, so their values reset on a generation swap; tag-indexed reuse is a follow-up.
