### PR TITLE
chore(ci): repair the dead cache restore-key ladders in the deb build path

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -84,10 +84,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}-${{ matrix.unbtver }}
+          key: ${{ runner.os }}-${{ matrix.unbtver }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ matrix.unbtver }}
-            ${{ runner.os }}-cargo-${{ matrix.unbtver }}
+            ${{ runner.os }}-${{ matrix.unbtver }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-${{ matrix.unbtver }}-cargo-
 
       - name: Install packaging tools
         run: |
@@ -107,9 +107,10 @@ jobs:
         with:
           path: |
             ${{ env.modcache }}
-          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}-${{ matrix.unbtver }}
+          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
-            ${{ env.cache_name }}-${{ runner.os }}-go-${{ matrix.unbtver }}
+            ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
+            ${{ env.cache_name }}-${{ runner.os }}-go-
       - name: Install Go Protobuf Plugins
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -36,7 +36,10 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-24.04
+          key: ${{ runner.os }}-24.04-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-24.04-cargo-${{ hashFiles('**/Cargo.lock') }}-
+            ${{ runner.os }}-24.04-cargo-
 
       - name: Install packaging tools
         run: |
@@ -59,9 +62,10 @@ jobs:
         with:
           path: |
             ${{ env.modcache }}
-          key: deb-build-24.04-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}-24.04
+          key: deb-build-24.04-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
-            deb-build-24.04-${{ runner.os }}-go-24.04
+            deb-build-24.04-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
+            deb-build-24.04-${{ runner.os }}-go-
 
       - name: Install Go Protobuf Plugins
         run: |


### PR DESCRIPTION
The deb and image build paths appended the Ubuntu version after the dependency hashes in their Go and Cargo cache keys. Restore keys match by prefix, and the hashes sit strictly between the shared prefix and that trailing version, so no fallback rung could ever be formed. Every miss on the exact key was therefore a full cold miss instead of a partial restore, on the longest job in CI.

Fixed by applying one rule at all four sites: the variable-length hash components come last, and any discriminator sits ahead of them. Each cache then gets the same two-level fallback the main build workflow already uses.

- Moved the Ubuntu discriminator ahead of the hashes in both Cargo caches, keeping the two Ubuntu releases partitioned so they never share a target directory.
- Dropped the redundant trailing Ubuntu version from the Go cache key in the deb workflow, since the cache name already carries it.
- Added the missing fallback ladder to the image workflow's Cargo cache, and aligned its key with the deb workflow so the two genuinely share one namespace as intended.

Also removes a pre-existing hazard in the opposite direction: the release build's bare Cargo fallback could previously restore a target directory built on a different Ubuntu release.

Verified by rendering every cache key and rung in the repository and asserting each rung is a real prefix of its key, for both Ubuntu values, plus a cross-entry collision matrix in both directions. The same check reports the four sites as dead before the change.

Closes #1800.