### PR TITLE
chore(ci): stop provisioning a build toolchain into the functional-test VM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,6 +411,11 @@ jobs:
               exit $QEMU_EXIT_CODE
           fi
 
+          # Watch file length: actions/cache restores the image dense, so disk
+          # size roughly doubles on every cache hit even with no real regrowth.
+          echo "=== yanet-test.qcow2 size ==="
+          qemu-img info yanet-test.qcow2 || true
+
         timeout-minutes: 130
 
       - name: Run functional tests

--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -128,7 +128,7 @@ define run_qemu
 		-device intel-iommu,intremap=on,device-iotlb=on \
 		-device ioh3420,id=pcie.1,chassis=1 \
 		-device ioh3420,id=pcie.2,chassis=2 \
-		-drive file=$(QEMU_IMAGE),if=virtio,format=qcow2 $(1) \
+		-drive file=$(QEMU_IMAGE),if=virtio,format=qcow2,discard=unmap,detect-zeroes=unmap $(1) \
 		-netdev user,id=net0 \
 		-device virtio-net-pci,netdev=net0,mac=AA:BB:CC:DD:CA:B0 \
 		-netdev stream,id=net1,server=on,addr.type=unix,addr.path=/tmp/yanetvm_sockdev_0.sock \

--- a/tests/functional/cloud-init-user-data.yaml
+++ b/tests/functional/cloud-init-user-data.yaml
@@ -40,40 +40,23 @@ network:
 
 packages:
   - qemu-guest-agent
-  - meson
-  - clang
-  - clang-format-19
-  - clang-tidy-19
-  - git
-  - just
   - jq
   - make
   - python3-pyelftools
   - libnuma-dev
   - libpcap-dev
   - libyaml-dev
-  - protobuf-compiler
-  - rustup
   - gdb
-  - gdbserver
-  - lldb
-  - lcov
-  - golang-go
-  - linux-headers-generic
-  - linux-image-extra-virtual
   - kmod
   - procps
   - util-linux
   - tcpdump
-  - tshark
   - vim-tiny
   - iputils-ping
   - net-tools
 
 runcmd:
   - exec &> /var/log/cloud-init-output.log
-  - apt-get update -y
-  - apt-get install -y linux-modules-extra-$(uname -r) --no-install-recommends
 
   # 1. Disable snap (- ~10s)
   - |
@@ -167,9 +150,6 @@ runcmd:
     systemctl daemon-reload
     systemctl disable getty.target
     systemctl enable serial-getty@ttyS0.service
-  # Configure Rust
-  - rustup set auto-self-update disable
-  - rustup install stable
   # Configure hugepages
   - echo 'vm.nr_hugepages = 192' >> /etc/sysctl.conf
   - sysctl -p
@@ -196,6 +176,15 @@ runcmd:
   - echo 'export TERM=xterm' >> /root/.bashrc
   # Add ubuntu user to necessary groups
   - usermod -aG sudo,adm,dialout,cdrom,floppy,audio,dip,video,plugdev,netdev ubuntu
+  # Reclaim disk before the image is cached. This only returns freed blocks to
+  # the qcow2 because run_qemu opens the drive with discard=unmap — remove that
+  # option and the image quietly grows back with every check still green.
+  - |
+    apt-get purge -y snapd 2>/dev/null || true
+    apt-get autoremove -y --purge 2>/dev/null || true
+    apt-get clean 2>/dev/null || true
+    rm -rf /var/lib/apt/lists/* 2>/dev/null || true
+    fstrim -av 2>/dev/null || true
   # Signal VM is fully ready
   - echo "YANET VM FULLY READY - $(date)" > /dev/ttyS0
   - echo "Autologin configured for ubuntu user" > /dev/ttyS0


### PR DESCRIPTION
The functional-test guest image carried a full development toolchain that the guest never runs: a Rust toolchain installed through rustup, a Go toolchain, two LLVM releases with their clang tooling, debuggers, a coverage tool and a packet analyser. The guest executes only pre-built binaries exposed from the host over shared directories, so none of it was ever reachable. It also never reclaimed what provisioning left behind, so the package archives stayed resident, and it pulled a second kernel ABI along with its module set and firmware.

Measured on a from-scratch rebuild, the image drops from 7.5 GiB to 425 MiB allocated, and the space genuinely used inside the guest from 7.3 GB to 469 MB. The Actions cache entry that stores it was 3879 MB, which was 62% of the repository's entire active cache budget and the reason eviction pressure kept falling on the ccache, Go and cargo entries that jobs on the critical path depend on.

Reclaiming the archives only works if the disk image is opened with discard enabled, so the image build now does that. The workflow reports the finished image size, since the regression this fixes accumulated silently with nothing reporting it.

The surviving library development packages are load-bearing beyond their own headers: they are what pull the RDMA runtime libraries a locally built dataplane links against, so they are not a leftover to trim later. Removing the toolchain also takes two network fetches out of the image build, which is a class of provisioning flake rather than only bytes.

Verified by rebuilding the image from scratch and running the QEMU functional suite against it, which passed 17 of 17 top-level tests and 115 of 115 subtests, exercising the vfio-pci bind and all five shared-directory mounts that the trimmed module set has to keep working.

Closes #1784.