### PR TITLE
fix(dataplane): refuse to start when a worker thread cannot be created

### DIFF
--- a/dataplane/dataplane.c
+++ b/dataplane/dataplane.c
@@ -834,10 +834,20 @@ stat_thread(void *arg) {
 int
 dataplane_start(struct dataplane *dataplane) {
 	for (size_t dev_idx = 0; dev_idx < dataplane->device_count; ++dev_idx) {
-		dataplane_device_start(dataplane, dataplane->devices + dev_idx);
+		if (dataplane_device_start(
+			    dataplane, dataplane->devices + dev_idx
+		    )) {
+			return -1;
+		}
 	}
+
 	pthread_t thread_id;
-	pthread_create(&thread_id, NULL, stat_thread, dataplane);
+	int rc = pthread_create(&thread_id, NULL, stat_thread, dataplane);
+	if (rc != 0) {
+		// The stat thread only feeds xstats counters, so a failure
+		// here degrades observability rather than packet processing.
+		LOG(WARN, "failed to create stat thread: %s", strerror(rc));
+	}
 
 	return 0;
 }

--- a/dataplane/device.c
+++ b/dataplane/device.c
@@ -79,7 +79,9 @@ dataplane_device_start(
 
 	for (uint32_t wrk_idx = 0; wrk_idx < device->worker_count; ++wrk_idx) {
 		struct dataplane_worker *worker = device->workers + wrk_idx;
-		dataplane_worker_start(worker);
+		if (dataplane_worker_start(worker)) {
+			return -1;
+		}
 	}
 
 	return 0;

--- a/dataplane/main.c
+++ b/dataplane/main.c
@@ -108,7 +108,11 @@ main(int argc, char **argv) {
 	}
 
 	LOG(INFO, "start dataplane");
-	dataplane_start(&dataplane);
+	rc = dataplane_start(&dataplane);
+	if (rc != 0) {
+		LOG(ERROR, "failed to start dataplane");
+		return -1;
+	}
 
 	// FIXME: infinite sleep effectively
 	LOG(INFO, "wait dataplane");

--- a/dataplane/worker.c
+++ b/dataplane/worker.c
@@ -60,6 +60,8 @@
 
 #include <rte_ethdev.h>
 
+#include <string.h>
+
 static void
 worker_read(
 	struct dataplane_worker *worker, struct packet_front *packet_front
@@ -610,11 +612,19 @@ dataplane_worker_start(struct dataplane_worker *worker) {
 
 	pthread_attr_setaffinity_np(&wrk_th_attr, sizeof(cpu_set_t), &mask);
 
-	pthread_create(
+	int rc = pthread_create(
 		&worker->thread_id, &wrk_th_attr, worker_thread_start, worker
 	);
 
 	pthread_attr_destroy(&wrk_th_attr);
+
+	if (rc != 0) {
+		LOG(ERROR,
+		    "failed to create thread for worker core_id=%u: %s",
+		    worker->config.core_id,
+		    strerror(rc));
+		return -1;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
A worker thread was created without checking the result, and every caller up to the entry point discarded it too. A worker that failed to start was still counted in shared memory, so its generation never advanced and the first configuration install after startup waited on it forever while holding the control-plane lock, with nothing logged anywhere.

- Propagate a worker thread creation failure up through device start and dataplane start, and refuse to start rather than proceeding with a worker that has no thread.
- Keep a failure to start the statistics thread non-fatal, since it only feeds counters and never touches packet processing.

The issue also proposed rejecting a configured core outside the online CPU set at configuration-parse time. That was implemented and then withdrawn after review. The process affinity mask is not the set the kernel checks a new thread against, so the check refused configurations that start correctly today: on a host booted with isolated CPUs the kernel narrows the init process affinity to the housekeeping set and every descendant inherits it, so pinning a worker to an isolated core succeeds while the check would have rejected it. Confirmed by probe, alongside the related finding that an out-of-range core identifier cannot corrupt the affinity mask because the platform bounds-checks it.

No test accompanies this change. The failure path has no unit-testable seam: worker start requires an initialized device port, and the only test target able to link that code excludes the device wrapper, so reaching the failure would need both a populated shared-memory fixture and linker-level interposition of thread creation, for which the repository has no precedent.

Closes #1882.