### PR TITLE
refactor(metrics): give the counter query an options API

### DIFF
--- a/common/go/metrics/filter.go
+++ b/common/go/metrics/filter.go
@@ -1,5 +1,7 @@
 package metrics
 
+import "slices"
+
 // NameValue is satisfied by any tag or label that reports a name and a
 // value.
 type NameValue interface {
@@ -70,25 +72,71 @@ func Filter[M Labeled[L], L NameValue, T NameValue](metrics []M, tags []T) []M {
 	return selected
 }
 
-// Query derives the counter-name include-list a collector should pass to
-// the dataplane counter read, from the tags attached to a metrics request.
+// QueryOption declares one part of a collector's counter shape to Query.
+type QueryOption func(*queryOptions)
+
+// queryOptions is the collector's counter shape, assembled from the
+// options passed to Query.
+type queryOptions struct {
+	// Structural holds the fixed counters whose metrics carry no
+	// "counter" label.
+	Structural []string
+	// Entry holds the per-entry counters whose metrics carry a
+	// "counter" label, enumerated up front.
+	Entry []string
+	// UnknownEntry reports that per-entry counters exist but cannot be
+	// enumerated, so a read that includes them must stay unrestricted.
+	UnknownEntry bool
+}
+
+// WithStructuralCounters declares the collector's fixed counters, whose
+// metrics carry no "counter" label.
 //
-// It reduces every tag named counterLabel with logical AND into a
-// single effective predicate. An absent value ("") means only the
-// fixed, structural counters that carry no counter label. A
-// present-any value ("*") means every per-entry counter. Any other
-// value names an exact counter. No counter tag at all falls back to
-// defaultNames, read unconditionally.
-// An absent predicate resolves to fixedNames, with the second return
-// reporting whether there are any to read at all. A present-any
-// predicate resolves to defaultNames read in full, since Matches still
-// drops the structural metrics that lack the label at emission time.
-// Two counter tags that can never both hold (e.g. two different exact
-// values) make the request unsatisfiable: the second return is false
-// and the caller must skip the counter read and emit no per-entry
-// metrics. Query only decides what to read, while Matches remains the
-// correctness gate applied to each emitted metric.
-func Query[T NameValue](tags []T, defaultNames, fixedNames []string) ([]string, bool) {
+// Omitted, the collector has no structural counter family.
+func WithStructuralCounters(names []string) QueryOption {
+	return func(o *queryOptions) {
+		o.Structural = names
+	}
+}
+
+// WithEntryCounters declares the collector's per-entry counters — those
+// whose metrics carry a "counter" label — enumerable up front.
+//
+// Omitted, the collector has no per-entry counters. Its names must be
+// disjoint from WithStructuralCounters', since Query unions the two sets
+// without deduping.
+func WithEntryCounters(names []string) QueryOption {
+	return func(o *queryOptions) {
+		o.Entry = names
+	}
+}
+
+// WithUnknownEntryCounters declares that the collector has per-entry
+// counters whose names it cannot enumerate, because the dataplane creates
+// them.
+//
+// It wins over WithEntryCounters when both are set.
+func WithUnknownEntryCounters() QueryOption {
+	return func(o *queryOptions) {
+		o.UnknownEntry = true
+	}
+}
+
+// Query derives the counter-name include-list for the dataplane counter
+// read from a metrics request's tags and the collector's counter shape.
+//
+// The second return says whether there is anything to read — false means
+// skip the read entirely. A nil or empty first return paired with true
+// happens only under WithUnknownEntryCounters, meaning leave the read
+// unrestricted. Otherwise a readable result is always non-empty, safe to
+// hand straight to ModuleCounters. Query only decides what to read —
+// Matches stays the correctness gate applied to each emitted metric.
+func Query[T NameValue](tags []T, opts ...QueryOption) ([]string, bool) {
+	var o queryOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+
 	var values []string
 	for _, tag := range tags {
 		if tag.GetName() == counterLabel {
@@ -97,7 +145,11 @@ func Query[T NameValue](tags []T, defaultNames, fixedNames []string) ([]string, 
 	}
 
 	if len(values) == 0 {
-		return defaultNames, true
+		if o.UnknownEntry {
+			return nil, true
+		}
+		names := union(o.Structural, o.Entry)
+		return names, len(names) > 0
 	}
 
 	value, ok := reduceValues(values)
@@ -107,11 +159,32 @@ func Query[T NameValue](tags []T, defaultNames, fixedNames []string) ([]string, 
 
 	switch value {
 	case "":
-		return fixedNames, len(fixedNames) > 0
+		return o.Structural, len(o.Structural) > 0
 	case "*":
-		return defaultNames, true
+		if o.UnknownEntry {
+			return nil, true
+		}
+		return o.Entry, len(o.Entry) > 0
 	default:
-		return []string{value}, true
+		if o.UnknownEntry || slices.Contains(o.Entry, value) {
+			return []string{value}, true
+		}
+		return nil, false
+	}
+}
+
+// union returns the combined structural and entry counter names.
+//
+// It returns the non-empty side unchanged rather than allocating, and
+// only concatenates when both sides hold names.
+func union(structural, entry []string) []string {
+	switch {
+	case len(entry) == 0:
+		return structural
+	case len(structural) == 0:
+		return entry
+	default:
+		return slices.Concat(structural, entry)
 	}
 }
 

--- a/common/go/metrics/filter_test.go
+++ b/common/go/metrics/filter_test.go
@@ -166,52 +166,96 @@ func TestFilter(t *testing.T) {
 }
 
 // TestQuery verifies the counter-name include-list derivation from the
-// counter tags attached to a metrics request.
+// counter tags attached to a metrics request, across every combination of
+// structural counters, enumerable entry counters, and an unknown entry
+// family.
 func TestQuery(t *testing.T) {
-	defaultNames := []string{"rx", "tx", "acl_rule"}
-	fixedNames := []string{"rx", "tx"}
+	structural := []string{"rx", "tx"}
+	entry := []string{"acl_rule", "acl_rule2"}
 
 	tests := []struct {
 		name          string
 		tags          []nameValue
-		fixedNames    []string
+		opts          []metrics.QueryOption
 		expectedNames []string
 		expectedRead  bool
 	}{
 		{
-			name:          "no counter tag reads the default set",
+			name:          "no options and no tag is not readable",
 			tags:          nil,
-			fixedNames:    fixedNames,
-			expectedNames: defaultNames,
-			expectedRead:  true,
-		},
-		{
-			name:          "absent counter reads the fixed set",
-			tags:          []nameValue{{name: "counter", value: ""}},
-			fixedNames:    fixedNames,
-			expectedNames: fixedNames,
-			expectedRead:  true,
-		},
-		{
-			name:          "absent counter with no fixed names skips the read",
-			tags:          []nameValue{{name: "counter", value: ""}},
-			fixedNames:    nil,
+			opts:          nil,
 			expectedNames: nil,
 			expectedRead:  false,
 		},
 		{
-			name:          "wildcard counter reads the default set in full",
-			tags:          []nameValue{{name: "counter", value: "*"}},
-			fixedNames:    fixedNames,
-			expectedNames: defaultNames,
+			name:          "no counter tag unions structural and entry names",
+			tags:          nil,
+			opts:          []metrics.QueryOption{metrics.WithStructuralCounters(structural), metrics.WithEntryCounters(entry)},
+			expectedNames: []string{"rx", "tx", "acl_rule", "acl_rule2"},
 			expectedRead:  true,
 		},
 		{
-			name:          "exact counter reads only that name",
+			name:          "no counter tag with only entry counters reads the entry set",
+			tags:          nil,
+			opts:          []metrics.QueryOption{metrics.WithEntryCounters(entry)},
+			expectedNames: entry,
+			expectedRead:  true,
+		},
+		{
+			name:          "no counter tag with only structural counters reads the structural set",
+			tags:          nil,
+			opts:          []metrics.QueryOption{metrics.WithStructuralCounters(structural)},
+			expectedNames: structural,
+			expectedRead:  true,
+		},
+		{
+			name:          "no counter tag with an unknown entry family among enumerable counters is unrestricted",
+			tags:          nil,
+			opts:          []metrics.QueryOption{metrics.WithStructuralCounters(structural), metrics.WithEntryCounters(entry), metrics.WithUnknownEntryCounters()},
+			expectedNames: nil,
+			expectedRead:  true,
+		},
+		{
+			name:          "absent counter reads the structural set",
+			tags:          []nameValue{{name: "counter", value: ""}},
+			opts:          []metrics.QueryOption{metrics.WithStructuralCounters(structural), metrics.WithEntryCounters(entry)},
+			expectedNames: structural,
+			expectedRead:  true,
+		},
+		{
+			name:          "absent counter with no structural names skips the read",
+			tags:          []nameValue{{name: "counter", value: ""}},
+			opts:          []metrics.QueryOption{metrics.WithEntryCounters(entry)},
+			expectedNames: nil,
+			expectedRead:  false,
+		},
+		{
+			name:          "wildcard counter reads the entry set in full",
+			tags:          []nameValue{{name: "counter", value: "*"}},
+			opts:          []metrics.QueryOption{metrics.WithStructuralCounters(structural), metrics.WithEntryCounters(entry)},
+			expectedNames: entry,
+			expectedRead:  true,
+		},
+		{
+			name:          "wildcard counter with an empty entry set is not readable",
+			tags:          []nameValue{{name: "counter", value: "*"}},
+			opts:          []metrics.QueryOption{metrics.WithStructuralCounters(structural)},
+			expectedNames: nil,
+			expectedRead:  false,
+		},
+		{
+			name:          "exact counter naming an entry member reads only that name",
 			tags:          []nameValue{{name: "counter", value: "acl_rule"}},
-			fixedNames:    fixedNames,
+			opts:          []metrics.QueryOption{metrics.WithStructuralCounters(structural), metrics.WithEntryCounters(entry)},
 			expectedNames: []string{"acl_rule"},
 			expectedRead:  true,
+		},
+		{
+			name:          "exact counter naming a non-member is not readable",
+			tags:          []nameValue{{name: "counter", value: "rx"}},
+			opts:          []metrics.QueryOption{metrics.WithStructuralCounters(structural), metrics.WithEntryCounters(entry)},
+			expectedNames: nil,
+			expectedRead:  false,
 		},
 		{
 			name: "conflicting exact counters are unsatisfiable",
@@ -219,7 +263,7 @@ func TestQuery(t *testing.T) {
 				{name: "counter", value: "acl_rule"},
 				{name: "counter", value: "acl_rule2"},
 			},
-			fixedNames:    fixedNames,
+			opts:          []metrics.QueryOption{metrics.WithEntryCounters(entry)},
 			expectedNames: nil,
 			expectedRead:  false,
 		},
@@ -229,7 +273,7 @@ func TestQuery(t *testing.T) {
 				{name: "counter", value: "acl_rule"},
 				{name: "counter", value: "acl_rule"},
 			},
-			fixedNames:    fixedNames,
+			opts:          []metrics.QueryOption{metrics.WithEntryCounters(entry)},
 			expectedNames: []string{"acl_rule"},
 			expectedRead:  true,
 		},
@@ -239,7 +283,7 @@ func TestQuery(t *testing.T) {
 				{name: "counter", value: "*"},
 				{name: "counter", value: "acl_rule"},
 			},
-			fixedNames:    fixedNames,
+			opts:          []metrics.QueryOption{metrics.WithEntryCounters(entry)},
 			expectedNames: []string{"acl_rule"},
 			expectedRead:  true,
 		},
@@ -249,15 +293,50 @@ func TestQuery(t *testing.T) {
 				{name: "counter", value: ""},
 				{name: "counter", value: "acl_rule"},
 			},
-			fixedNames:    fixedNames,
+			opts:          []metrics.QueryOption{metrics.WithEntryCounters(entry)},
 			expectedNames: nil,
 			expectedRead:  false,
+		},
+		{
+			name:          "unknown entry collector with no tag is unrestricted",
+			tags:          nil,
+			opts:          []metrics.QueryOption{metrics.WithStructuralCounters(structural), metrics.WithUnknownEntryCounters()},
+			expectedNames: nil,
+			expectedRead:  true,
+		},
+		{
+			name:          "unknown entry collector with a wildcard is unrestricted",
+			tags:          []nameValue{{name: "counter", value: "*"}},
+			opts:          []metrics.QueryOption{metrics.WithUnknownEntryCounters()},
+			expectedNames: nil,
+			expectedRead:  true,
+		},
+		{
+			name:          "unknown entry collector with an exact tag reads only that name",
+			tags:          []nameValue{{name: "counter", value: "unregistered_rule"}},
+			opts:          []metrics.QueryOption{metrics.WithUnknownEntryCounters()},
+			expectedNames: []string{"unregistered_rule"},
+			expectedRead:  true,
+		},
+		{
+			name:          "wildcard counter with unknown entry set wins over the entry set",
+			tags:          []nameValue{{name: "counter", value: "*"}},
+			opts:          []metrics.QueryOption{metrics.WithEntryCounters(entry), metrics.WithUnknownEntryCounters()},
+			expectedNames: nil,
+			expectedRead:  true,
+		},
+		{
+			name:          "exact counter naming a non-member with unknown entry set wins over the entry set",
+			tags:          []nameValue{{name: "counter", value: "unregistered_rule"}},
+			opts:          []metrics.QueryOption{metrics.WithEntryCounters(entry), metrics.WithUnknownEntryCounters()},
+			expectedNames: []string{"unregistered_rule"},
+			expectedRead:  true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			names, read := metrics.Query(test.tags, defaultNames, test.fixedNames)
+			names, read := metrics.Query(test.tags, test.opts...)
 
 			require.Equal(t, test.expectedRead, read)
 			require.Equal(t, test.expectedNames, names)

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -89,7 +89,10 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 
 	positions := dpConfig.AllModulePositions("acl")
 
-	names, read := metrics.Query(tags, nil, aclStructuralCounters)
+	names, read := metrics.Query(tags,
+		metrics.WithStructuralCounters(aclStructuralCounters),
+		metrics.WithUnknownEntryCounters(),
+	)
 
 	result := make([]*commonpb.Metric, 0)
 	gaugesEmitted := make(map[string]struct{})

--- a/modules/forward/controlplane/metrics.go
+++ b/modules/forward/controlplane/metrics.go
@@ -51,19 +51,18 @@ func (m *ForwardService) Metrics(tags ...*commonpb.MetricTag) ([]*commonpb.Metri
 //
 // A "counter" tag is pushed down into the dataplane counter read, so
 // per-rule counters excluded by tags are never read from shared memory.
-// Forward has no structural (non-per-rule) counters, so its full name list
-// is exactly the rule set. An empty derived name list therefore means there
-// is nothing to read, never "read everything", so the read is skipped
-// rather than passed on to ModuleCounters, which treats an empty list as
-// "all counters".
+// Forward has no structural (non-per-rule) counters, so an exact tag
+// naming anything outside a config's own rule set — including a generic
+// per-module counter such as "rx" — leaves that config with nothing to
+// read.
 func (m *ForwardService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*commonpb.Metric, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	result := make([]*commonpb.Metric, 0)
 	for configName, config := range m.configs {
-		names, read := metrics.Query(tags, ruleCounterNames(config.Rules), nil)
-		if !read || len(names) == 0 {
+		names, read := metrics.Query(tags, metrics.WithEntryCounters(ruleCounterNames(config.Rules)))
+		if !read {
 			continue
 		}
 

--- a/modules/forward/controlplane/service_test.go
+++ b/modules/forward/controlplane/service_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
 	"github.com/yanet-platform/yanet2/modules/forward/bindings/go/cforward"
 	forward "github.com/yanet-platform/yanet2/modules/forward/controlplane"
 	forwardpb "github.com/yanet-platform/yanet2/modules/forward/controlplane/forwardpb/v1"
@@ -63,6 +64,22 @@ type recordingBackend struct {
 func (m *recordingBackend) UpdateModule(name string, rules []cforward.ForwardRule) (forward.ModuleHandle, error) {
 	m.rules = rules
 	return &mockModuleHandle{}, nil
+}
+
+// counterQueryBackend records every counterNames slice handed to
+// ModuleCounters and always answers with a single view named "rx", the
+// generic per-module counter every module registers alongside its own.
+type counterQueryBackend struct {
+	mockBackend
+
+	queries [][]string
+}
+
+func (m *counterQueryBackend) ModuleCounters(name string, counterNames []string) []forward.CounterView {
+	m.queries = append(m.queries, counterNames)
+	return []forward.CounterView{
+		{Device: "dev0", Pipeline: "pipe0", Function: "func0", Chain: "chain0", Name: "rx", Values: [][]uint64{{1, 100}}},
+	}
 }
 
 // TestShowConfigUnknownConfig verifies that ShowConfig reports NotFound for
@@ -261,6 +278,31 @@ func TestUpdateConfigMaterializesEmptyCounterUTF8Boundary(t *testing.T) {
 
 	_, err = proto.Marshal(response)
 	require.NoError(t, err, "ShowConfigResponse carrying the materialised counter must marshal")
+}
+
+// TestMetricsExactTagNeverReadsForeignCounter verifies that an exact
+// "counter" tag naming a counter outside a config's own rule set never
+// reaches the dataplane read, so a generic per-module counter such as "rx"
+// can never surface mislabeled under the forward_rule_* family.
+func TestMetricsExactTagNeverReadsForeignCounter(t *testing.T) {
+	backend := &counterQueryBackend{}
+	svc := forward.NewForwardService(backend)
+
+	_, err := svc.UpdateConfig(t.Context(), &forwardpb.UpdateConfigRequest{
+		Name: "config",
+		Rules: []*forwardpb.Rule{
+			{Action: &forwardpb.Action{Target: "device0", Counter: "to_device0"}},
+		},
+	})
+	require.NoError(t, err)
+
+	all, err := svc.Metrics(&commonpb.MetricTag{Name: "counter", Value: "rx"})
+	require.NoError(t, err)
+
+	for _, metric := range all {
+		require.NotContains(t, metric.GetName(), "forward_rule")
+	}
+	require.Empty(t, backend.queries, "rx is not one of the config's own rule counters, so ModuleCounters must never be called")
 }
 
 // Run with: go test -race

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -126,7 +126,10 @@ func (m *FWStateService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]
 
 	positions := dpConfig.AllModulePositions("fwstate")
 
-	names, read := metrics.Query(tags, nil, fwstateStructuralCounters)
+	names, read := metrics.Query(tags,
+		metrics.WithStructuralCounters(fwstateStructuralCounters),
+		metrics.WithUnknownEntryCounters(),
+	)
 
 	result := make([]*commonpb.Metric, 0)
 	for pos := range positions {

--- a/modules/route/controlplane/metrics.go
+++ b/modules/route/controlplane/metrics.go
@@ -83,50 +83,22 @@ var counterMappings = map[string]counterMapping{
 // request is stable across scrapes.
 var counterNames = slices.Sorted(maps.Keys(counterMappings))
 
-// intersectSorted returns the elements common to two ascending,
-// deduplicated slices.
-func intersectSorted(a, b []string) []string {
-	result := make([]string, 0, min(len(a), len(b)))
-	for idxA, idxB := 0, 0; idxA < len(a) && idxB < len(b); {
-		switch {
-		case a[idxA] < b[idxB]:
-			idxA++
-		case a[idxA] > b[idxB]:
-			idxB++
-		default:
-			result = append(result, a[idxA])
-			idxA++
-			idxB++
-		}
-	}
-
-	return result
-}
-
-var noNexthopStructuralCounters = []string{}
-
 // collectNexthopMetrics gathers packet and byte counters for every
 // per-nexthop counter reachable through any applied config.
 //
 // A "counter" tag is pushed down into the dataplane counter read, so
-// counters excluded by tags are never read from shared memory. An empty
-// name list is never passed to ModuleCounters, which treats it as "all
-// counters", and an exact tag is intersected against the config's own
-// reachable names so a module-level or foreign-config counter can never
-// surface under this family.
+// counters excluded by tags are never read from shared memory, and an
+// exact tag naming anything outside a config's own reachable names leaves
+// that config with nothing to read — a module-level or foreign-config
+// counter can never surface under this family.
 func (m *RouteService) collectNexthopMetrics(tags []*commonpb.MetricTag) []*commonpb.Metric {
 	m.shmLock.RLock()
 	defer m.shmLock.RUnlock()
 
 	result := make([]*commonpb.Metric, 0)
 	for configName, entry := range m.configs {
-		names, ok := metrics.Query(tags, entry.NexthopCounterNames, noNexthopStructuralCounters)
+		names, ok := metrics.Query(tags, metrics.WithEntryCounters(entry.NexthopCounterNames))
 		if !ok {
-			continue
-		}
-
-		names = intersectSorted(names, entry.NexthopCounterNames)
-		if len(names) == 0 {
 			continue
 		}
 
@@ -164,16 +136,16 @@ func (m *RouteService) collectNexthopMetrics(tags []*commonpb.MetricTag) []*comm
 // of every config, summed across worker instances.
 //
 // A "counter" tag is pushed down into the dataplane counter read, so
-// counters excluded by tags are never read from shared memory. Every known
-// counter is emitted even when it reads zero. A series that disappears and
-// reappears breaks rate() in Prometheus, and the empty route list counters
-// are invariant canaries expected to read zero forever, which only works if
-// they are visible.
+// counters excluded by tags are never read from shared memory. Untagged,
+// every known counter is emitted even when it reads zero. A series that
+// disappears and reappears breaks rate() in Prometheus, and the empty
+// route list counters are invariant canaries expected to read zero
+// forever, which only works if they are visible.
 func (m *RouteService) collectDataplaneMetrics(tags []*commonpb.MetricTag) []*commonpb.Metric {
 	m.shmLock.RLock()
 	defer m.shmLock.RUnlock()
 
-	names, read := metrics.Query(tags, counterNames, counterNames)
+	names, read := metrics.Query(tags, metrics.WithStructuralCounters(counterNames))
 	if !read {
 		return []*commonpb.Metric{}
 	}

--- a/modules/route/controlplane/service_test.go
+++ b/modules/route/controlplane/service_test.go
@@ -754,8 +754,10 @@ func TestNexthopMetricsExactTagNeverReadsForeignCounter(t *testing.T) {
 	require.Empty(t, findMetrics(all, "route_nexthop_packets"))
 	require.Empty(t, findMetrics(all, "route_nexthop_bytes"))
 
-	// Only "nexthop_my_counter" is registered, so the foreign tag leaves
-	// collectNexthopMetrics nothing to query.
-	require.Len(t, backend.queries, 1)
-	require.Equal(t, []string{"route_forwarded_v4"}, backend.queries[0])
+	// "route_forwarded_v4" names a module-level counter, which carries no
+	// "counter" label, so neither collectNexthopMetrics (whose only
+	// reachable name is "nexthop_my_counter") nor collectDataplaneMetrics
+	// (whose exact-tag branch never matches a per-entry read) has anything
+	// left to query.
+	require.Empty(t, backend.queries)
 }


### PR DESCRIPTION
The shared helper that derives a module's dataplane counter include-list took two positional name lists whose meaning could not be recovered from a call site, and no two of its five callers passed the same combination. Each argument now names itself.

- Replace the two positional lists with options that separately declare a collector's structural counters (those whose metrics carry no counter label) and its per-entry ones. A collector with no structural family now says so by omission instead of by a bare nil, which previously had to mean two different things depending on which position it sat in: an empty set in one, an unrestricted read in the other.
- Give the collectors that cannot enumerate their per-entry counter names an option that says exactly that, so the unrestricted read is a stated intent rather than an inferred one.
- Move the intersection against the caller's own counter set into the helper. It previously returned an exactly-named counter unchecked, so a collector could read and export a counter that does not belong to it. That shipped once and was caught in review, and the fix at the time was for the caller to intersect the result itself, which every other caller would have had to remember to do too.
- Remove the hand-rolled intersection this leaves stranded in the route module, and close the same hole in the forward module, where an exact counter tag naming one of the generic per-module counters surfaced under the per-rule metric family.

Exported metrics are unchanged. Two request shapes that previously read counters only to have them filtered out of the response before it was sent now skip the read entirely.

Closes #1699.