### PR TITLE
refactor(route): encapsulate the FIB iterator walk behind the binding

### DIFF
--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -195,17 +195,6 @@ private:modules/acl/controlplane/service.go:ACLService.withEntries:e.updateMu:1 
 private:modules/acl/controlplane/service.go:ACLService.withEntries:e.updateMu:2  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.withEntry:entry.updateMu:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.withEntry:entry.updateMu:2  # legacy: encapsulate behind an exported method or field
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.ActiveNexthopCounterNames:iter.activeCounterNames:1  # mirrors the sibling fibIter accessors DumpFIB already reaches through
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.addressFamily:1  # legacy: encapsulate behind an exported method or field
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.destroy:1  # legacy: encapsulate behind an exported method or field
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.next:1  # legacy: encapsulate behind an exported method or field
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopCount:1  # legacy: encapsulate behind an exported method or field
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopCounterName:1  # mirrors the sibling fibIter accessors on the same iterator; encapsulating this one alone would split the pattern without benefit
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopDeviceName:1  # legacy: encapsulate behind an exported method or field
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopDstMAC:1  # legacy: encapsulate behind an exported method or field
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.nexthopSrcMAC:1  # legacy: encapsulate behind an exported method or field
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.prefixFrom:1  # legacy: encapsulate behind an exported method or field
-private:modules/route/bindings/go/croute/safe.go:ModuleConfig.DumpFIB:iter.prefixTo:1  # legacy: encapsulate behind an exported method or field
 private:operators/route/internal/operator/operator.go:applyStaticSeed:routeSvc.getOrCreateRib:1  # legacy: encapsulate behind an exported method or field
 receiver:common/go/dataplane/packet.go:Packet.Data:1  # legacy: rename the receiver to m
 receiver:common/go/dataplane/packet.go:Packet.Free:1  # legacy: rename the receiver to m

