### PR TITLE
fix(filter): name memory contexts after attributes instead of heap indexes

### DIFF
--- a/lib/filter/compiler.h
+++ b/lib/filter/compiler.h
@@ -30,6 +30,7 @@ typedef void (*filter_lookup_free_func)(
 );
 
 struct filter_lookup_handler {
+	const char *name;
 	filter_lookup_init_func init;
 	filter_lookup_free_func free;
 };
@@ -43,12 +44,29 @@ static inline void
 filter_free(
 	struct filter *filter, const struct filter_compiler *filter_compiler
 ) {
+	// Calling value_registry_fini below clears the registry's
+	// memory_context, so capture each leaf's attribute context now,
+	// before any teardown runs.
+	struct memory_context *attr_ctx[MAX_ATTRIBUTES];
+	for (size_t i = 0; i < filter_compiler->lookup_count; ++i) {
+		struct filter_vertex *v =
+			filter->v + filter_compiler->lookup_count + i;
+		attr_ctx[i] =
+			v->registry.memory_context != NULL
+				? ADDR_OF(&v->registry.memory_context->parent)
+				: NULL;
+	}
+
 	for (size_t i = 0; i < filter_compiler->lookup_count; ++i) {
 		struct filter_vertex *v =
 			filter->v + filter_compiler->lookup_count + i;
 		if (v->data != NULL) {
+			// Free against the attribute context the payload was
+			// allocated from (see filter_init), not the
+			// registry's own context, which value_registry_fini
+			// below releases on its own.
 			filter_compiler->lookups[i].free(
-				ADDR_OF(&v->data), &filter->memory_context
+				ADDR_OF(&v->data), attr_ctx[i]
 			);
 		}
 		SET_OFFSET_OF(&v->data, NULL);
@@ -58,6 +76,19 @@ filter_free(
 	}
 	for (size_t i = 1; i < filter_compiler->lookup_count; ++i) {
 		value_table_free(&filter->v[i].table);
+	}
+	// Release each leaf's own attribute context back into the filter
+	// context, now that the registry and payload it parented are gone.
+	for (size_t i = 0; i < filter_compiler->lookup_count; ++i) {
+		if (attr_ctx[i] == NULL) {
+			continue;
+		}
+		memory_context_fini(attr_ctx[i]);
+		memory_bfree(
+			&filter->memory_context,
+			attr_ctx[i],
+			sizeof(*attr_ctx[i])
+		);
 	}
 	if (filter_compiler->lookup_count == 1) {
 		struct filter_vertex *v0 = filter->v;
@@ -155,31 +186,52 @@ filter_init(
 	     ++lookup_idx) {
 		struct filter_vertex *v =
 			filter->v + filter_compiler->lookup_count + lookup_idx;
-		char name[64];
-		snprintf(
-			name,
-			sizeof(name),
-			"registry[%zu]",
-			(size_t)(filter_compiler->lookup_count + lookup_idx)
+
+		// Each leaf gets its own attribute context, named after the
+		// attribute, so the registry and the attribute's payload
+		// below can be siblings instead of one nesting under the
+		// other's teardown-sensitive context.
+		struct memory_context *attr_ctx =
+			(struct memory_context *)memory_balloc(
+				&filter->memory_context,
+				sizeof(struct memory_context)
+			);
+		if (attr_ctx == NULL) {
+			yanet_error_add(
+				err,
+				"out of memory: failed to init attribute "
+				"context for lookup %zu",
+				(size_t)lookup_idx
+			);
+			goto init_failed;
+		}
+		memory_context_init_from(
+			attr_ctx,
+			&filter->memory_context,
+			filter_compiler->lookups[lookup_idx].name
 		);
-		if (value_registry_init(
-			    &v->registry, &filter->memory_context, name
-		    )) {
+
+		if (value_registry_init(&v->registry, attr_ctx, "registry")) {
 			yanet_error_add(
 				err,
 				"out of memory: failed to init registry for "
 				"lookup %zu",
 				(size_t)lookup_idx
 			);
+			memory_context_fini(attr_ctx);
+			memory_bfree(
+				&filter->memory_context,
+				attr_ctx,
+				sizeof(*attr_ctx)
+			);
 			goto init_failed;
 		}
 		v->data = NULL;
+		// The attribute context must outlive the registry it
+		// parents, so the attribute receives it directly rather than
+		// the registry's own context.
 		if (filter_compiler->lookups[lookup_idx].init(
-			    &v->registry,
-			    &v->data,
-			    rules,
-			    rule_count,
-			    &filter->memory_context
+			    &v->registry, &v->data, rules, rule_count, attr_ctx
 		    )) {
 			yanet_error_add(
 				err,
@@ -222,9 +274,30 @@ filter_init(
 		goto init_finish;
 	}
 
+	// Each entry first_leaf[n] holds the attribute name of the first leaf
+	// reachable from vertex n, computed bottom-up from the leaves filled
+	// by the loop above. It gives every inner node a name derived from
+	// its own subtree instead of its heap index.
+	const char *first_leaf[2 * MAX_ATTRIBUTES];
+	for (uint64_t lookup_idx = 0;
+	     lookup_idx < filter_compiler->lookup_count;
+	     ++lookup_idx) {
+		first_leaf[filter_compiler->lookup_count + lookup_idx] =
+			filter_compiler->lookups[lookup_idx].name;
+	}
+	for (size_t idx = filter_compiler->lookup_count - 1; idx >= 1; --idx) {
+		first_leaf[idx] = first_leaf[2 * idx];
+	}
+
 	for (size_t idx = filter_compiler->lookup_count - 1; idx >= 2; --idx) {
 		char name[64];
-		snprintf(name, sizeof(name), "registry[%zu]", idx);
+		snprintf(
+			name,
+			sizeof(name),
+			"merge(%s,%s)",
+			first_leaf[2 * idx],
+			first_leaf[2 * idx + 1]
+		);
 		// The function merge_and_collect_registry only populates an
 		// already-initialised registry. The loop above initialised one
 		// only for leaf attributes, so this inner-node registry needs
@@ -244,7 +317,11 @@ filter_init(
 		}
 		char table_name[64];
 		snprintf(
-			table_name, sizeof(table_name), "merge-table[%zu]", idx
+			table_name,
+			sizeof(table_name),
+			"merge-table(%s,%s)",
+			first_leaf[2 * idx],
+			first_leaf[2 * idx + 1]
 		);
 		if (merge_and_collect_registry(
 			    &filter->memory_context,

--- a/lib/filter/compiler/declare.h
+++ b/lib/filter/compiler/declare.h
@@ -9,6 +9,7 @@
 
 #define FILTER_ATTR_LOOKUP_HANDLER(name)                                       \
 	{                                                                      \
+		#name,                                                         \
 		name##_attr_init,                                              \
 		name##_attr_free,                                              \
 	}

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -654,8 +654,6 @@ merge_net6_range(
 	return 0;
 
 error_registry:
-	value_registry_fini(registry);
-
 error_net_registry:
 	value_registry_fini(&net_registry);
 

--- a/lib/filter/tests/context_names.c
+++ b/lib/filter/tests/context_names.c
@@ -1,0 +1,444 @@
+// Pins the leaf and inner memory_context naming: nodes are named after the
+// attribute (or attribute pair) they classify instead of their heap-index
+// position, and an attribute's own payload nests under its own leaf instead
+// of colliding with a sibling attribute on a shared name.
+#include "common/asan.h"
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/test_assert.h"
+
+#include "lib/filter/compiler.h"
+#include "lib/filter/filter.h"
+
+#include "lib/filter/tests/helpers.h"
+
+#include "logging/log.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+FILTER_COMPILER_DECLARE(sign_small_compile, device, vlan, port_src, port_dst);
+FILTER_COMPILER_DECLARE(
+	sign_large_compile, device, vlan, port_src, port_dst, proto_range
+);
+
+#define CTX_NAMES_ARENA_SIZE (1 << 24)
+
+static struct memory_context *
+ctx_child(struct memory_context *ctx) {
+	return ADDR_OF(&ctx->first_child);
+}
+
+static struct memory_context *
+ctx_sibling(struct memory_context *ctx) {
+	return ADDR_OF(&ctx->next_sibling);
+}
+
+// Counts the direct children of ctx named name.
+static int
+direct_child_count(struct memory_context *ctx, const char *name) {
+	int count = 0;
+	for (struct memory_context *child = ctx_child(ctx); child != NULL;
+	     child = ctx_sibling(child)) {
+		if (strcmp(child->name, name) == 0) {
+			++count;
+		}
+	}
+	return count;
+}
+
+// Recursively checks that no two siblings, at any depth under ctx, share a
+// name.
+static int
+no_duplicate_siblings(struct memory_context *ctx) {
+	for (struct memory_context *child = ctx_child(ctx); child != NULL;
+	     child = ctx_sibling(child)) {
+		for (struct memory_context *sibling = ctx_sibling(child);
+		     sibling != NULL;
+		     sibling = ctx_sibling(sibling)) {
+			TEST_ASSERT(
+				strcmp(child->name, sibling->name) != 0,
+				"duplicate sibling name '%s' under '%s'",
+				child->name,
+				ctx->name
+			);
+		}
+		TEST_ASSERT_SUCCESS(
+			no_duplicate_siblings(child),
+			"duplicate siblings under '%s'",
+			child->name
+		);
+	}
+	return TEST_SUCCESS;
+}
+
+// Recursively checks that no context name under ctx contains '[' or ']'.
+static int
+no_index_syntax(struct memory_context *ctx) {
+	for (struct memory_context *child = ctx_child(ctx); child != NULL;
+	     child = ctx_sibling(child)) {
+		TEST_ASSERT(
+			strchr(child->name, '[') == NULL &&
+				strchr(child->name, ']') == NULL,
+			"index-shaped name '%s'",
+			child->name
+		);
+		TEST_ASSERT_SUCCESS(
+			no_index_syntax(child), "under '%s'", child->name
+		);
+	}
+	return TEST_SUCCESS;
+}
+
+static int
+build_filter(
+	const struct filter_compiler *compiler,
+	struct memory_context *mctx,
+	struct filter *filter
+) {
+	struct filter_rule_builder b1;
+	builder_init(&b1);
+	builder_add_port_src_range(&b1, 5, 7);
+	builder_add_port_dst_range(&b1, 1, 5);
+	builder_set_vlan(&b1, 10);
+	builder_add_proto_range(&b1, 6, 6);
+	struct filter_rule r1 = build_rule(&b1);
+
+	struct filter_rule_builder b2;
+	builder_init(&b2);
+	builder_add_port_src_range(&b2, 8, 9);
+	builder_add_port_dst_range(&b2, 6, 9);
+	builder_set_vlan(&b2, 20);
+	builder_add_proto_range(&b2, 17, 17);
+	struct filter_rule r2 = build_rule(&b2);
+
+	const struct filter_rule *rule_ptrs[2] = {&r1, &r2};
+
+	return filter_init(filter, compiler, rule_ptrs, 2, mctx, NULL);
+}
+
+// Shared per-case fixture: a root memory_context over a fresh block
+// allocator, plus the allocator's free-byte count captured before any
+// filter is built, so fixture_check_balance can assert that filter_free
+// hands back every byte filter_init took.
+struct ctx_names_fixture {
+	struct block_allocator allocator;
+	struct memory_context mctx;
+	size_t free_before;
+};
+
+static int
+fixture_init(struct ctx_names_fixture *fx, void *arena) {
+	block_allocator_init(&fx->allocator);
+	block_allocator_put_arena(&fx->allocator, arena, CTX_NAMES_ARENA_SIZE);
+	if (memory_context_init(&fx->mctx, "test", &fx->allocator)) {
+		return -1;
+	}
+	fx->free_before = block_allocator_free_size(&fx->allocator);
+	return 0;
+}
+
+static int
+fixture_check_balance(struct ctx_names_fixture *fx) {
+	TEST_ASSERT_EQUAL(
+		block_allocator_free_size(&fx->allocator),
+		fx->free_before,
+		"arena free size mismatch after filter_free"
+	);
+	return TEST_SUCCESS;
+}
+
+static void
+fixture_fini(struct ctx_names_fixture *fx) {
+	memory_context_fini(&fx->mctx);
+}
+
+// Verifies that every attribute in a signature appears exactly once as a
+// direct child of the filter's memory_context, spelled like its
+// FILTER_COMPILER_DECLARE literal.
+static int
+test_leaf_named_after_attribute(void *arena) {
+	struct ctx_names_fixture fx;
+	TEST_ASSERT_SUCCESS(
+		fixture_init(&fx, arena), "failed to init root memory context"
+	);
+
+	struct filter filter;
+	TEST_ASSERT_SUCCESS(
+		build_filter(sign_small_compile, &fx.mctx, &filter),
+		"failed to build small filter"
+	);
+
+	static const char *names[] = {"device", "vlan", "port_src", "port_dst"};
+	for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); ++i) {
+		TEST_ASSERT_EQUAL(
+			direct_child_count(&filter.memory_context, names[i]),
+			1,
+			"attribute '%s' is not a direct child exactly once",
+			names[i]
+		);
+	}
+
+	filter_free(&filter, sign_small_compile);
+	TEST_ASSERT_SUCCESS(
+		fixture_check_balance(&fx), "leak freeing the small filter"
+	);
+	fixture_fini(&fx);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a leaf's attribute name is unaffected by appending another
+// attribute to the signature, unlike the old heap-index naming.
+static int
+test_leaf_names_survive_signature_change(void *arena) {
+	struct ctx_names_fixture fx;
+	TEST_ASSERT_SUCCESS(
+		fixture_init(&fx, arena), "failed to init root memory context"
+	);
+
+	struct filter small_filter;
+	TEST_ASSERT_SUCCESS(
+		build_filter(sign_small_compile, &fx.mctx, &small_filter),
+		"failed to build small filter"
+	);
+
+	struct filter large_filter;
+	TEST_ASSERT_SUCCESS(
+		build_filter(sign_large_compile, &fx.mctx, &large_filter),
+		"failed to build large filter"
+	);
+
+	// Anchor each shared attribute name at exactly one direct child in
+	// both trees, rather than only comparing counts against each other:
+	// a count-to-count comparison passes 0 == 0 just as well as 1 == 1,
+	// so it cannot fail if a rename moves the leaf out from under both
+	// trees at once. The tree's direct children also include inner
+	// merge nodes, whose names are expected to change shape between a
+	// 4- and 5-leaf tree, but the leaves shared by both signatures must
+	// not.
+	for (uint64_t i = 0; i < sign_small_compile->lookup_count; ++i) {
+		const char *name = sign_small_compile->lookups[i].name;
+		TEST_ASSERT_EQUAL(
+			direct_child_count(&small_filter.memory_context, name),
+			1,
+			"leaf '%s' is not a direct child of the small filter",
+			name
+		);
+		TEST_ASSERT_EQUAL(
+			direct_child_count(&large_filter.memory_context, name),
+			1,
+			"leaf '%s' did not survive the signature change",
+			name
+		);
+	}
+
+	filter_free(&large_filter, sign_large_compile);
+	filter_free(&small_filter, sign_small_compile);
+	TEST_ASSERT_SUCCESS(
+		fixture_check_balance(&fx), "leak freeing the two filters"
+	);
+	fixture_fini(&fx);
+	return TEST_SUCCESS;
+}
+
+// Verifies that reparenting attribute payloads under their own leaf ends
+// the sibling collision where port_src and port_dst both produced a "port"
+// child of the shared filter root.
+static int
+check_no_sibling_collision(
+	const struct filter_compiler *compiler, void *arena, const char *label
+) {
+	struct ctx_names_fixture fx;
+	TEST_ASSERT_SUCCESS(
+		fixture_init(&fx, arena),
+		"failed to init root memory context for %s signature",
+		label
+	);
+
+	struct filter filter;
+	TEST_ASSERT_SUCCESS(
+		build_filter(compiler, &fx.mctx, &filter),
+		"failed to build %s filter",
+		label
+	);
+
+	TEST_ASSERT_SUCCESS(
+		no_duplicate_siblings(&filter.memory_context),
+		"sibling name collision under the %s filter",
+		label
+	);
+
+	filter_free(&filter, compiler);
+	TEST_ASSERT_SUCCESS(
+		fixture_check_balance(&fx), "leak freeing the %s filter", label
+	);
+	fixture_fini(&fx);
+	return TEST_SUCCESS;
+}
+
+// Verifies that no two siblings anywhere under the filter's memory_context
+// share a name, for both the small and the large signature.
+static int
+test_no_sibling_name_collision(void *arena) {
+	TEST_ASSERT_SUCCESS(
+		check_no_sibling_collision(sign_small_compile, arena, "small"),
+		"small signature"
+	);
+	TEST_ASSERT_SUCCESS(
+		check_no_sibling_collision(sign_large_compile, arena, "large"),
+		"large signature"
+	);
+	return TEST_SUCCESS;
+}
+
+// Verifies that an attribute's leaf context parents both its registry and
+// its own payload as siblings: port_src has a "registry" child and a "port"
+// child, rather than one nesting under the other.
+static int
+test_leaf_parents_registry_and_payload(void *arena) {
+	struct ctx_names_fixture fx;
+	TEST_ASSERT_SUCCESS(
+		fixture_init(&fx, arena), "failed to init root memory context"
+	);
+
+	struct filter filter;
+	TEST_ASSERT_SUCCESS(
+		build_filter(sign_small_compile, &fx.mctx, &filter),
+		"failed to build small filter"
+	);
+
+	struct memory_context *port_src_ctx = NULL;
+	for (struct memory_context *child = ctx_child(&filter.memory_context);
+	     child != NULL;
+	     child = ctx_sibling(child)) {
+		if (strcmp(child->name, "port_src") == 0) {
+			port_src_ctx = child;
+			break;
+		}
+	}
+	TEST_ASSERT(
+		port_src_ctx != NULL, "no 'port_src' child under the filter"
+	);
+
+	TEST_ASSERT_EQUAL(
+		direct_child_count(port_src_ctx, "registry"),
+		1,
+		"'port_src' has no 'registry' child"
+	);
+	TEST_ASSERT_EQUAL(
+		direct_child_count(port_src_ctx, "port"),
+		1,
+		"'port_src' has no 'port' child"
+	);
+
+	filter_free(&filter, sign_small_compile);
+	TEST_ASSERT_SUCCESS(
+		fixture_check_balance(&fx), "leak freeing the small filter"
+	);
+	fixture_fini(&fx);
+	return TEST_SUCCESS;
+}
+
+// Verifies that no context name under the filter encodes a vertex index.
+static int
+test_no_index_shaped_names(void *arena) {
+	struct ctx_names_fixture fx;
+	TEST_ASSERT_SUCCESS(
+		fixture_init(&fx, arena), "failed to init root memory context"
+	);
+
+	struct filter filter;
+	TEST_ASSERT_SUCCESS(
+		build_filter(sign_large_compile, &fx.mctx, &filter),
+		"failed to build large filter"
+	);
+
+	TEST_ASSERT_SUCCESS(
+		no_index_syntax(&filter.memory_context),
+		"index-shaped name found under the filter"
+	);
+
+	filter_free(&filter, sign_large_compile);
+	TEST_ASSERT_SUCCESS(
+		fixture_check_balance(&fx), "leak freeing the large filter"
+	);
+	fixture_fini(&fx);
+	return TEST_SUCCESS;
+}
+
+// Verifies that filter_free leaves the parent context childless and hands
+// the allocator back every byte filter_init took.
+static int
+test_teardown_leaves_nothing_behind(void *arena) {
+	struct ctx_names_fixture fx;
+	TEST_ASSERT_SUCCESS(
+		fixture_init(&fx, arena), "failed to init root memory context"
+	);
+
+	struct filter filter;
+	TEST_ASSERT_SUCCESS(
+		build_filter(sign_large_compile, &fx.mctx, &filter),
+		"failed to build large filter"
+	);
+
+	filter_free(&filter, sign_large_compile);
+
+	TEST_ASSERT_NULL(
+		ctx_child(&fx.mctx), "parent context still has children"
+	);
+	TEST_ASSERT_SUCCESS(
+		fixture_check_balance(&fx), "leak freeing the large filter"
+	);
+	fixture_fini(&fx);
+	return TEST_SUCCESS;
+}
+
+int
+main() {
+	log_enable_name("debug");
+	void *arena = malloc(CTX_NAMES_ARENA_SIZE);
+	int failed = 0;
+
+	struct {
+		const char *name;
+		int (*func)(void *);
+	} cases[] = {
+		{"leaf_named_after_attribute", test_leaf_named_after_attribute},
+		{"leaf_names_survive_signature_change",
+		 test_leaf_names_survive_signature_change},
+		{"no_sibling_name_collision", test_no_sibling_name_collision},
+		{"leaf_parents_registry_and_payload",
+		 test_leaf_parents_registry_and_payload},
+		{"no_index_shaped_names", test_no_index_shaped_names},
+		{"teardown_leaves_nothing_behind",
+		 test_teardown_leaves_nothing_behind},
+	};
+
+	for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {
+		// The previous case's filter_free left its freed blocks
+		// ASan-poisoned, so the arena needs unpoisoning before this
+		// case's fill can touch it.
+		asan_unpoison_memory_region(arena, CTX_NAMES_ARENA_SIZE);
+		memset(arena, 0, CTX_NAMES_ARENA_SIZE);
+		if (cases[i].func(arena) != TEST_SUCCESS) {
+			LOG(ERROR, "%s failed", cases[i].name);
+			failed = 1;
+			continue;
+		}
+		LOG(INFO, "%s passed", cases[i].name);
+	}
+
+	// The last case leaves the arena poisoned. The call to free below
+	// requires it unpoisoned first.
+	asan_unpoison_memory_region(arena, CTX_NAMES_ARENA_SIZE);
+	free(arena);
+
+	if (failed) {
+		LOG(ERROR, "context_names tests FAILED");
+		return 1;
+	}
+
+	LOG(INFO, "All context_names tests passed");
+	return 0;
+}

--- a/lib/filter/tests/meson.build
+++ b/lib/filter/tests/meson.build
@@ -81,6 +81,16 @@ test_filter_memory = executable('memory',
 )
 test('memory', test_filter_memory, suite: ['filter'])
 
+# test memory_context node naming
+test_filter_context_names = executable('context_names',
+  ['context_names.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: test_deps,
+  link_language: 'c'
+)
+test('context_names', test_filter_context_names, suite: ['filter'])
+
 # test vlan
 test_filter_vlan = executable('basic_vlan',
   ['basic_vlan.c'],

--- a/lib/filter/tests/oom_sweep.c
+++ b/lib/filter/tests/oom_sweep.c
@@ -294,6 +294,7 @@ sweep_signature(
 			name,
 			fail_at
 		);
+		size_t free_before = block_allocator_free_size(&allocator);
 
 		struct filter failed_filter;
 		int frc = sweep_compile(
@@ -309,6 +310,14 @@ sweep_signature(
 			-1,
 			"%s: injecting a failure at call %ld did not produce "
 			"a clean OOM",
+			name,
+			fail_at
+		);
+		SWEEP_ASSERT_EQUAL(
+			block_allocator_free_size(&allocator),
+			free_before,
+			"%s: injecting a failure at call %ld leaked arena "
+			"bytes",
 			name,
 			fail_at
 		);


### PR DESCRIPTION
Filter memory-context nodes were named after their position in the classification tree's implicit binary heap. Such a name carries no attribute identity, and it shifts whenever an attribute is added to or removed from a filter signature, so a dashboard or alert keyed on one of those paths silently starts measuring a different attribute instead of failing loudly.

- Each leaf attribute now owns a memory context named after the attribute itself, taken from the signature declaration, so reading a path identifies the attribute without cross-referencing the module source.
- The leaf value registry and everything the attribute allocates are nested under that context, which finally separates the source and destination variants of an attribute that previously produced indistinguishable sibling nodes.
- Inner merge nodes are named after the subtrees they merge rather than after their heap index, so a name changes when its content changes instead of persisting with a new meaning.
- Dropped a redundant teardown of a caller-owned registry in the IPv6 network attribute. It was harmless while it was merely a double release, but it destroyed the link the new per-attribute context relies on and leaked that context on every failed apply.
- Added a test pinning the naming invariants, and extended the allocation-failure sweep to require that a failed filter compile return every byte it took, which is the check that catches the leak above.

Closes #1821.
