### PR TITLE
test(xcfg,packaging): guard shipped default configs against silent drift

### DIFF
--- a/common/go/xcfg/known_keys.go
+++ b/common/go/xcfg/known_keys.go
@@ -1,0 +1,221 @@
+package xcfg
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+var yamlNodeType = reflect.TypeFor[yaml.Node]()
+
+// mergeTag is the resolved tag yaml.v3 assigns to a "<<" merge key.
+const mergeTag = "!!merge"
+
+// CheckKnownKeys reports every YAML mapping key in data that has no matching
+// field in T.
+//
+// Unlike WithKnownFields, it walks the parsed node tree directly against T's
+// reflected shape instead of driving yaml.v3's own strict decoder, so it
+// keeps working across a field whose type implements UnmarshalYAML by
+// re-decoding through a fresh, non-strict decoder — the case
+// WithKnownFields is blind to. All unknown keys are collected into one
+// error, each as a dotted path rooted at the document.
+func CheckKnownKeys[T any](data []byte) error {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("failed to parse yaml document: %w", err)
+	}
+	if len(doc.Content) == 0 {
+		return nil
+	}
+
+	var unknown []string
+	walkKnownKeys(doc.Content[0], reflect.TypeFor[T](), "", &unknown, map[*yaml.Node]bool{})
+	if len(unknown) == 0 {
+		return nil
+	}
+	return fmt.Errorf("unknown keys: %s", strings.Join(unknown, ", "))
+}
+
+// walkKnownKeys matches node's shape against t, appending the dotted path of
+// every mapping key that has no corresponding field to unknown.
+//
+// visiting holds the alias targets already on the current descent path, so
+// a self-referential merge anchor is caught here instead of recursing
+// forever — yaml.v3 only rejects that cycle when decoding into a Go value,
+// not into a node tree, and LoadConfig catches it separately, so stopping
+// silently is enough. The entry is removed on return, so a legitimate
+// anchor reused at sibling paths is still walked at each site.
+func walkKnownKeys(node *yaml.Node, t reflect.Type, path string, unknown *[]string, visiting map[*yaml.Node]bool) {
+	if node == nil {
+		return
+	}
+	if node.Kind == yaml.AliasNode {
+		target := node.Alias
+		if target == nil || visiting[target] {
+			return
+		}
+		visiting[target] = true
+		defer delete(visiting, target)
+		node = target
+	}
+
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() == reflect.Interface || t == yamlNodeType {
+		return
+	}
+
+	switch node.Kind {
+	case yaml.MappingNode:
+		walkMappingNode(node, t, path, unknown, visiting)
+	case yaml.SequenceNode:
+		walkSequenceNode(node, t, path, unknown, visiting)
+	}
+}
+
+// walkMappingNode checks a YAML mapping node against a struct or map type.
+//
+// Any other target type leaves the mapping with no declared keys to check
+// against, so it is skipped without reporting — for example a mapping
+// value against a plain scalar field is a shape mismatch that yaml.v3
+// itself rejects on the strict decode path.
+func walkMappingNode(node *yaml.Node, t reflect.Type, path string, unknown *[]string, visiting map[*yaml.Node]bool) {
+	switch t.Kind() {
+	case reflect.Struct:
+		fields, inlineElem := collectFields(t)
+		for idx := 0; idx+1 < len(node.Content); idx += 2 {
+			keyNode, valueNode := node.Content[idx], node.Content[idx+1]
+			if keyNode.Tag == mergeTag {
+				walkMergeValue(valueNode, t, path, unknown, visiting)
+				continue
+			}
+
+			fieldPath := joinPath(path, keyNode.Value)
+			fieldType, ok := fields[keyNode.Value]
+			switch {
+			case ok:
+				walkKnownKeys(valueNode, fieldType, fieldPath, unknown, visiting)
+			case inlineElem != nil:
+				walkKnownKeys(valueNode, inlineElem, fieldPath, unknown, visiting)
+			default:
+				*unknown = append(*unknown, fieldPath)
+			}
+		}
+	case reflect.Map:
+		elemType := t.Elem()
+		for idx := 0; idx+1 < len(node.Content); idx += 2 {
+			fieldPath := joinPath(path, node.Content[idx].Value)
+			walkKnownKeys(node.Content[idx+1], elemType, fieldPath, unknown, visiting)
+		}
+	}
+}
+
+// walkMergeValue walks a "<<" merge key's value against t, the struct type
+// of the mapping it merges into, since merged keys land in that mapping
+// rather than under a field of their own.
+//
+// The value can also be a scalar or a sequence of scalars — shapes YAML
+// permits, though neither carries keys to check. A sequence value is
+// walked in place rather than routed through walkSequenceNode, since its
+// elements share t rather than a slice element type.
+func walkMergeValue(node *yaml.Node, t reflect.Type, path string, unknown *[]string, visiting map[*yaml.Node]bool) {
+	if node.Kind == yaml.SequenceNode {
+		for _, item := range node.Content {
+			walkKnownKeys(item, t, path, unknown, visiting)
+		}
+		return
+	}
+	walkKnownKeys(node, t, path, unknown, visiting)
+}
+
+// walkSequenceNode checks each element of a YAML sequence node against a
+// slice or array type's element type.
+func walkSequenceNode(node *yaml.Node, t reflect.Type, path string, unknown *[]string, visiting map[*yaml.Node]bool) {
+	if t.Kind() != reflect.Slice && t.Kind() != reflect.Array {
+		return
+	}
+	elemType := t.Elem()
+	for idx, item := range node.Content {
+		walkKnownKeys(item, elemType, fmt.Sprintf("%s[%d]", path, idx), unknown, visiting)
+	}
+}
+
+func joinPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}
+
+// fieldSet maps a YAML key name to the Go type that decodes it.
+type fieldSet map[string]reflect.Type
+
+// collectFields returns t's exported fields keyed by their YAML name, plus
+// the element type of at most one inline map field, or nil if there is
+// none.
+//
+// The inline map field catches any key the named fields don't match
+// instead of the key being unknown. A field with no explicit tag name is
+// keyed by its lowercased Go name, matching yaml.v3's own default key
+// resolution. An inline struct field's own fields are merged in at the
+// same level.
+func collectFields(t reflect.Type) (fieldSet, reflect.Type) {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, nil
+	}
+
+	fields := fieldSet{}
+	var inlineElem reflect.Type
+	for idx := range t.NumField() {
+		f := t.Field(idx)
+		if !f.IsExported() {
+			continue
+		}
+
+		tag := f.Tag.Get("yaml")
+		if tag == "-" {
+			continue
+		}
+		if isInlineTag(tag) {
+			ft := f.Type
+			for ft.Kind() == reflect.Pointer {
+				ft = ft.Elem()
+			}
+			if ft.Kind() == reflect.Map {
+				inlineElem = ft.Elem()
+				continue
+			}
+			nested, nestedInlineElem := collectFields(f.Type)
+			maps.Copy(fields, nested)
+			if nestedInlineElem != nil {
+				inlineElem = nestedInlineElem
+			}
+			continue
+		}
+
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" {
+			name = strings.ToLower(f.Name)
+		}
+		fields[name] = f.Type
+	}
+	return fields, inlineElem
+}
+
+// isInlineTag reports whether a yaml struct tag carries the "inline" option.
+func isInlineTag(tag string) bool {
+	_, opts, found := strings.Cut(tag, ",")
+	if !found {
+		return false
+	}
+	return slices.Contains(strings.Split(opts, ","), "inline")
+}

