### PR TITLE
refactor(acl): encapsulate control-plane service access

### DIFF
--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -160,24 +160,8 @@ private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:ent
 private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:entry.published:2  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:entry.published:3  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/acl_adapter.go:ACLService.swapLinkedHandles:entry.published:4  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/aclpb/v1/convert.go:FromActions:result[idx].setFromCAclKind:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/aclpb/v1/convert.go:ToActions:action.toCAclKind:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:m.metricsState.load:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/metrics.go:ACLService.collectDataplaneMetrics:snapshot.configInfo:1  # acl metrics snapshot: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:config.acl:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:entry.published:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.DeleteConfig:entry.published:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.ListConfigs:entry.published:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published.fwstateName:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published.rules:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.ShowConfig:entry.published:3  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:entry.published:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:entry.published:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.acl:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.fwstateName:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.UpdateConfig:oldConfig.rules:1  # legacy: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:entry.published.acl:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:entry.published.acl:2  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:entry.published:1  # acl metrics snapshot: encapsulate behind an exported method or field
@@ -186,10 +170,6 @@ private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLoc
 private:modules/acl/controlplane/service.go:ACLService.publishMetricsSnapshotLocked:m.metricsState.publish:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.retention:m.metricsState.load:1  # acl metrics snapshot: encapsulate behind an exported method or field
 private:modules/acl/controlplane/service.go:ACLService.retention:snapshot.containsConfig:1  # acl metrics snapshot: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.withEntries:e.updateMu:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.withEntries:e.updateMu:2  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.withEntry:entry.updateMu:1  # legacy: encapsulate behind an exported method or field
-private:modules/acl/controlplane/service.go:ACLService.withEntry:entry.updateMu:2  # legacy: encapsulate behind an exported method or field
 private:operators/route/internal/operator/operator.go:applyStaticSeed:routeSvc.getOrCreateRib:1  # legacy: encapsulate behind an exported method or field
 receiver:common/go/dataplane/packet.go:Packet.Data:1  # legacy: rename the receiver to m
 receiver:common/go/dataplane/packet.go:Packet.Free:1  # legacy: rename the receiver to m

