### PR TITLE
chore(codeowners): align ownership with component boundaries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,53 +1,30 @@
-# Catch-all: cross-cutting changes need core review.
+# Default owner for paths without a more specific rule.
 *                                       @yanet-platform/yanet-core
 
-# Core
-/common/                                @yanet-platform/yanet-core
-/lib/                                   @yanet-platform/yanet-core
-/subprojects/                           @yanet-platform/yanet-core
-
-# Tests / functional.
-/tests/                                 @yanet-platform/yanet-core
-
-# Classifier —> /lib/
-/filter/                                @yanet-platform/yanet-core
-
-# Build / packaging / CI.
+# Security and policy.
 /.github/                               @yanet-platform/yanet-core
-/debian/                                @yanet-platform/yanet-core
-/deploy/                                @yanet-platform/yanet-core
-/Makefile                               @yanet-platform/yanet-core
-/meson.build                            @yanet-platform/yanet-core
 
-# Dataplane core.
-/api/                                   @yanet-platform/yanet-core
-/dataplane/                             @yanet-platform/yanet-core
-
-# Controlplane.
+# Control plane.
 /controlplane/                          @yanet-platform/yanet-controlplane
-
-# Bindings.
 /bindings/go/                           @yanet-platform/yanet-controlplane
-
-# Operators.
 /operators/                             @yanet-platform/yanet-controlplane
 
 # Modules.
-/modules/balancer/                      @yanet-platform/yanet-module-balancer
 /modules/balancer2/                     @yanet-platform/yanet-module-balancer
 /modules/route/                         @yanet-platform/yanet-module-route
 /modules/route-mpls/                    @yanet-platform/yanet-module-route
 /modules/acl/                           @yanet-platform/yanet-module-acl
 /modules/fwstate/                       @yanet-platform/yanet-module-acl
-/modules/dscp/                          @yanet-platform/yanet-core
-/modules/pdump/                         @yanet-platform/yanet-core
-/modules/decap/                         @yanet-platform/yanet-core
-/modules/forward/                       @yanet-platform/yanet-core
-/modules/nat64/                         @yanet-platform/yanet-core
 
-# CLI.
+# Core and shared CLI infrastructure.
 /cli/                                   @yanet-platform/yanet-cli
-/modules/*/cli/                         @yanet-platform/yanet-cli
+/common/rust/                           @yanet-platform/yanet-cli
+/Cargo.toml                             @yanet-platform/yanet-cli
+/Cargo.lock                             @yanet-platform/yanet-cli
+/.rustfmt.toml                          @yanet-platform/yanet-cli
 
-# Web.
+# Core and shared Web infrastructure.
 /web/                                   @yanet-platform/yanet-web
+/package.json                           @yanet-platform/yanet-web
+/package-lock.json                      @yanet-platform/yanet-web
+/.npmrc                                 @yanet-platform/yanet-web


### PR DESCRIPTION
- Keep component-owned CLI and Web code with the component owners.
- Limit the shared CLI and Web teams to repository-wide infrastructure.
- Remove stale and redundant ownership rules while retaining core as the default.