### PR TITLE
chore(ci): widen the build workflow's path filter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
       - "**.h"
       - "**.c"
       - "**/meson.build"
+      - "meson_options.txt"
+      - "subprojects/**"
+      - ".gitmodules"
+      # Protoc-generated Go is a build product, not a tracked file.
+      - "**.proto"
       - "**.go"
       - "go.mod"
       - "go.sum"
@@ -23,6 +28,11 @@ on:
       - "**.h"
       - "**.c"
       - "**/meson.build"
+      - "meson_options.txt"
+      - "subprojects/**"
+      - ".gitmodules"
+      # Protoc-generated Go is a build product, not a tracked file.
+      - "**.proto"
       - "**.go"
       - "go.mod"
       - "go.sum"


### PR DESCRIPTION
The workflow that runs the Go and meson test suite sits behind a path allow-list, and four classes of real build input matched nothing in it. A change touching only those ran no suite at all.

- The submodule pins. A DPDK or libpcap bump changes a gitlink under the subprojects directory, which the filter never listed. GitHub does report a gitlink as a changed file path, so the new pattern covers it.
- The meson options file. It sits at the repository root, and the pattern matching build definitions does not reach it.
- The submodule declarations file, which records each submodule's path and URL and so can redirect what gets built.
- The protobuf definitions. Every tracked proto generates Go that is itself untracked, so a proto-only change alters compiled source with no Go file in the diff. The proto lint job checks the schemas but never compiles the result.

This mattered less while the packaging job was accidentally re-running the same suite through debhelper's autodetected test step. #1826 removed that second run, which leaves this filter as the only thing deciding whether a build-affecting change gets tested.

The change is purely additive and order-preserving, applied identically to both trigger blocks, so no event that triggered before can stop triggering. The workflow file is already in its own allow-list, so this pull request runs the suite it is widening.

Closes #1828.