### PR TITLE
chore(ci): widen the gofmt gate beyond the control plane

### DIFF
--- a/.github/workflows/go-formatting.yml
+++ b/.github/workflows/go-formatting.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main, master]
     paths:
-      - "controlplane/**/*.go"
+      - "**/*.go"
       - "go.mod"
       - ".github/workflows/go-formatting.yml"
   pull_request:
     branches: [main, master]
     paths:
-      - "controlplane/**/*.go"
+      - "**/*.go"
       - "go.mod"
       - ".github/workflows/go-formatting.yml"
 
@@ -35,7 +35,7 @@ jobs:
 
       - name: Check gofmt
         run: |
-          cd controlplane
+          set -euo pipefail
           # Find Go files that are not properly formatted
           unformatted=$(gofmt -l .)
           if [ -n "$unformatted" ]; then


### PR DESCRIPTION
The formatting check ran against the control plane subtree only, behind a path filter watching the same subtree, although Go code also lives in the module, device, operator, common, binding, library and test trees. Nothing else covered them, either: the Go linter configuration disables every linter by default and enables a single modernisation linter, with no formatter among them. Outside that one subtree, formatting was ungated in CI entirely.

- Run the check from the repository root and widen its path filter to match, so every Go tree is gated rather than one of them.
- Declare the check script's error handling explicitly instead of inheriting it from the runner's default shell, matching the other multi-line scripts in the workflow tree. This changes no behaviour on the hosted runner, where that default already applies.

Widening costs nothing today, because every tracked Go file in the repository is already formatted under the toolchain version the job pins. That property decays: the longer the gap stays open, the likelier the widening run turns red and the change stops being a one-liner.

The workflow's own file is in its path filter, so this pull request exercises the widened check itself.

Closes #1831.