### PR TITLE
fix(route): quiet the log for neighbours without a hardware address

### DIFF
--- a/operators/route/internal/discovery/neigh/neigh.go
+++ b/operators/route/internal/discovery/neigh/neigh.go
@@ -411,8 +411,17 @@ func (m *NeighMonitor) updateNeighbours() error {
 			continue
 		}
 
-		// Skip entries with invalid MAC.
-		if len(neigh.HardwareAddr) != 6 {
+		// An absent hardware address leaves nothing to forward to and is
+		// routine, so it is logged at debug level. A present but non-EUI-48
+		// address is rarer and still warrants a warning.
+		switch {
+		case len(neigh.HardwareAddr) == 0:
+			m.log.Debug("skipping entry with no destination MAC address",
+				zap.Stringer("state", NeighbourState(neigh.State)),
+				zap.Stringer("nexthop_addr", nexthopAddr),
+			)
+			continue
+		case len(neigh.HardwareAddr) != 6:
 			m.log.Warn("skipping entry with unsupported MAC address: must be EUI-48",
 				zap.Stringer("mac", neigh.HardwareAddr),
 			)

--- a/operators/route/internal/discovery/neigh/neigh_test.go
+++ b/operators/route/internal/discovery/neigh/neigh_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/yanet-platform/yanet2/operators/route/internal/discovery/neigh"
 )
@@ -100,6 +102,78 @@ func TestNeighMonitorRejectsUnusableSourceMAC(t *testing.T) {
 				require.Equal(t, [6]byte(tt.linkHardwareAddr), entry.HardwareRoute.SourceMAC)
 				require.Equal(t, [6]byte(neighbourMAC), entry.HardwareRoute.DestinationMAC)
 			}
+		})
+	}
+}
+
+// TestNeighMonitorClassifiesMissingVsMalformedDestinationMAC verifies how a
+// destination hardware address is classified by its length.
+//
+// A neighbour with no hardware address is skipped without a warning, while a
+// present but non-EUI-48 address still warns. Both are excluded from the
+// resolved nexthop cache either way.
+func TestNeighMonitorClassifiesMissingVsMalformedDestinationMAC(t *testing.T) {
+	nexthop := netip.MustParseAddr("10.0.0.2")
+	linkHardwareAddr := net.HardwareAddr{0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+
+	tests := []struct {
+		name              string
+		neighHardwareAddr net.HardwareAddr
+		wantWarn          bool
+	}{
+		{
+			name:              "unresolved neighbour has no hardware address",
+			neighHardwareAddr: nil,
+			wantWarn:          false,
+		},
+		{
+			name:              "malformed non-empty hardware address",
+			neighHardwareAddr: net.HardwareAddr{0x0a, 0x00, 0x00, 0x01},
+			wantWarn:          true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			table := neigh.NewNeighTable()
+			source, err := table.CreateSource("kernel", 100, true)
+			require.NoError(t, err)
+
+			link := &netlink.Device{
+				LinkAttrs: netlink.LinkAttrs{
+					Index:        1,
+					Name:         "eth0",
+					HardwareAddr: linkHardwareAddr,
+				},
+			}
+			kernelNeigh := netlink.Neigh{
+				LinkIndex:    1,
+				IP:           nexthop.AsSlice(),
+				HardwareAddr: tt.neighHardwareAddr,
+				State:        netlink.NUD_INCOMPLETE,
+			}
+
+			fake := fakeKernelTable{
+				links:  []netlink.Link{link},
+				neighs: []netlink.Neigh{kernelNeigh},
+			}
+
+			core, logs := observer.New(zapcore.DebugLevel)
+			neigh.NewNeighMonitor(table, source,
+				neigh.WithKernelTable(fake),
+				neigh.WithLog(zap.New(core)),
+			)
+
+			_, ok := table.View().Lookup(nexthop)
+			require.False(t, ok, "entry with a bad destination MAC must never enter the cache")
+
+			gotWarn := false
+			for _, entry := range logs.All() {
+				if entry.Level == zapcore.WarnLevel {
+					gotWarn = true
+				}
+			}
+			require.Equal(t, tt.wantWarn, gotWarn)
 		})
 	}
 }


### PR DESCRIPTION
The route operator warned on every neighbour the kernel reports without a link-layer address. That is a routine steady state rather than an anomaly, so a running stand emitted the warning about once a second and buried the warnings that matter. This was observed on a load-test stand, where the message repeated continuously for the lifetime of the process.

Such an entry now drops to debug level and names the neighbour it skipped, matching how every other skip path in the same loop identifies its subject.

An address that is present but not of Ethernet length is still reported at warning level as before.

The change is observability-only: the set of entries the operator skips is unchanged, so the resolved nexthop cache and everything derived from it are unaffected.