--- a/common/go/xcfg/known_keys_test.go
+++ b/common/go/xcfg/known_keys_test.go
@@ -1,0 +1,268 @@
+package xcfg_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+)
+
+type knownKeysInner struct {
+	Addr string `yaml:"addr"`
+}
+
+type knownKeysConfig struct {
+	Name  string              `yaml:"name"`
+	Inner knownKeysInner      `yaml:"inner"`
+	Base  knownKeysInner      `yaml:"base"`
+	A     knownKeysInner      `yaml:"a"`
+	Extra map[string]string   `yaml:"extra"`
+	Nodes []knownKeysInner    `yaml:"nodes"`
+	Raw   yaml.Node           `yaml:"raw"`
+	Chain xcfg.NonEmptyString `yaml:"chain"`
+}
+
+// knownKeysUntagged has one field left without a yaml tag, to exercise
+// collectFields' fallback key resolution against yaml.v3's own.
+type knownKeysUntagged struct {
+	MemoryPath string
+}
+
+func Test_CheckKnownKeys_CleanDocument(t *testing.T) {
+	input := `
+name: foo
+inner:
+  addr: 1.2.3.4
+extra:
+  a: b
+nodes:
+  - addr: 5.6.7.8
+raw:
+  anything: goes
+chain: c
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_UnknownAtTopLevel(t *testing.T) {
+	input := `
+name: foo
+bogus: true
+`
+	err := xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bogus")
+}
+
+func Test_CheckKnownKeys_UnknownNested(t *testing.T) {
+	input := `
+name: foo
+inner:
+  addr: 1.2.3.4
+  bogus: true
+`
+	err := xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "inner.bogus")
+}
+
+func Test_CheckKnownKeys_ScalarAliasIntoStructFieldNotFlagged(t *testing.T) {
+	input := `
+name: &n foo
+inner: *n
+`
+	// inner decodes from a scalar alias into a struct type, which is a
+	// shape mismatch and must be skipped rather than flagged.
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_UnknownKeyBehindAlias(t *testing.T) {
+	input := `
+base: &b
+  addr: 1.2.3.4
+  bogus: true
+a: *b
+`
+	err := xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "base.bogus")
+	require.Contains(t, err.Error(), "a.bogus")
+}
+
+func Test_CheckKnownKeys_MapValueNotFlagged(t *testing.T) {
+	input := `
+name: foo
+extra:
+  anything_at_all: value
+  another_free_key: value
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_YAMLNodeFieldNotFlagged(t *testing.T) {
+	input := `
+name: foo
+raw:
+  whatever_shape: it_wants
+  nested:
+    also_free: true
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_SliceElement(t *testing.T) {
+	input := `
+name: foo
+nodes:
+  - addr: 1.2.3.4
+  - addr: 5.6.7.8
+    bogus: true
+`
+	err := xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nodes[1].bogus")
+}
+
+func Test_CheckKnownKeys_ScalarUnmarshalerNotFlagged(t *testing.T) {
+	// chain is xcfg.NonEmptyString, which decodes from a bare scalar. There
+	// are no keys to check underneath it.
+	input := `
+name: foo
+chain: some-value
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_MultipleUnknownKeysReportedTogether(t *testing.T) {
+	input := `
+name: foo
+bogus_one: true
+inner:
+  addr: 1.2.3.4
+  bogus_two: true
+`
+	err := xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "bogus_one")
+	require.Contains(t, err.Error(), "inner.bogus_two")
+}
+
+func Test_CheckKnownKeys_MergeKeySingleAliasNotFlagged(t *testing.T) {
+	input := `
+base: &b
+  addr: 1.2.3.4
+inner:
+  <<: *b
+name: x
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_MergeKeySequenceAliasNotFlagged(t *testing.T) {
+	input := `
+base: &b
+  addr: 1.2.3.4
+a: &c
+  addr: 5.6.7.8
+inner:
+  <<: [*b, *c]
+name: x
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_MergeKeyUnknownInMergedMappingReported(t *testing.T) {
+	input := `
+base: &b
+  addr: 1.2.3.4
+  bogus: true
+inner:
+  <<: *b
+name: x
+`
+	err := xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "base.bogus")
+	require.Contains(t, err.Error(), "inner.bogus")
+}
+
+func Test_CheckKnownKeys_SelfReferentialMergeAnchorTerminates(t *testing.T) {
+	// A merge key whose alias resolves back to its own mapping node is a
+	// cycle: yaml.v3 rejects it while decoding into a Go value but not
+	// while decoding into a node tree, so CheckKnownKeys must bound the
+	// recursion itself instead of overflowing the stack.
+	input := `
+base: &b
+  addr: 1.2.3.4
+  <<: *b
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_SelfReferentialMergeSequenceTerminates(t *testing.T) {
+	input := `
+base: &b
+  addr: 1.2.3.4
+  <<: [*b]
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_MergeKeySiblingsBothWalked(t *testing.T) {
+	// The same anchor merged into two independent mappings is not a cycle,
+	// so an unknown key inside it must be reported at both merge sites,
+	// proving the cycle guard is scoped to a descent path rather than
+	// shared globally across the whole walk.
+	input := `
+base: &b
+  addr: 1.2.3.4
+  bogus: true
+inner:
+  <<: *b
+a:
+  <<: *b
+name: x
+`
+	err := xcfg.CheckKnownKeys[knownKeysConfig]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "base.bogus")
+	require.Contains(t, err.Error(), "inner.bogus")
+	require.Contains(t, err.Error(), "a.bogus")
+}
+
+func Test_CheckKnownKeys_UntaggedFieldLowercasedNameNotFlagged(t *testing.T) {
+	// yaml.v3 decodes an untagged field under its lowercased Go name.
+	input := `
+memorypath: /dev/hugepages/yanet
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysUntagged]([]byte(input)))
+}
+
+func Test_CheckKnownKeys_UntaggedFieldOriginalCaseFlagged(t *testing.T) {
+	// yaml.v3 silently drops this key rather than decoding it into
+	// MemoryPath, so it must be reported rather than accepted.
+	input := `
+MemoryPath: /dev/hugepages/yanet
+`
+	err := xcfg.CheckKnownKeys[knownKeysUntagged]([]byte(input))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MemoryPath")
+}
+
+// knownKeysInlineMap has an inline map field that catches any key not
+// matched by Name, mirroring yaml.v3's own ",inline" decoding.
+type knownKeysInlineMap struct {
+	Name  string            `yaml:"name"`
+	Extra map[string]string `yaml:",inline"`
+}
+
+func Test_CheckKnownKeys_InlineMapCatchAllNotFlagged(t *testing.T) {
+	input := `
+name: foo
+anything_at_all: value
+another_free_key: value
+`
+	require.NoError(t, xcfg.CheckKnownKeys[knownKeysInlineMap]([]byte(input)))
+}

--- a/controlplane/yncp/cfg_test.go
+++ b/controlplane/yncp/cfg_test.go
@@ -1,0 +1,24 @@
+package yncp_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/controlplane/yncp"
+)
+
+// Test_ShippedDefaultConfig_NoUnknownKeys guards the shipped default config
+// against a key that matches no field in yncp.Config.
+//
+// Config.UnmarshalYAML re-decodes through a fresh, non-strict yaml.v3
+// decoder, so xcfg.WithKnownFields cannot see a stray key here.
+// xcfg.CheckKnownKeys walks the reflected struct shape directly instead,
+// which is unaffected by that re-decode.
+func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
+	data, err := os.ReadFile("../etc/yanet/controlplane-default.yaml")
+	require.NoError(t, err)
+	require.NoError(t, xcfg.CheckKnownKeys[yncp.Config](data))
+}

--- a/operators/decap/internal/operator/cfg_test.go
+++ b/operators/decap/internal/operator/cfg_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +10,27 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
+
+// Test_ShippedDefaultConfig_NoUnknownKeys guards the shipped default config
+// against a key that matches no field in Config.
+//
+// FunctionConfig.UnmarshalYAML re-decodes through a fresh, non-strict
+// yaml.v3 decoder, so xcfg.WithKnownFields cannot see a stray key inside a
+// functions entry. xcfg.CheckKnownKeys walks the reflected struct shape
+// directly instead, which is unaffected by that re-decode.
+func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
+	data, err := os.ReadFile("../../etc/yanet/yanet-decap-operator-default.yaml")
+	require.NoError(t, err)
+	require.NoError(t, xcfg.CheckKnownKeys[Config](data))
+}
+
+// Test_ShippedPrefixesDefault_NoUnknownKeys guards the shipped decap
+// prefixes file against a key that matches no field in yamlPrefixFile.
+func Test_ShippedPrefixesDefault_NoUnknownKeys(t *testing.T) {
+	data, err := os.ReadFile("../../etc/yanet/decap.d/default.yaml")
+	require.NoError(t, err)
+	require.NoError(t, xcfg.CheckKnownKeys[yamlPrefixFile](data))
+}
 
 func TestDefaultConfig_ServerEndpoint(t *testing.T) {
 	cfg := DefaultConfig()

--- a/operators/forward/internal/operator/cfg_test.go
+++ b/operators/forward/internal/operator/cfg_test.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -8,6 +9,28 @@ import (
 	"github.com/yanet-platform/yanet2/common/go/operator"
 	"github.com/yanet-platform/yanet2/common/go/xcfg"
 )
+
+// Test_ShippedDefaultConfig_NoUnknownKeys guards the shipped default config
+// against a key that matches no field in Config.
+func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
+	data, err := os.ReadFile("../../etc/yanet/yanet-forward-operator-default.yaml")
+	require.NoError(t, err)
+	require.NoError(t, xcfg.CheckKnownKeys[Config](data))
+}
+
+// Test_ShippedRulesDefault_NoUnknownKeys guards the shipped forward rules
+// files against a key that matches no field in yamlForwardConfig.
+func Test_ShippedRulesDefault_NoUnknownKeys(t *testing.T) {
+	paths := []string{
+		"../../etc/yanet/forward.d/vlan-phy-default.yaml",
+		"../../etc/yanet/forward.d/phy-vlan-default.yaml",
+	}
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		require.NoError(t, xcfg.CheckKnownKeys[yamlForwardConfig](data))
+	}
+}
 
 // TestDecode_FunctionMissingRequiredField verifies that xcfg.Decode catches a
 // functions entry that omits a required NonEmptyString field, surfacing it as a

--- a/operators/pipeline/internal/operator/cfg_test.go
+++ b/operators/pipeline/internal/operator/cfg_test.go
@@ -1,0 +1,19 @@
+package operator_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/operators/pipeline/internal/operator"
+)
+
+// Test_ShippedDefaultConfig_NoUnknownKeys guards the shipped default config
+// against a key that matches no field in operator.Config.
+func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
+	data, err := os.ReadFile("../../etc/yanet/yanet-pipeline-operator-default.yaml")
+	require.NoError(t, err)
+	require.NoError(t, xcfg.CheckKnownKeys[operator.Config](data))
+}

--- a/operators/route/internal/operator/cfg_test.go
+++ b/operators/route/internal/operator/cfg_test.go
@@ -1,0 +1,19 @@
+package operator_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yanet-platform/yanet2/common/go/xcfg"
+	"github.com/yanet-platform/yanet2/operators/route/internal/operator"
+)
+
+// Test_ShippedDefaultConfig_NoUnknownKeys guards the shipped default config
+// against a key that matches no field in operator.Config.
+func Test_ShippedDefaultConfig_NoUnknownKeys(t *testing.T) {
+	data, err := os.ReadFile("../../etc/yanet/yanet-route-operator-default.yaml")
+	require.NoError(t, err)
+	require.NoError(t, xcfg.CheckKnownKeys[operator.Config](data))
+}

--- a/tests/packaging/packaging_test.go
+++ b/tests/packaging/packaging_test.go
@@ -1,0 +1,171 @@
+// Package packaging_test guards against a shipped default config naming a
+// /etc/yanet2 path that the debian packaging never installs there.
+//
+// Such a path decodes fine and looks correct in review, but points at a file
+// that will not exist on a fresh install, so the gap only surfaces at
+// runtime. The check walks each shipped YAML's parsed node tree rather than
+// its raw text, because a shipped file may legitimately mention an
+// uninstalled /etc/yanet2 path inside a commented-out example.
+package packaging_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// etcYanet2Prefix is the path prefix a shipped config value must carry to be
+// checked against the debian install manifests.
+const etcYanet2Prefix = "/etc/yanet2/"
+
+// shippedConfigPaths lists every default config YAML installed under
+// /etc/yanet2, relative to the repository root.
+//
+// Some are shipped by the root Makefile's install target, others by an
+// operator's meson install_data.
+var shippedConfigPaths = []string{
+	"controlplane/etc/yanet/controlplane-default.yaml",
+	"dataplane.yaml",
+	"operators/bird-adapter/etc/yanet/bird-adapter-default.yaml",
+	"operators/pipeline/etc/yanet/yanet-pipeline-operator-default.yaml",
+	"operators/route/etc/yanet/yanet-route-operator-default.yaml",
+	"operators/decap/etc/yanet/yanet-decap-operator-default.yaml",
+	"operators/decap/etc/yanet/decap.d/default.yaml",
+	"operators/forward/etc/yanet/yanet-forward-operator-default.yaml",
+	"operators/forward/etc/yanet/forward.d/vlan-phy-default.yaml",
+	"operators/forward/etc/yanet/forward.d/phy-vlan-default.yaml",
+}
+
+// collectEtcYanet2Values walks node's mapping and sequence structure and
+// returns every scalar value carrying etcYanet2Prefix.
+//
+// It never inspects comments: yaml.v3 attaches comment text to the node
+// tree but not as a scalar value, so a path mentioned only in a
+// commented-out example is invisible here.
+func collectEtcYanet2Values(node *yaml.Node) []string {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.AliasNode {
+		node = node.Alias
+		if node == nil {
+			return nil
+		}
+	}
+
+	var found []string
+	switch node.Kind {
+	case yaml.ScalarNode:
+		if strings.HasPrefix(node.Value, etcYanet2Prefix) {
+			found = append(found, node.Value)
+		}
+	case yaml.MappingNode, yaml.SequenceNode, yaml.DocumentNode:
+		for _, child := range node.Content {
+			found = append(found, collectEtcYanet2Values(child)...)
+		}
+	}
+	return found
+}
+
+// loadInstalledPatterns returns the source-path patterns listed across every
+// debian/*.install manifest, one per line, matchable with filepath.Match.
+//
+// Each line's first whitespace-separated field is the source path; a
+// debhelper .install line may carry a second field naming the destination
+// directory, which this ignores.
+func loadInstalledPatterns(t *testing.T) []string {
+	t.Helper()
+
+	matches, err := filepath.Glob("../../debian/*.install")
+	require.NoError(t, err)
+	require.NotEmpty(t, matches, "no debian/*.install manifests found")
+
+	var patterns []string
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		for line := range strings.SplitSeq(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			patterns = append(patterns, strings.Fields(line)[0])
+		}
+	}
+	return patterns
+}
+
+// isInstalled reports whether path matches one of patterns, glob or literal.
+func isInstalled(patterns []string, path string) bool {
+	for _, pattern := range patterns {
+		if ok, err := filepath.Match(pattern, path); err == nil && ok {
+			return true
+		}
+	}
+	return false
+}
+
+// Test_ShippedEtcYanet2PathsAreInstalled verifies that every /etc/yanet2
+// path named in a shipped default config is listed in some debian/*.install
+// manifest.
+func Test_ShippedEtcYanet2PathsAreInstalled(t *testing.T) {
+	installed := loadInstalledPatterns(t)
+
+	for _, configPath := range shippedConfigPaths {
+		t.Run(configPath, func(t *testing.T) {
+			data, err := os.ReadFile(filepath.Join("../..", configPath))
+			require.NoError(t, err)
+
+			var doc yaml.Node
+			require.NoError(t, yaml.Unmarshal(data, &doc))
+			if len(doc.Content) == 0 {
+				return
+			}
+
+			for _, value := range collectEtcYanet2Values(doc.Content[0]) {
+				installPath := strings.TrimPrefix(value, "/")
+				require.True(t, isInstalled(installed, installPath),
+					"%s: %q is not listed in any debian/*.install manifest", configPath, value)
+			}
+		})
+	}
+}
+
+// Test_CommentedOutPathsAreNotFlagged pins the distinction between walking
+// parsed YAML values and scanning raw text.
+//
+// controlplane-default.yaml carries commented-out TLS and auth examples
+// naming /etc/yanet2 paths, none of which are installed. A raw-text scan
+// would flag them. The node walk must not, since a commented-out path was
+// never parsed as a value.
+func Test_CommentedOutPathsAreNotFlagged(t *testing.T) {
+	data, err := os.ReadFile("../../controlplane/etc/yanet/controlplane-default.yaml")
+	require.NoError(t, err)
+
+	var doc yaml.Node
+	require.NoError(t, yaml.Unmarshal(data, &doc))
+	require.NotEmpty(t, doc.Content)
+
+	parsedValues := collectEtcYanet2Values(doc.Content[0])
+
+	commentedOutPaths := []string{
+		"/etc/yanet2/tls/server.pem",
+		"/etc/yanet2/tls/server.key",
+		"/etc/yanet2/auth/identities.yaml",
+		"/etc/yanet2/auth/basic_auth.yaml",
+		"/etc/yanet2/auth/permissions.yaml",
+	}
+	for _, path := range commentedOutPaths {
+		require.NotContains(t, parsedValues, path,
+			"a commented-out example must never surface as a parsed value")
+	}
+
+	rawMatches := regexp.MustCompile(regexp.QuoteMeta(etcYanet2Prefix)).FindAllString(string(data), -1)
+	require.GreaterOrEqual(t, len(rawMatches), len(commentedOutPaths),
+		"expected the commented-out auth/tls examples to still mention /etc/yanet2")
+}


### PR DESCRIPTION
- A key in a shipped default config that matches no field in the struct it decodes into is dropped silently, leaving the field on a default the deployment never asked for. This has happened twice already, and nothing mechanical catches it.
- Strict decoding cannot close the gap. A config type that decodes through its own unmarshaller re-enters a fresh, lenient decoder, so strictness stops at that boundary and everything below it stays unchecked. A guard built on strict decoding alone would pass whether or not the defect were present.
- Add a checker that walks the parsed document against the destination type directly rather than driving the strict decoder, so it keeps working across that boundary. It reproduces the decoder's own key derivation, including merge keys, anchors and aliases, untagged fields, and free-form map keys, and reports every unmatched key at once as a dotted path.
- Apply it to every shipped default config. The operator config types are package-private, so each check lives beside the type it guards rather than in one central place.
- Assert separately that every installed path a shipped config points at is one the packaging actually installs, so a config naming a file that was never shipped fails mechanically instead of at deploy time. Commented-out examples are excluded deliberately, and a test pins that distinction.
- Every guard was verified able to fail: a stray key injected at each mapping level of each shipped file is caught in all cases, and a quarter of those are invisible to strict decoding.
