### PR TITLE
feat(route): show the FIB as ranges and keep nexthop counters on save

### DIFF
--- a/modules/route/web/FIBDrawer.tsx
+++ b/modules/route/web/FIBDrawer.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import type { FIBRowItem, FIBRowErrors } from './types';
 import { validateRow } from './validation';
+import { formatRangeInput, parseRangeInput } from './rangeInput';
 import { DraftItemDrawer } from '@yanet/core/components/draft';
-import { CidrPrefixField } from '@yanet/core/components';
 import { useRowDraft } from '@yanet/core/hooks';
 
 interface FIBDrawerProps {
@@ -22,6 +22,8 @@ export interface FIBDrawerHandle {
     flushAndApply(): boolean;
 }
 
+const EMPTY_ERRORS: FIBRowErrors = { range: null, dst_mac: null, src_mac: null, device: null, counter: null };
+
 /** Side drawer for adding/editing a single FIB row. */
 const FIBDrawer = React.forwardRef<FIBDrawerHandle, FIBDrawerProps>(({
     open,
@@ -34,8 +36,31 @@ const FIBDrawer = React.forwardRef<FIBDrawerHandle, FIBDrawerProps>(({
     onJump,
 }, ref) => {
     const { draft, errors, updateField, handleApply } = useRowDraft<FIBRowItem, FIBRowErrors>({
-        open, row, emptyErrors: { prefix: null, dst_mac: null, src_mac: null, device: null }, validateRow, onChange, onClose, handleRef: ref,
+        open, row, emptyErrors: EMPTY_ERRORS, validateRow, onChange, onClose, handleRef: ref,
     });
+
+    // The range field shows a single combined "CIDR or from - to" string,
+    // decoupled from draft.from/to so an in-progress invalid edit doesn't
+    // get silently dropped or reformatted mid-typing.
+    const [rangeText, setRangeText] = useState('');
+    useEffect(() => {
+        if (open && row) {
+            setRangeText(formatRangeInput(row.from, row.to));
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, row?.id]);
+
+    const handleRangeChange = (text: string): void => {
+        setRangeText(text);
+        const parsed = parseRangeInput(text);
+        if (parsed?.start && parsed?.end) {
+            updateField('from', parsed.start);
+            updateField('to', parsed.end);
+        } else {
+            updateField('from', text.trim());
+            updateField('to', '');
+        }
+    };
 
     return (
         <DraftItemDrawer
@@ -52,13 +77,20 @@ const FIBDrawer = React.forwardRef<FIBDrawerHandle, FIBDrawerProps>(({
             <section className="yn-section">
                 <div className="yn-section-h">Destination</div>
                 <div className="yn-section__body">
-                    <CidrPrefixField
-                        label="Prefix"
-                        placeholder="10.0.0.0/8 or 2a02:6b8::/32"
-                        value={draft?.prefix ?? ''}
-                        error={errors.prefix}
-                        onChange={(v) => updateField('prefix', v.trim())}
-                    />
+                    <div className="yn-field">
+                        <label className="yn-field__label">
+                            Range <span className="yn-field__req">*</span>
+                        </label>
+                        <input
+                            className={`yn-input yn-input--mono${errors.range ? ' yn-input--invalid' : ''}`}
+                            value={rangeText}
+                            placeholder="10.0.0.0/24 or 10.0.0.0 - 10.0.0.255"
+                            onChange={(e) => handleRangeChange(e.target.value)}
+                        />
+                        {errors.range
+                            ? <span className="yn-field__hint yn-field__error">{errors.range}</span>
+                            : <span className="yn-field__hint">CIDR prefix or an explicit "from - to" range.</span>}
+                    </div>
                 </div>
             </section>
 
@@ -111,6 +143,18 @@ const FIBDrawer = React.forwardRef<FIBDrawerHandle, FIBDrawerProps>(({
                         />
                         {errors.device && (
                             <span className="yn-field__hint yn-field__error">{errors.device}</span>
+                        )}
+                    </div>
+                    <div className="yn-field">
+                        <label className="yn-field__label">Counter</label>
+                        <input
+                            className={`yn-input yn-input--mono${errors.counter ? ' yn-input--invalid' : ''}`}
+                            value={draft?.counter ?? ''}
+                            placeholder="nexthop_custom-name (leave empty to auto-generate)"
+                            onChange={(e) => updateField('counter', e.target.value.trim())}
+                        />
+                        {errors.counter && (
+                            <span className="yn-field__hint yn-field__error">{errors.counter}</span>
                         )}
                     </div>
                 </div>

--- a/modules/route/web/FIBTable.tsx
+++ b/modules/route/web/FIBTable.tsx
@@ -6,28 +6,35 @@ import type { RemovedColumnDescriptor, TableColumnHeader, RowStatus, VirtualDraf
 import { DraftActionButtons } from '@yanet/core/components/draft';
 
 const COLUMN_WIDTHS = {
-    prefix: 220,
+    from: 170,
+    to: 170,
     dst_mac: 180,
     src_mac: 180,
     device: 120,
+    counter: 160,
 } as const;
 
 const TOTAL_WIDTH =
     LEADING_TOTAL_WIDTH +
-    COLUMN_WIDTHS.prefix + COLUMN_WIDTHS.dst_mac + COLUMN_WIDTHS.src_mac + COLUMN_WIDTHS.device;
+    COLUMN_WIDTHS.from + COLUMN_WIDTHS.to + COLUMN_WIDTHS.dst_mac + COLUMN_WIDTHS.src_mac +
+    COLUMN_WIDTHS.device + COLUMN_WIDTHS.counter;
 
 const COLUMN_HEADERS: TableColumnHeader[] = [
-    { width: COLUMN_WIDTHS.prefix, label: 'Prefix' },
+    { width: COLUMN_WIDTHS.from, label: 'From' },
+    { width: COLUMN_WIDTHS.to, label: 'To' },
     { width: COLUMN_WIDTHS.dst_mac, label: 'Dst MAC' },
     { width: COLUMN_WIDTHS.src_mac, label: 'Src MAC' },
     { width: COLUMN_WIDTHS.device, label: 'Device' },
+    { width: COLUMN_WIDTHS.counter, label: 'Counter' },
 ];
 
 const REMOVED_COLUMNS: RemovedColumnDescriptor<FIBRowItem>[] = [
-    { width: COLUMN_WIDTHS.prefix, render: (r) => <span className="yn-cell-mono">{r.prefix}</span> },
+    { width: COLUMN_WIDTHS.from, render: (r) => <span className="yn-cell-mono">{r.from}</span> },
+    { width: COLUMN_WIDTHS.to, render: (r) => <span className="yn-cell-mono">{r.to}</span> },
     { width: COLUMN_WIDTHS.dst_mac, render: (r) => <span className="yn-cell-mono yn-cell-muted">{r.dst_mac}</span> },
     { width: COLUMN_WIDTHS.src_mac, render: (r) => <span className="yn-cell-mono yn-cell-muted">{r.src_mac}</span> },
     { width: COLUMN_WIDTHS.device, render: (r) => <span className="yn-cell-mono yn-cell-muted">{r.device}</span> },
+    { width: COLUMN_WIDTHS.counter, render: (r) => <span className="yn-cell-mono yn-cell-muted">{r.counter}</span> },
 ];
 
 const dataCellStyle = (width: number, hasError: boolean): React.CSSProperties => ({
@@ -48,9 +55,14 @@ const renderFIBDataCells = (row: FIBRowItem): React.ReactNode => {
     const errors = validateRow(row);
     return (
         <>
-            <div style={dataCellStyle(COLUMN_WIDTHS.prefix, !!errors.prefix)} title={row.prefix || undefined}>
+            <div style={dataCellStyle(COLUMN_WIDTHS.from, !!errors.range)} title={row.from || undefined}>
                 <span className="yn-cell-mono yn-cell-strong">
-                    {row.prefix || <span style={{ color: 'var(--yn-text-3)', fontStyle: 'italic' }}>prefix?</span>}
+                    {row.from || <span style={{ color: 'var(--yn-text-3)', fontStyle: 'italic' }}>from?</span>}
+                </span>
+            </div>
+            <div style={dataCellStyle(COLUMN_WIDTHS.to, !!errors.range)} title={row.to || undefined}>
+                <span className="yn-cell-mono yn-cell-strong">
+                    {row.to || <span style={{ color: 'var(--yn-text-3)', fontStyle: 'italic' }}>to?</span>}
                 </span>
             </div>
             <div style={dataCellStyle(COLUMN_WIDTHS.dst_mac, !!errors.dst_mac)} title={row.dst_mac || undefined}>
@@ -61,6 +73,9 @@ const renderFIBDataCells = (row: FIBRowItem): React.ReactNode => {
             </div>
             <div style={dataCellStyle(COLUMN_WIDTHS.device, !!errors.device)} title={row.device || undefined}>
                 <span className="yn-cell-mono yn-cell-muted">{row.device || '—'}</span>
+            </div>
+            <div style={dataCellStyle(COLUMN_WIDTHS.counter, !!errors.counter)} title={row.counter || undefined}>
+                <span className="yn-cell-mono yn-cell-muted">{row.counter || '—'}</span>
             </div>
         </>
     );

--- a/modules/route/web/FIBYamlIO.tsx
+++ b/modules/route/web/FIBYamlIO.tsx
@@ -19,7 +19,7 @@ const FIBYamlIO: React.FC<FIBYamlIOProps> = ({ configName, rows, onImport, disab
         itemLabel="routes"
         downloadPrefix={`fib-${configName}`}
         toastPrefix="fib-yaml"
-        importPlaceholder={`config: ${configName}\nroutes:\n  - prefix: 10.0.0.0/8\n    dst_mac: 52:54:00:00:1c:57\n    src_mac: 52:54:00:12:34:56\n    device: eth0`}
+        importPlaceholder={`config: ${configName}\nroutes:\n  - from: 10.0.0.0\n    to: 10.0.0.255\n    dst_mac: 52:54:00:00:1c:57\n    src_mac: 52:54:00:12:34:56\n    device: eth0\n    counter: ""`}
         exportYaml={() => rowsToYaml(configName, rows)}
         parseImport={yamlToRows}
         disabled={disabled}

--- a/modules/route/web/RoutePage.tsx
+++ b/modules/route/web/RoutePage.tsx
@@ -12,9 +12,9 @@ import FIBYamlIO from './FIBYamlIO';
 import { FIBSaveDiffModal } from './FIBSaveDiffModal';
 import { AddConfigModal, DeleteConfigModal, BulkDeleteModal, CommandPaletteHeader } from '@yanet/core/components';
 import { useDraftPageHandlers, useDraftPageState, useDraftPageDerived } from '@yanet/core/components/draft';
-import { isValidCidr as isValidCIDR } from '@yanet/core/utils';
 import type { Command, RowAdapter, PagePaletteContribution } from '@yanet/core/components/command-palette';
 import { buildConfigCommands } from '@yanet/core/components/command-palette';
+import { isValidRangeInput, parseRangeInput } from './rangeInput';
 import '@yanet/core/styles/chrome.scss';
 import './route.scss';
 
@@ -25,16 +25,20 @@ let idCounter = 0;
 const makeRowId = (): string => `new-${++idCounter}-${Date.now()}`;
 
 const matchesFIBSearch = (r: FIBRowItem, q: string): boolean =>
-    r.prefix.toLowerCase().includes(q) ||
+    r.from.toLowerCase().includes(q) ||
+    r.to.toLowerCase().includes(q) ||
     r.dst_mac.toLowerCase().includes(q) ||
     r.src_mac.toLowerCase().includes(q) ||
-    r.device.toLowerCase().includes(q);
+    r.device.toLowerCase().includes(q) ||
+    r.counter.toLowerCase().includes(q);
 
 const fibRowsEqual = (s: FIBRowItem, r: FIBRowItem): boolean =>
-    s.prefix === r.prefix &&
+    s.from === r.from &&
+    s.to === r.to &&
     s.dst_mac === r.dst_mac &&
     s.src_mac === r.src_mac &&
-    s.device === r.device;
+    s.device === r.device &&
+    s.counter === r.counter;
 
 const RoutePage: React.FC = () => {
     const {
@@ -89,8 +93,17 @@ const RoutePage: React.FC = () => {
         dragDrop,
     });
 
-    const openAdd = useCallback((prefix = ''): void => {
-        const newRow: FIBRowItem = { id: makeRowId(), prefix, dst_mac: '', src_mac: '', device: '' };
+    const openAdd = useCallback((rangeInput = ''): void => {
+        const parsed = parseRangeInput(rangeInput);
+        const newRow: FIBRowItem = {
+            id: makeRowId(),
+            from: parsed?.start ?? '',
+            to: parsed?.end ?? '',
+            dst_mac: '',
+            src_mac: '',
+            device: '',
+            counter: '',
+        };
         dispatchDraft({ type: 'ADD_ROW', configName: currentConfig, row: newRow });
         setActiveRowId(newRow.id);
         setEditingRowId(newRow.id);
@@ -172,13 +185,13 @@ const RoutePage: React.FC = () => {
     }, [canCreate, currentIsDirty, currentConfig, draftConfigs, dirtySet, search, handlers, handleConfigSelect, handleSearchChange, openAdd]);
 
     const dynamicCommands = useCallback((q: string): Command[] => {
-        if (isValidCIDR(q.trim())) {
+        if (isValidRangeInput(q.trim())) {
             return [
                 {
                     id: '__add_cidr',
                     icon: '⌖',
                     label: `Add route for ${q.trim()}`,
-                    sub: 'Pre-fill a new route with this prefix',
+                    sub: 'Pre-fill a new route with this range',
                     onSelect: () => openAdd(q.trim()),
                 },
             ];
@@ -189,9 +202,9 @@ const RoutePage: React.FC = () => {
     const rowAdapter = useMemo((): RowAdapter<FIBRowItem> => ({
         rows: rawRows,
         getId: (r) => r.id,
-        getLabel: (r) => r.prefix || '(no prefix)',
+        getLabel: (r) => (r.from && r.to ? `${r.from} - ${r.to}` : '(no range)'),
         getSub: (r) => `${r.dst_mac || '—'} · ${r.device || '—'}`,
-        searchText: (r) => [r.prefix, r.dst_mac, r.src_mac, r.device].join(' '),
+        searchText: (r) => [r.from, r.to, r.dst_mac, r.src_mac, r.device, r.counter].join(' '),
         onSelect: (id) => { setActiveRowId(id); setEditingRowId(id); },
         icon: '→',
         max: 7,

--- a/modules/route/web/fibDraftReducer.ts
+++ b/modules/route/web/fibDraftReducer.ts
@@ -8,10 +8,12 @@ export type FIBDraftAction = DraftAction<FIBRowItem>;
 const { reducer: fibDraftReducer, initialState: initialFIBDraftState } = createDraftReducer<FIBRowItem>({
     getId: (r) => r.id,
     equals: (a, b) =>
-        a.prefix === b.prefix &&
+        a.from === b.from &&
+        a.to === b.to &&
         a.dst_mac === b.dst_mac &&
         a.src_mac === b.src_mac &&
-        a.device === b.device,
+        a.device === b.device &&
+        a.counter === b.counter,
 });
 
 export { fibDraftReducer, initialFIBDraftState };

--- a/modules/route/web/rangeInput.test.ts
+++ b/modules/route/web/rangeInput.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { formatRangeInput, isValidRangeInput, parseRangeInput } from './rangeInput';
+
+describe('parseRangeInput', () => {
+    it('normalizes a CIDR to its from/to endpoints', () => {
+        expect(parseRangeInput('10.0.0.0/24')).toEqual({ start: '10.0.0.0', end: '10.0.0.255' });
+    });
+
+    it('normalizes an explicit "from - to" range', () => {
+        expect(parseRangeInput('10.0.0.1 - 10.0.0.130')).toEqual({ start: '10.0.0.1', end: '10.0.0.130' });
+    });
+
+    it('treats a bare host address as a single-address range', () => {
+        expect(parseRangeInput('10.0.0.5')).toEqual({ start: '10.0.0.5', end: '10.0.0.5' });
+    });
+
+    it('rejects a reversed range', () => {
+        expect(parseRangeInput('10.0.0.130 - 10.0.0.1')).toBeUndefined();
+    });
+
+    it('rejects garbage input', () => {
+        expect(parseRangeInput('not an ip')).toBeUndefined();
+    });
+});
+
+describe('isValidRangeInput', () => {
+    it('mirrors parseRangeInput success/failure', () => {
+        expect(isValidRangeInput('10.0.0.0/24')).toBe(true);
+        expect(isValidRangeInput('garbage')).toBe(false);
+    });
+});
+
+describe('formatRangeInput', () => {
+    it('formats a CIDR-aligned range as a CIDR', () => {
+        expect(formatRangeInput('10.0.0.0', '10.0.0.255')).toBe('10.0.0.0/24');
+    });
+
+    it('formats a non-aligned range as "from - to"', () => {
+        expect(formatRangeInput('10.0.0.1', '10.0.0.130')).toBe('10.0.0.1 - 10.0.0.130');
+    });
+});

--- a/modules/route/web/rangeInput.ts
+++ b/modules/route/web/rangeInput.ts
@@ -1,0 +1,33 @@
+import { cidrToIPRange, ipRangeToCIDRs, normalizeIPRange } from '@yanet/core/utils/netip';
+import type { IPRangeWire } from '@yanet/core/utils/netip';
+
+/**
+ * Parse the FIB drawer's single range field, which accepts a CIDR
+ * ("10.0.0.0/24"), an explicit range ("10.0.0.0 - 10.0.0.255"), or a bare
+ * host address. Returns undefined for unparseable or reversed input.
+ */
+export const parseRangeInput = (text: string): IPRangeWire | undefined => {
+    const trimmed = text.trim();
+    if (!trimmed) return undefined;
+    if (trimmed.includes('/')) {
+        return cidrToIPRange(trimmed);
+    }
+    const dashIdx = trimmed.indexOf('-');
+    if (dashIdx === -1) {
+        return normalizeIPRange(trimmed, trimmed);
+    }
+    const from = trimmed.slice(0, dashIdx).trim();
+    const to = trimmed.slice(dashIdx + 1).trim();
+    return normalizeIPRange(from, to);
+};
+
+/** True when the text parses as a range field value (see parseRangeInput). */
+export const isValidRangeInput = (text: string): boolean => !!parseRangeInput(text);
+
+/** Format a range for display: as a CIDR when the endpoints align to one, else "from - to". */
+export const formatRangeInput = (from: string, to: string): string => {
+    if (!from && !to) return '';
+    if (!from || !to) return `${from} - ${to}`;
+    const cidrs = ipRangeToCIDRs({ start: from, end: to });
+    return cidrs.length === 1 ? cidrs[0] : `${from} - ${to}`;
+};

--- a/modules/route/web/types.ts
+++ b/modules/route/web/types.ts
@@ -1,11 +1,14 @@
-/** A single flattened row in the FIB table: one (prefix, nexthop) pair. */
+/** A single flattened row in the FIB table: one (range, nexthop) pair. */
 export interface FIBRowItem {
     /** Stable local ID — not sent to the server. */
     id: string;
-    prefix: string;
+    from: string;
+    to: string;
     dst_mac: string;
     src_mac: string;
     device: string;
+    /** Explicit nexthop counter name. Empty means "let the server generate it". */
+    counter: string;
 }
 
 /** Row status relative to the last-known server snapshot. */
@@ -13,8 +16,10 @@ export type FIBRowStatus = 'same' | 'added' | 'changed';
 
 /** Validation errors for a single row. null = valid, string = error message. */
 export interface FIBRowErrors {
-    prefix: string | null;
+    /** Applies to both the From and To columns, sourced from one drawer field. */
+    range: string | null;
     dst_mac: string | null;
     src_mac: string | null;
     device: string | null;
+    counter: string | null;
 }

--- a/modules/route/web/useFIBDraft.hook.test.ts
+++ b/modules/route/web/useFIBDraft.hook.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+const { showFIB, updateFIB, listConfigs } = vi.hoisted(() => ({
+    showFIB: vi.fn(),
+    updateFIB: vi.fn(),
+    listConfigs: vi.fn(),
+}));
+
+vi.mock('@yanet/core/api', async () => {
+    const actual = await vi.importActual<typeof import('@yanet/core/api')>('@yanet/core/api');
+    return {
+        ...actual,
+        inventoryConfigNames: vi.fn(async () => []),
+        API: {
+            ...actual.API,
+            route: { listConfigs, showFIB, updateFIB },
+        },
+    };
+});
+
+import { useFIBDraft } from './useFIBDraft';
+
+const fibResp = (device: string) => ({
+    entries: [{
+        range: { start: '10.0.0.0', end: '10.0.0.255' },
+        nexthops: [{ dst_mac: { addr: 'aa:bb:cc:dd:ee:ff' }, src_mac: { addr: '11:22:33:44:55:66' }, device, counter: '' }],
+    }],
+});
+
+describe('useFIBDraft commitConfig', () => {
+    beforeEach(() => {
+        showFIB.mockReset();
+        updateFIB.mockReset();
+        listConfigs.mockReset();
+        listConfigs.mockResolvedValue({ configs: ['route0', 'route1'] });
+        showFIB.mockImplementation(async ({ name }: { name: string }) => fibResp(name === 'route0' ? 'eth0' : 'eth1'));
+        updateFIB.mockResolvedValue({});
+    });
+
+    it('leaves other configs\' tabs and dirty state intact after committing one', async () => {
+        const { result } = renderHook(() => useFIBDraft());
+
+        await waitFor(() => expect(result.current.loading).toBe(false));
+        expect(result.current.draftConfigs).toEqual(['route0', 'route1']);
+
+        act(() => {
+            result.current.dispatchDraft({
+                type: 'UPDATE_ROW',
+                configName: 'route1',
+                id: result.current.draftRows('route1')[0].id,
+                patch: { device: 'eth9' },
+            });
+        });
+        expect(result.current.isDirty('route1')).toBe(true);
+
+        await act(async () => {
+            await result.current.commitConfig('route0');
+        });
+
+        expect(result.current.draftConfigs).toEqual(['route0', 'route1']);
+        expect(result.current.isDirty('route1')).toBe(true);
+        expect(result.current.draftRows('route1')[0].device).toBe('eth9');
+    });
+});

--- a/modules/route/web/useFIBDraft.test.ts
+++ b/modules/route/web/useFIBDraft.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import type { FIBEntry, FIBNexthop } from '@yanet/core/api/routes';
+import { flattenFIBEntries, rowsToFIBEntries } from './useFIBDraft';
+import type { FIBRowItem } from './types';
+
+const nexthop = (device: string, counter = ''): FIBNexthop[] => [{
+    dst_mac: { addr: 'aa:bb:cc:dd:ee:ff' },
+    src_mac: { addr: '11:22:33:44:55:66' },
+    device,
+    counter,
+}];
+
+const rowFor = (from: string, to: string, overrides: Partial<FIBRowItem> = {}): FIBRowItem => ({
+    id: `${from}-${to}`,
+    from,
+    to,
+    dst_mac: 'aa:bb:cc:dd:ee:ff',
+    src_mac: '11:22:33:44:55:66',
+    device: 'eth0',
+    counter: '',
+    ...overrides,
+});
+
+describe('flattenFIBEntries', () => {
+    it('keeps a non-CIDR-aligned range as a single row instead of exploding into CIDRs', () => {
+        const entries: FIBEntry[] = [{
+            range: { start: '10.0.0.1', end: '10.0.0.130' },
+            nexthops: nexthop('eth0'),
+        }];
+
+        const rows = flattenFIBEntries(entries);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].from).toBe('10.0.0.1');
+        expect(rows[0].to).toBe('10.0.0.130');
+    });
+
+    it('repeats the range on every ECMP nexthop row', () => {
+        const entries: FIBEntry[] = [{
+            range: { start: '10.0.0.0', end: '10.0.0.255' },
+            nexthops: [...nexthop('eth0'), ...nexthop('eth1')],
+        }];
+
+        const rows = flattenFIBEntries(entries);
+
+        expect(rows).toHaveLength(2);
+        expect(rows.every((r) => r.from === '10.0.0.0' && r.to === '10.0.0.255')).toBe(true);
+    });
+
+    it('preserves an explicit counter across a load-then-save round trip', () => {
+        const entries: FIBEntry[] = [{
+            range: { start: '10.0.0.0', end: '10.0.0.255' },
+            nexthops: nexthop('eth0', 'nexthop_custom-counter'),
+        }];
+
+        const rows = flattenFIBEntries(entries);
+        expect(rows[0].counter).toBe('nexthop_custom-counter');
+
+        const rebuilt = rowsToFIBEntries(rows);
+        expect(rebuilt[0].nexthops?.[0].counter).toBe('nexthop_custom-counter');
+    });
+
+    it('preserves an empty counter as empty, not undefined', () => {
+        const entries: FIBEntry[] = [{
+            range: { start: '10.0.0.0', end: '10.0.0.255' },
+            nexthops: nexthop('eth0', ''),
+        }];
+
+        const rows = flattenFIBEntries(entries);
+        expect(rows[0].counter).toBe('');
+
+        const rebuilt = rowsToFIBEntries(rows);
+        expect(rebuilt[0].nexthops?.[0].counter).toBe('');
+    });
+});
+
+describe('rowsToFIBEntries commit ordering', () => {
+    it('emits narrower ranges after broader ones so last-write-wins reproduces LPM', () => {
+        const rows = [
+            rowFor('10.0.0.0', '10.0.0.255'), // /24, narrower
+            rowFor('10.0.0.0', '10.255.255.255'), // /8, broader
+        ];
+
+        const entries = rowsToFIBEntries(rows);
+
+        expect(entries).toHaveLength(2);
+        expect(entries[0].range?.end).toBe('10.255.255.255');
+        expect(entries[1].range?.end).toBe('10.0.0.255');
+    });
+
+    it('keeps original relative order for ranges of equal span', () => {
+        const rows = [
+            rowFor('10.0.0.0', '10.0.0.255'),
+            rowFor('10.0.1.0', '10.0.1.255'),
+        ];
+
+        const entries = rowsToFIBEntries(rows);
+
+        expect(entries[0].range?.start).toBe('10.0.0.0');
+        expect(entries[1].range?.start).toBe('10.0.1.0');
+    });
+
+    it('throws rather than silently dropping a row with an unparseable range', () => {
+        const rows = [rowFor('not-an-ip', '10.0.0.255')];
+        expect(() => rowsToFIBEntries(rows)).toThrow();
+    });
+
+    it('merges two non-adjacent rows sharing a range into one entry with both nexthops', () => {
+        const rows = [
+            rowFor('10.0.0.0', '10.0.0.255', { device: 'eth0' }),
+            rowFor('10.0.1.0', '10.0.1.255', { device: 'eth1' }),
+            rowFor('10.0.0.0', '10.0.0.255', { device: 'eth2' }),
+        ];
+
+        const entries = rowsToFIBEntries(rows);
+
+        const merged = entries.find((e) => e.range?.start === '10.0.0.0' && e.range?.end === '10.0.0.255');
+        expect(entries).toHaveLength(2);
+        expect(merged?.nexthops?.map((nh) => nh.device)).toEqual(['eth0', 'eth2']);
+    });
+});

--- a/modules/route/web/useFIBDraft.ts
+++ b/modules/route/web/useFIBDraft.ts
@@ -2,7 +2,8 @@ import { useCallback } from 'react';
 import { API, inventoryConfigNames, loadKnownConfigs, unionConfigNames } from '@yanet/core/api';
 import { warnConfigsUnknown } from '@yanet/core/utils';
 import type { FIBEntry, FIBNexthop } from '@yanet/core/api/routes';
-import { cidrToIPRange, ipRangeToCIDRs } from '@yanet/core/utils/netip';
+import { ipRangeSpan, normalizeIPRange } from '@yanet/core/utils/netip';
+import type { IPRangeWire } from '@yanet/core/utils/netip';
 import type { FIBRowItem } from './types';
 import { fibDraftReducer, initialFIBDraftState } from './fibDraftReducer';
 import { useDraft } from '@yanet/core/components/draft';
@@ -11,74 +12,110 @@ import type { UseDraftResult } from '@yanet/core/components/draft';
 let rowIdCounter = 0;
 const newRowId = (): string => `row-${++rowIdCounter}-${Date.now()}`;
 
-/** Flatten FIBEntry array into flat (prefix, nexthop) row items. */
+/** Flatten FIBEntry array into flat (range, nexthop) row items, one row per nexthop. */
 export const flattenFIBEntries = (entries: FIBEntry[]): FIBRowItem[] => {
     const rows: FIBRowItem[] = [];
     for (const entry of entries) {
-        const cidrs = ipRangeToCIDRs(entry.range);
+        const from = entry.range?.start ?? '';
+        const to = entry.range?.end ?? '';
         const nexthops = entry.nexthops || [];
-        for (const prefix of cidrs) {
-            if (nexthops.length === 0) {
-                rows.push({ id: newRowId(), prefix, dst_mac: '', src_mac: '', device: '' });
-            } else {
-                for (const nh of nexthops) {
-                    rows.push({
-                        id: newRowId(),
-                        prefix,
-                        dst_mac: nh.dst_mac?.addr || '',
-                        src_mac: nh.src_mac?.addr || '',
-                        device: nh.device || '',
-                    });
-                }
+        if (nexthops.length === 0) {
+            rows.push({ id: newRowId(), from, to, dst_mac: '', src_mac: '', device: '', counter: '' });
+        } else {
+            for (const nh of nexthops) {
+                rows.push({
+                    id: newRowId(),
+                    from,
+                    to,
+                    dst_mac: nh.dst_mac?.addr || '',
+                    src_mac: nh.src_mac?.addr || '',
+                    device: nh.device || '',
+                    counter: nh.counter || '',
+                });
             }
         }
     }
     return rows;
 };
 
+/** Span of an entry whose range was already validated by rowsToFIBEntries. */
+const requireSpan = (entry: FIBEntry): bigint => {
+    const span = ipRangeSpan(entry.range);
+    if (span === undefined) {
+        throw new Error(`Cannot compute span for range "${entry.range?.start} - ${entry.range?.end}"`);
+    }
+    return span;
+};
+
 /**
- * Group flat rows back into a FIBEntry list (consecutive rows with the
- * same prefix collapse into one entry with several ECMP nexthops).
+ * Order entries so that lpm_insert's last-write-wins overlap resolution
+ * reproduces longest-prefix-match: broadest ranges are inserted first,
+ * narrowest last, so a more specific row always overrides a broader one it
+ * overlaps. The sort is stable, so non-overlapping entries of equal span
+ * keep their original relative order.
+ */
+const orderEntriesForCommit = (entries: FIBEntry[]): FIBEntry[] =>
+    [...entries].sort((a, b) => {
+        const spanA = requireSpan(a);
+        const spanB = requireSpan(b);
+        if (spanA === spanB) return 0;
+        return spanA > spanB ? -1 : 1;
+    });
+
+/**
+ * Group flat rows back into a FIBEntry list (rows sharing the same range,
+ * wherever they sit in the table, collapse into one entry with several ECMP
+ * nexthops — not just adjacent rows, since the table lets equal ranges land
+ * apart).
  *
- * A row can reach here without having passed validateRow at all, and even a
- * row that passed it can still fail conversion, since validateRow's
- * isValidCidrPrefix is a looser check than cidrToIPRange's strict parser.
- * Throwing here rather than dropping the row is deliberate: a dropped row
- * would silently delete a route from the FIB, which is worse than failing
- * the whole commit loudly.
+ * A row can reach here without having passed validateRow at all, via YAML
+ * import. Throwing here rather than dropping the row is deliberate: a
+ * dropped row would silently delete a route from the FIB, which is worse
+ * than failing the whole commit loudly.
  */
 export const rowsToFIBEntries = (rows: FIBRowItem[]): FIBEntry[] => {
+    const byRange = new Map<string, FIBEntry>();
     const entries: FIBEntry[] = [];
     for (const row of rows) {
-        const range = cidrToIPRange(row.prefix);
+        const range: IPRangeWire | undefined = normalizeIPRange(row.from, row.to);
         if (!range) {
-            throw new Error(`Cannot convert FIB row prefix "${row.prefix}" to an IP range`);
+            throw new Error(`Cannot convert FIB row range "${row.from} - ${row.to}" to an IP range`);
         }
 
-        const last = entries[entries.length - 1];
         const nh: FIBNexthop = {
             dst_mac: { addr: row.dst_mac },
             src_mac: { addr: row.src_mac },
             device: row.device,
+            counter: row.counter,
         };
-        if (last && last.range?.start === range.start && last.range?.end === range.end) {
-            last.nexthops = [...(last.nexthops || []), nh];
+        const key = `${range.start}-${range.end}`;
+        const existing = byRange.get(key);
+        if (existing) {
+            existing.nexthops = [...(existing.nexthops || []), nh];
         } else {
-            entries.push({ range, nexthops: [nh] });
+            const entry: FIBEntry = { range, nexthops: [nh] };
+            byRange.set(key, entry);
+            entries.push(entry);
         }
     }
-    return entries;
+    return orderEntriesForCommit(entries);
 };
 
 export type UseFIBDraftResult = UseDraftResult<FIBRowItem>;
+
+const loadConfig = async (name: string): Promise<{ name: string; rows: FIBRowItem[] }> => {
+    const fibResp = await API.route.showFIB({ name });
+    return { name, rows: flattenFIBEntries(fibResp.entries ?? []) };
+};
 
 /**
  * Wraps FIB config data with a local-draft layer.
  *
  * Server state is fetched once on mount via the route.listConfigs, inspect and route.showFIB APIs.
  * All UI mutations go through dispatchDraft and update only local state until the user
- * explicitly calls commitConfig. On commit the full draft rows are sent via API.route.updateFIB
- * and the local server snapshot is updated so dirty clears.
+ * explicitly calls commitConfig. On commit the full draft rows are sent via API.route.updateFIB.
+ * Since the server may materialize an empty counter into a generated name, the config is then
+ * re-fetched so the draft and server snapshots reflect what was actually saved.
  */
 export const useFIBDraft = (): UseFIBDraftResult => {
     const load = useCallback(async (): Promise<Array<{ name: string; rows: FIBRowItem[] }>> => {
@@ -87,10 +124,7 @@ export const useFIBDraft = (): UseFIBDraftResult => {
             inventoryConfigNames('route'),
         ]);
         const configNames = unionConfigNames(configsResp.configs ?? [], inventoryNames);
-        return loadKnownConfigs(configNames, async (name): Promise<{ name: string; rows: FIBRowItem[] }> => {
-            const fibResp = await API.route.showFIB({ name });
-            return { name, rows: flattenFIBEntries(fibResp.entries ?? []) };
-        }, { onDropped: warnConfigsUnknown('route-configs-unknown', 'route') });
+        return loadKnownConfigs(configNames, loadConfig, { onDropped: warnConfigsUnknown('route-configs-unknown', 'route') });
     }, []);
 
     const commit = useCallback(async (configName: string, draftRows: FIBRowItem[]): Promise<void> => {
@@ -98,7 +132,7 @@ export const useFIBDraft = (): UseFIBDraftResult => {
         await API.route.updateFIB({ module_name: configName, entries });
     }, []);
 
-    return useDraft<FIBRowItem>({
+    const draft = useDraft<FIBRowItem>({
         load,
         commit,
         reducer: fibDraftReducer,
@@ -107,4 +141,17 @@ export const useFIBDraft = (): UseFIBDraftResult => {
         errorSubject: 'FIB',
         cacheKey: 'route',
     });
+
+    const commitConfig = useCallback(async (configName: string): Promise<void> => {
+        await draft.commitConfig(configName);
+        try {
+            const { rows } = await loadConfig(configName);
+            draft.dispatchDraft({ type: 'REFRESH_CONFIG', configName, rows });
+        } catch {
+            // Best effort: the draft already reflects the save, just not any
+            // server-generated counter names until the next full reload.
+        }
+    }, [draft]);
+
+    return { ...draft, commitConfig };
 };

--- a/modules/route/web/validation.test.ts
+++ b/modules/route/web/validation.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { validateRow } from './validation';
+import type { FIBRowItem } from './types';
+
+const baseRow: FIBRowItem = {
+    id: 'r1',
+    from: '10.0.0.0',
+    to: '10.0.0.255',
+    dst_mac: 'aa:bb:cc:dd:ee:ff',
+    src_mac: '11:22:33:44:55:66',
+    device: 'eth0',
+    counter: '',
+};
+
+describe('validateRow range field', () => {
+    it('accepts a valid ascending range', () => {
+        expect(validateRow(baseRow).range).toBeNull();
+    });
+
+    it('rejects a reversed range', () => {
+        const row = { ...baseRow, from: '10.0.0.255', to: '10.0.0.0' };
+        expect(validateRow(row).range).not.toBeNull();
+    });
+
+    it('requires both endpoints when both are empty', () => {
+        const row = { ...baseRow, from: '', to: '' };
+        expect(validateRow(row).range).toBe('Required');
+    });
+});
+
+describe('validateRow counter field', () => {
+    it('accepts an empty counter as valid', () => {
+        expect(validateRow({ ...baseRow, counter: '' }).counter).toBeNull();
+    });
+
+    it('accepts a counter that starts with nexthop_', () => {
+        expect(validateRow({ ...baseRow, counter: 'nexthop_my-counter' }).counter).toBeNull();
+    });
+
+    it('rejects a non-empty counter that does not start with nexthop_', () => {
+        expect(validateRow({ ...baseRow, counter: 'my-counter' }).counter).not.toBeNull();
+    });
+
+    it('rejects a counter longer than 127 bytes', () => {
+        const tooLong = 'nexthop_' + 'a'.repeat(127);
+        expect(validateRow({ ...baseRow, counter: tooLong }).counter).not.toBeNull();
+    });
+
+    it('rejects a counter at exactly 128 bytes', () => {
+        const atLimit = 'nexthop_' + 'a'.repeat(128 - 'nexthop_'.length);
+        expect(validateRow({ ...baseRow, counter: atLimit }).counter).not.toBeNull();
+    });
+
+    it('accepts a counter at exactly 127 bytes', () => {
+        const exact = 'nexthop_' + 'a'.repeat(127 - 'nexthop_'.length);
+        expect(validateRow({ ...baseRow, counter: exact }).counter).toBeNull();
+    });
+});

--- a/modules/route/web/validation.ts
+++ b/modules/route/web/validation.ts
@@ -1,8 +1,12 @@
 import type { FIBRowItem, FIBRowErrors } from './types';
-import { isValidCidrPrefix, rowHasError as sharedRowHasError, countInvalidRows as sharedCountInvalidRows } from '@yanet/core/utils';
+import { normalizeIPRange } from '@yanet/core/utils/netip';
+import { rowHasError as sharedRowHasError, countInvalidRows as sharedCountInvalidRows } from '@yanet/core/utils';
 
-/** Returns true if s is a valid IPv4 or IPv6 CIDR prefix with a /mask. */
-export const isValidPrefix = isValidCidrPrefix;
+const MAX_COUNTER_NAME_BYTES = 127;
+
+/** Returns true if the row's from/to parse as a valid, non-reversed IP range. */
+export const isValidRange = (row: Pick<FIBRowItem, 'from' | 'to'>): boolean =>
+    !!normalizeIPRange(row.from, row.to);
 
 /** Returns true if s is a valid MAC address (colon-separated hex). */
 export const isValidMac = (s: string): boolean =>
@@ -12,12 +16,21 @@ export const isValidMac = (s: string): boolean =>
 export const isValidDevice = (s: string): boolean =>
     !!(s && /^[A-Za-z0-9_.\-]+$/.test(s));
 
+/** Returns the counter field's error, or null when empty (server-generated) or valid. */
+const counterError = (s: string): string | null => {
+    if (!s) return null;
+    if (!s.startsWith('nexthop_')) return 'Must start with nexthop_';
+    if (new TextEncoder().encode(s).length > MAX_COUNTER_NAME_BYTES) return 'Too long (max 127 bytes)';
+    return null;
+};
+
 /** Validate all fields of a FIB row. Returns null per field if valid. */
 export const validateRow = (row: FIBRowItem): FIBRowErrors => ({
-    prefix: isValidPrefix(row.prefix) ? null : (row.prefix ? 'Invalid CIDR' : 'Required'),
+    range: isValidRange(row) ? null : ((row.from || row.to) ? 'Invalid range' : 'Required'),
     dst_mac: isValidMac(row.dst_mac) ? null : (row.dst_mac ? 'Invalid MAC' : 'Required'),
     src_mac: isValidMac(row.src_mac) ? null : (row.src_mac ? 'Invalid MAC' : 'Required'),
     device: isValidDevice(row.device) ? null : (row.device ? 'Invalid device name' : 'Required'),
+    counter: counterError(row.counter),
 });
 
 /** Returns true if the row has any validation error. */

--- a/modules/route/web/yaml.test.ts
+++ b/modules/route/web/yaml.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { rowsToYaml, yamlToRows } from './yaml';
+import type { FIBRowItem } from './types';
+
+const row: FIBRowItem = {
+    id: 'r1',
+    from: '10.0.0.0',
+    to: '10.0.0.255',
+    dst_mac: 'aa:bb:cc:dd:ee:ff',
+    src_mac: '11:22:33:44:55:66',
+    device: 'eth0',
+    counter: 'nexthop_custom-name',
+};
+
+describe('FIB YAML round trip', () => {
+    it('round-trips from/to and counter', () => {
+        const yaml = rowsToYaml('cfg0', [row]);
+        const rows = yamlToRows(yaml);
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].from).toBe(row.from);
+        expect(rows[0].to).toBe(row.to);
+        expect(rows[0].counter).toBe(row.counter);
+    });
+
+    it('defaults a missing counter to the empty string', () => {
+        const yaml = `routes:\n  - from: 10.0.0.0\n    to: 10.0.0.255\n    dst_mac: aa:bb:cc:dd:ee:ff\n    src_mac: 11:22:33:44:55:66\n    device: eth0\n`;
+        const rows = yamlToRows(yaml);
+        expect(rows[0].counter).toBe('');
+    });
+
+    it('rejects a non-string counter instead of silently coercing it to empty', () => {
+        const yaml = `routes:\n  - from: 10.0.0.0\n    to: 10.0.0.255\n    dst_mac: aa:bb:cc:dd:ee:ff\n    src_mac: 11:22:33:44:55:66\n    device: eth0\n    counter: 123\n`;
+        expect(() => yamlToRows(yaml)).toThrow();
+    });
+
+    describe('legacy "prefix" rows (pre-range export)', () => {
+        it('converts a valid CIDR prefix to from/to', () => {
+            const yaml = `routes:\n  - prefix: 10.0.0.0/24\n    dst_mac: aa:bb:cc:dd:ee:ff\n    src_mac: 11:22:33:44:55:66\n    device: eth0\n`;
+            const rows = yamlToRows(yaml);
+            expect(rows).toHaveLength(1);
+            expect(rows[0].from).toBe('10.0.0.0');
+            expect(rows[0].to).toBe('10.0.0.255');
+        });
+
+        it('imports an invalid prefix as a flagged row instead of aborting the file', () => {
+            const yaml = `routes:\n  - prefix: not-a-cidr\n    dst_mac: aa:bb:cc:dd:ee:ff\n    src_mac: 11:22:33:44:55:66\n    device: eth0\n`;
+            const rows = yamlToRows(yaml);
+            expect(rows).toHaveLength(1);
+            expect(rows[0].from).toBe('not-a-cidr');
+            expect(rows[0].to).toBe('');
+        });
+
+        it('imports a blank row (no prefix, no from/to) as empty rather than throwing', () => {
+            const yaml = `routes:\n  - prefix: ''\n    dst_mac: ''\n    src_mac: ''\n    device: ''\n`;
+            const rows = yamlToRows(yaml);
+            expect(rows).toHaveLength(1);
+            expect(rows[0].from).toBe('');
+            expect(rows[0].to).toBe('');
+        });
+
+        it('keeps good rows when only one legacy row in the file is bad', () => {
+            const yaml = [
+                'routes:',
+                '  - prefix: 10.0.0.0/24',
+                '    dst_mac: aa:bb:cc:dd:ee:ff',
+                '    src_mac: 11:22:33:44:55:66',
+                '    device: eth0',
+                "  - prefix: ''",
+                '    dst_mac: ""',
+                '    src_mac: ""',
+                '    device: ""',
+                '  - prefix: garbage',
+                '    dst_mac: aa:bb:cc:dd:ee:ff',
+                '    src_mac: 11:22:33:44:55:66',
+                '    device: eth1',
+            ].join('\n');
+            const rows = yamlToRows(yaml);
+            expect(rows).toHaveLength(3);
+            expect(rows[0].from).toBe('10.0.0.0');
+            expect(rows[1].from).toBe('');
+            expect(rows[2].from).toBe('garbage');
+        });
+    });
+});

--- a/modules/route/web/yaml.ts
+++ b/modules/route/web/yaml.ts
@@ -1,12 +1,15 @@
 import { dumpYamlDoc, parseYamlList } from '@yanet/core/utils';
+import { cidrToIPRange } from '@yanet/core/utils/netip';
 import type { FIBRowItem } from './types';
 
 /** Single-config YAML shape: { config, routes: [...] }. Mirrors Forward's envelope style. */
 interface FIBYamlRoute {
-    prefix: string;
+    from: string;
+    to: string;
     dst_mac: string;
     src_mac: string;
     device: string;
+    counter: string;
 }
 
 interface FIBYamlDoc {
@@ -19,10 +22,12 @@ export const rowsToYaml = (configName: string, rows: FIBRowItem[]): string => {
     const doc: FIBYamlDoc = {
         config: configName,
         routes: rows.map((r) => ({
-            prefix: r.prefix,
+            from: r.from,
+            to: r.to,
             dst_mac: r.dst_mac,
             src_mac: r.src_mac,
             device: r.device,
+            counter: r.counter,
         })),
     };
     return dumpYamlDoc(doc);
@@ -32,10 +37,12 @@ export const rowsToYaml = (configName: string, rows: FIBRowItem[]): string => {
 export const rowsToDiffYaml = (rows: FIBRowItem[]): string => {
     const doc = {
         routes: rows.map((r) => ({
-            prefix: r.prefix,
+            from: r.from,
+            to: r.to,
             dst_mac: r.dst_mac,
             src_mac: r.src_mac,
             device: r.device,
+            counter: r.counter,
         })),
     };
     return dumpYamlDoc(doc);
@@ -43,15 +50,35 @@ export const rowsToDiffYaml = (rows: FIBRowItem[]): string => {
 
 /**
  * Parse YAML (either the full { config, routes } doc or just { routes }) into FIB rows.
- * Returns the parsed rows. Throws with a descriptive message on failure.
+ * Returns the parsed rows. Throws with a descriptive message on failure, including when
+ * a row's counter is present but not a string — a malformed value must not silently
+ * become the valid "auto-generate" empty string.
+ *
+ * A non-empty "prefix" with no from/to is a pre-range export. A valid CIDR converts
+ * through cidrToIPRange — an invalid one is kept as raw text in "from" so the row still
+ * imports and surfaces as invalid, the same way a malformed new-format row does.
  */
 export const yamlToRows = (text: string): FIBRowItem[] =>
-    parseYamlList<FIBRowItem>(text, 'routes', (r) => {
+    parseYamlList<FIBRowItem>(text, 'routes', (r, idx) => {
         const row = (r && typeof r === 'object') ? (r as Record<string, unknown>) : {};
+        const counterRaw = row['counter'];
+        if (counterRaw !== undefined && typeof counterRaw !== 'string') {
+            throw new Error(`Route #${idx + 1}: "counter" must be a string`);
+        }
+        let from = typeof row['from'] === 'string' ? row['from'] : '';
+        let to = typeof row['to'] === 'string' ? row['to'] : '';
+        const prefix = typeof row['prefix'] === 'string' ? row['prefix'] : '';
+        if (!from && !to && prefix) {
+            const range = cidrToIPRange(prefix);
+            from = (range?.start && range.end) ? range.start : prefix;
+            to = (range?.start && range.end) ? range.end : '';
+        }
         return {
-            prefix: typeof row['prefix'] === 'string' ? row['prefix'] : '',
+            from,
+            to,
             dst_mac: typeof row['dst_mac'] === 'string' ? row['dst_mac'] : '',
             src_mac: typeof row['src_mac'] === 'string' ? row['src_mac'] : '',
             device: typeof row['device'] === 'string' ? row['device'] : '',
+            counter: typeof counterRaw === 'string' ? counterRaw : '',
         };
     });

--- a/web/src/core/api/routes.ts
+++ b/web/src/core/api/routes.ts
@@ -94,6 +94,8 @@ export interface FIBNexthop {
     dst_mac?: MACAddress;
     src_mac?: MACAddress;
     device?: string;
+    /** Explicit nexthop counter name. Empty lets the server generate one. */
+    counter?: string;
 }
 
 const routeService = createService('modules.route.controlplane.routepb.v1.RouteService');

--- a/web/src/core/components/draft/draftReducer.test.ts
+++ b/web/src/core/components/draft/draftReducer.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { createDraftReducer } from './draftReducer';
+
+interface Row {
+    id: string;
+    value: string;
+}
+
+const { reducer, initialState } = createDraftReducer<Row>({
+    getId: (r) => r.id,
+    equals: (a, b) => a.value === b.value,
+});
+
+describe('REFRESH_CONFIG', () => {
+    it('updates only the named config, leaving other tabs and dirty state intact', () => {
+        const loaded = reducer(initialState, {
+            type: 'LOAD_ALL_CONFIGS',
+            configs: [
+                { name: 'route0', rows: [{ id: 'r0', value: 'a' }] },
+                { name: 'route1', rows: [{ id: 'r1', value: 'b' }] },
+            ],
+        });
+        const edited = reducer(loaded, {
+            type: 'UPDATE_ROW',
+            configName: 'route1',
+            id: 'r1',
+            patch: { value: 'edited' },
+        });
+        expect(edited.dirty.has('route1')).toBe(true);
+
+        const refreshed = reducer(edited, {
+            type: 'REFRESH_CONFIG',
+            configName: 'route0',
+            rows: [{ id: 'r0-new', value: 'a-refreshed' }],
+        });
+
+        expect(refreshed.serverConfigs).toEqual(['route0', 'route1']);
+        expect(refreshed.draft['route1']).toEqual([{ id: 'r1', value: 'edited' }]);
+        expect(refreshed.dirty.has('route1')).toBe(true);
+        expect(refreshed.dirty.has('route0')).toBe(false);
+        expect(refreshed.draft['route0']).toEqual([{ id: 'r0-new', value: 'a-refreshed' }]);
+    });
+
+    it('keeps a dirty draft untouched while updating its server snapshot', () => {
+        const loaded = reducer(initialState, {
+            type: 'LOAD_ALL_CONFIGS',
+            configs: [{ name: 'route0', rows: [{ id: 'r0', value: 'a' }] }],
+        });
+        const edited = reducer(loaded, {
+            type: 'UPDATE_ROW',
+            configName: 'route0',
+            id: 'r0',
+            patch: { value: 'edited-by-user' },
+        });
+        expect(edited.dirty.has('route0')).toBe(true);
+
+        const refreshed = reducer(edited, {
+            type: 'REFRESH_CONFIG',
+            configName: 'route0',
+            rows: [{ id: 'r0', value: 'changed-on-server' }],
+        });
+
+        expect(refreshed.draft['route0']).toEqual([{ id: 'r0', value: 'edited-by-user' }]);
+        expect(refreshed.server['route0']).toEqual([{ id: 'r0', value: 'changed-on-server' }]);
+        expect(refreshed.dirty.has('route0')).toBe(true);
+    });
+});

--- a/web/src/core/components/draft/draftReducer.ts
+++ b/web/src/core/components/draft/draftReducer.ts
@@ -15,6 +15,7 @@ export interface DraftState<T> {
 
 export type DraftAction<T> =
     | { type: 'LOAD_ALL_CONFIGS'; configs: Array<{ name: string; rows: T[] }> }
+    | { type: 'REFRESH_CONFIG'; configName: string; rows: T[] }
     | { type: 'ADD_ROW'; configName: string; row: T; afterIndex?: number }
     | { type: 'UPDATE_ROW'; configName: string; id: string; patch: Partial<T> }
     | { type: 'REMOVE_ROW'; configName: string; id: string }
@@ -91,6 +92,26 @@ export const createDraftReducer = <T extends { id?: unknown }>(
                     serverConfigs.push(name);
                 }
                 const next = { ...state, server: newServer, draft: newDraft, serverConfigs };
+                return { ...next, dirty: recomputeDirty(next, equals) };
+            }
+
+            /** Refreshes one config's server rows without touching any other config's tab or dirty state. */
+            case 'REFRESH_CONFIG': {
+                const { configName, rows } = action;
+                const prevServer = state.server[configName] ?? [];
+                const prevDraft = state.draft[configName] ?? [];
+                const unchanged =
+                    prevServer.length === prevDraft.length &&
+                    prevServer.every((r, idx) => equals(r, prevDraft[idx]));
+                const next = {
+                    ...state,
+                    server: { ...state.server, [configName]: rows },
+                    draft: unchanged ? { ...state.draft, [configName]: rows } : state.draft,
+                    serverConfigs: state.serverConfigs.includes(configName)
+                        ? state.serverConfigs
+                        : [...state.serverConfigs, configName],
+                    localOnlyConfigs: state.localOnlyConfigs.filter((n) => n !== configName),
+                };
                 return { ...next, dirty: recomputeDirty(next, equals) };
             }
 

--- a/web/src/core/utils/netip.test.ts
+++ b/web/src/core/utils/netip.test.ts
@@ -4,6 +4,8 @@ import {
     stringToIPAddress,
     ipRangeToCIDRs,
     cidrToIPRange,
+    normalizeIPRange,
+    ipRangeSpan,
     parseCIDRPrefix,
     parseCidrsToIPNets,
     parseIPToBytes,
@@ -555,5 +557,33 @@ describe('IPv6Address.toString round-trip', () => {
         if (result.ok) {
             expect(result.value.toString()).toBe('1:0:2:3:4:5:6:7');
         }
+    });
+});
+
+describe('normalizeIPRange', () => {
+    it('canonicalizes valid ascending endpoints', () => {
+        expect(normalizeIPRange('10.0.0.1', '10.0.0.130')).toEqual({ start: '10.0.0.1', end: '10.0.0.130' });
+    });
+
+    it('rejects a reversed range', () => {
+        expect(normalizeIPRange('10.0.0.130', '10.0.0.1')).toBeUndefined();
+    });
+
+    it('rejects mismatched address families', () => {
+        expect(normalizeIPRange('10.0.0.1', '::1')).toBeUndefined();
+    });
+});
+
+describe('ipRangeSpan', () => {
+    it('returns a larger span for a broader range', () => {
+        const narrow = ipRangeSpan({ start: '10.0.0.0', end: '10.0.0.255' });
+        const broad = ipRangeSpan({ start: '10.0.0.0', end: '10.255.255.255' });
+        expect(narrow).toBeDefined();
+        expect(broad).toBeDefined();
+        expect(broad! > narrow!).toBe(true);
+    });
+
+    it('returns undefined for a missing endpoint', () => {
+        expect(ipRangeSpan({ start: '10.0.0.0' })).toBeUndefined();
     });
 });

--- a/web/src/core/utils/netip.ts
+++ b/web/src/core/utils/netip.ts
@@ -897,6 +897,31 @@ export const cidrToIPRange = (cidr: string): IPRangeWire | undefined => {
     };
 };
 
+// Build a canonical wire IPRange from explicit endpoint strings. Both must
+// parse as the same address family and start must not exceed end. Returns
+// undefined otherwise.
+export const normalizeIPRange = (from: string, to: string): IPRangeWire | undefined => {
+    const fromBytes = parseIPToBytes(from);
+    const toBytes = parseIPToBytes(to);
+    if (!fromBytes || !toBytes || fromBytes.length !== toBytes.length) return undefined;
+    if (bytesToBigInt(fromBytes) > bytesToBigInt(toBytes)) return undefined;
+    return {
+        start: formatIPFromBytes(fromBytes),
+        end: formatIPFromBytes(toBytes),
+    };
+};
+
+// Number of addresses between a range's endpoints (end - start), used to
+// order ranges by specificity. Returns undefined for missing/unparseable
+// endpoints.
+export const ipRangeSpan = (range: IPRangeWire | undefined): bigint | undefined => {
+    if (!range?.start || !range?.end) return undefined;
+    const startBytes = parseIPToBytes(range.start);
+    const endBytes = parseIPToBytes(range.end);
+    if (!startBytes || !endBytes || startBytes.length !== endBytes.length) return undefined;
+    return bytesToBigInt(endBytes) - bytesToBigInt(startBytes);
+};
+
 /**
  * Parse CIDR strings to IPNet array with base64-encoded bytes.
  *


### PR DESCRIPTION
The route FIB table expanded each server range into its constituent CIDRs, so a range that is not CIDR-aligned became one row per synthetic prefix the operator never configured. The CLI has always rendered the same data as the ranges the server actually holds.

- Carry the range on the row itself, with separate From and To columns matching the CLI. An ECMP group repeats the range on each of its rows rather than leaving continuation cells blank, because the table can be searched, filtered and sorted, which would orphan a blank cell.
- Accept either a CIDR or an explicit range in the drawer's single range field, normalising both to the same endpoints.
- Emit broader ranges first on commit. A range editor makes partial overlaps easy to author, and the dataplane paints ranges last-write-wins, so this ordering is what reproduces longest-prefix-match.
- Merge rows that share a range into one entry. Grouping previously only looked at the adjacent row, so two nexthops for one prefix that were not next to each other in the table were sent as two entries and the second silently replaced the first.

The page also dropped the per-nexthop counter in both directions, so loading a config and saving it back replaced every explicit name with a generated one.

- Carry the counter through the whole round trip, and show and validate it in the table and drawer.
- Refresh the config after a successful save, so a name the server generated appears immediately rather than after a manual reload. The refresh updates one config in place, since rebuilding the whole list would drop every other config's tab along with its unsaved edits.
- Import a file written by the previous release, converting its prefix rows. A row whose prefix is malformed arrives flagged rather than aborting the import, matching how a malformed row in the current format behaves.
