### PR TITLE
fix(dataplane): yield while waiting for a generation acknowledgement

### DIFF
--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -1,5 +1,7 @@
 #include "zone.h"
 
+#include <sched.h>
+#include <time.h>
 #include <unistd.h>
 
 struct dp_config *
@@ -11,21 +13,45 @@ dp_config_nextk(struct dp_config *current, uint32_t k) {
 	return current;
 }
 
+// Number of sched_yield iterations tried before falling back to nanosleep.
+#define DP_CONFIG_GEN_ACK_YIELD_ITERS 1024
+
+// Fixed nanosleep interval used once the yield phase is exhausted.
+#define DP_CONFIG_GEN_ACK_SLEEP_NS UINT64_C(1000000)
+
+// Waits for a single worker to acknowledge gen.
+//
+// Backs off from sched_yield to a fixed-interval nanosleep, without ever
+// giving up.
+static void
+dp_config_wait_for_worker_gen(struct dp_worker *worker, uint64_t gen) {
+	for (unsigned iters = 0; iters < DP_CONFIG_GEN_ACK_YIELD_ITERS;
+	     ++iters) {
+		if (__atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE) >= gen) {
+			return;
+		}
+		sched_yield();
+	}
+
+	static const struct timespec sleep_ts = {
+		.tv_sec = (time_t)(DP_CONFIG_GEN_ACK_SLEEP_NS / 1000000000ULL),
+		.tv_nsec = (long)(DP_CONFIG_GEN_ACK_SLEEP_NS % 1000000000ULL),
+	};
+	for (;;) {
+		if (__atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE) >= gen) {
+			return;
+		}
+		nanosleep(&sleep_ts, NULL);
+	}
+}
+
 void
 dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen) {
 	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
-	uint64_t idx = 0;
-	do {
+	for (uint64_t idx = 0; idx < dp_config->worker_count; ++idx) {
 		struct dp_worker *worker = ADDR_OF(workers + idx);
-		uint64_t worker_gen =
-			__atomic_load_n(&worker->gen, __ATOMIC_ACQUIRE);
-		if (worker_gen < gen) {
-			// TODO cpu yield
-			continue;
-		}
-
-		++idx;
-	} while (idx < dp_config->worker_count);
+		dp_config_wait_for_worker_gen(worker, gen);
+	}
 }
 
 bool

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -201,5 +201,11 @@ dp_config_lookup_object(
 uint64_t
 dp_config_device_worker_count(struct dp_config *dp_config, uint32_t device_id);
 
+// Waits for every worker of dp_config to acknowledge generation gen.
+//
+// This is the grace period cp_config_gen_install needs before it may
+// reclaim the generation gen superseded. Blocks with no timeout, by
+// design: an early return would let an owner reclaim memory an
+// unacknowledged worker may still dereference.
 void
 dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen);


### PR DESCRIPTION
Addresses part of #1676. Deliberately does not close it — the bounding half stays open, see below.

The wait for every worker to acknowledge a new configuration generation spun with no yield and no pause, so the control-plane thread burned a full core for as long as the slowest worker took, all of it while holding the configuration lock. It now checks, then yields for a bounded phase, then sleeps at a fixed one-millisecond interval. Measured against a worker that never acknowledges, the waiting thread drops from 99.35% of a core to between 1.6% and 1.8%.

The healthy path is unaffected — a worker that has already acknowledged is noticed on the first check, before any yield, measured at 34, 46 and 55 nanoseconds for one, four and sixteen workers.

The walk is also bounded by the worker count rather than run at least once. That removes an unconditional first-iteration dereference on an instance with no workers, which #1901 has since made unreachable in production, so it is hardening rather than a fix.

Limits, stated because they are easy to read into this and are not here:

- The wait still blocks indefinitely, by design. Once the new generation is published there is no safe return value: reporting failure makes every caller free the generation the workers are executing, and reporting success makes the module services free the superseded one while an unacknowledged worker may still read it. Bounding the wait is blocked on #1887.
- Only the waiting thread stopped spinning. The configuration lock is still a bare compare-and-swap spin, so a concurrent writer keeps burning a core while the holder sleeps.
- The real-world trigger for an unbounded wait is a counted worker whose thread was never created, which is #1882 and is not addressed here.

On testing, which is the part worth knowing before approving:

- This change ships no test, and the existing suite does not exercise the new code. Every harness worker is seeded past any real generation, so the first check returns and nothing reaches the yield or sleep rungs. A green suite here means the change compiles and breaks nothing, not that the backoff works.
- That is deliberate rather than an omission. Earlier revisions added a harness entry point so a test could drive the wait directly, and three cases that pinned the comparison, the recheck and the walk over every worker. None of them failed against the unfixed revision, and reaching the interesting states needs a worker held behind while another thread advances it, which deadlocks in this harness for the reason tracked as #1881. The test-only surface was judged disproportionate for what remains and was removed.
- What remains is a change in how the wait spends its time, whose effect is a measurement, and a loop shape. Neither is something a test in this repository can pin today.