### PR TITLE
chore(ci): move cargo caching onto a cargo-aware action

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -77,17 +77,14 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # Only the cargo home is cached. Debuild runs the clean target first,
+      # which removes the target directory, so an entry holding it would be
+      # deleted before the build could use it.
       - name: Cache rust
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ matrix.unbtver }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.unbtver }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-${{ matrix.unbtver }}-cargo-
+          shared-key: deb-${{ matrix.unbtver }}
+          cache-targets: false
 
       - name: Install packaging tools
         run: |

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -29,17 +29,13 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      # Only the cargo home is cached. Debuild removes the target directory
+      # before the build starts, so an entry holding it would be wasted.
       - name: Cache rust
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-24.04-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-24.04-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-24.04-cargo-
+          shared-key: deb-24.04
+          cache-targets: false
 
       - name: Install packaging tools
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,17 +171,13 @@ jobs:
         with:
           toolchain: stable
 
+      # A cache written on a pull-request ref is readable only from that
+      # same pull request, so only main writes this one.
       - name: Cache rust
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-
-            ${{ runner.os }}-cargo-
+          shared-key: build-release
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - uses: hendrikmuhs/ccache-action@v1.2.18
         name: ccache

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -1,5 +1,12 @@
 name: Rust Check
 
+# Cargo caches here are shared and written from main only.
+#
+# Check and clippy compile dependencies in the same metadata mode, so one
+# entry serves both, while test compiles them fully and needs its own. A
+# cache written on a pull-request ref is readable only from that same pull
+# request, so saving one there costs repository quota and buys nothing.
+
 on:
   push:
     branches: ["main"]
@@ -43,15 +50,10 @@ jobs:
         with:
           toolchain: stable
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-check-
+          shared-key: rust-check
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/apt-packages
         with:
           packages: protobuf-compiler
@@ -66,15 +68,10 @@ jobs:
         with:
           toolchain: stable
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-test-
+          shared-key: rust-test
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/apt-packages
         with:
           packages: protobuf-compiler
@@ -90,15 +87,10 @@ jobs:
           toolchain: stable
           components: clippy
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: Swatinem/rust-cache@v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+          shared-key: rust-check
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: ./.github/actions/apt-packages
         with:
           packages: protobuf-compiler


### PR DESCRIPTION
Cargo caches occupied five distinct key families for one Rust workspace: one for the release build, one shared by the two package-building workflows, and one each for the check, test and clippy lint jobs. Together they measured about 1735 MB while the repository sat at 10.56 GB against a 10 GB cap, so live entries were being evicted. Caching a cargo build directory with the generic cache action is unreliable on top of that, because cargo fingerprints artifacts on modification times and the generic action does not preserve them on restore.

- All five blocks move to Swatinem/rust-cache, a cargo-aware action that prunes re-extractable and non-dependency artifacts before saving.
- The three lint keys become two. Check and clippy compile dependencies in the same metadata-emitting mode and genuinely share artifacts, so one entry serves both. Test compiles them as full build units, so folding it in would leave whichever job lost the write with a cold dependency build.
- The package path caches only the cargo home. Its build runs the clean target before building, which deletes the restored build directory, so an entry holding it was never usable.
- Only the default branch writes the two entries where that is possible. A cache written on a pull-request ref is readable only from that same pull request, so it consumed quota with almost no reuse, while pull requests still restore from the default branch's entry.
- Workspace-member crates stay uncached, which is the action's default. One of the proto-compiling crates reads files outside its own package and declares no rerun dependency on them, so caching its output would risk stale artifacts.

Dependency decision, recorded per the issue's acceptance criteria. Swatinem/rust-cache is the de facto standard cargo cache action, actively maintained, and licensed LGPL-3.0, which imposes nothing on distributed artifacts because it never enters them. It is pinned to an exact release tag, matching how the repository already pins its other third-party actions. Tag pinning rather than commit pinning is deliberate, because the same jobs already install the Rust toolchain from a moving tag with equal access to the cargo home, so hardening this one action alone would buy nothing. A move to commit pinning belongs in a separate repository-wide policy change.

One deliberate trade. A pull request pushed several times no longer gets an exact hit on a fully populated build directory, so its workspace crates recompile on each run. That is accepted for the quota goal, and the lint jobs it affects each finish in under a minute.

The superseded entries are not deleted by this change and age out on their own, so the reduction will not be visible immediately. The repository cache size will be re-measured on the issue once the new entries populate.

Closes #1785.