### PR TITLE
perf(ci): install clang-tidy from the distro package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,20 +282,13 @@ jobs:
       cache_name: clang-tidy
 
     steps:
-      - name: Install LLVM 19 toolchain
-        id: llvm
-        uses: KyleMayes/install-llvm-action@v2
-        with:
-          version: "19.1.1"
-          directory: ${{ runner.temp }}/llvm
-
       - uses: actions/checkout@v4
         with:
           submodules: true
 
       - uses: ./.github/actions/apt-packages
         with:
-          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
+          packages: meson clang clang-tidy-19 cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
 
       - uses: actions/setup-go@v5
         with:
@@ -327,9 +320,6 @@ jobs:
           meson setup build -Dbuildtype=release
 
       - name: Run clang-tidy
-        env:
-          # Use the same directory we asked the install-llvm-action to install to
-          LLVM_DIR: ${{ runner.temp }}/llvm
         run: |
           set -euo pipefail
           # Ensure compilation database exists
@@ -339,28 +329,6 @@ jobs:
               exit 1
           }
 
-          # Force using the freshly installed LLVM 19 to avoid ABI/lib conflicts with system packages
-          if [ ! -x "$LLVM_DIR/bin/clang-tidy" ]; then
-              echo "ERROR: LLVM 19 clang-tidy not found at $LLVM_DIR/bin/clang-tidy"
-              ls -la "$LLVM_DIR/bin" || true
-              exit 1
-          fi
-          export PATH="$LLVM_DIR/bin:$PATH"
-          export LD_LIBRARY_PATH="$LLVM_DIR/lib:${LD_LIBRARY_PATH:-}"
-
-          CTIDY="$LLVM_DIR/bin/clang-tidy"
-          # Locate run-clang-tidy.py shipped with LLVM
-          if [ -f "$LLVM_DIR/share/clang/run-clang-tidy.py" ]; then
-              RTIDY="$LLVM_DIR/share/clang/run-clang-tidy.py"
-          elif [ -f "$LLVM_DIR/lib/clang/run-clang-tidy.py" ]; then
-              RTIDY="$LLVM_DIR/lib/clang/run-clang-tidy.py"
-          else
-              RTIDY=""
-          fi
-
-          echo "Using clang-tidy binary: $CTIDY"
-          [ -n "$RTIDY" ] && echo "Using run-clang-tidy helper: $RTIDY"
-
           # Build file list from database (C files, exclude subprojects)
           FILES="$(jq -r '.[].file' build/compile_commands.json | sort -u | grep '\.c$' | grep -vE '(^|/)subprojects/' || true)"
           if [ -z "$FILES" ]; then
@@ -368,23 +336,13 @@ jobs:
               exit 0
           fi
 
-          if [ -n "$RTIDY" ] && [ -f "$RTIDY" ]; then
-              # Use run-clang-tidy.py (handles DB well and parallelism)
-              python3 "$RTIDY" \
-                  -p build \
-                  -j "$(nproc)" \
-                  -clang-tidy-binary "$CTIDY" \
+          # Invoke clang-tidy from the database directory so -p . resolves
+          cd build
+          printf "%s\n" $FILES |
+              xargs -P"$(nproc)" -I{} clang-tidy-19 \
+                  -p . \
                   -header-filter='^(?!.*\/subprojects\/).*' \
-                  $FILES
-          else
-              # Fallback: invoke clang-tidy directly from DB directory
-              cd build
-              printf "%s\n" $FILES |
-                  xargs -P"$(nproc)" -I{} "$CTIDY" \
-                      -p . \
-                      -header-filter='^(?!.*\/subprojects\/).*' \
-                      {}
-          fi
+                  {}
 
   functional-tests:
     name: Run Functional Tests


### PR DESCRIPTION
Stacked on #1791 — merge that one first. This pull request's base is its branch, so the diff shown here is only this change.

The job downloaded and unpacked a full upstream toolchain release, roughly one and a half gigabytes, in order to use a single binary from it. That cost about 116 seconds of a 205-second job and could not be cached, because the release asset alone exceeds the repository's remaining Actions cache allowance.

The distribution archive carries that binary at exactly the version the download was pinned to, in the updates and security pockets. So the download step is deleted outright and the package is added to the list the job already installs, leaving the job with one step fewer than before this stack and two fewer than the branch it targets.

Because the version is identical, this raises no question of the linter's findings drifting.

## What else falls out

The invocation loses everything that existed only to reach into an unpacked tree: a directory variable, an existence check, two environment exports, and an indirection through a variable holding the binary's path.

It also loses a branch that would have run an upstream helper tool if that tool were found. Two job logs show it never ran — the marker it would print appears only where the step's own script is echoed, never as output — because the release tarball installs that helper under a different name than the branch looked for. The packaged toolchain does ship it, under the name the branch would find, so keeping the branch would have quietly moved linting onto a path this repository has never exercised. The proven path stays and the dead one goes.

## Coherence, and one cost worth naming

The result is that continuous integration now runs the same binary the repository's own local lint recipe runs, and installs it the same way the development container image and the functional-test virtual machine already do. The deleted download step was the only place doing it differently.

The cost: adding a package changes that install step's cache key, so it mints a fresh entry of roughly seventy to ninety megabytes compressed, while the previous, much smaller one lingers until it ages out. The Actions cache is close to its ceiling, so this will bring forward the eviction of something else. It is not the driver of that pressure — a substantial share of the cache is duplicate entries under a handful of keys — but it is not free either, and the duplication deserves its own change.
