### PR TITLE
fix(packaging): keep runtime and dbgsym versions aligned

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -104,6 +104,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends devscripts
+      - name: Test Debian artifact verifier
+        run: ./scripts/test-verify-deb-artifacts.sh
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24.x"
@@ -124,6 +126,7 @@ jobs:
         with:
           name: debs-${{ matrix.unbtver }}
           path: |
+            outdeb/*.changes
             outdeb/*.deb
             outdeb/*.ddeb
 
@@ -133,17 +136,25 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
+      - name: Verify downloaded packages
+        run: ./scripts/verify-deb-artifacts.sh artifacts
+
       - name: Flatten artifacts
         run: |
           mkdir -p outdeb
-          find artifacts -type f -name "*.deb" -exec cp {} outdeb/ \;
+          find artifacts -type f \( -name "*.changes" -o -name "*.deb" -o -name "*.ddeb" \) -exec cp {} outdeb/ \;
+          ./scripts/verify-deb-artifacts.sh outdeb
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          files: outdeb/*
+          files: |
+            outdeb/*.deb
+            outdeb/*.ddeb

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -83,3 +83,4 @@ echo y | debuild --preserve-envvar=PATH -us -uc -b 2>&1 | tee build.log
 
 mkdir -p outdeb
 dcmd cp ../*.changes outdeb/
+./scripts/verify-deb-artifacts.sh outdeb

--- a/scripts/test-verify-deb-artifacts.sh
+++ b/scripts/test-verify-deb-artifacts.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+set -euo pipefail
+
+if ! script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd); then
+    echo "could not resolve the test script directory" >&2
+    exit 1
+fi
+verifier=$script_dir/verify-deb-artifacts.sh
+if ! tmpdir=$(mktemp -d); then
+    echo "could not create temporary directory" >&2
+    exit 1
+fi
+trap 'rm -rf "$tmpdir"' EXIT
+
+make_package() {
+    set -e
+
+    local case_dir=$1
+    local package_name=$2
+    local version=$3
+    local depends=$4
+    local extension=$5
+    local root="$case_dir/${package_name}-${extension#\.}"
+    local output="$case_dir/${package_name}_${version}_all$extension"
+
+    mkdir -p "$root/DEBIAN"
+    {
+        printf 'Package: %s\n' "$package_name"
+        printf 'Version: %s\n' "$version"
+        printf 'Architecture: all\n'
+        printf 'Maintainer: YANET CI <ci@yanet-platform.dev>\n'
+        if [[ -n $depends ]]; then
+            printf 'Depends: %s\n' "$depends"
+        fi
+        printf 'Description: package verifier fixture\n fixture\n'
+    } >"$root/DEBIAN/control"
+    dpkg-deb --build --root-owner-group "$root" "$output" >/dev/null
+}
+
+make_changes() {
+    set -e
+
+    local case_name=$1
+    local case_dir=$tmpdir/$case_name
+    local version=$2
+    shift 2
+    local output="$case_dir/yanet2_${version}_source.changes"
+
+    {
+        printf 'Format: 1.8\n'
+        printf 'Version: %s\n' "$version"
+        printf 'Files:\n'
+        for package_file_name in "$@"; do
+            printf ' 00000000000000000000000000000000 0 %s\n' "$package_file_name"
+        done
+        printf 'Checksums-Sha256:\n'
+        for package_file_name in "$@"; do
+            printf ' %064d 0 %s\n' 0 "$package_file_name"
+        done
+    } >"$output"
+}
+
+expect_pass() {
+    set -e
+
+    local case_name=$1
+    local case_dir=$tmpdir/$case_name
+    "$verifier" "$case_dir"
+}
+
+expect_fail() {
+    set -e
+
+    local case_name=$1
+    local case_dir=$tmpdir/$case_name
+    if "$verifier" "$case_dir"; then
+        echo "expected verifier failure for $case_name" >&2
+        exit 1
+    fi
+}
+
+mkdir -p "$tmpdir/valid"
+make_package "$tmpdir/valid" yanet2 1.0.0 '' .deb
+make_package "$tmpdir/valid" yanet2-dbgsym 1.0.0 'yanet2 (= 1.0.0), libc6' .ddeb
+make_package "$tmpdir/valid" yanet2-cli 1.0.0 '' .deb
+make_package "$tmpdir/valid" yanet2-cli-dbgsym 1.0.0 'yanet2-cli (= 1.0.0)' .ddeb
+make_package "$tmpdir/valid" yanet2-data 1.0.0 '' .deb
+make_changes valid 1.0.0 \
+    yanet2_1.0.0_all.deb \
+    yanet2-dbgsym_1.0.0_all.ddeb \
+    yanet2-cli_1.0.0_all.deb \
+    yanet2-cli-dbgsym_1.0.0_all.ddeb \
+    yanet2-data_1.0.0_all.deb
+expect_pass valid
+
+mkdir -p "$tmpdir/missing-manifest"
+make_package "$tmpdir/missing-manifest" yanet2 1.0.0 '' .deb
+make_package "$tmpdir/missing-manifest" yanet2-dbgsym 1.0.0 'yanet2 (= 1.0.0)' .ddeb
+expect_fail missing-manifest
+
+mkdir -p "$tmpdir/duplicate-manifest"
+make_package "$tmpdir/duplicate-manifest" yanet2 1.0.0 '' .deb
+make_package "$tmpdir/duplicate-manifest" yanet2-dbgsym 1.0.0 'yanet2 (= 1.0.0)' .ddeb
+make_changes duplicate-manifest 1.0.0 \
+    yanet2_1.0.0_all.deb \
+    yanet2-dbgsym_1.0.0_all.ddeb
+cp "$tmpdir/duplicate-manifest/yanet2_1.0.0_source.changes" \
+    "$tmpdir/duplicate-manifest/second.changes"
+expect_fail duplicate-manifest
+
+mkdir -p "$tmpdir/unmanifested-package"
+make_package "$tmpdir/unmanifested-package" yanet2 1.0.0 '' .deb
+make_package "$tmpdir/unmanifested-package" yanet2-dbgsym 1.0.0 'yanet2 (= 1.0.0)' .ddeb
+make_package "$tmpdir/unmanifested-package" yanet2-extra 1.0.0 '' .deb
+make_changes unmanifested-package 1.0.0 \
+    yanet2_1.0.0_all.deb \
+    yanet2-dbgsym_1.0.0_all.ddeb
+expect_fail unmanifested-package
+
+mkdir -p "$tmpdir/missing-dbgsym"
+make_package "$tmpdir/missing-dbgsym" yanet2 1.0.0 '' .deb
+make_changes missing-dbgsym 1.0.0 yanet2_1.0.0_all.deb
+expect_fail missing-dbgsym
+
+mkdir -p "$tmpdir/omitted-one-dbgsym"
+make_package "$tmpdir/omitted-one-dbgsym" yanet2 1.0.0 '' .deb
+make_package "$tmpdir/omitted-one-dbgsym" yanet2-dbgsym 1.0.0 'yanet2 (= 1.0.0)' .ddeb
+make_package "$tmpdir/omitted-one-dbgsym" yanet2-cli 1.0.0 '' .deb
+make_package "$tmpdir/omitted-one-dbgsym" yanet2-cli-dbgsym 1.0.0 'yanet2-cli (= 1.0.0)' .ddeb
+rm "$tmpdir/omitted-one-dbgsym/yanet2-cli-dbgsym_1.0.0_all.ddeb"
+make_changes omitted-one-dbgsym 1.0.0 \
+    yanet2_1.0.0_all.deb \
+    yanet2-dbgsym_1.0.0_all.ddeb \
+    yanet2-cli_1.0.0_all.deb \
+    yanet2-cli-dbgsym_1.0.0_all.ddeb
+expect_fail omitted-one-dbgsym
+
+mkdir -p "$tmpdir/mismatched-version"
+make_package "$tmpdir/mismatched-version" yanet2 1.0.0 '' .deb
+make_package "$tmpdir/mismatched-version" yanet2-dbgsym 2.0.0 'yanet2 (= 2.0.0)' .ddeb
+make_changes mismatched-version 1.0.0 \
+    yanet2_1.0.0_all.deb \
+    yanet2-dbgsym_2.0.0_all.ddeb
+expect_fail mismatched-version
+
+mkdir -p "$tmpdir/duplicate-package"
+make_package "$tmpdir/duplicate-package" yanet2 1.0.0 '' .deb
+cp "$tmpdir/duplicate-package/yanet2_1.0.0_all.deb" "$tmpdir/duplicate-package/renamed.deb"
+make_package "$tmpdir/duplicate-package" yanet2-dbgsym 1.0.0 'yanet2 (= 1.0.0)' .ddeb
+make_changes duplicate-package 1.0.0 \
+    yanet2_1.0.0_all.deb \
+    renamed.deb \
+    yanet2-dbgsym_1.0.0_all.ddeb
+expect_fail duplicate-package
+
+mkdir -p "$tmpdir/missing-runtime"
+make_package "$tmpdir/missing-runtime" yanet2-cli 1.0.0 '' .deb
+make_package "$tmpdir/missing-runtime" yanet2-dbgsym 1.0.0 'yanet2 (= 1.0.0)' .ddeb
+make_changes missing-runtime 1.0.0 \
+    yanet2-cli_1.0.0_all.deb \
+    yanet2-dbgsym_1.0.0_all.ddeb
+expect_fail missing-runtime
+
+mkdir -p "$tmpdir/wrong-dependency"
+make_package "$tmpdir/wrong-dependency" yanet2 1.0.0 '' .deb
+make_package "$tmpdir/wrong-dependency" yanet2-dbgsym 1.0.0 'yanet2 (= 1.0.1)' .ddeb
+make_changes wrong-dependency 1.0.0 \
+    yanet2_1.0.0_all.deb \
+    yanet2-dbgsym_1.0.0_all.ddeb
+expect_fail wrong-dependency
+
+mkdir -p "$tmpdir/non-exact-dependency"
+make_package "$tmpdir/non-exact-dependency" yanet2 1.0.0 '' .deb
+make_package "$tmpdir/non-exact-dependency" yanet2-dbgsym 1.0.0 'yanet2 (>= 1.0.0)' .ddeb
+make_changes non-exact-dependency 1.0.0 \
+    yanet2_1.0.0_all.deb \
+    yanet2-dbgsym_1.0.0_all.ddeb
+expect_fail non-exact-dependency
+
+echo "Debian artifact verifier regression tests passed"

--- a/scripts/verify-deb-artifacts.sh
+++ b/scripts/verify-deb-artifacts.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+set -euo pipefail
+
+fail() {
+    echo "deb artifact verification failed: $*" >&2
+    exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+    fail "usage: $0 <artifact-directory>"
+fi
+
+artifact_dir=$1
+[[ -d $artifact_dir ]] || fail "artifact directory does not exist: $artifact_dir"
+
+if ! tmpdir=$(mktemp -d); then
+    fail "could not create temporary directory"
+fi
+trap 'rm -rf "$tmpdir"' EXIT
+
+if ! find "$artifact_dir" -type f -name '*.changes' -print0 >"$tmpdir/changes-files"; then
+    fail "could not enumerate .changes files"
+fi
+mapfile -d '' changes_files <"$tmpdir/changes-files"
+(( ${#changes_files[@]} == 1 )) || fail "expected exactly one .changes file"
+changes_file=${changes_files[0]}
+
+read_changes_field() {
+    set -e
+
+    local field=$1
+    local file=$2
+    awk -v field="$field" '
+        index($0, field ":") == 1 {
+            sub(/^[^:]+:[[:space:]]*/, "")
+            print
+            exit
+        }
+    ' "$file"
+}
+
+extract_changes_packages() {
+    set -e
+
+    local section=$1
+    local file=$2
+    awk -v section="$section" '
+        $0 == section ":" {
+            in_section = 1
+            found_section = 1
+            next
+        }
+        in_section && /^[^[:space:]][^:]*:/ {
+            in_section = 0
+        }
+        in_section && /^[[:space:]]+/ && $NF ~ /\.(deb|ddeb)$/ {
+            print $NF
+        }
+        END {
+            if (!found_section) {
+                exit 1
+            }
+        }
+    ' "$file"
+}
+
+if ! changes_version=$(read_changes_field Version "$changes_file"); then
+    fail "could not read Version from $changes_file"
+fi
+[[ -n $changes_version ]] || fail "empty Version in $changes_file"
+
+if ! files_packages=$(extract_changes_packages Files "$changes_file"); then
+    fail "could not read package files from Files in $changes_file"
+fi
+if ! checksums_packages=$(extract_changes_packages Checksums-Sha256 "$changes_file"); then
+    fail "could not read package files from Checksums-Sha256 in $changes_file"
+fi
+
+validate_manifest_packages() {
+    set -e
+
+    local section=$1
+    local section_name=$2
+    if ! printf '%s\n' "$section" | awk '
+        BEGIN {
+            valid = 1
+        }
+        NF {
+            if ($0 !~ /^[^[:space:]]+\.(deb|ddeb)$/ || ++seen[$0] > 1) {
+                valid = 0
+                next
+            }
+            count++
+        }
+        END {
+            exit valid == 0 || count == 0 ? 1 : 0
+        }
+    '; then
+        fail "invalid or duplicate package files in $section_name of $changes_file"
+    fi
+}
+
+validate_manifest_packages "$files_packages" Files
+validate_manifest_packages "$checksums_packages" Checksums-Sha256
+
+printf '%s\n' "$files_packages" | sort >"$tmpdir/files-packages"
+printf '%s\n' "$checksums_packages" | sort >"$tmpdir/checksums-packages"
+if ! cmp -s "$tmpdir/files-packages" "$tmpdir/checksums-packages"; then
+    fail "Files and Checksums-Sha256 package lists differ in $changes_file"
+fi
+
+mapfile -t declared_packages <"$tmpdir/files-packages"
+declare -A declared_package
+for package_file_name in "${declared_packages[@]}"; do
+    declared_package[$package_file_name]=1
+done
+
+if ! find "$artifact_dir" -type f \( -name '*.deb' -o -name '*.ddeb' \) -print0 >"$tmpdir/package-files"; then
+    fail "could not enumerate package files"
+fi
+mapfile -d '' package_files <"$tmpdir/package-files"
+(( ${#package_files[@]} > 0 )) || fail "no .deb or .ddeb files found"
+
+declare -A actual_package
+for package_file_path in "${package_files[@]}"; do
+    package_file_name=${package_file_path##*/}
+    [[ ${declared_package[$package_file_name]+present} == present ]] ||
+        fail "unmanifested package file: $package_file_name"
+    if [[ ${actual_package[$package_file_name]+present} ]]; then
+        fail "duplicate package file: $package_file_name"
+    fi
+    actual_package[$package_file_name]=$package_file_path
+done
+
+for package_file_name in "${declared_packages[@]}"; do
+    [[ ${actual_package[$package_file_name]+present} == present ]] ||
+        fail "missing package file declared by $changes_file: $package_file_name"
+done
+
+declare -A package_file
+declare -A package_version
+runtime_count=0
+dbgsym_count=0
+dbgsym_ddeb_count=0
+artifact_version=
+
+read_field() {
+    set -e
+
+    local field=$1
+    local package_file_path=$2
+    dpkg-deb --field "$package_file_path" "$field"
+}
+
+for package_file_name in "${declared_packages[@]}"; do
+    package_file_path=${actual_package[$package_file_name]}
+    if ! package_name=$(read_field Package "$package_file_path"); then
+        fail "could not read Package from $package_file_path"
+    fi
+    if ! version=$(read_field Version "$package_file_path"); then
+        fail "could not read Version from $package_file_path"
+    fi
+    [[ -n $package_name ]] || fail "empty Package in $package_file_path"
+    [[ -n $version ]] || fail "empty Version in $package_file_path"
+
+    if [[ ${package_file[$package_name]+present} ]]; then
+        fail "duplicate package name: $package_name"
+    fi
+    package_file[$package_name]=$package_file_path
+    package_version[$package_name]=$version
+
+    if [[ -z $artifact_version ]]; then
+        artifact_version=$version
+    elif [[ $version != "$artifact_version" ]]; then
+        fail "mixed package versions: $artifact_version and $version"
+    fi
+
+    if [[ $package_name == *-dbgsym ]]; then
+        ((dbgsym_count += 1))
+        if [[ $package_file_path == *.ddeb ]]; then
+            ((dbgsym_ddeb_count += 1))
+        fi
+    else
+        ((runtime_count += 1))
+    fi
+done
+
+[[ $artifact_version == "$changes_version" ]] ||
+    fail "package version $artifact_version does not match $changes_file version $changes_version"
+(( runtime_count > 0 )) || fail "no ordinary packages found"
+(( dbgsym_count > 0 )) || fail "no dbgsym packages found"
+(( dbgsym_ddeb_count > 0 )) || fail "no dbgsym .ddeb files found"
+
+for package_name in "${!package_file[@]}"; do
+    [[ $package_name == *-dbgsym ]] || continue
+
+    runtime_name=${package_name%-dbgsym}
+    if [[ ${package_file[$runtime_name]+present} != present ]]; then
+        fail "missing runtime package $runtime_name for $package_name"
+    fi
+
+    if ! depends=$(read_field Depends "${package_file[$package_name]}"); then
+        fail "could not read Depends from ${package_file[$package_name]}"
+    fi
+    expected_dependency="$runtime_name (= ${package_version[$package_name]})"
+    if ! printf '%s\n' "$depends" | awk -F, -v expected="$expected_dependency" '
+        {
+            for (i = 1; i <= NF; i++) {
+                dependency = $i
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", dependency)
+                if (dependency == expected) {
+                    found = 1
+                }
+            }
+        }
+        END {
+            exit found ? 0 : 1
+        }
+    '; then
+        fail "$package_name must depend on $expected_dependency"
+    fi
+done
+
+echo "Verified $((runtime_count + dbgsym_count)) Debian packages at version $artifact_version"


### PR DESCRIPTION
- Publish Debian runtime and debug-symbol packages from the same build manifest.
- Validate each generated package set and exact dbgsym dependency before artifact upload and release.
- Cover complete and partial debug-symbol loss plus malformed manifests with regression tests.

Closes #1919.