### PR TITLE
fix(acl,forward): name where the counter name is actually shown

### DIFF
--- a/modules/acl/web/RuleDrawer.tsx
+++ b/modules/acl/web/RuleDrawer.tsx
@@ -233,7 +233,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                             onChange={e => updateField('counter', e.target.value)}
                         />
                         <span className="yn-field__hint">
-                            Counter name shown in /stats.
+                            Counter name shown in the table's Counter column.
                             {ruleItem !== null
                                 ? ' Leave empty to use the auto-assigned default name (shifts with rule position).'
                                 : ' Leave empty to use the auto-assigned default name.'}

--- a/modules/forward/web/RuleDrawer.tsx
+++ b/modules/forward/web/RuleDrawer.tsx
@@ -173,7 +173,7 @@ const RuleDrawer = React.forwardRef<RuleDrawerHandle, RuleDrawerProps>(({
                             onChange={(e) => updateField('counter', e.target.value)}
                         />
                         <span className="yn-field__hint">
-                            Name shown in /stats. Leave empty to use the auto-assigned default name (to_&lt;target&gt;).
+                            Name shown in the table's Counter column. Leave empty to use the auto-assigned default name (to_&lt;target&gt;).
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
- The acl and forward rule drawers told the user their counter name was shown on a stats page. No such route is mounted anywhere in the web UI, and the string appeared in no Go or Rust path either, so the hint sent them looking for a page that has never existed.
- Both hints now name the table column that actually renders the name, in the same table the drawer edits rows for. That column is unconditionally rendered and shows the auto-assigned default when the field is empty, so the claim holds for a rule the user never named.
- The rate column is deliberately not named: it renders a rate looked up by the counter name and never displays the name itself.
- Found by applying the convention landed in #1707, whose sweep across the sibling per-module web roots is what surfaced both copies of the stale claim.
