### PR TITLE
feat(controlplane): expose per-agent shared-memory arena utilization as metrics

### DIFF
--- a/controlplane/builtin/memory.go
+++ b/controlplane/builtin/memory.go
@@ -1,0 +1,152 @@
+package builtin
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	ynpb "github.com/yanet-platform/yanet2/controlplane/ynpb/v1"
+)
+
+// Memory is an in-process gRPC service for reporting per-agent
+// shared-memory arena utilization.
+type Memory struct {
+	ynpb.UnimplementedMemoryServiceServer
+
+	instanceID uint32
+	shm        *ffi.SharedMemory
+}
+
+// NewMemory creates a new Memory service.
+func NewMemory(instanceID uint32, shm *ffi.SharedMemory) *Memory {
+	return &Memory{
+		instanceID: instanceID,
+		shm:        shm,
+	}
+}
+
+// Name returns the service name.
+func (m *Memory) Name() string { return "memory" }
+
+// Endpoint returns empty string indicating in-process service.
+func (m *Memory) Endpoint() string { return "" }
+
+// ServicesNames returns the gRPC service names served by this service.
+func (m *Memory) ServicesNames() []string { return []string{"controlplane.ynpb.v1.MemoryService"} }
+
+// RegisterService registers the service on the given gRPC server.
+func (m *Memory) RegisterService(server *grpc.Server) {
+	ynpb.RegisterMemoryServiceServer(server, m)
+}
+
+// ListArenas returns arena utilization for every agent generation.
+func (m *Memory) ListArenas(
+	ctx context.Context,
+	request *ynpb.ListArenasRequest,
+) (*ynpb.ListArenasResponse, error) {
+	dpConfig := m.shm.DPConfig(m.instanceID)
+	agents := dpConfig.Agents()
+
+	arenas := make([]*ynpb.ArenaInfo, 0)
+	for _, agent := range agents {
+		for genIdx, instance := range agent.Instances {
+			arenas = append(arenas, &ynpb.ArenaInfo{
+				Agent:       agent.Name,
+				Generation:  instance.Gen,
+				Pid:         instance.PID,
+				MemoryLimit: instance.MemoryLimit,
+				FreeBytes:   instance.FreeBytes,
+				Retired:     genIdx > 0,
+			})
+		}
+	}
+
+	return &ynpb.ListArenasResponse{Arenas: arenas}, nil
+}
+
+// Collect returns arena occupancy and memory-context attribution gauges
+// for every agent.
+//
+// The free-byte count is the authoritative measure of how full an arena
+// is: the buddy allocator behind the memory-context tree rounds each
+// request up to a pool size, and an out-of-order module teardown can
+// drop a live subtree from the tree walk, so the tree is attribution
+// only.
+func (m *Memory) Collect() []*commonpb.Metric {
+	dpConfig := m.shm.DPConfig(m.instanceID)
+	return MemoryMetrics(dpConfig.Agents())
+}
+
+// MemoryMetrics converts a shared-memory agent snapshot into gauges.
+func MemoryMetrics(agents []ffi.AgentInfo) []*commonpb.Metric {
+	metrics := make([]*commonpb.Metric, 0)
+
+	for _, agent := range agents {
+		if len(agent.Instances) == 0 {
+			continue
+		}
+
+		live := agent.Instances[0]
+		agentLabel := commonpb.NewLabel("agent", agent.Name)
+
+		var retiredBytes uint64
+		for _, instance := range agent.Instances[1:] {
+			retiredBytes += instance.MemoryLimit
+		}
+
+		metrics = append(metrics,
+			commonpb.NewMetricGauge("memory_arena_limit_bytes", float64(live.MemoryLimit), agentLabel),
+			commonpb.NewMetricGauge("memory_arena_free_bytes", float64(live.FreeBytes), agentLabel),
+			commonpb.NewMetricGauge("memory_retired_arena_bytes", float64(retiredBytes), agentLabel),
+		)
+		metrics = append(metrics, contextUsedMetrics(agent.Name, live.MemoryTree)...)
+	}
+
+	return metrics
+}
+
+// contextUsedMetrics builds the per-context-path attribution gauge from
+// one agent generation's memory-context tree.
+//
+// Each series is keyed by a node's full path from the root, not by name
+// and parent alone, so same-named leaves under different module configs
+// stay distinguishable. Nodes that still resolve to an identical path
+// are summed into one series instead of being emitted as duplicates,
+// which a scraper would otherwise reject.
+func contextUsedMetrics(agent string, tree []ffi.AgentMemoryNode) []*commonpb.Metric {
+	paths := make([]string, len(tree))
+	used := make(map[string]uint64, len(tree))
+	order := make([]string, 0, len(tree))
+
+	for idx, node := range tree {
+		path := "/" + node.Name
+		if int(node.ParentIdx) < idx {
+			path = paths[node.ParentIdx] + "/" + node.Name
+		}
+		paths[idx] = path
+
+		var nodeUsed uint64
+		if node.BAllocSize > node.BFreeSize {
+			nodeUsed = node.BAllocSize - node.BFreeSize
+		}
+
+		if _, ok := used[path]; !ok {
+			order = append(order, path)
+		}
+		used[path] += nodeUsed
+	}
+
+	metrics := make([]*commonpb.Metric, 0, len(order))
+	for _, path := range order {
+		metrics = append(metrics, commonpb.NewMetricGauge(
+			"memory_context_used_bytes",
+			float64(used[path]),
+			commonpb.NewLabel("agent", agent),
+			commonpb.NewLabel("path", path),
+		))
+	}
+
+	return metrics
+}

