### PR TITLE
fix(dataplane): snapshot the worker count with the workers array

### DIFF
--- a/lib/dataplane/config/zone.c
+++ b/lib/dataplane/config/zone.c
@@ -47,8 +47,11 @@ dp_config_wait_for_worker_gen(struct dp_worker *worker, uint64_t gen) {
 
 void
 dp_config_wait_for_gen(struct dp_config *dp_config, uint64_t gen) {
-	struct dp_worker **workers = ADDR_OF(&dp_config->workers);
-	for (uint64_t idx = 0; idx < dp_config->worker_count; ++idx) {
+	// The loop bound and the array it indexes come from one observation.
+	struct dp_worker *const *workers = ADDR_OF(&dp_config->workers);
+	const uint64_t worker_count = dp_config->worker_count;
+
+	for (uint64_t idx = 0; idx < worker_count; ++idx) {
 		struct dp_worker *worker = ADDR_OF(workers + idx);
 		dp_config_wait_for_worker_gen(worker, gen);
 	}

--- a/lib/dataplane/config/zone.h
+++ b/lib/dataplane/config/zone.h
@@ -138,6 +138,8 @@ struct dp_config {
 
 	struct cp_config *cp_config;
 
+	// Both fields are filled in by dataplane_worker_init during dataplane
+	// startup and stay unchanged afterwards.
 	uint64_t worker_count;
 	struct dp_worker **workers;
 


### PR DESCRIPTION
- The generation wait loaded the workers array once, before its loop, but re-read the worker count in the loop condition on every iteration, so the loop bound and the array it indexed came from two different observations.
- Both are now read as a single snapshot taken before the walk, with the bound held in a constant local.
- The fields themselves now document that the pair is filled in during dataplane startup and stays unchanged afterwards, which is the invariant the single read relies on.
- The use-after-free the issue also raises is not reachable on this base: a control plane can only attach after the dataplane marks the instance ready, which happens only after every worker is registered, so the workers array is final before any control plane can install a generation. No regression test for the racing case is added, since the race cannot be constructed without first changing that ordering.

Closes #1895.