### PR TITLE
perf(ci): sweep superseded cache generations at the rate they appear

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -4,10 +4,14 @@ name: Actions cache cleanup
 # to LRU-evict live entries: superseded ccache-action generations (it never
 # prunes its own timestamped keys) and caches left on already-merged or
 # closed PR refs.
+#
+# Superseded generations pile up through the working day faster than a
+# once-daily sweep clears them, so the sweep runs hourly to match the rate
+# they appear.
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    - cron: "17 * * * *"
   workflow_dispatch:
     inputs:
       dry_run:
@@ -15,6 +19,14 @@ on:
         required: false
         default: true
         type: boolean
+
+# The hourly cron and a manual dispatch must never overlap: a losing sweep
+# would select caches the winner already deleted, so every one of its
+# delete calls fails and the every-delete-failed guard turns the run red.
+# Let a running sweep finish rather than cancelling it mid delete-loop.
+concurrency:
+  group: cache-cleanup
+  cancel-in-progress: false
 
 permissions:
   actions: write


### PR DESCRIPTION
The cache cleanup workflow prunes superseded compiler-cache generations, which the action that writes them never prunes itself. It ran on a single daily cron, and that cadence is scheduled at the wrong point in the accumulation cycle.

Its last daily run enumerated only 24 cache entries across the whole repository, selected one, and reclaimed 144 MiB, because it fires at the quietest hour, before the working day's generations exist. Eight hours later the repository held 91 entries at 9.83 GiB against the 10 GB cap, of which 2460 MB were superseded generations across four families — roughly 307 MB of new dead weight an hour. So about a quarter of the budget sat dead for most of each working day, forcing eviction of live entries, which is the umbrella problem #1804 named and #1806 was meant to solve.

Sweeping hourly matches the rate the generations appear. The selection logic is unchanged and was never at fault — the last run deleted exactly the entry it selected.

The sweeps are also serialized. A manual dispatch overlapping a cron tick would find its whole selection already deleted by the winner, and the guard that fails a run when every delete fails would then turn it red. Cancellation stays disabled so a running sweep finishes rather than being killed part-way through its deletes.

One caveat for the follow-up measurement: this repository's scheduler delivered the previous cron tick 63 minutes late, and missed schedule events are dropped rather than replayed, so the reclaim should be judged against the runs that actually fired rather than an assumed 24 a day. Even at half delivery the worst-case window is about a quarter of what was measured.

Closes #1855.