--- a/modules/route/bindings/go/croute/cgo.go
+++ b/modules/route/bindings/go/croute/cgo.go
@@ -10,6 +10,8 @@ import "C"
 
 import (
 	"fmt"
+	"net"
+	"net/netip"
 	"unsafe"
 
 	"github.com/yanet-platform/yanet2/bindings/go/cerrors"
@@ -241,9 +243,9 @@ func (m *fibIter) nexthopCounterName(idx uint64) string {
 	return C.GoString(C.fib_iter_nexthop_counter_name(m.ptr, C.uint64_t(idx)))
 }
 
-// activeCounterNames walks the remainder of the FIB, collecting every
+// ActiveCounterNames walks the remainder of the FIB, collecting every
 // non-empty per-nexthop counter name, then destroys the iterator.
-func (m *fibIter) activeCounterNames() map[string]struct{} {
+func (m *fibIter) ActiveCounterNames() map[string]struct{} {
 	defer m.destroy()
 
 	names := map[string]struct{}{}
@@ -255,4 +257,60 @@ func (m *fibIter) activeCounterNames() map[string]struct{} {
 		}
 	}
 	return names
+}
+
+// Entries walks the remainder of the FIB into Go-owned entries, then
+// destroys the iterator.
+//
+// The prefix bounds returned during a step are borrowed from the iterator's
+// own cursor and get overwritten on the next step. Keeping the walk beside
+// the accessors confines that lifetime rule here, so the safe layer only
+// ever sees Go-owned values.
+func (m *fibIter) Entries() []FIBEntry {
+	defer m.destroy()
+
+	var entries []FIBEntry
+
+	for m.next() {
+		af := m.addressFamily()
+
+		from := m.prefixFrom()
+		to := m.prefixTo()
+
+		var prefixFrom, prefixTo netip.Addr
+		switch af {
+		case AddressFamilyIPv4:
+			prefixFrom = netip.AddrFrom4(*(*[4]byte)(from))
+			prefixTo = netip.AddrFrom4(*(*[4]byte)(to))
+		case AddressFamilyIPv6:
+			prefixFrom = netip.AddrFrom16(*(*[16]byte)(from))
+			prefixTo = netip.AddrFrom16(*(*[16]byte)(to))
+		default:
+			continue
+		}
+
+		nhCount := m.nexthopCount()
+		nexthops := make([]FIBNexthop, nhCount)
+
+		for idx := range nhCount {
+			dstMAC := m.nexthopDstMAC(idx)
+			srcMAC := m.nexthopSrcMAC(idx)
+
+			nexthops[idx] = FIBNexthop{
+				DstMAC:  net.HardwareAddr(dstMAC[:]),
+				SrcMAC:  net.HardwareAddr(srcMAC[:]),
+				Device:  m.nexthopDeviceName(idx),
+				Counter: m.nexthopCounterName(idx),
+			}
+		}
+
+		entries = append(entries, FIBEntry{
+			AddressFamily: af,
+			PrefixFrom:    prefixFrom,
+			PrefixTo:      prefixTo,
+			Nexthops:      nexthops,
+		})
+	}
+
+	return entries
 }

--- a/modules/route/bindings/go/croute/safe.go
+++ b/modules/route/bindings/go/croute/safe.go
@@ -90,52 +90,8 @@ func (m *ModuleConfig) DumpFIB() ([]FIBEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create FIB iterator: %w", err)
 	}
-	defer iter.destroy()
 
-	var entries []FIBEntry
-
-	for iter.next() {
-		af := iter.addressFamily()
-
-		from := iter.prefixFrom()
-		to := iter.prefixTo()
-
-		var prefixFrom, prefixTo netip.Addr
-		switch af {
-		case AddressFamilyIPv4:
-			prefixFrom = netip.AddrFrom4(*(*[4]byte)(from))
-			prefixTo = netip.AddrFrom4(*(*[4]byte)(to))
-		case AddressFamilyIPv6:
-			prefixFrom = netip.AddrFrom16(*(*[16]byte)(from))
-			prefixTo = netip.AddrFrom16(*(*[16]byte)(to))
-		default:
-			continue
-		}
-
-		nhCount := iter.nexthopCount()
-		nexthops := make([]FIBNexthop, nhCount)
-
-		for idx := range nhCount {
-			dstMAC := iter.nexthopDstMAC(idx)
-			srcMAC := iter.nexthopSrcMAC(idx)
-
-			nexthops[idx] = FIBNexthop{
-				DstMAC:  net.HardwareAddr(dstMAC[:]),
-				SrcMAC:  net.HardwareAddr(srcMAC[:]),
-				Device:  iter.nexthopDeviceName(idx),
-				Counter: iter.nexthopCounterName(idx),
-			}
-		}
-
-		entries = append(entries, FIBEntry{
-			AddressFamily: af,
-			PrefixFrom:    prefixFrom,
-			PrefixTo:      prefixTo,
-			Nexthops:      nexthops,
-		})
-	}
-
-	return entries, nil
+	return iter.Entries(), nil
 }
 
 // ActiveNexthopCounterNames returns the deduplicated, sorted set of
@@ -150,5 +106,5 @@ func (m *ModuleConfig) ActiveNexthopCounterNames() ([]string, error) {
 		return nil, fmt.Errorf("failed to create FIB iterator: %w", err)
 	}
 
-	return slices.Sorted(maps.Keys(iter.activeCounterNames())), nil
+	return slices.Sorted(maps.Keys(iter.ActiveCounterNames())), nil
 }


### PR DESCRIPTION
- Moved the FIB walk out of the route binding's safe layer and next to the iterator accessors that produce the raw shared-memory pointers, so the lifetime rule for a cursor position stays in one place.
- The safe layer now only creates the iterator, wraps a creation failure, and shapes the result, handling values owned by Go throughout.
- Each walk owns the iterator's lifetime and releases it once, including on panic.
- Removed the eleven encapsulation debt rows this clears from the style ledger, leaving no reach-in behind them.
- No behaviour change and no change to the call surface across the C boundary. The existing route functional suite covers both walks against real shared memory.

Closes #1736.