### PR TITLE
refactor(counters): select level counters by owner-kind tag

### DIFF
--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -321,24 +321,26 @@ fn by_tags_request(tags: Vec<(&'static str, String)>) -> CountersByTagsRequest {
 fn tags_request(mode: Option<ModeCmd>, by_tags: ByTagsCmd) -> CountersByTagsRequest {
     match mode {
         None => by_tags.into(),
-        Some(ModeCmd::Device(cmd)) => by_tags_request(vec![("device", cmd.device_name), ("pipeline", String::new())]),
+        Some(ModeCmd::Device(cmd)) => {
+            by_tags_request(vec![("device", cmd.device_name), ("kind", "device".to_string())])
+        }
         Some(ModeCmd::Pipeline(cmd)) => by_tags_request(vec![
             ("device", cmd.device_name),
             ("pipeline", cmd.pipeline_name),
-            ("function", String::new()),
+            ("kind", "pipeline".to_string()),
         ]),
         Some(ModeCmd::Function(cmd)) => by_tags_request(vec![
             ("device", cmd.device_name),
             ("pipeline", cmd.pipeline_name),
             ("function", cmd.function_name),
-            ("chain", String::new()),
+            ("kind", "function".to_string()),
         ]),
         Some(ModeCmd::Chain(cmd)) => by_tags_request(vec![
             ("device", cmd.device_name),
             ("pipeline", cmd.pipeline_name),
             ("function", cmd.function_name),
             ("chain", cmd.chain_name),
-            ("module_type", String::new()),
+            ("kind", "chain".to_string()),
         ]),
         Some(ModeCmd::Module(cmd)) => by_tags_request(vec![
             ("device", cmd.device_name),
@@ -347,6 +349,7 @@ fn tags_request(mode: Option<ModeCmd>, by_tags: ByTagsCmd) -> CountersByTagsRequ
             ("chain", cmd.chain_name),
             ("module_type", cmd.module_type),
             ("module_name", cmd.module_name),
+            ("kind", "module".to_string()),
         ]),
         Some(ModeCmd::Perf(..)) | Some(ModeCmd::Workers) | Some(ModeCmd::Ports) => unreachable!(),
     }

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1612,10 +1612,13 @@ yanet_get_module_counters(
 		{.key = "function", .value = function_name},
 		{.key = "chain", .value = chain_name},
 		{.key = "module_type", .value = module_type},
-		{.key = "module_name", .value = module_name}
+		{.key = "module_name", .value = module_name},
+		// Select module-kind storages only; relation counters live on
+		// module_object_link-kind storages that share these six tags.
+		{.key = "kind", .value = "module"}
 	};
 	return yanet_get_counters_by_tags(
-		dp_config, tags, 6, query, query_count, NULL
+		dp_config, tags, 7, query, query_count, NULL
 	);
 }
 
@@ -1887,7 +1890,7 @@ yanet_get_chain_counters(
 		{.key = "pipeline", .value = pipeline_name},
 		{.key = "function", .value = function_name},
 		{.key = "chain", .value = chain_name},
-		{.key = "module_type", .value = ""}
+		{.key = "kind", .value = "chain"}
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 5, NULL, -1, NULL);
 }
@@ -1903,7 +1906,7 @@ yanet_get_function_counters(
 		{.key = "device", .value = device_name},
 		{.key = "pipeline", .value = pipeline_name},
 		{.key = "function", .value = function_name},
-		{.key = "chain", .value = ""}
+		{.key = "kind", .value = "function"}
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 4, NULL, -1, NULL);
 }
@@ -1917,7 +1920,7 @@ yanet_get_pipeline_counters(
 	struct counter_tag tags[] = {
 		{.key = "device", .value = device_name},
 		{.key = "pipeline", .value = pipeline_name},
-		{.key = "function", .value = ""}
+		{.key = "kind", .value = "pipeline"}
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 3, NULL, -1, NULL);
 }
