### PR TITLE
fix(common,filter): store value registry memory context as an offset pointer

### DIFF
--- a/common/registry.h
+++ b/common/registry.h
@@ -32,7 +32,7 @@ static inline int
 value_collector_init(
 	struct value_collector *collector, struct memory_context *memory_context
 ) {
-	collector->memory_context = memory_context;
+	SET_OFFSET_OF(&collector->memory_context, memory_context);
 	// zero-initialized array
 	collector->use_map = NULL;
 	collector->chunk_count = 0;
@@ -43,6 +43,8 @@ value_collector_init(
 
 static inline void
 value_collector_fini(struct value_collector *collector) {
+	struct memory_context *memory_context =
+		ADDR_OF(&collector->memory_context);
 	uint32_t **use_map = ADDR_OF(&collector->use_map);
 
 	if (use_map != NULL) {
@@ -51,7 +53,7 @@ value_collector_fini(struct value_collector *collector) {
 			uint32_t *chunk = ADDR_OF(&use_map[chunk_idx]);
 			if (chunk != NULL) {
 				memory_bfree(
-					collector->memory_context,
+					memory_context,
 					chunk,
 					VALUE_COLLECTOR_CHUNK_SIZE *
 						sizeof(uint32_t)
@@ -60,7 +62,7 @@ value_collector_fini(struct value_collector *collector) {
 			}
 		}
 		memory_bfree(
-			collector->memory_context,
+			memory_context,
 			use_map,
 			collector->chunk_count * sizeof(uint32_t *)
 		);
@@ -80,6 +82,8 @@ value_collector_reset(struct value_collector *collector) {
  */
 static inline int
 value_collector_check(struct value_collector *collector, uint32_t value) {
+	struct memory_context *memory_context =
+		ADDR_OF(&collector->memory_context);
 	uint32_t chunk_idx = value / VALUE_COLLECTOR_CHUNK_SIZE;
 	uint32_t **use_map = ADDR_OF(&collector->use_map);
 
@@ -87,8 +91,7 @@ value_collector_check(struct value_collector *collector, uint32_t value) {
 		uint32_t new_chunk_count = chunk_idx + 1;
 
 		uint32_t **new_use_map = (uint32_t **)memory_balloc(
-			collector->memory_context,
-			new_chunk_count * sizeof(uint32_t *)
+			memory_context, new_chunk_count * sizeof(uint32_t *)
 		);
 
 		if (new_use_map == NULL) {
@@ -108,7 +111,7 @@ value_collector_check(struct value_collector *collector, uint32_t value) {
 		}
 
 		memory_bfree(
-			collector->memory_context,
+			memory_context,
 			use_map,
 			collector->chunk_count * sizeof(uint32_t *)
 		);
@@ -121,7 +124,7 @@ value_collector_check(struct value_collector *collector, uint32_t value) {
 	uint32_t *chunk = ADDR_OF(&use_map[chunk_idx]);
 	if (chunk == NULL) {
 		chunk = (uint32_t *)memory_balloc(
-			collector->memory_context,
+			memory_context,
 			VALUE_COLLECTOR_CHUNK_SIZE * sizeof(uint32_t)
 		);
 
@@ -193,7 +196,7 @@ value_registry_init(
 	struct memory_context *memory_context = (struct memory_context *)
 		memory_balloc(parent_context, sizeof(*memory_context));
 	if (memory_context == NULL) {
-		registry->memory_context = NULL;
+		SET_OFFSET_OF(&registry->memory_context, NULL);
 		return -1;
 	}
 	memory_context_init_from(memory_context, parent_context, name);
@@ -206,11 +209,11 @@ value_registry_init(
 			ADDR_OF(&memory_context->parent);
 		memory_context_fini(memory_context);
 		memory_bfree(parent, memory_context, sizeof(*memory_context));
-		registry->memory_context = NULL;
+		SET_OFFSET_OF(&registry->memory_context, NULL);
 		return -1;
 	}
 
-	registry->memory_context = memory_context;
+	SET_OFFSET_OF(&registry->memory_context, memory_context);
 
 	registry->ranges = NULL;
 	registry->range_count = 0;
@@ -224,6 +227,8 @@ value_registry_init(
  */
 static inline int
 value_registry_start(struct value_registry *registry) {
+	struct memory_context *memory_context =
+		ADDR_OF(&registry->memory_context);
 	value_collector_reset(&registry->collector);
 
 	struct value_range *ranges = ADDR_OF(&registry->ranges);
@@ -234,7 +239,7 @@ value_registry_start(struct value_registry *registry) {
 
 		struct value_range *new_ranges =
 			(struct value_range *)memory_balloc(
-				registry->memory_context,
+				memory_context,
 				new_capacity * sizeof(struct value_range)
 			);
 
@@ -253,7 +258,7 @@ value_registry_start(struct value_registry *registry) {
 		SET_OFFSET_OF(&registry->ranges, new_ranges);
 
 		memory_bfree(
-			registry->memory_context,
+			memory_context,
 			ranges,
 			sizeof(struct value_range) * old_capacity
 		);
@@ -303,7 +308,7 @@ value_registry_collect(struct value_registry *registry, uint32_t value) {
 		struct value_range *range =
 			ADDR_OF(&registry->ranges) + registry->range_count - 1;
 		if (value_range_append(
-			    registry->memory_context, range, value
+			    ADDR_OF(&registry->memory_context), range, value
 		    )) {
 			return -1;
 		}
@@ -322,7 +327,8 @@ value_registry_collect(struct value_registry *registry, uint32_t value) {
 // back NULL and every other field is untouched.
 static inline void
 value_registry_fini(struct value_registry *registry) {
-	struct memory_context *memory_context = registry->memory_context;
+	struct memory_context *memory_context =
+		ADDR_OF(&registry->memory_context);
 	if (memory_context == NULL) {
 		return;
 	}
@@ -361,7 +367,7 @@ value_registry_fini(struct value_registry *registry) {
 	struct memory_context *parent = ADDR_OF(&memory_context->parent);
 	memory_context_fini(memory_context);
 	memory_bfree(parent, memory_context, sizeof(*memory_context));
-	registry->memory_context = NULL;
+	SET_OFFSET_OF(&registry->memory_context, NULL);
 }
 
 static inline uint32_t

--- a/lib/filter/compiler.h
+++ b/lib/filter/compiler.h
@@ -51,10 +51,11 @@ filter_free(
 	for (size_t i = 0; i < filter_compiler->lookup_count; ++i) {
 		struct filter_vertex *v =
 			filter->v + filter_compiler->lookup_count + i;
-		attr_ctx[i] =
-			v->registry.memory_context != NULL
-				? ADDR_OF(&v->registry.memory_context->parent)
-				: NULL;
+		struct memory_context *registry_ctx =
+			ADDR_OF(&v->registry.memory_context);
+		attr_ctx[i] = registry_ctx != NULL
+				      ? ADDR_OF(&registry_ctx->parent)
+				      : NULL;
 	}
 
 	for (size_t i = 0; i < filter_compiler->lookup_count; ++i) {

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -37,6 +37,15 @@ table_test = executable(
 )
 test('value_table', table_test, suite: ['common'])
 
+registry_rebase_test = executable(
+  'registry_rebase_test',
+  ['registry_rebase_test.c'],
+  c_args: yanet_test_c_args,
+  link_args: yanet_link_args,
+  dependencies: dependencies,
+)
+test('registry_rebase', registry_rebase_test, suite: ['common'])
+
 ttlmap_test = executable(
   'ttlmap_test',
   ['ttlmap_test.c'],

--- a/tests/common/registry_rebase_test.c
+++ b/tests/common/registry_rebase_test.c
@@ -1,0 +1,276 @@
+// Regression test for struct value_registry / struct value_collector storing
+// their memory_context as a raw virtual address instead of a shared-memory
+// offset pointer.
+//
+// Builds an arena through one mapping of a memfd and finalises it through a
+// second mapping of the same bytes, which is exactly what happens when the
+// dataplane rebases a shared-memory config at a different base than the
+// control plane that built it.
+
+#include "common/memory.h"
+#include "common/memory_block.h"
+#include "common/registry.h"
+#include "common/test_assert.h"
+#include "common/value.h"
+#include "lib/logging/log.h"
+
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define REGION_SIZE ((size_t)(16u << 20))
+
+struct arena {
+	struct block_allocator alloc;
+	struct memory_context root;
+	struct value_registry registry;
+	struct value_table table;
+};
+
+// Builds allocator, root context, a populated registry and a table, all
+// inside the mapping so every offset pointer in the chain is rebasable.
+static void
+build_arena(struct arena *a) {
+	if (block_allocator_init(&a->alloc)) {
+		_exit(4);
+	}
+
+	uintptr_t start = ((uintptr_t)a + sizeof(*a) + 63) & ~(uintptr_t)63;
+	uintptr_t end = (uintptr_t)a + REGION_SIZE;
+	block_allocator_put_arena(
+		&a->alloc, (void *)start, (size_t)(end - start)
+	);
+
+	if (memory_context_init(&a->root, "root", &a->alloc)) {
+		_exit(5);
+	}
+	if (value_registry_init(&a->registry, &a->root, "reg")) {
+		_exit(6);
+	}
+
+	// Two generations with several values each, so both the collector's
+	// use-map chunks and the ranges array really allocate and the fini
+	// path has something to walk.
+	for (int gen = 0; gen < 2; ++gen) {
+		if (value_registry_start(&a->registry)) {
+			_exit(7);
+		}
+		for (uint32_t v = 0; v < 24; ++v) {
+			if (value_registry_collect(&a->registry, v + gen)) {
+				_exit(8);
+			}
+		}
+	}
+
+	if (value_table_init(&a->table, &a->root, "tab", 8, 8)) {
+		_exit(9);
+	}
+}
+
+static int
+make_memfd(void) {
+	int fd = memfd_create("registry_rebase_test", 0);
+	if (fd < 0) {
+		return -1;
+	}
+	if (ftruncate(fd, REGION_SIZE) != 0) {
+		close(fd);
+		return -1;
+	}
+	return fd;
+}
+
+// Maps fd twice at kernel-chosen addresses backed by the same pages, so an
+// arena built through one base is read through a genuinely different one.
+static int
+map_pair(int fd, struct arena **out_a, struct arena **out_b) {
+	void *a = mmap(
+		NULL, REGION_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0
+	);
+	if (a == MAP_FAILED) {
+		return -1;
+	}
+	void *b = mmap(
+		NULL, REGION_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0
+	);
+	if (b == MAP_FAILED) {
+		munmap(a, REGION_SIZE);
+		return -1;
+	}
+	if (a == b) {
+		munmap(a, REGION_SIZE);
+		munmap(b, REGION_SIZE);
+		return -1;
+	}
+	*out_a = (struct arena *)a;
+	*out_b = (struct arena *)b;
+	return 0;
+}
+
+// Positive control: value_table_free, built through A and finalised through
+// B with A unmapped.
+//
+// table.memory_context already uses the offset convention, so a genuine
+// failure elsewhere is specific to the raw registry field, not the rebase
+// mechanics.
+static void
+phase_table_free(void) {
+	int fd = make_memfd();
+	if (fd < 0) {
+		_exit(3);
+	}
+	struct arena *a, *b;
+	if (map_pair(fd, &a, &b)) {
+		_exit(3);
+	}
+	build_arena(a);
+	munmap(a, REGION_SIZE);
+
+	value_table_free(&b->table);
+	_exit(0);
+}
+
+// The fix: value_registry_fini, built through A and finalised through B
+// with A unmapped.
+static void
+phase_registry_fini(void) {
+	int fd = make_memfd();
+	if (fd < 0) {
+		_exit(3);
+	}
+	struct arena *a, *b;
+	if (map_pair(fd, &a, &b)) {
+		_exit(3);
+	}
+	build_arena(a);
+	munmap(a, REGION_SIZE);
+
+	value_registry_fini(&b->registry);
+	_exit(0);
+}
+
+// Silent-corruption case: A stays mapped, so an unfixed raw pointer aliases
+// live memory rather than faulting, and fini pushes blocks onto the free
+// lists with a mismatched base.
+//
+// Checks that every pool's free-list head resolves inside b's mapping,
+// instead of provoking the corruption with a further allocation.
+static void
+phase_registry_fini_wild(void) {
+	int fd = make_memfd();
+	if (fd < 0) {
+		_exit(3);
+	}
+	struct arena *a, *b;
+	if (map_pair(fd, &a, &b)) {
+		_exit(3);
+	}
+	build_arena(a);
+
+	value_registry_fini(&b->registry);
+
+	for (size_t idx = 0; idx < MEMORY_BLOCK_ALLOCATOR_EXP; ++idx) {
+		void *head = ADDR_OF(&b->alloc.pools[idx].free_list);
+		if (head == NULL) {
+			continue;
+		}
+		if ((uintptr_t)head < (uintptr_t)b ||
+		    (uintptr_t)head >= (uintptr_t)b + REGION_SIZE) {
+			_exit(21);
+		}
+	}
+	_exit(0);
+}
+
+// Runs phase_func in a forked child so a real fault is reported as a
+// descriptive test failure instead of taking down this test binary.
+static int
+run_child(void (*phase_func)(void)) {
+	pid_t pid = fork();
+	if (pid < 0) {
+		return -1;
+	}
+	if (pid == 0) {
+		phase_func();
+		_exit(0);
+	}
+	int status = 0;
+	if (waitpid(pid, &status, 0) < 0) {
+		return -1;
+	}
+	if (WIFSIGNALED(status)) {
+		return 100 + WTERMSIG(status);
+	}
+	return WEXITSTATUS(status);
+}
+
+// Verifies that value_table_free survives a rebase (positive control).
+static int
+test_value_table_survives_rebase(void) {
+	int rc = run_child(phase_table_free);
+	TEST_ASSERT_EQUAL(rc, 0, "value_table_free must survive a rebase");
+	return 0;
+}
+
+// Verifies that value_registry_fini survives a rebase once memory_context
+// is stored as an offset pointer.
+static int
+test_value_registry_survives_rebase(void) {
+	int rc = run_child(phase_registry_fini);
+	TEST_ASSERT_EQUAL(rc, 0, "value_registry_fini must survive a rebase");
+	return 0;
+}
+
+// Verifies that finalising a rebased registry with the old mapping still
+// live leaves every free-list head resolving inside the new mapping.
+static int
+test_value_registry_rebase_no_wild_free_list(void) {
+	int rc = run_child(phase_registry_fini_wild);
+	TEST_ASSERT_EQUAL(
+		rc,
+		0,
+		"a free-list head resolved outside the mapping after rebase"
+	);
+	return 0;
+}
+
+int
+main(void) {
+	log_enable_name("info");
+
+	// Prove the rebase mechanism itself is sound before trusting it as a
+	// test oracle: two ordinary mappings of the same fd must land at
+	// different bases. A platform where this fails cannot run this test.
+	int probe_fd = make_memfd();
+	if (probe_fd < 0) {
+		LOG(ERROR, "memfd_create failed, skipping");
+		return 77;
+	}
+	struct arena *probe_a, *probe_b;
+	if (map_pair(probe_fd, &probe_a, &probe_b)) {
+		LOG(ERROR, "could not obtain two distinct mappings, skipping");
+		close(probe_fd);
+		return 77;
+	}
+	munmap(probe_a, REGION_SIZE);
+	munmap(probe_b, REGION_SIZE);
+	close(probe_fd);
+
+	if (test_value_table_survives_rebase() != 0) {
+		LOG(ERROR, "test_value_table_survives_rebase failed");
+		return -1;
+	}
+	if (test_value_registry_survives_rebase() != 0) {
+		LOG(ERROR, "test_value_registry_survives_rebase failed");
+		return -1;
+	}
+	if (test_value_registry_rebase_no_wild_free_list() != 0) {
+		LOG(ERROR,
+		    "test_value_registry_rebase_no_wild_free_list failed");
+		return -1;
+	}
+
+	LOG(INFO, "registry_rebase tests: OK");
+	return 0;
+}


### PR DESCRIPTION
The value registry and its collector kept their memory context as a raw virtual address, while every other pointer in the same shared-memory arena — including the memory context's own allocator and tree links, and the block allocator's free lists — is stored relative to its own slot. A registry built through one mapping and released through another therefore reached for an address that only means something to the process that created it.

Registries are embedded in every vertex of the classification tree, which modules publish into shared memory, so the field is genuinely reachable from a second mapping. Reproduced by mapping one region at two bases and finalising through the second: with the original mapping gone the teardown faults, and with it still live the teardown completes silently while pushing foreign blocks onto the allocator free lists, which then corrupts an ordinary later allocation. The sibling value table, which already stores the same field as an offset, survives the identical rebase — so the failure is specific to the raw pointer rather than to the rebase itself.

Converts every store and read of that field to the offset convention, matching the value table. The single reader outside the header, in the filter teardown path, converts in the same change: it is the first stale dereference on the real path, so leaving it would have turned a latent trap into a deterministic wild dereference on every filter release.

Adds a regression test that builds an arena through one mapping and finalises it through a second, asserting the table control, the registry teardown, and that no allocator free-list head is left resolving outside the mapping. It lands in the common test directory, alongside the other tests for these structures, and needs no DPDK. Both registry assertions were confirmed to fail against the unconverted code.

The two remaining structures in the same header family that store this field raw are compile-time scratch, never reachable through a second mapping, and are tracked separately in #1879.

Closes #1766.