### PR TITLE
chore(ci): pin the protobuf plugin versions instead of go install @latest

### DIFF
--- a/.github/actions/protoc-plugins/action.yml
+++ b/.github/actions/protoc-plugins/action.yml
@@ -1,0 +1,20 @@
+name: 'Install Go Protobuf Plugins'
+description: >-
+  Install protoc-gen-go and protoc-gen-go-grpc at versions pinned here rather
+  than at @latest, since an unpinned plugin can pick a newer Go directive
+  than the job's pinned toolchain and drag in a second Go download mid-job.
+  GOTOOLCHAIN=local turns that mismatch into a loud install failure instead.
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install pinned protoc-gen-go and protoc-gen-go-grpc
+      shell: bash
+      env:
+        GOTOOLCHAIN: local
+        PROTOC_GEN_GO_VERSION: v1.36.11
+        PROTOC_GEN_GO_GRPC_VERSION: v1.6.1
+      run: |
+        set -euo pipefail
+        go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}
+        go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}

--- a/.github/workflows/Dockerfile.base.dev
+++ b/.github/workflows/Dockerfile.base.dev
@@ -10,8 +10,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PATH="/usr/local/go/bin:${PATH}"
 
 ARG GO_VERSION=1.24.13
-ARG PROTOC_GEN_GO_VERSION=latest
-ARG PROTOC_GEN_GO_GRPC_VERSION=latest
+ARG PROTOC_GEN_GO_VERSION=v1.36.11
+ARG PROTOC_GEN_GO_GRPC_VERSION=v1.6.1
 
 RUN apt-get update -y && apt-get install -y \
     meson \
@@ -52,8 +52,8 @@ RUN apt-get update -y && apt-get install -y \
 RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" \
     | tar -C /usr/local -xz
 
-RUN GOBIN=/usr/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} \
-    && GOBIN=/usr/bin go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
+RUN GOBIN=/usr/bin GOTOOLCHAIN=local go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION} \
+    && GOBIN=/usr/bin GOTOOLCHAIN=local go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
 
 RUN rustup set auto-self-update disable \
     && rustup install stable

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -110,9 +110,7 @@ jobs:
       - name: Restore Go module cache
         uses: ./.github/actions/go-modcache
       - name: Install Go Protobuf Plugins
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+        uses: ./.github/actions/protoc-plugins
 
       - name: Build packages
         run: |

--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -52,9 +52,7 @@ jobs:
         uses: ./.github/actions/go-modcache
 
       - name: Install Go Protobuf Plugins
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+        uses: ./.github/actions/protoc-plugins
 
       - name: Build packages
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ on:
       - ".github/workflows/build.yml"
       - ".github/actions/apt-packages/**"
       - ".github/actions/go-modcache/**"
+      - ".github/actions/protoc-plugins/**"
   pull_request:
     # A stacked pull request has a non-main base, so a main-only filter would skip it.
     branches: ["**"]
@@ -44,6 +45,7 @@ on:
       - ".github/workflows/build.yml"
       - ".github/actions/apt-packages/**"
       - ".github/actions/go-modcache/**"
+      - ".github/actions/protoc-plugins/**"
 
 concurrency:
   # The run_id fallback keeps non-PR runs from cancelling each other.
@@ -81,9 +83,7 @@ jobs:
         uses: ./.github/actions/go-modcache
 
       - name: Install Go Protobuf Plugins
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+        uses: ./.github/actions/protoc-plugins
 
       - name: Build YANET (sanitize)
         run: |
@@ -128,9 +128,7 @@ jobs:
         uses: ./.github/actions/go-modcache
 
       - name: Install Go Protobuf Plugins
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+        uses: ./.github/actions/protoc-plugins
 
       - name: Run TSAN tests
         run: make test-tsan
@@ -183,9 +181,7 @@ jobs:
         uses: ./.github/actions/go-modcache
 
       - name: Install Go Protobuf Plugins
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+        uses: ./.github/actions/protoc-plugins
 
       - name: Build YANET (release)
         run: |

--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -39,9 +39,7 @@ jobs:
         uses: ./.github/actions/go-modcache
 
       - name: Install Go Protobuf Plugins
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+        uses: ./.github/actions/protoc-plugins
 
       - uses: hendrikmuhs/ccache-action@v1.2.18
         name: ccache

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -9,6 +9,7 @@ on:
       - '.golangci.yml'
       - '.github/workflows/go-lint.yml'
       - '.github/actions/apt-packages/**'
+      - '.github/actions/protoc-plugins/**'
   pull_request:
     paths:
       - '**/*.go'
@@ -16,6 +17,7 @@ on:
       - '.golangci.yml'
       - '.github/workflows/go-lint.yml'
       - '.github/actions/apt-packages/**'
+      - '.github/actions/protoc-plugins/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -54,10 +56,8 @@ jobs:
         with:
           packages: protobuf-compiler libpcap-dev
 
-      - name: Install Go protobuf plugins
-        run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+      - name: Install Go Protobuf Plugins
+        uses: ./.github/actions/protoc-plugins
 
       - name: Generate protobuf Go sources
         run: make proto-go

--- a/Makefile
+++ b/Makefile
@@ -162,8 +162,8 @@ proto-breaking:
 
 proto-go:
 	@command -v protoc >/dev/null 2>&1 || { echo "ERROR: protoc not found (install protobuf-compiler)"; exit 1; }
-	@command -v protoc-gen-go >/dev/null 2>&1 || { echo "ERROR: protoc-gen-go not found (go install google.golang.org/protobuf/cmd/protoc-gen-go@latest)"; exit 1; }
-	@command -v protoc-gen-go-grpc >/dev/null 2>&1 || { echo "ERROR: protoc-gen-go-grpc not found (go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest)"; exit 1; }
+	@command -v protoc-gen-go >/dev/null 2>&1 || { echo "ERROR: protoc-gen-go not found (go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11)"; exit 1; }
+	@command -v protoc-gen-go-grpc >/dev/null 2>&1 || { echo "ERROR: protoc-gen-go-grpc not found (go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1)"; exit 1; }
 	@set -e; protos=$$(find . \
 		\( -path './subprojects' -o -path './build*' -o -type d -name '.?*' \) -prune \
 		-o -name '*.proto' -print \


### PR DESCRIPTION
- Both protobuf plugins were installed at a floating latest in seven places across five workflows, so code generation was not reproducible between runs.
- One resolution already picked a gRPC plugin release requiring a newer Go than the workflows pin, and Go silently downloaded a second toolchain mid-job instead of naming the conflict.
- A shared composite action now installs both plugins and is the single place either version is declared.
- The protobuf plugin is pinned to the release matching the protobuf runtime the module already requires, and the gRPC plugin to the newest release whose Go requirement fits the toolchain the jobs pin.
- Enforcing the local Go toolchain during that install turns any future mismatch into an explicit failure naming the conflicting versions, rather than a silent second download.
- The two workflows that filter on changed paths now list the new action, so a later version bump still triggers them.
- The development image and the local build hints move to the same pinned versions.
- The functional-test virtual machine provisions Go from its distribution, which predates both pins, so it keeps the floating versions for now; correcting it means changing how that image provisions Go and is left to a follow-up together with the documentation describing the same setup.

Closes #1787.