### PR TITLE
fix(ci): compare a pull request against its own base branch

### DIFF
--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -44,8 +44,21 @@ jobs:
         with:
           setup_only: true
 
+      # Comparing against the base branch rather than main keeps a stacked pull
+      # request from being blamed for its parent's breaking changes.
       - name: Run buf breaking
-        run: buf breaking --against "https://github.com/${{ github.repository }}.git#branch=main"
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # Buf reads the fragment as a comma-separated option list, so a comma
+          # in the branch name would arrive as extra options, not as the name.
+          case "${BASE_REF}" in
+            *,*)
+              echo "::error::base branch name contains a comma: ${BASE_REF}"
+              exit 1
+              ;;
+          esac
+          buf breaking --against "https://github.com/${{ github.repository }}.git#branch=${BASE_REF}"
 
   protolint:
     name: Custom protolint linter

--- a/docs/proto-compatibility.md
+++ b/docs/proto-compatibility.md
@@ -91,9 +91,9 @@ Second, `reserved` is appropriate for field numbers that were removed from a pac
 
 ## What the Gate Enforces
 
-`buf breaking` runs on every pull request, comparing the branch against `main` using the `PACKAGE` breaking-change category configured in `buf.yaml`. The `PACKAGE` ruleset catches wire-incompatible changes at the package, file, message, field, enum, and RPC level — covering all cases described above. Critically, it is additive-only for existing packages: it blocks deleting fields, enum values, messages, RPCs, and services (via the `*_NO_DELETE` rules) in addition to catching type and number changes, so the only safe in-place evolution of a frozen `.v1` package is adding new elements. For the full rule taxonomy, see the [buf breaking overview](https://buf.build/docs/breaking/overview).
+`buf breaking` runs on every pull request, comparing the branch against its base using the `PACKAGE` breaking-change category configured in `buf.yaml`. The `PACKAGE` ruleset catches wire-incompatible changes at the package, file, message, field, enum, and RPC level — covering all cases described above. Critically, it is additive-only for existing packages: it blocks deleting fields, enum values, messages, RPCs, and services (via the `*_NO_DELETE` rules) in addition to catching type and number changes, so the only safe in-place evolution of a frozen `.v1` package is adding new elements. For the full rule taxonomy, see the [buf breaking overview](https://buf.build/docs/breaking/overview).
 
-In CI (`proto-lint.yml`), the `buf-breaking` job runs only on pull requests (not on direct pushes to `main`), comparing against `https://github.com/yanet-platform/yanet2.git#branch=main`.
+In CI (`proto-lint.yml`), the `buf-breaking` job runs only on pull requests (not on direct pushes to `main`), comparing against the pull request's own base branch. For an ordinary pull request that base is `main`. For one opened against another branch it is that branch, so the parent's breaking changes are not reported against the child.
 
 ## Documented Exclusions and Rule Exceptions
 
@@ -136,7 +136,7 @@ make proto-lint
 make proto-breaking
 ```
 
-`make proto-lint` also runs the custom Go-based `protolint` tool that checks `go_package` alignment across all protos. `make proto-breaking` invokes `buf breaking --against ".git#branch=main"` — run it on a feature branch to catch issues before opening a PR.
+`make proto-lint` also runs the custom Go-based `protolint` tool that checks `go_package` alignment across all protos. `make proto-breaking` invokes `buf breaking --against ".git#branch=main"` — run it on a feature branch to catch issues before opening a PR. It always compares against `main`, so for a pull request opened against another branch, point it at that branch instead to match what CI will check.
 
 ## PR Author Checklist
 


### PR DESCRIPTION
The breaking-change gate compared every pull request against `main`. A pull request opened against another branch carries that branch's changes too, so its parent's breaking proto edits were reported as the child's — and the reported violation names a file absent from the child's own diff, which invites a developer to "fix" their pull request by reverting the parent's change into it. That repair is actively wrong.

- Compares against the pull request's declared base instead, which is `main` for an ordinary pull request and leaves that common path byte-identical.
- Corrects `docs/proto-compatibility.md`, which quoted the old comparison base verbatim and would otherwise have documented a falsehood about the very gate this fixes.
- Leaves the local `make proto-breaking` target comparing against `main`, since there is no ambient pull-request base locally, and documents that divergence rather than inventing local base detection.

Two limits worth stating plainly. The fix keys on GitHub's declared base, not on git ancestry, so a branch forked from a parent but opened against `main` still compares against `main` and is unaffected. And because the comparison resolves the base branch's current tip, a parent that advances after the child forks contributes its newer commits — true of the previous `main`-based comparison as well, so not a change in behaviour.

This is also slightly stricter in one case: a child that retypes or removes an element its own parent introduced now reports a violation where comparing against `main` did not, because `main` never carried that element. Nothing outside the stack can depend on it, and the fix is to amend the parent. This is the unavoidable dual of attributing correctly — any basis that attributes correctly must treat the parent's tree as the contract.

Verified locally against buf 1.69.0 in a scratch clone rather than argued. With a breaking retype on a parent branch and a purely additive child on top, comparing the child against `main` exits 100 and names a file the child never touched, while comparing it against the parent exits 0; a child carrying its own breaking retype still exits 100 against the parent, and a missing base branch fails loudly at exit 1 rather than passing silently. Transitivity of the `PACKAGE` ruleset means a chain cannot smuggle a break onto `main`, since the first link's own pull request compares against `main`.

Closes #1852.