### PR TITLE
fix(route): scrape only nexthop counters the FIB can still reach

### DIFF
--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -195,6 +195,7 @@ private:modules/acl/controlplane/service.go:ACLService.withEntries:e.updateMu:1 
 private:modules/acl/controlplane/service.go:ACLService.withEntries:e.updateMu:2  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.withEntry:entry.updateMu:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.withEntry:entry.updateMu:2  # legacy: encapsulate behind an exported method or field
+private:modules/route/bindings/go/croute/safe.go:ModuleConfig.ActiveNexthopCounterNames:iter.activeCounterNames:1  # mirrors the sibling fibIter accessors DumpFIB already reaches through
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.addressFamily:1  # legacy: encapsulate behind an exported method or field
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.destroy:1  # legacy: encapsulate behind an exported method or field
 private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.next:1  # legacy: encapsulate behind an exported method or field

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -181,8 +181,13 @@ func newFIBIter(config *ModuleConfig) (*fibIter, error) {
 }
 
 // destroy maps 1:1 to fib_iter_free.
+//
+// Safe to call multiple times: subsequent calls are no-ops.
 func (m *fibIter) destroy() {
-	C.fib_iter_free(m.ptr)
+	if m.ptr != nil {
+		C.fib_iter_free(m.ptr)
+		m.ptr = nil
+	}
 }
 
 // next maps 1:1 to fib_iter_next.
