### PR TITLE
fix(controlplane): pass module type when deleting configs

### DIFF
--- a/controlplane/ffi/agent.go
+++ b/controlplane/ffi/agent.go
@@ -316,8 +316,8 @@ func (m *Agent) DeletePipeline(name string) error {
 	return nil
 }
 
-func (m *Agent) DeleteModuleConfig(configName string) error {
-	cTypeName := C.CString(m.name)
+func (m *Agent) DeleteModuleConfig(moduleType, configName string) error {
+	cTypeName := C.CString(moduleType)
 	defer C.free(unsafe.Pointer(cTypeName))
 
 	cConfigName := C.CString(configName)
@@ -331,7 +331,12 @@ func (m *Agent) DeleteModuleConfig(configName string) error {
 		&cErr,
 	)
 	if result != 0 {
-		return fmt.Errorf("failed to delete module config %q: %w", configName, cerrors.FromC(unsafe.Pointer(cErr)))
+		return fmt.Errorf(
+			"failed to delete module config type %q name %q: %w",
+			moduleType,
+			configName,
+			cerrors.FromC(unsafe.Pointer(cErr)),
+		)
 	}
 	return nil
 }

--- a/modules/acl/controlplane/backend.go
+++ b/modules/acl/controlplane/backend.go
@@ -35,7 +35,7 @@ func (m *backend) UpdateModule(handle ModuleHandle) error {
 }
 
 func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(name)
+	return m.agent.DeleteModuleConfig(moduleType, name)
 }
 
 func (m *backend) MemoryBytes() uint64 {

--- a/modules/acl/controlplane/metrics.go
+++ b/modules/acl/controlplane/metrics.go
@@ -87,7 +87,7 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 		return []*commonpb.Metric{}, nil
 	}
 
-	positions := dpConfig.AllModulePositions("acl")
+	positions := dpConfig.AllModulePositions(moduleType)
 
 	names, read := metrics.Query(tags,
 		metrics.WithStructuralCounters(aclStructuralCounters),
@@ -114,7 +114,7 @@ func (m *ACLService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]*com
 				pos.Pipeline,
 				pos.Function,
 				pos.Chain,
-				"acl",
+				moduleType,
 				configName,
 				names,
 			)

--- a/modules/acl/controlplane/mod.go
+++ b/modules/acl/controlplane/mod.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	agentName   = "acl"
+	moduleType  = "acl"
+	agentName   = moduleType
 	serviceName = "modules.acl.controlplane.aclpb.v1.ACLService"
 )
 
@@ -107,7 +108,7 @@ func NewACLModule(cfg *Config, options ...ModuleOption) (*ACLModule, error) {
 }
 
 func (m *ACLModule) Name() string {
-	return "acl"
+	return moduleType
 }
 
 func (m *ACLModule) Endpoint() string {

--- a/modules/blackhole/controlplane/backend.go
+++ b/modules/blackhole/controlplane/backend.go
@@ -36,5 +36,5 @@ func (m *backend) UpdateModule(name string) (ModuleHandle, error) {
 }
 
 func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(name)
+	return m.agent.DeleteModuleConfig(moduleName, name)
 }

--- a/modules/blackhole/controlplane/mod.go
+++ b/modules/blackhole/controlplane/mod.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	agentName   = "blackhole"
 	moduleName  = "blackhole"
+	agentName   = moduleName
 	serviceName = "modules.blackhole.controlplane.blackholepb.v1.BlackholeService"
 )
 

--- a/modules/forward/controlplane/backend.go
+++ b/modules/forward/controlplane/backend.go
@@ -48,14 +48,14 @@ func (m *backend) UpdateModule(name string, rules []cforward.ForwardRule) (Modul
 }
 
 func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(name)
