### PR TITLE
perf(ci): stop rebuilding Go twice and shrink the actions cache

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -22,6 +22,11 @@ on:
         type: boolean
         default: false
 
+concurrency:
+  # The run_id fallback keeps non-PR runs from cancelling each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   set-matrix:
     runs-on: ubuntu-latest
@@ -96,13 +101,11 @@ jobs:
       # https://github.com/actions/setup-go/issues/358
       - name: Get Go environment
         run: |
-          echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
           echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
       - name: Set up go cache
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.cache }}
             ${{ env.modcache }}
           key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}-${{ matrix.unbtver }}
           restore-keys: |

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -52,14 +52,12 @@ jobs:
       # https://github.com/actions/setup-go/issues/358
       - name: Get Go environment
         run: |
-          echo "cache=$(go env GOCACHE)" >> $GITHUB_ENV
           echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
 
       - name: Set up go cache
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.cache }}
             ${{ env.modcache }}
           key: deb-build-24.04-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}-24.04
           restore-keys: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ on:
       - ".github/workflows/build.yml"
       - ".github/actions/apt-packages/**"
 
+concurrency:
+  # The run_id fallback keeps non-PR runs from cancelling each other.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-asan-test:
     runs-on: ubuntu-24.04
@@ -53,6 +58,7 @@ jobs:
           key: ${{ runner.os }}-build-asan-test-cache
           max-size: 2G
           verbose: 2
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: actions/setup-go@v5
         with:
@@ -62,14 +68,12 @@ jobs:
 
       - name: Get Go environment
         run: |
-          echo "cache=$(go env GOCACHE)" >>$GITHUB_ENV
           echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
 
       - name: Set up go cache
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.cache }}
             ${{ env.modcache }}
           key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
@@ -88,9 +92,7 @@ jobs:
           make dataplane
 
       - name: Build and run tests (sanitize)
-        run: |
-          make go-cache-clean
-          make test-asan
+        run: make test-asan-only
 
       - name: Show meson test log
         if: always()
@@ -116,6 +118,7 @@ jobs:
           key: ${{ runner.os }}-build-tsan-test-cache
           max-size: 2G
           verbose: 2
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: actions/setup-go@v5
         with:
@@ -125,14 +128,12 @@ jobs:
 
       - name: Get Go environment
         run: |
-          echo "cache=$(go env GOCACHE)" >>$GITHUB_ENV
           echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
 
       - name: Set up go cache
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.cache }}
             ${{ env.modcache }}
           key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
@@ -188,6 +189,7 @@ jobs:
           key: ${{ runner.os }}-build-release-artifacts-cache
           max-size: 2G
           verbose: 2
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: actions/setup-go@v5
         with:
@@ -197,14 +199,12 @@ jobs:
 
       - name: Get Go environment
         run: |
-          echo "cache=$(go env GOCACHE)" >>$GITHUB_ENV
           echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
 
       - name: Set up go cache
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.cache }}
             ${{ env.modcache }}
           key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
@@ -223,7 +223,7 @@ jobs:
           make dataplane cli
 
       - name: Build and run tests (release)
-        run: make test
+        run: make test-only
 
       - name: Show meson test log
         if: always()
@@ -303,6 +303,7 @@ jobs:
           key: ${{ runner.os }}-clang-tidy-cache
           max-size: 2G
           verbose: 2
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: actions/setup-go@v5
         with:
@@ -312,14 +313,12 @@ jobs:
 
       - name: Get Go environment
         run: |
-          echo "cache=$(go env GOCACHE)" >>$GITHUB_ENV
           echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
 
       - name: Set up go cache
         uses: actions/cache@v3
         with:
           path: |
-            ${{ env.cache }}
             ${{ env.modcache }}
           key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -16,6 +16,10 @@ on:
       - ".github/actions/clang-format/**"
       - ".github/workflows/check-format.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   c-cpp-fmt:
     name: C formatting

--- a/.github/workflows/comment-lint.yml
+++ b/.github/workflows/comment-lint.yml
@@ -2,7 +2,12 @@ name: Comment Lint
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   commentlint:

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   commitlint:
     name: Custom commitlint linter

--- a/.github/workflows/go-formatting.yml
+++ b/.github/workflows/go-formatting.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - "controlplane/**/*.go"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   gofmt:
     name: Check Go Formatting

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -2,6 +2,7 @@ name: Go Lint
 
 on:
   push:
+    branches: [main]
     paths:
       - '**/*.go'
       - 'lint/style/**'
@@ -15,6 +16,10 @@ on:
       - '.golangci.yml'
       - '.github/workflows/go-lint.yml'
       - '.github/actions/apt-packages/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   stylelint:

--- a/.github/workflows/meson-lint.yml
+++ b/.github/workflows/meson-lint.yml
@@ -16,6 +16,10 @@ on:
       - 'meson_options.txt'
       - '.github/workflows/meson-lint.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   mesonlint:
     name: mesonlint

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -2,6 +2,7 @@ name: Proto Lint
 
 on:
   push:
+    branches: [main]
     paths:
       - '**/*.proto'
       - 'lint/protobuf/**'
@@ -13,6 +14,10 @@ on:
       - 'lint/protobuf/**'
       - 'buf.yaml'
       - '.github/workflows/proto-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   buf-lint:

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -18,6 +18,10 @@ on:
       - ".github/workflows/rust-check.yml"
       - ".github/actions/apt-packages/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     name: cargo fmt

