### PR TITLE
chore(counters)!: drop the redundant yanet_ prefix from builtin metric names

### DIFF
--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -282,7 +282,7 @@ func portMetrics(ports []ffi.PortGroup) []*commonpb.Metric {
 		portID := strconv.FormatUint(uint64(port.PortID), 10)
 		for _, counter := range port.Counters {
 			metrics = append(metrics, commonpb.NewMetricCounter(
-				"yanet_port_counter_value",
+				"port_counter_value",
 				counter.Value,
 				&commonpb.Label{Name: "port_id", Value: portID},
 				&commonpb.Label{Name: "port_name", Value: port.PortName},
@@ -304,21 +304,21 @@ func workerMetrics(workers []ffi.WorkerCounter) []*commonpb.Metric {
 		}
 
 		metrics = append(metrics,
-			commonpb.NewMetricCounter("yanet_worker_iterations", worker.Iterations, labels...),
-			commonpb.NewMetricCounter("yanet_worker_rx_packets", worker.RxPackets, labels...),
-			commonpb.NewMetricCounter("yanet_worker_rx_bytes", worker.RxBytes, labels...),
-			commonpb.NewMetricCounter("yanet_worker_tx_packets", worker.TxPackets, labels...),
-			commonpb.NewMetricCounter("yanet_worker_tx_bytes", worker.TxBytes, labels...),
-			commonpb.NewMetricCounter("yanet_worker_remote_rx_packets", worker.RemoteRxPackets, labels...),
-			commonpb.NewMetricCounter("yanet_worker_remote_tx_packets", worker.RemoteTxPackets, labels...),
-			commonpb.NewMetricCounter("yanet_worker_local_tx_drops", worker.LocalTxDrops, labels...),
-			commonpb.NewMetricCounter("yanet_worker_remote_tx_drops", worker.RemoteTxDrops, labels...),
-			commonpb.NewMetricCounter("yanet_worker_drops", worker.Drops, labels...),
+			commonpb.NewMetricCounter("worker_iterations", worker.Iterations, labels...),
+			commonpb.NewMetricCounter("worker_rx_packets", worker.RxPackets, labels...),
+			commonpb.NewMetricCounter("worker_rx_bytes", worker.RxBytes, labels...),
+			commonpb.NewMetricCounter("worker_tx_packets", worker.TxPackets, labels...),
+			commonpb.NewMetricCounter("worker_tx_bytes", worker.TxBytes, labels...),
+			commonpb.NewMetricCounter("worker_remote_rx_packets", worker.RemoteRxPackets, labels...),
+			commonpb.NewMetricCounter("worker_remote_tx_packets", worker.RemoteTxPackets, labels...),
+			commonpb.NewMetricCounter("worker_local_tx_drops", worker.LocalTxDrops, labels...),
+			commonpb.NewMetricCounter("worker_remote_tx_drops", worker.RemoteTxDrops, labels...),
+			commonpb.NewMetricCounter("worker_drops", worker.Drops, labels...),
 		)
 
 		if len(worker.RxBursts) > 0 {
 			metrics = append(metrics, makeHistogram(
-				"yanet_worker_rx_bursts",
+				"worker_rx_bursts",
 				worker.RxBursts,
 				labels...,
 			))


### PR DESCRIPTION
The builtin counters service was the only metric producer in the tree carrying a project-wide prefix. Every module and operator already exposes bare subsystem-scoped names, and the shared-memory arena gauges landing in the same package follow that shape too, so the prefix was legacy inconsistency rather than a convention.

Dropping it puts the port and worker metrics on the same shape as everything else, and the project name is already implied by the process serving them.

**Breaking, user-visible change.** All twelve builtin metric names lose their leading project prefix and are otherwise unchanged, so the eleven worker counters and the worker burst histogram move from a yanet_worker prefix to a plain worker one, and the port counter loses the same prefix. Any external scrape config, dashboard or alert rule keyed on the old names breaks at deploy and must be updated in lockstep. There is no exporter in this repository — metrics are served over the gRPC metrics API — so the set of external consumers cannot be enumerated from the tree, and this note is the only warning a deployer gets.

Nothing inside the repository keys on the old names: no test asserts on them, no dashboard or alert rule exists here, the CLI passes metric names through verbatim, and the web UI never references them.

Closes #1822.
