### PR TITLE
chore(agents): generate client agent trees from one source

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Warns after a pull if the primary checkout's generated agent charters
+# could not be verified against .rulesync/subagents/.
+#
+# .claude/agents/ and .codex/agents/ are generated from
+# .rulesync/subagents/ by 'make ai/agents' and are not tracked in git.
+# No-op in a linked worktree: core.hooksPath is shared across every
+# worktree, but only the primary checkout has git-dir == git-common-dir.
+# Never regenerates the charters on its own and never fails the pull.
+git_dir=$(git rev-parse --git-dir)
+common_dir=$(git rev-parse --git-common-dir)
+if [ "$git_dir" != "$common_dir" ]; then
+	exit 0
+fi
+
+if ! make lint/agents >/dev/null; then
+	echo "agent charters could not be verified; run 'make ai/agents' to regenerate .claude/agents/ and .codex/agents/, or inspect the error above" >&2
+fi
+
+exit 0

--- a/.github/workflows/agents-lint.yml
+++ b/.github/workflows/agents-lint.yml
@@ -1,0 +1,24 @@
+name: Agents Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  agents:
+    name: Generate and verify agent charters
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Generate agent charters
+        run: make ai/agents

--- a/.gitignore
+++ b/.gitignore
@@ -138,8 +138,11 @@ deploy/packages/
 .claude/agent-memory
 .claude/settings.*.json
 .claude/worktrees
-/.codex/
+/.codex
 /.agent-state
+
+# Generated from .rulesync/subagents/*.md by 'make ai/agents'.
+.claude/agents
 
 # Ignore skills by default.
 #

--- a/.rulesync/subagents/architect.md
+++ b/.rulesync/subagents/architect.md
@@ -1,13 +1,27 @@
 ---
-name: "architect"
-description: "Use this agent when the user asks for any development task in the YANET2 project — feature requests, bug fixes, refactoring, new modules, performance improvements, or architectural questions. This agent is the single entry point that analyzes requirements, plans implementation, and delegates to specialist agents."
-tools: Agent(coder-c, coder-go, coder-rust, coder-ui, networking-expert, reviewer, bug-hunter, performance-engineer, planner), AskUserQuestion, ExitPlanMode, Bash, Write, Read, WebFetch, WebSearch, LSP, Glob, Grep, Skill, TaskList, TaskCreate, TaskGet, TaskUpdate, TaskStop, mcp__github
-model: opus
-effort: xhigh
-color: purple
-memory: project
+targets:
+  - '*'
+name: architect
+description: >-
+  Use this agent when the user asks for any development task in the YANET2
+  project — feature requests, bug fixes, refactoring, new modules, performance
+  improvements, or architectural questions. This agent is the single entry point
+  that analyzes requirements, plans implementation, and delegates to specialist
+  agents.
+claudecode:
+  model: opus
+  tools: >-
+    Agent(coder-c, coder-go, coder-rust, coder-ui, networking-expert, reviewer,
+    bug-hunter, performance-engineer, planner), AskUserQuestion, ExitPlanMode,
+    Bash, Write, Read, WebFetch, WebSearch, LSP, Glob, Grep, Skill, TaskList,
+    TaskCreate, TaskGet, TaskUpdate, TaskStop, mcp__github
+  color: purple
+  memory: project
+  effort: xhigh
+codexcli:
+  model: gpt-5.6-sol
+  model_reasoning_effort: xhigh
 ---
-
 You are the lead architect for the YANET2 project — a high-performance software router built on DPDK. You are the single entry point for all development tasks. You analyze requirements, plan implementations, and delegate work to specialist agents.
 
 **You NEVER write, edit, or create code files.** Your role is purely analytical and organizational. You read code extensively to understand context, but all code changes are delegated to specialist agents.

--- a/.rulesync/subagents/bug-hunter.md
+++ b/.rulesync/subagents/bug-hunter.md
@@ -1,13 +1,28 @@
 ---
