### PR TITLE
chore(ci): share one Go module cache key across the build jobs

### DIFF
--- a/.github/actions/go-modcache/action.yml
+++ b/.github/actions/go-modcache/action.yml
@@ -1,0 +1,43 @@
+name: 'Go module cache (restore)'
+description: >-
+  Restore the shared Go module cache under one key common to every Linux job,
+  so the same modules are stored once. These jobs turn setup-go's own cache
+  off and manage GOMODCACHE by hand because that cache bundles the build
+  cache with the module cache under a key no job can discriminate
+  (actions/setup-go#358). Restore-only: exactly one job saves under this key,
+  see the "Save Go module cache" step in build.yml.
+
+outputs:
+  path:
+    description: 'Resolved GOMODCACHE directory'
+    value: ${{ steps.resolve.outputs.path }}
+  key:
+    description: 'Exact cache key for the current go.sum/go.mod'
+    value: ${{ steps.resolve.outputs.key }}
+  cache-hit:
+    description: 'True only on an exact-key match, false on a restore-keys fallback or a miss'
+    value: ${{ steps.restore.outputs.cache-hit }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Resolve the module cache location
+      id: resolve
+      shell: bash
+      env:
+        CACHE_KEY: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
+      run: |
+        set -euo pipefail
+        path=$(go env GOMODCACHE)
+        echo "path=$path" >>"$GITHUB_OUTPUT"
+        echo "key=$CACHE_KEY" >>"$GITHUB_OUTPUT"
+
+    - name: Restore the module cache
+      id: restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.resolve.outputs.path }}
+        key: ${{ steps.resolve.outputs.key }}
+        restore-keys: |
+          ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}-
+          ${{ runner.os }}-go-mod-

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -48,8 +48,6 @@ jobs:
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
 
     runs-on: ubuntu-${{ matrix.unbtver }}
-    env:
-      cache_name: deb-build-${{ matrix.unbtver }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -98,19 +96,8 @@ jobs:
           go-version: "1.24.x"
           cache: false
           check-latest: true
-      # https://github.com/actions/setup-go/issues/358
-      - name: Get Go environment
-        run: |
-          echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
-      - name: Set up go cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.modcache }}
-          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
-            ${{ env.cache_name }}-${{ runner.os }}-go-
+      - name: Restore Go module cache
+        uses: ./.github/actions/go-modcache
       - name: Install Go Protobuf Plugins
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -52,20 +52,8 @@ jobs:
           cache: false
           check-latest: true
 
-      # https://github.com/actions/setup-go/issues/358
-      - name: Get Go environment
-        run: |
-          echo "modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
-
-      - name: Set up go cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.modcache }}
-          key: deb-build-24.04-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            deb-build-24.04-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
-            deb-build-24.04-${{ runner.os }}-go-
+      - name: Restore Go module cache
+        uses: ./.github/actions/go-modcache
 
       - name: Install Go Protobuf Plugins
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
       - "**/Cargo.lock"
       - ".github/workflows/build.yml"
       - ".github/actions/apt-packages/**"
+      - ".github/actions/go-modcache/**"
   pull_request:
     branches: ["main"]
     paths:
@@ -31,6 +32,7 @@ on:
       - "**/Cargo.lock"
       - ".github/workflows/build.yml"
       - ".github/actions/apt-packages/**"
+      - ".github/actions/go-modcache/**"
 
 concurrency:
   # The run_id fallback keeps non-PR runs from cancelling each other.
@@ -40,8 +42,6 @@ concurrency:
 jobs:
   build-asan-test:
     runs-on: ubuntu-24.04
-    env:
-      cache_name: build-asan-test
 
     steps:
       - uses: actions/checkout@v4
@@ -66,19 +66,8 @@ jobs:
           cache: false
           check-latest: true
 
-      - name: Get Go environment
-        run: |
-          echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
-
-      - name: Set up go cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.modcache }}
-          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
-            ${{ env.cache_name }}-${{ runner.os }}-go-
+      - name: Restore Go module cache
+        uses: ./.github/actions/go-modcache
 
       - name: Install Go Protobuf Plugins
         run: |
@@ -100,8 +89,6 @@ jobs:
 
   build-tsan-test:
     runs-on: ubuntu-24.04
-    env:
-      cache_name: build-tsan-test
 
     steps:
       - uses: actions/checkout@v4
@@ -126,19 +113,8 @@ jobs:
           cache: false
           check-latest: true
 
-      - name: Get Go environment
-        run: |
-          echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
-
-      - name: Set up go cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.modcache }}
-          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
-            ${{ env.cache_name }}-${{ runner.os }}-go-
+      - name: Restore Go module cache
+        uses: ./.github/actions/go-modcache
 
       - name: Install Go Protobuf Plugins
         run: |
@@ -154,8 +130,6 @@ jobs:
 
   build-release-artifacts:
     runs-on: ubuntu-24.04
-    env:
-      cache_name: build-release-artifacts
 
     steps:
       - uses: actions/checkout@v4
@@ -197,19 +171,9 @@ jobs:
           cache: false
           check-latest: true
 
-      - name: Get Go environment
-        run: |
-          echo "modcache=$(go env GOMODCACHE)" >>$GITHUB_ENV
-
-      - name: Set up go cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ${{ env.modcache }}
-          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-
-            ${{ env.cache_name }}-${{ runner.os }}-go-
+      - name: Restore Go module cache
+        id: go-modcache
+        uses: ./.github/actions/go-modcache
 
       - name: Install Go Protobuf Plugins
         run: |
@@ -228,6 +192,19 @@ jobs:
       - name: Show meson test log
         if: always()
         run: grep -v 'Inherited environment' build/meson-logs/testlog.txt || true
+
+      # This job is the designated writer of the shared Go module cache key:
+      # its `make test-only` resolves the whole module list, unlike tsan's
+      # suite, which never invokes `go test` and would freeze a partial
+      # cache under the exact key. Saving here rather than via the cache
+      # action's post step avoids publishing a half-populated cache when an
+      # earlier step fails the job.
+      - name: Save Go module cache
+        if: steps.go-modcache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.go-modcache.outputs.path }}
+          key: ${{ steps.go-modcache.outputs.key }}
 
       - name: Verify binaries before upload
         run: |


### PR DESCRIPTION
Every build job prefixed its Go module cache key with its own job name, so the sanitizer, release, deb and image jobs each stored a private copy of the same download. All of them run the same OS and Go version against the same module graph, and the four copies measured 787 MB against a repository-wide cache budget of 10 GB.

- Move the module cache restore into a local composite action keyed only on the module graph, so every job shares one entry and the key is defined in one place instead of five.
- Make the release build the sole writer of that key. Its test run resolves the whole module list, while the thread-sanitizer suite never invokes the Go test runner, so letting every job write would allow a partial cache to freeze in under the shared key and never be repaired.
- Save from an explicit step after the tests rather than from the cache action's post step, so a job that fails early cannot publish a half-populated cache.
- Drop the now-unused per-job cache name from the build, deb and image workflows.

The first run after merge is a cold miss on all five call sites, since no existing entry carries the new prefix. The four superseded entries are not reclaimed by the scheduled cache prune, which only targets superseded ccache generations and dead pull-request refs, so they will be removed explicitly once the shared entry exists on the main branch.

Closes #1807.