### PR TITLE
chore(ci): repair Go module caching in the fuzz and gofmt jobs

### DIFF
--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -35,6 +35,9 @@ jobs:
           go-version: "1.24.x"
           cache: false
 
+      - name: Restore Go module cache
+        uses: ./.github/actions/go-modcache
+
       - name: Install Go Protobuf Plugins
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest

--- a/.github/workflows/go-formatting.yml
+++ b/.github/workflows/go-formatting.yml
@@ -5,10 +5,14 @@ on:
     branches: [main, master]
     paths:
       - "controlplane/**/*.go"
+      - "go.mod"
+      - ".github/workflows/go-formatting.yml"
   pull_request:
     branches: [main, master]
     paths:
       - "controlplane/**/*.go"
+      - "go.mod"
+      - ".github/workflows/go-formatting.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -21,12 +25,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # gofmt only reformats source text. It resolves no imports and never
+      # touches GOMODCACHE, so this job needs no module cache.
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
-          cache: true
-          cache-dependency-path: controlplane/go.sum
+          go-version-file: go.mod
+          cache: false
 
       - name: Check gofmt
         run: |


### PR DESCRIPTION
An audit of every workflow job that runs Go, prompted by the shared module cache work, turned up the two jobs that measurement had missed. A job that never saves a cache produces no entry to enumerate, so neither showed up in the cache-usage numbers. They sit at opposite extremes and get opposite remedies.

- Give the nightly fuzz job the shared module cache. It asked for none at all and re-resolved the whole graph on every run, although it installs the protobuf plugins and then runs the Go fuzz targets. It consumes the restore as a reader, like every call site other than the release build.
- Stop the formatting job asking for a cache it cannot use. It named a dependency file that has not existed since the Go module was consolidated at the root, and the setup action reports an unresolvable path as a warning rather than an error, so the job ran green with caching silently disabled in both directions. Pointing it at the real file would have been the wrong repair: the job only runs the formatter, which resolves no imports and never touches the module cache, so it would have restored and saved hundreds of megabytes that no step reads.
- Pin that job's toolchain to the version the module declares instead of a floating minor, matching the three sibling lint jobs. Formatter output can differ between releases, so an unpinned formatter is a latent inconsistency. The resolved version is unchanged today.
- Add the two inputs the job actually reads to its path filter. It watched one source subtree only, so it could not trigger on a change to the module file it now reads, nor on a change to itself, which every sibling workflow already lists.

Closes #1819.
Closes #1820.