### PR TITLE
feat(counters): add object counter query routine

### DIFF
--- a/api/counter.h
+++ b/api/counter.h
@@ -74,6 +74,13 @@ yanet_get_module_counters(
 );
 
 struct counter_handle_list *
+yanet_get_object_counters(
+	struct dp_config *dp_config,
+	const char *object_type,
+	const char *object_name
+);
+
+struct counter_handle_list *
 yanet_get_worker_counters(struct dp_config *dp_config);
 
 // Counters of a single DPDK port.

--- a/controlplane/ffi/shm.go
+++ b/controlplane/ffi/shm.go
@@ -669,6 +669,26 @@ func (m *DPConfig) ModuleCounters(
 	return m.encodeCounters(counters)
 }
 
+// ObjectCounters returns the counters of an object identified by its type
+// and name.
+func (m *DPConfig) ObjectCounters(
+	objectType string,
+	objectName string,
+) []CounterInfo {
+	cObjectType := C.CString(objectType)
+	defer C.free(unsafe.Pointer(cObjectType))
+	cObjectName := C.CString(objectName)
+	defer C.free(unsafe.Pointer(cObjectName))
+	counters := C.yanet_get_object_counters(m.ptr, cObjectType, cObjectName)
+	defer C.yanet_counter_handle_list_free(counters)
+
+	if counters == nil {
+		return nil
+	}
+
+	return m.encodeCounters(counters)
+}
+
 // CounterTag is a (key, value) predicate against a counter's tag set.
 // Value semantics follow the C API: an empty string requires the tag to
 // be absent, "*" requires the tag to be present with any value, and any

--- a/lib/controlplane/agent/agent.c
+++ b/lib/controlplane/agent/agent.c
@@ -1933,6 +1933,20 @@ yanet_get_device_counters(
 	return yanet_get_counters_by_tags(dp_config, tags, 2, NULL, -1, NULL);
 }
 
+struct counter_handle_list *
+yanet_get_object_counters(
+	struct dp_config *dp_config,
+	const char *object_type,
+	const char *object_name
+) {
+	struct counter_tag tags[] = {
+		{.key = "object_type", .value = object_type},
+		{.key = "object_name", .value = object_name},
+		{.key = "kind", .value = "object"}
+	};
+	return yanet_get_counters_by_tags(dp_config, tags, 3, NULL, -1, NULL);
+}
+
 struct counter_handle *
 yanet_get_counter(struct counter_handle_list *counters, uint64_t idx) {
 	if (idx >= counters->count) {


### PR DESCRIPTION
- Adds a per-object counter query to the dataplane public API, parallel to the device, pipeline, function, chain, and module level queries.
- Exposes it through the shared-memory Go bindings alongside the existing level queries.
- Objects already register object-kind counter storages on main, so the query is functional without further prerequisites.