### PR TITLE
feat(commonpb): add a contiguous IP network message

### DIFF
--- a/common/commonpb/meson.build
+++ b/common/commonpb/meson.build
@@ -7,12 +7,12 @@ common_proto_files = [
     join_paths(common_proto_dir, 'v1', 'macaddr.proto'),
     join_paths(common_proto_dir, 'v1', 'ipaddr.proto'),
     join_paths(common_proto_dir, 'v1', 'iprange.proto'),
+    join_paths(common_proto_dir, 'v1', 'ipnetwork.proto'),
 ]
 
-# Generate protobuf files. The root include dir is required so that
-# iprange.proto can import ipaddr.proto via the canonical path
-# "common/commonpb/v1/ipaddr.proto", which matches the import path used by
-# consumers outside this directory.
+# Generate protobuf files. The root include dir is required so that protos
+# in this directory can import each other via the canonical path that
+# consumers outside this directory use.
 common_protoc_gen = custom_target(
     'common-protoc',
     output: [
@@ -21,6 +21,7 @@ common_protoc_gen = custom_target(
         'macaddr.pb.go',
         'ipaddr.pb.go',
         'iprange.pb.go',
+        'ipnetwork.pb.go',
     ],
     input: common_proto_files,
     command: [

--- a/common/commonpb/v1/ipnetwork.go
+++ b/common/commonpb/v1/ipnetwork.go
@@ -1,0 +1,99 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/netip"
+)
+
+// NewContiguousIPNetworkFromPrefix creates a ContiguousIPNetwork from a
+// netip.Prefix value, masking off any host bits.
+//
+// Returns an error if prefix is not valid.
+func NewContiguousIPNetworkFromPrefix(prefix netip.Prefix) (*ContiguousIPNetwork, error) {
+	if !prefix.IsValid() {
+		return nil, fmt.Errorf("invalid prefix")
+	}
+	masked := prefix.Masked()
+	return &ContiguousIPNetwork{
+		Addr:      NewIPAddressFromAddr(masked.Addr()),
+		PrefixLen: uint32(masked.Bits()),
+	}, nil
+}
+
+// ParseContiguousIPNetwork parses s as a CIDR prefix, masking off any host
+// bits.
+func ParseContiguousIPNetwork(s string) (*ContiguousIPNetwork, error) {
+	prefix, err := netip.ParsePrefix(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse IP network: %w", err)
+	}
+	return NewContiguousIPNetworkFromPrefix(prefix)
+}
+
+// ToPrefix converts the ContiguousIPNetwork back to a netip.Prefix value.
+//
+// Returns an error if addr is malformed or if prefix_len exceeds the
+// address family's bit length. The returned prefix is masked, so host bits
+// never leak out even if the message was constructed by hand.
+func (m *ContiguousIPNetwork) ToPrefix() (netip.Prefix, error) {
+	addr, err := m.GetAddr().ToAddr()
+	if err != nil {
+		return netip.Prefix{}, fmt.Errorf("failed to parse network address: %w", err)
+	}
+	if m.GetPrefixLen() > uint32(addr.BitLen()) {
+		return netip.Prefix{}, fmt.Errorf(
+			"prefix length %d exceeds IPv%d address bit length %d",
+			m.GetPrefixLen(),
+			familyNum(addr),
+			addr.BitLen(),
+		)
+	}
+	return netip.PrefixFrom(addr, int(m.GetPrefixLen())).Masked(), nil
+}
+
+// AsLogValue implements xgrpc.ProtoLogValue for compact gRPC logging.
+func (m *ContiguousIPNetwork) AsLogValue() any {
+	prefix, err := m.ToPrefix()
+	if err != nil {
+		return "invalid"
+	}
+
+	return prefix.String()
+}
+
+// contiguousIPNetworkJSON is the JSON wire shape shared by MarshalJSON and
+// UnmarshalJSON.
+type contiguousIPNetworkJSON struct {
+	Network string `json:"network"`
+}
+
+// MarshalJSON serializes the network as a human-readable CIDR string.
+func (m *ContiguousIPNetwork) MarshalJSON() ([]byte, error) {
+	prefix, err := m.ToPrefix()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(contiguousIPNetworkJSON{Network: prefix.String()})
+}
+
+// UnmarshalJSON accepts the network as a CIDR string under the "network"
+// key.
+func (m *ContiguousIPNetwork) UnmarshalJSON(data []byte) error {
+	var raw contiguousIPNetworkJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.Network == "" {
+		return fmt.Errorf("empty IP network is not allowed")
+	}
+
+	parsed, err := ParseContiguousIPNetwork(raw.Network)
+	if err != nil {
+		return err
+	}
+
+	m.Addr = parsed.Addr
+	m.PrefixLen = parsed.PrefixLen
+	return nil
+}

--- a/common/commonpb/v1/ipnetwork.proto
+++ b/common/commonpb/v1/ipnetwork.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package common.commonpb.v1;
+
+option go_package = "github.com/yanet-platform/yanet2/common/commonpb/v1;commonpb";
+
+import "common/commonpb/v1/ipaddr.proto";
+
+// ContiguousIPNetwork represents an IPv4 or IPv6 CIDR prefix.
+//
+// "Contiguous" distinguishes this from a general per-bit mask: the network
+// mask must be expressible as a prefix length. Family is determined by the
+// length of addr, consistently with IPAddress.
+message ContiguousIPNetwork {
+  // Masked network base address.
+  //
+  // Host bits below prefix_len MUST be zero.
+  IPAddress addr = 1;
+  // Prefix length, in bits.
+  //
+  // MUST be <= 32 for a 4-byte addr and <= 128 for a 16-byte addr.
+  uint32 prefix_len = 2;
+}

--- a/common/commonpb/v1/ipnetwork_test.go
+++ b/common/commonpb/v1/ipnetwork_test.go
@@ -1,0 +1,245 @@
+package commonpb_test
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	commonpb "github.com/yanet-platform/yanet2/common/commonpb/v1"
+)
+
+// TestContiguousIPNetwork_ToPrefix_RoundTrip asserts that a prefix that is
+// already masked survives a New/ToPrefix round trip for both families.
+func TestContiguousIPNetwork_ToPrefix_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix netip.Prefix
+	}{
+		{name: "IPv4", prefix: netip.MustParsePrefix("10.0.0.0/24")},
+		{name: "IPv4 host route", prefix: netip.MustParsePrefix("10.0.0.1/32")},
+		{name: "IPv4 default route", prefix: netip.MustParsePrefix("0.0.0.0/0")},
+		{name: "IPv6", prefix: netip.MustParsePrefix("2001:db8::/32")},
+		{name: "IPv6 host route", prefix: netip.MustParsePrefix("2001:db8::1/128")},
+		{name: "IPv6 default route", prefix: netip.MustParsePrefix("::/0")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := commonpb.NewContiguousIPNetworkFromPrefix(tt.prefix)
+			require.NoError(t, err)
+			got, err := m.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, tt.prefix, got)
+		})
+	}
+}
+
+// TestContiguousIPNetwork_HostBitsNormalized asserts that construction and
+// decoding both mask host bits below prefix_len, so the normalization is
+// documented behavior rather than an accident of one direction.
+//
+// It checks the raw wire bytes (m.GetAddr().GetAddr()) directly rather than
+// only round-tripping through ToPrefix, because ToPrefix masks on the way
+// out too: a constructor that forgot to mask would still pass a
+// ToPrefix-only assertion.
+func TestContiguousIPNetwork_HostBitsNormalized(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantIn    string
+		wantBytes []byte
+	}{
+		{name: "IPv4", input: "10.0.0.1/24", wantIn: "10.0.0.0/24", wantBytes: []byte{10, 0, 0, 0}},
+		{
+			name:      "IPv6",
+			input:     "2001:db8::1/32",
+			wantIn:    "2001:db8::/32",
+			wantBytes: []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := netip.MustParsePrefix(tt.input)
+			want := netip.MustParsePrefix(tt.wantIn)
+
+			m, err := commonpb.NewContiguousIPNetworkFromPrefix(in)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBytes, m.GetAddr().GetAddr())
+			got, err := m.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+
+			parsed, err := commonpb.ParseContiguousIPNetwork(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantBytes, parsed.GetAddr().GetAddr())
+			got, err = parsed.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+
+	decodeTests := []struct {
+		name      string
+		addr      []byte
+		prefixLen uint32
+		wantIn    string
+	}{
+		{name: "IPv4 hand-built", addr: []byte{10, 0, 0, 1}, prefixLen: 24, wantIn: "10.0.0.0/24"},
+		{
+			name:      "IPv6 hand-built",
+			addr:      []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+			prefixLen: 32,
+			wantIn:    "2001:db8::/32",
+		},
+	}
+
+	for _, tt := range decodeTests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := netip.MustParsePrefix(tt.wantIn)
+			m := &commonpb.ContiguousIPNetwork{
+				Addr:      &commonpb.IPAddress{Addr: tt.addr},
+				PrefixLen: tt.prefixLen,
+			}
+			got, err := m.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}
+
+// TestContiguousIPNetwork_ToPrefix_PrefixLenOverflow asserts that a
+// prefix_len exceeding the address family's bit length is rejected rather
+// than silently truncated or wrapped.
+func TestContiguousIPNetwork_ToPrefix_PrefixLenOverflow(t *testing.T) {
+	tests := []struct {
+		name      string
+		addr      []byte
+		prefixLen uint32
+	}{
+		{name: "IPv4 overflow", addr: []byte{10, 0, 0, 0}, prefixLen: 33},
+		{name: "IPv6 overflow", addr: make([]byte, 16), prefixLen: 129},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &commonpb.ContiguousIPNetwork{
+				Addr:      &commonpb.IPAddress{Addr: tt.addr},
+				PrefixLen: tt.prefixLen,
+			}
+			_, err := m.ToPrefix()
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestContiguousIPNetwork_ToPrefix_MalformedAddr asserts that an addr byte
+// length other than 4 or 16 is rejected.
+func TestContiguousIPNetwork_ToPrefix_MalformedAddr(t *testing.T) {
+	m := &commonpb.ContiguousIPNetwork{
+		Addr:      &commonpb.IPAddress{Addr: []byte{1, 2, 3, 4, 5}},
+		PrefixLen: 24,
+	}
+	_, err := m.ToPrefix()
+	require.Error(t, err)
+}
+
+// TestNewContiguousIPNetworkFromPrefix_Invalid asserts that constructing
+// from an invalid netip.Prefix is rejected at construction time rather than
+// producing a message that fails later.
+func TestNewContiguousIPNetworkFromPrefix_Invalid(t *testing.T) {
+	_, err := commonpb.NewContiguousIPNetworkFromPrefix(netip.Prefix{})
+	require.Error(t, err)
+}
+
+// TestParseContiguousIPNetwork_Invalid asserts that a malformed CIDR
+// string is rejected.
+func TestParseContiguousIPNetwork_Invalid(t *testing.T) {
+	_, err := commonpb.ParseContiguousIPNetwork("not-a-cidr")
+	require.Error(t, err)
+}
+
+// TestContiguousIPNetwork_AsLogValue asserts the log-friendly string form,
+// including the "invalid" fallback for an undecodable message.
+func TestContiguousIPNetwork_AsLogValue(t *testing.T) {
+	ipv4, err := commonpb.NewContiguousIPNetworkFromPrefix(netip.MustParsePrefix("10.0.0.0/24"))
+	require.NoError(t, err)
+	ipv6, err := commonpb.NewContiguousIPNetworkFromPrefix(netip.MustParsePrefix("2001:db8::/32"))
+	require.NoError(t, err)
+
+	tests := []struct {
+		name string
+		m    *commonpb.ContiguousIPNetwork
+		want string
+	}{
+		{name: "IPv4", m: ipv4, want: "10.0.0.0/24"},
+		{name: "IPv6", m: ipv6, want: "2001:db8::/32"},
+		{
+			name: "invalid",
+			m:    &commonpb.ContiguousIPNetwork{Addr: &commonpb.IPAddress{Addr: []byte{1, 2, 3}}},
+			want: "invalid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.m.AsLogValue())
+		})
+	}
+}
+
+// TestContiguousIPNetwork_JSONRoundTrip asserts marshal/unmarshal round
+// trips through the "network" CIDR string for both families.
+func TestContiguousIPNetwork_JSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix netip.Prefix
+		want   string
+	}{
+		{name: "IPv4", prefix: netip.MustParsePrefix("10.0.0.0/24"), want: `{"network":"10.0.0.0/24"}`},
+		{name: "IPv6", prefix: netip.MustParsePrefix("2001:db8::/32"), want: `{"network":"2001:db8::/32"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original, err := commonpb.NewContiguousIPNetworkFromPrefix(tt.prefix)
+			require.NoError(t, err)
+
+			data, err := json.Marshal(original)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, string(data))
+
+			var got commonpb.ContiguousIPNetwork
+			require.NoError(t, json.Unmarshal(data, &got))
+			require.Equal(t, tt.prefix.Addr().AsSlice(), got.GetAddr().GetAddr())
+
+			gotPrefix, err := got.ToPrefix()
+			require.NoError(t, err)
+			require.Equal(t, tt.prefix, gotPrefix)
+		})
+	}
+}
+
+// TestContiguousIPNetwork_UnmarshalJSON_Errors asserts that an empty or
+// malformed "network" value is rejected.
+func TestContiguousIPNetwork_UnmarshalJSON_Errors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{name: "empty string", input: `{"network":""}`},
+		{name: "malformed CIDR", input: `{"network":"not-a-cidr"}`},
+		{name: "invalid JSON", input: `{"network":`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m commonpb.ContiguousIPNetwork
+			err := json.Unmarshal([]byte(tt.input), &m)
+			require.Error(t, err)
+		})
+	}
+}

--- a/common/rust/commonpb/build.rs
+++ b/common/rust/commonpb/build.rs
@@ -2,14 +2,12 @@ use core::error::Error;
 
 /// Messages that gain the ordinary `Serialize`/`Deserialize` derive.
 ///
-/// `IPAddress` and `MACAddress` are deliberately absent: `src/lib.rs` hand-
-/// writes their `Serialize`/`Deserialize` impls to go straight to and from
-/// an address string, and prost-build's attribute paths are additive, not
-/// subtractive -- a blanket `message_attribute(".", ...)` cannot exclude a
-/// single message, so every other message is listed here individually
-/// instead. `IPRange` needs no hand-written impl of its own: once its two
-/// `IPAddress` fields serialize as strings, its derived shape is already
-/// `{"start": "...", "end": "..."}`.
+/// `IPAddress`, `MACAddress`, and `ContiguousIPNetwork` are deliberately
+/// absent: `src/lib.rs` hand-writes their `Serialize`/`Deserialize` impls to
+/// go straight to and from a plain string, and prost-build's attribute
+/// paths are additive, not subtractive -- a blanket `message_attribute(".",
+/// ...)` cannot exclude a single message, so every other message is listed
+/// here individually instead.
 const SERDE_MESSAGES: &[&str] = &[
     ".common.commonpb.v1.ModuleId",
     ".common.commonpb.v1.FunctionId",
@@ -32,6 +30,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=common/commonpb/v1/macaddr.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/ipaddr.proto");
     println!("cargo:rerun-if-changed=common/commonpb/v1/iprange.proto");
+    println!("cargo:rerun-if-changed=common/commonpb/v1/ipnetwork.proto");
 
     let mut config = tonic_build::configure()
         .build_server(false)
@@ -56,6 +55,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
             "common/commonpb/v1/macaddr.proto",
             "common/commonpb/v1/ipaddr.proto",
             "common/commonpb/v1/iprange.proto",
+            "common/commonpb/v1/ipnetwork.proto",
         ],
         &["../../.."],
     )?;

--- a/common/rust/commonpb/src/lib.rs
+++ b/common/rust/commonpb/src/lib.rs
@@ -6,6 +6,7 @@ use core::{
 };
 
 use netip::{Contiguous, IpNetwork, MacAddr, ipv4_range_to_networks, ipv6_range_to_networks};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
 #[allow(clippy::all, clippy::std_instead_of_core, non_snake_case)]
 pub mod pb {
@@ -72,20 +73,20 @@ impl Display for pb::MacAddress {
     }
 }
 
-impl serde::Serialize for pb::MacAddress {
+impl Serialize for pb::MacAddress {
     /// Serializes as the string `Display` renders.
     ///
     /// A message with the upper 16 bits set renders as the literal
     /// `"invalid"`, since that is what `Display` already falls back to.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         serializer.collect_str(self)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for pb::MacAddress {
+impl<'de> Deserialize<'de> for pb::MacAddress {
     /// Parses the string `Serialize` produces, via `FromStr`.
     ///
     /// The literal `"invalid"` a set upper 16 bits serializes to is not
@@ -95,10 +96,10 @@ impl<'de> serde::Deserialize<'de> for pb::MacAddress {
     /// malformed case.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        s.parse::<Self>().map_err(serde::de::Error::custom)
+        s.parse::<Self>().map_err(de::Error::custom)
     }
 }
 
@@ -142,7 +143,7 @@ impl FromStr for pb::IpAddress {
     }
 }
 
-impl serde::Serialize for pb::IpAddress {
+impl Serialize for pb::IpAddress {
     /// Serializes as the plain address string `Display` renders.
     ///
     /// A malformed byte length renders as the literal `"invalid"`, since
@@ -151,13 +152,13 @@ impl serde::Serialize for pb::IpAddress {
     /// through this string is lossy for that one input shape as well.
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         serializer.collect_str(self)
     }
 }
 
-impl<'de> serde::Deserialize<'de> for pb::IpAddress {
+impl<'de> Deserialize<'de> for pb::IpAddress {
     /// Parses the string `Serialize` produces, via `FromStr`.
     ///
     /// The literal `"invalid"` a malformed byte length serializes to is
@@ -167,10 +168,10 @@ impl<'de> serde::Deserialize<'de> for pb::IpAddress {
     /// encoding, deliberately, rather than round-tripping.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        s.parse::<Self>().map_err(serde::de::Error::custom)
+        s.parse::<Self>().map_err(de::Error::custom)
     }
 }
 
@@ -231,6 +232,99 @@ impl pb::IpRange {
             }
             _ => Box::new(core::iter::empty()),
         }
+    }
+}
+
+impl From<Contiguous<IpNetwork>> for pb::ContiguousIpNetwork {
+    fn from(net: Contiguous<IpNetwork>) -> Self {
+        pb::ContiguousIpNetwork {
+            addr: Some(pb::IpAddress::from(net.addr())),
+            prefix_len: u32::from(net.prefix()),
+        }
+    }
+}
+
+impl TryFrom<IpNetwork> for pb::ContiguousIpNetwork {
+    type Error = Box<dyn Error>;
+
+    /// Fails when `net`'s mask is not expressible as a prefix length --
+    /// that contiguity is the whole point of this message.
+    fn try_from(net: IpNetwork) -> Result<Self, Self::Error> {
+        let prefix = net.prefix().ok_or("invalid IP network: mask is not contiguous")?;
+        Ok(pb::ContiguousIpNetwork {
+            addr: Some(pb::IpAddress::from(net.addr())),
+            prefix_len: u32::from(prefix),
+        })
+    }
+}
+
+impl TryFrom<&pb::ContiguousIpNetwork> for IpNetwork {
+    type Error = Box<dyn Error>;
+
+    /// Masks host bits to `prefix_len` rather than rejecting them.
+    fn try_from(net: &pb::ContiguousIpNetwork) -> Result<Self, Self::Error> {
+        let addr = net.addr.as_ref().ok_or("invalid IP network: missing address")?;
+        let addr = IpAddr::try_from(addr)?;
+        let prefix_len: u8 = net
+            .prefix_len
+            .try_into()
+            .map_err(|_| format!("invalid prefix length {}: exceeds 255", net.prefix_len))?;
+
+        let result = match addr {
+            IpAddr::V4(v4) => IpNetwork::try_from((v4, prefix_len)),
+            IpAddr::V6(v6) => IpNetwork::try_from((v6, prefix_len)),
+        };
+        result.map_err(|e| format!("invalid prefix length {prefix_len}: {e}").into())
+    }
+}
+
+impl Display for pb::ContiguousIpNetwork {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        match IpNetwork::try_from(self) {
+            Ok(net) => net.fmt(f),
+            Err(..) => f.write_str("invalid"),
+        }
+    }
+}
+
+impl FromStr for pb::ContiguousIpNetwork {
+    type Err = Box<dyn Error>;
+
+    /// Accepts CIDR (`10.0.0.0/24`), explicit-mask (`10.0.0.0/255.255.255.0`),
+    /// and bare-address (`10.0.0.1`) forms -- the last silently promoted to
+    /// a `/32` or `/128` host route -- and rejects a non-contiguous mask.
+    /// Wider than Go's CIDR-only `ParseContiguousIPNetwork`, which
+    /// accepts only the first form.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let net = Contiguous::<IpNetwork>::parse(s)?;
+        Ok(Self::from(net))
+    }
+}
+
+impl Serialize for pb::ContiguousIpNetwork {
+    /// Serializes as the CIDR string `Display` renders.
+    ///
+    /// A malformed message renders as the literal `"invalid"`, since that
+    /// is what `Display` already falls back to. That literal is not itself
+    /// a parseable network, so it deliberately does not deserialize back --
+    /// the same lossy treatment `pb::IpAddress` gives its own malformed
+    /// case.
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for pb::ContiguousIpNetwork {
+    /// Parses the string `Serialize` produces, via `FromStr`.
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<Self>().map_err(de::Error::custom)
     }
 }
 
@@ -536,5 +630,164 @@ mod test {
         };
         let cidrs: Vec<Contiguous<IpNetwork>> = range.cidrs().collect();
         assert_eq!(0, cidrs.len());
+    }
+
+    #[test]
+    fn contiguous_ip_network_v4_round_trip() {
+        let net = Contiguous::<IpNetwork>::parse("10.0.0.0/24").unwrap();
+        let msg = pb::ContiguousIpNetwork::from(net);
+        assert_eq!(24, msg.prefix_len);
+        let got = IpNetwork::try_from(&msg).unwrap();
+        assert_eq!(*net, got);
+    }
+
+    #[test]
+    fn contiguous_ip_network_v6_round_trip() {
+        let net = Contiguous::<IpNetwork>::parse("2001:db8::/32").unwrap();
+        let msg = pb::ContiguousIpNetwork::from(net);
+        assert_eq!(32, msg.prefix_len);
+        let got = IpNetwork::try_from(&msg).unwrap();
+        assert_eq!(*net, got);
+    }
+
+    /// `Display` alone would hide a wrong-family or unmasked encoding, so
+    /// this asserts on the raw wire bytes of `addr` instead.
+    #[test]
+    fn contiguous_ip_network_masks_host_bits() {
+        let msg: pb::ContiguousIpNetwork = "10.0.0.1/24".parse().unwrap();
+        assert_eq!(vec![10, 0, 0, 0], msg.addr.as_ref().unwrap().addr);
+        assert_eq!(24, msg.prefix_len);
+    }
+
+    /// Mirrors [`contiguous_ip_network_masks_host_bits`] on the decode side:
+    /// a hand-built message with host bits already set in `addr` still masks
+    /// down to the network base rather than merely echoing them back.
+    #[test]
+    fn contiguous_ip_network_try_from_masks_host_bits_v4() {
+        let msg = pb::ContiguousIpNetwork {
+            addr: Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)))),
+            prefix_len: 24,
+        };
+        let got = IpNetwork::try_from(&msg).unwrap();
+        assert_eq!(IpNetwork::parse("10.0.0.0/24").unwrap(), got);
+    }
+
+    #[test]
+    fn contiguous_ip_network_try_from_masks_host_bits_v6() {
+        let msg = pb::ContiguousIpNetwork {
+            addr: Some(pb::IpAddress::from(IpAddr::V6(Ipv6Addr::new(
+                0x2001, 0xdb8, 0, 0, 0, 0, 0, 1,
+            )))),
+            prefix_len: 32,
+        };
+        let got = IpNetwork::try_from(&msg).unwrap();
+        assert_eq!(IpNetwork::parse("2001:db8::/32").unwrap(), got);
+    }
+
+    #[test]
+    fn contiguous_ip_network_try_from_rejects_non_contiguous_mask() {
+        let net = IpNetwork::parse("192.168.0.1/255.255.0.255").unwrap();
+        assert!(pb::ContiguousIpNetwork::try_from(net).is_err());
+    }
+
+    #[test]
+    fn contiguous_ip_network_try_from_accepts_contiguous_mask() {
+        let net = IpNetwork::parse("192.168.0.0/255.255.255.0").unwrap();
+        let msg = pb::ContiguousIpNetwork::try_from(net).unwrap();
+        assert_eq!(24, msg.prefix_len);
+    }
+
+    #[test]
+    fn contiguous_ip_network_rejects_missing_addr() {
+        let msg = pb::ContiguousIpNetwork { addr: None, prefix_len: 24 };
+        assert!(IpNetwork::try_from(&msg).is_err());
+    }
+
+    #[test]
+    fn contiguous_ip_network_rejects_malformed_addr_length() {
+        let msg = pb::ContiguousIpNetwork {
+            addr: Some(pb::IpAddress { addr: vec![0u8; 5] }),
+            prefix_len: 8,
+        };
+        assert!(IpNetwork::try_from(&msg).is_err());
+    }
+
+    #[test]
+    fn contiguous_ip_network_rejects_out_of_range_prefix_len_v4() {
+        let msg = pb::ContiguousIpNetwork {
+            addr: Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0)))),
+            prefix_len: 33,
+        };
+        assert!(IpNetwork::try_from(&msg).is_err());
+    }
+
+    #[test]
+    fn contiguous_ip_network_rejects_out_of_range_prefix_len_v6() {
+        let msg = pb::ContiguousIpNetwork {
+            addr: Some(pb::IpAddress::from(IpAddr::V6(Ipv6Addr::new(
+                0x2001, 0xdb8, 0, 0, 0, 0, 0, 0,
+            )))),
+            prefix_len: 129,
+        };
+        assert!(IpNetwork::try_from(&msg).is_err());
+    }
+
+    /// `256` and `288` truncate to a valid `u8` (`0` and `32`), so a
+    /// checked narrowing is needed -- an unchecked `as u8` would silently
+    /// decode `256` as `/0` and `288` as `/32` instead of rejecting them.
+    #[test]
+    fn contiguous_ip_network_rejects_prefix_len_that_truncates_into_range() {
+        let addr = Some(pb::IpAddress::from(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 0))));
+        for prefix_len in [256, 288] {
+            let msg = pb::ContiguousIpNetwork { addr: addr.clone(), prefix_len };
+            assert!(
+                IpNetwork::try_from(&msg).is_err(),
+                "expected error for prefix_len {prefix_len}"
+            );
+        }
+    }
+
+    #[test]
+    fn contiguous_ip_network_display() {
+        let net = Contiguous::<IpNetwork>::parse("10.0.0.0/24").unwrap();
+        let msg = pb::ContiguousIpNetwork::from(net);
+        assert_eq!("10.0.0.0/24", msg.to_string());
+    }
+
+    #[test]
+    fn contiguous_ip_network_display_invalid() {
+        let msg = pb::ContiguousIpNetwork { addr: None, prefix_len: 24 };
+        assert_eq!("invalid", msg.to_string());
+    }
+
+    #[test]
+    fn serde_contiguous_ip_network_v4() {
+        let net = Contiguous::<IpNetwork>::parse("10.0.0.0/24").unwrap();
+        let msg = pb::ContiguousIpNetwork::from(net);
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(r#""10.0.0.0/24""#, json);
+        let got: pb::ContiguousIpNetwork = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, got);
+    }
+
+    #[test]
+    fn serde_contiguous_ip_network_v6() {
+        let net = Contiguous::<IpNetwork>::parse("2001:db8::/32").unwrap();
+        let msg = pb::ContiguousIpNetwork::from(net);
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(r#""2001:db8::/32""#, json);
+        let got: pb::ContiguousIpNetwork = serde_json::from_str(&json).unwrap();
+        assert_eq!(msg, got);
+    }
+
+    /// The `"invalid"` literal a malformed message serializes to is not
+    /// itself a parseable network, so deserializing it back is a
+    /// deliberate error rather than a silently reconstructed message.
+    #[test]
+    fn serde_contiguous_ip_network_invalid_does_not_deserialize() {
+        let malformed = pb::ContiguousIpNetwork { addr: None, prefix_len: 24 };
+        let json = serde_json::to_string(&malformed).unwrap();
+        assert_eq!(r#""invalid""#, json);
+        assert!(serde_json::from_str::<pb::ContiguousIpNetwork>(&json).is_err());
     }
 }


### PR DESCRIPTION
Add a shared wire type for a single IPv4 or IPv6 CIDR prefix, so callers that need a prefix can reuse a canonical commonpb message instead of a module-specific one or a plain string.

The address family is carried by the address byte length, consistently with the existing host-address message, and the prefix length is validated against that family on decode. A malformed address length, a missing address, and an out-of-range prefix length all return errors rather than an ambiguous value.

Host bits are normalised on both construction and decoding, in Go and in Rust alike, so the same message means the same thing in both languages. That choice is forced by the Rust network type, which cannot represent host bits at all, and it makes the round trip deliberately lossy for an input that carries them.

Both language bindings get parsing from a string, human-readable rendering, and conversion to the language's own network type, following the existing address and hardware-address types. JSON rendering matches each side's established shape for those types.

Existing module-specific prefix messages are deliberately left alone here and tracked as separate follow-ups.

Closes #1908.
