### PR TITLE
refactor(counters)!: rename the worker drops metric to disposed

### DIFF
--- a/controlplane/builtin/counters.go
+++ b/controlplane/builtin/counters.go
@@ -313,7 +313,7 @@ func workerMetrics(workers []ffi.WorkerCounter) []*commonpb.Metric {
 			commonpb.NewMetricCounter("worker_remote_tx_packets", worker.RemoteTxPackets, labels...),
 			commonpb.NewMetricCounter("worker_local_tx_drops", worker.LocalTxDrops, labels...),
 			commonpb.NewMetricCounter("worker_remote_tx_drops", worker.RemoteTxDrops, labels...),
-			commonpb.NewMetricCounter("worker_drops", worker.Drops, labels...),
+			commonpb.NewMetricCounter("worker_disposed", worker.Drops, labels...),
 		)
 
 		if len(worker.RxBursts) > 0 {


### PR DESCRIPTION
- Renamed the aggregate worker metric from `worker_drops` to `worker_disposed`, carrying the operator terminology introduced for the counters CLI column into the metric surface.
- Marked as breaking: the rename has no deprecation window and no dual emission, matching the precedent set when the redundant metric-name prefix was dropped, so any external dashboard or alert reading the old name has to be updated.
- Left the counter itself, its protobuf field, the dataplane counter name and the reason-specific transmit drop metrics unchanged, so the reported value is identical.

There are no consumers of the old name inside either repository.