### PR TITLE
build(dpdk): stop building the unused testpmd app

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -124,7 +124,10 @@ fuzzing_targets = {}
 libdpdk_default_options = [
   'platform=' + get_option('dpdk_platform'),
   'pkt_mbuf_headroom=@0@'.format(get_option('pkt_mbuf_headroom')),
-  'disable_apps=dumpcap,graph,pdump,proc-info,test-acl,test-bbdev,test-cmdline,test-compress-perf,test-crypto-perf,test-dma-perf,test-eventdev,test-fib,test-flow-perf,test-gpudev,test-mldev,test-pipeline,test-regex,test-sad,test-security-perf',
+  # An empty enable_apps means "build every app", so any app a disable list
+  # fails to name is still built. The glob also covers apps added upstream
+  # later, and nothing outside subprojects/ uses any of them.
+  'disable_apps=*',
   'enable_apps=',
   'disable_libs=bitratestats,cfgfile,flow_classify,gpudev,gro,gso,kni,jobstats,latencystats,metrics,node,pdump,pipeline,port,power,table,vhost',
   'enable_driver_sdk=true',


### PR DESCRIPTION
- The DPDK app options enumerated nineteen of DPDK's twenty apps in the disable list and left the enable list empty. An empty enable list means "build every app", so `test-pmd` — the one the enumeration failed to name — was still built in every job that compiles DPDK: the three build-matrix jobs, the deb build and the fuzz build.
- Nothing in this repository references it. That was checked with a grep that deliberately ignored gitignore rules, so generated files, the private tree and the agent-state directories were all covered.
- Replacing the enumeration with a glob removes 28 ninja edges and 35.4 s of CPU from a cold build, roughly 9 s of wall clock at the runners' four cores. Once ccache is warm the saving is close to nothing, so this is a cold-build and cache-rotation cost rather than a steady-state one.
- Measured with a positive control rather than an assumed baseline: the unmodified tree configures to 1082 ninja edges with 110 testpmd references in `build.ninja`, and this change gives 1054 edges and zero references, from a meson setup confirmed to have succeeded.
- A glob rather than adding the missing name, because the enumeration is what drifted in the first place and an app added upstream later now stays disabled by default.

Closes #1836.