### PR TITLE
perf(ci): skip the equivs metapackage build

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Install packaging tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends devscripts equivs
+          sudo apt-get install -y --no-install-recommends devscripts
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24.x"

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install packaging tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends devscripts equivs
+          sudo apt-get install -y --no-install-recommends devscripts
 
       - uses: actions/setup-go@v5
         with:

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -72,12 +72,7 @@ dch --newversion "$PKG_VERSION" --distribution unstable --force-bad-version "Aut
 
 # Install build deps with verbose output
 apt-get update
-(
-    curdir=$(pwd)
-    mkdir -p /tmp/build
-    cd /tmp/build 
-    echo y | mk-build-deps --install -t 'apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y --allow-downgrades --allow-remove-essential --allow-change-held-packages' $curdir/debian/control
-) 2>&1 | tee build-deps.log
+apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends -y --allow-downgrades --allow-remove-essential --allow-change-held-packages build-dep . 2>&1 | tee build-deps.log
 
 echo "Current PATH during build: $PATH" > build-path.log
 # Preserve environment variables for cargo (order matters in dpkg-buildpackage)


### PR DESCRIPTION
- Installs Debian build dependencies directly from source metadata, removing the throwaway package and its build-info scan.
- Drops the unused package from both Debian build workflow setup steps.
- Preserves solver flags, failure propagation, and build-dependency logs.
- Closes #1780.