### PR TITLE
perf(build): keep the build stamp out of the widely included config header

### DIFF
--- a/dataplane/main.c
+++ b/dataplane/main.c
@@ -6,7 +6,7 @@
 #include "config.h"
 #include "dataplane.h"
 #include "logging/log.h"
-#include "yanet_build_config.h"
+#include "yanet_build_stamp.h"
 
 static void
 print_version(void) {

--- a/meson.build
+++ b/meson.build
@@ -21,39 +21,57 @@ endif
 # The aarch64 branch appends its own ISA flag to yanet_project_args
 # further down, once the DPDK subproject() has resolved its ISA baseline.
 
+# Stable config: changes only when a build option changes, so it stays a
+# widely-included header without dragging per-build values into every
+# translation unit's ccache manifest.
 yanet_conf = configuration_data()
 yanet_conf.set('DEBUG_NAT64', get_option('buildtype') == 'debug')
 yanet_conf.set('ENABLE_TRACE_LOG', get_option('trace').enabled())
 yanet_conf.set('MBUF_MAX_SIZE', get_option('mbuf_max_size'))
 
+build_cfg = 'yanet_build_config.h'
+configure_file(output: build_cfg, configuration: yanet_conf)
+
+# Volatile config: version/commit/timestamp change on essentially every
+# build. Kept out of yanet_build_config.h and included only by the version
+# banner, so it does not poison ccache manifests across the rest of the tree.
+yanet_stamp = configuration_data()
+
 # Version and build info
 yanet_version = get_option('version') == '' ? meson.project_version() : get_option('version')
 
 cc = meson.get_compiler('c')
-yanet_conf.set_quoted('YANET_VERSION', yanet_version)
-yanet_conf.set_quoted('YANET_COMPILER_ID', cc.get_id())
-yanet_conf.set_quoted('YANET_COMPILER_VERSION', cc.version())
-yanet_conf.set_quoted('YANET_BUILD_TYPE', get_option('buildtype'))
+yanet_stamp.set_quoted('YANET_VERSION', yanet_version)
+yanet_stamp.set_quoted('YANET_COMPILER_ID', cc.get_id())
+yanet_stamp.set_quoted('YANET_COMPILER_VERSION', cc.version())
+yanet_stamp.set_quoted('YANET_BUILD_TYPE', get_option('buildtype'))
 
 # Git commit (if available)
 git = find_program('git', required: false)
 if git.found()
     git_commit = run_command(git, 'rev-parse', '--short', 'HEAD', check: false)
     if git_commit.returncode() == 0
-        yanet_conf.set_quoted('YANET_GIT_COMMIT', git_commit.stdout().strip())
+        yanet_stamp.set_quoted('YANET_GIT_COMMIT', git_commit.stdout().strip())
     else
-        yanet_conf.set_quoted('YANET_GIT_COMMIT', 'unknown')
+        yanet_stamp.set_quoted('YANET_GIT_COMMIT', 'unknown')
     endif
 else
-    yanet_conf.set_quoted('YANET_GIT_COMMIT', 'unknown')
+    yanet_stamp.set_quoted('YANET_GIT_COMMIT', 'unknown')
 endif
 
-# Build date
-build_date = run_command('date', '-u', '+%Y-%m-%d %H:%M:%S', check: true)
-yanet_conf.set_quoted('YANET_BUILD_DATE', build_date.stdout().strip())
+# Build date. Honours SOURCE_DATE_EPOCH (set by debhelper) for reproducible
+# builds, falling back to the wall clock otherwise.
+build_date = run_command(
+    'sh', '-c',
+    'if [ -n "$SOURCE_DATE_EPOCH" ]; then ' +
+    'date -u -d "@$SOURCE_DATE_EPOCH" +"%Y-%m-%d %H:%M:%S"; ' +
+    'else date -u +"%Y-%m-%d %H:%M:%S"; fi',
+    check: true,
+)
+yanet_stamp.set_quoted('YANET_BUILD_DATE', build_date.stdout().strip())
 
-build_cfg = 'yanet_build_config.h'
-configure_file(output: build_cfg, configuration: yanet_conf)
+build_stamp = 'yanet_build_stamp.h'
+configure_file(output: build_stamp, configuration: yanet_stamp)
 
 dataplane_only = get_option('dataplane_only')
 


### PR DESCRIPTION
- The generated config header mixed three values that change only when a build option changes against six that change on essentially every configure, one of them a wall-clock timestamp at second granularity. The logging header includes it, and 31 source files include the logging header directly with more reaching it transitively, so a large share of the tree recorded a compiler-cache manifest that moved every build and could never score a direct-mode hit across runs. The cost is loss of direct-mode eligibility, which degrades to a preprocessor-mode fallback rather than a full recompile.
- The six volatile values move to their own header, included only by the dataplane version banner that prints them. That banner is their sole consumer anywhere in either repository, so nothing else has to change.
- Proven by execution rather than inference: after a reconfigure, the stable header is byte- and mtime-identical, so it does not even dirty ninja, while the new stamp header changes — the positive control showing the comparison can fail.
- The build date now honours the source date the packaging tools export, which is the standard contract for a reproducible timestamp. Scoped honestly: this repository's own deb path rewrites the changelog with a wall-clock entry immediately before invoking the build, so that value is effectively "now" there and two builds of one commit still differ. The change makes the stamp a function of the changelog, and delivers a reproducible timestamp for a rebuild against a fixed changelog. Making the deb path itself reproducible needs the changelog rewrite addressed separately.
- An empty source date is handled explicitly, which is the case a known dpkg bug produces, and a malformed one fails the configure rather than silently falling back.
- The direct-hit rate for this repository's own translation units will be re-measured on this pull request's own build the way it was for #1834, and posted here.

Closes #1837.