+	return m.agent.DeleteModuleConfig(moduleType, name)
 }
 
 func (m *backend) ModuleCounters(name string, counterNames []string) []CounterView {
 	dpConfig := m.agent.DPConfig()
 
 	var views []CounterView
-	for pos := range dpConfig.AllModulePositions(agentName) {
+	for pos := range dpConfig.AllModulePositions(moduleType) {
 		if pos.ModuleName != name {
 			continue
 		}
@@ -65,7 +65,7 @@ func (m *backend) ModuleCounters(name string, counterNames []string) []CounterVi
 			pos.Pipeline,
 			pos.Function,
 			pos.Chain,
-			agentName,
+			moduleType,
 			name,
 			counterNames,
 		)

--- a/modules/forward/controlplane/mod.go
+++ b/modules/forward/controlplane/mod.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	agentName   = "forward"
+	moduleType  = "forward"
+	agentName   = moduleType
 	serviceName = "modules.forward.controlplane.forwardpb.v1.ForwardService"
 )
 
@@ -83,7 +84,7 @@ func NewForwardModule(cfg *Config, options ...Option) (*ForwardModule, error) {
 }
 
 func (m *ForwardModule) Name() string {
-	return agentName
+	return moduleType
 }
 
 func (m *ForwardModule) Endpoint() string {

--- a/modules/fwstate/controlplane/delete_test.go
+++ b/modules/fwstate/controlplane/delete_test.go
@@ -1,0 +1,152 @@
+package fwstate_test
+
+import (
+	"testing"
+
+	"github.com/c2h5oh/datasize"
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+	"github.com/yanet-platform/yanet2/controlplane/ffi"
+	"github.com/yanet-platform/yanet2/modules/acl/bindings/go/cacl"
+	fwstate "github.com/yanet-platform/yanet2/modules/fwstate/controlplane"
+	"github.com/yanet-platform/yanet2/modules/fwstate/controlplane/fwstatepb/v1"
+)
+
+const (
+	deleteTestCPMemory = 64 * datasize.MB
+	deleteTestDPMemory = 4 * datasize.MB
+	deleteTestAgentMem = 16 * datasize.MB
+	fwstateModuleType  = "fwstate"
+)
+
+type deleteTestACLProvider struct {
+	aclConfig ffi.ModuleConfig
+}
+
+func (m deleteTestACLProvider) LinkedConfigNames(string) []string {
+	return nil
+}
+
+func (m deleteTestACLProvider) RelinkConfigs(
+	_ *fwstate.FwStateConfig,
+	publish func([]ffi.ModuleConfig) error,
+) error {
+	return publish([]ffi.ModuleConfig{m.aclConfig})
+}
+
+func (m deleteTestACLProvider) LinkConfigs(
+	_ []string,
+	_ *fwstate.FwStateConfig,
+	publish func([]ffi.ModuleConfig) error,
+) error {
+	return publish([]ffi.ModuleConfig{m.aclConfig})
+}
+
+func newDeleteTestHarness(
+	testingTB testing.TB,
+	modules []string,
+	agentName string,
+) (*dataplaneut.Harness, *ffi.Agent) {
+	testingTB.Helper()
+
+	harness, err := dataplaneut.NewHarness(dataplaneut.Config{
+		CPMemory:      uint64(deleteTestCPMemory),
+		DPMemory:      uint64(deleteTestDPMemory),
+		WorkerCount:   1,
+		Modules:       modules,
+		DevicesToLoad: []string{},
+	})
+	require.NoError(testingTB, err)
+	testingTB.Cleanup(harness.Free)
+
+	agent, err := harness.SharedMemory().AgentAttach(
+		agentName,
+		0,
+		deleteTestAgentMem,
+	)
+	require.NoError(testingTB, err)
+	testingTB.Cleanup(func() { _ = agent.CleanUp() })
+
+	return harness, agent
+}
+
+func hasCPConfig(configs []ffi.CPConfig, moduleType, moduleName string) bool {
+	for _, config := range configs {
+		if config.Type == moduleType && config.Name == moduleName {
+			return true
+		}
+	}
+	return false
+}
+
+func newACLDeleteTestConfig(
+	testingTB testing.TB,
+	agent *ffi.Agent,
+	name string,
+) *cacl.ModuleConfig {
+	testingTB.Helper()
+
+	config, err := cacl.NewModuleConfig(agent, name)
+	require.NoError(testingTB, err)
+	testingTB.Cleanup(config.Free)
+	require.NoError(testingTB, config.UpdateRules(nil))
+
+	return config
+}
+
+func TestFWStateDeleteKeepsSameNamedACLConfig(t *testing.T) {
+	const configName = "shared-name"
+
+	_, agent := newDeleteTestHarness(t, []string{"acl", "fwstate"}, "acl")
+	aclConfig := newACLDeleteTestConfig(t, agent, configName)
+
+	service := fwstate.NewFWStateService(agent, deleteTestACLProvider{
+		aclConfig: aclConfig.AsFFIModule(),
+	})
+	_, err := service.UpdateConfig(t.Context(), validDeleteTestUpdateRequest(configName))
+	require.NoError(t, err)
+
+	_, err = service.DeleteConfig(t.Context(), &fwstatepb.DeleteConfigRequest{
+		Name: configName,
+	})
+	require.NoError(t, err)
+
+	configs := agent.DPConfig().CPConfigs()
+	require.True(t, hasCPConfig(configs, "acl", configName))
+	require.False(t, hasCPConfig(configs, fwstateModuleType, configName))
+}
+
+func TestDeleteModuleConfigUsesRegisteredType(t *testing.T) {
+	const configName = "fwstate-config"
+
+	_, agent := newDeleteTestHarness(t, []string{"fwstate"}, "fwstate-agent-instance")
+	config, err := fwstate.NewFWStateModuleConfig(agent, configName)
+	require.NoError(t, err)
+	t.Cleanup(config.Free)
+	require.NoError(t, config.CreateMaps(&fwstatepb.MapConfig{
+		IndexSize:        1024,
+		ExtraBucketCount: 64,
+	}, 1))
+	require.NoError(t, agent.UpdateModules([]ffi.ModuleConfig{config.AsFFIModule()}))
+
+	require.NoError(t, agent.DeleteModuleConfig(fwstateModuleType, configName))
+	require.False(t, hasCPConfig(agent.DPConfig().CPConfigs(), fwstateModuleType, configName))
+}
+
+func validDeleteTestUpdateRequest(name string) *fwstatepb.UpdateConfigRequest {
+	return &fwstatepb.UpdateConfigRequest{
+		Name: name,
+		SyncConfig: &fwstatepb.SyncConfig{
+			SrcAddr:          &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
+			DstEther:         commonpb.NewMACAddressEUI48([6]byte{1, 2, 3, 4, 5, 6}),
+			DstAddrMulticast: &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}},
+			PortMulticast:    9999,
+		},
+		MapConfig: &fwstatepb.MapConfig{
+			IndexSize:        1024,
+			ExtraBucketCount: 64,
+		},
+	}
+}

