### PR TITLE
fix(dataplane): transfer mbuf ownership to the consumer on the worker tx pipe

### DIFF
--- a/bindings/go/dataplane_ut/tx_pipe.go
+++ b/bindings/go/dataplane_ut/tx_pipe.go
@@ -1,0 +1,92 @@
+package dataplaneut
+
+/*
+#include <stdint.h>
+
+#include "lib/dataplane_ut/tx_pipe.h"
+*/
+import "C"
+
+import "fmt"
+
+// TxPipe is a handle to a dataplane_ut tx-pipe harness: one worker_tx_pipe
+// plus its own malloc-backed mock mempool, letting a test drive the tx pipe
+// producer/consumer paths directly.
+//
+// Free must be called when the test is done.
+type TxPipe struct {
+	ptr *C.struct_dataplane_ut_tx_pipe
+}
+
+// NewTxPipe constructs a TxPipe whose pipe holds (1 << pipeSize) entries,
+// per worker_tx_pipe_init.
+func NewTxPipe(pipeSize int) (*TxPipe, error) {
+	ptr := C.dataplane_ut_tx_pipe_new(C.size_t(pipeSize))
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to create tx pipe harness: dataplane_ut_tx_pipe_new returned NULL")
+	}
+	return &TxPipe{ptr: ptr}, nil
+}
+
+// Free tears down the harness. Nil-safe.
+func (m *TxPipe) Free() {
+	if m.ptr == nil {
+		return
+	}
+	C.dataplane_ut_tx_pipe_free(m.ptr)
+	m.ptr = nil
+}
+
+// TxMbuf is an opaque handle to a chained mbuf allocated from a TxPipe's
+// mock mempool by AllocMbuf, to be handed to Push.
+type TxMbuf struct {
+	ptr *C.struct_rte_mbuf
+}
+
+// AllocMbuf allocates a chained mbuf of segCount segments from the harness
+// mempool, each segment holding segSize bytes of payload.
+func (m *TxPipe) AllocMbuf(segCount, segSize uint32) (*TxMbuf, error) {
+	ptr := C.dataplane_ut_tx_pipe_alloc_mbuf(m.ptr, C.uint32_t(segCount), C.uint32_t(segSize))
+	if ptr == nil {
+		return nil, fmt.Errorf("failed to allocate mbuf: dataplane_ut_tx_pipe_alloc_mbuf returned NULL")
+	}
+	return &TxMbuf{ptr: ptr}, nil
+}
+
+// Push pushes mbuf into the harness pipe (producer side).
+//
+// Returns an error when the pipe is full.
+func (m *TxPipe) Push(mbuf *TxMbuf) error {
+	if C.dataplane_ut_tx_pipe_push(m.ptr, mbuf.ptr) != 0 {
+		return fmt.Errorf("failed to push mbuf: pipe is full")
+	}
+	return nil
+}
+
+// Drain drains the harness pipe (consumer side), accepting the first
+// acceptCount mbufs of each burst and freeing the rest, mirroring a NIC
+// tx_burst that only transmits part of a burst.
+//
+// Returns the number of items drained.
+func (m *TxPipe) Drain(acceptCount uint16) uint64 {
+	return uint64(C.dataplane_ut_tx_pipe_drain(m.ptr, C.uint16_t(acceptCount)))
+}
+
+// CompleteTx frees every mbuf accepted by the stub xmit across prior Drain
+// calls, modeling a NIC completing their tx (consumer side).
+func (m *TxPipe) CompleteTx() {
+	C.dataplane_ut_tx_pipe_complete_tx(m.ptr)
+}
+
+// Reclaim releases mbufs whose consumer-side tx has completed (producer
+// side).
+func (m *TxPipe) Reclaim() {
+	C.dataplane_ut_tx_pipe_reclaim(m.ptr)
+}
+
+// Outstanding reports the number of mbuf objects currently dequeued from the
+// harness mempool but not yet returned, so a test can assert exact balance
+// after a push/drain/reclaim sequence.
+func (m *TxPipe) Outstanding() uint64 {
+	return uint64(C.dataplane_ut_tx_pipe_outstanding(m.ptr))
+}

--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -82,22 +82,9 @@ dataplane_worker_connect(
 	}
 
 	struct worker_tx_pipe *tx_pipe = tx_conn->pipes + tx_conn->count;
-	if (data_pipe_init(&tx_pipe->pipe, WORKER_TX_PIPE_SIZE)) {
+	if (worker_tx_pipe_init(tx_pipe, WORKER_TX_PIPE_SIZE)) {
 		return -1;
 	}
-
-	uint32_t pending_capacity =
-		1u << (WORKER_TX_PIPE_SIZE + WORKER_TX_PIPE_PENDING_SHIFT);
-	tx_pipe->pending_mbufs = (struct worker_pending_mbuf *)malloc(
-		sizeof(struct worker_pending_mbuf) * pending_capacity
-	);
-	if (tx_pipe->pending_mbufs == NULL) {
-		data_pipe_fini(&tx_pipe->pipe);
-		return -1;
-	}
-	tx_pipe->pending_mask = pending_capacity - 1;
-	tx_pipe->pending_start = 0;
-	tx_pipe->pending_stop = 0;
 
 	++tx_conn->count;
 

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -95,64 +95,6 @@ worker_read(
 	}
 }
 