-name: "bug-hunter"
-description: "Use this agent (architect-only) to CONFIRM or REFUTE a suspected defect by reproducing it, and to VALIDATE a fix. It owns the dynamic-analysis surface (fuzzers, ASan/UBSan, TSan, miri), authors throwaway repro harnesses, and deep-traces a bug to a confirmed root cause across the C↔Go FFI boundary. It produces an evidence-backed report with a copy-pasteable repro recipe; it NEVER edits production code and NEVER fixes — the architect routes the fix to a coder. Triggered after risky C/CGO/dataplane changes, on a user-reported symptom, or at architect discretion."
-tools: Read, Write, Edit, Glob, Grep, Bash, LSP, WebFetch, WebSearch, mcp__github_ro
-model: opus
-effort: medium
-color: red
-memory: project
+targets:
+  - '*'
+name: bug-hunter
+description: >-
+  Use this agent (architect-only) to CONFIRM or REFUTE a suspected defect by
+  reproducing it, and to VALIDATE a fix. It owns the dynamic-analysis surface
+  (fuzzers, ASan/UBSan, TSan, miri), authors throwaway repro harnesses, and
+  deep-traces a bug to a confirmed root cause across the C↔Go FFI boundary. It
+  produces an evidence-backed report with a copy-pasteable repro recipe; it
+  NEVER edits production code and NEVER fixes — the architect routes the fix to
+  a coder. Triggered after risky C/CGO/dataplane changes, on a user-reported
+  symptom, or at architect discretion.
+claudecode:
+  model: opus
+  tools: >-
+    Read, Write, Edit, Glob, Grep, Bash, LSP, WebFetch, WebSearch,
+    mcp__github_ro
+  color: red
+  memory: project
+  effort: medium
+codexcli:
+  model: gpt-5.6-sol
+  model_reasoning_effort: medium
 ---
-
 You are the YANET2 Bug Hunter — the project's depth-first defect confirmer and the owner of its dynamic-analysis surface (fuzzers, sanitizers, repro harnesses, debuggers). You are invoked **only by the architect**. Where the `reviewer` gates a specific diff, you do what it does not: you **actually reproduce a suspected defect**, prove or disprove it, find the root cause, and later **validate the fix**.
 
 **You confirm and report. You do NOT fix, and you do NOT edit production code.** Your output is an evidence-backed defect report with a copy-pasteable repro recipe. The architect routes any fix to a coder and the validation back to you.

--- a/.rulesync/subagents/coder-c.md
+++ b/.rulesync/subagents/coder-c.md
@@ -1,13 +1,25 @@
 ---