@@ -234,4 +239,20 @@ func (m *fibIter) nexthopDeviceName(idx uint64) string {
 // nexthopCounterName maps 1:1 to fib_iter_nexthop_counter_name.
 func (m *fibIter) nexthopCounterName(idx uint64) string {
 	return C.GoString(C.fib_iter_nexthop_counter_name(m.ptr, C.uint64_t(idx)))
+}
+
+// activeCounterNames walks the remainder of the FIB, collecting every
+// non-empty per-nexthop counter name, then destroys the iterator.
+func (m *fibIter) activeCounterNames() map[string]struct{} {
+	defer m.destroy()
+
+	names := map[string]struct{}{}
+	for m.next() {
+		for idx := range m.nexthopCount() {
+			if name := m.nexthopCounterName(idx); name != "" {
+				names[name] = struct{}{}
+			}
+		}
+	}
+	return names
 }

--- a/modules/route/bindings/go/croute/safe.go
+++ b/modules/route/bindings/go/croute/safe.go
@@ -2,8 +2,10 @@ package croute
 
 import (
 	"fmt"
+	"maps"
 	"net"
 	"net/netip"
+	"slices"
 )
 
 const (
@@ -134,4 +136,19 @@ func (m *ModuleConfig) DumpFIB() ([]FIBEntry, error) {
 	}
 
 	return entries, nil
+}
+
+// ActiveNexthopCounterNames returns the deduplicated, sorted set of
+// per-nexthop counter names reachable through the resolved FIB.
+//
+// The iterator walks the LPM after overlap resolution, so a nexthop fully
+// shadowed by a later, overlapping entry is excluded here even though its
+// route and counter are still registered in shared memory.
+func (m *ModuleConfig) ActiveNexthopCounterNames() ([]string, error) {
+	iter, err := newFIBIter(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create FIB iterator: %w", err)
+	}
+
+	return slices.Sorted(maps.Keys(iter.activeCounterNames())), nil
 }

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -16,6 +16,11 @@ import (
 // memory.
 type ModuleHandle interface {
 	DumpFIB() ([]croute.FIBEntry, error)
+	// ActiveNexthopCounterNames returns the deduplicated, sorted set of
+	// per-nexthop counter names reachable through the resolved FIB.
+	//
+	// The only realistic failure is a control-plane allocation failure.
+	ActiveNexthopCounterNames() ([]string, error)
 	// RouteCount returns the number of distinct hardware nexthops the
 	// config resolves prefixes to.
 	RouteCount() uint64

--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -106,13 +106,13 @@ func intersectSorted(a, b []string) []string {
 var noNexthopStructuralCounters = []string{}
 
 // collectNexthopMetrics gathers packet and byte counters for every
-// per-nexthop counter registered by any applied config.
+// per-nexthop counter reachable through any applied config.
 //
 // A "counter" tag is pushed down into the dataplane counter read, so
 // counters excluded by tags are never read from shared memory. An empty
 // name list is never passed to ModuleCounters, which treats it as "all
 // counters", and an exact tag is intersected against the config's own
-// registered names so a module-level or foreign-config counter can never
+// reachable names so a module-level or foreign-config counter can never
 // surface under this family.
 func (m *RouteService) collectNexthopMetrics(tags []*commonpb.MetricTag) []*commonpb.Metric {
 	m.shmLock.RLock()

--- a/modules/route/controlplane/service.go
+++ b/modules/route/controlplane/service.go
@@ -67,8 +67,8 @@ type configEntry struct {
 	// resolves its prefixes to.
 	NexthopCount uint64
 	// NexthopCounterNames is the deduplicated, sorted set of per-nexthop
-	// counter names this config registered, so the metrics path can query
-	// them without re-walking the FIB.
+	// counter names reachable through this config, so the metrics path
+	// can query them without re-walking the FIB.
 	NexthopCounterNames []string
 	// UpdatedAt is when the FIB was applied to the dataplane, and backs
 	// the staleness gauge.
@@ -282,7 +282,7 @@ func materializeNexthopCounter(device string, dstMAC [6]byte) string {
 }
 
 // resolveNexthopCounters validates and materializes nexthop counter names
-// across entries, returning the deduplicated, sorted set of names.
+// across entries.
 //
 // A generated name is never truncated on overflow: the trailing MAC is what
 // makes two nexthops distinct, so truncating would merge their counters.
@@ -290,8 +290,7 @@ func materializeNexthopCounter(device string, dstMAC [6]byte) string {
 // The conflict check spans the whole request: backend.UpdateModule keys a
 // nexthop's route by hardware identity alone, so only the first entry for
 // an identity sets its counter, and a per-entry check could miss the clash.
-func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) ([]string, error) {
-	names := map[string]struct{}{}
+func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) error {
 	identityCounters := map[HardwareRoute]string{}
 
 	for _, entry := range entries {
@@ -300,7 +299,7 @@ func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) ([]st
 
 			if m.disableNexthopCounters {
 				if counter != "" {
-					return nil, status.Errorf(
+					return status.Errorf(
 						codes.InvalidArgument,
 						"nexthop for device %q (dst_mac=%x) carries a counter name but nexthop counters are disabled (disable_nexthop_counters)",
 						nh.GetDevice(),
@@ -315,7 +314,7 @@ func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) ([]st
 				counter = materializeNexthopCounter(nh.GetDevice(), nh.GetDstMac().EUI48())
 				nh.Counter = counter
 			} else if !strings.HasPrefix(counter, nexthopCounterPrefix) {
-				return nil, status.Errorf(
+				return status.Errorf(
 					codes.InvalidArgument,
 					"nexthop counter %q must start with %q",
 					counter,
@@ -324,9 +323,9 @@ func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) ([]st
 			}
 
 			// Rejected rather than silently truncated at the C strnlen
-			// boundary, which would diverge from the name in this dedup set.
+			// boundary, which would diverge from the name registered later.
 			if strings.IndexByte(counter, 0) >= 0 {
-				return nil, status.Errorf(
+				return status.Errorf(
 					codes.InvalidArgument,
 					"nexthop counter %q must not contain a NUL byte",
 					counter,
@@ -335,7 +334,7 @@ func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) ([]st
 
 			if len(counter) > croute.CounterNameMaxLen {
 				if generated {
-					return nil, status.Errorf(
+					return status.Errorf(
 						codes.InvalidArgument,
 						"generated nexthop counter %q for device %q exceeds the maximum length of %d",
 						counter,
@@ -343,7 +342,7 @@ func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) ([]st
 						croute.CounterNameMaxLen,
 					)
 				}
-				return nil, status.Errorf(
+				return status.Errorf(
 					codes.InvalidArgument,
 					"nexthop counter %q exceeds the maximum length of %d",
 					counter,
@@ -355,7 +354,7 @@ func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) ([]st
 			// reject — this check only needs the identity, not full validation.
 			if hardwareRoute, err := newHardwareRoute(nh); err == nil {
 				if prior, ok := identityCounters[hardwareRoute]; ok && prior != counter {
-					return nil, status.Errorf(
+					return status.Errorf(
 						codes.InvalidArgument,
 						"nexthop %s (device %q) carries conflicting counter names %q and %q",
 						hardwareRoute,
@@ -366,18 +365,10 @@ func (m *RouteService) resolveNexthopCounters(entries []*routepb.FIBEntry) ([]st
 				}
 				identityCounters[hardwareRoute] = counter
 			}
-
-			names[counter] = struct{}{}
 		}
 	}
 
-	result := make([]string, 0, len(names))
-	for name := range names {
-		result = append(result, name)
-	}
-	sort.Strings(result)
-
-	return result, nil
+	return nil
 }
 
 // UpdateFIB applies a freshly-built FIB to the dataplane atomically.
@@ -404,8 +395,7 @@ func (m *RouteService) UpdateFIB(
 	// Runs before the backend call: a disabled-but-set or over-long name is
 	// rejected before anything is applied, and the generated name written
 	// onto nh.Counter is what the backend and the FIBEntry list agree on.
-	nexthopCounterNames, err := m.resolveNexthopCounters(entries)
-	if err != nil {
+	if err := m.resolveNexthopCounters(entries); err != nil {
 		return nil, err
 	}
 
@@ -415,6 +405,18 @@ func (m *RouteService) UpdateFIB(
 	module, err := m.backend.UpdateModule(name, entries)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to apply FIB for %q: %v", name, err)
+	}
+
+	// The exported set is the reachable one, read back off the handle
+	// rather than the request: an entry a later one fully shadows never
+	// materializes a range here, so its counter name is not exported.
+	nexthopCounterNames, err := module.ActiveNexthopCounterNames()
+	if err != nil {
+		// module is live, so this must never free it here — workers may
+		// dereference it. The caller retries on error and resends the
+		// whole FIB, so surfacing this one would burn a fresh config
+		// generation from the arena, the worst response to memory pressure.
+		nexthopCounterNames = nil
 	}
 
 	if old, ok := m.configs[name]; ok {

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -1,7 +1,9 @@
 package route_test
 
 import (
+	"errors"
 	"net/netip"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -18,14 +20,26 @@ import (
 
 // fakeHandle is an in-memory implementation of route.ModuleHandle.
 type fakeHandle struct {
-	routeCount uint64
-	rangesV4   uint64
-	rangesV6   uint64
-	freed      bool
+	routeCount          uint64
+	rangesV4            uint64
+	rangesV6            uint64
+	nexthopCounterNames []string
+	// activeNamesErr, when set, is returned by ActiveNexthopCounterNames
+	// instead of nexthopCounterNames, standing in for the control-plane
+	// OOM that is the only realistic way that call fails.
+	activeNamesErr error
+	freed          bool
 }
 
 func (m *fakeHandle) DumpFIB() ([]croute.FIBEntry, error) {
 	return nil, nil
+}
+
+func (m *fakeHandle) ActiveNexthopCounterNames() ([]string, error) {
+	if m.activeNamesErr != nil {
+		return nil, m.activeNamesErr
+	}
+	return m.nexthopCounterNames, nil
 }
 
 func (m *fakeHandle) RouteCount() uint64 {
@@ -61,11 +75,31 @@ func newFakeBackend() *fakeBackend {
 	return &fakeBackend{handle: &fakeHandle{}}
 }
 
+// UpdateModule records the call and derives the handle's counter names
+// straight off entries, without resolving overlaps: the fake has no LPM, so
+// a test exercising shadowed-nexthop exclusion must go through the real
+// backend instead.
 func (m *fakeBackend) UpdateModule(name string, entries []*routepb.FIBEntry) (route.ModuleHandle, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	m.updateCalls = append(m.updateCalls, entries)
+
+	names := map[string]struct{}{}
+	for _, entry := range entries {
+		for _, nh := range entry.GetNexthops() {
+			if counter := nh.GetCounter(); counter != "" {
+				names[counter] = struct{}{}
+			}
+		}
+	}
+	sorted := make([]string, 0, len(names))
+	for name := range names {
+		sorted = append(sorted, name)
+	}
+	sort.Strings(sorted)
+	m.handle.nexthopCounterNames = sorted
+
 	return m.handle, nil
 }
 
@@ -549,7 +583,7 @@ func TestUpdateFIBRejectsOverlongCounter(t *testing.T) {
 // TestUpdateFIBRejectsCounterWithNULByte verifies that a counter name
 // carrying an embedded NUL byte is rejected, rather than silently
 // truncated at the C boundary where it would diverge from the name
-// recorded in the deduplicated counter-name set.
+// registered later.
 func TestUpdateFIBRejectsCounterWithNULByte(t *testing.T) {
 	backend := newFakeBackend()
 	service := route.NewRouteService(backend)
@@ -621,6 +655,40 @@ func TestUpdateFIBRejectsConflictingCounterNamesAcrossEntries(t *testing.T) {
 	})
 	require.Equal(t, codes.InvalidArgument, status.Code(err))
 	require.Empty(t, backend.updateCalls, "the backend must not be called when validation rejects the request")
+}
+
+// TestUpdateFIBToleratesActiveNexthopCounterNamesFailure verifies that a
+// failure reading back the reachable counter-name set off an
+// already-published handle still reports success, since the FIB itself did
+// apply, and leaves the handle live and tracked rather than freeing it.
+func TestUpdateFIBToleratesActiveNexthopCounterNamesFailure(t *testing.T) {
+	backend := newFakeBackend()
+	backend.handle = &fakeHandle{routeCount: 3, activeNamesErr: errors.New("fib_iter_new: allocation failure")}
+	backend.counters = []route.CounterView{
+		counterView("nexthop_my_counter", [][]uint64{{1, 100}}),
+	}
+	service := route.NewRouteService(backend)
+
+	entry := testFIBEntry(t, "10.0.0.0/32", testNexthop("eth0", "nexthop_my_counter"))
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "cfg",
+		Entries:    []*routepb.FIBEntry{entry},
+	})
+	require.NoError(t, err, "the FIB itself did apply, so the RPC must still report success")
+	require.False(t, backend.handle.freed, "a published handle must never be freed on this path")
+
+	requireConfigGauges(t, service, 0, 0, 3)
+
+	all, err := service.Metrics()
+	require.NoError(t, err)
+	require.Empty(t, findMetrics(all, "route_nexthop_packets"), "the counter set must be empty until the next update")
+	for _, query := range backend.queries {
+		require.NotContains(t, query, "nexthop_my_counter", "the empty counter set must never be queried for")
+	}
+
+	_, err = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "cfg"})
+	require.NoError(t, err)
+	require.True(t, backend.handle.freed, "the config must still be tracked so DeleteConfig can free it")
 }
 
 // TestNexthopMetricsSumWorkerInstances verifies that collectNexthopMetrics

--- a/modules/route/tests/functional/route_test.go
+++ b/modules/route/tests/functional/route_test.go
@@ -130,16 +130,8 @@ func wirePipeline(
 	}}))
 }
 
-// applyFIB pushes entries via backend.UpdateModule and registers cleanup.
-//
-// Returns the route.ModuleHandle. The caller may inspect it. The handle is
-// freed via tb.Cleanup.
-func applyFIB(
-	tb testing.TB,
-	backend route.Backend,
-	name string,
-	entries []FIBEntry,
-) route.ModuleHandle {
+// toFIBEntries converts test-domain FIB entries to their wire form.
+func toFIBEntries(tb testing.TB, entries []FIBEntry) []*routepb.FIBEntry {
 	tb.Helper()
 
 	pbEntries := make([]*routepb.FIBEntry, 0, len(entries))
@@ -160,8 +152,22 @@ func applyFIB(
 			Nexthops: nexthops,
 		})
 	}
+	return pbEntries
+}
 
-	handle, err := backend.UpdateModule(name, pbEntries)
+// applyFIB pushes entries via backend.UpdateModule and registers cleanup.
+//
+// Returns the route.ModuleHandle. The caller may inspect it. The handle is
+// freed via tb.Cleanup.
+func applyFIB(
+	tb testing.TB,
+	backend route.Backend,
+	name string,
+	entries []FIBEntry,
+) route.ModuleHandle {
+	tb.Helper()
+
+	handle, err := backend.UpdateModule(name, toFIBEntries(tb, entries))
 	require.NoError(tb, err)
 	tb.Cleanup(handle.Free)
 	return handle
@@ -1097,4 +1103,66 @@ func TestUpdateFIB_EmptyNexthopEntryDoesNotDisplaceEarlierEntry(t *testing.T) {
 	require.Len(t, fib[0].Nexthops, 1)
 	require.Equal(t, "port0", fib[0].Nexthops[0].Device)
 	require.Empty(t, fib[0].Nexthops[0].Counter, "uncounted nexthop must round-trip as empty, not a stale or garbage name")
+}
+
+// nexthopCounterLabels returns the "counter" label value of every
+// route_nexthop_packets series.
+func nexthopCounterLabels(all []*commonpb.Metric) []string {
+	var names []string
+	for _, metric := range all {
+		if metric.GetName() != "route_nexthop_packets" {
+			continue
+		}
+		for _, label := range metric.GetLabels() {
+			if label.GetName() == "counter" {
+				names = append(names, label.GetValue())
+			}
+		}
+	}
+	return names
+}
+
+// TestUpdateFIB_ShadowedNexthopCounterExcludedFromMetrics verifies that a
+// nexthop entirely shadowed by a later, overlapping entry never surfaces a
+// route_nexthop_* series, while the surviving nexthop's series does.
+//
+// It goes through RouteService.UpdateFIB and Metrics with the real backend:
+// only the real LPM resolves the overlap, and a fake ModuleCounters can't
+// reveal which names the metrics path actually asked the dataplane for.
+func TestUpdateFIB_ShadowedNexthopCounterExcludedFromMetrics(t *testing.T) {
+	shadowedHop := FIBNexthop{
+		DstMAC:  xerror.Unwrap(net.ParseMAC("de:ad:be:ef:00:07")),
+		SrcMAC:  xerror.Unwrap(net.ParseMAC("ca:fe:ba:be:00:07")),
+		Device:  "port0",
+		Counter: "nexthop_shadowed",
+	}
+	survivingHop := FIBNexthop{
+		DstMAC:  xerror.Unwrap(net.ParseMAC("de:ad:be:ef:00:08")),
+		SrcMAC:  xerror.Unwrap(net.ParseMAC("ca:fe:ba:be:00:08")),
+		Device:  "port0",
+		Counter: "nexthop_surviving",
+	}
+
+	_, agent, backend := setupRouteHarness(t, "port0")
+	service := route.NewRouteService(backend)
+
+	_, err := service.UpdateFIB(t.Context(), &routepb.UpdateFIBRequest{
+		ModuleName: "test",
+		Entries: toFIBEntries(t, []FIBEntry{
+			{Prefix: netip.MustParsePrefix("10.0.0.0/24"), Nexthops: []FIBNexthop{shadowedHop}},
+			// Applied later, so it wins the whole range above plus more.
+			{Prefix: netip.MustParsePrefix("10.0.0.0/23"), Nexthops: []FIBNexthop{survivingHop}},
+		}),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _, _ = service.DeleteConfig(t.Context(), &routepb.DeleteConfigRequest{Name: "test"}) })
+
+	wirePipeline(t, agent, "port0", "test")
+
+	all, err := service.Metrics()
+	require.NoError(t, err)
+
+	names := nexthopCounterLabels(all)
+	require.NotContains(t, names, "nexthop_shadowed", "a fully shadowed nexthop must not be scraped")
+	require.Contains(t, names, "nexthop_surviving")
 }


### PR DESCRIPTION
`UpdateFIB` applies entries in order and a later range overwrites every address it covers, so an earlier entry can end up fully shadowed and its nexthop unreachable. The exported counter names were collected from the request as sent, so such a nexthop kept a series no packet could ever move — indistinguishable from a genuinely idle one, and frozen at whatever an earlier generation left it at.

- Collect the names from the applied FIB rather than from the request. The FIB iterator walks the LPM, and overlaps are resolved when a range is inserted, so what it yields is exactly what remains reachable.
- Read them through a lighter sibling of the FIB dump that collects only names, since the dump materialises every range and every nexthop's addresses to answer a question about a few hundred strings.
- Tolerate a failure of that read rather than surfacing it. Its only reachable cause is a control-plane allocation failure, at which point the FIB is applied and serving, and the caller responds to an error by resending the whole FIB — which would allocate another config generation out of the same arena that just refused one.

The shadowed nexthop's route and counter stay registered in shared memory and simply go unscraped. Reclaiming the registration would mean resolving overlaps before the routes are built, which is a larger change.

Closes #1700.
