### PR TITLE
feat(filter,inspect): attribute filter memory per table and registry

### DIFF
--- a/cli/modules/inspect/src/main.rs
+++ b/cli/modules/inspect/src/main.rs
@@ -1,6 +1,7 @@
 //! CLI for YANET "inspect" module.
 
 use core::cmp::Reverse;
+use std::collections::BTreeMap;
 
 use bytesize::ByteSize;
 use clap::{ArgAction, CommandFactory, Parser};
@@ -228,35 +229,104 @@ fn node_live(node: &MemoryNode) -> u64 {
     node.balloc_size.saturating_sub(node.bfree_size)
 }
 
-/// Subtree total: a node's own live bytes plus the live bytes of all its
-/// descendants.
-fn subtree_live(nodes: &[MemoryNode], children_of: &[Vec<usize>], idx: usize) -> u64 {
-    let self_live = node_live(&nodes[idx]);
-    let children_total: u64 = children_of[idx]
-        .iter()
-        .map(|&child| subtree_live(nodes, children_of, child))
-        .sum();
+/// Fills `totals[idx]` and every descendant's slot with its subtree total:
+/// a node's own live bytes plus the live bytes of all its descendants.
+///
+/// Post-order, so each slot is computed exactly once regardless of how many
+/// times the tree is walked afterwards.
+fn compute_subtree_totals(nodes: &[MemoryNode], children_of: &[Vec<usize>], idx: usize, totals: &mut [u64]) {
+    let mut total = node_live(&nodes[idx]);
+    for &child in &children_of[idx] {
+        compute_subtree_totals(nodes, children_of, child, totals);
+        total = total.saturating_add(totals[child]);
+    }
 
-    self_live.saturating_add(children_total)
+    totals[idx] = total;
 }
 
 /// Render one node and its children into the tree builder.
 ///
 /// Children are ordered by subtree total descending so the heaviest
-/// subtrees come first; zero-total subtrees are skipped.
-fn render_memory_node(tree: &mut TreeBuilder, nodes: &[MemoryNode], idx: usize, children_of: &[Vec<usize>]) {
+/// subtrees come first; zero-total subtrees are skipped. The node's own
+/// live bytes are shown alongside the subtree total only when they differ
+/// — a leaf, or a node whose children are all zero, gets one number.
+fn render_memory_node(
+    tree: &mut TreeBuilder,
+    nodes: &[MemoryNode],
+    idx: usize,
+    children_of: &[Vec<usize>],
+    totals: &[u64],
+) {
     let node = &nodes[idx];
-    let total = subtree_live(nodes, children_of, idx);
-    tree.begin_child(format!("{} (Used: {})", node.name, ByteSize::b(total)));
+    let total = totals[idx];
+    let own = node_live(node);
+
+    let label = if own == total {
+        format!("{} (Used: {})", node.name, ByteSize::b(total))
+    } else {
+        format!(
+            "{} (Used: {}, own: {})",
+            node.name,
+            ByteSize::b(total),
+            ByteSize::b(own)
+        )
+    };
+    tree.begin_child(label);
 
     let mut children = children_of[idx].clone();
-    children.sort_by_key(|&child| Reverse(subtree_live(nodes, children_of, child)));
+    children.sort_by_key(|&child| Reverse(totals[child]));
     for child in children {
-        if subtree_live(nodes, children_of, child) > 0 {
-            render_memory_node(tree, nodes, child, children_of);
+        if totals[child] > 0 {
+            render_memory_node(tree, nodes, child, children_of, totals);
         }
     }
 
+    tree.end_child();
+}
+
+/// Cap on the number of context names shown in the "own bytes" rollup.
+const MEMORY_ROLLUP_LIMIT: usize = 10;
+
+/// Aggregates own live bytes and node count by context `name`, across the
+/// whole flat `nodes` slice regardless of depth or parent.
+///
+/// Own bytes (not subtree totals) avoid double-counting a parent and its
+/// children under the same name. Returns entries sorted by summed bytes
+/// descending, name ascending on ties, capped at [`MEMORY_ROLLUP_LIMIT`].
+fn rollup_by_name(nodes: &[MemoryNode]) -> Vec<(String, u64, usize)> {
+    let mut totals: BTreeMap<&str, (u64, usize)> = BTreeMap::new();
+    for node in nodes {
+        let entry = totals.entry(node.name.as_str()).or_insert((0, 0));
+        entry.0 = entry.0.saturating_add(node_live(node));
+        entry.1 += 1;
+    }
+
+    let mut rows: Vec<(String, u64, usize)> = totals
+        .into_iter()
+        .map(|(name, (bytes, count))| (name.to_string(), bytes, count))
+        .collect();
+    rows.sort_by_key(|&(_, bytes, _)| Reverse(bytes));
+    rows.truncate(MEMORY_ROLLUP_LIMIT);
+    rows
+}
+
+/// Render the "own bytes" rollup as plain aligned child lines.
+///
+/// Nested under the memory tree rather than a `tabled` table: it is a
+/// two-column list capped at [`MEMORY_ROLLUP_LIMIT`] rows inside a `ptree`
+/// branch, and `tabled`'s box-drawing output has no ptree-prefix awareness
+/// for a table embedded as a single multi-line child label.
+fn add_memory_rollup(tree: &mut TreeBuilder, nodes: &[MemoryNode]) {
+    let rows = rollup_by_name(nodes);
+    let Some(name_width) = rows.iter().map(|(name, _, _)| name.chars().count()).max() else {
+        return;
+    };
+
+    tree.begin_child("Top contexts by own bytes:".to_string());
+    for (name, bytes, count) in &rows {
+        let size = ByteSize::b(*bytes);
+        tree.add_empty_child(format!("{name:<name_width$}  {size:>10}  (×{count})"));
+    }
     tree.end_child();
 }
 
@@ -279,7 +349,85 @@ fn add_memory_tree(tree: &mut TreeBuilder, nodes: &[MemoryNode]) {
         return;
     };
 
+    let mut totals = vec![0u64; nodes.len()];
+    compute_subtree_totals(nodes, &children_of, root, &mut totals);
+
     tree.begin_child("Memory tree:".to_string());
-    render_memory_node(tree, nodes, root, &children_of);
+    render_memory_node(tree, nodes, root, &children_of, &totals);
+    add_memory_rollup(tree, nodes);
     tree.end_child();
+}
+
+#[cfg(test)]
+mod test {
+    use ynpb::pb::MemoryNode;
+
+    use super::{compute_subtree_totals, node_live, rollup_by_name};
+
+    fn node(name: &str, parent_idx: u32, balloc_size: u64, bfree_size: u64) -> MemoryNode {
+        MemoryNode {
+            name: name.to_string(),
+            parent_idx,
+            balloc_count: 0,
+            bfree_count: 0,
+            balloc_size,
+            bfree_size,
+        }
+    }
+
+    /// Builds the same parent -> children index map `add_memory_tree` does,
+    /// for tests exercising `compute_subtree_totals`/`rollup_by_name` directly.
+    fn children_of(nodes: &[MemoryNode]) -> Vec<Vec<usize>> {
+        let mut children_of: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
+        for (idx, node) in nodes.iter().enumerate() {
+            if node.parent_idx != u32::MAX {
+                children_of[node.parent_idx as usize].push(idx);
+            }
+        }
+        children_of
+    }
+
+    #[test]
+    fn subtree_total_equals_sum_of_own_bytes() {
+        let nodes = vec![
+            node("root", u32::MAX, 100, 0),
+            node("filter", 0, 50, 0),
+            node("lpm", 0, 30, 10),
+            node("value_table", 2, 15, 5),
+        ];
+        let children_of = children_of(&nodes);
+        let mut totals = vec![0u64; nodes.len()];
+        compute_subtree_totals(&nodes, &children_of, 0, &mut totals);
+
+        let sum_of_own: u64 = nodes.iter().map(node_live).sum();
+        assert_eq!(sum_of_own, totals[0]);
+        assert_eq!(180, totals[0]);
+    }
+
+    #[test]
+    fn rollup_groups_by_name_across_depths() {
+        let nodes = vec![
+            node("root", u32::MAX, 100, 0),
+            node("filter", 0, 500, 10), // own 490, first filter
+            node("lpm", 1, 20, 0),      // own 20, under the first filter
+            node("filter", 0, 20, 10),  // own 10, second filter at the same depth
+            node("lpm", 3, 30, 0),      // own 30, under the second filter
+        ];
+
+        let rows = rollup_by_name(&nodes);
+
+        let filter = rows
+            .iter()
+            .find(|(name, ..)| name == "filter")
+            .expect("filter row present");
+        assert_eq!(500, filter.1);
+        assert_eq!(2, filter.2);
+
+        let lpm = rows.iter().find(|(name, ..)| name == "lpm").expect("lpm row present");
+        assert_eq!(50, lpm.1);
+        assert_eq!(2, lpm.2);
+
+        // filter (500) outranks root (100) outranks lpm (50).
+        assert_eq!("filter", rows[0].0);
+    }
 }

--- a/common/registry.h
+++ b/common/registry.h
@@ -181,9 +181,32 @@ struct value_registry {
 
 static inline int
 value_registry_init(
-	struct value_registry *registry, struct memory_context *memory_context
+	struct value_registry *registry,
+	struct memory_context *parent_context,
+	const char *name
 ) {
+	// Balloc'd rather than embedded: a registry lives inside a tree
+	// vertex, and that tree is itself embedded by value inside
+	// shared-memory configs the dataplane reads, so an inline context
+	// here would multiply across every vertex of every tree — an ABI
+	// change, not an inspect-tree nicety.
+	struct memory_context *memory_context = (struct memory_context *)
+		memory_balloc(parent_context, sizeof(*memory_context));
+	if (memory_context == NULL) {
+		registry->memory_context = NULL;
+		return -1;
+	}
+	memory_context_init_from(memory_context, parent_context, name);
+
+	// The registry is the meaningful inspect-tree unit, so the collector's
+	// use-map allocations are attributed to the same child context rather
+	// than getting a node of their own.
 	if (value_collector_init(&registry->collector, memory_context)) {
+		struct memory_context *parent =
+			ADDR_OF(&memory_context->parent);
+		memory_context_fini(memory_context);
+		memory_bfree(parent, memory_context, sizeof(*memory_context));
+		registry->memory_context = NULL;
 		return -1;
 	}
 
@@ -293,15 +316,24 @@ value_registry_collect(struct value_registry *registry, uint32_t value) {
 	return 0;
 }
 
+// Releases a value registry, including its own memory-tree node.
+//
+// Safe on a zero-initialised registry (never inited): memory_context reads
+// back NULL and every other field is untouched.
 static inline void
 value_registry_fini(struct value_registry *registry) {
+	struct memory_context *memory_context = registry->memory_context;
+	if (memory_context == NULL) {
+		return;
+	}
+
 	value_collector_fini(&registry->collector);
 
 	for (uint64_t idx = 0; idx < registry->range_count; ++idx) {
 		struct value_range *range = ADDR_OF(&registry->ranges) + idx;
 
 		mem_array_free_exp(
-			registry->memory_context,
+			memory_context,
 			ADDR_OF(&range->values),
 			sizeof(uint32_t),
 			range->count
@@ -314,7 +346,7 @@ value_registry_fini(struct value_registry *registry) {
 		uint64_t capacity = 1 << uint64_log_up(registry->range_count);
 
 		memory_bfree(
-			registry->memory_context,
+			memory_context,
 			ADDR_OF(&registry->ranges),
 			capacity * sizeof(struct value_range)
 		);
@@ -322,6 +354,14 @@ value_registry_fini(struct value_registry *registry) {
 	SET_OFFSET_OF(&registry->ranges, NULL);
 	registry->range_count = 0;
 	registry->max_value = 0;
+
+	// The memory_context was balloc'd out of its parent in
+	// value_registry_init, so it is released the same way. Read the parent
+	// before fini, which memsets memory_context and destroys that link.
+	struct memory_context *parent = ADDR_OF(&memory_context->parent);
+	memory_context_fini(memory_context);
+	memory_bfree(parent, memory_context, sizeof(*memory_context));
+	registry->memory_context = NULL;
 }
 
 static inline uint32_t

--- a/common/value.h
+++ b/common/value.h
@@ -19,44 +19,76 @@ struct value_table {
 	uint32_t **values;
 };
 
+// Releases a value table, including its own memory-tree node.
+//
+// Safe on a zero-initialised table: value_table_init nulls memory_context
+// itself before returning on any failure, so an external caller sees the
+// same all-NULL state whether the table was never inited or failed to init.
 static inline void
 value_table_free(struct value_table *value_table) {
 	struct memory_context *memory_context =
 		ADDR_OF(&value_table->memory_context);
-
-	uint32_t **values = ADDR_OF(&value_table->values);
-	if (values == NULL) {
+	if (memory_context == NULL) {
 		return;
 	}
 
-	uint64_t value_count = value_table->v_dim;
-	value_count *= value_table->h_dim;
-	uint32_t chunk_count = (value_count + VALUE_TABLE_CHUNK_SIZE - 1) /
-			       VALUE_TABLE_CHUNK_SIZE;
+	uint32_t **values = ADDR_OF(&value_table->values);
+	if (values != NULL) {
+		uint64_t value_count = value_table->v_dim;
+		value_count *= value_table->h_dim;
+		uint32_t chunk_count =
+			(value_count + VALUE_TABLE_CHUNK_SIZE - 1) /
+			VALUE_TABLE_CHUNK_SIZE;
 
-	for (uint32_t chunk_idx = 0; chunk_idx < chunk_count; ++chunk_idx) {
-		uint32_t *chunk = ADDR_OF(values + chunk_idx);
-		if (chunk == NULL) {
-			continue;
+		for (uint32_t chunk_idx = 0; chunk_idx < chunk_count;
+		     ++chunk_idx) {
+			uint32_t *chunk = ADDR_OF(values + chunk_idx);
+			if (chunk == NULL) {
+				continue;
+			}
+			memory_bfree(
+				memory_context,
+				chunk,
+				VALUE_TABLE_CHUNK_SIZE * sizeof(uint32_t)
+			);
+			SET_OFFSET_OF(values + chunk_idx, NULL);
 		}
 		memory_bfree(
-			memory_context,
-			chunk,
-			VALUE_TABLE_CHUNK_SIZE * sizeof(uint32_t)
+			memory_context, values, chunk_count * sizeof(uint32_t *)
 		);
-		SET_OFFSET_OF(values + chunk_idx, NULL);
+		SET_OFFSET_OF(&value_table->values, NULL);
 	}
-	memory_bfree(memory_context, values, chunk_count * sizeof(uint32_t *));
-	SET_OFFSET_OF(&value_table->values, NULL);
+
+	// The memory_context was balloc'd out of its parent in
+	// value_table_init, so it is released the same way. Read the parent
+	// before fini, which memsets memory_context and destroys that link.
+	struct memory_context *parent = ADDR_OF(&memory_context->parent);
+	memory_context_fini(memory_context);
+	memory_bfree(parent, memory_context, sizeof(*memory_context));
+	SET_OFFSET_OF(&value_table->memory_context, NULL);
 }
 
 static inline int
 value_table_init(
 	struct value_table *value_table,
-	struct memory_context *memory_context,
+	struct memory_context *parent_context,
+	const char *name,
 	uint32_t v_dim,
 	uint32_t h_dim
 ) {
+	// Balloc'd rather than embedded: a table lives inside a tree vertex,
+	// and that tree is itself embedded by value inside shared-memory
+	// configs the dataplane reads, so an inline context here would
+	// multiply across every vertex of every tree — an ABI change, not
+	// an inspect-tree nicety.
+	struct memory_context *memory_context = (struct memory_context *)
+		memory_balloc(parent_context, sizeof(*memory_context));
+	if (memory_context == NULL) {
+		SET_OFFSET_OF(&value_table->memory_context, NULL);
+		SET_OFFSET_OF(&value_table->values, NULL);
+		return -1;
+	}
+	memory_context_init_from(memory_context, parent_context, name);
 	SET_OFFSET_OF(&value_table->memory_context, memory_context);
 
 	value_table->v_dim = v_dim;
@@ -73,6 +105,7 @@ value_table_init(
 		memory_context, chunk_count * sizeof(uint32_t *)
 	);
 	if (values == NULL) {
+		value_table_free(value_table);
 		return -1;
 	}
 

--- a/lib/filter/compiler.h
+++ b/lib/filter/compiler.h
@@ -10,7 +10,7 @@
 #include "common/registry.h"
 #include "common/value.h"
 #include "lib/errors/errors.h"
-#include <assert.h>
+#include <stdio.h>
 
 // Build and teardown functions for filter classification trees.
 //
@@ -155,8 +155,15 @@ filter_init(
 	     ++lookup_idx) {
 		struct filter_vertex *v =
 			filter->v + filter_compiler->lookup_count + lookup_idx;
+		char name[64];
+		snprintf(
+			name,
+			sizeof(name),
+			"registry[%zu]",
+			(size_t)(filter_compiler->lookup_count + lookup_idx)
+		);
 		if (value_registry_init(
-			    &v->registry, &filter->memory_context
+			    &v->registry, &filter->memory_context, name
 		    )) {
 			yanet_error_add(
 				err,
@@ -216,12 +223,36 @@ filter_init(
 	}
 
 	for (size_t idx = filter_compiler->lookup_count - 1; idx >= 2; --idx) {
+		char name[64];
+		snprintf(name, sizeof(name), "registry[%zu]", idx);
+		// The function merge_and_collect_registry only populates an
+		// already-initialised registry. The loop above initialised one
+		// only for leaf attributes, so this inner-node registry needs
+		// an explicit init first.
+		if (value_registry_init(
+			    &filter->v[idx].registry,
+			    &filter->memory_context,
+			    name
+		    )) {
+			yanet_error_add(
+				err,
+				"out of memory: failed to init registry at "
+				"index %zu",
+				idx
+			);
+			goto init_failed;
+		}
+		char table_name[64];
+		snprintf(
+			table_name, sizeof(table_name), "merge-table[%zu]", idx
+		);
 		if (merge_and_collect_registry(
 			    &filter->memory_context,
 			    &filter->v[2 * idx].registry,
 			    &filter->v[2 * idx + 1].registry,
 			    &filter->v[idx].table,
-			    &filter->v[idx].registry
+			    &filter->v[idx].registry,
+			    table_name
 		    )) {
 			yanet_error_add(
 				err,
@@ -252,12 +283,4 @@ init_finish:
 init_failed:
 	filter_free(filter, filter_compiler);
 	return -1;
-}
-
-// TODO: docs
-static inline uint64_t
-filter_memory_usage(struct filter *filter) {
-	struct memory_context *mctx = &filter->memory_context;
-	assert(mctx->balloc_size >= mctx->bfree_size);
-	return mctx->balloc_size - mctx->bfree_size;
 }

--- a/lib/filter/compiler/device.c
+++ b/lib/filter/compiler/device.c
@@ -36,7 +36,9 @@ FILTER_ATTR_COMPILER_INIT_FUNC(device)(
 	if (t == NULL) {
 		return -1;
 	}
-	int res = value_table_init(t, memory_context, 1, max_device_id + 1);
+	int res = value_table_init(
+		t, memory_context, "device", 1, max_device_id + 1
+	);
 	if (res < 0) {
 		goto error_init;
 	}

--- a/lib/filter/compiler/helper.c
+++ b/lib/filter/compiler/helper.c
@@ -37,7 +37,7 @@ init_dummy_registry(
 	uint32_t actions,
 	struct value_registry *registry
 ) {
-	int res = value_registry_init(registry, memory_context);
+	int res = value_registry_init(registry, memory_context, "dummy");
 	if (res < 0) {
 		return res;
 	}
@@ -82,6 +82,7 @@ merge_and_set_registry_values(
 	if (value_table_init(
 		    table,
 		    memory_context,
+		    "action-table",
 		    value_registry_capacity(registry1),
 		    value_registry_capacity(registry2)
 	    )) {
@@ -144,11 +145,13 @@ merge_registry_values(
 	struct memory_context *memory_context,
 	struct value_registry *registry1,
 	struct value_registry *registry2,
-	struct value_table *table
+	struct value_table *table,
+	const char *table_name
 ) {
 	if (value_table_init(
 		    table,
 		    memory_context,
+		    table_name,
 		    value_registry_capacity(registry1),
 		    value_registry_capacity(registry2)
 	    )) {
@@ -213,18 +216,21 @@ value_table_collect_action(uint32_t v1, uint32_t v2, uint32_t idx, void *data) {
 	return 0;
 }
 
+// The registry is populated here but never initialised.
+//
+// Both callers already hold an initialised registry: the inner-merge
+// caller in filter_init initialises it right before this call, and the
+// leaf-attribute caller (net6_fast, via merge_and_collect_registry) reuses
+// the registry filter_init already initialised for that lookup.
+// Re-initialising it here would balloc and orphan a second memory-tree
+// node for the same registry.
 static int
 collect_registry_values(
-	struct memory_context *memory_context,
 	struct value_registry *registry1,
 	struct value_registry *registry2,
 	struct value_table *table,
 	struct value_registry *registry
 ) {
-	if (value_registry_init(registry, memory_context)) {
-		return -1;
-	}
-
 	struct value_collect_ctx collect_ctx;
 	collect_ctx.table = table;
 	collect_ctx.registry = registry;
@@ -259,17 +265,16 @@ merge_and_collect_registry(
 	struct value_registry *registry1,
 	struct value_registry *registry2,
 	struct value_table *table,
-	struct value_registry *registry
+	struct value_registry *registry,
+	const char *table_name
 ) {
 	if (merge_registry_values(
-		    memory_context, registry1, registry2, table
+		    memory_context, registry1, registry2, table, table_name
 	    )) {
 		return -1;
 	}
 
-	if (collect_registry_values(
-		    memory_context, registry1, registry2, table, registry
-	    )) {
+	if (collect_registry_values(registry1, registry2, table, registry)) {
 		value_table_free(table);
 		return -1;
 	}

--- a/lib/filter/compiler/helper.h
+++ b/lib/filter/compiler/helper.h
@@ -15,7 +15,8 @@ merge_and_collect_registry(
 	struct value_registry *registry1,
 	struct value_registry *registry2,
 	struct value_table *table,
-	struct value_registry *registry
+	struct value_registry *registry,
+	const char *table_name
 );
 
 int

--- a/lib/filter/compiler/ipfrag.c
+++ b/lib/filter/compiler/ipfrag.c
@@ -20,7 +20,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(ip_frag)(
 		return -1;
 	}
 
-	if (value_table_init(t, memory_context, 1, 2)) {
+	if (value_table_init(t, memory_context, "ipfrag", 1, 2)) {
 		goto error_init;
 	}
 	SET_OFFSET_OF(data, t);

--- a/lib/filter/compiler/net4.c
+++ b/lib/filter/compiler/net4.c
@@ -151,7 +151,9 @@ collect_net4_values(
 	}
 
 	struct value_table table;
-	if (value_table_init(&table, memory_context, 1, collector.count)) {
+	if (value_table_init(
+		    &table, memory_context, "net4", 1, collector.count
+	    )) {
 		goto error_table;
 	}
 

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -410,7 +410,9 @@ build_net6_info(
 	}
 
 	struct value_table net_table;
-	if (value_table_init(&net_table, memory_context, 1, *net_count)) {
+	if (value_table_init(
+		    &net_table, memory_context, "net6-nets", 1, *net_count
+	    )) {
 		goto error_nets;
 	}
 
@@ -556,6 +558,7 @@ merge_net6_range(
 	if (value_table_init(
 		    table,
 		    memory_context,
+		    "comb",
 		    ri_hi->max_value + 1,
 		    ri_lo->max_value + 1
 	    )) {
@@ -575,7 +578,9 @@ merge_net6_range(
 	}
 
 	struct value_registry net_registry;
-	if (value_registry_init(&net_registry, memory_context)) {
+	if (value_registry_init(
+		    &net_registry, memory_context, "net6-net-registry"
+	    )) {
 		goto error_table;
 	}
 
@@ -585,9 +590,9 @@ merge_net6_range(
 		goto error_net_registry;
 	}
 
-	if (value_registry_init(registry, memory_context)) {
-		goto error_net_registry;
-	}
+	// The registry is the lookup's own registry, already initialised by
+	// filter_init before this attribute's init function ran, so it is
+	// populated directly below rather than re-initialised here.
 
 	for (const struct filter_rule **action_ptr = actions;
 	     action_ptr < actions + count;

--- a/lib/filter/compiler/net6_fast.c
+++ b/lib/filter/compiler/net6_fast.c
@@ -131,7 +131,7 @@ init_classifier(
 	}
 
 	struct value_registry high_registry;
-	if (value_registry_init(&high_registry, mctx) != 0) {
+	if (value_registry_init(&high_registry, mctx, "net6-fast-high") != 0) {
 		return -1;
 	}
 
@@ -150,7 +150,7 @@ init_classifier(
 	}
 
 	struct value_registry low_registry;
-	if (value_registry_init(&low_registry, mctx) != 0) {
+	if (value_registry_init(&low_registry, mctx, "net6-fast-low") != 0) {
 		value_registry_fini(&high_registry);
 		free_classifier_part(&classifier->high, mctx);
 		return -1;
@@ -177,7 +177,8 @@ init_classifier(
 		    &high_registry,
 		    &low_registry,
 		    &classifier->comb,
-		    registry
+		    registry,
+		    "net6-fast-comb"
 	    ) != 0) {
 		value_registry_fini(&high_registry);
 		value_registry_fini(&low_registry);

--- a/lib/filter/compiler/port.c
+++ b/lib/filter/compiler/port.c
@@ -21,7 +21,7 @@ collect_port_values(
 	struct value_table *table,
 	struct value_registry *registry
 ) {
-	if (value_table_init(table, memory_context, 1, 65536)) {
+	if (value_table_init(table, memory_context, "port", 1, 65536)) {
 		return -1;
 	}
 

--- a/lib/filter/compiler/proto_range.c
+++ b/lib/filter/compiler/proto_range.c
@@ -18,7 +18,11 @@ collect_proto_values(
 	struct value_registry *registry
 ) {
 	if (value_table_init(
-		    table, memory_context, 1, PROTO_RANGE_CLASSIFIER_MAX_VALUE
+		    table,
+		    memory_context,
+		    "proto-range",
+		    1,
+		    PROTO_RANGE_CLASSIFIER_MAX_VALUE
 	    )) {
 		return -1;
 	}

--- a/lib/filter/compiler/vlan.c
+++ b/lib/filter/compiler/vlan.c
@@ -20,7 +20,7 @@ FILTER_ATTR_COMPILER_INIT_FUNC(vlan)(
 		return -1;
 	}
 
-	if (value_table_init(t, memory_context, 1, 4096)) {
+	if (value_table_init(t, memory_context, "vlan", 1, 4096)) {
 		goto error_init;
 	}
 	SET_OFFSET_OF(data, t);

--- a/tests/common/memory_context_tree_test.c
+++ b/tests/common/memory_context_tree_test.c
@@ -1,6 +1,8 @@
 #include "common/memory.h"
 #include "common/memory_block.h"
+#include "common/registry.h"
 #include "common/test_assert.h"
+#include "common/value.h"
 #include "lib/logging/log.h"
 
 #include <stddef.h>
@@ -421,6 +423,127 @@ test_stress_init_fini_cycle(void) {
 	return 0;
 }
 
+// Verifies that a value_table gets its own named child node under its parent
+// and that the node, and every byte it used, is gone once the table is
+// freed.
+static int
+test_value_table_child_context(void) {
+	uint8_t *arena = malloc(RAW_ALLOC_SZ);
+	TEST_ASSERT(arena != NULL, "failed to allocate arena");
+
+	struct block_allocator ba;
+	TEST_ASSERT(
+		block_allocator_init(&ba) == 0, "block_allocator_init failed"
+	);
+	block_allocator_put_arena(&ba, arena, RAW_ALLOC_SZ);
+
+	struct memory_context root;
+	TEST_ASSERT(
+		memory_context_init(&root, "root", &ba) == 0, "root init failed"
+	);
+
+	size_t balloc_before = root.balloc_size;
+	size_t bfree_before = root.bfree_size;
+
+	struct value_table table;
+	TEST_ASSERT(
+		value_table_init(&table, &root, "vt", 4, 4) == 0,
+		"value_table_init failed"
+	);
+
+	TEST_ASSERT(
+		helper_count_children(&root) == 1,
+		"root must have exactly 1 child after value_table_init"
+	);
+	struct memory_context *child = ADDR_OF(&root.first_child);
+	TEST_ASSERT(strcmp(child->name, "vt") == 0, "child must be named 'vt'");
+
+	value_table_free(&table);
+
+	TEST_ASSERT(
+		helper_count_children(&root) == 0,
+		"root must have 0 children after value_table_free"
+	);
+	TEST_ASSERT(
+		root.balloc_size - root.bfree_size ==
+			balloc_before - bfree_before,
+		"root's live byte count must return to its pre-init value"
+	);
+
+	memory_context_fini(&root);
+	free(arena);
+	return 0;
+}
+
+// Verifies that a value_registry gets its own named child node (shared with
+// its embedded collector, not a separate node) and that the node is fully
+// released by value_registry_fini.
+static int
+test_value_registry_child_context(void) {
+	uint8_t *arena = malloc(RAW_ALLOC_SZ);
+	TEST_ASSERT(arena != NULL, "failed to allocate arena");
+
+	struct block_allocator ba;
+	TEST_ASSERT(
+		block_allocator_init(&ba) == 0, "block_allocator_init failed"
+	);
+	block_allocator_put_arena(&ba, arena, RAW_ALLOC_SZ);
+
+	struct memory_context root;
+	TEST_ASSERT(
+		memory_context_init(&root, "root", &ba) == 0, "root init failed"
+	);
+
+	size_t balloc_before = root.balloc_size;
+	size_t bfree_before = root.bfree_size;
+
+	struct value_registry registry;
+	TEST_ASSERT(
+		value_registry_init(&registry, &root, "vr") == 0,
+		"value_registry_init failed"
+	);
+
+	TEST_ASSERT(
+		helper_count_children(&root) == 1,
+		"root must have exactly 1 child after value_registry_init"
+	);
+	struct memory_context *child = ADDR_OF(&root.first_child);
+	TEST_ASSERT(strcmp(child->name, "vr") == 0, "child must be named 'vr'");
+
+	// Populate the registry so the collector and the ranges array both
+	// allocate through the shared child context.
+	for (uint32_t range_idx = 0; range_idx < 4; ++range_idx) {
+		TEST_ASSERT(
+			value_registry_start(&registry) == 0,
+			"value_registry_start failed"
+		);
+		TEST_ASSERT(
+			value_registry_collect(&registry, range_idx) == 0,
+			"value_registry_collect failed"
+		);
+	}
+	TEST_ASSERT(
+		helper_count_children(&root) == 1,
+		"populating the registry must not add a second child"
+	);
+
+	value_registry_fini(&registry);
+
+	TEST_ASSERT(
+		helper_count_children(&root) == 0,
+		"root must have 0 children after value_registry_fini"
+	);
+	TEST_ASSERT(
+		root.balloc_size - root.bfree_size ==
+			balloc_before - bfree_before,
+		"root's live byte count must return to its pre-init value"
+	);
+
+	memory_context_fini(&root);
+	free(arena);
+	return 0;
+}
+
 int
 main(void) {
 	log_enable_name("info");
@@ -455,6 +578,14 @@ main(void) {
 	}
 	if (test_stress_init_fini_cycle() != 0) {
 		LOG(ERROR, "test_stress_init_fini_cycle failed");
+		return -1;
+	}
+	if (test_value_table_child_context() != 0) {
+		LOG(ERROR, "test_value_table_child_context failed");
+		return -1;
+	}
+	if (test_value_registry_child_context() != 0) {
+		LOG(ERROR, "test_value_registry_child_context failed");
 		return -1;
 	}
 

--- a/tests/common/value_table.c
+++ b/tests/common/value_table.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 
 // value_table_free must be a no-op on an object whose value_table_init
-// failed, e.g. when the backing allocator cannot satisfy the values array.
+// failed, e.g. when the backing allocator cannot satisfy any allocation.
 // Before the fix the values field was left uninitialized and the subsequent
 // free dereferenced it.
 static void
@@ -19,15 +19,49 @@ test_free_after_failed_init(void) {
 	struct value_table table;
 	memset(&table, 0xa5, sizeof(table));
 
-	res = value_table_init(&table, &mem_ctx, 1, 10);
+	res = value_table_init(&table, &mem_ctx, "test-table", 1, 10);
 	assert(res == -1);
 
 	value_table_free(&table);
+
+	// A failed init must never leave a child memory context attached to
+	// the parent.
+	assert(ADDR_OF(&mem_ctx.first_child) == NULL);
+}
+
+// Verifies that value_table_init failing after it has already created its
+// child memory context (arena runs out on a later allocation) still leaves
+// no child attached to the parent.
+static void
+test_partial_failure_no_child(void) {
+	// Big enough for the context struct and the tiny values array (a
+	// single chunk pointer for these dims), too small for the first
+	// 64KB values chunk.
+	void *arena = malloc(1 << 12);
+	assert(arena != NULL);
+
+	struct block_allocator alloc;
+	block_allocator_init(&alloc);
+	block_allocator_put_arena(&alloc, arena, 1 << 12);
+
+	struct memory_context mem_ctx;
+	int res = memory_context_init(&mem_ctx, "partial-fail", &alloc);
+	assert(res == 0);
+
+	struct value_table table;
+	res = value_table_init(&table, &mem_ctx, "test-table", 1, 10);
+	assert(res == -1);
+
+	assert(ADDR_OF(&mem_ctx.first_child) == NULL);
+	assert(mem_ctx.balloc_size == mem_ctx.bfree_size);
+
+	free(arena);
 }
 
 int
 main() {
 	test_free_after_failed_init();
+	test_partial_failure_no_child();
 
 	void *arena0 = malloc(1 << 24); // 16MB
 	if (arena0 == NULL) {
@@ -43,9 +77,21 @@ main() {
 		return 1;
 	}
 
+	// Baseline to compare against once the table is freed below: nothing
+	// but the table (and the remap table) is allocated from mem_ctx.
+	size_t balloc_size_before = mem_ctx.balloc_size;
+	size_t bfree_size_before = mem_ctx.bfree_size;
+
 	struct value_table table;
-	int res = value_table_init(&table, &mem_ctx, 1, 10);
+	int res = value_table_init(&table, &mem_ctx, "test-table", 1, 10);
 	assert(res == 0);
+
+	// The table gets its own child node, named after the call site, in
+	// mem_ctx's memory tree.
+	struct memory_context *child = ADDR_OF(&mem_ctx.first_child);
+	assert(child != NULL);
+	assert(strcmp(child->name, "test-table") == 0);
+	assert(ADDR_OF(&child->next_sibling) == NULL);
 
 	struct remap_table remap_table;
 	res = remap_table_init(&remap_table, &mem_ctx, 10);
@@ -80,6 +126,13 @@ main() {
 
 	remap_table_free(&remap_table);
 	value_table_free(&table);
+
+	// The child node and every byte it (and its own context struct) used
+	// must be gone once the table is freed.
+	assert(ADDR_OF(&mem_ctx.first_child) == NULL);
+	assert(mem_ctx.balloc_size - mem_ctx.bfree_size ==
+	       balloc_size_before - bfree_size_before);
+
 	memory_context_fini(&mem_ctx);
 	free(arena0);
 


### PR DESCRIPTION
A production ACL config showed a filter holding 4.5 GiB in the inspect memory tree while its visible children accounted for 45 MiB. The remaining bytes were allocated straight from the filter's own context, so they had no node of their own and no printed number, and read as unexplained memory.

- Every value table and value registry a filter builds now owns a memory context named after its call site, so the tree accounts bytes per object rather than folding them into an anonymous share of the filter's own bytes.
- The context is allocated out of the parent and stored in the pointer field each object already had, so every shared-memory structure keeps byte-identical sizes and field offsets and no ABI version moves. Embedding the context by value would have grown the filter structure, which module configs carry by value in memory the dataplane reads.
- The inspect CLI prints a node's own live bytes beside its subtree total whenever the two differ, and adds a bounded rollup of own bytes grouped by context name. Subtree totals are computed once in a single pass instead of being recursed per lookup.
- A registry the filter had already initialised was initialised a second time on two paths. That was a silent no-op before and would have orphaned a context per network attribute on every compile, so the redundant initialisation is gone and the one inner node that depended on it is initialised explicitly.
- A dead memory-usage helper is removed. It had no callers, and this change would otherwise have silently narrowed what it reported.

Verified on a live stand: the tree now decomposes an ACL configuration down to individual tables and registries, and immediately showed that most of that agent's memory is allocated above the configuration level entirely.

Follow-ups this work surfaced, none of them fixed here: #1766, #1767 and #1768.