### PR TITLE
chore(ci): run the pull-request checks on stacked branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,8 @@ on:
       - ".github/actions/apt-packages/**"
       - ".github/actions/go-modcache/**"
   pull_request:
-    branches: ["main"]
+    # A stacked pull request has a non-main base, so a main-only filter would skip it.
+    branches: ["**"]
     paths:
       - "**.h"
       - "**.c"

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -9,7 +9,8 @@ on:
       - ".github/actions/clang-format/**"
       - ".github/workflows/check-format.yml"
   pull_request:
-    branches: ["main"]
+    # A stacked pull request has a non-main base, so a main-only filter would skip it.
+    branches: ["**"]
     paths:
       - "**.h"
       - "**.c"

--- a/.github/workflows/go-formatting.yml
+++ b/.github/workflows/go-formatting.yml
@@ -8,7 +8,8 @@ on:
       - "go.mod"
       - ".github/workflows/go-formatting.yml"
   pull_request:
-    branches: [main, master]
+    # A stacked pull request has a non-main base, so a main-only filter would skip it.
+    branches: ["**"]
     paths:
       - "**/*.go"
       - "go.mod"

--- a/.github/workflows/meson-lint.yml
+++ b/.github/workflows/meson-lint.yml
@@ -9,7 +9,8 @@ on:
       - 'meson_options.txt'
       - '.github/workflows/meson-lint.yml'
   pull_request:
-    branches: [main]
+    # A stacked pull request has a non-main base, so a main-only filter would skip it.
+    branches: ["**"]
     paths:
       - '**/meson.build'
       - '**/meson.options'

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -17,7 +17,8 @@ on:
       - ".github/workflows/rust-check.yml"
       - ".github/actions/apt-packages/**"
   pull_request:
-    branches: ["main"]
+    # A stacked pull request has a non-main base, so a main-only filter would skip it.
+    branches: ["**"]
     paths:
       - "**.rs"
       - "**/Cargo.toml"

--- a/.github/workflows/web-check.yml
+++ b/.github/workflows/web-check.yml
@@ -12,7 +12,8 @@ on:
       - "package-lock.json"
       - ".github/workflows/web-check.yml"
   pull_request:
-    branches: ["main"]
+    # A stacked pull request has a non-main base, so a main-only filter would skip it.
+    branches: ["**"]
     paths:
       - "web/**"
       - "modules/**/web/**"


### PR DESCRIPTION
A pull request whose base branch is not `main` — a stacked pull request — received the packaging job and nothing else, because six workflows restricted their pull-request trigger to a `main` base. Its own CI status was therefore not a coverage signal. Before #1826 the packaging job's autodetected debhelper test step happened to be such a pull request's only suite execution, which masked the gap.

- Widens the pull-request base filter to any branch in the six affected workflows: the build suite, the Rust, web, C-formatting and Meson checks, and the Go formatting check. The packaging workflow already accepted any base, so the trigger surface is now uniform and no workflow is restricted to a `main` base.
- Leaves every push filter on `main`. The asymmetry between the two triggers is deliberate, since widening the push filter would build a feature branch twice per commit, once for the push and once for the pull request. A one-line comment in each file records that reason so the asymmetry is not later mistaken for an inconsistency.
- Normalises the two filters that used an unquoted form. The glob has to be quoted, because an unquoted `**` parses as a YAML alias rather than a string.

On the wall-clock trade-off #1827 asks to weigh explicitly: this costs epic #1776 nothing that it measures. A pull request based on `main` already ran all six workflows, so its critical path is unchanged, and the packaging job that sets that critical path is untouched. The new cost falls only on stacked pull requests, which today pay for the single most expensive job while receiving the least signal.

Two assumptions that would have silently voided the change were checked rather than assumed. The widened glob does match a slash, so an ordinary `feat/step-1` base is covered. The shared build caches cannot be polluted either, because their write gates are already false on every pull request, and a pull-request cache write is scoped to the merge ref regardless.

Closes #1827.