--- a/modules/fwstate/controlplane/metrics.go
+++ b/modules/fwstate/controlplane/metrics.go
@@ -124,7 +124,7 @@ func (m *FWStateService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]
 		return []*commonpb.Metric{}, nil
 	}
 
-	positions := dpConfig.AllModulePositions("fwstate")
+	positions := dpConfig.AllModulePositions(moduleType)
 
 	names, read := metrics.Query(tags,
 		metrics.WithStructuralCounters(fwstateStructuralCounters),
@@ -150,7 +150,7 @@ func (m *FWStateService) collectDataplaneMetrics(tags []*commonpb.MetricTag) ([]
 				pos.Pipeline,
 				pos.Function,
 				pos.Chain,
-				"fwstate",
+				moduleType,
 				configName,
 				names,
 			)

--- a/modules/fwstate/controlplane/service.go
+++ b/modules/fwstate/controlplane/service.go
@@ -73,6 +73,9 @@ func NewMetricsFactory(extra ...grpcmetrics.Option) grpcmetrics.Factory {
 }
 
 const (
+	// moduleType is the registered shared-memory type for fwstate configs.
+	moduleType = "fwstate"
+
 	// defaultListEntriesBatchSize is the batch size used when the caller
 	// sends zero in the request.
 	defaultListEntriesBatchSize uint32 = 100
@@ -433,7 +436,7 @@ func (m *FWStateService) DeleteConfig(
 		return nil, status.Error(codes.NotFound, "config not found")
 	}
 
-	if err := m.agent.DeleteModuleConfig(name); err != nil {
+	if err := m.agent.DeleteModuleConfig(moduleType, name); err != nil {
 		return nil, status.Errorf(codes.Internal, "could not delete fwstate module config '%s': %v", name, err)
 	}
 

--- a/modules/mirror/controlplane/backend.go
+++ b/modules/mirror/controlplane/backend.go
@@ -39,5 +39,5 @@ func (m *backend) UpdateModule(name string, rules []cmirror.MirrorRule) (ModuleH
 }
 
 func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(name)
+	return m.agent.DeleteModuleConfig(moduleType, name)
 }

--- a/modules/mirror/controlplane/mod.go
+++ b/modules/mirror/controlplane/mod.go
@@ -10,7 +10,10 @@ import (
 	mirrorpb "github.com/yanet-platform/yanet2/modules/mirror/controlplane/mirrorpb/v1"
 )
 
-const agentName = "mirror"
+const (
+	moduleType = "mirror"
+	agentName  = moduleType
+)
 
 // Option configures the MirrorModule constructor.
 type Option func(*moduleOptions)
@@ -77,7 +80,7 @@ func NewMirrorModule(cfg *Config, options ...Option) (*MirrorModule, error) {
 }
 
 func (m *MirrorModule) Name() string {
-	return agentName
+	return moduleType
 }
 
 func (m *MirrorModule) Endpoint() string {

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -66,7 +66,7 @@ func NewPdumpModule(cfg *Config, options ...Option) (*PdumpModule, error) {
 		zap.Stringer("size", cfg.MemoryRequirements),
 	)
 
-	agent, err := shm.AgentAttach("pdump", cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
+	agent, err := shm.AgentAttach(moduleType, cfg.InstanceID, cfg.MemoryRequirements.Unwrap())
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
@@ -83,7 +83,7 @@ func NewPdumpModule(cfg *Config, options ...Option) (*PdumpModule, error) {
 }
 
 func (m *PdumpModule) Name() string {
-	return "pdump"
+	return moduleType
 }
 
 func (m *PdumpModule) Endpoint() string {

--- a/modules/pdump/controlplane/service.go
+++ b/modules/pdump/controlplane/service.go
@@ -22,7 +22,10 @@ import (
 	"github.com/yanet-platform/yanet2/modules/pdump/controlplane/pdumppb/v1"
 )
 
-const errMsgConfigNameRequired = "module config name is required"
+const (
+	errMsgConfigNameRequired = "module config name is required"
+	moduleType               = "pdump"
+)
 
 // PdumpService provides packet capture functionality through a gRPC interface.
 // It manages packet capture configurations and ring buffers.
@@ -249,7 +252,7 @@ func (m *PdumpService) DeleteConfig(
 
 	// Delete the module config from the data plane if it exists.
 	if config.FFIModule != nil {
-		if err := m.agent.DeleteModuleConfig(name); err != nil {
+		if err := m.agent.DeleteModuleConfig(moduleType, name); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to delete module config %q: %v", name, err)
 		}
 		config.Free()

--- a/modules/route-mpls/controlplane/backend.go
+++ b/modules/route-mpls/controlplane/backend.go
@@ -59,5 +59,5 @@ func (m *backend) UpdateModule(name string, rules []croutempls.Rule) (ModuleHand
 }
 
 func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(name)
+	return m.agent.DeleteModuleConfig(moduleType, name)
 }

--- a/modules/route-mpls/controlplane/mod.go
+++ b/modules/route-mpls/controlplane/mod.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	agentName = "route-mpls"
+	moduleType = "route-mpls"
+	agentName  = moduleType
 )
 
 // Option configures the RouteMPLSModule constructor.
@@ -81,7 +82,7 @@ func NewRouteMPLSModule(cfg *Config, options ...Option) (*RouteMPLSModule, error
 
 // Name returns the module name.
 func (m *RouteMPLSModule) Name() string {
-	return agentName
+	return moduleType
 }
 
 // Endpoint returns the gRPC endpoint for the route-mpls module.

--- a/modules/route/controlplane/backend.go
+++ b/modules/route/controlplane/backend.go
@@ -154,14 +154,14 @@ func (m *backend) UpdateModule(name string, entries []*routepb.FIBEntry) (Module
 }
 
 func (m *backend) DeleteModule(name string) error {
-	return m.agent.DeleteModuleConfig(name)
+	return m.agent.DeleteModuleConfig(moduleType, name)
 }
 
 func (m *backend) ModuleCounters(name string, counterNames []string) []CounterView {
 	dpConfig := m.agent.DPConfig()
 
 	var views []CounterView
-	for pos := range dpConfig.AllModulePositions(agentName) {
+	for pos := range dpConfig.AllModulePositions(moduleType) {
 		if pos.ModuleName != name {
 			continue
 		}
@@ -171,7 +171,7 @@ func (m *backend) ModuleCounters(name string, counterNames []string) []CounterVi
 			pos.Pipeline,
 			pos.Function,
 			pos.Chain,
-			agentName,
+			moduleType,
 			name,
 			counterNames,
 		)

--- a/modules/route/controlplane/mod.go
+++ b/modules/route/controlplane/mod.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	agentName = "route"
+	moduleType = "route"
+	agentName  = moduleType
 )
 
 // Option configures the RouteModule constructor.
@@ -99,7 +100,7 @@ func NewRouteModule(cfg *Config, options ...Option) (*RouteModule, error) {
 
 // Name returns the module name.
 func (m *RouteModule) Name() string {
-	return agentName
+	return moduleType
 }
 
 // Endpoint returns the gRPC endpoint for the route module shim.


### PR DESCRIPTION
- Passes registered module types explicitly when deleting shared-memory configs.
- Preserves same-named ACL configs when deleting fwstate configs.
- Covers type/name collisions and attach names that differ from module types.

Closes #1760.