### PR TITLE
chore(ci): stop installing unused protobuf plugins in the functional VM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ on:
       - ".github/actions/apt-packages/**"
       - ".github/actions/go-modcache/**"
       - ".github/actions/protoc-plugins/**"
+      - "tests/functional/**"
   pull_request:
     # A stacked pull request has a non-main base, so a main-only filter would skip it.
     branches: ["**"]
@@ -46,6 +47,7 @@ on:
       - ".github/actions/apt-packages/**"
       - ".github/actions/go-modcache/**"
       - ".github/actions/protoc-plugins/**"
+      - "tests/functional/**"
 
 concurrency:
   # The run_id fallback keeps non-PR runs from cancelling each other.

--- a/docs/qemu-run.md
+++ b/docs/qemu-run.md
@@ -224,8 +224,8 @@ apt-get install -y \
 apt-get install -y golang-go
 
 # Install Go modules
-GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-GOBIN=/usr/local/bin go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+GOBIN=/usr/local/bin go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1
 
 # Install Rust (self update disable need only for rustup installed from apt)
 rustup set auto-self-update disable

--- a/docs/virtual-run.org
+++ b/docs/virtual-run.org
@@ -58,8 +58,8 @@ sudo apt update
 sudo apt install golang-go
 
 # Install Go modules
-GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-GOBIN=/usr/local/bin go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+GOBIN=/usr/local/bin go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1
 
 # Install Rust (self update disable need only for rustup installed from apt)
 rustup set auto-self-update disable
@@ -81,8 +81,8 @@ https_proxy=socks5://127.0.0.1:8080 /home/moonug/rustup-init
 #+end_src
 
 #+begin_src shell
-https_proxy=socks5://127.0.0.1:8080 GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-https_proxy=socks5://127.0.0.1:8080 GOBIN=/usr/local/bin go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+https_proxy=socks5://127.0.0.1:8080 GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+https_proxy=socks5://127.0.0.1:8080 GOBIN=/usr/local/bin go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1
 #+end_src
 #+begin_src shell
 tar xf just-1.40.0-x86_64-unknown-linux-musl.tar.gz -C /usr/local/bin/

--- a/tests/functional/cloud-init-user-data.yaml
+++ b/tests/functional/cloud-init-user-data.yaml
@@ -167,12 +167,6 @@ runcmd:
     systemctl daemon-reload
     systemctl disable getty.target
     systemctl enable serial-getty@ttyS0.service
-  # Configure Go environment
-  - mkdir -p /root/go
-  - export GOPATH=/root/go
-  - export PATH=$PATH:$GOPATH/bin
-  - GOBIN=/usr/local/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-  - GOBIN=/usr/local/bin go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
   # Configure Rust
   - rustup set auto-self-update disable
   - rustup install stable


### PR DESCRIPTION
- The functional-test guest installed both protobuf plugins at a floating latest, yet it never runs a code generator or a Go toolchain at all: every binary it exercises is built on the host and exposed over shared directories, and its distribution Go is too old to build this module in any case.
- Those installs only cost provisioning time and pulled an unpinned toolchain whenever the image cache missed, so they are removed together with the Go environment block that existed solely to support them. Nothing else in the guest definition referenced it.
- The two virtual-machine guides are the opposite case: they describe building in place inside the guest, so their plugin installs are load-bearing and instead move to the versions the rest of the build already pins.
- The build workflow keyed its virtual-machine image cache on the guest definition without listing that directory among the paths that start the workflow, so editing the definition invalidated the cached image but scheduled nothing to rebuild it.
- Listing the directory closes that hole and also covers the rule sets the tests feed to the command line tools, which could previously change test behaviour without running anything.
- The guest packages are left alone deliberately; several are equally unused now, but separating the ones that still supply runtime libraries needs its own audit.

Closes #1860.