### PR TITLE
feat(cp): link modules to objects with per-worker link ectx

### DIFF
--- a/lib/controlplane/config/cp_counter.c
+++ b/lib/controlplane/config/cp_counter.c
@@ -475,10 +475,7 @@ cp_config_counter_storage_registry_lookup_module(
 	struct counter_tag tags[] = {
 		{.key = "device", .value = device_name},
 		{.key = "pipeline", .value = pipeline_name},
-		{
-			.key = "function",
-			.value = function_name,
-		},
+		{.key = "function", .value = function_name},
 		{.key = "chain", .value = chain_name},
 		{.key = "module_type", .value = module_type},
 		{.key = "module_name", .value = module_name},
@@ -542,5 +539,60 @@ cp_config_counter_storage_registry_insert_object(
 	};
 	return cp_config_counter_storage_registry_insert(
 		registry, tags, 3, counter_storage, err
+	);
+}
+
+struct counter_storage *
+cp_config_counter_storage_registry_lookup_module_object_link(
+	struct cp_config_counter_storage_registry *registry,
+	const char *device_name,
+	const char *pipeline_name,
+	const char *function_name,
+	const char *chain_name,
+	const char *module_type,
+	const char *module_name,
+	const char *object_type,
+	const char *object_name
+) {
+	struct counter_tag tags[] = {
+		{.key = "device", .value = device_name},
+		{.key = "pipeline", .value = pipeline_name},
+		{.key = "function", .value = function_name},
+		{.key = "chain", .value = chain_name},
+		{.key = "module_type", .value = module_type},
+		{.key = "module_name", .value = module_name},
+		{.key = "object_type", .value = object_type},
+		{.key = "object_name", .value = object_name}
+	};
+	return get_one(registry, tags, 8);
+}
+
+int
+cp_config_counter_storage_registry_insert_module_object_link(
+	struct cp_config_counter_storage_registry *registry,
+	const char *device_name,
+	const char *pipeline_name,
+	const char *function_name,
+	const char *chain_name,
+	const char *module_type,
+	const char *module_name,
+	const char *object_type,
+	const char *object_name,
+	struct counter_storage *counter_storage,
+	yanet_error **err
+) {
+	struct counter_tag tags[] = {
+		{.key = "device", .value = device_name},
+		{.key = "pipeline", .value = pipeline_name},
+		{.key = "function", .value = function_name},
+		{.key = "chain", .value = chain_name},
+		{.key = "module_type", .value = module_type},
+		{.key = "module_name", .value = module_name},
+		{.key = "object_type", .value = object_type},
+		{.key = "object_name", .value = object_name},
+		{.key = "kind", .value = "module_object_link"}
+	};
+	return cp_config_counter_storage_registry_insert(
+		registry, tags, 9, counter_storage, err
 	);
 }

--- a/lib/controlplane/config/cp_counter.h
+++ b/lib/controlplane/config/cp_counter.h
@@ -9,7 +9,7 @@ struct memory_context;
 
 #define KEY_MAX_SIZE 80
 #define VALUE_MAX_SIZE 80
-#define MAX_TAG_COUNT 8
+#define MAX_TAG_COUNT 16
 
 struct cp_counter_tag {
 	char key[KEY_MAX_SIZE];
@@ -160,6 +160,34 @@ cp_config_counter_storage_registry_lookup_object(
 int
 cp_config_counter_storage_registry_insert_object(
 	struct cp_config_counter_storage_registry *registry,
+	const char *object_type,
+	const char *object_name,
+	struct counter_storage *counter_storage,
+	yanet_error **err
+);
+
+struct counter_storage *
+cp_config_counter_storage_registry_lookup_module_object_link(
+	struct cp_config_counter_storage_registry *registry,
+	const char *device_name,
+	const char *pipeline_name,
+	const char *function_name,
+	const char *chain_name,
+	const char *module_type,
+	const char *module_name,
+	const char *object_type,
+	const char *object_name
+);
+
+int
+cp_config_counter_storage_registry_insert_module_object_link(
+	struct cp_config_counter_storage_registry *registry,
+	const char *device_name,
+	const char *pipeline_name,
+	const char *function_name,
+	const char *chain_name,
+	const char *module_type,
+	const char *module_name,
 	const char *object_type,
 	const char *object_name,
 	struct counter_storage *counter_storage,

--- a/lib/controlplane/config/cp_module.c
+++ b/lib/controlplane/config/cp_module.c
@@ -184,6 +184,18 @@ cp_module_fini(struct cp_module *cp_module) {
 	SET_OFFSET_OF(&cp_module->devices, NULL);
 	cp_module->device_count = 0;
 
+	struct cp_module_object *objects = ADDR_OF(&cp_module->objects);
+	if (objects != NULL) {
+		memory_bfree(
+			&cp_module->memory_context,
+			objects,
+			sizeof(struct cp_module_object) *
+				cp_module->object_count
+		);
+	}
+	SET_OFFSET_OF(&cp_module->objects, NULL);
+	cp_module->object_count = 0;
+
 	SET_OFFSET_OF(&cp_module->agent, NULL);
 
 	memory_context_fini(&cp_module->memory_context);
@@ -225,6 +237,56 @@ cp_module_link_device(
 	SET_OFFSET_OF(&cp_module->devices, devices);
 	*index = cp_module->device_count;
 	++cp_module->device_count;
+
+	return 0;
+}
+
+int
+cp_module_link_object(
+	struct cp_module *cp_module,
+	const char *object_type,
+	const char *object_name,
+	uint64_t *index,
+	yanet_error **err
+) {
+	struct cp_module_object *objects = ADDR_OF(&cp_module->objects);
+	for (uint64_t idx = 0; idx < cp_module->object_count; ++idx) {
+		if (!strncmp(
+			    objects[idx].type, object_type, CP_OBJECT_TYPE_LEN
+		    ) &&
+		    !strncmp(
+			    objects[idx].name, object_name, CP_OBJECT_NAME_LEN
+		    )) {
+			*index = idx;
+			return 0;
+		}
+	}
+
+	objects = (struct cp_module_object *)memory_brealloc(
+		&cp_module->memory_context,
+		objects,
+		sizeof(struct cp_module_object) * cp_module->object_count,
+		sizeof(struct cp_module_object) * (cp_module->object_count + 1)
+	);
+	if (objects == NULL) {
+		yanet_error_add(
+			err,
+			"failed to reallocate objects array for module '%s:%s'",
+			cp_module->type,
+			cp_module->name
+		);
+		return -1;
+	}
+
+	strtcpy(objects[cp_module->object_count].type,
+		object_type,
+		CP_OBJECT_TYPE_LEN);
+	strtcpy(objects[cp_module->object_count].name,
+		object_name,
+		CP_OBJECT_NAME_LEN);
+	SET_OFFSET_OF(&cp_module->objects, objects);
+	*index = cp_module->object_count;
+	++cp_module->object_count;
 
 	return 0;
 }

--- a/lib/controlplane/config/cp_module.h
+++ b/lib/controlplane/config/cp_module.h
@@ -32,6 +32,14 @@ struct cp_module_device {
 	char name[CP_DEVICE_NAME_LEN];
 };
 
+// A module's declared link to a cp_object, identified by the object's
+// (type, name) pair. Resolved to a per-worker object_ectx at execution-context
+// build time, mirroring cp_module_device's name-based device linkage.
+struct cp_module_object {
+	char type[CP_OBJECT_TYPE_LEN];
+	char name[CP_OBJECT_NAME_LEN];
+};
+
 struct cp_module {
 	struct registry_item config_item;
 
@@ -79,6 +87,11 @@ struct cp_module {
 
 	uint64_t device_count;
 	struct cp_module_device *devices;
+
+	// Objects this module links to, declared via cp_module_link_object and
+	// resolved to per-worker object execution contexts at build time.
+	uint64_t object_count;
+	struct cp_module_object *objects;
 };
 
 /**
@@ -96,6 +109,29 @@ int
 cp_module_link_device(
 	struct cp_module *cp_module,
 	const char *name,
+	uint64_t *index,
+	yanet_error **err
+);
+
+/**
+ * Link an object to a module configuration.
+ *
+ * Associates a cp_object with the module by the object's type and name. If an
+ * entry for the same (type, name) already exists, its index is returned
+ * unchanged; otherwise a new entry is appended.
+ *
+ * @param cp_module Pointer to the module configuration
+ * @param object_type Type identifier of the object to link
+ * @param object_name Name identifier of the object to link
+ * @param index Output parameter for the link index
+ * @param err Error output parameter
+ * @return 0 on success, negative error code on failure
+ */
+int
+cp_module_link_object(
+	struct cp_module *cp_module,
+	const char *object_type,
+	const char *object_name,
 	uint64_t *index,
 	yanet_error **err
 );

--- a/lib/controlplane/config/cp_object.c
+++ b/lib/controlplane/config/cp_object.c
@@ -52,6 +52,18 @@ cp_object_init(
 		goto err_out;
 	}
 
+	if (counter_registry_init(
+		    &self->link_counter_registry, &self->memory_context, 0
+	    )) {
+		yanet_error_add(
+			err,
+			"failed to initialize link counter registry for object "
+			"'%s'",
+			name
+		);
+		goto err_out;
+	}
+
 	return 0;
 
 err_out:
@@ -61,6 +73,7 @@ err_out:
 
 void
 cp_object_fini(struct cp_object *self) {
+	counter_registry_fini(&self->link_counter_registry);
 	counter_registry_fini(&self->counter_registry);
 
 	SET_OFFSET_OF(&self->agent, NULL);
@@ -215,6 +228,22 @@ cp_object_registry_upsert(
 		yanet_error_add(
 			err,
 			"failed to link counter registry for object '%s:%s'",
+			object_type,
+			object_name
+		);
+		return -1;
+	}
+
+	if (counter_registry_link(
+		    &new_object->link_counter_registry,
+		    (old_object != NULL) ? &old_object->link_counter_registry
+					 : NULL,
+		    err
+	    )) {
+		yanet_error_add(
+			err,
+			"failed to link link counter registry for object "
+			"'%s:%s'",
 			object_type,
 			object_name
 		);

--- a/lib/controlplane/config/cp_object.h
+++ b/lib/controlplane/config/cp_object.h
@@ -30,6 +30,12 @@ struct cp_object {
 
 	struct counter_registry counter_registry;
 
+	// Counters describing the relation between this object and the modules
+	// that link it. Each module's per-worker link execution context spawns
+	// its own counter storage from this registry, keeping the counter
+	// definitions on the object and the per-link values independent.
+	struct counter_registry link_counter_registry;
+
 	// Controlplane agent the configuration belongs to.
 	struct agent *agent;
 

--- a/lib/controlplane/config/econtext.c
+++ b/lib/controlplane/config/econtext.c
@@ -37,6 +37,25 @@ module_ectx_free(
 		);
 	}
 
+	struct module_object_link_ectx *object_links =
+		ADDR_OF(&module_ectx->object_links);
+	if (object_links != NULL) {
+		for (uint64_t idx = 0; idx < module_ectx->object_link_count;
+		     ++idx) {
+			struct counter_storage *link_storage =
+				ADDR_OF(&object_links[idx].counter_storage);
+			if (link_storage != NULL) {
+				counter_storage_free(link_storage);
+			}
+		}
+		memory_bfree(
+			memory_context,
+			object_links,
+			sizeof(struct module_object_link_ectx) *
+				module_ectx->object_link_count
+		);
+	}
+
 	memory_bfree(memory_context, module_ectx, sizeof(struct module_ectx));
 }
 
@@ -177,13 +196,157 @@ module_ectx_create(
 
 	SET_OFFSET_OF(&module_ectx->counter_storage, counter_storage);
 
+	if (cp_module->object_count > 0) {
+		struct memory_context *counter_storage_memory_context =
+			&cp_config->counter_storage_memory_context;
+
+		struct module_object_link_ectx *object_links =
+			(struct module_object_link_ectx *)memory_balloc(
+				memory_context,
+				sizeof(struct module_object_link_ectx) *
+					cp_module->object_count
+			);
+		if (object_links == NULL) {
+			yanet_error_add(
+				err,
+				"failed to allocate memory for module object "
+				"link execution contexts"
+			);
+			goto error;
+		}
+		memset(object_links,
+		       0,
+		       sizeof(struct module_object_link_ectx) *
+			       cp_module->object_count);
+		module_ectx->object_link_count = cp_module->object_count;
+		SET_OFFSET_OF(&module_ectx->object_links, object_links);
+
+		struct cp_module_object *linked_objects =
+			ADDR_OF(&cp_module->objects);
+		for (uint64_t link_idx = 0; link_idx < cp_module->object_count;
+		     ++link_idx) {
+			uint64_t object_idx;
+			if (cp_config_gen_lookup_object_index(
+				    cp_config_gen,
+				    linked_objects[link_idx].type,
+				    linked_objects[link_idx].name,
+				    &object_idx
+			    )) {
+				yanet_error_add(
+					err,
+					"linked object '%s:%s' not found for "
+					"module '%s:%s'",
+					linked_objects[link_idx].type,
+					linked_objects[link_idx].name,
+					cp_module->type,
+					cp_module->name
+				);
+				goto error;
+			}
+
+			struct cp_object *cp_object = cp_config_gen_get_object(
+				cp_config_gen, object_idx
+			);
+			struct object_ectx *object_ectx =
+				config_gen_ectx_get_object(
+					config_gen_ectx, object_idx
+				);
+			if (object_ectx == NULL) {
+				yanet_error_add(
+					err,
+					"object execution context for '%s:%s' "
+					"not found for module '%s:%s'",
+					linked_objects[link_idx].type,
+					linked_objects[link_idx].name,
+					cp_module->type,
+					cp_module->name
+				);
+				goto error;
+			}
+
+			// Carry the prior generation's link storage so relation
+			// counters survive unrelated config rebuilds, mirroring
+			// the module's own storage above.
+			struct counter_storage *old_link_storage = NULL;
+			if (old_ectx != NULL) {
+				old_link_storage =
+					cp_config_counter_storage_registry_lookup_module_object_link(
+						ADDR_OF(&old_ectx->counter_storage_registry
+						),
+						cp_device->name,
+						cp_pipeline->name,
+						cp_function->name,
+						cp_chain->name,
+						cp_module->type,
+						cp_module->name,
+						cp_object->type,
+						cp_object->name
+					);
+			}
+
+			struct counter_storage *link_storage =
+				counter_storage_spawn(
+					counter_storage_memory_context,
+					old_link_storage,
+					&cp_object->link_counter_registry
+				);
+			if (link_storage == NULL) {
+				yanet_error_add(
+					err,
+					"failed to spawn link counter storage "
+					"for object '%s:%s'",
+					cp_object->type,
+					cp_object->name
+				);
+				goto error;
+			}
+			SET_OFFSET_OF(
+				&object_links[link_idx].counter_storage,
+				link_storage
+			);
+			SET_OFFSET_OF(
+				&object_links[link_idx].object_ectx, object_ectx
+			);
+
+			// Register the link storage under tags from both the
+			// module's path and the linked object, so the relation
+			// counters are queryable by any combination of them.
+			if (cp_config_counter_storage_registry_insert_module_object_link(
+				    ADDR_OF(&config_gen_ectx
+						     ->counter_storage_registry
+				    ),
+				    cp_device->name,
+				    cp_pipeline->name,
+				    cp_function->name,
+				    cp_chain->name,
+				    cp_module->type,
+				    cp_module->name,
+				    cp_object->type,
+				    cp_object->name,
+				    link_storage,
+				    err
+			    )) {
+				yanet_error_add(
+					err,
+					"failed to insert link counter storage "
+					"for module '%s:%s' and object '%s:%s'",
+					cp_module->type,
+					cp_module->name,
+					cp_object->type,
+					cp_object->name
+				);
+				goto error;
+			}
+		}
+	}
+
 	return module_ectx;
 
 error_storage:
 	counter_storage_free(counter_storage);
 
 error:
-	memory_bfree(memory_context, module_ectx, ectx_size);
+	module_ectx_free(cp_config_gen, module_ectx);
 
 	return NULL;
 }
@@ -1599,8 +1762,62 @@ config_gen_ectx_create(
 	}
 	SET_OFFSET_OF(&config_gen_ectx->counter_storage_registry, registry);
 
+	// Set device_count before any fallible work so the error path's
+	// config_gen_ectx_free computes the correct flexible-array size.
 	config_gen_ectx->device_count =
 		cp_device_registry_capacity(&cp_config_gen->device_registry);
+
+	config_gen_ectx->object_count =
+		cp_object_registry_capacity(&cp_config_gen->object_registry);
+
+	if (config_gen_ectx->object_count > 0) {
+		struct object_ectx **objects =
+			(struct object_ectx **)memory_balloc(
+				memory_context,
+				sizeof(struct object_ectx *) *
+					config_gen_ectx->object_count
+			);
+		if (objects == NULL) {
+			yanet_error_add(
+				err,
+				"failed to allocate memory for object "
+				"execution contexts"
+			);
+			goto error;
+		}
+		memset(objects,
+		       0,
+		       sizeof(struct object_ectx *) *
+			       config_gen_ectx->object_count);
+		SET_OFFSET_OF(&config_gen_ectx->objects, objects);
+
+		// Objects are spawned before devices so that module execution
+		// contexts, created during device build, find their linked
+		// object's per-worker context already in place.
+		for (uint64_t object_idx = 0;
+		     object_idx < config_gen_ectx->object_count;
+		     ++object_idx) {
+			struct cp_object *cp_object = cp_config_gen_get_object(
+				cp_config_gen, object_idx
+			);
+			if (cp_object == NULL) {
+				continue;
+			}
+
+			struct object_ectx *object_ectx = object_ectx_create(
+				cp_config_gen,
+				cp_object,
+				config_gen_ectx,
+				old_config_gen,
+				worker_idx,
+				err
+			);
+			if (object_ectx == NULL) {
+				goto error;
+			}
+			SET_OFFSET_OF(objects + object_idx, object_ectx);
+		}
+	}
 
 	for (uint64_t device_idx = 0;
 	     // FIXME: cp_config_gen_device_count
@@ -1637,55 +1854,6 @@ config_gen_ectx_create(
 			"failed to link config generation execution context"
 		);
 		goto error;
-	}
-
-	config_gen_ectx->object_count =
-		cp_object_registry_capacity(&cp_config_gen->object_registry);
-
-	if (config_gen_ectx->object_count > 0) {
-		struct object_ectx **objects =
-			(struct object_ectx **)memory_balloc(
-				memory_context,
-				sizeof(struct object_ectx *) *
-					config_gen_ectx->object_count
-			);
-		if (objects == NULL) {
-			yanet_error_add(
-				err,
-				"failed to allocate memory for object "
-				"execution contexts"
-			);
-			goto error;
-		}
-		memset(objects,
-		       0,
-		       sizeof(struct object_ectx *) *
-			       config_gen_ectx->object_count);
-		SET_OFFSET_OF(&config_gen_ectx->objects, objects);
-
-		for (uint64_t object_idx = 0;
-		     object_idx < config_gen_ectx->object_count;
-		     ++object_idx) {
-			struct cp_object *cp_object = cp_config_gen_get_object(
-				cp_config_gen, object_idx
-			);
-			if (cp_object == NULL) {
-				continue;
-			}
-
-			struct object_ectx *object_ectx = object_ectx_create(
-				cp_config_gen,
-				cp_object,
-				config_gen_ectx,
-				old_config_gen,
-				worker_idx,
-				err
-			);
-			if (object_ectx == NULL) {
-				goto error;
-			}
-			SET_OFFSET_OF(objects + object_idx, object_ectx);
-		}
 	}
 
 	return config_gen_ectx;

--- a/lib/controlplane/tests/cp_object_gen_test.c
+++ b/lib/controlplane/tests/cp_object_gen_test.c
@@ -18,6 +18,9 @@
 
 #include "counters/counters.h"
 
+#include "devices/plain/api/controlplane.h"
+#include "modules/forward/api/controlplane.h"
+
 #include "lib/dataplane_ut/dataplane_ut.h"
 #include "lib/errors/errors.h"
 
@@ -28,6 +31,14 @@
 #include <string.h>
 
 #define CP_OBJECT_GEN_TEST_MEMORY_LIMIT (4u * 1024u * 1024u)
+// A link-object unit test allocates only a base cp_module and a small objects
+// array, so a small arena is plenty and avoids cumulative cp-pool pressure
+// from the other tests' no-op agent_detach cycles.
+#define CP_MODULE_LINK_TEST_MEMORY_LIMIT (256u * 1024u)
+// The module-object-link integration test builds a full
+// device-pipeline-function-chain-module ectx tree plus a forward module
+// and an object.
+#define MODULE_OBJECT_LINK_TEST_MEMORY_LIMIT (2u * 1024u * 1024u)
 
 // Update installs objects into the live generation; lookup, lookup_index,
 // and get_object all agree on identity and index, and a missing name
@@ -382,6 +393,12 @@ test_cp_object_gen_ectx_counter_storage(struct yanet_shm *shm) {
 		) != COUNTER_INVALID,
 		"failed to register counter on object"
 	);
+	TEST_ASSERT(
+		counter_registry_register(
+			&obj->link_counter_registry, "lookups", 1, &err
+		) != COUNTER_INVALID,
+		"failed to register counter on object link counter registry"
+	);
 
 	struct cp_object *objects[] = {obj};
 	TEST_ASSERT_SUCCESS(
@@ -422,6 +439,20 @@ test_cp_object_gen_ectx_counter_storage(struct yanet_shm *shm) {
 		(long)storage_registry->count,
 		1L,
 		"spawned storage must carry the object's registered counter"
+	);
+
+	// The dedicated link counter registry is independent of the object's
+	// own registry: it carries the relation counter registered above, and
+	// the object's spawned storage does not include it.
+	TEST_ASSERT_EQUAL(
+		(long)obj->link_counter_registry.count,
+		1L,
+		"link counter registry must hold its registered counter"
+	);
+	TEST_ASSERT(
+		storage_registry != &obj->link_counter_registry,
+		"object storage must spawn from the object's own registry, not "
+		"the link registry"
 	);
 
 	// The same storage is reachable through the tag-indexed registry, so
@@ -467,22 +498,409 @@ test_cp_object_gen_ectx_counter_storage(struct yanet_shm *shm) {
 	return TEST_SUCCESS;
 }
 
+// cp_module_link_object keys links by the object's (type, name): a repeat link
+// returns the existing index, a same-name different-type object is a distinct
+// link, and cp_module_fini reclaims the array. Uses a base cp_module whose
+// memory context is initialized directly, avoiding module-type loading.
+static int
+test_cp_module_link_object(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"cp-module-link-object",
+		CP_MODULE_LINK_TEST_MEMORY_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	size_t baseline = block_allocator_free_size(&agent->block_allocator);
+
+	struct cp_module *module = (struct cp_module *)memory_balloc(
+		&agent->memory_context, sizeof(struct cp_module)
+	);
+	TEST_ASSERT_NOT_NULL(module, "module allocation failed");
+	memset(module, 0, sizeof(struct cp_module));
+	memory_context_init_from(
+		&module->memory_context, &agent->memory_context, "test-module"
+	);
+
+	uint64_t idx1;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(module, "test", "obj-a", &idx1, &err),
+		"link_object(test:obj-a) failed"
+	);
+	TEST_ASSERT_EQUAL((long)idx1, 0L, "first link must be at index 0");
+
+	uint64_t idx1_again;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(
+			module, "test", "obj-a", &idx1_again, &err
+		),
+		"link_object(test:obj-a) repeat failed"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)idx1_again,
+		0L,
+		"repeat link must return the existing index"
+	);
+
+	uint64_t idx2;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(module, "other", "obj-a", &idx2, &err),
+		"link_object(other:obj-a) failed"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)idx2,
+		1L,
+		"same name, different type must append at index 1"
+	);
+
+	uint64_t idx3;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(module, "test", "obj-b", &idx3, &err),
+		"link_object(test:obj-b) failed"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)idx3, 2L, "third distinct link must append at index 2"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)module->object_count, 3L, "object_count must be 3"
+	);
+
+	struct cp_module_object *objects = ADDR_OF(&module->objects);
+	TEST_ASSERT(
+		!strncmp(objects[0].type, "test", CP_OBJECT_TYPE_LEN) &&
+			!strncmp(objects[0].name, "obj-a", CP_OBJECT_NAME_LEN),
+		"link 0 must keep the (test, obj-a) identity"
+	);
+	TEST_ASSERT(
+		!strncmp(objects[1].type, "other", CP_OBJECT_TYPE_LEN) &&
+			!strncmp(objects[1].name, "obj-a", CP_OBJECT_NAME_LEN),
+		"link 1 must keep the (other, obj-a) identity"
+	);
+	TEST_ASSERT(
+		!strncmp(objects[2].type, "test", CP_OBJECT_TYPE_LEN) &&
+			!strncmp(objects[2].name, "obj-b", CP_OBJECT_NAME_LEN),
+		"link 2 must keep the (test, obj-b) identity"
+	);
+
+	// cp_module_fini frees the objects array (and the base allocations),
+	// verifying the new cleanup path; the struct itself is then returned to
+	// the agent arena.
+	cp_module_fini(module);
+	memory_bfree(&agent->memory_context, module, sizeof(*module));
+
+	size_t after = block_allocator_free_size(&agent->block_allocator);
+	TEST_ASSERT_EQUAL(
+		(long)after,
+		(long)baseline,
+		"arena did not return to baseline: baseline=%zu after=%zu",
+		baseline,
+		after
+	);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+static int
+install_device_with_pipeline(
+	struct agent *agent,
+	struct dp_config *dp_config,
+	struct cp_config *cp_config,
+	const char *device_name,
+	const char *pipeline_name,
+	yanet_error **err
+) {
+	struct cp_device_plain_config *dev_cfg =
+		cp_device_plain_config_new(device_name, 1, 0, err);
+	if (dev_cfg == NULL) {
+		return -1;
+	}
+	cp_device_plain_config_set_input_pipeline(dev_cfg, 0, pipeline_name, 1);
+	struct cp_device *dev = cp_device_plain_new(agent, dev_cfg, err);
+	cp_device_plain_config_free(dev_cfg);
+	if (dev == NULL) {
+		return -1;
+	}
+	struct cp_device *devs[] = {dev};
+	return cp_config_update_devices(dp_config, cp_config, 1, devs, err);
+}
+
+// A forward module linked to an installed object produces a per-worker link
+// execution context whose spawned counter storage carries the object's link
+// counters and is reachable through the tag-indexed registry under tags
+// inherited from both the module's path and the linked object.
+static int
+test_module_object_link_ectx(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"mod-obj-link-ectx",
+		MODULE_OBJECT_LINK_TEST_MEMORY_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	// Install the object first so its per-worker ectx exists before the
+	// module ectx build resolves the link.
+	struct cp_object *obj = (struct cp_object *)memory_balloc(
+		&agent->memory_context, sizeof(struct cp_object)
+	);
+	TEST_ASSERT_NOT_NULL(obj, "object allocation failed");
+	TEST_ASSERT_SUCCESS(
+		cp_object_init(obj, agent, "test", "linked", &err),
+		"cp_object_init failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	TEST_ASSERT(
+		counter_registry_register(
+			&obj->link_counter_registry, "lookups", 1, &err
+		) != COUNTER_INVALID,
+		"failed to register link counter"
+	);
+
+	struct cp_object *objects[] = {obj};
+	TEST_ASSERT_SUCCESS(
+		agent_update_objects(agent, 1, objects, &err),
+		"agent_update_objects failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	// Create the forward module and link the object to it before install.
+	struct cp_module *module =
+		forward_module_config_init(agent, "fwd0", &err);
+	TEST_ASSERT_NOT_NULL(module, "forward_module_config_init failed");
+	uint64_t link_idx;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(
+			module, "test", "linked", &link_idx, &err
+		),
+		"cp_module_link_object failed"
+	);
+	TEST_ASSERT_EQUAL(
+		(long)link_idx, 0L, "first object link must be at index 0"
+	);
+	struct cp_module *modules[] = {module};
+	TEST_ASSERT_SUCCESS(
+		cp_config_update_modules(
+			dp_config, cp_config, 1, modules, &err
+		),
+		"update_modules failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	// Install the function, pipeline, then the device. The device install
+	// triggers the full ectx build where the module's object link is
+	// resolved and the link counter storage is spawned and registered.
+	const char *const chain_types[] = {"forward"};
+	const char *const chain_names[] = {"fwd0"};
+	struct cp_chain_config *chain_cfg =
+		cp_chain_config_create("chain0", 1, chain_types, chain_names);
+	TEST_ASSERT_NOT_NULL(chain_cfg, "chain_config_create failed");
+	struct cp_function_config *func_cfg =
+		cp_function_config_create("func0", 1);
+	TEST_ASSERT_NOT_NULL(func_cfg, "function_config_create failed");
+	TEST_ASSERT_SUCCESS(
+		cp_function_config_set_chain(func_cfg, 0, chain_cfg, 1),
+		"set_chain failed"
+	);
+	struct cp_function_config *func_cfgs[] = {func_cfg};
+	TEST_ASSERT_SUCCESS(
+		cp_config_update_functions(
+			dp_config, cp_config, 1, func_cfgs, &err
+		),
+		"update_functions failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_function_config_free(func_cfg);
+
+	struct cp_pipeline_config *pipe_cfg =
+		cp_pipeline_config_create("pipe0", 1);
+	TEST_ASSERT_NOT_NULL(pipe_cfg, "pipeline_config_create failed");
+	TEST_ASSERT_SUCCESS(
+		cp_pipeline_config_set_function(pipe_cfg, 0, "func0"),
+		"set_function failed"
+	);
+	struct cp_pipeline_config *pipe_cfgs[] = {pipe_cfg};
+	TEST_ASSERT_SUCCESS(
+		cp_config_update_pipelines(
+			dp_config, cp_config, 1, pipe_cfgs, &err
+		),
+		"update_pipelines failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_pipeline_config_free(pipe_cfg);
+
+	TEST_ASSERT_SUCCESS(
+		install_device_with_pipeline(
+			agent, dp_config, cp_config, "dev0", "pipe0", &err
+		),
+		"update_devices failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+
+	// The link counter storage is registered under tags combining the
+	// module's path and the linked object's identity.
+	struct cp_config_gen *gen = ADDR_OF(&cp_config->cp_config_gen);
+	struct config_gen_ectx *ectx = cp_config_gen_worker_ectx(gen, 0);
+	TEST_ASSERT_NOT_NULL(ectx, "worker 0 execution context must exist");
+
+	struct counter_tag tags[] = {
+		{.key = "module_type", .value = "forward"},
+		{.key = "module_name", .value = "fwd0"},
+		{.key = "object_type", .value = "test"},
+		{.key = "object_name", .value = "linked"}
+	};
+	struct cp_counter_storage **found =
+		cp_config_counter_storage_registry_find(
+			ADDR_OF(&ectx->counter_storage_registry), tags, 4, NULL
+		);
+	TEST_ASSERT_NOT_NULL(found, "tag find must not fail");
+	TEST_ASSERT(
+		found[0] != NULL && found[1] == NULL,
+		"tag find must match exactly the one link storage"
+	);
+
+	// The spawned storage carries the link counter registered on the
+	// object's link counter registry.
+	struct counter_storage *link_storage = ADDR_OF(&found[0]->storage);
+	struct counter_registry *storage_registry =
+		ADDR_OF(&link_storage->registry);
+	TEST_ASSERT_EQUAL(
+		(long)storage_registry->count,
+		1L,
+		"link storage must carry the object's link counter"
+	);
+	free(found);
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
+// Generation must fail when a module links to an object that is not installed:
+// the device install triggers the ectx build where the link resolution fails.
+//
+// Uses distinct names from the positive test so the inherited generation's
+// pipeline path is not disturbed.
+static int
+test_module_object_link_missing_fails(struct yanet_shm *shm) {
+	yanet_error *err = NULL;
+
+	struct agent *agent = agent_attach(
+		shm,
+		0,
+		"mod-obj-link-missing",
+		MODULE_OBJECT_LINK_TEST_MEMORY_LIMIT,
+		&err
+	);
+	TEST_ASSERT_NOT_NULL(agent, "agent_attach failed");
+
+	struct dp_config *dp_config = agent_dp_config(agent);
+	struct cp_config *cp_config = ADDR_OF(&agent->cp_config);
+
+	// Create the forward module linking to an object that was never
+	// installed. The module install succeeds because no device references
+	// a pipeline containing this module yet.
+	struct cp_module *module =
+		forward_module_config_init(agent, "fwd-missing", &err);
+	TEST_ASSERT_NOT_NULL(module, "forward_module_config_init failed");
+	uint64_t link_idx;
+	TEST_ASSERT_SUCCESS(
+		cp_module_link_object(
+			module, "test", "nonexistent", &link_idx, &err
+		),
+		"cp_module_link_object failed"
+	);
+	struct cp_module *modules[] = {module};
+	TEST_ASSERT_SUCCESS(
+		cp_config_update_modules(
+			dp_config, cp_config, 1, modules, &err
+		),
+		"update_modules must succeed before pipeline is wired"
+	);
+
+	const char *const chain_types[] = {"forward"};
+	const char *const chain_names[] = {"fwd-missing"};
+	struct cp_chain_config *chain_cfg = cp_chain_config_create(
+		"chain-missing", 1, chain_types, chain_names
+	);
+	TEST_ASSERT_NOT_NULL(chain_cfg, "chain_config_create failed");
+	struct cp_function_config *func_cfg =
+		cp_function_config_create("func-missing", 1);
+	TEST_ASSERT_NOT_NULL(func_cfg, "function_config_create failed");
+	TEST_ASSERT_SUCCESS(
+		cp_function_config_set_chain(func_cfg, 0, chain_cfg, 1),
+		"set_chain failed"
+	);
+	struct cp_function_config *func_cfgs[] = {func_cfg};
+	TEST_ASSERT_SUCCESS(
+		cp_config_update_functions(
+			dp_config, cp_config, 1, func_cfgs, &err
+		),
+		"update_functions failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_function_config_free(func_cfg);
+
+	struct cp_pipeline_config *pipe_cfg =
+		cp_pipeline_config_create("pipe-missing", 1);
+	TEST_ASSERT_NOT_NULL(pipe_cfg, "pipeline_config_create failed");
+	TEST_ASSERT_SUCCESS(
+		cp_pipeline_config_set_function(pipe_cfg, 0, "func-missing"),
+		"set_function failed"
+	);
+	struct cp_pipeline_config *pipe_cfgs[] = {pipe_cfg};
+	TEST_ASSERT_SUCCESS(
+		cp_config_update_pipelines(
+			dp_config, cp_config, 1, pipe_cfgs, &err
+		),
+		"update_pipelines failed: %s",
+		err ? yanet_error_message(err) : "?"
+	);
+	cp_pipeline_config_free(pipe_cfg);
+
+	// The device install triggers the full ectx build. The module's link
+	// to the non-existent object fails resolution, so the generation
+	// install must fail.
+	int rc = install_device_with_pipeline(
+		agent, dp_config, cp_config, "dev-missing", "pipe-missing", &err
+	);
+	TEST_ASSERT(
+		rc != 0,
+		"device install must fail when a linked object is missing"
+	);
+	yanet_error_free(err);
+	err = NULL;
+
+	agent_detach(agent);
+	return TEST_SUCCESS;
+}
+
 int
 main(void) {
 	log_enable_name("debug");
 
 	const char *port_names[] = {"01:00.0"};
+	const char *mods_to_load[] = {"forward"};
 	const char *devs_to_load[] = {"plain"};
 	const char *objs_to_load[] = {"test"};
 
 	struct dataplane_ut_config cfg = {
-		.cp_memory = 1u << 25,
+		.cp_memory = 1u << 26,
 		.dp_memory = 1u << 20,
 		.worker_count = 1,
 		.devices = port_names,
 		.device_count = 1,
-		.modules = NULL,
-		.module_count = 0,
+		.modules = mods_to_load,
+		.module_count = 1,
 		.devices_to_load = devs_to_load,
 		.devices_to_load_count = 1,
 		.objects_to_load = objs_to_load,
@@ -508,6 +926,15 @@ main(void) {
 	}
 	if (res == TEST_SUCCESS) {
 		res = test_cp_object_gen_ectx_counter_storage(shm);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_cp_module_link_object(shm);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_module_object_link_ectx(shm);
+	}
+	if (res == TEST_SUCCESS) {
+		res = test_module_object_link_missing_fails(shm);
 	}
 
 	dataplane_ut_free(ut);

--- a/lib/controlplane/tests/meson.build
+++ b/lib/controlplane/tests/meson.build
@@ -72,15 +72,18 @@ cp_object_gen_test = executable(
     '-Wl,-E',
     '-Wl,--undefined=new_device_plain',
     '-Wl,--export-dynamic-symbol=new_device_plain',
+    '-Wl,--undefined=new_module_forward',
+    '-Wl,--export-dynamic-symbol=new_module_forward',
   ],
   dependencies: [
     lib_dataplane_ut_dep,
     lib_logging_dep,
     lib_errors_dep,
     lib_dev_plain_api,
+    lib_forward_cp_dep,
     libdpdk_dep,
   ],
-  link_with: [lib_dev_plain_dp],
+  link_with: [lib_dev_plain_dp, lib_forward_dp],
   include_directories: yanet_rootdir,
 )
 

--- a/lib/dataplane/config/plugin_abi_assert.h
+++ b/lib/dataplane/config/plugin_abi_assert.h
@@ -36,11 +36,11 @@ _Static_assert(
 	"struct packet_front size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct cp_module) == 552,
+	sizeof(struct cp_module) == 568,
 	"struct cp_module size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(
-	sizeof(struct module_ectx) == 152,
+	sizeof(struct module_ectx) == 168,
 	"struct module_ectx size changed, bump YANET_MODULE_ABI_VERSION"
 );
 _Static_assert(

--- a/lib/dataplane/module/module.h
+++ b/lib/dataplane/module/module.h
@@ -9,7 +9,7 @@
 //
 // The dataplane's plugin loader rejects a .so whose exported version does
 // not match this constant.
-#define YANET_MODULE_ABI_VERSION 12
+#define YANET_MODULE_ABI_VERSION 13
 
 // Symbol name a module .so exports carrying its compiled-against
 // YANET_MODULE_ABI_VERSION, as a uint32_t global.

--- a/lib/dataplane/pipeline/econtext.h
+++ b/lib/dataplane/pipeline/econtext.h
@@ -43,7 +43,35 @@ struct module_ectx {
 
 	uint64_t cm_index_size;
 	uint64_t *cm_index;
+
+	// One entry per object this module links to. Each entry owns a counter
+	// storage spawned from the linked object's link counter registry and
+	// references that object's per-worker execution context.
+	uint64_t object_link_count;
+	struct module_object_link_ectx *object_links;
 };
+
+// Per-worker, per-link state for a module's link to a cp_object.
+//
+// counter_storage holds the values for the counters declared in the linked
+// object's link counter registry, private to this module link on this worker.
+// object_ectx references the linked object's per-worker execution context.
+struct module_object_link_ectx {
+	struct counter_storage *counter_storage;
+	struct object_ectx *object_ectx;
+};
+
+// Return the object link execution context at the given link index, or NULL
+// when the index is out of range (the module has no object link at that slot).
+static inline struct module_object_link_ectx *
+object_link_get_address(struct module_ectx *module_ectx, uint64_t index) {
+	if (index >= module_ectx->object_link_count) {
+		return NULL;
+	}
+	struct module_object_link_ectx *links =
+		ADDR_OF(&module_ectx->object_links);
+	return links + index;
+}
 
 static inline uint64_t
 module_ectx_encode_device(struct module_ectx *module_ectx, uint64_t index) {


### PR DESCRIPTION
- A cp_module declares links to cp_objects by (type, name) via cp_module_link_object, mirroring the device linkage.
- At execution-context build time each link resolves to a module_object_link_ectx inside the module_ectx, owning a counter storage spawned from the linked object's dedicated relation counter registry and referencing that object's per-worker execution context.
- Links are reached at runtime through object_link_get_address, which returns NULL when the module has no link at that index.
- cp_object gains the dedicated relation counter registry alongside its own, with init, fini, and cross-generation linking.
- Bumps YANET_MODULE_ABI_VERSION for the cp_module and module_ectx layout changes.

Builds on the per-worker object ectx work (merged in #1702). Link counter storages spawn without old-storage reuse for now, so their values reset on a generation swap; tag-indexed reuse is a follow-up.
