### PR TITLE
fix(gateway): synchronize test goroutine teardown

### DIFF
--- a/controlplane/gateway/registrar_test.go
+++ b/controlplane/gateway/registrar_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cenkalti/backoff/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -58,8 +59,14 @@ func startGRPCStub(t *testing.T, server ynpb.GatewayServer) string {
 	grpcServer := grpc.NewServer()
 	ynpb.RegisterGatewayServer(grpcServer, server)
 
-	go func() { _ = grpcServer.Serve(listener) }()
-	t.Cleanup(grpcServer.Stop)
+	var wg errgroup.Group
+	wg.Go(func() error {
+		return grpcServer.Serve(listener)
+	})
+	t.Cleanup(func() {
+		grpcServer.Stop()
+		_ = wg.Wait()
+	})
 
 	return listener.Addr().String()
 }

--- a/controlplane/gateway/registration_loop_test.go
+++ b/controlplane/gateway/registration_loop_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -65,10 +64,14 @@ func TestGateway_RegistrationLoop_SurvivesSweepsThatEvictOneShot(t *testing.T) {
 	t.Cleanup(func() { _ = gw.Close() })
 
 	ctx, cancel := context.WithCancel(t.Context())
+	wg, wgContext := errgroup.WithContext(ctx)
+	defer func() {
+		cancel()
+		require.ErrorIs(t, wg.Wait(), context.Canceled)
+	}()
 
-	group, groupContext := errgroup.WithContext(ctx)
-	group.Go(func() error {
-		return gw.Run(groupContext)
+	wg.Go(func() error {
+		return gw.Run(wgContext)
 	})
 
 	connection, err := grpc.NewClient(cfg.Server.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -113,8 +116,8 @@ func TestGateway_RegistrationLoop_SurvivesSweepsThatEvictOneShot(t *testing.T) {
 		loopedBackendAddr,
 		gateway.WithLoopInterval(20*time.Millisecond),
 	)
-	group.Go(func() error {
-		return registrationLoop.Run(groupContext)
+	wg.Go(func() error {
+		return registrationLoop.Run(wgContext)
 	})
 
 	// Vacuity guard: both services must actually reach the registry as
@@ -160,9 +163,8 @@ func TestGateway_RegistrationLoop_SurvivesSweepsThatEvictOneShot(t *testing.T) {
 	// looped service must survive many further sweep ticks, because its
 	// registration loop keeps refreshing the last-seen timestamp.
 	require.Never(t, func() bool {
-		response, listErr := client.ListServices(t.Context(), &ynpb.ListServicesRequest{})
+		response, listErr := client.ListServices(ctx, &ynpb.ListServicesRequest{})
 		if listErr != nil {
-			assert.NoError(t, listErr)
 			return true
 		}
 		_, found := findRegisteredService(response, loopedServiceName)
@@ -184,7 +186,4 @@ func TestGateway_RegistrationLoop_SurvivesSweepsThatEvictOneShot(t *testing.T) {
 	// satisfied by a transient blip that later re-appears.
 	_, oneShotStillFound := findRegisteredService(finalResponse, oneShotServiceName)
 	require.False(t, oneShotStillFound, "one-shot registration must remain evicted")
-
-	cancel()
-	require.ErrorIs(t, group.Wait(), context.Canceled)
 }

--- a/controlplane/gateway/runner_test.go
+++ b/controlplane/gateway/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 
 	"github.com/stretchr/testify/require"
@@ -106,11 +107,15 @@ func TestServiceRunner_registerClosesGatewayClientConnection(t *testing.T) {
 
 	gatewayServer := grpc.NewServer()
 	ynpb.RegisterGatewayServer(gatewayServer, gatewayService)
-	t.Cleanup(gatewayServer.Stop)
 
-	go func() {
-		_ = gatewayServer.Serve(trackingListener)
-	}()
+	var wg errgroup.Group
+	wg.Go(func() error {
+		return gatewayServer.Serve(trackingListener)
+	})
+	t.Cleanup(func() {
+		gatewayServer.Stop()
+		_ = wg.Wait()
+	})
 
 	serviceRunner := NewServiceRunner(&fakeService{}, trackingListener.Addr().String(), nil)
 


### PR DESCRIPTION
- Cancel and join gateway registration test workers on every exit, so early failures cannot leak work past test completion.
- Keep asynchronous polling callbacks independent of the test handle and stop and await sibling gRPC test servers during cleanup.
- Validate the affected race path across twenty repetitions together with the full Go and Meson test suites.
- Closes #1897.