### PR TITLE
perf(ci): build binary-only deb packages

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -80,8 +80,11 @@ apt-get update
 ) 2>&1 | tee build-deps.log
 
 echo "Current PATH during build: $PATH" > build-path.log
+# Build binary-only, skipping the source package. Nothing downstream consumes
+# it, and every path takes only the resulting .deb and .ddeb files. Skipping
+# it also avoids xz-compressing the whole working tree, DPDK submodule included.
 # Preserve environment variables for cargo (order matters in dpkg-buildpackage)
-echo y | debuild --preserve-envvar=PATH -us -uc 2>&1 | tee build.log 
+echo y | debuild --preserve-envvar=PATH -us -uc -b 2>&1 | tee build.log
 
 mkdir -p outdeb
 dcmd cp ../*.changes outdeb/


### PR DESCRIPTION
The packaging build ran a full build, so it assembled a source package — an xz-compressed tarball of the entire working tree, DPDK and libpcap submodules included — before it ever got to the binaries. Building binary-only skips that step outright.

Nothing downstream consumed it. All three invokers of the packaging script take only the resulting binary packages: both workflows upload just the deb and ddeb globs, the release job copies only debs out of those artifacts, the image build copies per-component debs into its Dockerfiles, and the local Docker target reads nothing else. The source artifact was produced and thrown away on every run.

Binary output is unchanged. Binary-only drives the same packaging rules targets as a full build, so the same nine packages and eight debug-symbol packages come out, and the changes filename it is collected under keeps the same architecture-suffixed form.

The removed step cost 19.3 s, 26.7 s and 27.4 s across the three most recent runs on main, measured between the source-package step and the start of the build rules. It scales with repository and submodule size rather than package size, on the job that sets the pull-request wall clock.

Closes #1779.