### PR TITLE
chore(ci): migrate off deprecated actions/cache@v3

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
       - name: Set up go cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.modcache }}

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -55,7 +55,7 @@ jobs:
           echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
 
       - name: Set up go cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.modcache }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
 
       - name: Set up go cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.modcache }}
@@ -131,7 +131,7 @@ jobs:
           echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
 
       - name: Set up go cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.modcache }}
@@ -202,7 +202,7 @@ jobs:
           echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
 
       - name: Set up go cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.modcache }}
@@ -308,7 +308,7 @@ jobs:
           echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
 
       - name: Set up go cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.modcache }}


### PR DESCRIPTION
GitHub is force-migrating the deprecated v3 cache action off its Node 20 runners. Once that lands, every job still on it stops restoring and writing its Go module cache without any change on our side — a live time bomb rather than a hypothetical one.

- Bumps the six remaining v3 cache references to v4, across the four heavy build jobs, the deb build, and the image build.
- Leaves cache paths, keys, and restore-key ladders byte-identical, so the existing key namespace is preserved. No step opts into failing on a cache miss, so the worst case is one cold miss that heals on the next save.
- Keeps the repository's bare-tag convention rather than introducing SHA pinning, matching the eight cache references that were already on v4.

Verified that no changed step uses an input whose meaning differs between the two major versions, and that every affected job runs directly on a hosted runner with no container, so there is no new runtime exposure. Two of the three files exercise the bumped steps on this pull request itself. The image workflow triggers only on release tags and manual dispatch, so its step first runs after merge — the edit is identical in shape to the validated ones, and that workflow already runs v4 in an adjacent step.

Closes #1786.