### PR TITLE
refactor(cli): rename the worker drops column to disposed

### DIFF
--- a/cli/modules/counters/src/main.rs
+++ b/cli/modules/counters/src/main.rs
@@ -444,7 +444,7 @@ struct WorkerRow {
     local_tx_drops: String,
     #[tabled(rename = "RemTX Drp")]
     remote_tx_drops: String,
-    #[tabled(rename = "Drops")]
+    #[tabled(rename = "Disposed")]
     drops: String,
 }
 


### PR DESCRIPTION
- Renamed the aggregate worker column in the counters CLI worker summary from `Drops` to `Disposed`, matching the requested operator terminology.
- Kept the underlying counter collection, its protobuf field and the displayed numeric value unchanged, so machine-facing contracts are untouched.
- Left the reason-specific local and remote transmit drop columns as they are, per the scope of the item.

Closes #1907.