### PR TITLE
fix(filter,lpm): name shared-memory contexts distinctly

### DIFF
--- a/common/lpm.h
+++ b/common/lpm.h
@@ -121,8 +121,10 @@ lpm_new_page(struct lpm *lpm, union lpm_value *value) {
 }
 
 static inline int
-lpm_init(struct lpm *lpm, struct memory_context *memory_context) {
-	memory_context_init_from(&lpm->memory_context, memory_context, "lpm");
+lpm_init(
+	struct lpm *lpm, struct memory_context *memory_context, const char *name
+) {
+	memory_context_init_from(&lpm->memory_context, memory_context, name);
 	lpm->pages = NULL;
 	lpm->page_count = 0;
 	return lpm_new_page(lpm, NULL);

--- a/lib/filter/compiler.h
+++ b/lib/filter/compiler.h
@@ -125,6 +125,7 @@ filter_init(
 	const struct filter_rule **rules,
 	uint32_t rule_count,
 	struct memory_context *memory_context,
+	const char *name,
 	yanet_error **err
 ) {
 	if (filter_compiler->lookup_count == 0) {
@@ -172,7 +173,7 @@ filter_init(
 	memset(filter, 0, sizeof(struct filter));
 
 	if (memory_context_init_from(
-		    &filter->memory_context, memory_context, "filter"
+		    &filter->memory_context, memory_context, name
 	    )) {
 		yanet_error_add(
 			err,

--- a/lib/filter/compiler/net4.c
+++ b/lib/filter/compiler/net4.c
@@ -134,7 +134,7 @@ collect_net4_values(
 			}
 		}
 	}
-	if (lpm_init(lpm, memory_context)) {
+	if (lpm_init(lpm, memory_context, "lpm")) {
 		goto error_lpm;
 	}
 	struct range_index range_index;

--- a/lib/filter/compiler/net6.c
+++ b/lib/filter/compiler/net6.c
@@ -64,6 +64,7 @@ collect_net6_range(
 	action_get_net6_func get_net6,
 	net6_get_part_func get_part,
 	struct lpm *lpm,
+	const char *lpm_name,
 	struct range_index *ri
 ) {
 	struct range_collector collector;
@@ -102,7 +103,7 @@ collect_net6_range(
 			}
 		}
 	}
-	if (lpm_init(lpm, memory_context)) {
+	if (lpm_init(lpm, memory_context, lpm_name)) {
 		goto error_lpm;
 	}
 
@@ -710,6 +711,7 @@ init_net6(
 		    get_net6,
 		    net6_get_hi_part,
 		    &net6->hi,
+		    "lpm_hi",
 		    &ri_hi
 	    )) {
 		goto error_hi;
@@ -723,6 +725,7 @@ init_net6(
 		    get_net6,
 		    net6_get_lo_part,
 		    &net6->lo,
+		    "lpm_lo",
 		    &ri_lo
 	    )) {
 		goto error_lo;
@@ -980,6 +983,7 @@ filter_net6_share_init(
 		    get_net6,
 		    net6_get_hi_part,
 		    &out->hi,
+		    is_src ? "net6_share_src_hi" : "net6_share_dst_hi",
 		    &ri
 	    )) {
 		yanet_error_add(
@@ -998,6 +1002,7 @@ filter_net6_share_init(
 		    get_net6,
 		    net6_get_lo_part,
 		    &out->lo,
+		    is_src ? "net6_share_src_lo" : "net6_share_dst_lo",
 		    &ri
 	    )) {
 		yanet_error_add(

--- a/lib/filter/tests/basic_net4.c
+++ b/lib/filter/tests/basic_net4.c
@@ -132,7 +132,13 @@ test_stress_seed12_regression(void *memory, size_t memory_size) {
 	// Initialize filter with all 20 rules
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net4_compile, rule_ptrs, 20, &memory_context, NULL
+		&filter,
+		sign_net4_compile,
+		rule_ptrs,
+		20,
+		&memory_context,
+		"filter",
+		NULL
 	);
 	assert(res == 0);
 
@@ -201,6 +207,7 @@ main() {
 		&action_ptr,
 		1,
 		&memory_context,
+		"filter",
 		NULL
 	);
 	assert(res == 0);
@@ -245,6 +252,7 @@ main() {
 		&action2_ptr,
 		1,
 		&memory_context,
+		"filter",
 		NULL
 	);
 	assert(res == 0);

--- a/lib/filter/tests/basic_net6.c
+++ b/lib/filter/tests/basic_net6.c
@@ -142,7 +142,13 @@ test1(void *memory) {
 	// init filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net6_dst_compile, rule_ptrs, 1, &mctx, NULL
+		&filter,
+		sign_net6_dst_compile,
+		rule_ptrs,
+		1,
+		&mctx,
+		"filter",
+		NULL
 	);
 	assert(res == 0);
 
@@ -293,7 +299,13 @@ test2(void *memory) {
 	// init filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net6_dst_compile, rule_ptrs, 1, &mctx, NULL
+		&filter,
+		sign_net6_dst_compile,
+		rule_ptrs,
+		1,
+		&mctx,
+		"filter",
+		NULL
 	);
 	assert(res == 0);
 
@@ -512,7 +524,7 @@ test3(void *memory) {
 	// init filter
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net6_compile, rule_ptrs, 2, &mctx, NULL
+		&filter, sign_net6_compile, rule_ptrs, 2, &mctx, "filter", NULL
 	);
 	assert(res == 0);
 
@@ -718,13 +730,25 @@ test_share(void *memory) {
 
 	struct filter filter_a;
 	res = filter_init(
-		&filter_a, sign_net6_compile, rule_ptrs_a, 2, &mctx, NULL
+		&filter_a,
+		sign_net6_compile,
+		rule_ptrs_a,
+		2,
+		&mctx,
+		"filter_a",
+		NULL
 	);
 	assert(res == 0);
 
 	struct filter filter_b;
 	res = filter_init(
-		&filter_b, sign_net6_compile, rule_ptrs_b, 2, &mctx, NULL
+		&filter_b,
+		sign_net6_compile,
+		rule_ptrs_b,
+		2,
+		&mctx,
+		"filter_b",
+		NULL
 	);
 	assert(res == 0);
 

--- a/lib/filter/tests/basic_ports.c
+++ b/lib/filter/tests/basic_ports.c
@@ -86,7 +86,13 @@ test_src_dst_ports(void *memory) {
 	// init filter
 	struct filter f;
 	res = filter_init(
-		&f, sign_ports_compile, action_ptrs, 2, &memory_context, NULL
+		&f,
+		sign_ports_compile,
+		action_ptrs,
+		2,
+		&memory_context,
+		"filter",
+		NULL
 	);
 	assert(res == 0);
 
@@ -133,7 +139,13 @@ src_dst_ports(void *memory) {
 
 	struct filter f;
 	res = filter_init(
-		&f, sign_ports_compile, action_ptrs, 3, &memory_context, NULL
+		&f,
+		sign_ports_compile,
+		action_ptrs,
+		3,
+		&memory_context,
+		"filter",
+		NULL
 	);
 	assert(res == 0);
 
@@ -198,7 +210,13 @@ test_any_port(void *memory) {
 
 	struct filter f;
 	res = filter_init(
-		&f, sign_ports_compile, action_ptrs, 3, &memory_context, NULL
+		&f,
+		sign_ports_compile,
+		action_ptrs,
+		3,
+		&memory_context,
+		"filter",
+		NULL
 	);
 	assert(res == 0);
 

--- a/lib/filter/tests/basic_proto_range.c
+++ b/lib/filter/tests/basic_proto_range.c
@@ -76,6 +76,7 @@ test_proto_1(void *memory) {
 		rule_ptrs,
 		2,
 		&memory_context,
+		"filter",
 		NULL
 	);
 	assert(res == 0);

--- a/lib/filter/tests/basic_vlan.c
+++ b/lib/filter/tests/basic_vlan.c
@@ -58,7 +58,13 @@ test_proto_1(void *memory) {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_vlan_compile, rule_ptrs, 3, &memory_context, NULL
+		&filter,
+		sign_vlan_compile,
+		rule_ptrs,
+		3,
+		&memory_context,
+		"filter",
+		NULL
 	);
 	assert(res == 0);
 

--- a/lib/filter/tests/bench_net4.c
+++ b/lib/filter/tests/bench_net4.c
@@ -558,6 +558,7 @@ main(int argc, char **argv) {
 			rule_ptrs,
 			config.num_rules,
 			&memory_context,
+			"filter",
 			NULL
 		);
 		break;
@@ -568,6 +569,7 @@ main(int argc, char **argv) {
 			rule_ptrs,
 			config.num_rules,
 			&memory_context,
+			"filter",
 			NULL
 		);
 		break;
@@ -578,6 +580,7 @@ main(int argc, char **argv) {
 			rule_ptrs,
 			config.num_rules,
 			&memory_context,
+			"filter",
 			NULL
 		);
 		break;

--- a/lib/filter/tests/bench_net6.c
+++ b/lib/filter/tests/bench_net6.c
@@ -604,6 +604,7 @@ main(int argc, char **argv) {
 			rule_ptrs,
 			config.num_rules,
 			&memory_context,
+			"filter",
 			NULL
 		);
 		break;
@@ -614,6 +615,7 @@ main(int argc, char **argv) {
 			rule_ptrs,
 			config.num_rules,
 			&memory_context,
+			"filter",
 			NULL
 		);
 		break;
@@ -624,6 +626,7 @@ main(int argc, char **argv) {
 			rule_ptrs,
 			config.num_rules,
 			&memory_context,
+			"filter",
 			NULL
 		);
 		break;

--- a/lib/filter/tests/context_names.c
+++ b/lib/filter/tests/context_names.c
@@ -22,6 +22,7 @@ FILTER_COMPILER_DECLARE(sign_small_compile, device, vlan, port_src, port_dst);
 FILTER_COMPILER_DECLARE(
 	sign_large_compile, device, vlan, port_src, port_dst, proto_range
 );
+FILTER_COMPILER_DECLARE(sign_net6_compile, net6_src, net6_dst);
 
 #define CTX_NAMES_ARENA_SIZE (1 << 24)
 
@@ -95,6 +96,7 @@ static int
 build_filter(
 	const struct filter_compiler *compiler,
 	struct memory_context *mctx,
+	const char *name,
 	struct filter *filter
 ) {
 	struct filter_rule_builder b1;
@@ -115,7 +117,46 @@ build_filter(
 
 	const struct filter_rule *rule_ptrs[2] = {&r1, &r2};
 
-	return filter_init(filter, compiler, rule_ptrs, 2, mctx, NULL);
+	return filter_init(filter, compiler, rule_ptrs, 2, mctx, name, NULL);
+}
+
+static struct net6
+net6_cidr(const uint8_t addr[NET6_LEN], int prefix_len) {
+	struct net6 net;
+	memcpy(net.addr, addr, NET6_LEN);
+	memset(net.mask, 0, NET6_LEN);
+	for (int idx = 0; idx < prefix_len; ++idx) {
+		net.mask[idx / 8] |= 0x80 >> (idx % 8);
+	}
+	return net;
+}
+
+// Builds a net6_src/net6_dst filter from real IPv6 prefixes, driving the
+// hi/lo lpm split inside init_net6 that collect_net6_range feeds.
+static int
+build_net6_filter(
+	struct memory_context *mctx, const char *name, struct filter *filter
+) {
+	const uint8_t dst_prefix[NET6_LEN] = {0xfe, 0x80};
+	const uint8_t src_prefix[NET6_LEN] = {0x2a, 0x02, 0x06, 0xb8};
+
+	struct filter_rule_builder b1;
+	builder_init(&b1);
+	builder_add_net6_dst(&b1, net6_cidr(dst_prefix, 64));
+	builder_add_net6_src(&b1, net6_cidr(src_prefix, 32));
+	struct filter_rule r1 = build_rule(&b1);
+
+	struct filter_rule_builder b2;
+	builder_init(&b2);
+	builder_add_net6_dst(&b2, net6_cidr(dst_prefix, 128));
+	builder_add_net6_src(&b2, net6_cidr(src_prefix, 48));
+	struct filter_rule r2 = build_rule(&b2);
+
+	const struct filter_rule *rule_ptrs[2] = {&r1, &r2};
+
+	return filter_init(
+		filter, sign_net6_compile, rule_ptrs, 2, mctx, name, NULL
+	);
 }
 
 // Shared per-case fixture: a root memory_context over a fresh block
@@ -166,7 +207,7 @@ test_leaf_named_after_attribute(void *arena) {
 
 	struct filter filter;
 	TEST_ASSERT_SUCCESS(
-		build_filter(sign_small_compile, &fx.mctx, &filter),
+		build_filter(sign_small_compile, &fx.mctx, "filter", &filter),
 		"failed to build small filter"
 	);
 
@@ -199,13 +240,23 @@ test_leaf_names_survive_signature_change(void *arena) {
 
 	struct filter small_filter;
 	TEST_ASSERT_SUCCESS(
-		build_filter(sign_small_compile, &fx.mctx, &small_filter),
+		build_filter(
+			sign_small_compile,
+			&fx.mctx,
+			"small_filter",
+			&small_filter
+		),
 		"failed to build small filter"
 	);
 
 	struct filter large_filter;
 	TEST_ASSERT_SUCCESS(
-		build_filter(sign_large_compile, &fx.mctx, &large_filter),
+		build_filter(
+			sign_large_compile,
+			&fx.mctx,
+			"large_filter",
+			&large_filter
+		),
 		"failed to build large filter"
 	);
 
@@ -258,7 +309,7 @@ check_no_sibling_collision(
 
 	struct filter filter;
 	TEST_ASSERT_SUCCESS(
-		build_filter(compiler, &fx.mctx, &filter),
+		build_filter(compiler, &fx.mctx, "filter", &filter),
 		"failed to build %s filter",
 		label
 	);
@@ -304,7 +355,7 @@ test_leaf_parents_registry_and_payload(void *arena) {
 
 	struct filter filter;
 	TEST_ASSERT_SUCCESS(
-		build_filter(sign_small_compile, &fx.mctx, &filter),
+		build_filter(sign_small_compile, &fx.mctx, "filter", &filter),
 		"failed to build small filter"
 	);
 
@@ -350,7 +401,7 @@ test_no_index_shaped_names(void *arena) {
 
 	struct filter filter;
 	TEST_ASSERT_SUCCESS(
-		build_filter(sign_large_compile, &fx.mctx, &filter),
+		build_filter(sign_large_compile, &fx.mctx, "filter", &filter),
 		"failed to build large filter"
 	);
 
@@ -378,7 +429,7 @@ test_teardown_leaves_nothing_behind(void *arena) {
 
 	struct filter filter;
 	TEST_ASSERT_SUCCESS(
-		build_filter(sign_large_compile, &fx.mctx, &filter),
+		build_filter(sign_large_compile, &fx.mctx, "filter", &filter),
 		"failed to build large filter"
 	);
 
@@ -389,6 +440,73 @@ test_teardown_leaves_nothing_behind(void *arena) {
 	);
 	TEST_ASSERT_SUCCESS(
 		fixture_check_balance(&fx), "leak freeing the large filter"
+	);
+	fixture_fini(&fx);
+	return TEST_SUCCESS;
+}
+
+// Verifies that a net6_src/net6_dst filter has no sibling collision between
+// the hi and lo lpm contexts collect_net6_range creates for each attribute.
+static int
+test_net6_no_sibling_collision(void *arena) {
+	struct ctx_names_fixture fx;
+	TEST_ASSERT_SUCCESS(
+		fixture_init(&fx, arena), "failed to init root memory context"
+	);
+
+	struct filter filter;
+	TEST_ASSERT_SUCCESS(
+		build_net6_filter(&fx.mctx, "filter", &filter),
+		"failed to build net6 filter"
+	);
+
+	TEST_ASSERT_SUCCESS(
+		no_duplicate_siblings(&filter.memory_context),
+		"sibling name collision under the net6 filter"
+	);
+
+	filter_free(&filter, sign_net6_compile);
+	TEST_ASSERT_SUCCESS(
+		fixture_check_balance(&fx), "leak freeing the net6 filter"
+	);
+	fixture_fini(&fx);
+	return TEST_SUCCESS;
+}
+
+// Verifies that two filters built under one shared parent context, as ACL
+// and friends do for their per-signature filters, do not collide as long as
+// filter_init is given distinct names.
+static int
+test_two_filters_one_context(void *arena) {
+	struct ctx_names_fixture fx;
+	TEST_ASSERT_SUCCESS(
+		fixture_init(&fx, arena), "failed to init root memory context"
+	);
+
+	struct filter filter_a;
+	TEST_ASSERT_SUCCESS(
+		build_filter(
+			sign_small_compile, &fx.mctx, "filter_a", &filter_a
+		),
+		"failed to build filter_a"
+	);
+	struct filter filter_b;
+	TEST_ASSERT_SUCCESS(
+		build_filter(
+			sign_small_compile, &fx.mctx, "filter_b", &filter_b
+		),
+		"failed to build filter_b"
+	);
+
+	TEST_ASSERT_SUCCESS(
+		no_duplicate_siblings(&fx.mctx),
+		"sibling name collision between filter_a and filter_b"
+	);
+
+	filter_free(&filter_b, sign_small_compile);
+	filter_free(&filter_a, sign_small_compile);
+	TEST_ASSERT_SUCCESS(
+		fixture_check_balance(&fx), "leak freeing the two filters"
 	);
 	fixture_fini(&fx);
 	return TEST_SUCCESS;
@@ -413,6 +531,8 @@ main() {
 		{"no_index_shaped_names", test_no_index_shaped_names},
 		{"teardown_leaves_nothing_behind",
 		 test_teardown_leaves_nothing_behind},
+		{"net6_no_sibling_collision", test_net6_no_sibling_collision},
+		{"two_filters_one_context", test_two_filters_one_context},
 	};
 
 	for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); ++i) {

--- a/lib/filter/tests/corner.c
+++ b/lib/filter/tests/corner.c
@@ -88,7 +88,13 @@ check_single_attribute(void *memory) {
 	// setup filter
 	struct filter filter;
 	int init_result = filter_init(
-		&filter, sign_port_src_compile, rules, 3, &memory_context, NULL
+		&filter,
+		sign_port_src_compile,
+		rules,
+		3,
+		&memory_context,
+		"filter",
+		NULL
 	);
 	assert(init_result == 0);
 

--- a/lib/filter/tests/macros.c
+++ b/lib/filter/tests/macros.c
@@ -33,7 +33,7 @@ run_case(void) {
 	// init filter
 	const struct filter_rule *r_ptr = &r;
 	struct filter f;
-	res = filter_init(&f, sign, &r_ptr, 1, &memory_context, NULL);
+	res = filter_init(&f, sign, &r_ptr, 1, &memory_context, "filter", NULL);
 	assert(res == 0);
 
 	// craft packet: UDP 4000

--- a/lib/filter/tests/memory.c
+++ b/lib/filter/tests/memory.c
@@ -116,6 +116,7 @@ test_src_dst_ports(void *memory) {
 		action_ptrs,
 		2,
 		&memory_context,
+		"filter",
 		NULL
 	);
 	assert(res == 0);
@@ -165,6 +166,7 @@ test_src_port_only(void *memory) {
 		action_ptrs,
 		2,
 		&memory_context,
+		"filter",
 		NULL
 	);
 	assert(res == 0);

--- a/lib/filter/tests/net4_ports.c
+++ b/lib/filter/tests/net4_ports.c
@@ -86,6 +86,7 @@ test(void *memory) {
 		action_ptrs,
 		2,
 		&memory_context,
+		"filter",
 		NULL
 	);
 	assert(res == 0);

--- a/lib/filter/tests/net6_overlap.c
+++ b/lib/filter/tests/net6_overlap.c
@@ -101,7 +101,7 @@ main() {
 
 	struct filter filter;
 	res = filter_init(
-		&filter, sign_net6_compile, rule_ptrs, 3, &mctx, NULL
+		&filter, sign_net6_compile, rule_ptrs, 3, &mctx, "filter", NULL
 	);
 	assert(res == 0);
 

--- a/lib/filter/tests/oom_sweep.c
+++ b/lib/filter/tests/oom_sweep.c
@@ -206,7 +206,7 @@ sweep_compile(
 	filter_test_oom_armed = 1;
 
 	int rc = filter_init(
-		filter, compiler, rule_ptrs, rule_count, mctx, NULL
+		filter, compiler, rule_ptrs, rule_count, mctx, "filter", NULL
 	);
 
 	filter_test_oom_armed = 0;

--- a/lib/filter/tests/shm/compiler.c
+++ b/lib/filter/tests/shm/compiler.c
@@ -48,7 +48,13 @@ build_filter(struct common *common, struct memory_context *mctx) {
 	}
 	LOG(INFO, "compiling %zu rules...", rule_count);
 	int res = filter_init(
-		&common->filter, filter_sign, rule_ptrs, rule_count, mctx, NULL
+		&common->filter,
+		filter_sign,
+		rule_ptrs,
+		rule_count,
+		mctx,
+		"filter",
+		NULL
 	);
 	if (res < 0) {
 		LOG(ERROR, "compilation failed: %d", res);

--- a/modules/acl/api/controlplane.c
+++ b/modules/acl/api/controlplane.c
@@ -351,6 +351,7 @@ acl_module_init_l2(
 		filter_rule_ptrs,
 		acl_rule_count,
 		&cp_module->memory_context,
+		"filter_vlan",
 		err
 	);
 	if (rc) {
@@ -385,6 +386,7 @@ acl_module_init_ip4(
 		filter_rule_ptrs,
 		acl_rule_count,
 		&cp_module->memory_context,
+		"filter_ip4",
 		err
 	);
 	if (rc) {
@@ -419,6 +421,7 @@ acl_module_init_ip4_port(
 		filter_rule_ptrs,
 		acl_rule_count,
 		&cp_module->memory_context,
+		"filter_ip4_port",
 		err
 	);
 	if (rc) {
@@ -453,6 +456,7 @@ acl_module_init_ip6(
 		filter_rule_ptrs,
 		acl_rule_count,
 		&cp_module->memory_context,
+		"filter_ip6",
 		err
 	);
 	if (rc) {
@@ -487,6 +491,7 @@ acl_module_init_ip6_port(
 		filter_rule_ptrs,
 		acl_rule_count,
 		&cp_module->memory_context,
+		"filter_ip6_port",
 		err
 	);
 	if (rc) {

--- a/modules/decap/api/controlplane.c
+++ b/modules/decap/api/controlplane.c
@@ -76,10 +76,10 @@ decap_module_config_data_init(
 	struct decap_module_config *config,
 	struct memory_context *memory_context
 ) {
-	if (lpm_init(&config->prefixes4, memory_context)) {
+	if (lpm_init(&config->prefixes4, memory_context, "prefixes4")) {
 		return -1;
 	}
-	if (lpm_init(&config->prefixes6, memory_context)) {
+	if (lpm_init(&config->prefixes6, memory_context, "prefixes6")) {
 		goto error_lpm_v6;
 	}
 

--- a/modules/decap/fuzzing/decap.c
+++ b/modules/decap/fuzzing/decap.c
@@ -35,10 +35,10 @@ decap_test_config(struct cp_module **cp_module) {
 
 	struct memory_context *memory_context =
 		&config->cp_module.memory_context;
-	if (lpm_init(&config->prefixes4, memory_context)) {
+	if (lpm_init(&config->prefixes4, memory_context, "prefixes4")) {
 		goto error_lpm_v4;
 	}
-	if (lpm_init(&config->prefixes6, memory_context)) {
+	if (lpm_init(&config->prefixes6, memory_context, "prefixes6")) {
 		goto error_lpm_v6;
 	}
 

--- a/modules/dscp/api/controlplane.c
+++ b/modules/dscp/api/controlplane.c
@@ -76,10 +76,10 @@ int
 dscp_module_config_data_init(
 	struct dscp_module_config *config, struct memory_context *memory_context
 ) {
-	if (lpm_init(&config->lpm_v4, memory_context)) {
+	if (lpm_init(&config->lpm_v4, memory_context, "lpm_v4")) {
 		return -1;
 	}
-	if (lpm_init(&config->lpm_v6, memory_context)) {
+	if (lpm_init(&config->lpm_v6, memory_context, "lpm_v6")) {
 		lpm_free(&config->lpm_v4);
 		return -1;
 	}

--- a/modules/dscp/fuzzing/dscp.c
+++ b/modules/dscp/fuzzing/dscp.c
@@ -36,10 +36,10 @@ dscp_test_config(struct cp_module **cp_module) {
 
 	struct memory_context *memory_context =
 		&config->cp_module.memory_context;
-	if (lpm_init(&config->lpm_v4, memory_context)) {
+	if (lpm_init(&config->lpm_v4, memory_context, "lpm_v4")) {
 		goto error_lpm_v4;
 	}
-	if (lpm_init(&config->lpm_v6, memory_context)) {
+	if (lpm_init(&config->lpm_v6, memory_context, "lpm_v6")) {
 		goto error_lpm_v6;
 	}
 

--- a/modules/dscp/tests/dataplane/dscp.go
+++ b/modules/dscp/tests/dataplane/dscp.go
@@ -9,6 +9,8 @@ package dscp_test
 #include "lib/dataplane/pipeline/econtext.h"
 #include "modules/dscp/dataplane/config.h"
 
+#include <stdlib.h>
+
 uint8_t dscp_mark_never = DSCP_MARK_NEVER;
 uint8_t dscp_mark_default = DSCP_MARK_DEFAULT;
 uint8_t dscp_mark_always = DSCP_MARK_ALWAYS;
@@ -57,8 +59,13 @@ func buildLPMs(
 	lpm4 *C.struct_lpm,
 	lpm6 *C.struct_lpm,
 ) {
-	C.lpm_init(lpm4, memCtx)
-	C.lpm_init(lpm6, memCtx)
+	lpm4Name := C.CString("lpm_v4")
+	C.lpm_init(lpm4, memCtx, lpm4Name)
+	C.free(unsafe.Pointer(lpm4Name))
+
+	lpm6Name := C.CString("lpm_v6")
+	C.lpm_init(lpm6, memCtx, lpm6Name)
+	C.free(unsafe.Pointer(lpm6Name))
 
 	for _, prefix := range prefixes {
 		if prefix.Addr().Is4() {

--- a/modules/forward/api/controlplane.c
+++ b/modules/forward/api/controlplane.c
@@ -197,6 +197,7 @@ forward_module_init_l2(
 		filter_rule_ptrs,
 		forward_rule_count,
 		&cp_module->memory_context,
+		"filter_vlan",
 		err
 	);
 	if (rc) {
@@ -232,6 +233,7 @@ forward_module_init_ip4(
 		filter_rule_ptrs,
 		forward_rule_count,
 		&cp_module->memory_context,
+		"filter_ip4",
 		err
 	);
 	if (rc) {
@@ -267,6 +269,7 @@ forward_module_init_ip6(
 		filter_rule_ptrs,
 		forward_rule_count,
 		&cp_module->memory_context,
+		"filter_ip6",
 		err
 	);
 	if (rc) {

--- a/modules/mirror/api/controlplane.c
+++ b/modules/mirror/api/controlplane.c
@@ -192,6 +192,7 @@ mirror_module_init_l2(
 		filter_rule_ptrs,
 		mirror_rule_count,
 		&cp_module->memory_context,
+		"filter_vlan",
 		err
 	);
 	if (rc) {
@@ -226,6 +227,7 @@ mirror_module_init_ip4(
 		filter_rule_ptrs,
 		mirror_rule_count,
 		&cp_module->memory_context,
+		"filter_ip4",
 		err
 	);
 	if (rc) {
@@ -260,6 +262,7 @@ mirror_module_init_ip6(
 		filter_rule_ptrs,
 		mirror_rule_count,
 		&cp_module->memory_context,
+		"filter_ip6",
 		err
 	);
 	if (rc) {

--- a/modules/nat64/api/nat64cp.c
+++ b/modules/nat64/api/nat64cp.c
@@ -97,14 +97,14 @@ nat64_module_config_data_init(
 
 	// Initialize LPM structures
 	LOG(DEBUG, "Initializing v4_to_v6 LPM");
-	if (lpm_init(&config->mappings.v4_to_v6, memory_context)) {
+	if (lpm_init(&config->mappings.v4_to_v6, memory_context, "v4_to_v6")) {
 		LOG(ERROR, "Failed to initialize v4_to_v6 LPM");
 		goto error_lpm_v4;
 	}
 	LOG(DEBUG, "v4_to_v6 LPM initialized successfully");
 
 	LOG(DEBUG, "Initializing v6_to_v4 LPM");
-	if (lpm_init(&config->mappings.v6_to_v4, memory_context)) {
+	if (lpm_init(&config->mappings.v6_to_v4, memory_context, "v6_to_v4")) {
 		LOG(ERROR, "Failed to initialize v6_to_v4 LPM");
 		goto error_lpm_v6;
 	}
@@ -112,7 +112,9 @@ nat64_module_config_data_init(
 
 	// Initialize v6 prefixes LPM
 	LOG(DEBUG, "Initializing v6_prefixes LPM");
-	if (lpm_init(&config->prefixes.v6_prefixes, memory_context)) {
+	if (lpm_init(
+		    &config->prefixes.v6_prefixes, memory_context, "v6_prefixes"
+	    )) {
 		LOG(ERROR, "Failed to initialize v6_prefixes LPM");
 		goto error_lpm_prefixes;
 	}

--- a/modules/nat64/fuzzing/nat64w.c
+++ b/modules/nat64/fuzzing/nat64w.c
@@ -44,13 +44,15 @@ nat64_test_config(struct cp_module **cp_module) {
 
 	struct memory_context *memory_context =
 		&config->cp_module.memory_context;
-	if (lpm_init(&config->mappings.v4_to_v6, memory_context)) {
+	if (lpm_init(&config->mappings.v4_to_v6, memory_context, "v4_to_v6")) {
 		goto error_config;
 	}
-	if (lpm_init(&config->mappings.v6_to_v4, memory_context)) {
+	if (lpm_init(&config->mappings.v6_to_v4, memory_context, "v6_to_v4")) {
 		goto error_lpm_v4;
 	}
-	if (lpm_init(&config->prefixes.v6_prefixes, memory_context)) {
+	if (lpm_init(
+		    &config->prefixes.v6_prefixes, memory_context, "v6_prefixes"
+	    )) {
 		goto error_lpm_v6;
 	}
 

--- a/modules/route-mpls/api/controlplane.c
+++ b/modules/route-mpls/api/controlplane.c
@@ -198,6 +198,7 @@ route_mpls_module_init_ip4(
 		filter_rule_ptrs,
 		route_mpls_rule_count,
 		&cp_module->memory_context,
+		"filter_ip4",
 		err
 	);
 	if (rc) {
@@ -232,6 +233,7 @@ route_mpls_module_init_ip6(
 		filter_rule_ptrs,
 		route_mpls_rule_count,
 		&cp_module->memory_context,
+		"filter_ip6",
 		err
 	);
 	if (rc) {

--- a/modules/route/api/controlplane.c
+++ b/modules/route/api/controlplane.c
@@ -128,10 +128,10 @@ route_module_config_data_init(
 	struct route_module_config *config,
 	struct memory_context *memory_context
 ) {
-	if (lpm_init(&config->lpm_v4, memory_context)) {
+	if (lpm_init(&config->lpm_v4, memory_context, "lpm_v4")) {
 		return -1;
 	}
-	if (lpm_init(&config->lpm_v6, memory_context)) {
+	if (lpm_init(&config->lpm_v6, memory_context, "lpm_v6")) {
 		lpm_free(&config->lpm_v4);
 		return -1;
 	}

--- a/modules/route/fuzzing/route.c
+++ b/modules/route/fuzzing/route.c
@@ -48,10 +48,10 @@ route_test_config(struct cp_module **cp_module, yanet_error **err) {
 
 	struct memory_context *memory_context =
 		&config->cp_module.memory_context;
-	if (lpm_init(&config->lpm_v4, memory_context)) {
+	if (lpm_init(&config->lpm_v4, memory_context, "lpm_v4")) {
 		goto error_lpm_v4;
 	}
-	if (lpm_init(&config->lpm_v6, memory_context)) {
+	if (lpm_init(&config->lpm_v6, memory_context, "lpm_v6")) {
 		goto error_lpm_v6;
 	}
 	config->route_count = 0;

--- a/tests/common/lpm_test.c
+++ b/tests/common/lpm_test.c
@@ -71,7 +71,7 @@ test_overlapping_prefixes(void) {
 	memory_context_init(&mctx, "lpm_overlap", &ba);
 
 	struct lpm tree;
-	if (lpm_init(&tree, &mctx)) {
+	if (lpm_init(&tree, &mctx, "lpm")) {
 		free(arena);
 		return -1;
 	}
@@ -127,7 +127,7 @@ main(int argc, char **argv) {
 	memory_context_init(&mctx, "lpm", &ba);
 
 	struct lpm lpm;
-	if (lpm_init(&lpm, &mctx)) {
+	if (lpm_init(&lpm, &mctx, "lpm")) {
 		fprintf(stdout, "could not initialize lpm\n");
 		return -1;
 	}


### PR DESCRIPTION
Filter and LPM memory contexts were each created under one hardcoded name, so a module that builds several of them beneath a single parent produced sibling nodes the exported context tree could not tell apart.

The per-agent utilization metric keys its series on a node's full path, so those siblings resolved to identical paths and were summed. An operator could not see whether it was the IPv6 filter or the VLAN filter eating an agent's arena, which is precisely the question the metric exists to answer. On a production ruleset the heaviest consumer reported a quarter of a gigabyte merged across four unrelated address classifiers.

Both init paths now take the context name from their caller, and every call site names the structure it builds. Sibling paths become unique, so the per-subsystem attribution appears from the existing tree walk with no control-plane change.

The audit also reached two call sites the report did not list. A network classifier splits its lookup into a high and a low half under one shared parent, and the shared IPv6 direction tables do the same for source and destination, in both cases producing indistinguishable siblings of exactly the kind this change removes.

The collector keeps folding identical paths regardless. Names are truncated to a fixed length and nothing structurally guarantees uniqueness, and a duplicate label set costs a scraper the whole scrape rather than just the affected series. This change makes that folding a no-op for these nodes, it does not remove the need for it.

The context-name test suite gains two cases: one pinning that a classifier's paired lookups stay distinct, one pinning that several filters under a shared module context do. Both were confirmed to fail against the old naming.

Closes #1801.