### PR TITLE
fix(dataplane): handle a failed module constructor instead of faulting

### DIFF
--- a/lib/dataplane/config/module_loader.c
+++ b/lib/dataplane/config/module_loader.c
@@ -52,6 +52,10 @@ dp_load_module(
 		return -1;
 	}
 	struct module *module = loader();
+	if (module == NULL) {
+		LOG(ERROR, "module constructor %s returned NULL", loader_name);
+		return -1;
+	}
 
 	struct dp_module *dp_modules = ADDR_OF(&dp_config->dp_modules);
 	if (mem_array_expand_exp(
@@ -61,7 +65,7 @@ dp_load_module(
 		    &dp_config->module_count
 	    )) {
 		LOG(ERROR, "failed to allocate memory for module %s", name);
-		// FIXME: free module
+		free(module);
 		return -1;
 	}
 
@@ -89,6 +93,10 @@ dp_load_device(struct dp_config *dp_config, void *bin_hndl, const char *name) {
 		return -1;
 	}
 	struct device *device = loader();
+	if (device == NULL) {
+		LOG(ERROR, "device constructor %s returned NULL", loader_name);
+		return -1;
+	}
 
 	struct dp_device *dp_devices = ADDR_OF(&dp_config->dp_devices);
 	if (mem_array_expand_exp(
@@ -98,7 +106,7 @@ dp_load_device(struct dp_config *dp_config, void *bin_hndl, const char *name) {
 		    &dp_config->device_count
 	    )) {
 		LOG(ERROR, "failed to allocate memory for device %s", name);
-		// FIXME: free device
+		free(device);
 		return -1;
 	}
 


### PR DESCRIPTION
- Every in-tree module and device constructor reports an allocation failure by returning nothing, while the loader used that result without checking it. A dataplane starting under memory pressure therefore faulted instead of naming the module it could not build.
- The scope here is deliberately small and the benefit is diagnosis rather than availability: startup fails either way, no packet is in flight at that point, and nothing on this path is attacker-influenced. What it buys is a named failure instead of a fault, and it makes the existing check inside every constructor meaningful rather than dead.
- The same two paths leaked the constructed object when the module or device array could not grow, which the code already carried as an acknowledged open defect.
- The review behind this change also examined the plugin ABI guards and confirmed a separate, real gap: the tripwires assert struct sizes only, so a field reshuffle that preserves a size passes every check while leaving a plugin reading the wrong offsets at packet rate, and the ABI version does not change, so an affected plugin still loads. Pinning offsets by hand was prepared and then deliberately withdrawn, because three distinct reachable structures were missed across three review rounds, which is evidence that a hand-kept set is the wrong shape for the problem rather than an argument for a fourth attempt. That gap is open and tracked in #1891.
- Two further cases the issue raised were settled as closed. A constructor whose signature or calling convention diverges cannot be detected at load time by any loader-side check, so the ABI version stays the only guard there. A deliberately malicious plugin is out of scope, because writing into the plugin directory already implies code execution as the dataplane user, so path and symlink hardening would cost the supported deployment flow without buying protection.
- Closes #1722.