### PR TITLE
perf(ci): stop the deb build poisoning its own ccache keys

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -65,7 +65,6 @@ jobs:
           key: ${{ runner.os }}-deb-ccache-${{ matrix.unbtver }}
           max-size: 2G
           verbose: 2
-          create-symlink: true
 
       - name: update apt (act hack)
         if: ${{ env.ACT }}

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,16 @@ export DEB_LDFLAGS_MAINT_APPEND = -fno-lto
 # Enable all hardening options
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
+# Pin the DWARF source path so it does not carry the package version.
+#
+# Ubuntu's fixfilepath feature maps the build directory to
+# /usr/src/<source>-<version>, and the CI build script gives every commit a
+# distinct +dev version. ccache hashes that mapped directory into both its
+# manifest and result keys, so a version-bearing path makes every key unique
+# and no cache entry is ever reused. Turning the feature off instead would
+# leave a relative path, which DWARF forbids for DW_AT_comp_dir.
+export DEB_BUILD_DEBUGPATH = /usr/src/yanet2
+
 # Set parallel build options
 export DEB_BUILD_OPTIONS = parallel=$(shell nproc)
 


### PR DESCRIPTION
- `build-deb`'s ccache produced zero direct-mode hits — 0 of 1605 direct lookups — and a 20% overall hit rate, against 77-98% direct in the three build jobs using the same action version. Two independent causes, both confirmed by reproducing the exact signature locally rather than by inference.
- Ubuntu's fixfilepath feature maps the build directory into the DWARF source path and stamps it with the package version, which the CI build script makes unique for every commit. ccache folds that mapped directory into both its manifest key and its result key, so every run computed fresh keys and the restored cache was dead on arrival. Pinning the debug path keeps it absolute, as DWARF requires for the compilation directory, while dropping the version.
- The ccache action's compiler-symlink option additionally routed Go cgo compiles through ccache. cgo names synthetic pseudo-files in its preprocessed output, ccache cannot stat them, and each such compile paid a full wasted preprocess before falling back to the real compiler — 782 errors, 32% of all invocations. Meson already prefixes ccache on its own compile rules whenever ccache is on the path, so the symlinks bought the C build nothing, and the three healthy jobs set no such option either.
- Measured on a local A/B in which only the changelog version differed between two runs: direct hits went from 0 of 1110 to 527 of 1110, and the overall hit rate from 11.8% to 93.5%. That is a floor taken after a single populating run, so the steady state should approach the rate the other jobs already reach.
- Only the 24.04 leg is affected. Jammy's dpkg has neither the debug-path override nor the versioned path, so the export is inert there and there was nothing to fix.
- Verifiable from the ccache action's own verbose summary on the second run after this lands: the error block should collapse to roughly two, and direct hits should be non-zero.

Closes #1781.