### PR TITLE
chore(dataplane): drop unused device stub

### DIFF
--- a/lib/dataplane/device/device.c
+++ b/lib/dataplane/device/device.c
@@ -1,1 +1,0 @@
-#include "device.h"


### PR DESCRIPTION
- Remove the uncompiled dataplane device source stub.
- Keep the live device header and existing consumers unchanged.
- Verify the full C, Go, Meson, and fuzzing gates.

Closes #1845.