@@ -1928,7 +1931,7 @@ yanet_get_device_counters(
 ) {
 	struct counter_tag tags[] = {
 		{.key = "device", .value = device_name},
-		{.key = "pipeline", .value = ""}
+		{.key = "kind", .value = "device"}
 	};
 	return yanet_get_counters_by_tags(dp_config, tags, 2, NULL, -1, NULL);
 }

--- a/web/builtin/dashboard/hooks.ts
+++ b/web/builtin/dashboard/hooks.ts
@@ -24,7 +24,7 @@ export const useWorkerCount = (deviceNames: string[]): number | null => {
                 const resp = await API.counters.byTags({
                     tags: [
                         { key: 'device', value: firstDevice },
-                        { key: 'pipeline', value: '' },
+                        { key: 'kind', value: 'device' },
                     ],
                     query: ['input_rx'],
                 });

--- a/web/builtin/functions/hooks/useModuleCounters.ts
+++ b/web/builtin/functions/hooks/useModuleCounters.ts
@@ -40,7 +40,7 @@ export const useModuleCounters = (
 
         try {
             const response = await API.counters.byTags({
-                tags: [{ key: 'module_type', value: '*' }],
+                tags: [{ key: 'kind', value: 'module' }],
                 query: ['rx'],
             });
             const grouped = groupCounterPacketsAndBytes(

--- a/web/builtin/inspect/hooks.ts
+++ b/web/builtin/inspect/hooks.ts
@@ -161,7 +161,7 @@ const useTagCounterSeries = (
 
 const PIPELINE_TAGS: CounterTag[] = [
     { key: 'pipeline', value: '*' },
-    { key: 'function', value: '' },
+    { key: 'kind', value: 'pipeline' },
 ];
 
 /**
@@ -176,7 +176,7 @@ export const usePipelineCounters = (
 
 const FUNCTION_TAGS: CounterTag[] = [
     { key: 'function', value: '*' },
-    { key: 'chain', value: '' },
+    { key: 'kind', value: 'function' },
 ];
 
 /**

--- a/web/builtin/pipelines/hooks/useFunctionRefCounters.ts
+++ b/web/builtin/pipelines/hooks/useFunctionRefCounters.ts
@@ -50,7 +50,7 @@ export const useFunctionRefCounters = (
                     tags: [
                         { key: 'pipeline', value: pipelineName },
                         { key: 'function', value: '*' },
-                        { key: 'chain', value: '' },
+                        { key: 'kind', value: 'function' },
                     ],
                     query: ['input'],
                 });
@@ -72,7 +72,7 @@ export const useFunctionRefCounters = (
                 const response = await API.counters.byTags({
                     tags: [
                         { key: 'pipeline', value: pipelineName },
-                        { key: 'function', value: '' },
+                        { key: 'kind', value: 'pipeline' },
                     ],
                     query: ['input'],
                 });

--- a/web/src/core/hooks/useDeviceCounters.ts
+++ b/web/src/core/hooks/useDeviceCounters.ts
@@ -140,7 +140,7 @@ export const useDeviceCounters = (
             const response = await API.counters.byTags({
                 tags: [
                     { key: 'device', value: '*' },
-                    { key: 'pipeline', value: '' },
+                    { key: 'kind', value: 'device' },
                 ],
                 query: DEVICE_COUNTER_FIELDS.map(({ name }) => name),
             });

--- a/web/src/core/hooks/useModuleRuleCounters.ts
+++ b/web/src/core/hooks/useModuleRuleCounters.ts
@@ -63,6 +63,7 @@ export const useModuleRuleCounters = <T extends { id: string }>(
                 tags: [
                     { key: 'module_type', value: moduleType },
                     { key: 'module_name', value: configName },
+                    { key: 'kind', value: 'module' },
                 ],
                 query: counterNames,
             });


### PR DESCRIPTION
- Counter level queries in the dataplane public API now select storages by their owner-kind tag instead of structural sentinel tags, covering device, pipeline, function, chain, and module.
- The web ByTags callers and the counters CLI switch to the same owner-kind selection.
- Builds on the owner-kind tag introduced in #1811; the module-kind filter is a no-op until module-object-link storages land, and is included here so the level queries ship together.
- Extracted from the module-object-link work so it can land independently first.