### PR TITLE
fix(controlplane): drop the default auth path to an uninstalled file

### DIFF
--- a/controlplane/etc/yanet/controlplane-default.yaml
+++ b/controlplane/etc/yanet/controlplane-default.yaml
@@ -19,12 +19,22 @@ gateway:
     # i.e. ::1). Override via `server_name` if you need a different SNI.
     # Cert rotation requires a director restart.
     # tls:
-    #   cert_file: /etc/yanet/tls/server.pem
-    #   key_file:  /etc/yanet/tls/server.key
+    #   cert_file: /etc/yanet2/tls/server.pem
+    #   key_file:  /etc/yanet2/tls/server.key
     #   server_name: localhost
   auth:
     disabled: true
-    permissions_path: /etc/yanet/auth/permissions.yaml
+    # Enabling auth means setting `disabled: false` plus all three keys
+    # below: an identity source, an authenticator, a permissions policy.
+    # None of the referenced files ships with the package — add per site.
+    # identity_providers:
+    #   - type: file
+    #     path: /etc/yanet2/auth/identities.yaml
+    # authenticators:
+    #   - type: basic
+    #     config:
+    #       credentials_path: /etc/yanet2/auth/basic_auth.yaml
+    # permissions_path: /etc/yanet2/auth/permissions.yaml
   registry:
     # The gateway drops backends that stopped refreshing their registration,
     # so a stopped operator disappears from the registry instead of

--- a/controlplane/internal/auth/sshcert/loader_test.go
+++ b/controlplane/internal/auth/sshcert/loader_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestNewLoader_FileAutoDetect(t *testing.T) {
-	loader := NewLoader("/etc/yanet/auth/ca.yaml")
+	loader := NewLoader("/etc/yanet2/auth/ca.yaml")
 	_, ok := loader.(*fileLoader)
 	assert.True(t, ok, "expected fileLoader for file path")
-	assert.Equal(t, "/etc/yanet/auth/ca.yaml", loader.Source())
+	assert.Equal(t, "/etc/yanet2/auth/ca.yaml", loader.Source())
 }
 
 func TestNewLoader_HTTPAutoDetect(t *testing.T) {


### PR DESCRIPTION
- The shipped control-plane default named an auth permissions file that no packaging manifest installs, so a deploy that enabled auth off the shipped default pointed at a file that was never there.
- That path also used an `/etc` prefix this distribution does not install to anywhere else, as did the two commented TLS paths beside it.
- Replace the dead key with a commented example that covers everything auth actually needs to come up, since an identity source, an authenticator and a permissions policy are all required and the previous single key could never work alone.
- Installing a real default policy file was considered and rejected: it would become a package configuration file that upgrades never replace, while its contents track the RPC surface of the binary shipped with it.
- Move the remaining stray paths, including one arbitrary literal in a loader test, onto the prefix the distribution actually installs to.