--- a/controlplane/builtin/memory_test.go
+++ b/controlplane/builtin/memory_test.go
@@ -1,0 +1,286 @@
+package builtin_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/builtin"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+)
+
+func findMetric(t *testing.T, metrics []*commonpb.Metric, name string, labels map[string]string) *commonpb.Metric {
+	t.Helper()
+
+	for _, metric := range metrics {
+		if metric.GetName() != name {
+			continue
+		}
+
+		match := true
+		for _, label := range metric.GetLabels() {
+			if want, ok := labels[label.GetName()]; ok && want != label.GetValue() {
+				match = false
+				break
+			}
+		}
+		if match && len(metric.GetLabels()) == len(labels) {
+			return metric
+		}
+	}
+
+	return nil
+}
+
+func gaugeValue(t *testing.T, metric *commonpb.Metric) float64 {
+	t.Helper()
+
+	require.NotNil(t, metric)
+	return metric.GetGauge()
+}
+
+// TestMemoryMetricsContextPathResolution verifies that the root node of
+// the memory-context tree resolves to a path of just its own name and
+// that a child node resolves to its full ancestry chain.
+func TestMemoryMetricsContextPathResolution(t *testing.T) {
+	agents := []ffi.AgentInfo{
+		{
+			Name: "acl",
+			Instances: []ffi.AgentInstanceInfo{
+				{
+					MemoryTree: []ffi.AgentMemoryNode{
+						{Name: "acl", ParentIdx: math.MaxUint32, BAllocSize: 100},
+						{Name: "acl-in", ParentIdx: 0, BAllocSize: 60},
+						{Name: "filter", ParentIdx: 1, BAllocSize: 40},
+						{Name: "net6-nets", ParentIdx: 2, BAllocSize: 10},
+					},
+				},
+			},
+		},
+	}
+
+	metrics := builtin.MemoryMetrics(agents)
+
+	root := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/acl"})
+	require.Equal(t, float64(100), gaugeValue(t, root))
+
+	leaf := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/acl/acl-in/filter/net6-nets"})
+	require.Equal(t, float64(10), gaugeValue(t, leaf))
+}
+
+// TestMemoryMetricsContextDistinguishesSiblingSubtrees verifies that
+// same-named leaves under different module-config subtrees produce
+// distinct series.
+func TestMemoryMetricsContextDistinguishesSiblingSubtrees(t *testing.T) {
+	agents := []ffi.AgentInfo{
+		{
+			Name: "acl",
+			Instances: []ffi.AgentInstanceInfo{
+				{
+					MemoryTree: []ffi.AgentMemoryNode{
+						{Name: "acl", ParentIdx: math.MaxUint32},
+						{Name: "acl-in", ParentIdx: 0},
+						{Name: "filter", ParentIdx: 1},
+						{Name: "net6-nets", ParentIdx: 2, BAllocSize: 10},
+						{Name: "acl-out", ParentIdx: 0},
+						{Name: "filter", ParentIdx: 4},
+						{Name: "net6-nets", ParentIdx: 5, BAllocSize: 25},
+					},
+				},
+			},
+		},
+	}
+
+	metrics := builtin.MemoryMetrics(agents)
+
+	inLeaf := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/acl/acl-in/filter/net6-nets"})
+	require.Equal(t, float64(10), gaugeValue(t, inLeaf))
+
+	outLeaf := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/acl/acl-out/filter/net6-nets"})
+	require.Equal(t, float64(25), gaugeValue(t, outLeaf))
+}
+
+// TestMemoryMetricsContextClampsUnderflow verifies that a torn snapshot
+// where BFreeSize exceeds BAllocSize publishes a zero gauge instead of the
+// unsigned-subtraction wraparound value.
+func TestMemoryMetricsContextClampsUnderflow(t *testing.T) {
+	agents := []ffi.AgentInfo{
+		{
+			Name: "acl",
+			Instances: []ffi.AgentInstanceInfo{
+				{
+					MemoryTree: []ffi.AgentMemoryNode{
+						{Name: "root", ParentIdx: math.MaxUint32, BAllocSize: 10, BFreeSize: 20},
+					},
+				},
+			},
+		},
+	}
+
+	metrics := builtin.MemoryMetrics(agents)
+
+	used := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/root"})
+	require.Equal(t, float64(0), gaugeValue(t, used))
+}
+
+// TestMemoryMetricsRetiredArenaBytes verifies that only the live generation
+// feeds the arena limit gauge, that retired generations are summed into
+// their own gauge, and that a single-generation agent still emits a
+// present, zero-valued retired gauge.
+func TestMemoryMetricsRetiredArenaBytes(t *testing.T) {
+	agents := []ffi.AgentInfo{
+		{
+			Name: "acl",
+			Instances: []ffi.AgentInstanceInfo{
+				{MemoryLimit: 1000, FreeBytes: 700},
+				{MemoryLimit: 200},
+				{MemoryLimit: 300},
+			},
+		},
+		{
+			Name: "decap",
+			Instances: []ffi.AgentInstanceInfo{
+				{MemoryLimit: 500, FreeBytes: 500},
+			},
+		},
+	}
+
+	metrics := builtin.MemoryMetrics(agents)
+
+	limit := findMetric(t, metrics, "memory_arena_limit_bytes", map[string]string{"agent": "acl"})
+	require.Equal(t, float64(1000), gaugeValue(t, limit))
+
+	free := findMetric(t, metrics, "memory_arena_free_bytes", map[string]string{"agent": "acl"})
+	require.Equal(t, float64(700), gaugeValue(t, free))
+
+	retired := findMetric(t, metrics, "memory_retired_arena_bytes", map[string]string{"agent": "acl"})
+	require.Equal(t, float64(500), gaugeValue(t, retired))
+
+	singleGenRetired := findMetric(t, metrics, "memory_retired_arena_bytes", map[string]string{"agent": "decap"})
+	require.Equal(t, float64(0), gaugeValue(t, singleGenRetired))
+}
+
+// TestMemoryMetricsNonDecreasingParentResolvesToRoot verifies that a node
+// whose ParentIdx is not strictly less than its own index -- out of
+// range, equal to its own index, greater than its own index, or the
+// math.MaxUint32 sentinel -- is treated as a root instead of panicking
+// or hanging, guarding against a torn best-effort snapshot.
+func TestMemoryMetricsNonDecreasingParentResolvesToRoot(t *testing.T) {
+	agents := []ffi.AgentInfo{
+		{
+			Name: "acl",
+			Instances: []ffi.AgentInstanceInfo{
+				{
+					MemoryTree: []ffi.AgentMemoryNode{
+						{Name: "out-of-range", ParentIdx: 99, BAllocSize: 10},
+						{Name: "self-ref", ParentIdx: 1, BAllocSize: 20},
+						{Name: "forward-ref", ParentIdx: 3, BAllocSize: 30},
+						{Name: "target", ParentIdx: math.MaxUint32, BAllocSize: 40},
+					},
+				},
+			},
+		},
+	}
+
+	var metrics []*commonpb.Metric
+	require.NotPanics(t, func() {
+		metrics = builtin.MemoryMetrics(agents)
+	})
+
+	outOfRange := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/out-of-range"})
+	require.Equal(t, float64(10), gaugeValue(t, outOfRange))
+
+	selfRef := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/self-ref"})
+	require.Equal(t, float64(20), gaugeValue(t, selfRef))
+
+	forwardRef := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/forward-ref"})
+	require.Equal(t, float64(30), gaugeValue(t, forwardRef))
+
+	target := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/target"})
+	require.Equal(t, float64(40), gaugeValue(t, target))
+}
+
+// TestMemoryMetricsContextAggregatesDuplicateLabels verifies that sibling
+// nodes sharing a name under the same parent resolve to an identical
+// path and are summed into a single series instead of being emitted as
+// duplicates under the same label set.
+func TestMemoryMetricsContextAggregatesDuplicateLabels(t *testing.T) {
+	agents := []ffi.AgentInfo{
+		{
+			Name: "acl",
+			Instances: []ffi.AgentInstanceInfo{
+				{
+					MemoryTree: []ffi.AgentMemoryNode{
+						{Name: "root", ParentIdx: math.MaxUint32, BAllocSize: 100},
+						{Name: "filter", ParentIdx: 0, BAllocSize: 30},
+						{Name: "filter", ParentIdx: 0, BAllocSize: 20},
+					},
+				},
+			},
+		},
+	}
+
+	metrics := builtin.MemoryMetrics(agents)
+
+	var seriesCount int
+	for _, metric := range metrics {
+		if metric.GetName() == "memory_context_used_bytes" {
+			seriesCount++
+		}
+	}
+	require.Equal(t, 2, seriesCount)
+
+	filter := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/root/filter"})
+	require.Equal(t, float64(50), gaugeValue(t, filter))
+}
+
+// TestMemoryMetricsContextClampsBeforeAggregating verifies that each
+// sibling is clamped to zero on underflow before the sum, so an
+// underflowing sibling cannot cancel a healthy one's contribution.
+func TestMemoryMetricsContextClampsBeforeAggregating(t *testing.T) {
+	agents := []ffi.AgentInfo{
+		{
+			Name: "acl",
+			Instances: []ffi.AgentInstanceInfo{
+				{
+					MemoryTree: []ffi.AgentMemoryNode{
+						{Name: "root", ParentIdx: math.MaxUint32, BAllocSize: 100},
+						{Name: "filter", ParentIdx: 0, BAllocSize: 100, BFreeSize: 0},
+						{Name: "filter", ParentIdx: 0, BAllocSize: 10, BFreeSize: 40},
+					},
+				},
+			},
+		},
+	}
+
+	metrics := builtin.MemoryMetrics(agents)
+
+	filter := findMetric(t, metrics, "memory_context_used_bytes",
+		map[string]string{"agent": "acl", "path": "/root/filter"})
+	require.Equal(t, float64(100), gaugeValue(t, filter))
+}
+
+// TestMemoryMetricsSkipsAgentWithNoInstances verifies that an agent whose
+// Instances slice is empty is skipped rather than indexed into.
+func TestMemoryMetricsSkipsAgentWithNoInstances(t *testing.T) {
+	agents := []ffi.AgentInfo{
+		{Name: "empty"},
+	}
+
+	require.NotPanics(t, func() {
+		metrics := builtin.MemoryMetrics(agents)
+		require.Empty(t, metrics)
+	})
+}

