### PR TITLE
test(dataplane-ut): share worker round preparation

### DIFF
--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -53,6 +53,7 @@
 #include "lib/controlplane/config/zone.h"
 #include "lib/dataplane/worker/counters.h"
 #include "lib/dataplane/worker/pipeline_round.h"
+#include "lib/dataplane/worker/round.h"
 
 #include "common/data_pipe.h"
 #include "logging/log.h"
@@ -323,27 +324,14 @@ worker_write(
 
 static void
 worker_loop_round(struct dataplane_worker *worker) {
-	// Initialize current worker time
-	// on the start of loop round
-	{
-		struct dp_worker *dp_worker = worker->dp_worker;
-		dp_worker->current_time =
-			dataplane_time_ns_fn(&dp_worker->clock);
-	}
-
 	struct cp_config *cp_config = worker->instance->cp_config;
-	// Acquire the generation pointer, paired with the release-publish
-	// in cp_config_gen_install.
-	struct cp_config_gen *cp_config_gen =
-		ATOMIC_ADDR_OF(&cp_config->cp_config_gen);
-	struct config_gen_ectx *config_gen_ectx = cp_config_gen_worker_ectx(
-		cp_config_gen, worker->dp_worker->idx
+	struct worker_round round = worker_round_prepare(
+		worker->dp_worker,
+		cp_config,
+		tsc_clock_get_time_ns(&worker->dp_worker->clock)
 	);
-
-	__atomic_store_n(
-		&worker->dp_worker->gen, cp_config_gen->gen, __ATOMIC_RELEASE
-	);
-	*worker->dp_worker->iterations += 1;
+	struct cp_config_gen *cp_config_gen = round.cp_config_gen;
+	struct config_gen_ectx *config_gen_ectx = round.config_gen_ectx;
 
 	// No configuration has been installed yet (startup). Drain the NIC
 	// RX ring into a throwaway stack front so packets that arrived

--- a/lib/dataplane/time/clock.c
+++ b/lib/dataplane/time/clock.c
@@ -40,5 +40,3 @@ tsc_clock_get_time_ns(struct tsc_clock *clock) {
 	return clock->real_time_ns +
 	       tsc_clock_ticks_to_ns(tsc, clock->tsc_to_ns_mult);
 }
-
-dataplane_time_ns_fn_t dataplane_time_ns_fn = tsc_clock_get_time_ns;

--- a/lib/dataplane/time/clock.h
+++ b/lib/dataplane/time/clock.h
@@ -69,19 +69,3 @@ static inline uint64_t
 tsc_clock_ticks_to_ns(uint64_t ticks, uint64_t mult) {
 	return (uint64_t)(((__uint128_t)ticks * mult) >> 32);
 }
-
-// Signature of the per-round wall-time read.
-//
-// The default implementation calls tsc_clock_get_time_ns. Tests and
-// alternative harnesses may install a substitute by assigning to
-// dataplane_time_ns_fn before any worker activity begins. The
-// substitute may ignore the clock argument and read a process-global
-// mock time source instead.
-typedef uint64_t (*dataplane_time_ns_fn_t)(struct tsc_clock *clock);
-
-// Process-global override point for wall-time reads inside the worker
-// loop.
-//
-// Defaults to tsc_clock_get_time_ns. Not thread-safe to swap — install
-// once before any worker thread starts.
-extern dataplane_time_ns_fn_t dataplane_time_ns_fn;

--- a/lib/dataplane/worker/round.h
+++ b/lib/dataplane/worker/round.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "common/memory_address.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/config/zone.h"
+
+// State shared by the preparation and processing parts of one worker round.
+struct worker_round {
+	struct cp_config_gen *cp_config_gen;
+	struct config_gen_ectx *config_gen_ectx;
+};
+
+// Prepare the worker state that precedes packet processing.
+//
+// The caller evaluates current_time_ns before entering this helper. The
+// release publication and iteration increment retain production ordering.
+static inline struct worker_round
+worker_round_prepare(
+	struct dp_worker *dp_worker,
+	struct cp_config *cp_config,
+	uint64_t current_time_ns
+) {
+	dp_worker->current_time = current_time_ns;
+
+	struct worker_round round = {
+		.cp_config_gen = ATOMIC_ADDR_OF(&cp_config->cp_config_gen),
+	};
+	round.config_gen_ectx =
+		cp_config_gen_worker_ectx(round.cp_config_gen, dp_worker->idx);
+
+	__atomic_store_n(
+		&dp_worker->gen, round.cp_config_gen->gen, __ATOMIC_RELEASE
+	);
+	*dp_worker->iterations += 1;
+
+	return round;
+}

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -27,6 +27,7 @@
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane/worker/counters.h"
 #include "lib/dataplane/worker/pipeline_round.h"
+#include "lib/dataplane/worker/round.h"
 #include "lib/dataplane_ut/mempool.h"
 #include "lib/errors/errors.h"
 #include "lib/logging/log.h"
@@ -493,16 +494,11 @@ dataplane_ut_run(
 	struct dp_worker **workers = ADDR_OF(&ut->dp_config->workers);
 	struct dp_worker *dp_worker = ADDR_OF(&workers[worker_idx]);
 
-	// Mirror worker_loop_round housekeeping: time, gen, iterations.
-	dp_worker->current_time = ut->mock_time_ns;
-
-	struct cp_config_gen *cp_config_gen =
-		ADDR_OF(&ut->cp_config->cp_config_gen);
-	struct config_gen_ectx *config_gen_ectx =
-		cp_config_gen_worker_ectx(cp_config_gen, worker_idx);
-
-	__atomic_store_n(&dp_worker->gen, cp_config_gen->gen, __ATOMIC_RELEASE);
-	*dp_worker->iterations += 1;
+	struct worker_round round = worker_round_prepare(
+		dp_worker, ut->cp_config, ut->mock_time_ns
+	);
+	struct cp_config_gen *cp_config_gen = round.cp_config_gen;
+	struct config_gen_ectx *config_gen_ectx = round.config_gen_ectx;
 
 	struct packet_front packet_front;
 	packet_front_init(&packet_front);

--- a/lib/dataplane_ut/tests/smoke_test.c
+++ b/lib/dataplane_ut/tests/smoke_test.c
@@ -1,4 +1,8 @@
+#include "api/agent.h"
+#include "common/memory_address.h"
 #include "common/test_assert.h"
+#include "lib/controlplane/config/zone.h"
+#include "lib/dataplane/config/zone.h"
 #include "lib/dataplane/packet/data.h"
 #include "lib/dataplane_ut/dataplane_ut.h"
 
@@ -34,6 +38,8 @@ main(void) {
 	{
 		struct dataplane_ut *ut = dataplane_ut_new(&cfg);
 		TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+		shm = dataplane_ut_shm(ut);
+		TEST_ASSERT_NOT_NULL(shm, "dataplane_ut_shm returned NULL");
 
 		// Time setter / getter round-trip.
 		dataplane_ut_set_time_ns(ut, 12345ULL);
@@ -41,6 +47,38 @@ main(void) {
 			(long)dataplane_ut_get_time_ns(ut),
 			(long)12345ULL,
 			"get_time_ns must echo set_time_ns"
+		);
+
+		struct dp_config *dp_config = yanet_shm_dp_config(shm, 0);
+		struct dp_worker **workers = ADDR_OF(&dp_config->workers);
+		struct dp_worker *dp_worker = ADDR_OF(workers);
+		struct cp_config *cp_config = ADDR_OF(&dp_config->cp_config);
+		struct cp_config_gen *cp_config_gen =
+			ADDR_OF(&cp_config->cp_config_gen);
+		uint64_t iterations = *dp_worker->iterations;
+
+		// The harness round uses shared preparation for mock time,
+		// generation publication and iteration count.
+		struct packet_list empty;
+		packet_list_init(&empty);
+		struct dataplane_ut_round_result result;
+		dataplane_ut_run(ut, 0, &empty, &result);
+		TEST_ASSERT_EQUAL(
+			(long)dp_worker->current_time,
+			(long)12345ULL,
+			"mock time must reach the worker round"
+		);
+		TEST_ASSERT_EQUAL(
+			(long)*dp_worker->iterations,
+			(long)(iterations + 1),
+			"one valid harness round must increment iterations once"
+		);
+		uint64_t published_gen =
+			__atomic_load_n(&dp_worker->gen, __ATOMIC_ACQUIRE);
+		TEST_ASSERT_EQUAL(
+			(long)published_gen,
+			(long)cp_config_gen->gen,
+			"harness round must publish its generation"
 		);
 
 		// Mbuf factory yields a usable mbuf.
@@ -52,9 +90,6 @@ main(void) {
 
 		// Empty-input round must complete cleanly and yield empty
 		// output and drop lists.
-		struct packet_list empty;
-		packet_list_init(&empty);
-		struct dataplane_ut_round_result result;
 		dataplane_ut_run(ut, 0, &empty, &result);
 		TEST_ASSERT_EQUAL(
 			(long)packet_list_count(&result.output),
@@ -100,6 +135,11 @@ main(void) {
 	{
 		struct dataplane_ut *ut = dataplane_ut_new(&cfg);
 		TEST_ASSERT_NOT_NULL(ut, "dataplane_ut_new returned NULL");
+		struct dp_config *dp_config =
+			yanet_shm_dp_config(dataplane_ut_shm(ut), 0);
+		struct dp_worker **workers = ADDR_OF(&dp_config->workers);
+		struct dp_worker *dp_worker = ADDR_OF(workers);
+		uint64_t iterations = *dp_worker->iterations;
 
 		struct rte_mbuf *mbuf = dataplane_ut_alloc_mbuf(ut);
 		TEST_ASSERT_NOT_NULL(
@@ -131,6 +171,11 @@ main(void) {
 			(long)packet_list_count(&result.drop),
 			1L,
 			"an out-of-range worker_idx must drop the input packet"
+		);
+		TEST_ASSERT_EQUAL(
+			(long)*dp_worker->iterations,
+			(long)iterations,
+			"an out-of-range worker_idx must not prepare a round"
 		);
 
 		struct packet *dropped;


### PR DESCRIPTION
- Shares worker-round preparation between the production loop and the in-process harness.
- Keeps deterministic harness clocks instance-local while preserving the direct TSC read in the dataplane.
- Verifies time, generation publication, iteration counting, and invalid-worker behavior.

Closes #1755.