### PR TITLE
refactor(pdump)!: make logging optional

### DIFF
--- a/lint/style/allowlist.txt
+++ b/lint/style/allowlist.txt
@@ -35,8 +35,6 @@
 
 barenew:common/go/grpcmetrics/grpcmetrics.go:New:1  # legacy: rename to a descriptive constructor name
 barenew:common/go/xbackoff/backoff.go:New:1  # legacy: rename to a descriptive constructor name
-logger:modules/pdump/controlplane/ffi.go:ModuleConfig.SetupRing:1  # legacy: migrate to the options pattern
-logger:modules/pdump/controlplane/service.go:NewPdumpService:1  # legacy: migrate to the options pattern
 loggerlast:common/go/readiness/readiness.go:options.Log:1  # legacy: move the *zap.Logger field to the end of the struct
 loggerlast:controlplane/gateway/gateway.go:gatewayOptions.Log:1  # legacy: move the *zap.Logger field to the end of the struct
 loggerlast:controlplane/internal/auth/sshkey/authenticator.go:authenticatorOptions.Log:1  # legacy: move the *zap.Logger field to the end of the struct

--- a/modules/pdump/controlplane/ffi.go
+++ b/modules/pdump/controlplane/ffi.go
@@ -98,9 +98,39 @@ func (e *errorCallbackContext) Close() {
 
 type ModuleConfig struct {
 	ptr ffi.ModuleConfig
+	log *zap.Logger
 }
 
-func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
+// ModuleConfigOption configures a pdump module configuration.
+type ModuleConfigOption func(*moduleConfigOptions)
+
+type moduleConfigOptions struct {
+	Log *zap.Logger
+}
+
+func newModuleConfigOptions() *moduleConfigOptions {
+	return &moduleConfigOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithModuleConfigLog sets the logger for a pdump module configuration.
+func WithModuleConfigLog(log *zap.Logger) ModuleConfigOption {
+	return func(o *moduleConfigOptions) {
+		o.Log = log
+	}
+}
+
+func NewModuleConfig(
+	agent *ffi.Agent,
+	name string,
+	options ...ModuleConfigOption,
+) (*ModuleConfig, error) {
+	opts := newModuleConfigOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
@@ -113,6 +143,7 @@ func NewModuleConfig(agent *ffi.Agent, name string) (*ModuleConfig, error) {
 
 	return &ModuleConfig{
 		ptr: ffi.NewModuleConfig(unsafe.Pointer(ptr)),
+		log: opts.Log,
 	}, nil
 }
 
@@ -198,7 +229,7 @@ func (m *ModuleConfig) SetSnapLen(snaplen uint32) error {
 	return nil
 }
 
-func (m *ModuleConfig) SetupRing(ring *ringBuffer, log *zap.Logger) error {
+func (m *ModuleConfig) SetupRing(ring *ringBuffer) error {
 	var workerCount C.uint64_t
 
 	errCtx := newErrorCallbackContext()
@@ -221,13 +252,14 @@ func (m *ModuleConfig) SetupRing(ring *ringBuffer, log *zap.Logger) error {
 	rings := unsafe.Slice(addr, workerCount)
 	for idx := range rings {
 		dataPtr := C.pdump_module_config_addr_of(&rings[idx].data)
+		log := m.log.With(zap.Int("ringIdx", idx))
 		worker := &workerArea{
 			writeIdx:    (*uint64)(&(rings[idx].write_idx)),
 			readableIdx: (*uint64)(&(rings[idx].readable_idx)),
 			readIdx:     0,
 			data:        unsafe.Slice((*byte)(dataPtr), rings[idx].size),
 			mask:        uint64(rings[idx].mask),
-			log:         log.With(zap.Int("ringIdx", idx)),
+			log:         log,
 		}
 		ring.workers = append(ring.workers, worker)
 	}

--- a/modules/pdump/controlplane/mod.go
+++ b/modules/pdump/controlplane/mod.go
@@ -71,7 +71,7 @@ func NewPdumpModule(cfg *Config, options ...Option) (*PdumpModule, error) {
 		return nil, fmt.Errorf("failed to attach agent to shared memory: %w", err)
 	}
 
-	service := NewPdumpService(agent, log)
+	service := NewPdumpService(agent, WithPdumpServiceLog(log))
 
 	return &PdumpModule{
 		cfg:     cfg,

--- a/modules/pdump/controlplane/service.go
+++ b/modules/pdump/controlplane/service.go
@@ -68,13 +68,38 @@ type ringReader struct {
 	DoneCh chan bool
 }
 
-// NewPdumpService initializes a new packet capture service with the specified agent and logger.
-func NewPdumpService(agent *ffi.Agent, log *zap.Logger) *PdumpService {
+// PdumpServiceOption configures a packet capture service.
+type PdumpServiceOption func(*pdumpServiceOptions)
+
+type pdumpServiceOptions struct {
+	Log *zap.Logger
+}
+
+func newPdumpServiceOptions() *pdumpServiceOptions {
+	return &pdumpServiceOptions{
+		Log: zap.NewNop(),
+	}
+}
+
+// WithPdumpServiceLog sets the logger for a packet capture service.
+func WithPdumpServiceLog(log *zap.Logger) PdumpServiceOption {
+	return func(o *pdumpServiceOptions) {
+		o.Log = log
+	}
+}
+
+// NewPdumpService initializes a new packet capture service.
+func NewPdumpService(agent *ffi.Agent, options ...PdumpServiceOption) *PdumpService {
+	opts := newPdumpServiceOptions()
+	for _, o := range options {
+		o(opts)
+	}
+
 	return &PdumpService{
 		agent:   agent,
 		configs: map[string]*pdumpConfig{},
 		quitCh:  make(chan bool),
-		log:     log,
+		log:     opts.Log,
 	}
 }
 
@@ -289,7 +314,7 @@ func (m *PdumpService) transferConfigParameters(
 	}
 
 	m.log.Debug("setup ring", zap.String("module", name))
-	if err := ffiConfig.SetupRing(oldConfig.Ring, m.log); err != nil {
+	if err := ffiConfig.SetupRing(oldConfig.Ring); err != nil {
 		return fmt.Errorf("failed to setup ring buffers for %s: %w", name, err)
 	}
 
@@ -333,7 +358,7 @@ func (m *PdumpService) updateModuleConfig(
 
 	modConfig := m.configs[name]
 
-	ffiConfig, err := NewModuleConfig(m.agent, name)
+	ffiConfig, err := NewModuleConfig(m.agent, name, WithModuleConfigLog(m.log))
 	if err != nil {
 		return fmt.Errorf("failed to create %q module config: %w", name, err)
 	}

--- a/modules/pdump/controlplane/service_test.go
+++ b/modules/pdump/controlplane/service_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -15,7 +14,7 @@ import (
 // TestShowConfigUnknownConfig verifies that ShowConfig reports NotFound for
 // a config name that was never set.
 func TestShowConfigUnknownConfig(t *testing.T) {
-	service := pdump.NewPdumpService(nil, zap.NewNop())
+	service := pdump.NewPdumpService(nil)
 
 	_, err := service.ShowConfig(t.Context(), &pdumppb.ShowConfigRequest{Name: "missing"})
 	require.Equal(t, codes.NotFound, status.Code(err))


### PR DESCRIPTION
- Makes service and module-config logging optional with no-op defaults.
- Moves ring logger ownership to the Go wrapper without changing C or shared-memory state.
- Removes the final two `logger:` style-debt entries.
- Requires downstream `NewPdumpService` callers to use `WithPdumpServiceLog`.

Closes #1727.