### PR TITLE
chore(packaging): stop the deb build discarding caller options

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,8 +21,15 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 # leave a relative path, which DWARF forbids for DW_AT_comp_dir.
 export DEB_BUILD_DEBUGPATH = /usr/src/yanet2
 
-# Set parallel build options
-export DEB_BUILD_OPTIONS = parallel=$(shell nproc)
+# Fall back to nproc for parallel jobs when the caller supplies none.
+#
+# The dpkg-buildpackage tool exports DEB_BUILD_OPTIONS with a parallel
+# value defaulting to the processor count (absent -j, -J, or parallel=)
+# before debian/rules runs, so this fallback only takes effect when
+# debian/rules is invoked directly.
+ifeq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
+export DEB_BUILD_OPTIONS += parallel=$(shell nproc)
+endif
 
 # Meson build directory
 BUILDDIR = build


### PR DESCRIPTION
The packaging rules replaced the whole build-options variable with a job count, so the documented Debian vocabulary for skipping tests, disabling optimisation or quieting the log was silently dropped before it could reach the build. Setting any of it in the environment had no effect on this package.

A job count is now appended only when the caller has not already chosen one, so an unrelated option and an explicit job count both survive. The guard keys on the presence of a job count rather than on the variable being empty, so an option that says nothing about parallelism still gets the default.

This is inert on the repository's own packaging path, because dpkg-buildpackage already defaults the job count to the processor count and exports it before the rules file runs. It matters when the rules file is driven directly, and it is what makes the documented environment interface work again.

Verified with a probe that reports the variable as the build actually receives it. On the base commit all five inputs collapse to the same job count, which is the bug. With the change, an unrelated option is preserved, two unrelated options are preserved, an explicit job count of one is left untouched, and a mixed pair keeps both.

Closes #1829.