### PR TITLE
perf(ci): stop the deb build re-running the test suite

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,11 @@ override_dh_auto_configure:
 			-Dtrace=disabled \
 			-Dversion=$(DEB_VERSION); \
 
+# The packaging build already compiles the whole tree, so running the suite here
+# validates the source rather than the packages.
+override_dh_auto_test:
+	:
+
 execute_after_dh_auto_install:
 	./scripts/gen-shell-completions.sh debian/yanet2-cli.install \
 		debian/tmp/usr/share/bash-completion/completions \


### PR DESCRIPTION
The packaging rules overrode only the configure step, so every other debhelper auto step fell through to the autodetected Makefile buildsystem. The test step therefore ran the full make target: wipe the Go build cache, run every Go package test, then run the meson suite. That cost 148.25 s of the packaging job in the most recent run, against 2.4 s for the install step that follows it.

Overriding the test step to a no-op removes it. The build step still runs the full make target beforehand and the install step re-runs the compile, so the packages continue to come from a fully compiled tree. The clean step at the top of every packaging build still wipes the Go cache and the build directory, so each run compiles from scratch as before.

Running that suite at package time validated the source tree rather than the packages, which is what the dedicated test jobs already exist for.

One honest caveat on coverage, since the review turned it up and it is worth recording. The build workflow carries a path allow-list and only triggers on pull requests based on the default branch, so three paths get no suite run of their own once this lands: a commit touching none of the allow-listed paths, a pull request stacked on another branch, and a local packaging build. None of these ships untested code to the default branch, because a stacked branch is tested when it reaches the default branch and a commit outside the allow-list contains no compiled source. The allow-list does have genuine blind spots — the submodule pins, the meson options file and the protobuf definitions all affect the build and match nothing — but those predate this change and are being tracked separately rather than widened here.

Closes #1778.