### PR TITLE
ci(format): pin the clang-format image by digest

### DIFF
--- a/.github/actions/clang-format/README.md
+++ b/.github/actions/clang-format/README.md
@@ -1,0 +1,32 @@
+# clang-format action
+
+This action runs `clang-format` inside a prebuilt container image, pinned in `action.yml` by an immutable `@sha256:...` digest rather than the mutable `:19` tag.
+
+## Why the pin
+
+`ghcr.io/yanet-platform/clang-format:19` is a mutable tag: the `Build and push clang-format image` workflow can rebuild and re-push it at any time, silently swapping the formatter binary underneath every consumer. A new `clang-format` patch release changes brace, wrapping, and alignment heuristics enough to either mass-reformat the tree on whichever unrelated PR happens to touch a changed file, or fail every open PR at once. Pinning to a digest makes a version bump a deliberate, reviewed step instead of something that happens silently on the next image rebuild.
+
+## The gotcha this creates
+
+Because CI consumes a digest, editing `Dockerfile` or `entrypoint.sh` does not change what the formatting gate runs, and editing `action.yml` in the same PR does not fix that, because no rebuild happens until the change reaches `main` or the workflow is dispatched manually. The concrete trap: a PR that adds a new action input together with the `entrypoint.sh` code that reads it gets a **green** `C formatting` check produced by the old image, which ignores that input entirely. So treat any change to the image as step 1 of the two-step bump below.
+
+## Bumping the pinned version
+
+1. Change `Dockerfile` or `entrypoint.sh`, or run the `Build and push clang-format image` workflow manually via `workflow_dispatch` to pick up a newer `release/19.x` patch release.
+2. After the rebuild completes, read the pushed reference and `clang-format --version` output from its job summary.
+3. Open a follow-up PR that replaces the `image:` digest and the version comment in `action.yml`.
+4. `check-format.yml` also triggers on changes under this directory, so that PR runs the formatting gate over the whole tree. Any reformatting the new version wants shows up as a red check on the bump PR itself — fold that reformatting into the same PR.
+
+## Reading the currently published digest without merging anything
+
+```
+docker buildx imagetools inspect ghcr.io/yanet-platform/clang-format:19 --format '{{.Manifest.Digest}}'
+```
+
+This is a public package and needs no authentication.
+
+## Notes
+
+The image is built for linux/amd64 only. The digest currently pinned in `action.yml` is clang-format 19.1.7, built from `llvmorg-19.1.7`. `Dockerfile` clones the `release/19.x` branch, so a rebuild resolves whatever that branch points to at build time — which is why the workflow's job summary reports the version it actually produced.
+
+Every rebuild publishes both the moving `:19` tag and an immutable `:19-<commit-sha>` tag, so the manifest a pin names always keeps a tag and cannot be swept by an untagged-version cleanup.

--- a/.github/actions/clang-format/action.yml
+++ b/.github/actions/clang-format/action.yml
@@ -16,4 +16,6 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/yanet-platform/clang-format:19'
+  # Immutable digest pin: clang-format 19.1.7, built from llvmorg-19.1.7.
+  # Read README.md before changing this line — a bump is a two-step process.
+  image: 'docker://ghcr.io/yanet-platform/clang-format@sha256:d5929186c477ddddd58a03d81b4029c868d9736c1eedbf4f4bac30fd31a1b241'

--- a/.github/workflows/build-push-clang-format-image.yml
+++ b/.github/workflows/build-push-clang-format-image.yml
@@ -6,6 +6,10 @@ on:
     branches: ["main"]
     paths:
       - ".github/actions/clang-format/**"
+      # The digest pin and the docs are not part of the image. Rebuilding on a
+      # pin bump would invalidate the digest that bump just adopted.
+      - "!.github/actions/clang-format/action.yml"
+      - "!.github/actions/clang-format/README.md"
 
 permissions:
   packages: write
@@ -27,8 +31,24 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .github/actions/clang-format
           push: true
-          tags: ghcr.io/yanet-platform/clang-format:19
+          tags: |
+            ghcr.io/yanet-platform/clang-format:19
+            ghcr.io/yanet-platform/clang-format:19-${{ github.sha }}
+
+      - name: Report pushed image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          ref="ghcr.io/yanet-platform/clang-format@$DIGEST"
+          version="$(docker run --rm --entrypoint /usr/bin/clang-format "$ref" --version)"
+          {
+              echo "### clang-format image pushed"
+              echo "- Reference: \`$ref\`"
+              echo "- Version: \`$version\`"
+              echo "- Pin this reference in \`.github/actions/clang-format/action.yml\`."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - "**.h"
       - "**.c"
+      - ".github/actions/clang-format/**"
+      - ".github/workflows/check-format.yml"
   pull_request:
     branches: ["main"]
     paths:
       - "**.h"
       - "**.c"
+      - ".github/actions/clang-format/**"
+      - ".github/workflows/check-format.yml"
 
 jobs:
   c-cpp-fmt:


### PR DESCRIPTION
- The C formatting gate ran from a mutable major-version image tag, so a rebuild of that image could silently change the formatter binary every pull request is checked against.
- A formatter version change rewrites brace, wrapping and alignment heuristics widely enough to land either as a surprise mass reformat on whichever unrelated change next touches an affected file, or as a simultaneous failure across every open pull request.
- The action now pins an immutable digest, recorded alongside the human-readable version it resolves to.
- The pin and its documentation are excluded from the triggers that rebuild and republish the image, so adopting a digest no longer invalidates the digest it just adopted.
- The formatting gate now also runs on changes to the action itself, so a bump is verified by the pull request that makes it and any reformatting a new version wants surfaces there rather than on an unrelated change later.
- Each rebuild reports the pushed reference and the formatter version it produced into the workflow summary, and publishes a permanent commit-tagged reference alongside the moving one.
- A README beside the action documents the bump procedure, including the consequence that changes to the image are inert until the pin is updated.