-struct worker_push_ctx {
-	struct worker_tx_pipe *tx_pipe;
-	struct rte_mbuf *mbuf;
-};
-
-static size_t
-worker_connection_push_cb(void **item, size_t count, void *data) {
-	struct worker_push_ctx *push_ctx = (struct worker_push_ctx *)data;
-	struct worker_tx_pipe *tx_pipe = push_ctx->tx_pipe;
-
-	if (count > 0) {
-		uint32_t ref_cnt =
-			rte_mbuf_refcnt_update(push_ctx->mbuf, 1) - 1;
-		memcpy(item, &push_ctx->mbuf, sizeof(struct rte_mbuf *));
-
-		uint32_t ofs = tx_pipe->pending_stop & tx_pipe->pending_mask;
-		tx_pipe->pending_mbufs[ofs].mbuf = push_ctx->mbuf;
-		tx_pipe->pending_mbufs[ofs].ref_cnt = ref_cnt;
-		++tx_pipe->pending_stop;
-
-		return 1;
-	}
-	return 0;
-}
-
-static size_t
-worker_rx_pipe_pop_cb(void **item, size_t count, void *data) {
-	struct dataplane_worker *worker = (struct dataplane_worker *)data;
-	struct rte_mbuf **mbufs = (struct rte_mbuf **)item;
-
-	(*worker->dp_worker->remote_rx_count) += count;
-
-	size_t written = rte_eth_tx_burst(
-		worker->port_id, worker->queue_id, mbufs, count
-	);
-	*(worker->dp_worker->tx_count) += written;
-
-	size_t dropped = count - written;
-	if (dropped > 0) {
-		*(worker->dp_worker->local_tx_drops) += dropped;
-		*(worker->dp_worker->drop_count) += dropped;
-	}
-
-	for (size_t idx = written; idx < count; ++idx) {
-		rte_pktmbuf_free(mbufs[idx]);
-	}
-
-	return count;
-}
-
-static size_t
-worker_connection_free_cb(void **item, size_t count, void *data) {
-	(void)item;
-	(void)data;
-
-	return count;
-}
-
 /*
  * FIXME: the function below sends a packet to a different worker
  * using corresponding data pipe so the routine name might be confusing.
@@ -169,46 +111,7 @@ worker_send_to_port(struct dataplane_worker *worker, struct packet *packet) {
 	struct worker_tx_pipe *tx_pipe =
 		tx_conn->pipes + packet->hash % tx_conn->count;
 
-	// Backpressure: drop when this pipe's pending ring is full.
-	if (tx_pipe->pending_stop - tx_pipe->pending_start >
-	    tx_pipe->pending_mask) {
-		return -1;
-	}
-
-	struct worker_push_ctx push_ctx = {
-		.tx_pipe = tx_pipe,
-		.mbuf = packet_to_mbuf(packet),
-	};
-
-	if (data_pipe_item_push(
-		    &tx_pipe->pipe, worker_connection_push_cb, &push_ctx
-	    ) != 1) {
-		return -1;
-	}
-
-	return 0;
-}
-
-static void
-worker_tx_pipe_reclaim(struct worker_tx_pipe *tx_pipe) {
-	// Reclaim consumed pipe slots (producer free phase).
-	data_pipe_item_free(&tx_pipe->pipe, worker_connection_free_cb, NULL);
-
-	// Release mbufs whose consumer-side NIC tx has completed. A single
-	// pipe feeds one rx worker and one NIC tx queue, so completion is
-	// FIFO: drain from the head and stop at the first mbuf still held.
-	while (tx_pipe->pending_start < tx_pipe->pending_stop) {
-		uint32_t ofs = tx_pipe->pending_start & tx_pipe->pending_mask;
-		struct worker_pending_mbuf *pending =
-			tx_pipe->pending_mbufs + ofs;
-
-		if (rte_mbuf_refcnt_read(pending->mbuf) > pending->ref_cnt) {
-			break;
-		}
-
-		rte_pktmbuf_free(pending->mbuf);
-		++tx_pipe->pending_start;
-	}
+	return worker_tx_pipe_push(tx_pipe, packet_to_mbuf(packet));
 }
 
 static void
@@ -245,6 +148,26 @@ worker_submit_burst(
 	for (uint16_t idx = written; idx < count; ++idx) {
 		packet_list_add(failed, mbuf_to_packet(mbufs[idx]));
 	}
+}
+
+static uint16_t
+worker_tx_pipe_xmit(void *ctx, struct rte_mbuf **mbufs, uint16_t count) {
+	struct dataplane_worker *worker = (struct dataplane_worker *)ctx;
+
+	(*worker->dp_worker->remote_rx_count) += count;
+
+	uint16_t written = rte_eth_tx_burst(
+		worker->port_id, worker->queue_id, mbufs, count
+	);
+	*(worker->dp_worker->tx_count) += written;
+
+	uint16_t dropped = count - written;
+	if (dropped > 0) {
+		*(worker->dp_worker->local_tx_drops) += dropped;
+		*(worker->dp_worker->drop_count) += dropped;
+	}
+
+	return written;
 }
 
 static void
@@ -307,8 +230,8 @@ worker_write(
 
 	// Read incoming mbufs from remote workers and write them to device
 	for (uint32_t pipe_idx = 0; pipe_idx < ctx->rx_pipe_count; ++pipe_idx) {
-		data_pipe_item_pop(
-			ctx->rx_pipes + pipe_idx, worker_rx_pipe_pop_cb, worker
+		worker_tx_pipe_drain(
+			ctx->rx_pipes + pipe_idx, worker_tx_pipe_xmit, worker
 		);
 	}
 
@@ -491,6 +414,11 @@ dataplane_worker_init(
 
 	uint32_t num_mbufs = config->num_mbufs ? config->num_mbufs : 16384;
 
+	// Gets are never concurrent: the PMD rx-ring prefill happens in
+	// dpdk_port_start(), strictly before this worker thread is created,
+	// and every later get is this worker's own. Puts are multi-producer:
+	// a consumer worker on another core frees mbufs drawn from this
+	// pool.
 	worker->rx_mempool = rte_mempool_create(
 		mempool_name,
 		num_mbufs,
@@ -502,7 +430,7 @@ dataplane_worker_init(
 		rte_pktmbuf_init,
 		NULL,
 		config->instance_id,
-		MEMPOOL_F_SP_PUT | MEMPOOL_F_SC_GET
+		MEMPOOL_F_SC_GET
 	);
 	if (worker->rx_mempool == NULL) {
 		LOG(ERROR, "failed to create worker rx pool %s", mempool_name);

--- a/dataplane/worker.h
+++ b/dataplane/worker.h
@@ -8,40 +8,15 @@
 
 #include "common/data_pipe.h"
 #include "lib/dataplane/packet/packet.h"
+#include "lib/dataplane/worker/tx_pipe.h"
 
 struct dataplane;
 struct dataplane_instance;
 
 struct dp_worker;
 
-// log2 of the per-connection SPSC data pipe capacity.
-#define WORKER_TX_PIPE_SIZE 10
-// The per-pipe deferred-free ring holds 2^(WORKER_TX_PIPE_SIZE + this)
-// mbufs, sized above the pipe capacity to absorb consumer-side NIC tx
-// backlog before backpressure drops further packets.
-#define WORKER_TX_PIPE_PENDING_SHIFT 2
-
 struct worker_read_ctx {
 	uint16_t read_size;
-};
-
-struct worker_pending_mbuf {
-	struct rte_mbuf *mbuf;
-	uint64_t ref_cnt;
-};
-
-// A data pipe to another worker paired with its own deferred-free ring.
-//
-// The producer holds an extra reference on each mbuf pushed into `pipe`
-// and records it in `pending_mbufs`; the reference is released once the
-// consumer's NIC tx completes. Per-pipe completion is FIFO, so the ring
-// is drained head-first.
-struct worker_tx_pipe {
-	struct data_pipe pipe;
-	struct worker_pending_mbuf *pending_mbufs;
-	uint32_t pending_mask;
-	uint64_t pending_start;
-	uint64_t pending_stop;
 };
 
 struct worker_tx_connection {

--- a/lib/dataplane/worker/meson.build
+++ b/lib/dataplane/worker/meson.build
@@ -14,6 +14,7 @@ sources = files(
   'pipeline_round.c',
   'worker.c',
   'counters.c',
+  'tx_pipe.c',
 )
 
 lib_worker_dp = static_library(

--- a/lib/dataplane/worker/tx_pipe.c
+++ b/lib/dataplane/worker/tx_pipe.c
@@ -1,0 +1,100 @@
+#include "tx_pipe.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include <rte_mbuf.h>
+
+int
+worker_tx_pipe_init(struct worker_tx_pipe *tx_pipe, size_t pipe_size) {
+	return data_pipe_init(&tx_pipe->pipe, pipe_size);
+}
+
+void
+worker_tx_pipe_fini(struct worker_tx_pipe *tx_pipe) {
+	data_pipe_fini(&tx_pipe->pipe);
+}
+
+struct worker_push_ctx {
+	struct rte_mbuf *mbuf;
+};
+
+static size_t
+worker_connection_push_cb(void **item, size_t count, void *data) {
+	struct worker_push_ctx *push_ctx = (struct worker_push_ctx *)data;
+
+	if (count > 0) {
+		memcpy(item, &push_ctx->mbuf, sizeof(struct rte_mbuf *));
+		return 1;
+	}
+	return 0;
+}
+
+int
+worker_tx_pipe_push(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf) {
+	struct worker_push_ctx push_ctx = {
+		.mbuf = mbuf,
+	};
+
+	if (data_pipe_item_push(
+		    &tx_pipe->pipe, worker_connection_push_cb, &push_ctx
+	    ) != 1) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static size_t
+worker_connection_free_cb(void **item, size_t count, void *data) {
+	(void)item;
+	(void)data;
+
+	return count;
+}
+
+void
+worker_tx_pipe_reclaim(struct worker_tx_pipe *tx_pipe) {
+	// Reclaim consumed pipe slots. data_pipe_item_push() sizes
+	// availability off f_pos, which only advances here, so this call
+	// must run even though it is now a no-op on the mbufs themselves.
+	data_pipe_item_free(&tx_pipe->pipe, worker_connection_free_cb, NULL);
+}
+
+struct worker_tx_pipe_drain_ctx {
+	worker_tx_pipe_xmit_fn xmit;
+	void *ctx;
+};
+
+static size_t
+worker_tx_pipe_drain_cb(void **item, size_t count, void *data) {
+	struct worker_tx_pipe_drain_ctx *drain_ctx =
+		(struct worker_tx_pipe_drain_ctx *)data;
+	struct rte_mbuf **mbufs = (struct rte_mbuf **)item;
+
+	// xmit's count is uint16_t - clamp the burst handed to it so a caller
+	// with a wider pipe (pipe_size >= 16) can't silently truncate count
+	// on the cast below. Anything past the clamp is freed by the tail
+	// loop below, same as a rejected item.
+	size_t burst = count < UINT16_MAX ? count : UINT16_MAX;
+	uint16_t written =
+		drain_ctx->xmit(drain_ctx->ctx, mbufs, (uint16_t)burst);
+
+	for (size_t idx = written; idx < count; ++idx) {
+		rte_pktmbuf_free(mbufs[idx]);
+	}
+
+	return count;
+}
+
+size_t
+worker_tx_pipe_drain(
+	struct data_pipe *rx_pipe, worker_tx_pipe_xmit_fn xmit, void *ctx
+) {
+	struct worker_tx_pipe_drain_ctx drain_ctx = {
+		.xmit = xmit,
+		.ctx = ctx,
+	};
+
+	return data_pipe_item_pop(rx_pipe, worker_tx_pipe_drain_cb, &drain_ctx);
+}

--- a/lib/dataplane/worker/tx_pipe.h
+++ b/lib/dataplane/worker/tx_pipe.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/data_pipe.h"
+
+struct rte_mbuf;
+
+// log2 of the per-connection SPSC data pipe capacity.
+#define WORKER_TX_PIPE_SIZE 10
+
+// A data pipe to another worker.
+struct worker_tx_pipe {
+	struct data_pipe pipe;
+};
+
+// Transmits the leading mbufs of a drained burst.
+//
+// Returns the number of leading mbufs accepted for transmit.
+typedef uint16_t (*worker_tx_pipe_xmit_fn)(
+	void *ctx, struct rte_mbuf **mbufs, uint16_t count
+);
+
+// Initialize a tx pipe: the underlying data pipe alone.
+//
+// Returns 0 on success, -1 on allocation failure.
+int
+worker_tx_pipe_init(struct worker_tx_pipe *tx_pipe, size_t pipe_size);
+
+// Release resources allocated by worker_tx_pipe_init().
+//
+// The caller must have drained the pipe first: this releases the ring
+// itself and does not free mbufs still queued in it.
+void
+worker_tx_pipe_fini(struct worker_tx_pipe *tx_pipe);
+
+// Push mbuf into the pipe (producer side).
+//
+// Returns 0 on success, -1 when the pipe is full.
+int
+worker_tx_pipe_push(struct worker_tx_pipe *tx_pipe, struct rte_mbuf *mbuf);
+
+// Reclaim consumed pipe slots (producer side).
+void
+worker_tx_pipe_reclaim(struct worker_tx_pipe *tx_pipe);
+
+// Drain a pipe's ready items, handing each burst to xmit and freeing the
+// rejected tail (consumer side).
+//
+// Returns the number of items drained.
+size_t
+worker_tx_pipe_drain(
+	struct data_pipe *rx_pipe, worker_tx_pipe_xmit_fn xmit, void *ctx
+);

--- a/lib/dataplane_ut/dataplane_ut.c
+++ b/lib/dataplane_ut/dataplane_ut.c
@@ -410,9 +410,7 @@ dataplane_ut_free(struct dataplane_ut *ut) {
 	}
 
 	if (ut->mempool != NULL) {
-		// Do NOT call rte_mempool_free — the test pool is not a real
-		// DPDK pool and has no backing memory to tear down that way.
-		free(ut->mempool);
+		test_mempool_free(ut->mempool);
 		ut->mempool = NULL;
 	}
 

--- a/lib/dataplane_ut/mempool.h
+++ b/lib/dataplane_ut/mempool.h
@@ -3,6 +3,7 @@
 #include <rte_mbuf.h>
 #include <rte_mempool.h>
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -25,6 +26,10 @@ static int
 test_pool_enqueue(struct rte_mempool *mp, void *const *obj_table, unsigned n) {
 	for (unsigned idx = 0; idx < n; idx++) {
 		free((char *)obj_table[idx] - mp->header_size);
+	}
+
+	if (mp->pool_data != NULL) {
+		*(uint64_t *)mp->pool_data -= n;
 	}
 
 	return 0;
@@ -51,6 +56,11 @@ test_pool_dequeue(struct rte_mempool *mp, void **obj_table, unsigned n) {
 
 		rte_pktmbuf_init(mp, NULL, obj_table[idx], 0);
 	}
+
+	if (mp->pool_data != NULL) {
+		*(uint64_t *)mp->pool_data += n;
+	}
+
 	return 0;
 }
 
@@ -69,7 +79,10 @@ static const struct rte_mempool_ops test_pool_ops = {
 	.get_count = test_pool_get_count,
 };
 
-struct rte_mempool *
+// Test-only mock mempool backed directly by malloc/free (see test_pool_ops
+// above), used in place of a real DPDK pool where no hugepage-backed memory
+// is available.
+static inline struct rte_mempool *
 test_mempool_create(void) {
 	rte_mempool_ops_table.num_ops = 0;
 	rte_mempool_register_ops(&test_pool_ops);
@@ -86,6 +99,32 @@ test_mempool_create(void) {
 		mp->header_size += 64 - (mp->header_size % 64);
 	}
 	mp->private_data_size = private_data_size;
+	// Outstanding-object counter, incremented/decremented by
+	// test_pool_dequeue/test_pool_enqueue - get_count() is a fixed stub and
+	// cannot serve this purpose.
+	mp->pool_data = calloc(1, sizeof(uint64_t));
 	rte_pktmbuf_pool_init(mp, NULL);
 	return mp;
+}
+
+// Release a mempool created by test_mempool_create(). NULL-safe.
+//
+// Do NOT call rte_mempool_free — the test pool is not a real DPDK pool and
+// has no backing memory to tear down that way.
+static inline void
+test_mempool_free(struct rte_mempool *mp) {
+	if (mp == NULL) {
+		return;
+	}
+	free(mp->pool_data);
+	free(mp);
+}
+
+// Report the number of objects currently dequeued and not yet returned.
+static inline uint64_t
+test_mempool_outstanding(const struct rte_mempool *mp) {
+	if (mp->pool_data == NULL) {
+		return 0;
+	}
+	return *(const uint64_t *)mp->pool_data;
 }

--- a/lib/dataplane_ut/meson.build
+++ b/lib/dataplane_ut/meson.build
@@ -12,6 +12,7 @@ dependencies = [
 
 sources = files(
   'dataplane_ut.c',
+  'tx_pipe.c',
 )
 
 lib_dataplane_ut = static_library(

--- a/lib/dataplane_ut/tx_pipe.c
+++ b/lib/dataplane_ut/tx_pipe.c
@@ -1,0 +1,196 @@
+#include "lib/dataplane_ut/tx_pipe.h"
+
+#include <stdlib.h>
+
+#include <rte_mbuf.h>
+
+#include "lib/dataplane/worker/tx_pipe.h"
+#include "lib/dataplane_ut/mempool.h"
+
+struct dataplane_ut_tx_pipe {
+	struct worker_tx_pipe pipe;
+	struct rte_mempool *mempool;
+	// Mbufs accepted by the stub xmit and not yet released by
+	// dataplane_ut_tx_pipe_complete_tx().
+	struct rte_mbuf **accepted;
+	size_t accepted_count;
+	size_t accepted_capacity;
+};
+
+struct dataplane_ut_tx_pipe *
+dataplane_ut_tx_pipe_new(size_t pipe_size) {
+	struct dataplane_ut_tx_pipe *harness = calloc(1, sizeof(*harness));
+	if (harness == NULL) {
+		return NULL;
+	}
+
+	harness->mempool = test_mempool_create();
+	if (harness->mempool == NULL) {
+		free(harness);
+		return NULL;
+	}
+
+	if (worker_tx_pipe_init(&harness->pipe, pipe_size)) {
+		test_mempool_free(harness->mempool);
+		free(harness);
+		return NULL;
+	}
+
+	return harness;
+}
+
+// Reject every item, so worker_tx_pipe_drain() frees it via its tail loop
+// instead of handing it to a caller-owned xmit.
+static uint16_t
+drain_reject_xmit(void *ctx, struct rte_mbuf **mbufs, uint16_t count) {
+	(void)ctx;
+	(void)mbufs;
+	(void)count;
+	return 0;
+}
+
+void
+dataplane_ut_tx_pipe_free(struct dataplane_ut_tx_pipe *harness) {
+	if (harness == NULL) {
+		return;
+	}
+
+	dataplane_ut_tx_pipe_complete_tx(harness);
+	// Free mbufs still pushed but never drained, so a test that skips
+	// draining before teardown does not leak them.
+	while (worker_tx_pipe_drain(
+		       &harness->pipe.pipe, drain_reject_xmit, NULL
+	       ) > 0) {
+	}
+	free(harness->accepted);
+	worker_tx_pipe_fini(&harness->pipe);
+	test_mempool_free(harness->mempool);
+	free(harness);
+}
+
+struct rte_mbuf *
+dataplane_ut_tx_pipe_alloc_mbuf(
+	struct dataplane_ut_tx_pipe *harness,
+	uint32_t seg_count,
+	uint32_t seg_size
+) {
+	if (seg_count == 0) {
+		return NULL;
+	}
+
+	struct rte_mbuf *head = rte_pktmbuf_alloc(harness->mempool);
+	if (head == NULL) {
+		return NULL;
+	}
+	if (rte_pktmbuf_append(head, seg_size) == NULL) {
+		rte_pktmbuf_free(head);
+		return NULL;
+	}
+
+	for (uint32_t idx = 1; idx < seg_count; ++idx) {
+		struct rte_mbuf *seg = rte_pktmbuf_alloc(harness->mempool);
+		if (seg == NULL) {
+			rte_pktmbuf_free(head);
+			return NULL;
+		}
+		if (rte_pktmbuf_append(seg, seg_size) == NULL ||
+		    rte_pktmbuf_chain(head, seg)) {
+			rte_pktmbuf_free(seg);
+			rte_pktmbuf_free(head);
+			return NULL;
+		}
+	}
+
+	return head;
+}
+
+int
+dataplane_ut_tx_pipe_push(
+	struct dataplane_ut_tx_pipe *harness, struct rte_mbuf *mbuf
+) {
+	return worker_tx_pipe_push(&harness->pipe, mbuf);
+}
+
+struct drain_accept_ctx {
+	struct dataplane_ut_tx_pipe *harness;
+	uint16_t accept_count;
+};
+
+// Grow harness->accepted and append mbuf. Returns -1 on allocation
+// failure, leaving the mbuf untracked; the caller stops accepting at that
+// point so the mbuf is freed via the rejected-tail path instead.
+static int
+harness_retain_accepted(
+	struct dataplane_ut_tx_pipe *harness, struct rte_mbuf *mbuf
+) {
+	if (harness->accepted_count == harness->accepted_capacity) {
+		size_t capacity = harness->accepted_capacity
+					  ? harness->accepted_capacity * 2
+					  : 8;
+		struct rte_mbuf **grown =
+			realloc(harness->accepted, capacity * sizeof(*grown));
+		if (grown == NULL) {
+			return -1;
+		}
+		harness->accepted = grown;
+		harness->accepted_capacity = capacity;
+	}
+
+	harness->accepted[harness->accepted_count++] = mbuf;
+	return 0;
+}
+
+// Stub xmit accepting only the leading accept_count mbufs of a burst, so a
+// test can force the tail-rejection path without a NIC. Accepted mbufs are
+// retained on the harness until dataplane_ut_tx_pipe_complete_tx() frees
+// them, modeling consumer ownership until NIC tx completion. On a retain
+// failure, the loop stops early and reports fewer accepted mbufs so the
+// untracked one is freed by the caller's rejected-tail path instead of
+// leaking.
+static uint16_t
+drain_accept_xmit(void *ctx, struct rte_mbuf **mbufs, uint16_t count) {
+	struct drain_accept_ctx *accept_ctx = (struct drain_accept_ctx *)ctx;
+	uint16_t accepted = accept_ctx->accept_count < count
+				    ? accept_ctx->accept_count
+				    : count;
+
+	uint16_t idx = 0;
+	for (; idx < accepted; ++idx) {
+		if (harness_retain_accepted(accept_ctx->harness, mbufs[idx])) {
+			break;
+		}
+	}
+
+	return idx;
+}
+
+size_t
+dataplane_ut_tx_pipe_drain(
+	struct dataplane_ut_tx_pipe *harness, uint16_t accept_count
+) {
+	struct drain_accept_ctx ctx = {
+		.harness = harness,
+		.accept_count = accept_count,
+	};
+	return worker_tx_pipe_drain(
+		&harness->pipe.pipe, drain_accept_xmit, &ctx
+	);
+}
+
+void
+dataplane_ut_tx_pipe_complete_tx(struct dataplane_ut_tx_pipe *harness) {
+	for (size_t idx = 0; idx < harness->accepted_count; ++idx) {
+		rte_pktmbuf_free(harness->accepted[idx]);
+	}
+	harness->accepted_count = 0;
+}
+
+void
+dataplane_ut_tx_pipe_reclaim(struct dataplane_ut_tx_pipe *harness) {
+	worker_tx_pipe_reclaim(&harness->pipe);
+}
+
+uint64_t
+dataplane_ut_tx_pipe_outstanding(struct dataplane_ut_tx_pipe *harness) {
+	return test_mempool_outstanding(harness->mempool);
+}

--- a/lib/dataplane_ut/tx_pipe.h
+++ b/lib/dataplane_ut/tx_pipe.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct rte_mbuf;
+
+// Test-only harness wrapping one worker_tx_pipe and its own mock mempool, so
+// a Go test can drive the tx pipe producer/consumer paths directly without
+// standing up a full dataplane_ut harness.
+struct dataplane_ut_tx_pipe;
+
+// Construct a harness: a mock mempool plus a worker_tx_pipe of
+// (1 << pipe_size) capacity, per worker_tx_pipe_init().
+//
+// Returns NULL on allocation failure.
+struct dataplane_ut_tx_pipe *
+dataplane_ut_tx_pipe_new(size_t pipe_size);
+
+// Tear down a harness previously returned by dataplane_ut_tx_pipe_new().
+// NULL-safe.
+void
+dataplane_ut_tx_pipe_free(struct dataplane_ut_tx_pipe *harness);
+
+// Allocate a chained mbuf of seg_count segments from the harness mempool,
+// each segment holding seg_size bytes of payload.
+//
+// Returns NULL on allocation failure.
+struct rte_mbuf *
+dataplane_ut_tx_pipe_alloc_mbuf(
+	struct dataplane_ut_tx_pipe *harness,
+	uint32_t seg_count,
+	uint32_t seg_size
+);
+
+// Push mbuf into the harness pipe (producer side). See worker_tx_pipe_push().
+//
+// Returns 0 on success, -1 when the pipe is full.
+int
+dataplane_ut_tx_pipe_push(
+	struct dataplane_ut_tx_pipe *harness, struct rte_mbuf *mbuf
+);
+
+// Drain the harness pipe (consumer side). See worker_tx_pipe_drain().
+//
+// Accepts the first accept_count mbufs of each burst and frees the rest,
+// mirroring a NIC tx_burst that only transmits part of a burst. Accepted
+// mbufs are retained by the stub xmit, owned by the consumer, until
+// dataplane_ut_tx_pipe_complete_tx() frees them the way a PMD would on tx
+// completion.
+//
+// Returns the number of items drained.
+size_t
+dataplane_ut_tx_pipe_drain(
+	struct dataplane_ut_tx_pipe *harness, uint16_t accept_count
+);
+
+// Free every mbuf accepted by the stub xmit across prior
+// dataplane_ut_tx_pipe_drain() calls, modeling a NIC completing their tx.
+void
+dataplane_ut_tx_pipe_complete_tx(struct dataplane_ut_tx_pipe *harness);
+
+// Reclaim pipe slots consumed by a prior drain (producer side). See
+// worker_tx_pipe_reclaim().
+void
+dataplane_ut_tx_pipe_reclaim(struct dataplane_ut_tx_pipe *harness);
+
+// Report the number of mbuf objects currently outstanding (dequeued from
+// the harness mempool but not yet returned), so a test can assert exact
+// balance after a push/drain/reclaim sequence.
+uint64_t
+dataplane_ut_tx_pipe_outstanding(struct dataplane_ut_tx_pipe *harness);

--- a/tests/worker/tx_pipe_test.go
+++ b/tests/worker/tx_pipe_test.go
@@ -1,0 +1,124 @@
+// Package worker_test holds regression tests for the dataplane tx pipe
+// implemented in lib/dataplane/worker/tx_pipe.c.
+//
+// Once a chained mbuf is pushed, the consumer owns the whole chain: it frees
+// a rejected mbuf immediately, and an accepted one once
+// dataplane_ut_tx_pipe_complete_tx models the NIC's tx completion. The
+// producer's reclaim call never frees mbufs itself — it only advances the
+// pipe's free position.
+package worker_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dataplaneut "github.com/yanet-platform/yanet2/bindings/go/dataplane_ut"
+)
+
+// newTxPipe constructs a TxPipe sized generously for a single test packet
+// and registers its cleanup.
+func newTxPipe(t *testing.T) *dataplaneut.TxPipe {
+	t.Helper()
+
+	pipe, err := dataplaneut.NewTxPipe(4)
+	require.NoError(t, err)
+	t.Cleanup(pipe.Free)
+
+	return pipe
+}
+
+// Verifies that a multi-segment mbuf rejected by the consumer returns every
+// segment, including the tail segments the producer's reclaim never itself
+// frees, to the mempool exactly once.
+func TestMultiSegmentRejectedTransmitBalancesMempool(t *testing.T) {
+	pipe := newTxPipe(t)
+
+	mbuf, err := pipe.AllocMbuf(3, 64)
+	require.NoError(t, err)
+
+	require.NoError(t, pipe.Push(mbuf))
+	require.EqualValues(t, 1, pipe.Drain(0))
+	pipe.Reclaim()
+
+	require.EqualValues(t, 0, pipe.Outstanding(),
+		"all segments of the rejected mbuf must be back in the mempool exactly once")
+}
+
+// Verifies the positive control for
+// TestMultiSegmentRejectedTransmitBalancesMempool: a single-segment mbuf has
+// no tail segments for the consumer's free to strand.
+func TestSingleSegmentRejectedTransmitBalancesMempool(t *testing.T) {
+	pipe := newTxPipe(t)
+
+	mbuf, err := pipe.AllocMbuf(1, 64)
+	require.NoError(t, err)
+
+	require.NoError(t, pipe.Push(mbuf))
+	require.EqualValues(t, 1, pipe.Drain(0))
+	pipe.Reclaim()
+
+	require.EqualValues(t, 0, pipe.Outstanding(),
+		"the rejected single-segment mbuf must be back in the mempool exactly once")
+}
+
+// Verifies that a multi-segment mbuf accepted by the consumer returns every
+// segment to the mempool exactly once, once dataplane_ut_tx_pipe_complete_tx
+// models the tx completion.
+func TestMultiSegmentAcceptedTransmitBalancesMempool(t *testing.T) {
+	pipe := newTxPipe(t)
+
+	mbuf, err := pipe.AllocMbuf(3, 64)
+	require.NoError(t, err)
+
+	require.NoError(t, pipe.Push(mbuf))
+	require.EqualValues(t, 1, pipe.Drain(1))
+	pipe.CompleteTx()
+	pipe.Reclaim()
+
+	require.EqualValues(t, 0, pipe.Outstanding(),
+		"all segments of the accepted mbuf must be back in the mempool exactly once")
+}
+
+// Verifies that worker_tx_pipe_reclaim frees pipe slots so a pipe filled to
+// capacity accepts pushes again.
+//
+// data_pipe_item_push sizes availability off f_pos, which only advances
+// during reclaim: without that call, a pipe once filled stays wedged even
+// after every mbuf has drained and completed.
+func TestReclaimUnwedgesPipeAfterFull(t *testing.T) {
+	const pipeSizeLog2 = 1
+	const capacity = 1 << pipeSizeLog2
+
+	pipe, err := dataplaneut.NewTxPipe(pipeSizeLog2)
+	require.NoError(t, err)
+	t.Cleanup(pipe.Free)
+
+	for range capacity {
+		mbuf, err := pipe.AllocMbuf(1, 64)
+		require.NoError(t, err)
+		require.NoError(t, pipe.Push(mbuf))
+	}
+
+	overflow, err := pipe.AllocMbuf(1, 64)
+	require.NoError(t, err)
+	require.Error(t, pipe.Push(overflow), "push must fail while the pipe is full at capacity")
+
+	require.EqualValues(t, capacity, pipe.Drain(capacity))
+	pipe.CompleteTx()
+	pipe.Reclaim()
+
+	require.NoError(t, pipe.Push(overflow), "push %d must succeed once reclaim has freed the slot filled in the first round", 0)
+	for idx := 1; idx < capacity; idx++ {
+		mbuf, err := pipe.AllocMbuf(1, 64)
+		require.NoError(t, err)
+		require.NoError(t, pipe.Push(mbuf), "push %d must succeed once reclaim has freed the slot filled in the first round", idx)
+	}
+
+	require.EqualValues(t, capacity, pipe.Drain(capacity))
+	pipe.CompleteTx()
+	pipe.Reclaim()
+
+	require.EqualValues(t, 0, pipe.Outstanding(),
+		"every mbuf across both rounds must be back in the mempool exactly once")
+}


### PR DESCRIPTION
The producer pinned only the head segment of a chained mbuf pushed to another worker, recorded a refcount baseline, and performed the final free itself. Both the producer and the consumer then called the chain-walking free, so every tail segment of a multi-segment packet was returned to the mempool twice.

Confirmed under ASan on both transmit paths, not only the rejected one the issue describes. When the consumer accepts, the PMD's completion free is the same per-segment free, so the tails go back to the pool while the head survives at its baseline with its next pointer intact, and the producer's later free walks into pool memory.

The pin turned out to serve exactly one undocumented purpose: the per-worker rx mempool was created with no cache and `MEMPOOL_F_SP_PUT`, which DPDK maps to a single-producer ring, so only the owning lcore could ever return an mbuf to it. The pin kept every consumer-side free short of the pool. Dropping that flag makes cross-core puts legal and lets the consumer own the mbuf outright, which deletes the pending ring, the reclaim scan and two atomics per remote packet.

- Drop `MEMPOOL_F_SP_PUT` from the per-worker rx pool, keeping single-consumer gets, which stay sound because the rx-ring prefill runs before the worker thread exists and every later allocation is that worker's own.
- Remove the producer-side pin, the pending-mbuf ring and the reclaim loop, leaving only the free-phase call that advances the pipe's free position.
- Move the tx pipe into its own unit so a test can drive the real producer and consumer paths, which were previously static.
- Add Go regression tests over the real pipe covering a rejected transmit, an accepted transmit and the single-segment control, plus a case pinning the free-phase call that would otherwise wedge the pipe.

At source level the original defect is a wrong-primitive mistake: `rte_mbuf_refcnt_update` pins one segment where `rte_pktmbuf_refcnt_update` pins the whole chain. Correcting just the primitive was considered and rejected, and the reason is not the primitive. With every segment pinned, the producer's readiness test can still observe the head back at its baseline while the consumer is midway through decrementing the tail segments, so the two walks race on a tail and the losing side's mempool put can land on the consumer lcore. That is the very invariant the pin exists to protect, and against a single-producer ring it corrupts silently rather than crashing, turning an ASan-visible double free into an invisible one. Closing the race needs the readiness test to check every segment, which re-reads N cachelines the consumer core has just dirtied, and the scheme also rests on three unenforced invariants: that no module ever shares an mbuf segment, that `RTE_ETH_TX_OFFLOAD_MBUF_FAST_FREE` is never enabled, and that consumers free head to tail.

Verification: the multi-segment test was written against the unfixed code and fails there with a use-after-free, so the before and after are both demonstrated rather than reconstructed. A bug-hunter pass reproduced all four original scenarios against the fixed code with a positive control, a randomized stress and a two-thread run over roughly 1.1M mbufs. On `lab-vla-fw3` at a saturating 20 Mpps the change is within the noise floor measured between two builds of identical source, and microbenchmarks put the removed cross-core cacheline round trip at 118-207 cycles per remote packet against 12-26 cycles added per mempool put.

Closes #1718.