### PR TITLE
chore(ci): sweep the C tree with the clang front end

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
 
       - uses: ./.github/actions/apt-packages
         with:
-          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler
+          packages: meson clang cmake python3-pyelftools libnuma-dev libpcap-dev git protobuf-compiler jq
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -191,6 +191,9 @@ jobs:
           make go-cache-clean
           meson setup build -Dbuildtype=release
           make dataplane cli
+
+      - name: Clang syntax sweep
+        run: make lint/clang-syntax
 
       - name: Build and run tests (release)
         run: make test-only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ cargo clippy                  # Rust lints
 make proto-lint               # protobuf formatting check
 make lint-go                  # stylelint + golangci-lint modernize (lint/style/, .golangci.yml)
 make lint/comments            # pure-run comment separator lint
+make lint/clang-syntax        # clang -fsyntax-only sweep; needs a configured build/ (meson setup)
 make lint-commit              # commit-subject convention check (lint/commit/)
 make proto-go                 # generate *.pb.go via protoc (needed before go lint locally)
 make hooks                    # install the git hooks (run once per clone)

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@ CARGO ?= cargo
 RULESYNC ?= npx --yes rulesync@16.8.0
 RULESYNC_GENERATE_ARGS := generate --targets claudecode,codexcli --features subagents
 
+# Compile database consumed by lint/clang-syntax.
+COMPILE_DB ?= build/compile_commands.json
+
 # Default PREFIX for debian packaging
 PREFIX ?= /usr
 BINDIR ?= $(PREFIX)/bin
@@ -114,6 +117,7 @@ CLI_RELEASE_BINARIES := $(addprefix $(RELEASE_DIR)/,$(CLI_BINARIES))
 	proto-go \
 	lint-go \
 	lint/comments \
+	lint/clang-syntax \
 	lint-commit \
 	ai/agents \
 	lint/agents \
@@ -183,6 +187,39 @@ lint-go:
 lint/comments:
 	go test ./lint/comment/cmd/commentlint/
 	go run ./lint/comment/cmd/commentlint/
+
+# Reparses the configured build's compile database with clang -fsyntax-only.
+#
+# Every C job in CI builds with gcc, so a construct gcc accepts and clang
+# rejects otherwise only surfaces overnight in the fuzzing workflow. This
+# is front-end only, no codegen, so replaying it here costs seconds and
+# needs no extra toolchain beyond the clang already on the job's image.
+lint/clang-syntax:
+	@command -v clang >/dev/null 2>&1 || { echo "ERROR: clang not found (install: apt install clang)"; exit 1; }
+	@command -v jq >/dev/null 2>&1 || { echo "ERROR: jq not found (install: apt install jq)"; exit 1; }
+	@test -f "$(COMPILE_DB)" || { echo "ERROR: $(COMPILE_DB) not found (run 'meson setup build' first)"; exit 1; }
+	@set -e; \
+	tmpdir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	dir=$$(jq -r '.[0].directory' "$(COMPILE_DB)"); \
+	jq -r '.[] | select(.file | endswith(".c")) | select(.file | contains("subprojects/") | not) | .command' "$(COMPILE_DB)" > "$$tmpdir/commands.txt"; \
+	awk '{ \
+			out = "clang"; started = 0; skip = 0; \
+			for (i = 1; i <= NF; i++) { \
+				tok = $$i; \
+				if (!started) { if (tok ~ /^-/) started = 1; else continue } \
+				if (skip) { skip = 0; continue } \
+				if (tok == "-c" || tok == "-MD") continue; \
+				if (tok == "-o" || tok == "-MF" || tok == "-MQ") { skip = 1; continue } \
+				out = out " " tok; \
+			} \
+			print out " -fsyntax-only"; \
+		}' "$$tmpdir/commands.txt" > "$$tmpdir/awk_out.txt"; \
+	sort -u "$$tmpdir/awk_out.txt" > "$$tmpdir/cmds.txt"; \
+	test -s "$$tmpdir/cmds.txt" || { echo "ERROR: no translation units extracted from $(COMPILE_DB)"; exit 1; }; \
+	n=$$(wc -l < "$$tmpdir/cmds.txt"); \
+	echo "clang-syntax: parsing $$n translation units with $$(clang --version | head -1)"; \
+	(cd "$$dir" && xargs -a "$$tmpdir/cmds.txt" -d '\n' -P "$$(nproc)" -I{} sh -c '{}')
 
 lint-commit:
 	lint/commit/commitlint_test.sh


### PR DESCRIPTION
- Resolves the open question left by #1794: the coverage comes back at pull-request time, in a form that costs seconds rather than the 5.8 minutes the removed job spent, so nightly-only clang was not accepted.
- Since that removal the build jobs prove the C tree against `gcc` alone, and the only clang left in continuous integration is the nightly fuzz workflow. A construct one compiler's parser or semantic analysis accepts and the other's rejects therefore reached `main` and surfaced at most a day later.
- The release build job now replays the compile database it already produces through clang with `-fsyntax-only`, keeping every recorded flag, including the project's own `-Werror`, and stopping before code generation and linking. No extra job, no toolchain install, no second build, no Go build: the job's package list already carries clang, and the database already exists by the time the step runs.
- Measured on this pull request's own run rather than extrapolated: the step parses 171 translation units with clang 18.1.3 in 18 seconds, against the 5.8 minutes of the job it replaces. Locally the same sweep is 2.6 s wall and 59 s CPU. The tree passes today with no diagnostic at all, warnings included.
- Proved capable of failing rather than assumed: a GNU nested function added to one project source makes the sweep exit non-zero naming that file, while the same file's own recorded `gcc` command still exits 0, which is exactly the gap being closed. A clang-only warning fails it too, through the inherited `-Werror`, and that class is the more common one. A database with no matching entry aborts loudly instead of reporting a green sweep over nothing.
- The launcher prefix meson writes when ccache is on `PATH`, which is the shape the runners produce and not the shape a developer's box produces, is handled and tested — a transform that only replaced the leading token would have been green locally and broken in continuous integration.
- The nightly workflow keeps its stronger property: it builds and links the whole tree with clang, including the fuzzing-only sources this sweep does not reach.
- Available locally as `make lint/clang-syntax` against any configured build directory.

Closes #1802.