--- a/.github/workflows/web-check.yml
+++ b/.github/workflows/web-check.yml
@@ -22,6 +22,10 @@ on:
       - "package-lock.json"
       - ".github/workflows/web-check.yml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: test

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,9 @@ CLI_RELEASE_BINARIES := $(addprefix $(RELEASE_DIR)/,$(CLI_BINARIES))
 	lint-commit \
 	hooks \
 	test \
+	test-only \
 	test-asan \
+	test-asan-only \
 	test-tsan \
 	test-functional \
 	bench \
@@ -256,11 +258,24 @@ cli-clean:
 cli-clean/%:
 	$(CARGO) clean || true
 
-test: go-cache-clean dataplane
+# Wipes the Go build cache first: a stale entry can link a stale C archive.
+#
+# The clean is a recipe step rather than a prerequisite so that -j cannot run
+# it concurrently with the build. A caller that has already cleaned once, such
+# as a CI job, invokes the -only target instead.
+test:
+	$(MAKE) go-cache-clean
+	$(MAKE) test-only
+
+test-only: dataplane
 	go test -count=1 $$(go list ./... | grep -v '^github.com/yanet-platform/yanet2/tests/functional')
 	meson test -C build
 
-test-asan: go-cache-clean
+test-asan:
+	$(MAKE) go-cache-clean
+	$(MAKE) test-asan-only
+
+test-asan-only:
 	@if [ ! -d "build" ]; then \
 		$(MAKE) setup-asan; \
 	else \
@@ -287,7 +302,9 @@ test-functional:
 #   go test -run='^$$' -bench=. -benchmem -count=6 ./bindings/go/dataplane_ut/... > old.txt
 #   go test -run='^$$' -bench=. -benchmem -count=6 ./bindings/go/dataplane_ut/... > new.txt
 #   benchstat old.txt new.txt
-bench: go-cache-clean dataplane
+bench:
+	$(MAKE) go-cache-clean
+	$(MAKE) dataplane
 	go test -run='^$$' -bench=. -benchmem ./bindings/go/dataplane_ut/... ./modules/acl/tests/functional/...
 
 fuzz:


### PR DESCRIPTION
Measured against the 12 most recent successful pull request runs per workflow, plus step-level replay of the build and deb job logs. A pull request currently costs about 50 runner-minutes, and its wall clock is set entirely by the deb job at 15.5 minutes.

## Measured effect of this change

From the first run on this pull request, against the recorded baseline:

| Job | Before | After |
| --- | --- | --- |
| Sanitizer build and test | 8.1 min | 6.65 min |
| Release build and test | 7.9 min | 6.6 min |
| Thread-sanitizer | 1.6 min | 2.0 min |
| clang-tidy | 5.8 min | 5.75 min |
| Deb packages | 15.5 min | 15.8 min |

The two jobs this targets came down by 87 and 79 seconds, close to the 98 and 90 predicted from the logs. The thread-sanitizer job is up by the expected one-time cold module-cache cost described at the end. Wall clock is unchanged, because the deb job still dominates it — that is tracked separately and not addressed here.

## Actions cache

The repository sits at 10.71 GB against GitHub's 10 GB per-repository limit, so entries are evicted least-recently-used continuously.

Dropping the Go build cache from the cached paths frees about 350 MB, measured after the fact by comparing old and new entries rather than estimated. The Go cache entries total about 1.36 GB, but roughly three quarters of that is the module download cache, which is retained and is genuinely useful.

The removal is free in three jobs — the sanitizer, release and clang-tidy jobs each wipe the build cache before their first Go build, so the restored copy was never read — and free in the thread-sanitizer job, which two run logs confirm builds zero Go targets, because a suite-filtered meson test rebuilds only the selected tests' dependencies.

The two deb-family workflows are different and worth stating plainly: there the restore genuinely is consumed, because debhelper's build step precedes the only cache wipe. Removing it is therefore a cache-budget tradeoff rather than a free win. The measurement argues it is harmless — those targets took about 110 seconds warm against about 91 seconds cold — and the deb job on this pull request landed 19 seconds above the baseline mean, inside its observed 14-to-17-minute spread. Worth confirming over a few post-merge runs.

Compiler-cache writes are now gated to main-branch pushes in the build workflow only, which is where 41 accumulated entries and about 2 GB came from. The deb workflow is deliberately left ungated: it has no branch-push trigger at all, so a main-gated predicate would never fire, and because caches are ref-scoped it would strand that workflow on a single stale entry.

## Cold builds and a parallel-make race

Go binaries were compiled from a cold cache twice per job, because the workflow step wiped the cache and the test target wiped it again. Splitting the wipe out of the test targets removes the second cold build.

The wipe was also a prerequisite rather than a recipe step, so a parallel make could run it concurrently with the build. That is live rather than theoretical: the packaging rules override only the configure step, so every other step falls through to debhelper's autodetected makefile buildsystem, and the deb job log shows it invoking the root makefile with parallelism. The wipe is now a sequential recipe step that parallelism cannot reorder.

## Scheduling and duplicate runs

Concurrency groups are added to the 11 pull-request-triggered workflows. The group key falls back from the head branch to the run identifier, because GitHub evicts a pending run from a group regardless of the cancel setting — a branch-keyed group would silently drop main-push builds, and with them the artifact the functional tests consume, whenever merges land inside one run.

Three lint workflows ran twice on roughly 60 percent of commits, since their push trigger carried no branch filter and a same-repository pull request branch fires both events. They are now filtered to main on push and left unfiltered on pull request.

## Expected on the first run after merge

Changing the cached path list changes the cache version, so the previous Go entries become unreachable and each job pays one cold module-cache download. Both versions coexist until the old ones age out, so the cache total drops gradually rather than immediately. This is self-healing.
