### PR TITLE
feat(counters): expose kind tag through the counters cli

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -155,7 +155,9 @@ yanet_get_counter_values(
 // value.
 //
 // Recognized keys are "device", "pipeline", "function", "chain",
-// "module_type", "module_name".
+// "module_type", "module_name", and "kind". The "kind" value names the
+// owner level: "device", "pipeline", "function", "chain", "module", or
+// "object".
 //
 // A tag is rejected with err filled and NULL returned if any of the
 // following holds: key is NULL; value is NULL; key is unrecognized;

--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -56,6 +56,10 @@ pub struct ByTagsCmd {
     pub module_type: Option<String>,
     #[arg(short = 'm', long)]
     pub module_name: Option<String>,
+    /// Owner level to filter by (device, pipeline, function, chain, module,
+    /// object).
+    #[arg(long)]
+    pub kind: Option<String>,
 }
 
 impl From<ByTagsCmd> for CountersByTagsRequest {
@@ -85,6 +89,9 @@ impl From<ByTagsCmd> for CountersByTagsRequest {
                 key: "module_name".to_string(),
                 value,
             });
+        }
+        if let Some(value) = cmd.kind {
+            tags.push(CounterTag { key: "kind".to_string(), value });
         }
 
         Self { tags, query: cmd.names }


### PR DESCRIPTION
- Document the kind tag as a recognized counter tag key in the public C contract, including its owner-level values (device, pipeline, function, chain, module, object).
- Add a --kind flag to yanet-cli counters so the owner level is requestable through the documented CLI surface rather than only through the generic by-tags path.

Follow-up to #1811.