--- a/modules/acl/controlplane/aclpb/v1/convert.go
+++ b/modules/acl/controlplane/aclpb/v1/convert.go
@@ -15,7 +15,7 @@ import (
 func ToActions(protoActions []*Action) ([]cacl.AclAction, error) {
 	out := make([]cacl.AclAction, len(protoActions))
 	for idx, action := range protoActions {
-		kind, err := action.toCAclKind()
+		kind, err := action.ToCAclKind()
 		if err != nil {
 			return nil, fmt.Errorf("action %d: %w", idx, err)
 		}
@@ -33,7 +33,7 @@ func FromActions(actions []cacl.AclAction) []*Action {
 	result := make([]*Action, len(actions))
 	for idx, a := range actions {
 		result[idx] = &Action{}
-		result[idx].setFromCAclKind(a.Kind)
+		result[idx].SetFromCAclKind(a.Kind)
 	}
 
 	return result
@@ -109,13 +109,13 @@ func FromRules(rules []cacl.AclRule) []*Rule {
 	return out
 }
 
-// setFromCAclKind sets m.Kind to the proto enum value corresponding
+// SetFromCAclKind sets m.Kind to the proto enum value corresponding
 // to the given cacl action kind.
 //
 // Unrecognized cacl kinds map to ActionKind_ACTION_KIND_PASS (the proto
 // zero value). FromActions does not surface an error in this direction
 // because input comes from a typed Go value, not the wire.
-func (m *Action) setFromCAclKind(kind uint32) {
+func (m *Action) SetFromCAclKind(kind uint32) {
 	switch kind {
 	case uint32(cacl.ActionAllow):
 		m.Kind = ActionKind_ACTION_KIND_PASS
@@ -155,8 +155,8 @@ func ipNetToProto(n filter.IPNet) *filterpb.IPNet {
 	return &filterpb.IPNet{Addr: addrBytes, Mask: maskBytes}
 }
 
-// toCAclKind maps the proto kind enum to the cacl action kind.
-func (m *Action) toCAclKind() (uint32, error) {
+// ToCAclKind maps the proto kind enum to the cacl action kind.
+func (m *Action) ToCAclKind() (uint32, error) {
 	switch m.GetKind() {
 	case ActionKind_ACTION_KIND_PASS:
 		return uint32(cacl.ActionAllow), nil

--- a/modules/acl/controlplane/service.go
+++ b/modules/acl/controlplane/service.go
@@ -87,6 +87,21 @@ type aclConfig struct {
 	fwstateName string
 }
 
+// Rules returns the rules held by the config.
+func (m *aclConfig) Rules() []*aclpb.Rule {
+	return m.rules
+}
+
+// Handle returns the module handle held by the config.
+func (m *aclConfig) Handle() ModuleHandle {
+	return m.acl
+}
+
+// FwStateName returns the linked fwstate config name.
+func (m *aclConfig) FwStateName() string {
+	return m.fwstateName
+}
+
 // Free releases the module handle held by the config.
 //
 // It is safe to call even when no handle is held.
@@ -138,6 +153,26 @@ type configEntry struct {
 	// An updateMu holder may read its own entry's published field without
 	// m.mu, since it is the only possible writer while updateMu is held.
 	published *aclConfig
+}
+
+// LockUpdate acquires the entry's update lock.
+func (m *configEntry) LockUpdate() {
+	m.updateMu.Lock()
+}
+
+// UnlockUpdate releases the entry's update lock.
+func (m *configEntry) UnlockUpdate() {
+	m.updateMu.Unlock()
+}
+
+// Published returns the config currently published for the entry.
+func (m *configEntry) Published() *aclConfig {
+	return m.published
+}
+
+// Publish stores the config currently published for the entry.
+func (m *configEntry) Publish(config *aclConfig) {
+	m.published = config
 }
 
 // ACLService implements the gRPC ACL service.
@@ -244,14 +279,13 @@ func (m *ACLService) hasEntry(name string) bool {
 // withEntry fetches or creates the entry for name, holds its updateMu for
 // the duration of fn, then returns fn's error.
 //
-// updateMu is locked and unlocked only here and in withEntries, nowhere
-// else in the package. That is what makes mutation serialization for a
-// name exhaustive: grep the package for updateMu.Lock( and
-// updateMu.Unlock( and every match resolves to one of these two helpers.
+// Every mutation path acquires and releases the entry lock through the
+// LockUpdate and UnlockUpdate receiver methods. Keeping that pair here makes
+// serialization exhaustive, including backend work and C compilation.
 func (m *ACLService) withEntry(name string, fn func(*configEntry) error) error {
 	entry := m.entry(name)
-	entry.updateMu.Lock()
-	defer entry.updateMu.Unlock()
+	entry.LockUpdate()
+	defer entry.UnlockUpdate()
 
 	return fn(entry)
 }
@@ -265,10 +299,9 @@ func (m *ACLService) withEntry(name string, fn func(*configEntry) error) error {
 // deadlocks between two calls that share some names but list them in a
 // different order.
 //
-// updateMu is locked and unlocked only here and in withEntry, nowhere else
-// in the package. That is what makes mutation serialization for a name
-// exhaustive: grep the package for updateMu.Lock( and updateMu.Unlock( and
-// every match resolves to one of these two helpers.
+// Every multi-name mutation acquires and releases entry locks through the
+// LockUpdate and UnlockUpdate receiver methods. Sorted acquisition and reverse
+// release preserve the consistent order that prevents deadlocks.
 func (m *ACLService) withEntries(names []string, fn func(map[string]*configEntry) error) error {
 	seen := make(map[string]struct{}, len(names))
 	sorted := make([]string, 0, len(names))
@@ -285,13 +318,13 @@ func (m *ACLService) withEntries(names []string, fn func(map[string]*configEntry
 	locked := make([]*configEntry, len(sorted))
 	for idx, name := range sorted {
 		e := m.entry(name)
-		e.updateMu.Lock()
+		e.LockUpdate()
 		locked[idx] = e
 		entries[name] = e
 	}
 	defer func() {
 		for _, e := range slices.Backward(locked) {
-			e.updateMu.Unlock()
+			e.UnlockUpdate()
 		}
 	}()
 
@@ -452,9 +485,9 @@ func (m *ACLService) UpdateConfig(
 
 	var resp *aclpb.UpdateConfigResponse
 	err := m.withEntry(name, func(entry *configEntry) error {
-		oldConfig := entry.published
+		oldConfig := entry.Published()
 
-		if oldConfig != nil && rulesEqual(oldConfig.rules, req.Rules) {
+		if oldConfig != nil && rulesEqual(oldConfig.Rules(), req.Rules) {
 			resp = &aclpb.UpdateConfigResponse{}
 			return nil
 		}
@@ -476,11 +509,11 @@ func (m *ACLService) UpdateConfig(
 
 		fwstateName := ""
 		if oldConfig != nil {
-			fwstateName = oldConfig.fwstateName
+			fwstateName = oldConfig.FwStateName()
 		}
 
 		if fwstateName != "" {
-			handle.TransferFwStateConfig(oldConfig.acl.AsFFIModule())
+			handle.TransferFwStateConfig(oldConfig.Handle().AsFFIModule())
 			m.log.Info("transferred fwstate config for ACL module", zap.String("config", name))
 		}
 
@@ -490,11 +523,11 @@ func (m *ACLService) UpdateConfig(
 		}
 
 		m.mu.Lock()
-		entry.published = &aclConfig{
+		entry.Publish(&aclConfig{
 			rules:       req.Rules,
 			acl:         handle,
 			fwstateName: fwstateName,
-		}
+		})
 		m.publishMetricsSnapshotLocked()
 		m.mu.Unlock()
 
@@ -525,14 +558,18 @@ func (m *ACLService) ShowConfig(
 	}
 
 	entry, ok := m.configs[name]
-	if !ok || entry.published == nil {
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
+	}
+	config := entry.Published()
+	if config == nil {
 		return nil, status.Errorf(codes.NotFound, "config %q not found", name)
 	}
 
 	response := &aclpb.ShowConfigResponse{
 		Name:        name,
-		Rules:       entry.published.rules,
-		FwstateName: entry.published.fwstateName,
+		Rules:       config.Rules(),
+		FwstateName: config.FwStateName(),
 	}
 
 	return response, nil
@@ -550,7 +587,7 @@ func (m *ACLService) ListConfigs(
 	}
 
 	for name, entry := range m.configs {
-		if entry.published == nil {
+		if entry.Published() == nil {
 			continue
 		}
 		response.Configs = append(response.Configs, name)
@@ -583,12 +620,12 @@ func (m *ACLService) DeleteConfig(
 	}
 
 	err := m.withEntry(name, func(entry *configEntry) error {
-		config := entry.published
+		config := entry.Published()
 		if config == nil {
 			return status.Errorf(codes.NotFound, "config %q not found", name)
 		}
 
-		if config.acl != nil {
+		if config.Handle() != nil {
 			if err := m.backend.DeleteModule(name); err != nil {
 				return status.Errorf(codes.Internal, "could not delete acl module config '%s': %v", name, err)
 			}
@@ -596,7 +633,7 @@ func (m *ACLService) DeleteConfig(
 		}
 
 		m.mu.Lock()
-		entry.published = nil
+		entry.Publish(nil)
 		m.publishMetricsSnapshotLocked()
 		m.mu.Unlock()
 


### PR DESCRIPTION
- Encapsulates ACL config and entry access behind receiver-owned methods.
- Exposes ACL action conversion through package APIs.
- Removes the corresponding 20 private-access style-debt entries.
- Leaves the service test-package migration in a separate PR.

Part of #1729.