### PR TITLE
chore(ci): drop the redundant cargo check job

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -2,10 +2,10 @@ name: Rust Check
 
 # Cargo caches here are shared and written from main only.
 #
-# Check and clippy compile dependencies in the same metadata mode, so one
-# entry serves both, while test compiles them fully and needs its own. A
-# cache written on a pull-request ref is readable only from that same pull
-# request, so saving one there costs repository quota and buys nothing.
+# Clippy and test compile dependencies in different metadata modes, so
+# each needs its own cache entry. A cache written on a pull-request ref
+# is readable only from that same pull request, so saving one there
+# costs repository quota and buys nothing.
 
 on:
   push:
@@ -41,24 +41,6 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
-  check:
-    name: cargo check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-      - name: Cache cargo registry
-        uses: Swatinem/rust-cache@v2.9.2
-        with:
-          shared-key: rust-check
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: ./.github/actions/apt-packages
-        with:
-          packages: protobuf-compiler
-      - run: cargo check --workspace
-
   test:
     name: cargo test
     runs-on: ubuntu-latest
@@ -67,7 +49,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - name: Cache cargo registry
+      - name: Cache cargo registry and target directory
         uses: Swatinem/rust-cache@v2.9.2
         with:
           shared-key: rust-test
@@ -77,6 +59,9 @@ jobs:
           packages: protobuf-compiler
       - run: cargo test --workspace
 
+  # Clippy runs the full compiler front end over the workspace, so a type
+  # error fails it exactly as a dedicated cargo check job would, which is
+  # why there is no separate compile-only job.
   clippy:
     name: cargo clippy
     runs-on: ubuntu-latest
@@ -86,7 +71,7 @@ jobs:
         with:
           toolchain: stable
           components: clippy
-      - name: Cache cargo registry
+      - name: Cache cargo registry and target directory
         uses: Swatinem/rust-cache@v2.9.2
         with:
           shared-key: rust-check


### PR DESCRIPTION
Answers both questions #1823 asked, against measured CI data rather than estimates.

## Keep the cargo target cache

Warm job times, measured against the cache entries #1818 populated, versus the cold numbers from #1818's own run: check 66s to 31s, clippy 92s to 34s, test 70s to 36s. That is roughly 127s of runner time and 56s of wall clock per rust-touching pull request.

The cost is two entries written only from main, 197 MB and 282 MB, which refresh in place rather than accumulating one per pull request. Both were still being read hours after they were written, so they are not the entries the repository cache cap is evicting — a 3.88 GB QEMU disk image and about a gigabyte of superseded compiler-cache generations are. Narrowing to registry-only would reclaim roughly 356 MB, which the next compiler-cache generation takes back within hours, while giving up most of the per-job saving. So the caching configuration is unchanged here.

## Drop the cargo check job

Clippy already runs the same compiler front end over the same workspace targets, so the dedicated compile-only job repeated that work on every rust-touching pull request. The two build plans are byte-identical, because clippy drives the same check pass under a compiler wrapper, so there is no configuration corner the deleted job covered alone. The test job independently compiles the same targets in stronger modes and adds doctests, leaving two survivors that each catch any compile error the deleted job caught.

The counter-argument was a distinct red signal for a compile error versus a lint failure. It loses to the runner cost, since a developer opens the failing job's log either way. Removing the job cannot leave a required check pending, as the repository ruleset requires no status checks, and nothing outside this workflow referenced it.

The shared cache key is deliberately left at its current value so the live main entry stays valid instead of repopulating cold. Clippy is now its only reader and writer.

The cache step names are also corrected, since they claimed to cache only the registry while the action stores the target directory as well.

Closes #1823.
