### PR TITLE
chore(ci): probe the stacked-branch trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build YANET
+# Probe commit for the stacked-branch trigger check. Never merged.
 
 on:
   push:


### PR DESCRIPTION
Throwaway probe. Do not merge, do not review — this will be closed and its branch deleted as soon as its check list has been read.

- Exists only to verify acceptance criterion 2 of #1827: that a pull request based on a branch other than `main` now runs the build workflow. Its base is #1848's branch, so the merge ref carries the widened trigger filters.
- Touches the build workflow itself, which is listed in that workflow's own path filter, so a missing run could not be blamed on the path filter rather than the branch filter.