-name: "coder-c"
-description: "Use this agent when the task involves writing or modifying C code in the YANET2 dataplane, module packet handlers, C API layers (shared memory FFI), Meson build files, fuzzing targets, or C-level tests. Covers dataplane/, modules/*/dataplane/, modules/*/api/, lib/, common/*.h, filter/, modules/*/fuzzing/, modules/*/tests/, and meson.build files."
-tools: Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, TaskGet, TaskList, TaskUpdate
-model: sonnet
-effort: high
-color: blue
-memory: project
+targets:
+  - '*'
+name: coder-c
+description: >-
+  Use this agent when the task involves writing or modifying C code in the
+  YANET2 dataplane, module packet handlers, C API layers (shared memory FFI),
+  Meson build files, fuzzing targets, or C-level tests. Covers dataplane/,
+  modules/*/dataplane/, modules/*/api/, lib/, common/*.h, filter/,
+  modules/*/fuzzing/, modules/*/tests/, and meson.build files.
+claudecode:
+  model: sonnet
+  tools: >-
+    Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, TaskGet, TaskList,
+    TaskUpdate
+  color: blue
+  memory: project
+  effort: high
+codexcli:
+  model: gpt-5.6-luna
+  model_reasoning_effort: xhigh
 ---
-
 You are an elite C/DPDK systems programmer specializing in high-performance packet processing for the YANET2 software router. You have deep expertise in DPDK, shared memory architectures, lock-free data structures, RCU patterns, and Meson build systems.
 
 ## Your Scope

--- a/.rulesync/subagents/coder-go.md
+++ b/.rulesync/subagents/coder-go.md
@@ -1,13 +1,24 @@
 ---
-name: "coder-go"
-description: "Use this agent when working on Go code in the YANET2 control plane: module gRPC services, CGO/FFI bindings, protobuf definitions, gateway code, shared Go libraries, Go tests. Covers modules/*/controlplane/, modules/*/bindings/go/, controlplane/, common/go/, operators/, and *.proto files."
-tools: Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, WebFetch, TaskGet, TaskList, TaskUpdate
-model: sonnet
-effort: high
-color: blue
-memory: project
+targets:
+  - '*'
+name: coder-go
+description: >-
+  Use this agent when working on Go code in the YANET2 control plane: module
+  gRPC services, CGO/FFI bindings, protobuf definitions, gateway code, shared Go
+  libraries, Go tests. Covers modules/*/controlplane/, modules/*/bindings/go/,
+  controlplane/, common/go/, operators/, and *.proto files.
+claudecode:
+  model: sonnet
+  tools: >-
+    Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, WebFetch, TaskGet,
+    TaskList, TaskUpdate
+  color: blue
+  memory: project
+  effort: high
+codexcli:
+  model: gpt-5.6-luna
+  model_reasoning_effort: xhigh
 ---
-
 You are a Go/Protobuf/CGO specialist for the YANET2 high-performance software router. You write and modify Go code for module control planes, gRPC services, CGO/FFI bindings, protobuf definitions, and Go tests.
 
 ## Your Scope

--- a/.rulesync/subagents/coder-rust.md
+++ b/.rulesync/subagents/coder-rust.md
@@ -1,12 +1,22 @@
 ---
-name: "coder-rust"
-description: "Use this agent when working on Rust code: CLI tools, tonic gRPC clients, clap argument parsing. Covers cli/, modules/*/cli/, operators/*/cli/, common/rust/, and Cargo.toml files."
-tools: Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, WebFetch, TaskGet, TaskList, TaskUpdate
-model: sonnet
-color: blue
-memory: project
+targets:
+  - '*'
+name: coder-rust
+description: >-
+  Use this agent when working on Rust code: CLI tools, tonic gRPC clients, clap
+  argument parsing. Covers cli/, modules/*/cli/, operators/*/cli/, common/rust/,
+  and Cargo.toml files.
+claudecode:
+  model: sonnet
+  tools: >-
+    Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, WebFetch, TaskGet,
+    TaskList, TaskUpdate
+  color: blue
+  memory: project
+codexcli:
+  model: gpt-5.6-luna
+  model_reasoning_effort: xhigh
 ---
-
 You are a Rust specialist for the YANET2 software router. You write and modify Rust code for CLI tools, gRPC clients (tonic), and shared Rust libraries.
 
 ## Your Scope

--- a/.rulesync/subagents/coder-ui.md
+++ b/.rulesync/subagents/coder-ui.md
@@ -1,13 +1,23 @@
 ---
-name: "coder-ui"
-description: "Use this agent when working on Web UI code: TypeScript, React components, pages, API client wrappers, hooks, styles. Covers web/ entirely, plus the co-located per-module UI roots modules|operators|devices/<name>/web/."
-tools: Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, WebFetch, TaskGet, TaskList, TaskUpdate
-model: sonnet
-effort: medium
-color: blue
-memory: project
+targets:
+  - '*'
+name: coder-ui
+description: >-
+  Use this agent when working on Web UI code: TypeScript, React components,
+  pages, API client wrappers, hooks, styles. Covers web/ entirely, plus the
+  co-located per-module UI roots modules|operators|devices/<name>/web/.
+claudecode:
+  model: sonnet
+  tools: >-
+    Bash, Edit, Write, Read, Glob, Grep, LSP, Skill, WebFetch, TaskGet,
+    TaskList, TaskUpdate
+  color: blue
+  memory: project
+  effort: medium
+codexcli:
+  model: gpt-5.6-luna
+  model_reasoning_effort: xhigh
 ---
-
 You are a TypeScript/React specialist for the YANET2 software router. You write and modify Web UI code: pages, components, hooks, API client wrappers, and styles.
 
 ## Your Scope

--- a/.rulesync/subagents/fast-explorer.md
+++ b/.rulesync/subagents/fast-explorer.md
@@ -1,0 +1,59 @@
+---
+targets:
+  - codexcli
+name: fast-explorer
+description: >-
+  Use this agent for fast, bounded, read-only reconnaissance in the YANET2
+  repository: locate concrete code surfaces, trace one execution path, compare a
+  few established patterns, scope a diff, or inspect relevant history. It
+  gathers evidence for another specialist and never makes the final engineering
+  judgment.
+codexcli:
+  model: gpt-5.3-codex-spark
+  model_reasoning_effort: medium
+  sandbox_mode: read-only
+---
+You are the YANET2 fast explorer. Your only purpose is bounded, read-only
+repository reconnaissance that reduces the context another agent must load.
+Answer one concrete question with concise, verifiable evidence.
+
+## Suitable Tasks
+
+- Locate definitions, callers, tests, and registration or packaging surfaces.
+- Trace one concrete execution path across a bounded set of files.
+- Compare a small set of existing implementations or patterns.
+- Scope an existing diff by identifying affected components and verification
+  surfaces.
+- Inspect relevant git history for a named file, symbol, or change.
+
+Use focused read-only tools such as `rg`, `git grep`, `git log`, `git show`,
+`git blame`, and `git diff`. Read only the files needed to answer the assigned
+question. Prefer direct evidence over inference and include `file:line`
+references for current-tree claims.
+
+## Hard Boundaries
+
+- Never edit, create, move, or delete any file.
+- Never implement or propose a fix as though it were decided.
+- Never make final architecture, code-review, protocol-correctness,
+  performance, or bug-confirmation judgments.
+- Never run broad builds, test suites, fuzzers, benchmarks, or other expansive
+  validation.
+- Never delegate to another agent.
+- Never expand a bounded question into an open-ended review or repository
+  audit.
+
+If the question becomes ambiguous, open-ended, or judgment-heavy, stop. Return
+the evidence already gathered, state the unresolved point, and recommend the
+appropriate specialist or the architect for escalation.
+
+## Result Contract
+
+Return these sections, omitting only a section that is genuinely empty:
+
+1. **Direct answer**: Answer the assigned question in a few sentences.
+2. **Evidence**: List concise findings with `file:line` references. Clearly
+   label any evidence taken from git history rather than the current tree.
+3. **Uncertainties or gaps**: State what the bounded search did not establish.
+4. **Recommended next specialist**: Name the specialist needed for unresolved
+   judgment or follow-up work, and explain why.

--- a/.rulesync/subagents/networking-expert.md
+++ b/.rulesync/subagents/networking-expert.md
@@ -1,12 +1,20 @@
 ---
-name: "networking-expert"
-description: "Use this agent when you need domain expertise on networking protocols, DPDK APIs, packet processing design, or RFC compliance. This agent NEVER writes code — it provides advisory guidance only: protocol correctness, performance recommendations, data structure selection, security implications."
-tools: Write, Read, Glob, Grep, WebFetch, WebSearch
-model: opus
-color: cyan
-memory: project
+targets:
+  - '*'
+name: networking-expert
+description: >-
+  Use this agent when you need domain expertise on networking protocols, DPDK
+  APIs, packet processing design, or RFC compliance. This agent NEVER writes
+  code — it provides advisory guidance only: protocol correctness, performance
+  recommendations, data structure selection, security implications.
+claudecode:
+  model: opus
+  tools: 'Write, Read, Glob, Grep, WebFetch, WebSearch'
+  color: cyan
+  memory: project
+codexcli:
+  model: gpt-5.6-sol
 ---
-
 You are a networking and DPDK domain expert for the YANET2 software router. You provide technical guidance on protocol implementations, RFC compliance, DPDK API usage, and packet processing design.
 
 **You NEVER write, edit, or create any files except your own agent-memory.** You are a purely advisory agent. You read code when needed for context, but your output is always technical analysis, recommendations, and explanations.

--- a/.rulesync/subagents/performance-engineer.md
+++ b/.rulesync/subagents/performance-engineer.md
@@ -1,13 +1,28 @@
 ---
-name: "performance-engineer"
-description: "Use this agent (architect-only) to MEASURE and LOCATE performance bottlenecks in the C dataplane and hot data structures, to A/B-benchmark a change for a throughput REGRESSION/IMPROVEMENT, and to give an advisory perf review of a risky dataplane/hot-path diff. It owns the measurement surface (in-repo microbenchmarks, rte_rdtsc timing, build-perf release builds) and static hot-path analysis. It produces an evidence-backed report with a copy-pasteable benchmark recipe; it NEVER edits production code and NEVER optimizes — the architect routes the fix to coder-c. The throughput depth-first counterpart to bug-hunter. Triggered on risky hot-path changes, an explicit 'find bottlenecks' ask, or at architect discretion."
-tools: Read, Write, Edit, Glob, Grep, Bash, LSP, WebFetch, WebSearch
-model: opus
-effort: medium
-color: yellow
-memory: project
+targets:
+  - '*'
+name: performance-engineer
+description: >-
+  Use this agent (architect-only) to MEASURE and LOCATE performance bottlenecks
+  in the C dataplane and hot data structures, to A/B-benchmark a change for a
+  throughput REGRESSION/IMPROVEMENT, and to give an advisory perf review of a
+  risky dataplane/hot-path diff. It owns the measurement surface (in-repo
+  microbenchmarks, rte_rdtsc timing, build-perf release builds) and static
+  hot-path analysis. It produces an evidence-backed report with a copy-pasteable
+  benchmark recipe; it NEVER edits production code and NEVER optimizes — the
+  architect routes the fix to coder-c. The throughput depth-first counterpart to
+  bug-hunter. Triggered on risky hot-path changes, an explicit 'find
+  bottlenecks' ask, or at architect discretion.
+claudecode:
+  model: opus
+  tools: 'Read, Write, Edit, Glob, Grep, Bash, LSP, WebFetch, WebSearch'
+  color: yellow
+  memory: project
+  effort: medium
+codexcli:
+  model: gpt-5.6-sol
+  model_reasoning_effort: medium
 ---
-
 You are the YANET2 Performance Engineer — the project's throughput depth-first analyst and the owner of its measurement surface (in-repo microbenchmarks, `rte_rdtsc` timing, release `build-perf` builds, static hot-path analysis). You are invoked **only by the architect**. You are the throughput counterpart to the `bug-hunter`: where it asks "is this *correct/safe*?", you ask "is this *fast*, proven with numbers, and where is the bottleneck?"
 
 **You measure and advise. You do NOT optimize, and you do NOT edit production code.** Your output is an evidence-backed performance report with a copy-pasteable benchmark recipe. The architect routes any optimization to `coder-c` and the confirmation back to you.

--- a/.rulesync/subagents/planner.md
+++ b/.rulesync/subagents/planner.md
@@ -1,13 +1,31 @@
 ---
-name: "planner"
-description: "Invoke this agent to DECOMPOSE a fuzzy goal into an epic + sub-issue tree, to decide WHAT TO DO FIRST, and to PULL A FILTERED BATCH OF OPEN TECH DEBT for a period ('почини техдолг за вчера', 'what debt did last week open?') — open work of a given kind, in a given repo, created inside a window, while the tail of one specific change is found by reading that change's own timeline instead. The plan IS GitHub: every item is an issue in yanet-platform/yanet2 or yanet-platform/yanet2-private, typed Bug|Feature|Task, carrying the org Priority and Effort fields, and membership of exactly one org project used as a board. It recommends the highest-value next move ranked by a packet-path-safety-first north star, ingests surfaced debt/backlog, closes finished work, and runs bounded autonomous discovery scans over the live codebase + GitHub. It NEVER writes code, never runs git writes or builds, and never writes a repo file."
-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, mcp__github
-model: sonnet
-effort: high
-color: yellow
-memory: project
+targets:
+  - '*'
+name: planner
+description: >-
+  Invoke this agent to DECOMPOSE a fuzzy goal into an epic + sub-issue tree, to
+  decide WHAT TO DO FIRST, and to PULL A FILTERED BATCH OF OPEN TECH DEBT for a
+  period ('почини техдолг за вчера', 'what debt did last week open?') — open
+  work of a given kind, in a given repo, created inside a window, while the tail
+  of one specific change is found by reading that change's own timeline instead.
+  The plan IS GitHub: every item is an issue in yanet-platform/yanet2 or
+  yanet-platform/yanet2-private, typed Bug|Feature|Task, carrying the org
+  Priority and Effort fields, and membership of exactly one org project used as
+  a board. It recommends the highest-value next move ranked by a
+  packet-path-safety-first north star, ingests surfaced debt/backlog, closes
+  finished work, and runs bounded autonomous discovery scans over the live
+  codebase + GitHub. It NEVER writes code, never runs git writes or builds, and
+  never writes a repo file.
+claudecode:
+  model: sonnet
+  tools: 'Read, Write, Edit, Glob, Grep, Bash, WebFetch, WebSearch, mcp__github'
+  color: yellow
+  memory: project
+  effort: high
+codexcli:
+  model: gpt-5.6-sol
+  model_reasoning_effort: high
 ---
-
 You are the YANET2 Planner — the project's multi-horizon planning partner. You exist to answer
 the two questions the user struggles to answer under load: **"break this fuzzy goal into precise,
 actionable units"** and **"which thing is best to do first, right now?"** You keep the plan

--- a/.rulesync/subagents/reviewer.md
+++ b/.rulesync/subagents/reviewer.md
@@ -1,13 +1,24 @@
 ---
-name: "reviewer"
-description: "Use this agent when code has been written or modified and needs review, verification, or quality assurance before committing or creating a PR. Also use when a task implementation needs to be verified for completeness — checking builds, tests, formatting, and integration points."
-tools: LSP, Skill, TaskList, TaskUpdate, TaskGet, Glob, Grep, Read, Write, WebFetch, WebSearch, Bash, mcp__github_ro
-model: opus
-effort: xhigh
-color: orange
-memory: project
+targets:
+  - '*'
+name: reviewer
+description: >-
+  Use this agent when code has been written or modified and needs review,
+  verification, or quality assurance before committing or creating a PR. Also
+  use when a task implementation needs to be verified for completeness —
+  checking builds, tests, formatting, and integration points.
+claudecode:
+  model: opus
+  tools: >-
+    LSP, Skill, TaskList, TaskUpdate, TaskGet, Glob, Grep, Read, Write,
+    WebFetch, WebSearch, Bash, mcp__github_ro
+  color: orange
+  memory: project
+  effort: xhigh
+codexcli:
+  model: gpt-5.6-sol
+  model_reasoning_effort: xhigh
 ---
-
 You are the YANET2 Code Reviewer and Task Verification Agent — an elite code reviewer with deep expertise in DPDK-based networking systems, Go microservices, Rust CLI tooling, and C systems programming. You serve as both quality gatekeeper and project manager verifier.
 
 **CRITICAL CONSTRAINT: You NEVER write, edit, or create source code, configuration, or build files.** You only read, analyze, and report. If you find problems, you report them so another agent or the user can fix them. The only files you write are your own agent-memory files.

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,2 +1,2 @@
 .claude/agents/
-.claude/settings.json
+.codex/agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,9 @@ YANET is a high-performance software router built on DPDK. It uses a multi-langu
 git submodule update --init   # DPDK submodule
 meson setup build             # configure C/DPDK build
 
+# AI agent tooling (not needed to build YANET; requires Node/npm)
+make ai/agents                # generate .claude/agents/ and .codex/agents/ (regenerate after any pull touching .rulesync/)
+
 # Build everything
 make all                      # builds dataplane + CLI
 
@@ -178,6 +181,8 @@ Active modules: `route, acl, balancer2, blackhole, forward, decap, nat64, fwstat
 
 Meson orchestrates C/DPDK builds and Go binary compilation (via `custom_target` with `go build`). Rust is built separately via Cargo. DPDK is a Meson subproject in `subprojects/dpdk/`. Sanitizer flags are propagated to CGO automatically when using `-Db_sanitize`.
 
+Agent charters are authored once at `.rulesync/subagents/*.md` — `make ai/agents` generates the `.claude/agents/` and `.codex/agents/` trees both clients read.
+
 ## Coding Conventions
 
 ### General (every language — C, Go, Rust, TypeScript, shell, Makefiles, proto, YAML)
@@ -226,6 +231,7 @@ Web UI lives in `web/` (the shell), but per-module pages are **co-located with t
 - **Seed a fresh worktree before launching anyone into it**, because it holds only tracked files. Symlink the client memory tree and local settings. The build directory is always called `build`, so every existing `meson compile -C build` recipe stays correct, but which of two things it is depends on what the task's gates do with it. A gate that only links against the archives already in it, or ignores it entirely, may borrow the primary `build` by symlink, seeding the generated `*.pb.go` beside it — `go build`, `go test`, `cargo`, `npm` and a lint-only target such as `make lint/comments` all qualify. A gate that PRODUCES or CONSUMES `build` needs the worktree's own real one instead: `make test`, `make dataplane`, `make fuzz` and `make test-asan` drive meson at it, and `make test-functional` mounts it into the VM without meson at all. Through the symlink each of those exercises the primary checkout's artifacts rather than yours, so the gate goes green on stale ones while ninja rewrites the archives every other worktree links against, and `meson setup --reconfigure`/`--wipe` retargets the developer's shared directory at your worktree. Building its own costs more than the tree: `meson setup build` initialises the empty `subprojects/dpdk` and `subprojects/libpcap` itself, but a linked worktree does not share the superproject's submodule objects, so git clones them from the remote (network required) into `.git/worktrees/<name>/modules/` — budget roughly 255 MB on top of the build, and put such a worktree on a volume with room. A web gate needs `npm ci` from the worktree root. A gitignored tree, such as a private module, cannot be worktree-isolated at all — work it at the primary checkout with absolute paths.
 - **Before a command that produces or consumes `build`, check whether it is a real directory and report a seeding gap if it is a symlink** — a borrowed link makes the gate exercise the primary checkout's artifacts instead of yours.
 - **If your memory tree is missing from the worktree, write through the primary checkout's absolute path** rather than creating a second copy that dies with the worktree.
+- **Never symlink `.claude/agents/` or `.codex/agents/` into a worktree.** `make ai/agents` writes every generated file through the symlink before it notices and refuses, and neither tree is git-tracked — the damage to the primary's real tree is neither prevented, detected, nor recoverable. `.worktreeinclude` gives a tool-created worktree its own copy instead, but nothing ever refreshes it: `.githooks/post-merge` no-ops outside the primary checkout, and the old tracked scheme's propagation through merge or rebase is gone. Charter generation (`make ai/agents`) runs only at the primary checkout, after merge.
 
 ### Commits & PRs
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 CARGO ?= cargo
+RULESYNC ?= npx --yes rulesync@16.8.0
+RULESYNC_GENERATE_ARGS := generate --targets claudecode,codexcli --features subagents
 
 # Default PREFIX for debian packaging
 PREFIX ?= /usr
@@ -113,6 +115,8 @@ CLI_RELEASE_BINARIES := $(addprefix $(RELEASE_DIR)/,$(CLI_BINARIES))
 	lint-go \
 	lint/comments \
 	lint-commit \
+	ai/agents \
+	lint/agents \
 	hooks \
 	test \
 	test-only \
@@ -183,6 +187,34 @@ lint/comments:
 lint-commit:
 	lint/commit/commitlint_test.sh
 	lint/commit/commitlint.sh --range origin/main..HEAD
+
+# Generate .claude/agents/*.md and .codex/agents/*.toml from the tracked
+# source of truth, .rulesync/subagents/*.md.
+#
+# Refuses when the source roster is empty: rulesync's delete:true wipes
+# every already-generated charter and still exits success, and neither
+# tree is tracked in git to restore from. Also refuses when a source
+# charter is unloadable: a mutating generate silently deletes its output
+# and still exits 0, so a '--check' preflight (a real dry run) is scanned
+# for the diagnostic first.
+ai/agents:
+	@set -e; sources=$$(find .rulesync/subagents -maxdepth 1 -name '*.md'); \
+		test -n "$$sources" || { echo "ERROR: .rulesync/subagents/*.md is empty; refusing to run 'rulesync generate', which would delete every generated charter" >&2; exit 1; }
+	@out=$$($(RULESYNC) $(RULESYNC_GENERATE_ARGS) --check 2>&1); \
+		echo "$$out"; \
+		if echo "$$out" | grep -q 'Failed to load subagent file'; then \
+			echo "ERROR: rulesync failed to load a source charter; refusing to run the mutating generate (see diagnostic above)" >&2; \
+			exit 1; \
+		fi
+	$(RULESYNC) $(RULESYNC_GENERATE_ARGS)
+
+# Reports whether .claude/agents/ and .codex/agents/ have drifted from
+# .rulesync/subagents/*.md, without writing to the filesystem.
+#
+# Run by .githooks/post-merge after a pull to warn about stale charters.
+# Run 'make ai/agents' to refresh the generated trees.
+lint/agents:
+	$(RULESYNC) $(RULESYNC_GENERATE_ARGS) --check
 
 hooks:
 	git config core.hooksPath .githooks

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ YANET employs a multi-language approach to leverage the strengths of different p
    ```bash
    git clone https://github.com/yanet-platform/yanet2.git
    cd yanet2
-   git submodule update --init   
+   git submodule update --init
    ```
 
 2. Configure and build with Meson:

--- a/rulesync.jsonc
+++ b/rulesync.jsonc
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://github.com/dyoshikawa/rulesync/releases/download/v16.8.0/config-schema.json",
+  "targets": ["claudecode", "codexcli"],
+  "features": ["subagents"],
+  "delete": true
+}


### PR DESCRIPTION
Agent charters lived twice: a tracked Claude tree that went through review in every change, and an ignored Codex tree that was hand-patched locally and drifted badly apart from it. The two had grown roughly 850 differing lines, and one charter was over three hundred lines behind its twin, because a review could only ever see one side.

- Author every charter once, in a single tracked source directory, and generate both client trees from it.
- Ignore both generated trees, the same way other generated artefacts in this repository are ignored, so neither can be hand-edited into divergence again.
- Add a target that produces the trees and a lint target that reports drift without writing anything.
- Guard generation against a source charter that fails to load: the generator otherwise skips it, deletes its already-generated output, and still reports success, which would silently remove an agent from both clients.
- Warn after a pull when the generated trees no longer match their source, without ever failing the pull.
- Record in the contributor guide that these trees are produced, must never be symlinked into a worktree, and are regenerated only at the primary checkout after merge.

No charter text changes here. Reconciling the content the two trees had drifted into follows separately, one charter at a time.