### PR TITLE
perf(ci): drop the unused build from the clang-tidy job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,14 +297,6 @@ jobs:
         with:
           packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
 
-      - uses: hendrikmuhs/ccache-action@v1.2.18
-        name: ccache
-        with:
-          key: ${{ runner.os }}-clang-tidy-cache
-          max-size: 2G
-          verbose: 2
-          save: ${{ github.ref == 'refs/heads/main' }}
-
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24.x"
@@ -330,11 +322,9 @@ jobs:
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 
-      - name: Build YANET (release)
+      - name: Generate compile database
         run: |
-          make go-cache-clean
           meson setup build -Dbuildtype=release
-          make dataplane
 
       - name: Run clang-tidy
         env:
@@ -372,7 +362,7 @@ jobs:
           [ -n "$RTIDY" ] && echo "Using run-clang-tidy helper: $RTIDY"
 
           # Build file list from database (C files, exclude subprojects)
-          FILES="$(jq -r '.[].file' build/compile_commands.json | sort -u | grep '\.c$' | grep -v '/subprojects/' || true)"
+          FILES="$(jq -r '.[].file' build/compile_commands.json | sort -u | grep '\.c$' | grep -vE '(^|/)subprojects/' || true)"
           if [ -z "$FILES" ]; then
               echo "No source files to lint (after filtering)."
               exit 0


### PR DESCRIPTION
The clang-tidy job spends about 120 seconds compiling the whole C tree and every Go control-plane and operator binary, and then reads none of it. Its only input is the compile database, and meson writes that at configure time, so configuring without compiling produces the same database. Measured against the job's own step logs, the linting itself takes about 20 seconds.

Verified rather than assumed, by building a configure-only directory and replaying the job's own steps against it:

- The database is complete. Its list of real sources matches a fully compiled directory's, once the compiled one is refreshed against the two refactors that landed today and deleted exactly the files that appeared to be missing.
- Both generated configuration headers, the project's own and the one from the packet-processing library, are present after configuring, because they are emitted at configure time.
- The only headers meson generates at build time belong to a subproject, are not included by any source here, and are excluded from linting anyway.
- Linting every real source from the configure-only directory reports no diagnostic errors, and the same warnings the job reports today.

Removing the compile also removes the job's only reason to keep a compiler cache, so that step goes too. It was holding roughly 110 MB of an Actions cache that is already at its limit, and costing a restore on every run for nothing. Its removal leaves the compile database recording the plain compiler rather than a cache wrapper, which is the more standard form for the tooling to consume.

## A filter that never did what it intended

The step selects sources by excluding a path fragment anchored on a leading slash. Generated sources, though, are recorded relative to the build directory with no leading slash, so a dozen of them were never excluded. Until now the compile created them, so they were linted quietly and the job stayed green — meaning the job was linting build artefacts it was explicitly written to skip.

Without the compile they do not exist, so the same filter would have failed the job outright. Anchoring the pattern to match a leading segment as well fixes both the latent defect and the failure it would otherwise have caused. Replaying the step confirms it: the old pattern exits non-zero with a dozen missing-file errors, the anchored one exits clean over the real sources.

## Not addressed here

The header filter passed to the linter uses a lookahead that the regex engine behind it does not support, so header diagnostics are effectively off. That is pre-existing, independent of this change, and turning it on is likely to surface findings of its own, so it belongs in its own change.
