### PR TITLE
perf(ci): give the deb build a warm base-branch ccache

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -2,7 +2,19 @@ name: Build DEB Packages
 
 on:
   push:
+    branches: ["main"]
     tags: ["v*"]
+    # Keep this list identical to the pull_request paths-ignore below.
+    paths-ignore:
+      - "web/**"
+      - "modules/**/web/**"
+      - "devices/**/web/**"
+      - "operators/**/web/**"
+      - "package.json"
+      - "package-lock.json"
+      - "**.md"
+      - ".claude/**"
+      - "docs/**"
   pull_request:
     branches: ["**"]
     paths-ignore:
@@ -23,8 +35,10 @@ on:
         default: false
 
 concurrency:
-  # The run_id fallback keeps non-PR runs from cancelling each other.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  # Pushes key on the ref, so a newer push supersedes an older one still
+  # running. A manual dispatch keys on its run id instead, so two explicit
+  # packaging runs (e.g. a 22.04 build alongside a default one) never collide.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || (github.event_name == 'workflow_dispatch' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -65,6 +79,7 @@ jobs:
           key: ${{ runner.os }}-deb-ccache-${{ matrix.unbtver }}
           max-size: 2G
           verbose: 2
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: update apt (act hack)
         if: ${{ env.ACT }}


### PR DESCRIPTION
- The workflow had no push trigger for branches — over its last 100 runs, 96 pull request, 4 manual, zero push. Actions caches are ref-scoped and a run may restore only from its own ref or the default branch, so with no entry on main a pull request could only ever restore what its own earlier push wrote, and cross-branch reuse never happened. Every one of the eighteen live cache entries sits on a pull request merge ref.
- That became worth fixing now because the cache finally works. #1834 and #1841 took this job to a 92.8% hit rate and 90.35% direct-mode lookups, but only on a second push to the same pull request. Meanwhile a cold cache is not merely neutral: measured back to back under matched load, ccache with nothing to restore costs 15-25% more wall time than not using ccache at all, so first-push runs were paying a tax and getting nothing back.
- Running on pushes to main seeds an entry every pull request can read, and gating the save to main stops each pull request writing a copy only it can use. This is the arrangement the three jobs in the build workflow already use, and why they sustain 77-98% direct-hit rates.
- The push trigger carries the same path-ignore list as the pull request one, so a documentation-only merge does not rebuild. Path filters are not evaluated for pushes of tags, so this narrows only the branch surface being added and cannot suppress a release build. The two lists must stay in step, which a comment records — this repository shipped a bug from exactly that kind of enumerated-list drift in #1836.
- The concurrency group now carries the event name as well as the ref. Without that, a manual dispatch on main and a push to main would share one group and silently cancel each other, which was structurally impossible under the previous run-id fallback.
- Accepted cost, which was the user's call: an added build on every merge to main. The first pull requests after this lands are still cold until the first main run completes.

Closes #1782.