### PR TITLE
fix(dataplane): refuse to start when a worker binding is invalid

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -727,6 +727,22 @@ dataplane_init(
 		}
 	}
 
+	// Reject a workerless instance before any instance is marked ready,
+	// so a later instance failing this check cannot leave an earlier one
+	// advertised in shared memory with no dataplane left to serve it.
+	for (uint32_t instance_idx = 0;
+	     instance_idx < dataplane->instance_count;
+	     ++instance_idx) {
+		struct dp_config *dp_config =
+			dataplane->instances[instance_idx].dp_config;
+		if (dp_config->worker_count == 0) {
+			LOG(ERROR,
+			    "instance %u has no workers configured",
+			    instance_idx);
+			return -1;
+		}
+	}
+
 	// init dataplane instances
 	for (uint32_t instance_idx = 0;
 	     instance_idx < dataplane->instance_count;

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -397,6 +397,17 @@ dataplane_worker_init(
 	    config->core_id,
 	    config->instance_id,
 	    device->port_id);
+
+	if (config->instance_id >= dataplane->instance_count) {
+		LOG(ERROR,
+		    "worker core=%u references instance=%u but only %u "
+		    "instances are configured",
+		    config->core_id,
+		    config->instance_id,
+		    dataplane->instance_count);
+		return -1;
+	}
+
 	worker->dataplane = dataplane;
 	worker->instance = dataplane->instances + config->instance_id;
 	worker->device = device;


### PR DESCRIPTION
Closes #1899.

Two startup validations for one invariant: a configured worker belongs to a real instance, and an instance advertised as ready has at least one worker.

- Rejects a worker whose instance index is out of range before that index is used. The value comes straight from the configuration file and was never checked, and the containing structure is an uninitialised stack variable, so an out-of-range value below the array bound read stack garbage and then wrote through it rather than faulting on a null pointer.
- Rejects an instance with no workers, so a dataplane that cannot forward a packet fails to start instead of advertising itself as ready. Readiness is the only gate a control-plane agent checks before attaching, so without this the control plane attaches to an instance that will never serve it.

The workerless check runs in its own pass, before any instance is published. Inside the publishing loop it would have marked earlier instances ready and only then rejected a later one, leaving a dead process behind an instance the control plane can still attach to.

Consequences worth stating rather than discovering:

- A configuration that declares several instances but pins workers to only some of them now refuses to start entirely, rather than serving the ones that have workers. That is the intended semantics. No committed, generated or lab configuration was found in that shape, and the error names the offending instance.
- A configuration with no devices at all is rejected transitively, since every instance then ends with no workers. No separate check is needed for it.

Neither check carries a unit test, and the reason is a property of the build rather than a judgement call. The dataplane library is built without the source that owns the device-initialisation symbols, which lives only in the executable, so a test target that links the library and calls into the worker path pulls in objects whose link closure cannot be satisfied. Forcing it would mean either stubbing those symbols or pulling device initialisation into a test, and neither is worth doing for this. The existing parser test avoids the problem only because the parser calls into nothing else.

The related partial-readiness hazard inside the publishing loop is unchanged and tracked separately in #1900: two allocation failures there can still return after earlier instances were marked ready.