--- a/controlplane/yncp/director.go
+++ b/controlplane/yncp/director.go
@@ -130,6 +130,9 @@ func NewDirector(cfg *Config, options ...DirectorOption) (*Director, error) {
 		gateway.WithBuiltinService(
 			builtin.NewDevice(cfg.Gateway.InstanceID, shm),
 		),
+		gateway.WithBuiltinService(
+			builtin.NewMemory(cfg.Gateway.InstanceID, shm),
+		),
 		gateway.WithLog(log),
 		gateway.WithAtomicLogLevel(opts.LogLevel),
 	}

--- a/controlplane/ynpb/meson.build
+++ b/controlplane/ynpb/meson.build
@@ -14,6 +14,7 @@ ynpb_proto_files = [
     join_paths(ynpb_dir, 'v1', 'auth.proto'),
     join_paths(ynpb_dir, 'v1', 'readiness.proto'),
     join_paths(ynpb_dir, 'v1', 'metrics.proto'),
+    join_paths(ynpb_dir, 'v1', 'memory.proto'),
 ]
 
 # Generate protobuf files
@@ -42,6 +43,8 @@ ynpb_gen = custom_target(
         'readiness_grpc.pb.go',
         'metrics.pb.go',
         'metrics_grpc.pb.go',
+        'memory.pb.go',
+        'memory_grpc.pb.go',
     ],
     input: ynpb_proto_files,
     command: [

--- a/controlplane/ynpb/v1/memory.proto
+++ b/controlplane/ynpb/v1/memory.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package controlplane.ynpb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/controlplane/ynpb/v1;ynpb";
+
+// MemoryService reports per-agent shared-memory arena utilization.
+//
+// It is the read side of a planned arena grow/shrink API: the sizing
+// decisions that API will make depend on the occupancy this service
+// already exposes.
+service MemoryService {
+  // ListArenas returns arena utilization for every agent generation.
+  rpc ListArenas(ListArenasRequest) returns (ListArenasResponse);
+}
+
+message ListArenasRequest {}
+
+message ListArenasResponse { repeated ArenaInfo arenas = 1; }
+
+// ArenaInfo describes one agent generation's shared-memory arena.
+//
+// It deliberately excludes the memory-context tree already exposed by
+// InspectService.Inspect, to avoid a second source of truth for it.
+message ArenaInfo {
+  string agent = 1;
+  uint64 generation = 2;
+  uint32 pid = 3;
+  uint64 memory_limit = 4;
+  uint64 free_bytes = 5;
+  // retired is true for a superseded generation still holding its arena.
+  bool retired = 6;
+}


### PR DESCRIPTION
Shared-memory exhaustion is a real failure mode that had no signal at any layer. Route tables grow with the global BGP table and ACL rulesets grow, so an agent can approach its memory limit with nothing reporting how full the arena is or which subsystem is consuming it.

- Add a platform-level memory service that reports arena occupancy and per-subsystem attribution for every agent of the instance, reusing the memory-context tree the info API already exports rather than introducing a second walk.
- Emit the figures through the gateway's existing metrics service, so the generic metrics command surfaces them alongside the server metrics with no client change.
- Serve an arena listing over the new service as well, giving a planned arena grow and shrink API its read side. It deliberately omits the context tree, which the inspect API already carries.

Occupancy and attribution are separate metric families on purpose. The allocator rounds every request up to a pool size and an out-of-order teardown can drop a live subtree from the walk, so the free-byte count is authoritative for how full an arena is, while the context tree only attributes what is inside it.

Attribution is keyed by each context's full path from the root. An agent holds one context per named module configuration, so a name-and-parent key collapsed same-named leaves from different configurations onto one series and made the most useful question unanswerable. Contexts that still resolve to an identical path are summed, because sibling contexts can share a hardcoded name and names truncate to a fixed length, and a duplicate label set costs a scraper the entire scrape rather than just the affected series. Naming those contexts distinctly is tracked in #1801.

Arena figures cover the live generation, with superseded generations reported separately so a stalled reclamation stays visible. Labels are limited to the agent and the context path, keeping the series set bounded by configuration.

Closes #1731.